### PR TITLE
TST: OmniSciDB - Enable logical value tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ Ibis currently provides tools for interacting with the following systems:
 - [Spark](https://spark.apache.org) (Experimental)
 
 Learn more about using the library at http://docs.ibis-project.org.
+
+
+## Notes
+
+- OmniSciDB backend support is tested against a development release
+of their database using the ``omnisci/core-os-cpu-dev`` Docker image.
+Check the docker image tag used at
+[docker-compose.yml](https://github.com/ibis-project/ibis/blob/master/ci/docker-compose.yml).
+Some features may not work on earlier releases.

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       KUDU_MASTER: "false"
 
   omniscidb:
-    image: omnisci/core-os-cpu:v5.1.0
+    image: omnisci/core-os-cpu-dev:d7e34d4
     hostname: omniscidb
 
     ports:

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -216,6 +216,10 @@ Create a client by passing in database connection parameters such as ``host``,
        password='HyperInteractive',
    )
 
+Note: OmniSciDB backend support is tested against the latest development
+release of their database using the ``omnisci/core-os-cpu-dev:latest``
+Docker image. Some features may not work on earlier releases.
+
 .. _install.mysql:
 
 `MySQL <https://www.mysql.com/>`_ Quickstart

--- a/ibis/tests/all/test_aggregation.py
+++ b/ibis/tests/all/test_aggregation.py
@@ -5,7 +5,6 @@ from pytest import param
 from ibis.tests.backends import (
     Clickhouse,
     MySQL,
-    OmniSciDB,
     PostgreSQL,
     PySpark,
     SQLite,
@@ -19,8 +18,6 @@ from ibis.tests.backends import (
             lambda t, where: t.bool_col.count(where=where),
             lambda t, where: len(t.bool_col[where].dropna()),
             id='count',
-            # OmniSciDB issue #375
-            marks=pytest.mark.skip_backends((OmniSciDB,)),
         ),
         param(
             lambda t, where: t.bool_col.any(),

--- a/ibis/tests/all/test_aggregation.py
+++ b/ibis/tests/all/test_aggregation.py
@@ -2,13 +2,7 @@ import numpy as np
 import pytest
 from pytest import param
 
-from ibis.tests.backends import (
-    Clickhouse,
-    MySQL,
-    PostgreSQL,
-    PySpark,
-    SQLite,
-)
+from ibis.tests.backends import Clickhouse, MySQL, PostgreSQL, PySpark, SQLite
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/all/test_generic.py
+++ b/ibis/tests/all/test_generic.py
@@ -8,7 +8,6 @@ from ibis.tests.backends import (
     BigQuery,
     Clickhouse,
     MySQL,
-    OmniSciDB,
     PostgreSQL,
     PySpark,
     Spark,
@@ -53,7 +52,6 @@ def test_fillna_nullif(backend, con, expr, expected):
     ],
 )
 @pytest.mark.xfail_unsupported
-@pytest.mark.skip_backends((OmniSciDB,))  # OmniSciDB issue #375
 def test_coalesce(backend, con, expr, expected):
     result = con.execute(expr)
 

--- a/ibis/tests/all/test_numeric.py
+++ b/ibis/tests/all/test_numeric.py
@@ -10,7 +10,7 @@ from pytest import param
 import ibis
 from ibis import literal as L
 from ibis.expr import datatypes as dt
-from ibis.tests.backends import MySQL, OmniSciDB, PostgreSQL
+from ibis.tests.backends import MySQL, PostgreSQL
 from ibis.tests.util import assert_equal
 
 try:
@@ -118,7 +118,6 @@ def test_isnan_isinf(
         param(L(11) % 3, 11 % 3, id='mod'),
     ],
 )
-@pytest.mark.skip_backends([OmniSciDB])
 @pytest.mark.xfail_unsupported
 def test_math_functions_literals(backend, con, alltypes, df, expr, expected):
     result = con.execute(expr)

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -14,7 +14,6 @@ from ibis.tests.backends import (
     Clickhouse,
     Csv,
     Impala,
-    OmniSciDB,
     Pandas,
     Parquet,
     PostgreSQL,
@@ -68,7 +67,6 @@ def test_timestamp_extract(backend, alltypes, df, attr):
     ],
 )
 @pytest.mark.xfail_unsupported
-@pytest.mark.skip_backends([OmniSciDB])
 def test_timestamp_truncate(backend, alltypes, df, unit):
     expr = alltypes.timestamp_col.truncate(unit)
 
@@ -124,7 +122,7 @@ def test_date_truncate(backend, alltypes, df, unit):
         param(
             'us',
             pd.Timedelta,
-            marks=pytest.mark.xfail_backends((Clickhouse, OmniSciDB, SQLite)),
+            marks=pytest.mark.xfail_backends((Clickhouse, SQLite)),
         ),
     ],
 )
@@ -414,7 +412,6 @@ def test_day_of_week_column_group_by(
 
 
 @pytest.mark.xfail_unsupported
-@pytest.mark.skip_backends([OmniSciDB])
 def test_now(backend, con):
     expr = ibis.now()
     result = con.execute(expr)
@@ -427,7 +424,6 @@ def test_now(backend, con):
 
 
 @pytest.mark.xfail_unsupported
-@pytest.mark.skip_backends([OmniSciDB])
 def test_now_from_projection(backend, con, alltypes, df):
     n = 5
     expr = alltypes[[ibis.now().name('ts')]].limit(n)


### PR DESCRIPTION
Enable tests that use queries without table and another tests that are already working on OmniSciDB

* it depends on OmniSciDB v5.2