### PR TITLE
FEAT: Allow window_agg_udf to handle the case where window and data has different frequency

### DIFF
--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -370,6 +370,7 @@ def window_agg_udf(
     window_lower_indices: pd.Series,
     window_upper_indices: pd.Series,
     mask: pd.Series,
+    result_index: pd.Index,
     dtype: np.dtype,
     max_lookback: int,
     *args: Tuple[Any],
@@ -383,8 +384,6 @@ def window_agg_udf(
     This is because pandas's rolling function doesn't support
     multi param UDFs.
     """
-    obj = getattr(grouped_data, 'obj', grouped_data)
-
     assert len(window_lower_indices) == len(window_upper_indices)
     assert len(window_lower_indices) == len(mask)
 
@@ -429,7 +428,7 @@ def window_agg_udf(
     valid_result.index = masked_window_lower_indices.index
     result = pd.Series(index=mask.index, dtype=dtype)
     result[mask] = valid_result
-    result.index = obj.index
+    result.index = result_index
 
     return result
 
@@ -528,6 +527,7 @@ class Window(AggregationContext):
                     window_lower_indices,
                     window_upper_indices,
                     mask,
+                    obj.index,
                     self.dtype,
                     self.max_lookback,
                     *args,

--- a/ibis/pandas/execution/tests/test_window.py
+++ b/ibis/pandas/execution/tests/test_window.py
@@ -76,12 +76,15 @@ class CustomAggContext(AggregationContext):
         lower_indices = upper_indices - window_sizes
         mask = upper_indices.notna()
 
+        result_index = grouped_data.obj.index
+
         result = window_agg_udf(
             grouped_data,
             function,
             lower_indices,
             upper_indices,
             mask,
+            result_index,
             self.dtype,
             self.max_lookback,
             *args,

--- a/ibis/pandas/tests/test_aggcontext.py
+++ b/ibis/pandas/tests/test_aggcontext.py
@@ -49,7 +49,7 @@ def test_window_agg_udf(param):
 
 
 def test_window_agg_udf_different_freq():
-    """ Test that window_agg_udf work when the window series and data series
+    """ Test that window_agg_udf works when the window series and data series
     have different frequencies.
     """
 

--- a/ibis/pandas/tests/test_aggcontext.py
+++ b/ibis/pandas/tests/test_aggcontext.py
@@ -27,6 +27,7 @@ def test_window_agg_udf(param):
     df = pd.DataFrame({'id': [1, 2, 1, 2], 'v': [1.0, 2.0, 3.0, 4.0]})
 
     grouped_data = df.sort_values('id').groupby("id")['v']
+    result_index = grouped_data.obj.index
 
     window_lower_indices = pd.Series([0, 0, 2, 2])
     window_higher_indices = pd.Series([1, 2, 3, 4])
@@ -37,6 +38,7 @@ def test_window_agg_udf(param):
         window_lower_indices,
         window_higher_indices,
         mask,
+        result_index,
         dtype='float',
         max_lookback=None,
     )

--- a/ibis/pandas/tests/test_aggcontext.py
+++ b/ibis/pandas/tests/test_aggcontext.py
@@ -30,13 +30,13 @@ def test_window_agg_udf(param):
     result_index = grouped_data.obj.index
 
     window_lower_indices = pd.Series([0, 0, 2, 2])
-    window_higher_indices = pd.Series([1, 2, 3, 4])
+    window_upper_indices = pd.Series([1, 2, 3, 4])
 
     result = window_agg_udf(
         grouped_data,
         lambda s: s.mean(),
         window_lower_indices,
-        window_higher_indices,
+        window_upper_indices,
         mask,
         result_index,
         dtype='float',
@@ -44,5 +44,34 @@ def test_window_agg_udf(param):
     )
 
     expected.index = grouped_data.obj.index
+
+    tm.assert_series_equal(result, expected)
+
+
+def test_window_agg_udf_different_freq():
+    """ Test that window_agg_udf work when the window series and data series
+    have different frequencies.
+    """
+
+    time = pd.Series([pd.Timestamp('20200101'), pd.Timestamp('20200201')])
+    data = pd.Series([1, 2, 3, 4, 5, 6])
+    window_lower_indices = pd.Series([0, 4])
+    window_upper_indices = pd.Series([5, 7])
+    mask = pd.Series([True, True])
+    result_index = time.index
+
+    result = window_agg_udf(
+        time,
+        lambda s: s.mean(),
+        window_lower_indices,
+        window_upper_indices,
+        mask,
+        result_index,
+        'float',
+        None,
+        data,
+    )
+
+    expected = pd.Series([data.iloc[0:5].mean(), data.iloc[4:7].mean()])
 
     tm.assert_series_equal(result, expected)


### PR DESCRIPTION
What change is proposed
==================
Currently, `window_agg_udf` assumes that the data series has the same frequency of the window series, i.e., there is one window per data point. However, this function can extended to support the case where there are less windows than data points, e.g., there is 10 data points, and 2 windows, the first window covers data[0: 7] and the second window covers data[5: 10]. 

This PR proposes supporting this use case.

There are no user facing changes, only changes to developer API that makes it easier to extend window operations.

How is this tested
=============
Added test in`test_aggcontext` to cover this case.
