### PR TITLE
CI: Simplifying dependencies to speed up conda resolve

### DIFF
--- a/ci/deps/clickhouse.yml
+++ b/ci/deps/clickhouse.yml
@@ -1,5 +1,5 @@
-sqlalchemy>=1.3
+sqlalchemy
 clickhouse-cityhash
-clickhouse-driver>=0.1.3
+clickhouse-driver
 clickhouse-sqlalchemy
 lz4

--- a/ci/deps/dask-min.yml
+++ b/ci/deps/dask-min.yml
@@ -1,1 +1,2 @@
- dask=2.22.0
+dask=2.22.0
+pyarrow

--- a/ci/deps/dask.yml
+++ b/ci/deps/dask.yml
@@ -1,1 +1,2 @@
- dask
+dask
+pyarrow

--- a/ci/deps/hdf5.yml
+++ b/ci/deps/hdf5.yml
@@ -1,0 +1,1 @@
+pytables

--- a/ci/deps/impala.yml
+++ b/ci/deps/impala.yml
@@ -4,3 +4,4 @@ requests>=2.24
 thrift>=0.9.3
 thriftpy2>=0.4
 thrift_sasl>=0.2.1
+python-hdfs

--- a/ci/deps/impala.yml
+++ b/ci/deps/impala.yml
@@ -1,7 +1,7 @@
-sqlalchemy>=1.3
-impyla>=0.15.0
-requests>=2.24
-thrift>=0.9.3
-thriftpy2>=0.4
-thrift_sasl>=0.2.1
+sqlalchemy
+impyla
+requests
+thrift
+thriftpy2
+thrift_sasl
 python-hdfs

--- a/ci/deps/mysql.yml
+++ b/ci/deps/mysql.yml
@@ -1,2 +1,2 @@
-sqlalchemy>=1.3
+sqlalchemy
 pymysql

--- a/ci/deps/parquet.yml
+++ b/ci/deps/parquet.yml
@@ -1,1 +1,1 @@
-pyarrow>=0.13
+pyarrow

--- a/ci/deps/postgres.yml
+++ b/ci/deps/postgres.yml
@@ -1,3 +1,3 @@
-sqlalchemy>=1.3
-psycopg2>=2.8
-geoalchemy2>=0.6
+sqlalchemy
+psycopg2
+geoalchemy2

--- a/ci/deps/pyspark.yml
+++ b/ci/deps/pyspark.yml
@@ -1,2 +1,1 @@
 pyspark>=3.1.1
-openjdk=8

--- a/ci/deps/pyspark.yml
+++ b/ci/deps/pyspark.yml
@@ -1,1 +1,2 @@
 pyspark>=3.1.1
+openjdk=8

--- a/ci/deps/pyspark.yml
+++ b/ci/deps/pyspark.yml
@@ -1,1 +1,1 @@
-pyspark>=3.1.1
+pyspark

--- a/ci/deps/spark.yml
+++ b/ci/deps/spark.yml
@@ -1,1 +1,1 @@
-pyspark>=2.4.3
+pyspark

--- a/ci/deps/spark.yml
+++ b/ci/deps/spark.yml
@@ -1,1 +1,2 @@
 pyspark>=2.4.3
+openjdk=8

--- a/ci/deps/spark.yml
+++ b/ci/deps/spark.yml
@@ -1,2 +1,1 @@
 pyspark>=2.4.3
-openjdk=8

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -12,32 +12,14 @@ echo "PYTHON_VERSION: $PYTHON_VERSION"
 echo "BACKENDS: $BACKENDS"
 echo "LOAD_TEST_DATA: $LOAD_TEST_DATA"
 
