### PR TITLE
BUG: Fix `aggregate` exploding the output of Reduction ops that return a list/ndarray

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2702` Fix `aggregate` exploding the output of Reduction ops that return a list/ndarray
 * :support:`2689` Supporting SQLAlchemy 1.4, and requiring minimum 1.3
 * :support:`2680` Namespace time_col config, fix type check for trim_with_timecontext for pandas window execution 
 * :feature:`2646` Support context adjustment for udfs for pandas backend

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -96,16 +96,17 @@ def coerce_to_output(
         return ibis.util.coerce_to_dataframe(result, expr.type().names)
     elif isinstance(result, pd.Series):
         return result.rename(result_name)
-    elif isinstance(result, np.ndarray):
-        return pd.Series(result, name=result_name)
     elif isinstance(expr.op(), ops.Reduction):
-        # We either wrap a scalar into a single element Series
-        # or broadcast the scalar to a multi element Series
         if index is None:
-            return pd.Series(result, name=result_name)
+            # Wrap `result` into a single-element Series.
+            return pd.Series([result], name=result_name)
         else:
+            # Broadcast `result` to a multi-element Series according to the
+            # given `index`.
             return pd.Series(
                 np.repeat(result, len(index)), index=index, name=result_name,
             )
+    elif isinstance(result, np.ndarray):
+        return pd.Series(result, name=result_name)
     else:
         raise ValueError(f"Cannot coerce_to_output. Result: {result}")

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -330,7 +330,7 @@ def test_topk_filter_op(backend, alltypes, df, result_fn, expected_fn):
     ],
 )
 @pytest.mark.xfail_unsupported
-def test_aggregate_list_like(backend, alltypes, pandas_df, agg_fn):
+def test_aggregate_list_like(backend, alltypes, df, agg_fn):
     """Tests .aggregate() where the result of an aggregation is a list-like.
 
     We expect the list / np.array to be treated as a scalar (in other words,
@@ -346,6 +346,6 @@ def test_aggregate_list_like(backend, alltypes, pandas_df, agg_fn):
     result = expr.execute()
 
     # Expecting a 1-row DataFrame
-    expected = pd.DataFrame({'result_col': [agg_fn(pandas_df.double_col)]})
+    expected = pd.DataFrame({'result_col': [agg_fn(df.double_col)]})
 
     backend.assert_frame_equal(result, expected)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -320,3 +320,32 @@ def test_topk_filter_op(backend, alltypes, df, result_fn, expected_fn):
     result = result_fn(t).execute()
     expected = expected_fn(df)
     assert result.shape[0] == expected.shape[0]
+
+
+@pytest.mark.parametrize(
+    'agg_fn',
+    [
+        param(lambda s: list(s), id='agg_to_list'),
+        param(lambda s: np.array(s), id='agg_to_ndarray'),
+    ],
+)
+@pytest.mark.xfail_unsupported
+def test_aggregate_list_like(backend, alltypes, pandas_df, agg_fn):
+    """Tests .aggregate() where the result of an aggregation is a list-like.
+
+    We expect the list / np.array to be treated as a scalar (in other words,
+    the resulting table expression should have one element, which is the
+    list / np.array).
+    """
+
+    udf = reduction(input_type=[dt.double], output_type=dt.Array(dt.double))(
+        agg_fn
+    )
+
+    expr = alltypes.aggregate(result_col=udf(alltypes.double_col))
+    result = expr.execute()
+
+    # Expecting a 1-row DataFrame
+    expected = pd.DataFrame({'result_col': [agg_fn(pandas_df.double_col)]})
+
+    backend.assert_frame_equal(result, expected)


### PR DESCRIPTION
# Problem

On the Pandas backend, when `.aggregate()` is passed an aggregation/reduction that results in a list/ndarray, `aggregate` will automatically explode that list/ndarray into **many rows** (one row per element in the array). This is not the desired behavior. A list/ndarray coming from a Reduction op should actually be treated as a scalar (i.e., **should result in a single row, not many rows**).

### Example code
```
## Setup Pandas backend
df = pd.DataFrame({
    'key': pd.Series([1, 1, 2]),
    'foo': pd.Series([100, 200, 300]),
})

ibis_pandas = ibis.pandas.connect({'test': df})

t = ibis_pandas.table('test')


## Create two Reduction UDFs: one that returns a list, and one that returns an ndarray
@udf.reduction(input_type=[dt.int32], output_type=dt.Array(dt.int32))
def to_list_udf(v):
    return list(v)

@udf.reduction(input_type=[dt.int32], output_type=dt.Array(dt.int32))
def to_np_array_udf(v):
    return np.array(v)


## Use UDFs in `aggregate`
ibis_pandas.execute(
    t.aggregate(
        foo_list=to_list_udf(t['foo']),
        foo_np_array=to_np_array_udf(t['foo']),
    )
)
```

### Current output
|    |   foo_list |   foo_np_array |
|---:|-----------:|---------------:|
|  0 |        100 |            100 |
|  1 |        200 |            200 |
|  2 |        300 |            300 |

### Desired output
|    | foo_list        | foo_np_array   |
|---:|:----------------|:---------------|
|  0 | [100, 200, 300] | [100 200 300]  |


# Solution

This PR fixes the `coerce_to_output` function used by `.aggregate()` so that it treats `lists` or `ndarrays` from `Reduction` ops as scalars, and doesn't explode them into multiple rows.