### PR TITLE
ENH: Add a data_preload step in pandas backend

### DIFF
--- a/ibis/pandas/dispatch.py
+++ b/ibis/pandas/dispatch.py
@@ -3,6 +3,20 @@ from __future__ import absolute_import
 from multipledispatch import Dispatcher
 
 
+# Main interface to execution; ties the following functions together
 execute = Dispatcher('execute')
+
+# Individual operation execution
 execute_node = Dispatcher('execute_node')
+
+# Compute from the top of the expression downward
 execute_first = Dispatcher('execute_first')
+
+# Possibly preload data from the client, given a node
+data_preload = Dispatcher('data_preload')
+
+
+# Default does nothing
+@data_preload.register(object, object)
+def data_preload_default(node, data, **kwargs):
+    return data

--- a/ibis/pandas/tests/test_core.py
+++ b/ibis/pandas/tests/test_core.py
@@ -11,6 +11,8 @@ pytest.importorskip('multipledispatch')
 from ibis.pandas.execution import (
     execute, execute_node, execute_first
 )  # noqa: E402
+from ibis.pandas.client import PandasTable  # noqa: E402
+from ibis.pandas.core import data_preload  # noqa: E402
 from multipledispatch.conflict import ambiguities  # noqa: E402
 
 pytestmark = pytest.mark.pandas
@@ -36,3 +38,17 @@ def test_execute_first_accepts_scope_keyword_argument(t, df):
     del execute_first.funcs[types]
     execute_first.reorder()
     execute_first._cache.clear()
+
+
+def test_data_preload(t, df):
+    @data_preload.register(PandasTable, pd.DataFrame)
+    def data_preload_check_a_thing(_, df, **kwargs):
+        assert isinstance(df, list)
+        return df
+
+    with pytest.raises(AssertionError):
+        t.execute()
+
+    del data_preload.funcs[PandasTable, pd.DataFrame]
+    data_preload.reorder()
+    data_preload._cache.clear()


### PR DESCRIPTION
This PR adds a `data_preload` step to the execution pipeline for the Pandas
backend.

The motivation for this is to allow clients to perform operations on `(Node,
ConcreteData)` pairs (including a `scope` argument) *before* the execution
for a particular operation starts.

Custom data source execution is the main use case here.

As a motivating example, consider a custom data source object that can be
turned into a DataFrame.

We want to be able to operate on our custom data source, but we don't want to
redefine every operation for this data source, or it doesn't make sense to
define operations on this custom object directly.

`data_preload` gives the ability to call a function on data pieces that are in scope before any execution happens. In the example above, `data_preload` would turn the `ConcreteData` object into a `pandas.DataFrame`.

The default behavior is no-op.

This also sets the stage for multi-client execution. More on that to come.