### PR TITLE
DEPR: Deprecate set_database

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -52,7 +52,6 @@ Backend methods
    BaseBackend.connect
    BaseBackend.database
    BaseBackend.current_database
-   BaseBackend.set_database
    BaseBackend.list_tables
    BaseBackend.table
    BaseBackend.version

--- a/docs/source/backends/clickhouse.rst
+++ b/docs/source/backends/clickhouse.rst
@@ -35,6 +35,5 @@ Use ``ibis.clickhouse.connect`` to create a client.
    ClickhouseClient.exists_table
    ClickhouseClient.exists_database
    ClickhouseClient.get_schema
-   ClickhouseClient.set_database
    ClickhouseClient.list_databases
    ClickhouseClient.list_tables

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,7 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
-* :support:`` Method `set_database` has been deprecated, in favor of creating a new connection to a different database
+* :support:`2913` Method `set_database` has been deprecated, in favor of creating a new connection to a different database
 * :feature:`2938` Serialization-deserialization of Node via pickle is now byte compatible between different processes
 * :support:`2914` Removed `log` method of clients, in favor of `verbose_log` option
 * :feature:`2916` Support joining on different columns in ClickHouse backend

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :support:`` Method `set_database` has been deprecated, in favor of creating a new connection to a different database
 * :feature:`2938` Serialization-deserialization of Node via pickle is now byte compatible between different processes
 * :support:`2914` Removed `log` method of clients, in favor of `verbose_log` option
 * :feature:`2916` Support joining on different columns in ClickHouse backend

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -132,20 +132,6 @@ class BaseBackend(abc.ABC):
         pattern = re.compile(like)
         return sorted(filter(lambda t: pattern.findall(t), values))
 
-    def set_database(self, name: str) -> None:
-        """
-        Set the current database.
-
-        Parameters
-        ----------
-        name : str
-            The name of the new current database.
-        """
-        raise NotImplementedError(
-            f'Cannot set database with {self.__class__.__name__} client. '
-            'To use a different database create a new client.'
-        )
-
     @abc.abstractmethod
     def list_tables(self, like: str = None, database: str = None) -> List[str]:
         """

--- a/ibis/backends/base/client.py
+++ b/ibis/backends/base/client.py
@@ -28,9 +28,6 @@ class Client:
     def exists_database(self, name):
         return self.backend.exists_database(name)
 
-    def set_database(self, name):
-        return self.backend.set_database(name)
-
 
 class Database:
     """Generic Database class."""

--- a/ibis/backends/base/sql/alchemy/client.py
+++ b/ibis/backends/base/sql/alchemy/client.py
@@ -249,12 +249,6 @@ class AlchemyClient(SQLClient):
         """The name of the current database this client is connected to."""
         return self.database_name
 
-    def set_database(self, name):
-        raise NotImplementedError(
-            f'Cannot set database with {self.__class__.__name__} client. '
-            f'To use a different database, use `client.database("{name}")`'
-        )
-
     def list_schemas(self):
         warnings.warn(
             '`list_schemas` is deprecated, use `list_databases` instead',

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -1,4 +1,6 @@
 """Impala backend"""
+import warnings
+
 import ibis.config
 from ibis.backends.base.sql import BaseSQLBackend
 from ibis.backends.base.sql.ddl import fully_qualified_re
@@ -137,6 +139,12 @@ class Backend(BaseSQLBackend):
         )
 
     def set_database(self, name):
+        warnings.warn(
+            '`set_database` is deprecated and will be removed in a future '
+            'version of Ibis. Create a new connection to the desired database '
+            'instead',
+            FutureWarning,
+        )
         self.client.con.set_database(name)
 
     @property

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -4,6 +4,7 @@ import re
 import threading
 import time
 import traceback
+import warnings
 import weakref
 from collections import deque
 from posixpath import join as pjoin
@@ -841,6 +842,12 @@ class ImpalaClient(SQLClient):
         # XXX The parent `Client` has a generic method that calls this same
         # method in the backend. But for whatever reason calling this code from
         # that method doesn't seem to work. Maybe `con` is a copy?
+        warnings.warn(
+            '`set_database` is deprecated and will be removed in a future '
+            'version of Ibis. Create a new connection to the desired database '
+            'instead',
+            FutureWarning,
+        )
         self.con.set_database(name)
 
     @property

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pyspark
 
 from ibis.backends.base import BaseBackend
@@ -35,6 +37,12 @@ class Backend(BaseBackend):
         return pyspark.__version__
 
     def set_database(self, name):
+        warnings.warn(
+            '`set_database` is deprecated and will be removed in a future '
+            'version of Ibis. Create a new connection to the desired database '
+            'instead',
+            FutureWarning,
+        )
         self.client._catalog.setCurrentDatabase(name)
 
     @property

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -371,6 +371,9 @@ class PySparkClient(SQLClient):
         except com.IbisInputError:
             return False
 
+    def set_database(self, name):
+        return self.backend.set_database(name)
+
     def create_database(self, name, path=None, force=False):
         """
         Create a new Spark database

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -19,26 +19,6 @@ def test_database_consistency(con):
     assert isinstance(current_database, str)
     assert current_database in databases
 
-    if len(databases) == 1:
-        new_database = current_database
-    else:
-        new_database = next(db for db in databases if db != current_database)
-
-    try:
-        con.set_database(new_database)
-    except NotImplementedError:
-        pass
-    else:
-        assert con.current_database == new_database
-        assert con.list_databases() == databases
-
-    # restoring the original database, in case the same connection is used
-    # in other tests
-    try:
-        con.set_database(current_database)
-    except NotImplementedError:
-        pass
-
 
 def test_list_tables(con):
     tables = con.list_tables()


### PR DESCRIPTION
Closes #2913

Only Impala and pyspark support `set_database`. It doesn't add much value, since a new client can be created for the different database. But it adds extra complexity, having to handle the not implement errors, and managing a state for the two backends implemented. Also, it creates wrong expectations in the users, since it's in the documentation, but almost no backend supports it.

CC: @cpcloud @jreback 