### PR TITLE
refactor(ir): deprecate ibis.prevent_rewrite

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1098,6 +1098,7 @@ class Table(Expr):
             suffixes=suffixes,
         )
 
+    @util.deprecated(version="4.0", instead="")
     def prevent_rewrite(self, client=None) -> Table:
         """Prevent optimization from happening below this expression.
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1099,7 +1099,7 @@ class Table(Expr):
         )
 
     @util.deprecated(version="4.0", instead="")
-    def prevent_rewrite(self, client=None) -> Table:
+    def prevent_rewrite(self, client=None) -> Table:  # pragma: no cover
         """Prevent optimization from happening below this expression.
 
         Only valid on SQL-string generating backends.


### PR DESCRIPTION
Doesn't seem to be used anywhere else than in an ibis-bigquery test case: https://github.com/ibis-project/ibis-bigquery/blob/9dc580800d607b809433bb2a3f2da2ba43b2f679/tests/system/test_client.py#L643

cc @tswast