### PR TITLE
Remove functionality from base_sql

### DIFF
--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -9,6 +9,7 @@ import ibis.expr.types as ir
 import ibis.util as util
 
 from . import transforms
+from . import translator
 from .base import DML, QueryAST, SetOp
 from .extract_subqueries import ExtractSubqueries
 
@@ -334,7 +335,7 @@ class Select(DML):
 
     @property
     def translator(self):
-        return self.context.dialect.translator
+        return translator.ExprTranslator
 
     def _translate(self, expr, named=False, permit_subquery=False):
         context = self.context
@@ -599,6 +600,7 @@ class SelectBuilder:
     select statements (and other DDL types, where necessary), and records
     relevant query unit aliases to be used when actually generating SQL.
     """
+    _select_class = Select
 
     def __init__(self, expr, context):
         self.expr = expr

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -7,7 +7,6 @@ import ibis.expr.analysis as L
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 import ibis.util as util
-from ibis.backends.base.sql.registry import quote_identifier
 
 from . import transforms
 from .base import DML, QueryAST, SetOp
@@ -205,6 +204,10 @@ class TableSetFormatter:
         return self._join_names[type(op)]
 
     def _quote_identifier(self, name):
+        # TODO the circular import shouldn't be a problem when
+        # ExistsSubquery is moved to the operations #2761
+        from ibis.backends.base.sql.registry import quote_identifier
+
         return quote_identifier(name)
 
     def _format_table(self, expr):

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -7,6 +7,7 @@ import ibis.expr.analysis as L
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 import ibis.util as util
+from ibis.backends.base.sql.registry import quote_identifier
 
 from . import transforms
 from .base import DML, QueryAST, SetOp
@@ -204,7 +205,7 @@ class TableSetFormatter:
         return self._join_names[type(op)]
 
     def _quote_identifier(self, name):
-        return name
+        return quote_identifier(name)
 
     def _format_table(self, expr):
         # TODO: This could probably go in a class and be significantly nicer

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -8,7 +8,7 @@ import ibis.expr.operations as ops
 import ibis.expr.types as ir
 import ibis.util as util
 
-from . import transforms, translator
+from . import transforms
 from .base import DML, QueryAST, SetOp
 from .extract_subqueries import ExtractSubqueries
 
@@ -334,7 +334,7 @@ class Select(DML):
 
     @property
     def translator(self):
-        return translator.ExprTranslator
+        return self.context.dialect.translator
 
     def _translate(self, expr, named=False, permit_subquery=False):
         context = self.context

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -8,8 +8,7 @@ import ibis.expr.operations as ops
 import ibis.expr.types as ir
 import ibis.util as util
 
-from . import transforms
-from . import translator
+from . import transforms, translator
 from .base import DML, QueryAST, SetOp
 from .extract_subqueries import ExtractSubqueries
 
@@ -600,6 +599,7 @@ class SelectBuilder:
     select statements (and other DDL types, where necessary), and records
     relevant query unit aliases to be used when actually generating SQL.
     """
+
     _select_class = Select
 
     def __init__(self, expr, context):

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -7,7 +7,10 @@ import ibis.expr.datatypes as dt
 import ibis.expr.format as fmt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
-from ibis.backends.base.sql.registry import operation_registry
+from ibis.backends.base.sql.registry import (
+    operation_registry,
+    quote_identifier,
+)
 
 
 class QueryContext:
@@ -246,6 +249,11 @@ class ExprTranslator:
             return False
 
         return True
+
+    def name(self, translated, name, force=True):
+        return '{} AS {}'.format(
+            translated, quote_identifier(name, force=force)
+        )
 
     def translate(self, expr):
         # The operation node type the typed expression wraps

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -7,6 +7,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.format as fmt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
+from ibis.backends.base.sql.registry import operation_registry
 
 
 class QueryContext:
