### PR TITLE
build(nix): improve usability of the nix shell

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -49,8 +49,15 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           extraPullNames: nix-community,poetry2nix
 
-      - name: pre-commit checks
+      # run against a smaller shell for speed for pull requests
+      - name: pre-commit checks pull_request
+        if: ${{ github.event_name == 'pull_request' }}
         run: nix develop -f nix preCommitShell --ignore-environment --keep-going -c pre-commit run --all-files
+
+      # run against the full shell.nix on push so it gets pushed to cachix
+      - name: pre-commit checks push
+        if: ${{ github.event_name == 'push' }}
+        run: nix develop -f shell.nix --ignore-environment --keep-going -c pre-commit run --all-files
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,6 @@ let
     commitlint
     lychee
     # packaging
-    cachix
     niv
     poetry
   ];


### PR DESCRIPTION
This PR addresses some usability concerns with the shell.nix setup: 1) cachix is unnecessary 2) shell.nix is not currently populating the cachix cache. Both concerns are addressed in this PR.