### PR TITLE
chore(impala): workaround retry failure by adding a `retries` pass through argument

### DIFF
--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -208,6 +208,7 @@ class Backend(BaseSQLBackend):
         kerberos_service_name: str = "impala",
         pool_size: int = 8,
         hdfs_client: fsspec.spec.AbstractFileSystem | None = None,
+        retries: int = 3,
     ):
         """Create an Impala Backend for use with Ibis.
 
@@ -240,6 +241,9 @@ class Backend(BaseSQLBackend):
             | `'GSSAPI'` | Kerberos-secured clusters      |
         kerberos_service_name
             Specify a particular `impalad` service principal.
+        retries
+            Number of times to try connecting with HiveServer2 before
+            failing
 
         Examples
         --------
@@ -261,19 +265,20 @@ class Backend(BaseSQLBackend):
         self._temp_objects = set()
         self._hdfs = hdfs_client
 
-        params = {
-            'host': host,
-            'port': port,
-            'database': database,
-            'timeout': timeout,
-            'use_ssl': use_ssl,
-            'ca_cert': str(ca_cert),
-            'user': user,
-            'password': password,
-            'auth_mechanism': auth_mechanism,
-            'kerberos_service_name': kerberos_service_name,
-        }
-        self.con = ImpalaConnection(pool_size=pool_size, **params)
+        self.con = ImpalaConnection(
+            pool_size=pool_size,
+            host=host,
+            port=port,
+            database=database,
+            timeout=timeout,
+            use_ssl=use_ssl,
+            ca_cert=str(ca_cert),
+            user=user,
+            password=password,
+            auth_mechanism=auth_mechanism,
+            kerberos_service_name=kerberos_service_name,
+            retries=retries,
+        )
 
         self._ensure_temp_db_exists()
 

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import concurrent.futures
 import itertools
+import multiprocessing
 import os
 import subprocess
 from pathlib import Path
@@ -149,6 +150,7 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
             if with_hdfs
             else None,
             database=database,
+            pool_size=min(8, multiprocessing.cpu_count()),
         )
 
     def _get_original_column_names(self, tablename: str) -> list[str]:

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -55,6 +55,7 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
         con = ibis.impala.connect(
             host=env.impala_host,
             port=env.impala_port,
+            retries=env.retries,
             hdfs_client=fsspec.filesystem(
                 env.hdfs_protocol,
                 host=env.nn_host,
@@ -137,6 +138,7 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
         return ibis.impala.connect(
             host=env.impala_host,
             port=env.impala_port,
+            retries=env.retries,
             auth_mechanism=env.auth_mechanism,
             hdfs_client=fsspec.filesystem(
                 env.hdfs_protocol,
@@ -178,6 +180,10 @@ class IbisTestEnv:
     def __init__(self):
         if options.impala is None:
             ibis.backends.impala.Backend.register_options()
+
+    @property
+    def retries(self):
+        return 10
 
     @property
     def impala_host(self):


### PR DESCRIPTION
Hopefully this alleviates some of the impala test flakiness until we can merge the 4.x.x branch into master