### PR TITLE
fix: fix millisecond extraction for postgres and duckdb

### DIFF
--- a/ibis/backends/base/sql/registry/literal.py
+++ b/ibis/backends/base/sql/registry/literal.py
@@ -60,7 +60,7 @@ def _date_literal_format(translator, expr):
 def _timestamp_literal_format(translator, expr):
     value = expr.op().value
     if isinstance(value, datetime.datetime):
-        value = value.strftime('%Y-%m-%d %H:%M:%S')
+        value = value.isoformat()
 
     return repr(value)
 

--- a/ibis/backends/impala/tests/test_value_exprs.py
+++ b/ibis/backends/impala/tests/test_value_exprs.py
@@ -329,17 +329,17 @@ def test_timestamp_deltas(table, unit, compiled_unit):
     [
         pytest.param(
             lambda v: L(pd.Timestamp(v)),
-            "'2015-01-01 12:34:56'",
+            "'2015-01-01T12:34:56'",
             id="literal_pd_timestamp",
         ),
         pytest.param(
             lambda v: L(pd.Timestamp(v).to_pydatetime()),
-            "'2015-01-01 12:34:56'",
+            "'2015-01-01T12:34:56'",
             id="literal_pydatetime",
         ),
         pytest.param(
             lambda v: ibis.timestamp(v),
-            "'2015-01-01 12:34:56'",
+            "'2015-01-01T12:34:56'",
             id="ibis_timestamp_function",
         ),
     ],
@@ -355,18 +355,18 @@ def test_timestamp_literals(expr_fn, expected):
     [
         pytest.param(
             lambda v: v.day_of_week.index(),
-            "pmod(dayofweek('2015-09-01 01:00:23') - 2, 7)",
+            "pmod(dayofweek('2015-09-01T01:00:23') - 2, 7)",
             id="index",
         ),
         pytest.param(
             lambda v: v.day_of_week.full_name(),
-            "dayname('2015-09-01 01:00:23')",
+            "dayname('2015-09-01T01:00:23')",
             id="full_name",
         ),
     ],
 )
 def test_timestamp_day_of_week(expr_fn, expected):
-    expr = expr_fn(ibis.timestamp('2015-09-01 01:00:23'))
+    expr = expr_fn(ibis.timestamp('2015-09-01T01:00:23'))
     result = translate(expr)
     assert result == expected
 

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -51,9 +51,9 @@ def _millisecond(t, expr):
     # we get total number of milliseconds including seconds with extract so we
     # mod 1000
     (sa_arg,) = map(t.translate, expr.op().args)
-    return (
-        sa.cast(sa.func.floor(sa.extract('millisecond', sa_arg)), sa.SMALLINT)
-        % 1000
+    return sa.cast(
+        sa.func.floor(sa.extract('millisecond', sa_arg)) % 1000,
+        sa.SMALLINT,
     )
 
 

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -14,9 +14,11 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pandas as pd
 import sqlalchemy as sa
 
 if TYPE_CHECKING:
@@ -69,6 +71,8 @@ class Backend(BaseAlchemyBackend):
         engine = sa.create_engine(
             f"sqlite:///{path if path is not None else ':memory:'}"
         )
+
+        sqlite3.register_adapter(pd.Timestamp, lambda value: value.isoformat())
 
         @sa.event.listens_for(engine, "connect")
         def connect(dbapi_connection, connection_record):

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -721,7 +721,7 @@ def test_date_column_from_iso(con, alltypes, df):
 
 
 @pytest.mark.notimpl(["datafusion"])
-@pytest.mark.notyet(["clickhouse"])
+@pytest.mark.notyet(["clickhouse", "pyspark"])
 @pytest.mark.broken(["mysql"])
 def test_timestamp_extract_milliseconds_with_big_value(con):
     timestamp = ibis.timestamp("2021-01-01 01:30:59.333")

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -718,3 +718,13 @@ def test_date_column_from_iso(con, alltypes, df):
     )
     actual = result.dt.strftime('%Y-%m-%d')
     tm.assert_series_equal(golden.rename('tmp'), actual.rename('tmp'))
+
+
+@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notyet(["clickhouse"])
+@pytest.mark.broken(["mysql"])
+def test_timestamp_extract_milliseconds_with_big_value(con):
+    timestamp = ibis.timestamp("2021-01-01 01:30:59.333")
+    millis = timestamp.millisecond()
+    result = con.execute(millis)
+    assert result == 333

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -294,14 +294,14 @@ SELECT t0.*
 FROM (
   SELECT t2.`a`
   FROM (
-    SELECT `a`, `b`, '2018-01-01 00:00:00' AS `the_date`
+    SELECT `a`, `b`, '2018-01-01T00:00:00' AS `the_date`
     FROM (
       SELECT *
       FROM (
         SELECT `a`, `b`, `c` AS `C`
         FROM t
       ) t5
-      WHERE `C` = '2018-01-01 00:00:00'
+      WHERE `C` = '2018-01-01T00:00:00'
     ) t4
   ) t2
     INNER JOIN s t1

--- a/ibis/tests/sql/test_select_sql.py
+++ b/ibis/tests/sql/test_select_sql.py
@@ -251,9 +251,9 @@ def test_where_analyze_scalar_op(functional_alltypes):
     expected = """\
 SELECT count(*) AS `count`
 FROM functional_alltypes
-WHERE (`timestamp_col` < date_add(cast({} as timestamp), INTERVAL 3 MONTH)) AND
+WHERE (`timestamp_col` < date_add(cast({!r} as timestamp), INTERVAL 3 MONTH)) AND
       (`timestamp_col` < date_add(cast(now() as timestamp), INTERVAL 10 DAY))"""  # noqa: E501
-    assert result == expected.format("'2010-01-01 00:00:00'")
+    assert result == expected.format("2010-01-01T00:00:00")
 
 
 def test_bug_duplicated_where(airlines):

--- a/shell.nix
+++ b/shell.nix
@@ -21,7 +21,7 @@ let
     cmake
     ninja
   ];
-  backendTestDeps = [ pkgs.docker-compose_2 ];
+  backendTestDeps = [ pkgs.docker-compose ];
   vizDeps = [ pkgs.graphviz-nox ];
   duckdbDeps = [ pkgs.duckdb ];
   mysqlDeps = [ pkgs.mariadb-client ];


### PR DESCRIPTION
Also fixes extraction for SQLite timestamp literals.

Closes #4054.