-if [[ -n "$CONDA" ]]; then
-    # Add conda to Path
-    OS_NAME=$(uname)
-    case $OS_NAME in
-        Linux)
-            CONDA_PATH="$CONDA/bin"
-            ;;
-        MINGW*)
-            # Windows
-            CONDA_POSIX=$(cygpath -u "$CONDA")
-            CONDA_PATH="$CONDA_POSIX:$CONDA_POSIX/Scripts:$CONDA_POSIX/Library:$CONDA_POSIX/Library/bin:$CONDA_POSIX/Library/mingw-w64/bin"
-            ;;
-        *)
-            echo "$OS_NAME not supported."
-            exit 1
-    esac
-    PATH=${CONDA_PATH}:${PATH}
-    # Prepend conda path to system path for the subsequent GitHub Actions
-    echo "${CONDA_PATH}" >> $GITHUB_PATH
-else
-    echo "Running without adding conda to PATH."
-fi
+# Install micromamba
+wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+./bin/micromamba shell init -s bash -p ~/micromamba
+source ~/.bashrc
 
-conda update -n base -c anaconda --all --yes conda
-conda install -n base -c anaconda --yes  python=${PYTHON_VERSION}
-conda env update -n base --file=environment.yml
+# Install base environment
+sed "s/dependencies:/dependencies:\n  - python=${PYTHON_VERSION}\n/" environment.yml
+micromamba install --file=environment.yml
 python -m pip install -e .
 
 if [[ -n "$BACKENDS" ]]; then
@@ -52,10 +34,10 @@ if [[ -n "$BACKENDS" ]]; then
         # (if there are dependencies). For other python versions we simply install
         # the normal dependencies if they exist.
         if [[ $PYTHON_VERSION == "3.7" && -f "ci/deps/$BACKEND-min.yml" ]]; then
-            conda install -n base -c conda-forge --file="ci/deps/$BACKEND-min.yml"
+            micromamba install --file="ci/deps/$BACKEND-min.yml"
         else
             if [[ -f "ci/deps/$BACKEND.yml" ]]; then
-                conda install -n base -c conda-forge --file="ci/deps/$BACKEND.yml"
+                micromamba install --file="ci/deps/$BACKEND.yml"
             fi
         fi
 

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -44,7 +44,7 @@ conda install -c conda-forge micromamba
 
 # Install base environment
 sed "s/dependencies:/dependencies:\n  - python=${PYTHON_VERSION}\n/" environment.yml
-micromamba install --file=environment.yml
+micromamba env install --file=environment.yml
 python -m pip install -e .
 
 if [[ -n "$BACKENDS" ]]; then

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -37,14 +37,14 @@ fi
 conda update -n base -c anaconda --all --yes conda
 
 # Install micromamba
-conda install -c conda-forge micromamba
+conda install -c conda-forge mamba
 # wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
 # ./bin/micromamba shell init -s bash -p ~/micromamba
 # source ~/.bashrc
 
 # Install base environment
 sed "s/dependencies:/dependencies:\n  - python=${PYTHON_VERSION}\n/" environment.yml
-micromamba env install --file=environment.yml
+mamba env install --file=environment.yml
 python -m pip install -e .
 
 if [[ -n "$BACKENDS" ]]; then
@@ -59,10 +59,10 @@ if [[ -n "$BACKENDS" ]]; then
         # (if there are dependencies). For other python versions we simply install
         # the normal dependencies if they exist.
         if [[ $PYTHON_VERSION == "3.7" && -f "ci/deps/$BACKEND-min.yml" ]]; then
-            micromamba install --file="ci/deps/$BACKEND-min.yml"
+            mamba install --file="ci/deps/$BACKEND-min.yml"
         else
             if [[ -f "ci/deps/$BACKEND.yml" ]]; then
-                micromamba install --file="ci/deps/$BACKEND.yml"
+                mamba install --file="ci/deps/$BACKEND.yml"
             fi
         fi
 

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -44,7 +44,7 @@ conda install -c conda-forge mamba
 
 # Install base environment
 sed "s/dependencies:/dependencies:\n  - python=${PYTHON_VERSION}\n/" environment.yml
