### PR TITLE
ENH: Refactor the pandas backend

### DIFF
--- a/ci/requirements-dev-2.7.yml
+++ b/ci/requirements-dev-2.7.yml
@@ -26,6 +26,7 @@ dependencies:
   - pymysql
   - pytables
   - pytest
+  - pytest-xdist
   - python=2.7
   - python-graphviz
   - python-hdfs>=2.0.16

--- a/ci/requirements-dev-3.5.yml
+++ b/ci/requirements-dev-3.5.yml
@@ -20,6 +20,7 @@ dependencies:
   - pyarrow>=0.6.0
   - pymysql
   - pytest
+  - pytest-xdist
   - python=3.5
   - python-graphviz
   - python-hdfs>=2.0.16

--- a/ci/requirements-dev-3.6.yml
+++ b/ci/requirements-dev-3.6.yml
@@ -21,6 +21,7 @@ dependencies:
   - pymysql
   - pytables
   - pytest
+  - pytest-xdist
   - python=3.6
   - python-graphviz
   - python-hdfs>=2.0.16

--- a/ci/requirements-docs-3.6.yml
+++ b/ci/requirements-docs-3.6.yml
@@ -25,6 +25,7 @@ dependencies:
   - pymysql
   - pytables
   - pytest
+  - pytest-xdist
   - python=3.6
   - python-graphviz
   - python-hdfs>=2.0.16

--- a/ibis/bigquery/udf/tests/test_find.py
+++ b/ibis/bigquery/udf/tests/test_find.py
@@ -1,6 +1,6 @@
 import ast
 from ibis.bigquery.udf.find import find_names
-from ibis.util import is_sequence
+from ibis.util import is_iterable
 
 
 def parse_expr(expr):
@@ -17,7 +17,7 @@ def eq(left, right):
     if type(left) != type(right):
         return False
 
-    if is_sequence(left) and is_sequence(right):
+    if is_iterable(left) and is_iterable(right):
         return all(map(eq, left, right))
 
     if not isinstance(left, ast.AST) and not isinstance(right, ast.AST):

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -28,6 +28,7 @@ if not PY2:
     from inspect import signature, Parameter, _empty
     import unittest.mock as mock
     range = range
+    map = map
     import builtins
     import pickle
     maketrans = str.maketrans
@@ -45,6 +46,7 @@ else:
     lzip = zip
     zip = itertools.izip
     zip_longest = itertools.izip_longest
+    map = itertools.imap
 
     def viewkeys(x):
         return x.viewkeys()

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -921,17 +921,15 @@ def _case(arg):
         string_col = Column[string*] 'string_col' from table
           ref_0
       cases:
-        ValueList[string*]
-          Literal[string]
-            a
-          Literal[string]
-            b
+        Literal[string]
+          a
+        Literal[string]
+          b
       results:
-        ValueList[string*]
-          Literal[string]
-            an a
-          Literal[string]
-            a b
+        Literal[string]
+          an a
+        Literal[string]
+          a b
       default:
         Literal[string]
           null or (not a and not b)

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -218,7 +218,7 @@ class ExprFormatter(object):
 
         if not arg_names:
             for arg in op.args:
-                if isinstance(arg, list):
+                if util.is_iterable(arg):
                     for x in arg:
                         visit(x)
                 else:
@@ -230,7 +230,7 @@ class ExprFormatter(object):
                     name = None
                 if name is not None:
                     name = self._indent('{0}:'.format(name))
-                if isinstance(arg, list):
+                if util.is_iterable(arg):
                     if name is not None and len(arg) > 0:
                         formatted_args.append(name)
                         indents = 1

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -4,16 +4,16 @@ import operator
 import itertools
 import collections
 
-from functools import partial
 from ibis.expr.schema import HasSchema, Schema
 
-import ibis.util as util
 import ibis.common as com
