### PR TITLE
ci: run nix builds only when relevant files have changed

### DIFF
--- a/.github/workflows/ibis-backends-skip-helper.yml
+++ b/.github/workflows/ibis-backends-skip-helper.yml
@@ -14,7 +14,7 @@ on:
     branches:
       - master
 jobs:
-  build:
+  backends:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required" '
+      - run: echo "No build required"

--- a/.github/workflows/ibis-main-skip-helper.yml
+++ b/.github/workflows/ibis-main-skip-helper.yml
@@ -14,7 +14,7 @@ on:
     branches:
       - master
 jobs:
-  build:
+  main:
     runs-on: ubuntu-latest
     steps:
-      - run: 'echo "No build required" '
+      - run: echo "No build required"

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -42,34 +42,6 @@ jobs:
 
       - name: nix-linter
         run: nix shell -f ./nix nix-linter -c nix-linter $(find . -name '*.nix' -and \( -not -wholename '*nix/sources.nix' \))
-  nix:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
-    steps:
-      - name: checkout
-        uses: actions/checkout@v2
-
-      - name: install nix
-        uses: cachix/install-nix-action@v16
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable-small
-
-      - name: setup cachix
-        uses: cachix/cachix-action@v10
-        with:
-          name: ibis
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          extraPullNames: nix-community,poetry2nix
-
-      - name: nix build and run tests
-        run: nix build --keep-going --print-build-logs --file . --argstr python ${{ matrix.python-version }}
 
   test_no_backends:
     name: Test ${{ matrix.os }} python-${{ matrix.python-version }}
@@ -122,13 +94,8 @@ jobs:
           path: junit.xml
 
   benchmarks:
-    name: Benchmark ${{ matrix.os }} python-${{ matrix.python-version }}
+    name: Benchmarks
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version:
-          - "3.10"
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -137,7 +104,7 @@ jobs:
         uses: actions/setup-python@v2
         id: install_python
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
 
       - name: install system dependencies
         run: sudo apt-get install -qq -y build-essential cmake krb5-config python-dev libkrb5-dev libboost-all-dev
@@ -163,3 +130,11 @@ jobs:
 
           poetry run asv machine --yes
           poetry run asv dev
+  main:
+    runs-on: ubuntu-latest
+    needs:
+      - nix-lint
+      - test_no_backends
+      - benchmarks
+    steps:
+      - run: exit 0

--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -1,0 +1,36 @@
+# This job intentionally collides with the Nix job in `nix.yml`
+# that would be skipped because the paths are ignored.  This is so the `Nix`
+# job isn't stuck in "expected" forever when it should be skipped
+name: Nix
+
+on:
+  push:
+    paths-ignore:
+      - "**/*.nix"
+      - "pyproject.toml"
+      - "poetry.lock"
+      - "nix/**"
+    branches:
+      - master
+  pull_request:
+    paths-ignore:
+      - "**/*.nix"
+      - "pyproject.toml"
+      - "poetry.lock"
+      - "nix/**"
+    branches:
+      - master
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+    steps:
+      - run: echo "No build required"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,54 @@
+# vim: filetype=yaml
+name: Nix
+
+on:
+  push:
+    paths:
+      - "**/*.nix"
+      - "pyproject.toml"
+      - "poetry.lock"
+      - "nix/**"
+    branches:
+      - master
+  pull_request:
+    paths:
+      - "**/*.nix"
+      - "pyproject.toml"
+      - "poetry.lock"
+      - "nix/**"
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: install nix
+        uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable-small
+
+      - name: setup cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: ibis
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: nix-community,poetry2nix
+
+      - name: nix build and run tests
+        run: nix build --keep-going --print-build-logs --file . --argstr python ${{ matrix.python-version }}

--- a/default.nix
+++ b/default.nix
@@ -4,8 +4,24 @@
 let
   pkgs = import ./nix;
   drv =
-    { poetry2nix, python }:
+    { poetry2nix
+    , python
+    , lib
+    }:
 
