### PR TITLE
Support comparison of ColumnExpr to timestamp literal

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2808` Support comparison of ColumnExpr to timestamp literal
 * :support:`2789` Simplification of data fetching. Backends don't need to implement `Query` anymore
 * :feature:`2805` Make op schema a cached property
 * :feature:`2613` :feature:`2778` Implement `.insert()` for SQLAlchemy backends

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -21,6 +21,7 @@ from ibis.backends.pandas.core import (
     integer_types,
     numeric_types,
     simple_types,
+    timestamp_types,
 )
 from ibis.backends.pandas.execution import constants
 from ibis.backends.pandas.execution.generic import (
@@ -277,6 +278,8 @@ def execute_not_scalar_or_series(op, data, **kwargs):
 )
 @execute_node.register((ops.Comparison, ops.Add, ops.Multiply), dd.Series, str)
 @execute_node.register((ops.Comparison, ops.Add, ops.Multiply), str, dd.Series)
+@execute_node.register(ops.Comparison, dd.Series, timestamp_types)
+@execute_node.register(ops.Comparison, timestamp_types, dd.Series)
 def execute_binary_op(op, left, right, **kwargs):
     op_type = type(op)
     try:

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -37,6 +37,7 @@ from ..core import (
     scalar_types,
     simple_types,
     timedelta_types,
+    timestamp_types,
 )
 from ..dispatch import execute_literal, execute_node
 from ..execution import constants
@@ -693,6 +694,8 @@ def execute_not_bool(op, data, **kwargs):
 @execute_node.register((ops.Comparison, ops.Add), str, str)
 @execute_node.register(ops.Multiply, integer_types, str)
 @execute_node.register(ops.Multiply, str, integer_types)
+@execute_node.register(ops.Comparison, pd.Series, timestamp_types)
+@execute_node.register(ops.Comparison, timestamp_types, pd.Series)
 def execute_binary_op(op, left, right, **kwargs):
     op_type = type(op)
     try:

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -306,6 +306,28 @@ def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
     backend.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    'comparison_fn',
+    [
+        lambda t: t.timestamp_col > pd.Timestamp('20100301'),
+        lambda t: t.timestamp_col >= pd.Timestamp('20100301'),
+        lambda t: t.timestamp_col < pd.Timestamp('20100301'),
+        lambda t: t.timestamp_col <= pd.Timestamp('20100301'),
+        lambda t: t.timestamp_col == pd.Timestamp('20100301'),
+        lambda t: t.timestamp_col != pd.Timestamp('20100301'),
+    ],
+)
+@pytest.mark.xfail_unsupported
+@pytest.mark.skip_backends(['spark'])
+def test_timestamp_comparison_filter(
+    backend, con, alltypes, df, comparison_fn
+):
+    expr = alltypes.filter(comparison_fn(alltypes))
+    expected = df[comparison_fn(df)]
+    result = con.execute(expr)
+    backend.assert_frame_equal(result, expected)
+
+
 @pytest.mark.xfail_unsupported
 @pytest.mark.skip_backends(['spark'])
 def test_interval_add_cast_scalar(backend, alltypes):

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -318,7 +318,7 @@ def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
     ],
 )
 @pytest.mark.xfail_unsupported
-@pytest.mark.skip_backends(['spark'])
+@pytest.mark.skip_backends(['spark', 'sqlite'])
 def test_timestamp_comparison_filter(
     backend, con, alltypes, df, comparison_fn
 ):


### PR DESCRIPTION
### Proposed Change

This PR adds support to execute the following types of expressions that compare a ColumnExpr to a timestamp literal, which was previously missing functionality in the Pandas and Dask backends:

```
expr.filter(expr['timestamp_col'] > pd.Timestamp('20100301'))
```

### Tests
Added tests for all comparison operations in test_temporal.py.