### PR TITLE
OmnisciDB doesn't support hash()

### DIFF
--- a/ibis/omniscidb/operations.py
+++ b/ibis/omniscidb/operations.py
@@ -966,6 +966,7 @@ _unsupported_ops = [
     ops.IsInf,
     ops.IsNan,
     ops.IfNull,
+    ops.Hash,
     # string
     ops.Lowercase,
     ops.Uppercase,


### PR DESCRIPTION
ops.Hash was added to _unsupported_ops