### PR TITLE
fix(duckdb): fix array column type discovery on leaf tables and add tests

### DIFF
--- a/ci/schema/clickhouse.sql
+++ b/ci/schema/clickhouse.sql
@@ -76,3 +76,11 @@ CREATE TABLE IF NOT EXISTS array_types (
     grouper Nullable(String),
     scalar_column Nullable(Float64)
 ) ENGINE = Memory;
+
+INSERT INTO array_types VALUES
+    ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0),
+    ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0),
+    ([6, NULL], ['f', NULL], [6.0, NULL], 'a', 3.0),
+    ([NULL, 1, NULL], [NULL, 'a', NULL], [], 'b', 4.0),
+    ([2, NULL, 3], ['b', NULL, 'c'], NULL, 'b', 5.0),
+    ([4, NULL, NULL, 5], ['d', NULL, NULL, 'e'], [4.0, NULL, NULL, 5.0], 'c', 6.0);

--- a/ci/schema/duckdb.sql
+++ b/ci/schema/duckdb.sql
@@ -70,3 +70,21 @@ CREATE TABLE functional_alltypes (
     year INTEGER,
     month INTEGER
 );
+
+DROP TABLE IF EXISTS array_types CASCADE;
+
+CREATE TABLE IF NOT EXISTS array_types (
+    x BIGINT[],
+    y TEXT[],
+    z DOUBLE PRECISION[],
+    grouper TEXT,
+    scalar_column DOUBLE PRECISION
+);
+
+INSERT INTO array_types VALUES
+    ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0),
+    ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0),
+    ([6, NULL], ['f', NULL], [6.0, NULL], 'a', 3.0),
+    ([NULL, 1, NULL], [NULL, 'a', NULL], [], 'b', 4.0),
+    ([2, NULL, 3], ['b', NULL, 'c'], NULL, 'b', 5.0),
+    ([4, NULL, NULL, 5], ['d', NULL, NULL, 'e'], [4.0, NULL, NULL, 5.0], 'c', 6.0);

--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -275,7 +275,7 @@ def sa_array(dialect, satype, nullable=True):
     return dt.Array(value_dtype, nullable=nullable)
 
 
