### PR TITLE
BUG: Fix overwrite logic to account for DestructColumn inside mutate API

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug: `2636` Fix overwrite logic to account for DestructColumn inside mutate API
 * :feature:`2379` Backends are defined as entry points
 * :bug: `2635` Fix fusion optimization bug that incorrectly changes operation order
 * :feature:`2615` Add `ibis.array` for creating array expressions

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -299,9 +299,12 @@ def test_elementwise_udf_overwrite_destruct(backend, alltypes):
         double_col=alltypes['double_col'] + 1, col2=alltypes['double_col'] + 2,
     ).execute()
 
-    # TODO currently when overwriting a column via a multi-col UDF, any
-    # new columns will be materialized directly after those overwritten
-    # columns rather than appended to the end.
+    # TODO issue #2649
+    # Due to a known limitation with how we treat DestructColumn
+    # in assignments, the ordering of op.selections may not exactly
+    # correspond with the column ordering we want (i.e. all new columns
+    # should appear at the end, but currently they are materialized
+    # directly after those overwritten columns).
     backend.assert_frame_equal(result, expected, check_like=True)
 
 
@@ -324,9 +327,12 @@ def test_elementwise_udf_overwrite_destruct_and_assign(backend, alltypes):
         col3=alltypes['int_col'] * 3,
     ).execute()
 
-    # TODO currently when overwriting a column via a multi-col UDF, any
-    # new columns will be materialized directly after those overwritten
-    # columns rather than appended to the end.
+    # TODO issue #2649
+    # Due to a known limitation with how we treat DestructColumn
+    # in assignments, the ordering of op.selections may not exactly
+    # correspond with the column ordering we want (i.e. all new columns
+    # should appear at the end, but currently they are materialized
+    # directly after those overwritten columns).
     backend.assert_frame_equal(result, expected, check_like=True)
 
 
@@ -347,9 +353,12 @@ def test_elementwise_udf_multiple_overwrite_destruct(backend, alltypes):
         float_col=alltypes['double_col'] + 3,
     ).execute()
 
-    # TODO currently when overwriting a column via a multi-col UDF, any
-    # new columns will be materialized directly after those overwritten
-    # columns rather than appended to the end.
+    # TODO issue #2649
+    # Due to a known limitation with how we treat DestructColumn
+    # in assignments, the ordering of op.selections may not exactly
+    # correspond with the column ordering we want (i.e. all new columns
+    # should appear at the end, but currently they are materialized
+    # directly after those overwritten columns).
     backend.assert_frame_equal(result, expected, check_like=True)
 
 
@@ -423,9 +432,12 @@ def test_analytic_udf_destruct_overwrite(backend, alltypes):
         demean_weight=alltypes['int_col'] - alltypes['int_col'].mean().over(w),
     ).execute()
 
-    # TODO currently when overwriting a column via a multi-col UDF, any
-    # new columns will be materialized directly after those overwritten
-    # columns rather than appended to the end.
+    # TODO issue #2649
+    # Due to a known limitation with how we treat DestructColumn
+    # in assignments, the ordering of op.selections may not exactly
+    # correspond with the column ordering we want (i.e. all new columns
+    # should appear at the end, but currently they are materialized
+    # directly after those overwritten columns).
     backend.assert_frame_equal(result, expected, check_like=True)
 
 
@@ -486,10 +498,12 @@ def test_reduction_udf_destruct_no_groupby_overwrite(backend, alltypes):
         double_col=alltypes['double_col'].mean(),
         mean_weight=alltypes['int_col'].mean(),
     ).execute()
