### PR TITLE
WIP: Add Support for ODBC Connection

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     # upgrade sqlite3 to # make sure we have the "instr" function available
     - sudo apt-get -qq install --only-upgrade sqlite3
     # clang/boost for UDFs and graphviz for visualization
-    - sudo apt-get -qq install clang libboost-dev graphviz
+    - sudo apt-get -qq install clang libboost-dev graphviz unixodbc-dev unixodbc-bin unixodbc
   environment:
     IBIS_TEST_SQLITE_DB_PATH: $HOME/ibis-testing-data/ibis_testing.db
     IBIS_TEST_POSTGRES_DB: circle_test

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -286,8 +286,11 @@ class ImpalaQuery(Query):
 
     def _fetch(self, cursor):
         batches = cursor.fetchall(columnar=True)
-        names = [x[0] for x in cursor.description]
-        return _column_batches_to_dataframe(names, batches)
+        try:
+            names = [x[0] for x in cursor.description]
+            return _column_batches_to_dataframe(names, batches)
+        except AttributeError:
+            return batches
 
     def _db_type_to_dtype(self, db_type):
         return _HS2_TTypeId_to_dtype[db_type]

--- a/ibis/odbc/impala.py
+++ b/ibis/odbc/impala.py
@@ -54,7 +54,7 @@ def connect(dsn=None, connection_string=None, turbodbc_options=None,
                                turbodbc_options=turbodbc_options)
 
     try:
-        client = ImpalaODBCCLient(con, hdfs_client=hdfs_client)
+        client = ImpalaClient(con, hdfs_client=hdfs_client)
 
         if options.default_backend is None:
             options.default_backend = client
@@ -105,39 +105,39 @@ class ImpalaODBCConnection(ImpalaConnection):
         return cursor
 
 
-class ImpalaODBCCLient(ImpalaClient):
-
-    def describe_formatted(self, name, database=None):
-        """
-        Retrieve results of DESCRIBE FORMATTED command. See Impala
-        documentation for more.
-
-        Parameters
-        ----------
-        name : string
-          Table name. Can be fully qualified (with database)
-        database : string, optional
-        """
-        from ibis.impala.metadata import parse_metadata
-
-        stmt = self._table_command('DESCRIBE FORMATTED',
-                                   name, database=database)
-        query = ImpalaODBCQuery(self, stmt)
-        result = query.execute()
-
-        # Leave formatting to pandas
-        for c in result.columns:
-            result[c] = result[c].str.strip()
-
-        return parse_metadata(result)
-
-
-    def _exec_statement(self, stmt, adapter=None):
-        query = ImpalaODBCQuery(self, stmt)
-        result = query.execute()
-        if adapter is not None:
-            result = adapter(result)
-        return result
+# class ImpalaODBCCLient(ImpalaClient):
+#
+#     def describe_formatted(self, name, database=None):
+#         """
+#         Retrieve results of DESCRIBE FORMATTED command. See Impala
+#         documentation for more.
+#
+#         Parameters
+#         ----------
+#         name : string
+#           Table name. Can be fully qualified (with database)
+#         database : string, optional
+#         """
+#         from ibis.impala.metadata import parse_metadata
+#
+#         stmt = self._table_command('DESCRIBE FORMATTED',
+#                                    name, database=database)
+#         query = ImpalaODBCQuery(self, stmt)
+#         result = query.execute()
+#
+#         # Leave formatting to pandas
+#         for c in result.columns:
+#             result[c] = result[c].str.strip()
+#
+#         return parse_metadata(result)
+#
+#
+#     def _exec_statement(self, stmt, adapter=None):
+#         query = ImpalaODBCQuery(self, stmt)
+#         result = query.execute()
+#         if adapter is not None:
+#             result = adapter(result)
+#         return result
 
 class ImpalaODBCCursor(ImpalaCursor):
 

--- a/ibis/odbc/impala.py
+++ b/ibis/odbc/impala.py
@@ -105,40 +105,6 @@ class ImpalaODBCConnection(ImpalaConnection):
         return cursor
 
 
-# class ImpalaODBCCLient(ImpalaClient):
-#
-#     def describe_formatted(self, name, database=None):
-#         """
-#         Retrieve results of DESCRIBE FORMATTED command. See Impala
-#         documentation for more.
-#
-#         Parameters
-#         ----------
-#         name : string
-#           Table name. Can be fully qualified (with database)
-#         database : string, optional
-#         """
-#         from ibis.impala.metadata import parse_metadata
-#
-#         stmt = self._table_command('DESCRIBE FORMATTED',
-#                                    name, database=database)
-#         query = ImpalaODBCQuery(self, stmt)
-#         result = query.execute()
-#
-#         # Leave formatting to pandas
-#         for c in result.columns:
-#             result[c] = result[c].str.strip()
-#
-#         return parse_metadata(result)
-#
-#
-#     def _exec_statement(self, stmt, adapter=None):
-#         query = ImpalaODBCQuery(self, stmt)
-#         result = query.execute()
-#         if adapter is not None:
-#             result = adapter(result)
-#         return result
-
 class ImpalaODBCCursor(ImpalaCursor):
 
     def execute(self, stmt, async=False):
