### PR TITLE
test: only grab the parent directory when loading data if running in parallel

### DIFF
--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -102,11 +102,12 @@ class TestConf(UnorderedComparator, BackendTest, RoundHalfToEven):
 
 
 @pytest.fixture(scope='module')
-def con(tmp_path_factory, data_directory, script_directory):
+def con(tmp_path_factory, data_directory, script_directory, worker_id):
     return TestConf.load_data(
         data_directory,
         script_directory,
         tmp_path_factory,
+        worker_id,
     ).connect(data_directory)
 
 

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -441,11 +441,15 @@ def pytest_runtest_call(item):
 
 
 @pytest.fixture(params=_get_backends_to_test(), scope='session')
-def backend(request, data_directory, script_directory, tmp_path_factory):
+def backend(
+    request, data_directory, script_directory, tmp_path_factory, worker_id
+):
     """Return an instance of BackendTest, loaded with data."""
 
     cls = _get_backend_conf(request.param)
-    return cls.load_data(data_directory, script_directory, tmp_path_factory)
+    return cls.load_data(
+        data_directory, script_directory, tmp_path_factory, worker_id
+    )
 
 
 @pytest.fixture(scope='session')
@@ -460,7 +464,7 @@ def con(backend):
 
 
 def _setup_backend(
-    request, data_directory, script_directory, tmp_path_factory
+    request, data_directory, script_directory, tmp_path_factory, worker_id
 ):
     if (
         backend := request.param
@@ -472,7 +476,7 @@ def _setup_backend(
     else:
         cls = _get_backend_conf(backend)
         return cls.load_data(
-            data_directory, script_directory, tmp_path_factory
+            data_directory, script_directory, tmp_path_factory, worker_id
         )
 
 
@@ -480,13 +484,15 @@ def _setup_backend(
     params=_get_backends_to_test(discard=("dask", "pandas")),
     scope='session',
 )
-def ddl_backend(request, data_directory, script_directory, tmp_path_factory):
+def ddl_backend(
+    request, data_directory, script_directory, tmp_path_factory, worker_id
+):
     """Set up the backends that are SQL-based.
 
     (sqlite, postgres, mysql, duckdb, datafusion, clickhouse, pyspark, impala)
     """
     return _setup_backend(
-        request, data_directory, script_directory, tmp_path_factory
+        request, data_directory, script_directory, tmp_path_factory, worker_id
     )
 
 
@@ -505,14 +511,14 @@ def ddl_con(ddl_backend):
     scope='session',
 )
 def alchemy_backend(
-    request, data_directory, script_directory, tmp_path_factory
+    request, data_directory, script_directory, tmp_path_factory, worker_id
 ):
     """Set up the SQLAlchemy-based backends.
 
     (sqlite, mysql, postgres, duckdb)
     """
     return _setup_backend(
-        request, data_directory, script_directory, tmp_path_factory
+        request, data_directory, script_directory, tmp_path_factory, worker_id
     )
 
 
@@ -528,12 +534,16 @@ def alchemy_con(alchemy_backend):
     params=_get_backends_to_test(keep=("dask", "pandas", "pyspark")),
     scope='session',
 )
-def udf_backend(request, data_directory, script_directory, tmp_path_factory):
+def udf_backend(
+    request, data_directory, script_directory, tmp_path_factory, worker_id
+):
     """
     Runs the UDF-supporting backends
     """
     cls = _get_backend_conf(request.param)
-    return cls.load_data(data_directory, script_directory, tmp_path_factory)
+    return cls.load_data(
+        data_directory, script_directory, tmp_path_factory, worker_id
+    )
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -279,11 +279,12 @@ def hdfs(env, tmp_dir):
 
 
 @pytest.fixture(scope="session")
-def backend(tmp_path_factory, data_directory, script_directory):
+def backend(tmp_path_factory, data_directory, script_directory, worker_id):
     return TestConf.load_data(
         data_directory,
         script_directory,
         tmp_path_factory,
+        worker_id,
     )
 
 

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -110,11 +110,12 @@ def _random_identifier(suffix):
 
 
 @pytest.fixture(scope='session')
-def con(tmp_path_factory, data_directory, script_directory):
+def con(tmp_path_factory, data_directory, script_directory, worker_id):
     return TestConf.load_data(
         data_directory,
         script_directory,
         tmp_path_factory,
+        worker_id,
     ).connect(data_directory)
 
 

--- a/ibis/backends/sqlite/tests/conftest.py
+++ b/ibis/backends/sqlite/tests/conftest.py
@@ -93,11 +93,12 @@ def dbpath(data_directory):
 
 
 @pytest.fixture(scope="session")
-def con(tmp_path_factory, data_directory, script_directory):
+def con(tmp_path_factory, data_directory, script_directory, worker_id):
     return TestConf.load_data(
         data_directory,
         script_directory,
         tmp_path_factory,
+        worker_id,
     ).connect(data_directory)
 
 

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -102,6 +102,7 @@ class BackendTest(abc.ABC):
         data_dir: Path,
         script_dir: Path,
         tmpdir: Path,
+        worker_id: str,
         **kwargs: Any,
     ) -> None:
         """Load testdata from `data_directory` into
@@ -109,7 +110,9 @@ class BackendTest(abc.ABC):
         # handling for multi-processes pytest
 
         # get the temp directory shared by all workers
-        root_tmp_dir = tmpdir.getbasetemp().parent
+        root_tmp_dir = tmpdir.getbasetemp()
+        if worker_id != "master":
+            root_tmp_dir = root_tmp_dir.parent
 
         fn = root_tmp_dir / f"lockfile_{cls.name()}"
         with FileLock(f"{fn}.lock"):


### PR DESCRIPTION
This PR ensures that we do not share the data loading lockfile across all invocations of pytest.