### PR TITLE
Parenthesize OR conditions in join predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Ibis currently provides tools for interacting with the following systems:
 - [Apache Impala (incubating)](http://impala.io/)
 - [Apache Kudu](http://getkudu.io)
 - [Hadoop Distributed File System (HDFS)](https://hadoop.apache.org/)
-- PostgreSQL (Experimental)
-- SQLite
-- Pandas DataFrames (Experimental)
+- [PostgreSQL](https://www.postgresql.org/) (Experimental)
+- [MySQL](https://www.mysql.com/) (Experimental)
+- [SQLite](http://sqlite.org/)
+- [Pandas DataFrames](https://pandas.pydata.org/) (Experimental)
 - [Clickhouse](https://clickhouse.yandex)
 - [BigQuery](https://cloud.google.com/bigquery)
 

--- a/ibis/impala/tests/test_sql.py
+++ b/ibis/impala/tests/test_sql.py
@@ -196,3 +196,20 @@ def test_logically_negate_complex_boolean_expr():
 SELECT NOT (`a` IN ('foo') AND `c` IS NOT NULL) AS `tmp`
 FROM t"""
     assert result == expected
+
+
+def test_join_with_nested_or_condition():
+    t1 = ibis.table([('a', 'string'),
+                     ('b', 'string')], 't')
+    t2 = t1.view()
+
+    joined = t1.join(t2, [t1.a == t2.a, (t1.a != t2.b) | (t1.b != t2.a)])
+    expr = joined[t1]
+
+    expected = """\
+SELECT t0.*
+FROM t t0
+  INNER JOIN t t1
+    ON t0.`a` = t1.`a` AND
+       ((t0.`a` != t1.`b`) OR (t0.`b` != t1.`a`))"""
+    assert to_sql(expr) == expected

--- a/ibis/impala/tests/test_sql.py
+++ b/ibis/impala/tests/test_sql.py
@@ -213,3 +213,20 @@ FROM t t0
     ON t0.`a` = t1.`a` AND
        ((t0.`a` != t1.`b`) OR (t0.`b` != t1.`a`))"""
     assert to_sql(expr) == expected
+
+
+def test_join_with_nested_xor_condition():
+    t1 = ibis.table([('a', 'string'),
+                     ('b', 'string')], 't')
+    t2 = t1.view()
+
+    joined = t1.join(t2, [t1.a == t2.a, (t1.a != t2.b) ^ (t1.b != t2.a)])
+    expr = joined[t1]
+
+    expected = """\
+SELECT t0.*
+FROM t t0
+  INNER JOIN t t1
+    ON t0.`a` = t1.`a` AND
+       (((t0.`a` != t1.`b`) OR (t0.`b` != t1.`a`)) AND NOT ((t0.`a` != t1.`b`) AND (t0.`b` != t1.`a`)))"""  # noqa: E501
+    assert to_sql(expr) == expected

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -1726,9 +1726,17 @@ class TableSetFormatter(object):
             buf.write('\n')
             buf.write(util.indent('{} {}'.format(jtype, table), self.indent))
 
-            if len(preds):
+            fmt_preds = []
+            for pred in preds:
+                new_pred = self._translate(pred)
+                if isinstance(pred.op(), ops.Or):
+                    # parens for OR exprs because it binds looser than AND
+                    new_pred = '({})'.format(new_pred)
+                fmt_preds.append(new_pred)
+
+            if len(fmt_preds):
                 buf.write('\n')
-                fmt_preds = [self._translate(pred) for pred in preds]
+
                 conj = ' AND\n{}'.format(' ' * 3)
                 fmt_preds = util.indent('ON ' + conj.join(fmt_preds),
                                         self.indent * 2)

--- a/ibis/sql/compiler.py
+++ b/ibis/sql/compiler.py
@@ -1551,7 +1551,7 @@ class Select(DDL):
         fmt_preds = []
         for pred in self.where:
             new_pred = self._translate(pred, permit_subquery=True)
-            if isinstance(pred.op(), ops.Or):
+            if isinstance(pred.op(), (ops.Or, ops.Xor)):
                 # parens for OR exprs because it binds looser than AND
                 new_pred = '({})'.format(new_pred)
             fmt_preds.append(new_pred)
@@ -1729,7 +1729,7 @@ class TableSetFormatter(object):
             fmt_preds = []
             for pred in preds:
                 new_pred = self._translate(pred)
-                if isinstance(pred.op(), ops.Or):
+                if isinstance(pred.op(), (ops.Or, ops.Xor)):
                     # parens for OR exprs because it binds looser than AND
                     new_pred = '({})'.format(new_pred)
                 fmt_preds.append(new_pred)


### PR DESCRIPTION
@cpcloud We need a generic solution to handle list of predicates and their precedence.

I think the best would be to `reduce(operator.and, predicates)` in the expression tree and let the translator decide about the flattening and parenthesization.

closes #1308 