### PR TITLE
ENH: Add check for dtype in trim_with_context for pandas backend

### DIFF
--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -7,6 +7,7 @@ from typing import Any, List, NoReturn, Optional
 
 import pandas as pd
 import toolz
+from pandas.core.dtypes.dtypes import DatetimeTZDtype
 from pandas.core.groupby import SeriesGroupBy
 
 import ibis.common.exceptions as com
@@ -183,7 +184,9 @@ def trim_with_timecontext(data, timecontext: Optional[TimeContext]):
     # Filter the data, here we preserve the time index so that when user is
     # computing a single column, the computation and the relevant time
     # indexes are retturned.
-    if TIME_COL not in df:
+    if TIME_COL not in df or not isinstance(
+        df[TIME_COL].dtype, DatetimeTZDtype
+    ):
         return data
     subset = df.loc[df[TIME_COL].between(*timecontext)]
 


### PR DESCRIPTION
Overview
=======
This PR improves the edge case checks in ``trim_with_context``.
Series that doesn't contain a ``TIME_COL``, or``TIME_COL`` is not of a ``DatetimeTZDtype``,  should not be trimmed, since trimming with context requires a time index of Timestamp type in the series to proceed.  Series that failed this test could be some intermediate results of UDFs, and is out of the scope for ``trim_with_context``, so it should return with nothing changed.

How is this tested
=======
Tests are already included in test_timecontext.py for pandas backend.