### PR TITLE
ENH: SQLAlchemy Default precision and scale to decimal types for PostgreSQL and MySQL

### DIFF
--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -119,8 +119,9 @@ def sa_postgres_numeric(_, satype, nullable=True):
     )
 
 
+@dt.dtype.register(SQLAlchemyDialect, sa.types.Numeric)
 @dt.dtype.register(SQLiteDialect, sa.dialects.sqlite.NUMERIC)
-def sa_sqlite_numeric(_, satype, nullable=True):
+def sa_numeric(_, satype, nullable=True):
     return dt.Decimal(satype.precision, satype.scale, nullable=nullable)
 
 

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -100,6 +100,25 @@ def sa_boolean(_, satype, nullable=True):
     return dt.Boolean(nullable=nullable)
 
 
+@dt.dtype.register(MySQLDialect, sa.types.Numeric)
+def sa_mysql_numeric(_, satype, nullable=True):
+    # https://dev.mysql.com/doc/refman/8.0/en/fixed-point-types.html
+    return dt.Decimal(
+        satype.precision or 10, satype.scale or 0, nullable=nullable
+    )
+
+
+@dt.dtype.register(PostgreSQLDialect, sa.types.Numeric)
+def sa_postgres_numeric(_, satype, nullable=True):
+    # PostgreSQL allows any precision for numeric values if not specified,
+    # up to the implementation limit. Here, default to the maximum value that
+    # can be specified by the user. The scale defaults to zero.
+    # https://www.postgresql.org/docs/10/datatype-numeric.html
+    return dt.Decimal(
+        satype.precision or 1000, satype.scale or 0, nullable=nullable
+    )
+
+
 @dt.dtype.register(SQLAlchemyDialect, sa.types.Numeric)
 def sa_numeric(_, satype, nullable=True):
     return dt.Decimal(satype.precision, satype.scale, nullable=nullable)

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -100,7 +100,7 @@ def sa_boolean(_, satype, nullable=True):
     return dt.Boolean(nullable=nullable)
 
 
-@dt.dtype.register(MySQLDialect, sa.types.Numeric)
+@dt.dtype.register(MySQLDialect, sa.dialects.mysql.NUMERIC)
 def sa_mysql_numeric(_, satype, nullable=True):
     # https://dev.mysql.com/doc/refman/8.0/en/fixed-point-types.html
     return dt.Decimal(
@@ -108,7 +108,7 @@ def sa_mysql_numeric(_, satype, nullable=True):
     )
 
 
-@dt.dtype.register(PostgreSQLDialect, sa.types.Numeric)
+@dt.dtype.register(PostgreSQLDialect, sa.dialects.postgresql.NUMERIC)
 def sa_postgres_numeric(_, satype, nullable=True):
     # PostgreSQL allows any precision for numeric values if not specified,
     # up to the implementation limit. Here, default to the maximum value that
@@ -119,8 +119,8 @@ def sa_postgres_numeric(_, satype, nullable=True):
     )
 
 
-@dt.dtype.register(SQLAlchemyDialect, sa.types.Numeric)
-def sa_numeric(_, satype, nullable=True):
+@dt.dtype.register(SQLiteDialect, sa.dialects.sqlite.NUMERIC)
+def sa_sqlite_numeric(_, satype, nullable=True):
     return dt.Decimal(satype.precision, satype.scale, nullable=nullable)
 
 

--- a/ibis/sql/postgres/tests/test_client.py
+++ b/ibis/sql/postgres/tests/test_client.py
@@ -224,3 +224,30 @@ def test_unsupported_intervals(con):
     assert t["a"].type() == dt.Interval("Y")
     assert t["b"].type() == dt.Interval("M")
     assert t["g"].type() == dt.Interval("M")
+
+
+def test_default_numeric_precision_and_scale():
+    typespec = [
+        # name, sqlalchemy type, ibis type
+        ('n1', sa.dialects.postgresql.NUMERIC, dt.Decimal(1000, 0)),
+        ('n2', sa.dialects.postgresql.NUMERIC(5), dt.Decimal(5, 0)),
+        ('n3', sa.dialects.postgresql.NUMERIC(None, 4), dt.Decimal(1000, 4)),
+        ('n4', sa.dialects.postgresql.NUMERIC(10, 2), dt.Decimal(10, 2)),
+    ]
+
+    sqla_types = []
+    ibis_types = []
+    for name, t, ibis_type in typespec:
+        sqla_type = sa.Column(name, t, nullable=True)
+        sqla_types.append(sqla_type)
+        ibis_types.append((name, ibis_type(nullable=True)))
+
+    # Create a table with the numeric types.
+    engine = sa.create_engine('postgresql://')
+    table = sa.Table('tname', sa.MetaData(bind=engine), *sqla_types)
+
+    # Check that we can correctly recover the default precision and scale.
+    schema = alch.schema_from_table(table)
+    expected = ibis.schema(ibis_types)
+
+    assert_equal(schema, expected)


### PR DESCRIPTION
Possible fix for #1273 

Adds default precision and scale to decimal types for PostgreSQL and MySQL. Numeric data types without defined precision and scale are allowed in these dialects (even if it is recommended that you specify them), and these tables exist in the wild.

I'm not sure if this is the best fix, but I was hoping to get a conversation started.