### PR TITLE
feat(duckdb): unsigned integer support

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -359,3 +359,22 @@ def test_in_memory(alchemy_backend):
     finally:
         con.raw_sql(f"DROP TABLE IF EXISTS {table_name}")
         assert table_name not in con.list_tables()
+
+
+@pytest.mark.parametrize(
+    "coltype", [dt.uint8, dt.uint16, dt.uint32, dt.uint64]
+)
+@pytest.mark.notyet(
+    ["postgres", "mysql", "sqlite"],
+    raises=TypeError,
+    reason="postgres, mysql and sqlite do not support unsigned integer types",
+)
+def test_unsigned_integer_type(alchemy_con, coltype):
+    tname = guid()
+    alchemy_con.create_table(
+        tname, schema=ibis.schema(dict(a=coltype)), force=True
+    )
+    try:
+        assert tname in alchemy_con.list_tables()
+    finally:
+        alchemy_con.drop_table(tname, force=True)

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -1344,11 +1344,13 @@ def infer_floating(value: float) -> Float64:
 
 
 @infer.register(int)
-def infer_integer(value: int) -> Integer:
-    for dtype in (int8, int16, int32, int64):
+def infer_integer(value: int, prefer_unsigned: bool = False) -> Integer:
+    types = (uint8, uint16, uint32, uint64) if prefer_unsigned else ()
+    types += (int8, int16, int32, int64)
+    for dtype in types:
         if dtype.bounds.lower <= value <= dtype.bounds.upper:
             return dtype
-    return int64
+    return uint64 if prefer_unsigned else int64
 
 
 @infer.register(enum.Enum)

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -368,7 +368,7 @@ class IntervalBinary(Binary):
             else arg
             for arg in self.args
         ]
-        value_dtype = rlz._promote_numeric_binop(integer_args, self.op)
+        value_dtype = rlz._promote_integral_binop(integer_args, self.op)
         left_dtype = self.left.type()
         return dt.Interval(
             unit=left_dtype.unit,


### PR DESCRIPTION
- Adds unsigned integer support for the sqlalchemy backends, only implemented for duckdb so far. Things work, but I'm 100% sure there's a better way.
- Modifies the integer numeric promotion rules so that (some) unsigned integer arithmetic works

At this point for duckdb, you can:
- create tables with unsigned integers in the schema
- load tables with unsigned integer columns
- compute reductions on unsigned integer columns
- do (some) arithmetic between unsigned integer columns

Still needs more work and tests.

Fixes #4224.