### PR TITLE
BUG: Allow group_by and order_by column as window input in pandas backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2252` Allow group_by and order_by as window operation input in pandas backend
 * :bug:`2229` Fix same column with multiple aliases not showing properly in repr
 * :feature:`2233` Add ibis.pandas.trace module to log time and call stack information.
 * :feature:`2198` Validate that the output type of a UDF is a single element

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -484,7 +484,6 @@ class Window(AggregationContext):
             # index
             # TODO: see if we can do this in the caller, when the context
             # is constructed rather than pulling out the data
-
             columns = group_by + order_by + [name]
             indexed_by_ordering = frame[columns].set_index(order_by)
 

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -476,7 +476,7 @@ class Window(AggregationContext):
             frame = getattr(parent, 'obj', parent)
             obj = getattr(grouped_data, 'obj', grouped_data)
             name = obj.name
-            if frame[name] is not obj:
+            if frame[name] is not obj or name in group_by or name in order_by:
                 name = f"{name}_{ibis.util.guid()}"
                 frame = frame.assign(**{name: obj})
 
@@ -484,6 +484,7 @@ class Window(AggregationContext):
             # index
             # TODO: see if we can do this in the caller, when the context
             # is constructed rather than pulling out the data
+
             columns = group_by + order_by + [name]
             indexed_by_ordering = frame[columns].set_index(order_by)
 

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -47,11 +47,6 @@ def range_window():
     return ibis.window(following=0, order_by='plain_datetimes_naive')
 
 
-@pytest.fixture
-def table1():
-    return
-
-
 @default
 @row_offset
 def test_lead(t, df, row_offset, default, row_window):

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -11,6 +11,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.expr.window import rows_with_max_lookback
 from ibis.pandas.dispatch import pre_execute
+from ibis.udf.vectorized import reduction
 
 execute = ibis.pandas.execute
 
@@ -44,6 +45,11 @@ def row_window():
 @pytest.fixture
 def range_window():
     return ibis.window(following=0, order_by='plain_datetimes_naive')
+
+
+@pytest.fixture
+def table1():
+    return
 
 
 @default
@@ -529,3 +535,55 @@ def test_window_grouping_key_has_scope(t, df):
     result = expr.execute(params={param: "a"})
     expected = df.groupby(df.dup_strings + "a").plain_int64.transform("mean")
     tm.assert_series_equal(result, expected)
+
+
+def test_window_on_and_by_key_as_window_input(t, df):
+    order_by = 'plain_int64'
+    group_by = 'dup_ints'
+    control = 'plain_float64'
+
+    row_window = ibis.trailing_window(
+        order_by=order_by, group_by=group_by, preceding=1
+    )
+
+    # Test built-in function
+
+    tm.assert_series_equal(
+        t[order_by].count().over(row_window).execute(),
+        t[control].count().over(row_window).execute(),
+        check_names=False,
+    )
+
+    tm.assert_series_equal(
+        t[group_by].count().over(row_window).execute(),
+        t[control].count().over(row_window).execute(),
+        check_names=False,
+    )
+
+    # Test UDF
+
+    @reduction(input_type=[dt.int64], output_type=dt.int64)
+    def count(v):
+        return len(v)
+
+    @reduction(input_type=[dt.int64, dt.int64], output_type=dt.int64)
+    def count_both(v1, v2):
+        return len(v1)
+
+    tm.assert_series_equal(
+        count(t[order_by]).over(row_window).execute(),
+        t[control].count().over(row_window).execute(),
+        check_names=False,
+    )
+
+    tm.assert_series_equal(
+        count(t[group_by]).over(row_window).execute(),
+        t[control].count().over(row_window).execute(),
+        check_names=False,
+    )
+
+    tm.assert_series_equal(
+        count_both(t[group_by], t[order_by]).over(row_window).execute(),
+        t[control].count().over(row_window).execute(),
+        check_names=False,
+    )


### PR DESCRIPTION
What change is proposed?
===================
This PR fixes a bug where `group_by` and `order_by` column cannot be used as window operation input columns. It used to throw an exception.

```
# This throws an exception before the patch

w = ibis.trailing_window(
    order_by="time",
    group_by="tid",
    preceding = 1000,
)
table['time'].count().over(w).execute()
```

Exception:
```
../generic.py:460: in execute_reduction_series_groupby
    return aggcontext.agg(data, type(op).__name__.lower())
../../aggcontext.py:489: in agg
    indexed_by_ordering = frame[columns].set_index(order_by)
/Users/icexelloss/miniconda3/envs/ibis-dev/lib/python3.7/site-packages/pandas/core/frame.py:4351: in set_index
    index = ensure_index_from_sequences(arrays, names)
/Users/icexelloss/miniconda3/envs/ibis-dev/lib/python3.7/site-packages/pandas/core/indexes/base.py:5288: in ensure_index_from_sequences
    return Index(sequences[0], name=names)
/Users/icexelloss/miniconda3/envs/ibis-dev/lib/python3.7/site-packages/pandas/core/indexes/base.py:390: in __new__
    return Int64Index(data, copy=copy, dtype=dtype, name=name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <class 'pandas.core.indexes.numeric.Int64Index'>
data = array([[1, 1],
       [3, 3],
       [2, 2]]), dtype = None, copy = False
name = 'plain_int64'

    def __new__(cls, data=None, dtype=None, copy=False, name=None):
        cls._validate_dtype(dtype)

	# Coerce to ndarray if not already ndarray or Index
        if not isinstance(data, (np.ndarray, Index)):
            if is_scalar(data):
                raise cls._scalar_data_error(data)

            # other iterable of some kind
            if not isinstance(data, (ABCSeries, list, tuple)):
                data = list(data)

            data = np.asarray(data, dtype=dtype)

	if issubclass(data.dtype.type, str):
            cls._string_data_error(data)

	if copy or not is_dtype_equal(data.dtype, cls._default_dtype):
            subarr = np.array(data, dtype=cls._default_dtype, copy=copy)
            cls._assert_safe_casting(data, subarr)
        else:
            subarr = data

	if subarr.ndim > 1:
            # GH#13601, GH#20285, GH#27125
>           raise ValueError("Index data must be 1-dimension
```

This PR fixes this issue.

How is this tested
=============
test_window_on_and_by_key_as_window_input is added 