### PR TITLE
refactor: remove geospatial from unsupported backends

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -604,8 +604,8 @@ if geospatial_supported:
         #   ST_GeomFromEWKT
         #   ST_GeomFromText
     }
-
-    sqlalchemy_operation_registry.update(_geospatial_functions)
+else:
+    _geospatial_functions = {}
 
 
 for _k, _v in _binary_ops.items():

--- a/ibis/backends/mysql/compiler.py
+++ b/ibis/backends/mysql/compiler.py
@@ -1,16 +1,19 @@
 import sqlalchemy.dialects.mysql as mysql
+import toolz
 
 import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy import (
     AlchemyCompiler,
     AlchemyExprTranslator,
 )
+from ibis.backends.base.sql.alchemy.registry import _geospatial_functions
 
 from .registry import operation_registry
 
 
 class MySQLExprTranslator(AlchemyExprTranslator):
-    _registry = operation_registry
+    # https://dev.mysql.com/doc/refman/8.0/en/spatial-function-reference.html
+    _registry = toolz.merge(operation_registry, _geospatial_functions)
     _rewrites = AlchemyExprTranslator._rewrites.copy()
     _type_map = AlchemyExprTranslator._type_map.copy()
     _type_map.update(

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -1,3 +1,4 @@
+import toolz
 from sqlalchemy.dialects import postgresql
 
 import ibis.expr.datatypes as dt
@@ -6,6 +7,7 @@ from ibis.backends.base.sql.alchemy import (
     AlchemyCompiler,
     AlchemyExprTranslator,
 )
+from ibis.backends.base.sql.alchemy.registry import _geospatial_functions
 
 from .registry import operation_registry
 
@@ -15,7 +17,7 @@ class PostgresUDFNode(ops.ValueOp):
 
 
 class PostgreSQLExprTranslator(AlchemyExprTranslator):
-    _registry = operation_registry
+    _registry = toolz.merge(operation_registry, _geospatial_functions)
     _rewrites = AlchemyExprTranslator._rewrites.copy()
     _type_map = AlchemyExprTranslator._type_map.copy()
     _type_map.update(

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,7 @@ let
     jq
     just
     lychee
+    mariadb
     niv
     nix-linter
     nixpkgs-fmt


### PR DESCRIPTION
This PR removes the spurious support for geospatial operations in duckdb