### PR TITLE
refactor: remove ImpalaTemporaryTable

### DIFF
--- a/ibis/backends/impala/tests/test_parquet_ddl.py
+++ b/ibis/backends/impala/tests/test_parquet_ddl.py
@@ -1,3 +1,4 @@
+import gc
 from posixpath import join as pjoin
 
 import pytest
@@ -8,8 +9,6 @@ from ibis.tests.util import assert_equal
 
 
 def test_cleanup_tmp_table_on_gc(con, test_data_dir):
-    import gc
-
     hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
     table = con.parquet_file(hdfs_path)
     name = table.op().name
@@ -19,8 +18,6 @@ def test_cleanup_tmp_table_on_gc(con, test_data_dir):
 
 
 def test_persist_parquet_file_with_name(con, test_data_dir, temp_table_db):
-    import gc
-
     hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
 
     tmp_db, name = temp_table_db


### PR DESCRIPTION
This PR removes `ImpalaTemporaryTable` in favor of a weakref
finalizer that has stronger guarantees on when it will be called.
