### PR TITLE
PREF: Do not materialize predicates on selection

### DIFF
--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -163,9 +163,6 @@ def execute_selection_dataframe(
             op.table.op(), predicates, data, scope, timecontext, **kwargs
         )
         predicate = functools.reduce(operator.and_, predicates)
-        assert len(predicate) == len(
-            result
-        ), 'Selection predicate length does not match underlying table'
         result = result.loc[predicate]
 
     if sort_keys:


### PR DESCRIPTION
Calling `len` here forces dask to materialize all the predicates, just to check the assertion. This was transplanted from the pandas code. 