### PR TITLE
test: run tpc-queries on CI

### DIFF
--- a/.github/workflows/ibis-tpch-queries.yml
+++ b/.github/workflows/ibis-tpch-queries.yml
@@ -1,0 +1,46 @@
+# vim: filetype=yaml
+name: TPC-H
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  tpch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: install python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - run: python -m pip install --upgrade pip click sqlparse
+
+      - name: install ibis
+        run: python -m pip install "ibis-framework[duckdb]"
+
+      - name: clone tpc-queries
+        uses: actions/checkout@v3
+        with:
+          repository: ibis-project/tpc-queries
+          path: ./tpc-queries
+          ref: master
+
+      - name: generate tpc-h data
+        working-directory: tpc-queries
+        run: python -c "import duckdb; con = duckdb.connect('tpch.ddb'); con.execute('CALL dbgen(sf=0.1);')"
+
+      - name: run tpc-h queries
+        working-directory: tpc-queries
+        run: ./runtpc -i ibis -i duckdb -d 'tpch.ddb' -b 'duckdb'


### PR DESCRIPTION
Resolves #3782 

This currently relies on ibis-project/tpc-queries#4 in order to run against Ibis master.  So it's currently pointed at my fork in order to run.  I'm leaving this as a draft for now -- once we cut a new release and merge the corresponding tpc-queries PR, I can update this to start the TPC-runs