### PR TITLE
ENH/BUG: Fix temporal truncation

### DIFF
--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -308,13 +308,15 @@ _timestamp_units.update(_date_units)
 
 def _truncate(kind, units):
     def truncator(translator, expr):
-        op = expr.op()
-        arg, unit = op.args
-
+        arg, unit = expr.op().args
         trans_arg = translator.translate(arg)
-        unit = units.get(unit)
-        assert unit is not None, 'unit {!r} not in {}'.format(unit, units)
-        return '{}_TRUNC({}, {})'.format(kind, trans_arg, unit)
+        valid_unit = units.get(unit)
+        if valid_unit is None:
+            raise com.UnsupportedOperationError(
+                'BigQuery does not support truncating {} values to unit '
+                '{!r}'.format(arg.type(), unit)
+            )
+        return '{}_TRUNC({}, {})'.format(kind, trans_arg, valid_unit)
     return truncator
 
 

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -395,6 +395,8 @@ _operation_registry.update({
     ops.DateTruncate: _truncate('DATE', _date_units),
     ops.TimeTruncate: _truncate('TIME', _timestamp_units),
 
+    ops.Time: _extract_field('TIME'),
+
     ops.TimestampAdd: _timestamp_op(
         'TIMESTAMP_ADD', {'h', 'm', 's', 'ms', 'us'}),
     ops.TimestampSub: _timestamp_op(

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -395,7 +395,7 @@ _operation_registry.update({
     ops.DateTruncate: _truncate('DATE', _date_units),
     ops.TimeTruncate: _truncate('TIME', _timestamp_units),
 
-    ops.Time: _extract_field('TIME'),
+    ops.Time: unary('TIME'),
 
     ops.TimestampAdd: _timestamp_op(
         'TIMESTAMP_ADD', {'h', 'm', 's', 'ms', 'us'}),

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -5,6 +5,7 @@ import pytest
 import pandas as pd
 
 import ibis
+import ibis.common as com
 import ibis.expr.datatypes as dt
 
 
@@ -437,4 +438,69 @@ FROM `ibis-gbq.testing.functional_alltypes`"""
     expected = """\
 SELECT APPROX_COUNT_DISTINCT(CASE WHEN `month` > 6 THEN `bool_col` ELSE NULL END) AS `approx_nunique`
 FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ('unit', 'expected_unit'),
+    [
+        ('Y', 'YEAR'),
+        ('Q', 'QUARTER'),
+        ('M', 'MONTH'),
+        ('W', 'WEEK'),
+        ('D', 'DAY'),
+        ('h', 'HOUR'),
+        ('m', 'MINUTE'),
+        ('s', 'SECOND'),
+        ('ms', 'MILLISECOND'),
+        ('us', 'MICROSECOND'),
+    ]
+)
+def test_timestamp_truncate(unit, expected_unit):
+    t = ibis.table([('a', dt.timestamp)], name='t')
+    expr = t.a.truncate(unit)
+    result = ibis.bigquery.compile(expr)
+    expected = """\
+SELECT TIMESTAMP_TRUNC(`a`, {}) AS `tmp`
+FROM t""".format(expected_unit)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ('unit', 'expected_unit'),
+    [
+        ('Y', 'YEAR'),
+        ('Q', 'QUARTER'),
+        ('M', 'MONTH'),
+        ('W', 'WEEK'),
+        ('D', 'DAY'),
+    ]
+)
+def test_date_truncate(unit, expected_unit):
+    t = ibis.table([('a', dt.date)], name='t')
+    expr = t.a.truncate(unit)
+    result = ibis.bigquery.compile(expr)
+    expected = """\
+SELECT DATE_TRUNC(`a`, {}) AS `tmp`
+FROM t""".format(expected_unit)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ('unit', 'expected_unit'),
+    [
+        ('h', 'HOUR'),
+        ('m', 'MINUTE'),
+        ('s', 'SECOND'),
+        ('ms', 'MILLISECOND'),
+        ('us', 'MICROSECOND'),
+    ]
+)
+def test_time_truncate(unit, expected_unit):
+    t = ibis.table([('a', dt.time)], name='t')
+    expr = t.a.truncate(unit)
+    result = ibis.bigquery.compile(expr)
+    expected = """\
+SELECT TIME_TRUNC(`a`, {}) AS `tmp`
+FROM t""".format(expected_unit)
     assert result == expected

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -5,7 +5,6 @@ import pytest
 import pandas as pd
 
 import ibis
-import ibis.common as com
 import ibis.expr.datatypes as dt
 
 
@@ -442,65 +441,37 @@ FROM `ibis-gbq.testing.functional_alltypes`"""  # noqa: E501
 
 
 @pytest.mark.parametrize(
-    ('unit', 'expected_unit'),
+    ('unit', 'expected_unit', 'expected_func'),
     [
-        ('Y', 'YEAR'),
-        ('Q', 'QUARTER'),
-        ('M', 'MONTH'),
-        ('W', 'WEEK'),
-        ('D', 'DAY'),
-        ('h', 'HOUR'),
-        ('m', 'MINUTE'),
-        ('s', 'SECOND'),
-        ('ms', 'MILLISECOND'),
-        ('us', 'MICROSECOND'),
+        ('Y', 'YEAR', 'TIMESTAMP'),
+        ('Q', 'QUARTER', 'TIMESTAMP'),
+        ('M', 'MONTH', 'TIMESTAMP'),
+        ('W', 'WEEK', 'TIMESTAMP'),
+        ('D', 'DAY', 'TIMESTAMP'),
+        ('h', 'HOUR', 'TIMESTAMP'),
+        ('m', 'MINUTE', 'TIMESTAMP'),
+        ('s', 'SECOND', 'TIMESTAMP'),
+        ('ms', 'MILLISECOND', 'TIMESTAMP'),
+        ('us', 'MICROSECOND', 'TIMESTAMP'),
+
+        ('Y', 'YEAR', 'DATE'),
+        ('Q', 'QUARTER', 'DATE'),
+        ('M', 'MONTH', 'DATE'),
+        ('W', 'WEEK', 'DATE'),
+        ('D', 'DAY', 'DATE'),
+
+        ('h', 'HOUR', 'TIME'),
+        ('m', 'MINUTE', 'TIME'),
+        ('s', 'SECOND', 'TIME'),
+        ('ms', 'MILLISECOND', 'TIME'),
+        ('us', 'MICROSECOND', 'TIME'),
     ]
 )
-def test_timestamp_truncate(unit, expected_unit):
-    t = ibis.table([('a', dt.timestamp)], name='t')
+def test_temporal_truncate(unit, expected_unit, expected_func):
+    t = ibis.table([('a', getattr(dt, expected_func.lower()))], name='t')
     expr = t.a.truncate(unit)
     result = ibis.bigquery.compile(expr)
     expected = """\
-SELECT TIMESTAMP_TRUNC(`a`, {}) AS `tmp`
-FROM t""".format(expected_unit)
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ('unit', 'expected_unit'),
-    [
-        ('Y', 'YEAR'),
-        ('Q', 'QUARTER'),
-        ('M', 'MONTH'),
-        ('W', 'WEEK'),
-        ('D', 'DAY'),
-    ]
-)
-def test_date_truncate(unit, expected_unit):
-    t = ibis.table([('a', dt.date)], name='t')
-    expr = t.a.truncate(unit)
-    result = ibis.bigquery.compile(expr)
-    expected = """\
-SELECT DATE_TRUNC(`a`, {}) AS `tmp`
-FROM t""".format(expected_unit)
-    assert result == expected
-
-
-@pytest.mark.parametrize(
-    ('unit', 'expected_unit'),
-    [
-        ('h', 'HOUR'),
-        ('m', 'MINUTE'),
-        ('s', 'SECOND'),
-        ('ms', 'MILLISECOND'),
-        ('us', 'MICROSECOND'),
-    ]
-)
-def test_time_truncate(unit, expected_unit):
-    t = ibis.table([('a', dt.time)], name='t')
-    expr = t.a.truncate(unit)
-    result = ibis.bigquery.compile(expr)
-    expected = """\
-SELECT TIME_TRUNC(`a`, {}) AS `tmp`
-FROM t""".format(expected_unit)
+SELECT {}_TRUNC(`a`, {}) AS `tmp`
+FROM t""".format(expected_func, expected_unit)
     assert result == expected

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -475,3 +475,23 @@ def test_temporal_truncate(unit, expected_unit, expected_func):
 SELECT {}_TRUNC(`a`, {}) AS `tmp`
 FROM t""".format(expected_func, expected_unit)
     assert result == expected
+
+
+def test_extract_time_from_timestamp():
+    t = ibis.table([('ts', 'timestamp')], name='t')
+    expr = t.ts.time()
+    result = ibis.bigquery.compile(expr)
+    expected = """\
+SELECT EXTRACT(TIME from `ts`) AS `tmp`
+FROM t"""
+    assert result == expected
+
+
+def test_extract_date_from_timestamp():
+    t = ibis.table([('ts', 'timestamp')], name='t')
+    expr = t.ts.date()
+    result = ibis.bigquery.compile(expr)
+    expected = """\
+SELECT DATE(`ts`) AS `tmp`
+FROM t"""
+    assert result == expected

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -7,6 +7,8 @@ import pandas as pd
 import ibis
 import ibis.expr.datatypes as dt
 
+from ibis.compat import PY2
+
 
 pytestmark = pytest.mark.bigquery
 pytest.importorskip('google.cloud.bigquery')
@@ -477,7 +479,20 @@ FROM t""".format(expected_func, expected_unit)
     assert result == expected
 
 
-@pytest.mark.parametrize('kind', ['date', 'time'])
+@pytest.mark.parametrize(
+    'kind',
+    [
+        'date',
+        pytest.param(
+            'time',
+            marks=pytest.mark.xfail(
+                PY2,
+                reason='Time operations are not supported in Python 2',
+                raises=ValueError
+            )
+        ),
+    ]
+)
 def test_extract_temporal_from_timestamp(kind):
     t = ibis.table([('ts', dt.timestamp)], name='t')
     expr = getattr(t.ts, kind)()

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -477,21 +477,12 @@ FROM t""".format(expected_func, expected_unit)
     assert result == expected
 
 
-def test_extract_time_from_timestamp():
-    t = ibis.table([('ts', 'timestamp')], name='t')
-    expr = t.ts.time()
+@pytest.mark.parametrize('kind', ['date', 'time'])
+def test_extract_temporal_from_timestamp(kind):
+    t = ibis.table([('ts', dt.timestamp)], name='t')
+    expr = getattr(t.ts, kind)()
     result = ibis.bigquery.compile(expr)
     expected = """\
-SELECT EXTRACT(TIME from `ts`) AS `tmp`
-FROM t"""
-    assert result == expected
-
-
-def test_extract_date_from_timestamp():
-    t = ibis.table([('ts', 'timestamp')], name='t')
-    expr = t.ts.date()
-    result = ibis.bigquery.compile(expr)
-    expected = """\
-SELECT DATE(`ts`) AS `tmp`
-FROM t"""
+SELECT {}(`ts`) AS `tmp`
+FROM t""".format(kind.upper())
     assert result == expected


### PR DESCRIPTION
Turns out that we hadn't implemented date truncation fully, nor had we
implemented time truncation at all. This PR remedies both and adds
bigquery compilation tests for ibis's truncate APIs.

Closes #1546