### PR TITLE
[WIP] feat: add dask windows

### DIFF
--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -202,7 +202,7 @@ def execute_selection_dataframe(
             raise NotImplementedError(
                 "Descending sort is not supported for the Dask backend"
             )
-        result = compute_sorted_frame(
+        result, _ = compute_sorted_frame(
             result,
             order_by=sort_key,
             scope=scope,

--- a/ibis/backends/dask/execution/window.py
+++ b/ibis/backends/dask/execution/window.py
@@ -1,28 +1,98 @@
 """Code for computing window functions in the dask backend."""
 
 import operator
-from typing import Any, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 
 import dask.dataframe as dd
+import dask.dataframe.groupby as ddgb
+import pandas
+import toolz
 
+import ibis.common.exceptions as com
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.window as win
-from ibis.backends.dask.core import execute, execute_with_scope
+from ibis.backends.dask.core import (
+    compute_time_context,
+    execute,
+    execute_with_scope,
+)
 from ibis.backends.dask.dispatch import execute_node
 from ibis.backends.dask.execution.util import (
     _pandas_dtype_from_dd_scalar,
     _wrap_dd_scalar,
     add_partitioned_sorted_column,
+    compute_sorted_frame,
     make_meta_series,
+)
+from ibis.backends.pandas.core import (
+    date_types,
+    integer_types,
+    simple_types,
+    timedelta_types,
+    timestamp_types,
+)
+from ibis.backends.pandas.execution.window import (
+    _post_process_group_by_order_by,
+    get_aggcontext,
 )
 from ibis.expr.scope import Scope
 from ibis.expr.typing import TimeContext
 
 
+def _check_valid_window(window: win.Window, operand_op):
+    # TODO consolidate this with pandas
+    if window.how == "range" and any(
+        not isinstance(ob.type(), (dt.Time, dt.Date, dt.Timestamp))
+        for ob in window._order_by
+    ):
+        raise NotImplementedError(
+            "The pandas backend only implements range windows with temporal "
+            "ordering keys"
+        )
+
+    if (
+        window._order_by
+        and window.following != 0
+        and not isinstance(operand_op, ops.ShiftBase)
+    ):
+        raise com.OperationNotDefinedError(
+            'Window functions affected by following with order_by are not '
+            'implemented'
+        )
+
+    if len(window._order_by) > 1:
+        raise NotImplementedError(
+            "Multiple order_bys are not supported in the dask backend"
+        )
+
+    if window._order_by and window._group_by:
+        raise NotImplementedError(
+            "Grouped and order windows are not supported in the dask backend."
+        )
+
+
+def _get_post_process_function(window: win.Window) -> Callable:
+    # TODO consolidate with pandas
+    if window._group_by:
+        if window._order_by:
+            return _post_process_group_by_order_by
+        else:
+            return _post_process_group_by
+    else:
+        if window._order_by:
+            return _post_process_order_by
+        else:
+            return _post_process_empty
+
+
 def _post_process_empty(
     result: Any,
     parent: Union[dd.Series, dd.DataFrame],
+    order_by: List[str],
+    group_by: List[str],
     timecontext: Optional[TimeContext],
+    **kwargs,
 ) -> dd.Series:
     """Post process non grouped, non ordered windows.
 
@@ -48,7 +118,46 @@ def _post_process_empty(
         return series[0]
     else:
         # Project any non delayed object to the shape of "parent"
-        return parent.apply(lambda row: result, meta=(None, 'object'))
+        if isinstance(parent, dd.DataFrame):
+            parent = parent[parent.columns[0]]
+
+        return parent.apply(
+            lambda row, result=result: result, meta=(None, 'object')
+        )
+
+
+def _post_process_order_by(
+    series,
+    parent: dd.DataFrame,
+    order_by: List[str],
+    group_by: List[str],
+    timecontext: Optional[TimeContext],
+    **kwargs,
+) -> dd.Series:
+    """Functions like pandas with dasky argsorting"""
+    assert order_by and not group_by
+    return series
+
+
+def _post_process_group_by(
+    series,
+    parent: dd.DataFrame,
+    order_by: List[str],
+    group_by: List[str],
+    timecontext: Optional[TimeContext],
+    op,
+    **kwargs,
+) -> dd.Series:
+    if not isinstance(op.expr._arg, ops.AnalyticVectorizedUDF):
+        series = dd.merge(
+            parent[series.index.name].to_frame(),
+            series.to_frame(),
+            left_on=series.index.name,
+            right_index=True,
+        )[series.name]
+        series.divisions = parent.divisions
+
+    return series
 
 
 @execute_node.register(ops.Window, dd.Series, win.Window)
@@ -62,57 +171,22 @@ def execute_window_op(
     clients=None,
     **kwargs,
 ):
-    # Currently this acts as an "unwrapper" for trivial windows (i.e. those
-    # with no ordering/grouping/preceding/following functionality).
-    if not all(
-        [
-            window.preceding is None,
-            window.following is None,
-            not window._order_by,
-        ]
-    ):
-        raise NotImplementedError(
-            "Window operations are unsupported in the dask backend"
-        )
+    _check_valid_window(window, op.expr.op())
 
-    if window._group_by:
-        # there's lots of complicated logic that only applies to grouped
-        # windows
-        return execute_grouped_window_op(
-            op,
-            data,
-            window,
-            scope,
-            timecontext,
-            aggcontext,
-            clients,
-            **kwargs,
-        )
-
-    result = execute_with_scope(
-        expr=op.expr,
-        scope=scope,
-        timecontext=timecontext,
-        aggcontext=aggcontext,
-        clients=clients,
-        **kwargs,
-    )
-    return _post_process_empty(result, data, timecontext)
-
-
-def execute_grouped_window_op(
-    op,
-    data,
-    window,
-    scope,
-    timecontext,
-    aggcontext,
-    clients,
-    **kwargs,
-):
     # extract the parent
     (root,) = op.root_tables()
     root_expr = root.to_expr()
+
+    adjusted_timecontext = None
+    if timecontext:
+        arg_timecontexts = compute_time_context(
+            op, timecontext=timecontext, clients=clients, scope=scope
+        )
+        # timecontext is the original time context required by parent node
+        # of this Window, while adjusted_timecontext is the adjusted context
+        # of this Window, since we are doing a manual execution here, use
+        # adjusted_timecontext in later execution phases
+        adjusted_timecontext = arg_timecontexts[0]
 
     root_data = execute(
         root_expr,
@@ -123,37 +197,147 @@ def execute_grouped_window_op(
         **kwargs,
     )
 
-    group_by = window._group_by
-    grouping_keys = [
-        key_op.name for key_op in map(operator.methodcaller('op'), group_by)
-    ]
+    if not (window._order_by or window._group_by):
+        source = root_data
+    if window._order_by:
+        source, order_by_col = compute_sorted_frame(
+            root_data, window._order_by[0], timecontext
+        )
+        order_by_col = [order_by_col]
+    else:
+        order_by_col = []
 
-    grouped_root_data = root_data.groupby(grouping_keys)
+    if window._group_by:
+        group_by_cols = get_grouping_keys(window._group_by)
+        source = root_data.groupby(group_by_cols)
+    else:
+        group_by_cols = []
+
+    # breakpoint()
     scope = scope.merge_scopes(
         [
-            Scope({t: grouped_root_data}, timecontext)
+            Scope({t: source}, adjusted_timecontext)
             for t in op.expr.op().root_tables()
         ],
         overwrite=True,
     )
+    if not window._group_by:
+        aggcontext = get_aggcontext(
+            window,
+            scope=scope,
+            operand=op.expr,
+            parent=source,
+            group_by=group_by_cols,
+            order_by=order_by_col,
+            **kwargs,
+        )
 
     result = execute_with_scope(
         expr=op.expr,
         scope=scope,
-        timecontext=timecontext,
+        timecontext=adjusted_timecontext,
         aggcontext=aggcontext,
         clients=clients,
         **kwargs,
     )
-    # If the grouped operation we performed is not an analytic UDF we have to
-    # realign the output to the input.
-    if not isinstance(op.expr._arg, ops.AnalyticVectorizedUDF):
-        result = dd.merge(
-            root_data[result.index.name].to_frame(),
-            result.to_frame(),
-            left_on=result.index.name,
-            right_index=True,
-        )[result.name]
-        result.divisions = root_data.divisions
 
+    return _get_post_process_function(window)(
+        result,
+        root_data,
+        order_by_col,
+        group_by_cols,
+        timecontext,
+        op=op,
+    )
+
+
+def get_grouping_keys(group_by):
+    return [
+        key_op.name for key_op in map(operator.methodcaller('op'), group_by)
+    ]
+
+
+@execute_node.register(
+    (ops.Lead, ops.Lag),
+    (dd.Series, ddgb.SeriesGroupBy),
+    integer_types + (type(None),),
+    simple_types + (type(None),),
+)
+def execute_series_lead_lag(op, data, offset, default, **kwargs):
+    func = toolz.identity if isinstance(op, ops.Lag) else operator.neg
+    result = data.shift(func(1 if offset is None else offset))
+    return post_lead_lag(result, default)
+
+
+@execute_node.register(
+    (ops.Lead, ops.Lag),
+    (dd.Series, ddgb.SeriesGroupBy),
+    timedelta_types,
+    date_types + timestamp_types + (str, type(None)),
+)
+def execute_series_lead_lag_timedelta(
+    op, data, offset, default, aggcontext=None, **kwargs
+):
+    """An implementation of shifting a column relative to another one that is
+    in units of time rather than rows.
+    """
+    # lagging adds time (delayed), leading subtracts time (moved up)
+    func = operator.add if isinstance(op, ops.Lag) else operator.sub
+    group_by = aggcontext.group_by
+    order_by = aggcontext.order_by
+
+    # get the parent object from which `data` originated
+    parent = aggcontext.parent
+
+    # get the DataFrame from the parent object, handling the DataFrameGroupBy
+    # case
+    parent_df = getattr(parent, 'obj', parent)
+
+    # perform the time shift
+    adjusted_parent_df = parent_df.assign(
+        **{k: func(parent_df[k], offset) for k in order_by}
+    )
+
+    # index the parent *after* adjustment
+    adjusted_indexed_parent = adjusted_parent_df.set_index(group_by + order_by)
+
+    # get the column we care about
+    result = adjusted_indexed_parent[getattr(data, 'obj', data).name]
+
+    # add a default if necessary
+    return post_lead_lag(result, default)
+
+
+def post_lead_lag(result, default):
+    if not pandas.isnull(default):
+        return result.fillna(default)
     return result
+
+
+@execute_node.register(ops.FirstValue, dd.Series)
+def execute_series_first_value(op, data, **kwargs):
+    arr = data.head(1, compute=False).values
+    # normally you shouldn't do this but we know that there is one row
+    # consider upstreaming to dask
+    arr._chunks = ((1,),)
+    return arr[0]
+
+
+@execute_node.register(ops.FirstValue, ddgb.SeriesGroupBy)
+def execute_series_group_by_first_value(op, data, aggcontext=None, **kwargs):
+    return aggcontext.agg(data, 'first')
+
+
+@execute_node.register(ops.LastValue, dd.Series)
+def execute_series_last_value(op, data, **kwargs):
+    arr = data.tail(1, compute=False).values
+
+    # normally you shouldn't do this but we know that there is one row
+    # consider upstreaming to dask
+    arr._chunks = ((1,),)
+    return arr[0]
+
+
+@execute_node.register(ops.LastValue, ddgb.SeriesGroupBy)
+def execute_series_group_by_last_value(op, data, aggcontext=None, **kwargs):
+    return aggcontext.agg(data, 'last')

--- a/ibis/backends/dask/tests/execution/test_window.py
+++ b/ibis/backends/dask/tests/execution/test_window.py
@@ -1,0 +1,187 @@
+# import io
+# from datetime import date
+# from operator import methodcaller
+
+# import numpy as np
+import pandas as pd
+import pytest
+from dask.dataframe.utils import tm
+
+import ibis
+
+# import ibis.common.exceptions as com
+# import ibis.expr.datatypes as dt
+# import ibis.expr.operations as ops
+# from ibis.backends.dask import Backend
+from ibis.backends.dask.execution import execute
+from ibis.backends.pandas.aggcontext import AggregationContext, window_agg_udf
+
+# from packaging.version import parse as vparse
+
+
+# from ibis.expr.scope import Scope
+# from ibis.expr.window import get_preceding_value, rows_with_max_lookback
+# from ibis.udf.vectorized import reduction
+
+# These custom classes are used inn test_custom_window_udf
+
+
+class CustomInterval:
+    def __init__(self, value):
+        self.value = value
+
+    # These are necessary because ibis.expr.window
+    # will compare preceding and following
+    # with 0 to see if they are valid
+    def __lt__(self, other):
+        return self.value < other
+
+    def __gt__(self, other):
+        return self.value > other
+
+
+class CustomWindow(ibis.expr.window.Window):
+    """This is a dummy custom window that return n preceding rows
+    where n is defined by CustomInterval.value."""
+
+    def _replace(self, **kwds):
+        new_kwds = {
+            'group_by': kwds.get('group_by', self._group_by),
+            'order_by': kwds.get('order_by', self._order_by),
+            'preceding': kwds.get('preceding', self.preceding),
+            'following': kwds.get('following', self.following),
+            'max_lookback': kwds.get('max_lookback', self.max_lookback),
+            'how': kwds.get('how', self.how),
+        }
+        return CustomWindow(**new_kwds)
+
+
+class CustomAggContext(AggregationContext):
+    def __init__(
+        self, parent, group_by, order_by, output_type, max_lookback, preceding
+    ):
+        super().__init__(
+            parent=parent,
+            group_by=group_by,
+            order_by=order_by,
+            output_type=output_type,
+            max_lookback=max_lookback,
+        )
+        self.preceding = preceding
+
+    def agg(self, grouped_data, function, *args, **kwargs):
+        upper_indices = pd.Series(range(1, len(self.parent) + 2))
+        window_sizes = (
+            grouped_data.rolling(self.preceding.value + 1, min_periods=0)
+            .count()
+            .reset_index(drop=True)
+        )
+        lower_indices = upper_indices - window_sizes
+        mask = upper_indices.notna()
+
+        result_index = grouped_data.obj.index
+
+        result = window_agg_udf(
+            grouped_data,
+            function,
+            lower_indices,
+            upper_indices,
+            mask,
+            result_index,
+            self.dtype,
+            self.max_lookback,
+            *args,
+            **kwargs,
+        )
+
+        return result
+
+
+@pytest.fixture(scope='session')
+def sort_kind():
+    return 'mergesort'
+
+
+default = pytest.mark.parametrize('default', [ibis.NA, ibis.literal('a')])
+row_offset = pytest.mark.parametrize(
+    'row_offset', list(map(ibis.literal, [-1, 1, 0]))
+)
+range_offset = pytest.mark.parametrize(
+    'range_offset',
+    [
+        ibis.interval(days=1),
+        2 * ibis.interval(days=1),
+        -2 * ibis.interval(days=1),
+    ],
+)
+
+
+@pytest.fixture
+def row_window():
+    return ibis.window(following=0, order_by='plain_int64')
+
+
+@pytest.fixture
+def range_window():
+    return ibis.window(following=0, order_by='plain_datetimes_naive')
+
+
+@pytest.fixture
+def custom_window():
+    return CustomWindow(
+        preceding=CustomInterval(1),
+        following=0,
+        group_by='dup_ints',
+        order_by='plain_int64',
+    )
+
+
+@default
+@row_offset
+def test_lead(t, df, row_offset, default, row_window):
+    expr = t.dup_strings.lead(row_offset, default=default).over(row_window)
+    result = expr.compile()
+    expected = df.dup_strings.shift(execute(-row_offset))
+    if default is not ibis.NA:
+        expected = expected.fillna(execute(default))
+    tm.assert_series_equal(result.compute(), expected.compute())
+
+
+@default
+@row_offset
+def test_lag(t, df, row_offset, default, row_window):
+    expr = t.dup_strings.lag(row_offset, default=default).over(row_window)
+    result = expr.compile()
+    expected = df.dup_strings.shift(execute(row_offset))
+    if default is not ibis.NA:
+        expected = expected.fillna(execute(default))
+    tm.assert_series_equal(result.compute(), expected.compute())
+
+
+@default
+@range_offset
+def test_lag_delta(t, df, range_offset, default, range_window):
+    expr = t.dup_strings.lag(range_offset, default=default).over(range_window)
+    result = expr.compile()
+    expected = (
+        df[['plain_datetimes_naive', 'dup_strings']]
+        .set_index('plain_datetimes_naive')
+        .squeeze()
+        .shift(freq=execute(range_offset))
+        .reset_index(drop=True)
+    )
+    if default is not ibis.NA:
+        expected = expected.fillna(execute(default))
+    tm.assert_series_equal(result.compute(), expected.compute())
+
+
+def test_first(t, df):
+    expr = t.dup_strings.first()
+    result = expr.compile()
+    assert result.compute() == df.dup_strings.compute().iloc[0]
+
+
+def test_last(t, df):
+    expr = t.dup_strings.last()
+    result = expr.compile()
+    assert result.compute() == df.dup_strings.compute().iloc[-1]

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -458,7 +458,7 @@ def test_grouped_unbounded_window(
             lambda df: df.float_col.shift(1),
             False,
             id='unordered-lag',
-            marks=pytest.mark.notimpl(["dask", "mysql", "pyspark"]),
+            marks=pytest.mark.notimpl(["mysql", "pyspark"]),
         ),
         param(
             lambda t, win: t.float_col.lead().over(win),
@@ -472,7 +472,7 @@ def test_grouped_unbounded_window(
             lambda df: df.float_col.shift(-1),
             False,
             id='unordered-lead',
-            marks=pytest.mark.notimpl(["dask", "mysql", "pyspark"]),
+            marks=pytest.mark.notimpl(["mysql", "pyspark"]),
         ),
         param(
             lambda t, win: calc_zscore(t.double_col).over(win),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,8 +235,10 @@ norecursedirs = ["site-packages", "dist-packages"]
 markers = [
   "backend: tests specific to a backend",
   "core: tests that do not required a backend",
+  "csv: ???",
   "geospatial: tests for geospatial functionality",
   "hdfs: Hadoop file system tests",
+  "hdf5: ???",
   "min_spark_version: backends tests that require a specific version of pyspark to pass",
   "skip_backends: skip tests on the provided backends",
   "notimpl: functionality that isn't implemented in ibis",
@@ -254,6 +256,7 @@ markers = [
   "postgres: PostgreSQL tests",
   "pyspark: PySpark tests",
   "sqlite: SQLite tests",
+  "parquet: ???"
 ]
 
 [tool.black]


### PR DESCRIPTION
Previously dask supported "noop" windows. This PR adds some limited window functionality. Draft to see how far I can reasonably get while keeping this a reasonable size. 

Notes:
- dask only supports single value sorts, so any window with grouping and sorting is not supported
- I'm trying to keep the structure quite close the pandas backend, which will make some eventual consolidation and refactoring much easier to do. However, the pandas windowing code definitely needs some broad refactoring so things look a bit messy. 