### PR TITLE
ENH: Allow specifying client in expr.execute()

### DIFF
--- a/ibis/client.py
+++ b/ibis/client.py
@@ -280,19 +280,21 @@ def validate_backends(backends):
     return backends
 
 
-def execute(expr, limit='default', params=None, client=None, **kwargs):
+def resolve_backends(expr, client):
     additional_backend = {client} if client is not None else set()
     (backend,) = validate_backends(
         set(find_backends(expr)).union(additional_backend)
     )
+    return backend
+
+
+def execute(expr, limit='default', params=None, client=None, **kwargs):
+    backend = resolve_backends(expr, client)
     return backend.execute(expr, limit=limit, params=params, **kwargs)
 
 
 def compile(expr, limit=None, params=None, client=None, **kwargs):
-    additional_backend = {client} if client is not None else set()
-    (backend,) = validate_backends(
-        set(find_backends(expr)).union(additional_backend)
-    )
+    backend = resolve_backends(expr, client)
     return backend.compile(expr, limit=limit, params=params, **kwargs)
 
 

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -281,25 +281,17 @@ def validate_backends(backends):
 
 
 def execute(expr, limit='default', params=None, client=None, **kwargs):
-    if client is not None:
-        explicit_backend = [client]
-    else:
-        explicit_backend = []
-
+    additional_backend = [client] if client is not None else []
     (backend,) = validate_backends(
-        list(find_backends(expr)) + explicit_backend
+        list(find_backends(expr)) + additional_backend
     )
     return backend.execute(expr, limit=limit, params=params, **kwargs)
 
 
 def compile(expr, limit=None, params=None, client=None, **kwargs):
-    if client is not None:
-        explicit_backend = [client]
-    else:
-        explicit_backend = []
-
+    additional_backend = [client] if client is not None else []
     (backend,) = validate_backends(
-        list(find_backends(expr)) + explicit_backend
+        list(find_backends(expr)) + additional_backend
     )
     return backend.compile(expr, limit=limit, params=params, **kwargs)
 

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -280,13 +280,27 @@ def validate_backends(backends):
     return backends
 
 
-def execute(expr, limit='default', params=None, **kwargs):
-    (backend,) = validate_backends(list(find_backends(expr)))
+def execute(expr, limit='default', params=None, client=None, **kwargs):
+    if client is not None:
+        explicit_backend = [client]
+    else:
+        explicit_backend = []
+
+    (backend,) = validate_backends(
+        list(find_backends(expr)) + explicit_backend
+    )
     return backend.execute(expr, limit=limit, params=params, **kwargs)
 
 
-def compile(expr, limit=None, params=None, **kwargs):
-    (backend,) = validate_backends(list(find_backends(expr)))
+def compile(expr, limit=None, params=None, client=None, **kwargs):
+    if client is not None:
+        explicit_backend = [client]
+    else:
+        explicit_backend = []
+
+    (backend,) = validate_backends(
+        list(find_backends(expr)) + explicit_backend
+    )
     return backend.compile(expr, limit=limit, params=params, **kwargs)
 
 

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -281,17 +281,17 @@ def validate_backends(backends):
 
 
 def execute(expr, limit='default', params=None, client=None, **kwargs):
-    additional_backend = [client] if client is not None else []
+    additional_backend = {client} if client is not None else set()
     (backend,) = validate_backends(
-        list(find_backends(expr)) + additional_backend
+        set(find_backends(expr)).union(additional_backend)
     )
     return backend.execute(expr, limit=limit, params=params, **kwargs)
 
 
 def compile(expr, limit=None, params=None, client=None, **kwargs):
-    additional_backend = [client] if client is not None else []
+    additional_backend = {client} if client is not None else set()
     (backend,) = validate_backends(
-        list(find_backends(expr)) + additional_backend
+        set(find_backends(expr)).union(additional_backend)
     )
     return backend.compile(expr, limit=limit, params=params, **kwargs)
 

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -181,7 +181,7 @@ class Expr:
     def _factory(self):
         return type(self)
 
