### PR TITLE
fix(clickhouse): use a context manager for execution

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -161,12 +161,13 @@ class Backend(BaseSQLBackend):
             )
 
         ibis.util.log(query)
-        return self.con.execute(
-            query,
-            columnar=True,
-            with_column_types=True,
-            external_tables=external_tables_list,
-        )
+        with self.con as con:
+            return con.execute(
+                query,
+                columnar=True,
+                with_column_types=True,
+                external_tables=external_tables_list,
+            )
 
     def fetch_from_cursor(self, cursor, schema):
         data, _ = cursor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,12 +160,12 @@ addopts = [
 filterwarnings = [
   # fail on any warnings that are not explicitly matched below
   "error",
+  # pyspark and impala leave sockets open
+  "ignore:Exception ignored in:",
   # Future warning from analytics.py
   "ignore:ibis.expr.analytics will be removed in ibis 3.0",
   # poetry
   "ignore:distutils Version classes are deprecated:DeprecationWarning",
-  # clickhouse sockets aren't closed by sqlalchemy when running tests in parallel
-  'ignore:Exception ignored in:',
   # older importlib metadata that there's no real point in breaking with
   "ignore:SelectableGroups:DeprecationWarning",
   # geopandas warning


### PR DESCRIPTION
Previously we ignored "ignored exception" warnings when running `pytest`.

It turns out that these were coming from ibis's slight misuse of the clickhouse-driver
Client, where we weren't closing the connection when an error occurred during execution of
an `xfail` test.

Using the `Client` instance as a context manager handles this for us, and the test is that
no new failures occur from removing the warning ignorance.
