### PR TITLE
FEAT: Validate that the output type of a UDF is a single element

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,7 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
-* :bug:`2198` Allow output type of vectorized UDFs to be specified as a single-element list
+* :feature:`2198` Validate that the output type of a UDF is a single element
 * :bug:`2223` Fix PySpark compiler error when elementwise UDF output_type is Decimal or Timestamp
 * :feature:`2186` ZeroIfNull and NullIfZero implementation for OmniSciDB  
 * :bug:`2157` Fix interactive mode returning a expression instead of the value when used in Jupyter

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2198` Allow output type of vectorized UDFs to be specified as a single-element list
 * :bug:`2223` Fix PySpark compiler error when elementwise UDF output_type is Decimal or Timestamp
 * :feature:`2186` ZeroIfNull and NullIfZero implementation for OmniSciDB  
 * :bug:`2157` Fix interactive mode returning a expression instead of the value when used in Jupyter

--- a/ibis/bigquery/udf/api.py
+++ b/ibis/bigquery/udf/api.py
@@ -5,6 +5,7 @@ import itertools
 
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
+import ibis.udf.validate as v
 from ibis.bigquery.compiler import BigQueryUDFNode, compiles
 from ibis.bigquery.datatypes import UDFContext, ibis_type_to_bigquery_type
 from ibis.bigquery.udf.core import PythonToJavaScriptTranslator
@@ -159,6 +160,8 @@ def udf(input_type, output_type, strict=True, libraries=None):
     return my_rectangle(width, height);
     """;
     '''
+    v.validate_output_type(output_type)
+
     if libraries is None:
         libraries = []
 

--- a/ibis/impala/udf.py
+++ b/ibis/impala/udf.py
@@ -19,6 +19,7 @@ import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
 import ibis.expr.signature as sig
 import ibis.impala.compiler as comp
+import ibis.udf.validate as v
 import ibis.util as util
 
 __all__ = [
@@ -121,6 +122,7 @@ class ImpalaUDF(ScalarFunction, ImpalaFunction):
     def __init__(
         self, inputs, output, so_symbol=None, lib_path=None, name=None
     ):
+        v.validate_output_type(output)
         self.so_symbol = so_symbol
         ImpalaFunction.__init__(self, name=name, lib_path=lib_path)
         ScalarFunction.__init__(self, inputs, output, name=self.name)
@@ -154,6 +156,8 @@ class ImpalaUDA(AggregateFunction, ImpalaFunction):
         self.merge_fn = merge_fn
         self.finalize_fn = finalize_fn
         self.serialize_fn = serialize_fn
+
+        v.validate_output_type(output)
 
         ImpalaFunction.__init__(self, name=name, lib_path=lib_path)
         AggregateFunction.__init__(self, inputs, output, name=self.name)

--- a/ibis/spark/udf.py
+++ b/ibis/spark/udf.py
@@ -13,9 +13,9 @@ import pyspark.sql.types as pt
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.signature as sig
+import ibis.udf.validate as v
 from ibis.spark.compiler import SparkUDAFNode, SparkUDFNode, compiles
 from ibis.spark.datatypes import spark_dtype
-from ibis.udf.vectorized import valid_function_signature
 
 _udf_name_cache = collections.defaultdict(itertools.count)
 
@@ -32,9 +32,10 @@ class SparkUDF:
         if not callable(func):
             raise TypeError('func must be callable, got {}'.format(func))
 
-        # validate that the input_type argument and the function signature
-        # match
-        valid_function_signature(self.input_type, func)
+        # Validate that the input_type argument and the function signature
+        # match and that the output_type is valid
+        v.validate_input_type_count(self.input_type, func)
+        v.validate_output_type(self.output_type)
 
         if not self.output_type.nullable:
             raise com.IbisTypeError(

--- a/ibis/spark/udf.py
+++ b/ibis/spark/udf.py
@@ -34,7 +34,7 @@ class SparkUDF:
 
         # Validate that the input_type argument and the function signature
         # match and that the output_type is valid
-        v.validate_input_type_count(self.input_type, func)
+        v.validate_input_type(self.input_type, func)
         v.validate_output_type(self.output_type)
 
         if not self.output_type.nullable:

--- a/ibis/sql/postgres/udf/api.py
+++ b/ibis/sql/postgres/udf/api.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import dialect as sa_postgres_dialect
 
 import ibis.expr.rules as rlz
+import ibis.udf.validate as v
 from ibis import IbisError
 from ibis.expr.signature import Argument as Arg
 from ibis.sql.alchemy import _to_sqla_type
@@ -80,6 +81,7 @@ def existing_udf(name, input_types, output_type, schema=None, parameters=None):
     Callable
         The wrapped function
     """
+
     if parameters is None:
         parameters = ['v{}'.format(i) for i in range(len(input_types))]
     elif len(input_types) != len(parameters):
@@ -89,6 +91,8 @@ def existing_udf(name, input_types, output_type, schema=None, parameters=None):
                 "len(input_types)={}, len(parameters)={}"
             ).format(len(input_types), len(parameters))
         )
+
+    v.validate_output_type(output_type)
 
     udf_node_fields = collections.OrderedDict(
         [

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -21,9 +21,8 @@ def test_elementwise_udf(backend, alltypes, df):
 @pytest.mark.xfail_unsupported
 def test_output_type_in_list(backend, alltypes, df):
     """
-    Test that a UDF's output type can be specified as a single datatype
-    wrapped in a list. This is equivalent to a single datatype that is not in a
-    list.
+    Test that a UDF's output type can be specified as a single datatype wrapped
+    in a list. This is equivalent to a single datatype that is not in a list.
     """
 
     @elementwise(input_type=[dt.double], output_type=[dt.double])

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -19,23 +19,6 @@ def test_elementwise_udf(backend, alltypes, df):
 
 @pytest.mark.only_on_backends([Pandas, PySpark])
 @pytest.mark.xfail_unsupported
-def test_output_type_in_list(backend, alltypes, df):
-    """
-    Test that a UDF's output type can be specified as a single datatype wrapped
-    in a list. This is equivalent to a single datatype that is not in a list.
-    """
-
-    @elementwise(input_type=[dt.double], output_type=[dt.double])
-    def add_one(s):
-        return s + 1
-
-    result = add_one(alltypes['double_col']).execute()
-    expected = add_one.func(df['double_col'])
-    backend.assert_series_equal(result, expected, check_names=False)
-
-
-@pytest.mark.only_on_backends([Pandas, PySpark])
-@pytest.mark.xfail_unsupported
 def test_valid_kwargs(backend, alltypes, df):
     # Test different forms of UDF definition
 

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -5,19 +5,13 @@ from ibis.tests.backends import Pandas, PySpark
 from ibis.udf.vectorized import elementwise
 
 
-@elementwise(input_type=[dt.double], output_type=dt.double)
-def add_one(s):
-    return s + 1
-
-
-@elementwise(input_type=[dt.double], output_type=[dt.double])
-def add_one_with_output_type_list(s):
-    return s + 1
-
-
 @pytest.mark.only_on_backends([Pandas, PySpark])
 @pytest.mark.xfail_unsupported
 def test_elementwise_udf(backend, alltypes, df):
+    @elementwise(input_type=[dt.double], output_type=dt.double)
+    def add_one(s):
+        return s + 1
+
     result = add_one(alltypes['double_col']).execute()
     expected = add_one.func(df['double_col'])
     backend.assert_series_equal(result, expected, check_names=False)
@@ -25,9 +19,19 @@ def test_elementwise_udf(backend, alltypes, df):
 
 @pytest.mark.only_on_backends([Pandas, PySpark])
 @pytest.mark.xfail_unsupported
-def test_elementwise_udf_with_output_type_list(backend, alltypes, df):
-    result = add_one_with_output_type_list(alltypes['double_col']).execute()
-    expected = add_one_with_output_type_list.func(df['double_col'])
+def test_elementwise_udf_with_output_type_in_list(backend, alltypes, df):
+    """
+    Test that a UDF's output type can be specified as a single datatype
+    wrapped in a list. This is equivalent to single datatype that is not in a
+    list.
+    """
+
+    @elementwise(input_type=[dt.double], output_type=[dt.double])
+    def add_one(s):
+        return s + 1
+
+    result = add_one(alltypes['double_col']).execute()
+    expected = add_one.func(df['double_col'])
     backend.assert_series_equal(result, expected, check_names=False)
 
 

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -18,8 +18,9 @@ def test_elementwise_udf(backend, alltypes, df):
     backend.assert_series_equal(result, expected, check_names=False)
 
 
+@pytest.mark.only_on_backends([Pandas, PySpark])
 @pytest.mark.xfail_unsupported
-def test_output_type_in_list(backend, alltypes, df):
+def test_output_type_in_list_invalid(backend, alltypes, df):
     # Test that an error is raised ifUDF output type is wrapped in a list
 
     with pytest.raises(

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -1,5 +1,6 @@
 import pytest
 
+import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.tests.backends import Pandas, PySpark
 from ibis.udf.vectorized import elementwise
@@ -15,6 +16,20 @@ def test_elementwise_udf(backend, alltypes, df):
     result = add_one(alltypes['double_col']).execute()
     expected = add_one.func(df['double_col'])
     backend.assert_series_equal(result, expected, check_names=False)
+
+
+@pytest.mark.xfail_unsupported
+def test_output_type_in_list(backend, alltypes, df):
+    # Test that an error is raised ifUDF output type is wrapped in a list
+
+    with pytest.raises(
+        com.IbisTypeError,
+        match="The output type of a UDF must be a single datatype.",
+    ):
+
+        @elementwise(input_type=[dt.double], output_type=[dt.double])
+        def add_one(s):
+            return s + 1
 
 
 @pytest.mark.only_on_backends([Pandas, PySpark])

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -19,7 +19,7 @@ def test_elementwise_udf(backend, alltypes, df):
 
 @pytest.mark.only_on_backends([Pandas, PySpark])
 @pytest.mark.xfail_unsupported
-def test_elementwise_udf_with_output_type_in_list(backend, alltypes, df):
+def test_output_type_in_list(backend, alltypes, df):
     """
     Test that a UDF's output type can be specified as a single datatype
     wrapped in a list. This is equivalent to a single datatype that is not in a

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -10,11 +10,24 @@ def add_one(s):
     return s + 1
 
 
+@elementwise(input_type=[dt.double], output_type=[dt.double])
+def add_one_with_output_type_list(s):
+    return s + 1
+
+
 @pytest.mark.only_on_backends([Pandas, PySpark])
 @pytest.mark.xfail_unsupported
 def test_elementwise_udf(backend, alltypes, df):
     result = add_one(alltypes['double_col']).execute()
     expected = add_one.func(df['double_col'])
+    backend.assert_series_equal(result, expected, check_names=False)
+
+
+@pytest.mark.only_on_backends([Pandas, PySpark])
+@pytest.mark.xfail_unsupported
+def test_elementwise_udf_with_output_type_list(backend, alltypes, df):
+    result = add_one_with_output_type_list(alltypes['double_col']).execute()
+    expected = add_one_with_output_type_list.func(df['double_col'])
     backend.assert_series_equal(result, expected, check_names=False)
 
 

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -22,7 +22,7 @@ def test_elementwise_udf(backend, alltypes, df):
 def test_elementwise_udf_with_output_type_in_list(backend, alltypes, df):
     """
     Test that a UDF's output type can be specified as a single datatype
-    wrapped in a list. This is equivalent to single datatype that is not in a
+    wrapped in a list. This is equivalent to a single datatype that is not in a
     list.
     """
 

--- a/ibis/udf/validate.py
+++ b/ibis/udf/validate.py
@@ -31,7 +31,7 @@ def _parameter_count(funcsig):
     )
 
 
-def validate_input_type_count(input_type, func):
+def validate_input_type(input_type, func):
     """Check that the declared number of inputs (the length of `input_type`)
     and the number of inputs to `func` are equal.
 

--- a/ibis/udf/validate.py
+++ b/ibis/udf/validate.py
@@ -6,11 +6,13 @@ DO NOT USE DIRECTLY.
 """
 
 from inspect import Parameter, signature
+from typing import Any, Callable, List
 
 import ibis.common.exceptions as com
+from ibis.expr.datatypes import DataType
 
 
-def _parameter_count(funcsig):
+def _parameter_count(funcsig: signature) -> int:
     """Get the number of positional-or-keyword or position-only parameters in a
     function signature.
 
@@ -31,7 +33,9 @@ def _parameter_count(funcsig):
     )
 
 
-def validate_input_type(input_type, func):
+def validate_input_type(
+    input_type: List[DataType], func: Callable
+) -> signature:
     """Check that the declared number of inputs (the length of `input_type`)
     and the number of inputs to `func` are equal.
 
@@ -62,7 +66,7 @@ def validate_input_type(input_type, func):
     return funcsig
 
 
-def validate_output_type(output_type):
+def validate_output_type(output_type: Any) -> None:
     """Check that the output type is a single datatype."""
 
     if isinstance(output_type, list):

--- a/ibis/udf/validate.py
+++ b/ibis/udf/validate.py
@@ -1,0 +1,71 @@
+"""Validation for UDFs.
+
+Warning: This is an experimental module and API here can change without notice.
+
+DO NOT USE DIRECTLY.
+"""
+
+from inspect import Parameter, signature
+
+import ibis.common.exceptions as com
+
+
+def _parameter_count(funcsig):
+    """Get the number of positional-or-keyword or position-only parameters in a
+    function signature.
+
+    Parameters
+    ----------
+    funcsig : inspect.Signature
+        A UDF signature
+
+    Returns
+    -------
+    int
+        The number of parameters
+    """
+    return sum(
+        param.kind in {param.POSITIONAL_OR_KEYWORD, param.POSITIONAL_ONLY}
+        for param in funcsig.parameters.values()
+        if param.default is Parameter.empty
+    )
+
+
+def validate_input_type_count(input_type, func):
+    """Check that the declared number of inputs (the length of `input_type`)
+    and the number of inputs to `func` are equal.
+
+    Parameters
+    ----------
+    input_type : List[DataType]
+    func : callable
+
+    Returns
+    -------
+    inspect.Signature
+    """
+    funcsig = signature(func)
+    declared_parameter_count = len(input_type)
+    function_parameter_count = _parameter_count(funcsig)
+
+    if declared_parameter_count != function_parameter_count:
+        raise TypeError(
+            'Function signature {!r} has {:d} parameters, '
+            'input_type has {:d}. These must match. Non-column '
+            'parameters must be defined as keyword only, i.e., '
+            'def foo(col, *, function_param).'.format(
+                func.__name__,
+                function_parameter_count,
+                declared_parameter_count,
+            )
+        )
+    return funcsig
+
+
+def validate_output_type(output_type):
+    """Check that the output type is a single datatype."""
+
+    if isinstance(output_type, list):
+        raise com.IbisTypeError(
+            'The output type of a UDF must be a single datatype.'
+        )

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -79,8 +79,13 @@ class UserDefinedFunction(object):
 
         self.func = func
         self.func_type = func_type
-        self.input_type = input_type
-        self.output_type = output_type
+
+        self.input_type = list(map(dt.dtype, input_type))
+
+        if type(output_type) is list:
+            [output_type] = output_type
+
+        self.output_type = dt.dtype(output_type)
 
     def __call__(self, *args, **kwargs):
         # kwargs cannot be part of the node object because it can contain

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -6,67 +6,15 @@ DO NOT USE DIRECTLY.
 """
 
 import functools
-from inspect import Parameter, signature
 
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
+import ibis.udf.validate as v
 from ibis.expr.operations import (
     AnalyticVectorizedUDF,
     ElementWiseVectorizedUDF,
     ReductionVectorizedUDF,
 )
-
-
-def parameter_count(funcsig):
-    """Get the number of positional-or-keyword or position-only parameters in a
-    function signature.
-
-    Parameters
-    ----------
-    funcsig : inspect.Signature
-        A UDF signature
-
-    Returns
-    -------
-    int
-        The number of parameters
-    """
-    return sum(
-        param.kind in {param.POSITIONAL_OR_KEYWORD, param.POSITIONAL_ONLY}
-        for param in funcsig.parameters.values()
-        if param.default is Parameter.empty
-    )
-
-
-def valid_function_signature(input_type, func):
-    """Check that the declared number of inputs (the length of `input_type`)
-    and the number of inputs to `func` are equal.
-
-    Parameters
-    ----------
-    input_type : List[DataType]
-    func : callable
-
-    Returns
-    -------
-    inspect.Signature
-    """
-    funcsig = signature(func)
-    declared_parameter_count = len(input_type)
-    function_parameter_count = parameter_count(funcsig)
-
-    if declared_parameter_count != function_parameter_count:
-        raise TypeError(
-            'Function signature {!r} has {:d} parameters, '
-            'input_type has {:d}. These must match. Non-column '
-            'parameters must be defined as keyword only, i.e., '
-            'def foo(col, *, function_param).'.format(
-                func.__name__,
-                function_parameter_count,
-                declared_parameter_count,
-            )
-        )
-    return funcsig
 
 
 class UserDefinedFunction(object):
@@ -76,24 +24,13 @@ class UserDefinedFunction(object):
     """
 
     def __init__(self, func, func_type, input_type, output_type):
-        valid_function_signature(input_type, func)
+        v.validate_input_type_count(input_type, func)
+        v.validate_output_type(output_type)
 
         self.func = func
         self.func_type = func_type
-
-        self.input_type = list(map(dt.dtype, input_type))
-
-        if isinstance(output_type, list):
-            try:
-                (output_type,) = output_type
-            except ValueError:
-                raise com.IbisTypeError(
-                    'The output type of a UDF must be either a single '
-                    'datatype, or equivalently, a single datatype wrapped in '
-                    'a list.'
-                )
-
-        self.output_type = dt.dtype(output_type)
+        self.input_type = input_type
+        self.output_type = output_type
 
     def __call__(self, *args, **kwargs):
         # kwargs cannot be part of the node object because it can contain
@@ -115,8 +52,12 @@ class UserDefinedFunction(object):
 
 
 def _udf_decorator(node_type, input_type, output_type):
-    input_type = input_type
-    output_type = output_type
+    if isinstance(output_type, list):
+        raise com.IbisTypeError(
+            'The output type of a UDF must be a single datatype.'
+        )
+    input_type = list(map(dt.dtype, input_type))
+    output_type = dt.dtype(output_type)
 
     def wrapper(func):
         return UserDefinedFunction(func, node_type, input_type, output_type)
@@ -134,10 +75,8 @@ def analytic(input_type, output_type):
         A list of the types found in :mod:`~ibis.expr.datatypes`. The
         length of this list must match the number of arguments to the
         function. Variadic arguments are not yet supported.
-    output_type : ibis.expr.datatypes.DataType or
-            List[ibis.expr.datatypes.DataType]
-        The return type of the function. This can be specified either
-        as a single value, or equivalently, a single value wrapped in a list.
+    output_type : ibis.expr.datatypes.DataType
+        The return type of the function.
 
     Examples
     --------
@@ -161,10 +100,8 @@ def elementwise(input_type, output_type):
         A list of the types found in :mod:`~ibis.expr.datatypes`. The
         length of this list must match the number of arguments to the
         function. Variadic arguments are not yet supported.
-    output_type : ibis.expr.datatypes.DataType or
-            List[ibis.expr.datatypes.DataType]
-        The return type of the function. This can be specified either
-        as a single value, or equivalently, a single value wrapped in a list.
+    output_type : ibis.expr.datatypes.DataType
+        The return type of the function.
 
     Examples
     --------
@@ -194,10 +131,8 @@ def reduction(input_type, output_type):
         A list of the types found in :mod:`~ibis.expr.datatypes`. The
         length of this list must match the number of arguments to the
         function. Variadic arguments are not yet supported.
-    output_type : ibis.expr.datatypes.DataType or
-            List[ibis.expr.datatypes.DataType]
-        The return type of the function. This can be specified either
-        as a single value, or equivalently, a single value wrapped in a list.
+    output_type : ibis.expr.datatypes.DataType
+        The return type of the function.
 
     Examples
     --------

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -7,7 +7,6 @@ DO NOT USE DIRECTLY.
 
 import functools
 
-import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.udf.validate as v
 from ibis.expr.operations import (
@@ -29,8 +28,8 @@ class UserDefinedFunction(object):
 
         self.func = func
         self.func_type = func_type
-        self.input_type = input_type
-        self.output_type = output_type
+        self.input_type = list(map(dt.dtype, input_type))
+        self.output_type = dt.dtype(output_type)
 
     def __call__(self, *args, **kwargs):
         # kwargs cannot be part of the node object because it can contain
@@ -52,13 +51,6 @@ class UserDefinedFunction(object):
 
 
 def _udf_decorator(node_type, input_type, output_type):
-    if isinstance(output_type, list):
-        raise com.IbisTypeError(
-            'The output type of a UDF must be a single datatype.'
-        )
-    input_type = list(map(dt.dtype, input_type))
-    output_type = dt.dtype(output_type)
-
     def wrapper(func):
         return UserDefinedFunction(func, node_type, input_type, output_type)
 

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -115,8 +115,8 @@ class UserDefinedFunction(object):
 
 
 def _udf_decorator(node_type, input_type, output_type):
-    input_type = list(map(dt.dtype, input_type))
-    output_type = dt.dtype(output_type)
+    input_type = input_type
+    output_type = output_type
 
     def wrapper(func):
         return UserDefinedFunction(func, node_type, input_type, output_type)

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -135,7 +135,7 @@ def analytic(input_type, output_type):
         length of this list must match the number of arguments to the
         function. Variadic arguments are not yet supported.
     output_type : ibis.expr.datatypes.DataType or
-            List[ibis.expr.datatypes.DataType]]
+            List[ibis.expr.datatypes.DataType]
         The return type of the function. This can be specified either
         as a single value, or equivalently, a single value wrapped in a list.
 
@@ -162,7 +162,7 @@ def elementwise(input_type, output_type):
         length of this list must match the number of arguments to the
         function. Variadic arguments are not yet supported.
     output_type : ibis.expr.datatypes.DataType or
-            List[ibis.expr.datatypes.DataType]]
+            List[ibis.expr.datatypes.DataType]
         The return type of the function. This can be specified either
         as a single value, or equivalently, a single value wrapped in a list.
 
@@ -195,7 +195,7 @@ def reduction(input_type, output_type):
         length of this list must match the number of arguments to the
         function. Variadic arguments are not yet supported.
     output_type : ibis.expr.datatypes.DataType or
-            List[ibis.expr.datatypes.DataType]]
+            List[ibis.expr.datatypes.DataType]
         The return type of the function. This can be specified either
         as a single value, or equivalently, a single value wrapped in a list.
 

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -23,7 +23,7 @@ class UserDefinedFunction(object):
     """
 
     def __init__(self, func, func_type, input_type, output_type):
-        v.validate_input_type_count(input_type, func)
+        v.validate_input_type(input_type, func)
         v.validate_output_type(output_type)
 
         self.func = func

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -8,6 +8,7 @@ DO NOT USE DIRECTLY.
 import functools
 from inspect import Parameter, signature
 
+import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.expr.operations import (
     AnalyticVectorizedUDF,
@@ -82,8 +83,15 @@ class UserDefinedFunction(object):
 
         self.input_type = list(map(dt.dtype, input_type))
 
-        if type(output_type) is list:
-            [output_type] = output_type
+        if isinstance(output_type, list):
+            try:
+                (output_type,) = output_type
+            except ValueError:
+                raise com.IbisTypeError(
+                    'The output type of a UDF must be either a single '
+                    'datatype, or equivalently, a single datatype wrapped in '
+                    'a list.'
+                )
 
         self.output_type = dt.dtype(output_type)
 

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -134,8 +134,10 @@ def analytic(input_type, output_type):
         A list of the types found in :mod:`~ibis.expr.datatypes`. The
         length of this list must match the number of arguments to the
         function. Variadic arguments are not yet supported.
-    output_type : ibis.expr.datatypes.DataType
-        The return type of the function.
+    output_type : ibis.expr.datatypes.DataType or
+            List[ibis.expr.datatypes.DataType]]
+        The return type of the function. This can be specified either
+        as a single value, or equivalently, a single value wrapped in a list.
 
     Examples
     --------
@@ -159,8 +161,10 @@ def elementwise(input_type, output_type):
         A list of the types found in :mod:`~ibis.expr.datatypes`. The
         length of this list must match the number of arguments to the
         function. Variadic arguments are not yet supported.
-    output_type : ibis.expr.datatypes.DataType
-        The return type of the function.
+    output_type : ibis.expr.datatypes.DataType or
+            List[ibis.expr.datatypes.DataType]]
+        The return type of the function. This can be specified either
+        as a single value, or equivalently, a single value wrapped in a list.
 
     Examples
     --------
@@ -190,8 +194,10 @@ def reduction(input_type, output_type):
         A list of the types found in :mod:`~ibis.expr.datatypes`. The
         length of this list must match the number of arguments to the
         function. Variadic arguments are not yet supported.
-    output_type : ibis.expr.datatypes.DataType
-        The return type of the function.
+    output_type : ibis.expr.datatypes.DataType or
+            List[ibis.expr.datatypes.DataType]]
+        The return type of the function. This can be specified either
+        as a single value, or equivalently, a single value wrapped in a list.
 
     Examples
     --------


### PR DESCRIPTION
The normal syntax for defining an elementwise UDF is passing a single value to `output_type`:
```
@elementwise(input_type=[dt.float64, dt.float64], output_type=dt.float64)
def sum_udf(a, b):
    return a + b
```


If the output type is placed into a list (similar to `input_type`) (see below), then executing an expression with the UDF succeeds on Pandas but fails on Spark with `TypeError: 'NoneType' object is not callable`
```
@elementwise(input_type=[dt.float64, dt.float64], output_type=[dt.float64])
def sum_udf(a, b):
    return a + b
```


Currently, `output_type=[dt.float64]` is interpreted as the output type being `array<float64>`

This PR unpacks the single value in `output_type` if it's a list and uses that as the output type so that e.g. `output_type=[dt.float64]` is treated as just a `float64`



**edit:** This PR was originally "BUG: Allow output type of vectorized UDFs to be specified as a single-element list" but was renamed (see below)