### PR TITLE
ci: rename workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
-name: Continuous Integration
+# vim: filetype=yaml
+name: CI
 
 on:
   push:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,7 +1,7 @@
 name: Test Report
 on:
   workflow_run:
-    workflows: ['Continuous Integration']
+    workflows: ['CI']
     types:
       - completed
 jobs:


### PR DESCRIPTION
This is a small PR to rename the main CI workflow to `CI` instead of the much longer `Continuous Integration`
that tends to push useful information about various checks in PRs to the right and obscure it.
