### PR TITLE
Re-enable pyarrow on py27 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ workflows:
   test:
     jobs:
       - python27_test
-      # - python27_conda_build
+      - python27_conda_build
 
       - python35_test
       - python35_conda_build

--- a/ci/requirements-dev-2.7.yml
+++ b/ci/requirements-dev-2.7.yml
@@ -22,7 +22,7 @@ dependencies:
   - pathlib2
   - plumbum
   - psycopg2
-  # - pyarrow>=0.6.0
+  - pyarrow>=0.6.0
   - pymysql
   - pytables
   - pytest


### PR DESCRIPTION
PyArrow conda packages are working now: https://issues.apache.org/jira/browse/ARROW-2783

Resolves #1511