### PR TITLE
Mapd session

### DIFF
--- a/ibis/mapd/api.py
+++ b/ibis/mapd/api.py
@@ -38,6 +38,7 @@ def connect(
     port=6274,
     database=None,
     protocol='binary',
+    sessionid=None,
     execution_type=EXECUTION_TYPE_CURSOR,
 ):
     """Create a MapDClient for use with Ibis
@@ -51,6 +52,7 @@ def connect(
     :param port: int
     :param database: str
     :param protocol: str
+    :param sessionid: str
     :param execution_type: int
     Returns
     -------
@@ -65,6 +67,7 @@ def connect(
         port=port,
         database=database,
         protocol=protocol,
+        sessionid=sessionid,
         execution_type=execution_type,
     )
 

--- a/ibis/mapd/api.py
+++ b/ibis/mapd/api.py
@@ -38,7 +38,7 @@ def connect(
     port=6274,
     database=None,
     protocol='binary',
-    sessionid=None,
+    session_id=None,
     execution_type=EXECUTION_TYPE_CURSOR,
 ):
     """Create a MapDClient for use with Ibis
@@ -52,7 +52,7 @@ def connect(
     :param port: int
     :param database: str
     :param protocol: str
-    :param sessionid: str
+    :param session_id: str
     :param execution_type: int
     Returns
     -------
@@ -67,7 +67,7 @@ def connect(
         port=port,
         database=database,
         protocol=protocol,
-        sessionid=sessionid,
+        session_id=session_id,
         execution_type=execution_type,
     )
 

--- a/ibis/mapd/client.py
+++ b/ibis/mapd/client.py
@@ -333,6 +333,7 @@ class MapDClient(SQLClient):
         port=6274,
         database=None,
         protocol='binary',
+        sessionid=None,
         execution_type=EXECUTION_TYPE_CURSOR,
     ):
         """
@@ -346,6 +347,7 @@ class MapDClient(SQLClient):
         port : int
         database : str
         protocol : {'binary', 'http', 'https'}
+        sessionid: str
         execution_type : {
           EXECUTION_TYPE_ICP, EXECUTION_TYPE_ICP_GPU, EXECUTION_TYPE_CURSOR
         }
@@ -358,6 +360,7 @@ class MapDClient(SQLClient):
         self.port = port
         self.db_name = database
         self.protocol = protocol
+        self.sessionid = sessionid
 
         if execution_type not in (
             EXECUTION_TYPE_ICP,
@@ -376,6 +379,7 @@ class MapDClient(SQLClient):
             port=port,
             dbname=database,
             protocol=protocol,
+            sessionid=sessionid,
         )
 
     def __del__(self):
@@ -721,6 +725,7 @@ class MapDClient(SQLClient):
                 port=self.port,
                 database=name,
                 protocol=self.protocol,
+                sessionid=self.sessionid,
                 execution_type=self.execution_type,
             )
             return self.database_class(name, new_client)
@@ -756,6 +761,7 @@ class MapDClient(SQLClient):
                 port=self.port,
                 dbname=name,
                 protocol=self.protocol,
+                sessionid=self.sessionid,
             )
             self.db_name = name
 

--- a/ibis/mapd/client.py
+++ b/ibis/mapd/client.py
@@ -371,16 +371,26 @@ class MapDClient(SQLClient):
 
         self.execution_type = execution_type
 
-        self.con = pymapd.connect(
-            uri=uri,
-            user=user,
-            password=password,
-            host=host,
-            port=port,
-            dbname=database,
-            protocol=protocol,
-            sessionid=session_id,
-        )
+        if session_id:
+            if self.version < pkg_resources.parse_version('0.12.0'):
+                raise Exception('Must have pympad > 0.12 to use session ID')
+            self.con = pymapd.connect(
+                uri=uri,
+                host=host,
+                port=port,
+                protocol=protocol,
+                sessionid=session_id,
+            )
+        else:
+            self.con = pymapd.connect(
+                uri=uri,
+                user=user,
+                password=password,
+                host=host,
+                port=port,
+                dbname=database,
+                protocol=protocol,
+            )
 
     def __del__(self):
         self.close()

--- a/ibis/mapd/client.py
+++ b/ibis/mapd/client.py
@@ -43,6 +43,10 @@ def _validate_compatible(from_schema, to_schema):
     return
 
 
+class PyMapDVersionError(Exception):
+    pass
+
+
 class MapDDataType:
 
     __slots__ = 'typename', 'nullable'
@@ -373,7 +377,9 @@ class MapDClient(SQLClient):
 
         if session_id:
             if self.version < pkg_resources.parse_version('0.12.0'):
-                raise Exception('Must have pympad > 0.12 to use session ID')
+                raise PyMapDVersionError(
+                    'Must have pymapd > 0.12 to use session ID'
+                )
             self.con = pymapd.connect(
                 uri=uri,
                 host=host,

--- a/ibis/mapd/client.py
+++ b/ibis/mapd/client.py
@@ -333,7 +333,7 @@ class MapDClient(SQLClient):
         port=6274,
         database=None,
         protocol='binary',
-        sessionid=None,
+        session_id=None,
         execution_type=EXECUTION_TYPE_CURSOR,
     ):
         """
