### PR TITLE
Avoid running PostGIS specific backends in all backends

### DIFF
--- a/ibis/backends/tests/test_geospatial.py
+++ b/ibis/backends/tests/test_geospatial.py
@@ -530,7 +530,7 @@ def test_geo_dataframe(backend, geo):
     assert isinstance(geo.execute(), geopandas.geodataframe.GeoDataFrame)
 
 
-@pytest.mark.only_on_backends(all_db_geo_supported)
+@pytest.mark.only_on_backends(['postgres'])
 @pytest.mark.parametrize(
     'modifier',
     [


### PR DESCRIPTION
Looks like in #2902 I made some PostGIS specific tests run in all backends, see [here](https://github.com/ibis-project/ibis/pull/2902/files#diff-3aa1fee3c73ec6755835d6873ca3727c0dda2a72ff779a55b7f38be5320e557bL17)

This is breaking the CI in the Ibis-OmniSci repo

@jreback we should merge this before the release