### PR TITLE
CI: Enable isort in the CI and fix pending imports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,8 +188,7 @@ jobs:
       if: always()
 
     - name: isort
-      # TODO: isort has errors that need to be fixed before it can be added
-      run: isort --check-only . || true
+      run: isort --check-only .
       if: always()
 
     - name: publish feedstock artifact

--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -143,8 +143,9 @@ def cli(quiet):
 )
 @click.option('-d', '--directory', default=DATA_DIR)
 def download(repo_url, directory):
-    from plumbum.cmd import curl
     from shutil import rmtree
+
+    from plumbum.cmd import curl
 
     directory = Path(directory)
     # download the master branch

--- a/ibis/backends/omniscidb/__init__.py
+++ b/ibis/backends/omniscidb/__init__.py
@@ -5,9 +5,9 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.config as cf
 from ibis.config import options
+
 from .client import OmniSciDBClient  # noqa: F401
 from .compiler import compiles, dialect, rewrites  # noqa: F401
-
 
 __all__ = 'compile', 'verify', 'connect'
 

--- a/ibis/backends/omniscidb/client.py
+++ b/ibis/backends/omniscidb/client.py
@@ -16,11 +16,12 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.client import Database, DatabaseEntity, Query, SQLClient
+from ibis.sql.compiler import DDL, DML
+from ibis.util import log
+
 from . import ddl
 from . import dtypes as omniscidb_dtypes
 from .compiler import OmniSciDBDialect, build_ast
-from ibis.sql.compiler import DDL, DML
-from ibis.util import log
 
 try:
     from cudf import DataFrame as GPUDataFrame

--- a/ibis/backends/omniscidb/ddl.py
+++ b/ibis/backends/omniscidb/ddl.py
@@ -5,9 +5,10 @@ from typing import Any, Dict, Optional, Union
 
 import ibis
 from ibis.common import exceptions as com
+from ibis.sql.compiler import DDL, DML
+
 from . import dtypes as omniscidb_dtypes
 from .compiler import _type_to_sql_string, quote_identifier
-from ibis.sql.compiler import DDL, DML
 
 fully_qualified_re = re.compile(r"(.*)\.(?:`(.*)`|(.*))")
 

--- a/ibis/backends/omniscidb/operations.py
+++ b/ibis/backends/omniscidb/operations.py
@@ -14,6 +14,7 @@ import ibis.expr.types as ir
 import ibis.util as util
 from ibis import literal as L
 from ibis.impala import compiler as impala_compiler
+
 from . import dtypes as omniscidb_dtypes
 from .identifiers import quote_identifier
 

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -7,21 +7,21 @@ import toolz
 # pandas compat
 try:
     from pandas.api.types import (  # noqa: F401
-        DatetimeTZDtype,
         CategoricalDtype,
+        DatetimeTZDtype,
         infer_dtype,
     )
 except ImportError:
     from pandas.types.dtypes import (  # noqa: F401
-        DatetimeTZDtype,
         CategoricalDtype,
+        DatetimeTZDtype,
         infer_dtype,
     )
 
 try:
-    from pandas.core.tools.datetimes import to_time, to_datetime  # noqa: F401
+    from pandas.core.tools.datetimes import to_datetime, to_time  # noqa: F401
 except ImportError:
-    from pandas.tseries.tools import to_time, to_datetime  # noqa: F401
+    from pandas.tseries.tools import to_datetime, to_time  # noqa: F401
 
 
 to_date = toolz.compose(operator.methodcaller('date'), to_datetime)

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -420,8 +420,8 @@ def register_option(key, defval, doc='', validator=None, cb=None):
     ------
     ValueError if `validator` is specified and `defval` is not a valid value.
     """
-    import tokenize
     import keyword
+    import tokenize
 
     key = key.lower()
 
@@ -710,8 +710,8 @@ def pp_options_list(keys: str, width: int = 80, _print: bool = False) -> str:
     -------
     string
     """
-    from textwrap import wrap
     from itertools import groupby
+    from textwrap import wrap
 
     def pp(name, ks):
         pfx = '- ' + name + '.[' if name else ''

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1027,8 +1027,8 @@ class WindowOp(ValueOp):
     display_argnames = False
 
     def __init__(self, expr, window):
