### PR TITLE
feat(api): add `argmin` and `argmax` APIs

### DIFF
--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -751,6 +751,8 @@ operation_registry = {
     ops.Sum: _agg('sum'),
     ops.Max: _agg('max'),
     ops.Min: _agg('min'),
+    ops.ArgMin: _agg('argMin'),
+    ops.ArgMax: _agg('argMax'),
     ops.ArrayCollect: _agg('groupArray'),
     ops.StandardDev: _agg_variance_like('stddev'),
     ops.Variance: _agg_variance_like('var'),

--- a/ibis/backends/dask/execution/reductions.py
+++ b/ibis/backends/dask/execution/reductions.py
@@ -176,3 +176,23 @@ def execute_standard_dev_series(op, data, mask, aggcontext=None, **kwargs):
         'std',
         ddof=variance_ddof[op.how],
     )
+
+
+@execute_node.register(
+    ops.ArgMax, dd.Series, dd.Series, (dd.Series, type(None))
+)
+def execute_argmax_series(op, data, key, mask, aggcontext=None, **kwargs):
+    idxmax = aggcontext.agg(
+        key[mask] if mask is not None else key, 'idxmax'
+    ).compute()
+    return data.loc[idxmax]
+
+
+@execute_node.register(
+    ops.ArgMin, dd.Series, dd.Series, (dd.Series, type(None))
+)
+def execute_argmin_series(op, data, key, mask, aggcontext=None, **kwargs):
+    idxmin = aggcontext.agg(
+        key[mask] if mask is not None else key, 'idxmin'
+    ).compute()
+    return data.loc[idxmin]

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -229,6 +229,8 @@ operation_registry.update(
         ops.Arbitrary: _arbitrary,
         ops.GroupConcat: _string_agg,
         ops.StructColumn: _struct_column,
+        ops.ArgMin: reduction(sa.func.min_by),
+        ops.ArgMax: reduction(sa.func.max_by),
     }
 )
 

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -192,6 +192,20 @@ class Min(Filterable, Reduction):
 
 
 @public
+class ArgMax(Filterable, Reduction):
+    arg = rlz.column(rlz.any)
+    key = rlz.column(rlz.any)
+    output_dtype = rlz.dtype_like("arg")
+
+
+@public
+class ArgMin(Filterable, Reduction):
+    arg = rlz.column(rlz.any)
+    key = rlz.column(rlz.any)
+    output_dtype = rlz.dtype_like("arg")
+
+
+@public
 class ApproxCountDistinct(Filterable, Reduction):
     """Approximate number of unique values using HyperLogLog algorithm.
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -652,14 +652,32 @@ class Column(Value):
         return ops.ApproxMedian(self, where).to_expr().name("approx_median")
 
     def max(self, where: ir.BooleanValue | None = None) -> Scalar:
+        """Return the maximum of a column."""
         import ibis.expr.operations as ops
 
         return ops.Max(self, where).to_expr().name("max")
 
     def min(self, where: ir.BooleanValue | None = None) -> Scalar:
+        """Return the minimum of a column."""
         import ibis.expr.operations as ops
 
         return ops.Min(self, where).to_expr().name("min")
+
+    def argmax(
+        self, key: ir.Value, where: ir.BooleanValue | None = None
+    ) -> Scalar:
+        """Return the value of `self` that maximizes `key`."""
+        import ibis.expr.operations as ops
+
+        return ops.ArgMax(self, key=key, where=where).to_expr()
+
+    def argmin(
+        self, key: ir.Value, where: ir.BooleanValue | None = None
+    ) -> Scalar:
+        """Return the value of `self` that minimizes `key`."""
+        import ibis.expr.operations as ops
+
+        return ops.ArgMin(self, key=key, where=where).to_expr()
 
     def nunique(
         self, where: ir.BooleanValue | None = None


### PR DESCRIPTION
This PR adds support for `argmin` and `argmax` methods on column expressions. This was motivated by trying to reproduce [Scrooge McDuck](https://pdet-blog.github.io/2022/08/16/scrooge.html)