### PR TITLE
BUG: Fix handling of Array types in Postgres UDF

### DIFF
--- a/ibis/sql/postgres/udf/api.py
+++ b/ibis/sql/postgres/udf/api.py
@@ -33,7 +33,9 @@ def ibis_to_pg_sa_type(ibis_type):
 def sa_type_to_postgres_str(sa_type):
     """Map a Postgres-compatible sqlalchemy type to a Postgres-appropriate
     string"""
-    return sa_type().compile(dialect=sa_postgres_dialect())
+    if callable(sa_type):
+        sa_type = sa_type()
+    return sa_type.compile(dialect=sa_postgres_dialect())
 
 
 def ibis_to_postgres_str(ibis_type):


### PR DESCRIPTION
Other scalar types can be represented either by the class or an instance, but Array types work differently. Array types must be an instance, because the Array class must be instantiated specifying the datatype of the elements of the array. This was causing an error in the translation.


```
ibis/sql/postgres/tests/test_udf.py:176 (test_array_type)
con_for_udf = <ibis.sql.postgres.client.PostgreSQLClient object at 0x11eb3ada0>
test_schema = 'udf_test_18'
table = PostgreSQLTable[table]
  name: udf_test_users
  schema:
    user_id : int32
    user_name : string
    name_length : int32

    def test_array_type(con_for_udf, test_schema, table):
        """Test that usage of Array types work
        Other scalar types can be represented either by the class or an instance,
        but Array types work differently. Array types must be an instance,
        because the Array class must be instantiated specifying the datatype
        of the elements of the array.
        """
        pysplit_udf = udf(
            con_for_udf,
            pysplit,
            (dt.string, dt.string),
            dt.Array(dt.string),
            schema=test_schema,
>           replace=True,
        )

test_udf.py:190: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../udf/api.py:179: in udf
    return_type = ibis_to_postgres_str(out_type)
../udf/api.py:43: in ibis_to_postgres_str
    return sa_type_to_postgres_str(ibis_to_pg_sa_type(ibis_type))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

sa_type = ARRAY(Text())

    def sa_type_to_postgres_str(sa_type):
        """Map a Postgres-compatible sqlalchemy type to a Postgres-appropriate
        string"""
>       return sa_type().compile(dialect=sa_postgres_dialect())
E       TypeError: 'ARRAY' object is not callable
```