### PR TITLE
Implement Range Windows

### DIFF
--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -546,14 +546,6 @@ def test_client_sql_query(client):
     tm.assert_frame_equal(result, expected)
 
 
-def test_trailing_time_window_order_by(alltypes):
-    # trailing_time_window must take time column in order_by
-    w = ibis.trailing_time_window(preceding=10, order_by='float_col')
-    expr = alltypes.int_col.mean().over(w)
-    with pytest.raises(com.IbisInputError):
-        expr.execute()
-
-
 def test_timestamp_column_parted_is_not_renamed(client):
     t = client.table('timestamp_column_parted')
     assert '_PARTITIONTIME' not in t.columns

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -568,3 +568,10 @@ FROM (
 ) t0
 WHERE `string_col` != 'wat'"""
     assert result == expected
+
+
+def test_trailing_time_window(alltypes):
+    with pytest.raises(com.IbisInputError):
+        w = ibis.trailing_time_window(preceding=10, order_by='float_col')
+        expr = alltypes.int_col.mean().over(w)
+        expr.execute()

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -546,6 +546,14 @@ def test_client_sql_query(client):
     tm.assert_frame_equal(result, expected)
 
 
+def test_trailing_time_window_order_by(alltypes):
+    # trailing_time_window must take time column in order_by
+    with pytest.raises(com.IbisInputError):
+        w = ibis.trailing_time_window(preceding=10, order_by='float_col')
+        expr = alltypes.int_col.mean().over(w)
+        expr.execute()
+
+
 def test_timestamp_column_parted_is_not_renamed(client):
     t = client.table('timestamp_column_parted')
     assert '_PARTITIONTIME' not in t.columns
@@ -568,11 +576,3 @@ FROM (
 ) t0
 WHERE `string_col` != 'wat'"""
     assert result == expected
-
-
-def test_trailing_time_window(alltypes):
-    # trailing_time_window must take time column in order_by
-    with pytest.raises(com.IbisInputError):
-        w = ibis.trailing_time_window(preceding=10, order_by='float_col')
-        expr = alltypes.int_col.mean().over(w)
-        expr.execute()

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -571,6 +571,7 @@ WHERE `string_col` != 'wat'"""
 
 
 def test_trailing_time_window(alltypes):
+    # trailing_time_window must take time column in order_by
     with pytest.raises(com.IbisInputError):
         w = ibis.trailing_time_window(preceding=10, order_by='float_col')
         expr = alltypes.int_col.mean().over(w)

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -548,9 +548,9 @@ def test_client_sql_query(client):
 
 def test_trailing_time_window_order_by(alltypes):
     # trailing_time_window must take time column in order_by
+    w = ibis.trailing_time_window(preceding=10, order_by='float_col')
+    expr = alltypes.int_col.mean().over(w)
     with pytest.raises(com.IbisInputError):
-        w = ibis.trailing_time_window(preceding=10, order_by='float_col')
-        expr = alltypes.int_col.mean().over(w)
         expr.execute()
 
 

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -211,13 +211,14 @@ FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     ('preceding', 'value'),
     [
         (5, 5),
+        (ibis.nanosecond(), 0.001),
         (ibis.microsecond(), 1),
-        (ibis.second(), 1000000.0),
-        (ibis.minute(), 1000000.0 * 60),
-        (ibis.hour(), 1000000.0 * 60 * 60),
-        (ibis.day(), 1000000.0 * 60 * 60 * 24),
-        (2 * ibis.day(), 1000000.0 * 60 * 60 * 24 * 2),
-        (ibis.week(), 1000000.0 * 60 * 60 * 24 * 7),
+        (ibis.second(), 1000000),
+        (ibis.minute(), 1000000 * 60),
+        (ibis.hour(), 1000000 * 60 * 60),
+        (ibis.day(), 1000000 * 60 * 60 * 24),
+        (2 * ibis.day(), 1000000 * 60 * 60 * 24 * 2),
+        (ibis.week(), 1000000 * 60 * 60 * 24 * 7),
     ]
 )
 def test_trailing_range_window(alltypes, preceding, value):

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -149,3 +149,33 @@ def test_literal_timestamp_or_time(case, expected, dtype):
     expr = ibis.literal(case, type=dtype).hour()
     result = ibis.bigquery.compile(expr)
     assert result == "SELECT EXTRACT(hour from {}) AS `tmp`".format(expected)
+
+
+def test_window_function(alltypes):
+    t = alltypes
+    w1 = ibis.window(preceding=1, following=0,
+                     group_by='year', order_by='timestamp_col')
+    expr = t.mutate(win_avg=t.float_col.mean().over(w1))
+    result = expr.compile()
+    expected = """\
+SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS `win_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected
+
+    w2 = ibis.window(preceding=0, following=2,
+                     group_by='year', order_by='timestamp_col')
+    expr = t.mutate(win_avg=t.float_col.mean().over(w2))
+    result = expr.compile()
+    expected = """\
+SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING) AS `win_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected
+
+
+def test_range_window_function(alltypes):
+    t = alltypes
+    w = ibis.range_window(preceding=1, following=0,
+                          group_by='year', order_by='month')
+    expr = t.mutate(two_month_avg=t.float_col.mean().over(w))
+    result = expr.compile()
+    expected = """\
+SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `month` RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) AS `two_month_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -220,10 +220,10 @@ FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
         (ibis.week(), 1000000.0 * 60 * 60 * 24 * 7),
     ]
 )
-def test_trailing_time_window(alltypes, preceding, value):
+def test_trailing_range_window(alltypes, preceding, value):
     t = alltypes
-    w = ibis.trailing_time_window(preceding=preceding,
-                                  order_by=t.timestamp_col)
+    w = ibis.trailing_range_window(preceding=preceding,
+                                   order_by=t.timestamp_col)
     expr = t.mutate(win_avg=t.float_col.mean().over(w))
     result = expr.compile()
     expected = """\
