### PR TITLE
CI: Force mamba to use conda-forge

### DIFF
--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -54,7 +54,7 @@ for BACKEND in $BACKENDS; do
     fi
 done
 cat environment.yml
-mamba env update -n base -c conda-forge --file=environment.yml
+mamba env update -n base --file=environment.yml
 python -m pip install -e .
 
 if [[ -n "$BACKENDS" ]]; then

--- a/ci/setup_env.sh
+++ b/ci/setup_env.sh
@@ -54,7 +54,7 @@ for BACKEND in $BACKENDS; do
     fi
 done
 cat environment.yml
-mamba env update -n base --file=environment.yml
+mamba env update -n base -c conda-forge --file=environment.yml
 python -m pip install -e .
 
 if [[ -n "$BACKENDS" ]]; then

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 # This file should have all the dependencies for development excluding the specific to the backends.
 name: ibis-dev
 channels:
+  - nodefaults
   - conda-forge
 dependencies:
   # Ibis hard dependencies


### PR DESCRIPTION
Closes #2801

In theory we are already using conda-forge, since it's the only channel in `environment.yml`, but that doesn't seem to be enough in practice.