### PR TITLE
[Lint] Use equality operator to compare strings

### DIFF
--- a/ibis/impala/tests/test_udf.py
+++ b/ibis/impala/tests/test_udf.py
@@ -273,7 +273,7 @@ def identity_func_testing(
     assert issubclass(type(expr), ir.ScalarExpr)
     result = udfcon.execute(expr)
     # Hacky
-    if datatype is 'timestamp':
+    if datatype == 'timestamp':
         assert type(result) == pd.Timestamp
     else:
         lop = literal.op()


### PR DESCRIPTION
The recent release of flake8 has highlighted this issue.