### PR TITLE
FEAT: Move ibis.pandas.udf.reduction and ibis.pandas.udf.analytics to ibis.udf.vectorized namespace

### DIFF
--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -3449,9 +3449,8 @@ class GeoAsText(GeoSpatialUnOp):
     output_type = rlz.shape_like('arg', dt.string)
 
 
-class VectorizedUDF(ValueOp):
-    """Base node for vectorized UDF.
-    """
+class ElementWiseVectorizedUDF(ValueOp):
+    """Node for element wise UDF."""
 
     func = Arg(callable)
     func_args = Arg(tuple)
@@ -3479,10 +3478,6 @@ class VectorizedUDF(ValueOp):
         )
 
         return result
-
-
-class ElementWiseVectorizedUDF(VectorizedUDF):
-    """Node for element wise UDF."""
 
 
 class ReductionVectorizedUDF(Reduction):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -3449,12 +3449,78 @@ class GeoAsText(GeoSpatialUnOp):
     output_type = rlz.shape_like('arg', dt.string)
 
 
-class ElementWiseVectorizedUDF(ValueOp):
-    """Node for element wise UDF.
+class VectorizedUDF(ValueOp):
+    """Base node for vectorized UDF.
     """
 
     func = Arg(callable)
-    func_args = Arg(list)
+    func_args = Arg(tuple)
+    input_type = Arg(rlz.shape_like('func_args'))
+    _output_type = Arg(rlz.noop)
+
+    def __init__(self, func, args, input_type, output_type):
+        self.func = func
+        self.func_args = args
+        self.input_type = input_type
+        self._output_type = output_type
+
+    @property
+    def inputs(self):
+        return self.func_args
+
+    def output_type(self):
+        return self._output_type.column_type()
+
+    def root_tables(self):
+        result = list(
+            toolz.unique(
+                toolz.concat(arg._root_tables() for arg in self.func_args)
+            )
+        )
+
+        return result
+
+
+class ElementWiseVectorizedUDF(VectorizedUDF):
+    """Node for element wise UDF."""
+
+
+class ReductionVectorizedUDF(Reduction):
+    """Node for reduction UDF."""
+
+    func = Arg(callable)
+    func_args = Arg(tuple)
+    input_type = Arg(rlz.shape_like('func_args'))
+    _output_type = Arg(rlz.noop)
+
+    def __init__(self, func, args, input_type, output_type):
+        self.func = func
+        self.func_args = args
+        self.input_type = input_type
+        self._output_type = output_type
+
+    @property
+    def inputs(self):
+        return self.func_args
+
+    def output_type(self):
+        return self._output_type.scalar_type()
+
+    def root_tables(self):
+        result = list(
+            toolz.unique(
+                toolz.concat(arg._root_tables() for arg in self.func_args)
+            )
+        )
+
+        return result
+
+
+class AnalyticsVectorizedUDF(AnalyticOp):
+    """Node for analytics UDF."""
+
+    func = Arg(callable)
+    func_args = Arg(tuple)
     input_type = Arg(rlz.shape_like('func_args'))
     _output_type = Arg(rlz.noop)
 

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -154,6 +154,7 @@ class udf:
         return ibis.udf.vectorized.analytic(input_type, output_type)
 
 
+@pre_execute.register(ops.ElementWiseVectorizedUDF)
 @pre_execute.register(ops.ElementWiseVectorizedUDF, ibis.client.Client)
 def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
     """Register execution rules for elementwise UDFs.
@@ -207,7 +208,9 @@ def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
     return scope
 
 
+@pre_execute.register(ops.AnalyticsVectorizedUDF)
 @pre_execute.register(ops.AnalyticsVectorizedUDF, ibis.client.Client)
