### PR TITLE
DEPS: Remove old pandas compatibility functionality

### DIFF
--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -6,19 +6,6 @@ import toolz
 
 # pandas compat
 try:
-    from pandas.api.types import (  # noqa: F401
-        CategoricalDtype,
-        DatetimeTZDtype,
-        infer_dtype,
-    )
-except ImportError:
-    from pandas.types.dtypes import (  # noqa: F401
-        CategoricalDtype,
-        DatetimeTZDtype,
-        infer_dtype,
-    )
-
-try:
     from pandas.core.tools.datetimes import to_datetime, to_time  # noqa: F401
 except ImportError:
     from pandas.tseries.tools import to_datetime, to_time  # noqa: F401

--- a/ibis/compat.py
+++ b/ibis/compat.py
@@ -1,16 +1,4 @@
 """Module for compatible functions."""
-import operator
 import sys
-
-import toolz
-
-# pandas compat
-try:
-    from pandas.core.tools.datetimes import to_datetime, to_time  # noqa: F401
-except ImportError:
-    from pandas.tseries.tools import to_datetime, to_time  # noqa: F401
-
-
-to_date = toolz.compose(operator.methodcaller('date'), to_datetime)
 
 PY38 = sys.version_info >= (3, 8, 0)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -10,6 +10,7 @@ from typing import Union
 import dateutil.parser
 import pandas as pd
 import toolz
+from pandas.core.tools.datetimes import to_datetime, to_time
 
 import ibis
 import ibis.common.exceptions as com
@@ -21,7 +22,6 @@ import ibis.expr.rules as rlz
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 import ibis.util as util
-from ibis.compat import to_date, to_time
 from ibis.expr.analytics import bucket, histogram
 from ibis.expr.groupby import GroupedTableExpr  # noqa
 from ibis.expr.random import random  # noqa
@@ -332,7 +332,7 @@ def date(value):
     result : TimeScalar
     """
     if isinstance(value, str):
-        value = to_date(value)
+        value = to_datetime(value).date()
     return literal(value, type=dt.date)
 
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -10,7 +10,6 @@ from typing import Union
 import dateutil.parser
 import pandas as pd
 import toolz
-from pandas.core.tools.datetimes import to_datetime, to_time
 
 import ibis
 import ibis.common.exceptions as com
@@ -332,7 +331,7 @@ def date(value):
     result : TimeScalar
     """
     if isinstance(value, str):
-        value = to_datetime(value).date()
+        value = pd.to_datetime(value).date()
     return literal(value, type=dt.date)
 
 
@@ -349,7 +348,7 @@ def time(value):
     result : TimeScalar
     """
     if isinstance(value, str):
-        value = to_time(value)
+        value = pd.to_datetime(value).time()
     return literal(value, type=dt.time)
 
 

--- a/ibis/pandas/client.py
+++ b/ibis/pandas/client.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytz
 import toolz
 from multipledispatch import Dispatcher
+from pandas.api.types import CategoricalDtype, DatetimeTZDtype
 from pkg_resources import parse_version
 
 import ibis.client as client
@@ -19,7 +20,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
-from ibis.compat import CategoricalDtype, DatetimeTZDtype
 from ibis.pandas.core import execute_and_reset
 
 try:

--- a/ibis/pandas/client.py
+++ b/ibis/pandas/client.py
@@ -22,10 +22,7 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.pandas.core import execute_and_reset
 
-try:
-    infer_pandas_dtype = pd.api.types.infer_dtype
-except AttributeError:
-    infer_pandas_dtype = pd.lib.infer_dtype
+infer_pandas_dtype = pd.api.types.infer_dtype
 
 
 _ibis_dtypes = toolz.valmap(

--- a/ibis/pandas/execution/generic.py
+++ b/ibis/pandas/execution/generic.py
@@ -13,6 +13,7 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 import toolz
+from pandas.api.types import DatetimeTZDtype
 from pandas.core.groupby import DataFrameGroupBy, SeriesGroupBy
 
 import ibis
@@ -21,7 +22,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 import ibis.pandas.aggcontext as agg_ctx
-from ibis.compat import DatetimeTZDtype
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import TIME_COL
 from ibis.expr.typing import TimeContext

--- a/ibis/pandas/tests/test_datatypes.py
+++ b/ibis/pandas/tests/test_datatypes.py
@@ -2,12 +2,12 @@ import numpy as np
 import pandas as pd
 import pytest
 from multipledispatch.conflict import ambiguities
+from pandas.api.types import CategoricalDtype, DatetimeTZDtype
 
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
-from ibis.compat import CategoricalDtype, DatetimeTZDtype
 
 
 def test_no_infer_ambiguities():


### PR DESCRIPTION
closes #2454

I have removed the pandas imports from `compat.py` and made explicit imports from pandas in the scripts that were using compat.

The only variable that remains in compat is `PY38`, probably it should be moved somewhere else. What do you think?

Please let me know if I can improve this.

Thanks