### PR TITLE
TST: Use user-defined port variables for Omnisci and PostgreSQL tests

### DIFF
--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -389,7 +389,11 @@ class OmniSciDB(Backend):
             'IBIS_TEST_OMNISCIDB_DATABASE', 'ibis_testing'
         )
         return ibis.omniscidb.connect(
-            host=host, port = port, user=user, password=password, database=database
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
         )
 
     @property

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -336,12 +336,19 @@ class PostgreSQL(Backend, RoundHalfToEven):
         host = os.environ.get(
             'IBIS_TEST_POSTGRES_HOST', os.environ.get('PGHOST', 'localhost')
         )
+        port = os.environ.get(
+            'IBIS_TEST_POSTGRES_PORT', os.environ.get('PGPORT', '5432')
+        )
         database = os.environ.get(
             'IBIS_TEST_POSTGRES_DATABASE',
             os.environ.get('PGDATABASE', 'ibis_testing'),
         )
         return ibis.postgres.connect(
-            host=host, user=user, password=password, database=database
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
         )
 
     @property

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -384,11 +384,12 @@ class OmniSciDB(Backend):
             'IBIS_TEST_OMNISCIDB_PASSWORD', 'HyperInteractive'
         )
         host = os.environ.get('IBIS_TEST_OMNISCIDB_HOST', 'localhost')
+        port = os.environ.get('IBIS_TEST_OMNISCIDB_PORT', '6274')
         database = os.environ.get(
             'IBIS_TEST_OMNISCIDB_DATABASE', 'ibis_testing'
         )
         return ibis.omniscidb.connect(
-            host=host, user=user, password=password, database=database
+            host=host, port = port, user=user, password=password, database=database
         )
 
     @property


### PR DESCRIPTION
Make the user the possibility to define the connection port to the database, so check IBIS_TEST_OMNISCIDB_PORT env variable.