### PR TITLE
Unpin rtree version

### DIFF
--- a/ci/requirements-3.6-dev.yml
+++ b/ci/requirements-3.6-dev.yml
@@ -43,7 +43,7 @@ dependencies:
   - pytz
   - regex
   - requests
-  - rtree<0.9
+  - rtree
   - ruamel.yaml
   - shapely
   - sqlalchemy>=1.1

--- a/ci/requirements-3.7-dev.yml
+++ b/ci/requirements-3.7-dev.yml
@@ -43,7 +43,7 @@ dependencies:
   - pytz
   - regex
   - requests
-  - rtree<0.9
+  - rtree
   - ruamel.yaml
   - shapely
   - sqlalchemy>=1.1


### PR DESCRIPTION
This is introduced in #2043 to get around the bug in rtree 0.9. Now I think this is no longer needed.