### PR TITLE
fix(sqlalchemy): fix parsing and construction of nested array types

### DIFF
--- a/ci/schema/clickhouse.sql
+++ b/ci/schema/clickhouse.sql
@@ -74,16 +74,17 @@ CREATE TABLE IF NOT EXISTS array_types (
     y Array(Nullable(String)),
     z Array(Nullable(Float64)),
     grouper Nullable(String),
-    scalar_column Nullable(Float64)
+    scalar_column Nullable(Float64),
+    multi_dim Array(Array(Nullable(Int64)))
 ) ENGINE = Memory;
 
 INSERT INTO array_types VALUES
-    ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0),
-    ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0),
-    ([6, NULL], ['f', NULL], [6.0, NULL], 'a', 3.0),
-    ([NULL, 1, NULL], [NULL, 'a', NULL], [], 'b', 4.0),
-    ([2, NULL, 3], ['b', NULL, 'c'], NULL, 'b', 5.0),
-    ([4, NULL, NULL, 5], ['d', NULL, NULL, 'e'], [4.0, NULL, NULL, 5.0], 'c', 6.0);
+    ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0, [[], [1, 2, 3], []]),
+    ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0, []),
+    ([6, NULL], ['f', NULL], [6.0, NULL], 'a', 3.0, [[], [], []]),
+    ([NULL, 1, NULL], [NULL, 'a', NULL], [], 'b', 4.0, [[1], [2], [], [3, 4, 5]]),
+    ([2, NULL, 3], ['b', NULL, 'c'], NULL, 'b', 5.0, []),
+    ([4, NULL, NULL, 5], ['d', NULL, NULL, 'e'], [4.0, NULL, NULL, 5.0], 'c', 6.0, [[1, 2, 3]]);
 
 
 CREATE TABLE IF NOT EXISTS struct (

--- a/ci/schema/duckdb.sql
+++ b/ci/schema/duckdb.sql
@@ -78,16 +78,17 @@ CREATE TABLE IF NOT EXISTS array_types (
     y TEXT[],
     z DOUBLE PRECISION[],
     grouper TEXT,
-    scalar_column DOUBLE PRECISION
+    scalar_column DOUBLE PRECISION,
+    multi_dim BIGINT[][]
 );
 
 INSERT INTO array_types VALUES
-    ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0),
-    ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0),
-    ([6, NULL], ['f', NULL], [6.0, NULL], 'a', 3.0),
-    ([NULL, 1, NULL], [NULL, 'a', NULL], [], 'b', 4.0),
-    ([2, NULL, 3], ['b', NULL, 'c'], NULL, 'b', 5.0),
-    ([4, NULL, NULL, 5], ['d', NULL, NULL, 'e'], [4.0, NULL, NULL, 5.0], 'c', 6.0);
+    ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0, [[], [1, 2, 3], NULL]),
+    ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0, []),
+    ([6, NULL], ['f', NULL], [6.0, NULL], 'a', 3.0, [NULL, [], NULL]),
+    ([NULL, 1, NULL], [NULL, 'a', NULL], [], 'b', 4.0, [[1], [2], [], [3, 4, 5]]),
+    ([2, NULL, 3], ['b', NULL, 'c'], NULL, 'b', 5.0, NULL),
+    ([4, NULL, NULL, 5], ['d', NULL, NULL, 'e'], [4.0, NULL, NULL, 5.0], 'c', 6.0, [[1, 2, 3]]);
 
 
 DROP TABLE IF EXISTS struct CASCADE;

--- a/ci/schema/postgresql.sql
+++ b/ci/schema/postgresql.sql
@@ -102,16 +102,17 @@ CREATE TABLE IF NOT EXISTS array_types (
     y TEXT[],
     z DOUBLE PRECISION[],
     grouper TEXT,
-    scalar_column DOUBLE PRECISION
+    scalar_column DOUBLE PRECISION,
+    multi_dim BIGINT[][]
 );
 
 INSERT INTO array_types VALUES
