### PR TITLE
CI: Pin tzlocal version

### DIFF
--- a/ci/deps/clickhouse.yml
+++ b/ci/deps/clickhouse.yml
@@ -3,3 +3,4 @@ clickhouse-cityhash
 clickhouse-driver
 clickhouse-sqlalchemy
 lz4
+tzlocal<3

--- a/ci/deps/clickhouse.yml
+++ b/ci/deps/clickhouse.yml
@@ -3,4 +3,3 @@ clickhouse-cityhash
 clickhouse-driver
 clickhouse-sqlalchemy
 lz4
-tzlocal<3

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -56,6 +56,7 @@ requirements:
     - thrift >=0.11
     - thriftpy2
     - toolz
+    - tzlocal < 3 # not directly needed, but need to pin since 3.0 is broken
 
 test:
   imports:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - thrift >=0.11
     - thriftpy2
     - toolz
-    - tzlocal < 3 # not directly needed, but need to pin since 3.0 is broken
+    - tzlocal <3 # not directly needed, but need to pin since 3.0 is broken
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -40,6 +40,7 @@ dependencies:
   - conda-build # feedstock
   - ruamel.yaml # feedstock
   - pygit2 # dev/genrelease.py
+  - tzlocal<3 # not directly needed, but need to pin since 3.0 is broken
 
   # Docs
   - pip


### PR DESCRIPTION
We're getting this error in the CI:

```
pkg_resources.ContextualVersionConflict: (tzlocal 3.0 (/usr/share/miniconda/lib/python3.8/site-packages), Requirement.parse('tzlocal<3.0'), {'clickhouse-driver'})
```

Not sure what's the problem, but looks like tzlocal has just been released, so I guess it's a compatibility problem with the new version. Pinning for now.

I see that there is a tzlocal 4.0 alpha after the yesterday's 3.0, so I guess it may be a known problem about to be fixed.