### PR TITLE
fix: fix a few broken assumptions in the dask and pandas backends

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       shell: bash
 
     - name: run tests
-      run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh --numprocesses 2
+      run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh --numprocesses auto
       shell: bash
 
     - name: pytest errors
@@ -51,7 +51,7 @@ jobs:
       shell: bash
 
     - name: run tests
-      run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh --numprocesses 2
+      run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh --numprocesses auto
       shell: bash
 
     - name: pytest errors

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       shell: bash
 
     - name: run tests
-      run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh
+      run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh --numprocesses 2
       shell: bash
 
     - name: pytest errors
@@ -51,7 +51,7 @@ jobs:
       shell: bash
 
     - name: run tests
-      run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh
+      run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh --numprocesses 2
       shell: bash
 
     - name: pytest errors

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
       run: ./ci/setup_env.sh "${{ matrix.python_version }}" "$BACKENDS"
 
     - name: run tests
-      run: PYTEST_BACKENDS=$BACKENDS PYTEST_EXPRESSION="not udf" ./ci/run_tests.sh
+      run: PYTEST_BACKENDS=$BACKENDS ./ci/run_tests.sh -m "not udf"
 
     - name: pytest errors
       run: ./ci/pytest_errors.sh

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -e
 # Run the Ibis tests. Two environment variables are considered:
 # - PYTEST_BACKENDS: Space-separated list of backends to run
-# - PYTEST_EXPRESSION: Marker expression, for example "not udf"
 
 TESTS_DIRS="ibis/tests ibis/backends/tests"
 for BACKEND in $PYTEST_BACKENDS; do
@@ -11,13 +10,11 @@ for BACKEND in $PYTEST_BACKENDS; do
 done
 
 echo "TESTS_DIRS: $TESTS_DIRS"
-echo "PYTEST_EXPRESSION: $PYTEST_EXPRESSION"
 
 set -o pipefail
 
 pytest $TESTS_DIRS \
     -q \
-    -m "${PYTEST_EXPRESSION}" \
     -ra \
     --junitxml=junit.xml \
     --cov=ibis \

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -21,4 +21,4 @@ pytest $TESTS_DIRS \
     -ra \
     --junitxml=junit.xml \
     --cov=ibis \
-    --cov-report=xml:coverage.xml | tee pytest.log
+    --cov-report=xml:coverage.xml "$@" | tee pytest.log

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
+  - pytest-xdist
 
   # Release
   - twine

--- a/ibis/backends/dask/trace.py
+++ b/ibis/backends/dask/trace.py
@@ -110,6 +110,13 @@ def trace(func):
 
     @functools.wraps(func)
     def traced_func(*args, **kwargs):
+        import ibis
+
+        # Similar to the pandas backend, it is possible to call this function
+        # without having initialized the configuration option. This can happen
+        # when tests are distributed across multiple processes, for example.
+        ibis.dask
+
         trace_enabled = get_option(_TRACE_CONFIG)
 
         if not trace_enabled:

--- a/ibis/backends/pandas/tests/test_client.py
+++ b/ibis/backends/pandas/tests/test_client.py
@@ -5,14 +5,12 @@ import pytest
 from pytest import param
 
 import ibis
-
-from .. import Backend
-from ..client import PandasTable  # noqa: E402
+from ibis.backends.pandas.client import PandasTable  # noqa: E402
 
 
 @pytest.fixture
 def client():
-    return Backend().connect(
+    return ibis.pandas.connect(
         {
             'df': pd.DataFrame({'a': [1, 2, 3], 'b': list('abc')}),
             'df_unknown': pd.DataFrame(

--- a/ibis/backends/pandas/trace.py
+++ b/ibis/backends/pandas/trace.py
@@ -117,13 +117,21 @@ def _log_trace(func, start=None):
 
 
 def trace(func):
-    """ Return a function decorator that wraped the decorated function with
+    """Return a function decorator that wraped the decorated function with
     tracing.
     """
     _trace_funcs.add(func.__name__)
 
     @functools.wraps(func)
     def traced_func(*args, **kwargs):
+        # Unfortunately, this function can be called before the `ibis.pandas`
+        # attribute has ever been accessed, which means the trace configuration
+        # option might never get registered and will raise an error. Accessing
+        # the pandas attribute here forces the option initialization
+        import ibis
+
+        ibis.pandas
+
         trace_enabled = get_option(_TRACE_CONFIG)
 
         if not trace_enabled:
@@ -139,13 +147,13 @@ def trace(func):
 
 
 class TraceTwoLevelDispatcher(TwoLevelDispatcher):
-    """ A Dispatcher that also wraps the registered function with tracing."""
+    """A Dispatcher that also wraps the registered function with tracing."""
 
     def __init__(self, name, doc=None):
         super().__init__(name, doc)
 
     def register(self, *types, **kwargs):
-        """ Register a function with this Dispatcher.
+        """Register a function with this Dispatcher.
 
         The function will also be wrapped with tracing information.
         """


### PR DESCRIPTION
Fix bug in pandas and dask backends, where options can not be initialized, if tests are run in an arbitrary order.

- ci: run tests across multiple processes
- fix: ensure that the pandas test client registers options
- fix: ensure that dask trace option is initialized
- fix: ensure that pandas trace option is initialized
