### PR TITLE
Do not print full tree repr in resolve_name error message

### DIFF
--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -139,7 +139,7 @@ class ValueOp(Node):
         return distinct_roots(*exprs)
 
     def resolve_name(self):
-        raise com.ExpressionError('Expression is not named: %s' % type(self))
+        raise com.ExpressionError(f'Expression is not named: {type(self)}')
 
     def has_resolved_name(self):
         return False

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -139,7 +139,7 @@ class ValueOp(Node):
         return distinct_roots(*exprs)
 
     def resolve_name(self):
-        raise com.ExpressionError('Expression is not named: %s' % repr(self))
+        raise com.ExpressionError('Expression is not named: %s' % type(self))
 
     def has_resolved_name(self):
         return False


### PR DESCRIPTION
### Proposed Change

`resolve_name` is a method defined on Ops, and is used to get the name of a given Expr (e.g. `get_name` on an Expr calls into its Op's `resolve_name` method). Currently, the `resolve_name` implementation of `ValueOp` raises an error that calls `repr(self)` to print out the entire expression tree. This O(N) error message is problematic especially for large trees, resulting in very slow performance just to raise an error message.

This change will print `type(self)` instead.