### PR TITLE
refactor: make Annotable truly immutable

### DIFF
--- a/ibis/backends/base/sql/alchemy/database.py
+++ b/ibis/backends/base/sql/alchemy/database.py
@@ -14,7 +14,7 @@ class AlchemyTable(ops.DatabaseTable):
     def __init__(self, table, source, schema=None):
         schema = sch.infer(table, schema=schema)
         super().__init__(table.name, schema, source)
-        self.sqla_table = table
+        object.__setattr__(self, "sqla_table", table)
 
     def __getstate__(self):
         d = super().__getstate__()

--- a/ibis/expr/datatypes/__init__.py
+++ b/ibis/expr/datatypes/__init__.py
@@ -702,6 +702,9 @@ class Set(Variadic):
         self.value_type = dtype(value_type)
         self._pretty += f"<{self.value_type}>"
 
+    def _literal_value_hash_key(self, value):
+        return self, _tuplize(value)
+
 
 class Enum(DataType):
     """Enumeration values."""
@@ -823,7 +826,7 @@ class GeoSpatial(DataType):
             )
             if isinstance(value, geo_shapes):
                 return self, value.wkt
-        return self, value
+        return self, _tuplize(value) if util.is_iterable(value) else value
 
 
 class Geometry(GeoSpatial):

--- a/ibis/expr/operations/analytic.py
+++ b/ibis/expr/operations/analytic.py
@@ -27,6 +27,7 @@ class WindowOp(ValueOp):
             "expr",
             propagate_down_window(self.expr, self.window),
         )
+        self.__init_args__()
 
     def over(self, window):
         new_window = self.window.combine(window)

--- a/ibis/expr/operations/analytic.py
+++ b/ibis/expr/operations/analytic.py
@@ -22,7 +22,11 @@ class WindowOp(ValueOp):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.expr = propagate_down_window(self.expr, self.window)
+        object.__setattr__(
+            self,
+            "expr",
+            propagate_down_window(self.expr, self.window),
+        )
 
     def over(self, window):
         new_window = self.window.combine(window)

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -39,7 +39,8 @@ class TableColumn(ValueOp):
         schema = table.schema()
 
         if isinstance(name, int):
-            self.name = name = schema.name_at_position(name)
+            name = schema.name_at_position(name)
+            object.__setattr__(self, "name", name)
 
         if name not in schema:
             raise com.IbisTypeError(

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -47,6 +47,8 @@ class TableColumn(ValueOp):
                 f"value {name!r} is not a field in {table.columns}"
             )
 
+        self.__init_args__()
+
     def parent(self):
         return self.table
 
@@ -282,7 +284,7 @@ class Literal(ValueOp):
     def root_tables(self):
         return []
 
-    def __hash__(self) -> int:
+    def _make_hash(self) -> int:
         """Return the hash of a literal value.
 
         We override this method to make sure that we can handle things that

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -265,12 +265,7 @@ class AsOfJoin(Join):
             signature.parameters["tolerance"].validate(self, tolerance),
         )
 
-    def _validate_args(self, args: list[str]):
-        # this should be removed altogether
-        for arg in args:
-            argument = self.__signature__.parameters[arg]
-            value = argument.validate(self, getattr(self, arg))
-            setattr(self, arg, value)
+        self.__init_args__()
 
 
 @public

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -251,10 +251,19 @@ class AsOfJoin(Join):
 
     def __init__(self, left, right, predicates, by, tolerance):
         super().__init__(left, right, predicates)
-        self.by = _clean_join_predicates(self.left, self.right, by)
-        self.tolerance = tolerance
-
-        self._validate_args(['by', 'tolerance'])
+        signature = self.__signature__
+        object.__setattr__(
+            self,
+            "by",
+            signature.parameters["by"].validate(
+                self, _clean_join_predicates(self.left, self.right, by)
+            ),
+        )
+        object.__setattr__(
+            self,
+            "tolerance",
+            signature.parameters["tolerance"].validate(self, tolerance),
+        )
 
     def _validate_args(self, args: list[str]):
         # this should be removed altogether

--- a/ibis/expr/signature.py
+++ b/ibis/expr/signature.py
@@ -169,10 +169,7 @@ class AnnotableMeta(type):
 class Annotable(metaclass=AnnotableMeta):
     """Base class for objects with custom validation rules."""
 
-    __slots__ = (
-        "args",
-        "_hash",
-    )
+    __slots__ = "args", "_hash"
 
     def __init__(self, *args, **kwargs):
         bound = self.__signature__.bind(*args, **kwargs)

--- a/ibis/expr/signature.py
+++ b/ibis/expr/signature.py
@@ -216,12 +216,9 @@ class Annotable(metaclass=AnnotableMeta):
         state
             A dictionary storing the objects attributes.
         """
-        args = ()
         for key, value in state.items():
             object.__setattr__(self, key, value)
-            args += (value,)
-        object.__setattr__(self, "args", args)
-        object.__setattr__(self, "_hash", self._make_hash())
+        self.__init_args__()
 
     def _make_hash(self) -> int:
         return hash((type(self), *map(_maybe_get_op, self.flat_args())))

--- a/ibis/tests/expr/test_signature.py
+++ b/ibis/tests/expr/test_signature.py
@@ -351,3 +351,12 @@ def test_multiple_inheritance_optional_argument_order():
         how = Optional(IsStr, default="strict")
 
     assert str(Between.__signature__) == "(min, max, where=None, how=None)"
+
+
+def test_immutability():
+    class ValueOp(Annotable):
+        a = IsInt
+
+    op = ValueOp(1)
+    with pytest.raises(TypeError):
+        op.a = 3


### PR DESCRIPTION
This PR makes Annotable subclasses immutable to the extent possible, as a follow up to #3600.