### PR TITLE
SUPP: Disable BigQuery explicitly in all/test_join.py

### DIFF
--- a/ibis/tests/all/test_join.py
+++ b/ibis/tests/all/test_join.py
@@ -30,7 +30,8 @@ all_db_join_supported = [Pandas, PySpark]
     ],
 )
 @pytest.mark.only_on_backends(all_db_join_supported)
-# Csv is a subclass of Pandas so need to skip it explicited
+# Csv is a subclass of Pandas so need to skip it explicitly.
+# BigQuery is also not skipped for unknown reason.
 @pytest.mark.skip_backends([Csv, BigQuery])
 @pytest.mark.xfail_unsupported
 def test_join_project_left_table(backend, con, batting, awards_players, how):

--- a/ibis/tests/all/test_join.py
+++ b/ibis/tests/all/test_join.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 from pytest import param
 
-from ibis.tests.backends import Csv, Pandas, PySpark
+from ibis.tests.backends import BigQuery, Csv, Pandas, PySpark
 
 # add here backends that passes join tests
 all_db_join_supported = [Pandas, PySpark]
@@ -31,7 +31,7 @@ all_db_join_supported = [Pandas, PySpark]
 )
 @pytest.mark.only_on_backends(all_db_join_supported)
 # Csv is a subclass of Pandas so need to skip it explicited
-@pytest.mark.skip_backends([Csv])
+@pytest.mark.skip_backends([Csv, BigQuery])
 @pytest.mark.xfail_unsupported
 def test_join_project_left_table(backend, con, batting, awards_players, how):
 


### PR DESCRIPTION
Strangely, `pytest.mark.only_on_backends` doesn't skip BigQuery, so I added an explicit skip as a workaround.