### PR TITLE
Call aggregation function directly for pandas Summarize

### DIFF
--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -373,11 +373,12 @@ class Summarize(AggregationContext):
             grouped_data, pd.core.groupby.generic.SeriesGroupBy
         ) and len(grouped_data):
             # `SeriesGroupBy.agg` does not allow np.arrays to be returned
-            # from UDFs. To avoid `SeriesGroupBy.agg`, we will us
-            # `Series.agg` manually on each group. (#2768)
+            # from UDFs. To avoid `SeriesGroupBy.agg`, we will call the
+            # aggregation function manually on each group. (#2768)
             aggs = {}
             for k, v in grouped_data:
-                aggs[k] = v.agg(wrap_for_agg(function, args, kwargs))
+                func_args = [d.get_group(k) for d in args]
+                aggs[k] = function(v, *func_args, **kwargs)
                 grouped_col_name = v.name
             return (
                 pd.Series(aggs)


### PR DESCRIPTION
### Proposed Change
In the Pandas backend Summarize agg function, since we are already looping through the grouped data, we can simply get the aggregation results by calling the function directly rather than calling Pandas `agg`, which should save us some overhead.

### Tests
This is an internal refactor, all existing tests should pass.