### PR TITLE
DOC: Update the url to ibis project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 |Service|Status|
 | -------------: | :---- |
-| Documentation  | [![Documentation Status](https://img.shields.io/badge/docs-docs.ibis--project.org-blue.svg)](http://docs.ibis-project.org) |
+| Documentation  | [![Documentation Status](https://img.shields.io/badge/docs-docs.ibis--project.org-blue.svg)](http://ibis-project.org) |
 | Conda packages | [![Anaconda-Server Badge](https://anaconda.org/conda-forge/ibis-framework/badges/version.svg)](https://anaconda.org/conda-forge/ibis-framework) |
 | PyPI           | [![PyPI](https://img.shields.io/pypi/v/ibis-framework.svg)](https://pypi.org/project/ibis-framework) |
 | Azure          | [![Azure Status](https://dev.azure.com/ibis-project/ibis/_apis/build/status/ibis-project.ibis)](https://dev.azure.com/ibis-project/ibis/_build) |
@@ -40,4 +40,4 @@ Ibis currently provides tools for interacting with the following systems:
 - [OmniSciDB](https://www.omnisci.com)
 - [Spark](https://spark.apache.org) (Experimental)
 
-Learn more about using the library at http://docs.ibis-project.org.
+Learn more about using the library at http://ibis-project.org.

--- a/docs/source/backends/omnisci.rst
+++ b/docs/source/backends/omnisci.rst
@@ -436,4 +436,4 @@ Pull Requests:
 References
 ----------
 
-- ibis API: http://docs.ibis-project.org/api.html
+- ibis API: http://ibis-project.org/docs/api.html

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import versioneer
 LONG_DESCRIPTION = """
 Ibis is a productivity-centric Python big data framework.
 
-See http://docs.ibis-project.org
+See http://ibis-project.org
 """
 
 VERSION = sys.version_info.major, sys.version_info.minor


### PR DESCRIPTION
cc @datapythonista in reference to https://github.com/ibis-project/ibis-dask/pull/2#discussion_r493405457. 

There are two references in the `omnisci.rst` docs to http://docs.ibis-project.org/design.html that I couldn't find a replacement for (the existing links currently 404). Please let me know if there's a good replacement or I should leave them as is. 