### PR TITLE
Allow empty arrays as arguments

### DIFF
--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -211,11 +211,14 @@ class DataType(object):
     def name(self):
         return type(self).__name__
 
+    def issubtype(self, other, cache=None):
+        return isinstance(other, Any) or isinstance(self, type(other))
+
     def equals(self, other, cache=None):
         if isinstance(other, six.string_types):
             other = validate_type(other)
 
-        return isinstance(self, Any) or isinstance(other, Any) or (
+        return (
             isinstance(other, type(self)) and
             self.nullable == other.nullable and
             self._equal_part(other, cache=cache)
@@ -225,7 +228,7 @@ class DataType(object):
         return True
 
     def can_implicit_cast(self, other):
-        return self.equals(other)
+        return self.issubtype(other)
 
     def scalar_type(self):
         import ibis.expr.types as ir

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -496,11 +496,26 @@ class AnyTyped(Argument):
 class ValueTyped(AnyTyped, ValueArgument):
 
     def __repr__(self):
-        return 'ValueTyped({0})'.format(repr(self.types))
+        return '{}({})'.format(type(self).__name__, repr(self.types))
 
     def _validate(self, args, i):
         ValueArgument._validate(self, args, i)
         return AnyTyped._validate(self, args, i)
+
+
+class ArrayValueTyped(ValueTyped):
+
+    def __init__(self, value_type, *args, **kwargs):
+        super(ArrayValueTyped, self).__init__(
+            dt.Array(value_type), *args, **kwargs
+        )
+
+    def _validate(self, args, i):
+        arg = super(ArrayValueTyped, self)._validate(args, i)
+        type, = self.types
+        if arg.type().equals(dt.Array(dt.any)):
+            return arg.cast(type)
+        return arg
 
 
 class MultipleTypes(Argument):
@@ -654,8 +669,8 @@ def string(**arg_kwds):
 
 
 def array(value_type, **arg_kwds):
-    return ValueTyped(
-        dt.Array(value_type),
+    return ArrayValueTyped(
+        value_type,
         'not array with value_type {0}'.format(value_type),
         **arg_kwds
     )

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -528,6 +528,8 @@ def infer_literal_type(value):
     elif isinstance(value, datetime.time):
         return dt.time
     elif isinstance(value, list):
+        if not value:
+            return dt.Array(dt.any)
         return dt.Array(rules.highest_precedence_type(
             list(map(literal, value))
         ))


### PR DESCRIPTION
Closes #1153.

This PR fills out support for empty arrays as input arguments.

1. `ibis.literal([])` now returns an array of type `array<any>`. Before this PR it raises an exception.
1. Cast `array<any>` to the required input type specified by the rule in the `Node` definition during argument validation.
   1. For example, a `Node` subclass accepting `rules.array(dt.int64)` will accept `Literal`s of type `dt.Array(dt.any)`
1. The previous point allows us to accept empty arrays as input arguments.