### PR TITLE
perf(lineage): fix large construction perf regression

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -1081,7 +1081,13 @@ def find_subqueries(expr: ir.Expr) -> Counter:
             return lin.proceed, None
 
     counts = Counter()
-    iterator = lin.traverse(functools.partial(predicate, counts), expr)
+    iterator = lin.traverse(
+        functools.partial(predicate, counts),
+        expr,
+        # keep duplicates so we can determine where an expression is used
+        # more than once
+        dedup=False,
+    )
     # consume the iterator
     collections.deque(iterator, maxlen=0)
     return counts

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -137,7 +137,7 @@ proceed = True
 halt = False
 
 
-def traverse(fn, expr, type=ir.Expr, container=Stack):
+def traverse(fn, expr, type=ir.Expr, container=Stack, dedup=True):
     """Utility for generic expression tree traversal
 
     Parameters
@@ -156,10 +156,17 @@ def traverse(fn, expr, type=ir.Expr, container=Stack):
     """
     args = expr if isinstance(expr, collections.abc.Iterable) else [expr]
     todo = container(arg for arg in args if isinstance(arg, type))
+    seen = set()
 
     while todo:
         expr = todo.get()
         op = expr.op()
+
+        if dedup:
+            if op in seen:
+                continue
+            else:
+                seen.add(op)
 
         control, result = fn(expr)
         if result is not None:

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import collections
 import itertools
+from typing import Any, Callable, Iterable, Iterator
 
 from toolz import compose, identity
 
@@ -137,22 +140,29 @@ proceed = True
 halt = False
 
 
-def traverse(fn, expr, type=ir.Expr, container=Stack, dedup=True):
+def traverse(
+    fn: Callable[[ir.Expr], tuple[bool | Iterable, Any]],
+    expr: ir.Expr | Iterable[ir.Expr],
+    type: type = ir.Expr,
+    container: Container = Stack,
+    dedup: bool = True,
+) -> Iterator[Any]:
     """Utility for generic expression tree traversal
 
     Parameters
     ----------
-    fn : Callable[[ir.Expr], Tuple[Union[Boolean, Iterable], Any]]
-        This function will be applied on each expressions, it must
-        return a tuple. The first element of the tuple controls the
-        traversal, and the second is the result if its not None.
-    expr: ir.Expr
+    fn
+        A function applied on each expression. The first element of the tuple
+        controls the traversal, and the second is the result if its not `None`.
+    expr
         The traversable expression or a list of expressions.
-    type: Type
-        Only the instances if this expression type gets traversed.
-    container: Union[Stack, Queue], default Stack
-        Defines the traversing order. Use Stack for depth-first and
-        Queue for breadth-first search.
+    type
+        Only the instances if this type are traversed.
+    container
+        Defines the traversal order. Use `Stack` for depth-first order and
+        `Queue` for breadth-first order.
+    dedup
+        Whether to allow expression traversal more than once
     """
     args = expr if isinstance(expr, collections.abc.Iterable) else [expr]
     todo = container(arg for arg in args if isinstance(arg, type))

--- a/justfile
+++ b/justfile
@@ -77,8 +77,8 @@ load-data *backends="all":
     python ci/datamgr.py -v load {{ backends }}
 
 # run the benchmark suite
-bench *args:
-    pytest --benchmark-only ibis/tests/benchmarks --benchmark-autosave {{ args }}
+bench +args='ibis/tests/benchmarks':
+    pytest --benchmark-only --benchmark-autosave {{ args }}
 
 # check for invalid links in a locally built version of the docs
 checklinks *args:


### PR DESCRIPTION
- perf(lineage): ensure that expressions are not traversed multiple times in most cases
- build: more reasonable default parameters for `just bench`
