### PR TITLE
BUG: Fix dask udaf_node_groupby for multiple key grouping

### DIFF
--- a/ibis/backends/dask/udf.py
+++ b/ibis/backends/dask/udf.py
@@ -142,26 +142,32 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
         # This way we rely on dask dealing with groups and pass the udf down
         # to the frame level.
         assert_identical_grouping_keys(*args)
-        func = op.func
 
-        grouped_df = args[0].obj.groupby(args[0].index)
+        func = op.func
+        groupings = args[0].index
+        out_type = op._output_type.to_dask()
+
+        grouped_df = args[0].obj.groupby(groupings)
         col_names = [col._meta._selected_obj.name for col in args]
 
         def apply_wrapper(df, apply_func, col_names):
             cols = (df[col] for col in col_names)
             return apply_func(*cols)
 
-        # NOTE - We add a detailed meta here so we do not drop the key index
-        # downstream. This seems to be fixed in versions of dask > 2020.12.0
+        if len(groupings) > 1:
+            meta_index = pandas.MultiIndex.from_arrays(
+                [[0], [0]], names=groupings
+            )
+            meta_value = [dd.utils.make_meta(out_type)]
+        else:
+            meta_index = pandas.Index([], name=groupings[0])
+            meta_value = list()
+
         return grouped_df.apply(
             apply_wrapper,
             func,
             col_names,
-            meta=pandas.Series(
-                [],
-                index=pandas.Index([], name=args[0].index[0]),
-                dtype=op._output_type.to_dask(),
-            ),
+            meta=pandas.Series(meta_value, index=meta_index, dtype=out_type),
         )
 
     return scope


### PR DESCRIPTION
If we don't pass a `multiindex` here correctly, the `reset_index`  call in the `op.by` operation (https://github.com/ibis-project/ibis/blob/master/ibis/backends/dask/execution/aggregations.py#L90) will cause a bad value for `result.columns` at https://github.com/ibis-project/ibis/blob/master/ibis/backends/dask/execution/aggregations.py#L92, which will break computation downstream.