### PR TITLE
ci: fix racy workflow run test reports

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -4,21 +4,25 @@ on:
     workflows: ['Ibis', 'Backends']
     types:
       - completed
+    branches-ignore:
+      - master
+
+concurrency: report
+
 jobs:
   report:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
-    concurrency: report
     steps:
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
-          workflow_conclusion: completed
+          pr: ${{ github.event.pull_request.number }}
           path: artifacts
 
       - name: publish test report
         uses: EnricoMi/publish-unit-test-result-action@v1
         with:
-          commit: ${{ github.event.workflow_run.head_sha }}
+          commit: ${{ github.event.pull_request.head_sha }}
           files: artifacts/**/junit.xml


### PR DESCRIPTION
This PR fixes an issue with test reports overwriting each other in the case where a lot of builds are queued, by running against PRs instead of the latest completed workflow