### PR TITLE
consolidate trailing window functions

### DIFF
--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -15,6 +15,7 @@
 import pytest
 
 import ibis
+from ibis.expr.window import _determine_how
 from ibis.tests.util import assert_equal
 
 
@@ -174,3 +175,21 @@ def test_preceding_following_validate(alltypes):
 @pytest.mark.xfail(raises=AssertionError, reason='NYT')
 def test_window_equals(alltypes):
     assert False
+
+
+def test_determine_how():
+    preceding = (None, 5)
+    how = _determine_how(preceding)
+    assert how == 'rows'
+
+    preceding = (3, 1)
+    how = _determine_how(preceding)
+    assert how == 'rows'
+
+    preceding = 5
+    how = _determine_how(preceding)
+    assert how == 'rows'
+
+    preceding = ibis.interval(days=3)
+    how = _determine_how(preceding)
+    assert how == 'range'

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import pytest
 
 import ibis
@@ -178,18 +179,32 @@ def test_window_equals(alltypes):
 
 
 def test_determine_how():
-    preceding = (None, 5)
-    how = _determine_how(preceding)
+    how = _determine_how((None, 5))
     assert how == 'rows'
 
-    preceding = (3, 1)
-    how = _determine_how(preceding)
+    how = _determine_how((3, 1))
     assert how == 'rows'
 
-    preceding = 5
-    how = _determine_how(preceding)
+    how = _determine_how(5)
     assert how == 'rows'
 
-    preceding = ibis.interval(days=3)
-    how = _determine_how(preceding)
+    how = _determine_how(np.int64(7))
+    assert how == 'rows'
+
+    how = _determine_how(ibis.interval(days=3))
     assert how == 'range'
+
+    how = _determine_how(ibis.interval(months=5) + ibis.interval(days=10))
+    assert how == 'range'
+
+    with pytest.raises(TypeError):
+        _determine_how(8.9)
+
+    with pytest.raises(TypeError):
+        _determine_how('invalid preceding')
+
+    with pytest.raises(TypeError):
+        _determine_how({'start': 1, 'end': 2})
+
+    with pytest.raises(TypeError):
+        _determine_how([3, 5])

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -1,5 +1,7 @@
 """Encapsulation of SQL window clauses."""
 
+import numpy as np
+
 import ibis.common as com
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
@@ -20,10 +22,15 @@ def _determine_how(preceding):
     else:
         offset_type = type(preceding)
 
-    if issubclass(offset_type, int):
+    if issubclass(offset_type, (int, np.integer)):
         how = 'rows'
-    else:
+    elif issubclass(offset_type, ir.IntervalScalar):
         how = 'range'
+    else:
+        raise TypeError(
+            'Type {} is not supported for row- or range- based trailing '
+            'window operations'.format(offset_type)
+        )
 
     return how
 

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -10,6 +10,24 @@ def _sequence_to_tuple(x):
     return tuple(x) if util.is_iterable(x) else x
 
 
+def _determine_how(preceding):
+    if isinstance(preceding, tuple):
+        start, end = preceding
+        if start is None:
+            offset_type = type(end)
+        else:
+            offset_type = type(start)
+    else:
+        offset_type = type(preceding)
+
+    if isinstance(offset_type, type(int)):
+        how = 'rows'
+    else:
+        how = 'range'
+
+    return how
+
+
 class Window:
     """Class to encapsulate the details of a window frame.
 
@@ -310,13 +328,16 @@ def cumulative_window(group_by=None, order_by=None):
     )
 
 
-def trailing_window(rows, group_by=None, order_by=None):
+def trailing_window(preceding, group_by=None, order_by=None):
     """Create a trailing window for use with aggregate window functions.
 
     Parameters
     ----------
-    rows : int
-        Number of trailing rows to include. 0 includes only the current row
+    preceding : int, float or expression of intervals, i.e.
+        ibis.interval(days=1) + ibis.interval(hours=5)
+        Int indicates number of trailing rows to include;
+        0 includes only the current row.
+        Interval indicates a trailing range window.
     group_by : expressions, default None
         Either specify here or with TableExpr.group_by
     order_by : expressions, default None
@@ -328,8 +349,13 @@ def trailing_window(rows, group_by=None, order_by=None):
     Window
 
     """
+    how = _determine_how(preceding)
     return Window(
-        preceding=rows, following=0, group_by=group_by, order_by=order_by
+        preceding=preceding,
+        following=0,
+        group_by=group_by,
+        order_by=order_by,
+        how=how
     )
 
 

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -20,7 +20,7 @@ def _determine_how(preceding):
     else:
         offset_type = type(preceding)
 
-    if isinstance(offset_type, type(int)):
+    if issubclass(offset_type, int):
         how = 'rows'
     else:
         how = 'range'


### PR DESCRIPTION
This constitutes one step of several required to extend Ibis trailing window functionality, where trailing_window will become more extensible to support various types of 'preceding' parameters. In this first step, trailing_window is able to handle not only integers but ibis intervals as well, using the type of the 'preceding' parameter to determine the 'how' of the window.