### PR TITLE
test: add failing test to trigger test reporter

### DIFF
--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -131,3 +131,7 @@ def test_multiple_backends(mocker):
     msg = "3 packages found for backend 'foo'"
     with pytest.raises(RuntimeError, match=msg):
         ibis.foo
+
+
+def test_bogus():
+    assert 1 + 1 == 3


### PR DESCRIPTION
This is to see whether the test report workflow is reporting in a useful way on test failures.