### PR TITLE
Pin bitarray version to 2.0.1 to fix CI

### DIFF
--- a/ci/deps/impala.yml
+++ b/ci/deps/impala.yml
@@ -1,5 +1,5 @@
 impyla
-bitarray>=2
+bitarray=2.0.1
 requests
 thrift_sasl
 python-hdfs


### PR DESCRIPTION
Issue to investigate failures: https://github.com/ibis-project/ibis/issues/2780

Noticed a maybe related PR here: https://github.com/ibis-project/ibis/pull/2737