### PR TITLE
ENH: Pandas UD(A)Fs

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -2,6 +2,6 @@
 
 docker-compose rm --force --stop
 docker-compose up -d --no-build postgres mysql clickhouse impala
-docker-compose run waiter
+docker-compose run --rm waiter
 docker-compose build --pull ibis
-docker-compose run ibis ci/load-data.sh
+docker-compose run --rm ibis ci/load-data.sh

--- a/ci/requirements-dev-2.7.yml
+++ b/ci/requirements-dev-2.7.yml
@@ -8,6 +8,8 @@ dependencies:
   - cmake
   - enum34
   - flake8
+  - funcsigs
+  - functools32
   - google-cloud-bigquery<0.28
   - graphviz
   - impyla>=0.13.7

--- a/conda-recipes/ibis-framework/meta.yaml
+++ b/conda-recipes/ibis-framework/meta.yaml
@@ -13,6 +13,8 @@ source:
 requirements:
   build:
     - enum34  # [py27]
+    - funcsigs # [py27]
+    - functools32 # [py27]
     - pathlib2  # [py27]
     - numpy >=1.10.0
     - pandas >=0.18.1
@@ -24,6 +26,8 @@ requirements:
     - toolz
   run:
     - enum34  # [py27]
+    - funcsigs # [py27]
+    - functools32 # [py27]
     - pathlib2  # [py27]
     - numpy >=1.10.0
     - pandas >=0.18.1

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -1,0 +1,81 @@
+.. _backends:
+
+Backends
+========
+
+This document describes the classes of backends, how they work, and any details
+about each backend that are relevant to end users.
+
+.. _classes_of_backends:
+
+Classes of Backends
+-------------------
+
+There are currently three classes of backends that live in ibis.
+
+#. String generating backends
+#. Expression generating backends
+#. Direct execution backends
+
+.. _string_generating_backends:
+
+String Generating Backends
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The first category of backend translates ibis expressions into strings.
+Generally speaking these backends also need to handle their own execution.
+They work by translating each node into a string, and passing the generated
+string to the database through a driver API.
+
+Impala
+******
+
+TODO
+
+Clickhouse
+**********
+
+TODO
+
+BigQuery
+********
+
+TODO
+
+.. _expression_generating_backends:
+
+Expression Generating Backends
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The second category of backends translates ibis expressions into other
+expressions. Currently, all expression generating backends generate `SQLAlchemy
+expressions <http://docs.sqlalchemy.org/en/latest/core/tutorial.html>`_.
+
+Instead of generating strings at each translation step, these backends build up
+an expression. These backends tend to execute their expressions directly
+through the driver APIs provided by SQLAlchemy (or one of its transitive
+dependencies).
+
+SQLite
+******
+
+TODO
+
+PostgreSQL
+**********
+
+TODO
+
+.. _direct_execution_backends:
+
+Direct Execution Backends
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The only existing backend that directly executes ibis expressions is the pandas
+backend. A full description of the implementation can be found in the module
+docstring of the pandas backend located in ``ibis/pandas/execution/core.py``.
+
+Pandas
+******
+
+TODO

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -87,6 +87,7 @@ places, but this will improve as things progress.
    developer
    design
    extending
+   backends
    release
    legal
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,6 +84,7 @@ places, but this will improve as things progress.
    tutorial
    api
    sql
+   udf
    developer
    design
    extending

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -36,6 +36,7 @@ New Features
   ``ORDER BY`` clause (:issue:`1371`)
 * Add ``.get()`` operation on a Map type (:issue:`1376`)
 * Allow visualization of custom defined expressions
+* Add experimental support for pandas UDFs/UDAFs (:issue:`1277`)
 
 Bug Fixes
 ~~~~~~~~~