+    let
+      backends = [
+        "csv"
+        "dask"
+        "datafusion"
+        "hdf5"
+        "pandas"
+        "parquet"
+        "sqlite"
+      ];
+
+      backendsString = lib.concatStringsSep " " backends;
+    in
     poetry2nix.mkPoetryApplication {
       inherit python;
 
@@ -26,15 +42,38 @@ let
       buildInputs = with pkgs; [ graphviz-nox ];
       checkInputs = with pkgs; [ graphviz-nox ];
 
+      preCheck = ''
+        export PYTEST_BACKENDS="${backendsString}"
+      '';
+
       checkPhase = ''
         runHook preCheck
-        pytest ibis/tests --numprocesses auto
+
+        tempdir="$(mktemp -d)"
+
+        cp -r ${pkgs.ibisTestingData}/* "$tempdir"
+
+        chmod -R u+rwx "$tempdir"
+
+        ln -s "$tempdir" ci/ibis-testing-data
+
+        for backend in ${backendsString}; do
+          python ci/datamgr.py "$backend" &
+        done
+
+        wait
+
+        pytest --numprocesses auto \
+          ibis/tests \
+          ibis/backends/tests \
+          ibis/backends/{${lib.concatStringsSep "," backends}}/tests
+
         runHook postCheck
       '';
 
       inherit doCheck;
 
-      pythonImportsCheck = [ "ibis" ];
+      pythonImportsCheck = [ "ibis" ] ++ (map (backend: "ibis.backends.${backend}") backends);
     };
 in
 pkgs.callPackage drv {

--- a/poetry.lock
+++ b/poetry.lock
@@ -703,7 +703,7 @@ test = ["pytest (!=5.3.4)", "pytest-cov", "flaky", "ipyparallel"]
 
 [[package]]
 name = "ipython"
-version = "7.31.0"
+version = "7.31.1"
 description = "IPython: Productive Interactive Computing"
 category = "dev"
 optional = false
@@ -2184,7 +2184,7 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.11"
-content-hash = "730cb160221b9a51b4f8d20b3647bfc664ab63da82a295a81f368b68e85f512b"
+content-hash = "c8a91bfe1596cd7cd1401544aac5d065bd7adf88ceb09d76dc11a50c30659f06"
 
 [metadata.files]
 alabaster = [
@@ -2628,8 +2628,8 @@ ipykernel = [
     {file = "ipykernel-6.7.0.tar.gz", hash = "sha256:d82b904fdc2fd8c7b1fbe0fa481c68a11b4cd4c8ef07e6517da1f10cc3114d24"},
 ]
 ipython = [
-    {file = "ipython-7.31.0-py3-none-any.whl", hash = "sha256:4c4234cdcc6b8f87c5b5c7af9899aa696ac5cfcf0e9f6d0688018bbee5c73bce"},
-    {file = "ipython-7.31.0.tar.gz", hash = "sha256:346c74db7312c41fa566d3be45d2e759a528dcc2994fe48aac1a03a70cd668a3"},
+    {file = "ipython-7.31.1-py3-none-any.whl", hash = "sha256:55df3e0bd0f94e715abd968bedd89d4e8a7bce4bf498fb123fed4f5398fea874"},
+    {file = "ipython-7.31.1.tar.gz", hash = "sha256:b5548ec5329a4bcf054a5deed5099b0f9622eb9ea51aaa7104d215fece201d8c"},
 ]
 ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ atpublic = ">=2.3,<3"
 cached_property = ">=1,<2"
 importlib-metadata = { version = ">=4,<5", python = "<3.8" }
 multipledispatch = ">=0.6,<0.7"
-numpy = { version = ">=1,<2" }
+numpy = ">=1,<2"
 pandas = ">=1.2.5,<2"
 parsy = ">=1.3.0,<2"
 regex = ">=2021.7.6"


### PR DESCRIPTION
This PR changes our nix builds to only when relevant files such as any nix files as well as dependency related files have changed.