### PR TITLE
FEAT: Added load_data to sqlalchemy's backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -25,6 +25,7 @@ Release Notes
 * :support:`2107` Added fragment_size to table creation for OmniSciDB
 * :feature:`2117` Add non-nullable info to schema output
 * :feature:`2083` fillna and nullif implementations for OmnisciDB
+* :feature:`1981` Add load_data to sqlalchemy's backends and fix database parameter for load/create/drop when database parameter is the same than the current database
 * :support:`2096` Added round() support for OmniSciDB
 * :feature:`2125` [OmniSciDB] Add support for within, d_fully_within and point
 * :feature:`2086` OmniSciDB - Refactor DDL and Client; Add temporary parameter to create_table and "force" parameter to drop_view

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -1472,7 +1472,7 @@ class ImpalaClient(SQLClient):
         )
 
     def load_data(
-        self, table_name, path, database=None, overwrite=False, partition=None
+        self, table_name, path, database=None, overwrite=False, partition=None,
     ):
         """
         Wraps the LOAD DATA DDL statement. Loads data into an Impala table by

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -1196,7 +1196,7 @@ class OmniSciDBClient(SQLClient):
         """
         _database = self.db_name
         self.set_database(database)
-        self.con.load_table(table_name, obj, **kwargs)
+        self.con.load_table(table_name, obj)
         self.set_database(_database)
 
     @property

--- a/ibis/sql/alchemy.py
+++ b/ibis/sql/alchemy.py
@@ -1077,6 +1077,7 @@ class AlchemyClient(SQLClient):
 
     dialect = AlchemyDialect
     query_class = AlchemyQuery
+    has_attachment = False
 
     def __init__(self, con: sa.engine.Engine) -> None:
         super().__init__()
@@ -1099,7 +1100,11 @@ class AlchemyClient(SQLClient):
 
     @invalidates_reflection_cache
     def create_table(self, name, expr=None, schema=None, database=None):
-        if database is not None and database != self.engine.url.database:
+        if database == self.database_name:
+            # avoid fully qualified name
+            database = None
+
+        if database is not None:
             raise NotImplementedError(
                 'Creating tables from a different database is not yet '
                 'implemented'
@@ -1150,7 +1155,11 @@ class AlchemyClient(SQLClient):
         database: Optional[str] = None,
         force: bool = False,
     ) -> None:
-        if database is not None and database != self.con.url.database:
+        if database == self.database_name:
+            # avoid fully qualified name
+            database = None
+
+        if database is not None:
             raise NotImplementedError(
                 'Dropping tables from a different database is not yet '
                 'implemented'
@@ -1171,6 +1180,54 @@ class AlchemyClient(SQLClient):
             del self._schemas[qualified_name]
         except KeyError:  # schemas won't be cached if created with raw_sql
             pass
+
+    def load_data(
+        self,
+        table_name: str,
+        data: pd.DataFrame,
+        database: str = None,
+        if_exists: str = 'fail',
+    ):
+        """
+        Load data from a dataframe to the backend.
+
+        Parameters
+        ----------
+        table_name : string
+        data: pandas.DataFrame
+        database : string, optional
+        if_exists : string, optional, default 'fail'
+            The values available are: {‘fail’, ‘replace’, ‘append’}
+
+        Raises
+        ------
+        NotImplementedError
+            Loading data to a table from a different database is not
+            yet implemented
+        """
+        if database == self.database_name:
+            # avoid fully qualified name
+            database = None
+
+        if database is not None:
+            raise NotImplementedError(
+                'Loading data to a table from a different database is not '
+                'yet implemented'
+            )
+
+        params = {}
+        if self.has_attachment:
+            # for database with attachment
+            # see: https://github.com/ibis-project/ibis/issues/1930
+            params['schema'] = self.database_name
+
+        data.to_sql(
+            table_name,
+            con=self.con,
+            index=False,
+            if_exists=if_exists,
+            **params,
+        )
 
     def truncate_table(
         self, table_name: str, database: Optional[str] = None

--- a/ibis/sql/postgres/tests/conftest.py
+++ b/ibis/sql/postgres/tests/conftest.py
@@ -36,6 +36,10 @@ IBIS_TEST_POSTGRES_DB = os.environ.get(
 )
 
 
+def _random_identifier(suffix):
+    return '__ibis_test_{}_{}'.format(suffix, ibis.util.guid())
+
+
 @pytest.fixture(scope='session')
 def con():
     return ibis.postgres.connect(
@@ -89,3 +93,24 @@ def translate():
     dialect = PostgreSQLDialect()
     context = dialect.make_context()
     return lambda expr: dialect.translator(expr, context).get_result()
+
+
+@pytest.fixture
+def temp_table(con) -> str:
+    """
+    Return a temporary table name.
+
+    Parameters
+    ----------
+    con : ibis.postgres.PostgreSQLClient
+
+    Yields
+    ------
+    name : string
+        Random table name for a temporary usage.
+    """
+    name = _random_identifier('table')
+    try:
+        yield name
+    finally:
+        con.drop_table(name, force=True)

--- a/ibis/sql/postgres/tests/test_client.py
+++ b/ibis/sql/postgres/tests/test_client.py
@@ -224,3 +224,23 @@ def test_unsupported_intervals(con):
     assert t["a"].type() == dt.Interval("Y")
     assert t["b"].type() == dt.Interval("M")
     assert t["g"].type() == dt.Interval("M")
+
+
+@pytest.mark.parametrize('params', [{}, {'database': POSTGRES_TEST_DB}])
+def test_create_and_drop_table(con, temp_table, params):
+    sch = ibis.schema(
+        [
+            ('first_name', 'string'),
+            ('last_name', 'string'),
+            ('department_name', 'string'),
+            ('salary', 'float64'),
+        ]
+    )
+
+    con.create_table(temp_table, schema=sch, **params)
+    assert con.table(temp_table, **params) is not None
+
+    con.drop_table(temp_table, **params)
+
+    with pytest.raises(sa.exc.NoSuchTableError):
+        con.table(temp_table, **params)

--- a/ibis/sql/sqlite/client.py
+++ b/ibis/sql/sqlite/client.py
@@ -370,6 +370,7 @@ class SQLiteClient(alch.AlchemyClient):
                 path=path, name=quoted_name
             )
         )
+        self.has_attachment = True
 
     @property
     def client(self):


### PR DESCRIPTION
In this PR:

- Added load_data 
- Allow database parameter for load/create/drop when database parameter is the same than the current database (fixes #1979)
- Added `has_attachment` to `AlchemyClient`, useful for some operations that need to use `schema` when database attachment is used, for example `to_sql`.