### PR TITLE
Work around isnull decimal return type issue

### DIFF
--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -192,8 +192,8 @@ class IfNull(ValueNode):
           .else_(null_substitute_expr)
     """
 
-    input_type = [value, value(name='ifnull_expr')]
-    # rules.cast_if_decimal(0, name='ifnull_expr')]
+    input_type = [value,
+                  rules.cast_if_decimal(0, name='ifnull_expr')]
     output_type = rules.type_of_arg(0)
 
 

--- a/ibis/sql/tests/test_exprs.py
+++ b/ibis/sql/tests/test_exprs.py
@@ -444,19 +444,20 @@ END"""
         cases = [
             (f.nullif(f == 0),
              'nullif(l_quantity, l_quantity = 0)'),
-            (f.fillna(0), 'isnull(l_quantity, 0)'),
+            (f.fillna(0),
+             'isnull(l_quantity, CAST(0 AS decimal(12,2)))'),
         ]
         self._check_expr_cases(cases)
 
-    # def test_decimal_fillna_cast_arg(self):
-    #     table = self.con.table('tpch_lineitem')
-    #     f = table.l_extendedprice
+    def test_decimal_fillna_cast_arg(self):
+        table = self.con.table('tpch_lineitem')
+        f = table.l_extendedprice
 
-    #     cases = [
-    #         (f.fillna(0),
-    #          'isnull(l_extendedprice, CAST(0 AS decimal(12,2)))')
-    #     ]
-    #     self._check_expr_cases(cases)
+        cases = [
+            (f.fillna(0),
+             'isnull(l_extendedprice, CAST(0 AS decimal(12,2)))')
+        ]
+        self._check_expr_cases(cases)
 
 
 class TestBucketHistogram(unittest.TestCase, ExprSQLTest):

--- a/ibis/tests/test_impala_e2e.py
+++ b/ibis/tests/test_impala_e2e.py
@@ -441,7 +441,7 @@ FROM ibis_testing.tpch_lineitem li
         cases = [
             (dc % 5, Decimal('0.245')),
 
-            # (dc.fillna(0), Decimal('5.245')),
+            (dc.fillna(0), Decimal('5.245')),
 
             (dc.exp(), 189.6158),
             (dc.log(), 1.65728),


### PR DESCRIPTION
Impala has some inconsistent type output in `isnull`. In the meantime, I'm inserting an explicit cast hack. per #345 
