### PR TITLE
BUG: Fix scope get to use hashmap lookup instead of list lookup

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -16,6 +16,7 @@ Release Notes
 * :support:`2288` Drop support to Python 3.6
 * :bug:`2367` Fix the covariance operator in the BigQuery backend.
 * :feature:`2366` Add PySpark support for ReductionVectorizedUDF
+* :bug:`2386` Fix scope get to use hashmap lookup instead of list lookup
 * :feature:`2306` Add time context in `scope` in execution for pandas backend
 * :support:`2351` Simplifying tests directories structure
 * :feature:`2081` Add ``start_point`` and ``end_point`` to PostGIS backend.

--- a/ibis/expr/scope.py
+++ b/ibis/expr/scope.py
@@ -49,7 +49,7 @@ class Scope:
         self._items = items or {}
 
     def __contains__(self, op):
-        return True if op in self._items.keys() else False
+        return op in self._items.keys()
 
     def get_value(
         self, op: Node, timecontext: Optional[TimeContext] = None

--- a/ibis/expr/scope.py
+++ b/ibis/expr/scope.py
@@ -49,7 +49,10 @@ class Scope:
         self._items = items or {}
 
     def __contains__(self, op):
-        return op in self._items.keys()
+        return op in self._items
+
+    def __iter__(self):
+        return iter(self._items.keys())
 
     def get_value(
         self, op: Node, timecontext: Optional[TimeContext] = None
@@ -116,10 +119,10 @@ class Scope:
         """
         result = Scope()
 
-        for op in self._items.keys():
+        for op in self:
             result._items[op] = self._items[op]
 
-        for op in other_scope._items.keys():
+        for op in other_scope._items:
             # if get_scope returns a not None value, then data is already
             # cached in scope and it is at least a greater range than
             # the current timecontext, so we drop the item. Otherwise
@@ -147,7 +150,7 @@ class Scope:
             a new Scope instance with items in two scope merged.
         """
         result = Scope()
-        for op in self._items.keys():
+        for op in self:
             result._items[op] = self._items[op]
 
         for s in other_scopes:

--- a/ibis/expr/scope.py
+++ b/ibis/expr/scope.py
@@ -77,7 +77,7 @@ class Scope:
         result: the cached result, an object whose types may differ in
         different backends.
         """
-        if op not in self.items():
+        if op not in self._items:
             return None
 
         # for ops without timecontext
@@ -122,10 +122,10 @@ class Scope:
         """
         result = Scope()
 
-        for op in self.items():
+        for op in self._items:
             result[op] = self[op]
 
-        for op in other_scope.items():
+        for op in other_scope._items:
             # if get_scope returns a not None value, then data is already
             # cached in scope and it is at least a greater range than
             # the current timecontext, so we drop the item. Otherwise
@@ -153,7 +153,7 @@ class Scope:
             a new Scope instance with items in two scope merged.
         """
         result = Scope()
-        for op in self.items():
+        for op in self._items:
             result[op] = self[op]
 
         for s in other_scopes:

--- a/ibis/expr/scope.py
+++ b/ibis/expr/scope.py
@@ -122,7 +122,7 @@ class Scope:
         for op in self:
             result._items[op] = self._items[op]
 
-        for op in other_scope._items:
+        for op in other_scope:
             # if get_scope returns a not None value, then data is already
             # cached in scope and it is at least a greater range than
             # the current timecontext, so we drop the item. Otherwise

--- a/ibis/expr/scope.py
+++ b/ibis/expr/scope.py
@@ -77,7 +77,7 @@ class Scope:
         result: the cached result, an object whose types may differ in
         different backends.
         """
-        if op not in self._items:
+        if op not in self._items.keys():
             return None
 
         # for ops without timecontext
@@ -122,10 +122,10 @@ class Scope:
         """
         result = Scope()
 
-        for op in self._items:
+        for op in self._items.keys():
             result[op] = self[op]
 
-        for op in other_scope._items:
+        for op in other_scope._items.keys():
             # if get_scope returns a not None value, then data is already
             # cached in scope and it is at least a greater range than
             # the current timecontext, so we drop the item. Otherwise
@@ -153,7 +153,7 @@ class Scope:
             a new Scope instance with items in two scope merged.
         """
         result = Scope()
-        for op in self._items:
+        for op in self._items.keys():
             result[op] = self[op]
 
         for s in other_scopes:

--- a/ibis/pandas/tests/test_core.py
+++ b/ibis/pandas/tests/test_core.py
@@ -9,7 +9,7 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.expr.scope import make_scope
+from ibis.expr.scope import Scope, make_scope
 from ibis.pandas.client import PandasClient
 from ibis.pandas.core import is_computable_input
 from ibis.pandas.dispatch import execute_node, post_execute, pre_execute
@@ -182,3 +182,13 @@ def test_is_computable_input():
     del dt.infer.funcs[(MyObject,)]
     dt.infer.reorder()
     dt.infer._cache.clear()
+
+
+def test_scope_look_up():
+    # test if scope could lookup items properly
+    scope = Scope()
+    one_day = ibis.interval(days=1).op()
+    one_hour = ibis.interval(hours=1).op()
+    scope = scope.merge_scope(make_scope(one_day, 1))
+    assert scope.get_value(one_hour) is None
+    assert scope.get_value(one_day) is not None


### PR DESCRIPTION
Overview
------
This PR aims to fix a bug in looking up an `op` in `scope`.  The current implementation is using a list lookup to look up items in `iter(_items)`. This is slower than a hashmap lookup, also it may cause bugs for objects if their equality is ill-defined.

Example
-------
```
a = ibis.interval(days=1).op()
b = ibis.interval(hours=1).op()
>>> a
Literal(1, Interval*value_type=int8, unit='D', nullable=True)
>>> a == b
True
```
In this case, `Literal` is ill-defined for equality. And if we have only `a` in scope`. `b in iter(scope._items)` will be `True` while `b in scope._items` return false. 

Tests
-------
This is tested in `ibis/pandas/tests/tes_core.py` with a new test case `test_scope_look_up`.