### PR TITLE
ENH: Allow more flexible return type for UDFs

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2776` Allow more flexible return type for UDFs
 * :feature:`2779` Implement Clip in the Pyspark backend
 * :bug:`2770` Fix error when using reduction UDF that returns np.array in a grouped aggregation
 * :feature:`2753` Use `ndarray` as array representation in Pandas backend

--- a/ibis/backends/dask/tests/test_udf.py
+++ b/ibis/backends/dask/tests/test_udf.py
@@ -489,7 +489,7 @@ def test_array_return_type_reduction(con, t, df, qs):
     expr = quantiles(t.b, quantiles=qs)
     result = expr.execute()
     expected = df.b.quantile(qs).compute()
-    assert result == expected.tolist()
+    assert list(result) == expected.tolist()
 
 
 @pytest.mark.xfail(

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -9,6 +9,7 @@ import ibis.common.exceptions as com
 import ibis.util
 from ibis.expr import operations as ops
 from ibis.expr import types as ir
+from ibis.expr.schema import coerce_to_dataframe
 from ibis.expr.scope import Scope
 
 from ..core import execute
@@ -107,12 +108,16 @@ def coerce_to_output(
     result_name = getattr(expr, '_name', None)
 
     if isinstance(expr, (ir.DestructColumn, ir.StructColumn)):
-        return ibis.util.coerce_to_dataframe(result, expr.type().names)
+        return coerce_to_dataframe(
+            result, expr.type().names, expr.type().types
+        )
     elif isinstance(expr, (ir.DestructScalar, ir.StructScalar)):
         # Here there are two cases, if this is groupby aggregate,
         # then the result e a Series of tuple/list, or
         # if this is non grouped aggregate, then the result
-        return ibis.util.coerce_to_dataframe(result, expr.type().names)
+        return coerce_to_dataframe(
+            result, expr.type().names, expr.type().types
+        )
     elif isinstance(result, pd.Series):
         return result.rename(result_name)
     elif isinstance(expr.op(), ops.Reduction):

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -108,16 +108,12 @@ def coerce_to_output(
     result_name = getattr(expr, '_name', None)
 
     if isinstance(expr, (ir.DestructColumn, ir.StructColumn)):
-        return coerce_to_dataframe(
-            result, expr.type().names, expr.type().types
-        )
+        return coerce_to_dataframe(result, expr.type())
     elif isinstance(expr, (ir.DestructScalar, ir.StructScalar)):
         # Here there are two cases, if this is groupby aggregate,
         # then the result e a Series of tuple/list, or
         # if this is non grouped aggregate, then the result
-        return coerce_to_dataframe(
-            result, expr.type().names, expr.type().types
-        )
+        return coerce_to_dataframe(result, expr.type())
     elif isinstance(result, pd.Series):
         return result.rename(result_name)
     elif isinstance(expr.op(), ops.Reduction):

--- a/ibis/backends/pandas/udf.py
+++ b/ibis/backends/pandas/udf.py
@@ -17,7 +17,7 @@ import ibis.client
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.udf.vectorized
-from ibis.util import coerce_to_dataframe
+from ibis.expr.schema import coerce_to_dataframe
 
 from .aggcontext import Summarize, Transform
 from .core import date_types, time_types, timedelta_types, timestamp_types
@@ -229,7 +229,9 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
             # because this is the inner loop and we do not want
             # to wrap a scalar value with a series.
             if isinstance(op._output_type, dt.Struct):
-                return coerce_to_dataframe(result, op._output_type.names)
+                return coerce_to_dataframe(
+                    result, op._output_type.names, op._output_type.types
+                )
             else:
                 return result
 
@@ -269,7 +271,9 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
                 # because this is the inner loop and we do not want
                 # to wrap a scalar value with a series.
                 if isinstance(op._output_type, dt.Struct):
-                    return coerce_to_dataframe(result, op._output_type.names)
+                    return coerce_to_dataframe(
+                        result, op._output_type.names, op._output_type.types
+                    )
                 else:
                     return result
 

--- a/ibis/backends/pandas/udf.py
+++ b/ibis/backends/pandas/udf.py
@@ -229,9 +229,7 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
             # because this is the inner loop and we do not want
             # to wrap a scalar value with a series.
             if isinstance(op._output_type, dt.Struct):
-                return coerce_to_dataframe(
-                    result, op._output_type.names, op._output_type.types
-                )
+                return coerce_to_dataframe(result, op._output_type)
             else:
                 return result
 
@@ -271,9 +269,7 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
                 # because this is the inner loop and we do not want
                 # to wrap a scalar value with a series.
                 if isinstance(op._output_type, dt.Struct):
-                    return coerce_to_dataframe(
-                        result, op._output_type.names, op._output_type.types
-                    )
+                    return coerce_to_dataframe(result, op._output_type)
                 else:
                     return result
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1751,11 +1751,11 @@ def compile_not_null(t, expr, scope, timecontext, **kwargs):
 # ------------------------- User defined function ------------------------
 
 
-def _wrap_struct_func(func, output_cols, output_types):
+def _wrap_struct_func(func, output_type):
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         result = func(*args, **kwargs)
-        return coerce_to_dataframe(result, output_cols, output_types)
+        return coerce_to_dataframe(result, output_type)
 
     return wrapped
 
@@ -1765,9 +1765,7 @@ def compile_elementwise_udf(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
     spark_output_type = spark_dtype(op._output_type)
     if isinstance(expr, (types.StructColumn, types.DestructColumn)):
-        func = _wrap_struct_func(
-            op.func, spark_output_type.names, op._output_type.types
-        )
+        func = _wrap_struct_func(op.func, op._output_type)
     else:
         func = op.func
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -22,7 +22,6 @@ from ibis.backends.spark.datatypes import (
     ibis_dtype_to_spark_dtype,
     spark_dtype,
 )
-from ibis.expr.schema import coerce_to_dataframe
 from ibis.expr.timecontext import adjust_context
 from ibis.util import guid
 
@@ -1751,24 +1750,11 @@ def compile_not_null(t, expr, scope, timecontext, **kwargs):
 # ------------------------- User defined function ------------------------
 
 
-def _wrap_struct_func(func, output_type):
-    @functools.wraps(func)
-    def wrapped(*args, **kwargs):
-        result = func(*args, **kwargs)
-        return coerce_to_dataframe(result, output_type)
-
-    return wrapped
-
-
 @compiles(ops.ElementWiseVectorizedUDF)
 def compile_elementwise_udf(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
     spark_output_type = spark_dtype(op._output_type)
-    if isinstance(expr, (types.StructColumn, types.DestructColumn)):
-        func = _wrap_struct_func(op.func, op._output_type)
-    else:
-        func = op.func
-
+    func = op.func
     spark_udf = pandas_udf(func, spark_output_type, PandasUDFType.SCALAR)
     func_args = (t.translate(arg, scope, timecontext) for arg in op.func_args)
     return spark_udf(*func_args)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1766,7 +1766,7 @@ def compile_elementwise_udf(t, expr, scope, timecontext, **kwargs):
     spark_output_type = spark_dtype(op._output_type)
     if isinstance(expr, (types.StructColumn, types.DestructColumn)):
         func = _wrap_struct_func(
-            op.func, spark_output_type.names, spark_output_type.types
+            op.func, spark_output_type.names, op._output_type.types
         )
     else:
         func = op.func

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -5,7 +5,7 @@ import pytest
 import ibis
 from ibis.config import option_context
 
-from .test_vectorized_udf import calc_mean, demean_struct
+from .test_vectorized_udf import calc_mean, create_demean_struct_udf
 
 GROUPBY_COL = 'month'
 ORDERBY_COL = 'timestamp_col'
@@ -77,8 +77,12 @@ def test_context_adjustment_multi_col_udf_non_grouped(alltypes, df, context):
     with option_context('context_adjustment.time_col', 'timestamp_col'):
         w = ibis.window(preceding=None, following=None)
 
+        demean_struct_udf = create_demean_struct_udf(
+            result_formatter=lambda v1, v2: (v1, v2)
+        )
+
         result = alltypes.mutate(
-            demean_struct(alltypes['double_col'], alltypes['int_col'])
+            demean_struct_udf(alltypes['double_col'], alltypes['int_col'])
             .over(w)
             .destructure()
         ).execute(timecontext=context)

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -201,9 +201,6 @@ mean_struct_udfs = [
     create_mean_struct_udf(
         result_formatter=lambda v1, v2: np.array([v1, v2])
     ),  # np.array of scalar
-    create_mean_struct_udf(
-        result_formatter=lambda v1, v2: pd.Series([v1, v2])
-    ),  # pd.Series of scalar
 ]
 
 

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -434,7 +434,8 @@ def test_elementwise_udf_overwrite_destruct(backend, alltypes):
     backend.assert_frame_equal(result, expected, check_like=True)
 
 
-@pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
+@pytest.mark.only_on_backends(['pandas', 'pyspark'])
+@pytest.mark.xfail_backends(['dask'])
 @pytest.mark.xfail_unsupported
 def test_elementwise_udf_overwrite_destruct_and_assign(backend, alltypes):
     result = (
@@ -531,8 +532,11 @@ def test_elementwise_udf_named_destruct(backend, alltypes):
 @pytest.mark.only_on_backends(['pyspark'])
 @pytest.mark.xfail_unsupported
 def test_elementwise_udf_struct(backend, alltypes):
+    add_one_struct_udf = create_add_one_struct_udf(
+        result_formatter=lambda v1, v2: (v1, v2)
+    )
     result = alltypes.mutate(
-        new_col=add_one_struct(alltypes['double_col'])
+        new_col=add_one_struct_udf(alltypes['double_col'])
     ).execute()
     result = result.assign(
         col1=result['new_col'].apply(lambda x: x[0]),

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -102,6 +102,9 @@ add_one_struct_udfs = [
     create_add_one_struct_udf(
         result_formatter=lambda v1, v2: [np.array(v1), np.array(v2)]
     ),  # list of np.array,
+    create_add_one_struct_udf(
+        result_formatter=lambda v1, v2: pd.DataFrame({'col1': v1, 'col2': v2})
+    ),  # pd.DataFrame,
 ]
 
 
@@ -166,6 +169,11 @@ demean_struct_udfs = [
     create_demean_struct_udf(
         result_formatter=lambda v1, v2: [np.array(v1), np.array(v2)]
     ),  # list of np.array,
+    create_demean_struct_udf(
+        result_formatter=lambda v1, v2: pd.DataFrame(
+            {'demean': v1, 'demean_weight': v2}
+        )
+    ),  # pd.DataFrame,
 ]
 
 
@@ -193,6 +201,9 @@ mean_struct_udfs = [
     create_mean_struct_udf(
         result_formatter=lambda v1, v2: np.array([v1, v2])
     ),  # np.array of scalar
+    create_mean_struct_udf(
+        result_formatter=lambda v1, v2: pd.Series([v1, v2])
+    ),  # pd.Series of scalar
 ]
 
 

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -223,19 +223,23 @@ def coerce_to_dataframe(
     0  1
     1  2
     2  3
+    dtype: int32
     >>> coerce_to_dataframe(pd.Series([[1, 2, 3]]), ['a', 'b', 'c'], [dt.int32, dt.int32, dt.int32])  # noqa: E501
        a  b  c
     0  1  2  3
+    dtypes: [int32, int32, int32]
     >>> coerce_to_dataframe(pd.Series([range(3), range(3)]), ['a', 'b', 'c'], [dt.int32, dt.int32, dt.int32])  # noqa: E501
        a  b  c
     0  0  1  2
     1  0  1  2
+    dtypes: [int32, int32, int32]
     >>> coerce_to_dataframe([pd.Series(x) for x in [1, 2, 3]], ['a', 'b', 'c'], [dt.int32, dt.int32, dt.int32])  # noqa: E501
        a  b  c
     0  1  2  3
     >>>  coerce_to_dataframe([1, 2, 3], ['a', 'b', 'c'], [dt.int32, dt.int32, dt.int32])  # noqa: E501
        a  b  c
     0  1  2  3
+    dtypes: [int32, int32, int32]
     """
     # We don't want to coerce any output that is intended as
     # an array shape.
@@ -247,7 +251,7 @@ def coerce_to_dataframe(
         num_cols = len(data.iloc[0])
         series = [data.apply(lambda t: t[i]) for i in range(num_cols)]
         result = pd.concat(series, axis=1)
-    elif isinstance(data, (tuple, list)):
+    elif isinstance(data, (tuple, list, np.ndarray)):
         if isinstance(data[0], pd.Series):
             result = pd.concat(data, axis=1)
         elif isinstance(data[0], np.ndarray):

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -227,7 +227,7 @@ def coerce_to_series(
     (3) A Series
 
     Note:
-    This method does NOT always return a new Series. If a DataFrame is
+    This method does NOT always return a new Series. If a Series is
     passed in, this method will return the original object.
 
     Parameters
@@ -247,7 +247,9 @@ def coerce_to_series(
     elif isinstance(data, pd.Series):
         result = data
     else:
-        raise ValueError(f"Cannot coerce to Series: {data}")
+        # This case is a non-vector elementwise or analytic UDF that should
+        # not be coerced to a Series.
+        return data
     if original_index is not None:
         result.index = original_index
     return result

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -1,5 +1,5 @@
 import collections
-from typing import Any, List
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -187,8 +187,76 @@ def schema_from_names_types(names, types):
     return Schema(names, types)
 
 
+def coerce_to_tuple(
+    data: Union[List, np.ndarray, pd.Series],
+    output_type: dt.Struct,
+    index: Optional[pd.Index] = None,
+) -> Tuple:
+    """Coerce the following shapes to a tuple.
+
+    (1) A list
+    (2) An np.ndarray
+    (3) A Series
+    """
+    return tuple(data)
+
+
+def coerce_to_np_array(
+    data: Union[List, np.ndarray, pd.Series],
+    output_type: dt.Struct,
+    index: Optional[pd.Index] = None,
+) -> np.ndarray:
+    """Coerce the following shapes to an np.ndarray.
+
+    (1) A list
+    (2) An np.ndarray
+    (3) A Series
+    """
+    return np.array(data)
+
+
+def coerce_to_series(
+    data: Union[List, np.ndarray, pd.Series],
+    output_type: dt.DataType,
+    original_index: Optional[pd.Index] = None,
+) -> pd.Series:
+    """Coerce the following shapes to a Series.
+
+    (1) A list
+    (2) An np.ndarray
+    (3) A Series
+
+    Note:
+    This method does NOT always return a new Series. If a DataFrame is
+    passed in, this method will return the original object.
+
+    Parameters
+    ----------
+    data : pd.Series, a list, or an np.array
+
+    output_type : the type of the output
+
+    original_index : Optional parameter containing the index of the output
+
+    Returns
+    -------
+    pd.Series
+    """
+    if isinstance(data, (list, np.ndarray)):
+        result = pd.Series(data)
+    elif isinstance(data, pd.Series):
+        result = data
+    else:
+        raise ValueError(f"Cannot coerce to Series: {data}")
+    if original_index is not None:
+        result.index = original_index
+    return result
+
+
 def coerce_to_dataframe(
-    data: Any, column_names: List[str], types: List[dt.DataType]
+    data: Any,
+    output_type: dt.Struct,
+    original_index: Optional[pd.Index] = None,
 ) -> pd.DataFrame:
     """Coerce the following shapes to a DataFrame.
 
@@ -208,9 +276,9 @@ def coerce_to_dataframe(
     data : pd.DataFrame, a tuple/list of pd.Series, a tuple/list of np.array
     or a pd.Series of tuple/list
 
-    column_names : a list containing the names of the output
+    output_type : a Struct containing the names and types of the output
 
-    types : a list containing the types of the output
+    original_index : Optional parameter containing the index of the output
 
     Returns
     -------
@@ -218,32 +286,32 @@ def coerce_to_dataframe(
 
     Examples
     --------
-    >>> coerce_to_dataframe(pd.DataFrame({'a': [1, 2, 3]}), ['b'], [dt.int32])
+    >>> coerce_to_dataframe(pd.DataFrame({'a': [1, 2, 3]}), dt.Struct([('b', 'int32')]))  # noqa: E501
        b
     0  1
     1  2
     2  3
     dtype: int32
-    >>> coerce_to_dataframe(pd.Series([[1, 2, 3]]), ['a', 'b', 'c'], [dt.int32, dt.int32, dt.int32])  # noqa: E501
+    >>> coerce_to_dataframe(pd.Series([[1, 2, 3]]), dt.Struct([('a', 'int32'), ('b', 'int32'), ('c', 'int32')]))  # noqa: E501
        a  b  c
     0  1  2  3
     dtypes: [int32, int32, int32]
-    >>> coerce_to_dataframe(pd.Series([range(3), range(3)]), ['a', 'b', 'c'], [dt.int32, dt.int32, dt.int32])  # noqa: E501
+    >>> coerce_to_dataframe(pd.Series([range(3), range(3)]), dt.Struct([('a', 'int32'), ('b', 'int32'), ('c', 'int32')]))  # noqa: E501
        a  b  c
     0  0  1  2
     1  0  1  2
     dtypes: [int32, int32, int32]
-    >>> coerce_to_dataframe([pd.Series(x) for x in [1, 2, 3]], ['a', 'b', 'c'], [dt.int32, dt.int32, dt.int32])  # noqa: E501
+    >>> coerce_to_dataframe([pd.Series(x) for x in [1, 2, 3]], dt.Struct([('a', 'int32'), ('b', 'int32'), ('c', 'int32')]))  # noqa: E501
        a  b  c
     0  1  2  3
-    >>>  coerce_to_dataframe([1, 2, 3], ['a', 'b', 'c'], [dt.int32, dt.int32, dt.int32])  # noqa: E501
+    >>>  coerce_to_dataframe([1, 2, 3], dt.Struct([('a', 'int32'), ('b', 'int32'), ('c', 'int32')]))  # noqa: E501
        a  b  c
     0  1  2  3
     dtypes: [int32, int32, int32]
     """
     # We don't want to coerce any output that is intended as
     # an array shape.
-    if any(isinstance(t, dt.Array) for t in types):
+    if any(isinstance(t, dt.Array) for t in output_type.types):
         return data
     if isinstance(data, pd.DataFrame):
         result = data
@@ -262,5 +330,7 @@ def coerce_to_dataframe(
     else:
         raise ValueError(f"Cannot coerce to DataFrame: {data}")
 
-    result.columns = column_names
+    result.columns = output_type.names
+    if original_index is not None:
+        result.index = original_index
     return result

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -43,7 +43,6 @@ class UserDefinedFunction(object):
         @functools.wraps(self.func)
         def func(*args):
             # If cols are pd.Series, then we save and restore the index.
-            # Otherwise, we will reset the index to the natural index.
             if hasattr(args[0], 'index'):
                 saved_index = args[0].index
             else:
@@ -67,8 +66,6 @@ class UserDefinedFunction(object):
                     # assigned to the original table with rows aligned
                     if saved_index is not None:
                         result.index = saved_index
-                    else:
-                        result = result.reset_index(drop=True)
                 elif isinstance(result, (list, np.ndarray)):
                     # Multi-col aggregation does not support
                     # returning np.ndarray
@@ -83,8 +80,6 @@ class UserDefinedFunction(object):
                     # assigned to the original table with rows aligned
                     if saved_index is not None:
                         result.index = saved_index
-                    else:
-                        result = result.reset_index(drop=True)
             return result
 
         op = self.func_type(

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -40,7 +40,7 @@ class UserDefinedFunction(object):
 
     def _get_coercion_function(self):
         """Return the appropriate function to coerce the result of the UDF,
-        according to the func type and output type of the struct."""
+        according to the func type and output type of the UDF."""
         if isinstance(self.output_type, dt.Struct):
             # Case 1: Struct output, non-reduction UDF -> coerce to DataFrame
             if (
@@ -51,7 +51,7 @@ class UserDefinedFunction(object):
             else:
                 # Case 2: Struct output, reduction UDF -> coerce to tuple
                 return coerce_to_tuple
-        # Case 3: List-like output, non-reduction UDF -> coerce to Series
+        # Case 3: Vector output, non-reduction UDF -> coerce to Series
         elif (
             self.func_type is ElementWiseVectorizedUDF
             or self.func_type is AnalyticVectorizedUDF

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -43,7 +43,7 @@ class UserDefinedFunction(object):
         @functools.wraps(self.func)
         def func(*args):
             # If cols are pd.Series, then we save and restore the index.
-            if hasattr(args[0], 'index'):
+            if isinstance(args[0], pd.Series):
                 saved_index = args[0].index
             else:
                 saved_index = None

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -48,7 +48,9 @@ class UserDefinedFunction(object):
                 saved_index = args[0].index
             else:
                 saved_index = None
+
             result = self.func(*args, **kwargs)
+
             if isinstance(self.output_type, dt.Struct):
                 if isinstance(result, pd.DataFrame) or (
                     isinstance(result[0], (pd.Series, list, np.ndarray))
@@ -72,7 +74,9 @@ class UserDefinedFunction(object):
                     # returning np.ndarray
                     result = tuple(result)
             else:
-                if isinstance(result, (list, np.ndarray)):
+                if isinstance(result, (list, np.ndarray)) and not isinstance(
+                    self.output_type, dt.Array
+                ):
                     result = pd.Series(result)
                 if isinstance(result, pd.Series):
                     # Restore original index so that the result can later be

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -19,6 +19,7 @@ from typing import (
 )
 from uuid import uuid4
 
+import numpy as np
 import pandas as pd
 import toolz
 
@@ -125,6 +126,8 @@ def coerce_to_dataframe(data: Any, names: List[str]) -> pd.DataFrame:
     elif isinstance(data, (tuple, list)):
         if isinstance(data[0], pd.Series):
             result = pd.concat(data, axis=1)
+        elif isinstance(data[0], np.ndarray):
+            result = pd.concat([pd.Series(v) for v in data], axis=1)
         else:
             # Promote scalar to Series
             result = pd.concat([pd.Series([v]) for v in data], axis=1)

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -19,8 +19,6 @@ from typing import (
 )
 from uuid import uuid4
 
-import numpy as np
-import pandas as pd
 import toolz
 
 from ibis.config import options
@@ -73,70 +71,6 @@ def is_one_of(values: Sequence[T], t: Type[U]) -> Iterator[bool]:
 
 any_of = toolz.compose(any, is_one_of)
 all_of = toolz.compose(all, is_one_of)
-
-
-def coerce_to_dataframe(data: Any, names: List[str]) -> pd.DataFrame:
-    """Coerce the following shapes to a DataFrame.
-
-    The following shapes are allowed:
-    (1) A list/tuple of Series
-    (2) A list/tuple np.ndarray
-    (3) A list/tuple of scalars
-    (4) A Series of list/tuple
-    (5) pd.DataFrame
-
-    Note:
-    This method does NOT always return a new DataFrame. If a DataFrame is
-    passed in, this method will return the original object.
-
-    Parameters
-    ----------
-    val : pd.DataFrame, a tuple/list of pd.Series or a pd.Series of tuple/list
-
-    Returns
-    -------
-    pd.DataFrame
-
-    Examples
-    --------
-    >>> coerce_to_dataframe(pd.DataFrame({'a': [1, 2, 3]}), ['b'])
-       b
-    0  1
-    1  2
-    2  3
-    >>> coerce_to_dataframe(pd.Series([[1, 2, 3]]), ['a', 'b', 'c'])
-       a  b  c
-    0  1  2  3
-    >>> coerce_to_dataframe(pd.Series([range(3), range(3)]), ['a', 'b', 'c'])
-       a  b  c
-    0  0  1  2
-    1  0  1  2
-    >>> coerce_to_dataframe([pd.Series(x) for x in [1, 2, 3]], ['a', 'b', 'c'])
-       a  b  c
-    0  1  2  3
-    >>>  coerce_to_dataframe([1, 2, 3], ['a', 'b', 'c'])
-       a  b  c
-    0  1  2  3
-    """
-    if isinstance(data, pd.DataFrame):
-        result = data
-    elif isinstance(data, pd.Series):
-        num_cols = len(data.iloc[0])
-        series = [data.apply(lambda t: t[i]) for i in range(num_cols)]
-        result = pd.concat(series, axis=1)
-    elif isinstance(data, (tuple, list)):
-        if isinstance(data[0], pd.Series):
-            result = pd.concat(data, axis=1)
-        elif isinstance(data[0], np.ndarray):
-            result = pd.concat([pd.Series(v) for v in data], axis=1)
-        else:
-            # Promote scalar to Series
-            result = pd.concat([pd.Series([v]) for v in data], axis=1)
-    else:
-        raise ValueError(f"Cannot coerce to DataFrame: {data}")
-
-    result.columns = names
-    return result
 
 
 def promote_list(val: Union[V, List[V]]) -> List[V]:

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -80,9 +80,10 @@ def coerce_to_dataframe(data: Any, names: List[str]) -> pd.DataFrame:
 
     The following shapes are allowed:
     (1) A list/tuple of Series
-    (2) A list/tuple of scalars
-    (3) A Series of list/tuple
-    (4) pd.DataFrame
+    (2) A list/tuple np.ndarray
+    (3) A list/tuple of scalars
+    (4) A Series of list/tuple
+    (5) pd.DataFrame
 
     Note:
     This method does NOT always return a new DataFrame. If a DataFrame is


### PR DESCRIPTION
### Overview

This PR adds support for more flexible return types of single- and multi-column UDFs.

### Proposed Changes

Before this PR:

Supported return types for single column UDF: pd.Series
Supported return types for multi column UDF: Tuple[pd.Series]
Supported return types for multi column aggregation UDF: tuple of scalar


After this PR:

Supported return types for single column UDF: pd.Series, list, np.ndarray
Supported return types for multi column UDF: Tuple[pd.Series], List[pd.Series], Tuple[np.ndarray], List[np.ndarray]
Supported return types for multi column aggregation UDF: tuple of scalar, list of scalar, np.ndarray of scalar


The proposed return types make the UDF API a bit more flexible for the user, and are also non-ambiguous when the return type of the UDF is not an Array type.


### Tests
Added tests in test_vectorized_udf.py to exercise the above return types for elementwise, analytic, and reduction UDFs.
