### PR TITLE
refactor(benchmarks): add compile benchmarks for backends where possible; add benchmark groups

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -80,7 +80,7 @@ jobs:
       - run: python -m pip install --upgrade pip poetry
 
       - name: install ibis
-        run: poetry install --extras impala
+        run: poetry install --extras all
 
       - run: mkdir .benchmarks
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2140,25 +2140,6 @@ python-versions = ">=3.7"
 test = ["pytest"]
 
 [[package]]
-name = "types-requests"
-version = "2.27.16"
-description = "Typing stubs for requests"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-urllib3 = "<1.27"
-
-[[package]]
-name = "types-urllib3"
-version = "1.26.11"
-description = "Typing stubs for urllib3"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "typing-extensions"
 version = "4.1.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
@@ -2272,7 +2253,7 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "b417719ecea1d514b253788de0a27f3634542d9d70b2891115fc10be7aac823a"
+content-hash = "997b084e885bd91b7cdf4d23a5a043997b9e7f298c91882d7d67a3a22a5530ff"
 
 [metadata.files]
 appnope = [
@@ -3963,14 +3944,6 @@ tornado = [
 traitlets = [
     {file = "traitlets-5.1.1-py3-none-any.whl", hash = "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"},
     {file = "traitlets-5.1.1.tar.gz", hash = "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7"},
-]
-types-requests = [
-    {file = "types-requests-2.27.16.tar.gz", hash = "sha256:c8010c18b291a7efb60b1452dbe12530bc25693dd657e70c62803fcdc4bffe9b"},
-    {file = "types_requests-2.27.16-py3-none-any.whl", hash = "sha256:2437a5f4d16c0c8bd7539a8126d492b7aeb41e6cda670d76b286c7f83a658d42"},
-]
-types-urllib3 = [
-    {file = "types-urllib3-1.26.11.tar.gz", hash = "sha256:24d64e441168851eb05f1d022de18ae31558f5649c8f1117e384c2e85e31315b"},
-    {file = "types_urllib3-1.26.11-py3-none-any.whl", hash = "sha256:bd0abc01e9fb963e4fddd561a56d21cc371b988d1245662195c90379077139cd"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ requests = ">=2,<3"
 setuptools = ">=57,<63"
 sqlalchemy = ">=1.4,<2.0"
 sqlparse = ">=0.4.2,<0.5.0"
-types-requests = ">=2.27.8,<3"
+tomli = ">=2.0.1,<3"
 
 [tool.poetry.extras]
 all = [


### PR DESCRIPTION
This PR improves benchmarks in a few ways:

1. Bump the alert threshold to 3x to avoid more spurious alerts
1. Use module scoped pytest fixtures to avoid recreating the same thing multiple times
1. Run the compilation benchmark across all possible backends (dask,
   datafusion, and pyspark are `xfail`ed because they don't support compiling
   `UnboundTable`s)
1. Give every benchmark a benchmark group
