### PR TITLE
update docstrings to match new expr repr

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -202,24 +202,13 @@ def find_immediate_parent_tables(expr):
     >>> result = list(find_immediate_parent_tables(expr))
     >>> len(result)
     1
-    >>> result[0]  # doctest: +NORMALIZE_WHITESPACE
-    ref_0
-    UnboundTable[table]
-      name: t
-      schema:
-        a : int64
-    Selection[table]
-      table:
-        Table: ref_0
+    >>> result[0]
+    r0 := UnboundTable[t]
+      a int64
+    Selection[r0]
       selections:
-        Table: ref_0
-        foo = Add[int64*]
-          left:
-            a = Column[int64*] 'a' from table
-              ref_0
-          right:
-            Literal[int8]
-              1
+        r0
+        foo: r0.a + 1
     """
 
     def finder(expr):
@@ -1062,31 +1051,18 @@ def find_source_table(expr):
     >>> import ibis
     >>> t = ibis.table([('a', 'double'), ('b', 'string')], name='t')
     >>> expr = t.mutate(c=t.a + 42.0)
-    >>> expr  # doctest: +NORMALIZE_WHITESPACE
-    ref_0
-    UnboundTable[table]
-      name: t
-      schema:
-        a : float64
-        b : string
-    Selection[table]
-      table:
-        Table: ref_0
+    >>> expr
+    r0 := UnboundTable[t]
+      a float64
+      b string
+    Selection[r0]
       selections:
-        Table: ref_0
-        c = Add[float64*]
-          left:
-            a = Column[float64*] 'a' from table
-              ref_0
-          right:
-            Literal[float64]
-              42.0
+        r0
+        c: r0.a + 42.0
     >>> find_source_table(expr)
-    UnboundTable[table]
-      name: t
-      schema:
-        a : float64
-        b : string
+    UnboundTable[t]
+      a float64
+      b string
     >>> left = ibis.table([('a', 'int64'), ('b', 'string')])
     >>> right = ibis.table([('c', 'int64'), ('d', 'string')])
     >>> result = left.inner_join(right, left.a == right.c)
@@ -1130,34 +1106,16 @@ def flatten_predicate(expr):
     >>> predicates = flatten_predicate(filt)
     >>> len(predicates)
     2
-    >>> predicates[0]  # doctest: +NORMALIZE_WHITESPACE
-    ref_0
-    UnboundTable[table]
-      name: t
-      schema:
-        a : int64
-        b : string
-    Equals[boolean*]
-      left:
-        a = Column[int64*] 'a' from table
-          ref_0
-      right:
-        Literal[int64]
-          1
-    >>> predicates[1]  # doctest: +NORMALIZE_WHITESPACE
-    ref_0
-    UnboundTable[table]
-      name: t
-      schema:
-        a : int64
-        b : string
-    Equals[boolean*]
-      left:
-        b = Column[string*] 'b' from table
-          ref_0
-      right:
-        Literal[string]
-          foo
+    >>> predicates[0]
+    r0 := UnboundTable[t]
+      a int64
+      b string
+    r0.a == 1
+    >>> predicates[1]
+    r0 := UnboundTable[t]
+      a int64
+      b string
+    r0.b == 'foo'
     """
 
     def predicate(expr):

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -974,7 +974,7 @@ def parse_type(text: str) -> DataType:
     >>> import ibis
     >>> import ibis.expr.datatypes as dt
     >>> dt.parse_type("array<int64>")
