### PR TITLE
docs(install): update backend specific install options

### DIFF
--- a/docs/source/backends/clickhouse.rst
+++ b/docs/source/backends/clickhouse.rst
@@ -1,13 +1,25 @@
 .. _install.clickhouse:
 
 `Clickhouse <https://clickhouse.yandex/>`_
-------------------------------------------
+==========================================
+
+Install
+-------
 
 Install dependencies for Ibis's Clickhouse dialect(minimal supported version is `0.1.3`):
 
 ::
 
   pip install 'ibis-framework[clickhouse]'
+
+or
+
+::
+
+  conda install -c conda-forge ibis-clickhouse
+
+Connect
+-------
 
 Create a client by passing in database connection parameters such as ``host``,
 ``port``, ``database``, and ``user`` to :func:`ibis.clickhouse.connect`:
@@ -20,7 +32,7 @@ Create a client by passing in database connection parameters such as ``host``,
 .. _api.clickhouse:
 
 API
-===
+---
 .. currentmodule:: ibis.backends.clickhouse
 
 The ClickHouse client is accessible through the ``ibis.clickhouse`` namespace.

--- a/docs/source/backends/datafusion.rst
+++ b/docs/source/backends/datafusion.rst
@@ -7,11 +7,23 @@
 
    The Datafusion backend is experimental
 
+Install
+-------
+
 Install ibis along with its dependencies for the datafusion backend:
 
 ::
 
   pip install 'ibis-framework[datafusion]'
+
+or
+
+::
+
+  conda install -c conda-forge ibis-datafusion
+
+Connect
+-------
 
 Create a client by passing a dictionary that maps table names to paths to
 :func:`ibis.datafusion.connect`:

--- a/docs/source/backends/impala.rst
+++ b/docs/source/backends/impala.rst
@@ -2,16 +2,15 @@
 
 .. _backends.impala:
 
-******
-Impala
-******
+`Impala <https://impala.apache.org/>`_
+=======================================
 
 One goal of Ibis is to provide an integrated Python API for an Impala cluster
 without requiring you to switch back and forth between Python code and the
 Impala shell (where one would be using a mix of DDL and SQL statements).
 
 If you find an Impala task that you cannot perform with Ibis, please get in
-touch on the `GitHub issue tracker <http://github.com/pandas-dev/ibis>`_.
+touch on the `GitHub issue tracker <http://github.com/ibis-project/ibis>`_.
 
 While interoperability between the Hadoop / Spark ecosystems and pandas / the
 PyData stack is overall poor (but improving), we also show some ways that you
@@ -19,14 +18,24 @@ can use pandas with Ibis and Impala.
 
 .. _install.impala:
 
-`Impala <https://impala.apache.org/>`_ Quickstart
--------------------------------------------------
+Install
+-------
 
 Install dependencies for Ibis's Impala dialect:
 
 ::
 
   pip install 'ibis-framework[impala]'
+
+or
+
+::
+
+  conda install -c conda-forge ibis-impala
+
+
+Connect
+-------
 
 To create an Ibis client, you must first connect your services and assemble the
 client using :func:`ibis.impala.connect`:

--- a/docs/source/backends/mysql.rst
+++ b/docs/source/backends/mysql.rst
@@ -3,11 +3,24 @@
 `MySQL <https://www.mysql.com/>`_
 =================================
 
+Install
+-------
+
 Install dependencies for Ibis's MySQL dialect:
 
 ::
 
   pip install 'ibis-framework[mysql]'
+
+
+or
+
+::
+
+  conda install -c conda-forge ibis-mysql
+
+Connect
+-------
 
 Create a client by passing a connection string or individual parameters to
 :func:`ibis.mysql.connect`:

--- a/docs/source/backends/postgres.rst
+++ b/docs/source/backends/postgres.rst
@@ -3,11 +3,23 @@
 `PostgreSQL <https://www.postgresql.org/>`_
 ===========================================
 
+Install
+-------
+
 Install dependencies for Ibis's PostgreSQL dialect:
 
 ::
 
   pip install 'ibis-framework[postgres]'
+
+or
+
+::
+
+  conda install -c conda-forge ibis-postgres
+
+Connect
+-------
 
 Create a client by passing a connection string to the ``url`` parameter or
 individual parameters to :func:`ibis.postgres.connect`:

--- a/docs/source/backends/pyspark.rst
+++ b/docs/source/backends/pyspark.rst
@@ -1,7 +1,10 @@
 .. _install.pyspark:
 
 `PySpark <https://spark.apache.org/sql/>`_
-====================================================
+==========================================
+
+Install
+-------
 
 Install dependencies for Ibis's PySpark dialect:
 
@@ -9,17 +12,23 @@ Install dependencies for Ibis's PySpark dialect:
 
   pip install 'ibis-framework[pyspark]'
 
+or
+
+::
+
+  conda install -c conda-forge ibis-pyspark
+
 .. note::
 
-   When using the PySpark backend with PySpark 2.4.x and pyarrow >= 0.15.0, you
-   need to set ``ARROW_PRE_0_15_IPC_FORMAT=1``. See `here
-   <https://spark.apache.org/docs/latest/api/python/user_guide/arrow_pandas.html#compatibility-setting-for-pyarrow-0-15-0-and-spark-2-3-x-2-4-x>`_
+   When using the PySpark backend with PySpark 2.3.x, 2.4.x and pyarrow >= 0.15.0, you
+   need to set ``ARROW_PRE_0_15_IPC_FORMAT=1``. See `here  <https://spark.apache.org/docs/3.0.1/sql-pyspark-pandas-with-arrow.html#compatibility-setting-for-pyarrow--0150-and-spark-23x-24x>`_
    for details
 
 .. _api.pyspark:
 
-PySpark client
-~~~~~~~~~~~~~~
+Connect
+-------
+
 .. currentmodule:: ibis.backends.pyspark
 
 The PySpark client is accessible through the ``ibis.pyspark`` namespace.

--- a/docs/source/backends/sqlite.rst
+++ b/docs/source/backends/sqlite.rst
@@ -3,11 +3,23 @@
 `SQLite <https://www.sqlite.org/>`_
 ===================================
 
+Install
+-------
+
 Install dependencies for Ibis's SQLite dialect:
 
 ::
 
   pip install 'ibis-framework[sqlite]'
+
+or
+
+::
+
+  conda install -c conda-forge ibis-sqlite
+
+Connect
+-------
 
 Create a client by passing a path to a SQLite database to
 :func:`ibis.sqlite.connect`:

--- a/docs/source/tutorial/01-Introduction-to-Ibis.ipynb
+++ b/docs/source/tutorial/01-Introduction-to-Ibis.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "### Getting started\n",
     "\n",
-    "To start using Ibis, you need a Python environment with Ibis installed. If you don't know how to create an environment, we recommend following the [setup instructions](https://ibis-project.org/getting_started.html) in the Ibis website.\n",
+    "To start using Ibis, you need a Python environment with Ibis installed. If you don't know how to create an environment, we recommend following the [setup instructions](https://ibis-project.org/getting_started/) in the Ibis website.\n",
     "\n",
     "Once you have your environment ready, to start using Ibis simply import the `ibis` module:"
    ]


### PR DESCRIPTION
Add in links to conda-forge backend-specific packages.
Also standardized heading precedence for the RST stuff that's still
here.

Finally, fixed a broken link in the tutorial intro notebook and fixed up
a rotten link to a pyspark + pyarrow explainer.

Finishing up #2448 