### PR TITLE
FEAT: Introduce vectorized UDF api

### DIFF
--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -7,10 +7,11 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`/release-pre-1.0`
 
+* :feature:`2048` Introduce a top level vectorized UDF module (experimental). Implement element-wise UDF for pandas and PySpark backend.
 * :release:`1.2.1 <pending>`
 * :support:`2034` Add initial documentation for OmniSciDB, MySQL, PySpark and SparkSQL backends, add initial documentation for geospatial methods and add links to Ibis wiki page
 * :bug:`2050` CI: Drop table only if it exists
-* :feature:`2044` Implemented covariance for bigquery backend
+* :feature:`2044` Implement covariance for bigquery backend
 * :feature:`2035` Add support for  multi arguments window UDAF for the pandas backend
 * :bug:`2041` Change pymapd connection parameter from "session_id" to "sessionid"
 * :support:`2037` Drop support for Python 3.5

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -3450,3 +3450,12 @@ class ElementWiseUDF(ValueOp):
 
     def output_type(self):
         return self._output_type.column_type()
+
+    def root_tables(self):
+        result = list(
+            toolz.unique(
+                toolz.concat(arg._root_tables() for arg in self.func_args)
+            )
+        )
+
+        return result

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -3427,3 +3427,26 @@ class GeoAsText(GeoSpatialUnOp):
     """
 
     output_type = rlz.shape_like('arg', dt.string)
+
+
+class ElementWiseUDF(ValueOp):
+    """Node for element wise UDF.
+    """
+
+    func = Arg(rlz.noop)
+    func_args = Arg(rlz.noop)
+    input_type = Arg(rlz.noop)
+    _output_type = Arg(rlz.noop)
+
+    def __init__(self, func, args, input_type, output_type):
+        self.func = func
+        self.func_args = args
+        self.input_type = input_type
+        self._output_type = output_type
+
+    @property
+    def inputs(self):
+        return self.func_args
+
+    def output_type(self):
+        return self._output_type.column_type()

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -3433,9 +3433,9 @@ class ElementWiseVectorizedUDF(ValueOp):
     """Node for element wise UDF.
     """
 
-    func = Arg(rlz.noop)
-    func_args = Arg(rlz.noop)
-    input_type = Arg(rlz.noop)
+    func = Arg(callable)
+    func_args = Arg(list)
+    input_type = Arg(rlz.shape_like('func_args'))
     _output_type = Arg(rlz.noop)
 
     def __init__(self, func, args, input_type, output_type):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -3429,7 +3429,7 @@ class GeoAsText(GeoSpatialUnOp):
     output_type = rlz.shape_like('arg', dt.string)
 
 
-class ElementWiseUDF(ValueOp):
+class ElementWiseVectorizedUDF(ValueOp):
     """Node for element wise UDF.
     """
 

--- a/ibis/pandas/execution/tests/test_functions.py
+++ b/ibis/pandas/execution/tests/test_functions.py
@@ -10,7 +10,6 @@ import pandas.util.testing as tm  # noqa: E402
 import pytest
 
 import ibis
-import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt  # noqa: E402
 from ibis.pandas.udf import udf
 
@@ -272,21 +271,19 @@ def test_ifelse_returning_bool():
         pytest.param(
             dt.float64,
             True,
-            marks=pytest.mark.xfail(
-                raises=com.IbisTypeError,
+            marks=pytest.mark.skip(
                 reason=(
                     "Implicit casting from boolean to float is not "
                     "implemented"
-                ),
+                )
             ),
             id='float_bool',
         ),
         pytest.param(
             dt.int64,
             1.0,
-            marks=pytest.mark.xfail(
-                raises=com.IbisTypeError,
-                reason="Implicit casting from float to int is not implemented",
+            marks=pytest.mark.skip(
+                reason="Implicit casting from float to int is not implemented"
             ),
             id='int_float',
         ),
@@ -294,30 +291,27 @@ def test_ifelse_returning_bool():
             dt.int64,
             True,
             id='int_bool',
-            marks=pytest.mark.xfail(
-                raises=com.IbisTypeError,
+            marks=pytest.mark.skip(
                 reason=(
                     "Implicit casting from boolean to int is not implemented"
-                ),
+                )
             ),
         ),
         pytest.param(
             dt.boolean,
             1.0,
-            marks=pytest.mark.xfail(
-                raises=com.IbisTypeError,
+            marks=pytest.mark.skip(
                 reason=(
                     "Implicit casting from float to boolean is not implemented"
-                ),
+                )
             ),
             id='bool_float',
         ),
         pytest.param(
             dt.boolean,
             1,
-            marks=pytest.mark.xfail(
-                raises=NotImplementedError,
-                reason="Implicit casting for UDFs is not yet implemented",
+            marks=pytest.mark.skip(
+                reason="Implicit casting for UDFs is not yet implemented"
             ),
             id='bool_int',
         ),

--- a/ibis/pandas/execution/tests/test_functions.py
+++ b/ibis/pandas/execution/tests/test_functions.py
@@ -271,50 +271,19 @@ def test_ifelse_returning_bool():
         pytest.param(
             dt.float64,
             True,
-            marks=pytest.mark.skip(
+            marks=pytest.mark.xfail(
+                raises=NotImplementedError,
                 reason=(
                     "Implicit casting from boolean to float is not "
                     "implemented"
-                )
+                ),
             ),
             id='float_bool',
         ),
-        pytest.param(
-            dt.int64,
-            1.0,
-            marks=pytest.mark.skip(
-                reason="Implicit casting from float to int is not implemented"
-            ),
-            id='int_float',
-        ),
-        pytest.param(
-            dt.int64,
-            True,
-            id='int_bool',
-            marks=pytest.mark.skip(
-                reason=(
-                    "Implicit casting from boolean to int is not implemented"
-                )
-            ),
-        ),
-        pytest.param(
-            dt.boolean,
-            1.0,
-            marks=pytest.mark.skip(
-                reason=(
-                    "Implicit casting from float to boolean is not implemented"
-                )
-            ),
-            id='bool_float',
-        ),
-        pytest.param(
-            dt.boolean,
-            1,
-            marks=pytest.mark.skip(
-                reason="Implicit casting for UDFs is not yet implemented"
-            ),
-            id='bool_int',
-        ),
+        pytest.param(dt.int64, 1.0, id='int_float'),
+        pytest.param(dt.int64, True, id='int_bool'),
+        pytest.param(dt.boolean, 1.0, id='bool_float'),
+        pytest.param(dt.boolean, 1, id='bool_int'),
     ],
 )
 def test_signature_does_not_match_input_type(dtype, value):

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -528,8 +528,8 @@ class udf:
         return wrapper
 
 
-@pre_execute.register(ops.ElementWiseUDF)
-@pre_execute.register(ops.ElementWiseUDF, PandasClient)
+@pre_execute.register(ops.ElementWiseVectorizedUDF)
+@pre_execute.register(ops.ElementWiseVectorizedUDF, PandasClient)
 def pre_execute_elementwise_udf(
     op, *clients, scope=None, aggcontet=None, **kwargs
 ):
@@ -549,7 +549,7 @@ def pre_execute_elementwise_udf(
 
     @toolz.compose(
         *(
-            execute_node.register(ops.ElementWiseUDF, *types)
+            execute_node.register(ops.ElementWiseVectorizedUDF, *types)
             for types in group_by_signatures
         )
     )
@@ -578,11 +578,11 @@ def pre_execute_elementwise_udf(
     # Define an execution rule for a simple elementwise Series
     # function
     @execute_node.register(
-        ops.ElementWiseUDF,
+        ops.ElementWiseVectorizedUDF,
         *udf_signature(input_type, pin=None, klass=pd.Series),
     )
     @execute_node.register(
-        ops.ElementWiseUDF,
+        ops.ElementWiseVectorizedUDF,
         *(
             rule_to_python_type(argtype) + nullable(argtype)
             for argtype in input_type

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -19,14 +19,16 @@ from pandas.core.groupby import SeriesGroupBy
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.signature as sig
+import ibis.udf
 from ibis.pandas.aggcontext import Window
+from ibis.pandas.client import PandasClient
 from ibis.pandas.core import (
     date_types,
     time_types,
     timedelta_types,
     timestamp_types,
 )
-from ibis.pandas.dispatch import execute_node
+from ibis.pandas.dispatch import execute_node, pre_execute
 
 
 @functools.singledispatch
@@ -358,87 +360,7 @@ class udf:
         ... def my_string_length(series):
         ...     return series.str.len() * 2
         """
