### PR TITLE
CLN: Removing Query class

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :support:`2789` Simplification of data fetching. Backends don't need to implement `Query` anymore
 * :feature:`2792` Infer categorical and decimal Series to more specific Ibis types in Pandas backend
 * :feature:`2790` Add `startswith` and `endswith` operations
 * :feature:`2776` :feature:`2797` Allow more flexible return type for UDFs

--- a/ibis/backends/base/sql/alchemy/client.py
+++ b/ibis/backends/base/sql/alchemy/client.py
@@ -300,8 +300,8 @@ class AlchemyClient(SQLClient):
         return _AlchemyProxy(self.con.execute(query))
 
     @_invalidates_reflection_cache
-    def raw_sql(self, query: str, results: bool = False, **kwargs):
-        return super().raw_sql(query, results=results, **kwargs)
+    def raw_sql(self, query: str):
+        return super().raw_sql(query)
 
     def _build_ast(self, expr, context):
         return build_ast(expr, context)

--- a/ibis/backends/base/sql/alchemy/client.py
+++ b/ibis/backends/base/sql/alchemy/client.py
@@ -11,7 +11,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.util as util
 from ibis.backends.base.sql.compiler import Dialect
-from ibis.client import Query, SQLClient
+from ibis.client import SQLClient
 
 from .datatypes import to_sqla_type
 from .geospatial import geospatial_supported
@@ -92,17 +92,6 @@ def _maybe_to_geodataframe(df, schema):
     return df
 
 
-class AlchemyQuery(Query):
-    def _fetch(self, cursor):
-        df = pd.DataFrame.from_records(
-            cursor.proxy.fetchall(),
-            columns=cursor.proxy.keys(),
-            coerce_float=True,
-        )
-        schema = self.schema()
-        return _maybe_to_geodataframe(schema.apply_to(df), schema)
-
-
 class AlchemyDialect(Dialect):
 
     translator = AlchemyExprTranslator
@@ -111,7 +100,6 @@ class AlchemyDialect(Dialect):
 class AlchemyClient(SQLClient):
 
     dialect = AlchemyDialect
-    query_class = AlchemyQuery
     has_attachment = False
 
     def __init__(self, con: sa.engine.Engine) -> None:
@@ -127,6 +115,14 @@ class AlchemyClient(SQLClient):
         if self._reflection_cache_is_dirty:
             self._inspector.info_cache.clear()
         return self._inspector
+
+    def fetch_from_cursor(self, cursor, schema):
+        df = pd.DataFrame.from_records(
+            cursor.proxy.fetchall(),
+            columns=cursor.proxy.keys(),
+            coerce_float=True,
+        )
+        return _maybe_to_geodataframe(schema.apply_to(df), schema)
 
     @contextlib.contextmanager
     def begin(self):
@@ -304,8 +300,8 @@ class AlchemyClient(SQLClient):
         return _AlchemyProxy(self.con.execute(query))
 
     @_invalidates_reflection_cache
-    def raw_sql(self, query: str, results: bool = False):
-        return super().raw_sql(query, results=results)
+    def raw_sql(self, query: str, results: bool = False, **kwargs):
+        return super().raw_sql(query, results=results, **kwargs)
 
     def _build_ast(self, expr, context):
         return build_ast(expr, context)

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -5,7 +5,6 @@ from .client import (
     ClickhouseClient,
     ClickhouseDatabase,
     ClickhouseDatabaseTable,
-    ClickhouseQuery,
     ClickhouseTable,
 )
 from .compiler import ClickhouseExprTranslator, ClickhouseQueryBuilder
@@ -24,7 +23,6 @@ class Backend(BaseBackend):
     builder = ClickhouseQueryBuilder
     translator = ClickhouseExprTranslator
     database_class = ClickhouseDatabase
-    query_class = ClickhouseQuery
     table_class = ClickhouseDatabaseTable
     table_expr_class = ClickhouseTable
 

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -191,14 +191,14 @@ class ClickhouseClient(SQLClient):
     def log(self, msg):
         log(msg)
 
-    def fetch_from_cursor(self, cursor):
+    def fetch_from_cursor(self, cursor, schema):
         data, colnames, _ = cursor
         if not len(data):
             # handle empty resultset
             return pd.DataFrame([], columns=colnames)
 
         df = pd.DataFrame.from_dict(OrderedDict(zip(colnames, data)))
