### PR TITLE
FIX: Avoid creating unnecessary `index` column when executing Aggregation node on Pandas backend

### DIFF
--- a/ibis/pandas/execution/generic.py
+++ b/ibis/pandas/execution/generic.py
@@ -428,8 +428,12 @@ def execute_aggregation_dataframe(op, data, scope=None, **kwargs):
         for metric in op.metrics
     ]
 
-    # group by always needs a reset to get the grouping key back as a column
-    result = pd.concat(pieces, axis=1).reset_index()
+    result = pd.concat(pieces, axis=1)
+
+    # If grouping, need a reset to get the grouping key back as a column
+    if op.by:
+        result = result.reset_index()
+
     result.columns = [columns.get(c, c) for c in result.columns]
 
     if op.having:

--- a/ibis/tests/all/test_aggregation.py
+++ b/ibis/tests/all/test_aggregation.py
@@ -1,8 +1,72 @@
 import numpy as np
+import pandas as pd
 import pytest
 from pytest import param
 
 from ibis.tests.backends import Clickhouse, MySQL, Postgres, PySpark, SQLite
+
+aggregate_test_params = [
+    param(lambda t: t.double_col.mean(), lambda s: s.mean(), id='mean',),
+    param(
+        lambda t: t.double_col.std(how='sample'),
+        lambda s: s.std(ddof=1),
+        id='std',
+    ),
+    param(lambda t: t.double_col.min(), lambda s: s.min(), id='min',),
+    param(lambda t: t.double_col.min(), lambda s: s.min(), id='max',),
+    param(
+        lambda t: (t.double_col + 5).sum(),
+        lambda s: (s + 5).sum(),
+        id='complex_sum',
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ('result_fn', 'expected_fn'), aggregate_test_params,
+)
+@pytest.mark.xfail_unsupported
+def test_aggregate(backend, alltypes, df, result_fn, expected_fn):
+    expr = alltypes.aggregate(tmp=result_fn)
+    result = expr.execute()
+
+    # Create a single-row single-column dataframe with the Pandas `agg` result
+    # (to match the output format of Ibis `aggregate`)
+    expected = pd.DataFrame({'tmp': [df.double_col.agg(expected_fn)]})
+
+    pd.testing.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ('result_fn', 'expected_fn'), aggregate_test_params,
+)
+@pytest.mark.xfail_unsupported
+def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
+    grouping_key_col = 'bigint_col'
+
+    # Two (equivalent) variations:
+    #  1) `groupby` then `aggregate`
+    #  2) `aggregate` with `by`
+    expr1 = alltypes.groupby(grouping_key_col).aggregate(tmp=result_fn)
+    expr2 = alltypes.aggregate(tmp=result_fn, by=grouping_key_col)
+    result1 = expr1.execute()
+    result2 = expr2.execute()
+
+    # Note: Using `reset_index` to get the grouping key as a column
+    expected = (
+        df.groupby(grouping_key_col)
+        .double_col.agg(expected_fn)
+        .rename('tmp')
+        .reset_index()
+    )
+
+    # Row ordering may differ depending on backend, so sort on the grouping key
+    result1 = result1.sort_values(by=grouping_key_col, ignore_index=True)
+    result2 = result2.sort_values(by=grouping_key_col, ignore_index=True)
+    expected = expected.sort_values(by=grouping_key_col, ignore_index=True)
+
+    pd.testing.assert_frame_equal(result1, expected)
+    pd.testing.assert_frame_equal(result2, expected)
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/all/test_aggregation.py
+++ b/ibis/tests/all/test_aggregation.py
@@ -56,9 +56,9 @@ def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
     )
 
     # Row ordering may differ depending on backend, so sort on the grouping key
-    result1 = result1.sort_values(by=grouping_key_col, ignore_index=True)
-    result2 = result2.sort_values(by=grouping_key_col, ignore_index=True)
-    expected = expected.sort_values(by=grouping_key_col, ignore_index=True)
+    result1 = result1.sort_values(by=grouping_key_col).reset_index(drop=True)
+    result2 = result2.sort_values(by=grouping_key_col).reset_index(drop=True)
+    expected = expected.sort_values(by=grouping_key_col).reset_index(drop=True)
 
     pd.testing.assert_frame_equal(result1, expected)
     pd.testing.assert_frame_equal(result2, expected)

