### PR TITLE
ENH/BUG: Fix broken decimal type support

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -qq update -y \
 ARG PYTHON
 ARG ENVKIND
 
-ADD ci/requirements-${ENVKIND}-${PYTHON}.yml /
+COPY ci/requirements-${ENVKIND}-${PYTHON}.yml /
 
 RUN conda env create -q -n ibis-${ENVKIND}-${PYTHON} -f /requirements-${ENVKIND}-${PYTHON}.yml \
  && conda install conda-build -y -q
@@ -20,7 +20,7 @@ RUN conda env create -q -n ibis-${ENVKIND}-${PYTHON} -f /requirements-${ENVKIND}
 
 RUN echo 'source activate ibis-'${ENVKIND}-${PYTHON}' && exec "$@"' > activate.sh
 
-ADD . /ibis
+COPY . /ibis
 WORKDIR /ibis
 RUN bash /activate.sh python setup.py develop
 

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -370,7 +370,7 @@ class Decimal(DataType):
 
     @property
     def largest(self):
-        return Decimal(self.precision, 38)
+        return Decimal(38, self.scale)
 
 
 assert hasattr(Decimal, '__hash__')

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -1,12 +1,13 @@
-import re
-import six
-import toolz
+import collections
 import datetime
 import itertools
-import collections
+import numbers
+import re
+
+import six
 import pandas as pd
-from functools import partial
-from collections import namedtuple, OrderedDict
+
+import toolz
 from multipledispatch import Dispatcher
 
 import ibis.common as com
@@ -87,10 +88,10 @@ class DataType(object):
         return cast(self, target, **kwargs)
 
     def scalar_type(self):
-        return partial(self.scalar, dtype=self)
+        return functools.partial(self.scalar, dtype=self)
 
     def array_type(self):
-        return partial(self.column, dtype=self)
+        return functools.partial(self.column, dtype=self)
 
 
 class Any(DataType):
@@ -128,7 +129,7 @@ class Boolean(Primitive):
     __slots__ = ()
 
 
-Bounds = namedtuple('Bounds', ('lower', 'upper'))
+Bounds = collections.namedtuple('Bounds', ('lower', 'upper'))
 
 
 class Integer(Primitive):
@@ -487,7 +488,7 @@ class Struct(DataType):
             raise ValueError('names and types must have the same length')
 
         super(Struct, self).__init__(nullable=nullable)
-        self.pairs = OrderedDict(zip(names, types))
+        self.pairs = collections.OrderedDict(zip(names, types))
 
     @classmethod
     def from_tuples(self, pairs):
@@ -701,14 +702,14 @@ _token_names = dict(
 )
 
 
-Token = namedtuple('Token', ('type', 'value'))
+Token = collections.namedtuple('Token', ('type', 'value'))
 
 
 # Adapted from tokenize.String
 _STRING_REGEX = """('[^\n'\\\\]*(?:\\\\.[^\n'\\\\]*)*'|"[^\n"\\\\"]*(?:\\\\.[^\n"\\\\]*)*")"""  # noqa: E501
 
 
