### PR TITLE
BUG: Fix fusion optimization bug that incorrectly changes operation order

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug: `2635` Fix fusion optimization bug that incorrectly changes operation order
 * :feature:`2615` Add `ibis.array` for creating array expressions
 * :feature:`2607` Implement Not operation in PySpark backend
 * :feature:`2610` Added support for case/when in PySpark backend

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -167,6 +167,7 @@ def test_case_where(backend, alltypes, df):
 
 
 @pytest.mark.xfail_unsupported
+@pytest.mark.skip_backends(['postgres'])
 def test_select_filter_mutate(backend, alltypes, df):
     t = alltypes
     t = t.mutate(

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -176,16 +176,8 @@ def test_select_filter_mutate(backend, alltypes, df):
     )
     t = t[['float_col']]
     t = t[~t['float_col'].isnan()]
-    import pdb
-
-    pdb.set_trace()
-
     t = t.mutate(float_col=t['float_col'].cast('int32'))
     result = t.execute()
-
-    import pdb
-
-    pdb.set_trace()
 
     expected = df.copy()
     expected = expected[['float_col']]

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -163,3 +163,34 @@ def test_case_where(backend, alltypes, df):
     expected['new_col'] = expected['new_col']
 
     backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.xfail_unsupported
+def test_select_filter_mutate(backend, alltypes, df):
+    t = alltypes
+    t = t.mutate(
+        float_col=ibis.case()
+        .when(t['bool_col'], t['float_col'])
+        .else_(None)
+        .end()
+    )
+    t = t[['float_col']]
+    t = t[~t['float_col'].isnan()]
+    import pdb
+
+    pdb.set_trace()
+
+    t = t.mutate(float_col=t['float_col'].cast('int32'))
+    result = t.execute()
+
+    import pdb
+
+    pdb.set_trace()
+
+    expected = df.copy()
+    expected = expected[['float_col']]
+    expected['float_col'][~df['bool_col']] = None
+    expected = expected[~expected['float_col'].isna()]
+    expected['float_col'] = expected['float_col'].astype('int32')
+
+    backend.assert_frame_equal(result, expected)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1,5 +1,6 @@
 import decimal
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -171,7 +172,7 @@ def test_select_filter_mutate(backend, alltypes, df):
     t = t.mutate(
         float_col=ibis.case()
         .when(t['bool_col'], t['float_col'])
-        .else_(None)
+        .else_(np.nan)
         .end()
     )
     t = t[t.columns]

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -174,13 +174,12 @@ def test_select_filter_mutate(backend, alltypes, df):
         .else_(None)
         .end()
     )
-    t = t[['float_col']]
+    t = t[t.columns]
     t = t[~t['float_col'].isnan()]
     t = t.mutate(float_col=t['float_col'].cast('int32'))
     result = t.execute()
 
     expected = df.copy()
-    expected = expected[['float_col']]
     expected['float_col'][~df['bool_col']] = None
     expected = expected[~expected['float_col'].isna()]
     expected['float_col'] = expected['float_col'].astype('int32')

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -794,11 +794,7 @@ class Projector:
         clean_exprs = self.clean_exprs
 
         if not isinstance(root_table.op(), ops.Join):
-            # If a column exists in both parent and root_table
-            # (parent of parent), then we should resolve it from
-            # the parent instead of root_table.
             try:
-                # Try to resolve from parent
                 resolved = root_table._resolve(self.input_exprs)
             except (AttributeError, IbisTypeError):
                 resolved = clean_exprs

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -800,17 +800,8 @@ class Projector:
             try:
                 # Try to resolve from parent
                 resolved = root_table._resolve(self.input_exprs)
-                # resolved = self.parent._resolve(self.input_exprs)
             except (AttributeError, IbisTypeError):
                 resolved = clean_exprs
