### PR TITLE
Implement Strptime in BigQuery

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -440,6 +440,7 @@ All string operations are valid either on scalar or array values
    StringValue.capitalize
    StringValue.contains
    StringValue.like
+   StringValue.to_datetime
    StringValue.parse_url
    StringValue.substr
    StringValue.left

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -440,7 +440,7 @@ All string operations are valid either on scalar or array values
    StringValue.capitalize
    StringValue.contains
    StringValue.like
-   StringValue.to_datetime
+   StringValue.to_timestamp
    StringValue.parse_url
    StringValue.substr
    StringValue.left

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -459,7 +459,7 @@ def compiles_string_to_timestamp(translator, expr):
     arg, format_string, timezone_arg = expr.op().args
     fmt_string = translator.translate(format_string)
     arg_formatted = translator.translate(arg)
-    if isinstance(timezone_arg, ir.StringValue):
+    if timezone_arg is not None:
         timezone_str = translator.translate(timezone_arg)
         return 'PARSE_TIMESTAMP({}, {}, {})'.format(
             fmt_string,

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -454,6 +454,21 @@ def compiles_strftime(translator, expr):
     )
 
 
+@compiles(ops.Strptime)
+def compiles_strptime(translator, expr):
+    arg, format_string, timezone_arg = expr.op().args
+    fmt_string = translator.translate(format_string)
+    arg_formatted = translator.translate(arg)
+    if isinstance(timezone_arg, ir.StringValue):
+        timezone_str = translator.translate(timezone_arg)
+        return 'PARSE_TIMESTAMP({}, {}, {})'.format(
+            fmt_string,
+            arg_formatted,
+            timezone_str
+        )
+    return 'PARSE_TIMESTAMP({}, {})'.format(fmt_string, arg_formatted)
+
+
 @rewrites(ops.Any)
 def bigquery_rewrite_any(expr):
     arg, = expr.op().args

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -454,8 +454,8 @@ def compiles_strftime(translator, expr):
     )
 
 
-@compiles(ops.Strptime)
-def compiles_strptime(translator, expr):
+@compiles(ops.StringToTimestamp)
+def compiles_string_to_timestamp(translator, expr):
     arg, format_string, timezone_arg = expr.op().args
     fmt_string = translator.translate(format_string)
     arg_formatted = translator.translate(arg)

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -531,12 +531,14 @@ def test_large_timestamp(client):
 
 
 def test_string_to_timestamp(client):
-    timestamp = pd.Timestamp(datetime(year=2017, month=2, day=6), tz=pytz.timezone('UTC'))
+    timestamp = pd.Timestamp(datetime(year=2017, month=2, day=6),
+                             tz=pytz.timezone('UTC'))
     expr = ibis.literal('2017-02-06').to_timestamp('%F')
     result = client.execute(expr)
     assert result == timestamp
 
-    timestamp_tz = pd.Timestamp(datetime(year=2017, month=2, day=6, hour=5), tz=pytz.timezone('UTC'))
+    timestamp_tz = pd.Timestamp(datetime(year=2017, month=2, day=6, hour=5),
+                                tz=pytz.timezone('UTC'))
     expr_tz = ibis.literal('2017-02-06').to_timestamp('%F', 'America/New_York')
     result_tz = client.execute(expr_tz)
     assert result_tz == timestamp_tz

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -518,13 +518,12 @@ def test_large_timestamp(client):
 
 
 def test_string_to_timestamp(client):
-    timestamp = pd.Timestamp(date(year=2017, month=2, day=6), tz='UTC')
+    timestamp = pd.Timestamp(datetime(year=2017, month=2, day=6))
     expr = ibis.literal('2017-02-06').to_timestamp('%F')
     result = client.execute(expr)
     assert result == timestamp
 
-    timestamp_tz = pd.Timestamp(datetime(year=2017, month=2, day=6, hour=5),
-                                tz='UTC')
+    timestamp_tz = pd.Timestamp(datetime(year=2017, month=2, day=6, hour=5))
     expr_tz = ibis.literal('2017-02-06').to_timestamp('%F', 'America/New_York')
     result_tz = client.execute(expr_tz)
     assert result_tz == timestamp_tz

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -515,3 +515,16 @@ def test_large_timestamp(client):
     expr = ibis.timestamp('4567-01-01 00:00:00')
     result = client.execute(expr)
     assert result == huge_timestamp
