### PR TITLE
[ENH] Dask backend aggregations

### DIFF
--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -176,6 +176,8 @@ def execute_and_reset(
         aggcontext=aggcontext,
         **kwargs,
     )
+    # Note - if `result` has npartitions > 1 `reset_index` will not create
+    # a monotonically increasing index.
     if isinstance(result, dd.DataFrame):
         schema = expr.schema()
         df = result.reset_index()

--- a/ibis/backends/dask/execution/numeric.py
+++ b/ibis/backends/dask/execution/numeric.py
@@ -7,26 +7,11 @@ import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
 import numpy as np
 
-import ibis.common.exceptions as com
 import ibis.expr.operations as ops
 from ibis.backends.pandas.core import numeric_types
 from ibis.backends.pandas.execution.generic import execute_node
 
 from .util import make_selected_obj
-
-
-# TODO - aggregations - #2553
-@execute_node.register(ops.Arbitrary, ddgb.SeriesGroupBy, type(None))
-def execute_arbitrary_series_groupby(op, data, _, aggcontext=None, **kwargs):
-    how = op.how
-    if how is None:
-        how = 'first'
-
-    if how not in {'first', 'last'}:
-        raise com.OperationNotDefinedError(
-            'Arbitrary {!r} is not supported'.format(how)
-        )
-    return aggcontext.agg(data, how)
 
 
 @execute_node.register(ops.Negate, dd.Series)

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -1,10 +1,12 @@
-from typing import Callable, Dict, List, Tuple, Type
+from typing import Any, Callable, Dict, List, Tuple, Type, Union
 
 import dask.dataframe as dd
+import pandas as pd
 from dask.dataframe.groupby import SeriesGroupBy
 
 import ibis.expr.operations as ops
 from ibis.backends.pandas.trace import TraceTwoLevelDispatcher
+from ibis.expr import types as ir
 
 DispatchRule = Tuple[Tuple[Type], Callable]
 
@@ -37,3 +39,54 @@ def make_selected_obj(gs: SeriesGroupBy):
         return gs.obj.set_index(gs.index, drop=False)[
             gs._meta._selected_obj.name
         ]
+
+
+def maybe_wrap_scalar(result: Any, expr: ir.Expr) -> Any:
+    """
+    A partial implementation of `coerce_to_output` in the pandas backend.
+
+    Currently only wraps scalars, but will change when udfs are added to the
+    dask backend.
+    """
+    result_name = expr.get_name()
+    if isinstance(result, dd.core.Scalar) and isinstance(
+        expr.op(), ops.Reduction
+    ):
+        # TODO - computation
+        return dd.from_pandas(
+            pd.Series(result.compute(), name=result_name), npartitions=1
+        )
+    else:
+        return result.rename(result_name)
+
+
+def safe_concat(dfs: List[Union[dd.Series, dd.DataFrame]]) -> dd.DataFrame:
+    """
+    Concat a list of `dd.Series` or `dd.DataFrame` objects into one DataFrame
+
+    This will use `DataFrame.concat` if all pieces are the same length.
+    Otherwise we will iterratively join.
+
+    When axis=1 and divisions are unknown, Dask `DataFrame.concat` can only
+    operate on objects with equal lengths, otherwise it will raise a
+    ValueError in `concat_and_check`.
+
+    See https://github.com/dask/dask/blob/2c2e837674895cafdb0612be81250ef2657d947e/dask/dataframe/multi.py#L907 # noqa
+
+    Note - this is likely to be quite slow, but this should be hit rarely in
+    real usage. A situtation that triggeres this slow path is aggregations
+    where aggregations return different numbers of rows (see
+    `test_aggregation_group_by` for a specific example).
+
+    TODO - performance.
+    """
+    lengths = list(map(len, dfs))
+    if len(set(lengths)) != 1:
+        result = dfs[0].to_frame()
+
+        for other in dfs[1:]:
+            result = result.join(other.to_frame(), how="outer")
+    else:
+        result = dd.concat(dfs, axis=1)
+
+    return result

--- a/ibis/backends/dask/tests/execution/conftest.py
+++ b/ibis/backends/dask/tests/execution/conftest.py
@@ -13,7 +13,7 @@ from ... import connect
 
 
 @pytest.fixture(scope='module')
