### PR TITLE
BUG: Aggregation with mixed reduction datatypes (array, scalar, etc) fails on Dask backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2820` Fix aggregation with mixed reduction datatypes (array + scalar) on Dask backend
 * :feature:`2808` Support comparison of ColumnExpr to timestamp literal
 * :support:`2789` Simplification of data fetching. Backends don't need to implement `Query` anymore
 * :feature:`2805` Make op schema a cached property

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -125,8 +125,13 @@ def coerce_to_output(
             out_dtype = _pandas_dtype_from_dd_scalar(result)
             out_len = 1 if index is None else len(index)
             meta = make_meta_series(dtype=out_dtype, name=result_name)
+            # Specify `divisions` so that the created Dask object has
+            # known divisions (to be concatenatable with Dask objects
+            # created using `dd.from_pandas`)
             series = dd.from_delayed(
-                _wrap_dd_scalar(result, result_name, out_len), meta=meta,
+                _wrap_dd_scalar(result, result_name, out_len),
+                meta=meta,
+                divisions=(0, out_len - 1),
             )
 
             return series


### PR DESCRIPTION
# Problem

Using `.aggregate()` with a reduction that outputs an array + a reduction that outputs a scalar fails on the Dask backend.

```
@udf.reduction(
    input_type=[dt.int64],
    output_type=dt.int64,
)
def sum_udf(v):
    return np.sum(v)

@udf.reduction(
    input_type=[dt.int64],
    output_type=dt.Array(dt.int64),
)
def collect_udf(v):
    return np.array(v)

t = t.aggregate(
    sum_col=sum_udf(t['int_col']),
    arr_col=collect_udf(t['int_col'])
)
t.execute()
```

```
~/miniconda3/envs/ibis-dev/lib/python3.9/site-packages/dask/dataframe/multi.py in concat(dfs, axis, join, interleave_partitions, ignore_unknown_divisions, **kwargs)
   1138             return concat_unindexed_dataframes(dfs, **kwargs)
   1139         else:
-> 1140             raise ValueError(
   1141                 "Unable to concatenate DataFrame with unknown "
   1142                 "division specifying axis=1"

ValueError: Unable to concatenate DataFrame with unknown division specifying axis=1
```

When executing `.aggregate()`, Dask computes the individual reductions, then concatenates them together to form a single DataFrame.

In this case, Dask does not want to concatenate the results of the two reductions because one has **known divisions**, and the other has **unknown divisions**:
1. The non-array reduction UDF results in a delayed object with unknown divisions. This is due to the way we are using `dd.from_delayed` in `coerce_to_output`: [util.py#L128-L130](https://github.com/ibis-project/ibis/blob/master/ibis/backends/dask/execution/util.py#L128-L130)
2. The array reduction UDF results in a delayed object with known divisions, due to `coerce_to_output` using `dd.from_pandas`: [util.py#L134-L136](https://github.com/ibis-project/ibis/blob/master/ibis/backends/dask/execution/util.py#L134-L136).

# Solution
In this PR, we change our use of `dd.from_delayed` in `coerce_to_output` to manually specify the divisions. Since the divisions are now always known, Dask will be able to concatenate the results of the individual reductions together.
