### PR TITLE
ENH: Namespace time_col config, fix type check for trim_with_timecontext for pandas window execution.

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :support:`2680` Namespace time_col config, fix type check for trim_with_timecontext for pandas window execution 
 * :feature:`2646` Support context adjustment for udfs for pandas backend
 * :feature:`2655` Add `auth_local_webserver`, `auth_external_data`, and
   `auth_cache` parameters to BigQuery connect method. Set

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -33,13 +33,14 @@ notebook.
     validator=ibis.config.is_bool,
 )
 ibis.config.register_option('default_backend', None)
-ibis.config.register_option(
-    'timecontext.time_col',
-    'time',
-    'Name of the timestamp col for execution with a timecontext'
-    'See ibis.expr.timecontext for details.',
-    validator=ibis.config.is_str,
-)
+with ibis.config.config_prefix('context_adjustment'):
+    ibis.config.register_option(
+        'time_col',
+        'time',
+        'Name of the timestamp col for execution with a timecontext'
+        'See ibis.expr.timecontext for details.',
+        validator=ibis.config.is_str,
+    )
 
 __version__ = get_versions()['version']
 del get_versions

--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -34,7 +34,7 @@ notebook.
 )
 ibis.config.register_option('default_backend', None)
 ibis.config.register_option(
-    'time_col',
+    'timecontext.time_col',
     'time',
     'Name of the timestamp col for execution with a timecontext'
     'See ibis.expr.timecontext for details.',

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -380,7 +380,8 @@ class Transform(AggregationContext):
             res = grouped_data.transform(function, *args, **kwargs)
 
         # The result series uses the name of the input. We should
-        # unset it to avoid confusion
+        # unset it to avoid confusion, when result is not guranteed
+        # to be the same series / have the same type after transform
         res.name = None
         return res
 

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -375,9 +375,14 @@ class Transform(AggregationContext):
         # Instead, we need to use "apply", which can return a non
         # numeric type, e.g, tuple of two double.
         if isinstance(self.output_type, dt.Struct):
-            return grouped_data.apply(function, *args, **kwargs)
+            res = grouped_data.apply(function, *args, **kwargs)
         else:
-            return grouped_data.transform(function, *args, **kwargs)
+            res = grouped_data.transform(function, *args, **kwargs)
+
+        # The result series uses the name of the input. We should
+        # unset it to avoid confusion
+        res.name = None
+        return res
 
 
 @functools.singledispatch

--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -7,7 +7,6 @@ from typing import Any, List, NoReturn, Optional
 
 import pandas as pd
 import toolz
-from pandas.api.types import is_datetime64_any_dtype
 from pandas.core.groupby import SeriesGroupBy
 
 import ibis.common.exceptions as com
@@ -210,7 +209,7 @@ def trim_with_timecontext(data, timecontext: Optional[TimeContext]):
     # computing a single column, the computation and the relevant time
     # indexes are returned.
     time_col = get_time_col()
-    if time_col not in df or not is_datetime64_any_dtype(df[time_col]):
+    if time_col not in df:
         return data
 
     # if Series dosen't contain a name, reset_index will assign

--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -7,7 +7,7 @@ from typing import Any, List, NoReturn, Optional
 
 import pandas as pd
 import toolz
-from pandas.api.types import is_datetime64_dtype
+from pandas.api.types import is_datetime64_any_dtype
 from pandas.core.groupby import SeriesGroupBy
 
 import ibis.common.exceptions as com
@@ -202,18 +202,20 @@ def trim_with_timecontext(data, timecontext: Optional[TimeContext]):
     # noop if timecontext is None
     if not timecontext:
         return data
+
     # reset multiindex and turn series into a dateframe
     df = data.reset_index()
-    # if Series dosen't contain a name, reset_index will assign
-    # '0' as the column name for the column of value
-    name = data.name if data.name else 0
 
     # Filter the data, here we preserve the time index so that when user is
     # computing a single column, the computation and the relevant time
     # indexes are returned.
     time_col = get_time_col()
-    if time_col not in df or not is_datetime64_dtype(df[time_col]):
+    if time_col not in df or not is_datetime64_any_dtype(df[time_col]):
         return data
+
+    # if Series dosen't contain a name, reset_index will assign
+    # '0' as the column name for the column of value
+    name = data.name if data.name else 0
     subset = df.loc[df[time_col].between(*timecontext)]
 
     # re-indexing index to count from 0

--- a/ibis/backends/pandas/tests/execution/test_timecontext.py
+++ b/ibis/backends/pandas/tests/execution/test_timecontext.py
@@ -153,7 +153,7 @@ def test_trim_with_timecontext(time_df3):
     # result should adjust time context accordingly
     tm.assert_series_equal(result.reset_index()['time'], expected)
 
-    # trim with a non-datetime type of 'time'
+    # trim with a non-datetime type of 'time' throws Exception
     wrong_series = df['id']
     df['time'] = df['time'].astype(str)
     time_index = df.set_index('time').index
@@ -161,13 +161,10 @@ def test_trim_with_timecontext(time_df3):
         [wrong_series.index, time_index],
         names=wrong_series.index.names + ['time'],
     )
