### PR TITLE
feat(duckdb): fill out regexp_replace and array indexing APIs

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -147,6 +147,7 @@ operation_registry.update(
     {
         ops.ArrayColumn: _array_column,
         ops.ArrayConcat: fixed_arity('array_concat', 2),
+        ops.ArrayIndex: fixed_arity('list_element', 2),
         ops.DayOfWeekName: unary(sa.func.dayname),
         ops.Literal: _literal,
         ops.Log2: unary(sa.func.log2),
@@ -161,7 +162,6 @@ operation_registry.update(
         ops.TimestampFromUNIX: _timestamp_from_unix,
         ops.Translate: fixed_arity('replace', 3),
         ops.TimestampNow: fixed_arity('now', 0),
-        ops.ArrayIndex: fixed_arity('list_element', 2),
         ops.RegexExtract: _regex_extract,
         ops.RegexReplace: fixed_arity("regexp_replace", 3),
     }

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -788,10 +788,13 @@ def compile_log(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
 
     src_column = t.translate(op.arg, scope, timecontext)
-    # Spark log method only takes float
-    return F.log(
-        float(t.translate(op.base, scope, timecontext, raw=True)), src_column
-    )
+    raw_base = t.translate(op.base, scope, timecontext, raw=True)
+    try:
+        base = float(raw_base)
+    except TypeError:
+        return F.log(src_column) / F.log(raw_base)
+    else:
+        return F.log(base, src_column)
 
 
 @compiles(ops.Ln)

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -274,6 +274,20 @@ def test_simple_math_functions_columns(
             lambda t: np.log10(t.double_col + 1),
             id='log10',
         ),
+        param(
+            lambda t: (t.double_col + 1).log(
+                ibis.greatest(
+                    9_000,
+                    t.bigint_col,
+                )
+            ),
+            lambda t: (
+                np.log(t.double_col + 1)
+                / np.log(np.maximum(9_000, t.bigint_col))
+            ),
+            id="log_base_bigint",
+            marks=pytest.mark.notimpl(["clickhouse", "datafusion"]),
+        ),
     ],
 )
 def test_complex_math_functions_columns(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -62,125 +62,22 @@ def test_string_col_is_unicode(backend, alltypes, df):
             ),
         ),
         param(
-            lambda t: t.string_col.re_search(r'[[:digit:]]+'),
-            lambda t: t.string_col.str.contains(r'\d+'),
-            id='re_search',
-            marks=pytest.mark.notimpl(["datafusion", "pyspark"]),
-        ),
-        param(
-            lambda t: t.string_col.re_extract(r'([[:digit:]]+)', 0),
-            lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
-            id='re_extract',
-            marks=pytest.mark.notimpl(["duckdb", "mysql", "pyspark"]),
-        ),
-        param(
-            lambda t: t.string_col.re_replace(r'[[:digit:]]+', 'a'),
-            lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
-            id='re_replace',
-            marks=pytest.mark.notimpl(
-                ['datafusion', "duckdb", "mysql", "pyspark"]
-            ),
-        ),
-        param(
-            lambda t: t.string_col.re_search(r'\\d+'),
-            lambda t: t.string_col.str.contains(r'\d+'),
-            id='re_search_spark_raw',
-            marks=(
-                # TODO: check if this test should pass with pyspark
-                # and if not, remove it
-                pytest.mark.notimpl(["pyspark"], reason="regression"),
-                pytest.mark.never(
-                    [
-                        "dask",
-                        "datafusion",
-                        "duckdb",
-                        "mysql",
-                        "pandas",
-                        "postgres",
-                        "sqlite",
-                    ],
-                    reason="not spark",
-                ),
-            ),
-        ),
-        param(
-            lambda t: t.string_col.re_extract(r'(\\d+)', 0),
-            lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
-            id='re_extract_spark',
-            marks=(
-                # TODO: check if this test should pass with pyspark
-                # and if not, remove it
-                pytest.mark.notimpl(["pyspark"], reason="regression"),
-                pytest.mark.never(
-                    [
-                        "dask",
-                        "datafusion",
-                        "duckdb",
-                        "mysql",
-                        "pandas",
-                        "postgres",
-                        "sqlite",
-                    ],
-                    reason="not spark",
-                ),
-            ),
-        ),
-        param(
-            lambda t: t.string_col.re_replace(r'\\d+', 'a'),
-            lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
-            id='re_replace_spark_raw',
-            marks=(
-                # TODO: check if this test should pass with pyspark
-                # and if not, remove it
-                pytest.mark.notimpl(["pyspark"], reason="regression"),
-                pytest.mark.never(
-                    [
-                        "dask",
-                        "datafusion",
-                        "duckdb",
-                        "mysql",
-                        "pandas",
-                        "postgres",
-                        "sqlite",
-                    ],
-                    reason="not spark",
-                ),
-            ),
-        ),
-        param(
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
-            id='re_search_spark',
-            marks=(
-                pytest.mark.notimpl(['impala']),
-                pytest.mark.never(["datafusion"], reason="not spark"),
-            ),
+            id='re_search',
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             lambda t: t.string_col.re_extract(r'(\d+)', 0),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
-            id='re_extract_spark_raw',
-            marks=(
-                pytest.mark.notimpl(
-                    [
-                        'impala',
-                        "duckdb",
-                    ]
-                ),
-                pytest.mark.never(["mysql"], reason="not spark"),
-            ),
+            id='re_extract',
+            marks=pytest.mark.notimpl(["mysql"]),
         ),
         param(
             lambda t: t.string_col.re_replace(r'\d+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
-            id='re_replace_spark',
-            marks=(
-                pytest.mark.notimpl(['impala']),
-                pytest.mark.never(
-                    ["datafusion", "duckdb", "mysql"],
-                    reason="not spark",
-                ),
-            ),
+            id='re_replace',
+            marks=pytest.mark.notimpl(['datafusion', "mysql"]),
         ),
         param(
             lambda t: t.string_col.repeat(2),

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -52,32 +52,46 @@ def test_string_col_is_unicode(backend, alltypes, df):
                 [
                     "clickhouse",
                     "datafusion",
-                    "duckdb",
                     "impala",
-                    "mysql",
-                    "postgres",
                     "pyspark",
-                    "sqlite",
                 ]
             ),
+        ),
+        param(
+            lambda t: t.string_col.re_search(r'[[:digit:]]+'),
+            lambda t: t.string_col.str.contains(r'\d+'),
+            id='re_search_posix',
+            marks=pytest.mark.notimpl(["datafusion", "pyspark"]),
+        ),
+        param(
+            lambda t: t.string_col.re_extract(r'([[:digit:]]+)', 0),
+            lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
+            id='re_extract_posix',
+            marks=pytest.mark.notimpl(["mysql", "pyspark"]),
+        ),
+        param(
+            lambda t: t.string_col.re_replace(r'[[:digit:]]+', 'a'),
+            lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
+            id='re_replace_posix',
+            marks=pytest.mark.notimpl(['datafusion', "mysql", "pyspark"]),
         ),
         param(
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(["impala", "datafusion"]),
         ),
         param(
             lambda t: t.string_col.re_extract(r'(\d+)', 0),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract',
-            marks=pytest.mark.notimpl(["mysql"]),
+            marks=pytest.mark.notimpl(["impala", "mysql"]),
         ),
         param(
             lambda t: t.string_col.re_replace(r'\d+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
             id='re_replace',
-            marks=pytest.mark.notimpl(['datafusion', "mysql"]),
+            marks=pytest.mark.notimpl(["impala", "datafusion", "mysql"]),
         ),
         param(
             lambda t: t.string_col.repeat(2),


### PR DESCRIPTION
This PR fills out a number of features in a few backends:

1. `StringSQLILike` equivalent to SQL's `ILIKE` operator, for all sqlalchemy backends
2. log base `b` for all backends except clickhouse and datafusion
3. `RegexExtract` for duckdb
4. `ArrayIndex` for duckdb
5. `RegexReplace` for duckdb

I also removed failing string tests that were pyspark specific since pyspark now passes on vanilla Perl regexen tests.