### PR TITLE
feat(pyspark): add option to allow treating nans as nulls in the pyspark backend

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 import pandas as pd
 import pyspark
+from pydantic import Field
 from pyspark.sql import DataFrame
 from pyspark.sql.column import Column
 
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
     import ibis.expr.operations as ops
 
 import ibis.common.exceptions as com
+import ibis.config
 import ibis.expr.schema as sch
 import ibis.expr.types as types
 import ibis.util as util
@@ -87,6 +89,12 @@ class Backend(BaseSQLBackend):
     name = 'pyspark'
     table_class = PySparkDatabaseTable
     table_expr_class = PySparkTable
+
+    class Options(ibis.config.BaseModel):
+        treat_nan_as_null: bool = Field(
+            default=False,
+            description="Treat NaNs in floating point expressions as NULL.",
+        )
 
     def do_connect(self, session: pyspark.sql.SparkSession) -> None:
         """Create a PySpark `Backend` for use with Ibis.

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -254,15 +254,16 @@ def client(data_directory):
     df = df.withColumn("str_col", F.lit('value'))
     df.createTempView('basic_table')
 
-    df_nans = client._session.createDataFrame(
+    df_nulls = client._session.createDataFrame(
         [
-            [np.NaN, 'Alfred', None],
-            [27.0, 'Batman', 'motocycle'],
-            [3.0, None, 'joker'],
+            ['k1', np.NaN, 'Alfred', None],
+            ['k1', 3.0, None, 'joker'],
+            ['k2', 27.0, 'Batman', 'batmobile'],
+            ['k2', None, 'Catwoman', 'motorcycle'],
         ],
-        ['age', 'user', 'toy'],
+        ['key', 'age', 'user', 'toy'],
     )
-    df_nans.createTempView('nan_table')
+    df_nulls.createTempView('null_table')
 
     df_dates = client._session.createDataFrame(
         [['2018-01-02'], ['2018-01-03'], ['2018-01-04']], ['date_str']

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -233,8 +233,7 @@ def get_common_spark_testing_client(data_directory, connect):
 
 def get_pyspark_testing_client(data_directory):
     return get_common_spark_testing_client(
-        data_directory,
-        lambda session: ibis.backends.pyspark.Backend().connect(session),
+        data_directory, ibis.pyspark.connect
     )
 
 

--- a/ibis/backends/pyspark/tests/test_aggregation.py
+++ b/ibis/backends/pyspark/tests/test_aggregation.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+from pytest import param
+
+pytest.importorskip("pyspark")
+
+
+@pytest.mark.parametrize(
+    ('result_fn', 'expected_fn'),
+    [
+        param(
+            lambda t: t.age.count(),
+            lambda t: len(t.age.dropna()),
+            id='count',
+        ),
+        param(
+            lambda t: t.age.sum(),
+            lambda t: t.age.sum(),
+            id='sum',
+        ),
+    ],
+)
+def test_aggregation_float_nulls(
+    client,
+    result_fn,
+    expected_fn,
+):
+    table = client.table('null_table')
+    df = table.compile().toPandas()
+
+    expr = result_fn(table)
+    result = expr.execute()
+
+    expected = expected_fn(df)
+    np.testing.assert_allclose(result, expected)

--- a/ibis/backends/pyspark/tests/test_null.py
+++ b/ibis/backends/pyspark/tests/test_null.py
@@ -5,7 +5,7 @@ pytest.importorskip("pyspark")
 
 
 def test_isnull(client):
-    table = client.table('nan_table')
+    table = client.table('null_table')
     table_pandas = table.compile().toPandas()
 
     for (col, _) in table_pandas.iteritems():
@@ -22,7 +22,7 @@ def test_isnull(client):
 
 
 def test_notnull(client):
-    table = client.table('nan_table')
+    table = client.table('null_table')
     table_pandas = table.compile().toPandas()
 
     for (col, _) in table_pandas.iteritems():

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -113,6 +113,7 @@ class Options(BaseSettings):
     dask: Optional[BaseModel] = None
     impala: Optional[BaseModel] = None
     pandas: Optional[BaseModel] = None
+    pyspark: Optional[BaseModel] = None
 
     class Config:
         validate_assignment = True


### PR DESCRIPTION
Backends like the Pandas backend treat `np.nan`s as nulls when computing aggregations. The PySpark backend was not treating `np.nan`s as nulls, leading to results for aggregations that are inconsistent with other backends (e.g. I would expect `count` to ignore `np.nan`s).

This change filters out `np.nan`s in float columns when computing built-in aggregations on the PySpark backend.

I wasn't sure how to classify this change, but I marked it as a breaking change since it changes the behavior of existing Reduction operations. Let me know if I should change that.
