### PR TITLE
feat(api): add toplevel ibis.connect()

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -686,3 +686,24 @@ def _(
     con = getattr(ibis, backend).connect(**kwargs)
     con.register(f"{extension}://{filename}")
     return con
+
+
+@_connect.register(
+    r"(?P<filename>.+\.(?P<extension>parquet|csv))",
+    priority=8,
+)
+def _(
+    _: str,
+    *,
+    filename: str,
+    extension: str,
+    **kwargs: Any,
+) -> BaseBackend:
+    """Connect to `duckdb` and register a parquet or csv file.
+
+    Examples
+    --------
+    >>> con = ibis.connect("relative/path/to/data.csv")
+    >>> con = ibis.connect("relative/path/to/more/data.parquet")
+    """
+    return _connect(f"duckdb://{filename}", **kwargs)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -18,6 +18,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+from ibis.backends.base import connect
 from ibis.expr.deferred import Deferred
 from ibis.expr.random import random
 from ibis.expr.schema import Schema
@@ -115,6 +116,7 @@ __all__ = (
     'array',
     'case',
     'coalesce',
+    'connect',
     'cross_join',
     'cumulative_window',
     'date',


### PR DESCRIPTION
Add a toplevel API that can take either a URL or a path string, and connect to it, without having to specify the backend explicitly.  Auto-detect based on URL scheme or path extension.