### PR TITLE
feat: add ADBC backend

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -35,8 +35,8 @@ jobs:
           - "3.8"
           - "3.10"
         backend:
-          - name: adbc
-            title: ADBC
+          - name: adbc_sqlite
+            title: ADBC (SQLite driver)
           - name: dask
             title: Dask
           - name: duckdb

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -39,7 +39,7 @@ jobs:
             title: ADBC
             sys-deps:
               - cmake
-              - ninja
+              - ninja-build
           - name: dask
             title: Dask
           - name: duckdb

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -25,6 +25,9 @@ jobs:
   test_backends:
     name: ${{ matrix.backend.title }} ${{ matrix.os }} python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ibis
     strategy:
       fail-fast: false
       matrix:
@@ -119,11 +122,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: apache/arrow-adbc
-          path: ./arrow-adbc
+          path: arrow-adbc
           ref: ef70af6aff8da61bbe2f19f14c607aa6c07caf33
-
-      - name: move arrow-adbc
-        run: mv arrow-adbc ..
 
       - name: install sqlite
         if: ${{ matrix.os == 'windows-latest' && matrix.backend.name == 'sqlite' }}
@@ -137,6 +137,8 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v3
+        with:
+          path: ibis
 
       - name: start services
         if: ${{ matrix.backend.services != null }}

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -25,9 +25,6 @@ jobs:
   test_backends:
     name: ${{ matrix.backend.title }} ${{ matrix.os }} python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: ibis
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -119,8 +119,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: apache/arrow-adbc
-          path: ../arrow-adbc
+          path: ./arrow-adbc
           ref: ef70af6aff8da61bbe2f19f14c607aa6c07caf33
+
+      - name: move arrow-adbc
+        run: mv arrow-adbc ..
 
       - name: install sqlite
         if: ${{ matrix.os == 'windows-latest' && matrix.backend.name == 'sqlite' }}

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -35,6 +35,11 @@ jobs:
           - "3.8"
           - "3.10"
         backend:
+          - name: adbc
+            title: ADBC
+            sys-deps:
+              - cmake
+              - ninja
           - name: dask
             title: Dask
           - name: duckdb
@@ -109,6 +114,13 @@ jobs:
 
           sudo apt-get update -qq -y
           sudo apt-get install -qq -y build-essential python-dev ${{ join(matrix.backend.sys-deps, ' ') }}
+
+      - name: clone adbc
+        uses: actions/checkout@v3
+        with:
+          repository: apache/arrow-adbc
+          path: ../arrow-adbc
+          rev: ef70af6aff8da61bbe2f19f14c607aa6c07caf33
 
       - name: install sqlite
         if: ${{ matrix.os == 'windows-latest' && matrix.backend.name == 'sqlite' }}

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -37,9 +37,6 @@ jobs:
         backend:
           - name: adbc
             title: ADBC
-            sys-deps:
-              - cmake
-              - ninja-build
           - name: dask
             title: Dask
           - name: duckdb
@@ -114,16 +111,6 @@ jobs:
 
           sudo apt-get update -qq -y
           sudo apt-get install -qq -y build-essential python-dev ${{ join(matrix.backend.sys-deps, ' ') }}
-
-      - name: clone adbc
-        uses: actions/checkout@v3
-        with:
-          repository: apache/arrow-adbc
-          path: arrow-adbc
-          ref: ef70af6aff8da61bbe2f19f14c607aa6c07caf33
-
-      - name: move adbc
-        run: mv arrow-adbc ..
 
       - name: install sqlite
         if: ${{ matrix.os == 'windows-latest' && matrix.backend.name == 'sqlite' }}

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -122,6 +122,9 @@ jobs:
           path: arrow-adbc
           ref: ef70af6aff8da61bbe2f19f14c607aa6c07caf33
 
+      - name: move adbc
+        run: mv arrow-adbc ..
+
       - name: install sqlite
         if: ${{ matrix.os == 'windows-latest' && matrix.backend.name == 'sqlite' }}
         run: choco install sqlite
@@ -134,8 +137,6 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v3
-        with:
-          path: ibis
 
       - name: start services
         if: ${{ matrix.backend.services != null }}

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           repository: apache/arrow-adbc
           path: ../arrow-adbc
-          rev: ef70af6aff8da61bbe2f19f14c607aa6c07caf33
+          ref: ef70af6aff8da61bbe2f19f14c607aa6c07caf33
 
       - name: install sqlite
         if: ${{ matrix.os == 'windows-latest' && matrix.backend.name == 'sqlite' }}