-@sch.infer.register(sa.Table)
+@sch.infer.register((sa.Table, sa.sql.TableClause))
 def schema_from_table(table, schema=None):
     """Retrieve an ibis schema from a SQLAlchemy ``Table``.
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
+
+from ibis.backends.base.sql.alchemy.datatypes import to_sqla_type
 
 if TYPE_CHECKING:
     import duckdb
@@ -76,6 +79,48 @@ class Backend(BaseAlchemyBackend):
                 for name, type in zip(rel.columns, rel.types)
             }
         )
+
+    def _get_sqla_table(
+        self,
+        name: str,
+        schema: str | None = None,
+        **kwargs: Any,
+    ) -> sa.Table:
+
+        with warnings.catch_warnings():
+            # don't fail or warn if duckdb-engine fails to discover types
+            warnings.filterwarnings(
+                "ignore",
+                message="Did not recognize type",
+                category=sa.exc.SAWarning,
+            )
+
+            t = super()._get_sqla_table(name, schema, **kwargs)
+
+        nulltype_cols = frozenset(
+            col.name
+            for col in t.c.values()
+            if isinstance(col.type, sa.types.NullType)
+        )
+
+        if nulltype_cols:
+            query = (
+                f"DESCRIBE {self.con.dialect.identifier_preparer.quote(name)}"
+            )
+            with self.con.connect() as con:
+                metadata = con.connection.c.execute(query).fetchall()
+
+            for colname, type, null, *_ in metadata:
+                if colname in nulltype_cols:
+                    column = sa.Column(
+                        colname,
+                        to_sqla_type(parse_type(type)),
+                        nullable=null == "YES",
+                    )
+                    # replace null types discovered by sqlite with non null
+                    # types
+                    t.append_column(column, replace_existing=True)
+        return t
 
     def _get_temp_view_definition(
         self,

--- a/ibis/backends/pandas/tests/conftest.py
+++ b/ibis/backends/pandas/tests/conftest.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 import ibis
@@ -31,6 +32,53 @@ class TestConf(BackendTest, RoundHalfToEven):
                 'batting': pd.read_csv(str(data_directory / 'batting.csv')),
                 'awards_players': pd.read_csv(
                     str(data_directory / 'awards_players.csv')
+                ),
+                'array_types': pd.DataFrame(
+                    [
+                        (
+                            [np.int64(1), 2, 3],
+                            ['a', 'b', 'c'],
+                            [1.0, 2.0, 3.0],
+                            'a',
+                            1.0,
+                        ),
+                        (
+                            [4, 5],
+                            ['d', 'e'],
+                            [4.0, 5.0],
+                            'a',
+                            2.0,
+                        ),
+                        (
+                            [6, None],
+                            ['f', None],
+                            [6.0, np.nan],
+                            'a',
+                            3.0,
+                        ),
+                        (
+                            [None, 1, None],
+                            [None, 'a', None],
+                            [],
+                            'b',
+                            4.0,
+                        ),
+                        (
+                            [2, None, 3],
+                            ['b', None, 'c'],
+                            np.nan,
+                            'b',
+                            5.0,
+                        ),
+                        (
+                            [4, None, None, 5],
+                            ['d', None, None, 'e'],
+                            [4.0, np.nan, np.nan, 5.0],
+                            'c',
+                            6.0,
+                        ),
+                    ],
+                    columns=["x", "y", "z", "grouper", "scalar_column"],
                 ),
             }
         )

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -150,6 +150,24 @@ def get_common_spark_testing_client(data_directory, connect):
         ],
     )
     df_nested_types.createOrReplaceTempView('nested_types')
+    df_array_types = s.createDataFrame(
+        [
+            ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0),
+            ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0),
+            ([6, None], ['f', None], [6.0, None], 'a', 3.0),
+            ([None, 1, None], [None, 'a', None], [], 'b', 4.0),
+            ([2, None, 3], ['b', None, 'c'], None, 'b', 5.0),
+            (
+                [4, None, None, 5],
+                ['d', None, None, 'e'],
+                [4.0, None, None, 5.0],
+                'c',
+                6.0,
+            ),
+        ],
+        ["x", "y", "z", "grouper", "scalar_column"],
+    )
+    df_array_types.createOrReplaceTempView("array_types")
 
     df_complicated = s.createDataFrame(
         [({(1, 3): [[2, 4], [3, 5]]},)], ['map_tuple_list_of_list_of_ints']

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
+import toolz
 
 import ibis
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 
 pytestmark = pytest.mark.never(["sqlite", "mysql"], reason="No array support")
@@ -23,7 +25,7 @@ def test_array_column(backend, alltypes, df):
 
 
 @pytest.mark.notimpl(["impala"])
-def test_array_scalar(backend, con, alltypes, df):
+def test_array_scalar(con):
     expr = ibis.array([1.0, 2.0, 3.0])
     assert isinstance(expr, ir.ArrayScalar)
 
@@ -37,7 +39,7 @@ def test_array_scalar(backend, con, alltypes, df):
 
 # Issues #2370
 @pytest.mark.notimpl(["impala", "datafusion"])
-def test_array_concat(backend, con):
+def test_array_concat(con):
     left = ibis.literal([1, 2, 3])
     right = ibis.literal([2, 1])
     expr = left + right
@@ -50,13 +52,13 @@ def test_array_concat(backend, con):
 
 
 @pytest.mark.notimpl(["impala", "datafusion"])
-def test_array_length(backend, con):
+def test_array_length(con):
     expr = ibis.literal([1, 2, 3]).length()
     assert con.execute(expr) == 3
 
 
 @pytest.mark.notimpl(["impala"])
-def test_list_literal(backend, con):
+def test_list_literal(con):
     arr = [1, 2, 3]
     expr = ibis.literal(arr)
     result = con.execute(expr)
@@ -67,7 +69,7 @@ def test_list_literal(backend, con):
 
 
 @pytest.mark.notimpl(["impala"])
-def test_np_array_literal(backend, con):
+def test_np_array_literal(con):
     arr = np.array([1, 2, 3])
     expr = ibis.literal(arr)
     result = con.execute(expr)
@@ -75,3 +77,39 @@ def test_np_array_literal(backend, con):
     # This does not check whether `result` is an np.array or a list,
     # because it varies across backends and backend configurations
     assert np.array_equal(result, arr)
+
+
+builtin_array = toolz.compose(
+    # the type parser needs additional work for this to work
+    pytest.mark.broken(
+        "clickhouse",
+        reason="nullable types can't yet be parsed",
+    ),
+    # these will almost certainly never be supported
+    pytest.mark.never(
+        ["mysql", "sqlite"],
+        reason="array types are unsupported",
+    ),
+    # someone just needs to implement these
+    pytest.mark.notimpl(["datafusion", "dask"]),
+    # unclear if thi will ever be supported
+    pytest.mark.notyet(
+        ["impala"],
+        reason="impala doesn't support array types",
+    ),
+)
+
+
+@builtin_array
+def test_array_discovery(con):
+    t = con.table("array_types")
+    expected = ibis.schema(
+        dict(
+            x=dt.Array(dt.int64),
+            y=dt.Array(dt.string),
+            z=dt.Array(dt.float64),
+            grouper=dt.string,
+            scalar_column=dt.float64,
+        )
+    )
+    assert t.schema() == expected


### PR DESCRIPTION
This PR fixes array column type discovery on leaf tables inside of a database.