### PR TITLE
CI: Add PR prefix labeler

### DIFF
--- a/.github/pr-prefix-labeler.yml
+++ b/.github/pr-prefix-labeler.yml
@@ -1,0 +1,8 @@
+"DOC": "docs"
+"CI": "ci"
+"BUG": "bug"
+"TST": "testing"
+"FEAT": "enhancement"
+"DEPS": "compatibility"
+"PERF": "performance"
+"WIP": "discussion"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Label the PR
+      uses: gerrymanoim/pr-prefix-labeler@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Awhile ago I made https://github.com/gerrymanoim/pr-prefix-labeler to automatically label PRs based on their prefix (following the numpy guidelines http://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message, we first used it on https://github.com/quantopian/libpy/pulls?q=is%3Apr+is%3Aclosed).

I figured I'd see if there's any interest from other projects that do PR prefixing. I tried to go through the PRs and fill out the custom mapping (in .github/pr-prefix-labeler.yml), apologies if I've missed any.

Note: Because this action is set to run on pull_request_target, it will not run on any PRs until this is merged (see https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target for detail).

