### PR TITLE
test: ensure that ddl and alchemy backends load data

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -462,13 +462,15 @@ def con(backend):
 def _setup_backend(
     request, data_directory, script_directory, tmp_path_factory
 ):
-    if request.param == "duckdb" and platform.system() == "Windows":
+    if (
+        backend := request.param
+    ) == "duckdb" and platform.system() == "Windows":
         pytest.xfail(
             "windows prevents two connections to the same duckdb file "
             "even in the same process"
         )
     else:
-        cls = _get_backend_conf(request.param)
+        cls = _get_backend_conf(backend)
         return cls.load_data(
             data_directory, script_directory, tmp_path_factory
         )

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -486,7 +486,9 @@ def ddl_con(ddl_backend):
     ),
     scope='session',
 )
-def alchemy_backend(request, data_directory, tmp_path_factory):
+def alchemy_backend(
+    request, data_directory, script_directory, tmp_path_factory
+):
     """
     Runs the SQLAlchemy-based backends
     (sqlite, mysql, postgres)
@@ -515,7 +517,7 @@ def alchemy_con(alchemy_backend):
     params=_get_backends_to_test(keep=("dask", "pandas", "pyspark")),
     scope='session',
 )
-def udf_backend(request, data_directory, tmp_path_factory):
+def udf_backend(request, data_directory, script_directory, tmp_path_factory):
     """
     Runs the UDF-supporting backends
     """

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -468,8 +468,16 @@ def ddl_backend(request, data_directory, script_directory, tmp_path_factory):
     Runs the SQL-ish backends
     (sqlite, postgres, mysql, datafusion, clickhouse, pyspark, impala)
     """
-    cls = _get_backend_conf(request.param)
-    return cls.load_data(data_directory, script_directory, tmp_path_factory)
+    if request.param == "duckdb" and platform.system() == "Windows":
+        pytest.xfail(
+            "windows prevents two connections to the same duckdb file "
+            "even in the same process"
+        )
+    else:
+        cls = _get_backend_conf(request.param)
+        return cls.load_data(
+            data_directory, script_directory, tmp_path_factory
+        )
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -463,13 +463,13 @@ def con(backend):
     params=_get_backends_to_test(discard=("dask", "pandas")),
     scope='session',
 )
-def ddl_backend(request, data_directory):
+def ddl_backend(request, data_directory, script_directory, tmp_path_factory):
     """
     Runs the SQL-ish backends
     (sqlite, postgres, mysql, datafusion, clickhouse, pyspark, impala)
     """
     cls = _get_backend_conf(request.param)
-    return cls(data_directory)
+    return cls.load_data(data_directory, script_directory, tmp_path_factory)
 
 
 @pytest.fixture(scope='session')
@@ -486,7 +486,7 @@ def ddl_con(ddl_backend):
     ),
     scope='session',
 )
