### PR TITLE
docs(workflow.md): adding to the cz install tip

### DIFF
--- a/docs/contribute/workflow.md
+++ b/docs/contribute/workflow.md
@@ -77,7 +77,7 @@ Setting `PYTEST_BACKENDS` unless you want to run the backend test suite
 !!! tip
 
     `cz` is already installed in your environment if you followed the [setup
-    instructions](environment.md)
+    instructions](environment.md) If not install it using `pip install commitizen`
 
 Next, you'll want to commit your changes.
 


### PR DESCRIPTION
Adding to the cz install tip in case users don't know the package name, don't have it  and want to install it.