--- a/docs/source/udf.rst
+++ b/docs/source/udf.rst
@@ -1,0 +1,107 @@
+.. _udf:
+
+User Defined Functions
+======================
+
+Ibis provides a mechanism for writing custom scalar and aggregate functions,
+with varying levels of support for different backends. UDFs/UDAFs are a complex
+topic.
+
+This section of the documentation will discuss some of the backend specific
+details of user defined functions.
+
+API
+---
+
+.. warning::
+
+   The UDF/UDAF API is quite experimental at this point and is therefore
+   provisional and subject to change.
+
+Going forward, the API for user defined *scalar* functions will look like this:
+
+.. code-block:: python
+
+   @udf(input_type=[double], output_type=double)
+   def add_one(x):
+       return x + 1.0
+
+
+User defined *aggregate* functions are nearly identical, with the exception
+of using the ``@udaf`` decorator instead of the ``@udf`` decorator.
+
+Impala
+------
+
+TODO
+
+Pandas
+------
+
+Pandas supports defining both UDFs and UDAFs.
+
+When you define a UDF you automatically get support for applying that UDF in a
+scalar context, *as well as* in any group by operation.
+
+When you define a UDAF you automatically get support for standard scalar
+aggregations, group bys, *as well as* any supported windowing operation.
+
+The API for these functions is the same as described above.
+
+The objects you receive as input arguments are either ``pandas.Series`` or
+python or numpy scalars depending on the operation.
+
+Using ``add_one`` from above as an example, the following call will receive a
+``pandas.Series`` for the ``x`` argument:
+
+.. code-block:: python
+
+   >>> import ibis
+   >>> import pandas as pd
+   >>> df = pd.DataFrame({'a': [1, 2, 3]})
+   >>> con = ibis.pandas.connect({'df': df})
+   >>> t = con.table('df')
+   >>> expr = add_one(t.a)
+
+And this will receive the ``int`` 1:
+
+.. code-block:: python
+
+   >>> expr = add_one(1)
+
+Finally, since the pandas backend passes around ``**kwargs`` you can accept
+``**kwargs`` in your function:
+
+.. code-block:: python
+
+   @udf([double], double)
+   def add_one(x, **kwargs):
+       return x + 1.0
+
+Or you can leave them out as we did in the example above. You can also
+optionally accept *specific* keyword arguments. This requires knowledge of how
+the pandas backend works for it to be useful:
+
+.. note::
+
+   Any keyword arguments (other than ``**kwargs``) must be given a default
+   value or the UDF/UDAF **will not work**. A standard Python convention is to
+   set the default value to ``None``.
+
+For example:
+
+.. code-block:: python
+
+   @udf([double], double)
+   def add_one(x, scope=None):
+       return x + 1.0
+
+BigQuery
+--------
+
+TODO
+
+SQLite
+------
+
+TODO

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -21,8 +21,8 @@ if not PY2:
     zip = zip
     zip_longest = itertools.zip_longest
 
-    def dict_values(x):
-        return list(x.values())
+    def viewkeys(x):
+        return x.keys()
 
     from decimal import Decimal
     from inspect import signature, Parameter, _empty
@@ -46,8 +46,8 @@ else:
     zip = itertools.izip
     zip_longest = itertools.izip_longest
 
-    def dict_values(x):
-        return x.values()
+    def viewkeys(x):
+        return x.viewkeys()
 
     try:
         import mock  # noqa: F401

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -1,17 +1,3 @@
-# Copyright 2015 Cloudera Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 from __future__ import absolute_import
 
 import itertools
@@ -39,17 +25,21 @@ if not PY2:
         return list(x.values())
 
     from decimal import Decimal
+    from inspect import signature
     import unittest.mock as mock
     range = range
     import builtins
     import pickle
     maketrans = str.maketrans
+    import functools
     from functools import reduce
 else:
     try:
         from cdecimal import Decimal
     except ImportError:
         from decimal import Decimal  # noqa: F401
+
+    from funcsigs import signature  # noqa: F401
 
     unicode_type = unicode  # noqa: F821
     lzip = zip
@@ -65,6 +55,7 @@ else:
         pass
 
     import __builtin__ as builtins  # noqa: F401
+    import functools32 as functools  # noqa: F401
 
     range = xrange  # noqa: F821
     reduce = reduce  # noqa: F821
@@ -83,8 +74,6 @@ else:
         if isinstance(x, six.text_type):
             return dict(zip(map(ord, x), y))
         return string.maketrans(x, y)
