### PR TITLE
CI: Adding workflow to self-assign issues

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,14 @@
+name: Assign
+on:
+  issue_comment:
+    types: created
+
+jobs:
+  one:
+    runs-on: ubuntu-latest
+    steps:
+    - if: github.event.comment.body == '/take'
+      name:
+      run: |
+        echo "Assigning issue ${{ github.event.issue.number }} to ${{ github.event.comment.user.login }}"
+        curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -d '{"assignees": ["${{ github.event.comment.user.login }}"]}' https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/assignees


### PR DESCRIPTION
Now that hacktoberfest is approaching, and I'm also thinking on organizing a sprint to take care of many "good first issue", I think it may be useful to let people assign issues to themselves via a comment. Adding it here.

Will add docs in a follow up, the contributing page needs several updates, and I'll add about assigning issues there.