### PR TITLE
TST/CI: Fix test failing in pandas 1.1

### DIFF
--- a/ibis/expr/tests/test_datatypes.py
+++ b/ibis/expr/tests/test_datatypes.py
@@ -453,7 +453,7 @@ def test_time_valid():
             ),
         ),
         param(
-            pd.Timedelta('3', unit='W'),
+            pd.Timedelta('3W'),
             dt.Interval(unit='W'),
             id='weeks',
             marks=pytest.mark.xfail(


### PR DESCRIPTION
We've got a typo in the tests that it's now captured by pandas 1.1, and raising an exception.