### PR TITLE
CI: Pinning SQLAlchemy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - toolz
 
   # Ibis soft dependencies
-  - sqlalchemy
+  - sqlalchemy<1.3.7
   - python-graphviz
 
   # Dev tools


### PR DESCRIPTION
xref #2689

Looks like It'll take more work than expected to make Ibis work with SQLAlchemy 1.4. Also, not sure why, but in `setup.py` we don't support SQLAlchemy after 1.3.6.

Pinning for now, so we can get the CI green, and will continue working on it without the CI blocking other work.