### PR TITLE
ENH: generalize load_test_data.py

### DIFF
--- a/scripts/create_test_data_archive.py
+++ b/scripts/create_test_data_archive.py
@@ -1,0 +1,126 @@
+# Copyright 2014 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Populates the ibis_testing Impala database
+
+from posixpath import join as pjoin
+import os
+import posixpath
+import shutil
+import tempfile
+import subprocess
+
+import numpy as np
+import pandas as pd
+import pandas.util.testing as tm
+
+from ibis.util import guid
+import ibis
+
+
+IMPALA_HOST = os.environ.get('IBIS_TEST_IMPALA_HOST', 'localhost')
+IMPALA_PROTOCOL = os.environ.get('IBIS_TEST_IMPALA_PROTOCOL', 'hiveserver2')
+IMPALA_PORT = int(os.environ.get('IBIS_TEST_IMPALA_PORT', 21050))
+NN_HOST = os.environ.get('IBIS_TEST_NN_HOST', 'localhost')
+WEBHDFS_PORT = int(os.environ.get('IBIS_TEST_WEBHDFS_PORT', 5070))
+
+
+HDFS_WRITABLE_PATH = os.environ.get('IBIS_HDFS_WRITABLE_PATH', '/tmp')
+IBIS_TEST_DATA_LOCAL_DIR = 'ibis-testing-data'
+TMP_DB_HDFS_PATH = pjoin(HDFS_WRITABLE_PATH, guid())
+TMP_DB = guid()
+
+
+def make_connection():
+    ic = ibis.impala_connect(host=IMPALA_HOST, port=IMPALA_PORT,
+                             protocol=IMPALA_PROTOCOL)
+    hdfs = ibis.hdfs_connect(host=NN_HOST, port=WEBHDFS_PORT)
+    return ibis.make_client(ic, hdfs_client=hdfs)
+
+
+def make_temp_database(con):
+    if con.exists_database(TMP_DB):
+        con.drop_database(TMP_DB, force=True)
+    con.create_database(TMP_DB, path=TMP_DB_HDFS_PATH)
+    print('Created database {0} at {1}'.format(TMP_DB, TMP_DB_HDFS_PATH))
+
+
+def scrape_parquet_files(con):
+    to_scrape = [('tpch', x) for x in con.list_tables(database='tpch')]
+    to_scrape.append(('functional', 'alltypes'))
+    for db, tname in to_scrape:
+        table = con.table(tname, database=db)
+        new_name = '{0}_{1}'.format(db, tname)
+        print('Creating {0}'.format(new_name))
+        con.create_table(new_name, table, database=TMP_DB)
+
+
+def download_parquet_files(con):
+    parquet_path = pjoin(IBIS_TEST_DATA_LOCAL_DIR, 'parquet')
+    print("Downloading {0}".format(parquet_path))
+    con.hdfs.get(TMP_DB_HDFS_PATH, parquet_path)
+
+
+def download_avro_files(con):
+    avro_path = '/test-warehouse/tpch.region_avro'
+    os.mkdir(os.path.join(IBIS_TEST_DATA_LOCAL_DIR, 'avro'))
+    print("Downloading {0}".format(avro_path))
+    con.hdfs.get(avro_path,
+                 pjoin(IBIS_TEST_DATA_LOCAL_DIR, 'avro', 'tpch.region'))
+
+
+def generate_csv_files():
+    N = 10
+    nfiles = 10
+
+    csv_base = os.path.join(IBIS_TEST_DATA_LOCAL_DIR, 'csv')
+    os.mkdir(csv_base)
+
+    df = pd.DataFrame({
+        'foo': [tm.rands(10) for _ in xrange(N)],
+        'bar': np.random.randn(N),
+        'baz': np.random.randint(0, 100, size=N)
+    }, columns=['foo', 'bar', 'baz'])
+
+    for i in xrange(nfiles):
+        csv_path = os.path.join(csv_base, '{0}.csv'.format(i))
+        print('Writing {0}'.format(csv_path))
+        df.to_csv(csv_path, index=False, header=False)
+
+
+def cleanup_temporary_stuff(con):
+    con.drop_database(TMP_DB, force=True)
+    assert not con.hdfs.exists(TMP_DB_HDFS_PATH)
+
+
+def make_local_test_archive():
+    con = make_connection()
+    make_temp_database(con)
+
+    try:
+        scrape_parquet_files(con)
+
+        if os.path.exists(IBIS_TEST_DATA_LOCAL_DIR):
+            shutil.rmtree(IBIS_TEST_DATA_LOCAL_DIR)
+        os.mkdir(IBIS_TEST_DATA_LOCAL_DIR)
+
+        download_parquet_files(con)
+        download_avro_files(con)
+        generate_csv_files()
+    finally:
+        cleanup_temporary_stuff(con)
+
+
+if __name__ == '__main__':
+    make_local_test_archive()

