### PR TITLE
ENH: Pass ops in scope instead of exprs

### DIFF
--- a/ibis/pandas/core.py
+++ b/ibis/pandas/core.py
@@ -92,7 +92,7 @@ def execute_with_scope(expr, scope, **kwargs):
     computed_args = [
         execute(arg, scope, **kwargs) if hasattr(arg, 'op') else arg
         for arg in args if isinstance(arg, _VALID_INPUT_TYPES)
-    ] or [scope.get(arg, arg) for arg in args]
+    ]
 
     # Compute our op, with its computed arguments
     return execute_node(op, *computed_args, scope=scope, **kwargs)

--- a/ibis/pandas/core.py
+++ b/ibis/pandas/core.py
@@ -11,7 +11,7 @@ import numpy as np
 import ibis.expr.types as ir
 import ibis.expr.datatypes as dt
 
-from ibis.pandas.dispatch import execute, execute_node
+from ibis.pandas.dispatch import execute, execute_node, execute_first
 
 
 integer_types = six.integer_types + (np.integer,)
@@ -50,11 +50,13 @@ def find_data(expr):
             seen.add(node)
 
             if hasattr(node, 'source'):
-                data[e] = node.source.dictionary[node.name]
+                data[node] = node.source.dictionary[node.name]
             elif isinstance(node, ir.Literal):
-                data[e] = node.value
+                data[node] = node.value
 
-            stack.extend(arg for arg in node.args if isinstance(arg, ir.Expr))
+            stack.extend(
+                arg for arg in reversed(node.args) if isinstance(arg, ir.Expr)
+            )
     return data
 
 
@@ -62,24 +64,77 @@ _VALID_INPUT_TYPES = (ir.Expr, dt.DataType, type(None)) + scalar_types
 
 
 @execute.register(ir.Expr, dict)
-def execute_with_scope(expr, scope):
-    if expr in scope:
-        return scope[expr]
+def execute_with_scope(expr, scope, **kwargs):
+    """Execute an expression `expr`, with data provided in `scope`.
 
+    Parameters
+    ----------
+    expr : ir.Expr
+        The expression to execute.
+    scope : dict
+        A dictionary mapping :class:`~ibis.expr.types.Node` subclass instances
+        to concrete data such as a pandas DataFrame.
+
+    Returns
+    -------
+    result : scalar, pd.Series, pd.DataFrame
+    """
     op = expr.op()
+
+    # base case: our op has been computed (or is a leaf data node), so
+    # return the corresponding value
+    if op in scope:
+        return scope[op]
+
+    try:
+        computed_args = [scope[t] for t in op.root_tables()]
+    except KeyError:
+        pass
+    else:
+        try:
+            # special case: we have a definition of execute_first that matches
+            # our current operation and data leaves
+            return execute_first(op, *computed_args, **kwargs)
+        except NotImplementedError:
+            pass
+
     args = op.args
 
+    # recursively compute the op's arguments
     computed_args = [
-        execute(arg, scope) if hasattr(arg, 'op') else arg
+        execute(arg, scope, **kwargs) if hasattr(arg, 'op') else arg
         for arg in args if isinstance(arg, _VALID_INPUT_TYPES)
     ] or [scope.get(arg, arg) for arg in args]
 
-    return execute_node(op, *computed_args, scope=scope)
+    # Compute our op, with its computed arguments
+    return execute_node(op, *computed_args, scope=scope, **kwargs)
 
 
 @execute.register(ir.Expr)
 def execute_without_scope(expr):
+    """Execute an expression against data that are bound to it. If no data
+    are bound, raise an Exception.
+
+    Parameters
+    ----------
+    expr : ir.Expr
+        The expression to execute
+
+    Returns
+    -------
+    result : scalar, pd.Series, pd.DataFrame
+
+    Raises
+    ------
+    ValueError
+        * If no data are bound to the input expression
+    """
+
     scope = find_data(expr)
     if not scope:
-        raise ValueError('No data sources found')
+        raise ValueError(
+            'No data sources found while trying to execute against the pandas '
+            'backend'
+        )
+
     return execute(expr, scope)

--- a/ibis/pandas/core.py
+++ b/ibis/pandas/core.py
@@ -11,7 +11,7 @@ import numpy as np
 import ibis.expr.types as ir
 import ibis.expr.datatypes as dt
 
-from ibis.pandas.dispatch import execute, execute_node, execute_first
+from ibis.pandas.dispatch import execute, execute_node
 
 
 integer_types = six.integer_types + (np.integer,)
@@ -85,18 +85,6 @@ def execute_with_scope(expr, scope, **kwargs):
     # return the corresponding value
     if op in scope:
         return scope[op]
-
-    try:
-        computed_args = [scope[t] for t in op.root_tables()]
-    except KeyError:
-        pass
-    else:
-        try:
-            # special case: we have a definition of execute_first that matches
-            # our current operation and data leaves
-            return execute_first(op, *computed_args, **kwargs)
-        except NotImplementedError:
-            pass
 
     args = op.args
 

--- a/ibis/pandas/dispatch.py
+++ b/ibis/pandas/dispatch.py
@@ -5,3 +5,4 @@ from multipledispatch import Dispatcher
 
 execute = Dispatcher('execute')
 execute_node = Dispatcher('execute_node')
+execute_first = Dispatcher('execute_first')

--- a/ibis/pandas/dispatch.py
+++ b/ibis/pandas/dispatch.py
@@ -5,4 +5,3 @@ from multipledispatch import Dispatcher
 
 execute = Dispatcher('execute')
 execute_node = Dispatcher('execute_node')
-execute_first = Dispatcher('execute_first')

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -109,15 +109,17 @@ TIMESTAMP_CONSTANT = ibis.literal('2015-09-01 14:48:05.359').cast('timestamp')
         (TIMESTAMP_CONSTANT.minute(), 48),
         (TIMESTAMP_CONSTANT.second(), 5),
         (TIMESTAMP_CONSTANT.millisecond(), 359),
-
-        # there could be pathological failure at midnight somewhere, but
-        # that's okay
-        (ibis.now().strftime('%Y%m%d %H'),
-         datetime.datetime.utcnow().strftime('%Y%m%d %H'))
     ]
 )
 def test_timestamp_functions(con, expr, expected):
     assert con.execute(expr) == expected
+
+
+def test_now():
+    expr = ibis.now().strftime('%Y%m%d %H')
+    result = expr.execute()
+    expected = datetime.datetime.utcnow().strftime('%Y%m%d %H')
+    assert result == expected
 
 
 @pytest.mark.parametrize(

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -115,9 +115,9 @@ def test_timestamp_functions(con, expr, expected):
     assert con.execute(expr) == expected
 
 
-def test_now():
+def test_now(con):
     expr = ibis.now().strftime('%Y%m%d %H')
-    result = expr.execute()
+    result = con.execute(expr)
     expected = datetime.datetime.utcnow().strftime('%Y%m%d %H')
     assert result == expected
 


### PR DESCRIPTION
Also fixes the `now` failures.

Closes #1106.