### PR TITLE
Fixes DOC: conda create command listed no longer works

### DIFF
--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -35,7 +35,7 @@ Conda Environment Setup
 
       # Create a conda environment ready for ibis development
       # including building the documentation
-      conda create -n ibis36 -c conda-forge --file=ci/requirements-dev.yml python=3.6
+      conda env create -n ibis36 -f ci/requirements-3.6-dev.yml
 
       # Activate the conda environment
       source activate ibis36


### PR DESCRIPTION
Fixes error in documentation, issue #1774

The following command in `developer.rst` no longer works for two reasons. One, the YAML file no longer exists. Two, creating a conda environment from YAML needs to be done with `conda env create` instead of `conda create`.

Failing instruction:
`conda create -n ibis36 -c conda-forge --file=ci/requirements-dev.yml python=3.6`

Should now be:
`conda env create -n ibis36 -f ci/requirements-3.6-dev.yml`