+@pre_execute.register(ops.ReductionVectorizedUDF)
 @pre_execute.register(ops.ReductionVectorizedUDF, ibis.client.Client)
 def pre_execute_reduction_udf(op, *clients, scope=None, **kwargs):
     input_type = op.input_type

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -52,7 +52,7 @@ def rule_to_python_type(datatype):
 def create_gens_from_args_groupby(args: Tuple[SeriesGroupBy]):
     """ Create generators for each args for groupby udaf.
 
-    Returns a generator taht outputs each group.
+    Returns a generator that outputs each group.
 
     Parameters
     ----------
@@ -139,81 +139,21 @@ def nullable(datatype):
 class udf:
     @staticmethod
     def elementwise(input_type, output_type):
-        """Define a UDF (user-defined function) that operates element wise on a
-        Pandas Series.
+        """Alias for ibis.udf.vectorized.elementwise."""
 
-        Parameters
-        ----------
-        input_type : List[ibis.expr.datatypes.DataType]
-            A list of the types found in :mod:`~ibis.expr.datatypes`. The
-            length of this list must match the number of arguments to the
-            function. Variadic arguments are not yet supported.
-        output_type : ibis.expr.datatypes.DataType
-            The return type of the function.
-
-        Examples
-        --------
-        >>> import ibis
-        >>> import ibis.expr.datatypes as dt
-        >>> from ibis.pandas.udf import udf
-        >>> @udf.elementwise(input_type=[dt.string], output_type=dt.int64)
-        ... def my_string_length(series):
-        ...     return series.str.len() * 2
-        """
         return ibis.udf.vectorized.elementwise(input_type, output_type)
 
     @staticmethod
     def reduction(input_type, output_type):
-        """Define a user-defined reduction function that takes N pandas Series
-        or scalar values as inputs and produces one row of output.
-
-        Parameters
-        ----------
-        input_type : List[ibis.expr.datatypes.DataType]
-            A list of the types found in :mod:`~ibis.expr.datatypes`. The
-            length of this list must match the number of arguments to the
-            function. Variadic arguments are not yet supported.
-        output_type : ibis.expr.datatypes.DataType
-            The return type of the function.
-
-        Examples
-        --------
-        >>> import ibis
-        >>> import ibis.expr.datatypes as dt
-        >>> from ibis.pandas.udf import udf
-        >>> @udf.reduction(input_type=[dt.string], output_type=dt.int64)
-        ... def my_string_length_agg(series, **kwargs):
-        ...     return (series.str.len() * 2).sum()
-        """
+        """Alias for ibis.udf.vectorized.reduction."""
         return ibis.udf.vectorized.reduction(input_type, output_type)
 
     @staticmethod
     def analytic(input_type, output_type):
-        """Define an *analytic* user-defined function that takes N
-        pandas Series or scalar values as inputs and produces N rows of output.
-
-        Parameters
-        ----------
-        input_type : List[ibis.expr.datatypes.DataType]
-            A list of the types found in :mod:`~ibis.expr.datatypes`. The
-            length of this list must match the number of arguments to the
-            function. Variadic arguments are not yet supported.
-        output_type : ibis.expr.datatypes.DataType
-            The return type of the function.
-
-        Examples
-        --------
-        >>> import ibis
-        >>> import ibis.expr.datatypes as dt
-        >>> from ibis.pandas.udf import udf
-        >>> @udf.analytic(input_type=[dt.double], output_type=dt.double)
-        ... def zscore(series):  # note the use of aggregate functions
-        ...     return (series - series.mean()) / series.std()
-        """
-        return ibis.udf.vectorized.analytics(input_type, output_type)
+        """Alias for ibis.udf.vectorized.analytics."""
+        return ibis.udf.vectorized.analytic(input_type, output_type)
 
 
-@pre_execute.register(ops.ElementWiseVectorizedUDF)
 @pre_execute.register(ops.ElementWiseVectorizedUDF, ibis.client.Client)
 def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
     """Register execution rules for elementwise UDFs.
@@ -267,9 +207,7 @@ def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
     return scope
 
 
-@pre_execute.register(ops.AnalyticsVectorizedUDF)
 @pre_execute.register(ops.AnalyticsVectorizedUDF, ibis.client.Client)
