### PR TITLE
CI: Skip hdfs tests for bigquery build

### DIFF
--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -25,4 +25,4 @@ jobs:
       run: GOOGLE_BIGQUERY_PROJECT_ID="ibis-gbq" GOOGLE_APPLICATION_CREDENTIALS=gcloud-service-key.json ./ci/setup_env.sh "${{ matrix.python_version }}" "$BACKENDS"
 
     - name: run tests
-      run: PYTEST_BACKENDS=$BACKENDS GOOGLE_BIGQUERY_PROJECT_ID="ibis-gbq" GOOGLE_APPLICATION_CREDENTIALS=gcloud-service-key.json ./ci/run_tests.sh
+      run: PYTEST_BACKENDS=$BACKENDS PYTEST_EXPRESSION="not hdfs" GOOGLE_BIGQUERY_PROJECT_ID="ibis-gbq" GOOGLE_APPLICATION_CREDENTIALS=gcloud-service-key.json ./ci/run_tests.sh


### PR DESCRIPTION
The hdfs tests are currently running in the bigquery build, but failing, see: https://github.com/ibis-project/ibis/runs/1063452941?check_suite_focus=true#step:5:28743

hdfs tests should only run when the impala container is loaded (xref #2341)