### PR TITLE
feat(sql): implement methods for mixing sql with expressions

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -263,3 +263,9 @@ class BaseSQLBackend(BaseBackend):
         translator = cls.compiler.translator_class
         op_classes = translator._registry.keys() | translator._rewrites.keys()
         return operation in op_classes
+
+    def _create_temp_view(self, view, definition):
+        raise NotImplementedError(
+            f"The {self.name} backend does not implement temporary view "
+            "creation"
+        )

--- a/ibis/backends/base/sql/compiler/extract_subqueries.py
+++ b/ibis/backends/base/sql/compiler/extract_subqueries.py
@@ -109,15 +109,19 @@ class ExtractSubqueries:
         self.visit(op.right)
         self.observe(expr)
 
-    def visit_MaterializedJoin(self, expr):
-        self.visit(expr.op().join)
-        self.observe(expr)
-
     def visit_Selection(self, expr):
         self.visit(expr.op().table)
         self.observe(expr)
 
     def visit_SQLQueryResult(self, expr):
+        self.observe(expr)
+
+    def visit_View(self, expr):
+        self.visit(expr.op().child)
+        self.observe(expr)
+
+    def visit_SQLStringView(self, expr):
+        self.visit(expr.op().child)
         self.observe(expr)
 
     def visit_TableColumn(self, expr):

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -75,7 +75,7 @@ class QueryContext:
             pass
 
         op = expr.op()
-        if isinstance(op, ops.SQLQueryResult):
+        if isinstance(op, (ops.SQLQueryResult, ops.SQLStringView)):
             result = op.query
         else:
             result = self._compile_subquery(expr)

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -262,7 +262,11 @@ def pytest_runtest_call(item):
 def backend(request, data_directory):
     """Return an instance of BackendTest."""
     cls = _get_backend_conf(request.param)
-    return cls(data_directory)
+    result = cls(data_directory)
+    try:
+        yield result
+    finally:
+        result.cleanup()
 
 
 @pytest.fixture(scope='session')
@@ -286,7 +290,11 @@ def ddl_backend(request, data_directory):
     (sqlite, postgres, mysql, datafusion, clickhouse, pyspark, impala)
     """
     cls = _get_backend_conf(request.param)
-    return cls(data_directory)
+    result = cls(data_directory)
+    try:
+        yield result
+    finally:
+        result.cleanup()
 
 
 @pytest.fixture(scope='session')
@@ -315,7 +323,11 @@ def alchemy_backend(request, data_directory):
         )
     else:
         cls = _get_backend_conf(request.param)
-        return cls(data_directory)
+        result = cls(data_directory)
+        try:
+            yield result
+        finally:
+            result.cleanup()
 
 
 @pytest.fixture(scope='session')
@@ -335,7 +347,11 @@ def udf_backend(request, data_directory):
     Runs the UDF-supporting backends
     """
     cls = _get_backend_conf(request.param)
-    return cls(data_directory)
+    result = cls(data_directory)
+    try:
+        yield result
+    finally:
+        result.cleanup()
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -7,13 +7,12 @@ from typing import Literal
 
 import sqlalchemy as sa
 
-import ibis.backends.duckdb.datatypes as ddb
-import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 from ibis import util
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 
 from .compiler import PostgreSQLCompiler
+from .datatypes import _get_type
 from .udf import udf
 
 
@@ -205,71 +204,9 @@ ORDER BY attnum
         tuples = [(col, _get_type(typestr)) for col, typestr in type_info]
         return sch.Schema.from_tuples(tuples)
 
