### PR TITLE
fix: disconnect from clickhouse when computing version

### DIFF
--- a/conda-lock/linux-64-3.7.lock
+++ b/conda-lock/linux-64-3.7.lock
@@ -94,7 +94,7 @@ https://conda.anaconda.org/conda-forge/linux-64/boost-cpp-1.74.0-h6cacc03_7.tar.
 https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h7f98852_6.tar.bz2#9e94bf16f14c78a36561d5019f490d22
 https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h10796ff_3.tar.bz2#21a8d66dc17f065023b33145c42652fe
 https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-13_linux64_openblas.tar.bz2#b17676dbd6688396c3a3076259fb7907
-https://conda.anaconda.org/conda-forge/linux-64/libglib-2.70.2-h174f98d_1.tar.bz2#d03a54631298fd1ab732ff65f6ed3a07
+https://conda.anaconda.org/conda-forge/linux-64/libglib-2.70.2-h174f98d_2.tar.bz2#6c9346fef15d50ef4db897bfbd0f0db6
 https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-13_linux64_openblas.tar.bz2#018b80e8f21d8560ae4961567e3e00c9
 https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.46.0-h812cca2_0.tar.bz2#507fa47e9075f889af8e8b72925379be
 https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.37-h21135ba_2.tar.bz2#b6acf807307d033d4b7e758b4f44b036
@@ -156,7 +156,7 @@ https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2#1
 https://conda.anaconda.org/conda-forge/noarch/parsy-1.3.0-pyhd8ed1ab_0.tar.bz2#94cd1a4bfe56d25b4e441c46e630b147
 https://conda.anaconda.org/conda-forge/noarch/pathspec-0.9.0-pyhd8ed1ab_0.tar.bz2#f93dc0ccbc0a8472624165f6e256c7d1
 https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2#415f0ebb6198cc2801c73438a9fb5761
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.3.0-pyhd8ed1ab_0.tar.bz2#7bc119135be2a43e1701432399d8c28a
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.4.1-pyhd8ed1ab_1.tar.bz2#ea1a07fd28b52b73239cacb4e39d380c
 https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2#359eeb6536da0e687af562ed265ec263
 https://conda.anaconda.org/conda-forge/noarch/pure-sasl-0.6.2-pyhd8ed1ab_0.tar.bz2#ac695eecf21ab48093bc33fd60b4102d
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
@@ -234,7 +234,7 @@ https://conda.anaconda.org/conda-forge/linux-64/rtree-0.9.7-py37h0b55af0_3.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/setuptools-59.8.0-py37h89c1867_0.tar.bz2#1da18279642c5070b8252f9ef937823e
 https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.3.23-py37h5e8e339_0.tar.bz2#a44874c02cf4967a3052009bf31bb3da
 https://conda.anaconda.org/conda-forge/linux-64/thrift-0.15.0-py37hcd2ae1e_1.tar.bz2#f92bedb410dfa58388294b9459cd789f
-https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.0-pyha770c72_0.tar.bz2#c15fc5814a1982a7a0bcafcde0c61e4d
+https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.1-pyha770c72_0.tar.bz2#bcb174bf45a1482a9c03c50eeb7e05b1
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.1-py37h5e8e339_2.tar.bz2#ec86ae00c96dea5f2d810957a8fabc26
 https://conda.anaconda.org/conda-forge/linux-64/typed-ast-1.4.3-py37h5e8e339_1.tar.bz2#d6843171ee158ea165e63faae1c6b640
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.0.1-hd8ed1ab_0.tar.bz2#c0d4ec4bcbceb927bff1103a997410d3
@@ -301,7 +301,7 @@ https://conda.anaconda.org/conda-forge/linux-64/pytables-3.7.0-py37h5dea08b_0.ta
 https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.0.2-py37hf9e9bfc_0.tar.bz2#9e57b04bbfa4292e83dfc55455bd11a0
 https://conda.anaconda.org/conda-forge/linux-64/tzlocal-4.1-py37h89c1867_1.tar.bz2#1cc88f5ac17f09e2d9bf1f276dfb6493
 https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_2.tar.bz2#5266fcd697043c59621fda522b3d78ee
-https://conda.anaconda.org/conda-forge/linux-64/clickhouse-driver-0.2.2-py37h5e8e339_1.tar.bz2#4972a25298f00947ac2c746176c87bef
+https://conda.anaconda.org/conda-forge/linux-64/clickhouse-driver-0.2.3-py37h5e8e339_0.tar.bz2#b979b6d5733dc0e67dec9835a8cbe4d2
 https://conda.anaconda.org/conda-forge/linux-64/gdal-3.4.0-py37h7b489ff_12.tar.bz2#3b9d250be7367ea13bb8f63560bc0bae
 https://conda.anaconda.org/conda-forge/noarch/jupytext-1.13.6-pyheef035f_0.tar.bz2#686b0fb2e2183e96ebb8faadbb491652
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-autorefs-0.3.1-pyhd8ed1ab_0.tar.bz2#29c8b44c216211e29b8b39c86f33c719
@@ -328,11 +328,11 @@ https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.11.0-pyhd8ed1ab_
 https://conda.anaconda.org/conda-forge/noarch/requests-2.27.1-pyhd8ed1ab_0.tar.bz2#7c1c427246b057b8fa97200ecdb2ed62
 https://conda.anaconda.org/conda-forge/noarch/clickhouse-sqlalchemy-0.1.8-pyhd8ed1ab_0.tar.bz2#48481fce44f344a572290d68456cb663
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2#44912901b45260e4338447b9d46f7058
-https://conda.anaconda.org/conda-forge/linux-64/ipykernel-6.8.0-py37h6531663_0.tar.bz2#9e5b91f887d82a77ac184150c83d9355
+https://conda.anaconda.org/conda-forge/linux-64/ipykernel-6.9.0-py37h6531663_0.tar.bz2#18dd74f70367f22ee70fcd28cd1c0ad3
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.5.0-pyhd8ed1ab_0.tar.bz2#1fdd1f3baccf0deb647385c677a1a48e
 https://conda.anaconda.org/conda-forge/noarch/questionary-1.10.0-pyhd8ed1ab_0.tar.bz2#360878a7fcb1d4aab3a05918be8b1397
 https://conda.anaconda.org/conda-forge/linux-64/requests-kerberos-0.12.0-py37h89c1867_3.tar.bz2#d8028e46104e85fd912c1bd6b5af32f6
-https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.4-pyhd8ed1ab_0.tar.bz2#89a6e0d0f0edcff4466f3c4a5d9a3281
+https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.5-pyhd8ed1ab_0.tar.bz2#084b9bbf396b64bd19a7302417b70faf
 https://conda.anaconda.org/conda-forge/noarch/geopandas-0.10.2-pyhd8ed1ab_1.tar.bz2#0682614964c1319304cfa554cbce90f0
 https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.6.0-pyhd8ed1ab_0.tar.bz2#6d826168a0cdc0ac13c33ae6a5bc4b43
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-jupyter-0.20.0-pyhd8ed1ab_0.tar.bz2#bb43006823fb14d16d02e283c0a0487b

--- a/conda-lock/linux-64-3.8.lock
+++ b/conda-lock/linux-64-3.8.lock
@@ -94,7 +94,7 @@ https://conda.anaconda.org/conda-forge/linux-64/boost-cpp-1.74.0-h6cacc03_7.tar.
 https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h7f98852_6.tar.bz2#9e94bf16f14c78a36561d5019f490d22
 https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h10796ff_3.tar.bz2#21a8d66dc17f065023b33145c42652fe
 https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-13_linux64_openblas.tar.bz2#b17676dbd6688396c3a3076259fb7907
-https://conda.anaconda.org/conda-forge/linux-64/libglib-2.70.2-h174f98d_1.tar.bz2#d03a54631298fd1ab732ff65f6ed3a07
+https://conda.anaconda.org/conda-forge/linux-64/libglib-2.70.2-h174f98d_2.tar.bz2#6c9346fef15d50ef4db897bfbd0f0db6
 https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-13_linux64_openblas.tar.bz2#018b80e8f21d8560ae4961567e3e00c9
 https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.46.0-h812cca2_0.tar.bz2#507fa47e9075f889af8e8b72925379be
 https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.37-h21135ba_2.tar.bz2#b6acf807307d033d4b7e758b4f44b036
@@ -156,7 +156,7 @@ https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2#1
 https://conda.anaconda.org/conda-forge/noarch/parsy-1.3.0-pyhd8ed1ab_0.tar.bz2#94cd1a4bfe56d25b4e441c46e630b147
 https://conda.anaconda.org/conda-forge/noarch/pathspec-0.9.0-pyhd8ed1ab_0.tar.bz2#f93dc0ccbc0a8472624165f6e256c7d1
 https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2#415f0ebb6198cc2801c73438a9fb5761
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.3.0-pyhd8ed1ab_0.tar.bz2#7bc119135be2a43e1701432399d8c28a
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.4.1-pyhd8ed1ab_1.tar.bz2#ea1a07fd28b52b73239cacb4e39d380c
 https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2#359eeb6536da0e687af562ed265ec263
 https://conda.anaconda.org/conda-forge/noarch/pure-sasl-0.6.2-pyhd8ed1ab_0.tar.bz2#ac695eecf21ab48093bc33fd60b4102d
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
@@ -235,7 +235,7 @@ https://conda.anaconda.org/conda-forge/linux-64/rtree-0.9.7-py38h02d302b_3.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/setuptools-60.7.1-py38h578d9bd_0.tar.bz2#8bf9c51a7e371df1673de909c1f46e6c
 https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.3.23-py38h497a2fe_0.tar.bz2#b717f380297da4ac057f543b3f373a72
 https://conda.anaconda.org/conda-forge/linux-64/thrift-0.15.0-py38h709712a_1.tar.bz2#32f0210055b8a89cb030e409b6bb142d
-https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.0-pyha770c72_0.tar.bz2#c15fc5814a1982a7a0bcafcde0c61e4d
+https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.1-pyha770c72_0.tar.bz2#bcb174bf45a1482a9c03c50eeb7e05b1
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.1-py38h497a2fe_2.tar.bz2#63b3b55c98b4239134e0be080f448944
 https://conda.anaconda.org/conda-forge/linux-64/typed-ast-1.5.2-py38h497a2fe_0.tar.bz2#082946878c5af9960bb639d993e3cda6
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.0.1-hd8ed1ab_0.tar.bz2#c0d4ec4bcbceb927bff1103a997410d3
@@ -306,7 +306,7 @@ https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.11.0-pyhd8ed1ab_
 https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.0.2-py38h1561384_0.tar.bz2#4a15e111a49087a5a36fc342904cf80b
 https://conda.anaconda.org/conda-forge/linux-64/tzlocal-4.1-py38h578d9bd_1.tar.bz2#669cb45465491c8697fb9fce6e2d19b5
 https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_2.tar.bz2#5266fcd697043c59621fda522b3d78ee
-https://conda.anaconda.org/conda-forge/linux-64/clickhouse-driver-0.2.2-py38h497a2fe_1.tar.bz2#8fd1e1c474e667cb559e75a67390b52a
+https://conda.anaconda.org/conda-forge/linux-64/clickhouse-driver-0.2.3-py38h497a2fe_0.tar.bz2#9e2b44c8bb593d08df8e0fb9e0d8575b
 https://conda.anaconda.org/conda-forge/linux-64/gdal-3.4.1-py38hcf2042a_2.tar.bz2#d33825e6073c1b9db6c025ed0ce0a743
 https://conda.anaconda.org/conda-forge/noarch/jupytext-1.13.6-pyheef035f_0.tar.bz2#686b0fb2e2183e96ebb8faadbb491652
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-autorefs-0.3.1-pyhd8ed1ab_0.tar.bz2#29c8b44c216211e29b8b39c86f33c719
@@ -328,10 +328,10 @@ https://conda.anaconda.org/conda-forge/noarch/pyspark-3.2.1-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/requests-2.27.1-pyhd8ed1ab_0.tar.bz2#7c1c427246b057b8fa97200ecdb2ed62
 https://conda.anaconda.org/conda-forge/noarch/clickhouse-sqlalchemy-0.1.8-pyhd8ed1ab_0.tar.bz2#48481fce44f344a572290d68456cb663
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2#44912901b45260e4338447b9d46f7058
-https://conda.anaconda.org/conda-forge/linux-64/ipykernel-6.8.0-py38he5a9106_0.tar.bz2#225f0cec77502274e561a937de2d727e
+https://conda.anaconda.org/conda-forge/linux-64/ipykernel-6.9.0-py38he5a9106_0.tar.bz2#c93e81250007423257352ecd4d4327a3
 https://conda.anaconda.org/conda-forge/noarch/questionary-1.10.0-pyhd8ed1ab_0.tar.bz2#360878a7fcb1d4aab3a05918be8b1397
 https://conda.anaconda.org/conda-forge/linux-64/requests-kerberos-0.12.0-py38h578d9bd_3.tar.bz2#21047b5928a4801ec0d70f2a4b2b7d74
