### PR TITLE
refactor(api): remove distinct ColumnExpr API

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -317,20 +317,8 @@ class SelectBuilder:
                 # Something more complicated.
                 base_table = L.find_source_table(expr)
 
-                if isinstance(op, ops.DistinctColumn):
-                    expr = op.arg
-                    try:
-                        name = op.arg.get_name()
-                    except Exception:
-                        name = 'tmp'
-
-                    table_expr = base_table.projection(
-                        [expr.name(name)]
-                    ).distinct()
-                    result_handler = _get_column(name)
-                else:
-                    table_expr = base_table.projection([expr.name('tmp')])
-                    result_handler = _get_column('tmp')
+                table_expr = base_table.projection([expr.name('tmp')])
+                result_handler = _get_column('tmp')
 
             return table_expr, result_handler
         else:

--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -1,5 +1,4 @@
 import math
-import operator
 from datetime import date, datetime
 from operator import methodcaller
 
@@ -525,21 +524,6 @@ def test_literal_none_to_nullable_colum(alltypes):
     result = expr['nullable_string_column'].execute()
     expected = pd.Series([None] * nrows, name='nullable_string_column')
     tm.assert_series_equal(result, expected)
-
-
-@pytest.mark.parametrize(
-    ('attr', 'expected'),
-    [
-        (operator.methodcaller('year'), {2009, 2010}),
-        (operator.methodcaller('month'), set(range(1, 13))),
-        (operator.methodcaller('day'), set(range(1, 32))),
-    ],
-)
-def test_date_extract_field(db, alltypes, attr, expected):
-    t = alltypes
-    expr = attr(t.timestamp_col.cast('date')).distinct()
-    result = expr.execute().astype(int)
-    assert set(result) == expected
 
 
 def test_timestamp_from_integer(con, alltypes, translate):

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -353,11 +353,6 @@ def execute_log_series_gb_series_gb(op, left, right, **kwargs):
     return result.groupby(left.index)
 
 
-@execute_node.register(ops.DistinctColumn, dd.Series)
-def execute_series_distinct(op, data, **kwargs):
-    return data.unique()
-
-
 @execute_node.register(ops.Union, dd.DataFrame, dd.DataFrame, bool)
 def execute_union_dataframe_dataframe(
     op, left: dd.DataFrame, right: dd.DataFrame, distinct, **kwargs

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -535,13 +535,6 @@ def test_complex_sort_by(t, df):
     )
 
 
-def test_distinct(t, df):
-    expr = t.dup_strings.distinct()
-    result = expr.compile()
-    expected = df.dup_strings.unique()
-    tm.assert_series_equal(result.compute(), expected.compute())
-
-
 def test_count_distinct(t, df):
     expr = t.dup_strings.nunique()
     result = expr.compile()

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -51,14 +51,6 @@ def test_summary_execute(alltypes):
     assert isinstance(result, pd.DataFrame)
 
 
-def test_distinct_array(con, alltypes):
-    table = alltypes
-
-    expr = table.string_col.distinct()
-    result = con.execute(expr)
-    assert isinstance(result, pd.Series)
-
-
 def test_decimal_metadata(con):
     table = con.table('tpch_lineitem')
 

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -796,11 +796,6 @@ def execute_between(op, data, lower, upper, **kwargs):
     return data.between(lower, upper)
 
 
-@execute_node.register(ops.DistinctColumn, pd.Series)
-def execute_series_distinct(op, data, **kwargs):
-    return pd.Series(data.unique(), name=data.name)
-
-
 @execute_node.register(ops.Union, pd.DataFrame, pd.DataFrame, bool)
 def execute_union_dataframe_dataframe(
     op, left: pd.DataFrame, right: pd.DataFrame, distinct, **kwargs

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -395,13 +395,6 @@ def test_complex_sort_by(t, df):
     tm.assert_frame_equal(result[expected.columns], expected)
 
 
-def test_distinct(t, df):
-    expr = t.dup_strings.distinct()
-    result = expr.execute()
-    expected = pd.Series(df.dup_strings.unique(), name='dup_strings')
-    tm.assert_series_equal(result, expected)
-
-
 def test_count_distinct(t, df):
     expr = t.dup_strings.nunique()
     result = expr.execute()

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -1345,22 +1345,6 @@ def test_negate_boolean(con, df):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    ('opname', 'expected'),
-    [
-        ('year', {2009, 2010}),
-        ('month', set(range(1, 13))),
-        ('day', set(range(1, 32))),
-    ],
-)
-def test_date_extract_field(db, opname, expected):
-    op = operator.methodcaller(opname)
-    t = db.functional_alltypes
-    expr = op(t.timestamp_col.cast('date')).distinct()
-    result = expr.execute().astype(int)
-    assert set(result) == expected
-
-
 @pytest.mark.parametrize('opname', ['sum', 'mean', 'min', 'max', 'std', 'var'])
 def test_boolean_reduction(alltypes, opname, df):
     op = operator.methodcaller(opname)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1176,6 +1176,12 @@ def compile_join(t, expr, scope, timecontext, *, how):
     return left_df.join(right_df, pred_columns, how)
 
 
