### PR TITLE
Add omniscidb udf support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
           - 6274:6274
           - 6278:6278
         volumes:
-          - omniscidb.conf:/omnisci-storage/omnisci.conf
+          - ci/omniscidb.conf:/omnisci-storage/omnisci.conf
     steps:
     - name: checkout
       uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
           - 6274:6274
           - 6278:6278
         volumes:
-          - ci/omniscidb.conf:/omnisci-storage/omnisci.conf
+          - ./ci/omniscidb.conf:/omnisci-storage/omnisci.conf
     steps:
     - name: checkout
       uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
           - 6274:6274
           - 6278:6278
         volumes:
-          - ./ci/omniscidb.conf:/omnisci-storage/omnisci.conf
+          - $HOME/ci/omniscidb.conf:/omnisci-storage/omnisci.conf
     steps:
     - name: checkout
       uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
           - 6274:6274
           - 6278:6278
         volumes:
-          - $HOME/ci/omniscidb.conf:/omnisci-storage/omnisci.conf
+          - /home/runner/work/ibis/ibis/ci/omniscidb.conf:/omnisci-storage/omnisci.conf
     steps:
     - name: checkout
       uses: actions/checkout@v1

--- a/ci/omniscidb.conf
+++ b/ci/omniscidb.conf
@@ -1,3 +1,5 @@
 enable-watchdog = false
 enable-window-functions = true
 cpu-buffer-mem-bytes = 1000000000
+enable-runtime-udf = true
+enable-table-functions = true

--- a/ibis/backends/omniscidb/client.py
+++ b/ibis/backends/omniscidb/client.py
@@ -16,6 +16,10 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.client import Database, DatabaseEntity, Query, SQLClient
+from ibis.omniscidb import ddl
+from ibis.omniscidb import dtypes as omniscidb_dtypes
+from ibis.omniscidb.compiler import OmniSciDBDialect, build_ast
+from ibis.omniscidb.udf import OmniSciDBUDF
 from ibis.sql.compiler import DDL, DML
 from ibis.util import log
 
@@ -649,6 +653,14 @@ class OmniSciDBClient(SQLClient):
                 dbname=database,
                 protocol=protocol,
             )
+        # used for UDF
+        self.udf = OmniSciDBUDF(
+            host=self.con._host,
+            port=self.con._port,
+            database=self.con._dbname,
+            user=self.con._user,
+            password=self.con._password,
+        )
 
     def __del__(self):
         """Close the connection when instance is deleted."""

--- a/ibis/backends/omniscidb/dtypes.py
+++ b/ibis/backends/omniscidb/dtypes.py
@@ -69,3 +69,8 @@ ibis_dtypes_str_to_sql = {
     'time': 'time',
     'timestamp': 'timestamp',
 }
+
+# example: {dt.int64: 'int64'}
+ibis_dtypes_to_str = {}
+for sql_type, ibis_type in sql_to_ibis_dtypes.items():
+    ibis_dtypes_to_str[ibis_type] = str(ibis_type)

--- a/ibis/backends/omniscidb/operations.py
+++ b/ibis/backends/omniscidb/operations.py
@@ -943,6 +943,17 @@ def _window_op_one_param(name):
     return formatter
 
 
