### PR TITLE
ci: ensure tpc-h test deps installed

### DIFF
--- a/.github/workflows/ibis-tpch-queries.yml
+++ b/.github/workflows/ibis-tpch-queries.yml
@@ -22,23 +22,27 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: install python
-        uses: actions/setup-python@v4
-        id: install_python
-        with:
-          python-version: "3.10"
-
-      - run: python -m pip install --upgrade pip click sqlparse coverage
-
-      - name: install ibis
-        run: python -m pip install ".[duckdb]"
-
       - name: clone tpc-queries
         uses: actions/checkout@v3
         with:
           repository: ibis-project/tpc-queries
           path: ./tpc-queries
           ref: master
+
+      - name: install python
+        uses: actions/setup-python@v4
+        id: install_python
+        with:
+          python-version: "3.10"
+
+      - run: python -m pip install --upgrade pip coverage
+
+      - name: install tpc-queries dependencies
+        working-directory: tpc-queries
+        run: python -m pip install -r requirements.txt
+
+      - name: install ibis
+        run: python -m pip install ".[sqlite,duckdb]"
 
       - name: generate tpc-h data
         working-directory: tpc-queries


### PR DESCRIPTION
Since these tests are installed from a separate repo, we'll want to install the requirements from that repo to ensure the tests still run properly. Currently things are broken since `ibis-substrait` is missing.