### PR TITLE
test: fix incorrect connection pool test

### DIFF
--- a/ibis/backends/impala/tests/test_connection_pool.py
+++ b/ibis/backends/impala/tests/test_connection_pool.py
@@ -8,7 +8,10 @@ def test_connection_pool_size(hdfs, env, test_data_db):
         host=env.impala_host,
         database=test_data_db,
     )
-    assert len(client.con.connection_pool) == 1
+
+    # the client cursor may or may not be GC'd, so the connection
+    # pool will contain either zero or one cursor
+    assert len(client.con.connection_pool) in (0, 1)
 
 
 def test_connection_pool_size_after_close(hdfs, env, test_data_db):


### PR DESCRIPTION
This PRs fixes an incorrect assumption in a test, that the cursor in the impala
client connection pool is never GCd, seen failing [here](https://github.com/ibis-project/ibis/runs/3652404022).
Under certain test run orderings, the cursor *is* GCd, and therefore never gets put into the connection pool.
