### PR TITLE
feat(api): accept `Schema` objects in public `ibis.schema` function

### DIFF
--- a/ibis/tests/expr/test_schema.py
+++ b/ibis/tests/expr/test_schema.py
@@ -194,3 +194,8 @@ def test_api_accepts_schema_objects():
     s1 = ibis.schema(dict(a="int", b="str"))
     s2 = ibis.schema(s1)
     assert s1 == s2
+
+
+def test_names_types():
+    s = ibis.schema(names=["a"], types=["array<float64>"])
+    assert s == ibis.schema(dict(a="array<float64>"))

--- a/ibis/tests/expr/test_schema.py
+++ b/ibis/tests/expr/test_schema.py
@@ -188,3 +188,9 @@ def test_apply_to_column_order(df):
     expected = df.rename({"A": "a"}, axis=1)
     new_df = schema.apply_to(df.copy())
     tm.assert_frame_equal(new_df, expected)
+
+
+def test_api_accepts_schema_objects():
+    s1 = ibis.schema(dict(a="int", b="str"))
+    s2 = ibis.schema(s1)
+    assert s1 == s2


### PR DESCRIPTION
This PR refactors `ibis.schema` to use `ibis.expr.schema.schema`, which allows `ibis.schema` to accept `Schema` objects as input. Closes #4159.