### PR TITLE
ci: split release docs build into separate workflow

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -88,14 +88,14 @@ jobs:
         run: poetry run pytest --benchmark-only --benchmark-json .benchmarks/output.json ibis/tests/benchmarks
 
       - uses: tibdex/github-app-token@v1
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name == 'push' }}
         id: generate-token
         with:
           app_id: ${{ secrets.SQUAWK_BOT_APP_ID }}
           private_key: ${{ secrets.SQUAWK_BOT_APP_PRIVATE_KEY }}
 
       - uses: benchmark-action/github-action-benchmark@v1
-        if: ${{ github.event_name != 'pull_request' }}
+        if: ${{ github.event_name == 'push' }}
         with:
           tool: pytest
           github-token: ${{ steps.generate-token.outputs.token }}
@@ -107,6 +107,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    concurrency: docs-${{ github.repository }}-${{ github.head_ref || github.sha }}
     needs:
       # wait on benchmarks to prevent a race condition when pushing to the
       # gh-pages branch
@@ -124,24 +125,14 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           extraPullNames: nix-community,poetry2nix
 
-      - name: Generate a GitHub token
-        if: ${{ github.event_name == 'push' }}
-        uses: tibdex/github-app-token@v1
-        id: generate_token
-        with:
-          app_id: ${{ secrets.DOCS_BOT_APP_ID }}
-          private_key: ${{ secrets.DOCS_BOT_APP_PRIVATE_KEY }}
-
       - name: checkout
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          token: ${{ steps.generate_token.outputs.token }}
 
-      - name: checkout
-        if: ${{ github.event_name != 'push' }}
-        uses: actions/checkout@v3
+      - name: build docs
+        run: nix develop -f shell.nix --ignore-environment --keep-going -c mkdocs build
+
+      - name: verify internal links
+        run: nix develop -f shell.nix --ignore-environment --keep-going -c just checklinks --offline --no-progress
 
       - name: Configure git info
         if: ${{ github.event_name == 'push' }}
@@ -151,24 +142,8 @@ jobs:
           git config user.name 'ibis-docs-bot[bot]'
           git config user.email 'ibis-docs-bot[bot]@users.noreply.github.com'
 
-      - name: build docs
-        if: ${{ github.event_name != 'push' }}
-        run: nix develop -f shell.nix --ignore-environment --keep-going -c mkdocs build
-
-      - name: verify internal links
-        if: ${{ github.event_name != 'push' }}
-        run: nix develop -f shell.nix --ignore-environment --keep-going -c just checklinks --offline --no-progress
-
-      - name: Pull gh-pages changes
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          set -euo pipefail
-
-          git fetch origin gh-pages
-          git update-ref refs/heads/gh-pages "$(git rev-parse origin/gh-pages)"
-
       - name: build and push dev docs
-        if: ${{ github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/') }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           set -euo pipefail
 
@@ -179,19 +154,6 @@ jobs:
               --prefix docs \
               --message 'docs(dev): ibis@${{ github.sha }}' \
                 dev
-
-      - name: build and push docs on tag
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-
-          nix develop -f shell.nix --keep-going -c \
-            mic deploy \
-              --push \
-              --rebase \
-              --prefix docs \
-              --message "docs(release): ibis@${GITHUB_REF_NAME}" \
-              "${GITHUB_REF_NAME}" latest
 
   simulate_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/ibis-docs-release.yml
+++ b/.github/workflows/ibis-docs-release.yml
@@ -1,0 +1,63 @@
+# vim: filetype=yaml
+name: Docs Release Build
+
+on:
+  release:
+    types:
+      - published
+jobs:
+  docs:
+    concurrency: docs-${{ github.repository }}-${{ github.head_ref || github.sha }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: install nix
+        uses: cachix/install-nix-action@v17
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable-small
+
+      - name: setup cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: ibis
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: nix-community,poetry2nix
+
+      - name: Generate a GitHub token
+        uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.DOCS_BOT_APP_ID }}
+          private_key: ${{ secrets.DOCS_BOT_APP_PRIVATE_KEY }}
+
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Configure git info
+        run: |
+          set -euo pipefail
+
+          git config user.name 'ibis-docs-bot[bot]'
+          git config user.email 'ibis-docs-bot[bot]@users.noreply.github.com'
+
+      - name: Pull gh-pages changes
+        run: |
+          set -euo pipefail
+
+          git fetch origin gh-pages
+          git update-ref refs/heads/gh-pages "$(git rev-parse origin/gh-pages)"
+
+      - name: build and push docs on tag
+        run: |
+          set -euo pipefail
+
+          nix develop -f shell.nix --keep-going -c \
+            mic deploy \
+              --push \
+              --rebase \
+              --update-aliases \
+              --prefix docs \
+              --message "docs(release): ibis@${GITHUB_REF_NAME}" \
+              "${GITHUB_REF_NAME}" latest


### PR DESCRIPTION
This PR splits the release docs build into a separate workflow. For 3.0.0 I had to manually push the docs because the tag was not available when the push job ran. This PR should address that.