### PR TITLE
fix(duckdb): ensure that in-memory connections remain in their creating thread

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -111,12 +111,13 @@ class Backend(BaseAlchemyBackend):
         read_only
             Whether the database is read-only
         """
-        if path != ":memory:":
+        if not (in_memory := path == ":memory:"):
             path = Path(path).absolute()
         super().do_connect(
             sa.create_engine(
                 f"duckdb:///{path}",
                 connect_args={"read_only": read_only},
+                poolclass=sa.pool.SingletonThreadPool if in_memory else None,
             )
         )
         self._meta = sa.MetaData(bind=self.con)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -343,3 +343,19 @@ def test_not_verify(alchemy_con, alchemy_backend):
 
     with pytest.warns(FutureWarning):
         assert not alchemy_backend.api.verify(expr)
+
+
+@pytest.mark.never(
+    ["postgres", "mysql"],
+    reason="postgres and mysql do not support in-memory tables",
+    raises=TypeError,
+)
+def test_in_memory(alchemy_backend):
+    con = getattr(ibis, alchemy_backend.name()).connect(path=":memory:")
+    table_name = f"t{guid()[:6]}"
+    con.raw_sql(f"CREATE TABLE {table_name} (x int)")
+    try:
+        assert table_name in con.list_tables()
+    finally:
+        con.raw_sql(f"DROP TABLE IF EXISTS {table_name}")
+        assert table_name not in con.list_tables()


### PR DESCRIPTION
Backwards compatible fix for #4282.

This is fixed upstream in https://github.com/Mause/duckdb_engine/issues/338,
but we can address it in ibis without requiring users to upgrade `duckdb_engine`.

This PR implements the same fix in ibis.

Fixes #4282.
