### PR TITLE
ci(docs): add dummy jobs that return in place of skipped required jobs

### DIFF
--- a/.github/workflows/ibis-backends-skip-helper.yml
+++ b/.github/workflows/ibis-backends-skip-helper.yml
@@ -1,0 +1,20 @@
+# This job intentionally collides with the Backend job in `ibis-backends.yml`
+# that would be skipped because the paths are ignored.  This is so the
+# `Backends` job isn't stuck in "expected" forever when it should be skipped
+name: Backends
+on:
+  push:
+    paths:
+      - "docs/**"
+    branches:
+      - master
+  pull_request:
+    paths:
+      - "docs/**"
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '

--- a/.github/workflows/ibis-main-skip-helper.yml
+++ b/.github/workflows/ibis-main-skip-helper.yml
@@ -1,0 +1,20 @@
+# This job intentionally collides with the Ibis job in `ibis-main.yml`
+# that would be skipped because the paths are ignored.  This is so the `Ibis`
+# job isn't stuck in "expected" forever when it should be skipped
+name: Ibis
+on:
+  push:
+    paths:
+      - "docs/**"
+    branches:
+      - master
+  pull_request:
+    paths:
+      - "docs/**"
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No build required" '


### PR DESCRIPTION
These intentionally collide with the jobs in `ibis-main.yml` and
`ibis-backends.yml` and run on the inverse of the path skipping logic
present in those two files.

This should allow CI to finish and all jobs to return, even if they're
skipped.

This is an ugly hack, but is the supported one for now:
https://github.com/github/docs/commit/4364076e0fb56c2579ae90cd048939eaa2c18954#diff-3052509b0e9a9ca90d0b911cc12c333506e652dbac7c7d5bd41d462be5c07dfdR48

Rendered docs for skipping procedure: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks