### PR TITLE
FEAT: Add destructure support for analtyic and reduction UDF

### DIFF
--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -358,7 +358,14 @@ class Transform(AggregationContext):
     __slots__ = ()
 
     def agg(self, grouped_data, function, *args, **kwargs):
-        return grouped_data.transform(function, *args, **kwargs)
+        # If function is a built-in function, e.g., 'mean'
+        # then we call transform because apply cannot take in str
+        # If function is a UDF, then we call apply because transform
+        # cannot take UDF that returns struct, but apply can
+        if isinstance(function, str):
+            return grouped_data.transform(function, *args, **kwargs)
+        else:
+            return grouped_data.apply(function, *args, **kwargs)
 
 
 @functools.singledispatch

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -440,7 +440,6 @@ def execute_aggregation_dataframe(
         )
 
         if isinstance(metric, ir.DestructValue):
-            # Destruct series of tuples to multiple series
             result = coerce_to_dataframe(result, metric.type().names)
             pieces.append(result)
         else:

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -437,7 +437,6 @@ def execute_aggregation_dataframe(
         coerce_to_output(
             execute(metric, scope=scope, timecontext=timecontext, **kwargs),
             metric,
-            index=None,
         )
         for metric in op.metrics
     ]

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -18,6 +18,7 @@ import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.expr.scope import Scope
 from ibis.expr.typing import TimeContext
+from ibis.util import coerce_to_dataframe
 
 from ..core import execute
 from ..dispatch import execute_node
@@ -146,8 +147,7 @@ def compute_projection_column_expr(
             name=result_name,
         )
     elif isinstance(expr, ir.DestructColumn):
-        result.columns = expr.type().names
-        return result
+        return coerce_to_dataframe(result, expr.type().names)
     else:
         return result.rename(result_name)
 

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -1,5 +1,5 @@
 import operator
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -63,8 +63,27 @@ def compute_sorted_frame(
 
 
 def coerce_to_output(
-    result: Any, expr: ir.Expr, index: pd.Index
+    result: Any, expr: ir.Expr, index: Optional[pd.Index] = None
 ) -> Union[pd.Series, pd.DataFrame]:
+    """ Cast the result to either a Series or DataFrame.
+
+    This method casts result of an execution to a Series or DataFrame,
+    depending on the type of the expression and shape of the result.
+
+    Parameters
+    ----------
+    result: Any
+        The result to cast
+    expr: ibis.expr.types.Expr
+        The expression associated with the result
+    index: pd.Index
+        Optional. If passed, scalar results will be broadcasted according
+        to the index.
+
+    Returns
+    -------
+    result: A Series or DataFrame
+    """
     result_name = getattr(expr, '_name', None)
 
     if isinstance(expr, (ir.DestructColumn, ir.StructColumn)):

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -56,13 +56,13 @@ class CustomWindow(ibis.expr.window.Window):
 
 class CustomAggContext(AggregationContext):
     def __init__(
-        self, parent, group_by, order_by, dtype, max_lookback, preceding
+        self, parent, group_by, order_by, output_type, max_lookback, preceding
     ):
         super().__init__(
             parent=parent,
             group_by=group_by,
             order_by=order_by,
-            dtype=dtype,
+            output_type=output_type,
             max_lookback=max_lookback,
         )
         self.preceding = preceding
@@ -696,7 +696,6 @@ def test_custom_window_udf(t, custom_window):
         *,
         scope,
         operand,
-        operand_dtype,
         parent,
         group_by,
         order_by,
@@ -708,7 +707,7 @@ def test_custom_window_udf(t, custom_window):
             parent=parent,
             group_by=group_by,
             order_by=order_by,
-            dtype=operand_dtype,
+            output_type=operand.type(),
             max_lookback=window.max_lookback,
             preceding=window.preceding,
         )

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -21,6 +21,7 @@ from ibis.backends.spark.datatypes import (
     spark_dtype,
 )
 from ibis.expr.timecontext import adjust_context
+from ibis.util import coerce_to_dataframe
 
 from .operations import PySparkTable
 from .timecontext import combine_time_context, filter_by_time_context
