### PR TITLE
fix: change TimestampType to Timestamp

### DIFF
--- a/ibis/backends/datafusion/datatypes.py
+++ b/ibis/backends/datafusion/datatypes.py
@@ -39,7 +39,7 @@ def from_pyarrow_primitive(arrow_type, nullable=True):
 
 @dt.dtype.register(pa.TimestampType)
 def from_pyarrow_timestamp(arrow_type, nullable=True):
-    return dt.TimestampType(timezone=arrow_type.tz)
+    return dt.Timestamp(timezone=arrow_type.tz)
 
 
 @sch.infer.register(pa.Schema)


### PR DESCRIPTION
In datafusion backend. 

I believe this is the correct type as I can't find `TimestampType` in `ibis.expr.datatypes`.