### PR TITLE
fix(pandas): use localized UTC time for `now` operation

### DIFF
--- a/ibis/backends/pandas/execution/temporal.py
+++ b/ibis/backends/pandas/execution/temporal.py
@@ -239,8 +239,9 @@ def execute_timestamp_from_unix(op, data, **kwargs):
 @pre_execute.register(ops.TimestampNow)
 @pre_execute.register(ops.TimestampNow, BaseBackend)
 def pre_execute_timestamp_now(op, *args, **kwargs):
-    timecontext = kwargs.get('timecontext', None)
-    return Scope({op: pd.Timestamp('now')}, timecontext)
+    timecontext = kwargs.get("timecontext", None)
+    now = pd.Timestamp("now", tz="UTC").tz_localize(None)
+    return Scope({op: now}, timecontext)
 
 
 @execute_node.register(ops.DayOfWeekIndex, (str, datetime.date))

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -726,15 +726,15 @@ def test_day_of_week_column_group_by(
 
 
 @pytest.mark.notimpl(["datafusion"])
-def test_now(backend, con):
+def test_now(con):
     expr = ibis.now()
     result = con.execute(expr)
-    pandas_now = pd.Timestamp('now')
     assert isinstance(result, pd.Timestamp)
 
-    # this could fail if we're testing in different timezones and we're testing
-    # on Dec 31st
-    assert result.year == pandas_now.year
+    pattern = "%Y%m%d %H"
+    result_strftime = con.execute(expr.strftime(pattern))
+    expected_strftime = datetime.datetime.utcnow().strftime(pattern)
+    assert result_strftime == expected_strftime
 
 
 @pytest.mark.notimpl(["dask"], reason="Limit #2553")


### PR DESCRIPTION
This PR unifies the result value of `now` between pandas and dask and the SQL backends to be a localized UTC value
