### PR TITLE
CLN: Remove unused and inconsistent backend markers

### DIFF
--- a/ibis/backends/clickhouse/tests/test_aggregations.py
+++ b/ibis/backends/clickhouse/tests/test_aggregations.py
@@ -7,8 +7,6 @@ import pytest
 
 from ibis import literal as L
 
-pytestmark = pytest.mark.clickhouse
-
 
 @pytest.mark.parametrize(
     ('reduction', 'func_translated'),

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -9,8 +9,6 @@ import ibis.config as config
 import ibis.expr.types as ir
 from ibis import literal as L
 
-pytestmark = pytest.mark.clickhouse
-
 
 def test_get_table_ref(db):
     table = db.functional_alltypes

--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -13,8 +13,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis import literal as L
 
-pytestmark = pytest.mark.clickhouse
-
 
 @pytest.mark.parametrize(
     ('to_type', 'expected'),

--- a/ibis/backends/clickhouse/tests/test_identifiers.py
+++ b/ibis/backends/clickhouse/tests/test_identifiers.py
@@ -1,8 +1,4 @@
-import pytest
-
 import ibis
-
-pytestmark = pytest.mark.clickhouse
 
 
 def test_column_ref_quoting(translate):

--- a/ibis/backends/clickhouse/tests/test_literals.py
+++ b/ibis/backends/clickhouse/tests/test_literals.py
@@ -4,8 +4,6 @@ from pandas import Timestamp
 import ibis
 from ibis import literal as L
 
-pytestmark = pytest.mark.clickhouse
-
 
 @pytest.mark.parametrize(
     'expr',

--- a/ibis/backends/clickhouse/tests/test_operators.py
+++ b/ibis/backends/clickhouse/tests/test_operators.py
@@ -10,8 +10,6 @@ import ibis
 import ibis.expr.datatypes as dt
 from ibis import literal as L
 
-pytestmark = pytest.mark.clickhouse
-
 
 @pytest.mark.parametrize(
     ('left', 'right', 'type'),

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -6,8 +6,6 @@ import pytest
 import ibis
 import ibis.common.exceptions as com
 
-pytestmark = pytest.mark.clickhouse
-
 
 @pytest.fixture(scope='module')
 def diamonds(con):

--- a/ibis/backends/clickhouse/tests/test_types.py
+++ b/ibis/backends/clickhouse/tests/test_types.py
@@ -1,7 +1,4 @@
-import pytest
 from pkg_resources import parse_version
-
-pytestmark = pytest.mark.clickhouse
 
 
 def test_column_types(alltypes):

--- a/ibis/backends/dask/tests/execution/test_cast.py
+++ b/ibis/backends/dask/tests/execution/test_cast.py
@@ -10,8 +10,6 @@ import ibis.expr.datatypes as dt  # noqa: E402
 
 from ...execution import execute
 
-pytestmark = pytest.mark.dask
-
 
 @pytest.mark.parametrize('from_', ['plain_float64', 'plain_int64'])
 @pytest.mark.parametrize(

--- a/ibis/backends/dask/tests/execution/test_functions.py
+++ b/ibis/backends/dask/tests/execution/test_functions.py
@@ -15,8 +15,6 @@ import ibis.expr.datatypes as dt  # noqa: E402
 
 from ...execution import execute
 
-pytestmark = pytest.mark.dask
-
 
 @pytest.mark.parametrize(
     'op',

--- a/ibis/backends/dask/tests/execution/test_join.py
+++ b/ibis/backends/dask/tests/execution/test_join.py
@@ -16,9 +16,6 @@ import ibis.common.exceptions as com
 # - https://github.com/dask/dask/issues/5060
 
 
-pytestmark = pytest.mark.dask
-
-
 join_type = pytest.mark.parametrize(
     'how',
     [

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -14,8 +14,6 @@ import ibis.expr.datatypes as dt
 
 from ...execution import execute
 
-pytestmark = pytest.mark.dask
-
 
 def test_table_column(t, df):
     expr = t.plain_int64

--- a/ibis/backends/dask/tests/execution/test_strings.py
+++ b/ibis/backends/dask/tests/execution/test_strings.py
@@ -4,8 +4,6 @@ import pytest
 from dask.dataframe.utils import tm  # noqa: E402
 from pytest import param
 
-pytestmark = pytest.mark.dask
-
 
 @pytest.mark.parametrize(
     ('case_func', 'expected_func'),

--- a/ibis/backends/dask/tests/execution/test_temporal.py
+++ b/ibis/backends/dask/tests/execution/test_temporal.py
@@ -15,8 +15,6 @@ from ibis.expr import datatypes as dt
 
 from ...execution import execute
 
-pytestmark = pytest.mark.dask
-
 
 @pytest.mark.parametrize(
     ('case_func', 'expected_func'),

--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -7,8 +7,6 @@ import ibis
 import ibis.common.exceptions as com
 from ibis.expr.timecontext import TimeContextRelation, compare_timecontext
 
-pytestmark = pytest.mark.dask
-
 
 def test_execute_with_timecontext(time_table):
     expr = time_table

--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -9,8 +9,6 @@ import ibis
 
 from ..client import DaskTable
 
-pytestmark = pytest.mark.dask
-
 
 def make_dask_data_frame(npartitions):
     df = pd.DataFrame(np.random.randn(30, 4), columns=list('ABCD'))

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -16,8 +16,6 @@ from ..client import DaskClient
 from ..core import execute, is_computable_input
 from ..dispatch import execute_node, post_execute, pre_execute
 
-pytestmark = pytest.mark.dask
-
 
 @pytest.mark.parametrize('func', [execute_node, pre_execute, post_execute])
 def test_no_execute_ambiguities(func):

--- a/ibis/backends/dask/tests/test_schema.py
+++ b/ibis/backends/dask/tests/test_schema.py
@@ -1,14 +1,11 @@
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-import pytest
 from dask.dataframe.utils import tm
 
 import ibis
 from ibis.expr import datatypes as dt
 from ibis.expr import schema as sch
-
-pytestmark = pytest.mark.dask
 
 
 def test_infer_exhaustive_dataframe(npartitions):

--- a/ibis/backends/impala/tests/test_client.py
+++ b/ibis/backends/impala/tests/test_client.py
@@ -14,8 +14,6 @@ import ibis.expr.types as ir
 import ibis.util as util
 from ibis.tests.util import assert_equal
 
-pytestmark = pytest.mark.impala
-
 
 @pytest.fixture(scope='module')
 def db(con, test_data_db):

--- a/ibis/backends/impala/tests/test_connection_pool.py
+++ b/ibis/backends/impala/tests/test_connection_pool.py
@@ -1,8 +1,4 @@
-import pytest
-
 import ibis
-
-pytestmark = pytest.mark.impala
 
 
 def test_connection_pool_size(hdfs, env, test_data_db):

--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -10,8 +10,6 @@ import ibis.util as util
 from ibis.backends.impala.compat import HS2Error
 from ibis.tests.util import assert_equal
 
-pytestmark = pytest.mark.impala
-
 
 def test_create_exists_view(con, temp_view):
     tmp_name = temp_view

--- a/ibis/backends/impala/tests/test_ddl_compilation.py
+++ b/ibis/backends/impala/tests/test_ddl_compilation.py
@@ -10,8 +10,6 @@ from ibis.backends.base.sql.ddl import (
 from ibis.backends.impala import ddl
 from ibis.backends.impala.compiler import ImpalaCompiler
 
-pytestmark = pytest.mark.impala
-
 
 def test_drop_table_compile():
     statement = DropTable('foo', database='bar', must_exist=True)

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -17,8 +17,6 @@ from ibis.tests.sql.test_compiler import ExprTestCases
 
 from ..compiler import ImpalaCompiler, ImpalaExprTranslator
 
-pytestmark = pytest.mark.impala
-
 
 def approx_equal(a, b, eps):
     assert abs(a - b) < eps

--- a/ibis/backends/impala/tests/test_metadata.py
+++ b/ibis/backends/impala/tests/test_metadata.py
@@ -1,12 +1,9 @@
 import unittest
 
 import pandas as pd
-import pytest
 from numpy import nan
 
 from ibis.backends.impala.metadata import parse_metadata
-
-pytestmark = pytest.mark.impala
 
 
 def _glue_lists_spacer(spacer, lists):

--- a/ibis/backends/impala/tests/test_pandas_interop.py
+++ b/ibis/backends/impala/tests/test_pandas_interop.py
@@ -8,8 +8,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 from ibis.backends.impala.pandas_interop import DataFrameWriter  # noqa: E402
 
-pytestmark = pytest.mark.impala
-
 
 @pytest.fixture
 def exhaustive_df():

--- a/ibis/backends/impala/tests/test_parquet_ddl.py
+++ b/ibis/backends/impala/tests/test_parquet_ddl.py
@@ -6,8 +6,6 @@ import ibis
 from ibis.backends.impala.compat import HS2Error
 from ibis.tests.util import assert_equal
 
-pytestmark = pytest.mark.impala
-
 
 def test_cleanup_tmp_table_on_gc(con, test_data_dir):
     import gc

--- a/ibis/backends/impala/tests/test_partition.py
+++ b/ibis/backends/impala/tests/test_partition.py
@@ -9,8 +9,6 @@ import ibis.util as util
 from ibis.backends.impala.compat import ImpylaError
 from ibis.tests.util import assert_equal
 
-pytestmark = pytest.mark.impala
-
 
 @pytest.fixture
 def df():

--- a/ibis/backends/impala/tests/test_patched.py
+++ b/ibis/backends/impala/tests/test_patched.py
@@ -1,9 +1,6 @@
 from unittest import mock
 
 import pandas as pd
-import pytest
-
-pytestmark = pytest.mark.impala
 
 
 def patch_execute(con):

--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -9,8 +9,6 @@ from ibis.tests.sql.test_compiler import ExprTestCases
 
 from ..compiler import ImpalaCompiler
 
-pytestmark = pytest.mark.impala
-
 
 class TestImpalaSQL(unittest.TestCase):
     def test_relabel_projection(self):

--- a/ibis/backends/impala/tests/test_udf.py
+++ b/ibis/backends/impala/tests/test_udf.py
@@ -18,7 +18,7 @@ from ibis.tests.expr.mocks import MockConnection
 
 from .. import ddl  # noqa: E402
 
-pytestmark = [pytest.mark.impala, pytest.mark.udf]
+pytestmark = pytest.mark.udf
 
 
 class TestWrapping(unittest.TestCase):

--- a/ibis/backends/impala/tests/test_window.py
+++ b/ibis/backends/impala/tests/test_window.py
@@ -8,8 +8,6 @@ from ibis.tests.util import assert_equal
 
 from ..compiler import ImpalaCompiler
 
-pytestmark = pytest.mark.impala
-
 
 @pytest.fixture
 def alltypes(con):

--- a/ibis/backends/pandas/tests/execution/test_cast.py
+++ b/ibis/backends/pandas/tests/execution/test_cast.py
@@ -11,8 +11,6 @@ import ibis.expr.datatypes as dt  # noqa: E402
 
 from ... import execute
 
-pytestmark = pytest.mark.pandas
-
 
 @pytest.mark.parametrize('from_', ['plain_float64', 'plain_int64'])
 @pytest.mark.parametrize(

--- a/ibis/backends/pandas/tests/execution/test_functions.py
+++ b/ibis/backends/pandas/tests/execution/test_functions.py
@@ -15,8 +15,6 @@ import ibis.expr.datatypes as dt  # noqa: E402
 from ... import execute
 from ...udf import udf
 
-pytestmark = pytest.mark.pandas
-
 
 @pytest.mark.parametrize(
     'op',

--- a/ibis/backends/pandas/tests/execution/test_join.py
+++ b/ibis/backends/pandas/tests/execution/test_join.py
@@ -8,9 +8,6 @@ import ibis.common.exceptions as com
 
 from ... import Backend
 
-pytestmark = pytest.mark.pandas
-
-
 join_type = pytest.mark.parametrize(
     'how',
     [

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -12,8 +12,6 @@ import ibis.expr.datatypes as dt
 
 from ... import Backend, execute
 
-pytestmark = pytest.mark.pandas
-
 
 def test_table_column(t, df):
     expr = t.plain_int64

--- a/ibis/backends/pandas/tests/execution/test_strings.py
+++ b/ibis/backends/pandas/tests/execution/test_strings.py
@@ -7,8 +7,6 @@ from pytest import param
 
 from ...execution.strings import sql_like_to_regex
 
-pytestmark = pytest.mark.pandas
-
 
 @pytest.mark.parametrize(
     ('case_func', 'expected_func'),

--- a/ibis/backends/pandas/tests/execution/test_temporal.py
+++ b/ibis/backends/pandas/tests/execution/test_temporal.py
@@ -13,8 +13,6 @@ from ibis.expr import datatypes as dt
 
 from ... import Backend, execute
 
-pytestmark = pytest.mark.pandas
-
 
 @pytest.mark.parametrize(
     ('case_func', 'expected_func'),

--- a/ibis/backends/pandas/tests/execution/test_timecontext.py
+++ b/ibis/backends/pandas/tests/execution/test_timecontext.py
@@ -12,8 +12,6 @@ from ibis.expr.timecontext import (
     construct_time_context_aware_series,
 )
 
-pytestmark = pytest.mark.pandas
-
 
 def test_execute_with_timecontext(time_table):
     expr = time_table

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -18,9 +18,6 @@ from ...aggcontext import AggregationContext, window_agg_udf
 from ...dispatch import pre_execute
 from ...execution.window import get_aggcontext
 
-pytestmark = pytest.mark.pandas
-
-
 # These custom classes are used inn test_custom_window_udf
 
 

--- a/ibis/backends/pandas/tests/test_client.py
+++ b/ibis/backends/pandas/tests/test_client.py
@@ -9,8 +9,6 @@ import ibis
 from .. import Backend
 from ..client import PandasTable  # noqa: E402
 
-pytestmark = pytest.mark.pandas
-
 
 @pytest.fixture
 def client():

--- a/ibis/backends/pandas/tests/test_core.py
+++ b/ibis/backends/pandas/tests/test_core.py
@@ -16,8 +16,6 @@ from ..client import PandasClient
 from ..core import is_computable_input
 from ..dispatch import execute_node, post_execute, pre_execute
 
-pytestmark = pytest.mark.pandas
-
 
 @pytest.fixture
 def dataframe():

--- a/ibis/backends/pandas/tests/test_schema.py
+++ b/ibis/backends/pandas/tests/test_schema.py
@@ -1,13 +1,10 @@
 import numpy as np
 import pandas as pd
 import pandas.testing as tm
-import pytest
 
 import ibis
 from ibis.expr import datatypes as dt
 from ibis.expr import schema as sch
-
-pytestmark = pytest.mark.pandas
 
 
 def test_infer_basic_types():

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -26,8 +26,6 @@ import ibis.expr.types as ir
 from ibis.backends.base.sql.alchemy import schema_from_table
 from ibis.tests.util import assert_equal
 
-pytestmark = pytest.mark.postgres
-
 POSTGRES_TEST_DB = os.environ.get(
     'IBIS_TEST_POSTGRES_DATABASE', 'ibis_testing'
 )

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -19,8 +19,6 @@ import ibis.expr.types as ir
 from ibis import literal as L
 from ibis.expr.window import rows_with_max_lookback
 
-pytestmark = pytest.mark.postgres
-
 
 @pytest.fixture
 def guid(con):

--- a/ibis/backends/postgres/tests/test_postgis.py
+++ b/ibis/backends/postgres/tests/test_postgis.py
@@ -5,7 +5,6 @@ from numpy import testing
 gp = pytest.importorskip('geopandas')
 
 pytestmark = [
-    pytest.mark.postgres,
     pytest.mark.postgis,
     pytest.mark.postgres_extensions,
 ]

--- a/ibis/backends/postgres/tests/test_udf.py
+++ b/ibis/backends/postgres/tests/test_udf.py
@@ -15,7 +15,6 @@ from ibis.backends.postgres.udf import PostgresUDFError, existing_udf, udf
 #     TODO: update Windows pipeline to exclude postgres_extensions
 #     TODO: remove postgis marker below once Windows pipeline updated
 pytestmark = [
-    pytest.mark.postgres,
     pytest.mark.udf,
     pytest.mark.postgis,
     pytest.mark.postgres_extensions,

--- a/ibis/backends/pyspark/tests/test_array.py
+++ b/ibis/backends/pyspark/tests/test_array.py
@@ -7,9 +7,6 @@ from pytest import param
 
 import ibis
 
-pytestmark = pytest.mark.pyspark
-
-
 if pyspark.__version__ < '3.0.0':
     null_representation = None
 else:

--- a/ibis/backends/pyspark/tests/test_basic.py
+++ b/ibis/backends/pyspark/tests/test_basic.py
@@ -7,8 +7,6 @@ import ibis
 import ibis.common.exceptions as com
 from ibis.backends.pyspark.compiler import _can_be_replaced_by_column_name
 
-pytestmark = pytest.mark.pyspark
-
 
 def test_basic(client):
     table = client.table('basic_table')

--- a/ibis/backends/pyspark/tests/test_ddl.py
+++ b/ibis/backends/pyspark/tests/test_ddl.py
@@ -9,8 +9,6 @@ import ibis.common.exceptions as com
 import ibis.util as util
 from ibis.tests.util import assert_equal
 
-pytestmark = pytest.mark.pyspark
-
 
 def test_create_exists_view(client, alltypes, temp_view):
     tmp_name = temp_view

--- a/ibis/backends/pyspark/tests/test_null.py
+++ b/ibis/backends/pyspark/tests/test_null.py
@@ -1,7 +1,4 @@
 import pandas.testing as tm
-import pytest
-
-pytestmark = pytest.mark.pyspark
 
 
 def test_isnull(client):

--- a/ibis/backends/pyspark/tests/test_timecontext.py
+++ b/ibis/backends/pyspark/tests/test_timecontext.py
@@ -4,8 +4,6 @@ import pytest
 
 from ibis.backends.pyspark.timecontext import combine_time_context
 
-pytestmark = pytest.mark.pyspark
-
 
 def test_table_with_timecontext(client):
     table = client.table('time_indexed_table')

--- a/ibis/backends/pyspark/tests/test_window.py
+++ b/ibis/backends/pyspark/tests/test_window.py
@@ -5,8 +5,6 @@ from pyspark.sql.window import Window
 
 import ibis
 
-pytestmark = pytest.mark.pyspark
-
 
 @pytest.mark.parametrize(
     ('ibis_windows', 'spark_range'),

--- a/ibis/backends/pyspark/tests/test_window_context_adjustment.py
+++ b/ibis/backends/pyspark/tests/test_window_context_adjustment.py
@@ -6,8 +6,6 @@ from pyspark.sql import Window
 
 import ibis
 
-pytestmark = pytest.mark.pyspark
-
 
 @pytest.mark.parametrize(
     ('ibis_windows', 'spark_range'),

--- a/ibis/backends/sqlite/tests/test_client.py
+++ b/ibis/backends/sqlite/tests/test_client.py
@@ -10,8 +10,6 @@ import ibis.config as config
 import ibis.expr.types as ir
 from ibis.util import guid
 
-pytestmark = pytest.mark.sqlite
-
 
 def test_file_not_exist_and_create():
     path = '__ibis_tmp_{}.db'.format(guid())

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -16,8 +16,6 @@ import ibis.expr.datatypes as dt
 from ibis import config
 from ibis import literal as L
 
-pytestmark = pytest.mark.sqlite
-
 
 @pytest.mark.parametrize(
     ('func', 'expected'),

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,25 +38,14 @@ xfail_strict = true
 addopts = --strict-markers
 markers =
     backend
-    clickhouse
-    csv
-    dask
     hdfs
-    hdf5
-    impala
     kudu
     min_spark_version
-    mysql
     only_on_backends
-    pandas
-    parquet
     postgis
-    postgres
     postgres_extensions
-    pyspark
     skip_backends
     skip_missing_feature
-    sqlite
     superuser
     udf
     xfail_backends


### PR DESCRIPTION
Markers for backends don't seem to add any value, since they are in separate directories, and we call them explicitly. I don't think there is any use case where the marker is useful, surely not excluding a backend from tests, since tests for a backend need to be added by path (e.g. `pytest ibis/tests ibis/backends/pandas`).

Also, in case we wanted to use them, they are not very reliable, some backends don't use them, some use them in only some of the tests...

Better to remove them to simplify things and avoid noise.