### PR TITLE
refactor(sqlalchemy): use exported_columns instead of corresponding_column

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -117,13 +117,9 @@ def get_col_or_deferred_col(sa_table, colname):
     where `table_set` is `sa_table` above.
     """
     try:
-        col = sa_table.c[colname]
+        return sa_table.exported_columns[colname]
     except KeyError:
-        out_expr = sa.column(colname)
-    else:
-        out_expr = sa_table.corresponding_column(col)
-
-    return out_expr
+        return sa.column(colname)
 
 
 def _table_column(t, expr):


### PR DESCRIPTION
This PR replaces corresponding_column with a simpler but equal-for-our-purposes API exported_columns