### PR TITLE
refactor: remove dead poetry-overrides

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,7 @@ repos:
       - id: nix-linter
         name: nix-linter
         language: system
-        entry: nix-linter
+        entry: nix-linter --check="no-FreeLetInFunc"
         exclude: nix/sources\.nix
         files: \.nix$
         types:

--- a/default.nix
+++ b/default.nix
@@ -27,10 +27,7 @@ let
       src = pkgs.gitignoreSource ./.;
 
       overrides = pkgs.poetry2nix.overrides.withDefaults (
-        import ./poetry-overrides.nix {
-          inherit pkgs;
-          inherit (pkgs) lib stdenv;
-        }
+        import ./poetry-overrides.nix
       );
 
       preConfigure = ''

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -24,10 +24,7 @@ import sources.nixpkgs {
           ibis = ../ibis;
         };
         overrides = pkgs.poetry2nix.overrides.withDefaults (
-          import ../poetry-overrides.nix {
-            inherit pkgs;
-            inherit (pkgs) lib stdenv;
-          }
+          import ../poetry-overrides.nix
         );
       };
 

--- a/shell.nix
+++ b/shell.nix
@@ -79,7 +79,7 @@ pkgs.mkShell {
     rsync
   ]);
 
-  PYTHONPATH = builtins.toPath ./.;
+  PYTHONPATH = ./.;
   PGPASSWORD = "postgres";
   MYSQL_PWD = "ibis";
 }


### PR DESCRIPTION
This PR cleans up some dead code in poetry-overrides.nix, from recent updates to nixpkgs and poetry2nix.