### PR TITLE
BUG: Reduction UDF returning `np.array` hits error when used in grouped aggregation

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2770` Fix error when using reduction UDF that returns np.array in a grouped aggregation
 * :feature:`2753` Use `ndarray` as array representation in Pandas backend
 * :support:`2665` Move BigQuery backend to a `separate repository <https://github.com/ibis-project/ibis-bigquery>`_.
   The backend will be released separately, use `pip install ibis-bigquery` or `conda install ibis-bigquery` to

--- a/ibis/backends/dask/tests/test_udf.py
+++ b/ibis/backends/dask/tests/test_udf.py
@@ -415,6 +415,7 @@ def qs(request):
 
 
 def test_array_return_type_reduction(con, t, df, qs):
+    """Tests reduction UDF returning an array."""
     expr = quantiles(t.b, quantiles=qs)
     result = expr.execute()
     expected = df.b.quantile(qs).compute()
@@ -425,6 +426,7 @@ def test_array_return_type_reduction(con, t, df, qs):
     raises=NotImplementedError, reason='TODO - windowing - #2553'
 )
 def test_array_return_type_reduction_window(con, t, df, qs):
+    """Tests reduction UDF returning an array, used over a window."""
     expr = quantiles(t.b, quantiles=qs).over(ibis.window())
     result = expr.execute()
     expected_raw = df.b.quantile(qs).tolist()
@@ -433,6 +435,7 @@ def test_array_return_type_reduction_window(con, t, df, qs):
 
 
 def test_array_return_type_reduction_group_by(con, t, df, qs):
+    """Tests reduction UDF returning an array, used in a grouped agg."""
     expr = t.groupby(t.key).aggregate(
         quantiles_col=quantiles(t.b, quantiles=qs)
     )

--- a/ibis/backends/dask/tests/test_udf.py
+++ b/ibis/backends/dask/tests/test_udf.py
@@ -432,6 +432,19 @@ def test_array_return_type_reduction_window(con, t, df, qs):
     tm.assert_series_equal(result, expected)
 
 
+def test_array_return_type_reduction_group_by(con, t, df, qs):
+    expr = t.groupby(t.key).aggregate(
+        quantiles_col=quantiles(t.b, quantiles=qs)
+    )
+    result = expr.execute()
+
+    df = df.compute()  # Convert to Pandas
+    expected_col = df.groupby(df.key).b.agg(lambda s: s.quantile(qs).tolist())
+    expected = pd.DataFrame({'quantiles_col': expected_col}).reset_index()
+
+    tm.assert_frame_equal(result, expected)
+
+
 def test_elementwise_udf_with_many_args(t2):
     @elementwise(
         input_type=[dt.double] * 16 + [dt.int32] * 8, output_type=dt.double

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -364,10 +364,15 @@ class Summarize(AggregationContext):
             )
 
         if isinstance(grouped_data, pd.core.groupby.generic.SeriesGroupBy):
-            # Using `apply` as a workaround for the fact that
             # `SeriesGroupBy.agg` does not allow np.arrays to be returned
-            # from UDFs.
-            return grouped_data.apply(wrap_for_agg(function, args, kwargs))
+            # from UDFs. To work around this, we will use `Series.agg`
+            # manually on each group. (#2768)
+            return pd.Series(
+                {
+                    k: v.agg(wrap_for_agg(function, args, kwargs))
+                    for k, v in grouped_data
+                }
+            )
         else:
             return grouped_data.agg(wrap_for_agg(function, args, kwargs))
 

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -363,7 +363,13 @@ class Summarize(AggregationContext):
                 'Object {} is not callable or a string'.format(function)
             )
 