-        return self.schema().apply_to(df)
+        return schema.apply_to(df)
 
     def close(self):
         """Close Clickhouse connection and drop any temporary objects"""

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -212,9 +212,9 @@ class ClickhouseClient(SQLClient):
     def fetch_from_cursor(self, cursor, schema):
         if not len(cursor):
             # handle empty resultset
-            return pd.DataFrame([], columns=schema.colnames)
+            return pd.DataFrame([], columns=schema.names)
 
-        df = pd.DataFrame.from_dict(OrderedDict(zip(schema.colnames, cursor)))
+        df = pd.DataFrame.from_dict(OrderedDict(zip(schema.names, cursor)))
         return schema.apply_to(df)
 
     def close(self):

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -142,9 +142,6 @@ class ClickhouseTable(ir.TableExpr, DatabaseEntity):
     def name(self):
         return self.op().name
 
-    def _execute(self, stmt):
-        return self._client._execute(stmt)
-
     def insert(self, obj, **kwargs):
         from .identifiers import quote_identifier
 
@@ -261,7 +258,7 @@ class ClickhouseClient(SQLClient):
                 return self.list_tables(like=like, database=database)
             statement += " LIKE '{0}'".format(like)
 
-        data, _, _ = self.raw_sql(statement, results=True)
+        data, _, _ = self._execute(statement, results=True)
         return data[0]
 
     def set_database(self, name):
@@ -303,7 +300,7 @@ class ClickhouseClient(SQLClient):
         if like:
             statement += " WHERE name LIKE '{0}'".format(like)
 
-        data, _, _ = self.raw_sql(statement, results=True)
+        data, _, _ = self._execute(statement, results=True)
         return data[0]
 
     def get_schema(self, table_name, database=None):
@@ -322,7 +319,7 @@ class ClickhouseClient(SQLClient):
         """
         qualified_name = self._fully_qualified_name(table_name, database)
         query = 'DESC {0}'.format(qualified_name)
-        data, _, _ = self.raw_sql(query, results=True)
+        data, _, _ = self._execute(query, results=True)
 
         colnames, coltypes = data[:2]
         coltypes = list(map(ClickhouseDataType.parse, coltypes))

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -222,10 +222,6 @@ class ClickhouseClient(SQLClient):
             external_tables=external_tables_list,
         )
 
-    def ast_schema(self, query_ast, **kwargs):
-        query = query_ast.compile()
-        return self._get_schema_using_query(query, **kwargs)
-
     def fetch_from_cursor(self, cursor, schema):
         data, columns = cursor
         if not len(data):

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -195,12 +195,14 @@ class ClickhouseClient(SQLClient):
             query, columnar=True, with_column_types=True, external_tables=[],
         )
         data, columns = response
-        data._columns = columns
         return data
 
     def ast_schema(self, query_ast):
         query = query_ast.compile()
-        columns = self.raw_sql(query)._columns
+        response = self.con.execute(
+            query, columnar=True, with_column_types=True, external_tables=[],
+        )
+        data, columns = response
 
         colnames, typenames = zip(*columns)
         coltypes = list(map(ClickhouseDataType.parse, typenames))

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -222,6 +222,10 @@ class ClickhouseClient(SQLClient):
             external_tables=external_tables_list,
         )
 
+    def ast_schema(self, query_ast, external_tables={}):
+        # Allowing signature to accept `external_tables`
+        return super().ast_schema(query_ast)
+
     def fetch_from_cursor(self, cursor, schema):
         data, columns = cursor
         if not len(data):

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -8,7 +8,6 @@ from .client import (  # noqa: F401
     ImpalaConnection,
     ImpalaDatabase,
     ImpalaDatabaseTable,
-    ImpalaQuery,
     ImpalaTable,
 )
 from .compiler import ImpalaExprTranslator, ImpalaQueryBuilder
@@ -22,7 +21,6 @@ class Backend(BaseBackend):
     builder = ImpalaQueryBuilder
     translator = ImpalaExprTranslator
     database_class = ImpalaDatabase
-    query_class = ImpalaQuery
     table_class = ImpalaDatabaseTable
     table_expr_class = ImpalaTable
     HDFS = HDFS

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -1863,7 +1863,7 @@ class ImpalaClient(SQLClient):
         stmt = self._table_command(
             'DESCRIBE FORMATTED', name, database=database
         )
-        result = self.fetch_from_cursor(self.raw_sql(stmt), schema=None)
+        result = self._exec_statement(stmt)
 
         # Leave formatting to pandas
         for c in result.columns:
@@ -1883,11 +1883,11 @@ class ImpalaClient(SQLClient):
         database : string, optional
         """
         stmt = self._table_command('SHOW FILES IN', name, database=database)
