### PR TITLE
BUG: BigQuery scalar parameters aren't properly named

### DIFF
--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -366,3 +366,11 @@ def test_scalar_param_scope(alltypes):
     assert mut == """\
 SELECT *, @param AS `param`
 FROM testing.functional_alltypes"""
+
+
+def test_scalar_param_partition_time(parted_alltypes):
+    t = parted_alltypes
+    param = ibis.param('timestamp').name('time_param')
+    expr = t[t.PARTITIONTIME < param]
+    df = expr.execute(params={param: '2017-01-01'})
+    assert df.empty


### PR DESCRIPTION
Closes #1397

This will be less of a hack after making expressions hashable.