### PR TITLE
ENH/TST: Add tests for complex typed scalar parameters in backends other than BigQuery

### DIFF
--- a/ibis/file/client.py
+++ b/ibis/file/client.py
@@ -36,7 +36,7 @@ class FileClient(ibis.client.Client):
     def execute(self, expr, params=None, **kwargs):  # noqa
         assert isinstance(expr, ir.Expr)
         scope = kwargs.pop('scope', {})
-        return execute_and_reset(expr, params=None, scope=scope, **kwargs)
+        return execute_and_reset(expr, params=params, scope=scope, **kwargs)
 
     def list_tables(self, path=None):
         raise NotImplementedError


### PR DESCRIPTION
Closes #1294

This PR doesn't *implement* complex scalar parameter for backends that
don't already have support for it.

Future contributors can see which backends are skipping and implement
this feature for those as desired.