### PR TITLE
FEAT: Support Ibis interval for window in pyspark backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2409` FEAT: Support Ibis interval for window in pyspark backend
 * :bug:`2229` Fix same column with multiple aliases not showing properly in repr
 * :feature:`2402` Use Scope class for scope in pyspark backend
 * :bug:`2395` Fix reduction UDFs over ungrouped, bounded windows on Pandas backend

--- a/ibis/pyspark/compiler.py
+++ b/ibis/pyspark/compiler.py
@@ -1097,10 +1097,10 @@ def compile_window_op(t, expr, scope, timecontext, **kwargs):
             pyspark_window = pyspark_window.rangeBetween(start, end)
         else:
             pyspark_window = pyspark_window.rowsBetween(start, end)
-
-    result = t.translate(operand, scope, timecontext, context=context).over(
-        pyspark_window
-    )
+    # TODO: completely remove window from params
+    result = t.translate(
+        operand, scope, timecontext, window=pyspark_window, context=context
+    ).over(pyspark_window)
 
     return result
 

--- a/ibis/pyspark/tests/test_timecontext.py
+++ b/ibis/pyspark/tests/test_timecontext.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import pandas.util.testing as tm
+import pyspark.sql.functions as F
 import pytest
+from pyspark.sql.window import Window
 
 import ibis
 
@@ -25,6 +27,7 @@ def test_time_indexed_window(client):
     window2 = ibis.trailing_window(
         preceding=ibis.interval(hours=2), order_by='time', group_by='key'
     )
+
     result = table.mutate(
         mean_1h=table['value'].mean().over(window1),
         mean_2h=table['value'].mean().over(window2),
@@ -46,6 +49,26 @@ def test_time_indexed_window(client):
         .mean()
         .rename('mean_2h')
     ).reset_index(drop=True)
-
     tm.assert_series_equal(result_pd['mean_1h'], expected_win_1)
     tm.assert_series_equal(result_pd['mean_2h'], expected_win_2)
+
+
+def test_foward_looking_window(client):
+    table = client.table('time_indexed_table')
+    window = ibis.range_window(
+        preceding=0, following=ibis.interval(hours=1), order_by='time'
+    )
+    result = table.mutate(
+        mean_following_1h=table['value'].mean().over(window),
+    ).compile()
+    result_pd = result.toPandas()
+    spark_window = (
+        Window.partitionBy()
+        .orderBy(F.col('time').cast('long'))
+        .rangeBetween(0, 3600)
+    )
+    spark_table = table.compile()
+    expected = spark_table.withColumn(
+        'mean_following_1h', F.mean(spark_table['value']).over(spark_window),
+    ).toPandas()
+    tm.assert_frame_equal(result_pd, expected)

--- a/ibis/pyspark/tests/test_timecontext.py
+++ b/ibis/pyspark/tests/test_timecontext.py
@@ -2,6 +2,8 @@ import pandas as pd
 import pandas.util.testing as tm
 import pytest
 
+import ibis
+
 pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
 
@@ -13,3 +15,37 @@ def test_table_with_timecontext(client):
     expected = table.compile().toPandas()
     expected = expected[expected.time.between(*context)]
     tm.assert_frame_equal(result, expected)
+
+
+def test_time_indexed_window(client):
+    table = client.table('time_indexed_table')
+    window1 = ibis.trailing_window(
+        preceding=ibis.interval(hours=1), order_by='time', group_by='key'
+    )
+    window2 = ibis.trailing_window(
+        preceding=ibis.interval(hours=2), order_by='time', group_by='key'
+    )
+    result = table.mutate(
+        mean_1h=table['value'].mean().over(window1),
+        mean_2h=table['value'].mean().over(window2),
+    ).compile()
+    result_pd = result.toPandas()
+
+    df = table.compile().toPandas()
+    expected_win_1 = (
+        df.set_index('time')
+        .groupby('key')
+        .value.rolling('1h', closed='both')
+        .mean()
+        .rename('mean_1h')
+    ).reset_index(drop=True)
+    expected_win_2 = (
+        df.set_index('time')
+        .groupby('key')
+        .value.rolling('2h', closed='both')
+        .mean()
+        .rename('mean_2h')
+    ).reset_index(drop=True)
+
+    tm.assert_series_equal(result_pd['mean_1h'], expected_win_1)
+    tm.assert_series_equal(result_pd['mean_2h'], expected_win_2)

--- a/ibis/pyspark/tests/test_window.py
+++ b/ibis/pyspark/tests/test_window.py
@@ -59,7 +59,7 @@ def test_time_indexed_window(client, ibis_window, spark_range):
 
 
 # TODO: multi windows don't update scope correctly
-@pytest.mark.xfail
+@pytest.mark.xfail(reason='Issue #2412', strict=True)
 def test_multiple_windows(client):
     table = client.table('time_indexed_table')
     window1 = ibis.trailing_window(

--- a/ibis/pyspark/tests/test_window.py
+++ b/ibis/pyspark/tests/test_window.py
@@ -2,6 +2,7 @@ import pandas.util.testing as tm
 import pyspark.sql.functions as F
 import pytest
 from pyspark.sql.window import Window
+from pytest import param
 
 import ibis
 
@@ -9,13 +10,67 @@ pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
 
 
-def test_time_indexed_window(client):
+@pytest.mark.parametrize(
+    ('ibis_window', 'spark_range'),
+    [
+        param(
+            ibis.trailing_window(
+                preceding=ibis.interval(hours=1),
+                order_by='time',
+                group_by='key',
+            ),
+            (-3600, 0),
+        ),
+        param(
+            ibis.trailing_window(
+                preceding=ibis.interval(hours=2),
+                order_by='time',
+                group_by='key',
+            ),
+            (-7200, 0),
+        ),
+        param(
+            ibis.range_window(
+                preceding=0,
+                following=ibis.interval(hours=1),
+                order_by='time',
+                group_by='key',
+            ),
+            (0, 3600),
+        ),
+    ],
+)
+def test_time_indexed_window(client, ibis_window, spark_range):
+    table = client.table('time_indexed_table')
+    result = table.mutate(
+        mean=table['value'].mean().over(ibis_window)
+    ).compile()
+    result_pd = result.toPandas()
+    spark_table = table.compile()
+    spark_window = (
+        Window.partitionBy('key')
+        .orderBy(F.col('time').cast('long'))
+        .rangeBetween(*spark_range)
+    )
+    expected = spark_table.withColumn(
+        'mean', F.mean(spark_table['value']).over(spark_window),
+    ).toPandas()
+    tm.assert_frame_equal(result_pd, expected)
+
+
+# TODO: multi windows don't update scope correctly
+@pytest.mark.xfail
+def test_multiple_windows(client):
     table = client.table('time_indexed_table')
     window1 = ibis.trailing_window(
         preceding=ibis.interval(hours=1), order_by='time', group_by='key'
     )
+    window2 = ibis.trailing_window(
+        preceding=ibis.interval(hours=2), order_by='time', group_by='key'
+    )
     result = table.mutate(
-        mean_1h=table['value'].mean().over(window1)
+        mean_1h=table['value'].mean().over(window1),
+        mean_2h=table['value'].mean().over(window2),
     ).compile()
     result_pd = result.toPandas()
 
@@ -27,25 +82,12 @@ def test_time_indexed_window(client):
         .mean()
         .rename('mean_1h')
     ).reset_index(drop=True)
+    expected_win_2 = (
+        df.set_index('time')
+        .groupby('key')
+        .value.rolling('2h', closed='both')
+        .mean()
+        .rename('mean_2h')
+    ).reset_index(drop=True)
     tm.assert_series_equal(result_pd['mean_1h'], expected_win_1)
-
-
-def test_foward_looking_window(client):
-    table = client.table('time_indexed_table')
-    window = ibis.range_window(
-        preceding=0, following=ibis.interval(hours=1), order_by='time'
-    )
-    result = table.mutate(
-        mean_following_1h=table['value'].mean().over(window),
-    ).compile()
-    result_pd = result.toPandas()
-    spark_window = (
-        Window.partitionBy()
-        .orderBy(F.col('time').cast('long'))
-        .rangeBetween(0, 3600)
-    )
-    spark_table = table.compile()
-    expected = spark_table.withColumn(
-        'mean_following_1h', F.mean(spark_table['value']).over(spark_window),
-    ).toPandas()
-    tm.assert_frame_equal(result_pd, expected)
+    tm.assert_series_equal(result_pd['mean_2h'], expected_win_2)

--- a/ibis/pyspark/tests/test_window.py
+++ b/ibis/pyspark/tests/test_window.py
@@ -14,13 +14,8 @@ def test_time_indexed_window(client):
     window1 = ibis.trailing_window(
         preceding=ibis.interval(hours=1), order_by='time', group_by='key'
     )
-    window2 = ibis.trailing_window(
-        preceding=ibis.interval(hours=2), order_by='time', group_by='key'
-    )
-
     result = table.mutate(
-        mean_1h=table['value'].mean().over(window1),
-        mean_2h=table['value'].mean().over(window2),
+        mean_1h=table['value'].mean().over(window1)
     ).compile()
     result_pd = result.toPandas()
 
@@ -32,15 +27,7 @@ def test_time_indexed_window(client):
         .mean()
         .rename('mean_1h')
     ).reset_index(drop=True)
-    expected_win_2 = (
-        df.set_index('time')
-        .groupby('key')
-        .value.rolling('2h', closed='both')
-        .mean()
-        .rename('mean_2h')
-    ).reset_index(drop=True)
     tm.assert_series_equal(result_pd['mean_1h'], expected_win_1)
-    tm.assert_series_equal(result_pd['mean_2h'], expected_win_2)
 
 
 def test_foward_looking_window(client):

--- a/ibis/pyspark/tests/test_window.py
+++ b/ibis/pyspark/tests/test_window.py
@@ -59,7 +59,11 @@ def test_time_indexed_window(client, ibis_window, spark_range):
 
 
 # TODO: multi windows don't update scope correctly
-@pytest.mark.xfail(reason='Issue #2412', strict=True)
+@pytest.mark.xfail(
+    reason='Issue #2412 Same window op with different window size on table '
+    'lead to incorrect results for pyspark backend',
+    strict=True,
+)
 def test_multiple_windows(client):
     table = client.table('time_indexed_table')
     window1 = ibis.trailing_window(


### PR DESCRIPTION
Overview
=======
Currently, window size defined by `ibis.interval` is broken for pyspark backend.  This PR aims to fix this issue. 

The Problem
=======
In pyspark backend, for a `table` generated by the following df:
```
df_time_indexed = client._session.createDataFrame(
        [
            [datetime(2017, 1, 2, 5, tzinfo=timezone.utc), 1, 1.0],
            [datetime(2017, 1, 2, 6, tzinfo=timezone.utc), 1, 3.0],
        ],
        ['time', 'key', 'value'],
    )
```
And calculate mean with a `trailing_window`, ordered by time column on this table:
```
window = ibis.trailing_window(
    preceding=ibis.interval(hours=2), order_by='time', group_by='key'
)
result = table.mutate(
    mean_2h=table['value'].mean().over(window)
).compile()
```
will result in error:

```
-> pyspark_window = pyspark_window.rowsBetween(start, end)  (compile_window_op inibis/pyspark/compiler.py)
TypeError: Arguments with datatype interval<int8>(unit='h') and int64 are not comparable
```

The Fix
=======
1. In compiling window op for pyspark backend, we cast `TimeStampColumn` to `long` type (seconds since epoch), this is required for spark to filtering and comparing time.
2. Add support to pass ibis interval in `preceding` and `following`, now `None`, `IntervalScalar` and `int` are supported for `preceding` and `following` in pyspark window.

Tests
=======
Tests are added in `ibis/pyspark/tests/test_window.py`. 

Follow-ups
=======
Once this is fixed, the next step is to add logic for context adjustment in pyspark backend. Again, to make things easier to review, will do context adjustment in follow-up PRs.