### PR TITLE
feat(repr): add interval info to interval repr

### DIFF
--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -534,6 +534,8 @@ def _fmt_value_negate(op: ops.Negate, *, aliases: Aliases) -> str:
 
 @fmt_value.register
 def _fmt_value_literal(op: ops.Literal, **_: Any) -> str:
+    if isinstance(op.dtype, dt.Interval):
+        return f"{op.value} {op.dtype.unit}"
     return repr(op.value)
 
 


### PR DESCRIPTION
trying this out.  there are a lot of ways to make this more complicated
and some of them might be worth it, but this seems to provide a little
more information with a tiny footprint.

closes #3668

in re: other options:
If we don't want to special-case the Interval repr, we could redefine Interval as a subclass of Literal so we can catch it explicitly in the single dispatch.

Other possible changes / improvements:
More verbose unit descriptions (`seconds` instead of `s`)