### PR TITLE
chore: remove dead backend markers

### DIFF
--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -196,14 +196,11 @@ def test_aggregate_grouped(
                 pytest.mark.notimpl(
                     [
                         "clickhouse",
-                        "csv",
                         "dask",
                         "duckdb",
-                        "hdf5",
                         "impala",
                         "mysql",
                         "pandas",
-                        "parquet",
                         "postgres",
                         "pyspark",
                         "sqlite",
@@ -219,14 +216,11 @@ def test_aggregate_grouped(
                 pytest.mark.notimpl(
                     [
                         "clickhouse",
-                        "csv",
                         "dask",
                         "duckdb",
-                        "hdf5",
                         "impala",
                         "mysql",
                         "pandas",
-                        "parquet",
                         "postgres",
                         "pyspark",
                         "sqlite",
@@ -343,7 +337,7 @@ def test_group_concat(backend, alltypes, df, result_fn, expected_fn):
         )
     ],
 )
-@mark.notimpl(["pandas", "dask", "csv", "hdf5", "parquet"])
+@mark.notimpl(["pandas", "dask"])
 @pytest.mark.notyet(["pyspark", "datafusion"])
 def test_topk_op(backend, alltypes, df, result_fn, expected_fn):
     # TopK expression will order rows by "count" but each backend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ addopts = [
   "--ignore=site-packages",
   "--ignore=dist-packages",
   "--strict-markers",
+  "--strict-config",
   "--benchmark-skip",
 ]
 empty_parameter_set_mark = "fail_at_collect"


### PR DESCRIPTION
This PR removes the use of markers that no longer exist.