### PR TITLE
fix(sqlalchemy): correctly render from clauses in correlated subqueries

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -131,7 +131,11 @@ def _table_column(t, expr):
     # If the column does not originate from the table set in the current SELECT
     # context, we should format as a subquery
     if t.permit_subquery and ctx.is_foreign_expr(table):
-        return sa.select([out_expr])
+        try:
+            subq = sa_table.subquery()
+        except AttributeError:
+            subq = sa_table
+        return sa.select(subq.c[out_expr.name])
 
     return out_expr
 


### PR DESCRIPTION
This PR fixes an issue where the `FROM` clause in correlated subqueries with `JOIN`s in the `FROM` clause
were not rendered.

The problem was that before SQLAlchemy 1.4 the behavior of automatically rendering a `FROM` clause
was implicit, while in 1.4 it's not. The solution was to make it explicit.
