### PR TITLE
ENH: Add properly cume_dist and percent_rank ops

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -161,8 +161,10 @@ Column methods
    ColumnExpr.last
    ColumnExpr.dense_rank
    ColumnExpr.rank
+   ColumnExpr.percent_rank
    ColumnExpr.lag
    ColumnExpr.lead
+   ColumnExpr.cume_dist
    ColumnExpr.cummin
    ColumnExpr.cummax
 

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -56,6 +56,7 @@ Release Notes
 * :bug:`2127` Fix PySpark error when doing alias after selection
 * :support:`2244` Use an OmniSciDB image stable on CI
 * :feature:`2175` Create ExtractQuarter operation and add its support to Clickhouse, CSV, Impala, MySQL, OmniSciDB, Pandas, Parquet, PostgreSQL, PySpark, SQLite and Spark
+* :feature:`2224` Create CumeDist operation, fix PercentRank and add/fix their support to CSV, Impala, MySQL, OmniSciDB, Pandas, Parquet, PostgreSQL and SQLite
 * :feature:`2126` Add translation rules for isnull() and notnull() for pyspark backend
 * :feature:`2232` Add window operations support to SQLite
 * :feature:`2062` Implement read_csv for omniscidb backend

--- a/ibis/backends/base_sql/__init__.py
+++ b/ibis/backends/base_sql/__init__.py
@@ -1104,6 +1104,7 @@ operation_registry = {
     ops.DenseRank: lambda *args: 'dense_rank()',
     ops.MinRank: lambda *args: 'rank()',
     ops.PercentRank: lambda *args: 'percent_rank()',
+    ops.CumeDist: lambda *args: 'cume_dist()',
     ops.FirstValue: unary('first_value'),
     ops.LastValue: unary('last_value'),
     ops.NthValue: nth_value,

--- a/ibis/backends/base_sqlalchemy/alchemy.py
+++ b/ibis/backends/base_sqlalchemy/alchemy.py
@@ -606,6 +606,7 @@ def _window(t, expr):
         ops.MinRank,
         ops.NTile,
         ops.PercentRank,
+        ops.CumeDist,
     )
 
     if isinstance(window_op, ops.CumulativeOp):
@@ -634,6 +635,7 @@ def _window(t, expr):
         ops.MinRank,
         ops.NTile,
         ops.PercentRank,
+        ops.CumeDist,
         ops.RowNumber,
     )
 
@@ -780,6 +782,7 @@ _window_functions = {
     ops.DenseRank: unary(lambda arg: sa.func.dense_rank()),
     ops.MinRank: unary(lambda arg: sa.func.rank()),
     ops.PercentRank: unary(lambda arg: sa.func.percent_rank()),
+    ops.CumeDist: unary(lambda arg: sa.func.cume_dist()),
     ops.WindowOp: _window,
     ops.CumulativeOp: _window,
     ops.CumulativeMax: unary(sa.func.max),

--- a/ibis/backends/omniscidb/operations.py
+++ b/ibis/backends/omniscidb/operations.py
@@ -1101,9 +1101,8 @@ _window_ops = {
     ops.Lag: _shift_like('lag'),
     ops.Lead: _shift_like('lead', 1),
     ops.MinRank: lambda *args: 'rank()',
-    # cume_dist vs percent_rank
-    # https://github.com/ibis-project/ibis/issues/1975
-    ops.PercentRank: lambda *args: 'cume_dist()',
+    ops.PercentRank: lambda *args: 'percent_rank()',
+    ops.CumeDist: lambda *args: 'cume_dist()',
     ops.RowNumber: lambda *args: 'row_number()',
     ops.WindowOp: _window,
 }

--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -482,17 +482,24 @@ def execute_series_group_by_last_value(op, data, aggcontext=None, **kwargs):
 
 @execute_node.register(ops.MinRank, (pd.Series, SeriesGroupBy))
 def execute_series_min_rank(op, data, **kwargs):
-    # TODO(phillipc): Handle ORDER BY
     return data.rank(method='min', ascending=True).astype('int64') - 1
 
 
 @execute_node.register(ops.DenseRank, (pd.Series, SeriesGroupBy))
 def execute_series_dense_rank(op, data, **kwargs):
-    # TODO(phillipc): Handle ORDER BY
     return data.rank(method='dense', ascending=True).astype('int64') - 1
 
 
-@execute_node.register(ops.PercentRank, (pd.Series, SeriesGroupBy))
+@execute_node.register(ops.PercentRank, pd.Series)
 def execute_series_percent_rank(op, data, **kwargs):
-    # TODO(phillipc): Handle ORDER BY
+    return (data.rank(method='min') - 1) / (len(data) - 1)
+
+
+@execute_node.register(ops.PercentRank, SeriesGroupBy)
+def execute_series_group_by_percent_rank(op, data, **kwargs):
+    return (data.rank(method='min') - 1) / (data.transform(len) - 1)
+
+
+@execute_node.register(ops.CumeDist, (pd.Series, SeriesGroupBy))
+def execute_series_cume_dist(op, data, **kwargs):
     return data.rank(method='min', ascending=True, pct=True)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1175,6 +1175,15 @@ def compile_percent_rank(t, expr, scope, timecontext, **kwargs):
     )
 
 
