### PR TITLE
BUG: Fix Summarize not always producing a scalar value (Pandas backend)

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,7 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
-* :bug:`2410` Fix ``Summarize`` not always producing scalar (Pandas backend)
+* :bug:`2410` Fix ``aggcontext.Summarize`` not always producing scalar (Pandas backend)
 * :bug:`2414` Fix same window op with different window size on table lead to incorrect results for pyspark backend
 * :feature:`2409` FEAT: Support Ibis interval for window in pyspark backend
 * :bug:`2229` Fix same column with multiple aliases not showing properly in repr

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2410` Fix ``Summarize`` not always producing scalar (Pandas backend)
 * :bug:`2229` Fix same column with multiple aliases not showing properly in repr
 * :feature:`2402` Use Scope class for scope in pyspark backend
 * :bug:`2395` Fix reduction UDFs over ungrouped, bounded windows on Pandas backend

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -255,7 +255,18 @@ class AggregationContext(abc.ABC):
 def wrap_for_apply(
     function: Callable, args: Optional[Tuple[Any]], kwargs: Optional[Dict[Any]]
 ) -> Callable:
-    """Wrap a function for use with Pandas `apply`."""
+    """Wrap a function for use with Pandas `apply`.
+
+    Parameters
+    ----------
+    function : Callable
+        A function to be used with Pandas `apply`.
+    args : Optional[Tuple[Any]]
+        args to be passed to function when it is called by Pandas `apply`
+    kwargs : Optional[Dict[Any]]
+        kwargs to be passed to function when it is called by Pandas `apply`
+
+    """
     assert callable(function), f'function {function} is not callable'
 
     @functools.wraps(function)
@@ -290,6 +301,16 @@ def wrap_for_agg(
     the function with logic that checks that a Series is being passed in, and
     raises a TypeError otherwise. When Pandas `agg` is attempting to use
     behavior #1 but sees the TypeError, it will fall back to behavior #2.
+
+    Parameters
+    ----------
+    function : Callable
+        An aggregation function to be used with Pandas `agg`.
+    args : Optional[Tuple[Any]]
+        args to be passed to function when it is called by Pandas `agg`
+    kwargs : Optional[Dict[Any]]
+        kwargs to be passed to function when it is called by Pandas `agg`
+
     """
     assert callable(function), f'function {function} is not callable'
 

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -218,7 +218,7 @@ import abc
 import functools
 import itertools
 import operator
-from typing import Any, Callable, Dict, Iterator, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -252,18 +252,27 @@ class AggregationContext(abc.ABC):
         pass
 
 
-def wrap_for_apply(function, args, kwargs):
+def wrap_for_apply(
+    function: Callable, args: Optional[Tuple[Any]], kwargs: Optional[Dict[Any]]
+) -> Callable:
     """Wrap a function for use with Pandas `apply`."""
-    assert callable(function), 'function {} is not callable'.format(function)
+    assert callable(function), f'function {function} is not callable'
 
     @functools.wraps(function)
-    def wrapped_func(data, function=function, args=args, kwargs=kwargs):
+    def wrapped_func(
+        data: Any,
+        function: Callable = function,
+        args: Optional[Tuple[Any]] = args,
+        kwargs: Optional[Dict[Any]] = kwargs,
+    ) -> Callable:
         return function(data, *args, **kwargs)
 
     return wrapped_func
 
 
-def wrap_for_agg(function, args, kwargs):
+def wrap_for_agg(
+    function: Callable, args: Optional[Tuple[Any]], kwargs: Optional[Dict[Any]]
+) -> Callable:
     """Wrap a function for use with Pandas `agg`.
 
     This includes special logic that will force Pandas `agg` to always treat
@@ -282,10 +291,15 @@ def wrap_for_agg(function, args, kwargs):
     raises a TypeError otherwise. When Pandas `agg` is attempting to use
     behavior #1 but sees the TypeError, it will fall back to behavior #2.
     """
-    assert callable(function), 'function {} is not callable'.format(function)
+    assert callable(function), f'function {function} is not callable'
 
     @functools.wraps(function)
-    def wrapped_func(data, function=function, args=args, kwargs=kwargs):
+    def wrapped_func(
+        data: Any,
+        function: Callable = function,
+        args: Optional[Tuple[Any]] = args,
+        kwargs: Optional[Dict[Any]] = kwargs,
+    ) -> Callable:
         # `data` will be a scalar here if Pandas `agg` is trying to behave like
         # like Pandas `apply`.
         if not isinstance(data, pd.Series):

--- a/ibis/pandas/aggcontext.py
+++ b/ibis/pandas/aggcontext.py
@@ -253,7 +253,9 @@ class AggregationContext(abc.ABC):
 
 
 def wrap_for_apply(
-    function: Callable, args: Optional[Tuple[Any]], kwargs: Optional[Dict[Any]]
+    function: Callable,
+    args: Optional[Tuple[Any]],
+    kwargs: Optional[Dict[Any, Any]],
 ) -> Callable:
     """Wrap a function for use with Pandas `apply`.
 
@@ -263,7 +265,7 @@ def wrap_for_apply(
         A function to be used with Pandas `apply`.
     args : Optional[Tuple[Any]]
         args to be passed to function when it is called by Pandas `apply`
-    kwargs : Optional[Dict[Any]]
+    kwargs : Optional[Dict[Any, Any]]
         kwargs to be passed to function when it is called by Pandas `apply`
 
     """
@@ -274,7 +276,7 @@ def wrap_for_apply(
         data: Any,
         function: Callable = function,
         args: Optional[Tuple[Any]] = args,
-        kwargs: Optional[Dict[Any]] = kwargs,
+        kwargs: Optional[Dict[Any, Any]] = kwargs,
     ) -> Callable:
         return function(data, *args, **kwargs)
 
@@ -282,7 +284,9 @@ def wrap_for_apply(
 
 
 def wrap_for_agg(
-    function: Callable, args: Optional[Tuple[Any]], kwargs: Optional[Dict[Any]]
+    function: Callable,
+    args: Optional[Tuple[Any]],
+    kwargs: Optional[Dict[Any, Any]],
 ) -> Callable:
     """Wrap a function for use with Pandas `agg`.
 
@@ -308,7 +312,7 @@ def wrap_for_agg(
         An aggregation function to be used with Pandas `agg`.
     args : Optional[Tuple[Any]]
         args to be passed to function when it is called by Pandas `agg`
-    kwargs : Optional[Dict[Any]]
+    kwargs : Optional[Dict[Any, Any]]
         kwargs to be passed to function when it is called by Pandas `agg`
 
     """
@@ -319,7 +323,7 @@ def wrap_for_agg(
         data: Any,
         function: Callable = function,
         args: Optional[Tuple[Any]] = args,
-        kwargs: Optional[Dict[Any]] = kwargs,
+        kwargs: Optional[Dict[Any, Any]] = kwargs,
     ) -> Callable:
         # `data` will be a scalar here if Pandas `agg` is trying to behave like
         # like Pandas `apply`.

--- a/ibis/pandas/tests/test_aggcontext.py
+++ b/ibis/pandas/tests/test_aggcontext.py
@@ -2,8 +2,84 @@ import numpy as np
 import pandas as pd
 import pytest
 from pandas.util import testing as tm
+from pytest import param
 
-from ibis.pandas.aggcontext import window_agg_udf
+from ibis.pandas.aggcontext import Summarize, window_agg_udf
+
+df = pd.DataFrame(
+    {
+        'id': [1, 2, 1, 2],
+        'v1': [1.0, 2.0, 3.0, 4.0],
+        'v2': [10.0, 20.0, 30.0, 40.0],
+    }
+)
+
+
+@pytest.mark.parametrize(
+    ('agg_fn', 'expected_fn'),
+    [
+        param(lambda v1: v1.mean(), lambda df: df['v1'].mean(), id='udf',),
+        param('mean', lambda df: df['v1'].mean(), id='string',),
+    ],
+)
+def test_summarize_single_series(agg_fn, expected_fn):
+    """Test Summarize.agg operating on a single Series."""
+
+    aggcontext = Summarize()
+
+    result = aggcontext.agg(df['v1'], agg_fn)
+    expected = expected_fn(df)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ('agg_fn', 'expected_fn'),
+    [
+        param(lambda v1: v1.mean(), lambda df: df['v1'].mean(), id='udf',),
+        param('mean', lambda df: df['v1'].mean(), id='string',),
+    ],
+)
+def test_summarize_single_seriesgroupby(agg_fn, expected_fn):
+    """Test Summarize.agg operating on a single SeriesGroupBy."""
+
+    aggcontext = Summarize()
+
+    df_grouped = df.sort_values('id').groupby('id')
+    result = aggcontext.agg(df_grouped['v1'], agg_fn)
+
+    expected = expected_fn(df_grouped)
+
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ('agg_fn', 'expected_fn'),
+    [
+        param(
+            lambda v1, v2: v1.mean() - v2.mean(),
+            lambda df: df['v1'].mean() - df['v2'].mean(),
+            id='two-column',
+        ),
+        # Two columns, but only the second one is actually used in UDF
+        param(
+            lambda v1, v2: v2.mean(),
+            lambda df: df['v2'].mean(),
+            id='redundant-column',
+        ),
+    ],
+)
+def test_summarize_multiple_series(agg_fn, expected_fn):
+    """Test Summarize.agg operating on many Series."""
+
+    aggcontext = Summarize()
+
+    args = [df['v1'], df['v2']]
+    result = aggcontext.agg(args[0], agg_fn, *args[1:])
+
+    expected = expected_fn(df)
+
+    assert result == expected
 
 
 @pytest.mark.parametrize(
@@ -24,9 +100,7 @@ def test_window_agg_udf(param):
 
     mask, expected = param
 
-    df = pd.DataFrame({'id': [1, 2, 1, 2], 'v': [1.0, 2.0, 3.0, 4.0]})
-
-    grouped_data = df.sort_values('id').groupby("id")['v']
+    grouped_data = df.sort_values('id').groupby('id')['v1']
     result_index = grouped_data.obj.index
 
     window_lower_indices = pd.Series([0, 0, 2, 2])


### PR DESCRIPTION
This PR is to fix a bug with the `Summarize` aggregation context class in the Pandas backend.

## Problem
Currently, `Summarize.agg` makes pretty straightforward use of `pandas.Series.agg` to produce its result.

However, `pandas.Series.agg` seems to have a quirk where if a single function is passed to `pandas.Series.agg`, it will behave exactly like `pandas.Series.apply` (in fact, it will call `pandas.Series.apply`) and produce a `Series` result, unless an exception is caught while doing this, in which case it will treat the function as an aggregation function (and produce a scalar result).

Because of this quirk, `Summarize.agg` will have unexpected results (i.e., will sometimes produce a `Series` rather than a scalar value) simply depending on whether the function passed to `Summarize.agg` happens to not raise an error when passed to `pandas.Series.apply`.


## Solution
Currently (before this PR), `Summarize.agg` would wrap the function passed to it. This PR essentially adds logic in that wrapper function to detect if the function is being passed to `pandas.Series.apply`, and raise a `TypeError` if so (which will force `pandas.Series.agg` to not behave like `pandas.Series.apply`).


## Example
### Code
```
import pandas as pd
import ibis
from ibis.pandas.aggcontext import Summarize

df = pd.DataFrame(
    {
        'id': [1, 2, 1, 2],
        'v1': [1.0, 2.0, 3.0, 4.0],
        'v2': [10.0, 20.0, 30.0, 40.0],
    }
)

aggcontext = Summarize()

# Note that this function takes two columns, but only does a reduction operation on the second column!
# This means that this function can technically be used with Pandas `apply` with no issues.
def some_udf(v1, v2):
    return v2.mean()

args = [df['v1'], df['v2']]

aggcontext.agg(args[0], some_udf, *args[1:])
```

### Output
#### Before
```
0    25.0
1    25.0
2    25.0
3    25.0
Name: v1, dtype: float64
```

#### After
```
25.0
```

## Testing
Created a few tests for `Summarize` in `ibis/pandas/tests/test_aggcontext.py`:
- `test_summarize_single_series`
- `test_summarize_single_seriesgroupby`
- `test_summarize_multiple_series`  <-- one test parameter for this fails before this PR
