### PR TITLE
BUG: [OmniSciDB] Fix TopK when used as filter

### DIFF
--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -10,6 +10,7 @@ Release Notes
 * :feature:`2060` Add initial support for ibis.random function
 * :support:`2096` Added round() support for OmniSciDB
 * :support:`2113` Enabled cumulative ops support for OmniSciDB
+* :bug:`2134` [OmniSciDB] Fix TopK when used as filter
 * :release:`1.3.0 <2020-02-27>`
 * :support:`2066` Add support to Python 3.8
 * :bug:`2089 major` Pin "clickhouse-driver" to ">=0.1.3"

--- a/ibis/file/parquet.py
+++ b/ibis/file/parquet.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pyarrow as pa
 import pyarrow.parquet as pq
 import regex as re
@@ -6,6 +8,7 @@ from pkg_resources import parse_version
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
+import ibis.expr.types as ir
 from ibis.file.client import FileClient
 from ibis.pandas.api import PandasDialect
 from ibis.pandas.core import execute, execute_node
@@ -75,7 +78,7 @@ class ParquetClient(FileClient):
         table = pa.Table.from_pandas(df)
         pq.write_table(table, str(path))
 
-    def table(self, name, path):
+    def table(self, name: str, path: Optional[str] = None) -> ir.TableExpr:
         if name not in self.list_tables(path):
             raise AttributeError(name)
 

--- a/ibis/omniscidb/compiler.py
+++ b/ibis/omniscidb/compiler.py
@@ -180,6 +180,7 @@ class OmniSciDBTableSetFormatter(compiles.TableSetFormatter):
     _join_names = {
         ops.InnerJoin: 'JOIN',
         ops.LeftJoin: 'LEFT JOIN',
+        ops.LeftSemiJoin: 'JOIN',  # needed by topk as filter
         ops.CrossJoin: 'JOIN',
     }
 


### PR DESCRIPTION
Resolve #1918 . Additionally fix #2129 