### PR TITLE
Add row_id pseudocolumn support

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -26,6 +26,7 @@ Release Notes
 * :bug:`2157` Fix interactive mode returning a expression instead of the value when used in Jupyter
 * :feature:`2093` IsNan implementation for OmniSciDB
 * :feature:`2094` [OmnisciDB] Support add_columns and drop_columns for OmnisciDB table
+* :feature:`2251` Add Pseudocolum column type, create RowID operation and add its support to OmniSciDB and SQLite
 * :support:`2234` Remove "experimental" mentions for OmniSciDB and Pandas backends
 * :bug:`2127` Fix PySpark error when doing alias after selection
 * :support:`2244` Use an OmniSciDB image stable on CI

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -26,7 +26,7 @@ Release Notes
 * :bug:`2157` Fix interactive mode returning a expression instead of the value when used in Jupyter
 * :feature:`2093` IsNan implementation for OmniSciDB
 * :feature:`2094` [OmnisciDB] Support add_columns and drop_columns for OmnisciDB table
-* :feature:`2251` Add Pseudocolum column type, create RowID operation and add its support to OmniSciDB and SQLite
+* :feature:`2251` Create RowID pseudocolumn expression and add its support to OmniSciDB and SQLite
 * :support:`2234` Remove "experimental" mentions for OmniSciDB and Pandas backends
 * :bug:`2127` Fix PySpark error when doing alias after selection
 * :support:`2244` Use an OmniSciDB image stable on CI

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4261,6 +4261,30 @@ def _table_drop(self, fields):
     return self[[field for field in schema if field not in field_set]]
 
 
