### PR TITLE
refactor: remove duplicate timestamp literal tests

### DIFF
--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -893,4 +893,3 @@ operation_registry.update(_undocumented_operations)
 operation_registry.update(_unsupported_ops)
 operation_registry.update(_unary_ops)
 operation_registry.update(_binary_infix_ops)
-

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -357,11 +357,14 @@ def _literal(translator, expr):
         return _interval_format(translator, expr)
     elif isinstance(expr, ir.TimestampValue):
         if isinstance(value, datetime):
-            if value.microsecond != 0:
-                msg = 'Unsupported subsecond accuracy {}'
-                raise ValueError(msg.format(value))
-            value = value.strftime('%Y-%m-%d %H:%M:%S')
-        return f"toDateTime('{value!s}')"
+            micros = value.microsecond
+            value = repr(value.isoformat())
+
+            if micros % 1000:
+                return f"toDateTime64({value}, 6)"
+            elif micros // 1000:
+                return f"toDateTime64({value}, 3)"
+        return f"toDateTime({value})"
     elif isinstance(expr, ir.DateValue):
         if isinstance(value, date):
             value = value.strftime('%Y-%m-%d')

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -356,15 +356,30 @@ def _literal(translator, expr):
     elif isinstance(expr, ir.IntervalValue):
         return _interval_format(translator, expr)
     elif isinstance(expr, ir.TimestampValue):
-        if isinstance(value, datetime):
-            micros = value.microsecond
-            value = repr(value.isoformat())
+        func = "toDateTime"
+        args = []
 
+        if isinstance(value, datetime):
+            fmt = "%Y-%m-%dT%H:%M:%S"
+
+            if micros := value.microsecond:
+                func = "toDateTime64"
+                fmt += ".%f"
+
+            args.append(value.strftime(fmt))
             if micros % 1000:
-                return f"toDateTime64({value}, 6)"
+                args.append(6)
             elif micros // 1000:
-                return f"toDateTime64({value}, 3)"
-        return f"toDateTime({value})"
+                args.append(3)
+        else:
+            args.append(str(value))
+
+        if (timezone := expr.type().timezone) is not None:
+            args.append(timezone)
+
+        joined_args = ", ".join(map(repr, args))
+        return f"{func}({joined_args})"
+
     elif isinstance(expr, ir.DateValue):
         if isinstance(value, date):
             value = value.strftime('%Y-%m-%d')
@@ -878,3 +893,4 @@ operation_registry.update(_undocumented_operations)
 operation_registry.update(_unsupported_ops)
 operation_registry.update(_unary_ops)
 operation_registry.update(_binary_infix_ops)
+

--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -124,26 +124,6 @@ def test_timestamp_truncate(con, unit, expected):
     assert con.execute(expr) == pd.Timestamp(expected)
 
 
-@pytest.mark.parametrize(
-    ('func', 'expected'),
-    [
-        (methodcaller('year'), 2015),
-        (methodcaller('month'), 9),
-        (methodcaller('day'), 1),
-        (methodcaller('hour'), 14),
-        (methodcaller('minute'), 48),
-        (methodcaller('second'), 5),
-    ],
-)
-def test_simple_datetime_operations(con, func, expected):
-    value = ibis.timestamp('2015-09-01 14:48:05.359')
-    with pytest.raises(ValueError):
-        con.execute(func(value))
-
-    value = ibis.timestamp('2015-09-01 14:48:05')
-    con.execute(func(value)) == expected
-
-
 @pytest.mark.parametrize(('value', 'expected'), [(0, None), (5.5, 5.5)])
 def test_nullifzero(con, value, expected):
     result = con.execute(L(value).nullifzero())

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -132,29 +132,6 @@ def test_timestamp_cast_noop(alltypes, at, translate):
 
 
 @pytest.mark.parametrize(
-    ('func', 'expected'),
-    [
-        param(operator.methodcaller('year'), 2015, id='year'),
-        param(operator.methodcaller('month'), 9, id='month'),
-        param(operator.methodcaller('day'), 1, id='day'),
-        param(operator.methodcaller('hour'), 14, id='hour'),
-        param(operator.methodcaller('minute'), 48, id='minute'),
-        param(operator.methodcaller('second'), 5, id='second'),
-        param(operator.methodcaller('millisecond'), 359, id='millisecond'),
-        param(lambda x: x.day_of_week.index(), 1, id='day_of_week_index'),
-        param(
-            lambda x: x.day_of_week.full_name(),
-            'Tuesday',
-            id='day_of_week_full_name',
-        ),
-    ],
-)
-def test_simple_datetime_operations(con, func, expected, translate):
-    value = ibis.timestamp('2015-09-01 14:48:05.359')
-    assert con.execute(func(value)) == expected
-
-
-@pytest.mark.parametrize(
     'pattern',
     [
         # there could be pathological failure at midnight somewhere, but

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -379,6 +379,8 @@ def compile_literal(t, expr, scope, timecontext, raw=False, **kwargs):
     elif isinstance(value, tuple):
         return F.array(*map(F.lit, value))
     else:
+        if isinstance(value, pd.Timestamp) and value.tz is None:
+            value = value.tz_localize("UTC").to_pydatetime()
         return F.lit(value)
 
 

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -62,23 +62,10 @@ def test_timestamp_cast_noop(
     assert translate(result) == sqla_compile(expected)
 
 
-TIMESTAMP_CONSTANT = ibis.literal('2015-09-01 14:48:05.359').cast('timestamp')
-
-
-@pytest.mark.parametrize(
-    ('expr', 'expected'),
-    [
-        (TIMESTAMP_CONSTANT.strftime('%Y%m%d'), '20150901'),
-        (TIMESTAMP_CONSTANT.year(), 2015),
-        (TIMESTAMP_CONSTANT.month(), 9),
-        (TIMESTAMP_CONSTANT.day(), 1),
-        (TIMESTAMP_CONSTANT.hour(), 14),
-        (TIMESTAMP_CONSTANT.minute(), 48),
-        (TIMESTAMP_CONSTANT.second(), 5),
-        (TIMESTAMP_CONSTANT.millisecond(), 359),
-    ],
-)
-def test_timestamp_functions(con, expr, expected):
+def test_timestamp_functions(con):
+    value = ibis.timestamp('2015-09-01 14:48:05.359')
+    expr = value.strftime('%Y%m%d')
+    expected = '20150901'
     assert con.execute(expr) == expected
 
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -73,7 +73,7 @@ def test_timestamp_extract(backend, alltypes, df, attr):
             359,
             id='millisecond',
             marks=[
-                pytest.mark.notimpl(["clickhouse"]),
+                pytest.mark.notimpl(["clickhouse", "pyspark"]),
                 pytest.mark.broken(
                     ["mysql"],
                     reason="MySQL implementation of milliseconds is broken",

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -437,7 +437,10 @@ def _timestamp_from_str(
         value = pd.Timestamp(value, tz=timezone)
     except pd.errors.OutOfBoundsDatetime:
         value = dateutil.parser.parse(value)
-    return literal(value, type=dt.Timestamp(timezone=timezone))
+    dtype = dt.Timestamp(
+        timezone=timezone if timezone is not None else value.tzname()
+    )
+    return literal(value, type=dtype)
 
 
 @functools.singledispatch


### PR DESCRIPTION
This PR removes duplicate timestamp literal tests from individual backends and integrates the test
into a single backend-suite test.

cc @anjakefala
