### PR TITLE
fix: allow an undefined PYTEST_BACKENDS variable to indicate no backends should be tested

### DIFF
--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -49,12 +49,20 @@ def _get_backends_to_test():
     """
     Get a list of `TestConf` classes of the backends to test.
 
-    The list of backends can be specified by theuse rwith the `PYTEST_BACKENDS`
-    environment variable, or otherwise all backends are being tested.
+    The list of backends can be specified by the user with the
+    `PYTEST_BACKENDS` environment variable.
+
+    - If the variable is undefined or empty, then no backends are returned
+    - Otherwise the variable must contain a space-separated list of backends to
+      test
+
     """
-    backends = os.environ.get('PYTEST_BACKENDS', '').split(' ')
-    if backends == ['']:
-        backends = _get_all_backends()
+    backends_raw = os.environ.get('PYTEST_BACKENDS')
+
+    if not backends_raw:
+        return []
+
+    backends = backends_raw.split()
 
     return [
         pytest.param(


### PR DESCRIPTION
This PR slighty changes the meaning of PYTEST_BACKENDS.

It's a really terrible developer experience to suddenly be
testing all backends because of an **undefined** environment variable.

The new behavior is:

- If the variable is undefined or empty, return an empty list, so no backends are tested
- If the variable is defined, existing behavior is retained
