### PR TITLE
CLN: Removing repeated methods from dask backend

### DIFF
--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -394,7 +394,6 @@ class PandasClient(Client):
             df = pd.DataFrame(obj)
         else:
             dtypes = ibis_schema_to_pandas(schema)
-            print(list(map(toolz.first, dtypes)))
             df = schema.apply_to(
                 pd.DataFrame(columns=list(map(toolz.first, dtypes)))
             )

--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -383,7 +383,7 @@ class PandasClient(Client):
 
         """
         # kwargs is a catch all for any options required by other backends.
-        self.dictionary[table_name] = pd.DataFrame(obj)
+        self.dictionary[table_name] = obj
 
     def create_table(self, table_name, obj=None, schema=None):
         """Create a table."""
@@ -394,6 +394,7 @@ class PandasClient(Client):
             df = pd.DataFrame(obj)
         else:
             dtypes = ibis_schema_to_pandas(schema)
+            print(list(map(toolz.first, dtypes)))
             df = schema.apply_to(
                 pd.DataFrame(columns=list(map(toolz.first, dtypes)))
             )


### PR DESCRIPTION
We'll be moving the methods from Client to Backend shortly, probably worth deleting all the duplicate ones from dask, and just moving the needed ones.