-https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.4-pyhd8ed1ab_0.tar.bz2#89a6e0d0f0edcff4466f3c4a5d9a3281
+https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.5-pyhd8ed1ab_0.tar.bz2#084b9bbf396b64bd19a7302417b70faf
 https://conda.anaconda.org/conda-forge/noarch/geopandas-0.10.2-pyhd8ed1ab_1.tar.bz2#0682614964c1319304cfa554cbce90f0
 https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.6.0-pyhd8ed1ab_0.tar.bz2#6d826168a0cdc0ac13c33ae6a5bc4b43
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-jupyter-0.20.0-pyhd8ed1ab_0.tar.bz2#bb43006823fb14d16d02e283c0a0487b

--- a/conda-lock/linux-64-3.9.lock
+++ b/conda-lock/linux-64-3.9.lock
@@ -94,7 +94,7 @@ https://conda.anaconda.org/conda-forge/linux-64/boost-cpp-1.74.0-h6cacc03_7.tar.
 https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h7f98852_6.tar.bz2#9e94bf16f14c78a36561d5019f490d22
 https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h10796ff_3.tar.bz2#21a8d66dc17f065023b33145c42652fe
 https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-13_linux64_openblas.tar.bz2#b17676dbd6688396c3a3076259fb7907
-https://conda.anaconda.org/conda-forge/linux-64/libglib-2.70.2-h174f98d_1.tar.bz2#d03a54631298fd1ab732ff65f6ed3a07
+https://conda.anaconda.org/conda-forge/linux-64/libglib-2.70.2-h174f98d_2.tar.bz2#6c9346fef15d50ef4db897bfbd0f0db6
 https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-13_linux64_openblas.tar.bz2#018b80e8f21d8560ae4961567e3e00c9
 https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.46.0-h812cca2_0.tar.bz2#507fa47e9075f889af8e8b72925379be
 https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.37-h21135ba_2.tar.bz2#b6acf807307d033d4b7e758b4f44b036
@@ -156,7 +156,7 @@ https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2#1
 https://conda.anaconda.org/conda-forge/noarch/parsy-1.3.0-pyhd8ed1ab_0.tar.bz2#94cd1a4bfe56d25b4e441c46e630b147
 https://conda.anaconda.org/conda-forge/noarch/pathspec-0.9.0-pyhd8ed1ab_0.tar.bz2#f93dc0ccbc0a8472624165f6e256c7d1
 https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2#415f0ebb6198cc2801c73438a9fb5761
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.3.0-pyhd8ed1ab_0.tar.bz2#7bc119135be2a43e1701432399d8c28a
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.4.1-pyhd8ed1ab_1.tar.bz2#ea1a07fd28b52b73239cacb4e39d380c
 https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2#359eeb6536da0e687af562ed265ec263
 https://conda.anaconda.org/conda-forge/noarch/pure-sasl-0.6.2-pyhd8ed1ab_0.tar.bz2#ac695eecf21ab48093bc33fd60b4102d
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
@@ -235,7 +235,7 @@ https://conda.anaconda.org/conda-forge/linux-64/rtree-0.9.7-py39hb102c33_3.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/setuptools-60.7.1-py39hf3d152e_0.tar.bz2#e0bf562327832b7ca3c57c58714fccb2
 https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-1.3.23-py39h3811e60_0.tar.bz2#bd084e01505dce7307b7a9010e00d61a
 https://conda.anaconda.org/conda-forge/linux-64/thrift-0.15.0-py39he80948d_1.tar.bz2#cba1e99efebc344cfc59b9c872be2314
-https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.0-pyha770c72_0.tar.bz2#c15fc5814a1982a7a0bcafcde0c61e4d
+https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.1-pyha770c72_0.tar.bz2#bcb174bf45a1482a9c03c50eeb7e05b1
 https://conda.anaconda.org/conda-forge/linux-64/tornado-6.1-py39h3811e60_2.tar.bz2#5a7bb7af2f3bcf31ee6cd817de1d5011
 https://conda.anaconda.org/conda-forge/linux-64/typed-ast-1.5.2-py39h3811e60_0.tar.bz2#f26209afd5f3cb9adbf46002061f6214
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.0.1-hd8ed1ab_0.tar.bz2#c0d4ec4bcbceb927bff1103a997410d3
@@ -286,7 +286,7 @@ https://conda.anaconda.org/conda-forge/linux-64/watchdog-2.1.6-py39hf3d152e_1.ta
 https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.tar.bz2#b8152341fc3fc9880c6e1b9d188974e5
 https://conda.anaconda.org/conda-forge/linux-64/bcrypt-3.2.0-py39h3811e60_2.tar.bz2#75bc55c2b4d3d2499b8d0c4e085bdb72
 https://conda.anaconda.org/conda-forge/noarch/branca-0.4.2-pyhd8ed1ab_0.tar.bz2#836c975d3ae4f21c3cd047c10b15a7cf
-https://conda.anaconda.org/conda-forge/linux-64/clickhouse-driver-0.2.2-py39h3811e60_1.tar.bz2#5684957061b36c2eff1700bd3af29d75
+https://conda.anaconda.org/conda-forge/linux-64/clickhouse-driver-0.2.3-py39h3811e60_0.tar.bz2#37003c5995c90e18fb38bc9d4b62cbd4
 https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.10.2-pyha770c72_1.tar.bz2#10584badfcd9fa04e6fc9a4d5dad1513
 https://conda.anaconda.org/conda-forge/noarch/impyla-0.17.0-pyhd8ed1ab_2.tar.bz2#6c2b6b92dacfa3e9fb974849c16b6e80
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
@@ -326,10 +326,10 @@ https://conda.anaconda.org/conda-forge/noarch/pyspark-3.2.1-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/noarch/requests-2.27.1-pyhd8ed1ab_0.tar.bz2#7c1c427246b057b8fa97200ecdb2ed62
 https://conda.anaconda.org/conda-forge/noarch/clickhouse-sqlalchemy-0.1.8-pyhd8ed1ab_0.tar.bz2#48481fce44f344a572290d68456cb663
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2#44912901b45260e4338447b9d46f7058
-https://conda.anaconda.org/conda-forge/linux-64/ipykernel-6.8.0-py39hef51801_0.tar.bz2#39bd7c4a1da3b99090e56bedae414fc7
+https://conda.anaconda.org/conda-forge/linux-64/ipykernel-6.9.0-py39hef51801_0.tar.bz2#cf24e24c583c75ba5cc90096dff05100
 https://conda.anaconda.org/conda-forge/noarch/questionary-1.10.0-pyhd8ed1ab_0.tar.bz2#360878a7fcb1d4aab3a05918be8b1397
 https://conda.anaconda.org/conda-forge/linux-64/requests-kerberos-0.12.0-py39hf3d152e_3.tar.bz2#ad68764c2346f14a9d1f6fb5bf261950
-https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.4-pyhd8ed1ab_0.tar.bz2#89a6e0d0f0edcff4466f3c4a5d9a3281
+https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.5-pyhd8ed1ab_0.tar.bz2#084b9bbf396b64bd19a7302417b70faf
 https://conda.anaconda.org/conda-forge/noarch/geopandas-0.10.2-pyhd8ed1ab_1.tar.bz2#0682614964c1319304cfa554cbce90f0
 https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.6.0-pyhd8ed1ab_0.tar.bz2#6d826168a0cdc0ac13c33ae6a5bc4b43
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-jupyter-0.20.0-pyhd8ed1ab_0.tar.bz2#bb43006823fb14d16d02e283c0a0487b

--- a/conda-lock/osx-64-3.7.lock
+++ b/conda-lock/osx-64-3.7.lock
@@ -71,7 +71,7 @@ https://conda.anaconda.org/conda-forge/osx-64/glog-0.5.0-h25b26a9_0.tar.bz2#b255
 https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-hefd3b78_3.tar.bz2#07bbe01a1cabdb9ec0d35524e09f4db4
 https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.10-h815e4d9_4.tar.bz2#adc6c89498c5f6fe5ba874d8259e7eeb
 https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-9_3_0_h6c81a4c_23.tar.bz2#60f48cef2d50674e0428c5579b6c3f66
-https://conda.anaconda.org/conda-forge/osx-64/libglib-2.70.2-hf1fb8c0_1.tar.bz2#f7344cac7a1aeab96626fe1cd166a7d0
+https://conda.anaconda.org/conda-forge/osx-64/libglib-2.70.2-hf1fb8c0_2.tar.bz2#6fb63d5c0be45cc4327d80615bedd5e7
 https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.46.0-h6f36284_0.tar.bz2#4a3025e50e0a3bc33034b798c6846927
 https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.37-h7cec526_2.tar.bz2#9e52521faba2b53269672628d34e1513
 https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-3.19.4-hcf210ce_0.tar.bz2#00feb1836b9b452beb42a9cc4e6c45f4
@@ -136,7 +136,7 @@ https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2#1
 https://conda.anaconda.org/conda-forge/noarch/parsy-1.3.0-pyhd8ed1ab_0.tar.bz2#94cd1a4bfe56d25b4e441c46e630b147
 https://conda.anaconda.org/conda-forge/noarch/pathspec-0.9.0-pyhd8ed1ab_0.tar.bz2#f93dc0ccbc0a8472624165f6e256c7d1
 https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2#415f0ebb6198cc2801c73438a9fb5761
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.3.0-pyhd8ed1ab_0.tar.bz2#7bc119135be2a43e1701432399d8c28a
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.4.1-pyhd8ed1ab_1.tar.bz2#ea1a07fd28b52b73239cacb4e39d380c
 https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2#359eeb6536da0e687af562ed265ec263
 https://conda.anaconda.org/conda-forge/noarch/pure-sasl-0.6.2-pyhd8ed1ab_0.tar.bz2#ac695eecf21ab48093bc33fd60b4102d
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
@@ -216,7 +216,7 @@ https://conda.anaconda.org/conda-forge/osx-64/rtree-0.9.7-py37hf13911c_3.tar.bz2
 https://conda.anaconda.org/conda-forge/osx-64/setuptools-59.8.0-py37hf985489_0.tar.bz2#913beba86709488821743d712911ee2f
 https://conda.anaconda.org/conda-forge/osx-64/sqlalchemy-1.3.23-py37h7585375_0.tar.bz2#0064112e193874f87c6156ebf7c735ed
 https://conda.anaconda.org/conda-forge/osx-64/thrift-0.15.0-py37hd8d24ac_1.tar.bz2#3b960c4d272705630b3fa8bd9b572fa2
