### PR TITLE
TST: WebHDFS parameters are now configurable

### DIFF
--- a/ibis/tests/test_filesystems.py
+++ b/ibis/tests/test_filesystems.py
@@ -70,14 +70,12 @@ class TestHDFSE2E(unittest.TestCase):
         cls.host = os.environ.get('IBIS_TEST_HOST', 'localhost')
         cls.protocol = os.environ.get('IBIS_TEST_PROTOCOL', 'hiveserver2')
         cls.port = os.environ.get('IBIS_TEST_PORT', 21050)
+        cls.hdfs_host = os.environ.get('IBIS_TEST_HDFS_HOST', 'localhost')
+        # Impala dev environment uses port 5070 for HDFS web interface
+        cls.webhdfs_port = os.environ.get('IBIS_TEST_WEBHDFS_PORT', 5070)
+        url = 'http://{}:{}'.format(cls.hdfs_host, cls.webhdfs_port)
 
         cls.test_dir = '/{}'.format(util.guid())
-
-        # Impala dev environment uses port 5070 for HDFS web interface
-
-        hdfs_host = 'localhost'
-        webhdfs_port = 5070
-        url = 'http://{}:{}'.format(hdfs_host, webhdfs_port)
 
         try:
             cls.hdfs_client = InsecureClient(url)

--- a/ibis/tests/test_impala_e2e.py
+++ b/ibis/tests/test_impala_e2e.py
@@ -39,12 +39,10 @@ class IbisTestEnv(object):
         self.port = os.environ.get('IBIS_TEST_PORT', 21050)
         self.database = os.environ.get('IBIS_TEST_DATABASE', 'ibis_testing')
         self.use_codegen = bool(os.environ.get('IBIS_TEST_USE_CODEGEN', False))
-
+        self.hdfs_host = os.environ.get('IBIS_TEST_HDFS_HOST', 'localhost')
         # Impala dev environment uses port 5070 for HDFS web interface
-
-        hdfs_host = 'localhost'
-        webhdfs_port = 5070
-        url = 'http://{}:{}'.format(hdfs_host, webhdfs_port)
+        self.webhdfs_port = os.environ.get('IBIS_TEST_WEBHDFS_PORT', 5070)
+        url = 'http://{}:{}'.format(self.hdfs_host, self.webhdfs_port)
         self.hdfs = InsecureClient(url)
 
 


### PR DESCRIPTION
Adds two additional environment variables
- `IBIS_TEST_HDFS_HOST`
- `IBIS_TEST_WEBHDFS_PORT`

that default to a localhost dev environment.

Fixes #324.
