### PR TITLE
fix: implement create_table correctly for pandas and dask backends

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,1 +1,4 @@
 !.github
+docs/source/tutorial/data/geography.json
+docs/source/tutorial/data/geography.db
+*.ipynb

--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -52,7 +52,8 @@ def test_load_data(client, npartitions):
 
 
 def test_create_table(client, npartitions):
-    client.create_table('testing', obj=make_dask_data_frame(npartitions))
+    ddf = make_dask_data_frame(npartitions)
+    client.create_table('testing', obj=ddf)
     assert 'testing' in client.list_tables()
     client.create_table('testingschema', schema=client.get_schema('testing'))
     assert 'testingschema' in client.list_tables()

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -96,13 +96,8 @@ def test_sql(backend, con, sql):
     con.sql(sql).execute()
 
 
-# test table
-
-
 @pytest.mark.xfail_unsupported
-@pytest.mark.xfail_backends(['pandas', 'dask'])
 def test_create_table_from_schema(con, backend, new_schema, temp_table):
-    # xfailing pandas and dask: #3020
     con.create_table(temp_table, schema=new_schema)
 
     t = con.table(temp_table)
@@ -114,7 +109,7 @@ def test_create_table_from_schema(con, backend, new_schema, temp_table):
 @pytest.mark.xfail_unsupported
 def test_rename_table(con, backend, temp_table, new_schema):
     if not hasattr(con, 'rename_table'):
-        pytest.xfail('{} backend doesn\'t have rename_table method.')
+        pytest.xfail(f"{backend.name} backend has no `rename_table` method")
 
     temp_table_original = f'{temp_table}_original'
     con.create_table(temp_table_original, schema=new_schema)
@@ -127,10 +122,9 @@ def test_rename_table(con, backend, temp_table, new_schema):
 
 
 @pytest.mark.xfail_unsupported
-@pytest.mark.xfail_backends(['impala', 'pyspark', 'spark', 'pandas', 'dask'])
+@pytest.mark.xfail_backends(['impala', 'pyspark', 'spark'])
 def test_nullable_input_output(con, backend, temp_table):
     # - Impala, PySpark and Spark non-nullable issues #2138 and #2137
-    # xfailing pandas and dask: #3020
     sch = ibis.schema(
         [
             ('foo', 'int64'),

--- a/ibis/common/exceptions.py
+++ b/ibis/common/exceptions.py
@@ -71,6 +71,10 @@ class UnsupportedArgumentError(IbisError):
     """UnsupportedArgumentError."""
 
 
+class BackendConversionError(IbisError):
+    """A backend cannot convert an input to its native type."""
+
+
 def mark_as_unsupported(f: Callable) -> Callable:
     """Decorate an unsupported method.
 


### PR DESCRIPTION
This PR addresses incorrect implementations of create_table in the pandas and dask backends.

The backends now store an additional dictionary mapping inferred or user-specified (when `create_table` is called)
ibis Schema objects, and uses those to construct `TableExpr`s from `client.table`.

Closes #3020.