-        return self.raw_sql(stmt)
+        return self._exec_statement(stmt)
 
     def list_partitions(self, name, database=None):
         stmt = self._table_command('SHOW PARTITIONS', name, database=database)
-        return self.raw_sql(stmt)
+        return self._exec_statement(stmt)
 
     def table_stats(self, name, database=None):
         """
@@ -1895,7 +1895,7 @@ class ImpalaClient(SQLClient):
         ImpalaTable.stats
         """
         stmt = self._table_command('SHOW TABLE STATS', name, database=database)
-        return self.raw_sql(stmt)
+        return self._exec_statement(stmt)
 
     def column_stats(self, name, database=None):
         """
@@ -1905,7 +1905,10 @@ class ImpalaClient(SQLClient):
         stmt = self._table_command(
             'SHOW COLUMN STATS', name, database=database
         )
-        return self.raw_sql(stmt)
+        return self._exec_statement(stmt)
+
+    def _exec_statement(self, stmt):
+        return self.fetch_from_cursor(self.raw_sql(stmt), schema=None)
 
     def _table_command(self, cmd, name, database=None):
         qualified_name = self._fully_qualified_name(name, database)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -1005,6 +1005,7 @@ class ImpalaClient(SQLClient):
 
         cur = self.raw_sql(statement)
         results = self._get_list(cur)
+        raise ValueError(str(dir(cur)))
         cur.close()
 
         return results

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -515,7 +515,7 @@ class ImpalaTable(ir.TableExpr, DatabaseEntity):
             partition_schema=partition_schema,
             overwrite=overwrite,
         )
-        return self.raw_sql(statement)
+        return self._client.raw_sql(statement.compile())
 
     def load_data(self, path, overwrite=False, partition=None):
         """
@@ -547,7 +547,7 @@ class ImpalaTable(ir.TableExpr, DatabaseEntity):
             partition_schema=partition_schema,
         )
 
-        return self.raw_sql(stmt)
+        return self.raw_sql(stmt.compile())
 
     @property
     def name(self):
@@ -1883,11 +1883,11 @@ class ImpalaClient(SQLClient):
         database : string, optional
         """
         stmt = self._table_command('SHOW FILES IN', name, database=database)
-        return self._exec_statement(stmt)
+        return self.raw_sql(stmt)
 
     def list_partitions(self, name, database=None):
         stmt = self._table_command('SHOW PARTITIONS', name, database=database)
-        return self._exec_statement(stmt)
+        return self.raw_sql(stmt)
 
     def table_stats(self, name, database=None):
         """
@@ -1895,7 +1895,7 @@ class ImpalaClient(SQLClient):
         ImpalaTable.stats
         """
         stmt = self._table_command('SHOW TABLE STATS', name, database=database)
-        return self._exec_statement(stmt)
+        return self.raw_sql(stmt)
 
     def column_stats(self, name, database=None):
         """
@@ -1905,13 +1905,7 @@ class ImpalaClient(SQLClient):
         stmt = self._table_command(
             'SHOW COLUMN STATS', name, database=database
         )
-        return self._exec_statement(stmt)
-
-    def _exec_statement(self, stmt, adapter=None):
-        result = self.raw_sql(stmt)
-        if adapter is not None:
-            result = adapter(result)
-        return result
+        return self.raw_sql(stmt)
 
     def _table_command(self, cmd, name, database=None):
         qualified_name = self._fully_qualified_name(name, database)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -789,7 +789,9 @@ class ImpalaClient(SQLClient):
         batches = cursor.fetchall(columnar=True)
         names = [x[0] for x in cursor.description]
         df = _column_batches_to_dataframe(names, batches)
