### PR TITLE
Json UUID any

### DIFF
--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -59,7 +59,7 @@ jobs:
           kudu-master
       displayName: 'Start databases'
 
-    - bash: docker-compose run waiter
+    - bash: ./ci/check-services.sh
       displayName: 'Wait for databases'
 
     - bash: docker ps
@@ -191,7 +191,7 @@ jobs:
           kudu-tserver
       displayName: 'Start databases'
 
-    - bash: docker-compose run waiter
+    - bash: ./ci/check-services.sh
       displayName: 'Wait for databases'
 
     - bash: docker-compose build ibis ibis-docs

--- a/ci/check-services.sh
+++ b/ci/check-services.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+docker-compose up --exit-code-from waiter waiter 2> /dev/null
+
+DOCKER_CODE=$?
+
+if [ $DOCKER_CODE -eq 0 ]
+then
+  echo "[II] Done."
+else
+  for s in 'clickhouse' 'impala' 'kudu-master' 'kudu-tserver' 'mysql' 'omniscidb' 'postgres'
+  do
+    docker container ls
+    echo "=============================================================="
+    echo "docker ${s} log"
+    echo "=============================================================="
+    docker logs --details $(docker ps -aqf "name=docker_${s}_1")
+  done
+
+fi
+exit $DOCKER_CODE

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -129,6 +129,9 @@ class DataType:
 
 
 class Any(DataType):
+    scalar = ir.AnyScalar
+    column = ir.AnyColumn
+
     __slots__ = ()
 
 

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -136,6 +136,21 @@ def sa_double(_, satype, nullable=True):
     return dt.Double(nullable=nullable)
 
 
+@dt.dtype.register(PostgreSQLDialect, sa.dialects.postgresql.UUID)
+def sa_uuid(_, satype, nullable=True):
+    return dt.Any(nullable=nullable)
+
+
+@dt.dtype.register(PostgreSQLDialect, sa.dialects.postgresql.JSON)
+def sa_json(_, satype, nullable=True):
+    return dt.Any(nullable=nullable)
+
+
+@dt.dtype.register(PostgreSQLDialect, sa.dialects.postgresql.JSONB)
+def sa_jsonb(_, satype, nullable=True):
+    return dt.Any(nullable=nullable)
+
+
 if geospatial_supported:
 
     @dt.dtype.register(SQLAlchemyDialect, (ga.Geometry, ga.types._GISType))

--- a/ibis/sql/tests/test_sqlalchemy.py
+++ b/ibis/sql/tests/test_sqlalchemy.py
@@ -104,32 +104,6 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
 
         assert_equal(schema, expected)
 
-    def test_sqla_postgres_schema_conversion(self):
-        typespec = [
-            # name, type, nullable
-            ('json', sa.dialects.postgresql.JSON, True, dt.any),
-            ('jsonb', sa.dialects.postgresql.JSONB, True, dt.any),
-            ('uuid', sa.dialects.postgresql.UUID, True, dt.any),
-        ]
-
-        sqla_types = []
-        ibis_types = []
-        for name, t, nullable, ibis_type in typespec:
-            sqla_type = sa.Column(name, t, nullable=nullable)
-            sqla_types.append(sqla_type)
-            ibis_types.append((name, ibis_type(nullable=nullable)))
-
-        # Create a table with placeholder stubs for JSON, JSONB, and UUID.
-        engine = sa.create_engine('postgresql://')
-        table = sa.Table('tname', sa.MetaData(bind=engine), *sqla_types)
-
-        # Check that we can correctly create a schema with dt.any for the
-        # missing types.
-        schema = alch.schema_from_table(table)
-        expected = ibis.schema(ibis_types)
-
-        assert_equal(schema, expected)
-
     @pytest.mark.xfail(raises=AssertionError, reason='NYT')
     def test_ibis_to_sqla_conversion(self):
         assert False


### PR DESCRIPTION
Fixes #1944. This does *not* add support for JSON, JSONB, and UUID PostgreSQL types. Instead, it marks them as having `dt.Any` type, allowing the tables to be loaded, and those columns mostly ignored.

There is also some black formatting on some lines I didn't touch...