### PR TITLE
DOC: Update hdfs_connect calls in docs

### DIFF
--- a/docs/source/backends/impala.rst
+++ b/docs/source/backends/impala.rst
@@ -35,7 +35,7 @@ client using :func:`ibis.impala.connect`:
 
    import ibis
 
-   hdfs = ibis.hdfs_connect(host='impala', port=50070)
+   hdfs = ibis.impala.hdfs_connect(host='impala', port=50070)
    con = ibis.impala.connect(
        host='impala', database='ibis_testing', hdfs_client=hdfs
    )
@@ -51,7 +51,7 @@ API
 .. currentmodule:: ibis.backends.impala
 
 These methods are available on the Impala client object after connecting to
-your HDFS cluster (``ibis.hdfs_connect``) and connecting to Impala with
+your HDFS cluster (``ibis.impala.hdfs_connect``) and connecting to Impala with
 ``ibis.impala.connect``. See :ref:`backends.impala` for a tutorial on using this
 backend.
 
@@ -201,7 +201,7 @@ connection:
 
    import ibis
 
-   hdfs = ibis.hdfs_connect(host=webhdfs_host, port=webhdfs_port)
+   hdfs = ibis.impala.hdfs_connect(host=webhdfs_host, port=webhdfs_port)
    client = ibis.impala.connect(
        host=impala_host, port=impala_port, hdfs_client=hdfs
    )

--- a/docs/source/tutorial/04-More-Value-Expressions.ipynb
+++ b/docs/source/tutorial/04-More-Value-Expressions.ipynb
@@ -23,7 +23,7 @@
     "import ibis\n",
     "import os\n",
     "hdfs_port = os.environ.get('IBIS_WEBHDFS_PORT', 50070)\n",
-    "hdfs = ibis.hdfs_connect(host='impala', port=hdfs_port)\n",
+    "hdfs = ibis.impala.hdfs_connect(host='impala', port=hdfs_port)\n",
     "con = ibis.impala.connect(host='impala', database='ibis_testing',\n",
     "                          hdfs_client=hdfs)\n",
     "ibis.options.interactive = True"

--- a/docs/source/tutorial/05-IO-Create-Insert-External-Data.ipynb
+++ b/docs/source/tutorial/05-IO-Create-Insert-External-Data.ipynb
@@ -26,7 +26,7 @@
     "import os\n",
     "hdfs_port = int(os.environ.get('IBIS_TEST_WEBHDFS_PORT', 50070))\n",
     "user = os.environ.get('IBIS_TEST_WEBHDFS_USER', 'ubuntu')\n",
-    "hdfs = ibis.hdfs_connect(host='impala', user=user, port=hdfs_port)\n",
+    "hdfs = ibis.impala.hdfs_connect(host='impala', user=user, port=hdfs_port)\n",
     "con = ibis.impala.connect(host='impala', database='ibis_testing',\n",
     "                          hdfs_client=hdfs)\n",
     "ibis.options.interactive = True"

--- a/docs/source/tutorial/06-Advanced-Topics-TopK-SelfJoins.ipynb
+++ b/docs/source/tutorial/06-Advanced-Topics-TopK-SelfJoins.ipynb
@@ -23,7 +23,7 @@
     "import ibis\n",
     "import os\n",
     "hdfs_port = os.environ.get('IBIS_WEBHDFS_PORT', 50070)\n",
-    "hdfs = ibis.hdfs_connect(host='impala', port=hdfs_port)\n",
+    "hdfs = ibis.impala.hdfs_connect(host='impala', port=hdfs_port)\n",
     "con = ibis.impala.connect(host='impala', database='ibis_testing',\n",
     "                          hdfs_client=hdfs)\n",
     "ibis.options.interactive = True"

--- a/docs/source/tutorial/07-Advanced-Topics-ComplexFiltering.ipynb
+++ b/docs/source/tutorial/07-Advanced-Topics-ComplexFiltering.ipynb
@@ -31,7 +31,7 @@
     "import ibis\n",
     "import os\n",
     "hdfs_port = os.environ.get('IBIS_WEBHDFS_PORT', 50070)\n",
-    "hdfs = ibis.hdfs_connect(host='impala', port=hdfs_port)\n",
+    "hdfs = ibis.impala.hdfs_connect(host='impala', port=hdfs_port)\n",
     "con = ibis.impala.connect(host='impala', database='ibis_testing',\n",
     "                          hdfs_client=hdfs)\n",
     "ibis.options.interactive = True"

