### PR TITLE
TST: create_database() now mkdirs its target path

### DIFF
--- a/ibis/client.py
+++ b/ibis/client.py
@@ -323,6 +323,10 @@ class ImpalaClient(SQLClient):
           HDFS path where to store the database data; otherwise uses Impala
           default
         """
+        if path:
+            # explicit mkdir ensures the user own the dir rather than impala,
+            # which is easier for manual cleanup, if necessary
+            self._hdfs.mkdir(path, create_parent=True)
         statement = ddl.CreateDatabase(name, path=path,
                                        fail_if_exists=fail_if_exists)
         self._execute(statement)

--- a/ibis/tests/test_impala_e2e.py
+++ b/ibis/tests/test_impala_e2e.py
@@ -199,10 +199,6 @@ class TestImpalaConnection(ImpalaE2E, unittest.TestCase):
         name = 'test_{0}'.format(util.guid())
         tmp_path = pjoin(base, name)
 
-        # We have to explicitly mkdir(base) because if we leave the dir
-        # creation to Impala, then the base dir will be owned by user impala,
-        # and we will not be able to remove it when we clean up
-        self.hdfs.mkdir(base, create_parent=True)
         self.con.create_database(name, path=tmp_path)
         assert self.hdfs.exists(base)
         self.con.drop_database(name)


### PR DESCRIPTION
Fixes #372.

@wesm, this change moves the `mkdir` call to `create_database`.  Is this ok with you?
