### PR TITLE
CI: Publish website instead of docs

### DIFF
--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -277,7 +277,7 @@ jobs:
 
     - task: PublishPipelineArtifact@1
       inputs:
-        path: /tmp/ibis/ibis-project.org/docs
+        path: /tmp/ibis/ibis-project.org
         artifact: Documentation
       displayName: 'Publish documentation to Azure'
       condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'False'))
@@ -292,7 +292,7 @@ jobs:
         ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
         sudo chown -R "${USER}":"${USER}" /tmp/ibis
-        pushd /tmp/ibis/ibis-project.org/docs
+        pushd /tmp/ibis/ibis-project.org
 
         git remote set-url origin git@github.com:ibis-project/docs.ibis-project.org
 


### PR DESCRIPTION
In #2206, the website is being built, with the docs in the `/docs/` directory, but I'm pushing the `/docs/` directory to GitHub pages, instead of the whole website.

This should fix it, and push both the website and the docs to docs.ibis-project.org