### PR TITLE
CI: Running isort with the latest version to fix CI

### DIFF
--- a/ibis/filesystems.py
+++ b/ibis/filesystems.py
@@ -15,8 +15,9 @@
 # This file may adapt small portions of https://github.com/mtth/hdfs (MIT
 # license), see the LICENSES directory.
 
-import posixpath
 from functools import wraps as implements
+
+import posixpath
 
 import ibis.common.exceptions as com
 from ibis.config import options

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -6,11 +6,11 @@ import time
 import traceback
 import weakref
 from collections import deque
-from posixpath import join as pjoin
 
 import numpy as np
 import pandas as pd
 from pkg_resources import parse_version
+from posixpath import join as pjoin
 
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt

--- a/ibis/impala/pandas_interop.py
+++ b/ibis/impala/pandas_interop.py
@@ -14,6 +14,7 @@
 
 import csv
 import tempfile
+
 from posixpath import join as pjoin
 
 import ibis.common.exceptions as com

--- a/ibis/impala/tests/test_ddl.py
+++ b/ibis/impala/tests/test_ddl.py
@@ -1,6 +1,5 @@
-from posixpath import join as pjoin
-
 import pytest
+from posixpath import join as pjoin
 
 import ibis
 import ibis.common.exceptions as com

--- a/ibis/impala/tests/test_parquet_ddl.py
+++ b/ibis/impala/tests/test_parquet_ddl.py
@@ -1,6 +1,5 @@
-from posixpath import join as pjoin
-
 import pytest
+from posixpath import join as pjoin
 
 import ibis
 from ibis.tests.util import assert_equal

--- a/ibis/impala/tests/test_partition.py
+++ b/ibis/impala/tests/test_partition.py
@@ -1,8 +1,7 @@
-from posixpath import join as pjoin
-
 import pandas as pd
 import pytest
 from pandas.util.testing import assert_frame_equal
+from posixpath import join as pjoin
 
 import ibis
 import ibis.util as util

--- a/ibis/impala/tests/test_udf.py
+++ b/ibis/impala/tests/test_udf.py
@@ -1,10 +1,10 @@
 import unittest
 from decimal import Decimal
-from posixpath import join as pjoin
 
 import numpy as np
 import pandas as pd
 import pytest
+from posixpath import join as pjoin
 
 import ibis
 import ibis.common.exceptions as com

--- a/ibis/spark/tests/test_ddl.py
+++ b/ibis/spark/tests/test_ddl.py
@@ -1,7 +1,7 @@
 import os
-from posixpath import join as pjoin
 
 import pytest
+from posixpath import join as pjoin
 
 import ibis
 import ibis.common.exceptions as com

--- a/ibis/tests/test_filesystems.py
+++ b/ibis/tests/test_filesystems.py
@@ -3,9 +3,9 @@ import shutil
 import unittest
 from io import BytesIO
 from os import path as osp
-from posixpath import join as pjoin
 
 import pytest
+from posixpath import join as pjoin
 
 import ibis
 import ibis.util as util


### PR DESCRIPTION
I assume because a new version of isort, the CI is failing for wrong order of imports. I run the latest conda version of isort, and it made these changes.