### PR TITLE
ENH: Remove Expr._root_tables()

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -21,7 +21,7 @@ class _AnyToExistsTransform:
         self.context = context
         self.expr = expr
         self.parent_table = parent_table
-        self.query_roots = frozenset(self.parent_table._root_tables())
+        self.query_roots = frozenset(self.parent_table.op().root_tables())
 
     def get_result(self):
         self.foreign_table = None
@@ -93,7 +93,7 @@ class _CorrelatedRefCheck:
         self.query = query
         self.ctx = query.context
         self.expr = expr
-        self.query_roots = frozenset(self.query.table_set._root_tables())
+        self.query_roots = frozenset(self.query.table_set.op().root_tables())
 
         # aliasing required
         self.foreign_refs = []

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -866,7 +866,7 @@ class Projector:
         assert self.parent.op() == root
 
         root_table = root.table
-        roots = root_table._root_tables()
+        roots = root_table.op().root_tables()
         validator = ExprValidator([root_table])
         fused_exprs = []
         can_fuse = False
@@ -899,7 +899,7 @@ class Projector:
                 # gross we share the same table root. Better way to
                 # detect?
                 or len(roots) == 1
-                and val._root_tables()[0] is roots[0]
+                and val.op().root_tables()[0] is roots[0]
             ):
                 can_fuse = True
                 have_root = False
@@ -939,7 +939,7 @@ class ExprValidator:
 
         self.roots = []
         for expr in self.parent_exprs:
-            self.roots.extend(expr._root_tables())
+            self.roots.extend(expr.op().root_tables())
 
     def has_common_roots(self, expr):
         return self.validate(expr)
@@ -953,7 +953,7 @@ class ExprValidator:
             if self._among_roots(op):
                 return True
 
-        expr_roots = expr._root_tables()
+        expr_roots = expr.op().root_tables()
         for root in expr_roots:
             if not self._among_roots(root):
                 return False
@@ -966,16 +966,16 @@ class ExprValidator:
         return sum(root.is_ancestor(node) for root in self.roots)
 
     def shares_some_roots(self, expr):
-        expr_roots = expr._root_tables()
+        expr_roots = expr.op().root_tables()
         return any(self._among_roots(root) for root in expr_roots)
 
     def shares_one_root(self, expr):
-        expr_roots = expr._root_tables()
+        expr_roots = expr.op().root_tables()
         total = sum(self.roots_shared(root) for root in expr_roots)
         return total == 1
 
     def shares_multiple_roots(self, expr):
-        expr_roots = expr._root_tables()
+        expr_roots = expr.op().root_tables()
         total = sum(self.roots_shared(expr_roots) for root in expr_roots)
         return total > 1
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -27,7 +27,7 @@ def _safe_repr(x, memo=None):
 # TODO: move to analysis
 def distinct_roots(*expressions):
     roots = toolz.concat(
-        expression._root_tables() for expression in expressions
+        expression.op().root_tables() for expression in expressions
     )
     return list(toolz.unique(roots))
 
@@ -243,7 +243,7 @@ class TableColumn(ValueOp):
         return True
 
     def root_tables(self):
-        return self.table._root_tables()
+        return self.table.op().root_tables()
 
     def _make_expr(self):
         dtype = self.table._get_type(self.name)
@@ -1136,7 +1136,7 @@ class WindowOp(ValueOp):
         result = list(
             toolz.unique(
                 toolz.concatv(
-                    self.expr._root_tables(),
+                    self.expr.op().root_tables(),
                     distinct_roots(
                         *toolz.concatv(
                             self.window._order_by, self.window._group_by
@@ -1377,7 +1377,7 @@ class Any(ValueOp):
 
     @property
     def _reduction(self):
-        roots = self.arg._root_tables()
+        roots = self.arg.op().root_tables()
         return len(roots) < 2
 
     def output_type(self):
@@ -1779,7 +1779,7 @@ class MaterializedJoin(TableNode, HasSchema):
         return self.join.op()._get_schema()
 
     def root_tables(self):
-        return self.join._root_tables()
+        return self.join.op().root_tables()
 
     def blocks(self):
         return True
@@ -1922,7 +1922,7 @@ class SortKey(Node):
         return ir.SortExpr
 
     def root_tables(self):
-        return self.expr._root_tables()
+        return self.expr.op().root_tables()
 
     def equals(self, other, cache=None):
         # TODO: might generalize this equals based on fields
@@ -3627,7 +3627,7 @@ class ElementWiseVectorizedUDF(ValueOp):
     def root_tables(self):
         result = list(
             toolz.unique(
-                toolz.concat(arg._root_tables() for arg in self.func_args)
+                toolz.concat(arg.op().root_tables() for arg in self.func_args)
             )
         )
 
@@ -3658,7 +3658,7 @@ class ReductionVectorizedUDF(Reduction):
     def root_tables(self):
         result = list(
             toolz.unique(
-                toolz.concat(arg._root_tables() for arg in self.func_args)
+                toolz.concat(arg.op().root_tables() for arg in self.func_args)
             )
         )
 
@@ -3689,7 +3689,7 @@ class AnalyticVectorizedUDF(AnalyticOp):
     def root_tables(self):
         result = list(
             toolz.unique(
-                toolz.concat(arg._root_tables() for arg in self.func_args)
+                toolz.concat(arg.op().root_tables() for arg in self.func_args)
             )
         )
 

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1132,9 +1132,7 @@ class WindowOp(ValueOp):
 
     def root_tables(self):
         return distinct_roots(
-            self.expr,
-            *self.window._order_by,
-            *self.window._group_by
+            self.expr, *self.window._order_by, *self.window._group_by
         )
 
 

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -313,9 +313,6 @@ class Expr:
             return False
         return self._arg.equals(other._arg, cache=cache)
 
-    def _root_tables(self):
-        return self.op().root_tables()
-
 
 class ExprList(Expr):
     def _type_display(self):
@@ -433,7 +430,7 @@ class ColumnExpr(ValueExpr):
         """
         Promote this column expression to a table projection
         """
-        roots = self._root_tables()
+        roots = self.op().root_tables()
         if len(roots) > 1:
             raise com.RelationError(
                 'Cannot convert array expression '

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -69,7 +69,7 @@ def test_view_new_relation(table):
     # meaning when it comes to execution
     tview = table.view()
 
-    roots = tview._root_tables()
+    roots = tview.op().root_tables()
     assert len(roots) == 1
     assert roots[0] is tview.op()
 


### PR DESCRIPTION
Root tables are operation specific, so call it explicitly rather than hiding it behind a proxy method. 