### PR TITLE
refactor: increase coverage of `select_builder.py`

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -40,7 +40,7 @@ class _CorrelatedRefCheck:
 
         visit_cache.add(key)
 
-        in_subquery = in_subquery or self.is_subquery(node)
+        in_subquery |= self.is_subquery(node)
 
         for arg in node.flat_args():
             if isinstance(arg, ir.Table):
@@ -59,21 +59,17 @@ class _CorrelatedRefCheck:
                 )
 
     def is_subquery(self, node):
-        # XXX
-        if isinstance(
+        return isinstance(
             node,
             (
                 ops.TableArrayView,
                 ops.ExistsSubquery,
                 ops.NotExistsSubquery,
             ),
-        ):
-            return True
-
-        if isinstance(node, ops.TableColumn):
-            return not self.is_root(node.table)
-
-        return False
+        ) or (
+            isinstance(node, ops.TableColumn)
+            and not self.is_root(node.table.op())
+        )
 
     def visit_table(
         self, expr, in_subquery=False, visit_cache=None, visit_table_cache=None

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -579,7 +579,13 @@ class SelectBuilder:
             self.table_set = table
             self.filters = filters
 
-    def _collect_MaterializedJoin(self, expr, toplevel=False):
+    @util.deprecated(
+        version="3.0.0",
+        instead="do nothing; MaterializedJoin is removed",
+    )
+    def _collect_MaterializedJoin(
+        self, expr, toplevel=False
+    ):  # pragma: no cover
         op = expr.op()
         join = op.join
 

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -157,8 +157,6 @@ class SelectBuilder:
         self.subqueries = []
         self.distinct = False
 
-        self.op_memo = set()
-
         # make idempotent
         if self.queries:
             return self._wrap_result()
@@ -489,10 +487,6 @@ class SelectBuilder:
         op = expr.op()
         method = f'_collect_{type(op).__name__}'
 
-        # Do not visit nodes twice
-        if op in self.op_memo:
-            return
-
         if hasattr(self, method):
             f = getattr(self, method)
             f(expr, toplevel=toplevel)
@@ -502,8 +496,6 @@ class SelectBuilder:
             self._collect_Join(expr, toplevel=toplevel)
         else:
             raise NotImplementedError(type(op))
-
-        self.op_memo.add(op)
 
     def _collect_Distinct(self, expr, toplevel=False):
         if toplevel:

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -570,7 +570,7 @@ class SelectBuilder:
                 sort_keys = sop.sort_keys
                 table = sop.table
 
-            if len(selections) == 0:
+            if not selections:
                 # select *
                 selections = [table]
 


### PR DESCRIPTION
- refactor: tighten up `is_subquery` check
- refactor: reduce the amount of branching in `is_root`
- chore: remove unused `op_memo` field
- style: check for truthiness not length
- chore: add `deprecated` to `_collect_MaterializedJoin` and prevent coverage
