### PR TITLE
ci: stop running backend tests in default.nix

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -13,6 +13,7 @@ jobs:
           - nixpkgs
           - poetry2nix
           - pre-commit-hooks
+          - gitignore.nix
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,6 +3,11 @@ let
 in
 import sources.nixpkgs {
   overlays = [
+    (pkgs: _: {
+      inherit (import sources."gitignore.nix" {
+        inherit (pkgs) lib;
+      }) gitignoreSource;
+    })
     (pkgs: super: {
       poetry2nix = import sources.poetry2nix {
         inherit pkgs;
@@ -34,6 +39,7 @@ import sources.nixpkgs {
       ibisDevEnv38 = pkgs.mkPoetryEnv pkgs.python38;
       ibisDevEnv39 = pkgs.mkPoetryEnv pkgs.python39;
       ibisDevEnv310 = pkgs.mkPoetryEnv pkgs.python310;
+      ibisDevEnv = pkgs.ibisDevEnv310;
     } // super.lib.optionalAttrs super.stdenv.isDarwin {
       arrow-cpp = super.arrow-cpp.override {
         enableS3 = false;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "gitignore.nix": {
+        "branch": "master",
+        "description": "Nix functions for filtering local git sources",
+        "homepage": "",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
+        "sha256": "01l4phiqgw9xgaxr6jr456qmww6kzghqrnbc7aiiww3h6db5vw53",
+        "type": "tarball",
+        "url": "https://github.com/hercules-ci/gitignore.nix/archive/5b9e0ff9d3b551234b4f3eb3983744fa354b17f1.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "nixos-unstable-small",
         "description": "Nix Packages collection",

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -70,8 +70,4 @@ self: super:
 
     pythonImportsCheck = [ "tables" ];
   });
-
-  typing-extensions = super.typing-extensions.overridePythonAttrs (attrs: {
-    buildInputs = (attrs.buildInputs or [ ]) ++ [ self.flit-core ];
-  });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,6 @@
 { python ? "3.10" }:
 let
   pkgs = import ./nix;
-  inherit (pkgs) lib;
 
   devDeps = with pkgs; [
     cacert
@@ -23,7 +22,7 @@ let
     cmake
   ];
 
-  vizDeps = [ pkgs.graphviz ];
+  vizDeps = [ pkgs.graphviz-nox ];
   pysparkDeps = [ pkgs.openjdk11 ];
   docDeps = [ pkgs.pandoc ];
 


### PR DESCRIPTION
We run the backends tests elsewher in CI, so we do not need to run them in the nix setup. Non backend tests are still run as a sanity check for the environment.