### PR TITLE
CLN: Removing unused test directory in call

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -8,9 +8,6 @@ for BACKEND in $PYTEST_BACKENDS; do
     if [[ -d ibis/$BACKEND/tests ]]; then
         TESTS_DIRS="$TESTS_DIRS ibis/$BACKEND/tests"
     fi
-    if [[ -d ibis/sql/$BACKEND/tests ]]; then
-        TESTS_DIRS="$TESTS_DIRS ibis/sql/$BACKEND/tests"
-    fi
 done
 
 echo "TESTS_DIRS: $TESTS_DIRS"


### PR DESCRIPTION
We do not have backends in `ibis/sql` anymore, so looking for tests there is not needed.