### PR TITLE
PySpark backend: cache all ops in translate()

### DIFF
--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -43,6 +43,18 @@ class PySparkExprTranslator:
         return decorator
 
     def translate(self, expr, scope, **kwargs):
+        """
+        Translate Ibis expression into a PySpark object.
+
+        All translated expressions are cached within scope. If an expression is
+        found within scope, it's returned. Otherwise, the it's translated and
+        cached for future reference.
+
+        :param expr: ibis expression
+        :param scope: dictionary mapping from operation to translated result
+        :param kwargs: parameters passed as keyword args (e.g. window)
+        :return: translated PySpark DataFrame or Column object
+        """
         # The operation node type the typed expression wraps
         op = expr.op()
 


### PR DESCRIPTION
Removing `compile_with_scope()` in favor of caching all operations in `scope` during `translate()`. Caching only select operations with `compile_with_scope()` is error prone. This change ensures we don't compile the same operation more than once.