### PR TITLE
chore: update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.6.4
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.9.3
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 21.8b0
     hooks:
       - id: black
         exclude: (ibis/_version|versioneer).py

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -155,8 +155,7 @@ class BaseBackend(abc.ABC):
 
     # @abc.abstractmethod
     def table(self, name: str, database: str = None) -> ir.TableExpr:
-        """
-        """
+        """ """
         warnings.warn(
             '`database` argument of `.table()` is deprecated and '
             'will be removed in a future version of Ibis. Change '
@@ -202,8 +201,7 @@ class BaseBackend(abc.ABC):
         return self.client_class.compiler.to_sql(expr, params=params)
 
     def execute(self, expr: ir.Expr) -> Any:  # XXX DataFrame for now?
-        """
-        """
+        """ """
 
     def verify(self, expr: ir.Expr, params=None) -> bool:
         """

--- a/ibis/backends/base/sql/alchemy/client.py
+++ b/ibis/backends/base/sql/alchemy/client.py
@@ -345,7 +345,9 @@ class AlchemyClient(SQLClient):
             if overwrite:
                 self.drop_table(table_name, database=database)
                 self.create_table(
-                    table_name, schema=to_table_schema, database=database,
+                    table_name,
+                    schema=to_table_schema,
+                    database=database,
                 )
 
             to_table = self._get_sqla_table(table_name, schema=database)

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -140,7 +140,11 @@ class _CorrelatedRefCheck:
         # XXX
         if isinstance(
             node,
-            (ops.TableArrayView, ops.ExistsSubquery, ops.NotExistsSubquery,),
+            (
+                ops.TableArrayView,
+                ops.ExistsSubquery,
+                ops.NotExistsSubquery,
+            ),
         ):
             return True
 

--- a/ibis/backends/base/sql/ddl.py
+++ b/ibis/backends/base/sql/ddl.py
@@ -43,7 +43,8 @@ def format_schema(schema):
 
 def _format_schema_element(name, t):
     return '{} {}'.format(
-        quote_identifier(name, force=True), type_to_sql_string(t),
+        quote_identifier(name, force=True),
+        type_to_sql_string(t),
     )
 
 

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -276,7 +276,10 @@ def test_non_equijoin(alltypes):
             ('any_left_join', 'ANY LEFT JOIN'),
             ('left_join', 'ALL LEFT JOIN'),
         ],
-        [('playerID', 'playerID'), ('playerID', 'awardID'),],  # noqa: E231
+        [
+            ('playerID', 'playerID'),
+            ('playerID', 'awardID'),
+        ],  # noqa: E231
     ),
 )
 def test_simple_joins(

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -394,7 +394,11 @@ def main_execute(
     params = {k.op() if hasattr(k, 'op') else k: v for k, v in params.items()}
     scope = scope.merge_scope(Scope(params, timecontext))
     return execute_with_scope(
-        expr, scope, timecontext=timecontext, aggcontext=aggcontext, **kwargs,
+        expr,
+        scope,
+        timecontext=timecontext,
+        aggcontext=aggcontext,
+        **kwargs,
     )
 
 

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -423,7 +423,10 @@ def execute_searched_case_dask(op, whens, thens, otherwise, **kwargs):
         thens = [da.from_array(np.array([t])) for t in thens]
     # TODO this only exists as of 2021.6.1
     raw = dask_array_select(whens, thens, otherwise)
-    out = dd.from_dask_array(raw, index=idx,)
+    out = dd.from_dask_array(
+        raw,
+        index=idx,
+    )
     return out
 
 

--- a/ibis/backends/dask/execution/indexing.py
+++ b/ibis/backends/dask/execution/indexing.py
@@ -24,7 +24,11 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
             execute_node_where_series_series_series,
         ),
         (
-            (boolean_types, dd.Series, dd.Series,),
+            (
+                boolean_types,
+                dd.Series,
+                dd.Series,
+            ),
             execute_node_where_scalar_scalar_scalar,
         ),
     ]

--- a/ibis/backends/dask/execution/maps.py
+++ b/ibis/backends/dask/execution/maps.py
@@ -47,9 +47,18 @@ for registered_type in PANDAS_REGISTERED_TYPES:
 
 DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ops.MapValueForKey: [
-        ((dd.Series, object,), execute_map_value_for_key_series_scalar),
         (
-            (collections.abc.Mapping, dd.Series,),
+            (
+                dd.Series,
+                object,
+            ),
+            execute_map_value_for_key_series_scalar,
+        ),
+        (
+            (
+                collections.abc.Mapping,
+                dd.Series,
+            ),
             execute_map_value_for_key_dict_series,
         ),
     ],
@@ -78,11 +87,19 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
             execute_map_value_default_dict_series_series,
         ),
         (
-            (collections.abc.Mapping, object, (dd.Series, pandas.Series),),
+            (
+                collections.abc.Mapping,
+                object,
+                (dd.Series, pandas.Series),
+            ),
             execute_map_value_default_dict_scalar_series,
         ),
         (
-            (collections.abc.Mapping, (dd.Series, pandas.Series), object,),
+            (
+                collections.abc.Mapping,
+                (dd.Series, pandas.Series),
+                object,
+            ),
             execute_map_value_default_dict_series_scalar,
         ),
     ],
@@ -121,7 +138,8 @@ def execute_map_concat_dict_series(op, lhs, rhs, **kwargs):
     if lhs is None:
         return none_filled_dask_series(len(rhs))
     return rhs.map(
-        lambda m, lhs=lhs: safe_merge(lhs, m), meta=(rhs.name, rhs.dtype),
+        lambda m, lhs=lhs: safe_merge(lhs, m),
+        meta=(rhs.name, rhs.dtype),
     )
 
 
@@ -132,7 +150,8 @@ def execute_map_concat_series_dict(op, lhs, rhs, **kwargs):
     if rhs is None:
         return none_filled_dask_series(len(lhs))
     return lhs.map(
-        lambda m, rhs=rhs: safe_merge(m, rhs), meta=(lhs.name, lhs.dtype),
+        lambda m, rhs=rhs: safe_merge(m, rhs),
+        meta=(lhs.name, lhs.dtype),
     )
 
 

--- a/ibis/backends/dask/execution/strings.py
+++ b/ibis/backends/dask/execution/strings.py
@@ -48,7 +48,11 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ops.StringLength: [((dd.Series,), execute_string_length_series)],
     ops.Substring: [
         (
-            (dd.Series, integer_types, integer_types,),
+            (
+                dd.Series,
+                integer_types,
+                integer_types,
+            ),
             execute_substring_int_int,
         ),
     ],
@@ -57,13 +61,21 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ops.RStrip: [((dd.Series,), execute_string_rstrip)],
     ops.LPad: [
         (
-            (dd.Series, (dd.Series,) + integer_types, (dd.Series, str),),
+            (
+                dd.Series,
+                (dd.Series,) + integer_types,
+                (dd.Series, str),
+            ),
             execute_string_lpad,
         ),
     ],
     ops.RPad: [
         (
-            (dd.Series, (dd.Series,) + integer_types, (dd.Series, str),),
+            (
+                dd.Series,
+                (dd.Series,) + integer_types,
+                (dd.Series, str),
+            ),
             execute_string_rpad,
         ),
     ],
@@ -87,11 +99,23 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ],
     ops.StringSQLLike: [
         (
-            (dd.Series, str, (str, type(None)),),
+            (
+                dd.Series,
+                str,
+                (str, type(None)),
+            ),
             execute_string_like_series_string,
         ),
     ],
-    ops.RegexSearch: [((dd.Series, str,), execute_series_regex_search)],
+    ops.RegexSearch: [
+        (
+            (
+                dd.Series,
+                str,
+            ),
+            execute_series_regex_search,
+        )
+    ],
     ops.RegexExtract: [
         (
             (dd.Series, (dd.Series, str), integer_types),
@@ -99,7 +123,14 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
         ),
     ],
     ops.RegexReplace: [
-        ((dd.Series, str, str,), execute_series_regex_replace),
+        (
+            (
+                dd.Series,
+                str,
+                str,
+            ),
+            execute_series_regex_replace,
+        ),
     ],
     ops.Translate: [
         (
@@ -143,7 +174,9 @@ def execute_substring_series_series(op, data, start, length, **kwargs):
 
     # TODO - this is broken
     def iterate(
-        value, start_iter=start.iteritems(), end_iter=end.iteritems(),
+        value,
+        start_iter=start.iteritems(),
+        end_iter=end.iteritems(),
     ):
         _, begin = next(start_iter)
         _, end = next(end_iter)

--- a/ibis/backends/dask/execution/temporal.py
+++ b/ibis/backends/dask/execution/temporal.py
@@ -91,7 +91,10 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ],
     ops.IntervalFloorDivide: [
         (
-            ((Timedelta, dd.Series), numeric_types + (dd.Series,),),
+            (
+                (Timedelta, dd.Series),
+                numeric_types + (dd.Series,),
+            ),
             execute_interval_multiply_fdiv_series_numeric,
         )
     ],

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -41,7 +41,10 @@ def register_types_to_dispatcher(
 
 def make_meta_series(dtype, name=None, index_name=None):
     return pd.Series(
-        [], index=pd.Index([], name=index_name), dtype=dtype, name=name,
+        [],
+        index=pd.Index([], name=index_name),
+        dtype=dtype,
+        name=name,
     )
 
 
@@ -160,7 +163,9 @@ def _pandas_dtype_from_dd_scalar(x: dd.core.Scalar):
 
 
 def _coerce_to_dataframe(
-    data: Any, column_names: List[str], types: List[dt.DataType],
+    data: Any,
+    column_names: List[str],
+    types: List[dt.DataType],
 ) -> dd.DataFrame:
     """
     Clone of ibis.util.coerce_to_dataframe that deals well with dask types

--- a/ibis/backends/dask/execution/window.py
+++ b/ibis/backends/dask/execution/window.py
@@ -102,7 +102,14 @@ def execute_window_op(
 
 
 def execute_grouped_window_op(
-    op, data, window, scope, timecontext, aggcontext, clients, **kwargs,
+    op,
+    data,
+    window,
+    scope,
+    timecontext,
+    aggcontext,
+    clients,
+    **kwargs,
 ):
     # extract the parent
     (root,) = op.root_tables()

--- a/ibis/backends/dask/tests/execution/test_arrays.py
+++ b/ibis/backends/dask/tests/execution/test_arrays.py
@@ -217,7 +217,8 @@ def test_array_repeat(t, df, n, mul):
     expr = t.projection([mul(t.array_of_strings, n).name('repeated')])
     result = expr.compile()
     expected = dd.from_pandas(
-        pd.DataFrame({'repeated': df.array_of_strings * n}), npartitions=1,
+        pd.DataFrame({'repeated': df.array_of_strings * n}),
+        npartitions=1,
     )
     tm.assert_frame_equal(result.compute(), expected.compute())
 

--- a/ibis/backends/dask/tests/execution/test_cast.py
+++ b/ibis/backends/dask/tests/execution/test_cast.py
@@ -162,7 +162,8 @@ def test_cast_to_decimal(t, df, type):
 
 
 @pytest.mark.parametrize(
-    'column', ['plain_int64', 'dup_strings', 'dup_ints', 'strings_with_nulls'],
+    'column',
+    ['plain_int64', 'dup_strings', 'dup_ints', 'strings_with_nulls'],
 )
 def test_cast_to_category(t, df, column):
     test = t[column].cast('category').compile()

--- a/ibis/backends/dask/tests/execution/test_functions.py
+++ b/ibis/backends/dask/tests/execution/test_functions.py
@@ -152,7 +152,10 @@ def test_quantile_list(t, df, ibis_func, dask_func, column):
     [
         (lambda x: x.quantile(0), lambda x: x.quantile(0)),
         (lambda x: x.quantile(1), lambda x: x.quantile(1)),
-        (lambda x: x.quantile(0.5), lambda x: x.quantile(0.5),),
+        (
+            lambda x: x.quantile(0.5),
+            lambda x: x.quantile(0.5),
+        ),
     ],
 )
 def test_quantile_scalar(t, df, ibis_func, dask_func):

--- a/ibis/backends/dask/tests/execution/test_maps.py
+++ b/ibis/backends/dask/tests/execution/test_maps.py
@@ -9,7 +9,8 @@ def test_map_length_expr(t):
     expr = t.map_of_integers_strings.length()
     result = expr.compile()
     expected = dd.from_pandas(
-        pd.Series([0, None, 2], name='map_of_integers_strings'), npartitions=1,
+        pd.Series([0, None, 2], name='map_of_integers_strings'),
+        npartitions=1,
     )
     tm.assert_series_equal(result.compute(), expected.compute())
 
@@ -93,6 +94,7 @@ def test_map_value_for_key_literal_broadcast(t):
     expr = lookup_table.get(t.dup_strings)
     result = expr.compile()
     expected = dd.from_pandas(
-        pd.Series([4, 1, 4], name='dup_strings'), npartitions=1,
+        pd.Series([4, 1, 4], name='dup_strings'),
+        npartitions=1,
     )
     tm.assert_series_equal(result.compute(), expected.compute())

--- a/ibis/backends/dask/tests/execution/test_structs.py
+++ b/ibis/backends/dask/tests/execution/test_structs.py
@@ -67,7 +67,8 @@ def test_struct_field_series(struct_table):
     expr = t.s['fruit']
     result = expr.compile()
     expected = dd.from_pandas(
-        pd.Series(["apple", "pear", "pear"], name="fruit"), npartitions=1,
+        pd.Series(["apple", "pear", "pear"], name="fruit"),
+        npartitions=1,
     )
     tm.assert_series_equal(result.compute(), expected.compute())
 

--- a/ibis/backends/dask/tests/execution/test_temporal.py
+++ b/ibis/backends/dask/tests/execution/test_temporal.py
@@ -68,7 +68,8 @@ def test_cast_datetime_strings_to_date(t, df, column):
     df_computed = df.compute()
     expected = dd.from_pandas(
         pd.to_datetime(
-            df_computed[column], infer_datetime_format=True,
+            df_computed[column],
+            infer_datetime_format=True,
         ).dt.normalize(),
         npartitions=1,
     )
@@ -145,7 +146,9 @@ def test_times_ops(t, df):
     'column', ['plain_datetimes_utc', 'plain_datetimes_naive']
 )
 def test_times_ops_with_tz(t, df, tz, rconstruct, column):
