### PR TITLE
Copy base SQL/Alchemy client methods into base Backends

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -18,6 +18,7 @@ class BaseSQLBackend(BaseBackend):
     """
     Base backend class for backends that compile to SQL.
     """
+
     compiler = Compiler
     table_class = ops.DatabaseTable
     table_expr_class = ir.TableExpr

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -1,6 +1,15 @@
+import abc
+from typing import Optional
+
+import ibis.expr.operations as ops
+import ibis.expr.schema as sch
+import ibis.expr.types as ir
+import ibis.util as util
 from ibis.backends.base import BaseBackend
+from ibis.expr.typing import TimeContext
 
 from .client import SQLClient
+from .compiler import Compiler
 
 __all__ = ('SQLClient', 'BaseSQLBackend')
 
@@ -9,3 +18,199 @@ class BaseSQLBackend(BaseBackend):
     """
     Base backend class for backends that compile to SQL.
     """
+    compiler = Compiler
+    table_class = ops.DatabaseTable
+    table_expr_class = ir.TableExpr
+
+    def table(self, name, database=None):
+        """Create a table expression.
+
+        Create a table expression that references a particular table in the
+        database.
+
+        Parameters
+        ----------
+        name : string
+        database : string, optional
+
+        Returns
+        -------
+        table : TableExpr
+        """
+        qualified_name = self._fully_qualified_name(name, database)
+        schema = self.get_schema(qualified_name)
+        node = self.table_class(qualified_name, schema, self)
+        return self.table_expr_class(node)
+
+    def _fully_qualified_name(self, name, database):
+        # XXX
+        return name
+
+    def sql(self, query):
+        """Convert a SQL query to an Ibis table expression.
+
+        Parameters
+        ----------
+        query : string
+
+        Returns
+        -------
+        table : TableExpr
+        """
+        # Get the schema by adding a LIMIT 0 on to the end of the query. If
+        # there is already a limit in the query, we find and remove it
+        limited_query = f'SELECT * FROM ({query}) t0 LIMIT 0'
+        schema = self._get_schema_using_query(limited_query)
+        return ops.SQLQueryResult(query, schema, self).to_expr()
+
+    def raw_sql(self, query: str, results=False):
+        """Execute a given query string.
+
+        Could have unexpected results if the query modifies the behavior of
+        the session in a way unknown to Ibis; be careful.
+
+        Parameters
+        ----------
+        query : string
+          DML or DDL statement
+
+        Returns
+        -------
+        Backend cursor
+        """
+        # TODO results is unused, it can be removed
+        # (requires updating Impala tests)
+        # TODO `self.con` is assumed to be defined in subclasses, but there
+        # is nothing that enforces it. We should find a way to make sure
+        # `self.con` is always a DBAPI2 connection, or raise an error
+        cursor = self.con.execute(query)  # type: ignore
+        if cursor:
+            return cursor
+        cursor.release()
+
+    def execute(self, expr, params=None, limit='default', **kwargs):
+        """Compile and execute the given Ibis expression.
+
+        Compile and execute Ibis expression using this backend client
+        interface, returning results in-memory in the appropriate object type
+
+        Parameters
+        ----------
+        expr : Expr
+        limit : int, default None
+          For expressions yielding result yets; retrieve at most this number of
+          values/rows. Overrides any limit already set on the expression.
+        params : not yet implemented
+        kwargs : Backends can receive extra params. For example, clickhouse
+            uses this to receive external_tables as dataframes.
+
+        Returns
+        -------
+        output : input type dependent
+          Table expressions: pandas.DataFrame
+          Array expressions: pandas.Series
+          Scalar expressions: Python scalar value
+        """
+        # TODO Reconsider having `kwargs` here. It's needed to support
+        # `external_tables` in clickhouse, but better to deprecate that
+        # feature than all this magic.
+        # we don't want to pass `timecontext` to `raw_sql`
+        kwargs.pop('timecontext', None)
+        query_ast = self.compiler.to_ast_ensure_limit(
+            expr, limit, params=params
+        )
+        sql = query_ast.compile()
+        self._log(sql)
+        cursor = self.raw_sql(sql, **kwargs)
+        schema = self.ast_schema(query_ast, **kwargs)
+        result = self.fetch_from_cursor(cursor, schema)
+
+        if hasattr(getattr(query_ast, 'dml', query_ast), 'result_handler'):
+            result = query_ast.dml.result_handler(result)
+
+        return result
+
+    @abc.abstractmethod
+    def fetch_from_cursor(self, cursor, schema):
+        """Fetch data from cursor."""
+
+    def ast_schema(self, query_ast):
+        """Return the schema of the expression.
+
+        Returns
+        -------
+        Schema
+
+        Raises
+        ------
+        ValueError
+            if self.expr doesn't have a schema.
+        """
+        dml = getattr(query_ast, 'dml', query_ast)
+        expr = getattr(dml, 'parent_expr', getattr(dml, 'table_set', None))
+
+        if isinstance(expr, (ir.TableExpr, ir.ExprList, sch.HasSchema)):
+            return expr.schema()
+        elif isinstance(expr, ir.ValueExpr):
+            return sch.schema([(expr.get_name(), expr.type())])
+        else:
+            raise ValueError(
+                'Expression with type {} does not have a '
+                'schema'.format(type(self.expr))
+            )
+
+    def _log(self, sql):
+        """Log the SQL, usually to the standard output.
+
+        This method can be implemented by subclasses. The logging happens
+        when `ibis.options.verbose` is `True`.
+        """
+        pass
+
+    def compile(
+        self,
+        expr,
+        limit=None,
+        params=None,
+        timecontext: Optional[TimeContext] = None,
+    ):
+        """Translate expression.
+
+        Translate expression to one or more queries according to
+        backend target.
+
+        Returns
+        -------
+        output : single query or list of queries
+        """
+        return self.compiler.to_ast_ensure_limit(
+            expr, limit, params=params
+        ).compile()
+
+    def explain(self, expr, params=None):
+        """Explain expression.
+
+        Query for and return the query plan associated with the indicated
+        expression or SQL query.
+
+        Returns
+        -------
+        plan : string
+        """
+        if isinstance(expr, ir.Expr):
+            context = self.compiler.make_context(params=params)
+            query_ast = self.compiler.to_ast(expr, context)
+            if len(query_ast.queries) > 1:
+                raise Exception('Multi-query expression')
+
+            query = query_ast.queries[0].compile()
+        else:
+            query = expr
+
+        statement = f'EXPLAIN {query}'
+
+        cur = self.raw_sql(statement)
+        result = self._get_list(cur)
+        cur.release()
+
+        return '\n'.join(['Query:', util.indent(query, 2), '', *result])

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -210,8 +210,9 @@ class BaseAlchemyBackend(BaseSQLBackend):
         self, name: str, schema: sch.Schema
     ) -> List[sqlalchemy.Column]:
         return [
-            sqlalchemy.Column(colname, to_sqla_type(dtype),
-                              nullable=dtype.nullable)
+            sqlalchemy.Column(
+                colname, to_sqla_type(dtype), nullable=dtype.nullable
+            )
             for colname, dtype in zip(schema.names, schema.types)
         ]
 
