### PR TITLE
perf(expr/operations): speed up args and argnames attribute access

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -293,14 +293,14 @@ def test_select_filter_mutate(backend, alltypes, df):
 
 def test_fillna_invalid(alltypes):
     with pytest.raises(
-        com.IbisTypeError, match=r"value \['invalid_col'\] is not a field in.*"
+        com.IbisTypeError, match=r"\['invalid_col'\] is not a field in.*"
     ):
         alltypes.fillna({'invalid_col': 0.0})
 
 
 def test_dropna_invalid(alltypes):
     with pytest.raises(
-        com.IbisTypeError, match=r"value 'invalid_col' is not a field in.*"
+        com.IbisTypeError, match=r"'invalid_col' is not a field in.*"
     ):
         alltypes.dropna(subset=['invalid_col'])
 


### PR DESCRIPTION
This PR speeds up attributes access.

Local benchmarking shows about a **6x** speed up when accessing attributes.

An individual access isn't that expensive, but in a tight loop, the overhead of `@property` plus tuple construction adds up to quite a lot.

This PR is a prerequisite for #3594. We should be able to get a sub-millisecond TPC-H query 2 repr in #3594 after this PR.