### PR TITLE
ENH: add .serialize() & Expr.deserialize support for expressions

### DIFF
--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -71,6 +71,15 @@ class Schema(object):
             )
         )
 
+    def _serialize(self, formatter, name=None):
+        return {
+            'module': 'datatypes',
+            'type': 'Schema',
+            'name': name,
+            'kwargs': {'names': self.names,
+                       'types': formatter.visit_args(self.types)}
+            }
+
     def __hash__(self):
         return hash((type(self), tuple(self.names), tuple(self.types)))
 
@@ -227,6 +236,15 @@ class DataType(object):
 
     def __str__(self):
         return self.name.lower()
+
+    def _serialize(self, formatter, name=None):
+        # we are serializing the class of the type
+        return {
+            'module': 'datatypes',
+            'type': str(self),
+            'name': name,
+            'is_class': True,
+            }
 
     @property
     def name(self):

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
+import json
 import ibis.util as util
-
+import ibis.expr as exprs
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 
@@ -22,7 +24,6 @@ class FormatMemo(object):
     # A little sanity hack to simplify the below
 
     def __init__(self):
-        from collections import defaultdict
         self.formatted = {}
         self.aliases = {}
         self.ops = {}
@@ -34,22 +35,10 @@ class FormatMemo(object):
     def __contains__(self, obj):
         return self._key(obj) in self.formatted
 
-    def _key(self, expr):
-        memo_key = id(expr)
-        if memo_key in self._repr_memo:
-            return self._repr_memo[memo_key]
-
-        result = self._format(expr)
-        self._repr_memo[memo_key] = result
-
-        return result
-
-    def _format(self, expr):
-        return expr.op()._repr(memo=self)
-
-    def observe(self, expr, formatter=None):
+    def observe(self, expr, formatter):
         if formatter is None:
             formatter = self._format
+
         key = self._key(expr)
         if key not in self.formatted:
             self.aliases[key] = 'ref_%d' % len(self.formatted)
@@ -68,11 +57,36 @@ class FormatMemo(object):
         return self.formatted[self._key(expr)]
 
 
+class FormatReprMemo(FormatMemo):
+
+    def _format(self, expr):
+        return expr.op()._repr(memo=self)
+
+    def _key(self, expr):
+        memo_key = id(expr)
+        if memo_key in self._repr_memo:
+            return self._repr_memo[memo_key]
+
+        # key always needs to be hashable
+        result = self._format(expr)
+        self._repr_memo[memo_key] = result
+
+        return result
+
+
+class FormatJsonMemo(FormatReprMemo):
+
+    def _format(self, expr):
+        return expr.op()._serialize(self)
+
+    def _key(self, expr):
+        return id(expr)
+
+
 class ExprFormatter(object):
 
     """
-    For creating a nice tree-like representation of an expression graph for
-    displaying in the console.
+    Base class for creating reprs of the expression tree
 
     TODO: detect reused DAG nodes and do not display redundant information
     """
@@ -82,17 +96,16 @@ class ExprFormatter(object):
         self.expr = expr
         self.indent_size = indent_size
         self.base_level = base_level
-
         self.memoize = memoize
 
         # For tracking "extracted" objects, like tables, that we don't want to
         # print out more than once, and simply alias in the expression tree
         if memo is None:
-            memo = FormatMemo()
+            memo = self._format_memo()
 
         self.memo = memo
 
-    def get_result(self):
+    def get_raw_result(self):
         what = self.expr.op()
 
         if self.memoize:
@@ -101,25 +114,23 @@ class ExprFormatter(object):
         if isinstance(what, ops.TableNode) and what.has_schema():
             # This should also catch aggregations
             if not self.memoize and self.expr in self.memo:
-                text = 'Table: %s' % self.memo.get_alias(self.expr)
+                text = self._format_aliased_table()
             elif isinstance(what, ops.PhysicalTable):
-                text = self._format_table(self.expr)
+                text = self._format_table()
             else:
                 # Any other node type
-                text = self._format_node(self.expr)
+                text = self._format_node()
         elif isinstance(what, ops.TableColumn):
-            text = self._format_column(self.expr)
+            text = self._format_column()
         elif isinstance(what, ir.Literal):
-            text = 'Literal[{}]\n  {}'.format(
-                self._get_type_display(), str(what.value)
-            )
+            text = self._format_literal(what)
         elif isinstance(what, ir.ScalarParameter):
-            text = 'ScalarParameter[{}]'.format(self._get_type_display())
+            text = self._format_scalar_parameter()
         elif isinstance(what, ir.Node):
