### PR TITLE
refactor(pandas): remove post_execute

### DIFF
--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -69,29 +69,6 @@ Then, when an expression is ready to be evaluated we call
 :func:`~ibis.dask.dispatch.execute_node` on the expression with its
 now-materialized arguments.
 
-4. ``post_execute``
--------------------
-The final step--``post_execute``--is called immediately after the previous call
-to ``execute_node`` and takes the instance of the
-:class:`~ibis.expr.operations.Node` just computed and the result of the
-computation.
-
-The purpose of this function is to allow additional computation to happen in
-the context of the current level of the execution loop. You might be wondering
-That may sound vague, so let's look at an example.
-
-Let's say you want to take a three day rolling average, and you want to include
-3 days of data prior to the first date of the input. You don't want to see that
-data in the result for a few reasons, one of which is that it would break the
-contract of window functions: given N rows of input there are N rows of output.
-
-Defining a ``post_execute`` rule for :class:`~ibis.expr.operations.WindowOp`
-allows you to encode such logic. One might want to implement this using
-:class:`~ibis.expr.operations.ScalarParameter`, in which case the ``scope``
-passed to ``post_execute`` would be the bound values passed in at the time the
-``execute`` method was called.
-
-
 Scope
 -----
 Scope is used across the execution phases, it iss a map that maps Ibis
@@ -106,7 +83,6 @@ stored in value
 
 See ibis.common.scope for details about the implementaion.
 """
-import functools
 from typing import Optional
 
 import dask.dataframe as dd
@@ -125,7 +101,7 @@ from ibis.expr.scope import Scope
 from ibis.expr.timecontext import canonicalize_context
 from ibis.expr.typing import TimeContext
 
-from .dispatch import execute_literal, execute_node, post_execute, pre_execute
+from .dispatch import execute_literal, execute_node, pre_execute
 from .trace import trace
 
 is_computable_input.register(dd.core.Scalar)(is_computable_input_arg)
@@ -185,17 +161,6 @@ def execute_with_scope(
         timecontext=timecontext,
         aggcontext=aggcontext,
         clients=clients,
-        # XXX: we *explicitly* pass in scope and not new_scope here so that
-        # post_execute sees the scope of execute_with_scope, not the scope of
-        # execute_until_in_scope
-        post_execute_=functools.partial(
-            post_execute,
-            scope=scope,
-            timecontext=timecontext,
-            aggcontext=aggcontext,
-            clients=clients,
-            **kwargs,
-        ),
         **kwargs,
     ).get_value(op, timecontext)
     return result
@@ -208,7 +173,6 @@ def execute_until_in_scope(
     timecontext: Optional[TimeContext] = None,
     aggcontext=None,
     clients=None,
-    post_execute_=None,
     **kwargs,
 ) -> Scope:
     """Execute until our op is in `scope`.
@@ -225,7 +189,6 @@ def execute_until_in_scope(
     # these should never be None
     assert aggcontext is not None, 'aggcontext is None'
     assert clients is not None, 'clients is None'
-    assert post_execute_ is not None, 'post_execute_ is None'
 
     # base case: our op has been computed (or is a leaf data node), so
     # return the corresponding value
@@ -294,7 +257,6 @@ def execute_until_in_scope(
             new_scope,
             timecontext=timecontext,
             aggcontext=aggcontext,
-            post_execute_=post_execute_,
             clients=clients,
             **kwargs,
         )
@@ -330,8 +292,7 @@ def execute_until_in_scope(
         clients=clients,
         **kwargs,
     )
-    computed = post_execute_(op, result, timecontext=timecontext)
-    return Scope({op: computed}, timecontext)
+    return Scope({op: result}, timecontext)
 
 
 execute = Dispatcher('execute')

--- a/ibis/backends/dask/dispatch.py
+++ b/ibis/backends/dask/dispatch.py
@@ -16,6 +16,3 @@ pre_execute.funcs.update(core_dispatch.pre_execute.funcs)
 
 execute_literal = Dispatcher('execute_literal')
 execute_literal.funcs.update(core_dispatch.execute_literal.funcs)
-
-post_execute = Dispatcher('post_execute')
-post_execute.funcs.update(core_dispatch.post_execute.funcs)

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -17,10 +17,10 @@ from dask.dataframe.utils import tm  # noqa: E402
 from ibis.backends.dask import Backend  # noqa: E402
 
 from ..core import execute, is_computable_input  # noqa: E402
-from ..dispatch import execute_node, post_execute, pre_execute  # noqa: E402
+from ..dispatch import execute_node, pre_execute  # noqa: E402
 
 
-@pytest.mark.parametrize('func', [execute_node, pre_execute, post_execute])
+@pytest.mark.parametrize('func', [execute_node, pre_execute])
 def test_no_execute_ambiguities(func):
     assert not ambiguities(func.funcs)
 
@@ -91,23 +91,6 @@ def test_missing_data_on_custom_client():
         ),
     ):
         con.execute(t)
