### PR TITLE
CI: Skipping time test in Azure

### DIFF
--- a/ibis/tests/test_version.py
+++ b/ibis/tests/test_version.py
@@ -8,7 +8,7 @@ import ibis
 
 
 @pytest.mark.skipif(
-    bool(os.environ.get("CI")),
+    bool(os.environ.get("CI")) or bool(os.environ.get("AZURECI")),
     reason="Testing import time on CI is flaky due to machine variance",
 )
 def test_import_time():


### PR DESCRIPTION
In #2548 we skipped the time test in GitHub Actions, but removing the skip in Azure, which was a mistake. Skipping it in both here.