### PR TITLE
ENH: Add support for date/time operations in PySpark backend

### DIFF
--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -161,12 +161,12 @@ def compile_cast(t, expr, scope, **kwargs):
 @compiles(ops.Limit)
 def compile_limit(t, expr, scope, **kwargs):
     op = expr.op()
-    df = compile_with_scope(t, op.table, scope)
     if op.offset != 0:
         raise com.UnsupportedArgumentError(
             'PySpark backend does not support non-zero offset is for '
             'limit operation. Got offset {}.'.format(op.offset)
         )
+    df = compile_with_scope(t, op.table, scope)
     return df.limit(op.n)
 
 

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -1097,7 +1097,7 @@ def compile_date(t, expr, scope, **kwargs):
     return F.to_date(src_column).cast('timestamp')
 
 
-def _extract_x_from_datetime(t, expr, scope, extract_fn, **kwargs):
+def _extract_component_from_datetime(t, expr, scope, extract_fn, **kwargs):
     op = expr.op()
     date_col = t.translate(op.arg, scope)
     return extract_fn(date_col)
@@ -1105,32 +1105,34 @@ def _extract_x_from_datetime(t, expr, scope, extract_fn, **kwargs):
 
 @compiles(ops.ExtractYear)
 def compile_extract_year(t, expr, scope, **kwargs):
-    return _extract_x_from_datetime(t, expr, scope, F.year, **kwargs)
+    return _extract_component_from_datetime(t, expr, scope, F.year, **kwargs)
 
 
 @compiles(ops.ExtractMonth)
 def compile_extract_month(t, expr, scope, **kwargs):
-    return _extract_x_from_datetime(t, expr, scope, F.month, **kwargs)
+    return _extract_component_from_datetime(t, expr, scope, F.month, **kwargs)
 
 
 @compiles(ops.ExtractDay)
 def compile_extract_day(t, expr, scope, **kwargs):
-    return _extract_x_from_datetime(t, expr, scope, F.dayofmonth, **kwargs)
+    return _extract_component_from_datetime(
+        t, expr, scope, F.dayofmonth, **kwargs
+    )
 
 
 @compiles(ops.ExtractHour)
 def compile_extract_hour(t, expr, scope, **kwargs):
-    return _extract_x_from_datetime(t, expr, scope, F.hour, **kwargs)
+    return _extract_component_from_datetime(t, expr, scope, F.hour, **kwargs)
 
 
 @compiles(ops.ExtractMinute)
 def compile_extract_minute(t, expr, scope, **kwargs):
-    return _extract_x_from_datetime(t, expr, scope, F.minute, **kwargs)
+    return _extract_component_from_datetime(t, expr, scope, F.minute, **kwargs)
 
 
 @compiles(ops.ExtractSecond)
 def compile_extract_second(t, expr, scope, **kwargs):
