### PR TITLE
fix(build): replace version before exec plugin runs

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,14 +13,6 @@
       }
     ],
     [
-      "@semantic-release/exec",
-      {
-        "verifyConditionsCmd": "ci/release/verify.sh",
-        "prepareCmd": "ci/release/prepare.sh ${nextRelease.version}",
-        "publishCmd": "ci/release/publish.sh"
-      }
-    ],
-    [
       "@google/semantic-release-replace-plugin",
       {
         "replacements": [
@@ -39,6 +31,14 @@
             "countMatches": true
           }
         ]
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "verifyConditionsCmd": "ci/release/verify.sh",
+        "prepareCmd": "ci/release/prepare.sh ${nextRelease.version}",
+        "publishCmd": "ci/release/publish.sh"
       }
     ],
     [


### PR DESCRIPTION
This PR moves the version replacement step to execute before exec plugin so that wheels are published with an updated `__init__.py`.