### PR TITLE
ENH: add application name option to BigQuery connect

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -13,7 +13,7 @@ Release Notes
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
 * :support:`2304` Update ``google-cloud-bigquery`` dependency minimum version to 1.12.0
-* :feature:`2303` Add ``user_agent`` argument to ``ibis.bigquery.connect`` to allow attributing Google API requests to projects that use Ibis.
+* :feature:`2303` Add ``application_name`` argument to ``ibis.bigquery.connect`` to allow attributing Google API requests to projects that use Ibis.
 * :bug:`1320` Added verbose logging to SQL backends
 * :feature:`2285` Add support for casting category dtype in pandas backend
 * :feature:`2270` Add support for Union in the PySpark backend

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -13,6 +13,7 @@ Release Notes
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
 * :support:`2304` Update ``google-cloud-bigquery`` dependency minimum version to 1.12.0
+* :feature:`2303` Add ``user_agent`` argument to ``ibis.bigquery.connect`` to allow attributing Google API requests to projects that use Ibis.
 * :bug:`1320` Added verbose logging to SQL backends
 * :feature:`2285` Add support for casting category dtype in pandas backend
 * :feature:`2270` Add support for Union in the PySpark backend

--- a/ibis/bigquery/api.py
+++ b/ibis/bigquery/api.py
@@ -57,7 +57,7 @@ def connect(
     project_id: Optional[str] = None,
     dataset_id: Optional[str] = None,
     credentials: Optional[google.auth.credentials.Credentials] = None,
-    user_agent: Optional[str] = None,
+    application_name: Optional[str] = None,
 ) -> BigQueryClient:
     """Create a BigQueryClient for use with Ibis.
 
@@ -69,7 +69,7 @@ def connect(
         A dataset id that lives inside of the project indicated by
         `project_id`.
     credentials : google.auth.credentials.Credentials
-    user_agent : str
+    application_name : str
         A string identifying your application to Google API endpoints.
 
     Returns
@@ -92,5 +92,5 @@ def connect(
         project_id,
         dataset_id=dataset_id,
         credentials=credentials,
-        user_agent=user_agent,
+        application_name=application_name,
     )

--- a/ibis/bigquery/api.py
+++ b/ibis/bigquery/api.py
@@ -57,6 +57,7 @@ def connect(
     project_id: Optional[str] = None,
     dataset_id: Optional[str] = None,
     credentials: Optional[google.auth.credentials.Credentials] = None,
+    user_agent: Optional[str] = None,
 ) -> BigQueryClient:
     """Create a BigQueryClient for use with Ibis.
 
