### PR TITLE
First step towards unifying dialects

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -42,6 +42,7 @@ class BaseBackend(abc.ABC):
         pass
 
     @property
+    @abc.abstractmethod
     def translator(self):
         pass
 

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -31,6 +31,8 @@ class BaseBackend(abc.ABC):
             SQL based backends, not based on a SQLAlchemy dialect.
         pandas
             Backends using pandas to store data and perform computations.
+        spark
+            Spark based backends.
         """
         pass
 

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -58,25 +58,31 @@ class BaseBackend(abc.ABC):
         # TODO check if the below dialects can be merged into a single one
         if self.kind == 'sqlalchemy':
             from ibis.backends.base_sqlalchemy.alchemy import AlchemyDialect
+
             dialect_class = AlchemyDialect
             dialect_class.translator = self.translator
         elif self.kind == 'sql':
             from ibis.backends.base_sqlalchemy.compiler import Dialect
+
             dialect_class = Dialect
             dialect_class.translator = self.translator
         elif self.kind == 'spark':
             from ibis.backends.base_sql.compiler import BaseDialect
+
             dialect_class = BaseDialect
             dialect_class.translator = self.translator
         elif self.kind == 'pandas':
             from ibis.backends.base_sqlalchemy.compiler import Dialect
             from ibis.backends.pandas import PandasExprTranslator
+
             dialect_class = Dialect
             dialect_class.translator = PandasExprTranslator
         else:
-            raise ValueError(f'Backend class "{self.kind}" unknown. '
-                             'Expected one of "sqlalchemy", "sql", '
-                             '"pandas" or "spark".')
+            raise ValueError(
+                f'Backend class "{self.kind}" unknown. '
+                'Expected one of "sqlalchemy", "sql", '
+                '"pandas" or "spark".'
+            )
 
         return dialect_class
 

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -62,23 +62,14 @@ class BaseBackend(abc.ABC):
             from ibis.backends.base_sqlalchemy.alchemy import AlchemyDialect
 
             dialect_class = AlchemyDialect
-            dialect_class.translator = self.translator
-        elif self.kind == 'sql':
+        elif self.kind in ('sql', 'pandas'):
             from ibis.backends.base_sqlalchemy.compiler import Dialect
 
             dialect_class = Dialect
-            dialect_class.translator = self.translator
         elif self.kind == 'spark':
             from ibis.backends.base_sql.compiler import BaseDialect
 
             dialect_class = BaseDialect
-            dialect_class.translator = self.translator
-        elif self.kind == 'pandas':
-            from ibis.backends.base_sqlalchemy.compiler import Dialect
-            from ibis.backends.pandas import PandasExprTranslator
-
-            dialect_class = Dialect
-            dialect_class.translator = PandasExprTranslator
         else:
             raise ValueError(
                 f'Backend class "{self.kind}" unknown. '
@@ -86,6 +77,7 @@ class BaseBackend(abc.ABC):
                 '"pandas" or "spark".'
             )
 
+        dialect_class.translator = self.translator
         return dialect_class
 
     @abc.abstractmethod

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -21,13 +21,64 @@ class BaseBackend(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def builder(self):
+    def kind(self):
+        """
+        Backend kind. One of:
+
+        sqlalchemy
+            Backends using a SQLAlchemy dialect.
+        sql
+            SQL based backends, not based on a SQLAlchemy dialect.
+        pandas
+            Backends using pandas to store data and perform computations.
+        """
         pass
 
     @property
     @abc.abstractmethod
-    def dialect(self):
+    def builder(self):
         pass
+
+    @property
+    def translator(self):
+        pass
+
+    @property
+    def dialect(self):
+        """
+        Dialect class of the backend.
+
+        We generate it dynamically to avoid repeating the code for each
+        backend.
+        """
+        # TODO importing dialects inside the function to avoid circular
+        # imports. In the future instead of this if statement we probably
+        # want to create subclasses for each of the kinds
+        # (e.g. `BaseSQLAlchemyBackend`)
+        # TODO check if the below dialects can be merged into a single one
+        if self.kind == 'sqlalchemy':
+            from ibis.backends.base_sqlalchemy.alchemy import AlchemyDialect
+            dialect_class = AlchemyDialect
+            dialect_class.translator = self.translator
+        elif self.kind == 'sql':
+            from ibis.backends.base_sqlalchemy.compiler import Dialect
+            dialect_class = Dialect
+            dialect_class.translator = self.translator
+        elif self.kind == 'spark':
+            from ibis.backends.base_sql.compiler import BaseDialect
+            dialect_class = BaseDialect
+            dialect_class.translator = self.translator
+        elif self.kind == 'pandas':
+            from ibis.backends.base_sqlalchemy.compiler import Dialect
+            from ibis.backends.pandas import PandasExprTranslator
+            dialect_class = Dialect
+            dialect_class.translator = PandasExprTranslator
+        else:
+            raise ValueError(f'Backend class "{self.kind}" unknown. '
+                             'Expected one of "sqlalchemy", "sql", '
+                             '"pandas" or "spark".')
+
+        return dialect_class
 
     @abc.abstractmethod
     def connect(connection_string, **options):

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -16,7 +16,7 @@ from .client import (
     BigQueryQuery,
     BigQueryTable,
 )
-from .compiler import BigQueryDialect, BigQueryQueryBuilder
+from .compiler import BigQueryExprTranslator, BigQueryQueryBuilder
 
 try:
     from .udf import udf  # noqa F401
@@ -38,8 +38,9 @@ CLIENT_SECRET = "iU5ohAF2qcqrujegE3hQ1cPt"
 
 class Backend(BaseBackend):
     name = 'bigquery'
+    kind = 'sql'
     builder = BigQueryQueryBuilder
-    dialect = BigQueryDialect
+    translator = BigQueryExprTranslator
     query_class = BigQueryQuery
     database_class = BigQueryDatabase
     table_class = BigQueryTable

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -623,7 +623,3 @@ def bigquery_compile_notall(translator, expr):
     return "LOGICAL_OR(NOT ({}))".format(
         *map(translator.translate, expr.op().args)
     )
-
-
-class BigQueryDialect(comp.Dialect):
-    translator = BigQueryExprTranslator

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -8,7 +8,7 @@ from .client import (
     ClickhouseQuery,
     ClickhouseTable,
 )
-from .compiler import ClickhouseDialect, ClickhouseQueryBuilder
+from .compiler import ClickhouseExprTranslator, ClickhouseQueryBuilder
 
 try:
     import lz4  # noqa: F401
@@ -20,8 +20,9 @@ except ImportError:
 
 class Backend(BaseBackend):
     name = 'clickhouse'
+    kind = 'sql'
     builder = ClickhouseQueryBuilder
-    dialect = ClickhouseDialect
+    translator = ClickhouseExprTranslator
     database_class = ClickhouseDatabase
     query_class = ClickhouseQuery
     table_class = ClickhouseDatabaseTable

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -151,11 +151,6 @@ class ClickhouseExprTranslator(comp.ExprTranslator):
         return _name_expr(translated, quote_identifier(name, force=force))
 
 
-class ClickhouseDialect(comp.Dialect):
-
-    translator = ClickhouseExprTranslator
-
-
 compiles = ClickhouseExprTranslator.compiles
 rewrites = ClickhouseExprTranslator.rewrites
 

--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -97,8 +97,8 @@ def df(alltypes):
 
 @pytest.fixture
 def translate():
-    from ..compiler import ClickhouseDialect
+    from ibis.backends.clickhouse import Backend
 
-    dialect = ClickhouseDialect()
+    dialect = Backend().dialect
     context = dialect.make_context()
     return lambda expr: dialect.translator(expr, context).get_result()

--- a/ibis/backends/csv/__init__.py
+++ b/ibis/backends/csv/__init__.py
@@ -6,6 +6,7 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 from ibis.backends.base import BaseBackend
 from ibis.backends.base_file import FileClient
+from ibis.backends.pandas import PandasExprTranslator
 from ibis.backends.pandas.core import execute, execute_node, pre_execute
 from ibis.backends.pandas.execution.selection import physical_tables
 from ibis.expr.scope import Scope
@@ -111,6 +112,7 @@ class Backend(BaseBackend):
     extension = 'csv'
     table_class = CSVTable
     builder = None
+    translator = PandasExprTranslator
 
     def connect(self, path):
         """Create a CSVClient for use with Ibis

