### PR TITLE
ci: insert directly into bigquery

### DIFF
--- a/.github/workflows/ci-data.yml
+++ b/.github/workflows/ci-data.yml
@@ -53,5 +53,8 @@ jobs:
 
           yesterday="${{ steps.set_date.outputs.yesterday }}"
 
-          gsutil cp -Z workflows.json "gs://ibis-workflow-data/${yesterday}/workflows.json"
-          gsutil cp -Z jobs.json "gs://ibis-workflow-data/${yesterday}/jobs.json"
+          for table in workflows jobs; do
+            gsuri="gs://ibis-workflow-data/${yesterday}/${table}.json"
+            gsutil cp -Z "${table}.json" "${gsuri}"
+            bq --synchronous_mode --headless load --source_format NEWLINE_DELIMITED_JSON "workflows.${table}" "${gsuri}"
+          done


### PR DESCRIPTION
This PR changes our GitHub Actions ci data to be inserted directly into BigQuery as opposed to reading from JSON. Queries on the data are much faster and can be integrated with Google's BI suite much better.