### PR TITLE
ENH: Allow expressions in pandas join predicates

### DIFF
--- a/ibis/pandas/execution.py
+++ b/ibis/pandas/execution.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 
+import datetime
+import decimal
+import functools
+import itertools
 import numbers
 import operator
-import datetime
-import functools
-import decimal
-import collections
 import re
+
+from collections import OrderedDict
 
 import six
 
@@ -360,19 +362,31 @@ def execute_selection_dataframe(op, data, scope=None, **kwargs):
                 pandas_object = data
             elif isinstance(selection, ir.ScalarExpr):
                 root_tables = selection_operation.root_tables()
-                additional_scope = collections.OrderedDict(
+                additional_scope = OrderedDict(
                     zip(root_tables, (data for _ in range(len(root_tables))))
                 )
                 new_scope = toolz.merge(
                     scope,
                     additional_scope,
-                    factory=collections.OrderedDict,
+                    factory=OrderedDict,
                 )
                 pandas_object = execute(selection, new_scope, **kwargs)
             elif isinstance(selection, ir.ColumnExpr):
                 if isinstance(selection_operation, ir.TableColumn):
                     # slightly faster path for simple column selection
-                    pandas_object = data[selection_operation.name]
+                    name = selection_operation.name
+
+                    if name in data:
+                        key = name
+                        pandas_object = data[name]
+                    elif name + _LEFT_JOIN_SUFFIX in data:
+                        key = name + _LEFT_JOIN_SUFFIX
+                    elif name + _RIGHT_JOIN_SUFFIX in data:
+                        key = name + _RIGHT_JOIN_SUFFIX
+                    else:
+                        raise KeyError(name)
+
+                    pandas_object = data[key]
                 elif isinstance(table_op, ops.Join):
                     pandas_object = execute(
                         selection,
@@ -573,6 +587,23 @@ _JOIN_TYPES = {
 }
 
 
+def compute_join_column(column_expr, **kwargs):
+    column_op = column_expr.op()
+    if isinstance(column_op, ops.TableColumn):
+        name, new_column = column_op.name, None
+    else:
+        name = util.guid()
+        new_column = execute(column_expr, **kwargs)
+
+    root_table, = column_op.root_tables()
+    return name, new_column, root_table
+
+
+_LEFT_JOIN_SUFFIX = '_ibis_left_{}'.format(util.guid())
+_RIGHT_JOIN_SUFFIX = '_ibis_right_{}'.format(util.guid())
+_JOIN_SUFFIXES = _LEFT_JOIN_SUFFIX, _RIGHT_JOIN_SUFFIX
+
+
 @execute_node.register(ops.Join, pd.DataFrame, pd.DataFrame)
 def execute_materialized_join(op, left, right, **kwargs):
     try:
@@ -580,35 +611,50 @@ def execute_materialized_join(op, left, right, **kwargs):
     except KeyError:
         raise NotImplementedError('{} not supported'.format(type(op).__name__))
 
-    overlapping_columns = set(left.columns) & set(right.columns)
+    left_op = op.left.op()
+    right_op = op.right.op()
 
-    left_on = []
-    right_on = []
+    on = {left_op: [], right_op: []}
+    new_columns = {left_op: {}, right_op: {}}
 
     for predicate in map(operator.methodcaller('op'), op.predicates):
         if not isinstance(predicate, ops.Equals):
             raise TypeError(
                 'Only equality join predicates supported with pandas'
             )
-        left_name = predicate.left._name
-        right_name = predicate.right._name
-        left_on.append(left_name)
-        right_on.append(right_name)
-
-        # TODO(phillipc): Is this the correct approach? That is, can we safely
-        #                 ignore duplicate join keys?
-        overlapping_columns -= {left_name, right_name}
-
-    if overlapping_columns:
-        raise ValueError(
-            'left and right DataFrame columns overlap on {} in a join. '
-            'Please specify the columns you want to select from the join, '
-            'e.g., join[left.column1, right.column2, ...]'.format(
-                overlapping_columns
-            )
+        left_name, new_left_column, left_pred_root = compute_join_column(
+            predicate.left,
+            **kwargs
         )
+        assert left_pred_root in new_columns
 
-    return pd.merge(left, right, how=how, left_on=left_on, right_on=right_on)
+        if new_left_column is not None:
+            new_columns[left_pred_root][left_name] = new_left_column
+
+        on[left_pred_root].append(left_name)
+
+        right_name, new_right_column, right_pred_root = compute_join_column(
+            predicate.right,
+            **kwargs
+        )
+        assert right_pred_root in new_columns
+
+        if new_right_column is not None:
+            new_columns[right_pred_root][right_name] = new_right_column
+
+        on[right_pred_root].append(right_name)
+
+    left_rel = left.assign(**new_columns[left_op])
+    right_rel = right.assign(**new_columns[right_op])
+
+    to_drop = list(itertools.chain.from_iterable(new_columns.values()))
+
+    result = pd.merge(
+        left_rel, right_rel,
+        how=how, left_on=on[left_op], right_on=on[right_op],
+        suffixes=_JOIN_SUFFIXES,
+    )
+    return result.drop(to_drop, axis=1)
 
 
 _BINARY_OPERATIONS = {
@@ -1074,10 +1120,8 @@ def execute_frame_window_op(op, data, scope=None, context=None, **kwargs):
 
     new_scope = toolz.merge(
         scope,
-        collections.OrderedDict(
-            (t, source) for t in operand.op().root_tables()
-        ),
-        factory=collections.OrderedDict,
+        OrderedDict((t, source) for t in operand.op().root_tables()),
+        factory=OrderedDict,
     )
 
     # no order by or group by: default summarization context


### PR DESCRIPTION
Closes #1137.

The algorithm used to compute the individual expressions of an `Equals` operation in a `Join` predicate is the following:

1. Initialize a `dict` whose keys are the left and right tables and whose values are a list of join keys coming from the left or right table respectively. [code](https://github.com/ibis-project/ibis/pull/1138/files#diff-11ea227652b650197999ccdfc364c5e0R613).
1. Initialize a `dict` whose keys are the left and right table and whose values are `dict`s mapping a generated column name to a `pandas.Series` object. [code](https://github.com/ibis-project/ibis/pull/1138/files#diff-11ea227652b650197999ccdfc364c5e0R614).
1. for each join predicate (which is, by assertion, an `Equals` operation): [code](https://github.com/ibis-project/ibis/pull/1138/files#diff-11ea227652b650197999ccdfc364c5e0R616).
   1. for the left and right sides of the `Equals` operation:
      1. compute the current side of the `Equals`, returning: [code](https://github.com/ibis-project/ibis/pull/1138/files#diff-11ea227652b650197999ccdfc364c5e0R621).
         1. a column name
         1. a `pd.Series` if the expression is not a `TableColumn` coming from the root tables for the predicate
         1. the root table of the predicate
      1. append the column name to the list of keys to join on (values are keyed by the root table of the predicate)
      1. insert any new columns into the dict of dicts for new columns
1. The left and right keys are passed to the `on` argument of `pd.merge`. [code](https://github.com/ibis-project/ibis/pull/1138/files#diff-11ea227652b650197999ccdfc364c5e0R648).
1. drop any new columns. [code](https://github.com/ibis-project/ibis/pull/1138/files#diff-11ea227652b650197999ccdfc364c5e0R653).