### PR TITLE
fix: address ibis-bigquery incompatibilities

### DIFF
--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -52,11 +52,9 @@ with ibis.config.config_prefix('sql'):
     )
 
 try:
-    _distribution_name = __name__
     __version__ = importlib_metadata.version(__name__)
 except Exception:
-    _distribution_name = "ibis-framework"
-    __version__ = importlib_metadata.version(_distribution_name)
+    __version__ = importlib_metadata.version("ibis-framework")
 
 
 def __getattr__(name: str) -> BaseBackend:
@@ -74,10 +72,10 @@ def __getattr__(name: str) -> BaseBackend:
     the `ibis.backends` entrypoints. If successful, the `ibis.sqlite`
     attribute is "cached", so this function is only called the first time.
     """
-    distribution = importlib_metadata.distribution(_distribution_name)
+    ibis_entry_points = importlib_metadata.entry_points()["ibis.backends"]
     entry_points = [
         entry_point
-        for entry_point in distribution.entry_points
+        for entry_point in ibis_entry_points
         if name == entry_point.name
     ]
 

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -190,7 +190,6 @@ class BaseBackend(abc.ABC):
         """
         self.do_connect(*self._con_args, **self._con_kwargs)
 
-    @abc.abstractmethod
     def do_connect(self, *args, **kwargs) -> None:
         """
         Connect to database specified by args and kwargs.

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -135,15 +135,17 @@ def test_missing_backend():
 
 def test_multiple_backends(mocker):
     if sys.version_info[:2] < (3, 8):
-        api = 'importlib_metadata.distribution'
+        module = 'importlib_metadata'
     else:
-        api = 'importlib.metadata.distribution'
+        module = 'importlib.metadata'
+
+    api = f"{module}.entry_points"
 
     class Distribution(NamedTuple):
         entry_points: list[EntryPoint]
 
-    return_value = Distribution(
-        entry_points=(
+    return_value = {
+        "ibis.backends": [
             EntryPoint(
                 name="foo",
                 value='ibis.backends.backend1',
@@ -154,8 +156,8 @@ def test_multiple_backends(mocker):
                 value='ibis.backends.backend1',
                 group="ibis.backends",
             ),
-        )
-    )
+        ],
+    }
 
     mocker.patch(api, return_value=return_value)
 


### PR DESCRIPTION
This PR removes the abstractmethod decorator from do_connect so that existing backends such as ibis-bigquery can continue to function with ibis 2.x