### PR TITLE
ENH: Add support for np.array literals

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2603` Add support for np.array as literals for backends that already support lists as literals
 * :bug:`2354` Fixes binary data type translation into BigQuery bytes data type
 * :bug:`2577` Make StructValue picklable
 * :support:`2505` Remove deprecated `ibis.HDFS`, `ibis.WebHDFS` and `ibis.hdfs_connect`

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -12,6 +12,8 @@ class TestConf(BackendTest, RoundHalfToEven):
     check_dtype = False
     supports_window_operations = False
     returned_timestamp_unit = 's'
+    supports_arrays = False
+    supports_arrays_outside_of_select = supports_arrays
 
     def __init__(self, data_directory: Path) -> None:
         super().__init__(data_directory)

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -6,6 +6,7 @@ import re
 import string
 import warnings
 
+import numpy as np
 import sqlalchemy as sa
 import sqlalchemy.dialects.postgresql as pg
 from sqlalchemy.ext.compiler import compiles
@@ -606,6 +607,8 @@ def _literal(t, expr):
     elif isinstance(expr, ir.GeoSpatialScalar):
         # inline_metadata ex: 'SRID=4326;POINT( ... )'
         return sa.text(geo.translate_literal(expr, inline_metadata=True))
+    elif isinstance(value, np.ndarray):
+        return sa.literal(value.tolist())
     else:
         return sa.literal(value)
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -3,6 +3,7 @@ import enum
 import functools
 import operator
 
+import numpy as np
 import pyspark.sql.functions as F
 from pyspark.sql import Window
 from pyspark.sql.functions import PandasUDFType, pandas_udf
@@ -324,8 +325,12 @@ def compile_literal(t, expr, scope, timecontext, raw=False, **kwargs):
             return value
     elif isinstance(value, list):
         return F.array(*[F.lit(v) for v in value])
+    elif isinstance(value, np.ndarray):
+        # Unpack np.generic's using .item(), otherwise Spark
+        # will not accept
+        return F.array(*[F.lit(v.item()) for v in value])
     else:
-        return F.lit(expr.op().value)
+        return F.lit(value)
 
 
 def _compile_agg(t, agg_expr, scope, timecontext, *, context, **kwargs):

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -31,7 +31,18 @@ def test_array_length(backend, con):
 @pytest.mark.skip_missing_feature(
     ['supports_arrays', 'supports_arrays_outside_of_select']
 )
-def test_np_array(backend, con):
+def test_list_literal(backend, con):
+    arr = [1, 2, 3]
+    expr = ibis.literal(arr)
+    result = con.execute(expr)
+    assert np.array_equal(result, arr)
+
+
+@pytest.mark.xfail_unsupported
+@pytest.mark.skip_missing_feature(
+    ['supports_arrays', 'supports_arrays_outside_of_select']
+)
+def test_np_array_literal(backend, con):
     arr = np.array([1, 2, 3])
     expr = ibis.literal(arr)
     result = con.execute(expr)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import ibis
@@ -24,3 +25,14 @@ def test_array_concat(backend, con):
 def test_array_length(backend, con):
     expr = ibis.literal([1, 2, 3]).length()
     assert con.execute(expr) == 3
+
+
+@pytest.mark.xfail_unsupported
+@pytest.mark.skip_missing_feature(
+    ['supports_arrays', 'supports_arrays_outside_of_select']
+)
+def test_np_array(backend, con):
+    arr = np.array([1, 2, 3])
+    expr = ibis.literal(arr)
+    result = con.execute(expr)
+    assert np.array_equal(result, arr)


### PR DESCRIPTION
This PR allows `np.array` literals in the PySpark backend. This was already supported on the Pandas backend.

```
import numpy as np

from ibis import backends
from ibis.expr.types import literal

spark = ...

ibis_pyspark = backends.pyspark.connect(spark)

ibis_pyspark.execute(literal(np.array([1, 2])))
```
Before:
```
AttributeError: 'numpy.int64' object has no attribute '_get_object_id'
```
After:
```
array([1, 2], dtype=int32)
```