-https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.0-pyha770c72_0.tar.bz2#c15fc5814a1982a7a0bcafcde0c61e4d
+https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.1-pyha770c72_0.tar.bz2#bcb174bf45a1482a9c03c50eeb7e05b1
 https://conda.anaconda.org/conda-forge/osx-64/tornado-6.1-py37h271585c_2.tar.bz2#911332a9a0c80d78b11cfedd5274f5d4
 https://conda.anaconda.org/conda-forge/osx-64/typed-ast-1.4.3-py37h271585c_1.tar.bz2#3c6e037010baeedb6dde58c7ddd16f4a
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.0.1-hd8ed1ab_0.tar.bz2#c0d4ec4bcbceb927bff1103a997410d3
@@ -280,7 +280,7 @@ https://conda.anaconda.org/conda-forge/osx-64/scipy-1.7.3-py37h4e3cf02_0.tar.bz2
 https://conda.anaconda.org/conda-forge/osx-64/shapely-1.8.0-py37hd43bd85_4.tar.bz2#7b40c651e48d5580936245ff1f67134b
 https://conda.anaconda.org/conda-forge/osx-64/tzlocal-4.1-py37hf985489_1.tar.bz2#2ad426b2c1450440d4c4df98011d30dd
 https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_2.tar.bz2#5266fcd697043c59621fda522b3d78ee
-https://conda.anaconda.org/conda-forge/osx-64/clickhouse-driver-0.2.2-py37h271585c_1.tar.bz2#ff595722c5c2f7cc88474cc2e0a62942
+https://conda.anaconda.org/conda-forge/osx-64/clickhouse-driver-0.2.3-py37h271585c_0.tar.bz2#14fa7d3c6c0421aa7cb7d616d525f0ee
 https://conda.anaconda.org/conda-forge/osx-64/gdal-3.4.0-py37h005c65d_12.tar.bz2#ddc9802e2d2c86a4e6b71c3faf692554
 https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.10.2-pyha770c72_1.tar.bz2#10584badfcd9fa04e6fc9a4d5dad1513
 https://conda.anaconda.org/conda-forge/noarch/jupytext-1.13.6-pyheef035f_0.tar.bz2#686b0fb2e2183e96ebb8faadbb491652
@@ -310,12 +310,12 @@ https://conda.anaconda.org/conda-forge/noarch/pytest-randomly-3.11.0-pyhd8ed1ab_
 https://conda.anaconda.org/conda-forge/noarch/requests-2.27.1-pyhd8ed1ab_0.tar.bz2#7c1c427246b057b8fa97200ecdb2ed62
 https://conda.anaconda.org/conda-forge/noarch/clickhouse-sqlalchemy-0.1.8-pyhd8ed1ab_0.tar.bz2#48481fce44f344a572290d68456cb663
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2#44912901b45260e4338447b9d46f7058
-https://conda.anaconda.org/conda-forge/osx-64/ipykernel-6.8.0-py37h4c52d7d_0.tar.bz2#676d2aee26ba1bcfdb8c43d7cec53d37
+https://conda.anaconda.org/conda-forge/osx-64/ipykernel-6.9.0-py37h4c52d7d_0.tar.bz2#01c293825884c7031a9415e769a60b9d
 https://conda.anaconda.org/conda-forge/noarch/pyspark-3.2.1-pyhd8ed1ab_0.tar.bz2#99883d37054647870c3c68f7d0691027
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.5.0-pyhd8ed1ab_0.tar.bz2#1fdd1f3baccf0deb647385c677a1a48e
 https://conda.anaconda.org/conda-forge/noarch/questionary-1.10.0-pyhd8ed1ab_0.tar.bz2#360878a7fcb1d4aab3a05918be8b1397
 https://conda.anaconda.org/conda-forge/osx-64/requests-kerberos-0.12.0-py37hf985489_3.tar.bz2#d2637d168e233ce922a5d97d27eb6923
-https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.4-pyhd8ed1ab_0.tar.bz2#89a6e0d0f0edcff4466f3c4a5d9a3281
+https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.5-pyhd8ed1ab_0.tar.bz2#084b9bbf396b64bd19a7302417b70faf
 https://conda.anaconda.org/conda-forge/noarch/geopandas-0.10.2-pyhd8ed1ab_1.tar.bz2#0682614964c1319304cfa554cbce90f0
 https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.6.0-pyhd8ed1ab_0.tar.bz2#6d826168a0cdc0ac13c33ae6a5bc4b43
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-jupyter-0.20.0-pyhd8ed1ab_0.tar.bz2#bb43006823fb14d16d02e283c0a0487b

--- a/conda-lock/osx-64-3.8.lock
+++ b/conda-lock/osx-64-3.8.lock
@@ -71,7 +71,7 @@ https://conda.anaconda.org/conda-forge/osx-64/glog-0.5.0-h25b26a9_0.tar.bz2#b255
 https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-hefd3b78_3.tar.bz2#07bbe01a1cabdb9ec0d35524e09f4db4
 https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.10-h815e4d9_4.tar.bz2#adc6c89498c5f6fe5ba874d8259e7eeb
 https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-9_3_0_h6c81a4c_23.tar.bz2#60f48cef2d50674e0428c5579b6c3f66
-https://conda.anaconda.org/conda-forge/osx-64/libglib-2.70.2-hf1fb8c0_1.tar.bz2#f7344cac7a1aeab96626fe1cd166a7d0
+https://conda.anaconda.org/conda-forge/osx-64/libglib-2.70.2-hf1fb8c0_2.tar.bz2#6fb63d5c0be45cc4327d80615bedd5e7
 https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.46.0-h6f36284_0.tar.bz2#4a3025e50e0a3bc33034b798c6846927
 https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.37-h7cec526_2.tar.bz2#9e52521faba2b53269672628d34e1513
 https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-3.19.4-hcf210ce_0.tar.bz2#00feb1836b9b452beb42a9cc4e6c45f4
@@ -136,7 +136,7 @@ https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2#1
 https://conda.anaconda.org/conda-forge/noarch/parsy-1.3.0-pyhd8ed1ab_0.tar.bz2#94cd1a4bfe56d25b4e441c46e630b147
 https://conda.anaconda.org/conda-forge/noarch/pathspec-0.9.0-pyhd8ed1ab_0.tar.bz2#f93dc0ccbc0a8472624165f6e256c7d1
 https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2#415f0ebb6198cc2801c73438a9fb5761
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.3.0-pyhd8ed1ab_0.tar.bz2#7bc119135be2a43e1701432399d8c28a
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.4.1-pyhd8ed1ab_1.tar.bz2#ea1a07fd28b52b73239cacb4e39d380c
 https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2#359eeb6536da0e687af562ed265ec263
 https://conda.anaconda.org/conda-forge/noarch/pure-sasl-0.6.2-pyhd8ed1ab_0.tar.bz2#ac695eecf21ab48093bc33fd60b4102d
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
@@ -217,7 +217,7 @@ https://conda.anaconda.org/conda-forge/osx-64/rtree-0.9.7-py38hc59ffc2_3.tar.bz2
 https://conda.anaconda.org/conda-forge/osx-64/setuptools-60.7.1-py38h50d1736_0.tar.bz2#769f3700e9a297dc281a0d1fd9ad87e7
 https://conda.anaconda.org/conda-forge/osx-64/sqlalchemy-1.3.23-py38hca655e8_0.tar.bz2#d825e0437232e013f80c6898a0be600e
 https://conda.anaconda.org/conda-forge/osx-64/thrift-0.15.0-py38ha048514_1.tar.bz2#d6ba2b6f92ed7e3963fb20f37cf90b56
-https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.0-pyha770c72_0.tar.bz2#c15fc5814a1982a7a0bcafcde0c61e4d
+https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.1-pyha770c72_0.tar.bz2#bcb174bf45a1482a9c03c50eeb7e05b1
 https://conda.anaconda.org/conda-forge/osx-64/tornado-6.1-py38h96a0964_2.tar.bz2#b0d3b8b55486dfd64167129b439e3959
 https://conda.anaconda.org/conda-forge/osx-64/typed-ast-1.5.2-py38h96a0964_0.tar.bz2#2e8dab16927b3f6eae5df014226552a7
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.0.1-hd8ed1ab_0.tar.bz2#c0d4ec4bcbceb927bff1103a997410d3
@@ -285,7 +285,7 @@ https://conda.anaconda.org/conda-forge/osx-64/scipy-1.8.0-py38hd329d04_0.tar.bz2
 https://conda.anaconda.org/conda-forge/osx-64/shapely-1.8.0-py38hf980569_5.tar.bz2#e2c81aa189660144fcce943b28f85581
 https://conda.anaconda.org/conda-forge/osx-64/tzlocal-4.1-py38h50d1736_1.tar.bz2#ff12d3363eb17732a74151d93a555712
 https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_2.tar.bz2#5266fcd697043c59621fda522b3d78ee
-https://conda.anaconda.org/conda-forge/osx-64/clickhouse-driver-0.2.2-py38h96a0964_1.tar.bz2#cbd616071f1b46ddd535f80aaac5c816
+https://conda.anaconda.org/conda-forge/osx-64/clickhouse-driver-0.2.3-py38h96a0964_0.tar.bz2#e2ff4c270bb75921cfb0dc629f7c99a5
 https://conda.anaconda.org/conda-forge/osx-64/gdal-3.4.1-py38hf509309_2.tar.bz2#ebde7cba0379a8762d8436fd5d68504a
 https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.10.2-pyha770c72_1.tar.bz2#10584badfcd9fa04e6fc9a4d5dad1513
 https://conda.anaconda.org/conda-forge/noarch/jupytext-1.13.6-pyheef035f_0.tar.bz2#686b0fb2e2183e96ebb8faadbb491652
@@ -310,11 +310,11 @@ https://conda.anaconda.org/conda-forge/osx-64/pyarrow-6.0.1-py38h2688f9d_8_cpu.t
 https://conda.anaconda.org/conda-forge/noarch/requests-2.27.1-pyhd8ed1ab_0.tar.bz2#7c1c427246b057b8fa97200ecdb2ed62
 https://conda.anaconda.org/conda-forge/noarch/clickhouse-sqlalchemy-0.1.8-pyhd8ed1ab_0.tar.bz2#48481fce44f344a572290d68456cb663
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2#44912901b45260e4338447b9d46f7058
-https://conda.anaconda.org/conda-forge/osx-64/ipykernel-6.8.0-py38h5fd9f69_0.tar.bz2#379db6c9313e85af5c267de33472b236
+https://conda.anaconda.org/conda-forge/osx-64/ipykernel-6.9.0-py38h5fd9f69_0.tar.bz2#1d83a8038c11bd6218062c1dace8e562
 https://conda.anaconda.org/conda-forge/noarch/pyspark-3.2.1-pyhd8ed1ab_0.tar.bz2#99883d37054647870c3c68f7d0691027
 https://conda.anaconda.org/conda-forge/noarch/questionary-1.10.0-pyhd8ed1ab_0.tar.bz2#360878a7fcb1d4aab3a05918be8b1397
 https://conda.anaconda.org/conda-forge/osx-64/requests-kerberos-0.12.0-py38h50d1736_3.tar.bz2#33d3d21dfa0ba93185473dd50294fe78
-https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.4-pyhd8ed1ab_0.tar.bz2#89a6e0d0f0edcff4466f3c4a5d9a3281
+https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.5-pyhd8ed1ab_0.tar.bz2#084b9bbf396b64bd19a7302417b70faf
 https://conda.anaconda.org/conda-forge/noarch/geopandas-0.10.2-pyhd8ed1ab_1.tar.bz2#0682614964c1319304cfa554cbce90f0
 https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.6.0-pyhd8ed1ab_0.tar.bz2#6d826168a0cdc0ac13c33ae6a5bc4b43
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-jupyter-0.20.0-pyhd8ed1ab_0.tar.bz2#bb43006823fb14d16d02e283c0a0487b

--- a/conda-lock/osx-64-3.9.lock
+++ b/conda-lock/osx-64-3.9.lock
@@ -71,7 +71,7 @@ https://conda.anaconda.org/conda-forge/osx-64/glog-0.5.0-h25b26a9_0.tar.bz2#b255
 https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-hefd3b78_3.tar.bz2#07bbe01a1cabdb9ec0d35524e09f4db4
 https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.10-h815e4d9_4.tar.bz2#adc6c89498c5f6fe5ba874d8259e7eeb
 https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-9_3_0_h6c81a4c_23.tar.bz2#60f48cef2d50674e0428c5579b6c3f66
