### PR TITLE
Add test database setup for BigQuery.

### DIFF
--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -101,6 +101,30 @@ Impala (with UDFs)
 
       ci/impalamgr.py load --data --data-dir ibis-testing-data
 
+BigQuery
+^^^^^^^^
+
+Before you begin, you must have a `Google Cloud Platform project
+<https://cloud.google.com/docs/overview/#projects>`__ with billing set up the
+BigQuery API enabled.
+
+#. **Set up application default credentials by following the `getting started with
+   GCP authentication guide
+   <https://cloud.google.com/docs/authentication/getting-started>`__.**
+
+#. **Set the ``GOOGLE_BIGQUERY_PROJECT_ID`` environment variable**:
+
+   .. code:: sh
+
+      export GOOGLE_BIGQUERY_PROJECT_ID=your-project-id
+
+#. **Load data into BigQuery**:
+
+   .. code:: sh
+
+      ci/datamgr.py bigquery
+
+
 Clickhouse
 ^^^^^^^^^^
 

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -105,12 +105,13 @@ BigQuery
 ^^^^^^^^
 
 Before you begin, you must have a `Google Cloud Platform project
-<https://cloud.google.com/docs/overview/#projects>`__ with billing set up the
-BigQuery API enabled.
+<https://cloud.google.com/docs/overview/#projects>`_ with billing set up and
+the `BigQuery API enabled
+<https://console.cloud.google.com/flows/enableapi?apiid=bigquery>`_.
 
 #. **Set up application default credentials by following the `getting started with
    GCP authentication guide
-   <https://cloud.google.com/docs/authentication/getting-started>`__.**
+   <https://cloud.google.com/docs/authentication/getting-started>`_.**
 
 #. **Set the ``GOOGLE_BIGQUERY_PROJECT_ID`` environment variable**:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,7 +49,7 @@ At this time, Ibis offers some level of support for the following systems:
 - `Apache Kudu (incubating) <http://getkudu.io/>`_
 - `PostgreSQL <https://www.postgresql.org/>`_
 - `SQLite <https://www.sqlite.org/>`_
-- `Google BigQuery <https://cloud.google.com/bigquery/>`
+- `Google BigQuery <https://cloud.google.com/bigquery/>`_
 - `Yandex Clickhouse <https://clickhouse.yandex/>`_
 - Direct execution of ibis expressions against `Pandas
   <http://pandas.pydata.org/>`_ objects

--- a/ibis/bigquery/tests/conftest.py
+++ b/ibis/bigquery/tests/conftest.py
@@ -22,6 +22,11 @@ def connect(project_id, dataset_id):
 
 
 @pytest.fixture(scope='session')
+def project_id():
+    return PROJECT_ID
+
+
+@pytest.fixture(scope='session')
 def client():
     return connect(PROJECT_ID, DATASET_ID)
 

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.bigquery
 pytest.importorskip('google.cloud.bigquery')
 
 
-def test_timestamp_accepts_date_literals(alltypes):
+def test_timestamp_accepts_date_literals(alltypes, project_id):
     date_string = '2009-03-01'
     param = ibis.param(dt.timestamp).name('param_0')
     expr = alltypes.mutate(param=param)
@@ -20,7 +20,7 @@ def test_timestamp_accepts_date_literals(alltypes):
     result = expr.compile(params=params)
     expected = """\
 SELECT *, @param AS `param`
-FROM `ibis-gbq.testing.functional_alltypes`"""
+FROM `{}.testing.functional_alltypes`""".format(project_id)
     assert result == expected
 
 
@@ -31,37 +31,39 @@ FROM `ibis-gbq.testing.functional_alltypes`"""
         (False, 'ALL'),
     ]
 )
