### PR TITLE
CI: Fix CI builds related to new pandas 1.0 compatibility

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -187,8 +187,8 @@ Create a client by supplying a dictionary of DataFrames using
    import pandas as pd
    con = ibis.pandas.connect(
        {
-          'A': pd.util.testing.makeDataFrame(),
-          'B': pd.util.testing.makeDataFrame(),
+          'A': pd._testing.makeDataFrame(),
+          'B': pd._testing.makeDataFrame(),
        }
    )
 

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -9,6 +9,7 @@ Release Notes
 
 * :feature:`2048` Introduce a top level vectorized UDF module (experimental). Implement element-wise UDF for pandas and PySpark backend.
 * :release:`1.2.1 <pending>`
+* :bug:`2061` Fix CI build errors
 * :feature:`1976` Add DenseRank, RowNumber, MinRank, Count, PercentRank/CumeDist window operations to OmniSciDB
 * :bug:`2055` Fix "cudf" import on OmniSciDB backend
 * :feature:`2052` added possibility to run tests for separate backend via `make test BACKENDS=[YOUR BACKEND]`

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -9,7 +9,7 @@ Release Notes
 
 * :feature:`2048` Introduce a top level vectorized UDF module (experimental). Implement element-wise UDF for pandas and PySpark backend.
 * :release:`1.2.1 <pending>`
-* :bug:`2061` Fix CI build errors
+* :bug:`2061` CI: Fix CI builds related to new pandas 1.0 compatibility
 * :feature:`1976` Add DenseRank, RowNumber, MinRank, Count, PercentRank/CumeDist window operations to OmniSciDB
 * :bug:`2055` Fix "cudf" import on OmniSciDB backend
 * :feature:`2052` added possibility to run tests for separate backend via `make test BACKENDS=[YOUR BACKEND]`

--- a/ibis/expr/tests/test_datatypes.py
+++ b/ibis/expr/tests/test_datatypes.py
@@ -461,6 +461,15 @@ def test_time_valid():
                 'not supported'
             ),
         ),
+        param(
+            None,
+            dt.Interval(unit='Y'),
+            id='years',
+            marks=pytest.mark.xfail(
+                reason='Year conversion from Timedelta to ibis interval '
+                'not supported'
+            ),
+        ),
     ],
 )
 def test_infer_dtype(value, expected_dtype):

--- a/ibis/expr/tests/test_datatypes.py
+++ b/ibis/expr/tests/test_datatypes.py
@@ -461,15 +461,6 @@ def test_time_valid():
                 'not supported'
             ),
         ),
-        param(
-            pd.Timedelta('3', unit='Y'),
-            dt.Interval(unit='Y'),
-            id='years',
-            marks=pytest.mark.xfail(
-                reason='Year conversion from Timedelta to ibis interval '
-                'not supported'
-            ),
-        ),
     ],
 )
 def test_infer_dtype(value, expected_dtype):

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -318,7 +318,7 @@ def compute_window_spec_interval(_, expr):
 
 def _window_agg_built_in(
     frame: pd.DataFrame,
-    windowed: pd.core.window._Window,
+    windowed: pd.core.window.Window,
     function: str,
     max_lookback: int,
     *args: Tuple[Any],
@@ -349,7 +349,7 @@ def _window_agg_built_in(
 
 def _window_agg_udf(
     grouped_data: SeriesGroupBy,
-    windowed: pd.core.window._Window,
+    windowed: pd.core.window.Window,
     function: Callable,
     dtype: np.dtype,
     max_lookback: int,

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -191,6 +191,9 @@ def test_udaf_analytic_groupby(con, t, df):
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.xfail(
+    reason="https://github.com/ibis-project/ibis/issues/2063", strict=True
+)
 def test_udaf_groupby():
     df = pd.DataFrame(
         {
@@ -373,6 +376,9 @@ def test_multiple_argument_udaf_window():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.xfail(
+    reason="https://github.com/ibis-project/ibis/issues/2063", strict=True
+)
 def test_udaf_window_nan():
     df = pd.DataFrame(
         {

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -191,7 +191,9 @@ def test_udaf_analytic_groupby(con, t, df):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(reason="https://github.com/ibis-project/ibis/issues/2063")
+@pytest.mark.xfail(
+    reason="https://github.com/ibis-project/ibis/issues/2063", strict=False
+)
 def test_udaf_groupby():
     df = pd.DataFrame(
         {
@@ -374,7 +376,9 @@ def test_multiple_argument_udaf_window():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(reason="https://github.com/ibis-project/ibis/issues/2063")
+@pytest.mark.xfail(
+    reason="https://github.com/ibis-project/ibis/issues/2063", strict=False
+)
 def test_udaf_window_nan():
     df = pd.DataFrame(
         {

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -191,9 +191,7 @@ def test_udaf_analytic_groupby(con, t, df):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="https://github.com/ibis-project/ibis/issues/2063", strict=True
-)
+@pytest.mark.xfail(reason="https://github.com/ibis-project/ibis/issues/2063")
 def test_udaf_groupby():
     df = pd.DataFrame(
         {
@@ -376,9 +374,7 @@ def test_multiple_argument_udaf_window():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    reason="https://github.com/ibis-project/ibis/issues/2063", strict=True
-)
+@pytest.mark.xfail(reason="https://github.com/ibis-project/ibis/issues/2063")
 def test_udaf_window_nan():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
This PR fixes a couple of issues with the documentation CI build that I noticed over in #2060 which are related to the recent Pandas 1.0 release (see https://dev.azure.com/ibis-project/ibis/_build/results?buildId=1791&view=logs&j=8f09edc2-e3b7-52de-126a-0225c4f3efa1&t=78a72aec-b398-558e-7c0d-2d33604b9e53&l=129)