### PR TITLE
Support column names with special characters in mapd

### DIFF
--- a/ibis/mapd/identifiers.py
+++ b/ibis/mapd/identifiers.py
@@ -134,9 +134,14 @@ _ibis = frozenset({
 _identifiers = _ddl | _dml | _data_type | _ibis
 
 
+_special_chars = (
+    ' ',
+    '*'
+)
+
 def quote_identifier(name, quotechar='"', force=False):
     if (
-        (force or name.count(' ') or name in _identifiers) and
+        (force or any(c in name for c in _special_chars) or name in _identifiers) and
         quotechar not in name
     ):
         return '{0}{1}{0}'.format(quotechar, name)

--- a/ibis/mapd/identifiers.py
+++ b/ibis/mapd/identifiers.py
@@ -139,9 +139,14 @@ _special_chars = (
     '*'
 )
 
+
 def quote_identifier(name, quotechar='"', force=False):
     if (
-        (force or any(c in name for c in _special_chars) or name in _identifiers) and
+        (
+            force or
+            any(c in name for c in _special_chars) or
+            name in _identifiers
+        ) and
         quotechar not in name
     ):
         return '{0}{1}{0}'.format(quotechar, name)

--- a/ibis/mapd/operations.py
+++ b/ibis/mapd/operations.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from ibis.mapd.identifiers import quote_identifier, _identifiers
+from ibis.mapd.identifiers import quote_identifier
 from ibis.impala import compiler as impala_compiler
 from io import StringIO
 
@@ -381,9 +381,7 @@ def raise_unsupported_op_error(translator, expr, *args):
 
 # translator
 def _name_expr(formatted_expr, quoted_name):
-    if quoted_name in _identifiers:
-        quoted_name = '"{}"'.format(quoted_name)
-    return '{} AS {}'.format(formatted_expr, quoted_name)
+    return '{} AS {}'.format(formatted_expr, quote_identifier(quoted_name))
 
 
 class CaseFormatter:

--- a/ibis/mapd/tests/test_operations.py
+++ b/ibis/mapd/tests/test_operations.py
@@ -95,8 +95,9 @@ def test_where_operator(alltypes):
 
 
 @pytest.mark.parametrize(('name',), [
-    ('count_*',),
-    ('regular_name',)
+    ('regular_name',),
+    ('star_name*',),
+    ('space_name ',),
 ])
 def test_quote_name(alltypes, name):
     expr = alltypes.aggregate(alltypes.count().name(name))

--- a/ibis/mapd/tests/test_operations.py
+++ b/ibis/mapd/tests/test_operations.py
@@ -94,10 +94,10 @@ def test_where_operator(alltypes):
     assert counts[1] == 5
 
 
-@pytest.mark.parametrize(('name',), [
-    ('regular_name',),
-    ('star_name*',),
-    ('space_name ',),
+@pytest.mark.parametrize('name', [
+    'regular_name',
+    'star_name*',
+    'space_name ',
 ])
 def test_quote_name(alltypes, name):
     expr = alltypes.aggregate(alltypes.count().name(name))

--- a/ibis/mapd/tests/test_operations.py
+++ b/ibis/mapd/tests/test_operations.py
@@ -92,3 +92,12 @@ def test_where_operator(alltypes):
     counts = expr.execute().value_counts()
     assert counts[0] == 5
     assert counts[1] == 5
+
+
+@pytest.mark.parametrize(('name',), [
+    ('count_*',),
+    ('regular_name',)
+])
+def test_quote_name(alltypes, name):
+    expr = alltypes.aggregate(alltypes.count().name(name))
+    assert name in expr.execute()


### PR DESCRIPTION
The mapd backend raises an error currently when you include some special characters in new table names

Ex:

```python
conn = ibis.mapd.connect(
    host='metis.mapd.com', user='mapd', password='HyperInteractive',
    port=443, database='mapd', protocol= 'https'
)
t = conn.table("flights_donotmodify")
t.aggregate(t.count().name("count_*")).execute()
```

Gives error

```
---------------------------------------------------------------------------
TMapDException                            Traceback (most recent call last)
/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/pymapd/cursor.py in execute(self, operation, parameters)
    119                 column_format=self.columnar,
--> 120                 nonce=None, first_n=-1, at_most_n=-1)
    121         except T.TMapDException as e:

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/mapd/MapD.py in sql_execute(self, session, query, column_format, nonce, first_n, at_most_n)
   1457         self.send_sql_execute(session, query, column_format, nonce, first_n, at_most_n)
-> 1458         return self.recv_sql_execute()
   1459 

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/mapd/MapD.py in recv_sql_execute(self)
   1486         if result.e is not None:
-> 1487             raise result.e
   1488         raise TApplicationException(TApplicationException.MISSING_RESULT, "sql_execute failed: unknown result")

TMapDException: TMapDException(error_msg='Exception: Parse failed: Encountered "*" at line 1, column 26.\nWas expecting one of:\n    <EOF> \n    "ORDER" ...\n    "LIMIT" ...\n    "OFFSET" ...\n    "FETCH" ...\n    "FROM" ...\n    "," ...\n    "UNION" ...\n    "INTERSECT" ...\n    "EXCEPT" ...\n    "MINUS" ...\n    ')

The above exception was the direct cause of the following exception:

ProgrammingError                          Traceback (most recent call last)
/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/ibis/mapd/client.py in _execute(self, query, results)
    407         try:
--> 408             result = MapDCursor(execute(query))
    409         except Exception as e:

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/pymapd/cursor.py in execute(self, operation, parameters)
    121         except T.TMapDException as e:
--> 122             six.raise_from(_translate_exception(e), e)
    123         self._description = _extract_description(result.row_set.row_desc)

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/six.py in raise_from(value, from_value)

ProgrammingError: Exception: Parse failed: Encountered "*" at line 1, column 26.
Was expecting one of:
    <EOF> 
    "ORDER" ...
    "LIMIT" ...
    "OFFSET" ...
    "FETCH" ...
    "FROM" ...
    "," ...
    "UNION" ...
    "INTERSECT" ...
    "EXCEPT" ...
    "MINUS" ...
    

During handling of the above exception, another exception occurred:

Exception                                 Traceback (most recent call last)
<ipython-input-12-ca2aa7d96001> in <module>
----> 1 t.aggregate(t.count().name("count_*")).execute()

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/ibis/expr/types.py in execute(self, limit, params, **kwargs)
    195         """
    196         from ibis.client import execute
--> 197         return execute(self, limit=limit, params=params, **kwargs)
    198 
    199     def compile(self, limit=None, params=None):

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/ibis/client.py in execute(expr, limit, params, **kwargs)
    282 def execute(expr, limit='default', params=None, **kwargs):
    283     backend, = validate_backends(list(find_backends(expr)))
--> 284     return backend.execute(expr, limit=limit, params=params, **kwargs)
    285 
    286 

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/ibis/client.py in execute(self, expr, params, limit, **kwargs)
    182         """
    183         query_ast = self._build_ast_ensure_limit(expr, limit, params=params)
--> 184         result = self._execute_query(query_ast, **kwargs)
    185         return result
    186 

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/ibis/client.py in _execute_query(self, dml, **kwargs)
    187     def _execute_query(self, dml, **kwargs):
    188         query = self.query_class(self, dml, **kwargs)
--> 189         return query.execute()
    190 
    191     def compile(self, expr, params=None, limit=None):

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/ibis/client.py in execute(self)
     39     def execute(self):
     40         # synchronous by default
---> 41         with self.client._execute(self.compiled_sql, results=True) as cur:
     42             result = self._fetch(cur)
     43 

/usr/local/miniconda3/envs/jupyterlab-omnisci/lib/python3.6/site-packages/ibis/mapd/client.py in _execute(self, query, results)
    408             result = MapDCursor(execute(query))
    409         except Exception as e:
--> 410             raise Exception('{}: {}'.format(e, query))
    411 
    412         if results:

Exception: Exception: Parse failed: Encountered "*" at line 1, column 26.
Was expecting one of:
    <EOF> 
    "ORDER" ...
    "LIMIT" ...
    "OFFSET" ...
    "FETCH" ...
    "FROM" ...
    "," ...
    "UNION" ...
    "INTERSECT" ...
    "EXCEPT" ...
    "MINUS" ...
    : SELECT count(*) AS count_*
FROM flights_donotmodify
LIMIT 10000
```

If instead we quote the name, then the query succeeds (like this):

```sql
SELECT count(*) AS "count_*"
FROM flights_donotmodify
LIMIT 10000
```

This PR will fix this by quoting names with * in them.


- [x] Add failing test case
- [x] fix test case