### PR TITLE
FEAT: Add execution_mode() to OmniSciDBClient that defines where the SQL is processed

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -226,6 +226,7 @@ Use ``ibis.omniscidb.connect`` to create a client.
    OmniSciDBClient.drop_table_or_view
    OmniSciDBClient.drop_user
    OmniSciDBClient.drop_view
+   OmniSciDBClient.execution_mode
    OmniSciDBClient.exists_table
    OmniSciDBClient.get_schema
    OmniSciDBClient.list_tables

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -29,6 +29,7 @@ Release Notes
 * :feature:`2126` Add translation rules for isnull() and notnull() for pyspark backend
 * :feature:`2232` Add window operations support to SQLite
 * :feature:`2062` Implement read_csv for omniscidb backend
+* :feature:`2254` [OmniSciDB] Allow users to specify where the backend execution will occur using backend client "execution_mode" method ('gpu' or 'cpu')
 * :feature:`2171` [OmniSciDB] Add support to week extraction
 * :feature:`2097` Date, DateDiff and TimestampDiff implementations for OmniSciDB
 * :bug:`2170` Fix millisecond issue for OmniSciDB :issue:`2167`, MySQL :issue:`2169`, PostgreSQL :issue:`2166` and Pandas :issue:`2168` backends

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -764,6 +764,27 @@ class OmniSciDBClient(SQLClient):
         query = self.query_class(self, dml, **kwargs)
         return query.execute(**kwargs)
 
+    def execution_mode(self, processing_unit: str):
+        """
+        Define where the SQL execution occurs (GPU or CPU).
+
+        Parameters
+        ----------
+        processing_unit : {'cpu', 'gpu'}
+          Define if the request will be executed on CPU or GPU.
+        """
+        if processing_unit not in ['cpu', 'gpu']:
+            raise Exception(
+                'Processing unit should be one of the follow values: '
+                '"cpu" or "gpu"'
+            )
+
+        PROCESSING_UNIT_MAP = {'cpu': 0, 'gpu': 1}
+
+        self.con._client.set_execution_mode(
+            self.con._session, PROCESSING_UNIT_MAP[processing_unit]
+        )
+
     def _execute(
         self,
         query: str,

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -782,13 +782,13 @@ class OmniSciDBClient(SQLClient):
         >>> expr.execute()  # doctest: +SKIP
         >>> con.execution_mode('cpu') # doctest: +SKIP
         """
-        if processing_unit not in ['cpu', 'gpu']:
-            raise Exception(
+        PROCESSING_UNIT_MAP = {'cpu': 0, 'gpu': 1}
+
+        if processing_unit not in PROCESSING_UNIT_MAP:
+            raise ValueError(
                 'Processing unit should be one of the follow values: '
                 '"cpu" or "gpu"'
             )
-
-        PROCESSING_UNIT_MAP = {'cpu': 0, 'gpu': 1}
 
         self.con._client.set_execution_mode(
             self.con._session, PROCESSING_UNIT_MAP[processing_unit]

--- a/ibis/omniscidb/client.py
+++ b/ibis/omniscidb/client.py
@@ -768,10 +768,19 @@ class OmniSciDBClient(SQLClient):
         """
         Define where the SQL execution occurs (GPU or CPU).
 
+        Use "execution_mode" before the expression execution to change
+        where it should be executed in the backend engine.
+
         Parameters
         ----------
         processing_unit : {'cpu', 'gpu'}
           Define if the request will be executed on CPU or GPU.
+
+        Examples
+        --------
+        >>> con.execution_mode('gpu') # doctest: +SKIP
+        >>> expr.execute()  # doctest: +SKIP
+        >>> con.execution_mode('cpu') # doctest: +SKIP
         """
         if processing_unit not in ['cpu', 'gpu']:
             raise Exception(

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -289,11 +289,13 @@ def test_cpu_ipc_gpu_device(
         mocked_method.stop()
 
 
-def test_cpu_ipc_execution_mode(con):
+def test_execution_mode_cpu(con):
     con.execution_mode('cpu')
     result = con.table('functional_alltypes').head().execute()
     assert isinstance(result, pd.DataFrame)
 
+
+def test_execution_mode_gpu(con):
     try:
         con.execution_mode('gpu')
     except Exception as e:
@@ -302,5 +304,7 @@ def test_cpu_ipc_execution_mode(con):
             ' server started in CPU-only mode.'
         )
 
+
+def test_execution_mode_invalid(con):
     with pytest.raises(ValueError):
         con.execution_mode('invalid-execution-mode')

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -240,7 +240,7 @@ def test_read_csv(con, temp_table, filename, alltypes, df_alltypes):
 
 @pytest.mark.parametrize('ipc', [None, True, False])
 @pytest.mark.parametrize('gpu_device', [None, 1])
-def test_cpu_execution_type(
+def test_cpu_ipc_gpu_device(
     mocker, con, ipc: Optional[bool], gpu_device: Optional[int]
 ):
     """Test the combination of ipc and gpu_device parameters for connection."""
@@ -287,3 +287,17 @@ def test_cpu_execution_type(
 
     for mocked_method in mocked_methods:
         mocked_method.stop()
+
+
+def test_cpu_ipc_execution_mode(con):
+    con.execution_mode('cpu')
+    result = con.table('functional_alltypes').head().execute()
+    assert isinstance(result, pd.DataFrame)
+
+    try:
+        con.execution_mode('gpu')
+    except Exception as e:
+        assert e.error_msg == (
+            'Cannot switch to GPU mode in a'
+            ' server started in CPU-only mode.'
+        )

--- a/ibis/omniscidb/tests/test_client.py
+++ b/ibis/omniscidb/tests/test_client.py
@@ -301,3 +301,6 @@ def test_cpu_ipc_execution_mode(con):
             'Cannot switch to GPU mode in a'
             ' server started in CPU-only mode.'
         )
+
+    with pytest.raises(ValueError):
+        con.execution_mode('invalid-execution-mode')


### PR DESCRIPTION
 `pymapd` execution_mode cpu|gpu controls the execution in the engine, not how the results are returned (defined by gpu_device).

This PR add a method that allows users to define the execution mode, for example:

```python
>>> con.execution_mode('cpu')
>>> expr.execute()
```