### PR TITLE
TST: Fix custom pytest marker skip_missing_feature

### DIFF
--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -90,7 +90,7 @@ def pytest_runtest_call(item):
             feature for feature in features if not getattr(backend, feature)
         ]
         if missing_features:
-            pytest.mark.skip(
+            pytest.skip(
                 f'Backend {backend} is missing features {missing_features} '
                 f'needed to run {nodeid}'
             )


### PR DESCRIPTION
We have a custom pytest marker `skip_missing_feature`, for example used like this:
https://github.com/ibis-project/ibis/blob/019ccd5122befd3b843b32abf8b59991244596c9/ibis/backends/tests/test_array.py#L20-L26

However it is not skipping tests. This PR fixes this by changing the implementation of `skip_missing_feature` to call `pytest.skip` instead of `pytest.mark.skip` (similar to the implementation of [`skip_backends`](https://github.com/timothydijamco/ibis/blob/019ccd5122befd3b843b32abf8b59991244596c9/ibis/backends/tests/conftest.py#L85))