### PR TITLE
ENH: More tightly bound dask versions

### DIFF
--- a/ci/deps/dask-min.yml
+++ b/ci/deps/dask-min.yml
@@ -1,2 +1,2 @@
-dask=2.22.0
+dask=2021.2.0
 pyarrow

--- a/ci/deps/dask.yml
+++ b/ci/deps/dask.yml
@@ -1,2 +1,2 @@
-dask
+dask=2021.5.0
 pyarrow

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ spark_requires = ['pyspark>=2.4.3']
 geospatial_requires = ['geoalchemy2', 'geopandas', 'shapely']
 
 dask_requires = [
-    'dask[dataframe, array]>=2.22.0',
+    'dask[dataframe, array]>=2021.1.1,<2021.5.1',
 ]
 
 all_requires = (


### PR DESCRIPTION
xref https://github.com/ibis-project/ibis/issues/2800. 

Looks like `2021.5.1` had some issue with meta:

- https://github.com/dask/dask/issues/7731
- https://github.com/dask/dask/pull/7503

For now, let's set a cap on the max dask version and wait for a fix in dask to happen. 