### PR TITLE
ci: run visualization tests in the main workflow

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -1,4 +1,4 @@
-name: Check setup.py
+name: Check Generated Files
 
 on:
   push:

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -76,11 +76,17 @@ jobs:
           requirement_files: poetry.lock
           custom_cache_key_element: no-backends-${{ steps.install_python.outputs.python-version }}
 
-      - name: update apt-get
-        run: sudo apt-get update -y -q
+      - name: install ${{ matrix.os }} system dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          set -euo pipefail
 
-      - name: install system dependencies
-        run: sudo apt-get install -y -q build-essential graphviz
+          sudo apt-get update -y -q
+          sudo apt-get install -y -q build-essential graphviz
+
+      - name: install ${{ matrix.os }} system dependencies
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: choco install graphviz
 
       - run: python -m pip install --upgrade pip poetry
 

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -76,10 +76,16 @@ jobs:
           requirement_files: poetry.lock
           custom_cache_key_element: no-backends-${{ steps.install_python.outputs.python-version }}
 
+      - name: update apt-get
+        run: sudo apt-get update -y -q
+
+      - name: install system dependencies
+        run: sudo apt-get install -y -q build-essential graphviz
+
       - run: python -m pip install --upgrade pip poetry
 
       - name: install ibis
-        run: poetry install
+        run: poetry install --extras visualization
 
       - uses: extractions/setup-just@v1
 


### PR DESCRIPTION
This PR runs the visualization tests in the main workflow, instead of only in the setuptools check.