-        return schema.apply_to(df)
+        if schema:
+            return schema.apply_to(df)
+        return df
 
     def _build_ast(self, expr, context):
         return build_ast(expr, context)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -1908,7 +1908,9 @@ class ImpalaClient(SQLClient):
         return self._exec_statement(stmt)
 
     def _exec_statement(self, stmt):
-        return self.fetch_from_cursor(self.raw_sql(stmt), schema=None)
+        return self.fetch_from_cursor(
+            self.raw_sql(stmt, results=True), schema=None
+        )
 
     def _table_command(self, cmd, name, database=None):
         qualified_name = self._fully_qualified_name(name, database)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -771,7 +771,6 @@ class ImpalaClient(SQLClient):
 
         self.dialect = backend.dialect
         self.database_class = backend.database_class
-        self.query_class = backend.query_class
         self.table_class = backend.table_class
         self.table_expr_class = backend.table_expr_class
 

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -1410,7 +1410,7 @@ class ImpalaClient(SQLClient):
         if persist:
             t = self.table(qualified_name)
         else:
-            schema = self._get_table_schema(qualified_name)
+            schema = self.get_schema(qualified_name)
             node = ImpalaTemporaryTable(qualified_name, schema, self)
             t = self.table_expr_class(node)
 
@@ -1558,9 +1558,6 @@ class ImpalaClient(SQLClient):
         """
         statement = ddl.CacheTable(table_name, database=database, pool=pool)
         self.raw_sql(statement)
-
-    def _get_table_schema(self, tname):
-        return self.get_schema(tname)
 
     def _get_schema_using_query(self, query):
         cur = self.raw_sql(query)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -881,7 +881,7 @@ class ImpalaClient(SQLClient):
 
         cur = self.raw_sql(statement)
         result = self._get_list(cur)
-        cur.close()
+        cur.release()
 
         return result
 
@@ -1006,7 +1006,7 @@ class ImpalaClient(SQLClient):
         cur = self.raw_sql(statement)
         results = self._get_list(cur)
         raise ValueError(str(dir(cur)))
-        cur.close()
+        cur.release()
 
         return results
 
@@ -1044,7 +1044,7 @@ class ImpalaClient(SQLClient):
     def version(self):
         cur = self.raw_sql('select version()')
         raw = self._get_list(cur)[0]
-        cur.close()
+        cur.release()
 
         vstring = raw.split()[2]
         return parse_version(vstring)
@@ -1568,7 +1568,7 @@ class ImpalaClient(SQLClient):
         # resets the state of the cursor and closes operation
         cur.fetchall()
         names, ibis_types = self._adapt_types(cur.description)
-        cur.close()
+        cur.release()
 
         # per #321; most Impala tables will be lower case already, but Avro
         # data, depending on the version of Impala, might have field names in
@@ -1717,7 +1717,7 @@ class ImpalaClient(SQLClient):
         statement = ddl.ListFunction(database, like=like, aggregate=False)
         cur = self.raw_sql(statement)
         result = self._get_udfs(cur, udf.ImpalaUDF)
-        cur.close()
+        cur.release()
         return result
 
     def list_udas(self, database=None, like=None):
@@ -1734,7 +1734,7 @@ class ImpalaClient(SQLClient):
         statement = ddl.ListFunction(database, like=like, aggregate=True)
         cur = self.raw_sql(statement)
         result = self._get_udfs(cur, udf.ImpalaUDA)
-        cur.close()
+        cur.release()
 
         return result
 

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -547,7 +547,7 @@ class ImpalaTable(ir.TableExpr, DatabaseEntity):
             partition_schema=partition_schema,
         )
 
-        return self.raw_sql(stmt.compile())
+        return self._client.raw_sql(stmt.compile())
 
     @property
     def name(self):

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -789,7 +789,7 @@ class ImpalaClient(SQLClient):
         batches = cursor.fetchall(columnar=True)
         names = [x[0] for x in cursor.description]
         df = _column_batches_to_dataframe(names, batches)
-        return df
+        return schema.apply_to(df)
 
     def _build_ast(self, expr, context):
         return build_ast(expr, context)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -1863,7 +1863,7 @@ class ImpalaClient(SQLClient):
         stmt = self._table_command(
             'DESCRIBE FORMATTED', name, database=database
         )
-        result = self.raw_sql(stmt)
+        result = self.fetch_from_cursor(self.raw_sql(stmt), schema=None)
 
         # Leave formatting to pandas
         for c in result.columns:

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -1005,7 +1005,6 @@ class ImpalaClient(SQLClient):
 
         cur = self.raw_sql(statement)
         results = self._get_list(cur)
-        raise ValueError(str(dir(cur)))
         cur.release()
 
         return results

--- a/ibis/backends/impala/tests/test_patched.py
+++ b/ibis/backends/impala/tests/test_patched.py
@@ -7,7 +7,7 @@ pytestmark = pytest.mark.impala
 
 
 def patch_execute(con):
-    return mock.patch.object(con, '_execute', wraps=con._execute)
+    return mock.patch.object(con, 'raw_sql', wraps=con.raw_sql)
 
 
 def test_invalidate_metadata(con, test_data_db):

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1,5 +1,5 @@
 from ibis.backends.base import BaseBackend
-from ibis.backends.spark.client import SparkDatabase, SparkQuery, SparkTable
+from ibis.backends.spark.client import SparkDatabase, SparkTable
 
 from .client import PySparkClient
 from .compiler import PySparkExprTranslator, PySparkTable
@@ -11,7 +11,6 @@ class Backend(BaseBackend):
     builder = None
     translator = PySparkExprTranslator
     database_class = SparkDatabase
-    query_class = SparkQuery
     table_class = PySparkTable
     table_expr_class = SparkTable
 

--- a/ibis/backends/spark/__init__.py
+++ b/ibis/backends/spark/__init__.py
@@ -1,13 +1,7 @@
 """Spark backend."""
 from ibis.backends.base import BaseBackend
 
-from .client import (
-    SparkClient,
-    SparkDatabase,
-    SparkDatabaseTable,
-    SparkQuery,
-    SparkTable,
-)
+from .client import SparkClient, SparkDatabase, SparkDatabaseTable, SparkTable
 from .compiler import SparkExprTranslator, SparkQueryBuilder
 from .udf import udf  # noqa: F401
 
@@ -18,7 +12,6 @@ class Backend(BaseBackend):
     builder = SparkQueryBuilder
     translator = SparkExprTranslator
     database_class = SparkDatabase
-    query_class = SparkQuery
     table_class = SparkDatabaseTable
     table_expr_class = SparkTable
 

--- a/ibis/backends/spark/client.py
+++ b/ibis/backends/spark/client.py
@@ -213,7 +213,7 @@ class SparkTable(ir.TableExpr):
         new_qualified_name = _fully_qualified_name(new_name, self._database)
 
         statement = ddl.RenameTable(self._qualified_name, new_name)
-        self._client._client.execute(statement.compile())
+        self._client.execute(statement.compile())
 
         op = self.op().change_name(new_qualified_name)
         return type(self)(op)

--- a/ibis/backends/spark/client.py
+++ b/ibis/backends/spark/client.py
@@ -194,7 +194,7 @@ class SparkTable(ir.TableExpr):
         statement = ddl.InsertSelect(
             self._qualified_name, select, overwrite=overwrite
         )
-        return self._client.execute(statement.compile())
+        return self._client.raw_sql(statement.compile())
 
     def rename(self, new_name):
         """
