### PR TITLE
refactor: move AnyToExistsTransform to expression construction time

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -521,8 +521,8 @@ class SelectBuilder:
         ),
         version="4.0.0",
     )
-    def _visit_filter_Any(self, expr):
-        transform = ir.relations._AnyToExistsTransform(expr, self.table_set)
+    def _visit_filter_Any(self, expr):  # pragma: no cover
+        transform = L._AnyToExistsTransform(expr, self.table_set)
         return transform.get_result()
 
     _visit_filter_NotAny = _visit_filter_Any

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -37,27 +37,20 @@ def _between(translator, expr):
 
 
 def _negate(translator, expr):
-    arg = expr.op().args[0]
-    if isinstance(expr, ir.BooleanValue):
-        arg_ = translator.translate(arg)
-        return f'NOT {arg_!s}'
-    else:
-        arg_ = _parenthesize(translator, arg)
-        return f'-{arg_!s}'
+    return f"-{_parenthesize(translator, expr.op().arg)}"
 
 
 def _not(translator, expr):
-    return 'NOT {}'.format(*map(translator.translate, expr.op().args))
+    return f"NOT {_parenthesize(translator, expr.op().arg)}"
 
 
 def _parenthesize(translator, expr):
     op = expr.op()
-    op_klass = type(op)
 
     # function calls don't need parens
     what_ = translator.translate(expr)
-    if (op_klass in _binary_infix_ops) or (op_klass in _unary_ops):
-        return f'({what_!s})'
+    if isinstance(op, (*_binary_infix_ops.keys(), *_unary_ops.keys())):
+        return f"({what_})"
     else:
         return what_
 

--- a/ibis/backends/dask/execution/numeric.py
+++ b/ibis/backends/dask/execution/numeric.py
@@ -14,8 +14,8 @@ from ibis.backends.pandas.core import numeric_types
 
 
 @execute_node.register(ops.Negate, dd.Series)
-def execute_series_negate(op, data, **kwargs):
-    return data.mul(-1)
+def execute_series_negate(_, data, **kwargs):
+    return -data
 
 
 @execute_node.register(ops.Negate, ddgb.SeriesGroupBy)

--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -6,6 +6,7 @@ import datafusion.functions
 import pyarrow as pa
 
 import ibis.common.exceptions as com
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.backends.datafusion.datatypes import to_pyarrow_type
@@ -390,6 +391,15 @@ def not_contains(op, expr):
     value = translate(op.value)
     options = _prepare_contains_options(op.options)
     return df.functions.in_list(value, options, negated=True)
+
+
+@translate.register(ops.Negate)
+def negate(op, expr):
+    op_arg = op.arg
+    arg = translate(op_arg)
+    if op_arg.type() == dt.boolean:
+        return ~arg
+    return df.lit(-1) * arg
 
 
 @translate.register(ops.ElementWiseVectorizedUDF)

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -681,8 +681,8 @@ def execute_count_frame(op, data, _, **kwargs):
     return len(data)
 
 
