### PR TITLE
BUG: Patch meta for DatetimeTZDtype

### DIFF
--- a/ibis/backends/dask/udf.py
+++ b/ibis/backends/dask/udf.py
@@ -122,10 +122,14 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
                 # we compute so we can work with items inside downstream.
                 result = lazy_result.compute()
             else:
+                output_meta = op._output_type.to_dask()
+                if isinstance(output_meta, pandas.DatetimeTZDtype):
+                    # patch until https://github.com/dask/dask/pull/7627
+                    output_meta = pandas.Timestamp(
+                        1, tz=output_meta.tz, unit=output_meta.unit
+                    )
                 result = dd.from_delayed(
-                    lazy_result,
-                    meta=op._output_type.to_dask(),
-                    verify_meta=False,
+                    lazy_result, meta=output_meta, verify_meta=False
                 )
 
         return result


### PR DESCRIPTION
Currently you can't pass in a `pd.DatetimeTZDtype`  to meta. I have a PR up for this in https://github.com/dask/dask/pull/7627, but we can patch this here until that goes through and we update min dependencies for the dask backend. 

This is the only place we're using the output meta in this way to create a scalar (it works fine in other contexts).