### PR TITLE
TST: Not importing backends globally in the tests

### DIFF
--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -14,8 +14,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 import ibis.sql.compiler as comp
-from ibis.bigquery.tests.conftest import connect as bigquery_connect
-from ibis.impala.tests.conftest import IbisTestEnv as ImpalaEnv
 
 
 class RoundingConvention:
@@ -485,6 +483,7 @@ class BigQuery(UnorderedComparator, Backend, RoundAwayFromZero):
 
     @staticmethod
     def connect(data_directory: Path) -> ibis.client.Client:
+        from ibis.bigquery.tests.conftest import connect
         project_id = os.environ.get('GOOGLE_BIGQUERY_PROJECT_ID')
         if project_id is None:
             pytest.skip(
@@ -495,7 +494,7 @@ class BigQuery(UnorderedComparator, Backend, RoundAwayFromZero):
             pytest.skip(
                 'Environment variable GOOGLE_BIGQUERY_PROJECT_ID is empty'
             )
-        return bigquery_connect(project_id, dataset_id='testing')
+        return connect(project_id, dataset_id='testing')
 
     @property
     def batting(self) -> ir.TableExpr:
@@ -515,7 +514,8 @@ class Impala(UnorderedComparator, Backend, RoundAwayFromZero):
 
     @staticmethod
     def connect(data_directory: Path) -> ibis.client.Client:
-        env = ImpalaEnv()
+        from ibis.impala.tests.conftest import IbisTestEnv
+        env = IbisTestEnv()
         hdfs_client = ibis.hdfs_connect(
             host=env.nn_host,
             port=env.webhdfs_port,

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -484,6 +484,7 @@ class BigQuery(UnorderedComparator, Backend, RoundAwayFromZero):
     @staticmethod
     def connect(data_directory: Path) -> ibis.client.Client:
         from ibis.bigquery.tests.conftest import connect
+
         project_id = os.environ.get('GOOGLE_BIGQUERY_PROJECT_ID')
         if project_id is None:
             pytest.skip(
@@ -515,6 +516,7 @@ class Impala(UnorderedComparator, Backend, RoundAwayFromZero):
     @staticmethod
     def connect(data_directory: Path) -> ibis.client.Client:
         from ibis.impala.tests.conftest import IbisTestEnv
+
         env = IbisTestEnv()
         hdfs_client = ibis.hdfs_connect(
             host=env.nn_host,


### PR DESCRIPTION
Those imports are giving problems when moving in the backends. Not sure why in master they don't cause them, but I think it's a good thing to not import the backends from the core tests.

Eventually I'd like to move these `Backend` testing classes to the backends, and import them lazily for the backends being tested.