+@compiles(ops.Distinct)
+def compile_distinct(t, expr, scope, timecontext):
+    op = expr.op()
+    return t.translate(op.table, scope, timecontext).distinct()
+
+
 def _canonicalize_interval(t, interval, scope, timecontext, **kwargs):
     """Convert interval to integer timestamp of second
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -213,15 +213,6 @@ def compile_column(t, expr, scope, timecontext, **kwargs):
     return table[op.name]
 
 
-@compiles(ops.DistinctColumn)
-def compile_distinct(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    root_table_expr = op.root_tables()[0].to_expr()
-    src_table = t.translate(root_table_expr, scope, timecontext)
-    src_column_name = op.arg.get_name()
-    return src_table.select(src_column_name).distinct()[src_column_name]
-
-
 @compiles(ops.SelfReference)
 def compile_self_reference(t, expr, scope, timecontext, **kwargs):
     op = expr.op()

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -1,6 +1,5 @@
 import datetime
 import math
-import operator
 import sqlite3
 import uuid
 
@@ -740,21 +739,6 @@ def test_compile_with_one_unnamed_table():
     sqla_join = sqla_t.join(sqla_s, sqla_t.c.a == sqla_s.c.b)
     expected = sa.select([sqla_t.c.a, sqla_s.c.b]).select_from(sqla_join)
     assert str(result) == str(expected)
-
-
-@pytest.mark.parametrize(
-    ('attr', 'expected'),
-    [
-        (operator.methodcaller('year'), {2009, 2010}),
-        (operator.methodcaller('month'), set(range(1, 13))),
-        (operator.methodcaller('day'), set(range(1, 32))),
-    ],
-)
-def test_date_extract_field(alltypes, attr, expected):
-    t = alltypes
-    expr = attr(t.timestamp_col.cast('date')).distinct()
-    result = expr.execute().astype(int)
-    assert set(result) == expected
 
 
 def test_scalar_parameter(alltypes):

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -445,25 +445,3 @@ class SearchedCase(ValueOp):
         exprs = self.results + [self.default]
         dtype = rlz.highest_precedence_dtype(exprs)
         return rlz.shape_like(self.cases, dtype)
-
-
-@public
-class DistinctColumn(ValueOp):
-
-    """
-    COUNT(DISTINCT ...) is really just syntactic suger, but we provide a
-    distinct().count() nicety for users nonetheless.
-
-    For all intents and purposes, like Distinct, but can be distinguished later
-    for evaluation if the result should be array-like versus table-like. Also
-    for calling count()
-    """
-
-    arg = rlz.column(rlz.any)
-    output_type = rlz.typeof('arg')
-
-    def count(self):
-        """Only valid if the distinct contains a single column"""
-        from .reductions import CountDistinct
-
-        return CountDistinct(self.arg)

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -620,21 +620,6 @@ class AnyColumn(ColumnExpr, AnyValue):
     def bottomk(self, k: int, by: ValueExpr | None = None) -> ir.TopKExpr:
         raise NotImplementedError("bottomk is not implemented")
 
-    def distinct(self) -> ColumnExpr:
-        """Compute the set of unique values.
-
-        Cannot be used in conjunction with other array expressions from the
-        same context.
-
-        Returns
-        -------
-        ColumnExpr
-            Distinct values
-        """
-        import ibis.expr.operations as ops
-
-        return ops.DistinctColumn(self).to_expr()
-
     def approx_nunique(
         self,
         where: ir.BooleanValue | None = None,
@@ -768,13 +753,7 @@ class AnyColumn(ColumnExpr, AnyValue):
         """
         import ibis.expr.operations as ops
 
