### PR TITLE
ENH: Support no-op windows in the dask backend

### DIFF
--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -62,3 +62,5 @@ class Backend(BaseBackend):
             'See ibis.dask.trace for details.',
             validator=ibis.config.is_bool,
         )
+        # forces the pandas backend to register options
+        getattr(ibis, "pandas")

--- a/ibis/backends/dask/execution/__init__.py
+++ b/ibis/backends/dask/execution/__init__.py
@@ -11,3 +11,4 @@ from .selection import *  # noqa: F401,F403
 from .strings import *  # noqa: F401,F403
 from .structs import *  # noqa: F401,F403
 from .temporal import *  # noqa: F401,F403
+from .window import *  # noqa: F401,F403

--- a/ibis/backends/dask/execution/window.py
+++ b/ibis/backends/dask/execution/window.py
@@ -1,0 +1,86 @@
+"""Code for computing window functions in the dask backend."""
+
+from typing import Any, Optional, Union
+
+import dask.dataframe as dd
+
+import ibis.expr.operations as ops
+import ibis.expr.window as win
+from ibis.expr.scope import Scope
+from ibis.expr.typing import TimeContext
+
+from ..core import execute_with_scope
+from ..dispatch import execute_node
+from .util import (
+    _pandas_dtype_from_dd_scalar,
+    _wrap_dd_scalar,
+    add_partitioned_sorted_column,
+    make_meta_series,
+)
+
+
+def _post_process_empty(
+    result: Any,
+    parent: Union[dd.Series, dd.DataFrame],
+    timecontext: Optional[TimeContext],
+) -> dd.Series:
+    """Post process non grouped, non ordered windows.
+
+    dd.Series/dd.DataFrame objects are passed through, otherwise we conform
+    the output to the parent input (i.e. so the shape an partitioning matches).
+
+    dd.core.Scalar needs special handling so downstream functions can work
+    with it.
+    """
+    if isinstance(result, (dd.Series, dd.DataFrame)):
+        return result
+    elif isinstance(result, dd.core.Scalar):
+        # TODO this should be refactored with similar logic in util.py
+        # both solve the generalish problem we have of wrapping a
+        # dd.core.Scalar into something dask can work with downstream
+        # TODO computation
+        lens = parent.index.map_partitions(len).compute().values
+        out_dtype = _pandas_dtype_from_dd_scalar(result)
+        meta = make_meta_series(dtype=out_dtype)
+        delayeds = [_wrap_dd_scalar(result, None, out_len) for out_len in lens]
+        series = dd.from_delayed(delayeds, meta=meta)
+        series = add_partitioned_sorted_column(series)
+        return series[0]
+    else:
+        # Project any non delayed object to the shape of "parent"
+        return parent.apply(lambda row: result, meta=(None, 'object'))
+
+
+@execute_node.register(ops.WindowOp, dd.Series, win.Window)
+def execute_window_op(
+    op,
+    data,
+    window,
+    scope: Scope = None,
+    timecontext: Optional[TimeContext] = None,
+    aggcontext=None,
+    clients=None,
+    **kwargs,
+):
+    # Currently this acts as an "unwrapper" for trivial windows (i.e. those
+    # with no ordering/grouping/preceding/following functionality).
+    if not all(
+        [
+            window.preceding is None,
+            window.following is None,
+            window._group_by == [],
+            window._order_by == [],
+        ]
+    ):
+        raise NotImplementedError(
+            "Window operations are unsuported in the dask backend"
+        )
+    result = execute_with_scope(
+        expr=op.expr,
+        scope=scope,
+        timecontext=timecontext,
+        aggcontext=aggcontext,
+        clients=clients,
+        **kwargs,
+    )
+    return _post_process_empty(result, data, timecontext)

--- a/ibis/backends/dask/tests/test_udf.py
+++ b/ibis/backends/dask/tests/test_udf.py
@@ -259,7 +259,7 @@ def test_udaf_analytic_groupby(con, t, df):
     def f(s):
         return s.sub(s.mean()).div(s.std())
 
-    expected = df.groupby('key').c.transform(f)
+    expected = df.groupby('key').c.transform(f).compute()
     tm.assert_series_equal(result, expected)
 
 
@@ -491,14 +491,11 @@ def test_array_return_type_reduction(con, t, df, qs):
     assert list(result) == expected.tolist()
 
 
-@pytest.mark.xfail(
-    raises=NotImplementedError, reason='TODO - windowing - #2553'
-)
 def test_array_return_type_reduction_window(con, t, df, qs):
     """Tests reduction UDF returning an array, used over a window."""
     expr = quantiles(t.b, quantiles=qs).over(ibis.window())
     result = expr.execute()
-    expected_raw = df.b.quantile(qs).tolist()
+    expected_raw = df.b.quantile(qs).compute().tolist()
     expected = pd.Series([expected_raw] * len(df))
     tm.assert_series_equal(result, expected)
 

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -265,8 +265,7 @@ def test_analytic_udf(backend, alltypes, df):
     backend.assert_series_equal(result, expected, check_names=False)
 
 
-@pytest.mark.only_on_backends(['pandas', 'pyspark'])
-# TODO - windowing - #2553
+@pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
 @pytest.mark.xfail_unsupported
 @pytest.mark.parametrize('udf', calc_zscore_udfs)
 def test_analytic_udf_mutate(backend, alltypes, df, udf):


### PR DESCRIPTION
Previously (in https://github.com/ibis-project/ibis/pull/2786) I tried to handle windowing + grouping/ordering in the same PR  and it got very messy. This is a simpler PR that "unwraps" a windowing operation and executes the logic inside. Only supports "no-op" windows (those with no lead/lag/group by/order by parameters).  But this can occur in situations like `test_analytic_udf_mutate`. The `add_partitioned_sorted_column` will be used in follow up PRs to support grouping and ordering windows (and I can probably get rid of all usages of `utils.safe_concat` now).

This code also fixes https://github.com/ibis-project/ibis/issues/2711 by using `da.select`. This was only introduced in dask 2021.6.1, so I've ported the code into a shim. https://github.com/ibis-project/ibis/issues/2847 is a follow up issue to remove this. 

Other follow-ups:

- Grouping + ordering windows
- consolidate some of the code around "wrapping a dd.core.Scalar" into a collection that dask can work with downstream. 
- Look into getting rid of `utils.safe_concat` now that selection is indexed

Post Merge:

- [ ] Update https://github.com/ibis-project/ibis/issues/2553