-        from ibis.expr.window import propagate_down_window
         from ibis.expr.analysis import is_analytic
+        from ibis.expr.window import propagate_down_window
 
         if not is_analytic(expr):
             raise com.IbisInputError(
@@ -2158,8 +2158,7 @@ class Aggregation(TableNode, HasSchema):
         )
 
     def _validate(self):
-        from ibis.expr.analysis import is_reduction
-        from ibis.expr.analysis import FilterValidator
+        from ibis.expr.analysis import FilterValidator, is_reduction
 
         # All aggregates are valid
         for expr in self.metrics:

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -11,9 +11,9 @@ import ibis.expr.types as ir
 import ibis.util as util
 
 try:
-    from cytoolz import curry, compose, identity
+    from cytoolz import compose, curry, identity
 except ImportError:
-    from toolz import curry, compose, identity
+    from toolz import compose, curry, identity
 
 
 def highest_precedence_dtype(exprs):

--- a/ibis/file/tests/conftest.py
+++ b/ibis/file/tests/conftest.py
@@ -73,6 +73,7 @@ def hdf(tmpdir, data):
 def parquet(tmpdir, data):
     pa = pytest.importorskip('pyarrow')
     import pyarrow.parquet as pq  # noqa: E402
+
     from ibis.file.parquet import ParquetClient
 
     # create single files

--- a/ibis/filesystems.py
+++ b/ibis/filesystems.py
@@ -15,9 +15,8 @@
 # This file may adapt small portions of https://github.com/mtth/hdfs (MIT
 # license), see the LICENSES directory.
 
-from functools import wraps as implements
-
 import posixpath
+from functools import wraps as implements
 
 import ibis.common.exceptions as com
 from ibis.config import options

--- a/ibis/impala/client.py
+++ b/ibis/impala/client.py
@@ -6,11 +6,11 @@ import time
 import traceback
 import weakref
 from collections import deque
+from posixpath import join as pjoin
 
 import numpy as np
 import pandas as pd
 from pkg_resources import parse_version
-from posixpath import join as pjoin
 
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt

--- a/ibis/impala/tests/test_ddl.py
+++ b/ibis/impala/tests/test_ddl.py
@@ -1,5 +1,6 @@
-import pytest
 from posixpath import join as pjoin
+
+import pytest
 
 import ibis
 import ibis.common.exceptions as com

--- a/ibis/impala/tests/test_exprs.py
+++ b/ibis/impala/tests/test_exprs.py
@@ -12,12 +12,12 @@ import ibis.expr.types as ir
 from ibis import literal as L
 from ibis.common.exceptions import RelationError
 from ibis.expr.datatypes import Category
-from ibis.tests.expr.mocks import MockConnection
 from ibis.impala.compiler import (  # noqa: E402
     ImpalaDialect,
     ImpalaExprTranslator,
     to_sql,
 )
+from ibis.tests.expr.mocks import MockConnection
 from ibis.tests.sql.test_compiler import ExprTestCases  # noqa: E402
 
 pytest.importorskip('hdfs')

--- a/ibis/impala/tests/test_parquet_ddl.py
+++ b/ibis/impala/tests/test_parquet_ddl.py
@@ -1,5 +1,6 @@
-import pytest
 from posixpath import join as pjoin
+
+import pytest
 
 import ibis
 from ibis.tests.util import assert_equal

--- a/ibis/impala/tests/test_partition.py
+++ b/ibis/impala/tests/test_partition.py
@@ -1,7 +1,8 @@
+from posixpath import join as pjoin
+
 import pandas as pd
 import pytest
 from pandas.util.testing import assert_frame_equal
-from posixpath import join as pjoin
 
 import ibis
 import ibis.util as util

--- a/ibis/impala/tests/test_udf.py
+++ b/ibis/impala/tests/test_udf.py
@@ -1,10 +1,10 @@
 import unittest
 from decimal import Decimal
+from posixpath import join as pjoin
 
 import numpy as np
 import pandas as pd
 import pytest
-from posixpath import join as pjoin
 
 import ibis
 import ibis.common.exceptions as com