-mamba env install --file=environment.yml
+mamba env update --file=environment.yml
 python -m pip install -e .
 
 if [[ -n "$BACKENDS" ]]; then

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -38,7 +38,7 @@ conda update -n base -c anaconda --all --yes conda
 conda install -c conda-forge mamba
 
 # Add selected Python version and backend dependencies to environment.yml and install
-echo "  - python=${PYTHON_VERSION}\n" >> environment.yml
+echo "  - python=${PYTHON_VERSION}" >> environment.yml
 for BACKEND in $BACKENDS; do
     # For the oldest python version supported (currently 3.7) we first try to
     # install the minimum supported dependencies `ci/deps/$BACKEND-min.yml`.

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -36,15 +36,11 @@ else
 fi
 conda update -n base -c anaconda --all --yes conda
 
-# Install micromamba
-conda install -c conda-forge mamba
-# wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
-# ./bin/micromamba shell init -s bash -p ~/micromamba
-# source ~/.bashrc
 
 # Install base environment
+conda install -c conda-forge mamba
 sed "s/dependencies:/dependencies:\n  - python=${PYTHON_VERSION}\n/" environment.yml
-mamba env update --file=environment.yml
+mamba env update -n base --file=environment.yml
 python -m pip install -e .
 
 if [[ -n "$BACKENDS" ]]; then

--- a/environment.yml
+++ b/environment.yml
@@ -4,63 +4,57 @@ channels:
   - conda-forge
 dependencies:
   # Ibis hard dependencies
-  - multipledispatch>=0.6.0
-  - numpy>=1.19
-  - pandas>=0.25 # XXX pymapd does not support pandas 1.0
-  - pytz>=2020.1
-  - regex>=2020.7
-  - toolz>=0.10
+  - multipledispatch
+  - numpy
+  - pandas
+  - pytz
+  - regex
+  - toolz
 
   # Ibis soft dependencies
-  # TODO This section is probably not very accurate right now (some dependencies should probably be in the backends files)
-  - sqlalchemy>=1.3
-  - dask>=2.22.0
+  - sqlalchemy
   - graphviz>=2.38, <= 2.42.3
-  - openjdk=8
-  - pytables>=3.6
   - python-graphviz>=0.14, <=0.15
-  - python-hdfs>=2.0.16 # XXX this verison can probably be increased
-
+  #
   # Dev tools
-  - asv>=0.4.2
+  - asv
   - black=19.10b0
-  - click>=7.1 # few scripts in ci/
+  - click # few scripts in ci/
   - conda-build # feedstock
-  - cmake>=3.17
-  - flake8>=3.8
-  - flake8-comprehensions>=3.3.0 # used by flake8, linting of unnecessary comprehensions
-  - isort>=5.3
-  - jinja2>=2.11 # feedstock
-  - mypy>=0.782
-  - plumbum>=1.6 # few scripts in ci/ and dev/
-  - pre-commit>=2.6
-  - pydocstyle>=4.0
-  - pygit2>=1.2 # dev/genrelease.py
-  - pytest>=5.4
-  - pytest-cov>=2.10
-  - pytest-mock>=3.1
-  - ruamel.yaml>=0.16 # feedstock
-  - libiconv>=1.15  # bug in repo2docker, see https://github.com/jupyter/repo2docker/issues/758
-  - xorg-libxpm>=3.5
-  - xorg-libxrender>=0.9
+  - cmake
+  - flake8
+  - flake8-comprehensions # used by flake8, linting of unnecessary comprehensions
+  - isort
+  - jinja2 # feedstock
+  - mypy
+  - plumbum # few scripts in ci/ and dev/
+  - pre-commit
+  - pydocstyle
+  - pygit2 # dev/genrelease.py
+  - pytest
+  - pytest-cov
+  - pytest-mock
+  - ruamel.yaml # feedstock
+  - libiconv  # bug in repo2docker, see https://github.com/jupyter/repo2docker/issues/758
+  - xorg-libxpm
+  - xorg-libxrender
 
   # Release