-@pre_execute.register(ops.ReductionVectorizedUDF)
 @pre_execute.register(ops.ReductionVectorizedUDF, ibis.client.Client)
 def pre_execute_reduction_udf(op, *clients, scope=None, **kwargs):
     input_type = op.input_type

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -7,18 +7,14 @@ from __future__ import absolute_import
 import collections
 import functools
 import itertools
-import operator
-from inspect import Parameter, signature
-from typing import Any, Tuple
+from typing import Tuple
 
 import numpy as np
 import pandas as pd
-import toolz
 from pandas.core.groupby import SeriesGroupBy
 
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-import ibis.expr.signature as sig
 import ibis.udf.vectorized
 from ibis.pandas.aggcontext import Window
 from ibis.pandas.core import (
@@ -53,91 +49,20 @@ def rule_to_python_type(datatype):
     )
 
 
-def arguments_from_signature(signature, *args, **kwargs):
-    """Validate signature against `args` and `kwargs` and return the kwargs
-    asked for in the signature
-
-    Parameters
-    ----------
-    args : Tuple[object...]
-    kwargs : Dict[str, object]
-
-    Returns
-    -------
-    Tuple[Tuple, Dict[str, Any]]
-
-    Examples
-    --------
-    >>> from inspect import signature
-    >>> def foo(a, b=1):
-    ...     return a + b
-    >>> foo_sig = signature(foo)
-    >>> args, kwargs = arguments_from_signature(foo_sig, 1, b=2)
-    >>> args
-    (1,)
-    >>> kwargs
-    {'b': 2}
-    >>> def bar(a):
-    ...     return a + 1
-    >>> bar_sig = signature(bar)
-    >>> args, kwargs = arguments_from_signature(bar_sig, 1, b=2)
-    >>> args
-    (1,)
-    >>> kwargs
-    {}
-    """
-    bound = signature.bind_partial(*args)
-    meta_kwargs = toolz.merge({'kwargs': kwargs}, kwargs)
-    remaining_parameters = signature.parameters.keys() - bound.arguments.keys()
-    new_kwargs = {
-        k: meta_kwargs[k]
-        for k in remaining_parameters
-        if k in signature.parameters
-        if signature.parameters[k].kind
-        in {
-            Parameter.KEYWORD_ONLY,
-            Parameter.POSITIONAL_OR_KEYWORD,
-            Parameter.VAR_KEYWORD,
-        }
-    }
-    return args, new_kwargs
-
-
-def create_gens_from_args_groupby(args: Tuple[Any]):
+def create_gens_from_args_groupby(args: Tuple[SeriesGroupBy]):
     """ Create generators for each args for groupby udaf.
 
-    Args can be one of two things:
-
-    If the arg is SeriesGroupBy, it's data passed to the user function.
-    In this case, return a generator that outputs each group.
-
-    If the arg is not SeriesGroupBy, it's user specified params.
-    In this case, return a generator that repeats the arg.
-
-    E.g,
-    @udf.aggregation(...)
-    def foo(col, my_arg):
-        if my_arg == 'something':
-            # Do something
-            ...
-        elif my_arg == 'something else':
-            # Do something else
-            ...
+    Returns a generator taht outputs each group.
 
     Parameters
     ----------
-    args : Tuple[object...]
+    args : Tuple[SeriesGroupBy...]
 
     Returns
     -------
     Tuple[Generator]
     """
-    iters = (
-        (data for _, data in arg)
-        if isinstance(arg, SeriesGroupBy)
-        else itertools.repeat(arg)
-        for arg in args
-    )
+    iters = ((data for _, data in arg) for arg in args)
     return iters
 
 
@@ -211,130 +136,6 @@ def nullable(datatype):
     return (type(None),) if datatype.nullable else ()
 
 
