### PR TITLE
WIP: Split build_ast from compile and make builder return a single query

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -97,18 +97,19 @@ class BaseBackend(abc.ABC):
         """
         pass
 
+    def build_ast(self, expr, context):
+        """
+        Return a QueryAST object for the given expression.
+        """
+        return self.builder(expr, context=context).get_result()
+
     def compile(self, expr, params=None):
         """
         Compile the expression.
         """
         context = self.dialect.make_context(params=params)
-        builder = self.builder(expr, context=context)
-        query_ast = builder.get_result()
-        # TODO make all builders return a QueryAST object
-        if isinstance(query_ast, list):
-            query_ast = query_ast[0]
-        compiled = query_ast.compile()
-        return compiled
+        ast = self.build_ast(expr, context)
+        return ast.compile()
 
     def verify(self, expr, params=None):
         """

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -97,19 +97,28 @@ class BaseBackend(abc.ABC):
         """
         pass
 
-    def build_ast(self, expr, context):
+    def build_ast(self, expr, context=None):
         """
         Return a QueryAST object for the given expression.
         """
+        if context is None:
+            context = self.dialect.make_context()
         return self.builder(expr, context=context).get_result()
+
+    def get_query(self, expr, context=None):
+        """
+        Return a Query object from the given expression.
+        """
+        queries = self.build_ast(expr, context)
+        return queries[0]
 
     def compile(self, expr, params=None):
         """
         Compile the expression.
         """
         context = self.dialect.make_context(params=params)
-        ast = self.build_ast(expr, context)
-        return ast.compile()
+        query = self.build_ast(expr, context)
+        return query.compile()
 
     def verify(self, expr, params=None):
         """

--- a/ibis/backends/base_file/__init__.py
+++ b/ibis/backends/base_file/__init__.py
@@ -7,6 +7,7 @@ from ibis.backends.pandas.core import execute_and_reset
 
 class FileClient(ibis.client.Client):
     def __init__(self, backend, root):
+        self.backend = backend
         self.dialect = backend.dialect
         self.extension = backend.extension
         self.table_class = backend.table_class

--- a/ibis/backends/base_sql/compiler.py
+++ b/ibis/backends/base_sql/compiler.py
@@ -6,7 +6,6 @@ from ibis.backends.base.sql import (
     quote_identifier,
 )
 
-
 # ----------------------------------------------------------------------
 # Select compilation
 
@@ -24,7 +23,11 @@ class BaseQueryBuilder(comp.QueryBuilder):
 
 class BaseContext(comp.QueryContext):
     def _to_sql(self, expr, ctx):
-        from ibis.backends.base import Backend
+        from ibis.backends.base import BaseBackend
+
+        class Backend(BaseBackend):
+            pass
+
         return Backend().compile(expr, ctx)
 
 

--- a/ibis/backends/base_sql/compiler.py
+++ b/ibis/backends/base_sql/compiler.py
@@ -7,28 +7,6 @@ from ibis.backends.base.sql import (
 )
 
 
-def build_ast(expr, context):
-    assert context is not None, 'context is None'
-    builder = BaseQueryBuilder(expr, context=context)
-    return builder.get_result()
-
-
-def _get_query(expr, context):
-    assert context is not None, 'context is None'
-    ast = build_ast(expr, context)
-    query = ast.queries[0]
-
-    return query
-
-
-def to_sql(expr, context=None):
-    if context is None:
-        context = BaseDialect.make_context()
-    assert context is not None, 'context is None'
-    query = _get_query(expr, context)
-    return query.compile()
-
-
 # ----------------------------------------------------------------------
 # Select compilation
 
@@ -46,7 +24,8 @@ class BaseQueryBuilder(comp.QueryBuilder):
 
 class BaseContext(comp.QueryContext):
     def _to_sql(self, expr, ctx):
-        return to_sql(expr, ctx)
+        from ibis.backends.base import Backend
+        return Backend().compile(expr, ctx)
 
 
 class BaseSelect(comp.Select):

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -16,8 +16,6 @@ from ibis.client import Database, DatabaseEntity, Query, SQLClient
 from ibis.config import options
 from ibis.util import log
 
-from .compiler import build_ast
-
 fully_qualified_re = re.compile(r"(.*)\.(?:`(.*)`|(.*))")
 base_typename_re = re.compile(r"(\w+)")
 
@@ -222,9 +220,6 @@ class ClickhouseClient(SQLClient):
         self.table_class = backend.table_class
         self.table_expr_class = backend.table_expr_class
         self.con = _DriverClient(*args, **kwargs)
-
-    def _build_ast(self, expr, context):
-        return build_ast(expr, context)
 
     @property
     def current_database(self):

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -9,11 +9,6 @@ from .identifiers import quote_identifier
 from .registry import operation_registry
 
 
