### PR TITLE
DOC: Restoring website

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -282,8 +282,11 @@ jobs:
     - name: set up environment
       run: ./ci/setup_env.sh "$PYTHON_VERSION" "$BACKENDS" "$LOAD_TEST_DATA"
 
+    - name: build web
+      run: python -m pysuerga docs/web --target-path=/tmp/ibis-project.org/
+
     - name: build docs
-      run: sphinx-build -b html docs/source /tmp/docs.ibis-project.org -W -T
+      run: sphinx-build -b html docs/source /tmp/docs.ibis-project.org/docs -W -T
 
     - name: Install github key
       run: |


### PR DESCRIPTION
Looks like in #2590 I forgot to build the website, and we are only publishing the docs in https://ibis-project.org/. Just realized now. Fixing it here.