### PR TITLE
CI: Pin pyspark pandas dep for pyarrow issues

### DIFF
--- a/ci/deps/pyspark-min.yml
+++ b/ci/deps/pyspark-min.yml
@@ -2,3 +2,4 @@
 double-conversion
 pyarrow=0.12.1
 pyspark=2.4.3
+pandas=1.2.5

--- a/ci/deps/spark-min.yml
+++ b/ci/deps/spark-min.yml
@@ -2,3 +2,4 @@
 double-conversion
 pyarrow=0.12.1
 pyspark=2.4.3
+pandas=1.2.5


### PR DESCRIPTION
Last successful CI run: https://github.com/ibis-project/ibis/runs/2967145346?check_suite_focus=true
First Broken CI run: https://github.com/ibis-project/ibis/runs/2975032046?check_suite_focus=true

Errors look like:

```
 ==================================== ERRORS ====================================
 ____________ ERROR collecting ibis/backends/spark/tests/test_udf.py ____________
 ibis/backends/spark/tests/test_udf.py:98: in <module>
     @udf.elementwise.pandas([dt.double], dt.double)
 ibis/backends/spark/udf.py:93: in __call__
     udf_func = self.pyspark_udf(func)
 ibis/backends/spark/udf.py:125: in pyspark_udf
     return f.pandas_udf(func, self.spark_output_type, self.pandas_udf_type)
 /usr/share/miniconda/lib/python3.7/site-packages/pyspark/sql/functions.py:2922: in pandas_udf
     return _create_udf(f=f, returnType=return_type, evalType=eval_type)
 /usr/share/miniconda/lib/python3.7/site-packages/pyspark/sql/udf.py:47: in _create_udf
     require_minimum_pyarrow_version()
 /usr/share/miniconda/lib/python3.7/site-packages/pyspark/sql/utils.py:143: in require_minimum_pyarrow_version
     import pyarrow
 /usr/share/miniconda/lib/python3.7/site-packages/pyarrow/__init__.py:54: in <module>
     from pyarrow.lib import cpu_count, set_cpu_count
 pyarrow/ipc.pxi:18: in init pyarrow.lib
     ???
 E   AttributeError: type object 'pyarrow.lib.Message' has no attribute '__reduce_cython__'
```


Main env difference I see is pandas. Not entirely sure what causes this issue. 