### PR TITLE
ci: only run benchmarks against push to `master` branch

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -63,6 +63,7 @@ jobs:
 
   benchmarks:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -91,20 +92,19 @@ jobs:
       - name: install ibis
         run: poetry install --extras all
 
-      - run: mkdir .benchmarks
+      - name: make benchmark output dir
+        run: mkdir .benchmarks
 
       - name: benchmark
-        run: poetry run pytest --benchmark-only --benchmark-json .benchmarks/output.json ibis/tests/benchmarks
+        run: poetry run pytest --benchmark-enable --benchmark-json .benchmarks/output.json ibis/tests/benchmarks
 
       - uses: tibdex/github-app-token@v1
-        if: ${{ github.event_name == 'push' }}
         id: generate-token
         with:
           app_id: ${{ secrets.SQUAWK_BOT_APP_ID }}
           private_key: ${{ secrets.SQUAWK_BOT_APP_PRIVATE_KEY }}
 
       - uses: benchmark-action/github-action-benchmark@v1
-        if: ${{ github.event_name == 'push' }}
         with:
           tool: pytest
           github-token: ${{ steps.generate-token.outputs.token }}
@@ -114,8 +114,37 @@ jobs:
           comment-on-alert: true
           alert-threshold: "300%"
 
-  docs:
+  docs_pr:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'push' }}
+    concurrency: docs-${{ github.repository }}-${{ github.head_ref || github.sha }}
+    steps:
+      - name: install nix
+        uses: cachix/install-nix-action@v17
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable-small
+
+      - name: setup cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: ibis
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: nix-community,poetry2nix
+
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: build docs
+        run: nix run -f nix ibisDevEnv310 -- -m mkdocs build
+
+      - name: verify internal links
+        run: nix shell -f nix --ignore-environment bash findutils just lychee -c just checklinks --offline --no-progress
+
+  docs_push:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
     concurrency: docs-${{ github.repository }}-${{ github.head_ref || github.sha }}
     needs:
       # wait on benchmarks to prevent a race condition when pushing to the
@@ -134,15 +163,8 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           extraPullNames: nix-community,poetry2nix
 
-      - name: checkout
-        uses: actions/checkout@v3
-        if: ${{ github.event_name != 'push' }}
-        with:
-          fetch-depth: 0
-
       - name: Generate a GitHub token
         uses: tibdex/github-app-token@v1
-        if: ${{ github.event_name == 'push' }}
         id: generate_token
         with:
           app_id: ${{ secrets.DOCS_BOT_APP_ID }}
@@ -150,21 +172,11 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v3
-        if: ${{ github.event_name == 'push' }}
         with:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
-      - name: build docs
-        if: ${{ github.event_name != 'push' }}
-        run: nix run -f nix ibisDevEnv310 -- -m mkdocs build
-
-      - name: verify internal links
-        if: ${{ github.event_name != 'push' }}
-        run: nix shell -f nix --ignore-environment bash findutils just lychee -c just checklinks --offline --no-progress
-
       - name: Configure git info
-        if: ${{ github.event_name == 'push' }}
         run: |
           set -euo pipefail
 
@@ -172,7 +184,6 @@ jobs:
           git config user.email 'ibis-docs-bot[bot]@users.noreply.github.com'
 
       - name: build and push dev docs
-        if: ${{ github.event_name == 'push' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -70,7 +70,7 @@ jobs:
       - run: python -m pip install --upgrade pip poetry
 
       - name: install ibis
-        run: poetry install --extras visualization
+        run: poetry install --extras all
 
       - uses: extractions/setup-just@v1
 

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -61,7 +61,7 @@ jobs:
           set -euo pipefail
 
           sudo apt-get update -y -q
-          sudo apt-get install -y -q build-essential graphviz
+          sudo apt-get install -y -q build-essential graphviz krb5-config libkrb5-dev libgeos-dev
 
       - name: install ${{ matrix.os }} system dependencies
         if: ${{ matrix.os == 'windows-latest' }}
@@ -70,14 +70,22 @@ jobs:
       - run: python -m pip install --upgrade pip poetry
 
       - name: install ibis
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: poetry install --extras all
+
+      - name: install ibis
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: poetry install --extras visualization
 
       - uses: extractions/setup-just@v1
 
-      - name: run tests
-        # run all the core tests (i.e., non-backend)
+      - name: run core tests
+        run: just ci-check -m core
+
+      - name: run benchmarks once
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         # run benchmarks once to make sure they aren't broken
-        run: just ci-check -m "'core or benchmark'"
+        run: just ci-check -m benchmark
 
       - name: upload code coverage
         if: success()

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -75,7 +75,9 @@ jobs:
       - uses: extractions/setup-just@v1
 
       - name: run tests
-        run: just ci-check -m core
+        # run all the core tests (i.e., non-backend)
+        # run benchmarks once to make sure they aren't broken
+        run: just ci-check -m "'core or benchmark'"
 
       - name: upload code coverage
         if: success()

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -289,7 +289,8 @@ def pytest_collection_modifyitems(session, config, items):
             item.add_marker(pytest.mark.backend)
         elif "backends" not in parts:
             # anything else is a "core" test and is run by default
-            item.add_marker(pytest.mark.core)
+            if not any(item.iter_markers(name="benchmark")):
+                item.add_marker(pytest.mark.core)
 
         for name in ("duckdb", "sqlite"):
             # build a list of markers so we're don't invalidate the item's

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -16,6 +16,8 @@ import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis.backends.pandas.udf import udf
 
+pytestmark = pytest.mark.benchmark
+
 
 def make_t():
     return ibis.table(
@@ -606,7 +608,7 @@ def multiple_joins(table, num_joins):
         table = table.left_join(table, ["dummy"])[[table]]
 
 
-@pytest.mark.parametrize("num_joins", [1, 10, 100])
+@pytest.mark.parametrize("num_joins", [1, 10])
 @pytest.mark.parametrize("num_columns", [1, 10, 100])
 def test_multiple_joins(benchmark, num_joins, num_columns):
     table = ibis.table(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ addopts = [
   "--ignore=dist-packages",
   "--strict-markers",
   "--strict-config",
-  "--benchmark-skip",
+  "--benchmark-disable",
   "--benchmark-group-by=name",
   "--benchmark-sort=name",
 ]
@@ -241,6 +241,7 @@ norecursedirs = [
 ]
 markers = [
   "backend: tests specific to a backend",
+  "benchmark: benchmarks",
   "core: tests that do not required a backend",
   "geospatial: tests for geospatial functionality",
   "hdfs: Hadoop file system tests",


### PR DESCRIPTION
This PR should reduce the amount of time to merge a PR by reducing the duration
of CI runs, specifically benchmarks.

I've moved the full benchmark suite to run only after a push to master, while
still running a single iteration of each benchmark to make sure they aren't
broken. I also reduced the join size in the multiple joins benchmark because a
single iteration of it takes about 60 seconds.
