### PR TITLE
ENH: Grouping operations in the dask backend

### DIFF
--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -50,7 +50,6 @@ def execute_array_collect(op, data, aggcontext=None, **kwargs):
     return aggcontext.agg(data, collect_list)
 
 
-# TODO - grouping - #2553
 @execute_node.register(ops.ArrayCollect, ddgb.SeriesGroupBy)
 def execute_array_collect_grouped_series(op, data, aggcontext=None, **kwargs):
     return data.agg(collect_list)

--- a/ibis/backends/dask/execution/numeric.py
+++ b/ibis/backends/dask/execution/numeric.py
@@ -12,6 +12,8 @@ import ibis.expr.operations as ops
 from ibis.backends.pandas.core import numeric_types
 from ibis.backends.pandas.execution.generic import execute_node
 
+from .util import make_selected_obj
+
 
 # TODO - aggregations - #2553
 @execute_node.register(ops.Arbitrary, ddgb.SeriesGroupBy, type(None))
@@ -32,12 +34,11 @@ def execute_series_negate(op, data, **kwargs):
     return data.mul(-1)
 
 
-# TODO - grouping - #2553
 @execute_node.register(ops.Negate, ddgb.SeriesGroupBy)
 def execute_series_group_by_negate(op, data, **kwargs):
-    return execute_series_negate(op, data.obj, **kwargs).groupby(
-        data.grouper.groupings
-    )
+    return execute_series_negate(
+        op, make_selected_obj(data), **kwargs
+    ).groupby(data.index)
 
 
 def call_numpy_ufunc(func, op, data, **kwargs):

--- a/ibis/backends/dask/execution/reductions.py
+++ b/ibis/backends/dask/execution/reductions.py
@@ -85,7 +85,7 @@ def _filtered_reduction(mask, method, data):
     return method(data[mask[data.index]])
 
 
