### PR TITLE
DOC: Added autosummary of ClickHouse API

### DIFF
--- a/docs/source/backends/clickhouse.rst
+++ b/docs/source/backends/clickhouse.rst
@@ -16,3 +16,25 @@ Create a client by passing in database connection parameters such as ``host``,
 .. code-block:: python
 
    con = ibis.clickhouse.connect(host='clickhouse', port=9000)
+
+.. _api.clickhouse:
+
+API
+===
+.. currentmodule:: ibis.backends.clickhouse
+
+The ClickHouse client is accessible through the ``ibis.clickhouse`` namespace.
+
+Use ``ibis.clickhouse.connect`` to create a client.
+
+.. autosummary::
+   :toctree: ../generated/
+
+   connect
+   ClickhouseClient.close
+   ClickhouseClient.exists_table
+   ClickhouseClient.exists_database
+   ClickhouseClient.get_schema
+   ClickhouseClient.set_database
+   ClickhouseClient.list_databases
+   ClickhouseClient.list_tables


### PR DESCRIPTION
As discussed with @datapythonista in https://github.com/ibis-project/ibis/pull/2437#issuecomment-702856451, I am adding in the docs the autosummary for the ClickHouse API that was missing.

I have tried to keep it consistent with the rest of the backends, and I have added for now only the client methods with docstrings. Should I add others?

Unfortunately I was not able to generate the docs locally to check if it looks ok visually, which command should I use to build the documentation?

Please let me know if there is anything else I should improve, thank you very much!