### PR TITLE
refactor(datatypes): make DataType and friends immutable and remove __slots__usage

### DIFF
--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -302,8 +302,8 @@ class IntervalBinaryOp(BinaryOp):
         dtype_type = type(left_dtype)
         additional_args = {
             attr: getattr(left_dtype, attr)
-            for attr in dtype_type.__slots__
-            if attr not in {'unit', 'value_type'}
+            for attr in left_dtype._fields
+            if attr not in ("unit", "value_type")
         }
         dtype = dtype_type(left_dtype.unit, expr.type(), **additional_args)
         return rlz.shape_like(self.args, dtype=dtype)

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -491,7 +491,7 @@ class IntervalValue(AnyValue):
             return self
 
         result = util.convert_unit(self, self._dtype.unit, target_unit)
-        result.type().unit = target_unit
+        object.__setattr__(result.type(), "unit", target_unit)
         return result
 
     @property


### PR DESCRIPTION
This PR moves `DataType` and its subclasses away from `__slots__` and replaces the current
property caching with `cached_property`s.
