### PR TITLE
fix: fix literal of Nullable in Clickhouse

### DIFF
--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -304,6 +304,8 @@ def _interval_from_integer(translator, expr):
 
 def _literal(translator, expr):
     value = expr.op().value
+    if value is None and expr._dtype.nullable:
+        return _null_literal(translator, expr)
     if isinstance(expr, ir.BooleanValue):
         return '1' if value else '0'
     elif isinstance(expr, ir.StringValue):

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -304,7 +304,7 @@ def _interval_from_integer(translator, expr):
 
 def _literal(translator, expr):
     value = expr.op().value
-    if value is None and expr._dtype.nullable:
+    if value is None and expr.type().nullable:
         return _null_literal(translator, expr)
     if isinstance(expr, ir.BooleanValue):
         return '1' if value else '0'

--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -500,6 +500,19 @@ def test_null_column(alltypes, translate):
     tm.assert_series_equal(result, expected)
 
 
+def test_literal_none_to_nullable_colum(alltypes):
+    t = alltypes
+    nrows = t.count().execute()
+    expr = t.mutate(
+        ibis.literal(None, dt.String(nullable=True)).name(
+            'nullable_string_column'
+        )
+    )
+    result = expr['nullable_string_column'].execute()
+    expected = pd.Series([None] * nrows, name='nullable_string_column')
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     ('attr', 'expected'),
     [

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -276,7 +276,10 @@ def test_non_equijoin(alltypes):
             ('any_left_join', 'ANY LEFT JOIN'),
             ('left_join', 'ALL LEFT JOIN'),
         ],
-        [('playerID', 'playerID'), ('playerID', 'awardID'),],  # noqa: E231
+        [
+            ('playerID', 'playerID'),
+            ('playerID', 'awardID'),
+        ],  # noqa: E231
     ),
 )
 def test_simple_joins(

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -276,10 +276,7 @@ def test_non_equijoin(alltypes):
             ('any_left_join', 'ANY LEFT JOIN'),
             ('left_join', 'ALL LEFT JOIN'),
         ],
-        [
-            ('playerID', 'playerID'),
-            ('playerID', 'awardID'),
-        ],  # noqa: E231
+        [('playerID', 'playerID'), ('playerID', 'awardID'),],  # noqa: E231
     ),
 )
 def test_simple_joins(


### PR DESCRIPTION
Split from https://github.com/ibis-project/ibis/pull/2983

---

When literal `None` to some Nullable column's type will raise error.

``` python
expr = table.mutate(ibis.literal(None, table['nullable_string_column'].type()).name('new_column'))
expr.compile()
# AttributeError: 'NoneType' object has no attribute 'replace'
```
