### PR TITLE
FEAT: Implement read_csv for omniscidb backend

### DIFF
--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -9,6 +9,7 @@ Release Notes
 
 * :bug:`2089` Pin "clickhouse-driver" to ">=0.1.3"
 * :release:`1.3.0 <pending>`
+* :feature:`2062` Implement read_csv for omniscidb backend
 * :support:`2077` Change omniscidb image tag from v5.0.0 to v5.1.0 on docker-compose recipe
 * :feature:`2071` Improve many arguments UDF performance in pandas backend.
 * :support:`2075` Disable Postgres tests on Windows CI.

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -392,8 +392,13 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         stmt = ddl.LoadData(self._qualified_name, df)
         return self._execute(stmt)
 
-    def read_csv(self, path: str, header: bool = True,
-                 quoted: bool = True, delimiter: str = ','):
+    def read_csv(
+        self,
+        path: str,
+        header: bool = True,
+        quoted: bool = True,
+        delimiter: str = ',',
+    ):
         """
         Load data into an Omniscidb table from CSV file.
 

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -399,7 +399,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         self,
         path: Union[str, Path],
         header: bool = True,
-        quoted: bool = True,
+        quotechar: str = '"',
         delimiter: str = ',',
     ):
         """
@@ -413,8 +413,8 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
           Path to the input data file
         header : bool, optional, default True
           Indicating whether the input file has a header line
-        quoted : bool, optional, default True
-          Indicating whether the input file contains quoted fields
+        quotechar : str, optional, default '"'
+          The character used to denote the start and end of a quoted item.
         delimiter : str, optional, default ','
 
         Returns
