### PR TITLE
SUPP: update min google-cloud-bigquery version

### DIFF
--- a/ci/deps/bigquery.yml
+++ b/ci/deps/bigquery.yml
@@ -1,3 +1,2 @@
-google-api-core=1.17.0
-google-cloud-bigquery>=1.0.0
+google-cloud-bigquery>=1.12.0
 pydata-google-auth

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :support:`2304` Update ``google-cloud-bigquery`` dependency minimum version to 1.12.0
 * :bug:`1320` Added verbose logging to SQL backends
 * :feature:`2285` Add support for casting category dtype in pandas backend
 * :feature:`2270` Add support for Union in the PySpark backend

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ clickhouse_requires = [
     'clickhouse-driver>=0.1.3',
     'clickhouse-cityhash',
 ]
-bigquery_requires = ['google-cloud-bigquery>=1.0.0', 'pydata-google-auth']
+bigquery_requires = ['google-cloud-bigquery>=1.12.0', 'pydata-google-auth']
 hdf5_requires = ['tables>=3.0.0']
 
 parquet_requires = ['pyarrow>=0.12.0']


### PR DESCRIPTION
This is needed in order to set the application name in the user agent
header. This feature to be added in:
https://github.com/ibis-project/ibis/pull/2303

Also, removes pin on google-api-core, now that
https://github.com/googleapis/python-api-core/issues/47 is closed.