### PR TITLE
BUG: `.cast()` to array outputs list instead of np.array in Pandas backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2770` Fix `.cast()` to array outputting list instead of np.array in Pandas backend
 * :feature:`2808` Support comparison of ColumnExpr to timestamp literal
 * :support:`2789` Simplification of data fetching. Backends don't need to implement `Query` anymore
 * :feature:`2805` Make op schema a cached property

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,7 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
-* :bug:`2770` Fix `.cast()` to array outputting list instead of np.array in Pandas backend
+* :bug:`2821` Fix `.cast()` to array outputting list instead of np.array in Pandas backend
 * :bug:`2820` Fix aggregation with mixed reduction datatypes (array + scalar) on Dask backend
 * :feature:`2808` Support comparison of ColumnExpr to timestamp literal
 * :support:`2789` Simplification of data fetching. Backends don't need to implement `Query` anymore

--- a/ibis/backends/dask/tests/execution/test_arrays.py
+++ b/ibis/backends/dask/tests/execution/test_arrays.py
@@ -234,9 +234,12 @@ def test_array_repeat_scalar(client, n, mul):
 
 
 @pytest.mark.xfail(
-    raises=NotImplementedError,
+    raises=ValueError,
     reason='TODO - arrays - #2553'
-    # Need an ops.ArrayConcat execution func that dispatches on dd.Series
+    # ValueError: Dask backend borrows Pandas backend's Cast execution
+    # function, which assumes array representation is np.array.
+    # NotImplementedError: Need an ops.ArrayConcat execution func that
+    # dispatches on dd.Series
 )
 @pytest.mark.parametrize('op', [lambda x, y: x + y, lambda x, y: y + x])
 def test_array_concat(t, df, op):

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -112,7 +112,7 @@ def execute_cast_series_array(op, data, type, **kwargs):
             '(e.g., number, string, or timestamp)'
         )
     return data.map(
-        lambda array, numpy_type=numpy_type: list(map(numpy_type, array))
+        lambda array, numpy_type=numpy_type: array.astype(numpy_type)
     )
 
 

--- a/ibis/backends/pandas/tests/execution/test_cast.py
+++ b/ibis/backends/pandas/tests/execution/test_cast.py
@@ -49,7 +49,7 @@ def test_cast_string(t, df, from_, to, expected):
 @pytest.mark.parametrize('from_', ['array_of_int64', 'array_of_float64'])
 @pytest.mark.parametrize(
     ('to', 'expected'),
-    [('array<double>', 'float64'), ('array<int64>', 'int64')],
+    [('array<double>', 'float64'), ('array<int32>', 'int32')],
 )
 def test_cast_array(t, df, from_, to, expected):
     c = t[from_].cast(to)

--- a/ibis/backends/pandas/tests/execution/test_cast.py
+++ b/ibis/backends/pandas/tests/execution/test_cast.py
@@ -1,5 +1,6 @@
 import decimal
 
+import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
@@ -43,6 +44,21 @@ def test_cast_string(t, df, from_, to, expected):
     c = t[from_].cast(to)
     result = c.execute()
     assert str(result.dtype) == expected
+
+
+@pytest.mark.parametrize('from_', ['array_of_int64', 'array_of_float64'])
+@pytest.mark.parametrize(
+    ('to', 'expected'),
+    [('array<double>', 'float64'), ('array<int64>', 'int64')],
+)
+def test_cast_array(t, df, from_, to, expected):
+    c = t[from_].cast(to)
+    result = c.execute()
+    # The Series of arrays
+    assert str(result.dtype) == 'object'
+    # One of the arrays in the Series
+    assert isinstance(result[0], np.ndarray)
+    assert str(result[0].dtype) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Problem

In the Pandas backend, when casting a column to an array type, a `list` is created as the output instead of a `np.array` (which is the new standard in the Pandas backend).

```
>>> series = t['arr_col'].execute()
>>> type(series[0])
numpy.ndarray
>>> series = t['arr_col'].cast('array<float64>').execute()
>>> type(series[0])
list
```

# Solution
Change the Pandas backend implementation of the cast operation to produce a `np.array`.