### PR TITLE
TST/ENH: More thorough ALL tests for date and timestamp arithmetics

### DIFF
--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -265,6 +265,12 @@ def _timestamp_op(func, units):
     def _formatter(translator, expr):
         op = expr.op()
         arg, offset = op.args
+        if not isinstance(offset, ir.IntervalValue):
+            raise com.UnsupportedOperationError(
+                'Binary operations between two timestamps or dates '
+                'are not yet supported in bigquery backend'
+            )
+
         if offset.unit not in units:
             raise com.UnsupportedOperationError(
                 'BigQuery does not allow binary operation '

--- a/ibis/clickhouse/operations.py
+++ b/ibis/clickhouse/operations.py
@@ -629,6 +629,8 @@ _operation_registry = {
     ops.TableColumn: _table_column,
     ops.TableArrayView: _table_array_view,
 
+    ops.DateAdd: binary_infix_op('+'),
+    ops.DateSubtract: binary_infix_op('-'),
     ops.TimestampAdd: binary_infix_op('+'),
     ops.TimestampSubtract: binary_infix_op('-'),
     ops.TimestampFromUNIX: _timestamp_from_unix,

--- a/ibis/pandas/client.py
+++ b/ibis/pandas/client.py
@@ -175,10 +175,11 @@ def ibis_schema_apply_to(schema, df):
     """Applies the Ibis schema on a pandas dataframe"""
 
     for column, dtype in schema.items():
+        pandas_dtype = dtype.to_pandas()
         if isinstance(dtype, dt.Interval):
-            df[column] = df[column].values.astype(dtype.to_pandas())
+            df[column] = df[column].values.astype(pandas_dtype)
         else:
-            df[column] = df[column].astype(dtype.to_pandas(), errors='ignore')
+            df[column] = df[column].astype(pandas_dtype, errors='ignore')
 
         if PY2 and dtype == dt.string:
             df[column] = df[column].str.decode('utf-8', errors='ignore')

--- a/ibis/sql/mysql/client.py
+++ b/ibis/sql/mysql/client.py
@@ -27,6 +27,11 @@ def mysql_tinyint(satype, nullable=True):
     return dt.Int8(nullable=nullable)
 
 
+@dt.dtype.register(mysql.BLOB)
+def mysql_blob(satype, nullable=True):
+    return dt.Binary(nullable=nullable)
+
+
 class MySQLTable(alch.AlchemyTable):
     pass
 

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -125,8 +125,8 @@ def test_integer_to_interval_date_failure(backend, con, alltypes, df, unit):
         date_col + interval
 
 
-iwontdrink_day = pd.Timestamp('2017-12-31')
-hangover_time = pd.Timestamp('2018-01-01 18:18:18')
+date_value = pd.Timestamp('2017-12-31')
+timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
 
 
 @pytest.mark.parametrize(('expr_fn', 'expected_fn'), [
@@ -142,12 +142,12 @@ hangover_time = pd.Timestamp('2018-01-01 18:18:18')
     param(lambda t: t.timestamp_col.date() - ibis.interval(days=14),
           lambda t: t.timestamp_col.dt.floor('d') - pd.Timedelta(days=14),
           id='date-subtract-interval'),
-    param(lambda t: t.timestamp_col - ibis.timestamp(hangover_time),
-          lambda t: pd.Series((t.timestamp_col - hangover_time)
+    param(lambda t: t.timestamp_col - ibis.timestamp(timestamp_value),
+          lambda t: pd.Series((t.timestamp_col - timestamp_value)
                               .values.astype('timedelta64[s]')),
           id='timestamp-subtract-timestamp'),
-    param(lambda t: t.timestamp_col.date() - ibis.date(iwontdrink_day),
-          lambda t: t.timestamp_col.dt.floor('d') - iwontdrink_day,
+    param(lambda t: t.timestamp_col.date() - ibis.date(date_value),
+          lambda t: t.timestamp_col.dt.floor('d') - date_value,
           id='date-subtract-date'),
 ])
 @tu.skipif_unsupported

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -125,22 +125,40 @@ def test_integer_to_interval_date_failure(backend, con, alltypes, df, unit):
         date_col + interval
 
 
+iwontdrink_day = pd.Timestamp('2017-12-31')
+hangover_time = pd.Timestamp('2018-01-01 18:18:18')
+
+
 @pytest.mark.parametrize(('expr_fn', 'expected_fn'), [
     param(lambda t: t.timestamp_col + ibis.interval(days=4),
           lambda t: t.timestamp_col + pd.Timedelta(days=4),
-          id='timestamp-add-days'),
-    param(lambda t: t.timestamp_col - ibis.interval(days=4),
-          lambda t: t.timestamp_col - pd.Timedelta(days=4),
-          id='timestamp-sub-days'),
+          id='timestamp-add-interval'),
+    param(lambda t: t.timestamp_col - ibis.interval(days=17),
+          lambda t: t.timestamp_col - pd.Timedelta(days=17),
+          id='timestamp-subtract-interval'),
+    param(lambda t: t.timestamp_col.date() + ibis.interval(days=4),
+          lambda t: t.timestamp_col.dt.floor('d') + pd.Timedelta(days=4),
+          id='date-add-interval'),
+    param(lambda t: t.timestamp_col.date() - ibis.interval(days=14),
+          lambda t: t.timestamp_col.dt.floor('d') - pd.Timedelta(days=14),
+          id='date-subtract-interval'),
+    param(lambda t: t.timestamp_col - ibis.timestamp(hangover_time),
+          lambda t: pd.Series((t.timestamp_col - hangover_time)
+                              .values.astype('timedelta64[s]')),
+          id='timestamp-subtract-timestamp'),
+    param(lambda t: t.timestamp_col.date() - ibis.date(iwontdrink_day),
+          lambda t: t.timestamp_col.dt.floor('d') - iwontdrink_day,
+          id='date-subtract-date'),
 ])
 @tu.skipif_unsupported
-def test_timestamp_binop(backend, con, alltypes, df,
-                         expr_fn, expected_fn):
+def test_temporal_binop(backend, con, alltypes, df,
+                        expr_fn, expected_fn):
     expr = expr_fn(alltypes)
     expected = expected_fn(df)
 
     result = con.execute(expr)
     expected = backend.default_series_rename(expected)
+
     backend.assert_series_equal(result, expected)
 
 


### PR DESCRIPTION
Implementations: clickhouse, impala
Support for mysql blob type.
`Schema.apply_to`uses numpy to apply timedelta dtypes.