### PR TITLE
ci: temporarily add pure-sasl to impala conda dependencies

### DIFF
--- a/ci/deps/impala.yml
+++ b/ci/deps/impala.yml
@@ -6,3 +6,5 @@ dependencies:
   - thrift_sasl
   - python-hdfs
   - boost
+  # TODO:remove when https://github.com/conda-forge/impyla-feedstock/pull/28 lands
+  - pure-sasl

--- a/ci/merge_and_update_env.sh
+++ b/ci/merge_and_update_env.sh
@@ -9,8 +9,8 @@ if [ "$#" -eq 0 ]; then
   exit 1
 fi
 
-# install conda-merge
-mamba install --name ibis conda-merge
+# install conda-merge, don't try to update already installed dependencies
+mamba install --freeze-installed --name ibis conda-merge
 
 additional_env_files=()
 


### PR DESCRIPTION
This PR adds `pure-sasl` to the impala backend dependencies due to `impyla`
not declaring a hard dependency on `pure-sasl` (https://github.com/cloudera/impyla/issues/471).
