### PR TITLE
refactor(ir): Remove ir.ExprList, ops.ExpressionList and ibis.expr_list() [WIP]

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,7 +30,6 @@ These methods are available directly in the ``ibis`` module namespace.
    now
    NA
    null
-   expr_list
    row_number
    window
    range_window

--- a/ibis/backends/base/sql/client.py
+++ b/ibis/backends/base/sql/client.py
@@ -145,7 +145,7 @@ class SQLClient(Client, metaclass=abc.ABCMeta):
         dml = getattr(query_ast, 'dml', query_ast)
         expr = getattr(dml, 'parent_expr', getattr(dml, 'table_set', None))
 
-        if isinstance(expr, (ir.TableExpr, ir.ExprList, sch.HasSchema)):
+        if isinstance(expr, (ir.TableExpr, sch.HasSchema)):
             return expr.schema()
         elif isinstance(expr, ir.ValueExpr):
             return sch.schema([(expr.get_name(), expr.type())])

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -277,7 +277,6 @@ class SelectBuilder:
             return scalar_handler
 
         if isinstance(expr, ir.ScalarExpr):
-
             if L.is_scalar_reduction(expr):
                 table_expr, name = L.reduction_to_aggregation(
                     expr, default_name='tmp'
@@ -300,26 +299,6 @@ class SelectBuilder:
 
         elif isinstance(expr, ir.AnalyticExpr):
             return expr.to_aggregation(), toolz.identity
-
-        elif isinstance(expr, ir.ExprList):
-            exprs = expr.exprs()
-
-            is_aggregation = True
-            any_aggregation = False
-
-            for x in exprs:
-                if not L.is_scalar_reduction(x):
-                    is_aggregation = False
-                else:
-                    any_aggregation = True
-
-            if is_aggregation:
-                table = ir.find_base_table(exprs[0])
-                return table.aggregate(exprs), toolz.identity
-            elif not any_aggregation:
-                return expr, toolz.identity
-            else:
-                raise NotImplementedError(expr._repr())
 
         elif isinstance(expr, ir.ColumnExpr):
             op = expr.op()

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -663,11 +663,7 @@ class SelectBuilder:
             if self.table_set is None:
                 raise com.InternalError('no table set')
         else:
-            # Expressions not depending on any table
-            if isinstance(root_op, ops.ExpressionList):
-                self.select_set = source_expr.exprs()
-            else:
-                self.select_set = [source_expr]
+            self.select_set = [source_expr]
 
     def _collect(self, expr, toplevel=False):
         op = expr.op()

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -135,18 +135,18 @@ def test_table_info(alltypes):
     assert buf.getvalue() is not None
 
 
-def test_execute_exprs_no_table_ref(con):
-    cases = [(L(1) + L(2), 3)]
+# def test_execute_exprs_no_table_ref(con):
+#     cases = [(L(1) + L(2), 3)]
 
-    for expr, expected in cases:
-        result = con.execute(expr)
-        assert result == expected
+#     for expr, expected in cases:
+#         result = con.execute(expr)
+#         assert result == expected
 
-    # ExprList
-    exlist = ibis.api.expr_list(
-        [L(1).name('a'), ibis.now().name('b'), L(2).log().name('c')]
-    )
-    con.execute(exlist)
+#     # ExprList
+#     exlist = ibis.api.expr_list(
+#         [L(1).name('a'), ibis.now().name('b'), L(2).log().name('c')]
+#     )
+#     con.execute(exlist)
 
 
 @pytest.mark.skip(reason="FIXME: it is raising KeyError: 'Unnamed: 0'")

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -4,10 +4,8 @@ import pandas as pd
 import pandas.testing as tm
 import pytest
 
-import ibis
 import ibis.config as config
 import ibis.expr.types as ir
-from ibis import literal as L
 
 
 def test_get_table_ref(db):

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -211,18 +211,18 @@ def test_scalar_exprs_no_table_refs(expr, expected):
     assert ibis.clickhouse.compile(expr) == expected
 
 
-def test_expr_list_no_table_refs():
-    exlist = ibis.api.expr_list(
-        [
-            ibis.literal(1).name('a'),
-            ibis.now().name('b'),
-            ibis.literal(2).log().name('c'),
-        ]
-    )
-    result = ibis.clickhouse.compile(exlist)
-    expected = """\
-SELECT 1 AS `a`, now() AS `b`, log(2) AS `c`"""
-    assert result == expected
+# def test_expr_list_no_table_refs():
+#     exlist = ibis.api.expr_list(
+#         [
+#             ibis.literal(1).name('a'),
+#             ibis.now().name('b'),
+#             ibis.literal(2).log().name('c'),
+#         ]
+#     )
+#     result = ibis.clickhouse.compile(exlist)
+#     expected = """\
+# SELECT 1 AS `a`, now() AS `b`, log(2) AS `c`"""
+#     assert result == expected
 
 
 # TODO: use alltypes

--- a/ibis/backends/dask/execution/reductions.py
+++ b/ibis/backends/dask/execution/reductions.py
@@ -3,7 +3,6 @@ Reduces sequences
 
 NOTE: This file overwrite the pandas backend registered handlers for:
 
-- execute_node_expr_list,
 - execute_node_greatest_list,
 - execute_node_least_list
 
@@ -26,7 +25,6 @@ import toolz
 import ibis
 import ibis.expr.operations as ops
 from ibis.backends.pandas.execution.generic import (
-    execute_node_expr_list,
     execute_node_greatest_list,
     execute_node_least_list,
 )

--- a/ibis/backends/dask/execution/reductions.py
+++ b/ibis/backends/dask/execution/reductions.py
@@ -19,17 +19,14 @@ import dask.array as da
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
 import numpy as np
-import pandas as pd
 import toolz
 
-import ibis
 import ibis.expr.operations as ops
 from ibis.backends.pandas.execution.generic import (
     execute_node_greatest_list,
     execute_node_least_list,
 )
 
-from ..core import execute
 from ..dispatch import execute_node
 from .util import make_selected_obj
 

--- a/ibis/backends/dask/execution/reductions.py
+++ b/ibis/backends/dask/execution/reductions.py
@@ -178,15 +178,3 @@ def execute_standard_dev_series(op, data, mask, aggcontext=None, **kwargs):
         'std',
         ddof=variance_ddof[op.how],
     )
