### PR TITLE
ci: update dependencies less often

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -3,8 +3,8 @@ name: Generate Conda Lockfiles
 
 on:
   schedule:
-    # At minute 30 past every 24th hour
-    - cron: "30 */24 * * *"
+    # At minute 30 on Sunday
+    - cron: "30 * * * SUN"
   workflow_dispatch:
   repository_dispatch:
     types:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,8 +1,8 @@
 name: Update Dependencies
 on:
   schedule:
-    # run every 24 hours at midnight
-    - cron: "0 */24 * * *"
+    # run every 3 days at midnight
+    - cron: "0 * * * */3"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This PR reduces the dependency update cycle to once a week for conda lock and every 3 days for nix updates. The goal here is to reduce the number of commits from bots while still staying up to date. The nix updates could be less often, but I wanted to avoid dealing with having to split huge commit lists in the update action for now.