### PR TITLE
feat: implement most remaining joins

### DIFF
--- a/ci/datamgr.py
+++ b/ci/datamgr.py
@@ -198,7 +198,7 @@ def cli(verbose):
 
 @cli.command()
 @click.pass_context
-def create(ctx):
+def generate_parquet(ctx):
     import pyarrow.parquet as pq
 
     executor = ctx.obj["executor"]

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -56,8 +56,13 @@ class ClickhouseSelect(Select):
 class ClickhouseTableSetFormatter(TableSetFormatter):
 
     _join_names = {
-        ops.InnerJoin: 'ALL INNER JOIN',
-        ops.LeftJoin: 'ALL LEFT JOIN',
+        ops.InnerJoin: 'INNER JOIN',
+        ops.LeftJoin: 'LEFT OUTER JOIN',
+        ops.RightJoin: 'RIGHT OUTER JOIN',
+        ops.OuterJoin: 'FULL OUTER JOIN',
+        ops.CrossJoin: 'CROSS JOIN',
+        ops.LeftSemiJoin: 'LEFT SEMI JOIN',
+        ops.LeftAntiJoin: 'LEFT ANTI JOIN',
         ops.AnyInnerJoin: 'ANY INNER JOIN',
         ops.AnyLeftJoin: 'ANY LEFT JOIN',
     }

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -56,15 +56,15 @@ class ClickhouseSelect(Select):
 class ClickhouseTableSetFormatter(TableSetFormatter):
 
     _join_names = {
-        ops.InnerJoin: 'INNER JOIN',
-        ops.LeftJoin: 'LEFT OUTER JOIN',
-        ops.RightJoin: 'RIGHT OUTER JOIN',
-        ops.OuterJoin: 'FULL OUTER JOIN',
+        ops.InnerJoin: 'ALL INNER JOIN',
+        ops.LeftJoin: 'ALL LEFT OUTER JOIN',
+        ops.RightJoin: 'ALL RIGHT OUTER JOIN',
+        ops.OuterJoin: 'ALL FULL OUTER JOIN',
         ops.CrossJoin: 'CROSS JOIN',
         ops.LeftSemiJoin: 'LEFT SEMI JOIN',
         ops.LeftAntiJoin: 'LEFT ANTI JOIN',
         ops.AnyInnerJoin: 'ANY INNER JOIN',
-        ops.AnyLeftJoin: 'ANY LEFT JOIN',
+        ops.AnyLeftJoin: 'ANY LEFT OUTER JOIN',
     }
 
     _non_equijoin_supported = False

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -260,8 +260,8 @@ def test_non_equijoin(alltypes):
         [
             ('any_inner_join', 'ANY INNER JOIN'),
             ('inner_join', 'ALL INNER JOIN'),
-            ('any_left_join', 'ANY LEFT JOIN'),
-            ('left_join', 'ALL LEFT JOIN'),
+            ('any_left_join', 'ANY LEFT OUTER JOIN'),
+            ('left_join', 'ALL LEFT OUTER JOIN'),
         ],
         [
             ('playerID', 'playerID'),

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -474,8 +474,6 @@ class Backend(BaseSQLBackend):
 
         names, types = zip(*pairs)
         ibis_types = [udf.parse_type(type.lower()) for type in types]
-        names = [name.lower() for name in names]
-
         return sch.Schema(names, ibis_types)
 
     @property
@@ -990,13 +988,6 @@ class Backend(BaseSQLBackend):
         cur.fetchall()
         names, ibis_types = self._adapt_types(cur.description)
         cur.release()
-
-        # per #321; most Impala tables will be lower case already, but Avro
-        # data, depending on the version of Impala, might have field names in
-        # the metastore cased according to the explicit case in the declared
-        # avro schema. This is very annoying, so it's easier to just conform on
-        # all lowercase fields from Impala.
-        names = [x.lower() for x in names]
 
         return sch.Schema(names, ibis_types)
 

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -1022,7 +1022,10 @@ def execute_node_nullif_scalar_series(op, value, series, **kwargs):
 
 
 def coalesce(values):
-    return functools.reduce(lambda x, y: x if not pd.isnull(x) else y, values)
+    return functools.reduce(
+        lambda a1, a2: np.where(pd.isnull(a1), a2, a1),
+        values,
+    )
 
 
 @toolz.curry

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -649,6 +649,17 @@ def compile_arbitrary(t, expr, scope, timecontext, context=None, **kwargs):
     )
 
 
