### PR TITLE
feat(api): enable `ibis.connect` for backends where it makes sense

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -47,6 +47,7 @@ jobs:
             title: Datafusion
           - name: pyspark
             title: PySpark
+            parallel: false
           - name: mysql
             title: MySQL
             services:
@@ -80,6 +81,7 @@ jobs:
             backend:
               name: impala
               title: Impala
+              parallel: false
               services:
                 - impala
                 - kudu
@@ -93,6 +95,7 @@ jobs:
             backend:
               name: impala
               title: Impala
+              parallel: false
               services:
                 - impala
                 - kudu
@@ -158,12 +161,12 @@ jobs:
       - name: download backend data
         run: just download-data
 
-      - name: run parallel ${{ matrix.backend.name }} tests
-        if: ${{ matrix.backend.name != 'pyspark' && matrix.backend.name != 'impala' }}
+      - name: "run parallel tests: ${{ matrix.backend.name }}"
+        if: ${{ matrix.backend.parallel || matrix.backend.parallel == null }}
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
 
-      - name: run non-parallel ${{ matrix.backend.name }} tests
-        if: ${{ matrix.backend.name == 'pyspark' || matrix.backend.name == 'impala' }}
+      - name: "run serial tests: ${{ matrix.backend.name }}"
+        if: ${{ !matrix.backend.parallel }}
         run: just ci-check -m ${{ matrix.backend.name }}
         env:
           IBIS_TEST_NN_HOST: localhost

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -47,7 +47,6 @@ jobs:
             title: Datafusion
           - name: pyspark
             title: PySpark
-            parallel: false
           - name: mysql
             title: MySQL
             services:
@@ -81,7 +80,6 @@ jobs:
             backend:
               name: impala
               title: Impala
-              parallel: false
               services:
                 - impala
                 - kudu
@@ -95,7 +93,6 @@ jobs:
             backend:
               name: impala
               title: Impala
-              parallel: false
               services:
                 - impala
                 - kudu
@@ -162,11 +159,11 @@ jobs:
         run: just download-data
 
       - name: "run parallel tests: ${{ matrix.backend.name }}"
-        if: ${{ matrix.backend.parallel || matrix.backend.parallel == null }}
+        if: ${{ matrix.backend.name != 'pyspark' && matrix.backend.name != 'impala' }}
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
 
       - name: "run serial tests: ${{ matrix.backend.name }}"
-        if: ${{ !matrix.backend.parallel }}
+        if: ${{ matrix.backend.name == 'pyspark' || matrix.backend.name == 'impala' }}
         run: just ci-check -m ${{ matrix.backend.name }}
         env:
           IBIS_TEST_NN_HOST: localhost

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,14 +16,14 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-  - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
   - repo: https://github.com/psf/black
     rev: 22.6.0
     hooks:
       - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
+    hooks:
+      - id: flake8
   - repo: https://github.com/MarcoGorelli/absolufy-imports
     rev: v0.3.1
     hooks:

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -104,7 +104,8 @@ class Backend(BaseAlchemyBackend):
 
     def do_connect(
         self,
-        path: str | Path = ":memory:",
+        database: str | Path = ":memory:",
+        path: str | Path = None,
         read_only: bool = False,
         **config: Any,
     ) -> None:
@@ -126,8 +127,14 @@ class Backend(BaseAlchemyBackend):
         >>> import ibis
         >>> ibis.duckdb.connect("database.ddb", threads=4, memory_limit="1GB")
         """
-        if not (in_memory := path == ":memory:"):
-            path = Path(path).absolute()
+        if path is not None:
+            warnings.warn(
+                "The `path` argument is deprecated in 4.0. Use `database=...` "
+                "instead."
+            )
+            database = path
+        if not (in_memory := database == ":memory:"):
+            database = Path(database).absolute()
         super().do_connect(
             sa.create_engine(
                 f"duckdb:///{database}",

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
+import itertools
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
 import pandas as pd
 import pyspark
+import sqlalchemy as sa
 from pydantic import Field
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.column import Column
-
-if TYPE_CHECKING:
-    import ibis.expr.types as ir
-    import ibis.expr.operations as ops
 
 import ibis.common.exceptions as com
 import ibis.config
@@ -34,6 +32,10 @@ from ibis.backends.pyspark.compiler import (
 from ibis.backends.pyspark.datatypes import spark_dtype
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import canonicalize_context, localize_context
+
+if TYPE_CHECKING:
+    import ibis.expr.operations as ops
+    import ibis.expr.types as ir
 
 _read_csv_defaults = {
     'header': True,
@@ -119,8 +121,8 @@ class Backend(BaseSQLBackend):
         Examples
         --------
         >>> import ibis
-        >>> import pyspark
-        >>> session = pyspark.sql.SparkSession.builder.getOrCreate()
+        >>> from pyspark.sql import SparkSession
+        >>> session = SparkSession.builder.getOrCreate()
         >>> ibis.pyspark.connect(session)
         <ibis.backends.pyspark.Backend at 0x...>
         """

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import sqlite3
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -49,15 +50,19 @@ class Backend(BaseAlchemyBackend):
         )
         return r
 
