### PR TITLE
Remove previously deprecated hdfs function from top level module

### DIFF
--- a/ci/impalamgr.py
+++ b/ci/impalamgr.py
@@ -36,7 +36,7 @@ for key, value in env_items:
 
 
 def make_ibis_client(env):
-    hc = ibis.hdfs_connect(
+    hc = ibis.impala.hdfs_connect(
         host=env.nn_host,
         port=env.webhdfs_port,
         auth_mechanism=env.auth_mechanism,

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :support:`2505` Remove deprecated `ibis.HDFS`, `ibis.WebHDFS` and `ibis.hdfs_connect`
 * :feature:`2514` Add Struct.from_dict
 * :feature:`2310` Add hash and hashbytes support for BigQuery backend
 * :feature:`2511` Support reduction UDF without groupby to return multiple columns for Pandas backend

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -1,5 +1,4 @@
 """Initialize Ibis module."""
-import warnings
 from contextlib import suppress
 
 import ibis.config
@@ -89,20 +88,3 @@ with suppress(ImportError):
 
 __version__ = get_versions()['version']
 del get_versions
-
-
-def __getattr__(name):
-    if name in ('HDFS', 'WebHDFS', 'hdfs_connect'):
-        warnings.warn(
-            f'`ibis.{name}` has been deprecated and will be removed in a '
-            f'future version, use `ibis.impala.{name}` instead',
-            FutureWarning,
-            stacklevel=2,
-        )
-        if 'impala' in globals():
-            return getattr(impala, name)
-        else:
-            raise AttributeError(
-                f'`ibis.{name}` requires impala backend to be installed'
-            )
-    raise AttributeError


### PR DESCRIPTION
Closes #2505 

Removing `ibis.hdfs_connect`... previously deprecated in favor of `ibis.impala.hdfs_connect`...