+
+
+def test_string_to_timestamp(client):
+    timestamp = pd.Timestamp(date(year=2017, month=2, day=6), tz='UTC')
+    expr = ibis.literal('2017-02-06').to_timestamp('%F')
+    result = client.execute(expr)
+    assert result == timestamp
+
+    timestamp_tz = pd.Timestamp(datetime(year=2017, month=2, day=6, hour=5),
+                                tz='UTC')
+    expr_tz = ibis.literal('2017-02-06').to_timestamp('%F', 'America/New_York')
+    result_tz = client.execute(expr_tz)
+    assert result_tz == timestamp_tz

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -1,6 +1,7 @@
 import collections
 
 from datetime import date, datetime
+import pytz
 
 import pytest
 
@@ -530,12 +531,12 @@ def test_large_timestamp(client):
 
 
 def test_string_to_timestamp(client):
-    timestamp = pd.Timestamp(datetime(year=2017, month=2, day=6))
+    timestamp = pd.Timestamp(datetime(year=2017, month=2, day=6), tz=pytz.timezone('UTC'))
     expr = ibis.literal('2017-02-06').to_timestamp('%F')
     result = client.execute(expr)
     assert result == timestamp
 
-    timestamp_tz = pd.Timestamp(datetime(year=2017, month=2, day=6, hour=5))
+    timestamp_tz = pd.Timestamp(datetime(year=2017, month=2, day=6, hour=5), tz=pytz.timezone('UTC'))
     expr_tz = ibis.literal('2017-02-06').to_timestamp('%F', 'America/New_York')
     result_tz = client.execute(expr_tz)
     assert result_tz == timestamp_tz

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -55,3 +55,24 @@ FROM `ibis-gbq.testing.functional_alltypes`
 WHERE (((`string_col` IS NULL) AND ('a' IS NULL)) OR (`string_col` = 'a')) AND
       (((`date_string_col` IS NULL) AND ('b' IS NULL)) OR (`date_string_col` = 'b'))"""  # noqa: E501
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    'timezone',
+    [
+        None,
+        'America/New_York'
+    ]
+)
+def test_to_timestamp(alltypes, timezone):
+    expr = alltypes.date_string_col.to_timestamp('%F', timezone)
+    result = expr.compile()
+    if timezone:
+        expected = """\
+SELECT PARSE_TIMESTAMP('%F', `date_string_col`, 'America/New_York') AS `tmp`
+FROM `ibis-gbq.testing.functional_alltypes`"""
+    else:
+        expected = """\
+SELECT PARSE_TIMESTAMP('%F', `date_string_col`) AS `tmp`
+FROM `ibis-gbq.testing.functional_alltypes`"""
+    assert result == expected

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1800,6 +1800,29 @@ def _string_replace(arg, pattern, replacement):
     return ops.StringReplace(arg, pattern, replacement).to_expr()
 
 
+def to_datetime(arg, format_str, timezone_str=None):
+    """
+    Parses a string and returns a timestamp.a
+
+    Parameters
+    ----------
+    format_str : A format string potentially of the type '%Y-%m-%d'
+    timezone_str : An optional string indicating the timezone, i.e. 'America/New_York'
+
+    Examples
+    --------
+    >>> import ibis
+    >>> date_as_str = ibis.literal('20170206')
+    >>> result = date_as_str.to_datetime('%Y%m%d')
+
+
+    Returns
+    -------
+    parsed : datetime
+    """
+    return ops.Strptime(arg, format_str, timezone_str).to_expr()
+
+
 def parse_url(arg, extract, key=None):
     """
     Returns the portion of a URL corresponding to a part specified
