### PR TITLE
CI: Fixing typo when pushing the docs

### DIFF
--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -302,7 +302,7 @@ jobs:
 
         git init
         git checkout -b gh-pages
-        git remote set-url origin git@github.com:ibis-project/docs.ibis-project.org
+        git remote add origin git@github.com:ibis-project/docs.ibis-project.org
         git config user.name 'Ibis Documentation Bot'
         git config user.email ''
 


### PR DESCRIPTION
Follow up of #2291. I forgot to update this, from when we were reusing a repo, to now that we create a new one.

Probably not worth waiting for the CI, since this step is not running in the CI of PRs.

CC: @jreback 