### PR TITLE
BUG: Fix PySpark error when doing alias after selection

### DIFF
--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -7,6 +7,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`/release-pre-1.0`
 
+* :bug:`2127` Fix PySpark error when doing alias after selection
 * :feature:`2126` Add translation rules for isnull() and notnull() for pyspark backend
 * :feature:`2062` Implement read_csv for omniscidb backend
 * :feature:`2097` Date, DateDiff and TimestampDiff implementations for OmniSciDB

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -208,7 +208,7 @@ def test_string_to_timestamp_tz_error(client):
 
 
 def test_alias_after_select(client):
-    # Issue 2136
+    # Regression test for issue 2136
     table = client.table('basic_table')
     table = table[['id']]
     table = table.mutate(id2=table['id'])

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -205,3 +205,12 @@ def test_string_to_timestamp_tz_error(client):
         table.mutate(
             date=table.date_str.to_timestamp('yyyy-MM-dd', 'non-utc-timezone')
         ).compile()
+
+
+def test_alias_after_select(client):
+    table = client.table('basic_table')
+    table = table[['id']]
+    table = table.mutate(id2=table['id'])
+
+    result = table.compile().toPandas()
+    tm.assert_series_equal(result['id'], result['id2'], check_names=False)

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -208,6 +208,7 @@ def test_string_to_timestamp_tz_error(client):
 
 
 def test_alias_after_select(client):
+    # Issue 2136
     table = client.table('basic_table')
     table = table[['id']]
     table = table.mutate(id2=table['id'])


### PR DESCRIPTION
This PR fixes the bug where PySpark backend is enable to handle this express correctly:

```
table = ...
table = table[[col]]
table = table.mutate(col2=table[col])
```