### PR TITLE
ENH: make Ibis compatible with Python 2.6

### DIFF
--- a/dev/merge-pr.py
+++ b/dev/merge-pr.py
@@ -68,10 +68,14 @@ def fail(msg):
 
 
 def run_cmd(cmd):
-    if isinstance(cmd, list):
-        return subprocess.check_output(cmd)
-    else:
-        return subprocess.check_output(cmd.split(" "))
+    # py2.6 does not have subprocess.check_output
+    if isinstance(cmd, basestring):
+        cmd = cmd.split(' ')
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    (out, err) = p.communicate()
+    if p.returncode != 0:
+        raise subprocess.CalledProcessError(p.returncode, str(cmd), out + err)
+    return out
 
 
 def continue_maybe(prompt):

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -113,7 +113,7 @@ def hdfs_connect(host='localhost', port=50070, protocol='webhdfs', **kwds):
     client : ibis HDFS client
     """
     from hdfs import InsecureClient
-    url = 'http://{}:{}'.format(host, port)
+    url = 'http://{0}:{1}'.format(host, port)
     client = InsecureClient(url, **kwds)
     return WebHDFS(client)
 

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -242,11 +242,11 @@ class ImpalaClient(SQLClient):
 
     def _fully_qualified_name(self, name, database):
         if database is not None:
-            return '{}.`{}`'.format(database, name)
+            return '{0}.`{1}`'.format(database, name)
         else:
             # TODO: This is not foolproof
             if '.' not in name and name.lower() in ident.impala_identifiers:
-                return '`{}`'.format(name)
+                return '`{0}`'.format(name)
             else:
                 return name
 
@@ -268,9 +268,9 @@ class ImpalaClient(SQLClient):
         """
         statement = 'SHOW TABLES'
         if database:
-            statement += ' IN {}'.format(database)
+            statement += ' IN {0}'.format(database)
         if like:
-            statement += " LIKE '{}'".format(like)
+            statement += " LIKE '{0}'".format(like)
 
         cur = self._execute(statement)
         return self._get_list(cur)
