### PR TITLE
Pin Mariadb to 10.8.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
         - mysqladmin
         - ping
       timeout: 5s
-    image: mariadb:10.8
+    image: mariadb:10.8.2
     ports:
       - 3306:3306
     networks:


### PR DESCRIPTION
When trying to run `docker-compose up` the `mysql` container would never come up. The logs mentioned "Can't initialize timers" and the first result that came up was https://github.com/MariaDB/mariadb-docker/issues/434 which has this comment https://github.com/MariaDB/mariadb-docker/issues/434#issuecomment-1135889824 which mentions pinning to `10.8.2`. After pinning to that version everything seemed to work fine. 