### PR TITLE
CI/BENCH: Stop publishing benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![circleci](https://circleci.com/gh/ibis-project/ibis.svg?style=shield&circle-token=b84ff8383cbb0d6788ee0f9635441cb962949a4f)](https://circleci.com/gh/ibis-project/ibis/tree/master)
 [![appveyor](https://ci.appveyor.com/api/projects/status/github/ibis-project/ibis?branch=master&svg=true)](https://ci.appveyor.com/project/cpcloud/ibis-xh5g1)
-[![asv](http://img.shields.io/badge/benchmarked%20by-asv-green.svg?style=flat)](https://ibis-project.github.io/ibis-benchmarks)
 
 Current release from Anaconda.org [![Anaconda-Server Badge](https://anaconda.org/conda-forge/ibis-framework/badges/version.svg)](https://anaconda.org/conda-forge/ibis-framework)
 

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -34,9 +34,6 @@ function benchmark()
 	git config --global user.email ""
 
 	pushd ../ibis-benchmarks
-	echo
-	ls -1 asv/results/circle/*.json
-	echo
 	git add --verbose --ignore-removal .
 	git commit --message="Update benchmarks ibis-project/ibis@${CIRCLE_SHA1:-$(git rev-parse HEAD)}"
 	git push origin master

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -9,6 +9,7 @@ function benchmark()
     pushd ..
     git clone git@github.com:ibis-project/ibis-benchmarks
     [ -e "asv/results" ] && mv asv/results ../ibis/.asv
+    [ -e "asv/html " ] && mv asv/html ../ibis/.asv
     popd
 
     # run an asv command
@@ -33,6 +34,9 @@ function benchmark()
 	git config --global user.email ""
 
 	pushd ../ibis-benchmarks
+	echo
+	ls -1 asv/results/circle/*.json
+	echo
 	git add --verbose --ignore-removal .
 	git commit --message="Update benchmarks ibis-project/ibis@${CIRCLE_SHA1:-$(git rev-parse HEAD)}"
 	git push origin master

--- a/circle.yml
+++ b/circle.yml
@@ -89,4 +89,4 @@ deployment:
     branch: master
     owner: ibis-project
     commands:
-      - ci/benchmark.sh asv "run -e master^..master" --publish
+      - ci/benchmark.sh asv "run -e master^..master"


### PR DESCRIPTION
Let's stop publishing benchmarks until we can get a machine with a persistent
disk to store the benchmark data rather than having to store it in the `ibis-project/ibis-benchmarks` repo.
Eventually, we'll only store the static web page content in that repo.