### PR TITLE
feat: implement quantile in more backends

### DIFF
--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -646,10 +646,7 @@ def _quantile(func, *, translate_qs):
                 "clickhouse"
             )
         quantile = translate_qs(q_op.value)
-        if (where := op.where) is not None:
-            return _call(translator, f"{func}If({quantile})", arg, where)
-        else:
-            return _call(translator, f"{func}({quantile})", arg)
+        return _call(translator, f"{func}({quantile})", arg)
 
     return translate
 

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -641,8 +641,9 @@ def _quantile(func, *, translate_qs):
         arg = op.arg
         if not isinstance(q_op := op.quantile.op(), ops.Literal):
             raise TypeError(
-                "clickhouse MultiQuantile only works with a literal list of "
-                "floats"
+                "quantile parameter must be a literal double or array of "
+                "doubles; arbitrary expressions are not supported by "
+                "clickhouse"
             )
         quantile = translate_qs(q_op.value)
         if (where := op.where) is not None:

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -177,10 +177,7 @@ def _quantile(t, expr):
     convert = list if isinstance(quantile_op.value, tuple) else str
     quantile = convert(quantile_op.value)
     lit_quantile = sa.text(str(quantile))
-    agg = sa.func.percentile_cont(lit_quantile).within_group(arg)
-    if (where := op.where) is not None:
-        return sa.funcfilter(agg, t.translate(where))
-    return agg
+    return sa.func.percentile_cont(lit_quantile).within_group(arg)
 
 
 operation_registry.update(

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -41,5 +41,10 @@ def _any_all_no_op(expr):
     return expr
 
 
+@rewrites(ops.CMSMedian)
+def _median(expr):
+    return expr.op().arg.quantile(0.5)
+
+
 class PostgreSQLCompiler(AlchemyCompiler):
     translator_class = PostgreSQLExprTranslator

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -501,8 +501,13 @@ def _string_agg(t, expr):
 def _quantile(t, expr):
     op = expr.op()
     arg = t.translate(op.arg)
-    quantile = t.translate(op.quantile)
-    agg = sa.func.percentile_cont(quantile).within_group(arg)
+    quantile = op.quantile
+    if not isinstance(quantile.op(), ops.Literal):
+        raise TypeError(
+            "quantile parameter must be a literal double or array of doubles; "
+            "arbitrary expressions are not supported by postgres"
+        )
+    agg = sa.func.percentile_cont(t.translate(quantile)).within_group(arg)
     if (where := op.where) is not None:
         return sa.funcfilter(agg, t.translate(where))
     return agg

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -498,6 +498,16 @@ def _string_agg(t, expr):
     return agg
 
 
+def _quantile(t, expr):
+    op = expr.op()
+    arg = t.translate(op.arg)
+    quantile = t.translate(op.quantile)
+    agg = sa.func.percentile_cont(quantile).within_group(arg)
+    if (where := op.where) is not None:
+        return sa.funcfilter(agg, t.translate(where))
+    return agg
+
+
 operation_registry.update(
     {
         ops.Literal: _literal,
@@ -578,5 +588,7 @@ operation_registry.update(
         ),
         ops.ArrayRepeat: _array_repeat,
         ops.Unnest: unary(sa.func.unnest),
+        ops.Quantile: _quantile,
+        ops.MultiQuantile: _quantile,
     }
 )

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -507,10 +507,7 @@ def _quantile(t, expr):
             "quantile parameter must be a literal double or array of doubles; "
             "arbitrary expressions are not supported by postgres"
         )
