### PR TITLE
refactor: move some config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ markers = [
 [tool.black]
 line_length = 79
 skip_string_normalization = true
+exclude = "(ibis/_version|versioneer)\\.py"
 
 [tool.isort]
 ensure_newline_before_comments = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,40 @@
+[tool.pytest.ini_options]
+xfail_strict = true
+addopts = [
+  "--ignore=site-packages",
+  "--ignore=dist-packages",
+  "--strict-markers"
+]
+norecursedirs = ["site-packages", "dist-packages"]
+markers = [
+  "backend",
+  "geo",
+  "hdfs",
+  "kudu",
+  "min_spark_version",
+  "only_on_backends",
+  "skip_backends",
+  "skip_missing_feature",
+  "superuser",
+  "udf",
+  "xfail_backends",
+  "xfail_unsupported",
+  "xpass_backends",
+]
+
 [tool.black]
-line-length = 79
-skip-string-normalization = true
-target-version = ["py36", "py37", "py38"]
-exclude = "(ibis/_version|versioneer)\\.py"
+line_length = 79
+skip_string_normalization = true
+
+[tool.isort]
+ensure_newline_before_comments = true
+line_length = 79
+multi_line_output = 3
+include_trailing_comma = true
+profile = "black"
+skip = ["versioneer.py"]
+
+[tool.pydocstyle]
+inherit = false
+convention = "numpy"
+match_dir = "(ibis|omniscidb)"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,18 +11,6 @@ ignore = D202,D203,W503,E203
 max-line-length = 79
 exclude = versioneer.py
 
-[pydocstyle]
-inherit = false
-convention = numpy
-
-[isort]
-known_third_party = cached_property,click,clickhouse_driver,dateutil,google,graphviz,impala,kudu,mock,multipledispatch,numpy,pandas,pkg_resources,plumbum,psycopg2,pyarrow,pydata_google_auth,pygit2,pymapd,pymysql,pyspark,pytest,pytz,regex,requests,setuptools,sphinx_rtd_theme,sqlalchemy,thrift,toolz
-ensure_newline_before_comments=true
-line_length = 79
-multi_line_output = 3
-include_trailing_comma = true
-skip = versioneer.py
-
 [bdist_wheel]
 universal = 0
 
@@ -32,21 +20,3 @@ exclude = versioneer.py
 
 [mypy-ibis._version]
 ignore_errors = true
-
-[tool:pytest]
-xfail_strict = true
-addopts = --strict-markers
-markers =
-    backend
-    geo
-    hdfs
-    kudu
-    min_spark_version
-    only_on_backends
-    skip_backends
-    skip_missing_feature
-    superuser
-    udf
-    xfail_backends
-    xfail_unsupported
-    xpass_backends


### PR DESCRIPTION
This PR moves some of the existing configuration in `setup.cfg` (`isort`,
`pydocstyle`, and `pytest`) to `pyproject.toml`. `mypy` just released a version
with `pyproject.toml` support so it's a bit early to move IMO.