-    expected = dd.from_array(rconstruct(len(df), dtype=bool),)
+    expected = dd.from_array(
+        rconstruct(len(df), dtype=bool),
+    )
     time = t[column].time()
     expr = time.between('01:00', '02:00', timezone=tz)
     result = expr.compile()
@@ -192,6 +195,7 @@ def test_interval_arithmetic(op, expected):
     expr = op(t1.td, t1.td)
     result = expr.compile()
     expected = dd.from_pandas(
-        pd.Series(expected(data, data), name='td'), npartitions=1,
+        pd.Series(expected(data, data), name='td'),
+        npartitions=1,
     )
     tm.assert_series_equal(result.compute(), expected.compute())

--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -191,9 +191,9 @@ def test_context_adjustment_multi_window(time_table, time_df3):
 
 @pytest.mark.xfail(reason="TODO - windowing - #2553")
 def test_context_adjustment_window_groupby_id(time_table, time_df3):
-    """ This test case is meant to test trim_window_result method
-        in dask/execution/window.py to see if it could trim Series
-        correctly with groupby params
+    """This test case is meant to test trim_window_result method
+    in dask/execution/window.py to see if it could trim Series
+    correctly with groupby params
     """
     expected = (
         time_df3.compute()

--- a/ibis/backends/dask/tests/test_dispatcher.py
+++ b/ibis/backends/dask/tests/test_dispatcher.py
@@ -55,8 +55,12 @@ def foo_dispatchers():
     def foo3(x, y):
         return 3
 
-    @foo.register((A1, A2),)
-    @foo_m.register((A1, A2),)
+    @foo.register(
+        (A1, A2),
+    )
+    @foo_m.register(
+        (A1, A2),
+    )
     def foo4(x):
         return 4
 

--- a/ibis/backends/dask/tests/test_udf.py
+++ b/ibis/backends/dask/tests/test_udf.py
@@ -62,7 +62,10 @@ def df_timestamp(npartitions):
         }
     )
     df["a"] = df.a.astype(pd.DatetimeTZDtype(tz='UTC'))
-    return dd.from_pandas(df, npartitions=npartitions,)
+    return dd.from_pandas(
+        df,
+        npartitions=npartitions,
+    )
 
 
 @pytest.fixture
@@ -149,7 +152,8 @@ def zscore(series):
 
 
 @reduction(
-    input_type=[dt.double], output_type=dt.Array(dt.double),
+    input_type=[dt.double],
+    output_type=dt.Array(dt.double),
 )
 def quantiles(series, *, quantiles):
     return list(series.quantile(quantiles))

--- a/ibis/backends/dask/trace.py
+++ b/ibis/backends/dask/trace.py
@@ -103,7 +103,7 @@ def _log_trace(func, start=None):
 
 
 def trace(func):
-    """ Return a function decorator that wraped the decorated function with
+    """Return a function decorator that wraped the decorated function with
     tracing.
     """
     _trace_funcs.add(func.__name__)
