### PR TITLE
refactor: rename CMSMedian to ApproxMedian, and HLLCardinality to ApproxCountDistinct

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -542,6 +542,9 @@ sqlalchemy_operation_registry: Dict[Any, Any] = {
     ops.BitXor: reduction(sa.func.bit_xor),
     ops.CountDistinct: reduction(lambda arg: sa.func.count(arg.distinct())),
     ops.HLLCardinality: reduction(lambda arg: sa.func.count(arg.distinct())),
+    ops.ApproxCountDistinct: reduction(
+        lambda arg: sa.func.count(arg.distinct())
+    ),
     ops.GroupConcat: _group_concat,
     ops.Between: fixed_arity(sa.between, 3),
     ops.IsNull: _is_null,

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -292,6 +292,8 @@ operation_registry = {
     # Unary aggregates
     ops.CMSMedian: aggregate.reduction('appx_median'),
     ops.HLLCardinality: aggregate.reduction('ndv'),
+    ops.ApproxMedian: aggregate.reduction('appx_median'),
+    ops.ApproxCountDistinct: aggregate.reduction('ndv'),
     ops.Mean: aggregate.reduction('avg'),
     ops.Sum: aggregate.reduction('sum'),
     ops.Max: aggregate.reduction('max'),

--- a/ibis/backends/base/sql/registry/window.py
+++ b/ibis/backends/base/sql/registry/window.py
@@ -254,9 +254,9 @@ def window(translator, expr):
     )
 
     _unsupported_reductions = (
-        ops.CMSMedian,
+        ops.ApproxMedian,
         ops.GroupConcat,
-        ops.HLLCardinality,
+        ops.ApproxCountDistinct,
     )
 
     if isinstance(window_op, _unsupported_reductions):

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -692,9 +692,11 @@ operation_registry = {
     ops.E: _fixed_arity("e", 0),
     # Unary aggregates
     ops.CMSMedian: _agg('median'),
+    ops.ApproxMedian: _agg('median'),
     # TODO: there is also a `uniq` function which is the
     #       recommended way to approximate cardinality
     ops.HLLCardinality: _agg('uniqHLL12'),
+    ops.ApproxCountDistinct: _agg('uniqHLL12'),
     ops.Mean: _agg('avg'),
     ops.Sum: _agg('sum'),
     ops.Max: _agg('max'),

--- a/ibis/backends/dask/execution/reductions.py
+++ b/ibis/backends/dask/execution/reductions.py
@@ -94,7 +94,9 @@ def execute_reduction_series_mask(op, data, mask, aggcontext=None, **kwargs):
 
 
 @execute_node.register(
-    (ops.CountDistinct, ops.HLLCardinality), ddgb.SeriesGroupBy, type(None)
+    (ops.CountDistinct, ops.ApproxCountDistinct),
+    ddgb.SeriesGroupBy,
+    type(None),
 )
 def execute_count_distinct_series_groupby(
     op, data, _, aggcontext=None, **kwargs
@@ -103,7 +105,7 @@ def execute_count_distinct_series_groupby(
 
 
 @execute_node.register(
-    (ops.CountDistinct, ops.HLLCardinality),
+    (ops.CountDistinct, ops.ApproxCountDistinct),
     ddgb.SeriesGroupBy,
     ddgb.SeriesGroupBy,
 )
@@ -115,7 +117,9 @@ def execute_count_distinct_series_groupby_mask(
 
 
 @execute_node.register(
-    (ops.CountDistinct, ops.HLLCardinality), dd.Series, (dd.Series, type(None))
+    (ops.CountDistinct, ops.ApproxCountDistinct),
+    dd.Series,
+    (dd.Series, type(None)),
 )
 def execute_count_distinct_series_mask(
     op, data, mask, aggcontext=None, **kwargs

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -187,11 +187,15 @@ operation_registry.update(
         ops.RegexReplace: fixed_arity(sa.func.regexp_replace, 3),
         ops.StringContains: fixed_arity(sa.func.contains, 2),
         ops.CMSMedian: reduction(
+            lambda arg: sa.func.approx_quantile(arg, sa.text(str(0.5)))
+        ),
+        ops.ApproxMedian: reduction(
             # without inline text, duckdb fails with
             # RuntimeError: INTERNAL Error: Invalid PhysicalType for GetTypeIdSize # noqa: E501
             lambda arg: sa.func.approx_quantile(arg, sa.text(str(0.5)))
         ),
         ops.HLLCardinality: reduction(sa.func.approx_count_distinct),
+        ops.ApproxCountDistinct: reduction(sa.func.approx_count_distinct),
         ops.Strftime: _strftime,
         ops.Arbitrary: _arbitrary,
     }

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -561,7 +561,9 @@ def execute_reduction_series_groupby_std(
 
 
 @execute_node.register(
-    (ops.CountDistinct, ops.HLLCardinality), SeriesGroupBy, type(None)
+    (ops.CountDistinct, ops.ApproxCountDistinct),
+    SeriesGroupBy,
+    type(None),
 )
 def execute_count_distinct_series_groupby(
     op, data, _, aggcontext=None, **kwargs
@@ -597,7 +599,9 @@ def execute_reduction_series_gb_mask(
 
 
 @execute_node.register(
-    (ops.CountDistinct, ops.HLLCardinality), SeriesGroupBy, SeriesGroupBy
+    (ops.CountDistinct, ops.ApproxCountDistinct),
+    SeriesGroupBy,
+    SeriesGroupBy,
 )
 def execute_count_distinct_series_groupby_mask(
     op, data, mask, aggcontext=None, **kwargs
@@ -643,7 +647,9 @@ def execute_reduction_series_mask(op, data, mask, aggcontext=None, **kwargs):
 
 
 @execute_node.register(
-    (ops.CountDistinct, ops.HLLCardinality), pd.Series, (pd.Series, type(None))
+    (ops.CountDistinct, ops.ApproxCountDistinct),
+    pd.Series,
+    (pd.Series, type(None)),
 )
 def execute_count_distinct_series_mask(
     op, data, mask, aggcontext=None, **kwargs

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -608,7 +608,7 @@ def compile_sum(t, expr, scope, timecontext, context=None, **kwargs):
     )
 
 
-@compiles(ops.HLLCardinality)
+@compiles(ops.ApproxCountDistinct)
 def compile_approx_count_distinct(
     t, expr, scope, timecontext, context=None, **kwargs
 ):
@@ -623,7 +623,7 @@ def compile_approx_count_distinct(
     )
 
 
-@compiles(ops.CMSMedian)
+@compiles(ops.ApproxMedian)
 def compile_approx_median(t, expr, scope, timecontext, context=None, **kwargs):
     return compile_aggregator(
         t,

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -8,6 +8,7 @@ from ibis.expr import rules as rlz
 from ibis.expr import types as ir
 from ibis.expr.operations.core import Value, distinct_roots
 from ibis.expr.operations.generic import _Negatable
+from ibis.util import deprecated
 
 
 @public
@@ -191,7 +192,7 @@ class Min(Filterable, Reduction):
 
 
 @public
-class HLLCardinality(Filterable, Reduction):
+class ApproxCountDistinct(Filterable, Reduction):
     """Approximate number of unique values using HyperLogLog algorithm.
 
     Impala offers the NDV built-in function for this.
@@ -204,6 +205,12 @@ class HLLCardinality(Filterable, Reduction):
 
 
 @public
+@deprecated(version='4.0', instead='use ApproxCountDistinct')
+class HLLCardinality(ApproxCountDistinct):
+    pass
+
+
+@public
 class GroupConcat(Filterable, Reduction):
     arg = rlz.column(rlz.any)
     sep = rlz.string
@@ -212,7 +219,7 @@ class GroupConcat(Filterable, Reduction):
 
 
 @public
-class CMSMedian(Filterable, Reduction):
+class ApproxMedian(Filterable, Reduction):
     """
     Compute the approximate median of a set of comparable values using the
     Count-Min-Sketch algorithm. Exposed in Impala using APPX_MEDIAN.
@@ -220,6 +227,12 @@ class CMSMedian(Filterable, Reduction):
 
     arg = rlz.column(rlz.any)
     output_dtype = rlz.dtype_like('arg')
+
+
+@public
+@deprecated(version="4.0", instead="use ApproxMedian")
+class CMSMedian(ApproxMedian):
+    pass
 
 
 @public

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -598,7 +598,11 @@ class Column(Value):
         """
         import ibis.expr.operations as ops
 
-        return ops.HLLCardinality(self, where).to_expr().name("approx_nunique")
+        return (
+            ops.ApproxCountDistinct(self, where)
+            .to_expr()
+            .name("approx_nunique")
+        )
 
     def approx_median(
         self,
@@ -624,7 +628,7 @@ class Column(Value):
         """
         import ibis.expr.operations as ops
 
-        return ops.CMSMedian(self, where).to_expr().name("approx_median")
+        return ops.ApproxMedian(self, where).to_expr().name("approx_median")
 
     def max(self, where: ir.BooleanValue | None = None) -> Scalar:
         import ibis.expr.operations as ops


### PR DESCRIPTION
Deprecated, with a plan to be fully removed in 4.0.0.

Closes #3961 