### PR TITLE
Move impala compiler to base_sql

### DIFF
--- a/ibis/backends/base_sql/__init__.py
+++ b/ibis/backends/base_sql/__init__.py
@@ -173,19 +173,6 @@ def quote_identifier(name, quotechar='`', force=False):
         return name
 
 
-# TODO move the name method to comp.ExprTranslator and use that instead
-class BaseExprTranslator(comp.ExprTranslator):
-    """Base expression translator."""
-
-    @staticmethod
-    def _name_expr(formatted_expr, quoted_name):
-        return '{} AS {}'.format(formatted_expr, quoted_name)
-
-    def name(self, translated, name, force=True):
-        """Return expression with its identifier."""
-        return self._name_expr(translated, quote_identifier(name, force=force))
-
-
 parenthesize = '({})'.format
 
 

--- a/ibis/backends/base_sql/compiler.py
+++ b/ibis/backends/base_sql/compiler.py
@@ -161,8 +161,7 @@ def _replace_interval_with_scalar(expr):
         return method(left_arg, right_arg)
 
 
-_operation_registry = {**operation_registry}
-_operation_registry.update(binary_infix_ops)
+_operation_registry = {**operation_registry, **binary_infix_ops}
 
 
 # TODO move the name method to comp.ExprTranslator and use that instead

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -14,16 +14,11 @@ import ibis.expr.lineage as lin
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.backends import base_sql
-from ibis.backends.base_sql import (
-    fixed_arity,
-    literal,
-    reduction,
-    unary,
-)
+from ibis.backends.base_sql import fixed_arity, literal, reduction, unary
 from ibis.backends.base_sql.compiler import (
+    BaseExprTranslator,
     BaseSelect,
     BaseTableSetFormatter,
-    BaseExprTranslator,
 )
 
 from .datatypes import ibis_type_to_bigquery_type

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -20,7 +20,11 @@ from ibis.backends.base_sql import (
     reduction,
     unary,
 )
-from ibis.backends.base_sql.compiler import BaseSelect, BaseTableSetFormatter
+from ibis.backends.base_sql.compiler import (
+    BaseSelect,
+    BaseTableSetFormatter,
+    BaseExprTranslator,
+)
 
 from .datatypes import ibis_type_to_bigquery_type
 

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -15,13 +15,12 @@ import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.backends import base_sql
 from ibis.backends.base_sql import (
-    BaseExprTranslator,
     fixed_arity,
     literal,
     reduction,
     unary,
 )
-from ibis.impala.compiler import ImpalaSelect, ImpalaTableSetFormatter
+from ibis.backends.base_sql.compiler import BaseSelect, BaseTableSetFormatter
 
 from .datatypes import ibis_type_to_bigquery_type
 
@@ -479,14 +478,14 @@ def compiles_string_to_timestamp(translator, expr):
     return 'PARSE_TIMESTAMP({}, {})'.format(fmt_string, arg_formatted)
 
 
-class BigQueryTableSetFormatter(ImpalaTableSetFormatter):
+class BigQueryTableSetFormatter(BaseTableSetFormatter):
     def _quote_identifier(self, name):
         if re.match(r'^[A-Za-z][A-Za-z_0-9]*$', name):
             return name
         return '`{}`'.format(name)
 
 
-class BigQuerySelect(ImpalaSelect):
+class BigQuerySelect(BaseSelect):
 
     translator = BigQueryExprTranslator
 

--- a/ibis/backends/spark/compiler.py
+++ b/ibis/backends/spark/compiler.py
@@ -39,10 +39,10 @@ from ibis.backends.base_sql import (
     sql_type_names,
     unary,
 )