-def alchemy_backend(request, data_directory):
+def alchemy_backend(request, data_directory, tmp_path_factory):
     """
     Runs the SQLAlchemy-based backends
     (sqlite, mysql, postgres)
@@ -498,7 +498,9 @@ def alchemy_backend(request, data_directory):
         )
     else:
         cls = _get_backend_conf(request.param)
-        return cls(data_directory)
+        return cls.load_data(
+            data_directory, script_directory, tmp_path_factory
+        )
 
 
 @pytest.fixture(scope='session')
@@ -513,12 +515,12 @@ def alchemy_con(alchemy_backend):
     params=_get_backends_to_test(keep=("dask", "pandas", "pyspark")),
     scope='session',
 )
-def udf_backend(request, data_directory):
+def udf_backend(request, data_directory, tmp_path_factory):
     """
     Runs the UDF-supporting backends
     """
     cls = _get_backend_conf(request.param)
-    return cls(data_directory)
+    return cls.load_data(data_directory, script_directory, tmp_path_factory)
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -553,7 +553,7 @@ def struct(backend):
 
 
 @pytest.fixture(scope='session')
-def sorted_alltypes(backend, alltypes):
+def sorted_alltypes(alltypes):
     return alltypes.sort_by('id')
 
 
@@ -593,7 +593,7 @@ def udf_df(udf_alltypes):
 
 
 @pytest.fixture(scope='session')
-def sorted_df(backend, df):
+def sorted_df(df):
     return df.sort_values('id').reset_index(drop=True)
 
 
@@ -686,7 +686,7 @@ def temp_view(ddl_con) -> str:
 
 
 @pytest.fixture(scope='session')
-def current_data_db(ddl_con, ddl_backend) -> str:
+def current_data_db(ddl_con) -> str:
     """Return current database name."""
     return ddl_con.current_database
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -92,13 +92,13 @@ def test_query_schema(ddl_backend, ddl_con, expr_fn, expected):
     ],
 )
 @mark.notimpl(["datafusion", "duckdb", "mysql", "postgres", "sqlite"])
-def test_sql(ddl_backend, ddl_con, sql):
+def test_sql(ddl_con, sql):
     # execute the expression using SQL query
     ddl_con.sql(sql).execute()
 
 
 @mark.notimpl(["clickhouse", "datafusion"])
-def test_create_table_from_schema(con, backend, new_schema, temp_table):
+def test_create_table_from_schema(con, new_schema, temp_table):
     con.create_table(temp_table, schema=new_schema)
 
     t = con.table(temp_table)
@@ -157,7 +157,7 @@ def test_nullable_input_output(con, temp_table):
     ["clickhouse", "datafusion", "duckdb", "mysql", "postgres", "sqlite"]
 )
 @mark.notyet(["pyspark"])
-def test_create_drop_view(ddl_con, ddl_backend, temp_view):
+def test_create_drop_view(ddl_con, temp_view):
     # setup
     table_name = 'functional_alltypes'
     expr = ddl_con.table(table_name).limit(1)
@@ -239,7 +239,6 @@ def employee_data_2_temp_table(
 
 
 def test_insert_no_overwrite_from_dataframe(
-    alchemy_backend,
     alchemy_con,
     test_employee_data_2,
     employee_empty_temp_table,
@@ -256,7 +255,6 @@ def test_insert_no_overwrite_from_dataframe(
 
 
 def test_insert_overwrite_from_dataframe(
-    alchemy_backend,
     alchemy_con,
     employee_data_1_temp_table,
     test_employee_data_2,
@@ -274,7 +272,6 @@ def test_insert_overwrite_from_dataframe(
 
 
 def test_insert_no_overwite_from_expr(
-    alchemy_backend,
     alchemy_con,
     employee_empty_temp_table,
     employee_data_2_temp_table,
@@ -293,7 +290,6 @@ def test_insert_no_overwite_from_expr(
 
 
 def test_insert_overwrite_from_expr(
-    alchemy_backend,
     alchemy_con,
     employee_data_1_temp_table,
     employee_data_2_temp_table,
@@ -311,7 +307,7 @@ def test_insert_overwrite_from_expr(
     tm.assert_frame_equal(result, from_table.execute())
 
 
-def test_list_databases(alchemy_backend, alchemy_con):
+def test_list_databases(alchemy_con):
     # Every backend has its own databases
     TEST_DATABASES = {
         'sqlite': ['main'],
@@ -322,7 +318,7 @@ def test_list_databases(alchemy_backend, alchemy_con):
     assert alchemy_con.list_databases() == TEST_DATABASES[alchemy_con.name]
 
 
-def test_list_schemas(alchemy_backend, alchemy_con):
+def test_list_schemas(alchemy_con):
     with pytest.warns(FutureWarning):
         alchemy_con.list_schemas()
 


### PR DESCRIPTION
The recent test flakiness for duckdb appears to be related to the fact that the ddl_backend and alchemy_backend fixtures are not currently loading their data. This PR fixes that.