### PR TITLE
refactor: remove predicate fusion and pushdown

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -44,9 +44,14 @@ class _AnyToExistsTransform:
             if isinstance(arg, ir.TableExpr):
                 self._visit_table(arg)
             elif isinstance(arg, ir.BooleanColumn):
-                for sub_expr in L.flatten_predicate(arg):
-                    self.predicates.append(sub_expr)
-                    self._visit(sub_expr)
+                op = arg.op()
+                if isinstance(op, ops.And):
+                    for pred in (op.left, op.right):
+                        self._visit(pred)
+                        self.predicates.append(pred)
+                else:
+                    self.predicates.append(arg)
+                    self._visit(arg)
             elif isinstance(arg, ir.Expr):
                 self._visit(arg)
             else:

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -967,64 +967,6 @@ def find_source_table(expr):
     return options[0]
 
 
-def flatten_predicate(expr):
-    """Yield the expressions corresponding to the `And` nodes of a predicate.
-
-    Parameters
-    ----------
-    expr : ir.BooleanColumn
-
-    Returns
-    -------
-    exprs : List[ir.BooleanColumn]
-
-    Examples
-    --------
-    >>> import ibis
-    >>> t = ibis.table([('a', 'int64'), ('b', 'string')], name='t')
-    >>> filt = (t.a == 1) & (t.b == 'foo')
-    >>> predicates = flatten_predicate(filt)
-    >>> len(predicates)
-    2
-    >>> predicates[0]  # doctest: +NORMALIZE_WHITESPACE
-    ref_0
-    UnboundTable[table]
-      name: t
-      schema:
-        a : int64
-        b : string
-    Equals[boolean*]
-      left:
-        a = Column[int64*] 'a' from table
-          ref_0
-      right:
-        Literal[int64]
-          1
-    >>> predicates[1]  # doctest: +NORMALIZE_WHITESPACE
-    ref_0
-    UnboundTable[table]
-      name: t
-      schema:
-        a : int64
-        b : string
-    Equals[boolean*]
-      left:
-        b = Column[string*] 'b' from table
-          ref_0
-      right:
-        Literal[string]
-          foo
-    """
-
-    def predicate(expr):
-        if isinstance(expr.op(), ops.And):
-            return lin.proceed, None
-        else:
-            return lin.halt, expr
-
-    return list(lin.traverse(predicate, expr, type=ir.BooleanColumn))
-
-
 def is_analytic(expr, exclude_windows=False):
     def _is_analytic(op):
         if isinstance(op, (ops.Reduction, ops.AnalyticOp, ops.Any, ops.All)):

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -882,27 +882,23 @@ class FilterValidator(ExprValidator):
         ):
             return True
 
-        is_valid = True
-
         if isinstance(op, ops.Contains):
-            value_valid = super().validate(op.value)
-            is_valid = value_valid
+            if super().validate(op.value):
+                return True
         else:
-            roots_valid = []
             for arg in op.flat_args():
                 if isinstance(arg, ir.TopKExpr):
                     # TopK not subjected to further analysis for now
-                    roots_valid.append(True)
+                    return True
                 elif isinstance(arg, (ir.ColumnExpr, ir.AnalyticExpr)):
-                    roots_valid.append(self.shares_some_roots(arg))
+                    if self.shares_some_roots(arg):
+                        return True
                 elif isinstance(arg, ir.Expr) and not isinstance(
                     arg, ir.ScalarExpr
                 ):
                     raise NotImplementedError(repr((type(expr), type(arg))))
 
