### PR TITLE
FEAT: Implement Not operation in PySpark backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2607` Implement Not operation in PySpark backend
 * :feature:`2603` Add support for np.array as literals for backends that already support lists as literals
 * :bug:`2354` Fixes binary data type translation into BigQuery bytes data type
 * :bug:`2577` Make StructValue picklable

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -246,6 +246,12 @@ def compile_equals(t, expr, scope, timecontext, **kwargs):
     )
 
 
+@compiles(ops.Not)
+def compile_not(t, expr, scope, timecontext, **kwargs):
+    op = expr.op()
+    return ~t.translate(op.arg, scope, timecontext)
+
+
 @compiles(ops.NotEquals)
 def compile_not_equals(t, expr, scope, timecontext, **kwargs):
     op = expr.op()

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -118,3 +118,20 @@ def test_notin(backend, alltypes, sorted_df, column, elements):
     expected = ~sorted_df[column].isin(elements)
     expected = backend.default_series_rename(expected)
     backend.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ('predicate_fn', 'expected_fn'),
+    [
+        (lambda t: t['bool_col'], lambda df: df['bool_col']),
+        (lambda t: ~t['bool_col'], lambda df: ~df['bool_col']),
+    ],
+)
+@pytest.mark.skip_backends(['dask'])  # TODO - sorting - #2553
+@pytest.mark.xfail_unsupported
+def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
+    sorted_alltypes = alltypes.sort_by('id')
+    table = sorted_alltypes[predicate_fn(sorted_alltypes)].sort_by('id')
+    result = table.execute()
+    expected = sorted_df[expected_fn(sorted_df)]
+    backend.assert_frame_equal(result, expected)


### PR DESCRIPTION
Should be self explanatory. 