### PR TITLE
WIP: Remove Ibis dialect concept, and simplify the whole compiler

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -44,39 +44,14 @@ class BaseBackend(abc.ABC):
         pass
 
     @property
-    @abc.abstractmethod
-    def translator(self):
+    def context_class(self):
+        # TODO this and builder should be attributes of a base SQL backend
         pass
 
     @property
-    def dialect(self):
-        """
-        Dialect class of the backend.
-
-        We generate it dynamically to avoid repeating the code for each
-        backend.
-        """
-        # TODO importing dialects inside the function to avoid circular
-        # imports. In the future instead of this if statement we probably
-        # want to create subclasses for each of the kinds
-        # (e.g. `BaseSQLAlchemyBackend`)
-        if self.kind == 'sqlalchemy':
-            from ibis.backends.base.sql.alchemy import AlchemyDialect
-
-            dialect_class = AlchemyDialect
-        elif self.kind in ('sql', 'pandas', 'spark'):
-            from ibis.backends.base.sql.compiler import Dialect
-
-            dialect_class = Dialect
-        else:
-            raise ValueError(
-                f'Backend class "{self.kind}" unknown. '
-                'Expected one of "sqlalchemy", "sql", '
-                '"pandas" or "spark".'
-            )
-
-        dialect_class.translator = self.translator
-        return dialect_class
+    @abc.abstractmethod
+    def translator(self):
+        pass
 
     @abc.abstractmethod
     def connect(connection_string, **options):
@@ -96,7 +71,8 @@ class BaseBackend(abc.ABC):
         """
         Compile the expression.
         """
-        context = self.dialect.make_context(params=params)
+        params = {expr.op(): value for expr, value in (params or {}).items()}
+        context = self.context_class(params=params)
         builder = self.builder(expr, context=context)
         query_ast = builder.get_result()
         # TODO make all builders return a QueryAST object

--- a/ibis/backends/base/file/__init__.py
+++ b/ibis/backends/base/file/__init__.py
@@ -7,9 +7,8 @@ from ibis.backends.pandas.core import execute_and_reset
 
 class FileClient(ibis.client.Client):
     def __init__(self, backend, root):
-        self.dialect = backend.dialect
+        super().__init__(backend=backend)
         self.extension = backend.extension
-        self.table_class = backend.table_class
         self.root = Path(str(root))
         self.dictionary = {}
 

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -1,7 +1,12 @@
-from .client import AlchemyClient, AlchemyDialect
+from .client import AlchemyClient, AlchemyQuery
 from .database import AlchemyDatabase, AlchemyDatabaseSchema, AlchemyTable
 from .datatypes import schema_from_table, table_from_schema, to_sqla_type
