### PR TITLE
Add initial mypy checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,8 @@ repos:
       - id: flake8
         types:
           - python
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.770'
+    hooks:
+      - id: mypy
+        files: ibis/

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ LOGLEVEL := WARNING
 ## Targets for code checks
 
 typecheck:
-	@mypy --ignore-missing-imports $(MAKEFILE_DIR)/ibis
+	@mypy --config-file $(MAKEFILE_DIR)/typecheck.ini $(MAKEFILE_DIR)/ibis
 
 lint:
 	flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,6 @@ skip = versioneer.py,ibis/_version.py
 [bdist_wheel]
 universal = 0
 
-[mypy-ibis._version]
-ignore_errors = true
-
 [tool:pytest]
 xfail_strict = true
 addopts = --strict-markers
@@ -59,3 +56,63 @@ markers =
     xfail_backends
     xfail_unsupported
     xpass_backends
+
+[mypy]
+ignore_missing_imports = True
+
+[mypy-ibis._version]
+ignore_errors = true
+
+[mypy-ibis.client]
+ignore_errors = true
+
+[mypy-ibis.config]
+ignore_errors = true
+
+[mypy-ibis.filesystems]
+ignore_errors = true
+
+[mypy-ibis.util]
+ignore_errors = true
+
+[mypy-ibis.bigquery.*]
+ignore_errors = True
+
+[mypy-ibis.clickhouse.*]
+ignore_errors = True
+
+[mypy-ibis.common.*]
+ignore_errors = True
+
+[mypy-ibis.expr.*]
+ignore_errors = True
+
+[mypy-ibis.file.*]
+ignore_errors = True
+
+[mypy-ibis.hive.*]
+ignore_errors = True
+
+[mypy-ibis.impala.*]
+ignore_errors = True
+
+[mypy-ibis.omniscidb.*]
+ignore_errors = True
+
+[mypy-ibis.pandas.*]
+ignore_errors = True
+
+[mypy-ibis.pyspark.*]
+ignore_errors = True
+
+[mypy-ibis.spark.*]
+ignore_errors = True
+
+[mypy-ibis.sql.*]
+ignore_errors = True
+
+[mypy-ibis.tests.*]
+ignore_errors = True
+
+[mypy-ibis.udf.*]
+ignore_errors = True

--- a/typecheck.ini
+++ b/typecheck.ini
@@ -1,0 +1,5 @@
+[mypy]
+ignore_missing_imports = True
+
+[mypy-ibis._version]
+ignore_errors = true


### PR DESCRIPTION
This PR is a propose for adding initial support for mypy.

The idea here is discuss if we should add support for mypy and how.  so, for now, I will keep this PR as draft.

This PR:

- Add to setup.cfg initial configuration for mypy and ignore errors for each ibis modules
- Add mypy to pre-commit hooks (pre-commit hooks checks is used inside CI, so mypy will be executed automatically inside CI)

Next steps would be remove the `ignore_errors` gradually and fix the errors pointed.

@jreback any thoughts about this?