### PR TITLE
refactor(common): more convenient way to define cached properties for Annotable subclasses

### DIFF
--- a/ibis/common/validators.py
+++ b/ibis/common/validators.py
@@ -48,7 +48,7 @@ class Optional(Validator):
         return self.validator(arg, **kwargs)
 
 
-class validator(toolz.curry, Validator):
+class Curried(toolz.curry, Validator):
     """
     Enable convenient validator definition by decorating plain functions.
     """
@@ -61,7 +61,24 @@ class validator(toolz.curry, Validator):
         )
 
 
+class ImmutableProperty(Callable):
+    """
+    Abstract base class for defining stored properties.
+    """
+
+    __slots__ = ("fn",)
+
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __call__(self, instance):
+        return self.fn(instance)
+
+
+# aliases for convenience
 optional = Optional
+validator = Curried
+immutable_property = ImmutableProperty
 
 
 @validator

--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -5,6 +5,7 @@ from public import public
 
 from ...common.exceptions import ExpressionError
 from ...common.grounds import Comparable
+from ...common.validators import immutable_property
 from ...util import is_iterable
 from .. import rules as rlz
 from ..schema import Schema
@@ -36,20 +37,12 @@ def _compare_tuples(a, b):
 
 @public
 class Node(Annotable, Comparable):
-    __slots__ = ("_flat_ops",)
-
-    def __post_init__(self):
+    @immutable_property
+    def _flat_ops(self):
         import ibis.expr.types as ir
 
-        super().__post_init__()
-        object.__setattr__(
-            self,
-            "_flat_ops",
-            tuple(
-                arg.op()
-                for arg in self.flat_args()
-                if isinstance(arg, ir.Expr)
-            ),
+        return tuple(
+            arg.op() for arg in self.flat_args() if isinstance(arg, ir.Expr)
         )
 
     def __equals__(self, other):

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -127,6 +127,7 @@ def _clean_join_predicates(left, right, predicates):
         elif isinstance(pred, str):
             pred = left[pred] == right[pred]
         elif not isinstance(pred, ir.Expr):
+            print(type(pred))
             raise NotImplementedError
 
         if not isinstance(pred, ir.BooleanColumn):
@@ -168,6 +169,7 @@ class Join(TableNode):
             left=left, right=right, predicates=predicates, **kwargs
         )
 
+    # could use @promoter here
     @property
     def schema(self):
         # For joins retaining both table schemas, merge them together here
@@ -239,14 +241,10 @@ class AsOfJoin(Join):
     by = rlz.optional(lambda x, this: x, default=())
     tolerance = rlz.optional(rlz.interval)
 
-    def __init__(self, left, right, predicates, by, tolerance):
+    def __init__(self, left, right, by, predicates, **kwargs):
         by = _clean_join_predicates(left, right, by)
         super().__init__(
-            left=left,
-            right=right,
-            predicates=predicates,
-            by=by,
-            tolerance=tolerance,
+            left=left, right=right, by=by, predicates=predicates, **kwargs
         )
 
 

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -8,7 +8,12 @@ from multipledispatch import Dispatcher
 
 from ..common.exceptions import IntegrityError
 from ..common.grounds import Annotable, Comparable
-from ..common.validators import instance_of, tuple_of, validator
+from ..common.validators import (
+    immutable_property,
+    instance_of,
+    tuple_of,
+    validator,
+)
 from ..expr import datatypes as dt
 from ..util import UnnamedMarker, indent
 
@@ -59,9 +64,8 @@ class Schema(Annotable, Comparable):
     names: Sequence[str] = tuple_of(instance_of((str, UnnamedMarker)))
     types: Sequence[dt.DataType] = tuple_of(datatype)
 
-    def __post_init__(self):
-        super().__post_init__()
-
+    @immutable_property
+    def _name_locs(self):
         # validate unique field names
         name_locs = {v: i for i, v in enumerate(self.names)}
         if len(name_locs) < len(self.names):
@@ -71,9 +75,7 @@ class Schema(Annotable, Comparable):
             raise IntegrityError(
                 f'Duplicate column name(s): {duplicate_names}'
             )
-
-        # store field positions
-        object.__setattr__(self, '_name_locs', name_locs)
+        return name_locs
 
     def __repr__(self):
         space = 2 + max(map(len, self.names), default=0)


### PR DESCRIPTION
Should be useful for scenarios like `output_dtype`, `output_shape` and `output_type` defined in https://github.com/ibis-project/ibis/pull/3276

The following class calculates and stores `double_a`'s output value in a slot like it were a cached property.

```py
    class ValueOp(Annotable):
        a = IsInt

        @promoter
        def double_a(self):
            return 2 * self.a
```

TODO: I'd like to mimic the use case of `output_dtype` in additional unit tests, meanwhile preliminary reviews are welcome.