### PR TITLE
TST: show the name of the backend when running tests

### DIFF
--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -60,6 +60,7 @@ def _get_backends_to_test():
         pytest.param(
             _backend_name_to_class(backend),
             marks=getattr(pytest.mark, backend),
+            id=backend,
         )
         for backend in sorted(backends)
     ]


### PR DESCRIPTION
Prior to this patch the backends all show up as `TestConf1`, `TestConf2`, etc.
