### PR TITLE
test: localize table creation instead of altering existing batting table

### DIFF
--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -93,10 +93,9 @@ class BaseAlchemyBackend(BaseSQLBackend):
         return '.'.join(map(str, self.con.dialect.server_version_info))
 
     def list_tables(self, like=None, database=None):
-        tables = self._inspector.get_table_names(
-            schema=database
-        ) + self._inspector.get_view_names(schema=database)
-        return self._filter_with_like(tables, like)
+        tables = self.inspector.get_table_names(schema=database)
+        views = self.inspector.get_view_names(schema=database)
+        return self._filter_with_like(tables + views, like)
 
     def list_databases(self, like=None):
         """List databases in the current server."""

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -262,11 +262,7 @@ def pytest_runtest_call(item):
 def backend(request, data_directory):
     """Return an instance of BackendTest."""
     cls = _get_backend_conf(request.param)
-    result = cls(data_directory)
-    try:
-        yield result
-    finally:
-        result.cleanup()
+    return cls(data_directory)
 
 
 @pytest.fixture(scope='session')
@@ -290,11 +286,7 @@ def ddl_backend(request, data_directory):
     (sqlite, postgres, mysql, datafusion, clickhouse, pyspark, impala)
     """
     cls = _get_backend_conf(request.param)
-    result = cls(data_directory)
-    try:
-        yield result
-    finally:
-        result.cleanup()
+    return cls(data_directory)
 
 
 @pytest.fixture(scope='session')
@@ -323,11 +315,7 @@ def alchemy_backend(request, data_directory):
         )
     else:
         cls = _get_backend_conf(request.param)
-        result = cls(data_directory)
-        try:
-            yield result
-        finally:
-            result.cleanup()
+        return cls(data_directory)
 
 
 @pytest.fixture(scope='session')
@@ -347,11 +335,7 @@ def udf_backend(request, data_directory):
     Runs the UDF-supporting backends
     """
     cls = _get_backend_conf(request.param)
-    result = cls(data_directory)
-    try:
-        yield result
-    finally:
-        result.cleanup()
+    return cls(data_directory)
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -150,6 +150,3 @@ class BackendTest(abc.ABC):
         self, params: Optional[Mapping[ir.ValueExpr, Any]] = None
     ):
         return self.api.compiler.make_context(params=params)
-
-    def cleanup(self):
-        pass


### PR DESCRIPTION
Hopefully this is the last of the flakiness fixes for the pyspark test suite.