### PR TITLE
CI/ENH: Use proper pg10 services spec in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,9 @@ environment:
     - PYTHON_VERSION: "3.6"
 
 services:
-  - postgresql10
+  - postgresql101
 
 test_script:
-  - "net start postgresql-x64-10"  # workaround until https://help.appveyor.com/discussions/problems/11031-postgresql-10-service-not-starting is resolved
   - "\"C:\\Program Files\\PostgreSQL\\10\\bin\\psql\" -c \"SELECT VERSION()\""
   - "%CONDA% --version"
   - "%CONDA% config --set always_yes true"


### PR DESCRIPTION
This was fixed upstream in appveyor.