-import ibis.compat as compat
 import ibis.expr.types as ir
 import ibis.expr.rules as rlz
 import ibis.expr.schema as sch
 import ibis.expr.datatypes as dt
+
+from ibis import util, compat
+from ibis.compat import functools, map
 from ibis.expr.signature import Annotable, Argument as Arg
 
 
@@ -55,6 +55,10 @@ class Node(Annotable):
             pprint_args.append(pp)
 
         return '%s(%s)' % (opname, ', '.join(pprint_args))
+
+    @property
+    def inputs(self):
+        return tuple(self.args)
 
     def blocks(self):
         # The contents of this node at referentially distinct and may not be
@@ -134,13 +138,9 @@ class ValueOp(Node):
 
 
 def all_equal(left, right, cache=None):
-    if isinstance(left, list):
-        if not isinstance(right, list):
-            return False
-        for a, b in zip(left, right):
-            if not all_equal(a, b, cache=cache):
-                return False
-        return True
+    if util.is_iterable(left):
+        return util.is_iterable(right) and all(
+            map(functools.partial(all_equal, cache=cache), left, right))
 
     if hasattr(left, 'equals'):
         return left.equals(right, cache=cache)
@@ -727,7 +727,7 @@ class Count(Reduction):
     where = Arg(rlz.boolean, default=None)
 
     def output_type(self):
-        return partial(ir.IntegerScalar, dtype=dt.int64)
+        return functools.partial(ir.IntegerScalar, dtype=dt.int64)
 
 
 class Arbitrary(Reduction):
@@ -827,7 +827,7 @@ class HLLCardinality(Reduction):
     def output_type(self):
         # Impala 2.0 and higher returns a DOUBLE
         # return ir.DoubleScalar
-        return partial(ir.IntegerScalar, dtype=dt.int64)
+        return functools.partial(ir.IntegerScalar, dtype=dt.int64)
 
 
 class GroupConcat(Reduction):
@@ -883,6 +883,10 @@ class WindowOp(ValueOp):
         new_window = self.window.combine(window)
         return WindowOp(self.expr, new_window)
 
