### PR TITLE
ENH: UDF operations for dask backend

### DIFF
--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -10,6 +10,7 @@ from ibis.backends.base import BaseBackend
 from ibis.backends.base_sqlalchemy.compiler import Dialect
 from ibis.backends.pandas import _flatten_subclass_tree
 
+from . import udf  # noqa: F401,F403 - register dispatchers
 from .client import DaskClient, DaskDatabase, DaskTable
 from .execution import execute, execute_node  # noqa F401
 

--- a/ibis/backends/dask/execution/aggregations.py
+++ b/ibis/backends/dask/execution/aggregations.py
@@ -22,7 +22,7 @@ from ibis.expr.typing import TimeContext
 
 from ..core import execute
 from ..dispatch import execute_node
-from .util import maybe_wrap_scalar, safe_concat
+from .util import coerce_to_output, safe_concat
 
 
 # TODO - aggregations - #2553
@@ -77,7 +77,7 @@ def execute_aggregation_dataframe(
     pieces = []
     for metric in op.metrics:
         piece = execute(metric, scope=scope, timecontext=timecontext, **kwargs)
-        piece = maybe_wrap_scalar(piece, metric)
+        piece = coerce_to_output(piece, metric)
         pieces.append(piece)
 
     # We must perform this check here otherwise dask will throw a ValueError

--- a/ibis/backends/dask/tests/execution/test_arrays.py
+++ b/ibis/backends/dask/tests/execution/test_arrays.py
@@ -57,7 +57,7 @@ def test_array_collect(t, df):
 
 
 @pytest.mark.xfail(
-    raises=NotImplementedError, reason='TODO - windowing -  #2553'
+    raises=NotImplementedError, reason='TODO - windowing - #2553'
 )
 def test_array_collect_rolling_partitioned(t, df):
     window = ibis.trailing_window(1, order_by=t.plain_int64)

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -57,7 +57,7 @@ def test_mutate(t, df):
     )
 
 
