### PR TITLE
BUG: Fix wrong row indexing in the result for 'window after filter' for timecontext adjustment

### DIFF
--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -193,7 +193,7 @@ def test_context_adjustment_multi_window(time_table, time_df3):
 
 @pytest.mark.xfail(reason="TODO - windowing - #2553")
 def test_context_adjustment_window_groupby_id(time_table, time_df3):
-    """ This test case is meant to test trim_with_timecontext method
+    """ This test case is meant to test trim_window_series method
         in dask/execution/window.py to see if it could trim Series
         correctly with groupby params
     """

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -928,7 +928,7 @@ def execute_database_table_client(
             )
         # filter with time context
         mask = df[time_col].between(begin, end)
-        return df.loc[mask].reset_index(drop=True)
+        return df.loc[mask]
     return df
 
 

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -335,17 +335,11 @@ def execute_selection_dataframe(
         new_pieces = [
             piece.reset_index(
                 level=list(range(1, piece.index.nlevels)), drop=True
-            ).sort_index()
+            )
             if piece.index.nlevels > 1
             else piece
             for piece in data_pieces
         ]
-        # assign data index to new_pieces manually, in case that
-        # indexes are not aligned when series are trimmed by time
-        # context
-        for i in range(len(new_pieces)):
-            assert len(new_pieces[i].index) == len(data.index)
-            new_pieces[i].index = data.index
         result = pd.concat(new_pieces, axis=1)
 
     if predicates:

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -335,11 +335,17 @@ def execute_selection_dataframe(
         new_pieces = [
             piece.reset_index(
                 level=list(range(1, piece.index.nlevels)), drop=True
-            )
+            ).sort_index()
             if piece.index.nlevels > 1
             else piece
             for piece in data_pieces
         ]
+        # assign data index to new_pieces manually, in case that
+        # indexes are not aligned when series are trimmed by time
+        # context
+        for i in range(len(new_pieces)):
+            assert len(new_pieces[i].index) == len(data.index)
+            new_pieces[i].index = data.index
         result = pd.concat(new_pieces, axis=1)
 
     if predicates:

--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -181,7 +181,7 @@ def get_aggcontext_window(
     return aggcontext
 
 
-def trim_with_timecontext(data, timecontext: Optional[TimeContext]):
+def trim_window_series(data, timecontext: Optional[TimeContext]):
     """ Trim data within time range defined by timecontext
 
         This is a util function used in ``execute_window_op``, where time
@@ -216,9 +216,6 @@ def trim_with_timecontext(data, timecontext: Optional[TimeContext]):
     # '0' as the column name for the column of value
     name = data.name if data.name else 0
     subset = df.loc[df[time_col].between(*timecontext)]
-
-    # re-indexing index to count from 0
-    subset = subset.reset_index(drop=True).reset_index()
 
     # get index columns for the Series
     non_target_columns = list(subset.columns.difference([name]))
@@ -373,7 +370,7 @@ def execute_window_op(
         series
     ), 'input data source and computed column do not have the same length'
     # trim data to original time context
-    series = trim_with_timecontext(series, timecontext)
+    series = trim_window_series(series, timecontext)
     return series
 
 

--- a/ibis/backends/pandas/tests/execution/test_timecontext.py
+++ b/ibis/backends/pandas/tests/execution/test_timecontext.py
@@ -4,7 +4,7 @@ import pytest
 
 import ibis
 import ibis.common.exceptions as com
