### PR TITLE
CI: Pinning pymapd to 0.23 to speed up conda solver

### DIFF
--- a/ci/requirements-dev-3.6-main.yml
+++ b/ci/requirements-dev-3.6-main.yml
@@ -31,7 +31,7 @@ dependencies:
   - pydata-google-auth
   - pydocstyle=4.0.1
   - pygit2
-  - pymapd>=0.24
+  - pymapd=0.23
   - pymysql
   - pyspark>=2.4.3
   - pytables>=3.0.0

--- a/ci/requirements-dev-3.6-main.yml
+++ b/ci/requirements-dev-3.6-main.yml
@@ -31,7 +31,7 @@ dependencies:
   - pydata-google-auth
   - pydocstyle=4.0.1
   - pygit2
-  - pymapd>=0.22
+  - pymapd>=0.24
   - pymysql
   - pyspark>=2.4.3
   - pytables>=3.0.0

--- a/ci/requirements-dev-3.7-main.yml
+++ b/ci/requirements-dev-3.7-main.yml
@@ -31,7 +31,7 @@ dependencies:
   - pydata-google-auth
   - pydocstyle=4.0.1
   - pygit2
-  - pymapd>=0.24
+  - pymapd=0.23
   - pymysql
   - pyspark>=2.4.3
   - pytables>=3.0.0

--- a/ci/requirements-dev-3.7-main.yml
+++ b/ci/requirements-dev-3.7-main.yml
@@ -31,7 +31,7 @@ dependencies:
   - pydata-google-auth
   - pydocstyle=4.0.1
   - pygit2
-  - pymapd>=0.22
+  - pymapd>=0.24
   - pymysql
   - pyspark>=2.4.3
   - pytables>=3.0.0


### PR DESCRIPTION
Closes #2271 

This should speed up conda, from taking more than one hour, to taking 30 minutes. It's still a lot, without pymapd it takes less than 5 minutes. But if this leaves the CI green, probably worth merging while we find a better solution.