### PR TITLE
CI: Unpin sphinx version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -58,7 +58,7 @@ dependencies:
   - nomkl
   - pyarrow>=0.12 # must pin again otherwise strange things happen
   - semantic_version=2.6 # https://github.com/ibis-project/ibis/issues/2027
-  - sphinx>=2.0.1, <=3.3.1
+  - sphinx>=2.0.1
   - sphinx-releases
   - sphinx_rtd_theme>=0.5
   - pip


### PR DESCRIPTION
Closes #2580 

[Sphinx 3.4.1 was released](https://github.com/sphinx-doc/sphinx/milestone/95?closed=1), which includes the fix to the issue that the Ibis docs CI was having