### PR TITLE
chore(dev): bring back `builtins.toPath` for `shell.nix` convenience

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -79,7 +79,7 @@ pkgs.mkShell {
     rsync
   ]);
 
-  PYTHONPATH = ./.;
+  PYTHONPATH = builtins.toPath ./.;
   PGPASSWORD = "postgres";
   MYSQL_PWD = "ibis";
 }


### PR DESCRIPTION
This PR brings back using `builtins.toPath` in `shell.nix` so that `PYTHONPATH` tracks the local repo outside the nix store.