-_TYPE_RULES = OrderedDict(
+_TYPE_RULES = collections.OrderedDict(
     [
         # any, null, bool|boolean
         ('(?P<ANY>any)', lambda token: Token(Tokens.ANY, any)),
@@ -1111,7 +1112,7 @@ def infer_dtype_default(value):
     raise com.InputTypeError(value)
 
 
-@infer.register(OrderedDict)
+@infer.register(collections.OrderedDict)
 def infer_struct(value):
     if not value:
         raise TypeError('Empty struct type not supported')

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -335,6 +335,24 @@ class Decimal(DataType):
     __slots__ = 'precision', 'scale'
 
     def __init__(self, precision, scale, nullable=True):
+        if not isinstance(precision, numbers.Integral):
+            raise TypeError('Decimal type precision must be an integer')
+        if not isinstance(scale, numbers.Integral):
+            raise TypeError('Decimal type scale must be an integer')
+        if precision < 0:
+            raise ValueError('Decimal type precision cannot be negative')
+        if not precision:
+            raise ValueError('Decimal type precision cannot be zero')
+        if scale < 0:
+            raise ValueError('Decimal type scale cannot be negative')
+        if precision < scale:
+            raise ValueError(
+                'Decimal type precision must be greater than or equal to '
+                'scale. Got precision={:d} and scale={:d}'.format(
+                    precision, scale
+                )
+            )
+
         super(Decimal, self).__init__(nullable=nullable)
         self.precision = precision
         self.scale = scale

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -808,7 +808,7 @@ class Mean(Reduction):
 
     def output_type(self):
         if isinstance(self.arg, ir.DecimalValue):
-            dtype = self.arg.type().largest
+            dtype = self.arg.type()
         else:
             dtype = dt.float64
         return dtype.scalar_type()

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -498,7 +498,7 @@ class MathUnaryOp(UnaryOp):
 class ExpandingTypeMathUnaryOp(MathUnaryOp):
     def output_type(self):
         if not isinstance(self.arg, ir.DecimalValue):
-            return super().output_type()
+            return super(ExpandingTypeMathUnaryOp, self).output_type()
         arg = self.arg
         return rlz.shape_like(arg, arg.type().largest)
 

--- a/ibis/expr/tests/test_decimal.py
+++ b/ibis/expr/tests/test_decimal.py
@@ -101,7 +101,7 @@ def test_invalid_precision_scale_combo(precision, scale):
     ]
 )
 def test_invalid_precision_scale_type(precision, scale):
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         dt.Decimal(precision, scale)
 
 

--- a/ibis/impala/tests/test_exprs.py
+++ b/ibis/impala/tests/test_exprs.py
@@ -1261,28 +1261,27 @@ def test_decimal_builtins(con, expr, expected):
     assert result == expected, to_sql(expr)
 
 
-def test_decimal_builtins_2(con):
-    d = L('5.245')
-    dc = d.cast('decimal(12, 5)')
-    cases = [
-        (dc % 5, 0.245),
-
-        (dc.fillna(0), 5.245),
-
-        (dc.exp(), 189.6158),
-        (dc.log(), 1.65728),
-        (dc.log2(), 2.39094),
-        (dc.log10(), 0.71975),
-        (dc.sqrt(), 2.29019),
-        (dc.zeroifnull(), 5.245),
-        (-dc, -5.245)
+@pytest.mark.parametrize(
+    ('func', 'expected'),
+    [
+        pytest.param(lambda dc: dc, '5.245', id='id'),
+        pytest.param(lambda dc: dc % 5, '0.245', id='mod'),
+        pytest.param(lambda dc: dc.fillna(0), '5.245', id='fillna'),
+        pytest.param(lambda dc: dc.exp(), '189.6158', id='exp'),
+        pytest.param(lambda dc: dc.log(), '1.65728', id='log'),
+        pytest.param(lambda dc: dc.log2(), '2.39094', id='log2'),
+        pytest.param(lambda dc: dc.log10(), '0.71975', id='log10'),
+        pytest.param(lambda dc: dc.sqrt(), '2.29019', id='sqrt'),
+        pytest.param(lambda dc: dc.zeroifnull(), '5.245', id='zeroifnull'),
+        pytest.param(lambda dc: -dc, '-5.245', id='neg'),
     ]
-
-    for expr, expected in cases:
-        result = con.execute(expr)
-        tol = 0.0001
-
-        approx_equal(result, expected, tol)
+)
+def test_decimal_builtins_2(con, func, expected):
+    dc = L('5.245').cast('decimal(12, 5)')
+    expr = func(dc)
+    result = con.execute(expr)
+    tol = Decimal('0.0001')
+    approx_equal(Decimal(result), Decimal(expected), tol)
 
 
 @pytest.mark.parametrize(

--- a/ibis/pandas/client.py
+++ b/ibis/pandas/client.py
@@ -53,7 +53,7 @@ _ibis_dtypes = toolz.valmap(
         dt.UInt64: np.uint64,
         dt.Float32: np.float32,
         dt.Float64: np.float64,
-        dt.Decimal: np.float64,
+        dt.Decimal: np.object_,
         dt.Struct: np.object_,
     }
 )


### PR DESCRIPTION
There are a number of places where we are computing the incorrect `output_type` for some operations as well as computing a `float64` output type for operations whose inputs are decimals. Impala explicitly does this and so does BigQuery. The upshot of this is that when `schema.apply_to(result)` is called in these backends we will convert the data (which will be `float64` `Series` objects) into `Decimal` columns.