### PR TITLE
ENH: Prevent column sorting during Pandas execution of Union node

### DIFF
--- a/ibis/pandas/execution/generic.py
+++ b/ibis/pandas/execution/generic.py
@@ -764,7 +764,7 @@ def execute_series_distinct(op, data, **kwargs):
 
 @execute_node.register(ops.Union, pd.DataFrame, pd.DataFrame, bool)
 def execute_union_dataframe_dataframe(op, left, right, distinct, **kwargs):
-    result = pd.concat([left, right], axis=0)
+    result = pd.concat([left, right], axis=0, sort=False)
     return result.drop_duplicates() if distinct else result
 
 


### PR DESCRIPTION
When using the Pandas backend (with Pandas 0.25.3) to execute the `Union` operation on tables whose columns are the same but **ordered differently**, 

1. A `FutureWarning` is shown
```
FutureWarning: Sorting because non-concatenation axis is not aligned. A future version
of pandas will change to not sort by default.

To accept the future behavior, pass 'sort=False'.

To retain the current behavior and silence the warning, pass 'sort=True'.

  result = pd.concat([left, right], axis=0)
```
2. The columns of the resulting dataframe are sorted alphabetically (if the columns in each table were in the same order, then the result is not sorted alphabetically)

This PR explicitly sets `sort=False` when the Pandas backend uses `pd.concat`. This makes the behavior of `Union` when using Pandas 0.25.3 consistent to when using Pandas 1.0.0+ or when using the PySpark backend. 