### PR TITLE
BUG: Rename AnalyticsVectorizedUDF to AnalyticVectorizedUDF

### DIFF
--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -3515,7 +3515,7 @@ class ReductionVectorizedUDF(Reduction):
         return result
 
 
-class AnalyticsVectorizedUDF(AnalyticOp):
+class AnalyticVectorizedUDF(AnalyticOp):
     """Node for analytics UDF."""
 
     func = Arg(callable)

--- a/ibis/pandas/udf.py
+++ b/ibis/pandas/udf.py
@@ -208,11 +208,11 @@ def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
     return scope
 
 
-@pre_execute.register(ops.AnalyticsVectorizedUDF)
-@pre_execute.register(ops.AnalyticsVectorizedUDF, ibis.client.Client)
+@pre_execute.register(ops.AnalyticVectorizedUDF)
+@pre_execute.register(ops.AnalyticVectorizedUDF, ibis.client.Client)
 @pre_execute.register(ops.ReductionVectorizedUDF)
 @pre_execute.register(ops.ReductionVectorizedUDF, ibis.client.Client)
-def pre_execute_reduction_udf(op, *clients, scope=None, **kwargs):
+def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
     input_type = op.input_type
     nargs = len(input_type)
 

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -10,7 +10,7 @@ from inspect import Parameter, signature
 
 import ibis.expr.datatypes as dt
 from ibis.expr.operations import (
-    AnalyticsVectorizedUDF,
+    AnalyticVectorizedUDF,
     ElementWiseVectorizedUDF,
     ReductionVectorizedUDF,
 )
@@ -133,7 +133,7 @@ def analytic(input_type, output_type):
     ... def zscore(series):  # note the use of aggregate functions
     ...     return (series - series.mean()) / series.std()
     """
-    return _udf_decorator(AnalyticsVectorizedUDF, input_type, output_type)
+    return _udf_decorator(AnalyticVectorizedUDF, input_type, output_type)
 
 
 def elementwise(input_type, output_type):


### PR DESCRIPTION
This is a minor change about renaming. This was an over sight in https://github.com/ibis-project/ibis/pull/2210 that accidentally name 'analytic' to `analytics`. This PR fixes that.