### PR TITLE
ENH: Use more useful fallback types for 'categorical' and 'decimal' Series'

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,7 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
-* :feature:`2792` Infer categorical, and decimal Series to more specific Ibis types in Pandas backend
+* :feature:`2792` Infer categorical and decimal Series to more specific Ibis types in Pandas backend
 * :feature:`2776` Allow more flexible return type for UDFs
 * :feature:`2779` Implement Clip in the Pyspark backend
 * :bug:`2770` Fix error when using reduction UDF that returns np.array in a grouped aggregation

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -13,7 +13,6 @@ Release Notes
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
 * :feature:`2792` Infer categorical and decimal Series to more specific Ibis types in Pandas backend
-* :feature:`2776` Allow more flexible return type for UDFs
 * :feature:`2776` :feature:`2797` Allow more flexible return type for UDFs
 * :feature:`2779` Implement Clip in the Pyspark backend
 * :bug:`2770` Fix error when using reduction UDF that returns np.array in a grouped aggregation

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,7 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
-* :feature:`2792` Infer empty, categorical, and decimal Series to more specific Ibis types in Pandas backend
+* :feature:`2792` Infer categorical, and decimal Series to more specific Ibis types in Pandas backend
 * :feature:`2776` Allow more flexible return type for UDFs
 * :feature:`2779` Implement Clip in the Pyspark backend
 * :bug:`2770` Fix error when using reduction UDF that returns np.array in a grouped aggregation

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2792` Infer empty, categorical, and decimal Series to more specific Ibis types in Pandas backend
 * :feature:`2776` Allow more flexible return type for UDFs
 * :feature:`2779` Implement Clip in the Pyspark backend
 * :bug:`2770` Fix error when using reduction UDF that returns np.array in a grouped aggregation

--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -86,9 +86,9 @@ _inferable_pandas_dtypes = {
     'integer': dt.int64,
     'mixed-integer': dt.binary,
     'mixed-integer-float': dt.float64,
-    'decimal': dt.binary,
+    'decimal': dt.float64,
     'complex': dt.binary,
-    'categorical': dt.binary,
+    'categorical': dt.category,
     'boolean': dt.boolean,
     'datetime64': dt.timestamp,
     'datetime': dt.timestamp,
@@ -98,7 +98,7 @@ _inferable_pandas_dtypes = {
     'time': dt.time,
     'period': dt.binary,
     'mixed': dt.binary,
-    'empty': dt.binary,
+    'empty': dt.string,
     'unicode': dt.string,
 }
 
@@ -157,7 +157,7 @@ def _infer_pandas_series_contents(s: pd.Series) -> dt.DataType:
     """
     if s.dtype == np.object_:
         inferred_dtype = infer_pandas_dtype(s, skipna=True)
-        if inferred_dtype in {'mixed', 'decimal'}:
+        if inferred_dtype == 'mixed':
             # We need to inspect an element to determine the Ibis dtype
             value = s.iloc[0]
             if isinstance(value, (np.ndarray, list, pd.Series)):

--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -98,7 +98,7 @@ _inferable_pandas_dtypes = {
     'time': dt.time,
     'period': dt.binary,
     'mixed': dt.binary,
-    'empty': dt.string,
+    'empty': dt.binary,
     'unicode': dt.string,
 }
 

--- a/ibis/backends/pandas/tests/test_datatypes.py
+++ b/ibis/backends/pandas/tests/test_datatypes.py
@@ -216,7 +216,7 @@ def test_series_to_ibis_literal():
         # mixed
         (pd.Series([b'1', '2', 3.0]), dt.binary),
         # empty
-        (pd.Series([], dtype='object'), dt.string),
+        (pd.Series([], dtype='object'), dt.binary),
     ],
 )
 def test_schema_infer(col_data, schema_type):

--- a/ibis/backends/pandas/tests/test_datatypes.py
+++ b/ibis/backends/pandas/tests/test_datatypes.py
@@ -181,12 +181,15 @@ def test_series_to_ibis_literal():
         (['foo', 'bar', 'hello'], "string"),
         (pd.Series(['a', 'b', 'c', 'a']).astype('category'), dt.Category()),
         (pd.Series([b'1', b'2', b'3']), dt.string),
+        # mixed-integer
         (pd.Series([1, 2, '3']), dt.binary),
+        # mixed-integer-float
         (pd.Series([1, 2, 3.0]), dt.float64),
         (
             pd.Series([Decimal('1.0'), Decimal('2.0'), Decimal('3.0')]),
-            dt.binary,
+            dt.float64,
         ),
+        # complex
         (pd.Series([1 + 1j, 1 + 2j, 1 + 3j], dtype=object), dt.binary),
         (
             pd.Series(
@@ -213,7 +216,7 @@ def test_series_to_ibis_literal():
         # mixed
         (pd.Series([b'1', '2', 3.0]), dt.binary),
         # empty
-        (pd.Series([], dtype='object'), dt.binary),
+        (pd.Series([], dtype='object'), dt.string),
     ],
 )
 def test_schema_infer(col_data, schema_type):


### PR DESCRIPTION
## Background

#2753 made some changes to type inference in the Pandas backend (i.e. the way that we infer column types in input data that is in the form of Pandas DataFrames). These changes made use of `dt.binary` as a general fallback type.

Specifically, the final type inference approach that we attempt is to call `pd.api.types.infer_dtype` on the Series, then match the result of that function to some Ibis dtype ([ibis/backends/pandas/client.py#L159](https://github.com/ibis-project/ibis/blob/fd62fe52f9f59a4c5964b30b2f061c354b736249/ibis/backends/pandas/client.py#L159)). For non-obvious mappings, we use `dt.binary`  ([ibis/backends/pandas/client.py#L82-L103](https://github.com/ibis-project/ibis/blob/fd62fe52f9f59a4c5964b30b2f061c354b736249/ibis/backends/pandas/client.py#L82-L103)).

## This PR

This PR changes some of those mappings to not map to `dt.binary`, but instead to another Ibis dtype that would be more useful:
- `'decimal'` now maps to `dt.float64`. Ibis float methods tend to work with `Decimals`
- `'categorical'` now maps to `dt.category`
- ~~`'empty'` now maps to `dt.string`. Assumes that empty `object`-dtype Series' are meant to be string columns~~

These inferred types are all still just guesses, but the goal is to hopefully be making guesses that are more useful.