### PR TITLE
Adds impyla dependency to enviroment.yaml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   # Ibis soft dependencies
   # TODO This section is probably not very accurate right now (some dependencies should probably be in the backends files)
   - sqlalchemy>=1.3
+  - impyla>=0.16.3
   - graphviz>=2.38
   - openjdk=8
   - pytables>=3.6


### PR DESCRIPTION
If the impyla package is installed, then tests are not skipped and actually run.