-        input_type = list(map(dt.dtype, input_type))
-        output_type = dt.dtype(output_type)
-
-        def wrapper(func):
-            # validate that the input_type argument and the function signature
-            # match
-            funcsig = valid_function_signature(input_type, func)
-
-            # generate a new custom node
-            UDFNode = type(
-                func.__name__,
-                (ops.ValueOp,),
-                {
-                    'signature': sig.TypeSignature.from_dtypes(input_type),
-                    'output_type': output_type.column_type,
-                },
-            )
-
-            # definitions
-
-            # Define an execution rule for elementwise operations on a
-            # grouped Series
-            nargs = len(input_type)
-            group_by_signatures = [
-                udf_signature(input_type, pin=pin, klass=SeriesGroupBy)
-                for pin in range(nargs)
-            ]
-
-            @toolz.compose(
-                *(
-                    execute_node.register(UDFNode, *types)
-                    for types in group_by_signatures
-                )
-            )
-            def execute_udf_node_groupby(op, *args, **kwargs):
-                groupers = [
-                    grouper
-                    for grouper in (
-                        getattr(arg, 'grouper', None) for arg in args
-                    )
-                    if grouper is not None
-                ]
-
-                # all grouping keys must be identical
-                assert all(groupers[0] == grouper for grouper in groupers[1:])
-
-                # we're performing a scalar operation on grouped column, so
-                # perform the operation directly on the underlying Series
-                # and regroup after it's finished
-                arguments = [getattr(arg, 'obj', arg) for arg in args]
-                groupings = groupers[0].groupings
-                args, kwargs = arguments_from_signature(
-                    signature(func), *arguments, **kwargs
-                )
-                return func(*args, **kwargs).groupby(groupings)
-
-            # Define an execution rule for a simple elementwise Series
-            # function
-            @execute_node.register(
-                UDFNode, *udf_signature(input_type, pin=None, klass=pd.Series)
-            )
-            @execute_node.register(
-                UDFNode,
-                *(
-                    rule_to_python_type(argtype) + nullable(argtype)
-                    for argtype in input_type
-                ),
-            )
-            def execute_udf_node(op, *args, **kwargs):
-                args, kwargs = arguments_from_signature(
-                    funcsig, *args, **kwargs
-                )
-                return func(*args, **kwargs)
-
-            @functools.wraps(func)
-            def wrapped(*args):
-                return UDFNode(*args).to_expr()
-
-            return wrapped
-
-        return wrapper
+        return ibis.udf.elementwise(input_type, output_type)
 
     @staticmethod
     def reduction(input_type, output_type):