@@ -360,7 +360,7 @@ class ImpalaClient(SQLClient):
         """
         statement = 'SHOW DATABASES'
         if like:
-            statement += " LIKE '{}'".format(like)
+            statement += " LIKE '{0}'".format(like)
 
         cur = self._execute(statement)
         return self._get_list(cur)
@@ -649,7 +649,7 @@ class ImpalaClient(SQLClient):
         self._execute(statement)
 
     def _get_table_schema(self, tname):
-        query = 'SELECT * FROM {} LIMIT 0'.format(tname)
+        query = 'SELECT * FROM {0} LIMIT 0'.format(tname)
         return self._get_schema_using_query(query)
 
     def _get_schema_using_query(self, query):
@@ -712,6 +712,6 @@ class ImpalaTemporaryTable(ops.DatabaseTable):
 
 
 def _set_limit(query, k):
-    limited_query = '{}\nLIMIT {}'.format(query, k)
+    limited_query = '{0}\nLIMIT {1}'.format(query, k)
 
     return limited_query

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -1,0 +1,24 @@
+# Copyright 2015 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+
+PY26 = sys.version_info[0] == 2 and sys.version_info[1] == 6
+
+
+if PY26:
+    import unittest2 as unittest
+else:
+    import unittest

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -699,7 +699,7 @@ def unwrap_ands(expr):
             walk(op.left)
             walk(op.right)
         else:
-            raise Exception('Invalid predicate: {!r}'.format(expr))
+            raise Exception('Invalid predicate: {0!r}'.format(expr))
 
     walk(expr)
     return out_exprs

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -990,7 +990,7 @@ def re_search(arg, pattern):
 
 
 def _string_contains(arg, substr):
-    return arg.like('%{}%'.format(substr))
+    return arg.like('%{0}%'.format(substr))
 
 
 def _string_dunder_contains(arg, substr):

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -97,7 +97,7 @@ class ExprFormatter(object):
                                        str(what.value))
 
         if isinstance(self.expr, ir.ValueExpr) and self.expr._name is not None:
-            text = '{} = {}'.format(self.expr.get_name(), text)
+            text = '{0} = {1}'.format(self.expr.get_name(), text)
 
         if self.memoize:
             alias_to_text = [(self.memo.aliases[x],
@@ -144,13 +144,13 @@ class ExprFormatter(object):
 
     def _format_table(self, table):
         # format the schema
-        rows = ['name: {!s}\nschema:'.format(table.name)]
+        rows = ['name: {0!s}\nschema:'.format(table.name)]
         rows.extend(['  %s : %s' % tup for tup in
                      zip(table.schema.names, table.schema.types)])
         opname = type(table).__name__
         type_display = self._get_type_display(table)
         opline = '%s[%s]' % (opname, type_display)
-        return '{}\n{}'.format(opline, self._indent('\n'.join(rows)))
+        return '{0}\n{1}'.format(opline, self._indent('\n'.join(rows)))
 
     def _format_column(self, expr):
         # HACK: if column is pulled from a Filter of another table, this parent
@@ -191,7 +191,7 @@ class ExprFormatter(object):
         else:
             for arg, name in zip(op.args, arg_names):
                 if name is not None:
-                    name = self._indent('{}:'.format(name))
+                    name = self._indent('{0}:'.format(name))
                 if isinstance(arg, list):
                     if name is not None and len(arg) > 0:
                         formatted_args.append(name)

--- a/ibis/expr/groupby.py
+++ b/ibis/expr/groupby.py
@@ -92,7 +92,7 @@ def _group_agg_dispatch(name):
     def wrapper(self, *args, **kwargs):
         f = getattr(self.arr, name)
         metric = f(*args, **kwargs)
-        alias = '{}({})'.format(name, self.arr.get_name())
+        alias = '{0}({1})'.format(name, self.arr.get_name())
         return self.parent.aggregate(metric.name(alias))
 
     wrapper.__name__ = name

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -206,7 +206,7 @@ class TableColumn(ArrayNode):
         Node.__init__(self, [name, table_expr])
 
         if name not in table_expr.schema():
-            raise KeyError("'{}' is not a field".format(name))
+            raise KeyError("'{0}' is not a field".format(name))
 
         self.name = name
         self.table = table_expr
@@ -1360,7 +1360,7 @@ class SortKey(object):
     def __repr__(self):
         # Temporary
         rows = ['Sort key:',
-                '  ascending: {!s}'.format(self.ascending),
+                '  ascending: {0!s}'.format(self.ascending),
                 util.indent(_safe_repr(self.expr), 2)]
         return '\n'.join(rows)
 
@@ -1543,7 +1543,7 @@ class Aggregation(ir.BlockingTableNode, HasSchema):
         for expr in self.having:
             if not isinstance(expr, ir.BooleanScalar):
                 raise ExpressionError('Having clause must be boolean '
-                                      'expression, was: {!s}'
+                                      'expression, was: {0!s}'
                                       .format(_safe_repr(expr)))
 
         # All non-scalar refs originate from the input table
@@ -1747,7 +1747,7 @@ class TopK(ArrayNode):
             raise TypeError(arg)
 
         if not isinstance(k, int) or k < 0:
-            raise ValueError('k must be positive integer, was: {}'.format(k))
+            raise ValueError('k must be positive integer, was: {0}'.format(k))
 
         self.arg = arg
         self.k = k
@@ -1825,7 +1825,7 @@ class TimestampFromUNIX(ValueNode):
         self.arg = as_value_expr(arg)
         self.unit = unit
 
-        if self.unit not in {'s', 'ms', 'us'}:
+        if self.unit not in set(['s', 'ms', 'us']):
             raise ValueError(self.unit)
 
         ValueNode.__init__(self, [self.arg, self.unit])

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -191,8 +191,8 @@ class _TypePrecedence(object):
     def _check_casts(self, typename):
         for expr in self.exprs:
             if not expr._can_cast_implicit(typename):
-                raise ValueError('Expression with type {} cannot be '
-                                 'implicitly casted to {}'
+                raise ValueError('Expression with type {0} cannot be '
+                                 'implicitly casted to {1}'
                                  .format(expr.type(), typename))
 
 

--- a/ibis/expr/temporal.py
+++ b/ibis/expr/temporal.py
@@ -41,9 +41,9 @@ class Timedelta(object):
         if self.n == 1:
             pretty_unit = self.unit_name
         else:
-            pretty_unit = '{}s'.format(self.unit_name)
+            pretty_unit = '{0}s'.format(self.unit_name)
 
-        return '<Timedelta: {} {}>'.format(self.n, pretty_unit)
+        return '<Timedelta: {0} {1}>'.format(self.n, pretty_unit)
 
     def replace(self, n):
         return type(self)(n)
@@ -99,7 +99,7 @@ class TimeIncrement(Timedelta):
 
     def combine(self, other):
         if not isinstance(other, TimeIncrement):
-            raise TypeError('Must be a fixed size timedelta, was {!r}'
+            raise TypeError('Must be a fixed size timedelta, was {0!r}'
                             .format(type(other)))
 
         a, b = _to_common_units([self, other])
@@ -205,7 +205,7 @@ class UnitConverter(object):
 
         if j < i:
             if n % factor:
-                raise IbisError('{} is not a multiple of {}'.format(n, factor))
+                raise IbisError('{0} is not a multiple of {1}'.format(n, factor))
             return n / factor
         else:
             return n * factor

--- a/ibis/expr/tests/test_analytics.py
+++ b/ibis/expr/tests/test_analytics.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
 from ibis.expr.tests.mocks import MockConnection
+from ibis.compat import unittest
 import ibis.expr.types as ir
 
 

--- a/ibis/expr/tests/test_base.py
+++ b/ibis/expr/tests/test_base.py
@@ -14,7 +14,7 @@
 
 import itertools
 import operator
-import unittest
+import sys
 
 from ibis.expr.types import ArrayExpr, TableExpr, RelationError
 from ibis.common import ExpressionError
@@ -24,6 +24,7 @@ import ibis.expr.types as ir
 import ibis.expr.operations as ops
 import ibis
 
+from ibis.compat import unittest
 from ibis.expr.format import ExprFormatter
 from ibis.expr.tests.mocks import MockConnection
 

--- a/ibis/expr/tests/test_decimal.py
+++ b/ibis/expr/tests/test_decimal.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
 import ibis.expr.api as api
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 
+from ibis.compat import unittest
 from ibis.expr.tests.mocks import MockConnection
 
 

--- a/ibis/expr/tests/test_pipe.py
+++ b/ibis/expr/tests/test_pipe.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
+from ibis.compat import unittest
 import ibis
 
 

--- a/ibis/expr/tests/test_sql_builtins.py
+++ b/ibis/expr/tests/test_sql_builtins.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
 from ibis.expr.tests.mocks import MockConnection
+from ibis.compat import unittest
 import ibis.expr.api as api
 import ibis.expr.operations as ops
 import ibis.expr.types as ir

--- a/ibis/expr/tests/test_string.py
+++ b/ibis/expr/tests/test_string.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
 import ibis.expr.api as api
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 
 from ibis.expr.tests.mocks import MockConnection
+from ibis.compat import unittest
 
 
 class TestStringOps(unittest.TestCase):

--- a/ibis/expr/tests/test_temporal.py
+++ b/ibis/expr/tests/test_temporal.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
 from ibis.common import IbisError
 import ibis.expr.operations as ops
@@ -20,6 +20,7 @@ import ibis.expr.types as ir
 import ibis.expr.temporal as T
 
 from ibis.expr.tests.mocks import MockConnection
+from ibis.compat import unittest
 
 
 class TestFixedOffsets(unittest.TestCase):

--- a/ibis/expr/tests/test_timestamp.py
+++ b/ibis/expr/tests/test_timestamp.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
 import pandas as pd
 
@@ -23,6 +23,7 @@ import ibis.expr.operations as ops
 import ibis.expr.types as ir
 
 from ibis.expr.tests.mocks import MockConnection
+from ibis.compat import unittest
 
 
 class TestTimestamp(unittest.TestCase):

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -1009,26 +1009,26 @@ class BooleanValue(NumericValue):
 class Int8Value(IntegerValue):
 
     _typename = 'int8'
-    _implicit_casts = {'int16', 'int32', 'int64', 'float', 'double',
-                       'decimal'}
+    _implicit_casts = set(['int16', 'int32', 'int64', 'float', 'double',
+                           'decimal'])
 
 
 class Int16Value(IntegerValue):
 
     _typename = 'int16'
-    _implicit_casts = {'int32', 'int64', 'float', 'double', 'decimal'}
+    _implicit_casts = set(['int32', 'int64', 'float', 'double', 'decimal'])
 
 
 class Int32Value(IntegerValue):
 
     _typename = 'int32'
-    _implicit_casts = {'int64', 'float', 'double', 'decimal'}
+    _implicit_casts = set(['int64', 'float', 'double', 'decimal'])
 
 
 class Int64Value(IntegerValue):
 
     _typename = 'int64'
-    _implicit_casts = {'float', 'double', 'decimal'}
+    _implicit_casts = set(['float', 'double', 'decimal'])
 
 
 class FloatingValue(NumericValue):
@@ -1038,13 +1038,13 @@ class FloatingValue(NumericValue):
 class FloatValue(FloatingValue):
 
     _typename = 'float'
-    _implicit_casts = {'double', 'decimal'}
+    _implicit_casts = set(['double', 'decimal'])
 
 
 class DoubleValue(FloatingValue):
 
     _typename = 'double'
-    _implicit_casts = {'decimal'}
+    _implicit_casts = set(['decimal'])
 
 
 class StringValue(AnyValue):
@@ -1093,7 +1093,7 @@ class DecimalType(DataType):
 class DecimalValue(NumericValue):
 
     _typename = 'decimal'
-    _implicit_casts = {'float', 'double'}
+    _implicit_casts = set(['float', 'double'])
 
     def __init__(self, meta):
         self.meta = meta

--- a/ibis/filesystems.py
+++ b/ibis/filesystems.py
@@ -206,7 +206,7 @@ class WebHDFS(HDFS):
         else:
             if is_path:
                 if verbose:
-                    self.log('Writing local {} to HDFS {}'.format(resource,
+                    self.log('Writing local {0} to HDFS {1}'.format(resource,
                                                                   hdfs_path))
                 self.client.upload(hdfs_path, resource,
                                    overwrite=overwrite, **kwargs)
@@ -237,7 +237,7 @@ class WebHDFS(HDFS):
 
         def _get_file(remote, local):
             if verbose:
-                self.log('Writing HDFS {} to local {}'.format(remote, local))
+                self.log('Writing HDFS {0} to local {1}'.format(remote, local))
             self.client.download(remote, local, overwrite=overwrite)
 
         def _scrape_dir(path, dst):

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -220,7 +220,7 @@ class SelectBuilder(object):
     def _visit_select_expr(self, expr):
         op = expr.op()
 
-        method = '_visit_select_{}'.format(type(op).__name__)
+        method = '_visit_select_{0}'.format(type(op).__name__)
         if hasattr(self, method):
             f = getattr(self, method)
             return f(expr)
@@ -300,7 +300,7 @@ class SelectBuilder(object):
 
         op = expr.op()
 
-        method = '_visit_filter_{}'.format(type(op).__name__)
+        method = '_visit_filter_{0}'.format(type(op).__name__)
         if hasattr(self, method):
             f = getattr(self, method)
             return f(expr)
@@ -406,7 +406,7 @@ class SelectBuilder(object):
 
     def _collect(self, expr, toplevel=False):
         op = expr.op()
-        method = '_collect_{}'.format(type(op).__name__)
+        method = '_collect_{0}'.format(type(op).__name__)
 
         # Do not visit nodes twice
         if op in self.op_memo:
@@ -618,7 +618,7 @@ class _ExtractSubqueries(object):
 
     def visit(self, expr):
         node = expr.op()
-        method = '_visit_{}'.format(type(node).__name__)
+        method = '_visit_{0}'.format(type(node).__name__)
 
         if hasattr(self, method):
             f = getattr(self, method)

--- a/ibis/sql/ddl.py
+++ b/ibis/sql/ddl.py
@@ -26,13 +26,13 @@ class DDLStatement(object):
 
     def _get_scoped_name(self, table_name, database):
         if database:
-            scoped_name = '{}.`{}`'.format(database, table_name)
+            scoped_name = '{0}.`{1}`'.format(database, table_name)
         else:
             if not _is_fully_qualified(table_name):
                 if _is_quoted(table_name):
                     return table_name
                 else:
-                    return '`{}`'.format(table_name)
+                    return '`{0}`'.format(table_name)
             else:
                 return table_name
         return scoped_name
@@ -163,7 +163,7 @@ class Select(DDLStatement):
                 buf.write(',\n')
             formatted = util.indent(context.get_formatted_query(expr), 2)
             alias = context.get_alias(expr)
-            buf.write('{} AS (\n{}\n)'.format(alias, formatted))
+            buf.write('{0} AS (\n{1}\n)'.format(alias, formatted))
 
         return buf.getvalue()
 
@@ -176,7 +176,7 @@ class Select(DDLStatement):
             elif isinstance(expr, ir.TableExpr):
                 # A * selection, possibly prefixed
                 if context.need_aliases():
-                    expr_str = '{}.*'.format(context.get_alias(expr))
+                    expr_str = '{0}.*'.format(context.get_alias(expr))
                 else:
                     expr_str = '*'
             formatted.append(expr_str)
@@ -218,7 +218,7 @@ class Select(DDLStatement):
         else:
             select_key = 'SELECT'
 
-        return '{}{}'.format(select_key, buf.getvalue())
+        return '{0}{1}'.format(select_key, buf.getvalue())
 
     def format_table_set(self, ctx):
         if self.table_set is None:
@@ -238,7 +238,7 @@ class Select(DDLStatement):
 
         lines = []
         if len(self.group_by) > 0:
-            clause = 'GROUP BY {}'.format(', '.join([
+            clause = 'GROUP BY {0}'.format(', '.join([
                 str(x + 1) for x in self.group_by]))
             lines.append(clause)
 
@@ -247,7 +247,7 @@ class Select(DDLStatement):
             for expr in self.having:
                 translated = translate_expr(expr, context=context)
                 trans_exprs.append(translated)
-            lines.append('HAVING {}'.format(' AND '.join(trans_exprs)))
+            lines.append('HAVING {0}'.format(' AND '.join(trans_exprs)))
 
         return '\n'.join(lines)
 
@@ -260,7 +260,7 @@ class Select(DDLStatement):
         fmt_preds = [translate_expr(pred, context=context,
                                     permit_subquery=True)
                      for pred in self.where]
-        conj = ' AND\n{}'.format(' ' * 6)
+        conj = ' AND\n{0}'.format(' ' * 6)
         buf.write(conj.join(fmt_preds))
         return buf.getvalue()
 
@@ -283,9 +283,9 @@ class Select(DDLStatement):
             if lines:
                 buf.write('\n')
             n, offset = self.limit['n'], self.limit['offset']
-            buf.write('LIMIT {}'.format(n))
+            buf.write('LIMIT {0}'.format(n))
             if offset is not None and offset != 0:
-                buf.write(' OFFSET {}'.format(offset))
+                buf.write(' OFFSET {0}'.format(offset))
             lines += 1
 
         if not lines:
@@ -331,13 +331,13 @@ class _TableSetFormatter(object):
         for jtype, table, preds in zip(self.join_types, self.join_tables[1:],
                                        self.join_predicates):
             buf.write('\n')
-            buf.write(util.indent('{} {}'.format(jtype, table), self.indent))
+            buf.write(util.indent('{0} {1}'.format(jtype, table), self.indent))
 
             if len(preds):
                 buf.write('\n')
                 fmt_preds = [translate_expr(pred, context=self.context)
                              for pred in preds]
-                conj = ' AND\n{}'.format(' ' * 3)
+                conj = ' AND\n{0}'.format(' ' * 3)
                 fmt_preds = util.indent('ON ' + conj.join(fmt_preds),
                                         self.indent * 2)
                 buf.write(fmt_preds)
@@ -409,7 +409,7 @@ def _format_table(ctx, expr, indent=2):
     if isinstance(ref_op, ops.PhysicalTable):
         name = op.name
         if name is None:
-            raise com.RelationError('Table did not have a name: {!r}'
+            raise com.RelationError('Table did not have a name: {0!r}'
                                     .format(expr))
         result = quote_identifier(name)
         is_subquery = False
@@ -422,16 +422,16 @@ def _format_table(ctx, expr, indent=2):
 
             # HACK: self-references have to be treated more carefully here
             if isinstance(op, ops.SelfReference):
-                return '{} {}'.format(ctx.get_alias(ref_expr), alias)
+                return '{0} {1}'.format(ctx.get_alias(ref_expr), alias)
             else:
                 return alias
 
         subquery = ctx.get_formatted_query(expr)
-        result = '(\n{}\n)'.format(util.indent(subquery, indent))
+        result = '(\n{0}\n)'.format(util.indent(subquery, indent))
         is_subquery = True
 
     if is_subquery or ctx.need_aliases():
-        result += ' {}'.format(ctx.get_alias(expr))
+        result += ' {0}'.format(ctx.get_alias(expr))
 
     return result
 
@@ -458,7 +458,7 @@ class Union(DDLStatement):
         left_set = context.get_formatted_query(self.left)
         right_set = context.get_formatted_query(self.right)
 
-        query = '{}\n{}\n{}'.format(left_set, union_keyword, right_set)
+        query = '{0}\n{1}\n{2}'.format(left_set, union_keyword, right_set)
         return query
 
 
@@ -483,7 +483,7 @@ class CreateTable(DDLStatement):
     def _validate_storage_format(self, format):
         format = format.lower()
         if format not in ('parquet', 'avro'):
-            raise ValueError('Invalid format: {}'.format(format))
+            raise ValueError('Invalid format: {0}'.format(format))
         return format
 
     def compile(self):
@@ -493,7 +493,7 @@ class CreateTable(DDLStatement):
         buf.write(self._storage())
 
         select_query = self.select.compile()
-        buf.write('\nAS\n{}'.format(select_query))
+        buf.write('\nAS\n{0}'.format(select_query))
 
         return buf.getvalue()
 
@@ -506,7 +506,7 @@ class CreateTable(DDLStatement):
         else:
             create_decl = 'CREATE TABLE'
 
-        create_line = '{} {}{}'.format(create_decl, if_exists,
+        create_line = '{0} {1}{2}'.format(create_decl, if_exists,
                                        scoped_name)
         return create_line
 
@@ -538,7 +538,7 @@ class CTAS(CreateTable):
         buf.write(self._storage())
 
         select_query = self.select.compile()
-        buf.write('\nAS\n{}'.format(select_query))
+        buf.write('\nAS\n{0}'.format(select_query))
         return buf.getvalue()
 
 
@@ -566,17 +566,17 @@ class CreateTableParquet(CreateTable):
         buf.write(self._create_line())
 
         if self.example_file is not None:
-            buf.write("\nLIKE PARQUET '{}'".format(self.example_file))
+            buf.write("\nLIKE PARQUET '{0}'".format(self.example_file))
         elif self.example_table is not None:
-            buf.write("\nLIKE {}".format(self.example_table))
+            buf.write("\nLIKE {0}".format(self.example_table))
         elif self.schema is not None:
             schema = format_schema(self.schema)
-            buf.write('\n{}'.format(schema))
+            buf.write('\n{0}'.format(schema))
         else:
             raise NotImplementedError
 
         buf.write('\nSTORED AS PARQUET')
-        buf.write("\nLOCATION '{}'".format(self.path))
+        buf.write("\nLOCATION '{0}'".format(self.path))
         return buf.getvalue()
 
 
@@ -594,7 +594,7 @@ class CreateTableWithSchema(CreateTable):
         buf.write(self._create_line())
 
         schema = format_schema(self.schema)
-        buf.write('\n{}'.format(schema))
+        buf.write('\n{0}'.format(schema))
 
         format_ddl = self.table_format.to_ddl()
         buf.write(format_ddl)
@@ -617,15 +617,15 @@ class DelimitedFormat(object):
         buf.write("\nROW FORMAT DELIMITED")
 
         if self.delimiter is not None:
-            buf.write("\nFIELDS TERMINATED BY '{}'".format(self.delimiter))
+            buf.write("\nFIELDS TERMINATED BY '{0}'".format(self.delimiter))
 
         if self.escapechar is not None:
-            buf.write("\nESCAPED BY '{}'".format(self.escapechar))
+            buf.write("\nESCAPED BY '{0}'".format(self.escapechar))
 
         if self.lineterminator is not None:
-            buf.write("\nLINES TERMINATED BY '{}'".format(self.lineterminator))
+            buf.write("\nLINES TERMINATED BY '{0}'".format(self.lineterminator))
 
-        buf.write("\nLOCATION '{}'".format(self.path))
+        buf.write("\nLOCATION '{0}'".format(self.path))
 
         return buf.getvalue()
 
@@ -641,11 +641,11 @@ class AvroFormat(object):
 
         buf = BytesIO()
         buf.write('\nSTORED AS AVRO')
-        buf.write("\nLOCATION '{}'".format(self.path))
+        buf.write("\nLOCATION '{0}'".format(self.path))
 
         schema = json.dumps(self.avro_schema, indent=2, sort_keys=True)
         schema = '\n'.join([x.rstrip() for x in schema.split('\n')])
-        buf.write("\nTBLPROPERTIES ('avro.schema.literal'='{}')"
+        buf.write("\nTBLPROPERTIES ('avro.schema.literal'='{0}')"
                   .format(schema))
 
         return buf.getvalue()
@@ -699,7 +699,7 @@ class InsertSelect(DDLStatement):
 
         select_query = self.select.compile()
         scoped_name = self._get_scoped_name(self.table_name, self.database)
-        return'{} {}\n{}'.format(cmd, scoped_name, select_query)
+        return'{0} {1}\n{2}'.format(cmd, scoped_name, select_query)
 
 
 class DropObject(DDLStatement):
@@ -739,7 +739,7 @@ class CacheTable(DDLStatement):
 
     def compile(self):
         scoped_name = self._get_scoped_name(self.table_name, self.database)
-        cache_line = ('ALTER TABLE {} SET CACHED IN \'{}\''
+        cache_line = ('ALTER TABLE {0} SET CACHED IN \'{1}\''
                       .format(scoped_name, self.pool))
         return cache_line
 
@@ -756,9 +756,9 @@ class CreateDatabase(DDLStatement):
         name = quote_identifier(self.name)
 
         create_decl = 'CREATE DATABASE'
-        create_line = '{} {}{}'.format(create_decl, if_exists, name)
+        create_line = '{0} {1}{2}'.format(create_decl, if_exists, name)
         if self.path is not None:
-            create_line += "\nLOCATION '{}'".format(self.path)
+            create_line += "\nLOCATION '{0}'".format(self.path)
 
         return create_line
 
@@ -785,17 +785,17 @@ def _join_not_none(sep, pieces):
 def format_schema(schema):
     elements = [_format_schema_element(name, t)
                 for name, t in zip(schema.names, schema.types)]
-    return '({})'.format(',\n '.join(elements))
+    return '({0})'.format(',\n '.join(elements))
 
 
 def _format_schema_element(name, t):
-    return '{} {}'.format(quote_identifier(name, force=True),
+    return '{0} {1}'.format(quote_identifier(name, force=True),
                           _format_type(t))
 
 
 def _format_type(t):
     if isinstance(t, ir.DecimalType):
-        return 'DECIMAL({},{})'.format(t.precision, t.scale)
+        return 'DECIMAL({0},{1})'.format(t.precision, t.scale)
     else:
         return _impala_type_names[t]
 

--- a/ibis/sql/exprs.py
+++ b/ibis/sql/exprs.py
@@ -56,12 +56,12 @@ def _cast(translator, expr):
         return arg
     else:
         sql_type = _type_to_sql_string(op.target_type)
-        return 'CAST({!s} AS {!s})'.format(arg, sql_type)
+        return 'CAST({0!s} AS {1!s})'.format(arg, sql_type)
 
 
 def _type_to_sql_string(tval):
     if isinstance(tval, ir.DecimalType):
-        return 'decimal({},{})'.format(tval.precision, tval.scale)
+        return 'decimal({0},{1})'.format(tval.precision, tval.scale)
     else:
         return _sql_type_names[tval]
 
@@ -71,28 +71,28 @@ def _between(translator, expr):
     comp = translator.translate(op.expr)
     lower = translator.translate(op.lower_bound)
     upper = translator.translate(op.upper_bound)
-    return '{!s} BETWEEN {!s} AND {!s}'.format(comp, lower, upper)
+    return '{0!s} BETWEEN {1!s} AND {2!s}'.format(comp, lower, upper)
 
 
 def _contains(translator, expr):
     op = expr.op()
     comp = translator.translate(op.value)
     options = translator.translate(op.options)
-    return '{!s} IN {!s}'.format(comp, options)
+    return '{0!s} IN {1!s}'.format(comp, options)
 
 
 def _like(translator, expr):
     op = expr.op()
     arg = translator.translate(op.arg)
     pattern = translator.translate(op.pattern)
-    return '{!s} LIKE {!s}'.format(arg, pattern)
+    return '{0!s} LIKE {1!s}'.format(arg, pattern)
 
 
 def _rlike(translator, expr):
     op = expr.op()
     arg = translator.translate(op.arg)
     pattern = translator.translate(op.pattern)
-    return '{!s} RLIKE {!s}'.format(arg, pattern)
+    return '{0!s} RLIKE {1!s}'.format(arg, pattern)
 
 
 def _not_contains(translator, expr):
@@ -100,38 +100,38 @@ def _not_contains(translator, expr):
     op = expr.op()
     comp = translator.translate(op.value)
     options = translator.translate(op.options)
-    return '{!s} NOT IN {!s}'.format(comp, options)
+    return '{0!s} NOT IN {1!s}'.format(comp, options)
 
 
 def _is_null(translator, expr):
     formatted_arg = translator.translate(expr.op().arg)
-    return '{!s} IS NULL'.format(formatted_arg)
+    return '{0!s} IS NULL'.format(formatted_arg)
 
 
 def _not_null(translator, expr):
     formatted_arg = translator.translate(expr.op().arg)
-    return '{!s} IS NOT NULL'.format(formatted_arg)
+    return '{0!s} IS NOT NULL'.format(formatted_arg)
 
 
 def _negate(translator, expr):
     arg = expr.op().arg
     formatted_arg = translator.translate(arg)
     if isinstance(expr, ir.BooleanValue):
-        return 'NOT {!s}'.format(formatted_arg)
+        return 'NOT {0!s}'.format(formatted_arg)
     else:
         if _needs_parens(arg):
             formatted_arg = _parenthesize(formatted_arg)
-        return '-{!s}'.format(formatted_arg)
+        return '-{0!s}'.format(formatted_arg)
 
 
 def _parenthesize(what):
-    return '({!s})'.format(what)
+    return '({0!s})'.format(what)
 
 
 def _unary_op(func_name):
     def formatter(translator, expr):
         arg = translator.translate(expr.op().arg)
-        return '{!s}({!s})'.format(func_name, arg)
+        return '{0!s}({1!s})'.format(func_name, arg)
     return formatter
 
 
@@ -145,7 +145,7 @@ def _reduction(func_name):
         else:
             arg = translator.translate(op.arg)
 
-        return '{!s}({!s})'.format(func_name, arg)
+        return '{0!s}({1!s})'.format(func_name, arg)
     return formatter
 
 
@@ -158,7 +158,7 @@ def _fixed_arity_call(func_name, arity):
             fmt_arg = translator.translate(arg)
             formatted_args.append(fmt_arg)
 
-        return '{!s}({!s})'.format(func_name, ', '.join(formatted_args))
+        return '{0!s}({1!s})'.format(func_name, ', '.join(formatted_args))
     return formatter
 
 
@@ -175,7 +175,7 @@ def _binary_infix_op(infix_sym):
         if _needs_parens(op.right):
             right_arg = _parenthesize(right_arg)
 
-        return '{!s} {!s} {!s}'.format(left_arg, infix_sym, right_arg)
+        return '{0!s} {1!s} {2!s}'.format(left_arg, infix_sym, right_arg)
     return formatter
 
 
@@ -197,7 +197,7 @@ def _xor(translator, expr):
 
 
 def _name_expr(formatted_expr, quoted_name):
-    return '{!s} AS {!s}'.format(formatted_expr, quoted_name)
+    return '{0!s} AS {1!s}'.format(formatted_expr, quoted_name)
 
 
 def _needs_parens(op):
@@ -229,7 +229,7 @@ def _number_literal_format(expr):
 
 def _string_literal_format(expr):
     value = expr.op().value
-    return "'{!s}'".format(value.replace("'", "\\'"))
+    return "'{0!s}'".format(value.replace("'", "\\'"))
 
 
 def _timestamp_literal_format(expr):
@@ -239,7 +239,7 @@ def _timestamp_literal_format(expr):
             raise ValueError(value)
         value = value.strftime('%Y-%m-%d %H:%M:%S')
 
-    return "'{!s}'".format(value)
+    return "'{0!s}'".format(value)
 
 
 def quote_identifier(name, quotechar='`', force=False):
@@ -272,18 +272,18 @@ class CaseFormatter(object):
         self.buf.write('CASE')
         if self.base is not None:
             base_str = self._trans(self.base)
-            self.buf.write(' {}'.format(base_str))
+            self.buf.write(' {0}'.format(base_str))
 
         for case, result in zip(self.cases, self.results):
             self._next_case()
             case_str = self._trans(case)
             result_str = self._trans(result)
-            self.buf.write('WHEN {} THEN {}'.format(case_str, result_str))
+            self.buf.write('WHEN {0} THEN {1}'.format(case_str, result_str))
 
         if self.default is not None:
             self._next_case()
             default_str = self._trans(self.default)
-            self.buf.write('ELSE {}'.format(default_str))
+            self.buf.write('ELSE {0}'.format(default_str))
 
         if self.multiline:
             self.buf.write('\nEND')
@@ -294,7 +294,7 @@ class CaseFormatter(object):
 
     def _next_case(self):
         if self.multiline:
-            self.buf.write('\n{}'.format(' ' * self.indent))
+            self.buf.write('\n{0}'.format(' ' * self.indent))
         else:
             self.buf.write(' ')
 
@@ -379,7 +379,7 @@ def _table_array_view(translator, expr):
     ctx = translator.context
     table = expr.op().table
     query = ctx.get_formatted_query(table)
-    return '(\n{}\n)'.format(util.indent(query, ctx.indent))
+    return '(\n{0}\n)'.format(util.indent(query, ctx.indent))
 
 
 # ---------------------------------------------------------------------
@@ -407,7 +407,7 @@ _impala_delta_functions = {
 
 def _timestamp_format_offset(offset, arg):
     f = _impala_delta_functions[type(offset)]
-    return '{}({}, {})'.format(f, arg, offset.n)
+    return '{0}({1}, {2})'.format(f, arg, offset.n)
 
 
 # ---------------------------------------------------------------------
@@ -451,7 +451,7 @@ def _exists_subquery(translator, expr):
     else:
         raise NotImplementedError
 
-    return '{} (\n{}\n)'.format(key, util.indent(subquery, ctx.indent))
+    return '{0} (\n{1}\n)'.format(key, util.indent(subquery, ctx.indent))
 
 
 def _table_column(translator, expr):
@@ -482,7 +482,7 @@ def _extract_field(sql_attr):
 
         # This is pre-2.0 Impala-style, which did not used to support the
         # SQL-99 format extract($FIELD from expr)
-        return "extract({!s}, '{!s}')".format(arg, sql_attr)
+        return "extract({0!s}, '{1!s}')".format(arg, sql_attr)
     return extract_field_formatter
 
 
@@ -496,19 +496,19 @@ def _timestamp_from_unix(translator, expr):
         val = (val / 1000000).cast('int32')
 
     arg = _from_unixtime(translator, val)
-    return 'CAST({} AS timestamp)'.format(arg)
+    return 'CAST({0} AS timestamp)'.format(arg)
 
 
 def _from_unixtime(translator, expr):
     arg = translator.translate(expr)
-    return 'from_unixtime({}, "yyyy-MM-dd HH:mm:ss")'.format(arg)
+    return 'from_unixtime({0}, "yyyy-MM-dd HH:mm:ss")'.format(arg)
 
 
 def _coalesce_like(func_name):
     def coalesce_like_formatter(translator, expr):
         op = expr.op()
         trans_args = [translator.translate(arg) for arg in op.args]
-        return '{}({})'.format(func_name, ', '.join(trans_args))
+        return '{0}({1})'.format(func_name, ', '.join(trans_args))
     return coalesce_like_formatter
 
 
@@ -518,16 +518,16 @@ def _substring(translator, expr):
 
     # Databases are 1-indexed
     if op.length:
-        return 'substr({}, {}, {})'.format(arg_formatted, op.start + 1,
+        return 'substr({0}, {1}, {2})'.format(arg_formatted, op.start + 1,
                                            op.length)
     else:
-        return 'substr({}, {})'.format(arg_formatted, op.start + 1)
+        return 'substr({0}, {1})'.format(arg_formatted, op.start + 1)
 
 
 def _strright(translator, expr):
     op = expr.op()
     arg_formatted = translator.translate(op.arg)
-    return 'strright({}, {})'.format(arg_formatted, op.nchars)
+    return 'strright({0}, {1})'.format(arg_formatted, op.nchars)
 
 
 def _round(translator, expr):
@@ -535,9 +535,9 @@ def _round(translator, expr):
     arg_formatted = translator.translate(op.arg)
 
     if op.digits is not None:
-        return 'round({}, {})'.format(arg_formatted, op.digits)
+        return 'round({0}, {1})'.format(arg_formatted, op.digits)
     else:
-        return 'round({})'.format(arg_formatted)
+        return 'round({0})'.format(arg_formatted)
 
 
 def _hash(translator, expr):
@@ -545,7 +545,7 @@ def _hash(translator, expr):
     arg_formatted = translator.translate(op.arg)
 
     if op.how == 'fnv':
-        return 'fnv_hash({})'.format(arg_formatted)
+        return 'fnv_hash({0})'.format(arg_formatted)
     else:
         raise NotImplementedError(op.how)
 
@@ -555,15 +555,15 @@ def _log(translator, expr):
     arg_formatted = translator.translate(op.arg)
 
     if op.base is None:
-        return 'ln({})'.format(arg_formatted)
+        return 'ln({0})'.format(arg_formatted)
     else:
-        return 'log({}, {})'.format(arg_formatted, op.base)
+        return 'log({0}, {1})'.format(arg_formatted, op.base)
 
 
 def _count_distinct(translator, expr):
     op = expr.op()
     arg_formatted = translator.translate(op.arg)
-    return 'COUNT(DISTINCT {})'.format(arg_formatted)
+    return 'COUNT(DISTINCT {0})'.format(arg_formatted)
 
 
 def _literal(translator, expr):
@@ -596,7 +596,7 @@ _literal_formatters = {
 def _value_list(translator, expr):
     op = expr.op()
     formatted = [translator.translate(x) for x in op.values]
-    return '({})'.format(', '.join(formatted))
+    return '({0})'.format(', '.join(formatted))
 
 
 def _not_implemented(translator, expr):

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
 import pandas as pd
 
@@ -20,6 +20,7 @@ import ibis
 
 from ibis.sql.compiler import build_ast, to_sql
 from ibis.expr.tests.mocks import MockConnection
+from ibis.compat import unittest
 import ibis.common as com
 
 import ibis.expr.api as api
@@ -1643,7 +1644,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS foo.`new_table`
  `bar` TINYINT,
  `baz` SMALLINT)
 STORED AS PARQUET
-LOCATION '{}'""".format(directory)
+LOCATION '{0}'""".format(directory)
 
         assert result == expected
 

--- a/ibis/sql/tests/test_exprs.py
+++ b/ibis/sql/tests/test_exprs.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
+import sys
 
 import pandas as pd
 
 from ibis.sql.exprs import ExprTranslator
 from ibis.sql.compiler import QueryContext, to_sql
 from ibis.expr.tests.mocks import MockConnection
+from ibis.compat import unittest
 import ibis.expr.types as ir
 import ibis
 
@@ -218,7 +219,7 @@ class TestValueExprs(unittest.TestCase, ExprSQLTest):
                   'second', 'millisecond']
 
         cases = [(getattr(self.table.i, field)(),
-                  "extract(i, '{}')".format(field))
+                  "extract(i, '{0}')".format(field))
                  for field in fields]
         self._check_expr_cases(cases)
 
@@ -252,7 +253,7 @@ FROM alltypes"""
         for unit in units:
             K = 5
             offset = getattr(ibis, unit)(K)