+@compiles(ops.Coalesce)
+def compile_coalesce(t, expr, scope, timecontext, **kwargs):
+    op = expr.op()
+
+    src_columns = t.translate(op.arg, scope, timecontext)
+    if len(src_columns) == 1:
+        return src_columns[0]
+    else:
+        return F.coalesce(*src_columns)
+
+
 @compiles(ops.Greatest)
 def compile_greatest(t, expr, scope, timecontext, **kwargs):
     op = expr.op()

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1157,6 +1157,16 @@ def compile_outer_join(t, expr, scope, timecontext, **kwargs):
     return compile_join(t, expr, scope, timecontext, how='outer')
 
 
+@compiles(ops.LeftSemiJoin)
+def compile_left_semi_join(t, expr, scope, timecontext, **kwargs):
+    return compile_join(t, expr, scope, timecontext, how='leftsemi')
+
+
+@compiles(ops.LeftAntiJoin)
+def compile_left_anti_join(t, expr, scope, timecontext, **kwargs):
+    return compile_join(t, expr, scope, timecontext, how='leftanti')
+
+
 def compile_join(t, expr, scope, timecontext, *, how):
     op = expr.op()
 

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -23,7 +23,6 @@ def get_common_spark_testing_client(data_directory, connect):
         SparkSession.builder.appName("ibis_testing")
         .master("local[1]")
         .config("spark.cores.max", 1)
-        .config("spark.driver.bindAddress", "127.0.0.1")
         .config("spark.executor.heartbeatInterval", "3600s")
         .config("spark.executor.instances", 1)
         .config("spark.network.timeout", "4200s")

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -72,6 +72,7 @@ class BackendTest(abc.ABC):
 
     def __init__(self, data_directory: Path) -> None:
         self.connection = self.connect(data_directory)
+        self.data_directory = data_directory
 
     def __str__(self):
         return f'<BackendTest {self.name()}>'

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -375,19 +375,7 @@ def test_topk_op(backend, alltypes, df, result_fn, expected_fn):
 @pytest.mark.xfail_backends(
     [('mysql', 'Issue #2131'), ('postgres', 'Issue #2132')]
 )
-@mark.notimpl(
-    [
-        "clickhouse",
-        "datafusion",
-        "pandas",
-        "dask",
-        "duckdb",
-        "hdf5",
-        "csv",
-        "parquet",
-        "pyspark",
-    ]
-)
+@mark.notimpl(["datafusion", "duckdb", "pandas", "dask", "pyspark"])
 def test_topk_filter_op(backend, alltypes, df, result_fn, expected_fn):
     # TopK expression will order rows by "count" but each backend
     # can have different result for that.
@@ -395,7 +383,8 @@ def test_topk_filter_op(backend, alltypes, df, result_fn, expected_fn):
     # and the field used by TopK
     t = alltypes.sort_by(alltypes.string_col)
     df = df.sort_values('string_col')
