### PR TITLE
[Omnisci] The same SRIDs for test_geo_spatial_binops

### DIFF
--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -260,7 +260,7 @@ def postgres(schema, tables, data_directory, psql_path, plpython, **params):
                 continue
             from geoalchemy2 import Geometry, WKTElement
 
-            srid = 4326
+            srid = 0
             df = pd.read_csv(src)
             df[df.columns[1:]] = df[df.columns[1:]].applymap(
                 lambda x: WKTElement(x, srid=srid)

--- a/ci/schema/omniscidb.sql
+++ b/ci/schema/omniscidb.sql
@@ -75,8 +75,8 @@ DROP TABLE IF EXISTS geo;
 
 CREATE TABLE geo (
   id INTEGER,
-  geo_point POINT,
-  geo_linestring LINESTRING,
-  geo_polygon POLYGON,
-  geo_multipolygon MULTIPOLYGON
+  geo_point GEOMETRY(POINT, 0),
+  geo_linestring GEOMETRY(LINESTRING, 0),
+  geo_polygon GEOMETRY(POLYGON, 0),
+  geo_multipolygon GEOMETRY(MULTIPOLYGON, 0)
 );

--- a/ibis/sql/postgres/tests/test_postgis.py
+++ b/ibis/sql/postgres/tests/test_postgis.py
@@ -229,7 +229,7 @@ def test_geo_perimeter(geotable):
 def test_geo_srid(geotable):
     expr = geotable.geo_linestring.srid()
     result = expr.execute()
-    assert (result == 4326).all()
+    assert (result == 0).all()
 
 
 def test_geo_difference(geotable, gdf):

--- a/ibis/tests/all/test_geospatial.py
+++ b/ibis/tests/all/test_geospatial.py
@@ -273,7 +273,12 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
     ('expr_fn', 'expected'),
     [
         param(
-            lambda t: t['geo_linestring'].contains(point_geom_1_srid0),
+            # there is no explicit definition srid in the table, backends set different default srid,
+            # so use points with relevant srid
+            {
+                'omniscidb': lambda t: t['geo_linestring'].contains(point_geom_1_srid0),
+                'postgres': lambda t: t['geo_linestring'].contains(point_geom_1),
+            },
             {
                 'omniscidb': [True, True, False, False, False],
                 'postgres': [False] * 5,  # not contains the border
@@ -281,7 +286,10 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='contains',
         ),
         param(
-            lambda t: t['geo_linestring'].disjoint(point_geom_0_srid0),
+            {
+                'omniscidb': lambda t: t['geo_linestring'].disjoint(point_geom_0_srid0),
+                'postgres': lambda t: t['geo_linestring'].disjoint(point_geom_0),
+            },
             {
                 'omniscidb': [False, True, True, True, True],
                 'postgres': [False, True, True, True, True],
@@ -289,7 +297,10 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='disjoint',
         ),
         param(
-            lambda t: t['geo_point'].d_within(point_geom_1_srid0, 2.0),
+            {
+                'omniscidb': lambda t: t['geo_linestring'].d_within(point_geom_1_srid0, 2.0),
+                'postgres': lambda t: t['geo_linestring'].d_within(point_geom_1, 2.0),
+            },
             {
                 'omniscidb': [True, True, True, False, False],
                 'postgres': [True, True, True, False, False],
@@ -297,7 +308,10 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='d_within',
         ),
         param(
-            lambda t: t['geo_linestring'].intersects(point_geom_0_srid0),
+            {
+                'omniscidb': lambda t: t['geo_linestring'].intersects(point_geom_0_srid0),
+                'postgres': lambda t: t['geo_linestring'].intersects(point_geom_0),
+            },
             {
                 'omniscidb': [True, False, False, False, False],
                 'postgres': [True, False, False, False, False],
@@ -305,7 +319,10 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='intersects',
         ),
         param(
-            lambda t: t['geo_linestring'].distance(point_geom_0_srid0),
+            {
+                'omniscidb': lambda t: t['geo_linestring'].distance(point_geom_0_srid0),
+                'postgres': lambda t: t['geo_linestring'].distance(point_geom_0),
+            },
             {
                 'omniscidb': [0.0, 1.41, 2.82, 4.24, 5.66],
                 'postgres': [0.0, 1.41, 2.82, 4.24, 5.66],
@@ -313,7 +330,10 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='distance',
         ),
         param(
-            lambda t: t['geo_linestring'].max_distance(point_geom_0_srid0),
+            {
+                'omniscidb': lambda t: t['geo_linestring'].max_distance(point_geom_0_srid0),
+                'postgres': lambda t: t['geo_linestring'].max_distance(point_geom_0),
+            },
             {
                 'omniscidb': [1.41, 2.82, 4.24, 5.66, 7.08],
                 'postgres': [1.41, 2.82, 4.24, 5.66, 7.08],
@@ -326,7 +346,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
 @pytest.mark.xfail_unsupported
 def test_geo_spatial_binops(backend, geo, expr_fn, expected):
     """Testing for geo spatial binary operations."""
-    expr = expr_fn(geo)
+    expr = expr_fn[backend.name](geo)
     result = expr.execute()
     testing.assert_almost_equal(result, expected[backend.name], decimal=2)
 

--- a/ibis/tests/all/test_geospatial.py
+++ b/ibis/tests/all/test_geospatial.py
@@ -273,32 +273,15 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
     ('expr_fn', 'expected'),
     [
         param(
-            # there is no explicit definition srid in the table,
-            # backends set different default srid,
-            # so use points with relevant srid
+            lambda t: t['geo_linestring'].contains(point_geom_1_srid0),
             {
-                'omniscidb': lambda t: t['geo_linestring'].contains(
-                    point_geom_1_srid0
-                ),
-                'postgres': lambda t: t['geo_linestring'].contains(
-                    point_geom_1
-                ),
-            },
-            {
-                'omniscidb': [True, True, False, False, False],
+                'omniscidb': [ True,  True, False, False, False],
                 'postgres': [False] * 5,  # not contains the border
             },
             id='contains',
         ),
         param(
-            {
-                'omniscidb': lambda t: t['geo_linestring'].disjoint(
-                    point_geom_0_srid0
-                ),
-                'postgres': lambda t: t['geo_linestring'].disjoint(
-                    point_geom_0
-                ),
-            },
+            lambda t: t['geo_linestring'].disjoint(point_geom_0_srid0),
             {
                 'omniscidb': [False, True, True, True, True],
                 'postgres': [False, True, True, True, True],
@@ -306,14 +289,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='disjoint',
         ),
         param(
-            {
-                'omniscidb': lambda t: t['geo_linestring'].d_within(
-                    point_geom_1_srid0, 2.0
-                ),
-                'postgres': lambda t: t['geo_linestring'].d_within(
-                    point_geom_1, 2.0
-                ),
-            },
+            lambda t: t['geo_point'].d_within(point_geom_1_srid0, 2.0),
             {
                 'omniscidb': [True, True, True, False, False],
                 'postgres': [True, True, True, False, False],
@@ -321,14 +297,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='d_within',
         ),
         param(
-            {
-                'omniscidb': lambda t: t['geo_linestring'].intersects(
-                    point_geom_0_srid0
-                ),
-                'postgres': lambda t: t['geo_linestring'].intersects(
-                    point_geom_0
-                ),
-            },
+            lambda t: t['geo_linestring'].intersects(point_geom_0_srid0),
             {
                 'omniscidb': [True, False, False, False, False],
                 'postgres': [True, False, False, False, False],
@@ -336,14 +305,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='intersects',
         ),
         param(
-            {
-                'omniscidb': lambda t: t['geo_linestring'].distance(
-                    point_geom_0_srid0
-                ),
-                'postgres': lambda t: t['geo_linestring'].distance(
-                    point_geom_0
-                ),
-            },
+            lambda t: t['geo_linestring'].distance(point_geom_0_srid0),
             {
                 'omniscidb': [0.0, 1.41, 2.82, 4.24, 5.66],
                 'postgres': [0.0, 1.41, 2.82, 4.24, 5.66],
@@ -351,14 +313,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='distance',
         ),
         param(
-            {
-                'omniscidb': lambda t: t['geo_linestring'].max_distance(
-                    point_geom_0_srid0
-                ),
-                'postgres': lambda t: t['geo_linestring'].max_distance(
-                    point_geom_0
-                ),
-            },
+            lambda t: t['geo_linestring'].max_distance(point_geom_0_srid0),
             {
                 'omniscidb': [1.41, 2.82, 4.24, 5.66, 7.08],
                 'postgres': [1.41, 2.82, 4.24, 5.66, 7.08],
@@ -371,7 +326,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
 @pytest.mark.xfail_unsupported
 def test_geo_spatial_binops(backend, geo, expr_fn, expected):
     """Testing for geo spatial binary operations."""
-    expr = expr_fn[backend.name](geo)
+    expr = expr_fn(geo)
     result = expr.execute()
     testing.assert_almost_equal(result, expected[backend.name], decimal=2)
 
@@ -421,15 +376,15 @@ def test_area(backend, geo, arg, expected):
     [
         (lambda t: point_geom_2.srid(), {'omniscidb': 4326, 'postgres': 4326}),
         (lambda t: point_geom_0.srid(), {'omniscidb': 4326, 'postgres': 4326}),
-        (lambda t: t.geo_point.srid(), {'omniscidb': 0, 'postgres': 4326}),
+        (lambda t: t.geo_point.srid(), {'omniscidb': 0, 'postgres': 0}),
         (
             lambda t: t.geo_linestring.srid(),
-            {'omniscidb': 0, 'postgres': 4326},
+            {'omniscidb': 0, 'postgres': 0},
         ),
-        (lambda t: t.geo_polygon.srid(), {'omniscidb': 0, 'postgres': 4326}),
+        (lambda t: t.geo_polygon.srid(), {'omniscidb': 0, 'postgres': 0}),
         (
             lambda t: t.geo_multipolygon.srid(),
-            {'omniscidb': 0, 'postgres': 4326},
+            {'omniscidb': 0, 'postgres': 0},
         ),
     ],
 )

--- a/ibis/tests/all/test_geospatial.py
+++ b/ibis/tests/all/test_geospatial.py
@@ -273,11 +273,16 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
     ('expr_fn', 'expected'),
     [
         param(
-            # there is no explicit definition srid in the table, backends set different default srid,
+            # there is no explicit definition srid in the table,
+            # backends set different default srid,
             # so use points with relevant srid
             {
-                'omniscidb': lambda t: t['geo_linestring'].contains(point_geom_1_srid0),
-                'postgres': lambda t: t['geo_linestring'].contains(point_geom_1),
+                'omniscidb': lambda t: t['geo_linestring'].contains(
+                    point_geom_1_srid0
+                ),
+                'postgres': lambda t: t['geo_linestring'].contains(
+                    point_geom_1
+                ),
             },
             {
                 'omniscidb': [True, True, False, False, False],
@@ -287,8 +292,12 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
         ),
         param(
             {
-                'omniscidb': lambda t: t['geo_linestring'].disjoint(point_geom_0_srid0),
-                'postgres': lambda t: t['geo_linestring'].disjoint(point_geom_0),
+                'omniscidb': lambda t: t['geo_linestring'].disjoint(
+                    point_geom_0_srid0
+                ),
+                'postgres': lambda t: t['geo_linestring'].disjoint(
+                    point_geom_0
+                ),
             },
             {
                 'omniscidb': [False, True, True, True, True],
@@ -298,8 +307,12 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
         ),
         param(
             {
-                'omniscidb': lambda t: t['geo_linestring'].d_within(point_geom_1_srid0, 2.0),
-                'postgres': lambda t: t['geo_linestring'].d_within(point_geom_1, 2.0),
+                'omniscidb': lambda t: t['geo_linestring'].d_within(
+                    point_geom_1_srid0, 2.0
+                ),
+                'postgres': lambda t: t['geo_linestring'].d_within(
+                    point_geom_1, 2.0
+                ),
             },
             {
                 'omniscidb': [True, True, True, False, False],
@@ -309,8 +322,12 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
         ),
         param(
             {
-                'omniscidb': lambda t: t['geo_linestring'].intersects(point_geom_0_srid0),
-                'postgres': lambda t: t['geo_linestring'].intersects(point_geom_0),
+                'omniscidb': lambda t: t['geo_linestring'].intersects(
+                    point_geom_0_srid0
+                ),
+                'postgres': lambda t: t['geo_linestring'].intersects(
+                    point_geom_0
+                ),
             },
             {
                 'omniscidb': [True, False, False, False, False],
@@ -320,8 +337,12 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
         ),
         param(
             {
-                'omniscidb': lambda t: t['geo_linestring'].distance(point_geom_0_srid0),
-                'postgres': lambda t: t['geo_linestring'].distance(point_geom_0),
+                'omniscidb': lambda t: t['geo_linestring'].distance(
+                    point_geom_0_srid0
+                ),
+                'postgres': lambda t: t['geo_linestring'].distance(
+                    point_geom_0
+                ),
             },
             {
                 'omniscidb': [0.0, 1.41, 2.82, 4.24, 5.66],
@@ -331,8 +352,12 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
         ),
         param(
             {
-                'omniscidb': lambda t: t['geo_linestring'].max_distance(point_geom_0_srid0),
-                'postgres': lambda t: t['geo_linestring'].max_distance(point_geom_0),
+                'omniscidb': lambda t: t['geo_linestring'].max_distance(
+                    point_geom_0_srid0
+                ),
+                'postgres': lambda t: t['geo_linestring'].max_distance(
+                    point_geom_0
+                ),
             },
             {
                 'omniscidb': [1.41, 2.82, 4.24, 5.66, 7.08],

--- a/ibis/tests/all/test_geospatial.py
+++ b/ibis/tests/all/test_geospatial.py
@@ -275,7 +275,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
         param(
             lambda t: t['geo_linestring'].contains(point_geom_1_srid0),
             {
-                'omniscidb': [ True,  True, False, False, False],
+                'omniscidb': [True, True, False, False, False],
                 'postgres': [False] * 5,  # not contains the border
             },
             id='contains',
@@ -377,15 +377,9 @@ def test_area(backend, geo, arg, expected):
         (lambda t: point_geom_2.srid(), {'omniscidb': 4326, 'postgres': 4326}),
         (lambda t: point_geom_0.srid(), {'omniscidb': 4326, 'postgres': 4326}),
         (lambda t: t.geo_point.srid(), {'omniscidb': 0, 'postgres': 0}),
-        (
-            lambda t: t.geo_linestring.srid(),
-            {'omniscidb': 0, 'postgres': 0},
-        ),
+        (lambda t: t.geo_linestring.srid(), {'omniscidb': 0, 'postgres': 0}),
         (lambda t: t.geo_polygon.srid(), {'omniscidb': 0, 'postgres': 0}),
-        (
-            lambda t: t.geo_multipolygon.srid(),
-            {'omniscidb': 0, 'postgres': 0},
-        ),
+        (lambda t: t.geo_multipolygon.srid(), {'omniscidb': 0, 'postgres': 0}),
     ],
 )
 @pytest.mark.only_on_backends(all_db_geo_supported)

--- a/ibis/tests/all/test_geospatial.py
+++ b/ibis/tests/all/test_geospatial.py
@@ -17,6 +17,8 @@ point_0_4326 = ibis.literal((0, 0), type='point;4326').name('tmp')
 
 point_geom_0 = ibis.literal((0, 0), type='point;4326:geometry').name('p')
 point_geom_1 = ibis.literal((1, 1), type='point;4326:geometry').name('p')
+point_geom_0_srid0 = ibis.literal((0, 0), type='point;0:geometry').name('p')
+point_geom_1_srid0 = ibis.literal((1, 1), type='point;0:geometry').name('p')
 point_geom_2 = ibis.literal((2, 2), type='point;4326:geometry').name('p')
 point_geog_0 = ibis.literal((0, 0), type='point;4326:geography').name('p')
 point_geog_1 = ibis.literal((1, 1), type='point;4326:geography').name('p')
@@ -271,15 +273,15 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
     ('expr_fn', 'expected'),
     [
         param(
-            lambda t: t['geo_linestring'].contains(point_geom_1),
+            lambda t: t['geo_linestring'].contains(point_geom_1_srid0),
             {
-                'omniscidb': [False] * 5,
+                'omniscidb': [True, True, False, False, False],
                 'postgres': [False] * 5,  # not contains the border
             },
             id='contains',
         ),
         param(
-            lambda t: t['geo_linestring'].disjoint(point_geom_0),
+            lambda t: t['geo_linestring'].disjoint(point_geom_0_srid0),
             {
                 'omniscidb': [False, True, True, True, True],
                 'postgres': [False, True, True, True, True],
@@ -287,7 +289,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='disjoint',
         ),
         param(
-            lambda t: t['geo_point'].d_within(point_geom_1, 2.0),
+            lambda t: t['geo_point'].d_within(point_geom_1_srid0, 2.0),
             {
                 'omniscidb': [True, True, True, False, False],
                 'postgres': [True, True, True, False, False],
@@ -295,7 +297,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='d_within',
         ),
         param(
-            lambda t: t['geo_linestring'].intersects(point_geom_0),
+            lambda t: t['geo_linestring'].intersects(point_geom_0_srid0),
             {
                 'omniscidb': [True, False, False, False, False],
                 'postgres': [True, False, False, False, False],
@@ -303,7 +305,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='intersects',
         ),
         param(
-            lambda t: t['geo_linestring'].distance(point_geom_0),
+            lambda t: t['geo_linestring'].distance(point_geom_0_srid0),
             {
                 'omniscidb': [0.0, 1.41, 2.82, 4.24, 5.66],
                 'postgres': [0.0, 1.41, 2.82, 4.24, 5.66],
@@ -311,7 +313,7 @@ def test_geo_spatial_unops(backend, geo, expr_fn, expected):
             id='distance',
         ),
         param(
-            lambda t: t['geo_linestring'].max_distance(point_geom_0),
+            lambda t: t['geo_linestring'].max_distance(point_geom_0_srid0),
             {
                 'omniscidb': [1.41, 2.82, 4.24, 5.66, 7.08],
                 'postgres': [1.41, 2.82, 4.24, 5.66, 7.08],


### PR DESCRIPTION
Different SRIDs aren't supported in Omnisci backend since [commit](https://github.com/omnisci/omniscidb/commit/ff6e70db3f01483700c04561b7c5e4ab44fcfcab) . [Exception](https://github.com/omnisci/omniscidb/blob/29e35f4d5804d193f225ff0b622b73c5b8cbd4ea/QueryEngine/RelAlgTranslatorGeo.cpp#L825) is occurred. Can't use transform func separately to change SRID in the database table so create new objects with the same default SRID.
