### PR TITLE
SUPP: Add support to Python 3.8

### DIFF
--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -11,23 +11,31 @@ jobs:
   variables:
     AZURECI: 1
     COMPOSE_FILE: ci/docker-compose.yml
-
+    PYTHONHASHSEED: "random"
+    PYTEST_MARK_EXPRESSION: "not udf"
+    BACKENDS: "clickhouse impala kudu-master kudu-tserver mysql omniscidb parquet postgres sqlite"
   strategy:
     matrix:
       py36:
-        PYTHONHASHSEED: "random"
         PYTHON_MAJOR_VERSION: "3"
         PYTHON_MINOR_VERSION: "6"
         PYTHON_VERSION: $(PYTHON_MAJOR_VERSION).$(PYTHON_MINOR_VERSION)
         PYTHON_NO_DOT_VERSION: $(PYTHON_MAJOR_VERSION)$(PYTHON_MINOR_VERSION)
-        PYTEST_MARK_EXPRESSION: "not udf"
       py37:
-        PYTHONHASHSEED: "random"
         PYTHON_MAJOR_VERSION: "3"
         PYTHON_MINOR_VERSION: "7"
         PYTHON_VERSION: $(PYTHON_MAJOR_VERSION).$(PYTHON_MINOR_VERSION)
         PYTHON_NO_DOT_VERSION: $(PYTHON_MAJOR_VERSION)$(PYTHON_MINOR_VERSION)
-        PYTEST_MARK_EXPRESSION: "not udf"
+      py38:
+        PYTHON_MAJOR_VERSION: "3"
+        PYTHON_MINOR_VERSION: "8"
+        PYTHON_VERSION: $(PYTHON_MAJOR_VERSION).$(PYTHON_MINOR_VERSION)
+        PYTHON_NO_DOT_VERSION: $(PYTHON_MAJOR_VERSION)$(PYTHON_MINOR_VERSION)
+        # pymapd and pyspark are not working on Ibis with Python 3.8
+        # https://github.com/ibis-project/ibis/issues/2091
+        # https://github.com/ibis-project/ibis/issues/2090
+        PYTEST_MARK_EXPRESSION: "not udf and not omniscidb and not spark and not pyspark"
+        BACKENDS: "clickhouse impala kudu-master kudu-tserver mysql parquet postgres sqlite"
 
   steps:
     - bash: |
@@ -40,10 +48,10 @@ jobs:
       displayName: 'Setup BigQuery credentials'
       condition: eq(variables['System.PullRequest.IsFork'], 'False')
 
-    - bash: make start PYTHON_VERSION=$PYTHON_VERSION
+    - bash: make start PYTHON_VERSION=$PYTHON_VERSION BACKENDS="${BACKENDS}"
       displayName: 'Start databases'
 
-    - bash: make wait PYTHON_VERSION=$PYTHON_VERSION
+    - bash: make wait PYTHON_VERSION=$PYTHON_VERSION BACKENDS="${BACKENDS}"
       displayName: 'Wait for databases'
 
     - bash: docker ps
@@ -76,7 +84,7 @@ jobs:
     - bash: make docker_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="conda list --export > /tmp/env/env.yml"
       displayName: 'Capture packages in conda environment'
 
-    - bash: make load PYTHON_VERSION=$PYTHON_VERSION
+    - bash: make load PYTHON_VERSION=$PYTHON_VERSION BACKENDS="${BACKENDS}"
       displayName: 'Load test datasets'
 
     - bash: |

--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -10,6 +10,7 @@ jobs:
 
   variables:
     AZURECI: 1
+    conda.version: "4.6"
 
   strategy:
     matrix:
@@ -19,14 +20,18 @@ jobs:
         python.version: "$(python.major.version).$(python.minor.version)"
         python.no.dot.version: "$(python.major.version)$(python.minor.version)"
         conda.env: "ibis$(python.no.dot.version)"
-        conda.version: "4.6"
       py37:
         python.major.version: "3"
         python.minor.version: "7"
         python.version: "$(python.major.version).$(python.minor.version)"
         python.no.dot.version: "$(python.major.version)$(python.minor.version)"
         conda.env: "ibis$(python.no.dot.version)"
