### PR TITLE
Adds proper binary column translation for BigQuery compiler

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2354` Fixes binary data type translation into BigQuery bytes data type
 * :bug:`2577` Make StructValue picklable
 * :support:`2505` Remove deprecated `ibis.HDFS`, `ibis.WebHDFS` and `ibis.hdfs_connect`
 * :feature:`2514` Add Struct.from_dict

--- a/ibis/backends/bigquery/datatypes.py
+++ b/ibis/backends/bigquery/datatypes.py
@@ -49,6 +49,11 @@ def trans_integer(t, context):
     return 'INT64'
 
 
+@ibis_type_to_bigquery_type.register(dt.Binary, TypeTranslationContext)
+def trans_binary(t, context):
+    return 'BYTES'
+
+
 @ibis_type_to_bigquery_type.register(
     dt.UInt64, (TypeTranslationContext, UDFContext)
 )

--- a/ibis/backends/bigquery/tests/test_compiler.py
+++ b/ibis/backends/bigquery/tests/test_compiler.py
@@ -548,6 +548,16 @@ def test_now():
     assert result == expected
 
 
+def test_binary():
+    t = ibis.table([('value', 'double')], name='t')
+    expr = t["value"].cast(dt.binary).name("value_hash")
+    result = ibis.bigquery.compile(expr)
+    expected = """\
+SELECT CAST(`value` AS BYTES) AS `tmp`
+FROM t"""
+    assert result == expected
+
+
 def test_bucket():
     t = ibis.table([('value', 'double')], name='t')
     buckets = [0, 1, 3]


### PR DESCRIPTION
Fixes #2354

Added a unit test for verifying that the expected generated SQL string is generated.