### PR TITLE
chore: disable semrel PR/issue commenting

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,6 +22,7 @@
     [
       "@semantic-release/github",
       {
+        "successComment": false,
         "assets": ["dist/*.whl"]
       }
     ],


### PR DESCRIPTION
This PR disables PR commenting by the semrel bot, because it's just too slow when there are a large number of PRs in between two releases.