### PR TITLE
fix: fix coalesce-like type inference

### DIFF
--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -464,11 +464,6 @@ def test_coalesce(con, expr, expected):
     [
         param(ibis.coalesce(ibis.NA, ibis.NA), None, id='all_null'),
         param(
-            ibis.coalesce(ibis.NA, ibis.NA, ibis.NA.cast('double')),
-            None,
-            id='all_nulls_with_one_cast',
-        ),
-        param(
             ibis.coalesce(
                 ibis.NA.cast('int8'),
                 ibis.NA.cast('int8'),
@@ -480,7 +475,12 @@ def test_coalesce(con, expr, expected):
     ],
 )
 def test_coalesce_all_na(con, expr, expected):
-    assert con.execute(expr) == expected
+    assert con.execute(expr) is None
+
+
+def test_coalesce_all_na_double(con):
+    expr = ibis.coalesce(ibis.NA, ibis.NA, ibis.NA.cast('double'))
+    assert np.isnan(con.execute(expr))
 
 
 def test_numeric_builtins_work(alltypes, df):

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -196,10 +196,12 @@ class CoalesceLike(ValueOp):
     arg = rlz.value_list_of(rlz.any)
 
     def output_type(self):
-        first = self.arg[0]
-        ty = first.type()
-        dtype = getattr(ty, "largest", ty)
-        # self.arg is a list of value expressions
+        # filter out null types
+        non_null_exprs = [arg for arg in self.arg if arg.type() != dt.null]
+        if not non_null_exprs:
+            dtype = dt.null
+        else:
+            dtype = rlz.highest_precedence_dtype(non_null_exprs)
         return rlz.shape_like(self.arg, dtype)
 
 

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1398,3 +1398,21 @@ def test_repr_html():
         assert t.a.sum()._repr_html_() is None
     finally:
         ibis.options.interactive = interactive
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected_type"),
+    [
+        (ibis.coalesce(ibis.NA, 1), dt.int8),
+        (ibis.coalesce(1, ibis.NA), dt.int8),
+        (ibis.coalesce(ibis.NA, 1000), dt.int16),
+        (ibis.coalesce(ibis.NA), dt.null),
+        (ibis.coalesce(ibis.NA, ibis.NA), dt.null),
+        (
+            ibis.coalesce(ibis.NA, ibis.NA.cast("array<string>")),
+            dt.Array(dt.string),
+        ),
+    ],
+)
+def test_coalesce_type_inference_with_nulls(expr, expected_type):
+    assert expr.type() == expected_type


### PR DESCRIPTION
This PR addresses a bug where a `null`-typed expression occuring first in a `CoalesceLike`
operation results in an expression `output_type` of `null`.

The algorithm used here is to remove all `null` typed expressions and then pass the
resulting list to `ibis.expr.datatypes.highest_precedence_dtype`.
