### PR TITLE
CI: Fix failing tests related to graphviz

### DIFF
--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -62,3 +62,5 @@ if [[ -n "$BACKENDS" ]]; then
         fi
     done
 fi
+
+conda list

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   # TODO This section is probably not very accurate right now (some dependencies should probably be in the backends files)
   - sqlalchemy>=1.3
   - dask>=2.22.0
-  - graphviz>=2.38 #
+  - graphviz>=2.42
   - openjdk=8
   - pytables>=3.6
   - python-graphviz>=0.14

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   # TODO This section is probably not very accurate right now (some dependencies should probably be in the backends files)
   - sqlalchemy>=1.3
   - dask>=2.22.0
-  - graphviz>=2.38
+  - graphviz>=2.38 #
   - openjdk=8
   - pytables>=3.6
   - python-graphviz>=0.14

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - graphviz>=2.38
   - openjdk=8
   - pytables>=3.6
-  - python-graphviz>=0.14, <=0.15
+  - python-graphviz>=0.14
   - python-hdfs>=2.0.16 # XXX this verison can probably be increased
 
   # Dev tools

--- a/environment.yml
+++ b/environment.yml
@@ -15,10 +15,10 @@ dependencies:
   # TODO This section is probably not very accurate right now (some dependencies should probably be in the backends files)
   - sqlalchemy>=1.3
   - dask>=2.22.0
-  - graphviz>=2.42
+  - graphviz>=2.38
   - openjdk=8
   - pytables>=3.6
-  - python-graphviz>=0.14
+  - python-graphviz>=0.14, <=0.15
   - python-hdfs>=2.0.16 # XXX this verison can probably be increased
 
   # Dev tools

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - graphviz>=2.38
   - openjdk=8
   - pytables>=3.6
-  - python-graphviz>=0.14
+  - python-graphviz>=0.14, <=0.15
   - python-hdfs>=2.0.16 # XXX this verison can probably be increased
 
   # Dev tools

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -70,8 +70,9 @@ with suppress(ImportError):
     # pip install ibis-framework[bigquery]
     from ibis.backends import bigquery  # noqa: F401
 
-# pip install ibis-framework[omniscidb]
-from ibis.backends import omniscidb  # noqa: F401, E402
+with suppress(ImportError):
+    # pip install ibis-framework[omniscidb]
+    from ibis.backends import omniscidb  # noqa: F401
 
 with suppress(ImportError):
     # pip install ibis-framework[spark]

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -70,9 +70,8 @@ with suppress(ImportError):
     # pip install ibis-framework[bigquery]
     from ibis.backends import bigquery  # noqa: F401
 
-with suppress(ImportError):
-    # pip install ibis-framework[omniscidb]
-    from ibis.backends import omniscidb  # noqa: F401
+# pip install ibis-framework[omniscidb]
+from ibis.backends import omniscidb  # noqa: F401, E402
 
 with suppress(ImportError):
     # pip install ibis-framework[spark]


### PR DESCRIPTION
In #2582, these tests are failing:
```
FAILED ibis/tests/expr/test_interactive.py::TestInteractiveUse::test_repr_png_is_not_none_in_not_interactive
FAILED ibis/tests/expr/test_visualize.py::test_optional_graphviz_repr - Asser...
FAILED ibis/tests/expr/test_visualize.py::test_html_escape - assert None is n...
= 3 failed, 4357 passed, 452 skipped, 229 xfailed, 1 xpassed, 116 warnings in 252.71s (0:04:12)
```
in these CI jobs:
* Tests pandas / files (windows-latest, 3.7)
* Tests pandas / files (windows-latest, 3.8)
* Tests dask (windows-latest, 3.7)
* Tests dask (windows-latest, 3.8)

In this PR, starting off with no changes to confirm that the tests still fail on a clean slate