### PR TITLE
feat: allow construction of decimal literals

### DIFF
--- a/ibis/expr/datatypes.py
+++ b/ibis/expr/datatypes.py
@@ -4,6 +4,7 @@ import ast
 import builtins
 import collections
 import datetime
+import decimal
 import enum
 import functools
 import itertools
@@ -1571,3 +1572,8 @@ def _str_to_uuid(typ: UUID, value: str) -> _uuid.UUID:
 @_normalize.register(String, _uuid.UUID)
 def _uuid_to_str(typ: String, value: _uuid.UUID) -> str:
     return str(value)
+
+
+@_normalize.register(Decimal, int)
+def _int_to_decimal(typ: Decimal, value: int) -> decimal.Decimal:
+    return decimal.Decimal(value).scaleb(-typ.scale)

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -1,4 +1,5 @@
 import datetime
+import decimal
 import enum
 import functools
 import itertools
@@ -242,6 +243,7 @@ class Literal(ValueOp):
                     tuple,
                     type(None),
                     uuid.UUID,
+                    decimal.Decimal,
                 )
             ),
             rlz.is_computable_input,


### PR DESCRIPTION
This PR allows the construction of decimal literals from strings, integers and decimal.Decimal objects. It will correctly adjust scale of the input depending the passed datatype