### PR TITLE
chore(dev-shell): speed up direnv by avoiding data copy on every reload

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -29,7 +29,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable-small
 
       - name: lint commits
-        run: nix shell -f '<nixpkgs>' commitlint -c commitlint --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }} --verbose
+        run: nix run 'nixpkgs#commitlint' -- --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }} --verbose
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -46,7 +46,7 @@ jobs:
           dependency: ${{ matrix.dep }}
 
       - name: update ${{ matrix.dep }}
-        run: nix shell -f '<nixpkgs>' niv -c niv update ${{ matrix.dep }}
+        run: nix run 'nixpkgs#niv' -- update ${{ matrix.dep }}
 
       - uses: cpcloud/niv-dep-info-action@v2.0.6
         id: get_new_commit

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -32,9 +32,27 @@ let
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
       submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; }
-      // (if builtins.compareVersions builtins.nixVersion "2.4" >= 0 then { inherit submodules; } else {});
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 

--- a/shell.nix
+++ b/shell.nix
@@ -60,10 +60,8 @@ pkgs.mkShell {
 
   shellHook = ''
     data_dir="$PWD/ci/ibis-testing-data"
-    mkdir -p "$data_dir"
-    chmod u+rwx "$data_dir"
-    cp -rf ${pkgs.ibisTestingData}/* "$data_dir"
-    chmod --recursive u+rw "$data_dir"
+
+    rsync --chmod=Du+rwx,Fu+rw --archive --delete ${pkgs.ibisTestingData}/ "$data_dir"
 
     export IBIS_TEST_DATA_DIRECTORY="$data_dir"
 
@@ -72,11 +70,13 @@ pkgs.mkShell {
   '';
 
   buildInputs = devDeps ++ libraryDevDeps ++ [
-    pkgs.changelog
-    pkgs.mic
     pythonEnv
     updateLockFiles
-  ] ++ pkgs.preCommitShell.buildInputs;
+  ] ++ pkgs.preCommitShell.buildInputs ++ (with pkgs; [
+    changelog
+    mic
+    rsync
+  ]);
 
   PYTHONPATH = builtins.toPath ./.;
 }

--- a/shell.nix
+++ b/shell.nix
@@ -59,11 +59,12 @@ pkgs.mkShell {
   name = "ibis${pythonShortVersion}";
 
   shellHook = ''
-    data_dir="$PWD/ci/ibis-testing-data"
+    export IBIS_TEST_DATA_DIRECTORY="$PWD/ci/ibis-testing-data"
 
-    rsync --chmod=Du+rwx,Fu+rw --archive --delete ${pkgs.ibisTestingData}/ "$data_dir"
-
-    export IBIS_TEST_DATA_DIRECTORY="$data_dir"
+    rsync \
+      --chmod=Du+rwx,Fu+rw --archive --delete \
+      "${pkgs.ibisTestingData}/" \
+      "$IBIS_TEST_DATA_DIRECTORY"
 
     export TEMPDIR
     TEMPDIR="$(python -c 'import tempfile; print(tempfile.gettempdir())')"

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,8 @@
 let
   pkgs = import ./nix;
 
+  pythonEnv = pkgs."ibisDevEnv${pythonShortVersion}";
+
   devDeps = with pkgs; [
     # terminal markdown rendering
     glow
@@ -13,7 +15,7 @@ let
     lychee
     # packaging
     niv
-    poetry
+    pythonEnv.pkgs.poetry
   ];
 
   impalaUdfDeps = with pkgs; [
@@ -42,9 +44,10 @@ let
     ++ mysqlDeps;
 
   pythonShortVersion = builtins.replaceStrings [ "." ] [ "" ] python;
-  pythonEnv = pkgs."ibisDevEnv${pythonShortVersion}";
+
   updateLockFiles = pkgs.writeShellApplication {
     name = "update-lock-files";
+    runtimeInputs = [ pythonEnv.pkgs.poetry ];
     text = ''
       poetry export --dev --without-hashes --no-ansi --extras all > requirements.txt
       poetry lock --no-update

--- a/shell.nix
+++ b/shell.nix
@@ -51,6 +51,7 @@ let
     text = ''
       poetry export --dev --without-hashes --no-ansi --extras all > requirements.txt
       poetry lock --no-update
+      ./dev/poetry2setup -o setup.py
     '';
   };
 in


### PR DESCRIPTION
This PR replaces use of cp with rsync in the nix shell shellHook which will avoid a copy when data already exists in ci/ibis-testing-data and thus speedup any direnv command that reloads the shell.