### PR TITLE
FEAT: Add Pandas and OmniSciDB NTile operation support

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -165,6 +165,7 @@ Column methods
    ColumnExpr.lead
    ColumnExpr.cummin
    ColumnExpr.cummax
+   ColumnExpr.ntile
 
 General numeric methods
 -----------------------

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -66,6 +66,7 @@ Release Notes
 * :feature:`2083` fillna and nullif implementations for OmnisciDB
 * :feature:`1981` Add load_data to sqlalchemy's backends and fix database parameter for load/create/drop when database parameter is the same than the current database
 * :support:`2096` Added round() support for OmniSciDB
+* :feature:`2146` Add Pandas and OmniSciDB NTile operation support and fix PySpark NTile operation
 * :feature:`2125` [OmniSciDB] Add support for within, d_fully_within and point
 * :feature:`2086` OmniSciDB - Refactor DDL and Client; Add temporary parameter to create_table and "force" parameter to drop_view
 * :support:`2113` Enabled cumulative ops support for OmniSciDB

--- a/ibis/backends/omniscidb/operations.py
+++ b/ibis/backends/omniscidb/operations.py
@@ -1098,6 +1098,7 @@ _window_ops = {
     ops.Lag: _shift_like('lag'),
     ops.Lead: _shift_like('lead', 1),
     ops.MinRank: lambda *args: 'rank()',
+    ops.NTile: _window_op_one_param('ntile'),
     # cume_dist vs percent_rank
     # https://github.com/ibis-project/ibis/issues/1975
     ops.PercentRank: lambda *args: 'cume_dist()',
@@ -1115,7 +1116,6 @@ _unsupported_ops = [
     ops.CumulativeAny,
     ops.CumulativeAll,
     ops.IdenticalTo,
-    ops.NTile,
     ops.NthValue,
     ops.GroupConcat,
     ops.IsInf,

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -1174,7 +1174,7 @@ def compile_percent_rank(t, expr, scope, timecontext, **kwargs):
 def compile_ntile(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
     buckets = op.buckets.op().value
-    return F.ntile(buckets)
+    return F.ntile(buckets) - 1
 
 
 @compiles(ops.FirstValue)

--- a/ibis/tests/all/conftest.py
+++ b/ibis/tests/all/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import ibis
 import ibis.common.exceptions as com
 import ibis.util as util
-from ibis.tests.backends import Backend
+from ibis.tests.backends import Backend, Pandas
 
 
 def _random_identifier(suffix):
@@ -213,6 +213,11 @@ def geo_df(geo):
     if geo is not None:
         return geo.execute(limit=None)
     return None
+
+
+@pytest.fixture
+def pandas_testing_client(data_directory):
+    return Pandas.connect(data_directory)
 
 
 _spark_testing_client = None


### PR DESCRIPTION
This PR

- Add Pandas and OmniSciDB NTile operation support.
- Add tests for NTile operation
- Change PySpark NTile to start sequential numbers from zero (added -1)
- Add ntile to api doc

Follow up of PR #1976 