### PR TITLE
TST: Remove low-utility test

### DIFF
--- a/ibis/tests/test_version.py
+++ b/ibis/tests/test_version.py
@@ -1,21 +1,7 @@
-import os
-
-import pytest
 from pkg_resources import parse_version
 from pkg_resources.extern.packaging.version import Version
 
 import ibis
-
-
-@pytest.mark.skipif(
-    bool(os.environ.get("CI")) or bool(os.environ.get("AZURECI")),
-    reason="Testing import time on CI is flaky due to machine variance",
-)
-def test_import_time():
-    pb = pytest.importorskip("plumbum")
-    lines = ["from timeit import timeit", "print(timeit('import ibis'))"]
-    delta = float(pb.cmd.python["-c", "; ".join(lines)]().strip())
-    assert delta < 2.0
 
 
 def test_version():


### PR DESCRIPTION
This test has low utility, as it cannot be validated in CI.
