### PR TITLE
FEAT: Implement two level dispatcher for execute_node

### DIFF
--- a/ci/azure/windows.yml
+++ b/ci/azure/windows.yml
@@ -56,6 +56,7 @@ jobs:
         call activate $(conda.env)
         pip install --upgrade "pytest>=4.5"
         pip install --upgrade pytest-xdist
+        pip install --upgrade pytest-mock
       displayName: 'Install latest pytest'
 
     - script: conda info

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2246` Implement two level dispatcher for execute_node
 * :bug:`2229` Fix same column with multiple aliases not showing properly in repr
 * :feature:`2233` Add ibis.pandas.trace module to log time and call stack information.
 * :feature:`2198` Validate that the output type of a UDF is a single element

--- a/ibis/pandas/api.py
+++ b/ibis/pandas/api.py
@@ -4,7 +4,7 @@ import toolz
 
 import ibis
 from ibis.pandas.client import PandasClient
-from ibis.pandas.execution import execute
+from ibis.pandas.execution import execute, execute_node
 from ibis.pandas.udf import udf
 
 __all__ = ('connect', 'dialect', 'execute', 'udf')
@@ -70,16 +70,11 @@ class PandasExprTranslator:
     # get the dispatched functions from the execute_node dispatcher and compute
     # and flatten the type tree of the first argument which is always the Node
     # subclass
-    # import pdb; pdb.set_trace()
-
-    _registry = {}
-
-    # _registry = frozenset(
-    #    toolz.concat(
-    #        _flatten_subclass_tree(types[0]) for types in execute_node.funcs
-    #    )
-    # )
-
+    _registry = frozenset(
+        toolz.concat(
+            _flatten_subclass_tree(types[0]) for types in execute_node.funcs
+        )
+    )
     _rewrites = {}
 
 

--- a/ibis/pandas/api.py
+++ b/ibis/pandas/api.py
@@ -4,7 +4,7 @@ import toolz
 
 import ibis
 from ibis.pandas.client import PandasClient
-from ibis.pandas.execution import execute, execute_node
+from ibis.pandas.execution import execute
 from ibis.pandas.udf import udf
 
 __all__ = ('connect', 'dialect', 'execute', 'udf')
@@ -70,11 +70,16 @@ class PandasExprTranslator:
     # get the dispatched functions from the execute_node dispatcher and compute
     # and flatten the type tree of the first argument which is always the Node
     # subclass
-    _registry = frozenset(
-        toolz.concat(
-            _flatten_subclass_tree(types[0]) for types in execute_node.funcs
-        )
-    )
+    # import pdb; pdb.set_trace()
+
+    _registry = {}
+
+    # _registry = frozenset(
+    #    toolz.concat(
+    #        _flatten_subclass_tree(types[0]) for types in execute_node.funcs
+    #    )
+    # )
+
     _rewrites = {}
 
 

--- a/ibis/pandas/dispatch.py
+++ b/ibis/pandas/dispatch.py
@@ -8,10 +8,10 @@ from multipledispatch import Dispatcher
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
-from ibis.pandas.dispatcher import TwoLevelDispatcher
+from ibis.pandas.trace import TraceTwoLevelDispatcher
 
 # Individual operation execution
-execute_node = TwoLevelDispatcher(
+execute_node = TraceTwoLevelDispatcher(
     'execute_node',
     doc=(
         'Execute an individual operation given the operation and its computed '

--- a/ibis/pandas/dispatch.py
+++ b/ibis/pandas/dispatch.py
@@ -8,16 +8,9 @@ from multipledispatch import Dispatcher
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
-from ibis.pandas.trace import TraceDispatcher
+from ibis.pandas.dispatcher import TwoLevelDispatcher
 
-# Individual operation execution
-execute_node = TraceDispatcher(
-    'execute_node',
-    doc=(
-        'Execute an individual operation given the operation and its computed '
-        'arguments'
-    ),
-)
+execute_node = TwoLevelDispatcher('execute_node')
 
 
 @execute_node.register(ops.Node)

--- a/ibis/pandas/dispatch.py
+++ b/ibis/pandas/dispatch.py
@@ -10,7 +10,14 @@ import ibis.common.exceptions as com
 import ibis.expr.operations as ops
 from ibis.pandas.dispatcher import TwoLevelDispatcher
 
-execute_node = TwoLevelDispatcher('execute_node')
+# Individual operation execution
+execute_node = TwoLevelDispatcher(
+    'execute_node',
+    doc=(
+        'Execute an individual operation given the operation and its computed '
+        'arguments'
+    ),
+)
 
 
 @execute_node.register(ops.Node)

--- a/ibis/pandas/dispatcher.py
+++ b/ibis/pandas/dispatcher.py
@@ -15,7 +15,7 @@ class TwoLevelDispatcher(Dispatcher):
     O(1000), and the max number of signatures for the meta dispatcher and
     second level dispatcher is O(100)), the overall dispatch_iter is faster.
 
-     This implementation consist of three Dispatcher instance:
+    This implementation consist of three Dispatcher instance:
 
     (1) This dispatcher, or the instance of this class itself. This class
     inherits Dispatcher to avoid duplicating __call__, cache, ambiguities

--- a/ibis/pandas/dispatcher.py
+++ b/ibis/pandas/dispatcher.py
@@ -21,7 +21,7 @@ class TwoLevelDispatcher(Dispatcher):
     inherits Dispatcher to avoid duplicating __call__, cache, ambiguities
     detection, as well as properties like ordering and funcs.
 
-    (2) First level dispatcher, aka, Meta dispatcher. This is the dispatcher
+    (2) First level dispatcher, aka, meta dispatcher. This is the dispatcher
     is used to dispatch to the second level dispatcher using the type of the
     first arg.
 
@@ -56,8 +56,8 @@ class TwoLevelDispatcher(Dispatcher):
     Because this dispatcher has the same func and ordering property as
     multipledispatch.Dispatcher. We can completely reuse the ambiguity
     detection logic of Dispatcher. Note:
-    (a) we never actually linear search through ordering of this dispatcher.
-    It's only used for ambiguity detection, which is called only once.
+    (a) we never actually linear search through ordering of this dispatcher
+    for dispatching. It's only used for ambiguity detection.
     (b) deleting an entry from func of this dispatcher (i.e. del
     dispatcher.func[A, B]) does not unregister it. Entries from the second
     level dispatcher also needs to be deleted. This is OK because it is not

--- a/ibis/pandas/dispatcher.py
+++ b/ibis/pandas/dispatcher.py
@@ -103,12 +103,6 @@ class TwoLevelDispatcher(Dispatcher):
         return _
 
     def dispatch_iter(self, *types):
-        # Trigger initializatin of ordering to defect ambiguities
-        # This follows the same behavior of Dispatcher where
-        # ordering is intialized when dispatcher_iter is called
-        # for the first time
-        self.ordering
-
         for dispatcher in self._meta_dispatcher.dispatch_iter(types[0]):
             func = dispatcher.dispatch(*types)
             if func is not None:

--- a/ibis/pandas/dispatcher.py
+++ b/ibis/pandas/dispatcher.py
@@ -100,6 +100,12 @@ class TwoLevelDispatcher(Dispatcher):
 
         return _
 
+    def __delitem__(self, types):
+        del self.funcs[types]
+        del self._meta_dispatcher.funcs[types[:1]].funcs[types]
+        if not self._meta_dispatcher.funcs[types[:1]].funcs:
+            del self._meta_dispatcher.funcs[types[1:]]
+
     def dispatch_iter(self, *types):
         for dispatcher in self._meta_dispatcher.dispatch_iter(types[0]):
             func = dispatcher.dispatch(*types)

--- a/ibis/pandas/dispatcher.py
+++ b/ibis/pandas/dispatcher.py
@@ -54,18 +54,3 @@ class TwoLevelDispatcher(Dispatcher):
             return func
         except StopIteration:
             return None
-
-    # def __call__(self, *args, **kwargs):
-    #     types = tuple(type(arg) for arg in args)
-
-    #     try:
-    #         func = self._cache[types]
-    #     except KeyError:
-    #         func = self.dispatch(*types)
-    #         if not func:
-    #             raise NotImplementedError(
-    #                 'Could not find signature for %s: <%s>' %
-    #                 (self.name, str_signature(types)))
-    #         self._cache[types] = func
-
-    #     return func(*args, **kwargs)

--- a/ibis/pandas/dispatcher.py
+++ b/ibis/pandas/dispatcher.py
@@ -1,0 +1,58 @@
+from multipledispatch import Dispatcher
+
+
+def _create_dispatcher_func(dispatcher):
+    return lambda _: dispatcher
+
+
+def _create_register_func(dispatcher_funcs, types, **kwargs):
+    def _(func):
+
+        # if len(dispatcher_funcs) == 3:
+        # import pdb; pdb.set_trace()
+
+        for dispatcher_func in dispatcher_funcs:
+            dispatcher_func(None).add(types, func, **kwargs)
+
+        return func
+
+    return _
+
+
+class TwoLevelDispatcher(object):
+    """A faster implementation of Dispatch."""
+
+    def __init__(self, name, doc=None):
+        self.name = self.__name__ = name
+        self.doc = doc
+        # The return value of _first_level_dispatcher(arg0) is a single arg
+        # function that returns the dispatcher for type(arg0).
+        self._meta_dispatcher = Dispatcher(f'{name}_meta')
+
+    def register(self, *types, **kwargs):
+        type0 = types[0]
+
+        if isinstance(type0, type):
+            type0 = [type0]
+
+        dispatcher_funcs = []
+
+        for t in type0:
+            if (t,) in self._meta_dispatcher.funcs:
+                dispatcher_func = self._meta_dispatcher.funcs[(t,)]
+            else:
+                # if t.__name__ == 'Add':
+                #    import pdb; pdb.set_trace()
+
+                dispatcher_func = _create_dispatcher_func(
+                    Dispatcher(f"{self.name}_{t.__name__}")
+                )
+                self._meta_dispatcher.register(t)(dispatcher_func)
+
+            dispatcher_funcs.append(dispatcher_func)
+
+        return _create_register_func(dispatcher_funcs, types, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        dispatcher = self._meta_dispatcher(args[0])
+        return dispatcher(*args, **kwargs)

--- a/ibis/pandas/dispatcher.py
+++ b/ibis/pandas/dispatcher.py
@@ -1,23 +1,80 @@
 from multipledispatch import Dispatcher
 
 
-def _create_register_func(dispatcher_funcs, types, **kwargs):
-    def _(func):
-        for dispatcher_func in dispatcher_funcs:
-            dispatcher_func.add(types, func, **kwargs)
-
-        return func
-
-    return _
-
-
 class TwoLevelDispatcher(Dispatcher):
-    """A faster implementation of Dispatch."""
+    """An implementation of multipledispatch.Dispatcher that utilizes two
+    levels of dispatching.
+
+    Using two level of dispatching speeds up the time
+    to perform linear search of matched function. If n is the number of
+    registered types for the first arg and m is the number of registered types
+    for the rest of the arguments. The time complexity of finding the first
+    match is O(n + m) with this implementaion, and O(n*m) with the multiple
+    dispatch.Dispatcher implementaion.
+
+    The first level (meta dispatcher), dispatches to the second level
+    dispatcher on the first argument.
+
+    The second level, dispatches to the function on args.
+
+    This implementation consist of three Dispatcher instance:
+
+    (1) This dispatcher, or the instance of this class itself. This class
+    inherits Dispatcher to avoid duplicating __call__, cache, ambiguities
+    detection, as well as properties like ordering and funcs.
+
+    (2) First level dispatcher, aka, Meta dispatcher. This is the dispatcher
+    is used to dispatch to the second level dispatcher using the type of the
+    first arg.
+
+    (3) Second level dispatcher. This is the actual dispatcher used for linear
+    searching of matched function given type of args.
+
+    Implementation notes:
+
+    (1) register:
+    This method will now (a) create the second level dispatcher
+    if missing and register it with the meta dispatcher. (b) return a function
+    decorator that will register with all the second level dispatcher. Note
+    that multiple second level dispatcher could be registered with because this
+    is supported:
+
+        @foo.register((C1, C2), ...)
+
+    The decorator will also register with this dispatcher so that func and
+    ordering works properly.
+
+    (2) dispatcher_iter:
+    Instead of searching through self.ordering, this method now searches
+    through:
+    (a) dispatch_iter of the meta dispatcher (to find matching second level
+    dispatcher).
+    (b) for each second level dispatcher, searches through its dispatch_iter.
+    Because dispatch_iter of meta dispatcher and second level dispatcher
+    searches through registered functions in proper order (from subclasses to
+    base classes).
+    The overall search also searches through all registered functions in proper
+    order.
+
+    (3) ambiguity detection, ordering, and funcs:
+    Because this dispatcher has the same func and ordering property as
+    multipledispatch.Dispatcher. We can completely reuse the ambiguity
+    detection logic of Dispatcher. Note:
+    (a) we never actually linear search through ordering of this dispatcher.
+    It's only used for ambiguity detection, which is called only once.
+    (b) deleting an entry from func of this dispatcher (i.e. del
+    dispatcher.func[A, B]) does not unregister it. Entries from the second
+    level dispatcher also needs to be deleted. This is OK because it is not
+    public API.
+
+    Performance:
+    A performance comparison using execute_node in ibis.pandas is under
+    xxx(TODO).
+
+    """
 
     def __init__(self, name, doc=None):
         super().__init__(name, doc)
-        # The return value of _first_level_dispatcher(arg0) is a single arg
-        # function that returns the dispatcher for type(arg0).
         self._meta_dispatcher = Dispatcher(f'{name}_meta')
 
     def register(self, *types, **kwargs):
@@ -26,31 +83,33 @@ class TwoLevelDispatcher(Dispatcher):
         if isinstance(type0, type):
             type0 = [type0]
 
-        dispatcher_funcs = []
+        dispatchers = []
 
         for t in type0:
             if (t,) in self._meta_dispatcher.funcs:
-                dispatcher_func = self._meta_dispatcher.funcs[(t,)]
+                dispatcher = self._meta_dispatcher.funcs[(t,)]
             else:
-                # dispatcher_func = _create_dispatcher_func(
-                # )
-                dispatcher_func = Dispatcher(f"{self.name}_{t.__name__}")
+                dispatcher = Dispatcher(f"{self.name}_{t.__name__}")
+                self._meta_dispatcher.register(t)(dispatcher)
 
-                self._meta_dispatcher.register(t)(dispatcher_func)
+            dispatchers.append((t, dispatcher))
 
-            dispatcher_funcs.append(dispatcher_func)
+        def _(func):
+            self.add(types, func, **kwargs)
+            for t, dispatcher in dispatchers:
+                dispatcher.add(tuple([t, *types[1:]]), func, **kwargs)
+            return func
 
-        return _create_register_func(dispatcher_funcs, types, **kwargs)
+        return _
 
     def dispatch_iter(self, *types):
-        for dispatcher_func in self._meta_dispatcher.dispatch_iter(types[0]):
-            func = dispatcher_func.dispatch(*types)
+        # Trigger initializatin of ordering to defect ambiguities
+        # This follows the same behavior of Dispatcher where
+        # ordering is intialized when dispatcher_iter is called
+        # for the first time
+        self.ordering
+
+        for dispatcher in self._meta_dispatcher.dispatch_iter(types[0]):
+            func = dispatcher.dispatch(*types)
             if func is not None:
                 yield func
-
-    def dispatch(self, *types):
-        try:
-            func = next(self.dispatch_iter(*types))
-            return func
-        except StopIteration:
-            return None

--- a/ibis/pandas/dispatcher.py
+++ b/ibis/pandas/dispatcher.py
@@ -1,26 +1,21 @@
 from multipledispatch import Dispatcher
 
 
-def _create_dispatcher_func(dispatcher):
-    return lambda _: dispatcher
-
-
 def _create_register_func(dispatcher_funcs, types, **kwargs):
     def _(func):
         for dispatcher_func in dispatcher_funcs:
-            dispatcher_func(None).add(types, func, **kwargs)
+            dispatcher_func.add(types, func, **kwargs)
 
         return func
 
     return _
 
 
-class TwoLevelDispatcher(object):
+class TwoLevelDispatcher(Dispatcher):
     """A faster implementation of Dispatch."""
 
     def __init__(self, name, doc=None):
-        self.name = self.__name__ = name
-        self.doc = doc
+        super().__init__(name, doc)
         # The return value of _first_level_dispatcher(arg0) is a single arg
         # function that returns the dispatcher for type(arg0).
         self._meta_dispatcher = Dispatcher(f'{name}_meta')
@@ -37,15 +32,40 @@ class TwoLevelDispatcher(object):
             if (t,) in self._meta_dispatcher.funcs:
                 dispatcher_func = self._meta_dispatcher.funcs[(t,)]
             else:
-                dispatcher_func = _create_dispatcher_func(
-                    Dispatcher(f"{self.name}_{t.__name__}")
-                )
+                # dispatcher_func = _create_dispatcher_func(
+                # )
+                dispatcher_func = Dispatcher(f"{self.name}_{t.__name__}")
+
                 self._meta_dispatcher.register(t)(dispatcher_func)
 
             dispatcher_funcs.append(dispatcher_func)
 
         return _create_register_func(dispatcher_funcs, types, **kwargs)
 
-    def __call__(self, *args, **kwargs):
-        dispatcher = self._meta_dispatcher(args[0])
-        return dispatcher(*args, **kwargs)
+    def dispatch_iter(self, *types):
+        for dispatcher_func in self._meta_dispatcher.dispatch_iter(types[0]):
+            func = dispatcher_func.dispatch(*types)
+            if func is not None:
+                yield func
+
+    def dispatch(self, *types):
+        try:
+            func = next(self.dispatch_iter(*types))
+            return func
+        except StopIteration:
+            return None
+
+    # def __call__(self, *args, **kwargs):
+    #     types = tuple(type(arg) for arg in args)
+
+    #     try:
+    #         func = self._cache[types]
+    #     except KeyError:
+    #         func = self.dispatch(*types)
+    #         if not func:
+    #             raise NotImplementedError(
+    #                 'Could not find signature for %s: <%s>' %
+    #                 (self.name, str_signature(types)))
+    #         self._cache[types] = func
+
+    #     return func(*args, **kwargs)

--- a/ibis/pandas/dispatcher.py
+++ b/ibis/pandas/dispatcher.py
@@ -7,10 +7,6 @@ def _create_dispatcher_func(dispatcher):
 
 def _create_register_func(dispatcher_funcs, types, **kwargs):
     def _(func):
-
-        # if len(dispatcher_funcs) == 3:
-        # import pdb; pdb.set_trace()
-
         for dispatcher_func in dispatcher_funcs:
             dispatcher_func(None).add(types, func, **kwargs)
 
@@ -41,9 +37,6 @@ class TwoLevelDispatcher(object):
             if (t,) in self._meta_dispatcher.funcs:
                 dispatcher_func = self._meta_dispatcher.funcs[(t,)]
             else:
-                # if t.__name__ == 'Add':
-                #    import pdb; pdb.set_trace()
-
                 dispatcher_func = _create_dispatcher_func(
                     Dispatcher(f"{self.name}_{t.__name__}")
                 )

--- a/ibis/pandas/tests/test_core.py
+++ b/ibis/pandas/tests/test_core.py
@@ -173,12 +173,7 @@ def test_is_computable_input():
     result = ibis.pandas.execute(four)
     assert result == 4.0
 
-    # Since execute_node is two level dispatcher, we need to delete it
-    # in multiple places
-    del execute_node.funcs[ops.Add, int, MyObject]
-    del execute_node._meta_dispatcher.funcs[(ops.Add,)].funcs[
-        ops.Add, int, MyObject
-    ]
+    del execute_node[ops.Add, int, MyObject]
 
     execute_node.reorder()
     execute_node._cache.clear()

--- a/ibis/pandas/tests/test_core.py
+++ b/ibis/pandas/tests/test_core.py
@@ -103,7 +103,7 @@ def test_missing_data_on_custom_client():
     with pytest.raises(
         NotImplementedError,
         match=(
-            'Could not find signature for execute_node: '
+            'Could not find signature for execute_node_Node: '
             '<DatabaseTable, MyClient>'
         ),
     ):

--- a/ibis/pandas/tests/test_core.py
+++ b/ibis/pandas/tests/test_core.py
@@ -173,7 +173,13 @@ def test_is_computable_input():
     result = ibis.pandas.execute(four)
     assert result == 4.0
 
+    # Since execute_node is two level dispatcher, we need to delete it
+    # in multiple places
     del execute_node.funcs[ops.Add, int, MyObject]
+    del execute_node._meta_dispatcher.funcs[(ops.Add,)].funcs[
+        ops.Add, int, MyObject
+    ]
+
     execute_node.reorder()
     execute_node._cache.clear()
 

--- a/ibis/pandas/tests/test_core.py
+++ b/ibis/pandas/tests/test_core.py
@@ -103,7 +103,7 @@ def test_missing_data_on_custom_client():
     with pytest.raises(
         NotImplementedError,
         match=(
-            'Could not find signature for execute_node_Node: '
+            'Could not find signature for execute_node: '
             '<DatabaseTable, MyClient>'
         ),
     ):

--- a/ibis/pandas/tests/test_dispatcher.py
+++ b/ibis/pandas/tests/test_dispatcher.py
@@ -151,7 +151,7 @@ def test_ambiguities_warning():
     bar.register(A2, B1)(lambda a, b: 2)
 
     with pytest.warns(AmbiguityWarning, match=".*Consider.*\n\n.*(A2, B2).*"):
-        bar(A2(), B2())
+        bar.reorder()
 
 
 def test_ambiguities_no_warning():
@@ -163,6 +163,6 @@ def test_ambiguities_no_warning():
     bar.register(A2, B2)(lambda a, b: 3)
 
     with pytest.warns(None) as warnings:
-        bar(A2(), B2())
+        bar.reorder()
 
     assert len(warnings) == 0

--- a/ibis/pandas/tests/test_dispatcher.py
+++ b/ibis/pandas/tests/test_dispatcher.py
@@ -1,39 +1,168 @@
 import pytest
+from multipledispatch import Dispatcher
+from multipledispatch.conflict import AmbiguityWarning
 
 from ibis.pandas.dispatcher import TwoLevelDispatcher
 
 
-@pytest.fixture
-def foo():
-    dispatcher = TwoLevelDispatcher('foo', 'test_dispatcher')
+class A1(object):
+    pass
 
-    @dispatcher.register(int, int)
+
+class A2(A1):
+    pass
+
+
+class A3(A2):
+    pass
+
+
+class B1(object):
+    pass
+
+
+class B2(B1):
+    pass
+
+
+class B3(B2):
+    pass
+
+
+@pytest.fixture(scope='module')
+def foo_dispatchers():
+
+    foo = TwoLevelDispatcher('foo', doc='Test dispatcher foo')
+    foo_m = Dispatcher('foo_m', doc='Control dispatcher foo_m')
+
+    @foo.register(A1, B1)
+    @foo_m.register(A1, B1)
     def foo0(x, y):
         return 0
 
-    @dispatcher.register(int, float)
+    @foo.register(A1, B2)
+    @foo_m.register(A1, B2)
     def foo1(x, y):
         return 1
 
-    @dispatcher.register(float, int)
+    @foo.register(A2, B1)
+    @foo_m.register(A2, B1)
     def foo2(x, y):
         return 2
 
-    @dispatcher.register(float, float)
+    @foo.register(A2, B2)
+    @foo_m.register(A2, B2)
     def foo3(x, y):
         return 3
 
-    @dispatcher.register((list, tuple),)
+    @foo.register((A1, A2),)
+    @foo_m.register((A1, A2),)
     def foo4(x):
         return 4
 
-    return dispatcher
+    return foo, foo_m
 
 
-def test_basic(foo):
-    assert foo(0, 0) == 0
-    assert foo(0, 0.0) == 1
-    assert foo(0.0, 0) == 2
-    assert foo(0.0, 0.0) == 3
-    assert foo(list()) == 4
-    assert foo(tuple()) == 4
+@pytest.fixture(scope='module')
+def foo(foo_dispatchers):
+    return foo_dispatchers[0]
+
+
+@pytest.fixture(scope='module')
+def foo_m(foo_dispatchers):
+    return foo_dispatchers[1]
+
+
+def test_cache(foo, mocker):
+    """Test that cache is properly set after calling with args."""
+
+    spy = mocker.spy(foo, 'dispatch')
+    a1, b1 = A1(), B1()
+
+    assert (A1, B1) not in foo._cache
+    foo(a1, b1)
+    assert (A1, B1) in foo._cache
+    foo(a1, b1)
+    spy.assert_called_once_with(A1, B1)
+
+
+def test_dispatch(foo, mocker):
+    """Test that calling dispatcher with a signature that is registered
+    does not trigger a linear search through dispatch_iter."""
+
+    spy = mocker.spy(foo, 'dispatch_iter')
+
+    # This should not trigger a linear search
+    foo(A1(), B1())
+    assert not spy.called, (
+        "Calling dispatcher with registered signature should "
+        "not trigger linear search"
+    )
+
+    foo(A3(), B3())
+    spy.assert_called_once_with(A3, B3)
+
+
+@pytest.mark.parametrize(
+    'args',
+    [
+        (A1(), B1()),
+        (A1(), B2()),
+        (A1(), B3()),
+        (A2(), B1()),
+        (A2(), B2()),
+        (A2(), B3()),
+        (A3(), B1()),
+        (A3(), B2()),
+        (A3(), B3()),
+        (A1(),),
+        (A2(),),
+        (A3(),),
+    ],
+)
+def test_registered(foo_dispatchers, args):
+    foo, foo_m = foo_dispatchers
+    assert foo(*args) == foo_m(*args)
+
+
+def test_ordering(foo, foo_m):
+    assert foo.ordering == foo_m.ordering
+
+
+def test_funcs(foo, foo_m):
+    assert foo.funcs == foo_m.funcs
+
+
+@pytest.mark.parametrize(
+    'args', [(B1(),), (B2(),), (A1(), A1()), (A1(), A2(), A3())]
+)
+def test_unregistered(foo, args):
+    with pytest.raises(
+        NotImplementedError, match="Could not find signature for foo.*"
+    ):
+        foo(*args)
+
+
+def test_ambiguities_warning():
+    bar = TwoLevelDispatcher('bar')
+
+    bar.register(A1, B1)(lambda a, b: 0)
+    bar.register(A1, B2)(lambda a, b: 1)
+    bar.register(A2, B1)(lambda a, b: 2)
+
+    with pytest.warns(AmbiguityWarning, match=".*Consider.*\n\n.*(A2, B2).*"):
+        bar(A2(), B2())
+
+
+def test_ambiguities_no_warning():
+    bar = TwoLevelDispatcher('bar')
+
+    bar.register(A1, B1)(lambda a, b: 0)
+    bar.register(A1, B2)(lambda a, b: 1)
+    bar.register(A2, B1)(lambda a, b: 2)
+    bar.register(A2, B2)(lambda a, b: 3)
+
+    with pytest.warns(None) as warnings:
+        bar(A2(), B2())
+
+    assert len(warnings) == 0

--- a/ibis/pandas/tests/test_dispatcher.py
+++ b/ibis/pandas/tests/test_dispatcher.py
@@ -1,0 +1,39 @@
+import pytest
+
+from ibis.pandas.dispatcher import TwoLevelDispatcher
+
+
+@pytest.fixture
+def foo():
+    dispatcher = TwoLevelDispatcher('foo', 'test_dispatcher')
+
+    @dispatcher.register(int, int)
+    def foo0(x, y):
+        return 0
+
+    @dispatcher.register(int, float)
+    def foo1(x, y):
+        return 1
+
+    @dispatcher.register(float, int)
+    def foo2(x, y):
+        return 2
+
+    @dispatcher.register(float, float)
+    def foo3(x, y):
+        return 3
+
+    @dispatcher.register((list, tuple),)
+    def foo4(x):
+        return 4
+
+    return dispatcher
+
+
+def test_basic(foo):
+    assert foo(0, 0) == 0
+    assert foo(0, 0.0) == 1
+    assert foo(0.0, 0) == 2
+    assert foo(0.0, 0.0) == 3
+    assert foo(list()) == 4
+    assert foo(tuple()) == 4


### PR DESCRIPTION
What is the change
==============
This PR implements a `TwoLevelDispatcher` and replace the `multipledispatch.Dispatcher` with `TwoLevelDispatcher` to define `ibis.pandas.execute_node`

The original dispatcher is found to be slow when
(1) dispatch the first execute_node
(2) dispatch after new signature for execute_node is registered (this happens when user uses UDF)

In this alternative dispatcher, neither of these two issue appears. For details, see docstring of `TwoLevelDispatcher`

How is the change tested
===================
* `ibis/pandas/tests/test_dispatcher.py` is added
* Also replies on existing pandas backend tests.
* Manually tested tracing and verified tracing still works.

Benchmark
========
A benchmark is performed by running all the pandas backend tests and record "time to dispatch" for all signatures. 

Here is the top 10 slowest dispatch in the original implementation (with the corresponding time in the new implementation):
![image](https://user-images.githubusercontent.com/793516/84524217-9c4c8d80-aca7-11ea-8ba2-8f84f3f1bf97.png)

Here is the top 10 slowest dispatch in the new implementation (with the corresponding time in the original implementation):
![image](https://user-images.githubusercontent.com/793516/84524288-b7b79880-aca7-11ea-861c-fa54d08d7a5f.png)
