### PR TITLE
fix(pyspark/pandas): fix range window bugs, disable arbitrary pandas range windows

### DIFF
--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -10,6 +10,7 @@ from multipledispatch import Dispatcher
 from pandas.core.groupby import SeriesGroupBy
 
 import ibis.common.exceptions as com
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.window as win
 from ibis.expr.scope import Scope
@@ -264,6 +265,14 @@ def execute_window_op(
     clients=None,
     **kwargs,
 ):
+    if window.how == "range" and any(
+        not isinstance(ob.type(), (dt.Time, dt.Date, dt.Timestamp))
+        for ob in window._order_by
+    ):
+        raise NotImplementedError(
+            "The pandas backend only implements range windows with temporal "
+            "ordering keys"
+        )
     operand = op.expr
     # pre execute "manually" here because otherwise we wouldn't pickup
     # relevant scope changes from the child operand since we're managing

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1246,8 +1246,10 @@ def compile_window_op(t, expr, scope, timecontext, **kwargs):
                 t, window.following, scope, timecontext, **kwargs
             )
 
-        if isinstance(window.preceding, ir.IntervalScalar) or isinstance(
-            window.following, ir.IntervalScalar
+        if (
+            isinstance(window.preceding, ir.IntervalScalar)
+            or isinstance(window.following, ir.IntervalScalar)
+            or window.how == "range"
         ):
             pyspark_window = pyspark_window.rangeBetween(start, end)
         else:

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -515,9 +515,7 @@ def test_ungrouped_unbounded_window(
     backend.assert_series_equal(left, right)
 
 
-@pytest.mark.notimpl(
-    ["clickhouse", "dask", "datafusion", "impala", "pandas", "pyspark"]
-)
+@pytest.mark.notimpl(["clickhouse", "dask", "datafusion", "impala", "pandas"])
 def test_grouped_bounded_range_window(backend, alltypes, df):
     # Explanation of the range window spec below:
     #

--- a/ibis/expr/types/sortkeys.py
+++ b/ibis/expr/types/sortkeys.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from public import public
+
+if TYPE_CHECKING:
+    import ibis.expr.datatypes as dt
 
 from .generic import Expr
 
@@ -9,3 +14,6 @@ from .generic import Expr
 class SortExpr(Expr):
     def get_name(self) -> str | None:
         return self.op().resolve_name()
+
+    def type(self) -> dt.DataType:
+        return self.op().expr.type()


### PR DESCRIPTION
This PR address issues with range windows in the pandas and pyspark backends.

1. PySpark does allow a wider range (forgive the pun!) of `RANGE` windows, so
   that was simply altering the code path and allowing the test through.
1. We don't yet implement arbitrary `RANGE` windows with the pandas backend
   because there's so obvious way to do this with pandas itself, so only
   temporal range windows are allowed (which have been implemented for a while).

Closes #2709.
