### PR TITLE
Adding skeleton for new backends API (Backend class)

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -11,6 +11,7 @@ class BaseBackend(abc.ABC):
     All Ibis backends are expected to subclass this `Backend` class,
     and implement all the required methods.
     """
+
     def __init__(self, connection_string):
         self.connection_string = connection_string
 

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -1,0 +1,71 @@
+import abc
+
+import ibis.config
+from ibis.common.exceptions import TranslationError
+
+
+class BaseBackend(abc.ABC):
+    """
+    Base backend class.
+
+    All Ibis backends are expected to subclass this `Backend` class,
+    and implement all the required methods.
+    """
+    def __init__(self, connection_string):
+        self.connection_string = connection_string
+
+        with ibis.config.config_prefix(self.name):
+            self.register_options()
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """
+        Name of the backend, for example 'sqlite'.
+        """
+        pass
+
+    @property
+    @abc.abstractmethod
+    def builder(self):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def dialect(self):
+        pass
+
+    @abc.abstractmethod
+    def connect(connection_string, **options):
+        """
+        Connect to the underlying database and return a client object.
+        """
+        pass
+
+    def register_options(self):
+        """
+        If the backend has custom options, register them here.
+        They will be prefixed with the name of the backend.
+        """
+        pass
+
+    def compile(self, expr, params=None):
+        """
+        Compile the expression.
+        """
+        context = self.dialect.make_context(params=params)
+        builder = self.builder(expr, context=context)
+        query_ast = builder.get_result()
+        # TODO bigquery doesn't use [0]
+        compiled = query_ast[0].compile()
+        return compiled
+
+    def verify(self, expr, params=None):
+        """
+        Verify `expr` is an expression that can be compiled.
+        """
+        try:
+            self.compile(expr, params=params)
+            return True
+        except TranslationError:
+            return False

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -6,9 +6,9 @@ import google.auth.credentials
 import google.cloud.bigquery  # noqa: F401, fail early if bigquery is missing
 import pydata_google_auth
 
-from ibis.backends.base import BaseBackend
 import ibis.common.exceptions as com
 import ibis.config
+from ibis.backends.base import BaseBackend
 from ibis.config import options  # noqa: F401
 
 from .client import BigQueryClient

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -6,6 +6,7 @@ import google.auth.credentials
 import google.cloud.bigquery  # noqa: F401, fail early if bigquery is missing
 import pydata_google_auth
 
+from ibis.backends.base import BaseBackend
 import ibis.common.exceptions as com
 import ibis.config
 from ibis.config import options  # noqa: F401
@@ -100,3 +101,10 @@ def connect(
         credentials=credentials,
         application_name=application_name,
     )
+
+
+class Backend(BaseBackend):
+    name = 'bigquery'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -1,7 +1,7 @@
 import ibis.common.exceptions as com
 import ibis.config
-from ibis.config import options
 from ibis.backends.base import BaseBackend
+from ibis.config import options
 
 from .client import ClickhouseClient
 from .compiler import dialect

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -1,6 +1,7 @@
 import ibis.common.exceptions as com
 import ibis.config
 from ibis.config import options
+from ibis.backends.base import BaseBackend
 
 from .client import ClickhouseClient
 from .compiler import dialect
@@ -113,3 +114,10 @@ def connect(
         options.default_backend = client
 
     return client
+
+
+class Backend(BaseBackend):
+    name = 'clickhouse'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/csv/__init__.py
+++ b/ibis/backends/csv/__init__.py
@@ -4,6 +4,7 @@ from pkg_resources import parse_version
 
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
+from ibis.backends.base import BaseBackend
 from ibis.backends.base_file import FileClient
 from ibis.backends.pandas import PandasDialect
 from ibis.backends.pandas.core import execute, execute_node, pre_execute
@@ -131,3 +132,10 @@ def csv_pre_execute_selection(
         ops = ops.merge_scope(Scope({table: result}, timecontext))
 
     return ops
+
+
+class Backend(BaseBackend):
+    name = 'csv'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -6,6 +6,7 @@ import toolz
 from dask.dataframe import DataFrame
 
 import ibis.config
+from ibis.backends.base import BaseBackend
 from ibis.backends.base_sqlalchemy.compiler import Dialect
 from ibis.backends.pandas import _flatten_subclass_tree
 
@@ -83,3 +84,10 @@ class DaskDialect(Dialect):
 
 
 DaskClient.dialect = dialect = DaskDialect
+
+
+class Backend(BaseBackend):
+    name = 'dask'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/hdf5/__init__.py
+++ b/ibis/backends/hdf5/__init__.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
+from ibis.backends.base import BaseBackend
 from ibis.backends.base_file import FileClient
 from ibis.backends.pandas.core import execute, execute_node
 
@@ -75,3 +76,10 @@ def hdf_read_table(op, client, scope, **kwargs):
     path = client.dictionary[key]
     df = pd.read_hdf(str(path), key, mode='r')
     return df
+
+
+class Backend(BaseBackend):
+    name = 'hdf5'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -2,6 +2,7 @@
 import ibis.common.exceptions as com
 import ibis.config
 from ibis.config import options
+from ibis.backends.base import BaseBackend
 
 # these objects are exposed in the public API and are not used in the module
 from .client import (  # noqa: F401
@@ -142,3 +143,10 @@ def connect(
             options.default_backend = client
 
     return client
+
+
+class Backend(BaseBackend):
+    name = 'impala'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -1,8 +1,8 @@
 """Impala backend"""
 import ibis.common.exceptions as com
 import ibis.config
-from ibis.config import options
 from ibis.backends.base import BaseBackend
+from ibis.config import options
 
 # these objects are exposed in the public API and are not used in the module
 from .client import (  # noqa: F401

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -1,3 +1,4 @@
+from ibis.backends.base import BaseBackend
 from ibis.backends.base_sqlalchemy.alchemy import to_sqlalchemy
 
 from .client import MySQLClient
@@ -120,3 +121,10 @@ def connect(
         url=url,
         driver=driver,
     )
+
+
+class Backend(BaseBackend):
+    name = 'sqlite'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -124,7 +124,7 @@ def connect(
 
 
 class Backend(BaseBackend):
-    name = 'sqlite'
+    name = 'mysql'
     buider = None
     dialect = None
     connect = connect

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import toolz
 
 import ibis.config
+from ibis.backends.base import BaseBackend
 from ibis.backends.base_sqlalchemy.compiler import Dialect
 
 from .client import PandasClient
@@ -94,3 +95,10 @@ class PandasDialect(Dialect):
 
 
 PandasClient.dialect = dialect = PandasDialect
+
+
+class Backend(BaseBackend):
+    name = 'pandas'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/parquet/__init__.py
+++ b/ibis/backends/parquet/__init__.py
@@ -9,6 +9,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+from ibis.backends.base import BaseBackend
 from ibis.backends.base_file import FileClient
 from ibis.backends.pandas import PandasDialect
 from ibis.backends.pandas.core import execute, execute_node
@@ -116,3 +117,10 @@ def parquet_read_table(op, client, scope, **kwargs):
     table = pq.read_table(str(path))
     df = table.to_pandas()
     return df
+
+
+class Backend(BaseBackend):
+    name = 'parquet'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -1,4 +1,5 @@
 """PostgreSQL backend."""
+from ibis.backends.base import BaseBackend
 from ibis.backends.base_sqlalchemy.alchemy import to_sqlalchemy
 
 from .client import PostgreSQLClient
@@ -122,3 +123,10 @@ def connect(
         url=url,
         driver=driver,
     )
+
+
+class Backend(BaseBackend):
+    name = 'postgres'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1,3 +1,5 @@
+from ibis.backends.base import BaseBackend
+
 from .client import PySparkClient
 from .compiler import dialect  # noqa: F401
 
@@ -19,3 +21,10 @@ def connect(session):
     client._session.conf.set('spark.sql.session.timeZone', 'UTC')
 
     return client
+
+
+class Backend(BaseBackend):
+    name = 'pyspark'
+    buider = None
+    dialect = None  # noqa: F811
+    connect = connect

--- a/ibis/backends/spark/__init__.py
+++ b/ibis/backends/spark/__init__.py
@@ -1,5 +1,6 @@
 """Spark backend."""
 import ibis.common.exceptions as com
+from ibis.backends.base import BaseBackend
 
 from .client import SparkClient
 from .compiler import dialect  # noqa: F401
@@ -47,3 +48,10 @@ def connect(spark_session):
     client._session.conf.set('spark.sql.session.timeZone', 'UTC')
 
     return client
+
+
+class Backend(BaseBackend):
+    name = 'spark'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -14,6 +14,7 @@
 
 
 from ibis.backends.base import BaseBackend
+
 from .client import SQLiteClient
 from .compiler import dialect, rewrites  # noqa: F401
 

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from ibis.backends.base import BaseBackend
 from .client import SQLiteClient
 from .compiler import dialect, rewrites  # noqa: F401
 
@@ -43,3 +44,10 @@ def connect(path=None, create=False):
     """
 
     return SQLiteClient(path, create=create)
+
+
+class Backend(BaseBackend):
+    name = 'sqlite'
+    buider = None
+    dialect = None
+    connect = connect

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -1,0 +1,4 @@
+
+
+def test_backend_name(backend):
+    assert backend.api.Backend.name == backend.name()

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -1,4 +1,2 @@
-
-
 def test_backend_name(backend):
     assert backend.api.Backend.name == backend.name()


### PR DESCRIPTION
At the moment, the API between Ibis and a backend is defined by whatever it's defined in `ibis/backends/<backend>/__init__.py`. Here, I start to change that to use a subclass of a base backend class. The main advantages are:

- The API now it's not explicit, since the abstract base class forces which methods must be implemented (for example, currently some backends have a `verify` method, and some others don't, and there is no consistency, and it's not clear what's the expected API and what's not)
- A lot of repetitive code among backends can be moved to the base class

A first draft of how things can look like has been built in #2550. That PR looks a great potential for simplifying things, besides the standardization, it deletes 500 lines of repetitive code, and the PR is not yet finished. Since that PR is huge, I'm going to implement things step by step, so we can build iteratively and make reviews easier and more meaningful.

This first PR simply creates the skeleton of what the backend classes will be. No code is removed, so the API is not changed yet. 