### PR TITLE
FEAT: API for creating array column from other columns

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2615` Add `ibis.array` for creating array expressions
 * :feature:`2607` Implement Not operation in PySpark backend
 * :feature:`2610` Added support for case/when in PySpark backend
 * :bug:`2610` Fixes a NPE issue with substr in PySpark backend

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -2,6 +2,7 @@ import itertools
 
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
+import numpy as np
 
 import ibis.expr.operations as ops
 from ibis.backends.pandas.execution.arrays import (
@@ -47,7 +48,9 @@ collect_list = dd.Aggregation(
 @execute_node.register(ops.ArrayColumn, list)
 def execute_array_column(op, cols, **kwargs):
     df = dd.concat(cols, axis=1)
-    return df.apply(lambda row: list(row), axis=1, meta=(None, 'object'))
+    return df.apply(
+        lambda row: np.array(row, dtype=object), axis=1, meta=(None, 'object')
+    )
 
 
 # TODO - aggregations - #2553

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -44,6 +44,12 @@ collect_list = dd.Aggregation(
 )
 
 
+@execute_node.register(ops.ArrayColumn, list)
+def execute_array_column(op, cols, **kwargs):
+    df = dd.concat(cols, axis=1)
+    return df.apply(lambda row: list(row), axis=1, meta=(None, 'object'))
+
+
 # TODO - aggregations - #2553
 @execute_node.register(ops.ArrayCollect, dd.Series)
 def execute_array_collect(op, data, aggcontext=None, **kwargs):

--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -1,5 +1,6 @@
 import operator
 
+import numpy as np
 import pandas as pd
 from pandas.core.groupby import SeriesGroupBy
 
@@ -11,7 +12,7 @@ from ..dispatch import execute_node
 @execute_node.register(ops.ArrayColumn, list)
 def execute_array_column(op, cols, **kwargs):
     df = pd.concat(cols, axis=1)
-    return df.apply(lambda row: list(row), axis=1)
+    return df.apply(lambda row: np.array(row, dtype=object), axis=1)
 
 
 @execute_node.register(ops.ArrayLength, pd.Series)

--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -8,6 +8,12 @@ import ibis.expr.operations as ops
 from ..dispatch import execute_node
 
 
+@execute_node.register(ops.ArrayColumn, list)
+def execute_array_column(op, cols, **kwargs):
+    df = pd.concat(cols, axis=1)
+    return df.apply(lambda row: list(row), axis=1)
+
+
 @execute_node.register(ops.ArrayLength, pd.Series)
 def execute_array_length(op, data, **kwargs):
     return data.apply(len)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1564,6 +1564,14 @@ def compile_interval_from_integer(t, expr, scope, timecontext, **kwargs):
 # -------------------------- Array Operations ----------------------------
 
 
+@compiles(ops.ArrayColumn)
+def compile_array_column(t, expr, scope, timecontext, **kwargs):
+    op = expr.op()
+
+    cols = t.translate(op.cols, scope, timecontext)
+    return F.array(cols)
+
+
 @compiles(ops.ArrayLength)
 def compile_array_length(t, expr, scope, timecontext, **kwargs):
     op = expr.op()

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -8,6 +8,19 @@ import ibis
 @pytest.mark.skip_missing_feature(
     ['supports_arrays', 'supports_arrays_outside_of_select']
 )
+def test_array_column(backend, alltypes, df):
+    expr = ibis.array_column(alltypes['double_col'], alltypes['double_col'],)
+    result = expr.execute()
+    expected = df.apply(
+        lambda row: [row['double_col'], row['double_col']], axis=1
+    )
+    backend.assert_series_equal(result, expected, check_names=False)
+
+
+@pytest.mark.xfail_unsupported
+@pytest.mark.skip_missing_feature(
+    ['supports_arrays', 'supports_arrays_outside_of_select']
+)
 # Issues #2370
 @pytest.mark.xfail_backends(['bigquery'])
 def test_array_concat(backend, con):

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -99,6 +99,7 @@ from ibis.expr.types import (  # noqa
     TimestampValue,
     TimeValue,
     ValueExpr,
+    array_column,
     as_value_expr,
     literal,
     null,
@@ -116,6 +117,7 @@ from ibis.expr.window import (
 
 __all__ = (
     'aggregate',
+    'array_column',
     'case',
     'cast',
     'coalesce',

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -99,7 +99,7 @@ from ibis.expr.types import (  # noqa
     TimestampValue,
     TimeValue,
     ValueExpr,
-    array_column,
+    array,
     as_value_expr,
     literal,
     null,
@@ -117,7 +117,7 @@ from ibis.expr.window import (
 
 __all__ = (
     'aggregate',
-    'array_column',
+    'array',
     'case',
     'cast',
     'coalesce',

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2835,6 +2835,21 @@ class IntervalFromInteger(ValueOp):
         return rlz.shape_like(self.arg, dtype=dtype)
 
 
+class ArrayColumn(ValueOp):
+    cols = Arg(rlz.list_of(rlz.column(rlz.any), min_length=1))
+
+    def _validate(self):
+        if len(set([col.type() for col in self.cols])) > 1:
+            raise com.IbisTypeError(
+                f'The types of all input columns must match exactly in a '
+                f'{type(self).__name__} operation.'
+            )
+
+    def output_type(self):
+        scalar_dtype = self.cols[0].type()
+        return dt.Array(scalar_dtype).column_type()
+
+
 class ArrayLength(UnaryOp):
     arg = Arg(rlz.array)
     output_type = rlz.shape_like('arg', dt.int64)

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2846,8 +2846,8 @@ class ArrayColumn(ValueOp):
             )
 
     def output_type(self):
-        scalar_dtype = self.cols[0].type()
-        return dt.Array(scalar_dtype).column_type()
+        first_dtype = self.cols[0].type()
+        return dt.Array(first_dtype).column_type()
 
 
 class ArrayLength(UnaryOp):

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -1267,6 +1267,36 @@ def as_value_expr(val):
     return val
 
 
+def array_column(*cols):
+    """Create an array column.
+
+    The input columns are concatenated row-wise to produce each array in the
+    output array column. Each array will have length n, where n is the number
+    of input columns.
+
+    All input columns should be of the same datatype.
+
+    Parameters
+    ----------
+    cols : list
+        List of Ibis column expressions
+
+    Returns
+    -------
+    array_column : ArrayColumn
+        An array column composed of values from the input columns
+
+    Examples
+    --------
+    >>> import ibis
+    >>> t = ibis.table([('a', 'int64'), ('b', 'int64')], name='t')
+    >>> result = ibis.array_column(t.a, t.b)
+    """
+    import ibis.expr.operations as ops
+
+    return ops.ArrayColumn(cols).to_expr()
+
+
 def param(type):
     """Create a parameter of a particular type to be defined just before
     execution.

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -8,7 +8,7 @@ def test_top_level_api():
         'NA',
         'Schema',
         'aggregate',
-        'array_column',
+        'array',
         'api',
         'case',
         'cast',

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -8,6 +8,7 @@ def test_top_level_api():
         'NA',
         'Schema',
         'aggregate',
+        'array_column',
         'api',
         'case',
         'cast',


### PR DESCRIPTION
## New operation

This PR adds a new operation called `ArrayColumn`.

**Input:** list of _n_ `ColumnExprs` (of the same datatype)
**Output:** single `ArrayColumn`, where each element is an array of length _n_. Each array is populated from the values in the input columns for that row.
(See *New API* section below for an example)

This operation is similar to PySpark's `array(*cols)` ([link](https://spark.apache.org/docs/latest/api/python/pyspark.sql.html#pyspark.sql.functions.array)) and Postgres's `array[...]` ([link](https://www.postgresql.org/docs/current/sql-expressions.html#SQL-SYNTAX-ARRAY-CONSTRUCTORS)).

I have implemented the operation on the following backends so far:
* PySpark
* Pandas
* Dask

## New API

The operation is exposed through a new top-level function: `ibis.array_column(*cols)` (other examples of a top-level functions are: `ibis.literal(value)`, `ibis.sequence(values)`, and `ibis.null()`).

Here is an example of the new API:

```
>>> t.execute()
   foo  bar
