### PR TITLE
CI: Using bigquery key as json, not base64

### DIFF
--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: set up bigquery credentials
-      run: base64 --decode --ignore-garbage <<< "${{ secrets.GCLOUD_SERVICE_KEY }}" > gcloud-service-key.json
+      run: echo "${{ secrets.GCLOUD_SERVICE_KEY }}" > gcloud-service-key.json
 
     - name: set up environment
       run: GOOGLE_BIGQUERY_PROJECT_ID="ibis-gbq" GOOGLE_APPLICATION_CREDENTIALS=gcloud-service-key.json ./ci/setup_env.sh "${{ matrix.python_version }}" "$BACKENDS"


### PR DESCRIPTION
Closes #2325

Based on [this comment](https://github.com/ibis-project/ibis/issues/2325#issuecomment-674083674) the bigquery key doesn't need to be saved as base64 anymore. So, making things simpler, and saving/loading it directly as json.