### PR TITLE
fix(pandas): implement `NotContains` on grouped data

### DIFF
--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -1002,6 +1002,17 @@ def execute_node_not_contains_series_sequence(op, data, elements, **kwargs):
     return ~(data.isin(elements))
 
 
+@execute_node.register(
+    ops.NotContains,
+    SeriesGroupBy,
+    (collections.abc.Sequence, collections.abc.Set, pd.Series),
+)
+def execute_node_not_contains_series_group_by_sequence(
+    op, data, elements, **kwargs
+):
+    return (~data.obj.isin(elements)).groupby(data.grouper.groupings)
+
+
 # Series, Series, Series
 # Series, Series, scalar
 @execute_node.register(ops.Where, pd.Series, pd.Series, pd.Series)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -509,6 +509,12 @@ def test_approx_median(alltypes):
             marks=mark.notimpl(["dask"]),
             id='is_in',
         ),
+        param(
+            lambda t: t.string_col.notin(['1', '7']),
+            lambda t: ~t.string_col.isin(['1', '7']),
+            marks=mark.notimpl(["dask"]),
+            id='not_in',
+        ),
     ],
 )
 @mark.notimpl(["datafusion"])


### PR DESCRIPTION
This PR is a follow up to #4304 to add the same support for `NotContains` as we have for `Contains`.
