### PR TITLE
refactor(ir): split `Any`/`NotAny` to reduction and `Exists`/`NotExists` subquery operators

### DIFF
--- a/.github/workflows/ibis-tpch-queries.yml
+++ b/.github/workflows/ibis-tpch-queries.yml
@@ -22,10 +22,11 @@ jobs:
 
       - name: install python
         uses: actions/setup-python@v3
+        id: install_python
         with:
           python-version: "3.10"
 
-      - run: python -m pip install --upgrade pip click sqlparse
+      - run: python -m pip install --upgrade pip click sqlparse coverage
 
       - name: install ibis
         run: python -m pip install ".[duckdb]"
@@ -43,4 +44,16 @@ jobs:
 
       - name: run tpc-h queries
         working-directory: tpc-queries
-        run: ./runtpc -i ibis -i duckdb -d 'tpch.ddb' -b 'duckdb'
+        run: coverage run --rcfile=../.coveragerc ./runtpc -i ibis -i duckdb -d 'tpch.ddb' -b 'duckdb'
+
+      - name: generate coverage report
+        working-directory: tpc-queries
+        run: coverage xml --rcfile=../.coveragerc -o ./junit.xml
+
+      - name: upload code coverage
+        if: success()
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./tpc-queries/junit.xml
+          fail_ci_if_error: true
+          flags: tpc,tpch,duckdb,${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -417,8 +417,7 @@ class SelectBuilder:
         version="4.0.0",
     )
     def _visit_filter_Any(self, expr):  # pragma: no cover
-        transform = L._AnyToExistsTransform(expr, self.table_set)
-        return transform.get_result()
+        return expr
 
     _visit_filter_NotAny = _visit_filter_Any
 

--- a/ibis/backends/impala/udf.py
+++ b/ibis/backends/impala/udf.py
@@ -81,9 +81,7 @@ class AggregateFunction(Function):
             f'_{i}': rlz.value(dtype) for i, dtype in enumerate(self.inputs)
         }
         fields['output_dtype'] = self.output
-        fields['output_shape'] = rlz.Shape.SCALAR
-        fields['_reduction'] = True
-        return type(f"UDA_{self.name}", (ops.Value,), fields)
+        return type(f"UDA_{self.name}", (ops.Reduction,), fields)
 
 
 class ImpalaFunction:

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -256,7 +256,7 @@ def test_multiple_inheritance():
         arg = InstanceOf(object)
 
     class Reduction(Value):
-        _reduction = True
+        pass
 
     class UDF(Value):
         func = ValidatorFunction(lambda fn, this: fn)
@@ -280,7 +280,6 @@ def test_multiple_inheritance():
     strlen = UDAF(arg=2, func=lambda value: len(str(value)), arity=1)
     assert strlen.arg == 2
     assert strlen.arity == 1
