### PR TITLE
fix: forward the spark entry point to pyspark

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
             'postgres = ibis.backends.postgres',
             'mysql = ibis.backends.mysql',
             'clickhouse = ibis.backends.clickhouse',
-            'spark = ibis.backends.spark',
+            'spark = ibis.backends.pyspark',
             'pyspark = ibis.backends.pyspark',
             'dask = ibis.backends.dask',
         ]


### PR DESCRIPTION
This fixes a bug that isn't caught in the current CI where the spark entrypoint
points to a non-existent `spark` attribute.
