### PR TITLE
FEAT: Add support for Postgres UDFs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/seed-isort-config
-    rev: v1.7.0
+    rev: v1.9.2
     hooks:
       - id: seed-isort-config
   - repo: https://github.com/pre-commit/mirrors-isort

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ COMPOSE_FILE := "$(MAKEFILE_DIR)/ci/docker-compose.yml"
 DOCKER := docker-compose -f $(COMPOSE_FILE)
 DOCKER_RUN := PYTHON_VERSION=${PYTHON_VERSION} $(DOCKER) run --rm
 PYTEST_OPTIONS :=
-SERVICES := omnisci postgres mysql clickhouse impala kudu-master kudu-tserver
+SERVICES := omnisci postgres waiter-postgres mysql clickhouse impala kudu-master kudu-tserver
 
 clean:
 	python setup.py clean

--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -51,6 +51,7 @@ jobs:
         docker-compose up -d --no-build \
           mysql \
           postgres \
+          waiter-postgres \
           impala \
           clickhouse \
           omnisci \

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -112,7 +112,7 @@ jobs:
 
     - script: |
         call activate $(conda.env)
-        python ci/datamgr.py postgres --psql-path="C:/Program Files/PostgreSQL/10/bin/psql.exe" -t functional_alltypes -t diamonds -t batting -t awards_players
+        python ci/datamgr.py postgres --no-plpython --psql-path="C:/Program Files/PostgreSQL/10/bin/psql.exe" -t functional_alltypes -t diamonds -t batting -t awards_players
       displayName: 'Load PostgreSQL data'
 
     - script: |

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -127,7 +127,7 @@ jobs:
 
     - script: |
         call activate $(conda.env)
-        pytest --tb=short --junitxml="junit-$(python.version).xml" -n auto -m "not backend and not clickhouse and not impala and not hdfs and not bigquery and not mapd and not postgis" -ra ibis
+        pytest --tb=short --junitxml="junit-$(python.version).xml" -n auto -m "not backend and not clickhouse and not impala and not hdfs and not bigquery and not mapd and not postgres_extensions" -ra ibis
       displayName: 'Run tests'
 
     - task: PublishTestResults@2

--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -239,6 +239,8 @@ def postgres(schema, tables, data_directory, psql_path, **params):
     if use_postgis:
         engine.execute("CREATE EXTENSION POSTGIS")
 
+    engine.execute("CREATE EXTENSION IF NOT EXISTS PLPYTHONU")
+
     query = "COPY {} FROM STDIN WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',')"
     database = params['database']
     for table in tables:

--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -231,8 +231,7 @@ def parquet(tables, data_directory, ignore_missing_dependency, **params):
 @click.option(
     '--plpython/--no-plpython',
     help='Create PL/Python extension in database',
-    is_flag=True,
-    default=False
+    default=True
 )
 def postgres(schema, tables, data_directory, psql_path, plpython, **params):
     psql = local[psql_path]
@@ -243,7 +242,7 @@ def postgres(schema, tables, data_directory, psql_path, plpython, **params):
     )
     use_postgis = 'geo' in tables and sys.version_info >= (3, 6)
     if use_postgis:
-        engine.execute("CREATE EXTENSION POSTGIS")
+        engine.execute("CREATE EXTENSION IF NOT EXISTS POSTGIS")
 
     if plpython:
         engine.execute("CREATE EXTENSION IF NOT EXISTS PLPYTHONU")

--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -240,6 +240,9 @@ def postgres(schema, tables, data_directory, psql_path, plpython, **params):
     engine = init_database(
         'postgresql', params, schema, isolation_level='AUTOCOMMIT'
     )
+
+    engine.execute("CREATE SEQUENCE IF NOT EXISTS test_sequence;")
+
     use_postgis = 'geo' in tables and sys.version_info >= (3, 6)
     if use_postgis:
         engine.execute("CREATE EXTENSION IF NOT EXISTS POSTGIS")

--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -228,7 +228,13 @@ def parquet(tables, data_directory, ignore_missing_dependency, **params):
     required=os.name == 'nt',
     default=None if os.name == 'nt' else '/usr/bin/psql',
 )
-def postgres(schema, tables, data_directory, psql_path, **params):
+@click.option(
+    '--plpython/--no-plpython',
+    help='Create PL/Python extension in database',
+    is_flag=True,
+    default=False
+)
+def postgres(schema, tables, data_directory, psql_path, plpython, **params):
     psql = local[psql_path]
     data_directory = Path(data_directory)
     logger.info('Initializing PostgreSQL...')
@@ -239,7 +245,8 @@ def postgres(schema, tables, data_directory, psql_path, **params):
     if use_postgis:
         engine.execute("CREATE EXTENSION POSTGIS")
 
-    engine.execute("CREATE EXTENSION IF NOT EXISTS PLPYTHONU")
+    if plpython:
+        engine.execute("CREATE EXTENSION IF NOT EXISTS PLPYTHONU")
 
     query = "COPY {} FROM STDIN WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',')"
     database = params['database']

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -2,12 +2,12 @@ version: '3'
 services:
 
   postgres:
-    image: mdillon/postgis
+    image: shajekpivotal/postgres-9.5-postgis-2.5
     hostname: postgres
     ports:
       - 5432:5432
     environment:
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: ''
 
   mysql:
     image: mariadb:10.2

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       - 25000:25000
       - 25010:25010
       - 25020:25020
+    depends_on:
+      - "waiter-postgres"
 
   clickhouse:
     image: yandex/clickhouse-server:18.12
@@ -103,6 +105,13 @@ services:
                 -wait tcp://clickhouse:9000
                 -wait-retry-interval 5s
                 -timeout 10m
+
+  waiter-postgres:
+    image: jwilder/dockerize
+    command: |
+      dockerize -wait tcp://postgres:5432
+    depends_on:
+      - "postgres"
 
   ibis:
     image: ibis:${PYTHON_VERSION:-3.6}

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
 
   postgres:
-    image: shajekpivotal/postgres-9.5-postgis-2.5
+    image: shajekpivotal/ibis-docker-postgres-9.5
     hostname: postgres
     ports:
       - 5432:5432

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -102,7 +102,7 @@ services:
                 -wait tcp://kudu-tserver:8050
                 -wait tcp://clickhouse:9000
                 -wait-retry-interval 5s
-                -timeout 5m
+                -timeout 10m
 
   ibis:
     image: ibis:${PYTHON_VERSION:-3.6}