-    assert strlen._reduction is True
 
 
 @pytest.mark.parametrize(
@@ -302,12 +301,11 @@ def test_multiple_inheritance_argument_order():
         version = IsInt
 
     class Reduction(Annotable):
-        _reduction = True
+        pass
 
     class Sum(VersionedOp, Reduction):
         where = Optional(IsBool, default=False)
 
-    assert Sum._reduction is True
     assert str(Sum.__signature__) == "(arg, version, where=None)"
 
 

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import abc
 import datetime
 import decimal
 import enum
@@ -477,3 +478,9 @@ class SearchedCase(Value):
     def output_dtype(self):
         exprs = [*self.results, self.default]
         return rlz.highest_precedence_dtype(exprs)
+
+
+class _Negatable(abc.ABC):
+    @abc.abstractmethod
+    def negate(self):  # pragma: no cover
+        ...

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from public import public
 
 from ibis.common.validators import immutable_property
@@ -5,12 +7,11 @@ from ibis.expr import datatypes as dt
 from ibis.expr import rules as rlz
 from ibis.expr import types as ir
 from ibis.expr.operations.core import Value, distinct_roots
+from ibis.expr.operations.generic import _Negatable
 
 
 @public
 class Reduction(Value):
-    _reduction = True
-
     output_shape = rlz.Shape.SCALAR
 
 
@@ -250,3 +251,23 @@ class ArrayCollect(Reduction):
     @immutable_property
     def output_dtype(self):
         return dt.Array(self.arg.type())
+
+
+@public
+class Any(Reduction, _Negatable):
+    arg = rlz.column(rlz.boolean)
+
+    output_dtype = dt.boolean
+
+    def negate(self) -> NotAny:
+        return NotAny(*self.args)
+
+
+@public
+class NotAny(Reduction, _Negatable):
+    arg = rlz.column(rlz.boolean)
+
+    output_dtype = dt.boolean
+
+    def negate(self) -> Any:
+        return Any(*self.args)

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -8,11 +8,11 @@ from public import public
 
 from ibis import util
 from ibis.common import exceptions as com
-from ibis.expr import datatypes as dt
 from ibis.expr import rules as rlz
 from ibis.expr import schema as sch
 from ibis.expr import types as ir
-from ibis.expr.operations.core import Node, Value, distinct_roots
+from ibis.expr.operations.core import Node, distinct_roots
+from ibis.expr.operations.logical import ExistsSubquery, NotExistsSubquery
 from ibis.expr.operations.sortkeys import _maybe_convert_sort_keys
 
 _table_names = (f'unbound_table_{i:d}' for i in itertools.count())
@@ -749,24 +749,6 @@ class Distinct(TableNode, sch.HasSchema):
 
 
 @public
-class ExistsSubquery(Value):
-    foreign_table = rlz.table
-    predicates = rlz.tuple_of(rlz.boolean)
-
-    output_dtype = dt.boolean
-    output_shape = rlz.Shape.COLUMNAR
-
-
-@public
-class NotExistsSubquery(Value):
-    foreign_table = rlz.table
-    predicates = rlz.tuple_of(rlz.boolean)
-
-    output_dtype = dt.boolean
-    output_shape = rlz.Shape.COLUMNAR
-
-
-@public
 class FillNa(TableNode, sch.HasSchema):
     """Fill null values in the table."""
 
@@ -865,3 +847,6 @@ def _dedup_join_columns(
         for column in right.columns
     ]
     return expr.projection(left_projections + right_projections)
+
+
+public(ExistsSubquery=ExistsSubquery, NotExistsSubquery=NotExistsSubquery)

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -90,14 +90,16 @@ class BooleanScalar(NumericScalar, BooleanValue):
 @public
 class BooleanColumn(NumericColumn, BooleanValue):
     def any(self) -> BooleanValue:
+        import ibis.expr.analysis as L
         from ibis.expr import operations as ops
 
-        return ops.Any(self).to_expr()
+        return L._make_any(self, ops.Any)
 
     def notany(self) -> BooleanValue:
+        import ibis.expr.analysis as L
         from ibis.expr import operations as ops
 
-        return ops.NotAny(self).to_expr()
+        return L._make_any(self, ops.NotAny)
 
     def all(self) -> BooleanScalar:
         from ibis.expr import operations as ops

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1252,9 +1252,8 @@ def _resolve_predicates(
     for pred in predicates:
         if isinstance(pred, ir.TopK):
             top_ks.append(pred._semi_join_components())
-        elif isinstance(pred.op(), ops.logical._AnyBase):
-            transform = an._AnyToExistsTransform(pred, table)
-            resolved_predicates.append(transform.get_result())
+        elif isinstance(pred_op := pred.op(), ops.logical._UnresolvedSubquery):
+            resolved_predicates.append(pred_op._resolve(table))
         else:
             resolved_predicates.append(pred)
 


### PR DESCRIPTION
This PR splits `Any` and `NotAny` into their reduction versions with the same names,
and the previously-mashed-together `ExistSubquery` while preserving the `.any()` API and semantics.

This is a backwards compatible expression API change, but the value of `.op()`
is different.

It's slightly more optimistic than that though, because we're only moving the
time at which `ExistSubquery` is constructed to earlier in the expression
construction pipeline. Previously it was happening right after a user called
`.compile()` whereas now the transformation happens any time a user calls `.any()`.

Closes #3925.
