### PR TITLE
fix(api): ensure that `Deferred` objects work in aggregations

### DIFF
--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -683,14 +683,17 @@ def test_agg_sort(alltypes):
 def test_filter(backend, alltypes, df):
     expr = (
         alltypes[_.string_col == "1"]
-        .group_by(_.bigint_col)
+        .mutate(x=L(1, "int64"))
+        .group_by(_.x)
         .aggregate(_.double_col.sum())
     )
 
-    result = expr.execute()
+    # TODO: The pyspark backend doesn't apply schemas to outputs
+    result = expr.execute().astype({"x": "int64"})
     expected = (
         df.loc[df.string_col == "1", :]
-        .groupby("bigint_col")
+        .assign(x=1)
+        .groupby("x")
         .double_col.sum()
         .rename("sum")
         .reset_index()

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -60,7 +60,10 @@ class GroupedTable:
         self, table, by, having=None, order_by=None, window=None, **expressions
     ):
         self.table = table
-        self.by = util.promote_list(by if by is not None else []) + [
+        self.by = [
+            _get_group_by_key(table, v)
+            for v in util.promote_list(by if by is not None else [])
+        ] + [
             _get_group_by_key(table, v).name(k)
             for k, v in sorted(expressions.items(), key=toolz.first)
         ]

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -343,9 +343,24 @@ class Table(Expr):
 
         op = self.op().aggregate(
             self,
-            metrics,
-            by=util.promote_list(by if by is not None else []),
-            having=util.promote_list(having if having is not None else []),
+            [
+                metric
+                if util.is_iterable(metric)
+                else self._ensure_expr(metric)
+                for metric in metrics
+            ],
+            by=list(
+                map(
+                    self._ensure_expr,
+                    util.promote_list(by if by is not None else []),
+                )
+            ),
+            having=list(
+                map(
+                    self._ensure_expr,
+                    util.promote_list(having if having is not None else []),
+                )
+            ),
         )
         return op.to_expr()
 


### PR DESCRIPTION
This PR fixes an issue where aggregation `by`, `metrics`, and `having` lists
containing `Deferred` objects (the thing that backs the `_` API) are not
resolved to expressions.