-from ibis.backends.pandas.execution.window import trim_with_timecontext
+from ibis.backends.pandas.execution.window import trim_window_series
 from ibis.expr.timecontext import (
     TimeContextRelation,
     adjust_context,
@@ -134,18 +134,18 @@ def test_context_adjustment_window(
     tm.assert_series_equal(result, expected)
 
 
-def test_trim_with_timecontext(time_df3):
-    """ Unit test `trim_with_timecontext` in Window execution"""
+def test_trim_window_series(time_df3):
+    """ Unit test `trim_window_series` in Window execution"""
     df = time_df3.copy()
     context = pd.Timestamp('20170105'), pd.Timestamp('20170111')
 
-    # trim_with_timecontext takes a MultiIndex Series as input
+    # trim_window_series takes a MultiIndex Series as input
     series = df['value']
     time_index = df.set_index('time').index
     series.index = pd.MultiIndex.from_arrays(
         [series.index, time_index], names=series.index.names + ['time'],
     )
-    result = trim_with_timecontext(series, context)
+    result = trim_window_series(series, context)
     expected = df['time'][df['time'] >= pd.Timestamp('20170105')].reset_index(
         drop=True
     )
@@ -164,10 +164,10 @@ def test_trim_with_timecontext(time_df3):
     with pytest.raises(
         TypeError, match=r".*not supported between instances.*"
     ):
-        trim_with_timecontext(wrong_series, context)
+        trim_window_series(wrong_series, context)
 
     # column is ignored and series is not trimmed
-    no_context_result = trim_with_timecontext(series, None)
+    no_context_result = trim_window_series(series, None)
     tm.assert_series_equal(no_context_result, series)
 
 
@@ -235,7 +235,7 @@ def test_context_adjustment_multi_window(time_table, time_df3):
 
 
 def test_context_adjustment_window_groupby_id(time_table, time_df3):
-    """ This test case is meant to test trim_with_timecontext method
+    """ This test case is meant to test trim_window_series method
         in pandas/execution/window.py to see if it could trim Series
         correctly with groupby params
     """

--- a/ibis/expr/timecontext.py
+++ b/ibis/expr/timecontext.py
@@ -141,7 +141,7 @@ def construct_time_context_aware_series(
     to be trimmed by timecontext. In order to do so, 'time'
     must be added as an index to the Series. We extract
     time column from the parent Dataframe `frame`.
-    See `trim_with_timecontext` in execution/window.py for
+    See `trim_window_series` in execution/window.py for
     trimming implementation.
 
     Parameters


### PR DESCRIPTION
Overview
=======
When time context is adjusted, the result of 'window after filer' is wrong for pandas backend. This PR fixes the bug.

Example:
```
        window = ibis.trailing_window(ibis.interval(days=3), order_by='time')
        # add a filter before window
        expr = exp[expr['bool_col']]
        expr = expr.mutate(v1=expr['value'].count().over(window))
        result = expr.execute(timecontext=context)
```

The result looks like:
```
 index  Unnamed: 0    id bool_col  tinyint_col  smallint_col  ...  date_string_col  string_col           timestamp_col    year month    v1
0   3938.0      3938.0  40.0     True          0.0           0.0  ...         01/05/09           0 2009-01-05 00:40:01.800  2009.0   1.0  11.0
1      NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  12.0
2   3940.0      3940.0  42.0     True          2.0           2.0  ...         01/05/09           2 2009-01-05 00:42:01.810  2009.0   1.0  13.0
3      NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  14.0
4   3942.0      3942.0  44.0     True          4.0           4.0  ...         01/05/09           4 2009-01-05 00:44:01.860  2009.0   1.0  15.0
5      NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  11.0
6   3944.0      3944.0  46.0     True          6.0           6.0  ...         01/05/09           6 2009-01-05 00:46:01.950  2009.0   1.0  12.0
7      NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  13.0
8   3946.0      3946.0  48.0     True          8.0           8.0  ...         01/05/09           8 2009-01-05 00:48:02.800  2009.0   1.0  14.0
9      NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  15.0
10  3948.0      3948.0  50.0     True          0.0           0.0  ...         01/06/09           0 2009-01-06 00:50:02.250  2009.0   1.0  11.0
11     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  12.0
12  3950.0      3950.0  52.0     True          2.0           2.0  ...         01/06/09           2 2009-01-06 00:52:02.260  2009.0   1.0  13.0
13     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  14.0
14  3952.0      3952.0  54.0     True          4.0           4.0  ...         01/06/09           4 2009-01-06 00:54:02.310  2009.0   1.0  15.0
15     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  11.0
16  3954.0      3954.0  56.0     True          6.0           6.0  ...         01/06/09           6 2009-01-06 00:56:02.400  2009.0   1.0  12.0
17     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  13.0
18  3956.0      3956.0  58.0     True          8.0           8.0  ...         01/06/09           8 2009-01-06 00:58:02.530  2009.0   1.0  14.0
19     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  15.0
20  3958.0      3958.0  60.0     True          0.0           0.0  ...         01/07/09           0 2009-01-07 01:00:02.700  2009.0   1.0  11.0
21     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  12.0
22  3960.0      3960.0  62.0     True          2.0           2.0  ...         01/07/09           2 2009-01-07 01:02:02.710  2009.0   1.0  13.0
23     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  14.0
24  3962.0      3962.0  64.0     True          4.0           4.0  ...         01/07/09           4 2009-01-07 01:04:02.760  2009.0   1.0  15.0
25     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  11.0
26  3964.0      3964.0  66.0     True          6.0           6.0  ...         01/07/09           6 2009-01-07 01:06:02.850  2009.0   1.0  12.0
27     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  13.0
28  3966.0      3966.0  68.0     True          8.0           8.0  ...         01/07/09           8 2009-01-07 01:08:02.980  2009.0   1.0  14.0
29     NaN         NaN   NaN      NaN          NaN           NaN  ...              NaN         NaN                     NaT     NaN   NaN  15.0
30  3968.0      3968.0  70.0     True          0.0           0.0  ...         01/08/09           0 2009-01-08 01:10:03.150  2009.0   1.0   NaN
31  3970.0      3970.0  72.0     True          2.0           2.0  ...         01/08/09           2 2009-01-08 01:12:03.160  2009.0   1.0   NaN
32  3972.0      3972.0  74.0     True          4.0           4.0  ...         01/08/09           4 2009-01-08 01:14:03.210  2009.0   1.0   NaN
33  3974.0      3974.0  76.0     True          6.0           6.0  ...         01/08/09           6 2009-01-08 01:16:03.300  2009.0   1.0   NaN
34  3976.0      3976.0  78.0     True          8.0           8.0  ...         01/08/09           8 2009-01-08 01:18:03.430  2009.0   1.0   NaN
35  3978.0      3978.0  80.0     True          0.0           0.0  ...         01/09/09           0 2009-01-09 01:20:03.600  2009.0   1.0   NaN
.....
```

Note that there are many `NaN` rows.  This is because indexes for the result series are misaligned. Caused by `reset_index` in time context trimming.

Another minor change in this PR is to rename `trim_with_timecontext` to be `trim_window_series`.  The method is used to trim the resulting series of window execution only.  The method name should not sound that general.

Test
====
A new test is added for this case in `ibis/backends/test/test_timecontext.py`