### PR TITLE
ci: make the test reporter fork friendly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -396,9 +396,10 @@ jobs:
           path: artifacts
 
       - name: publish test report
-        uses: mikepenz/action-junit-report@v2
+        uses: KyleAure/junit-report-annotations-action@1.5
+        name: pytest results
         with:
-          report_paths: artifacts/**/junit.xml
+          path: artifacts/**/junit.xml
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -397,8 +397,8 @@ jobs:
 
       - name: publish test report
         uses: KyleAure/junit-report-annotations-action@1.5
-        name: pytest results
         with:
+          name: pytest results
           path: artifacts/**/junit.xml
 
   benchmarks:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -385,10 +385,10 @@ jobs:
     if: failure()
     needs:
       - test_no_backends
-      - test_simple_backends
-      - test_pyspark
-      - test_mysql_postgres
-      - test_impala_clickhouse
+      # - test_simple_backends
+      # - test_pyspark
+      # - test_mysql_postgres
+      # - test_impala_clickhouse
     steps:
       - name: download test report artifacts
         uses: actions/download-artifact@v2
@@ -396,10 +396,9 @@ jobs:
           path: artifacts
 
       - name: publish test report
-        uses: KyleAure/junit-report-annotations-action@1.5
+        uses: EnricoMi/publish-unit-test-result-action@v1
         with:
-          name: pytest results
-          path: artifacts/**/junit.xml
+          files: artifacts/**/junit.xml
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: publish test report
         uses: actions/upload-artifact@v2
-        if: failure()
+        if: success() || failure()
         with:
           name: no_backends_${{ matrix.python-version }}-${{ matrix.os }}
           path: junit.xml
@@ -110,7 +110,7 @@ jobs:
 
       - name: publish test report
         uses: actions/upload-artifact@v2
-        if: failure()
+        if: success() || failure()
         with:
           name: simple_backends_${{ matrix.python-version }}-${{ matrix.os }}-${{ join(matrix.additional-deps, '-') }}
           path: junit.xml
@@ -166,7 +166,7 @@ jobs:
 
       - name: publish test report
         uses: actions/upload-artifact@v2
-        if: failure()
+        if: success() || failure()
         with:
           name: pyspark_${{ matrix.deps.python-version }}-${{ matrix.dep.env.ARROW_PRE_0_15_IPC_FORMAT }}-${{ join(matrix.deps.additional-deps, '-') }}
           path: junit.xml
@@ -250,7 +250,7 @@ jobs:
 
       - name: publish test report
         uses: actions/upload-artifact@v2
-        if: failure()
+        if: success() || failure()
         with:
           name: mysql_postgres_${{ matrix.python-version }}-${{ join(matrix.additional-deps, '-') }}
           path: junit.xml
@@ -375,30 +375,10 @@ jobs:
 
       - name: publish test report
         uses: actions/upload-artifact@v2
-        if: failure()
+        if: success() || failure()
         with:
           name: impala_clickhouse_${{ matrix.python-version }}
           path: junit.xml
-
-  publish_test_reports:
-    runs-on: ubuntu-latest
-    if: failure()
-    needs:
-      - test_no_backends
-      # - test_simple_backends
-      # - test_pyspark
-      # - test_mysql_postgres
-      # - test_impala_clickhouse
-    steps:
-      - name: download test report artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-
-      - name: publish test report
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        with:
-          files: artifacts/**/junit.xml
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,19 @@
+name: Test Report
+on:
+  workflow_run:
+    workflows: ['Continuous Integration']
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: download test report artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: publish test report
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: artifacts/**/junit.xml

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -8,9 +8,11 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - name: download test report artifacts
-        uses: actions/download-artifact@v2
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
         with:
+          workflow: main.yml
+          workflow_conclusion: completed
           path: artifacts
 
       - name: publish test report

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: main.yml
+          workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: completed
           path: artifacts
 

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -131,3 +131,7 @@ def test_multiple_backends(mocker):
     msg = "3 packages found for backend 'foo'"
     with pytest.raises(RuntimeError, match=msg):
         ibis.foo
+
+
+def test_bogus():
+    assert 1 + 1 == 3

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -131,7 +131,3 @@ def test_multiple_backends(mocker):
     msg = "3 packages found for backend 'foo'"
     with pytest.raises(RuntimeError, match=msg):
         ibis.foo
-
-
-def test_bogus():
-    assert 1 + 1 == 3


### PR DESCRIPTION
The current CI test reporter doesn't allow publishing test failures on runs from forks.

This PR attempts to address that.