-    (ARRAY[1, 2, 3], ARRAY['a', 'b', 'c'], ARRAY[1.0, 2.0, 3.0], 'a', 1.0),
-    (ARRAY[4, 5], ARRAY['d', 'e'], ARRAY[4.0, 5.0], 'a', 2.0),
-    (ARRAY[6, NULL], ARRAY['f', NULL], ARRAY[6.0, NULL], 'a', 3.0),
-    (ARRAY[NULL, 1, NULL], ARRAY[NULL, 'a', NULL], ARRAY[]::DOUBLE PRECISION[], 'b', 4.0),
-    (ARRAY[2, NULL, 3], ARRAY['b', NULL, 'c'], NULL, 'b', 5.0),
-    (ARRAY[4, NULL, NULL, 5], ARRAY['d', NULL, NULL, 'e'], ARRAY[4.0, NULL, NULL, 5.0], 'c', 6.0);
+    (ARRAY[1, 2, 3], ARRAY['a', 'b', 'c'], ARRAY[1.0, 2.0, 3.0], 'a', 1.0, ARRAY[ARRAY[NULL::BIGINT, NULL, NULL], ARRAY[1, 2, 3]]),
+    (ARRAY[4, 5], ARRAY['d', 'e'], ARRAY[4.0, 5.0], 'a', 2.0, ARRAY[]::BIGINT[][]),
+    (ARRAY[6, NULL], ARRAY['f', NULL], ARRAY[6.0, NULL], 'a', 3.0, ARRAY[NULL, ARRAY[]::BIGINT[], NULL]),
+    (ARRAY[NULL, 1, NULL], ARRAY[NULL, 'a', NULL], ARRAY[]::DOUBLE PRECISION[], 'b', 4.0, ARRAY[ARRAY[1], ARRAY[2], ARRAY[NULL::BIGINT], ARRAY[3]]),
+    (ARRAY[2, NULL, 3], ARRAY['b', NULL, 'c'], NULL, 'b', 5.0, NULL),
+    (ARRAY[4, NULL, NULL, 5], ARRAY['d', NULL, NULL, 'e'], ARRAY[4.0, NULL, NULL, 5.0], 'c', 6.0, ARRAY[ARRAY[1, 2, 3]]);
 
 DROP TABLE IF EXISTS films CASCADE;
 

--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -95,8 +95,11 @@ def _(itype, **kwargs):
 
 @to_sqla_type.register(dt.Array)
 def _(itype, **kwargs):
-    ibis_type = itype.value_type
-    return sa.ARRAY(to_sqla_type(ibis_type, **kwargs))
+    # Unwrap the array element type because sqlalchemy doesn't allow arrays of
+    # arrays. This doesn't affect the underlying data.
+    while isinstance(itype, dt.Array):
+        itype = itype.value_type
+    return sa.ARRAY(to_sqla_type(itype, **kwargs))
 
 
 @to_sqla_type.register(dt.Struct)

--- a/ibis/backends/duckdb/datatypes.py
+++ b/ibis/backends/duckdb/datatypes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import parsy as p
+import toolz
 
 from ibis import util
 
@@ -111,11 +112,15 @@ def parse(text: str, default_decimal_parameters=(18, 3)) -> DataType:
         return Array(value_type)
 
     @p.generate
+    def brackets():
+        yield spaceless(LBRACKET)
+        yield spaceless(RBRACKET)
+
+    @p.generate
     def pg_array():
         value_type = yield non_pg_array_type
-        yield LBRACKET
-        yield RBRACKET
-        return Array(value_type)
+        n = len((yield brackets.at_least(1)))
+        return toolz.nth(n, toolz.iterate(Array, value_type))
 
     @p.generate
     def map():

--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -56,6 +56,8 @@ EXPECTED_SCHEMA = dict(
             c=dt.Array(dt.Map(dt.string, dt.Array(dt.float64))),
         )
     ),
