### PR TITLE
Removing easy install which is depreciated 

### DIFF
--- a/docs/contribute/environment.md
+++ b/docs/contribute/environment.md
@@ -93,7 +93,7 @@ There are two primary ways to setup a development environment.
 
     1. Install your local copy of `ibis` into the Conda environment. In the root of the project run:
 
-            pip install .
+            pip install -e .
 
     1. If you want to run the backend test suite you'll need to install `docker-compose`:
 

--- a/docs/contribute/environment.md
+++ b/docs/contribute/environment.md
@@ -93,7 +93,7 @@ There are two primary ways to setup a development environment.
 
     1. Install your local copy of `ibis` into the Conda environment. In the root of the project run:
 
-            pip install -e .
+            pip install .
 
     1. If you want to run the backend test suite you'll need to install `docker-compose`:
 


### PR DESCRIPTION
Hi! 

I went through the contributing guide using miniconda and tried to install the ibis dependencies with easy install. It turns out it was [depreciated](https://setuptools.pypa.io/en/latest/deprecated/easy_install.html). Running `pip install -e` or `pip3 install -e` works fine though! 