@@ -341,8 +342,9 @@ class BaseAlchemyBackend(BaseSQLBackend):
             util.log(query_str)
 
     def _get_sqla_table(self, name, schema=None, autoload=True):
-        return sqlalchemy.Table(name, self.meta, schema=schema,
-                                autoload=autoload)
+        return sqlalchemy.Table(
+            name, self.meta, schema=schema, autoload=autoload
+        )
 
     def _sqla_table_to_expr(self, table):
         node = self.table_class(table, self)

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -1,10 +1,21 @@
+import contextlib
+import warnings
+from typing import List, Optional, Union
+
+import pandas as pd
 import sqlalchemy
 
+import ibis
+import ibis.expr.datatypes as dt
+import ibis.expr.schema as sch
+import ibis.expr.types as ir
+import ibis.util as util
 from ibis.backends.base.sql import BaseSQLBackend
 
 from .client import AlchemyClient
 from .database import AlchemyDatabase, AlchemyTable
 from .datatypes import schema_from_table, table_from_schema, to_sqla_type
+from .geospatial import geospatial_supported
 from .query_builder import AlchemyCompiler
 from .registry import (
     fixed_arity,
@@ -43,6 +54,28 @@ __all__ = (
 )
 
 
+class _AutoCloseCursor:
+    """
+    Wraps a SQLAlchemy ResultProxy and ensures that .close() is called on
+    garbage collection
+    """
+
+    def __init__(self, original_cursor):
+        self.original_cursor = original_cursor
+
+    def __del__(self):
+        self.original_cursor.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        self.original_cursor.close()
+
+    def fetchall(self):
+        return self.original_cursor.fetchall()
+
+
 class BaseAlchemyBackend(BaseSQLBackend):
     """
     Base backend class for backends that compile to SQL with SQLAlchemy.
@@ -50,13 +83,35 @@ class BaseAlchemyBackend(BaseSQLBackend):
 
     database_class = AlchemyDatabase
     table_class = AlchemyTable
+    compiler = AlchemyCompiler
+    has_attachment = False
+
+    @property
+    def con(self):
+        return self.client.con
+
+    @property
+    def meta(self):
+        return self.client.meta
+
+    @property
+    def _inspector(self):
+        return self.client._inspector
+
+    @property
+    def _schemas(self):
+        return self.client._schemas
+
+    @property
+    def database_name(self):
+        return self.client.database_name
 
     @property
     def version(self):
-        return '.'.join(map(str, self.client.con.dialect.server_version_info))
+        return '.'.join(map(str, self.con.dialect.server_version_info))
 
     def list_tables(self, like=None, database=None):
-        inspector = sqlalchemy.inspect(self.client.con)
+        inspector = sqlalchemy.inspect(self.con)
         tables = inspector.get_table_names(
             schema=database
         ) + inspector.get_view_names(schema=database)
@@ -64,9 +119,323 @@ class BaseAlchemyBackend(BaseSQLBackend):
 
     @property
     def current_database(self):
-        return self.client.database_name
+        return self.database_name
 
     def list_databases(self, like=None):
         """List databases in the current server."""
-        databases = self.client.inspector.get_schema_names()
+        databases = self.inspector.get_schema_names()
         return self._filter_with_like(databases, like)
+
+    # Non-standard methods
+
+    @property
+    def inspector(self):
+        self._inspector.info_cache.clear()
+        return self._inspector
+
+    @staticmethod
+    def _to_geodataframe(df, schema):
+        """
+        If the required libraries for geospatial support are installed, and if
+        a geospatial column is present in the dataframe, convert it to a
+        GeoDataFrame.
+        """
+        import geopandas
+        from geoalchemy2 import shape
+
+        def to_shapely(row, name):
+            return shape.to_shape(row[name]) if row[name] is not None else None
+
+        geom_col = None
+        for name, dtype in schema.items():
+            if isinstance(dtype, dt.GeoSpatial):
+                geom_col = geom_col or name
+                df[name] = df.apply(lambda x: to_shapely(x, name), axis=1)
+        if geom_col:
+            df = geopandas.GeoDataFrame(df, geometry=geom_col)
+        return df
+
+    def fetch_from_cursor(self, cursor, schema):
+        df = pd.DataFrame.from_records(
+            cursor.original_cursor.fetchall(),
+            columns=cursor.original_cursor.keys(),
+            coerce_float=True,
+        )
+        df = schema.apply_to(df)
+        if len(df) and geospatial_supported:
+            return self._to_geodataframe(df, schema)
+        return df
+
+    @contextlib.contextmanager
+    def begin(self):
+        with self.con.begin() as bind:
+            yield bind
+
+    def create_table(self, name, expr=None, schema=None, database=None):
+        if database == self.current_database:
+            # avoid fully qualified name
+            database = None
+
+        if database is not None:
+            raise NotImplementedError(
+                'Creating tables from a different database is not yet '
+                'implemented'
+            )
+
+        if expr is None and schema is None:
+            raise ValueError('You must pass either an expression or a schema')
+
+        if expr is not None and schema is not None:
+            if not expr.schema().equals(ibis.schema(schema)):
+                raise TypeError(
+                    'Expression schema is not equal to passed schema. '
+                    'Try passing the expression without the schema'
+                )
+        if schema is None:
+            schema = expr.schema()
+
+        self._schemas[self._fully_qualified_name(name, database)] = schema
+        t = self._table_from_schema(
+            name, schema, database=database or self.current_database
+        )
+
+        with self.begin() as bind:
+            t.create(bind=bind)
+            if expr is not None:
+                bind.execute(
+                    t.insert().from_select(list(expr.columns), expr.compile())
+                )
+
+    def _columns_from_schema(
+        self, name: str, schema: sch.Schema
+    ) -> List[sqlalchemy.Column]:
+        return [
+            sqlalchemy.Column(colname, to_sqla_type(dtype),
+                              nullable=dtype.nullable)
+            for colname, dtype in zip(schema.names, schema.types)
+        ]
+
+    def _table_from_schema(
+        self, name: str, schema: sch.Schema, database: Optional[str] = None
+    ) -> sqlalchemy.Table:
+        columns = self._columns_from_schema(name, schema)
+        return sqlalchemy.Table(name, self.meta, *columns)
+
+    def drop_table(
+        self,
+        table_name: str,
+        database: Optional[str] = None,
+        force: bool = False,
+    ) -> None:
+        if database == self.current_database:
+            # avoid fully qualified name
+            database = None
+
+        if database is not None:
+            raise NotImplementedError(
+                'Dropping tables from a different database is not yet '
+                'implemented'
+            )
+
+        t = self._get_sqla_table(table_name, schema=database, autoload=False)
+        t.drop(checkfirst=force)
+
+        assert (
+            not t.exists()
+        ), f'Something went wrong during DROP of table {t.name!r}'
+
+        self.meta.remove(t)
+
+        qualified_name = self._fully_qualified_name(table_name, database)
+
+        try:
+            del self._schemas[qualified_name]
+        except KeyError:  # schemas won't be cached if created with raw_sql
+            pass
+
+    def load_data(
+        self,
+        table_name: str,
+        data: pd.DataFrame,
+        database: str = None,
+        if_exists: str = 'fail',
+    ):
+        """
+        Load data from a dataframe to the backend.
+
+        Parameters
+        ----------
+        table_name : string
+        data : pandas.DataFrame
+        database : string, optional
+        if_exists : string, optional, default 'fail'
+            The values available are: {‘fail’, ‘replace’, ‘append’}
+
+        Raises
+        ------
+        NotImplementedError
+            Loading data to a table from a different database is not
+            yet implemented
+        """
+        if database == self.current_database:
+            # avoid fully qualified name
+            database = None
+
+        if database is not None:
+            raise NotImplementedError(
+                'Loading data to a table from a different database is not '
+                'yet implemented'
+            )
+
+        params = {}
+        if self.has_attachment:
+            # for database with attachment
+            # see: https://github.com/ibis-project/ibis/issues/1930
+            params['schema'] = self.current_database
+
+        data.to_sql(
+            table_name,
+            con=self.con,
+            index=False,
+            if_exists=if_exists,
+            **params,
+        )
+
+    def truncate_table(
+        self, table_name: str, database: Optional[str] = None
+    ) -> None:
+        t = self._get_sqla_table(table_name, schema=database)
+        t.delete().execute()
+
+    def schema(self, name):
+        """Get a schema object from the current database for the schema named `name`.
+
+        Parameters
+        ----------
+        name : str
+
+        Returns
+        -------
+        schema : ibis Schema
+            The schema of the object `name`.
+
+        """
+        return self.database().schema(name)
+
+    def list_schemas(self):
+        warnings.warn(
+            '`list_schemas` is deprecated, use `list_databases` instead',
+            FutureWarning,
+        )
+        return self.list_databases()
+
+    def raw_sql(self, query: str, results=False):
+        return _AutoCloseCursor(super().raw_sql(query))
+
+    def _log(self, sql):
+        try:
+            query_str = str(sql)
+        except sqlalchemy.exc.UnsupportedCompilationError:
+            pass
+        else:
+            util.log(query_str)
+
+    def _get_sqla_table(self, name, schema=None, autoload=True):
+        return sqlalchemy.Table(name, self.meta, schema=schema,
+                                autoload=autoload)
+
+    def _sqla_table_to_expr(self, table):
+        node = self.table_class(table, self)
+        return self.table_expr_class(node)
+
+    def insert(
+        self,
+        table_name: str,
+        obj: Union[pd.DataFrame, ir.TableExpr],
+        database: Optional[str] = None,
+        overwrite: Optional[bool] = False,
+    ) -> None:
+        """
+        Insert the given data to a table in backend.
+
+        Parameters
+        ----------
+        table_name : string
+            name of the table to which data needs to be inserted
+        obj : pandas DataFrame or ibis TableExpr
+            obj is either the dataframe (pd.DataFrame) containing data
+            which needs to be inserted to table_name or
+            the TableExpr type which ibis provides with data which needs
+            to be inserted to table_name
+        database : string, optional
+            name of the attached database that the table is located in.
+        overwrite : boolean, default False
+            If True, will replace existing contents of table else not
+
+        Raises
+        -------
+        NotImplementedError
+            Inserting data to a table from a different database is not
+            yet implemented
+
+        ValueError
+            No operation is being performed. Either the obj parameter
+            is not a pandas DataFrame or is not a ibis TableExpr.
+            The given obj is of type type(obj).__name__ .
+
+        """
+
+        if database == self.current_database:
+            # avoid fully qualified name
+            database = None
+
+        if database is not None:
+            raise NotImplementedError(
+                'Inserting data to a table from a different database is not '
+                'yet implemented'
+            )
+
+        params = {}
+        if self.has_attachment:
+            # for database with attachment
+            # see: https://github.com/ibis-project/ibis/issues/1930
+            params['schema'] = self.current_database
+
+        if isinstance(obj, pd.DataFrame):
+            obj.to_sql(
+                table_name,
+                self.con,
+                index=False,
+                if_exists='replace' if overwrite else 'append',
+                **params,
+            )
+        elif isinstance(obj, ir.TableExpr):
+            to_table_expr = self.table(table_name)
+            to_table_schema = to_table_expr.schema()
+
+            if overwrite:
+                self.drop_table(table_name, database=database)
+                self.create_table(
+                    table_name,
+                    schema=to_table_schema,
+                    database=database,
+                )
+
+            to_table = self._get_sqla_table(table_name, schema=database)
+
+            from_table_expr = obj
+
+            with self.begin() as bind:
+                if from_table_expr is not None:
+                    bind.execute(
+                        to_table.insert().from_select(
+                            list(from_table_expr.columns),
+                            from_table_expr.compile(),
+                        )
+                    )
+        else:
+            raise ValueError(
+                "No operation is being performed. Either the obj parameter "
+                "is not a pandas DataFrame or is not a ibis TableExpr."
+                f"The given obj is of type {type(obj).__name__} ."
+            )


### PR DESCRIPTION
In order to move one backend at a time from `Client` to `Backend` we need the methods of `Client` in both classes. So backends with the old and new API can coexist. The idea here is to duplicate the methods, and after the last backend using the base class is moved, the whole `client.py` can be moved.