### PR TITLE
perf: make multiple joins fast again

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -666,10 +666,7 @@ def _find_root_table(expr):
     if isinstance(op, ops.Selection):
         # remove predicates and sort_keys, so that child tables are considered
         # equivalent even if their predicates and sort_keys are not
-        return lin.proceed, op.__class__(
-            table=op.table,
-            selections=op.selections,
-        )
+        return lin.proceed, op._projection
     elif op.blocks():
         return lin.halt, op
     else:

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -405,6 +405,10 @@ class Selection(TableNode, sch.HasSchema):
         assert self.schema
 
     @cached_property
+    def _projection(self):
+        return self.__class__(table=self.table, selections=self.selections)
+
+    @cached_property
     def schema(self):
         # Resolve schema and initialize
         if not self.selections:

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -598,3 +598,19 @@ def test_eq_datatypes(benchmark, dtypes):
         assert a == b
 
     benchmark(eq, dtypes, copy.deepcopy(dtypes))
+
+
+def multiple_joins(table, num_joins):
+    for _ in range(num_joins):
+        table = table.mutate(dummy=ibis.literal(""))
+        table = table.left_join(table, ["dummy"])[[table]]
+
+
+@pytest.mark.parametrize("num_joins", [1, 10, 100])
+@pytest.mark.parametrize("num_columns", [1, 10, 100])
+def test_multiple_joins(benchmark, num_joins, num_columns):
+    table = ibis.table(
+        {f"col_{i:d}": "string" for i in range(num_columns)},
+        name="t",
+    )
+    benchmark(multiple_joins, table, num_joins)

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 import ibis
@@ -308,3 +310,21 @@ def test_agg_selection_does_not_share_roots():
 
     with pytest.raises(com.RelationError, match="Selection expressions"):
         gb.aggregate(n=n)
+
+
+@pytest.mark.parametrize("num_joins", [1, 10])
+def test_large_compile(num_joins):
+    num_columns = 20
+    table = ibis.table(
+        {f"col_{i:d}": "string" for i in range(num_columns)}, name="t"
+    )
+    for _ in range(num_joins):
+        start = time.time()
+        table = table.mutate(dummy=ibis.literal(""))
+        stop = time.time()
+        assert stop - start < 1.0
+
+        start = time.time()
+        table = table.left_join(table, ["dummy"])[[table]]
+        stop = time.time()
+        assert stop - start < 1.0


### PR DESCRIPTION
This PR addresses a performance regression when constructing chains of joins.

The proximate issue was the reconstruction of equivalent projections of
a traversed `Selection` using `op.__class__(op.table, op.selections)`.
I've addressed this by adding a cached private `_projection` property that is
tied to unique instances of `Selection`.

There's some more investigation of the repeated computation to be done, but that
will be done in a follow-up.

Fixes #4036.
