### PR TITLE
WIP: Unbounded windows in the dask backend

### DIFF
--- a/ibis/backends/dask/execution/__init__.py
+++ b/ibis/backends/dask/execution/__init__.py
@@ -11,3 +11,4 @@ from .selection import *  # noqa: F401,F403
 from .strings import *  # noqa: F401,F403
 from .structs import *  # noqa: F401,F403
 from .temporal import *  # noqa: F401,F403
+from .window import *  # noqa: F401,F403

--- a/ibis/backends/dask/execution/window.py
+++ b/ibis/backends/dask/execution/window.py
@@ -1,0 +1,128 @@
+import operator
+from typing import Optional
+
+import dask.dataframe as dd
+
+import ibis.expr.operations as ops
+import ibis.expr.window as win
+from ibis.backends.pandas.execution.window import (
+    _post_process_empty,
+    _post_process_group_by,
+    compute_time_context,
+    get_aggcontext,
+)
+from ibis.expr.scope import Scope
+from ibis.expr.typing import TimeContext
+
+from ..core import execute
+from ..dispatch import execute_node, pre_execute
+
+
+@execute_node.register(ops.WindowOp, dd.Series, win.Window)
+def execute_window_op(
+    op,
+    data,
+    window,
+    scope: Scope = None,
+    timecontext: Optional[TimeContext] = None,
+    aggcontext=None,
+    clients=None,
+    **kwargs,
+):
+    if not (window.preceding is None and window.following is None):
+        raise NotImplementedError(
+            "Window operations are unsuported in the dask backend"
+        )
+
+    operand = op.expr
+    # pre execute "manually" here because otherwise we wouldn't pickup
+    # relevant scope changes from the child operand since we're managing
+    # execution of that by hand
+    operand_op = operand.op()
+
+    adjusted_timecontext = None
+    if timecontext:
+        arg_timecontexts = compute_time_context(
+            op, timecontext=timecontext, clients=clients
+        )
+        # timecontext is the original time context required by parent node
+        # of this WindowOp, while adjusted_timecontext is the adjusted context
+        # of this Window, since we are doing a manual execution here, use
+        # adjusted_timecontext in later execution phases
+        adjusted_timecontext = arg_timecontexts[0]
+
+    pre_executed_scope = pre_execute(
+        operand_op,
+        *clients,
+        scope=scope,
+        timecontext=adjusted_timecontext,
+        aggcontext=aggcontext,
+        **kwargs,
+    )
+    scope = scope.merge_scope(pre_executed_scope)
+    (root,) = op.root_tables()
+    root_expr = root.to_expr()
+
+    data = execute(
+        root_expr,
+        scope=scope,
+        timecontext=adjusted_timecontext,
+        clients=clients,
+        aggcontext=aggcontext,
+        **kwargs,
+    )
+
+    group_by = window._group_by
+    grouping_keys = [
+        key_op.name
+        if isinstance(key_op, ops.TableColumn)
+        else execute(
+            key,
+            scope=scope,
+            clients=clients,
+            timecontext=adjusted_timecontext,
+            aggcontext=aggcontext,
+            **kwargs,
+        )
+        for key, key_op in zip(
+            group_by, map(operator.methodcaller('op'), group_by)
+        )
+    ]
+
+    if group_by:
+        source = data.groupby(grouping_keys, sort=False)
+        post_process = _post_process_group_by
+    else:
+        source = data
+        post_process = _post_process_empty
+
+    new_scope = scope.merge_scopes(
+        [
+            Scope({t: source}, adjusted_timecontext)
+            for t in operand.op().root_tables()
+        ],
+        overwrite=True,
+    )
+
+    aggcontext = get_aggcontext(
+        window,
+        scope=scope,
+        operand=operand,
+        parent=source,
+        group_by=grouping_keys,
+        order_by=[],
+        **kwargs,
+    )
+    result = execute(
+        operand,
+        scope=new_scope,
+        timecontext=adjusted_timecontext,
+        aggcontext=aggcontext,
+        clients=clients,
+        **kwargs,
+    )
+    result = post_process(
+        result, data, [], grouping_keys, adjusted_timecontext,
+    )
+
+    return result

--- a/ibis/backends/dask/tests/test_udf.py
+++ b/ibis/backends/dask/tests/test_udf.py
@@ -260,7 +260,9 @@ def test_udaf_analytic_groupby(con, t, df):
     def f(s):
         return s.sub(s.mean()).div(s.std())
 
-    expected = df.groupby('key').c.transform(f)
+    # these are named differenty.
+    # where can I get names from?
+    expected = df.groupby('key').c.transform(f).compute()
     tm.assert_series_equal(result, expected)
 
 
@@ -492,14 +494,11 @@ def test_array_return_type_reduction(con, t, df, qs):
     assert list(result) == expected.tolist()
 
 
-@pytest.mark.xfail(
-    raises=NotImplementedError, reason='TODO - windowing - #2553'
-)
 def test_array_return_type_reduction_window(con, t, df, qs):
     """Tests reduction UDF returning an array, used over a window."""
     expr = quantiles(t.b, quantiles=qs).over(ibis.window())
     result = expr.execute()
-    expected_raw = df.b.quantile(qs).tolist()
+    expected_raw = df.b.quantile(qs).compute().tolist()
     expected = pd.Series([expected_raw] * len(df))
     tm.assert_series_equal(result, expected)
 


### PR DESCRIPTION
**Status**: Rough cut - Need to fix newly broken tests (because we don't hard fail them anymore) and port some pandas tests. Add more utils testing. Consider bumping dask. 

The goal of this PR is to add unbounded window support to the dask backend. Unbounded windows provide a good skeleton for the rest of windowing support and allow the usage of `window()`. 