-https://conda.anaconda.org/conda-forge/osx-64/libglib-2.70.2-hf1fb8c0_1.tar.bz2#f7344cac7a1aeab96626fe1cd166a7d0
+https://conda.anaconda.org/conda-forge/osx-64/libglib-2.70.2-hf1fb8c0_2.tar.bz2#6fb63d5c0be45cc4327d80615bedd5e7
 https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.46.0-h6f36284_0.tar.bz2#4a3025e50e0a3bc33034b798c6846927
 https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.37-h7cec526_2.tar.bz2#9e52521faba2b53269672628d34e1513
 https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-3.19.4-hcf210ce_0.tar.bz2#00feb1836b9b452beb42a9cc4e6c45f4
@@ -136,7 +136,7 @@ https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2#1
 https://conda.anaconda.org/conda-forge/noarch/parsy-1.3.0-pyhd8ed1ab_0.tar.bz2#94cd1a4bfe56d25b4e441c46e630b147
 https://conda.anaconda.org/conda-forge/noarch/pathspec-0.9.0-pyhd8ed1ab_0.tar.bz2#f93dc0ccbc0a8472624165f6e256c7d1
 https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2#415f0ebb6198cc2801c73438a9fb5761
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.3.0-pyhd8ed1ab_0.tar.bz2#7bc119135be2a43e1701432399d8c28a
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.4.1-pyhd8ed1ab_1.tar.bz2#ea1a07fd28b52b73239cacb4e39d380c
 https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2#359eeb6536da0e687af562ed265ec263
 https://conda.anaconda.org/conda-forge/noarch/pure-sasl-0.6.2-pyhd8ed1ab_0.tar.bz2#ac695eecf21ab48093bc33fd60b4102d
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
@@ -217,7 +217,7 @@ https://conda.anaconda.org/conda-forge/osx-64/rtree-0.9.7-py39h7d0d40a_3.tar.bz2
 https://conda.anaconda.org/conda-forge/osx-64/setuptools-60.7.1-py39h6e9494a_0.tar.bz2#e61928bcc7cc612d00a32258e4afed1e
 https://conda.anaconda.org/conda-forge/osx-64/sqlalchemy-1.3.23-py39h4b0b724_0.tar.bz2#7473fdb4a50cd477f30438f11041bf6e
 https://conda.anaconda.org/conda-forge/osx-64/thrift-0.15.0-py39h9fcab8e_1.tar.bz2#9c72937f8ebf51eabe2e18897c9718bd
-https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.0-pyha770c72_0.tar.bz2#c15fc5814a1982a7a0bcafcde0c61e4d
+https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.1-pyha770c72_0.tar.bz2#bcb174bf45a1482a9c03c50eeb7e05b1
 https://conda.anaconda.org/conda-forge/osx-64/tornado-6.1-py39h89e85a6_2.tar.bz2#32d59d66d08f06a706865721ca8dd91d
 https://conda.anaconda.org/conda-forge/osx-64/typed-ast-1.5.2-py39h89e85a6_0.tar.bz2#16e738eaa71953d7b55822f606d5516e
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.0.1-hd8ed1ab_0.tar.bz2#c0d4ec4bcbceb927bff1103a997410d3
@@ -265,7 +265,7 @@ https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.ta
 https://conda.anaconda.org/conda-forge/osx-64/arrow-cpp-6.0.1-py39hf938c1e_8_cpu.tar.bz2#122faa4a8b85d5a5a9925831c448f18b
 https://conda.anaconda.org/conda-forge/osx-64/bcrypt-3.2.0-py39h89e85a6_2.tar.bz2#17f21e36164640da050c20f8e8940c4a
 https://conda.anaconda.org/conda-forge/noarch/branca-0.4.2-pyhd8ed1ab_0.tar.bz2#836c975d3ae4f21c3cd047c10b15a7cf
-https://conda.anaconda.org/conda-forge/osx-64/clickhouse-driver-0.2.2-py39h89e85a6_1.tar.bz2#ceb267269b7f9d292e60431cd51ef7e4
+https://conda.anaconda.org/conda-forge/osx-64/clickhouse-driver-0.2.3-py39h89e85a6_0.tar.bz2#2442c0bd7fbf27add0ab7a20669b60c9
 https://conda.anaconda.org/conda-forge/noarch/impyla-0.17.0-pyhd8ed1ab_2.tar.bz2#6c2b6b92dacfa3e9fb974849c16b6e80
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.4.1-h6c40076_2.tar.bz2#d5b22f87e0509dfe4197a5978d01b04a
@@ -308,11 +308,11 @@ https://conda.anaconda.org/conda-forge/osx-64/pyarrow-6.0.1-py39h4d6536f_8_cpu.t
 https://conda.anaconda.org/conda-forge/noarch/requests-2.27.1-pyhd8ed1ab_0.tar.bz2#7c1c427246b057b8fa97200ecdb2ed62
 https://conda.anaconda.org/conda-forge/noarch/clickhouse-sqlalchemy-0.1.8-pyhd8ed1ab_0.tar.bz2#48481fce44f344a572290d68456cb663
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2#44912901b45260e4338447b9d46f7058
-https://conda.anaconda.org/conda-forge/osx-64/ipykernel-6.8.0-py39h71a6800_0.tar.bz2#4846379626dc580188942cc764ce8b26
+https://conda.anaconda.org/conda-forge/osx-64/ipykernel-6.9.0-py39h71a6800_0.tar.bz2#7b562fb06f4b2fbd813da439b1341091
 https://conda.anaconda.org/conda-forge/noarch/pyspark-3.2.1-pyhd8ed1ab_0.tar.bz2#99883d37054647870c3c68f7d0691027
 https://conda.anaconda.org/conda-forge/noarch/questionary-1.10.0-pyhd8ed1ab_0.tar.bz2#360878a7fcb1d4aab3a05918be8b1397
 https://conda.anaconda.org/conda-forge/osx-64/requests-kerberos-0.12.0-py39h6e9494a_3.tar.bz2#4897112312572510e448cacc3cc3e477
-https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.4-pyhd8ed1ab_0.tar.bz2#89a6e0d0f0edcff4466f3c4a5d9a3281
+https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.5-pyhd8ed1ab_0.tar.bz2#084b9bbf396b64bd19a7302417b70faf
 https://conda.anaconda.org/conda-forge/noarch/geopandas-0.10.2-pyhd8ed1ab_1.tar.bz2#0682614964c1319304cfa554cbce90f0
 https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.6.0-pyhd8ed1ab_0.tar.bz2#6d826168a0cdc0ac13c33ae6a5bc4b43
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-jupyter-0.20.0-pyhd8ed1ab_0.tar.bz2#bb43006823fb14d16d02e283c0a0487b

--- a/conda-lock/win-64-3.7.lock
+++ b/conda-lock/win-64-3.7.lock
@@ -98,7 +98,7 @@ https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h0e5069d_3.tar.bz2#e63
 https://conda.anaconda.org/conda-forge/noarch/idna-3.3-pyhd8ed1ab_0.tar.bz2#40b50b8b030f5f2f22085c062ed013dd
 https://conda.anaconda.org/conda-forge/noarch/iniconfig-1.1.1-pyh9f0ad1d_0.tar.bz2#39161f81cc5e5ca45b8226fbb06c6905
 https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2#5071c982548b3a20caf70462f04f5287
-https://conda.anaconda.org/conda-forge/win-64/libglib-2.70.2-h3be07f2_1.tar.bz2#44c08484ca6321c1a13af600bbb56732
+https://conda.anaconda.org/conda-forge/win-64/libglib-2.70.2-h3be07f2_2.tar.bz2#9bf0fee1ab469a9343701c528b002d7b
 https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.18-pthreads_hc469a61_0.tar.bz2#249ba301d82d6985ba54453a107ae5db
 https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.37-h1d00b33_2.tar.bz2#005ddb14b8f876ed6a85b76dfc9892db
 https://conda.anaconda.org/conda-forge/win-64/libpq-14.1-hfcc5ef8_1.tar.bz2#e23697046d104225361a5b7d264b467d
@@ -118,7 +118,7 @@ https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2#1
 https://conda.anaconda.org/conda-forge/noarch/parsy-1.3.0-pyhd8ed1ab_0.tar.bz2#94cd1a4bfe56d25b4e441c46e630b147
 https://conda.anaconda.org/conda-forge/noarch/pathspec-0.9.0-pyhd8ed1ab_0.tar.bz2#f93dc0ccbc0a8472624165f6e256c7d1
 https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2#415f0ebb6198cc2801c73438a9fb5761
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.3.0-pyhd8ed1ab_0.tar.bz2#7bc119135be2a43e1701432399d8c28a
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.4.1-pyhd8ed1ab_1.tar.bz2#ea1a07fd28b52b73239cacb4e39d380c
 https://conda.anaconda.org/conda-forge/noarch/pure-sasl-0.6.2-pyhd8ed1ab_0.tar.bz2#ac695eecf21ab48093bc33fd60b4102d
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
 https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-8.0.0-pyhd8ed1ab_0.tar.bz2#37a9a8874b2e62987f8dc2434688f3cf
@@ -193,7 +193,7 @@ https://conda.anaconda.org/conda-forge/win-64/rtree-0.9.7-py37h13cc57e_3.tar.bz2
 https://conda.anaconda.org/conda-forge/win-64/setuptools-59.8.0-py37h03978a9_0.tar.bz2#f4f151f5d150a6e1707237a3ff0d726c
 https://conda.anaconda.org/conda-forge/win-64/sqlalchemy-1.3.23-py37hcc03f2d_0.tar.bz2#0b97aef724f52b6c07c1584c61710c77
 https://conda.anaconda.org/conda-forge/win-64/thrift-0.15.0-py37hf2a7229_1.tar.bz2#82f0d24080186b5a916414da573307f8
-https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.0-pyha770c72_0.tar.bz2#c15fc5814a1982a7a0bcafcde0c61e4d
+https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.1-pyha770c72_0.tar.bz2#bcb174bf45a1482a9c03c50eeb7e05b1
 https://conda.anaconda.org/conda-forge/win-64/tornado-6.1-py37hcc03f2d_2.tar.bz2#09aafcab336a493c1ac0e2649935b1ee
 https://conda.anaconda.org/conda-forge/win-64/typed-ast-1.4.3-py37hcc03f2d_1.tar.bz2#dee34ceff7900fac84e0c2de628e8024
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.0.1-hd8ed1ab_0.tar.bz2#c0d4ec4bcbceb927bff1103a997410d3
@@ -263,7 +263,7 @@ https://conda.anaconda.org/conda-forge/win-64/tiledb-2.5.3-h95dad36_0.tar.bz2#d7
 https://conda.anaconda.org/conda-forge/win-64/tzlocal-4.1-py37h03978a9_1.tar.bz2#dd577bb20e5f51ca2e660bb060686117
 https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_2.tar.bz2#5266fcd697043c59621fda522b3d78ee
 https://conda.anaconda.org/conda-forge/win-64/arrow-cpp-6.0.1-py37hb54f6c8_8_cpu.tar.bz2#9bbddc4123090e5e5785e569455cf2e6
-https://conda.anaconda.org/conda-forge/win-64/clickhouse-driver-0.2.2-py37hcc03f2d_1.tar.bz2#e27691a574d1ec17cf19fc897676eeab
+https://conda.anaconda.org/conda-forge/win-64/clickhouse-driver-0.2.3-py37hcc03f2d_0.tar.bz2#e2086c2dba5d6b0576032abdbe9e0bea
 https://conda.anaconda.org/conda-forge/noarch/jupytext-1.13.6-pyheef035f_0.tar.bz2#686b0fb2e2183e96ebb8faadbb491652
 https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.5.1-py37h4a79c79_0.tar.bz2#924637d761c43173c72cf75b493ef213
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-autorefs-0.3.1-pyhd8ed1ab_0.tar.bz2#29c8b44c216211e29b8b39c86f33c719
@@ -297,13 +297,13 @@ https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.0.2-py37hcabfae0_0.
 https://conda.anaconda.org/conda-forge/noarch/clickhouse-sqlalchemy-0.1.8-pyhd8ed1ab_0.tar.bz2#48481fce44f344a572290d68456cb663
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2#44912901b45260e4338447b9d46f7058
 https://conda.anaconda.org/conda-forge/win-64/gdal-3.4.0-py37h9ecaa47_12.tar.bz2#ef34b6693f4029db67f250c68b385901