-
-
-def test_post_execute_called_on_joins(dataframe, core_client, ibis_table):
-    count = [0]
-
-    @post_execute.register(ops.InnerJoin, dd.DataFrame)
-    def tmp_left_join_exe(op, lhs, **kwargs):
-        count[0] += 1
-        return lhs
-
-    left = ibis_table
-    right = left.view()
-    join = left.join(right, 'plain_strings')[left.plain_int64]
-    result = join.execute()
-    assert result is not None
-    assert len(result.index) > 0
-    assert count[0] == 1
 
 
 def test_is_computable_input():

--- a/ibis/backends/pandas/dispatch.py
+++ b/ibis/backends/pandas/dispatch.py
@@ -79,24 +79,4 @@ datatype : ibis.expr.datatypes.DataType
 )
 
 
-post_execute = Dispatcher(
-    'post_execute',
-    doc="""\
-Execute code on the result of a computation.
-
-Parameters
-----------
-op : ibis.expr.operations.Node
-    The operation that was just executed
-data : object
-    The result of the computation
-""",
-)
-
-
-@post_execute.register(ops.Node, object)
-def post_execute_default(op, data, **kwargs):
-    return data
-
-
 execute = Dispatcher("execute")

--- a/ibis/backends/pandas/execution/timecontext.py
+++ b/ibis/backends/pandas/execution/timecontext.py
@@ -14,8 +14,6 @@ to be in the time range.
 ``execute_node`` of a leaf node can use timecontext to trim data, or to pass
 it as a filter in the database query.
 
-In some cases, data need to be trimmed in ``post_execute``.
-
 Note: In order to use the feature we implemented here, there must be a
 column of Timestamp type, and named as 'time' in TableExpr. And this 'time'
 column should be preserved across the expression tree. If 'time' column is

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -65,7 +65,7 @@ def compute_sorted_frame(
         computed_sort_keys, ascending=ascending, kind='mergesort'
     )
     # TODO: we'll eventually need to return this frame with the temporary
-    # columns and drop them in the caller (maybe using post_execute?)
+    # columns and drop them in the caller
     ngrouping_keys = len(group_by)
     return (
         result,

--- a/ibis/backends/pandas/tests/test_core.py
+++ b/ibis/backends/pandas/tests/test_core.py
@@ -11,11 +11,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.backends.pandas import Backend
 from ibis.backends.pandas.core import is_computable_input
-from ibis.backends.pandas.dispatch import (
-    execute_node,
-    post_execute,
-    pre_execute,
-)
+from ibis.backends.pandas.dispatch import execute_node, pre_execute
 from ibis.backends.pandas.execution import execute
 from ibis.expr.scope import Scope
 
@@ -41,7 +37,7 @@ def ibis_table(core_client):
     return core_client.table('df')
 
 
-@pytest.mark.parametrize('func', [execute_node, pre_execute, post_execute])
+@pytest.mark.parametrize('func', [execute_node, pre_execute])
 def test_no_execute_ambiguities(func):
     assert not ambiguities(func.funcs)
 
@@ -112,23 +108,6 @@ def test_missing_data_on_custom_client():
         ),
     ):
         con.execute(t)
-
-
-def test_post_execute_called_on_joins(dataframe, core_client, ibis_table):
-    count = [0]
-
-    @post_execute.register(ops.InnerJoin, pd.DataFrame)
-    def tmp_left_join_exe(op, lhs, **kwargs):
-        count[0] += 1
-        return lhs
-
-    left = ibis_table
-    right = left.view()
-    join = left.join(right, 'plain_strings')[left.plain_int64]
-    result = join.execute()
-    assert result is not None
-    assert not result.empty
-    assert count[0] == 1
 
 
 def test_is_computable_input():


### PR DESCRIPTION
Seems like post-execute wasn't actually utilized, at least within ibis' codebase. 

@cpcloud shall we still support it?