### PR TITLE
Update __init__.py

### DIFF
--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -488,9 +488,17 @@ class Backend(BaseSQLBackend):
 
         names, types = zip(*pairs)
         ibis_types = [udf.parse_type(type.lower()) for type in types]
-        names = [name.lower() for name in names]
+        cols = []
+        tab_name = '.'.join(table_name.rsplit('.')[1:]).strip('`')
+        for name in names:
+            if not name.__contains__(tab_name):
+                new_col = tab_name + '.' + name.lower()
+            else:
+                new_col = name.lower()
+            cols.append(new_col)
+        #names = [name.lower() for name in names]
 
-        return sch.Schema(names, ibis_types)
+        return sch.Schema(cols, ibis_types)
 
     @property
     def client_options(self):

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -496,7 +496,7 @@ class Backend(BaseSQLBackend):
             else:
                 new_col = name.lower()
             cols.append(new_col)
-        #names = [name.lower() for name in names]
+        # names = [name.lower() for name in names]
 
         return sch.Schema(cols, ibis_types)
 


### PR DESCRIPTION
Using interface table() and then execute() like the following codes will get a KeyError: 

```python
import ibis
hdfs = ibis.impala.hdfs_connect(host='kudu1')
on = ibis.impala.connect(host='kudu3', port=10000, database='yy_test', user='us', hdfs_client=hdfs, kerberos_service_name=None, auth_mechanism='PLAIN')
res = on.table('employee').execute()
```

the error:

```
Traceback (most recent call last):
  File "/usr/local/conda3/envs/py37/lib/python3.7/site-packages/pandas/core/indexes/base.py", line 3361, in get_loc
    return self._engine.get_loc(casted_key)
  File "pandas/_libs/index.pyx", line 76, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/index.pyx", line 108, in pandas._libs.index.IndexEngine.get_loc
  File "pandas/_libs/hashtable_class_helper.pxi", line 5198, in pandas._libs.hashtable.PyObjectHashTable.get_item
  File "pandas/_libs/hashtable_class_helper.pxi", line 5206, in pandas._libs.hashtable.PyObjectHashTable.get_item
KeyError: 'shop_id'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/edy/src/PythonProjects/dt-center-algorithm/test/1.py", line 10, in <module>
    res = on.table('employee').execute()
  File "/usr/local/conda3/envs/py37/lib/python3.7/site-packages/ibis/expr/types.py", line 274, in execute
    self, limit=limit, timecontext=timecontext, params=params, **kwargs
  File "/usr/local/conda3/envs/py37/lib/python3.7/site-packages/ibis/backends/base/sql/__init__.py", line 126, in execute
    result = self.fetch_from_cursor(cursor, schema)
  File "/usr/local/conda3/envs/py37/lib/python3.7/site-packages/ibis/backends/impala/__init__.py", line 318, in fetch_from_cursor
    return schema.apply_to(df)
  File "/usr/local/conda3/envs/py37/lib/python3.7/site-packages/ibis/expr/schema.py", line 175, in apply_to
    col = df[column]
  File "/usr/local/conda3/envs/py37/lib/python3.7/site-packages/pandas/core/frame.py", line 3458, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/usr/local/conda3/envs/py37/lib/python3.7/site-packages/pandas/core/indexes/base.py", line 3363, in get_loc
    raise KeyError(key) from err
KeyError: 'shop_id'
```

I found the queried result about columns contains the table name, but there is no table name in 'df'. So I think it is a bug about interface get_schema(). I made a pr.  tks