### PR TITLE
Make TestConf.api work for third-party backends

### DIFF
--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -144,7 +144,7 @@ class BackendTest(abc.ABC):
 
     @property
     def api(self):
-        return getattr(ibis.backends, self.name()).Backend()
+        return getattr(ibis, self.name())
 
     def make_context(
         self, params: Optional[Mapping[ir.ValueExpr, Any]] = None


### PR DESCRIPTION
`TestConf.api` is assuming all backends can be accessed via `ibis.backends.<backend-name>.Backend()`, which is not true for third-party backends.