+    T=dt.Array(dt.Array(dt.int32)),
+    U=dt.Array(dt.Array(dt.int32)),
 )
 
 
@@ -109,6 +111,8 @@ EXPECTED_SCHEMA = dict(
             ("Q", "LIST<INTEGER>"),
             ("R", "MAP<STRING, BIGINT>"),
             ("S", "STRUCT(a INT, b TEXT, c LIST<MAP<TEXT, LIST<FLOAT8>>>)"),
+            ("T", "LIST<LIST<INTEGER>>"),
+            ("U", "INTEGER[][]"),
         ]
     ],
 )

--- a/ibis/backends/pandas/tests/conftest.py
+++ b/ibis/backends/pandas/tests/conftest.py
@@ -54,6 +54,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                             [1.0, 2.0, 3.0],
                             'a',
                             1.0,
+                            [[], [np.int64(1), 2, 3], None],
                         ),
                         (
                             [4, 5],
@@ -61,6 +62,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                             [4.0, 5.0],
                             'a',
                             2.0,
+                            [],
                         ),
                         (
                             [6, None],
@@ -68,6 +70,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                             [6.0, np.nan],
                             'a',
                             3.0,
+                            [None, [], None],
                         ),
                         (
                             [None, 1, None],
@@ -75,6 +78,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                             [],
                             'b',
                             4.0,
+                            [[1], [2], [], [3, 4, 5]],
                         ),
                         (
                             [2, None, 3],
@@ -82,6 +86,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                             np.nan,
                             'b',
                             5.0,
+                            None,
                         ),
                         (
                             [4, None, None, 5],
@@ -89,9 +94,17 @@ class TestConf(BackendTest, RoundHalfToEven):
                             [4.0, np.nan, np.nan, 5.0],
                             'c',
                             6.0,
+                            [[1, 2, 3]],
                         ),
                     ],
-                    columns=["x", "y", "z", "grouper", "scalar_column"],
+                    columns=[
+                        "x",
+                        "y",
+                        "z",
+                        "grouper",
+                        "scalar_column",
+                        "multi_dim",
+                    ],
                 ),
             }
         )

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -152,20 +152,35 @@ def get_common_spark_testing_client(data_directory, connect):
     df_nested_types.createOrReplaceTempView('nested_types')
     df_array_types = s.createDataFrame(
         [
-            ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0),
-            ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0),
-            ([6, None], ['f', None], [6.0, None], 'a', 3.0),
-            ([None, 1, None], [None, 'a', None], [], 'b', 4.0),
-            ([2, None, 3], ['b', None, 'c'], None, 'b', 5.0),
+            (
+                [1, 2, 3],
+                ['a', 'b', 'c'],
+                [1.0, 2.0, 3.0],
+                'a',
+                1.0,
+                [[], [1, 2, 3], None],
+            ),
+            ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0, []),
+            ([6, None], ['f', None], [6.0, None], 'a', 3.0, [None, [], None]),
+            (
+                [None, 1, None],
+                [None, 'a', None],
+                [],
+                'b',
+                4.0,
+                [[1], [2], [], [3, 4, 5]],
+            ),
+            ([2, None, 3], ['b', None, 'c'], None, 'b', 5.0, None),
             (
                 [4, None, None, 5],
                 ['d', None, None, 'e'],
                 [4.0, None, None, 5.0],
                 'c',
                 6.0,
+                [[1, 2, 3]],
             ),
         ],
-        ["x", "y", "z", "grouper", "scalar_column"],
+        ["x", "y", "z", "grouper", "scalar_column", "multi_dim"],
     )
     df_array_types.createOrReplaceTempView("array_types")
 


### PR DESCRIPTION
This PR adds the ability to parse the metadata from duckdb for multidimensional arrays as well as fixes a bug in type inference of such arrays. Closes #4236.