### PR TITLE
CI: Fix typo in bigquery build name

### DIFF
--- a/.github/workflows/bigquery.yml
+++ b/.github/workflows/bigquery.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   Tests_bigquery:
-    name: Tests pandas
+    name: Tests bigquery
     runs-on: ubuntu-latest
     env:
       BACKENDS: "bigquery"


### PR DESCRIPTION
Looks like the bigquery build was copied from the pandas one, but the name wasn't changed.