### PR TITLE
docs: make the operation support matrix more accurate

### DIFF
--- a/gen_matrix.py
+++ b/gen_matrix.py
@@ -25,6 +25,19 @@ def get_leaf_classes(op):
             yield from get_leaf_classes(child_class)
 
 
+EXCLUDED_OPS = {
+    # Never translates into anything
+    ops.UnresolvedExistsSubquery,
+    ops.UnresolvedNotExistsSubquery,
+    ops.ScalarParameter,
+}
+
+INCLUDED_OPS = {
+    # Parent class of MultiQuantile so it's ignored by `get_backends()`
+    ops.Quantile,
+}
+
+
 ICONS = {
     True: ":material-check-decagram:{ .verified }",
     False: ":material-cancel:{ .cancel }",
@@ -32,11 +45,11 @@ ICONS = {
 
 
 def main():
-    possible_ops = frozenset(get_leaf_classes(ops.Value))
+    possible_ops = (
+        frozenset(get_leaf_classes(ops.Value)) | INCLUDED_OPS
+    ) - EXCLUDED_OPS
 
-    support = {
-        "operation": [f"`{op.__name__}`" for op in possible_ops],
-    }
+    support = {"operation": [f"`{op.__name__}`" for op in possible_ops]}
     support.update(
         (name, list(map(backend.has_operation, possible_ops)))
         for name, backend in get_backends()

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -167,16 +167,15 @@ class BasePandasBackend(BaseBackend):
     @classmethod
     @lru_cache
     def _get_operations(cls):
-        execution = importlib.import_module(
-            f"ibis.backends.{cls.name}.execution"
-        )
+        backend = f"ibis.backends.{cls.name}"
+
+        execution = importlib.import_module(f"{backend}.execution")
         execute_node = execution.execute_node
 
-        importlib.import_module(f"ibis.backends.{cls.name}.udf")
+        # import UDF to pick up AnalyticVectorizedUDF and others
+        importlib.import_module(f"{backend}.udf")
 
-        dispatch = importlib.import_module(
-            f"ibis.backends.{cls.name}.dispatch"
-        )
+        dispatch = importlib.import_module(f"{backend}.dispatch")
         pre_execute = dispatch.pre_execute
 
         return frozenset(

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -168,8 +168,17 @@ class BasePandasBackend(BaseBackend):
         execution = importlib.import_module(
             f"ibis.backends.{cls.name}.execution"
         )
+        dispatch = importlib.import_module(
+            f"ibis.backends.{cls.name}.dispatch"
+        )
         execute_node = execution.execute_node
-        op_classes = {op for op, *_ in execute_node.funcs.keys()}
+
+        pre_execute = dispatch.pre_execute
+        pre_execute_keys = pre_execute.funcs.keys()
+
+        op_classes = {
+            op for op, *_ in execute_node.funcs.keys() | pre_execute_keys
+        }
         return operation in op_classes or any(
             issubclass(operation, op_impl)
             for op_impl in op_classes


### PR DESCRIPTION
This PR does two things:

1. Makes the operation support matrix more accurate by rolling in the
   pandas/dask UDFs as well as operations like Quantile that are not leaf
   classes but are nevertheless constructed directly in our APIs.
1. Speeds up `hash_operation` by storing the supported operation set in an
   `lru_cache`. This helps shave time on the backends that use single or
   multiple dispatch and require calling `isinstance`/`issubclass`.
