### PR TITLE
fix: fix timestamp-date comparisons

### DIFF
--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -227,6 +227,11 @@ def hash(translator, expr):
         raise NotImplementedError(how)
 
 
+def concat(translator, expr):
+    joined_args = ', '.join(map(translator.translate, expr.op().arg))
+    return f"concat({joined_args})"
+
+
 binary_infix_ops = {
     # Binary operations
     ops.Add: binary_infix.binary_infix_op('+'),
@@ -304,7 +309,7 @@ operation_registry = {
     ops.Count: aggregate.reduction('count'),
     ops.CountDistinct: aggregate.count_distinct,
     # string operations
-    ops.StringConcat: fixed_arity('concat', 2),
+    ops.StringConcat: concat,
     ops.StringLength: unary('length'),
     ops.StringAscii: unary('ascii'),
     ops.Lowercase: unary('lower'),

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -27,6 +27,7 @@ from ibis.backends.dask.execution.util import (
     register_types_to_dispatcher,
 )
 from ibis.backends.pandas.core import (
+    date_types,
     integer_types,
     numeric_types,
     simple_types,
@@ -34,6 +35,7 @@ from ibis.backends.pandas.core import (
 )
 from ibis.backends.pandas.execution import constants
 from ibis.backends.pandas.execution.generic import (
+    _execute_binary_op_impl,
     execute_between,
     execute_cast_series_array,
     execute_cast_series_generic,
@@ -314,15 +316,14 @@ def execute_not_scalar_or_series(op, data, **kwargs):
 @execute_node.register(ops.Comparison, dd.Series, timestamp_types)
 @execute_node.register(ops.Comparison, timestamp_types, dd.Series)
 def execute_binary_op(op, left, right, **kwargs):
-    op_type = type(op)
-    try:
-        operation = constants.BINARY_OPERATIONS[op_type]
-    except KeyError:
-        raise NotImplementedError(
-            f'Binary operation {op_type.__name__} not implemented'
-        )
-    else:
-        return operation(left, right)
+    return _execute_binary_op_impl(op, left, right, **kwargs)
+
+
+@execute_node.register(ops.Comparison, dd.Series, date_types)
+def execute_binary_op_date_right(op, left, right, **kwargs):
+    return _execute_binary_op_impl(
+        op, dd.to_datetime(left), pd.to_datetime(right), **kwargs
+    )
 
 
 @execute_node.register(ops.Binary, ddgb.SeriesGroupBy, ddgb.SeriesGroupBy)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -495,7 +495,7 @@ def test_approx_median(alltypes):
             L(":") + ":",
             "::",
             id="expr",
-            marks=mark.notyet(["duckdb", "impala", "mysql", "pyspark"]),
+            marks=mark.notyet(["duckdb", "mysql", "pyspark"]),
         ),
     ],
 )

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -264,19 +264,19 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col + t.date_string_col,
             lambda t: t.string_col + t.date_string_col,
             id='concat_columns',
-            marks=pytest.mark.notimpl(["datafusion", "impala"]),
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             lambda t: t.string_col + 'a',
             lambda t: t.string_col + 'a',
             id='concat_column_scalar',
-            marks=pytest.mark.notimpl(["datafusion", "impala"]),
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             lambda t: 'a' + t.string_col,
             lambda t: 'a' + t.string_col,
             id='concat_scalar_column',
-            marks=pytest.mark.notimpl(["datafusion", "impala"]),
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
     ],
 )


### PR DESCRIPTION
This PR fixes issues with comparing timestamps and dates in the pandas and dask
backends as well as a bug in the impala translation rule for `StringConcat`
along the way.

Closes #4291.
