### PR TITLE
BUG: Fix analytic ops over ungrouped and unordered windows on Pandas backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2367` Fix analytic ops over ungrouped and unordered windows on Pandas backend
 * :feature:`2366` Add PySpark support for ReductionVectorizedUDF
 * :feature:`2306` Add time context in `scope` in execution for pandas backend
 * :support:`2351` Simplifying tests directories structure

--- a/ibis/pandas/execution/window.py
+++ b/ibis/pandas/execution/window.py
@@ -3,7 +3,7 @@
 import functools
 import operator
 import re
-from typing import NoReturn, Optional
+from typing import Any, List, NoReturn, Optional
 
 import pandas as pd
 import toolz
@@ -30,27 +30,36 @@ from ibis.pandas.dispatch import execute_node, pre_execute
 from ibis.pandas.execution import util
 
 
-def _post_process_empty(result, parent, order_by, group_by):
+def _post_process_empty(
+    result: Any, parent: pd.DataFrame, order_by: List[str], group_by: List[str]
+) -> pd.Series:
     assert not order_by and not group_by
     if isinstance(result, pd.Series):
-        # `result` is a Series e.g. when an analytic operation is being
-        # applied over the window
+        # `result` is a Series when an analytic operation is being
+        # applied over the window, since analytic operations are N->N
         return result
     else:
-        # `result` is a scalar e.g. when a reduction operation is being
-        # applied over the window
+        # `result` is a scalar when a reduction operation is being
+        # applied over the window, since reduction operations are N->1
         index = parent.index
         result = pd.Series([result]).repeat(len(index))
         result.index = index
         return result
 
 
-def _post_process_group_by(series, parent, order_by, group_by):
+def _post_process_group_by(
+    series: pd.Series,
+    parent: pd.DataFrame,
+    order_by: List[str],
+    group_by: List[str],
+) -> pd.Series:
     assert not order_by and group_by
     return series
 
 
-def _post_process_order_by(series, parent, order_by, group_by):
+def _post_process_order_by(
+    series, parent: pd.DataFrame, order_by: List[str], group_by: List[str]
+) -> pd.Series:
     assert order_by and not group_by
     indexed_parent = parent.set_index(order_by)
     index = indexed_parent.index
@@ -61,7 +70,12 @@ def _post_process_order_by(series, parent, order_by, group_by):
     return series
 
 
-def _post_process_group_by_order_by(series, parent, order_by, group_by):
+def _post_process_group_by_order_by(
+    series: pd.Series,
+    parent: pd.DataFrame,
+    order_by: List[str],
+    group_by: List[str],
+) -> pd.Series:
     indexed_parent = parent.set_index(group_by + order_by, append=True)
     index = indexed_parent.index
 
@@ -278,7 +292,7 @@ def execute_window_op(
 
     order_by = window._order_by
     if not order_by:
-        ordering_keys = ()
+        ordering_keys = []
 
     if group_by:
         if order_by:

--- a/ibis/pandas/execution/window.py
+++ b/ibis/pandas/execution/window.py
@@ -30,12 +30,19 @@ from ibis.pandas.dispatch import execute_node, pre_execute
 from ibis.pandas.execution import util
 
 
-def _post_process_empty(scalar, parent, order_by, group_by):
+def _post_process_empty(result, parent, order_by, group_by):
     assert not order_by and not group_by
-    index = parent.index
-    result = pd.Series([scalar]).repeat(len(index))
-    result.index = index
-    return result
+    if isinstance(result, pd.Series):
+        # `result` is a Series e.g. when an analytic operation is being
+        # applied over the window
+        return result
+    else:
+        # `result` is a scalar e.g. when a reduction operation is being
+        # applied over the window
+        index = parent.index
+        result = pd.Series([result]).repeat(len(index))
+        result.index = index
+        return result
 
 
 def _post_process_group_by(series, parent, order_by, group_by):

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -399,10 +399,16 @@ def test_unbounded_window_grouped(
 @pytest.mark.parametrize(
     ('ordered'),
     [
-        param(True, id='orderered'),
+        param(
+            # Temporarily disabled on Spark and Imapala because their behavior
+            # is currently inconsistent with the other backends (see #2378).
+            True,
+            id='orderered',
+            marks=pytest.mark.skip_backends([Spark, Impala]),
+        ),
         param(
             # Disabled on MySQL and PySpark because they require a defined
-            # ordering for analytic ops like lag and lead
+            # ordering for analytic ops like lag and lead.
             False,
             id='unordered',
             marks=pytest.mark.skip_backends([MySQL, PySpark]),

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -401,15 +401,17 @@ def test_unbounded_window_grouped(
     [
         param(True, id='orderered'),
         param(
-            # Disabled on PySpark because PySpark requires a defined
+            # Disabled on MySQL and PySpark because they require a defined
             # ordering for analytic ops like lag and lead
             False,
             id='unordered',
-            marks=pytest.mark.skip_backends([PySpark]),
+            marks=pytest.mark.skip_backends([MySQL, PySpark]),
         ),
     ],
 )
 @pytest.mark.xfail_unsupported
+# Some backends do not support non-grouped window specs
+@pytest.mark.xfail_backends([OmniSciDB, SQLite])
 def test_unbounded_window_ungrouped(
     backend, alltypes, df, con, result_fn, expected_fn, ordered
 ):

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -421,6 +421,10 @@ def test_unbounded_window_grouped(
 def test_unbounded_window_ungrouped(
     backend, alltypes, df, con, result_fn, expected_fn, ordered
 ):
+    assert (
+        not df.empty
+    )  # Only for verifying this fails Impala CI. Remove before merging PR!
+
     if not backend.supports_window_operations:
         pytest.skip(
             'Backend {} does not support window operations'.format(backend)

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -409,9 +409,9 @@ def test_unbounded_window_grouped(
         ),
     ],
 )
-@pytest.mark.xfail_unsupported
 # Some backends do not support non-grouped window specs
-@pytest.mark.xfail_backends([OmniSciDB, SQLite])
+@pytest.mark.xfail_backends([OmniSciDB])
+@pytest.mark.xfail_unsupported
 def test_unbounded_window_ungrouped(
     backend, alltypes, df, con, result_fn, expected_fn, ordered
 ):

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -421,10 +421,6 @@ def test_unbounded_window_grouped(
 def test_unbounded_window_ungrouped(
     backend, alltypes, df, con, result_fn, expected_fn, ordered
 ):
-    assert (
-        not df.empty
-    )  # Only for verifying this fails Impala CI. Remove before merging PR!
-
     if not backend.supports_window_operations:
         pytest.skip(
             'Backend {} does not support window operations'.format(backend)

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -409,9 +409,11 @@ def test_unbounded_window_grouped(
         param(
             # Disabled on MySQL and PySpark because they require a defined
             # ordering for analytic ops like lag and lead.
+            # Disabled on Spark because its behavior is inconsistent with other
+            # backends (see #2381).
             False,
             id='unordered',
-            marks=pytest.mark.skip_backends([MySQL, PySpark]),
+            marks=pytest.mark.skip_backends([MySQL, PySpark, Spark]),
         ),
     ],
 )

--- a/ibis/tests/all/test_window.py
+++ b/ibis/tests/all/test_window.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 from pytest import param
 
@@ -16,12 +17,17 @@ from ibis.tests.backends import (
     Spark,
     SQLite,
 )
-from ibis.udf.vectorized import reduction
+from ibis.udf.vectorized import analytic, reduction
 
 
 @reduction(input_type=[dt.double], output_type=dt.double)
 def mean_udf(s):
     return s.mean()
+
+
+@analytic(input_type=[dt.double], output_type=dt.double)
+def calc_zscore(s):
+    return (s - s.mean()) / s.std()
 
 
 @pytest.mark.parametrize(
@@ -323,25 +329,110 @@ def test_bounded_preceding_windows(backend, alltypes, df, con, window_fn):
         ),
     ],
 )
+@pytest.mark.parametrize(
+    ('ordered'), [param(True, id='orderered'), param(False, id='unordered')],
+)
 @pytest.mark.xfail_unsupported
-def test_unbounded_window(backend, alltypes, df, con, result_fn, expected_fn):
+def test_unbounded_window_grouped(
+    backend, alltypes, df, con, result_fn, expected_fn, ordered
+):
     if not backend.supports_window_operations:
         pytest.skip(
             'Backend {} does not support window operations'.format(backend)
         )
 
-    expr = alltypes.mutate(
-        val=result_fn(
-            alltypes,
-            win=ibis.window(
-                group_by=[alltypes.string_col], order_by=[alltypes.id],
-            ),
-        )
-    )
+    # Define a window that is
+    # 1) Always grouped
+    # 2) Ordered if `ordered` is True
+    order_by = [alltypes.id] if ordered else None
+    window = ibis.window(group_by=[alltypes.string_col], order_by=order_by)
+    expr = alltypes.mutate(val=result_fn(alltypes, win=window,))
+    result = expr.execute()
+    result = result.set_index('id').sort_index()
 
-    result = expr.execute().set_index('id').sort_index()
-    column = expected_fn(df.sort_values('id').groupby('string_col'))
-    expected = df.assign(val=column).set_index('id').sort_index()
+    # Apply `expected_fn` onto a DataFrame that is
+    # 1) Always grouped
+    # 2) Ordered if `ordered` is True
+    df = df.sort_values('id') if ordered else df
+    expected = df.assign(val=expected_fn(df.groupby('string_col')))
+    expected = expected.set_index('id').sort_index()
+
+    left, right = result.val, expected.val
+
+    backend.assert_series_equal(left, right)
+
+
+@pytest.mark.parametrize(
+    ('result_fn', 'expected_fn'),
+    [
+        # Reduction ops
+        param(
+            lambda t, win: t.double_col.mean().over(win),
+            lambda df: pd.Series([df.double_col.mean()] * len(df.double_col)),
+            id='mean',
+        ),
+        param(
+            lambda t, win: mean_udf(t.double_col).over(win),
+            lambda df: pd.Series([df.double_col.mean()] * len(df.double_col)),
+            id='mean_udf',
+            marks=pytest.mark.udf,
+        ),
+        # Analytic ops
+        param(
+            lambda t, win: t.float_col.lag().over(win),
+            lambda df: df.float_col.shift(1),
+            id='lag',
+        ),
+        param(
+            lambda t, win: t.float_col.lead().over(win),
+            lambda df: df.float_col.shift(-1),
+            id='lead',
+        ),
+        param(
+            lambda t, win: calc_zscore(t.double_col).over(win),
+            lambda df: df.double_col.transform(calc_zscore.func),
+            id='zscore_udf',
+            marks=pytest.mark.udf,
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ('ordered'),
+    [
+        param(True, id='orderered'),
+        param(
+            # Disabled on PySpark because PySpark requires a defined
+            # ordering for analytic ops like lag and lead
+            False,
+            id='unordered',
+            marks=pytest.mark.skip_backends([PySpark]),
+        ),
+    ],
+)
+@pytest.mark.xfail_unsupported
+def test_unbounded_window_ungrouped(
+    backend, alltypes, df, con, result_fn, expected_fn, ordered
+):
+    if not backend.supports_window_operations:
+        pytest.skip(
+            'Backend {} does not support window operations'.format(backend)
+        )
+
+    # Define a window that is
+    # 1) Not grouped
+    # 2) Ordered if `ordered` is True
+    order_by = [alltypes.id] if ordered else None
+    window = ibis.window(order_by=order_by)
+    expr = alltypes.mutate(val=result_fn(alltypes, win=window,))
+    result = expr.execute()
+    result = result.set_index('id').sort_index()
+
+    # Apply `expected_fn` onto a DataFrame that is
+    # 1) Not grouped
+    # 2) Ordered if `ordered` is True
+    df = df.sort_values('id') if ordered else df
+    expected = df.assign(val=expected_fn(df))
+    expected = expected.set_index('id').sort_index()
 
     left, right = result.val, expected.val
 


### PR DESCRIPTION
## Overview

Using analytic ops (like `lead`, `lag`, `first`, `last`, or analytic UDFs) over a window where no `group_by` and no `order_by` are defined produces an incorrect result.

## Example
Analytic op `lag` over an ungrouped+unordered window

```
import pandas as pd
import ibis

