### PR TITLE
fix(ir): remove accidental print statement

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -614,7 +614,6 @@ def _binop_expr(name, klass):
             op = klass(self, other)
             return op.to_expr()
         except (com.IbisTypeError, NotImplementedError) as e:
-            print(e)
             return NotImplemented
 
     f.__name__ = name

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -613,7 +613,7 @@ def _binop_expr(name, klass):
             other = as_value_expr(other)
             op = klass(self, other)
             return op.to_expr()
-        except (com.IbisTypeError, NotImplementedError) as e:
+        except (com.IbisTypeError, NotImplementedError):
             return NotImplemented
 
     f.__name__ = name


### PR DESCRIPTION
At least I think it serves no purpose, I think it's a debugging leftover.