### PR TITLE
CI: Add some unsupported BigQuery ops inherited from Impala

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -34,10 +34,10 @@ Release Notes
 * :feature:`2062` Implement read_csv for omniscidb backend
 * :feature:`2171` [OmniSciDB] Add support to week extraction
 * :feature:`2097` Date, DateDiff and TimestampDiff implementations for OmniSciDB
-* :bug:`2170` Fix millisecond issue for OmniSciDB :issue:`2167`, MySQL :issue:`2169`, PostgreSQL :issue:`2166` and Pandas :issue:`2168` backends
+* :bug:`2170` Fix millisecond issue for OmniSciDB :issue:`2167`, MySQL :issue:`2169`, PostgreSQL :issue:`2166`, Pandas :issue:`2168`, BigQuery :issue:`2273` backends
 * :feature:`2060` Add initial support for ibis.random function
 * :support:`2107` Added fragment_size to table creation for OmniSciDB
-* :feature:`2178` Added epoch_seconds extraction operation to Clickhouse, CSV, Impala, MySQL, OmniSciDB, Pandas, Parquet, PostgreSQL, PySpark, SQLite and Spark
+* :feature:`2178` Added epoch_seconds extraction operation to Clickhouse, CSV, Impala, MySQL, OmniSciDB, Pandas, Parquet, PostgreSQL, PySpark, SQLite, Spark and BigQuery :issue:`2273`
 * :feature:`2117` Add non-nullable info to schema output
 * :feature:`2083` fillna and nullif implementations for OmnisciDB
 * :feature:`1981` Add load_data to sqlalchemy's backends and fix database parameter for load/create/drop when database parameter is the same than the current database

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -395,7 +395,7 @@ _invalid_operations = {
     ops.DateDiff,
     ops.TimestampDiff,
     ops.ExtractEpochSeconds,
-    ops.ExtractQuarter
+    ops.ExtractQuarter,
 }
 
 _operation_registry = {

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -96,9 +96,9 @@ def _extract_field(sql_attr):
         op = expr.op()
         arg = translator.translate(op.args[0])
         if sql_attr == 'epochseconds':
-            return 'UNIX_SECONDS({})'.format(arg)
+            return f'UNIX_SECONDS({arg})'
         else:
-            return 'EXTRACT({} from {})'.format(sql_attr, arg)
+            return f'EXTRACT({sql_attr} from {arg})'
 
     return extract_field_formatter
 

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -394,6 +394,8 @@ _invalid_operations = {
     ops.Capitalize,
     ops.DateDiff,
     ops.TimestampDiff,
+    ops.ExtractEpochSeconds,
+    ops.ExtractQuarter
 }
 
 _operation_registry = {

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -95,7 +95,10 @@ def _extract_field(sql_attr):
     def extract_field_formatter(translator, expr):
         op = expr.op()
         arg = translator.translate(op.args[0])
-        return 'EXTRACT({} from {})'.format(sql_attr, arg)
+        if sql_attr == 'epochseconds':
+            return 'UNIX_SECONDS({})'.format(arg)
+        else:
+            return 'EXTRACT({} from {})'.format(sql_attr, arg)
 
     return extract_field_formatter
 
@@ -337,12 +340,14 @@ _operation_registry = impala_compiler._operation_registry.copy()
 _operation_registry.update(
     {
         ops.ExtractYear: _extract_field('year'),
+        ops.ExtractQuarter: _extract_field('quarter'),
         ops.ExtractMonth: _extract_field('month'),
         ops.ExtractDay: _extract_field('day'),
         ops.ExtractHour: _extract_field('hour'),
         ops.ExtractMinute: _extract_field('minute'),
         ops.ExtractSecond: _extract_field('second'),
         ops.ExtractMillisecond: _extract_field('millisecond'),
+        ops.ExtractEpochSeconds: _extract_field('epochseconds'),
         ops.StringReplace: fixed_arity('REPLACE', 3),
         ops.StringSplit: fixed_arity('SPLIT', 2),
         ops.StringConcat: _string_concat,
@@ -394,8 +399,6 @@ _invalid_operations = {
     ops.Capitalize,
     ops.DateDiff,
     ops.TimestampDiff,
-    ops.ExtractEpochSeconds,
-    ops.ExtractQuarter,
 }
 
 _operation_registry = {


### PR DESCRIPTION
These two test were failing on master.

https://dev.azure.com/ibis-project/ibis/_build/results?buildId=2744&view=logs&j=1cbd69f0-78ce-5895-4e19-fcb1e813c2be&t=a8633626-0096-538a-5a80-67d017a633d1&l=1248
https://dev.azure.com/ibis-project/ibis/_build/results?buildId=2744&view=logs&j=1cbd69f0-78ce-5895-4e19-fcb1e813c2be&t=a8633626-0096-538a-5a80-67d017a633d1&l=1360

These ops were inherited from Impala but it doesn't look like they are supported by BigQuery