### PR TITLE
ENH: Pass scope to context-adjustment functions

### DIFF
--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -257,6 +257,7 @@ def execute_until_in_scope(
             num_args=len(computable_args),
             timecontext=timecontext,
             clients=clients,
+            scope=scope,
         )
     else:
         arg_timecontexts = [None] * len(computable_args)

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -293,6 +293,7 @@ def execute_until_in_scope(
             num_args=len(computable_args),
             timecontext=timecontext,
             clients=clients,
+            scope=scope,
         )
     else:
         arg_timecontexts = [None] * len(computable_args)
@@ -538,6 +539,9 @@ See ``computable_args`` in ``execute_until_in_scope``
 
 @compute_time_context.register(ops.Node)
 def compute_time_context_default(
-    node, timecontext: Optional[TimeContext] = None, **kwargs
+    node,
+    timecontext: Optional[TimeContext] = None,
+    scope: Optional[Scope] = None,
+    **kwargs,
 ):
     return [timecontext for arg in node.inputs if is_computable_input(arg)]

--- a/ibis/backends/pandas/execution/timecontext.py
+++ b/ibis/backends/pandas/execution/timecontext.py
@@ -32,6 +32,7 @@ time context.
 from typing import Optional
 
 import ibis.expr.operations as ops
+from ibis.expr.scope import Scope
 from ibis.expr.timecontext import adjust_context
 from ibis.expr.typing import TimeContext
 
@@ -40,7 +41,11 @@ from ..core import compute_time_context, is_computable_input
 
 @compute_time_context.register(ops.AsOfJoin)
 def compute_time_context_asof_join(
-    op, clients, timecontext: Optional[TimeContext] = None, **kwargs
+    op,
+    clients,
+    timecontext: Optional[TimeContext] = None,
+    scope: Optional[Scope] = None,
+    **kwargs
 ):
     new_timecontexts = [
         timecontext for arg in op.inputs if is_computable_input(arg)
@@ -52,7 +57,7 @@ def compute_time_context_asof_join(
     # right table is the second node in children
     new_timecontexts = [
         new_timecontexts[0],
-        adjust_context(op, timecontext=timecontext),
+        adjust_context(op, timecontext=timecontext, scope=scope),
         *new_timecontexts[2:],
     ]
     return new_timecontexts
@@ -60,7 +65,11 @@ def compute_time_context_asof_join(
 
 @compute_time_context.register(ops.WindowOp)
 def compute_time_context_window(
-    op, clients, timecontext: Optional[TimeContext] = None, **kwargs
+    op,
+    clients,
+    timecontext: Optional[TimeContext] = None,
+    scope: Optional[Scope] = None,
+    **kwargs
 ):
     new_timecontexts = [
         timecontext for arg in op.inputs if is_computable_input(arg)
@@ -69,7 +78,7 @@ def compute_time_context_window(
     if not timecontext:
         return new_timecontexts
 
-    result = adjust_context(op, timecontext=timecontext)
+    result = adjust_context(op, timecontext=timecontext, scope=scope)
 
     new_timecontexts = [
         result for arg in op.inputs if is_computable_input(arg)


### PR DESCRIPTION
This PR passes `scope` to the functions that compute context adjustment: `compute_context_adjustment` and `adjust_context`.

### Justification
The existing `compute_context_adjustment` and `adjust_context` functions don't make any use of `scope`. This change is useful for making context adjustment more extensible downstream of Ibis.

The `scope` variable is mainly used to cache ops that have already been calculated, but since it can store anything, it's also useful for storing general information that is accessible/updatable during the execution process. Before this PR, `adjust_context` has a limited view—the only information it has access to is the op-in-question and the current timecontext. Giving context adjustment functions access to `scope` makes them more extensible/flexible (e.g. to implement context-adjustment logic that needs any sort of information outside of the op and current timecontext).

### Testing
New test in `test_timecontext.py` that creates a custom `adjust_context` function and asserts that `scope` is passed in.
