### PR TITLE
 FEAT: Add PySpark support for ReductionVectorizedUDF

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2365` Add PySpark support for ReductionVectorizedUDF
 * :feature:`2306` Add time context in `scope` in execution for pandas backend
 * :support:`2351` Simplifying tests directories structure
 * :feature:`2081` Add ``start_point`` and ``end_point`` to PostGIS backend.

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,7 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
-* :feature:`2365` Add PySpark support for ReductionVectorizedUDF
+* :feature:`2366` Add PySpark support for ReductionVectorizedUDF
 * :feature:`2306` Add time context in `scope` in execution for pandas backend
 * :support:`2351` Simplifying tests directories structure
 * :feature:`2081` Add ``start_point`` and ``end_point`` to PostGIS backend.

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -332,18 +332,18 @@ def compile_aggregator(t, expr, scope, fn, context=None, **kwargs):
         src_col = F.when(condition, src_col)
 
     col = fn(src_col)
-    if context is None:
+    if context in (AggregationContext.ENTIRE, AggregationContext.GROUP):
+        return col
+    elif context == AggregationContext.WINDOW:
+        window = kwargs['window']
+        return col.over(window)
+    else:
         # We are trying to compile a expr such as some_col.max()
         # to a Spark expression.
         # Here we get the root table df of that column and compile
         # the expr to:
         # df.select(max(some_col))
         return t.translate(expr.op().arg.op().table, scope).select(col)
-    elif context == AggregationContext.WINDOW:
-        window = kwargs['window']
-        return col.over(window)
-    else:
-        return col
 
 
 @compiles(ops.GroupConcat)
@@ -1496,9 +1496,30 @@ def compile_not_null(t, expr, scope, **kwargs):
 
 
 @compiles(ops.ElementWiseVectorizedUDF)
-def compile_elementwise_udf(t, expr, scope):
+def compile_elementwise_udf(t, expr, scope, **kwargs):
     op = expr.op()
     spark_output_type = spark_dtype(op._output_type)
     spark_udf = pandas_udf(op.func, spark_output_type, PandasUDFType.SCALAR)
     func_args = (t.translate(arg, scope) for arg in op.func_args)
     return spark_udf(*func_args)
+
+
+@compiles(ops.ReductionVectorizedUDF)
+def compile_reduction_udf(t, expr, scope, context=None, **kwargs):
+    op = expr.op()
+
+    spark_output_type = spark_dtype(op._output_type)
+    spark_udf = pandas_udf(
+        op.func, spark_output_type, PandasUDFType.GROUPED_AGG
+    )
+    func_args = (t.translate(arg, scope) for arg in op.func_args)
+
+    col = spark_udf(*func_args)
+    if context in (AggregationContext.ENTIRE, AggregationContext.GROUP):
+        return col
+    elif context == AggregationContext.WINDOW:
+        window = kwargs['window']
+        return col.over(window)
+    else:
+        src_table = t.translate(op.func_args[0].op().table, scope)
+        return src_table.agg(col)

--- a/ibis/tests/all/test_aggregation.py
+++ b/ibis/tests/all/test_aggregation.py
@@ -3,10 +3,24 @@ import pandas as pd
 import pytest
 from pytest import param
 
+import ibis.expr.datatypes as dt
 from ibis.tests.backends import Clickhouse, MySQL, Postgres, PySpark, SQLite
+from ibis.udf.vectorized import reduction
+
+
+@reduction(input_type=[dt.double], output_type=dt.double)
+def mean_udf(s):
+    return s.mean()
+
 
 aggregate_test_params = [
     param(lambda t: t.double_col.mean(), lambda s: s.mean(), id='mean',),
+    param(
+        lambda t: mean_udf(t.double_col),
+        lambda s: s.mean(),
+        id='mean_udf',
+        marks=pytest.mark.udf,
+    ),
     param(lambda t: t.double_col.min(), lambda s: s.min(), id='min',),
     param(lambda t: t.double_col.max(), lambda s: s.max(), id='max',),
     param(

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -3,10 +3,19 @@ import pytest
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.tests.backends import Pandas, PySpark
-from ibis.udf.vectorized import elementwise
-
+from ibis.udf.vectorized import elementwise, reduction
 
 pytestmark = pytest.mark.udf
+
+
+@elementwise(input_type=[dt.double], output_type=dt.double)
+def add_one(s):
+    return s + 1
+
+
+@reduction(input_type=[dt.double], output_type=dt.double)
+def calc_mean(s):
+    return s.mean()
 
 
 @pytest.mark.only_on_backends([Pandas, PySpark])
@@ -19,6 +28,14 @@ def test_elementwise_udf(backend, alltypes, df):
     result = add_one(alltypes['double_col']).execute()
     expected = add_one.func(df['double_col'])
     backend.assert_series_equal(result, expected, check_names=False)
+
+
+@pytest.mark.only_on_backends([Pandas, PySpark])
+@pytest.mark.xfail_unsupported
+def test_reduction_udf(backend, alltypes, df):
+    result = calc_mean(alltypes['double_col']).execute()
+    expected = df['double_col'].agg(calc_mean.func)
+    assert result == expected
 
 
 @pytest.mark.only_on_backends([Pandas, PySpark])

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -3,6 +3,7 @@ from pytest import param
 
 import ibis
 import ibis.common.exceptions as com
+import ibis.expr.datatypes as dt
 from ibis.tests.backends import (
     Csv,
     Impala,
@@ -15,6 +16,12 @@ from ibis.tests.backends import (
     Spark,
     SQLite,
 )
+from ibis.udf.vectorized import reduction
+
+
+@reduction(input_type=[dt.double], output_type=dt.double)
+def mean_udf(s):
+    return s.mean()
 
 
 @pytest.mark.parametrize(
@@ -294,6 +301,47 @@ def test_bounded_preceding_windows(backend, alltypes, df, con, window_fn):
         .set_index('id')
         .sort_index()
     )
+
+    left, right = result.val, expected.val
+
+    backend.assert_series_equal(left, right)
+
+
+@pytest.mark.parametrize(
+    ('result_fn', 'expected_fn'),
+    [
+        param(
+            lambda t, win: t.double_col.mean().over(win),
+            lambda gb: (gb.double_col.transform('mean')),
+            id='mean',
+        ),
+        param(
+            lambda t, win: mean_udf(t.double_col).over(win),
+            lambda gb: (gb.double_col.transform('mean')),
+            id='mean_udf',
+            marks=pytest.mark.udf,
+        ),
+    ],
+)
+@pytest.mark.xfail_unsupported
+def test_unbounded_window(backend, alltypes, df, con, result_fn, expected_fn):
+    if not backend.supports_window_operations:
+        pytest.skip(
+            'Backend {} does not support window operations'.format(backend)
+        )
+
+    expr = alltypes.mutate(
+        val=result_fn(
+            alltypes,
+            win=ibis.window(
+                group_by=[alltypes.string_col], order_by=[alltypes.id],
+            ),
+        )
+    )
+
+    result = expr.execute().set_index('id').sort_index()
+    column = expected_fn(df.sort_values('id').groupby('string_col'))
+    expected = df.assign(val=column).set_index('id').sort_index()
 
     left, right = result.val, expected.val
 


### PR DESCRIPTION
This is a re-make of #2348.

#### Change
Add a compilation function for `ReductionVectorizedUDF` for the PySpark backend

#### Testing

- `test_vectorized_udf.py`: New basic test for reduction UDF
- `test_aggregation.py`: New test parameter (that uses reduction UDFs) for `test_aggregate` and `test_aggregate_grouped`
- `test_window.py`: New test for unbounded window, including a test parameter that uses reduction UDFs