### PR TITLE
[Impala] Type conversion for complex types

### DIFF
--- a/ibis/expr/tests/mocks.py
+++ b/ibis/expr/tests/mocks.py
@@ -126,6 +126,12 @@ class MockConnection(SQLClient):
             ('year', 'int32'),
             ('month', 'int32')
         ],
+        'functional_complextypes': [
+            ('array_col', 'array<string>'),
+            ('map_col', 'map<string,int32>'),
+            ('struct_col', 'struct<a:string>'),
+            ('complex_struct_col', 'struct<m:map<string,int32>>')
+        ],
         'airlines': [
             ('year', 'int32'),
             ('month', 'int32'),

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -145,11 +145,12 @@ def _type_to_sql_string(tval):
         return 'map<{}, {}>'.format(
             _type_to_sql_string(tval.key_type),
             _type_to_sql_string(tval.value_type)
-            )
+        )
     if isinstance(tval, dt.Array):
         return 'array<{}>'.format(_type_to_sql_string(tval.value_type))
     if isinstance(tval, dt.Struct):
-        parts = ["{}:{}".format(n, _type_to_sql_string(t)) for n, t in tval.pairs.items()] # noqa E501
+        parts = ["{}:{}".format(n, _type_to_sql_string(t)) for n, t
+                 in tval.pairs.items()]
         return 'struct<{}>'.format(','.join(parts))
     name = tval.name.lower()
     try:

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -118,6 +118,9 @@ _sql_type_names = {
     'boolean': 'boolean',
     'timestamp': 'timestamp',
     'decimal': 'decimal',
+    'map': 'map',
+    'array': 'array',
+    'struct': 'struct'
 }
 
 
@@ -138,6 +141,16 @@ def _cast(translator, expr):
 def _type_to_sql_string(tval):
     if isinstance(tval, dt.Decimal):
         return 'decimal({}, {})'.format(tval.precision, tval.scale)
+    if isinstance(tval, dt.Map):
+        return 'map<{}, {}>'.format(
+            _type_to_sql_string(tval.key_type),
+            _type_to_sql_string(tval.value_type)
+            )
+    if isinstance(tval, dt.Array):
+        return 'array<{}>'.format(_type_to_sql_string(tval.value_type))
+    if isinstance(tval, dt.Struct):
+        parts = ["{}:{}".format(n, _type_to_sql_string(t)) for n, t in tval.pairs.items()] # noqa E501
+        return 'struct<{}>'.format(','.join(parts))
     name = tval.name.lower()
     try:
         return _sql_type_names[name]


### PR DESCRIPTION
Allows the impala backend to read the schema of tables with complex types and write tables with complex types.  It does not implement the functionality to read or write data from these tables but only interact with the schema