@@ -1907,6 +1930,7 @@ _string_value_methods = dict(
     re_search=re_search,
     re_extract=regex_extract,
     re_replace=regex_replace,
+    to_datetime=to_datetime,
     parse_url=parse_url,
 
     substr=_string_substr,

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1807,7 +1807,8 @@ def to_datetime(arg, format_str, timezone_str=None):
     Parameters
     ----------
     format_str : A format string potentially of the type '%Y-%m-%d'
-    timezone_str : An optional string indicating the timezone, i.e. 'America/New_York'
+    timezone_str : An optional string indicating the timezone,
+        i.e. 'America/New_York'
 
     Examples
     --------

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1816,10 +1816,9 @@ def to_timestamp(arg, format_str, timezone=None):
     >>> date_as_str = ibis.literal('20170206')
     >>> result = date_as_str.to_timestamp('%Y%m%d')
 
-
     Returns
     -------
-    parsed : datetime
+    parsed : TimestampValue
     """
     return ops.StringToTimestamp(arg, format_str, timezone).to_expr()
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1800,28 +1800,28 @@ def _string_replace(arg, pattern, replacement):
     return ops.StringReplace(arg, pattern, replacement).to_expr()
 
 
-def to_datetime(arg, format_str, timezone_str=None):
+def to_timestamp(arg, format_str, timezone=None):
     """
-    Parses a string and returns a timestamp.a
+    Parses a string and returns a timestamp.
 
     Parameters
     ----------
     format_str : A format string potentially of the type '%Y-%m-%d'
-    timezone_str : An optional string indicating the timezone,
+    timezone : An optional string indicating the timezone,
         i.e. 'America/New_York'
 
     Examples
     --------
     >>> import ibis
     >>> date_as_str = ibis.literal('20170206')
-    >>> result = date_as_str.to_datetime('%Y%m%d')
+    >>> result = date_as_str.to_timestamp('%Y%m%d')
 
 
     Returns
     -------
     parsed : datetime
     """
-    return ops.Strptime(arg, format_str, timezone_str).to_expr()
+    return ops.StringToTimestamp(arg, format_str, timezone).to_expr()
 
 
 def parse_url(arg, extract, key=None):
@@ -1931,7 +1931,7 @@ _string_value_methods = dict(
     re_search=re_search,
     re_extract=regex_extract,
     re_replace=regex_replace,
-    to_datetime=to_datetime,
+    to_timestamp=to_timestamp,
     parse_url=parse_url,
 
     substr=_string_substr,

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2305,10 +2305,10 @@ class Strftime(ValueOp):
     output_type = rlz.shape_like('arg', dt.string)
 
 
-class Strptime(ValueOp):
+class StringToTimestamp(ValueOp):
     arg = Arg(rlz.string)
     format_str = Arg(rlz.string)
-    timezone_str = Arg(rlz.string, default=None)
+    timezone = Arg(rlz.string, default=None)
     output_type = rlz.shape_like('arg', dt.time)
 
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2309,7 +2309,7 @@ class StringToTimestamp(ValueOp):
     arg = Arg(rlz.string)
     format_str = Arg(rlz.string)
     timezone = Arg(rlz.string, default=None)
-    output_type = rlz.shape_like('arg', dt.time)
+    output_type = rlz.shape_like('arg', dt.timestamp)
 
 
 class ExtractTemporalField(TemporalUnaryOp):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2309,7 +2309,7 @@ class StringToTimestamp(ValueOp):
     arg = Arg(rlz.string)
     format_str = Arg(rlz.string)
     timezone = Arg(rlz.string, default=None)
-    output_type = rlz.shape_like('arg', dt.timestamp)
+    output_type = rlz.shape_like('arg', dt.Timestamp(timezone='UTC'))
 
 
 class ExtractTemporalField(TemporalUnaryOp):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2305,6 +2305,13 @@ class Strftime(ValueOp):
     output_type = rlz.shape_like('arg', dt.string)
 
 
+class Strptime(ValueOp):
+    arg = Arg(rlz.string)
+    format_str = Arg(rlz.string)
+    timezone_str = Arg(rlz.string, default=None)
+    output_type = rlz.shape_like('arg', dt.time)
+
+
 class ExtractTemporalField(TemporalUnaryOp):
     output_type = rlz.shape_like('arg', dt.int32)
 


### PR DESCRIPTION
Closes #1455 

As implemented, the string method `to_datetime` requires a format string argument and accepts an optional argument for timezones. All comments appreciated!