### PR TITLE
ENH: Silence warnings from selection in dask backend

### DIFF
--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -151,7 +151,7 @@ def execute_selection_dataframe(
             )
             data_pieces.append(dask_object)
 
-        result = dd.concat(data_pieces, axis=1)
+        result = dd.concat(data_pieces, axis=1, ignore_unknown_divisions=True)
 
     if predicates:
         predicates = _compute_predicates(


### PR DESCRIPTION
This silences the warnings in the dask backend from standard selection. Maybe revert once we have a fast path for the standard: https://github.com/ibis-project/ibis/issues/2742. This is deep in the implementation so shouldn't be user facing.