### PR TITLE
refactor(decimal): allow user to specify precision > 38

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -441,8 +441,10 @@ class Decimal(DataType):
     def largest(self):
         """Return the largest type of decimal."""
         return self.__class__(
-            precision=38 if self.precision is not None else None,
-            scale=2 if self.scale is not None else None,
+            precision=max(self.precision, 38)
+            if self.precision is not None
+            else None,
+            scale=max(self.scale, 2) if self.scale is not None else None,
         )
 
     @property

--- a/ibis/tests/expr/test_decimal.py
+++ b/ibis/tests/expr/test_decimal.py
@@ -31,12 +31,23 @@ def test_decimal_sum_type(lineitem):
     assert result.type() == dt.Decimal(38, 2)
 
 
-def test_decimal_sum_type_unbounded_precision():
-    t = ibis.table([("l_extendedprice", dt.Decimal(None, None))], name="t")
+@pytest.mark.parametrize(
+    "precision, scale, expected",
+    [
+        (None, None, (None, None)),
+        (38, 2, (38, 2)),
+        (16, 2, (38, 2)),
+        (39, 3, (39, 3)),
+    ],
+)
+def test_decimal_sum_type_precision(precision, scale, expected):
+    t = ibis.table(
+        [("l_extendedprice", dt.Decimal(precision, scale))], name="t"
+    )
     col = t.l_extendedprice
     result = col.sum()
     assert isinstance(result, ir.DecimalScalar)
-    assert result.type() == dt.decimal
+    assert result.type() == dt.Decimal(*expected)
 
 
 @pytest.mark.parametrize('func', ['mean', 'max', 'min'])


### PR DESCRIPTION
The previous fix for decimals imposes an effective limit on decimal
precision -- it can either be 38 or unbounded.  In the case that the
user does want to specify a bounded precision/scale that are larger than
our defaults, they can now do that.