### PR TITLE
refactor(analysis): remove `"tmp"` name from subquery filter rewriting

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -927,8 +927,4 @@ def _rewrite_filter_value(op, expr, **kwargs):
     if all(map(operator.is_, visited, args)):
         return expr
     else:
-        return (
-            op.__class__(*visited)
-            .to_expr()
-            .name("tmp" if not expr.has_name() else expr.get_name())
-        )
+        return op.__class__(*visited).to_expr()


### PR DESCRIPTION
This PR removes the `"tmp"` name that is assigned to subquery filters.

This alias is never necessary since the filter is always part of a `WHERE`
clause and never enters into a projection column list directly.

This isn't a problem for ibis, but in `ibis_substrait` it makes comparing
expressions decompiled from substrait fail because of the
inserted-and-pointless alias.
