### PR TITLE
refactor: dt.UUID inherits from DataType, not String

### DIFF
--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -802,7 +802,7 @@ class MultiPolygon(GeoSpatial):
     __slots__ = ()
 
 
-class UUID(String):
+class UUID(DataType):
     """A universally unique identifier (UUID) is a 128-bit number used to
     identify information in computer systems.
     """
@@ -1451,6 +1451,8 @@ def can_cast_geospatial(source, target, **kwargs):
 
 
 @castable.register(UUID, UUID)
+@castable.register(UUID, String)
+@castable.register(String, UUID)
 @castable.register(MACADDR, MACADDR)
 @castable.register(INET, INET)
 def can_cast_special_string(source, target, **kwargs):
@@ -1569,10 +1571,3 @@ def _str_to_uuid(typ: UUID, value: str) -> _uuid.UUID:
 @_normalize.register(String, _uuid.UUID)
 def _uuid_to_str(typ: String, value: _uuid.UUID) -> str:
     return str(value)
-
-
-@_normalize.register(UUID, _uuid.UUID)
-def _uuid_to_uuid(typ: UUID, value: _uuid.UUID) -> _uuid.UUID:
-    """Need this to override _uuid_to_str since dt.UUID is a child of
-    dt.String"""
-    return value

--- a/ibis/tests/expr/test_datatypes.py
+++ b/ibis/tests/expr/test_datatypes.py
@@ -497,6 +497,8 @@ def test_infer_dtype(value, expected_dtype):
     ('source', 'target'),
     [
         (dt.any, dt.string),
+        (dt.string, dt.uuid),
+        (dt.uuid, dt.string),
         (dt.null, dt.date),
         (dt.null, dt.any),
         (dt.int8, dt.int64),


### PR DESCRIPTION
Fixes #3136 

You can still cast from UUID to String, but UUID no longer inherits from string (this also removes the need for an extra dispatch rule in the `_normalize` function)