### PR TITLE
fix(literal): allow creating ibis literal with uuid

### DIFF
--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -2,6 +2,7 @@ import datetime
 import enum
 import functools
 import itertools
+import uuid
 
 import numpy as np
 import pandas as pd
@@ -247,6 +248,7 @@ class Literal(ValueOp):
                         str,
                         tuple,
                         type(None),
+                        uuid.UUID,
                     )
                 ),
                 rlz.is_computable_input,

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -4,7 +4,6 @@ import os
 from collections import OrderedDict
 from datetime import date, datetime, time
 from operator import methodcaller
-import uuid
 
 import numpy as np
 import pandas as pd

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -4,6 +4,7 @@ import os
 from collections import OrderedDict
 from datetime import date, datetime, time
 from operator import methodcaller
+import uuid
 
 import numpy as np
 import pandas as pd
@@ -118,6 +119,7 @@ multipolygon1 = [polygon1, polygon2]
         (tuple(multipoint), 'multipoint'),
         (list(multipolygon1), 'multipolygon'),
         (tuple(multipolygon1), 'multipolygon'),
+        (uuid.uuid4(), 'uuid'),
     ],
 )
 def test_literal_with_explicit_type(value, expected_type):

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1,6 +1,7 @@
 import functools
 import operator
 import os
+import uuid
 from collections import OrderedDict
 from datetime import date, datetime, time
 from operator import methodcaller

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1,10 +1,10 @@
 import functools
 import operator
 import os
-import uuid
 from collections import OrderedDict
 from datetime import date, datetime, time
 from operator import methodcaller
+import uuid
 
 import numpy as np
 import pandas as pd
@@ -120,6 +120,7 @@ multipolygon1 = [polygon1, polygon2]
         (list(multipolygon1), 'multipolygon'),
         (tuple(multipolygon1), 'multipolygon'),
         (uuid.uuid4(), 'uuid'),
+        (str(uuid.uuid4()), 'uuid'),
     ],
 )
 def test_literal_with_explicit_type(value, expected_type):

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1,10 +1,10 @@
 import functools
 import operator
 import os
+import uuid
 from collections import OrderedDict
 from datetime import date, datetime, time
 from operator import methodcaller
-import uuid
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
```
import ibis
import uuid

value = uuid.uuid4()
x = ibis.literal(value, type="uuid")
```

This was raising 
```
IbisTypeError: argument passes none of the following rules: instance_of((<class 'shapely.geometry.base.BaseGeometry'>, <class 'bytes'>, <class 'datetime.date'>, <class 'datetime.datetime'>, <class 'datetime.time'>, <class 'datetime.timedelta'>, <class 'dict'>, <enum 'Enum'>, <class 'float'>, <class 'frozenset'>, <class 'int'>, <class 'list'>, <class 'numpy.generic'>, <class 'numpy.ndarray'>, <class 'pandas._libs.tslibs.timedeltas.Timedelta'>, <class 'pandas._libs.tslibs.timestamps.Timestamp'>, <class 'set'>, <class 'str'>, <class 'tuple'>, <class 'NoneType'>),), is_computable_input()
```

but `ibis.literal(str(value), type="uuid")` wasn't.  Adding in `uuid.UUID` as a valid `instance_of` rule

Fixes #3130 