@@ -347,7 +347,7 @@ class MapDClient(SQLClient):
         port : int
         database : str
         protocol : {'binary', 'http', 'https'}
-        sessionid: str
+        session_id: str
         execution_type : {
           EXECUTION_TYPE_ICP, EXECUTION_TYPE_ICP_GPU, EXECUTION_TYPE_CURSOR
         }
@@ -360,7 +360,7 @@ class MapDClient(SQLClient):
         self.port = port
         self.db_name = database
         self.protocol = protocol
-        self.sessionid = sessionid
+        self.session_id = session_id
 
         if execution_type not in (
             EXECUTION_TYPE_ICP,
@@ -379,7 +379,7 @@ class MapDClient(SQLClient):
             port=port,
             dbname=database,
             protocol=protocol,
-            sessionid=sessionid,
+            sessionid=session_id,
         )
 
     def __del__(self):
@@ -725,7 +725,7 @@ class MapDClient(SQLClient):
                 port=self.port,
                 database=name,
                 protocol=self.protocol,
-                sessionid=self.sessionid,
+                session_id=self.session_id,
                 execution_type=self.execution_type,
             )
             return self.database_class(name, new_client)
@@ -761,7 +761,7 @@ class MapDClient(SQLClient):
                 port=self.port,
                 dbname=name,
                 protocol=self.protocol,
-                sessionid=self.sessionid,
+                session_id=self.session_id,
             )
             self.db_name = name
 

--- a/ibis/mapd/tests/conftest.py
+++ b/ibis/mapd/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 
+import pymapd
 import pytest
 
 import ibis
@@ -20,6 +21,23 @@ def con():
         user=OMNISCI_USER,
         password=OMNISCI_PASS,
         database=OMNISCI_DB,
+    )
+
+
+@pytest.fixture(scope='module')
+def session_con():
+    con = pymapd.connect(
+        host=OMNISCI_HOST,
+        port=OMNISCI_PORT,
+        user=OMNISCI_USER,
+        password=OMNISCI_PASS,
+        database=OMNISCI_DB,
+    )
+    sessionid = con._session
+    return ibis.mapd.connect(
+        host=OMNISCI_HOST,
+        port=OMNISCI_PORT,
+        sessionid=sessionid
     )
 
 

--- a/ibis/mapd/tests/conftest.py
+++ b/ibis/mapd/tests/conftest.py
@@ -1,6 +1,5 @@
 import os
 
-import pymapd
 import pytest
 
 import ibis
@@ -10,12 +9,14 @@ OMNISCI_HOST = os.environ.get('IBIS_TEST_OMNISCI_HOST', 'localhost')
 OMNISCI_PORT = int(os.environ.get('IBIS_TEST_OMNISCI_PORT', 6274))
 OMNISCI_USER = os.environ.get('IBIS_TEST_OMNISCI_USER', 'mapd')
 OMNISCI_PASS = os.environ.get('IBIS_TEST_OMNISCI_PASSWORD', 'HyperInteractive')