-        conda.version: "4.6"
+      py38:
+        python.major.version: "3"
+        python.minor.version: "8"
+        python.version: "$(python.major.version).$(python.minor.version)"
+        python.no.dot.version: "$(python.major.version)$(python.minor.version)"
+        conda.env: "ibis$(python.no.dot.version)"
 
   steps:
     - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/ci/requirements-3.8-dev.yml
+++ b/ci/requirements-3.8-dev.yml
@@ -1,0 +1,61 @@
+channels:
+  - conda-forge
+dependencies:
+  - black=19.10b0
+  - click
+  - clickhouse-cityhash
+  - clickhouse-driver>=0.1.3
+  - clickhouse-sqlalchemy
+  - cmake
+  - flake8
+  - geoalchemy2
+  - geopandas
+  - google-cloud-bigquery>=1.0.0
+  - graphviz
+  - impyla>=0.15.0
+  - jinja2
+  - libiconv  # see https://github.com/jupyter/repo2docker/issues/758
+  - lz4
+  - multipledispatch>=0.6.0
+  - mypy
+  - numpy>=1.15
+  - openjdk=8
+  - pandas>=0.25.3
+  - pip=19.3.1
+  - plumbum
+  - pre-commit
+  - psycopg2
+  - pyarrow>=0.13
+  - pydata-google-auth
+  - pydocstyle=4.0.1
+  - pygit2
+  # currently it introduces incompatible packages
+  # maybe it is related to the pinned arrow used
+  # - pymapd>=0.12
+  - pymysql
+  # not fully compatible with Python 3.8
+  # https://github.com/apache/spark/pull/26194#issuecomment-566592265
+  # - pyspark>=3.0
+  - pytables>=3.0.0
+  - pytest>=4.5
+  - pytest-cov
+  - pytest-xdist
+  - python=3.8
+  - python-graphviz
+  - python-hdfs>=2.0.16
+  - pytz
+  - regex
+  - requests
+  - rtree
+  - ruamel.yaml
+  - shapely
+  - sqlalchemy>=1.1
+  - thrift>=0.9.3
+  - thriftpy2  # required for impyla in case of py3
+  - toolz
+  - xorg-libxpm
+  - xorg-libxrender
+  - pip:
+    # see .pre-commit-config.yaml, isort pinned
+    - seed-isort-config
+    - git+git://github.com/timothycrosley/isort@18ad293fc9d1852776afe35015a932b68d26fb14#egg=isort

--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -8,12 +8,15 @@ Release Notes
    notes for pre-1.0 versions of ibis can be found at :doc:`/release-pre-1.0`
 
 * :bug:`2089` Pin "clickhouse-driver" to ">=0.1.3"
+* :release:`1.3.0 <pending>`
 * :support:`2077` Change omniscidb image tag from v5.0.0 to v5.1.0 on docker-compose recipe
 * :feature:`2071` Improve many arguments UDF performance in pandas backend.
 * :support:`2075` Disable Postgres tests on Windows CI.
 * :feature:`2048` Introduce a top level vectorized UDF module (experimental). Implement element-wise UDF for pandas and PySpark backend.
-* :release:`1.2.1 <pending>`
 * :bug:`2069` Fix load data stage for Linux CI
