### PR TITLE
BLD: Speed up azure builds 

### DIFF
--- a/ci/Dockerfile.dev
+++ b/ci/Dockerfile.dev
@@ -16,7 +16,7 @@ RUN /opt/conda/bin/conda config --add channels conda-forge \
 RUN /opt/conda/bin/conda create --yes --name ibis-env python=$PYTHON_VERSION \
   && /opt/conda/bin/conda env update --name ibis-env --file /environment.yml
 
-RUN for FNAME in $(ls /deps/*.yml | grep -v "\-min.yml\|omniscidb.yml"); do /opt/conda/bin/conda install --name ibis-env --file $FNAME; done
+RUN for FNAME in $(ls /deps/*.yml | grep -v "\-min.yml"); do /opt/conda/bin/conda install --name ibis-env --file $FNAME; done
 
 RUN echo 'source /opt/conda/bin/activate ibis-env && exec "$@"' > activate.sh
 

--- a/ci/Dockerfile.dev
+++ b/ci/Dockerfile.dev
@@ -16,7 +16,7 @@ RUN /opt/conda/bin/conda config --add channels conda-forge \
 RUN /opt/conda/bin/conda env create --name ibis-env --file /environment.yml \
   && /opt/conda/bin/conda install --name ibis-env python=$PYTHON_VERSION
 
-RUN for FNAME in $(ls /deps/*.yml | grep -v "\-min.yml"); do /opt/conda/bin/conda install --name ibis-env --file $FNAME; done
+RUN for FNAME in $(ls /deps/*.yml | grep -v "\-min.yml\|omniscidb.yml"); do /opt/conda/bin/conda install --name ibis-env --file $FNAME; done
 
 RUN echo 'source /opt/conda/bin/activate ibis-env && exec "$@"' > activate.sh
 

--- a/ci/Dockerfile.dev
+++ b/ci/Dockerfile.dev
@@ -13,8 +13,8 @@ RUN /opt/conda/bin/conda config --add channels conda-forge \
   && /opt/conda/bin/conda update --all --yes --quiet \
   && /opt/conda/bin/conda install --yes conda-build
 
-RUN /opt/conda/bin/conda env create --name ibis-env --file /environment.yml \
-  && /opt/conda/bin/conda install --name ibis-env python=$PYTHON_VERSION
+RUN /opt/conda/bin/conda env create --name ibis-env python=$PYTHON_VERSION -y \
+  && /opt/conda/bin/conda env update --name ibis-env --file /environment.yml
 
 RUN for FNAME in $(ls /deps/*.yml | grep -v "\-min.yml\|omniscidb.yml"); do /opt/conda/bin/conda install --name ibis-env --file $FNAME; done
 

--- a/ci/Dockerfile.dev
+++ b/ci/Dockerfile.dev
@@ -13,7 +13,7 @@ RUN /opt/conda/bin/conda config --add channels conda-forge \
   && /opt/conda/bin/conda update --all --yes --quiet \
   && /opt/conda/bin/conda install --yes conda-build
 
-RUN /opt/conda/bin/conda env create --name ibis-env python=$PYTHON_VERSION -y \
+RUN /opt/conda/bin/conda create --yes --name ibis-env python=$PYTHON_VERSION \
   && /opt/conda/bin/conda env update --name ibis-env --file /environment.yml
 
 RUN for FNAME in $(ls /deps/*.yml | grep -v "\-min.yml\|omniscidb.yml"); do /opt/conda/bin/conda install --name ibis-env --file $FNAME; done


### PR DESCRIPTION
Docs are built on azure via `BuildDocs` in ci/azure/linux.yml. 
This then builds `ibis-docs` (via make) in using `ci/docker-compose.yml`. 
This builds `Docker.docs` which depends on `Docker.dev`, which conda installs files from `ci/deps/. 

cc @jreback 
