### PR TITLE
MAINT: Add scratch file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ dist
 .gdb_history
 .DS_Store?
 Icon?
+
+# file to put random dev-related chicken-scratches
+scratch.txt


### PR DESCRIPTION
I like to put down lots of useful snippets (but not useful enough to check in, or dev env specific) in a file in the repo.  You have a problem with .gitignoring this, @wesm?
