### PR TITLE
ENH/BLD: Pass docker-compose file explicitly

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,17 +3,17 @@
 compose_file=$(dirname "$0")/docker-compose.yml
 
 # stop all running docker compose services
-docker-compose -f $compose_file rm --force --stop
+docker-compose -f "$compose_file" rm --force --stop
 
 # build the ibis image
-docker-compose -f $compose_file build --pull ibis
+docker-compose -f "$compose_file" build --pull ibis
 
 # start all docker compose services
-docker-compose -f $compose_file up -d --no-build \
+docker-compose -f "$compose_file" up -d --no-build \
     mapd postgres mysql clickhouse impala kudu-master kudu-tserver
 
 # wait for services to start
-docker-compose -f $compose_file run --rm waiter
+docker-compose -f "$compose_file" run --rm waiter
 
 # load data
-docker-compose -f $compose_file run -e LOGLEVEL --rm ibis ci/load-data.sh
+docker-compose -f "$compose_file" run -e LOGLEVEL --rm ibis ci/load-data.sh

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,17 +1,19 @@
 #!/bin/bash -e
 
+compose_file=$(dirname "$0")/docker-compose.yml
+
 # stop all running docker compose services
-docker-compose rm --force --stop
+docker-compose -f $compose_file rm --force --stop
 
 # build the ibis image
-docker-compose build --pull ibis
+docker-compose -f $compose_file build --pull ibis
 
 # start all docker compose services
-docker-compose up -d --no-build \
+docker-compose -f $compose_file up -d --no-build \
     mapd postgres mysql clickhouse impala kudu-master kudu-tserver
 
 # wait for services to start
-docker-compose run --rm waiter
+docker-compose -f $compose_file run --rm waiter
 
 # load data
-docker-compose run -e LOGLEVEL --rm ibis ci/load-data.sh
+docker-compose -f $compose_file run -e LOGLEVEL --rm ibis ci/load-data.sh

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -13,13 +13,13 @@ services:
     ports:
       - 3306:3306
     environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=1
-      - MYSQL_DATABASE=ibis_testing
-      - MYSQL_USER=ibis
-      - MYSQL_PASSWORD=ibis
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+      MYSQL_DATABASE: ibis_testing
+      MYSQL_USER: ibis
+      MYSQL_PASSWORD: ibis
 
   impala:
-    image: ibisproject/impala
+    image: impala
     hostname: impala
     networks:
       default:
@@ -63,9 +63,6 @@ services:
       - 8051:8051
     environment:
       KUDU_MASTER: "true"
-    volumes:
-      - /etc/timezone:/etc/timezone:ro
-      - /etc/localtime:/etc/localtime:ro
 
   kudu-tserver:
     image: ibisproject/kudu:latest
@@ -76,9 +73,6 @@ services:
       - 8050:8050
     environment:
       KUDU_MASTER: "false"
-    volumes:
-      - /etc/timezone:/etc/timezone:ro
-      - /etc/localtime:/etc/localtime:ro
 
   mapd:
     image: mapd/mapd-ce-cpu:v3.6.0
@@ -111,34 +105,34 @@ services:
   ibis:
     image: ibis:${PYTHON_VERSION:-3.6}
     environment:
