### PR TITLE
ENH/BUG: Default to closed intervals in the pandas backend for time based windows and fix a bug in projections in the pandas backend

### DIFF
--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -372,9 +372,14 @@ class Moving(Window):
     __slots__ = ()
 
     def __init__(self, preceding, *args, **kwargs):
+        from ibis.pandas.core import timedelta_types
         dtype = getattr(preceding, 'type', lambda: None)()
         preceding = compute_window_spec(preceding, dtype)
-        super(Moving, self).__init__('rolling', preceding, *args, **kwargs)
+        closed = None if not isinstance(
+            preceding, timedelta_types + (pd.offsets.BaseOffset,)) else 'both'
+        super(Moving, self).__init__(
+            'rolling', preceding, *args, closed=closed, **kwargs
+        )
 
     def short_circuit_method(self, grouped_data, function):
         raise AttributeError('No short circuit method for rolling operations')

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -376,7 +376,7 @@ class Moving(Window):
         dtype = getattr(preceding, 'type', lambda: None)()
         preceding = compute_window_spec(preceding, dtype)
         closed = None if not isinstance(
-            preceding, timedelta_types + (pd.offsets.BaseOffset,)) else 'both'
+            preceding, timedelta_types + (pd.offsets.DateOffset,)) else 'both'
         super(Moving, self).__init__(
             'rolling', preceding, *args, closed=closed, **kwargs
         )

--- a/ibis/pandas/execution/tests/test_operations.py
+++ b/ibis/pandas/execution/tests/test_operations.py
@@ -61,12 +61,15 @@ def test_project_scope_does_not_override(t, df):
         col.sum().over(ibis.window(group_by='dup_strings')).name('grouped')
     ]]
     result = expr.execute()
-    expected = df[['plain_int64', 'dup_strings']].assign(
-        new_col=lambda df: df.plain_int64,
-        grouped=lambda df: (
+    expected = pd.concat(
+        [
+            df[['plain_int64', 'dup_strings']].rename(
+                columns={'plain_int64': 'new_col'}),
             df.groupby('dup_strings').plain_int64.transform('sum').reset_index(
-                drop=True))
-    )
+                drop=True).rename('grouped')
+        ],
+        axis=1
+    )[['new_col', 'grouped']]
     tm.assert_frame_equal(result, expected)
 
 

--- a/ibis/pandas/execution/tests/test_operations.py
+++ b/ibis/pandas/execution/tests/test_operations.py
@@ -67,7 +67,7 @@ def test_project_scope_does_not_override(t, df):
             df.groupby('dup_strings').plain_int64.transform('sum').reset_index(
                 drop=True))
     )
-    tm.assert_result_equals(result, expected)
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -397,8 +397,8 @@ def test_window_with_preceding_expr():
     df = pd.DataFrame({'value': data, 'time': index}, index=index)
     client = ibis.pandas.connect({'df': df})
     t = client.table('df')
-    expected = df.set_index('time').value.rolling('3d').mean().reset_index(
-        drop=True)
+    expected = df.set_index('time').value.rolling(
+        '3d', closed='both').mean().reset_index(drop=True)
     expected.index.name = None
     day = ibis.day()
     window = ibis.trailing_window(3 * day, order_by=t.time)


### PR DESCRIPTION
Using `'closed'` for the default for rolling windows here makes pandas behave consistently with SQL engines.