### PR TITLE
refactor: reuse more sqlalchemy base class code

### DIFF
--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import warnings
 
@@ -121,33 +123,6 @@ class Backend(BaseAlchemyBackend):
             finally:
                 query = "SET @@session.time_zone = '{}'"
                 bind.execute(query.format(previous_timezone))
-
-    def table(self, name, database=None, schema=None):
-        """Create a table expression that references a particular a table
-        called `name` in a MySQL database called `database`.
-
-        Parameters
-        ----------
-        name : str
-            The name of the table to retrieve.
-        database : str, optional
-            The database in which the table referred to by `name` resides. If
-            ``None`` then the ``current_database`` is used.
-        schema : str, optional
-            The schema in which the table resides.  If ``None`` then the
-            `public` schema is assumed.
-
-        Returns
-        -------
-        table : TableExpr
-            A table expression.
-        """
-        if database is not None and database != self.current_database:
-            return self.database(name=database).table(name=name, schema=schema)
-        else:
-            alch_table = self._get_sqla_table(name, schema=schema)
-            node = self.table_class(alch_table, self, self._schemas.get(name))
-            return self.table_expr_class(node)
 
 
 # TODO(kszucs): unsigned integers

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -1,7 +1,7 @@
 import contextlib
 import warnings
 
-import sqlalchemy
+import sqlalchemy as sa
 import sqlalchemy.dialects.mysql as mysql
 
 import ibis.expr.datatypes as dt
@@ -103,7 +103,7 @@ class Backend(BaseAlchemyBackend):
         )
 
         self.database_name = alchemy_url.database
-        super().do_connect(sqlalchemy.create_engine(alchemy_url))
+        super().do_connect(sa.create_engine(alchemy_url))
 
     @contextlib.contextmanager
     def begin(self):

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -1,7 +1,7 @@
 """PostgreSQL backend."""
 import contextlib
 
-import sqlalchemy
+import sqlalchemy as sa
 
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 
@@ -100,7 +100,7 @@ class Backend(BaseAlchemyBackend):
             driver=f'postgresql+{driver}',
         )
         self.database_name = alchemy_url.database
-        super().do_connect(sqlalchemy.create_engine(alchemy_url))
+        super().do_connect(sa.create_engine(alchemy_url))
 
     def list_databases(self, like=None):
         # http://dba.stackexchange.com/a/1304/58517

--- a/ibis/backends/sqlite/tests/test_client.py
+++ b/ibis/backends/sqlite/tests/test_client.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 
 import numpy as np
@@ -8,25 +7,8 @@ import pytest
 import ibis
 import ibis.config as config
 import ibis.expr.types as ir
-from ibis.util import guid
 
 pytest.importorskip("sqlalchemy")
-
-from ibis.backends.sqlite import Backend  # noqa: E402
-
-
-def test_file_not_exist_and_create():
-    path = f'__ibis_tmp_{guid()}.db'
-
-    with pytest.raises(FileNotFoundError):
-        ibis.sqlite.connect(path)
-
-    con = ibis.sqlite.connect(path, create=True)
-    try:
-        assert os.path.exists(path)
-    finally:
-        con.con.dispose()
-        os.remove(path)
 
 
 def test_table(con):
@@ -60,7 +42,7 @@ def test_list_tables(con):
 
 
 def test_attach_file(dbpath):
-    client = Backend().connect(None)
+    client = ibis.sqlite.connect(None)
 
     client.attach('foo', dbpath)
     client.attach('bar', dbpath)
@@ -79,7 +61,7 @@ def test_compile_toplevel():
     result = ibis.sqlite.compile(expr)
     expected = """\
 SELECT sum(t0.foo) AS sum 
-FROM t0 AS t0"""  # noqa
+FROM t0 AS t0"""  # noqa: W291
     assert str(result) == expected
 
 
@@ -103,7 +85,7 @@ def test_verbose_log_queries(con):
     assert len(queries) == 1
     (query,) = queries
     expected = 'SELECT t0.year \n'
-    expected += 'FROM base.functional_alltypes AS t0\n'
+    expected += 'FROM functional_alltypes AS t0\n'
     expected += ' LIMIT ? OFFSET ?'
     assert query == expected
 

--- a/ibis/backends/sqlite/tests/test_client.py
+++ b/ibis/backends/sqlite/tests/test_client.py
@@ -85,7 +85,7 @@ def test_verbose_log_queries(con):
     assert len(queries) == 1
     (query,) = queries
     expected = 'SELECT t0.year \n'
-    expected += 'FROM functional_alltypes AS t0\n'
+    expected += 'FROM main.functional_alltypes AS t0\n'
     expected += ' LIMIT ? OFFSET ?'
     assert query == expected
 

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -797,6 +797,6 @@ def test_count_on_order_by(con):
         expr.compile().compile(compile_kwargs={'literal_binds': True})
     )
     expected = (
-        'SELECT count(\'*\') AS count \n' 'FROM batting AS t0'
-    )  # noqa: W291
+        "SELECT count('*') AS count \nFROM main.batting AS t0"  # noqa: W291
+    )
     assert result == expected

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -272,20 +272,16 @@ def test_insert_overwrite_from_expr(
 def test_list_databases(alchemy_backend, alchemy_con):
     # Every backend has its own databases
     TEST_DATABASES = {
-        'sqlite': ['main', 'base'],
+        'sqlite': ['main'],
         'postgres': ['postgres', 'ibis_testing'],
         'mysql': ['ibis_testing', 'information_schema'],
     }
     assert alchemy_con.list_databases() == TEST_DATABASES[alchemy_con.name]
 
 
-@mark.never(
-    ["postgres"], reason="schemas and databases are different in postgres"
-)
 def test_list_schemas(alchemy_backend, alchemy_con):
     with pytest.warns(FutureWarning):
-        schemas = alchemy_con.list_schemas()
-    assert schemas == alchemy_con.list_databases()
+        alchemy_con.list_schemas()
 
 
 def test_verify(ddl_backend, ddl_con):


### PR DESCRIPTION
This PR deletes a good chunk of code from some of the sqlalchemy-based backends,
allowing them to use the base class code where possible.

Notable changes:

- Remove of the `has_attachment` hack in favor of a private `_current_schema` property, specific to a backend.
- Removal of the `create` parameter to the sqlite backend. There is no substitute here, this is a breaking change.
- Allowance of the string `":memory:"` for the `path` argument to the sqlite connection API.
- Implementation of the `force` argument to `create_table` on the base sqlalchemy backend class.
