### PR TITLE
ENH: filter for PySpark backend

### DIFF
--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -73,8 +73,8 @@ def compile_selection(t, expr, scope, **kwargs):
     # Cache compile results for tables
     op = expr.op()
 
-    # TODO: Support predicates and sort_keys
-    if op.predicates or op.sort_keys:
+    # TODO: Support sort_keys
+    if op.sort_keys:
         raise NotImplementedError(
             "predicates and sort_keys are not supported with Selection")
 
@@ -90,7 +90,14 @@ def compile_selection(t, expr, scope, **kwargs):
             column = t.translate(selection, scope=scope)
             src_table = src_table.withColumn(column_name, column)
 
-    return src_table[col_names_in_selection_order]
+    if col_names_in_selection_order:
+        src_table = src_table[col_names_in_selection_order]
+
+    for predicate in op.predicates:
+        col = t.translate(predicate, scope)
+        src_table = src_table[col]
+
+    return src_table
 
 
 @compiles(ops.TableColumn)
@@ -115,10 +122,28 @@ def compile_self_reference(t, expr, scope, **kwargs):
     return t.translate(op.table, scope)
 
 
+@compiles(ops.And)
+def compile_and(t, expr, scope, **kwargs):
+    op = expr.op()
+    return t.translate(op.left, scope) & t.translate(op.right, scope)
+
+
+@compiles(ops.Or)
+def compile_or(t, expr, scope, **kwargs):
+    op = expr.op()
+    return t.translate(op.left, scope) | t.translate(op.right, scope)
+
+
 @compiles(ops.Equals)
 def compile_equals(t, expr, scope, **kwargs):
     op = expr.op()
     return t.translate(op.left, scope) == t.translate(op.right, scope)
+
+
+@compiles(ops.NotEquals)
+def compile_not_equals(t, expr, scope, **kwargs):
+    op = expr.op()
+    return t.translate(op.left, scope) != t.translate(op.right, scope)
 
 
 @compiles(ops.Greater)
@@ -131,6 +156,18 @@ def compile_greater(t, expr, scope, **kwargs):
 def compile_greater_equal(t, expr, scope, **kwargs):
     op = expr.op()
     return t.translate(op.left, scope) >= t.translate(op.right, scope)
+
+
+@compiles(ops.Less)
+def compile_less(t, expr, scope, **kwargs):
+    op = expr.op()
+    return t.translate(op.left, scope) < t.translate(op.right, scope)
+
+
+@compiles(ops.LessEqual)
+def compile_less_equal(t, expr, scope, **kwargs):
+    op = expr.op()
+    return t.translate(op.left, scope) <= t.translate(op.right, scope)
 
 
 @compiles(ops.Multiply)

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -73,7 +73,7 @@ def compile_selection(t, expr, scope, **kwargs):
     # Cache compile results for tables
     op = expr.op()
 
-    # TODO: Support sort_keys
+    # TODO: Support sort_keys (see issue #1957)
     if op.sort_keys:
         raise NotImplementedError(
             "predicates and sort_keys are not supported with Selection")

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -161,3 +161,28 @@ def test_join(client):
     )
 
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
+
+
+def test_filter(client):
+    table = client.table('table1')
+    filtered1 = table.filter(table.id < 5)
+    filtered2 = table.filter(table.id != 5)
+    filtered3 = table.filter([table.id < 5, table.str_col == 'na'])
+    filtered4 = table.filter((table.id > 3) & (table.id < 11))
+    filtered5 = table.filter((table.id == 3) | (table.id == 5))
+
+    result1 = filtered1.compile()
+    result2 = filtered2.compile()
+    result3 = filtered3.compile()
+    result4 = filtered4.compile()
+    result5 = filtered5.compile()
+
+    df = table.compile()
+    tm.assert_frame_equal(result1.toPandas(), df[df.id < 5].toPandas())
+    tm.assert_frame_equal(result2.toPandas(), df[df.id != 5].toPandas())
+    tm.assert_frame_equal(result3.toPandas(),
+                          df[df.id < 5][df.str_col == 'na'].toPandas())
+    tm.assert_frame_equal(result4.toPandas(),
+                          df[(df.id > 3) & (df.id < 11)].toPandas())
+    tm.assert_frame_equal(result5.toPandas(),
+                          df[(df.id == 3) | (df.id == 5)].toPandas())


### PR DESCRIPTION
Introduces predicate handling in `ops.Selection` for `filter()` functionality.

Also implemented a few missing comparison operations:

- `And`
- `Or`
- `NotEquals`
- `Less`
- `LessEquals`