-
-def _get_type(typestr: str) -> dt.DataType:
-    try:
-        return _type_mapping[typestr]
-    except KeyError:
-        return ddb.parse_type(typestr)
-
-
-_type_mapping = {
-    "boolean": dt.bool,
-    "boolean[]": dt.Array(dt.bool),
-    "bytea": dt.binary,
-    "bytea[]": dt.Array(dt.binary),
-    "character(1)": dt.string,
-    "character(1)[]": dt.Array(dt.string),
-    "bigint": dt.int64,
-    "bigint[]": dt.Array(dt.int64),
-    "smallint": dt.int16,
-    "smallint[]": dt.Array(dt.int16),
-    "integer": dt.int32,
-    "integer[]": dt.Array(dt.int32),
-    "text": dt.string,
-    "text[]": dt.Array(dt.string),
-    "json": dt.json,
-    "json[]": dt.Array(dt.json),
-    "point": dt.point,
-    "point[]": dt.Array(dt.point),
-    "polygon": dt.polygon,
-    "polygon[]": dt.Array(dt.polygon),
-    "line": dt.linestring,
-    "line[]": dt.Array(dt.linestring),
-    "real": dt.float32,
-    "real[]": dt.Array(dt.float32),
-    "double precision": dt.float64,
-    "double precision[]": dt.Array(dt.float64),
-    "macaddr8": dt.macaddr,
-    "macaddr8[]": dt.Array(dt.macaddr),
-    "macaddr": dt.macaddr,
-    "macaddr[]": dt.Array(dt.macaddr),
-    "inet": dt.inet,
-    "inet[]": dt.Array(dt.inet),
-    "character": dt.string,
-    "character[]": dt.Array(dt.string),
-    "character varying": dt.string,
-    "character varying[]": dt.Array(dt.string),
-    "date": dt.date,
-    "date[]": dt.Array(dt.date),
-    "time without time zone": dt.time,
-    "time without time zone[]": dt.Array(dt.time),
-    "timestamp without time zone": dt.timestamp,
-    "timestamp without time zone[]": dt.Array(dt.timestamp),
-    "timestamp with time zone": dt.Timestamp("UTC"),
-    "timestamp with time zone[]": dt.Array(dt.Timestamp("UTC")),
-    "interval": dt.interval,
-    "interval[]": dt.Array(dt.interval),
-    # NB: this isn"t correct, but we try not to fail
-    "time with time zone": "time",
-    "numeric": dt.decimal,
-    "numeric[]": dt.Array(dt.decimal),
-    "uuid": dt.uuid,
-    "uuid[]": dt.Array(dt.uuid),
-    "jsonb": dt.jsonb,
-    "jsonb[]": dt.Array(dt.jsonb),
-    "geometry": dt.geometry,
-    "geometry[]": dt.Array(dt.geometry),
-    "geography": dt.geography,
-    "geography[]": dt.Array(dt.geography),
-}
+    def _get_temp_view_definition(
+        self,
+        name: str,
+        definition: sa.sql.compiler.Compiled,
+    ) -> str:
+        return f"CREATE OR REPLACE TEMPORARY VIEW {name} AS {definition}"

--- a/ibis/backends/postgres/datatypes.py
+++ b/ibis/backends/postgres/datatypes.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import ibis.backends.duckdb.datatypes as ddb
+import ibis.expr.datatypes as dt
+
+
+def _get_type(typestr: str) -> dt.DataType:
+    try:
+        return _type_mapping[typestr]
+    except KeyError:
+        return ddb.parse_type(typestr)
+
+
+_type_mapping = {
+    "boolean": dt.bool,
+    "boolean[]": dt.Array(dt.bool),
+    "bytea": dt.binary,
+    "bytea[]": dt.Array(dt.binary),
+    "character(1)": dt.string,
+    "character(1)[]": dt.Array(dt.string),
+    "bigint": dt.int64,
+    "bigint[]": dt.Array(dt.int64),
+    "smallint": dt.int16,
+    "smallint[]": dt.Array(dt.int16),
+    "integer": dt.int32,
+    "integer[]": dt.Array(dt.int32),
+    "text": dt.string,
+    "text[]": dt.Array(dt.string),
+    "json": dt.json,
+    "json[]": dt.Array(dt.json),
+    "point": dt.point,
+    "point[]": dt.Array(dt.point),
+    "polygon": dt.polygon,
+    "polygon[]": dt.Array(dt.polygon),
+    "line": dt.linestring,
+    "line[]": dt.Array(dt.linestring),
+    "real": dt.float32,
+    "real[]": dt.Array(dt.float32),
+    "double precision": dt.float64,
+    "double precision[]": dt.Array(dt.float64),
+    "macaddr8": dt.macaddr,
+    "macaddr8[]": dt.Array(dt.macaddr),
+    "macaddr": dt.macaddr,
+    "macaddr[]": dt.Array(dt.macaddr),
+    "inet": dt.inet,
+    "inet[]": dt.Array(dt.inet),
+    "character": dt.string,
+    "character[]": dt.Array(dt.string),
+    "character varying": dt.string,
+    "character varying[]": dt.Array(dt.string),
+    "date": dt.date,
+    "date[]": dt.Array(dt.date),
+    "time without time zone": dt.time,
+    "time without time zone[]": dt.Array(dt.time),
+    "timestamp without time zone": dt.timestamp,
+    "timestamp without time zone[]": dt.Array(dt.timestamp),
+    "timestamp with time zone": dt.Timestamp("UTC"),
+    "timestamp with time zone[]": dt.Array(dt.Timestamp("UTC")),
+    "interval": dt.interval,
+    "interval[]": dt.Array(dt.interval),
+    # NB: this isn"t correct, but we try not to fail
+    "time with time zone": "time",
+    "numeric": dt.decimal,
+    "numeric[]": dt.Array(dt.decimal),
+    "uuid": dt.uuid,
+    "uuid[]": dt.Array(dt.uuid),
+    "jsonb": dt.jsonb,
+    "jsonb[]": dt.Array(dt.jsonb),
+    "geometry": dt.geometry,
+    "geometry[]": dt.Array(dt.geometry),
+    "geography": dt.geography,
+    "geography[]": dt.Array(dt.geography),
+}

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 from datetime import datetime, timezone
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -115,7 +117,7 @@ def get_common_spark_testing_client(data_directory, connect):
         .repartition(num_partitions)
         .sort('playerID')
     )