-            text = self._format_node(self.expr)
+            text = self._format_node()
 
         if isinstance(self.expr, ir.ValueExpr) and self.expr._name is not None:
-            text = '{} = {}'.format(self.expr.get_name(), text)
+            text = self._format_value_expr(text)
 
         if self.memoize:
             alias_to_text = [(self.memo.aliases[x],
@@ -130,12 +141,12 @@ class ExprFormatter(object):
 
             # A hack to suppress printing out of a ref that is the result of
             # the top level expression
-            refs = [x + '\n' + y
-                    for x, y, op in alias_to_text
-                    if not op.equals(what)]
+            text = self._format_aliases(alias_to_text, what, text)
 
-            text = '\n\n'.join(refs + [text])
+        return text
 
+    def get_result(self):
+        text = self.get_raw_result()
         return self._indent(text, self.base_level)
 
     def _memoize_tables(self):
@@ -169,10 +180,36 @@ class ExprFormatter(object):
 
                 memo.visit_memo.add(id(e))
 
+    def _get_type_display(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        return expr._type_display()
+
+
+class ExprReprFormatter(ExprFormatter):
+    """
+    For creating a nice tree-like representation of an expression graph for
+    displaying in the console.
+
+    TODO: detect reused DAG nodes and do not display redundant information
+    """
+    _format_memo = FormatReprMemo
+
     def _indent(self, text, indents=1):
         return util.indent(text, self.indent_size * indents)
 
-    def _format_table(self, expr):
+    def _format_aliases(self, alias_to_text, what, text):
+        refs = [x + '\n' + y
+                for x, y, op in alias_to_text
+                if not op.equals(what)]
+
+        return '\n\n'.join(refs + [text])
+
+    def _format_table(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
         table = expr.op()
         # format the schema
         rows = ['name: {0!s}\nschema:'.format(table.name)]
@@ -183,7 +220,27 @@ class ExprFormatter(object):
         opline = '%s[%s]' % (opname, type_display)
         return '{0}\n{1}'.format(opline, self._indent('\n'.join(rows)))
 
-    def _format_column(self, expr):
+    def _format_aliased_table(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        return 'Table: %s' % self.memo.get_alias(expr)
+
+    def _format_subexpr(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        key = id(expr)
+        if key not in self.memo.subexprs:
+            formatter = type(self)(expr, memo=self.memo, memoize=False)
+            self.memo.subexprs[key] = self._indent(formatter.get_result(), 1)
+
+        return self.memo.subexprs[key]
+
+    def _format_column(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
         # HACK: if column is pulled from a Filter of another table, this parent
         # will not be found in the memo
         col = expr.op()
@@ -199,7 +256,10 @@ class ExprFormatter(object):
         return ("Column[{0}] '{1}' from table\n{2}"
                 .format(type_display, col.name, table_formatted))
 
-    def _format_node(self, expr):
+    def _format_node(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
         op = expr.op()
         formatted_args = []
 
@@ -248,16 +308,216 @@ class ExprFormatter(object):
         opline = '%s[%s]' % (opname, type_display)
         return '\n'.join([opline] + formatted_args)
 
-    def _format_subexpr(self, expr):
-        key = id(expr)
-        if key not in self.memo.subexprs:
-            formatter = ExprFormatter(expr, memo=self.memo, memoize=False)
-            self.memo.subexprs[key] = self._indent(formatter.get_result(), 1)
-
-        return self.memo.subexprs[key]
-
-    def _get_type_display(self, expr=None):
+    def _format_value_expr(self, text, expr=None):
         if expr is None:
             expr = self.expr
 
-        return expr._type_display()
+        return '{} = {}'.format(expr.get_name(), text)
+
+    def _format_scalar_parameter(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        return 'ScalarParameter[{}]'.format(
+            self._get_type_display(expr))
+
+    def _format_literal(self, what, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        return 'Literal[{}]\n  {}'.format(
+            self._get_type_display(expr), str(what.value)
+        )
+
+
+class ExprJsonFormatter(ExprFormatter):
+    _format_memo = FormatJsonMemo
+
+    def _indent(self, text, indents=1):
+        return json.dumps(text, indent=self.indent_size * indents)
+
+    def _format_aliases(self, alias_to_text, what, text):
+        refs = [{'ref': x, 'value': op._serialize(self)}
+                for x, y, op in alias_to_text
+                if not op.equals(what)]
+
+        text['refs'] = refs
+        return text
+
+    def _format_value_expr(self, text, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        return {'expr': text,
+                'name': expr.get_name()}
+
+    def _format_table(self, expr=None):
+        if expr is None:
+            expr = self.expr
+        return expr.op()._serialize(self, name=getattr(expr, '_name', None))
+
+    def _format_column(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        # HACK: if column is pulled from a Filter of another table, this parent
+        # will not be found in the memo
+        col = expr.op()
+        parent = col.parent()
+
+        if parent not in self.memo:
+            self.memo.observe(parent, formatter=self._format_node)
+
+        table_formatted = self.memo.get_alias(parent)
+        return {'Column': table_formatted,
+                'name': col.name}
+
+    def _format_literal(self, what, expr=None):
+        if expr is None:
+            expr = self.expr
+        return expr.op()._serialize(self, name=getattr(expr, '_name', None))
+
+    def _format_aliased_table(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        return {'table': self.memo.get_alias(expr)}
+
+    def _format_subexpr(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        key = id(expr)
+        if key not in self.memo.subexprs:
+            formatter = type(self)(expr, memo=self.memo, memoize=False)
+            self.memo.subexprs[key] = formatter.get_raw_result()
+
+        return self.memo.subexprs[key]
+
+    def _format_node(self, expr=None):
+        if expr is None:
+            expr = self.expr
+
+        return expr.op()._serialize(self, name=getattr(expr, '_name', None))
+
+    def visit(self, what):
+        """ op visible visitor """
+        if isinstance(what, ir.Expr):
+            what = self._format_node(what)
+        elif hasattr(what, '_serialize'):
+            what = what._serialize(self)
+        return what
+
+    def visit_args(self, args):
+        """ format list of args """
+        return [self.visit(x) for x in args]
+
+    def visit_kwargs(self, keys, values):
+        """ format a dictionary of keys and values """
+        kwargs = {}
+        for name, arg in zip(keys, values):
+            if isinstance(arg, list):
+                kwargs[name] = [self.visit(x) for x in arg]
+            else:
+                kwargs[name] = self.visit(arg)
+        return kwargs
+
+
+class ExprJsonConstructor:
+
+    def __init__(self, s):
+        """ deserialize a string to an Expr """
+        self.data = json.loads(s)
+
+        # construct refs
+        self.refs = self.data.pop('refs', None)
+        if self.refs:
+            self.refs = self._construct_ref(self.refs)
+
+    def get_result(self):
+        """ construct & return the expr """
+        return self._construct_expr(self.data)
+
+    def _construct_ref(self, refs):
+        """
+        we have a ref(s) to a type(s),
+        reconstruct the refs to exprs as a dict
+        """
+
+        return {r['ref']: self._construct_type(r['value']) for r in refs}
+
+    def _construct_type(self, d):
+        """ we have a full-fledged type, reconstruct the expr """
+
+        type = d['type']
+        module = d['module']
+        name = d['name']
+        func = getattr(getattr(exprs, module), type)
+
+        # traverse the args for exprs
+        args = d.pop('args', None)
+        if args:
+            args = [self._construct_expr(a) for a in args]
+
+        # traverse the kwargs for exprs
+        kwargs = d.pop('kwargs', None)
+        if kwargs:
+            kwargs = {k: self._construct_expr(v) for k, v in kwargs.items()}
+
+        is_class = d.get('is_class')
+        if is_class:
+            return func
+
+        # construct
+        result = func(*(args or []), **(kwargs or {}))
+
+        # we originally serialized ops
+        if hasattr(result, 'to_expr'):
+            result = result.to_expr()
+            if name is not None:
+                result = result.name(name)
+
+        return result
+
+    def _construct_expr(self, expr):
+        """ reconstruct a sub-expression given the refs """
+
+        if isinstance(expr, list):
+            return [self._visit_expr(e) for e in expr]
+        elif isinstance(expr, dict):
+
+            # type to resolve
+            if 'type' in expr:
+                return self._construct_type(expr)
+
+            # we have a table ref to resolve
+            elif 'table' in expr:
+                return self._resolve_ref(expr['table'])
+
+        return self._visit_expr(expr)
+
+    def _resolve_ref(self, e):
+        if isinstance(e, dict):
+            if 'Column' in e:
+                r = self.refs[e['Column']]
+                e = r[e['name']]
+        else:
+            e = self.refs[e]
+
+        return e
+
+    def _visit_expr(self, e):
+        """ e is a dict of 'expr', construct the expression """
+
+        if isinstance(e, dict):
+            if 'expr' in e:
+                e = e['expr']
+                if isinstance(e, list):
+                    return [self._construct_expr(self._resolve_ref(e))
+                            for e_ in e]
+                e = self._construct_expr(self._resolve_ref(e))
+
+            elif 'type' in e:
+                return self._construct_type(e)
+
+        return e

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -17,7 +17,7 @@ import re
 import ibis
 
 from ibis.expr.types import Expr
-from ibis.expr.format import ExprFormatter
+from ibis.expr.format import ExprReprFormatter
 
 
 def test_format_custom_expr():
@@ -71,7 +71,7 @@ def test_memoize_aggregate_correctly(table):
 
     result = table.aggregate(metrics, by=['g'])
 
-    formatter = ExprFormatter(result)
+    formatter = ExprReprFormatter(result)
     formatted = formatter.get_result()
 
     alias = formatter.memo.get_alias(table)

--- a/ibis/expr/tests/test_serialize.py
+++ b/ibis/expr/tests/test_serialize.py
@@ -1,0 +1,52 @@
+import ibis
+import ibis.expr.types as ir
+
+
+def assert_round_trip(expr):
+    serialized = expr.serialize()
+    result = ir.Expr.deserialize(serialized)
+    assert result.equals(expr)
+
+
+def test_table(table):
+    assert_round_trip(table)
+
+
+def test_projection(table):
+    assert_round_trip(table[table.columns])
+    assert_round_trip(table[table.columns[0:2]])
+
+
+def test_predicates(table):
+    t = table[table.columns]
+    t = t[table.a > 1]
+    assert_round_trip(t)
+
+
+def test_filter_self_join():
+    # GH #667
+    purchases = ibis.table([('region', 'string'),
+                            ('kind', 'string'),
+                            ('user', 'int64'),
+                            ('amount', 'double')], 'purchases')
+
+    metric = purchases.amount.sum().name('total')
+    agged = (purchases.group_by(['region', 'kind'])
+             .aggregate(metric))
+
+    left = agged[agged.kind == 'foo']
+    right = agged[agged.kind == 'bar']
+
+    cond = left.region == right.region
+    joined = left.join(right, cond)
+    assert_round_trip(joined)
+
+
+def test_compound(table):
+
+    t = table.a + table.b / 2
+    assert_round_trip(t)
+
+
+def test_literal():
+    assert_round_trip(ibis.literal(5))

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -966,7 +966,7 @@ class QueryContext(object):
         self.query = None
 
         self._table_key_memo = {}
-        self.memo = memo or format.FormatMemo()
+        self.memo = memo or format.FormatReprMemo()
 
     def _compile_subquery(self, expr):
         sub_ctx = self.subcontext()


### PR DESCRIPTION
closes #1267 

still a bit of WIP, as not fully tested, but.

```
In [3]: def schema():
   ...:     return [
   ...:         ('a', 'int8'),
   ...:         ('b', 'int16'),
   ...:         ('c', 'int32'),
   ...:         ('d', 'int64'),
   ...:         ('e', 'float'),
   ...:         ('f', 'double'),
   ...:         ('g', 'string'),
   ...:         ('h', 'boolean'),
   ...:         ('i', 'timestamp'),
   ...:         ('j', 'date'),
   ...:         ('k', 'time'),
   ...:     ]
   ...: table = ibis.table(schema(), name='table')
   ...: 

In [4]: table
Out[4]: 
UnboundTable[table]
  name: table
  schema:
    a : int8
    b : int16
    c : int32
    d : int64
    e : float
    f : double
    g : string
    h : boolean
    i : timestamp
    j : date
    k : time

In [5]: t = table['a', 'b', 'c']

In [6]: t = t[t.a>1]

In [7]: json = t.serialize()
In [8]: json
Out[8]: '{\n"module": "operations",\n"type": "Selection",\n"kwargs": {\n"table_expr": {\n"module": "api",\n"type": "table",\n"kwargs": {\n"name": "table",\n"schema": {\n"module": "datatypes",\n"type": "Schema",\n"kwargs": {\n"names": [\n"a",\n"b",\n"c",\n"d",\n"e",\n"f",\n"g",\n"h",\n"i",\n"j",\n"k"\n],\n"types": [\n{\n"module": "datatypes",\n"type": "int8",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int16",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int32",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int64",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "float",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "double",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "string",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "boolean",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "timestamp",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "date",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "time",\n"is_class": true\n}\n]\n}\n}\n}\n},\n"proj_exprs": [\n{\n"module": "operations",\n"type": "TableColumn",\n"args": [\n"a",\n{\n"module": "api",\n"type": "table",\n"kwargs": {\n"name": "table",\n"schema": {\n"module": "datatypes",\n"type": "Schema",\n"kwargs": {\n"names": [\n"a",\n"b",\n"c",\n"d",\n"e",\n"f",\n"g",\n"h",\n"i",\n"j",\n"k"\n],\n"types": [\n{\n"module": "datatypes",\n"type": "int8",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int16",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int32",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int64",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "float",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "double",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "string",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "boolean",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "timestamp",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "date",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "time",\n"is_class": true\n}\n]\n}\n}\n}\n}\n]\n},\n{\n"module": "operations",\n"type": "TableColumn",\n"args": [\n"b",\n{\n"module": "api",\n"type": "table",\n"kwargs": {\n"name": "table",\n"schema": {\n"module": "datatypes",\n"type": "Schema",\n"kwargs": {\n"names": [\n"a",\n"b",\n"c",\n"d",\n"e",\n"f",\n"g",\n"h",\n"i",\n"j",\n"k"\n],\n"types": [\n{\n"module": "datatypes",\n"type": "int8",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int16",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int32",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int64",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "float",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "double",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "string",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "boolean",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "timestamp",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "date",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "time",\n"is_class": true\n}\n]\n}\n}\n}\n}\n]\n},\n{\n"module": "operations",\n"type": "TableColumn",\n"args": [\n"c",\n{\n"module": "api",\n"type": "table",\n"kwargs": {\n"name": "table",\n"schema": {\n"module": "datatypes",\n"type": "Schema",\n"kwargs": {\n"names": [\n"a",\n"b",\n"c",\n"d",\n"e",\n"f",\n"g",\n"h",\n"i",\n"j",\n"k"\n],\n"types": [\n{\n"module": "datatypes",\n"type": "int8",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int16",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int32",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int64",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "float",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "double",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "string",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "boolean",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "timestamp",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "date",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "time",\n"is_class": true\n}\n]\n}\n}\n}\n}\n]\n}\n],\n"predicates": [\n{\n"module": "operations",\n"type": "Greater",\n"args": [\n{\n"module": "operations",\n"type": "TableColumn",\n"args": [\n"a",\n{\n"module": "api",\n"type": "table",\n"kwargs": {\n"name": "table",\n"schema": {\n"module": "datatypes",\n"type": "Schema",\n"kwargs": {\n"names": [\n"a",\n"b",\n"c",\n"d",\n"e",\n"f",\n"g",\n"h",\n"i",\n"j",\n"k"\n],\n"types": [\n{\n"module": "datatypes",\n"type": "int8",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int16",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int32",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int64",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "float",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "double",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "string",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "boolean",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "timestamp",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "date",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "time",\n"is_class": true\n}\n]\n}\n}\n}\n}\n]\n},\n{\n"module": "api",\n"type": "literal",\n"args": [\n1\n]\n}\n]\n}\n],\n"sort_keys": []\n},\n"refs": [\n{\n"ref": "ref_0",\n"value": {\n"module": "api",\n"type": "table",\n"kwargs": {\n"name": "table",\n"schema": {\n"module": "datatypes",\n"type": "Schema",\n"kwargs": {\n"names": [\n"a",\n"b",\n"c",\n"d",\n"e",\n"f",\n"g",\n"h",\n"i",\n"j",\n"k"\n],\n"types": [\n{\n"module": "datatypes",\n"type": "int8",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int16",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int32",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "int64",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "float",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "double",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "string",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "boolean",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "timestamp",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "date",\n"is_class": true\n},\n{\n"module": "datatypes",\n"type": "time",\n"is_class": true\n}\n]\n}\n}\n}\n}\n}\n]\n}'

In [10]: r = ibis.expr.types.Expr.deserialize(json)

In [11]: r
Out[11]: 
ref_0
UnboundTable[table]
  name: table
  schema:
    a : int8
    b : int16
    c : int32
    d : int64
    e : float
    f : double
    g : string
    h : boolean
    i : timestamp
    j : date
    k : time

Selection[table]
  table:
    Table: ref_0
  selections:
    a = Column[int8*] 'a' from table
      ref_0
    b = Column[int16*] 'b' from table
      ref_0
    c = Column[int32*] 'c' from table
      ref_0
  predicates:
    Greater[boolean*]
      left:
        a = Column[int8*] 'a' from table
          ref_0
      right:
        Literal[int8]
          1

In [12]: t.equals(r)
Out[12]: True
```