### PR TITLE
ENH: Pyspark backend bounded windows

### DIFF
--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -993,11 +993,13 @@ def compile_window_op(t, expr, scope, **kwargs):
 
     if not isinstance(operand.op(), ops.ShiftBase):
         start = (
-            - window.preceding if window.preceding is not None
+            -window.preceding
+            if window.preceding is not None
             else Window.unboundedPreceding
         )
         end = (
-            window.following if window.following is not None
+            window.following
+            if window.following is not None
             else Window.unboundedFollowing
         )
         pyspark_window = pyspark_window.rowsBetween(start, end)

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -991,6 +991,8 @@ def compile_window_op(t, expr, scope, **kwargs):
 
     pyspark_window = Window.partitionBy(grouping_keys).orderBy(ordering_keys)
 
+    # If the operand is a shift op (e.g. lead, lag), Spark will set the window
+    # bounds. Only set window bounds here if not a shift operation.
     if not isinstance(operand.op(), ops.ShiftBase):
         start = (
             -window.preceding

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -990,6 +990,18 @@ def compile_window_op(t, expr, scope, **kwargs):
     ]
 
     pyspark_window = Window.partitionBy(grouping_keys).orderBy(ordering_keys)
+
+    if not isinstance(operand.op(), ops.ShiftBase):
+        start = (
+            - window.preceding if window.preceding is not None
+            else Window.unboundedPreceding
+        )
+        end = (
+            window.following if window.following is not None
+            else Window.unboundedFollowing
+        )
+        pyspark_window = pyspark_window.rowsBetween(start, end)
+
     result = t.translate(operand, scope, window=pyspark_window)
 
     return result

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -227,11 +227,16 @@ def test_bounded_following_window(backend, alltypes, df, con):
     # simulate forward looking window aggregation
     gdf = df.sort_values('id').groupby('string_col')
     gdf.id = gdf.apply(lambda t: t.id.shift(-2))
-    expected = df.assign(
-        val=gdf.id.rolling(3, min_periods=1)
-        .mean().sort_index(level=1)
-        .reset_index(drop=True)
-    ).set_index('id').sort_index()
+    expected = (
+        df.assign(
+            val=gdf.id.rolling(3, min_periods=1)
+            .mean()
+            .sort_index(level=1)
+            .reset_index(drop=True)
+        )
+        .set_index('id')
+        .sort_index()
+    )
 
     # discard first 2 rows of each group to account for the shift
     n = len(gdf) * 2
@@ -261,10 +266,16 @@ def test_bounded_preceding_window(backend, alltypes, df, con):
 
     result = expr.execute().set_index('id').sort_index()
     gdf = df.sort_values('id').groupby('string_col')
-    expected = df.assign(
-        val=gdf.double_col.rolling(3, min_periods=1).sum()
-        .sort_index(level=1).reset_index(drop=True)
-    ).set_index('id').sort_index()
+    expected = (
+        df.assign(
+            val=gdf.double_col.rolling(3, min_periods=1)
+            .sum()
+            .sort_index(level=1)
+            .reset_index(drop=True)
+        )
+        .set_index('id')
+        .sort_index()
+    )
 
     left, right = result.val, expected.val
 


### PR DESCRIPTION
Implemented `preceding` and `following` window boundaries for PySpark backend.

Also, added tests in `ibis/tests/all/test_window.py` that tests bounded windows. (note: filed issue #2000 for incorrect behavior in Pandas, Csv, and Parquet backends)