### PR TITLE
Restore build_ast in BigQuery backend

### DIFF
--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -25,6 +25,11 @@ from ibis.backends.base_sql.compiler import (
 from .datatypes import ibis_type_to_bigquery_type
 
 
+def build_ast(expr, context):
+    builder = BigQueryQueryBuilder(expr, context=context)
+    return builder.get_result()
+
+
 class BigQueryUDFNode(ops.ValueOp):
     pass
 


### PR DESCRIPTION
This PR fixes #2717 

The code change is just reversing the diff in the lines that are selected here: [Diff of ibis/backends/bigquery/compiler.py from #2661](https://github.com/ibis-project/ibis/pull/2661/files#diff-d7c2d45959c2baa00df6631a8818c081adecd87626c52ab82b7560933609e91cL79-L81)

I was able to confirm locally that `.compile()` using the BigQuery backend works with this PR. In the BigQuery CI, this should make `test_large_compile` in `ibis/backends/bigquery/tests/test_compiler.py` start succeeding again (note: BigQuery CI runs after PRs are merged).