--- a/ibis/backends/adbc/__init__.py
+++ b/ibis/backends/adbc/__init__.py
@@ -1,0 +1,317 @@
+# Copyright 2015 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import typing
+from typing import Any, Mapping
+
+import adbc_driver_manager
+import pandas as pd
+import pyarrow as pa
+import sqlalchemy as sa
+
+import ibis
+import ibis.backends.pyarrow.datatypes as pa_dt
+import ibis.expr.schema as sch
+import ibis.expr.types as ir
+from ibis.backends.base import Database
+from ibis.backends.base.sql import BaseSQLBackend
+
+
+class Backend(BaseSQLBackend):
+    name = 'adbc'
+    database_class = Database
+    sqla_dialect = None
+    table_expr_class = ir.Table
+
+    def __getstate__(self) -> dict:
+        r = super().__getstate__()
+        r.update(
+            dict(
+                compiler=self.compiler,
+                sqla_dialect=self.sqla_dialect,
+            )
+        )
+        return r
+
+    def create_table(
+        self,
+        name: str,
+        expr: pa.RecordBatch
+        | pa.RecordBatchReader
+        | pa.Table
+        | pd.DataFrame
+        | ir.Table
+        | None = None,
+        schema: sch.Schema | None = None,
+        database: str | None = None,
+        force: bool = False,
+    ) -> None:
+        """
+        Create a table.
+
+        Parameters
+        ----------
+        name
+            Table name to create
+        expr
+            DataFrame or table expression to use as the data source
+        schema
+            An ibis schema
+        database
+            A database
+        force
+            Check whether a table exists before creating it
+        """
+        # TODO: force
+        if database is not None:
+            raise NotImplementedError(
+                'Creating tables from a different database is not yet '
+                'implemented'
+            )
+
+        if expr is None and schema is None:
+            raise ValueError('You must pass either an expression or a schema')
+
+        if expr is not None and schema is not None:
+            if not expr.schema().equals(ibis.schema(schema)):
+                raise TypeError(
+                    'Expression schema is not equal to passed schema. '
+                    'Try passing the expression without the schema'
+                )
+        if schema is None:
+            schema = expr.schema()
+
+        if isinstance(expr, ir.Table):
+            raise NotImplementedError(
+                'Creating tables from an expression is not yet implemented'
+            )
+        if expr is None:
+            pyarrow_schema = pa.schema(
+                [
+                    (name, pa_dt.to_pyarrow_type(dt))
+                    for (name, dt) in schema.items()
+                ]
+            )
+            expr = pa.record_batch(
+                [
+                    chunked_arr.chunks[0]
+                    for chunked_arr in pyarrow_schema.empty_table()
+                ],
+                schema=pyarrow_schema,
+            )
+        elif isinstance(expr, pa.Table):
+            expr = pa.RecordBatchReader.from_batches(
+                expr.to_batches(), expr.schema
+            )
+
+        with adbc_driver_manager.AdbcStatement(self._conn) as stmt:
+            stmt.set_options(
+                **{adbc_driver_manager.INGEST_OPTION_TARGET_TABLE: name}
+            )
+
+            if isinstance(expr, pa.RecordBatch):
+                array = adbc_driver_manager.ArrowArrayHandle()
+                schema = adbc_driver_manager.ArrowSchemaHandle()
+                expr._export_to_c(array.address, schema.address)
+                stmt.bind(array, schema)
+            else:
+                stream = adbc_driver_manager.ArrowArrayStreamHandle()
+                expr._export_to_c(stream.address)
+                stmt.bind_stream(stream)
+
+            stmt.execute()
+
+    @property
+    def current_database(self) -> str:
+        """The name of the current database this client is connected to."""
+        # TODO: switching databases
+        # TODO: how to handle this in a generic way? may need some
+        # support from ADBC
+        return "main"
+
+    def do_connect(
+        self, *, driver, entrypoint, db_args=None, dialect=None, **kwargs
+    ) -> None:
+        """
+        Connect to the database.
+
+        Parameters
+        ----------
+        driver : str
+            The ADBC driver to use (e.g. "adbc_driver_flight_sql").
+
+        entrypoint : str
+            The entrypoint in the driver (e.g. "AdbcFlightSqlDriverInit").
+
+        db_args : dict, optional
+            Arguments to pass to the ADBC driver.
+
+        dialect : str, optional
+            Whether to use SQL or Substrait, and if SQL, which dialect
+            to use.  If not given, will try to detect Substrait vs SQL
+            and default to a generic (but extremely limited) SQL
+            dialect.
+
+        kwargs : dict, optional
+            Additional arguments.
+        """
+        # TODO: detect the dialect
+        # TODO: need to control compiler
+        self._db = adbc_driver_manager.AdbcDatabase(
+            driver=driver,
+            entrypoint=entrypoint,
+            **(db_args or {}),
+        )
+        self._conn = adbc_driver_manager.AdbcConnection(self._db)
+        if dialect == "sqlite":
+            from ibis.backends.sqlite.compiler import SQLiteCompiler
+
+            self.compiler = SQLiteCompiler
+            self.sqla_dialect = sa.dialects.sqlite.dialect()
+        elif not dialect:
+            pass
+        else:
+            raise NotImplementedError(
+                f"Unsupported or unknown dialect '{dialect}'"
+            )
+
+    def fetch_from_cursor(
+        self, cursor: IbisAdbcCursor, schema: sch.Schema
+    ) -> pd.DataFrame:
+        return cursor.read_pandas()
+
+    def list_databases(self, like=None):
+        """List databases in the current server."""
+        with self._conn.get_objects(
+            depth=adbc_driver_manager.GetObjectsDepth.CATALOGS
+        ) as stmt:
+            handle = stmt.get_stream()
+            reader = pa.RecordBatchReader._import_from_c(handle.address)
+            table = reader.read_all()
+            catalog_names = table[0]
+
+        names = []
+        # TODO: what should SQLite return? See what native backend does
+        for chunk in catalog_names.chunks:
+            names.extend(
+                self._filter_with_like(
+                    (x for x in chunk.to_pylist() if x is not None), like
+                )
+            )
+        return names
+
+    def list_tables(self, like=None, database=None):
+        with self._conn.get_objects(
+            depth=adbc_driver_manager.GetObjectsDepth.TABLES, catalog=database
+        ) as stmt:
+            handle = stmt.get_stream()
+            reader = pa.RecordBatchReader._import_from_c(handle.address)
+            table = reader.read_all()
+            db_schemas = table[1]
+
+        tables = []
+        for chunk in db_schemas.chunks:
+            schema_tables = chunk.flatten().flatten()[1].flatten()
+            table_names = schema_tables.flatten()[0]
+            tables.extend(
+                self._filter_with_like(table_names.to_pylist(), like)
+            )
+        return tables
+
+    def raw_sql(self, query: str) -> Any:
+        # Since we also accept sqlalchemy exprs (todo: type annotate)
+        query = str(query.compile(dialect=self.sqla_dialect))
+        try:
+            stmt = adbc_driver_manager.AdbcStatement(self._conn)
+            stmt.set_sql_query(query)
+            stmt.execute()
+            handle = stmt.get_stream()
+            reader = pa.RecordBatchReader._import_from_c(handle.address)
+        except Exception:
+            stmt.close()
+            raise
+        return IbisAdbcCursor(stmt, reader)
+
+    def table(
+        self,
+        name: str,
+        database: str | None = None,
+        schema: str | None = None,
+    ) -> ir.Table:
+        """Create a table expression from a table in the database.
+
+        Parameters
+        ----------
+        name
+            Table name
+        database
+            The database the table resides in (mapped to 'catalog')
+        schema
+            The schema inside `database` where the table resides.
+
+            !!! warning "`schema` refers to database organization"
+
+                The `schema` parameter does **not** refer to the column names
+                and types of `table`.
+
+        Returns
+        -------
+        Table
+            Table expression
+        """
+        handle = self._conn.get_table_schema(database, schema, name)
+        pyarrow_schema = pa.Schema._import_from_c(handle.address)
+        ibis_schema = pa_dt.infer_pyarrow_schema(pyarrow_schema)
+        node = self.table_class(name=name, schema=ibis_schema, source=self)
+        return self.table_expr_class(node)
+
+    @property
+    def version(self) -> str:
+        # TODO:
+        return '0.0.1'
+
+    def _get_schema_using_query(self, query: str) -> sch.Schema:
+        with adbc_driver_manager.AdbcStatement(self._conn) as stmt:
+            stmt.set_sql_query(query)
+            stmt.execute()
+            handle = stmt.get_stream()
+            reader = pa.RecordBatchReader._import_from_c(handle.address)
+            return pa_dt.infer_pyarrow_schema(reader.schema)
+
+
+class IbisAdbcCursor(typing.NamedTuple):
+    """
+    A cursor for a result set.
+    """
+
+    statement: adbc_driver_manager.AdbcStatement
+    reader: pa.RecordBatchReader
+
+    def read_all(self):
+        return self.reader.read_all()
+
+    def read_pandas(self, *args, **kwargs):
+        return self.reader.read_pandas(*args, **kwargs)
+
+    def close(self):
+        self.reader.close()
+        self.statement.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()

--- a/ibis/backends/adbc/__init__.py
+++ b/ibis/backends/adbc/__init__.py
@@ -14,304 +14,76 @@
 
 from __future__ import annotations
 
-import typing
-from typing import Any, Mapping
-
-import adbc_driver_manager
-import pandas as pd
-import pyarrow as pa
+import adbc_driver_manager.dbapi
 import sqlalchemy as sa
 
-import ibis
-import ibis.backends.pyarrow.datatypes as pa_dt
-import ibis.expr.schema as sch
-import ibis.expr.types as ir
-from ibis.backends.base import Database
-from ibis.backends.base.sql import BaseSQLBackend
+from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 
 
