### PR TITLE
BUG/CI/TST: Fix compatibility with pandas 0.23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 base: &base
   machine:
     image: circleci/classic:latest
-    docker_layer_caching: true
+    docker_layer_caching: false
   working_directory: ~/ibis/ci
 
 

--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -237,7 +237,9 @@ def clickhouse(schema, tables, data_directory, **params):
             cols = df.select_dtypes([object]).columns
             df[cols] = df[cols].fillna('')
 
-        df.to_sql(table, engine, index=False, if_exists='append')
+        t = sa.Table(table, sa.MetaData(bind=engine), autoload=True)
+        rows = list(map(lambda row: row._asdict(), df.itertuples(index=False)))
+        t.insert().values(rows).execute()
 
 
 if __name__ == '__main__':

--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -238,8 +238,13 @@ def clickhouse(schema, tables, data_directory, **params):
             df[cols] = df[cols].fillna('')
 
         t = sa.Table(table, sa.MetaData(bind=engine), autoload=True)
-        rows = list(map(lambda row: row._asdict(), df.itertuples(index=False)))
-        t.insert().values(rows).execute()
+        insert = t.insert()
+        keys = df.columns
+        rows = [
+            dict(zip(keys, row))
+            for row in df.itertuples(index=False, name=None)
+        ]
+        engine.execute(insert, rows)
 
 
 if __name__ == '__main__':

--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -68,15 +68,12 @@ def read_tables(names, data_directory):
         yield (name, df)
 
 
-def insert_tables(engine, names, data_directory):
+def insert_tables(engine, names, data_directory, chunksize=None):
     for table, df in read_tables(names, data_directory):
         with engine.begin() as connection:
             df.to_sql(
                 table, connection, index=False, if_exists='append',
-                chunksize=1 if os.name == 'nt' else None
-                # Pandas 0.23 uses multi value inserts which is very slow for a
-                # chunksize of 1. For some reason this only shows up on
-                # Appveyor Windows CI
+                chunksize=chunksize
             )
 
 
@@ -191,7 +188,7 @@ def sqlite(database, schema, tables, data_directory, **params):
 
     params['database'] = str(database)
     engine = init_database('sqlite', params, schema, recreate=False)
-    insert_tables(engine, tables, data_directory)
+    insert_tables(engine, tables, data_directory, chunksize=1)
 
 
 @cli.command()

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -290,7 +290,7 @@ def test_scalar_param_timestamp(alltypes, df, timestamp_value):
     result = expr.execute(
         params={param: timestamp_value}
     ).sort_values('timestamp_col').reset_index(drop=True)
-    value = pd.Timestamp(timestamp_value, tz='UTC')
+    value = pd.Timestamp(timestamp_value)
     expected = df.loc[
         df.timestamp_col <= value, ['timestamp_col']
     ].sort_values('timestamp_col').reset_index(drop=True)

--- a/ibis/clickhouse/tests/test_types.py
+++ b/ibis/clickhouse/tests/test_types.py
@@ -1,5 +1,4 @@
 import pytest
-import pandas as pd
 
 
 pytest.importorskip('clickhouse_driver')

--- a/ibis/clickhouse/tests/test_types.py
+++ b/ibis/clickhouse/tests/test_types.py
@@ -14,4 +14,4 @@ def test_column_types(alltypes):
     assert df.bigint_col.dtype.name == 'int64'
     assert df.float_col.dtype.name == 'float32'
     assert df.double_col.dtype.name == 'float64'
-    assert pd.core.common.is_datetime64_dtype(df.timestamp_col.dtype)
+    assert df.timestamp_col.dtype.name == 'datetime64[ns]'

--- a/ibis/impala/tests/test_connection_pool.py
+++ b/ibis/impala/tests/test_connection_pool.py
@@ -29,7 +29,7 @@ def test_connection_pool_size(env, hdfs_client):
         host=env.impala_host,
         database=env.test_data_db,
     )
-    assert client.con.connection_pool_size == 1
+    assert len(client.con.connection_pool) == 1
 
 
 @pytest.mark.impala
@@ -41,4 +41,4 @@ def test_connection_pool_size_after_close(env, hdfs_client):
         database=env.test_data_db,
     )
     client.close()
-    assert client.con.connection_pool_size == 0
+    assert len(client.con.connection_pool) == 0

--- a/ibis/impala/tests/test_exprs.py
+++ b/ibis/impala/tests/test_exprs.py
@@ -1214,7 +1214,7 @@ class TestImpalaExprs(ImpalaE2E, unittest.TestCase, ExprTestCases):
         assert df.bigint_col.dtype.name == 'int64'
         assert df.float_col.dtype.name == 'float32'
         assert df.double_col.dtype.name == 'float64'
-        assert pd.core.common.is_datetime64_dtype(df.timestamp_col.dtype)
+        assert df.timestamp_col.dtype.name == 'datetime64[ns]'
 
     def test_timestamp_builtins(self):
         i32 = L(50000)

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -168,21 +168,21 @@ def udf_signature(input_type, klass):
     >>> input_type = [dt.int64, dt.double]
     >>> sig = udf_signature(input_type, pd.Series)
     >>> pprint(sig)  # doctest: +ELLIPSIS
-    ((<class 'pandas.core.series.Series'>,
+    ((<class '...Series'>,
       <... 'int'>,
       <... 'numpy.integer'>,
       <... 'NoneType'>),
-     (<class 'pandas.core.series.Series'>,
+     (<class '...Series'>,
       <... 'float'>,
       <... 'numpy.floating'>,
       <... 'NoneType'>))
     >>> input_type = [dt.Int64(nullable=False), dt.Double(nullable=False)]
     >>> sig = udf_signature(input_type, SeriesGroupBy)
-    >>> pprint(sig)
-    ((<class 'pandas.core.groupby.SeriesGroupBy'>,
+    >>> pprint(sig)  # doctest: +ELLIPSIS
+    ((<class '...SeriesGroupBy'>,
       <... 'int'>,
       <... 'numpy.integer'>),
-     (<class 'pandas.core.groupby.SeriesGroupBy'>,
+     (<class '...SeriesGroupBy'>,
       <... 'float'>,
       <... 'numpy.floating'>))
     """


### PR DESCRIPTION
Pandas 0.23 changed the default behavior of the `chunksize` argument
which breaks SQLite when loading a large dataset because SQLite has an
upper bound on the number of rows in a single insert statement.

This PR works around that our `ci/datamgr.py` script so that we can get
master back to green.