### PR TITLE
BUG: fix the covariance operator in the BigQuery backend.

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2367` Fix the covariance operator in the BigQuery backend.
 * :feature:`2366` Add PySpark support for ReductionVectorizedUDF
 * :feature:`2306` Add time context in `scope` in execution for pandas backend
 * :support:`2351` Simplifying tests directories structure

--- a/ibis/bigquery/compiler.py
+++ b/ibis/bigquery/compiler.py
@@ -573,7 +573,9 @@ def compiles_covar(translator, expr):
         left = where.ifelse(left, ibis.NA)
         right = where.ifelse(right, ibis.NA)
 
-    return "COVAR_{}({}, {})".format(how, left, right)
+    return "COVAR_{}({}, {})".format(
+        how, translator.translate(left), translator.translate(right)
+    )
 
 
 @rewrites(ops.Any)

--- a/ibis/bigquery/tests/test_compiler.py
+++ b/ibis/bigquery/tests/test_compiler.py
@@ -457,9 +457,8 @@ SELECT COVAR_POP(`double_col`, `double_col`) AS `tmp`
 FROM `{project_id}.testing.functional_alltypes`"""
     assert result == expected
 
-    expr = d.cov(d, how='error')
     with pytest.raises(ValueError):
-        expr.compile()
+        d.cov(d, how='error')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Arguments weren't being translated.

Towards #2353
Closes #2367 