### PR TITLE
ENH: Change dask backend to return computed objects  with .execute()

### DIFF
--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -1,8 +1,8 @@
 """The dask backend is a very close port of the pandas backend, and thus
-has the same caveats.
+has the similar caveats.
 
 The dask backend is a departure from the typical ibis backend in that it
-doesn't compile to anything, and the execution of the ibis expression
+doesn't compile to anything and the execution of the ibis expression
 is under the purview of ibis itself rather than executing SQL on a server.
 
 Design
@@ -17,9 +17,8 @@ polymorphism to multiple arguments.
 
 Compilation
 -----------
-This is a no-op because we execute ibis expressions directly. However, the
-dask backend will pass back a dask expression that you can run `.compute()`
-on to evaluate it.
+The ibis backend uses the ibis dispatching machinery to "compile" a dask
+TaskGraph you can run `.compute()` on to evaluate it.
 
 Execution
 ---------

--- a/ibis/backends/dask/tests/conftest.py
+++ b/ibis/backends/dask/tests/conftest.py
@@ -48,44 +48,15 @@ class TestConf(PandasTest):
             }
         )
 
-    # @staticmethod
-    # def default_series_rename(
-    #     series: pd.Series, name: str = 'tmp'
-    # ) -> pd.Series:
-    #     return series.compute().rename(name)
-
     @classmethod
     def assert_series_equal(
-        cls, left, right, *args: Any, **kwargs: Any
+        cls, left: pd.DataFrame, right: pd.DataFrame, *args: Any, **kwargs: Any
     ) -> None:
         kwargs.setdefault('check_dtype', cls.check_dtype)
         kwargs.setdefault('check_names', cls.check_names)
-        # we sometimes use pandas to build the "expected" case in tests
-        incoming_types = tuple(map(type, (left, right)))
-        if incoming_types == (dd.Series, pd.Series):
-            if left.npartitions > 1:
-                # if there is more than one partition `reset_index` in
-                # `core.execute_and_reset` will not lead to a monotonically
-                # increasing index, so we reset to match our expected case.
-                left = left.compute().reset_index(drop=True)
-            else:
-                left = left.compute()
-        else:
-            left = left.compute()
-            right = right.compute()
-
-        tm.assert_series_equal(left, right, *args, **kwargs)
-
-    @classmethod
-    def assert_frame_equal(
-        cls, left, right, *args: Any, **kwargs: Any
-    ) -> None:
-        left = left.compute().reset_index(drop=True)
-        # we sometimes use pandas to build the "expected" case in tests
-        if isinstance(right, dd.DataFrame):
-            right = right.compute()
+        left = left.reset_index(drop=True)
         right = right.reset_index(drop=True)
-        tm.assert_frame_equal(left, right, *args, **kwargs)
+        tm.assert_series_equal(left, right, *args, **kwargs)
 
 
 @pytest.fixture

--- a/ibis/backends/dask/tests/execution/test_cast.py
+++ b/ibis/backends/dask/tests/execution/test_cast.py
@@ -132,7 +132,7 @@ def test_timestamp_with_timezone_is_inferred_correctly(t, df):
 )
 def test_cast_date(t, df, column):
     expr = t[column].cast('date')
-    result = expr.execute()
+    result = expr.compile()
     expected = df[column].dt.normalize()
     tm.assert_series_equal(result.compute(), expected.compute())
 
@@ -140,7 +140,7 @@ def test_cast_date(t, df, column):
 @pytest.mark.parametrize('type', [dt.Decimal(9, 0), dt.Decimal(12, 3)])
 def test_cast_to_decimal(t, df, type):
     expr = t.float64_as_strings.cast(type)
-    result = expr.execute()
+    result = expr.compile()
     context = decimal.Context(prec=type.precision)
     expected = df.float64_as_strings.apply(
         lambda x: context.create_decimal(x).quantize(
@@ -167,7 +167,7 @@ def test_cast_to_decimal(t, df, type):
     'column', ['plain_int64', 'dup_strings', 'dup_ints', 'strings_with_nulls'],
 )
 def test_cast_to_category(t, df, column):
-    test = t[column].cast('category').execute()
+    test = t[column].cast('category').compile()
     tm.assert_series_equal(
         test.compute(), df[column].astype('category').compute()
     )

--- a/ibis/backends/dask/tests/execution/test_join.py
+++ b/ibis/backends/dask/tests/execution/test_join.py
@@ -49,7 +49,7 @@ def test_join(how, left, right, df1, df2):
     expr = left.join(right, left.key == right.key, how=how)[
         left, right.other_value, right.key3
     ]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge(df1, df2, how=how, on='key')
     tm.assert_frame_equal(
         result[expected.columns].compute(scheduler='single-threaded'),
@@ -59,7 +59,7 @@ def test_join(how, left, right, df1, df2):
 
 def test_cross_join(left, right, df1, df2):
     expr = left.cross_join(right)[left, right.other_value, right.key3]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge(
         df1.assign(dummy=1), df2.assign(dummy=1), how='inner', on='dummy'
     ).rename(columns=dict(key_x='key'))
@@ -73,7 +73,7 @@ def test_cross_join(left, right, df1, df2):
 @join_type
 def test_join_project_left_table(how, left, right, df1, df2):
     expr = left.join(right, left.key == right.key, how=how)[left, right.key3]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge(df1, df2, how=how, on='key')[
         list(left.columns) + ['key3']
     ]
@@ -85,7 +85,7 @@ def test_join_project_left_table(how, left, right, df1, df2):
 
 def test_cross_join_project_left_table(left, right, df1, df2):
     expr = left.cross_join(right)[left, right.key3]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge(
         df1.assign(dummy=1), df2.assign(dummy=1), how='inner', on='dummy'
     ).rename(columns=dict(key_x='key'))[list(left.columns) + ['key3']]
@@ -100,7 +100,7 @@ def test_join_with_multiple_predicates(how, left, right, df1, df2):
     expr = left.join(
         right, [left.key == right.key, left.key2 == right.key3], how=how
     )[left, right.key3, right.other_value]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge(
         df1, df2, how=how, left_on=['key', 'key2'], right_on=['key', 'key3']
     ).reset_index(drop=True)
@@ -118,7 +118,7 @@ def test_join_with_multiple_predicates_written_as_one(
     expr = left.join(right, predicate, how=how)[
         left, right.key3, right.other_value
     ]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge(
         df1, df2, how=how, left_on=['key', 'key2'], right_on=['key', 'key3']
     ).reset_index(drop=True)
@@ -133,12 +133,12 @@ def test_join_with_invalid_predicates(how, left, right):
     predicate = (left.key == right.key) & (left.key2 <= right.key3)
     expr = left.join(right, predicate, how=how)
     with pytest.raises(TypeError):
-        expr.execute()
+        expr.compile()
 
     predicate = left.key >= right.key
     expr = left.join(right, predicate, how=how)
     with pytest.raises(TypeError):
-        expr.execute()
+        expr.compile()
 
 
 @join_type
@@ -151,7 +151,7 @@ def test_join_with_duplicate_non_key_columns(how, left, right, df1, df2):
     # This is undefined behavior because `x` is duplicated. This is difficult
     # to detect
     with pytest.raises(ValueError):
-        expr.execute()
+        expr.compile()
 
 
 @join_type
@@ -164,7 +164,7 @@ def test_join_with_duplicate_non_key_columns_not_selected(
     expr = left.join(right, left.key == right.key, how=how)[
         left, right.other_value
     ]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge(
         df1.assign(x=df1.value * 2),
         df2[['key', 'other_value']],
@@ -181,7 +181,7 @@ def test_join_with_duplicate_non_key_columns_not_selected(
 def test_join_with_post_expression_selection(how, left, right, df1, df2):
     join = left.join(right, left.key == right.key, how=how)
     expr = join[left.key, left.value, right.other_value]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge(df1, df2, on='key', how=how)[
         ['key', 'value', 'other_value']
     ]
@@ -199,10 +199,10 @@ def test_join_with_post_expression_filter(how, left):
     joined = lhs.join(rhs, 'key2', how=how)
     projected = joined[lhs, rhs.value]
     expr = projected[projected.value == 4]
-    result = expr.execute()
+    result = expr.compile()
 
-    df1 = lhs.execute()
-    df2 = rhs.execute()
+    df1 = lhs.compile()
+    df2 = rhs.compile()
     expected = dd.merge(df1, df2, on='key2', how=how)
     expected = expected.loc[expected.value == 4].reset_index(drop=True)
 
@@ -226,11 +226,11 @@ def test_multi_join_with_post_expression_filter(how, left, df1):
     projected2 = joined2[filtered.key, rhs2.value2]
     expr = projected2[projected2.value2 == 3]
 
-    result = expr.execute()
+    result = expr.compile()
 
-    df1 = lhs.execute()
-    df2 = rhs.execute()
-    df3 = rhs2.execute()
+    df1 = lhs.compile()
+    df2 = rhs.compile()
+    df3 = rhs2.compile()
     expected = dd.merge(df1, df2, on='key2', how=how)
     expected = expected.loc[expected.value == 4].reset_index(drop=True)
     expected = dd.merge(expected, df3, on='key2')[['key', 'value2']]
@@ -248,7 +248,7 @@ def test_join_with_non_trivial_key(how, left, right, df1, df2):
     # also test that the order of operands in the predicate doesn't matter
     join = left.join(right, right.key.length() == left.key.length(), how=how)
     expr = join[left.key, left.value, right.other_value]
-    result = expr.execute()
+    result = expr.compile()
 
     expected = (
         dd.merge(
@@ -273,7 +273,7 @@ def test_join_with_non_trivial_key_project_table(how, left, right, df1, df2):
     join = left.join(right, right.key.length() == left.key.length(), how=how)
     expr = join[left, right.other_value]
     expr = expr[expr.key.length() == 1]
-    result = expr.execute()
+    result = expr.compile()
 
     expected = (
         dd.merge(
@@ -298,7 +298,7 @@ def test_join_with_project_right_duplicate_column(client, how, left, df1, df3):
     right = client.table('df3')
     join = left.join(right, ['key'], how=how)
     expr = join[left.key, right.key2, right.other_value]
-    result = expr.execute()
+    result = expr.compile()
 
     expected = (
         dd.merge(df1, df3, on='key', how=how)
@@ -323,7 +323,7 @@ def test_join_with_window_function(
         team_avg=lambda d: d.G.mean(),
         demeaned_by_player=lambda d: d.G - d.G.mean(),
     )
-    result = expr.execute()
+    result = expr.compile()
 
     expected = dd.merge(
         batting_df, players_df[['playerID']], on='playerID', how='left'
@@ -350,7 +350,7 @@ def test_asof_join(time_left, time_right, time_df1, time_df2):
     expr = time_left.asof_join(time_right, 'time')[
         time_left, time_right.other_value
     ]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge_asof(time_df1, time_df2, on='time')
     tm.assert_frame_equal(
         result[expected.columns].compute(scheduler='single-threaded'),
@@ -363,7 +363,7 @@ def test_asof_join_predicate(time_left, time_right, time_df1, time_df2):
     expr = time_left.asof_join(time_right, time_left.time == time_right.time)[
         time_left, time_right.other_value
     ]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge_asof(time_df1, time_df2, on='time')
     tm.assert_frame_equal(
         result[expected.columns].compute(scheduler='single-threaded'),
@@ -378,7 +378,7 @@ def test_keyed_asof_join(
     expr = time_keyed_left.asof_join(time_keyed_right, 'time', by='key')[
         time_keyed_left, time_keyed_right.other_value
     ]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge_asof(
         time_keyed_df1, time_keyed_df2, on='time', by='key'
     )
@@ -395,7 +395,7 @@ def test_keyed_asof_join_with_tolerance(
     expr = time_keyed_left.asof_join(
         time_keyed_right, 'time', by='key', tolerance=2 * ibis.interval(days=1)
     )[time_keyed_left, time_keyed_right.other_value]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.merge_asof(
         time_keyed_df1,
         time_keyed_df2,
@@ -454,7 +454,7 @@ def test_select_on_unambiguous_join(how, func, npartitions):
     ]
     assert not expected.compute(scheduler='single-threaded').empty
     expr = func(join)
-    result = expr.execute()
+    result = expr.compile()
     tm.assert_frame_equal(
         result.compute(scheduler='single-threaded'),
         expected.compute(scheduler='single-threaded'),
@@ -492,7 +492,7 @@ def test_select_on_unambiguous_asof_join(func, npartitions):
     ]
     assert not expected.compute(scheduler='single-threaded').empty
     expr = func(join)
-    result = expr.execute()
+    result = expr.compile()
     tm.assert_frame_equal(
         result.compute(scheduler='single-threaded'),
         expected.compute(scheduler='single-threaded'),

--- a/ibis/backends/dask/tests/execution/test_maps.py
+++ b/ibis/backends/dask/tests/execution/test_maps.py
@@ -7,7 +7,7 @@ import ibis
 
 def test_map_length_expr(t):
     expr = t.map_of_integers_strings.length()
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_pandas(
         pd.Series([0, None, 2], name='map_of_integers_strings'), npartitions=1,
     )
@@ -16,7 +16,7 @@ def test_map_length_expr(t):
 
 def test_map_value_for_key_expr(t):
     expr = t.map_of_integers_strings[1]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_pandas(
         pd.Series([None, None, 'a'], name='map_of_integers_strings'),
         npartitions=1,
@@ -26,7 +26,7 @@ def test_map_value_for_key_expr(t):
 
 def test_map_value_or_default_for_key_expr(t):
     expr = t.map_of_complex_values.get('a')
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_pandas(
         pd.Series(
             [None, [1, 2, 3], None],
@@ -44,7 +44,7 @@ def safe_sorter(element):
 
 def test_map_keys_expr(t):
     expr = t.map_of_strings_integers.keys()
-    result = expr.execute().map(safe_sorter)
+    result = expr.compile().map(safe_sorter)
     expected = dd.from_pandas(
         pd.Series(
             [['a', 'b'], None, []],
@@ -58,7 +58,7 @@ def test_map_keys_expr(t):
 
 def test_map_values_expr(t):
     expr = t.map_of_complex_values.values()
-    result = expr.execute().map(safe_sorter)
+    result = expr.compile().map(safe_sorter)
     expected = dd.from_pandas(
         pd.Series(
             [None, [[], [1, 2, 3]], []],
@@ -72,7 +72,7 @@ def test_map_values_expr(t):
 
 def test_map_concat_expr(t):
     expr = t.map_of_complex_values + {'b': [4, 5, 6], 'c': [], 'a': []}
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_pandas(
         pd.Series(
             [
@@ -91,7 +91,7 @@ def test_map_concat_expr(t):
 def test_map_value_for_key_literal_broadcast(t):
     lookup_table = ibis.literal({'a': 1, 'b': 2, 'c': 3, 'd': 4})
     expr = lookup_table.get(t.dup_strings)
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_pandas(
         pd.Series([4, 1, 4], name='dup_strings'), npartitions=1,
     )

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.dask
 
 def test_table_column(t, df):
     expr = t.plain_int64
-    result = expr.execute()
+    result = expr.compile()
     expected = df.plain_int64
     tm.assert_series_equal(result.compute(), expected.compute())
 
@@ -38,7 +38,7 @@ def test_selection(t, df):
         ((t.plain_strings == 'a') | (t.plain_int64 == 3))
         & (t.dup_strings == 'd')
     ]
-    result = expr.execute()
+    result = expr.compile()
     expected = df[
         ((df.plain_strings == 'a') | (df.plain_int64 == 3))
         & (df.dup_strings == 'd')
@@ -50,7 +50,7 @@ def test_selection(t, df):
 
 def test_mutate(t, df):
     expr = t.mutate(x=t.plain_int64 + 1, y=t.plain_int64 * 2)
-    result = expr.execute()
+    result = expr.compile()
     expected = df.assign(x=df.plain_int64 + 1, y=df.plain_int64 * 2)
     tm.assert_frame_equal(
         result[expected.columns].compute(), expected.compute()
@@ -68,7 +68,7 @@ def test_project_scope_does_not_override(t, df):
             .name('grouped'),
         ]
     ]
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.concat(
         [
             df[['plain_int64', 'dup_strings']].rename(
@@ -122,7 +122,7 @@ def test_aggregation_group_by(t, df, where, ibis_func, dask_func):
         neg_mean_int64_with_zeros=(-t.int64_with_zeros).mean(where=ibis_where),
         nunique_dup_ints=t.dup_ints.nunique(),
     )
-    result = expr.execute()
+    result = expr.compile()
 
     dask_where = where(df.compute())
     mask = slice(None) if dask_where is None else dask_where
@@ -181,7 +181,7 @@ def test_aggregation_without_group_by(t, df):
         avg_plain_int64=t.plain_int64.mean(),
         sum_plain_float64=t.plain_float64.sum(),
     )
-    result = expr.execute()[['avg_plain_int64', 'sum_plain_float64']]
+    result = expr.compile()[['avg_plain_int64', 'sum_plain_float64']]
     new_names = {
         'plain_float64': 'sum_plain_float64',
         'plain_int64': 'avg_plain_int64',
@@ -208,7 +208,7 @@ def test_group_by_with_having(t, df):
         .having(t.plain_float64.sum() == 5)
         .aggregate(avg_a=t.plain_int64.mean(), sum_c=t.plain_float64.sum())
     )
-    result = expr.execute()
+    result = expr.compile()
 
     expected = (
         df.groupby('dup_strings')
@@ -229,7 +229,7 @@ def test_group_by_rename_key(t, df):
     )
 
     assert 'foo' in expr.schema()
-    result = expr.execute()
+    result = expr.compile()
     assert 'foo' in result.columns
 
     expected = (
@@ -256,7 +256,7 @@ def test_reduction(t, df, reduction, where):
     func = getattr(t.plain_int64, reduction)
     mask = where(t)
     expr = func(where=mask)
-    result = expr.execute()
+    result = expr.compile()
 
     df_mask = where(df)
     expected_func = getattr(
@@ -285,7 +285,7 @@ def test_grouped_reduction(t, df, where):
         var_plain_int64=t.plain_int64.var(where=ibis_where),
         nunique_plain_int64=t.plain_int64.nunique(where=ibis_where),
     )
-    result = expr.execute()
+    result = expr.compile()
 
     df_mask = where(df.compute())
     mask = slice(None) if df_mask is None else df_mask
@@ -359,7 +359,7 @@ def test_grouped_reduction(t, df, where):
 )
 def test_boolean_aggregation(t, df, reduction):
     expr = reduction(t.plain_int64 == 1)
-    result = expr.execute()
+    result = expr.compile()
     expected = reduction(df.plain_int64 == 1)
     assert result.compute() == expected.compute()
 
@@ -367,7 +367,7 @@ def test_boolean_aggregation(t, df, reduction):
 @pytest.mark.parametrize('column', ['float64_with_zeros', 'int64_with_zeros'])
 def test_null_if_zero(t, df, column):
     expr = t[column].nullifzero()
-    result = expr.execute()
+    result = expr.compile()
     expected = df[column].replace(0, np.nan)
     tm.assert_series_equal(result.compute(), expected.compute())
 
@@ -431,7 +431,7 @@ def test_nullif_inf(npartitions):
     con = connect(dict(t=df))
     t = con.table('t')
     expr = t.a.nullif(np.inf).nullif(-np.inf)
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_pandas(
         pd.Series([np.nan, 3.14, np.nan, 42.0], name='a'),
         npartitions=npartitions,
@@ -445,7 +445,7 @@ def test_group_concat(t, df):
     expr = t.groupby(t.dup_strings).aggregate(
         foo=t.plain_int64.group_concat(',')
     )
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.groupby('dup_strings')
         .apply(lambda df: ','.join(df.plain_int64.astype(str)))
@@ -461,7 +461,7 @@ def test_group_concat(t, df):
 def test_frame_limit(t, df, offset):
     n = 5
     df_expr = t.limit(n, offset=offset)
-    result = df_expr.execute()
+    result = df_expr.compile()
     expected = df.loc[offset : offset + n].reset_index(drop=True)
     tm.assert_frame_equal(
         result[expected.columns].compute(), expected.compute()
@@ -475,7 +475,7 @@ def test_frame_limit(t, df, offset):
 def test_series_limit(t, df, offset):
     n = 5
     s_expr = t.plain_int64.limit(n, offset=offset)
-    result = s_expr.execute()
+    result = s_expr.compile()
     tm.assert_series_equal(result, df.plain_int64.iloc[offset : offset + n])
 
 
@@ -508,7 +508,7 @@ def test_series_limit(t, df, offset):
 )
 def test_sort_by(t, df, column, key, dask_by, dask_ascending):
     expr = t.sort_by(key(t, column))
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.compute()
         .sort_values(dask_by(column), ascending=dask_ascending)
@@ -522,7 +522,7 @@ def test_complex_sort_by(t, df):
     expr = t.sort_by(
         [ibis.desc(t.plain_int64 * t.plain_float64), t.plain_float64]
     )
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.assign(foo=df.plain_int64 * df.plain_float64)
         .sort_values(['foo', 'plain_float64'], ascending=[False, True])
@@ -537,21 +537,21 @@ def test_complex_sort_by(t, df):
 
 def test_distinct(t, df):
     expr = t.dup_strings.distinct()
-    result = expr.execute()
+    result = expr.compile()
     expected = df.dup_strings.unique()
     tm.assert_series_equal(result.compute(), expected.compute())
 
 
 def test_count_distinct(t, df):
     expr = t.dup_strings.nunique()
-    result = expr.execute()
+    result = expr.compile()
     expected = df.dup_strings.nunique()
     assert result.compute() == expected.compute()
 
 
 def test_value_counts(t, df):
     expr = t.dup_strings.value_counts()
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.compute()
         .dup_strings.value_counts()
@@ -566,7 +566,7 @@ def test_value_counts(t, df):
 
 def test_table_count(t, df):
     expr = t.count()
-    result = expr.execute()
+    result = expr.compile()
     expected = len(df)
     assert result == expected
 
@@ -575,7 +575,7 @@ def test_weighted_average(t, df):
     expr = t.groupby(t.dup_strings).aggregate(
         avg=(t.plain_float64 * t.plain_int64).sum() / t.plain_int64.sum()
     )
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.groupby('dup_strings')
         .apply(
@@ -594,7 +594,7 @@ def test_group_by_multiple_keys(t, df):
     expr = t.groupby([t.dup_strings, t.dup_ints]).aggregate(
         avg_plain_float64=t.plain_float64.mean()
     )
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.groupby(['dup_strings', 'dup_ints'])
         .agg({'plain_float64': 'mean'})
@@ -611,7 +611,7 @@ def test_mutate_after_group_by(t, df):
         avg_plain_float64=t.plain_float64.mean()
     )
     expr = gb.mutate(x=gb.avg_plain_float64)
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.groupby('dup_strings')
         .agg({'plain_float64': 'mean'})
@@ -631,7 +631,7 @@ def test_groupby_with_unnamed_arithmetic(t, df):
         )
         / t.plain_float64.count()
     )
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.compute()
         .groupby('dup_strings')
@@ -649,14 +649,14 @@ def test_groupby_with_unnamed_arithmetic(t, df):
 
 def test_isnull(t, df):
     expr = t.strings_with_nulls.isnull()
-    result = expr.execute()
+    result = expr.compile()
     expected = df.strings_with_nulls.isnull()
     tm.assert_series_equal(result.compute(), expected.compute())
 
 
 def test_notnull(t, df):
     expr = t.strings_with_nulls.notnull()
-    result = expr.execute()
+    result = expr.compile()
     expected = df.strings_with_nulls.notnull()
     tm.assert_series_equal(result.compute(), expected.compute())
 
@@ -665,7 +665,7 @@ def test_notnull(t, df):
 def test_scalar_parameter(t, df, raw_value):
     value = ibis.param(dt.double)
     expr = t.float64_with_zeros == value
-    result = expr.execute(params={value: raw_value})
+    result = expr.compile(params={value: raw_value})
     expected = df.float64_with_zeros == raw_value
     tm.assert_series_equal(result.compute(), expected.compute())
 
@@ -674,7 +674,7 @@ def test_scalar_parameter(t, df, raw_value):
 def test_isin(t, df, elements):
     expr = t.plain_float64.isin(elements)
     expected = df.plain_float64.isin(elements)
-    result = expr.execute()
+    result = expr.compile()
     tm.assert_series_equal(result.compute(), expected.compute())
 
 
@@ -682,7 +682,7 @@ def test_isin(t, df, elements):
 def test_notin(t, df, elements):
     expr = t.plain_float64.notin(elements)
     expected = ~df.plain_float64.isin(elements)
-    result = expr.execute()
+    result = expr.compile()
     tm.assert_series_equal(result.compute(), expected.compute())
 
 
@@ -691,7 +691,7 @@ def test_cast_on_group_by(t, df):
         casted=(t.float64_with_zeros == 0).cast('int64').sum()
     )
 
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.groupby('dup_strings')
         .float64_with_zeros.apply(lambda s: (s == 0).astype('int64').sum())
@@ -717,7 +717,7 @@ def test_cast_on_group_by(t, df):
 @pytest.mark.parametrize('args', [lambda c: (1.0, c), lambda c: (c, 1.0)])
 def test_left_binary_op(t, df, op, args):
     expr = op(*args(t.float64_with_zeros))
-    result = expr.execute()
+    result = expr.compile()
     expected = op(*args(df.float64_with_zeros))
     tm.assert_series_equal(result.compute(), expected.compute())
 
@@ -740,7 +740,7 @@ def test_left_binary_op_gb(t, df, op, argfunc):
     expr = t.groupby('dup_strings').aggregate(
         foo=op(*argfunc(t.float64_with_zeros)).sum()
     )
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.groupby('dup_strings')
         .float64_with_zeros.apply(lambda s: op(*argfunc(s)).sum())
@@ -752,7 +752,7 @@ def test_left_binary_op_gb(t, df, op, argfunc):
 
 def test_where_series(t, df):
     col_expr = t['plain_int64']
-    result = ibis.where(col_expr > col_expr.mean(), col_expr, 0.0).execute()
+    result = ibis.where(col_expr > col_expr.mean(), col_expr, 0.0).compile()
 
     ser = df['plain_int64']
     expected = ser.where(ser > ser.mean(), other=0.0)
@@ -769,14 +769,14 @@ def test_where_series(t, df):
 )
 def test_where_scalar(t, df, cond, expected_func):
     expr = ibis.where(cond, t['plain_int64'], 3.0)
-    result = expr.execute()
+    result = expr.compile()
     expected = expected_func(df)
     tm.assert_series_equal(result.compute(), expected.compute())
 
 
 def test_where_long(batting, batting_df):
     col_expr = batting['AB']
-    result = ibis.where(col_expr > col_expr.mean(), col_expr, 0.0).execute()
+    result = ibis.where(col_expr > col_expr.mean(), col_expr, 0.0).compile()
 
     ser = batting_df['AB']
     expected = ser.where(ser > ser.mean(), other=0.0)
@@ -787,7 +787,7 @@ def test_where_long(batting, batting_df):
 def test_round(t, df):
     precision = 2
     mult = 3.33333
-    result = (t.count() * mult).round(precision).execute()
+    result = (t.count() * mult).round(precision).compile()
     expected = np.around(len(df) * mult, precision)
     npt.assert_almost_equal(result, expected, decimal=precision)
 
@@ -802,7 +802,7 @@ def test_quantile_groupby(batting, batting_df):
     result = (
         batting.groupby('teamID')
         .mutate(res=lambda x: x.RBI.quantile([frac, 1 - frac], intp))
-        .res.execute()
+        .res.compile()
     )
     expected = (
         batting_df.groupby('teamID')
@@ -814,7 +814,7 @@ def test_quantile_groupby(batting, batting_df):
 
 def test_summary_numeric(batting, batting_df):
     expr = batting.G.summary()
-    result = expr.execute()
+    result = expr.compile()
     assert len(result) == 1
 
     G = batting_df.G
@@ -832,7 +832,7 @@ def test_summary_numeric(batting, batting_df):
 
 def test_summary_numeric_group_by(batting, batting_df):
     expr = batting.groupby('teamID').G.summary()
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         batting_df.groupby('teamID')
         .G.apply(
@@ -862,7 +862,7 @@ def test_summary_numeric_group_by(batting, batting_df):
 
 def test_summary_non_numeric(batting, batting_df):
     expr = batting.teamID.summary()
-    result = expr.execute()
+    result = expr.compile()
     assert len(result) == 1
     assert len(result.columns) == 3
     expected = dict(
@@ -875,7 +875,7 @@ def test_summary_non_numeric(batting, batting_df):
 
 def test_summary_non_numeric_group_by(batting, batting_df):
     expr = batting.groupby('teamID').playerID.summary()
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         batting_df.groupby('teamID')
         .playerID.apply(
@@ -915,7 +915,7 @@ def test_searched_case_column(batting, batting_df):
         .else_(t.teamID)
         .end()
     )
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_array(
         np.select(
             [df.RBI < 5, df.teamID == 'PH1'],
@@ -945,7 +945,7 @@ def test_simple_case_column(batting, batting_df):
         .else_('could be good?')
         .end()
     )
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_array(
         np.select(
             [df.RBI == 5, df.RBI == 4, df.RBI == 3],
@@ -958,7 +958,7 @@ def test_simple_case_column(batting, batting_df):
 
 def test_table_distinct(t, df):
     expr = t[['dup_strings']].distinct()
-    result = expr.execute()
+    result = expr.compile()
     expected = df[['dup_strings']].drop_duplicates()
     tm.assert_frame_equal(result.compute(), expected.compute())
 
@@ -967,7 +967,7 @@ def test_table_distinct(t, df):
 def test_union(client, df1, distinct):
     t = client.table('df1')
     expr = t.union(t, distinct=distinct)
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df1 if distinct else dd.concat([df1, df1], axis=0, ignore_index=True)
     )
@@ -983,7 +983,7 @@ def test_intersect(client, df1, intersect_df2):
     t1 = client.table('df1')
     t2 = client.table('intersect_df2')
     expr = t1.intersect(t2)
-    result = expr.execute()
+    result = expr.compile()
     expected = df1.merge(intersect_df2, on=list(df1.columns))
     tm.assert_frame_equal(result.compute(), expected.compute())
 
@@ -992,7 +992,7 @@ def test_difference(client, df1, intersect_df2):
     t1 = client.table('df1')
     t2 = client.table('intersect_df2')
     expr = t1.difference(t2)
-    result = expr.execute()
+    result = expr.compile()
     merged = df1.merge(
         intersect_df2, on=list(df1.columns), how="outer", indicator=True
     )
@@ -1023,7 +1023,7 @@ def test_difference(client, df1, intersect_df2):
 )
 def test_union_with_list_types(t, df, distinct):
     expr = t.union(t, distinct=distinct)
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df if distinct else dd.concat([df, df], axis=0, ignore_index=True)
     )

--- a/ibis/backends/dask/tests/execution/test_strings.py
+++ b/ibis/backends/dask/tests/execution/test_strings.py
@@ -103,7 +103,7 @@ def test_string_ops(t, df, case_func, expected_func):
     # ignore matching UserWarnings
     with catch_warnings(record=True):
         expr = case_func(t.strings_with_space)
-        result = expr.execute()
+        result = expr.compile()
         series = expected_func(df.strings_with_space)
         tm.assert_series_equal(result.compute(), series.compute())
 
@@ -113,7 +113,7 @@ def test_grouped_string_re_search(t, df):
         sum=t.strings_with_space.re_search('(ab)+').cast('int64').sum()
     )
 
-    result = expr.execute()
+    result = expr.compile()
     expected = (
         df.groupby('dup_strings')
         .strings_with_space.apply(

--- a/ibis/backends/dask/tests/execution/test_structs.py
+++ b/ibis/backends/dask/tests/execution/test_structs.py
@@ -65,7 +65,7 @@ def test_struct_field_literal(value):
 def test_struct_field_series(struct_table):
     t = struct_table
     expr = t.s['fruit']
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_pandas(
         pd.Series(["apple", "pear", "pear"], name="fruit"), npartitions=1,
     )
@@ -75,7 +75,7 @@ def test_struct_field_series(struct_table):
 def test_struct_field_series_group_by_key(struct_table):
     t = struct_table
     expr = t.groupby(t.s['fruit']).aggregate(total=t.value.sum())
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_pandas(
         pd.DataFrame([("apple", 1), ("pear", 5)], columns=["fruit", "total"]),
         npartitions=1,
@@ -86,7 +86,7 @@ def test_struct_field_series_group_by_key(struct_table):
 def test_struct_field_series_group_by_value(struct_table):
     t = struct_table
     expr = t.groupby(t.key).aggregate(total=t.s['weight'].sum())
-    result = expr.execute()
+    result = expr.compile()
     # these are floats because we have a NULL value in the input data
     expected = dd.from_pandas(
         pd.DataFrame([("a", 0.0), ("b", 1.0)], columns=["key", "total"]),

--- a/ibis/backends/dask/tests/execution/test_temporal.py
+++ b/ibis/backends/dask/tests/execution/test_temporal.py
@@ -64,9 +64,8 @@ def test_timestamp_functions(case_func, expected_func):
     ['datetime_strings_naive', 'datetime_strings_ny', 'datetime_strings_utc'],
 )
 def test_cast_datetime_strings_to_date(t, df, column):
-    # TODO - this is changed from the pandas test, double check
     expr = t[column].cast('date')
-    result = expr.execute()
+    result = expr.compile()
     df_computed = df.compute()
     expected = dd.from_pandas(
         pd.to_datetime(
@@ -83,7 +82,7 @@ def test_cast_datetime_strings_to_date(t, df, column):
 )
 def test_cast_datetime_strings_to_timestamp(t, df, column):
     expr = t[column].cast('timestamp')
-    result = expr.execute()
+    result = expr.compile()
     df_computed = df.compute()
     expected = dd.from_pandas(
         pd.to_datetime(df_computed[column], infer_datetime_format=True),
@@ -101,7 +100,7 @@ def test_cast_datetime_strings_to_timestamp(t, df, column):
 def test_cast_integer_to_temporal_type(t, df, column):
     column_type = t[column].type()
     expr = t.plain_int64.cast(column_type)
-    result = expr.execute()
+    result = expr.compile()
     df_computed = df.compute()
     expected = dd.from_pandas(
         pd.Series(
@@ -116,7 +115,7 @@ def test_cast_integer_to_temporal_type(t, df, column):
 
 def test_cast_integer_to_date(t, df):
     expr = t.plain_int64.cast('date')
-    result = expr.execute()
+    result = expr.compile()
     df_computed = df.compute()
     expected = dd.from_pandas(
         pd.Series(
@@ -130,11 +129,11 @@ def test_cast_integer_to_date(t, df):
 
 
 def test_times_ops(t, df):
-    result = t.plain_datetimes_naive.time().between('10:00', '10:00').execute()
+    result = t.plain_datetimes_naive.time().between('10:00', '10:00').compile()
     expected = dd.from_array(np.zeros(len(df), dtype=bool))
     tm.assert_series_equal(result.compute(), expected.compute())
 
-    result = t.plain_datetimes_naive.time().between('01:00', '02:00').execute()
+    result = t.plain_datetimes_naive.time().between('01:00', '02:00').compile()
     expected = dd.from_array(np.ones(len(df), dtype=bool))
     tm.assert_series_equal(result.compute(), expected.compute())
 
@@ -150,13 +149,13 @@ def test_times_ops_with_tz(t, df, tz, rconstruct, column):
     expected = dd.from_array(rconstruct(len(df), dtype=bool),)
     time = t[column].time()
     expr = time.between('01:00', '02:00', timezone=tz)
-    result = expr.execute()
+    result = expr.compile()
     tm.assert_series_equal(result.compute(), expected.compute())
 
     # Test that casting behavior is the same as using the timezone kwarg
     ts = t[column].cast(dt.Timestamp(timezone=tz))
     expr = ts.time().between('01:00', '02:00')
-    result = expr.execute()
+    result = expr.compile()
     tm.assert_series_equal(result.compute(), expected.compute())
 
 
@@ -192,7 +191,7 @@ def test_interval_arithmetic(op, expected):
     )
     t1 = con.table('df1')
     expr = op(t1.td, t1.td)
-    result = expr.execute()
+    result = expr.compile()
     expected = dd.from_pandas(
         pd.Series(expected(data, data), name='td'), npartitions=1,
     )

--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -86,8 +86,8 @@ def test_context_adjustment_asof_join(
         on='time',
         by='key',
         tolerance=Timedelta('4D'),
-    )
-    tm.assert_frame_equal(result.compute(), expected.compute())
+    ).compute()
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.xfail(reason="TODO - windowing - #2553")

--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -83,7 +83,7 @@ def test_drop(table):
     expr = table.drop(['a'])
     result = expr.execute()
     expected = table[['b', 'c']].execute()
-    tm.assert_frame_equal(result.compute(), expected.compute())
+    tm.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -29,16 +29,16 @@ def test_from_dataframe(dataframe, ibis_table, core_client):
     t = from_dataframe(dataframe)
     result = t.execute()
     expected = ibis_table.execute()
-    tm.assert_frame_equal(result.compute(), expected.compute())
+    tm.assert_frame_equal(result, expected)
 
     t = from_dataframe(dataframe, name='foo')
     expected = ibis_table.execute()
-    tm.assert_frame_equal(result.compute(), expected.compute())
+    tm.assert_frame_equal(result, expected)
 
     client = core_client
     t = from_dataframe(dataframe, name='foo', client=client)
     expected = ibis_table.execute()
-    tm.assert_frame_equal(result.compute(), expected.compute())
+    tm.assert_frame_equal(result, expected)
 
 
 def test_pre_execute_basic():

--- a/ibis/backends/pandas/tests/execution/test_functions.py
+++ b/ibis/backends/pandas/tests/execution/test_functions.py
@@ -177,6 +177,8 @@ def test_quantile_scalar(t, df, ibis_func, pandas_func):
     expected = pandas_func(df.float64_with_zeros)
     assert result == expected
 
+    assert result == expected
+
     result = ibis_func(t.int64_with_zeros).execute()
     expected = pandas_func(df.int64_with_zeros)
     assert result == expected

--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -191,15 +191,8 @@ def df(alltypes):
 
 
 @pytest.fixture(scope='session')
-def pandas_df(backend, alltypes):
-    if backend.name() == "dask":
-        return alltypes.execute().compute()
-    return alltypes.execute()
-
-
-@pytest.fixture(scope='session')
-def sorted_df(backend, pandas_df):
-    return pandas_df.sort_values('id').reset_index(drop=True)
+def sorted_df(backend, df):
+    return df.sort_values('id').reset_index(drop=True)
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -58,16 +58,14 @@ aggregate_test_params = [
 )
 @pytest.mark.xfail_unsupported
 def test_aggregate(
-    backend, alltypes, pandas_df, result_fn, expected_fn, expected_col
+    backend, alltypes, df, result_fn, expected_fn, expected_col
 ):
     expr = alltypes.aggregate(tmp=result_fn)
     result = expr.execute()
 
     # Create a single-row single-column dataframe with the Pandas `agg` result
     # (to match the output format of Ibis `aggregate`)
-    expected = pd.DataFrame(
-        {'tmp': [pandas_df[expected_col].agg(expected_fn)]}
-    )
+    expected = pd.DataFrame({'tmp': [df[expected_col].agg(expected_fn)]})
 
     backend.assert_frame_equal(result, expected)
 
@@ -77,7 +75,7 @@ def test_aggregate(
 )
 @pytest.mark.xfail_unsupported
 def test_aggregate_grouped(
-    backend, alltypes, pandas_df, result_fn, expected_fn, expected_col
+    backend, alltypes, df, result_fn, expected_fn, expected_col
 ):
     grouping_key_col = 'bigint_col'
 
@@ -91,25 +89,17 @@ def test_aggregate_grouped(
 
     # Note: Using `reset_index` to get the grouping key as a column
     expected = (
-        pandas_df.groupby(grouping_key_col)[expected_col]
+        df.groupby(grouping_key_col)[expected_col]
         .agg(expected_fn)
         .rename('tmp')
         .reset_index()
     )
 
-    # TODO - pandas - #2553
-    if backend.name() != 'dask':
-        # Row ordering may differ depending on backend, so sort on the
-        # grouping key
-        result1 = result1.sort_values(by=grouping_key_col).reset_index(
-            drop=True
-        )
-        result2 = result2.sort_values(by=grouping_key_col).reset_index(
-            drop=True
-        )
-        expected = expected.sort_values(by=grouping_key_col).reset_index(
-            drop=True
-        )
+    # Row ordering may differ depending on backend, so sort on the
+    # grouping key
+    result1 = result1.sort_values(by=grouping_key_col).reset_index(drop=True)
+    result2 = result2.sort_values(by=grouping_key_col).reset_index(drop=True)
+    expected = expected.sort_values(by=grouping_key_col).reset_index(drop=True)
 
     backend.assert_frame_equal(result1, expected)
     backend.assert_frame_equal(result2, expected)
@@ -240,18 +230,12 @@ def test_aggregate_grouped(
 )
 @pytest.mark.xfail_unsupported
 def test_reduction_ops(
-    backend,
-    alltypes,
-    pandas_df,
-    result_fn,
-    expected_fn,
-    ibis_cond,
-    pandas_cond,
+    backend, alltypes, df, result_fn, expected_fn, ibis_cond, pandas_cond,
 ):
     expr = result_fn(alltypes, ibis_cond(alltypes))
     result = expr.execute()
 
-    expected = expected_fn(pandas_df, pandas_cond(pandas_df))
+    expected = expected_fn(df, pandas_cond(df))
     np.testing.assert_allclose(result, expected)
 
 
@@ -275,11 +259,11 @@ def test_reduction_ops(
     ],
 )
 @pytest.mark.xfail_unsupported
-def test_group_concat(backend, alltypes, pandas_df, result_fn, expected_fn):
+def test_group_concat(backend, alltypes, df, result_fn, expected_fn):
     expr = result_fn(alltypes)
     result = expr.execute()
 
-    expected = expected_fn(pandas_df)
+    expected = expected_fn(df)
 
     assert set(result.iloc[:, 1]) == set(expected.iloc[:, 1])
 
@@ -296,15 +280,15 @@ def test_group_concat(backend, alltypes, pandas_df, result_fn, expected_fn):
 )
 @pytest.mark.xfail_unsupported
 @pytest.mark.xfail_backends(['pyspark'])  # Issue #2130
-def test_topk_op(backend, alltypes, pandas_df, result_fn, expected_fn):
+def test_topk_op(backend, alltypes, df, result_fn, expected_fn):
     # TopK expression will order rows by "count" but each backend
     # can have different result for that.
     # Note: Maybe would be good if TopK could order by "count"
     # and the field used by TopK
     t = alltypes.sort_by(alltypes.string_col)
-    pandas_df = pandas_df.sort_values('string_col')
+    df = df.sort_values('string_col')
     result = result_fn(t).execute()
-    expected = expected_fn(pandas_df)
+    expected = expected_fn(df)
     assert all(result['count'].values == expected.values)
 
 
@@ -326,13 +310,13 @@ def test_topk_op(backend, alltypes, pandas_df, result_fn, expected_fn):
 # Issues #2369 #2133 #2131 #2132
 @pytest.mark.xfail_backends(['bigquery', 'clickhouse', 'mysql', 'postgres'])
 @pytest.mark.skip_backends(['sqlite'], reason='Issue #2128')
-def test_topk_filter_op(backend, alltypes, pandas_df, result_fn, expected_fn):
+def test_topk_filter_op(backend, alltypes, df, result_fn, expected_fn):
     # TopK expression will order rows by "count" but each backend
     # can have different result for that.
     # Note: Maybe would be good if TopK could order by "count"
     # and the field used by TopK
     t = alltypes.sort_by(alltypes.string_col)
-    pandas_df = pandas_df.sort_values('string_col')
+    df = df.sort_values('string_col')
     result = result_fn(t).execute()
-    expected = expected_fn(pandas_df)
+    expected = expected_fn(df)
     assert result.shape[0] == expected.shape[0]

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -138,7 +138,7 @@ def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
 
 
 @pytest.mark.xfail_unsupported
-def test_case_where(backend, alltypes, pandas_df):
+def test_case_where(backend, alltypes, df):
     table = alltypes
     table = table.mutate(
         new_col=(
@@ -153,7 +153,7 @@ def test_case_where(backend, alltypes, pandas_df):
 
     result = table.execute()
 
-    expected = pandas_df.copy()
+    expected = df.copy()
     mask_0 = expected['int_col'] == 1
     mask_1 = expected['int_col'] == 0
 

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -5,7 +5,6 @@ import ibis
 import ibis.expr.datatypes as dt
 
 
-@pytest.mark.xfail_backends(['dask'])  # TODO - pandas - #2553
 def test_string_col_is_unicode(backend, alltypes, df):
     dtype = alltypes.string_col.type()
     assert dtype == dt.String(nullable=dtype.nullable)
@@ -277,7 +276,7 @@ def test_special_strings(backend, con, alltypes, data, data_type):
 
 
 @pytest.mark.xfail_unsupported
-def test_substr_with_null_values(backend, alltypes, pandas_df):
+def test_substr_with_null_values(backend, alltypes, df):
     table = alltypes.mutate(
         substr_col_null=ibis.case()
         .when(alltypes['bool_col'], alltypes['string_col'])
@@ -288,7 +287,7 @@ def test_substr_with_null_values(backend, alltypes, pandas_df):
 
     result = table.execute()
 
-    expected = pandas_df.copy()
+    expected = df.copy()
     mask = ~expected['bool_col']
     expected['substr_col_null'] = expected['string_col']
     expected['substr_col_null'][mask] = None

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -150,12 +150,7 @@ def test_date_truncate(backend, alltypes, df, unit):
             # TODO - DateOffset - #2553
             marks=pytest.mark.xfail_backends(['dask']),
         ),
-        param(
-            'D',
-            pd.offsets.DateOffset,
-            # TODO - DateOffset - #2553
-            marks=pytest.mark.xfail_backends(['dask']),
-        ),
+        ('D', pd.offsets.DateOffset),
         ('h', pd.Timedelta),
         ('m', pd.Timedelta),
         ('s', pd.Timedelta),
@@ -288,8 +283,7 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
                 )
             ),
             id='timestamp-subtract-timestamp',
-            # TODO - pandas - #2553
-            marks=pytest.mark.xfail_backends(['dask', 'spark']),
+            marks=pytest.mark.xfail_backends(['spark']),
         ),
         param(
             lambda t, be: t.timestamp_col.date() - ibis.date(date_value),
@@ -322,9 +316,8 @@ def test_interval_add_cast_scalar(backend, alltypes):
 
 
 @pytest.mark.xfail_unsupported
-# TODO - pandas - #2553
 # PySpark does not support casting columns to intervals
-@pytest.mark.xfail_backends(['dask', 'pyspark'])
+@pytest.mark.xfail_backends(['pyspark'])
 @pytest.mark.skip_backends(['spark'])
 def test_interval_add_cast_column(backend, alltypes, df):
     timestamp_date = alltypes.timestamp_col.date()
@@ -460,8 +453,6 @@ def test_day_of_week_column(backend, con, alltypes, df):
         ),
     ],
 )
-# TODO - pandas - #2553
-@pytest.mark.xfail_backends(['dask'])
 @pytest.mark.xfail_unsupported
 def test_day_of_week_column_group_by(
     backend, con, alltypes, df, day_of_week_expr, day_of_week_pandas


### PR DESCRIPTION
Closes https://github.com/ibis-project/ibis/issues/2604. 

Changes:

- `.compile()` now returns an object that you can run `.compute()` on 
- `.execute()` calls `.compute()` on the object returned by `.compile()`

Most of the diff is updating all the tests in the dask backend for this new behavior and removing some shims we had in the generic ibis backend tests. Also un-xfails some `TODO - pandas` tests that now no longer fail. 

<hr />

- [ ] Update https://github.com/ibis-project/ibis/issues/2553 post merge 
 