### PR TITLE
FEAT: add `bit_xor` aggregate to BigQuery and MySQL backends

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -230,6 +230,9 @@ Scalar or column methods
 
    IntegerValue.convert_base
    IntegerValue.to_timestamp
+   IntegerColumn.bit_and
+   IntegerColumn.bit_or
+   IntegerColumn.bit_xor
 
 .. _api.string:
 

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2641` Add `bit_and`, `bit_or`, and `bit_xor` integer column aggregates (BigQuery and MySQL backends)
 * :feature:`2379` Backends are defined as entry points
 * :bug: `2635` Fix fusion optimization bug that incorrectly changes operation order
 * :feature:`2615` Add `ibis.array` for creating array expressions

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -358,6 +358,9 @@ _operation_registry = {
 }
 _operation_registry.update(
     {
+        ops.BitAnd: reduction('BIT_AND'),
+        ops.BitOr: reduction('BIT_OR'),
+        ops.BitXor: reduction('BIT_XOR'),
         ops.ExtractYear: _extract_field('year'),
         ops.ExtractQuarter: _extract_field('quarter'),
         ops.ExtractMonth: _extract_field('month'),

--- a/ibis/backends/bigquery/tests/test_compiler.py
+++ b/ibis/backends/bigquery/tests/test_compiler.py
@@ -475,6 +475,60 @@ FROM `{project_id}.testing.functional_alltypes`"""  # noqa: E501
     assert result == expected
 
 
+def test_bit_and(alltypes, project_id):
+    i = alltypes.int_col
+    expr = i.bit_and()
+    result = expr.compile()
+    expected = f"""\
+SELECT BIT_AND(`int_col`) AS `bit_and`
+FROM `{project_id}.testing.functional_alltypes`"""
+    assert result == expected
+
+    b = alltypes.bigint_col
+    expr2 = i.bit_and(where=b > 6)
+    result = expr2.compile()
+    expected = f"""\
+SELECT BIT_AND(CASE WHEN `bigint_col` > 6 THEN `int_col` ELSE NULL END) AS `bit_and`
+FROM `{project_id}.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected
+
+
+def test_bit_or(alltypes, project_id):
+    i = alltypes.int_col
+    expr = i.bit_or()
+    result = expr.compile()
+    expected = f"""\
+SELECT BIT_OR(`int_col`) AS `bit_or`
+FROM `{project_id}.testing.functional_alltypes`"""
+    assert result == expected
+
+    b = alltypes.bigint_col
+    expr2 = i.bit_or(where=b > 6)
+    result = expr2.compile()
+    expected = f"""\
+SELECT BIT_OR(CASE WHEN `bigint_col` > 6 THEN `int_col` ELSE NULL END) AS `bit_or`
+FROM `{project_id}.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected
+
+
+def test_bit_xor(alltypes, project_id):
+    i = alltypes.int_col
+    expr = i.bit_xor()
+    result = expr.compile()
+    expected = f"""\
+SELECT BIT_XOR(`int_col`) AS `bit_xor`
+FROM `{project_id}.testing.functional_alltypes`"""
+    assert result == expected
+
+    b = alltypes.bigint_col
+    expr2 = i.bit_xor(where=b > 6)
+    result = expr2.compile()
+    expected = f"""\
+SELECT BIT_XOR(CASE WHEN `bigint_col` > 6 THEN `int_col` ELSE NULL END) AS `bit_xor`
+FROM `{project_id}.testing.functional_alltypes`"""  # noqa: E501
+    assert result == expected
+
+
 def test_cov(alltypes, project_id):
     d = alltypes.double_col
     expr = d.cov(d)

--- a/ibis/backends/mysql/compiler.py
+++ b/ibis/backends/mysql/compiler.py
@@ -9,6 +9,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.backends.base_sqlalchemy.alchemy import (
+    _reduction,
     _variance_reduction,
     fixed_arity,
     infix_op,
@@ -240,6 +241,9 @@ _operation_registry.update(
         ops.ExtractSecond: _extract('second'),
         ops.ExtractMillisecond: _extract('millisecond'),
         # reductions
+        ops.BitAnd: _reduction(sa.func.bit_and),
+        ops.BitOr: _reduction(sa.func.bit_or),
+        ops.BitXor: _reduction(sa.func.bit_xor),
         ops.Variance: _variance_reduction('var'),
         ops.StandardDev: _variance_reduction('stddev'),
         ops.IdenticalTo: _identical_to,

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -678,6 +678,7 @@ def _agg_function(name, klass, assign_default_name=True):
         return expr
 
     f.__name__ = name
+    f.__doc__ = klass.__doc__
     return f
 
 
@@ -1523,6 +1524,10 @@ _integer_value_methods = {
 }
 
 
+bit_and = _agg_function('bit_and', ops.BitAnd, True)
+bit_or = _agg_function('bit_or', ops.BitOr, True)
+bit_xor = _agg_function('bit_xor', ops.BitXor, True)
+
 mean = _agg_function('mean', ops.Mean, True)
 cummean = _unary_op('cummean', ops.CumulativeMean)
 
@@ -1611,6 +1616,12 @@ _numeric_column_methods = {
     'summary': _numeric_summary,
 }
 
+_integer_column_methods = {
+    'bit_and': bit_and,
+    'bit_or': bit_or,
+    'bit_xor': bit_xor,
+}
+
 _floating_value_methods = {
     'isnan': _unary_op('isnull', ops.IsNan),
     'isinf': _unary_op('isinf', ops.IsInf),
@@ -1621,6 +1632,7 @@ _add_methods(ir.IntegerValue, _integer_value_methods)
 _add_methods(ir.FloatingValue, _floating_value_methods)
 
 _add_methods(ir.NumericColumn, _numeric_column_methods)
+_add_methods(ir.IntegerColumn, _integer_column_methods)
 
 # ----------------------------------------------------------------------
 # GeoSpatial API

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -871,6 +871,63 @@ class Arbitrary(Reduction):
     output_type = rlz.scalar_like('arg')
 
 
+class BitAnd(Reduction):
+    """Aggregate bitwise AND operation.
+
+    All elements in an integer column are ``AND``ed together. This can be used
+    to determine which bit flags are set on all elements.
+
+    Resources:
+
+    * `BigQuery BIT_AND
+      <https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#bit_and>`_
+    * `MySQL BIT_AND
+      <https://dev.mysql.com/doc/refman/5.7/en/aggregate-functions.html#function_bit-and>`_
+    """
+
+    arg = Arg(rlz.column(rlz.integer))
+    where = Arg(rlz.boolean, default=None)
+    output_type = rlz.scalar_like('arg')
+
+
+class BitOr(Reduction):
+    """Aggregate bitwise OR operation.
+
+    All elements in an integer column are ``OR``ed together. This can be used
+    to determine which bit flags are set on any element.
+
+    Resources:
+
+    * `BigQuery BIT_OR
+      <https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#bit_or>`_
+    * `MySQL BIT_OR
+      <https://dev.mysql.com/doc/refman/5.7/en/aggregate-functions.html#function_bit-or>`_
+    """
+
+    arg = Arg(rlz.column(rlz.integer))
+    where = Arg(rlz.boolean, default=None)
+    output_type = rlz.scalar_like('arg')
+
+
+class BitXor(Reduction):
+    """Aggregate bitwise XOR operation.
+
+    All elements in an integer column are ``XOR``ed together. This can be used
+    as a parity checksum of element values.
+
+    Resources:
+
+    * `BigQuery BIT_XOR
+      <https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#bit_xor>`_
+    * `MySQL BIT_XOR
+      <https://dev.mysql.com/doc/refman/5.7/en/aggregate-functions.html#function_bit-xor>`_
+    """
+
+    arg = Arg(rlz.column(rlz.integer))
+    where = Arg(rlz.boolean, default=None)
+    output_type = rlz.scalar_like('arg')
+
+
 class Sum(Reduction):
     arg = Arg(rlz.column(rlz.numeric))
     where = Arg(rlz.boolean, default=None)

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -874,7 +874,7 @@ class Arbitrary(Reduction):
 class BitAnd(Reduction):
     """Aggregate bitwise AND operation.
 
-    All elements in an integer column are ``AND``ed together. This can be used
+    All elements in an integer column are ANDed together. This can be used
     to determine which bit flags are set on all elements.
 
     Resources:
@@ -893,7 +893,7 @@ class BitAnd(Reduction):
 class BitOr(Reduction):
     """Aggregate bitwise OR operation.
 
-    All elements in an integer column are ``OR``ed together. This can be used
+    All elements in an integer column are ORed together. This can be used
     to determine which bit flags are set on any element.
 
     Resources:
@@ -912,7 +912,7 @@ class BitOr(Reduction):
 class BitXor(Reduction):
     """Aggregate bitwise XOR operation.
 
-    All elements in an integer column are ``XOR``ed together. This can be used
+    All elements in an integer column are XORed together. This can be used
     as a parity checksum of element values.
 
     Resources:


### PR DESCRIPTION
TODO:

- [x] Tests for BigQuery
- [ ] Tests for MySQL
- [x] Documentation

Closes #2641