### PR TITLE
style: remove omniscidb from pydocstyle config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,4 +38,4 @@ skip = ["versioneer.py"]
 [tool.pydocstyle]
 inherit = false
 convention = "numpy"
-match_dir = "(ibis|omniscidb)"
+match_dir = "ibis"


### PR DESCRIPTION
This PR removes omniscidb from the pydocstyle configuration