+@compiles(ops.CumeDist)
+def compile_cume_dist(t, expr, scope, timecontext, **kwargs):
+    raise com.UnsupportedOperationError(
+        'Pyspark cume_dist() function indexes from 0 '
+        'instead of 1, and does not match expected '
+        'output of ibis expressions.'
+    )
+
+
 @compiles(ops.NTile)
 def compile_ntile(t, expr, scope, timecontext, **kwargs):
     op = expr.op()

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1135,6 +1135,7 @@ last = _unary_op('last', ops.LastValue)
 rank = _unary_op('rank', ops.MinRank)
 dense_rank = _unary_op('dense_rank', ops.DenseRank)
 percent_rank = _unary_op('percent_rank', ops.PercentRank)
+cume_dist = _unary_op('cume_dist', ops.CumeDist)
 cummin = _unary_op('cummin', ops.CumulativeMin)
 cummax = _unary_op('cummax', ops.CumulativeMax)
 
@@ -1276,6 +1277,7 @@ _generic_column_methods = dict(
     dense_rank=dense_rank,
     rank=rank,
     percent_rank=percent_rank,
+    cume_dist=cume_dist,
     # nth=nth,
     ntile=ntile,
     lag=lag,

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1215,7 +1215,8 @@ class CumeDist(AnalyticOp):
 
     CumeDist calculates the cumulative distribution of a value within a group
     of values. In other words, CumeDist calculates the relative position of a
-    specified value in a group of values.
+    specified value in a group of values. It can be expressed as:
+    ``CUME_DIST = RANK/COUNT``
 
     For more information, consider reading the following reference:
     https://docs.microsoft.com/en-us/sql/t-sql/functions/cume-dist-transact-sql
@@ -1226,6 +1227,18 @@ class CumeDist(AnalyticOp):
 
 
 class PercentRank(AnalyticOp):
+    """
+    The percent rank operation.
+
+    PercentRank calculates the relative rank of a row within a group of rows,
+    in other words, it evaluates the relative standing of a value within a
+    query result set or partition. It can be expressed as:
+    ``PERCENT_RANK = (RANK – 1)/(COUNT -1)``
+
+    For more information, consider reading the following reference:
+    https://docs.microsoft.com/en-us/sql/t-sql/functions/percent-rank-transact-sql
+    """
+
     arg = Arg(rlz.column(rlz.any))
     output_type = rlz.shape_like('arg', dt.double)
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1209,6 +1209,22 @@ class CumulativeMin(CumulativeOp):
     output_type = rlz.array_like('arg')
 
 
+class CumeDist(AnalyticOp):
+    """
+    The cumulative distribution operation.
+
+    CumeDist calculates the cumulative distribution of a value within a group
+    of values. In other words, CumeDist calculates the relative position of a
+    specified value in a group of values.
+
+    For more information, consider reading the following reference:
+    https://docs.microsoft.com/en-us/sql/t-sql/functions/cume-dist-transact-sql
+    """
+
+    arg = Arg(rlz.column(rlz.any))
+    output_type = rlz.shape_like('arg', dt.double)
+
+
 class PercentRank(AnalyticOp):
     arg = Arg(rlz.column(rlz.any))
     output_type = rlz.shape_like('arg', dt.double)

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -54,18 +54,16 @@ def calc_zscore(s):
             id='dense_rank',
         ),
         param(
-            # these can't be equivalent, because pandas doesn't have a way to
-            # compute percentile rank with a strict less-than ordering
-            #
-            # cume_dist() is the corresponding function in databases that
-            # support window functions
             lambda t, win: t.id.percent_rank().over(win),
-            lambda t: t.id.rank(pct=True),
-            id='percent_rank',
-            marks=pytest.mark.xpass_backends(
-                [Csv, Pandas, Parquet, PySpark, OmniSciDB],
-                raises=AssertionError,
+            lambda t: (
+                (t.id.rank(method='min') - 1) / (t.id.transform(len) - 1)
             ),
+            id='percent_rank',
+        ),
+        param(
+            lambda t, win: t.id.cume_dist().over(win),
+            lambda t: t.id.rank(method='min') / t.id.transform(len),
+            id='cume_dist',
         ),
         param(
             lambda t, win: t.float_col.ntile(buckets=7).over(win),

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -372,7 +372,7 @@ class OmniSciDB(Backend, RoundAwayFromZero):
 class MySQL(Backend, RoundHalfToEven):
     # mysql has the same rounding behavior as postgres
     check_dtype = False
-    supports_window_operations = False
+    supports_window_operations = True
     returned_timestamp_unit = 's'
 
     def __init__(self, data_directory: Path) -> None:


### PR DESCRIPTION
This PR aims to resolve the confusion between cume_dist and percent_rank.

This gist shows the difference between both functions: https://gist.github.com/xmnlab/d676ff1b0ff474c634d62010ebca8b07 

depends on #2228  #2232 

resolve #949 
resolve #1975 