### PR TITLE
CI: Installing web generator pysuerga from pipy and not github

### DIFF
--- a/ci/azure/linux.yml
+++ b/ci/azure/linux.yml
@@ -137,7 +137,7 @@ jobs:
             cd /tmp/ibis-project.org && \
             echo \"ibis-project.org\" > CNAME && \
             touch .nojekyll && \
-            pip install git+https://github.com/datapythonista/pysuerga && \  # XXX pysuerga is already in environment.yml, should already be installed
+            pip install pysuerga && \  # XXX pysuerga is already in environment.yml, should already be installed
             python -m pysuerga /ibis/docs/web --target-path=/tmp/ibis-project.org/ && \
             sphinx-build -b html /ibis/docs/source /tmp/ibis-project.org/docs -W -T --keep-going"
       displayName: 'Build website and docs'

--- a/environment.yml
+++ b/environment.yml
@@ -56,4 +56,4 @@ dependencies:
   - sphinx_rtd_theme>=0.5
   - pip
   - pip:
-    - git+https://github.com/datapythonista/pysuerga
+    - pysuerga


### PR DESCRIPTION
The static site generator we use for the website seems stable enough, so I released it to pypi. Using that version instead the github path.