-    def do_connect(self, path: str | Path | None = None) -> None:
+    def do_connect(
+        self,
+        database: str | Path | None = None,
+        path: str | Path | None = None,
+    ) -> None:
         """Create an Ibis client connected to a SQLite database.
 
-        Multiple database files can be created using the `attach()` method
+        Multiple database files can be accessed using the `attach()` method.
 
         Parameters
         ----------
-        path
-            File path to the SQLite database file. If None, creates an
+        database
+            File path to the SQLite database file. If `None`, creates an
             in-memory transient database and you can use attach() to add more
             files
 
@@ -66,10 +71,16 @@ class Backend(BaseAlchemyBackend):
         >>> import ibis
         >>> ibis.sqlite.connect("path/to/my/sqlite.db")
         """
+        if path is not None:
+            warnings.warn(
+                "The `path` argument is deprecated in 4.0. Use `database=...`"
+            )
+            database = path
+
         self.database_name = "main"
 
         engine = sa.create_engine(
-            f"sqlite:///{path if path is not None else ':memory:'}"
+            f"sqlite:///{database if database is not None else ':memory:'}"
         )
 
         sqlite3.register_adapter(pd.Timestamp, lambda value: value.isoformat())

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -535,3 +535,21 @@ def test_invalid_connect():
     )
     with pytest.raises(ValueError):
         ibis.connect(url)
+
+
+@pytest.mark.never(
+    [
+        "clickhouse",
+        "dask",
+        "datafusion",
+        "impala",
+        "mysql",
+        "pandas",
+        "postgres",
+        "pyspark",
+    ],
+    reason="backend isn't file-based",
+)
+def test_deprecated_path_argument(backend, tmp_path):
+    with pytest.warns(UserWarning, match="The `path` argument is deprecated"):
+        getattr(ibis, backend.name()).connect(path=str(tmp_path / "test.db"))

--- a/ibis/common/dispatch.py
+++ b/ibis/common/dispatch.py
@@ -87,7 +87,17 @@ class RegexDispatcher:
             for r, func in self.funcs.items()
             if (match := r.match(s)) is not None
         )
-        return max(funcs, key=lambda pair: self.priorities.get(pair[0]))
+        priorities = self.priorities
+        value = max(
+            funcs,
+            key=lambda pair: priorities.get(pair[0]),
+            default=None,
+        )
+        if value is None:
+            raise NotImplementedError(
+                f"no pattern for `{self.name}` matches input string: {s!r}"
+            )
+        return value
 
     def __call__(self, s: str, *args: Any, **kwargs: Any) -> Any:
         func, match = self.dispatch(s)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ plugins:
         python:
           import:
             - https://docs.python.org/3/objects.inv
+            - https://docs.sqlalchemy.org/objects.inv
           selection:
             docstring_style: numpy
             filters:

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,7 +23,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-test = ["coverage", "flake8", "pexpect", "wheel"]
+test = ["wheel", "pexpect", "flake8", "coverage"]
 
 [[package]]
 name = "asttokens"
@@ -37,7 +37,7 @@ python-versions = "*"
 six = "*"
 
 [package.extras]
-test = ["astroid (<=2.5.3)", "pytest"]
+test = ["pytest", "astroid (<=2.5.3)"]
 
 [[package]]
 name = "astunparse"