-
-
-@execute_node.register(ops.ExpressionList, collections.abc.Sequence)
-def dask_execute_node_expr_list(op, sequence, **kwargs):
-    if all(type(s) != dd.Series for s in sequence):
-        execute_node_expr_list(op, sequence, **kwargs)
-    columns = [e.get_name() for e in op.exprs]
-    schema = ibis.schema(list(zip(columns, (e.type() for e in op.exprs))))
-    data = {col: [execute(el, **kwargs)] for col, el in zip(columns, sequence)}
-    return schema.apply_to(
-        dd.from_pandas(pd.DataFrame(data, columns=columns), npartitions=1)
-    )

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -1010,16 +1010,16 @@ def test_table_info(alltypes):
     assert buf.getvalue() is not None
 
 
-@pytest.mark.parametrize(('expr', 'expected'), [(L(1) + L(2), 3)])
-def test_execute_exprs_no_table_ref(con, expr, expected):
-    result = con.execute(expr)
-    assert result == expected
+# @pytest.mark.parametrize(('expr', 'expected'), [(L(1) + L(2), 3)])
+# def test_execute_exprs_no_table_ref(con, expr, expected):
+#     result = con.execute(expr)
+#     assert result == expected
 
-    # ExprList
-    exlist = ibis.api.expr_list(
-        [L(1).name('a'), ibis.now().name('b'), L(2).log().name('c')]
-    )
-    con.execute(exlist)
+#     # ExprList
+#     exlist = ibis.api.expr_list(
+#         [L(1).name('a'), ibis.now().name('b'), L(2).log().name('c')]
+#     )
+#     con.execute(exlist)
 
 
 def test_summary_execute(alltypes):
@@ -1036,9 +1036,8 @@ def test_summary_execute(alltypes):
 
     expr = table.group_by('string_col').aggregate(
         [
-            table.double_col.summary().prefix('double_'),
-            table.float_col.summary().prefix('float_'),
-            table.string_col.summary().suffix('_string'),
+            table.double_col.summary(prefix='double_'),
+            table.float_col.summary(prefix='float_'),
         ]
     )
     result = expr.execute()

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -1022,26 +1022,26 @@ def test_table_info(alltypes):
 #     con.execute(exlist)
 
 
-def test_summary_execute(alltypes):
-    table = alltypes
+# def test_summary_execute(alltypes):
+#     table = alltypes
 
-    # also test set_column while we're at it
-    table = table.set_column('double_col', table.double_col * 2)
+#     # also test set_column while we're at it
+#     table = table.set_column('double_col', table.double_col * 2)
 
-    expr = table.double_col.summary()
-    repr(expr)
+#     expr = table.double_col.summary()
+#     repr(expr)
 
-    result = expr.execute()
-    assert isinstance(result, pd.DataFrame)
+#     result = expr.execute()
+#     assert isinstance(result, pd.DataFrame)
 
