### PR TITLE
FEAT: ClickHouse: support joining on different columns.

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2916` Support joining on different columns in ClickHouse backend
 * :feature:`2908` Support summarization of empty data in Pandas backend
 * :support:`2883` Output of `Client.version` returned as a string, instead of a setuptools `Version`
 * :feature:`2882` Unify implementation of fillna and isna in Pyspark backend

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -1,8 +1,6 @@
 from io import StringIO
 
-import ibis.common.exceptions as com
 import ibis.expr.operations as ops
-import ibis.util as util
 from ibis.backends.base.sql.compiler import (
     Compiler,
     ExprTranslator,
@@ -11,7 +9,6 @@ from ibis.backends.base.sql.compiler import (
     TableSetFormatter,
 )
 
-from .identifiers import quote_identifier
 from .registry import operation_registry
 
 
@@ -66,71 +63,7 @@ class ClickhouseTableSetFormatter(TableSetFormatter):
         ops.AnyLeftJoin: 'ANY LEFT JOIN',
     }
 
-    def get_result(self):
-        # Got to unravel the join stack; the nesting order could be
-        # arbitrary, so we do a depth first search and push the join tokens
-        # and predicates onto a flat list, then format them
-        op = self.expr.op()
-
-        if isinstance(op, ops.Join):
-            self._walk_join_tree(op)
-        else:
-            self.join_tables.append(self._format_table(self.expr))
-
-        # TODO: Now actually format the things
-        buf = StringIO()
-        buf.write(self.join_tables[0])
-        for jtype, table, preds in zip(
-            self.join_types, self.join_tables[1:], self.join_predicates
-        ):
-            buf.write('\n')
-            buf.write(util.indent(f'{jtype} {table}', self.indent))
-
-            fmt_preds = []
-            npreds = len(preds)
-            using_clause_flag = True
-            for pred in preds:
-                op = pred.op()
-                if (
-                    not isinstance(op, ops.Equals)
-                    or op.args[0].get_name() != op.args[1].get_name()
-                ):
-                    using_clause_flag = False
-                new_pred = self._translate(pred)
-                if npreds > 1:
-                    new_pred = f'({new_pred})'
-                fmt_preds.append(new_pred)
-
-            if npreds > 0:
-                buf.write('\n')
-                if using_clause_flag:
-                    fmt_preds = map(self._format_predicate, preds)
-                    fmt_preds = util.indent(
-                        'USING ' + ', '.join(fmt_preds), self.indent * 2
-                    )
-                else:
-                    conj = f' AND\n{" " * 3}'
-                    fmt_preds = util.indent(
-                        'ON ' + conj.join(fmt_preds), self.indent * 2
-                    )
-                buf.write(fmt_preds)
-
-        return buf.getvalue()
-
-    def _validate_join_predicates(self, predicates):
-        for pred in predicates:
-            op = pred.op()
-            if not isinstance(op, ops.Equals):
-                raise com.TranslationError(
-                    'Non-equality join predicates are ' 'not supported'
-                )
-
-    def _format_predicate(self, predicate):
-        column = predicate.op().args[0]
-        return quote_identifier(column.get_name(), force=True)
-
-    def _quote_identifier(self, name):
-        return quote_identifier(name)
+    _non_equijoin_supported = False
 
 
 class ClickhouseExprTranslator(ExprTranslator):

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -474,7 +474,7 @@ def _table_column(translator, expr):
     if ctx.need_aliases():
         alias = ctx.get_ref(table)
         if alias is not None:
-            quoted_name = '{0}.{1}'.format(alias, quoted_name)
+            quoted_name = f'{alias}.{quoted_name}'
 
     return quoted_name
 

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -471,11 +471,10 @@ def _table_column(translator, expr):
         proj_expr = table.projection([field_name]).to_array()
         return _table_array_view(translator, proj_expr)
 
-    # TODO(kszucs): table aliasing is partially supported
-    # if ctx.need_aliases():
-    #     alias = ctx.get_ref(table)
-    #     if alias is not None:
-    #         quoted_name = '{0}.{1}'.format(alias, quoted_name)
+    if ctx.need_aliases():
+        alias = ctx.get_ref(table)
+        if alias is not None:
+            quoted_name = '{0}.{1}'.format(alias, quoted_name)
 
     return quoted_name
 

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import clickhouse_driver
 import pandas as pd
 import pandas.testing as tm
@@ -265,43 +267,46 @@ def test_non_equijoin(alltypes):
         expr.execute()
 
 
-def test_join_with_predicate_on_different_columns_raises(
-    con, batting, awards_players
-):
-    t1 = batting
-    t2 = awards_players
-
-    pred = t1['playerID'] == t2['awardID']
-    expr = t1.inner_join(t2, [pred])[[t1]]
-
-    with pytest.raises(com.TranslationError):
-        ibis.clickhouse.compile(expr)
-
-
 @pytest.mark.parametrize(
-    ('join_type', 'join_clause'),
-    [
-        ('any_inner_join', 'ANY INNER JOIN'),
-        ('inner_join', 'ALL INNER JOIN'),
-        ('any_left_join', 'ANY LEFT JOIN'),
-        ('left_join', 'ALL LEFT JOIN'),
-    ],
+    ('join_type_and_clause', 'join_keys'),
+    product(
+        [
+            ('any_inner_join', 'ANY INNER JOIN'),
+            ('inner_join', 'ALL INNER JOIN'),
+            ('any_left_join', 'ANY LEFT JOIN'),
+            ('left_join', 'ALL LEFT JOIN'),
+        ],
+        [
+            ('playerID',),
+            ('playerID', 'awardID'),
+        ],
+    ),
 )
 def test_simple_joins(
-    con, db, batting, awards_players, join_type, join_clause
+    con, db, batting, awards_players, join_type_and_clause, join_keys
 ):
+    join_type, join_clause = join_type_and_clause
     t1, t2 = batting, awards_players
-    expr = getattr(t1, join_type)(t2, ['playerID'])[[t1]]
+    if len(join_keys) == 1:
+        pred = join_keys
+        join_keys_str = f'    USING `{join_keys[0]}`'
+    else:
+        pred = [t1[join_keys[0]] == t2[join_keys[1]]]
+        join_keys_str = f'    ON t0.`{join_keys[0]}` = t1.`{join_keys[1]}`'
+    expr = getattr(t1, join_type)(t2, pred)[[t1]]
 
-    expected = """SELECT t0.*
-FROM {0}.`batting` t0
-  {join_clause} {0}.`awards_players` t1
-    USING `playerID`""".format(
-        db.name, join_clause=join_clause
+    expected = (
+        'SELECT t0.*\n'
+        f'FROM {db.name}.`batting` t0\n'
+        f'  {join_clause} {db.name}.`awards_players` t1\n'
+        f'{join_keys_str}'
     )
 
     assert ibis.clickhouse.compile(expr) == expected
-    assert len(con.execute(expr))
+    try:
+        con.execute(expr)
+    except clickhouse_driver.errors.ServerException:
+        pytest.fail('ClickHouse raise a `ServerException` error.')
 
 
 def test_self_reference_simple(con, db, alltypes):

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -276,10 +276,7 @@ def test_non_equijoin(alltypes):
             ('any_left_join', 'ANY LEFT JOIN'),
             ('left_join', 'ALL LEFT JOIN'),
         ],
-        [
-            ('playerID',),
-            ('playerID', 'awardID'),
-        ],
+        [('playerID',), ('playerID', 'awardID'),],  # noqa: E231
     ),
 )
 def test_simple_joins(
@@ -296,7 +293,7 @@ def test_simple_joins(
     expr = getattr(t1, join_type)(t2, pred)[[t1]]
 
     expected = (
-        'SELECT t0.*\n'
+        f'SELECT t0.*\n'
         f'FROM {db.name}.`batting` t0\n'
         f'  {join_clause} {db.name}.`awards_players` t1\n'
         f'{join_keys_str}'


### PR DESCRIPTION
It seems that for some historical reasons ClickHouse backend banned joining on different columns, and that has been supported by ClickHouse now. So i removed the vailidation and added some codes for that (refer to ibis SQL backend).