### PR TITLE
test: remove flaky test

### DIFF
--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -63,16 +63,6 @@ def test_list_tables(con):
     assert len(con.list_tables(like='functional')) == 1
 
 
-def test_database_layer(con, alltypes):
-    db = con.database()
-    t = db.functional_alltypes
-
-    # TODO: we can't use assert_equal here because of #2973
-    assert t.schema() == alltypes.schema()
-    assert t.op().name == alltypes.op().name
-    assert db.list_tables() == con.list_tables()
-
-
 def test_compile_toplevel():
     t = ibis.table([('foo', 'double')], name='t0')
 


### PR DESCRIPTION
This PR removes a test that is flaky when parallelized. Since the database API is deprecated, there is no reason to leave this around