@@ -122,8 +122,8 @@ python-versions = ">=3.6.0"
 soupsieve = ">1.2"
 
 [package.extras]
-html5lib = ["html5lib"]
 lxml = ["lxml"]
+html5lib = ["html5lib"]
 
 [[package]]
 name = "bitarray"
@@ -150,10 +150,10 @@ tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+jupyter = ["tokenize-rt (>=3.2.0)", "ipython (>=7.8.0)"]
+d = ["aiohttp (>=3.7.4)"]
+colorama = ["colorama (>=0.4.3)"]
 
 [[package]]
 name = "bleach"
@@ -168,8 +168,8 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [package.extras]
+dev = ["mypy (==0.961)", "black (==22.3.0)", "wheel (==0.37.1)", "twine (==4.0.1)", "tox (==3.25.0)", "Sphinx (==4.3.2)", "pytest (==7.1.2)", "pip-tools (==6.6.2)", "hashin (==0.17.0)", "flake8 (==4.0.1)", "build (==0.8.0)"]
 css = ["tinycss2 (>=1.1.0,<1.2)"]
-dev = ["build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "pip-tools (==6.6.2)", "pytest (==7.1.2)", "Sphinx (==4.3.2)", "tox (==3.25.0)", "twine (==4.0.1)", "wheel (==0.37.1)", "black (==22.3.0)", "mypy (==0.961)"]
 
 [[package]]
 name = "certifi"
@@ -340,7 +340,7 @@ python-versions = ">=3.8"
 [package.dependencies]
 cloudpickle = ">=1.1.1"
 fsspec = ">=0.6.0"
-numpy = {version = ">=1.18", optional = true, markers = "extra == \"array\""}
+numpy = {version = ">=1.18", optional = true, markers = "extra == \"dataframe\""}
 packaging = ">=20.0"
 pandas = {version = ">=1.0", optional = true, markers = "extra == \"dataframe\""}
 partd = ">=0.3.10"
@@ -348,12 +348,12 @@ pyyaml = ">=5.3.1"
 toolz = ">=0.8.2"
 
 [package.extras]
-array = ["numpy (>=1.18)"]
-complete = ["bokeh (>=2.4.2)", "distributed (==2022.7.1)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
-dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
-diagnostics = ["bokeh (>=2.4.2)", "jinja2"]
+test = ["pre-commit", "pytest-xdist", "pytest-rerunfailures", "pytest"]
 distributed = ["distributed (==2022.7.1)"]
-test = ["pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
+diagnostics = ["jinja2", "bokeh (>=2.4.2)"]
+dataframe = ["pandas (>=1.0)", "numpy (>=1.18)"]
+complete = ["pandas (>=1.0)", "numpy (>=1.18)", "jinja2", "distributed (==2022.7.1)", "bokeh (>=2.4.2)"]
+array = ["numpy (>=1.18)"]
 
 [[package]]
 name = "datafusion"
@@ -422,7 +422,7 @@ numpy = ">=1.14"
 
 [[package]]
 name = "duckdb-engine"
-version = "0.4.0"
+version = "0.5.0"
 description = "SQLAlchemy driver for duckdb"
 category = "main"
 optional = true
@@ -491,8 +491,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
-testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
+testing = ["pytest-timeout (>=2.1)", "pytest-cov (>=3)", "pytest (>=7.1.2)", "coverage (>=6.4.2)", "covdefaults (>=2.2)"]
+docs = ["sphinx-autodoc-typehints (>=1.19.1)", "sphinx (>=5.1.1)", "furo (>=2022.6.21)"]
 
 [[package]]
 name = "fiona"
@@ -512,10 +512,10 @@ munch = "*"
 six = ">=1.7"
 
 [package.extras]
-all = ["boto3 (>=1.2.4)", "pytest-cov", "shapely", "pytest (>=3)", "mock"]
-calc = ["shapely"]
+test = ["mock", "boto3 (>=1.2.4)", "pytest-cov", "pytest (>=3)"]
 s3 = ["boto3 (>=1.2.4)"]
-test = ["pytest (>=3)", "pytest-cov", "boto3 (>=1.2.4)", "mock"]
+calc = ["shapely"]
+all = ["mock", "pytest (>=3)", "shapely", "pytest-cov", "boto3 (>=1.2.4)"]
 
 [[package]]
 name = "flake8"
@@ -692,8 +692,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
+docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
 
 [[package]]
 name = "impyla"
@@ -781,17 +781,17 @@ stack-data = "*"
 traitlets = ">=5"
 
 [package.extras]
-all = ["black", "Sphinx (>=1.3)", "ipykernel", "nbconvert", "nbformat", "ipywidgets", "notebook", "ipyparallel", "qtconsole", "pytest (<7.1)", "pytest-asyncio", "testpath", "curio", "matplotlib (!=3.2.0)", "numpy (>=1.19)", "pandas", "trio"]
-black = ["black"]
-doc = ["Sphinx (>=1.3)"]
-kernel = ["ipykernel"]
-nbconvert = ["nbconvert"]
-nbformat = ["nbformat"]
-notebook = ["ipywidgets", "notebook"]
-parallel = ["ipyparallel"]
+test_extra = ["trio", "pandas", "numpy (>=1.19)", "nbformat", "matplotlib (!=3.2.0)", "curio", "testpath", "pytest-asyncio", "pytest (<7.1)"]
+test = ["testpath", "pytest-asyncio", "pytest (<7.1)"]
 qtconsole = ["qtconsole"]
-test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
-test_extra = ["pytest (<7.1)", "pytest-asyncio", "testpath", "curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "trio"]
+parallel = ["ipyparallel"]
+notebook = ["notebook", "ipywidgets"]
+nbformat = ["nbformat"]
+nbconvert = ["nbconvert"]
+kernel = ["ipykernel"]
+doc = ["Sphinx (>=1.3)"]
+black = ["black"]
+all = ["trio", "pandas", "numpy (>=1.19)", "matplotlib (!=3.2.0)", "curio", "testpath", "pytest-asyncio", "pytest (<7.1)", "qtconsole", "ipyparallel", "notebook", "ipywidgets", "nbformat", "nbconvert", "ipykernel", "Sphinx (>=1.3)", "black"]
 
 [[package]]
 name = "isort"
@@ -802,10 +802,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
 plugins = ["setuptools"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
+pipfile_deprecated_finder = ["requirementslib", "pipreqs"]
 
 [[package]]
 name = "jedi"
@@ -838,7 +838,7 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jsonschema"
-version = "4.11.0"
+version = "4.13.0"
 description = "An implementation of JSON Schema validation for Python"
 category = "dev"
 optional = false
@@ -851,8 +851,8 @@ pkgutil-resolve-name = {version = ">=1.3.10", markers = "python_version < \"3.9\
 pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
 
 [package.extras]
-format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
-format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
+format-nongpl = ["webcolors (>=1.11)", "uri-template", "rfc3986-validator (>0.1.0)", "rfc3339-validator", "jsonpointer (>1.13)", "isoduration", "idna", "fqdn"]
+format = ["webcolors (>=1.11)", "uri-template", "rfc3987", "rfc3339-validator", "jsonpointer (>1.13)", "isoduration", "idna", "fqdn"]
 
 [[package]]
 name = "jupyter-client"
@@ -956,9 +956,9 @@ optional = true
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx (>=1.6.0)", "sphinx-bootstrap-theme"]
+tests = ["pytest-cov", "psutil", "pytest (!=3.3.0)"]
 flake8 = ["flake8"]
-tests = ["pytest (!=3.3.0)", "psutil", "pytest-cov"]
+docs = ["sphinx-bootstrap-theme", "sphinx (>=1.6.0)"]
 
 [[package]]
 name = "markdown"
@@ -1272,8 +1272,8 @@ python-versions = "*"
 six = "*"
 
 [package.extras]
-testing = ["pytest", "coverage", "astroid (>=1.5.3,<1.6.0)", "pylint (>=1.7.2,<1.8.0)", "astroid (>=2.0)", "pylint (>=2.3.1,<2.4.0)"]
 yaml = ["PyYAML (>=5.1.0)"]
+testing = ["pylint (>=2.3.1,<2.4.0)", "astroid (>=2.0)", "pylint (>=1.7.2,<1.8.0)", "astroid (>=1.5.3,<1.6.0)", "coverage", "pytest"]
 
 [[package]]
 name = "mypy"
@@ -1316,8 +1316,8 @@ nest-asyncio = "*"
 traitlets = ">=5.2.2"
 
 [package.extras]
-sphinx = ["autodoc-traits", "mock", "moto", "myst-parser", "Sphinx (>=1.7)", "sphinx-book-theme"]
-test = ["black", "check-manifest", "flake8", "ipykernel", "ipython (<8.0.0)", "ipywidgets (<8.0.0)", "mypy", "pip (>=18.1)", "pre-commit", "pytest (>=4.1)", "pytest-asyncio", "pytest-cov (>=2.6.1)", "setuptools (>=60.0)", "testpath", "twine (>=1.11.0)", "xmltodict"]
+test = ["xmltodict", "twine (>=1.11.0)", "testpath", "setuptools (>=60.0)", "pytest-cov (>=2.6.1)", "pytest-asyncio", "pytest (>=4.1)", "pre-commit", "pip (>=18.1)", "mypy", "ipywidgets (<8.0.0)", "ipython (<8.0.0)", "ipykernel", "flake8", "check-manifest", "black"]
+sphinx = ["sphinx-book-theme", "Sphinx (>=1.7)", "myst-parser", "moto", "mock", "autodoc-traits"]
 
 [[package]]
 name = "nbconvert"
@@ -1347,11 +1347,11 @@ tinycss2 = "*"
 traitlets = ">=5.0"
 
 [package.extras]
-all = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pre-commit", "pyppeteer (>=1,<1.1)", "tornado (>=6.1)", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
-docs = ["sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
-serve = ["tornado (>=6.1)"]
-test = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pre-commit", "pyppeteer (>=1,<1.1)"]
 webpdf = ["pyppeteer (>=1,<1.1)"]
+test = ["pyppeteer (>=1,<1.1)", "pre-commit", "ipywidgets (>=7)", "ipykernel", "pytest-dependency", "pytest-cov", "pytest"]
+serve = ["tornado (>=6.1)"]
+docs = ["ipython", "nbsphinx (>=0.2.12)", "sphinx-rtd-theme", "sphinx (>=1.5.1)"]
+all = ["ipython", "nbsphinx (>=0.2.12)", "sphinx-rtd-theme", "sphinx (>=1.5.1)", "tornado (>=6.1)", "pyppeteer (>=1,<1.1)", "pre-commit", "ipywidgets (>=7)", "ipykernel", "pytest-dependency", "pytest-cov", "pytest"]
 
 [[package]]
 name = "nbformat"
@@ -1368,7 +1368,7 @@ jupyter-core = "*"
 traitlets = ">=5.1"
 
 [package.extras]
-test = ["check-manifest", "testpath", "pytest", "pre-commit"]
+test = ["pre-commit", "pytest", "testpath", "check-manifest"]
 
 [[package]]
 name = "nest-asyncio"
@@ -1804,9 +1804,9 @@ py-cpuinfo = "*"
 pytest = ">=3.8"
 
 [package.extras]
-aspect = ["aspectlib"]
+histogram = ["pygaljs", "pygal"]
 elasticsearch = ["elasticsearch"]
-histogram = ["pygal", "pygaljs"]
+aspect = ["aspectlib"]
 
 [[package]]
 name = "pytest-clarity"
@@ -1860,7 +1860,7 @@ python-versions = ">=3.7"
 pytest = ">=5.0"
 
 [package.extras]
-dev = ["pre-commit", "tox", "pytest-asyncio"]
+dev = ["pytest-asyncio", "tox", "pre-commit"]
 
 [[package]]
 name = "pytest-profiling"
@@ -2027,7 +2027,7 @@ python-versions = ">=3.6,<4.0"
 prompt_toolkit = ">=2.0,<4.0"
 
 [package.extras]
-docs = ["Sphinx (>=3.3,<4.0)", "sphinx-rtd-theme (>=0.5.0,<0.6.0)", "sphinx-autobuild (>=2020.9.1,<2021.0.0)", "sphinx-copybutton (>=0.3.1,<0.4.0)", "sphinx-autodoc-typehints (>=1.11.1,<2.0.0)"]
+docs = ["sphinx-autodoc-typehints (>=1.11.1,<2.0.0)", "sphinx-copybutton (>=0.3.1,<0.4.0)", "sphinx-autobuild (>=2020.9.1,<2021.0.0)", "sphinx-rtd-theme (>=0.5.0,<0.6.0)", "Sphinx (>=3.3,<4.0)"]
 
 [[package]]
 name = "regex"
@@ -2080,9 +2080,9 @@ optional = true
 python-versions = ">=3.6"
 
 [package.extras]
-all = ["pytest", "pytest-cov", "numpy"]
-test = ["pytest", "pytest-cov"]
 vectorized = ["numpy"]
+test = ["pytest-cov", "pytest"]
+all = ["numpy", "pytest-cov", "pytest"]
 
 [[package]]
 name = "six"
@@ -2150,7 +2150,7 @@ sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "sqlglot"
-version = "4.7.0"
+version = "4.7.1"
 description = "An easily customizable SQL parser and transpiler"
 category = "main"
 optional = true
@@ -2293,7 +2293,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-test = ["pre-commit", "pytest"]
+test = ["pytest", "pre-commit"]
 
 [[package]]
 name = "typing-extensions"
@@ -2325,8 +2325,8 @@ pytz-deprecation-shim = "*"
 tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
-devenv = ["black", "pyroma", "pytest-cov", "zest.releaser"]
-test = ["pytest-mock (>=3.3)", "pytest (>=4.3)"]
+test = ["pytest (>=4.3)", "pytest-mock (>=3.3)"]
+devenv = ["zest.releaser", "pytest-cov", "pyroma", "black"]
 
 [[package]]
 name = "urllib3"
@@ -2388,8 +2388,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "func-timeout", "jaraco.itertools", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
+docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
 
 [extras]
 all = ["clickhouse-cityhash", "clickhouse-driver", "dask", "datafusion", "duckdb", "duckdb-engine", "fsspec", "GeoAlchemy2", "geopandas", "graphviz", "impyla", "lz4", "psycopg2", "pyarrow", "pymysql", "pyspark", "requests", "Shapely", "sqlalchemy", "sqlglot"]
@@ -2991,8 +2991,8 @@ duckdb = [
     {file = "duckdb-0.4.0.tar.gz", hash = "sha256:569e5d618de871e21dd676925349a7a5e701b87ebda3433e0c1d57627a465c1c"},
 ]
 duckdb-engine = [
-    {file = "duckdb_engine-0.4.0-py3-none-any.whl", hash = "sha256:848471727b096a109d86294ffb5ba413ec4f1e5d648b064f812a3e81c1734668"},
-    {file = "duckdb_engine-0.4.0.tar.gz", hash = "sha256:879b81a656ca90c2068a832911f2c9efb1a9aa4f065475db42c4f02433263fc6"},
+    {file = "duckdb_engine-0.5.0-py3-none-any.whl", hash = "sha256:0be3126e00298fb788fcf4225e3a96e1222f74ca13eee37b4fddd74cc57a14e4"},
+    {file = "duckdb_engine-0.5.0.tar.gz", hash = "sha256:db5d7c0baf5c892f4cf4cfffaa06300f0ef6e36f67de44b43fb3a3dee526a603"},
 ]
 dunamai = [
     {file = "dunamai-1.12.0-py3-none-any.whl", hash = "sha256:00b9c1ef58d4950204f76c20f84afe7a28d095f77feaa8512dbb172035415e61"},
@@ -3168,8 +3168,8 @@ jinja2 = [
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.11.0-py3-none-any.whl", hash = "sha256:2ac503b91b4a9dcf9c93764b26e926e386ec1065fec4f685c0e458a375dadedf"},
-    {file = "jsonschema-4.11.0.tar.gz", hash = "sha256:706bbcafb49b1350fbcea40b209bdce8aed07c3288f7a77e9539bd5b3ddead3d"},
+    {file = "jsonschema-4.13.0-py3-none-any.whl", hash = "sha256:870a61bb45050b81103faf6a4be00a0a906e06636ffcf0b84f5a2e51faf901ff"},
+    {file = "jsonschema-4.13.0.tar.gz", hash = "sha256:3776512df4f53f74e6e28fe35717b5b223c1756875486984a31bc9165e7fc920"},
 ]
 jupyter-client = [
     {file = "jupyter_client-7.3.4-py3-none-any.whl", hash = "sha256:17d74b0d0a7b24f1c8c527b24fcf4607c56bee542ffe8e3418e50b21e514b621"},
@@ -4166,8 +4166,8 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.4.40.tar.gz", hash = "sha256:44a660506080cc975e1dfa5776fe5f6315ddc626a77b50bf0eee18b0389ea265"},
 ]
 sqlglot = [
-    {file = "sqlglot-4.7.0-py3-none-any.whl", hash = "sha256:5bd190d720793f906d480d1afc446ec5f44d8722aec31a81d5429448bb20bc3f"},
-    {file = "sqlglot-4.7.0.tar.gz", hash = "sha256:ff56d6b2a0876aef6572d2656638bf0843231116e16b95f2c589460947741b70"},
+    {file = "sqlglot-4.7.1-py3-none-any.whl", hash = "sha256:d19c0b308b9fd4b983880dacfe831d704a52d704ff06c7f342d04dd036382507"},
+    {file = "sqlglot-4.7.1.tar.gz", hash = "sha256:cb4a6dbf162de85182cb67ed1e24fca68e7efb40e19e948c88aaa2536c20e636"},
 ]
 stack-data = [
     {file = "stack_data-0.4.0-py3-none-any.whl", hash = "sha256:b94fed36d725cfabc6d09ed5886913e35eed9009766a1af1d5941b9da3a94aaa"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ decli==0.5.2; python_full_version >= "3.6.2" and python_full_version < "4.0.0" a
 decorator==5.1.1; python_version >= "3.8"
 defusedxml==0.7.1; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
 docstring-parser==0.13; python_version >= "3.6"
-duckdb-engine==0.4.0; python_full_version >= "3.6.1"
+duckdb-engine==0.5.0; python_full_version >= "3.6.1"
 duckdb==0.4.0
 dunamai==1.12.0; python_version >= "3.5" and python_version < "4.0"
 entrypoints==0.4; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
@@ -63,7 +63,7 @@ ipython==8.4.0; python_version >= "3.8"
 isort==5.10.1; python_full_version >= "3.6.1" and python_version < "4.0"
 jedi==0.18.1; python_version >= "3.8"
 jinja2==3.1.2; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and python_version >= "3.7" and python_version < "4"
-jsonschema==4.11.0; python_version >= "3.7" and python_version < "4.0" and python_full_version >= "3.7.1"
+jsonschema==4.13.0; python_version >= "3.7" and python_version < "4.0" and python_full_version >= "3.7.1"
 jupyter-client==7.3.4; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
 jupyter-core==4.11.1; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
 jupyterlab-pygments==0.2.2; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
@@ -168,7 +168,7 @@ smmap==5.0.0; python_version >= "3.7"
 snowballstemmer==2.2.0; python_version >= "3.6"
 soupsieve==2.3.2.post1; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
 sqlalchemy==1.4.40; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
-sqlglot==4.7.0
+sqlglot==4.7.1
 stack-data==0.4.0; python_version >= "3.8"
 tabulate==0.8.10; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 termcolor==1.1.0; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and python_version >= "3.5"


### PR DESCRIPTION
This PR rounds out support for `ibis.connect` in the remaining backends.

Working with @saulpw we tried to use ibis+clickhouse through visidata and discovered
that that didn't work.

This PR should fix that issue. See notes below for more information.

### Notes

* Query parameters are supported. They are passed in as keyword
  arguments to the backend's `do_connect` method. A new `_convert_kwargs`
  method on the base backend now exists to override any of the query parameter
  values after parsing but before they are passed to the underlying backend
  API.
* A backend test for exercising the different ways to use `ibis.connect` are included.
* This PR introduces `sqlalchemy` as a hard dependency for its handling of URL parsing.
* I deprecated `path` as a keyword argument to the sqlite and duckdb backend
  and replaced it with `database` because that is the name of the SQLAlchemy
  URL field name. `path` still works for the moment. It'll be removed in 4.0.0.
