### PR TITLE
Move ddl to base/sql and define its API

### DIFF
--- a/ibis/backends/base/sql/ddl.py
+++ b/ibis/backends/base/sql/ddl.py
@@ -109,7 +109,7 @@ class _BaseQualifiedSQLStatement:
         return scoped_name
 
 
-class _BaseDDL(DDL, _BaseQualifiedSQLStatement):
+class BaseDDL(DDL, _BaseQualifiedSQLStatement):
     pass
 
 
@@ -117,7 +117,7 @@ class _BaseDML(DML, _BaseQualifiedSQLStatement):
     pass
 
 
-class _CreateDDL(_BaseDDL):
+class _CreateDDL(BaseDDL):
     def _if_exists(self):
         return 'IF NOT EXISTS ' if self.can_exist else ''
 
@@ -299,7 +299,7 @@ class CreateDatabase(_CreateDDL):
         return create_line
 
 
-class DropObject(_BaseDDL):
+class DropObject(BaseDDL):
     def __init__(self, must_exist=True):
         self.must_exist = must_exist
 
@@ -339,7 +339,7 @@ class DropView(DropTable):
     _object_type = 'VIEW'
 
 
-class TruncateTable(_BaseDDL):
+class TruncateTable(BaseDDL):
 
     _object_type = 'TABLE'
 
@@ -390,7 +390,7 @@ class InsertSelect(_BaseDML):
         )
 
 
