### PR TITLE
FEAT: Create ExtractDayOfYear operation and add its support to Clickhouse, CSV, MySQL, OmniSciDB, Pandas, Parquet, PostgreSQL, PySpark, SQLite and Spark

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -30,6 +30,7 @@ Release Notes
 * :feature:`2086` OmniSciDB - Refactor DDL and Client; Add temporary parameter to create_table and "force" parameter to drop_view
 * :support:`2113` Enabled cumulative ops support for OmniSciDB
 * :bug:`2134` [OmniSciDB] Fix TopK when used as filter
+* :feature:`2173` Create ExtractDayOfYear operation and add its support to Clickhouse, CSV, MySQL, OmniSciDB, Pandas, Parquet, PostgreSQL, PySpark, SQLite and Spark
 * :feature:`2095` Implementations of Log Log2 Log10 for OmniSciDB backend
 * :release:`1.3.0 <2020-02-27>`
 * :support:`2066` Add support to Python 3.8

--- a/ibis/clickhouse/operations.py
+++ b/ibis/clickhouse/operations.py
@@ -598,6 +598,7 @@ _operation_registry = {
     ops.ExtractYear: unary('toYear'),
     ops.ExtractMonth: unary('toMonth'),
     ops.ExtractDay: unary('toDayOfMonth'),
+    ops.ExtractDayOfYear: unary('toDayOfYear'),
     ops.ExtractHour: unary('toHour'),
     ops.ExtractMinute: unary('toMinute'),
     ops.ExtractSecond: unary('toSecond'),

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -3356,6 +3356,8 @@ _timestamp_value_methods = dict(
     year=_extract_field('year', ops.ExtractYear),
     month=_extract_field('month', ops.ExtractMonth),
     day=_extract_field('day', ops.ExtractDay),
+    day_of_week=_day_of_week,
+    day_of_year=_extract_field('day_of_year', ops.ExtractDayOfYear),
     hour=_extract_field('hour', ops.ExtractHour),
     minute=_extract_field('minute', ops.ExtractMinute),
     second=_extract_field('second', ops.ExtractSecond),
@@ -3371,7 +3373,6 @@ _timestamp_value_methods = dict(
     radd=_timestamp_radd,
     __rsub__=_timestamp_sub,
     rsub=_timestamp_sub,
-    day_of_week=_day_of_week,
 )
 
 _add_methods(ir.TimestampValue, _timestamp_value_methods)
@@ -3421,6 +3422,7 @@ _date_value_methods = dict(
     month=_extract_field('month', ops.ExtractMonth),
     day=_extract_field('day', ops.ExtractDay),
     day_of_week=_day_of_week,
+    day_of_year=_extract_field('day_of_year', ops.ExtractDayOfYear),
     truncate=_date_truncate,
     __sub__=_date_sub,
     sub=_date_sub,

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2589,6 +2589,10 @@ class ExtractDay(ExtractDateField):
     pass
 
 
+class ExtractDayOfYear(ExtractDateField):
+    pass
+
+
 class ExtractHour(ExtractTimeField):
     pass
 

--- a/ibis/omniscidb/operations.py
+++ b/ibis/omniscidb/operations.py
@@ -1013,6 +1013,7 @@ _date_ops = {
     ops.ExtractYear: _extract_field('YEAR'),
     ops.ExtractMonth: _extract_field('MONTH'),
     ops.ExtractDay: _extract_field('DAY'),
+    ops.ExtractDayOfYear: _extract_field('DOY'),
     ops.ExtractHour: _extract_field('HOUR'),
     ops.ExtractMinute: _extract_field('MINUTE'),
     ops.ExtractSecond: _extract_field('SECOND'),

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -1105,6 +1105,13 @@ def compile_extract_day(t, expr, scope, **kwargs):
     )
 
 
+@compiles(ops.ExtractDayOfYear)
+def compile_extract_day_of_year(t, expr, scope, **kwargs):
+    return _extract_component_from_datetime(
+        t, expr, scope, F.dayofyear, **kwargs
+    )
+
+
 @compiles(ops.ExtractHour)
 def compile_extract_hour(t, expr, scope, **kwargs):
     return _extract_component_from_datetime(t, expr, scope, F.hour, **kwargs)

--- a/ibis/spark/compiler.py
+++ b/ibis/spark/compiler.py
@@ -324,6 +324,7 @@ _operation_registry.update(
         ops.ExtractYear: unary('year'),
         ops.ExtractMonth: unary('month'),
         ops.ExtractDay: unary('day'),
+        ops.ExtractDayOfYear: unary('dayofyear'),
         ops.ExtractHour: unary('hour'),
         ops.ExtractMinute: unary('minute'),
         ops.ExtractSecond: unary('second'),

--- a/ibis/sql/mysql/compiler.py
+++ b/ibis/sql/mysql/compiler.py
@@ -226,6 +226,7 @@ _operation_registry.update(
         ops.ExtractYear: _extract('year'),
         ops.ExtractMonth: _extract('month'),
         ops.ExtractDay: _extract('day'),
+        ops.ExtractDayOfYear: unary('dayofyear'),
         ops.ExtractHour: _extract('hour'),
         ops.ExtractMinute: _extract('minute'),
         ops.ExtractSecond: _extract('second'),

--- a/ibis/sql/postgres/compiler.py
+++ b/ibis/sql/postgres/compiler.py
@@ -677,6 +677,7 @@ _operation_registry.update(
         ops.ExtractYear: _extract('year'),
         ops.ExtractMonth: _extract('month'),
         ops.ExtractDay: _extract('day'),
+        ops.ExtractDayOfYear: _extract('doy'),
         ops.ExtractHour: _extract('hour'),
         ops.ExtractMinute: _extract('minute'),
         ops.ExtractSecond: _second,

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -227,6 +227,7 @@ _operation_registry.update(
         ops.ExtractYear: _strftime_int('%Y'),
         ops.ExtractMonth: _strftime_int('%m'),
         ops.ExtractDay: _strftime_int('%d'),
+        ops.ExtractDayOfYear: _strftime_int('%j'),
         ops.ExtractHour: _strftime_int('%H'),
         ops.ExtractMinute: _strftime_int('%M'),
         ops.ExtractSecond: _strftime_int('%S'),

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -36,7 +36,17 @@ def test_date_extract(backend, alltypes, df, attr):
 
 
 @pytest.mark.parametrize(
-    'attr', ['year', 'month', 'day', 'hour', 'minute', 'second', 'millisecond']
+    'attr',
+    [
+        'year',
+        'month',
+        'day',
+        'day_of_year',
+        'hour',
+        'minute',
+        'second',
+        'millisecond',
+    ],
 )
 @pytest.mark.xfail_unsupported
 def test_timestamp_extract(backend, alltypes, df, attr):
@@ -47,7 +57,9 @@ def test_timestamp_extract(backend, alltypes, df, attr):
             pytest.xfail(reason='Issue #2159')
         expected = (df.timestamp_col.dt.microsecond // 1000).astype('int32')
     else:
-        expected = getattr(df.timestamp_col.dt, attr).astype('int32')
+        expected = getattr(df.timestamp_col.dt, attr.replace('_', '')).astype(
+            'int32'
+        )
 
     expr = getattr(alltypes.timestamp_col, attr)()
 


### PR DESCRIPTION
Create ExtractDayOfYear operation and add its support to Clickhouse, CSV, MySQL, OmniSciDB, Pandas, Parquet, PostgreSQL, PySpark, SQLite and Spark