-        return grouped_data.agg(wrap_for_agg(function, args, kwargs))
+        if isinstance(grouped_data, pd.core.groupby.generic.SeriesGroupBy):
+            # Using `apply` as a workaround for the fact that
+            # `SeriesGroupBy.agg` does not allow np.arrays to be returned
+            # from UDFs.
+            return grouped_data.apply(wrap_for_agg(function, args, kwargs))
+        else:
+            return grouped_data.agg(wrap_for_agg(function, args, kwargs))
 
 
 class Transform(AggregationContext):

--- a/ibis/backends/pandas/tests/test_udf.py
+++ b/ibis/backends/pandas/tests/test_udf.py
@@ -2,7 +2,7 @@ import collections
 
 import numpy as np
 import pandas as pd
-import pandas.testing as tm
+import pandas._testing as tm
 import pytest
 
 import ibis
@@ -397,8 +397,8 @@ def test_array_return_type_reduction(con, t, df, qs):
     """Tests reduction UDF returning an array."""
     expr = quantiles(t.b, quantiles=qs)
     result = expr.execute()
-    expected = df.b.quantile(qs)
-    assert result == expected.tolist()
+    expected = np.array(df.b.quantile(qs))
+    tm.assert_numpy_array_equal(result, expected)
 
 
 def test_array_return_type_reduction_window(con, t, df, qs):

--- a/ibis/backends/pandas/tests/test_udf.py
+++ b/ibis/backends/pandas/tests/test_udf.py
@@ -408,6 +408,18 @@ def test_array_return_type_reduction_window(con, t, df, qs):
     tm.assert_series_equal(result, expected)
 
 
+def test_array_return_type_reduction_group_by(con, t, df, qs):
+    expr = t.groupby(t.key).aggregate(
+        quantiles_col=quantiles(t.b, quantiles=qs)
+    )
+    result = expr.execute()
+
+    expected_col = df.groupby(df.key).b.agg(lambda s: s.quantile(qs).tolist())
+    expected = pd.DataFrame({'quantiles_col': expected_col}).reset_index()
+
+    tm.assert_frame_equal(result, expected)
+
+
 def test_elementwise_udf_with_many_args(t2):
     @udf.elementwise(
         input_type=[dt.double] * 16 + [dt.int32] * 8, output_type=dt.double

--- a/ibis/backends/pandas/tests/test_udf.py
+++ b/ibis/backends/pandas/tests/test_udf.py
@@ -394,6 +394,7 @@ def qs(request):
 
 
 def test_array_return_type_reduction(con, t, df, qs):
+    """Tests reduction UDF returning an array."""
     expr = quantiles(t.b, quantiles=qs)
     result = expr.execute()
     expected = df.b.quantile(qs)
@@ -401,6 +402,7 @@ def test_array_return_type_reduction(con, t, df, qs):
 
 
 def test_array_return_type_reduction_window(con, t, df, qs):
+    """Tests reduction UDF returning an array, used over a window."""
     expr = quantiles(t.b, quantiles=qs).over(ibis.window())
     result = expr.execute()
     expected_raw = df.b.quantile(qs).tolist()
@@ -409,6 +411,11 @@ def test_array_return_type_reduction_window(con, t, df, qs):
 
 
 def test_array_return_type_reduction_group_by(con, t, df, qs):
+    """Tests reduction UDF returning an array, used in a grouped aggregation.
+
+    Getting this use case to succeed required avoiding use of
+    `SeriesGroupBy.agg` in the `Summarize` aggcontext implementation (#2768).
+    """
     expr = t.groupby(t.key).aggregate(
         quantiles_col=quantiles(t.b, quantiles=qs)
     )

--- a/ibis/backends/pandas/tests/test_udf.py
+++ b/ibis/backends/pandas/tests/test_udf.py
@@ -98,7 +98,7 @@ def zscore(series):
     input_type=[dt.double], output_type=dt.Array(dt.double),
 )
 def quantiles(series, *, quantiles):
-    return list(series.quantile(quantiles))
+    return np.array(series.quantile(quantiles))
 
 
 def test_udf(t, df):


### PR DESCRIPTION
Closes #2768