### PR TITLE
build: lock duckdb-engine to latest version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -429,7 +429,7 @@ numpy = ">=1.14"
 
 [[package]]
 name = "duckdb-engine"
-version = "0.1.8"
+version = "0.1.9"
 description = ""
 category = "main"
 optional = true
@@ -2949,8 +2949,8 @@ duckdb = [
     {file = "duckdb-0.3.4.tar.gz", hash = "sha256:ab94cfc9e4c25f93d4a7be2063879475c308d771d53588bfd6198a89a8c2bcd2"},
 ]
 duckdb-engine = [
-    {file = "duckdb_engine-0.1.8-py3-none-any.whl", hash = "sha256:308c1318b1b526a5d89be2c7b3da748a4189aae4916151fd3ade65611377fbec"},
-    {file = "duckdb_engine-0.1.8.tar.gz", hash = "sha256:08688e92e0c872e498f4f7bddec252fc0368bbc5b67028fab608ffdcd3d9197a"},
+    {file = "duckdb_engine-0.1.9-py3-none-any.whl", hash = "sha256:3fadc49baf795c43e6e7315703e7f42c05681db4a525975c8607f8a0aebec00b"},
+    {file = "duckdb_engine-0.1.9.tar.gz", hash = "sha256:71632b9abedeab44d72a31adfc0701c91eb342c4a36cf026c56957521441742a"},
 ]
 dunamai = [
     {file = "dunamai-1.12.0-py3-none-any.whl", hash = "sha256:00b9c1ef58d4950204f76c20f84afe7a28d095f77feaa8512dbb172035415e61"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,9 +205,9 @@ filterwarnings = [
   "ignore:Creating an ndarray from ragged nested sequences:",
   'ignore:`np\.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning',
   # sqlalchemy: most of these can be removed once we have a lower bound of sqlalchemy 1.4
-  'ignore:Dialect (postgresql\+psycopg2|sqlite\+pysqlite) does \*not\* support Decimal:',
+  'ignore:Dialect .+ does \*not\* support Decimal:',
   "ignore:Class (_regex_extract|_array_search|ST_.*) will not make use of SQL compilation caching:",
-  'ignore:Dialect postgresql.psycopg2 will not make use of SQL compilation caching:',
+  'ignore:Dialect .+ will not make use of SQL compilation caching:',
   "ignore:UserDefinedType .* will not produce a cache key because:",
   # duckdb-engine
   'ignore:The URL\.__to_string__ method is deprecated:',

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ decli==0.5.2; python_full_version >= "3.6.2" and python_full_version < "4.0.0" a
 decorator==5.1.1; python_version >= "3.8"
 defusedxml==0.7.1; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
 docstring-parser==0.13; python_version >= "3.6"
-duckdb-engine==0.1.8; python_full_version >= "3.6.1"
+duckdb-engine==0.1.9; python_full_version >= "3.6.1"
 duckdb==0.3.4
 dunamai==1.12.0; python_version >= "3.5" and python_version < "4.0"
 entrypoints==0.4; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"


### PR DESCRIPTION
This PR locks duckdb-engine to 0.1.9 so we can test against it in CI