### PR TITLE
DOC: Fixing website repo url

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -283,8 +283,8 @@ jobs:
         cd /tmp/docs.ibis-project.org
         echo "ibis-project.org" > CNAME
         git init
-        git remote add origin git@github.com:ibis-project/docs.ibis-project.org
-        git config user.name 'Ibis Documentation Bot'
+        git remote add origin git@github.com:ibis-project/ibis-project.org
+        git config user.name 'Ibis GitHub actions'
         git config user.email ''
         git add --all .
         git commit -m "Ibis docs - $(date) - $GITHUB_SHA"


### PR DESCRIPTION
Fixes the pushing of the docs (I didn't realize the old repo was docs.ibis-project.org and not the current domain ibis-project.org).

Merging before the CI finishes, so we restore the website asap (the changes here don't execute for PRs anyway).