### PR TITLE
CI: Fix isort after clickhouse refactoring

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -1,7 +1,8 @@
 import ibis.common.exceptions as com
+from ibis.config import options
+
 from .client import ClickhouseClient
 from .compiler import dialect
-from ibis.config import options
 
 __all__ = 'compile', 'verify', 'connect', 'dialect'
 

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -11,11 +11,12 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
-from .compiler import ClickhouseDialect, build_ast
 from ibis.client import Database, DatabaseEntity, Query, SQLClient
 from ibis.config import options
 from ibis.sql.compiler import DDL
 from ibis.util import log
+
+from .compiler import ClickhouseDialect, build_ast
 
 fully_qualified_re = re.compile(r"(.*)\.(?:`(.*)`|(.*))")
 base_typename_re = re.compile(r"(\w+)")

--- a/ibis/backends/clickhouse/operations.py
+++ b/ibis/backends/clickhouse/operations.py
@@ -6,6 +6,7 @@ import ibis.expr.operations as ops
 import ibis.expr.types as ir
 import ibis.sql.transforms as transforms
 import ibis.util as util
+
 from .identifiers import quote_identifier
 
 


### PR DESCRIPTION
We merge #2450 and #2437 together, and we've got the isort validation, but some incorrectly sorted imports in clickhouse (CI is red). Fixing it here.

Sorry for the mess with the isort PR, really bad timing for it.