@@ -132,13 +132,13 @@ def trace(func):
 
 
 class TraceTwoLevelDispatcher(TwoLevelDispatcher):
-    """ A Dispatcher that also wraps the registered function with tracing."""
+    """A Dispatcher that also wraps the registered function with tracing."""
 
     def __init__(self, name, doc=None):
         super().__init__(name, doc)
 
     def register(self, *types, **kwargs):
-        """ Register a function with this Dispatcher.
+        """Register a function with this Dispatcher.
         The function will also be wrapped with tracing information.
         """
 

--- a/ibis/backends/dask/udf.py
+++ b/ibis/backends/dask/udf.py
@@ -35,8 +35,7 @@ def make_struct_op_meta(op: ir.Expr) -> List[Tuple[str, np.dtype]]:
 @pre_execute.register(ops.ElementWiseVectorizedUDF)
 @pre_execute.register(ops.ElementWiseVectorizedUDF, Client)
 def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
-    """Register execution rules for elementwise UDFs.
-    """
+    """Register execution rules for elementwise UDFs."""
     input_type = op.input_type
 
     # definitions
@@ -129,7 +128,8 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
                 meta = make_struct_op_meta(op)
             else:
                 meta = make_meta_series(
-                    dtype=op._output_type.to_dask(), name=args[0].name,
+                    dtype=op._output_type.to_dask(),
+                    name=args[0].name,
                 )
             result = dd.from_delayed(lazy_result, meta=meta)
 
@@ -237,7 +237,10 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
             meta = dd.utils.make_meta(make_struct_op_meta(op))
             meta.index.name = parent_df.index.name
             result = grouped_df.apply(
-                apply_wrapper, func, col_names, meta=meta,
+                apply_wrapper,
+                func,
+                col_names,
+                meta=meta,
             )
             # we don't know how data moved around here
             result = result.reset_index().set_index(parent_df.index.name)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -1392,7 +1392,12 @@ class ImpalaClient(SQLClient):
         )
 
     def load_data(
-        self, table_name, path, database=None, overwrite=False, partition=None,
+        self,
+        table_name,
+        path,
+        database=None,
+        overwrite=False,
+        partition=None,
     ):
         """
         Wraps the LOAD DATA DDL statement. Loads data into an Impala table by

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -304,7 +304,9 @@ def wrap_for_apply(
 
 
 def wrap_for_agg(
-    function: Callable, args: Tuple[Any, ...], kwargs: Dict[str, Any],
+    function: Callable,
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
 ) -> Callable:
     """Wrap a function for use with Pandas `agg`.
 
@@ -443,8 +445,7 @@ def window_agg_built_in(
     *args: Tuple[Any],
     **kwargs: Dict[str, Any],
 ) -> pd.Series:
-    """Apply window aggregation with built-in aggregators.
-    """
+    """Apply window aggregation with built-in aggregators."""
     assert isinstance(function, str)
     method = operator.methodcaller(function, *args, **kwargs)
 

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -430,7 +430,11 @@ def main_execute(
     params = {k.op() if hasattr(k, 'op') else k: v for k, v in params.items()}
     scope = scope.merge_scope(Scope(params, timecontext))
     return execute_with_scope(
-        expr, scope, timecontext=timecontext, aggcontext=aggcontext, **kwargs,
+        expr,
+        scope,
+        timecontext=timecontext,
+        aggcontext=aggcontext,
+        **kwargs,
     )
 
 

--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -54,7 +54,8 @@ def execute_array_index_scalar(op, data, index, **kwargs):
 
 
 def _concat_iterables_to_series(
-    iter1: Collection[Any], iter2: Collection[Any],
+    iter1: Collection[Any],
+    iter2: Collection[Any],
 ) -> pd.Series:
     """Concatenate two collections elementwise ("horizontally") to create a
     Series. The two collections are assumed to have the same length.
@@ -96,7 +97,12 @@ def execute_array_concat_scalar(op, left, right, **kwargs):
 def execute_array_repeat(op, data, n, **kwargs):
     # Negative n will be treated as 0 (repeat will produce empty array)
     n = max(n, 0)
-    return pd.Series(map(lambda arr: np.tile(arr, n), data,))
+    return pd.Series(
+        map(
+            lambda arr: np.tile(arr, n),
+            data,
+        )
+    )
 
 
 @execute_node.register(ops.ArrayRepeat, np.ndarray, int)

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -67,7 +67,7 @@ def compute_sorted_frame(
 def coerce_to_output(
     result: Any, expr: ir.Expr, index: Optional[pd.Index] = None
 ) -> Union[pd.Series, pd.DataFrame]:
-    """ Cast the result to either a Series or DataFrame.
+    """Cast the result to either a Series or DataFrame.
 
     This method casts result of an execution to a Series or DataFrame,
     depending on the type of the expression and shape of the result.
@@ -124,7 +124,9 @@ def coerce_to_output(
             # Broadcast `result` to a multi-element Series according to the
             # given `index`.
             return pd.Series(
-                np.repeat(result, len(index)), index=index, name=result_name,
+                np.repeat(result, len(index)),
+                index=index,
+                name=result_name,
             )
     elif isinstance(result, np.ndarray):
         return pd.Series(result, name=result_name)

--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -122,7 +122,14 @@ get_aggcontext = Dispatcher('get_aggcontext')
 
 @get_aggcontext.register(object)
 def get_aggcontext_default(
-    window, *, scope, operand, parent, group_by, order_by, **kwargs,
+    window,
+    *,
+    scope,
+    operand,
+    parent,
+    group_by,
+    order_by,
+    **kwargs,
 ) -> NoReturn:
     raise NotImplementedError(
         f"get_aggcontext is not implemented for {type(window).__name__}"
@@ -131,7 +138,14 @@ def get_aggcontext_default(
 
 @get_aggcontext.register(win.Window)
 def get_aggcontext_window(
-    window, *, scope, operand, parent, group_by, order_by, **kwargs,
+    window,
+    *,
+    scope,
+    operand,
+    parent,
+    group_by,
+    order_by,
+    **kwargs,
 ) -> AggregationContext:
     # no order by or group by: default summarization aggcontext
     #
@@ -186,23 +200,23 @@ def get_aggcontext_window(
 def trim_window_result(
     data: Union[pd.Series, pd.DataFrame], timecontext: Optional[TimeContext]
 ):
-    """ Trim data within time range defined by timecontext
+    """Trim data within time range defined by timecontext
 
-        This is a util function used in ``execute_window_op``, where time
-        context might be adjusted for calculation. Data must be trimmed
-        within the original time context before return.
-        `data` is a pd.Series with Multiindex for most cases, for multi
-        column udf result, `data` could be a pd.DataFrame
+    This is a util function used in ``execute_window_op``, where time
+    context might be adjusted for calculation. Data must be trimmed
+    within the original time context before return.
+    `data` is a pd.Series with Multiindex for most cases, for multi
+    column udf result, `data` could be a pd.DataFrame
 
-        Params
-        ------
-        data: pd.Series or pd.DataFrame
-        timecontext: Optional[TimeContext]
+    Params
+    ------
+    data: pd.Series or pd.DataFrame
+    timecontext: Optional[TimeContext]
 
-        Returns:
-        ------
-        a trimmed pd.Series or or pd.DataFrame with the same Multiindex
-        as data's
+    Returns:
+    ------
+    a trimmed pd.Series or or pd.DataFrame with the same Multiindex
+    as data's
 
     """
     # noop if timecontext is None
@@ -385,7 +399,11 @@ def execute_window_op(
         **kwargs,
     )
     result = post_process(
-        result, data, ordering_keys, grouping_keys, adjusted_timecontext,
+        result,
+        data,
+        ordering_keys,
+        grouping_keys,
+        adjusted_timecontext,
     )
     assert len(data) == len(
         result

--- a/ibis/backends/pandas/tests/execution/test_arrays.py
+++ b/ibis/backends/pandas/tests/execution/test_arrays.py
@@ -209,7 +209,8 @@ def test_array_repeat(t, df, n, mul):
     expr = mul(t.array_of_strings, n)
     result = expr.execute()
     expected = df.apply(
-        lambda row: np.tile(row.array_of_strings, max(n, 0)), axis=1,
+        lambda row: np.tile(row.array_of_strings, max(n, 0)),
+        axis=1,
     )
     tm.assert_series_equal(result, expected)
 

--- a/ibis/backends/pandas/tests/execution/test_cast.py
+++ b/ibis/backends/pandas/tests/execution/test_cast.py
@@ -177,7 +177,8 @@ def test_cast_to_decimal(t, df, type):
 
 
 @pytest.mark.parametrize(
-    'column', ['plain_int64', 'dup_strings', 'dup_ints', 'strings_with_nulls'],
+    'column',
+    ['plain_int64', 'dup_strings', 'dup_ints', 'strings_with_nulls'],
 )
 def test_cast_to_category(t, df, column):
     test = t[column].cast('category').execute()

--- a/ibis/backends/pandas/tests/execution/test_timecontext.py
+++ b/ibis/backends/pandas/tests/execution/test_timecontext.py
@@ -133,7 +133,7 @@ def test_context_adjustment_window(
 
 
 def test_trim_window_result(time_df3):
-    """ Unit test `trim_window_result` in Window execution"""
+    """Unit test `trim_window_result` in Window execution"""
     df = time_df3.copy()
     context = pd.Timestamp('20170105'), pd.Timestamp('20170111')
 
@@ -141,7 +141,8 @@ def test_trim_window_result(time_df3):
     series = df['value']
     time_index = df.set_index('time').index
     series.index = pd.MultiIndex.from_arrays(
-        [series.index, time_index], names=series.index.names + ['time'],
+        [series.index, time_index],
+        names=series.index.names + ['time'],
     )
     result = trim_window_result(series, context)
     expected = df['time'][df['time'] >= pd.Timestamp('20170105')].reset_index(
@@ -233,9 +234,9 @@ def test_context_adjustment_multi_window(time_table, time_df3):
 
 
 def test_context_adjustment_window_groupby_id(time_table, time_df3):
-    """ This test case is meant to test trim_window_result method
-        in pandas/execution/window.py to see if it could trim Series
-        correctly with groupby params
+    """This test case is meant to test trim_window_result method
+    in pandas/execution/window.py to see if it could trim Series
+    correctly with groupby params
     """
     expected = (
         time_df3.set_index('time')
@@ -262,14 +263,14 @@ def test_context_adjustment_window_groupby_id(time_table, time_df3):
 
 
 def test_construct_time_context_aware_series(time_df3):
-    """Unit test for `construct_time_context_aware_series`
-    """
+    """Unit test for `construct_time_context_aware_series`"""
     # Series without 'time' index will result in a MultiIndex with 'time'
     df = time_df3
     expected = df['value']
     time_index = pd.Index(df['time'])
     expected.index = pd.MultiIndex.from_arrays(
-        [expected.index, time_index], names=expected.index.names + ['time'],
+        [expected.index, time_index],
+        names=expected.index.names + ['time'],
     )
     result = construct_time_context_aware_series(df['value'], df)
     tm.assert_series_equal(result, expected)

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -36,7 +36,7 @@ class CustomInterval:
 
 
 class CustomWindow(ibis.expr.window.Window):
-    """ This is a dummy custom window that return n preceding rows
+    """This is a dummy custom window that return n preceding rows
     where n is defined by CustomInterval.value."""
 
     def _replace(self, **kwds):
@@ -670,7 +670,7 @@ def test_window_on_and_by_key_as_window_input(t, df):
 
 
 def test_custom_window_udf(t, custom_window):
-    """ Test implementing  a (dummy) custom window.
+    """Test implementing  a (dummy) custom window.
 
     This test covers the advance use case to support custom window with udfs.
 

--- a/ibis/backends/pandas/tests/test_aggcontext.py
+++ b/ibis/backends/pandas/tests/test_aggcontext.py
@@ -18,8 +18,16 @@ df = pd.DataFrame(
 @pytest.mark.parametrize(
     ('agg_fn', 'expected_fn'),
     [
-        param(lambda v1: v1.mean(), lambda df: df['v1'].mean(), id='udf',),
-        param('mean', lambda df: df['v1'].mean(), id='string',),
+        param(
+            lambda v1: v1.mean(),
+            lambda df: df['v1'].mean(),
+            id='udf',
+        ),
+        param(
+            'mean',
+            lambda df: df['v1'].mean(),
+            id='string',
+        ),
     ],
 )
 def test_summarize_single_series(agg_fn, expected_fn):
@@ -36,8 +44,16 @@ def test_summarize_single_series(agg_fn, expected_fn):
 @pytest.mark.parametrize(
     ('agg_fn', 'expected_fn'),
     [
-        param(lambda v1: v1.mean(), lambda df: df['v1'].mean(), id='udf',),
-        param('mean', lambda df: df['v1'].mean(), id='string',),
+        param(
+            lambda v1: v1.mean(),
+            lambda df: df['v1'].mean(),
+            id='udf',
+        ),
+        param(
+            'mean',
+            lambda df: df['v1'].mean(),
+            id='string',
+        ),
     ],
 )
 def test_summarize_single_seriesgroupby(agg_fn, expected_fn):
@@ -96,7 +112,7 @@ def test_summarize_multiple_series(agg_fn, expected_fn):
     ],
 )
 def test_window_agg_udf(param):
-    """ Test passing custom window indices for window aggregation."""
+    """Test passing custom window indices for window aggregation."""
 
     mask, expected = param
 
@@ -123,7 +139,7 @@ def test_window_agg_udf(param):
 
 
 def test_window_agg_udf_different_freq():
-    """ Test that window_agg_udf works when the window series and data series
+    """Test that window_agg_udf works when the window series and data series
     have different frequencies.
     """
 

--- a/ibis/backends/pandas/tests/test_dispatcher.py
+++ b/ibis/backends/pandas/tests/test_dispatcher.py
@@ -55,8 +55,12 @@ def foo_dispatchers():
     def foo3(x, y):
         return 3
 
-    @foo.register((A1, A2),)
-    @foo_m.register((A1, A2),)
+    @foo.register(
+        (A1, A2),
+    )
+    @foo_m.register(
+        (A1, A2),
+    )
     def foo4(x):
         return 4
 

--- a/ibis/backends/pandas/tests/test_udf.py
+++ b/ibis/backends/pandas/tests/test_udf.py
@@ -95,7 +95,8 @@ def zscore(series):
 
 
 @udf.reduction(
-    input_type=[dt.double], output_type=dt.Array(dt.double),
+    input_type=[dt.double],
+    output_type=dt.Array(dt.double),
 )
 def quantiles(series, *, quantiles):
     return np.array(series.quantile(quantiles))

--- a/ibis/backends/pandas/udf.py
+++ b/ibis/backends/pandas/udf.py
@@ -47,7 +47,7 @@ def rule_to_python_type(datatype):
 
 
 def create_gens_from_args_groupby(args: Tuple[SeriesGroupBy]):
-    """ Create generators for each args for groupby udaf.
+    """Create generators for each args for groupby udaf.
 
     Returns a generator that outputs each group.
 
@@ -154,8 +154,7 @@ class udf:
 @pre_execute.register(ops.ElementWiseVectorizedUDF)
 @pre_execute.register(ops.ElementWiseVectorizedUDF, Client)
 def pre_execute_elementwise_udf(op, *clients, scope=None, **kwargs):
-    """Register execution rules for elementwise UDFs.
-    """
+    """Register execution rules for elementwise UDFs."""
     input_type = op.input_type
 
     # definitions

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -246,8 +246,7 @@ class PySparkClient(SQLClient):
         self.translator = PySparkExprTranslator()
 
     def compile(self, expr, timecontext=None, params=None, *args, **kwargs):
-        """Compile an ibis expression to a PySpark DataFrame object
-        """
+        """Compile an ibis expression to a PySpark DataFrame object"""
 
         if timecontext is not None:
             session_timezone = self._session.conf.get(

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -351,8 +351,7 @@ def compile_subtract(t, expr, scope, timecontext, **kwargs):
 
 @compiles(ops.Literal)
 def compile_literal(t, expr, scope, timecontext, raw=False, **kwargs):
-    """ If raw is True, don't wrap the result with F.lit()
-    """
+    """If raw is True, don't wrap the result with F.lit()"""
     value = expr.op().value
     dtype = expr.op().dtype
 
@@ -511,7 +510,12 @@ def compile_notany(t, expr, scope, timecontext, *, context=None, **kwargs):
         )
     else:
         return ~compile_any(
-            t, expr, scope, timecontext, context=context, **kwargs,
+            t,
+            expr,
+            scope,
+            timecontext,
+            context=context,
+            **kwargs,
         )
 
 
@@ -535,7 +539,12 @@ def compile_notall(t, expr, scope, timecontext, *, context=None, **kwargs):
         )
     else:
         return ~compile_all(
-            t, expr, scope, timecontext, context=context, **kwargs,
+            t,
+            expr,
+            scope,
+            timecontext,
+            context=context,
+            **kwargs,
         )
 
 
@@ -1148,7 +1157,7 @@ def compile_join(t, expr, scope, timecontext, *, how):
 
 
 def _canonicalize_interval(t, interval, scope, timecontext, **kwargs):
-    """ Convert interval to integer timestamp of second
+    """Convert interval to integer timestamp of second
 
     When pyspark cast timestamp to integer type, it uses the number of seconds
     since epoch. Therefore, we need cast ibis interval correspondingly.

--- a/ibis/backends/pyspark/ddl.py
+++ b/ibis/backends/pyspark/ddl.py
@@ -154,7 +154,8 @@ def format_schema(schema):
 
 def _format_schema_element(name, t):
     return '{} {}'.format(
-        quote_identifier(name, force=True), type_to_sql_string(t),
+        quote_identifier(name, force=True),
+        type_to_sql_string(t),
     )
 
 

--- a/ibis/backends/pyspark/tests/test_window.py
+++ b/ibis/backends/pyspark/tests/test_window.py
@@ -31,7 +31,8 @@ def test_time_indexed_window(client, ibis_windows, spark_range):
         .rangeBetween(*spark_range)
     )
     expected = spark_table.withColumn(
-        'mean', F.mean(spark_table['value']).over(spark_window),
+        'mean',
+        F.mean(spark_table['value']).over(spark_window),
     ).toPandas()
     tm.assert_frame_equal(result_pd, expected)
 
@@ -67,10 +68,12 @@ def test_multiple_windows(client, ibis_windows, spark_range):
     )
     expected = (
         spark_table.withColumn(
-            'mean_1h', F.mean(spark_table['value']).over(spark_window),
+            'mean_1h',
+            F.mean(spark_table['value']).over(spark_window),
         )
         .withColumn(
-            'mean_2h', F.mean(spark_table['value']).over(spark_window_2),
+            'mean_2h',
+            F.mean(spark_table['value']).over(spark_window_2),
         )
         .toPandas()
     )

--- a/ibis/backends/pyspark/tests/test_window_context_adjustment.py
+++ b/ibis/backends/pyspark/tests/test_window_context_adjustment.py
@@ -24,7 +24,7 @@ import ibis
     indirect=['ibis_windows'],
 )
 def test_window_with_timecontext(client, ibis_windows, spark_range):
-    """ Test context adjustment for trailing / range window
+    """Test context adjustment for trailing / range window
 
     We expand context according to window sizes, for example, for a table of:
     time       value
@@ -61,7 +61,8 @@ def test_window_with_timecontext(client, ibis_windows, spark_range):
         .rangeBetween(*spark_range)
     )
     expected = spark_table.withColumn(
-        'count', F.count(spark_table['value']).over(spark_window),
+        'count',
+        F.count(spark_table['value']).over(spark_window),
     ).toPandas()
     expected = expected[
         expected.time.between(*(t.tz_convert(None) for t in context))
@@ -75,7 +76,7 @@ def test_window_with_timecontext(client, ibis_windows, spark_range):
     indirect=['ibis_windows'],
 )
 def test_cumulative_window(client, ibis_windows, spark_range):
-    """ Test context adjustment for cumulative window
+    """Test context adjustment for cumulative window
 
     For cumulative window, by defination we should look back infinately.
     When data is trimmed by time context, we define the limit of looking
@@ -106,7 +107,8 @@ def test_cumulative_window(client, ibis_windows, spark_range):
         .rangeBetween(*spark_range)
     )
     expected = spark_table.withColumn(
-        'count_cum', F.count(spark_table['value']).over(spark_window),
+        'count_cum',
+        F.count(spark_table['value']).over(spark_window),
     ).toPandas()
     expected = expected[
         expected.time.between(*(t.tz_convert(None) for t in context))
@@ -125,7 +127,7 @@ def test_cumulative_window(client, ibis_windows, spark_range):
     indirect=['ibis_windows'],
 )
 def test_multiple_trailing_window(client, ibis_windows, spark_range):
-    """ Test context adjustment for multiple trailing window
+    """Test context adjustment for multiple trailing window
 
     When there are multiple window ops, we need to verify contexts are
     adjusted correctly for all windows. In this tests we are constucting
@@ -178,7 +180,7 @@ def test_multiple_trailing_window(client, ibis_windows, spark_range):
     indirect=['ibis_windows'],
 )
 def test_chained_trailing_window(client, ibis_windows, spark_range):
