### PR TITLE
TST: Add back assert in test_filter

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -135,6 +135,8 @@ def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
     result = table.execute()
     expected = sorted_df[expected_fn(sorted_df)]
 
+    backend.assert_frame_equal(result, expected)
+
 
 @pytest.mark.xfail_unsupported
 def test_case_where(backend, alltypes, pandas_df):


### PR DESCRIPTION
Looks like it was accidentally dropped in https://github.com/ibis-project/ibis/pull/2610/