-def udf_signature(input_type, pin, klass):
-    """Compute the appropriate signature for a
-    :class:`~ibis.expr.operations.Node` from a list of input types
-    `input_type`.
-
-    Parameters
-    ----------
-    input_type : List[ibis.expr.datatypes.DataType]
-        A list of :class:`~ibis.expr.datatypes.DataType` instances representing
-        the signature of a UDF/UDAF.
-    pin : Optional[int]
-        If this is not None, pin the `pin`-th argument type to `klass`
-    klass : Union[Type[pd.Series], Type[SeriesGroupBy]]
-        The pandas object that every argument type should contain
-
-    Returns
-    -------
-    Tuple[Type]
-        A tuple of types appropriate for use in a multiple dispatch signature.
-
-    Examples
-    --------
-    >>> from pprint import pprint
-    >>> import pandas as pd
-    >>> from pandas.core.groupby import SeriesGroupBy
-    >>> import ibis.expr.datatypes as dt
-    >>> input_type = [dt.string, dt.double]
-    >>> sig = udf_signature(input_type, pin=None, klass=pd.Series)
-    >>> pprint(sig)  # doctest: +ELLIPSIS
-    ((<class '...Series'>, <... '...str...'>, <... 'NoneType'>),
-     (<class '...Series'>,
-      <... 'float'>,
-      <... 'numpy.floating'>,
-      <... 'NoneType'>))
-    >>> not_nullable_types = [
-    ...     dt.String(nullable=False), dt.Double(nullable=False)]
-    >>> sig = udf_signature(not_nullable_types, pin=None, klass=pd.Series)
-    >>> pprint(sig)  # doctest: +ELLIPSIS
-    ((<class '...Series'>, <... '...str...'>),
-     (<class '...Series'>,
-      <... 'float'>,
-      <... 'numpy.floating'>))
-    >>> sig0 = udf_signature(input_type, pin=0, klass=SeriesGroupBy)
-    >>> sig1 = udf_signature(input_type, pin=1, klass=SeriesGroupBy)
-    >>> pprint(sig0)  # doctest: +ELLIPSIS
-    (<class '...SeriesGroupBy'>,
-     (<class '...SeriesGroupBy'>,
-      <... 'float'>,
-      <... 'numpy.floating'>,
-      <... 'NoneType'>))
-    >>> pprint(sig1)  # doctest: +ELLIPSIS
-    ((<class '...SeriesGroupBy'>,
-      <... '...str...'>,
-      <... 'NoneType'>),
-     <class '...SeriesGroupBy'>)
-    """
-    nargs = len(input_type)
-
-    if not nargs:
-        return ()
-
-    if nargs == 1:
-        (r,) = input_type
-        result = (klass,) + rule_to_python_type(r) + nullable(r)
-        return (result,)
-
-    return tuple(
-        klass
-        if pin is not None and pin == i
-        else ((klass,) + rule_to_python_type(r) + nullable(r))
-        for i, r in enumerate(input_type)
-    )
-
-
-def parameter_count(funcsig):
-    """Get the number of positional-or-keyword or position-only parameters in a
-    function signature.
-
-    Parameters
-    ----------
-    funcsig : inspect.Signature
-        A UDF signature
-
-    Returns
-    -------
-    int
-        The number of parameters
-    """
-    return sum(
-        param.kind in {param.POSITIONAL_OR_KEYWORD, param.POSITIONAL_ONLY}
-        for param in funcsig.parameters.values()
-        if param.default is Parameter.empty
-    )
-
-
-def valid_function_signature(input_type, func):
-    """Check that the declared number of inputs (the length of `input_type`)
-    and the number of inputs to `func` are equal.
-
-    Parameters
-    ----------
-    input_type : List[DataType]
-    func : callable
-
-    Returns
-    -------
-    inspect.Signature
-    """
-    funcsig = signature(func)
-    declared_parameter_count = len(input_type)
-    function_parameter_count = parameter_count(funcsig)
-
-    if declared_parameter_count != function_parameter_count:
-        raise TypeError(
-            'Function signature {!r} has {:d} parameters, '
-            'input_type has {:d}. These must match'.format(
-                func.__name__,
-                function_parameter_count,
-                declared_parameter_count,
-            )
-        )
-    return funcsig
-
-
 class udf:
     @staticmethod
     def elementwise(input_type, output_type):
