### PR TITLE
fix(mutate): do not lift table column that results from mutate

### DIFF
--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -133,17 +133,11 @@ def test_mutating_join(backend, con, batting, awards_players, how):
     [
         param(
             "semi",
-            marks=pytest.mark.notimpl(
-                ["clickhouse", "dask", "datafusion", "impala"]
-            ),
+            marks=pytest.mark.notimpl(["dask", "datafusion"]),
         ),
         param(
             "anti",
-            marks=pytest.mark.notimpl(
-                # clickhouse and impala are broken, the rest are not
-                # implemented
-                ["clickhouse", "dask", "datafusion", "impala"]
-            ),
+            marks=pytest.mark.notimpl(["dask", "datafusion"]),
         ),
     ],
 )

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -195,3 +195,16 @@ def test_join_then_filter_no_column_overlap(awards_players, batting):
     filters = [expr.RBI == 9]
     q = expr.filter(filters)
     q.execute()
+
+
+@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notyet(
+    ["pyspark"],
+    reason="pyspark doesn't support joining on differing column names",
+)
+def test_mutate_then_join_no_column_overlap(batting, awards_players):
+    left = batting.mutate(year=batting.yearID)
+    left = left["year", "RBI"]
+    right = awards_players
+    expr = left.join(right, left.year == right.yearID)
+    expr.execute()

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -351,20 +351,6 @@ class ExprSimplifier:
 
         if isinstance(root, ops.Selection):
             can_lift = False
-            all_simple_columns = all(
-                isinstance(sel.op(), ops.TableColumn)
-                and sel.op().name == sel.get_name()
-                for sel in root.selections
-                if isinstance(sel, ir.ValueExpr)
-                if sel.has_name()
-            )
-
-            # If there are predicates or sort keys,
-            # then we cannot lift the root
-            no_predicates_or_sort_keys = not (
-                root.predicates or root.sort_keys
-            )
-
             for val in root.selections:
                 value_op = val.op()
                 if (
@@ -373,15 +359,6 @@ class ExprSimplifier:
                 ):
                     can_lift = True
                     lifted_root = self.lift(val)
-                elif (
-                    all_simple_columns
-                    and no_predicates_or_sort_keys
-                    and isinstance(val, ir.ValueExpr)
-                    and val.has_name()
-                    and node.name == val.get_name()
-                ):
-                    can_lift = True
-                    lifted_root = self.lift(value_op.table)
 
             if can_lift and not block:
                 lifted_node = ops.TableColumn(lifted_root, node.name)

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -41,25 +41,6 @@ def test_rewrite_join_projection_without_other_ops(con):
     assert not op.table.equals(ex_expr)
 
 
-def test_rewrite_past_projection(con):
-    table = con.table('test1')
-
-    # Rewrite past a projection
-    table3 = table[['c', 'f']]
-    expr = table3['c'] == 2
-
-    result = L.substitute_parents(expr)
-    expected = table['c'] == 2
-    assert_equal(result, expected)
-
-    # Unsafe to rewrite past projection
-    table5 = table[(table.f * 2).name('c'), table.f]
-    expr = table5['c'] == 2
-    result = L.substitute_parents(expr)
-    expected = expr
-    assert result.equals(expected)
-
-
 def test_multiple_join_deeper_reference():
     # Join predicates down the chain might reference one or more root
     # tables in the hierarchy.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1843,6 +1843,14 @@ pymysql = ["pymysql (<1)", "pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
+name = "sqlparse"
+version = "0.4.2"
+description = "A non-validating SQL parser."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "stack-data"
 version = "0.2.0"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -2088,7 +2096,7 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "e4e316baa44594129d1f96925f4ee6aba962670a9dfb6c3b9b8b0ddfa69c33ea"
