### PR TITLE
BUG: timestamp('America/Los_Angles') was not working as a substitute for dt.Timestamp('America/Los_Angles')

### DIFF
--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -776,9 +776,6 @@ class DataTypeArgument(Argument):
     def _validate(self, args, i):
         arg = args[i]
 
-        if isinstance(arg, six.string_types):
-            arg = arg.lower()
-
         arg = args[i] = dt.validate_type(arg)
         return arg
 

--- a/ibis/pandas/tests/test_cast.py
+++ b/ibis/pandas/tests/test_cast.py
@@ -49,6 +49,10 @@ def test_cast_string(t, df, from_, to, expected):
         (
             dt.Timestamp('America/Los_Angeles'),
             'datetime64[ns, America/Los_Angeles]'
+        ),
+        (
+            "timestamp('America/Los_Angeles')",
+            'datetime64[ns, America/Los_Angeles]'
         )
     ]
 )


### PR DESCRIPTION
because of lowercasing of the timezone in type validation