### PR TITLE
TST: Add backend marker

### DIFF
--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -59,7 +59,7 @@ def _get_backends_to_test():
     return [
         pytest.param(
             _backend_name_to_class(backend),
-            marks=getattr(pytest.mark, backend),
+            marks=[getattr(pytest.mark, backend), pytest.mark.backend],
             id=backend,
         )
         for backend in sorted(backends)


### PR DESCRIPTION
This PR adds a `backend` marker for backend tests which makes it easier to run non-backend and backend tests in the same pytest session.
