### PR TITLE
feat(api): add order_by alias for sort_by

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4658,6 +4658,7 @@ _table_methods = {
     'anti_join': _regular_join_method('anti_join', 'anti'),
     'asof_join': asof_join,
     'sort_by': _table_sort_by,
+    'order_by': _table_sort_by,
     'to_array': _table_to_array,
     'union': _table_union,
     'intersect': _table_intersect,

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -4126,7 +4126,7 @@ def _regular_join_method(name, how, doc=None):
     return f
 
 
-def filter(table, predicates):
+def _filter(table, predicates):
     """
     Select rows from table based on boolean expressions
 
@@ -4641,7 +4641,7 @@ _table_methods = {
     'limit': _table_limit,
     'head': _head,
     'set_column': _table_set_column,
-    'filter': filter,
+    'filter': _filter,
     'materialize': _table_materialize,
     'mutate': mutate,
     'projection': projection,


### PR DESCRIPTION
@gforsyth and I experienced minor friction as we expected `order_by` to exist in the expr api, for parity with SQL `ORDER BY` . An alias seems reasonable.

This PR also includes a minor internal rename of the `filter()` function to avoid conflict with Python builtin `filter()`.