### PR TITLE
CI: Testing with older impyla and bitarray versions

### DIFF
--- a/ci/deps/impala-min.yml
+++ b/ci/deps/impala-min.yml
@@ -1,5 +1,5 @@
 impyla=0.15
-bitarray=1.8
+bitarray>=2
 requests
 thrift_sasl
 python-hdfs

--- a/ci/deps/impala-min.yml
+++ b/ci/deps/impala-min.yml
@@ -1,0 +1,5 @@
+impyla=0.15
+bitarray=1.8
+requests
+thrift_sasl
+python-hdfs

--- a/ci/deps/impala-min.yml
+++ b/ci/deps/impala-min.yml
@@ -1,6 +1,0 @@
-impyla=0.15
-bitarray>=2
-thriftpy2
-requests
-thrift_sasl
-python-hdfs

--- a/ci/deps/impala-min.yml
+++ b/ci/deps/impala-min.yml
@@ -1,5 +1,6 @@
 impyla=0.15
 bitarray>=2
+thriftpy2
 requests
 thrift_sasl
 python-hdfs

--- a/ci/deps/impala.yml
+++ b/ci/deps/impala.yml
@@ -1,4 +1,5 @@
 impyla
+bitarray>=2
 requests
 thrift_sasl
 python-hdfs


### PR DESCRIPTION
CI is broken, seems like the latest `bitarray` version is not installed in the Python 3.7 build.

Apparently bitarray is in its 2.0, but released a security version of 1.9, which is the one installed in Python 3.7, and it is failing our CI (`impyla` uses a private attribute, so it's not exactly a breaking change). So far testing if we can fix the CI by pinning versions, not sure what would be the best approach here.