### PR TITLE
DOC: Make tutorial 5 not require Impala

### DIFF
--- a/docs/source/backends/impala.rst
+++ b/docs/source/backends/impala.rst
@@ -944,6 +944,355 @@ For example:
 
    >>> to_insert.drop()
 
+Uploading / downloading data from HDFS
+--------------------------------------
+
+If you’ve set up an HDFS connection, you can use the Ibis HDFS interface
+to look through your data and read and write files to and from HDFS:
+
+.. code:: python
+
+    >>> hdfs = con.hdfs
+    >>> hdfs.ls('/__ibis/ibis-testing-data')
+    ['README.md',
+     'avro',
+     'awards_players.csv',
+     'batting.csv',
+     'csv',
+     'diamonds.csv',
+     'functional_alltypes.csv',
+     'functional_alltypes.parquet',
+     'geo.csv',
+     'ibis_testing.db',
+     'parquet',
+     'struct_table.avro',
+     'udf']
+
+.. code:: python
+
+    >>> hdfs.ls('/__ibis/ibis-testing-data/parquet')
+    ['functional_alltypes',
+     'tpch_customer',
+     'tpch_lineitem',
+     'tpch_nation',
+     'tpch_orders',
+     'tpch_part',
+     'tpch_partsupp',
+     'tpch_region',
+     'tpch_supplier']
+
+Suppose we wanted to download
+``/__ibis/ibis-testing-data/parquet/functional_alltypes``, which is a
+directory. We need only do:
+
+.. code:: bash
+
+    $ rm -rf parquet_dir/
+
+.. code:: python
+
+    >>> hdfs.get('/__ibis/ibis-testing-data/parquet/functional_alltypes',
+    ...          'parquet_dir')
+    '/ibis/docs/source/tutorial/parquet_dir'
+
+Now we have that directory locally:
+
+.. code:: bash
+
+    $ ls parquet_dir/
+    9a41de519352ab07-4e76bc4d9fb5a789_1624886651_data.0.parq
+    9a41de519352ab07-4e76bc4d9fb5a78a_778826485_data.0.parq
+    9a41de519352ab07-4e76bc4d9fb5a78b_1277612014_data.0.parq
+
+Files and directories can be written to HDFS just as easily using
+``put``:
+
+.. code:: python
+
+    >>> path = '/__ibis/dir-write-example'
+    >>> if hdfs.exists(path):
+    ...    hdfs.rmdir(path)
+    >>> hdfs.put(path, 'parquet_dir', verbose=True)
+    '/__ibis/dir-write-example'
+
+.. code:: python
+
+    >>> hdfs.ls('/__ibis/dir-write-example')
+    ['9a41de519352ab07-4e76bc4d9fb5a789_1624886651_data.0.parq',
+     '9a41de519352ab07-4e76bc4d9fb5a78a_778826485_data.0.parq',
+     '9a41de519352ab07-4e76bc4d9fb5a78b_1277612014_data.0.parq']
+
+Delete files with ``rm`` or directories with ``rmdir``:
+
+.. code:: python
+
+    >>> hdfs.rmdir('/__ibis/dir-write-example')
+
+.. code:: bash
+
+    rm -rf parquet_dir/
+
+Queries on Parquet, Avro, and Delimited files in HDFS
+-----------------------------------------------------
+
+Ibis can easily create temporary or persistent Impala tables that
+reference data in the following formats:
+
+-  Parquet (``parquet_file``)
+-  Avro (``avro_file``)
+-  Delimited text formats (CSV, TSV, etc.) (``delimited_file``)
+
+Parquet is the easiest because the schema can be read from the data
+files:
+
+.. code:: python
+
+    >>> path = '/__ibis/ibis-testing-data/parquet/tpch_lineitem'
+    >>> lineitem = con.parquet_file(path)
+    >>> lineitem.limit(2)
+       l_orderkey  l_partkey  l_suppkey  l_linenumber l_quantity l_extendedprice  \
+    0           1     155190       7706             1      17.00        21168.23
+    1           1      67310       7311             2      36.00        45983.16
+
+      l_discount l_tax l_returnflag l_linestatus  l_shipdate l_commitdate  \
+    0       0.04  0.02            N            O  1996-03-13   1996-02-12
+    1       0.09  0.06            N            O  1996-04-12   1996-02-28
+
+      l_receiptdate     l_shipinstruct l_shipmode  \
+    0    1996-03-22  DELIVER IN PERSON      TRUCK
+    1    1996-04-20   TAKE BACK RETURN       MAIL
+
+                                l_comment
+    0             egular courts above the
+    1  ly final dependencies: slyly bold
+
+.. code:: python
+
+    >>> lineitem.l_extendedprice.sum()
+    Decimal('229577310901.20')
+
+If you want to query a Parquet file and also create a table in Impala
+that remains after your session, you can pass more information to
+``parquet_file``:
+
+.. code:: python
+
+    >>> table = con.parquet_file(path, name='my_parquet_table',
+    ...                          database='ibis_testing',
+    ...                          persist=True)
+    >>> table.l_extendedprice.sum()
+    Decimal('229577310901.20')
+
+.. code:: python
+
+    >>> con.table('my_parquet_table').l_extendedprice.sum()
+    Decimal('229577310901.20')
+
+.. code:: python
+
+    >>> con.drop_table('my_parquet_table')
+
+To query delimited files, you need to write down an Ibis schema. At some
+point we’d like to build some helper tools that will infer the schema
+for you, all in good time.
+
+There’s some CSV files in the test folder, so let’s use those:
+
+.. code:: python
+
+    >>> hdfs.get('/__ibis/ibis-testing-data/csv', 'csv-files')
+    '/ibis/docs/source/tutorial/csv-files'
+
+.. code:: bash
+
+    $ cat csv-files/0.csv
+    63IEbRheTh,0.679388707915,6
+    mG4hlqnjeG,2.80710565922,15
+    JTPdX9SZH5,-0.155126406372,55
+    2jcl6FypOl,1.03787834032,21
+    k3TbJLaadQ,-1.40190801103,23
+    rP5J4xvinM,-0.442092712869,22
+    WniUylixYt,-0.863748033806,27
+    znsDuKOB1n,-0.566029637098,47
+    4SRP9jlo1M,0.331460412318,88
+    KsfjPyDf5e,-0.578930506363,70
+
+.. code:: bash
+
+    $ rm -rf csv-files/
+
+The schema here is pretty simple (see ``ibis.schema`` for more):
+
+.. code:: python
+
+    >>> schema = ibis.schema([('foo', 'string'),
+    ...                       ('bar', 'double'),
+    ...                       ('baz', 'int32')])
+
+    >>> table = con.delimited_file('/__ibis/ibis-testing-data/csv',
+    ...                            schema)
+    >>> table.limit(10)
+              foo       bar  baz
+    0  63IEbRheTh  0.679389    6
+    1  mG4hlqnjeG  2.807106   15
+    2  JTPdX9SZH5 -0.155126   55
+    3  2jcl6FypOl  1.037878   21
+    4  k3TbJLaadQ -1.401908   23
+    5  rP5J4xvinM -0.442093   22
+    6  WniUylixYt -0.863748   27
+    7  znsDuKOB1n -0.566030   47
+    8  4SRP9jlo1M  0.331460   88
+    9  KsfjPyDf5e -0.578931   70
+
+.. code:: python
+
+    >>> table.bar.summary()
+       count  nulls       min       max       sum    mean  approx_nunique
+    0    100      0 -1.401908  2.807106  8.479978  0.0848              10
+
+For functions like ``parquet_file`` and ``delimited_file``, an HDFS
+directory must be passed (we’ll add support for S3 and other filesystems
+later) and the directory must contain files all having the same schema.
+
+If you have Avro data, you can query it too if you have the full avro
+schema:
+
+.. code:: python
+
+    >>> avro_schema = {
+    ...     "fields": [
+    ...         {"type": ["int", "null"], "name": "R_REGIONKEY"},
+    ...         {"type": ["string", "null"], "name": "R_NAME"},
+    ...         {"type": ["string", "null"], "name": "R_COMMENT"}],
+    ...     "type": "record",
+    ...     "name": "a"
+    ... }
+
+    >>> path = '/__ibis/ibis-testing-data/avro/tpch.region'
+
+    >>> hdfs.mkdir(path)
+    >>> table = con.avro_file(path, avro_schema)
+    >>> table
+    Empty DataFrame
+    Columns: [r_regionkey, r_name, r_comment]
+    Index: []
+
+Other helper functions for interacting with the database
+--------------------------------------------------------
+
+We’re adding a growing list of useful utility functions for interacting
+with an Impala cluster on the client object. The idea is that you should
+be able to do any database-admin-type work with Ibis and not have to
+switch over to the Impala SQL shell. Any ways we can make this more
+pleasant, please let us know.
+
+Here’s some of the features, which we’ll give examples for:
+
+-  Listing and searching for available databases and tables
+-  Creating and dropping databases
+-  Getting table schemas
+
+.. code:: python
+
+    >>> con.list_databases(like='ibis*')
+    ['ibis_testing', 'ibis_testing_tmp_db']
+
+.. code:: python
+
+    >>> con.list_tables(database='ibis_testing', like='tpch*')
+    ['tpch_customer',
+     'tpch_lineitem',
+     'tpch_nation',
+     'tpch_orders',
+     'tpch_part',
+     'tpch_partsupp',
+     'tpch_region',
+     'tpch_region_avro',
+     'tpch_supplier']
+
+.. code:: python
+
+    >>> schema = con.get_schema('functional_alltypes')
+    >>> schema
+    ibis.Schema {
+      id               int32
+      bool_col         boolean
+      tinyint_col      int8
+      smallint_col     int16
+      int_col          int32
+      bigint_col       int64
+      float_col        float32
+      double_col       float64
+      date_string_col  string
+      string_col       string
+      timestamp_col    timestamp
+      year             int32
+      month            int32
+    }
+
+Databases can be created, too, and you can set the storage path in HDFS
+you want for the data files
+
+.. code:: python
+
+    >>> db = 'ibis_testing2'
+    >>> con.create_database(db, path='/__ibis/my-test-database', force=True)
+
+    >>> # you may or may not have to give the impala user write and execute permissions to '/__ibis/my-test-database'
+    >>> hdfs.chmod('/__ibis/my-test-database', '777')
+
+.. code:: python
+
+    >>> con.create_table('example_table', con.table('functional_alltypes'),
+    ...                  database=db, force=True)
+
+Hopefully, there will be data files in the indicated spot in HDFS:
+
+.. code:: python
+
+    >>> hdfs.ls('/__ibis/my-test-database')
+    ['example_table']
+
+To drop a database, including all tables in it, you can use
+``drop_database`` with ``force=True``:
+
+.. code:: python
+
+    >>> con.drop_database(db, force=True)
+
+Faster queries on small data in Impala
+--------------------------------------
+
+Since Impala internally uses LLVM to compile parts of queries (aka
+“codegen”) to make them faster on large data sets there is a certain
+amount of overhead with running many kinds of queries, even on small
+datasets. You can disable LLVM code generation when using Ibis, which
+may significantly speed up queries on smaller datasets:
+
+.. code:: python
+
+    >>> from numpy.random import rand
+    >>> con.disable_codegen()
+    >>> t = con.table('ibis_testing.functional_alltypes')
+
+.. code:: bash
+
+    $ time python -c "(t.double_col + rand()).sum().execute()"
+    27.7 ms ± 996 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+.. code:: python
+
+    # Turn codegen back on
+    con.disable_codegen(False)
+
+.. code:: bash
+
+    $ time python -c "(t.double_col + rand()).sum().execute()"
+    27 ms ± 1.62 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
+
+It’s important to remember that codegen is a fixed overhead and will
+significantly speed up queries on big data
+
 .. _udf.impala:
 
 User Defined functions (UDF)

