### PR TITLE
fix: don't mask udf module in __init__.py

### DIFF
--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -12,7 +12,7 @@ from ibis import util
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.postgres.compiler import PostgreSQLCompiler
 from ibis.backends.postgres.datatypes import _get_type
-from ibis.backends.postgres.udf import udf
+from ibis.backends.postgres.udf import udf as _udf
 
 
 class Backend(BaseAlchemyBackend):
@@ -170,7 +170,7 @@ class Backend(BaseAlchemyBackend):
         inheriting from PostgresUDFNode
         """
 
-        return udf(
+        return _udf(
             client=self,
             python_func=pyfunc,
             in_types=in_types,


### PR DESCRIPTION
This is only an issue with the `postgres` backend -- there's a
_function_ called `udf` inside of the `postgres.udf` _module_ and we
import that function into the `ibis.backends.postgres` namespace, which
then prevents direct access to the module itself, e.g.

you can
```python
from ibis.backends.postgres.udf import existing_udf
existing_udf(...)
```

but can't
```python
ibis.backends.postgres.udf.existing_udf(...)
```

I aliases the import to avoid the collision.