### PR TITLE
Update minimum Python version in getting started page

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -10,7 +10,7 @@ Installation
 System Dependencies
 ~~~~~~~~~~~~~~~~~~~
 
-Ibis requires a working Python 2.7 or 3.5+ installation. We recommend using
+Ibis requires a working Python 3.6+ installation. We recommend using
 `Anaconda <http://continuum.io/downloads>`_ to manage Python versions and
 environments.
 


### PR DESCRIPTION
In the release notes I see that Python 3.5 support has been dropped, so I guess 3.6 is the minimum required...