### PR TITLE
TST: Fix typo in number of backslashes in regexp expression at 'test_string'

### DIFF
--- a/ibis/tests/all/test_string.py
+++ b/ibis/tests/all/test_string.py
@@ -3,7 +3,14 @@ from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.tests.backends import Clickhouse, Impala, PostgreSQL, PySpark, Spark, OmniSciDB
+from ibis.tests.backends import (
+    Clickhouse,
+    Impala,
+    PostgreSQL,
+    PySpark,
+    Spark,
+    OmniSciDB,
+)
 
 
 def test_string_col_is_unicode(backend, alltypes, df):
@@ -60,7 +67,9 @@ def test_string_col_is_unicode(backend, alltypes, df):
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search_spark',
-            marks=pytest.mark.xpass_backends((Clickhouse, Impala, Spark, OmniSciDB)),
+            marks=pytest.mark.xpass_backends(
+                (Clickhouse, Impala, Spark, OmniSciDB)
+            ),
         ),
         param(
             lambda t: t.string_col.re_extract(r'(\d+)', 0),
@@ -78,7 +87,9 @@ def test_string_col_is_unicode(backend, alltypes, df):
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search_spark',
-            marks=pytest.mark.xfail_backends((Clickhouse, Impala, Spark, OmniSciDB)),
+            marks=pytest.mark.xfail_backends(
+                (Clickhouse, Impala, Spark, OmniSciDB)
+            ),
         ),
         param(
             lambda t: t.string_col.re_extract(r'(\d+)', 0),

--- a/ibis/tests/all/test_string.py
+++ b/ibis/tests/all/test_string.py
@@ -3,7 +3,7 @@ from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.tests.backends import Clickhouse, Impala, PostgreSQL, PySpark, Spark
+from ibis.tests.backends import Clickhouse, Impala, PostgreSQL, PySpark, Spark, OmniSciDB
 
 
 def test_string_col_is_unicode(backend, alltypes, df):
@@ -57,19 +57,19 @@ def test_string_col_is_unicode(backend, alltypes, df):
             marks=pytest.mark.xfail_backends((Spark, PySpark)),
         ),
         param(
-            lambda t: t.string_col.re_search(r'\\d+'),
+            lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search_spark',
-            marks=pytest.mark.xpass_backends((Clickhouse, Impala, Spark)),
+            marks=pytest.mark.xpass_backends((Clickhouse, Impala, Spark, OmniSciDB)),
         ),
         param(
-            lambda t: t.string_col.re_extract(r'(\\d+)', 0),
+            lambda t: t.string_col.re_extract(r'(\d+)', 0),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract_spark',
             marks=pytest.mark.xpass_backends((Clickhouse, Impala, Spark)),
         ),
         param(
-            lambda t: t.string_col.re_replace(r'\\d+', 'a'),
+            lambda t: t.string_col.re_replace(r'\d+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a'),
             id='re_replace_spark',
             marks=pytest.mark.xpass_backends((Clickhouse, Impala, Spark)),
@@ -78,7 +78,7 @@ def test_string_col_is_unicode(backend, alltypes, df):
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search_spark',
-            marks=pytest.mark.xfail_backends((Clickhouse, Impala, Spark)),
+            marks=pytest.mark.xfail_backends((Clickhouse, Impala, Spark, OmniSciDB)),
         ),
         param(
             lambda t: t.string_col.re_extract(r'(\d+)', 0),


### PR DESCRIPTION
`\\d+` means string that has `\ddd...dd` as substring,
`\d+` means string that contains decimals.
So it seems there is a typo in the number of backslashes that ruins some test in `test_string`  