### PR TITLE
CLN: Simplify SQLAlchemy client

### DIFF
--- a/ibis/backends/base/sql/alchemy/client.py
+++ b/ibis/backends/base/sql/alchemy/client.py
@@ -224,7 +224,7 @@ class AlchemyClient(SQLClient):
 
     def list_schemas(self):
         """List all the schemas in the current database."""
-        return self.inspector.get_schema_names()
+        return sa.inspect(self.con).get_schema_names()
 
     def list_tables(
         self,

--- a/ibis/backends/mysql/client.py
+++ b/ibis/backends/mysql/client.py
@@ -170,52 +170,8 @@ class MySQLClient(AlchemyClient):
     def list_databases(self):
         return [row.Database for row in self.con.execute('SHOW DATABASES')]
 
-    def list_schemas(self):
-        """List all the schemas in the current database."""
-        return self.inspector.get_schema_names()
-
     def set_database(self, name):
         raise NotImplementedError(
             'Cannot set database with MySQL client. To use a different'
             ' database, use client.database({!r})'.format(name)
         )
-
-    @property
-    def client(self):
-        return self
-
-    def table(self, name, database=None, schema=None):
-        """Create a table expression that references a particular a table
-        called `name` in a MySQL database called `database`.
-
-        Parameters
-        ----------
-        name : str
-            The name of the table to retrieve.
-        database : str, optional
-            The database in which the table referred to by `name` resides. If
-            ``None`` then the ``current_database`` is used.
-        schema : str, optional
-            The schema in which the table resides.  If ``None`` then the
-            `public` schema is assumed.
-
-        Returns
-        -------
-        table : TableExpr
-            A table expression.
-        """
-        if database is not None and database != self.current_database:
-            return self.database(name=database).table(name=name, schema=schema)
-        else:
-            alch_table = self._get_sqla_table(name, schema=schema)
-            node = self.table_class(alch_table, self, self._schemas.get(name))
-            return self.table_expr_class(node)
-
-    def list_tables(self, like=None, database=None, schema=None):
-        if database is not None and database != self.current_database:
-            return self.database(name=database).list_tables(
-                like=like, schema=schema
-            )
-        else:
-            parent = super(MySQLClient, self)
-            return parent.list_tables(like=like, schema=schema)

--- a/ibis/backends/postgres/client.py
+++ b/ibis/backends/postgres/client.py
@@ -145,55 +145,11 @@ class PostgreSQLClient(AlchemyClient):
             )
         ]
 
-    def list_schemas(self):
-        """List all the schemas in the current database."""
-        return self.inspector.get_schema_names()
-
     def set_database(self, name):
         raise NotImplementedError(
             'Cannot set database with PostgreSQL client. To use a different'
             ' database, use client.database({!r})'.format(name)
         )
-
-    @property
-    def client(self):
-        return self
-
-    def table(self, name, database=None, schema=None):
-        """Create a table expression that references a particular a table
-        called `name` in a PostgreSQL database called `database`.
-
-        Parameters
-        ----------
-        name : str
-            The name of the table to retrieve.
-        database : str, optional
-            The database in which the table referred to by `name` resides. If
-            ``None`` then the ``current_database`` is used.
-        schema : str, optional
-            The schema in which the table resides.  If ``None`` then the
-            `public` schema is assumed.
-
-        Returns
-        -------
-        table : TableExpr
-            A table expression.
-        """
-        if database is not None and database != self.current_database:
-            return self.database(name=database).table(name=name, schema=schema)
-        else:
-            alch_table = self._get_sqla_table(name, schema=schema)
-            node = self.table_class(alch_table, self, self._schemas.get(name))
-            return self.table_expr_class(node)
-
-    def list_tables(self, like=None, database=None, schema=None):
-        if database is not None and database != self.current_database:
-            return self.database(name=database).list_tables(
-                like=like, schema=schema
-            )
-        else:
-            parent = super(PostgreSQLClient, self)
-            return parent.list_tables(like=like, schema=schema)
 
     def udf(
         self, pyfunc, in_types, out_type, schema=None, replace=False, name=None

--- a/ibis/backends/sqlite/client.py
+++ b/ibis/backends/sqlite/client.py
@@ -75,43 +75,6 @@ class SQLiteClient(AlchemyClient):
         )
         self.has_attachment = True
 
-    @property
-    def client(self):
-        return self
-
-    def _get_sqla_table(self, name, schema=None, autoload=True):
-        return sa.Table(
-            name,
-            self.meta,
-            schema=schema or self.current_database,
-            autoload=autoload,
-        )
-
-    def table(self, name, database=None):
-        """
-        Create a table expression that references a particular table in the
-        SQLite database
-
-        Parameters
-        ----------
-        name : string
-        database : string, optional
-          name of the attached database that the table is located in.
-
-        Returns
-        -------
-        TableExpr
-
-        """
-        alch_table = self._get_sqla_table(name, schema=database)
-        node = self.table_class(alch_table, self)
-        return self.table_expr_class(node)
-
-    def list_tables(self, like=None, database=None, schema=None):
-        if database is None:
-            database = self.database_name
-        return super().list_tables(like, schema=database)
-
     def _table_from_schema(
         self, name, schema, database: Optional[str] = None
     ) -> sa.Table:


### PR DESCRIPTION
In preparation to move `Client` into `Backend`, some clean up of the SQLAlchemy backends:
- Moving repeated methods like `list_tables` or `table` to the main class, since those are common across SQLAlchemy backends
- Simplifying handling of `sqlalchemy.inspect()`. The function is immediate (and rarely called I think), and the code is overcomplicated to possibly save some micoseconds
- Remove `Client.client` property, which doesn't seem very useful