### PR TITLE
fix: fix cursor accounting races

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :bug:`2991` Fix data races in impala connection pool accounting
 * :support:`2977` Remove handwritten type parser; parsing errors that were previously `IbisTypeError` are now `parsy.ParseError`. `parsy` is now a hard requirement.
 * :support:`2962` Methods `current_database` and `list_databases` raise an exception for backends that do not support databases
 * :bug:`2956` Replace `equals` operation for geospatial datatype to `geo_equals` 

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -80,7 +80,8 @@ class ImpalaConnection:
         self._connections = weakref.WeakSet()
 
         self.connection_pool = deque(maxlen=pool_size)
-        self.connection_pool_size = 0
+        with self.lock:
+            self.connection_pool_size = 0
 
     def set_options(self, options):
         self.options.update(options)
@@ -134,7 +135,9 @@ class ImpalaConnection:
         try:
             cursor = self.connection_pool.popleft()
         except IndexError:  # deque is empty
-            if self.connection_pool_size < self.max_pool_size:
+            with self.lock:
+                connection_pool_size = self.connection_pool_size
+            if connection_pool_size < self.max_pool_size:
                 return self._new_cursor()
             raise com.InternalError('Too many concurrent / hung queries')
         else:
@@ -177,7 +180,8 @@ class ImpalaCursor:
         self.database = database
         self.options = options
         self.released = False
-        self.con.connection_pool_size += 1
+        with self.con.lock:
+            self.con.connection_pool_size += 1
 
     def __del__(self):
         try:

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -136,6 +136,10 @@ class ImpalaConnection:
             cursor = self.connection_pool.popleft()
         except IndexError:  # deque is empty
             with self.lock:
+                # NB: Do not put a lock around the entire if statement.
+                # This will cause a deadlock because _new_cursor calls the
+                # ImpalaCursor constructor which takes a lock to increment the
+                # connection pool size.
                 connection_pool_size = self.connection_pool_size
             if connection_pool_size < self.max_pool_size:
                 return self._new_cursor()


### PR DESCRIPTION
This PR fixes some possible race conditions in cursor management in the Impala backend
