### PR TITLE
fix path to temporary test files at 'test_read_csv'

### DIFF
--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -192,11 +192,9 @@ def test_read_csv(con, temp_table, filename, alltypes, df_alltypes):
     db = con.database()
     table = db.table(temp_table)
     table.read_csv(filename, header=False, quotechar='"', delimiter=",")
-
     df_read_csv = table.execute()
-    df_expected = df_alltypes
 
-    pd.testing.assert_frame_equal(df_expected, df_read_csv)
+    pd.testing.assert_frame_equal(df_alltypes, df_read_csv)
 
 
 @pytest.mark.parametrize('ipc', [None, True, False])

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -248,4 +248,3 @@ def test_cpu_execution_type(
 
     for mocked_method in mocked_methods:
         mocked_method.stop()
-

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -248,3 +248,4 @@ def test_cpu_execution_type(
 
     for mocked_method in mocked_methods:
         mocked_method.stop()
+

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -178,8 +178,8 @@ def test_explain(con, alltypes):
 @pytest.mark.parametrize(
     'filename',
     [
-        "/omnisci/test_read_csv.csv",
-        pathlib.Path("/omnisci/test_read_csv.csv"),
+        "/tmp/test_read_csv.csv",
+        pathlib.Path("/tmp/test_read_csv.csv"),
     ],
 )
 def test_read_csv(con, temp_table, filename):

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -177,10 +177,7 @@ def test_explain(con, alltypes):
 
 @pytest.mark.parametrize(
     'filename',
-    [
-        "/tmp/test_read_csv.csv",
-        pathlib.Path("/tmp/test_read_csv.csv"),
-    ],
+    ["/tmp/test_read_csv.csv", pathlib.Path("/tmp/test_read_csv.csv")],
 )
 def test_read_csv(con, temp_table, filename):
     schema = ibis.schema(

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -179,26 +179,8 @@ def test_explain(con, alltypes):
     'filename',
     ["/tmp/test_read_csv.csv", pathlib.Path("/tmp/test_read_csv.csv")],
 )
-def test_read_csv(con, temp_table, filename):
-    schema = ibis.schema(
-        [
-            ('index', 'int64'),
-            ('Unnamed__0', 'int64'),
-            ('id', 'int32'),
-            ('bool_col', 'bool'),
-            ('tinyint_col', 'int16'),
-            ('smallint_col', 'int16'),
-            ('int_col', 'int32'),
-            ('bigint_col', 'int64'),
-            ('float_col', 'float32'),
-            ('double_col', 'double'),
-            ('date_string_col', 'string'),
-            ('string_col', 'string'),
-            ('timestamp_col', 'timestamp'),
-            ('year_', 'int32'),
-            ('month_', 'int32'),
-        ]
-    )
+def test_read_csv(con, temp_table, filename, alltypes):
+    schema = alltypes.schema()
     con.create_table(temp_table, schema=schema)
 
     # prepare csv file inside omnisci docker container
@@ -212,7 +194,7 @@ def test_read_csv(con, temp_table, filename):
     table.read_csv(filename, header=False, quotechar='"', delimiter=",")
 
     df_read_csv = table.execute()
-    df_expected = db.table("functional_alltypes").execute()
+    df_expected = alltypes.execute()
 
     pd.testing.assert_frame_equal(df_expected, df_read_csv)
 

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -179,7 +179,7 @@ def test_explain(con, alltypes):
     'filename',
     ["/tmp/test_read_csv.csv", pathlib.Path("/tmp/test_read_csv.csv")],
 )
-def test_read_csv(con, temp_table, filename, alltypes):
+def test_read_csv(con, temp_table, filename, alltypes, df_alltypes):
     schema = alltypes.schema()
     con.create_table(temp_table, schema=schema)
 
@@ -194,7 +194,7 @@ def test_read_csv(con, temp_table, filename, alltypes):
     table.read_csv(filename, header=False, quotechar='"', delimiter=",")
 
     df_read_csv = table.execute()
-    df_expected = alltypes.execute()
+    df_expected = df_alltypes
 
     pd.testing.assert_frame_equal(df_expected, df_read_csv)
 


### PR DESCRIPTION
'test_read_csv' added at #2062 uses `/omnisci` directory to store test files, however that dir may not exists at some other environments, which causes errors while testing.

Since test files used as temporary, it's rational to store them at `/tmp` dir, which is always exists in Linux environment, unlike `/omnisci`