@@ -384,12 +185,7 @@ class udf:
         ... def my_string_length_agg(series, **kwargs):
         ...     return (series.str.len() * 2).sum()
         """
-        return udf._grouped(
-            input_type,
-            output_type,
-            base_class=ops.Reduction,
-            output_type_method=operator.attrgetter('scalar_type'),
-        )
+        return ibis.udf.vectorized.reduction(input_type, output_type)
 
     @staticmethod
     def analytic(input_type, output_type):
@@ -414,117 +210,7 @@ class udf:
         ... def zscore(series):  # note the use of aggregate functions
         ...     return (series - series.mean()) / series.std()
         """
-        return udf._grouped(
-            input_type,
-            output_type,
-            base_class=ops.AnalyticOp,
-            output_type_method=operator.attrgetter('column_type'),
-        )
-
-    @staticmethod
-    def _grouped(input_type, output_type, base_class, output_type_method):
-        """Define a user-defined function that is applied per group.
-
-        Parameters
-        ----------
-        input_type : List[ibis.expr.datatypes.DataType]
-            A list of the types found in :mod:`~ibis.expr.datatypes`. The
-            length of this list must match the number of arguments to the
-            function. Variadic arguments are not yet supported.
-        output_type : ibis.expr.datatypes.DataType
-            The return type of the function.
-        base_class : Type[T]
-            The base class of the generated Node
-        output_type_method : Callable
-            A callable that determines the method to call to get the expression
-            type of the UDF
-
-        See Also
-        --------
-        ibis.pandas.udf.reduction
-        ibis.pandas.udf.analytic
-        """
-        input_type = list(map(dt.dtype, input_type))
-        output_type = dt.dtype(output_type)
-
-        def wrapper(func):
-            funcsig = valid_function_signature(input_type, func)
-
-            UDAFNode = type(
-                func.__name__,
-                (base_class,),
-                {
-                    'signature': sig.TypeSignature.from_dtypes(input_type),
-                    'output_type': output_type_method(output_type),
-                },
-            )
-
-            # An execution rule for a simple aggregate node
-            @execute_node.register(
-                UDAFNode, *udf_signature(input_type, pin=None, klass=pd.Series)
-            )
-            def execute_udaf_node(op, *args, **kwargs):
-                args, kwargs = arguments_from_signature(
-                    funcsig, *args, **kwargs
-                )
-                return func(*args, **kwargs)
-
-            # An execution rule for a grouped aggregation node. This
-            # includes aggregates applied over a window.
-            nargs = len(input_type)
-            group_by_signatures = [
-                udf_signature(input_type, pin=pin, klass=SeriesGroupBy)
-                for pin in range(nargs)
-            ]
-
-            @toolz.compose(
-                *(
-                    execute_node.register(UDAFNode, *types)
-                    for types in group_by_signatures
-                )
-            )
-            def execute_udaf_node_groupby(op, *args, **kwargs):
-                # construct a generator that yields the next group of data
-                # for every argument excluding the first (pandas performs
-                # the iteration for the first argument) for each argument
-                # that is a SeriesGroupBy.
-                #
-                # If the argument is not a SeriesGroupBy then keep
-                # repeating it until all groups are exhausted.
-                aggcontext = kwargs.pop('aggcontext', None)
-                assert aggcontext is not None, 'aggcontext is None'
-
-                if isinstance(aggcontext, Window):
-                    # Call the func differently for Window because of
-                    # the custom rolling logic.
-                    result = aggcontext.agg(args[0], func, *args, **kwargs)
-                else:
-                    iters = create_gens_from_args_groupby(args[1:])
-                    funcsig = signature(func)
-
-                    # TODO: Unify calling convension here to be more like
-                    # window
-                    def aggregator(first, *rest, **kwargs):
-                        # map(next, *rest) gets the inputs for the next group
-                        # TODO: might be inefficient to do this on every call
-                        args, kwargs = arguments_from_signature(
-                            funcsig, first, *map(next, rest), **kwargs
-                        )
-                        return func(*args, **kwargs)
-
-                    result = aggcontext.agg(
-                        args[0], aggregator, *iters, **kwargs
-                    )
-
-                return result
-
-            @functools.wraps(func)
-            def wrapped(*args):
-                return UDAFNode(*args).to_expr()
-
-            return wrapped
-
-        return wrapper
+        return ibis.udf.vectorized.analytics(input_type, output_type)
 
 
 @pre_execute.register(ops.ElementWiseVectorizedUDF)