@@ -604,3 +526,73 @@ class udf:
             return wrapped
 
         return wrapper
+
+
+@pre_execute.register(ops.ElementWiseUDF)
+@pre_execute.register(ops.ElementWiseUDF, PandasClient)
+def pre_execute_elementwise_udf(
+    op, *clients, scope=None, aggcontet=None, **kwargs
+):
+    """Register execution rules for elementwise UDFs.
+    """
+    input_type = op.input_type
+
+    # definitions
+
+    # Define an execution rule for elementwise operations on a
+    # grouped Series
+    nargs = len(input_type)
+    group_by_signatures = [
+        udf_signature(input_type, pin=pin, klass=SeriesGroupBy)
+        for pin in range(nargs)
+    ]
+
+    @toolz.compose(
+        *(
+            execute_node.register(ops.ElementWiseUDF, *types)
+            for types in group_by_signatures
+        )
+    )
+    def execute_udf_node_groupby(op, *args, **kwargs):
+        func = op.func
+
+        groupers = [
+            grouper
+            for grouper in (getattr(arg, 'grouper', None) for arg in args)
+            if grouper is not None
+        ]
+
+        # all grouping keys must be identical
+        assert all(groupers[0] == grouper for grouper in groupers[1:])
+
+        # we're performing a scalar operation on grouped column, so
+        # perform the operation directly on the underlying Series
+        # and regroup after it's finished
+        arguments = [getattr(arg, 'obj', arg) for arg in args]
+        groupings = groupers[0].groupings
+        args, kwargs = arguments_from_signature(
+            signature(func), *arguments, **kwargs
+        )
+        return func(*args, **kwargs).groupby(groupings)
+
+    # Define an execution rule for a simple elementwise Series
+    # function
+    @execute_node.register(
+        ops.ElementWiseUDF,
+        *udf_signature(input_type, pin=None, klass=pd.Series),
+    )
+    @execute_node.register(
+        ops.ElementWiseUDF,
+        *(
+            rule_to_python_type(argtype) + nullable(argtype)
+            for argtype in input_type
+        ),
+    )
+    def execute_udf_node(op, *args, **kwargs):
+        func = op.func
+        funcsig = valid_function_signature(input_type, func)
+
+        args, kwargs = arguments_from_signature(funcsig, *args, **kwargs)
+        return func(*args, **kwargs)
+
+    return scope

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -19,7 +19,7 @@ from pandas.core.groupby import SeriesGroupBy
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.signature as sig
-import ibis.udf
+import ibis.udf.vectorized
 from ibis.pandas.aggcontext import Window
 from ibis.pandas.client import PandasClient
 from ibis.pandas.core import (
@@ -360,7 +360,7 @@ class udf:
         ... def my_string_length(series):
         ...     return series.str.len() * 2
         """
-        return ibis.udf.elementwise(input_type, output_type)
+        return ibis.udf.vectorized.elementwise(input_type, output_type)
 
     @staticmethod
     def reduction(input_type, output_type):

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -1436,3 +1436,15 @@ def compile_null_if(t, expr, scope, **kwargs):
     col = t.translate(op.arg, scope)
     nullif_col = t.translate(op.null_if_expr, scope)
     return F.when(col == nullif_col, F.lit(None)).otherwise(col)
+
+
+# ------------------------- User defined function ------------------------
+
+
+@compiles(ops.ElementWiseUDF)
+def compile_elementwise_udf(t, expr, scope):
+    op = expr.op()
+    spark_output_type = ibis_dtype_to_spark_dtype(op._output_type)
+    spark_udf = pandas_udf(op.func, spark_output_type, PandasUDFType.SCALAR)
+    func_args = (t.translate(arg, scope) for arg in op.func_args)
+    return spark_udf(*func_args)

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -1441,7 +1441,7 @@ def compile_null_if(t, expr, scope, **kwargs):
 # ------------------------- User defined function ------------------------
 
 
-@compiles(ops.ElementWiseUDF)
+@compiles(ops.ElementWiseVectorizedUDF)
 def compile_elementwise_udf(t, expr, scope):
     op = expr.op()
     spark_output_type = ibis_dtype_to_spark_dtype(op._output_type)

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -1,0 +1,18 @@
+import pytest
+
+import ibis.expr.datatypes as dt
+from ibis.tests.backends import Pandas, PySpark
+from ibis.udf.vectorized import elementwise
+
+
+@elementwise(input_type=[dt.double], output_type=dt.double)
+def add_one(s):
+    return s + 1
+
+
+@pytest.mark.xfail_unsupported
+@pytest.mark.only_on_backends([Pandas, PySpark])
+def test_elementwise_udf(backend, alltypes, df):
+    result = add_one(alltypes['double_col']).execute()
+    expected = add_one.func(df['double_col'])
+    backend.assert_series_equal(result, expected, check_names=False)

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -10,8 +10,8 @@ def add_one(s):
     return s + 1
 
 
-@pytest.mark.xfail_unsupported
 @pytest.mark.only_on_backends([Pandas, PySpark])
+@pytest.mark.xfail_unsupported
 def test_elementwise_udf(backend, alltypes, df):
     result = add_one(alltypes['double_col']).execute()
     expected = add_one.func(df['double_col'])

--- a/ibis/udf.py
+++ b/ibis/udf.py
@@ -1,0 +1,39 @@
+"""Top level APIs for defining UDFs that works for multiple backends.
+
+This *currently* mimics ibis.pandas.udf API.
+
+Warning: This is an experimental module and API here can change without notice.
+Do not use directly.
+"""
+
+import ibis.expr.datatypes as dt
+from ibis.expr.operations import ElementWiseUDF
+
+
+class UserDefinedFunction(object):
+    def __init__(self, func, func_type, input_type, output_type):
+        self.func = func
+        self.func_type = func_type
+        self.input_type = input_type
+        self.output_type = output_type
+
+    def __call__(self, *args, **kwargs):
+        op = self.func_type(
+            func=self.func,
+            args=args,
+            input_type=self.input_type,
+            output_type=self.output_type,
+        )
+        return op.to_expr()
+
+
+def elementwise(input_type, output_type):
+    input_type = list(map(dt.dtype, input_type))
+    output_type = dt.dtype(output_type)
+
+    def wrapper(func):
+        return UserDefinedFunction(
+            func, ElementWiseUDF, input_type, output_type
+        )
+
+    return wrapper

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -1,11 +1,12 @@
 """Top level APIs for defining vectorized UDFs.
 
 Warning: This is an experimental module and API here can change without notice.
-Do not use directly.
+
+DO NOT USE DIRECTLY.
 """
 
 import ibis.expr.datatypes as dt
-from ibis.expr.operations import ElementWiseUDF
+from ibis.expr.operations import ElementWiseVectorizedUDF
 
 
 class UserDefinedFunction(object):
@@ -33,7 +34,7 @@ def elementwise(input_type, output_type):
 
     def wrapper(func):
         return UserDefinedFunction(
-            func, ElementWiseUDF, input_type, output_type
+            func, ElementWiseVectorizedUDF, input_type, output_type
         )
 
     return wrapper

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -1,6 +1,4 @@
-"""Top level APIs for defining UDFs that works for multiple backends.
-
-This *currently* mimics ibis.pandas.udf API.
+"""Top level APIs for defining vectorized UDFs.
 
 Warning: This is an experimental module and API here can change without notice.
 Do not use directly.
@@ -28,6 +26,8 @@ class UserDefinedFunction(object):
 
 
 def elementwise(input_type, output_type):
+    """ Element wise vectorized UDFs.
+    """
     input_type = list(map(dt.dtype, input_type))
     output_type = dt.dtype(output_type)
 

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -10,6 +10,11 @@ from ibis.expr.operations import ElementWiseVectorizedUDF
 
 
 class UserDefinedFunction(object):
+    """ Class representing a user defined function.
+
+    This class Implements __call__ that returns an ibis expr for the UDF.
+    """
+
     def __init__(self, func, func_type, input_type, output_type):
         self.func = func
         self.func_type = func_type


### PR DESCRIPTION
One of Ibis' design goal is to have one common expression language that works for multiple backend execution engines. However, the current UDF api contradicts this design goal because the UDF is defined under per backend namespace (e.g., `ibis.pandas.udf`) and therefore, ibis program that contains UDF cannot move to another backend.

I propose to introduce a top level ibis UDF api, `ibis.udf.vectorized` to address this issue. Vectorized UDFs take vectorized data structure as input, this currently means `numpy.ndarray` `pd.Series` and `pd.DataFrame` and return Python scalar or vectorized data structure as output.

This is proposed as a very experimental API.

In this PR, I have made the following changes in particular:

- Introduced `ibis.udf.vectorized` namespace 
- Implemented elementwise UDF under the new namespace
    - Modified `ibis.pandas.udf` to use `ibis.udf.vectorized` directly
    - Implemented execution rule in PySpark backend for `ibis.udf.vectorized`
- Added a new common test `ibis/tests/all/test_vectorized_udf.py`

The following is not included in the PR and left as future work
- Refine `ibis.udf.vectorized` API
- Implement analytics and aggregation UDFs (currently defined under `ibis.pandas.udf`)

This PR addresses issue https://github.com/ibis-project/ibis/issues/2048