### PR TITLE
Support fillna and dropna on TableExpr

### DIFF
--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    These release notes are for versions of ibis **1.0 and later**. Release
    notes for pre-1.0 versions of ibis can be found at :doc:`release-pre-1.0`
 
+* :feature:`3097` Support TableExpr fillna and dropna in Pandas, Dask and Pyspark
 * :support:`3088` Added `atpublic` dependency for adding APIs to modules' `__all__`
 * :bug:`3086` Error when trying to join tables with Pandas backend
 * :support:`2678` Improvement of the backend API. The former `Client` subclasses have been replaced by a `Backend` class that must

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -37,6 +37,8 @@ from ibis.backends.pandas.execution.generic import (
     execute_isinf,
     execute_isnan,
     execute_node_contains_series_sequence,
+    execute_node_dropna_dataframe,
+    execute_node_fillna_dataframe,
     execute_node_ifnull_series,
     execute_node_not_contains_series_sequence,
     execute_node_nullif_series,
@@ -109,6 +111,12 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ],
     ops.Difference: [
         ((dd.DataFrame, dd.DataFrame), execute_difference_dataframe_dataframe)
+    ],
+    ops.DropNa: [
+        ((dd.DataFrame, simple_types), execute_node_dropna_dataframe)
+    ],
+    ops.FillNa: [
+        ((dd.DataFrame, simple_types), execute_node_fillna_dataframe)
     ],
     ops.IsNull: [((dd.Series,), execute_series_isnull)],
     ops.NotNull: [((dd.Series,), execute_series_notnnull)],

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -38,7 +38,8 @@ from ibis.backends.pandas.execution.generic import (
     execute_isnan,
     execute_node_contains_series_sequence,
     execute_node_dropna_dataframe,
-    execute_node_fillna_dataframe,
+    execute_node_fillna_dataframe_dict,
+    execute_node_fillna_dataframe_scalar,
     execute_node_ifnull_series,
     execute_node_not_contains_series_sequence,
     execute_node_nullif_series,
@@ -112,11 +113,10 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ops.Difference: [
         ((dd.DataFrame, dd.DataFrame), execute_difference_dataframe_dataframe)
     ],
-    ops.DropNa: [
-        ((dd.DataFrame, simple_types), execute_node_dropna_dataframe)
-    ],
+    ops.DropNa: [((dd.DataFrame,), execute_node_dropna_dataframe)],
     ops.FillNa: [
-        ((dd.DataFrame, simple_types), execute_node_fillna_dataframe)
+        ((dd.DataFrame, simple_types), execute_node_fillna_dataframe_scalar),
+        ((dd.DataFrame,), execute_node_fillna_dataframe_dict),
     ],
     ops.IsNull: [((dd.Series,), execute_series_isnull)],
     ops.NotNull: [((dd.Series,), execute_series_notnnull)],

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -964,20 +964,20 @@ def execute_node_log_number_number(op, value, base, **kwargs):
     return math.log(value, base)
 
 
-@execute_node.register(ops.DropNa, pd.DataFrame, simple_types)
-def execute_node_dropna_dataframe(op, df, how, **kwargs):
-    subset = [col.op().value for col in op.subset] if op.subset else None
-    return df.dropna(how=how, subset=subset)
+@execute_node.register(ops.DropNa, pd.DataFrame)
+def execute_node_dropna_dataframe(op, df, **kwargs):
+    subset = [col.get_name() for col in op.subset] if op.subset else None
+    return df.dropna(how=op.how, subset=subset)
 
 
 @execute_node.register(ops.FillNa, pd.DataFrame, simple_types)
-def execute_node_fillna_dataframe(op, df, replacement, **kwargs):
-    values = (
-        {c.op().value: replacement for c in op.subset}
-        if op.subset
-        else replacement
-    )
-    return df.fillna(values)
+def execute_node_fillna_dataframe_scalar(op, df, replacements, **kwargs):
+    return df.fillna(replacements)
+
+
+@execute_node.register(ops.FillNa, pd.DataFrame)
+def execute_node_fillna_dataframe_dict(op, df, **kwargs):
+    return df.fillna(op.replacements)
 
 
 @execute_node.register(ops.IfNull, pd.Series, simple_types)

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -964,6 +964,25 @@ def execute_node_log_number_number(op, value, base, **kwargs):
     return math.log(value, base)
 
 
+@execute_node.register(ops.DropNa, pd.DataFrame, simple_types)
+def execute_node_dropna_dataframe(op, df, how, **kwargs):
+    if op.subset:
+        subset = [col.op().value for col in op.subset]
+        return df.dropna(how=how, subset=subset)
+    else:
+        return df.dropna(how=how)
+
+
+@execute_node.register(ops.FillNa, pd.DataFrame, simple_types)
+def execute_node_fillna_dataframe(op, df, replacement, **kwargs):
+    values = (
+        {c.op().value: replacement for c in op.subset}
+        if op.subset
+        else replacement
+    )
+    return df.fillna(values)
+
+
 @execute_node.register(ops.IfNull, pd.Series, simple_types)
 @execute_node.register(ops.IfNull, pd.Series, pd.Series)
 def execute_node_ifnull_series(op, value, replacement, **kwargs):

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -966,11 +966,8 @@ def execute_node_log_number_number(op, value, base, **kwargs):
 
 @execute_node.register(ops.DropNa, pd.DataFrame, simple_types)
 def execute_node_dropna_dataframe(op, df, how, **kwargs):
-    if op.subset:
-        subset = [col.op().value for col in op.subset]
-        return df.dropna(how=how, subset=subset)
-    else:
-        return df.dropna(how=how)
+    subset = [col.op().value for col in op.subset] if op.subset else None
+    return df.dropna(how=how, subset=subset)
 
 
 @execute_node.register(ops.FillNa, pd.DataFrame, simple_types)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1772,6 +1772,30 @@ def compile_not_null(t, expr, scope, timecontext, **kwargs):
     return ~F.isnull(col) & ~F.isnan(col)
 
 
+@compiles(ops.DropNa)
+def compile_dropna_table(t, expr, scope, timecontext, **kwargs):
+    op = expr.op()
+    table = t.translate(op.table, scope, timecontext)
+    how = op.how.op().value
+    if op.subset:
+        subset = [col.op().value for col in op.subset]
+        return table.dropna(how=how, subset=subset)
+    else:
+        return table.dropna(how=how)
+
+
+@compiles(ops.FillNa)
+def compile_fillna_table(t, expr, scope, timecontext, **kwargs):
+    op = expr.op()
+    table = t.translate(op.table, scope, timecontext)
+    value = op.value.op().value
+    if op.subset:
+        subset = [col.op().value for col in op.subset]
+        return table.fillna(value=value, subset=subset)
+    else:
+        return table.fillna(value)
+
+
 # ------------------------- User defined function ------------------------
 
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1777,11 +1777,8 @@ def compile_dropna_table(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
     table = t.translate(op.table, scope, timecontext)
     how = op.how.op().value
-    if op.subset:
-        subset = [col.op().value for col in op.subset]
-        return table.dropna(how=how, subset=subset)
-    else:
-        return table.dropna(how=how)
+    subset = [col.op().value for col in op.subset] if op.subset else None
+    return table.dropna(how=how, subset=subset)
 
 
 @compiles(ops.FillNa)
@@ -1789,11 +1786,8 @@ def compile_fillna_table(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
     table = t.translate(op.table, scope, timecontext)
     value = op.value.op().value
-    if op.subset:
-        subset = [col.op().value for col in op.subset]
-        return table.fillna(value=value, subset=subset)
-    else:
-        return table.fillna(value)
+    subset = [col.op().value for col in op.subset] if op.subset else None
+    return table.fillna(value=value, subset=subset)
 
 
 # ------------------------- User defined function ------------------------

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1776,18 +1776,20 @@ def compile_not_null(t, expr, scope, timecontext, **kwargs):
 def compile_dropna_table(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
     table = t.translate(op.table, scope, timecontext)
-    how = op.how.op().value
-    subset = [col.op().value for col in op.subset] if op.subset else None
-    return table.dropna(how=how, subset=subset)
+    subset = [col.get_name() for col in op.subset] if op.subset else None
+    return table.dropna(how=op.how, subset=subset)
 
 
 @compiles(ops.FillNa)
 def compile_fillna_table(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
     table = t.translate(op.table, scope, timecontext)
-    value = op.value.op().value
-    subset = [col.op().value for col in op.subset] if op.subset else None
-    return table.fillna(value=value, subset=subset)
+    replacements = (
+        op.replacements.op().value
+        if hasattr(op.replacements, 'op')
+        else op.replacements
+    )
+    return table.fillna(replacements)
 
 
 # ------------------------- User defined function ------------------------

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -294,7 +294,7 @@ def test_fillna_table(backend, alltypes, value, subset):
     values = {c: value for c in subset} if subset else value
     expected = table_pandas.fillna(values).reset_index(drop=True)
 
-    backend.assert_frame_equal(result, expected)
+    backend.assert_frame_equal(result, expected, check_dtype=False)
 
 
 @pytest.mark.parametrize(
@@ -321,4 +321,4 @@ def test_dropna_table(backend, alltypes, how, subset):
         drop=True
     )
 
-    backend.assert_frame_equal(result, expected)
+    backend.assert_frame_equal(result, expected, check_dtype=False)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import ibis
+import ibis.common.exceptions as com
 from ibis import literal as L
 
 
@@ -258,41 +259,42 @@ def test_select_filter_mutate(backend, alltypes, df):
 
 def test_fillna_invalid(alltypes):
     with pytest.raises(
-        ValueError, match=r"Columns \['invalid_col'\] do not exist.*"
+        com.IbisTypeError, match=r"value \['invalid_col'\] is not a field in.*"
     ):
-        alltypes.fillna(0.0, subset=['invalid_col'])
+        alltypes.fillna({'invalid_col': 0.0})
 
 
 def test_dropna_invalid(alltypes):
     with pytest.raises(
-        ValueError, match=r"Columns \['invalid_col'\] do not exist.*"
+        com.IbisTypeError, match=r"value 'invalid_col' is not a field in.*"
     ):
         alltypes.dropna(subset=['invalid_col'])
 
-    with pytest.raises(ValueError, match=r".*either 'any' or 'all'.*"):
+    with pytest.raises(ValueError, match=r".*is not in.*"):
         alltypes.dropna(how='invalid')
 
 
 @pytest.mark.parametrize(
-    ('value', 'subset'),
+    'replacements',
     [
-        (0.0, None),
-        (0, []),
-        (0.0, ['na_col']),
-        (1, None),
-        (0.0, ['none_col']),
+        0.0,
+        0,
+        1,
+        ({'na_col': 0.0}),
+        ({'na_col': 1}),
+        ({'none_col': 0.0}),
+        ({'none_col': 1}),
     ],
 )
 @pytest.mark.only_on_backends(['pandas', 'dask', 'pyspark'])
-def test_fillna_table(backend, alltypes, value, subset):
+def test_fillna_table(backend, alltypes, replacements):
     table = alltypes.mutate(na_col=np.nan)
     table = table.mutate(none_col=None)
     table = table.mutate(none_col=table['none_col'].cast('float64'))
     table_pandas = table.execute()
 
-    result = table.fillna(value, subset).execute().reset_index(drop=True)
-    values = {c: value for c in subset} if subset else value
-    expected = table_pandas.fillna(values).reset_index(drop=True)
+    result = table.fillna(replacements).execute().reset_index(drop=True)
+    expected = table_pandas.fillna(replacements).reset_index(drop=True)
 
     backend.assert_frame_equal(result, expected, check_dtype=False)
 
@@ -315,7 +317,7 @@ def test_dropna_table(backend, alltypes, how, subset):
     table = table.mutate(none_col=table['none_col'].cast('float64'))
     table_pandas = table.execute()
 
-    result = table.dropna(how, subset).execute().reset_index(drop=True)
+    result = table.dropna(subset, how).execute().reset_index(drop=True)
     subset = subset if subset else table_pandas.columns
     expected = table_pandas.dropna(how=how, subset=subset).reset_index(
         drop=True

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -297,6 +297,10 @@ def test_fillna_table(backend, alltypes, replacements):
     result = table.fillna(replacements).execute().reset_index(drop=True)
     expected = table_pandas.fillna(replacements).reset_index(drop=True)
 
+    # check_dtype is False here because there are dtype diffs between
+    # Pyspark and Pandas on Java 8 - filling the 'none_col' with an int
+    # results in float in Pyspark, and int in Pandas. This diff does
+    # not exist in Java 11.
     backend.assert_frame_equal(result, expected, check_dtype=False)
 
 
@@ -324,4 +328,8 @@ def test_dropna_table(backend, alltypes, how, subset):
         drop=True
     )
 
+    # check_dtype is False here because there are dtype diffs between
+    # Pyspark and Pandas on Java 8 - the 'bool_col' of an empty DataFrame
+    # is type object in Pyspark, and type bool in Pandas. This diff does
+    # not exist in Java 11.
     backend.assert_frame_equal(result, expected, check_dtype=False)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -6,6 +6,7 @@ import pytest
 
 import ibis
 import ibis.common.exceptions as com
+import ibis.util as util
 from ibis import literal as L
 
 
@@ -307,7 +308,7 @@ def test_fillna_table(backend, alltypes, replacements):
         ('any', ['int_col', 'na_col']),
         ('all', None),
         ('all', ['int_col', 'na_col']),
-        ('all', ['none_col']),
+        ('all', 'none_col'),
     ],
 )
 @pytest.mark.only_on_backends(['pandas', 'dask', 'pyspark'])
@@ -318,7 +319,7 @@ def test_dropna_table(backend, alltypes, how, subset):
     table_pandas = table.execute()
 
     result = table.dropna(subset, how).execute().reset_index(drop=True)
-    subset = subset if subset else table_pandas.columns
+    subset = util.promote_list(subset) if subset else table_pandas.columns
     expected = table_pandas.dropna(how=how, subset=subset).reset_index(
         drop=True
     )

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4075,6 +4075,12 @@ def _table_fillna(self, replacements):
       keys are column name strings that map to their replacement value.
       If passed as a scalar, all columns are filled with that value.
 
+    Notes
+    -----
+    There is potential lack of type stability with the fillna API. For
+    example, different library versions may impact whether or not a given
+    backend type-promotes integer replacement values to floats.
+
     Examples
     --------
     >>> import ibis

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4032,6 +4032,53 @@ def _table_count(self):
     return ops.Count(self, None).to_expr().name('count')
 
 
+def _table_dropna(self, how='any', subset=None):
+    """
+    Remove rows with null values from the table.
+
+    Parameters
+    ----------
+    how : determine whether a row is removed if there is at least one null
+    value in the row ('any'), or if all row values are null ('all').
+    Options are 'any' or 'all'. Default is 'all'
+    subset : Optional list of columns names to consider.
+    Defaults to all columns.
+
+    Returns
+    -------
+    table : TableExpr
+      New table expression
+    """
+    if how not in {'any', 'all'}:
+        raise ValueError("Please specify how as either 'any' or 'all'.")
+    subset = util.promote_list(subset)
+    invalid = set(subset) - set(self.schema().names)
+    if invalid:
+        raise ValueError(f'Columns {list(invalid)} do not exist in the table.')
+    return ops.DropNa(self, how, subset).to_expr()
+
+
+def _table_fillna(self, value, subset=None):
+    """
+    Fill null values in the table.
+
+    Parameters
+    ----------
+    value : value with which to fill the nulls
+    subset : Optional list of columns to fill. Defaults to all columns.
+
+    Returns
+    -------
+    table : TableExpr
+      New table expression
+    """
+    subset = util.promote_list(subset)
+    invalid = set(subset) - set(self.schema().names)
+    if invalid:
+        raise ValueError(f'Columns {list(invalid)} do not exist in the table.')
+    return ops.FillNa(self, value, subset).to_expr()
+
+
 def _table_info(self, buf=None):
     """
     Similar to pandas DataFrame.info. Show column names, types, and null
@@ -4609,6 +4656,8 @@ _table_methods = {
     'count': _table_count,
     'distinct': _table_distinct,
     'drop': _table_drop,
+    'dropna': _table_dropna,
+    'fillna': _table_fillna,
     'info': _table_info,
     'limit': _table_limit,
     'head': _head,

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -785,3 +785,29 @@ class NotExistsSubquery(Node):
 
     def output_type(self):
         return ir.ExistsExpr
+
+
+@public
+class FillNa(TableNode, sch.HasSchema):
+    """Fill null values in the table."""
+
+    table = Arg(rlz.table)
+    value = Arg(rlz.any)
+    subset = Arg(rlz.list_of(rlz.string), default=[])
+
+    @cached_property
+    def schema(self):
+        return self.table.schema()
+
+
+@public
+class DropNa(TableNode, sch.HasSchema):
+    """Drop null values in the table."""
+
+    table = Arg(rlz.table)
+    how = Arg(rlz.string)
+    subset = Arg(rlz.list_of(rlz.string), default=[])
+
+    @cached_property
+    def schema(self):
+        return self.table.schema()

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -1,3 +1,4 @@
+import collections
 import itertools
 from typing import List
 
@@ -792,8 +793,15 @@ class FillNa(TableNode, sch.HasSchema):
     """Fill null values in the table."""
 
     table = Arg(rlz.table)
-    value = Arg(rlz.any)
-    subset = Arg(rlz.list_of(rlz.string), default=[])
+    replacements = Arg(
+        rlz.one_of(
+            (
+                rlz.numeric,
+                rlz.string,
+                rlz.instance_of(collections.abc.Mapping),
+            )
+        )
+    )
 
     @cached_property
     def schema(self):
@@ -805,8 +813,8 @@ class DropNa(TableNode, sch.HasSchema):
     """Drop null values in the table."""
 
     table = Arg(rlz.table)
-    how = Arg(rlz.string)
-    subset = Arg(rlz.list_of(rlz.string), default=[])
+    how = Arg(rlz.isin({'any', 'all'}))
+    subset = Arg(rlz.list_of(rlz.column_from("table")), default=[])
 
     @cached_property
     def schema(self):

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -84,8 +84,6 @@ def promote_list(val: Union[V, List[V]]) -> List[V]:
     -------
     list
     """
-    if val is None:
-        val = []
     if not isinstance(val, list):
         val = [val]
     return val

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -84,6 +84,8 @@ def promote_list(val: Union[V, List[V]]) -> List[V]:
     -------
     list
     """
+    if val is None:
+        val = []
     if not isinstance(val, list):
         val = [val]
     return val


### PR DESCRIPTION
### Proposed APIs

```
TableExpr.dropna(subset=None, how='any')
"""Drop  rows with null values from the table"""
   subset: Optional list of column names to consider
   how: {'any', 'all'} - whether to drop rows if any or all values are null

TableExpr.fillna(replacements)
"""Fill null values in the table"""
   replacements: scalar value (to fill all columns) or mapping of column names to replacement value
```

This PR adds support for the Pandas, Dask, and Pyspark backends only.
There is a follow-up issue to add support for SQL backends: #3110.

### Tests
Added new tests for both methods in test_generic.py