--- a/scripts/load_test_data.py
+++ b/scripts/load_test_data.py
@@ -12,131 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Populates the ibis_testing Impala database
+# Fetches the ibis-testing-data archive and loads it into Impala
 
 from posixpath import join as pjoin
 import os
 import posixpath
 import shutil
+import tempfile
+import subprocess
 
-from ibis.util import guid
 import ibis
 
-IMPALA_HOST = 'localhost'
-HDFS_HOST = 'localhost'
-WEBHDFS_PORT = 5070
-TEST_DB = 'ibis_testing'
-TEST_DATA_DIR = 'ibis-testing-data'
-TEST_DATA_HDFS_LOC = '/__ibis/ibis-testing-data'
+
+IMPALA_HOST = os.environ.get('IBIS_TEST_IMPALA_HOST', 'localhost')
+IMPALA_PROTOCOL = os.environ.get('IBIS_TEST_IMPALA_PROTOCOL', 'hiveserver2')
+IMPALA_PORT = int(os.environ.get('IBIS_TEST_IMPALA_PORT', 21050))
+NN_HOST = os.environ.get('IBIS_TEST_NN_HOST', 'localhost')
+WEBHDFS_PORT = int(os.environ.get('IBIS_TEST_WEBHDFS_PORT', 5070))
+
+
+IBIS_TEST_DATA_HDFS_DIR = os.environ.get('IBIS_TEST_DATA_HDFS_DIR',
+                                         '/__ibis/ibis-testing-data')
+IBIS_TEST_DB = os.environ.get('IBIS_TEST_DATABASE', 'ibis_testing')
+IBIS_TEST_DATA_URL = ('https://ibis-test-resources.s3.amazonaws.com/'
+                      'ibis-testing-data.tar.gz')
 
 
 def make_connection():
-    ic = ibis.impala_connect(host=IMPALA_HOST)
-    hdfs = ibis.hdfs_connect(host=HDFS_HOST, port=WEBHDFS_PORT)
-    con = ibis.make_client(ic, hdfs_client=hdfs)
-
-    return con
-
-# ----------------------------------------------------------------------
-# Functions for creating the test data archive to begin with
-
-TMP_DB_LOCATION = '/__ibis/{0}'.format(guid())
-TMP_DB = guid()
-
-def make_temp_database(con):
-    if con.exists_database(TMP_DB):
-        con.drop_database(TMP_DB, force=True)
-    con.create_database(TMP_DB, path=TMP_DB_LOCATION)
-    print('Created database {0} at {1}'.format(TMP_DB, TMP_DB_LOCATION))
+    ic = ibis.impala_connect(host=IMPALA_HOST, port=IMPALA_PORT,
+                             protocol=IMPALA_PROTOCOL)
+    hdfs = ibis.hdfs_connect(host=NN_HOST, port=WEBHDFS_PORT)
+    return ibis.make_client(ic, hdfs_client=hdfs)
 
 
-def cleanup_temporary_stuff(con):
-    con.drop_database(TMP_DB, force=True)
-    assert not con.hdfs.exists(TMP_DB_LOCATION)
-
-def download_parquet_files(con):
-    parquet_path = pjoin(TEST_DATA_DIR, 'parquet')
-    print("Downloading {0}".format(parquet_path))
-    con.hdfs.get(TMP_DB_LOCATION, parquet_path)
-
-
-def download_avro_files(con):
-    avro_path = '/test-warehouse/tpch.region_avro'
-    os.mkdir(os.path.join(TEST_DATA_DIR, 'avro'))
-    print("Downloading {0}".format(avro_path))
-    con.hdfs.get(avro_path, pjoin(TEST_DATA_DIR, 'avro', 'tpch.region'))
-
-
-def generate_csv_files():
-    import numpy as np
-    import pandas as pd
-    import pandas.util.testing as tm
-
-    N = 10
-    nfiles = 10
-
-    csv_base = os.path.join(TEST_DATA_DIR, 'csv')
-    os.mkdir(csv_base)
-
-    df = pd.DataFrame({
-        'foo': [tm.rands(10) for _ in xrange(N)],
-        'bar': np.random.randn(N),
-        'baz': np.random.randint(0, 100, size=N)
-    }, columns=['foo', 'bar', 'baz'])
-
-    for i in xrange(nfiles):
-        csv_path = os.path.join(csv_base, '{0}.csv'.format(i))
-        print('Writing {0}'.format(csv_path))
-        df.to_csv(csv_path, index=False, header=False)
-
-
-def scrape_parquet_files(con):
-    to_scrape = [('tpch', x) for x in con.list_tables(database='tpch')]
-    to_scrape.append(('functional', 'alltypes'))
-    for db, tname in to_scrape:
-        table = con.table(tname, database=db)
-        new_name = '{0}_{1}'.format(db, tname)
-        print('Creating {0}'.format(new_name))
-        con.create_table(new_name, table, database=TMP_DB)
-
-
-def make_local_test_archive():
-    con = make_connection()
-    make_temp_database(con)
-
-    try:
-        scrape_parquet_files(con)
-
-        if os.path.exists(TEST_DATA_DIR):
-            shutil.rmtree(TEST_DATA_DIR)
-        os.mkdir(TEST_DATA_DIR)
-
-        download_parquet_files(con)
-        download_avro_files(con)
-        generate_csv_files()
-    finally:
-        cleanup_temporary_stuff(con)
-
-# ----------------------------------------------------------------------
-#
-
-
-def write_data_to_hdfs(con):
-    # TODO per #278, write directly from the gzipped tarball
-    con.hdfs.put(TEST_DATA_HDFS_LOC, TEST_DATA_DIR,
-                 verbose=True, overwrite=True)
+def get_ibis_test_data(local_path):
+    cmd = 'cd {0} && wget {1} && tar -xzf {2}'.format(
+        local_path, IBIS_TEST_DATA_URL, os.path.basename(IBIS_TEST_DATA_URL))
+    subprocess.check_call(cmd, shell=True)
+    data_dir = pjoin(local_path,
+                     os.path.basename(IBIS_TEST_DATA_URL).split('.', 2)[0])
+    print('Downloaded {0} and unpacked it to {1}'.format(IBIS_TEST_DATA_URL,
+                                                         data_dir))
+    return data_dir
 
 
 def create_test_database(con):