@@ -558,12 +244,9 @@ def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
         # we're performing a scalar operation on grouped column, so
         # perform the operation directly on the underlying Series
         # and regroup after it's finished
-        arguments = [getattr(arg, 'obj', arg) for arg in args]
+        args = [getattr(arg, 'obj', arg) for arg in args]
         groupings = groupers[0].groupings
-        args, kwargs = arguments_from_signature(
-            signature(func), *arguments, **kwargs
-        )
-        return func(*args, **kwargs).groupby(groupings)
+        return func(*args).groupby(groupings)
 
     # Define an execution rule for a simple elementwise Series
     # function
@@ -574,10 +257,59 @@ def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
         ops.ElementWiseVectorizedUDF, *(itertools.repeat(object, nargs))
     )
     def execute_udf_node(op, *args, **kwargs):
-        func = op.func
-        funcsig = valid_function_signature(input_type, func)
+        # We have rewritten op.func to be a closure enclosing
+        # the kwargs, and therefore, we do not need to pass
+        # kwargs here. This is true for all udf execution in this
+        # file.
+        # See ibis.udf.vectorized.UserDefinedFunction
+        return op.func(*args)
 
-        args, kwargs = arguments_from_signature(funcsig, *args, **kwargs)
-        return func(*args, **kwargs)
+    return scope
+
+
+@pre_execute.register(ops.AnalyticsVectorizedUDF)
+@pre_execute.register(ops.AnalyticsVectorizedUDF, ibis.client.Client)
+@pre_execute.register(ops.ReductionVectorizedUDF)
+@pre_execute.register(ops.ReductionVectorizedUDF, ibis.client.Client)
+def pre_execute_reduction_udf(op, *clients, scope=None, **kwargs):
+    input_type = op.input_type
+    nargs = len(input_type)
+
+    # An execution rule for a simple aggregate node
+    @execute_node.register(type(op), *(itertools.repeat(pd.Series, nargs)))
+    def execute_udaf_node(op, *args, **kwargs):
+        return op.func(*args)
+
+    # An execution rule for a grouped aggregation node. This
+    # includes aggregates applied over a window.
+    @execute_node.register(type(op), *(itertools.repeat(SeriesGroupBy, nargs)))
+    def execute_udaf_node_groupby(op, *args, **kwargs):
+        # construct a generator that yields the next group of data
+        # for every argument excluding the first (pandas performs
+        # the iteration for the first argument) for each argument
+        # that is a SeriesGroupBy.
+        #
+        aggcontext = kwargs.pop('aggcontext', None)
+        assert aggcontext is not None, 'aggcontext is None'
+
+        func = op.func
+
+        if isinstance(aggcontext, Window):
+            # Call the func differently for Window because of
+            # the custom rolling logic.
+            result = aggcontext.agg(args[0], func, *args, **kwargs)
+        else:
+            iters = create_gens_from_args_groupby(args[1:])
+
+            # TODO: Unify calling convension here to be more like
+            # window
+            def aggregator(first, *rest, **kwargs):
+                # map(next, *rest) gets the inputs for the next group
+                # TODO: might be inefficient to do this on every call
+                return func(first, *map(next, rest))
+
+            result = aggcontext.agg(args[0], aggregator, *iters, **kwargs)
+
+        return result
 
     return scope

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -150,7 +150,7 @@ class udf:
 
     @staticmethod
     def analytic(input_type, output_type):