-    return _extract_x_from_datetime(t, expr, scope, F.second, **kwargs)
+    return _extract_component_from_datetime(t, expr, scope, F.second, **kwargs)
 
 
 @compiles(ops.ExtractMillisecond)

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -182,6 +182,17 @@ def test_filter(client, filter_fn, expected_fn):
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
 
 
+def test_cast(client):
+    table = client.table('table1')
+
+    result = table.mutate(id_string=table.id.cast('string')).compile()
+
+    df = table.compile()
+    df = df.withColumn('id_string', df.id.cast('string'))
+
+    tm.assert_frame_equal(result.toPandas(), df.toPandas())
+
+
 @pytest.mark.parametrize(
     'fn',
     [

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -4,6 +4,7 @@ import pytest
 from pytest import param
 
 import ibis
+import ibis.common.exceptions as com
 
 pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
@@ -20,7 +21,10 @@ def client():
     df = df.withColumn("str_col", F.lit('value'))
     df.createTempView('table1')
 
-    df1 = client._session.createDataFrame([(True,), (False,)]).toDF('v')
+    df1 = client._session.createDataFrame(
+        [['2018-01-02'], ['2018-01-03'], ['2018-01-04']],
+        ['date_str']
+    )
     df1.createTempView('table2')
     return client
 
@@ -73,7 +77,7 @@ def test_aggregation(client):
 
     table = client.table('table1')
     result = table.aggregate(table['id'].max()).compile()
-    expected = table.compile().agg(F.max('id'))
+    expected = table.compile().agg(F.max('id').alias('max'))
 
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
 
@@ -83,7 +87,7 @@ def test_groupby(client):
 
     table = client.table('table1')
     result = table.groupby('id').aggregate(table['id'].max()).compile()
-    expected = table.compile().groupby('id').agg(F.max('id'))
+    expected = table.compile().groupby('id').agg(F.max('id').alias('max'))
 
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
 
@@ -176,3 +180,36 @@ def test_filter(client, filter_fn, expected_fn):
     expected = expected_fn(df)
 
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
+
+
+@pytest.mark.parametrize(
+    'fn',
+    [
+        param(lambda t: t.date_str.to_timestamp('yyyy-MM-dd')),
+        param(lambda t: t.date_str.to_timestamp('yyyy-MM-dd', timezone='UTC'))
+    ],
+)
+def test_string_to_timestamp(client, fn):
+    import pyspark.sql.functions as F
+    table = client.table('table2')
+
+    result = table.mutate(date=fn(table)).compile()
+
+    df = table.compile()
+    expected = df.withColumn(
+        'date',
+        F.to_date(df.date_str, 'yyyy-MM-dd').alias('date')
+    )
+    expected_pdf = expected.toPandas()
+    expected_pdf['date'] = pd.to_datetime(expected_pdf['date'])
+
+    tm.assert_frame_equal(result.toPandas(), expected_pdf)
+
+
+def test_string_to_timestamp_tz_error(client):
+    table = client.table('table2')
+
+    with pytest.raises(com.UnsupportedArgumentError):
+        table.mutate(
+            date=table.date_str.to_timestamp('yyyy-MM-dd', 'non-utc-timezone')
+        ).compile()

--- a/ibis/tests/all/test_param.py
+++ b/ibis/tests/all/test_param.py
@@ -4,6 +4,7 @@ import pytest
 
 import ibis
 import ibis.expr.datatypes as dt
+from ibis.tests.backends import PySpark
 
 
 @pytest.mark.parametrize(
@@ -45,6 +46,7 @@ def test_date_scalar_parameter(
     backend.assert_series_equal(result, expected)
 
 
+@pytest.mark.xfail_backends([PySpark])
 @pytest.mark.xfail_unsupported
 def test_timestamp_accepts_date_literals(backend, alltypes):
     date_string = '2009-03-01'

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -3,7 +3,6 @@ import warnings
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
-from pandas.api.types import is_timedelta64_dtype
 import pytest
 from pytest import param
 
@@ -254,10 +253,6 @@ def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
 
     result = con.execute(expr)
     expected = backend.default_series_rename(expected)
-
-    # PySpark backend returns diff in days, no support for timedelta
-    if is_timedelta64_dtype(expected.dtype) and isinstance(backend, PySpark):
-        expected = expected.apply(lambda dt: dt.days).astype('int32')
 
     backend.assert_series_equal(result, expected)
 

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
+from pandas.api.types import is_timedelta64_dtype
 import pytest
 from pytest import param
 
@@ -18,6 +19,7 @@ from ibis.tests.backends import (
     Pandas,
     Parquet,
     PostgreSQL,
+    PySpark,
     Spark,
     SQLite,
 )
@@ -203,6 +205,15 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
             id='timestamp-add-interval',
         ),
         param(
+            lambda t, be: t.timestamp_col + (
+                ibis.interval(days=4) - ibis.interval(days=2)
+            ),
+            lambda t, be: t.timestamp_col + (
+                pd.Timedelta(days=4) - pd.Timedelta(days=2)
+            ),
+            id='timestamp-add-interval-binop',
+        ),
+        param(
             lambda t, be: t.timestamp_col - ibis.interval(days=17),
             lambda t, be: t.timestamp_col - pd.Timedelta(days=17),
             id='timestamp-subtract-interval',
@@ -244,6 +255,10 @@ def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
     result = con.execute(expr)
     expected = backend.default_series_rename(expected)
 
+    # PySpark backend returns diff in days, no support for timedelta
+    if is_timedelta64_dtype(expected.dtype) and isinstance(backend, PySpark):
+        expected = expected.apply(lambda dt: dt.days).astype('int32')
+
     backend.assert_series_equal(result, expected)
 
 
@@ -259,6 +274,8 @@ def test_interval_add_cast_scalar(backend, alltypes):
 
 
 @pytest.mark.xfail_unsupported
+# PySpark does not support casting columns to intervals
+@pytest.mark.xfail_backends([PySpark])
 @pytest.mark.skip_backends([Spark])
 def test_interval_add_cast_column(backend, alltypes, df):
     timestamp_date = alltypes.timestamp_col.date()

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -596,6 +596,8 @@ class Spark(Backend, RoundHalfToEven):
 
 
 class PySpark(Backend, RoundAwayFromZero):
+    supported_to_timestamp_units = {'s'}
+
     @staticmethod
     def skip_if_missing_dependencies() -> None:
         pytest.importorskip('pyspark')


### PR DESCRIPTION
Implemented date/time operations for PySpark backend to pass all supported tests in `ibis/tests/all/test_temporal.py`.

Features that are supported:
- `Date`
- `Timestamp`
- Date and time extraction
- Date and timestamp truncation
- Timestamp now
- String to timestamp
- Timestamp to formatted string - `strftime`
- Day of week index
- Day of week name
- Date add, subtract
- Timestamp add, subtract
- Interval add, subtract

Additional operations implemented to pass `test_temporal.py`:
- `cast`
- `limit`
- `array` index

Features that are not supported:
- `ms`, `us`, `ns` time units - unsupported in native PySpark sql functions
- non-literal `interval` (e.g. casting an integer column to an interval column) - this is because there is no timedelta type in PySpark
- Date and timestamp diff - again, no support for time delta type