### PR TITLE
Updating pandas Series.dt.weekofyear to avoid warnings

### DIFF
--- a/ibis/backends/pandas/execution/temporal.py
+++ b/ibis/backends/pandas/execution/temporal.py
@@ -38,6 +38,8 @@ def execute_extract_timestamp_field_timestamp(op, data, **kwargs):
 @execute_node.register(ops.ExtractTemporalField, pd.Series)
 def execute_extract_timestamp_field_series(op, data, **kwargs):
     field_name = type(op).__name__.lower().replace('extract', '')
+    if field_name == 'weekofyear':
+        return data.dt.isocalendar().week.astype(np.int32)
     return getattr(data.dt, field_name).astype(np.int32)
 
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -51,6 +51,8 @@ def test_timestamp_extract(backend, alltypes, df, attr):
         expected = (df.timestamp_col.dt.microsecond // 1000).astype('int32')
     elif attr == 'epoch_seconds':
         expected = df.timestamp_col.astype('int64') // int(1e9)
+    elif attr == 'week_of_year':
+        expected = df.timestamp_col.dt.isocalendar().week.astype('int32')
     else:
         expected = getattr(df.timestamp_col.dt, attr.replace('_', '')).astype(
             'int32'


### PR DESCRIPTION
pandas deprecated `Series.dt.weekyear`. Updating to the new syntax, to avoid warnings for users, in the tests, and to not have this breaking in future pandas updates.