-from .query_builder import AlchemyQueryBuilder, build_ast, to_sqlalchemy
+from .query_builder import (
+    AlchemyQueryBuilder,
+    AlchemyTableSetFormatter,
+    build_ast,
+    to_sqlalchemy,
+)
 from .registry import (
     fixed_arity,
     get_sqla_table,
@@ -19,9 +24,10 @@ __all__ = (
     'AlchemyExprTranslator',
     'AlchemyContext',
     'AlchemyQueryBuilder',
-    'AlchemyDialect',
+    'AlchemyQuery',
     'AlchemyClient',
     'AlchemyTable',
+    'AlchemyTableSetFormatter',
     'AlchemyDatabaseSchema',
     'AlchemyDatabase',
     'AlchemyContext',

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -1,4 +1,4 @@
-from .client import AlchemyClient, AlchemyQuery
+from .client import AlchemyClient
 from .database import AlchemyDatabase, AlchemyDatabaseSchema, AlchemyTable
 from .datatypes import schema_from_table, table_from_schema, to_sqla_type
 from .query_builder import (
@@ -24,7 +24,6 @@ __all__ = (
     'AlchemyExprTranslator',
     'AlchemyContext',
     'AlchemyQueryBuilder',
-    'AlchemyQuery',
     'AlchemyClient',
     'AlchemyTable',
     'AlchemyTableSetFormatter',

--- a/ibis/backends/base/sql/alchemy/client.py
+++ b/ibis/backends/base/sql/alchemy/client.py
@@ -10,13 +10,11 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.util as util
-from ibis.backends.base.sql.compiler import Dialect
 from ibis.client import Query, SQLClient
 
 from .datatypes import to_sqla_type
 from .geospatial import geospatial_supported
 from .query_builder import build_ast
-from .translator import AlchemyExprTranslator
 
 if geospatial_supported:
     import geoalchemy2.shape as shape
@@ -103,19 +101,11 @@ class AlchemyQuery(Query):
         return _maybe_to_geodataframe(schema.apply_to(df), schema)
 
 
-class AlchemyDialect(Dialect):
-
-    translator = AlchemyExprTranslator
-
-
 class AlchemyClient(SQLClient):
-
-    dialect = AlchemyDialect
-    query_class = AlchemyQuery
     has_attachment = False
 
-    def __init__(self, con: sa.engine.Engine) -> None:
-        super().__init__()
+    def __init__(self, backend, con: sa.engine.Engine) -> None:
+        super().__init__(backend=backend)
         self.con = con
         self.meta = sa.MetaData(bind=con)
         self._inspector = sa.inspect(con)

--- a/ibis/backends/base/sql/alchemy/translator.py
+++ b/ibis/backends/base/sql/alchemy/translator.py
@@ -25,9 +25,7 @@ class AlchemyContext(QueryContext):
         return queries[0]
 
     def subcontext(self):
-        return type(self)(
-            dialect=self.dialect, parent=self, params=self.params
-        )
+        return type(self)(parent=self, params=self.params)
 
     def _to_sql(self, expr, ctx):
         return to_sqlalchemy(expr, ctx)

--- a/ibis/backends/base/sql/compiler/__init__.py
+++ b/ibis/backends/base/sql/compiler/__init__.py
@@ -6,7 +6,7 @@ from .query_builder import (
     TableSetFormatter,
     Union,
 )
-from .translator import Dialect, ExprTranslator, QueryContext
+from .translator import ExprTranslator, QueryContext
 
 __all__ = (
     'QueryBuilder',
@@ -16,7 +16,6 @@ __all__ = (
     'TableSetFormatter',
     'ExprTranslator',
     'QueryContext',
-    'Dialect',
     'DML',
     'DDL',
 )

--- a/ibis/backends/base_sql/compiler.py
+++ b/ibis/backends/base_sql/compiler.py
@@ -1,5 +1,4 @@
 from ibis.backends.base.sql.compiler import (
-    Dialect,
     ExprTranslator,
     QueryBuilder,
     QueryContext,
@@ -22,10 +21,6 @@ class BaseExprTranslator(ExprTranslator):
     context_class = BaseContext
 
 
-class BaseDialect(Dialect):
-    translator = BaseExprTranslator
-
-
 class BaseSelect(Select):
     translator = BaseExprTranslator
     table_set_formatter = BaseTableSetFormatter
@@ -44,6 +39,5 @@ def build_ast(expr, context):
 
 
 def to_sql(expr, context=None):
-    if context is None:
-        context = BaseDialect.make_context()
+    context = context or BaseContext()
     return build_ast(expr, context).queries[0].compile()

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -8,7 +8,11 @@ from .client import (
     ClickhouseQuery,
     ClickhouseTable,
 )
-from .compiler import ClickhouseExprTranslator, ClickhouseQueryBuilder
+from .compiler import (
+    ClickhouseExprTranslator,
+    ClickhouseQueryBuilder,
+    ClickhouseQueryContext,
+)
 
 try:
     import lz4  # noqa: F401
@@ -27,6 +31,7 @@ class Backend(BaseBackend):
     query_class = ClickhouseQuery
     table_class = ClickhouseDatabaseTable
     table_expr_class = ClickhouseTable
+    context_class = ClickhouseQueryContext
 
     def connect(
         self,

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -216,11 +216,6 @@ class ClickhouseClient(SQLClient):
     """An Ibis client interface that uses Clickhouse"""
 
     def __init__(self, backend, *args, **kwargs):
-        self.database_class = backend.database_class
-        self.query_class = backend.query_class
-        self.dialect = backend.dialect
-        self.table_class = backend.table_class
-        self.table_expr_class = backend.table_expr_class
         self.con = _DriverClient(*args, **kwargs)
 
     def _build_ast(self, expr, context):

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -21,20 +21,6 @@ def build_ast(expr, context):
     return builder.get_result()
 
 
-class ClickhouseSelectBuilder(SelectBuilder):
-    @property
-    def _select_class(self):
-        return ClickhouseSelect
-
-    def _convert_group_by(self, exprs):
-        return exprs
-
-
-class ClickhouseQueryBuilder(QueryBuilder):
-
-    select_builder = ClickhouseSelectBuilder
-
-
 class ClickhouseQueryContext(QueryContext):
     def _to_sql(self, expr, ctx):
         builder = ClickhouseQueryBuilder(expr, context=ctx)
@@ -44,10 +30,6 @@ class ClickhouseQueryContext(QueryContext):
 
 
 class ClickhouseSelect(Select):
-    @property
-    def translator(self):
-        return ClickhouseExprTranslator
-
     @property
     def table_set_formatter(self):
         return ClickhouseTableSetFormatter
@@ -86,6 +68,13 @@ class ClickhouseSelect(Select):
             buf.write(', {}'.format(offset))
 
         return buf.getvalue()
+
+
+class ClickhouseSelectBuilder(SelectBuilder):
+    _select_class = ClickhouseSelect
+
+    def _convert_group_by(self, exprs):
+        return exprs
 
 
 class ClickhouseTableSetFormatter(TableSetFormatter):
@@ -158,6 +147,11 @@ class ClickhouseExprTranslator(ExprTranslator):
         return '{0!s} AS {1!s}'.format(
             translated, quote_identifier(name, force=force)
         )
+
+
+class ClickhouseQueryBuilder(QueryBuilder):
+    translator = ClickhouseExprTranslator
+    select_builder = ClickhouseSelectBuilder
 
 
 rewrites = ClickhouseExprTranslator.rewrites

--- a/ibis/backends/csv/__init__.py
+++ b/ibis/backends/csv/__init__.py
@@ -110,6 +110,7 @@ class Backend(BaseBackend):
     name = 'csv'
     kind = 'pandas'
     extension = 'csv'
+    database_class = None
     table_class = CSVTable
     builder = None
     translator = PandasExprTranslator

--- a/ibis/backends/dask/client.py
+++ b/ibis/backends/dask/client.py
@@ -165,7 +165,6 @@ class DaskDatabase(client.Database):
 
 class DaskClient(client.Client):
     def __init__(self, backend, dictionary: Dict[str, dd.DataFrame]):
-        self.dialect = backend.dialect
         self.database_class = backend.database_class
         self.table_class = backend.table_class
         self.dictionary = dictionary

--- a/ibis/backends/hdf5/__init__.py
+++ b/ibis/backends/hdf5/__init__.py
@@ -59,6 +59,7 @@ class Backend(BaseBackend):
     kind = 'pandas'
     builder = None
     extension = 'h5'
+    database_class = None
     table_class = HDFTable
     translator = PandasExprTranslator
 

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -11,7 +11,11 @@ from .client import (  # noqa: F401
     ImpalaQuery,
     ImpalaTable,
 )
-from .compiler import ImpalaExprTranslator, ImpalaQueryBuilder
+from .compiler import (
+    ImpalaExprTranslator,
+    ImpalaQueryBuilder,
+    ImpalaQueryContext,
+)
 from .hdfs import HDFS, WebHDFS, hdfs_connect
 from .udf import *  # noqa: F401,F403
 
@@ -25,6 +29,7 @@ class Backend(BaseBackend):
     query_class = ImpalaQuery
     table_class = ImpalaDatabaseTable
     table_expr_class = ImpalaTable
+    context_class = ImpalaQueryContext
     HDFS = HDFS
     WebHDFS = WebHDFS
 

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -784,11 +784,7 @@ class ImpalaClient(SQLClient):
     def __init__(self, backend, con, hdfs_client=None, **params):
         import hdfs
 
-        self.dialect = backend.dialect
-        self.database_class = backend.database_class
-        self.query_class = backend.query_class
-        self.table_class = backend.table_class
-        self.table_expr_class = backend.table_expr_class
+        super().__init__(backend=backend)
 
         self.con = con
 

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -23,34 +23,6 @@ def build_ast(expr, context=None):
     return builder.get_result()
 
 
-class ImpalaSelectBuilder(SelectBuilder):
-    @property
-    def _select_class(self):
-        return ImpalaSelect
-
-
-class ImpalaQueryBuilder(QueryBuilder):
-
-    select_builder = ImpalaSelectBuilder
-
-
-class ImpalaSelect(Select):
-
-    """
-    A SELECT statement which, after execution, might yield back to the user a
-    table, array/list, or scalar value, depending on the expression that
-    generated it
-    """
-
-    @property
-    def translator(self):
-        return ImpalaExprTranslator
-
-    @property
-    def table_set_formatter(self):
-        return ImpalaTableSetFormatter
-
-
 class ImpalaTableSetFormatter(TableSetFormatter):
     def _get_join_type(self, op):
         jname = self._join_names[type(op)]
@@ -63,6 +35,20 @@ class ImpalaTableSetFormatter(TableSetFormatter):
 
     def _quote_identifier(self, name):
         return quote_identifier(name)
+
+
+class ImpalaSelect(Select):
+    """
+    A SELECT statement which, after execution, might yield back to the user a
+    table, array/list, or scalar value, depending on the expression that
+    generated it
+    """
+
+    table_set_formatter = ImpalaTableSetFormatter
+
+
+class ImpalaSelectBuilder(SelectBuilder):
+    _select_class = ImpalaSelect
 
 
 class ImpalaQueryContext(QueryContext):
@@ -81,6 +67,11 @@ class ImpalaExprTranslator(ExprTranslator):
         return '{} AS {}'.format(
             translated, quote_identifier(name, force=force)
         )
+
+
+class ImpalaQueryBuilder(QueryBuilder):
+    translator = ImpalaExprTranslator
+    select_builder = ImpalaSelectBuilder
 
 
 rewrites = ImpalaExprTranslator.rewrites

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -1,8 +1,5 @@
 from ibis.backends.base import BaseBackend
-from ibis.backends.base.sql.alchemy import (
-    AlchemyContext,
-    AlchemyQueryBuilder,
-)
+from ibis.backends.base.sql.alchemy import AlchemyContext, AlchemyQueryBuilder
 
 from .client import MySQLClient, MySQLDatabase, MySQLTable
 from .compiler import MySQLExprTranslator

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -1,8 +1,12 @@
 from ibis.backends.base import BaseBackend
-from ibis.backends.base.sql.alchemy import AlchemyQuery, AlchemyQueryBuilder
+from ibis.backends.base.sql.alchemy import (
+    AlchemyContext,
+    AlchemyQuery,
+    AlchemyQueryBuilder,
+)
 
 from .client import MySQLClient, MySQLDatabase, MySQLTable
-from .compiler import MySQLExprTranslator, MySQLQueryContext
+from .compiler import MySQLExprTranslator
 
 
 class Backend(BaseBackend):
@@ -12,7 +16,7 @@ class Backend(BaseBackend):
     translator = MySQLExprTranslator
     database_class = MySQLDatabase
     table_class = MySQLTable
-    context_class = MySQLQueryContext
+    context_class = AlchemyContext
     query_class = AlchemyQuery
 
     def connect(

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -1,7 +1,6 @@
 from ibis.backends.base import BaseBackend
 from ibis.backends.base.sql.alchemy import (
     AlchemyContext,
-    AlchemyQuery,
     AlchemyQueryBuilder,
 )
 
@@ -17,7 +16,6 @@ class Backend(BaseBackend):
     database_class = MySQLDatabase
     table_class = MySQLTable
     context_class = AlchemyContext
-    query_class = AlchemyQuery
 
     def connect(
         self,

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -1,8 +1,8 @@
 from ibis.backends.base import BaseBackend
-from ibis.backends.base.sql.alchemy import AlchemyQueryBuilder
+from ibis.backends.base.sql.alchemy import AlchemyQuery, AlchemyQueryBuilder
 
 from .client import MySQLClient, MySQLDatabase, MySQLTable
-from .compiler import MySQLExprTranslator
+from .compiler import MySQLExprTranslator, MySQLQueryContext
 
 
 class Backend(BaseBackend):
@@ -12,6 +12,8 @@ class Backend(BaseBackend):
     translator = MySQLExprTranslator
     database_class = MySQLDatabase
     table_class = MySQLTable
+    context_class = MySQLQueryContext
+    query_class = AlchemyQuery
 
     def connect(
         self,

--- a/ibis/backends/mysql/client.py
+++ b/ibis/backends/mysql/client.py
@@ -69,9 +69,6 @@ class MySQLClient(AlchemyClient):
         url=None,
         driver='pymysql',
     ):
-        self.dialect = backend.dialect
-        self.database_class = backend.database_class
-        self.table_class = backend.table_class
         if url is None:
             if driver != 'pymysql':
                 raise NotImplementedError(
@@ -89,7 +86,7 @@ class MySQLClient(AlchemyClient):
         else:
             url = sa.engine.url.make_url(url)
 
-        super().__init__(sa.create_engine(url))
+        super().__init__(backend=backend, con=sa.create_engine(url))
         self.database_name = url.database
 
     @contextlib.contextmanager

--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -14,12 +14,12 @@ from multipledispatch import Dispatcher
 from pandas.api.types import CategoricalDtype, DatetimeTZDtype
 from pkg_resources import parse_version
 
-import ibis.client as client
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+from ibis import client
 
 from .core import execute_and_reset
 
@@ -406,9 +406,7 @@ class PandasTable(ops.DatabaseTable):
 
 class PandasClient(client.Client):
     def __init__(self, backend, dictionary):
-        self.dialect = backend.dialect
-        self.database_class = backend.database_class
-        self.table_class = backend.table_class
+        super().__init__(backend=backend)
         self.dictionary = dictionary
 
     def table(self, name, schema=None):

--- a/ibis/backends/parquet/__init__.py
+++ b/ibis/backends/parquet/__init__.py
@@ -104,6 +104,7 @@ class Backend(BaseBackend):
     kind = 'pandas'
     builder = None
     extension = 'parquet'
+    database_class = None
     table_class = ParquetTable
     translator = PandasExprTranslator
 

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -1,9 +1,13 @@
 """PostgreSQL backend."""
 from ibis.backends.base import BaseBackend
-from ibis.backends.base.sql.alchemy import AlchemyQuery, AlchemyQueryBuilder
+from ibis.backends.base.sql.alchemy import (
+    AlchemyContext,
+    AlchemyQuery,
+    AlchemyQueryBuilder,
+)
 
 from .client import PostgreSQLClient, PostgreSQLDatabase, PostgreSQLTable
-from .compiler import PostgreSQLExprTranslator, PostgreSQLQueryContext
+from .compiler import PostgreSQLExprTranslator
 
 
 class Backend(BaseBackend):
@@ -13,7 +17,7 @@ class Backend(BaseBackend):
     translator = PostgreSQLExprTranslator
     database_class = PostgreSQLDatabase
     table_class = PostgreSQLTable
-    context_class = PostgreSQLQueryContext
+    context_class = AlchemyContext
     query_class = AlchemyQuery
 
     def connect(

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -1,9 +1,9 @@
 """PostgreSQL backend."""
 from ibis.backends.base import BaseBackend
-from ibis.backends.base.sql.alchemy import AlchemyQueryBuilder
+from ibis.backends.base.sql.alchemy import AlchemyQuery, AlchemyQueryBuilder
 
 from .client import PostgreSQLClient, PostgreSQLDatabase, PostgreSQLTable
-from .compiler import PostgreSQLExprTranslator
+from .compiler import PostgreSQLExprTranslator, PostgreSQLQueryContext
 
 
 class Backend(BaseBackend):
@@ -13,6 +13,8 @@ class Backend(BaseBackend):
     translator = PostgreSQLExprTranslator
     database_class = PostgreSQLDatabase
     table_class = PostgreSQLTable
+    context_class = PostgreSQLQueryContext
+    query_class = AlchemyQuery
 
     def connect(
         self,

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -1,9 +1,6 @@
 """PostgreSQL backend."""
 from ibis.backends.base import BaseBackend
-from ibis.backends.base.sql.alchemy import (
-    AlchemyContext,
-    AlchemyQueryBuilder,
-)
+from ibis.backends.base.sql.alchemy import AlchemyContext, AlchemyQueryBuilder
 
 from .client import PostgreSQLClient, PostgreSQLDatabase, PostgreSQLTable
 from .compiler import PostgreSQLExprTranslator

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -2,7 +2,6 @@
 from ibis.backends.base import BaseBackend
 from ibis.backends.base.sql.alchemy import (
     AlchemyContext,
-    AlchemyQuery,
     AlchemyQueryBuilder,
 )
 
@@ -18,7 +17,6 @@ class Backend(BaseBackend):
     database_class = PostgreSQLDatabase
     table_class = PostgreSQLTable
     context_class = AlchemyContext
-    query_class = AlchemyQuery
 
     def connect(
         self,

--- a/ibis/backends/postgres/client.py
+++ b/ibis/backends/postgres/client.py
@@ -46,9 +46,6 @@ class PostgreSQLClient(AlchemyClient):
         url: Optional[str] = None,
         driver: str = 'psycopg2',
     ):
-        self.dialect = backend.dialect
-        self.database_class = backend.database_class
-        self.table_class = backend.table_class
         if url is None:
             if driver != 'psycopg2':
                 raise NotImplementedError(
@@ -65,7 +62,7 @@ class PostgreSQLClient(AlchemyClient):
         else:
             sa_url = sa.engine.url.make_url(url)
 
-        super().__init__(sa.create_engine(sa_url))
+        super().__init__(backend=backend, con=sa.create_engine(sa_url))
         self.database_name = sa_url.database
 
     @contextlib.contextmanager

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -2,7 +2,7 @@ from ibis.backends.base import BaseBackend
 from ibis.backends.spark.client import SparkDatabase, SparkQuery, SparkTable
 
 from .client import PySparkClient
-from .compiler import PySparkExprTranslator, PySparkTable
+from .compiler import PySparkExprTranslator, PySparkQueryContext, PySparkTable
 
 
 class Backend(BaseBackend):
@@ -14,6 +14,7 @@ class Backend(BaseBackend):
     query_class = SparkQuery
     table_class = PySparkTable
     table_expr_class = SparkTable
+    context_class = PySparkQueryContext
 
     def connect(self, session):
         """

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -2,7 +2,7 @@ from ibis.backends.base import BaseBackend
 from ibis.backends.spark.client import SparkDatabase, SparkQuery, SparkTable
 
 from .client import PySparkClient
-from .compiler import PySparkExprTranslator, PySparkQueryContext, PySparkTable
+from .compiler import PySparkContext, PySparkExprTranslator, PySparkTable
 
 
 class Backend(BaseBackend):
@@ -14,7 +14,7 @@ class Backend(BaseBackend):
     query_class = SparkQuery
     table_class = PySparkTable
     table_expr_class = SparkTable
-    context_class = PySparkQueryContext
+    context_class = PySparkContext
 
     def connect(self, session):
         """

--- a/ibis/backends/spark/__init__.py
+++ b/ibis/backends/spark/__init__.py
@@ -8,7 +8,7 @@ from .client import (
     SparkQuery,
     SparkTable,
 )
-from .compiler import SparkExprTranslator, SparkQueryBuilder, SparkQueryContext
+from .compiler import SparkContext, SparkExprTranslator, SparkQueryBuilder
 from .udf import udf  # noqa: F401
 
 
@@ -21,7 +21,7 @@ class Backend(BaseBackend):
     query_class = SparkQuery
     table_class = SparkDatabaseTable
     table_expr_class = SparkTable
-    context_class = SparkQueryContext
+    context_class = SparkContext
 
     def connect(self, spark_session):
         """

--- a/ibis/backends/spark/__init__.py
+++ b/ibis/backends/spark/__init__.py
@@ -8,7 +8,7 @@ from .client import (
     SparkQuery,
     SparkTable,
 )
-from .compiler import SparkExprTranslator, SparkQueryBuilder
+from .compiler import SparkExprTranslator, SparkQueryBuilder, SparkQueryContext
 from .udf import udf  # noqa: F401
 
 
@@ -21,6 +21,7 @@ class Backend(BaseBackend):
     query_class = SparkQuery
     table_class = SparkDatabaseTable
     table_expr_class = SparkTable
+    context_class = SparkQueryContext
 
     def connect(self, spark_session):
         """

--- a/ibis/backends/spark/client.py
+++ b/ibis/backends/spark/client.py
@@ -277,11 +277,7 @@ class SparkClient(SQLClient):
     """
 
     def __init__(self, backend, session):
-        self.dialect = backend.dialect
-        self.database_class = backend.database_class
-        self.query_class = backend.query_class
-        self.table_class = backend.table_class
-        self.table_expr_class = backend.table_expr_class
+        super().__init__(backend=backend)
 
         self._context = session.sparkContext
         self._session = session

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 from ibis.backends.base import BaseBackend
-from ibis.backends.base.sql.alchemy import AlchemyQueryBuilder
+from ibis.backends.base.sql.alchemy import (
+    AlchemyContext,
+    AlchemyQuery,
+    AlchemyQueryBuilder,
+)
 
 from .client import SQLiteClient, SQLiteDatabase, SQLiteTable
 from .compiler import SQLiteExprTranslator
@@ -26,6 +30,8 @@ class Backend(BaseBackend):
     translator = SQLiteExprTranslator
     database_class = SQLiteDatabase
     table_class = SQLiteTable
+    context_class = AlchemyContext
+    query_class = AlchemyQuery
 
     def connect(self, path=None, create=False):
 

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 from ibis.backends.base import BaseBackend
-from ibis.backends.base.sql.alchemy import (
-    AlchemyContext,
-    AlchemyQueryBuilder,
-)
+from ibis.backends.base.sql.alchemy import AlchemyContext, AlchemyQueryBuilder
 
 from .client import SQLiteClient, SQLiteDatabase, SQLiteTable
 from .compiler import SQLiteExprTranslator

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -15,7 +15,6 @@
 from ibis.backends.base import BaseBackend
 from ibis.backends.base.sql.alchemy import (
     AlchemyContext,
-    AlchemyQuery,
     AlchemyQueryBuilder,
 )
 
@@ -31,7 +30,6 @@ class Backend(BaseBackend):
     database_class = SQLiteDatabase
     table_class = SQLiteTable
     context_class = AlchemyContext
-    query_class = AlchemyQuery
 
     def connect(self, path=None, create=False):
 

--- a/ibis/backends/sqlite/client.py
+++ b/ibis/backends/sqlite/client.py
@@ -315,10 +315,7 @@ class SQLiteClient(AlchemyClient):
     """The Ibis SQLite client class."""
 
     def __init__(self, backend, path=None, create=False):
-        super().__init__(sa.create_engine("sqlite://"))
-        self.dialect = backend.dialect
-        self.database_class = backend.database_class
-        self.table_class = backend.table_class
+        super().__init__(backend=backend, con=sa.create_engine("sqlite://"))
         self.name = path
         self.database_name = "base"
 

--- a/ibis/backends/sqlite/tests/conftest.py
+++ b/ibis/backends/sqlite/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 import ibis
 import ibis.expr.types as ir
+from ibis.backends.base.sql.alchemy import AlchemyContext, AlchemyQueryBuilder
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 
 
@@ -47,29 +48,18 @@ def db(con):
 
 
 @pytest.fixture
-def dialect():
-    import sqlalchemy as sa
-
-    return sa.dialects.sqlite.dialect()
-
-
-@pytest.fixture
-def translate(dialect):
-    from ibis.backends.sqlite import Backend
-
-    ibis_dialect = Backend().dialect()
-    context = ibis_dialect.make_context()
+def translate():
     return lambda expr: str(
-        ibis_dialect.translator(expr, context)
+        AlchemyQueryBuilder(expr, AlchemyContext())
         .get_result()
-        .compile(dialect=dialect, compile_kwargs={'literal_binds': True})
+        .compile(compile_kwargs={'literal_binds': True})
     )
 
 
 @pytest.fixture
-def sqla_compile(dialect):
+def sqla_compile():
     return lambda expr: str(
-        expr.compile(dialect=dialect, compile_kwargs={'literal_binds': True})
+        expr.compile(compile_kwargs={'literal_binds': True})
     )
 
 

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -149,7 +149,7 @@ class BackendTest(abc.ABC):
     def make_context(
         self, params: Optional[Mapping[ir.ValueExpr, Any]] = None
     ):
-        return self.api.dialect.make_context(params=params)
+        return self.api.context_class(params=params)
 
 
 # TODO move to the spark/pyspark backends, #2565

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -11,13 +11,11 @@ def new_schema():
     return ibis.schema([('a', 'string'), ('b', 'bool'), ('c', 'int32')])
 
 
-@pytest.mark.xfail_unsupported
+@pytest.mark.only_on_backends(
+    ['sqlite', 'postgres', 'mysql'],
+    reason="run only if backend is SQLAlchemy based",
+)
 def test_load_data_sqlalchemy(backend, con, temp_table):
-    if not isinstance(
-        con.dialect(), ibis.backends.base.sql.alchemy.AlchemyDialect
-    ):
-        pytest.skip(f'{backend} is not a SQL Alchemy Client.')
-
     sch = ibis.schema(
         [
             ('first_name', 'string'),

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -13,9 +13,7 @@ from ibis.expr.typing import TimeContext
 
 
 class Client:
-    """
-    Base class for all clients.
-    """
+    """Base class for all clients."""
 
     def __init__(self, backend):
         self.database_class = backend.database_class

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -13,6 +13,10 @@ from ibis.expr.typing import TimeContext
 
 
 class Client:
+    """
+    Base class for all clients.
+    """
+
     def __init__(self, backend):
         self.database_class = backend.database_class
         self.table_class = backend.table_class

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -21,7 +21,6 @@ class Client:
 
         if backend.kind in ('sql', 'sqlalchemy', 'spark'):
             self.context_class = backend.context_class
-            self.query_class = backend.query_class
             if backend.kind in ('sql', 'spark'):
                 self.table_expr_class = backend.table_expr_class
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -6,7 +6,7 @@ import pytest
 import ibis
 import ibis.expr.api as api
 import ibis.expr.operations as ops
-from ibis.backends.base_sql.compiler import BaseDialect, build_ast, to_sql
+from ibis.backends.base_sql.compiler import BaseContext, build_ast, to_sql
 from ibis.tests.expr.mocks import MockConnection
 
 pytest.importorskip('sqlalchemy')
@@ -247,7 +247,7 @@ FROM alltypes"""
 
 
 def _get_query(expr):
-    ast = build_ast(expr, BaseDialect.make_context())
+    ast = build_ast(expr, BaseContext())
     return ast.queries[0]
 
 

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -24,7 +24,6 @@ import ibis
 import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy import (
     AlchemyContext,
-    AlchemyDialect,
     AlchemyExprTranslator,
     schema_from_table,
     to_sqlalchemy,
@@ -78,7 +77,7 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
                 assert result.name == expected.name
 
     def _translate(self, expr, named=False):
-        context = AlchemyDialect.make_context()
+        context = AlchemyContext()
         translator = AlchemyExprTranslator(expr, context=context, named=named)
         return translator.get_result()
 
@@ -623,7 +622,7 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
         self._compare_sqla(expr, ex)
 
     def _compare_sqla(self, expr, sqla):
-        context = AlchemyContext(dialect=AlchemyDialect())
+        context = AlchemyContext()
         result = to_sqlalchemy(expr, context)
         assert str(result.compile()) == str(sqla.compile())
 


### PR DESCRIPTION
The concept of Ibis dialect was a hack that made the compiler architecture extremely cumbersome and fragile. It was in a very weird way linking a translator and a query context, and use extensively in the compiler. Instead of using the dialect, this refactoring makes the client and the query builder know which are the right translator and query context for each backend, and the helper classes (`SelectBuilder`, `Select`...) get this information when instantiated.

There are few side clean ups, whether required to make this work, or for me to understand the code better and not become crazy.

There is still a test failure I need to investigate.