### PR TITLE
test: don't suppress test start info

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -20,7 +20,6 @@ done
 set -x
 
 pytest "${TESTS_DIRS[@]}" \
-    -q \
     -ra \
     --junitxml=junit.xml \
     --cov=ibis \


### PR DESCRIPTION
Now that we are using `pytest-randomly`, we should remove use of the `-q` option
so that if we need to reproduce a particular test run ordering we can see the
`--randomly-seed` value shown on test startup.
