### PR TITLE
BUG: Fix a bug in TableExpr.drop

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -3533,22 +3533,18 @@ def _table_view(self):
 
 
 def _table_drop(self, fields):
-    if len(fields) == 0:
-        # noop
+    if not fields:
+        # no-op if nothing to be dropped
         return self
 
-    fields = set(fields)
-    to_project = []
-    for name in self.schema():
-        if name in fields:
-            fields.remove(name)
-        else:
-            to_project.append(name)
+    schema = self.schema()
+    field_set = frozenset(fields)
+    missing_fields = field_set.difference(schema)
 
-    if len(fields) > 0:
-        raise KeyError('Fields not in table: {0!s}'.format(fields))
+    if missing_fields:
+        raise KeyError('Fields not in table: {0!s}'.format(missing_fields))
 
-    return self.projection(to_project)
+    return self[[field for field in schema if field not in field_set]]
 
 
 _table_methods = dict(

--- a/ibis/expr/tests/test_table.py
+++ b/ibis/expr/tests/test_table.py
@@ -1,4 +1,3 @@
-import datetime
 import re
 
 import pytest
@@ -1240,53 +1239,3 @@ def test_unbound_table_name():
     name = t.op().name
     match = re.match(r'^unbound_table_\d+$', name)
     assert match is not None
-
-
-def test_table_drop_with_filter():
-    left = ibis.table(
-        [('a', 'int64'), ('b', 'string'), ('c', 'timestamp')],
-        name='t',
-    ).relabel({'c': 'C'})
-    left = left.filter(left.C == datetime.date(2018, 1, 1))
-    left = left.drop(['C'])
-    left = left.mutate(the_date=datetime.date(2018, 1, 1))
-
-    right = ibis.table([('b', 'string')], name='s')
-    joined = left.join(right, left.b == right.b)
-    joined = joined[left.a]
-    joined = joined.filter(joined.a < 1.0)
-    result = ibis.bigquery.compile(joined)
-    # previously this was generating incorrect aliases due to not binding the
-    # self to expressions when calling projection:
-    # SELECT t0.`a`
-    # FROM (
-    #   SELECT `a`, `b`, DATE '2018-01-01' AS `the_date`
-    #   FROM (
-    #     SELECT *
-    #     FROM (
-    #       SELECT `a`, `b`, `c` AS `C`
-    #       FROM t
-    #     ) t3
-    #     WHERE `C` = TIMESTAMP '2018-01-01'
-    #   ) t2
-    # ) t0
-    #   INNER JOIN s t1
-    #     ON t0.`b` = t1.`b`
-    # WHERE t0.`a` < 1.0
-    expected = """\
-SELECT t0.`a`
-FROM (
-  SELECT `a`, `b`, DATE '2018-01-01' AS `the_date`
-  FROM (
-    SELECT *
-    FROM (
-      SELECT `a`, `b`, `c` AS `C`
-      FROM t
-    ) t3
-    WHERE `C` = TIMESTAMP '2018-01-01'
-  ) t2
-) t0
-  INNER JOIN s t1
-    ON t0.`b` = t1.`b`
-WHERE t0.`a` < 1.0"""
-    assert result == expected

--- a/ibis/expr/tests/test_table.py
+++ b/ibis/expr/tests/test_table.py
@@ -1256,6 +1256,23 @@ def test_table_drop_with_filter():
     joined = joined[left.a]
     joined = joined.filter(joined.a < 1.0)
     result = ibis.bigquery.compile(joined)
+    # previously this was generating incorrect aliases due to not binding the
+    # self to expressions when calling projection:
+    # SELECT t0.`a`
+    # FROM (
+    #   SELECT `a`, `b`, DATE '2018-01-01' AS `the_date`
+    #   FROM (
+    #     SELECT *
+    #     FROM (
+    #       SELECT `a`, `b`, `c` AS `C`
+    #       FROM t
+    #     ) t3
+    #     WHERE `C` = TIMESTAMP '2018-01-01'
+    #   ) t2
+    # ) t0
+    #   INNER JOIN s t1
+    #     ON t0.`b` = t1.`b`
+    # WHERE t0.`a` < 1.0
     expected = """\
 SELECT t0.`a`
 FROM (

--- a/ibis/expr/tests/test_table.py
+++ b/ibis/expr/tests/test_table.py
@@ -1251,9 +1251,11 @@ def test_table_drop_with_filter():
     left = left.drop(['C'])
     left = left.mutate(the_date=datetime.date(2018, 1, 1))
 
-    right = ibis.table([('a', 'float64'), ('b', 'string')], name='s')
+    right = ibis.table([('b', 'string')], name='s')
     joined = left.join(right, left.B == right.b)
-    joined = joined[left, right.a.name("A"), right.b]
-    joined = joined.filter(joined.A < 1.0)
+    joined = joined[left, right.b]
+    joined = joined.filter(True)
     result = ibis.bigquery.compile(joined)
+    print()
+    print(result)
     assert result

--- a/ibis/sql/tests/test_compiler.py
+++ b/ibis/sql/tests/test_compiler.py
@@ -2425,9 +2425,9 @@ def test_table_drop_with_filter():
         [('a', 'int64'), ('b', 'string'), ('c', 'timestamp')],
         name='t',
     ).relabel({'c': 'C'})
-    left = left.filter(left.C == datetime.date(2018, 1, 1))
+    left = left.filter(left.C == datetime.datetime(2018, 1, 1))
     left = left.drop(['C'])
-    left = left.mutate(the_date=datetime.date(2018, 1, 1))
+    left = left.mutate(the_date=datetime.datetime(2018, 1, 1))
 
     right = ibis.table([('b', 'string')], name='s')
     joined = left.join(right, left.b == right.b)
@@ -2438,15 +2438,12 @@ def test_table_drop_with_filter():
     # self to expressions when calling projection:
     # SELECT t0.`a`
     # FROM (
-    #   SELECT `a`, `b`, '2018-01-01' AS `the_date`
+    #   SELECT t2.`a`, t2.`b`, '2018-01-01 00:00:00' AS `the_date`
     #   FROM (
-    #     SELECT *
-    #     FROM (
-    #       SELECT `a`, `b`, `c` AS `C`
-    #       FROM t
-    #     ) t3
-    #     WHERE `C` = '2018-01-01'
-    #   ) t2
+    #     SELECT `a`, `b`, `c` AS `C`
+    #     FROM t
+    #   ) t3
+    #   WHERE t3.`C` = '2018-01-01 00:00:00'
     # ) t0
     #   INNER JOIN s t1
     #     ON t0.`b` = t1.`b`
@@ -2454,14 +2451,14 @@ def test_table_drop_with_filter():
     expected = """\
 SELECT t0.`a`
 FROM (
-  SELECT `a`, `b`, '2018-01-01' AS `the_date`
+  SELECT `a`, `b`, '2018-01-01 00:00:00' AS `the_date`
   FROM (
     SELECT *
     FROM (
       SELECT `a`, `b`, `c` AS `C`
       FROM t
     ) t3
-    WHERE `C` = '2018-01-01'
+    WHERE `C` = '2018-01-01 00:00:00'
   ) t2
 ) t0
   INNER JOIN s t1


### PR DESCRIPTION
This PR fixes a bug where the drop method wasn't using `__getitem__` to
project.

`__getitem__` calls a function `bind_expr` that binds a table to the projected
expression.

As a follow-up we should bring this behavior to projection to avoid issues like
this in the future.

One issue with adding a call to `ir.bind_expr(self, what)` to the `projection` method is that it breaks some fusion optimizations.

I think that as part of the the post 1.0.0 follow-up work we need to disable and remove all optimizations until we can restructure the compiler flow to separate optimization from expression construction.