### PR TITLE
Fix CondaBuild CI job

### DIFF
--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -176,7 +176,7 @@ jobs:
     - bash: docker images
       displayName: 'List docker images'
 
-    - bash: make docker_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="ci/feedstock.py test"
+    - bash: make docker_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="ci/feedstock.py test --python 3.7"
       displayName: 'Clone, update and build conda-forge recipe'
 
     - task: PublishPipelineArtifact@1

--- a/ci/feedstock.py
+++ b/ci/feedstock.py
@@ -32,6 +32,10 @@ default_repo = 'https://github.com/conda-forge/ibis-framework-feedstock'
 default_dest = os.path.join(tempfile.gettempdir(), 'ibis-framework-feedstock')
 default_branch = 'master'
 
+# needed until ibis-framework-feedstock #41 is merged
+default_repo = 'https://github.com/quansight/ibis-framework-feedstock'
+default_branch = 'fix-build-py38'
+
 
 @cli.command()
 @click.argument('repo-uri', default=default_repo)
@@ -99,7 +103,7 @@ def build(recipe, python):
     click.echo('Building {} recipe...'.format(recipe))
 
     cmd = conda[
-        'build', recipe, '--channel', 'conda-forge', '--python', python
+        'build', '--channel', 'conda-forge', '--python', python, recipe
     ]
 
     cmd(
@@ -131,10 +135,14 @@ def deploy(package_location, artifact_directory, architecture):
 
 @cli.command()
 @click.pass_context
-def test(ctx):
+@click.option(
+    '--python',
+    default='{}.{}'.format(sys.version_info.major, sys.version_info.minor),
+)
+def test(ctx, python):
     ctx.invoke(clone)
     ctx.invoke(update)
-    ctx.invoke(build)
+    ctx.invoke(build, python=python)
     ctx.invoke(deploy)
 
 

--- a/ci/feedstock.py
+++ b/ci/feedstock.py
@@ -32,10 +32,6 @@ default_repo = 'https://github.com/conda-forge/ibis-framework-feedstock'
 default_dest = os.path.join(tempfile.gettempdir(), 'ibis-framework-feedstock')
 default_branch = 'master'
 
-# needed until ibis-framework-feedstock #41 is merged
-default_repo = 'https://github.com/quansight/ibis-framework-feedstock'
-default_branch = 'fix-build-py38'
-
 
 @cli.command()
 @click.argument('repo-uri', default=default_repo)


### PR DESCRIPTION
Currently condabuild ci job is failing because:

- the current conda recipe doesn't work for python 3.8, because pymapd depends on pyarrow <= 0.13 and it has dependency conflict with another packages. also the current pyspark will not work well for python 3.8 (waiting pyspark v3) 
- as conda recipe uses noarch:python, and currently the conda build uses the python 3.8 to build, the build will have a very complex dependency tree to resolve

in this PR:
- I changed the repo and the branch used to get the conda recipe to check if the new recipe will work
- I added the `python` flag to `feedstock.py test` to specify the python version to conda-build 

notes:

- as can be observed, it worked. the time spent is not the desired yet (43m) but as the time limit is 1h, probably it is enough for now.
- would be good to improve more this, maybe in a follow up PR. something that could help to improve this would be: 1) use mamba for building and 2) change the pinning of some packages (in the conda recipe).