+content-hash = "e3df061e0e285fb91f66d6b3d27825a810afa80d161ed43f9f47f9bd0d576670"
 
 [metadata.files]
 appnope = [
@@ -3575,6 +3583,10 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.4.32-cp39-cp39-win32.whl", hash = "sha256:1bbac3e8293b34c4403d297e21e8f10d2a57756b75cff101dc62186adec725f5"},
     {file = "SQLAlchemy-1.4.32-cp39-cp39-win_amd64.whl", hash = "sha256:b3f1d9b3aa09ab9adc7f8c4b40fc3e081eb903054c9a6f9ae1633fe15ae503b4"},
     {file = "SQLAlchemy-1.4.32.tar.gz", hash = "sha256:6fdd2dc5931daab778c2b65b03df6ae68376e028a3098eb624d0909d999885bc"},
+]
+sqlparse = [
+    {file = "sqlparse-0.4.2-py3-none-any.whl", hash = "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"},
+    {file = "sqlparse-0.4.2.tar.gz", hash = "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae"},
 ]
 stack-data = [
     {file = "stack_data-0.2.0-py3-none-any.whl", hash = "sha256:999762f9c3132308789affa03e9271bbbe947bf78311851f4d485d8402ed858e"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1628,6 +1628,17 @@ importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""
 pytest = "*"
 
 [[package]]
+name = "pytest-repeat"
+version = "0.9.1"
+description = "pytest plugin for repeating tests"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+pytest = ">=3.6"
+
+[[package]]
 name = "pytest-xdist"
 version = "2.5.0"
 description = "pytest xdist plugin for distributed testing and loop-on-failing modes"
@@ -2096,7 +2107,7 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "e3df061e0e285fb91f66d6b3d27825a810afa80d161ed43f9f47f9bd0d576670"
+content-hash = "ebd39cbaa4824940f4ec2acd877af49d2ed2a1af842be884a0a003d9d65005f4"
 
 [metadata.files]
 appnope = [
@@ -3305,6 +3316,10 @@ pytest-mock = [
 pytest-randomly = [
     {file = "pytest-randomly-3.11.0.tar.gz", hash = "sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f"},
     {file = "pytest_randomly-3.11.0-py3-none-any.whl", hash = "sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610"},
+]
+pytest-repeat = [
+    {file = "pytest-repeat-0.9.1.tar.gz", hash = "sha256:5cd3289745ab3156d43eb9c8e7f7d00a926f3ae5c9cf425bec649b2fe15bad5b"},
+    {file = "pytest_repeat-0.9.1-py2.py3-none-any.whl", hash = "sha256:4474a7d9e9137f6d8cc8ae297f8c4168d33c56dd740aa78cfffe562557e6b96e"},
 ]
 pytest-xdist = [
     {file = "pytest-xdist-2.5.0.tar.gz", hash = "sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ setuptools = ">=57,<61"
 sqlalchemy = ">=1.3,<1.5"
 types-requests = ">=2.27.8,<3"
 sqlparse = "^0.4.2"
+pytest-repeat = "^0.9.1"
 
 [tool.poetry.extras]
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ requests = ">=2,<3"
 setuptools = ">=57,<61"
 sqlalchemy = ">=1.3,<1.5"
 types-requests = ">=2.27.8,<3"
+sqlparse = "^0.4.2"
 
 [tool.poetry.extras]
 all = [


### PR DESCRIPTION
Fixes #3529 
Fixes #3515 

I traced the failure mode in #3529 to `ibis.expr.analysis._lift_TableColumn` -- there wasn't a readily apparent way to fix the failure there (or even how to special case it), but removing the entire code path definitely fixes things.  That's not always the best way to fix things, but I think a lot of the expr rewriting stuff is probably causing a lot of issues on the edges.

In any case, I tried a bit to quantify what, if any, time savings are offered by having the `_lift_TableColumn` path available and the results are below.  Usual caveat around how all benchmarks are terrible.

TLDR: For the runs below, removing the expr rewrite has no performance impacts and allows joining on mutated columns, but there may be cases not covered here that would suffer.

**All times are in seconds**

## Running the whole backend test suite 

Use `pytest-repeat` to run each test 3 times to iron out any jitter (maybe)

`pytest -m "<backend>" ibis/backends/tests/ --count=3`

| Backend | with lifting | without lifting | pytest-repeat count |
|---------|--------------|-----------------|---------------------|
| duckdb  | 68.99        | 69.64           | 3                   |
| sqlite  | 83.13        | 84.95           | 3                   |

## Running only tests that hit `_lift_TableColumn`

tests that hit the code in question are:

`test_generic.py::test_select_filter_mutate`
`test_generic.py::test_mutate_rename`
`test_join.py::test_mutating_join[inner | left | right | outer]`
`test_join.py::test_filtering_join[anti | semi ]`

Only join tests (x5)

    pytest ibis/backends/tests/ -m "duckdb" -k "test_filtering_join or test_mutating_join" -v --count=5

| Backend | with lifting | without lifting | pytest-repeat count |
|---------|--------------|-----------------|---------------------|
| duckdb  | 4.15         | 4.15            | 5                   |
| sqlite  | 9.59         | 9.51            | 5                   |
| mysql   | 34.86        | 34.60           | 5                   |

Only generic tests (x5)

``` bash
pytest ibis/backends/tests/test_generic.py -k "test_select_filter_mutate or test_mutate_rename" -v --count=5 -m "duckdb"
```

| Backend | with lifting | without lifting | pytest-repeat count |
|---------|--------------|-----------------|---------------------|
| duckdb  | 3.60         | 3.59            | 15                  |
| sqlite  | 2.90         | 2.88            | 15                  |
| mysql   | 3.62         | 3.58            | 15                  |

## Pathological lifting case?

I tried to come up with a pathological case for where lifting would make a noticeable difference -- if folks have suggestions I'm all ears, but for this case, it makes next to no difference (e.g. the column only gets lifted up a single table-reference, not all the way up to the root table)

``` python
def test_mutate_then_join_no_column_overlap(batting, awards_players):
    left = batting.mutate(year=batting.yearID)
    left = left.mutate(year2=left.year)
    left = left.mutate(year3=left.year2)
    left = left.mutate(year4=left.year3)
    left = left.mutate(year5=left.year4)
    left = left["year5", "RBI"]
    right = awards_players
    expr = left.join(right, left.year5 == right.yearID)
    breakpoint()
    expr.execute()
```

``` diff
diff -u /home/gil/github.com/ibis-project/ibis/ibis/backends/tests/new2 /home/gil/github.com/ibis-project/ibis/ibis/backends/tests/new
--- /home/gil/github.com/ibis-project/ibis/ibis/backends/tests/new2 2022-03-09 14:06:26.810561337 -0500
+++ /home/gil/github.com/ibis-project/ibis/ibis/backends/tests/new  2022-03-09 14:06:27.757568290 -0500
@@ -80,6 +80,6 @@
   predicates:
     boolean = Equals
       left:
-        year5: int64 = r5.year5
+        year5: int64 = r6.year5
       right:
         yearID: int64 = r7.yearID

Diff finished.  Wed Mar  9 14:07:23 2022
```
