### PR TITLE
feat: add repr html for pretty notebook tables

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from public import public
 
+import ibis
 import ibis.common.exceptions as com
 
 from .core import Expr
@@ -77,6 +78,9 @@ class ScalarExpr(ValueExpr):
         table = TableExpr(roots[0])
         return table.projection([self])
 
+    def _repr_html_(self) -> str | None:
+        return None
+
 
 @public
 class ColumnExpr(ValueExpr):
@@ -102,6 +106,12 @@ class ColumnExpr(ValueExpr):
 
         table = TableExpr(roots[0])
         return table.projection([self])
+
+    def _repr_html_(self) -> str | None:
+        if not ibis.options.interactive:
+            return None
+
+        return self.execute().to_frame()._repr_html_()
 
 
 @public

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Iterable
 import numpy as np
 from public import public
 
+import ibis
 import ibis.common.exceptions as com
 import ibis.util as util
 
@@ -44,6 +45,12 @@ class TableExpr(Expr):
 
     def __contains__(self, name):
         return name in self.schema()
+
+    def _repr_html_(self) -> str | None:
+        if not ibis.options.interactive:
+            return None
+
+        return self.execute()._repr_html_()
 
     def __getitem__(self, what):
         from .analytic import AnalyticExpr

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1380,3 +1380,21 @@ def test_repr_list_of_lists_in_table():
     lit = ibis.literal([[1]])
     expr = t[t, lit.name('array_of_array')]
     repr(expr)
+
+
+def test_repr_html():
+    con = ibis.pandas.connect({"t": pd.DataFrame({"a": [1, 2, 3]})})
+    t = con.table("t")
+
+    assert t._repr_html_() is None
+    assert t.a._repr_html_() is None
+    assert t.a.sum()._repr_html_() is None
+
+    interactive = ibis.options.interactive
+    ibis.options.interactive = True
+    try:
+        assert 'table' in t._repr_html_()
+        assert 'table' in t.a._repr_html_()
+        assert t.a.sum()._repr_html_() is None
+    finally:
+        ibis.options.interactive = interactive


### PR DESCRIPTION
This PR implements `_repr_html_` for interactive mode (currently delegating to
pandas implementation) to enable pretty printing tables in the notebook.

![image](https://user-images.githubusercontent.com/417981/155140977-f40241f9-f386-45dd-a16b-98e8bdc850d1.png)