### PR TITLE
refactor(raw_sql): Remove unused `results` kwarg

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -73,7 +73,7 @@ class BaseSQLBackend(BaseBackend):
             f"Backend {self.name} does not support .sql()"
         )
 
-    def raw_sql(self, query: str, results: bool = False) -> Any:
+    def raw_sql(self, query: str) -> Any:
         """Execute a query string.
 
         Could have unexpected results if the query modifies the behavior of

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -1312,9 +1312,7 @@ class Backend(BaseSQLBackend):
         return self._exec_statement(stmt)
 
     def _exec_statement(self, stmt):
-        return self.fetch_from_cursor(
-            self.raw_sql(stmt, results=True), schema=None
-        )
+        return self.fetch_from_cursor(self.raw_sql(stmt), schema=None)
 
     def _table_command(self, cmd, name, database=None):
         qualified_name = self._fully_qualified_name(name, database)

--- a/ibis/backends/impala/tests/test_client.py
+++ b/ibis/backends/impala/tests/test_client.py
@@ -37,8 +37,8 @@ def test_execute_exprs_default_backend(con_no_hdfs):
 
 def test_cursor_garbage_collection(con):
     for i in range(5):
-        con.raw_sql('select 1', True).fetchall()
-        con.raw_sql('select 1', True).fetchone()
+        con.raw_sql('select 1').fetchall()
+        con.raw_sql('select 1').fetchone()
 
 
 def test_raise_ibis_error_no_hdfs(con_no_hdfs):
@@ -72,7 +72,7 @@ def test_sql_with_limit(con):
 
 def test_raw_sql(con):
     query = 'SELECT * from functional_alltypes limit 10'
-    cur = con.raw_sql(query, results=True)
+    cur = con.raw_sql(query)
     rows = cur.fetchall()
     cur.release()
     assert len(rows) == 10
@@ -298,17 +298,17 @@ def con2(env):
 def test_rerelease_cursor(con2):
     # we use a separate `con2` fixture here because any connection pool
     # manipulation we want to happen independently of `con`
-    with con2.raw_sql('select 1', True) as cur1:
+    with con2.raw_sql('select 1') as cur1:
         pass
 
     cur1.release()
 
-    with con2.raw_sql('select 1', True) as cur2:
+    with con2.raw_sql('select 1') as cur2:
         pass
 
     cur2.release()
 
-    with con2.raw_sql('select 1', True) as cur3:
+    with con2.raw_sql('select 1') as cur3:
         pass
 
     assert cur1 == cur2
@@ -337,7 +337,7 @@ def test_datetime_to_int_cast(con):
 
 def test_set_option_with_dot(con):
     con.set_options({'request_pool': 'baz.quux'})
-    result = dict(row[:2] for row in con.raw_sql('set', True).fetchall())
+    result = dict(row[:2] for row in con.raw_sql('set').fetchall())
     assert result['REQUEST_POOL'] == 'baz.quux'
 
 

--- a/ibis/backends/impala/tests/test_patched.py
+++ b/ibis/backends/impala/tests/test_patched.py
@@ -39,14 +39,14 @@ def test_refresh(con, spy, qname):
 def test_describe_formatted(con, spy, qname):
     t = con.table('functional_alltypes')
     desc = t.describe_formatted()
-    spy.assert_called_with(f'DESCRIBE FORMATTED {qname}', results=True)
+    spy.assert_called_with(f'DESCRIBE FORMATTED {qname}')
     assert isinstance(desc, metadata.TableMetadata)
 
 
 def test_show_files(con, spy, qname):
     t = con.table('functional_alltypes')
     desc = t.files()
-    spy.assert_called_with(f'SHOW FILES IN {qname}', results=True)
+    spy.assert_called_with(f'SHOW FILES IN {qname}')
     assert isinstance(desc, pd.DataFrame)
 
 
@@ -54,9 +54,9 @@ def test_table_column_stats(con, spy, qname):
     t = con.table('functional_alltypes')
 
     desc = t.stats()
-    spy.assert_called_with(f'SHOW TABLE STATS {qname}', results=True)
+    spy.assert_called_with(f'SHOW TABLE STATS {qname}')
     assert isinstance(desc, pd.DataFrame)
 
     desc = t.column_stats()
-    spy.assert_called_with(f'SHOW COLUMN STATS {qname}', results=True)
+    spy.assert_called_with(f'SHOW COLUMN STATS {qname}')
     assert isinstance(desc, pd.DataFrame)


### PR DESCRIPTION
This is _technically_ a breaking change but I am not marking it as
breaking because I don't imagine anyone is actually using the `results`
kwarg, and because it does nothing.