### PR TITLE
Use TableExpr validator in Join node

### DIFF
--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1706,8 +1706,8 @@ def _validate_join_predicates(left, right, predicates):
 
 
 class Join(TableNode):
-    left = Arg(rlz.noop)
-    right = Arg(rlz.noop)
+    left = Arg(ir.TableExpr)
+    right = Arg(ir.TableExpr)
     predicates = Arg(rlz.noop)
 
     def __init__(self, left, right, predicates):


### PR DESCRIPTION
Changing the rule validators for `left` and `right` from `rlz.noop` to the more precise `ir.TableExpr` in `Join` node.