0    1    4
1    2    5
2    3    6
>>> expr = ibis.array_column(t.foo, t.bar)
>>> type(expr)
<class 'ibis.expr.types.ArrayColumn'>
>>> expr.execute()
0    [1, 4]
1    [2, 5]
2    [3, 6]
dtype: object
```

#### Variation 1: Name the function `ibis.array(*cols)` instead
This would be more parallel to how PySpark and Postgres names this kind of operation.

I've initially chosen to name it `array_column` to avoid implying that this function could be used to create an `ArrayScalar` (it can only create an `ArrayColumn`). If the user wants to create an `ArrayScalar`, they must use `ibis.literal`:
```
>>> expr = ibis.literal([1, 2, 3])
>>> type(expr)
<class 'ibis.expr.types.ArrayScalar'>
```

As an extension to this, we could have `ibis.array(*exprs)` produce _either_ an `ArrayColumn` or `ArrayScalar`, depending on its inputs. My concern is that this would overlap with `ibis.literal`.

#### Variation 2: Allow a mix of column and scalar expressions as input
Currently, the inputs must be column expressions only. We could accept a mix of column expressions + scalar expressions as well (but there must be at least one column expression). Any scalars in the list of inputs would be broadcast to all the rows. PySpark `array` and Postgres `array` both allow this.

I've started this PR off with _only_ column expressions accepted, since it's more restrictive, but I think there's definitely merit to allowing scalar expressions.