-def df():
+def df(npartitions):
     pandas_df = pd.DataFrame(
         {
             'plain_int64': list(range(1, 4)),
@@ -71,7 +71,7 @@ def df():
             'map_of_complex_values': [None, {'a': [1, 2, 3], 'b': []}, {}],
         }
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 @pytest.fixture(scope='module')
@@ -103,47 +103,47 @@ def awards_players_df():
 
 
 @pytest.fixture(scope='module')
-def df1():
+def df1(npartitions):
     pandas_df = pd.DataFrame(
         {'key': list('abcd'), 'value': [3, 4, 5, 6], 'key2': list('eeff')}
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 @pytest.fixture(scope='module')
-def df2():
+def df2(npartitions):
     pandas_df = pd.DataFrame(
         {'key': list('ac'), 'other_value': [4.0, 6.0], 'key3': list('fe')}
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 @pytest.fixture(scope='module')
-def intersect_df2():
+def intersect_df2(npartitions):
     pandas_df = pd.DataFrame(
         {'key': list('cd'), 'value': [5, 6], 'key2': list('ff')}
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 @pytest.fixture(scope='module')
-def time_df1():
+def time_df1(npartitions):
     pandas_df = pd.DataFrame(
         {'time': pd.to_datetime([1, 2, 3, 4]), 'value': [1.1, 2.2, 3.3, 4.4]}
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 @pytest.fixture(scope='module')
-def time_df2():
+def time_df2(npartitions):
     pandas_df = pd.DataFrame(
         {'time': pd.to_datetime([2, 4]), 'other_value': [1.2, 2.0]}
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 @pytest.fixture(scope='module')
-def time_df3():
+def time_df3(npartitions):
     pandas_df = pd.DataFrame(
         {
             'time': pd.Series(
@@ -155,11 +155,11 @@ def time_df3():
             'value': [1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8],
         }
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 @pytest.fixture(scope='module')
-def time_keyed_df1():
+def time_keyed_df1(npartitions):
     pandas_df = pd.DataFrame(
         {
             'time': pd.Series(
@@ -171,11 +171,11 @@ def time_keyed_df1():
             'value': [1.2, 1.4, 2.0, 4.0, 8.0, 16.0],
         }
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 @pytest.fixture(scope='module')
-def time_keyed_df2():
+def time_keyed_df2(npartitions):
     pandas_df = pd.DataFrame(
         {
             'time': pd.Series(
@@ -187,7 +187,7 @@ def time_keyed_df2():
             'other_value': [1.1, 1.2, 2.2],
         }
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 @pytest.fixture(scope='module')
@@ -222,7 +222,7 @@ def client(
 
 
 @pytest.fixture(scope='module')
-def df3():
+def df3(npartitions):
     pandas_df = pd.DataFrame(
         {
             'key': list('ac'),
@@ -231,7 +231,7 @@ def df3():
             'key3': list('fe'),
         }
     )
-    return dd.from_pandas(pandas_df, npartitions=1)
+    return dd.from_pandas(pandas_df, npartitions=npartitions)
 
 
 t_schema = {

--- a/ibis/backends/dask/tests/execution/test_join.py
+++ b/ibis/backends/dask/tests/execution/test_join.py
@@ -435,12 +435,14 @@ def test_keyed_asof_join_with_tolerance(
     raises=(com.IbisError, AttributeError),
     reason="Select from unambiguous joins not implemented",
 )
-def test_select_on_unambiguous_join(how, func):
+def test_select_on_unambiguous_join(how, func, npartitions):
     df_t = dd.from_pandas(
-        pd.DataFrame(dict(a0=[1, 2, 3], b1=list("aab"))), npartitions=1,
+        pd.DataFrame(dict(a0=[1, 2, 3], b1=list("aab"))),
+        npartitions=npartitions,
     )
     df_s = dd.from_pandas(
-        pd.DataFrame(dict(a1=[2, 3, 4], b2=list("abc"))), npartitions=1,
+        pd.DataFrame(dict(a1=[2, 3, 4], b2=list("abc"))),
+        npartitions=npartitions,
     )
     con = connect({"t": df_t, "s": df_s})
     t = con.table("t")
@@ -472,14 +474,14 @@ def test_select_on_unambiguous_join(how, func):
     reason="Select from unambiguous joins not implemented",
 )
 @merge_asof_minversion
-def test_select_on_unambiguous_asof_join(func):
+def test_select_on_unambiguous_asof_join(func, npartitions):
     df_t = dd.from_pandas(
         pd.DataFrame(dict(a0=[1, 2, 3], b1=date_range("20180101", periods=3))),
-        npartitions=1,
+        npartitions=npartitions,
     )
     df_s = dd.from_pandas(
         pd.DataFrame(dict(a1=[2, 3, 4], b2=date_range("20171230", periods=3))),
-        npartitions=1,
+        npartitions=npartitions,
     )
     con = connect({"t": df_t, "s": df_s})
     t = con.table("t")

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -88,12 +88,8 @@ def test_project_scope_does_not_override(t, df):
     'where',
     [
         lambda t: None,
-        # TODO - aggregations - #2553
-        pytest.param(lambda t: t.dup_strings == 'd', marks=pytest.mark.xfail),
-        pytest.param(
-            lambda t: (t.dup_strings == 'd') | (t.plain_int64 < 100),
-            marks=pytest.mark.xfail,
-        ),
+        lambda t: t.dup_strings == 'd',
+        lambda t: (t.dup_strings == 'd') | (t.plain_int64 < 100),
     ],
 )
 @pytest.mark.parametrize(
@@ -128,7 +124,7 @@ def test_aggregation_group_by(t, df, where, ibis_func, dask_func):
     )
     result = expr.execute()
 
-    dask_where = where(df)
+    dask_where = where(df.compute())
     mask = slice(None) if dask_where is None else dask_where
     expected = (
         df.compute()
@@ -136,7 +132,8 @@ def test_aggregation_group_by(t, df, where, ibis_func, dask_func):
         .agg(
             {
                 'plain_int64': lambda x, mask=mask: x[mask].mean(),
-                'plain_float64': lambda x, mask=mask: x[mask].sum(),
+                # Note we force min count here to match dask behavior
+                'plain_float64': lambda x, mask=mask: x[mask].sum(min_count=1),
                 'dup_ints': 'nunique',
                 'float64_positive': (
                     lambda x, mask=mask, func=dask_func: func(x[mask]).mean()
@@ -155,6 +152,9 @@ def test_aggregation_group_by(t, df, where, ibis_func, dask_func):
             }
         )
     )
+
+    result = result.compute()
+
     # TODO(phillipc): Why does pandas not return floating point values here?
     expected['avg_plain_int64'] = expected.avg_plain_int64.astype('float64')
     result['avg_plain_int64'] = result.avg_plain_int64.astype('float64')
@@ -170,12 +170,12 @@ def test_aggregation_group_by(t, df, where, ibis_func, dask_func):
     result['mean_float64_positive'] = result.mean_float64_positive.astype(
         'float64'
     )
-    lhs = result[expected.columns].compute()
+
+    lhs = result[expected.columns]
     rhs = expected
     tm.assert_frame_equal(lhs, rhs)
 
 
-@pytest.mark.xfail(reason="TODO - aggregations - #2553")
 def test_aggregation_without_group_by(t, df):
     expr = t.aggregate(
         avg_plain_int64=t.plain_int64.mean(),
@@ -186,17 +186,20 @@ def test_aggregation_without_group_by(t, df):
         'plain_float64': 'sum_plain_float64',
         'plain_int64': 'avg_plain_int64',
     }
+    pandas_df = df.compute()
     expected = (
-        dd.from_array(
-            [df['plain_int64'].mean(), df['plain_float64'].sum()],
+        pd.Series(
+            [
+                pandas_df['plain_int64'].mean(),
+                pandas_df['plain_float64'].sum(),
+            ],
             index=['plain_int64', 'plain_float64'],
         )
         .to_frame()
         .T.rename(columns=new_names)
     )
-    tm.assert_frame_equal(
-        result[expected.columns].compute(), expected.compute()
-    )
+    lhs = result[expected.columns].compute()
+    tm.assert_frame_equal(lhs, expected)
 
 
 def test_group_by_with_having(t, df):
@@ -264,7 +267,87 @@ def test_reduction(t, df, reduction, where):
     assert result.compute() == expected.compute()
 
 
-@pytest.mark.xfail(NotImplementedError, reason="TODO - aggregations - #2553")
+@pytest.mark.parametrize(
+    'where',
+    [
+        lambda t: (t.plain_strings == 'a') | (t.plain_strings == 'c'),
+        lambda t: None,
+    ],
+)
+def test_grouped_reduction(t, df, where):
+    ibis_where = where(t)
+    expr = t.group_by(t.dup_strings).aggregate(
+        nunique_dup_ints=t.dup_ints.nunique(),
+        sum_plain_int64=t.plain_int64.sum(where=ibis_where),
+        mean_plain_int64=t.plain_int64.mean(where=ibis_where),
+        count_plain_int64=t.plain_int64.count(where=ibis_where),
+        std_plain_int64=t.plain_int64.std(where=ibis_where),
+        var_plain_int64=t.plain_int64.var(where=ibis_where),
+        nunique_plain_int64=t.plain_int64.nunique(where=ibis_where),
+    )
+    result = expr.execute()
+
+    df_mask = where(df.compute())
+    mask = slice(None) if df_mask is None else df_mask
+
+    expected = (
+        df.compute()
+        .groupby('dup_strings')
+        .agg(
+            {
+                'dup_ints': "nunique",
+                "plain_int64": [
+                    lambda x, mask=mask: x[mask].sum(),
+                    lambda x, mask=mask: x[mask].mean(),
+                    lambda x, mask=mask: x[mask].count(),
+                    lambda x, mask=mask: x[mask].std(),
+                    lambda x, mask=mask: x[mask].var(),
+                    lambda x, mask=mask: x[mask].nunique(),
+                ],
+            }
+        )
+        .reset_index()
+    )
+    result = result.compute()
+
+    assert len(result.columns) == len(expected.columns)
+
+    expected.columns = [
+        "dup_strings",
+        "nunique_dup_ints",
+        "sum_plain_int64",
+        "mean_plain_int64",
+        "count_plain_int64",
+        "std_plain_int64",
+        "var_plain_int64",
+        "nunique_plain_int64",
+    ]
+    # guarentee ordering
+    result = result[expected.columns]
+    # dask and pandas differ slightly in how they treat groups with no entry
+    # we're not testing that so fillna here.
+    result = result.fillna(0.0)
+    expected = expected.fillna(0.0)
+
+    # match the dtypes
+    if df_mask is None:
+        expected["mean_plain_int64"] = expected.mean_plain_int64.astype(
+            "float64"
+        )
+    else:
+        expected["sum_plain_int64"] = expected.sum_plain_int64.astype(
+            "float64"
+        )
+        expected["count_plain_int64"] = expected.count_plain_int64.astype(
+            "float64"
+        )
+        expected["nunique_plain_int64"] = expected.nunique_plain_int64.astype(
+            "float64"
+        )
+
+    tm.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     'reduction',
     [
@@ -340,17 +423,21 @@ def test_nullif(t, df, left, right, expected, compare):
         compare(result, expected(df))
 
 
-def test_nullif_inf():
+def test_nullif_inf(npartitions):
     df = dd.from_pandas(
-        pd.DataFrame({'a': [np.inf, 3.14, -np.inf, 42.0]}), npartitions=1,
+        pd.DataFrame({'a': [np.inf, 3.14, -np.inf, 42.0]}),
+        npartitions=npartitions,
     )
     con = connect(dict(t=df))
     t = con.table('t')
     expr = t.a.nullif(np.inf).nullif(-np.inf)
     result = expr.execute()
     expected = dd.from_pandas(
-        pd.Series([np.nan, 3.14, np.nan, 42.0], name='a'), npartitions=1,
-    )
+        pd.Series([np.nan, 3.14, np.nan, 42.0], name='a'),
+        npartitions=npartitions,
+    ).reset_index(
+        drop=True
+    )  # match dask reset index behavior
     tm.assert_series_equal(result.compute(), expected.compute())
 
 
@@ -878,7 +965,12 @@ def test_union(client, df1, distinct):
     expected = (
         df1 if distinct else dd.concat([df1, df1], axis=0, ignore_index=True)
     )
-    tm.assert_frame_equal(result.compute(), expected.compute())
+
+    # match indicies because of dask reset_index behavior
+    result = result.compute().reset_index(drop=True)
+    expected = expected.compute().reset_index(drop=True)
+
+    tm.assert_frame_equal(result, expected)
 
 
 def test_intersect(client, df1, intersect_df2):
@@ -899,7 +991,12 @@ def test_difference(client, df1, intersect_df2):
         intersect_df2, on=list(df1.columns), how="outer", indicator=True
     )
     expected = merged[merged["_merge"] != "both"].drop("_merge", 1)
-    tm.assert_frame_equal(result.compute(), expected.compute())
+
+    # force same index
+    result = result.compute().reset_index(drop=True)
+    expected = expected.compute().reset_index(drop=True)
+
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/dask/tests/execution/test_structs.py
+++ b/ibis/backends/dask/tests/execution/test_structs.py
@@ -17,7 +17,7 @@ def value():
 
 
 @pytest.fixture(scope="module")
-def struct_client(value):
+def struct_client(value, npartitions):
     df = dd.from_pandas(
         pd.DataFrame(
             {
@@ -30,7 +30,7 @@ def struct_client(value):
                 "value": [1, 2, 3],
             }
         ),
-        npartitions=1,
+        npartitions=npartitions,
     )
     return connect({"t": df})
 

--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -14,21 +14,21 @@ from ..client import DaskTable
 pytestmark = pytest.mark.dask
 
 
-def make_dask_data_frame():
-    return dd.from_pandas(pandas_tm.makeDataFrame(), npartitions=1)
+def make_dask_data_frame(npartitions):
+    return dd.from_pandas(pandas_tm.makeDataFrame(), npartitions=npartitions)
 
 
 @pytest.fixture
-def client():
+def client(npartitions):
     return connect(
         {
             'df': dd.from_pandas(
                 pd.DataFrame({'a': [1, 2, 3], 'b': list('abc')}),
-                npartitions=1,
+                npartitions=npartitions,
             ),
             'df_unknown': dd.from_pandas(
                 pd.DataFrame({'array_of_strings': [['a', 'b'], [], ['c']]}),
-                npartitions=1,
+                npartitions=npartitions,
             ),
         }
     )
@@ -48,14 +48,14 @@ def test_client_table_repr(table):
     assert 'DaskTable' in repr(table)
 
 
-def test_load_data(client):
-    client.load_data('testing', make_dask_data_frame())
+def test_load_data(client, npartitions):
+    client.load_data('testing', make_dask_data_frame(npartitions))
     assert client.exists_table('testing')
     assert client.get_schema('testing')
 
 
-def test_create_table(client):
-    client.create_table('testing', obj=make_dask_data_frame())
+def test_create_table(client, npartitions):
+    client.create_table('testing', obj=make_dask_data_frame(npartitions))
     assert client.exists_table('testing')
     client.create_table('testingschema', schema=client.get_schema('testing'))
     assert client.exists_table('testingschema')

--- a/ibis/backends/dask/tests/test_schema.py
+++ b/ibis/backends/dask/tests/test_schema.py
@@ -11,7 +11,7 @@ from ibis.expr import schema as sch
 pytestmark = pytest.mark.dask
 
 
-def test_infer_exhaustive_dataframe():
+def test_infer_exhaustive_dataframe(npartitions):
     df = dd.from_pandas(
         pd.DataFrame(
             {
@@ -138,7 +138,7 @@ def test_infer_exhaustive_dataframe():
                 ],
             }
         ),
-        npartitions=1,
+        npartitions=npartitions,
     )
 
     expected = [
@@ -160,9 +160,9 @@ def test_infer_exhaustive_dataframe():
     assert sch.infer(df) == ibis.schema(expected)
 
 
-def test_apply_to_schema_with_timezone():
+def test_apply_to_schema_with_timezone(npartitions):
     data = {'time': pd.date_range('2018-01-01', '2018-01-02', freq='H')}
-    df = dd.from_pandas(pd.DataFrame(data), npartitions=1)
+    df = dd.from_pandas(pd.DataFrame(data), npartitions=npartitions)
     expected = df.assign(time=df.time.astype('datetime64[ns, EST]'))
     desired_schema = ibis.schema([('time', 'timestamp("EST")')])
     result = desired_schema.apply_to(df.copy())

--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -193,6 +193,13 @@ def df(alltypes):
 
 
 @pytest.fixture(scope='session')
+def pandas_df(backend, alltypes):
+    if backend.name() == "dask":
+        return alltypes.execute().compute()
+    return alltypes.execute()
+
+
+@pytest.fixture(scope='session')
 def sorted_df(backend, df):
     if backend.name() == 'dask':
         pytest.skip("# TODO - sorting - #2553")


### PR DESCRIPTION
This PR does a few things:

1. Enables aggregations in the backend and adds missing test coverage for grouped/masked reductions
2. Changes dask `conftest.py`  objects to return `DataFrame` objects with `npartitions=2` to make sure we are exercising multi partition behavior. 
3. Fixes bugs uncovered by the change in `(2)`. 
4. Refactors backend testing fixtures so we don't need `if backend.name() == "dask"` calls in `ibis/backends/tests/test_aggregation.py`. 


- [ ]  On approval/merge update https://github.com/ibis-project/ibis/issues/2553