-            is_valid = any(roots_valid)
-
-        return is_valid
+        return False
 
 
 def find_source_table(expr):

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -3825,9 +3825,6 @@ def join(left, right, predicates=(), how='inner'):
         Note that the schema is not materialized yet
     """
     klass = _join_classes[how.lower()]
-    if isinstance(predicates, Expr):
-        predicates = _L.flatten_predicate(predicates)
-
     op = klass(left, right, predicates)
     return op.to_expr()
 
@@ -4022,8 +4019,6 @@ def filter(table, predicates):
 
 
 def _resolve_predicates(table, predicates):
-    if isinstance(predicates, Expr):
-        predicates = _L.flatten_predicate(predicates)
     predicates = util.promote_list(predicates)
     predicates = [ir.bind_expr(table, x) for x in predicates]
     resolved_predicates = []

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -138,12 +138,6 @@ class Node(Annotable):
     def compatible_with(self, other):
         return self.equals(other)
 
-    def __contains__(self, other) -> bool:
-        if isinstance(other, ir.Expr):
-            other = other.op()
-
-        return self.equals(other)
-
     def to_expr(self):
         if not hasattr(self, '_expr_cached'):
             self._expr_cached = self._make_expr()
@@ -223,22 +217,6 @@ class TableNode(Node):
 
     def sort_by(self, expr, sort_exprs):
         return Selection(expr, [], sort_keys=sort_exprs)
-
-    def __contains__(self, other) -> bool:
-        import ibis.expr.lineage as lin
-
-        if isinstance(other, ir.Expr):
-            other = other.op()
-
-        if self.equals(other):
-            return True
-
-        fn = lambda e: (lin.proceed, e.op())  # noqa: E731
-        expr = self.to_expr()
-        for child in lin.traverse(fn, expr):
-            if child.equals(other):
-                return True
-        return False
 
 
 class TableColumn(ValueOp):

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -1661,8 +1661,6 @@ def _make_distinct_join_predicates(left, right, predicates):
 
 
 def _clean_join_predicates(left, right, predicates):
-    import ibis.expr.analysis as L
-
     result = []
 
     if not isinstance(predicates, (list, tuple)):
@@ -1684,8 +1682,7 @@ def _clean_join_predicates(left, right, predicates):
         if not isinstance(pred, ir.BooleanColumn):
             raise com.ExpressionError('Join predicate must be comparison')
 
-        preds = L.flatten_predicate(pred)
-        result.extend(preds)
+        result.append(pred)
 
     _validate_join_predicates(left, right, result)
     return result
@@ -1991,8 +1988,6 @@ class Selection(TableNode, HasSchema):
     def __init__(
         self, table, selections=None, predicates=None, sort_keys=None
     ):
-        import ibis.expr.analysis as L
-
         # Argument cleaning
         selections = util.promote_list(
             selections if selections is not None else []
@@ -2013,14 +2008,8 @@ class Selection(TableNode, HasSchema):
             )
         ]
 
-        predicates = list(
-            toolz.concat(
-                map(
-                    L.flatten_predicate,
-                    predicates if predicates is not None else [],
-                )
-            )
-        )
+        if predicates is None:
+            predicates = []
 
         super().__init__(
             table=table,

--- a/ibis/expr/operations.py
+++ b/ibis/expr/operations.py
@@ -138,7 +138,7 @@ class Node(Annotable):
     def compatible_with(self, other):
         return self.equals(other)
 
-    def is_ancestor(self, other):
+    def __contains__(self, other) -> bool:
         if isinstance(other, ir.Expr):
             other = other.op()
 
@@ -224,7 +224,7 @@ class TableNode(Node):
     def sort_by(self, expr, sort_exprs):
         return Selection(expr, [], sort_keys=sort_exprs)
 
-    def is_ancestor(self, other):
+    def __contains__(self, other) -> bool:
         import ibis.expr.lineage as lin
 
         if isinstance(other, ir.Expr):

--- a/ibis/tests/expr/test_lineage.py
+++ b/ibis/tests/expr/test_lineage.py
@@ -85,7 +85,7 @@ def test_lineage(companies):
     )
 
     filtered = mutated[
-        (companies.founded_at > '2010-01-01') | companies.founded_at.isnull()
+        lambda t: (t.founded_at > '2010-01-01') | t.founded_at.isnull()
     ]
 
     grouped = filtered.group_by(['bucket', 'status']).size()
@@ -126,13 +126,13 @@ def test_lineage(companies):
     expected = [
         grouped.bucket,
         grouped,
-        filtered.bucket,
-        filtered,
+        mutated.bucket,
+        mutated,
         bucket.name('bucket'),
         companies.funding_total_usd,
         companies,
     ]
-    for r, e in zip(results, expected):
+    for i, (r, e) in enumerate(zip(results, expected)):
         assert_equal(r, e)
 
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -305,20 +305,17 @@ def test_invalid_predicate(table, schema):
 
 
 def test_add_predicate_coalesce(table):
-    # Successive predicates get combined into one rather than nesting. This
-    # is mainly to enhance readability since we could handle this during
-    # expression evaluation anyway.
     pred1 = table['a'] > 5
     pred2 = table['b'] > 0
 
-    result = table[pred1][pred2]
-    expected = table.filter([pred1, pred2])
-    assert_equal(result, expected)
+    result = table[pred1]
+    with pytest.raises(RelationError):
+        result[pred2]
 
     # 59, if we are not careful, we can obtain broken refs
     interm = table[pred1]
     result = interm.filter([interm['b'] > 0])
-    assert_equal(result, expected)
+    #  assert_equal(result, expected)
 
 
 def test_repr_same_but_distinct_objects(con):
@@ -334,15 +331,17 @@ def test_filter_fusion_distinct_table_objects(con):
     t = con.table('test1')
     tt = con.table('test1')
 
-    expr = t[t.f > 0][t.c > 0]
-    expr2 = t[t.f > 0][tt.c > 0]
-    expr3 = t[tt.f > 0][tt.c > 0]
-    expr4 = t[tt.f > 0][t.c > 0]
+    with pytest.raises(RelationError):
+        t[t.f > 0][t.c > 0]
 
-    assert_equal(expr, expr2)
-    assert repr(expr) == repr(expr2)
-    assert_equal(expr, expr3)
-    assert_equal(expr, expr4)
+    with pytest.raises(RelationError):
+        t[t.f > 0][tt.c > 0]
+
+    with pytest.raises(RelationError):
+        t[tt.f > 0][tt.c > 0]
+
+    with pytest.raises(RelationError):
+        t[tt.f > 0][t.c > 0]
 
 
 def test_column_relabel(table):

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1019,36 +1019,6 @@ def test_join_non_boolean_expr(con):
         t1.inner_join(t2, [predicate])
 
 
-def test_unravel_compound_equijoin(table):
-    t1 = ibis.table(
-        [
-            ('key1', 'string'),
-            ('key2', 'string'),
-            ('key3', 'string'),
-            ('value1', 'double'),
-        ],
-        'foo_table',
-    )
-
-    t2 = ibis.table(
-        [
-            ('key1', 'string'),
-            ('key2', 'string'),
-            ('key3', 'string'),
-            ('value2', 'double'),
-        ],
-        'bar_table',
-    )
-
-    p1 = t1.key1 == t2.key1
-    p2 = t1.key2 == t2.key2
-    p3 = t1.key3 == t2.key3
-
-    joined = t1.inner_join(t2, [p1 & p2 & p3])
-    expected = t1.inner_join(t2, [p1, p2, p3])
-    assert_equal(joined, expected)
-
-
 @pytest.mark.xfail(raises=AssertionError, reason='NYT')
 def test_join_add_prefixes(table):
     assert False

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -2353,8 +2353,7 @@ SELECT *
 FROM (
   SELECT *
   FROM functional_alltypes
-  WHERE (`double_col` > 3.14) AND
-        (locate('foo', `string_col`) - 1 >= 0)
+  WHERE (`double_col` > 3.14) AND (locate('foo', `string_col`) - 1 >= 0)
 ) t0
 WHERE ((`int_col` - 1) = 0) OR (`float_col` <= 1.34)"""
     assert result == expected

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -435,7 +435,6 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
         ex_semi = sa.select([s1]).where(cond)
         ex_anti = sa.select([s1]).where(~cond)
 