--- a/docs/source/tutorial/05-IO-Create-Insert-External-Data.ipynb
+++ b/docs/source/tutorial/05-IO-Create-Insert-External-Data.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# IO, `CREATE`/`INSERT`, and External Data"
+    "# Creating and inserting data"
    ]
   },
   {
@@ -22,21 +22,19 @@
    },
    "outputs": [],
    "source": [
-    "import ibis\n",
     "import os\n",
-    "hdfs_port = int(os.environ.get('IBIS_TEST_WEBHDFS_PORT', 50070))\n",
-    "user = os.environ.get('IBIS_TEST_WEBHDFS_USER', 'ubuntu')\n",
-    "hdfs = ibis.impala.hdfs_connect(host='impala', user=user, port=hdfs_port)\n",
-    "con = ibis.impala.connect(host='impala', database='ibis_testing',\n",
-    "                          hdfs_client=hdfs)\n",
-    "ibis.options.interactive = True"
+    "import ibis\n",
+    "\n",
+    "ibis.options.interactive = True\n",
+    "\n",
+    "connection = ibis.sqlite.connect(os.path.join('data', 'geography.db'))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creating new Impala tables from Ibis expressions\n",
+    "## Creating new tables from Ibis expressions\n",
     "\n",
     "\n",
     "Suppose you have an Ibis expression that produces a table:"
@@ -48,16 +46,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = con.table('functional_alltypes')\n",
+    "countries = connection.table('countries')\n",
     "\n",
-    "t2 = table[table, (table.bigint_col - table.int_col).name('foo')]\n",
+    "continent_name = (countries.continent\n",
+    "                           .case()\n",
+    "                           .when('AF', 'Africa')\n",
+    "                           .when('AN', 'Antarctica')\n",
+    "                           .when('AS', 'Asia')\n",
+    "                           .when('EU', 'Europe')\n",
+    "                           .when('NA', 'North America')\n",
+    "                           .when('OC', 'Oceania')\n",
+    "                           .when('SA', 'South America')\n",
+    "                           .else_(countries.continent)\n",
+    "                           .end()\n",
+    "                           .name('continent_name'))\n",
     "\n",
-    "expr = (t2\n",
-    "        [t2.bigint_col > 30]\n",
-    "        .group_by('string_col')\n",
-    "        .aggregate(min_foo=lambda t: t.foo.min(),\n",
-    "                   max_foo=lambda t: t.foo.max(),\n",
-    "                   sum_foo=lambda t: t.foo.sum()))\n",
+    "expr = countries[countries.continent, continent_name].distinct()\n",
     "expr"
    ]
   },