-    if con.exists_database(TEST_DB):
-        con.drop_database(TEST_DB, force=True)
-    con.create_database(TEST_DB)
-    print('Created database {0}'.format(TEST_DB))
+    if con.exists_database(IBIS_TEST_DB):
+        con.drop_database(IBIS_TEST_DB, force=True)
+    con.create_database(IBIS_TEST_DB)
+    print('Created database {0}'.format(IBIS_TEST_DB))
 
 
 def create_parquet_tables(con):
-    parquet_files = con.hdfs.ls(pjoin(TEST_DATA_HDFS_LOC, 'parquet'))
-
+    parquet_files = con.hdfs.ls(pjoin(IBIS_TEST_DATA_HDFS_DIR, 'parquet'))
     schemas = {
         'functional_alltypes': ibis.schema(
             [('id', 'int32'),
@@ -151,23 +79,25 @@ def create_parquet_tables(con):
              ('string_col', 'string'),
              ('timestamp_col', 'timestamp'),
              ('year', 'int32'),
-             ('month', 'int32')])
-    }
-
+             ('month', 'int32')])}
     for path in parquet_files:
         head, table_name = posixpath.split(path)
         print 'Creating {0}'.format(table_name)
-
         # if no schema infer!
         schema = schemas.get(table_name)
-
         con.parquet_file(path, schema=schema, name=table_name,
-                         database=TEST_DB, persist=True)
+                         database=IBIS_TEST_DB, persist=True)
 
 
 def setup_test_data():
     con = make_connection()
-    write_data_to_hdfs(con)
+    try:
+        tmp_dir = tempfile.mkdtemp(prefix='__ibis_tmp')
+        local_data_dir = get_ibis_test_data(tmp_dir)
+        con.hdfs.put(IBIS_TEST_DATA_HDFS_DIR, local_data_dir, overwrite=True,
+                     verbose=True)
+    finally:
+        shutil.rmtree(tmp_dir)
     create_test_database(con)
     create_parquet_tables(con)
 


### PR DESCRIPTION
`load_test_data.py` now has config options (through env variables) that make it suitable to work with arbitrary clusters.

It also now downloads the necessary test data from S3, and I removed some unnecessary(?) functions.

Is using `curl` discouraged in a case like this?  Should I use `boto` instead?
