### PR TITLE
chore: disable dask parallel testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
           done
 
       - name: run tests
-        run: ./ci/run_tests.sh --numprocesses auto
+        run: ./ci/run_tests.sh
         env:
           PYTEST_BACKENDS: ${{ join(fromJSON(steps.set_backends.outputs.backends), ' ') }}
 


### PR DESCRIPTION
Dask tests seem unable to be run in parallel.

This disables parallel in the simpler backend testing until it can be reproduced and fixed.

I do think it's a bug that we can't execute tests in parallel without failure
but I don't think this should hold up the release.
