### PR TITLE
docs: fix relative links in tutorial

### DIFF
--- a/docs/tutorial/01-Introduction-to-Ibis.ipynb
+++ b/docs/tutorial/01-Introduction-to-Ibis.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "### Getting started\n",
     "\n",
-    "To start using Ibis, you need a Python environment with Ibis installed. Follow the [installation instructions for SQLite](/backends/SQLite/#install) to setup an environment.\n",
+    "To start using Ibis, you need a Python environment with Ibis installed. Follow the <a href='../../backends/SQLite#install'>installation instructions for SQLite</a> to setup an environment.\n",
     "\n",
     "Once you have your environment ready, to start using Ibis simply import the `ibis` module:"
    ]

--- a/docs/tutorial/04-More-Value-Expressions.ipynb
+++ b/docs/tutorial/04-More-Value-Expressions.ipynb
@@ -48,7 +48,7 @@
    "source": [
     "## Type casting\n",
     "\n",
-    "The [Ibis type system](/api/datatypes) supports the most common data types used in analytics, including support for nested types like lists, structs, and maps.\n",
+    "The <a href='../../api/datatypes'>Ibis type system</a> supports the most common data types used in analytics, including support for nested types like lists, structs, and maps.\n",
     "\n",
     "Type names can be used to cast from one type to another."
    ]


### PR DESCRIPTION
mkdocs-jupyter cannot find relative links in upper directories with the
standard markdown syntax
(https://github.com/danielfrg/mkdocs-jupyter/issues/27). Switching to using relative hyperlinking with `<a>`.

Closes #4064, closes #4201

I tried to test using `mike` versioning in my local build, but had a hard time figuring out how to add my `docs-relative` branch to it. I tested with the basic `mkdocs serve` to make sure it was at least functional there. 

`mike` advice is welcome. Otherwise this has a decent chance of succeeding, and I feel worth trying out with the `dev` docs.