### PR TITLE
FEAT: Add scope and kwargs to get_aggcontext to allow passing custom data s…

### DIFF
--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -688,7 +688,7 @@ def test_custom_window_udf(t, custom_window):
 
     @get_aggcontext.register(CustomWindow)
     def get_aggcontext_custom(
-        window, *, operand, operand_dtype, parent, group_by, order_by
+        window, *, scope, operand, operand_dtype, parent, group_by, order_by
     ):
         return CustomAggContext(
             parent=parent,

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -688,8 +688,17 @@ def test_custom_window_udf(t, custom_window):
 
     @get_aggcontext.register(CustomWindow)
     def get_aggcontext_custom(
-        window, *, scope, operand, operand_dtype, parent, group_by, order_by
+        window,
+        *,
+        scope,
+        operand,
+        operand_dtype,
+        parent,
+        group_by,
+        order_by,
+        dummy_custom_window_data,
     ):
+        assert dummy_custom_window_data == 'dummy_data'
         # scope and operand are not used here
         return CustomAggContext(
             parent=parent,
@@ -700,7 +709,11 @@ def test_custom_window_udf(t, custom_window):
             preceding=window.preceding,
         )
 
-    result = my_sum(t['plain_float64']).over(custom_window).execute()
+    result = (
+        my_sum(t['plain_float64'])
+        .over(custom_window)
+        .execute(dummy_custom_window_data='dummy_data')
+    )
     expected = pd.Series([4.0, 10.0, 5.0])
 
     tm.assert_series_equal(result, expected)

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -690,6 +690,7 @@ def test_custom_window_udf(t, custom_window):
     def get_aggcontext_custom(
         window, *, scope, operand, operand_dtype, parent, group_by, order_by
     ):
+        # scope and operand are not used here
         return CustomAggContext(
             parent=parent,
             group_by=group_by,

--- a/ibis/pandas/execution/window.py
+++ b/ibis/pandas/execution/window.py
@@ -71,7 +71,15 @@ def _post_process_group_by_order_by(series, parent, order_by, group_by):
 
 @functools.singledispatch
 def get_aggcontext(
-    window, *, operand, operand_dtype, parent, group_by, order_by
+    window,
+    *,
+    scope,
+    operand,
+    operand_dtype,
+    parent,
+    group_by,
+    order_by,
+    **kwargs,
 ) -> NoReturn:
     raise NotImplementedError(
         f"get_aggcontext is not implemented for {type(window).__name__}"
@@ -80,7 +88,15 @@ def get_aggcontext(
 
 @get_aggcontext.register(win.Window)
 def get_aggcontext_window(
-    window, *, operand, operand_dtype, parent, group_by, order_by
+    window,
+    *,
+    scope,
+    operand,
+    operand_dtype,
+    parent,
+    group_by,
+    order_by,
+    **kwargs,
 ) -> AggregationContext:
     # no order by or group by: default summarization aggcontext
     #
@@ -218,11 +234,13 @@ def execute_window_op(
 
     aggcontext = get_aggcontext(
         window,
+        scope=scope,
         operand=operand,
         operand_dtype=operand_dtype,
         parent=source,
         group_by=grouping_keys,
         order_by=ordering_keys,
+        **kwargs,
     )
 
     result = execute(


### PR DESCRIPTION
…tructures when connstructinng aggcontext

In #2260 , we added support to construct custom window aggregation context. This PR is a follow up to #2260 to allow user to pass additional data structure to `get_aggcontext`. For example, when user want to define a custom business day window, it's reasonable that the user is allowed to pass in additional data structure for computing the custom business day. This PR adds support for this use case.