### PR TITLE
Implement Clip in the Pyspark backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2779` Implement Clip in the Pyspark backend
 * :bug:`2770` Fix error when using reduction UDF that returns np.array in a grouped aggregation
 * :feature:`2753` Use `ndarray` as array representation in Pandas backend
 * :support:`2665` Move BigQuery backend to a `separate repository <https://github.com/ibis-project/ibis-bigquery>`_.

--- a/ibis/backends/dask/tests/execution/test_functions.py
+++ b/ibis/backends/dask/tests/execution/test_functions.py
@@ -127,32 +127,6 @@ def test_round_decimal_with_negative_places(t, df):
     tm.assert_series_equal(result.compute(), expected.compute())
 
 
-@pytest.mark.parametrize(
-    ('ibis_func', 'dask_func'),
-    [
-        (lambda x: x.clip(lower=0), lambda x: x.clip(lower=0)),
-        (lambda x: x.clip(lower=0.0), lambda x: x.clip(lower=0.0)),
-        (lambda x: x.clip(upper=0), lambda x: x.clip(upper=0)),
-        (
-            lambda x: x.clip(lower=x - 1, upper=x + 1),
-            lambda x: x.clip(lower=x - 1, upper=x + 1),
-        ),
-        (
-            lambda x: x.clip(lower=0, upper=1),
-            lambda x: x.clip(lower=0, upper=1),
-        ),
-        (
-            lambda x: x.clip(lower=0, upper=1.0),
-            lambda x: x.clip(lower=0, upper=1.0),
-        ),
-    ],
-)
-def test_clip(t, df, ibis_func, dask_func):
-    result = ibis_func(t.float64_with_zeros).compile()
-    expected = dask_func(df.float64_with_zeros)
-    tm.assert_series_equal(result.compute(), expected.compute())
-
-
 @pytest.mark.xfail(
     raises=NotImplementedError,
     reason='TODO - arrays - #2553'

--- a/ibis/backends/pandas/tests/execution/test_functions.py
+++ b/ibis/backends/pandas/tests/execution/test_functions.py
@@ -121,32 +121,6 @@ def test_round_decimal_with_negative_places(t, df):
 @pytest.mark.parametrize(
     ('ibis_func', 'pandas_func'),
     [
-        (lambda x: x.clip(lower=0), lambda x: x.clip(lower=0)),
-        (lambda x: x.clip(lower=0.0), lambda x: x.clip(lower=0.0)),
-        (lambda x: x.clip(upper=0), lambda x: x.clip(upper=0)),
-        (
-            lambda x: x.clip(lower=x - 1, upper=x + 1),
-            lambda x: x.clip(lower=x - 1, upper=x + 1),
-        ),
-        (
-            lambda x: x.clip(lower=0, upper=1),
-            lambda x: x.clip(lower=0, upper=1),
-        ),
-        (
-            lambda x: x.clip(lower=0, upper=1.0),
-            lambda x: x.clip(lower=0, upper=1.0),
-        ),
-    ],
-)
-def test_clip(t, df, ibis_func, pandas_func):
-    result = ibis_func(t.float64_with_zeros).execute()
-    expected = pandas_func(df.float64_with_zeros)
-    tm.assert_series_equal(result, expected)
-
-
-@pytest.mark.parametrize(
-    ('ibis_func', 'pandas_func'),
-    [
         (lambda x: x.quantile(0), lambda x: x.quantile(0)),
         (lambda x: x.quantile(1), lambda x: x.quantile(1)),
         (

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -452,5 +452,7 @@ def test_random(con):
 )
 def test_clip(alltypes, df, ibis_func, pandas_func):
     result = ibis_func(alltypes.int_col).execute()
-    expected = pandas_func(df.int_col)
-    tm.assert_series_equal(result, expected)
+    expected = pandas_func(df.int_col).astype(result.dtype)
+    # Names won't match in the Pyspark backend since Pyspark
+    # gives 'tmp' name when executing a ColumnExpr
+    tm.assert_series_equal(result, expected, check_names=False)

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -4,6 +4,7 @@ import operator
 
 import numpy as np
 import pandas as pd
+import pandas.testing as tm
 import pytest
 from pytest import param
 
@@ -425,3 +426,31 @@ def test_random(con):
     assert isinstance(result2, float)
     assert 0 <= result2 < 1
     assert result != result2
+
+
+@pytest.mark.only_on_backends(['pandas', 'dask', 'pyspark'])
+@pytest.mark.xfail_unsupported
+@pytest.mark.parametrize(
+    ('ibis_func', 'pandas_func'),
+    [
+        (lambda x: x.clip(lower=0), lambda x: x.clip(lower=0)),
+        (lambda x: x.clip(lower=0.0), lambda x: x.clip(lower=0.0)),
+        (lambda x: x.clip(upper=0), lambda x: x.clip(upper=0)),
+        (
+            lambda x: x.clip(lower=x - 1, upper=x + 1),
+            lambda x: x.clip(lower=x - 1, upper=x + 1),
+        ),
+        (
+            lambda x: x.clip(lower=0, upper=1),
+            lambda x: x.clip(lower=0, upper=1),
+        ),
+        (
+            lambda x: x.clip(lower=0, upper=1.0),
+            lambda x: x.clip(lower=0, upper=1.0),
+        ),
+    ],
+)
+def test_clip(alltypes, df, ibis_func, pandas_func):
+    result = ibis_func(alltypes.int_col).execute()
+    expected = pandas_func(df.int_col)
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
### Proposed Change

Implement support to be able to execute `clip` in the Pyspark backend. For example:

```
t.col.clip(lower=0, upper=10).execute()
```

### Tests
Moved existing pandas and dask clip tests into test_numeric.py to call on pyspark as well.