@@ -213,7 +213,7 @@ class SparkTable(ir.TableExpr):
         new_qualified_name = _fully_qualified_name(new_name, self._database)
 
         statement = ddl.RenameTable(self._qualified_name, new_name)
-        self._client.execute(statement.compile())
+        self._client.raw_sql(statement.compile())
 
         op = self.op().change_name(new_qualified_name)
         return type(self)(op)
@@ -234,7 +234,7 @@ class SparkTable(ir.TableExpr):
         stmt = ddl.AlterTable(
             self._qualified_name, tbl_properties=tbl_properties
         )
-        return self._client.execute(stmt.compile())
+        return self._client.raw_sql(stmt.compile())
 
 
 class SparkClient(SQLClient):

--- a/ibis/backends/spark/client.py
+++ b/ibis/backends/spark/client.py
@@ -284,7 +284,7 @@ class SparkClient(SQLClient):
 
         for node in udf_nodes_unique:
             stmt = ddl.DropFunction(type(node).__name__, must_exist=True)
-            self._execute(stmt.compile())
+            self.raw_sql(stmt.compile())
 
         return result
 

--- a/ibis/backends/spark/client.py
+++ b/ibis/backends/spark/client.py
@@ -278,15 +278,13 @@ class SparkClient(SQLClient):
 
         # register UDFs in pyspark
         for node in udf_nodes_unique:
