### PR TITLE
DOC: Use SQLite instead of PostgreSQL in elementwise extending

### DIFF
--- a/docs/source/user_guide/extending/extending_elementwise_expr.ipynb
+++ b/docs/source/user_guide/extending/extending_elementwise_expr.ipynb
@@ -11,21 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are two parts of ibis that users typically want to extend:\n",
+    "This notebook will show you how to add a new elementwise operation to an existing backend.\n",
     "\n",
-    "1. Expressions (for example, by adding a new operation)\n",
-    "1. Backends\n",
+    "We are going to add `julianday`, a function supported by the SQLite database, to the SQLite Ibis backend.\n",
     "\n",
-    "This notebook will show you how to add a new elementwise operation--`sha1`--to an existing backend (PostgreSQL)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Description\n",
-    "\n",
-    "We're going to add a **`sha1`** method to ibis. [SHA1](https://en.wikipedia.org/wiki/SHA-1) is a hash algorithm, employed in systems such as git."
+    "The Julian day of a date, is the number of days since January 1st, 4713 BC. For more information check the [Julian day](https://en.wikipedia.org/wiki/Julian_day) wikipedia page."
    ]
   },
   {
@@ -39,10 +29,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's define the `sha` operation as a function that takes one string input argument and returns a hexidecimal string.\n",
+    "Let's define the `julianday` operation as a function that takes one string input argument and returns a float.\n",
     "\n",
-    "```haskell\n",
-    "sha1 :: String -> String\n",
+    "```python\n",
+    "def julianday(date str) -> float:\n",
+    "    \"\"\"Julian date\"\"\"\n",
     "```"
    ]
   },
@@ -58,16 +49,16 @@
     "from ibis.expr.operations import ValueOp, Arg\n",
     "\n",
     "\n",
-    "class SHA1(ValueOp):\n",
+    "class JulianDay(ValueOp):\n",
     "    arg = Arg(rlz.string)\n",
-    "    output_type = rlz.shape_like('arg', 'string')"
+    "    output_type = rlz.shape_like('arg', 'float')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We just defined a `SHA1` class that takes one argument of type string or binary, and returns a binary. This matches the description of the function provided by BigQuery."
+    "We just defined a `JulianDay` class that takes one argument of type string or binary, and returns a float."
    ]
   },
   {
@@ -81,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because we know the output type of the operation, to make an expression out of ``SHA1`` we simply need to construct it and call its `ibis.expr.types.Node.to_expr` method.\n",
+    "Because we know the output type of the operation, to make an expression out of ``JulianDay`` we simply need to construct it and call its `ibis.expr.types.Node.to_expr` method.\n",
     "\n",
     "We still need to add a method to `StringValue` and `BinaryValue` (this needs to work on both scalars and columns).\n",
     "\n",
@@ -100,11 +91,11 @@
     "from ibis.expr.types import StringValue, BinaryValue\n",
     "\n",
     "\n",
-    "def sha1(string_value):\n",
-    "    return SHA1(string_value).to_expr()\n",
+    "def julianday(string_value):\n",
+    "    return JulianDay(string_value).to_expr()\n",
     "\n",
     "\n",
-    "StringValue.sha1 = sha1"
+    "StringValue.julianday = julianday"
    ]
   },
   {
@@ -120,25 +111,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ibis"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t = ibis.table([('string_col', 'string')], name='t')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t.string_col.sha1()"
+    "import ibis\n",
+    "\n",
+    "t = ibis.table([('string_col', 'string')], name='t')\n",
+    "\n",
+    "t.string_col.julianday()"
    ]
   },
   {
@@ -157,16 +134,16 @@
     "import sqlalchemy as sa\n",
     "\n",
     "\n",
-    "@ibis.postgres.compiles(SHA1)\n",
-    "def compile_sha1(translator, expr):\n",
+    "@ibis.sqlite.compiler.compiles(JulianDay)\n",
+    "def compile_julianday(translator, expr):\n",
     "    # pull out the arguments to the expression\n",
     "    arg, = expr.op().args\n",
     "    \n",
     "    # compile the argument\n",
     "    compiled_arg = translator.translate(arg)\n",
     "    \n",
-    "    # return a SQLAlchemy expression that calls into the PostgreSQL pgcrypto extension\n",
-    "    return sa.func.encode(sa.func.digest(compiled_arg, 'sha1'), 'hex')"
+    "    # return a SQLAlchemy expression that calls into the SQLite julianday function\n",
+    "    return sa.func.julianday(compiled_arg)"
    ]
   },
   {
@@ -177,61 +154,24 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Connect to the `ibis_testing` database"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**NOTE:**\n",
-    "\n",
-    "To be able to execute the rest of this notebook you need to run the following command from your ibis clone:\n",
-    "\n",
-    "```sh\n",
-    "make init\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import pathlib\n",
     "import ibis\n",
-    "con = ibis.postgres.connect(\n",
-    "    database='ibis_testing', user='postgres', host='postgres', password='postgres')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Register the pgcrypto extension\n",
     "\n",
-    "See https://www.postgresql.org/docs/10/static/pgcrypto.html for details about this extension"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# the output here is an AlchemyProxy instance that cannot iterate\n",
-    "# (because there's no output from the database) so we hide it with a semicolon\n",
-    "con.raw_sql('CREATE EXTENSION IF NOT EXISTS pgcrypto');"
+    "db_fname = str(pathlib.Path().resolve().parent.parent / 'tutorial' / 'data' / 'geography.db')\n",
+    "\n",
+    "con = ibis.sqlite.connect(db_fname)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create and execute a `sha1` expression"
+    "### Create and execute a `julianday` expression"
    ]
   },
   {
@@ -240,8 +180,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t = con.table('functional_alltypes')\n",
-    "t"
+    "independence = con.table('independence')\n",
+    "independence"
    ]
   },
   {
@@ -250,8 +190,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sha1_expr = t.string_col.sha1()\n",
-    "sha1_expr"
+    "day = independence.independence_date.cast('string')\n",
+    "day"
    ]
   },
   {
@@ -260,7 +200,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sql_expr = sha1_expr.compile()\n",
+    "julianday_expr = day.julianday()\n",
+    "julianday_expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sql_expr = julianday_expr.compile()\n",
     "print(sql_expr)"
    ]
   },
@@ -270,15 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = sha1_expr.execute()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "result = julianday_expr.execute()\n",
     "result.head()"
    ]
   },
@@ -295,8 +237,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "string_scalar = ibis.literal('abcdefg')\n",
-    "string_scalar"
+    "scalar = ibis.literal('2010-03-14')\n",
+    "scalar"
    ]
   },
   {
@@ -305,7 +247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sha1_scalar = string_scalar.sha1()"
+    "julianday_scalar = scalar.julianday()"
    ]
   },
   {
@@ -314,7 +256,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "con.execute(sha1_scalar)"
+    "con.execute(julianday_scalar)"
    ]
   }
  ],
@@ -334,9 +276,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Towards #2590. Using SQLite in one more page, so no backend docker images are required to build the docs.