### PR TITLE
fix(datatypes): infer bytes literal as binary #2915

### DIFF
--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -1232,6 +1232,11 @@ def infer_string(value: str) -> String:
     return string
 
 
+@infer.register(bytes)
+def infer_bytes(value: bytes) -> Binary:
+    return binary
+
+
 @infer.register(builtins.float)
 def infer_floating(value: builtins.float) -> Double:
     return double

--- a/ibis/tests/expr/test_datatypes.py
+++ b/ibis/tests/expr/test_datatypes.py
@@ -379,6 +379,7 @@ class Foo(enum.Enum):
         (False, dt.boolean),
         (True, dt.boolean),
         ('foo', dt.string),
+        (b'fooblob', dt.binary),
         (datetime.date.today(), dt.date),
         (datetime.datetime.now(), dt.timestamp),
         (datetime.timedelta(days=3), dt.Interval(unit='D')),

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -63,6 +63,7 @@ def test_unicode():
         (-2147483649, 'int64'),
         (1.5, 'double'),
         ('foo', 'string'),
+        (b'fooblob', 'binary'),
         ([1, 2, 3], 'array<int8>'),
     ],
 )


### PR DESCRIPTION
Closes #2915 