### PR TITLE
BUG: Error processing colums of time timestamp with null values (ibis 1.4.0 on postgres)

### DIFF
--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -256,6 +256,7 @@ def convert_datetime64_to_timestamp(in_dtype, out_dtype, column):
     except pd.errors.OutOfBoundsDatetime:
         inferred_dtype = infer_pandas_dtype(column, skipna=True)
         if inferred_dtype in PANDAS_DATE_TYPES:
+            column.fillna(value=pd.NaT, inplace=True)
             # not great, but not really any other option
             return column.map(
                 partial(convert_timezone, timezone=out_dtype.timezone)


### PR DESCRIPTION
closes #2692

This PR fixes an unexpected behavior when a `timestamp` column with `null` values and datetimes outside `pandas` supported range. It avoids raising an exception by reinterpreting the `None` value as a `pandas.NaT` like it's done in the case of datetimes within the supported range.

An example on how to set the table in the database can be found in the issue related to this PR.