### PR TITLE
Remove uneeded excluded files from linting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ parentdir_prefix = ibis-
 [flake8]
 ignore = D202,D203,W503,E203
 max-line-length = 79
-exclude = build,dist,docs,versioneer.py,ibis/_version.py,.git,__pycache__,.tox,.eggs,*.egg,.asv
+exclude = versioneer.py
 
 [pydocstyle]
 inherit = false
@@ -21,7 +21,7 @@ ensure_newline_before_comments=true
 line_length = 79
 multi_line_output = 3
 include_trailing_comma = true
-skip = versioneer.py,ibis/_version.py
+skip = versioneer.py
 
 [bdist_wheel]
 universal = 0


### PR DESCRIPTION
I don't think the current list of ignored files is useful, removing everything that doesn't contain Python files or that is passing.