### PR TITLE
refactor: deprecate SummaryFilter in favor of inlining the semi-join

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -592,7 +592,11 @@ class SelectBuilder:
 
     _visit_filter_NotAny = _visit_filter_Any
 
-    def _visit_filter_SummaryFilter(self, expr):
+    @util.deprecated(
+        instead="do nothing; SummaryFilter will be removed",
+        version="4.0.0",
+    )
+    def _visit_filter_SummaryFilter(self, expr):  # pragma: no cover
         # Top K is rewritten as an
         # - aggregation
         # - sort by

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -365,7 +365,7 @@ def test_topk_op(backend, alltypes, df, result_fn, expected_fn):
         )
     ],
 )
-@mark.notimpl(["datafusion", "pandas", "dask", "pyspark"])
+@mark.notimpl(["datafusion", "pandas", "dask"])
 def test_topk_filter_op(alltypes, df, result_fn, expected_fn):
     # TopK expression will order rows by "count" but each backend
     # can have different result for that.

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -608,8 +608,9 @@ def apply_filter(expr, predicates):
 
             return ir.TableExpr(result)
 
-    result = ops.Selection(expr, [], predicates)
-    return ir.TableExpr(result)
+    if not predicates:
+        return expr
+    return ops.Selection(expr, [], predicates).to_expr()
 
 
 def _filter_selection(expr, predicates):

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -1019,8 +1019,13 @@ class FilterValidator(ExprValidator):
                 if isinstance(arg, ir.ScalarExpr):
                     # arg_valid = True
                     pass
-                elif isinstance(arg, ir.TopKExpr):
-                    # TopK not subjected to further analysis for now
+                elif isinstance(arg, ir.TopKExpr):  # pragma: no cover
+                    # we don't cover this branch because its implementation as
+                    # a filter is automatically turned into a semi-join before
+                    # this code path is hit
+                    #
+                    # we should change its base class to Expr instead of
+                    # AnalyticExpr and then remove this branch
                     roots_valid.append(True)
                 elif isinstance(arg, (ir.ColumnExpr, ir.AnalyticExpr)):
                     roots_valid.append(self.shares_some_roots(arg))

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -618,13 +618,6 @@ def _fmt_value_sort_key(op: ops.SortKey, *, aliases: Aliases) -> str:
 
 
 @fmt_value.register
-def _fmt_topk(op: ops.TopK, *, aliases: Aliases) -> str:
-    arg = fmt_value(op.arg, aliases=aliases)
-    by = fmt_value(op.by, aliases=aliases)
-    return f"TopK({arg}, {op.k}, {by})"
-
-
-@fmt_value.register
 def _fmt_value_physical_table(op: ops.PhysicalTable, **_: Any) -> str:
     """Format a table as value.
 

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -17,7 +17,7 @@ from ibis.expr import datatypes as dt
 from ibis.expr import rules as rlz
 from ibis.expr import types as ir
 from ibis.expr.operations.core import Node, UnaryOp, ValueOp, distinct_roots
-from ibis.util import frozendict
+from ibis.util import deprecated, frozendict
 
 try:
     import shapely
@@ -397,6 +397,10 @@ class HashBytes(ValueOp):
     output_shape = rlz.shape_like("arg")
 
 
+@deprecated(
+    instead="do nothing; SummaryFilter is no longer used internally",
+    version="4.0.0",
+)
 @public
 class SummaryFilter(ValueOp):
     expr = rlz.instance_of(ir.TopKExpr)
@@ -420,10 +424,10 @@ class TopK(Node):
 
     output_type = ir.TopKExpr
 
-    def blocks(self):
+    def blocks(self):  # pragma: no cover
         return True
 
-    def root_tables(self):
+    def root_tables(self):  # pragma: no cover
         args = (arg for arg in self.flat_args() if isinstance(arg, ir.Expr))
         return distinct_roots(*args)
 

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -284,3 +284,9 @@ def test_select_filter_mutate_fusion():
     # to remove materialize for some performance in the short term
     assert len(first_selection.op().selections) == 0
     assert len(first_selection.op().predicates) == 1
+
+
+def test_no_filter_means_no_selection():
+    t = ibis.table(dict(a="string"))
+    proj = t.filter([])
+    assert proj.equals(t)

--- a/ibis/tests/expr/test_analytics.py
+++ b/ibis/tests/expr/test_analytics.py
@@ -15,6 +15,7 @@
 import pytest
 
 import ibis
+import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.tests.expr.mocks import MockBackend
 from ibis.tests.util import assert_equal

--- a/ibis/tests/expr/test_analytics.py
+++ b/ibis/tests/expr/test_analytics.py
@@ -15,7 +15,6 @@
 import pytest
 
 import ibis
-import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.tests.expr.mocks import MockBackend
 from ibis.tests.util import assert_equal
@@ -111,7 +110,7 @@ def test_topk_analysis_bug(airlines):
 
     filtered = t.filter([delay_filter])
 
-    assert delay_filter._to_semi_join(t).equals(filtered)
+    assert delay_filter._to_semi_join(t)[t].equals(filtered)
 
 
 def test_topk_function_late_bind(airlines):

--- a/ibis/tests/expr/test_analytics.py
+++ b/ibis/tests/expr/test_analytics.py
@@ -110,8 +110,7 @@ def test_topk_analysis_bug(airlines):
 
     filtered = t.filter([delay_filter])
 
-    post_pred = filtered.op().predicates[0]
-    assert delay_filter.to_filter().equals(post_pred)
+    assert delay_filter._to_semi_join(t).equals(filtered)
 
 
 def test_topk_function_late_bind(airlines):
@@ -120,3 +119,12 @@ def test_topk_function_late_bind(airlines):
     expr2 = airlines.dest.topk(5, by=airlines.arrdelay.mean())
 
     assert_equal(expr1.to_aggregation(), expr2.to_aggregation())
+
+
+def test_summary_filter_warns(airlines):
+    dests = ['ORD', 'JFK', 'SFO']
+    t = airlines[airlines.dest.isin(dests)]
+    delay_filter = t.origin.topk(10, by=t.arrdelay.mean())
+
+    with pytest.warns(FutureWarning):
+        delay_filter.to_filter()


### PR DESCRIPTION
This PR deprecates SummaryFilter and the currently-public TopK.to_filter method in favor of eagerly generating the semi-join. As a bonus, topk is now supported in the pyspark backend. Closes #2130 for real.