### PR TITLE
fix: filter SettingWithCopyWarning to silence user-facing warning

### DIFF
--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -333,7 +333,8 @@ def build_df_from_selection(
             renamed_cols[from_col] = to_cols[0]
         else:
             for new_col in to_cols:
-                result[new_col] = result.loc[:, from_col]
+                if from_col != new_col:
+                    result[new_col] = result[from_col]
 
     if renamed_cols:
         result = result.rename(columns=renamed_cols)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,6 @@ filterwarnings = [
   'ignore:Using \.astype to convert from timezone-(naive|aware) dtype:FutureWarning',
   "ignore:This pattern is interpreted as a regular expression, and has match groups:UserWarning",
   "ignore:The default dtype for empty Series will be 'object':FutureWarning",
-  'ignore:\nA value is trying to be set on a copy of a slice from a DataFrame:',
   "ignore:the `interpolation=` argument to percentile was renamed to `method=`:DeprecationWarning",
   "ignore:Explicitly passing `name=None`:FutureWarning",
   # the warning suggestion to simply remove the argument in the call isn't correct


### PR DESCRIPTION
The warning is valid in many contexts, but it's spurious here and it's
quite loud.

Despite my memory of `warnings.filterwarnings` serving as a contextmanager, it
doesn't appear to do so, so I've created a simple one that silences the pandas
warning in question, then restores it on exit.

Fixes #3702 