### PR TITLE
docs: convert absolute links to relative links

### DIFF
--- a/.github/workflows/ibis-main-skip-helper.yml
+++ b/.github/workflows/ibis-main-skip-helper.yml
@@ -18,8 +18,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No build required"
-  benchmarks:
-    name: Benchmarks
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "No build required"

--- a/docs/backends/template.md
+++ b/docs/backends/template.md
@@ -33,7 +33,7 @@ Install ibis and dependencies for the {{ backend_name }} backend:
 {% else %}
 !!! info "The {{ backend_name }} backend isn't released yet!"
 
-    [Set up a development environment](/contribute/01_environment) to use this backend.
+    [Set up a development environment](../contribute/01_environment.md) to use this backend.
 
 {% endif %}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ python -c 'import ibis; print(ibis.__version__)'
 
 !!! tip "Coming from SQL?"
 
-    Check out [Ibis for SQL Programmers](/ibis-for-sql-programmers/)
+    Check out [Ibis for SQL Programmers](ibis-for-sql-programmers)
 
 ### Abstract Over SQL Dialects
 
@@ -151,7 +151,7 @@ Let's compute the number of citizens per squared kilometer in Asia:
 
 !!! tip "Learn more!"
 
-    Learn more about Ibis in [our tutorial](/tutorial/01-Introduction-to-Ibis).
+    Learn more about Ibis in [our tutorial](tutorial/01-Introduction-to-Ibis).
 
 ## Comparison to other tools
 
@@ -159,7 +159,7 @@ Let's compute the number of citizens per squared kilometer in Asia:
 
     !!! tip "Coming from SQL?"
 
-        Check out [Ibis for SQL Programmers](/ibis-for-sql-programmers)!
+        Check out [Ibis for SQL Programmers](ibis-for-sql-programmers)!
 
     Ibis gives you the benefit of a programming language. You don't need to
     sacrifice maintainability to get to those insights!
@@ -185,8 +185,8 @@ Let's compute the number of citizens per squared kilometer in Asia:
     !!! success "Ibis :heart:'s SQLAlchemy"
 
         Ibis generates SQLAlchemy expressions for some of our backends
-        including the [PostgreSQL](/backends/PostgreSQL) and
-        [SQLite](/backends/SQLite) backends!
+        including the [PostgreSQL](./backends/PostgreSQL.md) and
+        [SQLite](./backends/SQLite.md) backends!
 
     === "Ibis"
 
@@ -208,8 +208,8 @@ Let's compute the number of citizens per squared kilometer in Asia:
 
 !!! question "Need a specific backend?"
 
-    Take a look at the [backends](/backends) documentation!
+    Take a look at the [backends](./backends/index.md) documentation!
 
 !!! tip "Interested in contributing?"
 
-    Get started by [setting up a development environment](/contribute/01_environment)!
+    Get started by [setting up a development environment](./contribute/01_environment.md)!

--- a/docs/user_guide/udfs.md
+++ b/docs/user_guide/udfs.md
@@ -14,7 +14,7 @@ if you're interested in working on them!
 The following backends provide some level of support for user-defined functions:
 
 - [Google BigQuery](https://github.com/ibis-project/ibis-bigquery)
-- [Pandas](/backends/Pandas)
-- [PostgreSQL](/backends/PostgreSQL)
-- [Datafusion](/backends/Datafusion)
-- [Impala](/backends/Impala)
+- [Pandas](../backends/Pandas.md)
+- [PostgreSQL](../backends/PostgreSQL.md)
+- [Datafusion](../backends/Datafusion.md)
+- [Impala](../backends/Impala.md)


### PR DESCRIPTION
This PR converts absolute links to relative links, which is necessary after changing our
docs to support multiple versions. We don't want to link to the site root, but rather the link
should be relative.
