### PR TITLE
FEAT: Use pandas rolling apply to implement rows_with_max_lookback

### DIFF
--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -59,22 +59,40 @@ def test_combine_windows(alltypes):
     )
     assert_equal(w5, expected)
 
-    # Cannot combine windows of varying types.
-    w6 = ibis.range_window(preceding=5, following=5)
-    with pytest.raises(ibis.common.IbisInputError):
-        w1.combine(w6)
+    w6 = ibis.window(preceding=0, following=5)
+    w7 = ibis.window(preceding=7, following=10)
+    w8 = w6.combine(w7)
+    expected = ibis.window(preceding=7, following=5)
+    assert_equal(w8, expected)
 
-    w7 = ibis.trailing_window(
+    # Cannot combine windows of varying types.
+    w9 = ibis.range_window(preceding=5, following=5)
+    with pytest.raises(ibis.common.IbisInputError):
+        w1.combine(w9)
+
+    w10 = ibis.trailing_range_window(
+        preceding=ibis.interval(days=3), order_by=t.e
+    )
+    w11 = ibis.trailing_range_window(
+        preceding=ibis.interval(days=4), order_by=t.f
+    )
+    w12 = w10.combine(w11)
+    expected = ibis.trailing_range_window(
+        preceding=ibis.interval(days=3), order_by=[t.e, t.f]
+    )
+    assert_equal(w12, expected)
+
+    w13 = ibis.trailing_window(
         rows_with_max_lookback(3, ibis.interval(days=5))
     )
-    w8 = ibis.trailing_window(
+    w14 = ibis.trailing_window(
         rows_with_max_lookback(5, ibis.interval(days=7))
     )
-    w9 = w7.combine(w8)
+    w15 = w13.combine(w14)
     expected = ibis.trailing_window(
         rows_with_max_lookback(3, ibis.interval(days=5))
     )
-    assert_equal(w9, expected)
+    assert_equal(w15, expected)
 
 
 def test_replace_window(alltypes):

--- a/ibis/expr/tests/test_window_functions.py
+++ b/ibis/expr/tests/test_window_functions.py
@@ -59,40 +59,60 @@ def test_combine_windows(alltypes):
     )
     assert_equal(w5, expected)
 
-    w6 = ibis.window(preceding=0, following=5)
-    w7 = ibis.window(preceding=7, following=10)
-    w8 = w6.combine(w7)
-    expected = ibis.window(preceding=7, following=5)
-    assert_equal(w8, expected)
-
     # Cannot combine windows of varying types.
     w9 = ibis.range_window(preceding=5, following=5)
     with pytest.raises(ibis.common.IbisInputError):
         w1.combine(w9)
 
-    w10 = ibis.trailing_range_window(
+
+def test_combine_windows_with_zero_offset():
+    w1 = ibis.window(preceding=0, following=5)
+    w2 = ibis.window(preceding=7, following=10)
+    w3 = w1.combine(w2)
+    expected = ibis.window(preceding=7, following=5)
+    assert_equal(w3, expected)
+
+    w4 = ibis.window(preceding=3, following=0)
+    w5 = w4.combine(w2)
+    expected = ibis.window(preceding=3, following=10)
+    assert_equal(w5, expected)
+
+
+def test_combine_window_with_interval_offset(alltypes):
+    t = alltypes
+    w1 = ibis.trailing_range_window(
         preceding=ibis.interval(days=3), order_by=t.e
     )
-    w11 = ibis.trailing_range_window(
+    w2 = ibis.trailing_range_window(
         preceding=ibis.interval(days=4), order_by=t.f
     )
-    w12 = w10.combine(w11)
+    w3 = w1.combine(w2)
     expected = ibis.trailing_range_window(
         preceding=ibis.interval(days=3), order_by=[t.e, t.f]
     )
-    assert_equal(w12, expected)
+    assert_equal(w3, expected)
 
-    w13 = ibis.trailing_window(
+    w4 = ibis.range_window(following=ibis.interval(days=5), order_by=t.e)
+    w5 = ibis.range_window(following=ibis.interval(days=7), order_by=t.f)
+    expected = ibis.range_window(
+        following=ibis.interval(days=5), order_by=[t.e, t.f]
+    )
+    w6 = w4.combine(w5)
+    assert_equal(w6, expected)
+
+
+def test_combine_window_with_max_lookback():
+    w1 = ibis.trailing_window(
         rows_with_max_lookback(3, ibis.interval(days=5))
     )
-    w14 = ibis.trailing_window(
+    w2 = ibis.trailing_window(
         rows_with_max_lookback(5, ibis.interval(days=7))
     )
-    w15 = w13.combine(w14)
+    w3 = w1.combine(w2)
     expected = ibis.trailing_window(
         rows_with_max_lookback(3, ibis.interval(days=5))
     )
-    assert_equal(w15, expected)
+    assert_equal(w3, expected)
 
 
 def test_replace_window(alltypes):

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -22,6 +22,16 @@ RowsWithMaxLookback = NamedTuple('RowsWithMaxLookback',
                                  )
 
 
+def _choose_non_empty_val(first, second):
+    if isinstance(first, (int, np.integer)) and first:
+        non_empty_value = first
+    elif not isinstance(first, (int, np.integer)) and first is not None:
+        non_empty_value = first
+    else:
+        non_empty_value = second
+    return non_empty_value
+
+
 def _determine_how(preceding):
     offset_type = type(_get_preceding_value(preceding))
     if issubclass(offset_type, (int, np.integer)):
@@ -230,14 +240,10 @@ class Window:
                     "Expecting '{}' Window, got '{}'"
                 ).format(self.how.upper(), window.how.upper())
             )
-        prec = self.preceding
+
         kwds = dict(
-            preceding=(prec
-                       if (isinstance(prec, (int, np.integer)) and prec)
-                       or (not isinstance(prec, (int, np.integer))
-                           and prec is not None)
-                       else window.preceding),
-            following=self.following or window.following,
+            preceding=_choose_non_empty_val(self.preceding, window.preceding),
+            following=_choose_non_empty_val(self.following, window.following),
             max_lookback=self.max_lookback or window.max_lookback,
             group_by=self._group_by + window._group_by,
             order_by=self._order_by + window._order_by,

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -228,7 +228,7 @@ import ibis.util
 
 
 class AggregationContext(abc.ABC):
-    __slots__ = 'parent', 'group_by', 'order_by', 'dtype'
+    __slots__ = 'parent', 'group_by', 'order_by', 'dtype', 'max_lookback'
 
     def __init__(self,
                  parent=None,

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -371,9 +371,9 @@ class Window(AggregationContext):
             if max_lookback is not None:
                 agg_method = method
 
-                def f(s):
+                def sliced_agg(s):
                     return agg_method(s.iloc[-max_lookback:])
-                method = operator.methodcaller('apply', f, raw=False)
+                method = operator.methodcaller('apply', sliced_agg, raw=False)
 
         # get the DataFrame from which the operand originated (passed in when
         # constructing this context object in execute_node(ops.WindowOp))

--- a/ibis/pandas/execution/window.py
+++ b/ibis/pandas/execution/window.py
@@ -168,9 +168,11 @@ def execute_window_op(
         # XXX(phillipc): What a horror show
         preceding = window.preceding
         if preceding is not None:
+            max_lookback = window.max_lookback
             assert not isinstance(operand.op(), ops.CumulativeOp)
             aggcontext = agg_ctx.Moving(
                 preceding,
+                max_lookback,
                 parent=source,
                 group_by=grouping_keys,
                 order_by=ordering_keys,


### PR DESCRIPTION
The offset interval specified in RowsWithMaxLookback should be used in the determination of each row's window, not just the first n rows. For the pandas backend, rolling apply can be used to implement this functionality.