### PR TITLE
feat(api): add `ibis.memtable` API to support in-memory table expressions

### DIFF
--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -116,6 +116,13 @@ class TableSetFormatter:
                 raise com.RelationError(f'Table did not have a name: {expr!r}')
             result = self._quote_identifier(name)
             is_subquery = False
+        elif isinstance(ref_op, ops.InMemoryTable):
+            rows = ", ".join(
+                f"({', '.join(map(repr, col))})"
+                for col in ref_op.data.itertuples(index=False)
+            )
+            result = f"(VALUES {rows})"
+            is_subquery = True
         else:
             # A subquery
             if ctx.is_extracted(ref_expr):

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -513,6 +513,11 @@ class SelectBuilder:
             self.table_set = table
             self.filters = filters
 
+    def _collect_PandasInMemoryTable(self, expr, toplevel=False):
+        if toplevel:
+            self.select_set = [expr]
+            self.table_set = expr
+
     def _convert_group_by(self, exprs):
         return list(range(len(exprs)))
 

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from sqlalchemy.ext.compiler import compiles
 
 import ibis.backends.base.sql.alchemy.datatypes as sat

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -191,7 +191,10 @@ class Backend(BaseSQLBackend):
                 timecontext,
             )
         return PySparkExprTranslator().translate(
-            expr, scope=scope, timecontext=timecontext
+            expr,
+            scope=scope,
+            timecontext=timecontext,
+            session=self._session,
         )
 
     def execute(

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -558,3 +558,78 @@ def test_invalid_connect():
 def test_deprecated_path_argument(backend, tmp_path):
     with pytest.warns(UserWarning, match="The `path` argument is deprecated"):
         getattr(ibis, backend.name()).connect(path=str(tmp_path / "test.db"))
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected"),
+    [
+        param(
+            ibis.memtable([(1, 2.0, "3")], columns=list("abc")),
+            pd.DataFrame([(1, 2.0, "3")], columns=list("abc")),
+            id="simple",
+        ),
+        param(
+            ibis.memtable([(1, 2.0, "3")]),
+            pd.DataFrame([(1, 2.0, "3")], columns=["col0", "col1", "col2"]),
+            id="simple_auto_named",
+        ),
+        param(
+            ibis.memtable(
+                [(1, 2.0, "3")],
+                schema=ibis.schema(dict(a="int8", b="float32", c="string")),
+            ),
+            pd.DataFrame([(1, 2.0, "3")], columns=list("abc")).astype(
+                {"a": "int8", "b": "float32"}
+            ),
+            id="simple_schema",
+        ),
+        param(
+            ibis.memtable(
+                pd.DataFrame({"a": [1], "b": [2.0], "c": ["3"]}).astype(
+                    {"a": "int8", "b": "float32"}
+                )
+            ),
+            pd.DataFrame([(1, 2.0, "3")], columns=list("abc")).astype(
+                {"a": "int8", "b": "float32"}
+            ),
+            id="dataframe",
+        ),
+    ],
+)
+@pytest.mark.notyet(
+    ["clickhouse"],
+    reason="ClickHouse doesn't support a VALUES construct",
+)
+@pytest.mark.notyet(
+    ["mysql", "sqlite"],
+    reason="SQLAlchemy generates incorrect code for `VALUES` projections.",
+    raises=(sa.exc.ProgrammingError, sa.exc.OperationalError),
+)
+@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+def test_in_memory_table(backend, con, expr, expected):
+    result = con.execute(expr)
+    backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "t",
+    [
+        param(
+            ibis.memtable([("a", 1.0)], columns=["a", "b"]),
+            id="python",
+        ),
+        param(
+            ibis.memtable(pd.DataFrame([("a", 1.0)], columns=["a", "b"])),
+            id="pandas",
+        ),
+    ],
+)
+@pytest.mark.notimpl(["clickhouse", "dask", "datafusion", "pandas"])
+def test_create_from_in_memory_table(con, t):
+    tmp_name = guid()
+    con.create_table(tmp_name, t)
+    try:
+        assert tmp_name in con.list_tables()
+    finally:
+        con.drop_table(tmp_name)
+        assert tmp_name not in con.list_tables()

--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -66,6 +66,17 @@ class Parameter(inspect.Parameter):
             return self.validator(arg, this=this)
 
 