--- a/ibis/tests/all/test_aggregation.py
+++ b/ibis/tests/all/test_aggregation.py
@@ -7,13 +7,8 @@ from ibis.tests.backends import Clickhouse, MySQL, Postgres, PySpark, SQLite
 
 aggregate_test_params = [
     param(lambda t: t.double_col.mean(), lambda s: s.mean(), id='mean',),
-    param(
-        lambda t: t.double_col.std(how='sample'),
-        lambda s: s.std(ddof=1),
-        id='std',
-    ),
     param(lambda t: t.double_col.min(), lambda s: s.min(), id='min',),
-    param(lambda t: t.double_col.min(), lambda s: s.min(), id='max',),
+    param(lambda t: t.double_col.max(), lambda s: s.max(), id='max',),
     param(
         lambda t: (t.double_col + 5).sum(),
         lambda s: (s + 5).sum(),
@@ -193,7 +188,7 @@ def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
     ],
 )
 @pytest.mark.xfail_unsupported
-def test_aggregation(
+def test_reduction_ops(
     backend, alltypes, df, result_fn, expected_fn, ibis_cond, pandas_cond
 ):
     expr = result_fn(alltypes, ibis_cond(alltypes))


### PR DESCRIPTION
This is a really simple change, but a detailed explanation is unfortunately pretty long because of some nuances.

**TL;DR:** The Pandas backend sometimes does an unnecessary `reset_index` when executing the `Aggregation` node. This PR makes it only do `reset_index` when it actually should. This is simply an internal-logic correction that doesn't change any user-facing behavior.

# Detailed explanation
## Background

The Pandas backend's execution method for the `Aggregation` node is called `execute_aggregation_dataframe`.

`execute_aggregation_dataframe` does this:

1. [Executes the aggregation metrics requested by the user](https://github.com/ibis-project/ibis/blob/13387c5a0969c99be403af5b3e8aa70bdb671623/ibis/pandas/execution/generic.py#L426)
2. [Concats the metric results (`pd.Series`) into one `pd.DataFrame`](https://github.com/ibis-project/ibis/blob/13387c5a0969c99be403af5b3e8aa70bdb671623/ibis/pandas/execution/generic.py#L432)
3. [Calls `reset_index`](https://github.com/ibis-project/ibis/blob/13387c5a0969c99be403af5b3e8aa70bdb671623/ibis/pandas/execution/generic.py#L432)

The `reset_index` is great when **aggregating over groups,** because `reset_index` will make the resulting dataframe have a column containing the group-by keys (rather than having them in the index).

However, the `reset_index` is not as great when **aggregating with no grouping**, because `reset_index` will then create an unnecessary column named `index` (with values `0, 1, 2, ...`).


## This PR

This PR corrects `execute_aggregation_dataframe` so that it does not `reset_index` when aggregating with no grouping.

This avoids creating an unnecessary `index` column in the resulting dataframe (when aggregating with no grouping)


#### Note

This change is internal-facing.

[`ibis.pandas.core.execute`](https://github.com/ibis-project/ibis/blob/master/ibis/pandas/core.py#L349) will now output dataframes with no unnecessary `index` column.

However, [`ibis.pandas.client.PandasClient.execute`](https://github.com/ibis-project/ibis/blob/13387c5a0969c99be403af5b3e8aa70bdb671623/ibis/pandas/client.py#L359) (which most users would use) will have no change in behavior, since it uses [`ibis.pandas.core.execute_and_reset`](https://github.com/ibis-project/ibis/blob/13387c5a0969c99be403af5b3e8aa70bdb671623/ibis/pandas/core.py#L418), which is implemented in a way that _happens to_ get rid of columns that are not in the schema before returning the dataframe to user.

So why this change? This makes execution of `Aggregation` correct in and of itself. If using `ibis.pandas.core.execute` directly, a correct result will be obtained.

## Testing

I couldn't find comprehensive tests for `aggregate`, but I created some here. These tests are from the user's perspective, so they all pass both before and after this PR (again, no user-facing change in this PR). These new tests are just to help demonstrate this doesn't break anything.