### PR TITLE
ENH: Add dt.Struct support back to elementwise udfs

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,7 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
-* :feature:`2776` Allow more flexible return type for UDFs
+* :feature:`2776` :feature:`2797` Allow more flexible return type for UDFs
 * :feature:`2779` Implement Clip in the Pyspark backend
 * :bug:`2770` Fix error when using reduction UDF that returns np.array in a grouped aggregation
 * :feature:`2753` Use `ndarray` as array representation in Pandas backend

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -440,8 +440,7 @@ def test_invalid_kwargs(backend, alltypes):
             return v + 1
 
 
-@pytest.mark.only_on_backends(['pandas', 'pyspark'])
-@pytest.mark.xfail_backends(['dask'])
+@pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
 @pytest.mark.xfail_unsupported
 @pytest.mark.parametrize('udf', add_one_struct_udfs)
 def test_elementwise_udf_destruct(backend, alltypes, udf):
@@ -456,8 +455,7 @@ def test_elementwise_udf_destruct(backend, alltypes, udf):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.only_on_backends(['pandas', 'pyspark'])
-@pytest.mark.xfail_backends(['dask'])
+@pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
 @pytest.mark.xfail_unsupported
 def test_elementwise_udf_overwrite_destruct(backend, alltypes):
     result = alltypes.mutate(
@@ -477,8 +475,7 @@ def test_elementwise_udf_overwrite_destruct(backend, alltypes):
     backend.assert_frame_equal(result, expected, check_like=True)
 
 
-@pytest.mark.only_on_backends(['pandas', 'pyspark'])
-@pytest.mark.xfail_backends(['dask'])
+@pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
 @pytest.mark.xfail_unsupported
 def test_elementwise_udf_overwrite_destruct_and_assign(backend, alltypes):
     result = (
@@ -504,8 +501,7 @@ def test_elementwise_udf_overwrite_destruct_and_assign(backend, alltypes):
     backend.assert_frame_equal(result, expected, check_like=True)
 
 
-@pytest.mark.only_on_backends(['pandas', 'pyspark'])
-@pytest.mark.xfail_backends(['dask'])
+@pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
 @pytest.mark.xfail_unsupported
 @pytest.mark.min_spark_version('3.1')
 def test_elementwise_udf_destruct_exact_once(backend, alltypes):
@@ -531,8 +527,7 @@ def test_elementwise_udf_destruct_exact_once(backend, alltypes):
         assert len(result) > 0
 
 
-@pytest.mark.only_on_backends(['pandas', 'pyspark'])
-@pytest.mark.xfail_backends(['dask'])
+@pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
 @pytest.mark.xfail_unsupported
 def test_elementwise_udf_multiple_overwrite_destruct(backend, alltypes):
     result = alltypes.mutate(


### PR DESCRIPTION
This was temporarily removed in https://github.com/ibis-project/ibis/pull/2776 and tracked in https://github.com/ibis-project/ibis/issues/2553#issuecomment-843528132. 

This adds back support. 
