### PR TITLE
chore(expr): add quotes around expr in validator error

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -989,7 +989,7 @@ class ExprValidator:
 
     def _error_message(self, expr):
         return (
-            'The expression %s does not fully originate from '
+            'The expression "%s" does not fully originate from '
             'dependencies of the table expression.' % repr(expr)
         )
 


### PR DESCRIPTION
The source of my confusion was that the final line of the repr(Expr) for sort_by is the "reverse" boolean, so the final line of the error output was:

```
    False does not fully originate from dependencies of the table expression.
```

This adds quotes around the Expr for this error message, which would have provided a clue that the `False` is part of a larger multi-line expression.  Alternatively/additionally the Expr repr could have some some outer brackets or braces to indicate the bounds of the Expr.