### PR TITLE
fix(pandas): force backend options registration on trace.enable() calls

### DIFF
--- a/ibis/backends/dask/trace.py
+++ b/ibis/backends/dask/trace.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 from datetime import datetime
 
+import ibis
 from ibis.backends.pandas.dispatcher import TwoLevelDispatcher
 from ibis.config import options
 from ibis.expr import types as ir
@@ -69,6 +70,10 @@ _trace_funcs = set()
 
 def enable():
     """Enable tracing."""
+    if options.dask is None:
+        # dask options haven't been registered yet - force module __getattr__
+        ibis.dask
+
     options.dask.enable_trace = True
     logging.getLogger('ibis.dask.trace').setLevel(logging.DEBUG)
 

--- a/ibis/backends/pandas/trace.py
+++ b/ibis/backends/pandas/trace.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 from datetime import datetime
 
+import ibis
 from ibis.backends.pandas.dispatcher import TwoLevelDispatcher
 from ibis.config import options
 from ibis.expr import types as ir
@@ -82,6 +83,9 @@ _trace_funcs = set()
 
 def enable():
     """Enable tracing."""
+    if options.pandas is None:
+        # pandas options haven't been registered yet - force module __getattr__
+        ibis.pandas
     options.pandas.enable_trace = True
     logging.getLogger('ibis.backends.pandas.trace').setLevel(logging.DEBUG)
 


### PR DESCRIPTION
Closes https://github.com/ibis-project/ibis/issues/3171. 

We already had similarish logic in the `trace` functions themselves. 