### PR TITLE
BUG: add upper-bound to BigQuery dependency

### DIFF
--- a/ci/deps/bigquery.yml
+++ b/ci/deps/bigquery.yml
@@ -1,2 +1,2 @@
-google-cloud-bigquery>=1.12.0
+google-cloud-bigquery>=1.12.0,<2.0.0dev
 pydata-google-auth

--- a/ci/deps/bigquery.yml
+++ b/ci/deps/bigquery.yml
@@ -1,2 +1,2 @@
-google-cloud-bigquery>=1.12.0,<2.0.0dev
+google-cloud-bigquery-core >=1.12.0,<1.24.0dev
 pydata-google-auth

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,10 @@ clickhouse_requires = [
     'clickhouse-driver>=0.1.3',
     'clickhouse-cityhash',
 ]
-bigquery_requires = ['google-cloud-bigquery>=1.12.0', 'pydata-google-auth']
+bigquery_requires = [
+    'google-cloud-bigquery[bqstorage,pandas]>=1.12.0,<2.0.0dev',
+    'pydata-google-auth',
+]
 hdf5_requires = ['tables>=3.0.0']
 
 parquet_requires = ['pyarrow>=0.12.0']


### PR DESCRIPTION
There are breaking changes in `google-cloud-bigquery` 2.0 that aren't
handled yet. Also, 2.0 seems to require a newer version of the protobuf
library than is available in CI.

Closes #2413 