### PR TITLE
fix: fix order of limit and offset param in Clickhouse.

### DIFF
--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -45,9 +45,10 @@ class ClickhouseSelect(Select):
         buf = StringIO()
 
         n, offset = self.limit['n'], self.limit['offset']
-        buf.write(f'LIMIT {n}')
         if offset is not None and offset != 0:
-            buf.write(f', {offset}')
+            buf.write(f'LIMIT {offset}, {n}')
+        else:
+            buf.write(f'LIMIT {n}')
 
         return buf.getvalue()
 

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -76,8 +76,8 @@ def test_limit_offset(alltypes):
     tm.assert_frame_equal(alltypes.limit(4).execute(), expected.head(4))
     tm.assert_frame_equal(alltypes.limit(8).execute(), expected.head(8))
     tm.assert_frame_equal(
-        alltypes.limit(4, offset=4).execute(),
-        expected.iloc[4:8].reset_index(drop=True),
+        alltypes.limit(4, offset=2).execute(),
+        expected.iloc[2:6].reset_index(drop=True),
     )
 
 


### PR DESCRIPTION
Split from https://github.com/ibis-project/ibis/pull/2983

---

The order of limit and offset in compiled SQL is reversed 🤣.
 
 https://clickhouse.tech/docs/en/sql-reference/statements/select/limit/#limit-clause