### PR TITLE
CI: Calling generic and base backend tests

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -3,7 +3,7 @@
 # - PYTEST_BACKENDS: Space-separated list of backends to run
 # - PYTEST_EXPRESSION: Marker expression, for example "not udf"
 
-TESTS_DIRS="ibis/tests"
+TESTS_DIRS="ibis/tests ibis/backends/tests ibis/backends/base*/tests"
 for BACKEND in $PYTEST_BACKENDS; do
     if [[ -d ibis/backends/$BACKEND/tests ]]; then
         TESTS_DIRS="$TESTS_DIRS ibis/backends/$BACKEND/tests"


### PR DESCRIPTION
Closes #2572 

After #2566 generic backend tests are not being called. Also, I think we should also call the base backend tests, since the base backends will be packaged with ibis and should always work, not matter which backends are installed.