-    """ Test context adjustment for chained windows
+    """Test context adjustment for chained windows
 
     When there are chained window ops, we need to verify contexts are
     adjusted correctly for all windows. In this tests we are constucting
@@ -190,7 +192,9 @@ def test_chained_trailing_window(client, ibis_windows, spark_range):
         pd.Timestamp('20170102 07:00:00', tz='UTC'),
         pd.Timestamp('20170105', tz='UTC'),
     )
-    table = table.mutate(new_col=table['value'].count().over(ibis_windows[0]),)
+    table = table.mutate(
+        new_col=table['value'].count().over(ibis_windows[0]),
+    )
     table = table.mutate(count=table['new_col'].count().over(ibis_windows[1]))
     result_pd = table.execute(timecontext=context)
 
@@ -234,7 +238,7 @@ def test_chained_trailing_window(client, ibis_windows, spark_range):
     indirect=['ibis_windows'],
 )
 def test_rolling_with_cumulative_window(client, ibis_windows, spark_range):
-    """ Test context adjustment for rolling window and cumulative window
+    """Test context adjustment for rolling window and cumulative window
 
     cumulative window should calculate only with in user's context,
     while rolling window should calculate on expanded context.
@@ -296,7 +300,7 @@ def test_rolling_with_cumulative_window(client, ibis_windows, spark_range):
     indirect=['ibis_windows'],
 )
 def test_rolling_with_non_window_op(client, ibis_windows, spark_range):