-    wrong_result = trim_with_timecontext(wrong_series, context)
-    expected_unchanged = df['time']
-
-    # column is ignored and result is not trimmed
-    tm.assert_series_equal(
-        wrong_result.reset_index()['time'], expected_unchanged
-    )
+    with pytest.raises(
+        TypeError, match=r".*not supported between instances.*"
+    ):
+        trim_with_timecontext(wrong_series, context)
 
     # column is ignored and series is not trimmed
     no_context_result = trim_with_timecontext(series, None)

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -616,6 +616,7 @@ def test_window_grouping_key_has_scope(t, df):
     expr = t.plain_int64.mean().over(window)
     result = expr.execute(params={param: "a"})
     expected = df.groupby(df.dup_strings + "a").plain_int64.transform("mean")
+    expected.name = None
     tm.assert_series_equal(result, expected)
 
 

--- a/ibis/backends/pandas/tests/test_udf.py
+++ b/ibis/backends/pandas/tests/test_udf.py
@@ -179,6 +179,7 @@ def test_udaf_analytic_groupby(con, t, df):
         return s.sub(s.mean()).div(s.std())
 
     expected = df.groupby('key').c.transform(f)
+    expected.name = None
     tm.assert_series_equal(result, expected)
 
 

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -95,7 +95,7 @@ def test_context_adjustment_window_udf(
     """ This test case aims to test context adjustment of
         udfs in window method.
     """
-    with option_context('timecontext.time_col', 'timestamp_col'):
+    with option_context('context_adjustment.time_col', 'timestamp_col'):
         expr = alltypes.mutate(v1=calc_mean(alltypes[TARGET_COL]).over(window))
         result = expr.execute(timecontext=context)
         tm.assert_series_equal(result["v1"], expected_series[exp_idx])

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -95,7 +95,7 @@ def test_context_adjustment_window_udf(
     """ This test case aims to test context adjustment of
         udfs in window method.
     """
-    with option_context('time_col', 'timestamp_col'):
+    with option_context('timecontext.time_col', 'timestamp_col'):
         expr = alltypes.mutate(v1=calc_mean(alltypes[TARGET_COL]).over(window))
         result = expr.execute(timecontext=context)
         tm.assert_series_equal(result["v1"], expected_series[exp_idx])

--- a/ibis/expr/timecontext.py
+++ b/ibis/expr/timecontext.py
@@ -50,7 +50,7 @@ from ibis.expr.typing import TimeContext
 
 
 def get_time_col():
-    return config.options.time_col
+    return config.options.context_adjustment.time_col
 
 
 class TimeContextRelation(enum.Enum):


### PR DESCRIPTION
Overview
=======
As a follow-up of #2646, add namespace `timecontext` for the ibis config `time_col`.

Also, fix a type check in `trim_with_time_context` for pandas window execution. The type check to check a DataFrame has a `time_col` column and its type is a Datetime type, will not hit by any user level APIs, removing it.

For the result series of a Groupby Transform. The result series is still using the name of the input series. We should unset it to avoid confusion. e.g. If the input series is 'time' and the result series is float but still named 'time' Then in trimming with context the series will be identified as a time column and result in an error.

Tests
=======
Still using the tests implemented in `ibis/backends/tests/test_timecontext.py`, and `ibis/backends/execution/pandas/test_timecontext.py`