### PR TITLE
ENH: Partial sorting support in dask backend

### DIFF
--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -479,20 +479,26 @@ def test_series_limit(t, df, offset):
     tm.assert_series_equal(result, df.plain_int64.iloc[offset : offset + n])
 
 
-@pytest.mark.xfail(reason="TODO - sorting - #2553")
 @pytest.mark.parametrize(
     ('key', 'dask_by', 'dask_ascending'),
     [
-        (lambda t, col: [ibis.desc(t[col])], lambda col: [col], False),
-        (
-            lambda t, col: [t[col], ibis.desc(t.plain_int64)],
+        (lambda t, col: [t[col]], lambda col: [col], True),
+        pytest.param(
+            lambda t, col: [ibis.desc(t[col])],
+            lambda col: [col],
+            False,
+            marks=pytest.mark.xfail(reason="TODO -sorting - #2553"),
+        ),
+        pytest.param(
+            lambda t, col: [t[col], t.plain_int64],
             lambda col: [col, 'plain_int64'],
             [True, False],
+            marks=pytest.mark.xfail(reason="TODO - sorting - #2553"),
         ),
         (
-            lambda t, col: [ibis.desc(t.plain_int64 * 2)],
+            lambda t, col: [t.plain_int64 * 2],
             lambda col: ['plain_int64'],
-            False,
+            True,
         ),
     ],
 )

--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -160,8 +160,6 @@ def alltypes(backend):
 
 @pytest.fixture(scope='session')
 def sorted_alltypes(backend, alltypes):
-    if backend.name() == 'dask':
-        pytest.skip("# TODO - sorting - #2553")
     return alltypes.sort_by('id')
 
 
@@ -200,10 +198,8 @@ def pandas_df(backend, alltypes):
 
 
 @pytest.fixture(scope='session')
-def sorted_df(backend, df):
-    if backend.name() == 'dask':
-        pytest.skip("# TODO - sorting - #2553")
-    return df.sort_values('id').reset_index(drop=True)
+def sorted_df(backend, pandas_df):
+    return pandas_df.sort_values('id').reset_index(drop=True)
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -97,7 +97,7 @@ def test_aggregate_grouped(
         .reset_index()
     )
 
-    # TODO - sorting - #2553
+    # TODO - pandas - #2553
     if backend.name() != 'dask':
         # Row ordering may differ depending on backend, so sort on the
         # grouping key
@@ -295,17 +295,16 @@ def test_group_concat(backend, alltypes, pandas_df, result_fn, expected_fn):
     ],
 )
 @pytest.mark.xfail_unsupported
-# TODO - sorting - #2553
-@pytest.mark.xfail_backends(['dask', 'pyspark'])  # Issue #2130
-def test_topk_op(backend, alltypes, df, result_fn, expected_fn):
+@pytest.mark.xfail_backends(['pyspark'])  # Issue #2130
+def test_topk_op(backend, alltypes, pandas_df, result_fn, expected_fn):
     # TopK expression will order rows by "count" but each backend
     # can have different result for that.
     # Note: Maybe would be good if TopK could order by "count"
     # and the field used by TopK
     t = alltypes.sort_by(alltypes.string_col)
-    df = df.sort_values('string_col')
+    pandas_df = pandas_df.sort_values('string_col')
     result = result_fn(t).execute()
-    expected = expected_fn(df)
+    expected = expected_fn(pandas_df)
     assert all(result['count'].values == expected.values)
 
 
@@ -325,18 +324,15 @@ def test_topk_op(backend, alltypes, df, result_fn, expected_fn):
 )
 @pytest.mark.xfail_unsupported
 # Issues #2369 #2133 #2131 #2132
-# TODO - sorting - #2553
-@pytest.mark.xfail_backends(
-    ['bigquery', 'clickhouse', 'dask', 'mysql', 'postgres']
-)
+@pytest.mark.xfail_backends(['bigquery', 'clickhouse', 'mysql', 'postgres'])
 @pytest.mark.skip_backends(['sqlite'], reason='Issue #2128')
