### PR TITLE
ENH: Let dask handle scalar projection

### DIFF
--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -60,9 +60,7 @@ def compute_projection_scalar_expr(
         for t in op.root_tables()
     )
     scalar = execute(expr, scope=scope, **kwargs)
-    result = pandas.Series([scalar], name=name).repeat(len(data.index))
-    result.index = data.index
-    return dd.from_pandas(result, npartitions=data.npartitions)
+    return data.assign(**{name: scalar})[name]
 
 
 @compute_projection.register(ir.ColumnExpr, ops.Selection, dd.DataFrame)


### PR DESCRIPTION
Instead of constructing a `pd.Series` in memory and forcing computation to get the length of the dask index, we assign the scalar into the dataframe directly and pull out just the series. This also ensures that the `dd.Series` we get back from `compute_projection_scalar_expr` will match the rest of the selections in `compute_projections` (in terms of `n_partitions`, `known_divisions`, etc