### PR TITLE
ENH: Adding separate dispatchers for dask backend

### DIFF
--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -110,14 +110,10 @@ See ibis.common.scope for details about the implementaion.
 
 from __future__ import absolute_import
 
-import datetime
 import functools
-import numbers
 from typing import Optional
 
 import dask.dataframe as dd
-import numpy as np
-import pandas as pd
 from multipledispatch import Dispatcher
 
 import ibis.common.exceptions as com
@@ -136,19 +132,6 @@ from ibis.expr.typing import TimeContext
 
 from .dispatch import execute_literal, execute_node, post_execute, pre_execute
 from .trace import trace
-
-integer_types = np.integer, int
-floating_types = (numbers.Real,)
-numeric_types = integer_types + floating_types
-boolean_types = bool, np.bool_
-fixed_width_types = numeric_types + boolean_types
-date_types = (datetime.date,)
-time_types = (datetime.time,)
-timestamp_types = pd.Timestamp, datetime.datetime, np.datetime64
-timedelta_types = pd.Timedelta, datetime.timedelta, np.timedelta64
-temporal_types = date_types + time_types + timestamp_types + timedelta_types
-scalar_types = fixed_width_types + temporal_types
-simple_types = scalar_types + (str, type(None))
 
 is_computable_input.register(dd.core.Scalar)(is_computable_input_arg)
 

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -134,10 +134,7 @@ from ibis.expr.scope import Scope
 from ibis.expr.timecontext import canonicalize_context
 from ibis.expr.typing import TimeContext
 
-from .dispatch import dask_execute_literal as execute_literal
-from .dispatch import dask_execute_node as execute_node
-from .dispatch import dask_post_execute as post_execute
-from .dispatch import dask_pre_execute as pre_execute
+from .dispatch import execute_literal, execute_node, post_execute, pre_execute
 from .trace import trace
 
 integer_types = np.integer, int