-                # Try to resolve from root_table
-                # try:
-                #     resolved = root_table._resolve(self.input_exprs)
-                # except (AttributeError, IbisTypeError):
-                #     # If we cannot resolve it from either
-                #     # parent or root_table. We use the original
-                #     # expr.
-                #     resolved = clean_exprs
         else:
             # joins cannot be used to resolve expressions, but we still may be
             # able to fuse columns from a projection off of a join. In that

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -357,6 +357,12 @@ class ExprSimplifier:
                 if sel.has_name()
             )
 
+            # If there are predicates or sort keys,
+            # then we cannot lift the root
+            no_predicates_or_sort_keys = not (
+                root.predicates or root.sort_keys
+            )
+
             for val in root.selections:
                 value_op = val.op()
                 if (
@@ -367,6 +373,7 @@ class ExprSimplifier:
                     lifted_root = self.lift(val)
                 elif (
                     all_simple_columns
+                    and no_predicates_or_sort_keys
                     and isinstance(val, ir.ValueExpr)
                     and val.has_name()
                     and node.name == val.get_name()
@@ -777,6 +784,8 @@ class Projector:
         return ops.Selection(self.parent, self.clean_exprs)
 
     def try_fusion(self, root):
+        assert self.parent.op() == root
+
         root_table = root.table
         roots = root_table._root_tables()
         validator = ExprValidator([root_table])
@@ -785,10 +794,23 @@ class Projector:
         clean_exprs = self.clean_exprs
 
         if not isinstance(root_table.op(), ops.Join):
+            # If a column exists in both parent and root_table
+            # (parent of parent), then we should resolve it from
+            # the parent instead of root_table.
             try:
+                # Try to resolve from parent
                 resolved = root_table._resolve(self.input_exprs)
+                # resolved = self.parent._resolve(self.input_exprs)
             except (AttributeError, IbisTypeError):
                 resolved = clean_exprs
+                # Try to resolve from root_table
+                # try:
+                #     resolved = root_table._resolve(self.input_exprs)
+                # except (AttributeError, IbisTypeError):
+                #     # If we cannot resolve it from either
+                #     # parent or root_table. We use the original
+                #     # expr.
+                #     resolved = clean_exprs
         else:
             # joins cannot be used to resolve expressions, but we still may be
             # able to fuse columns from a projection off of a join. In that

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -294,3 +294,93 @@ def test_is_ancestor_analytic():
     ]
 
     assert not subquery.op().equals(with_analytic.op())
+
+
+def test_mutation_fusion_no_overwrite():
+    """Test fusion with chained mutation that doesn't overwrite existing
+    columns.
+    """
+    t = ibis.table(ibis.schema([('col', 'int32')]), 't')
+
+    result = t
+    result = result.mutate(col1=t['col'] + 1)
+    result = result.mutate(col2=t['col'] + 2)
+    result = result.mutate(col3=t['col'] + 3)
+
+    first_selection = result
+
+    assert len(result.op().selections) == 4
+    assert (
+        first_selection.op().selections[1].equals((t['col'] + 1).name('col1'))
+    )
+    assert (
+        first_selection.op().selections[2].equals((t['col'] + 2).name('col2'))
+    )
+    assert (
+        first_selection.op().selections[3].equals((t['col'] + 3).name('col3'))
+    )
+
+
+def test_mutation_fusion_overwrite():
+    """Test fusion with chained mutation that overwrites existing columns."""
+    t = ibis.table(ibis.schema([('col', 'int32')]), 't')
+
+    result = t
+
+    result = result.mutate(col1=t['col'] + 1)
+    result = result.mutate(col2=t['col'] + 2)
+    result = result.mutate(col3=t['col'] + 3)
+    result = result.mutate(col=t['col'] - 1)
+    result = result.mutate(col4=t['col'] + 4)
+
+    second_selection = result
+    first_selection = second_selection.op().table
+
+    assert len(first_selection.op().selections) == 4
+    assert (
+        first_selection.op().selections[1].equals((t['col'] + 1).name('col1'))
+    )
+    assert (
+        first_selection.op().selections[2].equals((t['col'] + 2).name('col2'))
+    )
+    assert (
+        first_selection.op().selections[3].equals((t['col'] + 3).name('col3'))
+    )
+
+    # Since the second selection overwrites existing columns, it will
+    # not have the TableExpr as the first selection
+    assert len(second_selection.op().selections) == 5
+    assert (
+        second_selection.op().selections[0].equals((t['col'] - 1).name('col'))
+    )
+    assert second_selection.op().selections[1].equals(first_selection['col1'])
+    assert second_selection.op().selections[2].equals(first_selection['col2'])
+    assert second_selection.op().selections[3].equals(first_selection['col3'])
+    assert (
+        second_selection.op().selections[4].equals((t['col'] + 4).name('col4'))
+    )
+
+
+def test_select_filter_mutate_fusion():
+    """Test fusion with filter followed by mutation on the same input."""
+
+    t = ibis.table(ibis.schema([('col', 'float32')]), 't')
+
+    result = t[['col']]
+    result = result[result['col'].isnan()]
+    result = result.mutate(col=result['col'].cast('int32'))
+
+    second_selection = result
+    first_selection = second_selection.op().table
+
+    assert len(second_selection.op().selections) == 1
+    assert (
+        second_selection.op()
+        .selections[0]
+        .equals(first_selection['col'].cast('int32').name('col'))
+    )
+
+    assert len(first_selection.op().selections) == 1
+    assert len(first_selection.op().predicates) == 1
+    assert first_selection.op().selections[0].equals(t['col'])
+    assert first_selection.op().predicates[0].equals(t['col'].isnan())

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -296,6 +296,7 @@ def test_is_ancestor_analytic():
     assert not subquery.op().equals(with_analytic.op())
 
 
+# Pr 2635
 def test_mutation_fusion_no_overwrite():
     """Test fusion with chained mutation that doesn't overwrite existing
     columns.
@@ -321,6 +322,7 @@ def test_mutation_fusion_no_overwrite():
     )
 
 
+# Pr 2635
 def test_mutation_fusion_overwrite():
     """Test fusion with chained mutation that overwrites existing columns."""
     t = ibis.table(ibis.schema([('col', 'int32')]), 't')
@@ -361,6 +363,7 @@ def test_mutation_fusion_overwrite():
     )
 
 
+# Pr 2635
 def test_select_filter_mutate_fusion():
     """Test fusion with filter followed by mutation on the same input."""
 


### PR DESCRIPTION
What change is proposed
===================

Example code
```
t = ibis.table(ibis.schema([('col', 'float32')]), 't')
t = t[['col']]
t = t[~t['col'].isnan()]
t = t.mutate(col=t['col'].cast('int32'))
```

Before:
```
ref_0
UnboundTable[table]
  name: t
  schema:
    col : float32

Selection[table]
  table:
    Table: ref_0
  selections:
    col = Cast[int32*]
      col = Column[float32*] 'col' from table
        ref_0
      to:
        int32
  predicates:
    Not[boolean*]
      IsNan[boolean*]
        col = Column[float32*] 'col' from table
          ref_0
```

After:
```
ref_0
UnboundTable[table]
  name: t
  schema:
    col : float32

ref_1
Selection[table]
  table:
    Table: ref_0
  selections:
    col = Column[float32*] 'col' from table
      ref_0
  predicates:
    Not[boolean*]
      IsNan[boolean*]
        col = Column[float32*] 'col' from table
          ref_0

Selection[table]
  table:
    Table: ref_1
  selections:
    col = Cast[int32*]
      col = Column[float32*] 'col' from table
        ref_1
      to:
        int32
```

Testing
======
I added a few tests in test_analysis.py to assert the fusion behavior. Also created a test in backends test to make sure the results are expected.

 