### PR TITLE
BUG: `sql` method doesn't work when the query uses LIMIT clause

### DIFF
--- a/ibis/mapd/api.py
+++ b/ibis/mapd/api.py
@@ -1,4 +1,5 @@
 import ibis.common.exceptions as com
+import ibis.config as cf
 from ibis.config import options
 from ibis.mapd.client import EXECUTION_TYPE_CURSOR, MapDClient
 from ibis.mapd.compiler import compiles, dialect, rewrites  # noqa: F401
@@ -73,5 +74,9 @@ def connect(
 
     if options.default_backend is None:
         options.default_backend = client
+
+    with cf.config_prefix('sql'):
+        k = 'default_limit'
+        cf.set_option(k, None)
 
     return client

--- a/ibis/mapd/client.py
+++ b/ibis/mapd/client.py
@@ -929,6 +929,10 @@ class MapDClient(SQLClient):
         -------
         table : TableExpr
         """
+        if pymapd_dtype is None:
+            raise com.UnsupportedOperationError(
+                'This method is available just on Python version >= 3.6.'
+            )
         # Remove `;` + `--` (comment)
         query = re.sub(r'\s*;\s*--', '\n--', query.strip())
         # Remove trailing ;

--- a/ibis/mapd/client.py
+++ b/ibis/mapd/client.py
@@ -535,14 +535,14 @@ class MapDClient(SQLClient):
             database, table_name = table_name_
         return self.get_schema(table_name, database)
 
-    def _execute(self, query, results=True, limit=None, **kwargs):
+    def _execute(self, query, results=True):
         """
 
         query:
         :return:
         """
         if isinstance(query, (DDL, DML)):
-            query = query.compile(limit=None, **kwargs)
+            query = query.compile()
 
         if self.execution_type == EXECUTION_TYPE_ICP:
             execute = self.con.select_ipc

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -41,14 +41,14 @@ def test_list_tables(con):
 
 @pytest.mark.skipif(
     parse_version(get_distribution('pymapd').version) < parse_version('0.12'),
-    reason='must have pymapd>=12 to connect to existing session'
+    reason='must have pymapd>=12 to connect to existing session',
 )
 def test_session_id_connection(session_con):
     new_connection = ibis.mapd.connect(
         protocol=session_con.protocol,
         host=session_con.host,
         port=session_con.port,
-        session_id=session_con.con._session
+        session_id=session_con.con._session,
     )
     assert new_connection.list_tables()
 
@@ -133,3 +133,18 @@ def test_create_table_schema(con):
         assert isinstance(t.w, ir.MultiPolygonColumn)
     finally:
         con.drop_table(t_name)
+
+
+@pytest.mark.parametrize(
+    'sql',
+    [
+        'select * from functional_alltypes limit 10--test',
+        'select * from functional_alltypes \nlimit 10\n;',
+        'select * from functional_alltypes \nlimit 10;',
+        'select * from functional_alltypes \nlimit 10;--test',
+    ],
+)
+@pytest.mark.xfail_unsupported
+def test_sql(con, sql):
+    # execute the expression using SQL query
+    con.sql(sql).execute()

--- a/ibis/mapd/tests/test_client.py
+++ b/ibis/mapd/tests/test_client.py
@@ -1,3 +1,5 @@
+import sys
+
 import pandas as pd
 import pytest
 from pkg_resources import get_distribution, parse_version
@@ -144,7 +146,10 @@ def test_create_table_schema(con):
         'select * from functional_alltypes \nlimit 10;--test',
     ],
 )
-@pytest.mark.xfail_unsupported
+@pytest.mark.skipif(
+    sys.version_info < (3, 6),
+    reason='`sql` method just available for Python 3.6 or greater.',
+)
 def test_sql(con, sql):
     # execute the expression using SQL query
     con.sql(sql).execute()

--- a/ibis/tests/all/test_client.py
+++ b/ibis/tests/all/test_client.py
@@ -55,10 +55,6 @@ def test_query_schema(backend, con, alltypes, expr_fn, expected):
     [
         'select * from functional_alltypes limit 10',
         'select * from functional_alltypes \nlimit 10\n',
-        'select * from functional_alltypes limit 10--test',
-        'select * from functional_alltypes \nlimit 10\n;',
-        'select * from functional_alltypes \nlimit 10;',
-        'select * from functional_alltypes \nlimit 10;--test',
     ],
 )
 @pytest.mark.xfail_unsupported

--- a/ibis/tests/all/test_client.py
+++ b/ibis/tests/all/test_client.py
@@ -51,26 +51,20 @@ def test_query_schema(backend, con, alltypes, expr_fn, expected):
 
 
 @pytest.mark.parametrize(
-    'field',
+    'sql',
     [
-        'bool_col',
-        'tinyint_col',
-        'smallint_col',
-        'int_col',
-        'bigint_col',
-        'float_col',
-        'double_col',
-        'date_string_col',
-        'string_col',
-        'timestamp_col',
+        'select * from functional_alltypes limit 10',
+        'select * from functional_alltypes \nlimit 10\n',
+        'select * from functional_alltypes limit 10--test',
+        'select * from functional_alltypes \nlimit 10\n;',
+        'select * from functional_alltypes \nlimit 10;',
+        'select * from functional_alltypes \nlimit 10;--test',
     ],
 )
 @pytest.mark.xfail_unsupported
-def test_sql(backend, con, alltypes, field):
-
+def test_sql(backend, con, sql):
     if not hasattr(con, 'sql') or not hasattr(con, '_get_schema_using_query'):
         pytest.skip('Backend {} does not support sql method'.format(backend))
 
-    result = con.sql(alltypes.compile())
-    assert hasattr(result, field)
-    assert hasattr(alltypes, field)
+    # execute the expression using SQL query
+    con.sql(sql).execute()


### PR DESCRIPTION
Currently, SQL expressions which contain a LIMIT statement trigger an exception from the Omnisci Validator, as 'LIMIT 1' is used in the get_schema_using_query routine.  
`Exception: Sort node not supported as input to another sort`

This PR introduced a BUGFIX which utilizes the built in mapd sql_validate routine, and associated thrift type mappings to build the schema via direct reference, without the one line query.

UPDATE:

- added regex to remove `;`
- added tests using raw sql queries
-  set option 'default_limit' to `None` to avoid default `LIMIT 10000` 