### PR TITLE
refactor: remove blanket __call__ for Expr

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -187,8 +187,6 @@ class Expr:
         else:
             return f(self, *args, **kwargs)
 
-    __call__ = pipe
-
     def op(self) -> ops.Node:
         return self._arg
 

--- a/ibis/tests/expr/test_pipe.py
+++ b/ibis/tests/expr/test_pipe.py
@@ -58,9 +58,3 @@ def test_pipe_pass_to_keyword(pipe_table):
     expected = pipe_table['value'] + 4
 
     assert result.equals(expected)
-
-
-def test_call_pipe_equivalence(pipe_table):
-    result = pipe_table(lambda x: x['key1'].cast('double').sum())
-    expected = pipe_table.key1.cast('double').sum()
-    assert result.equals(expected)


### PR DESCRIPTION
`__call__` is gone and it isn't coming back.

Resolves #2258

BREAKING CHANGE: `Expr() -> Expr.pipe()`