### PR TITLE
fix: expose ops.IfNull for mysql backend

### DIFF
--- a/ibis/backends/mysql/registry.py
+++ b/ibis/backends/mysql/registry.py
@@ -227,6 +227,7 @@ def _day_of_week_name(t, expr):
 operation_registry.update(
     {
         ops.Literal: _literal,
+        ops.IfNull: fixed_arity(sa.func.ifnull, 2),
         # strings
         ops.Substring: _substr,
         ops.StringFind: _string_find,

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -19,7 +19,7 @@ from ibis import literal as L
         (L(10).nullif(5), 10),
     ],
 )
-@pytest.mark.xfail_unsupported
+@pytest.mark.xfail_backends(["datafusion"])  # not implemented
 def test_fillna_nullif(backend, con, expr, expected):
     if expected is None:
         # The exact kind of null value used differs per backend (and version).


### PR DESCRIPTION
Quick fix to add `ops.IfNull` to the `mysql` backend and remove a now-unnecessary test decorator.