-https://conda.anaconda.org/conda-forge/win-64/ipykernel-6.8.0-py37h4038f58_0.tar.bz2#349f10a47d112a5b1980a673ea1f35e5
+https://conda.anaconda.org/conda-forge/win-64/ipykernel-6.9.0-py37h4038f58_0.tar.bz2#839b2bd45f039f4fcdaab3fc545223c8
 https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.4.3-pyhd8ed1ab_0.tar.bz2#908bbfb54da154042c5cbda77b37a3d1
 https://conda.anaconda.org/conda-forge/win-64/pyarrow-6.0.1-py37ha6b0ef9_8_cpu.tar.bz2#eb8ac9a3dcf1aef09e96c8b7a11e27ab
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.5.0-pyhd8ed1ab_0.tar.bz2#1fdd1f3baccf0deb647385c677a1a48e
 https://conda.anaconda.org/conda-forge/noarch/questionary-1.10.0-pyhd8ed1ab_0.tar.bz2#360878a7fcb1d4aab3a05918be8b1397
 https://conda.anaconda.org/conda-forge/win-64/requests-kerberos-0.12.0-py37h03978a9_3.tar.bz2#5aee30595fec1e06683f5cf6b496ac7a
-https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.4-pyhd8ed1ab_0.tar.bz2#89a6e0d0f0edcff4466f3c4a5d9a3281
+https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.5-pyhd8ed1ab_0.tar.bz2#084b9bbf396b64bd19a7302417b70faf
 https://conda.anaconda.org/conda-forge/win-64/fiona-1.8.20-py37heec31cd_4.tar.bz2#2b49618da749dd35f9359843201a30e3
 https://conda.anaconda.org/conda-forge/noarch/pyspark-3.2.1-pyhd8ed1ab_0.tar.bz2#99883d37054647870c3c68f7d0691027
 https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.6.0-pyhd8ed1ab_0.tar.bz2#6d826168a0cdc0ac13c33ae6a5bc4b43

--- a/conda-lock/win-64-3.8.lock
+++ b/conda-lock/win-64-3.8.lock
@@ -98,7 +98,7 @@ https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h0e5069d_3.tar.bz2#e63
 https://conda.anaconda.org/conda-forge/noarch/idna-3.3-pyhd8ed1ab_0.tar.bz2#40b50b8b030f5f2f22085c062ed013dd
 https://conda.anaconda.org/conda-forge/noarch/iniconfig-1.1.1-pyh9f0ad1d_0.tar.bz2#39161f81cc5e5ca45b8226fbb06c6905
 https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2#5071c982548b3a20caf70462f04f5287
-https://conda.anaconda.org/conda-forge/win-64/libglib-2.70.2-h3be07f2_1.tar.bz2#44c08484ca6321c1a13af600bbb56732
+https://conda.anaconda.org/conda-forge/win-64/libglib-2.70.2-h3be07f2_2.tar.bz2#9bf0fee1ab469a9343701c528b002d7b
 https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.18-pthreads_hc469a61_0.tar.bz2#249ba301d82d6985ba54453a107ae5db
 https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.37-h1d00b33_2.tar.bz2#005ddb14b8f876ed6a85b76dfc9892db
 https://conda.anaconda.org/conda-forge/win-64/libpq-14.1-hfcc5ef8_1.tar.bz2#e23697046d104225361a5b7d264b467d
@@ -118,7 +118,7 @@ https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2#1
 https://conda.anaconda.org/conda-forge/noarch/parsy-1.3.0-pyhd8ed1ab_0.tar.bz2#94cd1a4bfe56d25b4e441c46e630b147
 https://conda.anaconda.org/conda-forge/noarch/pathspec-0.9.0-pyhd8ed1ab_0.tar.bz2#f93dc0ccbc0a8472624165f6e256c7d1
 https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2#415f0ebb6198cc2801c73438a9fb5761
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.3.0-pyhd8ed1ab_0.tar.bz2#7bc119135be2a43e1701432399d8c28a
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.4.1-pyhd8ed1ab_1.tar.bz2#ea1a07fd28b52b73239cacb4e39d380c
 https://conda.anaconda.org/conda-forge/noarch/pure-sasl-0.6.2-pyhd8ed1ab_0.tar.bz2#ac695eecf21ab48093bc33fd60b4102d
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
 https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-8.0.0-pyhd8ed1ab_0.tar.bz2#37a9a8874b2e62987f8dc2434688f3cf
@@ -194,7 +194,7 @@ https://conda.anaconda.org/conda-forge/win-64/rtree-0.9.7-py38h8b54edf_3.tar.bz2
 https://conda.anaconda.org/conda-forge/win-64/setuptools-60.7.1-py38haa244fe_0.tar.bz2#af22086da3af906ef5fbc1f7aaaa046d
 https://conda.anaconda.org/conda-forge/win-64/sqlalchemy-1.3.23-py38h294d835_0.tar.bz2#76faae51942ff5bd32bdc151dbb784d8
 https://conda.anaconda.org/conda-forge/win-64/thrift-0.15.0-py38h885f38d_1.tar.bz2#28285d51a165fd7d42669e9f55dcd981
-https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.0-pyha770c72_0.tar.bz2#c15fc5814a1982a7a0bcafcde0c61e4d
+https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.1-pyha770c72_0.tar.bz2#bcb174bf45a1482a9c03c50eeb7e05b1
 https://conda.anaconda.org/conda-forge/win-64/tornado-6.1-py38h294d835_2.tar.bz2#dcc01fcb0cba8459d09aa97342adcecc
 https://conda.anaconda.org/conda-forge/win-64/typed-ast-1.5.2-py38h294d835_0.tar.bz2#7fffc0d04196c897155e51e87faead07
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.0.1-hd8ed1ab_0.tar.bz2#c0d4ec4bcbceb927bff1103a997410d3
@@ -268,7 +268,7 @@ https://conda.anaconda.org/conda-forge/win-64/tiledb-2.6.2-h95dad36_1.tar.bz2#b0
 https://conda.anaconda.org/conda-forge/win-64/tzlocal-4.1-py38haa244fe_1.tar.bz2#ff8dd4724029648eb977765411ab9213
 https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.5-pyh9f0ad1d_2.tar.bz2#5266fcd697043c59621fda522b3d78ee
 https://conda.anaconda.org/conda-forge/win-64/arrow-cpp-6.0.1-py38hcfbcb3e_8_cpu.tar.bz2#6641e871400c7bde5301fe66e485d46c
-https://conda.anaconda.org/conda-forge/win-64/clickhouse-driver-0.2.2-py38h294d835_1.tar.bz2#ca66cd5b198f433b6b3cfd9a2fd3e394
+https://conda.anaconda.org/conda-forge/win-64/clickhouse-driver-0.2.3-py38h294d835_0.tar.bz2#5ad4a01a968f60bb0ee3a357c7d9203a
 https://conda.anaconda.org/conda-forge/noarch/jupytext-1.13.6-pyheef035f_0.tar.bz2#686b0fb2e2183e96ebb8faadbb491652
 https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.5.1-py38h1f000d6_0.tar.bz2#068477aed25283fbb44fe01997ac696a
 https://conda.anaconda.org/conda-forge/noarch/mkdocs-autorefs-0.3.1-pyhd8ed1ab_0.tar.bz2#29c8b44c216211e29b8b39c86f33c719
@@ -297,12 +297,12 @@ https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.0.2-py38hb60ee80_0.
 https://conda.anaconda.org/conda-forge/noarch/clickhouse-sqlalchemy-0.1.8-pyhd8ed1ab_0.tar.bz2#48481fce44f344a572290d68456cb663
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2#44912901b45260e4338447b9d46f7058
 https://conda.anaconda.org/conda-forge/win-64/gdal-3.4.1-py38h117dad8_2.tar.bz2#9bd5cbf18aee920b7542dbef2de18b10
-https://conda.anaconda.org/conda-forge/win-64/ipykernel-6.8.0-py38h595d716_0.tar.bz2#d865fde25928979f9479272bbf69c3a7
+https://conda.anaconda.org/conda-forge/win-64/ipykernel-6.9.0-py38h595d716_0.tar.bz2#7dd266b7217bf45a903ce6e236d692db
 https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.4.3-pyhd8ed1ab_0.tar.bz2#908bbfb54da154042c5cbda77b37a3d1
 https://conda.anaconda.org/conda-forge/win-64/pyarrow-6.0.1-py38h0b4a547_8_cpu.tar.bz2#308dbd778b4437a5ca17bf93b58e66e0
 https://conda.anaconda.org/conda-forge/noarch/questionary-1.10.0-pyhd8ed1ab_0.tar.bz2#360878a7fcb1d4aab3a05918be8b1397
 https://conda.anaconda.org/conda-forge/win-64/requests-kerberos-0.12.0-py38haa244fe_3.tar.bz2#320a732580423ca12cf0d8c025625e30
-https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.4-pyhd8ed1ab_0.tar.bz2#89a6e0d0f0edcff4466f3c4a5d9a3281
+https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.5-pyhd8ed1ab_0.tar.bz2#084b9bbf396b64bd19a7302417b70faf
 https://conda.anaconda.org/conda-forge/win-64/fiona-1.8.20-py38h19672d5_4.tar.bz2#b24b18975ba2d9b671e0e55bb7a65f0e
 https://conda.anaconda.org/conda-forge/noarch/pyspark-3.2.1-pyhd8ed1ab_0.tar.bz2#99883d37054647870c3c68f7d0691027
 https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.6.0-pyhd8ed1ab_0.tar.bz2#6d826168a0cdc0ac13c33ae6a5bc4b43

--- a/conda-lock/win-64-3.9.lock
+++ b/conda-lock/win-64-3.9.lock
@@ -98,7 +98,7 @@ https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h0e5069d_3.tar.bz2#e63
 https://conda.anaconda.org/conda-forge/noarch/idna-3.3-pyhd8ed1ab_0.tar.bz2#40b50b8b030f5f2f22085c062ed013dd
 https://conda.anaconda.org/conda-forge/noarch/iniconfig-1.1.1-pyh9f0ad1d_0.tar.bz2#39161f81cc5e5ca45b8226fbb06c6905
 https://conda.anaconda.org/conda-forge/noarch/ipython_genutils-0.2.0-py_1.tar.bz2#5071c982548b3a20caf70462f04f5287
-https://conda.anaconda.org/conda-forge/win-64/libglib-2.70.2-h3be07f2_1.tar.bz2#44c08484ca6321c1a13af600bbb56732
+https://conda.anaconda.org/conda-forge/win-64/libglib-2.70.2-h3be07f2_2.tar.bz2#9bf0fee1ab469a9343701c528b002d7b
 https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.18-pthreads_hc469a61_0.tar.bz2#249ba301d82d6985ba54453a107ae5db
 https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.37-h1d00b33_2.tar.bz2#005ddb14b8f876ed6a85b76dfc9892db
 https://conda.anaconda.org/conda-forge/win-64/libpq-14.1-hfcc5ef8_1.tar.bz2#e23697046d104225361a5b7d264b467d
@@ -118,7 +118,7 @@ https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2#1
 https://conda.anaconda.org/conda-forge/noarch/parsy-1.3.0-pyhd8ed1ab_0.tar.bz2#94cd1a4bfe56d25b4e441c46e630b147
 https://conda.anaconda.org/conda-forge/noarch/pathspec-0.9.0-pyhd8ed1ab_0.tar.bz2#f93dc0ccbc0a8472624165f6e256c7d1
 https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2#415f0ebb6198cc2801c73438a9fb5761
