### PR TITLE
docs(tutorial): correct spelling of Antarctica

### DIFF
--- a/docs/tutorial/02-Aggregates-Joins.ipynb
+++ b/docs/tutorial/02-Aggregates-Joins.ipynb
@@ -124,7 +124,7 @@
     "    .when('AF', 'Africa')\n",
     "    .when('AS', 'Asia')\n",
     "    .when('OC', 'Oceania')\n",
-    "    .when('AN', 'Anctartica')\n",
+    "    .when('AN', 'Antarctica')\n",
     "    .else_('Unknown continent')\n",
     "    .end()\n",
     "    .name('continent_name')\n",
@@ -274,7 +274,7 @@
       "text/plain": [
        "  continent_name  total_population\n",
        "0         Africa        1021238685\n",
-       "1     Anctartica               170\n",
+       "1     Antarctica               170\n",
        "2           Asia        4130584841\n",
        "3         Europe         750724554\n",
        "4  North America         540204371\n",
@@ -348,7 +348,7 @@
       "text/plain": [
        "  continent_name  total_population\n",
        "0         Africa        1021238685\n",
-       "1     Anctartica               170\n",
+       "1     Antarctica               170\n",
        "2           Asia        4130584841\n",
        "3         Europe         750724554\n",
        "4  North America         540204371\n",


### PR DESCRIPTION
Referenced:https://en.wikipedia.org/wiki/Antarctica