### PR TITLE
BUG: Fix pyspark client that was being used to test without data

### DIFF
--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -198,9 +198,8 @@ class TestConf(BackendTest, RoundAwayFromZero):
 
 
 @pytest.fixture(scope='session')
-def client():
-    session = SparkSession.builder.getOrCreate()
-    client = ibis.backends.pyspark.Backend().connect(session)
+def client(data_directory):
+    client = get_pyspark_testing_client(data_directory)
 
     df = client._session.range(0, 10)
     df = df.withColumn("str_col", F.lit('value'))


### PR DESCRIPTION
Tests were being run without data for the backend, causing them to fail
