### PR TITLE
feat: implement covariance and correlation where possible

### DIFF
--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -150,6 +150,15 @@ def _agg_variance_like(func):
     return formatter
 
 
+def _corr(translator, expr):
+    op = expr.op()
+    if op.how == "pop":
+        raise ValueError(
+            "ClickHouse only implements `sample` correlation coefficient"
+        )
+    return _aggregate(translator, "corr", op.left, op.right, where=op.where)
+
+
 def _call(translator, func, *args):
     args_ = ', '.join(map(translator.translate, args))
     return f'{func!s}({args_!s})'
@@ -714,6 +723,8 @@ operation_registry = {
     ops.ArrayCollect: _agg('groupArray'),
     ops.StandardDev: _agg_variance_like('stddev'),
     ops.Variance: _agg_variance_like('var'),
+    ops.Covariance: _agg_variance_like('covar'),
+    ops.Correlation: _corr,
     ops.GroupConcat: _group_concat,
     ops.Count: _agg('count'),
     ops.CountDistinct: _agg('uniq'),

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -64,7 +64,7 @@ class Backend(BasePandasBackend):
         limit: str = 'default',
         **kwargs,
     ):
-        if limit != 'default':
+        if limit != 'default' and limit is not None:
             raise ValueError(
                 'limit parameter to execute is not yet implemented in the '
                 'dask backend'

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -200,7 +200,7 @@ class Backend(BasePandasBackend):
     def execute(self, query, params=None, limit='default', **kwargs):
         from ibis.backends.pandas.core import execute_and_reset
 
-        if limit != 'default':
+        if limit != 'default' and limit is not None:
             raise ValueError(
                 'limit parameter to execute is not yet implemented in the '
                 'pandas backend'

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -200,8 +200,6 @@ def test_aggregate_grouped(
                         "impala",
                         "mysql",
                         "pandas",
-                        "postgres",
-                        "pyspark",
                         "sqlite",
                     ]
                 )
@@ -220,8 +218,6 @@ def test_aggregate_grouped(
                         "impala",
                         "mysql",
                         "pandas",
-                        "postgres",
-                        "pyspark",
                         "sqlite",
                     ]
                 )

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -195,7 +195,6 @@ def test_aggregate_grouped(
             marks=[
                 pytest.mark.notimpl(
                     [
-                        "clickhouse",
                         "dask",
                         "duckdb",
                         "impala",


### PR DESCRIPTION
This PR implements covariance and correlation for the backends that support it.

Correlation in particular is odd in that there don't seem to be any backend
that we support that implement both population and sample correlation, despite
many of them implementing population and sample variance, standard deviation,
and covariance.

Here's the support matrix for correlation among the backends:

| Backend    | Population | Sample |
|------------|------------|--------|
| ClickHouse | ❌         | ✅     |
| Dask       | ❌         | ✅     |
| DuckDB     | ✅         | ❌     |
| Impala     | ❌         | ❌     |
| MySQL      | ❌         | ❌     |
| Pandas     | ❌         | ✅     |
| PostgreSQL | ✅         | ❌     |
| PySpark    | ❌         | ✅     |
| SQLite     | ❌         | ❌     |

To make this more difficult I don't think any of the backends document which of
the population or sample correlation coefficient is implemented.