-def build_ast(expr, context):
-    builder = ClickhouseQueryBuilder(expr, context=context)
-    return builder.get_result()
-
-
 class ClickhouseSelectBuilder(comp.SelectBuilder):
     @property
     def _select_class(self):

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -41,7 +41,6 @@ from ibis.util import log
 
 from . import ddl, udf
 from .compat import HS2Error, ImpylaError, impyla
-from .compiler import build_ast
 from .hdfs import HDFS, WebHDFS
 
 
@@ -521,7 +520,7 @@ class ImpalaTable(ir.TableExpr, DatabaseEntity):
         else:
             partition_schema = None
 
-        ast = build_ast(expr)
+        ast = self._client.backend.build_ast(expr)
         select = ast.queries[0]
         statement = InsertSelect(
             self._qualified_name,
@@ -784,6 +783,7 @@ class ImpalaClient(SQLClient):
     def __init__(self, backend, con, hdfs_client=None, **params):
         import hdfs
 
+        self.backend = backend
         self.dialect = backend.dialect
         self.database_class = backend.database_class
         self.query_class = backend.query_class
@@ -803,9 +803,6 @@ class ImpalaClient(SQLClient):
         self._temp_objects = weakref.WeakSet()
 
         self._ensure_temp_db_exists()
-
-    def _build_ast(self, expr, context):
-        return build_ast(expr, context)
 
     def _get_hdfs(self):
         if self._hdfs is None:
@@ -1111,7 +1108,7 @@ class ImpalaClient(SQLClient):
         expr : ibis TableExpr
         database : string, default None
         """
-        ast = build_ast(expr)
+        ast = self.backend.build_ast(expr)
         select = ast.queries[0]
         statement = CreateView(name, select, database=database)
         return self._execute(statement)
@@ -1187,7 +1184,7 @@ class ImpalaClient(SQLClient):
                 writer, to_insert = write_temp_dataframe(self, obj)
             else:
                 to_insert = obj
-            ast = build_ast(to_insert)
+            ast = self.backend.build_ast(to_insert)
             select = ast.queries[0]
 
             statement = CTAS(

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -10,35 +10,6 @@ from ibis.backends.base_sql.compiler import (
 )
 
 
-def _get_context():
-    from ibis.backends.impala import Backend
-
-    return Backend().dialect.make_context()
-
-
-def build_ast(expr, context=None):
-    if context is None:
-        context = _get_context()
-    builder = ImpalaQueryBuilder(expr, context=context)
-    return builder.get_result()
-
-
-def _get_query(expr, context):
-    if context is None:
-        context = _get_context()
-    ast = build_ast(expr, context)
-    query = ast.queries[0]
-
-    return query
-
-
-def to_sql(expr, context=None):
-    if context is None:
-        context = _get_context()
-    query = _get_query(expr, context)
-    return query.compile()
-
-
 # ----------------------------------------------------------------------
 # Select compilation
 

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -9,7 +9,6 @@ from ibis.backends.base_sql.compiler import (
     BaseTableSetFormatter,
 )
 
-
 # ----------------------------------------------------------------------
 # Select compilation
 

--- a/ibis/backends/impala/kudu_support.py
+++ b/ibis/backends/impala/kudu_support.py
@@ -145,7 +145,7 @@ class KuduImpalaInterface:
             else:
                 to_insert = obj
             # XXX: exposing a lot of internals
-            ast = self.impala_client._build_ast(to_insert)
+            ast = self.impala_client.backend.build_ast(to_insert)
             select = ast.queries[0]
 
             stmt = CTASKudu(

--- a/ibis/backends/impala/tests/mocks.py
+++ b/ibis/backends/impala/tests/mocks.py
@@ -7,8 +7,3 @@ class MockImpalaConnection(BaseMockConnection):
         from ibis.backends.impala import Backend
 
         return Backend().dialect
-
-    def _build_ast(self, expr, context):
-        from ibis.backends.impala.compiler import build_ast
-
-        return build_ast(expr, context)

--- a/ibis/backends/impala/tests/test_ddl_compilation.py
+++ b/ibis/backends/impala/tests/test_ddl_compilation.py
@@ -2,8 +2,7 @@ import pytest
 
 import ibis
 from ibis.backends.base_sql import ddl as base_ddl
-from ibis.backends.impala import ddl
-from ibis.backends.impala import Backend
+from ibis.backends.impala import Backend, ddl
 
 pytestmark = pytest.mark.impala
 

--- a/ibis/backends/impala/tests/test_ddl_compilation.py
+++ b/ibis/backends/impala/tests/test_ddl_compilation.py
@@ -3,7 +3,7 @@ import pytest
 import ibis
 from ibis.backends.base_sql import ddl as base_ddl
 from ibis.backends.impala import ddl
-from ibis.backends.impala.client import build_ast
+from ibis.backends.impala import Backend
 
 pytestmark = pytest.mark.impala
 
@@ -530,7 +530,7 @@ def test_partition_by():
 def _create_table(
     table_name, expr, database=None, can_exist=False, format='parquet'
 ):
-    ast = build_ast(expr)
+    ast = Backend().build_ast(expr)
     select = ast.queries[0]
     statement = base_ddl.CTAS(
         table_name,
@@ -543,7 +543,7 @@ def _create_table(
 
 
 def _get_select(expr, context=None):
-    ast = build_ast(expr, context)
+    ast = Backend().build_ast(expr, context)
     select = ast.queries[0]
     context = ast.context
     return select, context

--- a/ibis/backends/impala/tests/test_kudu_support.py
+++ b/ibis/backends/impala/tests/test_kudu_support.py
@@ -3,11 +3,12 @@ import unittest
 
 import pytest
 
-import ibis  # noqa: E402
-import ibis.expr.datatypes as dt  # noqa: E402
-import ibis.util as util  # noqa: E402
-from ibis.tests.expr.mocks import MockConnection  # noqa: E402
-from ibis.tests.util import assert_equal  # noqa: E402
+import ibis
+import ibis.expr.datatypes as dt
+import ibis.util as util
+from ibis.tests.expr.mocks import MockConnection
+from ibis.tests.util import assert_equal
+from ibis.backends.impala import Backend
 
 ksupport = pytest.importorskip('ibis.backends.impala.kudu_support')
 kudu = pytest.importorskip('kudu')
@@ -16,8 +17,6 @@ from ibis.backends.impala.tests.conftest import (  # noqa: E402, isort:skip
     IbisTestEnv,
     ImpalaE2E,
 )
-
-from ibis.backends.impala.client import build_ast  # noqa: E402, isort:skip
 
 
 pytestmark = pytest.mark.kudu
@@ -117,7 +116,7 @@ TBLPROPERTIES (
     def test_ctas_ddl(self):
         con = MockConnection()
 
-        select = build_ast(con.table('test1')).queries[0]
+        select = Backend().build_ast(con.table('test1')).queries[0]
         statement = ksupport.CTASKudu(
             'another_table',
             'kudu_name',

--- a/ibis/backends/impala/tests/test_kudu_support.py
+++ b/ibis/backends/impala/tests/test_kudu_support.py
@@ -6,9 +6,9 @@ import pytest
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.util as util
+from ibis.backends.impala import Backend
 from ibis.tests.expr.mocks import MockConnection
 from ibis.tests.util import assert_equal
-from ibis.backends.impala import Backend
 
 ksupport = pytest.importorskip('ibis.backends.impala.kudu_support')
 kudu = pytest.importorskip('kudu')

--- a/ibis/backends/impala/tests/test_window.py
+++ b/ibis/backends/impala/tests/test_window.py
@@ -3,11 +3,15 @@ import pytest
 import ibis
 import ibis.common.exceptions as com
 from ibis import window
-from ibis.backends.impala.compiler import to_sql  # noqa: E402
+from ibis.backends.impala import Backend
 from ibis.expr.window import rows_with_max_lookback
 from ibis.tests.util import assert_equal
 
 pytestmark = pytest.mark.impala
+
+
+def to_sql(expr):
+    return Backend().compile(expr)
 
 
 @pytest.fixture

--- a/ibis/backends/mysql/client.py
+++ b/ibis/backends/mysql/client.py
@@ -64,6 +64,7 @@ class MySQLClient(alch.AlchemyClient):
         url=None,
         driver='pymysql',
     ):
+        self.backend = backend
         self.dialect = backend.dialect
         self.database_class = backend.database_class
         self.table_class = backend.table_class

--- a/ibis/backends/postgres/client.py
+++ b/ibis/backends/postgres/client.py
@@ -41,6 +41,7 @@ class PostgreSQLClient(alch.AlchemyClient):
         url: Optional[str] = None,
         driver: str = 'psycopg2',
     ):
+        self.backend = backend
         self.dialect = backend.dialect
         self.database_class = backend.database_class
         self.table_class = backend.table_class

--- a/ibis/backends/spark/compiler.py
+++ b/ibis/backends/spark/compiler.py
@@ -35,7 +35,6 @@ from ibis.backends.base_sql.compiler import (
 
 from .registry import operation_registry
 
-
 # ----------------------------------------------------------------------
 # Select compilation
 

--- a/ibis/backends/spark/compiler.py
+++ b/ibis/backends/spark/compiler.py
@@ -36,15 +36,6 @@ from ibis.backends.base_sql.compiler import (
 from .registry import operation_registry
 
 
-def build_ast(expr, context=None):
-    from ibis.backends.spark import Backend
-
-    if context is None:
-        context = Backend().dialect.make_context()
-    builder = SparkQueryBuilder(expr, context=context)
-    return builder.get_result()
-
-
 # ----------------------------------------------------------------------
 # Select compilation
 

--- a/ibis/backends/spark/tests/test_ddl_compilation.py
+++ b/ibis/backends/spark/tests/test_ddl_compilation.py
@@ -3,8 +3,7 @@ import pytest
 import ibis
 from ibis.backends.base_sql import ddl as base_ddl
 
-from .. import ddl
-from .. import Backend
+from .. import Backend, ddl
 
 pytestmark = pytest.mark.spark
 

--- a/ibis/backends/spark/tests/test_ddl_compilation.py
+++ b/ibis/backends/spark/tests/test_ddl_compilation.py
@@ -4,7 +4,7 @@ import ibis
 from ibis.backends.base_sql import ddl as base_ddl
 
 from .. import ddl
-from ..compiler import build_ast
+from .. import Backend
 
 pytestmark = pytest.mark.spark
 
@@ -30,7 +30,7 @@ def test_select_basics(t):
     name = 'testing123456'
 
     expr = t.limit(10)
-    ast = build_ast(expr)
+    ast = Backend().build_ast(expr)
     select = ast.queries[0]
 
     stmt = ddl.InsertSelect(name, select, database='foo')
@@ -138,7 +138,7 @@ def test_partition_by():
 def _create_table(
     table_name, expr, database=None, can_exist=False, format='parquet'
 ):
-    ast = build_ast(expr)
+    ast = Backend().build_ast(expr)
     select = ast.queries[0]
     statement = ddl.CTAS(
         table_name,

--- a/ibis/backends/sqlite/client.py
+++ b/ibis/backends/sqlite/client.py
@@ -316,6 +316,7 @@ class SQLiteClient(alch.AlchemyClient):
 
     def __init__(self, backend, path=None, create=False):
         super().__init__(sa.create_engine("sqlite://"))
+        self.backend = backend
         self.dialect = backend.dialect
         self.database_class = backend.database_class
         self.table_class = backend.table_class

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -62,17 +62,10 @@ def test_version(backend, con):
     ],
 )
 def test_query_schema(backend, con, alltypes, expr_fn, expected):
-    if not hasattr(con, '_build_ast'):
-        pytest.skip(
-            '{} backend has no _build_ast method'.format(
-                type(backend).__name__
-            )
-        )
-
     expr = expr_fn(alltypes)
 
     # we might need a public API for it
-    ast = con._build_ast(expr, backend.make_context())
+    ast = con.backend.build_ast(expr, backend.make_context())
     query = con.query_class(con, ast)
     schema = query.schema()
 

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -258,7 +258,7 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
     def _build_ast_ensure_limit(self, expr, limit, params=None):
         context = self.dialect.make_context(params=params)
 
-        query_ast = self._build_ast(expr, context)
+        query_ast = self.backend.build_ast(expr, context)
         # note: limit can still be None at this point, if the global
         # default_limit is None
         for query in reversed(query_ast.queries):
@@ -290,7 +290,7 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         """
         if isinstance(expr, ir.Expr):
             context = self.dialect.make_context(params=params)
-            query_ast = self._build_ast(expr, context)
+            query_ast = self.backend.build_ast(expr, context)
             if len(query_ast.queries) > 1:
                 raise Exception('Multi-query expression')
 
@@ -306,10 +306,6 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         return 'Query:\n{0}\n\n{1}'.format(
             util.indent(query, 2), '\n'.join(result)
         )
-
-    def _build_ast(self, expr, context):
-        # Implement in clients
-        raise NotImplementedError(type(self).__name__)
 
 
 class QueryPipeline:

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -251,7 +251,10 @@ FROM alltypes"""
 
 
 def _get_query(expr):
-    ast = BaseBackend().build_ast(expr)
+    class Backend(BaseBackend):
+        pass
+
+    ast = Backend().build_ast(expr)
     return ast.queries[0]
 
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -6,10 +6,14 @@ import pytest
 import ibis
 import ibis.expr.api as api
 import ibis.expr.operations as ops
-from ibis.backends.base_sql.compiler import BaseDialect, build_ast, to_sql
+from ibis.backends.base import BaseBackend
 from ibis.tests.expr.mocks import MockConnection
 
 pytest.importorskip('sqlalchemy')
+
+
+def to_sql(expr):
+    return BaseBackend().to_sql(expr)
 
 
 class TestASTBuilder(unittest.TestCase):
@@ -247,7 +251,7 @@ FROM alltypes"""
 
 
 def _get_query(expr):
-    ast = build_ast(expr, BaseDialect.make_context())
+    ast = BaseBackend().build_ast(expr)
     return ast.queries[0]
 
 


### PR DESCRIPTION
Checking the builders of which backends return a list of queries, instead of a single query AST object.