+# pseudocolumns
+
+
+def row_id(self, col_name: str):
+    """
+    Row ID pseudo column operation.
+
+    Parameters
+    ----------
+    col_name : str
+
+    Returns
+    -------
+    row_id : ir.IntegerColumn
+    """
+    if isinstance(self._arg, ops.Selection):
+        raise NotImplementedError(
+            'Pseudocolumns operations cannot be used for a table selection. '
+            'Use it directly on a table expresion.'
+        )
+
+    return ops.RowID(col_name, self).to_expr()
+
+
 _table_methods = dict(
     aggregate=aggregate,
     count=_table_count,
@@ -4290,6 +4314,8 @@ _table_methods = dict(
     to_array=_table_to_array,
     union=_table_union,
     view=_table_view,
+    # pseudocolumns
+    row_id=row_id,
 )
 
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -277,7 +277,7 @@ class RowID(TableColumn):
         return klass(self, name=self.name)
 
     def output_type(self):
-        return functools.partial(ir.IntegerColumn, dtype=dt.int64)
+        return dt.int64.column_type()
 
 
 def find_all_base_tables(expr, memo=None):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -249,6 +249,37 @@ class TableColumn(ValueOp):
         return klass(self, name=self.name)
 
 
+class PseudoColumn(TableColumn):
+    """
+    PseudoColumn expression.
+
+    A Pseudocolumn is a "column" that yields a value when selected,
+    but which is not an actual column of the table.
+
+    See Also
+    --------
+    https://en.wikipedia.org/wiki/Pseudocolumn
+    """
+
+    def _validate(self):
+        return True
+
+    def _make_expr(self):
+        klass = self.output_type()
+        return klass(self, name=self.name)
+
+
+class RowID(PseudoColumn):
+    """
+    Operation for a pseudocolumn row ID.
+
+    Row ID returns a sequential integer, starting from 0, for each row.
+    """
+
+    def output_type(self):
+        return functools.partial(ir.IntegerColumn, dtype=dt.int64)
+
+
 def find_all_base_tables(expr, memo=None):
     if memo is None:
         memo = {}

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -249,16 +249,24 @@ class TableColumn(ValueOp):
         return klass(self, name=self.name)
 
 
-class PseudoColumn(TableColumn):
+class RowID(TableColumn):
     """
-    PseudoColumn expression.
+    A pseudocolumn Row ID expression.
+
+    Row ID returns a sequential integer, starting from 0, for each row.
 
     A Pseudocolumn is a "column" that yields a value when selected,
     but which is not an actual column of the table.
 
+    Note
+    ----
+    For the next pseudocolumn classes, that would be good to abstract
+    the PseudoColumn methods to be shared between PseudoColumn implementations
+
     See Also
     --------
     https://en.wikipedia.org/wiki/Pseudocolumn
+
     """
 
     def _validate(self):
@@ -267,14 +275,6 @@ class PseudoColumn(TableColumn):
     def _make_expr(self):
         klass = self.output_type()
         return klass(self, name=self.name)
-
-
-class RowID(PseudoColumn):
-    """
-    Operation for a pseudocolumn row ID.
-
-    Row ID returns a sequential integer, starting from 0, for each row.
-    """
 
     def output_type(self):
         return functools.partial(ir.IntegerColumn, dtype=dt.int64)

--- a/ibis/omniscidb/operations.py
+++ b/ibis/omniscidb/operations.py
@@ -1085,6 +1085,7 @@ _general_ops = {
     ops.IsNan: unary('isNan'),
     ops.NullIfZero: _nullifzero,
     ops.ZeroIfNull: _zeroifnull,
+    ops.RowID: lambda *args: 'rowid',
 }
 
 # WINDOW

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import sqlalchemy as sa
 import toolz
 
@@ -235,6 +234,23 @@ def _rpad(t, expr):
     return arg + _generic_pad(arg, length, pad)
 
 
+def _row_id(t, expr: ir.Expr):
+    """
+    Pseudo column Row ID translation.
+
+    Parameters
+    ----------
+    t : SQLiteExprTranslator
+    expr : ir.Expr
+
+    Returns
+    -------
+    row_id : str
+    """
+    sa_expr = sa.literal_column('rowid') - 1
+    return sa_expr.label(expr.get_name())
+
+
 _operation_registry.update(
     {
         ops.Cast: _cast,
@@ -285,6 +301,7 @@ _operation_registry.update(
         ops.StandardDev: toolz.compose(
             sa.func._ibis_sqlite_sqrt, _variance_reduction('_ibis_sqlite_var')
         ),
+        ops.RowID: _row_id,
     }
 )
 

--- a/ibis/tests/all/test_column.py
+++ b/ibis/tests/all/test_column.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pandas as pd
 import pytest
 
 
@@ -16,3 +18,45 @@ def test_distinct_column(backend, alltypes, df, column):
     result = expr.execute()
     expected = df[column].unique()
     assert set(result) == set(expected)
+
+
+@pytest.mark.parametrize(
+    'backend_pseudocolumn', [{'omniscidb': 'rowid', 'sqlite': 'rowid'}]
+)
+@pytest.mark.xfail_unsupported
+def test_pseudocolumn_rowid(con, backend, backend_pseudocolumn):
+    # pseudocolumn needs to be used by a table expression directly
+    # alltypes fixture from some backends maybe apply some operation on it
+    t = con.table('functional_alltypes')
+    backend_col_name = backend_pseudocolumn.get(backend.name, None)
+
+    if not backend_col_name:
+        pytest.xfail('No test defined for {}'.format(backend.name))
+
+    row_id = t.row_id(backend_col_name)
+
+    expr = t[[row_id]]
+    result = expr.execute()
+    expected = pd.Series(np.arange(len(result)))
+    pd.testing.assert_series_equal(
+        result.rowid, expected, check_names=False, check_dtype=False
+    )
+
+
+@pytest.mark.parametrize(
+    'backend_pseudocolumn', [{'omniscidb': 'rowid', 'sqlite': 'rowid'}]
+)
+@pytest.mark.xfail_unsupported
+def test_pseudocolumn_rowid_xfail(con, backend, backend_pseudocolumn):
+    # pseudocolumn needs to be used by a table expression directly
+    # alltypes fixture from some backends maybe apply some operation on it
+    t = con.table('functional_alltypes')
+    t = t.mutate(newcol=1)
+
+    backend_col_name = backend_pseudocolumn.get(backend.name, None)
+
+    if not backend_col_name:
+        pytest.xfail('No test defined for {}'.format(backend.name))
+
+    with pytest.raises(NotImplementedError):
+        t.row_id(backend_col_name)


### PR DESCRIPTION
This PR aims to start a discussion about pseudocolumn support (https://en.wikipedia.org/wiki/Pseudocolumn).

Initially it adds:

- initial support for pseudo columns support
- support for row_id pseudocolum to omniscidb and sqlite backends.

example:

```python
>>> con = ibis.sqlite.connect(**conf['sqlite'])
>>> t = con.table('functional_alltypes')
>>> rowid = t.row_id('rowid')  # it needs the name used for the backend as a parameter
>>> expr = t[row_id, t.index].head()
>>> print(expr.compile())
SELECT rowid - ? AS rowid, t0."index" 
FROM base.functional_alltypes AS t0
LIMIT ? OFFSET ?
```

limitations:

A pseudocolumn needs to be used by a table expression directly, if it is used by a selection it will raise `NotImplementedError`error.

Resolves: #1462