### PR TITLE
docs: fix broken url

### DIFF
--- a/docs/about/team.md
+++ b/docs/about/team.md
@@ -3,7 +3,7 @@
 ## Contributors
 
 {{ config.extra.project_name }} is developed and maintained by a [community of
-volunteer contributors]({{ config.repo_url }}graphs/contributors).
+volunteer contributors]({{ config.repo_url }}/graphs/contributors).
 
 {% for group in config.extra.team %}
 


### PR DESCRIPTION
Page with current url: https://ibis-project.org/docs/3.0.2/about/team/
"ibis is developed and maintained by a [community of volunteer contributors](https://github.com/ibis-project/ibisgraphs/contributors)."
Expected url: https://github.com/ibis-project/ibis/graphs/contributors