### PR TITLE
CI: Removing pep8speaks config

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,5 +1,0 @@
-# File : .pep8speaks.yml
-
-scanner:
-  diff_only: True  # If True, errors caused by only the patch are shown
-  linter: flake8

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -15,6 +15,8 @@ from ibis.filesystems import HDFS, WebHDFS  # noqa: F401
 
 from ._version import get_versions  # noqa: E402
 
+
+
 with suppress(ImportError):
     # pip install ibis-framework[csv]
     import ibis.file.csv as csv  # noqa: F401

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -15,8 +15,6 @@ from ibis.filesystems import HDFS, WebHDFS  # noqa: F401
 
 from ._version import get_versions  # noqa: E402
 
-
-
 with suppress(ImportError):
     # pip install ibis-framework[csv]
     import ibis.file.csv as csv  # noqa: F401


### PR DESCRIPTION
pep8speaks doesn't seem to be set up or working. And I don't think we need it, since linting is performed in GitHub actions. Removing the config file.