+* :support:`2066` SUPP: Add support to Python 3.8
+* :support:`2075` Disable Postgres tests on Windows CI.
+* :feature:`2048` Introduce a top level vectorized UDF module (experimental). Implement element-wise UDF for pandas and PySpark backend.
 * :bug:`2057` Fix datamgr.py fail if IBIS_TEST_OMNISCIDB_DATABASE=omnisci
 * :bug:`2061` CI: Fix CI builds related to new pandas 1.0 compatibility
 * :feature:`1976` Add DenseRank, RowNumber, MinRank, Count, PercentRank/CumeDist window operations to OmniSciDB

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -71,7 +71,7 @@ def hdfs_connect(
     auth_mechanism='NOSASL',
     verify=True,
     session=None,
-    **kwds
+    **kwds,
 ):
     """Connect to HDFS.
 

--- a/ibis/bigquery/udf/api.py
+++ b/ibis/bigquery/udf/api.py
@@ -67,7 +67,7 @@ def udf(input_type, output_type, strict=True, libraries=None):
     Examples
     --------
     >>> if PY38:
-    ...     import pytest; pytest.xfail(reason='Issue #2085')
+    ...     import pytest; pytest.skip("Issue #2085")
     >>> from ibis.bigquery import udf
     >>> import ibis.expr.datatypes as dt
     >>> @udf(input_type=[dt.double], output_type=dt.double)

--- a/ibis/bigquery/udf/api.py
+++ b/ibis/bigquery/udf/api.py
@@ -8,10 +8,10 @@ import ibis.expr.rules as rlz
 from ibis.bigquery.compiler import BigQueryUDFNode, compiles
 from ibis.bigquery.datatypes import UDFContext, ibis_type_to_bigquery_type
 from ibis.bigquery.udf.core import PythonToJavaScriptTranslator
+from ibis.compat import PY38  # noqa: F401
 from ibis.expr.signature import Argument as Arg
 
 __all__ = ('udf',)
-
 
 _udf_name_cache = collections.defaultdict(itertools.count)
 
@@ -58,12 +58,16 @@ def udf(input_type, output_type, strict=True, libraries=None):
 
     Notes
     -----
-    ``INT64`` is not supported as an argument type or a return type, as per
-    `the BigQuery documentation
-    <https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#sql-type-encodings-in-javascript>`_.
+    - ``INT64`` is not supported as an argument type or a return type, as per
+      `the BigQuery documentation
+      <https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#sql-type-encodings-in-javascript>`_.
+    - `The follow example doctest doesn't work for Python 3.8
+      <https://github.com/ibis-project/ibis/issues/2085>`_.
 
     Examples
     --------
+    >>> if PY38:
+    ...     import pytest; pytest.xfail(reason='Issue #2085')
     >>> from ibis.bigquery import udf
     >>> import ibis.expr.datatypes as dt
     >>> @udf(input_type=[dt.double], output_type=dt.double)

--- a/ibis/bigquery/udf/tests/test_core.py
+++ b/ibis/bigquery/udf/tests/test_core.py
@@ -5,8 +5,14 @@ import tempfile
 import pytest
 
 from ibis.bigquery.udf.core import PythonToJavaScriptTranslator, SymbolTable
+from ibis.compat import PY38
 
-pytestmark = pytest.mark.bigquery
+if PY38:
+    # ref: https://github.com/ibis-project/ibis/issues/2098
+    # note: UDF is already skipt on CI
+    pytestmark = [pytest.mark.bigquery, pytest.mark.udf]
+else:
+    pytestmark = pytest.mark.bigquery
 
 
 def test_symbol_table():

--- a/ibis/bigquery/udf/tests/test_find.py
+++ b/ibis/bigquery/udf/tests/test_find.py
@@ -3,9 +3,15 @@ import ast
 import pytest
 
 from ibis.bigquery.udf.find import find_names
+from ibis.compat import PY38
 from ibis.util import is_iterable
 
-pytestmark = pytest.mark.bigquery
+if PY38:
+    # ref: https://github.com/ibis-project/ibis/issues/2098
+    # note: UDF is already skipt on CI
+    pytestmark = [pytest.mark.bigquery, pytest.mark.udf]
+else:
+    pytestmark = pytest.mark.bigquery
 
 
 def parse_expr(expr):

--- a/ibis/bigquery/udf/tests/test_udf_execute.py
+++ b/ibis/bigquery/udf/tests/test_udf_execute.py
@@ -8,10 +8,16 @@ from pytest import param
 import ibis
 import ibis.expr.datatypes as dt
 from ibis.bigquery import udf  # noqa: E402
+from ibis.compat import PY38
 
 pytest.importorskip('google.cloud.bigquery')
 
-pytestmark = pytest.mark.bigquery
+if PY38:
+    # ref: https://github.com/ibis-project/ibis/issues/2098
+    # note: UDF is already skipt on CI
+    pytestmark = [pytest.mark.bigquery, pytest.mark.udf]
+else:
+    pytestmark = pytest.mark.bigquery
 
 
 PROJECT_ID = os.environ.get('GOOGLE_BIGQUERY_PROJECT_ID', 'ibis-gbq')

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -1,5 +1,6 @@
 """Module for compatible functions."""
 import operator
+import sys
 
 import toolz
 
@@ -24,3 +25,5 @@ except ImportError:
 
 
 to_date = toolz.compose(operator.methodcaller('date'), to_datetime)
+
+PY38 = sys.version_info >= (3, 8, 0)

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -1805,7 +1805,7 @@ def can_cast_string_to_temporal(
     source: String,
     target: Union[Date, Time, Timestamp],
     value: Optional[str] = None,
-    **kwargs
+    **kwargs,
 ) -> bool:
     if value is None:
         return False

--- a/ibis/filesystems.py
+++ b/ibis/filesystems.py
@@ -169,7 +169,7 @@ class HDFS:
         resource,
         overwrite: bool = False,
         verbose: bool = None,
-        **kwargs
+        **kwargs,
     ) -> str:
         """
         Write file or directory to HDFS.