@@ -423,7 +423,8 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         """
         kwargs = {
             'header': header,
-            'quoted': quoted,
+            'quote': quotechar,
+            'qouted': True if quotechar != '' else False,
             'delimiter': delimiter,
         }
         stmt = ddl.LoadData(self._qualified_name, path, **kwargs)

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -439,6 +439,51 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         Returns
         -------
         query : OmniSciDBQuery
+
+        Examples
+        --------
+        # assumptions:
+        #   - dataset can be found on ./datasets/functional_alltypes.csv
+        #       https://github.com/ibis-project/testing-data/blob/master/functional_alltypes.csv
+        #   - omnisci server is launched on localhost and using port: 6274
+
+        import ibis
+
+        conn = ibis.omniscidb.connect(
+            host="localhost",
+            port="6274",
+            user="admin",
+            password="HyperInteractive",
+        )
+
+        t_name = "functional_alltypes"
+        db_name = "ibis_testing"
+        filename = "./datasets/functional_alltypes.csv"
+
+        schema = ibis.schema(
+            [
+                ('index', 'int64'),
+                ('Unnamed__0', 'int64'),
+                ('id', 'int32'),
+                ('bool_col', 'bool'),
+                ('tinyint_col', 'int16'),
+                ('smallint_col', 'int16'),
+                ('int_col', 'int32'),
+                ('bigint_col', 'int64'),
+                ('float_col', 'float32'),
+                ('double_col', 'double'),
+                ('date_string_col', 'string'),
+                ('string_col', 'string'),
+                ('timestamp_col', 'timestamp'),
+                ('year_', 'int32'),
+                ('month_', 'int32'),
+            ]
+        )
+        conn.create_table(t_name, schema=schema)
+
+        db = conn.database(db_name)
+        table = db.table(t_name)
+        table.read_csv(filename, header=False, quotechar='"', delimiter=",")
         """
         kwargs = {
             'header': header,

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -392,17 +392,15 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         stmt = ddl.LoadData(self._qualified_name, df)
         return self._execute(stmt)
 
-    def load_data(self, path, delimiter, header=True, quoted=True):
+    def read_csv(self, path, header=True, quoted=True):
         """
-        Wraps the LOAD DATA DDL statement. Loads data into an Omniscidb table by
-        physically moving data files.
+        Wraps the COPY FROM DML statement
+		Loads data into an Omniscidb table from CSV files
 
         Parameters
         ----------
         path : string
           Path to the imput data file
-        delimiter : string
-          A single-character string for the delimiter between input fields
         header : boolean, optional, default True
           Indicating whether the input file has a header line in Line 1 that should be skipped
         quoted : boolean, optional, default True
@@ -412,7 +410,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         -------
         query : OmniSciDBQuery
         """
-        stmt = ddl.LoadData(self._qualified_name, path, delimiter, header, quoted)
+        stmt = ddl.LoadData(self._qualified_name, path, header, quoted)
         return self._execute(stmt)
 
     @property

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -394,15 +394,15 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
 
     def read_csv(self, path, header=True, quoted=True):
         """
-        Wraps the COPY FROM DML statement
-		Loads data into an Omniscidb table from CSV files
+        Wraps the COPY FROM DML statement.
+        Loads data into an Omniscidb table from CSV files
 
         Parameters
         ----------
         path : string
           Path to the imput data file
         header : boolean, optional, default True
-          Indicating whether the input file has a header line in Line 1 that should be skipped
+          Indicating whether the input file has a header line
         quoted : boolean, optional, default True
           Indicating whether the input file contains quoted fields
 

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -392,6 +392,29 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         stmt = ddl.LoadData(self._qualified_name, df)
         return self._execute(stmt)
 
+    def load_data(self, path, delimiter, header=True, quoted=True):
+        """
+        Wraps the LOAD DATA DDL statement. Loads data into an Omniscidb table by
+        physically moving data files.
+
+        Parameters
+        ----------
+        path : string
+          Path to the imput data file
+        delimiter : string
+          A single-character string for the delimiter between input fields
+        header : boolean, optional, default True
+          Indicating whether the input file has a header line in Line 1 that should be skipped
+        quoted : boolean, optional, default True
+          Indicating whether the input file contains quoted fields
+
+        Returns
+        -------
+        query : OmniSciDBQuery
+        """
+        stmt = ddl.LoadData(self._qualified_name, path, delimiter, header, quoted)
+        return self._execute(stmt)
+
     @property
     def name(self) -> str:
         """Return the operation name.

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -392,7 +392,8 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         stmt = ddl.LoadData(self._qualified_name, df)
         return self._execute(stmt)
 
-    def read_csv(self, path, header=True, quoted=True, delimiter=','):
+    def read_csv(self, path: str, header: bool = True,
+                 quoted: bool = True, delimiter: str = ','):
         """
         Load data into an Omniscidb table from CSV file.
 
@@ -400,13 +401,13 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
 
         Parameters
         ----------
-        path : string
+        path : str
           Path to the input data file
-        header : boolean, optional, default True
+        header : bool, optional, default True
           Indicating whether the input file has a header line
-        quoted : boolean, optional, default True
+        quoted : bool, optional, default True
           Indicating whether the input file contains quoted fields
-        delimiter : string, optional, default ','
+        delimiter : str, optional, default ','
 
         Returns
         -------

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -1,6 +1,6 @@
 """Ibis OmniSciDB Client."""
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 import pandas as pd
 import pkg_resources
@@ -398,9 +398,9 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
     def read_csv(
         self,
         path: Union[str, Path],
-        header: bool = True,
-        quotechar: str = '"',
-        delimiter: str = ',',
+        header: Optional[bool] = True,
+        quotechar: Optional[str] = '"',
+        delimiter: Optional[str] = ',',
     ):
         """
         Load data into an Omniscidb table from CSV file.
@@ -424,7 +424,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         kwargs = {
             'header': header,
             'quote': quotechar,
-            'quoted': True if quotechar != '' else False,
+            'quoted': bool(quotechar),
             'delimiter': delimiter,
         }
         stmt = ddl.LoadData(self._qualified_name, path, **kwargs)

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -1,4 +1,7 @@
 """Ibis OmniSciDB Client."""
+from pathlib import Path
+from typing import Union
+
 import pandas as pd
 import pkg_resources
 import pymapd
@@ -394,7 +397,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
 
     def read_csv(
         self,
-        path: str,
+        path: Union[str, Path],
         header: bool = True,
         quoted: bool = True,
         delimiter: str = ',',
@@ -406,7 +409,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
 
         Parameters
         ----------
-        path : str
+        path : str or pathlib.Path
           Path to the input data file
         header : bool, optional, default True
           Indicating whether the input file has a header line

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -417,6 +417,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         header: Optional[bool] = True,
         quotechar: Optional[str] = '"',
         delimiter: Optional[str] = ',',
+        threads: Optional[int] = None,
     ):
         """
         Load data into an Omniscidb table from CSV file.
@@ -425,13 +426,15 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
 
         Parameters
         ----------
-        path : str or pathlib.Path
+        path: str or pathlib.Path
           Path to the input data file
-        header : bool, optional, default True
+        header: bool, optional, default True
           Indicating whether the input file has a header line
-        quotechar : str, optional, default '"'
+        quotechar: str, optional, default '"'
           The character used to denote the start and end of a quoted item.
-        delimiter : str, optional, default ','
+        delimiter: str, optional, default ','
+        threads: int, optional, default number of CPU cores on the system
+          Number of threads for performing the data import.
 
         Returns
         -------
@@ -442,6 +445,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
             'quote': quotechar,
             'quoted': bool(quotechar),
             'delimiter': delimiter,
+            'threads': threads,
         }
         stmt = ddl.LoadData(self._qualified_name, path, **kwargs)
         return self._execute(stmt)

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -392,7 +392,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         stmt = ddl.LoadData(self._qualified_name, df)
         return self._execute(stmt)
 
-    def read_csv(self, path, header=True, quoted=True):
+    def read_csv(self, path, header=True, quoted=True, delimiter=','):
         """
         Load data into an Omniscidb table from CSV file.
 
@@ -406,6 +406,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
           Indicating whether the input file has a header line
         quoted : boolean, optional, default True
           Indicating whether the input file contains quoted fields
+        delimiter : string, optional, default ','
 
         Returns
         -------
@@ -414,6 +415,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         kwargs = {
             'header': header,
             'quoted': quoted,
+            'delimiter': delimiter,
         }
         stmt = ddl.LoadData(self._qualified_name, path, **kwargs)
         return self._execute(stmt)

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -424,7 +424,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         kwargs = {
             'header': header,
             'quote': quotechar,
-            'qouted': True if quotechar != '' else False,
+            'quoted': True if quotechar != '' else False,
             'delimiter': delimiter,
         }
         stmt = ddl.LoadData(self._qualified_name, path, **kwargs)

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -442,7 +442,8 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         """
         kwargs = {
             'header': header,
-            'quote': quotechar,
+            # 'quote' field couldn't be empty string for omnisci backend
+            'quote': quotechar if quotechar else '"',
             'quoted': bool(quotechar),
             'delimiter': delimiter,
             'threads': threads,

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -374,7 +374,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         """Delete all rows from, but do not drop, an existing table."""
         self._client.truncate_table(self._qualified_name)
 
-    def load_data(self, source, **kwargs):
+    def load_data(self, df):
         """
         Load a data frame into database.
 
@@ -389,7 +389,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         -------
         query : OmniSciDBQuery
         """
-        stmt = ddl.LoadData(self._qualified_name, source, **kwargs)
+        stmt = ddl.LoadData(self._qualified_name, df)
         return self._execute(stmt)
 
     def read_csv(self, path, header=True, quoted=True):
@@ -411,7 +411,11 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         -------
         query : OmniSciDBQuery
         """
-        stmt = ddl.LoadData(self._qualified_name, path, header, quoted)
+        kwargs = {
+            'header': header,
+            'quoted': quoted,
+        }
+        stmt = ddl.LoadData(self._qualified_name, path, **kwargs)
         return self._execute(stmt)
 
     @property

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -374,7 +374,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         """Delete all rows from, but do not drop, an existing table."""
         self._client.truncate_table(self._qualified_name)
 
-    def load_data(self, df):
+    def load_data(self, source, **kwargs):
         """
         Load a data frame into database.
 
@@ -389,7 +389,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         -------
         query : OmniSciDBQuery
         """
-        stmt = ddl.LoadData(self._qualified_name, df)
+        stmt = ddl.LoadData(self._qualified_name, source, **kwargs)
         return self._execute(stmt)
 
     def read_csv(self, path, header=True, quoted=True):

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -394,13 +394,14 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
 
     def read_csv(self, path, header=True, quoted=True):
         """
+        Load data into an Omniscidb table from CSV file.
+
         Wraps the COPY FROM DML statement.
-        Loads data into an Omniscidb table from CSV files
 
         Parameters
         ----------
         path : string
-          Path to the imput data file
+          Path to the input data file
         header : boolean, optional, default True
           Indicating whether the input file has a header line
         quoted : boolean, optional, default True

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -418,7 +418,7 @@ class OmniSciDBTable(ir.TableExpr, DatabaseEntity):
         quotechar: Optional[str] = '"',
         delimiter: Optional[str] = ',',
         threads: Optional[int] = None,
-    ):
+    ) -> OmniSciDBQuery:
         """
         Load data into an Omniscidb table from CSV file.
 

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -18,6 +18,7 @@ def _is_quoted(x):
     quoted, _ = regex.match(x).groups()
     return quoted is not None
 
+
 def _bool_str(x):
     return 'true' if x else 'false'
 
@@ -553,8 +554,6 @@ class LoadData(OmniSciDBDDL):
     def compile(self):
         scoped_name = self._get_scoped_name(self.table_name, self.database)
         return "COPY {} FROM '{}' WITH (header = '{}', quoted = '{}')".format(
-            scoped_name,
-			self.path, 
-			_bool_str(self.header), 
-			_bool_str(self.quoted)
-    	)
+            scoped_name, self.path,
+            _bool_str(self.header), _bool_str(self.quoted)
+        )

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -536,12 +536,16 @@ class LoadData(OmniSciDBDDL):
         self.options = kwargs
 
     def _get_options(self):
