### PR TITLE
FEAT: Add support for Union in PySpark backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2270` Add support for Union in the PySpark backend
 * :feature:`2260` Add support for implementign custom window object for pandas backend
 * :bug:`2237` Add missing float types to pandas backend
 * :bug:`2252` Allow group_by and order_by as window operation input in pandas backend

--- a/ibis/pandas/execution/tests/test_operations.py
+++ b/ibis/pandas/execution/tests/test_operations.py
@@ -819,17 +819,6 @@ def test_table_distinct(t, df):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("distinct", [True, False])
-def test_union(client, df1, distinct):
-    t = client.table('df1')
-    expr = t.union(t, distinct=distinct)
-    result = expr.execute()
-    expected = (
-        df1 if distinct else pd.concat([df1, df1], axis=0, ignore_index=True)
-    )
-    tm.assert_frame_equal(result, expected)
-
-
 @pytest.mark.parametrize(
     "distinct",
     [

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -302,6 +302,13 @@ def compile_aggregation(t, expr, scope, **kwargs):
         return src_table.agg(*aggs)
 
 
+@compiles(ops.Union)
+def compile_union(t, expr, scope, **kwargs):
+    op = expr.op()
+    result = t.translate(op.left, scope).union(t.translate(op.right, scope))
+    return result.distinct() if op.distinct else result
+
+
 @compiles(ops.Contains)
 def compile_contains(t, expr, scope, **kwargs):
     op = expr.op()

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -163,25 +163,6 @@ def test_filter(client, filter_fn, expected_fn):
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
 
 
-@pytest.mark.parametrize('distinct', [False, True])
-def test_union(client, distinct):
-    table = client.table('basic_table')
-
-    result = table.union(table, distinct=distinct).compile().toPandas()
-
-    if distinct:
-        expected = pd.DataFrame({'id': range(0, 10), 'str_col': 'value'})
-    else:
-        expected = pd.DataFrame(
-            {'id': list(range(0, 10)) * 2, 'str_col': 'value'}
-        )
-
-    result = result.sort_values(['id']).reset_index(drop=True)
-    expected = expected.sort_values(['id']).reset_index(drop=True)
-
-    tm.assert_frame_equal(result, expected)
-
-
 def test_cast(client):
     table = client.table('basic_table')
 

--- a/ibis/pyspark/tests/test_basic.py
+++ b/ibis/pyspark/tests/test_basic.py
@@ -163,6 +163,25 @@ def test_filter(client, filter_fn, expected_fn):
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
 
 
+@pytest.mark.parametrize('distinct', [False, True])
+def test_union(client, distinct):
+    table = client.table('basic_table')
+
+    result = table.union(table, distinct=distinct).compile().toPandas()
+
+    if distinct:
+        expected = pd.DataFrame({'id': range(0, 10), 'str_col': 'value'})
+    else:
+        expected = pd.DataFrame(
+            {'id': list(range(0, 10)) * 2, 'str_col': 'value'}
+        )
+
+    result = result.sort_values(['id']).reset_index(drop=True)
+    expected = expected.sort_values(['id']).reset_index(drop=True)
+
+    tm.assert_frame_equal(result, expected)
+
+
 def test_cast(client):
     table = client.table('basic_table')
 

--- a/ibis/sql/postgres/tests/test_functions.py
+++ b/ibis/sql/postgres/tests/test_functions.py
@@ -593,24 +593,6 @@ def test_category_label(alltypes, df):
     tm.assert_series_equal(result, expected)
 
 
-def test_union(alltypes):
-    t = alltypes
-
-    expr = (
-        t.group_by('string_col')
-        .aggregate(t.double_col.sum().name('foo'))
-        .sort_by('string_col')
-    )
-
-    t1 = expr.limit(4)
-    t2 = expr.limit(4, offset=4)
-    t3 = expr.limit(8)
-
-    result = t1.union(t2).execute()
-    expected = t3.execute()
-    tm.assert_frame_equal(result, expected)
-
-
 @pytest.mark.parametrize(
     ('distinct1', 'distinct2', 'expected1', 'expected2'),
     [

--- a/ibis/tests/all/test_union.py
+++ b/ibis/tests/all/test_union.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import pytest
+
+from ibis.tests.backends import BigQuery, Impala, Pandas, PostgreSQL, PySpark
+
+
+@pytest.mark.parametrize('distinct', [False, True])
+@pytest.mark.only_on_backends([BigQuery, Impala, Pandas, PostgreSQL, PySpark])
+@pytest.mark.xfail_unsupported
+def test_union(backend, alltypes, df, distinct):
+    result = alltypes.union(alltypes, distinct=distinct).execute()
+    expected = df if distinct else pd.concat([df, df], axis=0)
+
+    # Result is not in original order on PySpark backend when distinct=True
+    result = result.sort_values(['id'])
+    expected = expected.sort_values(['id'])
+
+    backend.assert_frame_equal(result, expected)


### PR DESCRIPTION
Add a compilation function for the `Union` node in the PySpark backend (roughly mirroring [the execution function for `Union` in the Pandas backend](https://github.com/ibis-project/ibis/blob/master/ibis/pandas/execution/generic.py#L762)).

#### Testing

Added a new test in `pyspark/tests/test_basic.py` to test the compilation function (exposed by [`union`](https://github.com/ibis-project/ibis/blob/master/ibis/expr/api.py#L4290) in the table API)