### PR TITLE
refactor(ir): make Annotable immutable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ ci/udf/build.ninja
 junit.xml
 spark-warehouse
 docs/backends/support_matrix.csv
+__pycache__

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -354,7 +354,12 @@ class BaseAlchemyBackend(BaseSQLBackend):
 
     def _sqla_table_to_expr(self, table: sa.Table) -> ir.TableExpr:
         schema = self._schemas.get(table.name)
-        node = self.table_class(table, self, schema)
+        node = self.table_class(
+            source=self,
+            sqla_table=table,
+            name=table.name,
+            schema=schema,
+        )
         return self.table_expr_class(node)
 
     def table(

--- a/ibis/backends/base/sql/alchemy/database.py
+++ b/ibis/backends/base/sql/alchemy/database.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
+from typing import Hashable, MutableMapping
+
 import ibis.expr.operations as ops
+import ibis.expr.rules as rlz
 import ibis.expr.schema as sch
 from ibis.backends.base import Database
 
@@ -11,12 +16,28 @@ class AlchemyDatabase(Database):
 
 
 class AlchemyTable(ops.DatabaseTable):
-    def __init__(self, table, source, schema=None):
-        schema = sch.infer(table, schema=schema)
-        super().__init__(table.name, schema, source)
-        self.sqla_table = table
+    sqla_table = rlz.instance_of(object)
+    name = rlz.optional(rlz.instance_of(str), default=None)
+    schema = rlz.optional(rlz.instance_of(sch.Schema), default=None)
 
-    def __getstate__(self):
-        d = super().__getstate__()
-        d['sqla_table'] = self.sqla_table
-        return d
+    def __init__(self, source, sqla_table, name, schema):
+        if name is None:
+            name = sqla_table.name
+        if schema is None:
+            schema = sch.infer(sqla_table, schema=schema)
+        super().__init__(
+            name=name, schema=schema, sqla_table=sqla_table, source=source
+        )
+
+    # TODO(cpcloud): implement this as __component_eq__ after #3621
+    def equals(
+        self,
+        other: AlchemyTable,
+        cache: MutableMapping[Hashable, bool] | None = None,
+    ) -> bool:
+        return (
+            type(self) == type(other)
+            and self.name == other.name
+            and self.source == other.source
+            and self.schema.equals(other.schema, cache=cache)
+        )

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -378,11 +378,19 @@ def _literal(translator, expr):
             value = value.strftime('%Y-%m-%d')
         return f"toDate('{value!s}')"
     elif isinstance(expr, ir.ArrayValue):
-        return str(list(value))
+        return str(list(_tuple_to_list(value)))
     elif isinstance(expr, ir.SetScalar):
         return '({})'.format(', '.join(map(repr, value)))
     else:
         raise NotImplementedError(type(expr))
+
+
+def _tuple_to_list(t: tuple):
+    for element in t:
+        if util.is_iterable(element):
+            yield list(_tuple_to_list(element))
+        else:
+            yield element
 
 
 class _CaseFormatter:

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -112,7 +112,7 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ops.Difference: [
         ((dd.DataFrame, dd.DataFrame), execute_difference_dataframe_dataframe)
     ],
-    ops.DropNa: [((dd.DataFrame,), execute_node_dropna_dataframe)],
+    ops.DropNa: [((dd.DataFrame, tuple), execute_node_dropna_dataframe)],
     ops.FillNa: [
         ((dd.DataFrame, simple_types), execute_node_fillna_dataframe_scalar),
         ((dd.DataFrame,), execute_node_fillna_dataframe_dict),

--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -157,13 +157,17 @@ def build_df_from_projection(
     return dd.concat(data_pieces, axis=1).reset_index(drop=True)
 
 
-@execute_node.register(ops.Selection, dd.DataFrame)
+@execute_node.register(ops.Selection, dd.DataFrame, tuple, tuple, tuple)
 def execute_selection_dataframe(
-    op, data, scope: Scope, timecontext: Optional[TimeContext], **kwargs
+    op,
+    data,
+    selections,
+    predicates,
+    sort_keys,
+    scope: Scope,
+    timecontext: Optional[TimeContext],
+    **kwargs,
 ):
-    selections = op.selections
-    predicates = op.predicates
-    sort_keys = op.sort_keys
     result = data
 
     if selections:

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -369,13 +369,17 @@ def build_df_from_projection(
     return pd.concat(new_pieces, axis=1)
 
 
-@execute_node.register(ops.Selection, pd.DataFrame)
+@execute_node.register(ops.Selection, pd.DataFrame, tuple, tuple, tuple)
 def execute_selection_dataframe(
-    op, data, scope: Scope, timecontext: Optional[TimeContext], **kwargs
+    op,
+    data,
+    selections,
+    predicates,
+    sort_keys,
+    scope: Scope,
+    timecontext: Optional[TimeContext],
+    **kwargs,
 ):
-    selections = op.selections
-    predicates = op.predicates
-    sort_keys = op.sort_keys
     result = data
 
     # Build up the individual pandas structures from column expressions

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -6,7 +6,6 @@ import re
 import string
 import warnings
 
-import numpy as np
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.compiler import compiles
@@ -30,6 +29,7 @@ from ibis.backends.base.sql.alchemy import (
     unary,
     variance_reduction,
 )
+from ibis.backends.base.sql.alchemy.datatypes import to_sqla_type
 from ibis.backends.base.sql.alchemy.registry import get_col_or_deferred_col
 
 operation_registry = sqlalchemy_operation_registry.copy()
@@ -608,9 +608,11 @@ def _literal(t, expr):
     # geo spatial data type
     elif isinstance(expr, ir.GeoSpatialScalar):
         # inline_metadata ex: 'SRID=4326;POINT( ... )'
-        return sa.text(geo.translate_literal(expr, inline_metadata=True))
-    elif isinstance(value, np.ndarray):
-        return sa.literal(value.tolist())
+        return sa.literal_column(
+            geo.translate_literal(expr, inline_metadata=True)
+        )
+    elif isinstance(value, tuple):
+        return sa.literal(value, type_=to_sqla_type(dtype))
     else:
         return sa.literal(value)
 

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -121,7 +121,7 @@ class Backend(BaseAlchemyBackend):
             Table expression
         """
         alch_table = self._get_sqla_table(name, schema=database)
-        node = self.table_class(alch_table, self)
+        node = self.table_class(source=self, sqla_table=alch_table)
         return self.table_expr_class(node)
 
     def _table_from_schema(

--- a/ibis/common/geospatial.py
+++ b/ibis/common/geospatial.py
@@ -1,15 +1,8 @@
 from typing import Iterable, List, TypeVar
 
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis.common import exceptions as ex
-
-IS_SHAPELY_AVAILABLE = False
-try:
-    import shapely
-
-    IS_SHAPELY_AVAILABLE = True
-except ImportError:
-    ...
 
 NumberType = TypeVar('NumberType', int, float)
 # Geometry primitives (2D)
@@ -137,10 +130,8 @@ def translate_literal(expr, inline_metadata: bool = False) -> str:
     op = expr.op()
     value = op.value
 
-    if IS_SHAPELY_AVAILABLE and isinstance(
-        value, shapely.geometry.base.BaseGeometry
-    ):
-        result = value.wkt
+    if isinstance(value, dt._WellKnownText):
+        result = value.text
     elif isinstance(expr, ir.PointScalar):
         result = translate_point(value)
     elif isinstance(expr, ir.LineStringScalar):

--- a/ibis/expr/operations/analytic.py
+++ b/ibis/expr/operations/analytic.py
@@ -20,9 +20,9 @@ class WindowOp(ValueOp):
 
     display_argnames = False
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.expr = propagate_down_window(self.expr, self.window)
+    def __init__(self, expr, window):
+        expr = propagate_down_window(expr, window)
+        super().__init__(expr=expr, window=window)
 
     def over(self, window):
         new_window = self.window.combine(window)

--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -10,12 +10,13 @@ from .core import UnaryOp, ValueOp
 class ArrayColumn(ValueOp):
     cols = rlz.value_list_of(rlz.column(rlz.any), min_length=1)
 
-    def _validate(self):
-        if len({col.type() for col in self.cols}) > 1:
+    def __init__(self, cols):
+        if len({col.type() for col in cols}) > 1:
             raise com.IbisTypeError(
                 f'The types of all input columns must match exactly in a '
                 f'{type(self).__name__} operation.'
             )
+        super().__init__(cols=cols)
 
     def output_type(self):
         first_dtype = self.cols[0].type()
@@ -52,8 +53,8 @@ class ArrayConcat(ValueOp):
     right = rlz.array
     output_type = rlz.shape_like('left')
 
-    def _validate(self):
-        left_dtype, right_dtype = self.left.type(), self.right.type()
+    def __init__(self, left, right):
+        left_dtype, right_dtype = left.type(), right.type()
         if left_dtype != right_dtype:
             raise com.IbisTypeError(
                 'Array types must match exactly in a {} operation. '
@@ -61,6 +62,7 @@ class ArrayConcat(ValueOp):
                     type(self).__name__, left_dtype, right_dtype
                 )
             )
+        super().__init__(left=left, right=right)
 
 
 @public

--- a/ibis/expr/operations/logical.py
+++ b/ibis/expr/operations/logical.py
@@ -52,7 +52,8 @@ class Comparison(BinaryOp):
         :param left:
         :param right:
         """
-        super().__init__(*self._maybe_cast_args(left, right))
+        left, right = self._maybe_cast_args(left, right)
+        super().__init__(left=left, right=right)
 
     def _maybe_cast_args(self, left, right):
         # it might not be necessary?

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -51,7 +51,7 @@ class Expr:
             return repr(result)
 
     def __hash__(self) -> int:
-        return hash(self._key)
+        return hash((self.__class__, self._safe_name, self._arg))
 
     def __bool__(self) -> bool:
         raise ValueError(

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -605,7 +605,7 @@ class AnyValue(ValueExpr):
         return ops.GroupConcat(self, sep=sep, where=where).to_expr()
 
     def __hash__(self) -> int:
-        return super().__hash__()
+        return hash((self._name, self._dtype, self._arg))
 
     def __eq__(self, other: AnyValue) -> ir.BooleanValue:
         import ibis.expr.operations as ops

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -442,14 +442,13 @@ class TableExpr(Expr):
         TableExpr
             Sorted table
         """
-        return (
-            self.op()
-            .sort_by(
-                self,
-                [] if sort_exprs is None else util.promote_list(sort_exprs),
-            )
-            .to_expr()
-        )
+        if isinstance(sort_exprs, tuple):
+            sort_exprs = [sort_exprs]
+        elif sort_exprs is None:
+            sort_exprs = []
+        else:
+            sort_exprs = util.promote_list(sort_exprs)
+        return self.op().sort_by(self, sort_exprs).to_expr()
 
     def union(
         self,

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -419,11 +419,13 @@ class MockAlchemyBackend(MockBackend):
 
     def _inject_table(self, name, schema):
         try:
-            table = self.meta.tables[name]
+            alchemy_table = self.meta.tables[name]
         except KeyError:
-            table = table_from_schema(name, self.meta, schema)
+            alchemy_table = table_from_schema(name, self.meta, schema)
 
-        return self.table_class(table, self).to_expr()
+        return self.table_class(
+            source=self, sqla_table=alchemy_table, schema=schema
+        ).to_expr()
 
 
 GEO_TABLE = {

--- a/ibis/tests/expr/test_array.py
+++ b/ibis/tests/expr/test_array.py
@@ -16,7 +16,7 @@ import ibis.expr.operations as ops
 )
 def test_array_literal(arg, typestr, type):
     x = ibis.literal(arg, type=typestr)
-    assert x._arg.value == arg
+    assert x._arg.value == tuple(arg)
     assert x.type() == type
 
 

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -6,6 +6,7 @@ import ibis
 from ibis.expr import datatypes
 from ibis.expr.operations import Literal
 from ibis.tests.util import assert_pickle_roundtrip
+from ibis.util import frozendict
 
 
 def test_literal_equality_basic():
@@ -106,7 +107,9 @@ def test_normalized_underlying_value(userinput, literal_type, expected_type):
 def test_struct_literal(value):
     typestr = "struct<field1: string, field2: float64>"
     a = ibis.struct(value, type=typestr)
-    assert a.op().value == value
+    assert a.op().value == frozendict(
+        field1=value['field1'], field2=value['field2']
+    )
     assert a.type() == datatypes.dtype(typestr)
 
 

--- a/ibis/tests/expr/test_rules.py
+++ b/ibis/tests/expr/test_rules.py
@@ -221,7 +221,7 @@ def test_valid_value_list_of(validator, values, expected):
 
 def test_valid_list_of_extra():
     validator = rlz.list_of(identity)
-    assert validator((3, 2)) == [3, 2]
+    assert validator((3, 2)) == tuple([3, 2])
 
     validator = rlz.list_of(rlz.list_of(rlz.string))
     result = validator([[], ['a']])
@@ -302,11 +302,9 @@ def test_invalid_column_or_scalar(validator, value, expected):
     ],
 )
 def test_valid_column_from(check_table, value, expected):
-    class Test:
-        table = check_table
-
     validator = rlz.column_from("table")
-    assert validator(value, this=Test()).equals(expected)
+    this = dict(table=table)
+    assert validator(value, this=this).equals(expected)
 
 
 @pytest.mark.parametrize(
@@ -322,10 +320,7 @@ def test_valid_column_from(check_table, value, expected):
     ],
 )
 def test_invalid_column_from(check_table, validator, value):
-    class Test:
-        table = check_table
-
-    test = Test()
+    test = dict(table=check_table)
 
     with pytest.raises(IbisTypeError):
         validator(value, this=test)

--- a/ibis/tests/expr/test_signature.py
+++ b/ibis/tests/expr/test_signature.py
@@ -242,13 +242,13 @@ def test_positional_argument_reordering():
 
 
 def test_copy_default():
-    default = []
+    default = tuple()
 
     class Op(Annotable):
-        arg = Optional(InstanceOf(list), default=default)
+        arg = Optional(InstanceOf(tuple), default=default)
 
     op = Op()
-    assert op.arg is not default
+    assert op.arg is default
 
 
 def test_slots_are_inherited_and_overridable():

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1024,7 +1024,7 @@ def test_join_invalid_expr_type(con):
     invalid_right = left.foo_id
     join_key = ['bar_id']
 
-    with pytest.raises(NotImplementedError, match="string __getitem__"):
+    with pytest.raises(com.IbisTypeError, match="Argument is not a table"):
         left.inner_join(invalid_right, join_key)
 
 
@@ -1379,8 +1379,12 @@ def test_multiple_db_different_backends():
     backend1_table = con1.table('alltypes')
     backend2_table = con2.table('alltypes')
 
-    with pytest.raises(RelationError):
-        backend1_table.union(backend2_table)
+    expr = backend1_table.union(backend2_table)
+    with pytest.raises(
+        ValueError,
+        match=re.compile("multiple backends", flags=re.IGNORECASE),
+    ):
+        expr.compile()
 
 
 def test_merge_as_of_allows_overlapping_columns():

--- a/ibis/tests/expr/test_udf.py
+++ b/ibis/tests/expr/test_udf.py
@@ -37,7 +37,7 @@ def test_vectorized_udf_operations(table, klass, output_type):
     assert udf.func_args[0].equals(table.a)
     assert udf.func_args[1].equals(table.b)
     assert udf.func_args[2].equals(table.c)
-    assert udf.input_type == [dt.int8(), dt.string(), dt.boolean()]
+    assert udf.input_type == tuple([dt.int8(), dt.string(), dt.boolean()])
     assert udf.return_type == dt.int8()
 
     factory = udf.output_type()

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -10,9 +10,11 @@ import warnings
 from numbers import Real
 from typing import (
     Any,
+    Hashable,
     Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Sequence,
     Type,
@@ -28,6 +30,33 @@ from ibis.config import options
 T = TypeVar("T", covariant=True)
 U = TypeVar("U", covariant=True)
 V = TypeVar("V")
+
+
+class frozendict(Mapping, Hashable):
+
+    __slots__ = ("_dict", "_hash")
+
+    def __init__(self, *args, **kwargs):
+        self._dict = dict(*args, **kwargs)
+        self._hash = hash(tuple(self._dict.items()))
+
+    def __str__(self):
+        return str(self._dict)
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._dict!r})"
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __hash__(self):
+        return self._hash
 
 
 def guid() -> str:
@@ -86,9 +115,12 @@ def promote_list(val: Union[V, Sequence[V]]) -> List[V]:
     -------
     list
     """
-    if not isinstance(val, list):
-        val = [val]
-    return val
+    if isinstance(val, list):
+        return val
+    elif isinstance(val, tuple):
+        return list(val)
+    else:
+        return [val]
 
 
 def is_function(v: Any) -> bool:


### PR DESCRIPTION
Alternative implementation of https://github.com/ibis-project/ibis/pull/3609

Additions:
 - enforced immutable node arguments making the hashing easier
 - execute the rules before calling `__init__()` (using `AnnotableMeta.__call__()`)
 - implicitly called `__post_init__` setting the `args` tuple and `_hash`