### PR TITLE
ci: delay codecov reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,21 @@
+codecov:
+  notify:
+    # a high number to try to delay codecov reporting until most of the test
+    # runs have finished. Should match with comment.after_n_builds below.
+    after_n_builds: 32
+
 comment:
+  after_n_builds: 32
   layout: "reach, diff, files"
   behavior: default
   require_changes: true # if true: only post the comment if coverage changes
   require_base: false # [yes :: must have a base report to post]
   require_head: true # [yes :: must have a head report to post]
   branches: null
+
 ignore:
   - "docs/**"
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Tries to delay codecov reporting until most CI runs have finished,
should cut down on PR noise.