### PR TITLE
BUG: Fix a few more places dask could recieve tz meta

### DIFF
--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -329,3 +329,14 @@ def assert_identical_grouping_keys(*args):
         raise AssertionError(
             f"Differing grouping keys passed: {grouping_keys}"
         )
+
+
+def safe_scalar_type(output_meta):
+    """
+    Patch until https://github.com/dask/dask/pull/7627 is merged and that
+    version of dask is used in ibis
+    """
+    if isinstance(output_meta, pd.DatetimeTZDtype):
+        output_meta = pd.Timestamp(1, tz=output_meta.tz, unit=output_meta.unit)
+
+    return output_meta


### PR DESCRIPTION
This fixes a few more UDFs areas affected by https://github.com/dask/dask/pull/7627. I created a `safe_scalar_type` util function to handle this conversion and expanded the udf test coverage to test in all these cases. 