-    expr = table.group_by('string_col').aggregate(
-        [
-            table.double_col.summary(prefix='double_'),
-            table.float_col.summary(prefix='float_'),
-        ]
-    )
-    result = expr.execute()
-    assert isinstance(result, pd.DataFrame)
+#     expr = table.group_by('string_col').aggregate(
+#         [
+#             table.double_col.summary(prefix='double_'),
+#             table.float_col.summary(prefix='float_'),
+#         ]
+#     )
+#     result = expr.execute()
+#     assert isinstance(result, pd.DataFrame)
 
 
 def test_distinct_array(con, alltypes):

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -16,7 +16,6 @@ import toolz
 from pandas.api.types import DatetimeTZDtype
 from pandas.core.groupby import DataFrameGroupBy, SeriesGroupBy
 
-import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -1039,15 +1039,6 @@ def execute_node_coalesce(op, values, **kwargs):
     return compute_row_reduction(coalesce, values)
 
 
-@execute_node.register(ops.ExpressionList, collections.abc.Sequence)
-def execute_node_expr_list(op, sequence, **kwargs):
-    # TODO: no true approx count distinct for pandas, so we use exact for now
-    columns = [e.get_name() for e in op.exprs]
-    schema = ibis.schema(list(zip(columns, (e.type() for e in op.exprs))))
-    data = {col: [execute(el, **kwargs)] for col, el in zip(columns, sequence)}
-    return schema.apply_to(pd.DataFrame(data, columns=columns))
-
-
 def wrap_case_result(raw, expr):
     """Wrap a CASE statement result in a Series and handle returning scalars.
 

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -729,6 +729,7 @@ def test_summary_non_numeric(batting, batting_df):
 
 def test_summary_non_numeric_group_by(batting, batting_df):
     expr = batting.groupby('teamID').playerID.summary()
+
     result = expr.execute()
     expected = (
         batting_df.groupby('teamID')

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -612,7 +612,7 @@ def _binop_expr(name, klass):
             other = as_value_expr(other)
             op = klass(self, other)
             return op.to_expr()
-        except (com.IbisTypeError, NotImplementedError) as e:
+        except (com.IbisTypeError, NotImplementedError):
             return NotImplemented
 
     f.__name__ = name

--- a/ibis/expr/groupby.py
+++ b/ibis/expr/groupby.py
@@ -311,8 +311,9 @@ class GroupedArray:
     group_concat = _group_agg_dispatch('group_concat')
 
     def summary(self, exact_nunique=False):
-        metric = self.arr.summary(exact_nunique=exact_nunique)
-        return self.parent.aggregate(metric)
+        expr = self.arr.summary(exact_nunique=exact_nunique)
+        metrics = expr.op().metrics
+        return self.parent.aggregate(metrics)
 
 
 class GroupedNumbers(GroupedArray):
@@ -321,5 +322,6 @@ class GroupedNumbers(GroupedArray):
     sum = _group_agg_dispatch('sum')
 
     def summary(self, exact_nunique=False):
-        metric = self.arr.summary(exact_nunique=exact_nunique)
-        return self.parent.aggregate(metric)
+        expr = self.arr.summary(exact_nunique=exact_nunique)
+        metrics = expr.op().metrics
+        return self.parent.aggregate(metrics)

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1445,8 +1445,7 @@ class TypedCaseBuilder:
     __slots__ = ()
 
     def type(self):
-        types = [result.type() for result in self.results]
-        return dt.highest_precedence(types)
+        return rlz.highest_precedence_dtype(self.results)
 
     def else_(self, result_expr):
         """

--- a/ibis/expr/types.py
+++ b/ibis/expr/types.py
@@ -9,8 +9,8 @@ import numpy as np
 import ibis
 import ibis.common.exceptions as com
 import ibis.config as config
-import ibis.expr.types as ir  # TODO(kszucs) remove this
 import ibis.expr.operations as ops
+import ibis.expr.types as ir  # TODO(kszucs) remove this
 import ibis.util as util
 from ibis.config import options
 from ibis.expr.typing import TimeContext

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -523,13 +523,13 @@ def test_groupby_alias(table):
     assert_equal(result, expected)
 
 
-def test_summary_expand_list(table):
-    summ = table.f.summary()
-
-    metric = table.g.group_concat().name('bar')
-    result = table.aggregate([metric, summ])
-    expected = table.aggregate([metric] + summ.exprs())
-    assert_equal(result, expected)
+# TODO(kszucs): we should perhaps change the API to table.aggregate(metrics=table.f.summary()) ?
+# def test_summary_expand_list(table):
+#     summ = table.f.summary()
+#     metric = table.g.group_concat().name('bar')
+#     result = table.aggregate([metric, summ])
+#     expected = table.aggregate([metric] + summ.exprs())
+#     assert_equal(result, expected)
 
 
 @pytest.mark.xfail(raises=AssertionError, reason='NYT')

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -523,7 +523,8 @@ def test_groupby_alias(table):
     assert_equal(result, expected)
 
 
