### PR TITLE
Generic utility for expression traversal 

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -1042,7 +1042,7 @@ def find_source_table(expr):
         else:
             return lin.proceed, None
 
-    first_tables = lin.traverse(finder, expr)
+    first_tables = lin.traverse(finder, expr.op().flat_args())
     options = list(toolz.unique(first_tables, key=id))
 
     if len(options) > 1:

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -223,7 +223,7 @@ def find_immediate_parent_tables(expr):
     """
     def finder(expr):
         if isinstance(expr, ir.TableExpr):
-            return lin.stop, expr
+            return lin.halt, expr
         else:
             return lin.proceed, None
 
@@ -1038,7 +1038,7 @@ def find_source_table(expr):
     """
     def finder(expr):
         if isinstance(expr, ir.TableExpr):
-            return lin.stop, expr
+            return lin.halt, expr
         else:
             return lin.proceed, None
 
@@ -1103,6 +1103,6 @@ def flatten_predicate(expr):
         if isinstance(expr.op(), ops.And):
             return lin.proceed, None
         else:
-            return lin.stop, expr
+            return lin.halt, expr
 
     return list(lin.traverse(predicate, expr, type=ir.BooleanColumn))

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -173,7 +173,7 @@ def lineage(expr, container=Stack):
 
 # these could be callables instead
 proceed = True
-stop = False
+halt = False
 
 
 def traverse(fn, expr, type=ir.Expr, container=Stack):
@@ -207,7 +207,7 @@ def traverse(fn, expr, type=ir.Expr, container=Stack):
         if result is not None:
             yield result
 
-        if control is not stop:
+        if control is not halt:
             if control is proceed:
                 args = op.flat_args()
             elif isinstance(control, Iterable):

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -186,7 +186,7 @@ def traverse(fn, expr, type=ir.Expr, container=Stack):
         return a tuple. The first element of the tuple controls the
         traversal, and the second is the result if its not None.
     expr: ir.Expr
-        Expression or list of expressions.
+        The traversable expression or a list of expressions.
     type: Type
         Only the instances if this type are traversed.
     container: Union[Stack, Queue], default Stack

--- a/ibis/pandas/execution/selection.py
+++ b/ibis/pandas/execution/selection.py
@@ -15,7 +15,6 @@ import toolz
 
 from multipledispatch import Dispatcher
 
-import ibis.common as com
 import ibis.expr.types as ir
 import ibis.expr.operations as ops
 
@@ -226,46 +225,6 @@ def _compute_predicates(table_op, predicates, data, scope, **kwargs):
 
         new_scope = toolz.merge(scope, additional_scope)
         yield execute(predicate, new_scope, **kwargs)
-
-
-def get_table_columns(expression):
-    """Yield named column expressions.
-
-    Parameters
-    ----------
-    expression : ir.Expr
-
-    Yields
-    ------
-    node : Node
-        Underlying :class:`~ibis.expr.types.Node` of a
-        :class:`~ibis.expr.types.ColumnExpr`, if the node has a name.
-    """
-    stack = [expression]
-    seen = set()
-
-    while stack:
-        expr = stack.pop()
-        node = expr.op()
-        node_key = str(node)
-
-        if node_key not in seen:
-            seen.add(node_key)
-
-            if isinstance(expr, ir.ColumnExpr):
-                try:
-                    yield expr.get_name(), node
-                except com.ExpressionError:
-                    pass
-
-            if isinstance(node, ops.PhysicalTable):
-                # Special case PhysicalTable to look at the individual columns
-                stack.extend(expr[name] for name in node.schema.names)
-            else:
-                # Otherwise flatten the args of the current node
-                stack.extend(
-                    arg for arg in node.flat_args() if isinstance(arg, ir.Expr)
-                )
 
 
 physical_tables = Dispatcher(


### PR DESCRIPTION
It could be further improved to support more specific cases, e.g. with passing callable as control variable. Probably we should avoid specific scenarios (like `_get_args`) and refactor the underlying structure instead.