### PR TITLE
FIX: Pandas and Dask backends fail when adjusted context is not a superset of original context

### DIFF
--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -318,7 +318,7 @@ def execute_until_in_scope(
         new_scope.get_value(arg.op(), timecontext)
         if hasattr(arg, 'op')
         else arg
-        for arg in computable_args
+        for (arg, timecontext) in zip(computable_args, arg_timecontexts)
     ]
 
     result = execute_node(

--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -8,6 +8,7 @@ from pandas import Timedelta, Timestamp
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
+from ibis.backends.pandas.execution import execute
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import (
     TimeContextRelation,
@@ -269,6 +270,8 @@ def test_adjust_context_complete_shift(
     This results in an adjusted context that is NOT a subset of the
     original context. This is unlike an `adjust_context` function
     that only expands the context.
+
+    See #3104
     """
 
     # Create a contrived `adjust_context` function for
@@ -281,8 +284,6 @@ def test_adjust_context_complete_shift(
         scope: Optional[Scope] = None,
     ) -> TimeContext:
         """Shifts both the begin and end in the same direction."""
-        from ibis.backends.pandas.execution import execute
-
         begin, end = timecontext
         timedelta = execute(op.tolerance)
         return (begin - timedelta, end - timedelta)

--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import dask.dataframe as dd
 import pytest
 from dask.dataframe.utils import tm
@@ -5,7 +7,18 @@ from pandas import Timedelta, Timestamp
 
 import ibis
 import ibis.common.exceptions as com
-from ibis.expr.timecontext import TimeContextRelation, compare_timecontext
+import ibis.expr.operations as ops
+from ibis.expr.scope import Scope
+from ibis.expr.timecontext import (
+    TimeContextRelation,
+    adjust_context,
+    compare_timecontext,
+)
+from ibis.expr.types import TimeContext
+
+
+class CustomAsOfJoin(ops.AsOfJoin):
+    pass
 
 
 def test_execute_with_timecontext(time_table):
@@ -218,3 +231,88 @@ def test_context_adjustment_window_groupby_id(time_table, time_df3):
     # result should adjust time context accordingly
     result = expr.execute(timecontext=context)
     tm.assert_series_equal(result, expected)
+
+
+def test_adjust_context_scope(time_keyed_left, time_keyed_right):
+    """Test that `adjust_context` has access to `scope` by default."""
+
+    @adjust_context.register(CustomAsOfJoin)
+    def adjust_context_custom_asof_join(
+        op: ops.AsOfJoin,
+        timecontext: TimeContext,
+        scope: Optional[Scope] = None,
+    ) -> TimeContext:
+        """Confirms that `scope` is passed in."""
+        assert scope is not None
+        return timecontext
+
+    expr = CustomAsOfJoin(
+        left=time_keyed_left,
+        right=time_keyed_right,
+        predicates='time',
+        by='key',
+        tolerance=ibis.interval(days=4),
+    ).to_expr()
+    expr = expr[time_keyed_left, time_keyed_right.other_value]
+    context = (Timestamp('20170105'), Timestamp('20170111'))
+    expr.execute(timecontext=context)
+
+
+def test_adjust_context_complete_shift(
+    time_keyed_left,
+    time_keyed_right,
+    time_keyed_df1,
+    time_keyed_df2,
+):
+    """Test `adjust_context` function that completely shifts the context.
+
+    This results in an adjusted context that is NOT a subset of the
+    original context. This is unlike an `adjust_context` function
+    that only expands the context.
+    """
+
+    # Create a contrived `adjust_context` function for
+    # CustomAsOfJoin to mock this.
+
+    @adjust_context.register(CustomAsOfJoin)
+    def adjust_context_custom_asof_join(
+        op: ops.AsOfJoin,
+        timecontext: TimeContext,
+        scope: Optional[Scope] = None,
+    ) -> TimeContext:
+        """Shifts both the begin and end in the same direction."""
+        from ibis.backends.pandas.execution import execute
+
+        begin, end = timecontext
+        timedelta = execute(op.tolerance)
+        return (begin - timedelta, end - timedelta)
+
+    expr = CustomAsOfJoin(
+        left=time_keyed_left,
+        right=time_keyed_right,
+        predicates='time',
+        by='key',
+        tolerance=ibis.interval(days=4),
+    ).to_expr()
+    expr = expr[time_keyed_left, time_keyed_right.other_value]
+    context = (Timestamp('20170101'), Timestamp('20170111'))
+    result = expr.execute(timecontext=context)
+
+    # Compare with asof_join of manually trimmed tables
+    # Left table: No shift for context
+    # Right table: Shift both begin and end of context by 4 days
+    trimmed_df1 = time_keyed_df1[time_keyed_df1['time'] >= context[0]][
+        time_keyed_df1['time'] < context[1]
+    ]
+    trimmed_df2 = time_keyed_df2[
+        time_keyed_df2['time'] >= context[0] - Timedelta(days=4)
+    ][time_keyed_df2['time'] < context[1] - Timedelta(days=4)]
+    expected = dd.merge_asof(
+        trimmed_df1,
+        trimmed_df2,
+        on='time',
+        by='key',
+        tolerance=Timedelta('4D'),
+    ).compute()
+
+    tm.assert_frame_equal(result, expected)

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -354,7 +354,7 @@ def execute_until_in_scope(
         new_scope.get_value(arg.op(), timecontext)
         if hasattr(arg, 'op')
         else arg
-        for arg in computable_args
+        for (arg, timecontext) in zip(computable_args, arg_timecontexts)
     ]
     result = execute_node(
         op,

--- a/ibis/backends/pandas/tests/execution/test_timecontext.py
+++ b/ibis/backends/pandas/tests/execution/test_timecontext.py
@@ -7,6 +7,7 @@ import pytest
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
+from ibis.backends.pandas.execution import execute
 from ibis.backends.pandas.execution.window import trim_window_result
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import (
@@ -307,6 +308,8 @@ def test_adjust_context_complete_shift(
     This results in an adjusted context that is NOT a subset of the
     original context. This is unlike an `adjust_context` function
     that only expands the context.
+
+    See #3104
     """
 
     # Create a contrived `adjust_context` function for
@@ -319,7 +322,6 @@ def test_adjust_context_complete_shift(
         scope: Optional[Scope] = None,
     ) -> TimeContext:
         """Shifts both the begin and end in the same direction."""
-        from ibis.backends.pandas.execution import execute
 
         begin, end = timecontext
         timedelta = execute(op.tolerance)

--- a/ibis/backends/pandas/tests/execution/test_timecontext.py
+++ b/ibis/backends/pandas/tests/execution/test_timecontext.py
@@ -289,11 +289,71 @@ def test_adjust_context_scope(time_keyed_left, time_keyed_right):
         right=time_keyed_right,
         predicates='time',
         by='key',
-        tolerance=4 * ibis.interval(days=1),
+        tolerance=ibis.interval(days=4),
     ).to_expr()
     expr = expr[time_keyed_left, time_keyed_right.other_value]
     context = (pd.Timestamp('20170105'), pd.Timestamp('20170111'))
     expr.execute(timecontext=context)
+
+
+def test_adjust_context_complete_shift(
+    time_keyed_left,
+    time_keyed_right,
+    time_keyed_df1,
+    time_keyed_df2,
+):
+    """Test `adjust_context` function that completely shifts the context.
+
+    This results in an adjusted context that is NOT a subset of the
+    original context. This is unlike an `adjust_context` function
+    that only expands the context.
+    """
+
+    # Create a contrived `adjust_context` function for
+    # CustomAsOfJoin to mock this.
+
+    @adjust_context.register(CustomAsOfJoin)
+    def adjust_context_custom_asof_join(
+        op: ops.AsOfJoin,
+        timecontext: TimeContext,
+        scope: Optional[Scope] = None,
+    ) -> TimeContext:
+        """Shifts both the begin and end in the same direction."""
+        from ibis.backends.pandas.execution import execute
+
+        begin, end = timecontext
+        timedelta = execute(op.tolerance)
+        return (begin - timedelta, end - timedelta)
+
+    expr = CustomAsOfJoin(
+        left=time_keyed_left,
+        right=time_keyed_right,
+        predicates='time',
+        by='key',
+        tolerance=ibis.interval(days=4),
+    ).to_expr()
+    expr = expr[time_keyed_left, time_keyed_right.other_value]
+    context = (pd.Timestamp('20170101'), pd.Timestamp('20170111'))
+    result = expr.execute(timecontext=context)
+
+    # Compare with asof_join of manually trimmed tables
+    # Left table: No shift for context
+    # Right table: Shift both begin and end of context by 4 days
+    trimmed_df1 = time_keyed_df1[time_keyed_df1['time'] >= context[0]][
+        time_keyed_df1['time'] < context[1]
+    ]
+    trimmed_df2 = time_keyed_df2[
+        time_keyed_df2['time'] >= context[0] - pd.Timedelta(days=4)
+    ][time_keyed_df2['time'] < context[1] - pd.Timedelta(days=4)]
+    expected = pd.merge_asof(
+        trimmed_df1,
+        trimmed_df2,
+        on='time',
+        by='key',
+        tolerance=pd.Timedelta('4D'),
+    )
+
+    tm.assert_frame_equal(result, expected)
 
 
 def test_construct_time_context_aware_series(time_df3):


### PR DESCRIPTION
## Problem

Before this PR, any `adjust_context` function (i.e., a function that defines logic for adjusting the timecontext for a particular Node) that results in **an adjusted context is not a superset of the original context** would cause an error in the Pandas and Dask backends.

--

Example:
- Begin adjusted from `2020-02-01` to `2020-01-29`
- End adjusted from `2020-02-07` to `2020-02-03`

The adjusted context is _not_ a superset of the original context.

--

This is not causing any user-facing issues currently, because all of our existing `adjust_context` functions produce an adjusted timecontext that is a superset of the original timecontext, which doesn't trigger this error. However, this bug is not ideal because context adjustment functions should not be restricted to only being able to _expand_ the original timecontext.

### Root cause

In the Pandas backend's and Dask backend's core execution code, there is a problem in the logic that fetches materialized data (e.g. materialized left and right tables when executing `AsOfJoinNode`) from `scope` to feed into `execute_node`. The bug is that it was querying `scope` for the materialized data **using the old, non-adjusted timecontexts as part of the key, instead of the new, adjusted timecontexts**. Then, it would fail to fetch the materialized data, and try to execute the node with `None`s instead.

## Fix

This PR patches the Pandas and Dask backend's core execution code by making it query `scope` using adjusted timecontexts.

## Testing

New test that creates a contrived `adjust_context` function for a mock `AsOfJoinNode`, which creates a completely-shifted adjusted context. Created this test for both backends:
- `ibis/backends/pandas/tests/execution/test_timecontext.py`
- `ibis/backends/dask/tests/execution/test_timecontext.py`