@@ -151,7 +117,3 @@ class ImpalaODBCCursor(ImpalaCursor):
         else:
             return self._cursor.fetchall()
 
-
-class ImpalaODBCQuery(Query):
-    def _fetch(self, cursor):
-        return cursor.fetchall(columnar=True)

--- a/ibis/odbc/impala.py
+++ b/ibis/odbc/impala.py
@@ -1,0 +1,112 @@
+# Copyright 2015 Cloudera Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import traceback
+import turbodbc
+
+from ibis.impala.client import (ImpalaConnection,
+                                ImpalaClient,
+                                ImpalaCursor)
+from ibis.config import options
+from ibis.client import (Query)
+
+
+def connect(dsn=None, connection_string=None, turbodbc_options=None,
+            hdfs_client=None, pool_size=8):
+    """
+    Using ODBC  to create ImpalaClient connection.
+
+    Parameters
+    ----------
+    dsn : str, optional
+        Data source name as given in the (unix) odbc.ini file or (Windows)
+        ODBC Data Source Administrator tool.
+    connection_string : str, optional
+        Preformatted ODBC connection string. Specifying this and dsn at the
+        same time raises ParameterError
+    turbodbc_options : dict, optional
+        to be passed to turbodbc_options
+
+    Returns
+    -------
+    ImpalaClient
+    """
+
+    con = ImpalaODBCConnection(pool_size=pool_size,
+                               connection_string=connection_string,
+                               dsn=dsn,
+                               turbodbc_options=turbodbc_options)
+
+    try:
+        client = ImpalaClient(con, hdfs_client=hdfs_client)
+
+        if options.default_backend is None:
+            options.default_backend = client
+    except:
+        con.close()
+        raise
+
+    return client
+
+
+class ImpalaODBCConnection(ImpalaConnection):
+    def _new_cursor(self):
+        params = self.params.copy()
+
+        options = turbodbc.make_options(autocommit=True,
+                                        **params['turbodbc_options'])
+        con = turbodbc.connect(dsn=params['dsn'],
+                               connection_string=params['connection_string'],
+                               turbodbc_options=options)
+
+        self._connections.add(con)
+
+        cursor = con.cursor()
+
+        wrapper = ImpalaODBCCursor(cursor, self, con, self.database,
+                                   self.options.copy())
+        wrapper.set_options()
+
+        return wrapper
+
+    def ping(self):
+        self._get_cursor()
+
+    def execute(self, query, async=False):
+        if isinstance(query):
+            query = query.compile()
+
+        cursor = self._get_cursor()
+        self.log(query)
+
+        try:
+            cursor.execute(query)
+        except:
+            exc = traceback.format_exc()
+            self.error('Exception caused by {}: {}'.format(query, exc))
+            raise
+
+        return cursor
+
+
+class ImpalaODBCCursor(ImpalaCursor):
+    def execute(self, stmt):
+        self._cursor.execute(stmt)
+
+    def fetchall(self):
+        return self._cursor.fetchallarrow().to_pandas()
+
+
+class ImpalaODBCQuery(Query):
+    def _fetch(self, cursor):
+        return cursor.fetchall()

