### PR TITLE
FEAT: Add auth_local_webserver, auth_external_data, and auth_cache to BigQuery connect

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,12 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2655` Add `auth_local_webserver`, `auth_external_data`, and
+  `auth_cache` parameters to BigQuery connect method. Set
+  `auth_local_webserver` to use a local server instead of copy-pasting an
+  authorization code. Set `auth_external_data` to true to request additional
+  scopes required to query Google Drive and Sheets. Set `auth_cache` to
+  `reauth` or `none` to force reauthentication.
 * :bug:`2588` Fix BigQuery connect bug that ignored project ID parameter
 * :bug: `2636` Fix overwrite logic to account for DestructColumn inside mutate API
 * :feature:`2641` Add `bit_and`, `bit_or`, and `bit_xor` integer column aggregates (BigQuery and MySQL backends)

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -1,6 +1,5 @@
 """BigQuery public API."""
 
-from collections import namedtuple
 from typing import Optional
 
 import google.auth.credentials
@@ -65,9 +64,6 @@ CLIENT_ID = (
     "546535678771-gvffde27nd83kfl6qbrnletqvkdmsese.apps.googleusercontent.com"
 )
 CLIENT_SECRET = "iU5ohAF2qcqrujegE3hQ1cPt"
-
-
-AuthOptions = namedtuple("AuthOptions", [],)
 
 
 def connect(

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -1,10 +1,12 @@
 """BigQuery public API."""
 
+from collections import namedtuple
 from typing import Optional
 
 import google.auth.credentials
 import google.cloud.bigquery  # noqa: F401, fail early if bigquery is missing
 import pydata_google_auth
+from pydata_google_auth import cache
 
 import ibis.common.exceptions as com
 import ibis.config
@@ -54,10 +56,18 @@ def verify(expr, params=None):
 
 
 SCOPES = ["https://www.googleapis.com/auth/bigquery"]
+EXTERNAL_DATA_SCOPES = [
+    "https://www.googleapis.com/auth/bigquery",
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/drive",
+]
 CLIENT_ID = (
     "546535678771-gvffde27nd83kfl6qbrnletqvkdmsese.apps.googleusercontent.com"
 )
 CLIENT_SECRET = "iU5ohAF2qcqrujegE3hQ1cPt"
+
+
+AuthOptions = namedtuple("AuthOptions", [],)
 
 
 def connect(
@@ -65,6 +75,9 @@ def connect(
     dataset_id: Optional[str] = None,
     credentials: Optional[google.auth.credentials.Credentials] = None,
     application_name: Optional[str] = None,
+    auth_local_webserver: bool = False,
+    auth_external_data: bool = False,
+    auth_cache: str = "default",
 ) -> BigQueryClient:
     """Create a BigQueryClient for use with Ibis.
 
@@ -78,6 +91,31 @@ def connect(
     credentials : google.auth.credentials.Credentials
     application_name : str
         A string identifying your application to Google API endpoints.
+    auth_local_webserver : bool
+        Use a local webserver for the user authentication.  Binds a webserver
+        to an open port on localhost between 8080 and 8089, inclusive, to
+        receive authentication token. If not set, defaults to False, which
+        requests a token via the console.
+    auth_external_data : bool
+        Authenticate using additional scopes required to `query external data
+        sources <https://cloud.google.com/bigquery/external-data-sources>`_,
+        such as Google Sheets, files in Google Cloud Storage, or files in
+        Google Drive. If not set, defaults to False, which requests the default
+        BigQuery scopes.
+    auth_cache : str
+        Selects the behavior of the credentials cache.
+
+        ``'default'``
+            Reads credentials from disk if available, otherwise authenticates
+            and caches credentials to disk.
+
+        ``'reauth'``
+            Authenticates and caches credentials to disk.
+
+        ``'none'``
+            Authenticates and does **not** cache credentials.
+
+        Defaults to ``'default'``.
 
     Returns
     -------
