### PR TITLE
refactor(ir): simplify expressions by not storing dtype and name

### DIFF
--- a/docs/user_guide/design.md
+++ b/docs/user_guide/design.md
@@ -77,9 +77,14 @@ import ibis.expr.rules as rlz
 from ibis.expr.operations import ValueOp
 
 class Log(ValueOp):
-   arg = rlz.double  # A double scalar or column
-   base = rlz.optional(rlz.double)  # Optional argument, defaults to None
-   output_type = rlz.typeof('arg')
+   # A double scalar or column
+   arg = rlz.double
+   # Optional argument, defaults to None
+   base = rlz.optional(rlz.double)
+   # Output expression's datatype will correspond to arg's datatype
+   output_dtype = rlz.dtype_like('arg')
+   # Output expression will be scalar if arg is scalar, column otherwise
+   output_shape = rlz.shape_like('arg')
 ```
 
 This class describes an operation called `Log` that takes one required

--- a/ibis/backends/base/sql/alchemy/translator.py
+++ b/ibis/backends/base/sql/alchemy/translator.py
@@ -36,9 +36,7 @@ class AlchemyExprTranslator(ExprTranslator):
     context_class = AlchemyContext
 
     def name(self, translated, name, force=True):
-        if hasattr(translated, 'label'):
-            return translated.label(name)
-        return translated
+        return translated.label(name)
 
     def get_sqla_type(self, data_type):
         return to_sqla_type(data_type, type_map=self._type_map)

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -525,8 +525,15 @@ class Compiler:
     @classmethod
     def make_context(cls, params=None):
         params = params or {}
-        params = {expr.op(): value for expr, value in params.items()}
-        return cls.context_class(compiler=cls, params=params)
+
+        unaliased_params = {}
+        for expr, value in params.items():
+            op = expr.op()
+            if isinstance(op, ops.Alias):
+                op = op.arg.op()
+            unaliased_params[op] = value
+
+        return cls.context_class(compiler=cls, params=unaliased_params)
 
     @classmethod
     def to_ast(cls, expr, context=None):

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -13,6 +13,7 @@ from ibis.backends.base.sql.registry import (
     operation_registry,
     quote_identifier,
 )
+from ibis.expr.types.core import unnamed
 
 
 class QueryContext:
@@ -200,6 +201,22 @@ class ExprTranslator:
         # For now, governing whether the result will have a name
         self.named = named
 
+    def _needs_name(self, expr):
+        if not self.named:
+            return False
+
+        op = expr.op()
+        if isinstance(op, ops.TableColumn):
+            # This column has been given an explicitly different name
+            return expr.get_name() != op.name
+
+        return expr.get_name() is not unnamed
+
+    def name(self, translated, name, force=True):
+        return '{} AS {}'.format(
+            translated, quote_identifier(name, force=force)
+        )
+
     def get_result(self):
         """Compile SQL expression into a string."""
         translated = self.translate(self.expr)
@@ -220,27 +237,6 @@ class ExprTranslator:
         UDFs which are added dynamically.
         """
         cls._registry[operation] = translate_function
-
-    def _needs_name(self, expr):
-        if not self.named:
-            return False
-
-        op = expr.op()
-        if isinstance(op, ops.TableColumn):
-            # This column has been given an explicitly different name
-            if expr.get_name() != op.name:
-                return True
-            return False
-
-        if expr.get_name() is ir.core.unnamed:
-            return False
-
-        return True
-
-    def name(self, translated: str, name: str, force: bool = True) -> str:
-        return '{} AS {}'.format(
-            translated, quote_identifier(name, force=force)
-        )
 
     def translate(self, expr):
         # The operation node type the typed expression wraps
@@ -331,7 +327,11 @@ def _bucket(expr):
         stmt = stmt.when(cmp(op.buckets[-1], op.arg), bucket_id)
         bucket_id += 1
 
-    return stmt.end().name(expr._name)
+    result = stmt.end()
+    if expr.has_name():
+        result = result.name(expr.get_name())
+
+    return result
 
 
 @rewrites(ops.CategoryLabel)
@@ -345,7 +345,11 @@ def _category_label(expr):
     if op.nulls is not None:
         stmt = stmt.else_(op.nulls)
 
-    return stmt.end().name(expr._name)
+    result = stmt.end()
+    if expr.has_name():
+        result = result.name(expr.get_name())
+
+    return result
 
 
 @rewrites(ops.Any)
@@ -357,7 +361,7 @@ def _any_expand(expr):
 @rewrites(ops.NotAny)
 def _notany_expand(expr):
     arg = expr.op().args[0]
-    return arg.max() == 0
+    return arg.max() == ibis.literal(0, type=arg.type())
 
 
 @rewrites(ops.All)
@@ -369,7 +373,7 @@ def _all_expand(expr):
 @rewrites(ops.NotAll)
 def _notall_expand(expr):
     arg = expr.op().args[0]
-    return arg.min() == 0
+    return arg.min() == ibis.literal(0, type=arg.type())
 
 
 @rewrites(ops.Cast)

--- a/ibis/backends/base/sql/ddl.py
+++ b/ibis/backends/base/sql/ddl.py
@@ -220,7 +220,8 @@ class CTAS(CreateTable):
         if self.partition is not None:
             return 'PARTITIONED BY ({})'.format(
                 ', '.join(
-                    quote_identifier(expr._name) for expr in self.partition
+                    quote_identifier(expr.get_name())
+                    for expr in self.partition
                 )
             )
         return None

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -8,6 +8,13 @@ from . import aggregate, binary_infix, case, helpers, string, timestamp, window
 from .literal import literal, null_literal
 
 
+def alias(translator, expr):
+    # just compile the underlying argument because the naming is handled
+    # by the translator for the top level expression
+    op = expr.op()
+    return translator.translate(op.arg)
+
+
 def fixed_arity(func_name, arity):
     def formatter(translator, expr):
         op = expr.op()
@@ -237,6 +244,7 @@ binary_infix_ops = {
 
 
 operation_registry = {
+    ops.Alias: alias,
     # Unary operations
     ops.NotNull: not_null,
     ops.IsNull: is_null,

--- a/ibis/backends/base/sql/registry/window.py
+++ b/ibis/backends/base/sql/registry/window.py
@@ -95,7 +95,9 @@ def cumulative_to_window(translator, expr, window):
 
     klass = _cumulative_to_reduction[type(op)]
     new_op = klass(*op.args)
-    new_expr = expr._factory(new_op, name=expr._name)
+    new_expr = new_op.to_expr()
+    if expr.has_name():
+        new_expr = new_expr.name(expr.get_name())
 
     if type(new_op) in translator._rewrites:
         new_expr = translator._rewrites[type(new_op)](new_expr)

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -9,6 +9,15 @@ import ibis.util as util
 
 from .identifiers import quote_identifier
 
+# TODO(kszucs): should inherit operation registry from the base compiler
+
+
+def _alias(translator, expr):
+    # just compile the underlying argument because the naming is handled
+    # by the translator for the top level expression
+    op = expr.op()
+    return translator.translate(op.arg)
+
 
 def _cast(translator, expr):
     from .client import ClickhouseDataType
@@ -624,6 +633,7 @@ _unary_ops = {ops.Negate: _negate, ops.Not: _not}
 
 
 operation_registry = {
+    ops.Alias: _alias,
     # Unary operations
     ops.TypeOf: _unary('toTypeName'),
     ops.IsNan: _unary('isNaN'),

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -157,6 +157,13 @@ def execute_node_value_list(op, _, **kwargs):
     return [execute(arg, **kwargs) for arg in op.values]
 
 
+@execute_node.register(ops.Alias, object)
+def execute_alias_series(op, _, **kwargs):
+    # just compile the underlying argument because the naming is handled
+    # by the translator for the top level expression
+    return execute(op.arg, **kwargs)
+
+
 @execute_node.register(ops.Arbitrary, dd.Series, (dd.Series, type(None)))
 def execute_arbitrary_series_mask(op, data, mask, aggcontext=None, **kwargs):
     """

--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -42,7 +42,7 @@ def compute_projection_scalar_expr(
     timecontext: Optional[TimeContext] = None,
     **kwargs,
 ):
-    name = expr._name
+    name = expr.get_name()
     assert name is not None, 'Scalar selection name is None'
 
     op = expr.op()
@@ -76,7 +76,7 @@ def compute_projection_column_expr(
     timecontext: Optional[TimeContext],
     **kwargs,
 ):
-    result_name = getattr(expr, '_name', None)
+    result_name = expr._safe_name
     op = expr.op()
     parent_table_op = parent.table.op()
 
@@ -111,8 +111,6 @@ def compute_projection_column_expr(
 
     result = execute(expr, scope=scope, timecontext=timecontext, **kwargs)
     result = coerce_to_output(result, expr, data.index)
-    assert result_name is not None, 'Column selection name is None'
-
     return result
 
 

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -92,9 +92,8 @@ def coerce_to_output(
 
     Examples
     --------
-    For dataframe outputs, see ``_coerce_to_dataframe``. Examples below use
-    pandas objects for legibility, but functionality is the same on dask
-    objects.
+    Examples below use pandas objects for legibility, but functionality is the
+    same on dask objects.
 
     >>> coerce_to_output(pd.Series(1), expr)
     0    1
@@ -111,7 +110,7 @@ def coerce_to_output(
     0    [1, 2, 3]
     Name: result, dtype: object
     """
-    result_name = expr.get_name()
+    result_name = expr._safe_name
     dataframe_exprs = (
         ir.DestructColumn,
         ir.StructColumn,
@@ -125,7 +124,7 @@ def coerce_to_output(
     elif isinstance(result, (pd.Series, dd.Series)):
         # Series from https://github.com/ibis-project/ibis/issues/2711
         return result.rename(result_name)
-    elif isinstance(expr.op(), ops.Reduction):
+    elif isinstance(expr, ir.ScalarExpr):
         if isinstance(result, dd.core.Scalar):
             # wrap the scalar in a series
             out_dtype = _pandas_dtype_from_dd_scalar(result)

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -61,7 +61,7 @@ def test_decimal_metadata(con):
     # TODO: what if user impyla version does not have decimal Metadata?
 
 
-def test_builtins_1(con, alltypes):
+def test_builtins(con, alltypes):
     table = alltypes
 
     i1 = table.tinyint_col

--- a/ibis/backends/impala/tests/test_udf.py
+++ b/ibis/backends/impala/tests/test_udf.py
@@ -143,13 +143,10 @@ def test_udf_primitive_output_types(ty, value, column, table):
     ibis_type = dt.validate_type(ty)
 
     expr = func(value)
-    assert type(expr) == type(  # noqa: E501, E721
-        ibis_type.scalar_type()(expr.op())
-    )
+    assert type(expr) == ibis_type.scalar
+
     expr = func(table[column])
-    assert type(expr) == type(  # noqa: E501, E721
-        ibis_type.column_type()(expr.op())
-    )
+    assert type(expr) == ibis_type.column
 
 
 @pytest.mark.parametrize(
@@ -170,17 +167,16 @@ def test_udf_primitive_output_types(ty, value, column, table):
         ),
     ],
 )
-def test_uda_primitive_output_types(ty, value, table):
+def test_uda_primitive_output_types(ty, value):
     func = _register_uda([ty], ty, 'test')
 
     ibis_type = dt.validate_type(ty)
 
     expr1 = func(value)
+    assert isinstance(expr1, ibis_type.scalar)
+
     expr2 = func(value)
-    expected_type1 = type(ibis_type.scalar_type()(expr1.op()))
-    expected_type2 = type(ibis_type.scalar_type()(expr2.op()))
-    assert isinstance(expr1, expected_type1)
-    assert isinstance(expr2, expected_type2)
+    assert isinstance(expr2, ibis_type.scalar)
 
 
 def test_decimal(dec):

--- a/ibis/backends/impala/udf.py
+++ b/ibis/backends/impala/udf.py
@@ -71,7 +71,8 @@ class ScalarFunction(Function):
         fields = {
             f'_{i}': rlz.value(dtype) for i, dtype in enumerate(self.inputs)
         }
-        fields['output_type'] = rlz.shape_like('args', self.output)
+        fields['output_dtype'] = self.output
+        fields['output_shape'] = rlz.shape_like('args')
         return type(f"UDF_{self.name}", (ops.ValueOp,), fields)
 
 
@@ -80,7 +81,8 @@ class AggregateFunction(Function):
         fields = {
             f'_{i}': rlz.value(dtype) for i, dtype in enumerate(self.inputs)
         }
-        fields['output_type'] = lambda op: self.output.scalar_type()
+        fields['output_dtype'] = self.output
+        fields['output_shape'] = rlz.Shape.SCALAR
         fields['_reduction'] = True
         return type(f"UDA_{self.name}", (ops.ValueOp,), fields)
 

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -848,6 +848,13 @@ def execute_node_self_reference_dataframe(op, data, **kwargs):
     return data
 
 
+@execute_node.register(ops.Alias, object)
+def execute_alias(op, _, **kwargs):
+    # just compile the underlying argument because the naming is handled
+    # by the translator for the top level expression
+    return execute(op.arg, **kwargs)
+
+
 @execute_node.register(ops.ValueList, collections.abc.Sequence)
 def execute_node_value_list(op, _, **kwargs):
     return [execute(arg, **kwargs) for arg in op.values]

--- a/ibis/backends/pandas/execution/join.py
+++ b/ibis/backends/pandas/execution/join.py
@@ -168,8 +168,8 @@ def _extract_predicate_names(predicates):
             raise TypeError(
                 'Only equality join predicates supported with pandas'
             )
-        left_name = predicate.left._name
-        right_name = predicate.right._name
+        left_name = predicate.left.get_name()
+        right_name = predicate.right.get_name()
         lefts.append(left_name)
         rights.append(right_name)
     return lefts, rights

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -57,7 +57,7 @@ def compute_projection_scalar_expr(
     timecontext: Optional[TimeContext] = None,
     **kwargs,
 ):
-    name = expr._name
+    name = expr.get_name()
     assert name is not None, 'Scalar selection name is None'
 
     op = expr.op()
@@ -97,7 +97,7 @@ def compute_projection_column_expr(
     timecontext: Optional[TimeContext],
     **kwargs,
 ):
-    result_name = getattr(expr, '_name', None)
+    result_name = expr._safe_name
     op = expr.op()
     parent_table_op = parent.table.op()
 
@@ -137,7 +137,6 @@ def compute_projection_column_expr(
         expr,
         data.index,
     )
-    assert result_name is not None, 'Column selection name is None'
     return result
 
 
@@ -323,7 +322,9 @@ def build_df_from_selection(
             if selection + join_suffix not in data:
                 raise KeyError(selection)
             selection += join_suffix
-        cols[selection].append(getattr(expr, "_name", selection))
+        cols[selection].append(
+            expr.get_name() if expr.has_name() else selection
+        )
 
     result = data[list(cols.keys())]
 

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -115,7 +115,7 @@ def coerce_to_output(
     0    [1, 2, 3]
     Name: result, dtype: object
     """
-    result_name = getattr(expr, '_name', None)
+    result_name = expr._safe_name
 
     if isinstance(expr, (ir.DestructColumn, ir.StructColumn)):
         return _coerce_to_dataframe(result, expr.type())
@@ -126,7 +126,7 @@ def coerce_to_output(
         return _coerce_to_dataframe(result, expr.type())
     elif isinstance(result, pd.Series):
         return result.rename(result_name)
-    elif isinstance(expr.op(), ops.Reduction):
+    elif isinstance(expr, ir.ScalarExpr):
         if index is None:
             # Wrap `result` into a single-element Series.
             return pd.Series([result], name=result_name)

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -3,6 +3,7 @@ from sqlalchemy.dialects import postgresql
 
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+import ibis.expr.rules as rlz
 from ibis.backends.base.sql.alchemy import (
     AlchemyCompiler,
     AlchemyExprTranslator,
@@ -13,7 +14,7 @@ from .registry import operation_registry
 
 
 class PostgresUDFNode(ops.ValueOp):
-    pass
+    output_shape = rlz.shape_like("args")
 
 
 class PostgreSQLExprTranslator(AlchemyExprTranslator):

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -1241,11 +1241,11 @@ def test_anti_join(t, s):
 def test_create_table_from_expr(con, trunc, guid2):
     con.create_table(guid2, expr=trunc)
     t = con.table(guid2)
-    assert list(t.name.execute()) == list('abc')
+    assert list(t['name'].execute()) == list('abc')
 
 
 def test_truncate_table(con, trunc):
-    assert list(trunc.name.execute()) == list('abc')
+    assert list(trunc['name'].execute()) == list('abc')
     con.truncate_table(trunc.op().name)
     assert not len(trunc.execute())
 

--- a/ibis/backends/postgres/udf.py
+++ b/ibis/backends/postgres/udf.py
@@ -100,20 +100,10 @@ def existing_udf(name, input_types, output_type, schema=None, parameters=None):
 
     v.validate_output_type(output_type)
 
-    udf_node_fields = collections.OrderedDict(
-        [
-            (name, rlz.value(type_))
-            for name, type_ in zip(parameters, input_types)
-        ]
-        + [
-            (
-                'output_type',
-                lambda self, output_type=output_type: rlz.shape_like(
-                    self.args, dtype=output_type
-                ),
-            )
-        ]
-    )
+    udf_node_fields = {
+        name: rlz.value(type_) for name, type_ in zip(parameters, input_types)
+    }
+    udf_node_fields['output_dtype'] = output_type
     udf_node_fields['resolve_name'] = lambda self: name
 
     udf_node = _create_udf_node(name, udf_node_fields)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -113,6 +113,13 @@ def _can_be_replaced_by_column_name(column_expr, table):
     )
 
 
+@compiles(ops.Alias)
+def compile_alias(t, expr, scope, timecontext, **kwargs):
+    op = expr.op()
+    arg = t.translate(op.arg, scope, timecontext, **kwargs)
+    return arg.alias(op.name)
+
+
 @compiles(ops.Selection)
 def compile_selection(t, expr, scope, timecontext, **kwargs):
     op = expr.op()

--- a/ibis/backends/pyspark/tests/test_timecontext.py
+++ b/ibis/backends/pyspark/tests/test_timecontext.py
@@ -110,7 +110,9 @@ def test_adjust_context_scope(client):
         order_by='time',
         group_by='key',
     )
-    value_count_over_win = CustomWindowOp(value_count, win).to_expr()
+    # the argument needs to be pull out from the alias
+    # any extensions must do the same
+    value_count_over_win = CustomWindowOp(value_count.op().arg, win).to_expr()
 
     expr = table.mutate(value_count_over_win.name('value_count_over_win'))
 

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -577,6 +577,11 @@ def _fmt_value_value_op(op: ops.ValueOp, *, aliases: Aliases) -> str:
 
 
 @fmt_value.register
+def _fmt_value_alias(op: ops.Alias, *, aliases: Aliases) -> str:
+    return fmt_value(op.arg, aliases=aliases)
+
+
+@fmt_value.register
 def _fmt_value_table_column(op: ops.TableColumn, *, aliases: Aliases) -> str:
     return f"{aliases[op.table.op()]}.{op.name}"
 
@@ -591,6 +596,13 @@ def _fmt_value_sort_key(op: ops.SortKey, *, aliases: Aliases) -> str:
     expr = fmt_value(op.expr, aliases=aliases)
     sort_direction = " asc" if op.ascending else "desc"
     return f"{sort_direction}|{expr}"
+
+
+@fmt_value.register
+def _fmt_topk(op: ops.TopK, *, aliases: Aliases) -> str:
+    arg = fmt_value(op.arg, aliases=aliases)
+    by = fmt_value(op.by, aliases=aliases)
+    return f"TopK({arg}, {op.k}, {by})"
 
 
 @fmt_value.register

--- a/ibis/expr/operations/geospatial.py
+++ b/ibis/expr/operations/geospatial.py
@@ -25,14 +25,14 @@ class GeoSpatialUnOp(UnaryOp):
 class GeoDistance(GeoSpatialBinOp):
     """Returns minimum distance between two geo spatial data"""
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
 class GeoContains(GeoSpatialBinOp):
     """Check if the first geo spatial data contains the second one"""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -40,14 +40,14 @@ class GeoContainsProperly(GeoSpatialBinOp):
     """Check if the first geo spatial data contains the second one,
     and no boundary points are shared."""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
 class GeoCovers(GeoSpatialBinOp):
     """Returns True if no point in Geometry B is outside Geometry A"""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -55,7 +55,7 @@ class GeoCoveredBy(GeoSpatialBinOp):
     """Returns True if no point in Geometry/Geography A is
     outside Geometry/Geography B"""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -63,7 +63,7 @@ class GeoCrosses(GeoSpatialBinOp):
     """Returns True if the supplied geometries have some, but not all,
     interior points in common."""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -71,14 +71,14 @@ class GeoDisjoint(GeoSpatialBinOp):
     """Returns True if the Geometries do not “spatially intersect” -
     if they do not share any space together."""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
 class GeoEquals(GeoSpatialBinOp):
     """Returns True if the given geometries represent the same geometry."""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -86,15 +86,14 @@ class GeoGeometryN(GeoSpatialUnOp):
     """Returns the Nth Geometry of a Multi geometry."""
 
     n = rlz.integer
-
-    output_type = rlz.shape_like('args', dt.geometry)
+    output_dtype = dt.geometry
 
 
 @public
 class GeoGeometryType(GeoSpatialUnOp):
     """Returns the type of the geometry."""
 
-    output_type = rlz.shape_like('args', dt.string)
+    output_dtype = dt.string
 
 
 @public
@@ -103,14 +102,14 @@ class GeoIntersects(GeoSpatialBinOp):
     - (share any portion of space) and False if they don’t (they are Disjoint).
     """
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
 class GeoIsValid(GeoSpatialUnOp):
     """Returns true if the geometry is well-formed."""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -126,7 +125,7 @@ class GeoLineLocatePoint(GeoSpatialBinOp):
     left = rlz.linestring
     right = rlz.point
 
-    output_type = rlz.shape_like('args', dt.halffloat)
+    output_dtype = dt.halffloat
 
 
 @public
@@ -140,7 +139,7 @@ class GeoLineMerge(GeoSpatialUnOp):
     geometry collection.
     """
 
-    output_type = rlz.shape_like('args', dt.geometry)
+    output_dtype = dt.geometry
 
 
 @public
@@ -158,7 +157,7 @@ class GeoLineSubstring(GeoSpatialUnOp):
     start = rlz.floating
     end = rlz.floating
 
-    output_type = rlz.shape_like('args', dt.linestring)
+    output_dtype = dt.linestring
 
 
 @public
@@ -170,7 +169,7 @@ class GeoOrderingEquals(GeoSpatialBinOp):
     are in the same order.
     """
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -178,7 +177,7 @@ class GeoOverlaps(GeoSpatialBinOp):
     """Returns True if the Geometries share space, are of the same dimension,
     but are not completely contained by each other."""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -186,45 +185,42 @@ class GeoTouches(GeoSpatialBinOp):
     """Returns True if the geometries have at least one point in common,
     but their interiors do not intersect."""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
-class GeoUnaryUnion(Reduction):
+class GeoUnaryUnion(Reduction, GeoSpatialUnOp):
     """Returns the pointwise union of the geometries in the column."""
 
-    arg = rlz.column(rlz.geospatial)
-
-    def output_type(self):
-        return dt.geometry.scalar_type()
+    output_dtype = dt.geometry
 
 
 @public
 class GeoUnion(GeoSpatialBinOp):
     """Returns the pointwise union of the two geometries."""
 
-    output_type = rlz.shape_like('args', dt.geometry)
+    output_dtype = dt.geometry
 
 
 @public
 class GeoArea(GeoSpatialUnOp):
     """Area of the geo spatial data"""
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
 class GeoPerimeter(GeoSpatialUnOp):
     """Perimeter of the geo spatial data"""
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
 class GeoLength(GeoSpatialUnOp):
     """Length of geo spatial data"""
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
@@ -235,7 +231,7 @@ class GeoMaxDistance(GeoSpatialBinOp):
     in that geometry
     """
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
@@ -244,7 +240,7 @@ class GeoX(GeoSpatialUnOp):
     Input must be a point
     """
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
@@ -253,35 +249,35 @@ class GeoY(GeoSpatialUnOp):
     Input must be a point
     """
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
 class GeoXMin(GeoSpatialUnOp):
     """Returns Y minima of a bounding box 2d or 3d or a geometry"""
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
 class GeoXMax(GeoSpatialUnOp):
     """Returns X maxima of a bounding box 2d or 3d or a geometry"""
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
 class GeoYMin(GeoSpatialUnOp):
     """Returns Y minima of a bounding box 2d or 3d or a geometry"""
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
 class GeoYMax(GeoSpatialUnOp):
     """Returns Y maxima of a bounding box 2d or 3d or a geometry"""
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
@@ -290,7 +286,7 @@ class GeoStartPoint(GeoSpatialUnOp):
     NULL if the input parameter is not a LINESTRING
     """
 
-    output_type = rlz.shape_like('arg', dt.point)
+    output_dtype = dt.point
 
 
 @public
@@ -299,7 +295,7 @@ class GeoEndPoint(GeoSpatialUnOp):
     NULL if the input parameter is not a LINESTRING
     """
 
-    output_type = rlz.shape_like('arg', dt.point)
+    output_dtype = dt.point
 
 
 @public
@@ -311,7 +307,8 @@ class GeoPoint(GeoSpatialBinOp):
 
     left = rlz.numeric
     right = rlz.numeric
-    output_type = rlz.shape_like('args', dt.point)
+
+    output_dtype = dt.point
 
 
 @public
@@ -323,14 +320,14 @@ class GeoPointN(GeoSpatialUnOp):
     """
 
     n = rlz.integer
-    output_type = rlz.shape_like('args', dt.point)
+    output_dtype = dt.point
 
 
 @public
 class GeoNPoints(GeoSpatialUnOp):
     """Return the number of points in a geometry. Works for all geometries"""
 
-    output_type = rlz.shape_like('args', dt.int64)
+    output_dtype = dt.int64
 
 
 @public
@@ -339,14 +336,14 @@ class GeoNRings(GeoSpatialUnOp):
     rings. It counts the outer rings as well
     """
 
-    output_type = rlz.shape_like('args', dt.int64)
+    output_dtype = dt.int64
 
 
 @public
 class GeoSRID(GeoSpatialUnOp):
     """Returns the spatial reference identifier for the ST_Geometry."""
 
-    output_type = rlz.shape_like('args', dt.int64)
+    output_dtype = dt.int64
 
 
 @public
@@ -354,7 +351,8 @@ class GeoSetSRID(GeoSpatialUnOp):
     """Set the spatial reference identifier for the ST_Geometry."""
 
     srid = rlz.integer
-    output_type = rlz.shape_like('args', dt.geometry)
+
+    output_dtype = dt.geometry
 
 
 @public
@@ -365,15 +363,14 @@ class GeoBuffer(GeoSpatialUnOp):
     """
 
     radius = rlz.floating
-
-    output_type = rlz.shape_like('args', dt.geometry)
+    output_dtype = dt.geometry
 
 
 @public
 class GeoCentroid(GeoSpatialUnOp):
     """Returns the geometric center of a geometry."""
 
-    output_type = rlz.shape_like('arg', dt.point)
+    output_dtype = dt.point
 
 
 @public
@@ -384,7 +381,7 @@ class GeoDFullyWithin(GeoSpatialBinOp):
 
     distance = rlz.floating
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -395,14 +392,14 @@ class GeoDWithin(GeoSpatialBinOp):
 
     distance = rlz.floating
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
 class GeoEnvelope(GeoSpatialUnOp):
     """Represents the bounding box of the supplied geometry."""
 
-    output_type = rlz.shape_like('arg', dt.polygon)
+    output_dtype = dt.polygon
 
 
 @public
@@ -415,14 +412,14 @@ class GeoAzimuth(GeoSpatialBinOp):
     left = rlz.point
     right = rlz.point
 
-    output_type = rlz.shape_like('args', dt.float64)
+    output_dtype = dt.float64
 
 
 @public
 class GeoWithin(GeoSpatialBinOp):
     """Returns True if the geometry A is completely inside geometry B"""
 
-    output_type = rlz.shape_like('args', dt.boolean)
+    output_dtype = dt.boolean
 
 
 @public
@@ -431,7 +428,7 @@ class GeoIntersection(GeoSpatialBinOp):
     of the Geometries.
     """
 
-    output_type = rlz.shape_like('args', dt.geometry)
+    output_dtype = dt.geometry
 
 
 @public
@@ -440,7 +437,7 @@ class GeoDifference(GeoSpatialBinOp):
     that does not intersect with geometry B
     """
 
-    output_type = rlz.shape_like('args', dt.geometry)
+    output_dtype = dt.geometry
 
 
 @public
@@ -450,7 +447,7 @@ class GeoSimplify(GeoSpatialUnOp):
     tolerance = rlz.floating
     preserve_collapsed = rlz.boolean
 
-    output_type = rlz.shape_like('arg', dt.geometry)
+    output_dtype = dt.geometry
 
 
 @public
@@ -459,7 +456,7 @@ class GeoTransform(GeoSpatialUnOp):
 
     srid = rlz.integer
 
-    output_type = rlz.shape_like('arg', dt.geometry)
+    output_dtype = dt.geometry
 
 
 @public
@@ -468,7 +465,7 @@ class GeoAsBinary(GeoSpatialUnOp):
     geometry/geography without SRID meta data.
     """
 
-    output_type = rlz.shape_like('arg', dt.binary)
+    output_dtype = dt.binary
 
 
 @public
@@ -477,7 +474,7 @@ class GeoAsEWKB(GeoSpatialUnOp):
     geometry/geography with SRID meta data.
     """
 
-    output_type = rlz.shape_like('arg', dt.binary)
+    output_dtype = dt.binary
 
 
 @public
@@ -486,7 +483,7 @@ class GeoAsEWKT(GeoSpatialUnOp):
     geometry/geography with SRID meta data.
     """
 
-    output_type = rlz.shape_like('arg', dt.string)
+    output_dtype = dt.string
 
 
 @public
@@ -495,4 +492,4 @@ class GeoAsText(GeoSpatialUnOp):
     geometry/geography without SRID metadata.
     """
 
-    output_type = rlz.shape_like('arg', dt.string)
+    output_dtype = dt.string

--- a/ibis/expr/operations/histograms.py
+++ b/ibis/expr/operations/histograms.py
@@ -7,13 +7,15 @@ from .core import ValueOp
 
 @public
 class BucketLike(ValueOp):
+    output_shape = rlz.Shape.COLUMNAR
+
     @property
     def nbuckets(self):
         return None
 
-    def output_type(self):
-        dtype = dt.Category(self.nbuckets)
-        return dtype.column_type()
+    @property
+    def output_dtype(self):
+        return dt.Category(self.nbuckets)
 
 
 @public
@@ -63,9 +65,10 @@ class Histogram(BucketLike):
             raise ValueError('nbins and binwidth are mutually exclusive')
         super().__init__(nbins=nbins, binwidth=binwidth, **kwargs)
 
-    def output_type(self):
+    @property
+    def output_dtype(self):
         # always undefined cardinality (for now)
-        return dt.category.column_type()
+        return dt.category
 
 
 @public
@@ -73,7 +76,9 @@ class CategoryLabel(ValueOp):
     arg = rlz.category
     labels = rlz.tuple_of(rlz.instance_of(str))
     nulls = rlz.optional(rlz.instance_of(str))
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_dtype = dt.string
+    output_shape = rlz.shape_like("arg")
 
     def __init__(self, arg, labels, **kwargs):
         cardinality = arg.type().cardinality

--- a/ibis/expr/operations/sortkeys.py
+++ b/ibis/expr/operations/sortkeys.py
@@ -70,8 +70,7 @@ class SortKey(Node):
         default=True,
     )
 
-    def output_type(self):
-        return ir.SortExpr
+    output_type = ir.SortExpr
 
     def root_tables(self):
         return self.expr.op().root_tables()

--- a/ibis/expr/operations/strings.py
+++ b/ibis/expr/operations/strings.py
@@ -8,7 +8,7 @@ from .core import UnaryOp, ValueOp
 @public
 class StringUnaryOp(UnaryOp):
     arg = rlz.string
-    output_type = rlz.shape_like('arg', dt.string)
+    output_dtype = dt.string
 
 
 @public
@@ -51,21 +51,25 @@ class Substring(ValueOp):
     arg = rlz.string
     start = rlz.integer
     length = rlz.optional(rlz.integer)
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_dtype = dt.string
+    output_shape = rlz.shape_like('arg')
 
 
 @public
 class StrRight(ValueOp):
     arg = rlz.string
     nchars = rlz.integer
-    output_type = rlz.shape_like('arg', dt.string)
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
 class Repeat(ValueOp):
     arg = rlz.string
     times = rlz.integer
-    output_type = rlz.shape_like('arg', dt.string)
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
@@ -74,7 +78,9 @@ class StringFind(ValueOp):
     substr = rlz.string
     start = rlz.optional(rlz.integer)
     end = rlz.optional(rlz.integer)
-    output_type = rlz.shape_like('arg', dt.int64)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.int64
 
 
 @public
@@ -82,7 +88,9 @@ class Translate(ValueOp):
     arg = rlz.string
     from_str = rlz.string
     to_str = rlz.string
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
@@ -90,7 +98,9 @@ class LPad(ValueOp):
     arg = rlz.string
     length = rlz.integer
     pad = rlz.optional(rlz.string)
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
@@ -98,14 +108,18 @@ class RPad(ValueOp):
     arg = rlz.string
     length = rlz.integer
     pad = rlz.optional(rlz.string)
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
 class FindInSet(ValueOp):
     needle = rlz.string
     values = rlz.value_list_of(rlz.string, min_length=1)
-    output_type = rlz.shape_like('needle', dt.int64)
+
+    output_shape = rlz.shape_like("needle")
+    output_dtype = dt.int64
 
 
 @public
@@ -113,29 +127,32 @@ class StringJoin(ValueOp):
     sep = rlz.string
     arg = rlz.value_list_of(rlz.string, min_length=1)
 
-    def output_type(self):
-        return rlz.shape_like(tuple(self.flat_args()), dt.string)
+    output_dtype = dt.string
+    output_shape = rlz.shape_like("arg")
 
 
 @public
 class StartsWith(ValueOp):
     arg = rlz.string
-    start = rlz.string
-    output_type = rlz.shape_like("arg", dt.boolean)
+    start = rlz.scalar(rlz.string)
+    output_dtype = dt.boolean
+    output_shape = rlz.shape_like("arg")
 
 
 @public
 class EndsWith(ValueOp):
     arg = rlz.string
-    end = rlz.string
-    output_type = rlz.shape_like("arg", dt.boolean)
+    end = rlz.scalar(rlz.string)
+    output_dtype = dt.boolean
+    output_shape = rlz.shape_like("arg")
 
 
 @public
 class FuzzySearch(ValueOp):
     arg = rlz.string
     pattern = rlz.string
-    output_type = rlz.shape_like('arg', dt.boolean)
+    output_dtype = dt.boolean
+    output_shape = rlz.shape_like('arg')
 
 
 @public
@@ -160,7 +177,9 @@ class RegexExtract(ValueOp):
     arg = rlz.string
     pattern = rlz.string
     index = rlz.integer
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
@@ -168,7 +187,9 @@ class RegexReplace(ValueOp):
     arg = rlz.string
     pattern = rlz.string
     replacement = rlz.string
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
@@ -176,20 +197,26 @@ class StringReplace(ValueOp):
     arg = rlz.string
     pattern = rlz.string
     replacement = rlz.string
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
 class StringSplit(ValueOp):
     arg = rlz.string
     delimiter = rlz.string
-    output_type = rlz.shape_like('arg', dt.Array(dt.string))
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.Array(dt.string)
 
 
 @public
 class StringConcat(ValueOp):
     arg = rlz.value_list_of(rlz.string)
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
@@ -208,14 +235,16 @@ class ParseURL(ValueOp):
         }
     )
     key = rlz.optional(rlz.string)
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
 class StringLength(UnaryOp):
-    output_type = rlz.shape_like('arg', dt.int32)
+    output_dtype = dt.int32
 
 
 @public
 class StringAscii(UnaryOp):
-    output_type = rlz.shape_like('arg', dt.int32)
+    output_dtype = dt.int32

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -3,6 +3,8 @@ import operator
 import toolz
 from public import public
 
+from ... import util
+from ...common.validators import immutable_property
 from .. import datatypes as dt
 from .. import rules as rlz
 from .. import types as ir
@@ -78,28 +80,36 @@ _timestamp_units = toolz.merge(_date_units, _time_units)
 class TimestampTruncate(ValueOp):
     arg = rlz.timestamp
     unit = rlz.isin(_timestamp_units)
-    output_type = rlz.shape_like('arg', dt.timestamp)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.timestamp
 
 
 @public
 class DateTruncate(ValueOp):
     arg = rlz.date
     unit = rlz.isin(_date_units)
-    output_type = rlz.shape_like('arg', dt.date)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.date
 
 
 @public
 class TimeTruncate(ValueOp):
     arg = rlz.time
     unit = rlz.isin(_time_units)
-    output_type = rlz.shape_like('arg', dt.time)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.time
 
 
 @public
 class Strftime(ValueOp):
     arg = rlz.temporal
     format_str = rlz.string
-    output_type = rlz.shape_like('arg', dt.string)
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.string
 
 
 @public
@@ -107,12 +117,14 @@ class StringToTimestamp(ValueOp):
     arg = rlz.string
     format_str = rlz.string
     timezone = rlz.optional(rlz.string)
-    output_type = rlz.shape_like('arg', dt.Timestamp(timezone='UTC'))
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = dt.Timestamp(timezone='UTC')
 
 
 @public
 class ExtractTemporalField(TemporalUnaryOp):
-    output_type = rlz.shape_like('arg', dt.int32)
+    output_dtype = dt.int32
 
 
 ExtractTimestampField = ExtractTemporalField
@@ -186,31 +198,29 @@ class ExtractMillisecond(ExtractTimeField):
 @public
 class DayOfWeekIndex(UnaryOp):
     arg = rlz.one_of([rlz.date, rlz.timestamp])
-    output_type = rlz.shape_like('arg', dt.int16)
+    output_dtype = dt.int16
 
 
 @public
 class DayOfWeekName(UnaryOp):
     arg = rlz.one_of([rlz.date, rlz.timestamp])
-    output_type = rlz.shape_like('arg', dt.string)
+    output_dtype = dt.string
 
 
 @public
 class DayOfWeekNode(Node):
     arg = rlz.one_of([rlz.date, rlz.timestamp])
-
-    def output_type(self):
-        return ir.DayOfWeek
+    output_type = ir.DayOfWeek
 
 
 @public
 class Time(UnaryOp):
-    output_type = rlz.shape_like('arg', dt.time)
+    output_dtype = dt.time
 
 
 @public
 class Date(UnaryOp):
-    output_type = rlz.shape_like('arg', dt.date)
+    output_dtype = dt.date
 
 
 @public
@@ -218,7 +228,9 @@ class DateFromYMD(ValueOp):
     year = rlz.integer
     month = rlz.integer
     day = rlz.integer
-    output_type = rlz.shape_like('args', dt.date)
+
+    output_dtype = dt.date
+    output_shape = rlz.shape_like("args")
 
 
 @public
@@ -226,7 +238,9 @@ class TimeFromHMS(ValueOp):
     hours = rlz.integer
     minutes = rlz.integer
     seconds = rlz.integer
-    output_type = rlz.shape_like('args', dt.time)
+
+    output_dtype = dt.time
+    output_shape = rlz.shape_like("args")
 
 
 @public
@@ -238,7 +252,9 @@ class TimestampFromYMDHMS(ValueOp):
     minutes = rlz.integer
     seconds = rlz.integer
     timezone = rlz.optional(rlz.string)
-    output_type = rlz.shape_like('args', dt.timestamp)
+
+    output_dtype = dt.timestamp
+    output_shape = rlz.shape_like("args")
 
 
 @public
@@ -246,49 +262,52 @@ class TimestampFromUNIX(ValueOp):
     arg = rlz.any
     # Only pandas-based backends support 'ns'
     unit = rlz.isin({'s', 'ms', 'us', 'ns'})
-    output_type = rlz.shape_like('arg', dt.timestamp)
+    output_shape = rlz.shape_like('arg')
+
+    output_dtype = dt.timestamp
+    output_shape = rlz.shape_like("args")
 
 
 @public
 class DateAdd(BinaryOp):
     left = rlz.date
     right = rlz.interval(units={'Y', 'Q', 'M', 'W', 'D'})
-    output_type = rlz.shape_like('left')
+    output_dtype = rlz.dtype_like('left')
 
 
 @public
 class DateSub(BinaryOp):
     left = rlz.date
     right = rlz.interval(units={'Y', 'Q', 'M', 'W', 'D'})
-    output_type = rlz.shape_like('left')
+    output_dtype = rlz.dtype_like('left')
 
 
 @public
 class DateDiff(BinaryOp):
     left = rlz.date
     right = rlz.date
-    output_type = rlz.shape_like('left', dt.Interval('D'))
+    output_dtype = dt.Interval('D')
 
 
 @public
 class TimeAdd(BinaryOp):
     left = rlz.time
     right = rlz.interval(units={'h', 'm', 's', 'ms', 'us', 'ns'})
-    output_type = rlz.shape_like('left')
+    output_dtype = rlz.dtype_like('left')
 
 
 @public
 class TimeSub(BinaryOp):
     left = rlz.time
     right = rlz.interval(units={'h', 'm', 's', 'ms', 'us', 'ns'})
-    output_type = rlz.shape_like('left')
+    output_dtype = rlz.dtype_like('left')
 
 
 @public
 class TimeDiff(BinaryOp):
     left = rlz.time
     right = rlz.time
-    output_type = rlz.shape_like('left', dt.Interval('s'))
+    output_dtype = dt.Interval('s')
 
 
 @public
@@ -297,7 +316,7 @@ class TimestampAdd(BinaryOp):
     right = rlz.interval(
         units={'Y', 'Q', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'}
     )
-    output_type = rlz.shape_like('left')
+    output_dtype = rlz.dtype_like('left')
 
 
 @public
@@ -306,35 +325,56 @@ class TimestampSub(BinaryOp):
     right = rlz.interval(
         units={'Y', 'Q', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'}
     )
-    output_type = rlz.shape_like('left')
+    output_dtype = rlz.dtype_like('left')
 
 
 @public
 class TimestampDiff(BinaryOp):
     left = rlz.timestamp
     right = rlz.timestamp
-    output_type = rlz.shape_like('left', dt.Interval('s'))
+    output_dtype = dt.Interval('s')
+
+
+@public
+class ToIntervalUnit(ValueOp):
+    arg = rlz.interval
+    unit = rlz.isin({'Y', 'Q', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'})
+
+    output_shape = rlz.shape_like("arg")
+
+    def __init__(self, arg, unit):
+        dtype = arg.type()
+        if dtype.unit != unit:
+            arg = util.convert_unit(arg, dtype.unit, unit)
+        super().__init__(arg=arg, unit=unit)
+
+    @immutable_property
+    def output_dtype(self):
+        dtype = self.arg.type()
+        return dt.Interval(
+            unit=self.unit,
+            value_type=dtype.value_type,
+            nullable=dtype.nullable,
+        )
 
 
 @public
 class IntervalBinaryOp(BinaryOp):
-    def output_type(self):
-        args = [
+    @immutable_property
+    def output_dtype(self):
+        integer_args = [
             arg.cast(arg.type().value_type)
             if isinstance(arg.type(), dt.Interval)
             else arg
             for arg in self.args
         ]
-        expr = rlz.numeric_like(args, self.__class__.op)(self)
+        value_dtype = rlz._promote_numeric_binop(integer_args, self.op)
         left_dtype = self.left.type()
-        dtype_type = type(left_dtype)
-        additional_args = {
-            attr: getattr(left_dtype, attr)
-            for attr in left_dtype.argnames
-            if attr not in ("unit", "value_type")
-        }
-        dtype = dtype_type(left_dtype.unit, expr.type(), **additional_args)
-        return rlz.shape_like(self.args, dtype=dtype)
+        return dt.Interval(
+            unit=left_dtype.unit,
+            value_type=value_dtype,
+            nullable=left_dtype.nullable,
+        )
 
 
 @public
@@ -370,13 +410,15 @@ class IntervalFromInteger(ValueOp):
     arg = rlz.integer
     unit = rlz.isin({'Y', 'Q', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'})
 
+    output_shape = rlz.shape_like("arg")
+
+    @immutable_property
+    def output_dtype(self):
+        return dt.Interval(self.unit, self.arg.type())
+
     @property
     def resolution(self):
-        return dt.Interval(self.unit).resolution
-
-    def output_type(self):
-        dtype = dt.Interval(self.unit, self.arg.type())
-        return rlz.shape_like(self.arg, dtype=dtype)
+        return self.output_dtype.resolution
 
 
 @public

--- a/ibis/expr/operations/vectorized.py
+++ b/ibis/expr/operations/vectorized.py
@@ -11,12 +11,18 @@ from .reductions import Reduction
 class VectorizedUDF(ValueOp):
     func = rlz.instance_of((FunctionType, LambdaType))
     func_args = rlz.tuple_of(rlz.column(rlz.any))
+    # TODO(kszucs): should rename these arguments to
+    # input_dtypes and return_dtype
     input_type = rlz.tuple_of(rlz.datatype)
     return_type = rlz.datatype
 
     @property
     def inputs(self):
         return self.func_args
+
+    @property
+    def output_dtype(self):
+        return self.return_type
 
     def root_tables(self):
         return distinct_roots(*self.func_args)
@@ -26,21 +32,19 @@ class VectorizedUDF(ValueOp):
 class ElementWiseVectorizedUDF(VectorizedUDF):
     """Node for element wise UDF."""
 
-    def output_type(self):
-        return self.return_type.column_type()
+    output_shape = rlz.Shape.COLUMNAR
 
 
 @public
 class ReductionVectorizedUDF(VectorizedUDF, Reduction):
     """Node for reduction UDF."""
 
-    def output_type(self):
-        return self.return_type.scalar_type()
+    output_shape = rlz.Shape.SCALAR
 
 
+# TODO(kszucs): revisit
 @public
 class AnalyticVectorizedUDF(VectorizedUDF, AnalyticOp):
     """Node for analytics UDF."""
 
-    def output_type(self):
-        return self.return_type.column_type()
+    output_shape = rlz.Shape.COLUMNAR

--- a/ibis/expr/timecontext.py
+++ b/ibis/expr/timecontext.py
@@ -281,6 +281,14 @@ def adjust_context_node(
     return timecontext
 
 
+@adjust_context.register(ops.Alias)
+def adjust_context_alias(
+    op: ops.Node, scope: 'Scope', timecontext: TimeContext
+) -> TimeContext:
+    # For any node, by default, do not adjust time context
+    return adjust_context(op.arg.op(), scope, timecontext)
+
+
 @adjust_context.register(ops.AsOfJoin)
 def adjust_context_asof_join(
     op: ops.AsOfJoin, scope: 'Scope', timecontext: TimeContext

--- a/ibis/expr/types/analytic.py
+++ b/ibis/expr/types/analytic.py
@@ -3,25 +3,22 @@ from __future__ import annotations
 from public import public
 
 import ibis.common.exceptions as com
+import ibis.expr.types as ir
 
 from .core import Expr
 
 
 @public
 class AnalyticExpr(Expr):
-    @property
-    def _factory(self):
-        def factory(arg):
-            return type(self)(arg)
 
-        return factory
-
+    # TODO(kszucs): should be removed
     def type(self):
         return 'analytic'
 
 
 @public
 class ExistsExpr(AnalyticExpr):
+    # TODO(kszucs): should be removed
     def type(self):
         return 'exists'
 
@@ -35,6 +32,7 @@ class TopKExpr(AnalyticExpr):
         return self.to_filter()
 
     def to_filter(self):
+        # TODO: move to api.py
         import ibis.expr.operations as ops
 
         return ops.SummaryFilter(self).to_expr()
@@ -42,19 +40,19 @@ class TopKExpr(AnalyticExpr):
     def to_aggregation(
         self, metric_name=None, parent_table=None, backup_metric_name=None
     ):
-        """Convert the TopK operation to a table aggregation."""
-        from .relations import find_base_table
-
+        """
+        Convert the TopK operation to a table aggregation
+        """
         op = self.op()
 
-        arg_table = find_base_table(op.arg)
+        arg_table = ir.relations.find_base_table(op.arg)
 
         by = op.by
         if not isinstance(by, Expr):
             by = by(arg_table)
             by_table = arg_table
         else:
-            by_table = find_base_table(op.by)
+            by_table = ir.relations.find_base_table(op.by)
 
         if metric_name is None:
             if by.get_name() == op.arg.get_name():

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -71,6 +71,12 @@ class Expr:
 
     __nonzero__ = __bool__
 
+    def has_name(self):
+        return self.op().has_resolved_name()
+
+    def get_name(self):
+        return self.op().resolve_name()
+
     @cached_property
     def _safe_name(self) -> str | None:
         """Get the name of an expression `expr` if one exists
@@ -182,10 +188,6 @@ class Expr:
 
     def op(self) -> ops.Node:
         return self._arg
-
-    @property
-    def _factory(self) -> type[Expr]:
-        return type(self)
 
     def _find_backends(self) -> list[BaseBackend]:
         """Return the possible backends for an expression.

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -75,13 +75,6 @@ def _regular_join_method(
 
 @public
 class TableExpr(Expr):
-    @property
-    def _factory(self):
-        def factory(arg):
-            return TableExpr(arg)
-
-        return factory
-
     def _is_valid(self, exprs):
         try:
             self._assert_valid(util.promote_list(exprs))
@@ -170,10 +163,12 @@ class TableExpr(Expr):
     def __dir__(self):
         return sorted(frozenset(dir(type(self)) + self.columns))
 
+    # TODO(kszucs): should be removed
     def _resolve(self, exprs):
         exprs = util.promote_list(exprs)
-        return list(self._ensure_expr(x) for x in exprs)
+        return list(map(self._ensure_expr, exprs))
 
+    # TODO(kszucs): should be removed
     def _ensure_expr(self, expr):
         if isinstance(expr, str):
             return self[expr]
@@ -184,11 +179,13 @@ class TableExpr(Expr):
         else:
             return expr
 
+    # TODO(kszucs): should be removed
     def _get_type(self, name):
         return self._arg.get_type(name)
 
     def get_columns(self, iterable: Iterable[str]) -> list[ColumnExpr]:
-        """Get multiple columns from the table.
+        """
+        Get multiple columns from the table
 
         Examples
         --------
@@ -212,7 +209,8 @@ class TableExpr(Expr):
         return [self.get_column(x) for x in iterable]
 
     def get_column(self, name: str) -> ColumnExpr:
-        """Get a reference to a single column from the table.
+        """
+        Get a reference to a single column from the table
 
         Returns
         -------
@@ -229,7 +227,8 @@ class TableExpr(Expr):
         return list(self.schema().names)
 
     def schema(self) -> sch.Schema:
-        """Return the table's schema.
+        """
+        Get the schema for this table (if one is known)
 
         Returns
         -------
@@ -243,7 +242,8 @@ class TableExpr(Expr):
         by=None,
         **additional_grouping_expressions: Any,
     ) -> GroupedTableExpr:
-        """Create a grouped table expression.
+        """
+        Create a grouped table expression.
 
         Parameters
         ----------
@@ -556,8 +556,8 @@ class TableExpr(Expr):
             baz: 5
             qux: r0.foo + r0.bar
 
-        Use the [`ValueExpr.name`][ibis.expr.types.generic.ValueExpr.name]
-        method to name the new columns.
+        Use the [`name`][ibis.expr.types.generic.ValueExpr.name] method to name
+        the new columns.
 
         >>> new_columns = [ibis.literal(5).name('baz',),
         ...                (table.foo + table.bar).name('qux')]
@@ -881,7 +881,7 @@ class TableExpr(Expr):
         """
         expr = self._ensure_expr(expr)
 
-        if expr._name != name:
+        if expr._safe_name != name:
             expr = expr.name(name)
 
         if name not in self:

--- a/ibis/expr/types/sortkeys.py
+++ b/ibis/expr/types/sortkeys.py
@@ -12,8 +12,5 @@ from .generic import Expr
 
 @public
 class SortExpr(Expr):
-    def get_name(self) -> str | None:
-        return self.op().resolve_name()
-
     def type(self) -> dt.DataType:
         return self.op().expr.type()

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -89,7 +89,7 @@ class StructValue(AnyValue):
         DestructValue
             A destruct value expression.
         """
-        return DestructValue(self._arg, self._dtype).name("")
+        return DestructValue(self._arg)
 
 
 @public
@@ -105,7 +105,7 @@ class StructScalar(AnyScalar, StructValue):
         DestructScalar
             A destruct scalar expression.
         """
-        return DestructScalar(self._arg, self._dtype).name("")
+        return DestructScalar(self._arg)
 
 
 @public
@@ -121,7 +121,7 @@ class StructColumn(AnyColumn, StructValue):
         DestructColumn
             A destruct column expression.
         """
-        return DestructColumn(self._arg, self._dtype).name("")
+        return DestructColumn(self._arg)
 
 
 @public
@@ -131,6 +131,10 @@ class DestructValue(AnyValue):
     When assigning a destruct column, the field inside this destruct column
     will be destructured and assigned to multiple columnns.
     """
+
+    def name(self, name):
+        res = super().name(name)
+        return self.__class__(res.op())
 
 
 @public

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
     import pandas as pd
     from .. import types as ir
 
-from ... import util
 from .core import Expr, _binop
 from .generic import AnyColumn, AnyScalar, AnyValue
 
@@ -487,12 +486,11 @@ class TimestampColumn(TemporalColumn, TimestampValue):
 class IntervalValue(AnyValue):
     def to_unit(self, target_unit: str) -> IntervalValue:
         """Convert this interval to units of `target_unit`."""
-        if self._dtype.unit == target_unit:
-            return self
+        import ibis.expr.operations as ops
 
-        result = util.convert_unit(self, self._dtype.unit, target_unit)
-        object.__setattr__(result.type(), "unit", target_unit)
-        return result
+        # TODO(kszucs): should use a separate operation for unit conversion
+        # which we can rewrite/simplify to integer multiplication/division
+        return ops.ToIntervalUnit(self, unit=target_unit).to_expr()
 
     @property
     def years(self) -> ir.IntegerValue:

--- a/ibis/expr/visualize.py
+++ b/ibis/expr/visualize.py
@@ -20,7 +20,7 @@ def get_type(expr):
     except (AttributeError, NotImplementedError):
         try:
             # As a last resort try get the name of the output_type class
-            return expr.op().output_type().__name__
+            return expr.op().output_type.__name__
         except (AttributeError, NotImplementedError):
             return '\u2205'  # empty set character
     except com.IbisError:

--- a/ibis/tests/expr/conftest.py
+++ b/ibis/tests/expr/conftest.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
-
 import pytest
 
 import ibis
@@ -36,11 +34,6 @@ def schema():
         ('j', 'date'),
         ('k', 'time'),
     ]
-
-
-@pytest.fixture
-def schema_dict(schema):
-    return collections.OrderedDict(schema)
 
 
 @pytest.fixture

--- a/ibis/tests/expr/test_format.py
+++ b/ibis/tests/expr/test_format.py
@@ -203,9 +203,6 @@ def test_scalar_parameter_repr():
     value = ibis.param(dt.timestamp).name('value')
     assert repr(value) == "value: $(timestamp)"
 
-    value_op = value.op()
-    assert "ScalarParameter" in repr(value_op)
-
 
 def test_repr_exact():
     # NB: This is the only exact repr test. Do

--- a/ibis/tests/expr/test_lineage.py
+++ b/ibis/tests/expr/test_lineage.py
@@ -104,9 +104,11 @@ def test_lineage(companies):
         mutated.bucket,
         mutated,
         bucket.name('bucket'),
+        bucket,
         companies.funding_total_usd,
         companies,
     ]
+    assert len(results) == len(expected)
     for r, e in zip(results, expected):
         assert_equal(r, e)
 
@@ -115,9 +117,11 @@ def test_lineage(companies):
         filtered.bucket,
         filtered,
         bucket.name('bucket'),
+        bucket,
         companies.funding_total_usd,
         companies,
     ]
+    assert len(results) == len(expected)
     for r, e in zip(results, expected):
         assert_equal(r, e)
 
@@ -128,9 +132,11 @@ def test_lineage(companies):
         filtered.bucket,
         filtered,
         bucket.name('bucket'),
+        bucket,
         companies.funding_total_usd,
         companies,
     ]
+    assert len(results) == len(expected)
     for r, e in zip(results, expected):
         assert_equal(r, e)
 
@@ -171,9 +177,7 @@ def test_lineage_join(companies, rounds):
         rounds.company_city,
         rounds.raised_amount_usd,
     ]
-    perc_raised = (expr.raised_amount_usd / expr.funding_total_usd).name(
-        'perc_raised'
-    )
+    perc_raised = expr.raised_amount_usd / expr.funding_total_usd
     results = list(lin.lineage(perc_raised))
 
     expected = [
@@ -183,7 +187,6 @@ def test_lineage_join(companies, rounds):
         rounds.raised_amount_usd,
         rounds,
         expr.funding_total_usd,
-        # expr,  # *could* appear here as well, but we've already traversed it
         companies.funding_total_usd,
         companies,
     ]

--- a/ibis/tests/expr/test_operations.py
+++ b/ibis/tests/expr/test_operations.py
@@ -21,7 +21,6 @@ def test_operation():
 
 def test_ops_smoke():
     expr = ir.literal(3)
-    ops.UnaryOp(expr)
     ops.Cast(expr, to='int64')
     ops.TypeOf(arg=2)
     ops.Negate(4)
@@ -90,7 +89,8 @@ def test_instance_of_operation():
 def test_array_input():
     class MyOp(ops.ValueOp):
         value = rlz.value(dt.Array(dt.double))
-        output_type = rlz.typeof('value')
+        output_dtype = rlz.dtype_like('value')
+        output_shape = rlz.shape_like('value')
 
     raw_value = [1.0, 2.0, 3.0]
     op = MyOp(raw_value)
@@ -104,6 +104,7 @@ def test_custom_table_expr():
         pass
 
     class SpecialTable(ops.DatabaseTable):
+        @property
         def output_type(self):
             return MyTableExpr
 

--- a/ibis/tests/expr/test_rules.py
+++ b/ibis/tests/expr/test_rules.py
@@ -355,12 +355,6 @@ def test_table_with_schema_invalid(table):
         validator(table)
 
 
-def test_shape_like_with_no_arguments():
-    with pytest.raises(ValueError) as e:
-        rlz.shape_like([])
-    assert str(e.value) == 'Must pass at least one expression'
-
-
 @pytest.mark.parametrize(
     ('rule', 'input'),
     [

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -624,7 +624,7 @@ def test_complex_date_comparisons(
 def test_interval_column_name(table):
     c = table.i
     expr = (c - c).name('foo')
-    assert expr._name == 'foo'
+    assert expr.get_name() == 'foo'
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/expr/test_timestamp.py
+++ b/ibis/tests/expr/test_timestamp.py
@@ -42,7 +42,8 @@ def test_extract_fields(field, expected_operation, expected_type, alltypes):
     result = getattr(alltypes.i, field)()
     assert result.get_name() == field
     assert isinstance(result, expected_type)
-    assert isinstance(result.op(), expected_operation)
+    assert isinstance(result.op(), ops.Alias)
+    assert isinstance(result.op().arg.op(), expected_operation)
 
 
 def test_now():
@@ -77,12 +78,12 @@ def test_comparisons_string(alltypes):
     val = '2015-01-01 00:00:00'
     expr = alltypes.i > val
     op = expr.op()
-    assert isinstance(op.right, ir.TimestampScalar)
+    assert isinstance(op.right, ir.StringScalar)
 
     expr2 = val < alltypes.i
     op = expr2.op()
     assert isinstance(op, ops.Greater)
-    assert isinstance(op.right, ir.TimestampScalar)
+    assert isinstance(op.right, ir.StringScalar)
 
 
 def test_comparisons_pandas_timestamp(alltypes):
@@ -119,8 +120,10 @@ def test_timestamp_field_access_on_date(
 ):
     date_col = alltypes.i.date()
     result = getattr(date_col, field)()
+    assert result.get_name() == field
     assert isinstance(result, expected_type)
-    assert isinstance(result.op(), expected_operation)
+    assert isinstance(result.op(), ops.Alias)
+    assert isinstance(result.op().arg.op(), expected_operation)
 
 
 @pytest.mark.parametrize(
@@ -154,8 +157,10 @@ def test_timestamp_field_access_on_time(
 ):
     time_col = alltypes.i.time()
     result = getattr(time_col, field)()
+    assert result.get_name() == field
     assert isinstance(result, expected_type)
-    assert isinstance(result.op(), expected_operation)
+    assert isinstance(result.op(), ops.Alias)
+    assert isinstance(result.op().arg.op(), expected_operation)
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/expr/test_udf.py
+++ b/ibis/tests/expr/test_udf.py
@@ -40,9 +40,8 @@ def test_vectorized_udf_operations(table, klass, output_type):
     assert udf.input_type == tuple([dt.int8(), dt.string(), dt.boolean()])
     assert udf.return_type == dt.int8()
 
-    factory = udf.output_type()
-    expr = factory(udf)
-    assert isinstance(expr, output_type)
+    expr = udf.to_expr()
+    assert isinstance(expr, udf.output_type)
 
     with pytest.raises(com.IbisTypeError):
         # wrong function type

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1,4 +1,3 @@
-import functools
 import operator
 import uuid
 from collections import OrderedDict
@@ -323,7 +322,8 @@ def test_distinct_table(functional_alltypes):
 
 def test_nunique(functional_alltypes):
     expr = functional_alltypes.string_col.nunique()
-    assert isinstance(expr.op(), ops.CountDistinct)
+    assert isinstance(expr.op(), ops.Alias)
+    assert isinstance(expr.op().arg.op(), ops.CountDistinct)
 
 
 def test_isnull(table):
@@ -1019,11 +1019,12 @@ def test_custom_type_binary_operations():
 
         __radd__ = __add__
 
-    class FooNode(ops.ValueOp):
+    class FooNode(ops.Node):
         value = rlz.integer
 
+        @property
         def output_type(self):
-            return functools.partial(Foo, dtype=dt.int64)
+            return Foo
 
     left = ibis.literal(2)
     right = FooNode(3).to_expr()
@@ -1042,7 +1043,7 @@ def test_empty_array_as_argument():
     class Foo(ir.Expr):
         pass
 
-    class FooNode(ops.ValueOp):
+    class FooNode(ops.Node):
         value = rlz.value(dt.Array(dt.int64))
 
         def output_type(self):

--- a/ibis/tests/expr/test_visualize.py
+++ b/ibis/tests/expr/test_visualize.py
@@ -49,9 +49,7 @@ def test_custom_expr():
     class MyExprNode(ops.Node):
         foo = rlz.string
         bar = rlz.numeric
-
-        def output_type(self):
-            return MyExpr
+        output_type = MyExpr
 
     op = MyExprNode('Hello!', 42.3)
     expr = op.to_expr()
@@ -71,6 +69,7 @@ def test_custom_expr_with_not_implemented_type():
         foo = rlz.string
         bar = rlz.numeric
 
+        @property
         def output_type(self):
             return MyExpr
 


### PR DESCRIPTION
The point here is to not store any data in the expression classes but only the user facing API. This will enable us to keep a simpler operation hierarchy (without intermediare expressions) wrapped with a single top level user facing expression. 

A pretty small objective ended up as an invasive chage which highlights how coupled these module are. 

Though I managed to fix the majority of the issues, there are still multiple errors left. 