### PR TITLE
fix(decimal): add decimal type inference

### DIFF
--- a/ibis/tests/expr/test_decimal.py
+++ b/ibis/tests/expr/test_decimal.py
@@ -31,6 +31,37 @@ def test_decimal_sum_type(lineitem):
     assert result.type() == dt.Decimal(38, 2)
 
 
+def test_promote_decimal_type_mul(lineitem):
+    col_1 = lineitem.l_extendedprice
+    col_2 = lineitem.l_discount
+    result = col_1 * col_2
+    assert result.type().precision == 24
+    assert result.type().scale == 4
+
+
+def test_promote_decimal_type_add(lineitem):
+    col_1 = lineitem.l_extendedprice
+    col_2 = lineitem.l_discount
+    result = col_1 + col_2
+    assert result.type().precision == 13
+    assert result.type().scale == 2
+
+
+def test_promote_decimal_type_mod(lineitem):
+    col_1 = lineitem.l_extendedprice
+    col_2 = lineitem.l_discount
+    result = col_1 % col_2
+    assert result.type().precision == 12
+    assert result.type().scale == 2
+
+
+def test_promote_decimal_type_max():
+    t = ibis.table([("a", "decimal(31, 3)"), ("b", "decimal(31, 3)")], "t")
+    result = t.a * t.b
+    assert result.type().precision == 31
+    assert result.type().scale == 6
+
+
 @pytest.mark.parametrize(
     "precision, scale, expected",
     [


### PR DESCRIPTION
closes #4319 

This PR addresses the type evolution for decimal types as specified [here](https://www.ibm.com/docs/en/i/7.1?topic=operators-decimal-arithmetic-in-sql). As I am relatively new to the ibis development environment, I was not sure where/how to add a testcase for this, so I just used the following code:

```python
import ibis

table = ibis.table(
    schema=[("a", "decimal(4, 2)"), ("b", "decimal(5, 3)")], name="t"
)

res = table.projection((table.a + table.b).name('c'))

print(res.c.type())

res = table.projection((table.a * table.b).name('c'))

print(res.c.type())
```

Currently there are two main shortcomings of this PR that I see, both are hard for me to fix as I do not know ibis in-depth.

1. It only handles cases where there are two args given. I cannot see a case where this is not a given as it only works on sub, mul and add, but feel free to point out if I am missing something.
2. The maximum precision and maximum scale are currently not handled at all. This is because both seem to be specifiable in some way, something I don't know where it should/could happen in the ibis infrastructure and how to implement it properly. I am very open for suggestions.

