### PR TITLE
FEAT: Add support for destruct for aggregation with no groupby

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2473` Support analytic and reduction UDF to return multiple columns for Pandas backend
 * :support:`2497` Move `ibis.HDFS`, `ibis.WebHDFS` and `ibis.hdfs_connect` to `ibis.impala.*`
 * :feature:`2473` Support elementwise UDF to return multiple columns for Pandas and PySpark backend
 * :bug:`2462` Table expressions do not recognize inet datatype (Postgres backend)

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,7 +12,8 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
-* :feature:`2473` Support analytic and reduction UDF to return multiple columns for Pandas backend
+* :feature:`2511` Support reduction UDF without groupby to return multiple columns for Pandas backend
+* :feature:`2487` Support analytic and reduction UDF to return multiple columns for Pandas backend
 * :support:`2497` Move `ibis.HDFS`, `ibis.WebHDFS` and `ibis.hdfs_connect` to `ibis.impala.*`
 * :feature:`2473` Support elementwise UDF to return multiple columns for Pandas and PySpark backend
 * :bug:`2462` Table expressions do not recognize inet datatype (Postgres backend)

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -93,12 +93,12 @@ def coerce_to_output(
         # then the result e a Series of tuple/list, or
         # if this is non grouped aggregate, then the result
         return ibis.util.coerce_to_dataframe(result, expr.type().names)
-    elif np.isscalar(result):
+    elif isinstance(result, pd.Series):
+        return result.rename(result_name)
+    else:
         if index is None:
             return pd.Series(result, name=result_name)
         else:
             return pd.Series(
                 np.repeat(result, len(index)), index=index, name=result_name,
             )
-    else:
-        return result.rename(result_name)

--- a/ibis/backends/pandas/tests/test_udf.py
+++ b/ibis/backends/pandas/tests/test_udf.py
@@ -9,7 +9,7 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 
-from .. import connect, execute
+from .. import connect
 from ..udf import nullable, udf
 
 
@@ -94,11 +94,6 @@ def zscore(series):
     return (series - series.mean()) / series.std()
 
 
-@udf.elementwise([], dt.int64)
-def a_single_number(**kwargs):
-    return 1
-
-
 @udf.reduction(
     input_type=[dt.double], output_type=dt.Array(dt.double),
 )
@@ -114,12 +109,6 @@ def test_udf(t, df):
     result = expr.execute()
     expected = df.a.str.len().mul(2)
     tm.assert_series_equal(result, expected)
-
-
-def test_zero_argument_udf(con, t, df):
-    expr = t.projection([a_single_number().name('foo')])
-    result = execute(expr)
-    assert result is not None
 
 
 def test_elementwise_udf_with_non_vectors(con):

--- a/ibis/tests/all/test_vectorized_udf.py
+++ b/ibis/tests/all/test_vectorized_udf.py
@@ -321,6 +321,20 @@ def test_reduction_udf_destruct_groupby(backend, alltypes):
 
 
 @pytest.mark.only_on_backends([Pandas])
+def test_reduction_udf_destruct_no_groupby(backend, alltypes):
+    result = alltypes.aggregate(
+        mean_struct(alltypes['double_col'], alltypes['int_col']).destructure()
+    ).execute()
+
+    expected = alltypes.aggregate(
+        mean=alltypes['double_col'].mean(),
+        mean_weight=alltypes['int_col'].mean(),
+    ).execute()
+
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.only_on_backends([Pandas])
 def test_reduction_udf_destruct_window(backend, alltypes):
     win = window(
         preceding=ibis.interval(hours=2),

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -79,8 +79,9 @@ def coerce_to_dataframe(data: Any, names: List[str]) -> pd.DataFrame:
 
     The following shapes are allowed:
     (1) A list/tuple of Series
-    (2) A Series of list/tuple
-    (3) pd.DataFrame
+    (2) A list/tuple of scalars
+    (3) A Series of list/tuple
+    (4) pd.DataFrame
 
     Note:
     This method does NOT always return a new DataFrame. If a DataFrame is
@@ -101,7 +102,11 @@ def coerce_to_dataframe(data: Any, names: List[str]) -> pd.DataFrame:
         series = [data.apply(lambda t: t[i]) for i in range(num_cols)]
         result = pd.concat(series, axis=1)
     elif isinstance(data, (tuple, list)):
-        result = pd.concat(data, axis=1)
+        if isinstance(data[0], pd.Series):
+            result = pd.concat(data, axis=1)
+        else:
+            # Promote scalar to Series
+            result = pd.concat([pd.Series([v]) for v in data], axis=1)
     else:
         raise ValueError(f"Cannot coerce to DataFrame: {data}")
 


### PR DESCRIPTION
What is the change
==============
Follow up of #2487 

Added support for aggregation without groupby with destruct.

This change itself is straight forward. The main change is in `coerce_to_output` where I added support for coercing a tuple of scalar, e.g., (1.0, 2.0) to a single row DataFrame, which is what we used for other destruct columns.

How is this tested
=============
Added `test_reduction_udf_no_groupby`