### PR TITLE
[MapD] Added Union op as a unsupported operation

### DIFF
--- a/ibis/mapd/client.py
+++ b/ibis/mapd/client.py
@@ -1,4 +1,5 @@
-from pkg_resources import parse_version
+import ibis.common as com
+from ibis.compat import parse_version
 from ibis.client import Database, Query, SQLClient, DatabaseEntity
 from ibis.mapd.compiler import MapDDialect, build_ast
 from ibis.mapd import ddl
@@ -286,6 +287,10 @@ class MapDTable(ir.TableExpr, DatabaseEntity):
             result = f(**{k: v})
             results.append(result)
         return results
+
+    def union(self, *args, **kwargs):
+        msg = "MapD backend doesn't support Union operation!"
+        raise com.UnsupportedOperationError(msg)
 
 
 class MapDClient(SQLClient):

--- a/ibis/mapd/client.py
+++ b/ibis/mapd/client.py
@@ -1,10 +1,8 @@
-import ibis.common as com
-from ibis.compat import parse_version
-from ibis.client import Database, Query, SQLClient, DatabaseEntity
-from ibis.mapd.compiler import MapDDialect, build_ast
-from ibis.mapd import ddl
-from ibis.sql.compiler import DDL, DML
-from ibis.util import log
+import regex as re
+import pandas as pd
+import pymapd
+
+from pkg_resources import parse_version
 from pymapd.cursor import Cursor
 
 try:
@@ -12,14 +10,16 @@ try:
 except ImportError:
     GPUDataFrame = None
 
-import regex as re
-import pandas as pd
-import pymapd
-
 import ibis.common as com
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+
+from ibis.client import Database, Query, SQLClient, DatabaseEntity
+from ibis.mapd.compiler import MapDDialect, build_ast
+from ibis.mapd import ddl
+from ibis.sql.compiler import DDL, DML
+from ibis.util import log
 
 EXECUTION_TYPE_ICP = 1
 EXECUTION_TYPE_ICP_GPU = 2
@@ -287,10 +287,6 @@ class MapDTable(ir.TableExpr, DatabaseEntity):
             result = f(**{k: v})
             results.append(result)
         return results
-
-    def union(self, *args, **kwargs):
-        msg = "MapD backend doesn't support Union operation"
-        raise com.UnsupportedOperationError(msg)
 
 
 class MapDClient(SQLClient):

--- a/ibis/mapd/client.py
+++ b/ibis/mapd/client.py
@@ -289,7 +289,7 @@ class MapDTable(ir.TableExpr, DatabaseEntity):
         return results
 
     def union(self, *args, **kwargs):
-        msg = "MapD backend doesn't support Union operation!"
+        msg = "MapD backend doesn't support Union operation"
         raise com.UnsupportedOperationError(msg)
 
 

