### PR TITLE
FEAT: Add ExtractDayOfYear, ExtractWeekOfYear, ExtractQuarter and ExtractMicrosecond and add support for more extraction date and datetime to PostgreSQL and OmniSciDB

### DIFF
--- a/docs/source/release.rst
+++ b/docs/source/release.rst
@@ -17,6 +17,7 @@ Release Notes
 * :support:`2107` Added fragment_size to table creation for OmniSciDB
 * :feature:`2117` Add non-nullable info to schema output
 * :support:`2096` Added round() support for OmniSciDB
+* :feature:`2149` Add ExtractDayOfYear, ExtractWeekOfYear, ExtractQuarter and ExtractMicrosecond and add support for more extraction date and datetime to PostgreSQL and OmniSciDB
 * :feature:`2125` [OmniSciDB] Add support for within, d_fully_within and point
 * :feature:`2086` OmniSciDB - Refactor DDL and Client; Add temporary parameter to create_table and "force" parameter to drop_view
 * :support:`2113` Enabled cumulative ops support for OmniSciDB

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -3356,10 +3356,15 @@ _timestamp_value_methods = dict(
     year=_extract_field('year', ops.ExtractYear),
     month=_extract_field('month', ops.ExtractMonth),
     day=_extract_field('day', ops.ExtractDay),
+    day_of_week=_day_of_week,
+    day_of_year=_extract_field('day_of_year', ops.ExtractDayOfYear),
+    quarter=_extract_field('quarter', ops.ExtractQuarter),
+    week_of_year=_extract_field('week_of_year', ops.ExtractWeekOfYear),
     hour=_extract_field('hour', ops.ExtractHour),
     minute=_extract_field('minute', ops.ExtractMinute),
     second=_extract_field('second', ops.ExtractSecond),
     millisecond=_extract_field('millisecond', ops.ExtractMillisecond),
+    microsecond=_extract_field('microsecond', ops.ExtractMicrosecond),
     truncate=_timestamp_truncate,
     time=_timestamp_time,
     date=_timestamp_date,
@@ -3371,7 +3376,6 @@ _timestamp_value_methods = dict(
     radd=_timestamp_radd,
     __rsub__=_timestamp_sub,
     rsub=_timestamp_sub,
-    day_of_week=_day_of_week,
 )
 
 _add_methods(ir.TimestampValue, _timestamp_value_methods)
@@ -3421,6 +3425,9 @@ _date_value_methods = dict(
     month=_extract_field('month', ops.ExtractMonth),
     day=_extract_field('day', ops.ExtractDay),
     day_of_week=_day_of_week,
+    day_of_year=_extract_field('day_of_year', ops.ExtractDayOfYear),
+    quarter=_extract_field('quarter', ops.ExtractQuarter),
+    week_of_year=_extract_field('week_of_year', ops.ExtractWeekOfYear),
     truncate=_date_truncate,
     __sub__=_date_sub,
     sub=_date_sub,

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2589,6 +2589,18 @@ class ExtractDay(ExtractDateField):
     pass
 
 
+class ExtractDayOfYear(ExtractDateField):
+    pass
+
+
+class ExtractQuarter(ExtractDateField):
+    pass
+
+
+class ExtractWeekOfYear(ExtractDateField):
+    pass
+
+
 class ExtractHour(ExtractTimeField):
     pass
 
@@ -2602,6 +2614,10 @@ class ExtractSecond(ExtractTimeField):
 
 
 class ExtractMillisecond(ExtractTimeField):
+    pass
+
+
+class ExtractMicrosecond(ExtractTimeField):
     pass
 
 

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -1036,8 +1036,9 @@ class DayOfWeek(Expr):
         Returns
         -------
         IntegerValue
-            The index of the day of the week. Ibis follows pandas conventions,
-            where **Monday = 0 and Sunday = 6**.
+            Use pandas conventions (``ISO 8601`` starting on zero),
+            where week starts on Sunday (0) and ends on
+            Saturday (6).
         """
         import ibis.expr.operations as ops
 

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -1195,8 +1195,9 @@ class OmniSciDBClient(SQLClient):
         database : string, optional
         """
         _database = self.db_name
+        method = kwargs.pop('method', 'rows')
         self.set_database(database)
-        self.con.load_table(table_name, obj, **kwargs)
+        self.con.load_table(table_name, obj, method=method, **kwargs)
         self.set_database(_database)
 
     @property

--- a/ibis/omniscidb/dtypes.py
+++ b/ibis/omniscidb/dtypes.py
@@ -17,6 +17,7 @@ sql_to_ibis_dtypes = {
     'POLYGON': dt.polygon,
     'SMALLINT': dt.int16,
     'STR': dt.string,
+    'TEXT': dt.string,
     'TIME': dt.time,
     'TIMESTAMP': dt.timestamp,
     'TINYINT': dt.int8,
@@ -67,5 +68,5 @@ ibis_dtypes_str_to_sql = {
     'polygon': 'polygon',
     'string': 'text',
     'time': 'time',
-    'timestamp': 'timestamp',
+    'timestamp': 'timestamp(9)',
 }

--- a/ibis/omniscidb/operations.py
+++ b/ibis/omniscidb/operations.py
@@ -274,10 +274,7 @@ def _extract_field(sql_attr):
 
         op = expr.op()
         arg = op.args[0]
-        modify = ''
-        if sql_attr == 'DOW':
-            sql_attr = 'ISODOW'
-            modify = ' - 1'
+        modify = ' -1' if sql_attr == 'ISODOW' else ''
 
         arg_str = translator.translate(arg)
         result = 'EXTRACT({} FROM {}){}'.format(sql_attr, arg_str, modify)
@@ -1104,8 +1101,8 @@ _date_ops = {
     ops.ExtractYear: _extract_field('YEAR'),
     ops.ExtractMonth: _extract_field('MONTH'),
     ops.ExtractDay: _extract_field('DAY'),
-    ops.DayOfWeekIndex: _extract_field('DOW'),
-    ops.DayOfWeekName: _extract_field_dow_name('DOW'),
+    ops.DayOfWeekIndex: _extract_field('ISODOW'),
+    ops.DayOfWeekName: _extract_field_dow_name('ISODOW'),
     ops.ExtractDayOfYear: _extract_field('DOY'),
     ops.ExtractQuarter: _extract_field('QUARTER'),
     ops.ExtractWeekOfYear: _extract_woy,

--- a/ibis/omniscidb/operations.py
+++ b/ibis/omniscidb/operations.py
@@ -303,11 +303,11 @@ def _n_weeks_year(year: ir.NumericValue):
     -------
     Ibis.expr.types.Expr
 
-    See also
+    See Also
     --------
     https://en.wikipedia.org/wiki/ISO_week_date
     """
-
+    # n_weeks_year adjustment
     def _p(year):
         return (year + (year // 4) - (year // 100) + (year // 400)) % 7
 
@@ -331,7 +331,7 @@ def _woy_preliminary(d: Union[ir.DateValue, ir.TimestampValue]) -> ir.Expr:
     -------
     ir.Expr
 
-    See also
+    See Also
     --------
     https://en.wikipedia.org/wiki/ISO_week_date
 

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -223,42 +223,25 @@ def test_explain(con, alltypes):
         pathlib.Path("/omnisci/test_read_csv.csv"),
     ],
 )
-def test_read_csv(con, temp_table, filename):
-    schema = ibis.schema(
-        [
-            ('index', 'int64'),
-            ('Unnamed__0', 'int64'),
-            ('id', 'int32'),
-            ('bool_col', 'bool'),
-            ('tinyint_col', 'int16'),
-            ('smallint_col', 'int16'),
-            ('int_col', 'int32'),
-            ('bigint_col', 'int64'),
-            ('float_col', 'float32'),
-            ('double_col', 'double'),
-            ('date_string_col', 'string'),
-            ('string_col', 'string'),
-            ('timestamp_col', 'timestamp'),
-            ('year_', 'int32'),
-            ('month_', 'int32'),
-        ]
-    )
-    con.create_table(temp_table, schema=schema)
-
+def test_read_csv(con, temp_table, df_alltypes, filename):
     # prepare csv file inside omnisci docker container
     # if the file exists, then it will be overwritten
     con._execute(
         "COPY (SELECT * FROM functional_alltypes) TO '{}'".format(filename)
     )
 
+    # create a empty table based on functional_alltypes
+    con._execute(
+        'CREATE TABLE IF NOT EXISTS {} AS (SELECT * FROM functional_alltypes'
+        ' LIMIT 0)'.format(temp_table)
+    )
+
     db = con.database()
     table = db.table(temp_table)
     table.read_csv(filename, header=False, quotechar='"', delimiter=",")
-
     df_read_csv = table.execute()
-    df_expected = db.table("functional_alltypes").execute()
 
-    pd.testing.assert_frame_equal(df_expected, df_read_csv)
+    pd.testing.assert_frame_equal(df_alltypes, df_read_csv)
 
 
 @pytest.mark.parametrize('ipc', [None, True, False])

--- a/ibis/pandas/execution/temporal.py
+++ b/ibis/pandas/execution/temporal.py
@@ -41,7 +41,10 @@ def execute_extract_millisecond_timestamp(op, data, **kwargs):
 @execute_node.register(ops.ExtractTemporalField, pd.Series)
 def execute_extract_timestamp_field_series(op, data, **kwargs):
     field_name = type(op).__name__.lower().replace('extract', '')
-    return getattr(data.dt, field_name).astype(np.int32)
+    if field_name == 'millisecond':
+        return (data.dt.microsecond // 1000).astype(np.int32)
+    else:
+        return getattr(data.dt, field_name).astype(np.int32)
 
 
 @execute_node.register(

--- a/ibis/sql/mysql/compiler.py
+++ b/ibis/sql/mysql/compiler.py
@@ -55,7 +55,11 @@ def _extract(fmt):
     def translator(t, expr):
         (arg,) = expr.op().args
         sa_arg = t.translate(arg)
-        return sa.extract(fmt, sa_arg)
+        if fmt == 'millisecond':
+            result = sa.extract('microsecond', sa_arg) % 1000
+        else:
+            result = sa.extract(fmt, sa_arg)
+        return result
 
     return translator
 

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -625,16 +625,14 @@ def _random(t, expr):
 
 
 def _day_of_week_index(t, expr):
-    # arg[-1] is "how" parameter
-    sa_arg = t.translate(expr.op().args[0])
+    (sa_arg,) = map(t.translate, expr.op().args)
     return sa.cast(
         sa.cast(sa.extract('dow', sa_arg) + 6, sa.SMALLINT) % 7, sa.SMALLINT
     )
 
 
 def _day_of_week_name(t, expr):
-    # arg[-1] is "how" parameter
-    sa_arg = t.translate(expr.op().args[0])
+    (sa_arg,) = map(t.translate, expr.op().args)
     return sa.func.trim(sa.func.to_char(sa_arg, 'Day'))
 
 

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -23,11 +23,15 @@ from ibis.tests.backends import (
 )
 
 
-@pytest.mark.parametrize('attr', ['year', 'month', 'day'])
+@pytest.mark.parametrize(
+    'attr', ['year', 'month', 'day', 'day_of_year', 'week_of_year', 'quarter']
+)
 @pytest.mark.xfail_unsupported
 def test_date_extract(backend, alltypes, df, attr):
     expr = getattr(alltypes.timestamp_col.date(), attr)()
-    expected = getattr(df.timestamp_col.dt, attr).astype('int32')
+    expected = getattr(df.timestamp_col.dt, attr.replace('_', '')).astype(
+        'int32'
+    )
 
     result = expr.execute()
     expected = backend.default_series_rename(expected)
@@ -36,12 +40,25 @@ def test_date_extract(backend, alltypes, df, attr):
 
 
 @pytest.mark.parametrize(
-    'attr', ['year', 'month', 'day', 'hour', 'minute', 'second']
+    'attr',
+    [
+        'year',
+        'month',
+        'day',
+        'hour',
+        'minute',
+        'second',
+        'millisecond',
+        'microsecond',
+    ],
 )
 @pytest.mark.xfail_unsupported
 def test_timestamp_extract(backend, alltypes, df, attr):
     expr = getattr(alltypes.timestamp_col, attr)()
-    expected = getattr(df.timestamp_col.dt, attr).astype('int32')
+    if attr == 'millisecond':
+        expected = (df.timestamp_col.dt.microsecond // 1000).astype('int32')
+    else:
+        expected = getattr(df.timestamp_col.dt, attr).astype('int32')
 
     result = expr.execute()
     expected = backend.default_series_rename(expected)

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -54,12 +54,14 @@ def test_date_extract(backend, alltypes, df, attr):
 )
 @pytest.mark.xfail_unsupported
 def test_timestamp_extract(backend, alltypes, df, attr):
-    expr = getattr(alltypes.timestamp_col, attr)()
     if attr == 'millisecond':
+        if backend.name == 'sqlite':
+            pytest.xfail(reason=('Issue #2156'))
         expected = (df.timestamp_col.dt.microsecond // 1000).astype('int32')
     else:
         expected = getattr(df.timestamp_col.dt, attr).astype('int32')
 
+    expr = getattr(alltypes.timestamp_col, attr)()
     result = expr.execute()
     expected = backend.default_series_rename(expected)
 

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -57,6 +57,9 @@ def test_timestamp_extract(backend, alltypes, df, attr):
     if attr == 'millisecond':
         if backend.name == 'sqlite':
             pytest.xfail(reason=('Issue #2156'))
+        if backend.name == 'spark':
+            pytest.xfail(reason='Issue #2159')
+
         expected = (df.timestamp_col.dt.microsecond // 1000).astype('int32')
     else:
         expected = getattr(df.timestamp_col.dt, attr).astype('int32')


### PR DESCRIPTION
Resolve partially #1916

this PR proposes:

- add new core extract operations: ExtractDayOfYear, ExtractWeekOfYear, ExtractQuarter and ExtractMicrosecond and their support to OmniSciDB and PostgreSQL
- add support for ops.DayOfWeekIndex, ExtractMillisecond, ops.DayOfWeekName
- change default OmniSciDB timestamp to timestamp(9) (needed by millisecond and microsecond operation)
- Fix millisecond extraction operation for Pandas, MySQL and PostgreSQL
- adding support for ExtractMillisecond on PostgreSQL

As I added more tests to all/tests it raises error for other backends. I tried to fix some of these issues to try to keep the tests more consistent.

I added support for the the new operations initially to OmniSciDB and PostgreSQL, it is very useful to add support at least to 2 backends to compare the results.

I will open an issue to add support for these new operations to the other backends.