-class Backend(BaseSQLBackend):
-    name = 'adbc'
-    database_class = Database
-    sqla_dialect = None
-    table_expr_class = ir.Table
-
-    def __getstate__(self) -> dict:
-        r = super().__getstate__()
-        r.update(
-            dict(
-                compiler=self.compiler,
-                sqla_dialect=self.sqla_dialect,
-            )
-        )
-        return r
-
-    def create_table(
-        self,
-        name: str,
-        expr: pa.RecordBatch
-        | pa.RecordBatchReader
-        | pa.Table
-        | pd.DataFrame
-        | ir.Table
-        | None = None,
-        schema: sch.Schema | None = None,
-        database: str | None = None,
-        force: bool = False,
-    ) -> None:
-        """
-        Create a table.
-
-        Parameters
-        ----------
-        name
-            Table name to create
-        expr
-            DataFrame or table expression to use as the data source
-        schema
-            An ibis schema
-        database
-            A database
-        force
-            Check whether a table exists before creating it
-        """
-        # TODO: force
-        if database is not None:
-            raise NotImplementedError(
-                'Creating tables from a different database is not yet '
-                'implemented'
-            )
-
-        if expr is None and schema is None:
-            raise ValueError('You must pass either an expression or a schema')
-
-        if expr is not None and schema is not None:
-            if not expr.schema().equals(ibis.schema(schema)):
-                raise TypeError(
-                    'Expression schema is not equal to passed schema. '
-                    'Try passing the expression without the schema'
-                )
-        if schema is None:
-            schema = expr.schema()
-
-        if isinstance(expr, ir.Table):
-            raise NotImplementedError(
-                'Creating tables from an expression is not yet implemented'
-            )
-        if expr is None:
-            pyarrow_schema = pa.schema(
-                [
-                    (name, pa_dt.to_pyarrow_type(dt))
-                    for (name, dt) in schema.items()
-                ]
-            )
-            expr = pa.record_batch(
-                [
-                    chunked_arr.chunks[0]
-                    for chunked_arr in pyarrow_schema.empty_table()
-                ],
-                schema=pyarrow_schema,
-            )
-        elif isinstance(expr, pa.Table):
-            expr = pa.RecordBatchReader.from_batches(
-                expr.to_batches(), expr.schema
-            )
-
-        with adbc_driver_manager.AdbcStatement(self._conn) as stmt:
-            stmt.set_options(
-                **{adbc_driver_manager.INGEST_OPTION_TARGET_TABLE: name}
-            )
-
-            if isinstance(expr, pa.RecordBatch):
-                array = adbc_driver_manager.ArrowArrayHandle()
-                schema = adbc_driver_manager.ArrowSchemaHandle()
-                expr._export_to_c(array.address, schema.address)
-                stmt.bind(array, schema)
-            else:
-                stream = adbc_driver_manager.ArrowArrayStreamHandle()
-                expr._export_to_c(stream.address)
-                stmt.bind_stream(stream)
-
-            stmt.execute()
+class Backend(BaseAlchemyBackend):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._dialect = None
 
     @property
-    def current_database(self) -> str:
-        """The name of the current database this client is connected to."""
-        # TODO: switching databases
-        # TODO: how to handle this in a generic way? may need some
-        # support from ADBC
+    def database_name(self) -> str:
+        # TODO(arrow/arrow-adbc#55): retrieve the actual current database
         return "main"
 
+    @property
+    def name(self) -> str:
+        if self._dialect is None:
+            return "adbc"
+        return f"adbc_{self._dialect}"
+
     def do_connect(
-        self, *, driver, entrypoint, db_args=None, dialect=None, **kwargs
+        self, *, driver: str, entrypoint: str, dialect=None, db_args=None
     ) -> None:
         """
-        Connect to the database.
+        Create an Ibis client connected via ADBC.
 
         Parameters
         ----------
-        driver : str
-            The ADBC driver to use (e.g. "adbc_driver_flight_sql").
+        driver
+            The driver name. Example: adbc_driver_sqlite will load
+            libadbc_driver_sqlite.so (Unixes) or
+            adbc_driver_sqlite.dll (Windows).
+        entrypoint
+            The driver-specific entrypoint.
+        dialect
+            The SQLAlchemy dialect name (the scheme of a connection URI).
+        db_args
+            Driver-specific arguments.
 
-        entrypoint : str
-            The entrypoint in the driver (e.g. "AdbcFlightSqlDriverInit").
-
-        db_args : dict, optional
-            Arguments to pass to the ADBC driver.
-
-        dialect : str, optional
-            Whether to use SQL or Substrait, and if SQL, which dialect
-            to use.  If not given, will try to detect Substrait vs SQL
-            and default to a generic (but extremely limited) SQL
-            dialect.
-
-        kwargs : dict, optional
-            Additional arguments.
         """