-
-    reduce = reduce
 
 
 integer_types = six.integer_types + (np.integer,)
@@ -132,15 +121,3 @@ except ImportError:
 
 def to_date(*args, **kwargs):
     return to_datetime(*args, **kwargs).date()
-
-
-if PY2:
-    def wrapped(f):
-        def wrapper(functools_wrapped):
-            functools_wrapped.__wrapped__ = f
-            return functools_wrapped
-        return wrapper
-else:
-    def wrapped(f):
-        import toolz
-        return toolz.identity

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -25,7 +25,7 @@ if not PY2:
         return list(x.values())
 
     from decimal import Decimal
-    from inspect import signature
+    from inspect import signature, Parameter, _empty
     import unittest.mock as mock
     range = range
     import builtins
@@ -39,7 +39,7 @@ else:
     except ImportError:
         from decimal import Decimal  # noqa: F401
 
-    from funcsigs import signature  # noqa: F401
+    from funcsigs import signature, Parameter, _empty  # noqa: F401
 
     unicode_type = unicode  # noqa: F821
     lzip = zip

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -17,11 +17,12 @@ from __future__ import print_function
 import warnings
 import operator
 import datetime
-import functools
 import collections
 
 import six
 import toolz
+
+from ibis.compat import functools
 
 from ibis.expr.schema import Schema
 from ibis.expr import datatypes as dt

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -17,14 +17,13 @@ import six
 import toolz
 import datetime
 import itertools
-import functools
 import pandas as pd
 
 from collections import namedtuple, OrderedDict
 from multipledispatch import Dispatcher
 
 import ibis.common as com
-from ibis.compat import builtins, PY2
+from ibis.compat import PY2, builtins, functools
 
 
 class DataType(object):

--- a/ibis/pandas/core.py
+++ b/ibis/pandas/core.py
@@ -80,7 +80,6 @@ from __future__ import absolute_import
 import collections
 import numbers
 import datetime
-import functools
 
 import six
 
@@ -91,6 +90,8 @@ import toolz
 import ibis.expr.types as ir
 import ibis.expr.lineage as lin
 import ibis.expr.datatypes as dt
+
+from ibis.compat import functools
 from ibis.client import find_backends
 
 

--- a/ibis/pandas/dispatch.py
+++ b/ibis/pandas/dispatch.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
-from multipledispatch import Dispatcher
+import contextlib
+
+from multipledispatch import Dispatcher, halt_ordering, restart_ordering
 
 
 # Main interface to execution; ties the following functions together
@@ -32,3 +34,14 @@ def data_preload_default(node, data, **kwargs):
 @pre_execute.register(object, object)
 def pre_execute_default(node, client, **kwargs):
     return {}
+
+
+@contextlib.contextmanager
+def pause_ordering():
+    """Pause multipledispatch ordering
+    """
+    halt_ordering()
+    try:
+        yield
+    finally:
+        restart_ordering()

--- a/ibis/pandas/execution/generic.py
+++ b/ibis/pandas/execution/generic.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import datetime
 import decimal
-import functools
 import numbers
 import operator
 