@@ -1651,8 +1652,7 @@ def _wrap_struct_func(func, output_cols):
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         result = func(*args, **kwargs)
-        result.columns = output_cols
-        return result
+        return coerce_to_dataframe(result, output_cols)
 
     return wrapped
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -43,6 +43,7 @@ from ibis.expr.types import (  # noqa
     DecimalValue,
     DestructColumn,
     DestructScalar,
+    DestructValue,
     Expr,
     FloatingColumn,
     FloatingScalar,
@@ -3268,6 +3269,10 @@ def _destructure(expr: StructColumn) -> DestructColumn:
         return DestructScalar(expr._arg, expr._dtype).name("")
     elif isinstance(expr, StructColumn):
         return DestructColumn(expr._arg, expr._dtype).name("")
+    elif isinstance(expr, StructValue):
+        return DestructValue(expr._arg, expr._dtype).name("")
+    else:
+        raise AssertionError()
 
 
 _struct_value_methods = dict(

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -42,6 +42,7 @@ from ibis.expr.types import (  # noqa
     DecimalScalar,
     DecimalValue,
     DestructColumn,
+    DestructScalar,
     Expr,
     FloatingColumn,
     FloatingScalar,
@@ -3263,16 +3264,19 @@ def _destructure(expr: StructColumn) -> DestructColumn:
     """
     # Set name to empty string here so that we can detect and error when
     # user set name for a destruct column.
-    return DestructColumn(expr._arg, expr._dtype).name("")
+    if isinstance(expr, StructScalar):
+        return DestructScalar(expr._arg, expr._dtype).name("")
+    elif isinstance(expr, StructColumn):
+        return DestructColumn(expr._arg, expr._dtype).name("")
 
 
-_struct_column_methods = dict(
+_struct_value_methods = dict(
     destructure=_destructure,
     __getattr__=_struct_get_field,
     __getitem__=_struct_get_field,
 )
 
-_add_methods(ir.StructValue, _struct_column_methods)
+_add_methods(ir.StructValue, _struct_value_methods)
 
 
 # ---------------------------------------------------------------------

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2220,10 +2220,15 @@ class Aggregation(TableNode, HasSchema):
         names = []
         types = []
 
-        # All exprs must be named
         for e in self.by + self.metrics:
-            names.append(e.get_name())
-            types.append(e.type())
+            if isinstance(e, ir.DestructValue):
+                struct_type = e.type()
+                for name in struct_type.names:
+                    names.append(name)
+                    types.append(struct_type[name])
+            else:
+                names.append(e.get_name())
+                types.append(e.type())
 
         return Schema(names, types)
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1967,6 +1967,8 @@ class Selection(TableNode, HasSchema):
 
         for projection in self.selections:
             if isinstance(projection, ir.DestructColumn):
+                # If this is a destruct, then we destructure
+                # the result and assign to multiple columns
                 struct_type = projection.type()
                 for name in struct_type.names:
                     names.append(name)

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2224,6 +2224,8 @@ class Aggregation(TableNode, HasSchema):
 
         for e in self.by + self.metrics:
             if isinstance(e, ir.DestructValue):
+                # If this is a destruct, then we destructure
+                # the result and assign to multiple columns
                 struct_type = e.type()
                 for name in struct_type.names:
                     names.append(name)

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -863,12 +863,20 @@ class StructColumn(AnyColumn, StructValue):
     pass  # noqa: E701,E302
 
 
-class DestructColumn(AnyColumn):
-    """ Class that represents a destruct column.
+class DestructValue(AnyValue):
+    """ Class that represents a destruct value.
 
     When assigning a destruct column, the field inside this destruct column
     will be destructured and assigned to multipe columnns.
     """
+
+
+class DestructScalar(AnyScalar, DestructValue):
+    pass
+
+
+class DestructColumn(AnyColumn, DestructValue):
+    pass
 
 
 class IntervalValue(AnyValue):

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -1,8 +1,9 @@
-import pandas as pd
 import pytest
 
+import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
+from ibis.expr.window import window
 from ibis.tests.backends import Pandas, PySpark
 from ibis.udf.vectorized import analytic, elementwise, reduction
 
@@ -29,7 +30,23 @@ def calc_mean(s):
     output_type=dt.Struct(['col1', 'col2'], [dt.double, dt.double]),
 )
 def add_one_struct(v):
-    return pd.concat([v + 1, v + 2], axis=1)
+    return v + 1, v + 2
+
+
+@analytic(
+    input_type=[dt.double, dt.double],
+    output_type=dt.Struct(['demean', 'demean_weight'], [dt.double, dt.double]),
+)
+def demean_struct(v, w):
+    return v - v.mean(), w - w.mean()
+
+
+@reduction(
+    input_type=[dt.double, dt.double],
+    output_type=dt.Struct(['mean', 'mean_weight'], [dt.double, dt.double]),
+)
+def mean_struct(v, w):
+    return v.mean(), w.mean()
 
 
 @pytest.mark.only_on_backends([Pandas, PySpark])
@@ -244,7 +261,6 @@ def test_elementwise_udf_named_destruct(backend, alltypes):
 
 
 @pytest.mark.only_on_backends([PySpark])
-@pytest.mark.xfail_unsupported
 def test_elementwise_udf_struct(backend, alltypes):
     result = alltypes.mutate(
         new_col=add_one_struct(alltypes['double_col'])
@@ -256,6 +272,71 @@ def test_elementwise_udf_struct(backend, alltypes):
     result = result.drop('new_col', axis=1)
     expected = alltypes.mutate(
         col1=alltypes['double_col'] + 1, col2=alltypes['double_col'] + 2,
+    ).execute()
+
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.only_on_backends([Pandas])
+def test_analytic_udf_destruct(backend, alltypes):
+    w = window(preceding=None, following=None, group_by='year')
+
+    result = alltypes.mutate(
+        demean_struct(alltypes['double_col'], alltypes['int_col'])
+        .over(w)
+        .destructure()
+    ).execute()
+
+    expected = alltypes.mutate(
+        demean=alltypes['double_col'] - alltypes['double_col'].mean().over(w),
+        demean_weight=alltypes['int_col'] - alltypes['int_col'].mean().over(w),
+    ).execute()
+
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.only_on_backends([Pandas])
+def test_reduction_udf_destruct_groupby(backend, alltypes):
+    result = (
+        alltypes.groupby('year')
+        .aggregate(
+            mean_struct(
+                alltypes['double_col'], alltypes['int_col']
+            ).destructure()
+        )
+        .execute()
+    )
+
+    expected = (
+        alltypes.groupby('year')
+        .aggregate(
+            mean=alltypes['double_col'].mean(),
+            mean_weight=alltypes['int_col'].mean(),
+        )
+        .execute()
+    )
+
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.only_on_backends([Pandas])
+def test_reduction_udf_destruct_window(backend, alltypes):
+    win = window(
+        preceding=ibis.interval(hours=2),
+        following=0,
+        group_by='year',
+        order_by='timestamp_col',
+    )
+
+    result = alltypes.mutate(
+        mean_struct(alltypes['double_col'], alltypes['int_col'])
+        .over(win)
+        .destructure()
+    ).execute()
+
+    expected = alltypes.mutate(
+        mean=alltypes['double_col'].mean().over(win),
+        mean_weight=alltypes['int_col'].mean().over(win),
     ).execute()
 
     backend.assert_frame_equal(result, expected)

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -261,6 +261,7 @@ def test_elementwise_udf_named_destruct(backend, alltypes):
 
 
 @pytest.mark.only_on_backends([PySpark])
+@pytest.mark.xfail_unsupported
 def test_elementwise_udf_struct(backend, alltypes):
     result = alltypes.mutate(
         new_col=add_one_struct(alltypes['double_col'])

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Mapping, Optional
 
 import numpy as np
 import pandas as pd
-import pandas.util.testing as tm
+import pandas.testing as tm
 import pytest
 from pkg_resources import parse_version
 

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -165,6 +165,7 @@ def reduction(input_type, output_type):
     ...     return (series.str.len() * 2).sum()
 
     Define and use an UDF with multiple return columns:
+
     >>> @reduction(
     ...     input_type=[dt.double],
     ...     output_type=dt.Struct(['mean', 'std'], [dt.double, dt.double])

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -76,6 +76,8 @@ all_of = toolz.compose(all, is_one_of)
 
 def coerce_to_dataframe(data: Any, names: List[str]) -> pd.DataFrame:
     """Coerce the following shapes to a DataFrame.
+
+    The following shapes are allowed:
     (1) A list/tuple of Series
     (2) A Series of list/tuple
 

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -80,6 +80,11 @@ def coerce_to_dataframe(data: Any, names: List[str]) -> pd.DataFrame:
     The following shapes are allowed:
     (1) A list/tuple of Series
     (2) A Series of list/tuple
+    (3) pd.DataFrame
+
+    Note:
+    This method does NOT always return a new DataFrame. If a DataFrame is
+    passed in, this method will return the original object.
 
     Parameters
     ----------


### PR DESCRIPTION
What is this change
===============
This PR is a follow up of #2473. In this PR, I added the support for `destructure` for analytics and reduction UDFs:

- Support for groupby aggregation UDF
- Support for window analytic UDF (unbounded window)
- Support for window aggregation UDF (moving window)

Example:
- groupby aggregation UDF
```
    Define and use an UDF with multiple return columns:                                                                                                                                                     
                                                                                                                                                                                                            
    >>> @reduction(                                                                                                                                                                                         
    ...     input_type=[dt.double],                                                                                                                                                                         
    ...     output_type=dt.Struct(['mean', 'std'], [dt.double, dt.double])                                                                                                                                  
    ... )                                                                                                                                                                                                   
    ... def mean_and_std(v):                                                                                                                                                                                
    ...     return v.mean(), v.std()                                                                                                                                                                        
    >>>                                                                                                                                                                                                     
    >>> # create aggregation columns "mean" and "std"                                                                                                                                                       
    >>> table = table.groupby('key').aggregate(                                                                                                                                                             
    ...     mean_and_std(table['v']).destructure()                                                                                                                                                          
    ... )
```

- window analytic UDF
```
    >>> @analytic(                                                                                                                                                                                          
    ...     input_type=[dt.double],                                                                                                                                                                         
    ...     output_type=dt.Struct(['demean', 'zscore'], [dt.double, dt.double])                                                                                                                             
    ... )                                                                                                                                                                                                   
    ... def demean_and_zscore(v):                                                                                                                                                                           
    ...     mean = v.mean()                                                                                                                                                                                 
    ...     std = v.std()                                                                                                                                                                                   
    ...     return v - mean, (v - mean) / std                                                                                                                                                               
    >>>                                                                                                                                                                                                     
    >>> win = ibis.window(preceding=None, following=None, group_by='key')                                                                                                                                   
    >>> # add two columns "demean" and "zscore"                                                                                                                                                             
    >>> table = table.mutate(                                                                                                                                                                               
    ...     demean_and_zscore(table['v']).over(win).destructure()                                                                                                                                           
    ... )                                                                                                                                                                                                                                                                                                                                                          
```

- window aggregation UDF
```
    >>> @reduction(                                                                                                                                                                                         
    ...     input_type=[dt.double],                                                                                                                                                                         
    ...     output_type=dt.Struct(['mean', 'std'], [dt.double, dt.double])                                                                                                                                  
    ... )                                                                                                                                                                                                   
    ... def mean_and_std(v):                                                                                                                                                                                
    ...     return v.mean(), v.std()                                                                                                                                                                        
    >>>                                                                                                                                                                                                     
    >>> # create aggregation columns "mean" and "std"                                                                                                                                                       
    >>> table = table.groupby('key').aggregate(                                                                                                                                                             
    ...     mean_and_std(table['v']).destructure()                                                                                                                                                          
    ... )
    >>> win = ibis.window(preceding=ibis.interval(hours=1), following=None, group_by='key', order_by='time')
    >>> # add two columns "mean" and "std"
    >>> table = table.mutate(                                                                                                                                                                               
    ...     mean_and_std(table['v']).over(win).destructure()                                                                                                                                           
    ... )      
```

Note
-----
A lot of these changes don't work in PySpark backend because the support for struct in `pandas_udf` is limited (Only works in elementwise UDF from 3.0)

Tests
====
Added tests in `test_vectorized_udf.py`