### PR TITLE
ENH: Grouped unbounded windows in the dask backend 

### DIFF
--- a/ibis/backends/dask/execution/window.py
+++ b/ibis/backends/dask/execution/window.py
@@ -1,5 +1,6 @@
 """Code for computing window functions in the dask backend."""
 
+import operator
 from typing import Any, Optional, Union
 
 import dask.dataframe as dd
@@ -9,7 +10,7 @@ import ibis.expr.window as win
 from ibis.expr.scope import Scope
 from ibis.expr.typing import TimeContext
 
-from ..core import execute_with_scope
+from ..core import execute, execute_with_scope
 from ..dispatch import execute_node
 from .util import (
     _pandas_dtype_from_dd_scalar,
@@ -68,13 +69,27 @@ def execute_window_op(
         [
             window.preceding is None,
             window.following is None,
-            window._group_by == [],
             window._order_by == [],
         ]
     ):
         raise NotImplementedError(
             "Window operations are unsuported in the dask backend"
         )
+
+    if window._group_by:
+        # there's lots of complicated logic that only applies to grouped
+        # windows
+        return execute_grouped_window_op(
+            op,
+            data,
+            window,
+            scope,
+            timecontext,
+            aggcontext,
+            clients,
+            **kwargs,
+        )
+
     result = execute_with_scope(
         expr=op.expr,
         scope=scope,
@@ -84,3 +99,55 @@ def execute_window_op(
         **kwargs,
     )
     return _post_process_empty(result, data, timecontext)
+
+
+def execute_grouped_window_op(
+    op, data, window, scope, timecontext, aggcontext, clients, **kwargs,
+):
+    # extract the parent
+    (root,) = op.root_tables()
+    root_expr = root.to_expr()
+
+    root_data = execute(
+        root_expr,
+        scope=scope,
+        timecontext=timecontext,
+        clients=clients,
+        aggcontext=aggcontext,
+        **kwargs,
+    )
+
+    group_by = window._group_by
+    grouping_keys = [
+        key_op.name for key_op in map(operator.methodcaller('op'), group_by)
+    ]
+
+    grouped_root_data = root_data.groupby(grouping_keys)
+    scope = scope.merge_scopes(
+        [
+            Scope({t: grouped_root_data}, timecontext)
+            for t in op.expr.op().root_tables()
+        ],
+        overwrite=True,
+    )
+
+    result = execute_with_scope(
+        expr=op.expr,
+        scope=scope,
+        timecontext=timecontext,
+        aggcontext=aggcontext,
+        clients=clients,
+        **kwargs,
+    )
+    # If the grouped operation we performed is not an analytic UDF we have to
+    # realign the output to the input.
+    if not isinstance(op.expr._arg, ops.AnalyticVectorizedUDF):
+        result = dd.merge(
+            root_data[result.index.name].to_frame(),
+            result.to_frame(),
+            left_on=result.index.name,
+            right_index=True,
+        )[result.name]
+        result.divisions = root_data.divisions
+
+    return result

--- a/ibis/backends/dask/tests/test_udf.py
+++ b/ibis/backends/dask/tests/test_udf.py
@@ -246,9 +246,6 @@ def test_udaf_analytic(con, t, df):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(
-    raises=NotImplementedError, reason='TODO - windowing - #2553'
-)
 def test_udaf_analytic_groupby(con, t, df):
     expr = zscore(t.c).over(ibis.window(group_by=t.key))
 
@@ -260,7 +257,10 @@ def test_udaf_analytic_groupby(con, t, df):
         return s.sub(s.mean()).div(s.std())
 
     expected = df.groupby('key').c.transform(f).compute()
-    tm.assert_series_equal(result, expected)
+    # We don't check names here because the udf is used "directly".
+    # We could potentially special case this and set the name directly
+    # if the udf is only being run on one column.
+    tm.assert_series_equal(result, expected, check_names=False)
 
 
 def test_udaf_groupby(t2, df2):

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -587,9 +587,7 @@ def test_elementwise_udf_struct(backend, alltypes):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.only_on_backends(['pandas'])
-# TODO - windowing - #2553
-@pytest.mark.xfail_backends(['dask'])
+@pytest.mark.only_on_backends(['pandas', 'dask'])
 @pytest.mark.parametrize('udf', demean_struct_udfs)
 def test_analytic_udf_destruct(backend, alltypes, udf):
     w = window(preceding=None, following=None, group_by='year')
@@ -602,13 +600,10 @@ def test_analytic_udf_destruct(backend, alltypes, udf):
         demean=alltypes['double_col'] - alltypes['double_col'].mean().over(w),
         demean_weight=alltypes['int_col'] - alltypes['int_col'].mean().over(w),
     ).execute()
-
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.only_on_backends(['pandas'])
-# TODO - udf - #2553
-@pytest.mark.xfail_backends(['dask'])
+@pytest.mark.only_on_backends(['pandas', 'dask'])
 def test_analytic_udf_destruct_no_groupby(backend, alltypes):
     w = window(preceding=None, following=None)
 
@@ -629,9 +624,7 @@ def test_analytic_udf_destruct_no_groupby(backend, alltypes):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.only_on_backends(['pandas', 'pyspark'])
-# TODO - windowing - #2553
-@pytest.mark.xfail_backends(['dask'])
+@pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
 @pytest.mark.xfail_unsupported
 def test_analytic_udf_destruct_overwrite(backend, alltypes):
     w = window(preceding=None, following=None, group_by='year')


### PR DESCRIPTION
Part two of windows in the dask backend, built on top op noop windows in https://github.com/ibis-project/ibis/pull/2843. 

## Notes:

- `execute_grouped_window_op` directly follows the pandas logic in https://github.com/ibis-project/ibis/blob/master/ibis/backends/pandas/execution/window.py#L239. It felt better to section off all the grouping specific logic while windows are only partially supported by the dask backend, though we can refactor this later. 
- I've split up the handlers for grouped analytic and grouped reduction function application, the logic was getting a bit messy to put into one function like pandas does. 
- Using the udf directly, as in https://github.com/ibis-project/ibis/blob/master/ibis/backends/dask/tests/test_udf.py#L253 meant I needed to handle some of the "cleanup" actions inside the UDF. I dropped the names check as I couldn't think of a good way to get that working without "cheating" (i.e. making the name the single key). 
- As a follow up to this, I'd like to start doing some larger refactors in the dask and dask/pandas backends:
  - [ ] Cleaning up the usage `coerce_to_output`. I think a lot of the code paths were emergent and can now be cleaned up (for example struct output handling). 
  - [ ] Combining a lot of the pandas + dask udf testing
  - [ ] Combining a lot of the pandas + dask window testing.