### PR TITLE
ENH: Pass scope around to execute_first

### DIFF
--- a/ibis/pandas/execution.py
+++ b/ibis/pandas/execution.py
@@ -1023,7 +1023,7 @@ def _post_process_group_by_order_by(series, index):
 
 
 @execute_first.register(ops.WindowOp, pd.DataFrame)
-def execute_frame_window_op(op, data, context=None, **kwargs):
+def execute_frame_window_op(op, data, scope=None, context=None, **kwargs):
     operand, window = op.args
 
     following = window.following
@@ -1072,7 +1072,13 @@ def execute_frame_window_op(op, data, context=None, **kwargs):
             source = data
             post_process = _post_process_empty
 
-    new_scope = {t: source for t in operand.op().root_tables()}
+    new_scope = toolz.merge(
+        scope,
+        collections.OrderedDict(
+            (t, source) for t in operand.op().root_tables()
+        ),
+        factory=collections.OrderedDict,
+    )
 
     # no order by or group by: default summarization context
     #

--- a/ibis/pandas/tests/test_cast.py
+++ b/ibis/pandas/tests/test_cast.py
@@ -7,6 +7,9 @@ import ibis.expr.datatypes as dt  # noqa: E402
 import ibis
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.mark.parametrize('from_', ['plain_float64', 'plain_int64'])
 @pytest.mark.parametrize(
     ('to', 'expected'),

--- a/ibis/pandas/tests/test_core.py
+++ b/ibis/pandas/tests/test_core.py
@@ -1,13 +1,38 @@
 import pytest
 
+import pandas as pd
+
+import ibis
+import ibis.expr.datatypes as dt
+import ibis.expr.types as ir
+
 pytest.importorskip('multipledispatch')
 
-from ibis.pandas.execution import execute, execute_node  # noqa: E402
+from ibis.pandas.execution import (
+    execute, execute_node, execute_first
+)  # noqa: E402
 from multipledispatch.conflict import ambiguities  # noqa: E402
 
 pytestmark = pytest.mark.pandas
 
 
-@pytest.mark.parametrize('func', [execute, execute_node])
+@pytest.mark.parametrize('func', [execute, execute_node, execute_first])
 def test_no_execute_ambiguities(func):
     assert not ambiguities(func.funcs)
+
+
+def test_execute_first_accepts_scope_keyword_argument(t, df):
+
+    param = ibis.param(dt.int64)
+    types = ir.Node, pd.DataFrame
+
+    @execute_first.register(*types)
+    def foo(op, data, scope=None, **kwargs):
+        assert scope is not None
+        return data.dup_strings.str.len() + scope[param.op()]
+
+    expr = t.dup_strings.length() + param
+    assert expr.execute(params={param: 2}) is not None
+    del execute_first.funcs[types]
+    execute_first.reorder()
+    execute_first._cache.clear()

--- a/ibis/pandas/tests/test_datetimelike.py
+++ b/ibis/pandas/tests/test_datetimelike.py
@@ -10,6 +10,9 @@ from ibis import literal as L  # noqa: E402
 from ibis.compat import PY2
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.mark.parametrize(
     ('case_func', 'expected_func'),
     [

--- a/ibis/pandas/tests/test_funcs.py
+++ b/ibis/pandas/tests/test_funcs.py
@@ -14,6 +14,9 @@ import ibis.expr.datatypes as dt  # noqa: E402
 from ibis.common import IbisTypeError  # noqa: E402
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.mark.parametrize(
     'op',
     [

--- a/ibis/pandas/tests/test_strings.py
+++ b/ibis/pandas/tests/test_strings.py
@@ -3,6 +3,9 @@ from warnings import catch_warnings
 import pandas.util.testing as tm  # noqa: E402
 
 
+pytestmark = pytest.mark.pandas
+
+
 @pytest.mark.parametrize(
     ('case_func', 'expected_func'),
     [

--- a/ibis/pandas/tests/test_window.py
+++ b/ibis/pandas/tests/test_window.py
@@ -5,6 +5,8 @@ import ibis
 from pandas.util import testing as tm
 import ibis.expr.types as ir
 
+pytestmark = pytest.mark.pandas
+
 
 def test_lead(t, df):
     expr = t.dup_strings.lead()


### PR DESCRIPTION
This is a small fix to make sure that scope gets passed around to every dispatched function so that those functions can take advantage of bound parameters.