### PR TITLE
perf(ir): speed up expr and op equality comparisons by caching

### DIFF
--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -1,16 +1,19 @@
+from __future__ import annotations
+
 import datetime
 import decimal
 import enum
 import functools
 import itertools
 import uuid
+from typing import Hashable, MutableMapping
 
 import numpy as np
 import pandas as pd
 from public import public
 
 from ...common import exceptions as com
-from ...util import frozendict
+from ...util import frozendict, seq_eq
 from .. import datatypes as dt
 from .. import rules as rlz
 from .. import types as ir
@@ -43,6 +46,16 @@ class TableColumn(ValueOp):
             )
 
         super().__init__(table=table, name=name)
+
+    def __component_eq__(
+        self,
+        other: TableColumn,
+        cache: MutableMapping[Hashable, bool],
+    ) -> bool:
+        return self.name == other.name and self.table.equals(
+            other.table,
+            cache=cache,
+        )
 
     def parent(self):
         return self.table
@@ -336,6 +349,13 @@ class ValueList(ValueOp):
 
     def root_tables(self):
         return distinct_roots(*self.values)
+
+    def __component_eq__(
+        self,
+        other: ValueList,
+        cache: MutableMapping[Hashable, bool],
+    ) -> bool:
+        return seq_eq(self.values, other.values, cache=cache)
 
 
 @public

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import webbrowser
-from typing import TYPE_CHECKING, Any, Hashable, Mapping
+from typing import TYPE_CHECKING, Any, Hashable, Mapping, MutableMapping
 
 from public import public
 
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 
 @public
-class Expr:
+class Expr(util.EqMixin):
     """Base expression class"""
 
     def _type_display(self) -> str:
@@ -51,7 +51,7 @@ class Expr:
             return repr(result)
 
     def __hash__(self) -> int:
-        return hash((self.__class__, self._safe_name, self._arg))
+        return hash(self._key)
 
     def __bool__(self) -> bool:
         raise ValueError(
@@ -306,9 +306,22 @@ class Expr:
         else:
             return True
 
-    def equals(self, other, cache=None):
-        if type(self) != type(other):
-            return False
+    def equals(
+        self, other: Any, cache: MutableMapping[Hashable, bool] | None = None
+    ) -> bool:
+        return super().equals(other, cache=cache)
+
+    def _type_check(self, other: Any) -> None:
+        if not isinstance(other, Expr):
+            raise TypeError(
+                f"Cannot compare non-Expr object {type(other)} with Expr"
+            )
+
+    def __component_eq__(
+        self,
+        other: ir.Expr,
+        cache: MutableMapping[Hashable, bool] | None = None,
+    ) -> bool:
         return self._arg.equals(other._arg, cache=cache)
 
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -4,6 +4,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Hashable,
     Iterable,
     MutableMapping,
     Sequence,
@@ -40,16 +41,16 @@ class ValueExpr(Expr):
         self._name = name
         self._dtype = dtype
 
-    def equals(
+    def __component_eq__(
         self,
-        other: Any,
-        cache: MutableMapping[Any, bool] | None = None,
+        other: ValueExpr,
+        cache: MutableMapping[Hashable, bool] | None = None,
     ) -> bool:
         return (
             isinstance(other, ValueExpr)
             and self._name == other._name
-            and self._dtype == other._dtype
-            and super().equals(other, cache=cache)
+            and self._dtype.equals(other._dtype, cache=cache)
+            and super().__component_eq__(other, cache=cache)
         )
 
     def has_name(self) -> bool:

--- a/ibis/tests/expr/test_datatypes.py
+++ b/ibis/tests/expr/test_datatypes.py
@@ -30,30 +30,23 @@ def test_validate_type():
         ([dt.uint8], dt.Array(dt.uint8)),
         ([dt.float32, dt.float64], dt.Array(dt.float64)),
         ({dt.string}, dt.Set(dt.string)),
-        ('point', dt.point),
-        ('point;4326', dt.point),
-        ('point;4326:geometry', dt.point),
-        ('point;4326:geography', dt.point),
-        ('linestring', dt.linestring),
-        ('linestring;4326', dt.linestring),
-        ('linestring;4326:geometry', dt.linestring),
-        ('linestring;4326:geography', dt.linestring),
-        ('polygon', dt.polygon),
-        ('polygon;4326', dt.polygon),
-        ('polygon;4326:geometry', dt.polygon),
-        ('polygon;4326:geography', dt.polygon),
-        ('multilinestring', dt.multilinestring),
-        ('multilinestring;4326', dt.multilinestring),
-        ('multilinestring;4326:geometry', dt.multilinestring),
-        ('multilinestring;4326:geography', dt.multilinestring),
-        ('multipoint', dt.multipoint),
-        ('multipoint;4326', dt.multipoint),
-        ('multipoint;4326:geometry', dt.multipoint),
-        ('multipoint;4326:geography', dt.multipoint),
-        ('multipolygon', dt.multipolygon),
-        ('multipolygon;4326', dt.multipolygon),
-        ('multipolygon;4326:geometry', dt.multipolygon),
-        ('multipolygon;4326:geography', dt.multipolygon),
+    ]
+    + [
+        (f"{cls.__name__.lower()}{suffix}", expected)
+        for cls in [
+            dt.Point,
+            dt.LineString,
+            dt.Polygon,
+            dt.MultiLineString,
+            dt.MultiPoint,
+            dt.MultiPolygon,
+        ]
+        for suffix, expected in [
+            ("", cls()),
+            (";4326", cls(srid=4326)),
+            (";4326:geometry", cls(geotype="geometry", srid=4326)),
+            (";4326:geography", cls(geotype="geography", srid=4326)),
+        ]
     ],
 )
 def test_dtype(spec, expected):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,8 @@ addopts = [
   "--strict-markers",
   "--strict-config",
   "--benchmark-skip",
+  "--benchmark-group-by=name",
+  "--benchmark-sort=name",
 ]
 empty_parameter_set_mark = "fail_at_collect"
 norecursedirs = ["site-packages", "dist-packages"]


### PR DESCRIPTION
This PR refactors the caching mechanism for expr and op equality comparison. Previously we were caching in a very ad hoc manner. After this PR, subclasses of util.CachedEq need only implement the `_raw_equals` interface to gain the benefits of caching. Additionally, some comparisons have been specifically implemented to hit the short circuit path as soon as possible.