-            self.client._session.udf.register(
-                type(node).__name__, node.udf_func
-            )
+            self._session.udf.register(type(node).__name__, node.udf_func)
 
         result = super().execute(expr, params, limit, **kwargs)
 
         for node in udf_nodes_unique:
             stmt = ddl.DropFunction(type(node).__name__, must_exist=True)
-            self.client._execute(stmt.compile())
+            self._execute(stmt.compile())
 
         return result
 

--- a/ibis/backends/spark/client.py
+++ b/ibis/backends/spark/client.py
@@ -302,9 +302,6 @@ class SparkClient(SQLClient):
         """
         return self._catalog.currentDatabase()
 
-    def _get_table_schema(self, table_name):
-        return self.get_schema(table_name)
-
     def _get_schema_using_query(self, query):
         cur = self.raw_sql(query)
         return spark_dataframe_schema(cur.query)
@@ -340,7 +337,7 @@ class SparkClient(SQLClient):
 
         qualified_name = _fully_qualified_name(name, database)
 
-        schema = self._get_table_schema(qualified_name)
+        schema = self.get_schema(qualified_name)
         node = self.table_class(qualified_name, schema, self)
         return self.table_expr_class(node)
 

--- a/ibis/backends/spark/tests/test_ddl.py
+++ b/ibis/backends/spark/tests/test_ddl.py
@@ -221,9 +221,7 @@ def test_change_properties(con, table):
     props = {'foo': '1', 'bar': '2'}
 
     table.alter(tbl_properties=props)
-    tbl_props_rows = con.raw_sql(
-        "show tblproperties {}".format(table.name), results=True
-    ).fetchall()
+    tbl_props_rows = con.raw_sql(f"show tblproperties {table.name}").fetchall()
     for row in tbl_props_rows:
         key = row.key
         value = row.value

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -73,8 +73,7 @@ def test_query_schema(backend, con, alltypes, expr_fn, expected):
 
     # we might need a public API for it
     ast = con._build_ast(expr, backend.make_context())
-    query = con.query_class(con, ast)
-    schema = query.schema()
+    schema = con.ast_schema(ast)
 
     # clickhouse columns has been defined as non-nullable
     # whereas other backends don't support non-nullable columns yet
@@ -84,7 +83,7 @@ def test_query_schema(backend, con, alltypes, expr_fn, expected):
             for name, dtype in expected
         ]
     )
-    assert query.schema().equals(expected)
+    assert schema.equals(expected)
 
 
 @pytest.mark.parametrize(

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -143,15 +143,14 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         schema = self.ast_schema(query_ast)
         result = self.fetch_from_cursor(cursor, schema)
 
-        if hasattr(query_ast, 'result_handler'):
-            result = query_ast.result_handler(result)
+        if hasattr(getattr(query_ast, 'dml', query_ast), 'result_handler'):
+            result = query_ast.dml.result_handler(result)
 
         return result
 
     @abc.abstractmethod
     def fetch_from_cursor(self, cursor, schema):
         """Fetch data from cursor."""
-        pass
 
     def ast_schema(self, query_ast):
         """Return the schema of the expression.

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -44,7 +44,7 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         table : TableExpr
         """
         qualified_name = self._fully_qualified_name(name, database)
-        schema = self._get_table_schema(qualified_name)
+        schema = self.get_schema(qualified_name)
         node = self.table_class(qualified_name, schema, self)
         return self.table_expr_class(node)
 

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -111,7 +111,7 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         Backend cursor
         """
         cursor = self.con.execute(query)
-        if query.upper().startswith('SELECT'):
+        if cursor:
             return cursor
         cursor.release()
 

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -95,7 +95,7 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         schema = self._get_schema_using_query(limited_query)
         return ops.SQLQueryResult(query, schema, self).to_expr()
 
