### PR TITLE
CI/DOC: Make docs work with the latest Sphinx

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -52,6 +52,6 @@ dependencies:
   - nbsphinx
   - nomkl
   - semantic_version=2.6 # https://github.com/ibis-project/ibis/issues/2027
-  - sphinx<4.0.0 # https://github.com/ibis-project/ibis/issues/2771
+  - sphinx
   - sphinx-releases
   - sphinx_rtd_theme


### PR DESCRIPTION
Closes #2783

I didn't really make any changes.
The latest version of Sphinx running correctly.