### PR TITLE
Pushing the docs to GitHub pages from the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,7 +274,7 @@ jobs:
     - name: Install github key
       run: |
         mkdir -m 700 -p ~/.ssh
-        echo "${{ secrets.github_key }}" > ~/.ssh/id_rsa
+        echo "${{ secrets.DOCS_KEY }}" > ~/.ssh/id_rsa
         chmod 600 ~/.ssh/id_rsa
       if: github.event_name == 'push'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -270,3 +270,22 @@ jobs:
 
     - name: build docs
       run: sphinx-build -b html docs/source /tmp/docs.ibis-project.org -W -T
+
+    - name: Install github key
+      run: |
+        mkdir -m 700 -p ~/.ssh
+        echo "${{ secrets.github_key }}" > ~/.ssh/id_rsa
+        chmod 600 ~/.ssh/id_rsa
+      if: github.event_name == 'push'
+
+    - name: Push docs
+      run: |
+        cd /tmp/docs.ibis-project.org
+        git init
+        git remote add origin git@github.com:ibis-project/docs.ibis-project.org
+        git config user.name 'Ibis Documentation Bot'
+        git config user.email ''
+        git add --all .
+        git commit -m "Ibis docs - $(date) - $GITHUB_SHA"
+        git push -f -u origin master
+      if: github.event_name == 'push'


### PR DESCRIPTION
Follow up of #2590. Pushes the docs to github pages, as it was done before from azure.

**Note** it requires #2637 for this to work.