### PR TITLE
DOC: fix simple typo, valudators -> validators

### DIFF
--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -103,7 +103,7 @@ def one_of(inners, arg):
 
 @validator
 def all_of(inners, arg):
-    """All of the inner valudators must pass.
+    """All of the inner validators must pass.
 
     The order of inner validators matters.
 


### PR DESCRIPTION
There is a small typo in ibis/expr/rules.py.

Should read `validators` rather than `valudators`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md