### PR TITLE
DOC: Adding nojekyll file so static files are served by GitHub pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,6 +281,7 @@ jobs:
     - name: Push docs
       run: |
         cd /tmp/docs.ibis-project.org
+        touch .nojekyll
         echo "ibis-project.org" > CNAME
         git init
         git remote add origin git@github.com:ibis-project/ibis-project.org


### PR DESCRIPTION
This was missing for static files to be served by the GitHub pages server. Not sure how it was added before, I haven't seen this code in azure.