-        """Alias for ibis.udf.vectorized.analytics."""
+        """Alias for ibis.udf.vectorized.analytic."""
         return ibis.udf.vectorized.analytic(input_type, output_type)
 
 

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -941,7 +941,8 @@ def compile_join(t, expr, scope, how):
     return left_df.join(right_df, pred_columns, how)
 
 
-def compile_window_op_fallback(t, expr, scope, **kwargs):
+@compiles(ops.WindowOp)
+def compile_window_op(t, expr, scope, **kwargs):
     op = expr.op()
     window = op.window
     operand = op.expr

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -941,8 +941,7 @@ def compile_join(t, expr, scope, how):
     return left_df.join(right_df, pred_columns, how)
 
 
-@compiles(ops.WindowOp)
-def compile_window_op(t, expr, scope, **kwargs):
+def compile_window_op_fallback(t, expr, scope, **kwargs):
     op = expr.op()
     window = op.window
     operand = op.expr

--- a/ibis/spark/udf.py
+++ b/ibis/spark/udf.py
@@ -13,9 +13,9 @@ import pyspark.sql.types as pt
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.signature as sig
-from ibis.pandas.udf import valid_function_signature
 from ibis.spark.compiler import SparkUDAFNode, SparkUDFNode, compiles
 from ibis.spark.datatypes import spark_dtype
+from ibis.udf.vectorized import valid_function_signature
 
 _udf_name_cache = collections.defaultdict(itertools.count)
 

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -16,3 +16,56 @@ def test_elementwise_udf(backend, alltypes, df):
     result = add_one(alltypes['double_col']).execute()
     expected = add_one.func(df['double_col'])
     backend.assert_series_equal(result, expected, check_names=False)
