### PR TITLE
ENH: Add __getstate__ and __setstate__ for Nodes

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`2938` Serialization-deserialization of Node via pickle is now byte compatible between different processes
 * :support:`2914` Removed `log` method of clients, in favor of `verbose_log` option
 * :feature:`2916` Support joining on different columns in ClickHouse backend
 * :feature:`2908` Support summarization of empty data in Pandas backend

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -3,7 +3,7 @@ import functools
 import itertools
 import operator
 from contextlib import suppress
-from typing import List
+from typing import Any, Dict, List
 
 import numpy as np
 import toolz
@@ -56,6 +56,37 @@ class Node(Annotable):
             pprint_args.append(pp)
 
         return '{}({})'.format(opname, ', '.join(pprint_args))
+
+    def __getstate__(self) -> Dict[str, Any]:
+        """The attributes _expr_cached and _hash are
+        used as caches; they can be excluded from
+        serialization without affecting correctness.
+
+        Excluding _expr_cached and _hash from serialization
+        will allow the serialized bytes to be the same for
+        equivalent Node objets.
+
+        Returns
+        -------
+        Dict[str, Any]
+            A dictionary storing the objects attributes.
+        """
+        excluded_slots = {'_expr_cached', '_hash'}
+        return {
+            slot: getattr(self, slot)
+            for slot in self.__slots__
+            if slot not in excluded_slots
+        }
+
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        """
+        Parameters
+        ----------
+        state: Dict[str, Any]
+            A dictionary storing the objects attributes.
+        """
+        for slot in state:
+            setattr(self, slot, state[slot])
 
     @property
     def inputs(self):

--- a/ibis/tests/expr/test_case.py
+++ b/ibis/tests/expr/test_case.py
@@ -4,7 +4,7 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
-from ibis.tests.util import assert_equal
+from ibis.tests.util import assert_equal, assert_pickle_roundtrip
 
 
 def test_ifelse(table):
@@ -64,6 +64,29 @@ def test_multiple_case_expr(table):
     assert isinstance(expr, ir.FloatingColumn)
     assert isinstance(op, ops.SearchedCase)
     assert op.default is default
+
+
+def test_pickle_multiple_case_node(table):
+    case1 = table.a == 5
+    case2 = table.b == 128
+    case3 = table.c == 1000
+
+    result1 = table.f
+    result2 = table.b * 2
+    result3 = table.e
+
+    default = table.d
+    expr = (
+        ibis.case()
+        .when(case1, result1)
+        .when(case2, result2)
+        .when(case3, result3)
+        .else_(default)
+        .end()
+    )
+
+    op = expr.op()
+    assert_pickle_roundtrip(op)
 
 
 @pytest.mark.xfail(raises=AssertionError, reason='NYT')

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -1,6 +1,7 @@
 import ibis
 from ibis.expr import datatypes
 from ibis.expr.operations import Literal
+from ibis.tests.util import assert_pickle_roundtrip
 
 
 def test_literal_equality_basic():
@@ -45,3 +46,17 @@ def test_literal_equality_interval():
     d = ibis.interval(minutes=1).op()
 
     assert c != d
+
+
+def test_pickle_literal():
+    a = Literal(1, datatypes.int16)
+    b = Literal(1, datatypes.int32)
+
+    assert_pickle_roundtrip(a)
+    assert_pickle_roundtrip(b)
+
+
+def test_pickle_literal_interval():
+    a = ibis.interval(seconds=1).op()
+
+    assert_pickle_roundtrip(a)

--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -1,9 +1,9 @@
-import pickle
 from collections import OrderedDict
 
 import ibis
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
+from ibis.tests.util import assert_pickle_roundtrip
 
 
 def test_struct_operations():
@@ -31,7 +31,4 @@ def test_struct_pickle():
         OrderedDict([("fruit", "pear"), ("weight", 0)])
     )
 
-    raw = pickle.dumps(struct_scalar_expr)
-    loaded = pickle.loads(raw)
-
-    assert loaded.equals(struct_scalar_expr)
+    assert_pickle_roundtrip(struct_scalar_expr)

--- a/ibis/tests/util.py
+++ b/ibis/tests/util.py
@@ -1,5 +1,7 @@
 """Test utilities."""
 
+import pickle
+
 import ibis
 import ibis.util as util
 
@@ -15,3 +17,12 @@ def assert_equal(left, right):
         assert left.equals(right), 'Objects unequal: {}\nvs\n{}'.format(
             repr(left), repr(right)
         )
+
+
+def assert_pickle_roundtrip(obj):
+    """Assert that an ibis object remains the
+    same after pickling and unpickling."""
+
+    raw = pickle.dumps(obj)
+    loaded = pickle.loads(raw)
+    assert obj.equals(loaded)


### PR DESCRIPTION
From icexelloss:
We are trying to build "consistent hash" for ibis Expression (hash that doesn't change cross Python interpreter restart for ibis Expression) and the current implementation depends on first pickling the ibis Expression then use something like hashlib.sha256() to compute the hash from the pickled bytes.

During this, we found that because ibis Node class that "_cached_expr" and "_hash" attributes, the pickled bytes can be different for the same table depending on whether those two fields are created, which is not a very desirable behavior. This PR aims to fix the serialization/deserialization method so that they produce consistent results for the equivalent Node object.