### PR TITLE
Fall back to single-backend clickhouse external tables

### DIFF
--- a/ibis/clickhouse/api.py
+++ b/ibis/clickhouse/api.py
@@ -1,11 +1,11 @@
 import ibis.common as com
 
 from ibis.config import options
-from ibis.clickhouse.client import ClickhouseClient, external_table
+from ibis.clickhouse.client import ClickhouseClient
 from ibis.clickhouse.compiler import dialect
 
 
-__all__ = 'compile', 'verify', 'connect', 'external_table', 'dialect'
+__all__ = 'compile', 'verify', 'connect', 'dialect'
 
 
 try:

--- a/ibis/clickhouse/client.py
+++ b/ibis/clickhouse/client.py
@@ -404,28 +404,3 @@ class ClickhouseTable(ir.TableExpr, DatabaseEntity):
 
         data = obj.to_dict('records')
         return self._client.con.process_insert_query(query, data, **kwargs)
-
-
-# class ClickhouseExternalTable(ops.DatabaseTable):
-
-#     def execute(self, *args, **kwargs):
-#         return self.source.execute(*args, **kwargs)
-
-#     def root_tables(self):
-#         return [self]
-
-
-# def external_table(name, table):
-#     """
-#     Flag a Selection or a DatabaseTable as external to Clickhouse
-
-#     Parameters
-#     ----------
-#     table : TableExpr
-
-#     Returns
-#     -------
-#     table : ClickhouseExternalTable
-#     """
-#     op = ClickhouseExternalTable(name, table.schema(), table)
-#     return ClickhouseTable(op)

--- a/ibis/clickhouse/compiler.py
+++ b/ibis/clickhouse/compiler.py
@@ -47,10 +47,10 @@ class ClickhouseQueryContext(comp.QueryContext):
         return to_sql(expr, context=ctx)
 
     def need_aliases(self, expr=None):
-        from ibis.clickhouse.client import ClickhouseExternalTable
+        # from ibis.clickhouse.client import ClickhouseExternalTable
 
-        if isinstance(expr.op(), ClickhouseExternalTable):
-            return False
+        # if isinstance(expr.op(), ClickhouseExternalTable):
+        #     return False
 
         return super(ClickhouseQueryContext, self).need_aliases()
 

--- a/ibis/clickhouse/compiler.py
+++ b/ibis/clickhouse/compiler.py
@@ -46,14 +46,6 @@ class ClickhouseQueryContext(comp.QueryContext):
     def _to_sql(self, expr, ctx):
         return to_sql(expr, context=ctx)
 
-    def need_aliases(self, expr=None):
-        # from ibis.clickhouse.client import ClickhouseExternalTable
-
-        # if isinstance(expr.op(), ClickhouseExternalTable):
-        #     return False
-
-        return super(ClickhouseQueryContext, self).need_aliases()
-
 
 class ClickhouseSelect(comp.Select):
 

--- a/ibis/clickhouse/tests/test_client.py
+++ b/ibis/clickhouse/tests/test_client.py
@@ -12,8 +12,6 @@ from ibis.compat import StringIO
 pytest.importorskip('clickhouse_driver')
 pytestmark = pytest.mark.clickhouse
 
-from ibis.clickhouse.client import ClickhouseExternalTable, external_table  # NOQA
-
 
 def test_get_table_ref(db):
     table = db.functional_alltypes
@@ -172,25 +170,6 @@ def test_execute_exprs_no_table_ref(con):
                                  ibis.now().name('b'),
                                  L(2).log().name('c')])
     con.execute(exlist)
-
-
-def test_define_external_table(con, alltypes):
-    external_df = pd.DataFrame([
-        ('alpha', 1, 'first'),
-        ('beta', 2, 'second'),
-        ('gamma', 3, 'third')
-    ], columns=['a', 'b', 'c'])
-
-    pandas_connection = ibis.pandas.connect({'external': external_df})
-    pandas_table = pandas_connection.table('external')
-
-    table = external_table('external', pandas_table)
-    assert isinstance(table.op(), ClickhouseExternalTable)
-
-    expected_schema = ibis.schema([('a', 'string'),
-                                   ('b', 'int64'),
-                                   ('c', 'string')])
-    assert table.schema() == expected_schema
 
 
 def test_insert(con, alltypes, df):


### PR DESCRIPTION
- forward keyword arguments to backends 
- pass external tables as pure dataframes instead of confusing multi-backend expressions