@@ -68,6 +69,8 @@ def connect(
         A dataset id that lives inside of the project indicated by
         `project_id`.
     credentials : google.auth.credentials.Credentials
+    user_agent : str
+        A string identifying your application to Google API endpoints.
 
     Returns
     -------
@@ -86,5 +89,8 @@ def connect(
         )
 
     return BigQueryClient(
-        project_id, dataset_id=dataset_id, credentials=credentials
+        project_id,
+        dataset_id=dataset_id,
+        credentials=credentials,
+        user_agent=user_agent,
     )

--- a/ibis/bigquery/client.py
+++ b/ibis/bigquery/client.py
@@ -51,14 +51,14 @@ _LEGACY_TO_STANDARD = {
 _USER_AGENT_DEFAULT_TEMPLATE = 'ibis/{}'
 
 
-def _create_client_info(user_agent):
-    user_agent_components = [
-        _USER_AGENT_DEFAULT_TEMPLATE.format(ibis.__version__)
-    ]
-    if user_agent:
-        user_agent_components.insert(0, user_agent)
+def _create_client_info(application_name):
+    user_agent = []
 
-    return ClientInfo(user_agent=" ".join(user_agent_components))
+    if application_name:
+        user_agent.append(application_name)
+
+    user_agent.append(_USER_AGENT_DEFAULT_TEMPLATE.format(ibis.__version__))
+    return ClientInfo(user_agent=" ".join(user_agent))
 
 
 @dt.dtype.register(bq.schema.SchemaField)
@@ -379,7 +379,11 @@ class BigQueryClient(SQLClient):
     dialect = comp.BigQueryDialect
 
     def __init__(
-        self, project_id, dataset_id=None, credentials=None, user_agent=None
+        self,
+        project_id,
+        dataset_id=None,
+        credentials=None,
+        application_name=None,
     ):
         """Construct a BigQueryClient.
 
@@ -390,7 +394,7 @@ class BigQueryClient(SQLClient):
         dataset_id : Optional[str]
             A ``<project_id>.<dataset_id>`` string or just a dataset name
         credentials : google.auth.credentials.Credentials
-        user_agent : str
+        application_name : str
             A string identifying your application to Google API endpoints.
 
         """
@@ -402,7 +406,7 @@ class BigQueryClient(SQLClient):
         self.client = bq.Client(
             project=self.data_project,
             credentials=credentials,
-            client_info=_create_client_info(user_agent),
+            client_info=_create_client_info(application_name),
         )
 
     def _parse_project_and_dataset(self, dataset):

--- a/ibis/bigquery/client.py
+++ b/ibis/bigquery/client.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 import google.cloud.bigquery as bq
 import pandas as pd
 import regex as re
+from google.api_core.client_info import ClientInfo
 from google.api_core.exceptions import NotFound
 from multipledispatch import Dispatcher
 from pkg_resources import parse_version
@@ -45,6 +46,19 @@ _LEGACY_TO_STANDARD = {
     'FLOAT': 'FLOAT64',
     'BOOLEAN': 'BOOL',
 }
+
+
+_USER_AGENT_DEFAULT_TEMPLATE = 'ibis/{}'
+
+
+def _create_client_info(user_agent):
+    user_agent_components = [
+        _USER_AGENT_DEFAULT_TEMPLATE.format(ibis.__version__)
+    ]
+    if user_agent:
+        user_agent_components.insert(0, user_agent)
+
+    return ClientInfo(user_agent=" ".join(user_agent_components))
 
 
 @dt.dtype.register(bq.schema.SchemaField)
@@ -364,7 +378,9 @@ class BigQueryClient(SQLClient):
     table_class = BigQueryTable
     dialect = comp.BigQueryDialect
 
-    def __init__(self, project_id, dataset_id=None, credentials=None):
+    def __init__(
+        self, project_id, dataset_id=None, credentials=None, user_agent=None
+    ):
         """Construct a BigQueryClient.
 
         Parameters
@@ -374,6 +390,8 @@ class BigQueryClient(SQLClient):
         dataset_id : Optional[str]
             A ``<project_id>.<dataset_id>`` string or just a dataset name
         credentials : google.auth.credentials.Credentials
+        user_agent : str
+            A string identifying your application to Google API endpoints.
 
         """
         (
@@ -382,7 +400,9 @@ class BigQueryClient(SQLClient):
             self.dataset,
         ) = parse_project_and_dataset(project_id, dataset_id)
         self.client = bq.Client(
-            project=self.data_project, credentials=credentials
+            project=self.data_project,
+            credentials=credentials,
+            client_info=_create_client_info(user_agent),
         )
 
     def _parse_project_and_dataset(self, dataset):

--- a/ibis/bigquery/tests/conftest.py
+++ b/ibis/bigquery/tests/conftest.py
@@ -8,7 +8,7 @@ PROJECT_ID = os.environ.get('GOOGLE_BIGQUERY_PROJECT_ID', 'ibis-gbq')
 DATASET_ID = 'testing'
 
 
-def connect(project_id, dataset_id):
+def connect(project_id, dataset_id, application_name=None):
     ga = pytest.importorskip('google.auth')
     service_account = pytest.importorskip('google.oauth2.service_account')
     google_application_credentials = os.environ.get(
@@ -40,7 +40,10 @@ def connect(project_id, dataset_id):
     )
     try:
         return ibis.bigquery.connect(
-            project_id, dataset_id, credentials=credentials
+            project_id,
+            dataset_id,
+            credentials=credentials,
+            application_name=application_name,
         )
     except ga.exceptions.DefaultCredentialsError:
         pytest.skip(skip_message)

--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -1,6 +1,7 @@
 import collections
 import datetime
 import decimal
+from unittest import mock
 
 import numpy as np
 import pandas as pd
@@ -722,3 +723,17 @@ def test_client_without_dataset(project_id):
     con = connect(project_id, dataset_id=None)
     with pytest.raises(ValueError, match="Unable to determine BigQuery"):
         con.list_tables()
+
+
+def test_client_sets_user_agent(project_id, monkeypatch):
+    mock_client = mock.create_autospec(bq.Client)
+    monkeypatch.setattr(bq, 'Client', mock_client)
+    connect(
+        project_id,
+        dataset_id='bigquery-public-data.stackoverflow',
+        application_name='my-great-app/0.7.0',
+    )
+    info = mock_client.call_args[1]['client_info']
+    user_agent = info.to_user_agent()
+    assert ' ibis/{}'.format(ibis.__version__) in user_agent
+    assert 'my-great-app/0.7.0 ' in user_agent


### PR DESCRIPTION
This allows Google API requests by Ibis or tools using Ibis to be
attributed to the project.