### PR TITLE
ENH/CLN: Fix DataType hashing

### DIFF
--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -56,6 +56,7 @@ Bug Fixes
   (:issue:`1179`, :issue:`1181`)
 * Fix ``ORDER BY`` generation without a ``GROUP BY`` (:issue:`1180`,
   :issue:`1181`)
+* Ensure that :class:`~ibis.expr.datatypes.DataType` and subclasses hash properly (:issue:`1172`)
 * Ensure that the pandas backend can deal with unary operations in groupby
 * (:issue:`1182`)
 * Incorrect impala code generated for NOT with complex argument (:issue:`1176`)

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -42,7 +42,7 @@ def genname():
 class TableNode(Node):
 
     def get_type(self, name):
-        return self.get_schema().get_type(name)
+        return self.schema[name]
 
     def _make_expr(self):
         return TableExpr(self)
@@ -1580,15 +1580,16 @@ class Limit(TableNode):
     _arg_names = [None, 'n', 'offset']
 
     def __init__(self, table, n, offset=0):
+        super(Limit, self).__init__([table, n, offset])
         self.table = table
         self.n = n
         self.offset = offset
-        TableNode.__init__(self, [table, n, offset])
 
     def blocks(self):
         return True
 
-    def get_schema(self):
+    @property
+    def schema(self):
         return self.table.schema()
 
     def has_schema(self):

--- a/ibis/expr/tests/test_datatypes.py
+++ b/ibis/expr/tests/test_datatypes.py
@@ -320,7 +320,7 @@ def test_timestamp_with_invalid_timezone():
 
 def test_timestamp_with_timezone_repr():
     ts = dt.Timestamp('UTC')
-    assert repr(ts) == "Timestamp(timezone='UTC')"
+    assert repr(ts) == "Timestamp(timezone='UTC', nullable=True)"
 
 
 def test_timestamp_with_timezone_str():

--- a/ibis/expr/tests/test_decimal.py
+++ b/ibis/expr/tests/test_decimal.py
@@ -99,13 +99,14 @@ def test_invalid_precision_scale_combo():
 def test_decimal_str(lineitem):
     col = lineitem.l_extendedprice
     t = col.type()
-    assert str(t) == 'decimal({0:d}, {1:d})'.format(t.precision, t.scale)
+    assert str(t) == 'decimal({:d}, {:d})'.format(t.precision, t.scale)
 
 
 def test_decimal_repr(lineitem):
     col = lineitem.l_extendedprice
     t = col.type()
-    assert repr(t) == 'Decimal(precision={0:d}, scale={1:d})'.format(
+    expected = 'Decimal(precision={:d}, scale={:d}, nullable=True)'.format(
         t.precision,
         t.scale,
     )
+    assert repr(t) == expected

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -907,7 +907,7 @@ class TableExpr(Expr):
         """
         if not self._is_materialized():
             raise IbisError('Table operation is not yet materialized')
-        return self.op().get_schema()
+        return self.op().schema
 
     def _is_materialized(self):
         # The operation produces a known schema


### PR DESCRIPTION
Before this PR, every datatype's hash function was `hash(type(self))`, which
means collisions galore (triggering __eq__ comparison when using complex types
as dict keys). This PR provides a hash function based on ``__slots__`` giving
every type a unique hash based on ``type(self)``, its slots (if any) + the
``nullable`` field from the ``DataType`` parent class.