### PR TITLE
fix(pandas): Fix anti-joins

### DIFF
--- a/ibis/backends/pandas/execution/join.py
+++ b/ibis/backends/pandas/execution/join.py
@@ -1,4 +1,3 @@
-import functools
 import operator
 
 import pandas as pd
@@ -47,16 +46,13 @@ def _get_semi_anti_join_filter(op, left, right, predicates, **kwargs):
         predicates,
         **kwargs,
     )
-    inner = pd.merge(
-        left,
-        right,
-        how="inner",
-        left_on=left_on,
-        right_on=right_on,
-        suffixes=constants.JOIN_SUFFIXES,
+    inner = left.merge(
+        right[right_on].drop_duplicates(),
+        on=left_on,
+        how="left",
+        indicator=True,
     )
-    predicates = [left.loc[:, key].isin(inner.loc[:, key]) for key in left_on]
-    return functools.reduce(operator.and_, predicates)
+    return (inner["_merge"] == "both").values
 
 
 @execute_node.register(ops.LeftSemiJoin, pd.DataFrame, pd.DataFrame, tuple)

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -15,10 +15,8 @@ def _pandas_semi_join(left, right, on, **_):
 
 
 def _pandas_anti_join(left, right, on, **_):
-    assert len(on) == 1, str(on)
-    inner = pd.merge(left, right, how="inner", on=on)
-    filt = left.loc[:, on[0]].isin(inner.loc[:, on[0]])
-    return left.loc[~filt, :]
+    inner = pd.merge(left, right, how="left", indicator=True, on=on)
+    return inner[inner["_merge"] == "left_only"]
 
 
 def _merge(


### PR DESCRIPTION
This PR fixes support for anti-joins in pandas. Currently a pandas anti-join will filter out a row if any of the columns match versus all of the columns matching. This changes the behavior to only remove rows where all columns match. This matches the behavior of the duckdb backend.

Potentially fixes: https://github.com/ibis-project/ibis/issues/4268