### PR TITLE
Upgrade SQLAlchemy dependency to latest version

### DIFF
--- a/ci/requirements-dev-2.7.yml
+++ b/ci/requirements-dev-2.7.yml
@@ -36,7 +36,7 @@ dependencies:
   - requests
   - ruamel.yaml
   - six
-  - sqlalchemy>=1.0.0,<1.1.15
+  - sqlalchemy
   - thriftpy<=0.3.9
   - thrift<=0.9.3
   - toolz

--- a/ci/requirements-dev-3.5.yml
+++ b/ci/requirements-dev-3.5.yml
@@ -31,7 +31,7 @@ dependencies:
   - requests
   - ruamel.yaml
   - six
-  - sqlalchemy>=1.0.0,<1.1.15
+  - sqlalchemy
   - toolz
   - xorg-libxpm
   - xorg-libxrender

--- a/ci/requirements-dev-3.6.yml
+++ b/ci/requirements-dev-3.6.yml
@@ -32,7 +32,7 @@ dependencies:
   - requests
   - ruamel.yaml
   - six
-  - sqlalchemy>=1.0.0,<1.1.15
+  - sqlalchemy
   - thrift
   - toolz
   - xorg-libxpm

--- a/ci/requirements-docs-3.6.yml
+++ b/ci/requirements-docs-3.6.yml
@@ -38,7 +38,7 @@ dependencies:
   - ruamel.yaml
   - six
   - sphinx_rtd_theme<0.3
-  - sqlalchemy>=1.0.0,<1.1.15
+  - sqlalchemy
   - thrift
   - toolz
   - xorg-libxpm

--- a/ibis/sql/sqlite/client.py
+++ b/ibis/sql/sqlite/client.py
@@ -336,7 +336,7 @@ class SQLiteClient(alch.AlchemyClient):
     def __init__(self, path=None, create=False):
         super(SQLiteClient, self).__init__(sa.create_engine('sqlite://'))
         self.name = path
-        self.database_name = 'default'
+        self.database_name = 'base'
 
         if path is not None:
             self.attach(self.database_name, path, create=create)

--- a/ibis/sql/sqlite/tests/test_client.py
+++ b/ibis/sql/sqlite/tests/test_client.py
@@ -1,17 +1,3 @@
-# Copyright 2015 Cloudera Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 import os
 import uuid
 
@@ -50,7 +36,7 @@ def test_table(con):
     assert isinstance(table, ir.TableExpr)
 
 
-def test_array_execute(alltypes, df):
+def test_column_execute(alltypes, df):
     expr = alltypes.double_col
     result = expr.execute()
     expected = df.double_col

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -833,5 +833,5 @@ def test_count_on_order_by(db):
         expr.compile().compile(compile_kwargs={'literal_binds': True})
     )
     expected = ('SELECT count(\'*\') AS count \n'
-                'FROM "default".batting AS t0')  # noqa: W291
+                'FROM base.batting AS t0')  # noqa: W291
     assert result == expected

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ See http://ibis-project.org
 impala_requires = [
     'hdfs>=2.0.16',
     'impyla>=0.14.0',
-    'sqlalchemy>=1.0.0,<1.1.15',
+    'sqlalchemy',
     'requests',
 ]
 
-sqlite_requires = ['sqlalchemy>=1.0.0,<1.1.15']
+sqlite_requires = ['sqlalchemy']
 postgres_requires = sqlite_requires + ['psycopg2']
 mysql_requires = sqlite_requires + ['pymysql']
 mapd_requires = ['pymapd']


### PR DESCRIPTION
This exposed a bug fixed here: https://github.com/zzzeek/sqlalchemy/pull/463

The solution to avoid a large dependency version gap is to use a
different name than "default" (because "default" is a keyword in SQLite)
for the default database

Closes #1384