### PR TITLE
ENH: Add support for params, query_schema, and sql in PySpark backend

### DIFF
--- a/ibis/pyspark/api.py
+++ b/ibis/pyspark/api.py
@@ -1,4 +1,5 @@
 from ibis.pyspark.client import PySparkClient
+from ibis.pyspark.compiler import dialect  # noqa: F401
 
 
 def connect(session):

--- a/ibis/pyspark/client.py
+++ b/ibis/pyspark/client.py
@@ -2,7 +2,7 @@ from pyspark.sql.column import Column
 
 import ibis.common.exceptions as com
 import ibis.expr.types as types
-from ibis.pyspark.compiler import PySparkExprTranslator
+from ibis.pyspark.compiler import PySparkDialect, PySparkExprTranslator
 from ibis.pyspark.operations import PySparkTable
 from ibis.spark.client import SparkClient
 
@@ -12,26 +12,37 @@ class PySparkClient(SparkClient):
     An ibis client that uses PySpark SQL Dataframe
     """
 
+    dialect = PySparkDialect
     table_class = PySparkTable
 
     def __init__(self, session):
         super().__init__(session)
         self.translator = PySparkExprTranslator()
 
-    def compile(self, expr, *args, **kwargs):
+    def compile(self, expr, params=None, *args, **kwargs):
         """Compile an ibis expression to a PySpark DataFrame object
         """
-        return self.translator.translate(expr, scope={})
+
+        # Insert params in scope
+        if params is None:
+            scope = {}
+        else:
+            scope = dict(
+                (param.op(), raw_value) for param, raw_value in params.items()
+            )
+        return self.translator.translate(expr, scope=scope)
 
     def execute(self, expr, params=None, limit='default', **kwargs):
         if isinstance(expr, types.TableExpr):
-            return self.compile(expr).toPandas()
+            return self.compile(expr, params, **kwargs).toPandas()
         elif isinstance(expr, types.ColumnExpr):
             # expression must be named for the projection
             expr = expr.name('tmp')
-            return self.compile(expr.to_projection()).toPandas()['tmp']
+            return self.compile(
+                expr.to_projection(), params, **kwargs
+            ).toPandas()['tmp']
         elif isinstance(expr, types.ScalarExpr):
-            compiled = self.compile(expr)
+            compiled = self.compile(expr, params, **kwargs)
             if isinstance(compiled, Column):
                 # attach result column to a fake DataFrame and
                 # select the result
@@ -41,6 +52,3 @@ class PySparkClient(SparkClient):
             raise com.IbisError(
                 "Cannot execute expression of type: {}".format(type(expr))
             )
-
-    def sql(self, query):
-        raise NotImplementedError("PySpark backend doesn't support sql query")

--- a/ibis/tests/all/test_client.py
+++ b/ibis/tests/all/test_client.py
@@ -3,7 +3,7 @@ from pkg_resources import parse_version
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.tests.backends import BigQuery, PySpark
+from ibis.tests.backends import BigQuery
 
 
 @pytest.mark.xfail_unsupported
@@ -25,7 +25,6 @@ def test_version(backend, con):
         ),
     ],
 )
-@pytest.mark.xfail_backends((PySpark,))
 def test_query_schema(backend, con, alltypes, expr_fn, expected):
     if not hasattr(con, '_build_ast'):
         pytest.skip(


### PR DESCRIPTION
Pass ibis/all/test_client.py and ibis/all/test_params.py

test_params.py is partially supported