-@pytest.mark.xfail(reason='TODO - windowing -  #2553')
+@pytest.mark.xfail(reason='TODO - windowing - #2553')
 def test_project_scope_does_not_override(t, df):
     col = t.plain_int64
     expr = t[

--- a/ibis/backends/dask/tests/execution/test_util.py
+++ b/ibis/backends/dask/tests/execution/test_util.py
@@ -1,0 +1,28 @@
+import pytest
+
+from ...execution.util import assert_identical_grouping_keys
+
+
+@pytest.mark.parametrize(
+    'grouping, bad_grouping',
+    [
+        ("dup_strings", "dup_ints"),
+        (["dup_strings"], ["dup_ints"]),
+        (["dup_strings", "dup_ints"], ["dup_ints", "dup_strings"]),
+    ],
+)
+def test_identical_grouping_keys_assertion(df, grouping, bad_grouping):
+    gdf = df.groupby(grouping)
+
+    a = gdf.plain_int64
+    b = gdf.plain_strings
+
+    # should not raise
+    assert_identical_grouping_keys(a, b)
+
+    c = df.groupby(bad_grouping).plain_int64
+
+    with pytest.raises(
+        AssertionError, match=r"Differing grouping keys passed*"
+    ):
+        assert_identical_grouping_keys(a, b, c)

--- a/ibis/backends/dask/tests/test_udf.py
+++ b/ibis/backends/dask/tests/test_udf.py
@@ -1,0 +1,482 @@
+import collections
+
+import dask.dataframe as dd
+import numpy as np
+import pandas as pd
+import pandas.testing as tm
+import pytest
+
+import ibis
+import ibis.expr.datatypes as dt
+import ibis.expr.types as ir
+from ibis.udf.vectorized import analytic, elementwise, reduction
+
+from .. import Backend
+from ..udf import nullable
+
+# --------
+# Fixtures
+# --------
+
+
+@pytest.fixture
+def df(npartitions):
+    return dd.from_pandas(
+        pd.DataFrame(
+            {
+                'a': list('abc'),
+                'b': [1, 2, 3],
+                'c': [4.0, 5.0, 6.0],
+                'key': list('aab'),
+            }
+        ),
+        npartitions=npartitions,
+    )
+
+
+@pytest.fixture
+def df2(npartitions):
+    # df with some randomness
+    return dd.from_pandas(
+        pd.DataFrame(
+            {
+                'a': np.arange(4, dtype=float).tolist()
+                + np.random.rand(3).tolist(),
+                'b': np.arange(4, dtype=float).tolist()
+                + np.random.rand(3).tolist(),
+                'c': np.arange(7, dtype=int).tolist(),
+                'key': list('ddeefff'),
+            }
+        ),
+        npartitions=npartitions,
+    )
+
+
+@pytest.fixture
+def con(df, df2):
+    return Backend().connect({'df': df, 'df2': df2})
+
+
+@pytest.fixture
+def t(con):
+    return con.table('df')
+
+
+@pytest.fixture
+def t2(con):
+    return con.table('df2')
+
+
+# -------------
+# UDF Functions
+# -------------
+
+
+@elementwise(input_type=['string'], output_type='int64')
+def my_string_length(series, **kwargs):
+    return series.str.len() * 2
+
+
+@elementwise(input_type=[dt.double, dt.double], output_type=dt.double)
+def my_add(series1, series2, **kwargs):
+    return series1 + series2
+
+
+@reduction(['double'], 'double')
+def my_mean(series):
+    return series.mean()
+
+
+@reduction(input_type=[dt.string], output_type=dt.int64)
+def my_string_length_sum(series, **kwargs):
+    return (series.str.len() * 2).sum()
+
+
+@reduction(input_type=[dt.double, dt.double], output_type=dt.double)
+def my_corr(lhs, rhs, **kwargs):
+    return lhs.corr(rhs)
+
+
+@elementwise([dt.double], dt.double)
+def add_one(x):
+    return x + 1.0
+
+
+@elementwise([dt.double], dt.double)
+def times_two(x):
+    return x * 2.0
+
+
+@analytic(input_type=['double'], output_type='double')
+def zscore(series):
+    return (series - series.mean()) / series.std()
+
+
+@reduction(
+    input_type=[dt.double], output_type=dt.Array(dt.double),
+)
+def quantiles(series, *, quantiles):
+    return list(series.quantile(quantiles))
+
+
+# -----
+# Tests
+# -----
+
+
+def test_udf(t, df):
+    expr = my_string_length(t.a)
+
+    assert isinstance(expr, ir.ColumnExpr)
+
+    result = expr.execute()
+    expected = df.a.str.len().mul(2).compute()
+
+    tm.assert_series_equal(result, expected, check_names=False)
+
+
+def test_elementwise_udf_with_non_vectors(con):
+    expr = my_add(1.0, 2.0)
+    result = con.execute(expr)
+    assert result == 3.0
+
+
+def test_multiple_argument_udf(con, t, df):
+    expr = my_add(t.b, t.c)
+
+    assert isinstance(expr, ir.ColumnExpr)
+    assert isinstance(expr, ir.NumericColumn)
+    assert isinstance(expr, ir.FloatingColumn)
+
+    result = expr.execute()
+    expected = (df.b + df.c).compute()
+    tm.assert_series_equal(result, expected)
+
+
+def test_multiple_argument_udf_group_by(con, t, df):
+    expr = t.groupby(t.key).aggregate(my_add=my_add(t.b, t.c).sum())
+
+    assert isinstance(expr, ir.TableExpr)
+    assert isinstance(expr.my_add, ir.ColumnExpr)
+    assert isinstance(expr.my_add, ir.NumericColumn)
+    assert isinstance(expr.my_add, ir.FloatingColumn)
+
+    result = expr.execute()
+    expected = pd.DataFrame(
+        {'key': list('ab'), 'my_add': [sum([1.0 + 4.0, 2.0 + 5.0]), 3.0 + 6.0]}
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+def test_udaf(con, t, df):
+    expr = my_string_length_sum(t.a)
+
+    assert isinstance(expr, ir.ScalarExpr)
+
+    result = expr.execute()
+    expected = t.a.execute().str.len().mul(2).sum()
+    assert result == expected
+
+
+def test_udaf_analytic(con, t, df):
+    expr = zscore(t.c)
+
+    assert isinstance(expr, ir.ColumnExpr)
+
+    result = expr.execute()
+
+    def f(s):
+        return s.sub(s.mean()).div(s.std())
+
+    expected = (f(df.c)).compute()
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.xfail(
+    raises=NotImplementedError, reason='TODO - windowing - #2553'
+)
+def test_udaf_analytic_groupby(con, t, df):
+    expr = zscore(t.c).over(ibis.window(group_by=t.key))
+
+    assert isinstance(expr, ir.ColumnExpr)
+
+    result = expr.execute()
+
+    def f(s):
+        return s.sub(s.mean()).div(s.std())
+
+    expected = df.groupby('key').c.transform(f)
+    tm.assert_series_equal(result, expected)
+
+
+def test_udaf_groupby(t2, df2):
+    expr = t2.groupby(t2.key).aggregate(my_corr=my_corr(t2.a, t2.b))
+
+    result = expr.execute().sort_values('key').reset_index()
+
+    dfi = df2.set_index('key').compute()
+    expected = pd.DataFrame(
+        {
+            'key': list('def'),
+            'my_corr': [
+                dfi.loc[value, 'a'].corr(dfi.loc[value, 'b'])
+                for value in 'def'
+            ],
+        }
+    )
+
+    columns = ['key', 'my_corr']
+    tm.assert_frame_equal(result[columns], expected[columns])
+
+
+def test_nullable():
+    t = ibis.table([('a', 'int64')])
+    assert nullable(t.a.type()) == (type(None),)
+
+
+def test_nullable_non_nullable_field():
+    t = ibis.table([('a', dt.String(nullable=False))])
+    assert nullable(t.a.type()) == ()
+
+
+def test_compose_udfs(t2, df2):
+    expr = times_two(add_one(t2.a))
+    result = expr.execute().reset_index(drop=True)
+    expected = df2.a.add(1.0).mul(2.0).compute()
+    tm.assert_series_equal(result, expected, check_names=False)
+
+
+@pytest.mark.xfail(
+    raises=NotImplementedError, reason='TODO - windowing - #2553'
+)
+def test_udaf_window(t2, df2):
+    window = ibis.trailing_window(2, order_by='a', group_by='key')
+    expr = t2.mutate(rolled=my_mean(t2.b).over(window))
+    result = expr.execute().sort_values(['key', 'a'])
+    expected = df2.sort_values(['key', 'a']).assign(
+        rolled=lambda df: df.groupby('key')
+        .b.rolling(3, min_periods=1)
+        .mean()
+        .reset_index(level=0, drop=True)
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.xfail(
+    raises=NotImplementedError, reason='TODO - windowing - #2553'
+)
+def test_udaf_window_interval(npartitions):
+    df = pd.DataFrame(
+        collections.OrderedDict(
+            [
+                (
+                    "time",
+                    pd.date_range(
+                        start='20190105', end='20190101', freq='-1D'
+                    ),
+                ),
+                ("key", [1, 2, 1, 2, 1]),
+                ("value", np.arange(5)),
+            ]
+        )
+    )
+    df = dd.from_pandas(df, npartitions=npartitions)
+
+    con = Backend().connect({'df': df})
+    t = con.table('df')
+    window = ibis.trailing_range_window(
+        ibis.interval(days=2), order_by='time', group_by='key'
+    )
+
+    expr = t.mutate(rolled=my_mean(t.value).over(window))
+
+    result = expr.execute().sort_values(['time', 'key']).reset_index(drop=True)
+    expected = (
+        df.sort_values(['time', 'key'])
+        .set_index('time')
+        .assign(
+            rolled=lambda df: df.groupby('key')
+            .value.rolling('2D', closed='both')
+            .mean()
+            .reset_index(level=0, drop=True)
+        )
+    ).reset_index(drop=False)
+
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.xfail(
+    raises=NotImplementedError, reason='TODO - windowing - #2553'
+)
+def test_multiple_argument_udaf_window(npartitions):
+    @reduction(['double', 'double'], 'double')
+    def my_wm(v, w):
+        return np.average(v, weights=w)
+
+    df = pd.DataFrame(
+        {
+            'a': np.arange(4, 0, dtype=float, step=-1).tolist()
+            + np.random.rand(3).tolist(),
+            'b': np.arange(4, dtype=float).tolist()
+            + np.random.rand(3).tolist(),
+            'c': np.arange(4, dtype=float).tolist()
+            + np.random.rand(3).tolist(),
+            'd': np.repeat(1, 7),
+            'key': list('deefefd'),
+        }
+    )
+    df = dd.from_pandas(df, npartitions=npartitions)
+
+    con = Backend().connect({'df': df})
+    t = con.table('df')
+    window = ibis.trailing_window(2, order_by='a', group_by='key')
+    window2 = ibis.trailing_window(1, order_by='b', group_by='key')
+    expr = t.mutate(
+        wm_b=my_wm(t.b, t.d).over(window),
+        wm_c=my_wm(t.c, t.d).over(window),
+        wm_c2=my_wm(t.c, t.d).over(window2),
+    )
+    result = expr.execute().sort_values(['key', 'a'])
+    expected = (
+        df.sort_values(['key', 'a'])
+        .assign(
+            wm_b=lambda df: df.groupby('key')
+            .b.rolling(3, min_periods=1)
+            .mean()
+            .reset_index(level=0, drop=True)
+        )
+        .assign(
+            wm_c=lambda df: df.groupby('key')
+            .c.rolling(3, min_periods=1)
+            .mean()
+            .reset_index(level=0, drop=True)
+        )
+    )
+    expected = expected.sort_values(['key', 'b']).assign(
+        wm_c2=lambda df: df.groupby('key')
+        .c.rolling(2, min_periods=1)
+        .mean()
+        .reset_index(level=0, drop=True)
+    )
+    expected = expected.sort_values(['key', 'a'])
+
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.xfail(
+    raises=NotImplementedError, reason='TODO - windowing - #2553'
+)
+def test_udaf_window_nan(npartitions):
+    df = pd.DataFrame(
+        {
+            'a': np.arange(10, dtype=float),
+            'b': [3.0, np.NaN] * 5,
+            'key': list('ddeefffggh'),
+        }
+    )
+    df = dd.from_pandas(df, npartitions=npartitions)
+
+    con = Backend().connect({'df': df})
+    t = con.table('df')
+    window = ibis.trailing_window(2, order_by='a', group_by='key')
+    expr = t.mutate(rolled=my_mean(t.b).over(window))
+    result = expr.execute().sort_values(['key', 'a'])
+    expected = df.sort_values(['key', 'a']).assign(
+        rolled=lambda d: d.groupby('key')
+        .b.rolling(3, min_periods=1)
+        .apply(lambda x: x.mean(), raw=True)
+        .reset_index(level=0, drop=True)
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.fixture(params=[[0.25, 0.75], [0.01, 0.99]])
+def qs(request):
+    return request.param
+
+
+def test_array_return_type_reduction(con, t, df, qs):
+    expr = quantiles(t.b, quantiles=qs)
+    result = expr.execute()
+    expected = df.b.quantile(qs).compute()
+    assert result == expected.tolist()
+
+
+@pytest.mark.xfail(
+    raises=NotImplementedError, reason='TODO - windowing - #2553'
+)
+def test_array_return_type_reduction_window(con, t, df, qs):
+    expr = quantiles(t.b, quantiles=qs).over(ibis.window())
+    result = expr.execute()
+    expected_raw = df.b.quantile(qs).tolist()
+    expected = pd.Series([expected_raw] * len(df))
+    tm.assert_series_equal(result, expected)
+
+
+def test_elementwise_udf_with_many_args(t2):
+    @elementwise(
+        input_type=[dt.double] * 16 + [dt.int32] * 8, output_type=dt.double
+    )
+    def my_udf(
+        c1,
+        c2,
+        c3,
+        c4,
+        c5,
+        c6,
+        c7,
+        c8,
+        c9,
+        c10,
+        c11,
+        c12,
+        c13,
+        c14,
+        c15,
+        c16,
+        c17,
+        c18,
+        c19,
+        c20,
+        c21,
+        c22,
+        c23,
+        c24,
+    ):
+        return c1
+
+    expr = my_udf(*([t2.a] * 8 + [t2.b] * 8 + [t2.c] * 8))
+    result = expr.execute()
+    expected = t2.a.execute()
+
+    tm.assert_series_equal(result, expected, check_names=False)
+
+
+# -----------------
+# Test raied errors
+# -----------------
+
+
+def test_udaf_parameter_mismatch():
+    with pytest.raises(TypeError):
+
+        @reduction(input_type=[dt.double], output_type=dt.double)
+        def my_corr(lhs, rhs, **kwargs):
+            pass
+
+
+def test_udf_parameter_mismatch():
+    with pytest.raises(TypeError):
+
+        @reduction(input_type=[], output_type=dt.double)
+        def my_corr2(lhs, **kwargs):
+            pass
+
+
+def test_udf_error(t):
+    @elementwise(input_type=[dt.double], output_type=dt.double)
+    def error_udf(s):
+        raise ValueError('xxx')
+
+    with pytest.raises(ValueError):
+        error_udf(t.c).execute()

--- a/ibis/backends/dask/udf.py
+++ b/ibis/backends/dask/udf.py
@@ -1,0 +1,167 @@
+import itertools
+
+import dask.dataframe as dd
+import dask.dataframe.groupby as ddgb
+import dask.delayed
+import pandas
+
+import ibis.client
+import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
+import ibis.udf.vectorized
+from ibis.backends.pandas.udf import nullable  # noqa
+
+from .dispatch import execute_node, pre_execute
+from .execution.util import assert_identical_grouping_keys, make_selected_obj
+
+
+@pre_execute.register(ops.ElementWiseVectorizedUDF)
+@pre_execute.register(ops.ElementWiseVectorizedUDF, ibis.client.Client)
+def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
+    """Register execution rules for elementwise UDFs.
+    """
+    input_type = op.input_type
+
+    # definitions
+
+    # Define an execution rule for elementwise operations on a
+    # grouped Series
+    nargs = len(input_type)
+
+    @execute_node.register(
+        ops.ElementWiseVectorizedUDF,
+        *(itertools.repeat(ddgb.SeriesGroupBy, nargs)),
+    )
+    def execute_udf_node_groupby(op, *args, **kwargs):
+        func = op.func
+
+        # all grouping keys must be identical
+        assert_identical_grouping_keys(*args)
+
+        # we're performing a scalar operation on grouped column, so
+        # perform the operation directly on the underlying Series
+        # and regroup after it's finished
+        args_objs = [make_selected_obj(arg) for arg in args]
+        groupings = args[0].index
+        return dd.map_partitions(func, *args_objs).groupby(groupings)
+
+    # Define an execution rule for a simple elementwise Series
+    # function
+    @execute_node.register(
+        ops.ElementWiseVectorizedUDF, *(itertools.repeat(dd.Series, nargs))
+    )
+    def execute_udf_node(op, *args, **kwargs):
+        # We have rewritten op.func to be a closure enclosing
+        # the kwargs, and therefore, we do not need to pass
+        # kwargs here. This is true for all udf execution in this
+        # file.
+        # See ibis.udf.vectorized.UserDefinedFunction
+        if isinstance(op._output_type, dt.Struct):
+            # dask does not know how to glue together Tuple[*pd.Series].
+            # We create a wrapper that performs the "gluing" in each partition
+            def wrapper(func, *cols):
+                raw = func(*cols)
+                return pandas.Series(zip(*raw))
+
+            df = dd.map_partitions(wrapper, op.func, *args, meta="object")
+            df.index = args[0].index
+            return df
+        else:
+            df = dd.map_partitions(
+                op.func, *args, meta=op._output_type.to_dask()
+            )
+
+            return df
+
+    @execute_node.register(
+        ops.ElementWiseVectorizedUDF, *(itertools.repeat(object, nargs))
+    )
+    def execute_udf_node_non_dask(op, *args, **kwargs):
+        return op.func(*args)
+
+    return scope
+
+
+@pre_execute.register(ops.AnalyticVectorizedUDF)
+@pre_execute.register(ops.AnalyticVectorizedUDF, ibis.client.Client)
+@pre_execute.register(ops.ReductionVectorizedUDF)
+@pre_execute.register(ops.ReductionVectorizedUDF, ibis.client.Client)
+def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
+    input_type = op.input_type
+    nargs = len(input_type)
+
+    # An execution rule to handle analytic and reduction UDFs over
+    # 1) an ungrouped window,
+    # 2) an ungrouped Aggregate node, or
+    # 3) an ungrouped custom aggregation context
+    # Ungrouped analytic/reduction functions recieve the entire Series at once
+    # This is generally not recommened.
+    @execute_node.register(type(op), *(itertools.repeat(dd.Series, nargs)))
+    def execute_udaf_node_no_groupby(op, *args, aggcontext, **kwargs):
+
+        meta = pandas.Series([], dtype=op._output_type.to_dask())
+
+        # This function is in essence fully materializing the dd.Series and
+        # passing that (now) pd.Series to aggctx. This materialization
+        # happens at `.compute()` time, making this "lazy"
+        @dask.delayed
+        def lazy_agg(*series: pandas.Series):
+            return aggcontext.agg(series[0], op.func, *series[1:])
+
+        lazy_result = lazy_agg(*args)
+
+        # Depending on the type of operation, lazy_result is a Delayed that
+        # could become a dd.Series or a dd.core.Scalar
+        if isinstance(op, ops.AnalyticVectorizedUDF):
+            result = dd.from_delayed(lazy_result, meta=meta)
+        else:
+            # lazy_result is a dd.core.Scalar from an ungrouped reduction
+            if isinstance(op._output_type, (dt.Array, dt.Struct)):
+                # we're outputing a dt.Struct that will need to be destructured
+                # or an array of an unknown size.
+                # we compute so we can work with items inside downstream.
+                result = lazy_result.compute()
+            else:
+                result = dd.from_delayed(
+                    lazy_result,
+                    meta=op._output_type.to_dask(),
+                    verify_meta=False,
+                )
+
+        return result
+
+    @execute_node.register(
+        type(op), *(itertools.repeat(ddgb.SeriesGroupBy, nargs))
+    )
+    def execute_udaf_node_groupby(op, *args, aggcontext, **kwargs):
+        # To apply a udf func to a list of grouped series we:
+        # 1. Grab the dataframe they're grouped off of
+        # 2. Grab the column name for each series
+        # 3. .apply a wrapper that performs the selection using the col name
+        #    and applies the udf on to those
+        # This way we rely on dask dealing with groups and pass the udf down
+        # to the frame level.
+        assert_identical_grouping_keys(*args)
+        func = op.func
+
+        grouped_df = args[0].obj.groupby(args[0].index)
+        col_names = [col._meta._selected_obj.name for col in args]
+
+        def apply_wrapper(df, apply_func, col_names):
+            cols = (df[col] for col in col_names)
+            return apply_func(*cols)
+
+        # NOTE - We add a detailed meta here so we do not drop the key index
+        # downstream. This seems to be fixed in versions of dask > 2020.12.0
+        return grouped_df.apply(
+            apply_wrapper,
+            func,
+            col_names,
+            meta=pandas.Series(
+                [],
+                index=pandas.Index([], name=args[0].index[0]),
+                dtype=op._output_type.to_dask(),
+            ),
+        )
+
+    return scope

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -84,6 +84,25 @@ def coerce_to_output(
     Returns
     -------
     result: A Series or DataFrame
+
+    Examples
+    --------
+    For dataframe outputs, see ``ibis.util.coerce_to_dataframe``.
+
+    >>> coerce_to_output(pd.Series(1), expr)
+    0    1
+    Name: result, dtype: int64
+    >>> coerce_to_output(1, expr)
+    0    1
+    Name: result, dtype: int64
+    >>> coerce_to_output(1, expr, [1,2,3])
+    1    1
+    2    1
+    3    1
+    Name: result, dtype: int64
+    >>> coerce_to_output([1,2,3], expr)
+    0    [1, 2, 3]
+    Name: result, dtype: object
     """
     result_name = getattr(expr, '_name', None)
 

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -94,6 +94,27 @@ def coerce_to_dataframe(data: Any, names: List[str]) -> pd.DataFrame:
     Returns
     -------
     pd.DataFrame
+
+    Examples
+    --------
+    >>> coerce_to_dataframe(pd.DataFrame({'a': [1, 2, 3]}), ['b'])
+       b
+    0  1
+    1  2
+    2  3
+    >>> coerce_to_dataframe(pd.Series([[1, 2, 3]]), ['a', 'b', 'c'])
+       a  b  c
+    0  1  2  3
+    >>> coerce_to_dataframe(pd.Series([range(3), range(3)]), ['a', 'b', 'c'])
+       a  b  c
+    0  0  1  2
+    1  0  1  2
+    >>> coerce_to_dataframe([pd.Series(x) for x in [1, 2, 3]], ['a', 'b', 'c'])
+       a  b  c
+    0  1  2  3
+    >>>  coerce_to_dataframe([1, 2, 3], ['a', 'b', 'c'])
+       a  b  c
+    0  1  2  3
     """
     if isinstance(data, pd.DataFrame):
         result = data


### PR DESCRIPTION
This PR adds support for udf operations to the dask backend. It unskips all non-window tests in

- `ibis/backends/tests/test_vectorized_udf.py`
- `ibis/backends/dask/tests/test_udf.py` (which were ported from the pandas backend. I've purposely left in xfail window tests so I can add to the tracker. )

In addition, I've built out the dask backend clones of `coerce_to_output` and `coerce_to_dataframe` which get used in udf/section operations. 

Post Merge:

- [ ] Update https://github.com/ibis-project/ibis/issues/2553 post merge (for things that are no longer skipped + more things skipped due to windowing). 
