### PR TITLE
CI: Make GitHub Actions builds compatible with Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: set up environment
-      run: ./ci/setup_env.sh "${{ matrix.python_version }}" "$BACKENDS" ""${{ runner.os }}""
+      run: ./ci/setup_env.sh "${{ matrix.python_version }}" "$BACKENDS"
       shell: bash
 
     - name: run tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]  # TODO add windows and fix bash scripts (conda not found)
+        os: [ubuntu-latest, windows-latest]
         python_version: ["3.7", "3.8"]
     steps:
     - name: checkout
       uses: actions/checkout@v1
 
     - name: set up environment
-      run: ./ci/setup_env.sh "${{ matrix.python_version }}" "$BACKENDS"
+      run: ./ci/setup_env.sh "${{ matrix.python_version }}" "$BACKENDS" ""${{ runner.os }}""
       shell: bash
 
     - name: run tests

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -12,7 +12,7 @@ RUNNER_OS="${3:-Linux}"
 if [[ "$RUNNER_OS" == "Linux" ]]; then
     CONDA_PATH="/usr/share/miniconda/bin"
 elif [[ "$RUNNER_OS" == "Windows" ]]; then
-    CONDA_PATH="/c/Miniconda/Scripts"
+    CONDA_PATH="/c/Miniconda:/c/Miniconda/Scripts:/c/Miniconda/Library:/c/Miniconda/Library/bin:/c/Miniconda/Library/mingw-w64/bin"
 else
     echo "RUNNER_OS: ${RUNNER_OS} not supported"
     exit 1

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -7,26 +7,31 @@
 PYTHON_VERSION="${1:-3.7}"
 BACKENDS="$2"
 
-# Add conda to path
-OS_NAME=$(uname)
-case $OS_NAME in
-    Linux)
-        CONDA_PATH="$CONDA/bin"
-        ;;
-    MINGW*)
-        CONDA_POSIX=$(cygpath -u "$CONDA")
-        CONDA_PATH="$CONDA_POSIX:$CONDA_POSIX/Scripts:$CONDA_POSIX/Library:$CONDA_POSIX/Library/bin:$CONDA_POSIX/Library/mingw-w64/bin"
-        ;;
-    *)
-        echo "$OS_NAME not supported."
-        exit 1
-esac
-PATH=${CONDA_PATH}:${PATH}
-
 echo "PYTHON_VERSION: $PYTHON_VERSION"
 echo "BACKENDS: $BACKENDS"
-# Prepend conda path to system path for the subsequent actions
-echo "${CONDA_PATH}" >> $GITHUB_PATH
+
+if [ -z "$CONDA" ]; then
+    # Add conda to Path
+    OS_NAME=$(uname)
+    case $OS_NAME in
+        Linux)
+            CONDA_PATH="$CONDA/bin"
+            ;;
+        MINGW*)
+            # Windows
+            CONDA_POSIX=$(cygpath -u "$CONDA")
+            CONDA_PATH="$CONDA_POSIX:$CONDA_POSIX/Scripts:$CONDA_POSIX/Library:$CONDA_POSIX/Library/bin:$CONDA_POSIX/Library/mingw-w64/bin"
+            ;;
+        *)
+            echo "$OS_NAME not supported."
+            exit 1
+    esac
+    PATH=${CONDA_PATH}:${PATH}
+    # Prepend conda path to system path for the subsequent GitHub Actions
+    echo "${CONDA_PATH}" >> $GITHUB_PATH
+else
+    echo "Running without adding conda to PATH."
+fi
 
 conda update -n base -c anaconda --all --yes conda
 conda install -n base -c anaconda --yes  python=${PYTHON_VERSION}

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -6,7 +6,6 @@
 
 PYTHON_VERSION="${1:-3.7}"
 BACKENDS="$2"
-RUNNER_OS="${3:-Linux}"
 
 # Add conda to path
 if [[ "$RUNNER_OS" == "Linux" ]]; then
@@ -21,7 +20,6 @@ PATH=${CONDA_PATH}:${PATH}
 
 echo "PYTHON_VERSION: $PYTHON_VERSION"
 echo "BACKENDS: $BACKENDS"
-echo "OS: $RUNNER_OS"
 echo "::add-path::${CONDA_PATH}"
 
 conda update -n base -c anaconda --all --yes conda

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -21,7 +21,8 @@ PATH=${CONDA_PATH}:${PATH}
 
 echo "PYTHON_VERSION: $PYTHON_VERSION"
 echo "BACKENDS: $BACKENDS"
-echo "::add-path::${CONDA_PATH}"
+# Prepend conda path to system path for the subsequent actions
+echo "${CONDA_PATH}" >> $GITHUB_PATH
 
 conda update -n base -c anaconda --all --yes conda
 conda install -n base -c anaconda --yes  python=${PYTHON_VERSION}

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -6,11 +6,21 @@
 
 PYTHON_VERSION="${1:-3.7}"
 BACKENDS="$2"
-CONDA_PATH="/usr/share/miniconda/bin"
+
+# Add conda to path
+if [[ "$OS" == "Linux" ]]; then
+    CONDA_PATH="/usr/share/miniconda/bin"
+elif [[ "$OS" == "Windows" ]]; then
+    CONDA_PATH="/c/Miniconda/Scripts"
+else
+    echo "OS: ${OS} not supported"
+    exit 1
+fi
 PATH=${CONDA_PATH}:${PATH}
 
 echo "PYTHON_VERSION: $PYTHON_VERSION"
 echo "BACKENDS: $BACKENDS"
