### PR TITLE
Loading TestConf correctly for third-party backends

### DIFF
--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -33,16 +33,15 @@ def _backend_name_to_class(backend_str: str):
     """
     Convert a backend string to the test configuration class for the backend.
     """
-    known_backends = _get_all_backends()
-    if backend_str not in known_backends:
+    try:
+        backend_package = getattr(ibis, backend_str).__module__
+    except AttributeError:
         raise ValueError(
             f'Unknown backend {backend_str}. '
-            f'Known backends: {known_backends}'
+            f'Known backends: {_get_all_backends()}'
         )
 
-    conftest = importlib.import_module(
-        f'ibis.backends.{backend_str}.tests.conftest'
-    )
+    conftest = importlib.import_module(f'{backend_package}.tests.conftest')
     return conftest.TestConf
 
 

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -110,7 +110,8 @@ def test_top_level_api():
 
 def test_backends_are_cached():
     # can't use `hasattr` since it calls `__getattr__`
-    assert 'sqlite' not in dir(ibis)
+    if 'sqlite' in dir(ibis):
+        del ibis.sqlite
     assert isinstance(ibis.sqlite, BaseBackend)
     assert 'sqlite' in dir(ibis)
 


### PR DESCRIPTION
Follow up of #2836

I didn't realise that the `TestConf` class was being loaded from the path in the Ibis repo. So that part had to be changed to load relative to the module in #2836. Changing it here, so Ibis backend tests can run in third-party backends.