### PR TITLE
Remove pandas exception for rows_with_max_lookback

### DIFF
--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -298,7 +298,15 @@ class Window:
 
 
 def rows_with_max_lookback(rows, max_lookback):
-    """Create a bound preceding value for use with trailing window functions"""
+    """Create a bound preceding value for use with trailing window functions
+
+    Notes
+    -----
+    This function is exposed for use by external clients, but Ibis itself does
+    not currently do anything with the max_lookback parameter in any of its
+    backends.
+
+    """
     return RowsWithMaxLookback(rows, max_lookback)
 
 

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -466,8 +466,10 @@ def test_window_with_mlb():
             ibis.trailing_window(rows_with_mlb, order_by='time')
         )
     )
-    with pytest.raises(NotImplementedError):
-        expr.execute()
+    result = expr.execute()
+    expected = df
+    expected['sum'] = expected.a.rolling(5, min_periods=1).sum()
+    tm.assert_frame_equal(result, expected)
 
     rows_with_mlb = rows_with_max_lookback(5, 10)
     with pytest.raises(com.IbisInputError):

--- a/ibis/pandas/execution/window.py
+++ b/ibis/pandas/execution/window.py
@@ -90,10 +90,6 @@ def execute_window_op(
         **kwargs,
     )
 
-    if window.max_lookback is not None:
-        raise NotImplementedError('Rows with max lookback is not implemented '
-                                  'for pandas backend.')
-
     following = window.following
     order_by = window._order_by
 


### PR DESCRIPTION
Without this exception external clients will be able to use rows_with_max_lookback with pandas