+class Immutable(Hashable):
+
+    __slots__ = ()
+
+    def __setattr__(self, name: str, _: Any) -> None:
+        raise TypeError(
+            f"Attribute {name!r} cannot be assigned to immutable instance of "
+            f"type {type(self)}"
+        )
+
+
 class AnnotableMeta(BaseMeta):
     """
     Metaclass to turn class annotations into a validatable function signature.
@@ -132,7 +143,7 @@ class AnnotableMeta(BaseMeta):
         return super().__new__(metacls, clsname, bases, attribs)
 
 
-class Annotable(Base, Hashable, metaclass=AnnotableMeta):
+class Annotable(Base, Immutable, metaclass=AnnotableMeta):
     """Base class for objects with custom validation rules."""
 
     __slots__ = ("args", "_hash")
@@ -181,12 +192,6 @@ class Annotable(Base, Hashable, metaclass=AnnotableMeta):
 
     def __eq__(self, other):
         return super().__eq__(other)
-
-    def __setattr__(self, name: str, _: Any) -> None:
-        raise TypeError(
-            f"Attribute {name!r} cannot be assigned to immutable instance of "
-            f"type {type(self)}"
-        )
 
     def __repr__(self) -> str:
         args = ", ".join(

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import itertools
+from abc import abstractmethod
 from functools import cached_property
 
 from public import public
@@ -94,6 +95,17 @@ class SQLQueryResult(TableNode, sch.HasSchema):
 
     def blocks(self):
         return True
+
+
+@public
+class InMemoryTable(TableNode, sch.HasSchema):
+    name = rlz.optional(rlz.instance_of(str))
+    schema = rlz.instance_of(sch.Schema)
+
+    @property
+    @abstractmethod
+    def data(self):
+        """Return the data of an in-memory table."""
 
 
 def _make_distinct_join_predicates(left, right, predicates):

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -351,25 +351,29 @@ def table(arg, *, schema=None, **kwargs):
 
     Parameters
     ----------
-    schema : Union[sch.Schema, List[Tuple[str, dt.DataType], None]
+    schema
         A validator for the table's columns. Only column subset validators are
         currently supported. Accepts any arguments that `sch.schema` accepts.
         See the example for usage.
-    arg : The validatable argument.
+    arg
+        An argument
 
-    Examples
-    --------
-    The following op will accept an argument named ``'table'``. Note that the
-    ``schema`` argument specifies rules for columns that are required to be in
-    the table: ``time``, ``group`` and ``value1``. These must match the types
-    specified in the column rules. Column ``value2`` is optional, but if
-    present it must be of the specified type. The table may have extra columns
-    not specified in the schema.
+    The following op will accept an argument named `'table'`. Note that the
+    `schema` argument specifies rules for columns that are required to be in
+    the table: `time`, `group` and `value1`. These must match the types
+    specified in the column rules. Column `value2` is optional, but if present
+    it must be of the specified type. The table may have extra columns not
+    specified in the schema.
     """
+    import ibis
+
     if not isinstance(arg, ir.Table):
-        raise com.IbisTypeError(
-            f'Argument is not a table; got type {type(arg).__name__}'
-        )
+        try:
+            return ibis.table(data=arg, schema=schema)
+        except Exception as e:
+            raise com.IbisTypeError(
+                f'Argument is not a table; got type {type(arg).__name__}'
+            ) from e
 
     if schema is not None:
         if arg.schema() >= sch.schema(schema):

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1110,7 +1110,8 @@ class Table(Expr):
         if isinstance(predicates, ir.Expr):
             predicates = an.flatten_predicate(predicates)
 
-        expr = klass(left, right, predicates).to_expr()
+        op = klass(left, right, predicates)
+        expr = op.to_expr()
 
         # semi/anti join only give access to the left table's fields, so
         # there's never overlap
@@ -1119,8 +1120,8 @@ class Table(Expr):
 
         return ops.relations._dedup_join_columns(
             expr,
-            left=left,
-            right=right,
+            left=op.left,
+            right=op.right,
             suffixes=suffixes,
         )
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1535,3 +1535,12 @@ def test_exprs_to_select():
     with pytest.warns(FutureWarning, match="Passing `exprs`"):
         result = t.select(exprs=exprs)
     assert result.equals(t.select(len=t.a.length()))
+
+
+def test_python_table_ambiguous():
+    with pytest.raises(NotImplementedError):
+        ibis.memtable(
+            [(1,)],
+            schema=ibis.schema(dict(a="int8")),
+            columns=["a"],
+        )


### PR DESCRIPTION
This PR adds support for an API to work with in-memory tables: `ibis.memtable`.

`ibis.memtable` returns a `Table` expression.

The motivation is to allow use of simple in memory datasets in expressions.

`ibis.memtable` defers to pandas to for type inference which makes it suitable
for handling the case of inserting into/creating tables from various kinds of
Python objects.

### Notes

#### API Stuff

1. Whatever the `pd.DataFrame` constructor supports can be passed to `memtable`.
1. `ibis.memtable` has both a `columns` argument and a `schema` argument. If
   `schema` is `None`, the function performs type inference on the entire table.
1. I'm not entirely sure where the row count performance falls over.
1. When both `columns` and `schema` are `None` and the row type is not a
   mapping the default naming scheme is `col{i}` where i is the zero-indexed
   ith column number. This template can be changed using an option
   `rows_default_column_name_template`.

#### Backend Specific Stuff

1. ClickHouse doesn't seem to support the notion of `VALUES`. It might be
   posible to implement it by `arrayJoin`-ing an array of `Tuple` types. I left
   that as a follow up. Even better would be to support `ibis.memtable`
   constructs using `external_tables`. This will probably have to wait until
   4.0.
1. MySQL and SQLite don't support `SELECT`-ing from a `VALUES` statement
   directly, because SQLAlchemy compiles these incorrectly to a form that these
   two dialects of SQL don't support. Expressions based on `ibis.rows` won't
   work those backends. OTOH, `con.create_table` works and is tested for both.
1. PySpark translation is implemented.
1. Pandas and Dask are not implemented, these are in theory straightforward.

cc @tswast

Closes #3832.
