### PR TITLE
doc(sqlite): remove unavailable sql method from sqlite docs

### DIFF
--- a/docs/backends/SQLite.md
+++ b/docs/backends/SQLite.md
@@ -3,6 +3,40 @@ backend_name: SQLite
 backend_url: https://www.sqlite.org/
 backend_module: sqlite
 backend_param_style: a path to a SQLite database
+exclude_backend_api: true
 ---
 
 {% include 'backends/template.md' %}
+
+## Backend API
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.sqlite.Backend
+    rendering:
+      heading_level: 3
+    selection:
+      inherited_members: true
+      members:
+        - add_operation
+        - attach
+        - compile
+        - connect
+        - create_database
+        - create_table
+        - create_view
+        - database
+        - drop_table
+        - drop_view
+        - execute
+        - exists_database
+        - exists_table
+        - explain
+        - insert
+        - list_databases
+        - list_tables
+        - load_data
+        - raw_sqlite
+        - schema
+        - table
+        - verify
+<!-- prettier-ignore-end -->

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -67,6 +67,11 @@ class BaseSQLBackend(BaseBackend):
         schema = self._get_schema_using_query(limited_query)
         return ops.SQLQueryResult(query, schema, self).to_expr()
 
+    def _get_schema_using_query(self, query):
+        raise NotImplementedError(
+            f"Backend {self.name} does not support .sql()"
+        )
+
     def raw_sql(self, query: str, results: bool = False) -> Any:
         """Execute a query string.
 


### PR DESCRIPTION
Also adds a `NotImplementedError` to the base class for child classes
that don't implement `_get_schema_using_query`.

This isn't the solution that I wanted for the docs, but it works.

There are options to `filter` out `members` in `mkdocstrings` but the
`filter` option is currently incompatible with `inherited_members`.

ref: #3610 