-      - IBIS_TEST_DOWNLOAD_DIRECTORY=/tmp
-      - IBIS_TEST_DATA_DIRECTORY=/tmp/ibis-testing-data
-      - IBIS_TEST_SQLITE_DATABASE=/tmp/ibis_testing.db
-      - IBIS_TEST_NN_HOST=impala
-      - IBIS_TEST_IMPALA_HOST=impala
-      - IBIS_TEST_IMPALA_PORT=21050
-      - IBIS_TEST_WEBHDFS_PORT=50070
-      - IBIS_TEST_WEBHDFS_USER=hdfs
-      - IBIS_TEST_MYSQL_HOST=mysql
-      - IBIS_TEST_MYSQL_PORT=3306
-      - IBIS_TEST_MYSQL_USER=ibis
-      - IBIS_TEST_MYSQL_PASSWORD=ibis
-      - IBIS_TEST_MYSQL_DATABASE=ibis_testing
-      - IBIS_TEST_POSTGRES_HOST=postgres
-      - IBIS_TEST_POSTGRES_PORT=5432
-      - IBIS_TEST_POSTGRES_USER=postgres
-      - IBIS_TEST_POSTGRES_PASSWORD=postgres
-      - IBIS_TEST_POSTGRES_DATABASE=ibis_testing
-      - IBIS_TEST_CLICKHOUSE_HOST=clickhouse
-      - IBIS_TEST_CLICKHOUSE_PORT=9000
-      - IBIS_TEST_CLICKHOUSE_DATABASE=ibis_testing
-      - IBIS_TEST_MAPD_HOST=mapd
-      - IBIS_TEST_MAPD_PORT=9091
-      - IBIS_TEST_MAPD_DATABASE=ibis_testing
-      - IBIS_TEST_MAPD_USER=mapd
-      - IBIS_TEST_MAPD_PASSWORD=HyperInteractive
-      - GOOGLE_BIGQUERY_PROJECT_ID=ibis-gbq
-      - GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcloud-service-key.json
+      IBIS_TEST_DOWNLOAD_DIRECTORY: /tmp
+      IBIS_TEST_DATA_DIRECTORY: /tmp/ibis-testing-data
+      IBIS_TEST_SQLITE_DATABASE: /tmp/ibis_testing.db
+      IBIS_TEST_NN_HOST: impala
+      IBIS_TEST_IMPALA_HOST: impala
+      IBIS_TEST_IMPALA_PORT: 21050
+      IBIS_TEST_WEBHDFS_PORT: 50070
+      IBIS_TEST_WEBHDFS_USER: hdfs
+      IBIS_TEST_MYSQL_HOST: mysql
+      IBIS_TEST_MYSQL_PORT: 3306
+      IBIS_TEST_MYSQL_USER: ibis
+      IBIS_TEST_MYSQL_PASSWORD: ibis
+      IBIS_TEST_MYSQL_DATABASE: ibis_testing
+      IBIS_TEST_POSTGRES_HOST: postgres
+      IBIS_TEST_POSTGRES_PORT: 5432
+      IBIS_TEST_POSTGRES_USER: postgres
+      IBIS_TEST_POSTGRES_PASSWORD: postgres
+      IBIS_TEST_POSTGRES_DATABASE: ibis_testing
+      IBIS_TEST_CLICKHOUSE_HOST: clickhouse
+      IBIS_TEST_CLICKHOUSE_PORT: 9000
+      IBIS_TEST_CLICKHOUSE_DATABASE: ibis_testing
+      IBIS_TEST_MAPD_HOST: mapd
+      IBIS_TEST_MAPD_PORT: 9091
+      IBIS_TEST_MAPD_DATABASE: ibis_testing
+      IBIS_TEST_MAPD_USER: mapd
+      IBIS_TEST_MAPD_PASSWORD: HyperInteractive
+      GOOGLE_BIGQUERY_PROJECT_ID: ibis-gbq
+      GOOGLE_APPLICATION_CREDENTIALS: /tmp/gcloud-service-key.json
     volumes:
       - /tmp/ibis:/tmp
     build:

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       MYSQL_PASSWORD: ibis
 
   impala:
-    image: impala
+    image: ibisproject/impala
     hostname: impala
     networks:
       default:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,5 +3,5 @@
 compose_file=$(dirname "$0")/docker-compose.yml
 
 cmd='$(find /ibis -name "*.py[co]" -delete > /dev/null 2>&1 || true) && pytest "$@"'
-docker-compose -f $compose_file build --pull ibis
-docker-compose -f $compose_file run --rm ibis bash -c "$cmd" -- "$@"
+docker-compose -f "$compose_file" build --pull ibis
+docker-compose -f "$compose_file" run --rm ibis bash -c "$cmd" -- "$@"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+compose_file=$(dirname "$0")/docker-compose.yml
+
 cmd='$(find /ibis -name "*.py[co]" -delete > /dev/null 2>&1 || true) && pytest "$@"'
-docker-compose build --pull ibis
-docker-compose run --rm ibis bash -c "$cmd" -- "$@"
+docker-compose -f $compose_file build --pull ibis
+docker-compose -f $compose_file run --rm ibis bash -c "$cmd" -- "$@"


### PR DESCRIPTION
Don't need to `cd` into `ibis/ci` to run build and test scripts.