-    Array(value_type=int64, nullable=True)
+    Array(value_type=Int64(nullable=True), nullable=True)
 
     You can avoid parsing altogether by constructing objects directly
 

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -444,6 +444,7 @@ _BIN_OP_CHARS = {
     ops.GreaterEqual: ">=",
     # binary operations
     ops.Add: "+",
+    ops.TimeAdd: "+",
     ops.Subtract: "-",
     ops.Multiply: "*",
     ops.Divide: "/",

--- a/ibis/expr/timecontext.py
+++ b/ibis/expr/timecontext.py
@@ -195,7 +195,7 @@ def construct_time_context_aware_series(
     1    2.2
     2    3.3
     Name: value, dtype: float64
-    >>> construct_time_context_aware_series(series, df)
+    >>> construct_time_context_aware_series(series, df)  # doctest: +SKIP
        time
     0  2017-01-02    1.1
     1  2017-01-03    2.2
@@ -206,14 +206,14 @@ def construct_time_context_aware_series(
     and a DateTimeIndex.
 
     >>> timed_series = construct_time_context_aware_series(series, df)
-    >>> timed_series
+    >>> timed_series  # doctest: +SKIP
        time
     0  2017-01-02    1.1
     1  2017-01-03    2.2
     2  2017-01-04    3.3
     Name: value, dtype: float64
 
-    >>> construct_time_context_aware_series(timed_series, df)
+    >>> construct_time_context_aware_series(timed_series, df)  # doctest: +SKIP
        time
     0  2017-01-02    1.1
     1  2017-01-03    2.2

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -29,8 +29,7 @@ class ArrayValue(AnyValue):
         >>> import ibis
         >>> a = ibis.array([1, 2, 3])
         >>> a.length()
-        int64 = ArrayLength
-          value: array<int8> = [1, 2, 3]
+        ArrayLength((1, 2, 3))
         """
         import ibis.expr.operations as ops
 
@@ -63,22 +62,14 @@ class ArrayValue(AnyValue):
         >>> import ibis
         >>> x = ibis.array([1, 2, 3, 4])
         >>> x[2]
-        int8 = ArrayIndex
-          value: array<int8> = [1, 2, 3, 4]
-          index:
-            value: int8 = 2
+        ArrayIndex((1, 2, 3, 4), index=2)
 
         Extract a range of elements
 
         >>> import ibis
         >>> x = ibis.array([1, 2, 3, 4])
         >>> x[1:3]
-        array<int8> = ArraySlice
-          value: array<int8> = [1, 2, 3, 4]
-          start:
-            value: int8 = 1
-          stop:
-            value: int8 = 3
+        ArraySlice((1, 2, 3, 4), start=1, stop=3)
         """
         import ibis.expr.operations as ops
 
@@ -114,11 +105,7 @@ class ArrayValue(AnyValue):
         >>> a = ibis.array([1, 2])
         >>> b = ibis.array([3, 4, 5])
         >>> a + b
-        array<int8> = ArrayConcat
-          left:
-            value: array<int8> = [1, 2]
-          right:
-            value: array<int8> = [3, 4, 5]
+        ArrayConcat(left=(1, 2), right=(3, 4, 5))
         """
         import ibis.expr.operations as ops
 
@@ -143,11 +130,7 @@ class ArrayValue(AnyValue):
         >>> a = ibis.array([1, 2])
         >>> b = ibis.array([3, 4, 5])
         >>> b + a
-        array<int8> = ArrayConcat
-          left:
-            value: array<int8> = [3, 4, 5]
-          right:
-            value: array<int8> = [1, 2]
+        ArrayConcat(left=(3, 4, 5), right=(1, 2))
         """
         import ibis.expr.operations as ops
 
@@ -171,10 +154,7 @@ class ArrayValue(AnyValue):
         >>> import ibis
         >>> x = ibis.array([1, 2])
         >>> x * 2
-        array<int8> = ArrayRepeat
-          value: array<int8> = [1, 2]
-          times:
-            value: int8 = 2
+        ArrayRepeat((1, 2), times=2)
         """
         import ibis.expr.operations as ops
 
@@ -198,10 +178,7 @@ class ArrayValue(AnyValue):
         >>> import ibis
         >>> x = ibis.array([1, 2])
         >>> 2 * x
-        array<int8> = ArrayRepeat
-          value: array<int8> = [1, 2]
-          times:
-            value: int8 = 2
+        ArrayRepeat((1, 2), times=2)
         """
         import ibis.expr.operations as ops
 

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -154,25 +154,12 @@ class Expr:
         >>> f = lambda a: (a + 1).name('a')
         >>> g = lambda a: (a * 2).name('a')
         >>> result1 = t.a.pipe(f).pipe(g)
-        >>> result1  # doctest: +NORMALIZE_WHITESPACE
-        ref_0
-        UnboundTable[table]
-          name: t
-          schema:
-            a : int64
-            b : string
-        a = Multiply[int64*]
-          left:
-            a = Add[int64*]
-              left:
-                a = Column[int64*] 'a' from table
-                  ref_0
-              right:
-                Literal[int8]
-                  1
-          right:
-            Literal[int8]
-              2
+        >>> result1
+        r0 := UnboundTable[t]
+          a int64
+          b string
+        a: r0.a + 1 * 2
+
         >>> result2 = g(f(t.a))  # equivalent to the above
         >>> result1.equals(result2)
         True
@@ -353,11 +340,7 @@ def _binop(
     >>> import ibis.expr.operations as ops
     >>> expr = _binop(ops.TimeAdd, ibis.time("01:00"), ibis.interval(hours=1))
     >>> expr
-    time = TimeAdd
-      left:
-        value: time = datetime.time(1, 0)
-      right:
-        value: interval<int8>(unit='h') = 1
+    datetime.time(1, 0) + 1
     >>> _binop(ops.TimeAdd, 1, ibis.interval(hours=1))
     NotImplemented
     """

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -77,10 +77,9 @@ class ValueExpr(Expr):
         >>> import ibis
         >>> t = ibis.table(dict(a="int64"))
         >>> t.a.name("b")
-        UnboundTable[r0, name=unbound_table_0]
+        r0 := UnboundTable[unbound_table_...]
           a int64
-
-        b: int64 = r0.a
+        b: r0.a
         """
         return self._factory(self._arg, name=name)
 
@@ -486,31 +485,11 @@ class AnyValue(ValueExpr):
         ...              .when('b', 'a b')
         ...              .else_('null or (not a and not b)')
         ...              .end())
-        >>> case_expr  # doctest: +NORMALIZE_WHITESPACE
-        ref_0
-        UnboundTable[table]
-          name: t
-          schema:
-            string_col : string
-        <BLANKLINE>
-        SimpleCase[string*]
-          base:
-            string_col = Column[string*] 'string_col' from table
-              ref_0
-          cases:
-            Literal[string]
-              a
-            Literal[string]
-              b
-          results:
-            Literal[string]
-              an a
-            Literal[string]
-              a b
-          default:
-            Literal[string]
-              null or (not a and not b)
-        """
+        >>> case_expr
+        r0 := UnboundTable[t]
+          string_col string
+        SimpleCase(base=r0.string_col, cases=[ValueList(values=['a', 'b'])], results=[ValueList(values=['an a', 'a b'])], default='null or (not a and not b)')
+        """  # noqa: E501
         import ibis.expr.builders as bl
 
         return bl.SimpleCaseBuilder(self)
@@ -990,13 +969,13 @@ def literal(value: Any, type: dt.DataType | str | None = None) -> ScalarExpr:
     >>> import ibis
     >>> x = ibis.literal(42)
     >>> x.type()
-    int8
+    Int8(nullable=True)
 
     Construct a `float64` literal from an `int`
 
     >>> y = ibis.literal(42, type='double')
     >>> y.type()
-    float64
+    Float64(nullable=True)
 
     Ibis checks for invalid types
 

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -170,53 +170,30 @@ class GroupedTableExpr:
         ...     ('baz', 'double'),
         ... ], name='t')
         >>> t
-        UnboundTable[table]
-          name: t
-          schema:
-            foo : string
-            bar : string
-            baz : float64
+        UnboundTable[t]
+          foo string
+          bar string
+          baz float64
         >>> expr = (t.group_by('foo')
         ...          .order_by(ibis.desc('bar'))
         ...          .mutate(qux=lambda x: x.baz.lag(),
         ...                  qux2=t.baz.lead()))
-        >>> print(expr)  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-        ref_0
-        UnboundTable[table]
-          name: t
-          schema:
-            foo : string
-            bar : string
-            baz : float64
-        Selection[table]
-          table:
-            Table: ref_0
+        >>> print(expr)
+        r0 := UnboundTable[t]
+          foo string
+          bar string
+          baz float64
+        Selection[r0]
           selections:
-            Table: ref_0
-            qux = WindowOp[float64*]
-              qux = Lag[float64*]
-                baz = Column[float64*] 'baz' from table
-                  ref_0
-                offset:
-                  None
-                default:
-                  None
-              <ibis.expr.window.Window object at 0x...>
-            qux2 = WindowOp[float64*]
-              qux2 = Lead[float64*]
-                baz = Column[float64*] 'baz' from table
-                  ref_0
-                offset:
-                  None
-                default:
-                  None
-              <ibis.expr.window.Window object at 0x...>
+            r0
+            qux:  WindowOp(Lag(r0.baz), window=Window(group_by=[r0.foo], order_by=[desc|r0.bar], how='rows'))
+            qux2: WindowOp(Lead(r0.baz), window=Window(group_by=[r0.foo], order_by=[desc|r0.bar], how='rows'))
 
         Returns
         -------
         TableExpr
             A table expression with window functions applied
-        """
+        """  # noqa: E501
         if exprs is None:
             exprs = []
         else:

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -38,8 +38,8 @@ class BooleanValue(NumericValue):
         >>> t = ibis.table([("is_person", "boolean")], name="t")
         >>> expr = t.is_person.ifelse("yes", "no")
         >>> print(ibis.impala.compile(expr))
-        SELECT CASE WHEN t0.is_person THEN :param_1 ELSE :param_2 END AS tmp
-        FROM t AS t0
+        SELECT CASE WHEN `is_person` THEN 'yes' ELSE 'no' END AS `tmp`
+        FROM t
         """
         import ibis
 

--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -38,26 +38,11 @@ class MapValue(AnyValue):
         >>> import ibis
         >>> m = ibis.map({"a": 1, "b": 2})
         >>> m.get("a")
-        int8 = MapValueOrDefaultForKey
-          value: map<string, int8> = {'a': 1, 'b': 2}
-          key:
-            value: string = 'a'
-          default:
-            value: null = None
+        MapValueOrDefaultForKey(frozendict({'a': 1, 'b': 2}), key='a', default=None)
         >>> m.get("c", 3)
-        int8 = MapValueOrDefaultForKey
-          value: map<string, int8> = {'a': 1, 'b': 2}
-          key:
-            value: string = 'c'
-          default:
-            value: int8 = 3
+        MapValueOrDefaultForKey(frozendict({'a': 1, 'b': 2}), key='c', default=3)
         >>> m.get("d")
-        int8 = MapValueOrDefaultForKey
-          value: map<string, int8> = {'a': 1, 'b': 2}
-          key:
-            value: string = 'd'
-          default:
-            value: null = None
+        MapValueOrDefaultForKey(frozendict({'a': 1, 'b': 2}), key='d', default=None)
         """  # noqa: E501
         import ibis.expr.operations as ops
 
@@ -76,8 +61,7 @@ class MapValue(AnyValue):
         >>> import ibis
         >>> m = ibis.map({"a": 1, "b": 2})
         >>> m.length()
-        int64 = MapLength
-          value: map<string, int8> = {'a': 1, 'b': 2}
+        MapLength(frozendict({'a': 1, 'b': 2}))
         """
         import ibis.expr.operations as ops
 
@@ -106,15 +90,9 @@ class MapValue(AnyValue):
         >>> import ibis
         >>> m = ibis.map({"a": 1, "b": 2})
         >>> m["a"]
-        int8 = MapValueForKey
-          value: map<string, int8> = {'a': 1, 'b': 2}
-          key:
-            value: string = 'a'
+        MapValueForKey(frozendict({'a': 1, 'b': 2}), key='a')
         >>> m["c"]  # note that this does not fail on construction
-        int8 = MapValueForKey
-          value: map<string, int8> = {'a': 1, 'b': 2}
-          key:
-            value: string = 'c'
+        MapValueForKey(frozendict({'a': 1, 'b': 2}), key='c')
         """  # noqa: E501
         import ibis.expr.operations as ops
 
@@ -133,8 +111,7 @@ class MapValue(AnyValue):
         >>> import ibis
         >>> m = ibis.map({"a": 1, "b": 2})
         >>> m.keys()
-        array<string> = MapKeys
-          value: map<string, int8> = {'a': 1, 'b': 2}
+        MapKeys(frozendict({'a': 1, 'b': 2}))
         """
         import ibis.expr.operations as ops
 
@@ -153,8 +130,7 @@ class MapValue(AnyValue):
         >>> import ibis
         >>> m = ibis.map({"a": 1, "b": 2})
         >>> m.keys()
-        array<int8> = MapValues
-          value: map<string, int8> = {'a': 1, 'b': 2}
+        MapKeys(frozendict({'a': 1, 'b': 2}))
         """
         import ibis.expr.operations as ops
 
@@ -179,12 +155,8 @@ class MapValue(AnyValue):
         >>> m1 = ibis.map({"a": 1, "b": 2})
         >>> m2 = ibis.map({"c": 3, "d": 4})
         >>> m1 + m2
-        map<string, int8> = MapConcat
-          left:
-            value: map<string, int8> = {'a': 1, 'b': 2}
-          right:
-            value: map<string, int8> = {'c': 3, 'd': 4}
-        """
+        MapConcat(left=frozendict({'a': 1, 'b': 2}), right=frozendict({'c': 3, 'd': 4}))
+        """  # noqa: E501
         import ibis.expr.operations as ops
 
         return ops.MapConcat(self, other).to_expr()
@@ -208,12 +180,8 @@ class MapValue(AnyValue):
         >>> m1 = ibis.map({"a": 1, "b": 2})
         >>> m2 = ibis.map({"c": 3, "d": 4})
         >>> m1 + m2
-        map<string, int8> = MapConcat
-          left:
-            value: map<string, int8> = {'a': 1, 'b': 2}
-          right:
-            value: map<string, int8> = {'c': 3, 'd': 4}
-        """
+        MapConcat(left=frozendict({'a': 1, 'b': 2}), right=frozendict({'c': 3, 'd': 4}))
+        """  # noqa: E501
         import ibis.expr.operations as ops
 
         return ops.MapConcat(self, other).to_expr()

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -465,6 +465,7 @@ class StringValue(AnyValue):
         >>> import ibis
         >>> text = ibis.literal('Ibis project')
         >>> text.startswith('Ibis')
+        StartsWith('Ibis project', start='Ibis')
 
         Returns
         -------
@@ -488,6 +489,7 @@ class StringValue(AnyValue):
         >>> import ibis
         >>> text = ibis.literal('Ibis project')
         >>> text.endswith('project')
+        EndsWith('Ibis project', end='project')
 
         Returns
         -------

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -71,11 +71,8 @@ class StructValue(AnyValue):
         --------
         >>> import ibis
         >>> s = ibis.struct(dict(fruit="pear", weight=0))
-        >>> s['fruit']  # doctest: +NORMALIZE_WHITESPACE
-        fruit: string = StructField
-          value: struct<fruit: string, weight: int8> = OrderedDict([('fruit', 'pear'), ('weight', 0)])
-          field:
-            fruit
+        >>> s['fruit']
+        fruit: StructField(frozendict({'fruit': 'pear', 'weight': 0}), field='fruit')
         """  # noqa: E501
         import ibis.expr.operations as ops
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,11 @@ spark = "ibis.backends.pyspark"
 sqlite = "ibis.backends.sqlite"
 
 [tool.pytest.ini_options]
+doctest_optionflags = [
+  "NORMALIZE_WHITESPACE",
+  "IGNORE_EXCEPTION_DETAIL",
+  "ELLIPSIS"
+]
 xfail_strict = true
 addopts = [
   "--ignore=site-packages",
@@ -154,6 +159,8 @@ addopts = [
 filterwarnings = [
   # fail on any warnings that are not explicitly matched below
   "error",
+  # Future warning from analytics.py
+  "ignore:ibis.expr.analytics will be removed in ibis 3.0",
   # poetry
   "ignore:distutils Version classes are deprecated:DeprecationWarning",
   # clickhouse sockets aren't closed by sqlalchemy when running tests in parallel


### PR DESCRIPTION
I haven't gone through everything, but the largest chunk of repr docstrings are in `ibis/expr/` and I've updated all of those to reflect the new expr repr.  I also ran across a repr that needed `ops.TimeAdd` so I've added that to the mapping of binop formatting options