### PR TITLE
BUG: Fix projection fusion bug

### DIFF
--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -344,7 +344,7 @@ GROUP BY 1""".format(expected1, expected2)
     assert result == expected
 
 
-def test_subquery_bug():
+def test_projection_fusion_only_peeks_at_immediate_parent():
     schema = [
         ('file_date', 'timestamp'),
         ('PARTITIONTIME', 'date'),

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -342,3 +342,41 @@ SELECT `string_col`, sum(`double_col`) AS `metric`
 FROM `ibis-gbq.testing.functional_alltypes`
 GROUP BY 1""".format(expected1, expected2)
     assert result == expected
+
+
+def test_subquery_bug():
+    schema = [
+        ('file_date', 'timestamp'),
+        ('PARTITIONTIME', 'date'),
+        ('val', 'int64'),
+    ]
+    table = ibis.table(schema, name='unbound_table')
+    table = table[table.PARTITIONTIME < ibis.date('2017-01-01')]
+    table = table.mutate(file_date=table.file_date.cast('date'))
+    table = table[table.file_date < ibis.date('2017-01-01')]
+    table = table.mutate(XYZ=table.val * 2)
+    expr = table.join(table.view())[table]
+    result = ibis.bigquery.compile(expr)
+    expected = """\
+WITH t0 AS (
+  SELECT *
+  FROM unbound_table
+  WHERE `PARTITIONTIME` < DATE '2017-01-01'
+),
+t1 AS (
+  SELECT CAST(`file_date` AS DATE) AS `file_date`, `PARTITIONTIME`, `val`
+  FROM t0
+),
+t2 AS (
+  SELECT t1.*
+  FROM t1
+  WHERE t1.`file_date` < DATE '2017-01-01'
+),
+t3 AS (
+  SELECT *, `val` * 2 AS `XYZ`
+  FROM t2
+)
+SELECT t3.*
+FROM t3
+  CROSS JOIN t3 t4"""
+    assert result == expected

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -343,18 +343,15 @@ class ExprSimplifier(object):
 
     def _lift_TableColumn(self, expr, block=None):
         node = expr.op()
-
-        tnode = node.table.op()
-        root = _base_table(tnode)
-
+        root = node.table.op()
         result = expr
+
         if isinstance(root, ops.Selection):
             can_lift = False
 
             for val in root.selections:
                 if (isinstance(val.op(), ops.PhysicalTable) and
                         node.name in val.schema()):
-
                     can_lift = True
                     lifted_root = self.lift(val)
                 elif (isinstance(val.op(), ops.TableColumn) and
@@ -362,9 +359,6 @@ class ExprSimplifier(object):
                       node.name == val.get_name()):
                     can_lift = True
                     lifted_root = self.lift(val.op().table)
-
-                # XXX
-                # can_lift = False
 
             # HACK: If we've projected a join, do not lift the children
             # TODO: what about limits and other things?


### PR DESCRIPTION
Closes #1496 

The change here still allows fusion across projections without predicates, e.g., two calls to `mutate` on independent columns will be fused into a single projection:

```python
In [6]: con = ibis.bigquery.connect('ibis-gbq', 'testing')

In [7]: t = con.table('functional_alltypes')

In [8]: expr = t.mutate(a=t.int_col + 1).mutate(b=t.float_col + 2)

In [9]: print(ibis.bigquery.compile(expr))
SELECT *, `int_col` + 1 AS `a`, `float_col` + 2 AS `b`
FROM `ibis-gbq.testing.functional_alltypes`
```

If there's a dependency introduced then a subquery will be generated:

```python
In [13]: expr = t.mutate(a=t.int_col + 1).mutate(b=lambda t: t.a + 2)

In [14]: print(ibis.bigquery.compile(expr))
SELECT *, `a` + 2 AS `b`
FROM (
  SELECT *, `int_col` + 1 AS `a`
  FROM `ibis-gbq.testing.functional_alltypes`
) t0
```