-
-    # TODO currently when overwriting a column via a multi-col UDF, any
-    # new columns will be materialized directly after those overwritten
-    # columns rather than appended to the end.
+    # TODO issue #2649
+    # Due to a known limitation with how we treat DestructColumn
+    # in assignments, the ordering of op.selections may not exactly
+    # correspond with the column ordering we want (i.e. all new columns
+    # should appear at the end, but currently they are materialized
+    # directly after those overwritten columns).
     backend.assert_frame_equal(result, expected, check_like=True)
 
 

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -404,9 +404,10 @@ def test_analytic_udf_destruct(backend, alltypes):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.only_on_backends(['pandas'])
+@pytest.mark.only_on_backends(['pandas', 'pyspark'])
 # TODO - udf - #2553
 @pytest.mark.xfail_backends(['dask'])
+@pytest.mark.xfail_unsupported
 def test_analytic_udf_destruct_overwrite(backend, alltypes):
     w = window(preceding=None, following=None, group_by='year')
 
@@ -470,9 +471,10 @@ def test_reduction_udf_destruct_no_groupby(backend, alltypes):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.only_on_backends(['pandas'])
+@pytest.mark.only_on_backends(['pandas', 'pyspark'])
 # TODO - udf - #2553
 @pytest.mark.xfail_backends(['dask'])
