### PR TITLE
DOC: Fixing style of level 4 headers

### DIFF
--- a/docs/web/contribute.md
+++ b/docs/web/contribute.md
@@ -129,6 +129,7 @@ for more information.
 ### Releasing
 
 Ibis is released in two places:
+
 - [PyPI](https://pypi.org/) (the **PY**thon **P**ackage **I**ndex), to enable `pip install ibis-framework`
 - [Conda Forge](https://conda-forge.org/), to enable `conda install ibis-framework`
 

--- a/docs/web/static/css/ibis.css
+++ b/docs/web/static/css/ibis.css
@@ -22,7 +22,7 @@ h3 a {
 }
 h4 {
     font-size: 1rem;
-    font-weight: 500;
+    font-weight: 600;
     color: #444;
 }
 a {


### PR DESCRIPTION
Headers of level 4 (i.e. markdown `#### Header`) don't look so much as headers. Making them more visible.

Also fixing a typo in the markdown here.