-# TODO - grouping - #2553
+# TODO - aggregations - #2553
 @execute_node.register(ops.Reduction, ddgb.SeriesGroupBy, ddgb.SeriesGroupBy)
 def execute_reduction_series_gb_mask(
     op, data, mask, aggcontext=None, **kwargs
@@ -149,7 +149,7 @@ def execute_reduction_series_groupby_var(
     return aggcontext.agg(data, 'var', ddof=variance_ddof[op.how])
 
 
-# TODO - grouping - #2553
+# TODO - aggregations - #2553
 @execute_node.register(ops.Variance, ddgb.SeriesGroupBy, ddgb.SeriesGroupBy)
 def execute_var_series_groupby_mask(op, data, mask, aggcontext=None, **kwargs):
     return aggcontext.agg(
@@ -178,7 +178,7 @@ def execute_reduction_series_groupby_std(
     return aggcontext.agg(data, 'std', ddof=variance_ddof[op.how])
 
 
-# TODO - grouping - #2553
+# TODO - aggregations - #2553
 @execute_node.register(ops.StandardDev, ddgb.SeriesGroupBy, ddgb.SeriesGroupBy)
 def execute_std_series_groupby_mask(op, data, mask, aggcontext=None, **kwargs):
     return aggcontext.agg(

--- a/ibis/backends/dask/execution/structs.py
+++ b/ibis/backends/dask/execution/structs.py
@@ -8,6 +8,8 @@ import dask.dataframe.groupby as ddgb
 import ibis.expr.operations as ops
 from ibis.backends.pandas.execution.structs import execute_node
 
+from .util import make_selected_obj
+
 
 @execute_node.register(ops.StructField, dd.Series)
 def execute_node_struct_field_series(op, data, **kwargs):
@@ -18,12 +20,12 @@ def execute_node_struct_field_series(op, data, **kwargs):
     ).rename(field)
 
 
-# TODO - grouping - #2553
 @execute_node.register(ops.StructField, ddgb.SeriesGroupBy)
 def execute_node_struct_field_series_group_by(op, data, **kwargs):
     field = op.field
+    selected_obj = make_selected_obj(data)
     return (
-        data.obj.map(operator.itemgetter(field))
+        selected_obj.map(operator.itemgetter(field), meta=selected_obj._meta)
         .rename(field)
-        .groupby(data.grouper.groupings)
+        .groupby(data.index)
     )

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -1,5 +1,8 @@
 from typing import Callable, Dict, List, Tuple, Type
 
+import dask.dataframe as dd
+from dask.dataframe.groupby import SeriesGroupBy
+
 import ibis.expr.operations as ops
 from ibis.backends.pandas.trace import TraceTwoLevelDispatcher
 
@@ -18,3 +21,19 @@ def register_types_to_dispatcher(
     for ibis_op, registration_list in types.items():
         for types_to_register, fn in registration_list:
             dispatcher.register(ibis_op, *types_to_register)(fn)
+
+
+def make_selected_obj(gs: SeriesGroupBy):
+    """
+    When you select a column from a `pandas.DataFrameGroupBy` the underlying
+    `.obj` reflects that selection. This function emulates that behavior.
+    """
+    # TODO profile this for data shuffling
+    # We specify drop=False in the case that we are grouping on the column
+    # we are selecting
+    if isinstance(gs.obj, dd.Series):
+        return gs.obj
+    else:
+        return gs.obj.set_index(gs.index, drop=False)[
+            gs._meta._selected_obj.name
+        ]

--- a/ibis/backends/dask/tests/execution/test_strings.py
+++ b/ibis/backends/dask/tests/execution/test_strings.py
@@ -18,17 +18,24 @@ pytestmark = pytest.mark.dask
         param(lambda s: s.substr(1, 2), lambda s: s.str[1:3], id='substr'),
         param(lambda s: s[1:3], lambda s: s.str[1:3], id='slice'),
         # TODO - execute_substring_series_series is broken
-        # param(
-        #     lambda s: s[s.length() - 1 :],
-        #     lambda s: s.str[-1:],
-        #     id='expr_slice_begin',
-        # ),
-        # param(lambda s: s[: s.length()], lambda s: s, id='expr_slice_end'),
-        # param(
-        #     lambda s: s[s.length() - 2 : s.length() - 1],
-        #     lambda s: s.str[-2:-1],
-        #     id='expr_slice_begin_end',
-        # ),
+        param(
+            lambda s: s[s.length() - 1 :],
+            lambda s: s.str[-1:],
+            id='expr_slice_begin',
+            marks=pytest.mark.xfail,
+        ),
+        param(
+            lambda s: s[: s.length()],
+            lambda s: s,
+            id='expr_slice_end',
+            marks=pytest.mark.xfail,
+        ),
+        param(
+            lambda s: s[s.length() - 2 : s.length() - 1],
+            lambda s: s.str[-2:-1],
+            id='expr_slice_begin_end',
+            marks=pytest.mark.xfail,
+        ),
         param(lambda s: s.strip(), lambda s: s.str.strip(), id='strip'),
         param(lambda s: s.lstrip(), lambda s: s.str.lstrip(), id='lstrip'),
         param(lambda s: s.rstrip(), lambda s: s.str.rstrip(), id='rstrip'),
@@ -99,3 +106,21 @@ def test_string_ops(t, df, case_func, expected_func):
         result = expr.execute()
         series = expected_func(df.strings_with_space)
         tm.assert_series_equal(result.compute(), series.compute())
+
+
+def test_grouped_string_re_search(t, df):
+    expr = t.groupby(t.dup_strings).aggregate(
+        sum=t.strings_with_space.re_search('(ab)+').cast('int64').sum()
+    )
+
+    result = expr.execute()
+    expected = (
+        df.groupby('dup_strings')
+        .strings_with_space.apply(
+            lambda s: s.str.contains('(ab)+', regex=True).sum()
+        )
+        .reset_index()
+        .rename(columns={'strings_with_space': 'sum'})
+    )
+
+    tm.assert_frame_equal(result.compute(), expected.compute())

--- a/ibis/backends/dask/tests/execution/test_structs.py
+++ b/ibis/backends/dask/tests/execution/test_structs.py
@@ -83,7 +83,6 @@ def test_struct_field_series_group_by_key(struct_table):
     tm.assert_frame_equal(result.compute(), expected.compute())
 
 
-@pytest.mark.xfail(reason="TODO - grouping - #2553")
 def test_struct_field_series_group_by_value(struct_table):
     t = struct_table
     expr = t.groupby(t.key).aggregate(total=t.s['weight'].sum())

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -460,7 +460,7 @@ def test_day_of_week_column(backend, con, alltypes, df):
         ),
     ],
 )
-# TODO - grouping - #2553
+# TODO - pandas - #2553
 @pytest.mark.xfail_backends(['dask'])
 @pytest.mark.xfail_unsupported
 def test_day_of_week_column_group_by(


### PR DESCRIPTION
This PR adds more complicated grouping operations to the dask backend. Previously simple operations worked, but more complicated operations failed. See changes in `test_operations` for examples. 

I'm a bit concerned about potential performance issues in `_make_selection_obj` but I figure those can be fixed separately from the base functionality working. 

Aggregation/aggcontext is fairly intertwined with grouping. I _think_ it makes sense to do that as a separate PR, but I'm going to tackle that next anyway, so happy to do it as part of this one. 

TODOs

- [x] Update the tracker in https://github.com/ibis-project/ibis/issues/2553