### PR TITLE
Add GitHub Actions step with only pytest errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,9 +198,6 @@ jobs:
     - name: run tests
       run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh
 
-    - name: tests summary
-      run: cat pytest_summary.log
-
     - name: pytest errors
       run: ./ci/pytest_errors.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
       run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh
       shell: bash
 
+    - name: pytest errors
+      run: ./ci/pytest_errors.sh
+
   Tests_dask:
     name: Tests dask
     runs-on: ubuntu-latest
@@ -49,6 +52,9 @@ jobs:
     - name: run tests
       run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh
       shell: bash
+
+    - name: pytest errors
+      run: ./ci/pytest_errors.sh
 
   Tests_sql:
     name: Tests SQL
@@ -86,6 +92,9 @@ jobs:
 
     - name: run tests
       run: PYTEST_BACKENDS=$BACKENDS PYTEST_EXPRESSION="not udf" ./ci/run_tests.sh
+
+    - name: pytest errors
+      run: ./ci/pytest_errors.sh
 
   Tests_impala_clickhouse:
     name: Tests Impala / Clickhouse
@@ -167,6 +176,9 @@ jobs:
     - name: run tests
       run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh
 
+    - name: pytest errors
+      run: ./ci/pytest_errors.sh
+
   Tests_pyspark:
     name: Tests PySpark
     runs-on: ubuntu-18.04
@@ -186,6 +198,11 @@ jobs:
     - name: run tests
       run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh
 
+    - name: tests summary
+      run: cat pytest_summary.log
+
+    - name: pytest errors
+      run: ./ci/pytest_errors.sh
 
   Lint_and_benchmarks:
     name: Lint and benckmarks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
 
     - name: pytest errors
       run: ./ci/pytest_errors.sh
+      if: failure()
 
   Tests_dask:
     name: Tests dask
@@ -55,6 +56,7 @@ jobs:
 
     - name: pytest errors
       run: ./ci/pytest_errors.sh
+      if: failure()
 
   Tests_sql:
     name: Tests SQL
@@ -95,6 +97,7 @@ jobs:
 
     - name: pytest errors
       run: ./ci/pytest_errors.sh
+      if: failure()
 
   Tests_impala_clickhouse:
     name: Tests Impala / Clickhouse
@@ -178,6 +181,7 @@ jobs:
 
     - name: pytest errors
       run: ./ci/pytest_errors.sh
+      if: failure()
 
   Tests_pyspark:
     name: Tests PySpark
@@ -200,6 +204,7 @@ jobs:
 
     - name: pytest errors
       run: ./ci/pytest_errors.sh
+      if: failure()
 
   Lint_and_benchmarks:
     name: Lint and benckmarks

--- a/ci/pytest_errors.sh
+++ b/ci/pytest_errors.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+# parse the pytest log and print the pytest errors in a concise way
+
+csplit pytest.log "/short test summary info/" '{*}' > /dev/null
+mv xx00 pytest_errors.log
+mv xx01 pytest_summary.log
+
+head -n1 pytest_summary.log >> pytest_errors.log
+grep "^FAILED \|^ERROR " pytest_summary.log >> pytest_errors.log
+tail -n1 pytest_summary.log >> pytest_errors.log
+
+cat pytest_errors.log

--- a/ci/pytest_errors.sh
+++ b/ci/pytest_errors.sh
@@ -1,12 +1,15 @@
 #!/bin/bash -e
 # parse the pytest log and print the pytest errors in a concise way
 
-csplit pytest.log "/short test summary info/" '{*}' > /dev/null
-mv xx00 pytest_errors.log
-mv xx01 pytest_summary.log
+if [[ -f "pytest.log" ]]; then
+    csplit pytest.log "/= FAILURES =/" "/= short test summary info =/" '{*}' > /dev/null
+    mv xx00 pytest_progress.log
+    mv xx01 pytest_errors.log
+    mv xx02 pytest_summary.log
 
-head -n1 pytest_summary.log >> pytest_errors.log
-grep "^FAILED \|^ERROR " pytest_summary.log >> pytest_errors.log
-tail -n1 pytest_summary.log >> pytest_errors.log
+    head -n1 pytest_summary.log >> pytest_errors.log
+    grep "^FAILED \|^ERROR " pytest_summary.log >> pytest_errors.log
+    tail -n1 pytest_summary.log >> pytest_errors.log
 
-cat pytest_errors.log
+    cat pytest_errors.log
+fi

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -15,8 +15,9 @@ echo "PYTEST_EXPRESSION: $PYTEST_EXPRESSION"
 
 
 pytest $TESTS_DIRS \
+    -q \
     -m "${PYTEST_EXPRESSION}" \
     -ra \
     --junitxml=junit.xml \
     --cov=ibis \
-    --cov-report=xml:coverage.xml
+    --cov-report=xml:coverage.xml | tee pytest.log

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -13,6 +13,7 @@ done
 echo "TESTS_DIRS: $TESTS_DIRS"
 echo "PYTEST_EXPRESSION: $PYTEST_EXPRESSION"
 
+set -o pipefail
 
 pytest $TESTS_DIRS \
     -q \

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -119,7 +119,7 @@ def test_backends_are_cached():
 def test_missing_backend():
     msg = "If you are trying to access the 'foo' backend"
     with pytest.raises(AttributeError, match=msg):
-        ibis.foo
+        pass  # ibis.foo
 
 
 def test_multiple_backends(mocker):

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -119,7 +119,7 @@ def test_backends_are_cached():
 def test_missing_backend():
     msg = "If you are trying to access the 'foo' backend"
     with pytest.raises(AttributeError, match=msg):
-        pass  # ibis.foo
+        ibis.foo
 
 
 def test_multiple_backends(mocker):


### PR DESCRIPTION
It takes a lot of scrolling to find the traceback of tests errors. This adds a new step in GitHub actions with only the useful information, so it's immediate to find.