### PR TITLE
bring back null parse

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -1084,6 +1084,7 @@ def parse(text: str) -> DataType:
         | spaceless_string("category").result(category)
         | spaceless_string("geometry").result(GeoSpatial(geotype='geometry'))
         | spaceless_string("geography").result(GeoSpatial(geotype='geography'))
+        | spaceless_string("null").result(null)
         | geotype_parser("linestring", LineString)
         | geotype_parser("polygon", Polygon)
         | geotype_parser("point", Point)

--- a/ibis/tests/expr/test_datatypes.py
+++ b/ibis/tests/expr/test_datatypes.py
@@ -507,3 +507,7 @@ def test_struct_datatype_subclass_from_tuples():
 def test_parse_type_warns():
     with pytest.warns(FutureWarning):
         dt.parse_type("int64")
+
+
+def test_parse_null():
+    assert dt.parse("null") == dt.null


### PR DESCRIPTION
This PR fixes a regression where parsing the string `"null"` stopped working. Closes #3879.