### PR TITLE
FEAT: Support Spark filter with window operation

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2687` Support Spark filter with window operation
 * :bug:`2696` Fix wrong row indexing in the result for 'window after filter' for timecontext adjustment
 * :bug:`2702` Fix `aggregate` exploding the output of Reduction ops that return a list/ndarray
 * :bug:`2693` Fix issues with context adjustment for filter with PySpark backend

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -144,13 +144,14 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
             ]
             col_in_selection_order.extend(cols)
         elif isinstance(selection, (types.ColumnExpr, types.ScalarExpr)):
-            # If the selection is a table column from the root table itself,
-            # we can get the selection name directly.
+            # If the selection is a projection of a table column from the
+            # root table itself, we can get the selection name directly.
             if (
                 isinstance(selection.op(), ops.TableColumn)
                 and selection.op().table == op.table
+                and selection.get_name() in op.table.columns
             ):
-                col_in_selection_order.append(selection.op().name)
+                col_in_selection_order.append(selection.get_name())
             else:
                 col = t.translate(
                     selection, scope, adjusted_timecontext

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -145,12 +145,14 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
             ]
             col_in_selection_order.extend(cols)
         elif isinstance(selection, (types.ColumnExpr, types.ScalarExpr)):
-            # If the selection is a projection of a table column from the
-            # root table itself, we can get the selection name directly.
+            # If the selection is a straightforward projection of a table
+            # column from the root table itself (i.e. excluding mutations and
+            # renames), we can get the selection name directly.
             if (
                 isinstance(selection.op(), ops.TableColumn)
                 and selection.op().table == op.table
-                and selection.get_name() in op.table.columns
+                and selection.get_name() in op.table.schema()
+                and selection.op() == op.table[selection.get_name()].op()
             ):
                 col_in_selection_order.append(selection.get_name())
             else:

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -106,7 +106,7 @@ def compile_sql_query_result(t, expr, scope, timecontext, **kwargs):
 
 def _can_be_replaced_by_column_name(column_expr, table):
     """
-    Return whether the column_expr can be replaced by its literal
+    Return whether the given column_expr can be replaced by its literal
     name, which is True when column_expr and table[column_expr.get_name()]
     is semantically the same.
     """

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -8,7 +8,6 @@ import pyspark
 import pyspark.sql.functions as F
 from pyspark.sql import Window
 from pyspark.sql.functions import PandasUDFType, pandas_udf
-from pyspark.sql.utils import AnalysisException
 
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dtypes
@@ -162,17 +161,7 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
 
     for predicate in op.predicates:
         col = t.translate(predicate, scope, timecontext)
-        # Due to an upstream Spark issue (SPARK-33057) we cannot
-        # directly use filter with a window operation. The workaround
-        # here is to assign a temporary column for the filter predicate,
-        # do the filtering, and then drop the temporary column.
-        try:
-            filter_column = 'internal_column_for_filtering_only'
-            result_table = result_table.withColumn(filter_column, col)
-            result_table = result_table.filter(F.col(filter_column))
-            result_table = result_table.drop(F.col(filter_column))
-        except AnalysisException:
-            result_table = result_table[col]
+        result_table = result_table[col]
 
     if op.sort_keys:
         sort_cols = [

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -2,6 +2,7 @@ import collections
 import enum
 import functools
 import operator
+import uuid
 
 import numpy as np
 import pyspark
@@ -173,10 +174,10 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
         # directly use filter with a window operation. The workaround
         # here is to assign a temporary column for the filter predicate,
         # do the filtering, and then drop the temporary column.
-        filter_column = 'internal_column_for_filtering_only'
+        filter_column = f'predicate_{uuid.uuid4()}'
         result_table = result_table.withColumn(filter_column, col)
         result_table = result_table.filter(F.col(filter_column))
-        result_table = result_table.drop(F.col(filter_column))
+        result_table = result_table.drop(filter_column)
 
     if op.sort_keys:
         sort_cols = [

--- a/ibis/backends/pyspark/tests/test_basic.py
+++ b/ibis/backends/pyspark/tests/test_basic.py
@@ -162,19 +162,6 @@ def test_filter(client, filter_fn, expected_fn):
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
 
 
-def test_filter_with_window_op(client):
-    table = client.table('basic_table')
-    window = ibis.window(group_by=table.id)
-    result = table.filter(lambda t: t['id'].mean().over(window) > 3).compile()
-    df = table.compile().toPandas()
-    expected = (
-        df.groupby(['id'])
-        .filter(lambda t: t['id'].mean() > 3)
-        .reset_index(drop=True)
-    )
-    tm.assert_frame_equal(result.toPandas(), expected)
-
-
 def test_cast(client):
     table = client.table('basic_table')
 

--- a/ibis/backends/pyspark/tests/test_basic.py
+++ b/ibis/backends/pyspark/tests/test_basic.py
@@ -162,6 +162,19 @@ def test_filter(client, filter_fn, expected_fn):
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
 
 
+def test_filter_with_window_op(client):
+    table = client.table('basic_table')
+    window = ibis.window(group_by=table.id)
+    result = table.filter(lambda t: t['id'].mean().over(window) > 3).compile()
+    df = table.compile().toPandas()
+    expected = (
+        df.groupby(['id'])
+        .filter(lambda t: t['id'].mean() > 3)
+        .reset_index(drop=True)
+    )
+    tm.assert_frame_equal(result.toPandas(), expected)
+
+
 def test_cast(client):
     table = client.table('basic_table')
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -139,6 +139,23 @@ def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
 
 
 @pytest.mark.xfail_unsupported
+def test_filter_with_window_op(backend, alltypes, sorted_df):
+    sorted_alltypes = alltypes.sort_by('id')
+    table = sorted_alltypes
+    window = ibis.window(group_by=table.id)
+    table = table.filter(lambda t: t['id'].mean().over(window) > 3).sort_by(
+        'id'
+    )
+    result = table.execute()
+    expected = (
+        sorted_df.groupby(['id'])
+        .filter(lambda t: t['id'].mean() > 3)
+        .reset_index(drop=True)
+    )
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.xfail_unsupported
 def test_case_where(backend, alltypes, df):
     table = alltypes
     table = table.mutate(

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -138,8 +138,8 @@ def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail_unsupported
 @pytest.mark.only_on_backends(['dask', 'pandas', 'pyspark'])
+@pytest.mark.xfail_unsupported
 def test_filter_with_window_op(backend, alltypes, sorted_df):
     sorted_alltypes = alltypes.sort_by('id')
     table = sorted_alltypes

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -139,6 +139,9 @@ def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
 
 
 @pytest.mark.xfail_unsupported
+@pytest.mark.skip_backends(
+    ['spark', 'mysql', 'postgres', 'sql', 'clickhouse', 'impala']
+)
 def test_filter_with_window_op(backend, alltypes, sorted_df):
     sorted_alltypes = alltypes.sort_by('id')
     table = sorted_alltypes

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -140,7 +140,7 @@ def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
 
 @pytest.mark.xfail_unsupported
 @pytest.mark.skip_backends(
-    ['spark', 'mysql', 'postgres', 'sql', 'clickhouse', 'impala']
+    ['spark', 'mysql', 'sqlite', 'postgres', 'sql', 'clickhouse', 'impala']
 )
 def test_filter_with_window_op(backend, alltypes, sorted_df):
     sorted_alltypes = alltypes.sort_by('id')

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -139,9 +139,7 @@ def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
 
 
 @pytest.mark.xfail_unsupported
-@pytest.mark.skip_backends(
-    ['spark', 'mysql', 'sqlite', 'postgres', 'sql', 'clickhouse', 'impala']
-)
+@pytest.mark.only_on_backends(['dask', 'pandas', 'pyspark'])
 def test_filter_with_window_op(backend, alltypes, sorted_df):
     sorted_alltypes = alltypes.sort_by('id')
     table = sorted_alltypes


### PR DESCRIPTION
### Overview

Currently, if you write an expression that does a filter on a window operation and execute this in the pyspark backend, we get a failure from upstream Spark. For example:
`table.filter(lambda t: t['id'].mean().over(window) > 3)`
would raise `pyspark.sql.utils.AnalysisException: It is not allowed to use window functions inside WHERE clause;`. There is an upstream Spark issue about this: https://issues.apache.org/jira/browse/SPARK-33057.

### Proposed Change

A simple workaround can be implemented to avoid passing a window operation directly to filter in the pyspark backend. We can achieve the same filter by first assigning the filter predicate to a temporary, internal column, performing the filter using that column, and then dropping the column.

### Tests
Added a test in test_basic.py that does a window operation in a filter.