-    """ Test context adjustment for rolling window and non window ops
+    """Test context adjustment for rolling window and non window ops
 
     non window ops should calculate only with in user's context,
     while rolling window should calculate on expanded context.
@@ -350,9 +354,9 @@ def test_rolling_with_non_window_op(client, ibis_windows, spark_range):
     strict=True,
 )
 def test_complex_window(client):
-    """ Test window with different sizes
-        mix context adjustment for window op that require context
-        adjustment and non window op that doesn't adjust context
+    """Test window with different sizes
+    mix context adjustment for window op that require context
+    adjustment and non window op that doesn't adjust context
     """
     table = client.table('time_indexed_table')
     context = (

--- a/ibis/backends/pyspark/timecontext.py
+++ b/ibis/backends/pyspark/timecontext.py
@@ -13,7 +13,7 @@ def filter_by_time_context(
     timecontext: Optional[TimeContext],
     adjusted_timecontext: Optional[TimeContext] = None,
 ) -> DataFrame:
-    """ Filter a Dataframe by given time context
+    """Filter a Dataframe by given time context
     Parameters
     ----------
     df : pyspark.sql.dataframe.DataFrame
@@ -56,7 +56,7 @@ def filter_by_time_context(
 def combine_time_context(
     timecontexts: List[TimeContext],
 ) -> Optional[TimeContext]:
-    """ Return a combined time context of `timecontexts`
+    """Return a combined time context of `timecontexts`
 
     The combined time context starts from the earliest begin time
     of `timecontexts`, and ends with the latest end time of `timecontexts`

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -54,7 +54,8 @@ aggregate_test_params = [
 
 
 @pytest.mark.parametrize(
-    ('result_fn', 'expected_fn', 'expected_col'), aggregate_test_params,
+    ('result_fn', 'expected_fn', 'expected_col'),
+    aggregate_test_params,
 )
 @pytest.mark.xfail_unsupported
 def test_aggregate(
@@ -71,7 +72,8 @@ def test_aggregate(
 
 
 @pytest.mark.parametrize(
-    ('result_fn', 'expected_fn', 'expected_col'), aggregate_test_params,
+    ('result_fn', 'expected_fn', 'expected_col'),
+    aggregate_test_params,
 )
 @pytest.mark.xfail_unsupported
 def test_aggregate_grouped(
@@ -230,7 +232,13 @@ def test_aggregate_grouped(
 )
 @pytest.mark.xfail_unsupported
 def test_reduction_ops(
-    backend, alltypes, df, result_fn, expected_fn, ibis_cond, pandas_cond,
+    backend,
+    alltypes,
+    df,
+    result_fn,
+    expected_fn,
+    ibis_cond,
+    pandas_cond,
 ):
     expr = result_fn(alltypes, ibis_cond(alltypes))
     result = expr.execute()

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -15,7 +15,8 @@ def new_schema():
 
 
 @pytest.mark.only_on_backends(
-    SQLALCHEMY_BACKENDS, reason="run only if backend is SQLAlchemy based",
+    SQLALCHEMY_BACKENDS,
+    reason="run only if backend is SQLAlchemy based",
 )
 @pytest.mark.xfail_unsupported
 def test_load_data_sqlalchemy(backend, con, temp_table):
@@ -211,7 +212,8 @@ def _create_temp_table_with_schema(con, temp_table_name, schema, data=None):
 
 
 @pytest.mark.only_on_backends(
-    SQLALCHEMY_BACKENDS, reason="run only if backend is SQLAlchemy based",
+    SQLALCHEMY_BACKENDS,
+    reason="run only if backend is SQLAlchemy based",
 )
 def test_insert_no_overwrite_from_dataframe(
     con, test_employee_schema, test_employee_data_2
@@ -219,7 +221,9 @@ def test_insert_no_overwrite_from_dataframe(
 
     temp_table = f'temp_to_table_{guid()}'
     temporary = _create_temp_table_with_schema(
-        con, temp_table, test_employee_schema,
+        con,
+        temp_table,
+        test_employee_schema,
     )
 
     con.insert(temp_table, obj=test_employee_data_2, overwrite=False)
@@ -228,7 +232,8 @@ def test_insert_no_overwrite_from_dataframe(
 
 
 @pytest.mark.only_on_backends(
-    SQLALCHEMY_BACKENDS, reason="run only if backend is SQLAlchemy based",
+    SQLALCHEMY_BACKENDS,
+    reason="run only if backend is SQLAlchemy based",
 )
 def test_insert_overwrite_from_dataframe(
     con, test_employee_schema, test_employee_data_1, test_employee_data_2
@@ -236,7 +241,10 @@ def test_insert_overwrite_from_dataframe(
 
     temp_table = f'temp_to_table_{guid()}'
     temporary = _create_temp_table_with_schema(
-        con, temp_table, test_employee_schema, data=test_employee_data_1,
+        con,
+        temp_table,
+        test_employee_schema,
+        data=test_employee_data_1,
     )
 
     con.insert(temp_table, obj=test_employee_data_2, overwrite=True)
@@ -245,7 +253,8 @@ def test_insert_overwrite_from_dataframe(
 
 
 @pytest.mark.only_on_backends(
-    SQLALCHEMY_BACKENDS, reason="run only if backend is SQLAlchemy based",
+    SQLALCHEMY_BACKENDS,
+    reason="run only if backend is SQLAlchemy based",
 )
 def test_insert_no_overwite_from_expr(
     con, test_employee_schema, test_employee_data_2
@@ -253,12 +262,17 @@ def test_insert_no_overwite_from_expr(
 
     temp_table = f'temp_to_table_{guid()}'
     temporary = _create_temp_table_with_schema(
-        con, temp_table, test_employee_schema,
+        con,
+        temp_table,
+        test_employee_schema,
     )
 
     from_table_name = f'temp_from_table_{guid()}'
     from_table = _create_temp_table_with_schema(
-        con, from_table_name, test_employee_schema, data=test_employee_data_2,
+        con,
+        from_table_name,
+        test_employee_schema,
+        data=test_employee_data_2,
     )
 
     con.insert(temp_table, obj=from_table, overwrite=False)
@@ -267,7 +281,8 @@ def test_insert_no_overwite_from_expr(
 
 
 @pytest.mark.only_on_backends(
-    SQLALCHEMY_BACKENDS, reason="run only if backend is SQLAlchemy based",
+    SQLALCHEMY_BACKENDS,
+    reason="run only if backend is SQLAlchemy based",
 )
 def test_insert_overwrite_from_expr(
     con, test_employee_schema, test_employee_data_1, test_employee_data_2
@@ -275,12 +290,18 @@ def test_insert_overwrite_from_expr(
 
     temp_table = f'temp_to_table_{guid()}'
     temporary = _create_temp_table_with_schema(
-        con, temp_table, test_employee_schema, data=test_employee_data_1,
+        con,
+        temp_table,
+        test_employee_schema,
+        data=test_employee_data_1,
     )
 
     from_table_name = f'temp_from_table_{guid()}'
     from_table = _create_temp_table_with_schema(
-        con, from_table_name, test_employee_schema, data=test_employee_data_2,
+        con,
+        from_table_name,
+        test_employee_schema,
+        data=test_employee_data_2,
     )
 
     con.insert(temp_table, obj=from_table, overwrite=True)
@@ -289,7 +310,8 @@ def test_insert_overwrite_from_expr(
 
 
 @pytest.mark.only_on_backends(
-    SQLALCHEMY_BACKENDS, reason="run only if backend is SQLAlchemy based",
+    SQLALCHEMY_BACKENDS,
+    reason="run only if backend is SQLAlchemy based",
 )
 def test_list_databases(con):
     # Every backend has its own databases

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -33,13 +33,15 @@ def filter_by_time_context(df, context):
     [
         ibis.trailing_window(ibis.interval(days=3), order_by=ORDERBY_COL),
         ibis.trailing_window(
-            ibis.interval(days=3), order_by=ORDERBY_COL, group_by=GROUPBY_COL,
+            ibis.interval(days=3),
+            order_by=ORDERBY_COL,
+            group_by=GROUPBY_COL,
         ),
     ],
 )
 def test_context_adjustment_window_udf(alltypes, df, context, window):
-    """ This test case aims to test context adjustment of
-        udfs in window method.
+    """This test case aims to test context adjustment of
+    udfs in window method.
     """
     with option_context('context_adjustment.time_col', 'timestamp_col'):
         expr = alltypes.mutate(v1=calc_mean(alltypes[TARGET_COL]).over(window))

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -229,7 +229,8 @@ def overwrite_struct_reduction(v, w):
 
 
 @reduction(
-    input_type=[dt.double], output_type=dt.Array(dt.double),
+    input_type=[dt.double],
+    output_type=dt.Array(dt.double),
 )
 def quantiles(series, *, quantiles):
     return series.quantile(quantiles)
