### PR TITLE
ci: only produce a test report if the workflow succeeded or failed

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -6,6 +6,7 @@ on:
       - completed
 jobs:
   report:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact


### PR DESCRIPTION
This PR ensures the test report is only produced when a workflow suceeded or failed, and not for example in the case where the workflow was cancelled.