### PR TITLE
Simplify fully originate from checking

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -104,7 +104,6 @@ class ScalarAggregate(object):
 
     def get_result(self):
         expr = self.expr
-
         subbed_expr = self._visit(expr)
 
         try:
@@ -871,71 +870,18 @@ class ExprValidator(object):
                 'dependencies of the table expression.' % repr(expr))
 
 
-class CommonSubexpr(object):
+def source_tables(expr):
+    def finder(expr):
+        if isinstance(expr.op(), ops.PhysicalTable):
+            return lin.halt, expr
+        else:
+            return lin.proceed, None
 
-    def __init__(self, exprs):
-        self.parent_exprs = exprs
+    return lin.traverse(finder, expr)
 
-    def validate(self, expr):
-        if isinstance(expr, ir.TableExpr):
-            if not self._check(expr):
-                return False
 
-        op = expr.op()
-
-        for arg in op.flat_args():
-            if not isinstance(arg, ir.Expr):
-                continue
-            elif not isinstance(arg, ir.TableExpr):
-                if not self.validate(arg):
-                    return False
-            else:
-                # Table expression. Must be found in a parent table expr a
-                # blocking root of one of the parent tables
-                if not self._check(arg):
-                    return False
-
-        return True
-
-    def _check(self, expr):
-        # Table dependency matches one of the parent exprs
-        is_valid = False
-        for parent in self.parent_exprs:
-            is_valid = is_valid or self._check_table(parent, expr)
-        return is_valid
-
-    def _check_table(self, parent, needle):
-        def _matches(expr):
-            op = expr.op()
-
-            if expr.equals(needle):
-                return True
-
-            if op.blocks():
-                return False
-
-            for arg in op.flat_args():
-                if not isinstance(arg, ir.Expr):
-                    continue
-                if _matches(arg):
-                    return True
-
-            return True
-
-        return _matches(parent)
-
-    def validate_all(self, exprs):
-        for expr in exprs:
-            self.assert_valid(expr)
-
-    def assert_valid(self, expr):
-        if not self.validate(expr):
-            msg = self._error_message(expr)
-            raise RelationError(msg)
-
-    def _error_message(self, expr):
-        return ('The expression %s does not fully originate from '
-                'dependencies of the table expression.' % repr(expr))
+def fully_originate_from(expr, parents):
+    return set(source_tables(expr)) <= set(source_tables(parents))
 
 
 class FilterValidator(ExprValidator):

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -201,8 +201,9 @@ def traverse(fn, expr, type=ir.Expr, container=Stack):
         op = expr.op()
         if op in seen:
             continue
+        else:
+            seen.add(op)
 
-        seen.add(op)
         control, result = fn(expr)
         if result is not None:
             yield result

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1476,11 +1476,15 @@ def _clean_join_predicates(left, right, predicates):
 
 
 def _validate_join_predicates(left, right, predicates):
+    from ibis.expr.analysis import fully_originate_from
+
     # Validate join predicates. Each predicate must be valid jointly when
     # considering the roots of each input table
-    from ibis.expr.analysis import CommonSubexpr
-    validator = CommonSubexpr([left, right])
-    validator.validate_all(predicates)
+    for predicate in predicates:
+        if not fully_originate_from(predicate, [left, right]):
+            raise com.RelationError('The expression {!r} does not fully '
+                                    'originate from dependencies of the table '
+                                    'expression.'.format(predicate))
 
 
 class Join(TableNode):

--- a/ibis/expr/tests/test_analysis.py
+++ b/ibis/expr/tests/test_analysis.py
@@ -142,7 +142,7 @@ def test_filter_on_projected_field(con):
     assert result.op().table is tpch
 
 
-def test_join_predicate_from_derived():
+def test_join_predicate_from_derived_raises():
     # Join predicate references a derived table, but we can salvage and
     # rewrite it to get the join semantics out
     # see ibis #74

--- a/ibis/expr/tests/test_analysis.py
+++ b/ibis/expr/tests/test_analysis.py
@@ -142,7 +142,7 @@ def test_filter_on_projected_field(con):
     assert result.op().table is tpch
 
 
-def test_bad_join_predicate_raises():
+def test_join_predicate_from_derived():
     # Join predicate references a derived table, but we can salvage and
     # rewrite it to get the join semantics out
     # see ibis #74
@@ -160,11 +160,31 @@ def test_bad_join_predicate_raises():
     filter_pred = table['f'] > 0
     table3 = table[filter_pred]
 
-    with pytest.raises(com.ExpressionError):
-        table.inner_join(table2, [table3['g'] == table2['key']])
-
+    result = table.inner_join(table2, [table3['g'] == table2['key']])
+    repr(result)
     # expected = table.inner_join(table2, [table['g'] == table2['key']])
     # assert_equal(result, expected)
+
+
+def test_bad_join_predicate_raises():
+    table = ibis.table([
+        ('c', 'int32'),
+        ('f', 'double'),
+        ('g', 'string')
+    ], 'foo_table')
+
+    table2 = ibis.table([
+        ('key', 'string'),
+        ('value', 'double')
+    ], 'bar_table')
+
+    table3 = ibis.table([
+        ('key', 'string'),
+        ('value', 'double')
+    ], 'baz_table')
+
+    with pytest.raises(com.ExpressionError):
+        table.inner_join(table2, [table['g'] == table3['key']])
 
 
 def test_filter_self_join():

--- a/ibis/expr/tests/test_analysis.py
+++ b/ibis/expr/tests/test_analysis.py
@@ -160,10 +160,8 @@ def test_join_predicate_from_derived():
     filter_pred = table['f'] > 0
     table3 = table[filter_pred]
 
-    result = table.inner_join(table2, [table3['g'] == table2['key']])
-    repr(result)
-    # expected = table.inner_join(table2, [table['g'] == table2['key']])
-    # assert_equal(result, expected)
+    with pytest.raises(com.ExpressionError):
+        table.inner_join(table2, [table3['g'] == table2['key']])
 
 
 def test_bad_join_predicate_raises():


### PR DESCRIPTION
I want to simplify analysis functions, because currently I can hardly understand their logic.
Due to it's only used by join predicate validation, I've started with `CommonSubexpr`.

~~I had to change one test case which has a confusing history. Read more in the comments.~~