### PR TITLE
ci: set up checks with dependencies

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -447,3 +447,13 @@ jobs:
         with:
           name: ${{ matrix.backend }}-${{ matrix.python-version }}
           path: junit.xml
+
+  backends:
+    # this job exists so that we can use a single job from this workflow to gate merging
+    runs-on: ubuntu-latest
+    needs:
+      - test_impala
+      - test_mysql_clickhouse
+      - test_postgres
+      - test_pyspark
+      - test_simple_backends

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -457,3 +457,5 @@ jobs:
       - test_postgres
       - test_pyspark
       - test_simple_backends
+    steps:
+      - run: exit 0

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -327,6 +327,13 @@ jobs:
 
   simulate_release:
     runs-on: ubuntu-latest
+    needs:
+      - nix
+      - lint
+      - test_no_backends
+      - benchmarks
+      - docs
+      - conda_package
     steps:
       - name: checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR sets up `simulate_release` (for non-backend CI) and a new `backends` job (for backend CI)
to have dependencies so that we can gate merging on these two jobs.
