### PR TITLE
feat: implement zeroifnull for most remaining backends

### DIFF
--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -61,6 +61,7 @@ from ibis.backends.pandas.execution.generic import (
     execute_series_notnnull,
     execute_sort_key_series_bool,
     execute_table_column_df_or_df_groupby,
+    execute_zero_if_null_series,
 )
 
 # Many dask and pandas functions are functionally equivalent, so we just add
@@ -150,6 +151,13 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
         ((dd.Series, simple_types), execute_node_nullif_series_scalar),
     ],
     ops.Distinct: [((dd.DataFrame,), execute_distinct_dataframe)],
+    ops.ZeroIfNull: [
+        ((dd.Series,), execute_zero_if_null_series),
+        (
+            (type(None), type(pd.NA), np.floating, float),
+            execute_zero_if_null_series,
+        ),
+    ],
 }
 
 register_types_to_dispatcher(execute_node, DASK_DISPATCH_TYPES)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -2012,3 +2012,9 @@ def compile_degrees(t, expr, scope, timecontext, **kwargs):
 @compiles(ops.Radians)
 def compile_radians(t, expr, scope, timecontext, **kwargs):
     return F.radians(t.translate(expr.op().arg, scope, timecontext, **kwargs))
+
+
+@compiles(ops.ZeroIfNull)
+def compile_zero_if_null(t, expr, scope, timecontext, **kwargs):
+    col = t.translate(expr.op().arg, scope, timecontext, **kwargs)
+    return F.when(col.isNull() | F.isnan(col), F.lit(0)).otherwise(col)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -546,7 +546,7 @@ def test_logical_negation_column(backend, alltypes, df, op):
     backend.assert_series_equal(result, expected, check_names=False)
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+@pytest.mark.notimpl(["dask", "datafusion"])
 @pytest.mark.parametrize(
     ("dtype", "zero", "expected"),
     [("int64", 0, 1), ("float64", 0.0, 1.0)],
@@ -559,9 +559,9 @@ def test_zeroifnull_literals(con, dtype, zero, expected):
     )
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+@pytest.mark.notimpl(["dask", "datafusion"])
 def test_zeroifnull_column(backend, alltypes, df):
     expr = alltypes.int_col.nullif(1).zeroifnull()
-    result = expr.execute()
-    expected = df.int_col.replace(1, 0).rename("tmp")
+    result = expr.execute().astype("int32")
+    expected = df.int_col.replace(1, 0).rename("tmp").astype("int32")
     backend.assert_series_equal(result, expected)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -546,7 +546,7 @@ def test_logical_negation_column(backend, alltypes, df, op):
     backend.assert_series_equal(result, expected, check_names=False)
 
 
-@pytest.mark.notimpl(["dask", "datafusion"])
+@pytest.mark.notimpl(["datafusion"])
 @pytest.mark.parametrize(
     ("dtype", "zero", "expected"),
     [("int64", 0, 1), ("float64", 0.0, 1.0)],
@@ -559,7 +559,7 @@ def test_zeroifnull_literals(con, dtype, zero, expected):
     )
 
 
-@pytest.mark.notimpl(["dask", "datafusion"])
+@pytest.mark.notimpl(["datafusion"])
 def test_zeroifnull_column(backend, alltypes, df):
     expr = alltypes.int_col.nullif(1).zeroifnull()
     result = expr.execute().astype("int32")

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -546,7 +546,7 @@ def test_logical_negation_column(backend, alltypes, df, op):
     backend.assert_series_equal(result, expected, check_names=False)
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pandas", "pyspark"])
+@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
 @pytest.mark.parametrize(
     ("dtype", "zero", "expected"),
     [("int64", 0, 1), ("float64", 0.0, 1.0)],
@@ -559,7 +559,7 @@ def test_zeroifnull_literals(con, dtype, zero, expected):
     )
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pandas", "pyspark"])
+@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
 def test_zeroifnull_column(backend, alltypes, df):
     expr = alltypes.int_col.nullif(1).zeroifnull()
     result = expr.execute()


### PR DESCRIPTION
- test(generic): add zeroifnull tests
- feat(sqlalchemy): implement zeroifnull
- feat(pyspark): implement zeroifnull
- test(pandas): enable zeroifnull test
- feat(pandas): implement zeroifnull
- test(dask): enable zeroifnull tests
- feat(dask): implement zeroifnull
