### PR TITLE
Prepare backends to merge Client methods into Backend

### DIFF
--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -10,6 +10,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+from ibis.backends.base import BaseBackendForClient
 from ibis.backends.base.sql import SQLClient
 from ibis.config import options
 
@@ -159,7 +160,7 @@ class ClickhouseTable(ir.TableExpr):
         return self._client.con.execute(query, data, **kwargs)
 
 
-class ClickhouseClient(SQLClient):
+class ClickhouseClient(SQLClient, BaseBackendForClient):
     """An Ibis client interface that uses Clickhouse"""
 
     compiler = ClickhouseCompiler

--- a/ibis/backends/csv/__init__.py
+++ b/ibis/backends/csv/__init__.py
@@ -4,6 +4,7 @@ from pkg_resources import parse_version
 
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
+from ibis.backends.base import BaseBackendForClient
 from ibis.backends.base.file import BaseFileBackend, FileClient
 from ibis.backends.pandas.core import execute, execute_node, pre_execute
 from ibis.backends.pandas.execution.selection import physical_tables
@@ -28,7 +29,7 @@ class CSVTable(ops.DatabaseTable):
         self.read_csv_kwargs = kwargs
 
 
-class CSVClient(FileClient):
+class CSVClient(FileClient, BaseBackendForClient):
     def insert(self, path, expr, index=False, **kwargs):
         path = self.root / path
         data = execute(expr)

