### PR TITLE
ENH: BigQuery backend should default `/` to `IEEE_DIVIDE`

### DIFF
--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -395,6 +395,11 @@ compiles = BigQueryExprTranslator.compiles
 rewrites = BigQueryExprTranslator.rewrites
 
 
+@compiles(ops.Divide)
+def bigquery_compiles_divide(t, e):
+    return 'IEEE_DIVIDE({}, {})'.format(*map(t.translate, e.op().args))
+
+
 @rewrites(ops.Any)
 def bigquery_rewrite_any(expr):
     arg, = expr.op().args

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -33,3 +33,12 @@ UNION {}
 SELECT *
 FROM testing.functional_alltypes""".format(expected_keyword)
     assert result == expected
+
+
+def test_ieee_divide(alltypes):
+    expr = alltypes.double_col / 0
+    result = expr.compile()
+    expected = """\
+SELECT IEEE_DIVIDE(`double_col`, 0) AS `tmp`
+FROM testing.functional_alltypes"""
+    assert result == expected

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -17,6 +17,7 @@ class Backend(object):
     supports_arrays_outside_of_select = supports_arrays
     supports_window_operations = True
     additional_skipped_operations = frozenset()
+    supports_divide_by_zero = False
 
     def __init__(self, data_directory):
         try:
@@ -77,6 +78,7 @@ class UnorderedSeriesComparator(object):
 
 class Csv(Backend):
     check_names = False
+    supports_divide_by_zero = True
 
     def connect(self, data_directory):
         filename = data_directory / 'functional_alltypes.csv'
@@ -95,6 +97,7 @@ class Csv(Backend):
 
 class Parquet(Backend):
     check_names = False
+    supports_divide_by_zero = True
 
     def connect(self, data_directory):
         filename = data_directory / 'functional_alltypes.parquet'
@@ -106,6 +109,7 @@ class Parquet(Backend):
 class Pandas(Backend):
     check_names = False
     additional_skipped_operations = frozenset({ops.StringSQLLike})
+    supports_divide_by_zero = True
 
     def connect(self, data_directory):
         return ibis.pandas.connect({
@@ -211,6 +215,7 @@ class Clickhouse(Backend):
 
 
 class BigQuery(UnorderedSeriesComparator, Backend):
+    supports_divide_by_zero = True
 
     def connect(self, data_directory):
         ga = pytest.importorskip('google.auth')
@@ -234,6 +239,7 @@ class Impala(UnorderedSeriesComparator, Backend):
     supports_arrays = True
     supports_arrays_outside_of_select = False
     check_dtype = False
+    supports_divide_by_zero = True
 
     @classmethod
     def connect(cls, data_directory):


### PR DESCRIPTION
Closes #1390