-https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.3.0-pyhd8ed1ab_0.tar.bz2#7bc119135be2a43e1701432399d8c28a
+https://conda.anaconda.org/conda-forge/noarch/platformdirs-2.4.1-pyhd8ed1ab_1.tar.bz2#ea1a07fd28b52b73239cacb4e39d380c
 https://conda.anaconda.org/conda-forge/noarch/pure-sasl-0.6.2-pyhd8ed1ab_0.tar.bz2#ac695eecf21ab48093bc33fd60b4102d
 https://conda.anaconda.org/conda-forge/noarch/py-1.11.0-pyh6c4a22f_0.tar.bz2#b4613d7e7a493916d867842a6a148054
 https://conda.anaconda.org/conda-forge/noarch/py-cpuinfo-8.0.0-pyhd8ed1ab_0.tar.bz2#37a9a8874b2e62987f8dc2434688f3cf
@@ -194,7 +194,7 @@ https://conda.anaconda.org/conda-forge/win-64/rtree-0.9.7-py39h09fdee3_3.tar.bz2
 https://conda.anaconda.org/conda-forge/win-64/setuptools-60.7.1-py39hcbf5309_0.tar.bz2#a144e9bd5e066b885ae01c374f20f16e
 https://conda.anaconda.org/conda-forge/win-64/sqlalchemy-1.3.23-py39hb82d6ee_0.tar.bz2#9075e5233bfd2b78b8a4d228c2b230d6
 https://conda.anaconda.org/conda-forge/win-64/thrift-0.15.0-py39h415ef7b_1.tar.bz2#34126aae0911d90a966c3c447f075df5
-https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.0-pyha770c72_0.tar.bz2#c15fc5814a1982a7a0bcafcde0c61e4d
+https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.9.1-pyha770c72_0.tar.bz2#bcb174bf45a1482a9c03c50eeb7e05b1
 https://conda.anaconda.org/conda-forge/win-64/tornado-6.1-py39hb82d6ee_2.tar.bz2#f74a5656b36abfe880da1028e4e45d49
 https://conda.anaconda.org/conda-forge/win-64/typed-ast-1.5.2-py39hb82d6ee_0.tar.bz2#d2d162597e33b69c6315bf9b13839612
 https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.0.1-hd8ed1ab_0.tar.bz2#c0d4ec4bcbceb927bff1103a997410d3
@@ -245,7 +245,7 @@ https://conda.anaconda.org/conda-forge/noarch/argcomplete-1.12.3-pyhd8ed1ab_2.ta
 https://conda.anaconda.org/conda-forge/win-64/bcrypt-3.2.0-py39hb82d6ee_2.tar.bz2#73cb805e0c7f99598debdb01fdec2f89
 https://conda.anaconda.org/conda-forge/noarch/branca-0.4.2-pyhd8ed1ab_0.tar.bz2#836c975d3ae4f21c3cd047c10b15a7cf
 https://conda.anaconda.org/conda-forge/win-64/cairo-1.16.0-h15b3021_1009.tar.bz2#14f7d817e6daaadf279cbcc344346c50
-https://conda.anaconda.org/conda-forge/win-64/clickhouse-driver-0.2.2-py39hb82d6ee_1.tar.bz2#182c9d409c83a09576fd105385f3f2ff
+https://conda.anaconda.org/conda-forge/win-64/clickhouse-driver-0.2.3-py39hb82d6ee_0.tar.bz2#56d253d0521cf09738681122c3946524
 https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.0-h144821f_6.tar.bz2#7c08cc4d8140e2f26e1939ad34c4cc5c
 https://conda.anaconda.org/conda-forge/noarch/impyla-0.17.0-pyhd8ed1ab_2.tar.bz2#6c2b6b92dacfa3e9fb974849c16b6e80
 https://conda.anaconda.org/conda-forge/noarch/jupyter_client-7.1.2-pyhd8ed1ab_0.tar.bz2#9a332b6f8f05629435ce59032df8cfa9
@@ -295,12 +295,12 @@ https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.0.2-py39he931e04_0.
 https://conda.anaconda.org/conda-forge/noarch/clickhouse-sqlalchemy-0.1.8-pyhd8ed1ab_0.tar.bz2#48481fce44f344a572290d68456cb663
 https://conda.anaconda.org/conda-forge/noarch/folium-0.12.1.post1-pyhd8ed1ab_1.tar.bz2#44912901b45260e4338447b9d46f7058
 https://conda.anaconda.org/conda-forge/win-64/gdal-3.4.1-py39h3f5efd6_2.tar.bz2#88f06ffce0d32525fe4a1564447f0d4a
-https://conda.anaconda.org/conda-forge/win-64/ipykernel-6.8.0-py39h832f523_0.tar.bz2#b2eaf60c09836a88a2585822d3bd9830
+https://conda.anaconda.org/conda-forge/win-64/ipykernel-6.9.0-py39h832f523_0.tar.bz2#a8d46e88c1b91f08275b8e927ad3d368
 https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.4.3-pyhd8ed1ab_0.tar.bz2#908bbfb54da154042c5cbda77b37a3d1
 https://conda.anaconda.org/conda-forge/win-64/pyarrow-6.0.1-py39ha05331a_8_cpu.tar.bz2#b887a30f398992b3278e77210aeb44ea
 https://conda.anaconda.org/conda-forge/noarch/questionary-1.10.0-pyhd8ed1ab_0.tar.bz2#360878a7fcb1d4aab3a05918be8b1397
 https://conda.anaconda.org/conda-forge/win-64/requests-kerberos-0.12.0-py39hcbf5309_3.tar.bz2#f4f6262c92f90ec782550bf72d099a18
-https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.4-pyhd8ed1ab_0.tar.bz2#89a6e0d0f0edcff4466f3c4a5d9a3281
+https://conda.anaconda.org/conda-forge/noarch/commitizen-2.20.5-pyhd8ed1ab_0.tar.bz2#084b9bbf396b64bd19a7302417b70faf
 https://conda.anaconda.org/conda-forge/win-64/fiona-1.8.20-py39hd99abff_4.tar.bz2#18dde0c2020e7903b1812959ed0b992f
 https://conda.anaconda.org/conda-forge/noarch/pyspark-3.2.1-pyhd8ed1ab_0.tar.bz2#99883d37054647870c3c68f7d0691027
 https://conda.anaconda.org/conda-forge/noarch/python-hdfs-2.6.0-pyhd8ed1ab_0.tar.bz2#6d826168a0cdc0ac13c33ae6a5bc4b43

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -104,9 +104,8 @@ class Backend(BaseSQLBackend):
         self.con.connection.force_connect()
         try:
             info = self.con.connection.server_info
-        except Exception:
+        finally:
             self.con.connection.disconnect()
-            raise
 
         return f'{info.version_major}.{info.version_minor}.{info.revision}'
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -85,7 +85,7 @@ tzdata = ["tzdata"]
 
 [[package]]
 name = "bitarray"
-version = "2.3.5"
+version = "2.3.6"
 description = "efficient arrays of booleans -- C extension"
 category = "main"
 optional = true
@@ -193,7 +193,7 @@ dev = ["pytest (>=3.6)", "pytest-cov", "wheel", "coveralls"]
 
 [[package]]
 name = "clickhouse-driver"
-version = "0.2.2"
+version = "0.2.3"
 description = "Python driver with native interface for ClickHouse"
 category = "main"
 optional = false
@@ -253,7 +253,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "commitizen"
-version = "2.20.4"
+version = "2.20.5"
 description = "Python commitizen client tool"
 category = "dev"
 optional = false
@@ -413,7 +413,7 @@ testing = ["pre-commit"]
 
 [[package]]
 name = "fiona"
-version = "1.8.20"
+version = "1.8.21"
 description = "Fiona reads and writes spatial data files"
 category = "main"
 optional = true
@@ -429,7 +429,7 @@ munch = "*"
 six = ">=1.7"
 
 [package.extras]
-all = ["pytest (>=3)", "boto3 (>=1.2.4)", "pytest-cov", "shapely", "mock"]
+all = ["boto3 (>=1.2.4)", "pytest-cov", "shapely", "pytest (>=3)", "mock"]
 calc = ["shapely"]
 s3 = ["boto3 (>=1.2.4)"]
 test = ["pytest (>=3)", "pytest-cov", "boto3 (>=1.2.4)", "mock"]
@@ -628,7 +628,7 @@ python-versions = "*"
 
 [[package]]
 name = "ipykernel"
-version = "6.8.0"
+version = "6.9.0"
 description = "IPython Kernel for Jupyter"
 category = "dev"
 optional = false
