### PR TITLE
Remove full tree repr from rule validator error message

### DIFF
--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -447,11 +447,11 @@ def column_from(name, column, *, this):
                 return column
             else:
                 raise com.IbisTypeError(
-                    f"Passed column is not a column in {table}"
+                    f"Passed column is not a column in {type(table)}"
                 )
         except com.IbisError:
             raise com.IbisTypeError(
-                f"Cannot get column {maybe_column} from {table}"
+                f"Cannot get column {maybe_column} from {type(table)}"
             )
 
     raise com.IbisTypeError(


### PR DESCRIPTION
### Proposed Change
Avoid calling into the TableExpr's repr within these rule validator error messages, and instead use `type(table)`. Using the O(N) repr causes performance issues when called in a tight loop.

See this issue for a follow-up idea: https://github.com/ibis-project/ibis/issues/3334