### PR TITLE
chore(dev-deps): use a headless jdk in nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -32,7 +32,7 @@ let
 
   backendTestDeps = [ pkgs.docker-compose_2 ];
   vizDeps = [ pkgs.graphviz-nox ];
-  pysparkDeps = [ pkgs.openjdk11 ];
+  pysparkDeps = [ pkgs.openjdk11_headless ];
   docDeps = [ pkgs.pandoc ];
 
   # postgresql is the client, not the server


### PR DESCRIPTION
This PR reduces the size of the nix shell JDK by using the headless version.

Here's a comparison of their sizes:

```
❯ nix path-info -ShsL 'nixpkgs#openjdk11_headless' 'nixpkgs#openjdk11' | sort -h -k2
/nix/store/6x9vk1cm44d9hlv2cvv4jzn2qqlxgasm-openjdk-headless-11.0.12+7   523.5M  563.1M
/nix/store/2k27v0z85z9das0c70qs2vqpgxiky6kh-openjdk-11.0.12+7            681.7M    1.4G
```
