### PR TITLE
docs: fix copyright years for Sphinx pages

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
+SOURCE_DATE_EPOCH = $(shell git log -1 --format=%ct)
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)


### PR DESCRIPTION
In further evidence that computers were a mistake, because `nix` sets
`SOURCE_DATE_EPOCH=1` when it builds things and because Sphinx has a
workaround for bugs in _different_ packages that might be doing
something silly with dates, we need to explicitly set
`SOURCE_DATE_EPOCH` so we don't end up 40+ years in the past.

https://github.com/sphinx-doc/sphinx/issues/3451