### PR TITLE
TST/BUG: Fix run_tests.sh for new backend directory structure

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -5,8 +5,8 @@
 
 TESTS_DIRS="ibis/tests"
 for BACKEND in $PYTEST_BACKENDS; do
-    if [[ -d ibis/$BACKEND/tests ]]; then
-        TESTS_DIRS="$TESTS_DIRS ibis/$BACKEND/tests"
+    if [[ -d ibis/backends/$BACKEND/tests ]]; then
+        TESTS_DIRS="$TESTS_DIRS ibis/backends/$BACKEND/tests"
     fi
 done
 

--- a/ibis/backends/omniscidb/tests/test_client.py
+++ b/ibis/backends/omniscidb/tests/test_client.py
@@ -296,7 +296,7 @@ def test_cpu_execution_type(
     [
         ('rows', 'pandas'),
         ('columnar', 'pandas'),
-        ('infer' 'pandas'),
+        ('infer', 'pandas'),
         ('infer', 'arrow'),
         ('arrow', 'arrow'),
     ],

--- a/ibis/backends/omniscidb/tests/test_operations.py
+++ b/ibis/backends/omniscidb/tests/test_operations.py
@@ -84,7 +84,7 @@ def test_join_diff_name(awards_players, batting):
         .materialize()
         .execute()
     )
-    assert df.size == 80
+    assert df.size == 70
 
 
 def test_cross_join(alltypes):

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -88,7 +88,7 @@ def intervals(con):
 
 @pytest.fixture
 def translate():
-    from ibis.sql.postgres.compiler import PostgreSQLDialect
+    from ibis.backends.postgres.compiler import PostgreSQLDialect
 
     dialect = PostgreSQLDialect()
     context = dialect.make_context()

--- a/ibis/backends/postgres/tests/test_udf.py
+++ b/ibis/backends/postgres/tests/test_udf.py
@@ -6,7 +6,7 @@ import pytest
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.backends.postgres.udf.api import existing_udf, udf, PostgresUDFError
+from ibis.backends.postgres.udf.api import PostgresUDFError, existing_udf, udf
 
 # mark test module as postgresql (for ability to easily exclude,
 # e.g. in conda build tests)

--- a/ibis/backends/postgres/tests/test_udf.py
+++ b/ibis/backends/postgres/tests/test_udf.py
@@ -6,8 +6,7 @@ import pytest
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.sql.postgres import existing_udf, udf
-from ibis.sql.postgres.udf.api import PostgresUDFError
+from ibis.backends.postgres.udf.api import existing_udf, udf, PostgresUDFError
 
 # mark test module as postgresql (for ability to easily exclude,
 # e.g. in conda build tests)

--- a/ibis/backends/pyspark/tests/test_timecontext.py
+++ b/ibis/backends/pyspark/tests/test_timecontext.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pandas.util.testing as tm
 import pytest
 
-from ibis.pyspark.timecontext import combine_time_context
+from ibis.backends.pyspark.timecontext import combine_time_context
 
 pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark

--- a/ibis/backends/spark/tests/test_ddl_compilation.py
+++ b/ibis/backends/spark/tests/test_ddl_compilation.py
@@ -1,24 +1,25 @@
 import pytest
 
 import ibis
+from ibis.backends.base_sql import ddl as base_ddl
 
 from ..compiler import (  # noqa: E402, isort:skip
     SparkDialect,
     build_ast,
 )
-from ibis.backends.base_sql import ddl
+from .. import ddl  # noqa: E402, isort:skip
 
 
 pytestmark = pytest.mark.spark
 
 
 def test_drop_table_compile():
-    statement = ddl.DropTable('foo', database='bar', must_exist=True)
+    statement = base_ddl.DropTable('foo', database='bar', must_exist=True)
     query = statement.compile()
     expected = "DROP TABLE bar.`foo`"
     assert query == expected
 
-    statement = ddl.DropTable('foo', database='bar', must_exist=False)
+    statement = base_ddl.DropTable('foo', database='bar', must_exist=False)
     query = statement.compile()
     expected = "DROP TABLE IF EXISTS bar.`foo`"
     assert query == expected

--- a/ibis/backends/spark/tests/test_ddl_compilation.py
+++ b/ibis/backends/spark/tests/test_ddl_compilation.py
@@ -6,7 +6,7 @@ from ..compiler import (  # noqa: E402, isort:skip
     SparkDialect,
     build_ast,
 )
-from .. import ddl  # noqa: E402, isort:skip
+from ibis.backends.base_sql import ddl
 
 
 pytestmark = pytest.mark.spark

--- a/ibis/backends/sqlite/tests/conftest.py
+++ b/ibis/backends/sqlite/tests/conftest.py
@@ -34,7 +34,7 @@ def dialect():
 
 @pytest.fixture
 def translate(dialect):
-    from .sqlite.compiler import SQLiteDialect
+    from ibis.backends.sqlite.compiler import SQLiteDialect
 
     ibis_dialect = SQLiteDialect()
     context = ibis_dialect.make_context()


### PR DESCRIPTION
`run_tests.sh` was still expecting the old directory structure and thus not running tests specific to each backend. 

For example compare test dirs/number of tests in https://github.com/ibis-project/ibis/pull/2536/checks?check_run_id=1433682341#step:4:6 vs https://github.com/ibis-project/ibis/runs/1433974150?check_suite_focus=true#step:4:10

This PR also fixes various other test failures uncovered now that backend tests are running again. 