### PR TITLE
CI: Making Ibis compatible with latest graphviz

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,7 @@ dependencies:
 
   # Ibis soft dependencies
   - sqlalchemy
-  - graphviz>=2.38, <= 2.42.3
-  - python-graphviz>=0.14, <=0.15
+  - python-graphviz
 
   # Dev tools
   - asv


### PR DESCRIPTION
Closes #2631 

Looks like the latest graphviz doesn't cause problems anymore. Checked the test logs, and `test_interactive.py` is not being skipped, so the broken test in #2629 works with the latest version.