### PR TITLE
fix(dask): workaround dask/dask#8857

### DIFF
--- a/ibis/backends/dask/execution/join.py
+++ b/ibis/backends/dask/execution/join.py
@@ -31,9 +31,17 @@ def execute_asof_join(op, left, right, by, tolerance, predicates, **kwargs):
         overlapping_columns, left_on, right_on, left_by, right_by
     )
 
+    assert 0 <= len(left_on) <= 1, f"len(left_on) == {len(left_on)}"
+    assert 0 <= len(right_on) <= 1, f"len(right_on) == {len(right_on)}"
+
     return dd.merge_asof(
         left=left,
         right=right,
+        # NB: dask 2022.4.1 contains a bug from
+        # https://github.com/dask/dask/pull/8857 that keeps a column if `on` is
+        # non-empty without checking whether `left_on` is non-empty, this
+        # check works around that
+        on=left_on if left_on == right_on else None,
         left_on=left_on,
         right_on=right_on,
         left_by=left_by or None,

--- a/poetry.lock
+++ b/poetry.lock
@@ -303,7 +303,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "dask"
-version = "2022.3.0"
+version = "2022.4.0"
 description = "Parallel PyData with Task Scheduling"
 category = "main"
 optional = true
@@ -321,10 +321,10 @@ toolz = ">=0.8.2"
 
 [package.extras]
 array = ["numpy (>=1.18)"]
-complete = ["bokeh (>=2.4.2)", "distributed (==2022.03.0)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
+complete = ["bokeh (>=2.4.2)", "distributed (==2022.04.0)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
 dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
 diagnostics = ["bokeh (>=2.4.2)", "jinja2"]
-distributed = ["distributed (==2022.03.0)"]
+distributed = ["distributed (==2022.04.0)"]
 test = ["pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
 
 [[package]]
@@ -2660,8 +2660,8 @@ coverage = [
     {file = "coverage-6.3.2.tar.gz", hash = "sha256:03e2a7826086b91ef345ff18742ee9fc47a6839ccd517061ef8fa1976e652ce9"},
 ]
 dask = [
-    {file = "dask-2022.3.0-py3-none-any.whl", hash = "sha256:52e9f8a4b798439f01a02a07fa7e66004d024c3f9fb6f1f5d3ecc11642298597"},
-    {file = "dask-2022.3.0.tar.gz", hash = "sha256:9e0188dd4397099f148e80e04902703c465e577c747591f0e9b801998ad3abf0"},
+    {file = "dask-2022.4.0-py3-none-any.whl", hash = "sha256:b689cb0ab40c042c5445b886c2136f42966aa57bf6c86561916ab6449b5bad1a"},
+    {file = "dask-2022.4.0.tar.gz", hash = "sha256:e8d0f5840c9df56c60a48b1b3ca326a7a9597a19175b7cd55e12709ccf13ac78"},
 ]
 datafusion = [
     {file = "datafusion-0.5.1-cp36-abi3-macosx_10_7_x86_64.whl", hash = "sha256:fa4d8d8d23e65b06dd51406e4c207c5abc1cc222d9b20c789c07b2413ff99810"},


### PR DESCRIPTION
This PR works around a bug introduced in merge_asof in https://github.com/dask/dask/pull/8857, where when the `on` argument is falsey the `right_on` columns are duplicated in the right dataframe. The subsequent call to `reset_index` in the `merge_asof` implementation fails.