### PR TITLE
Clean up most xpassing tests

### DIFF
--- a/ibis/clickhouse/tests/test_functions.py
+++ b/ibis/clickhouse/tests/test_functions.py
@@ -103,10 +103,10 @@ def test_timestamp_now(con, translate):
 @pytest.mark.parametrize(
     ('unit', 'expected'),
     [
-        param('y', '2009-01-01', marks=pytest.mark.xfail),
+        ('y', '2009-01-01'),
         param('m', '2009-05-01', marks=pytest.mark.xfail),
-        param('d', '2009-05-17', marks=pytest.mark.xfail),
-        param('w', '2009-05-11', marks=pytest.mark.xfail),
+        ('d', '2009-05-17'),
+        ('w', '2009-05-11'),
         ('h', '2009-05-17 12:00:00'),
         ('minute', '2009-05-17 12:34:00'),
     ],
@@ -494,14 +494,6 @@ def test_numeric_builtins_work(con, alltypes, df, translate):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    raises=clickhouse_driver.errors.UnknownTypeError,
-    reason=(
-        'Newer clickhouse server uses Nullable(Nothing) type '
-        'for Null values which is currently unhandled by '
-        'clickhouse-driver'
-    ),
-)
 def test_null_column(alltypes, translate):
     t = alltypes
     nrows = t.count().execute()

--- a/ibis/impala/tests/test_partition.py
+++ b/ibis/impala/tests/test_partition.py
@@ -211,7 +211,6 @@ def test_add_drop_partition_owned_by_impala(hdfs, con, temp_table):
     assert len(table.partitions()) == 1
 
 
-@pytest.mark.xfail(raises=impala.error.HiveServer2Error, reason='HIVE-12613')
 def test_add_drop_partition_hive_bug(con, temp_table):
     schema = ibis.schema(
         [('foo', 'string'), ('year', 'int32'), ('month', 'int16')]

--- a/ibis/tests/all/test_aggregation.py
+++ b/ibis/tests/all/test_aggregation.py
@@ -3,6 +3,7 @@ import pytest
 from pytest import param
 
 import ibis.tests.util as tu
+from ibis.tests.backends import Clickhouse, MySQL, SQLite
 
 
 @pytest.mark.parametrize(
@@ -67,7 +68,7 @@ import ibis.tests.util as tu
             lambda t, where: t.double_col.approx_median(),
             lambda t, where: t.double_col.median(),
             id='double_col_approx_median',
-            marks=pytest.mark.xfail,
+            marks=pytest.mark.xpass_backends([Clickhouse]),
         ),
         param(
             lambda t, where: t.double_col.std(how='sample'),
@@ -93,7 +94,7 @@ import ibis.tests.util as tu
             lambda t, where: t.string_col.approx_nunique(),
             lambda t, where: t.string_col.nunique(),
             id='string_col_approx_nunique',
-            marks=pytest.mark.xfail,
+            marks=pytest.mark.xfail_backends([MySQL, SQLite]),
         ),
         param(
             lambda t, where: t.string_col.group_concat(','),

--- a/ibis/tests/all/test_generic.py
+++ b/ibis/tests/all/test_generic.py
@@ -1,12 +1,18 @@
 import decimal
 
 import pytest
-from pytest import param
 
 import ibis
 import ibis.tests.util as tu
 from ibis import literal as L
-from ibis.tests.backends import MapD
+from ibis.tests.backends import (
+    BigQuery,
+    Clickhouse,
+    MapD,
+    MySQL,
+    PostgreSQL,
+    SQLite,
+)
 
 
 @pytest.mark.parametrize(
@@ -14,7 +20,13 @@ from ibis.tests.backends import MapD
     [
         (ibis.NA.fillna(5), 5),
         (L(5).fillna(10), 5),
-        pytest.param(L(5).nullif(5), None, marks=pytest.mark.xfail),
+        pytest.param(
+            L(5).nullif(5),
+            None,
+            marks=pytest.mark.xpass_backends(
+                [BigQuery, Clickhouse, MySQL, PostgreSQL, SQLite]
+            ),
+        ),
         (L(10).nullif(5), 10),
     ],
 )
@@ -71,20 +83,8 @@ def test_identical_to(backend, sorted_alltypes, con, sorted_df):
         ('int_col', (1, 2, 3)),
         ('string_col', ['1', '2', '3']),
         ('string_col', ('1', '2', '3')),
-        param(
-            'int_col',
-            {1},
-            marks=pytest.mark.xfail(
-                raises=TypeError, reason='Not yet implemented'
-            ),
-        ),
-        param(
-            'int_col',
-            frozenset({1}),
-            marks=pytest.mark.xfail(
-                raises=TypeError, reason='Not yet implemented'
-            ),
-        ),
+        ('int_col', {1}),
+        ('int_col', frozenset({1})),
     ],
 )
 @tu.skipif_unsupported
@@ -107,20 +107,8 @@ def test_isin(backend, sorted_alltypes, sorted_df, column, elements):
         ('int_col', (1, 2, 3)),
         ('string_col', ['1', '2', '3']),
         ('string_col', ('1', '2', '3')),
-        param(
-            'int_col',
-            {1},
-            marks=pytest.mark.xfail(
-                raises=TypeError, reason='Not yet implemented'
-            ),
-        ),
-        param(
-            'int_col',
-            frozenset({1}),
-            marks=pytest.mark.xfail(
-                raises=TypeError, reason='Not yet implemented'
-            ),
-        ),
+        ('int_col', {1}),
+        ('int_col', frozenset({1})),
     ],
 )
 @tu.skipif_unsupported

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -39,7 +39,9 @@ from ibis.tests.backends import Csv, Pandas, Parquet
             lambda t, win: t.id.percent_rank().over(win),
             lambda t: t.id.rank(pct=True),
             id='percent_rank',
-            marks=pytest.mark.xfail(raises=AssertionError),
+            marks=pytest.mark.xpass_backends(
+                [Csv, Pandas, Parquet], raises=AssertionError
+            ),
         ),
         param(
             lambda t, win: t.float_col.ntile(buckets=7).over(win),

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,6 @@ universal = 0
 
 [mypy-ibis._version]
 ignore_errors = true
+
+[tool:pytest]
+xfail_strict = true


### PR DESCRIPTION
This PR makes all `XPASS`ing tests pass in the typical way, by customizing the
behavior of two fixtures `xfail_backends` (all listed backends are permitted to
fail) and `xpass_backends` (all backends *not* listed are permitted to fail)

I've also added `xfail_strict = true` to `setup.cfg` to make sure that we don't introduce any `XPASS`ing tests in the future. Of course, that's always up for debate in the future but I think there's probably a way to customize `xfail`s similar to what I've done here such that we don't need to have any future `XPASS`es.