### PR TITLE
chore: revert `PYTHONHASHSEED` removal

### DIFF
--- a/ci/release/verify.sh
+++ b/ci/release/verify.sh
@@ -10,6 +10,9 @@ dry_run="${1}"
 poetry check
 
 # verify that the lock file is up to date
+#
+# go through the rigamarole of yj and dyff because poetry is sensitive to
+# PYTHONHASHSEED
 bash ./dev/lockfile_diff.sh
 
 # verify that we have a token available to push to pypi using set -u

--- a/dev/lockfile_diff.sh
+++ b/dev/lockfile_diff.sh
@@ -12,7 +12,7 @@ new="$(mktemp --suffix=".yaml")"
 # go through the rigamarole of yj and dyff because poetry is sensitive to
 # PYTHONHASHSEED
 yj -ty < poetry.lock > "$old"
-poetry lock --no-update
+PYTHONHASHSEED=42 poetry lock --no-update
 yj -ty < poetry.lock > "$new"
 
 if ! dyff between "$old" "$new" --ignore-order-changes --omit-header --set-exit-code; then

--- a/dev/lockfile_diff.sh
+++ b/dev/lockfile_diff.sh
@@ -12,7 +12,7 @@ new="$(mktemp --suffix=".yaml")"
 # go through the rigamarole of yj and dyff because poetry is sensitive to
 # PYTHONHASHSEED
 yj -ty < poetry.lock > "$old"
-PYTHONHASHSEED=42 poetry lock --no-update
+PYTHONHASHSEED=0 poetry lock --no-update
 yj -ty < poetry.lock > "$new"
 
 if ! dyff between "$old" "$new" --ignore-order-changes --omit-header --set-exit-code; then

--- a/dev/poetry2setup
+++ b/dev/poetry2setup
@@ -12,4 +12,4 @@ dir="$(readlink -f "$(dirname "$0")")"
 # Because the `extras` data structure in poetry is a frozenset and therefore
 # arbitrarily ordered, regenerating setup.py without a fixed hash seed can
 # cause unnecessary reordering of extras.
-PYTHONHASHSEED=42 python "$dir/poetry2setup.py" "$@"
+PYTHONHASHSEED=0 python "$dir/poetry2setup.py" "$@"

--- a/dev/poetry2setup
+++ b/dev/poetry2setup
@@ -7,4 +7,9 @@ set -euo pipefail
 
 dir="$(readlink -f "$(dirname "$0")")"
 
-python "$dir/poetry2setup.py" "$@"
+# PYTHONHASHSEED is set is to ensure reproducible setup.py generation
+#
+# Because the `extras` data structure in poetry is a frozenset and therefore
+# arbitrarily ordered, regenerating setup.py without a fixed hash seed can
+# cause unnecessary reordering of extras.
+PYTHONHASHSEED=42 python "$dir/poetry2setup.py" "$@"

--- a/dev/update-lock-files.sh
+++ b/dev/update-lock-files.sh
@@ -3,6 +3,8 @@
 # shellcheck shell=bash
 set -euo pipefail
 
+export PYTHONHASHSEED=42
+
 TOP="${1:-$(dirname "$(dirname "$(readlink -f "$0")")")}"
 
 pushd "${TOP}" > /dev/null || exit 1

--- a/dev/update-lock-files.sh
+++ b/dev/update-lock-files.sh
@@ -3,7 +3,7 @@
 # shellcheck shell=bash
 set -euo pipefail
 
-export PYTHONHASHSEED=42
+export PYTHONHASHSEED=0
 
 TOP="${1:-$(dirname "$(dirname "$(readlink -f "$0")")")}"
 

--- a/docs/contribute/05_maintainers_guide.md
+++ b/docs/contribute/05_maintainers_guide.md
@@ -60,7 +60,7 @@ cases contributors do not have to remember to generate and commit these files.
         Run the following command
 
         ```sh
-        PYTHONHASHSEED=42 python ./dev/poetry2setup.py -o setup.py
+        PYTHONHASHSEED=0 python ./dev/poetry2setup.py -o setup.py
         ```
 
         !!! question "Why do we need to set `PYTHONHASHSEED`?"

--- a/docs/contribute/05_maintainers_guide.md
+++ b/docs/contribute/05_maintainers_guide.md
@@ -60,8 +60,17 @@ cases contributors do not have to remember to generate and commit these files.
         Run the following command
 
         ```sh
-        python ./dev/poetry2setup.py -o setup.py
+        PYTHONHASHSEED=42 python ./dev/poetry2setup.py -o setup.py
         ```
