### PR TITLE
BUG: can't mutate and then drop

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -821,7 +821,7 @@ class Projector(object):
 def _maybe_resolve_exprs(table, exprs):
     try:
         return table._resolve(exprs)
-    except AttributeError:
+    except (AttributeError, IbisTypeError):
         return None
 
 

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -758,9 +758,10 @@ class Projector(object):
 
     def get_result(self):
         roots = self.parent_roots
+        first_root = roots[0]
 
-        if len(roots) == 1 and isinstance(roots[0], ops.Selection):
-            fused_op = self._check_fusion(roots[0])
+        if len(roots) == 1 and isinstance(first_root, ops.Selection):
+            fused_op = self._check_fusion(first_root)
             if fused_op is not None:
                 return fused_op
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2813,22 +2813,17 @@ def _table_view(self):
 
 
 def _table_drop(self, fields):
-    if len(fields) == 0:
-        # noop
+    if not fields:
         return self
 
-    fields = set(fields)
-    to_project = []
-    for name in self.schema():
-        if name in fields:
-            fields.remove(name)
-        else:
-            to_project.append(name)
+    field_set = frozenset(fields)
+    schema = self.schema()
+    schema_names = schema.names
 
-    if len(fields) > 0:
-        raise KeyError('Fields not in table: {0!s}'.format(fields))
+    if field_set - frozenset(schema_names):
+        raise KeyError('Fields not in table: {}'.format(fields))
 
-    return self.projection(to_project)
+    return self[[c for c in schema_names if c not in field_set]]
 
 
 _table_methods = dict(

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2813,17 +2813,22 @@ def _table_view(self):
 
 
 def _table_drop(self, fields):
-    if not fields:
+    if len(fields) == 0:
+        # noop
         return self
 
-    field_set = frozenset(fields)
-    schema = self.schema()
-    schema_names = schema.names
+    fields = set(fields)
+    to_project = []
+    for name in self.schema():
+        if name in fields:
+            fields.remove(name)
+        else:
+            to_project.append(name)
 
-    if field_set - frozenset(schema_names):
-        raise KeyError('Fields not in table: {}'.format(fields))
+    if len(fields) > 0:
+        raise KeyError('Fields not in table: {0!s}'.format(fields))
 
-    return self[[c for c in schema_names if c not in field_set]]
+    return self.projection(to_project)
 
 
 _table_methods = dict(

--- a/ibis/pandas/tests/test_client.py
+++ b/ibis/pandas/tests/test_client.py
@@ -49,5 +49,5 @@ def test_drop(table):
     table = table.mutate(c=table.a)
     expr = table.drop(['a'])
     result = expr.execute()
-    expected = table.execute()[['b']]
+    expected = table[['b', 'c']].execute()
     tm.assert_frame_equal(result, expected)

--- a/ibis/pandas/tests/test_client.py
+++ b/ibis/pandas/tests/test_client.py
@@ -46,6 +46,7 @@ def test_read_with_undiscoverable_type(client):
 
 
 def test_drop(table):
+    table = table.mutate(c=table.a)
     expr = table.drop(['a'])
     result = expr.execute()
     expected = table.execute()[['b']]

--- a/ibis/pandas/tests/test_client.py
+++ b/ibis/pandas/tests/test_client.py
@@ -1,6 +1,7 @@
 import pytest
 
 import pandas as pd
+import pandas.util.testing as tm
 
 import ibis
 
@@ -14,7 +15,7 @@ pytestmark = pytest.mark.pandas
 @pytest.fixture
 def client():
     return ibis.pandas.connect({
-        'df': pd.DataFrame({'a': [1, 2, 3]}),
+        'df': pd.DataFrame({'a': [1, 2, 3], 'b': list('abc')}),
         'df_unknown': pd.DataFrame({
             'array_of_strings': [['a', 'b'], [], ['c']],
         }),
@@ -42,3 +43,10 @@ def test_literal(client):
 def test_read_with_undiscoverable_type(client):
     with pytest.raises(TypeError):
         client.table('df_unknown')
+
+
+def test_drop(table):
+    expr = table.drop(['a'])
+    result = expr.execute()
+    expected = table.execute()[['b']]
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #1296 

The issue is that `_maybe_resolve_exprs` was not ignoring columns that don't exist in a child `Selection` so it would try to resolve them and throw an `IbisTypeError`. This is okay, because the expressions have already been resolved in the `Projector` constructor so trying to project a column that doesn't anywhere would raise this exception long before getting to `_maybe_resolve_exprs`.