--- a/ibis/backends/dask/client.py
+++ b/ibis/backends/dask/client.py
@@ -15,7 +15,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
-from ibis.backends.base import Client, Database
+from ibis.backends.base import BaseBackendForClient, Client, Database
 from ibis.backends.pandas.client import (
     PANDAS_DATE_TYPES,
     PANDAS_STRING_TYPES,
@@ -156,7 +156,7 @@ class DaskDatabase(Database):
     pass
 
 
-class DaskClient(Client):
+class DaskClient(Client, BaseBackendForClient):
     def __init__(self, backend, dictionary: Dict[str, dd.DataFrame]):
         self.backend = backend
         self.database_class = backend.database_class

--- a/ibis/backends/hdf5/__init__.py
+++ b/ibis/backends/hdf5/__init__.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
+from ibis.backends.base import BaseBackendForClient
 from ibis.backends.base.file import BaseFileBackend, FileClient
 from ibis.backends.pandas.core import execute, execute_node
 
@@ -12,7 +13,7 @@ class HDFTable(ops.DatabaseTable):
     pass
 
 
-class HDFClient(FileClient):
+class HDFClient(FileClient, BaseBackendForClient):
     def insert(
         self, path, key, expr, format='table', data_columns=True, **kwargs
     ):

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -19,7 +19,7 @@ import ibis.expr.rules as rlz
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 import ibis.util as util
-from ibis.backends.base import Database
+from ibis.backends.base import BaseBackendForClient, Database
 from ibis.backends.base.sql import SQLClient
 from ibis.backends.base.sql.compiler import DDL, DML
 from ibis.backends.base.sql.ddl import (
@@ -751,7 +751,7 @@ class ImpalaTable(ir.TableExpr):
         return self._client.column_stats(self._qualified_name)
 
 
-class ImpalaClient(SQLClient):
+class ImpalaClient(SQLClient, BaseBackendForClient):
 
     """
     An Ibis client interface that uses Impala

--- a/ibis/backends/mysql/client.py
+++ b/ibis/backends/mysql/client.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 import sqlalchemy.dialects.mysql as mysql
 
 import ibis.expr.datatypes as dt
+from ibis.backends.base import BaseBackendForClient
 from ibis.backends.base.sql.alchemy import AlchemyClient
 
 from .compiler import MySQLCompiler
@@ -34,7 +35,7 @@ def mysql_blob(satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
 
-class MySQLClient(AlchemyClient):
+class MySQLClient(AlchemyClient, BaseBackendForClient):
 
     """The Ibis MySQL client class
 

--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -13,7 +13,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
-from ibis.backends.base import Client, Database
+from ibis.backends.base import BaseBackendForClient, Client, Database
 
 from .core import execute_and_reset
 
@@ -332,7 +332,7 @@ class PandasTable(ops.DatabaseTable):
     pass
 
 
-class PandasClient(Client):
+class PandasClient(Client, BaseBackendForClient):
     def __init__(self, backend, dictionary):
         self.backend = backend
         self.database_class = backend.database_class

--- a/ibis/backends/parquet/__init__.py
+++ b/ibis/backends/parquet/__init__.py
@@ -9,6 +9,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+from ibis.backends.base import BaseBackendForClient
 from ibis.backends.base.file import BaseFileBackend, FileClient
 from ibis.backends.pandas.core import execute, execute_node
 
@@ -58,7 +59,7 @@ class ParquetTable(ops.DatabaseTable):
     pass
 
 
-class ParquetClient(FileClient):
+class ParquetClient(FileClient, BaseBackendForClient):
     def insert(self, path, expr, **kwargs):
         path = self.root / path
         df = execute(expr)

--- a/ibis/backends/postgres/client.py
+++ b/ibis/backends/postgres/client.py
@@ -5,13 +5,14 @@ from typing import Optional
 import psycopg2  # NOQA fail early if the driver is missing
 import sqlalchemy as sa
 
+from ibis.backends.base import BaseBackendForClient
 from ibis.backends.base.sql.alchemy import AlchemyClient
 from ibis.backends.postgres import udf
 
 from .compiler import PostgreSQLCompiler
 
 
-class PostgreSQLClient(AlchemyClient):
+class PostgreSQLClient(AlchemyClient, BaseBackendForClient):
 
     """The Ibis PostgreSQL client class
 

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -7,6 +7,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.expr.types as types
 import ibis.expr.types as ir
+from ibis.backends.base import BaseBackendForClient
 from ibis.backends.base.sql import SQLClient
 from ibis.backends.base.sql.ddl import (
     CreateDatabase,
@@ -229,7 +230,7 @@ class PySparkCursor:
         """No-op for compatibility."""
 
 
-class PySparkClient(SQLClient):
+class PySparkClient(SQLClient, BaseBackendForClient):
     """
     An ibis client that uses PySpark SQL Dataframe
     """

--- a/ibis/backends/sqlite/client.py
+++ b/ibis/backends/sqlite/client.py
@@ -4,13 +4,14 @@ from typing import Optional
 
 import sqlalchemy as sa
 
+from ibis.backends.base import BaseBackendForClient
 from ibis.backends.base.sql.alchemy import AlchemyClient
 
 from . import udf
 from .compiler import SQLiteCompiler
 
 
-class SQLiteClient(AlchemyClient):
+class SQLiteClient(AlchemyClient, BaseBackendForClient):
     """The Ibis SQLite client class."""
 
     compiler = SQLiteCompiler

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -323,7 +323,7 @@ class UnboundTable(PhysicalTable):
 class DatabaseTable(PhysicalTable):
     name = Arg(str)
     schema = Arg(sch.Schema)
-    source = Arg(rlz.client)
+    source = Arg(rlz.backend)
 
     def change_name(self, new_name):
         return type(self)(new_name, self.args[1], self.source)
@@ -334,7 +334,7 @@ class SQLQueryResult(TableNode, HasSchema):
 
     query = Arg(rlz.noop)
     schema = Arg(sch.Schema)
-    source = Arg(rlz.client)
+    source = Arg(rlz.backend)
 
     def blocks(self):
         return True

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -290,10 +290,10 @@ def interval(arg, units=None):
 
 
 @validator
-def client(arg):
-    from ibis.backends.base import Client
+def backend(arg):
+    from ibis.backends.base import BaseBackend
 
-    return instance_of(Client, arg)
+    return instance_of(BaseBackend, arg)
 
 
 # ---------------------------------------------------------------------

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -18,6 +18,7 @@ from typing import Optional
 import pytest
 
 import ibis.expr.types as ir
+from ibis.backends.base import BaseBackendForClient
 from ibis.backends.base.sql import SQLClient
 from ibis.backends.base.sql.alchemy import (
     AlchemyCompiler,
@@ -28,7 +29,7 @@ from ibis.expr.schema import Schema
 from ibis.expr.typing import TimeContext
 
 
-class MockConnection(SQLClient, metaclass=abc.ABCMeta):
+class MockConnection(SQLClient, BaseBackendForClient, metaclass=abc.ABCMeta):
     def __init__(self):
         self.executed_queries = []
 


### PR DESCRIPTION
This is a bit hacky, but it's the only way I found to be able to move methods from Client to Backend one backend at a time.

With this PR `connect` can return both `Client` (as now) or `Backend` (as we are moving to).