### PR TITLE
ENH/BUG: pre_execute one additional time in window functions in the pandas backend

### DIFF
--- a/ibis/pandas/client.py
+++ b/ibis/pandas/client.py
@@ -347,7 +347,9 @@ class PandasClient(client.Client):
         schema = sch.infer(df, schema=schema)
         return PandasTable(name, schema, self).to_expr()
 
-    def execute(self, query, params=None, limit='default', async=False):
+    def execute(
+        self, query, params=None, limit='default', async=False, **kwargs
+    ):
         from ibis.pandas.core import execute_and_reset
 
         if limit != 'default':
@@ -362,7 +364,7 @@ class PandasClient(client.Client):
             )
 
         assert isinstance(query, ir.Expr)
-        return execute_and_reset(query, params=params)
+        return execute_and_reset(query, params=params, **kwargs)
 
     def compile(self, expr, *args, **kwargs):
         return expr

--- a/ibis/pandas/execution/generic.py
+++ b/ibis/pandas/execution/generic.py
@@ -370,7 +370,7 @@ def execute_aggregation_dataframe(op, data, scope=None, **kwargs):
     if predicates:
         predicate = functools.reduce(
             operator.and_,
-            (execute(p, scope, **kwargs) for p in predicates)
+            (execute(p, scope=scope, **kwargs) for p in predicates)
         )
         data = data.loc[predicate]
 
@@ -382,7 +382,7 @@ def execute_aggregation_dataframe(op, data, scope=None, **kwargs):
         )
         grouping_keys = [
             by_op.name if isinstance(by_op, ops.TableColumn)
-            else execute(by, scope, **kwargs).rename(by.get_name())
+            else execute(by, scope=scope, **kwargs).rename(by.get_name())
             for by, by_op in grouping_key_pairs
         ]
         columns.update(
@@ -395,7 +395,8 @@ def execute_aggregation_dataframe(op, data, scope=None, **kwargs):
 
     new_scope = toolz.merge(scope, {op.table.op(): source})
     pieces = [
-        pd.Series(execute(metric, new_scope, **kwargs), name=metric.get_name())
+        pd.Series(
+            execute(metric, scope=new_scope, **kwargs), name=metric.get_name())
         for metric in op.metrics
     ]
 
@@ -415,7 +416,8 @@ def execute_aggregation_dataframe(op, data, scope=None, **kwargs):
         # TODO(phillipc): Don't recompute identical subexpressions
         predicate = functools.reduce(
             operator.and_,
-            (execute(having, new_scope, **kwargs) for having in op.having)
+            (execute(having, scope=new_scope, **kwargs)
+             for having in op.having)
         )
         assert len(predicate) == len(result), \
             'length of predicate does not match length of DataFrame'

--- a/ibis/pandas/execution/selection.py
+++ b/ibis/pandas/execution/selection.py
@@ -70,7 +70,7 @@ def compute_projection_scalar_expr(expr, parent, data, scope=None, **kwargs):
     )
 
     new_scope = toolz.merge(scope, additional_scope, factory=OrderedDict)
-    scalar = execute(expr, new_scope, **kwargs)
+    scalar = execute(expr, scope=new_scope, **kwargs)
     result = pd.Series([scalar], name=name).repeat(len(data.index))
     result.index = data.index
     return result
@@ -111,7 +111,7 @@ def compute_projection_column_expr(expr, parent, data, scope=None, **kwargs):
     }
 
     new_scope = toolz.merge(scope, additional_scope)
-    result = execute(expr, new_scope, **kwargs)
+    result = execute(expr, scope=new_scope, **kwargs)
     assert result_name is not None, 'Column selection name is None'
     return result.rename(result_name)
 
@@ -219,7 +219,7 @@ def _compute_predicates(table_op, predicates, data, scope, **kwargs):
             additional_scope[root_table] = new_data
 
         new_scope = toolz.merge(scope, additional_scope)
-        yield execute(predicate, new_scope, **kwargs)
+        yield execute(predicate, scope=new_scope, **kwargs)
 
 
 physical_tables = Dispatcher(

--- a/ibis/pandas/execution/util.py
+++ b/ibis/pandas/execution/util.py
@@ -10,7 +10,7 @@ import ibis.common as com
 from ibis.pandas.core import execute
 
 
-def compute_sort_key(key, data, **kwargs):
+def compute_sort_key(key, data, scope=None, **kwargs):
     by = key.to_expr()
     try:
         if isinstance(by, six.string_types):
@@ -18,7 +18,7 @@ def compute_sort_key(key, data, **kwargs):
         return by.get_name(), None
     except com.ExpressionError:
         new_scope = {t: data for t in by.op().root_tables()}
-        new_column = execute(by, new_scope, **kwargs)
+        new_column = execute(by, scope=toolz.merge(scope, new_scope), **kwargs)
         name = ibis.util.guid()
         new_column.name = name
         return name, new_column


### PR DESCRIPTION
- fixes a bug, which is that we were passing scope to the params argument instead of passing to scope.
- adds the ability to pre_execute at the beginning of a window operation
- removes the restriction on the `following` parameter to window specificiations for lag/lead functions