### PR TITLE
TST: Make sure fixture names do not clash

### DIFF
--- a/ibis/expr/tests/conftest.py
+++ b/ibis/expr/tests/conftest.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ibis.expr.tests.mocks import MockConnection
+import collections
 
 import pytest
+
 import ibis
+
+from ibis.expr.tests.mocks import MockConnection
 
 
 @pytest.fixture
@@ -35,7 +38,7 @@ def schema():
 
 @pytest.fixture
 def schema_dict(schema):
-    return dict(schema)
+    return collections.OrderedDict(schema)
 
 
 @pytest.fixture

--- a/ibis/expr/tests/test_pipe.py
+++ b/ibis/expr/tests/test_pipe.py
@@ -17,7 +17,7 @@ import ibis
 
 
 @pytest.fixture
-def table():
+def pipe_table():
     return ibis.table([
         ('key1', 'string'),
         ('key2', 'string'),
@@ -26,37 +26,37 @@ def table():
     ], 'foo_table')
 
 
-def test_pipe_positional_args(table):
+def test_pipe_positional_args(pipe_table):
     def my_func(data, foo, bar):
         return data[bar] + foo
 
-    result = table.pipe(my_func, 4, 'value')
-    expected = table['value'] + 4
+    result = pipe_table.pipe(my_func, 4, 'value')
+    expected = pipe_table['value'] + 4
 
     assert result.equals(expected)
 
 
-def test_pipe_keyword_args(table):
+def test_pipe_keyword_args(pipe_table):
     def my_func(data, foo=None, bar=None):
         return data[bar] + foo
 
-    result = table.pipe(my_func, foo=4, bar='value')
-    expected = table['value'] + 4
+    result = pipe_table.pipe(my_func, foo=4, bar='value')
+    expected = pipe_table['value'] + 4
 
     assert result.equals(expected)
 
 
-def test_pipe_pass_to_keyword(table):
+def test_pipe_pass_to_keyword(pipe_table):
     def my_func(x, y, data=None):
         return data[x] + y
 
-    result = table.pipe((my_func, 'data'), 'value', 4)
-    expected = table['value'] + 4
+    result = pipe_table.pipe((my_func, 'data'), 'value', 4)
+    expected = pipe_table['value'] + 4
 
     assert result.equals(expected)
 
 
-def test_call_pipe_equivalence(table):
-    result = table(lambda x: x['key1'].cast('double').sum())
-    expected = table.key1.cast('double').sum()
+def test_call_pipe_equivalence(pipe_table):
+    result = pipe_table(lambda x: x['key1'].cast('double').sum())
+    expected = pipe_table.key1.cast('double').sum()
     assert result.equals(expected)

--- a/ibis/expr/tests/test_sql_builtins.py
+++ b/ibis/expr/tests/test_sql_builtins.py
@@ -38,7 +38,7 @@ def lineitem(con):
 
 
 @pytest.fixture
-def table():
+def sql_table():
     return ibis.table([
         ('v1', 'decimal(12, 2)'),
         ('v2', 'decimal(10, 4)'),
@@ -183,18 +183,18 @@ def _check_unary_op(expr, fname, ex_op, ex_type):
     assert type(result) == ex_type
 
 
-def test_coalesce_instance_method(table):
-    v7 = table.v7
-    v5 = table.v5.cast('string')
-    v8 = table.v8.cast('string')
+def test_coalesce_instance_method(sql_table):
+    v7 = sql_table.v7
+    v5 = sql_table.v5.cast('string')
+    v8 = sql_table.v8.cast('string')
 
     result = v7.coalesce(v5, v8, 'foo')
     expected = ibis.coalesce(v7, v5, v8, 'foo')
     assert_equal(result, expected)
 
 
-def test_integer_promotions(table, function):
-    t = table
+def test_integer_promotions(sql_table, function):
+    t = sql_table
 
     expr = function(t.v3, t.v4)
     assert isinstance(expr, ir.Int64Column)
@@ -206,8 +206,8 @@ def test_integer_promotions(table, function):
     assert isinstance(expr, ir.Int64Scalar)
 
 
-def test_floats(table, function):
-    t = table
+def test_floats(sql_table, function):
+    t = sql_table
 
     expr = function(t.v5)
     assert isinstance(expr, ir.DoubleColumn)


### PR DESCRIPTION
This works around a pytest issue where fixtures with the same name seem to override each other. Without this fix, `conda build` does not work.