@@ -21,6 +20,8 @@ import ibis.common as com
 import ibis.expr.types as ir
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+
+from ibis.compat import functools
 
 from ibis.pandas.core import (
     boolean_types,

--- a/ibis/pandas/execution/selection.py
+++ b/ibis/pandas/execution/selection.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 
-import functools
 import itertools
 import operator
 
@@ -17,6 +16,8 @@ from multipledispatch import Dispatcher
 
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
+
+from ibis.compat import functools
 
 from ibis.pandas.dispatch import execute, execute_node
 from ibis.pandas.execution import constants, util

--- a/ibis/pandas/execution/tests/test_functions.py
+++ b/ibis/pandas/execution/tests/test_functions.py
@@ -3,7 +3,6 @@ import pytest
 
 import math
 import decimal
-import functools
 import operator
 from operator import methodcaller
 
@@ -11,6 +10,8 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm  # noqa: E402
 import ibis.expr.datatypes as dt  # noqa: E402
+
+from ibis.compat import functools
 from ibis.common import IbisTypeError  # noqa: E402
 
 

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -1,0 +1,105 @@
+import pytest
+
+import numpy as np
+
+import pandas as pd
+import pandas.util.testing as tm
+
+import ibis
+import ibis.expr.types as ir
+import ibis.expr.datatypes as dt
+
+from ibis.pandas.udf import udf, udaf, nullable
+from ibis.pandas.dispatch import pause_ordering
+
+
+with pause_ordering():
+
+    @udf(input_type=[dt.string], output_type=dt.int64)
+    def my_string_length(series, **kwargs):
+        return series.str.len() * 2
+
+    @udaf(input_type=[dt.string], output_type=dt.int64)
+    def my_string_length_sum(series, **kwargs):
+        return (series.str.len() * 2).sum()
+
+    @udaf(input_type=[dt.double, dt.double], output_type=dt.double)
+    def my_corr(lhs, rhs, **kwargs):
+        return lhs.corr(rhs)
+
+
+def test_udf():
+    df = pd.DataFrame({'a': list('abc')})
+    con = ibis.pandas.connect({'df': df})
+    t = con.table('df')
+    expr = my_string_length(t.a)
+
+    assert isinstance(expr, ir.Expr)
+
+    result = expr.execute()
+    expected = t.a.execute().str.len().mul(2)
+    tm.assert_series_equal(result, expected)
+
+
+def test_udaf():
+    df = pd.DataFrame({'a': list('cba')})
+    con = ibis.pandas.connect({'df': df})
+    t = con.table('df')
+    expr = my_string_length_sum(t.a)
+
+    assert isinstance(expr, ir.Expr)
+
+    result = expr.execute()
+    expected = t.a.execute().str.len().mul(2).sum()
+    assert result == expected
+
+
+def test_udaf_in_groupby():
+    df = pd.DataFrame({
+        'a': np.arange(4, dtype=float).tolist() + np.random.rand(3).tolist(),
+        'b': np.arange(4, dtype=float).tolist() + np.random.rand(3).tolist(),
+        'key': list('ddeefff')})
+    con = ibis.pandas.connect({'df': df})
+    t = con.table('df')
+    expr = t.groupby(t.key).aggregate(my_corr=my_corr(t.a, t.b))
+
+    assert isinstance(expr, ir.Expr)
+
+    result = expr.execute().sort_values('key')
+
+    dfi = df.set_index('key')
+    expected = pd.DataFrame({
+        'key': list('def'),
+        'my_corr': [
+            dfi.loc[value, 'a'].corr(dfi.loc[value, 'b']) for value in 'def'
+        ]
+    })
+
+    columns = ['key', 'my_corr']
+    tm.assert_frame_equal(result[columns], expected[columns])
+
+
+def test_nullable():
+    t = ibis.table([('a', 'int64')])
+    assert nullable(t.a.type()) == (type(None),)
+
+
+@pytest.mark.xfail(
+    raises=AssertionError, reason='Nullability is not propagated')
+def test_nullable_non_nullable_field():
+    t = ibis.table([('a', dt.String(nullable=False))])
+    assert nullable(t.a.type()) == ()
+
+
+def test_udaf_parameter_mismatch():
+    with pytest.raises(TypeError):
+        @udaf(input_type=[dt.double], output_type=dt.double)
+        def my_corr(lhs, rhs, **kwargs):
+            pass
+
+
+def test_udf_parameter_mismatch():
+    with pytest.raises(TypeError):
+        @udf(input_type=[], output_type=dt.double)
+        def my_corr2(lhs, **kwargs):
+            return 1.0

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -1,0 +1,321 @@
+from __future__ import absolute_import
+
+import collections
+
+import itertools
+
+import six
+
+import numpy as np
+import pandas as pd
+
+from pandas.core.groupby import SeriesGroupBy
+
+import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
+
+from ibis.pandas.core import scalar_types
+from ibis.pandas.dispatch import execute_node, Dispatcher, pause_ordering
+from ibis.compat import functools, signature
+
+
+rule_to_python_type = Dispatcher(
+    'rule_to_python_type',
+    doc="""\
+Convert an ibis :class:`~ibis.expr.datatypes.DataType` into a pandas backend
+friendly ``multipledispatch`` signature.
+
+Parameters
+----------
+rule : DataType
+    The :class:`~ibis.expr.datatypes.DataType` subclass to map to a pandas
+    friendly type.
+
+Returns
+-------
+types : Union[type, Tuple[type...]]
+    A pandas backend friendly signature
+"""
+)
+
+
+@rule_to_python_type.register(dt.DataType)
+def datatype_rule(rule):
+    return scalar_types
+
+
+@rule_to_python_type.register(dt.Array)
+def array_rule(rule):
+    return (list,)
+
+
+@rule_to_python_type.register(dt.Map)
+def map_rule(rule):
+    return (dict,)
+
+
+@rule_to_python_type.register(dt.Struct)
+def struct_rule(rule):
+    return (collections.OrderedDict,)
+
+
+@rule_to_python_type.register(dt.String)
+def string_rule(rule):
+    return six.string_types
+
+
+@rule_to_python_type.register(dt.Integer)
+def int_rule(rule):
+    return six.integer_types + (np.integer,)
+
+
+@rule_to_python_type.register(dt.Floating)
+def float_rule(rule):
+    return (float, np.floating)
+
+
+def nullable(datatype):
+    """Return the signature of a scalar value that is allowed to be NULL (in
+    SQL parlance).
+
+    Parameters
+    ----------
+    datatype : ibis.expr.datatypes.DataType
+
+    Returns
+    -------
+    Tuple[Type]
+    """
+    return (type(None),) if datatype.nullable else ()
+
+
+def udf_signature(input_type, klass):
+    """Compute the appropriate signature for an ibis Node from a list of input
+    types.
+
+    Parameters
+    ----------
+    input_type : List[ibis.expr.datatypes.DataType]
+        A list of ibis DataType instances
+    klass : Type
+        pd.Series or SeriesGroupBy
+
+    Returns
+    -------
+    Tuple[Type]
+        A tuple of types appropriate for use in a multiple dispatch signature.
+
+    Examples
+    --------
+    >>> from pprint import pprint
+    >>> import pandas as pd
+    >>> from pandas.core.groupby import SeriesGroupBy
+    >>> import ibis.expr.datatypes as dt
+    >>> input_type = [dt.int64, dt.double]
+    >>> sig = udf_signature(input_type, pd.Series)
+    >>> pprint(sig)  # doctest: +ELLIPSIS
+    ((<class 'pandas.core.series.Series'>,
+      <... 'int'>,
+      <... 'numpy.integer'>,
+      <... 'NoneType'>),
+     (<class 'pandas.core.series.Series'>,
+      <... 'float'>,
+      <... 'numpy.floating'>,
+      <... 'NoneType'>))
+    >>> input_type = [dt.Int64(nullable=False), dt.Double(nullable=False)]
+    >>> sig = udf_signature(input_type, SeriesGroupBy)
+    >>> pprint(sig)
+    ((<class 'pandas.core.groupby.SeriesGroupBy'>,
+      <... 'int'>,
+      <... 'numpy.integer'>),
+     (<class 'pandas.core.groupby.SeriesGroupBy'>,
+      <... 'float'>,
+      <... 'numpy.floating'>))
+    """
+    return tuple(
+        (klass,) + rule_to_python_type(r) + nullable(r) for r in input_type
+    )
+
+
+def check_matching_signature(input_type):
+    """Make sure that the number of arguments declared by the user in
+    `input_type` matches that of the wrapped function's signature.
+
+    Parameters
+    ----------
+    input_type : List[DataType]
+
+    Returns
+    -------
+    wrapper : callable
+    """
+    def wrapper(func):
+        num_params = sum(
+            param.kind in {param.POSITIONAL_OR_KEYWORD, param.POSITIONAL_ONLY}
+            for param in signature(func).parameters.values()
+        )
+        num_declared = len(input_type)
+        if num_params != num_declared:
+            raise TypeError(
+                'Function {!r} has {:d} parameters, '
+                'input_type has {:d}. These must match'.format(
+                    func.__name__,
+                    num_params,
+                    num_declared,
+                )
+            )
+
+        return func
+    return wrapper
+
+
+def udf(input_type, output_type):
+    """Define a UDF (user-defined function) that operates element wise on a
+    Pandas Series.
+
+    Parameters
+    ----------
+    input_type : List[ibis.rules]
+        A rules encoding the abstract type of each argument. These are found in
+        :mod:`~ibis.expr.rules`. The length of this list must match the number
+        of arguments to the function. Argument splatting in the UDF signature
+        is not supported.
+    output_type : ibis.rules or ibis.expr.datatypes.DataType
+        The return type of the function.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> @udf(input_type=[dt.string], output_type=dt.int64)
+    ... def my_string_length(series, **kwargs):
+    ...     return series.str.len() * 2
+    """
+    def wrapper(func):
+        # generate a new custom node
+
+        UDFNode = type(
+            func.__name__,
+            (ops.ValueOp,),
+            dict(input_type=input_type, output_type=output_type.array_type)
+        )
+
+        # Don't reorder the multiple dispatch graph for each of these
+        # definitions
+        with pause_ordering():
+
+            # Define a execution rule for a simple elementwise Series function
+            @execute_node.register(
+                UDFNode, *udf_signature(input_type, klass=pd.Series)
+            )
+            def execute_udf_node(op, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            # Define an execution rule for elementwise operations on a grouped
+            # Series
+            @execute_node.register(
+                UDFNode, *udf_signature(input_type, klass=SeriesGroupBy)
+            )
+            def execute_udf_node_groupby(op, *args, **kwargs):
+                groupers = [
+                    grouper for grouper in (
+                        getattr(arg, 'grouper', None) for arg in args
+                    ) if grouper is not None
+                ]
+
+                # all grouping keys must be identical
+                assert all(groupers[0] == grouper for grouper in groupers[1:])
+
+                # we're performing a scalar operation on grouped column, so
+                # perform the operation directly on the underlying Series and
+                # regroup after it's finished
+                arguments = [getattr(arg, 'obj', arg) for arg in args]
+                groupings = groupers[0].groupings
+                return func(*arguments, **kwargs).groupby(groupings)
+
+        @check_matching_signature(input_type)
+        @functools.wraps(func)
+        def wrapped(*args):
+            return UDFNode(*args).to_expr()
+
+        return wrapped
+
+    return wrapper
+
+
+def udaf(input_type, output_type):
+    """Define a UDAF (user-defined aggregation function) that takes N pandas.
+    Series or scalar values as inputs.
+
+    Parameters
+    ----------
+    input_type : List[T]
+        A rules encoding the abstract type of each argument or one of the types
+        found in :mod:`~ibis.expr.datatypes`. These are found in
+        :mod:`~ibis.expr.rules`. The length of this list must match the number
+        of arguments to the function. Argument splatting in the UDF signature
+        is not supported.
+    output_type : rule or ibis.expr.datatypes.DataType
+        The abstract return type of the function. This *cannot* be a rule that
+        encodes a :class:`~ibis.expr.types.ColumnExpr` since this API is for
+        defining *aggregation* functions.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> @udaf(input_type=[dt.string], output_type=dt.int64)
+    ... def my_string_length_agg(series, **kwargs):
+    ...     return (series.str.len() * 2).sum()
+    """
+    def wrapper(func):
+
+        UDAFNode = type(
+            func.__name__,
+            (ops.Reduction,),
+            dict(input_type=input_type, output_type=output_type.scalar_type)
+        )
+
+        with pause_ordering():
+
+            # An execution rule for a simple aggregate node
+            @execute_node.register(
+                UDAFNode, *udf_signature(input_type, klass=pd.Series)
+            )
+            def execute_udaf_node(op, *args, **kwargs):
+                return func(*args, **kwargs)
+
+            # An execution rule for a grouped aggregation node. This includes
+            # aggregates applied over a window.
+            @execute_node.register(
+                UDAFNode, *udf_signature(input_type, klass=SeriesGroupBy)
+            )
+            def execute_udaf_node_groupby(op, *args, **kwargs):
+                # construct a generator that yields the next group of data for
+                # every argument excluding the first (pandas performs the
+                # iteration for the first argument) for each argument that is a
+                # SeriesGroupBy.
+                #
+                # If the argument is not a SeriesGroupBy then keep repeating it
+                # until all groups are exhausted.
+                context = kwargs.pop('context', None)
+                assert context is not None, 'context is None'
+                iters = (
+                    (data for _, data in arg)
+                    if isinstance(arg, SeriesGroupBy)
+                    else itertools.repeat(arg) for arg in args[1:]
+                )
+
+                def aggregator(first, *rest, **kwargs):
+                    # map(next, *rest) gets the inputs for the next group
+                    return func(first, *map(next, rest), **kwargs)
+
+                result = context.agg(args[0], aggregator, *iters, **kwargs)
+                return result
+
+        @check_matching_signature(input_type)
+        @functools.wraps(func)
+        def wrapped(*args):
+            return UDAFNode(*args).to_expr()
+
+        return wrapped
+
+    return wrapper

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -18,7 +18,8 @@ import ibis.expr.operations as ops
 
 from ibis.pandas.core import scalar_types
 from ibis.pandas.dispatch import execute_node, Dispatcher, pause_ordering
-from ibis.compat import functools, signature, Parameter, _empty as empty
+from ibis.compat import (
+    functools, signature, Parameter, _empty as empty, viewkeys)
 
 
 rule_to_python_type = Dispatcher(
@@ -76,7 +77,9 @@ def arguments_from_signature(signature, *args, **kwargs):
     """
     bound = signature.bind_partial(*args)
     meta_kwargs = toolz.merge({'kwargs': kwargs}, kwargs)
-    remaining_parameters = signature.parameters.keys() - bound.arguments.keys()
+    remaining_parameters = viewkeys(signature.parameters) - viewkeys(
+        bound.arguments
+    )
     new_kwargs = {
         k: meta_kwargs[k] for k in remaining_parameters
         if k in signature.parameters

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -15,7 +15,6 @@
 import six
 import numbers
 import operator
-import functools
 import contextlib
 
 import sqlalchemy as sa
@@ -26,7 +25,7 @@ from sqlalchemy.ext.compiler import compiles as sa_compiles
 
 import pandas as pd
 
-from ibis.compat import parse_version
+from ibis.compat import parse_version, functools
 from ibis.client import SQLClient, AsyncQuery, Query, Database
 from ibis.sql.compiler import Select, Union, TableSetFormatter, Dialect
 

--- a/ibis/sql/postgres/api.py
+++ b/ibis/sql/postgres/api.py
@@ -1,7 +1,11 @@
 from ibis.sql.alchemy import to_sqlalchemy
 
 from ibis.sql.postgres.client import PostgreSQLClient
-from ibis.sql.postgres.compiler import compiles, rewrites, dialect  # noqa: F401, E501
+from ibis.sql.postgres.compiler import (  # noqa: F401
+    compiles,
+    rewrites,
+    dialect
+)
 
 
 def compile(expr, params=None):

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -18,14 +18,15 @@ import string
 import platform
 import warnings
 
-from functools import reduce
-
 import sqlalchemy as sa
+
 from sqlalchemy.sql import expression
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.functions import GenericFunction
 
 import ibis
+
+from ibis.compat import functools
 from ibis.sql.alchemy import (unary, fixed_arity, infix_op,
                               _variance_reduction, _get_sqla_table)
 import ibis.common as com
@@ -308,7 +309,7 @@ def _reduce_tokens(tokens, arg):
                     )
 
                 new_tokens, _ = _scanner.scan(new_pattern)
-                value = reduce(
+                value = functools.reduce(
                     sa.sql.ColumnElement.concat,
                     _reduce_tokens(new_tokens, arg)
                 )
@@ -339,7 +340,7 @@ def _strftime(t, expr):
     arg, pattern = map(t.translate, expr.op().args)
     tokens, _ = _scanner.scan(pattern.value)
     reduced = _reduce_tokens(tokens, arg)
-    return reduce(sa.sql.ColumnElement.concat, reduced)
+    return functools.reduce(sa.sql.ColumnElement.concat, reduced)
 
 
 class array_search(expression.FunctionElement):

--- a/ibis/sql/sqlite/client.py
+++ b/ibis/sql/sqlite/client.py
@@ -16,13 +16,13 @@ import os
 import regex as re
 import math
 import inspect
-import functools
 
 import sqlalchemy as sa
 
 from ibis.client import Database
-from ibis.compat import maketrans
+from ibis.compat import maketrans, functools
 from ibis.sql.sqlite.compiler import SQLiteDialect
+
 import ibis.sql.alchemy as alch
 import ibis.common as com
 

--- a/ibis/tests/all/test_array.py
+++ b/ibis/tests/all/test_array.py
@@ -1,14 +1,12 @@
 import pytest
-import functools
 
 import ibis
 import ibis.tests.util as tu
 
-from ibis.compat import wrapped
+from ibis.compat import functools
 
 
 def array_test(f):
-    @wrapped(f)
     @functools.wraps(f)
     def wrapper(backend, *args, **kwargs):
         if not backend.supports_arrays:
@@ -18,7 +16,6 @@ def array_test(f):
 
 
 def direct_array_operation_test(f):
-    @wrapped(f)
     @functools.wraps(array_test(f))
     def wrapper(backend, *args, **kwargs):
         if not backend.supports_arrays_outside_of_select:

--- a/ibis/tests/test_version.py
+++ b/ibis/tests/test_version.py
@@ -1,6 +1,7 @@
 import os
 
-from pkg_resources import parse_version, SetuptoolsVersion
+from pkg_resources import parse_version
+from pkg_resources.extern.packaging.version import Version
 
 import pytest
 
@@ -24,4 +25,4 @@ def test_import_time():
 
 
 def test_version():
-    assert isinstance(parse_version(ibis.__version__), SetuptoolsVersion)
+    assert isinstance(parse_version(ibis.__version__), Version)

--- a/ibis/tests/test_version.py
+++ b/ibis/tests/test_version.py
@@ -1,6 +1,6 @@
 import os
 
-from pkg_resources import parse_version, SetuptoolsLegacyVersion
+from pkg_resources import parse_version, SetuptoolsVersion
 
 import pytest
 
@@ -24,7 +24,4 @@ def test_import_time():
 
 
 def test_version():
-    assert not isinstance(
-        parse_version(ibis.__version__),
-        SetuptoolsLegacyVersion
-    )
+    assert isinstance(parse_version(ibis.__version__), SetuptoolsVersion)

--- a/ibis/tests/util.py
+++ b/ibis/tests/util.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 import pytest
-import functools
 
 import ibis
 import ibis.common as com
 import ibis.util as util
 
-from ibis.compat import wrapped
+from ibis.compat import functools
 
 
 def assert_equal(left, right):
@@ -32,7 +31,6 @@ def assert_equal(left, right):
 
 
 def skipif_unsupported(f):
-    @wrapped(f)
     @functools.wraps(f)
     def wrapper(backend, *args, **kwargs):
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 enum34; python_version < '3'
+funcsigs; python_version < '3'
+functools32; python_version < '3'
 multipledispatch
 numpy>=1.10.0
 pandas>=0.18.1


### PR DESCRIPTION
This PR introduces a way for users to hook their own functions into the ibis
expression tree for the pandas backend.

Here are some things to be aware of:

1. Inputs to the function can be any number of columns (`Series` during
   execution) or scalars (Python + numpy scalar types), Tables (`DataFrame`s)
   are not allowed as inputs. Whether or not we should allow tables as inputs
   is an open discussion.
1. Reductions also take any number of the above types of inputs, so something
   like computing the correlation coefficient is possible in a group by using
   this machinery
1. ~User defined functions must accept `**kwargs`.~ Functions can opt-in to specific keyword arguments or all of them with `**kwargs`. The UDF mechanism decides what to pass in based on the signature of the UDF.
1. Users must specify the input and output types of the function in the
  `@udf`/`@udaf` decorators.

After this is merged, I'd like to rewrite all of the pandas `execute_node`
definitions using the UDF/UDAF machinery which would reduce the amount of code
by about a factor of 2 to 3 for that backend.