--- a/ibis/backends/csv/__init__.py
+++ b/ibis/backends/csv/__init__.py
@@ -6,7 +6,6 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 from ibis.backends.base import BaseBackend
 from ibis.backends.base_file import FileClient
-from ibis.backends.pandas import PandasDialect
 from ibis.backends.pandas.core import execute, execute_node, pre_execute
 from ibis.backends.pandas.execution.selection import physical_tables
 from ibis.expr.scope import Scope
@@ -108,7 +107,7 @@ def csv_pre_execute_selection(
 
 class Backend(BaseBackend):
     name = 'csv'
-    dialect = PandasDialect
+    kind = 'pandas'
     extension = 'csv'
     table_class = CSVTable
     builder = None

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -1,20 +1,34 @@
 from typing import Dict
 
+import toolz
 from dask.dataframe import DataFrame
 
 import ibis.config
 from ibis.backends.base import BaseBackend
-from ibis.backends.pandas import PandasExprTranslator
+from ibis.backends.pandas import _flatten_subclass_tree
 
 from . import udf  # noqa: F401,F403 - register dispatchers
 from .client import DaskClient, DaskDatabase, DaskTable
+from .execution import execute, execute_node  # noqa F401
+
+
+class DaskExprTranslator:
+    # get the dispatched functions from the execute_node dispatcher and compute
+    # and flatten the type tree of the first argument which is always the Node
+    # subclass
+    _registry = frozenset(
+        toolz.concat(
+            _flatten_subclass_tree(types[0]) for types in execute_node.funcs
+        )
+    )
+    _rewrites = {}
 
 
 class Backend(BaseBackend):
     name = 'dask'
     kind = 'pandas'
     builder = None
-    translator = PandasExprTranslator
+    translator = DaskExprTranslator
     database_class = DaskDatabase
     table_class = DaskTable
 

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -7,7 +7,6 @@ from dask.dataframe import DataFrame
 
 import ibis.config
 from ibis.backends.base import BaseBackend
-from ibis.backends.base_sqlalchemy.compiler import Dialect
 from ibis.backends.pandas import _flatten_subclass_tree
 
 from . import udf  # noqa: F401,F403 - register dispatchers
@@ -15,6 +14,8 @@ from .client import DaskClient, DaskDatabase, DaskTable
 from .execution import execute, execute_node  # noqa F401
 
 
+# TODO This is a copy of PandasExprTranslator, can we remove it and use
+# the pandas translator instead?
 class DaskExprTranslator:
     # get the dispatched functions from the execute_node dispatcher and compute
     # and flatten the type tree of the first argument which is always the Node
@@ -27,17 +28,11 @@ class DaskExprTranslator:
     _rewrites = {}
 
 
-class DaskDialect(Dialect):
-
-    translator = DaskExprTranslator
-
-
 class Backend(BaseBackend):
     name = 'dask'
+    kind = 'pandas'
     builder = None
-    # XXX dialect in client was None. Maybe to avoid circular imports
-    # since it's define here and not in `compile.py`? (same in pandas backend)
-    dialect = DaskDialect
+    translator = DaskExprTranslator
     database_class = DaskDatabase
     table_class = DaskTable
 

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -1,38 +1,20 @@
-from __future__ import absolute_import
-
 from typing import Dict
 
-import toolz
 from dask.dataframe import DataFrame
 
 import ibis.config
 from ibis.backends.base import BaseBackend
-from ibis.backends.pandas import _flatten_subclass_tree
+from ibis.backends.pandas import PandasExprTranslator
 
 from . import udf  # noqa: F401,F403 - register dispatchers
 from .client import DaskClient, DaskDatabase, DaskTable
-from .execution import execute, execute_node  # noqa F401
-
-
-# TODO This is a copy of PandasExprTranslator, can we remove it and use
-# the pandas translator instead?
-class DaskExprTranslator:
-    # get the dispatched functions from the execute_node dispatcher and compute
-    # and flatten the type tree of the first argument which is always the Node
-    # subclass
-    _registry = frozenset(
-        toolz.concat(
-            _flatten_subclass_tree(types[0]) for types in execute_node.funcs
-        )
-    )
-    _rewrites = {}
 
 
 class Backend(BaseBackend):
     name = 'dask'
     kind = 'pandas'
     builder = None
-    translator = DaskExprTranslator
+    translator = PandasExprTranslator
     database_class = DaskDatabase
     table_class = DaskTable
 

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -106,9 +106,6 @@ stored in value
 
 See ibis.common.scope for details about the implementaion.
 """
-
-from __future__ import absolute_import
-
 import functools
 from typing import Optional
 

--- a/ibis/backends/dask/tests/execution/test_cast.py
+++ b/ibis/backends/dask/tests/execution/test_cast.py
@@ -8,7 +8,7 @@ from pytest import param
 import ibis
 import ibis.expr.datatypes as dt  # noqa: E402
 
-from ... import execute
+from ...execution import execute
 
 pytestmark = pytest.mark.dask
 

--- a/ibis/backends/dask/tests/execution/test_functions.py
+++ b/ibis/backends/dask/tests/execution/test_functions.py
@@ -13,7 +13,7 @@ from dask.dataframe.utils import tm  # noqa: E402
 import ibis
 import ibis.expr.datatypes as dt  # noqa: E402
 
-from ... import execute
+from ...execution import execute
 
 pytestmark = pytest.mark.dask
 

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -12,7 +12,8 @@ from dask.dataframe.utils import tm
 import ibis
 import ibis.expr.datatypes as dt
 
-from ... import Backend, execute
+from ... import Backend
+from ...execution import execute
 
 pytestmark = pytest.mark.dask
 

--- a/ibis/backends/dask/tests/execution/test_structs.py
+++ b/ibis/backends/dask/tests/execution/test_structs.py
@@ -8,7 +8,8 @@ from dask.dataframe.utils import tm
 import ibis
 import ibis.expr.datatypes as dt
 
-from ... import Backend, execute
+from ... import Backend
+from ...execution import execute
 
 
 @pytest.fixture(scope="module")

--- a/ibis/backends/dask/tests/execution/test_temporal.py
+++ b/ibis/backends/dask/tests/execution/test_temporal.py
@@ -12,7 +12,8 @@ from pytest import param
 from ibis import literal as L  # noqa: E402
 from ibis.expr import datatypes as dt
 
-from ... import Backend, execute
+from ... import Backend
+from ...execution import execute
 
 pytestmark = pytest.mark.dask
 

--- a/ibis/backends/hdf5/__init__.py
+++ b/ibis/backends/hdf5/__init__.py
@@ -4,6 +4,7 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 from ibis.backends.base import BaseBackend
 from ibis.backends.base_file import FileClient
+from ibis.backends.pandas import PandasExprTranslator
 from ibis.backends.pandas.core import execute, execute_node
 
 
@@ -59,6 +60,7 @@ class Backend(BaseBackend):
     builder = None
     extension = 'h5'
     table_class = HDFTable
+    translator = PandasExprTranslator
 
     def connect(self, path):
         """Create a HDF5Client for use with Ibis

--- a/ibis/backends/hdf5/__init__.py
+++ b/ibis/backends/hdf5/__init__.py
@@ -55,8 +55,8 @@ class HDFClient(FileClient):
 
 class Backend(BaseBackend):
     name = 'hdf5'
+    kind = 'pandas'
     builder = None
-    dialect = None
     extension = 'h5'
     table_class = HDFTable
 

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -11,15 +11,16 @@ from .client import (  # noqa: F401
     ImpalaQuery,
     ImpalaTable,
 )
-from .compiler import ImpalaDialect, ImpalaQueryBuilder
+from .compiler import ImpalaExprTranslator, ImpalaQueryBuilder
 from .hdfs import HDFS, WebHDFS, hdfs_connect
 from .udf import *  # noqa: F401,F403
 
 
 class Backend(BaseBackend):
     name = 'impala'
+    kind = 'sql'
     builder = ImpalaQueryBuilder
-    dialect = ImpalaDialect
+    translator = ImpalaExprTranslator
     database_class = ImpalaDatabase
     query_class = ImpalaQuery
     table_class = ImpalaDatabaseTable

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -39,7 +39,7 @@ from ibis.client import Database, DatabaseEntity, Query, SQLClient
 from ibis.config import options
 from ibis.util import log
 
-from . import Backend, ddl, udf
+from . import ddl, udf
 from .compat import HS2Error, ImpylaError, impyla
 from .compiler import build_ast
 from .hdfs import HDFS, WebHDFS
@@ -521,7 +521,7 @@ class ImpalaTable(ir.TableExpr, DatabaseEntity):
         else:
             partition_schema = None
 
-        ast = build_ast(expr, Backend().dialect.make_context())
+        ast = build_ast(expr)
         select = ast.queries[0]
         statement = InsertSelect(
             self._qualified_name,
@@ -803,9 +803,6 @@ class ImpalaClient(SQLClient):
         self._temp_objects = weakref.WeakSet()
 
         self._ensure_temp_db_exists()
-
-    def _build_ast(self, expr, context):
-        return build_ast(expr, context)
 
     def _get_hdfs(self):
         if self._hdfs is None:
@@ -1111,7 +1108,7 @@ class ImpalaClient(SQLClient):
         expr : ibis TableExpr
         database : string, default None
         """
-        ast = self._build_ast(expr, Backend().dialect.make_context())
+        ast = build_ast(expr)
         select = ast.queries[0]
         statement = CreateView(name, select, database=database)
         return self._execute(statement)
@@ -1187,7 +1184,7 @@ class ImpalaClient(SQLClient):
                 writer, to_insert = write_temp_dataframe(self, obj)
             else:
                 to_insert = obj
-            ast = self._build_ast(to_insert, Backend().dialect.make_context())
+            ast = build_ast(to_insert)
             select = ast.queries[0]
 
             statement = CTAS(

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -39,9 +39,9 @@ from ibis.client import Database, DatabaseEntity, Query, SQLClient
 from ibis.config import options
 from ibis.util import log
 
-from . import ddl, udf
+from . import Backend, ddl, udf
 from .compat import HS2Error, ImpylaError, impyla
-from .compiler import ImpalaDialect, build_ast
+from .compiler import build_ast
 from .hdfs import HDFS, WebHDFS
 
 
@@ -521,7 +521,7 @@ class ImpalaTable(ir.TableExpr, DatabaseEntity):
         else:
             partition_schema = None
 
-        ast = build_ast(expr, ImpalaDialect.make_context())
+        ast = build_ast(expr, Backend().dialect.make_context())
         select = ast.queries[0]
         statement = InsertSelect(
             self._qualified_name,
@@ -1111,7 +1111,7 @@ class ImpalaClient(SQLClient):
         expr : ibis TableExpr
         database : string, default None
         """
-        ast = self._build_ast(expr, ImpalaDialect.make_context())
+        ast = self._build_ast(expr, Backend().dialect.make_context())
         select = ast.queries[0]
         statement = CreateView(name, select, database=database)
         return self._execute(statement)
@@ -1187,7 +1187,7 @@ class ImpalaClient(SQLClient):
                 writer, to_insert = write_temp_dataframe(self, obj)
             else:
                 to_insert = obj
-            ast = self._build_ast(to_insert, ImpalaDialect.make_context())
+            ast = self._build_ast(to_insert, Backend().dialect.make_context())
             select = ast.queries[0]
 
             statement = CTAS(

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -804,6 +804,9 @@ class ImpalaClient(SQLClient):
 
         self._ensure_temp_db_exists()
 
+    def _build_ast(self, expr, context):
+        return build_ast(expr, context)
+
     def _get_hdfs(self):
         if self._hdfs is None:
             raise com.IbisError(

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -158,10 +158,6 @@ class ImpalaExprTranslator(BaseExprTranslator):
     context_class = BaseContext
 
 
-class ImpalaDialect(BaseDialect):
-    pass
-
-
 compiles = ImpalaExprTranslator.compiles
 rewrites = ImpalaExprTranslator.rewrites
 

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -17,6 +17,7 @@ from ibis.backends.base_sql.compiler import (
 
 def _get_context():
     from ibis.backends.impala import Backend
+
     return Backend().dialect.make_context()
 
 

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -8,7 +8,6 @@ import ibis.expr.types as ir
 from ibis.backends.base_sql import binary_infix_ops, operation_registry
 from ibis.backends.base_sql.compiler import (
     BaseContext,
-    BaseDialect,
     BaseExprTranslator,
     BaseQueryBuilder,
     BaseSelectBuilder,
@@ -16,14 +15,21 @@ from ibis.backends.base_sql.compiler import (
 )
 
 
-def build_ast(expr, context):
-    assert context is not None, 'context is None'
+def _get_context():
+    from ibis.backends.impala import Backend
+    return Backend().dialect.make_context()
+
+
+def build_ast(expr, context=None):
+    if context is None:
+        context = _get_context()
     builder = ImpalaQueryBuilder(expr, context=context)
     return builder.get_result()
 
 
 def _get_query(expr, context):
-    assert context is not None, 'context is None'
+    if context is None:
+        context = _get_context()
     ast = build_ast(expr, context)
     query = ast.queries[0]
 
@@ -32,8 +38,7 @@ def _get_query(expr, context):
 
 def to_sql(expr, context=None):
     if context is None:
-        context = BaseDialect.make_context()
-    assert context is not None, 'context is None'
+        context = _get_context()
     query = _get_query(expr, context)
     return query.compile()
 

--- a/ibis/backends/impala/tests/mocks.py
+++ b/ibis/backends/impala/tests/mocks.py
@@ -4,9 +4,9 @@ from ibis.tests.expr.mocks import BaseMockConnection
 class MockImpalaConnection(BaseMockConnection):
     @property
     def dialect(self):
-        from ibis.backends.impala.compiler import ImpalaDialect
+        from ibis.backends.impala import Backend
 
-        return ImpalaDialect
+        return Backend().dialect
 
     def _build_ast(self, expr, context):
         from ibis.backends.impala.compiler import build_ast

--- a/ibis/backends/impala/tests/test_ddl_compilation.py
+++ b/ibis/backends/impala/tests/test_ddl_compilation.py
@@ -2,14 +2,8 @@ import pytest
 
 import ibis
 from ibis.backends.base_sql import ddl as base_ddl
-
-from ibis.backends.impala.compiler import (  # noqa: E402, isort:skip
-    ImpalaDialect,
-)
-
-from ibis.backends.impala import ddl  # noqa: E402, isort:skip
-from ibis.backends.impala.client import build_ast  # noqa: E402, isort:skip
-
+from ibis.backends.impala import ddl
+from ibis.backends.impala.client import build_ast
 
 pytestmark = pytest.mark.impala
 
@@ -35,7 +29,7 @@ def test_select_basics(t):
     name = 'testing123456'
 
     expr = t.limit(10)
-    select, _ = _get_select(expr, ImpalaDialect.make_context())
+    select, _ = _get_select(expr)
 
     stmt = base_ddl.InsertSelect(name, select, database='foo')
     result = stmt.compile()
@@ -254,9 +248,7 @@ def expr(t):
 
 def test_create_external_table_as(mockcon):
     path = '/path/to/table'
-    select, _ = _get_select(
-        mockcon.table('test1'), ImpalaDialect.make_context()
-    )
+    select, _ = _get_select(mockcon.table('test1'))
     statement = base_ddl.CTAS(
         'another_table',
         select,
@@ -538,7 +530,7 @@ def test_partition_by():
 def _create_table(
     table_name, expr, database=None, can_exist=False, format='parquet'
 ):
-    ast = build_ast(expr, ImpalaDialect.make_context())
+    ast = build_ast(expr)
     select = ast.queries[0]
     statement = base_ddl.CTAS(
         table_name,
@@ -550,7 +542,7 @@ def _create_table(
     return statement
 
 
-def _get_select(expr, context):
+def _get_select(expr, context=None):
     ast = build_ast(expr, context)
     select = ast.queries[0]
     context = ast.context

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -10,16 +10,13 @@ import ibis
 import ibis.expr.api as api
 import ibis.expr.types as ir
 from ibis import literal as L
+from ibis.backends.impala import Backend
 from ibis.common.exceptions import RelationError
 from ibis.expr.datatypes import Category
 from ibis.tests.expr.mocks import MockConnection
-from ibis.tests.sql.test_compiler import ExprTestCases  # noqa: E402
+from ibis.tests.sql.test_compiler import ExprTestCases
 
-from ..compiler import (  # noqa: E402
-    ImpalaDialect,
-    ImpalaExprTranslator,
-    to_sql,
-)
+from ..compiler import ImpalaExprTranslator, to_sql
 
 pytestmark = pytest.mark.impala
 
@@ -37,7 +34,7 @@ class ExprSQLTest:
 
     def _translate(self, expr, context=None, named=False):
         if context is None:
-            context = ImpalaDialect.make_context()
+            context = Backend().dialect.make_context()
         translator = ImpalaExprTranslator(expr, context=context, named=named)
         return translator.get_result()
 
@@ -83,7 +80,7 @@ class TestValueExprs(unittest.TestCase, ExprSQLTest):
         self._check_literals(cases)
 
     def test_column_ref_table_aliases(self):
-        context = ImpalaDialect.make_context()
+        context = Backend().dialect.make_context()
 
         table1 = ibis.table([('key1', 'string'), ('value1', 'double')])
 
@@ -335,7 +332,7 @@ FROM alltypes"""
 
         expr = t0.g == t1.g
 
-        ctx = ImpalaDialect.make_context()
+        ctx = Backend().dialect.make_context()
         ctx.make_alias(t0)
 
         # Grab alias from parent context

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -2,13 +2,14 @@ from ibis.backends.base import BaseBackend
 from ibis.backends.base_sqlalchemy.alchemy import AlchemyQueryBuilder
 
 from .client import MySQLClient, MySQLDatabase, MySQLTable
-from .compiler import MySQLDialect
+from .compiler import MySQLExprTranslator
 
 
 class Backend(BaseBackend):
     name = 'mysql'
+    kind = 'sqlalchemy'
     builder = AlchemyQueryBuilder
-    dialect = MySQLDialect
+    translator = MySQLExprTranslator
     database_class = MySQLDatabase
     table_class = MySQLTable
 

--- a/ibis/backends/mysql/compiler.py
+++ b/ibis/backends/mysql/compiler.py
@@ -278,11 +278,6 @@ rewrites = MySQLExprTranslator.rewrites
 compiles = MySQLExprTranslator.compiles
 
 
-class MySQLDialect(alch.AlchemyDialect):
-
-    translator = MySQLExprTranslator
-
-
 @compiles(ops.GroupConcat)
 def mysql_compiles_group_concat(t, expr):
     op = expr.op()

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -42,6 +42,7 @@ class Backend(BaseBackend):
     builder = None
     database_class = PandasDatabase
     table_class = PandasTable
+    translator = PandasExprTranslator
 
     def connect(self, dictionary):
         """Construct a pandas client from a dictionary of DataFrames.

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -4,7 +4,7 @@ import ibis.config
 from ibis.backends.base import BaseBackend
 
 from .client import PandasClient, PandasDatabase, PandasTable
-from .execution import execute_node, execute
+from .execution import execute, execute_node
 from .udf import udf  # noqa F401
 
 

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -1,13 +1,10 @@
-from __future__ import absolute_import
-
 import toolz
 
 import ibis.config
 from ibis.backends.base import BaseBackend
-from ibis.backends.base_sqlalchemy.compiler import Dialect
 
 from .client import PandasClient, PandasDatabase, PandasTable
-from .execution import execute, execute_node
+from .execution import execute_node, execute
 from .udf import udf  # noqa F401
 
 
@@ -39,20 +36,10 @@ class PandasExprTranslator:
     _rewrites = {}
 
 
-class PandasDialect(Dialect):
-
-    translator = PandasExprTranslator
-
-
-PandasClient.dialect = dialect = PandasDialect
-
-
 class Backend(BaseBackend):
     name = 'pandas'
+    kind = 'pandas'
     builder = None
-    # XXX dialect in client was None. Maybe to avoid circular imports
-    # since it's define here and not in `compile.py`?
-    dialect = PandasDialect
     database_class = PandasDatabase
     table_class = PandasTable
 

--- a/ibis/backends/pandas/dispatch.py
+++ b/ibis/backends/pandas/dispatch.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from functools import partial
 
 from multipledispatch import Dispatcher

--- a/ibis/backends/parquet/__init__.py
+++ b/ibis/backends/parquet/__init__.py
@@ -11,7 +11,6 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.backends.base import BaseBackend
 from ibis.backends.base_file import FileClient
-from ibis.backends.pandas import PandasDialect
 from ibis.backends.pandas.core import execute, execute_node
 
 # TODO(jreback) complex types are not implemented
@@ -101,8 +100,8 @@ class ParquetClient(FileClient):
 
 class Backend(BaseBackend):
     name = 'parquet'
+    kind = 'pandas'
     builder = None
-    dialect = PandasDialect
     extension = 'parquet'
     table_class = ParquetTable
 

--- a/ibis/backends/parquet/__init__.py
+++ b/ibis/backends/parquet/__init__.py
@@ -11,6 +11,7 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.backends.base import BaseBackend
 from ibis.backends.base_file import FileClient
+from ibis.backends.pandas import PandasExprTranslator
 from ibis.backends.pandas.core import execute, execute_node
 
 # TODO(jreback) complex types are not implemented
@@ -104,6 +105,7 @@ class Backend(BaseBackend):
     builder = None
     extension = 'parquet'
     table_class = ParquetTable
+    translator = PandasExprTranslator
 
     def connect(self, dictionary):
         return ParquetClient(backend=self, root=dictionary)

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -3,13 +3,14 @@ from ibis.backends.base import BaseBackend
 from ibis.backends.base_sqlalchemy.alchemy import AlchemyQueryBuilder
 
 from .client import PostgreSQLClient, PostgreSQLDatabase, PostgreSQLTable
-from .compiler import PostgreSQLDialect
+from .compiler import PostgreSQLExprTranslator
 
 
 class Backend(BaseBackend):
     name = 'postgres'
+    kind = 'sqlalchemy'
     builder = AlchemyQueryBuilder
-    dialect = PostgreSQLDialect
+    translator = PostgreSQLExprTranslator
     database_class = PostgreSQLDatabase
     table_class = PostgreSQLTable
 

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -738,7 +738,3 @@ compiles = PostgreSQLExprTranslator.compiles
 @rewrites(ops.NotAll)
 def _any_all_no_op(expr):
     return expr
-
-
-class PostgreSQLDialect(alch.AlchemyDialect):
-    translator = PostgreSQLExprTranslator

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -132,7 +132,7 @@ def intervals(con):
 def translate():
     from ibis.backends.postgres import Backend
 
-    dialect = Backend.dialect
+    dialect = Backend().dialect
     context = dialect.make_context()
     return lambda expr: dialect.translator(expr, context).get_result()
 

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -130,9 +130,9 @@ def intervals(con):
 
 @pytest.fixture
 def translate():
-    from ibis.backends.postgres.compiler import PostgreSQLDialect
+    from ibis.backends.postgres import Backend
 
-    dialect = PostgreSQLDialect()
+    dialect = Backend.dialect()
     context = dialect.make_context()
     return lambda expr: dialect.translator(expr, context).get_result()
 

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -132,7 +132,7 @@ def intervals(con):
 def translate():
     from ibis.backends.postgres import Backend
 
-    dialect = Backend.dialect()
+    dialect = Backend.dialect
     context = dialect.make_context()
     return lambda expr: dialect.translator(expr, context).get_result()
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -2,14 +2,15 @@ from ibis.backends.base import BaseBackend
 from ibis.backends.spark.client import SparkDatabase, SparkQuery, SparkTable
 
 from .client import PySparkClient
-from .compiler import PySparkDialect
+from .compiler import PySparkExprTranslator
 from .operations import PySparkTable
 
 
 class Backend(BaseBackend):
     name = 'pyspark'
+    kind = 'spark'
     builder = None
-    dialect = PySparkDialect
+    translator = PySparkExprTranslator
     database_class = SparkDatabase
     query_class = SparkQuery
     table_class = PySparkTable

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -16,7 +16,7 @@ import ibis.expr.types as ir
 import ibis.expr.types as types
 from ibis import interval
 from ibis.backends.pandas.execution import execute
-from ibis.backends.spark.compiler import SparkContext, SparkDialect
+from ibis.backends.spark.compiler import SparkContext
 from ibis.backends.spark.datatypes import (
     ibis_array_dtype_to_spark_dtype,
     ibis_dtype_to_spark_dtype,
@@ -80,10 +80,6 @@ class PySparkExprTranslator:
             raise com.OperationNotDefinedError(
                 'No translation rule for {}'.format(type(op))
             )
-
-
-class PySparkDialect(SparkDialect):
-    translator = PySparkExprTranslator
 
 
 compiles = PySparkExprTranslator.compiles

--- a/ibis/backends/spark/__init__.py
+++ b/ibis/backends/spark/__init__.py
@@ -8,14 +8,15 @@ from .client import (
     SparkQuery,
     SparkTable,
 )
-from .compiler import SparkDialect, SparkQueryBuilder
+from .compiler import SparkExprTranslator, SparkQueryBuilder
 from .udf import udf  # noqa: F401
 
 
 class Backend(BaseBackend):
     name = 'spark'
+    kind = 'spark'
     builder = SparkQueryBuilder
-    dialect = SparkDialect
+    translator = SparkExprTranslator
     database_class = SparkDatabase
     query_class = SparkQuery
     table_class = SparkDatabaseTable

--- a/ibis/backends/spark/client.py
+++ b/ibis/backends/spark/client.py
@@ -20,9 +20,10 @@ from ibis.backends.base_sql.ddl import (
 from ibis.client import Database, Query, SQLClient
 from ibis.util import log
 
+from . import Backend
 from . import compiler as comp
 from . import ddl
-from .compiler import SparkDialect, build_ast
+from .compiler import build_ast
 from .datatypes import spark_dtype
 
 
@@ -222,7 +223,7 @@ class SparkTable(ir.TableExpr):
             if not insert_schema.equals(existing_schema):
                 _validate_compatible(insert_schema, existing_schema)
 
-        ast = build_ast(expr, SparkDialect.make_context())
+        ast = build_ast(expr, Backend().dialect.make_context())
         select = ast.queries[0]
         statement = ddl.InsertSelect(
             self._qualified_name, select, overwrite=overwrite
@@ -600,7 +601,7 @@ class SparkClient(SQLClient):
                 )
                 return
 
-            ast = self._build_ast(obj, SparkDialect.make_context())
+            ast = self._build_ast(obj, Backend().dialect.make_context())
             select = ast.queries[0]
 
             statement = ddl.CTAS(
@@ -638,7 +639,7 @@ class SparkClient(SQLClient):
           Replace an existing view of the same name if it exists
         temporary : boolean, default False
         """
-        ast = self._build_ast(expr, SparkDialect.make_context())
+        ast = self._build_ast(expr, Backend().dialect.make_context())
         select = ast.queries[0]
         statement = ddl.CreateView(
             name,

--- a/ibis/backends/spark/client.py
+++ b/ibis/backends/spark/client.py
@@ -20,7 +20,6 @@ from ibis.backends.base_sql.ddl import (
 from ibis.client import Database, Query, SQLClient
 from ibis.util import log
 
-from . import Backend
 from . import compiler as comp
 from . import ddl
 from .compiler import build_ast
@@ -223,7 +222,7 @@ class SparkTable(ir.TableExpr):
             if not insert_schema.equals(existing_schema):
                 _validate_compatible(insert_schema, existing_schema)
 
-        ast = build_ast(expr, Backend().dialect.make_context())
+        ast = build_ast(expr)
         select = ast.queries[0]
         statement = ddl.InsertSelect(
             self._qualified_name, select, overwrite=overwrite
@@ -295,7 +294,7 @@ class SparkClient(SQLClient):
         self._context.stop()
 
     def _build_ast(self, expr, context):
-        result = comp.build_ast(expr, context)
+        result = build_ast(expr, context)
         return result
 
     def _execute(self, stmt, results=False):
@@ -601,7 +600,7 @@ class SparkClient(SQLClient):
                 )
                 return
 
-            ast = self._build_ast(obj, Backend().dialect.make_context())
+            ast = build_ast(obj)
             select = ast.queries[0]
 
             statement = ddl.CTAS(
@@ -639,7 +638,7 @@ class SparkClient(SQLClient):
           Replace an existing view of the same name if it exists
         temporary : boolean, default False
         """
-        ast = self._build_ast(expr, Backend().dialect.make_context())
+        ast = build_ast(expr)
         select = ast.queries[0]
         statement = ddl.CreateView(
             name,

--- a/ibis/backends/spark/compiler.py
+++ b/ibis/backends/spark/compiler.py
@@ -48,6 +48,7 @@ from ibis.backends.base_sql.compiler import (
 
 def build_ast(expr, context=None):
     from ibis.backends.spark import Backend
+
     if context is None:
         context = Backend().dialect.make_context()
     builder = SparkQueryBuilder(expr, context=context)

--- a/ibis/backends/spark/compiler.py
+++ b/ibis/backends/spark/compiler.py
@@ -79,7 +79,7 @@ class SparkQueryBuilder(comp.QueryBuilder):
 class SparkContext(comp.QueryContext):
     def _to_sql(self, expr, ctx):
         if ctx is None:
-            ctx = SparkDialect.make_context()
+            ctx = BaseDialect.make_context()
         builder = SparkQueryBuilder(expr, context=ctx)
         ast = builder.get_result()
         query = ast.queries[0]
@@ -378,8 +378,4 @@ def spark_rewrites_is_inf(expr):
 
 
 class SparkSelect(BaseSelect):
-    translator = SparkExprTranslator
-
-
-class SparkDialect(BaseDialect):
     translator = SparkExprTranslator

--- a/ibis/backends/spark/compiler.py
+++ b/ibis/backends/spark/compiler.py
@@ -46,8 +46,10 @@ from ibis.backends.base_sql.compiler import (
 )
 
 
-def build_ast(expr, context):
-    assert context is not None, 'context is None'
+def build_ast(expr, context=None):
+    from ibis.backends.spark import Backend
+    if context is None:
+        context = Backend().dialect.make_context()
     builder = SparkQueryBuilder(expr, context=context)
     return builder.get_result()
 

--- a/ibis/backends/spark/tests/test_ddl_compilation.py
+++ b/ibis/backends/spark/tests/test_ddl_compilation.py
@@ -3,12 +3,8 @@ import pytest
 import ibis
 from ibis.backends.base_sql import ddl as base_ddl
 
-from ..compiler import (  # noqa: E402, isort:skip
-    SparkDialect,
-    build_ast,
-)
-from .. import ddl  # noqa: E402, isort:skip
-
+from .. import ddl
+from ..compiler import build_ast
 
 pytestmark = pytest.mark.spark
 
@@ -34,7 +30,7 @@ def test_select_basics(t):
     name = 'testing123456'
 
     expr = t.limit(10)
-    ast = build_ast(expr, SparkDialect.make_context())
+    ast = build_ast(expr)
     select = ast.queries[0]
 
     stmt = ddl.InsertSelect(name, select, database='foo')
@@ -142,7 +138,7 @@ def test_partition_by():
 def _create_table(
     table_name, expr, database=None, can_exist=False, format='parquet'
 ):
-    ast = build_ast(expr, SparkDialect.make_context())
+    ast = build_ast(expr)
     select = ast.queries[0]
     statement = ddl.CTAS(
         table_name,

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -16,13 +16,14 @@ from ibis.backends.base import BaseBackend
 from ibis.backends.base_sqlalchemy.alchemy import AlchemyQueryBuilder
 
 from .client import SQLiteClient, SQLiteDatabase, SQLiteTable
-from .compiler import SQLiteDialect
+from .compiler import SQLiteExprTranslator
 
 
 class Backend(BaseBackend):
     name = 'sqlite'
+    kind = 'sqlalchemy'
     builder = AlchemyQueryBuilder
-    dialect = SQLiteDialect
+    translator = SQLiteExprTranslator
     database_class = SQLiteDatabase
     table_class = SQLiteTable
 

--- a/ibis/backends/sqlite/compiler.py
+++ b/ibis/backends/sqlite/compiler.py
@@ -311,11 +311,6 @@ rewrites = SQLiteExprTranslator.rewrites
 compiles = SQLiteExprTranslator.compiles
 
 
-class SQLiteDialect(alch.AlchemyDialect):
-
-    translator = SQLiteExprTranslator
-
-
 @rewrites(ops.DayOfWeekIndex)
 def day_of_week_index(expr):
     return ((expr.op().arg.strftime('%w').cast(dt.int16) + 6) % 7).cast(

--- a/ibis/backends/sqlite/tests/conftest.py
+++ b/ibis/backends/sqlite/tests/conftest.py
@@ -61,9 +61,9 @@ def dialect():
 
 @pytest.fixture
 def translate(dialect):
-    from ibis.backends.sqlite.compiler import SQLiteDialect
+    from ibis.backends.sqlite import Backend
 
-    ibis_dialect = SQLiteDialect()
+    ibis_dialect = Backend().dialect()
     context = ibis_dialect.make_context()
     return lambda expr: str(
         ibis_dialect.translator(expr, context)

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -451,9 +451,9 @@ class GeoMockConnectionPostGIS(MockAlchemyConnection):
 
     @property
     def dialect(self):
-        from ibis.backends.postgres.compiler import PostgreSQLDialect
+        from ibis.backends.postgres import Backend
 
-        return PostgreSQLDialect
+        return Backend.dialect
 
 
 class GeoMockConnectionOmniSciDB(SQLClient):


### PR DESCRIPTION
xref #2707

Centralizing dialects code, and specifying translator in `Backend` class, instead of the dialect. This PR doesn't add a lot of value per se, but it's necessary to move in the next directions:
- Unify the dialect base classes, reduce duplication, and make it easy to have consistency on what base dialects are being used
- Remove duplicate code on dialects and translators. Ideally backends won't have to implement the dialect and translator, which are always the same (with minor things) and instead they'll specify the registry, context...