### PR TITLE
ci: use the precise python version installed for cache lookups

### DIFF
--- a/.github/workflows/check-setup-py.yml
+++ b/.github/workflows/check-setup-py.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -38,7 +39,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pypoetry
-          key: check-setup-py-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: check-setup-py-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: install base ibis env
         run: poetry install
@@ -70,6 +71,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -86,7 +88,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: check-setuptools-install-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          key: check-setuptools-install-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
 
       - name: install using requirements.txt
         run: pip install -r requirements.txt

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -72,14 +73,14 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && (matrix.backend.name != 'dask' || matrix.backend.deps == null) }}
         with:
           path: ~/.cache/pypoetry
-          key: ${{ matrix.backend.name }}-${{ join(matrix.backend.deps, '-') }}-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: ${{ matrix.backend.name }}-${{ join(matrix.backend.deps, '-') }}-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: cache dependencies windows
         uses: actions/cache@v2
         if: ${{ matrix.os == 'windows-latest' && (matrix.backend.name != 'dask' || matrix.backend.deps == null) }}
         with:
           path: ~\AppData\Local\pypoetry
-          key: ${{ matrix.backend.name }}-${{ join(matrix.backend.deps, '-') }}-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: ${{ matrix.backend.name }}-${{ join(matrix.backend.deps, '-') }}-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: install minimum dask version
         if: ${{ matrix.backend.name == 'dask' && matrix.backend.deps != null }}
@@ -135,6 +136,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -149,7 +151,7 @@ jobs:
         if: ${{ toJSON(matrix.deps) == '[]' }}
         with:
           path: ~/.cache/pypoetry
-          key: postgres-geospatial-${{ join(matrix.deps, '-') }}-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: postgres-geospatial-${{ join(matrix.deps, '-') }}-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: install minimum postgres dependencies
         run: |
@@ -209,6 +211,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -225,7 +228,7 @@ jobs:
         if: ${{ matrix.pyspark.version == 'latest' }}
         with:
           path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-pyspark-${{ matrix.pyspark.version }}
+          key: ${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-pyspark-${{ matrix.pyspark.version }}
 
       - name: pin pyspark
         if: ${{ matrix.pyspark.version != 'latest' }}
@@ -316,6 +319,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -329,7 +333,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pypoetry
-          key: impala-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: impala-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: install ibis
         run: poetry install --extras impala
@@ -388,6 +392,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -398,7 +403,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pypoetry
-          key: ${{ matrix.backend.name }}-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: ${{ matrix.backend.name }}-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: install ibis
         run: poetry install --extras ${{ matrix.backend.name }}

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -45,14 +46,14 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           path: ~/.cache/pypoetry
-          key: no-backends-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: no-backends-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: cache dependencies windows
         uses: actions/cache@v2
         if: ${{ matrix.os == 'windows-latest' }}
         with:
           path: ~\AppData\Local\pypoetry
-          key: no-backends-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: no-backends-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: install ibis
         run: poetry install
@@ -82,6 +83,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -95,7 +97,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pypoetry
-          key: benchmarks-impala-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: benchmarks-impala-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: install ibis
         run: poetry install --extras impala
@@ -124,6 +126,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -134,7 +137,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pypoetry
-          key: docs-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: docs-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: install ibis
         run: poetry install --extras all

--- a/.github/workflows/update-setup-py.yml
+++ b/.github/workflows/update-setup-py.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: "3.x"
 
@@ -35,7 +36,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/pypoetry
-          key: update-setup-py-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
+          key: update-setup-py-${{ runner.os }}-${{ steps.install_python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: generate setup.py
         env:


### PR DESCRIPTION
This PR uses the installed python version for cache hits to avoid breakage
when setup-python starts installing a new patch release of Python.

This failure can be seen here: https://github.com/ibis-project/ibis/runs/4355031281?check_suite_focus=true

cc @gforsyth
