### PR TITLE
feat(api): add `StructValue.lift()` and `Table.unpack(*args)` API for projecting struct fields

### DIFF
--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -5,7 +5,20 @@ import pytest
 import ibis
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
+from ibis import _
 from ibis.tests.util import assert_pickle_roundtrip
+
+
+@pytest.fixture
+def t():
+    return ibis.table(
+        dict(a="struct<b: float, c: string>", d="string"), name="t"
+    )
+
+
+@pytest.fixture
+def s():
+    return ibis.table(dict(a="struct<f: float, g: string>"), name="s")
 
 
 def test_struct_operations():
@@ -42,3 +55,34 @@ def test_struct_pickle():
     )
 
     assert_pickle_roundtrip(struct_scalar_expr)
+
+
+def test_lift(t):
+    assert t.a.lift().equals(t[_.a.b, _.a.c])
+
+
+def test_unpack_from_table(t):
+    assert t.unpack("a").equals(t[_.a.b, _.a.c, _.d])
+
+
+def test_lift_join(t, s):
+    join = t.join(s, t.d == s.a.g)
+    result = join.a_y.lift()
+    expected = join[_.a_y.f, _.a_y.g]
+    assert result.equals(expected)
+
+
+def test_unpack_join_from_table(t, s):
+    join = t.join(s, t.d == s.a.g)
+    result = join.unpack("a_y")
+    expected = join[_.a_x, _.d, _.a_y.f, _.a_y.g]
+    assert result.equals(expected)
+
+
+def test_nested_lift():
+    t = ibis.table(
+        {"a": "struct<b:struct<x: int, y: int>, c: string>", "d": "string"},
+        name="t",
+    )
+    expr = t.a.b.lift()
+    assert expr.schema() == ibis.schema({"x": "int", "y": "int"})


### PR DESCRIPTION
This PR adds a `Table.unpack()` API to support projecting struct fields into
their child tables as well as a `StructValue.lift` method that lifts struct fields into a table.

Tests and docstrings are included and showcase examples.