-def test_topk_filter_op(backend, alltypes, df, result_fn, expected_fn):
+def test_topk_filter_op(backend, alltypes, pandas_df, result_fn, expected_fn):
     # TopK expression will order rows by "count" but each backend
     # can have different result for that.
     # Note: Maybe would be good if TopK could order by "count"
     # and the field used by TopK
     t = alltypes.sort_by(alltypes.string_col)
-    df = df.sort_values('string_col')
+    pandas_df = pandas_df.sort_values('string_col')
     result = result_fn(t).execute()
-    expected = expected_fn(df)
+    expected = expected_fn(pandas_df)
     assert result.shape[0] == expected.shape[0]

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -50,6 +50,7 @@ def test_coalesce(backend, con, expr, expected):
         assert result == expected
 
 
+@pytest.mark.skip_backends(['dask'])  # TODO - identicalTo - #2553
 @pytest.mark.xfail_unsupported
 def test_identical_to(backend, alltypes, con, sorted_df):
     sorted_alltypes = alltypes.sort_by('id')
@@ -81,7 +82,6 @@ def test_identical_to(backend, alltypes, con, sorted_df):
         ('int_col', frozenset({1})),
     ],
 )
-@pytest.mark.skip_backends(['dask'])  # TODO - sorting - #2553
 @pytest.mark.xfail_unsupported
 def test_isin(backend, alltypes, sorted_df, column, elements):
     sorted_alltypes = alltypes.sort_by('id')
@@ -106,7 +106,6 @@ def test_isin(backend, alltypes, sorted_df, column, elements):
         ('int_col', frozenset({1})),
     ],
 )
-@pytest.mark.skip_backends(['dask'])  # TODO - sorting - #2553
 @pytest.mark.xfail_unsupported
 def test_notin(backend, alltypes, sorted_df, column, elements):
     sorted_alltypes = alltypes.sort_by('id')

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -29,7 +29,7 @@ all_db_join_supported = ['pandas', 'pyspark']
 )
 @pytest.mark.only_on_backends(all_db_join_supported)
 # Csv is a subclass of Pandas so need to skip it explicitly.
-# TODO - sorting - #2553
+# TODO - pandas - #2553
 @pytest.mark.skip_backends(['csv', 'dask'])
 @pytest.mark.xfail_unsupported
 def test_join_project_left_table(backend, con, batting, awards_players, how):

--- a/ibis/backends/tests/test_union.py
+++ b/ibis/backends/tests/test_union.py
@@ -6,7 +6,7 @@ import pytest
 @pytest.mark.only_on_backends(
     ['bigquery', 'impala', 'pandas', 'postrges', 'pyspark']
 )
-@pytest.mark.skip_backends(['dask'])  # TODO - sorting - #2553 (pd.concat)
+@pytest.mark.skip_backends(['dask'])  # TODO - pandas - #2553
 @pytest.mark.xfail_unsupported
 def test_union(backend, alltypes, df, distinct):
     result = alltypes.union(alltypes, distinct=distinct).execute()


### PR DESCRIPTION
This PR adds limited sorting support for the dask backend. These limitations stem form `dask` having no existing way to do sorting, see discussion below. 

Limitations:

- Sorts must be on a single column (or expression resulting in a single column)
- Only ascending sort is supported. 

To accomplish sorting in the dask backend, we cheat a bit and `assign` a temporary column, `set_index` it, then `reset_index(drop=True)`. 

Having dug around a bit, I think it is definitely possible to use the machinery of `set_index` to create a more general sorting method here, though arguably that should live in upstream dask, not an ibis util function. I'm not yet sure how we would support multi column sorts without making that too complicated (should be doable if we can partition the frame correctly and use `map_partitions` to `sort_values` inside each partition. 


<hr />

This PR also:

-  Reclassifies some tests for failing for "pandas used in tests code" reasons rather than dask backend reasons. These should go away via https://github.com/ibis-project/ibis/issues/2604. 
- Uncovered a bug in the dask backend using `ops.IdenticalTo`. I've xfailed for now, will add to the tracker, and do as a follow on. 

Todo: 

- [ ] Update https://github.com/ibis-project/ibis/issues/2553 with things that were done + reclassification. 

