### PR TITLE
fix: restore the ability to have more than two option levels

### DIFF
--- a/ibis/config.py
+++ b/ibis/config.py
@@ -570,14 +570,10 @@ def _get_root(
     tuple
     """
     path = key.split('.')
-    if len(path) == 1:
-        return _global_config, path[0]
-    elif len(path) == 2:
-        return _global_config[path[0]], path[1]
-    else:
-        raise AssertionError(
-            f'Option keys cannot have more than 2 levels, found: {key}'
-        )
+    cursor = _global_config
+    for p in path[:-1]:
+        cursor = cursor[p]
+    return (cursor, path[-1])
 
 
 def _is_deprecated(key: str) -> bool:

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -133,11 +133,7 @@ def test_multiple_backends(mocker):
 
 
 @pytest.mark.parametrize(
-    ('key', 'value'),
-    [
-        ("two.levels", True),
-        ("gt.two.levels", 55)
-    ]
+    ('key', 'value'), [("two.levels", True), ("gt.two.levels", 55)]
 )
 def test_getting_setting_config_options(key, value):
     ibis.config.register_option(key, "DEFAULT")

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -130,3 +130,17 @@ def test_multiple_backends(mocker):
     msg = "3 packages found for backend 'foo'"
     with pytest.raises(RuntimeError, match=msg):
         ibis.foo
+
+
+@pytest.mark.parametrize(
+    ('key', 'value'),
+    [
+        ("two.levels", True),
+        ("gt.two.levels", 55)
+    ]
+)
+def test_getting_setting_config_options(key, value):
+    ibis.config.register_option(key, "DEFAULT")
+    assert ibis.config.get_option(key) == "DEFAULT"
+    ibis.config.set_option(key, value)
+    assert ibis.config.get_option(key) == value


### PR DESCRIPTION
Closes https://github.com/ibis-project/ibis/issues/3145

Adds a basic test of reading/writing options. 