-@execute_node.register(ops.Not, (bool, np.bool_))
-def execute_not_bool(op, data, **kwargs):
+@execute_node.register((ops.Not, ops.Negate), (bool, np.bool_))
+def execute_not_bool(_, data, **kwargs):
     return not data
 
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -830,6 +830,8 @@ def compile_negate(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
 
     src_column = t.translate(op.arg, scope, timecontext)
+    if expr.type() == dtypes.boolean:
+        return ~src_column
     return -src_column
 
 

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -209,7 +209,6 @@ def test_math_functions_literals(backend, con, alltypes, df, expr, expected):
             lambda t: (-t.double_col).abs(),
             lambda t: (-t.double_col).abs(),
             id='abs-neg',
-            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             lambda t: t.double_col.abs(),

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -1133,7 +1133,10 @@ def flatten_predicate(expr):
 
 def is_analytic(expr, exclude_windows=False):
     def _is_analytic(op):
-        if isinstance(op, (ops.Reduction, ops.Analytic, ops.Any, ops.All)):
+        if isinstance(
+            op,
+            (ops.Reduction, ops.Analytic, ops.logical._AnyBase, ops.All),
+        ):
             return True
         elif isinstance(op, ops.Window) and exclude_windows:
             return False

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import operator
 
 import toolz
@@ -1007,6 +1008,9 @@ class FilterValidator(ExprValidator):
         if isinstance(op, ops.Contains):
             value_valid = super().validate(op.value)
             is_valid = value_valid
+        elif isinstance(op, (ops.ExistsSubquery, ops.NotExistsSubquery)):
+            predicate = functools.reduce(operator.and_, op.predicates)
+            is_valid = self.shares_some_roots(predicate)
         else:
             roots_valid = []
             for arg in op.flat_args():

--- a/ibis/expr/operations/analytic.py
+++ b/ibis/expr/operations/analytic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from public import public
 
 from ibis.common.validators import immutable_property
@@ -232,37 +234,6 @@ class NthValue(Analytic):
     arg = rlz.column(rlz.any)
     nth = rlz.integer
     output_dtype = rlz.dtype_like("arg")
-
-
-@public
-class Any(Value):
-
-    # Depending on the kind of input boolean array, the result might either be
-    # array-like (an existence-type predicate) or scalar (a reduction)
-    arg = rlz.column(rlz.boolean)
-
-    output_dtype = dt.boolean
-
-    @property
-    def _reduction(self):
-        roots = self.arg.op().root_tables()
-        return len(roots) < 2
-
-    @immutable_property
-    def output_shape(self):
-        if self._reduction:
-            return rlz.Shape.SCALAR
-        else:
-            return rlz.Shape.COLUMNAR
-
-    def negate(self):
-        return NotAny(self.arg)
-
-
-@public
-class NotAny(Any):
-    def negate(self):
-        return Any(self.arg)
 
 
 public(WindowOp=Window, AnalyticOp=Analytic)

--- a/ibis/expr/operations/logical.py
+++ b/ibis/expr/operations/logical.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+import abc
+
 from public import public
 
+from ibis.common.validators import immutable_property
 from ibis.expr import datatypes as dt
 from ibis.expr import rules as rlz
 from ibis.expr.operations.core import Binary, Unary, Value
@@ -179,7 +184,7 @@ class _AnyBase(Value):
             return rlz.Shape.COLUMNAR
 
     @abc.abstractmethod
-    def negate(self):  # pragma: no cover
+    def negate(self):
         ...
 
 

--- a/ibis/expr/operations/logical.py
+++ b/ibis/expr/operations/logical.py
@@ -184,7 +184,7 @@ class _AnyBase(Value):
             return rlz.Shape.COLUMNAR
 
     @abc.abstractmethod
-    def negate(self):
+    def negate(self):  # pragma: no cover
         ...
 
 

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -758,15 +758,15 @@ class ExistsSubquery(Value):
 
     output_dtype = dt.boolean
     output_shape = rlz.Shape.COLUMNAR
-    output_type = ir.Exists
 
 
 @public
-class NotExistsSubquery(Node):
+class NotExistsSubquery(Value):
     foreign_table = rlz.table
     predicates = rlz.tuple_of(rlz.boolean)
 
-    output_type = ir.Exists
+    output_dtype = dt.boolean
+    output_shape = rlz.Shape.COLUMNAR
 
 
 @public

--- a/ibis/expr/types/analytic.py
+++ b/ibis/expr/types/analytic.py
@@ -17,6 +17,10 @@ class Analytic(Expr):
 
 
 @public
+@deprecated(
+    instead="remove usage of Exists/ExistsExpr, it will be removed",
+    version="4.0.0",
+)
 class Exists(Analytic):
     # TODO(kszucs): should be removed
     def type(self):

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -73,12 +73,7 @@ class BooleanValue(NumericValue):
     __rxor__ = __xor__
 
     def __invert__(self) -> BooleanValue:
-        from ibis.expr import operations as ops
-
-        try:
-            return self.negate()
-        except AttributeError:
-            return ops.Not(self).to_expr()
+        return self.negate()
 
 
 @public

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -75,6 +75,12 @@ class BooleanValue(NumericValue):
     def __invert__(self) -> BooleanValue:
         return self.negate()
 
+    @staticmethod
+    def __negate_op__():
+        from ibis.expr import operations as ops
+
+        return ops.Not
+
 
 @public
 class BooleanScalar(NumericScalar, BooleanValue):

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -75,7 +75,10 @@ class BooleanValue(NumericValue):
     def __invert__(self) -> BooleanValue:
         from ibis.expr import operations as ops
 
-        return ops.Not(self).to_expr()
+        try:
+            return self.negate()
+        except AttributeError:
+            return ops.Not(self).to_expr()
 
 
 @public

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -14,6 +14,12 @@ if TYPE_CHECKING:
 
 @public
 class NumericValue(Value):
+    @staticmethod
+    def __negate_op__():
+        from ibis.expr import operations as ops
+
+        return ops.Negate
+
     def negate(self) -> NumericValue:
         """Negate a numeric expression.
 
@@ -22,13 +28,12 @@ class NumericValue(Value):
         NumericValue
             A numeric value expression
         """
-        from ibis.expr import operations as ops
-
         op = self.op()
-        if hasattr(op, 'negate'):
+        try:
             result = op.negate()
-        else:
-            result = ops.Negate(self)
+        except AttributeError:
+            op_class = self.__negate_op__()
+            result = op_class(self)
 
         return result.to_expr()
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1261,7 +1261,7 @@ def _resolve_predicates(
         if isinstance(pred, ir.TopK):
             top_ks.append(pred._semi_join_components())
         elif isinstance(pred.op(), ops.logical._AnyBase):
-            transform = _AnyToExistsTransform(pred, table)
+            transform = an._AnyToExistsTransform(pred, table)
             resolved_predicates.append(transform.get_result())
         else:
             resolved_predicates.append(pred)
@@ -1289,81 +1289,3 @@ def find_base_table(expr):
 
 
 public(TableExpr=Table)
-
-
-class _AnyToExistsTransform:
-
-    """
-    Some code duplication with the correlated ref check; should investigate
-    better code reuse.
-    """
-
-    def __init__(self, expr, parent_table):
-        self.expr = expr
-        self.parent_table = parent_table
-        self.query_roots = frozenset(self.parent_table.op().root_tables())
-
-    def get_result(self):
-        import ibis.expr.operations as ops
-
-        self.foreign_table = None
-        self.predicates = []
-
-        self._visit(self.expr)
-
-        op = self.expr.op()
-
-        if isinstance(op, ops.Any):
-            op_class = ops.ExistsSubquery
-        else:
-            assert isinstance(op, ops.NotAny)
-            op_class = ops.NotExistsSubquery
-
-        return op_class(self.foreign_table, self.predicates).to_expr()
-
-    def _visit(self, expr):
-        import ibis.expr.analysis as L
-        import ibis.expr.types as ir
-
-        node = expr.op()
-
-        for arg in node.flat_args():
-            if isinstance(arg, ir.Table):
-                self._visit_table(arg)
-            elif isinstance(arg, ir.BooleanColumn):
-                for sub_expr in L.flatten_predicate(arg):
-                    self.predicates.append(sub_expr)
-                    self._visit(sub_expr)
-            elif isinstance(arg, ir.Expr):
-                self._visit(arg)
-
-    def _find_blocking_table(self, expr):
-        import ibis.expr.types as ir
-
-        node = expr.op()
-
-        if node.blocks():
-            return expr
-
-        return next(
-            (
-                result
-                for arg in node.flat_args()
-                if (
-                    isinstance(arg, ir.Expr)
-                    and (result := self._find_blocking_table(arg)) is not None
-                )
-            ),
-            None,
-        )
-
-    def _visit_table(self, expr):
-        import ibis.expr.types as ir
-
-        if isinstance(expr, ir.Table):
-            base_table = self._find_blocking_table(expr)
-            if (
-                base_table is not None
-                and base_table.op() not in self.query_roots
-            ):
-                self.foreign_table = expr

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -622,6 +622,12 @@ class IntervalValue(Value):
 
     __neg__ = negate
 
+    @staticmethod
+    def __negate_op__():
+        import ibis.expr.operations as ops
+
+        return ops.Negate
+
 
 @public
 class IntervalScalar(Scalar, IntervalValue):

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -466,7 +466,7 @@ def test_casted_exprs_are_named(table):
     expr.value_counts()
 
 
-@pytest.mark.parametrize('col', list('abcdefh'))
+@pytest.mark.parametrize('col', list('abcdef'))
 def test_negate(table, col):
     c = table[col]
     result = -c
@@ -474,10 +474,19 @@ def test_negate(table, col):
     assert isinstance(result.op(), ops.Negate)
 
 
-def test_negate_boolean_scalar():
-    result = -(ibis.literal(False))
+@pytest.mark.parametrize("op", [operator.neg, operator.invert])
+@pytest.mark.parametrize("value", [True, False])
+def test_negate_boolean_scalar(op, value):
+    result = op(ibis.literal(value))
     assert isinstance(result, ir.BooleanScalar)
-    assert isinstance(result.op(), ops.Negate)
+    assert isinstance(result.op(), ops.Not)
+
+
+@pytest.mark.parametrize("op", [operator.neg, operator.invert])
+def test_negate_boolean_column(table, op):
+    result = op(table["h"])
+    assert isinstance(result, ir.BooleanColumn)
+    assert isinstance(result.op(), ops.Not)
 
 
 @pytest.mark.parametrize('column', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'])


### PR DESCRIPTION
This PR moves the transformation of `.any()`/`.notany()` filters with outer
table references to happen at expression construction time, rather than the
current phase which is inside the compiler.

The changes are motivated by the following requirements:

1. Allow representation of `EXISTS` queries using Substrait
2. Simplify the codebase by moving towards removing rewrites during
   compilation.

This PR fixes the modeling of `EXISTS` which is currently incorrectly modeled
as an analytic expression.

`EXISTS` expressions are nothing more than fancy predicates so they are modeled
as `BooleanColumn`s here.
