### PR TITLE
FEAT: Refactor window_agg_udf to take window indices instead of window sizes

### DIFF
--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -316,7 +316,7 @@ def compute_window_spec_interval(_, expr):
     return pd.tseries.frequencies.to_offset(value)
 
 
-def _window_agg_built_in(
+def window_agg_built_in(
     frame: pd.DataFrame,
     windowed: pd.core.window.Window,
     function: str,
@@ -347,10 +347,12 @@ def _window_agg_built_in(
     return result
 
 
-def _window_agg_udf(
+def window_agg_udf(
     grouped_data: SeriesGroupBy,
-    windowed: pd.core.window.Window,
     function: Callable,
+    window_lower_indices: pd.Series,
+    window_upper_indices: pd.Series,
+    mask: pd.Series,
     dtype: np.dtype,
     max_lookback: int,
     *args: Tuple[Any],
@@ -364,31 +366,16 @@ def _window_agg_udf(
     This is because pandas's rolling function doesn't support
     multi param UDFs.
     """
-
-    def create_input_iter(
-        grouped_series: SeriesGroupBy, window_size: int
-    ) -> Iterator[np.ndarray]:
-        # create a generator for each input series
-        # the generator will yield a slice of the
-        # input series for each valid window
-        data = getattr(grouped_series, 'obj', grouped_series).values
-        window_size_array = window_size.values
-        for i in range(len(window_size_array)):
-            k = window_size.index[i]
-            yield data[k - window_size_array[i] + 1 : k + 1]
-
     obj = getattr(grouped_data, 'obj', grouped_data)
+
+    assert len(window_lower_indices) == len(window_upper_indices)
+    assert len(window_lower_indices) == len(mask)
 
     # Compute window indices and manually roll
     # over the window.
     # If an window has only nan values, we output nan for
     # the window result. This follows pandas rolling apply
     # behavior.
-    raw_window_size = windowed.apply(len, raw=True).reset_index(drop=True)
-    mask = ~(raw_window_size.isna())
-    window_size = raw_window_size[mask].astype('i8')
-    window_size_array = window_size.values
-
     # If there is no args, then the UDF only takes a single
     # input which is defined by grouped_data
     # This is a complication due to the lack of standard
@@ -396,8 +383,25 @@ def _window_agg_udf(
     # to AggregationContext.agg()
     inputs = args if len(args) > 0 else [grouped_data]
 
+    masked_window_lower_indices = window_lower_indices[mask].astype('i8')
+    masked_window_upper_indices = window_upper_indices[mask].astype('i8')
+
+    def create_input_iter(
+        grouped_series: SeriesGroupBy,
+    ) -> Iterator[np.ndarray]:
+        # create a generator for each input series
+        # the generator will yield a slice of the
+        # input series for each valid window
+        data = getattr(grouped_series, 'obj', grouped_series).values
+        lower_indices_array = masked_window_lower_indices.values
+        upper_indices_array = masked_window_upper_indices.values
+        for i in range(len(lower_indices_array)):
+            lower_index = lower_indices_array[i]
+            upper_index = upper_indices_array[i]
+            yield data[lower_index:upper_index]
+
     input_iters = list(
-        create_input_iter(arg, window_size)
+        create_input_iter(arg)
         if isinstance(arg, (pd.Series, SeriesGroupBy))
         else itertools.repeat(arg)
         for arg in inputs
@@ -405,11 +409,11 @@ def _window_agg_udf(
 
     valid_result = pd.Series(
         function(*(next(gen) for gen in input_iters))
-        for i in range(len(window_size_array))
+        for i in range(len(masked_window_lower_indices))
     )
 
     valid_result = pd.Series(valid_result)
-    valid_result.index = window_size.index
+    valid_result.index = masked_window_lower_indices.index
     result = pd.Series(index=mask.index, dtype=dtype)
     result[mask] = valid_result
     result.index = obj.index
@@ -498,17 +502,26 @@ class Window(AggregationContext):
             windowed = self.construct_window(grouped)
 
             if callable(function):
-                result = _window_agg_udf(
+                window_sizes = windowed.apply(len, raw=True).reset_index(
+                    drop=True
+                )
+                mask = ~(window_sizes.isna())
+                window_upper_indices = pd.Series(range(len(window_sizes))) + 1
+                window_lower_indices = window_upper_indices - window_sizes
+
+                result = window_agg_udf(
                     grouped_data,
-                    windowed,
                     function,
+                    window_lower_indices,
+                    window_upper_indices,
+                    mask,
                     self.dtype,
                     self.max_lookback,
                     *args,
                     **kwargs,
                 )
             else:
-                result = _window_agg_built_in(
+                result = window_agg_built_in(
                     frame,
                     windowed,
                     function,

--- a/ibis/pandas/tests/test_aggcontext.py
+++ b/ibis/pandas/tests/test_aggcontext.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.util import testing as tm
+
+from ibis.pandas.aggcontext import window_agg_udf
+
+
+@pytest.mark.parametrize(
+    'param',
+    [
+        (
+            pd.Series([True, True, True, True]),
+            pd.Series([1.0, 2.0, 2.0, 3.0]),
+        ),
+        (
+            pd.Series([False, True, True, False]),
+            pd.Series([np.NaN, 2.0, 2.0, np.NaN]),
+        ),
+    ],
+)
+def test_window_agg_udf(param):
+    mask, expected = param
+
+    df = pd.DataFrame({'id': [1, 2, 1, 2], 'v': [1.0, 2.0, 3.0, 4.0]})
+
+    grouped_data = df.sort_values('id').groupby("id")['v']
+
+    window_lower_indices = pd.Series([0, 0, 2, 2])
+    window_higher_indices = pd.Series([1, 2, 3, 4])
+
+    result = window_agg_udf(
+        grouped_data,
+        lambda s: s.mean(),
+        window_lower_indices,
+        window_higher_indices,
+        mask,
+        dtype='float',
+        max_lookback=None,
+    )
+
+    expected.index = grouped_data.obj.index
+
+    tm.assert_series_equal(result, expected)

--- a/ibis/pandas/tests/test_aggcontext.py
+++ b/ibis/pandas/tests/test_aggcontext.py
@@ -20,6 +20,8 @@ from ibis.pandas.aggcontext import window_agg_udf
     ],
 )
 def test_window_agg_udf(param):
+    """ Test passing custom window indices for window aggregation."""
+
     mask, expected = param
 
     df = pd.DataFrame({'id': [1, 2, 1, 2], 'v': [1.0, 2.0, 3.0, 4.0]})


### PR DESCRIPTION
This PR refactors window_agg_udf inside aggcontext.py to take window upper and lower indices instead of window sizes. This allows more flexible way of specifying window indices.

This is tested with existing window tests. Also added a new test file `test_aggcontext.py`