### PR TITLE
docs: add goatcounter analytics

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,6 +2,8 @@
 
 {% block extrahead %}
 <meta name="google-site-verification" content="IVqzkYiD5E35oD4kkVOcTYCTfqWKU1f6zOHCnLIPkUU">
+<script data-goatcounter="https://ibis.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This adds analytics for ibis-project.org using [goatcounter](https://www.goatcounter.com/).

goatcounter is privacy preserving, and strives to be GDPR compliant.