@@ -74,14 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.create_table('testing_table', expr, database='ibis_testing')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "By default, this creates a table stored as **Parquet format** in HDFS. Support for views, external tables, configurable file formats, and so forth, will come in the future. Feedback on what kind of interface would be useful for that would help."
+    "connection.create_table('continents', expr)"
    ]
   },
   {
@@ -90,7 +87,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.table('testing_table')"
+    "continents = connection.table('continents')\n",
+    "continents"
    ]
   },
   {
@@ -106,534 +104,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.drop_table('testing_table', database='ibis_testing')"
+    "connection.drop_table('continents')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Inserting data into existing Impala tables\n",
+    "## Inserting data into existing tables\n",
     "\n",
     "\n",
-    "The client's `insert` method can append new data to an existing table or overwrite the data that is in there."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.create_table('testing_table', expr)\n",
-    "con.table('testing_table')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.insert('testing_table', expr)\n",
-    "con.table('testing_table')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.drop_table('testing_table')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Uploading / downloading data from HDFS"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you've set up an HDFS connection, you can use the Ibis HDFS interface to look through your data and read and write files to and from HDFS:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hdfs = con.hdfs\n",
-    "hdfs.ls('/__ibis/ibis-testing-data')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hdfs.ls('/__ibis/ibis-testing-data/parquet')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Suppose we wanted to download `/__ibis/ibis-testing-data/parquet/functional_alltypes`, which is a directory. We need only do:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!rm -rf parquet_dir/\n",
-    "hdfs.get('/__ibis/ibis-testing-data/parquet/functional_alltypes', 'parquet_dir')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we have that directory locally:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ls parquet_dir/"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Files and directories can be written to HDFS just as easily using `put`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "path = '/__ibis/dir-write-example'\n",
-    "if hdfs.exists(path):\n",
-    "    hdfs.rmdir(path)\n",
-    "hdfs.put(path, 'parquet_dir', verbose=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hdfs.ls('/__ibis/dir-write-example')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Delete files with `rm` or directories with `rmdir`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hdfs.rmdir('/__ibis/dir-write-example')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!rm -rf parquet_dir/"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Queries on Parquet, Avro, and Delimited files in HDFS\n",
-    "\n",
-    "\n",
-    "Ibis can easily create temporary or persistent Impala tables that reference data in the following formats:\n",
-    "\n",
-    "- Parquet (`parquet_file`)\n",
-    "- Avro (`avro_file`)\n",
-    "- Delimited text formats (CSV, TSV, etc.) (`delimited_file`)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Parquet is the easiest because the schema can be read from the data files:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "path = '/__ibis/ibis-testing-data/parquet/tpch_lineitem'\n",
-    "\n",
-    "lineitem = con.parquet_file(path)\n",
-    "lineitem.limit(2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lineitem.l_extendedprice.sum()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you want to query a Parquet file and also create a table in Impala that remains after your session, you can pass more information to `parquet_file`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "table = con.parquet_file(path, name='my_parquet_table', \n",
-    "                         database='ibis_testing',\n",
-    "                         persist=True)\n",
-    "table.l_extendedprice.sum()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.table('my_parquet_table').l_extendedprice.sum()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.drop_table('my_parquet_table')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To query delimited files, you need to write down an Ibis schema. At some point we'd like to build some helper tools that will infer the schema for you, all in good time.\n",
-    "\n",
-    "There's some CSV files in the test folder, so let's use those:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hdfs.get('/__ibis/ibis-testing-data/csv', 'csv-files')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat csv-files/0.csv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!rm -rf csv-files/"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The schema here is pretty simple (see `ibis.schema` for more):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "schema = ibis.schema([('foo', 'string'),\n",
-    "                      ('bar', 'double'),\n",
-    "                      ('baz', 'int32')])\n",
-    "\n",
-    "table = con.delimited_file('/__ibis/ibis-testing-data/csv',\n",
-    "                           schema)\n",
-    "table.limit(10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "table.bar.summary()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For functions like `parquet_file` and `delimited_file`, an HDFS directory must be passed (we'll add support for S3 and other filesystems later) and the directory must contain files all having the same schema."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you have Avro data, you can query it too if you have the full avro schema:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "avro_schema = {\n",
-    "    \"fields\": [\n",
-    "        {\"type\": [\"int\", \"null\"], \"name\": \"R_REGIONKEY\"},\n",
-    "        {\"type\": [\"string\", \"null\"], \"name\": \"R_NAME\"},\n",
-    "        {\"type\": [\"string\", \"null\"], \"name\": \"R_COMMENT\"}],\n",
-    "    \"type\": \"record\",\n",
-    "    \"name\": \"a\"\n",
-    "}\n",
-    "\n",
-    "path = '/__ibis/ibis-testing-data/avro/tpch.region'\n",
-    "\n",
-    "hdfs.mkdir(path)\n",
-    "table = con.avro_file(path, avro_schema)\n",
-    "table"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Other helper functions for interacting with the database\n",
-    "\n",
-    "\n",
-    "We're adding a growing list of useful utility functions for interacting with an Impala cluster on the client object. The idea is that you should be able to do any database-admin-type work with Ibis and not have to switch over to the Impala SQL shell. Any ways we can make this more pleasant, please let us know.\n",
-    "\n",
-    "Here's some of the features, which we'll give examples for:\n",
-    "\n",
-    "- Listing and searching for available databases and tables\n",
-    "- Creating and dropping databases\n",
-    "- Getting table schemas"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.list_databases(like='ibis*')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.list_tables(database='ibis_testing', like='tpch*')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "schema = con.get_schema('functional_alltypes')\n",
-    "schema"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Databases can be created, too, and you can set the storage path in HDFS you want for the data files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "db = 'ibis_testing2'\n",
-    "con.create_database(db, path='/__ibis/my-test-database', force=True)\n",
-    "\n",
-    "# you may or may not have to give the impala user write and execute permissions to '/__ibis/my-test-database'\n",
-    "hdfs.chmod('/__ibis/my-test-database', '777')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.create_table('example_table', con.table('functional_alltypes'),\n",
-    "                 database=db, force=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Hopefully, there will be data files in the indicated spot in HDFS:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hdfs.ls('/__ibis/my-test-database')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To drop a database, including all tables in it, you can use `drop_database` with `force=True`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.drop_database(db, force=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Dealing with Partitioned tables in Impala"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Placeholder:** This is not yet implemented. If you have use cases, please let us know."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Faster queries on small data in Impala\n",
-    "\n",
-    "\n",
-    "Since Impala internally uses LLVM to compile parts of queries (aka \"codegen\") to make them faster on large data sets there is a certain amount of overhead with running many kinds of queries, even on small datasets. You can disable LLVM code generation when using Ibis, which may significantly speed up queries on smaller datasets:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from numpy.random import rand"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "con.disable_codegen()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t = con.table('ibis_testing.functional_alltypes')\n",
-    "\n",
-    "%timeit (t.double_col + rand()).sum().execute()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Turn codegen back on\n",
-    "con.disable_codegen(False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%timeit (t.double_col + rand()).sum().execute()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "It's important to remember that codegen is a fixed overhead and will significantly speed up queries on big data"
+    "Some backends support inserting data into existing tables from expressions. This can be done using `connection.insert('table_name', expr)`."
    ]
   }
  ],
@@ -653,9 +134,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Moving the Impala specific examples to the Impala backend doc, and using the standard examples for the rest of the tutorial 5.