### PR TITLE
Support binary operation with Timedelta in Pyspark backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2873` Support binary operation with Timedelta in Pyspark backend
 * :support:`2865` Deprecated `ibis.<backend>.verify()` in favor of capturing exception in `ibis.<backend>.compile()`
 * :bug:`2845` Fix projection on differences and intersections for SQL backends
 * :bug:`2827` Backends are loaded in a lazy way, so third-party backends can import Ibis without circular imports

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -317,7 +317,7 @@ def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
         ],
     ),
 )
-@pytest.mark.xfail_unsupported
+@pytest.mark.only_on_backends(['dask', 'pandas', 'pyspark'])
 def test_temporal_binop_pandas_timedelta(
     backend, con, alltypes, df, timedelta, temporal_fn
 ):


### PR DESCRIPTION
This PR adds support in the Pyspark backend for doing binary operations (e.g. add/subtract) on timestamp columns using Pandas Timedeltas, for example:

```
dt['timestamp_col'] + pd.Timedelta(days=5)
```