### PR TITLE
Remove unneeded check about arrays in coerce_to_dataframe

### DIFF
--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -311,10 +311,6 @@ def coerce_to_dataframe(
     0  1  2  3
     dtypes: [int32, int32, int32]
     """
-    # We don't want to coerce any output that is intended as
-    # an array shape.
-    if any(isinstance(t, dt.Array) for t in output_type.types):
-        return data
     if isinstance(data, pd.DataFrame):
         result = data
     elif isinstance(data, pd.Series):


### PR DESCRIPTION
This logic was mistakenly not removed after a refactor in a commit in this PR: https://github.com/ibis-project/ibis/pull/2776/
