### PR TITLE
TST: unskip or recategorize dask pandas skipped tests

### DIFF
--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -3,7 +3,7 @@ import pytest
 from pytest import param
 
 # add here backends that passes join tests
-all_db_join_supported = ['pandas', 'pyspark']
+all_db_join_supported = ['pandas', 'pyspark', 'dask']
 
 
 @pytest.mark.parametrize(
@@ -29,8 +29,7 @@ all_db_join_supported = ['pandas', 'pyspark']
 )
 @pytest.mark.only_on_backends(all_db_join_supported)
 # Csv is a subclass of Pandas so need to skip it explicitly.
-# TODO - pandas - #2553
-@pytest.mark.skip_backends(['csv', 'dask'])
+@pytest.mark.skip_backends(['csv'])
 @pytest.mark.xfail_unsupported
 def test_join_project_left_table(backend, con, batting, awards_players, how):
 

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -162,7 +162,7 @@ def test_string_col_is_unicode(backend, alltypes, df):
             lambda t: t.string_col.ascii_str(),
             lambda t: t.string_col.map(ord).astype('int32'),
             id='ascii_str',
-            # TODO - pandas - #2553
+            # TODO - dtype - #2553
             marks=pytest.mark.skip_backends(['dask']),
         ),
         param(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -78,7 +78,9 @@ def test_timestamp_extract(backend, alltypes, df, attr):
         # Pandas backend is probably doing this wrong
         param(
             'W',
-            marks=pytest.mark.xpass_backends(('csv', 'pandas', 'parquet')),
+            marks=pytest.mark.xpass_backends(
+                ('csv', 'pandas', 'dask', 'parquet')
+            ),
         ),
         'h',
         'm',
@@ -88,7 +90,6 @@ def test_timestamp_extract(backend, alltypes, df, attr):
         'ns',
     ],
 )
-@pytest.mark.skip_backends(['dask'])  # TODO - pandas - #2553
 @pytest.mark.xfail_unsupported
 def test_timestamp_truncate(backend, alltypes, df, unit):
     expr = alltypes.timestamp_col.truncate(unit)
@@ -110,11 +111,12 @@ def test_timestamp_truncate(backend, alltypes, df, unit):
         'D',
         param(
             'W',
-            marks=pytest.mark.xpass_backends(('csv', 'pandas', 'parquet')),
+            marks=pytest.mark.xpass_backends(
+                ('csv', 'pandas', 'dask', 'parquet')
+            ),
         ),
     ],
 )
-@pytest.mark.skip_backends(['dask'])  # TODO - pandas - #2553
 @pytest.mark.xfail_unsupported
 def test_date_truncate(backend, alltypes, df, unit):
     expr = alltypes.timestamp_col.date().truncate(unit)
@@ -487,7 +489,7 @@ def test_now(backend, con):
     assert result.year == pandas_now.year
 
 
-# TODO - pandas - #2553
+# # TODO - limit - #2553
 @pytest.mark.xfail_backends(['dask'])
 @pytest.mark.xfail_unsupported
 def test_now_from_projection(backend, con, alltypes, df):

--- a/ibis/backends/tests/test_union.py
+++ b/ibis/backends/tests/test_union.py
@@ -4,9 +4,8 @@ import pytest
 
 @pytest.mark.parametrize('distinct', [False, True])
 @pytest.mark.only_on_backends(
-    ['bigquery', 'impala', 'pandas', 'postrges', 'pyspark']
+    ['bigquery', 'impala', 'pandas', 'postrges', 'pyspark', 'dask']
 )
-@pytest.mark.skip_backends(['dask'])  # TODO - pandas - #2553
 @pytest.mark.xfail_unsupported
 def test_union(backend, alltypes, df, distinct):
     result = alltypes.union(alltypes, distinct=distinct).execute()


### PR DESCRIPTION
After merging https://github.com/ibis-project/ibis/pull/2623 it seems I didn't unskip/unxfail certain dask tests. 

I've gone through and either removed the dask restriction or reclassified it (in the code and on the tracker https://github.com/ibis-project/ibis/issues/2553). 