+echo "OS: $OS"
 echo "::add-path::${CONDA_PATH}"
 
 conda update -n base -c anaconda --all --yes conda

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -6,7 +6,7 @@
 
 PYTHON_VERSION="${1:-3.7}"
 BACKENDS="$2"
-RUNNER_OS="$3"
+RUNNER_OS="${3:-Linux}"
 
 # Add conda to path
 if [[ "$RUNNER_OS" == "Linux" ]]; then

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -10,7 +10,7 @@ BACKENDS="$2"
 echo "PYTHON_VERSION: $PYTHON_VERSION"
 echo "BACKENDS: $BACKENDS"
 
-if [ -z "$CONDA" ]; then
+if [[ -n "$CONDA" ]]; then
     # Add conda to Path
     OS_NAME=$(uname)
     case $OS_NAME in

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -8,15 +8,19 @@ PYTHON_VERSION="${1:-3.7}"
 BACKENDS="$2"
 
 # Add conda to path
-if [[ "$RUNNER_OS" == "Linux" ]]; then
-    CONDA_PATH="$CONDA/bin"
-elif [[ "$RUNNER_OS" == "Windows" ]]; then
-    CONDA_POSIX=$(cygpath -u "$CONDA")
-    CONDA_PATH="$CONDA_POSIX:$CONDA_POSIX/Scripts:$CONDA_POSIX/Library:$CONDA_POSIX/Library/bin:$CONDA_POSIX/Library/mingw-w64/bin"
-else
-    echo "RUNNER_OS: ${RUNNER_OS} not supported"
-    exit 1
-fi
+OS_NAME=$(uname)
+case $OS_NAME in
+    Linux)
+        CONDA_PATH="$CONDA/bin"
+        ;;
+    MINGW*)
+        CONDA_POSIX=$(cygpath -u "$CONDA")
+        CONDA_PATH="$CONDA_POSIX:$CONDA_POSIX/Scripts:$CONDA_POSIX/Library:$CONDA_POSIX/Library/bin:$CONDA_POSIX/Library/mingw-w64/bin"
+        ;;
+    *)
+        echo "$OS_NAME not supported."
+        exit 1
+esac
 PATH=${CONDA_PATH}:${PATH}
 
 echo "PYTHON_VERSION: $PYTHON_VERSION"

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -9,9 +9,10 @@ BACKENDS="$2"
 
 # Add conda to path
 if [[ "$RUNNER_OS" == "Linux" ]]; then
-    CONDA_PATH="/usr/share/miniconda/bin"
+    CONDA_PATH="$CONDA/bin"
 elif [[ "$RUNNER_OS" == "Windows" ]]; then
-    CONDA_PATH="/c/Miniconda:/c/Miniconda/Scripts:/c/Miniconda/Library:/c/Miniconda/Library/bin:/c/Miniconda/Library/mingw-w64/bin"
+    CONDA_POSIX=$(cygpath -u "$CONDA")
+    CONDA_PATH="$CONDA_POSIX:$CONDA_POSIX/Scripts:$CONDA_POSIX/Library:$CONDA_POSIX/Library/bin:$CONDA_POSIX/Library/mingw-w64/bin"
 else
     echo "RUNNER_OS: ${RUNNER_OS} not supported"
     exit 1

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -8,9 +8,9 @@ PYTHON_VERSION="${1:-3.7}"
 BACKENDS="$2"
 
 # Add conda to path
-if [[ "$OS" == "Linux" ]]; then
+if [ "$OS" == "Linux" ]; then
     CONDA_PATH="/usr/share/miniconda/bin"
-elif [[ "$OS" == "Windows" ]]; then
+elif [ "$OS" == "Windows" ]; then
     CONDA_PATH="/c/Miniconda/Scripts"
 else
     echo "OS: ${OS} not supported"

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -6,21 +6,22 @@
 
 PYTHON_VERSION="${1:-3.7}"
 BACKENDS="$2"
+RUNNER_OS="$3"
 
 # Add conda to path
-if [ "$OS" == "Linux" ]; then
+if [[ "$RUNNER_OS" == "Linux" ]]; then
     CONDA_PATH="/usr/share/miniconda/bin"
-elif [ "$OS" == "Windows" ]; then
+elif [[ "$RUNNER_OS" == "Windows" ]]; then
     CONDA_PATH="/c/Miniconda/Scripts"
 else
-    echo "OS: ${OS} not supported"
+    echo "RUNNER_OS: ${RUNNER_OS} not supported"
     exit 1
 fi
 PATH=${CONDA_PATH}:${PATH}
 
 echo "PYTHON_VERSION: $PYTHON_VERSION"
 echo "BACKENDS: $BACKENDS"
-echo "OS: $OS"
+echo "OS: $RUNNER_OS"
 echo "::add-path::${CONDA_PATH}"
 
 conda update -n base -c anaconda --all --yes conda


### PR DESCRIPTION
closes #2389

I have changed `setup_env.sh` to set the CONDA_PATH based on which OS is running the script.
At the moment, I am passing the OS name using the value in `runner.os` as an argument as seen [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#runner-context), but as suggested by @datapythonista I will try something else like `uname`.

I am still working on it , but please let me know if you have any suggestions.