### PR TITLE
COMPAT: Support tz-aware timestamp types

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
 
 services:
   - postgresql

--- a/conda-recipes/ibis-framework/meta.yaml
+++ b/conda-recipes/ibis-framework/meta.yaml
@@ -30,23 +30,17 @@ requirements:
 
 test:
   requires:
-    - enum34  # [py27]
     - graphviz
     - mock  # [py27]
     - multipledispatch
-    - numpy >=1.7.0
-    - pandas >=0.12.0
-    - pytest <3 # [py27]
+    - pytest <3  # [py27]
     - pytest >=3  # [py3k]
-    - python
     - python-graphviz
-    - six
-    - toolz
   imports:
     - ibis
     - ibis.expr
-    - ibis.expr.visualize
     - ibis.expr.tests
+    - ibis.expr.visualize
     - ibis.hive
     - ibis.hive.tests
     - ibis.impala

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -40,6 +40,9 @@ class Query(object):
 
     def __init__(self, client, ddl):
         self.client = client
+        self.expr = getattr(
+            ddl, 'parent_expr', getattr(ddl, 'table_set', None)
+        )
 
         if isinstance(ddl, comp.DDL):
             self.compiled_ddl = ddl.compile()
@@ -74,7 +77,7 @@ class Query(object):
                 cols[name] = pd.Series(col)
         return pd.DataFrame(cols, columns=names)
 
-    def _db_type_to_dtype(self, db_type):
+    def _db_type_to_dtype(self, db_type, column):
         raise NotImplementedError
 
 

--- a/ibis/expr/tests/test_datatypes.py
+++ b/ibis/expr/tests/test_datatypes.py
@@ -112,9 +112,20 @@ def test_struct_with_string_types():
     )
 
 
-def test_decimal_failure():
+@pytest.mark.parametrize(
+    'case',
+    [
+        'decimal(',
+        'decimal()',
+        'decimal(3)',
+        'decimal(,)',
+        'decimal(3,)',
+        'decimal(3,',
+    ]
+)
+def test_decimal_failure(case):
     with pytest.raises(SyntaxError):