@@ -239,10 +239,10 @@ FROM `ibis-gbq.testing.functional_alltypes`""".format(value)  # noqa: E501
         (ibis.year(), None),
     ]
 )
-def test_trailing_time_window_unsupported(alltypes, preceding, value):
+def test_trailing_range_window_unsupported(alltypes, preceding, value):
     t = alltypes
-    w = ibis.trailing_time_window(preceding=preceding,
-                                  order_by=t.timestamp_col)
+    w = ibis.trailing_range_window(preceding=preceding,
+                                   order_by=t.timestamp_col)
     expr = t.mutate(win_avg=t.float_col.mean().over(w))
     with pytest.raises(ValueError):
         expr.compile()

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -169,6 +169,14 @@ SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp
 SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING) AS `win_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected
 
+    w3 = ibis.window(preceding=(4, 2),
+                     group_by='year', order_by='timestamp_col')
+    expr = t.mutate(win_avg=t.float_col.mean().over(w3))
+    result = expr.compile()
+    expected = """\
+SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected
+
 
 def test_range_window_function(alltypes):
     t = alltypes
@@ -178,4 +186,12 @@ def test_range_window_function(alltypes):
     result = expr.compile()
     expected = """\
 SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `month` RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) AS `two_month_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected
+
+    w3 = ibis.range_window(preceding=(4, 2),
+                           group_by='year', order_by='timestamp_col')
+    expr = t.mutate(win_avg=t.float_col.mean().over(w3))
+    result = expr.compile()
+    expected = """\
+SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` RANGE BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -202,7 +202,7 @@ FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     result = expr.compile()
     expected = """\
 SELECT *,
-       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` RANGE BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`
+       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY UNIX_MICROS(`timestamp_col`) RANGE BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`
 FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected
 

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -207,13 +207,42 @@ FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected
 
 
-def test_trailing_time_window(alltypes):
+@pytest.mark.parametrize(
+    ('preceding', 'value'),
+    [
+        (5, 5),
+        (ibis.microsecond(), 1),
+        (ibis.second(), 1000000.0),
+        (ibis.minute(), 1000000.0 * 60),
+        (ibis.hour(), 1000000.0 * 60 * 60),
+        (ibis.day(), 1000000.0 * 60 * 60 * 24),
+        (2 * ibis.day(), 1000000.0 * 60 * 60 * 24 * 2),
+        (ibis.week(), 1000000.0 * 60 * 60 * 24 * 7),
+    ]
+)
+def test_trailing_time_window(alltypes, preceding, value):
     t = alltypes
-    w = ibis.trailing_time_window(5, order_by=t.timestamp_col)
+    w = ibis.trailing_time_window(preceding=preceding,
+                                  order_by=t.timestamp_col)
     expr = t.mutate(win_avg=t.float_col.mean().over(w))
     result = expr.compile()
     expected = """\
 SELECT *,
-       avg(`float_col`) OVER (ORDER BY UNIX_MICROS(`timestamp_col`) RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) AS `win_avg`
-FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+       avg(`float_col`) OVER (ORDER BY UNIX_MICROS(`timestamp_col`) RANGE BETWEEN {} PRECEDING AND CURRENT ROW) AS `win_avg`
+FROM `ibis-gbq.testing.functional_alltypes`""".format(value)  # noqa: E501
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    ('preceding', 'value'),
+    [
+        (ibis.year(), None),
+    ]
+)
+def test_trailing_time_window_unsupported(alltypes, preceding, value):
+    t = alltypes
+    w = ibis.trailing_time_window(preceding=preceding,
+                                  order_by=t.timestamp_col)
+    expr = t.mutate(win_avg=t.float_col.mean().over(w))
+    with pytest.raises(KeyError):
+        expr.compile()

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -205,3 +205,15 @@ SELECT *,
        avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` RANGE BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`
 FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected
+
+
+def test_trailing_time_window(alltypes):
+    t = alltypes
+    w = ibis.trailing_time_window(5, order_by=t.timestamp_col)
+    expr = t.mutate(win_avg=t.float_col.mean().over(w))
+    result = expr.compile()
+    expected = """\
+SELECT *,
+       avg(`float_col`) OVER (ORDER BY UNIX_MICROS(`timestamp_col`) RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) AS `win_avg`
+FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -158,7 +158,9 @@ def test_window_function(alltypes):
     expr = t.mutate(win_avg=t.float_col.mean().over(w1))
     result = expr.compile()
     expected = """\
-SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS `win_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+SELECT *,
+       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS `win_avg`
+FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected
 
     w2 = ibis.window(preceding=0, following=2,
@@ -166,7 +168,9 @@ SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp
     expr = t.mutate(win_avg=t.float_col.mean().over(w2))
     result = expr.compile()
     expected = """\
-SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING) AS `win_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+SELECT *,
+       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING) AS `win_avg`
+FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected
 
     w3 = ibis.window(preceding=(4, 2),
@@ -174,7 +178,9 @@ SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp
     expr = t.mutate(win_avg=t.float_col.mean().over(w3))
     result = expr.compile()
     expected = """\
-SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+SELECT *,
+       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`
+FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected
 
 
@@ -185,7 +191,9 @@ def test_range_window_function(alltypes):
     expr = t.mutate(two_month_avg=t.float_col.mean().over(w))
     result = expr.compile()
     expected = """\
-SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `month` RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) AS `two_month_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+SELECT *,
+       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `month` RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) AS `two_month_avg`
+FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected
 
     w3 = ibis.range_window(preceding=(4, 2),
@@ -193,5 +201,7 @@ SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `month` RA
     expr = t.mutate(win_avg=t.float_col.mean().over(w3))
     result = expr.compile()
     expected = """\
-SELECT *,\n       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` RANGE BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`\nFROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+SELECT *,
+       avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` RANGE BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`
+FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -244,5 +244,5 @@ def test_trailing_time_window_unsupported(alltypes, preceding, value):
     w = ibis.trailing_time_window(preceding=preceding,
                                   order_by=t.timestamp_col)
     expr = t.mutate(win_avg=t.float_col.mean().over(w))
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         expr.compile()

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -30,7 +30,9 @@ from ibis.expr.schema import Schema
 
 from ibis.expr.analytics import bucket, histogram
 from ibis.expr.groupby import GroupedTableExpr  # noqa
-from ibis.expr.window import window, trailing_window, cumulative_window
+from ibis.expr.window import (
+    window, range_window, trailing_window, cumulative_window
+)
 
 from ibis.expr.types import (  # noqa
     ValueExpr, ScalarExpr, ColumnExpr, TableExpr,
@@ -84,6 +86,7 @@ __all__ = (
     'null',
     'param',
     'prevent_rewrite',
+    'range_window',
     'row_number',
     'schema',
     'Schema',

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -32,7 +32,7 @@ from ibis.expr.analytics import bucket, histogram
 from ibis.expr.groupby import GroupedTableExpr  # noqa
 from ibis.expr.window import (
     window, range_window, trailing_window, cumulative_window,
-    trailing_time_window
+    trailing_range_window
 )
 
 from ibis.expr.types import (  # noqa
@@ -96,7 +96,7 @@ __all__ = (
     'table',
     'time',
     'timestamp',
-    'trailing_time_window',
+    'trailing_range_window',
     'trailing_window',
     'week',
     'where',

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2297,7 +2297,6 @@ def _interval_property(target_unit):
 
 
 _interval_add = _binop_expr('__add__', ops.IntervalAdd)
-_interval_sub = _binop_expr('__sub__', ops.IntervalSubtract)
 _interval_radd = _binop_expr('__radd__', ops.IntervalAdd)
 _interval_sub = _binop_expr('__sub__', ops.IntervalSubtract)
 _interval_mul = _binop_expr('__mul__', ops.IntervalMultiply)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -31,7 +31,8 @@ from ibis.expr.schema import Schema
 from ibis.expr.analytics import bucket, histogram
 from ibis.expr.groupby import GroupedTableExpr  # noqa
 from ibis.expr.window import (
-    window, range_window, trailing_window, cumulative_window
+    window, range_window, trailing_window, cumulative_window,
+    trailing_time_window
 )
 
 from ibis.expr.types import (  # noqa
@@ -95,6 +96,7 @@ __all__ = (
     'table',
     'time',
     'timestamp',
+    'trailing_time_window',
     'trailing_window',
     'week',
     'where',

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2297,6 +2297,7 @@ def _interval_property(target_unit):
 
 
 _interval_add = _binop_expr('__add__', ops.IntervalAdd)
+_interval_sub = _binop_expr('__sub__', ops.IntervalSubtract)
 _interval_radd = _binop_expr('__radd__', ops.IntervalAdd)
 _interval_sub = _binop_expr('__sub__', ops.IntervalSubtract)
 _interval_mul = _binop_expr('__mul__', ops.IntervalMultiply)

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -55,6 +55,7 @@ def test_combine_windows(alltypes):
                            preceding=5, following=5)
     assert_equal(w5, expected)
 
+    # Cannot combine windows of varying types.
     w6 = ibis.range_window(preceding=5, following=5)
     with pytest.raises(ibis.common.IbisInputError):
         w1.combine(w6)

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -132,14 +132,6 @@ def test_window_bind_to_table(alltypes):
     assert_equal(w2, expected)
 
 
-# def test_trailing_time_window(alltypes):
-#     t = alltypes
-#     ibis.trailing_time_window(preceding=5, order_by=t.i)
-#     with pytest.raises(ibis.common.IbisInputError):
-#         ibis.trailing_time_window(preceding=5,
-#                                   order_by=t.e)
-
-
 def test_preceding_following_validate(alltypes):
     # these all work
     [

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -38,13 +38,6 @@ def test_compose_group_by_apis(alltypes):
     assert_equal(expr, expr3)
 
 
-def test_window_how_kwarg():
-    ibis.window(how='row')
-    ibis.window(how='range')
-    with pytest.raises(ibis.common.IbisInputError):
-        ibis.window(how='other')
-
-
 def test_combine_windows(alltypes):
     t = alltypes
     w1 = ibis.window(group_by=t.g, order_by=t.f)
@@ -62,7 +55,7 @@ def test_combine_windows(alltypes):
                            preceding=5, following=5)
     assert_equal(w5, expected)
 
-    w6 = ibis.window(preceding=5, following=5, how='range')
+    w6 = ibis.range_window(preceding=5, following=5)
     with pytest.raises(ibis.common.IbisInputError):
         w1.combine(w6)
 

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -62,6 +62,10 @@ def test_combine_windows(alltypes):
                            preceding=5, following=5)
     assert_equal(w5, expected)
 
+    w6 = ibis.window(preceding=5, following=5, how='range')
+    with pytest.raises(ibis.common.IbisInputError):
+        w1.combine(w6)
+
 
 def test_over_auto_bind(alltypes):
     # GH #542

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -131,6 +131,14 @@ def test_window_bind_to_table(alltypes):
     assert_equal(w2, expected)
 
 
+def test_trailing_time_window(alltypes):
+    t = alltypes
+    ibis.trailing_time_window(prior_interval=5, order_by=t.i)
+    with pytest.raises(ibis.common.IbisInputError):
+        ibis.trailing_time_window(prior_interval=5,
+                                  order_by=t.e)
+
+
 def test_preceding_following_validate(alltypes):
     # these all work
     [

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -38,6 +38,13 @@ def test_compose_group_by_apis(alltypes):
     assert_equal(expr, expr3)
 
 
+def test_window_how_kwarg():
+    ibis.window(how='row')
+    ibis.window(how='range')
+    with pytest.raises(ibis.common.IbisInputError):
+        ibis.window(how='other')
+
+
 def test_combine_windows(alltypes):
     t = alltypes
     w1 = ibis.window(group_by=t.g, order_by=t.f)

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -131,12 +131,12 @@ def test_window_bind_to_table(alltypes):
     assert_equal(w2, expected)
 
 
-def test_trailing_time_window(alltypes):
-    t = alltypes
-    ibis.trailing_time_window(prior_interval=5, order_by=t.i)
-    with pytest.raises(ibis.common.IbisInputError):
-        ibis.trailing_time_window(prior_interval=5,
-                                  order_by=t.e)
+# def test_trailing_time_window(alltypes):
+#     t = alltypes
+#     ibis.trailing_time_window(preceding=5, order_by=t.i)
+#     with pytest.raises(ibis.common.IbisInputError):
+#         ibis.trailing_time_window(preceding=5,
+#                                   order_by=t.e)
 
 
 def test_preceding_following_validate(alltypes):

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -21,7 +21,7 @@ class Window(object):
     """
 
     def __init__(self, group_by=None, order_by=None,
-                 preceding=None, following=None, how='row'):
+                 preceding=None, following=None, how='rows'):
         if group_by is None:
             group_by = []
 
@@ -89,9 +89,10 @@ class Window(object):
                             self.following
                         )
                     )
-        if self.how not in {'row', 'range', 'time_range'}:
+        if self.how not in {'rows', 'range', 'time_range'}:
             raise com.IbisInputError(
-                "'how' must be 'row', 'range', or 'time_range', got {}".format(
+                "'how' must be 'rows', 'range', or 'time_range', got {}"
+                .format(
                     self.how
                 )
             )
@@ -201,7 +202,7 @@ def window(preceding=None, following=None, group_by=None, order_by=None):
     win : ibis Window
     """
     return Window(preceding=preceding, following=following,
-                  group_by=group_by, order_by=order_by, how='row')
+                  group_by=group_by, order_by=order_by, how='rows')
 
 
 def range_window(preceding=None, following=None, group_by=None, order_by=None):

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -167,7 +167,8 @@ class Window(object):
         return equal
 
 
-def window(preceding=None, following=None, group_by=None, order_by=None, how='row'):
+def window(preceding=None, following=None,
+           group_by=None, order_by=None, how='row'):
     """
     Create a window clause for use with window (analytic and aggregate)
     functions.

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -104,6 +104,13 @@ class Window(object):
         return self._replace(group_by=groups, order_by=sorts)
 
     def combine(self, window):
+        if self.how != window.how:
+            raise com.IbisInputError(
+                "Window types must match. Expecting '{}'' Window, got '{}'"
+                .format(
+                    self.how.upper(), window.how.upper()
+                )
+            )
         kwds = dict(
             preceding=self.preceding or window.preceding,
             following=self.following or window.following,

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -174,11 +174,11 @@ class Window(object):
         return equal
 
 
-def window(preceding=None, following=None,
-           group_by=None, order_by=None, how='row'):
+def window(preceding=None, following=None, group_by=None, order_by=None):
     """
     Create a window clause for use with window (analytic and aggregate)
-    functions.
+    functions. This ROW window clause aggregates adjacent rows based
+    on differences in row number.
 
     All window frames / ranges are inclusive.
 
@@ -195,15 +195,43 @@ def window(preceding=None, following=None,
     order_by : expressions, default None
       For analytic functions requiring an ordering, specify here, or let Ibis
       determine the default ordering (for functions like rank)
-    how : string, default 'row'
-      Specify whether windowing by ROWS or RANGE of values
 
     Returns
     -------
     win : ibis Window
     """
     return Window(preceding=preceding, following=following,
-                  group_by=group_by, order_by=order_by, how=how)
+                  group_by=group_by, order_by=order_by, how='row')
+
+
+def range_window(preceding=None, following=None, group_by=None, order_by=None):
+    """
+    Create a window clause for use with window (analytic and aggregate)
+    functions. This RANGE window clause aggregates rows based upon differences
+    in the value of the order-by expression.
+
+    All window frames / ranges are inclusive.
+
+    Parameters
+    ----------
+    preceding : int, tuple, or None, default None
+      Specify None for unbounded, 0 to include current row
+      tuple for off-center window
+    following : int, tuple, or None, default None
+      Specify None for unbounded, 0 to include current row
+      tuple for off-center window
+    group_by : expressions, default None
+      Either specify here or with TableExpr.group_by
+    order_by : expressions, default None
+      For analytic functions requiring an ordering, specify here, or let Ibis
+      determine the default ordering (for functions like rank)
+
+    Returns
+    -------
+    win : ibis Window
+    """
+    return Window(preceding=preceding, following=following,
+                  group_by=group_by, order_by=order_by, how='range')
 
 
 def cumulative_window(group_by=None, order_by=None):
@@ -235,7 +263,7 @@ def trailing_window(periods, group_by=None, order_by=None):
     Parameters
     ----------
     periods : int
-      Number of trailing periods to include. 0 includes only the current period
+      Number of trailing rows to include. 0 includes only the current row
     group_by : expressions, default None
       Either specify here or with TableExpr.group_by
     order_by : expressions, default None

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -278,13 +278,13 @@ def trailing_window(rows, group_by=None, order_by=None):
                   group_by=group_by, order_by=order_by)
 
 
-def trailing_time_window(prior_interval, order_by, group_by=None):
+def trailing_time_window(preceding, order_by, group_by=None):
     """
     Create a trailing time window for use with aggregate window functions.
 
     Parameters
     ----------
-    prior_interval : TODO
+    preceding : TODO
     order_by : Union[ir.TimeColumn, ir.DateColumn, ir.TimestampColumn]
       Specify the column over which the window will look back
     group_by : expressions, default None
@@ -307,7 +307,7 @@ def trailing_time_window(prior_interval, order_by, group_by=None):
     # Convert Time Column to Unix_Micro
     order_by = order_by.cast('timestamp').cast('int64')
 
-    return Window(preceding=prior_interval, following=0,
+    return Window(preceding=preceding, following=0,
                   group_by=group_by, order_by=order_by, how='range')
 
 

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -89,7 +89,7 @@ class Window(object):
                             self.following
                         )
                     )
-        if self.how not in ['row', 'range']:
+        if self.how not in {'row', 'range'}:
             raise com.IbisInputError(
                 "'how' must be either 'row' or 'range', got {}".format(
                     self.how
@@ -106,7 +106,7 @@ class Window(object):
     def combine(self, window):
         if self.how != window.how:
             raise com.IbisInputError(
-                "Window types must match. Expecting '{}'' Window, got '{}'"
+                "Window types must match. Expecting '{}' Window, got '{}'"
                 .format(
                     self.how.upper(), window.how.upper()
                 )
@@ -256,13 +256,13 @@ def cumulative_window(group_by=None, order_by=None):
                   group_by=group_by, order_by=order_by)
 
 
-def trailing_window(periods, group_by=None, order_by=None):
+def trailing_window(rows, group_by=None, order_by=None):
     """
     Create a trailing window for use with aggregate window functions.
 
     Parameters
     ----------
-    periods : int
+    rows : int
       Number of trailing rows to include. 0 includes only the current row
     group_by : expressions, default None
       Either specify here or with TableExpr.group_by
@@ -274,7 +274,7 @@ def trailing_window(periods, group_by=None, order_by=None):
     -------
     win : ibis Window
     """
-    return Window(preceding=periods, following=0,
+    return Window(preceding=rows, following=0,
                   group_by=group_by, order_by=order_by)
 
 

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -89,9 +89,9 @@ class Window(object):
                             self.following
                         )
                     )
-        if self.how not in {'row', 'range'}:
+        if self.how not in {'row', 'range', 'time_range'}:
             raise com.IbisInputError(
-                "'how' must be either 'row' or 'range', got {}".format(
+                "'how' must be 'row', 'range', or 'time_range', got {}".format(
                     self.how
                 )
             )
@@ -294,21 +294,8 @@ def trailing_time_window(preceding, order_by, group_by=None):
     -------
     win: ibis Window
     """
-
-    if not isinstance(order_by, (ir.TimeColumn, ir.DateColumn,
-                                 ir.TimestampColumn)):
-        raise com.IbisInputError(
-            "'order_by' must be a TimeColumn, DateColumn, or TimestampColumn" +
-            ", got {}".format(
-                type(order_by)
-            )
-        )
-
-    # Convert Time Column to Unix_Micro
-    order_by = order_by.cast('timestamp').cast('int64')
-
     return Window(preceding=preceding, following=0,
-                  group_by=group_by, order_by=order_by, how='range')
+                  group_by=group_by, order_by=order_by, how='time_range')
 
 
 def propagate_down_window(expr, window):

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -284,7 +284,7 @@ def trailing_time_window(preceding, order_by, group_by=None):
 
     Parameters
     ----------
-    preceding : int or expression of intervals, i.e. 
+    preceding : float or expression of intervals, i.e.
       1 * ibis.day() + 5 * ibis.hour()
     order_by : Union[ir.TimeColumn, ir.DateColumn, ir.TimestampColumn]
       Specify the column over which the window will look back

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -278,6 +278,39 @@ def trailing_window(rows, group_by=None, order_by=None):
                   group_by=group_by, order_by=order_by)
 
 
+def trailing_time_window(prior_interval, order_by, group_by=None):
+    """
+    Create a trailing time window for use with aggregate window functions.
+
+    Parameters
+    ----------
+    prior_interval : TODO
+    order_by : Union[ir.TimeColumn, ir.DateColumn, ir.TimestampColumn]
+      Specify the column over which the window will look back
+    group_by : expressions, default None
+      Either specify here or with TableExpr.group_by
+
+    Returns
+    -------
+    win: ibis Window
+    """
+
+    if not isinstance(order_by, (ir.TimeColumn, ir.DateColumn,
+                                 ir.TimestampColumn)):
+        raise com.IbisInputError(
+            "'order_by' must be a TimeColumn, DateColumn, or TimestampColumn" +
+            ", got {}".format(
+                type(order_by)
+            )
+        )
+
+    # Convert Time Column to Unix_Micro
+    order_by = order_by.cast('timestamp').cast('int64')
+
+    return Window(preceding=prior_interval, following=0,
+                  group_by=group_by, order_by=order_by, how='range')
+
+
 def propagate_down_window(expr, window):
     op = expr.op()
 

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -279,7 +279,7 @@ def trailing_window(rows, group_by=None, order_by=None):
                   group_by=group_by, order_by=order_by)
 
 
-def trailing_time_window(preceding, order_by, group_by=None):
+def trailing_range_window(preceding, order_by, group_by=None):
     """
     Create a trailing time window for use with aggregate window functions.
 
@@ -287,8 +287,9 @@ def trailing_time_window(preceding, order_by, group_by=None):
     ----------
     preceding : float or expression of intervals, i.e.
       1 * ibis.day() + 5 * ibis.hour()
-    order_by : Union[ir.TimeColumn, ir.DateColumn, ir.TimestampColumn]
-      Specify the column over which the window will look back
+    order_by : expressions, default None
+      For analytic functions requiring an ordering, specify here, or let Ibis
+      determine the default ordering (for functions like rank)
     group_by : expressions, default None
       Either specify here or with TableExpr.group_by
 

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -89,9 +89,9 @@ class Window(object):
                             self.following
                         )
                     )
-        if self.how not in {'rows', 'range', 'time_range'}:
+        if self.how not in {'rows', 'range'}:
             raise com.IbisInputError(
-                "'how' must be 'rows', 'range', or 'time_range', got {}"
+                "'how' must be 'rows' or 'range', got {}"
                 .format(
                     self.how
                 )
@@ -297,7 +297,7 @@ def trailing_time_window(preceding, order_by, group_by=None):
     win: ibis Window
     """
     return Window(preceding=preceding, following=0,
-                  group_by=group_by, order_by=order_by, how='time_range')
+                  group_by=group_by, order_by=order_by, how='range')
 
 
 def propagate_down_window(expr, window):

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -284,7 +284,8 @@ def trailing_time_window(preceding, order_by, group_by=None):
 
     Parameters
     ----------
-    preceding : TODO
+    preceding : int or expression of intervals, i.e. 
+      1 * ibis.day() + 5 * ibis.hour()
     order_by : Union[ir.TimeColumn, ir.DateColumn, ir.TimestampColumn]
       Specify the column over which the window will look back
     group_by : expressions, default None

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -21,7 +21,7 @@ class Window(object):
     """
 
     def __init__(self, group_by=None, order_by=None,
-                 preceding=None, following=None):
+                 preceding=None, following=None, how='row'):
         if group_by is None:
             group_by = []
 
@@ -40,6 +40,7 @@ class Window(object):
 
         self.preceding = _list_to_tuple(preceding)
         self.following = _list_to_tuple(following)
+        self.how = how
 
         self._validate_frame()
 
@@ -88,6 +89,12 @@ class Window(object):
                             self.following
                         )
                     )
+        if self.how not in ['row', 'range']:
+            raise com.IbisInputError(
+                "'how' must be either 'row' or 'range', got {}".format(
+                    self.how
+                )
+            )
 
     def bind(self, table):
         # Internal API, ensure that any unresolved expr references (as strings,
@@ -114,7 +121,8 @@ class Window(object):
             group_by=kwds.get('group_by', self._group_by),
             order_by=kwds.get('order_by', self._order_by),
             preceding=kwds.get('preceding', self.preceding),
-            following=kwds.get('following', self.following)
+            following=kwds.get('following', self.following),
+            how=kwds.get('how', self.how)
         )
         return Window(**new_kwds)
 
@@ -159,7 +167,7 @@ class Window(object):
         return equal
 
 
-def window(preceding=None, following=None, group_by=None, order_by=None):
+def window(preceding=None, following=None, group_by=None, order_by=None, how='row'):
     """
     Create a window clause for use with window (analytic and aggregate)
     functions.
@@ -179,13 +187,15 @@ def window(preceding=None, following=None, group_by=None, order_by=None):
     order_by : expressions, default None
       For analytic functions requiring an ordering, specify here, or let Ibis
       determine the default ordering (for functions like rank)
+    how : string, default 'row'
+      Specify whether windowing by ROWS or RANGE of values
 
     Returns
     -------
     win : ibis Window
     """
     return Window(preceding=preceding, following=following,
-                  group_by=group_by, order_by=order_by)
+                  group_by=group_by, order_by=order_by, how=how)
 
 
 def cumulative_window(group_by=None, order_by=None):

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -1,5 +1,6 @@
 from six import StringIO
 import datetime
+from operator import add, mul, sub
 
 import ibis
 import ibis.expr.analysis as L
@@ -202,10 +203,10 @@ _map_interval_op_to_op = {
     # Literal Intervals have two args, i.e.
     # Literal(1, Interval(value_type=int8, unit='D', nullable=True))
     # Parse both args and multipy 1 * _map_interval_to_microseconds['D']
-    ops.Literal: lambda x, y: x * y,
-    ops.IntervalMultiply: lambda x, y: x * y,
-    ops.IntervalAdd: lambda x, y: x + y,
-    ops.IntervalSubtract: lambda x, y: x - y,
+    ops.Literal: mul,
+    ops.IntervalMultiply: mul,
+    ops.IntervalAdd: add,
+    ops.IntervalSubtract: sub,
 }
 
 

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -263,7 +263,9 @@ def _format_window(translator, window):
     elif p is not None:
         if isinstance(p, tuple):
             start, end = p
-            frame = 'ROWS BETWEEN {} AND {}'.format(_prec(start), _prec(end))
+            kind = 'ROWS' if window.how == 'row' else 'RANGE'
+            frame = '{} BETWEEN {} AND {}'.format(
+                kind, _prec(start), _prec(end))
         else:
             kind = 'ROWS' if p > 0 else 'RANGE'
             frame = '{} BETWEEN {} AND UNBOUNDED FOLLOWING'.format(
@@ -272,7 +274,9 @@ def _format_window(translator, window):
     elif f is not None:
         if isinstance(f, tuple):
             start, end = f
-            frame = 'ROWS BETWEEN {} AND {}'.format(_foll(start), _foll(end))
+            kind = 'ROWS' if window.how == 'row' else 'RANGE'
+            frame = '{} BETWEEN {} AND {}'.format(
+                kind, _foll(start), _foll(end))
         else:
             kind = 'ROWS' if f > 0 else 'RANGE'
             frame = '{} BETWEEN UNBOUNDED PRECEDING AND {}'.format(

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -125,6 +125,9 @@ def _cast(translator, expr):
 
     if isinstance(arg, ir.CategoryValue) and target_type == 'int32':
         return arg_formatted
+    if (isinstance(arg, (ir.TimeValue, ir.DateValue, ir.TimestampValue)) and
+            target_type == 'int64'):  # noqa E129
+        return '1e6 * unix_timestamp({})'.format(arg_formatted)
     else:
         sql_type = _type_to_sql_string(target_type)
         return 'CAST({} AS {})'.format(arg_formatted, sql_type)

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -185,12 +185,6 @@ def _cumulative_to_window(translator, expr, window):
     return new_expr
 
 
-_window_types = {
-    'row': 'ROWS',
-    'range': 'RANGE'
-}
-
-
 _map_interval_to_microseconds = dict(
     W=6.048e11,
     D=8.64e10,
@@ -370,13 +364,13 @@ def _format_window(translator, window):
 
     if p is not None and f is not None:
         frame = '{} BETWEEN {} AND {}'.format(
-            _window_types[window.how], _prec(p), _foll(f))
+            window.how.upper(), _prec(p), _foll(f))
 
     elif p is not None:
         if isinstance(p, tuple):
             start, end = p
             frame = '{} BETWEEN {} AND {}'.format(
-                _window_types[window.how], _prec(start), _prec(end))
+                window.how.upper(), _prec(start), _prec(end))
         else:
             kind = 'ROWS' if p > 0 else 'RANGE'
             frame = '{} BETWEEN {} AND UNBOUNDED FOLLOWING'.format(
@@ -386,7 +380,7 @@ def _format_window(translator, window):
         if isinstance(f, tuple):
             start, end = f
             frame = '{} BETWEEN {} AND {}'.format(
-                _window_types[window.how], _foll(start), _foll(end))
+                window.how.upper(), _foll(start), _foll(end))
         else:
             kind = 'ROWS' if f > 0 else 'RANGE'
             frame = '{} BETWEEN UNBOUNDED PRECEDING AND {}'.format(

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -260,15 +260,13 @@ def _time_range_to_range_window(translator, window):
     order_by_vars = [x.op().args[0] for x in window._order_by]
     if len(order_by_vars) > 1:
         raise com.IbisInputError(
-                "Expected 1 order-by variable, got {}".format(
-                    len(order_by_vars)
-                )
+            "Expected 1 order-by variable, got {}".format(
+                len(order_by_vars)
+            )
         )
 
     order_var = window._order_by[0].op().args[0]
-    print(type(order_var))
     timestamp_order_var = order_var.cast('int64')
-    print(type(timestamp_order_var))
     window = window._replace(order_by=timestamp_order_var,
                              how='range')
 
@@ -321,7 +319,7 @@ def _window(translator, expr):
     if window.how == 'range':
         order_by_types = [type(x.op().args[0]) for x in window._order_by]
         time_range_types = (ir.TimeColumn, ir.DateColumn, ir.TimestampColumn)
-        if any([col_type in time_range_types for col_type in order_by_types]):
+        if any(col_type in time_range_types for col_type in order_by_types):
             window = _time_range_to_range_window(translator, window)
 
     window_formatted = _format_window(translator, window)

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -256,7 +256,10 @@ def _format_window(translator, window):
         return '{} FOLLOWING'.format(f) if f > 0 else 'CURRENT ROW'
 
     if p is not None and f is not None:
-        frame = 'ROWS BETWEEN {} AND {}'.format(_prec(p), _foll(f))
+        if window.how == 'row':
+            frame = 'ROWS BETWEEN {} AND {}'.format(_prec(p), _foll(f))
+        else:
+            frame = 'RANGE BETWEEN {} AND {}'.format(_prec(p), _foll(f))
     elif p is not None:
         if isinstance(p, tuple):
             start, end = p

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -234,7 +234,7 @@ def _replace_interval_with_scalar(expr):
             microseconds = _map_interval_to_microseconds[expr.unit]
             return microseconds
         except KeyError:
-            raise KeyError(
+            raise ValueError(
                 "Expected preceding values of week(), " +
                 "day(), hour(), minute(), second(), millisecond(), " +
                 "microseconds(), nanoseconds(); got {}".format(expr)

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -192,7 +192,6 @@ _window_types = {
 
 
 _map_interval_to_microseconds = dict(
-    Y=3.154e13,
     W=6.048e11,
     D=8.64e10,
     h=3.6e9,
@@ -237,7 +236,7 @@ def _replace_interval_with_scalar(expr):
             return microseconds
         except KeyError:
             raise KeyError(
-                "Expected preceding values of year(), week(), " +
+                "Expected preceding values of week(), " +
                 "day(), hour(), minute(), second(), millisecond(), " +
                 "microseconds(), nanoseconds(); got {}".format(expr)
                 )

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -187,11 +187,11 @@ def _cumulative_to_window(translator, expr, window):
 
 
 _map_interval_to_microseconds = dict(
-    W=6.048e11,
-    D=8.64e10,
-    h=3.6e9,
-    m=6e7,
-    s=1e6,
+    W=604800000000,
+    D=86400000000,
+    h=3600000000,
+    m=60000000,
+    s=1000000,
     ms=1000,
     us=1,
     ns=.001

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -128,7 +128,7 @@ def _cast(translator, expr):
         return arg_formatted
     if (isinstance(arg, (ir.TimeValue, ir.DateValue, ir.TimestampValue)) and
             target_type == 'int64'):  # noqa E129
-        return '1e6 * unix_timestamp({})'.format(arg_formatted)
+        return '1000000 * unix_timestamp({})'.format(arg_formatted)
     else:
         sql_type = _type_to_sql_string(target_type)
         return 'CAST({} AS {})'.format(arg_formatted, sql_type)

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -235,7 +235,7 @@ def _replace_interval_with_scalar(expr):
         try:
             microseconds = _map_interval_to_microseconds[expr.unit]
             return microseconds
-        except KeyError as e:
+        except KeyError:
             raise KeyError(
                 "Expected preceding values of year(), week(), " +
                 "day(), hour(), minute(), second(), millisecond(), " +

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -181,6 +181,12 @@ def _cumulative_to_window(translator, expr, window):
     return new_expr
 
 
+_window_types = {
+    'row': 'ROWS',
+    'range': 'RANGE'
+}
+
+
 def _window(translator, expr):
     op = expr.op()
 
@@ -256,16 +262,14 @@ def _format_window(translator, window):
         return '{} FOLLOWING'.format(f) if f > 0 else 'CURRENT ROW'
 
     if p is not None and f is not None:
-        if window.how == 'row':
-            frame = 'ROWS BETWEEN {} AND {}'.format(_prec(p), _foll(f))
-        else:
-            frame = 'RANGE BETWEEN {} AND {}'.format(_prec(p), _foll(f))
+        frame = '{} BETWEEN {} AND {}'.format(
+            _window_types[window.how], _prec(p), _foll(f))
+
     elif p is not None:
         if isinstance(p, tuple):
             start, end = p
-            kind = 'ROWS' if window.how == 'row' else 'RANGE'
             frame = '{} BETWEEN {} AND {}'.format(
-                kind, _prec(start), _prec(end))
+                _window_types[window.how], _prec(start), _prec(end))
         else:
             kind = 'ROWS' if p > 0 else 'RANGE'
             frame = '{} BETWEEN {} AND UNBOUNDED FOLLOWING'.format(
@@ -274,9 +278,8 @@ def _format_window(translator, window):
     elif f is not None:
         if isinstance(f, tuple):
             start, end = f
-            kind = 'ROWS' if window.how == 'row' else 'RANGE'
             frame = '{} BETWEEN {} AND {}'.format(
-                kind, _foll(start), _foll(end))
+                _window_types[window.how], _foll(start), _foll(end))
         else:
             kind = 'ROWS' if f > 0 else 'RANGE'
             frame = '{} BETWEEN UNBOUNDED PRECEDING AND {}'.format(

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -219,6 +219,15 @@ def _replace_interval_with_scalar(expr):
     """
     Good old Depth-First Search to identify the Interval and IntervalValue
     components of the expression and return a comparable scalar expression.
+
+    Parameters
+    ----------
+    expr : float or expression of intervals, i.e.
+      1 * ibis.day() + 5 * ibis.hour()
+
+    Returns
+    -------
+    preceding : float or ir.FloatingScalar, depending upon the expr
     """
     if not isinstance(expr, (dt.Interval, ir.IntervalValue)):
         return expr
@@ -272,7 +281,8 @@ def _time_range_to_range_window(translator, window):
     preceding = window.preceding
     if isinstance(preceding, ir.IntervalScalar):
         new_preceding = _replace_interval_with_scalar(preceding)
-        new_preceding = eval(translator.translate(new_preceding))
+        if isinstance(new_preceding, ir.AnyScalar):
+            new_preceding = eval(translator.translate(new_preceding))
         window = window._replace(preceding=new_preceding)
 
     return window

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -126,8 +126,10 @@ def _cast(translator, expr):
 
     if isinstance(arg, ir.CategoryValue) and target_type == 'int32':
         return arg_formatted
-    if (isinstance(arg, (ir.TimeValue, ir.DateValue, ir.TimestampValue)) and
-            target_type == 'int64'):  # noqa E129
+    if (
+        isinstance(arg, (ir.TimeValue, ir.DateValue, ir.TimestampValue)) and
+            target_type == 'int64'
+            ):
         return '1000000 * unix_timestamp({})'.format(arg_formatted)
     else:
         sql_type = _type_to_sql_string(target_type)

--- a/ibis/impala/tests/test_client.py
+++ b/ibis/impala/tests/test_client.py
@@ -1,7 +1,9 @@
 import unittest
 
+from datetime import datetime
 import numpy as np
 import pandas as pd
+import pytz
 
 from ibis.impala.tests.common import IbisTestEnv, ImpalaE2E, connect_test
 from ibis.tests.util import assert_equal
@@ -125,13 +127,10 @@ LIMIT 10"""
         assert isinstance(result, pd.Series)
 
     def test_time_to_int_cast(self):
-        d = self.ibis.literal('2017-02-06').cast('date')
+        now = pytz.utc.localize(datetime.now())
+        d = ibis.literal(now)
         result = self.con.execute(d.cast('int64'))
-        assert result == 1486339200000000
-
-        t = self.ibis.literal('2017-02-06').cast('timestamp')
-        result = self.con.execute(t.cast('int64'))
-        assert result == 1486339200000000
+        assert result == int(now.timestamp() * 1e6)  # Convert to Micro
 
     def test_interactive_repr_call_failure(self):
         t = self.con.table('tpch_lineitem').limit(100000)

--- a/ibis/impala/tests/test_client.py
+++ b/ibis/impala/tests/test_client.py
@@ -131,7 +131,7 @@ LIMIT 10"""
         now = pytz.utc.localize(datetime.now())
         d = ibis.literal(now)
         result = self.con.execute(d.cast('int64'))
-        assert result == int(time.mktime(now.timetuple())) * 1e6
+        assert result == int(time.mktime(now.timetuple())) * 1000000
 
     def test_interactive_repr_call_failure(self):
         t = self.con.table('tpch_lineitem').limit(100000)

--- a/ibis/impala/tests/test_client.py
+++ b/ibis/impala/tests/test_client.py
@@ -130,7 +130,7 @@ LIMIT 10"""
         now = pytz.utc.localize(datetime.now())
         d = ibis.literal(now)
         result = self.con.execute(d.cast('int64'))
-        assert result == int(now.timestamp() * 1e6)  # Convert to Micro
+        assert result == int(now.timestamp()) * 1e6  # Convert to Micro
 
     def test_interactive_repr_call_failure(self):
         t = self.con.table('tpch_lineitem').limit(100000)

--- a/ibis/impala/tests/test_client.py
+++ b/ibis/impala/tests/test_client.py
@@ -1,6 +1,7 @@
 import unittest
 
 from datetime import datetime
+import time
 import numpy as np
 import pandas as pd
 import pytz
@@ -130,7 +131,7 @@ LIMIT 10"""
         now = pytz.utc.localize(datetime.now())
         d = ibis.literal(now)
         result = self.con.execute(d.cast('int64'))
-        assert result == int(now.timestamp()) * 1e6  # Convert to Micro
+        assert result == int(time.mktime(now.timetuple())) * 1e6
 
     def test_interactive_repr_call_failure(self):
         t = self.con.table('tpch_lineitem').limit(100000)

--- a/ibis/impala/tests/test_client.py
+++ b/ibis/impala/tests/test_client.py
@@ -124,6 +124,15 @@ LIMIT 10"""
         result = self.con.execute(expr)
         assert isinstance(result, pd.Series)
 
+    def test_time_to_int_cast(self):
+        d = self.ibis.literal('2017-02-06').cast('date')
+        result = self.con.execute(d.cast('int64'))
+        assert result == 1486339200000000
+
+        t = self.ibis.literal('2017-02-06').cast('timestamp')
+        result = self.con.execute(t.cast('int64'))
+        assert result == 1486339200000000
+
     def test_interactive_repr_call_failure(self):
         t = self.con.table('tpch_lineitem').limit(100000)
 


### PR DESCRIPTION
Closes #1349 

To Do:
- [x] Write compile and execution tests.
- [x] Remove string kwarg from `window` function and implement `range_window`.
- [x] Implement assert in `combine` to preclude combining different types of windows.
- [x] Implement trailing time-window function that a) requires a date variable in order-by and b) accepts interval expressions for preceding argument.