### PR TITLE
style(release): use conventional-commits style

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,7 @@
 {
   "branches": ["master"],
   "tagFormat": "${version}",
+  "preset": "conventionalcommits",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",

--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -29,9 +29,11 @@ npx --yes \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
   -p "@google/semantic-release-replace-plugin" \
+  -p "conventional-changelog-conventionalcommits" \
   semantic-release \
   --ci \
   --dry-run \
+  --preset conventionalcommits \
   --plugins \
   --analyze-commits "@semantic-release/commit-analyzer" \
   --generate-notes "@semantic-release/release-notes-generator" \

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -13,4 +13,5 @@ npx --yes \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
   -p "@google/semantic-release-replace-plugin" \
+  -p "conventional-changelog-conventionalcommits" \
   semantic-release --ci


### PR DESCRIPTION
This PR changes our release notes style to conventionalcommits. Among other small cosmetic changes, this puts breaking changes at the top of the release notes for maximum visibility.

Here's an example of what that looks like:
![image](https://user-images.githubusercontent.com/417981/162284892-7539013b-4449-4b66-86eb-d4b79179ab38.png)
