### PR TITLE
DOC: Fix website CNAME and stop using a fork as a base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,3 @@ doc: builddoc docclean
 
 docker_run:
 	$(DOCKER_RUN) ibis $(DOCKER_RUN_COMMAND)
-
-docker_docs_run:
-	$(DOCKER_RUN) ibis-docs $(DOCKER_RUN_COMMAND)

--- a/ci/Dockerfile.docs
+++ b/ci/Dockerfile.docs
@@ -1,25 +1,19 @@
 ARG PYTHON_VERSION
 FROM ibis:$PYTHON_VERSION-main
 
-# fonts are for docs
-RUN apt-get -qq update --yes \
- && apt-get -qq install --yes ttf-dejavu iputils-ping \
- && rm -rf /var/lib/apt/lists/*
-
 ADD ci/requirements-docs.yml /
-
-RUN /opt/conda/bin/conda config --add channels conda-forge \
- && /opt/conda/bin/conda update --all --yes \
- && /opt/conda/bin/conda clean --all --yes
-
-RUN /opt/conda/bin/conda env update --file=/requirements-docs.yml \
- && /opt/conda/bin/conda clean --all --yes
-
-RUN echo 'source /opt/conda/bin/activate ibis-env && exec "$@"' > activate.sh
-
 COPY . /ibis
 WORKDIR /ibis
 
-RUN bash /activate.sh pip install -e . --no-deps --ignore-installed --no-cache-dir
+# fonts are for docs
+RUN apt-get -qq update --yes \
+ && apt-get -qq install --yes ttf-dejavu iputils-ping \
+ && rm -rf /var/lib/apt/lists/* \
+ && /opt/conda/bin/conda config --add channels conda-forge \
+ && /opt/conda/bin/conda update --all --yes \
+ && /opt/conda/bin/conda clean --all --yes \
+ && /opt/conda/bin/conda env update --file=/requirements-docs.yml \
+ && /opt/conda/bin/conda clean --all --yes \
+ && pip install -e . --no-deps --ignore-installed --no-cache-dir
 
-ENTRYPOINT ["bash", "/activate.sh"]
+SHELL ["conda", "run", "-n", "ibis-env", "/bin/bash", "-c"]

--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -266,13 +266,14 @@ jobs:
       displayName: 'Load test datasets'
 
     - bash: |
-        make docker_docs_run DOCKER_RUN_COMMAND="ping -c 1 impala && conda list && \
-                                                 mkdir -p /tmp/ibis-project.org && \
-                                                 cd /tmp/ibis-project.org && \
-                                                 echo \"ibis-project.org\" > CNAME && \
-                                                 touch .nojekyll && \
-                                                 python -m pysuerga /ibis/docs/web --target-path=/tmp/ibis-project.org/ && \
-                                                 sphinx-build -b html /ibis/docs/source /tmp/ibis-project.org/docs -W -T --keep-going"
+        make docker_docs_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="\
+            ping -c 1 impala && conda list && \
+            mkdir -p /tmp/ibis-project.org && \
+            cd /tmp/ibis-project.org && \
+            echo \"ibis-project.org\" > CNAME && \
+            touch .nojekyll && \
+            python -m pysuerga /ibis/docs/web --target-path=/tmp/ibis-project.org/ && \
+            sphinx-build -b html /ibis/docs/source /tmp/ibis-project.org/docs -W -T --keep-going"
       displayName: 'Build website and docs'
 
     - task: PublishPipelineArtifact@1

--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -267,12 +267,12 @@ jobs:
 
     - bash: |
         make docker_docs_run DOCKER_RUN_COMMAND="ping -c 1 impala && conda list && \
-                                                 mkdir -p /ibis-project.org && \
-                                                 cd /ibis-project.org && \
+                                                 mkdir -p /tmp/ibis-project.org && \
+                                                 cd /tmp/ibis-project.org && \
                                                  echo \"ibis-project.org\" > CNAME && \
                                                  touch .nojekyll && \
-                                                 python -m pysuerga /ibis/docs/web --target-path=. && \
-                                                 sphinx-build -b html /ibis/docs/source /ibis-project.org/docs -W -T --keep-going"
+                                                 python -m pysuerga /ibis/docs/web --target-path=/tmp/ibis-project.org/ && \
+                                                 sphinx-build -b html /ibis/docs/source /tmp/ibis-project.org/docs -W -T --keep-going"
       displayName: 'Build website and docs'
 
     - task: PublishPipelineArtifact@1

--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -266,7 +266,7 @@ jobs:
       displayName: 'Load test datasets'
 
     - bash: |
-        docker-compose -f ci/docker-compose.yml run --rm ibis-docs "\
+        docker-compose -f ci/docker-compose.yml run --rm ibis-docs bash -c "\
             ping -c 1 impala && conda list && \
             mkdir -p /tmp/ibis-project.org && \
             cd /tmp/ibis-project.org && \

--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -265,11 +265,9 @@ jobs:
     - bash: make load PYTHON_VERSION=$PYTHON_VERSION BACKENDS="${BACKENDS}" LOADS="${LOADS}"
       displayName: 'Load test datasets'
 
-    - bash: make docker_docs_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="ping -c 1 impala && conda list"
-      displayName: 'Ping the impala host used in the tutorial notebooks, and show conda deps'
-
     - bash: |
-        make docker_docs_run DOCKER_RUN_COMMAND="mkdir -p /ibis-project.org && \
+        make docker_docs_run DOCKER_RUN_COMMAND="ping -c 1 impala && conda list && \
+                                                 mkdir -p /ibis-project.org && \
                                                  cd /ibis-project.org && \
                                                  echo \"ibis-project.org\" > CNAME && \
                                                  touch .nojekyll && \

--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -266,7 +266,7 @@ jobs:
       displayName: 'Load test datasets'
 
     - bash: |
-        make docker_docs_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="\
+        docker-compose -f ci/docker-compose.yml run --rm ibis-docs "\
             ping -c 1 impala && conda list && \
             mkdir -p /tmp/ibis-project.org && \
             cd /tmp/ibis-project.org && \

--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -265,41 +265,17 @@ jobs:
     - bash: make load PYTHON_VERSION=$PYTHON_VERSION BACKENDS="${BACKENDS}" LOADS="${LOADS}"
       displayName: 'Load test datasets'
 
-    - bash: make docker_docs_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="ping -c 1 impala"
-      displayName: 'Ping the impala host used in the tutorial notebooks'
+    - bash: make docker_docs_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="ping -c 1 impala && conda list"
+      displayName: 'Ping the impala host used in the tutorial notebooks, and show conda deps'
 
     - bash: |
-        make docker_docs_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="git clone --branch gh-pages \
-          https://github.com/cpcloud/docs.ibis-project.org \
-          /tmp/ibis-project.org"
-      displayName: 'Clone doc repo'
-
-    - bash: |
-        docker-compose run ibis-docs \
-          find /tmp/ibis-project.org \
-            -maxdepth 1 \
-            # ignore the directory we're searching in itself
-            ! -wholename /tmp/ibis-project.org/ \
-            # ignore git files
-            ! -name '*.git' \
-            # ignore the CNAME record
-            ! -name CNAME \
-            # ignore files ending in nojekyll
-            ! -name '*.nojekyll' \
-            -exec rm -rf {} \;
-      displayName: 'Clear out old docs'
-
-    - bash: make docker_docs_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="conda list"
-      displayName: 'Show the doc env'
-
-    - bash: |
-        make docker_docs_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="python -m pysuerga docs/web --target-path=/tmp/ibis-project.org"
-      displayName: 'Build website'
-
-    - bash: |
-        make docker_docs_run PYTHON_VERSION=$PYTHON_VERSION DOCKER_RUN_COMMAND="sphinx-build -b html \
-          docs/source /tmp/ibis-project.org/docs -W -T --keep-going"
-      displayName: 'Build docs'
+        make docker_docs_run DOCKER_RUN_COMMAND="mkdir -p /ibis-project.org && \
+                                                 cd /ibis-project.org && \
+                                                 echo \"ibis-project.org\" > CNAME && \
+                                                 touch .nojekyll && \
+                                                 python -m pysuerga /ibis/docs/web --target-path=. && \
+                                                 sphinx-build -b html /ibis/docs/source /ibis-project.org/docs -W -T --keep-going"
+      displayName: 'Build website and docs'
 
     - task: PublishPipelineArtifact@1
       inputs:
@@ -314,18 +290,23 @@ jobs:
         chmod 700 ~/.ssh
         chmod 600 ~/.ssh/id_rsa
 
-        # add github to known hosts
         ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+      displayName: 'Set up ssh'
+      condition: |
+        and(eq(variables['System.PullRequest.IsFork'], 'False'),
+            eq(variables['Build.Repository.Name'], 'ibis-project/ibis'),
+            eq(variables['Build.SourceBranchName'], 'master'))
 
+    - bash: |
         sudo chown -R "${USER}":"${USER}" /tmp/ibis
         pushd /tmp/ibis/ibis-project.org
 
+        git init
+        git checkout -b gh-pages
         git remote set-url origin git@github.com:ibis-project/docs.ibis-project.org
-
         git config user.name 'Ibis Documentation Bot'
         git config user.email ''
 
-        # Add everything
         git add --all .
         git commit -m "Docs from ibis at $(Build.SourceVersion)"
         git push --force origin gh-pages


### PR DESCRIPTION
https://ibis-project.org is currently broken. The problem comes from the domain change from docs.ibis-project.org to ibis-project.org. We updated the domain in the github setting of the project, but the setting is overwritten by the `CNAME` file in the repo. This file is coming from the fork https://github.com/cpcloud/docs.ibis-project.org, which is used as a base to build the website/docs. I opened https://github.com/cpcloud/docs.ibis-project.org/pull/1 for an immediate fix, but doesn't look like the fork is being maintained. And I think it's a bad practice and unnecessary to use that fork as a base.

So, in this PR I create the repo that will be pushed to GitHub pages from scratch, instead of cloning the fork. I fix the `CNAME` content, which now is in the Azure setting, and not in the fork. And I speed up things a bit, by starting the docker container of the docs just once, instead of starting it for every command.