@@ -191,6 +192,7 @@ class ExprTranslator:
     SQL.
     """
 
+    _registry = operation_registry
     _rewrites = {}
 
     context_class = QueryContext

--- a/ibis/backends/base_sql/compiler.py
+++ b/ibis/backends/base_sql/compiler.py
@@ -41,14 +41,11 @@ def to_sql(expr, context=None):
 
 
 class BaseSelectBuilder(SelectBuilder):
-    @property
-    def _select_class(self):
-        return BaseSelect
+    pass
 
 
 class BaseQueryBuilder(QueryBuilder):
-
-    select_builder = BaseSelectBuilder
+    pass
 
 
 class BaseContext(QueryContext):
@@ -57,39 +54,10 @@ class BaseContext(QueryContext):
 
 
 class BaseSelect(Select):
-
-    """
-    A SELECT statement which, after execution, might yield back to the user a
-    table, array/list, or scalar value, depending on the expression that
-    generated it
-    """
-
-    @property
-    def translator(self):
-        return BaseExprTranslator
-
-    @property
-    def table_set_formatter(self):
-        return BaseTableSetFormatter
+    pass
 
 
 class BaseTableSetFormatter(TableSetFormatter):
-
-    _join_names = {
-        ops.InnerJoin: 'INNER JOIN',
-        ops.LeftJoin: 'LEFT OUTER JOIN',
-        ops.RightJoin: 'RIGHT OUTER JOIN',
-        ops.OuterJoin: 'FULL OUTER JOIN',
-        ops.LeftAntiJoin: 'LEFT ANTI JOIN',
-        ops.LeftSemiJoin: 'LEFT SEMI JOIN',
-        ops.CrossJoin: 'CROSS JOIN',
-    }
-
-    def _get_join_type(self, op):
-        jname = self._join_names[type(op)]
-
-        return jname
-
     def _quote_identifier(self, name):
         return quote_identifier(name)
 

--- a/ibis/backends/base_sql/compiler.py
+++ b/ibis/backends/base_sql/compiler.py
@@ -7,10 +7,7 @@ from ibis.backends.base.sql.compiler import (
     SelectBuilder,
     TableSetFormatter,
 )
-from ibis.backends.base.sql.registry import (
-    operation_registry,
-    quote_identifier,
-)
+from ibis.backends.base.sql.registry import quote_identifier
 
 
 class BaseTableSetFormatter(TableSetFormatter):
@@ -24,13 +21,7 @@ class BaseContext(QueryContext):
 
 
 class BaseExprTranslator(ExprTranslator):
-    _registry = operation_registry
     context_class = BaseContext
-
-    def name(self, translated, name, force=True):
-        return '{} AS {}'.format(
-            translated, quote_identifier(name, force=force)
-        )
 
 
 class BaseDialect(Dialect):

--- a/ibis/backends/base_sql/compiler.py
+++ b/ibis/backends/base_sql/compiler.py
@@ -1,4 +1,3 @@
-import ibis.expr.operations as ops
 from ibis.backends.base.sql.compiler import (
     Dialect,
     ExprTranslator,
@@ -32,12 +31,6 @@ class BaseExprTranslator(ExprTranslator):
         return '{} AS {}'.format(
             translated, quote_identifier(name, force=force)
         )
-
-
-@BaseExprTranslator.rewrites(ops.FloorDivide)
-def _floor_divide(expr):
-    left, right = expr.op().args
-    return left.div(right).floor()
 
 
 class BaseDialect(Dialect):

--- a/ibis/backends/base_sql/compiler.py
+++ b/ibis/backends/base_sql/compiler.py
@@ -7,12 +7,10 @@ from ibis.backends.base.sql.compiler import (
     SelectBuilder,
     TableSetFormatter,
 )
-from ibis.backends.base.sql.registry import quote_identifier
 
 
 class BaseTableSetFormatter(TableSetFormatter):
-    def _quote_identifier(self, name):
-        return quote_identifier(name)
+    pass
 
 
 class BaseContext(QueryContext):


### PR DESCRIPTION
Removing some of the functionality of `base_sql` in favor of the base compiler.

Going step by step with this, since the whole refactoring has been breaking mysteriously.