-            template = '{}s_add({}, {})'
+            template = '{0}s_add({1}, {2})'
 
             cases.append((t + offset, template.format(unit, f, K)))
             cases.append((t - offset, template.format(unit, f, -K)))
@@ -330,7 +331,7 @@ class TestUnaryBuiltins(unittest.TestCase, ExprSQLTest):
 
             for cname in ['double_col', 'int_col']:
                 expr = getattr(self.table[cname], ibis_name)()
-                cases.append((expr, '{}({})'.format(sql_name, cname)))
+                cases.append((expr, '{0}({1})'.format(sql_name, cname)))
 
         self._check_expr_cases(cases)
 
@@ -362,7 +363,7 @@ class TestUnaryBuiltins(unittest.TestCase, ExprSQLTest):
     def test_reduction_where(self):
         cond = self.table.bigint_col < 70
         c = self.table.double_col
-        tmp = '{}(CASE WHEN bigint_col < 70 THEN double_col ELSE NULL END)'
+        tmp = '{0}(CASE WHEN bigint_col < 70 THEN double_col ELSE NULL END)'
         cases = [
             (c.sum(where=cond), tmp.format('sum')),
             (c.count(where=cond), tmp.format('count')),

--- a/ibis/tests/test_comms.py
+++ b/ibis/tests/test_comms.py
@@ -15,13 +15,14 @@
 import os
 import sys
 import threading
-import unittest
+import sys
 
 import pytest
 
 import numpy as np
 
 from ibis.util import guid
+from ibis.compat import unittest
 
 try:
     import ibis.comms as comms

--- a/ibis/tests/test_filesystems.py
+++ b/ibis/tests/test_filesystems.py
@@ -14,16 +14,16 @@
 
 from six import BytesIO
 
-
 from posixpath import join as pjoin
 import os
 import shutil
-import unittest
+import sys
 
 from hdfs import InsecureClient
 import pytest
 
 from ibis.filesystems import HDFS, WebHDFS
+from ibis.compat import unittest
 import ibis.util as util
 
 
@@ -76,16 +76,16 @@ class TestHDFSE2E(unittest.TestCase):
         cls.hdfs_host = os.environ.get('IBIS_TEST_HDFS_HOST', 'localhost')
         # Impala dev environment uses port 5070 for HDFS web interface
         cls.webhdfs_port = os.environ.get('IBIS_TEST_WEBHDFS_PORT', 5070)
-        url = 'http://{}:{}'.format(cls.hdfs_host, cls.webhdfs_port)
+        url = 'http://{0}:{1}'.format(cls.hdfs_host, cls.webhdfs_port)
 
-        cls.test_dir = '/{}'.format(util.guid())
+        cls.test_dir = '/{0}'.format(util.guid())
 
         try:
             cls.hdfs_client = InsecureClient(url)
             cls.hdfs = WebHDFS(cls.hdfs_client)
             cls.hdfs.mkdir(cls.test_dir)
         except Exception as e:
-            pytest.skip('Could not connect to HDFS: {}'.format(e.message))
+            pytest.skip('Could not connect to HDFS: {0}'.format(e.message))
 
     @classmethod
     def tearDownClass(cls):

--- a/ibis/tests/test_impala_e2e.py
+++ b/ibis/tests/test_impala_e2e.py
@@ -16,13 +16,14 @@ from posixpath import join as pjoin
 import gc
 import os
 import pytest
-import unittest
+import sys
 
 import pandas as pd
 
 from hdfs import InsecureClient
 
 import ibis
+from ibis.compat import unittest
 
 import ibis.common as com
 import ibis.config as config
@@ -42,7 +43,7 @@ class IbisTestEnv(object):
         self.hdfs_host = os.environ.get('IBIS_TEST_HDFS_HOST', 'localhost')
         # Impala dev environment uses port 5070 for HDFS web interface
         self.webhdfs_port = os.environ.get('IBIS_TEST_WEBHDFS_PORT', 5070)
-        url = 'http://{}:{}'.format(self.hdfs_host, self.webhdfs_port)
+        url = 'http://{0}:{1}'.format(self.hdfs_host, self.webhdfs_port)
         self.hdfs = InsecureClient(url)
 
 
@@ -302,7 +303,7 @@ FROM ibis_testing.tpch_lineitem li
             self.con.insert(table_name, expr.limit(10), database=db)
             self.con.insert(table_name, expr.limit(10), database=db)
 
-            sz = self.con.table('{}.{}'.format(db, table_name)).count()
+            sz = self.con.table('{0}.{1}'.format(db, table_name)).count()
             assert sz.execute() == 20
 
             # Overwrite and verify only 10 rows now
@@ -647,7 +648,7 @@ class TestQueryHDFSData(ImpalaE2E, unittest.TestCase):
 
         name = table.op().name
         assert 'ibis_tmp_' in name
-        assert name.startswith('{}.'.format(self.test_db))
+        assert name.startswith('{0}.'.format(self.test_db))
 
         # table exists
         self.con.table(name)

--- a/ibis/tests/test_server.py
+++ b/ibis/tests/test_server.py
@@ -19,8 +19,9 @@ import psutil
 import socket
 import struct
 import threading
-import unittest
+import sys
 
+from ibis.compat import unittest
 from ibis.server import IbisServerNode
 
 

--- a/ibis/tests/test_tasks.py
+++ b/ibis/tests/test_tasks.py
@@ -14,7 +14,7 @@
 
 import os
 import pytest
-import unittest
+import sys
 
 import pandas as pd
 
@@ -26,6 +26,7 @@ from ibis.util import guid
 from ibis.wire import BytesIO
 import ibis.wire as wire
 
+from ibis.compat import unittest
 from ibis.tests.test_server import WorkerTestFixture
 
 try:

--- a/scripts/load_test_data.py
+++ b/scripts/load_test_data.py
@@ -85,8 +85,8 @@ def generate_csv_files():
     }, columns=['foo', 'bar', 'baz'])
 
     for i in xrange(nfiles):
