### PR TITLE
FEAT: Support rolling window UDF with non numeric inputs

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2386` FEAT: Support rolling window UDF with non numeric inputs for pandas backend.
 * :bug:`2386` Fix scope get to use hashmap lookup instead of list lookup
 * :bug:`2387` Fix equality behavior for Literal ops
 * :bug:`2376` Fix analytic ops over ungrouped and unordered windows on Pandas backend

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -453,6 +453,7 @@ class Window(AggregationContext):
         *args: Tuple[Any],
         **kwargs: Dict[str, Any],
     ) -> pd.Series:
+
         # avoid a pandas warning about numpy arrays being passed through
         # directly
         group_by = self.group_by
@@ -501,7 +502,10 @@ class Window(AggregationContext):
             # TODO: see if we can do this in the caller, when the context
             # is constructed rather than pulling out the data
             columns = group_by + order_by + [name]
-            indexed_by_ordering = frame[columns].set_index(order_by)
+            indexed_by_ordering = frame[columns]
+            # placeholder column to compute window_sizes below
+            indexed_by_ordering['_placeholder'] = 0
+            indexed_by_ordering = indexed_by_ordering.set_index(order_by)
 
             # regroup if needed
             if group_by:
@@ -510,12 +514,24 @@ class Window(AggregationContext):
                 grouped_frame = indexed_by_ordering
             grouped = grouped_frame[name]
 
-            # perform the per-group rolling operation
-            windowed = self.construct_window(grouped)
-
             if callable(function):
-                window_sizes = windowed.apply(len, raw=True).reset_index(
-                    drop=True
+                # To compute the window_size, we need to contruct a
+                # RollingGroupby and compute count using construct_window.
+                # However, if the RollingGroupby is not numeric, e.g.,
+                # we are calling window UDF on a timestamp column, we
+                # cannot compute rolling count directly because:
+                # (1) windowed.count() will exclude NaN observations
+                #     , which results in incorrect window sizes.
+                # (2) windowed.apply(len, raw=True) will include NaN
+                #     obversations, but doesn't work on non-numeric types.
+                #
+                # To deal with this, we create a _placeholder column
+
+                windowed_frame = self.construct_window(grouped_frame)
+                window_sizes = (
+                    windowed_frame['_placeholder']
+                    .count()
+                    .reset_index(drop=True)
                 )
                 mask = ~(window_sizes.isna())
                 window_upper_indices = pd.Series(range(len(window_sizes))) + 1
@@ -534,6 +550,8 @@ class Window(AggregationContext):
                     **kwargs,
                 )
             else:
+                # perform the per-group rolling operation
+                windowed = self.construct_window(grouped)
                 result = window_agg_built_in(
                     frame,
                     windowed,

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -501,7 +501,8 @@ class Window(AggregationContext):
             # TODO: see if we can do this in the caller, when the context
             # is constructed rather than pulling out the data
             columns = group_by + order_by + [name]
-            indexed_by_ordering = frame[columns]
+            # Create a new frame to avoid mutating the original one
+            indexed_by_ordering = frame[columns].copy()
             # placeholder column to compute window_sizes below
             indexed_by_ordering['_placeholder'] = 0
             indexed_by_ordering = indexed_by_ordering.set_index(order_by)
@@ -523,7 +524,7 @@ class Window(AggregationContext):
                 #     , which results in incorrect window sizes.
                 # (2) windowed.apply(len, raw=True) will include NaN
                 #     obversations, but doesn't work on non-numeric types.
-                #
+                #     https://github.com/pandas-dev/pandas/issues/23002
                 # To deal with this, we create a _placeholder column
 
                 windowed_frame = self.construct_window(grouped_frame)

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -453,7 +453,6 @@ class Window(AggregationContext):
         *args: Tuple[Any],
         **kwargs: Dict[str, Any],
     ) -> pd.Series:
-
         # avoid a pandas warning about numpy arrays being passed through
         # directly
         group_by = self.group_by

--- a/ibis/pandas/tests/execution/test_window.py
+++ b/ibis/pandas/tests/execution/test_window.py
@@ -727,6 +727,7 @@ def test_custom_window_udf(t, custom_window):
     'group_by,order_by',
     [
         (None, None),
+        # Enable this after #2395 is merged
         # (None, 'plain_datetimes_utc'),
         ('dup_ints', None),
         ('dup_ints', 'plain_datetimes_utc'),


### PR DESCRIPTION
The Problem
=========

Currently, user defined function doesn't support non numeric inputs for rolling window:

```
win = ibis.trailing_window(preceding=1, group_by=...,order_by=...)

my_udf(t['non_numeric_column']).over(w)
```

will raise exception because we try to compute window bounds by calling `grouped_series.rolling(1).apply(len, raw=True)`, which doesn't work on non numeric columns.

The Fix
=====
I changed the logic to compute window bounds to no longer rely on the input series to the UDF, instead, I created an placeholder column used just for the window bounds computation. The placeholder column is an int column and doesn't have NaNs.

Test
===
Added a new test `test_rolling_window_udf_nan_and_non_numeric` to cover this case as well as the case where input columns contains NaN values.