+
+        !!! question "Why do we need to set `PYTHONHASHSEED`?"
+
+            Dependencies' [`extras`](https://python-poetry.org/docs/pyproject/#extras) are stored
+            in-memory using a `frozenset`, the elements of which are arbitrarily ordered.
+
+            As of 2022-02-24 this is [fixed in the default
+            branch](https://github.com/python-poetry/poetry-core/pull/280) of
+            [`poetry-core`] but isn't yet released.
 
 Updates of minor and patch versions of dependencies are handled automatically by
 [`renovate`](https://github.com/renovatebot/renovate).

--- a/poetry.lock
+++ b/poetry.lock
@@ -75,10 +75,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
+dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
 
 [[package]]
 name = "babel"
@@ -539,27 +539,27 @@ optional = true
 python-versions = ">=3.7"
 
 [package.extras]
-abfs = ["adlfs"]
-adl = ["adlfs"]
-arrow = ["pyarrow (>=1)"]
-dask = ["dask", "distributed"]
-dropbox = ["dropboxdrivefs", "requests", "dropbox"]
-entrypoints = ["importlib-metadata"]
-fuse = ["fusepy"]
-gcs = ["gcsfs"]
-git = ["pygit2"]
-github = ["requests"]
-gs = ["gcsfs"]
-gui = ["panel"]
-hdfs = ["pyarrow (>=1)"]
-http = ["requests", "aiohttp"]
-libarchive = ["libarchive-c"]
-oci = ["ocifs"]
-s3 = ["s3fs"]
-sftp = ["paramiko"]
-smb = ["smbprotocol"]
-ssh = ["paramiko"]
 tqdm = ["tqdm"]
+ssh = ["paramiko"]
+smb = ["smbprotocol"]
+sftp = ["paramiko"]
+s3 = ["s3fs"]
+oci = ["ocifs"]
+libarchive = ["libarchive-c"]
+http = ["aiohttp", "requests"]
+hdfs = ["pyarrow (>=1)"]
+gui = ["panel"]
+gs = ["gcsfs"]
+github = ["requests"]
+git = ["pygit2"]
+gcs = ["gcsfs"]
+fuse = ["fusepy"]
+entrypoints = ["importlib-metadata"]
+dropbox = ["dropbox", "requests", "dropboxdrivefs"]
+dask = ["distributed", "dask"]
+arrow = ["pyarrow (>=1)"]
+adl = ["adlfs"]
+abfs = ["adlfs"]
 
 [[package]]
 name = "geoalchemy2"
@@ -641,9 +641,9 @@ optional = true
 python-versions = ">=3.7"
 
 [package.extras]
-dev = ["tox (>=3)", "flake8", "pep8-naming", "wheel", "twine"]
-docs = ["sphinx (>=5)", "sphinx-autodoc-typehints", "sphinx-rtd-theme"]
-test = ["pytest (>=7)", "pytest-mock (>=3)", "mock (>=4)", "pytest-cov", "coverage"]
+test = ["coverage", "pytest-cov", "mock (>=4)", "pytest-mock (>=3)", "pytest (>=7)"]
+docs = ["sphinx-rtd-theme", "sphinx-autodoc-typehints", "sphinx (>=5)"]
+dev = ["twine", "wheel", "pep8-naming", "flake8", "tox (>=3)"]
 
 [[package]]
 name = "greenlet"
@@ -676,9 +676,9 @@ python-versions = ">=3.7"
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+testing = ["importlib-resources (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "pytest-perf (>=0.9.2)", "flufl.flake8", "pyfakefs", "packaging", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
 
 [[package]]
 name = "importlib-resources"
@@ -872,8 +872,8 @@ tornado = ">=6.0"
 traitlets = "*"
 
 [package.extras]
-doc = ["ipykernel", "myst-parser", "sphinx-rtd-theme", "sphinx (>=1.3.6)", "sphinxcontrib-github-alt"]
-test = ["codecov", "coverage", "ipykernel (>=6.5)", "ipython", "mypy", "pre-commit", "pytest", "pytest-asyncio (>=0.18)", "pytest-cov", "pytest-timeout"]
+test = ["pytest-timeout", "pytest-cov", "pytest-asyncio (>=0.18)", "pytest", "pre-commit", "mypy", "ipython", "ipykernel (>=6.5)", "coverage", "codecov"]
+doc = ["sphinxcontrib-github-alt", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "myst-parser", "ipykernel"]
 
 [[package]]
 name = "jupyter-core"
@@ -942,10 +942,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
 
 [package.extras]
-cssselect = ["cssselect (>=0.7)"]
-html5 = ["html5lib"]
-htmlsoup = ["beautifulsoup4"]
 source = ["Cython (>=0.29.7)"]
+htmlsoup = ["beautifulsoup4"]
+html5 = ["html5lib"]
+cssselect = ["cssselect (>=0.7)"]
 
 [[package]]
 name = "lz4"
@@ -972,7 +972,7 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 
 [package.extras]
-testing = ["coverage", "pyyaml"]
+testing = ["pyyaml", "coverage"]
 
 [[package]]
 name = "markdown-it-py"
@@ -1289,9 +1289,9 @@ tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
-dmypy = ["psutil (>=4.0)"]
-python2 = ["typed-ast (>=1.4.0,<2)"]
 reports = ["lxml"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+dmypy = ["psutil (>=4.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -1407,16 +1407,16 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
-    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
-    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
     {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
+    {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
 [package.extras]
-test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
+test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
 
 [[package]]
 name = "pandocfilters"
@@ -1435,8 +1435,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
-testing = ["docopt", "pytest (<6.0.0)"]
+testing = ["pytest (<6.0.0)", "docopt"]
+qa = ["mypy (==0.782)", "flake8 (==3.8.3)"]
 
 [[package]]
 name = "parsy"
@@ -1505,8 +1505,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+test = ["pytest (>=6)", "pytest-mock (>=3.6)", "pytest-cov (>=2.7)", "appdirs (==1.4.4)"]
+docs = ["sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)", "proselint (>=0.10.2)", "furo (>=2021.7.5b38)"]
 
 [[package]]
 name = "pluggy"
@@ -1561,7 +1561,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-test = ["ipaddress", "mock", "enum34", "pywin32", "wmi"]
+test = ["wmi", "pywin32", "enum34", "mock", "ipaddress"]
 
 [[package]]
 name = "psycopg2"
@@ -1664,8 +1664,8 @@ python-versions = ">=3.6.1"
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
-dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
+dotenv = ["python-dotenv (>=0.10.4)"]
 
 [[package]]
 name = "pydocstyle"
@@ -1789,7 +1789,7 @@ py = ">=1.8.2"
 tomli = ">=1.0.0"
 
 [package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+testing = ["xmlschema", "requests", "pygments (>=2.7.2)", "nose", "mock", "hypothesis (>=3.56)", "argcomplete"]
 
 [[package]]
 name = "pytest-benchmark"
@@ -1915,9 +1915,9 @@ pytest = ">=6.2.0"
 pytest-forked = "*"
 
 [package.extras]
-psutil = ["psutil (>=3.0)"]
-setproctitle = ["setproctitle"]
 testing = ["filelock"]
+setproctitle = ["setproctitle"]
+psutil = ["psutil (>=3.0)"]
 
 [[package]]
 name = "python-dateutil"
@@ -2052,8 +2052,8 @@ idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 
 [[package]]
 name = "rich"

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ extras_require = {
     'all': [
         'clickhouse-cityhash>=1.0.2,<2',
         'clickhouse-driver[numpy]>=0.1,<0.3',
-        'dask[array,dataframe]>=2021.10.0,<2022.8.0',
+        'dask[dataframe,array]>=2021.10.0,<2022.8.0',
         'datafusion>=0.4,<0.7',
         'duckdb>=0.3.2,<1',
         'duckdb-engine>=0.1.8,<1',
@@ -92,7 +92,7 @@ extras_require = {
         'lz4>=3.1.10,<5',
         'sqlglot>=4.5.0,<5',
     ],
-    'dask': ['dask[array,dataframe]>=2021.10.0,<2022.8.0', 'pyarrow>=1,<10'],
+    'dask': ['dask[dataframe,array]>=2021.10.0,<2022.8.0', 'pyarrow>=1,<10'],
     'datafusion': ['datafusion>=0.4,<0.7'],
     'duckdb': [
         'duckdb>=0.3.2,<1',

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ extras_require = {
     'all': [
         'clickhouse-cityhash>=1.0.2,<2',
         'clickhouse-driver[numpy]>=0.1,<0.3',
-        'dask[dataframe,array]>=2021.10.0,<2022.8.0',
+        'dask[array,dataframe]>=2021.10.0,<2022.8.0',
         'datafusion>=0.4,<0.7',
         'duckdb>=0.3.2,<1',
         'duckdb-engine>=0.1.8,<1',
@@ -92,7 +92,7 @@ extras_require = {
         'lz4>=3.1.10,<5',
         'sqlglot>=4.5.0,<5',
     ],
-    'dask': ['dask[dataframe,array]>=2021.10.0,<2022.8.0', 'pyarrow>=1,<10'],
+    'dask': ['dask[array,dataframe]>=2021.10.0,<2022.8.0', 'pyarrow>=1,<10'],
     'datafusion': ['datafusion>=0.4,<0.7'],
     'duckdb': [
         'duckdb>=0.3.2,<1',


### PR DESCRIPTION
Turns out that we cannot workaround the hash seed stuff by ignoring ordering. Occasionally a poetry solve will result in different dask markers for the dataframe extra, depending on the ordering of extras it seems. This PR is to get other PRs to stop failing the dry run release step so often. I will follow up on the poetry issue tracker as soon as I have simple reproducer.