### PR TITLE
refactor: remove backend specific test_binary_arithmetic which are already in larger suite

### DIFF
--- a/ibis/backends/clickhouse/tests/test_operators.py
+++ b/ibis/backends/clickhouse/tests/test_operators.py
@@ -51,27 +51,6 @@ def test_string_temporal_compare(con, op, left, right, type):
 
 
 @pytest.mark.parametrize(
-    ('func', 'left', 'right', 'expected'),
-    [
-        (operator.add, L(3), L(4), 7),
-        (operator.sub, L(3), L(4), -1),
-        (operator.mul, L(3), L(4), 12),
-        (operator.truediv, L(12), L(4), 3),
-        (operator.pow, L(12), L(2), 144),
-        (operator.mod, L(12), L(5), 2),
-        (operator.truediv, L(7), L(2), 3.5),
-        (operator.floordiv, L(7), L(2), 3),
-        (lambda x, y: x.floordiv(y), L(7), 2, 3),
-        (lambda x, y: x.rfloordiv(y), L(2), 7, 3),
-    ],
-)
-def test_binary_arithmetic(con, func, left, right, expected):
-    expr = func(left, right)
-    result = con.execute(expr)
-    assert result == expected
-
-
-@pytest.mark.parametrize(
     ('op', 'expected'),
     [
         (lambda a, b: a + b, '`int_col` + `tinyint_col`'),

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -180,31 +180,6 @@ def test_strftime(con, pattern):
 
 
 @pytest.mark.parametrize(
-    ('func', 'left', 'right', 'expected'),
-    [
-        param(operator.add, L(3), L(4), 7, id='add'),
-        param(operator.sub, L(3), L(4), -1, id='sub'),
-        param(operator.mul, L(3), L(4), 12, id='mul'),
-        param(operator.truediv, L(12), L(4), 3, id='truediv_no_remainder'),
-        param(operator.pow, L(12), L(2), 144, id='pow'),
-        param(operator.mod, L(12), L(5), 2, id='mod'),
-        param(operator.truediv, L(7), L(2), 3.5, id='truediv_remainder'),
-        param(operator.floordiv, L(7), L(2), 3, id='floordiv'),
-        param(
-            lambda x, y: x.floordiv(y), L(7), 2, 3, id='floordiv_no_literal'
-        ),
-        param(
-            lambda x, y: x.rfloordiv(y), L(2), 7, 3, id='rfloordiv_no_literal'
-        ),
-    ],
-)
-def test_binary_arithmetic(con, func, left, right, expected):
-    expr = func(left, right)
-    result = con.execute(expr)
-    assert result == expected
-
-
-@pytest.mark.parametrize(
     ('value', 'expected'),
     [
         param(L('foo_bar'), 'text', id='text'),


### PR DESCRIPTION
https://github.com/ibis-project/ibis/blob/8c026390abe7a22742c538d6011a1db8bc2d62c9/ibis/backends/tests/test_numeric.py#L409

https://github.com/ibis-project/ibis/blob/d6f95d79256eb97427f043c02cc960d8749339d0/ibis/backends/tests/test_temporal.py#L768

Part of work for https://github.com/ibis-project/ibis/issues/3994