### PR TITLE
SparkClient stub for testing

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,6 +4,7 @@ FROM ibisproject/miniconda3
 RUN apt-get -qq update -y \
  && apt-get -qq install -y --no-install-recommends ttf-dejavu \
     git gcc make clang libboost-dev postgresql-client ca-certificates \
+    openjdk-8-jre-headless ca-certificates-java \
  && rm -rf /var/lib/apt/lists/*
 
 ARG PYTHON

--- a/ci/requirements-dev-2.7.yml
+++ b/ci/requirements-dev-2.7.yml
@@ -20,6 +20,7 @@ dependencies:
   - psycopg2
   - pyarrow>=0.6.0
   - pymysql
+  - pyspark>=2.2.1
   - pytables
   - pytest
   - python=2.7

--- a/ci/requirements-dev-3.5.yml
+++ b/ci/requirements-dev-3.5.yml
@@ -18,6 +18,7 @@ dependencies:
   - psycopg2
   - pyarrow>=0.6.0
   - pymysql
+  - pyspark>=2.2.1
   - pytest
   - python=3.5
   - python-graphviz

--- a/ci/requirements-dev-3.6.yml
+++ b/ci/requirements-dev-3.6.yml
@@ -18,6 +18,7 @@ dependencies:
   - psycopg2
   - pyarrow>=0.6.0
   - pymysql
+  - pyspark>=2.2.1
   - pytables
   - pytest
   - python=3.6

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -71,6 +71,9 @@ with suppress(ImportError):
     # pip install ibis-framework[bigquery]
     import ibis.bigquery.api as bigquery
 
+with suppress(ImportError):
+    import ibis.spark.api as spark
+
 restart_ordering()
 
 

--- a/ibis/spark/api.py
+++ b/ibis/spark/api.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+
+from ibis.spark.client import SparkClient
+
+
+__all__ = ['connect']
+
+
+def connect(dictionary):
+    return SparkClient(dictionary)

--- a/ibis/spark/client.py
+++ b/ibis/spark/client.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import
+
+import pyspark
+from pyspark import SparkConf, SparkContext
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (BooleanType, NullType, ArrayType,
+                               StringType, BinaryType, DateType,
+                               TimestampType, ShortType, IntegerType,
+                               LongType, FloatType, DoubleType,
+                               DecimalType, StructType)
+
+import ibis.client as client
+import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
+
+from ibis.compat import parse_version
+
+
+_ibis_dtypes = {
+    dt.Boolean: BooleanType,
+    dt.Null: NullType,
+    dt.Array: ArrayType,
+    dt.String: StringType,
+    dt.Binary: BinaryType,
+    dt.Date: DateType,
+    dt.Time: TimestampType,
+    dt.Timestamp: TimestampType,
+    dt.Int8: ShortType,
+    dt.Int16: ShortType,
+    dt.Int32: IntegerType,
+    dt.Int64: LongType,
+    dt.UInt8: IntegerType,
+    dt.UInt16: IntegerType,
+    dt.UInt32: LongType,
+    dt.UInt64: LongType,
+    dt.Float32: FloatType,
+    dt.Float64: DoubleType,
+    dt.Decimal: DecimalType,
+    dt.Struct: StructType
+}
+
+
+def ibis_dtype_to_spark(ibis_dtype):
+    """Convert ibis dtype to the pandas / numpy alternative"""
+    return _ibis_dtypes[type(ibis_dtype)]
+
+
+def ibis_schema_to_spark(schema):
+    return list(zip(schema.names, map(ibis_dtype_to_spark,
+                                      schema.types)))
+
+
+class SparkTable(ops.DatabaseTable):
+    pass
+
+
+class SparkClient(client.Client):
+
+    def __init__(self, dictionary, sc=None):
+        if sc is None:
+            conf = (SparkConf()
+                    .setAppName('ibis')
+                    .setMaster('local[*]'))
+            sc = SparkContext.getOrCreate(conf=conf)
+        self.sc = sc
+        self.spark = SparkSession(self.sc)
+
+        # Instantiate the lambda functions in dictionary with the
+        # SparkSession
+        dictionary_inst = {}
+        for k, func in dictionary.items():
+            dictionary_inst[k] = func(self.spark)
+
+        self.dictionary = dictionary_inst
+
+    def table(self, name, schema=None):
+        raise NotImplementedError
+
+    def execute(self, expr):
+        raise NotImplementedError
+
+    def database(self, name=None):
+        return SparkDatabase(name, self)
+
+    @property
+    def version(self):
+        return parse_version(pyspark.__version__)
+
+
+class SparkDatabase(client.Database):
+    pass

--- a/ibis/tests/all/conftest.py
+++ b/ibis/tests/all/conftest.py
@@ -1,8 +1,9 @@
 import os
 import pytest
+import sys
 
 from ibis.compat import Path
-from ibis.tests.backends import (Csv, Parquet, Pandas,
+from ibis.tests.backends import (Csv, Parquet, Pandas, Spark,
                                  SQLite, Postgres, MySQL,
                                  Clickhouse, Impala, BigQuery)
 
@@ -28,12 +29,17 @@ def data_directory():
     pytest.param(Csv, marks=pytest.mark.csv),
     pytest.param(Parquet, marks=pytest.mark.parquet),
     pytest.param(Pandas, marks=pytest.mark.pandas),
+    pytest.param(Spark, marks=[
+        pytest.mark.spark,
+        pytest.mark.skipif((3, 4) <= sys.version_info < (3, 5),
+                           reason='requires python 2.7 or 3.5+'),
+        pytest.mark.xfail(reason='not implemented')]),
     pytest.param(SQLite, marks=pytest.mark.sqlite),
     pytest.param(Postgres, marks=pytest.mark.postgres),
     pytest.param(MySQL, marks=pytest.mark.mysql),
     pytest.param(Clickhouse, marks=pytest.mark.clickhouse),
     pytest.param(BigQuery, marks=pytest.mark.bigquery),
-    pytest.param(Impala, marks=pytest.mark.impala)
+    pytest.param(Impala, marks=pytest.mark.impala),
 ], scope='session')
 def backend(request, data_directory):
     return request.param(data_directory)

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -125,6 +125,34 @@ class Pandas(Backend):
         })
 
 
+class Spark(Backend):
+    check_names = False
+
+    @staticmethod
+    def _read_csv_func(csv_file):
+        """Returns a function thats reads the given ``csv_file`` with
+        :class:`pyspark.sql.SparkSession` as a parameter."""
+        return lambda spark: spark.read.csv(str(csv_file))
+
+    def connect(self, data_directory):
+        return ibis.spark.connect({
+            'functional_alltypes': Spark._read_csv_func(
+                data_directory / 'functional_alltypes.csv'),
+            'batting': Spark._read_csv_func(
+                data_directory / 'batting.csv'),
+            'awards_players': Spark._read_csv_func(
+                data_directory / 'awards_players.csv')
+        })
+
+    def assert_series_equal(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def assert_frame_equal(self, *args, **kwargs):
+        pandas_args = [arg.toPandas() for arg in args]
+        return super(Spark, self).assert_frame_equal(*pandas_args,
+                                                     **kwargs)
+
+
 class SQLite(Backend):
     supports_arrays = False
     supports_arrays_outside_of_select = supports_arrays


### PR DESCRIPTION
This is a really rough SparkClient stub for testing. Supports Python 2.7 and 3.5+, but pyspark packages don't exist for Python 3.4.