### PR TITLE
ci: fix docs push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -535,11 +535,12 @@ jobs:
 
       - name: Push docs
         if: ${{ github.event_name == 'push' }}
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@v1.3
         env:
           API_TOKEN_GITHUB: ${{ secrets.IBIS_PROJECT_DOCS_PAT }}
         with:
           source-directory: docbuild
+          target-branch: master
           destination-github-username: ibis-project
           destination-repository-name: ibis-project.org
           user-name: github-actions


### PR DESCRIPTION
This fixes pushing docs to `ibis-project/ibis-project.org`, and prevents
future breakage by tracking a released version instead of `main` of the action.
