### PR TITLE
FEAT: Improve pandas udf performance for many arguments

### DIFF
--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -7,6 +7,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`/release-pre-1.0`
 
+* :feature:`2071` Improve many arguments UDF performance in pandas backend.
 * :support:`2075` Disable Postgres tests on Windows CI.
 * :feature:`2048` Introduce a top level vectorized UDF module (experimental). Implement element-wise UDF for pandas and PySpark backend.
 * :release:`1.2.1 <pending>`

--- a/ibis/pandas/execution/tests/test_functions.py
+++ b/ibis/pandas/execution/tests/test_functions.py
@@ -259,27 +259,8 @@ def test_ifelse_returning_bool():
 @pytest.mark.parametrize(
     ('dtype', 'value'),
     [
-        pytest.param(
-            dt.float64,
-            1,
-            marks=pytest.mark.xfail(
-                raises=NotImplementedError,
-                reason="Implicit casting for UDFs is not yet implemented",
-            ),
-            id='float_int',
-        ),
-        pytest.param(
-            dt.float64,
-            True,
-            marks=pytest.mark.xfail(
-                raises=NotImplementedError,
-                reason=(
-                    "Implicit casting from boolean to float is not "
-                    "implemented"
-                ),
-            ),
-            id='float_bool',
-        ),
+        pytest.param(dt.float64, 1, id='float_int'),
+        pytest.param(dt.float64, True, id='float_bool'),
         pytest.param(dt.int64, 1.0, id='int_float'),
         pytest.param(dt.int64, True, id='int_bool'),
         pytest.param(dt.boolean, 1.0, id='bool_float'),

--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -31,6 +31,7 @@ def df2():
             + np.random.rand(3).tolist(),
             'b': np.arange(4, dtype=float).tolist()
             + np.random.rand(3).tolist(),
+            'c': np.arange(7, dtype=int).tolist(),
             'key': list('ddeefff'),
         }
     )
@@ -418,4 +419,43 @@ def test_array_return_type_reduction_window(con, t, df, qs):
     result = expr.execute()
     expected_raw = df.b.quantile(qs).tolist()
     expected = pd.Series([expected_raw] * len(df))
+    tm.assert_series_equal(result, expected)
+
+
+def test_elementwise_udf_with_many_args(t2):
+    @udf.elementwise(
+        input_type=[dt.double] * 16 + [dt.int32] * 8, output_type=dt.double
+    )
+    def my_udf(
+        c1,
+        c2,
+        c3,
+        c4,
+        c5,
+        c6,
+        c7,
+        c8,
+        c9,
+        c10,
+        c11,
+        c12,
+        c13,
+        c14,
+        c15,
+        c16,
+        c17,
+        c18,
+        c19,
+        c20,
+        c21,
+        c22,
+        c23,
+        c24,
+    ):
+        return c1
+
+    expr = my_udf(*([t2.a] * 8 + [t2.b] * 8 + [t2.c] * 8))
+    result = expr.execute()
+    expected = t2.a.execute()
+
     tm.assert_series_equal(result, expected)

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -21,7 +21,6 @@ import ibis.expr.operations as ops
 import ibis.expr.signature as sig
 import ibis.udf.vectorized
 from ibis.pandas.aggcontext import Window
-from ibis.pandas.client import PandasClient
 from ibis.pandas.core import (
     date_types,
     time_types,
@@ -529,10 +528,8 @@ class udf:
 
 
 @pre_execute.register(ops.ElementWiseVectorizedUDF)
-@pre_execute.register(ops.ElementWiseVectorizedUDF, PandasClient)
-def pre_execute_elementwise_udf(
-    op, *clients, scope=None, aggcontet=None, **kwargs
-):
+@pre_execute.register(ops.ElementWiseVectorizedUDF, ibis.client.Client)
+def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
     """Register execution rules for elementwise UDFs.
     """
     input_type = op.input_type


### PR DESCRIPTION
Problem
--------

The existing pandas udf implementation suffers from huge performance problem when the udf takes many arguments. 

The problem is that, the existing implementation tries to register execution rules for every possible combination of argument types, resulting in an exponential growth execution rules (exponential to the number of udf arguments)

For an example, if a udf takes n arguments, it will ended register O(4^n) rules because each argument can take >4 different types, e.g., for floating numbers, (float, np.floating, pd.Series, pd.SeriesGroupBy) and the existing implementation tries to register the Cartesian product of those.

Proposed Solution
------------------
In this PR, the number of rules registered for a given number of arguments is reduced to 3. I.e., for a 10 argument UDF, only 3 rules will be registered. 
* (pd.SeriesGroupBy, pd.SeriesGroupBy, ..., pd.SeriesGroupBy)
* (pd.Series, pd.Series, ..., pd.Series) 
* (object, object, ..., object)

The last rule (object, object, ..., object) is a "catch all" rule to handle scalar inputs.

Additional Changes
--------------------
In this PR, I also take the chance to simplify pandas/core.py. This is because I found a bug in the existing implementation where pre_execute is not called for all nodes. 

Microbenchmark
-----------------
```
import numpy as np
import pandas as pd
import ibis
import ibis.expr.datatypes as dt
from ibis.pandas.udf import udf
import time

df = pd.DataFrame(
    {
        'a': np.arange(4, dtype=float).tolist()
        + np.random.rand(3).tolist(),
        'b': np.arange(4, dtype=float).tolist()
        + np.random.rand(3).tolist(),
        'c': np.arange(7, dtype=int).tolist(),
        'key': list('ddeefff'),
    }
)

client = ibis.pandas.connect({'table': df})

t2 = client.table('table')

@udf.elementwise(input_type=[dt.double] * 6, output_type=dt.double)
def my_udf(
    c1,
    c2,
    c3,
    c4,
    c5,
    c6
):
    return c1

expr = my_udf(*([t2.a] * 6))

start = time.time()
result = expr.execute()

print("Elapsed time:", time.time() - start)
```

Before the PR:
```
Elapsed time: 0.1456921100616455
```

After the PR:
```
Elapsed time: 0.0021181106567382812
```