-from ibis.impala.compiler import (
-    ImpalaDialect,
-    ImpalaExprTranslator,
-    ImpalaSelect,
+from ibis.backends.base_sql.compiler import (
+    BaseDialect,
+    BaseExprTranslator,
+    BaseSelect,
 )
 
 
@@ -349,7 +349,7 @@ _operation_registry.update(
 )
 
 
-class SparkExprTranslator(ImpalaExprTranslator):
+class SparkExprTranslator(BaseExprTranslator):
     _registry = _operation_registry
 
     context_class = SparkContext
@@ -388,11 +388,11 @@ def spark_rewrites_is_inf(expr):
     return (arg == ibis.literal(math.inf)) | (arg == ibis.literal(-math.inf))
 
 
-class SparkSelect(ImpalaSelect):
+class SparkSelect(BaseSelect):
     translator = SparkExprTranslator
 
 
-class SparkDialect(ImpalaDialect):
+class SparkDialect(BaseDialect):
     translator = SparkExprTranslator
 
 

--- a/ibis/impala/compiler.py
+++ b/ibis/impala/compiler.py
@@ -12,6 +12,7 @@ from ibis.backends.base_sql import (
 )
 from ibis.backends.base_sql.compiler import (
     BaseContext,
+    BaseDialect,
     BaseExprTranslator,
     BaseQueryBuilder,
     BaseSelectBuilder,
@@ -35,7 +36,7 @@ def _get_query(expr, context):
 
 def to_sql(expr, context=None):
     if context is None:
-        context = ImpalaDialect.make_context()
+        context = BaseDialect.make_context()
     assert context is not None, 'context is None'
     query = _get_query(expr, context)
     return query.compile()
@@ -54,11 +55,6 @@ class ImpalaSelectBuilder(BaseSelectBuilder):
 class ImpalaQueryBuilder(BaseQueryBuilder):
 
     select_builder = ImpalaSelectBuilder
-
-
-class ImpalaContext(BaseContext):
-    def _to_sql(self, expr, ctx):
-        return to_sql(expr, ctx)
 
 
 class ImpalaSelect(comp.Select):
@@ -158,17 +154,16 @@ def _replace_interval_with_scalar(expr):
         return method(left_arg, right_arg)
 
 
-_operation_registry = {**operation_registry}
-_operation_registry.update(binary_infix_ops)
+_operation_registry = {**operation_registry, **binary_infix_ops}
 
 
 class ImpalaExprTranslator(BaseExprTranslator):
     _registry = _operation_registry
-    context_class = ImpalaContext
+    context_class = BaseContext
 
 
-class ImpalaDialect(comp.Dialect):
-    translator = BaseExprTranslator
+class ImpalaDialect(BaseDialect):
+    pass
 
 
 dialect = ImpalaDialect

--- a/ibis/impala/tests/mocks.py
+++ b/ibis/impala/tests/mocks.py
@@ -1,0 +1,14 @@
+from ibis.tests.expr.mocks import BaseMockConnection
+
+
+class MockImpalaConnection(BaseMockConnection):
+    @property
+    def dialect(self):
+        from ibis.impala.compiler import ImpalaDialect
+
+        return ImpalaDialect
+
+    def _build_ast(self, expr, context):
+        from ibis.impala.compiler import build_ast
+
+        return build_ast(expr, context)

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -387,12 +387,12 @@ class MockConnection(BaseMockConnection):
     #       MockAlchemyConnection instead?
     @property
     def dialect(self):
-        from ibis.impala.compiler import ImpalaDialect
+        from ibis.backends.base_sql.compiler import BaseDialect
 
-        return ImpalaDialect
+        return BaseDialect
 
     def _build_ast(self, expr, context):
-        from ibis.impala.compiler import build_ast
+        from ibis.backends.base_sql.compiler import build_ast
 
         return build_ast(expr, context)
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -1977,7 +1977,7 @@ WITH t0 AS (
 )
 SELECT t0.*
 FROM t0
-  CROSS JOIN t0 t1"""
+  INNER JOIN t0 t1"""
 
         assert result == expected
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -928,27 +928,6 @@ FROM tpch_nation t0
         result = to_sql(joined.materialize())
         assert result == expected
 
-    def test_join_no_predicates_for_impala(self):
-        # Impala requires that joins without predicates be written explicitly
-        # as CROSS JOIN, since result sets can accidentally get too large if a
-        # query is executed before predicates are written
-        t1 = self.con.table('star1')
-        t2 = self.con.table('star2')
-
-        joined2 = t1.cross_join(t2)[[t1]]
-
-        expected = """SELECT t0.*
-FROM star1 t0
-  CROSS JOIN star2 t1"""
-        result2 = to_sql(joined2)
-        assert result2 == expected
-
-        for jtype in ['inner_join', 'left_join', 'outer_join']:
-            joined = getattr(t1, jtype)(t2)[[t1]]
-
-            result = to_sql(joined)
-            assert result == expected
-
     def test_semi_anti_joins(self):
         sj, aj = self._case_semi_anti_joins()
 
@@ -1988,6 +1967,7 @@ WHERE NOT EXISTS (
 
     def test_limit_cte_extract(self):
         case = self._case_limit_cte_extract()
+        result = to_sql(case)
 
         expected = """\
 WITH t0 AS (
@@ -1999,7 +1979,7 @@ SELECT t0.*
 FROM t0
   CROSS JOIN t0 t1"""
 
-        self._compare_sql(case, expected)
+        assert result == expected
 
     def test_sort_by(self):
         cases = self._case_sort_by()


### PR DESCRIPTION
Closes #2501

@datapythonista from starting on this it looks like even `base_sql` relies on the `base_sqlalchemy` compiler - so that definitely emphasizes your point on eventually having just one base sql backend.  i def still have ways to go but my approach was as follows:

1. Move impala compiler classes and functions to new `base_sql.compiler.py` file (and update names from `Impala` to `Base`
2. Update `impala.compiler.py` to subclass from these new `base_sql` classes
3. Update other backends that use impalas compiler to use the new `base_sql` one instead

By doing this i thought i would be able to leave the rest of the impala code untouched and have it still pull from impala compiler while the impala compiler is based on base_sql.

I def still have ways to go but can you let me know if this is the right direction to be going in?