### PR TITLE
chore: fix dask array literal test

### DIFF
--- a/ibis/backends/dask/tests/execution/test_arrays.py
+++ b/ibis/backends/dask/tests/execution/test_arrays.py
@@ -7,7 +7,6 @@ import pytest
 from dask.dataframe.utils import tm
 
 import ibis
-from ibis.common.exceptions import IbisTypeError
 
 
 def test_array_length(t, df):
@@ -77,21 +76,8 @@ def test_array_collect_rolling_partitioned(t, df):
     tm.assert_frame_equal(result.compute(), expected.compute())
 
 
-@pytest.mark.xfail(raises=IbisTypeError, reason='Not sure if this should work')
-def test_array_collect_scalar(client):
-    raw_value = 'abcd'
-    value = ibis.literal(raw_value)
-    expr = value.collect()
-    result = client.execute(expr)
-    expected = [raw_value]
-    assert result == expected
-
-
-@pytest.mark.xfail(
-    raises=NotImplementedError,
-    reason='TODO - arrays - #2553'
-    # Need an ops.ArraySlice execution func that dispatches on dd.Series
-)
+# Need an ops.ArraySlice execution func that dispatches on dd.Series
+@pytest.mark.xfail(raises=NotImplementedError, reason="TODO - arrays - #2553")
 @pytest.mark.parametrize(
     ['start', 'stop'],
     [

--- a/ibis/backends/dask/tests/test_datatypes.py
+++ b/ibis/backends/dask/tests/test_datatypes.py
@@ -8,7 +8,6 @@ from pandas.api.types import CategoricalDtype, DatetimeTZDtype
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
-import ibis.expr.types as ir
 
 
 def test_no_infer_ambiguities():
@@ -85,14 +84,15 @@ def test_dask_dtype(dask_dtype, ibis_dtype):
     assert dt.dtype(dask_dtype) == ibis_dtype
 
 
-@pytest.mark.xfail(TypeError, reason="TODO - as_value_expr - #2553")
-def test_series_to_ibis_literal():
+def test_series_to_ibis_literal(core_client):
     values = [1, 2, 3, 4]
     s = dd.from_pandas(pd.Series(values), npartitions=1)
 
-    expr = ir.as_value_expr(s)
-    expected = ir.sequence(list(s))
-    assert expr.equals(expected)
+    expr = ibis.array(s)
+
+    assert expr.equals(ibis.array(values))
+
+    assert core_client.execute(expr) == pytest.approx([1, 2, 3, 4])
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/pandas/tests/execution/test_arrays.py
+++ b/ibis/backends/pandas/tests/execution/test_arrays.py
@@ -6,7 +6,6 @@ import pandas._testing as tm
 import pytest
 
 import ibis
-from ibis.common.exceptions import IbisTypeError
 
 
 @pytest.mark.parametrize('arr', [[1, 3, 5], np.array([1, 3, 5])])
@@ -81,16 +80,6 @@ def test_array_collect_rolling_partitioned(t, df):
         }
     )[expr.columns]
     tm.assert_frame_equal(result, expected)
-
-
-@pytest.mark.xfail(raises=IbisTypeError, reason='Not sure if this should work')
-def test_array_collect_scalar(client):
-    raw_value = 'abcd'
-    value = ibis.literal(raw_value)
-    expr = value.collect()
-    result = client.execute(expr)
-    expected = [raw_value]
-    tm.assert_numpy_array_equal(result, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Small fixes to some of the dask tests to remove tests that aren't checking anything of value and editing `test_series_to_ibis_literal` to make use of `ibis.array` and check execution.