### PR TITLE
BUG: PySpark compiler cannot compile elementwise UDF for some output types

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -11,6 +11,7 @@ Release Notes
 
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
+
 * :bug:`2223` Fix PySpark compiler error when elementwise UDF output_type is Decimal or Timestamp
 * :feature:`2186` ZeroIfNull and NullIfZero implementation for OmniSciDB  
 * :bug:`2157` Fix interactive mode returning a expression instead of the value when used in Jupyter

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -11,7 +11,7 @@ Release Notes
 
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
-
+* :bug:`2223` Fix PySpark compiler error when elementwise UDF output_type is Decimal or Timestamp
 * :feature:`2186` ZeroIfNull and NullIfZero implementation for OmniSciDB  
 * :bug:`2157` Fix interactive mode returning a expression instead of the value when used in Jupyter
 * :feature:`2093` IsNan implementation for OmniSciDB

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -17,6 +17,7 @@ from ibis.spark.compiler import SparkContext, SparkDialect
 from ibis.spark.datatypes import (
     ibis_array_dtype_to_spark_dtype,
     ibis_dtype_to_spark_dtype,
+    spark_dtype,
 )
 
 
@@ -1476,7 +1477,7 @@ def compile_not_null(t, expr, scope, **kwargs):
 @compiles(ops.ElementWiseVectorizedUDF)
 def compile_elementwise_udf(t, expr, scope):
     op = expr.op()
-    spark_output_type = ibis_dtype_to_spark_dtype(op._output_type)
+    spark_output_type = spark_dtype(op._output_type)
     spark_udf = pandas_udf(op.func, spark_output_type, PandasUDFType.SCALAR)
     func_args = (t.translate(arg, scope) for arg in op.func_args)
     return spark_udf(*func_args)

--- a/ibis/spark/datatypes.py
+++ b/ibis/spark/datatypes.py
@@ -19,6 +19,7 @@ _SPARK_DTYPE_TO_IBIS_DTYPE = {
     pt.IntegerType: dt.Int32,
     pt.LongType: dt.Int64,
     pt.ShortType: dt.Int16,
+    pt.TimestampType: dt.Timestamp,
 }
 
 
@@ -27,11 +28,6 @@ def spark_dtype_to_ibis_dtype(spark_dtype_obj, nullable=True):
     """Convert Spark SQL type objects to ibis type objects."""
     ibis_type_class = _SPARK_DTYPE_TO_IBIS_DTYPE.get(type(spark_dtype_obj))
     return ibis_type_class(nullable=nullable)
-
-
-@dt.dtype.register(pt.TimestampType)
-def spark_timestamp_dtype_to_ibis_dtype(spark_dtype_obj, nullable=True):
-    return dt.Timestamp(nullable=nullable)
 
 
 @dt.dtype.register(pt.DecimalType)
@@ -89,11 +85,6 @@ def from_spark_dtype(value: pt.DataType) -> pt.DataType:
 def ibis_dtype_to_spark_dtype(ibis_dtype_obj):
     """Convert ibis types types to Spark SQL."""
     return _IBIS_DTYPE_TO_SPARK_DTYPE.get(type(ibis_dtype_obj))()
-
-
-@spark_dtype.register(dt.Timestamp)
-def ibis_timestamp_dtype_to_spark_dtype(ibis_dtype_obj):
-    return dt.TimestampType()
 
 
 @spark_dtype.register(dt.Decimal)

--- a/ibis/spark/datatypes.py
+++ b/ibis/spark/datatypes.py
@@ -91,6 +91,11 @@ def ibis_dtype_to_spark_dtype(ibis_dtype_obj):
     return _IBIS_DTYPE_TO_SPARK_DTYPE.get(type(ibis_dtype_obj))()
 
 
+@spark_dtype.register(dt.Timestamp)
+def ibis_timestamp_dtype_to_spark_dtype(ibis_dtype_obj):
+    return dt.TimestampType()
+
+
 @spark_dtype.register(dt.Decimal)
 def ibis_decimal_dtype_to_spark_dtype(ibis_dtype_obj):
     precision = ibis_dtype_obj.precision


### PR DESCRIPTION
The PySpark compiler will raise a
```
TypeError: 'NoneType' object is not callable
```
when trying to compile a `ElementWiseVectorizedUDF` node whose `output_type` argument is not in [this list](https://github.com/timothydijamco/ibis/blob/f92adea724da4c6a1af3887a8e3e0ff407e497a7/ibis/spark/datatypes.py#L10) (e.g. `Decimal` and `TimestampType` is not in the list)

This PR:

- Have the PySpark compiler use a more general conversion function (`spark_dtype` instead of `ibis_dtype_to_spark_dtype`)
- Allow `spark_dtype` to convert an Ibis `TimestampType` to an Spark `TimestampType` (add another dispatch function to `spark_dtype`)