### PR TITLE
ENH: create parquet table from pandas dataframe

### DIFF
--- a/ibis/client.py
+++ b/ibis/client.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from itertools import izip
+from posixpath import join as pjoin
+from six import BytesIO
 
 import hdfs
 
@@ -433,7 +435,7 @@ class ImpalaClient(SQLClient):
         ibis_types = []
         for t in types:
             t = t.lower()
-            t = _impala_type_mapping.get(t, t)
+            t = _impala_to_ibis_type_mapping.get(t, t)
             ibis_types.append(t)
 
         names = [x.lower() for x in names]
@@ -524,6 +526,36 @@ class ImpalaClient(SQLClient):
             raise com.IbisError('Must pass expr or schema')
 
         self._execute(statement)
+
+    def pandas(self, df, name=None, database=None, persist=False):
+        """
+        Create a (possibly temp) parquet table from a local pandas DataFrame.
+        """
+        name, database = self._get_concrete_table_path(name, database,
+                                                       persist=persist)
+        qualified_name = self._fully_qualified_name(name, database)
+
+        # write df to a temp CSV file on HDFS
+        temp_csv_hdfs_dir = pjoin(options.impala.temp_hdfs_path, util.guid())
+        buf = BytesIO()
+        df.to_csv(buf, header=False, index=False, na_rep='\N')
+        self.hdfs.put(pjoin(temp_csv_hdfs_dir, '0.csv'), buf)
+
+        # define a temporary table using delimited data
+        schema = util.pandas_to_ibis_schema(df)
+        table = self.delimited_file(
+            temp_csv_hdfs_dir, schema,
+            name='ibis_tmp_pandas_{0}'.format(util.guid()), database=database,
+            external=True, persist=False)
+
+        # CTAS into Parquet
+        self.create_table(name, expr=table, database=database,
+                          format='parquet', overwrite=False)
+
+        # cleanup
+        self.hdfs.delete(temp_csv_hdfs_dir, recursive=True)
+
+        return self._wrap_new_table(qualified_name, persist)
 
     def avro_file(self, hdfs_dir, avro_schema,
                   name=None, database=None,
@@ -820,7 +852,7 @@ class ImpalaClient(SQLClient):
         for col in descr:
             names.append(col[0])
             impala_typename = col[1]
-            typename = _impala_type_mapping[impala_typename.lower()]
+            typename = _impala_to_ibis_type_mapping[impala_typename.lower()]
 
             if typename == 'decimal':
                 precision, scale = col[4:6]
@@ -830,7 +862,7 @@ class ImpalaClient(SQLClient):
         return names, adapted_types
 
 
-_impala_type_mapping = {
+_impala_to_ibis_type_mapping = {
     'boolean': 'boolean',
     'tinyint': 'int8',
     'smallint': 'int16',

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -114,6 +114,9 @@ class Schema(object):
         return ((self.names == other.names) and
                 (self.types == other.types))
 
+    def __eq__(self, other):
+        return self.equals(other)
+
     def get_type(self, name):
         return self.types[self._name_locs[name]]
 

--- a/ibis/filesystems.py
+++ b/ibis/filesystems.py
@@ -276,8 +276,9 @@ class WebHDFS(HDFS):
             else:
                 if verbose:
                     self.log('Writing buffer to HDFS {0}'.format(hdfs_path))
-                self.client.write(hdfs_path, resource, overwrite=overwrite,
-                                  **kwargs)
+                # TODO: eliminate the .getvalue() call to support general handle types
+                self.client.write(hdfs_path, resource.getvalue(),
+                                  overwrite=overwrite, **kwargs)
 
     @implements(HDFS.get)
     def get(self, hdfs_path, local_path, overwrite=False, verbose=None):

--- a/ibis/tests/test_pandas_interop.py
+++ b/ibis/tests/test_pandas_interop.py
@@ -1,0 +1,202 @@
+# Copyright 2015 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import ibis
+from ibis.compat import unittest
+from ibis.util import pandas_to_ibis_schema
+from ibis.common import IbisTypeError
+from ibis.tests.util import ImpalaE2E
+
+
+functional_alltypes_with_nulls = pd.DataFrame({
+    'bigint_col': np.int64([0, 10, 20, 30, 40, 50, 60, 70, 80, 90]),
+    'bool_col': np.bool_([True, False, True, False, True, None, True, False, True,
+                 False]),
+    'date_string_col': ['11/01/10', None, '11/01/10', '11/01/10',
+                        '11/01/10', '11/01/10', '11/01/10', '11/01/10',
+                        '11/01/10', '11/01/10'],
+    'double_col': np.float64([0.0, 10.1, None, 30.299999999999997,
+                   40.399999999999999, 50.5, 60.599999999999994,
+                   70.700000000000003, 80.799999999999997, 90.899999999999991]),
+    'float_col': np.float32([None, 1.1000000238418579, 2.2000000476837158,
+                  3.2999999523162842, 4.4000000953674316, 5.5,
+                  6.5999999046325684, 7.6999998092651367, 8.8000001907348633,
+                  9.8999996185302734]),
+    'int_col': np.int32([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    'month': [11, 11, 11, 11, 2, 11, 11, 11, 11, 11],
+    'smallint_col': np.int16([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    'string_col': ['0', '1', None, '3', '4', '5', '6', '7', '8', '9'],
+    'timestamp_col': [pd.Timestamp('2010-11-01 00:00:00'),
+                      None,
+                      pd.Timestamp('2010-11-01 00:02:00.100000'),
+                      pd.Timestamp('2010-11-01 00:03:00.300000'),
+                      pd.Timestamp('2010-11-01 00:04:00.600000'),
+                      pd.Timestamp('2010-11-01 00:05:00.100000'),
+                      pd.Timestamp('2010-11-01 00:06:00.150000'),
+                      pd.Timestamp('2010-11-01 00:07:00.210000'),
+                      pd.Timestamp('2010-11-01 00:08:00.280000'),
+                      pd.Timestamp('2010-11-01 00:09:00.360000')],
+    'tinyint_col': np.int8([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+    'year': [2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010, 2010]})
+
+
+class TestPandasSchemaInference(unittest.TestCase):
+
+    def test_dtype_bool(self):
+        df = pd.DataFrame({'col': [True, False, False]})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'boolean')])
+        assert inferred == expected
+
+    def test_dtype_int8(self):
+        df = pd.DataFrame({'col': np.int8([-3, 9, 17])})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'int8')])
+        assert inferred == expected
+
+    def test_dtype_int16(self):
+        df = pd.DataFrame({'col': np.int16([-5, 0, 12])})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'int16')])
+        assert inferred == expected
+
+    def test_dtype_int32(self):
+        df = pd.DataFrame({'col': np.int32([-12, 3, 25000])})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'int32')])
+        assert inferred == expected
+
+    def test_dtype_int64(self):
+        df = pd.DataFrame({'col': np.int64([102, 67228734, -0])})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'int64')])
+        assert inferred == expected
+
+    def test_dtype_float32(self):
+        df = pd.DataFrame({'col': np.float32([45e-3, -0.4, 99.])})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'float')])
+        assert inferred == expected
+
+    def test_dtype_float64(self):
+        df = pd.DataFrame({'col': np.float64([-3e43, 43., 10000000.])})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'double')])
+        assert inferred == expected
+
+    def test_dtype_uint8(self):
+        df = pd.DataFrame({'col': np.uint8([3, 0, 16])})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'int16')])
+        assert inferred == expected
+
+    def test_dtype_uint16(self):
+        df = pd.DataFrame({'col': np.uint16([5569, 1, 33])})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'int32')])
+        assert inferred == expected
+
+    def test_dtype_uint32(self):
+        df = pd.DataFrame({'col': np.uint32([100, 0, 6])})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'int64')])
+        assert inferred == expected
+
+    def test_dtype_uint64(self):
+        df = pd.DataFrame({'col': np.uint64([666, 2, 3])})
+        with self.assertRaises(IbisTypeError):
+            inferred = pandas_to_ibis_schema(df)
+
+    def test_dtype_datetime64(self):
+        df = pd.DataFrame({
+            'col': [pd.Timestamp('2010-11-01 00:01:00'),
+                    pd.Timestamp('2010-11-01 00:02:00.1000'),
+                    pd.Timestamp('2010-11-01 00:03:00.300000')]})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'timestamp')])
+        assert inferred == expected
+
+    def test_dtype_timedelta64(self):
+        df = pd.DataFrame({
+            'col': [pd.Timedelta('1 days'),
+                    pd.Timedelta('-1 days 2 min 3us'),
+                    pd.Timedelta('-2 days +23:57:59.999997')]})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'int64')])
+        assert inferred == expected
+
+    def test_dtype_string(self):
+        df = pd.DataFrame({'col': ['foo', 'bar', 'hello']})
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'string')])
+        assert inferred == expected
+
+    def test_dtype_categorical(self):
+        df = pd.DataFrame({'col': ['a', 'b', 'c', 'a']}, dtype='category')
+        inferred = pandas_to_ibis_schema(df)
+        expected = ibis.schema([('col', 'category')])
+        assert inferred == expected
+
+
+@pytest.mark.e2e
+class TestPandasRoundTrip(ImpalaE2E, unittest.TestCase):
+
+    def test_round_trip(self):
+        df1 = self.alltypes.execute()
+        df2 = self.con.pandas(df, 'bamboo', database=self.tmp_db).execute()
+        assert (df1.columns == df2.columns).all()
+        assert (df1.dtypes == df2.dtypes).all()
+        assert (df1 == df2).all().all()
+
+    def test_round_trip_non_int_missing_data(self):
+        df1 = functional_alltypes_with_nulls
+        table = self.con.pandas(df1, 'fawn', database=self.tmp_db)
+        df2 = table.execute()
+        assert (df1.columns == df2.columns).all()
+        assert (df1.dtypes == df2.dtypes).all()
+        # bool/int cols should be exact
+        assert (df1.bool_col == df2.bool_col).all()
+        assert (df1.tinyint_col == df2.tinyint_col).all()
+        assert (df1.smallint_col == df2.smallint_col).all()
+        assert (df1.int_col == df2.int_col).all()
+        assert (df1.bigint_col == df2.bigint_col).all()
+        assert (df1.month == df2.month).all()
+        assert (df1.year == df2.year).all()
+        # string cols should be equal everywhere except for the NULLs
+        assert (df1.string_col == df2.string_col) == [1, 1, 0, 1, 1, 1, 1, 1, 1, 1]
+        assert (df1.date_string_col == df2.date_string_col) == [1, 0, 1, 1, 1, 1, 1, 1, 1, 1]
+        # float cols within tolerance, and NULLs should be False
+        assert (df1.double_col - df2.double_col < 1e-9) == [1, 1, 0, 1, 1, 1, 1, 1, 1, 1]
+        assert (df1.float_col - df2.float_col < 1e-9) == [0, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+    def test_round_trip_missing_type_promotion(self):
+        # prepare Impala table with missing ints
+        # TODO: switch to self.con.raw_sql once #412 is fixed
+        create_query = ('CREATE TABLE {0}.missing_ints '
+                        '  (tinyint_col TINYINT, bigint_col BIGINT) '
+                        'STORED AS PARQUET'.format(self.tmp_db))
+        insert_query = ('INSERT INTO {0}.missing_ints '
+                        'VALUES (NULL, 3), (-5, NULL), (19, 444444)'.format(
+                            self.tmp_db))
+        self.con.con.cursor.execute(create_query)
+        self.con.con.cursor.execute(insert_query)
+
+        table = self.con.table('missing_ints', database=self.tmp_db)
+        df = table.execute()
+
+        # WHAT NOW?

--- a/ibis/tests/util.py
+++ b/ibis/tests/util.py
@@ -14,9 +14,12 @@
 
 import os
 
+import pytest
+
 from ibis import Schema
 from ibis import options
 import ibis.util as util
+import ibis
 
 
 class IbisTestEnv(object):
@@ -51,6 +54,66 @@ class IbisTestEnv(object):
     def __repr__(self):
         kvs = ['{0}={1}'.format(k, v) for (k, v) in self.__dict__.iteritems()]
         return 'IbisTestEnv(\n    {0})'.format(',\n    '.join(kvs))
+
+
+def test_connect(env, with_hdfs=True):
+    con = ibis.impala_connect(host=env.impala_host,
+                              protocol=env.impala_protocol,
+                              database=env.test_data_db,
+                              port=env.impala_port,
+                              use_kerberos=env.use_kerberos)
+    if with_hdfs:
+        if env.use_kerberos:
+            from hdfs.ext.kerberos import KerberosClient
+            hdfs_client = KerberosClient(env.hdfs_url, mutual_auth='REQUIRED')
+        else:
+            from hdfs.client import InsecureClient
+            hdfs_client = InsecureClient(env.hdfs_url)
+        return ibis.make_client(con, hdfs_client)
+    else:
+        return ibis.make_client(con)
+
+
+@pytest.mark.e2e
+class ImpalaE2E(object):
+
+    @classmethod
+    def setUpClass(cls):
+        ENV = IbisTestEnv()
+        cls.con = test_connect(ENV)
+        # Tests run generally faster without it
+        if not ENV.use_codegen:
+            cls.con.disable_codegen()
+        cls.hdfs = cls.con.hdfs
+        cls.test_data_dir = ENV.test_data_dir
+        cls.test_data_db = ENV.test_data_db
+        cls.tmp_dir = ENV.tmp_dir
+        cls.tmp_db = ENV.tmp_db
+        cls.alltypes = cls.con.table('functional_alltypes')
+
+        if not cls.con.exists_database(cls.tmp_db):
+            cls.con.create_database(cls.tmp_db)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.con.drop_database(cls.tmp_db, force=True)
+
+    def setUp(self):
+        self.temp_databases = []
+        self.temp_tables = []
+        self.temp_views = []
+
+    def tearDown(self):
+        for t in self.temp_tables:
+            self.con.drop_table(t, force=True)
+
+        for t in self.temp_views:
+            self.con.drop_view(t, force=True)
+
+        self.con.set_database(self.test_data_db)
+        for t in self.temp_databases:
+            self.con.drop_database(t, force=True)
+
 
 
 def assert_equal(left, right):

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import pandas as pd
+import pandas.core.common as pdcom
+
+import ibis
+from ibis.common import IbisTypeError
+
 
 def guid():
     try:
@@ -114,3 +121,62 @@ class IbisMap(object):
             if key.equals(k):
                 return v
         raise KeyError(key)
+
+
+def pandas_col_to_ibis_type(col):
+    dty = col.dtype
+
+    # datetime types
+    if pdcom.is_datetime64_dtype(dty):
+        if pdcom.is_datetime64_ns_dtype(dty):
+            return 'timestamp'
+        else:
+            raise IbisTypeError(
+                "Column {0} has dtype {1}, which is datetime64-like but does "
+                "not use nanosecond units".format(col.name, dty))
+    if pdcom.is_timedelta64_dtype(dty):
+        print("Warning: encoding a timedelta64 as an int64")
+        return 'int64'
+
+    if pdcom.is_categorical_dtype(dty):
+        return 'category'
+
+    if pdcom.is_bool_dtype(dty):
+        return 'boolean'
+
+    # simple numerical types
+    if issubclass(dty.type, np.int8):
+        return 'int8'
+    if issubclass(dty.type, np.int16):
+        return 'int16'
+    if issubclass(dty.type, np.int32):
+        return 'int32'
+    if issubclass(dty.type, np.int64):
+        return 'int64'
+    if issubclass(dty.type, np.float32):
+        return 'float'
+    if issubclass(dty.type, np.float64):
+        return 'double'
+    if issubclass(dty.type, np.uint8):
+        return 'int16'
+    if issubclass(dty.type, np.uint16):
+        return 'int32'
+    if issubclass(dty.type, np.uint32):
+        return 'int64'
+    if issubclass(dty.type, np.uint64):
+        raise IbisTypeError("Column {0} is an unsigned int64".format(col.name))
+
+    if pdcom.is_object_dtype(dty):
+        # TODO: overly broad?
+        return 'string'
+
+    raise IbisTypeError("Column {0} is dtype {1}".format(col.name, dty))
+
+
+def pandas_to_ibis_schema(frame):
+    # no analog for decimal in pandas
+    pairs = []
+    for col_name in frame:
+        ibis_type = pandas_col_to_ibis_type(frame[col_name])
+        pairs.append((col_name, ibis_type))
+    return ibis.schema(pairs)


### PR DESCRIPTION
Part of #197.

WebHDFS.write() no longer supports a bona fide file-like object.  See #410.
