### PR TITLE
ENH: PySpark backend string and column ops

### DIFF
--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -3,7 +3,6 @@ import enum
 import functools
 
 import pyspark.sql.functions as F
-from pyspark.sql.functions import pandas_udf, PandasUDFType
 
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -535,48 +535,32 @@ def compile_reverse(t, expr, scope, **kwargs):
 def compile_strip(t, expr, scope, **kwargs):
     op = expr.op()
 
-    @pandas_udf('string', PandasUDFType.SCALAR)
-    def strip(s):
-        return s.str.strip()
-
     src_column = t.translate(op.arg, scope)
-    return strip(src_column)
+    return F.trim(src_column)
 
 
 @compiles(ops.LStrip)
 def compile_lstrip(t, expr, scope, **kwargs):
     op = expr.op()
 
-    @pandas_udf('string', PandasUDFType.SCALAR)
-    def lstrip(s):
-        return s.str.lstrip()
-
     src_column = t.translate(op.arg, scope)
-    return lstrip(src_column)
+    return F.ltrim(src_column)
 
 
 @compiles(ops.RStrip)
 def compile_rstrip(t, expr, scope, **kwargs):
     op = expr.op()
 
-    @pandas_udf('string', PandasUDFType.SCALAR)
-    def rstrip(s):
-        return s.str.lstrip()
-
     src_column = t.translate(op.arg, scope)
-    return rstrip(src_column)
+    return F.rtrim(src_column)
 
 
 @compiles(ops.Capitalize)
 def compile_capitalize(t, expr, scope, **kwargs):
     op = expr.op()
 
-    @pandas_udf('string', PandasUDFType.SCALAR)
-    def capitalize(s):
-        return s.str.capitalize()
-
     src_column = t.translate(op.arg, scope)
-    return capitalize(src_column)
+    return F.initcap(src_column)
 
 
 @compiles(ops.Substring)

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -511,36 +511,24 @@ def compile_isinf(t, expr, scope, **kwargs):
 def compile_uppercase(t, expr, scope, **kwargs):
     op = expr.op()
 
-    @pandas_udf('string', PandasUDFType.SCALAR)
-    def upper(v):
-        return v.str.upper()
-
     src_column = t.translate(op.arg, scope)
-    return upper(src_column)
+    return F.upper(src_column)
 
 
 @compiles(ops.Lowercase)
 def compile_lowercase(t, expr, scope, **kwargs):
     op = expr.op()
 
-    @pandas_udf('string', PandasUDFType.SCALAR)
-    def lower(v):
-        return v.str.lower()
-
     src_column = t.translate(op.arg, scope)
-    return lower(src_column)
+    return F.lower(src_column)
 
 
 @compiles(ops.Reverse)
 def compile_reverse(t, expr, scope, **kwargs):
     op = expr.op()
 
-    @pandas_udf('string', PandasUDFType.SCALAR)
-    def reverse(s):
-        return s.str[::-1]
-
     src_column = t.translate(op.arg, scope)
-    return reverse(src_column)
+    return F.reverse(src_column)
 
 
 @compiles(ops.Strip)
@@ -610,12 +598,8 @@ def compile_substring(t, expr, scope, **kwargs):
 def compile_string_length(t, expr, scope, **kwargs):
     op = expr.op()
 
-    @pandas_udf('int', PandasUDFType.SCALAR)
-    def length(s):
-        return s.str.len()
-
     src_column = t.translate(op.arg, scope)
-    return length(src_column)
+    return F.length(src_column)
 
 
 @compiles(ops.StrRight)

--- a/ibis/tests/all/test_string.py
+++ b/ibis/tests/all/test_string.py
@@ -78,19 +78,19 @@ def test_string_col_is_unicode(backend, alltypes, df):
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search_spark',
-            marks=pytest.mark.xpass_backends((PySpark,)),
+            marks=pytest.mark.xfail_backends((Clickhouse, Impala, Spark,)),
         ),
         param(
             lambda t: t.string_col.re_extract(r'(\d+)', 0),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract_spark',
-            marks=pytest.mark.xpass_backends((PySpark,)),
+            marks=pytest.mark.xfail_backends((Clickhouse, Impala, Spark,)),
         ),
         param(
             lambda t: t.string_col.re_replace(r'\d+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a'),
             id='re_replace_spark',
-            marks=pytest.mark.xpass_backends((PySpark,)),
+            marks=pytest.mark.xfail_backends((Clickhouse, Impala, Spark,)),
         ),
         param(
             lambda t: t.string_col.repeat(2),

--- a/ibis/tests/all/test_string.py
+++ b/ibis/tests/all/test_string.py
@@ -3,7 +3,7 @@ from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.tests.backends import Clickhouse, Impala, Spark
+from ibis.tests.backends import Clickhouse, Impala, Spark, PySpark
 
 
 def test_string_col_is_unicode(backend, alltypes, df):
@@ -42,19 +42,19 @@ def test_string_col_is_unicode(backend, alltypes, df):
             lambda t: t.string_col.re_search(r'[[:digit:]]+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search',
-            marks=pytest.mark.xfail_backends((Spark,)),
+            marks=pytest.mark.xfail_backends((Spark, PySpark)),
         ),
         param(
             lambda t: t.string_col.re_extract(r'([[:digit:]]+)', 0),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract',
-            marks=pytest.mark.xfail_backends((Spark,)),
+            marks=pytest.mark.xfail_backends((Spark, PySpark)),
         ),
         param(
             lambda t: t.string_col.re_replace(r'[[:digit:]]+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a'),
             id='re_replace',
-            marks=pytest.mark.xfail_backends((Spark,)),
+            marks=pytest.mark.xfail_backends((Spark, PySpark)),
         ),
         param(
             lambda t: t.string_col.re_search(r'\\d+'),
@@ -73,6 +73,24 @@ def test_string_col_is_unicode(backend, alltypes, df):
             lambda t: t.string_col.str.replace(r'\d+', 'a'),
             id='re_replace_spark',
             marks=pytest.mark.xpass_backends((Clickhouse, Impala, Spark)),
+        ),
+        param(
+            lambda t: t.string_col.re_search(r'\d+'),
+            lambda t: t.string_col.str.contains(r'\d+'),
+            id='re_search_spark',
+            marks=pytest.mark.xpass_backends((PySpark,)),
+        ),
+        param(
+            lambda t: t.string_col.re_extract(r'(\d+)', 0),
+            lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
+            id='re_extract_spark',
+            marks=pytest.mark.xpass_backends((PySpark,)),
+        ),
+        param(
+            lambda t: t.string_col.re_replace(r'\d+', 'a'),
+            lambda t: t.string_col.str.replace(r'\d+', 'a'),
+            id='re_replace_spark',
+            marks=pytest.mark.xpass_backends((PySpark,)),
         ),
         param(
             lambda t: t.string_col.repeat(2),


### PR DESCRIPTION
This PR implements column operations and string operations for the PySpark backend to pass all/test_column.py and all/test_string.py tests.

String operations not implemented and skipped:
- find_in_set - no equivalent behavior in Pyspark