-    def raw_sql(self, query):
+    def raw_sql(self, query: str):
         """Execute a given query string.
 
         Could have unexpected results if the query modifies the behavior of
@@ -108,9 +108,12 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
 
         Returns
         -------
-        cur : Cursor
+        Backend cursor
         """
-        return self.con.execute(query)
+        cursor = self.con.execute(query)
+        if query.upper().startswith('SELECT'):
+            return cursor
+        cursor.release()
 
     def execute(self, expr, params=None, limit='default', **kwargs):
         """Compile and execute the given Ibis expression.

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -95,7 +95,7 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         schema = self._get_schema_using_query(limited_query)
         return ops.SQLQueryResult(query, schema, self).to_expr()
 
-    def raw_sql(self, query: str):
+    def raw_sql(self, query: str, results=False):
         """Execute a given query string.
 
         Could have unexpected results if the query modifies the behavior of
@@ -110,6 +110,8 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         -------
         Backend cursor
         """
+        # TODO results is unused, it can be removed
+        # (requires updating Impala tests)
         cursor = self.con.execute(query)
         if cursor:
             return cursor

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -256,7 +256,7 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
 
         statement = 'EXPLAIN {0}'.format(query)
 
-        cur = self._execute(statement)
+        cur = self.raw_sql(statement)
         result = self._get_list(cur)
         cur.close()
 

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -258,7 +258,7 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
 
         cur = self.raw_sql(statement)
         result = self._get_list(cur)
-        cur.close()
+        cur.release()
 
         return '\n'.join(['Query:', util.indent(query, 2), '', *result])
 

--- a/ibis/client.py
+++ b/ibis/client.py
@@ -148,13 +148,14 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         schema = self.ast_schema(query_ast)
         result = self.fetch_from_cursor(cursor, schema)
 
-        if getattr(query_ast, 'result_handler'):
+        if hasattr(query_ast, 'result_handler'):
             result = query_ast.result_handler(result)
 
         return result
 
     @abc.abstractmethod
     def fetch_from_cursor(self, cursor, schema):
+        """Fetch data from cursor."""
         pass
 
     def ast_schema(self, query_ast):

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -367,7 +367,7 @@ class BaseMockConnection(SQLClient, metaclass=abc.ABCMeta):
     def fetch_from_cursor(self, cursor, schema):
         pass
 
-    def _get_table_schema(self, name):
+    def get_schema(self, name):
         name = name.replace('`', '')
         return Schema.from_tuples(self._tables[name])
 
@@ -412,7 +412,7 @@ class MockAlchemyConnection(BaseMockConnection):
         self.meta = sa.MetaData()
 
     def table(self, name, database=None):
-        schema = self._get_table_schema(name)
+        schema = self.get_schema(name)
         return self._inject_table(name, schema)
 
     def _inject_table(self, name, schema):
@@ -450,7 +450,7 @@ class GeoMockConnectionPostGIS(MockAlchemyConnection):
         super().__init__()
         self.executed_queries = []
 
-    def _get_table_schema(self, name):
+    def get_schema(self, name):
         return Schema.from_tuples(self._tables[name])
 
     @property
@@ -467,7 +467,7 @@ class GeoMockConnectionOmniSciDB(SQLClient):
         super().__init__()
         self.executed_queries = []
 
-    def _get_table_schema(self, name):
+    def get_schema(self, name):
         return Schema.from_tuples(self._tables[name])
 
     @property

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -364,6 +364,9 @@ class BaseMockConnection(SQLClient, metaclass=abc.ABCMeta):
         ],
     }
 
+    def fetch_from_cursor(self, cursor, schema):
+        pass
+
     def _get_table_schema(self, name):
         name = name.replace('`', '')
         return Schema.from_tuples(self._tables[name])


### PR DESCRIPTION
The `Query` class and subclasses have a tricky implementation, and are causing problems in #2777.

The class `SQLClient` instantiates the `Query` class, passing itself as a parameter, and then calls it's `execute` method, which will call the client `_execute` method. This seems nonsense, and just implementing the functionality of `Query` (which is quite simple) in `SQLClient` seems to be much more reasonable.