### PR TITLE
Allow vectorized UDFs to accept *args

### DIFF
--- a/ibis/pandas/tests/test_udf.py
+++ b/ibis/pandas/tests/test_udf.py
@@ -58,7 +58,7 @@ def my_string_length(series, **kwargs):
 
 
 @udf.elementwise(input_type=[dt.double, dt.double], output_type=dt.double)
-def my_add(series1, series2, *kwargs):
+def my_add(series1, series2, **kwargs):
     return series1 + series2
 
 

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -36,7 +36,7 @@ def test_output_type_in_list_invalid(backend, alltypes, df):
 @pytest.mark.only_on_backends([Pandas, PySpark])
 @pytest.mark.xfail_unsupported
 def test_valid_kwargs(backend, alltypes, df):
-    # Test different forms of UDF definition
+    # Test different forms of UDF definition with keyword arguments
 
     @elementwise(input_type=[dt.double], output_type=dt.double)
     def foo1(v):
@@ -76,11 +76,81 @@ def test_valid_kwargs(backend, alltypes, df):
 
 @pytest.mark.only_on_backends([Pandas, PySpark])
 @pytest.mark.xfail_unsupported
+def test_valid_args(backend, alltypes, df):
+    # Test UDF with variable-length positional arguments (e.g. *args)
+
+    @elementwise(input_type=[dt.double, dt.string], output_type=dt.double)
+    def foo1(*args):
+        return args[0] + len(args[1])
+
+    result = alltypes.mutate(
+        v1=foo1(alltypes['double_col'], alltypes['string_col']),
+    ).execute()
+
+    expected = df.assign(v1=df['double_col'] + len(df['string_col']),)
+
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.only_on_backends([Pandas, PySpark])
+@pytest.mark.xfail_unsupported
+def test_valid_args_and_kwargs(backend, alltypes, df):
+    # Test UDFs with both variable-length positional arguments (e.g. *args)
+    # and keyword arguments
+
+    @elementwise(input_type=[dt.double, dt.string], output_type=dt.double)
+    def foo1(*args, amount):
+        # UDF with *args and a keyword-only argument
+        return args[0] + len(args[1]) + amount
+
+    @elementwise(input_type=[dt.double, dt.string], output_type=dt.double)
+    def foo2(*args, **kwargs):
+        # UDF with *args and **kwargs
+        return args[0] + len(args[1]) + kwargs.get('amount', 1)
+
+    result = alltypes.mutate(
+        v1=foo1(alltypes['double_col'], alltypes['string_col'], amount=1),
+        v2=foo1(alltypes['double_col'], alltypes['string_col'], amount=2),
+        v3=foo2(alltypes['double_col'], alltypes['string_col']),
+        v4=foo2(alltypes['double_col'], alltypes['string_col'], amount=2),
+        v5=foo2(alltypes['double_col'], alltypes['string_col'], amount=3),
+    ).execute()
+
+    expected = df.assign(
+        v1=df['double_col'] + len(df['string_col']) + 1,
+        v2=df['double_col'] + len(df['string_col']) + 2,
+        v3=df['double_col'] + len(df['string_col']) + 1,
+        v4=df['double_col'] + len(df['string_col']) + 2,
+        v5=df['double_col'] + len(df['string_col']) + 3,
+    )
+
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.only_on_backends([Pandas, PySpark])
+@pytest.mark.xfail_unsupported
 def test_invalid_kwargs(backend, alltypes):
-    # Test different invalid UDFs
+    # Test that defining a UDF with a non-column argument that is not a
+    # keyword argument raises an error
 
     with pytest.raises(TypeError, match=".*must be defined as keyword only.*"):
 
         @elementwise(input_type=[dt.double], output_type=dt.double)
         def foo1(v, amount):
             return v + 1
+
+
+@pytest.mark.only_on_backends([Pandas, PySpark])
+@pytest.mark.xfail_unsupported
+def test_invalid_args(backend, alltypes, df):
+    # Test that defining a UDF with both positional arguments and variable-
+    # length positional arguments (e.g. *args) raises an error
+
+    with pytest.raises(
+        com.IbisError,
+        match=".*cannot have both positional arguments and \\*args",
+    ):
+
+        @elementwise(input_type=[dt.double, dt.string], output_type=dt.double)
+        def foo1(v, *args):
+            return v + len(args[0])

