### PR TITLE
fix: ibis.expr.signature.Parameter is not pickleable

### DIFF
--- a/ibis/expr/signature.py
+++ b/ibis/expr/signature.py
@@ -50,10 +50,16 @@ class Parameter(inspect.Parameter):
 
     __slots__ = ('_validator',)
 
-    def __init__(self, name, *, validator=EMPTY):
+    def __init__(
+        self,
+        name,
+        kind=inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        *,
+        validator=EMPTY
+    ):
         super().__init__(
             name,
-            kind=Parameter.POSITIONAL_OR_KEYWORD,
+            kind,
             default=None if isinstance(validator, Optional) else EMPTY,
         )
         self._validator = validator

--- a/ibis/tests/expr/test_signature.py
+++ b/ibis/tests/expr/test_signature.py
@@ -1,4 +1,3 @@
-import pickle
 from inspect import Signature
 
 import pytest
@@ -11,6 +10,7 @@ from ibis.expr.signature import (
     Parameter,
     Validator,
 )
+from ibis.tests.util import assert_pickle_roundtrip
 
 
 class ValidatorFunction(Validator):
@@ -310,11 +310,15 @@ def test_multiple_inheritance():
     assert strlen._reduction is True
 
 
-def test_pickling_support():
-    op = MagicString(arg="something", foo="magic", bar=True, baz=8)
-    raw = pickle.dumps(op)
-    loaded = pickle.loads(raw)
-    assert op == loaded
+@pytest.mark.parametrize(
+    "obj",
+    [
+        MagicString(arg="something", foo="magic", bar=True, baz=8),
+        Parameter("test"),
+    ],
+)
+def test_pickling_support(obj):
+    assert_pickle_roundtrip(obj)
 
 
 def test_multiple_inheritance_argument_order():

--- a/ibis/tests/util.py
+++ b/ibis/tests/util.py
@@ -22,7 +22,8 @@ def assert_equal(left, right):
 def assert_pickle_roundtrip(obj):
     """Assert that an ibis object remains the
     same after pickling and unpickling."""
-
-    raw = pickle.dumps(obj)
-    loaded = pickle.loads(raw)
-    assert obj.equals(loaded)
+    loaded = pickle.loads(pickle.dumps(obj))
+    if hasattr(obj, "equals"):
+        assert obj.equals(loaded)
+    else:
+        assert obj == loaded


### PR DESCRIPTION
Fixes https://github.com/ibis-project/ibis/issues/3358. 