### PR TITLE
fix(duckdb): ensure that paths with non-extension `.` chars are parsed correctly

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -57,7 +57,8 @@ def _csv(_, path, table_name=None):
 
 @_register.register(r"(?:file://)?(?P<path>.+)", priority=9)
 def _file(_, path, table_name=None):
-    *_, extension = str(path).split(os.extsep, 1)
+    num_sep_chars = len(os.extsep)
+    extension = "".join(Path(path).suffixes)[num_sep_chars:]
     return _register(f"{extension}://{path}", table_name=table_name)
 
 

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -64,6 +64,18 @@ def test_register_csv(
     assert table.count().execute()
 
 
+def test_register_with_dotted_name(data_directory, tmp_path):
+    con = ibis.duckdb.connect()
+    basename = "foo.bar.baz/diamonds.csv"
+    f = tmp_path.joinpath(basename)
+    f.parent.mkdir()
+    data = data_directory.joinpath("diamonds.csv").read_bytes()
+    f.write_bytes(data)
+    con.register(str(f.absolute()))
+    table = con.table("diamonds")
+    assert table.count().execute()
+
+
 @pytest.mark.parametrize(
     "fname, in_table_name, out_table_name",
     [


### PR DESCRIPTION
This PR fixes an issue where the non-specific `file://`-or-no-prefix dispatcher rule split on the first `os.extsep` which meant
that paths like `/tmp/python3.10` would return an extension of `10`. Here we change it to use `Path.suffixes` instead.
