### PR TITLE
ENH: Add category integration for cast to pandas backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2285` Add support for casting category dtype in pandas backend
 * :feature:`2270` Add support for Union in the PySpark backend
 * :feature:`2260` Add support for implementign custom window object for pandas backend
 * :bug:`2237` Add missing float types to pandas backend

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -874,6 +874,7 @@ _primitive_types = [
     ('time', time),
     ('timestamp', timestamp),
     ('interval', interval),
+    ('category', category),
 ]  # type: List[Tuple[str, DataType]]
 
 

--- a/ibis/pandas/execution/constants.py
+++ b/ibis/pandas/execution/constants.py
@@ -40,6 +40,7 @@ IBIS_TYPE_TO_PANDAS_TYPE = {
     dt.string: str,
     dt.timestamp: 'datetime64[ns]',
     dt.boolean: np.bool_,
+    dt.category: 'category',
 }
 
 

--- a/ibis/pandas/execution/tests/test_cast.py
+++ b/ibis/pandas/execution/tests/test_cast.py
@@ -158,3 +158,11 @@ def test_cast_to_decimal(t, df, type):
         1 <= len(element.as_tuple().digits) <= type.precision
         for element in result.values
     )
+
+
+@pytest.mark.parametrize(
+    'column', ['plain_int64', 'dup_strings', 'dup_ints', 'strings_with_nulls'],
+)
+def test_cast_to_category(t, df, column):
+    test = t[column].cast('category').execute()
+    tm.assert_series_equal(test, df[column].astype('category'))


### PR DESCRIPTION
Noticed that you couldn't use cast with the dtype category