### PR TITLE
FEAT: Add startswith and endswith

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2790` Add `startswith` and `endswith` operations
 * :feature:`2776` Allow more flexible return type for UDFs
 * :feature:`2779` Implement Clip in the Pyspark backend
 * :bug:`2770` Fix error when using reduction UDF that returns np.array in a grouped aggregation

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -266,13 +266,16 @@ def _string_like(t, expr):
     result = t.translate(arg).like(t.translate(pattern), escape=escape)
     return result
 
+
 def _startswith(t, expr):
     arg, start = expr.op().args
     return t.translate(arg).startswith(t.translate(start))
 
+
 def _endswith(t, expr):
     arg, start = expr.op().args
     return t.translate(arg).endswith(t.translate(start))
+
 
 _cumulative_to_reduction = {
     ops.CumulativeSum: ops.Sum,

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -266,6 +266,13 @@ def _string_like(t, expr):
     result = t.translate(arg).like(t.translate(pattern), escape=escape)
     return result
 
+def _startswith(t, expr):
+    arg, start = expr.op().args
+    return t.translate(arg).startswith(t.translate(start))
+
+def _endswith(t, expr):
+    arg, start = expr.op().args
+    return t.translate(arg).endswith(t.translate(start))
 
 _cumulative_to_reduction = {
     ops.CumulativeSum: ops.Sum,
@@ -444,6 +451,8 @@ sqlalchemy_operation_registry = {
     ops.StringLength: unary(sa.func.length),
     ops.StringReplace: fixed_arity(sa.func.replace, 3),
     ops.StringSQLLike: _string_like,
+    ops.StartsWith: _startswith,
+    ops.EndsWith: _endswith,
     # math
     ops.Ln: unary(sa.func.ln),
     ops.Exp: unary(sa.func.exp),

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -300,6 +300,8 @@ operation_registry = {
     ops.RegexExtract: fixed_arity('regexp_extract', 3),
     ops.RegexReplace: fixed_arity('regexp_replace', 3),
     ops.ParseURL: string.parse_url,
+    ops.StartsWith: string.startswith,
+    ops.EndsWith: string.endswith,
     # Timestamp operations
     ops.Date: unary('to_date'),
     ops.TimestampNow: lambda *args: 'now()',

--- a/ibis/backends/base/sql/registry/string.py
+++ b/ibis/backends/base/sql/registry/string.py
@@ -80,3 +80,20 @@ def parse_url(translator, expr):
         return "parse_url({}, '{}', {})".format(
             arg_formatted, extract, key_fmt
         )
+
+
+def startswith(translator, expr):
+    arg, start = expr.op().args
+    
+    arg_formatted= translator.translate(arg)
+    start_formatted = translator.translate(start)
+
+    return f"starts_with({arg_formatted}, {start_formatted})"
+
+def endswith(translator, expr):
+    arg, start = expr.op().args
+    
+    arg_formatted= translator.translate(arg)
+    end_formatted = translator.translate(start)
+
+    return f"ends_with({arg_formatted}, {end_formatted})"

--- a/ibis/backends/base/sql/registry/string.py
+++ b/ibis/backends/base/sql/registry/string.py
@@ -88,7 +88,7 @@ def startswith(translator, expr):
     arg_formatted = translator.translate(arg)
     start_formatted = translator.translate(start)
 
-    return f"starts_with({arg_formatted}, {start_formatted})"
+    return f"{arg_formatted} like {start_formatted} || %"
 
 
 def endswith(translator, expr):
@@ -97,4 +97,4 @@ def endswith(translator, expr):
     arg_formatted = translator.translate(arg)
     end_formatted = translator.translate(start)
 
-    return f"ends_with({arg_formatted}, {end_formatted})"
+    return f"{arg_formatted} like % || {end_formatted}"

--- a/ibis/backends/base/sql/registry/string.py
+++ b/ibis/backends/base/sql/registry/string.py
@@ -88,7 +88,7 @@ def startswith(translator, expr):
     arg_formatted = translator.translate(arg)
     start_formatted = translator.translate(start)
 
-    return f"{arg_formatted} like {start_formatted} || %"
+    return f"{arg_formatted} like {start_formatted} || '%'"
 
 
 def endswith(translator, expr):
@@ -97,4 +97,4 @@ def endswith(translator, expr):
     arg_formatted = translator.translate(arg)
     end_formatted = translator.translate(start)
 
-    return f"{arg_formatted} like % || {end_formatted}"
+    return f"{arg_formatted} like '%' || {end_formatted}"

--- a/ibis/backends/base/sql/registry/string.py
+++ b/ibis/backends/base/sql/registry/string.py
@@ -88,7 +88,7 @@ def startswith(translator, expr):
     arg_formatted = translator.translate(arg)
     start_formatted = translator.translate(start)
 
-    return f"{arg_formatted} like {start_formatted} || '%'"
+    return f"{arg_formatted} like concat('{start_formatted}', '%')"
 
 
 def endswith(translator, expr):
@@ -97,4 +97,4 @@ def endswith(translator, expr):
     arg_formatted = translator.translate(arg)
     end_formatted = translator.translate(start)
 
-    return f"{arg_formatted} like '%' || {end_formatted}"
+    return f"{arg_formatted} like concat('%', '{end_formatted}')"

--- a/ibis/backends/base/sql/registry/string.py
+++ b/ibis/backends/base/sql/registry/string.py
@@ -84,16 +84,17 @@ def parse_url(translator, expr):
 
 def startswith(translator, expr):
     arg, start = expr.op().args
-    
-    arg_formatted= translator.translate(arg)
+
+    arg_formatted = translator.translate(arg)
     start_formatted = translator.translate(start)
 
     return f"starts_with({arg_formatted}, {start_formatted})"
 
+
 def endswith(translator, expr):
     arg, start = expr.op().args
-    
-    arg_formatted= translator.translate(arg)
+
+    arg_formatted = translator.translate(arg)
     end_formatted = translator.translate(start)
 
     return f"ends_with({arg_formatted}, {end_formatted})"

--- a/ibis/backends/base/sql/registry/string.py
+++ b/ibis/backends/base/sql/registry/string.py
@@ -88,7 +88,7 @@ def startswith(translator, expr):
     arg_formatted = translator.translate(arg)
     start_formatted = translator.translate(start)
 
-    return f"{arg_formatted} like concat('{start_formatted}', '%')"
+    return f"{arg_formatted} like concat({start_formatted}, '%')"
 
 
 def endswith(translator, expr):
@@ -97,4 +97,4 @@ def endswith(translator, expr):
     arg_formatted = translator.translate(arg)
     end_formatted = translator.translate(start)
 
-    return f"{arg_formatted} like concat('%', '{end_formatted}')"
+    return f"{arg_formatted} like concat('%', {end_formatted})"

--- a/ibis/backends/pandas/execution/strings.py
+++ b/ibis/backends/pandas/execution/strings.py
@@ -99,6 +99,16 @@ def execute_string_upper(op, data, **kwargs):
     return data.str.upper()
 
 
+@execute_node.register(ops.StartsWith, pd.Series)
+def execute_startswith(op, data, start, **kwargs):
+    return data.str.startswith(start)
+
+
+@execute_node.register(ops.EndsWith, pd.Series)
+def execute_startswith(op, data, end, **kwargs):
+    return data.str.endswith(end)
+
+
 @execute_node.register(ops.Capitalize, pd.Series)
 def execute_string_capitalize(op, data, **kwargs):
     return data.str.capitalize()

--- a/ibis/backends/pandas/execution/strings.py
+++ b/ibis/backends/pandas/execution/strings.py
@@ -105,7 +105,7 @@ def execute_startswith(op, data, start, **kwargs):
 
 
 @execute_node.register(ops.EndsWith, pd.Series)
-def execute_startswith(op, data, end, **kwargs):
+def execute_endswith(op, data, end, **kwargs):
     return data.str.endswith(end)
 
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -437,6 +437,7 @@ def compile_not_contains(t, expr, scope, timecontext, **kwargs):
     col = t.translate(op.value, scope, timecontext)
     return ~(col.isin(t.translate(op.options, scope, timecontext)))
 
+
 @compiles(ops.StartsWith)
 def compile_startswith(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
@@ -446,11 +447,12 @@ def compile_startswith(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.EndsWith)
-def compile_startswith(t, expr, scope, timecontext, **kwargs):
+def compile_endswith(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
     col = t.translate(op.arg, scope, timecontext)
     end = t.translate(op.end, scope, timecontext)
     return col.startswith(end)
+
 
 def compile_aggregator(
     t, expr, scope, timecontext, *, fn, context=None, **kwargs

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -437,6 +437,20 @@ def compile_not_contains(t, expr, scope, timecontext, **kwargs):
     col = t.translate(op.value, scope, timecontext)
     return ~(col.isin(t.translate(op.options, scope, timecontext)))
 
+@compiles(ops.StartsWith)
+def compile_startswith(t, expr, scope, timecontext, **kwargs):
+    op = expr.op()
+    col = t.translate(op.arg, scope, timecontext)
+    start = t.translate(op.start, scope, timecontext)
+    return col.startswith(start)
+
+
+@compiles(ops.EndsWith)
+def compile_startswith(t, expr, scope, timecontext, **kwargs):
+    op = expr.op()
+    col = t.translate(op.arg, scope, timecontext)
+    end = t.translate(op.end, scope, timecontext)
+    return col.startswith(end)
 
 def compile_aggregator(
     t, expr, scope, timecontext, *, fn, context=None, **kwargs

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -8,7 +8,7 @@ import ibis.expr.datatypes as dt
 def test_string_col_is_unicode(backend, alltypes, df):
     dtype = alltypes.string_col.type()
     assert dtype == dt.String(nullable=dtype.nullable)
-    is_text_type = lambda x: isinstance(x, str)  # noqa: E731
+    def is_text_type(x): return isinstance(x, str)  # noqa: E731
     assert df.string_col.map(is_text_type).all()
     result = alltypes.string_col.execute()
     assert result.map(is_text_type).all()
@@ -171,6 +171,10 @@ def test_string_col_is_unicode(backend, alltypes, df):
             id='length',
             marks=pytest.mark.xfail_backends(['omniscidb']),  # #2338
         ),
+        param(lambda t: t.string_col.startswith('foo'),
+              lambda t: t.string_col.startswith('foo'), id='startswith'),
+        param(lambda t: t.string_col.endswith('foo'),
+              lambda t: t.string_col.endswith('foo'), id='endsswith'),
         param(
             lambda t: t.string_col.strip(),
             lambda t: t.string_col.str.strip(),

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -8,7 +8,7 @@ import ibis.expr.datatypes as dt
 def test_string_col_is_unicode(backend, alltypes, df):
     dtype = alltypes.string_col.type()
     assert dtype == dt.String(nullable=dtype.nullable)
-    is_text_type = lambda x: isinstance(x, str)  # noqa: E731
+    def is_text_type(x): return isinstance(x, str)  # noqa: E731
     assert df.string_col.map(is_text_type).all()
     result = alltypes.string_col.execute()
     assert result.map(is_text_type).all()

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -5,10 +5,13 @@ import ibis
 import ibis.expr.datatypes as dt
 
 
+def is_text_type(x):
+    return isinstance(x, str)
+
+
 def test_string_col_is_unicode(backend, alltypes, df):
     dtype = alltypes.string_col.type()
     assert dtype == dt.String(nullable=dtype.nullable)
-    is_text_type = lambda x: isinstance(x, str)  # noqa: E731
     assert df.string_col.map(is_text_type).all()
     result = alltypes.string_col.execute()
     assert result.map(is_text_type).all()

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -172,9 +172,9 @@ def test_string_col_is_unicode(backend, alltypes, df):
             marks=pytest.mark.xfail_backends(['omniscidb']),  # #2338
         ),
         param(lambda t: t.string_col.startswith('foo'),
-              lambda t: t.string_col.startswith('foo'), id='startswith'),
+              lambda t: t.string_col.str.startswith('foo'), id='startswith'),
         param(lambda t: t.string_col.endswith('foo'),
-              lambda t: t.string_col.endswith('foo'), id='endsswith'),
+              lambda t: t.string_col.str.endswith('foo'), id='endswith'),
         param(
             lambda t: t.string_col.strip(),
             lambda t: t.string_col.str.strip(),

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -8,7 +8,7 @@ import ibis.expr.datatypes as dt
 def test_string_col_is_unicode(backend, alltypes, df):
     dtype = alltypes.string_col.type()
     assert dtype == dt.String(nullable=dtype.nullable)
-    def is_text_type(x): return isinstance(x, str)  # noqa: E731
+    is_text_type = lambda x: isinstance(x, str)  # noqa: E731
     assert df.string_col.map(is_text_type).all()
     result = alltypes.string_col.execute()
     assert result.map(is_text_type).all()

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -174,10 +174,16 @@ def test_string_col_is_unicode(backend, alltypes, df):
             id='length',
             marks=pytest.mark.xfail_backends(['omniscidb']),  # #2338
         ),
-        param(lambda t: t.string_col.startswith('foo'),
-              lambda t: t.string_col.str.startswith('foo'), id='startswith'),
-        param(lambda t: t.string_col.endswith('foo'),
-              lambda t: t.string_col.str.endswith('foo'), id='endswith'),
+        param(
+            lambda t: t.string_col.startswith('foo'),
+            lambda t: t.string_col.str.startswith('foo'),
+            id='startswith',
+        ),
+        param(
+            lambda t: t.string_col.endswith('foo'),
+            lambda t: t.string_col.str.endswith('foo'),
+            id='endswith',
+        ),
         param(
             lambda t: t.string_col.strip(),
             lambda t: t.string_col.str.strip(),

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2900,8 +2900,13 @@ def _startswith(self, start):
     --------
     >>> import ibis
     >>> text = ibis.literal('Ibis project)
-    >>> result = text.startswith('Ibis')
-
+    >>> text.startswith('Ibis')
+    StartsWith[boolean]
+      Literal[string]
+        Ibis project
+      start:
+        Literal[string]
+          Ibis
     Returns
     -------
     result : boolean
@@ -2921,7 +2926,13 @@ def _endswith(self, end):
     --------
     >>> import ibis
     >>> text = ibis.literal('Ibis project)
-    >>> result = text.endswith('project')
+    >>> text.endswith('project')
+    EndsWith[boolean]
+      Literal[string]
+        Ibis project
+      end:
+        Literal[string]
+          project
 
     Returns
     -------

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2887,6 +2887,46 @@ def _string_join(self, strings):
     """
     return ops.StringJoin(self, strings).to_expr()
 
+def _startswith(self, start):
+    """
+    Determine if `self` string starts with `start` string.
+
+    Parameters
+    ----------
+    start: string
+
+    Examples
+    --------
+    >>> import ibis
+    >>> text = ibis.literal('Ibis project)
+    >>> result = text.startswith('Ibis')
+
+    Returns
+    -------
+    result : boolean
+    """
+    return ops.StartsWith(self, self, start).to_expr()
+
+def _endswith(self, end):
+    """
+    Determine if `self` string ends with `end` string.
+
+    Parameters
+    ----------
+    end: string
+
+    Examples
+    --------
+    >>> import ibis
+    >>> text = ibis.literal('Ibis project)
+    >>> result = text.endswith('project')
+
+    Returns
+    -------
+    result : boolean
+    """
+    return ops.EndsWith(self, end).to_expr()
+
 
 def _string_like(self, patterns):
     """
@@ -3177,6 +3217,8 @@ _string_value_methods = {
     'find_in_set': _find_in_set,
     'split': _string_split,
     'join': _string_join,
+    'startswith': _startswith,
+    'endswith': _endswith,
     'lpad': _lpad,
     'rpad': _rpad,
     '__add__': _string_concat,

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2887,6 +2887,7 @@ def _string_join(self, strings):
     """
     return ops.StringJoin(self, strings).to_expr()
 
+
 def _startswith(self, start):
     """
     Determine if `self` string starts with `start` string.
@@ -2906,6 +2907,7 @@ def _startswith(self, start):
     result : boolean
     """
     return ops.StartsWith(self, self, start).to_expr()
+
 
 def _endswith(self, end):
     """

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2906,7 +2906,7 @@ def _startswith(self, start):
     -------
     result : boolean
     """
-    return ops.StartsWith(self, self, start).to_expr()
+    return ops.StartsWith(self, start).to_expr()
 
 
 def _endswith(self, end):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -755,6 +755,16 @@ class StringJoin(ValueOp):
     def output_type(self):
         return rlz.shape_like(tuple(self.flat_args()), dt.string)
 
+class StartsWith(ValueOp):
+    arg = Arg(rlz.string)
+    start = Arg(rlz.string)
+    output_type = rlz.shape_like("arg", dt.boolean)
+
+class EndsWith(ValueOp):
+    arg = Arg(rlz.string)
+    end = Arg(rlz.string)
+    output_type = rlz.shape_like("arg", dt.boolean)
+
 
 class BooleanValueOp:
     pass

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -204,7 +204,7 @@ class TableNode(Node):
         if self.equals(other):
             return True
 
-        def fn(e): return (lin.proceed, e.op())  # noqa: E731
+        fn = lambda e: (lin.proceed, e.op())  # noqa: E731
         expr = self.to_expr()
         for child in lin.traverse(fn, expr):
             if child.equals(other):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -204,7 +204,7 @@ class TableNode(Node):
         if self.equals(other):
             return True
 
-        fn = lambda e: (lin.proceed, e.op())  # noqa: E731
+        def fn(e): return (lin.proceed, e.op())  # noqa: E731
         expr = self.to_expr()
         for child in lin.traverse(fn, expr):
             if child.equals(other):
@@ -755,10 +755,12 @@ class StringJoin(ValueOp):
     def output_type(self):
         return rlz.shape_like(tuple(self.flat_args()), dt.string)
 
+
 class StartsWith(ValueOp):
     arg = Arg(rlz.string)
     start = Arg(rlz.string)
     output_type = rlz.shape_like("arg", dt.boolean)
+
 
 class EndsWith(ValueOp):
     arg = Arg(rlz.string)

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -311,10 +311,6 @@ def coerce_to_dataframe(
     0  1  2  3
     dtypes: [int32, int32, int32]
     """
-    # We don't want to coerce any output that is intended as
-    # an array shape.
-    if any(isinstance(t, dt.Array) for t in output_type.types):
-        return data
     if isinstance(data, pd.DataFrame):
         result = data
     elif isinstance(data, pd.Series):

--- a/ibis/tests/expr/test_operations.py
+++ b/ibis/tests/expr/test_operations.py
@@ -74,6 +74,8 @@ def test_ops_smoke():
     ops.StringReplace('asd', 'as', 'a')
     ops.StringSplit('asd', 's')
     ops.StringConcat(['s', 'e'])
+    ops.StartsWith('asd', 'as')
+    ops.EndsWith('asd', 'xyz')
 
 
 def test_instance_of_operation():

--- a/ibis/tests/expr/test_string.py
+++ b/ibis/tests/expr/test_string.py
@@ -112,3 +112,13 @@ def test_add_radd(table, string_col):
     assert isinstance('bar' + literal('foo'), ir.StringScalar)
     assert isinstance(string_col + 'bar', ir.StringColumn)
     assert isinstance('bar' + string_col, ir.StringColumn)
+
+
+def test_startswith(table):
+    assert isinstance(table.g.startswith('foo'), ir.BooleanColumn)
+    assert isinstance(literal('bar').startswith('foo'), ir.BooleanScalar)
+
+
+def test_startswith(table):
+    assert isinstance(table.g.endswith('foo'), ir.BooleanColumn)
+    assert isinstance(literal('bar').endswith('foo'), ir.BooleanScalar)

--- a/ibis/tests/expr/test_string.py
+++ b/ibis/tests/expr/test_string.py
@@ -119,6 +119,6 @@ def test_startswith(table):
     assert isinstance(literal('bar').startswith('foo'), ir.BooleanScalar)
 
 
-def test_startswith(table):
+def test_endswith(table):
     assert isinstance(table.g.endswith('foo'), ir.BooleanColumn)
     assert isinstance(literal('bar').endswith('foo'), ir.BooleanScalar)

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -2209,14 +2209,14 @@ FROM (
     def test_startswith(self):
         expr = self._case_startswith()
         expected = """\
-SELECT `foo_id` like 'foo' || % AS `tmp`
+SELECT `foo_id` like 'foo' || '%' AS `tmp`
 FROM star1"""
         assert to_sql(expr) == expected
 
     def test_endswith(self):
         expr = self._case_endswith()
         expected = """\
-SELECT `foo_id` like % || 'foo' AS `tmp`
+SELECT `foo_id` like '%' || 'foo' AS `tmp`
 FROM star1"""
         assert to_sql(expr) == expected
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -2209,14 +2209,14 @@ FROM (
     def test_startswith(self):
         expr = self._case_startswith()
         expected = """\
-SELECT `foo_id` like 'foo' || '%' AS `tmp`
+SELECT `foo_id` like concat('foo', '%') AS `tmp`
 FROM star1"""
         assert to_sql(expr) == expected
 
     def test_endswith(self):
         expr = self._case_endswith()
         expected = """\
-SELECT `foo_id` like '%' || 'foo' AS `tmp`
+SELECT `foo_id` like concat('%', 'foo') AS `tmp`
 FROM star1"""
         assert to_sql(expr) == expected
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -2209,14 +2209,14 @@ FROM (
     def test_startswith(self):
         expr = self._case_startswith()
         expected = """\
-SELECT starts_with(`foo_id`, 'foo') AS `tmp`
+SELECT `foo_id` like 'foo' || % AS `tmp`
 FROM star1"""
         assert to_sql(expr) == expected
 
     def test_endswith(self):
         expr = self._case_endswith()
         expected = """\
-SELECT ends_with(`foo_id`, 'foo') AS `tmp`
+SELECT `foo_id` like % || 'foo' AS `tmp`
 FROM star1"""
         assert to_sql(expr) == expected
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -808,6 +808,14 @@ class ExprTestCases:
 
         return expr1, expr2, expr3
 
+    def _case_startswith(self):
+        t1 = self.con.table('star1')
+        return t1.foo_id.startswith('foo')
+
+    def _case_endswith(self):
+        t1 = self.con.table('star1')
+        return t1.foo_id.endswith('foo')
+
 
 class TestSelectSQL(unittest.TestCase, ExprTestCases):
     @classmethod
@@ -2197,6 +2205,20 @@ FROM (
        (t0.`desc` = t1.`desc`)"""
 
         assert result == expected
+
+    def test_startswith(self):
+        expr = self._case_startswith()
+        expected = """\
+SELECT starts_with(`foo_id`, 'foo') AS `tmp`
+FROM star1"""
+        assert to_sql(expr) == expected
+
+    def test_endswith(self):
+        expr = self._case_endswith()
+        expected = """\
+SELECT ends_with(`foo_id`, 'foo') AS `tmp`
+FROM star1"""
+        assert to_sql(expr) == expected
 
 
 class TestUnions(unittest.TestCase, ExprTestCases):


### PR DESCRIPTION
Closes #2790 .

Adds `StartsWith` and `EndsWith` operations and adds compilers to base SQL and SQLAlchemy.

I haven't written any tests yet. 

I assume I should add the operations to `test_ops_smoke` in *expr/test_operations.py* and test them in _sql/test_compiler.py_ and _sql/test_sqlalchemy.py_ ?


Anything else I am missing?