### PR TITLE
fix(sqlalchemy): don't generate cartesian product for semi/anti-join in topk

### DIFF
--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -58,12 +58,12 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
             elif jtype is ops.OuterJoin:
                 result = result.outerjoin(table, onclause, full=True)
             elif jtype is ops.LeftSemiJoin:
-                result = sa.select([result]).where(
-                    sa.exists(sa.select([1]).where(onclause))
+                result = result.select().where(
+                    sa.exists(sa.select(1).where(onclause))
                 )
             elif jtype is ops.LeftAntiJoin:
-                result = sa.select([result]).where(
-                    ~(sa.exists(sa.select([1]).where(onclause)))
+                result = result.select().where(
+                    ~sa.exists(sa.select(1).where(onclause))
                 )
             else:
                 raise NotImplementedError(jtype)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -365,11 +365,8 @@ def test_topk_op(backend, alltypes, df, result_fn, expected_fn):
         )
     ],
 )
-@pytest.mark.notyet(['sqlite'], reason='Issue #2128')
-@pytest.mark.notyet(["mysql"], reason="Issue #2131")
-@pytest.mark.notyet(["postgres"], reason="Issue #2132")
-@mark.notimpl(["datafusion", "duckdb", "pandas", "dask", "pyspark"])
-def test_topk_filter_op(backend, alltypes, df, result_fn, expected_fn):
+@mark.notimpl(["datafusion", "pandas", "dask", "pyspark"])
+def test_topk_filter_op(alltypes, df, result_fn, expected_fn):
     # TopK expression will order rows by "count" but each backend
     # can have different result for that.
     # Note: Maybe would be good if TopK could order by "count"

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -12,6 +12,7 @@ import types
 import warnings
 from numbers import Real
 from typing import (
+    IO,
     TYPE_CHECKING,
     Any,
     Hashable,
@@ -28,6 +29,8 @@ import toolz
 from ibis.config import options
 
 if TYPE_CHECKING:
+    import sqlalchemy as sa
+
     from .expr import operations as ops
     from .expr import types as ir
 

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -538,3 +538,32 @@ def toposort(graph: Graph) -> Iterator[ops.Node]:
 
     if any(in_degree.values()):
         raise ValueError("cycle in expression graph")
+
+
+def psql(
+    expr: ir.Expr | sa.sql.ClauseElement,
+    reindent: bool = True,
+    file: IO[str] = None,
+    **kwargs: Any,
+) -> None:
+    """Pretty-print the compiled SQL string of an expression.
+
+    Accepts both ibis and SQLAlchemy expressions.
+
+    Parameters
+    ----------
+    expr
+        Expression whose SQL will be printed
+    reindent
+        Tell `sqlparse` to reindent the SQL string
+    file
+        File to write output to
+    kwargs
+        `sqlparse.format` options
+    """
+    import sqlparse as sp
+
+    print(
+        sp.format(str(expr.compile()), reindent=reindent, **kwargs),
+        file=file,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,6 @@ filterwarnings = [
   "ignore:Class (_regex_extract|_array_search|ST_.*) will not make use of SQL compilation caching:",
   'ignore:Dialect postgresql.psycopg2 will not make use of SQL compilation caching:',
   "ignore:UserDefinedType .* will not produce a cache key because:",
-  'ignore:The Selectable.replace_selectable\(\) method is deprecated:',
   # duckdb-engine
   'ignore:The URL\.__to_string__ method is deprecated:',
   # ibis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,10 +201,9 @@ filterwarnings = [
   "ignore:Class (_regex_extract|_array_search|ST_.*) will not make use of SQL compilation caching:",
   'ignore:Dialect postgresql.psycopg2 will not make use of SQL compilation caching:',
   "ignore:UserDefinedType .* will not produce a cache key because:",
+  'ignore:The Selectable.replace_selectable\(\) method is deprecated:',
   # duckdb-engine
   'ignore:The URL\.__to_string__ method is deprecated:',
-  # this is coming from sqlalchemy 1.4, and indicates the bug we're tracking in #3526
-  'ignore:SELECT statement has a cartesian product between FROM element\(s\):',
   # ibis
   "ignore:`database` is deprecated:FutureWarning",
   "ignore:`set_database` is deprecated:FutureWarning",


### PR DESCRIPTION
This PR addresses an annoying bug where we were inadvertently generating an
implicit cross join for left semi/anti-join queries for the SQLAlchemy
backends.

The fix is to always select from the compiled `table_set` by replacing the
single `FROM` in the `result` selections with `table_set`.

Closes #2131.
Closes #2132.
Closes #2612.
Closes #3526.