+    @property
+    def inputs(self):
+        return self.expr.op().inputs[0], self.window
+
     def root_tables(self):
         result = list(toolz.unique(
             toolz.concatv(
@@ -901,7 +905,7 @@ class WindowOp(ValueOp):
 
 class ShiftBase(AnalyticOp):
     arg = Arg(rlz.column(rlz.any))
-    offset = Arg(rlz.integer, default=None)
+    offset = Arg(rlz.one_of((rlz.integer, rlz.interval)), default=None)
     default = Arg(rlz.any, default=None)
     output_type = rlz.typeof('arg')
 
@@ -2202,7 +2206,7 @@ class TimestampNow(Constant):
 class E(Constant):
 
     def output_type(self):
-        return partial(ir.FloatingScalar, dtype=dt.float64)
+        return functools.partial(ir.FloatingScalar, dtype=dt.float64)
 
 
 class TemporalUnaryOp(UnaryOp):
@@ -2666,8 +2670,7 @@ class ExpressionList(Node):
     exprs = Arg(rlz.noop)
 
     def __init__(self, values):
-        values = list(map(rlz.any, values))
-        super(ExpressionList, self).__init__(values)
+        super(ExpressionList, self).__init__(list(map(rlz.any, values)))
 
     def root_tables(self):
         return distinct_roots(self.exprs)
@@ -2683,12 +2686,11 @@ class ValueList(ValueOp):
     display_argnames = False  # disable showing argnames in repr
 
     def __init__(self, values):
-        values = list(map(rlz.any, values))
-        super(ValueList, self).__init__(values)
+        super(ValueList, self).__init__(tuple(map(rlz.any, values)))
+
+    def output_type(self):
+        dtype = rlz.highest_precedence_dtype(self.values)
+        return functools.partial(ir.ListExpr, dtype=dtype)
 
     def root_tables(self):
         return distinct_roots(*self.values)
-
-    def _make_expr(self):
-        dtype = rlz.highest_precedence_dtype(self.values)
-        return ir.ListExpr(self, dtype=dtype)

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -680,11 +680,11 @@ class ListExpr(ColumnExpr, AnyValue):
         return self.values[key]
 
     def __add__(self, other):
-        other_values = getattr(other, 'values', other)
+        other_values = tuple(getattr(other, 'values', other))
         return type(self.op())(self.values + other_values).to_expr()
 
     def __radd__(self, other):
-        other_values = getattr(other, 'values', other)
+        other_values = tuple(getattr(other, 'values', other))
         return type(self.op())(other_values + self.values).to_expr()
 
     def __bool__(self):

--- a/ibis/file/hdf5.py
+++ b/ibis/file/hdf5.py
@@ -2,7 +2,7 @@ import pandas as pd
 import ibis.expr.schema as sch
 import ibis.expr.operations as ops
 from ibis.file.client import FileClient
-from ibis.pandas.core import pre_execute, execute  # noqa
+from ibis.pandas.core import execute_node, execute
 
 
 def connect(path):
@@ -66,14 +66,9 @@ class HDFClient(FileClient):
         return self._list_databases_dirs_or_files(path)
 
 
-@pre_execute.register(HDFClient.table_class, HDFClient)
-def hdf_pre_execute_table(op, client, scope, **kwargs):
-
-    # cache
-    if isinstance(scope.get(op), pd.DataFrame):
-        return {}
-
+@execute_node.register(HDFClient.table_class, HDFClient)
+def hdf_read_table(op, client, scope, **kwargs):
     key = op.name
     path = client.dictionary[key]
     df = pd.read_hdf(str(path), key, mode='r')
-    return {op: df}
+    return df

--- a/ibis/pandas/execution/join.py
+++ b/ibis/pandas/execution/join.py
@@ -4,7 +4,8 @@ import pandas as pd
 
 import ibis.expr.operations as ops
 
-from ibis.pandas.dispatch import execute, execute_node
+from ibis.pandas.dispatch import execute_node
+from ibis.pandas.core import execute
 from ibis.pandas.execution import constants
 
 

--- a/ibis/pandas/execution/selection.py
+++ b/ibis/pandas/execution/selection.py
@@ -19,7 +19,8 @@ import ibis.expr.operations as ops
 
 from ibis.compat import functools
 
-from ibis.pandas.dispatch import execute, execute_node
+from ibis.pandas.dispatch import execute_node
+from ibis.pandas.core import execute
 from ibis.pandas.execution import constants, util
 
 
@@ -44,8 +45,7 @@ Notes
 -----
 :class:`~ibis.expr.types.ScalarExpr` instances occur when a specific column
 projection is a window operation.
-"""
-)
+""")
 
 
 @compute_projection.register(ir.ScalarExpr, ops.Selection, pd.DataFrame)

--- a/ibis/pandas/execution/tests/conftest.py
+++ b/ibis/pandas/execution/tests/conftest.py
@@ -53,6 +53,11 @@ def df():
 
 
 @pytest.fixture(scope='module')
+def time_df(df):
+    return df.set_index('plain_datetimes_naive')
+
+
+@pytest.fixture(scope='module')
 def batting_df():
     path = os.path.join(
         os.environ.get('IBIS_TEST_DATA_DIRECTORY', ''),
@@ -136,7 +141,8 @@ def time_keyed_df2():
 
 @pytest.fixture(scope='module')
 def client(
-    df, df1, df2, df3, time_df1, time_df2, time_keyed_df1, time_keyed_df2
+    df, df1, df2, df3, time_df1, time_df2, time_keyed_df1, time_keyed_df2,
+    time_df
 ):
     return ibis.pandas.connect(
         dict(
@@ -149,7 +155,8 @@ def client(
             time_df1=time_df1,
             time_df2=time_df2,
             time_keyed_df1=time_keyed_df1,
-            time_keyed_df2=time_keyed_df2
+            time_keyed_df2=time_keyed_df2,
+            time_df=time_df
         )
     )
 
@@ -168,6 +175,19 @@ def df3():
 def t(client):
     return client.table(
         'df',
+        schema={
+            'decimal': dt.Decimal(4, 3),
+            'array_of_float64': dt.Array(dt.double),
+            'array_of_int64': dt.Array(dt.int64),
+            'array_of_strings': dt.Array(dt.string),
+        }
+    )
+
+
+@pytest.fixture(scope='module')
+def time_t(client):
+    return client.table(
+        'time_df',
         schema={
             'decimal': dt.Decimal(4, 3),
             'array_of_float64': dt.Array(dt.double),

--- a/ibis/pandas/execution/tests/test_functions.py
+++ b/ibis/pandas/execution/tests/test_functions.py
@@ -31,17 +31,16 @@ pytestmark = pytest.mark.pandas
 def test_binary_operations(t, df, op):
     expr = op(t.plain_float64, t.plain_int64)
     result = expr.execute()
-    tm.assert_series_equal(result, op(df.plain_float64, df.plain_int64))
+    expected = op(df.plain_float64, df.plain_int64)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize('op', [operator.and_, operator.or_, operator.xor])
 def test_binary_boolean_operations(t, df, op):
     expr = op(t.plain_int64 == 1, t.plain_int64 == 2)
     result = expr.execute()
-    tm.assert_series_equal(
-        result,
-        op(df.plain_int64 == 1, df.plain_int64 == 2)
-    )
+    expected = op(df.plain_int64 == 1, df.plain_int64 == 2)
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize('places', [-2, 0, 1, 2, None])

--- a/ibis/pandas/execution/tests/test_join.py
+++ b/ibis/pandas/execution/tests/test_join.py
@@ -135,7 +135,7 @@ def test_join_with_post_expression_selection(how, left, right, df1, df2):
 
 
 @join_type
-def test_join_with_post_expression_filter(how, left, df1):
+def test_join_with_post_expression_filter(how, left):
     lhs = left[['key', 'key2']]
     rhs = left[['key2', 'value']]
 

--- a/ibis/pandas/execution/tests/test_operations.py
+++ b/ibis/pandas/execution/tests/test_operations.py
@@ -637,17 +637,7 @@ def test_scalar_parameter(t, df, raw_value):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    'elements',
-    [
-        [1],
-        (1,),
-        pytest.mark.xfail({1}, raises=TypeError, reason='Not yet implemented'),
-        pytest.mark.xfail(
-            frozenset({1}), raises=TypeError, reason='Not yet implemented'
-        ),
-    ]
-)
+@pytest.mark.parametrize('elements', [[1], (1,), {1}, frozenset({1})])
 def test_isin(t, df, elements):
     expr = t.plain_float64.isin(elements)
     expected = df.plain_float64.isin(elements)
@@ -655,17 +645,7 @@ def test_isin(t, df, elements):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    'elements',
-    [
-        [1],
-        (1,),
-        pytest.mark.xfail({1}, raises=TypeError, reason='Not yet implemented'),
-        pytest.mark.xfail(
-            frozenset({1}), raises=TypeError, reason='Not yet implemented'
-        ),
-    ]
-)
+@pytest.mark.parametrize('elements', [[1], (1,), {1}, frozenset({1})])
 def test_notin(t, df, elements):
     expr = t.plain_float64.notin(elements)
     expected = ~df.plain_float64.isin(elements)

--- a/ibis/pandas/execution/util.py
+++ b/ibis/pandas/execution/util.py
@@ -3,7 +3,7 @@ import operator
 import ibis
 import ibis.common as com
 
-from ibis.pandas.dispatch import execute
+from ibis.pandas.core import execute
 
 
 def compute_sort_key(key, data, **kwargs):
@@ -33,6 +33,8 @@ def compute_sorted_frame(sort_keys, df, **kwargs):
             new_columns[computed_sort_key] = temporary_column
 
     result = df.assign(**new_columns)
-    result = result.sort_values(computed_sort_keys, ascending=ascending)
+    result = result.sort_values(
+        computed_sort_keys, ascending=ascending, kind='mergesort'
+    )
     result = result.drop(new_columns.keys(), axis=1)
     return result

--- a/ibis/pandas/tests/test_client.py
+++ b/ibis/pandas/tests/test_client.py
@@ -37,7 +37,9 @@ def test_client_table_repr(table):
 
 
 def test_literal(client):
-    assert client.execute(ibis.literal(1)) == 1
+    lit = ibis.literal(1)
+    result = client.execute(lit)
+    assert result == 1
 
 
 def test_read_with_undiscoverable_type(client):

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -92,8 +92,6 @@ def test_nullable():
     assert nullable(t.a.type()) == (type(None),)
 
 
-@pytest.mark.xfail(
-    raises=AssertionError, reason='Nullability is not propagated')
 def test_nullable_non_nullable_field():
     t = ibis.table([('a', dt.String(nullable=False))])
     assert nullable(t.a.type()) == ()

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -7,6 +7,8 @@ import types
 
 import six
 
+import toolz
+
 import ibis.compat as compat
 from ibis.config import options
 
@@ -26,18 +28,12 @@ def indent(text, spaces):
     return ''.join(prefix + line for line in text.splitlines(True))
 
 
-def any_of(values, t):
-    for x in values:
-        if isinstance(x, t):
-            return True
-    return False
+def is_one_of(values, t):
+    return (isinstance(x, t) for x in values)
 
 
-def all_of(values, t):
-    for x in values:
-        if not isinstance(x, t):
-            return False
-    return True
+any_of = toolz.compose(any, is_one_of)
+all_of = toolz.compose(all, is_one_of)
 
 
 def promote_list(val):
@@ -182,8 +178,8 @@ def safe_index(elements, value):
         return -1
 
 
-def is_sequence(o):
-    """Return whether `o` is a non-string sequence.
+def is_iterable(o):
+    """Return whether `o` is a non-string iterable.
 
     Parameters
     ----------
@@ -193,6 +189,20 @@ def is_sequence(o):
     Returns
     -------
     is_seq : bool
+
+    Examples
+    --------
+    >>> x = '1'
+    >>> is_iterable(x)
+    False
+    >>> is_iterable(iter(x))
+    True
+    >>> is_iterable(i for i in range(1))
+    True
+    >>> is_iterable(1)
+    False
+    >>> is_iterable([])
+    True
     """
     return (not isinstance(o, six.string_types) and
             isinstance(o, collections.Iterable))


### PR DESCRIPTION
This is a major refactor of the pandas backend to support new functionality as
well as to clean up and simplify the architecture.

1. `execute_first` is removed: This was originally useful for implementing the
``WindowOp`` rule, but is made obsolete by allowing ``ibis.client.Client``s to
be data arguments in ``execute_node`` rules.
1. `data_preload` is removed: This was originally use to load in data from the
pandas backend specifically, and was very much a special snowflake in the
execute loop. This is also made obsolete by allowing ``ibis.client.Client``s to
be data arguments in ``execute_node`` rules.
1. ``execute_literal`` was introduced to avoid the performance overhead of
dispatching a call to ``execute_node`` for the few cases we have of evaluating
``ops.Literal`` nodes.
1. I've introduced a new ``inputs`` property to the ``Node`` class, which is
the sequence of arguments required to evaluate an expression without any
additional context.  Currently, only ``WindowOp`` requires something different
because it needs access to the column underlying the ``expr`` since you cannot
blindly evaluate ``expr`` and get the correct result, all other ``Node``
subclasses define ``inputs`` as ``return self.args``.
1. Finally, I've added support for expressions in the `preceding` and `following` arguments of `WindowOp`.