### PR TITLE
feat(connect): support globs and brace expansion using `bracex` in `ibis.connect`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -172,6 +172,14 @@ css = ["tinycss2 (>=1.1.0,<1.2)"]
 dev = ["build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "pip-tools (==6.6.2)", "pytest (==7.1.2)", "Sphinx (==4.3.2)", "tox (==3.25.0)", "twine (==4.0.1)", "wheel (==0.37.1)", "black (==22.3.0)", "mypy (==0.961)"]
 
 [[package]]
+name = "bracex"
+version = "2.3.post1"
+description = "Bash style brace expander."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "certifi"
 version = "2022.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -2394,7 +2402,7 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "1d4139881e1f11d1a6a802d6800dbae4b0d37d4a57de8eca7655e0ed8545ca65"
+content-hash = "1fbbeb3c08ca4004875c799fd12f894799437d5ad52ab2a611ea6fec3506e3c4"
 
 [metadata.files]
 absolufy-imports = [
@@ -2560,6 +2568,10 @@ black = [
 bleach = [
     {file = "bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a"},
     {file = "bleach-5.0.1.tar.gz", hash = "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"},
+]
+bracex = [
+    {file = "bracex-2.3.post1-py3-none-any.whl", hash = "sha256:351b7f20d56fb9ea91f9b9e9e7664db466eb234188c175fd943f8f755c807e73"},
+    {file = "bracex-2.3.post1.tar.gz", hash = "sha256:e7b23fc8b2cd06d3dec0692baabecb249dda94e06a617901ff03a6c56fd71693"},
 ]
 certifi = [
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pattern = "^(?P<base>\\d+(\\.\\d+)*)"
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 atpublic = ">=2.3,<4"
+bracex = ">=2.3.post1,<3"
 importlib-metadata = { version = ">=4,<5", python = "<3.10" }
 multipledispatch = ">=0.6,<0.7"
 numpy = ">=1,<2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ beautifulsoup4==4.11.1; python_full_version >= "3.7.1" and python_version < "4" 
 bitarray==2.5.1
 black==22.6.0; python_full_version >= "3.6.2"
 bleach==5.0.1; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
+bracex==2.3.post1; python_version >= "3.7"
 certifi==2022.6.15; python_version >= "3.8" and python_version < "4"
 cffi==1.15.1; implementation_name == "pypy" and python_version >= "3.7"
 charset-normalizer==2.1.0; python_version >= "3.7" and python_version < "4" and python_full_version >= "3.6.0"

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ package_data = {'': ['*']}
 
 install_requires = [
     'atpublic>=2.3,<4',
+    'bracex>=2.3.post1,<3',
     'multipledispatch>=0.6,<0.7',
     'numpy>=1,<2',
     'packaging>=21.3,<22',


### PR DESCRIPTION
This PR is a slight rework of #4205.

The original discussion was around the ambiguity of a glob pattern in `ibis.connect`.

My thinking is that since `ibis.connect` always returns a `BaseBackend`
instance, the only reasonable thing to do with a glob in `ibis.connect` is to
register individual tables one by one, expanding the glob pattern directly in
Python.

`ibis.connect` is not meant to cover the case of globs of files with the same
schema and is provided as a convenience.

On the other hand I think it makes sense for `con.register(glob_pattern)` to
handle the union case: its API is explicitly per-table.
The main wrinkle with the glob pattern there is that we have to at least expand
the glob to 2 elements to force the user to pass a `table_name` argument.
