### PR TITLE
TST: fix failing BigQuery backend tests

### DIFF
--- a/ibis/bigquery/tests/test_client.py
+++ b/ibis/bigquery/tests/test_client.py
@@ -716,7 +716,9 @@ def test_approx_median(alltypes):
 
     expr = m.approx_median()
     result = expr.execute()
-    assert result == expected
+    # Since 6 and 7 are right on the edge for median in the range of months
+    # (1-12), accept either for the approximate function.
+    assert result in (6, 7)
 
 
 def test_client_without_dataset(project_id):

--- a/ibis/tests/all/test_temporal.py
+++ b/ibis/tests/all/test_temporal.py
@@ -68,8 +68,12 @@ def test_timestamp_extract(backend, alltypes, df, attr):
     expr = getattr(alltypes.timestamp_col, attr)()
 
     result = expr.execute()
-    if attr == 'epoch_seconds' and backend.name in ['postgres', 'spark']:
-        # note: postgres and spark cast to bigint are not changing the result
+    if attr == 'epoch_seconds' and backend.name in [
+        'bigquery',
+        'postgres',
+        'spark',
+    ]:
+        # note: these backends cast to bigint are not changing the result
         result = result.astype('int64')
     expected = backend.default_series_rename(expected)
 


### PR DESCRIPTION
These failures appear to be less substantial than the others in #2353.
Cleaning those easy ones up first before digging in to the true
failures.