### PR TITLE
TST: Run tests for backends defined as entrypoints

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - regex
   - toolz
   - cached_property # for 3.7 compat, functools.cached_property is for >=3.8
+  - setuptools
 
   # Ibis soft dependencies
   - sqlalchemy

--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -1,6 +1,6 @@
 import importlib
 import os
-from pathlib import Path
+import pkg_resources
 from typing import List
 
 import pandas as pd
@@ -21,11 +21,9 @@ def _get_all_backends() -> List[str]:
     """
     Return the list of known backend names.
     """
-    return [
-        d.name
-        for d in (Path(ibis.__file__).parent / 'backends').iterdir()
-        if list(d.glob('tests/conftest.py'))
-    ]
+    return [entry_point.name
+            for entry_point in
+            pkg_resources.iter_entry_points(group='ibis.backends', name=None)]
 
 
 def _backend_name_to_class(backend_str: str):

--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -1,9 +1,9 @@
 import importlib
 import os
-import pkg_resources
 from typing import List
 
 import pandas as pd
+import pkg_resources
 import pytest
 
 import ibis
@@ -21,9 +21,12 @@ def _get_all_backends() -> List[str]:
     """
     Return the list of known backend names.
     """
-    return [entry_point.name
-            for entry_point in
-            pkg_resources.iter_entry_points(group='ibis.backends', name=None)]
+    return [
+        entry_point.name
+        for entry_point in pkg_resources.iter_entry_points(
+            group='ibis.backends', name=None
+        )
+    ]
 
 
 def _backend_name_to_class(backend_str: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytz
 regex
 toolz
 cached_property
+setuptools


### PR DESCRIPTION
The backend tests currently run for all backends in `ibis/backends/`. With this PR it will run with backends defined as entrypoints. So, besides the core backends i nthat directory, tests can be run from third-party backends.