@@ -587,7 +587,7 @@ class WebHDFS(HDFS):
         resource,
         overwrite: bool = False,
         verbose: bool = None,
-        **kwargs
+        **kwargs,
     ):
         """
         Write file or directory to HDFS.
@@ -629,7 +629,7 @@ class WebHDFS(HDFS):
         local_path: str,
         overwrite: bool = False,
         verbose: bool = None,
-        **kwargs
+        **kwargs,
     ) -> str:
         """
         Download remote file or directory to the local filesystem.

--- a/ibis/impala/ddl.py
+++ b/ibis/impala/ddl.py
@@ -226,7 +226,7 @@ class CreateTableParquet(CreateTable):
         example_table=None,
         schema=None,
         external=True,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             table_name,
@@ -361,7 +361,7 @@ class CreateTableDelimited(CreateTableWithSchema):
         lineterminator=None,
         na_rep=None,
         external=True,
-        **kwargs
+        **kwargs,
     ):
         table_format = DelimitedFormat(
             path,

--- a/ibis/impala/kudu_support.py
+++ b/ibis/impala/kudu_support.py
@@ -238,7 +238,7 @@ class CreateTableKudu(ddl.CreateTable):
         schema,
         key_columns,
         external=True,
-        **kwargs
+        **kwargs,
     ):
         self.kudu_table_name = kudu_table_name
         self.master_addrs = master_addrs

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -322,7 +322,7 @@ def _window_agg_built_in(
     function: str,
     max_lookback: int,
     *args: Tuple[Any],
-    **kwargs: Dict[str, Any]
+    **kwargs: Dict[str, Any],
 ) -> pd.Series:
     """Apply window aggregation with built-in aggregators.
     """
@@ -354,7 +354,7 @@ def _window_agg_udf(
     dtype: np.dtype,
     max_lookback: int,
     *args: Tuple[Any],
-    **kwargs: Dict[str, Any]
+    **kwargs: Dict[str, Any],
 ) -> pd.Series:
     """Apply window aggregation with UDFs.
 
@@ -435,7 +435,7 @@ class Window(AggregationContext):
         grouped_data: Union[pd.Series, SeriesGroupBy],
         function: Union[str, Callable],
         *args: Tuple[Any],
-        **kwargs: Dict[str, Any]
+        **kwargs: Dict[str, Any],
     ) -> pd.Series:
         # avoid a pandas warning about numpy arrays being passed through
         # directly

--- a/ibis/spark/client.py
+++ b/ibis/spark/client.py
@@ -519,7 +519,7 @@ class SparkClient(SQLClient):
         force=False,
         temp_view=False,
         format='parquet',
-        **kwargs
+        **kwargs,
     ):
         options = _read_csv_defaults.copy()
         options.update(kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
 line-length = 79
 skip-string-normalization = true
-target-version = ["py35", "py36", "py37"]
+target-version = ["py36", "py37", "py38"]
 exclude = "(ibis/_version|versioneer)\\.py"


### PR DESCRIPTION
Resolves #2036 

this PR: 

- adds support to Python 3.8 without pyspark and pymapd*
- adds a udf pytest mark for bigquery.udf tests
- improves ci/azure/linux variables
- skip a doctest check on ibis.bigquery.udf for Python 3.8

`* package conflicts:`
- it needs pyspark v3 https://github.com/apache/spark/pull/26194#issuecomment-566592265
- it needs omniscidb/pymapd with pyarrow=0.15 support