--- a/ibis/mapd/compiler.py
+++ b/ibis/mapd/compiler.py
@@ -52,6 +52,12 @@ class MapDQueryBuilder(compiles.QueryBuilder):
 
     """
     select_builder = MapDSelectBuilder
+    union_class = None
+
+    def _make_union(self):
+        raise com.UnsupportedOperationError(
+            "MapD backend doesn't support Union operation"
+        )
 
 
 class MapDQueryContext(compiles.QueryContext):
@@ -253,5 +259,3 @@ _add_methods(
         byte_length=_unary_op('length', mapd_ops.ByteLength)
     )
 )
-
-_add_methods(ir.TableExpr, dict(union=mapd_ops._union))

--- a/ibis/mapd/compiler.py
+++ b/ibis/mapd/compiler.py
@@ -253,3 +253,5 @@ _add_methods(
         byte_length=_unary_op('length', mapd_ops.ByteLength)
     )
 )
+
+_add_methods(ir.TableExpr, dict(union=mapd_ops._union))

--- a/ibis/mapd/operations.py
+++ b/ibis/mapd/operations.py
@@ -726,4 +726,5 @@ _operation_registry.update(_geometric_ops)
 _operation_registry.update(_string_ops)
 _operation_registry.update(_date_ops)
 _operation_registry.update(_agg_ops)
+# the last update should be with unsupported ops
 _operation_registry.update(_unsupported_ops)

--- a/ibis/mapd/operations.py
+++ b/ibis/mapd/operations.py
@@ -401,12 +401,6 @@ def raise_unsupported_op_error(translator, expr, *args):
     raise com.UnsupportedOperationError(msg.format(type(op)))
 
 
-# unsupported operations
-def _union(*args, **kwargs):
-    msg = "MapD backend doesn't support Union operation!"
-    raise com.UnsupportedOperationError(msg)
-
-
 # translator
 def _name_expr(formatted_expr, quoted_name):
     return '{} AS {}'.format(formatted_expr, quote_identifier(quoted_name))

--- a/ibis/mapd/operations.py
+++ b/ibis/mapd/operations.py
@@ -401,6 +401,12 @@ def raise_unsupported_op_error(translator, expr, *args):
     raise com.UnsupportedOperationError(msg.format(type(op)))
 
 
+# unsupported operations
+def _union(*args, **kwargs):
+    msg = "MapD backend doesn't support Union operation!"
+    raise com.UnsupportedOperationError(msg)
+
+
 # translator
 def _name_expr(formatted_expr, quoted_name):
     return '{} AS {}'.format(formatted_expr, quote_identifier(quoted_name))

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -1,6 +1,7 @@
 from ibis.tests.util import assert_equal
 
 import ibis
+import ibis.common as com
 import ibis.expr.types as ir
 import pandas as pd
 import pytest
@@ -54,19 +55,28 @@ def test_database_layer(con, alltypes):
 
 def test_compile_toplevel():
     t = ibis.table([('foo', 'double')], name='t0')
-
-    # it works!
     expr = t.foo.sum()
     result = ibis.mapd.compile(expr)
     expected = 'SELECT sum("foo") AS "sum"\nFROM t0'  # noqa
     assert str(result) == expected
 
 
-def text_exists_table_with_database(
-    con, alltypes, test_data_db, temp_table, temp_database
-):
+def text_exists_table_with_database(con, alltypes, test_data_db, temp_table,
+                                    temp_database):
     tmp_db = test_data_db
     con.create_table(temp_table, alltypes, database=tmp_db)
 
     assert con.exists_table(temp_table, database=tmp_db)
     assert not con.exists_table(temp_table, database=temp_database)
+
+
+def test_union_op(alltypes):
+    with pytest.raises(com.UnsupportedOperationError):
+        t1 = alltypes
+        t2 = alltypes
+        t1.union(t2)
+
+    with pytest.raises(com.UnsupportedOperationError):
+        t1 = alltypes.head()
+        t2 = alltypes.head()
+        t1.union(t2)

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -73,12 +73,13 @@ def text_exists_table_with_database(con, alltypes, test_data_db, temp_table,
 def test_union_op(alltypes):
     t1 = alltypes
     t2 = alltypes
+    expr = t1.union(t2)
+
     with pytest.raises(com.UnsupportedOperationError):
-        print(t1.union(t2))
+        expr.compile()
 
     t1 = alltypes.head()
     t2 = alltypes.head()
+    expr = t1.union(t2)
     with pytest.raises(com.UnsupportedOperationError):
-        t1 = alltypes.head()
-        t2 = alltypes.head()
-        t1.union(t2)
+        expr.compile()

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -71,11 +71,13 @@ def text_exists_table_with_database(con, alltypes, test_data_db, temp_table,
 
 
 def test_union_op(alltypes):
+    t1 = alltypes
+    t2 = alltypes
     with pytest.raises(com.UnsupportedOperationError):
-        t1 = alltypes
-        t2 = alltypes
-        t1.union(t2)
+        print(t1.union(t2))
 
+    t1 = alltypes.head()
+    t2 = alltypes.head()
     with pytest.raises(com.UnsupportedOperationError):
         t1 = alltypes.head()
         t2 = alltypes.head()


### PR DESCRIPTION
This PR fixes #1630. It add Union op as a unsupported operation.