@@ -1330,7 +1330,7 @@ ssh = ["paramiko"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.26"
+version = "3.0.27"
 description = "Library for building powerful interactive command lines in Python"
 category = "dev"
 optional = false
@@ -1935,7 +1935,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "tomlkit"
-version = "0.9.0"
+version = "0.9.1"
 description = "Style preserving TOML library"
 category = "dev"
 optional = false
@@ -2149,7 +2149,7 @@ backcall = [
     {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
 ]
 bitarray = [
-    {file = "bitarray-2.3.5.tar.gz", hash = "sha256:60285184cb02fdba5e1cc8605ac84e150a50f940e9383ab43564e5258d1f47bb"},
+    {file = "bitarray-2.3.6.tar.gz", hash = "sha256:3bfdb59ded15c961e6e3d5b7f167155cda053be2475ea8017461df0b4d820b7d"},
 ]
 black = [
     {file = "black-22.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6"},
@@ -2253,62 +2253,77 @@ click-plugins = [
     {file = "click_plugins-1.1.1-py2.py3-none-any.whl", hash = "sha256:5d262006d3222f5057fd81e1623d4443e41dcda5dc815c06b442aa3c02889fc8"},
 ]
 clickhouse-driver = [
-    {file = "clickhouse-driver-0.2.2.tar.gz", hash = "sha256:d16cfae6d3085854ebdef47a7920ce2ef839bde44c60a64d7963a8c9834d7440"},
-    {file = "clickhouse_driver-0.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:96af5d26ed7b4e6a0eebcf95846c921e3311e73aa6bda98bc33633e7e59a183c"},
-    {file = "clickhouse_driver-0.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab029ba9bed6ff1118190fd05bdf001bd085a72caeb1fbb23fc6e8a0a5cc2bbd"},
-    {file = "clickhouse_driver-0.2.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:817426d25024fb31d2b6b87f5ddbc0b94881ea73305180f693fa7c9b54ba12c3"},
-    {file = "clickhouse_driver-0.2.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fcfc774aa36fdfdcd6a53053dbcd8c2da3046c68e4005b0cba7aa7c3677bafe7"},
-    {file = "clickhouse_driver-0.2.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:568586e3bf901516582ee11705e9aa97ee187bd7bd0cef42d762751352b3aecd"},
-    {file = "clickhouse_driver-0.2.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a4d0de837557468f3097443b8414868440792da2d0e167e21c7d725f0122beb6"},
-    {file = "clickhouse_driver-0.2.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4712143e554bc0e32c4a0a12c0b04ca2e1ab9ac0b541916cc598bbb03267af9e"},
-    {file = "clickhouse_driver-0.2.2-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:56ec4ad0880072b990b3f55a1ea5b23439cf43908024b6330853ebb5edacc45d"},
-    {file = "clickhouse_driver-0.2.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:eece04cadf0bf19a063869c39456c5eb4ed14ec19b4fed089615a0aff38c3e73"},
-    {file = "clickhouse_driver-0.2.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b015664786376421c08e4e9a02c4976784e858be191c0adda24fb4ae6e15f9ee"},
-    {file = "clickhouse_driver-0.2.2-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:fbc771bc3b27fab872a302b8d174b933dc9a2bd9ab6bdd2a89bf18de6f7e9445"},
-    {file = "clickhouse_driver-0.2.2-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:86a744aeea30c7251110e4b7d6e9103000274f74794feed14017e501081f0f75"},
-    {file = "clickhouse_driver-0.2.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:e9bc9258fea1e5d5d8ab4c8d9f52c37cf5d6ed3e1f82d17833d052a9c7d68ed8"},
-    {file = "clickhouse_driver-0.2.2-cp35-cp35m-win32.whl", hash = "sha256:d6548baf0ddca4084cde97e9439b75a2194fc2a383f4002014520b837b19913c"},
-    {file = "clickhouse_driver-0.2.2-cp35-cp35m-win_amd64.whl", hash = "sha256:671dada39a5c51e721ca0d546653c57d66e40e7c9835c06879042775abf624fc"},
-    {file = "clickhouse_driver-0.2.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:489c1606b79b185f1ed8ed6210d0f0781ab51f2d1b6b9e5378b9372c28055e2f"},
-    {file = "clickhouse_driver-0.2.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:64643a2e65c5f1f96ed4b0fbf56af0b225e437d9a84551cec9fce49b3ed27ada"},
-    {file = "clickhouse_driver-0.2.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:9487800152d9cb8412639f88a3d70c11e086d420b0f72c28541e391d24f12ecf"},
-    {file = "clickhouse_driver-0.2.2-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b49f64a61e7a322746e1a6bb65a9e57d8abf29fa1274a177fee81574de5feca"},
-    {file = "clickhouse_driver-0.2.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:643883cc04df1d9e5eebc63f73df860722c905959dcc9b95f8bc30b417beaff6"},
-    {file = "clickhouse_driver-0.2.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:4a221e4f70e69c13bab23fa8277c30ce1659ca62b83decb4371aef83ec0c845c"},
-    {file = "clickhouse_driver-0.2.2-cp36-cp36m-win32.whl", hash = "sha256:2c01b396dd6393f68a367746d647775e92aa26125932f47e186dd5d6f0410a78"},
-    {file = "clickhouse_driver-0.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:ef794cff7fff0123525865c5b4fb4c1a0d78bbae54c4edeb553c24d42d01bcae"},
-    {file = "clickhouse_driver-0.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e944f11926db7a9d3c7f8a1d3d9f96b1e6939e5d81b61f8a8b24e647bf2170f7"},
-    {file = "clickhouse_driver-0.2.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:397bf434d1e514949d089b1f0cc2829a5c108ba93c89ef99d020c5f62809bc2b"},
-    {file = "clickhouse_driver-0.2.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ce040a64f3d18927950588968bba89f0be67f5a4cc936b12c85700089d211681"},
-    {file = "clickhouse_driver-0.2.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6770729416e7a79b161a752001d52f81c2ccbf080b244a0cb86fd4e33c141b5e"},
-    {file = "clickhouse_driver-0.2.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:4cb7ec8f9e506466d6e30ec07416ebb4c4be84959946eb4c26ac8c3369dc045e"},
-    {file = "clickhouse_driver-0.2.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e685b109c549d6a23c77816520d39e4183936b9a7a39d42ebc06cf64df87900b"},
-    {file = "clickhouse_driver-0.2.2-cp37-cp37m-win32.whl", hash = "sha256:f3795955d200e0f7a12e8f6641dd488c773004af827895a2a870af3dcb9d2f23"},
-    {file = "clickhouse_driver-0.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:7c0fb49bb5af47816322c66d7929d3a8b4561d5ed79aeabc779da490bb8073e0"},
-    {file = "clickhouse_driver-0.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:aaf06448710d07767a56cddaaf29f4b068badad601a21d2a729cd13caa8690f0"},
-    {file = "clickhouse_driver-0.2.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:f932731fe1a184848f36fabf68d68b26ca5371c7b9d0cbed9b74bc09b6350fed"},
-    {file = "clickhouse_driver-0.2.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:e0574a1f08d94b1b5a6c9e508e98df6ce646541f5743e05f9a88540bc55e9a26"},
-    {file = "clickhouse_driver-0.2.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d47427c8df42065daba310710dbfe35b05ab03a62276146836a6bf8feec64719"},
-    {file = "clickhouse_driver-0.2.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:28274fd0060c577859b1e88661c7a0fa690ff1656bac5fa0760a3a90fb0af2a8"},
-    {file = "clickhouse_driver-0.2.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:6c7cc232a7ba8fef01b04f37c2548e9ac56f297925ab56125816e2355c24b9d0"},
-    {file = "clickhouse_driver-0.2.2-cp38-cp38-win32.whl", hash = "sha256:bf6bfa7b1019af22eb2e393bae6834da09526c7e068438dfe824a6ae5ba615ff"},
-    {file = "clickhouse_driver-0.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:17f4f18a07e878b8da9a5a5fda05e14a787d79b78f30d4154785cac7c85b9378"},
-    {file = "clickhouse_driver-0.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:831b3c1084b1f5283bd7ac6b7b6bd9ebc898e0c7821fed830f68206ac7c5681a"},
-    {file = "clickhouse_driver-0.2.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:8a79355b930258f2d730aad11682f42e9fc6791da5c9c43958c6bd575cb42b51"},
-    {file = "clickhouse_driver-0.2.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:5440e023e6fbcda2f56f2360c3b4683152e7d4c1c805ecbbd280186b2647be82"},
-    {file = "clickhouse_driver-0.2.2-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:6058592b25160907f84ebebd45c6e7d8047e0b86b477d1c7e6fb344861cc03fd"},
-    {file = "clickhouse_driver-0.2.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:9c950170c459659924a7ddade52c9312863d707b5c61ae915b323a0902e7ba43"},
-    {file = "clickhouse_driver-0.2.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6309fa95482086126949c7ccf3f45f55976b41d0fd586d2c098dd2c86a1fda4f"},
-    {file = "clickhouse_driver-0.2.2-cp39-cp39-win32.whl", hash = "sha256:2242d4c4b1201f016ef17f5f006b0ea79ce8549def33db2c3381eafda706cbec"},
-    {file = "clickhouse_driver-0.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:15fe435392fb871b634b7a58dd221c34fe952fa15885a7f04c02cebaf90b84bb"},
-    {file = "clickhouse_driver-0.2.2-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8a5b00482cddb99629e9fb60bf0b9017fb61d578fd4a551bc677079ef7fa04b9"},
-    {file = "clickhouse_driver-0.2.2-pp36-pypy36_pp73-manylinux1_x86_64.whl", hash = "sha256:06b9547d7da5f9126c49a49f80689fd35c90e47f6eabfc71f5cd56d83971e4d1"},
-    {file = "clickhouse_driver-0.2.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:b1657a3d5acb0a283a6af85ba799691a8344f9186dc8ed3ae9c84269eaed3bd3"},
-    {file = "clickhouse_driver-0.2.2-pp36-pypy36_pp73-win32.whl", hash = "sha256:82e30654b58ce7aa06ab11ba0ce70ce99a9617ddf82c6a2c77088423b018efd9"},
-    {file = "clickhouse_driver-0.2.2-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b6f4477a87853a4f063af941dd7052a2514dfaf0d4e9ada86c9c73320b9708e6"},
-    {file = "clickhouse_driver-0.2.2-pp37-pypy37_pp73-manylinux1_x86_64.whl", hash = "sha256:c4bc35e74270cb97442d87b6d607d82487f57679a0fe1f28762a735dd8235756"},
-    {file = "clickhouse_driver-0.2.2-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:2bbba461a504b1e88719a6cc2b9865cd5885377fd9eb31be72cd86d77b83da1c"},
-    {file = "clickhouse_driver-0.2.2-pp37-pypy37_pp73-win32.whl", hash = "sha256:cea99c3a508ecc87cf26c7b615e23b76d9be6ee0a34018efa028107904409c6f"},
+    {file = "clickhouse-driver-0.2.3.tar.gz", hash = "sha256:519c591a96976bb136b1e82cdaf91385b6dc1f7d3e717d95c4f32adec62fd119"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f7af8a0d20fdc968fc79f58086c8a8a171c51ee438a8235a34bfc185be85d185"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b06d41498eac00180cfd39551fda19a255cd61de32478f97128c61d19265653d"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b34dae4b3388b680efcdbb56d4a9809fa1d7eac60b95c487de1c34962525c2b"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc52dbb10e4af8dc6ae65020c17dd4575a9fc79d43770ff910cfaa81cc873e6b"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0ed68a1d5026e833029a43b1728a2a502fbced10ba563db490d1673b36533914"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:17c554e28cff0b073c3db36c5911dc439ca091fcb3975f4c9e24475bd0fb80c2"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ab179bd808fe6684c2e6f3bd69b140c648faa27d0a4694569bc424f2bb2be753"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8c3605521fed461709af6bfd15b3ff131c8324b8e535b3c9920cdbee8c4d9587"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:9c7fba6c550988cc34f6f98b7ec50e0bb65bc3e61ba0ec4640aed49c01ec106e"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:6607b4ceb2d2d891675cae176387ab98fa5d6ec519d96d61c8f8b18dee7803dc"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9e6e232f3cc47d9b8047bd7f091664c6064b82475c0e110a2a4c91565b8fe193"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-win32.whl", hash = "sha256:10c37eff1ec69c76997480333e42ce822f31565837ff180ba3995062fa2ff79d"},
+    {file = "clickhouse_driver-0.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:6701c0a7cf7d63a674632d038f3385115e15ef58284e75e889c8f1f4c10c93b7"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4862ba3579ece265daecdabaf56094a5264aca8fb613bc8ef6be9c10b9bf8ce8"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bdc8daaa899827864f9f5fd1af464b89f6ccaf4523a41eba92c8e37ef995f32"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09f00a5fbb0d1b4ab918edabc69723c92513c5392cb953b665877061c2eb4592"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d6d93fcf708e9dacbb5337b11560814e81da14c33cf122fc5e28b75e14623e8a"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2ee60734c3966efe994dcbab3b278fd9bd24629949f350a8658e967a2e5b3059"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:879f86780e87dac0ec5046d1f777fb3ba720350860caef2014ace4e076814929"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:aef00b224828aab6120b29bc882ab0b8371f8fd5bd5b8051ddaf9c95c4116261"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:60020294cf3ab4be5ea00715d9a0fba7b65982ecb3c2e9904464cc867f216ea3"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:d081dd3fb4d438d910e79053a9ec2431e54ed3d9e148a3d3150c6630d73194bd"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:4c07d9e381238c55a4fa75e71bf36f9ae7ee861ffa150df3cd4cf2236b3cf4e1"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:44b58f45ad9b5f9e85183018211d41e1016820fd573795b7cb0a1ee3ccc0945d"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-win32.whl", hash = "sha256:5ad793c077b248356d4b84aa99a4428072cec96c2f059e87a7f52b7af48d1652"},
+    {file = "clickhouse_driver-0.2.3-cp36-cp36m-win_amd64.whl", hash = "sha256:aaa3f3ba7bcbeaf3b557102558cff95fa016b7e4cc82caeaf731f7f83ae90a55"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3480f8ef9f7308ea38bdba4e832ea2a7967167506332df9387f600ba3cf0fe7b"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c7b20b97021f752e7078f85948e2f7be934ae654ce83a16c2e703384e506be3"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a445036bcd2a86aa510a786b71417ab969ea05547fc94a74966886ad4901c430"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7f628f245ae96608b07e2ed33c14453f0d9446db9cceeb1ca23bb1a4e9349211"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:956634d62bfbd58fbea5f0bcf81bcf0b6a0bb5cbeba45e1423095afae2fd6a2b"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d03f37ce9ea5a7569ad00afb91f26b18e5b192ca1837ef362df87b1a69a8b310"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b7cf9390c19c5f0eba67ddc9e02c0bfb7184ed878a35f546e9848980e8a256a1"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:66f5145b21d5058153fd9775d764ff1d4e98d1f5202df66e52c4d9a1333d16ca"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:56a79709059d46eabeafb970ae5c6e720f5814e8391af7be5f47e5091369dd0a"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:95a3c5d8f8a89992786dc8e40816f6ea2a28af447bbbd06aea25ea8165d75435"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:077d1f9a36d80f6d4122980d181c3bf957f786c3adf083ddb783c0065999288e"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-win32.whl", hash = "sha256:086aacee7a1b2eb558e55435d1509818cc08098b0b5f1daf4a17c4282d93d890"},
+    {file = "clickhouse_driver-0.2.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ae9535652e308ec6e117d0d01917fe183dda908ff92e32b14f47c7664350aef"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:47c42830f96fe8574438c06a5c2b057f8f4ae0560685a1db8d53374cce9b021f"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02cf0ebb6371b165bb410144d5bc616dcd9df312239254449777fc15608facc6"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f889727c12cda1b4fa736bdf8da2257aaa9a9b93702db87778687aba94c06079"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0d6075f24ea8dc293d0b0b0630d4ee50f953bd50c2fe20d5e81aa222ec94be7c"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c067d9b3516d9123d089c343397e6b8d506959cc0292525822d51872d7e611f0"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d827ad8ed1b66cd4625fbb36a3210a57af6b8cf501001792ecae4128c736f7b0"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:d174450ceb4a20a63cd0ab853006a57d557014fd265ac4c506f91c262380986b"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:007f4e343a41075da2e66bb9b024708341fdf07478fceae75a326c10a3ff2625"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:01aa2d7bba194008f3a5cdc12201eb18461315026801828af9e0c1aa71004c85"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:f962d4cd0ac36a161f696a7a214ae5f1ae96427f2a9057f3b22ee2b3a034401c"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d625d6c13ff2519a10d46eb46de5bb8f66f4f37446805cdd7969d773df54b303"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-win32.whl", hash = "sha256:87718fbef63df4f6b9fb10d2ec031b8cc056e884d1a4edc9e31b2069fe19e0f1"},
+    {file = "clickhouse_driver-0.2.3-cp38-cp38-win_amd64.whl", hash = "sha256:9753eb3a615501f060566df160cb0f602288c4c076bf16e8f459f40e83300977"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9ccd13c7dfa6cf9de24faea73f7a5e5c66daad1100d564f209a83855d46a633f"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6221974d66cb12068ffa2bc065fe54ad1ec70811c02d7adcbde80723fbafad27"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10179f5e9f863431a9724cd3400fd74e8cd4b32a1911ea447a811d22b7994810"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a2608fc680a77e55696bf601b2dbbb9bc6a87c9f95f6a5f4416290b73cfa7725"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bbe05f531a8d2f5e6696d4d05360cf4d27a625e9600df85172265ef9c7068ab7"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e00bc089b81313cb1a2e7a434f174a5e084081eb56fc57c7e26fc65c468ecc95"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:7dbc2ccc1b76fcab5559dd99e9e5c9451c8195be610b3581068ac6fbd757dc95"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f2dcb966009fb3d17d99298bd9f1ed82cb9fd32dfe97a61f2189b9bfb7a1ecc2"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:cf2223b82e99c2dd6d7373816ee41b85eed9f18a2f141389b351ec1357c3ac63"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:f6e7afe0e38dd1c3dd15a1e2960bf4c90056adaccbe70d03f0b91822c8102af9"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c94b3f8164cec8b4ff4f9ba6abe77057066e682aceec53d06faa4cafd72f2a5c"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-win32.whl", hash = "sha256:695f39bdf6754e9e9b2e5376313071b204f8ceb5722534ee9803dd5f7c7e249f"},
+    {file = "clickhouse_driver-0.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:7f789ed07e5f2c75e8cf95d626b1cd6562a4e3ae84ac5f8fe0de77fc0e02da37"},
+    {file = "clickhouse_driver-0.2.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9f2a0c70cd09dd14c2e8fab258e02dad78c52b40dcb95e3d675e7edb38b8dd41"},
+    {file = "clickhouse_driver-0.2.3-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93631f87cce3fe398e21351de575e6ef9a95d02ef9aff19b942286f86a742d4e"},
+    {file = "clickhouse_driver-0.2.3-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:89951808eb2194bd84dff79ea97fd49171415356cd37b4209f6fdcd8930e7219"},
+    {file = "clickhouse_driver-0.2.3-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a995ebefa0dc945cb67f2516d599cc18f8fa1119a92ad774baffc02d1f4a0506"},
+    {file = "clickhouse_driver-0.2.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:89fdde631156fe9b7778a2bdc9e1a58d607190ccaf1ef0aed322e60320647c4f"},
 ]
 clickhouse-sqlalchemy = [
     {file = "clickhouse-sqlalchemy-0.1.8.tar.gz", hash = "sha256:0ebd727fe9e250a119ea00134a7290a19fbadb79243b8936af1437f674c1e413"},
@@ -2326,8 +2341,8 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 commitizen = [
-    {file = "commitizen-2.20.4-py3-none-any.whl", hash = "sha256:8bd422319abcdbdbe620aea947b94a58c407996b80c724556c6d7f0e8ab07d49"},
-    {file = "commitizen-2.20.4.tar.gz", hash = "sha256:33fe190935412011a9e9e0a3fc80f4b874bc250461a9374b1169f2d86cb81901"},
+    {file = "commitizen-2.20.5-py3-none-any.whl", hash = "sha256:836229809351f38bbe616fd81dce70be7cf59b82e64a37b976171a9c9412e829"},
+    {file = "commitizen-2.20.5.tar.gz", hash = "sha256:abc14650e79b5366d200c5fcf484e4389337c05aaef0285d09329cc367eab836"},
 ]
 coverage = [
     {file = "coverage-6.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eeffd96882d8c06d31b65dddcf51db7c612547babc1c4c5db6a011abe9798525"},
@@ -2454,15 +2469,15 @@ execnet = [
     {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
 ]
 fiona = [
-    {file = "Fiona-1.8.20-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:02880556540e36ad6aac97687799d9b3093c354787a47bc0e73026c7fc15f1b3"},
-    {file = "Fiona-1.8.20-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:3f668c471fa2f8c9c0a9ca83639cb2c8dcc93edc3d93d43dba2f9e8da38ad53e"},
-    {file = "Fiona-1.8.20-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:54f81039e913d0f88728ef23edf5a69038dec94dea54f4c799f972ba8e2a7d40"},
-    {file = "Fiona-1.8.20-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:328340a448bed5c43d119f61f760368a04d13a302c59d2fccb051a3ff021f4b8"},
-    {file = "Fiona-1.8.20-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:03f910380dbe684730b59b817aa030e6e9a3ee79211b66c6db2d1c8fe6ea12de"},
-    {file = "Fiona-1.8.20-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:bef100ebd82afb9a4d67096216e82611b82ca9341330e4805832d7ff8c9bc1f7"},
-    {file = "Fiona-1.8.20-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5e1cef608c6de9039eaa65b395024096e3189ab0559a5a328c68c4690c3302ce"},
-    {file = "Fiona-1.8.20-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e72e4a5b84ec410be531d4fe4c1a5c87c6c0e92d01116c145c0f1b33f81c8080"},
-    {file = "Fiona-1.8.20.tar.gz", hash = "sha256:a70502d2857b82f749c09cb0dea3726787747933a2a1599b5ab787d74e3c143b"},
+    {file = "Fiona-1.8.21-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:39c656421e25b4d0d73d0b6acdcbf9848e71f3d9b74f44c27d2d516d463409ae"},
+    {file = "Fiona-1.8.21-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43b1d2e45506e56cf3a9f59ba5d6f7981f3f75f4725d1e6cb9a33ba856371ebd"},
+    {file = "Fiona-1.8.21-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:b69054ed810eb7339d7effa88589afca48003206d7627d0b0b149715fc3fde41"},
+    {file = "Fiona-1.8.21-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:11532ccfda1073d3f5f558e4bb78d45b268e8680fd6e14993a394c564ddbd069"},
+    {file = "Fiona-1.8.21-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:3789523c811809a6e2e170cf9c437631f959f4c7a868f024081612d30afab468"},
+    {file = "Fiona-1.8.21-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:085f18d943097ac3396f3f9664ac1ae04ad0ff272f54829f03442187f01b6116"},
+    {file = "Fiona-1.8.21-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:388acc9fa07ba7858d508dfe826d4b04d813818bced16c4049de19cc7ca322ef"},
+    {file = "Fiona-1.8.21-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40b4eaf5b88407421d6c9e707520abd2ff16d7cd43efb59cd398aa41d2de332c"},
+    {file = "Fiona-1.8.21.tar.gz", hash = "sha256:3a0edca2a7a070db405d71187214a43d2333a57b4097544a3fcc282066a58bfc"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
@@ -2534,8 +2549,8 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 ipykernel = [
-    {file = "ipykernel-6.8.0-py3-none-any.whl", hash = "sha256:6c977ead67ec22151993a5f848b97e57a5e771f979b510941e157b2e7fe54184"},
-    {file = "ipykernel-6.8.0.tar.gz", hash = "sha256:67d316d527eca24e3ded45a2b38689615bcda1aa520a11af0accdcea7152c18a"},
+    {file = "ipykernel-6.9.0-py3-none-any.whl", hash = "sha256:1626b91c50e4605555ac6e5b29f1e5206d299a4a4a21483770a181be97f0f0e0"},
+    {file = "ipykernel-6.9.0.tar.gz", hash = "sha256:b556e292dc6fa223f24328b1c936b9c921fafcc2f420bb0d6cfdfc42eaa90225"},
 ]
 ipython = [
     {file = "ipython-7.31.1-py3-none-any.whl", hash = "sha256:55df3e0bd0f94e715abd968bedd89d4e8a7bce4bf498fb123fed4f5398fea874"},
@@ -2907,8 +2922,8 @@ plumbum = [
     {file = "plumbum-1.7.2.tar.gz", hash = "sha256:0d1bf908076bbd0484d16412479cb97d6843069ee19f99e267e11dd980040523"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.26-py3-none-any.whl", hash = "sha256:4bcf119be2200c17ed0d518872ef922f1de336eb6d1ddbd1e089ceb6447d97c6"},
-    {file = "prompt_toolkit-3.0.26.tar.gz", hash = "sha256:a51d41a6a45fd9def54365bca8f0402c8f182f2b6f7e29c74d55faeb9fb38ac4"},
+    {file = "prompt_toolkit-3.0.27-py3-none-any.whl", hash = "sha256:cb7dae7d2c59188c85a1d6c944fad19aded6a26bd9c8ae115a4e1c20eb90b713"},
+    {file = "prompt_toolkit-3.0.27.tar.gz", hash = "sha256:f2b6a8067a4fb959d3677d1ed764cc4e63e0f6f565b9a4fc7edc2b18bf80217b"},
 ]
 psycopg2 = [
     {file = "psycopg2-2.9.3-cp310-cp310-win32.whl", hash = "sha256:083707a696e5e1c330af2508d8fab36f9700b26621ccbcb538abe22e15485362"},
@@ -3434,8 +3449,8 @@ tomli = [
     {file = "tomli-2.0.0.tar.gz", hash = "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.9.0-py3-none-any.whl", hash = "sha256:c1b0fc73abd4f1e77c29ea4061ca0f2e11cbfb77342e17df3d3fdd496fc3f899"},
-    {file = "tomlkit-0.9.0.tar.gz", hash = "sha256:5a83672c565f78f5fc8f1e44e5f2726446cc6b765113efd21d03e9331747d9ab"},
+    {file = "tomlkit-0.9.1-py3-none-any.whl", hash = "sha256:01407892165b513969231085a33d4be2cb41f186d9fd072c975b6bd1435371b0"},
+    {file = "tomlkit-0.9.1.tar.gz", hash = "sha256:3bdbfffc3ae6c8628b5fb6ed7b459edb8476472eae15033b705bc7d1380b3e3d"},
 ]
 toolz = [
     {file = "toolz-0.11.2-py3-none-any.whl", hash = "sha256:a5700ce83414c64514d82d60bcda8aabfde092d1c1a8663f9200c07fdcc6da8f"},


### PR DESCRIPTION
Tests starting failing for `clickhouse_driver==0.2.3` (showing up after running `poetry update`). This PR fixes the underlying cause.