### PR TITLE
FEAT: Add support for case/when in PySpark backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -13,6 +13,8 @@ Release Notes
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
 * :feature:`2607` Implement Not operation in PySpark backend
+* :feature:`2610` Added support for case/when in PySpark backend
+* :bug:`2610` Fixes a NPE issue with substr in PySpark backend
 * :feature:`2603` Add support for np.array as literals for backends that already support lists as literals
 * :bug:`2354` Fixes binary data type translation into BigQuery bytes data type
 * :bug:`2577` Make StructValue picklable

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -274,3 +274,24 @@ def test_special_strings(backend, con, alltypes, data, data_type):
     expr = alltypes[[alltypes.id, lit]].head(1)
     df = expr.execute()
     assert df['tmp'].iloc[0] == data
+
+
+@pytest.mark.xfail_unsupported
+def test_substr_with_null_values(backend, alltypes, pandas_df):
+    table = alltypes.mutate(
+        substr_col_null=ibis.case()
+        .when(alltypes['bool_col'], alltypes['string_col'])
+        .else_(None)
+        .end()
+        .substr(0, 2)
+    )
+
+    result = table.execute()
+
+    expected = pandas_df.copy()
+    mask = ~expected['bool_col']
+    expected['substr_col_null'] = expected['string_col']
+    expected['substr_col_null'][mask] = None
+    expected['substr_col_null'] = expected['substr_col_null'].str.slice(0, 2)
+
+    backend.assert_frame_equal(result, expected)


### PR DESCRIPTION
What's the change
==============
* Added support for case/when clause in PySpark backend
* Fixed a NPE issue with substr in PySpark backend
* Switch the implementation of substr in PySpark backend from UDF to built-in function and raise errors for unsupported case (when start and length is not static) 

How is this tested
=============
Add test under test_string.py for `substr`
Add test under test_generic.py for `case/when`