### PR TITLE
FEAT: Support custom window in pandas backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2260` Add support for implementign custom window object for pandas backend
 * :bug:`2237` Add missing float types to pandas backend
 * :bug:`2252` Allow group_by and order_by as window operation input in pandas backend
 * :feature:`2246` Implement two level dispatcher for execute_node

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -33,7 +33,7 @@ def _choose_non_empty_val(first, second):
 
 
 def _determine_how(preceding):
-    offset_type = type(_get_preceding_value(preceding))
+    offset_type = type(get_preceding_value(preceding))
     if issubclass(offset_type, (int, np.integer)):
         how = 'rows'
     elif issubclass(offset_type, ir.IntervalScalar):
@@ -47,15 +47,15 @@ def _determine_how(preceding):
 
 
 @functools.singledispatch
-def _get_preceding_value(preceding):
+def get_preceding_value(preceding):
     raise TypeError(
         "Type {} is not a valid type for 'preceding' "
         "parameter".format(type(preceding))
     )
 
 
-@_get_preceding_value.register(tuple)
-def _get_preceding_value_tuple(preceding):
+@get_preceding_value.register(tuple)
+def get_preceding_value_tuple(preceding):
     start, end = preceding
     if start is None:
         preceding_value = end
@@ -64,15 +64,15 @@ def _get_preceding_value_tuple(preceding):
     return preceding_value
 
 
-@_get_preceding_value.register(int)
-@_get_preceding_value.register(np.integer)
-@_get_preceding_value.register(ir.IntervalScalar)
-def _get_preceding_value_simple(preceding):
+@get_preceding_value.register(int)
+@get_preceding_value.register(np.integer)
+@get_preceding_value.register(ir.IntervalScalar)
+def get_preceding_value_simple(preceding):
     return preceding
 
 
-@_get_preceding_value.register(RowsWithMaxLookback)
-def _get_preceding_value_mlb(preceding):
+@get_preceding_value.register(RowsWithMaxLookback)
+def get_preceding_value_mlb(preceding):
     preceding_value = preceding.rows
     if not isinstance(preceding_value, (int, np.integer)):
         raise TypeError(

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -599,7 +599,7 @@ def test_custom_window_udf(t, df):
     def my_sum(v):
         return v.sum()
 
-    class CustomInterval(object):
+    class CustomInterval:
         def __init__(self, value):
             self.value = value
 

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -9,8 +9,10 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.expr.window import rows_with_max_lookback
+from ibis.expr.window import get_preceding_value, rows_with_max_lookback
+from ibis.pandas.aggcontext import AggregationContext, window_agg_udf
 from ibis.pandas.dispatch import pre_execute
+from ibis.pandas.execution.window import get_aggcontext
 from ibis.udf.vectorized import reduction
 
 execute = ibis.pandas.execute
@@ -582,3 +584,124 @@ def test_window_on_and_by_key_as_window_input(t, df):
         t[control].count().over(row_window).execute(),
         check_names=False,
     )
+
+
+def test_custom_window_udf(t, df):
+    """ Test implementing  a (dummy) custom window.
+
+    This test covers the advance use case to support custom window with udfs.
+
+    Note that method used in this example (e.g, get_preceding, get_aggcontext)
+    are unstable developer API, not stable public API.
+    """
+
+    @reduction(input_type=[dt.float64], output_type=dt.float64)
+    def my_sum(v):
+        return v.sum()
+
+    class CustomInterval(object):
+        def __init__(self, value):
+            self.value = value
+
+        # These are necessary because ibis.expr.window
+        # will compare preceding and following
+        # with 0 to see if they are valid
+        def __lt__(self, other):
+            return self.value < other
+
+        def __gt__(self, other):
+            return self.value > other
+
+    class CustomWindow(ibis.expr.window.Window):
+        """ This is a dummy custom window that return n preceding rows
+        where n is defined by CustomInterval.value."""
+
+        def _replace(self, **kwds):
+            new_kwds = dict(
+                group_by=kwds.get('group_by', self._group_by),
+                order_by=kwds.get('order_by', self._order_by),
+                preceding=kwds.get('preceding', self.preceding),
+                following=kwds.get('following', self.following),
+                max_lookback=kwds.get('max_lookback', self.max_lookback),
+                how=kwds.get('how', self.how),
+            )
+            return CustomWindow(**new_kwds)
+
+    class CustomAggContext(AggregationContext):
+        def __init__(
+            self, parent, group_by, order_by, dtype, max_lookback, preceding
+        ):
+            super().__init__(
+                parent=parent,
+                group_by=group_by,
+                order_by=order_by,
+                dtype=dtype,
+                max_lookback=max_lookback,
+            )
+            self.preceding = preceding
+
+        def agg(self, grouped_data, function, *args, **kwargs):
+            upper_indices = pd.Series(range(len(self.parent) + 1)) + 1
+            window_sizes = (
+                grouped_data.rolling(self.preceding.value + 1)
+                .count()
+                .reset_index(drop=True)
+            )
+            lower_indices = upper_indices - window_sizes
+            mask = ~upper_indices.isna()
+
+            result = window_agg_udf(
+                grouped_data,
+                function,
+                lower_indices,
+                upper_indices,
+                mask,
+                self.dtype,
+                self.max_lookback,
+                *args,
+                **kwargs,
+            )
+
+            return result
+
+    custom_window_0 = CustomWindow(
+        preceding=CustomInterval(0),
+        following=0,
+        group_by='dup_ints',
+        order_by='plain_int64',
+    )
+
+    custom_window_1 = CustomWindow(
+        preceding=CustomInterval(1),
+        following=0,
+        group_by='dup_ints',
+        order_by='plain_int64',
+    )
+
+    # Unfortunately we cannot unregister these because singledispatch
+    # doesn't support it, but this won't cause any issues either.
+    @get_preceding_value.register(CustomInterval)
+    def get_preceding_value_custom(preceding):
+        return preceding
+
+    @get_aggcontext.register(CustomWindow)
+    def get_aggcontext_custom(
+        window, *, operand, operand_dtype, parent, group_by, order_by
+    ):
+        return CustomAggContext(
+            parent=parent,
+            group_by=group_by,
+            order_by=order_by,
+            dtype=operand_dtype,
+            max_lookback=window.max_lookback,
+            preceding=window.preceding,
+        )
+
+    result_0 = my_sum(t['plain_float64']).over(custom_window_0).execute()
+    result_1 = my_sum(t['plain_float64']).over(custom_window_1).execute()
+
+    expected_0 = pd.Series([4.0, 6.0, 5.0])
+    expected_1 = pd.Series([4.0, 10.0, 5.0])
+
+    tm.assert_series_equal(result_0, expected_0)
+    tm.assert_series_equal(result_1, expected_1)

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -641,14 +641,14 @@ def test_custom_window_udf(t, df):
             self.preceding = preceding
 
         def agg(self, grouped_data, function, *args, **kwargs):
-            upper_indices = pd.Series(range(len(self.parent) + 1)) + 1
+            upper_indices = pd.Series(range(1, len(self.parent) + 2))
             window_sizes = (
                 grouped_data.rolling(self.preceding.value + 1)
                 .count()
                 .reset_index(drop=True)
             )
             lower_indices = upper_indices - window_sizes
-            mask = ~upper_indices.isna()
+            mask = upper_indices.notna()
 
             result = window_agg_udf(
                 grouped_data,

--- a/ibis/pandas/execution/window.py
+++ b/ibis/pandas/execution/window.py
@@ -72,7 +72,7 @@ def get_aggcontext(
     window, *, operand, operand_dtype, parent, group_by, order_by
 ):
     raise NotImplementedError(
-        f"get_aggcontext is not implemented for {type(window)}"
+        f"get_aggcontext is not implemented for {type(window).__name__}"
     )
 
 

--- a/ibis/pandas/execution/window.py
+++ b/ibis/pandas/execution/window.py
@@ -4,6 +4,7 @@ import functools
 import operator
 import re
 from collections import OrderedDict
+from typing import NoReturn
 
 import pandas as pd
 import toolz
@@ -13,6 +14,7 @@ import ibis.common.exceptions as com
 import ibis.expr.operations as ops
 import ibis.expr.window as win
 import ibis.pandas.aggcontext as agg_ctx
+from ibis.pandas.aggcontext import AggregationContext
 from ibis.pandas.core import (
     date_types,
     execute,
@@ -70,7 +72,7 @@ def _post_process_group_by_order_by(series, parent, order_by, group_by):
 @functools.singledispatch
 def get_aggcontext(
     window, *, operand, operand_dtype, parent, group_by, order_by
-):
+) -> NoReturn:
     raise NotImplementedError(
         f"get_aggcontext is not implemented for {type(window).__name__}"
     )
@@ -79,7 +81,7 @@ def get_aggcontext(
 @get_aggcontext.register(win.Window)
 def get_aggcontext_window(
     window, *, operand, operand_dtype, parent, group_by, order_by
-):
+) -> AggregationContext:
     # no order by or group by: default summarization aggcontext
     #
     # if we're reducing and we have an order by expression then we need to

--- a/ibis/pandas/execution/window.py
+++ b/ibis/pandas/execution/window.py
@@ -1,5 +1,6 @@
 """Code for computing window functions with ibis and pandas."""
 
+import functools
 import operator
 import re
 from collections import OrderedDict
@@ -64,6 +65,67 @@ def _post_process_group_by_order_by(series, parent, order_by, group_by):
     if len(reordered_levels) > 1:
         series = series.reorder_levels(reordered_levels)
     return series
+
+
+@functools.singledispatch
+def get_aggcontext(
+    window, *, operand, operand_dtype, parent, group_by, order_by
+):
+    raise NotImplementedError(
+        f"get_aggcontext is not implemented for {type(window)}"
+    )
+
+
+@get_aggcontext.register(win.Window)
+def get_aggcontext_window(
+    window, *, operand, operand_dtype, parent, group_by, order_by
+):
+    # no order by or group by: default summarization aggcontext
+    #
+    # if we're reducing and we have an order by expression then we need to
+    # expand or roll.
+    #
+    # otherwise we're transforming
+
+    if not group_by and not order_by:
+        aggcontext = agg_ctx.Summarize()
+    elif (
+        isinstance(
+            operand.op(), (ops.Reduction, ops.CumulativeOp, ops.Any, ops.All)
+        )
+        and order_by
+    ):
+        # XXX(phillipc): What a horror show
+        preceding = window.preceding
+        if preceding is not None:
+            max_lookback = window.max_lookback
+            assert not isinstance(operand.op(), ops.CumulativeOp)
+            aggcontext = agg_ctx.Moving(
+                preceding,
+                max_lookback,
+                parent=parent,
+                group_by=group_by,
+                order_by=order_by,
+                dtype=operand_dtype,
+            )
+        else:
+            # expanding window
+            aggcontext = agg_ctx.Cumulative(
+                parent=parent,
+                group_by=group_by,
+                order_by=order_by,
+                dtype=operand_dtype,
+            )
+    else:
+        # groupby transform (window with a partition by clause in SQL parlance)
+        aggcontext = agg_ctx.Transform(
+            parent=parent,
+            group_by=group_by,
+            order_by=order_by,
+            dtype=operand_dtype,
+        )
+
+    return aggcontext
 
 
 @execute_node.register(ops.WindowOp, pd.Series, win.Window)
@@ -152,49 +214,14 @@ def execute_window_op(
     operand_type = operand.type()
     operand_dtype = operand_type.to_pandas()
 
-    # no order by or group by: default summarization aggcontext
-    #
-    # if we're reducing and we have an order by expression then we need to
-    # expand or roll.
-    #
-    # otherwise we're transforming
-    if not grouping_keys and not ordering_keys:
-        aggcontext = agg_ctx.Summarize()
-    elif (
-        isinstance(
-            operand.op(), (ops.Reduction, ops.CumulativeOp, ops.Any, ops.All)
-        )
-        and ordering_keys
-    ):
-        # XXX(phillipc): What a horror show
-        preceding = window.preceding
-        if preceding is not None:
-            max_lookback = window.max_lookback
-            assert not isinstance(operand.op(), ops.CumulativeOp)
-            aggcontext = agg_ctx.Moving(
-                preceding,
-                max_lookback,
-                parent=source,
-                group_by=grouping_keys,
-                order_by=ordering_keys,
-                dtype=operand_dtype,
-            )
-        else:
-            # expanding window
-            aggcontext = agg_ctx.Cumulative(
-                parent=source,
-                group_by=grouping_keys,
-                order_by=ordering_keys,
-                dtype=operand_dtype,
-            )
-    else:
-        # groupby transform (window with a partition by clause in SQL parlance)
-        aggcontext = agg_ctx.Transform(
-            parent=source,
-            group_by=grouping_keys,
-            order_by=ordering_keys,
-            dtype=operand_dtype,
-        )
+    aggcontext = get_aggcontext(
+        window,
+        operand=operand,
+        operand_dtype=operand_dtype,
+        parent=source,
+        group_by=grouping_keys,
+        order_by=ordering_keys,
+    )
 
     result = execute(
         operand,


### PR DESCRIPTION
This PR refactors the existing pandas window execution to allow implementing custom window with pandas backend.

The change is tested with a new test `test_custom_window_udf` which implements a dummy custom window and test it with pandas backend.