### PR TITLE
ci: run renovate over docker-compose setup

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
   "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
   "semanticCommits": "enabled",
   "lockFileMaintenance": { "enabled": true },
-  "enabledManagers": ["github-actions", "poetry"],
+  "enabledManagers": ["docker-compose", "github-actions", "poetry"],
   "automerge": false,
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
This PR enables renovate on our docker-compose setup.