### PR TITLE
ENH: Implementing rowid

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -397,7 +397,7 @@ Table methods
    TableExpr.mutate
    TableExpr.projection
    TableExpr.relabel
-   TableExpr.rowid
+   TableExpr.row_id
    TableExpr.schema
    TableExpr.set_column
    TableExpr.sort_by

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -397,6 +397,7 @@ Table methods
    TableExpr.mutate
    TableExpr.projection
    TableExpr.relabel
+   TableExpr.rowid
    TableExpr.schema
    TableExpr.set_column
    TableExpr.sort_by

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -397,7 +397,7 @@ Table methods
    TableExpr.mutate
    TableExpr.projection
    TableExpr.relabel
-   TableExpr.row_id
+   TableExpr.rowid
    TableExpr.schema
    TableExpr.set_column
    TableExpr.sort_by

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2251` Add ``rowid`` expression, supported by SQLite and OmniSciDB
 * :feature:`2230` Add intersection to general ibis api
 * :support:`2304` Update ``google-cloud-bigquery`` dependency minimum version to 1.12.0
 * :feature:`2303` Add ``application_name`` argument to ``ibis.bigquery.connect`` to allow attributing Google API requests to projects that use Ibis.

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4278,6 +4278,27 @@ def _table_drop(self, fields):
     return self[[field for field in schema if field not in field_set]]
 
 
+def _row_id(self):
+    """
+    An autonumeric representing the row number of the results.
+
+    It can be 0 or 1 indexed depending on the backend. Check the backend
+    documentation.
+
+    Returns
+    -------
+    ir.IntegerColumn
+
+    Examples
+    --------
+    >>> my_table[my_table.row_id, mytable.name].execute()
+    1|Ibis
+    2|pandas
+    3|Dask
+    """
+    return ops.RowID().to_expr()
+
+
 _table_methods = dict(
     aggregate=aggregate,
     count=_table_count,
@@ -4308,6 +4329,7 @@ _table_methods = dict(
     union=_table_union,
     intersect=_table_intersect,
     view=_table_view,
+    row_id=_row_id,
 )
 
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4278,7 +4278,7 @@ def _table_drop(self, fields):
     return self[[field for field in schema if field not in field_set]]
 
 
-def _row_id(self):
+def _rowid(self):
     """
     An autonumeric representing the row number of the results.
 
@@ -4296,7 +4296,7 @@ def _row_id(self):
 
     Examples
     --------
-    >>> my_table[my_table.row_id, mytable.name].execute()
+    >>> my_table[my_table.rowid(), mytable.name].execute()
     1|Ibis
     2|pandas
     3|Dask
@@ -4334,7 +4334,7 @@ _table_methods = dict(
     union=_table_union,
     intersect=_table_intersect,
     view=_table_view,
-    row_id=_row_id,
+    rowid=_rowid,
 )
 
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4285,6 +4285,11 @@ def _row_id(self):
     It can be 0 or 1 indexed depending on the backend. Check the backend
     documentation.
 
+    Note that this is different from the window function row number
+    (even if they are conceptually the same), and different from row
+    id in backends where it represents the physical location (e.g. Oracle
+    or PostgreSQL's ctid).
+
     Returns
     -------
     ir.IntegerColumn

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4296,7 +4296,7 @@ def _rowid(self):
 
     Examples
     --------
-    >>> my_table[my_table.rowid(), mytable.name].execute()
+    >>> my_table[my_table.rowid(), my_table.name].execute()
     1|Ibis
     2|pandas
     3|Dask

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -250,14 +250,7 @@ class TableColumn(ValueOp):
 
 
 class RowID(ValueOp):
-    """
-    The row number (an autonumeric) of the returned result, 1-indexed.
-
-    Note that this is different from the window function row number
-    (even if they are conceptually the same), and different from row
-    id in backends where it represents the memory location (e.g. Oracle).
-    """
-
+    """The row number (an autonumeric) of the returned result."""
     def output_type(self):
         return dt.int64.column_type()
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -257,6 +257,7 @@ class RowID(ValueOp):
     (even if they are conceptually the same), and different from row
     id in backends where it represents the memory location (e.g. Oracle).
     """
+
     def output_type(self):
         return dt.int64.column_type()
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -249,6 +249,24 @@ class TableColumn(ValueOp):
         return klass(self, name=self.name)
 
 
+class RowID(ValueOp):
+    """
+    The row number (an autonumeric) of the returned result, 1-indexed.
+
+    Note that this is different from the window function row number
+    (even if they are conceptually the same), and different from row
+    id in backends where it represents the memory location (e.g. Oracle).
+    """
+    def output_type(self):
+        return dt.int64.column_type()
+
+    def resolve_name(self):
+        return 'rowid'
+
+    def has_resolved_name(self):
+        return True
+
+
 def find_all_base_tables(expr, memo=None):
     if memo is None:
         memo = {}

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -251,6 +251,7 @@ class TableColumn(ValueOp):
 
 class RowID(ValueOp):
     """The row number (an autonumeric) of the returned result."""
+
     def output_type(self):
         return dt.int64.column_type()
 

--- a/ibis/omniscidb/operations.py
+++ b/ibis/omniscidb/operations.py
@@ -1085,6 +1085,7 @@ _general_ops = {
     ops.IsNan: unary('isNan'),
     ops.NullIfZero: _nullifzero,
     ops.ZeroIfNull: _zeroifnull,
+    ops.RowID: lambda *args: 'rowid',
 }
 
 # WINDOW

--- a/ibis/pandas/execution/generic.py
+++ b/ibis/pandas/execution/generic.py
@@ -1066,3 +1066,9 @@ def execute_simple_case_series(op, value, whens, thens, otherwise, **kwargs):
 @execute_node.register(ops.Distinct, pd.DataFrame)
 def execute_distinct_dataframe(op, df, **kwargs):
     return df.drop_duplicates()
+
+
+@execute_node.register(ops.RowID)
+def execute_rowid(op, *args, **kwargs):
+    raise com.UnsupportedOperationError(
+        'rowid is not supported in pandas backends')

--- a/ibis/pandas/execution/generic.py
+++ b/ibis/pandas/execution/generic.py
@@ -1071,4 +1071,5 @@ def execute_distinct_dataframe(op, df, **kwargs):
 @execute_node.register(ops.RowID)
 def execute_rowid(op, *args, **kwargs):
     raise com.UnsupportedOperationError(
-        'rowid is not supported in pandas backends')
+        'rowid is not supported in pandas backends'
+    )

--- a/ibis/sql/sqlite/compiler.py
+++ b/ibis/sql/sqlite/compiler.py
@@ -285,6 +285,7 @@ _operation_registry.update(
         ops.StandardDev: toolz.compose(
             sa.func._ibis_sqlite_sqrt, _variance_reduction('_ibis_sqlite_var')
         ),
+        ops.RowID: lambda t, expr: sa.literal_column('rowid'),
     }
 )
 

--- a/ibis/tests/all/test_column.py
+++ b/ibis/tests/all/test_column.py
@@ -26,7 +26,7 @@ def test_distinct_column(backend, alltypes, df, column):
 @pytest.mark.xfail_unsupported
 def test_rowid(con, backend):
     t = con.table('functional_alltypes')
-    result = t[t.row_id()].execute()
+    result = t[t.rowid()].execute()
     first_value = 0 if backend.name in ROWID_ZERO_INDEXED_BACKENDS else 1
     expected = pd.Series(
         range(first_value, first_value + len(result)),
@@ -39,7 +39,7 @@ def test_rowid(con, backend):
 @pytest.mark.xfail_unsupported
 def test_named_rowid(con, backend):
     t = con.table('functional_alltypes')
-    result = t[t.row_id().name('number')].execute()
+    result = t[t.rowid().name('number')].execute()
     first_value = 0 if backend.name in ROWID_ZERO_INDEXED_BACKENDS else 1
     expected = pd.Series(
         range(first_value, first_value + len(result)),

--- a/ibis/tests/all/test_column.py
+++ b/ibis/tests/all/test_column.py
@@ -28,9 +28,11 @@ def test_rowid(con, backend):
     t = con.table('functional_alltypes')
     result = t[t.row_id()].execute()
     first_value = 0 if backend.name in ROWID_ZERO_INDEXED_BACKENDS else 1
-    expected = pd.Series(range(first_value, first_value + len(result)),
-                         dtype=np.int64,
-                         name='rowid')
+    expected = pd.Series(
+        range(first_value, first_value + len(result)),
+        dtype=np.int64,
+        name='rowid',
+    )
     pd.testing.assert_series_equal(result.iloc[:, 0], expected)
 
 
@@ -39,7 +41,9 @@ def test_named_rowid(con, backend):
     t = con.table('functional_alltypes')
     result = t[t.row_id().name('number')].execute()
     first_value = 0 if backend.name in ROWID_ZERO_INDEXED_BACKENDS else 1
-    expected = pd.Series(range(first_value, first_value + len(result)),
-                         dtype=np.int64,
-                         name='number')
+    expected = pd.Series(
+        range(first_value, first_value + len(result)),
+        dtype=np.int64,
+        name='number',
+    )
     pd.testing.assert_series_equal(result.iloc[:, 0], expected)

--- a/ibis/tests/all/test_column.py
+++ b/ibis/tests/all/test_column.py
@@ -1,4 +1,9 @@
+import numpy as np
+import pandas as pd
 import pytest
+
+
+ROWID_ZERO_INDEXED_BACKENDS = 'omniscidb'
 
 
 @pytest.mark.parametrize(
@@ -16,3 +21,25 @@ def test_distinct_column(backend, alltypes, df, column):
     result = expr.execute()
     expected = df[column].unique()
     assert set(result) == set(expected)
+
+
+@pytest.mark.xfail_unsupported
+def test_rowid(con, backend):
+    t = con.table('functional_alltypes')
+    result = t[t.row_id()].execute()
+    first_value = 0 if backend.name in ROWID_ZERO_INDEXED_BACKENDS else 1
+    expected = pd.Series(range(first_value, first_value + len(result)),
+                         dtype=np.int64,
+                         name='rowid')
+    pd.testing.assert_series_equal(result.iloc[:, 0], expected)
+
+
+@pytest.mark.xfail_unsupported
+def test_named_rowid(con, backend):
+    t = con.table('functional_alltypes')
+    result = t[t.row_id().name('number')].execute()
+    first_value = 0 if backend.name in ROWID_ZERO_INDEXED_BACKENDS else 1
+    expected = pd.Series(range(first_value, first_value + len(result)),
+                         dtype=np.int64,
+                         name='number')
+    pd.testing.assert_series_equal(result.iloc[:, 0], expected)

--- a/ibis/tests/all/test_column.py
+++ b/ibis/tests/all/test_column.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 
-ROWID_ZERO_INDEXED_BACKENDS = 'omniscidb',
+ROWID_ZERO_INDEXED_BACKENDS = ('omniscidb',)
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/all/test_column.py
+++ b/ibis/tests/all/test_column.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 
-ROWID_ZERO_INDEXED_BACKENDS = 'omniscidb'
+ROWID_ZERO_INDEXED_BACKENDS = 'omniscidb',
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #1462
Supersedes #2251

Implementing `rowid` for backends that support it. Based on the implementation in #2251, but I think this implementation is simpler, and also tried to make the docs more useful for users.