### PR TITLE
CI: Remove import skip in tests/all

### DIFF
--- a/ibis/tests/all/conftest.py
+++ b/ibis/tests/all/conftest.py
@@ -37,7 +37,9 @@ def pytest_runtest_call(item):
             type(backend).__name__
         )
         if not isinstance(backend, backend_types):
-            pytest.skip(f"Only on backends: {backend_types} {nodeid}")
+            pytest.skip(
+                f"Only on backends: {backend} not in {backend_types} {nodeid}"
+            )
 
     for marker in list(item.iter_markers(name="skip_backends")):
         (backend_types,) = map(tuple, marker.args)

--- a/ibis/tests/all/conftest.py
+++ b/ibis/tests/all/conftest.py
@@ -37,7 +37,7 @@ def pytest_runtest_call(item):
             type(backend).__name__
         )
         if not isinstance(backend, backend_types):
-            pytest.skip(nodeid)
+            pytest.skip(f"Only on backends: {backend_types} {nodeid}")
 
     for marker in list(item.iter_markers(name="skip_backends")):
         (backend_types,) = map(tuple, marker.args)
@@ -46,7 +46,7 @@ def pytest_runtest_call(item):
             type(backend).__name__
         )
         if isinstance(backend, backend_types):
-            pytest.skip(nodeid)
+            pytest.skip(f"Skip backends: {backend} {nodeid}")
 
     for marker in list(item.iter_markers(name="skip_missing_feature")):
         backend = item.funcargs["backend"]

--- a/ibis/tests/all/conftest.py
+++ b/ibis/tests/all/conftest.py
@@ -38,7 +38,8 @@ def pytest_runtest_call(item):
         )
         if not isinstance(backend, backend_types):
             pytest.skip(
-                f"Only on backends: {backend} not in {backend_types} {nodeid}"
+                f"only_on_backends: {backend} is not in {backend_types} "
+                f"{nodeid}"
             )
 
     for marker in list(item.iter_markers(name="skip_backends")):
@@ -48,7 +49,7 @@ def pytest_runtest_call(item):
             type(backend).__name__
         )
         if isinstance(backend, backend_types):
-            pytest.skip(f"Skip backends: {backend} {nodeid}")
+            pytest.skip(f"skip_backends: {backend} {nodeid}")
 
     for marker in list(item.iter_markers(name="skip_missing_feature")):
         backend = item.funcargs["backend"]

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -126,11 +126,7 @@ class Backend(abc.ABC):
 
     @property
     def api(self):
-        name = self.name
-        module = getattr(ibis, name, None)
-        if module is None:
-            pytest.skip("Unable to access module ibis.{}".format(name))
-        return module
+        return getattr(ibis, self.name)
 
     def make_context(
         self, params: Optional[Mapping[ir.ValueExpr, Any]] = None


### PR DESCRIPTION
During https://github.com/ibis-project/ibis/pull/2431#issuecomment-702334682 we found that PySpark CI doesn't fail properly. I think this will fix it.