--- a/ci/load-data.sh
+++ b/ci/load-data.sh
@@ -4,7 +4,7 @@ CWD="$(dirname "${0}")"
 
 declare -A argcommands=([sqlite]=sqlite
                         [parquet]="parquet -i"
-                        [postgres]='postgres --plpython'
+                        [postgres]=postgres
                         [clickhouse]=clickhouse
                         [omnisci]=omnisci
                         [mysql]=mysql

--- a/ci/load-data.sh
+++ b/ci/load-data.sh
@@ -4,7 +4,7 @@ CWD="$(dirname "${0}")"
 
 declare -A argcommands=([sqlite]=sqlite
                         [parquet]="parquet -i"
-                        [postgres]=postgres
+                        [postgres]='postgres --plpython'
                         [clickhouse]=clickhouse
                         [omnisci]=omnisci
                         [mysql]=mysql

--- a/ibis/sql/postgres/__init__.py
+++ b/ibis/sql/postgres/__init__.py
@@ -1,3 +1,3 @@
-from ibis.sql.postgres.udf import existing_udf
+from ibis.sql.postgres.udf import existing_udf, udf
 
-__all__ = ('existing_udf',)
+__all__ = ('existing_udf', 'udf')

--- a/ibis/sql/postgres/__init__.py
+++ b/ibis/sql/postgres/__init__.py
@@ -1,3 +1,3 @@
-from ibis.sql.postgres.udf import existing_udf, func_to_udf
+from ibis.sql.postgres.udf import existing_udf
 
-__all__ = ('existing_udf', 'func_to_udf')
+__all__ = ('existing_udf',)

--- a/ibis/sql/postgres/__init__.py
+++ b/ibis/sql/postgres/__init__.py
@@ -1,0 +1,3 @@
+from ibis.sql.postgres.udf import existing_udf, func_to_udf
+
+__all__ = ('existing_udf', 'func_to_udf')

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -203,13 +203,8 @@ class PostgreSQLClient(alch.AlchemyClient):
             return parent.list_tables(like=like, schema=schema)
 
     def udf(
-            self,
-            pyfunc,
-            in_types,
-            out_type,
-            schema=None,
-            replace=False,
-            name=None):
+        self, pyfunc, in_types, out_type, schema=None, replace=False, name=None
+    ):
         """Decorator that defines a PL/Python UDF in-database based on the
         wrapped function and turns it into an ibis function expression.
 
@@ -237,5 +232,5 @@ class PostgreSQLClient(alch.AlchemyClient):
             out_type=out_type,
             schema=schema,
             replace=replace,
-            name=name
+            name=name,
         )

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -210,6 +210,7 @@ class PostgreSQLClient(alch.AlchemyClient):
 
         Parameters
         ----------
+        pyfunc : function
         in_types : List[ibis.expr.datatypes.DataType]
         out_type : ibis.expr.datatypes.DataType
         schema : str
@@ -221,8 +222,10 @@ class PostgreSQLClient(alch.AlchemyClient):
 
         Returns
         -------
-        wrapper : Callable that takes in a python function and returns
-            an ibis function
+        Callable
+
+        Function that takes in ColumnExpr arguments and returns an instance
+        inheriting from PostgresUDFNode
         """
 
         return func_to_udf(

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -19,8 +19,8 @@ import psycopg2  # NOQA fail early if the driver is missing
 import sqlalchemy as sa
 
 import ibis.sql.alchemy as alch
+from ibis.sql.postgres import udf
 from ibis.sql.postgres.compiler import PostgreSQLDialect
-from ibis.sql.postgres.udf.api import func_to_udf
 
 
 class PostgreSQLTable(alch.AlchemyTable):
@@ -228,8 +228,8 @@ class PostgreSQLClient(alch.AlchemyClient):
         inheriting from PostgresUDFNode
         """
 
-        return func_to_udf(
-            conn=self.con,
+        return udf(
+            client=self,
             python_func=pyfunc,
             in_types=in_types,
             out_type=out_type,

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -20,7 +20,7 @@ import sqlalchemy as sa
 
 import ibis.sql.alchemy as alch
 from ibis.sql.postgres.compiler import PostgreSQLDialect
-from ibis.sql.postgres.udf import func_to_udf
+from ibis.sql.postgres.udf.api import func_to_udf
 
 
 class PostgreSQLTable(alch.AlchemyTable):

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 import contextlib
 import getpass
 
@@ -21,7 +20,7 @@ import sqlalchemy as sa
 
 import ibis.sql.alchemy as alch
 from ibis.sql.postgres.compiler import PostgreSQLDialect
-from ibis.sql.postgres.udf import func_to_udf
+from ibis.sql.postgres.udf import UdfDecorator
 
 
 class PostgreSQLTable(alch.AlchemyTable):
@@ -223,10 +222,9 @@ class PostgreSQLClient(alch.AlchemyClient):
         wrapper : Callable that takes in a python function and returns
             an ibis function
         """
-        raise NotImplementedError
-        return functools.partial(
-            func_to_udf,
-            self,
+
+        return UdfDecorator(
+            engine=self.con,
             in_types=in_types,
             out_type=out_type,
             schema=schema,

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import contextlib
 import getpass
 
@@ -20,6 +21,7 @@ import sqlalchemy as sa
 
 import ibis.sql.alchemy as alch
 from ibis.sql.postgres.compiler import PostgreSQLDialect
+from ibis.sql.postgres.udf import func_to_udf
 
 
 class PostgreSQLTable(alch.AlchemyTable):
@@ -200,3 +202,34 @@ class PostgreSQLClient(alch.AlchemyClient):
         else:
             parent = super(PostgreSQLClient, self)
             return parent.list_tables(like=like, schema=schema)
+
+    def udf(self, in_types, out_type, schema=None, overwrite=False, name=None):
+        """Decorator that defines a PL/Python UDF in-database based on the
+        wrapped function and turns it into an ibis function expression.
+
+        Parameters
+        ----------
+        in_types : List[ibis.expr.datatypes.DataType]
+        out_type : ibis.expr.datatypes.DataType
+        schema : str
+            optionally specify the schema in which to define the UDF
+        overwrite : bool
+            replace UDF in database if already exists
+        name: str
+            name for the UDF to be defined in database
+
+        Returns
+        -------
+        wrapper : Callable that takes in a python function and returns
+            an ibis function
+        """
+        raise NotImplementedError
+        return functools.partial(
+            func_to_udf,
+            self,
+            in_types=in_types,
+            out_type=out_type,
+            schema=schema,
+            overwrite=overwrite,
+            name=name
+        )

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -202,7 +202,7 @@ class PostgreSQLClient(alch.AlchemyClient):
             parent = super(PostgreSQLClient, self)
             return parent.list_tables(like=like, schema=schema)
 
-    def udf(self, in_types, out_type, schema=None, overwrite=False, name=None):
+    def udf(self, in_types, out_type, schema=None, replace=False, name=None):
         """Decorator that defines a PL/Python UDF in-database based on the
         wrapped function and turns it into an ibis function expression.
 
@@ -212,7 +212,7 @@ class PostgreSQLClient(alch.AlchemyClient):
         out_type : ibis.expr.datatypes.DataType
         schema : str
             optionally specify the schema in which to define the UDF
-        overwrite : bool
+        replace : bool
             replace UDF in database if already exists
         name: str
             name for the UDF to be defined in database
@@ -228,6 +228,6 @@ class PostgreSQLClient(alch.AlchemyClient):
             in_types=in_types,
             out_type=out_type,
             schema=schema,
-            overwrite=overwrite,
+            replace=replace,
             name=name
         )

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -202,7 +202,14 @@ class PostgreSQLClient(alch.AlchemyClient):
             parent = super(PostgreSQLClient, self)
             return parent.list_tables(like=like, schema=schema)
 
-    def udf(self, in_types, out_type, schema=None, replace=False, name=None):
+    def udf(
+            self,
+            pyfunc,
+            in_types,
+            out_type,
+            schema=None,
+            replace=False,
+            name=None):
         """Decorator that defines a PL/Python UDF in-database based on the
         wrapped function and turns it into an ibis function expression.
 
@@ -223,15 +230,12 @@ class PostgreSQLClient(alch.AlchemyClient):
             an ibis function
         """
 
-        def udf_decorator(f):
-            return func_to_udf(
-                conn=self.con,
-                python_func=f,
-                in_types=in_types,
-                out_type=out_type,
-                schema=schema,
-                replace=replace,
-                name=name
-            )
-
-        return udf_decorator
+        return func_to_udf(
+            conn=self.con,
+            python_func=pyfunc,
+            in_types=in_types,
+            out_type=out_type,
+            schema=schema,
+            replace=replace,
+            name=name
+        )

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -20,7 +20,7 @@ import sqlalchemy as sa
 
 import ibis.sql.alchemy as alch
 from ibis.sql.postgres.compiler import PostgreSQLDialect
-from ibis.sql.postgres.udf import UdfDecorator
+from ibis.sql.postgres.udf import func_to_udf
 
 
 class PostgreSQLTable(alch.AlchemyTable):
@@ -223,11 +223,15 @@ class PostgreSQLClient(alch.AlchemyClient):
             an ibis function
         """
 
-        return UdfDecorator(
-            engine=self.con,
-            in_types=in_types,
-            out_type=out_type,
-            schema=schema,
-            replace=replace,
-            name=name
-        )
+        def udf_decorator(f):
+            return func_to_udf(
+                conn=self.con,
+                python_func=f,
+                in_types=in_types,
+                out_type=out_type,
+                schema=schema,
+                replace=replace,
+                name=name
+            )
+
+        return udf_decorator

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -29,6 +29,10 @@ _operation_registry = alch._operation_registry.copy()
 _operation_registry.update(alch._window_functions)
 
 
+class PostgresUDFNode(ops.ValueOp):
+    pass
+
+
 # TODO: substr and find are copied from SQLite, we should really have a
 # "base" set of SQL functions that are the most common APIs across the major
 # RDBMS

--- a/ibis/sql/postgres/tests/conftest.py
+++ b/ibis/sql/postgres/tests/conftest.py
@@ -36,7 +36,7 @@ IBIS_TEST_POSTGRES_DB = os.environ.get(
 )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='session')
 def con():
     return ibis.postgres.connect(
         host=PG_HOST,

--- a/ibis/sql/postgres/tests/test_postgis.py
+++ b/ibis/sql/postgres/tests/test_postgis.py
@@ -5,7 +5,7 @@ gp = pytest.importorskip('geopandas')
 sa = pytest.importorskip('sqlalchemy')
 pytest.importorskip('psycopg2')
 
-pytestmark = pytest.mark.postgis
+pytestmark = [pytest.mark.postgis, pytest.mark.postgres_extensions]
 
 
 def test_load_geodata(con):

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -15,7 +15,15 @@ datatypes = ibis.expr.datatypes
 
 # mark test module as postgresql (for ability to easily exclude,
 # e.g. in conda build tests)
-pytestmark = pytest.mark.postgresql
+# (Temporarily adding `postgis` marker so Azure Windows pipeline will exclude
+#     pl/python tests.
+#     TODO: update Windows pipeline to exclude postgres_extensions
+#     TODO: remove postgis marker below once Windows pipeline updated
+pytestmark = [
+    pytest.mark.postgresql,
+    pytest.mark.postgis,
+    pytest.mark.postgres_extensions,
+]
 
 # Database setup (tables and UDFs)
 

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -209,3 +209,11 @@ def orig_func(x, y, z):
     return x * y + z
 """
     assert remove_decorators(input_) == expected
+
+
+def test_remove_decorators_when_none_exist():
+    input_ = """\
+def orig_func(x, y, z):
+    return x * y + z
+"""
+    assert remove_decorators(input_) == input_

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -1,0 +1,98 @@
+"""Test support for already-defined UDFs in Postgres"""
+
+import pytest
+
+import ibis.expr.datatypes
+import ibis.sql.postgres.udf.api
+
+
+# Database setup (tables and UDFs)
+
+
+table_name = 'udf_test_users'
+
+sql_table_setup = """DROP TABLE IF EXISTS public.{table_name};
+CREATE TABLE public.{table_name} (
+    user_id integer,
+    user_name varchar,
+    name_length integer
+);
+INSERT INTO {table_name} VALUES
+(1, 'Raj', 3),
+(2, 'Judy', 4),
+(3, 'Jonathan', 8)
+;
+""".format(table_name=table_name)
+
+sql_create_plpython = "CREATE EXTENSION plpythonu"
+
+sql_define_py_udf = """CREATE OR REPLACE FUNCTION public.pylen(x varchar)
+RETURNS integer
+LANGUAGE plpythonu
+AS
+$$
+return len(x)
+$$;"""
+
+sql_define_udf = """CREATE OR REPLACE FUNCTION public.custom_len(x varchar)
+RETURNS integer
+LANGUAGE SQL
+AS
+$$
+SELECT length(x);
+$$;"""
+
+
+@pytest.fixture
+def con_for_udf(con):
+    # with con.con.begin() as cur_conn:
+    #     cur_conn.execute(sql_table_setup)
+    #     yield con
+    #     con.rollback()
+    con.con.execute(sql_table_setup)
+    con.con.execute(sql_define_udf)
+    con.con.execute(sql_define_py_udf)
+    # con.con.execute(sql_create_plpython)
+    yield con
+
+
+@pytest.fixture
+def table(con_for_udf):
+    return con_for_udf.table(table_name, schema='public')
+
+
+# Create ibis UDF objects referring to UDFs already created in the database
+
+custom_length_udf = ibis.sql.postgres.udf.api.existing_udf(
+    'custom_len',
+    input_type=[ibis.expr.datatypes.String()],
+    output_type=ibis.expr.datatypes.Integer(),
+    schema='public'
+)
+
+py_length_udf = ibis.sql.postgres.udf.api.existing_udf(
+    'pylen',
+    input_type=[ibis.expr.datatypes.String()],
+    output_type=ibis.expr.datatypes.Integer(),
+    schema='public'
+)
+
+
+# Tests
+
+def test_sql_length_udf_worked(table):
+    result_obj = table[
+        table,
+        custom_length_udf(table['user_name']).name('custom_len')
+    ]
+    result = result_obj.execute()
+    assert result['custom_len'].sum() == result['name_length'].sum()
+
+
+def test_py_length_udf_worked(table):
+    result_obj = table[
+        table,
+        py_length_udf(table['user_name']).name('custom_len')
+    ]
+    result = result_obj.execute()
+    assert result['custom_len'].sum() == result['name_length'].sum()

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -3,8 +3,11 @@
 import pytest
 
 import ibis.expr.datatypes as dt
-from ibis.sql.postgres import existing_udf, func_to_udf
-from ibis.sql.postgres.udf.api import remove_decorators
+from ibis.sql.postgres import existing_udf
+from ibis.sql.postgres.udf.api import (
+    func_to_udf,
+    remove_decorators
+)
 
 
 # mark test module as postgresql (for ability to easily exclude,

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -90,6 +90,7 @@ py_length_udf = ibis.sql.postgres.udf.api.existing_udf(
 # Tests
 
 def test_sql_length_udf_worked(table):
+    """Test creating ibis UDF object based on existing UDF in the database"""
     result_obj = table[
         table,
         custom_length_udf(table['user_name']).name('custom_len')
@@ -114,6 +115,8 @@ def mult_a_b(a, b):
 
 
 def test_func_to_udf_smoke(con_for_udf, table):
+    """Test creating a UDF in database based on Python function
+    and then creating an ibis UDF object based on that"""
     mult_a_b_udf = ibis.sql.postgres.udf.api.func_to_udf(
         con_for_udf.con,
         mult_a_b,

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -5,8 +5,8 @@ import functools
 import pytest
 
 import ibis.expr.datatypes as dt
-from ibis.sql.postgres import existing_udf
-from ibis.sql.postgres.udf.api import PostgresUDFError, func_to_udf
+from ibis.sql.postgres import existing_udf, udf
+from ibis.sql.postgres.udf.api import PostgresUDFError
 
 # mark test module as postgresql (for ability to easily exclude,
 # e.g. in conda build tests)
@@ -148,11 +148,11 @@ def mult_a_b(a, b):
     return a * b
 
 
-def test_func_to_udf(con_for_udf, test_schema, table):
+def test_udf(con_for_udf, test_schema, table):
     """Test creating a UDF in database based on Python function
     and then creating an ibis UDF object based on that"""
-    mult_a_b_udf = func_to_udf(
-        con_for_udf.con,
+    mult_a_b_udf = udf(
+        con_for_udf,
         mult_a_b,
         (dt.int32, dt.int32),
         dt.int32,

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -157,7 +157,7 @@ def test_func_to_udf_smoke(con_for_udf, test_schema, table):
         (dt.int32, dt.int32),
         dt.int32,
         schema=test_schema,
-        overwrite=True
+        replace=True
     )
     table_filt = table.filter(table['user_id'] == 2)
     expr = table_filt[
@@ -177,7 +177,7 @@ def test_client_udf_api(con_for_udf, test_schema, table):
         [dt.int32, dt.int32],
         dt.int32,
         schema=test_schema,
-        overwrite=True)
+        replace=True)
     def multiply(a, b):
         return a * b
 

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -2,79 +2,88 @@
 
 import pytest
 
+import sqlalchemy.exc
 import ibis.expr.datatypes
 import ibis.sql.postgres.udf.api
 
 
+datatypes = ibis.expr.datatypes
+
 # Database setup (tables and UDFs)
 
 
+test_schema = 'test'
+
 table_name = 'udf_test_users'
 
-sql_table_setup = """DROP TABLE IF EXISTS public.{table_name};
-CREATE TABLE public.{table_name} (
+sql_table_setup = """DROP TABLE IF EXISTS {schema}.{table_name};
+CREATE TABLE {schema}.{table_name} (
     user_id integer,
     user_name varchar,
     name_length integer
 );
-INSERT INTO {table_name} VALUES
+INSERT INTO {schema}.{table_name} VALUES
 (1, 'Raj', 3),
 (2, 'Judy', 4),
 (3, 'Jonathan', 8)
 ;
-""".format(table_name=table_name)
+""".format(table_name=table_name, schema=test_schema)
 
-sql_create_plpython = "CREATE EXTENSION plpythonu"
+sql_create_plpython = "CREATE EXTENSION plpythonu "
 
-sql_define_py_udf = """CREATE OR REPLACE FUNCTION public.pylen(x varchar)
+sql_define_py_udf = """CREATE OR REPLACE FUNCTION {schema}.pylen(x varchar)
 RETURNS integer
 LANGUAGE plpythonu
 AS
 $$
 return len(x)
-$$;"""
+$$;""".format(schema=test_schema)
 
-sql_define_udf = """CREATE OR REPLACE FUNCTION public.custom_len(x varchar)
+sql_define_udf = """CREATE OR REPLACE FUNCTION {schema}.custom_len(x varchar)
 RETURNS integer
 LANGUAGE SQL
 AS
 $$
 SELECT length(x);
-$$;"""
+$$;""".format(schema=test_schema)
 
 
 @pytest.fixture
 def con_for_udf(con):
-    # with con.con.begin() as cur_conn:
-    #     cur_conn.execute(sql_table_setup)
-    #     yield con
-    #     con.rollback()
+    con.con.execute("DROP SCHEMA IF EXISTS {} CASCADE".format(test_schema))
+    con.con.execute("CREATE SCHEMA {}".format(test_schema))
     con.con.execute(sql_table_setup)
     con.con.execute(sql_define_udf)
+    try:
+        con.con.execute(sql_create_plpython)
+    except sqlalchemy.exc.ProgrammingError as e:
+        if '"plpythonu" already exists' not in str(e):
+            raise Exception('PL/Python extension creation failed') from e
     con.con.execute(sql_define_py_udf)
-    # con.con.execute(sql_create_plpython)
     yield con
+    # teardown
+    con.con.execute("DROP SCHEMA IF EXISTS {} CASCADE".format(test_schema))
 
 
 @pytest.fixture
 def table(con_for_udf):
-    return con_for_udf.table(table_name, schema='public')
+    return con_for_udf.table(table_name, schema=test_schema)
 
 
 # Create ibis UDF objects referring to UDFs already created in the database
 
 custom_length_udf = ibis.sql.postgres.udf.api.existing_udf(
     'custom_len',
-    input_type=[ibis.expr.datatypes.String()],
+    input_types=[ibis.expr.datatypes.String()],
     output_type=ibis.expr.datatypes.Integer(),
-    schema='public'
+    schema=test_schema
 )
 
 py_length_udf = ibis.sql.postgres.udf.api.existing_udf(
     'pylen',
-    input_type=[ibis.expr.datatypes.String()],
+    input_types=[ibis.expr.datatypes.String()],
     output_type=ibis.expr.datatypes.Integer(),
-    schema='public'
+    schema=test_schema
 )
 
 
@@ -96,3 +105,29 @@ def test_py_length_udf_worked(table):
     ]
     result = result_obj.execute()
     assert result['custom_len'].sum() == result['name_length'].sum()
+
+
+def mult_a_b(a, b):
+    """Test function to be defined in-database as a UDF
+    and used via ibis UDF"""
+    return a * b
+
+
+def test_func_to_udf_smoke(con_for_udf, table):
+    mult_a_b_udf = ibis.sql.postgres.udf.api.func_to_udf(
+        con_for_udf.con,
+        mult_a_b,
+        (datatypes.Int32(), datatypes.Int32()),
+        datatypes.Int32(),
+        schema=test_schema,
+        overwrite=True
+    )
+    table_filt = table.filter(table['user_id'] == 2)
+    expr = table_filt[
+        mult_a_b_udf(
+            table_filt['user_id'],
+            table_filt['name_length']
+        ).name('mult_result')
+    ]
+    result = expr.execute()
+    assert result['mult_result'].iloc[0] == 8

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -111,7 +111,7 @@ def table(con_for_udf, table_name, test_schema):
 # Tests
 
 
-def test_sql_length_udf_worked(test_schema, table):
+def test_existing_sql_udf(test_schema, table):
     """Test creating ibis UDF object based on existing UDF in the database"""
     # Create ibis UDF objects referring to UDFs already created in the database
     custom_length_udf = existing_udf(
@@ -127,7 +127,7 @@ def test_sql_length_udf_worked(test_schema, table):
     assert result['custom_len'].sum() == result['name_length'].sum()
 
 
-def test_py_length_udf_worked(test_schema, table):
+def test_existing_plpython_udf(test_schema, table):
     # Create ibis UDF objects referring to UDFs already created in the database
     py_length_udf = existing_udf(
         'pylen',
@@ -148,7 +148,7 @@ def mult_a_b(a, b):
     return a * b
 
 
-def test_func_to_udf_smoke(con_for_udf, test_schema, table):
+def test_func_to_udf(con_for_udf, test_schema, table):
     """Test creating a UDF in database based on Python function
     and then creating an ibis UDF object based on that"""
     mult_a_b_udf = func_to_udf(

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -6,12 +6,10 @@ import string
 import pytest
 
 import pandas as pd
-import ibis.expr.datatypes
-import ibis.sql.postgres.udf.api
+import ibis.expr.datatypes as dt
+from ibis.sql.postgres import existing_udf, func_to_udf
 from ibis.sql.postgres.client import PostgreSQLClient
 
-
-datatypes = ibis.expr.datatypes
 
 # mark test module as postgresql (for ability to easily exclude,
 # e.g. in conda build tests)
@@ -26,9 +24,6 @@ pytestmark = [
 ]
 
 # Database setup (tables and UDFs)
-
-
-test_schema = None
 
 
 def gen_schema_name(basename='test'):
@@ -55,14 +50,24 @@ def create_test_schema(connection: PostgreSQLClient, max_tries=20):
         schema_exists = df_result['n_recs'].iloc[0] > 0
         tries += 1
     assert tries > 0
-    global test_schema
     test_schema = new_name
     connection.con.execute("CREATE SCHEMA {};".format(new_name))
+    return test_schema
 
 
-table_name = 'udf_test_users'
+@pytest.fixture
+def test_schema(con):
+    return create_test_schema(con)
 
-sql_table_setup = """DROP TABLE IF EXISTS {schema}.{table_name};
+
+@pytest.fixture
+def table_name():
+    return 'udf_test_users'
+
+
+@pytest.fixture
+def sql_table_setup(test_schema, table_name):
+    return """DROP TABLE IF EXISTS {schema}.{table_name};
 CREATE TABLE {schema}.{table_name} (
     user_id integer,
     user_name varchar,
@@ -73,52 +78,64 @@ INSERT INTO {schema}.{table_name} VALUES
 (2, 'Judy', 4),
 (3, 'Jonathan', 8)
 ;
-"""
+""".format(schema=test_schema, table_name=table_name)
 
-sql_define_py_udf = """CREATE OR REPLACE FUNCTION {schema}.pylen(x varchar)
+
+@pytest.fixture
+def sql_define_py_udf(test_schema):
+    return """CREATE OR REPLACE FUNCTION {schema}.pylen(x varchar)
 RETURNS integer
 LANGUAGE plpythonu
 AS
 $$
 return len(x)
-$$;"""
+$$;""".format(schema=test_schema)
 
-sql_define_udf = """CREATE OR REPLACE FUNCTION {schema}.custom_len(x varchar)
+
+@pytest.fixture
+def sql_define_udf(test_schema):
+    return """CREATE OR REPLACE FUNCTION {schema}.custom_len(x varchar)
 RETURNS integer
 LANGUAGE SQL
 AS
 $$
 SELECT length(x);
-$$;"""
+$$;""".format(schema=test_schema)
 
 
 @pytest.fixture
-def con_for_udf(con):
+def con_for_udf(
+        con,
+        test_schema,
+        sql_table_setup,
+        sql_define_udf,
+        sql_define_py_udf
+):
     create_test_schema(con)
-    con.con.execute(
-        sql_table_setup.format(table_name=table_name, schema=test_schema)
-    )
-    con.con.execute(sql_define_udf.format(schema=test_schema))
-    con.con.execute(sql_define_py_udf.format(schema=test_schema))
-    yield con
-    # teardown
-    con.con.execute("DROP SCHEMA IF EXISTS {} CASCADE".format(test_schema))
+    con.con.execute(sql_table_setup)
+    con.con.execute(sql_define_udf)
+    con.con.execute(sql_define_py_udf)
+    try:
+        yield con
+    finally:
+        # teardown
+        con.con.execute("DROP SCHEMA IF EXISTS {} CASCADE".format(test_schema))
 
 
 @pytest.fixture
-def table(con_for_udf):
+def table(con_for_udf, table_name, test_schema):
     return con_for_udf.table(table_name, schema=test_schema)
 
 # Tests
 
 
-def test_sql_length_udf_worked(table):
+def test_sql_length_udf_worked(test_schema, table):
     """Test creating ibis UDF object based on existing UDF in the database"""
     # Create ibis UDF objects referring to UDFs already created in the database
-    custom_length_udf = ibis.sql.postgres.udf.api.existing_udf(
+    custom_length_udf = existing_udf(
         'custom_len',
-        input_types=[ibis.expr.datatypes.String()],
-        output_type=ibis.expr.datatypes.Integer(),
+        input_types=[dt.string],
+        output_type=dt.int32,
         schema=test_schema
     )
     result_obj = table[
@@ -129,12 +146,12 @@ def test_sql_length_udf_worked(table):
     assert result['custom_len'].sum() == result['name_length'].sum()
 
 
-def test_py_length_udf_worked(table):
+def test_py_length_udf_worked(test_schema, table):
     # Create ibis UDF objects referring to UDFs already created in the database
-    py_length_udf = ibis.sql.postgres.udf.api.existing_udf(
+    py_length_udf = existing_udf(
         'pylen',
-        input_types=[ibis.expr.datatypes.String()],
-        output_type=ibis.expr.datatypes.Integer(),
+        input_types=[dt.string],
+        output_type=dt.int32,
         schema=test_schema
     )
     result_obj = table[
@@ -151,20 +168,43 @@ def mult_a_b(a, b):
     return a * b
 
 
-def test_func_to_udf_smoke(con_for_udf, table):
+def test_func_to_udf_smoke(con_for_udf, test_schema, table):
     """Test creating a UDF in database based on Python function
     and then creating an ibis UDF object based on that"""
-    mult_a_b_udf = ibis.sql.postgres.udf.api.func_to_udf(
+    mult_a_b_udf = func_to_udf(
         con_for_udf.con,
         mult_a_b,
-        (datatypes.Int32(), datatypes.Int32()),
-        datatypes.Int32(),
+        (dt.int32, dt.int32),
+        dt.int32,
         schema=test_schema,
         overwrite=True
     )
     table_filt = table.filter(table['user_id'] == 2)
     expr = table_filt[
         mult_a_b_udf(
+            table_filt['user_id'],
+            table_filt['name_length']
+        ).name('mult_result')
+    ]
+    result = expr.execute()
+    assert result['mult_result'].iloc[0] == 8
+
+
+@pytest.mark.xfail
+def test_client_udf_api(con_for_udf, test_schema, table):
+    """Test creating a UDF in database based on Python function
+    using an ibis client method."""
+    @con_for_udf.udf(
+        [dt.int32, dt.int32],
+        dt.int32,
+        schema=test_schema,
+        overwrite=True)
+    def multiply(a, b):
+        return a * b
+
+    table_filt = table.filter(table['user_id'] == 2)
+    expr = table_filt[
+        multiply(
             table_filt['user_id'],
             table_filt['name_length']
         ).name('mult_result')

--- a/ibis/sql/postgres/tests/test_udf.py
+++ b/ibis/sql/postgres/tests/test_udf.py
@@ -13,6 +13,10 @@ from ibis.sql.postgres.client import PostgreSQLClient
 
 datatypes = ibis.expr.datatypes
 
+# mark test module as postgresql (for ability to easily exclude,
+# e.g. in conda build tests)
+pytestmark = pytest.mark.postgresql
+
 # Database setup (tables and UDFs)
 
 

--- a/ibis/sql/postgres/udf/__init__.py
+++ b/ibis/sql/postgres/udf/__init__.py
@@ -1,3 +1,3 @@
-from ibis.sql.postgres.udf.api import existing_udf
+from ibis.sql.postgres.udf.api import existing_udf, udf
 
-__all__ = ('existing_udf',)
+__all__ = ('existing_udf', 'udf')

--- a/ibis/sql/postgres/udf/__init__.py
+++ b/ibis/sql/postgres/udf/__init__.py
@@ -1,3 +1,3 @@
-from ibis.sql.postgres.udf.api import existing_udf, func_to_udf
+from ibis.sql.postgres.udf.api import existing_udf, func_to_udf, UdfDecorator
 
-__all__ = ('existing_udf', 'func_to_udf')
+__all__ = ('existing_udf', 'func_to_udf', 'UdfDecorator')

--- a/ibis/sql/postgres/udf/__init__.py
+++ b/ibis/sql/postgres/udf/__init__.py
@@ -1,3 +1,3 @@
-from ibis.sql.postgres.udf.api import existing_udf, func_to_udf
+from ibis.sql.postgres.udf.api import existing_udf
 
-__all__ = ('existing_udf', 'func_to_udf')
+__all__ = ('existing_udf',)

--- a/ibis/sql/postgres/udf/__init__.py
+++ b/ibis/sql/postgres/udf/__init__.py
@@ -1,3 +1,3 @@
-from ibis.sql.postgres.udf.api import existing_udf, func_to_udf, UdfDecorator
+from ibis.sql.postgres.udf.api import existing_udf, func_to_udf
 
-__all__ = ('existing_udf', 'func_to_udf', 'UdfDecorator')
+__all__ = ('existing_udf', 'func_to_udf')

--- a/ibis/sql/postgres/udf/__init__.py
+++ b/ibis/sql/postgres/udf/__init__.py
@@ -1,0 +1,3 @@
+from ibis.sql.postgres.udf.api import existing_udf, func_to_udf
+
+__all__ = ('existing_udf', 'func_to_udf')

--- a/ibis/sql/postgres/udf/api.py
+++ b/ibis/sql/postgres/udf/api.py
@@ -53,7 +53,7 @@ def create_udf_node(name, fields):
 
     Returns
     -------
-    result : type
+    type
         A new PostgresUDFNode subclass
     """
     definition = next(_udf_name_cache[name])
@@ -75,7 +75,7 @@ def existing_udf(name, input_types, output_type, schema=None, parameters=None):
 
     Returns
     -------
-    wrapper : Callable
+    Callable
         The wrapped function
     """
     if parameters is None:
@@ -148,7 +148,8 @@ def func_to_udf(
 
     Returns
     -------
-    wrapper : Callable
+    Callable
+
         The ibis UDF object as a wrapped function
     """
     if name is None:
@@ -176,20 +177,20 @@ $$;
     return_type = ibis_to_postgres_str(out_type)
     # If function definition is indented extra,
     # Postgres UDF will fail with indentation error.
-    # Also, need to remove decorators, because they
-    # won't be defined in the UDF body.
     func_definition = dedent(inspect.getsource(python_func))
     if func_definition.strip().startswith('@'):
         raise PostgresUDFError(
-            'Use of decorators on function to be turned into Postgres UDF '
-            'is not supported, because the body of the UDF must be wholly '
-            'self-contained. Since the decorator syntax does not first bind '
-            'the function name to the wrapped function but instead includes '
-            'the decorator(s). Therefore, the decorators themselves will '
-            'be included in the string coming from `inspect.getsource()`.  '
-            'Since the decorator objects are not defined, execution of the '
-            'UDF results in a NameError. '
+            'Use of decorators on a function to be turned into Postgres UDF '
+            'is not supported. The body of the UDF must be wholly '
+            'self-contained. '
         )
+        # Since the decorator syntax does not first bind
+        # the function name to the wrapped function but instead includes
+        # the decorator(s). Therefore, the decorators themselves will
+        # be included in the string coming from `inspect.getsource()`.
+        # Since the decorator objects are not defined, execution of the
+        # UDF results in a NameError.
+
     formatted_sql = template.format(
         replace=replace_text,
         schema_fragment=schema_fragment,

--- a/ibis/sql/postgres/udf/api.py
+++ b/ibis/sql/postgres/udf/api.py
@@ -1,14 +1,63 @@
+import inspect
+from decimal import Decimal
 import collections
 import itertools
 
 import sqlalchemy
 
 import ibis.expr.rules as rlz
+from ibis.expr import datatypes
 from ibis.expr.signature import Argument as Arg
 from ibis.sql.postgres.compiler import PostgresUDFNode, add_operation
 
 
 _udf_name_cache = collections.defaultdict(itertools.count)
+
+
+# type mapping based on: https://www.postgresql.org/docs/10/plpython-data.html
+sql_default_type = 'VARCHAR'
+
+pytype_sql = {
+    bool: 'BOOLEAN',
+    int: "INTEGER",
+    float: 'DOUBLE',
+    Decimal: 'NUMERIC',
+    bytes: 'BYTEA',
+    str: sql_default_type,
+}
+
+pytype_ibistype = {
+    bool: datatypes.Boolean(),
+    int: datatypes.Int32(),
+    float: datatypes.Float(),
+    Decimal: datatypes.Float(),
+    bytes: datatypes.Binary(),
+    str: datatypes.String(),
+}
+
+ibistype_pytype = {v: k for k, v in pytype_ibistype.items()}
+
+
+def get_sqltype(type_):
+    """Map input to the string specifying the Postgres data type
+    (as is used in SQL defining UDF signatures)
+
+    :param type_: str, a Python data type,
+                  or an ibis DataType (instance or class)
+    :return: string symbol of Postgres data type
+    """
+    if isinstance(type_, str) and type_ in pytype_sql.values():
+        return type_
+    elif type_ in pytype_sql.keys():
+        return pytype_sql[type_]
+    elif type_ in ibistype_pytype:
+        return pytype_sql[ibistype_pytype[type_]]
+    elif type_ in set(map(type, ibistype_pytype.keys())):
+        return pytype_sql[ibistype_pytype[type_()]]
+    else:
+        raise ValueError(
+            "Postgres data type not defined for: {}".format(type_)
+        )
 
 
 def create_udf_node(name, fields):
@@ -31,14 +80,18 @@ def create_udf_node(name, fields):
     return type(external_name, (PostgresUDFNode,), fields)
 
 
-def existing_udf(name, input_type, output_type, schema=None, parameter_names=None):
+def existing_udf(name,
+                 input_types,
+                 output_type,
+                 schema=None,
+                 parameter_names=None):
     """Create a ibis function that refers to an existing Postgres UDF already
     defined in database
 
     Parameters
     ----------
     name: str
-    input_type : List[DataType]
+    input_types : List[DataType]
     output_type : DataType
     schema: str - optionally specify the schema that the UDF is defined in
     parameter_names: str - give names to the arguments of the UDF
@@ -49,13 +102,13 @@ def existing_udf(name, input_type, output_type, schema=None, parameter_names=Non
         The wrapped function
     """
     if parameter_names is None:
-        parameter_names = ['v{}'.format(i) for i in range(len(input_type))]
+        parameter_names = ['v{}'.format(i) for i in range(len(input_types))]
     else:
-        assert len(input_type) == len(parameter_names)
+        assert len(input_types) == len(parameter_names)
 
     udf_node_fields = collections.OrderedDict([
-        (name, Arg(rlz.value(type)))
-        for name, type in zip(parameter_names, input_type)
+        (name, Arg(rlz.value(type_)))
+        for name, type_ in zip(parameter_names, input_types)
     ] + [
         (
             'output_type',
@@ -85,3 +138,81 @@ def existing_udf(name, input_type, output_type, schema=None, parameter_names=Non
         return node.to_expr()
 
     return wrapped
+
+
+def func_to_udf(conn,
+                python_func,
+                in_types=None,
+                out_type=None,
+                schema=None,
+                name=None,
+                overwrite=False):
+    """Defines a UDF in the database
+
+    Parameters
+    ----------
+    conn: sqlalchemy engine
+    python_func: python function
+    in_types: List[DataType]; if left None, will try to infer datatypes from
+    function signature
+    out_type : DataType
+    schema: str - optionally specify the schema in which to define the UDF
+    name: str - name for the UDF to be defined in database
+    overwrite: bool - replace UDF in database if already exists
+
+    Returns
+    -------
+    wrapper : Callable
+        The ibis UDF object as a wrapped function
+    """
+    if name is None:
+        internal_name = python_func.__name__
+    else:
+        internal_name = name
+    signature = inspect.signature(python_func)
+    parameter_names = signature.parameters.keys()
+    if in_types is None:
+        raise NotImplementedError('inferring in_types not implemented')
+    if out_type is None:
+        raise NotImplementedError('inferring out_type not implemented')
+    replace = ' OR REPLACE ' if overwrite else ''
+    schema_fragment = (schema + '.') if schema else ''
+    template = """CREATE {replace} FUNCTION
+{schema_fragment}{name}({signature})
+RETURNS {return_type}
+LANGUAGE plpythonu
+AS $$
+{func_definition}
+return {internal_name}({args})
+$$;
+"""
+
+    postgres_signature = ', '.join(
+        '{name} {type}'.format(
+            name=name,
+            type=get_sqltype(type_),
+        )
+        for name, type_ in zip(parameter_names, in_types)
+    )
+    return_type = get_sqltype(out_type)
+    func_definition = inspect.getsource(python_func)
+    formatted_sql = template.format(
+        replace=replace,
+        schema_fragment=schema_fragment,
+        name=internal_name,
+        signature=postgres_signature,
+        return_type=return_type,
+        func_definition=func_definition,
+        # for internal_name, need to make sure this works if passing
+        # name parameter
+        internal_name=python_func.__name__,
+        args=', '.join(parameter_names)
+    )
+    conn.execute(formatted_sql)
+    return existing_udf(
+        name=internal_name,
+        input_types=in_types,
+        output_type=out_type,
+        schema=schema,
+        parameter_names=parameter_names
+    )

--- a/ibis/sql/postgres/udf/api.py
+++ b/ibis/sql/postgres/udf/api.py
@@ -125,8 +125,8 @@ def existing_udf(name, input_types, output_type, schema=None, parameters=None):
     return wrapped
 
 
-def func_to_udf(
-    conn,
+def udf(
+    client,
     python_func,
     in_types,
     out_type,
@@ -138,7 +138,7 @@ def func_to_udf(
 
     Parameters
     ----------
-    conn: sqlalchemy engine
+    client: PostgreSQLClient
     python_func: python function
     in_types: List[DataType]
     out_type : DataType
@@ -203,7 +203,7 @@ $$;
         internal_name=python_func.__name__,
         args=', '.join(parameter_names),
     )
-    conn.execute(formatted_sql)
+    client.con.execute(formatted_sql)
     return existing_udf(
         name=internal_name,
         input_types=in_types,

--- a/ibis/sql/postgres/udf/api.py
+++ b/ibis/sql/postgres/udf/api.py
@@ -130,8 +130,8 @@ def existing_udf(name,
 
 def func_to_udf(conn,
                 python_func,
-                in_types=None,
-                out_type=None,
+                in_types,
+                out_type,
                 schema=None,
                 replace=False,
                 name=None):
@@ -141,8 +141,7 @@ def func_to_udf(conn,
     ----------
     conn: sqlalchemy engine
     python_func: python function
-    in_types: List[DataType]; if left None, will try to infer datatypes from
-    function signature
+    in_types: List[DataType]
     out_type : DataType
     schema: str - optionally specify the schema in which to define the UDF
     replace: bool - replace UDF in database if already exists
@@ -159,10 +158,6 @@ def func_to_udf(conn,
         internal_name = name
     signature = inspect.signature(python_func)
     parameter_names = signature.parameters.keys()
-    if in_types is None:
-        raise NotImplementedError('inferring in_types not implemented')
-    if out_type is None:
-        raise NotImplementedError('inferring out_type not implemented')
     replace_text = ' OR REPLACE ' if replace else ''
     schema_fragment = (schema + '.') if schema else ''
     template = """CREATE {replace} FUNCTION

--- a/ibis/sql/postgres/udf/api.py
+++ b/ibis/sql/postgres/udf/api.py
@@ -184,7 +184,7 @@ def func_to_udf(conn,
                 in_types=None,
                 out_type=None,
                 schema=None,
-                overwrite=False,
+                replace=False,
                 name=None):
     """Defines a UDF in the database
 
@@ -196,7 +196,7 @@ def func_to_udf(conn,
     function signature
     out_type : DataType
     schema: str - optionally specify the schema in which to define the UDF
-    overwrite: bool - replace UDF in database if already exists
+    replace: bool - replace UDF in database if already exists
     name: str - name for the UDF to be defined in database
 
     Returns
@@ -214,7 +214,7 @@ def func_to_udf(conn,
         raise NotImplementedError('inferring in_types not implemented')
     if out_type is None:
         raise NotImplementedError('inferring out_type not implemented')
-    replace = ' OR REPLACE ' if overwrite else ''
+    replace_text = ' OR REPLACE ' if replace else ''
     schema_fragment = (schema + '.') if schema else ''
     template = """CREATE {replace} FUNCTION
 {schema_fragment}{name}({signature})
@@ -244,7 +244,7 @@ $$;
         )
     )
     formatted_sql = template.format(
-        replace=replace,
+        replace=replace_text,
         schema_fragment=schema_fragment,
         name=internal_name,
         signature=postgres_signature,
@@ -274,7 +274,7 @@ class UdfDecorator(object):
             in_types,
             out_type,
             schema=None,
-            overwrite=False,
+            replace=False,
             name=None):
         """
 
@@ -285,7 +285,7 @@ class UdfDecorator(object):
         out_type : DataType
         schema : str (optional)
                 The schema in which to define the UDF
-        overwrite :  bool  (optional)
+        replace :  bool  (optional)
         name :  str (optional)
                 Name to define the UDF in the database. If None, define with
                 the name of the python function object.
@@ -294,7 +294,7 @@ class UdfDecorator(object):
         self.in_types = in_types
         self.out_type = out_type
         self.schema = schema
-        self.overwrite = overwrite
+        self.replace = replace
         self.name = name
 
     def __call__(self, python_func):
@@ -304,6 +304,6 @@ class UdfDecorator(object):
             in_types=self.in_types,
             out_type=self.out_type,
             schema=self.schema,
-            overwrite=self.overwrite,
+            replace=self.replace,
             name=self.name
         )

--- a/ibis/sql/postgres/udf/api.py
+++ b/ibis/sql/postgres/udf/api.py
@@ -1,0 +1,87 @@
+import collections
+import itertools
+
+import sqlalchemy
+
+import ibis.expr.rules as rlz
+from ibis.expr.signature import Argument as Arg
+from ibis.sql.postgres.compiler import PostgresUDFNode, add_operation
+
+
+_udf_name_cache = collections.defaultdict(itertools.count)
+
+
+def create_udf_node(name, fields):
+    """Create a new UDF node type.
+
+    Parameters
+    ----------
+    name : str
+        Then name of the UDF node
+    fields : OrderedDict
+        Mapping of class member name to definition
+
+    Returns
+    -------
+    result : type
+        A new PostgresUDFNode subclass
+    """
+    definition = next(_udf_name_cache[name])
+    external_name = '{}_{:d}'.format(name, definition)
+    return type(external_name, (PostgresUDFNode,), fields)
+
+
+def existing_udf(name, input_type, output_type, schema=None, parameter_names=None):
+    """Create a ibis function that refers to an existing Postgres UDF already
+    defined in database
+
+    Parameters
+    ----------
+    name: str
+    input_type : List[DataType]
+    output_type : DataType
+    schema: str - optionally specify the schema that the UDF is defined in
+    parameter_names: str - give names to the arguments of the UDF
+
+    Returns
+    -------
+    wrapper : Callable
+        The wrapped function
+    """
+    if parameter_names is None:
+        parameter_names = ['v{}'.format(i) for i in range(len(input_type))]
+    else:
+        assert len(input_type) == len(parameter_names)
+
+    udf_node_fields = collections.OrderedDict([
+        (name, Arg(rlz.value(type)))
+        for name, type in zip(parameter_names, input_type)
+    ] + [
+        (
+            'output_type',
+            lambda self, output_type=output_type: rlz.shape_like(
+                self.args, dtype=output_type
+            )
+        )
+    ])
+    udf_node_fields['resolve_name'] = lambda self: name
+
+    udf_node = create_udf_node(name, udf_node_fields)
+
+    def _translate_udf(t, expr):
+        func_obj = sqlalchemy.func
+        if schema is not None:
+            func_obj = getattr(func_obj, schema)
+        func_obj = getattr(func_obj, name)
+
+        sa_args = [t.translate(arg) for arg in expr.op().args]
+
+        return func_obj(*sa_args)
+
+    add_operation(udf_node, _translate_udf)
+
+    def wrapped(*args, **kwargs):
+        node = udf_node(*args, **kwargs)
+        return node.to_expr()
+
+    return wrapped

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ markers =
     parquet
     postgis
     postgresql
+    postgres_extensions
     skip_backends
     skip_missing_feature
     spark


### PR DESCRIPTION
The following functionality is included: 
* ability to use user-defined functions (UDFs) 
* ability to use UDFs that are already defined in the database (I just want to refer to them and use them)
* ability to wrap a python function, automatically define it as a PL/Python function in the database, and be able to use it with ibis objects
* changed Docker image to support testing of Postgres PL/Python UDF functionality in the ibis test suite
* Tests for UDF functionality

The current API looks like this. Comments and feedback are welcome. 

```
import ibis.expr.datatypes as dt
from ibis.sql.postgres.udf.api import existing_udf, func_to_udf

my_udf = existing_udf(
    'my_udf',
    input_types=[dt.String()],
    output_type=dt.Integer(),
    schema='my_schema'
)

expr = table[my_udf(table['str_col']).name('int_col_output')]

def mult_a_b(a, b):
    return a * b

mult_a_b_udf = func_to_udf(
    sqlalchemy_engine,
    mult_a_b,
    (dt.Int32(), dt.Int32()),
    dt.Int32(),
    schema='my_schema',
    overwrite=True
)

expr2 = table[mult_a_b_udf(table['int_col1'], table['int_col2']).name('int_col_output')]
```