+@pytest.mark.xfail_unsupported
 def test_reduction_udf_destruct_no_groupby_overwrite(backend, alltypes):
     result = alltypes.aggregate(
         overwrite_struct_reduction(

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -40,6 +40,16 @@ def overwrite_struct_elementwise(v):
     return v + 1, v + 2
 
 
+@elementwise(
+    input_type=[dt.double],
+    output_type=dt.Struct(
+        ['double_col', 'col2', 'float_col'], [dt.double, dt.double, dt.double]
+    ),
+)
+def multiple_overwrite_struct_elementwise(v):
+    return v + 1, v + 2, v + 3
+
+
 @analytic(
     input_type=[dt.double, dt.double],
     output_type=dt.Struct(
@@ -312,6 +322,29 @@ def test_elementwise_udf_overwrite_destruct_and_assign(backend, alltypes):
         double_col=alltypes['double_col'] + 1,
         col2=alltypes['double_col'] + 2,
         col3=alltypes['int_col'] * 3,
+    ).execute()
+
+    # TODO currently when overwriting a column via a multi-col UDF, any
+    # new columns will be materialized directly after those overwritten
+    # columns rather than appended to the end.
+    backend.assert_frame_equal(result, expected, check_like=True)
+
+
+@pytest.mark.only_on_backends(['pandas', 'pyspark'])
+# TODO - udf - #2553
+@pytest.mark.xfail_backends(['dask'])
+@pytest.mark.xfail_unsupported
+def test_elementwise_udf_multiple_overwrite_destruct(backend, alltypes):
+    result = alltypes.mutate(
+        multiple_overwrite_struct_elementwise(
+            alltypes['double_col']
+        ).destructure()
+    ).execute()
+
+    expected = alltypes.mutate(
+        double_col=alltypes['double_col'] + 1,
+        col2=alltypes['double_col'] + 2,
+        float_col=alltypes['double_col'] + 3,
     ).execute()
 
     # TODO currently when overwriting a column via a multi-col UDF, any

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4193,6 +4193,14 @@ def mutate(table, exprs=None, **mutations):
         for name, expr in sorted(mutations.items(), key=operator.itemgetter(0))
     )
 
+    # The below logic computes the mutation node exprs by splitting the
+    # assignment exprs into two disjoint sets:
+    # 1) overwriting_cols_to_expr, which maps a column name to its expr
+    # if the expr contains a column that overwrites an existing table column
+    # 2) non_overwriting_exprs, which is a list of all exprs that do not do
+    # any overwriting.
+    # Given these two data structures, we can compute the mutation node exprs
+    # based on whether any columns are being overwritten.
     overwriting_cols_to_expr = {}
     non_overwriting_exprs = []
     table_schema = table.schema()

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4196,9 +4196,18 @@ def mutate(table, exprs=None, **mutations):
     # The below logic computes the mutation node exprs by splitting the
     # assignment exprs into two disjoint sets:
     # 1) overwriting_cols_to_expr, which maps a column name to its expr
-    # if the expr contains a column that overwrites an existing table column
+    # if the expr contains a column that overwrites an existing table column.
+    # All keys in this dict are columns in the original table that are being
+    # overwritten by an assignment expr. All values in this dict are either:
+    #     (a) The expr of the overwriting column. Note that in the case of
+    #     DestructColumn, this will specifically only happen for the first
+    #     overwriting column within that expr.
+    #     (b) None. This is the case for the second (and beyond) overwriting
+    #     column(s) inside the DestructColumn and is used as a flag to prevent
+    #     the same DestructColumn expr from being duplicated in the output.
     # 2) non_overwriting_exprs, which is a list of all exprs that do not do
-    # any overwriting.
+    # any overwriting. That is, if an expr is in this list, then its column
+    # name does not exist in the original table.
     # Given these two data structures, we can compute the mutation node exprs
     # based on whether any columns are being overwritten.
     overwriting_cols_to_expr = {}

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4239,7 +4239,7 @@ def _get_names_from_selections(selections):
     columns represented in the given list of selections."""
     names = []
     for expr in selections:
-        if isin(expr, ir.DestructColumn):
+        if isinstance(expr, ir.DestructColumn):
             struct_type = expr.type()
             names.extend(struct_type.names)
         elif isinstance(expr, ir.ValueExpr):

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4210,6 +4210,12 @@ def mutate(table, exprs=None, **mutations):
     # name does not exist in the original table.
     # Given these two data structures, we can compute the mutation node exprs
     # based on whether any columns are being overwritten.
+    # TODO issue #2649
+    # Due to a known limitation with how we treat DestructColumn
+    # in assignments, the ordering of op.selections may not exactly
+    # correspond with the column ordering we want (i.e. all new columns
+    # should appear at the end, but currently they are materialized
+    # directly after those overwritten columns).
     overwriting_cols_to_expr = {}
     non_overwriting_exprs = []
     table_schema = table.schema()


### PR DESCRIPTION
### Overview

Currently ibis does some checking inside the mutate API method to determine whether any assigned columns are overwriting an existing column in the table. It then uses this logic to correctly select the column expr from the assignment expr that does the overwriting. This also ensures that there are no duplicate columns detected in schema computation.

However, this logic does not properly account for an overwrite that may occur within a DestructColumn, which are used to specify output of multi-column UDFs. Since DestructColumns by design cannot be named (since they can represent many columns internally), the current logic does not detect if a column inside a DestructColumn is overwriting an existing column. The result is an error at expression creation time as duplicate columns are detected in the schema.


### Proposed Change

This PR modifies the logic inside mutate to account for overwrites that may happen inside a DestructColumn. First it properly constructs the dict of assignment -> expr by checking for DestructColumn specifically. Then, it determines:

1) Dict of column name -> expr for all assignments that overwrite an existing column
2) List of exprs for all assignments that do not represent any overwriting.

From the above, if an overwrite is detected, the mutation node can be constructed by iterating through all table columns, selecting the expr either from the overwritten dict or the table itself, and then appending all new exprs from the list above.


### Testing

Added several new tests in test_vectorized_udf.py to assert that overwriting a column within a multi-col UDF (elementwise, analytic, and reduction) works correctly.


### Known Limitations

Since a DestructColumn can represent many columns internally, if one of those columns is overwriting an existing column and the remaining columns are new assignments, the result from the mutation will not respect correct column ordering. That is, if we have a table with columns ['A', 'B', C'] and a mutation with DestructColumn ['B', 'D', 'E'], the output table schema after execution will be ['A', 'B', 'D', 'E', 'C'] since all the DestructColumns are grouped together in the same expr.

A follow-up can explore destructing these columns inside the mutate API, which would change the execution path but ensure correct column ordering.