-class AlterTable(_BaseDDL):
+class AlterTable(BaseDDL):
     def __init__(
         self,
         table,
@@ -494,6 +494,7 @@ __all__ = (
     'format_schema',
     'format_partition',
     'format_tblproperties',
+    'BaseDDL',
     'CreateTable',
     'CTAS',
     'CreateView',

--- a/ibis/backends/base/sql/ddl.py
+++ b/ibis/backends/base/sql/ddl.py
@@ -76,7 +76,7 @@ def format_partition(partition, partition_schema):
     return 'PARTITION ({})'.format(', '.join(tokens))
 
 
-def format_properties(props):
+def _format_properties(props):
     tokens = []
     for k, v in sorted(props.items()):
         tokens.append("  '{}'='{}'".format(k, v))
@@ -85,16 +85,16 @@ def format_properties(props):
 
 
 def format_tblproperties(props):
-    formatted_props = format_properties(props)
+    formatted_props = _format_properties(props)
     return 'TBLPROPERTIES {}'.format(formatted_props)
 
 
 def _serdeproperties(props):
-    formatted_props = format_properties(props)
+    formatted_props = _format_properties(props)
     return 'SERDEPROPERTIES {}'.format(formatted_props)
 
 
-class BaseQualifiedSQLStatement:
+class _BaseQualifiedSQLStatement:
     def _get_scoped_name(self, obj_name, database):
         if database:
             scoped_name = '{}.`{}`'.format(database, obj_name)
@@ -109,20 +109,20 @@ class BaseQualifiedSQLStatement:
         return scoped_name
 
 
-class BaseDDL(DDL, BaseQualifiedSQLStatement):
+class _BaseDDL(DDL, _BaseQualifiedSQLStatement):
     pass
 
 
-class BaseDML(DML, BaseQualifiedSQLStatement):
+class _BaseDML(DML, _BaseQualifiedSQLStatement):
     pass
 
 
-class CreateDDL(BaseDDL):
+class _CreateDDL(_BaseDDL):
     def _if_exists(self):
         return 'IF NOT EXISTS ' if self.can_exist else ''
 
 
-class CreateTable(CreateDDL):
+class CreateTable(_CreateDDL):
 
     """
 
@@ -282,7 +282,7 @@ class CreateTableWithSchema(CreateTable):
         yield self._location()
 
 
-class CreateDatabase(CreateDDL):
+class CreateDatabase(_CreateDDL):
     def __init__(self, name, path=None, can_exist=False):
         self.name = name
         self.path = path
@@ -299,7 +299,7 @@ class CreateDatabase(CreateDDL):
         return create_line
 
 
-class DropObject(BaseDDL):
+class DropObject(_BaseDDL):
     def __init__(self, must_exist=True):
         self.must_exist = must_exist
 
@@ -339,7 +339,7 @@ class DropView(DropTable):
     _object_type = 'VIEW'
 
 
-class TruncateTable(BaseDDL):
+class TruncateTable(_BaseDDL):
 
     _object_type = 'TABLE'
 
@@ -352,7 +352,7 @@ class TruncateTable(BaseDDL):
         return 'TRUNCATE TABLE {}'.format(name)
 
 
-class InsertSelect(BaseDML):
+class InsertSelect(_BaseDML):
     def __init__(
         self,
         table_name,
@@ -390,7 +390,7 @@ class InsertSelect(BaseDML):
         )
 
 
-class AlterTable(BaseDDL):
+class AlterTable(_BaseDDL):
     def __init__(
         self,
         table,
@@ -486,3 +486,26 @@ class RenameTable(AlterTable):
             self.old_qualified_name, self.new_qualified_name
         )
         return self._wrap_command(cmd)
+
+
+__all__ = (
+    'fully_qualified_re',
+    'is_fully_qualified',
+    'format_schema',
+    'format_partition',
+    'format_tblproperties',
+    'CreateTable',
+    'CTAS',
+    'CreateView',
+    'CreateTableWithSchema',
+    'CreateDatabase',
+    'DropObject',
+    'DropDatabase',
+    'DropTable',
+    'DropView',
+    'TruncateTable',
+    'InsertSelect',
+    'AlterTable',
+    'DropFunction',
+    'RenameTable',
+)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -20,7 +20,7 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 import ibis.util as util
 from ibis.backends.base.sql.compiler import DDL, DML
-from ibis.backends.base_sqlalchemy.ddl import (
+from ibis.backends.base.sql.ddl import (
     CTAS,
     AlterTable,
     CreateDatabase,

--- a/ibis/backends/impala/ddl.py
+++ b/ibis/backends/impala/ddl.py
@@ -14,17 +14,17 @@
 
 import json
 
-from ibis.backends.base.sql.registry import type_to_sql_string
-from ibis.backends.base_sqlalchemy import ddl as base_sql_ddl
-from ibis.backends.base_sqlalchemy.ddl import (
+from ibis.backends.base.sql.ddl import (
     AlterTable,
     BaseDDL,
     CreateTable,
     CreateTableWithSchema,
+    DropFunction,
     format_partition,
     format_schema,
     format_tblproperties,
 )
+from ibis.backends.base.sql.registry import type_to_sql_string
 
 
 class CreateTableParquet(CreateTable):
@@ -312,7 +312,7 @@ class CreateUDA(CreateFunction):
         return ' '.join([create_decl, impala_sig]) + ' ' + '\n'.join(tokens)
 
 
-class DropFunction(base_sql_ddl.DropFunction):
+class DropFunction(DropFunction):
     def _impala_signature(self):
         full_name = self._get_scoped_name(self.name, self.database)
         input_sig = _impala_input_signature(self.inputs)

--- a/ibis/backends/impala/kudu_support.py
+++ b/ibis/backends/impala/kudu_support.py
@@ -4,7 +4,7 @@ import kudu
 import pandas as pd
 
 import ibis.expr.datatypes as dt
-from ibis.backends.base_sqlalchemy.ddl import (
+from ibis.backends.base.sql.ddl import (
     CreateTable,
     format_schema,
     format_tblproperties,

--- a/ibis/backends/spark/client.py
+++ b/ibis/backends/spark/client.py
@@ -10,7 +10,7 @@ import ibis.expr.lineage as lin
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
-from ibis.backends.base_sqlalchemy.ddl import (
+from ibis.backends.base.sql.ddl import (
     CreateDatabase,
     DropTable,
     TruncateTable,

--- a/ibis/backends/spark/ddl.py
+++ b/ibis/backends/spark/ddl.py
@@ -1,5 +1,13 @@
+from ibis.backends.base.sql.ddl import (
+    CTAS,
+    AlterTable,
+    CreateTable,
+    CreateTableWithSchema,
+    DropObject,
+    InsertSelect,
+    RenameTable,
+)
 from ibis.backends.base.sql.registry import quote_identifier
-from ibis.backends.base_sqlalchemy import ddl as base_ddl
 
 from .datatypes import type_to_sql_string
 
@@ -40,7 +48,7 @@ def _format_properties(props):
     return '(\n{}\n)'.format(',\n'.join(tokens))
 
 
-class CreateTable(base_ddl.CreateTable):
+class CreateTable(CreateTable):
 
     """Create a table"""
 
@@ -66,12 +74,12 @@ class CreateTable(base_ddl.CreateTable):
         return 'USING {}'.format(self.format)
 
 
-class CreateTableWithSchema(base_ddl.CreateTableWithSchema):
+class CreateTableWithSchema(CreateTableWithSchema):
     def _storage(self):
         return 'USING {}'.format(self.format)
 
 
-class CTAS(base_ddl.CTAS):
+class CTAS(CTAS):
 
     """
     Create Table As Select
@@ -150,7 +158,7 @@ def _format_schema_element(name, t):
     )
 
 
-class DropDatabase(base_ddl.DropObject):
+class DropDatabase(DropObject):
 
     _object_type = 'DATABASE'
 
@@ -170,7 +178,7 @@ class DropDatabase(base_ddl.DropObject):
             return compiled
 
 
-class DropFunction(base_ddl.DropObject):
+class DropFunction(DropObject):
 
     _object_type = 'TEMPORARY FUNCTION'
 
@@ -183,7 +191,7 @@ class DropFunction(base_ddl.DropObject):
         return self.name
 
 
-class InsertSelect(base_ddl.InsertSelect):
+class InsertSelect(InsertSelect):
     def __init__(
         self, table_name, select_expr, database=None, overwrite=False
     ):
@@ -207,7 +215,7 @@ class InsertSelect(base_ddl.InsertSelect):
         return '{0} {1}\n{2}'.format(cmd, scoped_name, select_query)
 
 
-class AlterTable(base_ddl.AlterTable):
+class AlterTable(AlterTable):
     def __init__(self, table, tbl_properties=None):
         super().__init__(
             table,
@@ -223,7 +231,7 @@ class AlterTable(base_ddl.AlterTable):
         return self._wrap_command(action)
 
 
-class RenameTable(base_ddl.RenameTable):
+class RenameTable(RenameTable):
     def __init__(self, old_name, new_name):
         super().__init__(
             old_name, new_name, old_database=None, new_database=None

--- a/ibis/backends/spark/tests/test_ddl_compilation.py
+++ b/ibis/backends/spark/tests/test_ddl_compilation.py
@@ -1,7 +1,7 @@
 import pytest
 
 import ibis
-from ibis.backends.base_sqlalchemy import ddl as base_ddl
+from ibis.backends.base.sql.ddl import DropTable
 
 from .. import ddl
 from ..compiler import build_ast
@@ -10,12 +10,12 @@ pytestmark = pytest.mark.spark
 
 
 def test_drop_table_compile():
-    statement = base_ddl.DropTable('foo', database='bar', must_exist=True)
+    statement = DropTable('foo', database='bar', must_exist=True)
     query = statement.compile()
     expected = "DROP TABLE bar.`foo`"
     assert query == expected
 
-    statement = base_ddl.DropTable('foo', database='bar', must_exist=False)
+    statement = DropTable('foo', database='bar', must_exist=False)
     query = statement.compile()
     expected = "DROP TABLE IF EXISTS bar.`foo`"
     assert query == expected


### PR DESCRIPTION
Just moving the `ddl.py` from `base_sqlalchemy` (which is removed) to `base/sql`.

Also making private few functions, and adding an `__all__`.