### PR TITLE
feat(sqlite): implement string join and concat

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -434,6 +434,11 @@ def _sort_key(t, expr):
     return sort_direction(t.translate(by))
 
 
+def _string_join(t, expr):
+    sep, elements = expr.op().args
+    return sa.func.concat_ws(t.translate(sep), *map(t.translate, elements))
+
+
 sqlalchemy_operation_registry: Dict[Any, Any] = {
     ops.And: fixed_arity(sql.and_, 2),
     ops.Or: fixed_arity(sql.or_, 2),
@@ -482,6 +487,7 @@ sqlalchemy_operation_registry: Dict[Any, Any] = {
     ops.Uppercase: unary(sa.func.upper),
     ops.StringAscii: unary(sa.func.ascii),
     ops.StringLength: unary(sa.func.length),
+    ops.StringJoin: _string_join,
     ops.StringReplace: fixed_arity(sa.func.replace, 3),
     ops.StringSQLLike: functools.partial(_string_like, "like"),
     ops.StringSQLILike: functools.partial(_string_like, "ilike"),

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -551,6 +551,12 @@ def _string_join(translator, expr):
     )
 
 
+def _string_concat(translator, expr):
+    args = expr.op().arg
+    args_formatted = ", ".join(map(translator.translate, args))
+    return f"arrayStringConcat([{args_formatted}])"
+
+
 def _string_like(translator, expr):
     value, pattern = expr.op().args[:2]
     return '{} LIKE {}'.format(
@@ -662,6 +668,7 @@ operation_registry = {
     ops.RStrip: _unary('trimRight'),
     ops.Strip: _unary('trimBoth'),
     ops.Repeat: _fixed_arity("repeat", 2),
+    ops.StringConcat: _string_concat,
     ops.RegexSearch: _fixed_arity('match', 2),
     # TODO: extractAll(haystack, pattern)[index + 1]
     ops.RegexExtract: _regex_extract,

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -596,11 +596,6 @@ def _array_slice(t, expr):
     return sa_arg[sa_start + 1 : sa_stop]
 
 
-def _string_join(t, expr):
-    sep, elements = expr.op().args
-    return sa.func.concat_ws(t.translate(sep), *map(t.translate, elements))
-
-
 def _literal(t, expr):
     dtype = expr.type()
     op = expr.op()
@@ -669,7 +664,6 @@ operation_registry.update(
             ),
             2,
         ),
-        ops.StringJoin: _string_join,
         ops.FindInSet: _find_in_set,
         # math
         ops.Log: _log,

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -289,7 +289,7 @@ def _string_join(t, expr):
     sep, elements = expr.op().args
     return functools.reduce(
         operator.add,
-        map(t.translate, toolz.interpose(sep, elements)),
+        toolz.interpose(t.translate(sep), map(t.translate, elements)),
     )
 
 

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -262,7 +262,24 @@ def test_string_col_is_unicode(backend, alltypes, df):
             lambda t: ibis.literal('-').join(['a', t.string_col, 'c']),
             lambda t: 'a-' + t.string_col + '-c',
             id='join',
-            marks=pytest.mark.notimpl(["datafusion", "mysql", "sqlite"]),
+        ),
+        param(
+            lambda t: t.string_col + t.date_string_col,
+            lambda t: t.string_col + t.date_string_col,
+            id='concat_columns',
+            marks=pytest.mark.notimpl(["datafusion", "clickhouse"]),
+        ),
+        param(
+            lambda t: t.string_col + 'a',
+            lambda t: t.string_col + 'a',
+            id='concat_column_scalar',
+            marks=pytest.mark.notimpl(["datafusion", "clickhouse"]),
+        ),
+        param(
+            lambda t: 'a' + t.string_col,
+            lambda t: 'a' + t.string_col,
+            id='concat_scalar_column',
+            marks=pytest.mark.notimpl(["datafusion", "clickhouse"]),
         ),
     ],
 )

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -9,7 +9,7 @@ def is_text_type(x):
     return isinstance(x, str)
 
 
-def test_string_col_is_unicode(backend, alltypes, df):
+def test_string_col_is_unicode(alltypes, df):
     dtype = alltypes.string_col.type()
     assert dtype == dt.String(nullable=dtype.nullable)
     assert df.string_col.map(is_text_type).all()
@@ -262,24 +262,25 @@ def test_string_col_is_unicode(backend, alltypes, df):
             lambda t: ibis.literal('-').join(['a', t.string_col, 'c']),
             lambda t: 'a-' + t.string_col + '-c',
             id='join',
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             lambda t: t.string_col + t.date_string_col,
             lambda t: t.string_col + t.date_string_col,
             id='concat_columns',
-            marks=pytest.mark.notimpl(["datafusion", "clickhouse"]),
+            marks=pytest.mark.notimpl(["datafusion", "impala"]),
         ),
         param(
             lambda t: t.string_col + 'a',
             lambda t: t.string_col + 'a',
             id='concat_column_scalar',
-            marks=pytest.mark.notimpl(["datafusion", "clickhouse"]),
+            marks=pytest.mark.notimpl(["datafusion", "impala"]),
         ),
         param(
             lambda t: 'a' + t.string_col,
             lambda t: 'a' + t.string_col,
             id='concat_scalar_column',
-            marks=pytest.mark.notimpl(["datafusion", "clickhouse"]),
+            marks=pytest.mark.notimpl(["datafusion", "impala"]),
         ),
     ],
 )

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -269,7 +269,6 @@ def test_integer_to_interval_timestamp(
 # TODO - DateOffset - #2553
 @pytest.mark.notimpl(
     [
-        "clickhouse",
         "dask",
         "datafusion",
         "impala",


### PR DESCRIPTION
This PR adds StringJoin and StringConcat rules for the SQLite backend. Unit tests are also included. Closes #3611.