### PR TITLE
Support summarization of empty data in Pandas backend

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2908` Support summarization of empty data in Pandas backend
 * :support:`2883` Output of `Client.version` returned as a string, instead of a setuptools `Version`
 * :feature:`2882` Unify implementation of fillna and isna in Pyspark backend
 * :support:`2862` Deprecated `list_schemas` in SQLAlchemy backends in favor of `list_databases`

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -369,7 +369,9 @@ class Summarize(AggregationContext):
                 'Object {} is not callable or a string'.format(function)
             )
 
-        if isinstance(grouped_data, pd.core.groupby.generic.SeriesGroupBy):
+        if isinstance(
+            grouped_data, pd.core.groupby.generic.SeriesGroupBy
+        ) and len(grouped_data):
             # `SeriesGroupBy.agg` does not allow np.arrays to be returned
             # from UDFs. To avoid `SeriesGroupBy.agg`, we will us
             # `Series.agg` manually on each group. (#2768)

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -311,8 +311,9 @@ def test_reduction_udf_on_empty_data(backend, alltypes):
         t.groupby('year').aggregate(mean=calc_mean(t['int_col'])).execute()
     )
     expected = pd.DataFrame({'year': [], 'mean': []})
-    expected = expected.assign(year=expected['year'].astype('int'))
-    backend.assert_frame_equal(result, expected)
+    # We check that the result is an empty DataFrame,
+    # rather than an error.
+    backend.assert_frame_equal(result, expected, check_dtype=False)
 
 
 @pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -303,6 +303,20 @@ def test_reduction_udf_array_return_type(backend, alltypes, df):
 
 @pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
 @pytest.mark.xfail_unsupported
+def test_reduction_udf_on_empty_data(backend, alltypes):
+    """Test that summarization can handle empty data"""
+    # First filter down to zero rows
+    t = alltypes[alltypes['int_col'] > np.inf]
+    result = (
+        t.groupby('year').aggregate(mean=calc_mean(t['int_col'])).execute()
+    )
+    expected = pd.DataFrame({'year': [], 'mean': []})
+    expected = expected.assign(year=expected['year'].astype('int'))
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.only_on_backends(['pandas', 'pyspark', 'dask'])
+@pytest.mark.xfail_unsupported
 def test_output_type_in_list_invalid(backend, alltypes, df):
     # Test that an error is raised if UDF output type is wrapped in a list
 

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -370,7 +370,7 @@ def coerce_to_dataframe(
         result = data
     elif isinstance(data, pd.Series):
         if not len(data):
-            result = pd.concat([data], axis=1)
+            result = data.to_frame()
         else:
             num_cols = len(data.iloc[0])
             series = [data.apply(lambda t: t[i]) for i in range(num_cols)]

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -369,9 +369,12 @@ def coerce_to_dataframe(
     if isinstance(data, pd.DataFrame):
         result = data
     elif isinstance(data, pd.Series):
-        num_cols = len(data.iloc[0])
-        series = [data.apply(lambda t: t[i]) for i in range(num_cols)]
-        result = pd.concat(series, axis=1)
+        if not len(data):
+            result = pd.concat([data], axis=1)
+        else:
+            num_cols = len(data.iloc[0])
+            series = [data.apply(lambda t: t[i]) for i in range(num_cols)]
+            result = pd.concat(series, axis=1)
     elif isinstance(data, (tuple, list, np.ndarray)):
         if isinstance(data[0], pd.Series):
             result = pd.concat(data, axis=1)


### PR DESCRIPTION
### Proposed Change
Handle empty input data in summarization.

Currently, when a summarization gets passed empty data in the Pandas backend, we error out with a confusing 
```
UnboundLocalError: local variable 'grouped_col_name' referenced before assignment
```

This PR adds checks in a couple of places for empty data, such that we gracefully return an empty DataFrame instead.

### Tests
Added a new test for this in test_vectorized_udf.py.