### PR TITLE
BUG: execute() was ignoring the default_limit arg

### DIFF
--- a/ibis/expr/tests/mocks.py
+++ b/ibis/expr/tests/mocks.py
@@ -129,8 +129,8 @@ class MockConnection(SQLClient):
         name = name.replace('`', '')
         return ir.Schema.from_tuples(self._tables[name])
 
-    def execute(self, expr, default_limit=None):
-        ast, expr = self._build_ast_ensure_limit(expr, default_limit)
+    def execute(self, expr, limit=None):
+        ast, expr = self._build_ast_ensure_limit(expr, limit)
         for query in ast.queries:
             query.compile()
 

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -189,7 +189,7 @@ class Expr(object):
             limit = config.options.sql.default_limit
 
             try:
-                result = self.execute(default_limit=limit)
+                result = self.execute(limit=limit)
                 return repr(result)
             except com.TranslationError:
                 output = ('Translation to backend failed, repr follows:\n%s'
@@ -261,7 +261,7 @@ class Expr(object):
     def _can_implicit_cast(self, arg):
         return False
 
-    def execute(self, default_limit=None):
+    def execute(self, limit=None):
         """
         If this expression is based on physical tables in a database backend,
         execute it against that backend.
@@ -273,7 +273,7 @@ class Expr(object):
         """
         import ibis.expr.analysis as L
         backend = L.find_backend(self)
-        return backend.execute(self, default_limit=default_limit)
+        return backend.execute(self, limit=limit)
 
     def equals(self, other):
         if type(self) != type(other):

--- a/ibis/tests/test_impala_e2e.py
+++ b/ibis/tests/test_impala_e2e.py
@@ -831,6 +831,37 @@ FROM {0}.tpch_lineitem li
             self.test_data_db)
         assert queries[0] == expected
 
+    def test_sql_query_limits(self):
+        table = self.con.table('tpch_nation', database=self.test_data_db)
+        with config.option_context('sql.default_limit', 100000):
+            # table has 25 rows
+            assert len(table.execute()) == 25
+            # comply with limit arg for TableExpr
+            assert len(table.execute(limit=10)) == 10
+            # state hasn't changed
+            assert len(table.execute()) == 25
+            # non-TableExpr ignores default_limit
+            assert table.count().execute() == 25
+            # non-TableExpr doesn't observe limit arg
+            assert table.count().execute(limit=10) == 25
+        with config.option_context('sql.default_limit', 20):
+            # TableExpr observes default limit setting
+            assert len(table.execute()) == 20
+            # explicit limit= overrides default
+            assert len(table.execute(limit=15)) == 15
+            assert len(table.execute(limit=23)) == 23
+            # non-TableExpr ignores default_limit
+            assert table.count().execute() == 25
+            # non-TableExpr doesn't observe limit arg
+            assert table.count().execute(limit=10) == 25
+        # eliminating default_limit doesn't break anything
+        with config.option_context('sql.default_limit', None):
+            assert len(table.execute()) == 25
+            assert len(table.execute(limit=15)) == 15
+            assert len(table.execute(limit=10000)) == 25
+            assert table.count().execute() == 25
+            assert table.count().execute(limit=10) == 25
+
 
 def _ensure_drop(con, table_name, database=None):
     con.drop_table(table_name, database=database, force=True)


### PR DESCRIPTION
Fixes #414.

This patch also changes the `default_limit` arg to `limit` where it makes sense.
