### PR TITLE
fix(ir): make projection fusion more conservative to prevent mutation erasure

### DIFF
--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -196,12 +196,15 @@ FROM (
 WHERE t2.`movieid` IN (
   SELECT `movieid`
   FROM (
-    SELECT t1.*
-    FROM t1
-    WHERE (t1.`userid` = 118205) AND
-          (extract(t1.`datetime`, 'year') > 2001) AND
-          (t1.`userid` = 118205) AND
-          (extract(t1.`datetime`, 'year') < 2009)
+    SELECT `movieid`
+    FROM (
+      SELECT t1.*
+      FROM t1
+      WHERE (t1.`userid` = 118205) AND
+            (extract(t1.`datetime`, 'year') > 2001) AND
+            (t1.`userid` = 118205) AND
+            (extract(t1.`datetime`, 'year') < 2009)
+    ) t5
   ) t4
 )"""
     result = ImpalaCompiler.to_sql(result)

--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -204,8 +204,8 @@ WHERE t2.`movieid` IN (
           (extract(t1.`datetime`, 'year') < 2009)
   ) t4
 )"""
-    compiled_result = ImpalaCompiler.to_sql(result)
-    assert compiled_result == expected
+    result = ImpalaCompiler.to_sql(result)
+    assert result == expected
 
 
 def test_logically_negate_complex_boolean_expr():

--- a/ibis/backends/pyspark/tests/test_window_context_adjustment.py
+++ b/ibis/backends/pyspark/tests/test_window_context_adjustment.py
@@ -351,11 +351,6 @@ def test_rolling_with_non_window_op(client, ibis_windows, spark_range):
     tm.assert_frame_equal(result_pd, expected)
 
 
-@pytest.mark.xfail(
-    reason='Issue #2453 chain mutate() for window op and'
-    'non window op throws error for pyspark backend',
-    strict=True,
-)
 def test_complex_window(client):
     """Test window with different sizes
     mix context adjustment for window op that require context

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -664,6 +664,14 @@ class Projector:
                 ]
             except (AttributeError, IbisTypeError):
                 resolved = clean_exprs
+            else:
+                # if any expressions aren't exactly equivalent then don't try
+                # to fuse them
+                if any(
+                    not res_root_root.equals(res_root)
+                    for res_root_root, res_root in zip(resolved, clean_exprs)
+                ):
+                    return None
         else:
             # joins cannot be used to resolve expressions, but we still may be
             # able to fuse columns from a projection off of a join. In that

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -290,3 +290,11 @@ def test_no_filter_means_no_selection():
     t = ibis.table(dict(a="string"))
     proj = t.filter([])
     assert proj.equals(t)
+
+
+def test_mutate_overwrites_existing_column():
+    t = ibis.table(dict(a="string"))
+    mut = t.mutate(a=42).select(["a"])
+    sel = mut.op().selections[0].op().table.op().selections[0].op().arg
+    assert isinstance(sel.op(), ops.Literal)
+    assert sel.op().value == 42

--- a/ibis/tests/sql/test_select_sql.py
+++ b/ibis/tests/sql/test_select_sql.py
@@ -423,7 +423,23 @@ def test_projection_filter_fuse(projection_fuse_filter):
     sql3 = Compiler.to_sql(expr3)
 
     assert sql1 == sql2
-    assert sql1 == sql3
+
+    # ideally sql1 == sql3 but the projection logic has been a mess for a long
+    # time and causes bugs like
+    #
+    # https://github.com/ibis-project/ibis/issues/4003
+    #
+    # so we're conservative in fusing projections and filters
+    #
+    # even though it may seem obvious what to do, it's not
+    expected_sql3 = """\
+SELECT `a`, `b`, `c`
+FROM (
+  SELECT *
+  FROM foo
+  WHERE `a` > 0
+) t0"""
+    assert sql3 == expected_sql3
 
 
 def test_bug_project_multiple_times(customer, nation, region):


### PR DESCRIPTION
This PR fixes an issue where mutations with overlapping names
are erased during projection fusion.

Name overlap is only a symptom though and not the underlycausing
cause of the problem.

The real distinction that needs to be made is between projection columns that
are not equivalent expressions.

Here, the approach I took to prevent fusion in those cases was exactly that.

It's more conservative than it could be (for example, equivalence can be
considerd across a Selection with an empty `selections` list, for example), but
this code is already a pile of spaghetti and I didn't want to add to it.

Fixes #4003.
Fixes #2453.