@@ -87,14 +125,32 @@ def connect(
     default_project_id = None
 
     if credentials is None:
-        credentials_cache = pydata_google_auth.cache.ReadWriteCredentialsCache(
-            filename="ibis.json"
-        )
+        scopes = SCOPES
+        if auth_external_data:
+            scopes = EXTERNAL_DATA_SCOPES
+
+        if auth_cache == "default":
+            credentials_cache = cache.ReadWriteCredentialsCache(
+                filename="ibis.json"
+            )
+        elif auth_cache == "reauth":
+            credentials_cache = cache.WriteOnlyCredentialsCache(
+                filename="ibis.json"
+            )
+        elif auth_cache == "none":
+            credentials_cache = cache.NOOP
+        else:
+            raise ValueError(
+                f"Got unexpected value for auth_cache = '{auth_cache}'. "
+                "Expected one of 'default', 'reauth', or 'none'."
+            )
+
         credentials, default_project_id = pydata_google_auth.default(
-            SCOPES,
+            scopes,
             client_id=CLIENT_ID,
             client_secret=CLIENT_SECRET,
             credentials_cache=credentials_cache,
+            use_local_webserver=auth_local_webserver,
         )
 
     project_id = project_id or default_project_id

--- a/ibis/backends/bigquery/tests/test_connect.py
+++ b/ibis/backends/bigquery/tests/test_connect.py
@@ -54,3 +54,125 @@ def test_application_name_sets_user_agent(
     user_agent = info.to_user_agent()
     assert ' ibis/{}'.format(ibis.__version__) in user_agent
     assert 'my-great-app/0.7.0 ' in user_agent
+
+
+def test_auth_default(project_id, credentials, monkeypatch):
+    mock_calls = []
+
+    def mock_default(*args, **kwargs):
+        mock_calls.append((args, kwargs))
+        return credentials, project_id
+
+    monkeypatch.setattr(pydata_google_auth, "default", mock_default)
+
+    bq_backend.connect(
+        project_id=project_id, dataset_id='bigquery-public-data.stackoverflow',
+    )
+
+    assert len(mock_calls) == 1
+    args, kwargs = mock_calls[0]
+    assert len(args) == 1
+    scopes = args[0]
+    assert scopes == bq_backend.SCOPES
+    auth_local_webserver = kwargs["use_local_webserver"]
+    auth_cache = kwargs["credentials_cache"]
+    assert not auth_local_webserver
+    assert isinstance(
+        auth_cache, pydata_google_auth.cache.ReadWriteCredentialsCache,
+    )
+
+
+def test_auth_local_webserver(project_id, credentials, monkeypatch):
+    mock_calls = []
+
+    def mock_default(*args, **kwargs):
+        mock_calls.append((args, kwargs))
+        return credentials, project_id
+
+    monkeypatch.setattr(pydata_google_auth, "default", mock_default)
+
+    bq_backend.connect(
+        project_id=project_id,
+        dataset_id='bigquery-public-data.stackoverflow',
+        auth_local_webserver=True,
+    )
+
+    assert len(mock_calls) == 1
+    _, kwargs = mock_calls[0]
+    auth_local_webserver = kwargs["use_local_webserver"]
+    assert auth_local_webserver
+
+
+def test_auth_external_data(project_id, credentials, monkeypatch):
+    mock_calls = []
+
+    def mock_default(*args, **kwargs):
+        mock_calls.append((args, kwargs))
+        return credentials, project_id
+
+    monkeypatch.setattr(pydata_google_auth, "default", mock_default)
+
+    bq_backend.connect(
+        project_id=project_id,
+        dataset_id='bigquery-public-data.stackoverflow',
+        auth_external_data=True,
+    )
+
+    assert len(mock_calls) == 1
+    args, _ = mock_calls[0]
+    assert len(args) == 1
+    scopes = args[0]
+    assert scopes == bq_backend.EXTERNAL_DATA_SCOPES
+
+
+def test_auth_cache_reauth(project_id, credentials, monkeypatch):
+    mock_calls = []
+
+    def mock_default(*args, **kwargs):
+        mock_calls.append((args, kwargs))
+        return credentials, project_id
+
+    monkeypatch.setattr(pydata_google_auth, "default", mock_default)
+
+    bq_backend.connect(
+        project_id=project_id,
+        dataset_id="bigquery-public-data.stackoverflow",
+        auth_cache="reauth",
+    )
+
+    assert len(mock_calls) == 1
+    _, kwargs = mock_calls[0]
+    auth_cache = kwargs["credentials_cache"]
+    assert isinstance(
+        auth_cache, pydata_google_auth.cache.WriteOnlyCredentialsCache,
+    )
+
+
+def test_auth_cache_none(project_id, credentials, monkeypatch):
+    mock_calls = []
+
+    def mock_default(*args, **kwargs):
+        mock_calls.append((args, kwargs))
+        return credentials, project_id
+
+    monkeypatch.setattr(pydata_google_auth, "default", mock_default)
+
+    bq_backend.connect(
+        project_id=project_id,
+        dataset_id="bigquery-public-data.stackoverflow",
+        auth_cache="none",
+    )
+
+    assert len(mock_calls) == 1
+    _, kwargs = mock_calls[0]
+    auth_cache = kwargs["credentials_cache"]
+    assert auth_cache is pydata_google_auth.cache.NOOP
+
+
+def test_auth_cache_unknown(project_id):
+    with pytest.raises(ValueError, match="unexpected value for auth_cache"):
+        bq_backend.connect(
+            project_id=project_id,
+            dataset_id="bigquery-public-data.stackoverflow",
+            auth_cache="not_a_real_cache",
+        )


### PR DESCRIPTION
Towards #2179 

In order to verify the application, I need to submit a video demonstrating the need for the requested scopes. I realized that we don't make it easy to query data in Google Drive, so this PR remedies that.