+
+
+@pytest.mark.only_on_backends([Pandas, PySpark])
+@pytest.mark.xfail_unsupported
+def test_valid_kwargs(backend, alltypes, df):
+    # Test different forms of UDF definition
+
+    @elementwise(input_type=[dt.double], output_type=dt.double)
+    def foo1(v):
+        # Basic UDF with kwargs
+        return v + 1
+
+    @elementwise(input_type=[dt.double], output_type=dt.double)
+    def foo2(v, *, amount):
+        # UDF with keyword only arguments
+        return v + amount
+
+    @elementwise(input_type=[dt.double], output_type=dt.double)
+    def foo3(v, **kwargs):
+        # UDF with kwargs
+        return v + kwargs.get('amount', 1)
+
+    result = alltypes.mutate(
+        v1=foo1(alltypes['double_col']),
+        v2=foo2(alltypes['double_col'], amount=1),
+        v3=foo2(alltypes['double_col'], amount=2),
+        v4=foo3(alltypes['double_col']),
+        v5=foo3(alltypes['double_col'], amount=2),
+        v6=foo3(alltypes['double_col'], amount=3),
+    ).execute()
+
+    expected = df.assign(
+        v1=df['double_col'] + 1,
+        v2=df['double_col'] + 1,
+        v3=df['double_col'] + 2,
+        v4=df['double_col'] + 1,
+        v5=df['double_col'] + 2,
+        v6=df['double_col'] + 3,
+    )
+
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.only_on_backends([Pandas, PySpark])
+@pytest.mark.xfail_unsupported
+def test_invalid_kwargs(backend, alltypes):
+    # Test different invalid UDFs
+
+    with pytest.raises(TypeError, match=".*must be defined as keyword only.*"):
+
+        @elementwise(input_type=[dt.double], output_type=dt.double)
+        def foo1(v, amount):
+            return v + 1

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -5,8 +5,65 @@ Warning: This is an experimental module and API here can change without notice.
 DO NOT USE DIRECTLY.
 """
 
+import functools
+from inspect import Parameter, signature
+
 import ibis.expr.datatypes as dt
-from ibis.expr.operations import ElementWiseVectorizedUDF
+from ibis.expr.operations import (
+    AnalyticsVectorizedUDF,
+    ElementWiseVectorizedUDF,
+    ReductionVectorizedUDF,
+)
+
+
+def parameter_count(funcsig):
+    """Get the number of positional-or-keyword or position-only parameters in a
+    function signature.
+
+    Parameters
+    ----------
+    funcsig : inspect.Signature
+        A UDF signature
+
+    Returns
+    -------
+    int
+        The number of parameters
+    """
+    return sum(
+        param.kind in {param.POSITIONAL_OR_KEYWORD, param.POSITIONAL_ONLY}
+        for param in funcsig.parameters.values()
+        if param.default is Parameter.empty
+    )
+
+
+def valid_function_signature(input_type, func):
+    """Check that the declared number of inputs (the length of `input_type`)
+    and the number of inputs to `func` are equal.
+
+    Parameters
+    ----------
+    input_type : List[DataType]
+    func : callable
+
+    Returns
+    -------
+    inspect.Signature
+    """
+    funcsig = signature(func)
+    declared_parameter_count = len(input_type)
+    function_parameter_count = parameter_count(funcsig)
+
+    if declared_parameter_count != function_parameter_count:
+        raise TypeError(
+            'Function signature {!r} has {:d} parameters, '
+            'input_type has {:d}. These must match'.format(
+                func.__name__,
+                function_parameter_count,
+                declared_parameter_count,
+            )
+        )
+    return funcsig
 
 
 class UserDefinedFunction(object):
@@ -16,30 +73,52 @@ class UserDefinedFunction(object):
     """
 
     def __init__(self, func, func_type, input_type, output_type):
+        valid_function_signature(input_type, func)
+
         self.func = func
         self.func_type = func_type
         self.input_type = input_type
         self.output_type = output_type
 
     def __call__(self, *args, **kwargs):
+        # kwargs cannot be part of the node object because it can contain
+        # unhashable object, e.g., list.
+        # Here, we keep the node hashable by creating a closure that contains
+        # kwargs.
+        @functools.wraps(self.func)
+        def func(*args):
+            return self.func(*args, **kwargs)
+
         op = self.func_type(
-            func=self.func,
+            func=func,
             args=args,
             input_type=self.input_type,
             output_type=self.output_type,
         )
+
         return op.to_expr()
 
 
-def elementwise(input_type, output_type):
-    """ Element wise vectorized UDFs.
-    """
+def _udf_decorator(node_type, input_type, output_type):
     input_type = list(map(dt.dtype, input_type))
     output_type = dt.dtype(output_type)
 
     def wrapper(func):
-        return UserDefinedFunction(
-            func, ElementWiseVectorizedUDF, input_type, output_type
-        )
+        return UserDefinedFunction(func, node_type, input_type, output_type)
 
     return wrapper
+
+
+def analytics(input_type, output_type):
+    """ Reduction vectorized UDFs."""
+    return _udf_decorator(AnalyticsVectorizedUDF, input_type, output_type)
+
+
+def elementwise(input_type, output_type):
+    """ Element wise vectorized UDFs."""
+    return _udf_decorator(ElementWiseVectorizedUDF, input_type, output_type)
+
+
+def reduction(input_type, output_type):
+    """ Reduction vectorized UDFs."""
+    return _udf_decorator(ReductionVectorizedUDF, input_type, output_type)


### PR DESCRIPTION
This PR refactor `ibis.pandas.udf.reduction` and `ibis.pandas.udf.analytics` into `ibis.udf.vectorized`.

This is similar to the first vectorized UDF PR:
https://github.com/ibis-project/ibis/pull/2047

