### PR TITLE
fix: correct results when a group_by is followed by a filter

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -620,7 +620,12 @@ def apply_filter(expr, predicates):
         # Potential fusion opportunity
         # GH1344: We can't sub in things with correlated subqueries
         simplified_predicates = [
-            sub_for(predicate, [(expr, op.table)])
+            # Originally this line tried substituting op.table in for expr, but
+            # that is too aggressive in the presence of filters that occur
+            # after aggregations.
+            #
+            # See https://github.com/ibis-project/ibis/pull/3341 for details
+            sub_for(predicate, [(op.table, expr)])
             if not has_reduction(predicate)
             else predicate
             for predicate in predicates

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1361,3 +1361,14 @@ def test_multiple_db():
     con2 = MockAlchemyBackend()
 
     con1.table('alltypes').union(con2.table('alltypes')).execute()
+
+
+def test_filter_group_by_agg_with_same_name():
+    # GH 2907
+    t = ibis.table([("int_col", "int32"), ("bigint_col", "int64")], name="t")
+    expr = (
+        t.group_by("int_col")
+        .aggregate(bigint_col=lambda t: t.bigint_col.sum())
+        .filter(lambda t: t.bigint_col == 60)
+    )
+    assert isinstance(expr.op(), ops.Selection)

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1361,14 +1361,3 @@ def test_multiple_db():
     con2 = MockAlchemyBackend()
 
     con1.table('alltypes').union(con2.table('alltypes')).execute()
-
-
-def test_filter_group_by_agg_with_same_name():
-    # GH 2907
-    t = ibis.table([("int_col", "int32"), ("bigint_col", "int64")], name="t")
-    expr = (
-        t.group_by("int_col")
-        .aggregate(bigint_col=lambda t: t.bigint_col.sum())
-        .filter(lambda t: t.bigint_col == 60)
-    )
-    assert isinstance(expr.op(), ops.Selection)

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -2038,20 +2038,23 @@ ORDER BY `string_col`"""
         expr, _ = self._case_filter_self_join_analysis_bug()
 
         expected = """\
-SELECT t0.`region`, t0.`total` - t1.`total` AS `diff`
-FROM (
+WITH t0 AS (
   SELECT `region`, `kind`, sum(`amount`) AS `total`
   FROM purchases
-  WHERE `kind` = 'foo'
   GROUP BY 1, 2
-) t0
+)
+SELECT t1.`region`, t1.`total` - t2.`total` AS `diff`
+FROM (
+  SELECT *
+  FROM t0
+  WHERE `kind` = 'foo'
+) t1
   INNER JOIN (
-    SELECT `region`, `kind`, sum(`amount`) AS `total`
-    FROM purchases
+    SELECT *
+    FROM t0
     WHERE `kind` = 'bar'
-    GROUP BY 1, 2
-  ) t1
-    ON t0.`region` = t1.`region`"""
+  ) t2
+    ON t1.`region` = t2.`region`"""
         self._compare_sql(expr, expected)
 
     def test_join_filtered_tables_no_pushdown(self):


### PR DESCRIPTION
This PR addresses an annoying bug where filtering an aggregate column
after aggregation would get merged into its child. This optimization
is only valid for non-aggregate columns.

The solution here is to force incoming predicates to derive from the
aggregate table instead of trying to push them into the aggregate.

This allows projection fusion to continue to work, while fixing
#2907.

Here are the other approaches I tried before arriving at this solution:

1. Removal of the predicate pushdown code

This isn't viable because it breaks a number of APIs around projection and predicate creation

2. Adjusting the `blocks()` method to return `True` when an incoming column name overlaps with an
   aggregate column during substitution

This might be viable, but it was more code to change

Closes #2907