+OMNISCI_PROTOCOL = os.environ.get('IBIS_TEST_OMNISCI_PROTOCOL', 'binary')
 OMNISCI_DB = os.environ.get('IBIS_TEST_DATA_DB', 'ibis_testing')
 
 
 @pytest.fixture(scope='module')
 def con():
     return ibis.mapd.connect(
+        protocol=OMNISCI_PROTOCOL,
         host=OMNISCI_HOST,
         port=OMNISCI_PORT,
         user=OMNISCI_USER,
@@ -26,19 +27,15 @@ def con():
 
 @pytest.fixture(scope='module')
 def session_con():
-    con = pymapd.connect(
+    return ibis.mapd.connect(
+        protocol=OMNISCI_PROTOCOL,
         host=OMNISCI_HOST,
         port=OMNISCI_PORT,
         user=OMNISCI_USER,
         password=OMNISCI_PASS,
-        dbname=OMNISCI_DB,
+        database=OMNISCI_DB,
     )
-    session_id = con._session
-    return ibis.mapd.connect(
-        host=OMNISCI_HOST,
-        port=OMNISCI_PORT,
-        session_id=session_id
-    )
+    return session_con
 
 
 @pytest.fixture(scope='module')

--- a/ibis/mapd/tests/conftest.py
+++ b/ibis/mapd/tests/conftest.py
@@ -31,7 +31,7 @@ def session_con():
         port=OMNISCI_PORT,
         user=OMNISCI_USER,
         password=OMNISCI_PASS,
-        database=OMNISCI_DB,
+        dbname=OMNISCI_DB,
     )
     sessionid = con._session
     return ibis.mapd.connect(

--- a/ibis/mapd/tests/conftest.py
+++ b/ibis/mapd/tests/conftest.py
@@ -33,11 +33,11 @@ def session_con():
         password=OMNISCI_PASS,
         dbname=OMNISCI_DB,
     )
-    sessionid = con._session
+    session_id = con._session
     return ibis.mapd.connect(
         host=OMNISCI_HOST,
         port=OMNISCI_PORT,
-        sessionid=sessionid
+        session_id=session_id
     )
 
 

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -1,7 +1,6 @@
-import sys
-
 import pandas as pd
 import pytest
+from pkg_resources import get_distribution, parse_version
 
 import ibis
 import ibis.common as com
@@ -40,9 +39,18 @@ def test_list_tables(con):
     assert len(con.list_tables(like='functional_alltypes')) == 1
 
 
-@pytest.mark.skipif(sys.version_info < (3, 6), reason='must have pymapd>=12')
+@pytest.mark.skipif(
+    parse_version(get_distribution('pymapd').version) < parse_version('0.12'),
+    reason='must have pymapd>=12 to connect to existing session'
+)
 def test_session_id_connection(session_con):
-    assert session_con.list_tables()
+    new_connection = ibis.mapd.connect(
+        protocol=session_con.protocol,
+        host=session_con.host,
+        port=session_con.port,
+        session_id=session_con.con._session
+    )
+    assert new_connection.list_tables()
 
 
 def test_compile_verify(alltypes):

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -38,6 +38,10 @@ def test_list_tables(con):
     assert len(con.list_tables(like='functional_alltypes')) == 1
 
 
+def test_sessionid_connection(session_con):
+    assert len(session_con.list_tables()) > 0
+
+
 def test_compile_verify(alltypes):
     supported_expr = alltypes.double_col.sum()
     assert supported_expr.verify()

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -41,7 +41,7 @@ def test_list_tables(con):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason='must have pymapd>=12')
-def test_sessionid_connection(session_con):
+def test_session_id_connection(session_con):
     assert session_con.list_tables()
 
 

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -39,7 +39,7 @@ def test_list_tables(con):
 
 
 def test_sessionid_connection(session_con):
-    assert len(session_con.list_tables()) > 0
+    assert session_con.list_tables()
 
 
 def test_compile_verify(alltypes):

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -1,3 +1,5 @@
+import sys
+
 import pandas as pd
 import pytest
 
@@ -38,6 +40,7 @@ def test_list_tables(con):
     assert len(con.list_tables(like='functional_alltypes')) == 1
 
 
+@pytest.mark.skipif(sys.version_info < (3, 6), reason='must have pymapd>=12')
 def test_sessionid_connection(session_con):
     assert session_con.list_tables()
 


### PR DESCRIPTION
`pymapd` recently gained the ability to connect via a pre-authenticated session ID. It would be nice if the Ibis mapd connector could do that as well. cc @xmnlab 