-        csv_path = os.path.join(csv_base, '{}.csv'.format(i))
-        print('Writing {}'.format(csv_path))
+        csv_path = os.path.join(csv_base, '{0}.csv'.format(i))
+        print('Writing {0}'.format(csv_path))
         df.to_csv(csv_path, index=False, header=False)
 
 
@@ -95,8 +95,8 @@ def scrape_parquet_files(con):
     to_scrape.append(('functional', 'alltypes'))
     for db, tname in to_scrape:
         table = con.table(tname, database=db)
-        new_name = '{}_{}'.format(db, tname)
-        print('Creating {}'.format(new_name))
+        new_name = '{0}_{1}'.format(db, tname)
+        print('Creating {0}'.format(new_name))
         con.create_table(new_name, table, database=TMP_DB)
 
 

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,11 @@ with open('requirements.txt') as f:
     file_reqs = f.read().splitlines()
     requirements = requirements + file_reqs
 
+PY26 = sys.version_info[0] == 2 and sys.version_info[1] == 6
+if PY26:
+  requirements.append('argparse')
+  requirements.append('unittest2')
+
 if COMMS_EXT_ENABLED:
     import numpy as np
     


### PR DESCRIPTION
Changes are:
- Fixing lots of strings for .format() to include the explicit arg number.
- Using the set() constructor instead of set literals
- Added argparse to requirements if installing on py2.6
- Refactoring out the use of subprocess.check_output()

Fixes #215.
