### PR TITLE
CI: Pin pytest version to be below 6.0.0rc1 to fix failing CI

### DIFF
--- a/ci/requirements-dev-3.6-main.yml
+++ b/ci/requirements-dev-3.6-main.yml
@@ -35,7 +35,7 @@ dependencies:
   - pymysql
   - pyspark>=2.4.3
   - pytables>=3.0.0
-  - pytest>=4.5, <=5.4.3
+  - pytest>=4.5, <6.0.0rc1
   - pytest-cov
   - pytest-mock
   - pytest-xdist

--- a/ci/requirements-dev-3.6-main.yml
+++ b/ci/requirements-dev-3.6-main.yml
@@ -35,7 +35,7 @@ dependencies:
   - pymysql
   - pyspark>=2.4.3
   - pytables>=3.0.0
-  - pytest>=4.5
+  - pytest>=4.5, <=5.4.3
   - pytest-cov
   - pytest-mock
   - pytest-xdist

--- a/ci/requirements-dev-3.6-pyspark-spark.yml
+++ b/ci/requirements-dev-3.6-pyspark-spark.yml
@@ -23,7 +23,7 @@ dependencies:
   - pydocstyle=4.0.1
   - pygit2
   - pyspark>=2.4.3
-  - pytest>=4.5, <=5.4.3
+  - pytest>=4.5, <6.0.0rc1
   - pytest-cov
   - pytest-mock
   - pytest-xdist

--- a/ci/requirements-dev-3.6-pyspark-spark.yml
+++ b/ci/requirements-dev-3.6-pyspark-spark.yml
@@ -23,7 +23,7 @@ dependencies:
   - pydocstyle=4.0.1
   - pygit2
   - pyspark>=2.4.3
-  - pytest>=4.5
+  - pytest>=4.5, <=5.4.3
   - pytest-cov
   - pytest-mock
   - pytest-xdist

--- a/ci/requirements-dev-3.7-main.yml
+++ b/ci/requirements-dev-3.7-main.yml
@@ -35,7 +35,7 @@ dependencies:
   - pymysql
   - pyspark>=2.4.3
   - pytables>=3.0.0
-  - pytest>=4.5, <=5.4.3
+  - pytest>=4.5, <6.0.0rc1
   - pytest-cov
   - pytest-mock
   - pytest-xdist

--- a/ci/requirements-dev-3.7-main.yml
+++ b/ci/requirements-dev-3.7-main.yml
@@ -35,7 +35,7 @@ dependencies:
   - pymysql
   - pyspark>=2.4.3
   - pytables>=3.0.0
-  - pytest>=4.5
+  - pytest>=4.5, <=5.4.3
   - pytest-cov
   - pytest-mock
   - pytest-xdist

--- a/ci/requirements-dev-3.7-pyspark-spark.yml
+++ b/ci/requirements-dev-3.7-pyspark-spark.yml
@@ -23,7 +23,7 @@ dependencies:
   - pydocstyle=4.0.1
   - pygit2
   - pyspark>=2.4.3
-  - pytest>=4.5, <=5.4.3
+  - pytest>=4.5, <6.0.0rc1
   - pytest-cov
   - pytest-mock
   - pytest-xdist

--- a/ci/requirements-dev-3.7-pyspark-spark.yml
+++ b/ci/requirements-dev-3.7-pyspark-spark.yml
@@ -23,7 +23,7 @@ dependencies:
   - pydocstyle=4.0.1
   - pygit2
   - pyspark>=2.4.3
-  - pytest>=4.5
+  - pytest>=4.5, <=5.4.3
   - pytest-cov
   - pytest-mock
   - pytest-xdist

--- a/ci/requirements-dev-3.8-main.yml
+++ b/ci/requirements-dev-3.8-main.yml
@@ -39,7 +39,7 @@ dependencies:
   # https://github.com/apache/spark/pull/26194#issuecomment-566592265
   # - pyspark>=3.0
   - pytables>=3.0.0
-  - pytest>=4.5, <=5.4.3
+  - pytest>=4.5, <6.0.0rc1
   - pytest-cov
   - pytest-mock
   - pytest-xdist

--- a/ci/requirements-dev-3.8-main.yml
+++ b/ci/requirements-dev-3.8-main.yml
@@ -39,7 +39,7 @@ dependencies:
   # https://github.com/apache/spark/pull/26194#issuecomment-566592265
   # - pyspark>=3.0
   - pytables>=3.0.0
-  - pytest>=4.5
+  - pytest>=4.5, <=5.4.3
   - pytest-cov
   - pytest-mock
   - pytest-xdist


### PR DESCRIPTION
This PR is an immediate (and maybe temporary) fix for the failing CI (#2275)

I'll soon add a commit to pin `pytest` to be <=5.4.3, but I'm starting with an empty commit just to confirm that the CI fails in the current state