### PR TITLE
BUG: Fix equality behavior for Literal ops

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2387` Fix equality behavior for Literal ops
 * :bug:`2376` Fix analytic ops over ungrouped and unordered windows on Pandas backend
 * :support:`2288` Drop support to Python 3.6
 * :bug:`2367` Fix the covariance operator in the BigQuery backend.

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2948,6 +2948,7 @@ class Literal(ValueOp):
             isinstance(other, Literal)
             and isinstance(other.value, type(self.value))
             and self.value == other.value
+            and self.dtype == other.dtype
         )
 
     def output_type(self):

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -1,0 +1,37 @@
+import ibis
+
+
+def test_literal_equality_basic():
+    a = ibis.literal(1).op()
+    b = ibis.literal(1).op()
+
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_literal_equality_int_float():
+    # Note: This is different from the Python behavior for int/float comparison
+    a = ibis.literal(1).op()
+    b = ibis.literal(1.0).op()
+
+    assert a != b
+
+
+def test_literal_equality_int_interval():
+    a = ibis.literal(1).op()
+    b = ibis.interval(seconds=1).op()
+
+    assert a != b
+
+
+def test_literal_equality_interval():
+    a = ibis.interval(seconds=1).op()
+    b = ibis.interval(minutes=1).op()
+
+    assert a != b
+
+    # Currently these does't equal, but perhaps should be?
+    c = ibis.interval(seconds=60).op()
+    d = ibis.interval(minutes=1).op()
+
+    assert c != d

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -1,4 +1,6 @@
 import ibis
+from ibis.expr import datatypes
+from ibis.expr.operations import Literal
 
 
 def test_literal_equality_basic():
@@ -13,6 +15,14 @@ def test_literal_equality_int_float():
     # Note: This is different from the Python behavior for int/float comparison
     a = ibis.literal(1).op()
     b = ibis.literal(1.0).op()
+
+    assert a != b
+
+
+def test_literal_equality_int16_int32():
+    # Note: This is different from the Python behavior for int/float comparison
+    a = Literal(1, datatypes.int16)
+    b = Literal(1, datatypes.int32)
 
     assert a != b
 


### PR DESCRIPTION
The Problem
=========

Currently the equality method for Literal is ill defined, e.g.:

```
>>> a = Literal(1, datatypes.int16)
>>> b = Literal(1, datatypes.int32)
>>> a != b
False
>>> a == b
True
>>> hash(a)
1536673607048974696
>>> hash(b)
-4587729510117789678
```

This IMO is bad behavior because it breaks the contract of equal and hashcode (if a == b, then hash(a) must == hash(b)).

What's even worse:
```
>>> a = ibis.interval(hours=1).op()
>>> b = ibis.interval(seconds=1).op()
>>> a == b
True
```
Here a and b are totally different objects.

The Fix
=====
The PR proposes a fix where we also checks the dtype equality in literal equality check.

This fix deals with the two problems above. However, it does change some existing behavior:

Before the PR:

```
a = Literal(1, datatypes.int16)                                                                                                                                                                       
b = Literal(1, datatypes.int32)

a == b # True
```

After the PR:
```
a = Literal(1, datatypes.int16)                                                                                                                                                                       
b = Literal(1, datatypes.int32)

a == b # False
```

I'd like to be more careful with this and hear what other people think. I think after PR behavior is more correct but might break people's code if they are relying the correct behavior. Thoughts?