### PR TITLE
DOC: Updating titles of backend pages

### DIFF
--- a/docs/source/backends/bigquery.rst
+++ b/docs/source/backends/bigquery.rst
@@ -2,8 +2,8 @@
 
 .. _backends.bigquery:
 
-Using Ibis with BigQuery
-========================
+BigQuery
+========
 
 To use the BigQuery client, you will need a Google Cloud Platform account.
 Use the `BigQuery sandbox <https://cloud.google.com/bigquery/docs/sandbox>`__

--- a/docs/source/backends/clickhouse.rst
+++ b/docs/source/backends/clickhouse.rst
@@ -1,7 +1,7 @@
 .. _install.clickhouse:
 
-`Clickhouse <https://clickhouse.yandex/>`_ Quickstart
------------------------------------------------------
+`Clickhouse <https://clickhouse.yandex/>`_
+------------------------------------------
 
 Install dependencies for Ibis's Clickhouse dialect(minimal supported version is `0.1.3`):
 

--- a/docs/source/backends/impala.rst
+++ b/docs/source/backends/impala.rst
@@ -2,9 +2,9 @@
 
 .. _backends.impala:
 
-**********************
-Using Ibis with Impala
-**********************
+******
+Impala
+******
 
 One goal of Ibis is to provide an integrated Python API for an Impala cluster
 without requiring you to switch back and forth between Python code and the

--- a/docs/source/backends/mysql.rst
+++ b/docs/source/backends/mysql.rst
@@ -1,7 +1,7 @@
 .. _install.mysql:
 
-`MySQL <https://www.mysql.com/>`_ Quickstart
---------------------------------------------
+`MySQL <https://www.mysql.com/>`_
+---------------------------------
 
 Install dependencies for Ibis's MySQL dialect:
 

--- a/docs/source/backends/omnisci.rst
+++ b/docs/source/backends/omnisci.rst
@@ -1,8 +1,8 @@
 .. _omnisci:
 
-*************************
-Using Ibis with OmniSciDB
-*************************
+*********
+OmniSciDB
+*********
 
 To get started with the OmniSci client, check the :ref:`OmniSci quick start <install.omniscidb>`.
 

--- a/docs/source/backends/pandas.rst
+++ b/docs/source/backends/pandas.rst
@@ -1,7 +1,7 @@
-`Pandas <https://pandas.pydata.org/>`_ Quickstart
--------------------------------------------------
+`pandas <https://pandas.pydata.org/>`_
+--------------------------------------
 
-Ibis's Pandas backend is available in core Ibis:
+Ibis's pandas backend is available in core Ibis:
 
 Create a client by supplying a dictionary of DataFrames using
 :func:`ibis.pandas.connect`. The keys become the table names:

--- a/docs/source/backends/postgres.rst
+++ b/docs/source/backends/postgres.rst
@@ -1,7 +1,7 @@
 .. _install.postgres:
 
-`PostgreSQL <https://www.postgresql.org/>`_ Quickstart
-------------------------------------------------------
+`PostgreSQL <https://www.postgresql.org/>`_
+-------------------------------------------
 
 Install dependencies for Ibis's PostgreSQL dialect:
 

--- a/docs/source/backends/spark.rst
+++ b/docs/source/backends/spark.rst
@@ -1,7 +1,7 @@
 .. _install.spark:
 
-`PySpark/Spark SQL <https://spark.apache.org/sql/>`_ Quickstart
----------------------------------------------------------------
+`PySpark/Spark SQL <https://spark.apache.org/sql/>`_
+----------------------------------------------------
 
 Install dependencies for Ibis's Spark dialect:
 

--- a/docs/source/backends/sqlite.rst
+++ b/docs/source/backends/sqlite.rst
@@ -1,7 +1,7 @@
 .. _install.sqlite:
 
-`SQLite <https://www.sqlite.org/>`_ Quickstart
-----------------------------------------------
+`SQLite <https://www.sqlite.org/>`_
+-----------------------------------
 
 Install dependencies for Ibis's SQLite dialect:
 


### PR DESCRIPTION
The pages of the backends were moved from different places, and now the titles are a mix of things like:
- Using Ibis with BigQuery
- Clickhouse Quickstart

See https://ibis-project.org/docs/backends/index.html. Which doesn't make sense. Leaving just the name of the backend.