-    def execute(self, limit='default', params=None, **kwargs):
+    def execute(self, limit='default', params=None, client=None, **kwargs):
         """
         If this expression is based on physical tables in a database backend,
         execute it against that backend.
@@ -192,6 +192,12 @@ class Expr:
           Pass an integer to effect a specific row limit. limit=None means "no
           limit". The default is whatever is in ibis.options.
 
+        client : ibis.Client or None, default None
+          Pass an ibis Client to execute this expression with. This is used
+          when the expression is not associated with a particular client. If
+          the expression is already associated with a client, setting this
+          param will cause an exception.
+
         Returns
         -------
         result : expression-dependent
@@ -199,9 +205,11 @@ class Expr:
         """
         from ibis.client import execute
 
-        return execute(self, limit=limit, params=params, **kwargs)
+        return execute(
+            self, limit=limit, params=params, client=client, **kwargs
+        )
 
-    def compile(self, limit=None, params=None):
+    def compile(self, limit=None, params=None, client=None):
         """
         Compile expression to whatever execution target, to verify
 
@@ -212,7 +220,7 @@ class Expr:
         """
         from ibis.client import compile
 
-        return compile(self, limit=limit, params=params)
+        return compile(self, limit=limit, params=params, client=client)
 
     def verify(self):
         """

--- a/ibis/pyspark/client.py
+++ b/ibis/pyspark/client.py
@@ -18,7 +18,7 @@ class PySparkClient(SparkClient):
 
     def __init__(self, session):
         super().__init__(session)
-        self.translator = PySparkExprTranslator()
+        self.translator = PySparkExprTranslator(session)
 
     def compile(self, expr, params=None, scope=None, *args, **kwargs):
         """Compile an ibis expression to a PySpark DataFrame object

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -4,8 +4,8 @@ import functools
 import operator
 
 import pyspark.sql.functions as F
-from pyspark.sql.functions import pandas_udf, PandasUDFType
 from pyspark.sql import Window
+from pyspark.sql.functions import PandasUDFType, pandas_udf
 
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dtypes
@@ -16,7 +16,7 @@ from ibis.pyspark.operations import PySparkTable
 from ibis.spark.compiler import SparkContext, SparkDialect
 from ibis.spark.datatypes import (
     ibis_array_dtype_to_spark_dtype,
-    ibis_dtype_to_spark_dtype
+    ibis_dtype_to_spark_dtype,
 )
 
 
@@ -33,6 +33,9 @@ class AggregationContext(enum.Enum):
 class PySparkExprTranslator:
     _registry = {}
     context_class = PySparkContext
+
+    def __init__(self, session):
+        self.session = session
 
     @classmethod
     def compiles(cls, klass):
@@ -1118,7 +1121,7 @@ _time_unit_mapping = {
     'D': 'day',
     'h': 'hour',
     'm': 'minute',
-    's': 'second'
+    's': 'second',
 }
 
 
@@ -1292,9 +1295,9 @@ def _get_interval_col(t, interval_ibis_expr, scope, allowed_units=None):
             'Interval unit "{}" is not allowed. Allowed units are: '
             '{}'.format(dtype.unit, allowed_units)
         )
-    return F.expr('INTERVAL {} {}'.format(
-        op.value, _time_unit_mapping[dtype.unit]
-    ))
+    return F.expr(
+        'INTERVAL {} {}'.format(op.value, _time_unit_mapping[dtype.unit])
+    )
 
 
 def _compile_datetime_binop(t, expr, scope, fn, allowed_units, **kwargs):
@@ -1310,8 +1313,12 @@ def _compile_datetime_binop(t, expr, scope, fn, allowed_units, **kwargs):
 def compile_date_add(t, expr, scope, **kwargs):
     allowed_units = ['Y', 'W', 'M', 'D']
     return _compile_datetime_binop(
-        t, expr, scope, (lambda l, r: (l + r).cast('timestamp')),
-        allowed_units, **kwargs
+        t,
+        expr,
+        scope,
+        (lambda l, r: (l + r).cast('timestamp')),
+        allowed_units,
+        **kwargs,
     )
 
 
@@ -1319,8 +1326,12 @@ def compile_date_add(t, expr, scope, **kwargs):
 def compile_date_sub(t, expr, scope, **kwargs):
     allowed_units = ['Y', 'W', 'M', 'D']
     return _compile_datetime_binop(
-        t, expr, scope, (lambda l, r: (l - r).cast('timestamp')),
-        allowed_units, **kwargs
+        t,
+        expr,
+        scope,
+        (lambda l, r: (l - r).cast('timestamp')),
+        allowed_units,
+        **kwargs,
     )
 
 
