### PR TITLE
Add initial support for ibis.random function

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -329,6 +329,7 @@ These methods are available directly in the ``ibis`` module namespace.
    trailing_window
    cumulative_window
    trailing_range_window
+   random
 
 .. _api.expr:
 

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -9,6 +9,7 @@ Release Notes
 
 * :feature:`2048` Introduce a top level vectorized UDF module (experimental). Implement element-wise UDF for pandas and PySpark backend.
 * :release:`1.2.1 <pending>`
+* :feature:`2060` Add initial support for ibis.random function
 * :bug:`2061` CI: Fix CI builds related to new pandas 1.0 compatibility
 * :feature:`1976` Add DenseRank, RowNumber, MinRank, Count, PercentRank/CumeDist window operations to OmniSciDB
 * :bug:`2055` Fix "cudf" import on OmniSciDB backend

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -187,6 +187,7 @@ __all__ = (
     'param',
     'pi',
     'prevent_rewrite',
+    'random',
     'range_window',
     'row_number',
     'rows_with_max_lookback',
@@ -1341,6 +1342,11 @@ def clip(arg, lower=None, upper=None):
         raise ValueError("at least one of lower and " "upper must be provided")
 
     op = ops.Clip(arg, lower, upper)
+    return op.to_expr()
+
+
+def random():
+    op = ops.Random()
     return op.to_expr()
 
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -23,6 +23,7 @@ import ibis.util as util
 from ibis.compat import to_date, to_time
 from ibis.expr.analytics import bucket, histogram
 from ibis.expr.groupby import GroupedTableExpr  # noqa
+from ibis.expr.random import random  # noqa
 from ibis.expr.schema import Schema
 from ibis.expr.types import (  # noqa
     ArrayColumn,
@@ -1342,11 +1343,6 @@ def clip(arg, lower=None, upper=None):
         raise ValueError("at least one of lower and " "upper must be provided")
 
     op = ops.Clip(arg, lower, upper)
-    return op.to_expr()
-
-
-def random():
-    op = ops.Random()
     return op.to_expr()
 
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2450,7 +2450,7 @@ class TimestampNow(Constant):
         return dt.timestamp.scalar_type()
 
 
-class Random(Constant):
+class RandomScalar(Constant):
     def output_type(self):
         return dt.float64.scalar_type()
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2450,6 +2450,11 @@ class TimestampNow(Constant):
         return dt.timestamp.scalar_type()
 
 
+class Random(Constant):
+    def output_type(self):
+        return dt.float64.scalar_type()
+
+
 class E(Constant):
     def output_type(self):
         return functools.partial(ir.FloatingScalar, dtype=dt.float64)

--- a/ibis/expr/random.py
+++ b/ibis/expr/random.py
@@ -1,0 +1,17 @@
+"""Ibis random number generation expression definitions."""
+
+import ibis.expr.operations as ops
+
+
+def random():
+    """
+    Return a random floating point number in the range [0.0, 1.0). Similar to
+    ``random.random`` in the Python standard library
+    https://docs.python.org/library/random.html
+
+    Returns
+    -------
+    random : random float value expression
+    """
+    op = ops.RandomScalar()
+    return op.to_expr()

--- a/ibis/sql/mysql/compiler.py
+++ b/ibis/sql/mysql/compiler.py
@@ -208,7 +208,7 @@ _operation_registry.update(
         ops.Log2: unary(sa.func.log2),
         ops.Log10: unary(sa.func.log10),
         ops.Round: _round,
-        ops.Random: _random,
+        ops.RandomScalar: _random,
         # dates and times
         ops.Date: unary(sa.func.date),
         ops.DateAdd: infix_op('+'),

--- a/ibis/sql/mysql/compiler.py
+++ b/ibis/sql/mysql/compiler.py
@@ -191,6 +191,10 @@ def _literal(t, expr):
         return sa.literal(value)
 
 
+def _random(t, expr):
+    return sa.func.random()
+
+
 _operation_registry.update(
     {
         ops.Literal: _literal,
@@ -204,6 +208,7 @@ _operation_registry.update(
         ops.Log2: unary(sa.func.log2),
         ops.Log10: unary(sa.func.log10),
         ops.Round: _round,
+        ops.Random: _random,
         # dates and times
         ops.Date: unary(sa.func.date),
         ops.DateAdd: infix_op('+'),

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -686,7 +686,7 @@ _operation_registry.update(
         ops.Max: _reduction('max'),
         ops.Variance: _variance_reduction('var'),
         ops.StandardDev: _variance_reduction('stddev'),
-        ops.Random: _random,
+        ops.RandomScalar: _random,
         # now is in the timezone of the server, but we want UTC
         ops.TimestampNow: lambda *args: sa.func.timezone('UTC', sa.func.now()),
         ops.CumulativeAll: unary(sa.func.bool_and),

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -607,6 +607,10 @@ def _literal(t, expr):
         return sa.literal(value)
 
 
+def _random(t, expr):
+    return sa.func.random()
+
+
 def _day_of_week_index(t, expr):
     (sa_arg,) = map(t.translate, expr.op().args)
     return sa.cast(
@@ -682,6 +686,7 @@ _operation_registry.update(
         ops.Max: _reduction('max'),
         ops.Variance: _variance_reduction('var'),
         ops.StandardDev: _variance_reduction('stddev'),
+        ops.Random: _random,
         # now is in the timezone of the server, but we want UTC
         ops.TimestampNow: lambda *args: sa.func.timezone('UTC', sa.func.now()),
         ops.CumulativeAll: unary(sa.func.bool_and),

--- a/ibis/tests/all/test_numeric.py
+++ b/ibis/tests/all/test_numeric.py
@@ -405,3 +405,11 @@ def test_sa_default_numeric_precision_and_scale(
 
     assert_equal(schema, expected)
     con.drop_table(table_name, force=True)
+
+
+@pytest.mark.only_on_backends([PostgreSQL, MySQL])
+def test_random_seed(backend, con):
+    expr = ibis.random()
+    result = con.execute(expr)
+    assert isinstance(result, float)
+    assert 0 <= result < 1

--- a/ibis/tests/all/test_numeric.py
+++ b/ibis/tests/all/test_numeric.py
@@ -408,8 +408,14 @@ def test_sa_default_numeric_precision_and_scale(
 
 
 @pytest.mark.only_on_backends([PostgreSQL, MySQL])
-def test_random_seed(backend, con):
+def test_random(con):
     expr = ibis.random()
     result = con.execute(expr)
     assert isinstance(result, float)
     assert 0 <= result < 1
+
+    # Ensure a different random number of produced on subsequent calls
+    result2 = con.execute(expr)
+    assert isinstance(result2, float)
+    assert 0 <= result2 < 1
+    assert result != result2


### PR DESCRIPTION
This PR adds an `ibis.random` function which returns a random number between 0 (inclusive) and 1 (exclusive). I've started with initial support for the postgresql and mysql backends

Closes #1450