-        # TODO: detect the dialect
-        # TODO: need to control compiler
-        self._db = adbc_driver_manager.AdbcDatabase(
-            driver=driver,
-            entrypoint=entrypoint,
-            **(db_args or {}),
+        self._dialect = dialect
+        engine = sa.create_engine(
+            f"{dialect}://",
+            connect_args={
+                "driver": driver,
+                "entrypoint": entrypoint,
+                "db_args": db_args,
+            },
         )
-        self._conn = adbc_driver_manager.AdbcConnection(self._db)
+        sa.event.listen(engine, "do_connect", self._sqla_connect)
+
         if dialect == "sqlite":
             from ibis.backends.sqlite.compiler import SQLiteCompiler
 
             self.compiler = SQLiteCompiler
-            self.sqla_dialect = sa.dialects.sqlite.dialect()
-        elif not dialect:
-            pass
-        else:
-            raise NotImplementedError(
-                f"Unsupported or unknown dialect '{dialect}'"
-            )
 
-    def fetch_from_cursor(
-        self, cursor: IbisAdbcCursor, schema: sch.Schema
-    ) -> pd.DataFrame:
-        return cursor.read_pandas()
+        super().do_connect(engine)
 
-    def list_databases(self, like=None):
-        """List databases in the current server."""
-        with self._conn.get_objects(
-            depth=adbc_driver_manager.GetObjectsDepth.CATALOGS
-        ) as stmt:
-            handle = stmt.get_stream()
-            reader = pa.RecordBatchReader._import_from_c(handle.address)
-            table = reader.read_all()
-            catalog_names = table[0]
+    def fetch_from_cursor(self, cursor, schema):
+        df = cursor.cursor.fetch_df()
+        return schema.apply_to(df)
 
-        names = []
-        # TODO: what should SQLite return? See what native backend does
-        for chunk in catalog_names.chunks:
-            names.extend(
-                self._filter_with_like(
-                    (x for x in chunk.to_pylist() if x is not None), like
-                )
-            )
-        return names
-
-    def list_tables(self, like=None, database=None):
-        with self._conn.get_objects(
-            depth=adbc_driver_manager.GetObjectsDepth.TABLES, catalog=database
-        ) as stmt:
-            handle = stmt.get_stream()
-            reader = pa.RecordBatchReader._import_from_c(handle.address)
-            table = reader.read_all()
-            db_schemas = table[1]
-
-        tables = []
-        for chunk in db_schemas.chunks:
-            schema_tables = chunk.flatten().flatten()[1].flatten()
-            table_names = schema_tables.flatten()[0]
-            tables.extend(
-                self._filter_with_like(table_names.to_pylist(), like)
-            )
-        return tables
-
-    def raw_sql(self, query: str) -> Any:
-        # Since we also accept sqlalchemy exprs (todo: type annotate)
-        query = str(query.compile(dialect=self.sqla_dialect))
-        try:
-            stmt = adbc_driver_manager.AdbcStatement(self._conn)
-            stmt.set_sql_query(query)
-            stmt.execute()
-            handle = stmt.get_stream()
-            reader = pa.RecordBatchReader._import_from_c(handle.address)
-        except Exception:
-            stmt.close()
-            raise
-        return IbisAdbcCursor(stmt, reader)
-
-    def table(
-        self,
-        name: str,
-        database: str | None = None,
-        schema: str | None = None,
-    ) -> ir.Table:
-        """Create a table expression from a table in the database.
-
-        Parameters
-        ----------
-        name
-            Table name
-        database
-            The database the table resides in (mapped to 'catalog')
-        schema
-            The schema inside `database` where the table resides.
-
-            !!! warning "`schema` refers to database organization"
-
-                The `schema` parameter does **not** refer to the column names
-                and types of `table`.
-
-        Returns
-        -------
-        Table
-            Table expression
-        """
-        handle = self._conn.get_table_schema(database, schema, name)
-        pyarrow_schema = pa.Schema._import_from_c(handle.address)
-        ibis_schema = pa_dt.infer_pyarrow_schema(pyarrow_schema)
-        node = self.table_class(name=name, schema=ibis_schema, source=self)
-        return self.table_expr_class(node)
-
-    @property
-    def version(self) -> str:
-        # TODO:
-        return '0.0.1'
-
-    def _get_schema_using_query(self, query: str) -> sch.Schema:
-        with adbc_driver_manager.AdbcStatement(self._conn) as stmt:
-            stmt.set_sql_query(query)
-            stmt.execute()
-            handle = stmt.get_stream()
-            reader = pa.RecordBatchReader._import_from_c(handle.address)
-            return pa_dt.infer_pyarrow_schema(reader.schema)
-
-
-class IbisAdbcCursor(typing.NamedTuple):
-    """
-    A cursor for a result set.
-    """
-
-    statement: adbc_driver_manager.AdbcStatement
-    reader: pa.RecordBatchReader
-
-    def read_all(self):
-        return self.reader.read_all()
-
-    def read_pandas(self, *args, **kwargs):
-        return self.reader.read_pandas(*args, **kwargs)
-
-    def close(self):
-        self.reader.close()
-        self.statement.close()
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        self.close()
+    def _sqla_connect(self, dialect, conn_rec, conn_args, conn_params):
+        conn = adbc_driver_manager.dbapi.connect(
+            driver=conn_params["driver"],
+            entrypoint=conn_params["entrypoint"],
+            db_kwargs=conn_params.get("db_args"),
+        )
+        # XXX: stub out create_function for SQLite backend
+        conn.create_function = lambda *args, **kwargs: None
+        return conn

--- a/ibis/backends/adbc/tests/conftest.py
+++ b/ibis/backends/adbc/tests/conftest.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+
+import ibis
+from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
+
+
+class TestConf(BackendTest, RoundAwayFromZero):
+    supports_arrays = False
+    supports_arrays_outside_of_select = supports_arrays
+    supports_window_operations = False
+    returned_timestamp_unit = 's'
+    supports_structs = False
+
+    @staticmethod
+    def connect(data_directory: Path):
+        path = Path(
+            os.environ.get(
+                'IBIS_TEST_SQLITE_DATABASE', data_directory / 'ibis_testing.db'
+            )
+        )
+        return ibis.adbc.connect(
+            driver="adbc_driver_sqlite",
+            entrypoint="AdbcSqliteDriverInit",
+            db_args=dict(
+                filename=str(path),
+            ),
+            dialect="sqlite",
+        )
+
+    @property
+    def functional_alltypes(self) -> ir.Table:
+        t = super().functional_alltypes
+        return t.mutate(timestamp_col=t.timestamp_col.cast('timestamp'))

--- a/ibis/backends/adbc/tests/sqlite/conftest.py
+++ b/ibis/backends/adbc/tests/sqlite/conftest.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-import pytest
-import sqlalchemy as sa
-
 import ibis
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 
@@ -34,6 +31,6 @@ class TestConf(BackendTest, RoundAwayFromZero):
         )
 
     @property
-    def functional_alltypes(self) -> ir.Table:
+    def functional_alltypes(self):
         t = super().functional_alltypes
         return t.mutate(timestamp_col=t.timestamp_col.cast('timestamp'))

--- a/ibis/backends/adbc/tests/sqlite/conftest.py
+++ b/ibis/backends/adbc/tests/sqlite/conftest.py
@@ -30,6 +30,10 @@ class TestConf(BackendTest, RoundAwayFromZero):
             dialect="sqlite",
         )
 
+    @staticmethod
+    def name():
+        return "adbc_sqlite"
+
     @property
     def functional_alltypes(self):
         t = super().functional_alltypes

--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -89,7 +89,7 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
 
         if isinstance(ref_op, AlchemyTable):
             result = ref_op.sqla_table
