### PR TITLE
DOC: Fixed PySpark docstrings and changed some public function to private.

### DIFF
--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -74,7 +74,7 @@ jobs:
       displayName: 'Lint'
 
     # TODO: change match-dir when docstrings are fixed for other backends
-    - bash: docker-compose run ibis pydocstyle --match-dir="(ibis|omniscidb)"
+    - bash: docker-compose run ibis pydocstyle -v --match-dir="(ibis|omniscidb|pyspark"
       displayName: "Docstring check"
 
     - bash: docker-compose run ibis black --check .

--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -74,7 +74,7 @@ jobs:
       displayName: 'Lint'
 
     # TODO: change match-dir when docstrings are fixed for other backends
-    - bash: docker-compose run ibis pydocstyle -v --match-dir="(ibis|omniscidb|pyspark"
+    - bash: docker-compose run ibis pydocstyle -v --match-dir="(ibis|omniscidb|pyspark)"
       displayName: "Docstring check"
 
     - bash: docker-compose run ibis black --check .

--- a/ibis/pyspark/__init__.py
+++ b/ibis/pyspark/__init__.py
@@ -1,0 +1,1 @@
+"""PySpark backend."""

--- a/ibis/pyspark/api.py
+++ b/ibis/pyspark/api.py
@@ -1,12 +1,23 @@
+"""PySpark backend API module."""
 from ibis.pyspark.client import PySparkClient
 from ibis.pyspark.compiler import dialect  # noqa: F401
 
 
 def connect(session):
     """
-    Create a `SparkClient` for use with Ibis. Pipes **kwargs into SparkClient,
-    which pipes them into SparkContext. See documentation for SparkContext:
+    Create a `SparkClient` for use with Ibis.
+
+    Pipes **kwargs into SparkClient, which pipes them into SparkContext.
+    See documentation for SparkContext:
     https://spark.apache.org/docs/latest/api/python/_modules/pyspark/context.html#SparkContext
+
+    Parameters
+    ----------
+    session
+
+    Returns
+    -------
+    client : PySparkClient
     """
     client = PySparkClient(session)
 

--- a/ibis/pyspark/client.py
+++ b/ibis/pyspark/client.py
@@ -1,3 +1,4 @@
+"""PySpark backend client module."""
 from pyspark.sql.column import Column
 
 import ibis.common.exceptions as com
@@ -8,9 +9,7 @@ from ibis.spark.client import SparkClient
 
 
 class PySparkClient(SparkClient):
-    """
-    An ibis client that uses PySpark SQL Dataframe
-    """
+    """An ibis client that uses PySpark SQL Dataframe."""
 
     dialect = PySparkDialect
     table_class = PySparkTable
@@ -20,9 +19,7 @@ class PySparkClient(SparkClient):
         self.translator = PySparkExprTranslator()
 
     def compile(self, expr, params=None, *args, **kwargs):
-        """Compile an ibis expression to a PySpark DataFrame object
-        """
-
+        """Compile an ibis expression to a PySpark DataFrame object."""
         # Insert params in scope
         if params is None:
             scope = {}
@@ -33,6 +30,7 @@ class PySparkClient(SparkClient):
         return self.translator.translate(expr, scope=scope)
 
     def execute(self, expr, params=None, limit='default', **kwargs):
+        """Execute given expression using PySpark."""
         if isinstance(expr, types.TableExpr):
             return self.compile(expr, params, **kwargs).toPandas()
         elif isinstance(expr, types.ColumnExpr):

--- a/ibis/pyspark/operations.py
+++ b/ibis/pyspark/operations.py
@@ -1,5 +1,8 @@
+"""PySpark backend operations module."""
 import ibis.expr.operations as ops
 
 
 class PySparkTable(ops.DatabaseTable):
+    """PySparkTable class."""
+
     pass

--- a/ibis/pyspark/tests/conftest.py
+++ b/ibis/pyspark/tests/conftest.py
@@ -1,3 +1,4 @@
+"""PySpark backend test configuration module."""
 import pytest
 
 import ibis
@@ -5,6 +6,7 @@ import ibis
 
 @pytest.fixture(scope='session')
 def client():
+    """Create a fixture for PySpark client."""
     from pyspark.sql import SparkSession
     import pyspark.sql.functions as F
 


### PR DESCRIPTION
This PR is related to issue #2011 

- public functions that don't need to be public inside the PySpark backend API changed to private
- Added some docstrings for public functions/methods. 