### PR TITLE
ci: remove pure-sasl dependency

### DIFF
--- a/ci/deps/impala.yml
+++ b/ci/deps/impala.yml
@@ -6,5 +6,3 @@ dependencies:
   - thrift_sasl
   - python-hdfs
   - boost
-  # TODO:remove when https://github.com/conda-forge/impyla-feedstock/pull/28 lands
-  - pure-sasl


### PR DESCRIPTION
This removes the `pure-sasl` dependency now that the upstream PR has landed.
