### PR TITLE
TST: Avoid skiping tests if backend dependencies are missing

### DIFF
--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -2,9 +2,11 @@ import os
 from pathlib import Path
 
 import pytest
+from google.oauth2 import service_account
 
 import ibis
 import ibis.expr.types as ir
+from ibis.backends import bigquery as bq
 from ibis.backends.tests.base import (
     BackendTest,
     RoundAwayFromZero,
@@ -16,7 +18,6 @@ DATASET_ID = 'testing'
 
 
 def _credentials():
-    service_account = pytest.importorskip('google.oauth2.service_account')
     google_application_credentials = os.environ.get(
         "GOOGLE_APPLICATION_CREDENTIALS", None
     )
@@ -49,7 +50,6 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
 
     @staticmethod
     def connect(data_directory: Path) -> ibis.client.Client:
-        bq = pytest.importorskip('ibis.backends.bigquery')
         project_id = os.environ.get('GOOGLE_BIGQUERY_PROJECT_ID')
         if project_id is None:
             pytest.skip(
@@ -87,7 +87,6 @@ def credentials():
 
 @pytest.fixture(scope='session')
 def client(credentials, project_id):
-    bq = pytest.importorskip('ibis.backends.bigquery')
     return bq.connect(
         project_id=project_id, dataset_id=DATASET_ID, credentials=credentials,
     )
@@ -95,7 +94,6 @@ def client(credentials, project_id):
 
 @pytest.fixture(scope='session')
 def client2(credentials, project_id):
-    bq = pytest.importorskip('ibis.backends.bigquery')
     return bq.connect(
         project_id=project_id, dataset_id=DATASET_ID, credentials=credentials,
     )
@@ -133,7 +131,6 @@ def numeric_table(client):
 
 @pytest.fixture(scope='session')
 def public(project_id, credentials):
-    bq = pytest.importorskip('ibis.backends.bigquery')
     return bq.connect(
         project_id=project_id,
         dataset_id='bigquery-public-data.stackoverflow',

--- a/ibis/backends/bigquery/tests/test_client.py
+++ b/ibis/backends/bigquery/tests/test_client.py
@@ -7,17 +7,15 @@ import pandas as pd
 import pandas.testing as tm
 import pytest
 import pytz
+from google.api_core import exceptions
 
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 
-pytestmark = pytest.mark.bigquery
-bq = pytest.importorskip('google.cloud.bigquery')
-ga = pytest.importorskip('google.auth')
-exceptions = pytest.importorskip('google.api_core.exceptions')
+from ..client import bigquery_param
 
-from ..client import bigquery_param  # noqa: E402, isort:skip
+pytestmark = pytest.mark.bigquery
 
 
 def test_table(alltypes):

--- a/ibis/backends/bigquery/tests/test_compiler.py
+++ b/ibis/backends/bigquery/tests/test_compiler.py
@@ -10,7 +10,6 @@ import ibis.expr.operations as ops
 from ibis.expr.types import TableExpr
 
 pytestmark = pytest.mark.bigquery
-pytest.importorskip('google.cloud.bigquery')
 
 
 def test_timestamp_accepts_date_literals(alltypes, project_id):

--- a/ibis/backends/bigquery/tests/test_connect.py
+++ b/ibis/backends/bigquery/tests/test_connect.py
@@ -1,13 +1,14 @@
 from unittest import mock
 
+import pydata_google_auth
 import pytest
+from google.auth import credentials as auth
+from google.cloud import bigquery as bq
 
 import ibis
+from ibis.backends import bigquery as bq_backend
 
 pytestmark = pytest.mark.bigquery
-bq = pytest.importorskip('google.cloud.bigquery')
-bq_backend = pytest.importorskip('ibis.backends.bigquery')
-pydata_google_auth = pytest.importorskip('pydata_google_auth')
 
 
 def test_repeated_project_name(project_id, credentials):
@@ -20,7 +21,6 @@ def test_repeated_project_name(project_id, credentials):
 
 
 def test_project_id_different_from_default_credentials(monkeypatch):
-    auth = pytest.importorskip('google.auth.credentials')
     creds = mock.create_autospec(auth.Credentials)
 
     def mock_credentials(*args, **kwargs):

--- a/ibis/backends/bigquery/tests/udf/test_udf_execute.py
+++ b/ibis/backends/bigquery/tests/udf/test_udf_execute.py
@@ -11,8 +11,6 @@ from ibis.compat import PY38
 
 from ... import udf  # noqa: E402
 
-pytest.importorskip('google.cloud.bigquery')
-
 if PY38:
     # ref: https://github.com/ibis-project/ibis/issues/2098
     # note: UDF is already skipt on CI

--- a/ibis/backends/clickhouse/tests/test_aggregations.py
+++ b/ibis/backends/clickhouse/tests/test_aggregations.py
@@ -7,7 +7,6 @@ import pytest
 
 from ibis import literal as L
 
-pytest.importorskip('clickhouse_driver')
 pytestmark = pytest.mark.clickhouse
 
 

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -9,7 +9,6 @@ import ibis.config as config
 import ibis.expr.types as ir
 from ibis import literal as L
 
-pytest.importorskip('clickhouse_driver')
 pytestmark = pytest.mark.clickhouse
 
 

--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -13,7 +13,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis import literal as L
 
-clickhouse_driver = pytest.importorskip('clickhouse_driver')
 pytestmark = pytest.mark.clickhouse
 
 

--- a/ibis/backends/clickhouse/tests/test_identifiers.py
+++ b/ibis/backends/clickhouse/tests/test_identifiers.py
@@ -2,7 +2,6 @@ import pytest
 
 import ibis
 
-pytest.importorskip('clickhouse_driver')
 pytestmark = pytest.mark.clickhouse
 
 

--- a/ibis/backends/clickhouse/tests/test_literals.py
+++ b/ibis/backends/clickhouse/tests/test_literals.py
@@ -4,7 +4,6 @@ from pandas import Timestamp
 import ibis
 from ibis import literal as L
 
-pytest.importorskip('clickhouse_driver')
 pytestmark = pytest.mark.clickhouse
 
 

--- a/ibis/backends/clickhouse/tests/test_operators.py
+++ b/ibis/backends/clickhouse/tests/test_operators.py
@@ -10,7 +10,6 @@ import ibis
 import ibis.expr.datatypes as dt
 from ibis import literal as L
 
-pytest.importorskip('clickhouse_driver')
 pytestmark = pytest.mark.clickhouse
 
 

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -1,3 +1,4 @@
+import clickhouse_driver
 import pandas as pd
 import pandas.testing as tm
 import pytest
@@ -5,7 +6,6 @@ import pytest
 import ibis
 import ibis.common.exceptions as com
 
-driver = pytest.importorskip('clickhouse_driver')
 pytestmark = pytest.mark.clickhouse
 
 
@@ -474,7 +474,7 @@ def test_join_with_external_table_errors(con, alltypes, df):
         external_table.a, external_table.c, alltypes.id
     ]
 
-    with pytest.raises(driver.errors.ServerException):
+    with pytest.raises(clickhouse_driver.errors.ServerException):
         expr.execute()
 
     with pytest.raises(TypeError):

--- a/ibis/backends/clickhouse/tests/test_types.py
+++ b/ibis/backends/clickhouse/tests/test_types.py
@@ -1,6 +1,5 @@
 import pytest
 
-pytest.importorskip('clickhouse_driver')
 pytestmark = pytest.mark.clickhouse
 
 

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import warnings
 from pathlib import Path
 
+import impala
 import pytest
 
 import ibis
@@ -159,8 +160,6 @@ def hdfs_superuser(env):
 
 @pytest.fixture(scope='session')
 def hdfs(env, tmp_dir):
-    pytest.importorskip('requests')
-
     if env.auth_mechanism in {'GSSAPI', 'LDAP'}:
         warnings.warn("Ignoring invalid Certificate Authority errors")
 
@@ -232,7 +231,6 @@ CREATE TABLE IF NOT EXISTS {} (
 
 @pytest.fixture(scope='session')
 def tmp_db(env, con, test_data_db):
-    impala = pytest.importorskip("impala")
     tmp_db = env.tmp_db
 
     if not con.exists_database(tmp_db):

--- a/ibis/backends/impala/tests/test_client.py
+++ b/ibis/backends/impala/tests/test_client.py
@@ -14,10 +14,6 @@ import ibis.expr.types as ir
 import ibis.util as util
 from ibis.tests.util import assert_equal
 
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('hdfs')
-pytest.importorskip('impala.dbapi')
-
 pytestmark = pytest.mark.impala
 
 

--- a/ibis/backends/impala/tests/test_connection_pool.py
+++ b/ibis/backends/impala/tests/test_connection_pool.py
@@ -2,9 +2,6 @@ import pytest
 
 import ibis
 
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
 pytestmark = pytest.mark.impala
 
 

--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -7,13 +7,8 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 import ibis.util as util
+from ibis.backends.impala.compat import HS2Error
 from ibis.tests.util import assert_equal
-
-pytest.importorskip('hdfs')
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
-from ibis.backends.impala.compat import HS2Error  # noqa: E402, isort:skip
 
 pytestmark = pytest.mark.impala
 

--- a/ibis/backends/impala/tests/test_ddl_compilation.py
+++ b/ibis/backends/impala/tests/test_ddl_compilation.py
@@ -3,9 +3,6 @@ import pytest
 import ibis
 from ibis.backends.base_sql import ddl as base_ddl
 
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
 from ibis.backends.impala.compiler import (  # noqa: E402, isort:skip
     ImpalaDialect,
 )

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -21,11 +21,6 @@ from ..compiler import (  # noqa: E402
     to_sql,
 )
 
-pytest.importorskip('hdfs')
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
-
 pytestmark = pytest.mark.impala
 
 

--- a/ibis/backends/impala/tests/test_kudu_support.py
+++ b/ibis/backends/impala/tests/test_kudu_support.py
@@ -9,10 +9,6 @@ import ibis.util as util  # noqa: E402
 from ibis.tests.expr.mocks import MockConnection  # noqa: E402
 from ibis.tests.util import assert_equal  # noqa: E402
 
-pytest.importorskip('hdfs')
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
 ksupport = pytest.importorskip('ibis.backends.impala.kudu_support')
 kudu = pytest.importorskip('kudu')
 

--- a/ibis/backends/impala/tests/test_pandas_interop.py
+++ b/ibis/backends/impala/tests/test_pandas_interop.py
@@ -10,10 +10,6 @@ from ibis.backends.impala.pandas_interop import DataFrameWriter  # noqa: E402
 
 pytestmark = pytest.mark.impala
 
-pytest.importorskip('hdfs')
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
 
 @pytest.fixture
 def exhaustive_df():

--- a/ibis/backends/impala/tests/test_parquet_ddl.py
+++ b/ibis/backends/impala/tests/test_parquet_ddl.py
@@ -3,14 +3,8 @@ from posixpath import join as pjoin
 import pytest
 
 import ibis
+from ibis.backends.impala.compat import HS2Error
 from ibis.tests.util import assert_equal
-
-pytest.importorskip('hdfs')
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
-from ibis.backends.impala.compat import HS2Error  # noqa: E402, isort:skip
-
 
 pytestmark = pytest.mark.impala
 

--- a/ibis/backends/impala/tests/test_partition.py
+++ b/ibis/backends/impala/tests/test_partition.py
@@ -6,15 +6,8 @@ import pytest
 
 import ibis
 import ibis.util as util
+from ibis.backends.impala.compat import ImpylaError
 from ibis.tests.util import assert_equal
-
-pytest.importorskip('hdfs')
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
-impala = pytest.importorskip('impala')
-
-from ibis.backends.impala.compat import ImpylaError  # noqa: E402, isort:skip
 
 pytestmark = pytest.mark.impala
 

--- a/ibis/backends/impala/tests/test_patched.py
+++ b/ibis/backends/impala/tests/test_patched.py
@@ -3,10 +3,6 @@ from unittest import mock
 import pandas as pd
 import pytest
 
-pytest.importorskip('hdfs')
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
 pytestmark = pytest.mark.impala
 
 

--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -8,10 +8,6 @@ from ibis.backends.impala.compiler import to_sql  # noqa: E402
 from ibis.backends.impala.tests.mocks import MockImpalaConnection
 from ibis.tests.sql.test_compiler import ExprTestCases
 
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
-
 pytestmark = pytest.mark.impala
 
 

--- a/ibis/backends/impala/tests/test_udf.py
+++ b/ibis/backends/impala/tests/test_udf.py
@@ -18,10 +18,6 @@ from ibis.tests.expr.mocks import MockConnection
 
 from .. import ddl  # noqa: E402
 
-pytest.importorskip('hdfs')
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
 pytestmark = [pytest.mark.impala, pytest.mark.udf]
 
 

--- a/ibis/backends/impala/tests/test_window.py
+++ b/ibis/backends/impala/tests/test_window.py
@@ -7,11 +7,6 @@ from ibis.backends.impala.compiler import to_sql  # noqa: E402
 from ibis.expr.window import rows_with_max_lookback
 from ibis.tests.util import assert_equal
 
-pytest.importorskip('hdfs')
-pytest.importorskip('sqlalchemy')
-pytest.importorskip('impala.dbapi')
-
-
 pytestmark = pytest.mark.impala
 
 

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -17,15 +17,13 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
+import sqlalchemy as sa
 
 import ibis
 import ibis.backends.base_sqlalchemy.alchemy as alch  # noqa: E402
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis.tests.util import assert_equal
-
-sa = pytest.importorskip('sqlalchemy')
-pytest.importorskip('psycopg2')
 
 pytestmark = pytest.mark.postgres
 

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
+import sqlalchemy as sa
 from pytest import param
 
 import ibis
@@ -16,9 +17,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis import literal as L
 from ibis.expr.window import rows_with_max_lookback
-
-sa = pytest.importorskip('sqlalchemy')
-pytest.importorskip('psycopg2')
 
 pytestmark = pytest.mark.postgres
 

--- a/ibis/backends/postgres/tests/test_postgis.py
+++ b/ibis/backends/postgres/tests/test_postgis.py
@@ -3,8 +3,6 @@ import pytest
 from numpy import testing
 
 gp = pytest.importorskip('geopandas')
-sa = pytest.importorskip('sqlalchemy')
-pytest.importorskip('psycopg2')
 
 pytestmark = [
     pytest.mark.postgres,

--- a/ibis/backends/pyspark/tests/test_array.py
+++ b/ibis/backends/pyspark/tests/test_array.py
@@ -7,7 +7,6 @@ from pytest import param
 
 import ibis
 
-pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
 
 

--- a/ibis/backends/pyspark/tests/test_basic.py
+++ b/ibis/backends/pyspark/tests/test_basic.py
@@ -6,7 +6,6 @@ from pytest import param
 import ibis
 import ibis.common.exceptions as com
 
-pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
 
 

--- a/ibis/backends/pyspark/tests/test_null.py
+++ b/ibis/backends/pyspark/tests/test_null.py
@@ -1,7 +1,6 @@
 import pandas.testing as tm
 import pytest
 
-pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
 
 

--- a/ibis/backends/pyspark/tests/test_timecontext.py
+++ b/ibis/backends/pyspark/tests/test_timecontext.py
@@ -4,7 +4,6 @@ import pytest
 
 from ibis.backends.pyspark.timecontext import combine_time_context
 
-pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
 
 

--- a/ibis/backends/pyspark/tests/test_window.py
+++ b/ibis/backends/pyspark/tests/test_window.py
@@ -5,7 +5,6 @@ from pyspark.sql.window import Window
 
 import ibis
 
-pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
 
 

--- a/ibis/backends/pyspark/tests/test_window_context_adjustment.py
+++ b/ibis/backends/pyspark/tests/test_window_context_adjustment.py
@@ -6,7 +6,6 @@ from pyspark.sql import Window
 
 import ibis
 
-pytest.importorskip('pyspark')
 pytestmark = pytest.mark.pyspark
 
 

--- a/ibis/backends/spark/tests/conftest.py
+++ b/ibis/backends/spark/tests/conftest.py
@@ -42,7 +42,6 @@ def test_data_db(client):
 
 @pytest.fixture(scope='session')
 def client(data_directory):
-    pytest.importorskip('pyspark')
     return get_spark_testing_client(data_directory)
 
 

--- a/ibis/backends/spark/tests/test_api.py
+++ b/ibis/backends/spark/tests/test_api.py
@@ -3,7 +3,6 @@ import pytest
 import ibis
 
 pytestmark = pytest.mark.spark
-pytest.importorskip('pyspark')
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/spark/tests/test_ddl.py
+++ b/ibis/backends/spark/tests/test_ddl.py
@@ -1,6 +1,7 @@
 import os
 from posixpath import join as pjoin
 
+import pyspark as ps
 import pytest
 
 import ibis
@@ -9,7 +10,6 @@ import ibis.util as util
 from ibis.tests.util import assert_equal
 
 pytestmark = pytest.mark.spark
-ps = pytest.importorskip('pyspark')
 
 
 def test_create_exists_view(con, alltypes, temp_view):

--- a/ibis/backends/spark/tests/test_udf.py
+++ b/ibis/backends/spark/tests/test_udf.py
@@ -9,11 +9,9 @@ import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis.backends.spark.tests.conftest import TestConf as SparkTest
 
-pytestmark = [pytest.mark.spark, pytest.mark.udf]
+from ..udf import udf
 
-py4j = pytest.importorskip('py4j')
-ps = pytest.importorskip('pyspark')
-from ..udf import udf  # noqa: E402, isort:skip
+pytestmark = [pytest.mark.spark, pytest.mark.udf]
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/sqlite/tests/test_client.py
+++ b/ibis/backends/sqlite/tests/test_client.py
@@ -10,9 +10,6 @@ import ibis.config as config
 import ibis.expr.types as ir
 from ibis.util import guid
 
-sa = pytest.importorskip('sqlalchemy')
-
-
 pytestmark = pytest.mark.sqlite
 
 

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -8,14 +8,12 @@ import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
+import sqlalchemy as sa
 
 import ibis  # noqa: E402
 import ibis.config as config  # noqa: E402
 import ibis.expr.datatypes as dt  # noqa: E402
 from ibis import literal as L  # noqa: E402
-
-sa = pytest.importorskip('sqlalchemy')
-
 
 try:
     from packaging.version import parse as get_version


### PR DESCRIPTION
We only run the backend tests explicitly, so those `importorskip` shouldn't be needed, and would be great for things to fail if there is any problem.