### PR TITLE
DOC: Set up custom domain when pushing the docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,6 +281,7 @@ jobs:
     - name: Push docs
       run: |
         cd /tmp/docs.ibis-project.org
+        echo "ibis-project.org" > CNAME
         git init
         git remote add origin git@github.com:ibis-project/docs.ibis-project.org
         git config user.name 'Ibis Documentation Bot'


### PR DESCRIPTION
Pushing of the docs to GitHub pages in #2638 worked well (investigating a problem with the static files, but they are pushed).

I forgot the custom domain configuration is not kept if we don't create the `CNAME` file manually. Adding it here.