### PR TITLE
feat(ux): use `rich` to format `Table.info()` output

### DIFF
--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -5,11 +5,15 @@ from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, Hashable
 from weakref import WeakValueDictionary
 
+from rich.console import Console
+
 from ibis.common.caching import WeakCache
 from ibis.common.validators import ImmutableProperty, Optional, Validator
 from ibis.util import frozendict
 
 EMPTY = inspect.Parameter.empty  # marker for missing argument
+
+console = Console()
 
 
 class BaseMeta(ABCMeta):

--- a/poetry.lock
+++ b/poetry.lock
@@ -316,7 +316,7 @@ typing-extensions = ">=4.0.1,<5.0.0"
 name = "commonmark"
 version = "0.9.1"
 description = "Python parser for the CommonMark Markdown spec"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -1690,7 +1690,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pygments"
 version = "2.12.0"
 description = "Pygments is a syntax highlighting package written in Python."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -2053,7 +2053,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 name = "rich"
 version = "12.5.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6.3,<4.0.0"
 
@@ -2170,7 +2170,7 @@ tests = ["cython", "littleutils", "pygments", "typeguard", "pytest"]
 name = "tabulate"
 version = "0.8.10"
 description = "Pretty-print tabular data"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -2403,7 +2403,7 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "5f1ba45df83838aef0d7f83b4ce289930dbe93eef08df5d4654fae6dc6403889"
+content-hash = "711603383c942072e373fc3c3600018d003e69a4092d7d2b53340cb40ed7172f"
 
 [metadata.files]
 absolufy-imports = [
@@ -3663,6 +3663,7 @@ pyparsing = [
 ]
 pyproj = [
     {file = "pyproj-3.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:473961faef7a9fd723c5d432f65220ea6ab3854e606bf84b4d409a75a4261c78"},
+    {file = "pyproj-3.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07c9d8d7ec009bbac09e233cfc725601586fe06880e5538a3a44eaf560ba3a62"},
     {file = "pyproj-3.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fef9c1e339f25c57f6ae0558b5ab1bbdf7994529a30d8d7504fc6302ea51c03"},
     {file = "pyproj-3.3.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:140fa649fedd04f680a39f8ad339799a55cb1c49f6a84e1b32b97e49646647aa"},
     {file = "pyproj-3.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b59c08aea13ee428cf8a919212d55c036cc94784805ed77c8f31a4d1f541058c"},
@@ -3675,6 +3676,7 @@ pyproj = [
     {file = "pyproj-3.3.1-cp38-cp38-win32.whl", hash = "sha256:c99f7b5757a28040a2dd4a28c9805fdf13eef79a796f4a566ab5cb362d10630d"},
     {file = "pyproj-3.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:5dac03d4338a4c8bd0f69144c527474f517b4cbd7d2d8c532cd8937799723248"},
     {file = "pyproj-3.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:56b0f9ee2c5b2520b18db30a393a7b86130cf527ddbb8c96e7f3c837474a9d79"},
+    {file = "pyproj-3.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f1032e5dfb50eae06382bcc7b9011b994f7104d932fe91bd83a722275e30e8ce"},
     {file = "pyproj-3.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f92d8f6514516124abb714dce912b20867831162cfff9fae2678ef07b6fcf0f"},
     {file = "pyproj-3.3.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1ef1bfbe2dcc558c7a98e2f1836abdcd630390f3160724a6f4f5c818b2be0ad5"},
     {file = "pyproj-3.3.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ca5f32b56210429b367ca4f9a57ffe67975c487af82e179a24370879a3daf68"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pandas = ">=1.2.5,<2"
 parsy = ">=1.3.0,<2"
 pydantic = ">=1.9.0,<2"
 regex = ">=2021.7.6"
-tabulate = ">=0.8.9,<1"
+rich = ">=12.4.4,<13"
 toolz = ">=0.11,<0.13"
 clickhouse-cityhash = { version = ">=1.0.2,<2", optional = true }
 clickhouse-driver = { version = ">=0.1,<0.3", optional = true, extras = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,7 +132,7 @@ pycparser==2.21; python_version >= "3.7" and python_full_version < "3.0.0" and i
 pydantic==1.9.1; python_full_version >= "3.6.1"
 pydocstyle==6.1.1; python_version >= "3.6"
 pyflakes==2.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
-pygments==2.12.0; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.8" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
+pygments==2.12.0; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and python_version >= "3.8" and python_version < "4" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
 pymdown-extensions==9.5; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
 pymysql==1.0.2; python_version >= "3.6"
 pyparsing==3.0.9; python_full_version >= "3.6.8" and python_version >= "3.8" and python_full_version < "4.0.0"
@@ -161,7 +161,7 @@ pyzmq==23.2.0; python_version >= "3.7"
 questionary==1.10.0; python_version >= "3.6" and python_version < "4.0" and python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 regex==2022.7.24; python_version >= "3.6"
 requests==2.28.1; python_version >= "3.7" and python_version < "4"
-rich==12.5.1; python_full_version >= "3.6.3" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
+rich==12.5.1; python_full_version >= "3.6.3" and python_full_version < "4.0.0"
 shapely==1.8.2; python_version >= "3.6"
 six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "3.9"
 smmap==5.0.0; python_version >= "3.7"
@@ -170,7 +170,7 @@ soupsieve==2.3.2.post1; python_full_version >= "3.7.1" and python_version < "4" 
 sqlalchemy==1.4.39; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 sqlparse==0.4.2; python_version >= "3.5"
 stack-data==0.3.0; python_version >= "3.8"
-tabulate==0.8.10; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+tabulate==0.8.10; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 termcolor==1.1.0; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and python_version >= "3.5"
 thrift-sasl==0.4.3
 thrift==0.11.0; python_version >= "3.0"
@@ -182,7 +182,7 @@ tomlkit==0.11.1; python_version >= "3.6" and python_version < "4.0" and python_f
 toolz==0.12.0; python_version >= "3.5"
 tornado==6.2; python_version >= "3.7"
 traitlets==5.3.0; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.8"
-typing-extensions==4.3.0; python_version >= "3.7" and python_full_version >= "3.6.3" and python_version < "3.9" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
+typing-extensions==4.3.0; python_version >= "3.7" and python_full_version >= "3.6.3" and python_full_version < "4.0.0" and python_version < "3.9" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
 tzdata==2022.1; python_version >= "3.6" and python_version < "4" and platform_system == "Windows" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.6.0")
 tzlocal==4.2; python_version >= "3.6" and python_version < "4"
 urllib3==1.26.10; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.7"

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ install_requires = [
     'parsy>=1.3.0,<2',
     'pydantic>=1.9.0,<2',
     'regex>=2021.7.6',
-    'tabulate>=0.8.9,<1',
+    'rich>=12.4.4,<13',
     'toolz>=0.11,<0.13',
 ]
 


### PR DESCRIPTION
**Please read the entire description before reviewing**.

This PR introduces `rich` for outputting the content of `Table.info()`.

Ultimately I want to use `rich` to format the `Node` tree including datatypes
and schemas, so that deeply nested objects are approachable.

This PR is just a taste of using it in a non-invasive place.

**Note: this DOES NOT change the `Expr` repr**.

The `Expr` repr will continue to be the same: optimized for speed and concision.

Here's a screenshot of what it looks like after this PR:

![image](https://user-images.githubusercontent.com/417981/179495859-10e5ed63-dc52-4c1c-962f-fc4b39b2c9fa.png)