### PR TITLE
test(bench): add attribute access benchmarks

### DIFF
--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -449,3 +449,15 @@ def test_repr_huge_union(benchmark):
     ]
     expr = functools.reduce(ir.TableExpr.union, tables)
     benchmark(repr, expr)
+
+
+def test_op_argnames(benchmark):
+    t = ibis.table([("a", "int64")])
+    expr = t[["a"]]
+    benchmark(lambda op: op.argnames, expr.op())
+
+
+def test_op_args(benchmark):
+    t = ibis.table([("a", "int64")])
+    expr = t[["a"]]
+    benchmark(lambda op: op.args, expr.op())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ addopts = [
   "--ignore=dist-packages",
   "--strict-markers",
   "--benchmark-skip",
+  "--benchmark-autosave",
 ]
 empty_parameter_set_mark = "fail_at_collect"
 norecursedirs = ["site-packages", "dist-packages"]


### PR DESCRIPTION
This PR adds attribute access benchmarks so that we have a baseline