--- a/ibis/udf/validate.py
+++ b/ibis/udf/validate.py
@@ -5,8 +5,8 @@ Warning: This is an experimental module and API here can change without notice.
 DO NOT USE DIRECTLY.
 """
 
-from inspect import Parameter, signature
-from typing import Any, Callable, List
+from inspect import Parameter, _ParameterKind, signature
+from typing import Any, Callable, List, Set
 
 import ibis.common.exceptions as com
 from ibis.expr.datatypes import DataType
@@ -33,11 +33,54 @@ def _parameter_count(funcsig: signature) -> int:
     )
 
 
+def _parameter_kinds(funcsig: signature) -> Set[_ParameterKind]:
+    """Returns a set containing the kinds of parameters that are defined in
+    the function signature. For example, a function with **kwargs would have
+    typing._ParameterKind.VAR_KEYWORD in its set of parameter kinds.
+
+    Parameters
+    ----------
+    funcsig : inspect.Signature
+        A UDF signature
+
+    Returns
+    -------
+    Set[typing._ParameterKind]
+        Set containing the kinds of parameters in the function signature
+    """
+    return {param.kind for param in funcsig.parameters.values()}
+
+
+def validate_parameter_kinds(func: Callable) -> None:
+    """Check that the kinds of parameters used in the signature of `func` is
+    valid, and raises an error otherwise.
+
+    The signature is invalid if both positional-only arguments and *args are
+    used at the same time in the function signature.
+
+    Parameters
+    ----------
+    func : callable
+    """
+    kinds = _parameter_kinds(signature(func))
+
+    if Parameter.VAR_POSITIONAL in kinds and (
+        Parameter.POSITIONAL_ONLY in kinds
+        or Parameter.POSITIONAL_OR_KEYWORD in kinds
+    ):
+        raise com.IbisError(
+            'UDF signature cannot have both positional arguments and *args'
+        )
+
+
 def validate_input_type(
     input_type: List[DataType], func: Callable
 ) -> signature:
     """Check that the declared number of inputs (the length of `input_type`)
     and the number of inputs to `func` are equal.
+
+    If `func` is defined to use *args rather than a fixed number of positional
+    arguments, then no check is done (since no check can be done).
 
     Parameters
     ----------
@@ -49,20 +92,23 @@ def validate_input_type(
     inspect.Signature
     """
     funcsig = signature(func)
-    declared_parameter_count = len(input_type)
-    function_parameter_count = _parameter_count(funcsig)
 
-    if declared_parameter_count != function_parameter_count:
-        raise TypeError(
-            'Function signature {!r} has {:d} parameters, '
-            'input_type has {:d}. These must match. Non-column '
-            'parameters must be defined as keyword only, i.e., '
-            'def foo(col, *, function_param).'.format(
-                func.__name__,
-                function_parameter_count,
-                declared_parameter_count,
+    if Parameter.VAR_POSITIONAL not in _parameter_kinds(funcsig):
+        declared_parameter_count = len(input_type)
+        function_parameter_count = _parameter_count(funcsig)
+
+        if declared_parameter_count != function_parameter_count:
+            raise TypeError(
+                'Function signature {!r} has {:d} parameters, '
+                'input_type has {:d}. These must match. Non-column '
+                'parameters must be defined as keyword only, i.e., '
+                'def foo(col, *, function_param).'.format(
+                    func.__name__,
+                    function_parameter_count,
+                    declared_parameter_count,
+                )
             )
-        )
+
     return funcsig
 
 

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -23,7 +23,6 @@ class UserDefinedFunction(object):
     """
 
     def __init__(self, func, func_type, input_type, output_type):
-        v.validate_parameter_kinds(func)
         v.validate_input_type(input_type, func)
         v.validate_output_type(output_type)
 

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -23,6 +23,7 @@ class UserDefinedFunction(object):
     """
 
     def __init__(self, func, func_type, input_type, output_type):
+        v.validate_parameter_kinds(func)
         v.validate_input_type(input_type, func)
         v.validate_output_type(output_type)
 


### PR DESCRIPTION
This PR makes it legal to define a vectorized UDF to take `*args` (previously, a `TypeError` is raised):
```
@elementwise(input_type=[dt.double, dt.double], output_type=dt.double)
def add_cols(*args):
    return args[0] + args[1]
```

Before this PR, users _must_ define an explicit positional argument per input defined in `input_type`, like this:
```
@elementwise(input_type=[dt.double, dt.double], output_type=dt.double)
def add_cols(col1, col2):
    return col1 + col2
```

Having to explicitly define the positional arguments is a little restrictive. By allowing `*args`, we'll allow users to dynamically generate UDFs even when the number of columns the UDF should accept is not known beforehand.

### Note

I'm making it illegal to mix `*args` with explicit positional arguments since the function signatures could get pretty confusing (in other words, users will have to choose between only `*args` or only explicit positional arguments). For example, these wouldn't be allowed:
```
@elementwise(input_type=[dt.double, dt.double], output_type=dt.double)
def add_cols(col1, *args):
    return col1 + args[0]
```
```
@elementwise(input_type=[dt.double, dt.double], output_type=dt.double)
def add_cols(col1, *args, amount):
    return col1 + args[0] + amount
```