### PR TITLE
TST: Not skipping tests if data directory not found

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,7 +23,4 @@ def data_directory() -> Path:
     datadir = os.environ.get('IBIS_TEST_DATA_DIRECTORY', default)
     datadir = Path(datadir)
 
-    if not datadir.exists():
-        pytest.skip('test data directory not found')
-
     return datadir


### PR DESCRIPTION
Not failing silently if test data directory is not found. We may end up not running the tests without realizing (hopefully it's not the case already).