### PR TITLE
fix(repr): allow DestructValue selections to be formatted by fmt

### DIFF
--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -447,12 +447,18 @@ def type_info(datatype: dt.DataType) -> str:
 def _fmt_selection_column_value_expr(
     expr: ir.Value, *, aliases: Aliases, maxlen: int = 0
 ) -> str:
-    raw_name = expr._safe_name
-    assert raw_name is not None, (
-        "`_safe_name` property should never be None when formatting a "
-        "selection column expression"
-    )
-    name = f"{raw_name}:"
+    if isinstance(expr, ir.DestructValue):
+        # Destruct exprs won't have a name
+        # (The resulting column names will be the fields in the struct)
+        name = "<unnamed>:"
+    else:
+        raw_name = expr._safe_name
+
+        assert raw_name is not None, (
+            "`_safe_name` property should never be None when formatting a "
+            "selection column expression"
+        )
+        name = f"{raw_name}:"
     # the additional 1 is for the colon
     aligned_name = f"{name:<{maxlen + 1}}"
     value = fmt_value(expr, aliases=aliases)


### PR DESCRIPTION
## Repro
```
import ibis
import ibis.expr.datatypes as dt
import ibis.udf.vectorized as udf

table = ibis.table([('col', 'int64')], name='t')

@udf.reduction(
    input_type=['int64'],
    output_type=dt.Struct.from_dict({
        'sum': 'int64',
        'mean': 'float64',
    })
)
def multi_output_udf(v):
    return v.sum(), v.mean()

expr = table.aggregate(multi_output_udf(table['col']).destructure())

print(expr)
```

### Before
```
File /workspaces/ibis-dev/ibis/ibis/expr/format.py:451, in _fmt_selection_column_value_expr(expr, aliases, maxlen)
    446 @fmt_selection_column.register
    447 def _fmt_selection_column_value_expr(
    448     expr: ir.Value, *, aliases: Aliases, maxlen: int = 0
    449 ) -> str:
    450     raw_name = expr._safe_name
--> 451     assert raw_name is not None, (
    452         "`_safe_name` property should never be None when formatting a "
    453         "selection column expression"
    454     )
    455     name = f"{raw_name}:"
    456     # the additional 1 is for the colon

AssertionError: `_safe_name` property should never be None when formatting a selection column expression
```

### After
```
r0 := UnboundTable: t
  col int64

Aggregation[r0]
  metrics:
    <unnamed>: ReductionVectorizedUDF(func=multi_output_udf, func_args=[r0.col], input_type=[int64], return_type=struct<sum: int64, mean: float64>)
```

## Cause

`Selection` selections or `Aggregation` metrics that are `DestructValues` are naturally unnamed—the names of the struct fields are what define the names of the columns that should be created as a result of the `Selection`/`Aggregation`. However, `_fmt_selection_column_value_expr` (which is used by `Selection` for formatting its selections, and `Aggregation` for formatting its metrics) assumes that the value expressions will always have names, and raises an error otherwise.
https://github.com/ibis-project/ibis/blob/7623ae9597e8b82fe12ca3b5ccac5e6e8540c6fb/ibis/expr/format.py#L450-L454


## Fix

This PR changes `_fmt_selection_column_value_expr` to handle `DestructValues`.