-    result = result_fn(t).execute()
+    expr = result_fn(t)
+    result = expr.execute()
     expected = expected_fn(df)
     assert result.shape[0] == expected.shape[0]
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -88,17 +88,17 @@ def test_fillna(backend, alltypes):
         param(
             ibis.coalesce(5, None, 4),
             5,
-            marks=pytest.mark.notimpl(["pyspark", "datafusion"]),
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             ibis.coalesce(ibis.NA, 4, ibis.NA),
             4,
-            marks=pytest.mark.notimpl(["pyspark", "datafusion"]),
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             ibis.coalesce(ibis.NA, ibis.NA, 3.14),
             3.14,
-            marks=pytest.mark.notimpl(["pyspark", "datafusion"]),
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
     ],
 )

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -531,7 +531,6 @@ def test_clip(alltypes, df, ibis_func, pandas_func):
 
 @pytest.mark.notimpl(
     [
-        "clickhouse",
         "dask",
         "datafusion",
         "pandas",

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -167,9 +167,16 @@ class Schema:
         -----
         Mutates `df`
         """
+        schema_names = self.names
+        data_columns = df.columns
 
-        for column, dtype in self.items():
+        assert len(schema_names) == len(
+            data_columns
+        ), "schema column count does not match input data column count"
+
+        for column, dtype in zip(data_columns, self.types):
             pandas_dtype = dtype.to_pandas()
+
             col = df[column]
             col_dtype = col.dtype
 
@@ -181,8 +188,14 @@ class Schema:
                 not_equal = True
 
             if not_equal or isinstance(dtype, dt.String):
-                df[column] = convert(col_dtype, dtype, col)
+                new_col = convert(col_dtype, dtype, col)
+            else:
+                new_col = col
+            df[column] = new_col
 
+        # return data with the schema's columns which may be different than the
+        # input columns
+        df.columns = schema_names
         return df
 
 

--- a/ibis/tests/expr/test_schema.py
+++ b/ibis/tests/expr/test_schema.py
@@ -1,3 +1,7 @@
+import pandas as pd
+import pandas.util.testing as tm
+import pytest
+
 import ibis
 from ibis.expr import datatypes as dt
 
@@ -166,3 +170,21 @@ def test_nullable_output():
     assert 'bar  int64[non-nullable]' in sch_str
     assert 'baz  boolean' in sch_str
     assert 'baz  boolean[non-nullable]' not in sch_str
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame({"A": pd.Series([1], dtype="int8"), "b": ["x"]})
+
+
+def test_apply_to_column_rename(df):
+    schema = ibis.schema([("a", "int8"), ("B", "string")])
+    expected = df.rename({"A": "a", "b": "B"}, axis=1)
+    tm.assert_frame_equal(schema.apply_to(df.copy()), expected)
+
+
+def test_apply_to_column_order(df):
+    schema = ibis.schema([("a", "int8"), ("b", "string")])
+    expected = df.rename({"A": "a"}, axis=1)
+    new_df = schema.apply_to(df.copy())
+    tm.assert_frame_equal(new_df, expected)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -18,7 +18,7 @@ import sources.nixpkgs {
         owner = "ibis-project";
         repo = "testing-data";
         rev = "master";
-        sha256 = "1lm66g5kvisxsjf1jwayiyxl2d3dhlmxj13ijrya3pfg07mq9r66";
+        sha256 = "sha256-BZWi4kEumZemQeYoAtlUSw922p+R6opSWp/bmX0DjAo=";
       };
 
       mkPoetryEnv = python: pkgs.poetry2nix.mkPoetryEnv {


### PR DESCRIPTION
This PR implements most remaining joins, to allow nearly all of them to
successfully pass the join backend test. The test itself has also been
simplified.

Things done:

- clickhouse joins
- pyspark coalesce
- semi/anti join for pyspark
- semi/anti join for pandas
- enforcing column names, not just types, in `Schema.apply_to`; this is the handle the
  impala case where column names' case may not match the actual schema's
  columns' case.

Things still not working:

- clickhouse right/outer joins; the results don't seem to match up to any other
  backend because values selected from the right table on right join are zero
  or null when there's no match, similar behavior occurs with outer joins


Things not yet implemented in ibis:

- datafusion; joins aren't implemented
- dask; semi/anti joins aren't implemented

Things that aren't yet implemented upstream and may never be:

- right joins in sqlite
- full outer joins in mysql and sqlite

Things that seem broken:

- The clickhouse and impala compilers generate invalid SQL for the semi/anti join query in `test_filtering_join`. This needs to be fixed in a subsequent PR.