-# TODO(kszucs): we should perhaps change the API to table.aggregate(metrics=table.f.summary()) ?
+# TODO(kszucs): we should perhaps change the API to
+# table.aggregate(metrics=table.f.summary()) ?
 # def test_summary_expand_list(table):
 #     summ = table.f.summary()
 #     metric = table.g.group_concat().name('bar')

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -891,40 +891,6 @@ def expr():
     return ibis.expr_list(exprs)
 
 
-def test_names(expr):
-    assert expr.names() == ['a', 'b']
-
-
-def test_prefix(expr):
-    prefixed = expr.prefix('foo_')
-    result = prefixed.names()
-    assert result == ['foo_a', 'foo_b']
-
-
-def test_rename(expr):
-    renamed = expr.rename(lambda x: f'foo({x})')
-    result = renamed.names()
-    assert result == ['foo(a)', 'foo(b)']
-
-
-def test_suffix(expr):
-    suffixed = expr.suffix('.x')
-    result = suffixed.names()
-    assert result == ['a.x', 'b.x']
-
-
-def test_concat():
-    exprs = [ibis.literal(1).name('a'), ibis.literal(2).name('b')]
-    exprs2 = [ibis.literal(3).name('c'), ibis.literal(4).name('d')]
-
-    list1 = ibis.expr_list(exprs)
-    list2 = ibis.expr_list(exprs2)
-
-    result = list1.concat(list2)
-    expected = ibis.expr_list(exprs + exprs2)
-    assert_equal(result, expected)
-
-
 def test_substitute_dict():
     table = ibis.table([('foo', 'string'), ('bar', 'string')], 't1')
     subs = {'a': 'one', 'b': table.bar}

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -220,18 +220,18 @@ SELECT 1 + 2 AS `tmp`"""
             result = Compiler.to_sql(expr)
             assert result == expected
 
-#     def test_expr_list_no_table_refs(self):
-#         exlist = ibis.api.expr_list(
-#             [
-#                 ibis.literal(1).name('a'),
-#                 ibis.now().name('b'),
-#                 ibis.literal(2).log().name('c'),
-#             ]
-#         )
-#         result = Compiler.to_sql(exlist)
-#         expected = """\
-# SELECT 1 AS `a`, now() AS `b`, ln(2) AS `c`"""
-#         assert result == expected
+    #     def test_expr_list_no_table_refs(self):
+    #         exlist = ibis.api.expr_list(
+    #             [
+    #                 ibis.literal(1).name('a'),
+    #                 ibis.now().name('b'),
+    #                 ibis.literal(2).log().name('c'),
+    #             ]
+    #         )
+    #         result = Compiler.to_sql(exlist)
+    #         expected = """\
+    # SELECT 1 AS `a`, now() AS `b`, ln(2) AS `c`"""
+    #         assert result == expected
 
     def test_isnull_case_expr_rewrite_failure(self):
         # #172, case expression that was not being properly converted into an

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -220,18 +220,18 @@ SELECT 1 + 2 AS `tmp`"""
             result = Compiler.to_sql(expr)
             assert result == expected
 
-    def test_expr_list_no_table_refs(self):
-        exlist = ibis.api.expr_list(
-            [
-                ibis.literal(1).name('a'),
-                ibis.now().name('b'),
-                ibis.literal(2).log().name('c'),
-            ]
-        )
-        result = Compiler.to_sql(exlist)
-        expected = """\
-SELECT 1 AS `a`, now() AS `b`, ln(2) AS `c`"""
-        assert result == expected
+#     def test_expr_list_no_table_refs(self):
+#         exlist = ibis.api.expr_list(
+#             [
+#                 ibis.literal(1).name('a'),
+#                 ibis.now().name('b'),
+#                 ibis.literal(2).log().name('c'),
+#             ]
+#         )
+#         result = Compiler.to_sql(exlist)
+#         expected = """\
+# SELECT 1 AS `a`, now() AS `b`, ln(2) AS `c`"""
+#         assert result == expected
 
     def test_isnull_case_expr_rewrite_failure(self):
         # #172, case expression that was not being properly converted into an

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -20,7 +20,6 @@ def test_top_level_api():
         'cumulative_window',
         'date',
         'desc',
-        'expr_list',
         'geo_area',
         'geo_as_binary',
         'geo_as_ewkb',


### PR DESCRIPTION
Resolves #3000, this is an API breaking change.

Seems like `ops.ExpressionList` was mainly used to group the value expressions of summary into a standalone expression in order to execute it by itself or through `table.aggregate(..)`

