### PR TITLE
feat(sqlite): implement date_truncate

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -496,6 +496,7 @@ sqlalchemy_operation_registry: Dict[Any, Any] = {
     ops.FloorDivide: _floor_divide,
     # other
     ops.SortKey: _sort_key,
+    ops.Date: unary(lambda arg: sa.cast(arg, sa.DATE)),
 }
 
 

--- a/ibis/backends/mysql/registry.py
+++ b/ibis/backends/mysql/registry.py
@@ -240,7 +240,6 @@ operation_registry.update(
         ops.Round: _round,
         ops.RandomScalar: _random,
         # dates and times
-        ops.Date: unary(sa.func.date),
         ops.DateAdd: infix_op('+'),
         ops.DateSub: infix_op('-'),
         ops.DateDiff: fixed_arity(sa.func.datediff, 2),

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -119,15 +119,10 @@ def _timestamp_truncate(t, expr):
 
 
 def _interval_from_integer(t, expr):
-    arg, unit = expr.op().args
-    sa_arg = t.translate(arg)
+    op = expr.op()
+    sa_arg = t.translate(op.arg)
     interval = sa.text(f"INTERVAL '1 {expr.type().resolution}'")
     return sa_arg * interval
-
-
-def _timestamp_add(t, expr):
-    sa_args = list(map(t.translate, expr.op().args))
-    return sa_args[0] + sa_args[1]
 
 
 def _is_nan(t, expr):
@@ -678,7 +673,6 @@ operation_registry.update(
         ops.Round: _round,
         ops.Modulus: _mod,
         # dates and times
-        ops.Date: unary(lambda x: sa.cast(x, sa.Date)),
         ops.DateTruncate: _timestamp_truncate,
         ops.TimestampTruncate: _timestamp_truncate,
         ops.IntervalFromInteger: _interval_from_integer,

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -27,10 +27,8 @@ def test_floating_scalar_parameter(backend, alltypes, df, column, raw_value):
     ('start_string', 'end_string'),
     [('2009-03-01', '2010-07-03'), ('2014-12-01', '2017-01-05')],
 )
-@pytest.mark.notimpl(["datafusion", "pyspark", "sqlite"])
-def test_date_scalar_parameter(
-    backend, alltypes, df, start_string, end_string
-):
+@pytest.mark.notimpl(["datafusion", "pyspark"])
+def test_date_scalar_parameter(backend, alltypes, start_string, end_string):
     start, end = ibis.param(dt.date), ibis.param(dt.date)
 
     col = alltypes.timestamp_col.date()

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -13,9 +13,20 @@ from ibis.backends.pandas.execution.temporal import day_name
 
 
 @pytest.mark.parametrize('attr', ['year', 'month', 'day'])
-@pytest.mark.notimpl(["datafusion", "sqlite"])
-def test_date_extract(backend, alltypes, df, attr):
-    expr = getattr(alltypes.timestamp_col.date(), attr)()
+@pytest.mark.parametrize(
+    "expr_fn",
+    [
+        param(lambda c: c.date(), id="date"),
+        param(
+            lambda c: c.cast("date"),
+            id="cast",
+            marks=pytest.mark.notimpl(["impala"]),
+        ),
+    ],
+)
+@pytest.mark.notimpl(["datafusion"])
+def test_date_extract(backend, alltypes, df, attr, expr_fn):
+    expr = getattr(expr_fn(alltypes.timestamp_col), attr)()
     expected = getattr(df.timestamp_col.dt, attr).astype('int32')
 
     result = expr.execute()
@@ -167,16 +178,17 @@ def test_timestamp_truncate(backend, alltypes, df, unit):
                     "mysql",
                     "postgres",
                     "pyspark",
+                    "sqlite",
                 ]
             ),
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "sqlite"])
+@pytest.mark.notimpl(["datafusion"])
 def test_date_truncate(backend, alltypes, df, unit):
     expr = alltypes.timestamp_col.date().truncate(unit)
 
-    dtype = f'datetime64[{unit}]'
+    dtype = f"datetime64[{unit}]"
     expected = pd.Series(df.timestamp_col.values.astype(dtype))
 
     result = expr.execute()


### PR DESCRIPTION
This PR implements truncate for date types in the SQLite backend, and generalizes the implementation of date for the SQLAlchemy based backends.