### PR TITLE
DOC: Fixing the backends toc tree

### DIFF
--- a/docs/source/backends/index.rst
+++ b/docs/source/backends/index.rst
@@ -24,9 +24,6 @@ For more information on a specific backend, check the next backend pages:
 
 .. _classes_of_backends:
 
-Classes of Backends
--------------------
-
 There are currently three classes of backends that live in ibis.
 
 #. String generating backends
@@ -35,8 +32,7 @@ There are currently three classes of backends that live in ibis.
 
 .. _string_generating_backends:
 
-String Generating Backends
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+**String Generating Backends**
 
 The first category of backend translates ibis expressions into strings.
 Generally speaking these backends also need to handle their own execution.
@@ -52,8 +48,7 @@ string to the database through a driver API.
 
 .. _expression_generating_backends:
 
-Expression Generating Backends
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+**Expression Generating Backends**
 
 The second category of backends translates ibis expressions into other
 expressions. Currently, all expression generating backends generate `SQLAlchemy
@@ -70,8 +65,7 @@ dependencies).
 
 .. _direct_execution_backends:
 
-Direct Execution Backends
-~~~~~~~~~~~~~~~~~~~~~~~~~
+**Direct Execution Backends**
 
 The only existing backend that directly executes ibis expressions is the pandas
 backend. A full description of the implementation can be found in the module

--- a/docs/source/backends/mysql.rst
+++ b/docs/source/backends/mysql.rst
@@ -1,7 +1,7 @@
 .. _install.mysql:
 
 `MySQL <https://www.mysql.com/>`_
----------------------------------
+=================================
 
 Install dependencies for Ibis's MySQL dialect:
 

--- a/docs/source/backends/pandas.rst
+++ b/docs/source/backends/pandas.rst
@@ -1,5 +1,5 @@
 `pandas <https://pandas.pydata.org/>`_
---------------------------------------
+======================================
 
 Ibis's pandas backend is available in core Ibis:
 

--- a/docs/source/backends/postgres.rst
+++ b/docs/source/backends/postgres.rst
@@ -1,7 +1,7 @@
 .. _install.postgres:
 
 `PostgreSQL <https://www.postgresql.org/>`_
--------------------------------------------
+===========================================
 
 Install dependencies for Ibis's PostgreSQL dialect:
 

--- a/docs/source/backends/spark.rst
+++ b/docs/source/backends/spark.rst
@@ -1,7 +1,7 @@
 .. _install.spark:
 
 `PySpark/Spark SQL <https://spark.apache.org/sql/>`_
-----------------------------------------------------
+====================================================
 
 Install dependencies for Ibis's Spark dialect:
 

--- a/docs/source/backends/sqlite.rst
+++ b/docs/source/backends/sqlite.rst
@@ -1,7 +1,7 @@
 .. _install.sqlite:
 
 `SQLite <https://www.sqlite.org/>`_
------------------------------------
+===================================
 
 Install dependencies for Ibis's SQLite dialect:
 


### PR DESCRIPTION
Looks like we've got some title sections mixed, and currently the left bar of the navigation in the docs shows the backends mixed with other sections (e.g. `API`): https://ibis-project.org/docs/backends/

This leaves the navigation bar with just the backend names under the `Backend` section.