### PR TITLE
Tests failing due to change in pandas astype() API

### DIFF
--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import pytest
+from pandas.core.dtypes.dtypes import CategoricalDtype
 from pytest import param
 
 import ibis
@@ -584,7 +585,7 @@ def test_category_label(alltypes, df):
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        result = result.astype('category', ordered=True)
+        result = result.astype(CategoricalDtype(ordered=True))
 
     result.name = 'double_col'
 

--- a/ibis/sql/sqlite/tests/test_functions.py
+++ b/ibis/sql/sqlite/tests/test_functions.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm  # noqa: E402
 import pytest
+from pandas.core.dtypes.dtypes import CategoricalDtype
 
 import ibis  # noqa: E402
 import ibis.config as config  # noqa: E402
@@ -426,7 +427,7 @@ def test_category_label(alltypes, df):
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore')
-        result = result.astype('category', ordered=True)
+        result = result.astype(CategoricalDtype(ordered=True))
 
     result.name = 'double_col'
 


### PR DESCRIPTION
fix pandas astype() usage in tests

Newer versions of pandas have deprecated the use of ordered=True keyword.
Instead need to explicitly pass an instance of CategoricalDtype(ordered=True).
Our pipeline tests had started failing because of this change and newer versions of pandas were being used in the pipelines.