-        elif isinstance(ref_op, ops.UnboundTable):
+        elif isinstance(ref_op, (ops.DatabaseTable, ops.UnboundTable)):
             # use SQLAlchemy's TableClause and ColumnClause for unbound tables
             schema = ref_op.schema
             result = sa.table(

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -407,7 +407,9 @@ def pytest_runtest_call(item):
     # Ibis hasn't exposed existing functionality
     # This xfails so that you know when it starts to pass
     for marker in item.iter_markers(name="notimpl"):
-        if backend in marker.args[0]:
+        if backend in marker.args[0] or (
+            backend.startswith("adbc_") and backend[5:] in marker.args[0]
+        ):
             reason = marker.kwargs.get("reason")
             item.add_marker(
                 pytest.mark.xfail(
@@ -421,7 +423,9 @@ def pytest_runtest_call(item):
     # Functionality is unavailable upstream (but could be)
     # This xfails so that you know when it starts to pass
     for marker in item.iter_markers(name="notyet"):
-        if backend in marker.args[0]:
+        if backend in marker.args[0] or (
+            backend.startswith("adbc_") and backend[5:] in marker.args[0]
+        ):
             reason = marker.kwargs.get("reason")
             item.add_marker(
                 pytest.mark.xfail(
@@ -434,7 +438,9 @@ def pytest_runtest_call(item):
             )
 
     for marker in item.iter_markers(name="never"):
-        if backend in marker.args[0]:
+        if backend in marker.args[0] or (
+            backend.startswith("adbc_") and backend[5:] in marker.args[0]
+        ):
             if "reason" not in marker.kwargs.keys():
                 raise ValueError("never requires a reason")
             item.add_marker(
@@ -447,7 +453,9 @@ def pytest_runtest_call(item):
     # imperative for a contributor to fix it just because they happened to
     # bring it to attention  -- USE SPARINGLY
     for marker in item.iter_markers(name="broken"):
-        if backend in marker.args[0]:
+        if backend in marker.args[0] or (
+            backend.startswith("adbc_") and backend[5:] in marker.args[0]
+        ):
             reason = marker.kwargs.get("reason")
             item.add_marker(
                 pytest.mark.xfail(

--- a/ibis/backends/pyarrow/datatypes.py
+++ b/ibis/backends/pyarrow/datatypes.py
@@ -9,6 +9,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 
 _to_pyarrow_types = {
+    dt.Null: pa.null(),
     dt.Int8: pa.int8(),
     dt.Int16: pa.int16(),
     dt.Int32: pa.int32(),
@@ -51,6 +52,7 @@ def from_ibis_interval(dtype):
 
 
 _to_ibis_dtypes = {
+    pa.null(): dt.Null,
     pa.int8(): dt.Int8,
     pa.int16(): dt.Int16,
     pa.int32(): dt.Int32,

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -16,7 +16,9 @@ except ImportError:
     duckdb = None
 
 pytestmark = [
-    pytest.mark.never(["sqlite", "mysql"], reason="No array support"),
+    pytest.mark.never(
+        ["adbc_sqlite", "sqlite", "mysql"], reason="No array support"
+    ),
 ]
 
 

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -54,37 +54,43 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.re_search(r'[[:digit:]]+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search_posix',
-            marks=pytest.mark.notimpl(["datafusion", "pyspark"]),
+            marks=pytest.mark.notimpl(
+                ["adbc_sqlite", "datafusion", "pyspark"]
+            ),
         ),
         param(
             lambda t: t.string_col.re_extract(r'([[:digit:]]+)', 0),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract_posix',
-            marks=pytest.mark.notimpl(["mysql", "pyspark"]),
+            marks=pytest.mark.notimpl(["adbc_sqlite", "mysql", "pyspark"]),
         ),
         param(
             lambda t: t.string_col.re_replace(r'[[:digit:]]+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
             id='re_replace_posix',
-            marks=pytest.mark.notimpl(['datafusion', "mysql", "pyspark"]),
+            marks=pytest.mark.notimpl(
+                ["adbc_sqlite", "datafusion", "mysql", "pyspark"]
+            ),
         ),
         param(
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search',
-            marks=pytest.mark.notimpl(["impala", "datafusion"]),
+            marks=pytest.mark.notimpl(["adbc_sqlite", "impala", "datafusion"]),
         ),
         param(
             lambda t: t.string_col.re_extract(r'(\d+)', 0),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract',
-            marks=pytest.mark.notimpl(["impala", "mysql"]),
+            marks=pytest.mark.notimpl(["adbc_sqlite", "impala", "mysql"]),
         ),
         param(
             lambda t: t.string_col.re_replace(r'\d+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
             id='re_replace',
-            marks=pytest.mark.notimpl(["impala", "datafusion", "mysql"]),
+            marks=pytest.mark.notimpl(
+                ["adbc_sqlite", "impala", "datafusion", "mysql"]
+            ),
         ),
         param(
             lambda t: t.string_col.repeat(2),
@@ -105,7 +111,9 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.translate('0', 'a'),
             lambda t: t.string_col.str.translate(str.maketrans('0', 'a')),
             id='translate',
-            marks=pytest.mark.notimpl(["clickhouse", "datafusion", "mysql"]),
+            marks=pytest.mark.notimpl(
+                ["adbc_sqlite", "clickhouse", "datafusion", "mysql"]
+            ),
         ),
         param(
             lambda t: t.string_col.find('a'),
@@ -127,13 +135,17 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.find_in_set(['1']),
             lambda t: t.string_col.str.find('1'),
             id='find_in_set',
-            marks=pytest.mark.notimpl(["datafusion", "pyspark", "sqlite"]),
+            marks=pytest.mark.notimpl(
+                ["adbc_sqlite", "datafusion", "pyspark", "sqlite"]
+            ),
         ),
         param(
             lambda t: t.string_col.find_in_set(['a']),
             lambda t: t.string_col.str.find('a'),
             id='find_in_set_all_missing',
-            marks=pytest.mark.notimpl(["datafusion", "pyspark", "sqlite"]),
+            marks=pytest.mark.notimpl(
+                ["adbc_sqlite", "datafusion", "pyspark", "sqlite"]
+            ),
         ),
         param(
             lambda t: t.string_col.lower(),
@@ -149,13 +161,16 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.reverse(),
             lambda t: t.string_col.str[::-1],
             id='reverse',
+            marks=pytest.mark.notimpl(["adbc_sqlite"]),
         ),
         param(
             lambda t: t.string_col.ascii_str(),
             lambda t: t.string_col.map(ord).astype('int32'),
             id='ascii_str',
             # TODO(dask) - dtype - #2553
-            marks=pytest.mark.notimpl(["clickhouse", "dask", "datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["adbc_sqlite", "clickhouse", "dask", "datafusion"]
+            ),
         ),
         param(
             lambda t: t.string_col.length(),
@@ -193,7 +208,7 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.capitalize(),
             lambda t: t.string_col.str.capitalize(),
             id='capitalize',
-            marks=pytest.mark.notimpl(["clickhouse", "duckdb"]),
+            marks=pytest.mark.notimpl(["adbc_sqlite", "clickhouse", "duckdb"]),
         ),
         param(
             lambda t: t.date_string_col.substr(2, 3),
@@ -251,7 +266,14 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.date_string_col.str.split('/'),
             id='split',
             marks=pytest.mark.notimpl(
-                ["dask", "datafusion", "impala", "mysql", "sqlite"]
+                [
+                    "adbc_sqlite",
+                    "dask",
+                    "datafusion",
+                    "impala",
+                    "mysql",
+                    "sqlite",
+                ]
             ),
         ),
         param(

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -8,7 +8,9 @@ import ibis
 import ibis.expr.datatypes as dt
 
 pytestmark = [
-    pytest.mark.never(["mysql", "sqlite"], reason="No struct support"),
+    pytest.mark.never(
+        ["adbc_sqlite", "mysql", "sqlite"], reason="No struct support"
+    ),
     pytest.mark.notyet(["impala"]),
     pytest.mark.notimpl(["datafusion", "pyspark"]),
 ]

--- a/nix/adbc.nix
+++ b/nix/adbc.nix
@@ -1,0 +1,44 @@
+{ fetchFromGitHub
+, lib
+, stdenv
+, arrow-cpp
+, cmake
+, gtest
+, ninja
+, sqlite
+, pname
+, sourceRoot
+, installCheckPhase ? ""
+, doInstallCheck ? false
+}:
+stdenv.mkDerivation rec {
+  inherit pname;
+  version = "0.0.1"; # not actually a version (yet)
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "arrow-adbc";
+    rev = "ef70af6aff8da61bbe2f19f14c607aa6c07caf33";
+    hash = "sha256-ibk30T0EXbI5ZB5so0+TV6SCiIC7M4taAqUL0ohW4us=";
+  };
+
+  inherit sourceRoot;
+
+  nativeBuildInputs = [ cmake ninja ];
+  buildInputs = [ arrow-cpp sqlite ] ++ lib.optionals doInstallCheck [ gtest ];
+
+  cmakeFlags = [
+    "-DADBC_BUILD_TESTS=${if doInstallCheck then "ON" else "OFF"}"
+    "-DADBC_BUILD_SHARED=ON"
+    "-DADBC_BUILD_STATIC=OFF"
+  ];
+
+  inherit doInstallCheck installCheckPhase;
+
+  meta = with lib; {
+    description = "Arrow Database Connectivity";
+    homepage = "https://github.com/apache/arrow-adbc";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ cpcloud ];
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -98,6 +98,22 @@ import sources.nixpkgs {
           shfmt
         ];
       };
+
+      adbc-sqlite = pkgs.callPackage ./adbc.nix {
+        pname = "adbc-sqlite";
+        sourceRoot = "source/c/drivers/sqlite";
+      };
+
+      adbc-driver-manager = pkgs.callPackage ./adbc.nix {
+        pname = "adbc-driver-manager";
+        sourceRoot = "source/c/driver_manager";
+        doInstallCheck = true;
+        installCheckPhase = ''
+          runHook preInstallCheck
+          ctest
+          runHook postInstallCheck
+        '';
+      };
     } // super.lib.optionalAttrs super.stdenv.isDarwin {
       arrow-cpp = super.arrow-cpp.override {
         enableS3 = false;

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -89,14 +89,16 @@ in
 
   adbc-driver-manager = self.buildPythonPackage {
     pname = "adbc-driver-manager";
-    inherit (pkgs.adbc-sqlite) version src;
+    inherit (pkgs.adbc-driver-manager) version src;
     sourceRoot = "source/python/adbc_driver_manager";
     format = "setuptools";
 
     nativeBuildInputs = [ self.cython ];
     propagatedBuildInputs = [ self.pyarrow ];
 
-    LD_LIBRARY_PATH = "${pkgs.adbc-sqlite}/lib";
+    preCheck = ''
+      export LD_LIBRARY_PATH="${pkgs.adbc-sqlite}/lib"
+    '';
 
     checkInputs = [ self.pytest ];
     checkPhase = ''

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -86,4 +86,23 @@ in
     '';
     SETUPTOOLS_SCM_PRETEND_VERSION = version;
   });
+
+  adbc-driver-manager = self.buildPythonPackage {
+    pname = "adbc-driver-manager";
+    inherit (pkgs.adbc-sqlite) version src;
+    sourceRoot = "source/python/adbc_driver_manager";
+    format = "setuptools";
+
+    nativeBuildInputs = [ self.cython ];
+    propagatedBuildInputs = [ self.pyarrow ];
+
+    LD_LIBRARY_PATH = "${pkgs.adbc-sqlite}/lib";
+
+    checkInputs = [ self.pytest ];
+    checkPhase = ''
+      runHook preCheck
+      pytest
+      runHook postCheck
+    '';
+  };
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,17 +7,12 @@ optional = false
 python-versions = ">=3.6.1"
 
 [[package]]
-name = "ADBC-Driver-Manager"
-version = "0.0.0"
+name = "adbc-driver-manager"
+version = "0.0.1a0"
 description = ""
 category = "main"
 optional = true
-python-versions = "*"
-develop = false
-
-[package.source]
-type = "directory"
-url = "../arrow-adbc/python/adbc_driver_manager"
+python-versions = ">=3.10,<4.0"
 
 [[package]]
 name = "appnope"
@@ -2434,14 +2429,17 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "2b5f155aa98da27330735621334d8cec4f1133c9f82e419bcac4dcb7a307d112"
+content-hash = "0a5d7630e398417af82ea8655577411b35b3cb320cc651e2cf4691f9c382ace5"
 
 [metadata.files]
 absolufy-imports = [
     {file = "absolufy_imports-0.3.1-py2.py3-none-any.whl", hash = "sha256:49bf7c753a9282006d553ba99217f48f947e3eef09e18a700f8a82f75dc7fc5c"},
     {file = "absolufy_imports-0.3.1.tar.gz", hash = "sha256:c90638a6c0b66826d1fb4880ddc20ef7701af34192c94faf40b95d32b59f9793"},
 ]
-ADBC-Driver-Manager = []
+adbc-driver-manager = [
+    {file = "adbc_driver_manager-0.0.1a0-cp310-cp310-manylinux_2_27_x86_64.whl", hash = "sha256:32c24da013097e0bdd05131c009a7b5a6cefb2301478bfd5c5d8cad23341ffe9"},
+    {file = "adbc_driver_manager-0.0.1a0.tar.gz", hash = "sha256:5b45293bf40311e42b5fdb3db1b664caabeda111553029fab1d52def541b47a5"},
+]
 appnope = [
     {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
     {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,19 @@ optional = false
 python-versions = ">=3.6.1"
 
 [[package]]
+name = "ADBC-Driver-Manager"
+version = "0.0.0"
+description = ""
+category = "main"
+optional = true
+python-versions = "*"
+develop = false
+
+[package.source]
+type = "directory"
+url = "../arrow-adbc/python/adbc_driver_manager"
+
+[[package]]
 name = "appnope"
 version = "0.1.3"
 description = "Disable App Nap on macOS >= 10.9"
@@ -336,6 +349,14 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 
 [package.extras]
 toml = ["tomli"]
+
+[[package]]
+name = "cython"
+version = "0.29.32"
+description = "The Cython compiler for writing C extensions for the Python language."
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "dask"
@@ -2395,6 +2416,7 @@ docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tideli
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
+adbc = ["adbc-driver-manager", "pyarrow", "sqlalchemy"]
 all = ["clickhouse-cityhash", "clickhouse-driver", "dask", "datafusion", "duckdb", "duckdb-engine", "fsspec", "GeoAlchemy2", "geopandas", "graphviz", "impyla", "lz4", "psycopg2", "pyarrow", "pymysql", "pyspark", "requests", "Shapely", "sqlalchemy"]
 clickhouse = ["clickhouse-driver", "clickhouse-cityhash", "lz4"]
 dask = ["dask", "pyarrow"]
@@ -2412,13 +2434,14 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "abdb00f45d9e48af4ec4b356bff99d04340c9ec53ca53e9ca8a3e4116b4b78e3"
+content-hash = "2b5f155aa98da27330735621334d8cec4f1133c9f82e419bcac4dcb7a307d112"
 
 [metadata.files]
 absolufy-imports = [
     {file = "absolufy_imports-0.3.1-py2.py3-none-any.whl", hash = "sha256:49bf7c753a9282006d553ba99217f48f947e3eef09e18a700f8a82f75dc7fc5c"},
     {file = "absolufy_imports-0.3.1.tar.gz", hash = "sha256:c90638a6c0b66826d1fb4880ddc20ef7701af34192c94faf40b95d32b59f9793"},
 ]
+ADBC-Driver-Manager = []
 appnope = [
     {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
     {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
@@ -2901,6 +2924,48 @@ coverage = [
     {file = "coverage-6.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:edfdabe7aa4f97ed2b9dd5dde52d2bb29cb466993bb9d612ddd10d0085a683cf"},
     {file = "coverage-6.4.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:e2618cb2cf5a7cc8d698306e42ebcacd02fb7ef8cfc18485c59394152c70be97"},
     {file = "coverage-6.4.2.tar.gz", hash = "sha256:6c3ccfe89c36f3e5b9837b9ee507472310164f352c9fe332120b764c9d60adbe"},
+]
+cython = [
+    {file = "Cython-0.29.32-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:39afb4679b8c6bf7ccb15b24025568f4f9b4d7f9bf3cbd981021f542acecd75b"},
+    {file = "Cython-0.29.32-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:dbee03b8d42dca924e6aa057b836a064c769ddfd2a4c2919e65da2c8a362d528"},
+    {file = "Cython-0.29.32-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ba622326f2862f9c1f99ca8d47ade49871241920a352c917e16861e25b0e5c3"},
+    {file = "Cython-0.29.32-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e6ffa08aa1c111a1ebcbd1cf4afaaec120bc0bbdec3f2545f8bb7d3e8e77a1cd"},
+    {file = "Cython-0.29.32-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:97335b2cd4acebf30d14e2855d882de83ad838491a09be2011745579ac975833"},
+    {file = "Cython-0.29.32-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:06be83490c906b6429b4389e13487a26254ccaad2eef6f3d4ee21d8d3a4aaa2b"},
+    {file = "Cython-0.29.32-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:eefd2b9a5f38ded8d859fe96cc28d7d06e098dc3f677e7adbafda4dcdd4a461c"},
+    {file = "Cython-0.29.32-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5514f3b4122cb22317122a48e175a7194e18e1803ca555c4c959d7dfe68eaf98"},
+    {file = "Cython-0.29.32-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:656dc5ff1d269de4d11ee8542f2ffd15ab466c447c1f10e5b8aba6f561967276"},
+    {file = "Cython-0.29.32-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:cdf10af3e2e3279dc09fdc5f95deaa624850a53913f30350ceee824dc14fc1a6"},
+    {file = "Cython-0.29.32-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:3875c2b2ea752816a4d7ae59d45bb546e7c4c79093c83e3ba7f4d9051dd02928"},
+    {file = "Cython-0.29.32-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:79e3bab19cf1b021b613567c22eb18b76c0c547b9bc3903881a07bfd9e7e64cf"},
+    {file = "Cython-0.29.32-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0595aee62809ba353cebc5c7978e0e443760c3e882e2c7672c73ffe46383673"},
+    {file = "Cython-0.29.32-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0ea8267fc373a2c5064ad77d8ff7bf0ea8b88f7407098ff51829381f8ec1d5d9"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:c8e8025f496b5acb6ba95da2fb3e9dacffc97d9a92711aacfdd42f9c5927e094"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:afbce249133a830f121b917f8c9404a44f2950e0e4f5d1e68f043da4c2e9f457"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:513e9707407608ac0d306c8b09d55a28be23ea4152cbd356ceaec0f32ef08d65"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e83228e0994497900af954adcac27f64c9a57cd70a9ec768ab0cb2c01fd15cf1"},
+    {file = "Cython-0.29.32-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ea1dcc07bfb37367b639415333cfbfe4a93c3be340edf1db10964bc27d42ed64"},
+    {file = "Cython-0.29.32-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8669cadeb26d9a58a5e6b8ce34d2c8986cc3b5c0bfa77eda6ceb471596cb2ec3"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:ed087eeb88a8cf96c60fb76c5c3b5fb87188adee5e179f89ec9ad9a43c0c54b3"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:3f85eb2343d20d91a4ea9cf14e5748092b376a64b7e07fc224e85b2753e9070b"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:63b79d9e1f7c4d1f498ab1322156a0d7dc1b6004bf981a8abda3f66800e140cd"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e1958e0227a4a6a2c06fd6e35b7469de50adf174102454db397cec6e1403cce3"},
+    {file = "Cython-0.29.32-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:856d2fec682b3f31583719cb6925c6cdbb9aa30f03122bcc45c65c8b6f515754"},
+    {file = "Cython-0.29.32-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:479690d2892ca56d34812fe6ab8f58e4b2e0129140f3d94518f15993c40553da"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:67fdd2f652f8d4840042e2d2d91e15636ba2bcdcd92e7e5ffbc68e6ef633a754"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:4a4b03ab483271f69221c3210f7cde0dcc456749ecf8243b95bc7a701e5677e0"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:40eff7aa26e91cf108fd740ffd4daf49f39b2fdffadabc7292b4b7dc5df879f0"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0bbc27abdf6aebfa1bce34cd92bd403070356f28b0ecb3198ff8a182791d58b9"},
+    {file = "Cython-0.29.32-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:cddc47ec746a08603037731f5d10aebf770ced08666100bd2cdcaf06a85d4d1b"},
+    {file = "Cython-0.29.32-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:eca3065a1279456e81c615211d025ea11bfe4e19f0c5650b859868ca04b3fcbd"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:d968ffc403d92addf20b68924d95428d523436adfd25cf505d427ed7ba3bee8b"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:f3fd44cc362eee8ae569025f070d56208908916794b6ab21e139cea56470a2b3"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:b6da3063c5c476f5311fd76854abae6c315f1513ef7d7904deed2e774623bbb9"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:061e25151c38f2361bc790d3bcf7f9d9828a0b6a4d5afa56fbed3bd33fb2373a"},
+    {file = "Cython-0.29.32-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f9944013588a3543fca795fffb0a070a31a243aa4f2d212f118aa95e69485831"},
+    {file = "Cython-0.29.32-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:07d173d3289415bb496e72cb0ddd609961be08fe2968c39094d5712ffb78672b"},
+    {file = "Cython-0.29.32-py2.py3-none-any.whl", hash = "sha256:eeb475eb6f0ccf6c039035eb4f0f928eb53ead88777e0a760eccb140ad90930b"},
+    {file = "Cython-0.29.32.tar.gz", hash = "sha256:8733cf4758b79304f2a4e39ebfac5e92341bce47bcceb26c1254398b2f8c1af7"},
 ]
 dask = [
     {file = "dask-2022.7.1-py3-none-any.whl", hash = "sha256:501bdd2fc3f7bce7a42f4cb85a7883e831d45ce1c2be2465e5e687f9e9d35d74"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pydantic = ">=1.9.0,<2"
 regex = ">=2021.7.6"
 rich = ">=12.4.4,<13"
 toolz = ">=0.11,<0.13"
+adbc-driver-manager = { path = "../arrow-adbc/python/adbc_driver_manager", optional = true }
 clickhouse-cityhash = { version = ">=1.0.2,<2", optional = true }
 clickhouse-driver = { version = ">=0.1,<0.3", optional = true, extras = [
   "numpy"
@@ -129,7 +130,7 @@ all = [
   "Shapely",
   "sqlalchemy",
 ]
-adbc = ["pyarrow", "sqlalchemy"]
+adbc = ["adbc-driver-manager", "pyarrow", "sqlalchemy"]
 clickhouse = ["clickhouse-driver", "clickhouse-cityhash", "lz4"]
 dask = ["dask", "pyarrow"]
 datafusion = ["datafusion"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,12 @@ Shapely = { version = ">=1.6,<1.8.3", optional = true }
 sqlalchemy = { version = ">=1.4,<2.0", optional = true }
 
 [tool.poetry.dev-dependencies]
+Cython = ">=0.29,<1"
 absolufy-imports = ">=0.3.1,<1"
 black = ">=22.1.0,<23"
 click = ">=8.0.1,<9"
 commitizen = ">=2.20.3,<3"
+filelock = ">=3.7.0,<4"
 flake8 = ">=4.0.0,<6"
 ipdb = "^0.13.9"
 ipykernel = ">=6,<7"
@@ -98,7 +100,6 @@ pytest-profiling = ">=1.7.0,<2"
 pytest-randomly = ">=3.10.1,<4"
 pytest-repeat = ">=0.9.1,<0.10"
 pytest-xdist = ">=2.3.0,<3"
-filelock = ">=3.7.0,<4"
 pytkdocs = { version = ">=0.15.0,<0.17.0", extras = ["numpy-style"] }
 pyupgrade = ">=2.26.0,<3"
 requests = ">=2,<3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ pydantic = ">=1.9.0,<2"
 regex = ">=2021.7.6"
 rich = ">=12.4.4,<13"
 toolz = ">=0.11,<0.13"
-adbc-driver-manager = { path = "../arrow-adbc/python/adbc_driver_manager", optional = true }
+adbc-driver-manager = { version = "0.0.1a0", allow-prereleases = true, optional = true, python = "^3.10" }
 clickhouse-cityhash = { version = ">=1.0.2,<2", optional = true }
 clickhouse-driver = { version = ">=0.1,<0.3", optional = true, extras = [
   "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ tomli = ">=2.0.1,<3"
 
 [tool.poetry.extras]
 all = [
+  "adbc",
   "clickhouse-cityhash",
   "clickhouse-driver",
   "dask",
@@ -128,6 +129,7 @@ all = [
   "Shapely",
   "sqlalchemy",
 ]
+adbc = ["pyarrow", "sqlalchemy"]
 clickhouse = ["clickhouse-driver", "clickhouse-cityhash", "lz4"]
 dask = ["dask", "pyarrow"]
 datafusion = ["datafusion"]
@@ -142,6 +144,7 @@ sqlite = ["sqlalchemy"]
 visualization = ["graphviz"]
 
 [tool.poetry.plugins."ibis.backends"]
+adbc = "ibis.backends.adbc"
 clickhouse = "ibis.backends.clickhouse"
 dask = "ibis.backends.dask"
 datafusion = "ibis.backends.datafusion"
@@ -237,6 +240,7 @@ markers = [
   "never: tests for functionality that a backend is likely to never implement",
   "broken: test has exposed existing broken functionality",
   "sqlalchemy_only: tests for SQLAlchemy based backends",
+  "adbc: ADBC tests",
   "clickhouse: ClickHouse tests",
   "dask: Dask tests",
   "datafusion: Apache Datafusion tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,7 +242,7 @@ markers = [
   "never: tests for functionality that a backend is likely to never implement",
   "broken: test has exposed existing broken functionality",
   "sqlalchemy_only: tests for SQLAlchemy based backends",
-  "adbc: ADBC tests",
+  "adbc_sqlite: ADBC tests (SQLite driver)",
   "clickhouse: ClickHouse tests",
   "dask: Dask tests",
   "datafusion: Apache Datafusion tests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ colorama==0.4.5; platform_system == "Windows" and python_version >= "3.8" and py
 commitizen==2.29.3; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 commonmark==0.9.1; python_full_version >= "3.6.3" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
 coverage==6.4.2; python_version >= "3.7"
-cython==0.29.32; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 dask==2022.7.1; python_version >= "3.8"
 datafusion==0.6.0; python_version >= "3.6"
 debugpy==1.6.2; python_version >= "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ colorama==0.4.5; platform_system == "Windows" and python_version >= "3.8" and py
 commitizen==2.29.3; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 commonmark==0.9.1; python_full_version >= "3.6.3" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
 coverage==6.4.2; python_version >= "3.7"
+cython==0.29.32; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 dask==2022.7.1; python_version >= "3.8"
 datafusion==0.6.0; python_version >= "3.6"
 debugpy==1.6.2; python_version >= "3.7"

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,13 @@ from setuptools import setup
 packages = [
     'ibis',
     'ibis.backends',
+    'ibis.backends.adbc',
+    'ibis.backends.adbc.tests',
     'ibis.backends.base',
     'ibis.backends.base.sql',
     'ibis.backends.base.sql.alchemy',
     'ibis.backends.base.sql.compiler',
     'ibis.backends.base.sql.registry',
-    'ibis.backends.adbc',
     'ibis.backends.clickhouse',
     'ibis.backends.clickhouse.tests',
     'ibis.backends.dask',
@@ -65,6 +66,11 @@ install_requires = [
 ]
 
 extras_require = {
+    'adbc': [
+        'adbc-driver-manager @ ../arrow-adbc/python/adbc_driver_manager',
+        'pyarrow>=1,<9',
+        'sqlalchemy>=1.4,<2.0',
+    ],
     'all': [
         'clickhouse-cityhash>=1.0.2,<2',
         'clickhouse-driver[numpy]>=0.1,<0.3',

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ packages = [
     'ibis.backends.base.sql.alchemy',
     'ibis.backends.base.sql.compiler',
     'ibis.backends.base.sql.registry',
+    'ibis.backends.adbc',
     'ibis.backends.clickhouse',
     'ibis.backends.clickhouse.tests',
     'ibis.backends.dask',
@@ -116,6 +117,7 @@ extras_require = {
 
 entry_points = {
     'ibis.backends': [
+        'adbc = ibis.backends.adbc',
         'clickhouse = ibis.backends.clickhouse',
         'dask = ibis.backends.dask',
         'datafusion = ibis.backends.datafusion',

--- a/setup.py
+++ b/setup.py
@@ -66,10 +66,9 @@ install_requires = [
 ]
 
 extras_require = {
-    'adbc': [
-        'adbc-driver-manager @ ../arrow-adbc/python/adbc_driver_manager',
-        'pyarrow>=1,<9',
-        'sqlalchemy>=1.4,<2.0',
+    'adbc': ['pyarrow>=1,<9', 'sqlalchemy>=1.4,<2.0'],
+    'adbc:python_version >= "3.10" and python_version < "4.0"': [
+        'adbc-driver-manager==0.0.1a0'
     ],
     'all': [
         'clickhouse-cityhash>=1.0.2,<2',

--- a/shell.nix
+++ b/shell.nix
@@ -81,6 +81,7 @@ pkgs.mkShell {
   ]);
 
   PYTHONPATH = builtins.toPath ./.;
+  LD_LIBRARY_PATH = "${pkgs.adbc-sqlite}/lib";
   PGPASSWORD = "postgres";
   MYSQL_PWD = "ibis";
 }


### PR DESCRIPTION
This adds the skeleton of a very minimal ADBC backend. Most tests
do not yet pass. The main thing is that ADBC is really a database
API abstraction akin to PEP 249, JDBC, or ODBC, so this backend
eventually needs to be able to let the user specify the SQL
dialect to compile to (or: to use Substrait instead).

Also, I haven't yet updated the dependencies, CI, etc. This is 
mostly to prove that it (generally) is possible.

ADBC doesn't yet have packages/releases, so getting this up and
working takes some work. Basically:

1. Add cython to shell.nix
1. Get the ADBC C SQLite driver built (I did this outside of Nix): https://github.com/apache/arrow-adbc/blob/main/CONTRIBUTING.md#cc
1. Inside the Nix dev environment, get the Python package built: https://github.com/apache/arrow-adbc/blob/main/CONTRIBUTING.md#python (this only worked if I made a virtualenv inside the Nix shell)
1. `export LD_LIBRARY_PATH=path/to/folder/with/libadbc_driver_sqlite.so`
1. `export PYTHONPATH=$PYTHONPATH:path/to/folder/with/adbc_driver_manager/package`
1. `python -m pytest -m adbc`