### PR TITLE
ENH: Implement join for PySpark backend

### DIFF
--- a/ibis/file/csv.py
+++ b/ibis/file/csv.py
@@ -69,7 +69,7 @@ class CSVClient(FileClient):
         sample = _read_csv(f, schema=schema, header=0, nrows=50, **kwargs)
 
         # infer sample's schema and define table
-        schema = sch.infer(sample)
+        schema = sch.infer(sample, schema=schema)
         table = self.table_class(name, schema, self, **kwargs).to_expr()
 
         self.dictionary[name] = f

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -139,9 +139,6 @@ def test_selection(client):
     )
 
 
-@pytest.mark.xfail(
-    reason='Join is not fully implemented', raises=AssertionError
-)
 def test_join(client):
     table = client.table('table1')
     result = table.join(table, ['id', 'str_col']).compile()

--- a/ibis/tests/all/test_join.py
+++ b/ibis/tests/all/test_join.py
@@ -2,12 +2,10 @@ import pandas as pd
 import pytest
 from pytest import param
 
-from ibis.tests.backends import Csv, Impala, Pandas, PySpark
+from ibis.tests.backends import Csv, Pandas, PySpark
 
 # add here backends that passes join tests
 all_db_join_supported = [Pandas, PySpark]
-
-all_db_join_unsupported = [Csv, Impala]
 
 
 @pytest.fixture(scope='module')

--- a/ibis/tests/all/test_join.py
+++ b/ibis/tests/all/test_join.py
@@ -2,6 +2,11 @@ import pandas as pd
 import pytest
 from pytest import param
 
+from ibis.tests.backends import Csv, MySQL, PostgreSQL, SQLite
+
+# add here backends that passes join tests
+all_db_join_unsupported = [Csv, MySQL, PostgreSQL, SQLite]
+
 
 @pytest.fixture(scope='module')
 def left(batting):
@@ -44,6 +49,7 @@ def right_df(right):
         ),
     ],
 )
+@pytest.mark.skip_backends([])
 @pytest.mark.xfail_unsupported
 def test_join_project_left_table(
     backend, con, left, right, left_df, right_df, how

--- a/ibis/tests/all/test_join.py
+++ b/ibis/tests/all/test_join.py
@@ -8,16 +8,6 @@ from ibis.tests.backends import Csv, Pandas, PySpark
 all_db_join_supported = [Pandas, PySpark]
 
 
-@pytest.fixture(scope='module')
-def left(batting):
-    return batting[batting.yearID == 2015]
-
-
-@pytest.fixture(scope='module')
-def right(awards_players):
-    return awards_players[awards_players.lgID == 'NL'].drop(['yearID', 'lgID'])
-
-
 @pytest.mark.parametrize(
     'how',
     [
@@ -43,7 +33,12 @@ def right(awards_players):
 # Csv is a subclass of Pandas so need to skip it explicited
 @pytest.mark.skip_backends([Csv])
 @pytest.mark.xfail_unsupported
-def test_join_project_left_table(backend, con, left, right, how):
+def test_join_project_left_table(backend, con, batting, awards_players, how):
+
+    left = batting[batting.yearID == 2015]
+    right = awards_players[awards_players.lgID == 'NL'].drop(
+        ['yearID', 'lgID']
+    )
 
     left_df = left.execute()
     right_df = right.execute()

--- a/ibis/tests/all/test_join.py
+++ b/ibis/tests/all/test_join.py
@@ -2,10 +2,10 @@ import pandas as pd
 import pytest
 from pytest import param
 
-from ibis.tests.backends import Csv, MySQL, PostgreSQL, SQLite
+from ibis.tests.backends import Pandas, PySpark
 
 # add here backends that passes join tests
-all_db_join_unsupported = [Csv, MySQL, PostgreSQL, SQLite]
+all_db_join_supported = [Pandas, PySpark]
 
 
 @pytest.fixture(scope='module')
@@ -49,7 +49,7 @@ def right_df(right):
         ),
     ],
 )
-@pytest.mark.skip_backends([])
+@pytest.mark.only_on_backends(all_db_join_supported)
 @pytest.mark.xfail_unsupported
 def test_join_project_left_table(
     backend, con, left, right, left_df, right_df, how

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -554,6 +554,14 @@ class Impala(UnorderedComparator, Backend, RoundAwayFromZero):
             database='ibis_testing',
         )
 
+    @property
+    def batting(self) -> ir.TableExpr:
+        return None
+
+    @property
+    def awards_players(self) -> ir.TableExpr:
+        return None
+
 
 class Spark(Backend, RoundHalfToEven):
     @staticmethod

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -219,6 +219,34 @@ class Csv(Pandas):
         )
         return self.connection.table('functional_alltypes', schema=schema)
 
+    @property
+    def batting(self) -> ir.TableExpr:
+        schema = ibis.schema(
+            [
+                ('lgID', dt.string),
+                ('G', dt.float64),
+                ('AB', dt.float64),
+                ('R', dt.float64),
+                ('H', dt.float64),
+                ('X2B', dt.float64),
+                ('X3B', dt.float64),
+                ('HR', dt.float64),
+                ('RBI', dt.float64),
+                ('SB', dt.float64),
+                ('CS', dt.float64),
+                ('BB', dt.float64),
+                ('SO', dt.float64),
+            ]
+        )
+        return self.connection.table('batting', schema=schema)
+
+    @property
+    def awards_players(self) -> ir.TableExpr:
+        schema = ibis.schema(
+            [('lgID', dt.string), ('tie', dt.string), ('notes', dt.string)]
+        )
+        return self.connection.table('awards_players', schema=schema)
+
 
 class Parquet(Pandas):
     check_names = False


### PR DESCRIPTION
Implement join functionality for PySpark backend. This PR only enables tests/all/test_join.py