### PR TITLE
ci: only run coverage on pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,17 @@
 comment:
-  layout: "reach, diff, flags, files"
+  layout: "reach, diff, files"
   behavior: default
-  require_changes: false # if true: only post the comment if coverage changes
-  require_base: no # [yes :: must have a base report to post]
-  require_head: yes # [yes :: must have a head report to post]
+  require_changes: true # if true: only post the comment if coverage changes
+  require_base: false # [yes :: must have a base report to post]
+  require_head: true # [yes :: must have a head report to post]
   branches: null
 ignore:
   - "docs/**"
+coverage:
+  status:
+    project:
+      default:
+        only_pulls: true
+    patch:
+      default:
+        only_pulls: true


### PR DESCRIPTION
This PR changes our codecov configuration to only run coverage against PRs.