-    df_batting.createOrReplaceTempView('batting')
+    df_batting.write.saveAsTable("batting", format="parquet", mode="overwrite")
 
     df_awards_players = (
         s.read.csv(
@@ -216,6 +218,11 @@ class TestConf(BackendTest, RoundAwayFromZero):
     @staticmethod
     def connect(data_directory):
         return get_pyspark_testing_client(data_directory)
+
+    def cleanup(self):
+        (path,) = map(Path, ibis.__path__)
+        path = path.parent / "spark-warehouse"
+        shutil.rmtree(path, ignore_errors=True)
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -150,3 +150,6 @@ class BackendTest(abc.ABC):
         self, params: Optional[Mapping[ir.ValueExpr, Any]] = None
     ):
         return self.api.compiler.make_context(params=params)
+
+    def cleanup(self):
+        pass

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -1,0 +1,123 @@
+import pandas as pd
+import pytest
+
+dot_sql_notimpl = pytest.mark.notimpl(
+    ["clickhouse", "datafusion", "impala", "sqlite"]
+)
+dot_sql_never = pytest.mark.never(
+    ["dask", "pandas"],
+    reason="dask and pandas do not accept SQL",
+)
+
+pytestmark = pytest.mark.xdist_group("dot_sql")
+
+
+@dot_sql_notimpl
+@dot_sql_never
+def test_dot_sql(backend, con):
+    alltypes = con.table("functional_alltypes")
+    t = (
+        alltypes.sql(
+            """
+            SELECT
+                string_col as s,
+                double_col + 1.0 AS new_col
+            FROM functional_alltypes
+            """
+        )
+        .group_by("s")  # group by a column from SQL
+        .aggregate(fancy_af=lambda t: t.new_col.mean())
+        .alias("awesome_t")  # create a name for the aggregate
+        .sql("SELECT fancy_af AS yas FROM awesome_t ORDER BY fancy_af")
+    )
+
+    alltypes_df = alltypes.execute()
+    result = t.execute()["yas"]
+    expected = (
+        alltypes_df.assign(
+            s=alltypes_df.string_col, new_col=alltypes_df.double_col + 1.0
+        )
+        .groupby("s")
+        .new_col.mean()
+        .rename("yas")
+        .reset_index()
+        .yas
+    )
+    backend.assert_series_equal(result, expected)
+
+
+@dot_sql_notimpl
+@dot_sql_never
+def test_dot_sql_with_join(backend, con):
+    alltypes = con.table("functional_alltypes")
+    t = (
+        alltypes.sql(
+            """
+            SELECT
+                string_col as s,
+                double_col + 1.0 AS new_col
+            FROM functional_alltypes
+            """
+        )
+        .alias("ft")
+        .group_by("s")  # group by a column from SQL
+        .aggregate(fancy_af=lambda t: t.new_col.mean())
+        .alias("awesome_t")  # create a name for the aggregate
+        .sql(
+            """
+            SELECT
+                l.fancy_af AS yas,
+                r.s
+            FROM awesome_t AS l
+            LEFT JOIN ft AS r
+            ON l.s = r.s
+            """
+        )
+        .sort_by(["s", "yas"])
+    )
+
+    alltypes_df = alltypes.execute()
+    result = t.execute()
+
+    ft = alltypes_df.assign(
+        s=alltypes_df.string_col, new_col=alltypes_df.double_col + 1.0
+    )
+    expected = pd.merge(
+        ft.groupby("s").new_col.mean().rename("yas").reset_index(),
+        ft[["s"]],
+        on=["s"],
+        how="left",
+    )[["yas", "s"]].sort_values(["s", "yas"])
+    backend.assert_frame_equal(result, expected)
+
+
+@dot_sql_notimpl
+@dot_sql_never
+def test_dot_sql_repr(con):
+    alltypes = con.table("functional_alltypes")
+    t = (
+        alltypes.sql(
+            """
+            SELECT
+                string_col as s,
+                double_col + 1.0 AS new_col
+            FROM functional_alltypes
+            """
+        )
+        .group_by("s")  # group by a column from SQL
+        .aggregate(fancy_af=lambda t: t.new_col.mean())
+        .alias("awesome_t")  # create a name for the aggregate
+        .sql("SELECT fancy_af AS yas FROM awesome_t ORDER BY fancy_af")
+    )
+
+    assert repr(t)
+
+
+@dot_sql_notimpl
+@dot_sql_never
+def test_dot_sql_does_not_clobber_existing_tables(con):
+    expr = con.table("functional_alltypes").sql(
+        "SELECT 1 as x FROM functional_alltypes"
+    )
+    with pytest.raises(ValueError):
+        expr.alias("batting")

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -797,6 +797,32 @@ class DropNa(TableNode, sch.HasSchema):
         return self.table.schema()
 
 
+@public
+class View(PhysicalTable):
+    """A view created from an expression."""
+
+    child = rlz.table
+    name = rlz.instance_of(str)
+
+    @property
+    def schema(self):
+        return self.child.schema()
+
+
+@public
+class SQLStringView(PhysicalTable):
+    """A view created from a SQL string."""
+
+    child = rlz.table
+    name = rlz.instance_of(str)
+    query = rlz.instance_of(str)
+
+    @cached_property
+    def schema(self):
+        backend = self.child._find_backend()
+        return backend._get_schema_using_query(self.query)
+
+
 def _dedup_join_columns(
     expr: ir.TableExpr,
     *,

--- a/ibis/tests/expr/test_format.py
+++ b/ibis/tests/expr/test_format.py
@@ -35,7 +35,7 @@ def test_table_type_output():
     result = repr(expr)
 
     assert 'SelfReference[r0]' in result
-    assert 'UnboundTable[foo]' in result
+    assert 'UnboundTable: foo' in result
 
 
 def test_aggregate_arg_names(table):
@@ -193,7 +193,7 @@ def test_same_column_multiple_aliases():
     expr = table[table.col.name('fakealias1'), table.col.name('fakealias2')]
     result = repr(expr)
 
-    assert "UnboundTable[t]" in result
+    assert "UnboundTable: t" in result
     assert "col int64" in result
     assert "fakealias1: r0.col" in result
     assert "fakealias2: r0.col" in result
@@ -217,7 +217,7 @@ def test_repr_exact():
     ).mutate(col4=lambda t: t.col2.length())
     result = repr(table)
     expected = """\
-r0 := UnboundTable[t]
+r0 := UnboundTable: t
   col  int64
   col2 string
   col3 float64


### PR DESCRIPTION
# Description

This PR implements methods for mixing SQL strings inline with ibis expressions
as well as the reverse, using ibis table expressions in SQL strings:

Here's an example of what this looks like:

```python
alltypes = con.table("functional_alltypes")
t = (
    alltypes.sql(
        """
        SELECT
            string_col as s,
            double_col + 1.0 AS new_col
        FROM functional_alltypes
        """
    )
    .group_by("s")  # group by a column from SQL
    .aggregate(fancy_af=lambda t: t.new_col.mean())
    .alias("awesome_t")  # create a name for the aggregate
    .sql("SELECT fancy_af AS yas FROM awesome_t ORDER BY fancy_af")
)
```

# Implementation

## Limitations

This functionality currently only works for the following backends:

1. PostgreSQL
1. DuckDB
1. PySpark

In principle any backend that:

1. Is SQL-based
2. Supports views
3. Implements `_get_schema_using_query`

Should be able to implement this functionality.

## Design

There are two new `PhysicalTable` nodes:

1. `View` for named tables, created by the `alias(name)` method.
1. `SQLStringView` for names tables whose computation is described by a SQL string.

## Implementation

During compilation a temporary view is created using `CREATE OR REPLACE VIEW ...`.

Views with the same name as an existing view are replaced.

### `View`

For `View` the view's name is the user-provided `name` argument to the `alias`
method.

Its definition is the compiled ibis expression.

### `SQLStringView`

For `SQLStringView` a temporary name (current `_ibis_view_$N`, where `N` is an incrementing integer) is generated.
Its definition is the SQL string provided by the user.


### Cleanup

~Any views created are dropped using an `atexit` handler.~ All cleanup is handled by the database. Any future implementations for databases that do not support temporary view creation will need to handle cleanup.
