### PR TITLE
Adding builder and dialect to Backend classes

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -12,7 +12,7 @@ from ibis.backends.base import BaseBackend
 from ibis.config import options  # noqa: F401
 
 from .client import BigQueryClient
-from .compiler import dialect
+from .compiler import dialect, BigQueryQueryBuilder, BigQueryDialect
 
 try:
     from .udf import udf
@@ -109,6 +109,6 @@ def connect(
 
 class Backend(BaseBackend):
     name = 'bigquery'
-    buider = None
-    dialect = None
+    builder = BigQueryQueryBuilder
+    dialect = BigQueryDialect
     connect = connect

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -12,7 +12,7 @@ from ibis.backends.base import BaseBackend
 from ibis.config import options  # noqa: F401
 
 from .client import BigQueryClient
-from .compiler import dialect, BigQueryQueryBuilder, BigQueryDialect
+from .compiler import BigQueryDialect, BigQueryQueryBuilder, dialect
 
 try:
     from .udf import udf

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -4,7 +4,7 @@ from ibis.backends.base import BaseBackend
 from ibis.config import options
 
 from .client import ClickhouseClient
-from .compiler import dialect, ClickhouseQueryBuilder, ClickhouseDialect
+from .compiler import ClickhouseDialect, ClickhouseQueryBuilder, dialect
 
 __all__ = 'compile', 'verify', 'connect', 'dialect'
 

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -4,7 +4,7 @@ from ibis.backends.base import BaseBackend
 from ibis.config import options
 
 from .client import ClickhouseClient
-from .compiler import dialect
+from .compiler import dialect, ClickhouseQueryBuilder, ClickhouseDialect
 
 __all__ = 'compile', 'verify', 'connect', 'dialect'
 
@@ -118,6 +118,6 @@ def connect(
 
 class Backend(BaseBackend):
     name = 'clickhouse'
-    buider = None
-    dialect = None
+    builder = ClickhouseQueryBuilder
+    dialect = ClickhouseDialect
     connect = connect

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -11,7 +11,7 @@ from .client import (  # noqa: F401
     ImpalaDatabase,
     ImpalaTable,
 )
-from .compiler import dialect  # noqa: F401
+from .compiler import dialect, ImpalaDialect, ImpalaQueryBuilder  # noqa: F401
 from .hdfs import HDFS, WebHDFS, hdfs_connect  # noqa: F401
 from .udf import *  # noqa: F401,F403
 
@@ -147,6 +147,6 @@ def connect(
 
 class Backend(BaseBackend):
     name = 'impala'
-    buider = None
-    dialect = None
+    builder = ImpalaQueryBuilder
+    dialect = ImpalaDialect
     connect = connect

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -11,7 +11,7 @@ from .client import (  # noqa: F401
     ImpalaDatabase,
     ImpalaTable,
 )
-from .compiler import dialect, ImpalaDialect, ImpalaQueryBuilder  # noqa: F401
+from .compiler import ImpalaDialect, ImpalaQueryBuilder, dialect  # noqa: F401
 from .hdfs import HDFS, WebHDFS, hdfs_connect  # noqa: F401
 from .udf import *  # noqa: F401,F403
 

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -1,8 +1,9 @@
 from ibis.backends.base import BaseBackend
-from ibis.backends.base_sqlalchemy.alchemy import to_sqlalchemy
+from ibis.backends.base_sqlalchemy.alchemy import (to_sqlalchemy,
+                                                   AlchemyQueryBuilder)
 
 from .client import MySQLClient
-from .compiler import dialect, rewrites  # noqa: F401
+from .compiler import dialect, rewrites, MySQLDialect  # noqa: F401
 
 
 def compile(expr, params=None):
@@ -125,6 +126,6 @@ def connect(
 
 class Backend(BaseBackend):
     name = 'mysql'
-    buider = None
-    dialect = None
+    builder = AlchemyQueryBuilder
+    dialect = MySQLDialect
     connect = connect

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -1,9 +1,11 @@
 from ibis.backends.base import BaseBackend
-from ibis.backends.base_sqlalchemy.alchemy import (to_sqlalchemy,
-                                                   AlchemyQueryBuilder)
+from ibis.backends.base_sqlalchemy.alchemy import (
+    AlchemyQueryBuilder,
+    to_sqlalchemy,
+)
 
 from .client import MySQLClient
-from .compiler import dialect, rewrites, MySQLDialect  # noqa: F401
+from .compiler import MySQLDialect, dialect, rewrites  # noqa: F401
 
 
 def compile(expr, params=None):

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -99,6 +99,6 @@ PandasClient.dialect = dialect = PandasDialect
 
 class Backend(BaseBackend):
     name = 'pandas'
-    buider = None
-    dialect = None
+    builder = None
+    dialect = PandasDialect
     connect = connect

--- a/ibis/backends/parquet/__init__.py
+++ b/ibis/backends/parquet/__init__.py
@@ -121,6 +121,6 @@ def parquet_read_table(op, client, scope, **kwargs):
 
 class Backend(BaseBackend):
     name = 'parquet'
-    buider = None
+    builder = None
     dialect = None
     connect = connect

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -1,9 +1,10 @@
 """PostgreSQL backend."""
 from ibis.backends.base import BaseBackend
-from ibis.backends.base_sqlalchemy.alchemy import to_sqlalchemy
+from ibis.backends.base_sqlalchemy.alchemy import (to_sqlalchemy,
+                                                   AlchemyQueryBuilder)
 
 from .client import PostgreSQLClient
-from .compiler import compiles, dialect, rewrites  # noqa: F401, E501
+from .compiler import compiles, dialect, rewrites, PostgreSQLDialect  # noqa: F401, E501
 
 __all__ = 'compile', 'connect'
 
@@ -127,6 +128,6 @@ def connect(
 
 class Backend(BaseBackend):
     name = 'postgres'
-    buider = None
-    dialect = None
+    builder = AlchemyQueryBuilder
+    dialect = PostgreSQLDialect
     connect = connect

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -1,10 +1,17 @@
 """PostgreSQL backend."""
 from ibis.backends.base import BaseBackend
-from ibis.backends.base_sqlalchemy.alchemy import (to_sqlalchemy,
-                                                   AlchemyQueryBuilder)
+from ibis.backends.base_sqlalchemy.alchemy import (
+    AlchemyQueryBuilder,
+    to_sqlalchemy,
+)
 
 from .client import PostgreSQLClient
-from .compiler import compiles, dialect, rewrites, PostgreSQLDialect  # noqa: F401, E501
+from .compiler import (  # noqa: F401, E501
+    PostgreSQLDialect,
+    compiles,
+    dialect,
+    rewrites,
+)
 
 __all__ = 'compile', 'connect'
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -25,6 +25,6 @@ def connect(session):
 
 class Backend(BaseBackend):
     name = 'pyspark'
-    buider = None
-    dialect = None  # noqa: F811
+    builder = None
+    dialect = dialect
     connect = connect

--- a/ibis/backends/spark/__init__.py
+++ b/ibis/backends/spark/__init__.py
@@ -52,6 +52,6 @@ def connect(spark_session):
 
 class Backend(BaseBackend):
     name = 'spark'
-    buider = None
-    dialect = None
+    builder = None
+    dialect = dialect
     connect = connect

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from ibis.backends.base import BaseBackend
+from ibis.backends.base_sqlalchemy.alchemy import (to_sqlalchemy,
+                                                   AlchemyQueryBuilder)
 
 from .client import SQLiteClient
-from .compiler import dialect, rewrites  # noqa: F401
+from .compiler import dialect, rewrites, SQLiteDialect  # noqa: F401
 
 
 def compile(expr, params=None):
     """
     Force compilation of expression for the SQLite target
     """
-    from ibis.backends.base_sqlalchemy.alchemy import to_sqlalchemy
-
     return to_sqlalchemy(expr, dialect.make_context(params=params))
 
 
@@ -49,6 +48,6 @@ def connect(path=None, create=False):
 
 class Backend(BaseBackend):
     name = 'sqlite'
-    buider = None
-    dialect = None
+    builder = AlchemyQueryBuilder
+    dialect = SQLiteDialect
     connect = connect

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 from ibis.backends.base import BaseBackend
-from ibis.backends.base_sqlalchemy.alchemy import (to_sqlalchemy,
-                                                   AlchemyQueryBuilder)
+from ibis.backends.base_sqlalchemy.alchemy import (
+    AlchemyQueryBuilder,
+    to_sqlalchemy,
+)
 
 from .client import SQLiteClient
-from .compiler import dialect, rewrites, SQLiteDialect  # noqa: F401
+from .compiler import SQLiteDialect, dialect, rewrites  # noqa: F401
 
 
 def compile(expr, params=None):


### PR DESCRIPTION
Specifying the builder and the dialect of each backend. This is still unused, but will be used soon when we move from using the `compile` function in each backend module, to using the generic one in the base backend class.