@@ -1336,8 +1347,12 @@ def compile_date_diff(t, expr, scope, **kwargs):
 def compile_timestamp_add(t, expr, scope, **kwargs):
     allowed_units = ['Y', 'W', 'M', 'D', 'h', 'm', 's']
     return _compile_datetime_binop(
-        t, expr, scope, (lambda l, r: (l + r).cast('timestamp')),
-        allowed_units, **kwargs
+        t,
+        expr,
+        scope,
+        (lambda l, r: (l + r).cast('timestamp')),
+        allowed_units,
+        **kwargs,
     )
 
 
@@ -1345,8 +1360,12 @@ def compile_timestamp_add(t, expr, scope, **kwargs):
 def compile_timestamp_sub(t, expr, scope, **kwargs):
     allowed_units = ['Y', 'W', 'M', 'D', 'h', 'm', 's']
     return _compile_datetime_binop(
-        t, expr, scope, (lambda l, r: (l - r).cast('timestamp')),
-        allowed_units, **kwargs
+        t,
+        expr,
+        scope,
+        (lambda l, r: (l - r).cast('timestamp')),
+        allowed_units,
+        **kwargs,
     )
 
 

--- a/ibis/pyspark/tests/test_expr.py
+++ b/ibis/pyspark/tests/test_expr.py
@@ -1,0 +1,32 @@
+import pandas.testing as mct
+
+import ibis
+import ibis.expr.operations as ops
+from ibis.pyspark.compiler import compiles
+
+
+class UnboundDatabaseTable(ops.UnboundTable):
+    """Test-only unbound database table."""
+
+
+@compiles(UnboundDatabaseTable)
+def compile_unbound_database_table(t, expr, scope):
+    return t.session.table(expr.op().name)
+
+
+def test_execute(client):
+    table1 = UnboundDatabaseTable(
+        name='basic_table',
+        schema=ibis.schema([('value', 'string'), ('str_col', 'string')]),
+    ).to_expr()
+
+    result1 = table1.execute(client=client)
+    expected1 = client.execute(table1)
+    mct.assert_frame_equal(result1, expected1)
+
+    # Test duplicate client
+    table2 = client.table('basic_table')
+
+    result2 = table2.execute(client=client)
+    expected2 = client.execute(table2, client=client)
+    mct.assert_frame_equal(result2, expected2)

--- a/ibis/pyspark/tests/test_expr.py
+++ b/ibis/pyspark/tests/test_expr.py
@@ -3,7 +3,6 @@ import pytest
 
 import ibis
 import ibis.expr.operations as ops
-from ibis.pyspark.compiler import compiles
 
 pytest.importorskip('pyspark')
 
@@ -12,12 +11,14 @@ class UnboundDatabaseTable(ops.UnboundTable):
     """Test-only unbound database table."""
 
 
-@compiles(UnboundDatabaseTable)
-def compile_unbound_database_table(t, expr, scope):
-    return t.session.table(expr.op().name)
-
-
 def test_execute(client):
+    # Conditional imports
+    from ibis.pyspark.compiler import compiles
+
+    @compiles(UnboundDatabaseTable)
+    def compile_unbound_database_table(t, expr, scope):
+        return t.session.table(expr.op().name)
+
     table1 = UnboundDatabaseTable(
         name='basic_table',
         schema=ibis.schema([('value', 'string'), ('str_col', 'string')]),

--- a/ibis/pyspark/tests/test_expr.py
+++ b/ibis/pyspark/tests/test_expr.py
@@ -1,8 +1,11 @@
 import pandas.testing as mct
+import pytest
 
 import ibis
 import ibis.expr.operations as ops
 from ibis.pyspark.compiler import compiles
+
+pytest.importorskip('pyspark')
 
 
 class UnboundDatabaseTable(ops.UnboundTable):


### PR DESCRIPTION
This PR adds an optional "client" argument to Expr's execute method:

```
client : ibis.Client or None, default None
          Pass an ibis Client to execute this expression with. This is used
          when the expression is not associated with a particular client. If
          the expression is already associated with a client, setting this
          param will cause an exception.
```

This enables down stream users to define "unbound" tables that is not associated with a Particular backend and be able to execute the expr with a specific client, i.e.

```
expr.execute(client=client)
```

This is equivalent to 
```
client.execute(expr)
``` 