-    agg = sa.func.percentile_cont(t.translate(quantile)).within_group(arg)
-    if (where := op.where) is not None:
-        return sa.funcfilter(agg, t.translate(where))
-    return agg
+    return sa.func.percentile_cont(t.translate(quantile)).within_group(arg)
 
 
 operation_registry.update(

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -803,7 +803,7 @@ def test_interactive_repr_shows_error(alltypes):
     # #591. Doing this in PostgreSQL because so many built-in functions are
     # not available
 
-    expr = alltypes.double_col.approx_median()
+    expr = alltypes.string_col.hashbytes()
 
     with config.option_context('interactive', True):
         result = repr(expr)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -340,18 +340,16 @@ def test_reduction_ops(
     np.testing.assert_allclose(result, expected)
 
 
-@pytest.mark.notimpl(
+@pytest.mark.notimpl(["dask", "datafusion", "mysql", "pandas", "sqlite"])
+@pytest.mark.parametrize(
+    'cond',
     [
-        "dask",
-        "datafusion",
-        "mysql",
-        "pandas",
-        "postgres",
-        "sqlite",
-    ]
+        param(lambda _: None, id='no_cond'),
+        param(lambda t: t.string_col.isin(['1', '7']), id='is_in'),
+    ],
 )
-def test_approx_median(alltypes):
-    expr = alltypes.double_col.approx_median()
+def test_approx_median(alltypes, cond):
+    expr = alltypes.double_col.approx_median(where=cond(alltypes))
     result = expr.execute()
     assert isinstance(result, float)
 

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -367,16 +367,18 @@ def test_reduction_ops(
     np.testing.assert_allclose(result, expected)
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "mysql", "pandas", "sqlite"])
-@pytest.mark.parametrize(
-    'cond',
+@pytest.mark.notimpl(
     [
-        param(lambda _: None, id='no_cond'),
-        param(lambda t: t.string_col.isin(['1', '7']), id='is_in'),
-    ],
+        "dask",
+        "datafusion",
+        "mysql",
+        "pandas",
+        "postgres",
+        "sqlite",
+    ]
 )
-def test_approx_median(alltypes, cond):
-    expr = alltypes.double_col.approx_median(where=cond(alltypes))
+def test_approx_median(alltypes):
+    expr = alltypes.double_col.approx_median()
     result = expr.execute()
     assert isinstance(result, float)
 

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 from pytest import mark, param
 
+import ibis
 import ibis.expr.datatypes as dt
 from ibis.udf.vectorized import reduction
 
@@ -296,20 +297,46 @@ def test_aggregate_grouped(
             ],
         ),
         param(
-            lambda t, where: t.double_col.quantile(0.5, where=where),
-            lambda t, where: t.double_col[where].quantile(0.5),
+            lambda t, _: t.double_col.quantile(0.5),
+            lambda t, _: t.double_col.quantile(0.5),
             id='quantile',
             marks=pytest.mark.notimpl(
                 ["dask", "impala", "mysql", "pandas", "pyspark", "sqlite"]
             ),
         ),
         param(
-            lambda t, where: t.double_col.quantile([0.25, 0.5], where=where),
-            lambda t, where: t.double_col[where].quantile([0.25, 0.5]),
+            lambda t, _: t.double_col.quantile(ibis.literal(1.0) / 90.9),
+            lambda *_: None,
+            id='quantile_expr',
+            marks=[
+                pytest.mark.notimpl(
+                    ["dask", "datafusion", "pandas", "pyspark", "impala"]
+                ),
+                pytest.mark.notyet(
+                    ["sqlite", "mysql", "postgres", "duckdb", "clickhouse"]
+                ),
+            ],
+        ),
+        param(
+            lambda t, _: t.double_col.quantile([0.25, 0.5]),
+            lambda t, _: t.double_col.quantile([0.25, 0.5]),
             id='multi_quantile',
             marks=pytest.mark.notimpl(
                 ["dask", "impala", "mysql", "pandas", "pyspark", "sqlite"]
             ),
+        ),
+        param(
+            lambda t, _: t.double_col.quantile([ibis.literal(1.0) / 90.9]),
+            lambda *_: None,
+            id='multi_quantile_expr',
+            marks=[
+                pytest.mark.notimpl(
+                    ["dask", "datafusion", "pandas", "pyspark", "impala"]
+                ),
+                pytest.mark.notyet(
+                    ["sqlite", "mysql", "postgres", "duckdb", "clickhouse"]
+                ),
+            ],
         ),
     ],
 )

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -301,7 +301,7 @@ def test_aggregate_grouped(
             lambda t, _: t.double_col.quantile(0.5),
             id='quantile',
             marks=pytest.mark.notimpl(
-                ["dask", "impala", "mysql", "pandas", "pyspark", "sqlite"]
+                ["dask", "impala", "mysql", "pyspark", "sqlite"]
             ),
         ),
         param(
@@ -322,7 +322,7 @@ def test_aggregate_grouped(
             lambda t, _: t.double_col.quantile([0.25, 0.5]),
             id='multi_quantile',
             marks=pytest.mark.notimpl(
-                ["dask", "impala", "mysql", "pandas", "pyspark", "sqlite"]
+                ["dask", "impala", "mysql", "pyspark", "sqlite"]
             ),
         ),
         param(

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -367,16 +367,7 @@ def test_reduction_ops(
     np.testing.assert_allclose(result, expected)
 
 
-@pytest.mark.notimpl(
-    [
-        "dask",
-        "datafusion",
-        "mysql",
-        "pandas",
-        "postgres",
-        "sqlite",
-    ]
-)
+@pytest.mark.notimpl(["dask", "datafusion", "mysql", "pandas", "sqlite"])
 def test_approx_median(alltypes):
     expr = alltypes.double_col.approx_median()
     result = expr.execute()

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -295,6 +295,22 @@ def test_aggregate_grouped(
                 pytest.mark.notyet(["impala", "pyspark"]),
             ],
         ),
+        param(
+            lambda t, where: t.double_col.quantile(0.5, where=where),
+            lambda t, where: t.double_col[where].quantile(0.5),
+            id='quantile',
+            marks=pytest.mark.notimpl(
+                ["dask", "impala", "mysql", "pandas", "pyspark", "sqlite"]
+            ),
+        ),
+        param(
+            lambda t, where: t.double_col.quantile([0.25, 0.5], where=where),
+            lambda t, where: t.double_col[where].quantile([0.25, 0.5]),
+            id='multi_quantile',
+            marks=pytest.mark.notimpl(
+                ["dask", "impala", "mysql", "pandas", "pyspark", "sqlite"]
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -337,7 +337,10 @@ def test_verify(ddl_backend, ddl_con):
         assert ddl_backend.api.verify(expr)
 
 
-@pytest.mark.never(["duckdb"], reason="duckdb supports approximate median")
+@pytest.mark.never(
+    ["duckdb", "postgres"],
+    reason="duckdb and postgres support approximate median",
+)
 def test_not_verify(alchemy_con, alchemy_backend):
     # There is no expression that can't be compiled to any backend
     # Testing `not verify()` only for an expression not supported in postgres

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -201,10 +201,7 @@ def substitute(fn, expr):
     """
     Substitute expressions with other expressions.
     """
-    try:
-        node = expr.op()
-    except AttributeError:
-        return expr
+    node = expr.op()
 
     result = fn(node)
     if result is lin.halt:

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -201,7 +201,10 @@ def substitute(fn, expr):
     """
     Substitute expressions with other expressions.
     """
-    node = expr.op()
+    try:
+        node = expr.op()
+    except AttributeError:
+        return expr
 
     result = fn(node)
     if result is lin.halt:


### PR DESCRIPTION
This PR implements the `Quantile` and `MultiQuantile` (where supported by the
backend) for the ClickHouse, DuckDB and PostgreSQL backends.