--- a/ibis/odbc/impala.py
+++ b/ibis/odbc/impala.py
@@ -45,6 +45,9 @@ def connect(dsn=None, connection_string=None, turbodbc_options=None,
     ImpalaClient
     """
 
+    if turbodbc_options is None:
+        turbodbc_options = {}
+
     con = ImpalaODBCConnection(pool_size=pool_size,
                                connection_string=connection_string,
                                dsn=dsn, nthreads=nthreads,

--- a/ibis/odbc/impala.py
+++ b/ibis/odbc/impala.py
@@ -106,14 +106,18 @@ class ImpalaODBCConnection(ImpalaConnection):
 
 
 class ImpalaODBCCursor(ImpalaCursor):
-    def execute(self, stmt):
+
+    def execute(self, stmt, async=False):
         self._cursor.execute(stmt)
 
-    def fetchall(self):
-        nthreads = self.con.params['nthreads']
-        return self._cursor.fetchallarrow().to_pandas(nthreads=nthreads)
+    def fetchall(self, columnar=False):
+        if columnar:
+            nthreads = self.con.params['nthreads']
+            return self._cursor.fetchallarrow().to_pandas(nthreads=nthreads)
+        else:
+            return self._cursor.fetchall()
 
 
 class ImpalaODBCQuery(Query):
     def _fetch(self, cursor):
-        return cursor.fetchall()
+        return cursor.fetchall(columnar=True)

--- a/ibis/odbc/impala.py
+++ b/ibis/odbc/impala.py
@@ -104,18 +104,14 @@ class ImpalaODBCConnection(ImpalaConnection):
 
         return cursor
 
-    def fetchall(self, query):
-        with self.execute(query) as cur:
-            results = cur.fetchall(self.params['nthreads'])
-        return results
-
 
 class ImpalaODBCCursor(ImpalaCursor):
     def execute(self, stmt):
         self._cursor.execute(stmt)
 
-    def fetchall(self, nthreads):
-        return self._cursor.fetchallarrow().to_pandas()
+    def fetchall(self):
+        nthreads = self.con.params['nthreads']
+        return self._cursor.fetchallarrow().to_pandas(nthreads=nthreads)
 
 
 class ImpalaODBCQuery(Query):

--- a/ibis/odbc/impala.py
+++ b/ibis/odbc/impala.py
@@ -18,7 +18,6 @@ from ibis.impala.client import (ImpalaConnection,
                                 ImpalaClient,
                                 ImpalaCursor)
 from ibis.config import options
-from ibis.client import Query
 from ibis.sql.compiler import DDL
 
 
@@ -116,4 +115,3 @@ class ImpalaODBCCursor(ImpalaCursor):
             return self._cursor.fetchallarrow().to_pandas(nthreads=nthreads)
         else:
             return self._cursor.fetchall()
-

--- a/ibis/odbc/impala.py
+++ b/ibis/odbc/impala.py
@@ -54,7 +54,7 @@ def connect(dsn=None, connection_string=None, turbodbc_options=None,
                                turbodbc_options=turbodbc_options)
 
     try:
-        client = ImpalaClient(con, hdfs_client=hdfs_client)
+        client = ImpalaODBCCLient(con, hdfs_client=hdfs_client)
 
         if options.default_backend is None:
             options.default_backend = client
@@ -104,6 +104,40 @@ class ImpalaODBCConnection(ImpalaConnection):
 
         return cursor
 
+
+class ImpalaODBCCLient(ImpalaClient):
+
+    def describe_formatted(self, name, database=None):
+        """
+        Retrieve results of DESCRIBE FORMATTED command. See Impala
+        documentation for more.
+
+        Parameters
+        ----------
+        name : string
+          Table name. Can be fully qualified (with database)
+        database : string, optional
+        """
+        from ibis.impala.metadata import parse_metadata
+
+        stmt = self._table_command('DESCRIBE FORMATTED',
+                                   name, database=database)
+        query = ImpalaODBCQuery(self, stmt)
+        result = query.execute()
+
+        # Leave formatting to pandas
+        for c in result.columns:
+            result[c] = result[c].str.strip()
+
+        return parse_metadata(result)
+
+
+    def _exec_statement(self, stmt, adapter=None):
+        query = ImpalaODBCQuery(self, stmt)
+        result = query.execute()
+        if adapter is not None:
+            result = adapter(result)
+        return result
 
 class ImpalaODBCCursor(ImpalaCursor):
 

--- a/setup.py
+++ b/setup.py
@@ -40,13 +40,15 @@ postgres_requires = sqlite_requires + ['psycopg2']
 kerberos_requires = ['requests-kerberos']
 visualization_requires = ['graphviz']
 pandas_requires = ['multipledispatch']
+turbodbc_requires = ['turbodbc>=2.0.0']
 
 all_requires = (
     impala_requires +
     postgres_requires +
     kerberos_requires +
     visualization_requires +
-    pandas_requires
+    pandas_requires +
+    turbodbc_requires
 )
 
 develop_requires = all_requires + [
@@ -75,6 +77,7 @@ setup(
         'sqlite': sqlite_requires,
         'visualization': visualization_requires,
         'pandas': pandas_requires,
+        'turbodbc': turbodbc_requires,
     },
     scripts=[
         os.path.join(

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ postgres_requires = sqlite_requires + ['psycopg2']
 kerberos_requires = ['requests-kerberos']
 visualization_requires = ['graphviz']
 pandas_requires = ['multipledispatch']
-turbodbc_requires = ['turbodbc>=2.0.0']
+turbodbc_requires = ['pybind11','pyarrow','turbodbc>=2.0.0']
 
 all_requires = (
     impala_requires +

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ postgres_requires = sqlite_requires + ['psycopg2']
 kerberos_requires = ['requests-kerberos']
 visualization_requires = ['graphviz']
 pandas_requires = ['multipledispatch']
-turbodbc_requires = ['pybind11','pyarrow','turbodbc>=2.0.0']
+turbodbc_requires = ['pybind11', 'pyarrow', 'turbodbc>=2.0.0']
 
 all_requires = (
     impala_requires +


### PR DESCRIPTION
Closes #985

Some caveats:
* I’m not sure ODBC connection belong to impala module, since all databases are supported, provided a supporting ODBC driver. I should probably create ODBCConnection class and derived sub for each of the client.
* I choose turbodbc over pyodbc for two things, 
    * I’m unable to create weakref out of pyodbc connection object
    * turbodbc support fetchnumpy object which I believe integrate nicely to  pandas.
* There is no ping in turbodbc cursor
* I have to modify `_column_batches_to_dataframe` to make a space for turbodbc
* If someone willing me to point a test connection would be great. 


cc @mariusvniekerk 

- [x] nthreads option

- [ ] unit tests 


