### PR TITLE
CLN: Remove overcomplicatted logging

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :support:`2914` Removed `log` method of clients, in favor of `verbose_log` option
 * :feature:`2916` Support joining on different columns in ClickHouse backend
 * :feature:`2908` Support summarization of empty data in Pandas backend
 * :support:`2883` Output of `Client.version` returned as a string, instead of a setuptools `Version`

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -5,13 +5,13 @@ import numpy as np
 import pandas as pd
 from clickhouse_driver.client import Client as _DriverClient
 
+import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.backends.base.sql import SQLClient
 from ibis.config import options
-from ibis.util import log
 
 from .compiler import ClickhouseCompiler
 
@@ -171,9 +171,6 @@ class ClickhouseClient(SQLClient):
         self.table_expr_class = backend.table_expr_class
         self.con = _DriverClient(*args, **kwargs)
 
-    def log(self, msg):
-        log(msg)
-
     def raw_sql(self, query: str, external_tables={}):
         external_tables_list = []
         for name, df in external_tables.items():
@@ -198,7 +195,7 @@ class ClickhouseClient(SQLClient):
                 }
             )
 
-        self.log(query)
+        ibis.util.log(query)
         return self.con.execute(
             query,
             columnar=True,

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -37,7 +37,6 @@ from ibis.backends.base.sql.ddl import (
     is_fully_qualified,
 )
 from ibis.config import options
-from ibis.util import log
 
 from . import ddl, udf
 from .compat import HS2Error, ImpylaError, impyla
@@ -114,13 +113,13 @@ class ImpalaConnection:
             query = query.compile()
 
         cursor = self._get_cursor()
-        self.log(query)
+        util.log(query)
 
         try:
             cursor.execute(query)
         except Exception:
             cursor.release()
-            self.error(
+            util.log(
                 'Exception caused by {}: {}'.format(
                     query, traceback.format_exc()
                 )
@@ -128,12 +127,6 @@ class ImpalaConnection:
             raise
 
         return cursor
-
-    def log(self, msg):
-        log(msg)
-
-    def error(self, msg):
-        self.log(msg)
 
     def fetchall(self, query):
         with self.execute(query) as cur:
@@ -837,9 +830,6 @@ class ImpalaClient(SQLClient):
         """
         self.con.disable_codegen(disabled)
 
-    def log(self, msg):
-        log(msg)
-
     def _fully_qualified_name(self, name, database):
         if is_fully_qualified(name):
             return name
@@ -938,10 +928,10 @@ class ImpalaClient(SQLClient):
             udas = []
         if force:
             for table in tables:
-                self.log('Dropping {0}'.format('{0}.{1}'.format(name, table)))
+                util.log('Dropping {0}'.format('{0}.{1}'.format(name, table)))
                 self.drop_table_or_view(table, database=name)
             for func in udfs:
-                self.log(
+                util.log(
                     'Dropping function {0}({1})'.format(func.name, func.inputs)
                 )
                 self.drop_udf(
@@ -951,7 +941,7 @@ class ImpalaClient(SQLClient):
                     force=True,
                 )
             for func in udas:
-                self.log(
+                util.log(
                     'Dropping aggregate function {0}({1})'.format(
                         func.name, func.inputs
                     )

--- a/ibis/backends/impala/hdfs.py
+++ b/ibis/backends/impala/hdfs.py
@@ -35,15 +35,6 @@ class HDFS:
     user/developer against) various 3rd party library API differences.
     """
 
-    def log(self, message: str):
-        """Print a log message.
-
-        Parameters
-        ----------
-        message: string
-        """
-        print(message)
-
     def exists(self, path: str) -> bool:
         """Check if the file exists.
 

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -18,7 +18,6 @@ from ibis.backends.base.sql.ddl import (
 )
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import canonicalize_context, localize_context
-from ibis.util import log
 
 from . import ddl
 from .compiler import PySparkExprTranslator
@@ -321,9 +320,6 @@ class PySparkClient(SQLClient):
     def _get_schema_using_query(self, query):
         cur = self.raw_sql(query)
         return spark_dataframe_schema(cur.query)
-
-    def log(self, msg):
-        log(msg)
 
     def _get_jtable(self, name, database=None):
         try:


### PR DESCRIPTION
Some backends implement `Client.log`, which doesn't seem useful at all. I guess the original reason was to be able to overwrite the method, so the logging could be replaced. I don't think `Client` is subclassed for any of the backends that provide the `log` method. And also, the provided implementation of the logging uses `options.verbose_log`, which can be set to change the logging in an easier way than overwritting the method.

Removing those `log` methods here, which are inconsistent among backends, don't provided any feature, and polute the public `Client` API.