-  - twine>=3.2.0
-  - wheel>=0.35.1
-  - conda-smithy>=3.8.5
+  - twine
+  - wheel
+  - conda-smithy
 
   # Docs
-  - ipython>=7.17
-  - jupyter>=1.0
-  - matplotlib>=2 # XXX test if this can be bumped
+  - ipython
+  - jupyter
+  - matplotlib
   - nbconvert
-  - nbsphinx>=0.7
+  - nbsphinx
   - nomkl
-  - pyarrow>=0.12 # must pin again otherwise strange things happen
   - semantic_version=2.6 # https://github.com/ibis-project/ibis/issues/2027
-  - sphinx>=2.0.1
+  - sphinx
   - sphinx-releases
-  - sphinx_rtd_theme>=0.5
+  - sphinx_rtd_theme
   - pip
   - pip:
     - pysuerga

--- a/environment.yml
+++ b/environment.yml
@@ -15,34 +15,33 @@ dependencies:
   - sqlalchemy
   - graphviz>=2.38, <= 2.42.3
   - python-graphviz>=0.14, <=0.15
-  #
+
   # Dev tools
   - asv
   - black=19.10b0
   - click # few scripts in ci/
-  - conda-build # feedstock
-  - cmake
+  # - cmake
   - flake8
   - flake8-comprehensions # used by flake8, linting of unnecessary comprehensions
   - isort
   - jinja2 # feedstock
   - mypy
   - plumbum # few scripts in ci/ and dev/
-  - pre-commit
   - pydocstyle
-  - pygit2 # dev/genrelease.py
   - pytest
   - pytest-cov
   - pytest-mock
-  - ruamel.yaml # feedstock
-  - libiconv  # bug in repo2docker, see https://github.com/jupyter/repo2docker/issues/758
-  - xorg-libxpm
-  - xorg-libxrender
+  # - libiconv  # bug in repo2docker, see https://github.com/jupyter/repo2docker/issues/758
+  # - xorg-libxpm
+  # - xorg-libxrender
 
   # Release
   - twine
   - wheel
   - conda-smithy
+  - conda-build # feedstock
+  - ruamel.yaml # feedstock
+  - pygit2 # dev/genrelease.py
 
   # Docs
   - ipython

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,6 @@ dependencies:
   - asv
   - black=19.10b0
   - click # few scripts in ci/
-  # - cmake
   - flake8
   - flake8-comprehensions # used by flake8, linting of unnecessary comprehensions
   - isort
@@ -31,9 +30,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
-  # - libiconv  # bug in repo2docker, see https://github.com/jupyter/repo2docker/issues/758
-  # - xorg-libxpm
-  # - xorg-libxrender
 
   # Release
   - twine

--- a/environment.yml
+++ b/environment.yml
@@ -40,6 +40,9 @@ dependencies:
   - pygit2 # dev/genrelease.py
 
   # Docs
+  - pip
+  - pip:
+    - pysuerga
   - ipython
   - jupyter
   - matplotlib
@@ -50,6 +53,3 @@ dependencies:
   - sphinx
   - sphinx-releases
   - sphinx_rtd_theme
-  - pip
-  - pip:
-    - pysuerga

--- a/ibis/backends/base_file/tests/test_schema.py
+++ b/ibis/backends/base_file/tests/test_schema.py
@@ -2,13 +2,13 @@ import tempfile
 
 import numpy as np
 import pandas as pd
-import pyarrow.parquet as pq
 import pytest
 
 import ibis
 import ibis.expr.datatypes as dt
 
 pa = pytest.importorskip('pyarrow')  # noqa: E402
+pq = pytest.importorskip('pyarrow.parquet')  # noqa: E402
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #2670

Trying to speed up CI builds by speeding up conda solver.

Unpining most dependencies in the base file, and moving few dependencies from the base file to the backend dependencies.

The base file resolves in a bit more than a minute locally. 