@@ -463,7 +464,8 @@ def test_elementwise_udf_destruct(backend, alltypes, udf):
     ).execute()
 
     expected = alltypes.mutate(
-        col1=alltypes['double_col'] + 1, col2=alltypes['double_col'] + 2,
+        col1=alltypes['double_col'] + 1,
+        col2=alltypes['double_col'] + 2,
     ).execute()
 
     backend.assert_frame_equal(result, expected)
@@ -477,7 +479,8 @@ def test_elementwise_udf_overwrite_destruct(backend, alltypes):
     ).execute()
 
     expected = alltypes.mutate(
-        double_col=alltypes['double_col'] + 1, col2=alltypes['double_col'] + 2,
+        double_col=alltypes['double_col'] + 1,
+        col2=alltypes['double_col'] + 2,
     ).execute()
 
     # TODO issue #2649
@@ -596,7 +599,8 @@ def test_elementwise_udf_struct(backend, alltypes):
     )
     result = result.drop('new_col', axis=1)
     expected = alltypes.mutate(
-        col1=alltypes['double_col'] + 1, col2=alltypes['double_col'] + 2,
+        col1=alltypes['double_col'] + 1,
+        col2=alltypes['double_col'] + 2,
     ).execute()
 
     backend.assert_frame_equal(result, expected)

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -248,7 +248,8 @@ def test_ungrouped_bounded_expanding_window(
 
     expr = alltypes.mutate(
         val=result_fn(
-            alltypes, win=ibis.window(following=0, order_by=[alltypes.id]),
+            alltypes,
+            win=ibis.window(following=0, order_by=[alltypes.id]),
         )
     )
     result = expr.execute().set_index('id').sort_index()
@@ -369,7 +370,8 @@ def test_grouped_bounded_preceding_windows(
     ],
 )
 @pytest.mark.parametrize(
-    ('ordered'), [param(True, id='orderered'), param(False, id='unordered')],
+    ('ordered'),
+    [param(True, id='orderered'), param(False, id='unordered')],
 )
 @pytest.mark.xfail_unsupported
 def test_grouped_unbounded_window(
@@ -386,7 +388,12 @@ def test_grouped_unbounded_window(
     # 3) Unbounded
     order_by = [alltypes.id] if ordered else None
     window = ibis.window(group_by=[alltypes.string_col], order_by=order_by)
-    expr = alltypes.mutate(val=result_fn(alltypes, win=window,))
+    expr = alltypes.mutate(
+        val=result_fn(
+            alltypes,
+            win=window,
+        )
+    )
     result = expr.execute()
     result = result.set_index('id').sort_index()
 
@@ -474,7 +481,12 @@ def test_ungrouped_unbounded_window(
     # 3) Unbounded
     order_by = [alltypes.id] if ordered else None
     window = ibis.window(order_by=order_by)
-    expr = alltypes.mutate(val=result_fn(alltypes, win=window,))
+    expr = alltypes.mutate(
+        val=result_fn(
+            alltypes,
+            win=window,
+        )
+    )
     result = expr.execute()
     result = result.set_index('id').sort_index()
 
@@ -512,7 +524,10 @@ def test_grouped_bounded_range_window(backend, alltypes, df, con):
     #     have the same 'string_col' value.
     #
     window = ibis.range_window(
-        preceding=10, following=0, order_by='id', group_by='string_col',
+        preceding=10,
+        following=0,
+        order_by='id',
+        group_by='string_col',
     )
     expr = alltypes.mutate(val=alltypes.double_col.sum().over(window))
     result = expr.execute().set_index('id').sort_index()

--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -531,7 +531,9 @@ class Struct(DataType):
 
     @classmethod
     def from_dict(
-        cls, pairs: Mapping[str, Union[str, DataType]], nullable: bool = True,
+        cls,
+        pairs: Mapping[str, Union[str, DataType]],
+        nullable: bool = True,
     ) -> 'Struct':
         names, types = pairs.keys(), pairs.values()
         return cls(list(names), list(map(dtype, types)), nullable=nullable)
@@ -1719,7 +1721,10 @@ def infer_integer(value: int, allow_overflow: bool = False) -> Integer:
 
 @infer.register(enum.Enum)
 def infer_enum(value: enum.Enum) -> Enum:
-    return Enum(infer(value.name), infer(value.value),)
+    return Enum(
+        infer(value.name),
+        infer(value.value),
+    )
 
 
 @infer.register(bool)

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -107,8 +107,9 @@ class Container:
 
 
 class Stack(Container):
+    """Wrapper around `collections.deque`.
 
-    """Wrapper around a list to provide a common API for graph traversal
+    Implements the `Container` API for depth-first graph traversal.
     """
 
     __slots__ = ('data',)
@@ -122,8 +123,9 @@ class Stack(Container):
 
 
 class Queue(Container):
+    """Wrapper around `collections.deque`.
 
-    """Wrapper around a queue.Queue to provide a common API for graph traversal
+    Implements the `Container` API for breadth-first graph traversal.
     """
 
     __slots__ = ('data',)

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -3533,8 +3533,7 @@ class GeoDWithin(GeoSpatialBinOp):
 
 
 class GeoEnvelope(GeoSpatialUnOp):
-    """Returns a geometry representing the boundingbox of the supplied geometry.
-    """
+    """Represents the bounding box of the supplied geometry."""
 
     output_type = rlz.shape_like('arg', dt.polygon)
 

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -144,8 +144,7 @@ class Schema:
         return zip(self.names, self.types)
 
     def name_at_position(self, i):
-        """
-        """
+        """ """
         upper = len(self.names) - 1
         if not 0 <= i <= upper:
             raise ValueError(

--- a/ibis/expr/scope.py
+++ b/ibis/expr/scope.py
@@ -50,7 +50,7 @@ class Scope:
         param: Dict[Node, Any] = None,
         timecontext: Optional[TimeContext] = None,
     ):
-        """ Take a dict of `op`, `result`, create a new scope and save
+        """Take a dict of `op`, `result`, create a new scope and save
         those pairs in scope. Associate None as timecontext by default.
         This is mostly used to init a scope with a set of given params.
         """
@@ -61,7 +61,7 @@ class Scope:
         )
 
     def __contains__(self, op):
-        """ Given an `op`, return if `op` is present in Scope.
+        """Given an `op`, return if `op` is present in Scope.
         Note that this `__contain__` method doesn't take `timecontext`
         as a parameter. This could be used to iterate all keys in
         current scope, or any case that doesn't care about value, just
@@ -80,7 +80,7 @@ class Scope:
     def set_value(
         self, op: Node, timecontext: Optional[TimeContext], value: Any
     ) -> None:
-        """ Set values in scope.
+        """Set values in scope.
 
             Given an `op`, `timecontext` and `value`, set `op` and
             `(value, timecontext)` in scope.
@@ -110,7 +110,7 @@ class Scope:
     def get_value(
         self, op: Node, timecontext: Optional[TimeContext] = None
     ) -> Any:
-        """ Given a op and timecontext, get the result from scope
+        """Given a op and timecontext, get the result from scope
 
         Parameters
         ----------

--- a/ibis/expr/timecontext.py
+++ b/ibis/expr/timecontext.py
@@ -54,7 +54,7 @@ def get_time_col():
 
 
 class TimeContextRelation(enum.Enum):
-    """ Enum to classify the relationship between two time contexts
+    """Enum to classify the relationship between two time contexts
     Assume that we have two timecontext `c1 (begin1, end1)`,
     `c2(begin2, end2)`:
         - SUBSET means `c1` is a subset of `c2`, `begin1` is greater than or
@@ -105,7 +105,7 @@ def canonicalize_context(
     timecontext: Optional[TimeContext],
 ) -> Optional[TimeContext]:
     """Convert a timecontext to canonical one with type pandas.Timestamp
-       for its begin and end time. Raise Exception for illegal inputs
+    for its begin and end time. Raise Exception for illegal inputs
     """
     SUPPORTS_TIMESTAMP_TYPE = pd.Timestamp
     if not isinstance(timecontext, tuple) or len(timecontext) != 2:
@@ -147,7 +147,7 @@ def localize_context(timecontext: TimeContext, timezone: str) -> TimeContext:
 def construct_time_context_aware_series(
     series: pd.Series, frame: pd.DataFrame
 ) -> pd.Series:
-    """ Construct a Series by adding 'time' in its MultiIndex
+    """Construct a Series by adding 'time' in its MultiIndex
 
     In window execution, the result Series of udf may need
     to be trimmed by timecontext. In order to do so, 'time'

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -919,7 +919,7 @@ class StructColumn(AnyColumn, StructValue):
 
 
 class DestructValue(AnyValue):
-    """ Class that represents a destruct value.
+    """Class that represents a destruct value.
 
     When assigning a destruct column, the field inside this destruct column
     will be destructured and assigned to multipe columnns.

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -91,9 +91,7 @@ class TestASTBuilder(unittest.TestCase):
 
 class TestNonTabularResults(unittest.TestCase):
 
-    """
-
-    """
+    """ """
 
     def setUp(self):
         self.con = MockConnection()

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -23,7 +23,7 @@ from ibis.expr.schema import (
 
 
 class UserDefinedFunction(object):
-    """ Class representing a user defined function.
+    """Class representing a user defined function.
 
     This class Implements __call__ that returns an ibis expr for the UDF.
     """


### PR DESCRIPTION
This PR updates `pre-commit` to use the latest isort and black.

Generally not a fan of these kinds of changes, but we have to update these
dependencies at some point.

Going forward, we should enable dependabot after we move to poetry, which will
automate this process and should result in smaller sets of changes.

Supercedes #2972.