### PR TITLE
fix(docs): fix tempdir location for docs build

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -71,7 +71,7 @@ let
       # indavertently preventing this.
       export PYTHONPATH TEMPDIR
       PYTHONPATH="$(python -c 'import os, sys; print(os.pathsep.join(sys.path))')"
-      TEMPDIR="$(mktemp -d)"
+      TEMPDIR="$(python -c 'import tempfile; print(tempfile.gettempdir())')"
 
       mike "$@"
     '';


### PR DESCRIPTION
This PR fixes the possible TEMPDIR mismatch when building docs.