### PR TITLE
fix: use bounded precision for decimal aggregations

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -440,7 +440,10 @@ class Decimal(DataType):
     @property
     def largest(self):
         """Return the largest type of decimal."""
-        return self.__class__(precision=None, scale=None)
+        return self.__class__(
+            precision=38 if self.precision is not None else None,
+            scale=2 if self.scale is not None else None,
+        )
 
     @property
     def _pretty_piece(self) -> str:

--- a/ibis/tests/expr/test_decimal.py
+++ b/ibis/tests/expr/test_decimal.py
@@ -2,6 +2,7 @@ import operator
 
 import pytest
 
+import ibis
 import ibis.expr.api as api
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
@@ -25,6 +26,14 @@ def test_cast_scalar_to_decimal():
 
 def test_decimal_sum_type(lineitem):
     col = lineitem.l_extendedprice
+    result = col.sum()
+    assert isinstance(result, ir.DecimalScalar)
+    assert result.type() == dt.Decimal(38, 2)
+
+
+def test_decimal_sum_type_unbounded_precision():
+    t = ibis.table([("l_extendedprice", dt.Decimal(None, None))], name="t")
+    col = t.l_extendedprice
     result = col.sum()
     assert isinstance(result, ir.DecimalScalar)
     assert result.type() == dt.decimal


### PR DESCRIPTION
This tweaks the new behavior around decimal precision and scale.  If a
decimal has unbounded precision/scale, specified as `(None, None)`, then
the precision/scale of an aggregation of that column will also have
unbounded precision.

For a decimal with some bounded precision/scale, e.g. `(18, 2)`, the
precision/scale of an aggregation of that column will have a precision
of `(38, 2)` which is the previous default maximum for bounded precision
and matches up with _most_ backends.

Fixes #3833 