### PR TITLE
CI: Skipping time test in CI

### DIFF
--- a/ibis/tests/test_version.py
+++ b/ibis/tests/test_version.py
@@ -8,7 +8,7 @@ import ibis
 
 
 @pytest.mark.skipif(
-    bool(os.environ.get("AZURECI")),
+    bool(os.environ.get("CI")),
     reason="Testing import time on CI is flaky due to machine variance",
 )
 def test_import_time():


### PR DESCRIPTION
Closes #2520

After moving tests to actions, the time test that was was supposed to be skipped in the CI started running again, and failing quite often. Skipping it here.