### PR TITLE
ENH: Avoid top-level circular imports in ibis/expr/types.py

### DIFF
--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -1,7 +1,7 @@
 import itertools
 import os
 import webbrowser
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
@@ -9,8 +9,10 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.config as config
 import ibis.util as util
-from ibis.expr.format import FormatMemo
 from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.format import FormatMemo
 
 # TODO move methods containing ops import to api.py
 
@@ -26,6 +28,8 @@ class Expr:
         self._arg = arg
 
     def __repr__(self):
+        from ibis.expr.format import FormatMemo
+
         if not config.options.interactive:
             return self._repr(memo=FormatMemo(get_text_repr=True))
 
@@ -51,7 +55,7 @@ class Expr:
 
     __nonzero__ = __bool__
 
-    def _repr(self, memo: Optional[FormatMemo] = None):
+    def _repr(self, memo: 'Optional[FormatMemo]' = None):
         from ibis.expr.format import ExprFormatter
 
         return ExprFormatter(self, memo=memo).get_result()


### PR DESCRIPTION
### The circular imports
- [`ibis.expr.types`](https://github.com/ibis-project/ibis/blob/master/ibis/expr/types.py#L12) imports `ibis.expr.format`, then
- [`ibis.expr.format`](https://github.com/ibis-project/ibis/blob/master/ibis/expr/format.py#L4) imports `ibis.expr.types` and `ibis.expr.operations` (this forms two circular imports, see diagram below)

In the context of Ibis these circular imports are not a problem (works fine and causes no issues/bugs/errors). I'll explain more below.

```
                            +--------------------+
          +---->----------->|ibis.expr.operations|
          |                 +---------+----------+
          |                           |
          |                           |
         /|\                         \|/
          |                 +--------------------+
          |                 |ibis.expr.datatypes |
          |                 +---------+----------+
          |                           |
          |                           |
          |                          \|/
          |                 +--------------------+
          +---->----------->|ibis.expr.types     |
          |                 +---------+----------+
         /|\                          |
          |                           |   (This edge was added in #2284)
          |                          \|/
+---------+----------+                |
|ibis.expr.format    |<----------<----+
+--------------------+
```

### This PR
In this PR, I am changing `ibis/expr/types.py` to use **deferred** and **conditional** import statements for importing `ibis.expr.format`, rather than a **top-level** import statement. (See diff.)

### Why this PR?
I think whether to accept this PR or not just depends on **stylistic preference** in Ibis. Should top-level circular imports be avoided by using deferred imports (`import` in the function where its needed) and conditional imports (`if TYPE_CHECKING: import ...`)?

I notice that deferred importing is already being used in [ibis/expr/types.py#L55](https://github.com/ibis-project/ibis/blob/master/ibis/expr/types.py#L55) (however, this might have been out of necessity). Avoiding top-level circular imports seems slightly safer for development (prevents possible circular import problems as changes are being made to `ibis/expr/types.py` or `ibis/expr/format.py`).

For context (why so much effort into a stylistic change PR?): my ulterior motive for making this PR is that (as an Ibis user) we have usages of Ibis with Python 3.**6**, and `import ibis` fails now. Again, the circular imports themselves are fine—but Python 3.6 has [a niche bug with _**named** absolute circular imports_](https://stackoverflow.com/questions/49051706/whats-new-in-python-3-7-about-circular-imports), which we happen to have here. This PR would conveniently make Ibis avoid this Python 3.6 bug.

But Ibis no longer supports Python 3.6 (Python 3.6 support was dropped in #2329), and this bug was [fixed in Python 3.7](https://stackoverflow.com/questions/49051706/whats-new-in-python-3-7-about-circular-imports). So I think we shouldn't consider Python 3.6 compatibility as a justification for this PR. If not this PR, this can be handled on the user side.