### PR TITLE
refactor: move filter rewriting to expression construction

### DIFF
--- a/ibis/backends/base/sql/registry/binary_infix.py
+++ b/ibis/backends/base/sql/registry/binary_infix.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Literal
 
 import ibis.expr.types as ir

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -1175,3 +1175,8 @@ def execute_rowid(op, *args, **kwargs):
     raise com.UnsupportedOperationError(
         'rowid is not supported in pandas backends'
     )
+
+
+@execute_node.register(ops.TableArrayView, pd.DataFrame)
+def execute_table_array_view(op, _, **kwargs):
+    return execute(op.table).squeeze()

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -476,9 +476,9 @@ def test_isin_notin(backend, alltypes, df, ibis_op, pandas_op):
             id="isin_col",
         ),
         param(
-            (_.bigint_col + 1).isin(_.string_col.cast("int64") + 1),
-            lambda df: (df.bigint_col + 1).isin(
-                df.string_col.astype("int64") + 1
+            (_.bigint_col + 1).isin(_.string_col.length() + 1),
+            lambda df: df.bigint_col.add(1).isin(
+                df.string_col.str.len().add(1)
             ),
             id="isin_expr",
         ),
@@ -488,9 +488,9 @@ def test_isin_notin(backend, alltypes, df, ibis_op, pandas_op):
             id="notin_col",
         ),
         param(
-            (_.bigint_col + 1).notin(_.string_col.cast("int64") + 1),
-            lambda df: ~(df.bigint_col + 1).isin(
-                df.string_col.astype("int64") + 1
+            (_.bigint_col + 1).notin(_.string_col.length() + 1),
+            lambda df: ~(df.bigint_col.add(1)).isin(
+                df.string_col.str.len().add(1)
             ),
             id="notin_expr",
         ),

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import operator
+from typing import AbstractSet, MutableSequence
 
 import toolz
 
@@ -1132,23 +1133,24 @@ def is_scalar_reduction(expr):
 
 
 class _AnyToExistsTransform:
+    __slots__ = (
+        "expr",
+        "parent_table",
+        "query_roots",
+        "foreign_table",
+        "predicates",
+    )
 
-    """
-    Some code duplication with the correlated ref check; should investigate
-    better code reuse.
-    """
-
-    def __init__(self, expr, parent_table):
+    def __init__(self, expr: ir.Expr, parent_table: ir.Table) -> None:
         self.expr = expr
         self.parent_table = parent_table
-        self.query_roots = frozenset(self.parent_table.op().root_tables())
+        self.query_roots: AbstractSet[ops.TableNode] = frozenset(
+            self.parent_table.op().root_tables()
+        )
+        self.foreign_table: ir.Table | None = None
+        self.predicates: MutableSequence[ir.BooleanValue] = []
 
-    def get_result(self):
-        import ibis.expr.operations as ops
-
-        self.foreign_table = None
-        self.predicates = []
-
+    def get_result(self) -> ir.BooleanColumn:
         self._visit(self.expr)
 
         op = self.expr.op()
@@ -1161,25 +1163,20 @@ class _AnyToExistsTransform:
 
         return op_class(self.foreign_table, self.predicates).to_expr()
 
-    def _visit(self, expr):
-        import ibis.expr.analysis as L
-        import ibis.expr.types as ir
-
+    def _visit(self, expr: ir.Expr) -> None:
         node = expr.op()
 
         for arg in node.flat_args():
             if isinstance(arg, ir.Table):
                 self._visit_table(arg)
             elif isinstance(arg, ir.BooleanColumn):
-                for sub_expr in L.flatten_predicate(arg):
+                for sub_expr in flatten_predicate(arg):
                     self.predicates.append(sub_expr)
                     self._visit(sub_expr)
             elif isinstance(arg, ir.Expr):
                 self._visit(arg)
 
-    def _find_blocking_table(self, expr):
-        import ibis.expr.types as ir
-
+    def _find_blocking_table(self, expr: ir.Expr) -> ir.Expr:
         node = expr.op()
 
         if node.blocks():
@@ -1197,16 +1194,13 @@ class _AnyToExistsTransform:
             None,
         )
 
-    def _visit_table(self, expr):
-        import ibis.expr.types as ir
-
-        if isinstance(expr, ir.Table):
-            base_table = self._find_blocking_table(expr)
-            if (
-                base_table is not None
-                and base_table.op() not in self.query_roots
-            ):
-                self.foreign_table = expr
+    def _visit_table(self, expr: ir.Expr) -> None:
+        if (
+            isinstance(expr, ir.Table)
+            and (base_table := self._find_blocking_table(expr)) is not None
+            and base_table.op() not in self.query_roots
+        ):
+            self.foreign_table = expr
 
 
 @functools.singledispatch
@@ -1238,9 +1232,10 @@ def _rewrite_filter_subqueries(_, expr, **kwargs):
 @_rewrite_filter.register(ops.Alias)
 def _rewrite_filter_alias(op, _, name: str | None = None, **kwargs):
     """Rewrite filters on aliases."""
+    arg = op.arg
     return _rewrite_filter(
-        op.arg.op(),
-        op.arg,
+        arg.op(),
+        arg,
         name=name if name is not None else op.name,
         **kwargs,
     )

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -738,7 +738,13 @@ class Table(Expr):
         child = self
         for predicate, right in top_ks:
             child = child.semi_join(right, predicate)[child]
-        return an.apply_filter(child, resolved_predicates)
+        return an.apply_filter(
+            child,
+            [
+                an._rewrite_filter(pred.op(), pred)
+                for pred in resolved_predicates
+            ],
+        )
 
     def count(self) -> ir.IntegerScalar:
         """Compute the number of rows in the table.

--- a/ibis/tests/sql/test_select_sql.py
+++ b/ibis/tests/sql/test_select_sql.py
@@ -785,21 +785,21 @@ def test_filter_subquery_derived_reduction(filter_subquery_derived_reduction):
     result = Compiler.to_sql(expr3)
     expected = """SELECT *
 FROM star1
-WHERE `f` > (
-  SELECT ln(avg(`f`)) AS `tmp`
+WHERE `f` > ln((
+  SELECT avg(`f`) AS `mean`
   FROM star1
   WHERE `foo_id` = 'foo'
-)"""
+))"""
     assert result == expected
 
     result = Compiler.to_sql(expr4)
     expected = """SELECT *
 FROM star1
-WHERE `f` > (
-  SELECT ln(avg(`f`)) + 1 AS `tmp`
+WHERE `f` > ln((
+  SELECT avg(`f`) AS `mean`
   FROM star1
   WHERE `foo_id` = 'foo'
-)"""
+)) + 1"""
     assert result == expected
 
 


### PR DESCRIPTION
- refactor: rewrite filters at expression construction time
- chore(pandas/dask): implement TableArrayView
- chore: don't rewrite filters with Window operations
