### PR TITLE
ENH: Support multi args window UDF for pandas backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ testfast:
 	PYTHONHASHSEED=${PYTHONHASHSEED} $(MAKEFILE_DIR)/ci/test.sh -n auto -m 'not (udf or impala or hdfs or bigquery)' -k 'not test_import_time' \
 	    --doctest-modules --doctest-ignore-import-errors ${PYTEST_OPTIONS}
 
+testpandas:
+	PYTHONHASHSEED=${PYTHONHASHSEED} $(MAKEFILE_DIR)/ci/test.sh -n auto -m 'pandas' -k 'not test_import_time' \
+	    --doctest-modules --doctest-ignore-import-errors ${PYTEST_OPTIONS}
+
 testspark:
 	PYTHONHASHSEED=${PYTHONHASHSEED} $(MAKEFILE_DIR)/ci/test.sh -n auto -m 'pyspark' -k 'not test_import_time' \
 	    --doctest-modules --doctest-ignore-import-errors ${PYTEST_OPTIONS}

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -203,10 +203,10 @@ class PandasBackend:
         def my_mean(series):
             return series.mean()
 
-        self.low_card_grouped_rolling_udf = my_mean(t.value).over(
+        self.low_card_grouped_rolling_udf_mean = my_mean(t.value).over(
             low_card_rolling_window
         )
-        self.high_card_grouped_rolling_udf = my_mean(t.value).over(
+        self.high_card_grouped_rolling_udf_mean = my_mean(t.value).over(
             high_card_rolling_window
         )
 
@@ -223,6 +223,18 @@ class PandasBackend:
         )
         self.high_card_window_analytics_udf = my_zscore(t.value).over(
             high_card_window
+        )
+
+        @udf.reduction(['double', 'double'], 'double')
+        def my_wm(v, w):
+            return np.average(v, weights=w)
+
+        self.low_card_grouped_rolling_udf_wm = my_wm(t.value, t.value).over(
+            low_card_rolling_window
+        )
+
+        self.high_card_grouped_rolling_udf_wm = my_wm(t.value, t.value).over(
+            low_card_rolling_window
         )
 
     def time_high_cardinality_group_by(self):
@@ -264,5 +276,8 @@ class PandasBackend:
     def time_low_card_window_analytics_udf(self):
         self.low_card_window_analytics_udf.execute()
 
-    def time_high_card_window_analytics_udf(self):
-        self.high_card_window_analytics_udf.execute()
+    def time_high_card_grouped_rolling_udf_wm(self):
+        self.high_card_grouped_rolling_udf_wm.execute()
+
+    def time_low_card_grouped_rolling_udf_wm(self):
+        self.low_card_grouped_rolling_udf_wm.execute()

--- a/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks.py
@@ -139,7 +139,7 @@ class Compilation(Suite):
 class PandasBackend:
     def setup(self):
         n = 30 * int(2e5)
-        data = pd.DataFrame(
+        self.data = pd.DataFrame(
             {
                 'key': np.random.choice(16000, size=n),
                 'low_card_key': np.random.choice(30, size=n),
@@ -156,7 +156,7 @@ class PandasBackend:
             }
         )
 
-        t = ibis.pandas.connect({'df': data}).table('df')
+        t = ibis.pandas.connect({'df': self.data}).table('df')
 
         self.high_card_group_by = t.groupby(t.key).aggregate(
             avg_value=t.value.mean()

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -8,6 +8,7 @@ Release Notes
    notes for pre-1.0 versions of ibis can be found at :doc:`/release-pre-1.0`
 
 * :release:`1.2.1 <pending>`
+* :feature:`2035` Add support for  multi arguments window UDAF for the pandas backend
 * :bug:`2041` Change pymapd connection parameter from "session_id" to "sessionid"
 * :support:`2037` Drop support for Python 3.5
 * :bug:`2023` HTML escape column names and types in png repr.

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -222,6 +222,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+from pandas import Series
 from pandas.core.groupby import SeriesGroupBy
 
 import ibis
@@ -389,13 +390,13 @@ class Window(AggregationContext):
             # multi param UDFs.
 
             # Data is used to compute window bounds for each row.
-            data = grouped_data.obj
+            data = getattr(grouped_data, 'obj', grouped_data)
 
             def create_valid_inputs(grouped_series, valid_window_size):
                 # create a generator for each input series
                 # the generator will yield a slice of the
                 # input series for each valid window
-                series = grouped_series.obj
+                series = getattr(grouped_series, 'obj', grouped_series)
                 for i in valid_window_size.index:
                     yield series[i - valid_window_size[i] + 1 : i + 1]
 
@@ -420,7 +421,7 @@ class Window(AggregationContext):
 
             input_gens = list(
                 create_valid_inputs(arg, valid_window_size)
-                if isinstance(arg, SeriesGroupBy)
+                if isinstance(arg, (Series, SeriesGroupBy))
                 else itertools.repeat(arg)
                 for arg in inputs
             )

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -330,9 +330,10 @@ def _window_agg_built_in(
     method = operator.methodcaller(function, *args, **kwargs)
 
     if max_lookback is not None:
+        agg_method = method
 
         def sliced_agg(s):
-            return method(s.iloc[-max_lookback:], *args, **kwargs)
+            return agg_method(s.iloc[-max_lookback:])
 
         method = operator.methodcaller('apply', sliced_agg, raw=False)
 

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -327,15 +327,14 @@ def _window_agg_built_in(
     """Apply window aggregation with built-in aggregators.
     """
     assert isinstance(function, str)
+    method = operator.methodcaller(function, *args, **kwargs)
 
     if max_lookback is not None:
 
         def sliced_agg(s):
-            return function(s.iloc[-max_lookback:], *args, **kwargs)
+            return method(s.iloc[-max_lookback:], *args, **kwargs)
 
         method = operator.methodcaller('apply', sliced_agg, raw=False)
-    else:
-        method = operator.methodcaller(function, *args, **kwargs)
 
     result = method(windowed)
     index = result.index

--- a/ibis/pandas/execution/tests/test_arrays.py
+++ b/ibis/pandas/execution/tests/test_arrays.py
@@ -52,15 +52,8 @@ def test_array_collect(t, df):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    raises=TypeError,
-    reason=(
-        'Pandas does not implement rolling for functions that do not return '
-        'numbers'
-    ),
-)
 def test_array_collect_rolling_partitioned(t, df):
-    window = ibis.trailing_window(2, order_by=t.plain_int64)
+    window = ibis.trailing_window(1, order_by=t.plain_int64)
     colexpr = t.plain_float64.collect().over(window)
     expr = t['dup_strings', 'plain_int64', colexpr.name('collected')]
     result = expr.execute()

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -313,10 +313,6 @@ def test_udaf_window_interval():
 def test_udaf_window_multi_params():
     @udf.reduction(['double', 'double'], 'double')
     def my_wm(v, w):
-        print("v")
-        print(v)
-        print("w")
-        print(w)
         return np.average(v, weights=w)
 
     df = pd.DataFrame(
@@ -373,7 +369,7 @@ def test_udaf_window_nan():
     expected = df.sort_values(['key', 'a']).assign(
         rolled=lambda d: d.groupby('key')
         .b.rolling(3, min_periods=1)
-        .mean()
+        .apply(lambda x: x.mean(), raw=True)
         .reset_index(level=0, drop=True)
     )
     tm.assert_frame_equal(result, expected)

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -1,3 +1,5 @@
+import collections
+
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
@@ -273,18 +275,19 @@ def test_udaf_window():
 
 
 def test_udaf_window_interval():
-    @udf.reduction(['double'], 'double')
-    def my_mean(series):
-        return series.mean()
-
     df = pd.DataFrame(
-        {
-            "time": pd.date_range(
-                start='20190105', end='20190101', freq='-1D'
-            ),
-            "key": [1, 2, 1, 2, 1],
-            "value": np.arange(5),
-        }
+        collections.OrderedDict(
+            [
+                (
+                    "time",
+                    pd.date_range(
+                        start='20190105', end='20190101', freq='-1D'
+                    ),
+                ),
+                ("key", [1, 2, 1, 2, 1]),
+                ("value", np.arange(5)),
+            ]
+        )
     )
 
     con = ibis.pandas.connect({'df': df})

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -313,7 +313,7 @@ def test_udaf_window_interval():
     tm.assert_frame_equal(result, expected)
 
 
-def test_udaf_window_multi_params():
+def test_udaf_window_multi_args():
     @udf.reduction(['double', 'double'], 'double')
     def my_wm(v, w):
         return np.average(v, weights=w)

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -159,7 +159,7 @@ def test_udaf_analytic(con, t, df):
     tm.assert_series_equal(result, expected)
 
 
-def test_udaf_analytic_group_by(con, t, df):
+def test_udaf_analytic_groupby(con, t, df):
     expr = zscore(t.c).over(ibis.window(group_by=t.key))
 
     assert isinstance(expr, ir.ColumnExpr)

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -259,7 +259,7 @@ def test_compose_udfs(t2, df2):
 
 def test_udaf_window(t2, df2):
     window = ibis.trailing_window(2, order_by='a', group_by='key')
-    expr = t.mutate(rolled=my_mean(t.b).over(window))
+    expr = t2.mutate(rolled=my_mean(t2.b).over(window))
     result = expr.execute().sort_values(['key', 'a'])
     expected = df2.sort_values(['key', 'a']).assign(
         rolled=lambda df: df.groupby('key')

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -9,6 +9,7 @@ import functools
 import itertools
 import operator
 from inspect import Parameter, signature
+from typing import Any, Tuple
 
 import numpy as np
 import pandas as pd
@@ -101,11 +102,26 @@ def arguments_from_signature(signature, *args, **kwargs):
     return args, new_kwargs
 
 
-def create_gens_from_args_groupby(args):
+def create_gens_from_args_groupby(args: Tuple[Any]):
     """ Create generators for each args for groupby udaf.
 
-    If the arg is SeriesGroupBy, return a generator that outputs each group.
-    If the arg is not SeriesGroupBy, return a generator that repeats the arg.
+    Args can be one of two things:
+
+    If the arg is SeriesGroupBy, it's data passed to the user function.
+    In this case, return a generator that outputs each group.
+
+    If the arg is not SeriesGroupBy, it's user specified params.
+    In this case, return a generator that repeats the arg.
+
+    E.g,
+    @udf.aggregation(...)
+    def foo(col, my_arg):
+        if my_arg == 'something':
+            # Do something
+            ...
+        elif my_arg == 'something else':
+            # Do something else
+            ...
 
     Parameters
     ----------


### PR DESCRIPTION
This PR addresses issue https://github.com/ibis-project/ibis/issues/1998

Currently, when using UDAF with rolling window, pandas backend will throw an exception:

```
import ibis
import pandas as pd
import numpy as np

from ibis.pandas.udf import udf
import ibis.expr.datatypes as dt

client = ibis.pandas.connect({'table': pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6], 'key': ['a', 'a', 'a']})})
t = client.table('table')
w = ibis.trailing_window(preceding=1, order_by='key', group_by='key')
#w = ibis.window(group_by='key')


@udf.reduction(input_type=[dt.double, dt.double], output_type=dt.double)
def my_average(v, w):
    return np.average(v, weights=w)

t = t.mutate(new_col=my_average(t.a, t.b).over(w))

t.execute()
```

With this PR, it will support this use case.

The main idea of this PR is that instead of using `groupby().rolling().apply(func)` to compute the result, we use `groupby().rolling().apply(len, raw=True)` to get the size of each window, and then manually apply `func` to each window in a Python for-loop. This way, we work around issue that `groupby().rolling().apply(func)` can only take function that apply on a single series.

Benchmarks
------------

Before the change:

```
In [4]: %time pandas.time_low_card_window_analytics_udf()                                                                                                     
CPU times: user 898 ms, sys: 248 ms, total: 1.15 s
Wall time: 1.15 s

In [5]: %time pandas.time_high_card_window_analytics_udf()                                                                                                    
CPU times: user 12.4 s, sys: 324 ms, total: 12.7 s
Wall time: 12.8 s

In [6]: %time pandas.time_low_card_grouped_rolling()                                                                                                          
CPU times: user 7.99 s, sys: 1.95 s, total: 9.94 s
Wall time: 10.1 s

In [7]: %time pandas.time_high_card_grouped_rolling()                                                                                                         
CPU times: user 15.3 s, sys: 1.83 s, total: 17.1 s
Wall time: 17.3 s

In [8]: %time pandas.time_low_card_grouped_rolling_udf()                                                                                                      
CPU times: user 2min 1s, sys: 1.96 s, total: 2min 3s
Wall time: 2min 4s

In [9]: %time pandas.time_high_card_grouped_rolling_udf()                                                                                                     
CPU times: user 1min 41s, sys: 2.17 s, total: 1min 43s
Wall time: 1min 43s
```

After the change:

```
time pandas.time_low_card_window_analytics_udf()
CPU times: user 856 ms, sys: 235 ms, total: 1.09 s
Wall time: 1.08 s
time pandas.time_high_card_window_analytics_udf()
CPU times: user 12.7 s, sys: 316 ms, total: 13 s
Wall time: 13.1 s
time pandas.time_low_card_grouped_rolling()
CPU times: user 9.3 s, sys: 3.15 s, total: 12.4 s
Wall time: 13 s
time pandas.time_high_card_grouped_rolling()
CPU times: user 15.5 s, sys: 1.9 s, total: 17.4 s
Wall time: 17.5 s
time pandas.time_low_card_grouped_rolling_udf()
CPU times: user 1min 26s, sys: 1.74 s, total: 1min 27s
Wall time: 1min 28s
time pandas.time_high_card_grouped_rolling_udf()
CPU times: user 1min 4s, sys: 1.79 s, total: 1min 6s
Wall time: 1min 6s
```