-def test_union(alltypes, distinct, expected_keyword):
+def test_union(alltypes, distinct, expected_keyword, project_id):
     expr = alltypes.union(alltypes, distinct=distinct)
     result = expr.compile()
     expected = """\
 SELECT *
-FROM `ibis-gbq.testing.functional_alltypes`
+FROM `{project}.testing.functional_alltypes`
 UNION {}
 SELECT *
-FROM `ibis-gbq.testing.functional_alltypes`""".format(expected_keyword)
+FROM `{project}.testing.functional_alltypes`""".format(
+        expected_keyword, project=project_id)
     assert result == expected
 
 
-def test_ieee_divide(alltypes):
+def test_ieee_divide(alltypes, project_id):
     expr = alltypes.double_col / 0
     result = expr.compile()
     expected = """\
 SELECT IEEE_DIVIDE(`double_col`, 0) AS `tmp`
-FROM `ibis-gbq.testing.functional_alltypes`"""
+FROM `{}.testing.functional_alltypes`""".format(project_id)
     assert result == expected
 
 
-def test_identical_to(alltypes):
+def test_identical_to(alltypes, project_id):
     t = alltypes
     pred = t.string_col.identical_to('a') & t.date_string_col.identical_to('b')
     expr = t[pred]
     result = expr.compile()
     expected = """\
 SELECT *
-FROM `ibis-gbq.testing.functional_alltypes`
+FROM `{}.testing.functional_alltypes`
 WHERE (((`string_col` IS NULL) AND ('a' IS NULL)) OR (`string_col` = 'a')) AND
-      (((`date_string_col` IS NULL) AND ('b' IS NULL)) OR (`date_string_col` = 'b'))"""  # noqa: E501
+      (((`date_string_col` IS NULL) AND ('b' IS NULL)) OR (`date_string_col` = 'b'))""".format(  # noqa: E501
+        project_id)
     assert result == expected
 
 
@@ -72,17 +74,17 @@ WHERE (((`string_col` IS NULL) AND ('a' IS NULL)) OR (`string_col` = 'a')) AND
         'America/New_York'
     ]
 )
-def test_to_timestamp(alltypes, timezone):
+def test_to_timestamp(alltypes, timezone, project_id):
     expr = alltypes.date_string_col.to_timestamp('%F', timezone)
     result = expr.compile()
     if timezone:
         expected = """\
 SELECT PARSE_TIMESTAMP('%F', `date_string_col`, 'America/New_York') AS `tmp`
-FROM `ibis-gbq.testing.functional_alltypes`"""
+FROM `{}.testing.functional_alltypes`""".format(project_id)
     else:
         expected = """\
 SELECT PARSE_TIMESTAMP('%F', `date_string_col`) AS `tmp`
-FROM `ibis-gbq.testing.functional_alltypes`"""
+FROM `{}.testing.functional_alltypes`""".format(project_id)
     assert result == expected
 
 
@@ -210,7 +212,7 @@ def test_literal_timestamp_or_time(case, expected, dtype):
     assert result == "SELECT EXTRACT(hour from {}) AS `tmp`".format(expected)
 
 
-def test_window_function(alltypes):
+def test_window_function(alltypes, project_id):
     t = alltypes
     w1 = ibis.window(preceding=1, following=0,
                      group_by='year', order_by='timestamp_col')
@@ -219,7 +221,7 @@ def test_window_function(alltypes):
     expected = """\
 SELECT *,
        avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS `win_avg`
-FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+FROM `{}.testing.functional_alltypes`""".format(project_id)  # noqa: E501
     assert result == expected
 
     w2 = ibis.window(preceding=0, following=2,
@@ -229,7 +231,7 @@ FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     expected = """\
 SELECT *,
        avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING) AS `win_avg`
-FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+FROM `{}.testing.functional_alltypes`""".format(project_id)  # noqa: E501
     assert result == expected
 
     w3 = ibis.window(preceding=(4, 2),
@@ -239,11 +241,11 @@ FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     expected = """\
 SELECT *,
        avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `timestamp_col` ROWS BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`
-FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+FROM `{}.testing.functional_alltypes`""".format(project_id)  # noqa: E501
     assert result == expected
 
 
-def test_range_window_function(alltypes):
+def test_range_window_function(alltypes, project_id):
     t = alltypes
     w = ibis.range_window(preceding=1, following=0,
                           group_by='year', order_by='month')
@@ -252,7 +254,7 @@ def test_range_window_function(alltypes):
     expected = """\
 SELECT *,
        avg(`float_col`) OVER (PARTITION BY `year` ORDER BY `month` RANGE BETWEEN 1 PRECEDING AND CURRENT ROW) AS `two_month_avg`
-FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+FROM `{}.testing.functional_alltypes`""".format(project_id)  # noqa: E501
     assert result == expected
 
     w3 = ibis.range_window(preceding=(4, 2),
@@ -262,7 +264,7 @@ FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
     expected = """\
 SELECT *,
        avg(`float_col`) OVER (PARTITION BY `year` ORDER BY UNIX_MICROS(`timestamp_col`) RANGE BETWEEN 4 PRECEDING AND 2 PRECEDING) AS `win_avg`
-FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+FROM `{}.testing.functional_alltypes`""".format(project_id)  # noqa: E501
     assert result == expected
 
 
@@ -280,7 +282,7 @@ FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
         (ibis.week(), 1000000 * 60 * 60 * 24 * 7),
     ]
 )
-def test_trailing_range_window(alltypes, preceding, value):
+def test_trailing_range_window(alltypes, preceding, value, project_id):
     t = alltypes
     w = ibis.trailing_range_window(preceding=preceding,
                                    order_by=t.timestamp_col)
@@ -289,7 +291,8 @@ def test_trailing_range_window(alltypes, preceding, value):
     expected = """\
 SELECT *,
        avg(`float_col`) OVER (ORDER BY UNIX_MICROS(`timestamp_col`) RANGE BETWEEN {} PRECEDING AND CURRENT ROW) AS `win_avg`
-FROM `ibis-gbq.testing.functional_alltypes`""".format(value)  # noqa: E501
+FROM `{}.testing.functional_alltypes`""".format(  # noqa: E501
+        value, project_id)
     assert result == expected
 
 
@@ -317,7 +320,8 @@ def test_trailing_range_window_unsupported(alltypes, preceding, value):
         (False, False, 'UNION ALL', 'UNION ALL'),
     ]
 )
-def test_union_cte(alltypes, distinct1, distinct2, expected1, expected2):
+def test_union_cte(
+        alltypes, distinct1, distinct2, expected1, expected2, project_id):
     t = alltypes
     expr1 = t.group_by(t.string_col).aggregate(metric=t.double_col.sum())
     expr2 = expr1.view()
@@ -328,17 +332,17 @@ def test_union_cte(alltypes, distinct1, distinct2, expected1, expected2):
     expected = """\
 WITH t0 AS (
   SELECT `string_col`, sum(`double_col`) AS `metric`
-  FROM `ibis-gbq.testing.functional_alltypes`
+  FROM `{project}.testing.functional_alltypes`
   GROUP BY 1
 )
 SELECT *
 FROM t0
 {}
 SELECT `string_col`, sum(`double_col`) AS `metric`
-FROM `ibis-gbq.testing.functional_alltypes`
+FROM `{project}.testing.functional_alltypes`
 GROUP BY 1
 {}
 SELECT `string_col`, sum(`double_col`) AS `metric`
-FROM `ibis-gbq.testing.functional_alltypes`
-GROUP BY 1""".format(expected1, expected2)
+FROM `{project}.testing.functional_alltypes`
+GROUP BY 1""".format(expected1, expected2, project=project_id)
     assert result == expected


### PR DESCRIPTION
This allows you to run ./ci/datamgr.py bigquery to create a test
database for the BigQuery integrations. You no longer need to access the
ibis-gbq GCP project to run the tests.