### PR TITLE
docs: rebrand OmniSciDB to HeavyAI

### DIFF
--- a/docs/backends/index.md
+++ b/docs/backends/index.md
@@ -10,7 +10,7 @@ database through a driver API for execution.
 - [Apache Impala](Impala.md)
 - [ClickHouse](ClickHouse.md)
 - [Google BigQuery](https://github.com/ibis-project/ibis-bigquery/)
-- [OmniSciDB](https://github.com/omnisci/ibis-omniscidb)
+- [HeavyAI](https://github.com/heavyai/ibis-heavyai)
 
 ## Expression Generating Backends
 


### PR DESCRIPTION
OmniSci is being rebranded to HeavyAI. This updates the documentation link to the new `ibis-heavyai` backend.

The current link is already resolving to this new URL since the repo got renamed. There is a PR in progress that does the internal rebranding.