+# UDF
+
+
+def _udf(traslator, expr):
+    """UDF translation."""
+    f_name = expr._arg.func.__name__
+    args_translated = ', '.join(map(traslator.translate, expr._arg.func_args))
+
+    return '{}({})'.format(f_name, args_translated)
+
+
 # operation map
 
 _binary_infix_ops = {
@@ -1105,6 +1116,13 @@ _window_ops = {
     ops.WindowOp: _window,
 }
 
+# UDF
+_udf_ops = {
+    ops.ElementWiseVectorizedUDF: _udf,
+    ops.ReductionVectorizedUDF: _udf,
+    ops.AnalyticVectorizedUDF: _udf,
+}
+
 # UNSUPPORTED OPERATIONS
 _unsupported_ops = [
     # generic/aggregation
@@ -1174,5 +1192,6 @@ _operation_registry.update(_date_ops)
 _operation_registry.update(_agg_ops)
 _operation_registry.update(_geospatial_ops)
 _operation_registry.update(_window_ops)
+_operation_registry.update(_udf_ops)
 # the last update should be with unsupported ops
 _operation_registry.update(_unsupported_ops)

--- a/ibis/omniscidb/tests/test_udf.py
+++ b/ibis/omniscidb/tests/test_udf.py
@@ -1,0 +1,94 @@
+import pandas as pd
+import pytest
+
+import ibis
+import ibis.expr.datatypes as dt
+import ibis.expr.types as ir
+
+pymapd = pytest.importorskip('pymapd')
+rbc = pytest.importorskip('rbc')
+
+pytestmark = pytest.mark.omniscidb
+
+
+@pytest.fixture
+def add_number(con):
+    def my_add_number(left, right):
+        return left + right
+
+    for dtype in [
+        dt.float32,
+        dt.float64,
+        dt.int8,
+        dt.int16,
+        dt.int32,
+        dt.int64,
+    ]:
+        con.udf.elementwise(
+            input_type=[dtype, dtype], output_type=dtype, infer_literal=True
+        )(my_add_number)
+    return my_add_number
+
+
+@pytest.mark.parametrize(
+    'left_arg, right_arg, expected_fn',
+    [
+        pytest.param(
+            lambda t: t.float_col,
+            lambda t: t.float_col,
+            lambda df: df.float_col + df.float_col,
+            id='elementwise_float_col_plus_float_col',
+        ),
+        pytest.param(
+            lambda t: t.double_col,
+            lambda t: t.double_col,
+            lambda df: df.double_col + df.double_col,
+            id='elementwise_double_col_plus_double_col',
+        ),
+        pytest.param(
+            lambda t: t.int_col,
+            lambda t: t.int_col,
+            lambda df: df.int_col + df.int_col,
+            id='elementwise_int_col_plus_int_col',
+        ),
+        pytest.param(
+            lambda t: t.bigint_col,
+            lambda t: t.bigint_col,
+            lambda df: df.bigint_col + df.bigint_col,
+            id='elementwise_bigint_col_plus_bigint_col',
+        ),
+        pytest.param(
+            lambda t: t.int_col,
+            lambda t: 1,
+            lambda df: df.int_col + 1,
+            id='elementwise_int_col_plus_literal_int',
+        ),
+        pytest.param(
+            lambda t: t.float_col,
+            lambda t: 1.0,
+            lambda df: df.float_col + 1.0,
+            id='elementwise_float_col_plus_literal_float',
+        ),
+        pytest.param(
+            lambda t: t.bigint_col,
+            lambda t: ibis.literal(1, type='int64'),
+            lambda df: df.bigint_col + 1,
+            id='elementwise_bigint_col_plus_literal_bigint',
+        ),
+    ],
+)
+def test_elementwise_udf_number(
+    con, alltypes, add_number, left_arg, right_arg, expected_fn
+):
+    expr = add_number(left_arg(alltypes), right_arg(alltypes))
+
+    assert isinstance(expr, ir.ColumnExpr)
+    assert isinstance(expr, ir.NumericColumn)
+
+    result = expr.execute()
+
+    df = alltypes.execute()
+    expected = expected_fn(df)
+    pd.testing.assert_series_equal(
+        result, expected, check_dtype=False, check_names=False
+    )

--- a/ibis/omniscidb/udf.py
+++ b/ibis/omniscidb/udf.py
@@ -1,0 +1,199 @@
+"""OmniSciDB User Defined Function (UDF) Implementation."""
+import types
+from typing import Callable, List, Optional
+
+from rbc.omniscidb import RemoteOmnisci
+
+from ibis.expr import datatypes as dt
+from ibis.omniscidb.dtypes import ibis_dtypes_to_str
+from ibis.udf import vectorized
+
+
+def _create_function(name, nargs):
+    """
+    Create a function dinamically for the given name and number of arguments.
+
+    Parameters
+    ----------
+    name : str
+        name of the function
+    nargs : int
+        number of the arguments the function accept.
+
+    Returns
+    -------
+    Callable
+    """
+    # this function is used just as a template
+    def y():
+        pass
+
+    args_name = tuple('arg{}'.format(i) for i in range(nargs))
+
+    co_args = (
+        nargs,  # argcount
+        0,  # kwonlyargcount
+        0,  # nlocals
+        1,  # stacksize
+        0,  # flags
+        bytes(),  # codestring
+        (),  # constants
+        args_name,  # names
+        args_name,  # varnames
+        y.__code__.co_filename,  # filename
+        name,  # name
+        0,  # firstlineno
+        bytes(),  # lnotab
+    )
+    new_code = types.CodeType(*co_args)
+    return types.FunctionType(new_code, {}, name)
+
+
+class OmniSciDBUDF:
+    """
+    OmniSciDB UDF class.
+
+    OmniSciDB uses RBC (Remote Backend Client) to support UDF.
+    """
+
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        port: Optional[int] = 6274,
+        database: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+    ):
+        self.remote_backend_compiler = RemoteOmnisci(
+            host=host,
+            port=port,
+            dbname=database,
+            user=user,
+            password=password,
+        )
+
+    def _udf(
+        self,
+        udf_operation: Callable,
+        input_type: List[dt.DataType],
+        output_type: Optional[dt.DataType] = None,
+        name: Optional[str] = None,
+        infer_literal: bool = True,
+    ) -> Callable:
+        """
+        Elementwise operation for UDF.
+
+        Parameters
+        ----------
+        udf_operation : Callable
+            Used for creating UDF operation
+        input_type : List[dt.DataType]
+        output_type: dt.DataType
+        name : str
+            Used for reusing an existent UDF
+        infer_literal : bool, default True
+            Define if literal scalar values should be infered or if this method
+            should accept explicitly just ibis literal.
+
+        Returns
+        -------
+        Callable
+
+        """
+        if name:
+            f = _create_function(name, len(input_type))
+            return udf_operation(
+                input_type, output_type, infer_literal=infer_literal
+            )(f)
+
+        def omnisci_wrapper(f, input_type=input_type, output_type=output_type):
+            signature = '{}({})'.format(
+                ibis_dtypes_to_str[output_type],
+                ', '.join([ibis_dtypes_to_str[v] for v in input_type]),
+            )
+
+            if isinstance(f, vectorized.UserDefinedFunction):
+                f = f.func
+
+            self.remote_backend_compiler(signature)(f)
+            self.remote_backend_compiler.register()
+            return udf_operation(
+                input_type, output_type, infer_literal=infer_literal
+            )(f)
+
+        return omnisci_wrapper
+
+    def elementwise(
+        self,
+        input_type: List[dt.DataType],
+        output_type: Optional[dt.DataType] = None,
+        name: Optional[str] = None,
+        infer_literal: bool = True,
+    ) -> Callable:
+        """
+        Create an elementwise UDF operation.
+
+        Parameters
+        ----------
+        input_type : List[dt.DataType]
+        output_type: dt.DataType
+        name : str
+            Used for reusing an existent UDF
+        infer_literal : bool, default True
+            Define if literal scalar values should be infered or if this method
+            should accept explicitly just ibis literal.
+
+        Returns
+        -------
+        Callable
+
+        """
+        return self._udf(
+            udf_operation=vectorized.elementwise,
+            input_type=input_type,
+            output_type=output_type,
+            name=name,
+            infer_literal=infer_literal,
+        )
+
+    def reduction(
+        self,
+        input_type: List[dt.DataType],
+        output_type: Optional[dt.DataType] = None,
+        name: Optional[str] = None,
+    ) -> Callable:
+        """
+        Create a reduction UDF operation.
+
+        Parameters
+        ----------
+        input_type : List[dt.DataType]
+        output_type: dt.DataType
+        name : str
+            Used for reusing an existent UDF
+        Returns
+        -------
+        Callable
+        """
+        raise NotImplementedError('UDF Reduction is not implemented yet.')
+
+    def analytic(
+        self,
+        input_type: List[dt.DataType],
+        output_type: Optional[dt.DataType] = None,
+        name: Optional[str] = None,
+    ) -> Callable:
+        """
+        Create an analytic UDF operation.
+
+        Parameters
+        ----------
+        input_type : List[dt.DataType]
+        output_type: dt.DataType
+        name : str
+            Used for reusing an existent UDF
+        Returns
+        -------
+        Callable
+        """
+        raise NotImplementedError('UDF Analytic is not implemented yet.')

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ inherit = false
 convention = numpy
 
 [isort]
-known_third_party = asv,click,clickhouse_driver,dateutil,google,graphviz,impala,kudu,mock,multipledispatch,numpy,pandas,pkg_resources,plumbum,psycopg2,pyarrow,pydata_google_auth,pygit2,pymapd,pymysql,pyspark,pytest,pytz,regex,requests,setuptools,sphinx_rtd_theme,sqlalchemy,thrift,toolz
+known_third_party = asv,click,clickhouse_driver,dateutil,google,graphviz,impala,kudu,mock,multipledispatch,numpy,pandas,pkg_resources,plumbum,psycopg2,pyarrow,pydata_google_auth,pygit2,pymapd,pymysql,pyspark,pytest,pytz,rbc,regex,requests,setuptools,sphinx_rtd_theme,sqlalchemy,thrift,toolz
 ensure_newline_before_comments=true
 line_length = 79
 multi_line_output = 3


### PR DESCRIPTION
This PR aims to add initial support for OmniSciDB UDF. 
Currently, it adds support just for numeric data types (float and int) and just for elementwise operations.

Some information about this PR:

- OmniSciDB UDF uses RBC library (that is already a dependency of `pymapd`)
- Add an option that allows python literals as arguments for the UDF calls