-        op = self.op()
-        if isinstance(op, ops.DistinctColumn):
-            result = ops.CountDistinct(op.args[0], where).to_expr()
-        else:
-            result = ops.Count(self, where).to_expr()
-
-        return result.name("count")
+        return ops.Count(self, where).to_expr().name("count")
 
     def value_counts(self, metric_name: str = "count") -> ir.TableExpr:
         """Compute a frequency table.

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -314,68 +314,11 @@ def test_scalar_isin_list_with_array(table):
     assert isinstance(not_expr, ir.BooleanColumn)
 
 
-def test_distinct_basic(functional_alltypes):
+def test_distinct_table(functional_alltypes):
     expr = functional_alltypes.distinct()
     assert isinstance(expr.op(), ops.Distinct)
     assert isinstance(expr, ir.TableExpr)
     assert expr.op().table is functional_alltypes
-
-    expr = functional_alltypes.string_col.distinct()
-    assert isinstance(expr.op(), ops.DistinctColumn)
-
-    assert isinstance(expr, ir.StringColumn)
-
-
-@pytest.mark.xfail(reason='NYT')
-def test_distinct_array_interactions(functional_alltypes):
-    # array cardinalities / shapes are likely to be different.
-    a = functional_alltypes.int_col.distinct()
-    b = functional_alltypes.bigint_col
-
-    with pytest.raises(ir.RelationError):
-        a + b
-
-
-@pytest.mark.parametrize('where', [lambda t: None, lambda t: t.int_col != 0])
-def test_distinct_count(functional_alltypes, where):
-    result = functional_alltypes.string_col.distinct().count(
-        where=where(functional_alltypes)
-    )
-    assert isinstance(result.op(), ops.CountDistinct)
-
-    expected = functional_alltypes.string_col.nunique(
-        where=where(functional_alltypes)
-    ).name('count')
-    assert result.equals(expected)
-
-
-def test_distinct_unnamed_array_expr():
-    table = ibis.table(
-        [('year', 'int32'), ('month', 'int32'), ('day', 'int32')], 'foo'
-    )
-
-    # it works!
-    expr = (
-        ibis.literal('-')
-        .join(
-            [
-                table.year.cast('string'),
-                table.month.cast('string'),
-                table.day.cast('string'),
-            ]
-        )
-        .distinct()
-    )
-    repr(expr)
-
-
-def test_distinct_count_numeric_types(functional_alltypes):
-    metric = (
-        functional_alltypes.bigint_col.distinct()
-        .count()
-        .name('unique_bigints')
-    )
-    functional_alltypes.group_by('string_col').aggregate(metric)
 
 
 def test_nunique(functional_alltypes):

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -71,7 +71,7 @@ FROM functional_alltypes"""
 
 def test_column_distinct(con):
     t = con.table('functional_alltypes')
-    expr = t[["string_col"]].distinct()
+    expr = t[t.string_col].distinct()
 
     result = Compiler.to_sql(expr)
     expected = """SELECT DISTINCT `string_col`

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -69,9 +69,9 @@ FROM functional_alltypes"""
     assert result == expected
 
 
-def test_array_distinct(con):
+def test_column_distinct(con):
     t = con.table('functional_alltypes')
-    expr = t.string_col.distinct()
+    expr = t[["string_col"]].distinct()
 
     result = Compiler.to_sql(expr)
     expected = """SELECT DISTINCT `string_col`

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -656,7 +656,7 @@ def test_not_exists(con, not_exists):
             ).distinct(),
         ),
         (
-            lambda t: t.string_col.distinct(),
+            lambda t: t[["string_col"]].distinct(),
             lambda sat: sa.select([sat.c.string_col.distinct()]),
         ),
         (

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -656,7 +656,7 @@ def test_not_exists(con, not_exists):
             ).distinct(),
         ),
         (
-            lambda t: t[["string_col"]].distinct(),
+            lambda t: t[t.string_col].distinct(),
             lambda sat: sa.select([sat.c.string_col.distinct()]),
         ),
         (


### PR DESCRIPTION
Remove `ColumnExpr.distinct()` because it's a confusing API.

This is a breaking change.

Here are a few examples of why this method is easily misused, confusing and error prone:

```
>>> import ibis
>>> t = ibis.table(schema=[("a", "int64"), ("b", "string"), ("c", "string")], name="t")
>>> t.a.distinct().log().distinct()  # what does this even compile to?
>>> t.b.length().distinct() + t.c.distinct().length()  # again, this is very ambiguous if defined at all
```

The `TableExpr.distinct()` method still exists, so it's still possible to
compute distict rows, but it can no longer be done with `t.foo.distinct()`.


Note that this doesn't prevent the following operation from being constructed, but
it will fail to compile due to the expression having multiple leaf tables outside of
a join or correlated subquery:

```
>>> t[["a"]].distinct().a + t["a"]
UnboundTable[r0, name=t]
  a int64
  b string
  c string

Selection[r1]
  table:
    ref: r0
  selections:
    a: int64 = r0.a

Distinct[r2]
  table:
    ref: r1

int64 = Add
  left:
    a: int64 = r2.a
  right:
    a: int64 = r0.a
```
