### PR TITLE
ci: test latest postgres backend deps with python 3.7

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -122,7 +122,7 @@ jobs:
           path: junit.xml
 
   test_postgres:
-    name: PostgreSQL deps-${{ (matrix.deps && '') || 'un' }}bounded python-${{ matrix.python-version }}
+    name: PostgreSQL deps-${{ (matrix.deps && 'bounded') || 'unbounded' }} python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -122,7 +122,7 @@ jobs:
           path: junit.xml
 
   test_postgres:
-    name: PostgreSQL deps-${{ (matrix.deps && "") || "un" }}bounded python-${{ matrix.python-version }}
+    name: PostgreSQL deps-${{ (matrix.deps && '') || 'un' }}bounded python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -122,7 +122,7 @@ jobs:
           path: junit.xml
 
   test_postgres:
-    name: PostgreSQL ubuntu-latest python-${{ matrix.python-version }}
+    name: PostgreSQL ubuntu-latest deps-${{ (matrix.deps && "") || "un" }}bounded python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -122,7 +122,7 @@ jobs:
           path: junit.xml
 
   test_postgres:
-    name: PostgreSQL ubuntu-latest deps-${{ (matrix.deps && "") || "un" }}bounded python-${{ matrix.python-version }}
+    name: PostgreSQL deps-${{ (matrix.deps && "") || "un" }}bounded python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -204,7 +204,7 @@ jobs:
           path: junit.xml
 
   test_pyspark:
-    name: PySpark ${{ matrix.pyspark.version }} ubuntu-latest python-${{ matrix.python-version }}
+    name: PySpark ${{ matrix.pyspark.version }} python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -279,7 +279,7 @@ jobs:
           path: junit.xml
 
   test_impala:
-    name: Impala ubuntu-latest python-${{ matrix.python-version }}
+    name: Impala python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     env:
       IBIS_TEST_NN_HOST: localhost
@@ -386,7 +386,7 @@ jobs:
           path: junit.xml
 
   test_mysql_clickhouse:
-    name: ${{ matrix.backend.title }} ubuntu-latest python-${{ matrix.python-version }}
+    name: ${{ matrix.backend.title }} python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -460,7 +460,7 @@ jobs:
           path: junit.xml
 
   test_datafusion:
-    name: DataFusion ${{ matrix.datafusion-version }} ubuntu-latest python-${{ matrix.python-version }}
+    name: DataFusion ${{ matrix.datafusion-version }} python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -130,6 +130,8 @@ jobs:
         python-version:
           - "3.7"
           - "3.9"
+        deps:
+          - null
         include:
           - python-version: "3.7"
             deps:


### PR DESCRIPTION
This PR brings back an additional job which is running the postgres backend tests with 3.7 agains the latest set of dependencies for that backend