### PR TITLE
Disable aggregation expr optimization due to N squared performance

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2830` Disable aggregation optimization due to N squared performance
 * :bug:`2821` Fix `.cast()` to array outputting list instead of np.array in Pandas backend
 * :bug:`2820` Fix aggregation with mixed reduction datatypes (array + scalar) on Dask backend
 * :feature:`2808` Support comparison of ColumnExpr to timestamp literal

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2264,8 +2264,6 @@ class Aggregation(TableNode, HasSchema):
         assert self.schema
 
     def _rewrite_exprs(self, table, what):
-        from ibis.expr.analysis import substitute_parents
-
         what = util.promote_list(what)
 
         all_exprs = []
@@ -2276,9 +2274,15 @@ class Aggregation(TableNode, HasSchema):
                 bound_expr = ir.bind_expr(table, expr)
                 all_exprs.append(bound_expr)
 
-        return [
-            substitute_parents(x, past_projection=False) for x in all_exprs
-        ]
+        return all_exprs
+        # TODO this optimization becomes O(n^2) when it calls into
+        #  _lift_TableColumn in analysis.py, which itself is O(n) and is
+        # called on each input to the aggregation - thus creating the
+        # aggregation expression can be extremely slow on wide tables
+        # that contain a Selection.
+        # return [
+        #     substitute_parents(x, past_projection=False) for x in all_exprs
+        # ]
 
     def blocks(self):
         return True

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -2275,8 +2275,9 @@ class Aggregation(TableNode, HasSchema):
                 all_exprs.append(bound_expr)
 
         return all_exprs
-        # TODO this optimization becomes O(n^2) when it calls into
-        #  _lift_TableColumn in analysis.py, which itself is O(n) and is
+        # TODO - #2832
+        # this optimization becomes O(n^2) when it calls into
+        # _lift_TableColumn in analysis.py, which itself is O(n) and is
         # called on each input to the aggregation - thus creating the
         # aggregation expression can be extremely slow on wide tables
         # that contain a Selection.


### PR DESCRIPTION
Currently, on instantiation of the ``Aggregation`` node, ibis calls into [this expr optimization logic](https://github.com/ibis-project/ibis/blob/master/ibis/expr/analysis.py#L266), where this line will attempt to simplify a projection by lifting the root. This optimization method is O(n) as it iterates over all the root.selections ([here](https://github.com/ibis-project/ibis/blob/master/ibis/expr/analysis.py#L353) and [here](https://github.com/ibis-project/ibis/blob/master/ibis/expr/analysis.py#L367)), and in practice when called inside the ``Aggregation`` constructor, the outcome is O(n^2) as this logic runs for each table column - the result can be very slow expression creation on wide tables when there is a Selection followed by an aggregation.

```
# create wide table
N = 3000
df = pd.DataFrame({'a': [1, 2, 3]})
cols = {f'col_{i}': [1] * 3 for i in range(N)}
df = df.assign(**cols)
con = Backend().connect({'df': df})
table = con.table('df')

@udf.reduction(input_type=['double'] * N, output_type='double')
def my_reduction_fn(*args, **kwargs):
    return 3.0

# define expr with selection followed by aggregation with all input columns
expr = table.mutate(a=table['a'].cast('float')
all_cols = tuple(expr[col] for col in expr.columns if col != 'a')

%%time
expr = expr.groupby(expr.a).aggregate(result=my_reduction_fn(*all_args))
Wall time: 3.13s
```

Performance from here is quadratic:
```
6,000 cols -> Wall time 12.9s  (x2 cols, x2^2 performance)
9,000 cols -> Wall time 28.9 s (x3 cols, x2^3 performance)
```

For now it is likely better to disable this optimization inside the ``Aggregation`` construction until we can improve the performance.