--- a/docs/source/tutorial/08-More-Analytics-Helpers.ipynb
+++ b/docs/source/tutorial/08-More-Analytics-Helpers.ipynb
@@ -23,7 +23,7 @@
     "import ibis\n",
     "import os\n",
     "hdfs_port = os.environ.get('IBIS_WEBHDFS_PORT', 50070)\n",
-    "hdfs = ibis.hdfs_connect(host='impala', port=hdfs_port)\n",
+    "hdfs = ibis.impala.hdfs_connect(host='impala', port=hdfs_port)\n",
     "con = ibis.impala.connect(host='impala', database='ibis_testing',\n",
     "                          hdfs_client=hdfs)\n",
     "ibis.options.interactive = True"

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -80,7 +80,7 @@ This method also takes arguments to configure SSL (``use_ssl``, ``ca_cert``).
 See the documentation for the Impala shell for more details.
 
 Ibis also includes functionality that communicates directly with HDFS, using
-the WebHDFS REST API.  When calling ``ibis.hdfs_connect(...)``, also pass
+the WebHDFS REST API.  When calling ``ibis.impala.hdfs_connect(...)``, also pass
 ``auth_mechanism='GSSAPI'`` or ``auth_mechanism='LDAP'``, and ensure that you
 are connecting to the correct port, which may likely be an SSL-secured WebHDFS
 port.  Also note that you can pass ``verify=False`` to avoid verifying SSL

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -103,7 +103,7 @@ def connect(
     >>> hdfs_port = int(os.environ.get('IBIS_TEST_NN_PORT', 50070))
     >>> impala_host = os.environ.get('IBIS_TEST_IMPALA_HOST', 'localhost')
     >>> impala_port = int(os.environ.get('IBIS_TEST_IMPALA_PORT', 21050))
-    >>> hdfs = ibis.hdfs_connect(host=hdfs_host, port=hdfs_port)
+    >>> hdfs = ibis.impala.hdfs_connect(host=hdfs_host, port=hdfs_port)
     >>> hdfs  # doctest: +ELLIPSIS
     <ibis.filesystems.WebHDFS object at 0x...>
     >>> client = ibis.impala.connect(

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -118,7 +118,7 @@ def hdfs(env, tmp_dir):
     if env.auth_mechanism in {'GSSAPI', 'LDAP'}:
         warnings.warn("Ignoring invalid Certificate Authority errors")
 
-    client = ibis.hdfs_connect(
+    client = ibis.impala.hdfs_connect(
         host=env.nn_host,
         port=env.webhdfs_port,
         auth_mechanism=env.auth_mechanism,

--- a/ibis/backends/impala/tests/test_hdfs.py
+++ b/ibis/backends/impala/tests/test_hdfs.py
@@ -56,7 +56,7 @@ class TestHDFSE2E(unittest.TestCase):
         cls.tmp_dir = pjoin(cls.ENV.tmp_dir, util.guid())
         if cls.ENV.auth_mechanism in ['GSSAPI', 'LDAP']:
             print("Warning: ignoring invalid Certificate Authority errors")
-        cls.hdfs = ibis.hdfs_connect(
+        cls.hdfs = ibis.impala.hdfs_connect(
             host=cls.ENV.nn_host,
             port=cls.ENV.webhdfs_port,
             auth_mechanism=cls.ENV.auth_mechanism,
@@ -393,7 +393,7 @@ class TestSuperUserHDFSE2E(unittest.TestCase):
         if cls.ENV.auth_mechanism in ['GSSAPI', 'LDAP']:
             print("Warning: ignoring invalid Certificate Authority errors")
         # NOTE: specifying superuser as set in IbisTestEnv
-        cls.hdfs = ibis.hdfs_connect(
+        cls.hdfs = ibis.impala.hdfs_connect(
             host=cls.ENV.nn_host,
             port=cls.ENV.webhdfs_port,
             auth_mechanism=cls.ENV.auth_mechanism,

--- a/ibis/tests/backends.py
+++ b/ibis/tests/backends.py
@@ -519,7 +519,7 @@ class Impala(UnorderedComparator, Backend, RoundAwayFromZero):
         from ibis.backends.impala.tests.conftest import IbisTestEnv
 
         env = IbisTestEnv()
-        hdfs_client = ibis.hdfs_connect(
+        hdfs_client = ibis.impala.hdfs_connect(
             host=env.nn_host,
             port=env.webhdfs_port,
             auth_mechanism=env.auth_mechanism,


### PR DESCRIPTION
Closes #2555 

Not sure why the CI didn't fail for #2545, but looks like there were some missing calls to `ibis.hdfs_connect` that weren't updated to be `ibis.impala..hdfs_connected` and this is making the docs build fail.