### PR TITLE
BUG: Fix issues with context adjustment for filter with PySpark backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,8 +12,9 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2693` Fix issues with context adjustment for filter with PySpark backend
 * :support:`2689` Supporting SQLAlchemy 1.4, and requiring minimum 1.3
-* :support:`2680` Namespace time_col config, fix type check for trim_with_timecontext for pandas window execution 
+* :support:`2680` Namespace time_col config, fix type check for trim_with_timecontext for pandas window execution
 * :feature:`2646` Support context adjustment for udfs for pandas backend
 * :feature:`2655` Add `auth_local_webserver`, `auth_external_data`, and
   `auth_cache` parameters to BigQuery connect method. Set

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -4,7 +4,7 @@ import ibis.common.exceptions as com
 import ibis.expr.types as types
 from ibis.backends.spark.client import SparkClient
 from ibis.expr.scope import Scope
-from ibis.expr.timecontext import canonicalize_context
+from ibis.expr.timecontext import canonicalize_context, localize_context
 
 from .compiler import PySparkDialect, PySparkExprTranslator
 from .operations import PySparkTable
@@ -27,7 +27,15 @@ class PySparkClient(SparkClient):
         """
 
         if timecontext is not None:
-            timecontext = canonicalize_context(timecontext)
+            session_timezone = self._session.conf.get(
+                'spark.sql.session.timeZone'
+            )
+            # Since spark use session timezone for tz-naive timestamps
+            # we localize tz-naive context here to match that behavior
+            timecontext = localize_context(
+                canonicalize_context(timecontext), session_timezone
+            )
+
         # Insert params in scope
         if params is None:
             scope = Scope()

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -38,7 +38,7 @@ def client():
     from pyspark.sql import SparkSession
 
     session = SparkSession.builder.getOrCreate()
-    client = ibis.pyspark.connect(session)
+    client = ibis.backends.pyspark.connect(session)
 
     df = client._session.range(0, 10)
     df = df.withColumn("str_col", F.lit('value'))

--- a/ibis/backends/pyspark/timecontext.py
+++ b/ibis/backends/pyspark/timecontext.py
@@ -9,7 +9,9 @@ from ibis.expr.typing import TimeContext
 
 
 def filter_by_time_context(
-    df: DataFrame, timecontext: Optional[TimeContext] = None
+    df: DataFrame,
+    timecontext: Optional[TimeContext],
+    adjusted_timecontext: Optional[TimeContext] = None,
 ) -> DataFrame:
     """ Filter a Dataframe by given time context
     Parameters
@@ -21,7 +23,13 @@ def filter_by_time_context(
     -------
     filtered Spark Dataframe
     """
-    if not timecontext:
+    # Return original df if there is no timecontext (timecontext is not used)
+    # or timecontext and adjusted_timecontext are the same
+    if (not timecontext) or (
+        timecontext
+        and adjusted_timecontext
+        and timecontext == adjusted_timecontext
+    ):
         return df
 
     time_col = get_time_col()

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -32,6 +32,7 @@ def filter_by_time_context(df, context):
 
 
 @pytest.mark.only_on_backends(['pandas', 'pyspark'])
+@pytest.mark.min_spark_version('3.1')
 @pytest.mark.parametrize(
     'window',
     [

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -25,7 +25,6 @@ def context():
 
 
 def filter_by_time_context(df, context):
-    # timestamp_col is tz naive, so we need to tz_localize context
     return df[
         (df['timestamp_col'] >= context[0])
         & (df['timestamp_col'] < context[1])

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -18,84 +18,60 @@ def calc_mean(series):
 
 
 @pytest.fixture
-def df(alltypes):
-    return alltypes.execute().sort_values(by=[ORDERBY_COL])
-
-
-@pytest.fixture
 def context():
+    # These need to be tz-naive because the timestamp_col in
+    # the test data is tz-naive
     return pd.Timestamp('20090105'), pd.Timestamp('20090111')
 
 
-@pytest.fixture
-def expected_series(df, context):
-    # expected result series for context adjustment tests
-    exp_raw_win = df.set_index(ORDERBY_COL).assign(v1=df[TARGET_COL].mean())
-    exp_raw_win = exp_raw_win[exp_raw_win.index >= context[0]]
-    exp_raw_win = exp_raw_win[exp_raw_win.index <= context[1]].reset_index(
-        drop=True
-    )['v1']
-
-    exp_orderby = (
-        df.set_index(ORDERBY_COL)
-        .rename(columns={TARGET_COL: 'v1'})['v1']
-        .rolling('3d', closed='both')
-        .mean()
-    )
-    exp_orderby = exp_orderby[exp_orderby.index >= context[0]]
-    exp_orderby = exp_orderby[exp_orderby.index <= context[1]].reset_index(
-        drop=True
-    )
-
-    exp_groupby_orderby = (
-        df.set_index(ORDERBY_COL)
-        .groupby(GROUPBY_COL)
-        .rolling('3d', closed='both')[TARGET_COL]
-        .mean()
-    ).reset_index()
-
-    # Result is a MultiIndexed Series
-    exp_groupby_orderby = exp_groupby_orderby[
-        exp_groupby_orderby[ORDERBY_COL] >= context[0]
+def filter_by_time_context(df, context):
+    # timestamp_col is tz naive, so we need to tz_localize context
+    return df[
+        (df['timestamp_col'] >= context[0])
+        & (df['timestamp_col'] < context[1])
     ]
-    exp_groupby_orderby = exp_groupby_orderby[
-        exp_groupby_orderby[ORDERBY_COL] <= context[1]
-    ]
-    exp_groupby_orderby = exp_groupby_orderby.reset_index(drop=True)[
-        TARGET_COL
-    ].rename('v1')
-    return [exp_raw_win, exp_orderby, exp_groupby_orderby]
 
 
 @pytest.mark.only_on_backends(['pandas', 'pyspark'])
-@pytest.mark.xfail_unsupported
 @pytest.mark.parametrize(
-    ['window', 'exp_idx'],
+    'window',
     [
-        (ibis.trailing_window(3 * ibis.interval(days=1)), 0),
-        (
-            ibis.trailing_window(
-                3 * ibis.interval(days=1), order_by=ORDERBY_COL
-            ),
-            1,
-        ),
-        (
-            ibis.trailing_window(
-                3 * ibis.interval(days=1),
-                order_by=ORDERBY_COL,
-                group_by=GROUPBY_COL,
-            ),
-            2,
+        ibis.trailing_window(ibis.interval(days=3), order_by=ORDERBY_COL),
+        ibis.trailing_window(
+            ibis.interval(days=3), order_by=ORDERBY_COL, group_by=GROUPBY_COL,
         ),
     ],
 )
-def test_context_adjustment_window_udf(
-    alltypes, df, context, expected_series, window, exp_idx
-):
+def test_context_adjustment_window_udf(alltypes, df, context, window):
     """ This test case aims to test context adjustment of
         udfs in window method.
     """
     with option_context('context_adjustment.time_col', 'timestamp_col'):
         expr = alltypes.mutate(v1=calc_mean(alltypes[TARGET_COL]).over(window))
         result = expr.execute(timecontext=context)
-        tm.assert_series_equal(result["v1"], expected_series[exp_idx])
+
+        expected = expr.execute()
+        expected = filter_by_time_context(expected, context).reset_index(
+            drop=True
+        )
+
+        tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.only_on_backends(['pyspark'])
+def test_context_adjustment_filter_before_window(alltypes, df, context):
+    with option_context('context_adjustment.time_col', 'timestamp_col'):
+        window = ibis.trailing_window(
+            ibis.interval(days=3), order_by=ORDERBY_COL
+        )
+
+        expr = alltypes[alltypes['bool_col']]
+        expr = expr.mutate(v1=expr[TARGET_COL].count().over(window))
+
+        result = expr.execute(timecontext=context)
+
+        expected = expr.execute()
+        expected = filter_by_time_context(expected, context)
+        expected = expected.reset_index(drop=True)
+
+        tm.assert_frame_equal(result, expected)

--- a/ibis/expr/timecontext.py
+++ b/ibis/expr/timecontext.py
@@ -132,6 +132,18 @@ def canonicalize_context(
     return begin, end
 
 
+def localize_context(timecontext: TimeContext, timezone: str) -> TimeContext:
+    """Localize tz-naive context."""
+    begin, end = timecontext
+    if begin.tz is None:
+        begin = begin.tz_localize(timezone)
+
+    if end.tz is None:
+        end = end.tz_localize(timezone)
+
+    return begin, end
+
+
 def construct_time_context_aware_series(
     series: pd.Series, frame: pd.DataFrame
 ) -> pd.Series:


### PR DESCRIPTION
Mixture of a few minor issues with context adjustment for pyspark:

Main change:
- Fix Selection node that is filter only so that we pass the original timecontext correctly.

Minor changes:
- Localize tz-naive time context with spark.sql.session.localTimezone. This is consistent with how does Spark treats timestamps in the DataFrame.
- Only trim if the context and adjusted_context are different
- (Minor) Clean up test_timecontext.py
- (Minor) Fix error in backends/pyspark/testconf.py (verified manually)

Tests
====
Add new test in test_timecontext.py
