### PR TITLE
Fixing several warnings

### DIFF
--- a/ibis/backends/clickhouse/tests/test_aggregations.py
+++ b/ibis/backends/clickhouse/tests/test_aggregations.py
@@ -40,8 +40,8 @@ def test_std_var_pop(con, alltypes, translate):
 
     assert translate(expr1) == 'stddevPopIf(`double_col`, `bigint_col` < 70)'
     assert translate(expr2) == 'varPopIf(`double_col`, `bigint_col` < 70)'
-    assert isinstance(con.execute(expr1), np.float)
-    assert isinstance(con.execute(expr2), np.float)
+    assert isinstance(con.execute(expr1), float)
+    assert isinstance(con.execute(expr2), float)
 
 
 @pytest.mark.parametrize('reduction', ['sum', 'count', 'max', 'min'])

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -177,8 +177,8 @@ def test_case_where(backend, alltypes, df):
     mask_1 = expected['int_col'] == 0
 
     expected['new_col'] = 0
-    expected['new_col'][mask_0] = 20
-    expected['new_col'][mask_1] = 10
+    expected.loc[mask_0, 'new_col'] = 20
+    expected.loc[mask_1, 'new_col'] = 10
     expected['new_col'] = expected['new_col']
 
     backend.assert_frame_equal(result, expected)

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -312,9 +312,7 @@ def test_binary_arithmetic_operations(backend, alltypes, df, op):
         result = result.astype('float64')
 
     expected = backend.default_series_rename(expected)
-    backend.assert_series_equal(
-        result, expected, check_exact=False, check_less_precise=True
-    )
+    backend.assert_series_equal(result, expected, check_exact=False)
 
 
 def test_mod(backend, alltypes, df):
@@ -336,9 +334,7 @@ def test_floating_mod(backend, alltypes, df):
     expected = operator.mod(df.double_col, df.smallint_col + 1)
 
     expected = backend.default_series_rename(expected)
-    backend.assert_series_equal(
-        result, expected, check_exact=False, check_less_precise=True
-    )
+    backend.assert_series_equal(result, expected, check_exact=False)
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -59,7 +59,7 @@ def test_string_col_is_unicode(backend, alltypes, df):
         ),
         param(
             lambda t: t.string_col.re_replace(r'[[:digit:]]+', 'a'),
-            lambda t: t.string_col.str.replace(r'\d+', 'a'),
+            lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
             id='re_replace',
             marks=pytest.mark.xfail_backends(('spark', 'pyspark')),
         ),
@@ -81,7 +81,7 @@ def test_string_col_is_unicode(backend, alltypes, df):
         ),
         param(
             lambda t: t.string_col.re_replace(r'\\d+', 'a'),
-            lambda t: t.string_col.str.replace(r'\d+', 'a'),
+            lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
             id='re_replace_spark',
             marks=pytest.mark.xpass_backends(
                 ('clickhouse', 'impala', 'spark')
@@ -105,7 +105,7 @@ def test_string_col_is_unicode(backend, alltypes, df):
         ),
         param(
             lambda t: t.string_col.re_replace(r'\d+', 'a'),
-            lambda t: t.string_col.str.replace(r'\d+', 'a'),
+            lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
             id='re_replace_spark',
             marks=pytest.mark.xfail_backends(
                 ('clickhouse', 'impala', 'spark')


### PR DESCRIPTION
The warnings list if quite long, and makes it quite time consuming to find test failures (and the github CI log is quite slow to load). Besides many of them are future warnings that will eventually make Ibis or the tests fail. Fixing several here.