### PR TITLE
BUG: Fix subqueries with parameters

### DIFF
--- a/ci/schema/sqlite.sql
+++ b/ci/schema/sqlite.sql
@@ -8,7 +8,7 @@ CREATE TABLE functional_alltypes (
     int_col BIGINT,
     bigint_col BIGINT,
     float_col FLOAT,
-    double_col FLOAT,
+    double_col REAL,
     date_string_col TEXT,
     string_col TEXT,
     timestamp_col TEXT,

--- a/ibis/bigquery/api.py
+++ b/ibis/bigquery/api.py
@@ -2,9 +2,10 @@ import google.cloud.bigquery  # noqa: F401 fail early if bigquery is missing
 import ibis.common as com
 from ibis.config import options  # noqa: F401
 from ibis.bigquery.client import BigQueryClient
+from ibis.bigquery.compiler import dialect
 
 
-def compile(expr):
+def compile(expr, params=None):
     """
     Force compilation of expression as though it were an expression depending
     on BigQuery. Note you can also call expr.compile()
@@ -13,17 +14,17 @@ def compile(expr):
     -------
     compiled : string
     """
-    from .compiler import to_sql
-    return to_sql(expr)
+    from ibis.bigquery.compiler import to_sql
+    return to_sql(expr, dialect.make_context(params=params))
 
 
-def verify(expr):
+def verify(expr, params=None):
     """
     Determine if expression can be successfully translated to execute on
     BigQuery
     """
     try:
-        compile(expr)
+        compile(expr, params=params)
         return True
     except com.TranslationError:
         return False

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -1,0 +1,14 @@
+import ibis
+import ibis.expr.datatypes as dt
+
+
+def test_timestamp_accepts_date_literals(alltypes):
+    date_string = '2009-03-01'
+    param = ibis.param(dt.timestamp, name='param')
+    expr = alltypes.mutate(param=param)
+    params = {param: date_string}
+    result = expr.compile(params=params)
+    expected = """\
+SELECT *, @param AS `param`
+FROM testing.functional_alltypes"""
+    assert result == expected

--- a/ibis/clickhouse/api.py
+++ b/ibis/clickhouse/api.py
@@ -2,9 +2,10 @@ import ibis.common as com
 
 from ibis.config import options
 from ibis.clickhouse.client import ClickhouseClient, external_table
+from ibis.clickhouse.compiler import dialect
 
 
-__all__ = ('compile', 'verify', 'connect', 'external_table')
+__all__ = 'compile', 'verify', 'connect', 'external_table', 'dialect'
 
 
 try:
@@ -14,7 +15,7 @@ except ImportError:
     _default_compression = False
 
 
-def compile(expr):
+def compile(expr, params=None):
     """
     Force compilation of expression as though it were an expression depending
     on Clickhouse. Note you can also call expr.compile()
@@ -23,17 +24,17 @@ def compile(expr):
     -------
     compiled : string
     """
-    from .compiler import to_sql
-    return to_sql(expr)
+    from ibis.clickhouse.compiler import to_sql
+    return to_sql(expr, dialect.make_context(params=params))
 
 
-def verify(expr):
+def verify(expr, params=None):
     """
     Determine if expression can be successfully translated to execute on
     Clickhouse
     """
     try:
-        compile(expr)
+        compile(expr, params=params)
         return True
     except com.TranslationError:
         return False

--- a/ibis/clickhouse/client.py
+++ b/ibis/clickhouse/client.py
@@ -145,8 +145,8 @@ class ClickhouseClient(SQLClient):
     def __init__(self, *args, **kwargs):
         self.con = _DriverClient(*args, **kwargs)
 
-    def _build_ast(self, expr, params=None):
-        return build_ast(expr, params=params)
+    def _build_ast(self, expr, context):
+        return build_ast(expr, context)
 
     @property
     def current_database(self):

--- a/ibis/clickhouse/compiler.py
+++ b/ibis/clickhouse/compiler.py
@@ -1,6 +1,5 @@
 from six import StringIO
 
-import ibis
 import ibis.common as com
 import ibis.util as util
 import ibis.expr.operations as ops
@@ -10,8 +9,8 @@ from .identifiers import quote_identifier
 from .operations import _operation_registry, _name_expr
 
 
-def build_ast(expr, context=None, params=None):
-    builder = ClickhouseQueryBuilder(expr, context=context, params=params)
+def build_ast(expr, context):
+    builder = ClickhouseQueryBuilder(expr, context=context)
     return builder.get_result()
 
 
@@ -40,10 +39,6 @@ class ClickhouseSelectBuilder(comp.SelectBuilder):
 class ClickhouseQueryBuilder(comp.QueryBuilder):
 
     select_builder = ClickhouseSelectBuilder
-
-    @property
-    def _make_context(self):
-        return ClickhouseQueryContext
 
 
 class ClickhouseQueryContext(comp.QueryContext):
@@ -165,17 +160,19 @@ class ClickhouseTableSetFormatter(comp.TableSetFormatter):
 class ClickhouseExprTranslator(comp.ExprTranslator):
 
     _registry = _operation_registry
-    _context_class = ClickhouseQueryContext
+    context_class = ClickhouseQueryContext
 
     def name(self, translated, name, force=True):
         return _name_expr(translated,
                           quote_identifier(name, force=force))
 
 
-class ClickhouseDialect(ibis.client.Dialect):
+class ClickhouseDialect(comp.Dialect):
 
     translator = ClickhouseExprTranslator
 
+
+dialect = ClickhouseDialect
 
 compiles = ClickhouseExprTranslator.compiles
 rewrites = ClickhouseExprTranslator.rewrites

--- a/ibis/clickhouse/tests/conftest.py
+++ b/ibis/clickhouse/tests/conftest.py
@@ -38,5 +38,7 @@ def df(alltypes):
 
 @pytest.fixture
 def translate():
-    from ibis.clickhouse.compiler import ClickhouseExprTranslator
-    return lambda expr: ClickhouseExprTranslator(expr).get_result()
+    from ibis.clickhouse.compiler import ClickhouseDialect
+    dialect = ClickhouseDialect()
+    context = dialect.make_context()
+    return lambda expr: dialect.translator(expr, context).get_result()

--- a/ibis/expr/tests/mocks.py
+++ b/ibis/expr/tests/mocks.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ibis.client import SQLClient, Dialect
+from ibis.client import SQLClient
 from ibis.expr.schema import Schema
 
 
 class MockConnection(SQLClient):
 
-    dialect = Dialect
+    @property
+    def dialect(self):
+        from ibis.impala.compiler import ImpalaDialect
+        return ImpalaDialect
 
     _tables = {
         'alltypes': [
@@ -349,9 +352,9 @@ class MockConnection(SQLClient):
         name = name.replace('`', '')
         return Schema.from_tuples(self._tables[name])
 
-    def _build_ast(self, expr, params=None):
+    def _build_ast(self, expr, context):
         from ibis.impala.compiler import build_ast
-        return build_ast(expr, params=params)
+        return build_ast(expr, context)
 
     def execute(self, expr, limit=None, async=False, params=None):
         if async:

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -233,6 +233,4 @@ NullIf[int64*]
 
 def test_scalar_parameter_formatting():
     value = ibis.param('array<date>')
-    assert re.match(
-        r'param\[\d+\] = ScalarParameter\[array<date>\]', str(value)
-    )
+    assert re.match(r'param_\d+ = ScalarParameter\[array<date>\]', str(value))

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -551,7 +551,7 @@ _parameter_counter = itertools.count()
 
 
 def _parameter_name():
-    return 'param[{:d}]'.format(next(_parameter_counter))
+    return 'param_{:d}'.format(next(_parameter_counter))
 
 
 class ScalarParameter(ValueOp):

--- a/ibis/file/csv.py
+++ b/ibis/file/csv.py
@@ -11,6 +11,9 @@ from ibis.pandas.core import pre_execute, execute  # noqa
 from ibis.pandas.execution.selection import physical_tables
 
 
+dialect = PandasDialect
+
+
 def _read_csv(path, schema, **kwargs):
     dtypes = dict(schema.to_pandas())
 
@@ -44,7 +47,7 @@ class CSVTable(ops.DatabaseTable):
 
 class CSVClient(FileClient):
 
-    dialect = PandasDialect
+    dialect = dialect
     extension = 'csv'
 
     def insert(self, path, expr, index=False, **kwargs):

--- a/ibis/file/parquet.py
+++ b/ibis/file/parquet.py
@@ -12,6 +12,9 @@ from ibis.pandas.api import PandasDialect
 from ibis.pandas.core import pre_execute, execute
 
 
+dialect = PandasDialect
+
+
 # TODO(jreback) complex types are not implemented
 _arrow_dtypes = {
     'int8': dt.Int8,
@@ -58,7 +61,8 @@ class ParquetTable(ops.DatabaseTable):
 
 
 class ParquetClient(FileClient):
-    dialect = PandasDialect
+
+    dialect = dialect
     extension = 'parquet'
 
     def insert(self, path, expr, **kwargs):

--- a/ibis/impala/api.py
+++ b/ibis/impala/api.py
@@ -11,16 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ibis.impala.client import (ImpalaConnection,  # noqa
+from ibis.impala.client import (ImpalaConnection,  # noqa: F401
                                 ImpalaClient,
                                 ImpalaDatabase,
                                 ImpalaTable)
-from ibis.impala.udf import *  # noqa
+from ibis.impala.compiler import dialect  # noqa: F401
+from ibis.impala.udf import *  # noqa: F401,F403
 from ibis.config import options
 import ibis.common as com
 
 
-def compile(expr):
+def compile(expr, params=None):
     """
     Force compilation of expression as though it were an expression depending
     on Impala. Note you can also call expr.compile()
@@ -29,16 +30,16 @@ def compile(expr):
     -------
     compiled : string
     """
-    from .compiler import to_sql
-    return to_sql(expr)
+    from ibis.impala.compiler import to_sql
+    return to_sql(expr, dialect.make_context(params=params))
 
 
-def verify(expr):
+def verify(expr, params=None):
     """
     Determine if expression can be successfully translated to execute on Impala
     """
     try:
-        compile(expr)
+        compile(expr, params=params)
         return True
     except com.TranslationError:
         return False

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -492,8 +492,8 @@ class ImpalaClient(SQLClient):
 
         self._ensure_temp_db_exists()
 
-    def _build_ast(self, expr, params=None):
-        return build_ast(expr, params=params)
+    def _build_ast(self, expr, context):
+        return build_ast(expr, context)
 
     def _get_hdfs(self):
         if self._hdfs is None:
@@ -794,7 +794,7 @@ class ImpalaClient(SQLClient):
         expr : ibis TableExpr
         database : string, default None
         """
-        ast = self._build_ast(expr)
+        ast = self._build_ast(expr, ImpalaDialect.make_context())
         select = ast.queries[0]
         statement = ddl.CreateView(name, select, database=database)
         return self._execute(statement)
@@ -861,7 +861,7 @@ class ImpalaClient(SQLClient):
                 writer, to_insert = write_temp_dataframe(self, obj)
             else:
                 to_insert = obj
-            ast = self._build_ast(to_insert)
+            ast = self._build_ast(to_insert, ImpalaDialect.make_context())
             select = ast.queries[0]
 
             statement = ddl.CTAS(table_name, select,
@@ -1715,7 +1715,7 @@ class ImpalaTable(ir.TableExpr, DatabaseEntity):
         else:
             partition_schema = None
 
-        ast = build_ast(expr)
+        ast = build_ast(expr, ImpalaDialect.make_context())
         select = ast.queries[0]
         statement = ddl.InsertSelect(self._qualified_name,
                                      select,

--- a/ibis/impala/tests/test_sql.py
+++ b/ibis/impala/tests/test_sql.py
@@ -24,7 +24,7 @@ class TestImpalaSQL(unittest.TestCase):
     def test_relabel_projection(self):
         # GH #551
         types = ['int32', 'string', 'double']
-        table = ibis.table(zip(['foo', 'bar', 'baz'], types), 'table')
+        table = ibis.table(zip(['foo', 'bar', 'baz'], types), name='table')
         relabeled = table.relabel({'foo': 'one', 'baz': 'three'})
 
         result = to_sql(relabeled)

--- a/ibis/impala/tests/test_window.py
+++ b/ibis/impala/tests/test_window.py
@@ -15,9 +15,10 @@
 
 import pytest
 
-from ibis import window
 import ibis
 import ibis.common as com
+
+from ibis import window
 from ibis.tests.util import assert_equal
 
 pytest.importorskip('hdfs')
@@ -30,8 +31,9 @@ from ibis.impala.tests.common import ImpalaE2E  # noqa: E402
 
 @pytest.yield_fixture(scope='module')
 def con(request):
+    ImpalaE2E.setUpClass()
+
     try:
-        ImpalaE2E.setUpClass()
         yield ImpalaE2E.con
     finally:
         ImpalaE2E.tearDownClass()

--- a/ibis/pandas/api.py
+++ b/ibis/pandas/api.py
@@ -8,7 +8,7 @@ from ibis.pandas.decimal import execute_node  # noqa: F401
 from ibis.pandas.execution import execute  # noqa: F401
 
 
-__all__ = 'connect', 'execute'
+__all__ = 'connect', 'execute', 'dialect'
 
 
 def connect(dictionary):
@@ -77,9 +77,9 @@ class PandasExprTranslator(object):
     _rewrites = {}
 
 
-class PandasDialect(ibis.client.Dialect):
+class PandasDialect(ibis.sql.compiler.Dialect):
 
     translator = PandasExprTranslator
 
 
-PandasClient.dialect = PandasDialect
+PandasClient.dialect = dialect = PandasDialect

--- a/ibis/sql/mysql/api.py
+++ b/ibis/sql/mysql/api.py
@@ -1,7 +1,7 @@
 from ibis.sql.alchemy import to_sqlalchemy
 
-from .client import MySQLClient, MySQLDialect
-from .compiler import rewrites  # noqa
+from ibis.sql.mysql.client import MySQLClient
+from ibis.sql.mysql.compiler import rewrites, dialect  # noqa: F401
 
 
 def compile(expr, params=None):
@@ -41,7 +41,7 @@ def compile(expr, params=None):
     SELECT t0.double_col + %(param_1)s AS tmp
     FROM functional_alltypes AS t0
     """
-    return to_sqlalchemy(expr, dialect=MySQLDialect, params=params)
+    return to_sqlalchemy(expr, dialect.make_context(params=params))
 
 
 def connect(

--- a/ibis/sql/mysql/compiler.py
+++ b/ibis/sql/mysql/compiler.py
@@ -206,3 +206,6 @@ compiles = MySQLExprTranslator.compiles
 class MySQLDialect(alch.AlchemyDialect):
 
     translator = MySQLExprTranslator
+
+
+dialect = MySQLDialect

--- a/ibis/sql/postgres/api.py
+++ b/ibis/sql/postgres/api.py
@@ -15,8 +15,8 @@
 
 from ibis.sql.alchemy import to_sqlalchemy
 
-from .client import PostgreSQLClient, PostgreSQLDialect
-from .compiler import rewrites  # noqa
+from ibis.sql.postgres.client import PostgreSQLClient
+from ibis.sql.postgres.compiler import rewrites, dialect  # noqa: F401
 
 
 def compile(expr, params=None):
@@ -56,7 +56,7 @@ def compile(expr, params=None):
     SELECT t0.double_col + %(param_1)s AS tmp
     FROM functional_alltypes AS t0
     """
-    return to_sqlalchemy(expr, dialect=PostgreSQLDialect, params=params)
+    return to_sqlalchemy(expr, dialect.make_context(params=params))
 
 
 def connect(

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -692,5 +692,7 @@ compiles = PostgreSQLExprTranslator.compiles
 
 
 class PostgreSQLDialect(alch.AlchemyDialect):
-
     translator = PostgreSQLExprTranslator
+
+
+dialect = PostgreSQLDialect

--- a/ibis/sql/postgres/tests/conftest.py
+++ b/ibis/sql/postgres/tests/conftest.py
@@ -73,5 +73,7 @@ def at(alltypes):
 
 @pytest.fixture
 def translate():
-    from ibis.sql.postgres.compiler import PostgreSQLExprTranslator
-    return lambda expr: PostgreSQLExprTranslator(expr).get_result()
+    from ibis.sql.postgres.compiler import PostgreSQLDialect
+    dialect = PostgreSQLDialect()
+    context = dialect.make_context()
+    return lambda expr: dialect.translator(expr, context).get_result()

--- a/ibis/sql/sqlite/api.py
+++ b/ibis/sql/sqlite/api.py
@@ -13,17 +13,16 @@
 # limitations under the License.
 
 
-from .client import SQLiteClient
-from .compiler import rewrites  # noqa
+from ibis.sql.sqlite.client import SQLiteClient
+from ibis.sql.sqlite.compiler import rewrites, dialect  # noqa: F401
 
 
-def compile(expr):
+def compile(expr, params=None):
     """
     Force compilation of expression for the SQLite target
     """
-    from .client import SQLiteDialect
     from ibis.sql.alchemy import to_sqlalchemy
-    return to_sqlalchemy(expr, dialect=SQLiteDialect)
+    return to_sqlalchemy(expr, dialect.make_context(params=params))
 
 
 def connect(path=None, create=False):

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -301,3 +301,6 @@ compiles = SQLiteExprTranslator.compiles
 class SQLiteDialect(alch.AlchemyDialect):
 
     translator = SQLiteExprTranslator
+
+
+dialect = SQLiteDialect

--- a/ibis/sql/sqlite/tests/conftest.py
+++ b/ibis/sql/sqlite/tests/conftest.py
@@ -38,9 +38,11 @@ def dialect():
 
 @pytest.fixture
 def translate(dialect):
-    from ibis.sql.sqlite.compiler import SQLiteExprTranslator
+    from ibis.sql.sqlite.compiler import SQLiteDialect
+    ibis_dialect = SQLiteDialect()
+    context = ibis_dialect.make_context()
     return lambda expr: str(
-        SQLiteExprTranslator(expr).get_result().compile(
+        ibis_dialect.translator(expr, context).get_result().compile(
             dialect=dialect,
             compile_kwargs=dict(literal_binds=True)
         )

--- a/ibis/sql/tests/test_sqlalchemy.py
+++ b/ibis/sql/tests/test_sqlalchemy.py
@@ -94,7 +94,8 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
             if named:
                 assert result.name == expected.name
 
-    def _translate(self, expr, named=False, context=None):
+    def _translate(self, expr, named=False):
+        context = alch.AlchemyDialect.make_context()
         translator = alch.AlchemyExprTranslator(expr, context=context,
                                                 named=named)
         return translator.get_result()
@@ -584,7 +585,8 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
         self._compare_sqla(expr, ex)
 
     def _compare_sqla(self, expr, sqla):
-        result = alch.to_sqlalchemy(expr)
+        context = alch.AlchemyContext(dialect=alch.AlchemyDialect())
+        result = alch.to_sqlalchemy(expr, context)
         assert str(result.compile()) == str(sqla.compile())
 
     def _to_sqla(self, table):

--- a/ibis/tests/all/test_client.py
+++ b/ibis/tests/all/test_client.py
@@ -14,18 +14,22 @@ def test_version(backend, con):
 
 @pytest.mark.parametrize(('expr_fn', 'expected'), [
     (lambda t: t.string_col, [('string_col', 'string')]),
-    (lambda t: t[t.string_col, t.float_col],
-     [('string_col', 'string'), ('float_col', 'float')])
+    (lambda t: t[t.string_col, t.bigint_col],
+     [('string_col', 'string'), ('bigint_col', 'int64')])
 ])
 def test_query_schema(backend, con, alltypes, expr_fn, expected):
     if not hasattr(con, '_build_ast'):
-        pytest.skip()
-    if backend.name == 'bigquery':
-        pytest.skip()
+        pytest.skip(
+            '{} backend has no _build_ast method'.format(
+                type(backend).__name__
+            )
+        )
 
     expr = expr_fn(alltypes)
+
     # we might need a public API for it
-    query = con.sync_query(con, con._build_ast(expr).queries[0])
+    ast = con._build_ast(expr, backend.make_context())
+    query = con.sync_query(con, ast.queries[0])
 
     # test single columns
     expected = ibis.schema(expected)

--- a/ibis/tests/all/test_param.py
+++ b/ibis/tests/all/test_param.py
@@ -41,3 +41,16 @@ def test_date_scalar_parameter(backend, alltypes, df, start_string,
     expected = expected_expr.execute()
 
     backend.assert_series_equal(result, expected)
+
+
+@tu.skipif_unsupported
+def test_timestamp_accepts_date_literals(backend, alltypes):
+    date_string = '2009-03-01'
+    param = ibis.param(dt.timestamp, name='param')
+    expr = alltypes.mutate(param=param)
+    params = {param: date_string}
+
+    param_in_expr = expr.op().args[1][-1]
+
+    assert param_in_expr in params
+    assert param_in_expr.equals(param)

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -57,6 +57,14 @@ class Backend(object):
     def awards_players(self):
         return self.connection.database().awards_players
 
+    @classmethod
+    def make_context(cls, params=None):
+        module_name = cls.__name__.lower()
+        module = getattr(ibis, module_name, None)
+        if module is None:
+            pytest.skip('Unable to import backend {!r}'.format(module_name))
+        return module.dialect.make_context(params=params)
+
 
 class UnorderedSeriesComparator(object):
 


### PR DESCRIPTION
closes #1300 
closes #1331 

This was a somewhat invasive change, but nets a lot fewer places where the `params` argument has to be used outside of the `compile` and `execute` functions and methods on clients. Now, `params` are part of the `context` and `context` is never `None` so it's easier to reason about where parameters are coming from.