-        if self.options:
-            return 'WITH ({})'.format(
-                ', '.join("%s='%s'" % x for x in self.options.items())
-            )
-        else:
-            return ''
+        with_stmt = ','.join(
+            [
+                '{}={}'.format(
+                    i, "'{}'".format(v) if isinstance(v, str) else v
+                )
+                for i, v in self.options.items()
+                if v is not None
+            ]
+        )
+        return ' WITH ({})'.format(with_stmt)
 
     def compile(self):
         """Compile the LoadData expression."""

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -539,7 +539,7 @@ class LoadData(OmniSciDBDDL):
         with_stmt = ','.join(
             [
                 '{}={}'.format(
-                    i, "'{}'".format(v) if isinstance(v, str) else v
+                    i, "'{}'".format(v) if not isinstance(v, int) else v
                 )
                 for i, v in self.options.items()
                 if v is not None

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -1,5 +1,7 @@
 """Module for DDL operations."""
 import re
+from pathlib import Path
+from typing import Any, Dict, Union
 
 import ibis
 from ibis.sql.compiler import DDL, DML
@@ -530,12 +532,17 @@ class InsertPandas(OmniSciDBDML):
 class LoadData(OmniSciDBDDL):
     """Generate DDL for LOAD DATA command. Cannot be cancelled."""
 
-    def __init__(self, table_name, source, **kwargs):
+    def __init__(
+        self,
+        table_name: str,
+        source: Union[str, Path],
+        **kwargs: Dict[str, Any],
+    ):
         self.table_name = table_name
         self.source = source
         self.options = kwargs
 
-    def _get_options(self):
+    def _get_options(self) -> str:
         with_stmt = ','.join(
             [
                 '{}={}'.format(
@@ -547,7 +554,7 @@ class LoadData(OmniSciDBDDL):
         )
         return ' WITH ({})'.format(with_stmt)
 
-    def compile(self):
+    def compile(self) -> str:
         """Compile the LoadData expression."""
         return "COPY {} FROM '{}' {}".format(
             self.table_name, self.source, self._get_options()

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -19,10 +19,6 @@ def _is_quoted(x):
     return quoted is not None
 
 
-def _bool_str(x):
-    return 'true' if x else 'false'
-
-
 class OmniSciDBQualifiedSQLStatement:
     """OmniSciDBQualifiedSQLStatement."""
 
@@ -542,7 +538,7 @@ class LoadData(OmniSciDBDDL):
     def _get_options(self):
         if self.kwargs:
             return (
-                ' WITH('.join('%s=%r' % x for x in self.options.iteritems())
+                'WITH (' + ', '.join('%s=%r' % x for x in options.items())
                 + ')'
             )
         else:
@@ -551,7 +547,7 @@ class LoadData(OmniSciDBDDL):
     def compile(self):
         """Compile the LoadData expression."""
         if isinstance(self.source, str):
-            return "COPY {} FROM '{}'{})".format(
+            return "COPY {} FROM '{}' {})".format(
                 self.table_name, self.source, self._get_options()
             )
         else:

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -532,10 +532,7 @@ class InsertPandas(OmniSciDBDML):
 
 
 class LoadData(OmniSciDBDDL):
-
-    """
-    Generate DDL for LOAD DATA command. Cannot be cancelled
-    """
+    """Generate DDL for LOAD DATA command. Cannot be cancelled."""
 
     def __init__(self, table_name, source, **kwargs):
         self.table_name = table_name
@@ -552,6 +549,7 @@ class LoadData(OmniSciDBDDL):
             return ''
 
     def compile(self):
+        """Compile the LoadData expression."""
         if isinstance(self.source, str):
             return "COPY {} FROM '{}'{})".format(
                 self.table_name, self.source, self._get_options()

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -537,9 +537,9 @@ class LoadData(OmniSciDBDDL):
 
     def _get_options(self):
         if self.options:
-            return (
-                'WITH (' + ', '.join("%s='%s'" % x
-                                     for x in self.options.items()) + ')')
+            return 'WITH ({})'.format(
+                ', '.join("%s='%s'" % x for x in self.options.items())
+            )
         else:
             return ''
 

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -18,6 +18,9 @@ def _is_quoted(x):
     quoted, _ = regex.match(x).groups()
     return quoted is not None
 
+def _bool_str(x):
+    return 'true' if x else 'false'
+
 
 class OmniSciDBQualifiedSQLStatement:
     """OmniSciDBQualifiedSQLStatement."""
@@ -525,3 +528,32 @@ class InsertPandas(OmniSciDBDML):
     def compile(self):
         """Compile the Insert expression."""
         return '\n'.join(self.pieces)
+
+
+class LoadData(OmniSciDBDDL):
+
+    """
+    Generate DDL for LOAD DATA command. Cannot be cancelled
+    """
+
+    def __init__(
+        self,
+        table_name,
+        path,
+        delimiter=',',
+        header=True,
+        quoted=True,
+        database=None
+    ):
+        self.table_name = table_name
+        self.database = database
+        self.path = path
+        self.delimiter = delimiter
+        self.header = header
+        self.quoted = quoted
+
+    def compile(self):
+        scoped_name = self._get_scoped_name(self.table_name, self.database)
+        return "COPY {} FROM '{}' WITH (delimiter = '{}', header = '{}', quoted = '{}')".format(
+            scoped_name, self.path, self.delimiter, _bool_str(self.header), _bool_str(self.quoted)
+    )

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -539,7 +539,7 @@ class LoadData(OmniSciDBDDL):
         with_stmt = ','.join(
             [
                 '{}={}'.format(
-                    i, "'{}'".format(v) if not isinstance(v, int) else v
+                    i, "'{}'".format(v) if isinstance(v, (str, bool)) else v
                 )
                 for i, v in self.options.items()
                 if v is not None

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -536,9 +536,9 @@ class LoadData(OmniSciDBDDL):
         self.options = kwargs
 
     def _get_options(self):
-        if self.kwargs:
+        if self.options:
             return (
-                'WITH (' + ', '.join('%s=%r' % x for x in options.items())
+                'WITH (' + ', '.join("%s='%s'" % x for x in self.options.items())
                 + ')'
             )
         else:
@@ -547,7 +547,7 @@ class LoadData(OmniSciDBDDL):
     def compile(self):
         """Compile the LoadData expression."""
         if isinstance(self.source, str):
-            return "COPY {} FROM '{}' {})".format(
+            return "COPY {} FROM '{}' {}".format(
                 self.table_name, self.source, self._get_options()
             )
         else:

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -538,9 +538,8 @@ class LoadData(OmniSciDBDDL):
     def _get_options(self):
         if self.options:
             return (
-                'WITH (' + ', '.join("%s='%s'" % x for x in self.options.items())
-                + ')'
-            )
+                'WITH (' + ', '.join("%s='%s'" % x
+                                     for x in self.options.items()) + ')')
         else:
             return ''
 

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -538,12 +538,7 @@ class LoadData(OmniSciDBDDL):
     """
 
     def __init__(
-        self,
-        table_name,
-        path,
-        header=True,
-        quoted=True,
-        database=None
+        self, table_name, path, header=True, quoted=True, database=None
     ):
         self.table_name = table_name
         self.database = database
@@ -554,6 +549,8 @@ class LoadData(OmniSciDBDDL):
     def compile(self):
         scoped_name = self._get_scoped_name(self.table_name, self.database)
         return "COPY {} FROM '{}' WITH (header = '{}', quoted = '{}')".format(
-            scoped_name, self.path,
-            _bool_str(self.header), _bool_str(self.quoted)
+            scoped_name,
+            self.path,
+            _bool_str(self.header),
+            _bool_str(self.quoted),
         )

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -540,7 +540,6 @@ class LoadData(OmniSciDBDDL):
         self,
         table_name,
         path,
-        delimiter=',',
         header=True,
         quoted=True,
         database=None
@@ -548,12 +547,14 @@ class LoadData(OmniSciDBDDL):
         self.table_name = table_name
         self.database = database
         self.path = path
-        self.delimiter = delimiter
         self.header = header
         self.quoted = quoted
 
     def compile(self):
         scoped_name = self._get_scoped_name(self.table_name, self.database)
-        return "COPY {} FROM '{}' WITH (delimiter = '{}', header = '{}', quoted = '{}')".format(
-            scoped_name, self.path, self.delimiter, _bool_str(self.header), _bool_str(self.quoted)
-    )
+        return "COPY {} FROM '{}' WITH (header = '{}', quoted = '{}')".format(
+            scoped_name,
+			self.path, 
+			_bool_str(self.header), 
+			_bool_str(self.quoted)
+    	)

--- a/ibis/omniscidb/ddl.py
+++ b/ibis/omniscidb/ddl.py
@@ -545,13 +545,6 @@ class LoadData(OmniSciDBDDL):
 
     def compile(self):
         """Compile the LoadData expression."""
-        if isinstance(self.source, str):
-            return "COPY {} FROM '{}' {}".format(
-                self.table_name, self.source, self._get_options()
-            )
-        else:
-            raise NotImplementedError(
-                'Load data from the {} not implemented'.format(
-                    type(self.source)
-                )
-            )
+        return "COPY {} FROM '{}' {}".format(
+            self.table_name, self.source, self._get_options()
+        )

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pandas as pd
 import pytest
 from pkg_resources import get_distribution, parse_version
@@ -150,11 +152,15 @@ def test_explain(con, alltypes):
     con.explain(alltypes)
 
 
-def test_read_csv(con):
+@pytest.mark.parametrize(
+    'filename',
+    [
+        "/omnisci/test_read_csv.csv",
+        pathlib.Path("/omnisci/test_read_csv.csv"),
+    ],
+)
+def test_read_csv(con, filename):
     t_name = "test_read_csv"
-
-    # omnisci specific
-    filename = "/omnisci/test_read_csv.csv"
 
     con.drop_table(t_name, force=True)
     schema = ibis.schema(
@@ -178,7 +184,8 @@ def test_read_csv(con):
     )
     con.create_table(t_name, schema=schema)
 
-    # prepare csv file inside omnisci docker container for read_csv test
+    # prepare csv file inside omnisci docker container
+    # if the file exists, then it will be overwritten
     con._execute(
         "COPY (SELECT * FROM functional_alltypes) TO '{}'".format(filename)
     )

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -148,3 +148,49 @@ def test_sql(con, sql):
 def test_explain(con, alltypes):
     # execute the expression using SQL query
     con.explain(alltypes)
+
+
+def test_read_csv(con):
+    t_name = "test_read_csv"
+
+    # omnisci specific
+    filename = "/omnisci/test_read_csv.csv"
+
+    con.drop_table(t_name, force=True)
+    schema = ibis.schema(
+        [
+            ('index', 'int64'),
+            ('Unnamed__0', 'int64'),
+            ('id', 'int32'),
+            ('bool_col', 'bool'),
+            ('tinyint_col', 'int16'),
+            ('smallint_col', 'int16'),
+            ('int_col', 'int32'),
+            ('bigint_col', 'int64'),
+            ('float_col', 'float32'),
+            ('double_col', 'double'),
+            ('date_string_col', 'string'),
+            ('string_col', 'string'),
+            ('timestamp_col', 'timestamp'),
+            ('year_', 'int32'),
+            ('month_', 'int32'),
+        ]
+    )
+    con.create_table(t_name, schema=schema)
+
+    # prepare csv file inside omnisci docker container for read_csv test
+    con._execute(
+        "COPY (SELECT * FROM functional_alltypes) TO '{}'".format(filename)
+    )
+
+    try:
+        db = con.database()
+        table = db.table(t_name)
+        table.read_csv(filename, header=False, quoted=True, delimiter=",")
+
+        df_read_csv = table.execute()
+        df_expected = db.table("functional_alltypes").execute()
+
+        pd.testing.assert_frame_equal(df_expected, df_read_csv)
+    finally:
+        con.drop_table(t_name)

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -193,7 +193,7 @@ def test_read_csv(con, filename):
     try:
         db = con.database()
         table = db.table(t_name)
-        table.read_csv(filename, header=False, quoted=True, delimiter=",")
+        table.read_csv(filename, header=False, quotechar='"', delimiter=",")
 
         df_read_csv = table.execute()
         df_expected = db.table("functional_alltypes").execute()


### PR DESCRIPTION
continuation of #1977

The advantage of this approach is the avoidance of additional memory costs.

Problem:

- for test purpose I should have dataset inside omniscidb container. What the best way for this?