### PR TITLE
BUG: Fix Makefile targets for running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ test: init
 		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) ${PYTEST_MARKERS} -k 'not test_import_time'"
 
 testnoinit:
+	# Same as make test, but does not run init first
 	$(DOCKER_RUN) -e PYTHONHASHSEED="$(PYTHONHASHSEED)" ibis bash -c "${REMOVE_COMPILED_PYTHON_SCRIPTS} && \
 		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) ${PYTEST_MARKERS} -k 'not test_import_time'"
 
@@ -136,6 +137,7 @@ testparallel: init
 		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) ${PYTEST_MARKERS} -n auto -k 'not test_import_time'"
 
 testparallelnoinit:
+	# Same as make testparallel, but does not run init first
 	$(DOCKER_RUN) -e PYTHONHASHSEED="$(PYTHONHASHSEED)" ibis bash -c "${REMOVE_COMPILED_PYTHON_SCRIPTS} && \
 		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) ${PYTEST_MARKERS} -n auto -k 'not test_import_time'"
 

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,11 @@ init: restart
 	$(MAKE) build
 	$(MAKE) load
 
-# Targets for testing ibis inside docker's containers
+# Targets for running backend specific Ibis tests inside docker's containers
+# BACKENDS can be set to choose which tests should be run:
+#   make --directory ibis testparallel BACKENDS='omniscidb impala'
 
 test: init
-	# use this target to run backend specific tests
 	$(DOCKER_RUN) -e PYTHONHASHSEED="$(PYTHONHASHSEED)" ibis bash -c "${REMOVE_COMPILED_PYTHON_SCRIPTS} && \
 		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) ${PYTEST_MARKERS} -k 'not test_import_time'"
 
@@ -130,12 +131,7 @@ testnoinit:
 	$(DOCKER_RUN) -e PYTHONHASHSEED="$(PYTHONHASHSEED)" ibis bash -c "${REMOVE_COMPILED_PYTHON_SCRIPTS} && \
 		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) ${PYTEST_MARKERS} -k 'not test_import_time'"
 
-testall:
-	$(DOCKER_RUN) -e PYTHONHASHSEED="$(PYTHONHASHSEED)" ibis bash -c "${REMOVE_COMPILED_PYTHON_SCRIPTS} && \
-		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) -k 'not test_import_time'"
-
 testparallel: init
-	# use this target to run backend specific tests in parallel
 	$(DOCKER_RUN) -e PYTHONHASHSEED="$(PYTHONHASHSEED)" ibis bash -c "${REMOVE_COMPILED_PYTHON_SCRIPTS} && \
 		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) ${PYTEST_MARKERS} -n auto -k 'not test_import_time'"
 
@@ -143,9 +139,13 @@ testparallelnoinit:
 	$(DOCKER_RUN) -e PYTHONHASHSEED="$(PYTHONHASHSEED)" ibis bash -c "${REMOVE_COMPILED_PYTHON_SCRIPTS} && \
 		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) ${PYTEST_MARKERS} -n auto -k 'not test_import_time'"
 
-testparallelall: init
-	$(DOCKER_RUN) -e PYTHONHASHSEED="$(PYTHONHASHSEED)" ibis bash -c "${REMOVE_COMPILED_PYTHON_SCRIPTS} && \
-		pytest $(PYTEST_DOCTEST_OPTIONS) $(PYTEST_OPTIONS) -m 'not udf' -n auto -k 'not test_import_time'"
+# Shortcut targets for running a subset of the Ibis tests inside docker's containers
+
+testall:
+	@echo "You should use make testmain instead"
+
+testmain:
+	$(MAKE) testparallelnoinit REQUIREMENTS_TAG="main" PYTEST_MARKERS="-m 'not (udf or spark or pyspark)'"
 
 testmost:
 	$(MAKE) testparallelnoinit REQUIREMENTS_TAG="main" PYTEST_MARKERS="-m 'not (udf or impala or hdfs or spark or pyspark)'"
@@ -156,7 +156,7 @@ testfast:
 testpandas:
 	$(MAKE) testparallelnoinit REQUIREMENTS_TAG="main" PYTEST_MARKERS="-m pandas"
 
-testspark:
+testpyspark:
 	$(MAKE) testparallelnoinit REQUIREMENTS_TAG="pyspark-spark" PYTEST_MARKERS="-m pyspark"
 
 fastopt:

--- a/docs/web/contribute.md
+++ b/docs/web/contribute.md
@@ -45,20 +45,29 @@ rough steps on how to get things set up:
 - Be sure to follow the [post-install instructions](https://docs.docker.com/install/linux/linux-postinstall/) if you are running on Linux.
 - Log in to your Docker hub account with ``docker login`` (create an account at <https://hub.docker.com/> if you don't have one).
 
-Here are the steps to start database services and run the test suite:
+First, start the database services and load the test data:
 
 ```sh
 make --directory ibis init
-make --directory ibis testall
 ```
 
-Also you can run tests for a specific backend:
+To run tests for all backends except PySpark and Spark:
+```sh
+make --directory ibis testmain
+```
+
+To run tests for the PySpark backend:
+```sh
+make --directory ibis testpyspark
+```
+
+You can run tests for a custom subset of backends:
 
 ```sh
 make --directory ibis testparallel BACKENDS='omniscidb impala'
 ```
 
-or start database services for a specific backend:
+or start database services for a specific subset of backends:
 
 ```sh
 make --directory ibis init BACKENDS='omniscidb impala'


### PR DESCRIPTION
The Makefile target `testspark` broke after #2216. `testspark` tries to use the main requirements file (which no longer has PySpark/Spark dependencies) for building the `ibis` docker image.

**This PR changes `testspark` to use the requirements file for PySpark/Spark.** To keep the Makefile consistent, I also refactored other `test...` targets further.

The diff is confusing, so here's a list of changes:

### Changes

1. Add `testnoinit` and `testparallelnoinit`. These are the same as `test` and `testparallel`, except that they do not run `init` before running the tests.

2. Change `testmost`, `testfast`, `testpandas`, `testspark` to simply run `make testparallelnoinit` (passing in which requirements file should be used and which pytest markers should be tested) Example:
```
testspark:
	$(MAKE) testparallelnoinit REQUIREMENTS_TAG="pyspark-spark" PYTEST_MARKERS="-m pyspark"
```

3. Split `testparallel` into `testparallel` and `testparallelall` to be consistent with the existing `test` and `testall` targets