### PR TITLE
BUG: Add temporary struct col in pyspark backend to ensure that UDFs are e…

### DIFF
--- a/ci/deps/pyspark.yml
+++ b/ci/deps/pyspark.yml
@@ -1,1 +1,1 @@
-pyspark>=2.4.3
+pyspark>=3.1.1

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2657` Add temporary struct col in pyspark backend to ensure that UDFs are executed only once
 * :bug:`2588` Fix BigQuery connect bug that ignored project ID parameter
 * :bug: `2636` Fix overwrite logic to account for DestructColumn inside mutate API
 * :feature:`2641` Add `bit_and`, `bit_or`, and `bit_xor` integer column aggregates (BigQuery and MySQL backends)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -23,7 +23,7 @@ from ibis.backends.spark.datatypes import (
     spark_dtype,
 )
 from ibis.expr.timecontext import adjust_context
-from ibis.util import coerce_to_dataframe
+from ibis.util import coerce_to_dataframe, guid
 
 from .operations import PySparkTable
 from .timecontext import combine_time_context, filter_by_time_context
@@ -121,15 +121,22 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
     src_table = t.translate(op.table, scope, combined_timecontext)
 
     col_in_selection_order = []
+    col_to_drop = []
     for selection in op.selections:
         if isinstance(selection, types.TableExpr):
             col_in_selection_order.extend(selection.columns)
         elif isinstance(selection, types.DestructColumn):
             struct_col = t.translate(selection, scope, combined_timecontext)
+            # assign struct col and drop it later
+            # This is a work around to ensure that the struct_col
+            # is only executed once
+            struct_col_name = f"destruct_col_{guid()}"
+            col_in_selection_order.append(struct_col.alias(struct_col_name))
+            col_to_drop.append(struct_col_name)
             cols = [
                 struct_col[name].alias(name) for name in selection.type().names
             ]
-            col_in_selection_order += cols
+            col_in_selection_order.extend(cols)
         elif isinstance(selection, (types.ColumnExpr, types.ScalarExpr)):
             col = t.translate(selection, scope, combined_timecontext).alias(
                 selection.get_name()
@@ -140,20 +147,24 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
                 f"Unrecoginized type in selections: {type(selection)}"
             )
 
+    result_table = src_table
     if col_in_selection_order:
-        src_table = src_table[col_in_selection_order]
+        result_table = result_table[col_in_selection_order]
+
+    if col_to_drop:
+        result_table = result_table.drop(*col_to_drop)
 
     for predicate in op.predicates:
         col = t.translate(predicate, scope, timecontext)
-        src_table = src_table[col]
+        result_table = result_table[col]
 
     if op.sort_keys:
         sort_cols = [
             t.translate(key, scope, timecontext) for key in op.sort_keys
         ]
-        src_table = src_table.sort(*sort_cols)
+        result_table = result_table.sort(*sort_cols)
 
-    return filter_by_time_context(src_table, timecontext)
+    return filter_by_time_context(result_table, timecontext)
 
 
 @compiles(ops.SortKey)

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -145,7 +145,7 @@ class BackendTest(abc.ABC):
 
     @property
     def api(self):
-        return getattr(ibis, self.name())
+        return getattr(ibis.backends, self.name())
 
     def make_context(
         self, params: Optional[Mapping[ir.ValueExpr, Any]] = None
@@ -163,7 +163,8 @@ def get_spark_testing_client(data_directory):
     global _spark_testing_client
     if _spark_testing_client is None:
         _spark_testing_client = get_common_spark_testing_client(
-            data_directory, lambda session: ibis.spark.connect(session)
+            data_directory,
+            lambda session: ibis.backends.spark.connect(session),
         )
     return _spark_testing_client
 
@@ -173,7 +174,8 @@ def get_pyspark_testing_client(data_directory):
     global _pyspark_testing_client
     if _pyspark_testing_client is None:
         _pyspark_testing_client = get_common_spark_testing_client(
-            data_directory, lambda session: ibis.pyspark.connect(session)
+            data_directory,
+            lambda session: ibis.backends.pyspark.connect(session),
         )
     return _pyspark_testing_client
 

--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -113,6 +113,22 @@ def pytest_runtest_call(item):
                 )
             )
 
+    for marker in item.iter_markers(name='min_spark_version'):
+        min_version = marker.args[0]
+        if backend.name() in ['spark', 'pyspark']:
+            from distutils.version import LooseVersion
+
+            import pyspark
+
+            if LooseVersion(pyspark.__version__) < LooseVersion(min_version):
+                item.add_marker(
+                    pytest.mark.xfail(
+                        reason=f'Require minimal spark version {min_version}, '
+                        f'but is {pyspark.__version__}',
+                        **marker.kwargs,
+                    )
+                )
+
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_pyfunc_call(pyfuncitem):

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -352,7 +352,6 @@ def test_elementwise_udf_destruct_exact_once(backend, alltypes):
             output_type=dt.Struct(['col1', 'col2'], [dt.double, dt.double]),
         )
         def add_one_struct_exact_once(v):
-            print(v)
             key = v.iloc[0]
             path = Path(f"{tempdir}/{key}")
             assert not path.exists()

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -343,18 +343,8 @@ def test_elementwise_udf_overwrite_destruct_and_assign(backend, alltypes):
 # TODO - udf - #2553
 @pytest.mark.xfail_backends(['dask'])
 @pytest.mark.xfail_unsupported
+@pytest.mark.min_spark_version('3.1')
 def test_elementwise_udf_destruct_exact_once(backend, alltypes):
-    # xfail on Spark version < 3.1.1
-    try:
-        from distutils.version import LooseVersion
-
-        import pyspark
-
-        if LooseVersion(pyspark.__version__) < LooseVersion("3.1.1"):
-            pytest.xfail("This test only works on Spark >= 3.1.1")
-    except ImportError:
-        pass
-
     with tempfile.TemporaryDirectory() as tempdir:
 
         @elementwise(

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ markers =
     hdf5
     impala
     kudu
+    min_spark_version
     mysql
     only_on_backends
     pandas


### PR DESCRIPTION
…xecuted once

What change is proposed
=================
Spark sometimes execute the UDF multiple times if 

- The output of the UDF is a struct type
- The struct column is not explicit assigned the Spark DataFrame

This change ensures that struct column is always assigned to the Spark DataFrame before destructing to ensure exact once execution.

How is this tested
============
Add test for exact once execution verification under `test_vectorized_udf.py`