### PR TITLE
ENH: window operations for pyspark backend

### DIFF
--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -195,12 +195,12 @@ def compile_aggregator(t, expr, scope, fn, context=None, **kwargs):
     op = expr.op()
     src_col = t.translate(op.arg, scope)
 
-    if getattr(op, "where", None) is not None:
+    if getattr(op, 'where', None) is not None:
         condition = t.translate(op.where, scope)
         src_col = F.when(condition, src_col)
 
     col = fn(src_col)
-    if context or "window" in kwargs:
+    if context or 'window' in kwargs:
         return col
     else:
         # We are trying to compile a expr such as some_col.max()
@@ -224,8 +224,8 @@ def compile_group_concat(t, expr, scope, context=None, **kwargs):
 def compile_any(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        if "window" in kwargs:
-            window = kwargs["window"]
+        if 'window' in kwargs:
+            window = kwargs['window']
             return F.max(col).over(window)
         else:
             return F.max(col)
@@ -237,8 +237,8 @@ def compile_any(t, expr, scope, context=None, **kwargs):
 def compile_notany(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        if "window" in kwargs:
-            window = kwargs["window"]
+        if 'window' in kwargs:
+            window = kwargs['window']
             return ~F.max(col).over(window)
         else:
             return ~F.max(col)
@@ -250,8 +250,8 @@ def compile_notany(t, expr, scope, context=None, **kwargs):
 def compile_all(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        if "window" in kwargs:
-            window = kwargs["window"]
+        if 'window' in kwargs:
+            window = kwargs['window']
             return F.min(col).over(window)
         else:
             return F.min(col)
@@ -263,8 +263,8 @@ def compile_all(t, expr, scope, context=None, **kwargs):
 def compile_notall(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        if "window" in kwargs:
-            window = kwargs["window"]
+        if 'window' in kwargs:
+            window = kwargs['window']
             return ~F.min(col).over(window)
         else:
             return ~F.min(col)
@@ -276,8 +276,8 @@ def compile_notall(t, expr, scope, context=None, **kwargs):
 def compile_count(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        if "window" in kwargs:
-            window = kwargs["window"]
+        if 'window' in kwargs:
+            window = kwargs['window']
             return F.count(col).over(window)
         else:
             return F.count(col)
@@ -289,8 +289,8 @@ def compile_count(t, expr, scope, context=None, **kwargs):
 def compile_max(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        if "window" in kwargs:
-            window = kwargs["window"]
+        if 'window' in kwargs:
+            window = kwargs['window']
             return F.max(col).over(window)
         else:
             return F.max(col)
@@ -302,8 +302,8 @@ def compile_max(t, expr, scope, context=None, **kwargs):
 def compile_min(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        if "window" in kwargs:
-            window = kwargs["window"]
+        if 'window' in kwargs:
+            window = kwargs['window']
             return F.min(col).over(window)
         else:
             return F.min(col)
@@ -315,8 +315,8 @@ def compile_min(t, expr, scope, context=None, **kwargs):
 def compile_mean(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        if "window" in kwargs:
-            window = kwargs["window"]
+        if 'window' in kwargs:
+            window = kwargs['window']
             return F.mean(col).over(window)
         else:
             return F.mean(col)
@@ -328,8 +328,8 @@ def compile_mean(t, expr, scope, context=None, **kwargs):
 def compile_sum(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        if "window" in kwargs:
-            window = kwargs["window"]
+        if 'window' in kwargs:
+            window = kwargs['window']
             return F.sum(col).over(window)
         else:
             return F.sum(col)
@@ -891,9 +891,9 @@ def compile_dense_rank(t, expr, scope, *, window, **kwargs):
 
 @compiles(ops.PercentRank)
 def compile_percent_rank(t, expr, scope, *, window, **kwargs):
-    raise NotImplementedError("Pyspark percent_rank() function indexes from 0 "
-                              "instead of 1, and does not match expected "
-                              "output of ibis expressions.")
+    raise NotImplementedError('Pyspark percent_rank() function indexes from 0 '
+                              'instead of 1, and does not match expected '
+                              'output of ibis expressions.')
 
 
 @compiles(ops.NTile)

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -1,8 +1,10 @@
 import collections
 import enum
 import functools
+import operator
 
 import pyspark.sql.functions as F
+from pyspark.sql import Window
 
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
@@ -198,7 +200,7 @@ def compile_aggregator(t, expr, scope, fn, context=None, **kwargs):
         src_col = F.when(condition, src_col)
 
     col = fn(src_col)
-    if context:
+    if context or "window" in kwargs:
         return col
     else:
         # We are trying to compile a expr such as some_col.max()
@@ -220,53 +222,119 @@ def compile_group_concat(t, expr, scope, context=None, **kwargs):
 
 @compiles(ops.Any)
 def compile_any(t, expr, scope, context=None, **kwargs):
-    return compile_aggregator(t, expr, scope, F.max, context)
+
+    def fn(col):
+        if "window" in kwargs:
+            window = kwargs["window"]
+            return F.max(col).over(window)
+        else:
+            return F.max(col)
+
+    return compile_aggregator(t, expr, scope, fn, context, **kwargs)
 
 
 @compiles(ops.NotAny)
 def compile_notany(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        return ~F.max(col)
-    return compile_aggregator(t, expr, scope, fn, context)
+        if "window" in kwargs:
+            window = kwargs["window"]
+            return ~F.max(col).over(window)
+        else:
+            return ~F.max(col)
+
+    return compile_aggregator(t, expr, scope, fn, context, **kwargs)
 
 
 @compiles(ops.All)
 def compile_all(t, expr, scope, context=None, **kwargs):
-    return compile_aggregator(t, expr, scope, F.min, context)
+
+    def fn(col):
+        if "window" in kwargs:
+            window = kwargs["window"]
+            return F.min(col).over(window)
+        else:
+            return F.min(col)
+
+    return compile_aggregator(t, expr, scope, fn, context, **kwargs)
 
 
 @compiles(ops.NotAll)
 def compile_notall(t, expr, scope, context=None, **kwargs):
 
     def fn(col):
-        return ~F.min(col)
-    return compile_aggregator(t, expr, scope, fn, context)
+        if "window" in kwargs:
+            window = kwargs["window"]
+            return ~F.min(col).over(window)
+        else:
+            return ~F.min(col)
+
+    return compile_aggregator(t, expr, scope, fn, context, **kwargs)
 
 
 @compiles(ops.Count)
 def compile_count(t, expr, scope, context=None, **kwargs):
-    return compile_aggregator(t, expr, scope, F.count, context)
+
+    def fn(col):
+        if "window" in kwargs:
+            window = kwargs["window"]
+            return F.count(col).over(window)
+        else:
+            return F.count(col)
+
+    return compile_aggregator(t, expr, scope, fn, context, **kwargs)
 
 
 @compiles(ops.Max)
 def compile_max(t, expr, scope, context=None, **kwargs):
-    return compile_aggregator(t, expr, scope, F.max, context)
+
+    def fn(col):
+        if "window" in kwargs:
+            window = kwargs["window"]
+            return F.max(col).over(window)
+        else:
+            return F.max(col)
+
+    return compile_aggregator(t, expr, scope, fn, context, **kwargs)
 
 
 @compiles(ops.Min)
 def compile_min(t, expr, scope, context=None, **kwargs):
-    return compile_aggregator(t, expr, scope, F.min, context)
+
+    def fn(col):
+        if "window" in kwargs:
+            window = kwargs["window"]
+            return F.min(col).over(window)
+        else:
+            return F.min(col)
+
+    return compile_aggregator(t, expr, scope, fn, context, **kwargs)
 
 
 @compiles(ops.Mean)
 def compile_mean(t, expr, scope, context=None, **kwargs):
-    return compile_aggregator(t, expr, scope, F.mean, context)
+
+    def fn(col):
+        if "window" in kwargs:
+            window = kwargs["window"]
+            return F.mean(col).over(window)
+        else:
+            return F.mean(col)
+
+    return compile_aggregator(t, expr, scope, fn, context, **kwargs)
 
 
 @compiles(ops.Sum)
 def compile_sum(t, expr, scope, context=None, **kwargs):
-    return compile_aggregator(t, expr, scope, F.sum, context)
+
+    def fn(col):
+        if "window" in kwargs:
+            window = kwargs["window"]
+            return F.sum(col).over(window)
+        else:
+            return F.sum(col)
+
+    return compile_aggregator(t, expr, scope, fn, context, **kwargs)
 
 
 @compiles(ops.StandardDev)
@@ -754,3 +822,139 @@ def compile_join(t, expr, scope, how):
     predicates = t.translate(op.predicates[0], scope)
 
     return left_df.join(right_df, predicates, how)
+
+
+@compiles(ops.WindowOp)
+def compile_window_op(t, expr, scope, **kwargs):
+    op = expr.op()
+    window = op.window
+    operand = op.expr
+
+    group_by = window._group_by
+    grouping_keys = [
+        key_op.name
+        if isinstance(key_op, ops.TableColumn)
+        else compile_with_scope(
+            t, key, scope
+        )
+        for key, key_op in zip(
+            group_by, map(operator.methodcaller('op'), group_by)
+        )
+    ]
+
+    order_by = window._order_by
+    ordering_keys = [
+        key.to_expr().get_name()
+        for key in map(operator.methodcaller('op'), order_by)
+    ]
+
+    pyspark_window = Window.partitionBy(grouping_keys).orderBy(ordering_keys)
+    result = t.translate(operand, scope, window=pyspark_window)
+
+    return result
+
+
+@compiles(ops.Lag)
+def compile_lag(t, expr, scope, *, window, **kwargs):
+    op = expr.op()
+
+    src_column = t.translate(op.arg, scope)
+    default = op.default.op().value if op.default is not None else op.default
+    offset = op.offset.op().value if op.offset is not None else op.offset
+
+    if offset:
+        return F.lag(src_column, count=offset, default=default).over(window)
+    else:
+        return F.lag(src_column, default=default).over(window)
+
+
+@compiles(ops.Lead)
+def compile_lead(t, expr, scope, *, window, **kwargs):
+    op = expr.op()
+
+    src_column = t.translate(op.arg, scope)
+    default = op.default.op().value if op.default is not None else op.default
+    offset = op.offset.op().value if op.offset is not None else op.offset
+
+    if offset:
+        return F.lead(src_column, count=offset, default=default).over(window)
+    else:
+        return F.lead(src_column, default=default).over(window)
+
+
+@compiles(ops.MinRank)
+def compile_rank(t, expr, scope, *, window, **kwargs):
+    return F.rank().over(window).astype('long') - F.lit(1)
+
+
+@compiles(ops.DenseRank)
+def compile_dense_rank(t, expr, scope, *, window, **kwargs):
+    return F.dense_rank().over(window).astype('long') - F.lit(1)
+
+
+@compiles(ops.PercentRank)
+def compile_percent_rank(t, expr, scope, *, window, **kwargs):
+    raise NotImplementedError("Pyspark percent_rank() function indexes from 0 "
+                              "instead of 1, and does not match expected "
+                              "output of ibis expressions.")
+
+
+@compiles(ops.NTile)
+def compile_ntile(t, expr, scope, *, window, **kwargs):
+    op = expr.op()
+
+    buckets = op.buckets.op().value
+    return F.ntile(buckets).over(window)
+
+
+@compiles(ops.FirstValue)
+def compile_first_value(t, expr, scope, *, window, **kwargs):
+    op = expr.op()
+
+    src_column = t.translate(op.arg, scope)
+    return F.first(src_column).over(window)
+
+
+@compiles(ops.LastValue)
+def compile_last_value(t, expr, scope, *, window, **kwargs):
+    op = expr.op()
+
+    src_column = t.translate(op.arg, scope)
+    return F.last(src_column).over(window)
+
+
+@compiles(ops.RowNumber)
+def compile_row_number(t, expr, scope, *, window, **kwargs):
+    return F.row_number().over(window).astype('long') - F.lit(1)
+
+
+@compiles(ops.CumulativeSum)
+def compile_cumulative_sum(t, expr, scope, *, window, **kwargs):
+    op = expr.op()
+
+    src_column = t.translate(op.arg, scope)
+    return F.sum(src_column).over(window)
+
+
+@compiles(ops.CumulativeMean)
+def compile_cumulative_mean(t, expr, scope, *, window, **kwargs):
+    op = expr.op()
+
+    src_column = t.translate(op.arg, scope)
+    return F.mean(src_column).over(window)
+
+
+@compiles(ops.CumulativeMin)
+def compile_cumulative_min(t, expr, scope, *, window, **kwargs):
+    op = expr.op()
+
+    src_column = t.translate(op.arg, scope)
+    return F.min(src_column).over(window)
+
+
+@compiles(ops.CumulativeMax)
+def compile_cumulative_max(t, expr, scope, *, window, **kwargs):
+    op = expr.op()
+
+    src_column = t.translate(op.arg, scope)
+    return F.max(src_column).over(window)

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -3,7 +3,6 @@ import pandas.util.testing as tm
 import pytest
 
 import ibis
-import ibis.common.exceptions as comm
 
 pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
@@ -92,10 +91,6 @@ def test_groupby(client):
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
 
 
-@pytest.mark.xfail(
-    reason='This is not implemented yet',
-    raises=comm.OperationNotDefinedError
-)
 def test_window(client):
     import pyspark.sql.functions as F
     from pyspark.sql.window import Window
@@ -108,13 +103,6 @@ def test_window(client):
             grouped_demeaned=table['id'] - table['id'].mean().over(w))
         .compile()
     )
-    result2 = (
-        table
-        .groupby('id')
-        .mutate(
-            grouped_demeaned=table['id'] - table['id'].mean())
-        .compile()
-    )
 
     spark_window = Window.partitionBy()
     spark_table = table.compile()
@@ -124,7 +112,6 @@ def test_window(client):
     )
 
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
-    tm.assert_frame_equal(result2.toPandas(), expected.toPandas())
 
 
 def test_greatest(client):

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -3,8 +3,8 @@ from pytest import param
 
 import ibis
 import ibis.common.exceptions as com
-from ibis.tests.backends import Csv, Impala, OmniSciDB, Pandas, Parquet, \
-    PostgreSQL, PySpark, Spark
+from ibis.tests.backends import (Csv, Impala, OmniSciDB, Pandas, Parquet,
+                                 PostgreSQL, PySpark, Spark)
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -16,48 +16,10 @@ from ibis.tests.backends import Csv, Impala, OmniSciDB, Pandas, Parquet, \
             id='lag',
         ),
         param(
-            lambda t, win: t.float_col.lag(2).over(win),
-            lambda t: t.float_col.shift(2),
-            id='lag_with_offset',
-        ),
-        param(
-            # default kwarg not supported in OmniSciDB
-            lambda t, win: t.float_col.lag(default=0).over(win),
-            lambda t: t.float_col.shift(1, fill_value=0),
-            id='lag_with_default',
-            marks=pytest.mark.skip_backends((OmniSciDB,)),
-        ),
-        param(
-            # default kwarg not supported in OmniSciDB
-            lambda t, win: t.float_col.lag(2, default=0).over(win),
-            lambda t: t.float_col.shift(2, fill_value=0),
-            id='lag_with_offset_and_default',
-            marks=pytest.mark.skip_backends((OmniSciDB,)),
-        ),
-        param(
             lambda t, win: t.float_col.lead().over(win),
             lambda t: t.float_col.shift(-1),
             id='lead',
             marks=pytest.mark.xfail_backends((OmniSciDB,)),
-        ),
-        param(
-            lambda t, win: t.float_col.lead(2).over(win),
-            lambda t: t.float_col.shift(-2),
-            id='lead_with_offset',
-        ),
-        param(
-            # default kwarg not supported in OmniSciDB
-            lambda t, win: t.float_col.lead(default=0).over(win),
-            lambda t: t.float_col.shift(-1, fill_value=0),
-            id='lead_with_default',
-            marks=pytest.mark.skip_backends((OmniSciDB,)),
-        ),
-        param(
-            # default kwarg not supported in OmniSciDB
-            lambda t, win: t.float_col.lead(2, default=0).over(win),
-            lambda t: t.float_col.shift(-2, fill_value=0),
-            id='lead_with_offset_and_default',
-            marks=pytest.mark.skip_backends((OmniSciDB,)),
         ),
         param(
             lambda t, win: t.id.rank().over(win),

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -25,14 +25,14 @@ from ibis.tests.backends import Csv, Impala, OmniSciDB, Pandas, Parquet, \
             lambda t, win: t.float_col.lag(default=0).over(win),
             lambda t: t.float_col.shift(1, fill_value=0),
             id='lag_with_default',
-            marks=pytest.mark.xfail_backends((OmniSciDB,)),
+            marks=pytest.mark.skip_backends((OmniSciDB,)),
         ),
         param(
             # default kwarg not supported in OmniSciDB
             lambda t, win: t.float_col.lag(2, default=0).over(win),
             lambda t: t.float_col.shift(2, fill_value=0),
             id='lag_with_offset_and_default',
-            marks=pytest.mark.xfail_backends((OmniSciDB,)),
+            marks=pytest.mark.skip_backends((OmniSciDB,)),
         ),
         param(
             lambda t, win: t.float_col.lead().over(win),
@@ -50,14 +50,14 @@ from ibis.tests.backends import Csv, Impala, OmniSciDB, Pandas, Parquet, \
             lambda t, win: t.float_col.lead(default=0).over(win),
             lambda t: t.float_col.shift(-1, fill_value=0),
             id='lead_with_default',
-            marks=pytest.mark.xfail_backends((OmniSciDB,)),
+            marks=pytest.mark.skip_backends((OmniSciDB,)),
         ),
         param(
             # default kwarg not supported in OmniSciDB
             lambda t, win: t.float_col.lead(2, default=0).over(win),
             lambda t: t.float_col.shift(-2, fill_value=0),
             id='lead_with_offset_and_default',
-            marks=pytest.mark.xfail_backends((OmniSciDB,)),
+            marks=pytest.mark.skip_backends((OmniSciDB,)),
         ),
         param(
             lambda t, win: t.id.rank().over(win),


### PR DESCRIPTION
Implemented window operations for PySpark backend to pass all tests in `ibis/tests/all/test_window.py`:

- `WindowOp`
- `Lag`
- `Lead`
- `MinRank`
- `DenseRank`
- `NTile`
- `FirstValue`
- `LastValue`
- `RowNumber`
- `CumulativeSum`
- `CumulativeMean`
- `CumulativeMin`
- `CumulativeMax`

Also enhanced select aggregation operations (e.g. `Any`, `NotAny`, `All`, `NotAll`, `Count`, `Max`, `Min`, `Mean`, `Sum`) to be interoperable with windows. 