client = ibis.pandas.connect({'df': pd.DataFrame({'id': [1, 2, 3], 'value_col': [16, 92, 51]})})
table = client.table('df')

window = ibis.window()
expr = table.value_col.lag().over(window)  # lag operation over window
df = expr.execute()

df.to_markdown()
```

#### Before this PR
The result of the analytic op is a `Series`. That `Series` result is strangely copied `n` times, where `n` is the number of rows of the original column.
|    | 0                               |
|---:|:--------------------------------|
|  0 | 0     NaN                       |
|    | 1    16.0                            |
|    | 2    92.0                       |
|    | Name: value_col, dtype: float64 |
|  1 | 0     NaN                       |
|    | 1    16.0                            |
|    | 2    92.0                       |
|    | Name: value_col, dtype: float64 |
|  2 | 0     NaN                       |
|    | 1    16     .0                       |
|    | 2    92.0                       |
|    | Name: value_col, dtype: float64 |

#### After this PR
The `Series` result of the analytic op is treated as the end result of using the analytic op over the window. 
|    |   value_col |
|---:|------------:|
|  0 |         nan |
|  1 |          16 |
|  2 |          92 |

As additional verification that this is the correct result: the above table is what we get when we use the exact same code but with `window = ibis.window(order_by=[table.id])` (both before and after this PR).

## Testing
New tests in `test_window.py` to exercise the four kinds of windows:
1.  Window with `group_by` and `order_by`
2.  Window with `group_by` only
3.  Window with `order_by` only
4.  Window with neither `group_by` nor `order_by` 

New test in `test_vectorized_udf.py` to test using an analytic op and adding the result to a table using `mutate`. This implicitly executes the analytic op over a window. (Also a few additional general UDF tests for completeness)
