### PR TITLE
refactor(api): add no-op materialize

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -224,7 +224,7 @@ class BaseBackend(abc.ABC):
     def do_connect(self, *args, **kwargs) -> None:
         """Connect to database specified by `args` and `kwargs`."""
 
-    @deprecated(instead='equivalent methods in the backend')
+    @deprecated(instead='use equivalent methods in the backend')
     def database(self, name: str | None = None) -> Database:
         """Return a `Database` object for the `name` database.
 
@@ -272,7 +272,7 @@ class BaseBackend(abc.ABC):
             the `like` pattern if provided.
         """
 
-    @deprecated(version='2.0', instead='`name in client.list_databases()`')
+    @deprecated(version='2.0', instead='use `name in client.list_databases()`')
     def exists_database(self, name: str) -> bool:
         """Return whether a database name exists in the current connection.
 
@@ -342,7 +342,7 @@ class BaseBackend(abc.ABC):
             The list of the table names that match the pattern `like`.
         """
 
-    @deprecated(version='2.0', instead='`name in client.list_tables()`')
+    @deprecated(version='2.0', instead='use `name in client.list_tables()`')
     def exists_table(self, name: str, database: str | None = None) -> bool:
         """Return whether a table name exists in the database.
 
@@ -367,7 +367,7 @@ class BaseBackend(abc.ABC):
     def table(self, name: str, database: str | None = None) -> ir.TableExpr:
         """Return a table expression from the database."""
 
-    @deprecated(version='2.0', instead='`.table(name).schema()`')
+    @deprecated(version='2.0', instead='use `.table(name).schema()`')
     def get_schema(self, table_name: str, database: str = None) -> sch.Schema:
         """Return the schema of `table_name`."""
         return self.table(name=table_name, database=database).schema()

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -331,7 +331,7 @@ class BaseAlchemyBackend(BaseSQLBackend):
         """The name of the current database this client is connected to."""
         return self.database_name
 
-    @util.deprecated(version='2.0', instead='`list_databases`')
+    @util.deprecated(version='2.0', instead='use `list_databases`')
     def list_schemas(self, like: str | None = None) -> list[str]:
         return self.list_databases()
 

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -360,7 +360,10 @@ class Backend(BaseSQLBackend):
         tuples = cur.fetchall()
         return list(map(operator.itemgetter(0), tuples))
 
-    @util.deprecated(version='2.0', instead='a new connection to database')
+    @util.deprecated(
+        version='2.0',
+        instead='use a new connection to the database',
+    )
     def set_database(self, name):
         # XXX The parent `Client` has a generic method that calls this same
         # method in the backend. But for whatever reason calling this code from

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -114,7 +114,7 @@ class Backend(BaseAlchemyBackend):
         ]
         return self._filter_with_like(databases, like)
 
-    @util.deprecated(version='2.0', instead='`list_databases`')
+    @util.deprecated(version='2.0', instead='use `list_databases`')
     def list_schemas(self, like=None):
         """List all the schemas in the current database."""
         # In Postgres we support schemas, which in other engines (e.g. MySQL)

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -114,7 +114,10 @@ class Backend(BaseSQLBackend):
     def version(self):
         return pyspark.__version__
 
-    @util.deprecated(version='2.0', instead='a new connection to database')
+    @util.deprecated(
+        version='2.0',
+        instead='use a new connection to the database',
+    )
     def set_database(self, name):
         self._catalog.setCurrentDatabase(name)
 

--- a/ibis/expr/signature.py
+++ b/ibis/expr/signature.py
@@ -96,7 +96,7 @@ class _InstanceOf(Validator):
         return arg
 
 
-@util.deprecated(version="3.0", instead="Validator")
+@util.deprecated(version="3.0", instead="use Validator if needed")
 def Argument(validator, default=EMPTY):
     """Argument constructor
     Parameters

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -297,7 +297,7 @@ class Expr:
     @util.deprecated(
         version='2.0',
         instead=(
-            "[`Expr.compile`][ibis.expr.types.core.Expr.compile] and "
+            "call [`Expr.compile`][ibis.expr.types.core.Expr.compile] and "
             "catch TranslationError"
         ),
     )

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1170,6 +1170,13 @@ class TableExpr(Expr):
     any_inner_join = _regular_join_method("any_inner_join", "any_inner")
     any_left_join = _regular_join_method("any_left_join", "any_left")
 
+    @util.deprecated(
+        version="3.0",
+        instead="remove the `.materialize()` call, it has no effect",
+    )
+    def materialize(self) -> TableExpr:
+        return self
+
 
 def _resolve_predicates(table: TableExpr, predicates) -> list[ir.BooleanValue]:
     from .. import analysis as an

--- a/ibis/tests/expr/test_signature.py
+++ b/ibis/tests/expr/test_signature.py
@@ -57,7 +57,7 @@ class MagicString(StringOp):
 
 
 def test_argument_is_deprecated():
-    msg = r".*Argument.* is deprecated .* v3\.0; use Validator\."
+    msg = r".*Argument.* is deprecated .* v3\.0; use Validator"
     with pytest.warns(FutureWarning, match=msg):
         Argument(str)
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1460,3 +1460,11 @@ def test_join_suffixes(how):
     method = getattr(left, f"{how}_join")
     expr = method(right, suffixes=("_left", "_right"))
     assert expr.columns == ["id_left", "first_name", "id_right", "last_name"]
+
+
+def test_materialize_no_op():
+    left = ibis.table([("id", "int64")])
+    right = ibis.table([("id", "int64")])
+    expr = left.inner_join(right, "id")
+    with pytest.warns(FutureWarning):
+        expr.materialize()

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -413,7 +413,7 @@ def deprecated_msg(name, *, instead, version=''):
     if version:
         msg += f' as of v{version}'
 
-    msg += f'; use {instead}.'
+    msg += f'; {instead}'
     return msg
 
 


### PR DESCRIPTION
This PR adds a no-op materialize along with a deprecation warning.

This will help us break less code out in the wild, since in many cases
materialize was a pass through.
