### PR TITLE
CI: Making conda build use Python 3.7

### DIFF
--- a/ci/feedstock.py
+++ b/ci/feedstock.py
@@ -99,7 +99,7 @@ def build(recipe, python):
     click.echo('Building {} recipe...'.format(recipe))
 
     cmd = conda[
-        'build', recipe, '--channel', 'conda-forge', '--python', python
+        'build', recipe, '--channel', 'conda-forge', '--python', '3.7'
     ]
 
     cmd(


### PR DESCRIPTION
I think this is what is needed from #2195, so the build passes after the feedstock branch has been merged.

Testing if this is the case.