@@ -484,10 +481,3 @@ def execute_and_reset(
     elif isinstance(result, dd.Series):
         return result.reset_index(drop=True)
     return result
-
-
-@compute_time_context.register(ops.Node)
-def compute_time_context_default(
-    node, timecontext: Optional[TimeContext] = None, **kwargs
-):
-    return [timecontext for arg in node.inputs if is_computable_input(arg)]

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -110,18 +110,317 @@ See ibis.common.scope for details about the implementaion.
 
 from __future__ import absolute_import
 
+import datetime
+import functools
+import numbers
 from typing import Optional
 
 import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+from multipledispatch import Dispatcher
 
+import ibis.common.exceptions as com
+import ibis.expr.operations as ops
+import ibis.expr.types as ir
+from ibis.backends.pandas import aggcontext as agg_ctx
 from ibis.backends.pandas.core import (
-    execute,
+    compute_time_context,
     is_computable_input,
     is_computable_input_arg,
 )
+from ibis.client import find_backends
+from ibis.expr.scope import Scope
+from ibis.expr.timecontext import canonicalize_context
 from ibis.expr.typing import TimeContext
 
+from .dispatch import dask_execute_literal as execute_literal
+from .dispatch import dask_execute_node as execute_node
+from .dispatch import dask_post_execute as post_execute
+from .dispatch import dask_pre_execute as pre_execute
+from .trace import trace
+
+integer_types = np.integer, int
+floating_types = (numbers.Real,)
+numeric_types = integer_types + floating_types
+boolean_types = bool, np.bool_
+fixed_width_types = numeric_types + boolean_types
+date_types = (datetime.date,)
+time_types = (datetime.time,)
+timestamp_types = pd.Timestamp, datetime.datetime, np.datetime64
+timedelta_types = pd.Timedelta, datetime.timedelta, np.timedelta64
+temporal_types = date_types + time_types + timestamp_types + timedelta_types
+scalar_types = fixed_width_types + temporal_types
+simple_types = scalar_types + (str, type(None))
+
 is_computable_input.register(dd.core.Scalar)(is_computable_input_arg)
+
+
+def execute_with_scope(
+    expr,
+    scope: Scope,
+    timecontext: Optional[TimeContext] = None,
+    aggcontext=None,
+    clients=None,
+    **kwargs,
+):
+    """Execute an expression `expr`, with data provided in `scope`.
+
+    Parameters
+    ----------
+    expr : ibis.expr.types.Expr
+        The expression to execute.
+    scope : Scope
+        A Scope class, with dictionary mapping
+        :class:`~ibis.expr.operations.Node` subclass instances to concrete
+        data such as a pandas DataFrame.
+    timecontext : Optional[TimeContext]
+        A tuple of (begin, end) that is passed from parent Node to children
+        see [timecontext.py](ibis/backends/pandas/execution/timecontext.py) for
+        detailed usage for this time context.
+    aggcontext : Optional[ibis.backends.pandas.aggcontext.AggregationContext]
+
+    Returns
+    -------
+    result : scalar, pd.Series, pd.DataFrame
+    """
+    op = expr.op()
+
+    # Call pre_execute, to allow clients to intercept the expression before
+    # computing anything *and* before associating leaf nodes with data. This
+    # allows clients to provide their own data for each leaf.
+    if clients is None:
+        clients = list(find_backends(expr))
+
+    if aggcontext is None:
+        aggcontext = agg_ctx.Summarize()
+
+    pre_executed_scope = pre_execute(
+        op,
+        *clients,
+        scope=scope,
+        timecontext=timecontext,
+        aggcontext=aggcontext,
+        **kwargs,
+    )
+    new_scope = scope.merge_scope(pre_executed_scope)
+    result = execute_until_in_scope(
+        expr,
+        new_scope,
+        timecontext=timecontext,
+        aggcontext=aggcontext,
+        clients=clients,
+        # XXX: we *explicitly* pass in scope and not new_scope here so that
+        # post_execute sees the scope of execute_with_scope, not the scope of
+        # execute_until_in_scope
+        post_execute_=functools.partial(
+            post_execute,
+            scope=scope,
+            timecontext=timecontext,
+            aggcontext=aggcontext,
+            clients=clients,
+            **kwargs,
+        ),
+        **kwargs,
+    ).get_value(op, timecontext)
+    return result
+
+
+@trace
+def execute_until_in_scope(
+    expr,
+    scope: Scope,
+    timecontext: Optional[TimeContext] = None,
+    aggcontext=None,
+    clients=None,
+    post_execute_=None,
+    **kwargs,
+) -> Scope:
+    """Execute until our op is in `scope`.
+
+    Parameters
+    ----------
+    expr : ibis.expr.types.Expr
+    scope : Scope
+    timecontext : Optional[TimeContext]
+    aggcontext : Optional[AggregationContext]
+    clients : List[ibis.client.Client]
+    kwargs : Mapping
+    """
+    # these should never be None
+    assert aggcontext is not None, 'aggcontext is None'
+    assert clients is not None, 'clients is None'
+    assert post_execute_ is not None, 'post_execute_ is None'
+
+    # base case: our op has been computed (or is a leaf data node), so
+    # return the corresponding value
+    op = expr.op()
+    if scope.get_value(op, timecontext) is not None:
+        return scope
+    if isinstance(op, ops.Literal):
+        # special case literals to avoid the overhead of dispatching
+        # execute_node
+        return Scope(
+            {
+                op: execute_literal(
+                    op, op.value, expr.type(), aggcontext=aggcontext, **kwargs
+                )
+            },
+            timecontext,
+        )
+
+    # figure out what arguments we're able to compute on based on the
+    # expressions inputs. things like expressions, None, and scalar types are
+    # computable whereas ``list``s are not
+    computable_args = [arg for arg in op.inputs if is_computable_input(arg)]
+
+    # pre_executed_states is a list of states with same the length of
+    # computable_args, these states are passed to each arg
+    if timecontext:
+        arg_timecontexts = compute_time_context(
+            op,
+            num_args=len(computable_args),
+            timecontext=timecontext,
+            clients=clients,
+        )
+    else:
+        arg_timecontexts = [None] * len(computable_args)
+
+    pre_executed_scope = pre_execute(
+        op,
+        *clients,
+        scope=scope,
+        timecontext=timecontext,
+        aggcontext=aggcontext,
+        **kwargs,
+    )
+
+    new_scope = scope.merge_scope(pre_executed_scope)
+
+    # Short circuit: if pre_execute puts op in scope, then we don't need to
+    # execute its computable_args
+    if new_scope.get_value(op, timecontext) is not None:
+        return new_scope
+
+    # recursively compute each node's arguments until we've changed type.
+    # compute_time_context should return with a list with the same length
+    # as computable_args, the two lists will be zipping together for
+    # further execution
+    if len(arg_timecontexts) != len(computable_args):
+        raise com.IbisError(
+            'arg_timecontexts differ with computable_arg in length '
+            f'for type:\n{type(op).__name__}.'
+        )
+
+    scopes = [
+        execute_until_in_scope(
+            arg,
+            new_scope,
+            timecontext=timecontext,
+            aggcontext=aggcontext,
+            post_execute_=post_execute_,
+            clients=clients,
+            **kwargs,
+        )
+        if hasattr(arg, 'op')
+        else Scope({arg: arg}, timecontext)
+        for (arg, timecontext) in zip(computable_args, arg_timecontexts)
+    ]
+
+    # if we're unable to find data then raise an exception
+    if not scopes and computable_args:
+        raise com.UnboundExpressionError(
+            'Unable to find data for expression:\n{}'.format(repr(expr))
+        )
+
+    # there should be exactly one dictionary per computable argument
+    assert len(computable_args) == len(scopes)
+
+    new_scope = new_scope.merge_scopes(scopes)
+    # pass our computed arguments to this node's execute_node implementation
+    data = [
+        new_scope.get_value(arg.op(), timecontext)
+        if hasattr(arg, 'op')
+        else arg
+        for arg in computable_args
+    ]
+
+    result = execute_node(
+        op,
+        *data,
+        scope=scope,
+        timecontext=timecontext,
+        aggcontext=aggcontext,
+        clients=clients,
+        **kwargs,
+    )
+    computed = post_execute_(op, result, timecontext=timecontext)
+    return Scope({op: computed}, timecontext)
+
+
+execute = Dispatcher('execute')
+
+
+@execute.register(ir.Expr)
+@trace
+def main_execute(
+    expr,
+    params=None,
+    scope=None,
+    timecontext: Optional[TimeContext] = None,
+    aggcontext=None,
+    **kwargs,
+):
+    """Execute an expression against data that are bound to it. If no data
+    are bound, raise an Exception.
+
+    Parameters
+    ----------
+    expr : ibis.expr.types.Expr
+        The expression to execute
+    params : Mapping[ibis.expr.types.Expr, object]
+        The data that an unbound parameter in `expr` maps to
+    scope : Mapping[ibis.expr.operations.Node, object]
+        Additional scope, mapping ibis operations to data
+    timecontext : Optional[TimeContext]
+        timecontext needed for execution
+    aggcontext : Optional[ibis.backends.pandas.aggcontext.AggregationContext]
+        An object indicating how to compute aggregations. For example,
+        a rolling mean needs to be computed differently than the mean of a
+        column.
+    kwargs : Dict[str, object]
+        Additional arguments that can potentially be used by individual node
+        execution
+
+    Returns
+    -------
+    result : Union[
+        pandas.Series, pandas.DataFrame, ibis.backends.pandas.core.simple_types
+    ]
+
+    Raises
+    ------
+    ValueError
+        * If no data are bound to the input expression
+    """
+
+    if scope is None:
+        scope = Scope()
+
+    if timecontext is not None:
+        # convert timecontext to datetime type, if time strings are provided
+        timecontext = canonicalize_context(timecontext)
+
+    if params is None:
+        params = {}
+
+    # TODO: make expresions hashable so that we can get rid of these .op()
+    # calls everywhere
+    params = {k.op() if hasattr(k, 'op') else k: v for k, v in params.items()}
+    scope = scope.merge_scope(Scope(params, timecontext))
+    return execute_with_scope(
+        expr, scope, timecontext=timecontext, aggcontext=aggcontext, **kwargs,
+    )
 
 
 def execute_and_reset(
@@ -185,3 +484,10 @@ def execute_and_reset(
     elif isinstance(result, dd.Series):
         return result.reset_index(drop=True)
     return result
+
+
+@compute_time_context.register(ops.Node)
+def compute_time_context_default(
+    node, timecontext: Optional[TimeContext] = None, **kwargs
+):
+    return [timecontext for arg in node.inputs if is_computable_input(arg)]

--- a/ibis/backends/dask/dispatch.py
+++ b/ibis/backends/dask/dispatch.py
@@ -1,0 +1,21 @@
+from multipledispatch import Dispatcher
+
+import ibis.backends.pandas.core as core_dispatch
+import ibis.backends.pandas.dispatch as pandas_dispatch
+from ibis.backends.dask.trace import TraceTwoLevelDispatcher
+
+dask_execute_node = TraceTwoLevelDispatcher('dask_execute_node')
+for types, func in pandas_dispatch.execute_node.funcs.items():
+    dask_execute_node.register(*types)(func)
+
+dask_execute = Dispatcher('dask_execute')
+dask_execute.funcs.update(core_dispatch.execute.funcs)
+
+dask_pre_execute = Dispatcher('dask_pre_execute')
+dask_pre_execute.funcs.update(core_dispatch.pre_execute.funcs)
+
+dask_execute_literal = Dispatcher('dask_execute_literal')
+dask_execute_literal.funcs.update(core_dispatch.execute_literal.funcs)
+
+dask_post_execute = Dispatcher('dask_post_execute')
+dask_post_execute.funcs.update(core_dispatch.post_execute.funcs)

--- a/ibis/backends/dask/dispatch.py
+++ b/ibis/backends/dask/dispatch.py
@@ -4,18 +4,18 @@ import ibis.backends.pandas.core as core_dispatch
 import ibis.backends.pandas.dispatch as pandas_dispatch
 from ibis.backends.dask.trace import TraceTwoLevelDispatcher
 
-execute_node = TraceTwoLevelDispatcher('dask_execute_node')
+execute_node = TraceTwoLevelDispatcher('execute_node')
 for types, func in pandas_dispatch.execute_node.funcs.items():
     execute_node.register(*types)(func)
 
-execute = Dispatcher('dask_execute')
+execute = Dispatcher('execute')
 execute.funcs.update(core_dispatch.execute.funcs)
 
-pre_execute = Dispatcher('dask_pre_execute')
+pre_execute = Dispatcher('pre_execute')
 pre_execute.funcs.update(core_dispatch.pre_execute.funcs)
 
-execute_literal = Dispatcher('dask_execute_literal')
+execute_literal = Dispatcher('execute_literal')
 execute_literal.funcs.update(core_dispatch.execute_literal.funcs)
 
-post_execute = Dispatcher('dask_post_execute')
+post_execute = Dispatcher('post_execute')
 post_execute.funcs.update(core_dispatch.post_execute.funcs)

--- a/ibis/backends/dask/dispatch.py
+++ b/ibis/backends/dask/dispatch.py
@@ -4,18 +4,18 @@ import ibis.backends.pandas.core as core_dispatch
 import ibis.backends.pandas.dispatch as pandas_dispatch
 from ibis.backends.dask.trace import TraceTwoLevelDispatcher
 
-dask_execute_node = TraceTwoLevelDispatcher('dask_execute_node')
+execute_node = TraceTwoLevelDispatcher('dask_execute_node')
 for types, func in pandas_dispatch.execute_node.funcs.items():
-    dask_execute_node.register(*types)(func)
+    execute_node.register(*types)(func)
 
-dask_execute = Dispatcher('dask_execute')
-dask_execute.funcs.update(core_dispatch.execute.funcs)
+execute = Dispatcher('dask_execute')
+execute.funcs.update(core_dispatch.execute.funcs)
 
-dask_pre_execute = Dispatcher('dask_pre_execute')
-dask_pre_execute.funcs.update(core_dispatch.pre_execute.funcs)
+pre_execute = Dispatcher('dask_pre_execute')
+pre_execute.funcs.update(core_dispatch.pre_execute.funcs)
 
-dask_execute_literal = Dispatcher('dask_execute_literal')
-dask_execute_literal.funcs.update(core_dispatch.execute_literal.funcs)
+execute_literal = Dispatcher('dask_execute_literal')
+execute_literal.funcs.update(core_dispatch.execute_literal.funcs)
 
-dask_post_execute = Dispatcher('dask_post_execute')
-dask_post_execute.funcs.update(core_dispatch.post_execute.funcs)
+post_execute = Dispatcher('dask_post_execute')
+post_execute.funcs.update(core_dispatch.post_execute.funcs)

--- a/ibis/backends/dask/execution/aggregations.py
+++ b/ibis/backends/dask/execution/aggregations.py
@@ -16,13 +16,12 @@ import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
 
 import ibis.expr.operations as ops
-from ibis.backends.pandas.execution.generic import (
-    agg_ctx,
-    execute,
-    execute_node,
-)
+from ibis.backends.pandas.execution.generic import agg_ctx
 from ibis.expr.scope import Scope
 from ibis.expr.typing import TimeContext
+
+from ..core import execute
+from ..dispatch import dask_execute_node as execute_node
 
 from .util import maybe_wrap_scalar, safe_concat
 

--- a/ibis/backends/dask/execution/aggregations.py
+++ b/ibis/backends/dask/execution/aggregations.py
@@ -21,8 +21,7 @@ from ibis.expr.scope import Scope
 from ibis.expr.typing import TimeContext
 
 from ..core import execute
-from ..dispatch import dask_execute_node as execute_node
-
+from ..dispatch import execute_node
 from .util import maybe_wrap_scalar, safe_concat
 
 

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -10,9 +10,9 @@ from ibis.backends.pandas.execution.arrays import (
     execute_array_length,
     execute_array_repeat,
     execute_array_slice,
-    execute_node,
 )
 
+from ..dispatch import dask_execute_node as execute_node
 from .util import TypeRegistrationDict, register_types_to_dispatcher
 
 DASK_DISPATCH_TYPES: TypeRegistrationDict = {

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -12,7 +12,7 @@ from ibis.backends.pandas.execution.arrays import (
     execute_array_slice,
 )
 
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from .util import TypeRegistrationDict, register_types_to_dispatcher
 
 DASK_DISPATCH_TYPES: TypeRegistrationDict = {

--- a/ibis/backends/dask/execution/decimal.py
+++ b/ibis/backends/dask/execution/decimal.py
@@ -7,7 +7,7 @@ import dask.dataframe as dd
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 
 
 @execute_node.register(ops.Cast, dd.Series, dt.Decimal)

--- a/ibis/backends/dask/execution/decimal.py
+++ b/ibis/backends/dask/execution/decimal.py
@@ -6,7 +6,8 @@ import dask.dataframe as dd
 
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.pandas.execution.decimal import execute_node
+
+from ..dispatch import dask_execute_node as execute_node
 
 
 @execute_node.register(ops.Cast, dd.Series, dt.Decimal)

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -52,7 +52,7 @@ from ibis.backends.pandas.execution.generic import (
 
 from ..client import DaskClient, DaskTable
 from ..core import execute
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from .util import (
     TypeRegistrationDict,
     make_selected_obj,

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -35,7 +35,6 @@ from ibis.backends.pandas.execution.generic import (
     execute_intersection_dataframe_dataframe,
     execute_isinf,
     execute_isnan,
-    execute_node,
     execute_node_contains_series_sequence,
     execute_node_ifnull_series,
     execute_node_not_contains_series_sequence,
@@ -52,6 +51,8 @@ from ibis.backends.pandas.execution.generic import (
 )
 
 from ..client import DaskClient, DaskTable
+from ..core import execute
+from ..dispatch import dask_execute_node as execute_node
 from .util import (
     TypeRegistrationDict,
     make_selected_obj,
@@ -136,9 +137,15 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ],
     ops.Distinct: [((dd.DataFrame,), execute_distinct_dataframe)],
 }
+
 register_types_to_dispatcher(execute_node, DASK_DISPATCH_TYPES)
 
 execute_node.register(DaskTable, DaskClient)(execute_database_table_client)
+
+
+@execute_node.register(ops.ValueList, collections.abc.Sequence)
+def execute_node_value_list(op, _, **kwargs):
+    return [execute(arg, **kwargs) for arg in op.values]
 
 
 @execute_node.register(ops.Arbitrary, dd.Series, (dd.Series, type(None)))

--- a/ibis/backends/dask/execution/indexing.py
+++ b/ibis/backends/dask/execution/indexing.py
@@ -10,7 +10,7 @@ from ibis.backends.pandas.execution.generic import (
     execute_node_where_series_series_series,
 )
 
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from .util import TypeRegistrationDict, register_types_to_dispatcher
 
 DASK_DISPATCH_TYPES: TypeRegistrationDict = {

--- a/ibis/backends/dask/execution/indexing.py
+++ b/ibis/backends/dask/execution/indexing.py
@@ -6,11 +6,11 @@ import numpy as np
 import ibis.expr.operations as ops
 from ibis.backends.pandas.core import boolean_types, scalar_types
 from ibis.backends.pandas.execution.generic import (
-    execute_node,
     execute_node_where_scalar_scalar_scalar,
     execute_node_where_series_series_series,
 )
 
+from ..dispatch import dask_execute_node as execute_node
 from .util import TypeRegistrationDict, register_types_to_dispatcher
 
 DASK_DISPATCH_TYPES: TypeRegistrationDict = {

--- a/ibis/backends/dask/execution/join.py
+++ b/ibis/backends/dask/execution/join.py
@@ -9,9 +9,9 @@ from ibis.backends.pandas.execution.join import (
     _compute_join_column,
     _extract_predicate_names,
     _validate_columns,
-    execute_node,
 )
 
+from ..dispatch import dask_execute_node as execute_node
 from ..execution import constants
 
 

--- a/ibis/backends/dask/execution/join.py
+++ b/ibis/backends/dask/execution/join.py
@@ -11,7 +11,7 @@ from ibis.backends.pandas.execution.join import (
     _validate_columns,
 )
 
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from ..execution import constants
 
 

--- a/ibis/backends/dask/execution/maps.py
+++ b/ibis/backends/dask/execution/maps.py
@@ -20,7 +20,7 @@ from ibis.backends.pandas.execution.maps import (
     safe_merge,
 )
 
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from .util import TypeRegistrationDict, register_types_to_dispatcher
 
 # NOTE - to avoid dispatch ambiguities we must unregister pandas, only to

--- a/ibis/backends/dask/execution/maps.py
+++ b/ibis/backends/dask/execution/maps.py
@@ -14,13 +14,13 @@ from ibis.backends.pandas.execution.maps import (
     execute_map_value_for_key_dict_series,
     execute_map_value_for_key_series_scalar,
     execute_map_values_series,
-    execute_node,
     map_value_default_series_scalar_scalar,
     map_value_default_series_scalar_series,
     map_value_default_series_series_scalar,
     safe_merge,
 )
 
+from ..dispatch import dask_execute_node as execute_node
 from .util import TypeRegistrationDict, register_types_to_dispatcher
 
 # NOTE - to avoid dispatch ambiguities we must unregister pandas, only to

--- a/ibis/backends/dask/execution/numeric.py
+++ b/ibis/backends/dask/execution/numeric.py
@@ -9,8 +9,8 @@ import numpy as np
 
 import ibis.expr.operations as ops
 from ibis.backends.pandas.core import numeric_types
-from ibis.backends.pandas.execution.generic import execute_node
 
+from ..dispatch import dask_execute_node as execute_node
 from .util import make_selected_obj
 
 

--- a/ibis/backends/dask/execution/numeric.py
+++ b/ibis/backends/dask/execution/numeric.py
@@ -10,7 +10,7 @@ import numpy as np
 import ibis.expr.operations as ops
 from ibis.backends.pandas.core import numeric_types
 
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from .util import make_selected_obj
 
 

--- a/ibis/backends/dask/execution/reductions.py
+++ b/ibis/backends/dask/execution/reductions.py
@@ -32,8 +32,7 @@ from ibis.backends.pandas.execution.generic import (
 )
 
 from ..core import execute
-from ..dispatch import dask_execute_node as execute_node
-
+from ..dispatch import execute_node
 from .util import make_selected_obj
 
 

--- a/ibis/backends/dask/execution/reductions.py
+++ b/ibis/backends/dask/execution/reductions.py
@@ -25,13 +25,14 @@ import toolz
 
 import ibis
 import ibis.expr.operations as ops
-from ibis.backends.pandas.core import execute
 from ibis.backends.pandas.execution.generic import (
-    execute_node,
     execute_node_expr_list,
     execute_node_greatest_list,
     execute_node_least_list,
 )
+
+from ..core import execute
+from ..dispatch import dask_execute_node as execute_node
 
 from .util import make_selected_obj
 

--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -15,17 +15,16 @@ from toolz import concatv
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.backends.pandas.execution.selection import (
-    _compute_predicates,
     compute_projection,
     compute_projection_table_expr,
-    execute,
-    execute_node,
     map_new_column_names_to_data,
     remap_overlapping_column_names,
 )
 from ibis.expr.scope import Scope
 from ibis.expr.typing import TimeContext
 
+from ..core import execute
+from ..dispatch import dask_execute_node as execute_node
 from ..execution import constants
 
 
@@ -199,3 +198,59 @@ def execute_selection_dataframe(
 
     # drop every temporary column we created for ordering or grouping
     return result.drop(temporary_columns, axis=1)
+
+
+def _compute_predicates(
+    table_op,
+    predicates,
+    data,
+    scope: Scope,
+    timecontext: Optional[TimeContext],
+    **kwargs,
+):
+    """Compute the predicates for a table operation.
+
+    Parameters
+    ----------
+    table_op : TableNode
+    predicates : List[ir.ColumnExpr]
+    data : pd.DataFrame
+    scope : Scope
+    timecontext: Optional[TimeContext]
+    kwargs : dict
+
+    Returns
+    -------
+    computed_predicate : pd.Series[bool]
+
+    Notes
+    -----
+    This handles the cases where the predicates are computed columns, in
+    addition to the simple case of named columns coming directly from the input
+    table.
+    """
+    for predicate in predicates:
+        # Map each root table of the predicate to the data so that we compute
+        # predicates on the result instead of any left or right tables if the
+        # Selection is on a Join. Project data to only inlude columns from
+        # the root table.
+        root_tables = predicate.op().root_tables()
+
+        # handle suffixes
+        data_columns = frozenset(data.columns)
+
+        additional_scope = Scope()
+        for root_table in root_tables:
+            mapping = remap_overlapping_column_names(
+                table_op, root_table, data_columns
+            )
+            if mapping is not None:
+                new_data = data.loc[:, mapping.keys()].rename(columns=mapping)
+            else:
+                new_data = data
+            additional_scope = additional_scope.merge_scope(
+                Scope({root_table: new_data}, timecontext)
+            )
+
+        scope = scope.merge_scope(additional_scope)
+        yield execute(predicate, scope=scope, **kwargs)

--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -24,7 +24,7 @@ from ibis.expr.scope import Scope
 from ibis.expr.typing import TimeContext
 
 from ..core import execute
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from ..execution import constants
 
 

--- a/ibis/backends/dask/execution/strings.py
+++ b/ibis/backends/dask/execution/strings.py
@@ -11,7 +11,6 @@ import ibis
 import ibis.expr.operations as ops
 from ibis.backends.pandas.core import integer_types, scalar_types
 from ibis.backends.pandas.execution.strings import (
-    execute_node,
     execute_series_join_scalar_sep,
     execute_series_regex_extract,
     execute_series_regex_replace,
@@ -38,6 +37,7 @@ from ibis.backends.pandas.execution.strings import (
     haystack_to_series_of_lists,
 )
 
+from ..dispatch import dask_execute_node as execute_node
 from .util import (
     TypeRegistrationDict,
     make_selected_obj,

--- a/ibis/backends/dask/execution/strings.py
+++ b/ibis/backends/dask/execution/strings.py
@@ -37,7 +37,7 @@ from ibis.backends.pandas.execution.strings import (
     haystack_to_series_of_lists,
 )
 
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from .util import (
     TypeRegistrationDict,
     make_selected_obj,

--- a/ibis/backends/dask/execution/structs.py
+++ b/ibis/backends/dask/execution/structs.py
@@ -6,8 +6,8 @@ import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
 
 import ibis.expr.operations as ops
-from ibis.backends.pandas.execution.structs import execute_node
 
+from ..dispatch import dask_execute_node as execute_node
 from .util import make_selected_obj
 
 

--- a/ibis/backends/dask/execution/structs.py
+++ b/ibis/backends/dask/execution/structs.py
@@ -7,7 +7,7 @@ import dask.dataframe.groupby as ddgb
 
 import ibis.expr.operations as ops
 
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from .util import make_selected_obj
 
 

--- a/ibis/backends/dask/execution/temporal.py
+++ b/ibis/backends/dask/execution/temporal.py
@@ -28,7 +28,6 @@ from ibis.backends.pandas.execution.temporal import (
     execute_interval_add_multiply_delta_series,
     execute_interval_from_integer_series,
     execute_interval_multiply_fdiv_series_numeric,
-    execute_node,
     execute_strftime_series_str,
     execute_timestamp_add_datetime_series,
     execute_timestamp_date,
@@ -41,6 +40,7 @@ from ibis.backends.pandas.execution.temporal import (
     execute_timestamp_sub_series_timedelta,
 )
 
+from ..dispatch import dask_execute_node as execute_node
 from .util import (
     TypeRegistrationDict,
     make_selected_obj,

--- a/ibis/backends/dask/execution/temporal.py
+++ b/ibis/backends/dask/execution/temporal.py
@@ -40,7 +40,7 @@ from ibis.backends.pandas.execution.temporal import (
     execute_timestamp_sub_series_timedelta,
 )
 
-from ..dispatch import dask_execute_node as execute_node
+from ..dispatch import execute_node
 from .util import (
     TypeRegistrationDict,
     make_selected_obj,

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -9,6 +9,7 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+from ibis.backends.pandas.dispatch import execute_node as pandas_execute_node
 from ibis.expr.scope import Scope
 
 from .. import from_dataframe
@@ -173,3 +174,9 @@ def test_scope_look_up():
     scope = scope.merge_scope(Scope({one_day: 1}, None))
     assert scope.get_value(one_hour) is None
     assert scope.get_value(one_day) is not None
+
+
+def test_new_dispatcher():
+    types = (ops.TableColumn, dd.DataFrame)
+    assert execute_node.dispatch(*types) is not None
+    assert pandas_execute_node.dispatch(*types) is None

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -14,9 +14,7 @@ from ibis.expr.scope import Scope
 from .. import from_dataframe
 from ..client import DaskClient
 from ..core import execute, is_computable_input
-from ..dispatch import dask_execute_node as execute_node  # noqa: F401
-from ..dispatch import dask_post_execute as post_execute
-from ..dispatch import dask_pre_execute as pre_execute
+from ..dispatch import execute_node, post_execute, pre_execute
 
 pytestmark = pytest.mark.dask
 

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -85,7 +85,7 @@ def test_missing_data_on_custom_client():
     with pytest.raises(
         NotImplementedError,
         match=(
-            'Could not find signature for dask_execute_node: '
+            'Could not find signature for execute_node: '
             '<DatabaseTable, MyClient>'
         ),
     ):

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -9,16 +9,14 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.pandas.dispatch import (  # noqa: F401
-    execute_node,
-    post_execute,
-    pre_execute,
-)
 from ibis.expr.scope import Scope
 
-from .. import execute, from_dataframe
+from .. import from_dataframe
 from ..client import DaskClient
-from ..core import is_computable_input
+from ..core import execute, is_computable_input
+from ..dispatch import dask_execute_node as execute_node  # noqa: F401
+from ..dispatch import dask_post_execute as post_execute
+from ..dispatch import dask_pre_execute as pre_execute
 
 pytestmark = pytest.mark.dask
 
@@ -89,7 +87,7 @@ def test_missing_data_on_custom_client():
     with pytest.raises(
         NotImplementedError,
         match=(
-            'Could not find signature for execute_node: '
+            'Could not find signature for dask_execute_node: '
             '<DatabaseTable, MyClient>'
         ),
     ):


### PR DESCRIPTION
Closes #2601

Here, we create new dispatchers specifically for the dask backend (instead of just adding onto the ones in the pandas backend). We copy over the existing python functions and then switch other files to use the dask specific dispatchers. 