@@ -14,8 +14,8 @@ import ibis.expr.types as ir
 import ibis.impala as api  # noqa: E402
 import ibis.util as util
 from ibis.common.exceptions import IbisTypeError
-from ibis.tests.expr.mocks import MockConnection
 from ibis.impala import ddl  # noqa: E402
+from ibis.tests.expr.mocks import MockConnection
 
 pytest.importorskip('hdfs')
 pytest.importorskip('sqlalchemy')

--- a/ibis/pyspark/tests/conftest.py
+++ b/ibis/pyspark/tests/conftest.py
@@ -8,8 +8,8 @@ import ibis
 
 @pytest.fixture(scope='session')
 def client():
-    from pyspark.sql import SparkSession
     import pyspark.sql.functions as F
+    from pyspark.sql import SparkSession
 
     session = SparkSession.builder.getOrCreate()
     client = ibis.pyspark.connect(session)

--- a/ibis/spark/tests/test_ddl.py
+++ b/ibis/spark/tests/test_ddl.py
@@ -1,7 +1,7 @@
 import os
+from posixpath import join as pjoin
 
 import pytest
-from posixpath import join as pjoin
 
 import ibis
 import ibis.common.exceptions as com

--- a/ibis/sql/mysql/client.py
+++ b/ibis/sql/mysql/client.py
@@ -2,15 +2,13 @@ import contextlib
 import getpass
 import warnings
 
+import pymysql  # NOQA fail early if the driver is missing
 import sqlalchemy as sa
 import sqlalchemy.dialects.mysql as mysql
 
 import ibis.expr.datatypes as dt
 import ibis.sql.alchemy as alch
 from ibis.sql.mysql.compiler import MySQLDialect
-
-import pymysql  # NOQA fail early if the driver is missing
-
 
 # TODO(kszucs): unsigned integers
 

--- a/ibis/sql/postgres/client.py
+++ b/ibis/sql/postgres/client.py
@@ -2,13 +2,12 @@ import contextlib
 import getpass
 from typing import Optional
 
+import psycopg2  # NOQA fail early if the driver is missing
 import sqlalchemy as sa
 
 import ibis.sql.alchemy as alch
 from ibis.sql.postgres import udf
 from ibis.sql.postgres.compiler import PostgreSQLDialect
-
-import psycopg2  # NOQA fail early if the driver is missing
 
 
 class PostgreSQLTable(alch.AlchemyTable):

--- a/ibis/tests/all/test_column.py
+++ b/ibis/tests/all/test_column.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-
 ROWID_ZERO_INDEXED_BACKENDS = ('omniscidb',)
 
 

--- a/ibis/tests/expr/test_visualize.py
+++ b/ibis/tests/expr/test_visualize.py
@@ -13,7 +13,6 @@ pytest.importorskip('graphviz')
 import ibis.expr.visualize as viz  # noqa: E402, isort:skip
 import ibis.expr.api as api  # noqa; E402
 
-
 pytestmark = pytest.mark.skipif(
     int(os.environ.get('CONDA_BUILD', 0)) == 1, reason='CONDA_BUILD defined'
 )

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -7,8 +7,8 @@ import ibis
 import ibis.expr.api as api
 import ibis.expr.operations as ops
 from ibis import impala  # noqa: E402
-from ibis.tests.expr.mocks import MockConnection
 from ibis.impala.compiler import ImpalaDialect, build_ast, to_sql  # noqa: E402
+from ibis.tests.expr.mocks import MockConnection
 
 pytest.importorskip('sqlalchemy')
 pytest.importorskip('impala.dbapi')

--- a/ibis/tests/test_filesystems.py
+++ b/ibis/tests/test_filesystems.py
@@ -3,9 +3,9 @@ import shutil
 import unittest
 from io import BytesIO
 from os import path as osp
+from posixpath import join as pjoin
 
 import pytest
-from posixpath import join as pjoin
 
 import ibis
 import ibis.util as util


### PR DESCRIPTION
We're supposed to be using isort, but it wasn't validated in the CI. Several PRs lately had some unrelated imports resorted, if the contributor run isort manually in some files that don't pass isort.

Running isort in all files, and enabling it in the CI, so we stop having those unrelated changes in PRs.