### PR TITLE
TST: fix failing test_query_parquet_file_like_table

### DIFF
--- a/ibis/tests/test_impala_e2e.py
+++ b/ibis/tests/test_impala_e2e.py
@@ -784,7 +784,7 @@ class TestQueryHDFSData(ImpalaE2E, unittest.TestCase):
                                  ('r_name', 'string'),
                                  ('r_comment', 'string')])
 
-        table = self.con.parquet_file(hdfs_path, like_table='tpch.region')
+        table = self.con.parquet_file(hdfs_path, like_table='tpch_region')
 
         assert table.schema().equals(ex_schema)
 
@@ -793,6 +793,9 @@ class TestQueryHDFSData(ImpalaE2E, unittest.TestCase):
 
         table = self.con.parquet_file(hdfs_path)
 
+        # NOTE: the actual schema should have an int16, but bc this is being
+        # inferred from a parquet file, which has no notion of int16, the
+        # inferred schema will have an int32 instead.
         ex_schema = ibis.schema([('r_regionkey', 'int32'),
                                  ('r_name', 'string'),
                                  ('r_comment', 'string')])

--- a/scripts/load_test_data.py
+++ b/scripts/load_test_data.py
@@ -73,7 +73,11 @@ def create_parquet_tables(con):
              ('string_col', 'string'),
              ('timestamp_col', 'timestamp'),
              ('year', 'int32'),
-             ('month', 'int32')])}
+             ('month', 'int32')]),
+        'tpch_region': ibis.schema(
+            [('r_regionkey', 'int16'),
+             ('r_name', 'string'),
+             ('r_comment', 'string')])}
     for path in parquet_files:
         head, table_name = posixpath.split(path)
         print 'Creating {0}'.format(table_name)


### PR DESCRIPTION
Accidentally referenced `tpch.region` instead of `tpch_region` and specified an `int16` by accident.

Fixes #341.