-        dt.validate_type('decimal(')
+        dt.validate_type(case)
 
 
 @pytest.mark.parametrize(
@@ -270,3 +281,48 @@ def test_array_type_equals():
     assert left.equals(right)
     assert left == right
     assert not (left != right)
+
+
+def test_timestamp_with_timezone_parser_single_quote():
+    t = dt.validate_type("timestamp('US/Eastern')")
+    assert isinstance(t, dt.Timestamp)
+    assert t.timezone == 'US/Eastern'
+
+
+def test_timestamp_with_timezone_parser_double_quote():
+    t = dt.validate_type("timestamp('US/Eastern')")
+    assert isinstance(t, dt.Timestamp)
+    assert t.timezone == 'US/Eastern'
+
+
+def test_timestamp_with_timezone_parser_invalid_timezone():
+    ts = dt.validate_type("timestamp('US/Ea')")
+    assert str(ts) == "timestamp('US/Ea')"
+
+
+@pytest.mark.parametrize(
+    'case',
+    [
+        "timestamp(US/Ea)",
+        "timestamp('US/Eastern\")",
+        'timestamp("US/Eastern\')',
+    ]
+)
+def test_timestamp_parsing_failure_mode(case):
+    with pytest.raises(SyntaxError):
+        dt.validate_type(case)
+
+
+def test_timestamp_with_invalid_timezone():
+    ts = dt.Timestamp('Foo/Bar&234')
+    assert str(ts) == "timestamp('Foo/Bar&234')"
+
+
+def test_timestamp_with_timezone_repr():
+    ts = dt.Timestamp('UTC')
+    assert repr(ts) == "Timestamp(timezone='UTC')"
+
+
+def test_timestamp_with_timezone_str():
+    ts = dt.Timestamp('UTC')
+    assert str(ts) == "timestamp('UTC')"

--- a/ibis/expr/tests/test_table.py
+++ b/ibis/expr/tests/test_table.py
@@ -16,7 +16,6 @@ import pytest
 
 from ibis.expr.types import ColumnExpr, TableExpr, RelationError
 from ibis.common import ExpressionError
-from ibis.expr.datatypes import array_type
 import ibis.expr.api as api
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
@@ -66,7 +65,6 @@ def test_getitem_column_select(table, schema_dict):
 
         # Make sure it's the right type
         assert isinstance(col, ColumnExpr)
-        assert isinstance(col, array_type(v))
 
         # Ensure we have a field selection with back-reference to the table
         parent = col.parent()

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -289,7 +289,7 @@ class ImpalaQuery(Query):
         names = [x[0] for x in cursor.description]
         return _column_batches_to_dataframe(names, batches)
 
-    def _db_type_to_dtype(self, db_type):
+    def _db_type_to_dtype(self, db_type, column):
         return _HS2_TTypeId_to_dtype[db_type]
 
 

--- a/ibis/impala/tests/test_pandas_interop.py
+++ b/ibis/impala/tests/test_pandas_interop.py
@@ -246,5 +246,14 @@ class TestPandasInterop(ImpalaE2E, unittest.TestCase):
 
         table = writer.delimited_table(path)
         df2 = table.execute()
-
         assert_frame_equal(df2, df)
+
+
+def test_timestamp_with_timezone():
+    df = pd.DataFrame({
+        'A': pd.date_range('20130101', periods=3, tz='US/Eastern')
+    })
+    schema = pandas_to_ibis_schema(df)
+    expected = ibis.schema([('A', "timestamp('US/Eastern')")])
+    assert schema.equals(expected)
+    assert schema.types[0].equals(dt.Timestamp('US/Eastern'))

--- a/ibis/impala/tests/test_udf.py
+++ b/ibis/impala/tests/test_udf.py
@@ -90,9 +90,9 @@ class TestWrapping(unittest.TestCase):
             ibis_type = validate_type(t)
 
             expr = func(sv)
-            assert type(expr) == ibis_type.scalar_type()
+            assert type(expr) == type(ibis_type.scalar_type()(expr.op()))  # noqa: E501, E721
             expr = func(av)
-            assert type(expr) == ibis_type.array_type()
+            assert type(expr) == type(ibis_type.array_type()(expr.op()))  # noqa: E501, E721
 
     def test_uda_primitive_output_types(self):
         types = [
@@ -113,8 +113,10 @@ class TestWrapping(unittest.TestCase):
 
             expr1 = func(sv)
             expr2 = func(sv)
-            assert isinstance(expr1, ibis_type.scalar_type())
-            assert isinstance(expr2, ibis_type.scalar_type())
+            expected_type1 = type(ibis_type.scalar_type()(expr1.op()))
+            expected_type2 = type(ibis_type.scalar_type()(expr2.op()))
+            assert isinstance(expr1, expected_type1)
+            assert isinstance(expr2, expected_type2)
 
     def test_decimal(self):
         func = self._register_udf(['decimal(9,0)'], 'decimal(9,0)', 'test')

--- a/ibis/pandas/client.py
+++ b/ibis/pandas/client.py
@@ -1,11 +1,13 @@
 import six
 
+import numpy as np
 import pandas as pd
 
 import ibis
 import ibis.client as client
-import ibis.expr.operations as ops
 import ibis.expr.types as ir
+import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
 
 
 try:
@@ -15,9 +17,9 @@ except AttributeError:
 
 
 _DTYPE_TO_IBIS_TYPE = {
-    'float64': 'double',
-    'float32': 'float',
-    'datetime64[ns]': 'timestamp',
+    'float64': dt.double,
+    'float32': dt.float,
+    'datetime64[ns]': dt.timestamp,
 }
 
 
@@ -38,13 +40,15 @@ def pandas_dtypes_to_ibis_schema(df):
             raise TypeError(
                 'Column names must be strings to use the pandas backend'
             )
-        dtype_string = str(dtype)
 
-        if dtype_string == 'object':
+        if dtype == np.object_:
             ibis_type = _INFERRED_DTYPE_TO_IBIS_TYPE[
                 infer_dtype(df[column_name])
             ]
+        elif hasattr(dtype, 'tz'):
+            ibis_type = dt.Timestamp(str(dtype.tz))
         else:
+            dtype_string = str(dtype)
             ibis_type = _DTYPE_TO_IBIS_TYPE.get(dtype_string, dtype_string)
 
         pairs.append((column_name, ibis_type))

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -20,18 +20,22 @@ import math
 
 import pytest
 
-from .common import SQLiteTests
-from ibis import literal as L
-import ibis.expr.types as ir
-import ibis
-import pandas.util.testing as tm
+sa = pytest.importorskip('sqlalchemy')
 
-import sqlalchemy as sa
+from .common import SQLiteTests  # noqa: E402
+from ibis import literal as L  # noqa: E402
+import ibis.expr.types as ir  # noqa: E402
+import ibis  # noqa: E402
+import pandas.util.testing as tm  # noqa: E402
 
 
 @pytest.fixture
 def con():
-    return ibis.sqlite.connect(os.environ['IBIS_TEST_SQLITE_DB_PATH'])
+    # If we haven't defined an environment variable with the path of the SQLite
+    # database, assume it's in $PWD
+    return ibis.sqlite.connect(
+        os.environ.get('IBIS_TEST_SQLITE_DB_PATH', 'ibis_testing.db')
+    )
 
 
 @pytest.fixture

--- a/ibis/sql/tests/test_sqlalchemy.py
+++ b/ibis/sql/tests/test_sqlalchemy.py
@@ -116,7 +116,7 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
         for name, t, nullable, ibis_type in typespec:
             sqla_type = sa.Column(name, t, nullable=nullable)
             sqla_types.append(sqla_type)
-            ibis_types.append((name, ibis_type(nullable)))
+            ibis_types.append((name, ibis_type(nullable=nullable)))
 
         table = sa.Table('tname', self.meta, *sqla_types)
 


### PR DESCRIPTION
This was a rabbit hole.

Closes #989 