### PR TITLE
refactor(expr): preserve column ordering in aggregations

### DIFF
--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -222,11 +222,10 @@ class GroupedTableExpr:
         else:
             exprs = util.promote_list(exprs)
 
-        kwd_names = list(kwds.keys())
-        kwd_values = list(kwds.values())
-        kwd_values = self.table._resolve(kwd_values)
+        kwd_keys = list(kwds.keys())
+        kwd_values = self.table._resolve(list(kwds.values()))
 
-        for k, v in sorted(zip(kwd_names, kwd_values)):
+        for k, v in zip(kwd_keys, kwd_values):
             exprs.append(v.name(k))
 
         return self.projection([self.table] + exprs)

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -356,10 +356,7 @@ class TableExpr(Expr):
         """
         metrics = [] if metrics is None else util.promote_list(metrics)
         metrics.extend(
-            self._ensure_expr(expr).name(name)
-            for name, expr in sorted(
-                kwargs.items(), key=operator.itemgetter(0)
-            )
+            self._ensure_expr(expr).name(name) for name, expr in kwargs.items()
         )
 
         op = self.op().aggregate(

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -499,7 +499,7 @@ def test_aggregate_keywords(table):
     expr = t.aggregate(foo=t.f.sum(), bar=lambda x: x.f.mean(), by='g')
     expr2 = t.group_by('g').aggregate(foo=t.f.sum(), bar=lambda x: x.f.mean())
     expected = t.aggregate(
-        [t.f.mean().name('bar'), t.f.sum().name('foo')], by='g'
+        [t.f.sum().name('foo'), t.f.mean().name('bar')], by='g'
     )
 
     assert_equal(expr, expected)

--- a/ibis/tests/expr/test_window_functions.py
+++ b/ibis/tests/expr/test_window_functions.py
@@ -187,27 +187,6 @@ def test_auto_windowize_analysis_bug(con):
     assert_equal(enriched, expected)
 
 
-def test_mutate_sorts_keys(con):
-    t = con.table('airlines')
-    m = t.arrdelay.mean()
-    g = t.group_by('dest')
-
-    result = g.mutate(zzz=m, yyy=m, ddd=m, ccc=m, bbb=m, aaa=m)
-
-    expected = g.mutate(
-        [
-            m.name('aaa'),
-            m.name('bbb'),
-            m.name('ccc'),
-            m.name('ddd'),
-            m.name('yyy'),
-            m.name('zzz'),
-        ]
-    )
-
-    assert_equal(result, expected)
-
-
 def test_window_bind_to_table(alltypes):
     t = alltypes
     w = ibis.window(group_by='g', order_by=ibis.desc('f'))


### PR DESCRIPTION
BREAKING CHANGE: Columns that were added or used in an aggregation would
be alphabetically sorted in compiled SQL outputs.  This was a vestige
from when Python dicts didn't preserve insertion order.  Now columns
will appear in the order in which they were passed to `aggregate`