### PR TITLE
fix: correlated subquery with join generates incorrect SQL

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -77,7 +77,7 @@ def _varargs_call(sa_func, t, expr):
 
 
 def get_sqla_table(ctx, table):
-    if ctx.has_ref(table):
+    if ctx.has_ref(table, parent_contexts=True):
         ctx_level = ctx
         sa_table = ctx_level.get_ref(table)
         while sa_table is None and ctx_level.parent is not ctx_level:


### PR DESCRIPTION
This PR addresses #3163.

It turns out that we weren't examining parent contexts when looking up tables
in the SQLAlchemy backend. Without this, a table subexpression would get
recompiled instead of looked up. We have to look into the outer scope since the
referenced expression may not be available in the current context, in this case
precisely because of the correlated subquery.

Closes #3163.
