### PR TITLE
BUG: Chained mutate operations give wrong results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ testfast:
 	PYTHONHASHSEED=${PYTHONHASHSEED} $(MAKEFILE_DIR)/ci/test.sh -n auto -m 'not (udf or impala or hdfs or bigquery)' -k 'not test_import_time' \
 	    --doctest-modules --doctest-ignore-import-errors ${PYTEST_OPTIONS}
 
+testlocal:
+	PYTHONHASHSEED=${PYTHONHASHSEED} pytest -n auto -m 'not (udf or impala or hdfs or bigquery or mysql or mapd or postgresql or clickhouse)' -k 'not test_import_time' \
+	    ${PYTEST_OPTIONS}
+
 docclean:
 	$(DOCKER_RUN) ibis-docs rm -rf /tmp/docs.ibis-project.org
 

--- a/ibis/expr/tests/test_analysis.py
+++ b/ibis/expr/tests/test_analysis.py
@@ -56,7 +56,8 @@ def test_rewrite_past_projection(con):
     table5 = table[(table.f * 2).name('c'), table.f]
     expr = table5['c'] == 2
     result = L.substitute_parents(expr)
-    assert result is expr
+    expected = expr
+    assert result.equals(expected)
 
 
 def test_multiple_join_deeper_reference():
@@ -207,14 +208,11 @@ def test_fuse_filter_sort_by():
 
 def test_no_rewrite(con):
     table = con.table('test1')
-
-    # Substitution not fully possible if we depend on a new expr in a
-    # projection
     table4 = table[['c', (table['c'] * 2).name('foo')]]
     expr = table4['c'] == table4['foo']
     result = L.substitute_parents(expr)
-    expected = table['c'] == table4['foo']
-    assert_equal(result, expected)
+    expected = expr
+    assert result.equals(expected)
 
 
 # def test_projection_with_join_pushdown_rewrite_refs():

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -2,6 +2,8 @@ import itertools
 import os
 import webbrowser
 
+import numpy as np
+
 import ibis
 import ibis.common as com
 import ibis.config as config
@@ -177,10 +179,7 @@ class Expr:
 
     @property
     def _factory(self):
-        def factory(arg, name=None):
-            return type(self)(arg, name=name)
-
-        return factory
+        return type(self)
 
     def execute(self, limit='default', params=None, **kwargs):
         """
@@ -472,18 +471,12 @@ class TableExpr(Expr):
 
     def _resolve(self, exprs):
         exprs = util.promote_list(exprs)
-
-        # Stash this helper method here for now
-        out_exprs = []
-        for expr in exprs:
-            expr = self._ensure_expr(expr)
-            out_exprs.append(expr)
-        return out_exprs
+        return list(map(self._ensure_expr, exprs))
 
     def _ensure_expr(self, expr):
         if isinstance(expr, str):
             return self[expr]
-        elif isinstance(expr, int):
+        elif isinstance(expr, (int, np.integer)):
             return self[self.schema().name_at_position(expr)]
         elif not isinstance(expr, Expr):
             return expr(self)

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -308,7 +308,7 @@ class MySQL(Backend, RoundHalfToEven):
         return t.mutate(bool_col=t.bool_col == 1)
 
 
-class Clickhouse(Backend, RoundHalfToEven):
+class Clickhouse(UnorderedComparator, Backend, RoundHalfToEven):
     check_dtype = False
     supports_window_operations = False
     returned_timestamp_unit = 's'


### PR DESCRIPTION
Closes #1799

This was kind of a nasty one. The query flattening optimization was far too
aggressive.

@toryhaavik Do you feel comfortable reviewing this?

One downside to this fix is that simple, single expression columns are not flattened into their subquery anymore. This will be addressed in the future after the compiler is refactored.