### PR TITLE
Setup standalone test data load and adapt e2e tests

### DIFF
--- a/ibis/client.py
+++ b/ibis/client.py
@@ -271,7 +271,7 @@ class ImpalaClient(SQLClient):
                                        fail_if_exists=fail_if_exists)
         self._execute(statement)
 
-    def drop_database(self, name, must_exist=True, drop_tables=False):
+    def drop_database(self, name, must_exist=True, force=False):
         """
         Drop an Impala database
 
@@ -279,12 +279,12 @@ class ImpalaClient(SQLClient):
         ----------
         name : string
           Database name
-        drop_tables : boolean, default False
+        force : boolean, default False
           If False and there are any tables in this database, raises an
           IntegrityError
         """
         tables = self.list_tables(database=name)
-        if drop_tables:
+        if force:
             for table in tables:
                 self.log('Dropping {0}'.format('{0}.{1}'.format(name, table)))
                 self.drop_table(table, database=name)
@@ -292,7 +292,7 @@ class ImpalaClient(SQLClient):
             if len(tables) > 0:
                 raise com.IntegrityError('Database {0} must be empty before '
                                          'being dropped, or set '
-                                         'drop_tables=True'.format(name))
+                                         'force=True'.format(name))
         statement = ddl.DropDatabase(name, must_exist=must_exist)
         self._execute(statement)
 

--- a/ibis/tests/test_impala_e2e.py
+++ b/ibis/tests/test_impala_e2e.py
@@ -146,7 +146,7 @@ class TestImpalaConnection(ImpalaE2E, unittest.TestCase):
 
         self.assertRaises(com.IntegrityError, self.con.drop_database, tmp_db)
 
-        self.con.drop_database(tmp_db, drop_tables=True)
+        self.con.drop_database(tmp_db, force=True)
         assert not self.con.exists_database(tmp_db)
 
     def test_create_database_with_location(self):

--- a/scripts/load_test_data.py
+++ b/scripts/load_test_data.py
@@ -45,13 +45,13 @@ TMP_DB = guid()
 
 def make_temp_database(con):
     if con.exists_database(TMP_DB):
-        con.drop_database(TMP_DB, drop_tables=True)
+        con.drop_database(TMP_DB, force=True)
     con.create_database(TMP_DB, path=TMP_DB_LOCATION)
     print('Created database {0} at {1}'.format(TMP_DB, TMP_DB_LOCATION))
 
 
 def cleanup_temporary_stuff(con):
-    con.drop_database(TMP_DB, drop_tables=True)
+    con.drop_database(TMP_DB, force=True)
     assert not con.hdfs.exists(TMP_DB_LOCATION)
 
 def download_parquet_files(con):
@@ -129,7 +129,7 @@ def write_data_to_hdfs(con):
 
 def create_test_database(con):
     if con.exists_database(TEST_DB):
-        con.drop_database(TEST_DB, drop_tables=True)
+        con.drop_database(TEST_DB, force=True)
     con.create_database(TEST_DB)
     print('Created database {0}'.format(TEST_DB))
 


### PR DESCRIPTION
The e2e test suite now no longer depends on having a full-blown Impala
`/test-warehouse` (which is quite laborious to load). This PR adds code to
generate a test data directory from an Impala dev environment that can be
tarred up and distributed to Ibis developers, and then loaded into an
`ibis_testing` database against which the test suite will run.

Also provides additional dogfooding for end-to-end ETL workflows with Ibis
