### PR TITLE
[FEAT] Cache hash of expression

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2587` Add caching for Expr.__hash__
 * :bug:`2577` Make StructValue picklable
 * :support:`2505` Remove deprecated `ibis.HDFS`, `ibis.WebHDFS` and `ibis.hdfs_connect`
 * :feature:`2514` Add Struct.from_dict

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 class Expr:
     """Base expression class"""
 
+    __slots__ = ['_hash']
+
     def _type_display(self):
         return type(self).__name__
 
@@ -46,7 +48,9 @@ class Expr:
             return repr(result)
 
     def __hash__(self):
-        return hash(self._key)
+        if not hasattr(self, '_hash'):
+            self._hash = hash(self._key)
+        return self._hash
 
     def __bool__(self):
         raise ValueError(


### PR DESCRIPTION
### Proposed Change

Add caching to `Expr.__hash__`

The code is similar to what is done for Node classes: 

https://github.com/ibis-project/ibis/blob/master/ibis/expr/operations.py#L79

### Motivation
Expr hash is used for look up str presentation memo in formatter: https://github.com/ibis-project/ibis/blob/master/ibis/expr/format.py#L40

By caching the hash of expr, it significantly improves the performance of `str(expr)`.