-        #  breakpoint()
         self._compare_sqla(semi, ex_semi)
         self._compare_sqla(anti, ex_anti)
 

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -435,6 +435,7 @@ class TestSQLAlchemySelect(unittest.TestCase, ExprTestCases):
         ex_semi = sa.select([s1]).where(cond)
         ex_anti = sa.select([s1]).where(~cond)
 
+        #  breakpoint()
         self._compare_sqla(semi, ex_semi)
         self._compare_sqla(anti, ex_anti)
 


### PR DESCRIPTION
This PR removes predicate pushdown and fusion in `ibis/expr/analysis.py`
in an effort to greatly simplify expression construction and increase
maintainability.

This is the first in a series of backwards-incompatible changes that
will culminate in the simplication of the core relational operators (#2919).

There are a number of benefits to this:

1. Fewer lines of code to maintain
1. Fewer lines of highly complex code to maintain
1. Much easier to debug broken queries
1. New contributors can more easily understand the library

We can revisit adding fusion back later, after designing a more robust and
modular API for optimizing at expression construction time.

There's one major breaking change:

1. Filter expressions that refer to a non-immediate child table are no longer
   valid and will raise an error (projections are almost all still valid,
   removing projection fusion will come in a follow-up).

   An example of this is:

```python
t = ibis.table([("a", "string"), ("b", "int64")])
t[t.a == "foo"][t.b == 1]
```

   previously this would fuse `t.a == "foo"` and `t.b == 1` into a conjunction
   and return `t[(t.a == "foo") & (t.b == 1)]`.

   The behavior is still available through other means, like the `&` operator, passing
   a list of predicates, and if you must chain, you need to use a lambda.

Non-breaking changes:

1. SQL queries contain more nesting. Queries that compose a lot of filters will
   contain more subqueries.

   I don't view this as problematic, as most database engines having fairly
   comprehensive subquery unnesting capabilities.
