### PR TITLE
refactor(ir): remove intermediate expressions

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -211,12 +211,12 @@ class BaseSQLBackend(BaseBackend):
             if `self.expr` doesn't have a schema.
         """
         dml = getattr(query_ast, 'dml', query_ast)
-        expr = getattr(dml, 'parent_expr', getattr(dml, 'table_set', None))
+        op = getattr(dml, 'parent_op', getattr(dml, 'table_set', None))
 
-        if isinstance(expr, (ir.Table, sch.HasSchema)):
-            return expr.schema()
-        elif isinstance(expr, ir.Value):
-            return sch.schema([(expr.get_name(), expr.type())])
+        if isinstance(op, ops.TableNode):
+            return op.schema
+        elif isinstance(op, ops.Value):
+            return sch.schema({op.resolve_name(): op.output_dtype})
         else:
             raise ValueError(
                 'Expression with type {} does not have a '

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -27,7 +27,6 @@ from ibis.backends.base.sql.alchemy.query_builder import AlchemyCompiler
 from ibis.backends.base.sql.alchemy.registry import (
     fixed_arity,
     get_sqla_table,
-    infix_op,
     reduction,
     sqlalchemy_operation_registry,
     sqlalchemy_window_functions_registry,

--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -8,7 +8,6 @@ import sqlalchemy.sql as sql
 import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
-import ibis.expr.types as ir
 from ibis.backends.base.sql.alchemy.database import AlchemyTable
 from ibis.backends.base.sql.alchemy.datatypes import to_sqla_type
 from ibis.backends.base.sql.alchemy.translator import (
@@ -33,12 +32,12 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
         # Got to unravel the join stack; the nesting order could be
         # arbitrary, so we do a depth first search and push the join tokens
         # and predicates onto a flat list, then format them
-        op = self.expr.op()
+        op = self.node
 
         if isinstance(op, ops.Join):
             self._walk_join_tree(op)
         else:
-            self.join_tables.append(self._format_table(self.expr))
+            self.join_tables.append(self._format_table(op))
 
         result = self.join_tables[0]
         for jtype, table, preds in zip(
@@ -71,22 +70,20 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
             else:
                 raise NotImplementedError(jtype)
 
-        self.context.set_ref(self.expr, result)
+        self.context.set_ref(op, result)
         return result
 
     def _get_join_type(self, op):
         return type(op)
 
-    def _format_table(self, expr):
+    def _format_table(self, op):
         ctx = self.context
-        ref_expr = expr
-        op = ref_op = expr.op()
+        ref_op = op
 
         if isinstance(op, ops.SelfReference):
-            ref_expr = op.table
-            ref_op = ref_expr.op()
+            ref_op = op.table
 
-        alias = ctx.get_ref(expr)
+        alias = ctx.get_ref(op)
 
         if isinstance(ref_op, AlchemyTable):
             result = ref_op.sqla_table
@@ -101,35 +98,37 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
             columns = _schema_to_sqlalchemy_columns(ref_op.schema)
             result = sa.text(ref_op.query).columns(*columns).cte(ref_op.name)
         elif isinstance(ref_op, ops.View):
-            definition = ref_op.child.compile()
+            # TODO(kszucs): avoid converting to expression
+            child_expr = ref_op.child.to_expr()
+            definition = child_expr.compile()
             result = sa.table(
                 ref_op.name,
                 *_schema_to_sqlalchemy_columns(ref_op.schema),
             )
-            backend = ref_op.child._find_backend()
+            backend = child_expr._find_backend()
             backend._create_temp_view(view=result, definition=definition)
         else:
             # A subquery
-            if ctx.is_extracted(ref_expr):
+            if ctx.is_extracted(ref_op):
                 # Was put elsewhere, e.g. WITH block, we just need to grab
                 # its alias
-                alias = ctx.get_ref(expr)
+                alias = ctx.get_ref(op)
 
                 # hack
                 if isinstance(op, ops.SelfReference):
-                    table = ctx.get_ref(ref_expr)
+                    table = ctx.get_ref(ref_op)
                     self_ref = (
                         alias if hasattr(alias, "name") else table.alias(alias)
                     )
-                    ctx.set_ref(expr, self_ref)
+                    ctx.set_ref(op, self_ref)
                     return self_ref
                 return alias
 
-            alias = ctx.get_ref(expr)
-            result = ctx.get_compiled_expr(expr)
+            alias = ctx.get_ref(op)
+            result = ctx.get_compiled_expr(op)
 
         result = alias if hasattr(alias, "name") else result.alias(alias)
-        ctx.set_ref(expr, result)
+        ctx.set_ref(op, result)
         return result
 
 
@@ -152,7 +151,7 @@ def _can_lower_sort_column(table_set, expr):
     if isinstance(base, ops.Aggregation):
         return base.table.equals(table_set)
     elif isinstance(base, ops.Selection):
-        return base.equals(table_set.op())
+        return base.equals(table_set)
     else:
         return False
 
@@ -206,21 +205,21 @@ class AlchemySelect(Select):
         to_select = []
 
         has_select_star = False
-        for expr in self.select_set:
-            if isinstance(expr, ir.Value):
-                arg = self._translate(expr, named=True)
-            elif isinstance(expr, ir.Table):
-                if expr.equals(self.table_set):
-                    cached_table = self.context.get_ref(expr)
+        for op in self.select_set:
+            if isinstance(op, ops.Value):
+                arg = self._translate(op, named=True)
+            elif isinstance(op, ops.TableNode):
+                if op.equals(self.table_set):
+                    cached_table = self.context.get_ref(op)
                     if cached_table is None:
                         has_select_star = True
                         continue
                     else:
                         arg = table_set
                 else:
-                    arg = self.context.get_ref(expr)
+                    arg = self.context.get_ref(op)
                     if arg is None:
-                        raise ValueError(expr)
+                        raise ValueError(op)
 
             to_select.append(arg)
 
@@ -302,14 +301,13 @@ class AlchemySelect(Select):
             return fragment
 
         clauses = []
-        for expr in self.order_by:
-            key = expr.op()
+        for key in self.order_by:
             sort_expr = key.expr
 
             # here we have to determine if key.expr is in the select set (as it
             # will be in the case of order_by fused with an aggregation
             if _can_lower_sort_column(self.table_set, sort_expr):
-                arg = sort_expr.get_name()
+                arg = sort_expr.resolve_name()
             else:
                 arg = self._translate(sort_expr)
 

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -14,49 +14,40 @@ import ibis.expr.window as W
 from ibis.backends.base.sql.alchemy.database import AlchemyTable
 from ibis.backends.base.sql.alchemy.datatypes import to_sqla_type
 from ibis.backends.base.sql.alchemy.geospatial import geospatial_supported
+from ibis.expr.rules import Shape
 
 
 def variance_reduction(func_name):
     suffix = {'sample': 'samp', 'pop': 'pop'}
 
-    def variance_compiler(t, expr):
-        arg, how, where = expr.op().args
+    def variance_compiler(t, op):
+        arg, how, where = op.args
 
-        if arg.type().equals(dt.boolean):
-            arg = arg.cast('int32')
+        if isinstance(op.arg.output_dtype, dt.Boolean):
+            arg = ops.Cast(op.arg, to=dt.int32)
+        else:
+            arg = op.arg
 
-        func = getattr(
-            sa.func, '{}_{}'.format(func_name, suffix.get(how, 'samp'))
-        )
+        func = getattr(sa.func, f'{func_name}_{suffix[op.how]}')
 
-        if where is not None:
-            arg = where.ifelse(arg, None)
+        if op.where is not None:
+            # TODO(kszucs): avoid roundtripping to expression
+            arg = op.where.to_expr().ifelse(arg, None).op()
+
         return func(t.translate(arg))
 
     return variance_compiler
-
-
-def infix_op(infix_sym):
-    def formatter(t, expr):
-        op = expr.op()
-        left, right = op.args
-
-        left_arg = t.translate(left)
-        right_arg = t.translate(right)
-        return left_arg.op(infix_sym)(right_arg)
-
-    return formatter
 
 
 def fixed_arity(sa_func, arity):
     if isinstance(sa_func, str):
         sa_func = getattr(sa.func, sa_func)
 
-    def formatter(t, expr):
-        if arity != len(expr.op().args):
+    def formatter(t, op):
+        if arity != len(op.args):
             raise com.IbisError('incorrect number of args')
 
-        return _varargs_call(sa_func, t, expr.op().args)
+        return _varargs_call(sa_func, t, op.args)
 
     return formatter
 
@@ -74,8 +65,8 @@ def _varargs_call(sa_func, t, args):
 
 
 def varargs(sa_func):
-    def formatter(t, expr):
-        return _varargs_call(sa_func, t, expr.op().arg)
+    def formatter(t, op):
+        return _varargs_call(sa_func, t, op.arg.values)
 
     return formatter
 
@@ -88,9 +79,8 @@ def get_sqla_table(ctx, table):
             ctx_level = ctx_level.parent
             sa_table = ctx_level.get_ref(table)
     else:
-        op = table.op()
-        if isinstance(op, AlchemyTable):
-            sa_table = op.sqla_table
+        if isinstance(table, AlchemyTable):
+            sa_table = table.sqla_table
         else:
             sa_table = ctx.get_compiled_expr(table)
 
@@ -118,8 +108,7 @@ def get_col_or_deferred_col(sa_table, colname):
         return sa.column(colname)
 
 
-def _table_column(t, expr):
-    op = expr.op()
+def _table_column(t, op):
     ctx = t.context
     table = op.table
 
@@ -139,20 +128,23 @@ def _table_column(t, expr):
     return out_expr
 
 
-def _table_array_view(t, expr):
+def _table_array_view(t, op):
     ctx = t.context
-    table = ctx.get_compiled_expr(expr.op().table)
+    table = ctx.get_compiled_expr(op.table)
     return table
 
 
-def _exists_subquery(t, expr):
+def _exists_subquery(t, op):
     from ibis.backends.base.sql.alchemy.query_builder import AlchemyCompiler
 
-    op = expr.op()
     ctx = t.context
 
-    filtered = op.foreign_table.filter(op.predicates).projection(
-        [ir.literal(1).name(ir.core.unnamed)]
+    # TODO(kszucs): avoid converting the predicates to expressions
+    # this should be done by the rewrite step before compilation
+    filtered = (
+        op.foreign_table.to_expr()
+        .filter([pred.to_expr() for pred in op.predicates])
+        .projection([ir.literal(1).name(ir.core.unnamed)])
     )
 
     sub_ctx = ctx.subcontext()
@@ -164,8 +156,9 @@ def _exists_subquery(t, expr):
     return clause
 
 
-def _cast(t, expr):
-    arg, typ = expr.op().args
+def _cast(t, op):
+    arg = op.arg
+    typ = op.to
 
     sa_arg = t.translate(arg)
     sa_type = t.get_sqla_type(typ)
@@ -174,13 +167,15 @@ def _cast(t, expr):
         return sa_arg
 
     # specialize going from an integer type to a timestamp
-    if isinstance(arg.type(), dt.Integer) and isinstance(sa_type, sa.DateTime):
+    if isinstance(arg.output_dtype, dt.Integer) and isinstance(
+        sa_type, sa.DateTime
+    ):
         return t.integer_to_timestamp(sa_arg)
 
-    if arg.type().equals(dt.binary) and typ.equals(dt.string):
+    if isinstance(arg.output_dtype, dt.Binary) and isinstance(typ, dt.String):
         return sa.func.encode(sa_arg, 'escape')
 
-    if typ.equals(dt.binary):
+    if isinstance(typ, dt.Binary):
         #  decode yields a column of memoryview which is annoying to deal with
         # in pandas. CAST(expr AS BYTEA) is correct and returns byte strings.
         return sa.cast(sa_arg, sa.LargeBinary())
@@ -189,17 +184,15 @@ def _cast(t, expr):
 
 
 def _contains(func):
-    def translate(t, expr):
-        op = expr.op()
-
+    def translate(t, op):
         left = t.translate(op.value)
         right = t.translate(op.options)
 
         if (
             # not a list expr
-            not isinstance(op.options, ir.ValueList)
+            not isinstance(op.options, ops.ValueList)
             # but still a column expr
-            and isinstance(op.options, ir.ColumnExpr)
+            and op.options.output_shape is Shape.COLUMNAR
             # wasn't already compiled into a select statement
             and not isinstance(right, sa.sql.Selectable)
         ):
@@ -212,26 +205,25 @@ def _contains(func):
     return translate
 
 
-def _group_concat(t, expr):
-    op = expr.op()
+def _group_concat(t, op):
     sep = t.translate(op.sep)
     if op.where is not None:
-        arg = t.translate(op.where.ifelse(op.arg, ibis.NA))
+        # TODO(kszucs): avoid expression roundtrip
+        arg = t.translate(op.where.to_expr().ifelse(op.arg, ibis.NA).op())
     else:
         arg = t.translate(op.arg)
     return sa.func.group_concat(arg, sep)
 
 
-def _alias(t, expr):
+def _alias(t, op):
     # just compile the underlying argument because the naming is handled
     # by the translator for the top level expression
-    op = expr.op()
     return t.translate(op.arg)
 
 
-def _literal(_, expr):
-    dtype = expr.type()
-    value = expr.op().value
+def _literal(_, op):
+    dtype = op.output_dtype
+    value = op.value
 
     if isinstance(dtype, dt.Set):
         return list(map(sa.literal, value))
@@ -239,49 +231,45 @@ def _literal(_, expr):
     return sa.literal(value)
 
 
-def _value_list(t, expr):
-    return [t.translate(x) for x in expr.op().values]
+def _value_list(t, op):
+    return [t.translate(x) for x in op.values]
 
 
-def _is_null(t, expr):
-    arg = t.translate(expr.op().args[0])
+def _is_null(t, op):
+    arg = t.translate(op.arg)
     return arg.is_(sa.null())
 
 
-def _not_null(t, expr):
-    arg = t.translate(expr.op().args[0])
+def _not_null(t, op):
+    arg = t.translate(op.arg)
     return arg.isnot(sa.null())
 
 
-def _round(t, expr):
-    op = expr.op()
-    arg, digits = op.args
-    sa_arg = t.translate(arg)
+def _round(t, op):
+    sa_arg = t.translate(op.arg)
 
     f = sa.func.round
 
-    if digits is not None:
-        sa_digits = t.translate(digits)
+    if op.digits is not None:
+        sa_digits = t.translate(op.digits)
         return f(sa_arg, sa_digits)
     else:
         return f(sa_arg)
 
 
-def _floor_divide(t, expr):
-    left, right = map(t.translate, expr.op().args)
+def _floor_divide(t, op):
+    left = t.translate(op.left)
+    right = t.translate(op.right)
     return sa.func.floor(left / right)
 
 
-def _simple_case(t, expr):
-    op = expr.op()
-
-    cases = [op.base == case for case in op.cases]
-    return _translate_case(t, cases, op.results, op.default)
+def _simple_case(t, op):
+    cases = [ops.Equals(op.base, case) for case in op.cases.values]
+    return _translate_case(t, cases, op.results.values, op.default)
 
 
-def _searched_case(t, expr):
-    op = expr.op()
-    return _translate_case(t, op.cases, op.results, op.default)
+def _searched_case(t, op):
+    return _translate_case(t, op.cases.values, op.results.values, op.default)
 
 
 def _translate_case(t, cases, results, default):
@@ -294,30 +282,28 @@ def _translate_case(t, cases, results, default):
     return sa.case(list(whens), else_=default)
 
 
-def _negate(t, expr):
-    op = expr.op()
-    (arg,) = map(t.translate, op.args)
-    return sa.not_(arg) if isinstance(expr, ir.BooleanValue) else -arg
+def _negate(t, op):
+    arg = t.translate(op.arg)
+    return (
+        sa.not_(arg) if isinstance(op.arg.output_dtype, dt.Boolean) else -arg
+    )
 
 
 def unary(sa_func):
     return fixed_arity(sa_func, 1)
 
 
-def _string_like(method_name, t, expr):
-    op = expr.op()
+def _string_like(method_name, t, op):
     method = getattr(t.translate(op.arg), method_name)
     return method(t.translate(op.pattern), escape=op.escape)
 
 
-def _startswith(t, expr):
-    arg, start = expr.op().args
-    return t.translate(arg).startswith(t.translate(start))
+def _startswith(t, op):
+    return t.translate(op.arg).startswith(t.translate(op.start))
 
 
-def _endswith(t, expr):
-    arg, start = expr.op().args
-    return t.translate(arg).endswith(t.translate(start))
+def _endswith(t, op):
+    return t.translate(op.arg).endswith(t.translate(op.end))
 
 
 _cumulative_to_reduction = {
@@ -330,31 +316,27 @@ _cumulative_to_reduction = {
 }
 
 
-def _cumulative_to_window(translator, expr, window):
+def _cumulative_to_window(translator, op, window):
     win = W.cumulative_window()
     win = win.group_by(window._group_by).order_by(window._order_by)
-
-    op = expr.op()
 
     klass = _cumulative_to_reduction[type(op)]
     new_op = klass(*op.args)
     new_expr = new_op.to_expr()
-    if expr.has_name():
-        new_expr = new_expr.name(expr.get_name())
 
     if type(new_op) in translator._rewrites:
         new_expr = translator._rewrites[type(new_op)](new_expr)
 
+    # TODO(kszucs): rewrite to receive and return an ops.Node
     return L.windowize_function(new_expr, win)
 
 
-def _window(t, expr):
-    op = expr.op()
+def _window(t, op):
 
     arg, window = op.args
     reduction = t.translate(arg)
 
-    window_op = arg.op()
+    window_op = arg
 
     _require_order_by = (
         ops.DenseRank,
@@ -365,7 +347,7 @@ def _window(t, expr):
     )
 
     if isinstance(window_op, ops.CumulativeOp):
-        arg = _cumulative_to_window(t, arg, window)
+        arg = _cumulative_to_window(t, arg, window).op()
         return t.translate(arg)
 
     if window.max_lookback is not None:
@@ -379,9 +361,9 @@ def _window(t, expr):
     if isinstance(window_op, _require_order_by) and not window._order_by:
         order_by = t.translate(window_op.args[0])
     else:
-        order_by = list(map(t.translate, window._order_by))
+        order_by = [t.translate(arg) for arg in window._order_by]
 
-    partition_by = list(map(t.translate, window._group_by))
+    partition_by = [t.translate(arg) for arg in window._group_by]
 
     frame_clause_not_allowed = (
         ops.Lag,
@@ -418,42 +400,38 @@ def _window(t, expr):
         return result
 
 
-def _lag(t, expr):
-    arg, offset, default = expr.op().args
-    if default is not None:
+def _lag(t, op):
+    if op.default is not None:
         raise NotImplementedError()
 
-    sa_arg = t.translate(arg)
-    sa_offset = t.translate(offset) if offset is not None else 1
+    sa_arg = t.translate(op.arg)
+    sa_offset = t.translate(op.offset) if op.offset is not None else 1
     return sa.func.lag(sa_arg, sa_offset)
 
 
-def _lead(t, expr):
-    arg, offset, default = expr.op().args
-    if default is not None:
+def _lead(t, op):
+    if op.default is not None:
         raise NotImplementedError()
-    sa_arg = t.translate(arg)
-    sa_offset = t.translate(offset) if offset is not None else 1
+    sa_arg = t.translate(op.arg)
+    sa_offset = t.translate(op.offset) if op.offset is not None else 1
     return sa.func.lead(sa_arg, sa_offset)
 
 
-def _ntile(t, expr):
-    op = expr.op()
-    args = op.args
-    _, buckets = map(t.translate, args)
-    return sa.func.ntile(buckets)
+def _ntile(t, op):
+    return sa.func.ntile(t.translate(op.buckets))
 
 
-def _sort_key(t, expr):
+def _sort_key(t, op):
     # We need to define this for window functions that have an order by
-    by, ascending = expr.op().args
+    by, ascending = op.args
     sort_direction = sa.asc if ascending else sa.desc
     return sort_direction(t.translate(by))
 
 
-def _string_join(t, expr):
-    sep, elements = expr.op().args
-    return sa.func.concat_ws(t.translate(sep), *map(t.translate, elements))
+def _string_join(t, op):
+    return sa.func.concat_ws(
+        t.translate(op.sep), *map(t.translate, op.arg.values)
+    )
 
 
 def reduction(sa_func):
@@ -463,19 +441,15 @@ def reduction(sa_func):
     return compile_expr
 
 
-def _zero_if_null(t, expr):
-    op = expr.op()
-    arg = op.arg
+def _zero_if_null(t, op):
     sa_arg = t.translate(op.arg)
     return sa.case(
-        [(sa_arg.is_(None), sa.cast(0, to_sqla_type(arg.type())))],
+        [(sa_arg.is_(None), sa.cast(0, to_sqla_type(op.output_dtype)))],
         else_=sa_arg,
     )
 
 
-def _substring(t, expr):
-    op = expr.op()
-
+def _substring(t, op):
     args = t.translate(op.arg), t.translate(op.start) + 1
 
     if (length := op.length) is not None:
@@ -485,9 +459,7 @@ def _substring(t, expr):
 
 
 def _gen_string_find(func):
-    def string_find(t, expr):
-        op = expr.op()
-
+    def string_find(t, op):
         if op.start is not None:
             raise NotImplementedError("`start` not yet implemented")
 
@@ -499,14 +471,12 @@ def _gen_string_find(func):
     return string_find
 
 
-def _nth_value(t, expr):
-    op = expr.op()
+def _nth_value(t, op):
     return sa.func.nth_value(t.translate(op.arg), t.translate(op.nth) + 1)
 
 
 def _clip(*, min_func, max_func):
-    def translate(t, expr):
-        op = expr.op()
+    def translate(t, op):
         arg = t.translate(op.arg)
 
         if (upper := op.upper) is not None:
@@ -612,8 +582,8 @@ sqlalchemy_operation_registry: Dict[Any, Any] = {
     ops.Date: unary(lambda arg: sa.cast(arg, sa.DATE)),
     ops.DateFromYMD: fixed_arity(sa.func.date, 3),
     ops.TimeFromHMS: fixed_arity(sa.func.time, 3),
-    ops.TimestampFromYMDHMS: lambda t, expr: sa.func.make_timestamp(
-        *map(t.translate, expr.op().args[:6])  # ignore timezone
+    ops.TimestampFromYMDHMS: lambda t, op: sa.func.make_timestamp(
+        *map(t.translate, op.args[:6])  # ignore timezone
     ),
     ops.Degrees: unary(sa.func.degrees),
     ops.Radians: unary(sa.func.radians),

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -34,11 +34,11 @@ class TableSetFormatter:
         ops.CrossJoin: 'CROSS JOIN',
     }
 
-    def __init__(self, parent, expr, indent=2):
+    def __init__(self, parent, node, indent=2):
         # `parent` is a `Select` instance, not a `TableSetFormatter`
         self.parent = parent
         self.context = parent.context
-        self.expr = expr
+        self.node = node
         self.indent = indent
 
         self.join_tables = []
@@ -48,27 +48,23 @@ class TableSetFormatter:
     def _translate(self, expr):
         return self.parent._translate(expr)
 
+    # TODO(kszucs): could use lin.traverse here
     def _walk_join_tree(self, op):
-        left = op.left.op()
-        right = op.right.op()
-
-        if util.all_of([left, right], ops.Join):
+        if util.all_of([op.left, op.right], ops.Join):
             raise NotImplementedError(
                 'Do not support joins between ' 'joins yet'
             )
-
-        self._validate_join_predicates(op.predicates)
 
         jname = self._get_join_type(op)
 
         # Read off tables and join predicates left-to-right in
         # depth-first order
-        if isinstance(left, ops.Join):
-            self._walk_join_tree(left)
+        if isinstance(op.left, ops.Join):
+            self._walk_join_tree(op.left)
             self.join_tables.append(self._format_table(op.right))
-        elif isinstance(right, ops.Join):
+        elif isinstance(op.right, ops.Join):
             self.join_tables.append(self._format_table(op.left))
-            self._walk_join_tree(right)
+            self._walk_join_tree(op.right)
         else:
             # Both tables
             self.join_tables.append(self._format_table(op.left))
@@ -77,64 +73,48 @@ class TableSetFormatter:
         self.join_types.append(jname)
         self.join_predicates.append(op.predicates)
 
-    # Placeholder; revisit when supporting other databases
-    _non_equijoin_supported = True
-
-    def _validate_join_predicates(self, predicates):
-        for pred in predicates:
-            op = pred.op()
-
-            if (
-                not isinstance(op, ops.Equals)
-                and not self._non_equijoin_supported
-            ):
-                raise com.TranslationError(
-                    'Non-equality join predicates, '
-                    'i.e. non-equijoins, are not '
-                    'supported'
-                )
-
     def _get_join_type(self, op):
         return self._join_names[type(op)]
 
     def _quote_identifier(self, name):
         return quote_identifier(name)
 
-    def _format_table(self, expr):
+    def _format_table(self, op):
         # TODO: This could probably go in a class and be significantly nicer
         ctx = self.context
 
-        ref_expr = expr
-        op = ref_op = expr.op()
+        ref_op = op
         if isinstance(op, ops.SelfReference):
-            ref_expr = op.table
-            ref_op = ref_expr.op()
+            ref_op = op.table
 
         if isinstance(ref_op, ops.PhysicalTable):
             name = ref_op.name
+            # TODO(kszucs): add a mandatory `name` field to the base
+            # PhyisicalTable instead of the child classes, this should prevent
+            # this error scenario
             if name is None:
-                raise com.RelationError(f'Table did not have a name: {expr!r}')
+                raise com.RelationError(f'Table did not have a name: {op!r}')
             result = self._quote_identifier(name)
             is_subquery = False
         else:
             # A subquery
-            if ctx.is_extracted(ref_expr):
+            if ctx.is_extracted(ref_op):
                 # Was put elsewhere, e.g. WITH block, we just need to grab its
                 # alias
-                alias = ctx.get_ref(expr)
+                alias = ctx.get_ref(op)
 
                 # HACK: self-references have to be treated more carefully here
                 if isinstance(op, ops.SelfReference):
-                    return f'{ctx.get_ref(ref_expr)} {alias}'
+                    return f'{ctx.get_ref(ref_op)} {alias}'
                 else:
                     return alias
 
-            subquery = ctx.get_compiled_expr(expr)
+            subquery = ctx.get_compiled_expr(op)
             result = f'(\n{util.indent(subquery, self.indent)}\n)'
             is_subquery = True
 
-        if is_subquery or ctx.need_aliases(expr):
-            result += f' {ctx.get_ref(expr)}'
+        if is_subquery or ctx.need_aliases(op):
+            result += f' {ctx.get_ref(op)}'
 
         return result
 
@@ -142,12 +122,12 @@ class TableSetFormatter:
         # Got to unravel the join stack; the nesting order could be
         # arbitrary, so we do a depth first search and push the join tokens
         # and predicates onto a flat list, then format them
-        op = self.expr.op()
+        op = self.node
 
         if isinstance(op, ops.Join):
             self._walk_join_tree(op)
         else:
-            self.join_tables.append(self._format_table(self.expr))
+            self.join_tables.append(self._format_table(op))
 
         # TODO: Now actually format the things
         buf = StringIO()
@@ -202,7 +182,7 @@ class Select(DML, Comparable):
         distinct=False,
         indent=2,
         result_handler=None,
-        parent_expr=None,
+        parent_op=None,
     ):
         self.translator_class = translator_class
         self.table_set_formatter_class = table_set_formatter_class
@@ -212,7 +192,7 @@ class Select(DML, Comparable):
         self.table_set = table_set
         self.distinct = distinct
 
-        self.parent_expr = parent_expr
+        self.parent_op = parent_op
 
         self.where = where or []
 
@@ -320,17 +300,18 @@ class Select(DML, Comparable):
         # TODO:
         context = self.context
         formatted = []
-        for expr in self.select_set:
-            if isinstance(expr, ir.Value):
-                expr_str = self._translate(expr, named=True)
-            elif isinstance(expr, ir.Table):
+        for node in self.select_set:
+            if isinstance(node, ops.Value):
+                expr_str = self._translate(node, named=True)
+            elif isinstance(node, ops.TableNode):
                 # A * selection, possibly prefixed
-                if context.need_aliases(expr):
-                    alias = context.get_ref(expr)
-
+                if context.need_aliases(node):
+                    alias = context.get_ref(node)
                     expr_str = f'{alias}.*' if alias else '*'
                 else:
                     expr_str = '*'
+            else:
+                raise TypeError(node)
             formatted.append(expr_str)
 
         buf = StringIO()
@@ -433,8 +414,7 @@ class Select(DML, Comparable):
         buf.write('ORDER BY ')
 
         formatted = []
-        for expr in self.order_by:
-            key = expr.op()
+        for key in self.order_by:
             translated = self._translate(key.expr)
             if not key.ascending:
                 translated += ' DESC'
@@ -469,18 +449,16 @@ class Difference(SetOp):
     _keyword = "EXCEPT"
 
 
-def flatten_set_op(table: ir.Table):
+def flatten_set_op(op):
     """Extract all union queries from `table`.
-
     Parameters
     ----------
-    table : Table
-
+    table : ops.TableNode
     Returns
     -------
     Iterable[Union[Table, bool]]
     """
-    op = table.op()
+
     if isinstance(op, ops.SetOp):
         # For some reason mypy considers `op.left` and `op.right`
         # of `Argument` type, and fails the validation. While in
@@ -490,21 +468,18 @@ def flatten_set_op(table: ir.Table):
             [op.distinct],
             flatten_set_op(op.right),  # type: ignore
         )
-    return [table]
+    return [op]
 
 
-def flatten(table: ir.Table):
+def flatten(op: ops.TableNode):
     """Extract all intersection or difference queries from `table`.
-
     Parameters
     ----------
     table : Table
-
     Returns
     -------
     Iterable[Union[Table]]
     """
-    op = table.op()
     return list(
         toolz.concatv(flatten_set_op(op.left), flatten_set_op(op.right))
     )
@@ -528,35 +503,37 @@ class Compiler:
         for expr, value in params.items():
             op = expr.op()
             if isinstance(op, ops.Alias):
-                op = op.arg.op()
+                op = op.arg
             unaliased_params[op] = value
 
         return cls.context_class(compiler=cls, params=unaliased_params)
 
     @classmethod
-    def to_ast(cls, expr, context=None):
+    def to_ast(cls, node, context=None):
+        # TODO(kszucs): consider to support a single type only
+        if isinstance(node, ir.Expr):
+            node = node.op()
+
         if context is None:
             context = cls.make_context()
 
-        op = expr.op()
-
         # collect setup and teardown queries
-        setup_queries = cls._generate_setup_queries(expr, context)
-        teardown_queries = cls._generate_teardown_queries(expr, context)
+        setup_queries = cls._generate_setup_queries(node, context)
+        teardown_queries = cls._generate_teardown_queries(node, context)
 
         # TODO: any setup / teardown DDL statements will need to be done prior
         # to building the result set-generating statements.
-        if isinstance(op, ops.Union):
-            query = cls._make_union(expr, context)
-        elif isinstance(op, ops.Intersection):
-            query = cls._make_intersect(expr, context)
-        elif isinstance(op, ops.Difference):
-            query = cls._make_difference(expr, context)
+        if isinstance(node, ops.Union):
+            query = cls._make_union(node, context)
+        elif isinstance(node, ops.Intersection):
+            query = cls._make_intersect(node, context)
+        elif isinstance(node, ops.Difference):
+            query = cls._make_difference(node, context)
         else:
             query = cls.select_builder_class().to_select(
                 select_class=cls.select_class,
                 table_set_formatter_class=cls.table_set_formatter_class,
-                expr=expr,
+                node=node,
                 context=context,
                 translator_class=cls.translator_class,
             )
@@ -594,10 +571,16 @@ class Compiler:
         return query_ast
 
     @classmethod
-    def to_sql(cls, expr, context=None, params=None):
+    def to_sql(cls, node, context=None, params=None):
+        # TODO(kszucs): consider to support a single type only
+        if isinstance(node, ir.Expr):
+            node = node.op()
+
+        assert isinstance(node, ops.Node)
+
         if context is None:
             context = cls.make_context(params=params)
-        return cls.to_ast(expr, context).queries[0].compile()
+        return cls.to_ast(node, context).queries[0].compile()
 
     @staticmethod
     def _generate_setup_queries(expr, context):
@@ -608,9 +591,9 @@ class Compiler:
         return []
 
     @staticmethod
-    def _make_set_op(cls, expr, context):
+    def _make_set_op(cls, op, context):
         # flatten unions so that we can codegen them all at once
-        set_op_info = list(flatten_set_op(expr))
+        set_op_info = list(flatten_set_op(op))
 
         # since op is a union, we have at least 3 elements in union_info (left
         # distinct right) and if there is more than a single union we have an
@@ -626,18 +609,18 @@ class Compiler:
         # 2. every other object starting from 1 is a bool indicating the type
         #    of $set_op (distinct or not distinct)
         table_exprs, distincts = set_op_info[::2], set_op_info[1::2]
-        return cls(table_exprs, expr, distincts=distincts, context=context)
+        return cls(table_exprs, op, distincts=distincts, context=context)
 
     @classmethod
-    def _make_union(cls, expr, context):
-        return cls._make_set_op(cls.union_class, expr, context)
+    def _make_union(cls, op, context):
+        return cls._make_set_op(cls.union_class, op, context)
 
     @classmethod
-    def _make_intersect(cls, expr, context):
+    def _make_intersect(cls, op, context):
         # flatten intersections so that we can codegen them all at once
-        return cls._make_set_op(cls.intersect_class, expr, context)
+        return cls._make_set_op(cls.intersect_class, op, context)
 
     @classmethod
-    def _make_difference(cls, expr, context):
+    def _make_difference(cls, op, context):
         # flatten differences so that we can codegen them all at once
-        return cls._make_set_op(cls.difference_class, expr, context)
+        return cls._make_set_op(cls.difference_class, op, context)

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -7,11 +7,11 @@ import toolz
 import ibis.common.exceptions as com
 import ibis.expr.analysis as L
 import ibis.expr.operations as ops
-import ibis.expr.types as ir
 import ibis.util as util
 from ibis.backends.base.sql.compiler.base import (
     _extract_common_table_expressions,
 )
+from ibis.expr.rules import Shape
 
 
 class _LimitSpec(NamedTuple):
@@ -20,10 +20,10 @@ class _LimitSpec(NamedTuple):
 
 
 class _CorrelatedRefCheck:
-    def __init__(self, query, expr):
+    def __init__(self, query, node):
         self.query = query
         self.ctx = query.context
-        self.expr = expr
+        self.node = node
         self.query_roots = frozenset(
             L.find_immediate_parent_tables(self.query.table_set)
         )
@@ -31,39 +31,17 @@ class _CorrelatedRefCheck:
         self.has_query_root = False
 
     def get_result(self):
-        self.visit(self.expr)
+        self.visit(self.node, in_subquery=False)
         return self.has_query_root and self.has_foreign_root
 
-    def visit(
-        self, expr, in_subquery=False, visit_cache=None, visit_table_cache=None
-    ):
-        if visit_cache is None:
-            visit_cache = set()
-
-        node = expr.op()
-        key = node, in_subquery
-        if key in visit_cache:
-            return
-
-        visit_cache.add(key)
-
+    def visit(self, node, in_subquery):
         in_subquery |= self.is_subquery(node)
 
         for arg in node.flat_args():
-            if isinstance(arg, ir.Table):
-                self.visit_table(
-                    arg,
-                    in_subquery=in_subquery,
-                    visit_cache=visit_cache,
-                    visit_table_cache=visit_table_cache,
-                )
-            elif isinstance(arg, ir.Expr):
-                self.visit(
-                    arg,
-                    in_subquery=in_subquery,
-                    visit_cache=visit_cache,
-                    visit_table_cache=visit_table_cache,
-                )
+            if isinstance(arg, ops.TableNode):
+                self.visit_table(arg, in_subquery=in_subquery)
+            elif isinstance(arg, ops.Node):
+                self.visit(arg, in_subquery=in_subquery)
 
     def is_subquery(self, node):
         return isinstance(
@@ -74,36 +52,18 @@ class _CorrelatedRefCheck:
                 ops.NotExistsSubquery,
             ),
         ) or (
-            isinstance(node, ops.TableColumn)
-            and not self.is_root(node.table.op())
+            isinstance(node, ops.TableColumn) and not self.is_root(node.table)
         )
 
-    def visit_table(
-        self, expr, in_subquery=False, visit_cache=None, visit_table_cache=None
-    ):
-        if visit_table_cache is None:
-            visit_table_cache = set()
-
-        key = expr._key, in_subquery
-        if key in visit_table_cache:
-            return
-        visit_table_cache.add(key)
-
-        node = expr.op()
-
+    def visit_table(self, node, in_subquery):
         if isinstance(node, (ops.PhysicalTable, ops.SelfReference)):
             self.ref_check(node, in_subquery=in_subquery)
 
         for arg in node.flat_args():
-            if isinstance(arg, ir.Expr):
-                self.visit(
-                    arg,
-                    in_subquery=in_subquery,
-                    visit_cache=visit_cache,
-                    visit_table_cache=visit_table_cache,
-                )
+            if isinstance(arg, ops.Node):
+                self.visit(arg, in_subquery=in_subquery)
 
-    def ref_check(self, node, in_subquery: bool = False) -> None:
+    def ref_check(self, node, in_subquery) -> None:
         ctx = self.ctx
 
         is_root = self.is_root(node)
@@ -152,17 +112,17 @@ class SelectBuilder:
         self,
         select_class,
         table_set_formatter_class,
-        expr,
+        node,
         context,
         translator_class,
     ):
         self.select_class = select_class
         self.table_set_formatter_class = table_set_formatter_class
-        self.expr = expr
         self.context = context
         self.translator_class = translator_class
 
-        self.query_expr, self.result_handler = self._adapt_expr(self.expr)
+        self.op, self.result_handler = self._adapt_operation(node)
+        assert isinstance(self.op, ops.Node), type(self.op)
 
         self.table_set = None
         self.select_set = None
@@ -186,51 +146,49 @@ class SelectBuilder:
         return checker.get_result()
 
     @staticmethod
-    def _adapt_expr(expr):
+    def _adapt_operation(node):
         # Non-table expressions need to be adapted to some well-formed table
         # expression, along with a way to adapt the results to the desired
         # arity (whether array-like or scalar, for example)
         #
         # Canonical case is scalar values or arrays produced by some reductions
         # (simple reductions, or distinct, say)
+        if isinstance(node, ops.TableNode):
+            return node, toolz.identity
 
-        if isinstance(expr, ir.Table):
-            return expr, toolz.identity
+        elif isinstance(node, ops.Value):
+            if not node.has_resolved_name():
+                node = ops.Alias(node, name="tmp")
+            if node.output_shape is Shape.SCALAR:
+                if L.is_scalar_reduction(node):
+                    table_expr = L.reduction_to_aggregation(node)
+                    return table_expr.op(), _get_scalar(node.resolve_name())
+                else:
+                    return node, _get_scalar(node.resolve_name())
+            elif node.output_shape is Shape.COLUMNAR:
+                if isinstance(node, ops.TableColumn):
+                    table_expr = node.table.to_expr()[[node.name]]
+                    result_handler = _get_column(node.name)
+                else:
+                    table_expr = node.to_expr().to_projection()
+                    result_handler = _get_column(node.resolve_name())
 
-        if isinstance(expr, ir.Scalar):
-            if not expr.has_name():
-                expr = expr.name('tmp')
-
-            if L.is_scalar_reduction(expr):
-                table_expr = L.reduction_to_aggregation(expr)
-                return table_expr, _get_scalar(expr.get_name())
+                return table_expr.op(), result_handler
             else:
-                return expr, _get_scalar(expr.get_name())
+                raise com.TranslationError(
+                    f"Unexpected shape {node.output_shape}"
+                )
 
-        elif isinstance(expr, ir.Analytic):
-            return expr.to_aggregation(), toolz.identity
+        elif isinstance(node, (ops.Analytic, ops.TopK)):
+            return node.to_expr().to_aggregation().op(), toolz.identity
 
-        elif isinstance(expr, ir.Column):
-            op = expr.op()
-
-            if isinstance(op, ops.TableColumn):
-                table_expr = op.table[[op.name]]
-                result_handler = _get_column(op.name)
-            else:
-                if not expr.has_name():
-                    expr = expr.name('tmp')
-                table_expr = expr.to_projection()
-                result_handler = _get_column(expr.get_name())
-
-            return table_expr, result_handler
         else:
             raise com.TranslationError(
-                f'Do not know how to execute: {type(expr)}'
+                f'Do not know how to execute: {type(node)}'
             )
 
     def _build_result_query(self):
         self._collect_elements()
-
         self._analyze_select_exprs()
         self._analyze_subqueries()
         self._populate_context()
@@ -249,7 +207,7 @@ class SelectBuilder:
             order_by=self.sort_by,
             distinct=self.distinct,
             result_handler=self.result_handler,
-            parent_expr=self.query_expr,
+            parent_op=self.op,
         )
 
     def _populate_context(self):
@@ -274,22 +232,22 @@ class SelectBuilder:
             if needs_alias:
                 self.context.set_always_alias()
 
-    def _make_table_aliases(self, expr):
+    # TODO(kszucs): should be rewritten using lin.traverse()
+    def _make_table_aliases(self, node):
         ctx = self.context
-        node = expr.op()
+
         if isinstance(node, ops.Join):
             for arg in node.args:
-                if isinstance(arg, ir.Table):
+                if isinstance(arg, ops.TableNode):
                     self._make_table_aliases(arg)
+        elif not ctx.is_extracted(node):
+            ctx.make_alias(node)
         else:
-            if not ctx.is_extracted(expr):
-                ctx.make_alias(expr)
-            else:
-                # The compiler will apply a prefix only if the current context
-                # contains two or more table references. So, if we've extracted
-                # a subquery into a CTE, we need to propagate that reference
-                # down to child contexts so that they aren't missing any refs.
-                ctx.set_ref(expr, ctx.top_context.get_ref(expr))
+            # The compiler will apply a prefix only if the current context
+            # contains two or more table references. So, if we've extracted
+            # a subquery into a CTE, we need to propagate that reference
+            # down to child contexts so that they aren't missing any refs.
+            ctx.set_ref(node, ctx.top_context.get_ref(node))
 
     # ---------------------------------------------------------------------
     # Expr analysis / rewrites
@@ -297,73 +255,61 @@ class SelectBuilder:
     def _analyze_select_exprs(self):
         new_select_set = []
 
-        for expr in self.select_set:
-            new_expr = self._visit_select_expr(expr)
-            new_select_set.append(new_expr)
+        for op in self.select_set:
+            new_op = self._visit_select_expr(op)
+            new_select_set.append(new_op)
 
         self.select_set = new_select_set
 
-    def _visit_select_expr(self, expr):
-        op = expr.op()
-
+    # TODO(kszucs): this should be rewritten using analysis.substitute()
+    def _visit_select_expr(self, op):
         method = f'_visit_select_{type(op).__name__}'
         if hasattr(self, method):
             f = getattr(self, method)
-            return f(expr)
-
-        unchanged = True
-
-        if isinstance(op, ops.Value):
+            return f(op)
+        elif isinstance(op, ops.Value):
             new_args = []
             for arg in op.args:
-                if isinstance(arg, ir.Expr):
-                    new_arg = self._visit_select_expr(arg)
-                    if arg is not new_arg:
-                        unchanged = False
-                    new_args.append(new_arg)
-                else:
-                    new_args.append(arg)
+                if isinstance(arg, ops.Node):
+                    arg = self._visit_select_expr(arg)
+                new_args.append(arg)
 
-            if not unchanged:
-                new_op = type(op)(*new_args)
-                return new_op.to_expr()
-            else:
-                return expr
+            return type(op)(*new_args)
         else:
-            return expr
+            return op
 
-    def _visit_select_Histogram(self, expr):
-        op = expr.op()
-
+    # TODO(kszucs): avoid roundtripping between extpressions and operations
+    def _visit_select_Histogram(self, op):
+        assert isinstance(op, ops.Node), type(op)
         EPS = 1e-13
 
         if op.binwidth is None or op.base is None:
             aux_hash = op.aux_hash or util.guid()[:6]
-
             min_name = 'min_%s' % aux_hash
             max_name = 'max_%s' % aux_hash
 
-            minmax = self.table_set.aggregate(
-                [op.arg.min().name(min_name), op.arg.max().name(max_name)]
+            minmax = self.table_set.to_expr().aggregate(
+                [
+                    op.arg.to_expr().min().name(min_name),
+                    op.arg.to_expr().max().name(max_name),
+                ]
             )
-            self.table_set = self.table_set.cross_join(minmax)
+            self.table_set = self.table_set.to_expr().cross_join(minmax).op()
 
             if op.base is None:
                 base = minmax[min_name] - EPS
             else:
-                base = op.base
+                base = op.base.to_expr()
 
             binwidth = (minmax[max_name] - base) / (op.nbins - 1)
         else:
             # Have both a bin width and a base
-            binwidth = op.binwidth
-            base = op.base
+            binwidth = op.binwidth.to_expr()
+            base = op.base.to_expr()
 
-        bucket = ((op.arg - base) / binwidth).floor()
-        if expr.has_name():
-            bucket = bucket.name(expr.get_name())
+        bucket = ((op.arg.to_expr() - base) / binwidth).floor()
 
-        return bucket
+        return bucket.op()
 
     # ---------------------------------------------------------------------
     # Analysis of table set
@@ -376,42 +322,35 @@ class SelectBuilder:
         # expression that is being translated only depends on a single table
         # expression.
 
-        source_expr = self.query_expr
-
-        # hm, is this the best place for this?
-        root_op = source_expr.op()
-
-        if isinstance(root_op, ops.TableNode):
-            self._collect(source_expr, toplevel=True)
+        if isinstance(self.op, ops.TableNode):
+            self._collect(self.op, toplevel=True)
             assert self.table_set is not None
         else:
-            self.select_set = [source_expr]
+            self.select_set = [self.op]
 
-    def _collect(self, expr, toplevel=False):
-        op = expr.op()
+    def _collect(self, op, toplevel=False):
         method = f'_collect_{type(op).__name__}'
 
         if hasattr(self, method):
             f = getattr(self, method)
-            f(expr, toplevel=toplevel)
+            f(op, toplevel=toplevel)
         elif isinstance(op, (ops.PhysicalTable, ops.SQLQueryResult)):
-            self._collect_PhysicalTable(expr, toplevel=toplevel)
+            self._collect_PhysicalTable(op, toplevel=toplevel)
         elif isinstance(op, ops.Join):
-            self._collect_Join(expr, toplevel=toplevel)
+            self._collect_Join(op, toplevel=toplevel)
         else:
             raise NotImplementedError(type(op))
 
-    def _collect_Distinct(self, expr, toplevel=False):
+    def _collect_Distinct(self, op, toplevel=False):
         if toplevel:
             self.distinct = True
 
-        self._collect(expr.op().table, toplevel=toplevel)
+        self._collect(op.table, toplevel=toplevel)
 
-    def _collect_Limit(self, expr, toplevel=False):
+    def _collect_Limit(self, op, toplevel=False):
         if not toplevel:
             return
 
-        op = expr.op()
         n = op.n
         offset = op.offset or 0
 
@@ -425,26 +364,25 @@ class SelectBuilder:
 
         self._collect(op.table, toplevel=toplevel)
 
-    def _collect_Union(self, expr, toplevel=False):
+    def _collect_Union(self, op, toplevel=False):
         if toplevel:
             raise NotImplementedError()
 
-    def _collect_Difference(self, expr, toplevel=False):
+    def _collect_Difference(self, op, toplevel=False):
         if toplevel:
             raise NotImplementedError()
 
-    def _collect_Intersection(self, expr, toplevel=False):
+    def _collect_Intersection(self, op, toplevel=False):
         if toplevel:
             raise NotImplementedError()
 
-    def _collect_Aggregation(self, expr, toplevel=False):
+    def _collect_Aggregation(self, op, toplevel=False):
         # The select set includes the grouping keys (if any), and these are
         # duplicated in the group_by set. SQL translator can decide how to
         # format these depending on the database. Most likely the
         # GROUP BY 1, 2, ... style
         if toplevel:
-            subbed_expr = self._sub(expr)
-            sub_op = subbed_expr.op()
+            sub_op = L.substitute_parents(op)
 
             self.group_by = self._convert_group_by(sub_op.by)
             self.having = sub_op.having
@@ -453,14 +391,13 @@ class SelectBuilder:
             self.filters = sub_op.predicates
             self.sort_by = sub_op.sort_keys
 
-            self._collect(expr.op().table)
+            self._collect(op.table)
 
-    def _collect_Selection(self, expr, toplevel=False):
-        op = expr.op()
+    def _collect_Selection(self, op, toplevel=False):
         table = op.table
 
         if toplevel:
-            if isinstance(table.op(), ops.Join):
+            if isinstance(table, ops.Join):
                 self._collect_Join(table)
             else:
                 self._collect(table)
@@ -478,27 +415,23 @@ class SelectBuilder:
             self.table_set = table
             self.filters = filters
 
-    def _convert_group_by(self, exprs):
-        return list(range(len(exprs)))
+    def _convert_group_by(self, nodes):
+        return list(range(len(nodes)))
 
-    def _collect_Join(self, expr, toplevel=False):
+    def _collect_Join(self, op, toplevel=False):
         if toplevel:
-            subbed = self._sub(expr)
+            subbed = L.substitute_parents(op)
             self.table_set = subbed
             self.select_set = [subbed]
 
-    def _collect_PhysicalTable(self, expr, toplevel=False):
+    def _collect_PhysicalTable(self, op, toplevel=False):
         if toplevel:
-            self.select_set = [expr]
-            self.table_set = expr
+            self.select_set = [op]
+            self.table_set = op
 
-    def _collect_SelfReference(self, expr, toplevel=False):
-        op = expr.op()
+    def _collect_SelfReference(self, op, toplevel=False):
         if toplevel:
             self._collect(op.table, toplevel=toplevel)
-
-    def _sub(self, what):
-        return L.substitute_parents(what)
 
     # --------------------------------------------------------------------
     # Subquery analysis / extraction
@@ -530,8 +463,8 @@ class SelectBuilder:
         )
 
         self.subqueries = []
-        for expr in subqueries:
+        for node in subqueries:
             # See #173. Might have been extracted already in a parent context.
-            if not self.context.is_extracted(expr):
-                self.subqueries.append(expr)
-                self.context.set_extracted(expr)
+            if not self.context.is_extracted(node):
+                self.subqueries.append(node)
+                self.context.set_extracted(node)

--- a/ibis/backends/base/sql/registry/case.py
+++ b/ibis/backends/base/sql/registry/case.py
@@ -11,29 +11,26 @@ class _CaseFormatter:
 
         # HACK
         self.indent = 2
-        self.multiline = len(cases) > 1
+        self.multiline = len(cases.values) > 1
         self.buf = StringIO()
-
-    def _trans(self, expr):
-        return self.translator.translate(expr)
 
     def get_result(self):
         self.buf.seek(0)
 
         self.buf.write('CASE')
         if self.base is not None:
-            base_str = self._trans(self.base)
+            base_str = self.translator.translate(self.base)
             self.buf.write(f' {base_str}')
 
-        for case, result in zip(self.cases, self.results):
+        for case, result in zip(self.cases.values, self.results.values):
             self._next_case()
-            case_str = self._trans(case)
-            result_str = self._trans(result)
+            case_str = self.translator.translate(case)
+            result_str = self.translator.translate(result)
             self.buf.write(f'WHEN {case_str} THEN {result_str}')
 
         if self.default is not None:
             self._next_case()
-            default_str = self._trans(self.default)
+            default_str = self.translator.translate(self.default)
             self.buf.write(f'ELSE {default_str}')
 
         if self.multiline:
@@ -50,16 +47,14 @@ class _CaseFormatter:
             self.buf.write(' ')
 
 
-def simple_case(translator, expr):
-    op = expr.op()
+def simple_case(translator, op):
     formatter = _CaseFormatter(
         translator, op.base, op.cases, op.results, op.default
     )
     return formatter.get_result()
 
 
-def searched_case(translator, expr):
-    op = expr.op()
+def searched_case(translator, op):
     formatter = _CaseFormatter(
         translator, None, op.cases, op.results, op.default
     )

--- a/ibis/backends/base/sql/registry/helpers.py
+++ b/ibis/backends/base/sql/registry/helpers.py
@@ -1,7 +1,6 @@
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-import ibis.expr.types as ir
 from ibis.backends.base.sql.registry import identifiers
 
 
@@ -45,10 +44,9 @@ _NEEDS_PARENS_OPS = (
 )
 
 
-def needs_parens(expr: ir.Expr):
-    op = expr.op()
+def needs_parens(op: ops.Node):
     if isinstance(op, ops.Alias):
-        op = op.arg.op()
+        op = op.arg
     return isinstance(op, _NEEDS_PARENS_OPS)
 
 

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -15,16 +15,14 @@ from ibis.backends.base.sql.registry import (
 from ibis.backends.base.sql.registry.literal import literal, null_literal
 
 
-def alias(translator, expr):
+def alias(translator, op):
     # just compile the underlying argument because the naming is handled
     # by the translator for the top level expression
-    op = expr.op()
     return translator.translate(op.arg)
 
 
 def fixed_arity(func_name, arity):
-    def formatter(translator, expr):
-        op = expr.op()
+    def formatter(translator, op):
         if arity != len(op.args):
             raise com.IbisError('incorrect number of args')
         return helpers.format_call(translator, func_name, *op.args)
@@ -36,37 +34,36 @@ def unary(func_name):
     return fixed_arity(func_name, 1)
 
 
-def not_null(translator, expr):
-    formatted_arg = translator.translate(expr.op().args[0])
+def not_null(translator, op):
+    formatted_arg = translator.translate(op.arg)
     return f'{formatted_arg} IS NOT NULL'
 
 
-def is_null(translator, expr):
-    formatted_arg = translator.translate(expr.op().args[0])
+def is_null(translator, op):
+    formatted_arg = translator.translate(op.arg)
     return f'{formatted_arg} IS NULL'
 
 
-def not_(translator, expr):
-    (arg,) = expr.op().args
+def not_(translator, op):
+    (arg,) = op.args
     formatted_arg = translator.translate(arg)
     if helpers.needs_parens(arg):
         formatted_arg = helpers.parenthesize(formatted_arg)
     return f'NOT {formatted_arg}'
 
 
-def negate(translator, expr):
-    arg = expr.op().args[0]
+def negate(translator, op):
+    arg = op.args[0]
     formatted_arg = translator.translate(arg)
-    if isinstance(expr, ir.BooleanValue):
-        return not_(translator, expr)
+    if isinstance(op.output_dtype, dt.Boolean):
+        return not_(translator, op)
     else:
         if helpers.needs_parens(arg):
             formatted_arg = helpers.parenthesize(formatted_arg)
         return f'-{formatted_arg}'
 
 
-def ifnull_workaround(translator, expr):
-    op = expr.op()
+def ifnull_workaround(translator, op):
     a, b = op.args
 
     # work around per #345, #360
@@ -76,20 +73,19 @@ def ifnull_workaround(translator, expr):
     return helpers.format_call(translator, 'isnull', a, b)
 
 
-def sign(translator, expr):
-    (arg,) = expr.op().args
-    translated_arg = translator.translate(arg)
-    translated_type = helpers.type_to_sql_string(expr.type())
-    if expr.type() != dt.float32:
+def sign(translator, op):
+    translated_arg = translator.translate(op.arg)
+    dtype = op.output_dtype
+    translated_type = helpers.type_to_sql_string(dtype)
+    if not isinstance(dtype, dt.Float32):
         return f'CAST(sign({translated_arg}) AS {translated_type})'
     return f'sign({translated_arg})'
 
 
-def hashbytes(translator, expr):
-    op = expr.op()
-    arg, how = op.args
+def hashbytes(translator, op):
+    how = op.how
 
-    arg_formatted = translator.translate(arg)
+    arg_formatted = translator.translate(op.arg)
 
     if how == 'md5':
         return f'md5({arg_formatted})'
@@ -103,91 +99,87 @@ def hashbytes(translator, expr):
         raise NotImplementedError(how)
 
 
-def log(translator, expr):
-    op = expr.op()
-    arg, base = op.args
-    arg_formatted = translator.translate(arg)
+def log(translator, op):
+    arg_formatted = translator.translate(op.arg)
 
-    if base is None:
+    if op.base is None:
         return f'ln({arg_formatted})'
 
-    base_formatted = translator.translate(base)
+    base_formatted = translator.translate(op.base)
     return f'log({base_formatted}, {arg_formatted})'
 
 
-def value_list(translator, expr):
-    op = expr.op()
+def value_list(translator, op):
     formatted = [translator.translate(x) for x in op.values]
     return helpers.parenthesize(', '.join(formatted))
 
 
-def cast(translator, expr):
-    op = expr.op()
-    arg, target_type = op.args
-    arg_formatted = translator.translate(arg)
+def cast(translator, op):
+    arg_formatted = translator.translate(op.arg)
 
-    if isinstance(arg, ir.CategoryValue) and target_type == dt.int32:
+    if isinstance(op.arg.output_dtype, dt.Category) and op.to == dt.int32:
         return arg_formatted
-    if isinstance(arg, ir.TemporalValue) and target_type == dt.int64:
+    if (
+        isinstance(op.arg.output_dtype, (dt.Timestamp, dt.Date, dt.Time))
+        and op.to == dt.int64
+    ):
         return f'1000000 * unix_timestamp({arg_formatted})'
     else:
-        sql_type = helpers.type_to_sql_string(target_type)
+        sql_type = helpers.type_to_sql_string(op.to)
         return f'CAST({arg_formatted} AS {sql_type})'
 
 
 def varargs(func_name):
-    def varargs_formatter(translator, expr):
-        op = expr.op()
-        return helpers.format_call(translator, func_name, *op.arg)
+    def varargs_formatter(translator, op):
+        return helpers.format_call(translator, func_name, *op.arg.values)
 
     return varargs_formatter
 
 
-def between(translator, expr):
-    op = expr.op()
-    comp, lower, upper = (translator.translate(x) for x in op.args)
+def between(translator, op):
+    comp = translator.translate(op.arg)
+    lower = translator.translate(op.lower_bound)
+    upper = translator.translate(op.upper_bound)
     return f'{comp} BETWEEN {lower} AND {upper}'
 
 
-def table_array_view(translator, expr):
+def table_array_view(translator, op):
     ctx = translator.context
-    table = expr.op().table
-    query = ctx.get_compiled_expr(table)
+    query = ctx.get_compiled_expr(op.table)
     return f'(\n{util.indent(query, ctx.indent)}\n)'
 
 
-def table_column(translator, expr):
-    op = expr.op()
-    field_name = op.name
-    quoted_name = helpers.quote_identifier(field_name, force=True)
+def table_column(translator, op):
+    quoted_name = helpers.quote_identifier(op.name, force=True)
 
-    table = op.table
     ctx = translator.context
 
     # If the column does not originate from the table set in the current SELECT
     # context, we should format as a subquery
-    if translator.permit_subquery and ctx.is_foreign_expr(table):
-        proj_expr = table.projection([field_name]).to_array()
+    if translator.permit_subquery and ctx.is_foreign_expr(op.table):
+        # TODO(kszucs): avoid the expression roundtrip
+        proj_expr = op.table.to_expr().projection([op.name]).to_array().op()
         return table_array_view(translator, proj_expr)
 
     if ctx.need_aliases():
-        alias = ctx.get_ref(table)
+        alias = ctx.get_ref(op.table)
         if alias is not None:
             quoted_name = f'{alias}.{quoted_name}'
 
     return quoted_name
 
 
-def exists_subquery(translator, expr):
-    op = expr.op()
+def exists_subquery(translator, op):
     ctx = translator.context
 
     dummy = ir.literal(1).name(ir.core.unnamed)
 
-    filtered = op.foreign_table.filter(op.predicates)
-    expr = filtered.projection([dummy])
+    filtered = op.foreign_table.to_expr().filter(
+        [pred.to_expr() for pred in op.predicates]
+    )
+    node = filtered.projection([dummy]).op()
 
-    subquery = ctx.get_compiled_expr(expr)
+    subquery = ctx.get_compiled_expr(node)
 
     if isinstance(op, ops.ExistsSubquery):
         key = 'EXISTS'
@@ -201,8 +193,7 @@ def exists_subquery(translator, expr):
 
 # XXX this is not added to operation_registry, but looks like impala is
 # using it in the tests, and it works, even if it's not imported anywhere
-def round(translator, expr):
-    op = expr.op()
+def round(translator, op):
     arg, digits = op.args
 
     arg_formatted = translator.translate(arg)
@@ -215,11 +206,10 @@ def round(translator, expr):
 
 # XXX this is not added to operation_registry, but looks like impala is
 # using it in the tests, and it works, even if it's not imported anywhere
-def hash(translator, expr):
-    op = expr.op()
-    arg, how = op.args
+def hash(translator, op):
+    how = op.how
 
-    arg_formatted = translator.translate(arg)
+    arg_formatted = translator.translate(op.arg)
 
     if how == 'fnv':
         return f'fnv_hash({arg_formatted})'
@@ -227,9 +217,14 @@ def hash(translator, expr):
         raise NotImplementedError(how)
 
 
-def concat(translator, expr):
-    joined_args = ', '.join(map(translator.translate, expr.op().arg))
+def concat(translator, op):
+    joined_args = ', '.join(map(translator.translate, op.arg.values))
     return f"concat({joined_args})"
+
+
+def sort_key(translator, op):
+    sort_direction = " DESC" * (not op.ascending)
+    return f"{translator.translate(op.expr)}{sort_direction}"
 
 
 binary_infix_ops = {
@@ -378,11 +373,11 @@ operation_registry = {
     ops.ExistsSubquery: exists_subquery,
     ops.NotExistsSubquery: exists_subquery,
     # RowNumber, and rank functions starts with 0 in Ibis-land
-    ops.RowNumber: lambda *args: 'row_number()',
-    ops.DenseRank: lambda *args: 'dense_rank()',
-    ops.MinRank: lambda *args: 'rank()',
-    ops.PercentRank: lambda *args: 'percent_rank()',
-    ops.CumeDist: lambda *args: 'cume_dist()',
+    ops.RowNumber: lambda *_: 'row_number()',
+    ops.DenseRank: lambda *_: 'dense_rank()',
+    ops.MinRank: lambda *_: 'rank()',
+    ops.PercentRank: lambda *_: 'percent_rank()',
+    ops.CumeDist: lambda *_: 'cume_dist()',
     ops.FirstValue: unary('first_value'),
     ops.LastValue: unary('last_value'),
     ops.Lag: window.shift_like('lag'),
@@ -392,5 +387,6 @@ operation_registry = {
     ops.DayOfWeekIndex: timestamp.day_of_week_index,
     ops.DayOfWeekName: timestamp.day_of_week_name,
     ops.Strftime: timestamp.strftime,
+    ops.SortKey: sort_key,
     **binary_infix_ops,
 }

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -31,7 +31,7 @@ class ClickhouseSelect(Select):
 
         lines = []
         if len(self.group_by) > 0:
-            columns = [f'`{expr.get_name()}`' for expr in self.group_by]
+            columns = [f'`{op.resolve_name()}`' for op in self.group_by]
             clause = 'GROUP BY {}'.format(', '.join(columns))
             lines.append(clause)
 
@@ -73,8 +73,6 @@ class ClickhouseTableSetFormatter(TableSetFormatter):
         ops.AnyLeftJoin: 'ANY LEFT OUTER JOIN',
     }
 
-    _non_equijoin_supported = False
-
 
 class ClickhouseExprTranslator(ExprTranslator):
     _registry = operation_registry
@@ -84,13 +82,16 @@ rewrites = ClickhouseExprTranslator.rewrites
 
 
 @rewrites(ops.FloorDivide)
-def _floor_divide(expr):
-    left, right = expr.op().args
-    return left.div(right).floor()
+def _floor_divide(op):
+    # TODO(kszucs): avoid the expression roundtrip
+    left = op.left.to_expr()
+    right = op.right.to_expr()
+    new_expr = left.div(right).floor()
+    return new_expr.op()
 
 
 @rewrites(ops.DayOfWeekName)
-def day_of_week_name(expr):
+def day_of_week_name(op):
     # ClickHouse 20 doesn't support dateName
     #
     # ClickHouse 21 supports dateName is broken for regexen:
@@ -101,8 +102,8 @@ def day_of_week_name(expr):
     #
     # We test against 20 in CI, so we implement day_of_week_name as follows
     return (
-        expr.op()
-        .arg.day_of_week.index()
+        op.arg.to_expr()
+        .day_of_week.index()
         .case()
         .when(0, "Monday")
         .when(1, "Tuesday")
@@ -114,6 +115,7 @@ def day_of_week_name(expr):
         .else_("")
         .end()
         .nullif("")
+        .op()
     )
 
 

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -13,42 +13,35 @@ from ibis.backends.clickhouse.identifiers import quote_identifier
 # TODO(kszucs): should inherit operation registry from the base compiler
 
 
-def _alias(translator, expr):
+def _alias(translator, op):
     # just compile the underlying argument because the naming is handled
     # by the translator for the top level expression
-    op = expr.op()
     return translator.translate(op.arg)
 
 
-def _cast(translator, expr):
-    op = expr.op()
-    arg = op.arg
-    target = op.to
-    arg_ = translator.translate(arg)
-    type_ = serialize(target)
+def _cast(translator, op):
+    arg_ = translator.translate(op.arg)
+    type_ = serialize(op.to)
 
     return f'CAST({arg_!s} AS {type_!s})'
 
 
-def _between(translator, expr):
-    op = expr.op()
+def _between(translator, op):
     arg_, lower_, upper_ = map(translator.translate, op.args)
     return f'{arg_!s} BETWEEN {lower_!s} AND {upper_!s}'
 
 
-def _negate(translator, expr):
-    return f"-{_parenthesize(translator, expr.op().arg)}"
+def _negate(translator, op):
+    return f"-{_parenthesize(translator, op.arg)}"
 
 
-def _not(translator, expr):
-    return f"NOT {_parenthesize(translator, expr.op().arg)}"
+def _not(translator, op):
+    return f"NOT {_parenthesize(translator, op.arg)}"
 
 
-def _parenthesize(translator, expr):
-    op = expr.op()
-
+def _parenthesize(translator, op):
     # function calls don't need parens
-    what_ = translator.translate(expr)
+    what_ = translator.translate(op)
     if isinstance(op, (*_binary_infix_ops.keys(), *_unary_ops.keys())):
         return f"({what_})"
     else:
@@ -59,14 +52,12 @@ def _unary(func_name):
     return _fixed_arity(func_name, 1)
 
 
-def _extract_epoch_seconds(translator, expr):
-    op = expr.op()
+def _extract_epoch_seconds(translator, op):
     return _call(translator, 'toRelativeSecondNum', *op.args)
 
 
 def _fixed_arity(func_name, arity):
-    def formatter(translator, expr):
-        op = expr.op()
+    def formatter(translator, op):
         arg_count = len(op.args)
         if arity != arg_count:
             msg = 'Incorrect number of args {0} instead of {1}'
@@ -76,43 +67,32 @@ def _fixed_arity(func_name, arity):
     return formatter
 
 
-def _array_index_op(translator, expr):
-    op = expr.op()
+def _array_index_op(translator, op):
+    arg_ = translator.translate(op.arg)
+    index_ = _parenthesize(translator, op.index)
 
-    arr = op.args[0]
-    idx = op.args[1]
+    correct_idx_ = f'if({index_} >= 0, {index_} + 1, {index_})'
 
-    arr_ = translator.translate(arr)
-    idx_ = _parenthesize(translator, idx)
-
-    correct_idx = f'if({idx_} >= 0, {idx_} + 1, {idx_})'
-
-    return f'arrayElement({arr_}, {correct_idx})'
+    return f'arrayElement({arg_}, {correct_idx_})'
 
 
-def _array_repeat_op(translator, expr):
-    op = expr.op()
-    arr, times = op.args
-
-    arr_ = _parenthesize(translator, arr)
-    times_ = _parenthesize(translator, times)
+def _array_repeat_op(translator, op):
+    arg_ = _parenthesize(translator, op.arg)
+    times_ = _parenthesize(translator, op.times)
 
     select = 'arrayFlatten(groupArray(arr))'
-    from_ = f'(select {arr_} as arr from system.numbers limit {times_})'
+    from_ = f'(select {arg_} as arr from system.numbers limit {times_})'
     return f'(select {select} from {from_})'
 
 
-def _array_slice_op(translator, expr):
-    op = expr.op()
-    arg, start, stop = op.args
-
-    start_ = _parenthesize(translator, start)
-    arg_ = translator.translate(arg)
+def _array_slice_op(translator, op):
+    start_ = _parenthesize(translator, op.start)
+    arg_ = translator.translate(op.arg)
 
     start_correct_ = f'if({start_} < 0, {start_}, {start_} + 1)'
 
-    if stop is not None:
-        stop_ = _parenthesize(translator, stop)
+    if op.stop is not None:
+        stop_ = _parenthesize(translator, op.stop)
 
         cast_arg_ = f'if({arg_} = [], CAST({arg_} AS Array(UInt8)), {arg_})'
         neg_start_ = f'(arrayCount({cast_arg_}) + {start_})'
@@ -129,8 +109,7 @@ def _array_slice_op(translator, expr):
 
 
 def _agg(func):
-    def formatter(translator, expr):
-        op = expr.op()
+    def formatter(translator, op):
         where = getattr(op, "where", None)
         args = tuple(
             arg for arg in op.args if arg is not None and arg is not where
@@ -143,15 +122,14 @@ def _agg(func):
 def _agg_variance_like(func):
     variants = {'sample': f'{func}Samp', 'pop': f'{func}Pop'}
 
-    def formatter(translator, expr):
-        *args, how, where = expr.op().args
+    def formatter(translator, op):
+        *args, how, where = op.args
         return _aggregate(translator, variants[how], *args, where=where)
 
     return formatter
 
 
-def _corr(translator, expr):
-    op = expr.op()
+def _corr(translator, op):
     if op.how == "pop":
         raise ValueError(
             "ClickHouse only implements `sample` correlation coefficient"
@@ -171,23 +149,20 @@ def _aggregate(translator, func, *args, where=None):
         return _call(translator, func, *args)
 
 
-def _xor(translator, expr):
-    op = expr.op()
+def _xor(translator, op):
     left_ = _parenthesize(translator, op.left)
     right_ = _parenthesize(translator, op.right)
     return f'xor({left_}, {right_})'
 
 
 def _varargs(func_name):
-    def varargs_formatter(translator, expr):
-        op = expr.op()
-        return _call(translator, func_name, *op.arg)
+    def varargs_formatter(translator, op):
+        return _call(translator, func_name, *op.arg.values)
 
     return varargs_formatter
 
 
-def _arbitrary(translator, expr):
-    op = expr.op()
+def _arbitrary(translator, op):
     functions = {
         None: 'any',
         'first': 'any',
@@ -197,37 +172,35 @@ def _arbitrary(translator, expr):
     return _aggregate(translator, functions[op.how], op.arg, where=op.where)
 
 
-def _substring(translator, expr):
-    # arg_ is the formatted notation
-    op = expr.op()
-    arg, start, length = op.args
-    arg_, start_ = translator.translate(arg), translator.translate(start)
+def _substring(translator, op):
+    arg_, start_ = translator.translate(op.arg), translator.translate(op.start)
 
     # Clickhouse is 1-indexed
-    if length is None or isinstance(length.op(), ops.Literal):
-        if length is not None:
-            length_ = length.op().value
+    if op.length is None or isinstance(op.length, ops.Literal):
+        if op.length is not None:
+            length_ = op.length.value
             return f'substring({arg_}, {start_} + 1, {length_})'
         else:
             return f'substring({arg_}, {start_} + 1)'
     else:
-        length_ = translator.translate(length)
+        length_ = translator.translate(op.length)
         return f'substring({arg_}, {start_} + 1, {length_})'
 
 
-def _string_find(translator, expr):
-    op = expr.op()
-    arg, substr, start, _ = op.args
-    if start is not None:
+def _string_find(translator, op):
+    if op.start is not None:
         raise com.UnsupportedOperationError(
             "String find doesn't support start argument"
         )
+    if op.end is not None:
+        raise com.UnsupportedOperationError(
+            "String find doesn't support end argument"
+        )
 
-    return _call(translator, 'position', arg, substr) + ' - 1'
+    return _call(translator, 'position', op.arg, op.substr) + ' - 1'
 
 
-def _regex_extract(translator, expr):
-    op = expr.op()
+def _regex_extract(translator, op):
     arg_ = translator.translate(op.arg)
     pattern_ = translator.translate(op.pattern)
     index = op.index
@@ -238,58 +211,44 @@ def _regex_extract(translator, expr):
     return base
 
 
-def _parse_url(translator, expr):
-    op = expr.op()
-    arg, extract, key = op.args
-
-    if extract == 'HOST':
-        return _call(translator, 'domain', arg)
-    elif extract == 'PROTOCOL':
-        return _call(translator, 'protocol', arg)
-    elif extract == 'PATH':
-        return _call(translator, 'path', arg)
-    elif extract == 'QUERY':
-        if key is not None:
-            return _call(translator, 'extractURLParameter', arg, key)
+def _parse_url(translator, op):
+    if op.extract == 'HOST':
+        return _call(translator, 'domain', op.arg)
+    elif op.extract == 'PROTOCOL':
+        return _call(translator, 'protocol', op.arg)
+    elif op.extract == 'PATH':
+        return _call(translator, 'path', op.arg)
+    elif op.extract == 'QUERY':
+        if op.key is not None:
+            return _call(translator, 'extractURLParameter', op.arg, op.key)
         else:
-            return _call(translator, 'queryString', arg)
+            return _call(translator, 'queryString', op.arg)
     else:
         raise com.UnsupportedOperationError(
-            f'Parse url with extract {extract} is not supported'
+            f'Parse url with extract {op.extract} is not supported'
         )
 
 
-def _index_of(translator, expr):
-    op = expr.op()
-
-    arg, arr = op.args
-    arg_formatted = translator.translate(arg)
-    arr_formatted = ','.join(map(translator.translate, arr))
-    return f"indexOf([{arr_formatted}], {arg_formatted}) - 1"
+def _index_of(translator, op):
+    needle_ = translator.translate(op.needle)
+    values_ = ','.join(map(translator.translate, op.values.values))
+    return f"indexOf([{values_}], {needle_}) - 1"
 
 
-def _sign(translator, expr):
+def _sign(translator, op):
     """Workaround for missing sign function"""
-    op = expr.op()
-    (arg,) = op.args
-    arg_ = translator.translate(arg)
+    arg_ = translator.translate(op.arg)
     return 'intDivOrZero({0}, abs({0}))'.format(arg_)
 
 
-def _round(translator, expr):
-    op = expr.op()
-    arg, digits = op.args
-
-    if digits is not None:
-        return _call(translator, 'round', arg, digits)
+def _round(translator, op):
+    if op.digits is not None:
+        return _call(translator, 'round', op.arg, op.digits)
     else:
-        return _call(translator, 'round', arg)
+        return _call(translator, 'round', op.arg)
 
 
-def _hash(translator, expr):
-    op = expr.op()
-    arg, how = op.args
-
+def _hash(translator, op):
     algorithms = {
         'MD5',
         'halfMD5',
@@ -303,73 +262,66 @@ def _hash(translator, expr):
         'sipHash128',
     }
 
-    if how not in algorithms:
+    if op.how not in algorithms:
         raise com.UnsupportedOperationError(
-            f'Unsupported hash algorithm {how}'
+            f'Unsupported hash algorithm {op.how}'
         )
 
-    return _call(translator, how, arg)
+    return _call(translator, op.how, op.arg)
 
 
-def _log(translator, expr):
-    op = expr.op()
-    arg, base = op.args
-
-    if base is None:
+def _log(translator, op):
+    if op.base is None:
         func = 'log'
-    elif base._arg.value == 2:
+    elif op.base.value == 2:
         func = 'log2'
-    elif base._arg.value == 10:
+    elif op.base.value == 10:
         func = 'log10'
     else:
-        raise ValueError(f'Base {base} for logarithm not supported!')
+        raise ValueError(f'Base {op.base} for logarithm not supported!')
 
-    return _call(translator, func, arg)
+    return _call(translator, func, op.arg)
 
 
-def _value_list(translator, expr):
-    op = expr.op()
+def _value_list(translator, op):
     values_ = map(translator.translate, op.values)
     return '({})'.format(', '.join(values_))
 
 
-def _interval_format(translator, expr):
-    dtype = expr.type()
+def _interval_format(translator, op):
+    dtype = op.output_dtype
     if dtype.unit in {'ms', 'us', 'ns'}:
         raise com.UnsupportedOperationError(
             "Clickhouse doesn't support subsecond interval resolutions"
         )
 
-    return f'INTERVAL {expr.op().value} {dtype.resolution.upper()}'
+    return f'INTERVAL {op.value} {dtype.resolution.upper()}'
 
 
-def _interval_from_integer(translator, expr):
-    op = expr.op()
-    arg, unit = op.args
-
-    dtype = expr.type()
+def _interval_from_integer(translator, op):
+    dtype = op.output_dtype
     if dtype.unit in {'ms', 'us', 'ns'}:
         raise com.UnsupportedOperationError(
             "Clickhouse doesn't support subsecond interval resolutions"
         )
 
-    arg_ = translator.translate(arg)
+    arg_ = translator.translate(op.arg)
     return f'INTERVAL {arg_} {dtype.resolution.upper()}'
 
 
-def _literal(translator, expr):
-    value = expr.op().value
-    if value is None and expr.type().nullable:
-        return _null_literal(translator, expr)
-    if isinstance(expr, ir.BooleanValue):
+def _literal(translator, op):
+    value = op.value
+    if value is None and op.output_dtype.nullable:
+        return _null_literal(translator, op)
+    if isinstance(op.output_dtype, dt.Boolean):
         return '1' if value else '0'
-    elif isinstance(expr, ir.StringValue):
+    elif isinstance(op.output_dtype, dt.String):
         return "'{!s}'".format(value.replace("'", "\\'"))
-    elif isinstance(expr, ir.NumericValue):
+    elif isinstance(op.output_dtype, (dt.Integer, dt.Decimal, dt.Floating)):
         return repr(value)
-    elif isinstance(expr, ir.IntervalValue):
-        return _interval_format(translator, expr)
-    elif isinstance(expr, ir.TimestampValue):
+    elif isinstance(op.output_dtype, dt.Interval):
+        return _interval_format(translator, op)
+    elif isinstance(op.output_dtype, dt.Timestamp):
         func = "toDateTime"
         args = []
 
@@ -388,27 +340,27 @@ def _literal(translator, expr):
         else:
             args.append(str(value))
 
-        if (timezone := expr.type().timezone) is not None:
+        if (timezone := op.output_dtype.timezone) is not None:
             args.append(timezone)
 
         joined_args = ", ".join(map(repr, args))
         return f"{func}({joined_args})"
 
-    elif isinstance(expr, ir.DateValue):
+    elif isinstance(op.output_dtype, dt.Date):
         if isinstance(value, date):
             value = value.strftime('%Y-%m-%d')
         return f"toDate('{value!s}')"
-    elif isinstance(expr, ir.ArrayValue):
+    elif isinstance(op.output_dtype, dt.Array):
         return str(list(_tuple_to_list(value)))
-    elif isinstance(expr, ir.SetScalar):
+    elif isinstance(op.output_dtype, dt.Set):
         return '({})'.format(', '.join(map(repr, value)))
-    elif isinstance(expr, ir.StructScalar):
+    elif isinstance(op.output_dtype, dt.Struct):
         fields = ", ".join(
-            f"{value} as `{key}`" for key, value in expr.op().value.items()
+            f"{value} as `{key}`" for key, value in op.value.items()
         )
         return f"tuple({fields})"
     else:
-        raise NotImplementedError(type(expr))
+        raise NotImplementedError(type(op))
 
 
 def _tuple_to_list(t: tuple):
@@ -429,7 +381,7 @@ class _CaseFormatter:
 
         # HACK
         self.indent = 2
-        self.multiline = len(cases) > 1
+        self.multiline = len(cases.values) > 1
         self.buf = StringIO()
 
     def _trans(self, expr):
@@ -443,7 +395,7 @@ class _CaseFormatter:
             base_str = self._trans(self.base)
             self.buf.write(f' {base_str}')
 
-        for case, result in zip(self.cases, self.results):
+        for case, result in zip(self.cases.values, self.results.values):
             self._next_case()
             case_str = self._trans(case)
             result_str = self._trans(result)
@@ -468,43 +420,34 @@ class _CaseFormatter:
             self.buf.write(' ')
 
 
-def _simple_case(translator, expr):
-    op = expr.op()
+def _simple_case(translator, op):
     formatter = _CaseFormatter(
         translator, op.base, op.cases, op.results, op.default
     )
     return formatter.get_result()
 
 
-def _searched_case(translator, expr):
-    op = expr.op()
+def _searched_case(translator, op):
     formatter = _CaseFormatter(
         translator, None, op.cases, op.results, op.default
     )
     return formatter.get_result()
 
 
-def _table_array_view(translator, expr):
+def _table_array_view(translator, op):
     ctx = translator.context
-    table = expr.op().table
-    query = ctx.get_compiled_expr(table)
+    query = ctx.get_compiled_expr(op.table)
     return f'(\n{util.indent(query, ctx.indent)}\n)'
 
 
-def _timestamp_from_unix(translator, expr):
-    op = expr.op()
-    arg, unit = op.args
+def _timestamp_from_unix(translator, op):
+    if op.unit in {'ms', 'us', 'ns'}:
+        raise ValueError(f'`{op.unit}` unit is not supported!')
 
-    if unit in {'ms', 'us', 'ns'}:
-        raise ValueError(f'`{unit}` unit is not supported!')
-
-    return _call(translator, 'toDateTime', arg)
+    return _call(translator, 'toDateTime', op.arg)
 
 
-def _truncate(translator, expr):
-    op = expr.op()
-    arg, unit = op.args
-
+def _truncate(translator, op):
     converters = {
         'Y': 'toStartOfYear',
         'M': 'toStartOfMonth',
@@ -516,17 +459,16 @@ def _truncate(translator, expr):
     }
 
     try:
-        converter = converters[unit]
+        converter = converters[op.unit]
     except KeyError:
         raise com.UnsupportedOperationError(
-            f'Unsupported truncate unit {unit}'
+            f'Unsupported truncate unit {op.unit}'
         )
 
-    return _call(translator, converter, arg)
+    return _call(translator, converter, op.arg)
 
 
-def _exists_subquery(translator, expr):
-    op = expr.op()
+def _exists_subquery(translator, op):
     ctx = translator.context
 
     dummy = ir.literal(1).name(ir.core.unnamed)
@@ -546,8 +488,7 @@ def _exists_subquery(translator, expr):
     return f'{key} (\n{util.indent(subquery, ctx.indent)}\n)'
 
 
-def _table_column(translator, expr):
-    op = expr.op()
+def _table_column(translator, op):
     field_name = op.name
     quoted_name = quote_identifier(field_name, force=True)
     table = op.table
@@ -567,48 +508,41 @@ def _table_column(translator, expr):
     return quoted_name
 
 
-def _string_split(translator, expr):
-    op = expr.op()
+def _string_split(translator, op):
     delim = translator.translate(op.delimiter)
     val = translator.translate(op.arg)
     return f"splitByString({delim}, CAST({val} AS String))"
 
 
-def _string_join(translator, expr):
-    sep, elements = expr.op().args
+def _string_join(translator, op):
+    sep, elements = op.args
     assert isinstance(
-        elements.op(), ops.ValueList
-    ), f'elements must be a ValueList, got {type(elements.op())}'
-    return 'arrayStringConcat([{}], {})'.format(
-        ', '.join(map(translator.translate, elements)),
-        translator.translate(sep),
-    )
+        elements, ops.ValueList
+    ), f'elements must be a ValueList, got {type(elements)}'
+    sep_ = translator.translate(sep)
+    elements_ = ', '.join(map(translator.translate, elements.values))
+    return f'arrayStringConcat([{elements_}], {sep_})'
 
 
-def _string_concat(translator, expr):
-    args = expr.op().arg
-    args_formatted = ", ".join(map(translator.translate, args))
+def _string_concat(translator, op):
+    args_formatted = ", ".join(map(translator.translate, op.arg.values))
     return f"arrayStringConcat([{args_formatted}])"
 
 
-def _string_like(translator, expr):
-    value, pattern = expr.op().args[:2]
+def _string_like(translator, op):
     return '{} LIKE {}'.format(
-        translator.translate(value), translator.translate(pattern)
+        translator.translate(op.arg), translator.translate(op.pattern)
     )
 
 
-def _string_ilike(translator, expr):
-    op = expr.op()
+def _string_ilike(translator, op):
     return 'lower({}) LIKE lower({})'.format(
         translator.translate(op.arg),
         translator.translate(op.pattern),
     )
 
 
-def _group_concat(translator, expr):
-    op = expr.op()
-
+def _group_concat(translator, op):
     arg = translator.translate(op.arg)
     sep = translator.translate(op.sep)
 
@@ -624,51 +558,46 @@ def _group_concat(translator, expr):
     return f"CASE WHEN empty({call}) THEN NULL ELSE {expr} END"
 
 
-def _string_right(translator, expr):
-    op = expr.op()
+def _string_right(translator, op):
     arg = translator.translate(op.arg)
     nchars = translator.translate(op.nchars)
     return f"substring({arg}, -({nchars}))"
 
 
-def _cotangent(translator, expr):
-    op = expr.op()
+def _cotangent(translator, op):
     arg = translator.translate(op.arg)
     return f"cos({arg}) / sin({arg})"
 
 
 def _bit_agg(func):
-    def compile(translator, expr):
-        op = expr.op()
-        raw_arg = op.arg
-        arg = translator.translate(raw_arg)
-        if not isinstance((type := raw_arg.type()), dt.UnsignedInteger):
+    def compile(translator, op):
+        arg_ = translator.translate(op.arg)
+        if not isinstance((type := op.arg.output_dtype), dt.UnsignedInteger):
             nbits = type._nbytes * 8
-            arg = f"reinterpretAsUInt{nbits}({arg})"
+            arg_ = f"reinterpretAsUInt{nbits}({arg_})"
 
         if (where := op.where) is not None:
-            return f"{func}If({arg}, {translator.translate(where)})"
+            return f"{func}If({arg_}, {translator.translate(where)})"
         else:
-            return f"{func}({arg})"
+            return f"{func}({arg_})"
 
     return compile
 
 
-def _array_column(translator, expr):
-    args = ", ".join(map(translator.translate, expr.op().cols))
+def _array_column(translator, op):
+    args = ", ".join(map(translator.translate, op.cols.values))
     return f"[{args}]"
 
 
-def _struct_column(translator, expr):
-    args = ", ".join(map(translator.translate, expr.op().values))
+def _struct_column(translator, op):
+    args = ", ".join(map(translator.translate, op.values))
     # ClickHouse struct types cannot be nullable
     # (non-nested fields can be nullable)
-    struct_type = serialize(expr.type()(nullable=False))
+    struct_type = serialize(op.output_dtype.copy(nullable=False))
     return f"CAST(({args}) AS {struct_type})"
 
 
-def _clip(translator, expr):
-    op = expr.op()
+def _clip(translator, op):
     arg = translator.translate(op.arg)
 
     if (upper := op.upper) is not None:
@@ -680,8 +609,7 @@ def _clip(translator, expr):
     return arg
 
 
-def _struct_field(translator, expr):
-    op = expr.op()
+def _struct_field(translator, op):
     return f"{translator.translate(op.arg)}.`{op.field}`"
 
 
@@ -851,34 +779,28 @@ operation_registry = {
 }
 
 
-def _raise_error(translator, expr, *args):
+def _raise_error(translator, op, *args):
     msg = "Clickhouse backend doesn't support {0} operation!"
-    op = expr.op()
     raise com.UnsupportedOperationError(msg.format(type(op)))
 
 
-def _null_literal(translator, expr):
+def _null_literal(translator, op):
     return 'Null'
 
 
-def _null_if_zero(translator, expr):
-    op = expr.op()
-    arg = op.args[0]
-    arg_ = translator.translate(arg)
+def _null_if_zero(translator, op):
+    arg_ = translator.translate(op.arg)
     return f'nullIf({arg_}, 0)'
 
 
-def _zero_if_null(translator, expr):
-    op = expr.op()
-    arg = op.args[0]
-    arg_ = translator.translate(arg)
+def _zero_if_null(translator, op):
+    arg_ = translator.translate(op.arg)
     return f'ifNull({arg_}, 0)'
 
 
-def _day_of_week_index(translator, expr):
-    (arg,) = expr.op().args
+def _day_of_week_index(translator, op):
     weekdays = 7
-    offset = f"toDayOfWeek({translator.translate(arg)})"
+    offset = f"toDayOfWeek({translator.translate(op.arg)})"
     return f"((({offset} - 1) % {weekdays:d}) + {weekdays:d}) % {weekdays:d}"
 
 

--- a/ibis/backends/clickhouse/tests/test_aggregations.py
+++ b/ibis/backends/clickhouse/tests/test_aggregations.py
@@ -30,7 +30,7 @@ def test_reduction_where(con, alltypes, translate, reduction, func_translated):
     cond = alltypes.bigint_col < 70
     expr = method(where=cond)
 
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
 
 
 def test_std_var_pop(con, alltypes, translate):
@@ -38,8 +38,10 @@ def test_std_var_pop(con, alltypes, translate):
     expr1 = alltypes.double_col.std(where=cond, how='pop')
     expr2 = alltypes.double_col.var(where=cond, how='pop')
 
-    assert translate(expr1) == 'stddevPopIf(`double_col`, `bigint_col` < 70)'
-    assert translate(expr2) == 'varPopIf(`double_col`, `bigint_col` < 70)'
+    assert (
+        translate(expr1.op()) == 'stddevPopIf(`double_col`, `bigint_col` < 70)'
+    )
+    assert translate(expr2.op()) == 'varPopIf(`double_col`, `bigint_col` < 70)'
     assert isinstance(con.execute(expr1), float)
     assert isinstance(con.execute(expr2), float)
 

--- a/ibis/backends/clickhouse/tests/test_identifiers.py
+++ b/ibis/backends/clickhouse/tests/test_identifiers.py
@@ -8,20 +8,11 @@ pytest.importorskip("clickhouse_driver")
 def test_column_ref_quoting(translate):
     schema = [('has a space', 'double')]
     table = ibis.table(schema)
-    assert translate(table['has a space']) == '`has a space`'
+    assert translate(table['has a space'].op()) == '`has a space`'
 
 
 def test_identifier_quoting(translate):
     schema = [('date', 'double'), ('table', 'string')]
     table = ibis.table(schema)
-    assert translate(table['date']) == '`date`'
-    assert translate(table['table']) == '`table`'
-
-
-# TODO: fix it
-# def test_named_expression(alltypes, translate):
-#     a, b = alltypes.get_columns(['int_col', 'float_col'])
-#     expr = ((a - b) * a).name('expr')
-
-#     expected = '(`int_col` - `float_col`) * `int_col` AS `expr`'
-#     assert translate(expr) == expected
+    assert translate(table['date'].op()) == '`date`'
+    assert translate(table['table'].op()) == '`table`'

--- a/ibis/backends/clickhouse/tests/test_literals.py
+++ b/ibis/backends/clickhouse/tests/test_literals.py
@@ -19,7 +19,7 @@ pytest.importorskip("clickhouse_driver")
 def test_timestamp_literals(con, translate, expr):
     expected = "toDateTime('2015-01-01T12:34:56')"
 
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
     assert con.execute(expr) == Timestamp('2015-01-01 12:34:56')
 
 
@@ -49,7 +49,7 @@ def test_timestamp_literals(con, translate, expr):
     ],
 )
 def test_subsecond_timestamp_literals(con, translate, expr, expected):
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
     assert con.execute(expr) == expr.op().value
 
 
@@ -63,7 +63,7 @@ def test_subsecond_timestamp_literals(con, translate, expr, expected):
 )
 def test_string_literals(con, translate, value, expected):
     expr = ibis.literal(value)
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
     # TODO clickhouse-driver escaping problem
     # assert con.execute(expr) == expected
 
@@ -71,12 +71,12 @@ def test_string_literals(con, translate, value, expected):
 @pytest.mark.parametrize(('value', 'expected'), [(5, '5'), (1.5, '1.5')])
 def test_number_literals(con, translate, value, expected):
     expr = ibis.literal(value)
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
     assert con.execute(expr) == value
 
 
 @pytest.mark.parametrize(('value', 'expected'), [(True, '1'), (False, '0')])
 def test_boolean_literals(con, translate, value, expected):
     expr = ibis.literal(value)
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
     assert con.execute(expr) == value

--- a/ibis/backends/clickhouse/tests/test_operators.py
+++ b/ibis/backends/clickhouse/tests/test_operators.py
@@ -69,7 +69,7 @@ def test_string_temporal_compare(con, op, left, right, type):
 def test_binary_infix_operators(con, alltypes, translate, op, expected):
     a, b = alltypes.int_col, alltypes.tinyint_col
     expr = op(a, b)
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
     assert len(con.execute(expr))
 
 
@@ -99,13 +99,13 @@ def test_binary_infix_parenthesization(con, alltypes, translate, op, expected):
     c = alltypes.double_col
 
     expr = op(a, b, c)
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
     assert len(con.execute(expr))
 
 
 def test_between(con, alltypes, translate):
     expr = alltypes.int_col.between(0, 10)
-    assert translate(expr) == '`int_col` BETWEEN 0 AND 10'
+    assert translate(expr.op()) == '`int_col` BETWEEN 0 AND 10'
     assert len(con.execute(expr))
 
 
@@ -148,11 +148,11 @@ def test_field_in_literals(con, alltypes, translate, container):
     expected = tuple(values)
 
     expr = alltypes.string_col.isin(foobar)
-    assert translate(expr) == f"`string_col` IN {expected}"
+    assert translate(expr.op()) == f"`string_col` IN {expected}"
     assert len(con.execute(expr))
 
     expr = alltypes.string_col.notin(foobar)
-    assert translate(expr) == f"`string_col` NOT IN {expected}"
+    assert translate(expr.op()) == f"`string_col` NOT IN {expected}"
     assert len(con.execute(expr))
 
 
@@ -160,7 +160,7 @@ def test_field_in_literals(con, alltypes, translate, container):
 def test_negate(con, alltypes, translate, column):
     # clickhouse represent boolean as UInt8
     expr = -getattr(alltypes, column)
-    assert translate(expr) == f'-`{column}`'
+    assert translate(expr.op()) == f'-`{column}`'
     assert len(con.execute(expr))
 
 
@@ -233,7 +233,7 @@ def test_simple_case(con, alltypes, translate):
   WHEN 'baz' THEN 'qux'
   ELSE 'default'
 END"""
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
     assert len(con.execute(expr))
 
 
@@ -252,7 +252,7 @@ def test_search_case(con, alltypes, translate):
   WHEN `float_col` < 0 THEN `int_col`
   ELSE 0
 END"""
-    assert translate(expr) == expected
+    assert translate(expr.op()) == expected
     assert len(con.execute(expr))
 
 

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -93,7 +93,16 @@ class Backend(BasePandasBackend):
         For the dask backend returns a dask graph that you can run ``.compute``
         on to get a pandas object.
         """
-        return execute_and_reset(query, params=params, **kwargs)
+        node = query.op()
+
+        if params is None:
+            params = {}
+        else:
+            params = {
+                k.op() if hasattr(k, 'op') else k: v for k, v in params.items()
+            }
+
+        return execute_and_reset(node, params=params, **kwargs)
 
     @classmethod
     def _supports_conversion(cls, obj: Any) -> bool:

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -114,7 +114,6 @@ from multipledispatch import Dispatcher
 
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
-import ibis.expr.types as ir
 from ibis.backends.dask.dispatch import (
     execute_literal,
     execute_node,
@@ -135,8 +134,10 @@ from ibis.expr.typing import TimeContext
 is_computable_input.register(dd.core.Scalar)(is_computable_input_arg)
 
 
+# TODO(kszucs): should deduplicate with pandas code since it is an exact copy
+# of pandas.execute_with_scope()
 def execute_with_scope(
-    expr,
+    node,
     scope: Scope,
     timecontext: Optional[TimeContext] = None,
     aggcontext=None,
@@ -147,8 +148,8 @@ def execute_with_scope(
 
     Parameters
     ----------
-    expr : ibis.expr.types.Expr
-        The expression to execute.
+    node : ibis.expr.operations.Node
+        The operation node to execute.
     scope : Scope
         A Scope class, with dictionary mapping
         :class:`~ibis.expr.operations.Node` subclass instances to concrete
@@ -163,19 +164,17 @@ def execute_with_scope(
     -------
     result : scalar, pd.Series, pd.DataFrame
     """
-    op = expr.op()
-
     # Call pre_execute, to allow clients to intercept the expression before
     # computing anything *and* before associating leaf nodes with data. This
     # allows clients to provide their own data for each leaf.
     if clients is None:
-        clients = expr._find_backends()
+        clients = node.to_expr()._find_backends()
 
     if aggcontext is None:
         aggcontext = agg_ctx.Summarize()
 
     pre_executed_scope = pre_execute(
-        op,
+        node,
         *clients,
         scope=scope,
         timecontext=timecontext,
@@ -184,7 +183,7 @@ def execute_with_scope(
     )
     new_scope = scope.merge_scope(pre_executed_scope)
     result = execute_until_in_scope(
-        expr,
+        node,
         new_scope,
         timecontext=timecontext,
         aggcontext=aggcontext,
@@ -201,13 +200,15 @@ def execute_with_scope(
             **kwargs,
         ),
         **kwargs,
-    ).get_value(op, timecontext)
+    ).get_value(node, timecontext)
     return result
 
 
+# TODO(kszucs): should deduplicate with pandas code since it is an exact copy
+# of pandas.execute_until_in_scope()
 @trace
 def execute_until_in_scope(
-    expr,
+    node,
     scope: Scope,
     timecontext: Optional[TimeContext] = None,
     aggcontext=None,
@@ -219,7 +220,7 @@ def execute_until_in_scope(
 
     Parameters
     ----------
-    expr : ibis.expr.types.Expr
+    node : ibis.expr.operations.Node
     scope : Scope
     timecontext : Optional[TimeContext]
     aggcontext : Optional[AggregationContext]
@@ -233,16 +234,19 @@ def execute_until_in_scope(
 
     # base case: our op has been computed (or is a leaf data node), so
     # return the corresponding value
-    op = expr.op()
-    if scope.get_value(op, timecontext) is not None:
+    if scope.get_value(node, timecontext) is not None:
         return scope
-    if isinstance(op, ops.Literal):
+    if isinstance(node, ops.Literal):
         # special case literals to avoid the overhead of dispatching
         # execute_node
         return Scope(
             {
-                op: execute_literal(
-                    op, op.value, expr.type(), aggcontext=aggcontext, **kwargs
+                node: execute_literal(
+                    node,
+                    node.value,
+                    node.output_dtype,
+                    aggcontext=aggcontext,
+                    **kwargs,
                 )
             },
             timecontext,
@@ -251,13 +255,13 @@ def execute_until_in_scope(
     # figure out what arguments we're able to compute on based on the
     # expressions inputs. things like expressions, None, and scalar types are
     # computable whereas ``list``s are not
-    computable_args = [arg for arg in op.inputs if is_computable_input(arg)]
+    computable_args = [arg for arg in node.inputs if is_computable_input(arg)]
 
     # pre_executed_states is a list of states with same the length of
     # computable_args, these states are passed to each arg
     if timecontext:
         arg_timecontexts = compute_time_context(
-            op,
+            node,
             num_args=len(computable_args),
             timecontext=timecontext,
             clients=clients,
@@ -267,7 +271,7 @@ def execute_until_in_scope(
         arg_timecontexts = [None] * len(computable_args)
 
     pre_executed_scope = pre_execute(
-        op,
+        node,
         *clients,
         scope=scope,
         timecontext=timecontext,
@@ -279,7 +283,7 @@ def execute_until_in_scope(
 
     # Short circuit: if pre_execute puts op in scope, then we don't need to
     # execute its computable_args
-    if new_scope.get_value(op, timecontext) is not None:
+    if new_scope.get_value(node, timecontext) is not None:
         return new_scope
 
     # recursively compute each node's arguments until we've changed type.
@@ -289,7 +293,7 @@ def execute_until_in_scope(
     if len(arg_timecontexts) != len(computable_args):
         raise com.IbisError(
             'arg_timecontexts differ with computable_arg in length '
-            f'for type:\n{type(op).__name__}.'
+            f'for type:\n{type(node).__name__}.'
         )
 
     scopes = [
@@ -302,7 +306,7 @@ def execute_until_in_scope(
             clients=clients,
             **kwargs,
         )
-        if hasattr(arg, 'op')
+        if isinstance(arg, ops.Node)
         else Scope({arg: arg}, timecontext)
         for (arg, timecontext) in zip(computable_args, arg_timecontexts)
     ]
@@ -310,7 +314,7 @@ def execute_until_in_scope(
     # if we're unable to find data then raise an exception
     if not scopes and computable_args:
         raise com.UnboundExpressionError(
-            f'Unable to find data for expression:\n{repr(expr)}'
+            f'Unable to find data for node:\n{repr(node)}'
         )
 
     # there should be exactly one dictionary per computable argument
@@ -319,14 +323,14 @@ def execute_until_in_scope(
     new_scope = new_scope.merge_scopes(scopes)
     # pass our computed arguments to this node's execute_node implementation
     data = [
-        new_scope.get_value(arg.op(), timecontext)
-        if hasattr(arg, 'op')
+        new_scope.get_value(arg, timecontext)
+        if isinstance(arg, ops.Node)
         else arg
         for (arg, timecontext) in zip(computable_args, arg_timecontexts)
     ]
 
     result = execute_node(
-        op,
+        node,
         *data,
         scope=scope,
         timecontext=timecontext,
@@ -334,17 +338,17 @@ def execute_until_in_scope(
         clients=clients,
         **kwargs,
     )
-    computed = post_execute_(op, result, timecontext=timecontext)
-    return Scope({op: computed}, timecontext)
+    computed = post_execute_(node, result, timecontext=timecontext)
+    return Scope({node: computed}, timecontext)
 
 
 execute = Dispatcher('execute')
 
 
-@execute.register(ir.Expr)
+@execute.register(ops.Node)
 @trace
 def main_execute(
-    expr,
+    node,
     params=None,
     scope=None,
     timecontext: Optional[TimeContext] = None,
@@ -357,9 +361,9 @@ def main_execute(
 
     Parameters
     ----------
-    expr : ibis.expr.types.Expr
-        The expression to execute
-    params : Mapping[ibis.expr.types.Expr, object]
+    node : ibis.expr.operations.Node
+        The operation node to execute
+    params : Mapping[ibis.expr.operations.Node, object]
         The data that an unbound parameter in `expr` maps to
     scope : Mapping[ibis.expr.operations.Node, object]
         Additional scope, mapping ibis operations to data
@@ -403,7 +407,7 @@ def main_execute(
     params = {k.op() if hasattr(k, 'op') else k: v for k, v in params.items()}
     scope = scope.merge_scope(Scope(params, timecontext))
     return execute_with_scope(
-        expr,
+        node,
         scope,
         timecontext=timecontext,
         aggcontext=aggcontext,
@@ -413,7 +417,7 @@ def main_execute(
 
 
 def execute_and_reset(
-    expr,
+    node,
     params=None,
     scope=None,
     timecontext: Optional[TimeContext] = None,
@@ -429,9 +433,9 @@ def execute_and_reset(
     an index.
     Parameters
     ----------
-    expr : ibis.expr.types.Expr
-        The expression to execute
-    params : Mapping[ibis.expr.types.Expr, object]
+    node : ibis.expr.operations.Node
+        The operation node to execute
+    params : Mapping[ibis.expr.operations.Node, object]
         The data that an unbound parameter in `expr` maps to
     scope : Mapping[ibis.expr.operations.Node, object]
         Additional scope, mapping ibis operations to data
@@ -457,7 +461,7 @@ def execute_and_reset(
         * If no data are bound to the input expression
     """
     result = execute(
-        expr,
+        node,
         params=params,
         scope=scope,
         timecontext=timecontext,
@@ -467,9 +471,8 @@ def execute_and_reset(
     # Note - if `result` has npartitions > 1 `reset_index` will not create
     # a monotonically increasing index.
     if isinstance(result, dd.DataFrame):
-        schema = expr.schema()
         df = result.reset_index()
-        return df[list(schema.names)]
+        return df[list(node.schema.names)]
     elif isinstance(result, dd.Series):
         return result.reset_index(drop=True)
     return result

--- a/ibis/backends/dask/execution/aggregations.py
+++ b/ibis/backends/dask/execution/aggregations.py
@@ -67,27 +67,24 @@ def execute_aggregation_dataframe(
     columns = {}
 
     if by:
-        grouping_key_pairs = list(
-            zip(by, map(operator.methodcaller('op'), by))
-        )
         grouping_keys = [
-            by_op.name
-            if isinstance(by_op, ops.TableColumn)
+            key.name
+            if isinstance(key, ops.TableColumn)
             else execute(
-                by, scope=scope, timecontext=timecontext, **kwargs
-            ).rename(by.get_name())
-            for by, by_op in grouping_key_pairs
+                key, scope=scope, timecontext=timecontext, **kwargs
+            ).rename(key.resolve_name())
+            for key in by
         ]
         columns.update(
-            (by_op.name, by.get_name())
-            for by, by_op in grouping_key_pairs
-            if hasattr(by_op, 'name')
+            (key.name, key.resolve_name())
+            for key in by
+            if hasattr(key, 'name')
         )
         source = data.groupby(grouping_keys)
     else:
         source = data
 
-    scope = scope.merge_scope(Scope({op.table.op(): source}, timecontext))
+    scope = scope.merge_scope(Scope({op.table: source}, timecontext))
 
     pieces = []
     for metric in metrics:

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -226,7 +226,7 @@ def execute_cast_series_group_by(op, data, type, **kwargs):
 @execute_node.register(ops.Cast, dd.Series, dt.Timestamp)
 def execute_cast_series_timestamp(op, data, type, **kwargs):
     arg = op.arg
-    from_type = arg.type()
+    from_type = arg.output_dtype
 
     if from_type.equals(type):  # noop cast
         return data
@@ -257,7 +257,7 @@ def execute_cast_series_timestamp(op, data, type, **kwargs):
 @execute_node.register(ops.Cast, dd.Series, dt.Date)
 def execute_cast_series_date(op, data, type, **kwargs):
     arg = op.args[0]
-    from_type = arg.type()
+    from_type = arg.output_dtype
 
     if from_type.equals(type):
         return data

--- a/ibis/backends/dask/execution/join.py
+++ b/ibis/backends/dask/execution/join.py
@@ -1,5 +1,3 @@
-import operator
-
 import dask.dataframe as dd
 from pandas import Timedelta
 
@@ -93,11 +91,8 @@ def execute_join(op, left, right, predicates, **kwargs):
     except KeyError:
         raise NotImplementedError(f'{op_type.__name__} not supported')
 
-    left_op = op.left.op()
-    right_op = op.right.op()
-
-    on = {left_op: [], right_op: []}
-    for predicate in map(operator.methodcaller('op'), predicates):
+    on = {op.left: [], op.right: []}
+    for predicate in predicates:
         if not isinstance(predicate, ops.Equals):
             raise TypeError(
                 'Only equality join predicates supported with dask'
@@ -116,8 +111,8 @@ def execute_join(op, left, right, predicates, **kwargs):
         left,
         right,
         how=how,
-        left_on=on[left_op],
-        right_on=on[right_op],
+        left_on=on[op.left],
+        right_on=on[op.right],
         suffixes=constants.JOIN_SUFFIXES,
     )
     return df

--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -12,7 +12,6 @@ from toolz import concatv
 
 import ibis.expr.analysis as an
 import ibis.expr.operations as ops
-import ibis.expr.types as ir
 from ibis.backends.dask.core import execute
 from ibis.backends.dask.dispatch import execute_node
 from ibis.backends.dask.execution.util import (
@@ -23,103 +22,122 @@ from ibis.backends.dask.execution.util import (
 )
 from ibis.backends.pandas.execution.selection import (
     build_df_from_selection,
-    compute_projection,
-    compute_projection_table_expr,
     map_new_column_names_to_data,
     remap_overlapping_column_names,
 )
 from ibis.backends.pandas.execution.util import get_join_suffix_for_op
+from ibis.expr.rules import Shape
 from ibis.expr.scope import Scope
 from ibis.expr.typing import TimeContext
 
 
-@compute_projection.register(ir.Scalar, ops.Selection, dd.DataFrame)
-def compute_projection_scalar_expr(
-    expr,
+# TODO(kszucs): deduplicate with pandas.compute_projection() since it is almost
+# an exact copy of that function
+def compute_projection(
+    node,
     parent,
     data,
-    scope: Scope,
+    scope: Scope = None,
     timecontext: Optional[TimeContext] = None,
     **kwargs,
 ):
-    name = expr.get_name()
-    assert name is not None, 'Scalar selection name is None'
+    """
+    Compute a projection.
 
-    parent_table_op = parent.table.op()
+    Parameters
+    ----------
+    node : Union[ops.Scalar, ops.Column, ops.TableNode]
+    parent : ops.Selection
+    data : pd.DataFrame
+    scope : Scope
+    timecontext:Optional[TimeContext]
 
-    data_columns = frozenset(data.columns)
-    scope = scope.merge_scopes(
-        Scope(
-            {
-                t: map_new_column_names_to_data(
-                    remap_overlapping_column_names(
-                        parent_table_op, t, data_columns
-                    ),
-                    data,
-                )
-            },
-            timecontext,
+    Returns
+    -------
+    value : scalar, pd.Series, pd.DataFrame
+
+    Notes
+    -----
+    :class:`~ibis.expr.types.Scalar` instances occur when a specific column
+    projection is a window operation.
+    """
+    if isinstance(node, ops.TableNode):
+        if node == parent.table:
+            return data
+
+        assert isinstance(parent.table, ops.Join)
+        assert node == parent.table.left or node == parent.table.right
+
+        mapping = remap_overlapping_column_names(
+            parent.table,
+            root_table=node,
+            data_columns=frozenset(data.columns),
         )
-        for t in an.find_immediate_parent_tables(expr)
-    )
-    scalar = execute(expr, scope=scope, **kwargs)
-    return data.assign(**{name: scalar})[name]
+        return map_new_column_names_to_data(mapping, data)
+    elif isinstance(node, ops.Value):
+        name = node.resolve_name()
+        assert name is not None, 'Value selection name is None'
 
+        if node.output_shape is Shape.SCALAR:
+            data_columns = frozenset(data.columns)
 
-@compute_projection.register(ir.Column, ops.Selection, dd.DataFrame)
-def compute_projection_column_expr(
-    expr,
-    parent,
-    data,
-    scope: Scope,
-    timecontext: Optional[TimeContext],
-    **kwargs,
-):
-    result_name = expr._safe_name
-    op = expr.op()
-    parent_table_op = parent.table.op()
+            if scope is None:
+                scope = Scope()
 
-    if isinstance(op, ops.TableColumn):
-        # slightly faster path for simple column selection
-        name = op.name
-
-        if name in data:
-            return data[name].rename(result_name or name)
-
-        if not isinstance(parent_table_op, ops.Join):
-            raise KeyError(name)
-        suffix = get_join_suffix_for_op(op, parent_table_op)
-        return data.loc[:, name + suffix].rename(result_name or name)
-
-    data_columns = frozenset(data.columns)
-
-    scope = scope.merge_scopes(
-        Scope(
-            {
-                t: map_new_column_names_to_data(
-                    remap_overlapping_column_names(
-                        parent_table_op, t, data_columns
-                    ),
-                    data,
+            scope = scope.merge_scopes(
+                Scope(
+                    {
+                        t: map_new_column_names_to_data(
+                            remap_overlapping_column_names(
+                                parent.table, t, data_columns
+                            ),
+                            data,
+                        )
+                    },
+                    timecontext,
                 )
-            },
-            timecontext,
-        )
-        for t in an.find_immediate_parent_tables(expr)
-    )
+                for t in an.find_immediate_parent_tables(node)
+            )
+            scalar = execute(node, scope=scope, **kwargs)
+            return data.assign(**{name: scalar})[name]
+        else:
+            if isinstance(node, ops.TableColumn):
+                if name in data:
+                    return data[name].rename(name)
 
-    result = execute(expr, scope=scope, timecontext=timecontext, **kwargs)
-    result = coerce_to_output(result, expr, data.index)
-    return result
+                if not isinstance(parent.table, ops.Join):
+                    raise KeyError(name)
 
+                suffix = get_join_suffix_for_op(node, parent.table)
+                return data.loc[:, name + suffix].rename(name)
 
-compute_projection.register(ir.Table, ops.Selection, dd.DataFrame)(
-    compute_projection_table_expr
-)
+            data_columns = frozenset(data.columns)
+
+            scope = scope.merge_scopes(
+                Scope(
+                    {
+                        t: map_new_column_names_to_data(
+                            remap_overlapping_column_names(
+                                parent.table, t, data_columns
+                            ),
+                            data,
+                        )
+                    },
+                    timecontext,
+                )
+                for t in an.find_immediate_parent_tables(node)
+            )
+
+            result = execute(
+                node, scope=scope, timecontext=timecontext, **kwargs
+            )
+            return coerce_to_output(result, node, data.index)
+    else:
+        raise TypeError(node)
 
 
 def build_df_from_projection(
-    selection_exprs: List[ir.Expr],
+    selections: List[ops.Node],
     op: ops.Selection,
     data: dd.DataFrame,
     **kwargs,
@@ -129,11 +147,11 @@ def build_df_from_projection(
     for each expression.
     """
     # Fast path for when we're assigning columns into the same table.
-    if (selection_exprs[0] is op.table) and all(
-        is_row_order_preserving(selection_exprs[1:])
+    if (selections[0] is op.table) and all(
+        is_row_order_preserving(selections[1:])
     ):
-        for expr in selection_exprs[1:]:
-            projection = compute_projection(expr, op, data, **kwargs)
+        for node in selections[1:]:
+            projection = compute_projection(node, op, data, **kwargs)
             if isinstance(projection, dd.Series):
                 data = data.assign(**{projection.name: projection})
             else:
@@ -147,8 +165,7 @@ def build_df_from_projection(
     # used in dd.concat to merge the pieces back together.
     data = add_partitioned_sorted_column(data)
     data_pieces = [
-        compute_projection(expr, op, data, **kwargs)
-        for expr in selection_exprs
+        compute_projection(node, op, data, **kwargs) for node in selections
     ]
 
     return dd.concat(data_pieces, axis=1).reset_index(drop=True)
@@ -170,8 +187,8 @@ def execute_selection_dataframe(
     if selections:
         # if we are just performing select operations we can do a direct
         # selection
-        if all(isinstance(s.op(), ops.TableColumn) for s in selections):
-            result = build_df_from_selection(selections, data, op.table.op())
+        if all(isinstance(s, ops.TableColumn) for s in selections):
+            result = build_df_from_selection(selections, data, op.table)
         else:
             result = build_df_from_projection(
                 selections,
@@ -184,7 +201,7 @@ def execute_selection_dataframe(
 
     if predicates:
         predicates = _compute_predicates(
-            op.table.op(), predicates, data, scope, timecontext, **kwargs
+            op.table, predicates, data, scope, timecontext, **kwargs
         )
         predicate = functools.reduce(operator.and_, predicates)
         result = result.loc[predicate]
@@ -197,7 +214,7 @@ def execute_selection_dataframe(
                 """
             )
         sort_key = sort_keys[0]
-        ascending = getattr(sort_key.op(), 'ascending', True)
+        ascending = getattr(sort_key, 'ascending', True)
         if not ascending:
             raise NotImplementedError(
                 "Descending sort is not supported for the Dask backend"

--- a/ibis/backends/dask/tests/execution/test_cast.py
+++ b/ibis/backends/dask/tests/execution/test_cast.py
@@ -92,8 +92,8 @@ def test_cast_timestamp_column(t, df, column, to, expected):
 def test_cast_timestamp_scalar_naive(to, expected):
     literal_expr = ibis.literal(Timestamp(TIMESTAMP))
     value = literal_expr.cast(to)
-    result = execute(value)
-    raw = execute(literal_expr)
+    result = execute(value.op())
+    raw = execute(literal_expr.op())
     assert result == expected(raw)
 
 
@@ -113,8 +113,8 @@ def test_cast_timestamp_scalar_naive(to, expected):
 def test_cast_timestamp_scalar(to, expected, tz):
     literal_expr = ibis.literal(Timestamp(TIMESTAMP).tz_localize(tz))
     value = literal_expr.cast(to)
-    result = execute(value)
-    raw = execute(literal_expr)
+    result = execute(value.op())
+    raw = execute(literal_expr.op())
     assert result == expected(raw)
 
 

--- a/ibis/backends/dask/tests/execution/test_functions.py
+++ b/ibis/backends/dask/tests/execution/test_functions.py
@@ -205,5 +205,5 @@ def test_ifelse_returning_bool():
     true = ibis.literal(True)
     false = ibis.literal(False)
     expr = ibis.ifelse(one + one == two, true, false)
-    result = execute(expr)
+    result = execute(expr.op())
     assert result is True

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -416,7 +416,7 @@ def test_null_if_zero(t, df, column):
 )
 def test_nullif(t, df, left, right, expected, compare):
     expr = left(t).nullif(right(t))
-    result = execute(expr)
+    result = execute(expr.op())
     if isinstance(result, (dd.Series, dd.DataFrame)):
         compare(result.compute(), expected(df).compute())
     else:

--- a/ibis/backends/dask/tests/execution/test_structs.py
+++ b/ibis/backends/dask/tests/execution/test_structs.py
@@ -56,11 +56,11 @@ def test_struct_field_literal(value):
     )
 
     expr = struct['fruit']
-    result = execute(expr)
+    result = execute(expr.op())
     assert result == "pear"
 
     expr = struct['weight']
-    result = execute(expr)
+    result = execute(expr.op())
     assert result == 0
 
 

--- a/ibis/backends/dask/tests/execution/test_temporal.py
+++ b/ibis/backends/dask/tests/execution/test_temporal.py
@@ -56,7 +56,7 @@ def test_timestamp_functions(case_func, expected_func):
     )
     result = case_func(v)
     expected = expected_func(vt)
-    assert execute(result) == expected
+    assert execute(result.op()) == expected
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -56,7 +56,7 @@ def test_pre_execute_basic():
 
     one = ibis.literal(1)
     expr = one + one
-    result = execute(expr)
+    result = execute(expr.op())
     assert result == 4
 
     del pre_execute.funcs[(ops.Add,)]
@@ -66,7 +66,7 @@ def test_pre_execute_basic():
 
 def test_execute_parameter_only():
     param = ibis.param('int64')
-    result = execute(param, params={param: 42})
+    result = execute(param.op(), params={param.op(): 42})
     assert result == 42
 
 
@@ -74,7 +74,7 @@ def test_missing_data_sources():
     t = ibis.table([('a', 'string')])
     expr = t.a.length()
     with pytest.raises(com.UnboundExpressionError):
-        execute(expr)
+        execute(expr.op())
 
 
 def test_missing_data_on_custom_client():
@@ -156,7 +156,7 @@ def test_is_computable_input():
 
     three = one + two
     four = three + 1
-    result = execute(four)
+    result = execute(four.op())
     assert result == 4.0
 
     del execute_node[ops.Add, int, MyObject]

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -173,7 +173,7 @@ class Backend(BaseBackend):
             table = _to_pyarrow_table(frame)
             return table['tmp'].to_pandas()
         elif isinstance(expr, ir.Scalar):
-            if an.find_immediate_parent_tables(expr):
+            if an.find_immediate_parent_tables(expr.op()):
                 # there are associated datafusion tables so convert the expr
                 # to a selection which we can directly convert to a datafusion
                 # plan
@@ -197,7 +197,7 @@ class Backend(BaseBackend):
         params: Mapping[ir.Expr, object] = None,
         **kwargs: Any,
     ):
-        return translate(expr)
+        return translate(expr.op())
 
     @classmethod
     @lru_cache

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -22,8 +22,8 @@ operation_registry = {
 }
 
 
-def _round(t, expr):
-    arg, digits = expr.op().args
+def _round(t, op):
+    arg, digits = op.args
     sa_arg = t.translate(arg)
 
     if digits is None:
@@ -42,8 +42,8 @@ def _generic_log(arg, base):
     return sa.func.ln(arg) / sa.func.ln(base)
 
 
-def _log(t, expr):
-    arg, base = expr.op().args
+def _log(t, op):
+    arg, base = op.args
     sa_arg = t.translate(arg)
     if base is not None:
         sa_base = t.translate(base)
@@ -57,8 +57,7 @@ def _log(t, expr):
     return sa.func.ln(sa_arg)
 
 
-def _timestamp_from_unix(t, expr):
-    op = expr.op()
+def _timestamp_from_unix(t, op):
     arg, unit = op.args
     arg = t.translate(arg)
 
@@ -71,10 +70,9 @@ def _timestamp_from_unix(t, expr):
         return sa.func.to_timestamp(arg)
 
 
-def _literal(_, expr):
-    dtype = expr.type()
+def _literal(_, op):
+    dtype = op.output_dtype
     sqla_type = to_sqla_type(dtype)
-    op = expr.op()
     value = op.value
 
     if isinstance(dtype, dt.Interval):
@@ -98,7 +96,7 @@ def _literal(_, expr):
                     for i, val in enumerate(value.values())
                 )
             )
-            name = expr.get_name() if expr.has_name() else "tmp"
+            name = op.resolve_name() if op.has_resolved_name() else "tmp"
             params = {name: to_sqla_type(dtype)}
             return bound_text.columns(**params).scalar_subquery()
         raise NotImplementedError(
@@ -109,23 +107,24 @@ def _literal(_, expr):
     return sa.cast(sa.literal(value), sqla_type)
 
 
-def _array_column(t, expr):
-    (arg,) = expr.op().args
-    sqla_type = to_sqla_type(expr.type())
-    return sa.cast(sa.func.list_value(*map(t.translate, arg)), sqla_type)
-
-
-def _struct_field(t, expr):
-    op = expr.op()
-    return sa.func.struct_extract(
-        t.translate(op.arg),
-        sa.text(repr(op.field)),
-        type_=to_sqla_type(expr.type()),
+def _array_column(t, op):
+    (arg,) = op.args
+    sqla_type = to_sqla_type(op.output_dtype)
+    return sa.cast(
+        sa.func.list_value(*map(t.translate, arg.values)), sqla_type
     )
 
 
-def _regex_extract(t, expr):
-    string, pattern, index = map(t.translate, expr.op().args)
+def _struct_field(t, op):
+    return sa.func.struct_extract(
+        t.translate(op.arg),
+        sa.text(repr(op.field)),
+        type_=to_sqla_type(op.output_dtype),
+    )
+
+
+def _regex_extract(t, op):
+    string, pattern, index = map(t.translate, op.args)
     result = sa.case(
         [
             (
@@ -150,10 +149,9 @@ def _regex_extract(t, expr):
     return result
 
 
-def _strftime(t, expr):
-    op = expr.op()
+def _strftime(t, op):
     format_str = op.format_str
-    if not isinstance(format_str_op := format_str.op(), ops.Literal):
+    if not isinstance(format_str_op := format_str, ops.Literal):
         raise TypeError(
             "DuckDB format_str must be a literal `str`; "
             f"got {type(format_str)}"
@@ -163,26 +161,24 @@ def _strftime(t, expr):
     )
 
 
-def _arbitrary(t, expr):
-    if (how := expr.op().how) == "heavy":
+def _arbitrary(t, op):
+    if (how := op.how) == "heavy":
         raise ValueError(f"how={how!r} not supported in the DuckDB backend")
-    return t._reduction(getattr(sa.func, how), expr)
+    return t._reduction(getattr(sa.func, how), op)
 
 
-def _string_agg(t, expr):
-    op = expr.op()
-    if not isinstance(lit := op.sep.op(), ops.Literal):
+def _string_agg(t, op):
+    if not isinstance(op.sep, ops.Literal):
         raise TypeError(
             "Separator argument to group_concat operation must be a constant"
         )
-    agg = sa.func.string_agg(t.translate(op.arg), sa.text(repr(lit.value)))
+    agg = sa.func.string_agg(t.translate(op.arg), sa.text(repr(op.sep.value)))
     if (where := op.where) is not None:
         return agg.filter(t.translate(where))
     return agg
 
 
-def _struct_column(t, expr):
-    op = expr.op()
+def _struct_column(t, op):
     compile_kwargs = dict(literal_binds=True)
     translated_pairs = (
         (name, t.translate(value).compile(compile_kwargs=compile_kwargs))

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -857,7 +857,10 @@ class Backend(BaseSQLBackend):
         t = self.table(qualified_name)
         if not persist:
             self._temp_objects.add(
-                weakref.finalize(t, self._drop_table, qualified_name)
+                # weakref the op instead of the expression because the table is
+                # potentially collected after subsequent use when `_erase_expr`
+                # unwraps the Expr layer
+                weakref.finalize(t.op(), self._drop_table, qualified_name)
             )
 
         # Compute number of rows in table for better default query planning

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -29,9 +29,8 @@ rewrites = ImpalaExprTranslator.rewrites
 
 
 @rewrites(ops.FloorDivide)
-def _floor_divide(expr):
-    left, right = expr.op().args
-    return left.div(right).floor()
+def _floor_divide(op):
+    return ops.Floor(ops.Divide(op.left, op.right))
 
 
 class ImpalaCompiler(Compiler):

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -470,7 +470,7 @@ TBLPROPERTIES (
 def translate(expr, context=None, named=False):
     if context is None:
         context = ImpalaCompiler.make_context()
-    translator = ImpalaExprTranslator(expr, context=context, named=named)
+    translator = ImpalaExprTranslator(expr.op(), context=context, named=named)
     return translator.get_result()
 
 

--- a/ibis/backends/impala/tests/test_case_exprs.py
+++ b/ibis/backends/impala/tests/test_case_exprs.py
@@ -108,12 +108,12 @@ def test_nullif_ifnull(tpch_lineitem, expr_fn, expected):
     [
         pytest.param(
             lambda t: t.l_quantity.fillna(0),
-            'isnull(`l_quantity`, CAST(0 AS decimal(12, 2)))',
+            'isnull(`l_quantity`, 0)',
             id="fillna_l_quantity",
         ),
         pytest.param(
             lambda t: t.l_extendedprice.fillna(0),
-            'isnull(`l_extendedprice`, CAST(0 AS decimal(12, 2)))',
+            'isnull(`l_extendedprice`, 0)',
             id="fillna_l_extendedprice",
         ),
         pytest.param(

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -213,4 +213,14 @@ class Backend(BasePandasBackend):
                     type(query).__name__
                 )
             )
-        return execute_and_reset(query, params=params, **kwargs)
+
+        node = query.op()
+
+        if params is None:
+            params = {}
+        else:
+            params = {
+                k.op() if hasattr(k, 'op') else k: v for k, v in params.items()
+            }
+
+        return execute_and_reset(node, params=params, **kwargs)

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -119,7 +119,7 @@ def execute_cast_series_array(op, data, type, **kwargs):
 @execute_node.register(ops.Cast, pd.Series, dt.Timestamp)
 def execute_cast_series_timestamp(op, data, type, **kwargs):
     arg = op.arg
-    from_type = arg.type()
+    from_type = arg.output_dtype
 
     if from_type.equals(type):  # noop cast
         return data
@@ -152,7 +152,7 @@ def _normalize(values, original_index, name, timezone=None):
 @execute_node.register(ops.Cast, pd.Series, dt.Date)
 def execute_cast_series_date(op, data, type, **kwargs):
     arg = op.args[0]
-    from_type = arg.type()
+    from_type = arg.output_dtype
 
     if from_type.equals(type):
         return data
@@ -475,27 +475,24 @@ def execute_aggregation_dataframe(
     columns: Dict[str, str] = {}
 
     if op.by:
-        grouping_key_pairs = list(
-            zip(by, map(operator.methodcaller('op'), by))
-        )
         grouping_keys = [
-            by_op.name
-            if isinstance(by_op, ops.TableColumn)
+            key.name
+            if isinstance(key, ops.TableColumn)
             else execute(
-                by, scope=scope, timecontext=timecontext, **kwargs
-            ).rename(by.get_name())
-            for by, by_op in grouping_key_pairs
+                key, scope=scope, timecontext=timecontext, **kwargs
+            ).rename(key.resolve_name())
+            for key in by
         ]
         columns.update(
-            (by_op.name, by.get_name())
-            for by, by_op in grouping_key_pairs
-            if hasattr(by_op, 'name')
+            (key.name, key.resolve_name())
+            for key in by
+            if hasattr(key, 'name')
         )
         source = data.groupby(grouping_keys)
     else:
         source = data
 
-    scope = scope.merge_scope(Scope({op.table.op(): source}, timecontext))
+    scope = scope.merge_scope(Scope({op.table: source}, timecontext))
 
     pieces = [
         coerce_to_output(
@@ -1143,7 +1140,7 @@ def execute_node_log_number_number(op, value, base, **kwargs):
 
 @execute_node.register(ops.DropNa, pd.DataFrame, tuple)
 def execute_node_dropna_dataframe(op, df, subset, **kwargs):
-    subset = [col.get_name() for col in subset] if subset else None
+    subset = [col.resolve_name() for col in subset] if subset else None
     return df.dropna(how=op.how, subset=subset)
 
 
@@ -1305,7 +1302,7 @@ def execute_table_array_view(op, _, **kwargs):
 
 @execute_node.register(ops.ZeroIfNull, pd.Series)
 def execute_zero_if_null_series(op, data, **kwargs):
-    zero = op.arg.type().to_pandas().type(0)
+    zero = op.arg.output_dtype.to_pandas().type(0)
     return data.replace({np.nan: zero, None: zero, pd.NA: zero})
 
 
@@ -1315,5 +1312,5 @@ def execute_zero_if_null_series(op, data, **kwargs):
 )
 def execute_zero_if_null_scalar(op, data, **kwargs):
     if data is None or pd.isna(data) or math.isnan(data) or np.isnan(data):
-        return op.arg.type().to_pandas().type(0)
+        return op.arg.output_dtype.to_pandas().type(0)
     return data

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -1,4 +1,3 @@
-import operator
 from typing import Any, Optional, Union
 
 import pandas as pd
@@ -10,12 +9,11 @@ import ibis.util
 from ibis.backends.pandas.core import execute
 from ibis.backends.pandas.execution import constants
 from ibis.expr import operations as ops
-from ibis.expr import types as ir
 from ibis.expr.scope import Scope
 
 
 def get_join_suffix_for_op(op: ops.TableColumn, join_op: ops.Join):
-    (root_table,) = an.find_immediate_parent_tables(op.to_expr())
+    (root_table,) = an.find_immediate_parent_tables(op)
     left_root, right_root = an.find_immediate_parent_tables(
         [join_op.left, join_op.right]
     )
@@ -26,19 +24,18 @@ def get_join_suffix_for_op(op: ops.TableColumn, join_op: ops.Join):
 
 
 def compute_sort_key(key, data, timecontext, scope=None, **kwargs):
-    by = key.to_expr()
     try:
-        if isinstance(by, str):
-            return by, None
-        return by.get_name(), None
+        if isinstance(key, str):
+            return key, None
+        return key.resolve_name(), None
     except com.ExpressionError:
         if scope is None:
             scope = Scope()
         scope = scope.merge_scopes(
             Scope({t: data}, timecontext)
-            for t in an.find_immediate_parent_tables(by)
+            for t in an.find_immediate_parent_tables(key)
         )
-        new_column = execute(by, scope=scope, **kwargs)
+        new_column = execute(key, scope=scope, **kwargs)
         name = ibis.util.guid()
         new_column.name = name
         return name, new_column
@@ -49,10 +46,10 @@ def compute_sorted_frame(
 ):
     computed_sort_keys = []
     sort_keys = list(toolz.concatv(group_by, order_by))
-    ascending = [getattr(key.op(), 'ascending', True) for key in sort_keys]
+    ascending = [getattr(key, "ascending", True) for key in sort_keys]
     new_columns = {}
 
-    for i, key in enumerate(map(operator.methodcaller('op'), sort_keys)):
+    for i, key in enumerate(sort_keys):
         computed_sort_key, temporary_column = compute_sort_key(
             key, df, timecontext, **kwargs
         )
@@ -76,7 +73,7 @@ def compute_sorted_frame(
 
 
 def coerce_to_output(
-    result: Any, expr: ir.Expr, index: Optional[pd.Index] = None
+    result: Any, node: ops.Node, index: Optional[pd.Index] = None
 ) -> Union[pd.Series, pd.DataFrame]:
     """Cast the result to either a Series or DataFrame.
 
@@ -87,8 +84,8 @@ def coerce_to_output(
     ----------
     result: Any
         The result to cast
-    expr: ibis.expr.types.Expr
-        The expression associated with the result
+    node: ibis.expr.operations.Node
+        The operation node associated with the result
     index: pd.Index
         Optional. If passed, scalar results will be broadcasted according
         to the index.
@@ -101,22 +98,22 @@ def coerce_to_output(
     --------
     For dataframe outputs, see ``ibis.util.coerce_to_dataframe``.
 
-    >>> coerce_to_output(pd.Series(1), expr)
+    >>> coerce_to_output(pd.Series(1), node)
     0    1
     Name: result, dtype: int64
-    >>> coerce_to_output(1, expr)
+    >>> coerce_to_output(1, node)
     0    1
     Name: result, dtype: int64
-    >>> coerce_to_output(1, expr, [1,2,3])
+    >>> coerce_to_output(1, node, [1,2,3])
     1    1
     2    1
     3    1
     Name: result, dtype: int64
-    >>> coerce_to_output([1,2,3], expr)
+    >>> coerce_to_output([1,2,3], node)
     0    [1, 2, 3]
     Name: result, dtype: object
     """
-    result_name = expr.get_name()
+    result_name = node.resolve_name()
 
     if isinstance(result, pd.DataFrame):
         rows = result.to_dict(orient="records")

--- a/ibis/backends/pandas/tests/execution/test_cast.py
+++ b/ibis/backends/pandas/tests/execution/test_cast.py
@@ -104,8 +104,8 @@ def test_cast_timestamp_column(t, df, column, to, expected):
 def test_cast_timestamp_scalar_naive(to, expected):
     literal_expr = ibis.literal(pd.Timestamp(TIMESTAMP))
     value = literal_expr.cast(to)
-    result = execute(value)
-    raw = execute(literal_expr)
+    result = execute(value.op())
+    raw = execute(literal_expr.op())
     assert result == expected(raw)
 
 
@@ -129,8 +129,8 @@ def test_cast_timestamp_scalar_naive(to, expected):
 def test_cast_timestamp_scalar(to, expected, tz):
     literal_expr = ibis.literal(pd.Timestamp(TIMESTAMP).tz_localize(tz))
     value = literal_expr.cast(to)
-    result = execute(value)
-    raw = execute(literal_expr)
+    result = execute(value.op())
+    raw = execute(literal_expr.op())
     assert result == expected(raw)
 
 

--- a/ibis/backends/pandas/tests/execution/test_functions.py
+++ b/ibis/backends/pandas/tests/execution/test_functions.py
@@ -220,7 +220,7 @@ def test_execute_with_same_hash_value_in_scope(
     table = ibis.pandas.from_dataframe(df)
 
     expr = my_func(table.left, table.right)
-    result = execute(expr)
+    result = execute(expr.op())
     assert isinstance(result, pd.Series)
 
     result = result.tolist()
@@ -234,7 +234,7 @@ def test_ifelse_returning_bool():
     true = ibis.literal(True)
     false = ibis.literal(False)
     expr = ibis.ifelse(one + one == two, true, false)
-    result = execute(expr)
+    result = execute(expr.op())
     assert result is True
 
 
@@ -257,7 +257,7 @@ def test_signature_does_not_match_input_type(dtype, value):
     df = pd.DataFrame({"col": [value]})
     table = ibis.pandas.from_dataframe(df)
 
-    result = execute(table.col)
+    result = execute(table.col.op())
     assert isinstance(result, pd.Series)
 
     result = result.tolist()

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -308,7 +308,7 @@ def test_null_if_zero(t, df, column):
 )
 def test_nullif(t, df, left, right, expected, compare):
     expr = left(t).nullif(right(t))
-    result = execute(expr)
+    result = execute(expr.op())
     compare(result, expected(df))
 
 

--- a/ibis/backends/pandas/tests/execution/test_structs.py
+++ b/ibis/backends/pandas/tests/execution/test_structs.py
@@ -50,11 +50,11 @@ def test_struct_field_literal(value):
     )
 
     expr = struct['fruit']
-    result = execute(expr)
+    result = execute(expr.op())
     assert result == "pear"
 
     expr = struct['weight']
-    result = execute(expr)
+    result = execute(expr.op())
     assert result == 0
 
 

--- a/ibis/backends/pandas/tests/execution/test_temporal.py
+++ b/ibis/backends/pandas/tests/execution/test_temporal.py
@@ -53,7 +53,7 @@ def test_timestamp_functions(case_func, expected_func):
     )
     result = case_func(v)
     expected = expected_func(vt)
-    assert execute(result) == expected
+    assert execute(result.op()) == expected
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -139,9 +139,9 @@ def custom_window():
 def test_lead(t, df, row_offset, default, row_window):
     expr = t.dup_strings.lead(row_offset, default=default).over(row_window)
     result = expr.execute()
-    expected = df.dup_strings.shift(execute(-row_offset))
+    expected = df.dup_strings.shift(execute((-row_offset).op()))
     if default is not ibis.NA:
-        expected = expected.fillna(execute(default))
+        expected = expected.fillna(execute(default.op()))
     tm.assert_series_equal(result, expected)
 
 
@@ -150,9 +150,9 @@ def test_lead(t, df, row_offset, default, row_window):
 def test_lag(t, df, row_offset, default, row_window):
     expr = t.dup_strings.lag(row_offset, default=default).over(row_window)
     result = expr.execute()
-    expected = df.dup_strings.shift(execute(row_offset))
+    expected = df.dup_strings.shift(execute(row_offset.op()))
     if default is not ibis.NA:
-        expected = expected.fillna(execute(default))
+        expected = expected.fillna(execute(default.op()))
     tm.assert_series_equal(result, expected)
 
 
@@ -165,12 +165,12 @@ def test_lead_delta(t, df, range_offset, default, range_window):
         df[['plain_datetimes_naive', 'dup_strings']]
         .set_index('plain_datetimes_naive')
         .squeeze()
-        .shift(freq=execute(-range_offset))
+        .shift(freq=execute((-range_offset).op()))
         .reindex(df.plain_datetimes_naive)
         .reset_index(drop=True)
     )
     if default is not ibis.NA:
-        expected = expected.fillna(execute(default))
+        expected = expected.fillna(execute(default.op()))
     tm.assert_series_equal(result, expected)
 
 
@@ -183,12 +183,12 @@ def test_lag_delta(t, df, range_offset, default, range_window):
         df[['plain_datetimes_naive', 'dup_strings']]
         .set_index('plain_datetimes_naive')
         .squeeze()
-        .shift(freq=execute(range_offset))
+        .shift(freq=execute(range_offset.op()))
         .reindex(df.plain_datetimes_naive)
         .reset_index(drop=True)
     )
     if default is not ibis.NA:
-        expected = expected.fillna(execute(default))
+        expected = expected.fillna(execute(default.op()))
     tm.assert_series_equal(result, expected)
 
 
@@ -717,7 +717,7 @@ def test_custom_window_udf(t, custom_window):
             parent=parent,
             group_by=group_by,
             order_by=order_by,
-            output_type=operand.type(),
+            output_type=operand.output_dtype,
             max_lookback=window.max_lookback,
             preceding=window.preceding,
         )

--- a/ibis/backends/pandas/tests/test_core.py
+++ b/ibis/backends/pandas/tests/test_core.py
@@ -74,7 +74,7 @@ def test_pre_execute_basic():
 
     one = ibis.literal(1)
     expr = one + one
-    result = execute(expr)
+    result = execute(expr.op())
     assert result == 4
 
     del pre_execute.funcs[(ops.Add,)]
@@ -84,7 +84,7 @@ def test_pre_execute_basic():
 
 def test_execute_parameter_only():
     param = ibis.param('int64')
-    result = execute(param, params={param: 42})
+    result = execute(param.op(), params={param.op(): 42})
     assert result == 42
 
 
@@ -92,7 +92,7 @@ def test_missing_data_sources():
     t = ibis.table([('a', 'string')])
     expr = t.a.length()
     with pytest.raises(com.UnboundExpressionError):
-        execute(expr)
+        execute(expr.op())
 
 
 def test_missing_data_on_custom_client():
@@ -174,7 +174,7 @@ def test_is_computable_input():
 
     three = one + two
     four = three + 1
-    result = execute(four)
+    result = execute(four.op())
     assert result == 4.0
 
     del execute_node[ops.Add, int, MyObject]

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -14,7 +14,6 @@ import ibis.common.exceptions as com
 import ibis.common.geospatial as geo
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-import ibis.expr.types as ir
 
 # used for literal translate
 from ibis.backends.base.sql.alchemy import (
@@ -32,25 +31,24 @@ operation_registry.update(sqlalchemy_window_functions_registry)
 
 
 def _extract(fmt, output_type=sa.SMALLINT):
-    def translator(t, expr, output_type=output_type):
-        (arg,) = expr.op().args
-        sa_arg = t.translate(arg)
+    def translator(t, op, output_type=output_type):
+        sa_arg = t.translate(op.arg)
         return sa.cast(sa.extract(fmt, sa_arg), output_type)
 
     return translator
 
 
-def _second(t, expr):
+def _second(t, op):
     # extracting the second gives us the fractional part as well, so smash that
     # with a cast to SMALLINT
-    (sa_arg,) = map(t.translate, expr.op().args)
+    sa_arg = t.translate(op.arg)
     return sa.cast(sa.func.FLOOR(sa.extract('second', sa_arg)), sa.SMALLINT)
 
 
-def _millisecond(t, expr):
+def _millisecond(t, op):
     # we get total number of milliseconds including seconds with extract so we
     # mod 1000
-    (sa_arg,) = map(t.translate, expr.op().args)
+    sa_arg = t.translate(op.arg)
     return sa.cast(
         sa.func.floor(sa.extract('millisecond', sa_arg)) % 1000,
         sa.SMALLINT,
@@ -71,49 +69,44 @@ _truncate_precisions = {
 }
 
 
-def _timestamp_truncate(t, expr):
-    arg, unit = expr.op().args
-    sa_arg = t.translate(arg)
+def _timestamp_truncate(t, op):
+    sa_arg = t.translate(op.arg)
     try:
-        precision = _truncate_precisions[unit]
+        precision = _truncate_precisions[op.unit]
     except KeyError:
         raise com.UnsupportedOperationError(
-            f'Unsupported truncate unit {unit!r}'
+            f'Unsupported truncate unit {op.unit!r}'
         )
     return sa.func.date_trunc(precision, sa_arg)
 
 
-def _interval_from_integer(t, expr):
-    op = expr.op()
+def _interval_from_integer(t, op):
     sa_arg = t.translate(op.arg)
-    interval = sa.text(f"INTERVAL '1 {expr.type().resolution}'")
+    interval = sa.text(f"INTERVAL '1 {op.output_dtype.resolution}'")
     return sa_arg * interval
 
 
-def _is_nan(t, expr):
-    (arg,) = expr.op().args
-    sa_arg = t.translate(arg)
+def _is_nan(t, op):
+    sa_arg = t.translate(op.arg)
     return sa_arg == float('nan')
 
 
-def _is_inf(t, expr):
-    (arg,) = expr.op().args
-    sa_arg = t.translate(arg)
+def _is_inf(t, op):
+    sa_arg = t.translate(op.arg)
     inf = float('inf')
     return sa.or_(sa_arg == inf, sa_arg == -inf)
 
 
-def _typeof(t, expr):
-    (arg,) = expr.op().args
-    sa_arg = t.translate(arg)
+def _typeof(t, op):
+    sa_arg = t.translate(op.arg)
     typ = sa.cast(sa.func.pg_typeof(sa_arg), sa.TEXT)
 
     # select pg_typeof('thing') returns unknown so we have to check the child's
     # type for nullness
     return sa.case(
         [
-            ((typ == 'unknown') & (arg.type() != dt.null), 'text'),
-            ((typ == 'unknown') & (arg.type() == dt.null), 'null'),
+            ((typ == 'unknown') & (op.arg.output_dtype != dt.null), 'text'),
+            ((typ == 'unknown') & (op.arg.output_dtype == dt.null), 'null'),
         ],
         else_=typ,
     )
@@ -265,22 +258,21 @@ def _reduce_tokens(tokens, arg):
     return reduced
 
 
-def _strftime(t, expr):
-    arg, pattern = map(t.translate, expr.op().args)
+def _strftime(t, op):
+    arg, pattern = map(t.translate, op.args)
     tokens, _ = _scanner.scan(pattern.value)
     reduced = _reduce_tokens(tokens, arg)
     return functools.reduce(sa.sql.ColumnElement.concat, reduced)
 
 
-def _find_in_set(t, expr):
+def _find_in_set(t, op):
     # TODO
     # this operation works with any type, not just strings. should the
     # operation itself also have this property?
-    op = expr.op()
     return (
         sa.func.coalesce(
             sa.func.array_position(
-                postgresql.array(list(map(t.translate, op.values))),
+                postgresql.array(list(map(t.translate, op.values.values))),
                 t.translate(op.needle),
             ),
             0,
@@ -289,15 +281,15 @@ def _find_in_set(t, expr):
     )
 
 
-def _regex_replace(t, expr):
-    string, pattern, replacement = map(t.translate, expr.op().args)
+def _regex_replace(t, op):
+    string, pattern, replacement = map(t.translate, op.args)
 
     # postgres defaults to replacing only the first occurrence
     return sa.func.regexp_replace(string, pattern, replacement, 'g')
 
 
-def _log(t, expr):
-    arg, base = expr.op().args
+def _log(t, op):
+    arg, base = op.args
     sa_arg = t.translate(arg)
     if base is not None:
         sa_base = t.translate(base)
@@ -305,13 +297,12 @@ def _log(t, expr):
             sa.func.log(
                 sa.cast(sa_base, sa.NUMERIC), sa.cast(sa_arg, sa.NUMERIC)
             ),
-            t.get_sqla_type(expr.type()),
+            t.get_sqla_type(op.output_dtype),
         )
     return sa.func.ln(sa_arg)
 
 
-def _regex_extract(t, expr):
-    op = expr.op()
+def _regex_extract(t, op):
     arg = t.translate(op.arg)
     pattern = t.translate(op.pattern)
     return sa.case(
@@ -336,9 +327,8 @@ def _cardinality(array):
     )
 
 
-def _array_repeat(t, expr):
+def _array_repeat(t, op):
     """Repeat an array."""
-    op = expr.op()
     arg = t.translate(op.arg)
     times = t.translate(op.times)
 
@@ -371,19 +361,15 @@ def _array_repeat(t, expr):
     )
 
 
-def _table_column(t, expr):
-    op = expr.op()
+def _table_column(t, op):
     ctx = t.context
     table = op.table
 
     sa_table = get_sqla_table(ctx, table)
-
     out_expr = get_col_or_deferred_col(sa_table, op.name)
 
-    expr_type = expr.type()
-
-    if isinstance(expr_type, dt.Timestamp):
-        timezone = expr_type.timezone
+    if isinstance(op.output_dtype, dt.Timestamp):
+        timezone = op.output_dtype.timezone
         if timezone is not None:
             out_expr = out_expr.op('AT TIME ZONE')(timezone).label(op.name)
 
@@ -395,8 +381,8 @@ def _table_column(t, expr):
     return out_expr
 
 
-def _round(t, expr):
-    arg, digits = expr.op().args
+def _round(t, op):
+    arg, digits = op.args
     sa_arg = t.translate(arg)
 
     if digits is None:
@@ -406,23 +392,23 @@ def _round(t, expr):
     # number of digits (though simple truncation on doubles is allowed) so
     # we cast to numeric and then cast back if necessary
     result = sa.func.round(sa.cast(sa_arg, sa.NUMERIC), t.translate(digits))
-    if digits is not None and isinstance(arg.type(), dt.Decimal):
+    if digits is not None and isinstance(arg.output_dtype, dt.Decimal):
         return result
     result = sa.cast(result, sa.dialects.postgresql.DOUBLE_PRECISION())
     return result
 
 
-def _mod(t, expr):
-    left, right = map(t.translate, expr.op().args)
+def _mod(t, op):
+    left, right = map(t.translate, op.args)
 
     # postgres doesn't allow modulus of double precision values, so upcast and
     # then downcast later if necessary
-    if not isinstance(expr.type(), dt.Integer):
+    if not isinstance(op.output_dtype, dt.Integer):
         left = sa.cast(left, sa.NUMERIC)
         right = sa.cast(right, sa.NUMERIC)
 
     result = left % right
-    if expr.type().equals(dt.double):
+    if isinstance(op.output_dtype, dt.Float64):
         return sa.cast(result, sa.dialects.postgresql.DOUBLE_PRECISION())
     else:
         return result
@@ -438,8 +424,8 @@ def _neg_idx_to_pos(array, idx):
     )
 
 
-def _array_slice(t, expr):
-    arg, start, stop = expr.op().args
+def _array_slice(t, op):
+    arg, start, stop = op.args
     sa_arg = t.translate(arg)
     sa_start = t.translate(start)
 
@@ -453,9 +439,8 @@ def _array_slice(t, expr):
     return sa_arg[sa_start + 1 : sa_stop]
 
 
-def _literal(_, expr):
-    dtype = expr.type()
-    op = expr.op()
+def _literal(_, op):
+    dtype = op.output_dtype
     value = op.value
 
     if isinstance(dtype, dt.Interval):
@@ -463,10 +448,10 @@ def _literal(_, expr):
     elif isinstance(dtype, dt.Set):
         return list(map(sa.literal, value))
     # geo spatial data type
-    elif isinstance(expr, ir.GeoSpatialScalar):
+    elif isinstance(dtype, dt.GeoSpatial):
         # inline_metadata ex: 'SRID=4326;POINT( ... )'
         return sa.literal_column(
-            geo.translate_literal(expr, inline_metadata=True)
+            geo.translate_literal(op, inline_metadata=True)
         )
     elif isinstance(value, tuple):
         return sa.literal(value, type_=to_sqla_type(dtype))
@@ -474,56 +459,53 @@ def _literal(_, expr):
         return sa.literal(value)
 
 
-def _day_of_week_index(t, expr):
-    (sa_arg,) = map(t.translate, expr.op().args)
+def _day_of_week_index(t, op):
+    sa_arg = t.translate(op.arg)
     return sa.cast(
         sa.cast(sa.extract('dow', sa_arg) + 6, sa.SMALLINT) % 7, sa.SMALLINT
     )
 
 
-def _day_of_week_name(t, expr):
-    (sa_arg,) = map(t.translate, expr.op().args)
+def _day_of_week_name(t, op):
+    sa_arg = t.translate(op.arg)
     return sa.func.trim(sa.func.to_char(sa_arg, 'Day'))
 
 
-def _array_column(t, expr):
-    return postgresql.array(list(map(t.translate, expr.op().cols)))
+def _array_column(t, op):
+    return postgresql.array(list(map(t.translate, op.cols.values)))
 
 
-def _string_agg(t, expr):
-    op = expr.op()
+def _string_agg(t, op):
     agg = sa.func.string_agg(t.translate(op.arg), t.translate(op.sep))
     if (where := op.where) is not None:
         return agg.filter(t.translate(where))
     return agg
 
 
-def _corr(t, expr):
-    if expr.op().how == "sample":
+def _corr(t, op):
+    if op.how == "sample":
         raise ValueError(
             "PostgreSQL only implements population correlation coefficient"
         )
-    return _binary_variance_reduction(sa.func.corr)(t, expr)
+    return _binary_variance_reduction(sa.func.corr)(t, op)
 
 
-def _covar(t, expr):
+def _covar(t, op):
     suffix = {"sample": "samp", "pop": "pop"}
-    how = suffix.get(expr.op().how, "samp")
+    how = suffix.get(op.how, "samp")
     func = getattr(sa.func, f"covar_{how}")
-    return _binary_variance_reduction(func)(t, expr)
+    return _binary_variance_reduction(func)(t, op)
 
 
 def _binary_variance_reduction(func):
-    def variance_compiler(t, expr):
-        op = expr.op()
-
+    def variance_compiler(t, op):
         x = op.left
-        if isinstance(x_type := x.type(), dt.Boolean):
-            x = x.cast(dt.Int32(nullable=x_type.nullable))
+        if isinstance(x_type := x.output_dtype, dt.Boolean):
+            x = ops.Cast(x, dt.Int32(nullable=x_type.nullable))
 
         y = op.right
-        if isinstance(y_type := y.type(), dt.Boolean):
-            y = y.cast(dt.Int32(nullable=y_type.nullable))
+        if isinstance(y_type := y.output_dtype, dt.Boolean):
+            y = ops.Cast(y, dt.Int32(nullable=y_type.nullable))
 
         result = func(t.translate(x), t.translate(y))
 

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -79,13 +79,13 @@ def guid2(con):
 def test_cast(alltypes, at, translate, left_func, right_func):
     left = left_func(alltypes)
     right = right_func(at)
-    assert str(translate(left).compile()) == str(right.compile())
+    assert str(translate(left.op()).compile()) == str(right.compile())
 
 
 def test_date_cast(alltypes, at, translate):
     result = alltypes.date_string_col.cast('date')
     expected = sa.cast(at.c.date_string_col, sa.DATE)
-    assert str(translate(result)) == str(expected)
+    assert str(translate(result.op())) == str(expected)
 
 
 @pytest.mark.parametrize(
@@ -113,7 +113,7 @@ def test_noop_cast(alltypes, at, translate, column):
     result = col.cast(col.type())
     expected = at.c[column]
     assert result.equals(col)
-    assert str(translate(result)) == str(expected)
+    assert str(translate(result.op())) == str(expected)
 
 
 def test_timestamp_cast_noop(alltypes, at, translate):
@@ -127,8 +127,8 @@ def test_timestamp_cast_noop(alltypes, at, translate):
     expected1 = at.c.timestamp_col
     expected2 = sa.func.to_timestamp(at.c.int_col)
 
-    assert str(translate(result1)) == str(expected1)
-    assert str(translate(result2)) == str(expected2)
+    assert str(translate(result1.op())) == str(expected1)
+    assert str(translate(result2.op())) == str(expected2)
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/postgres/udf.py
+++ b/ibis/backends/postgres/udf.py
@@ -108,13 +108,13 @@ def existing_udf(name, input_types, output_type, schema=None, parameters=None):
 
     udf_node = _create_udf_node(name, udf_node_fields)
 
-    def _translate_udf(t, expr):
+    def _translate_udf(t, op):
         func_obj = sa.func
         if schema is not None:
             func_obj = getattr(func_obj, schema)
         func_obj = getattr(func_obj, name)
 
-        sa_args = [t.translate(arg) for arg in expr.op().args]
+        sa_args = [t.translate(arg) for arg in op.args]
 
         return func_obj(*sa_args)
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -190,7 +190,7 @@ class Backend(BaseSQLBackend):
                 timecontext,
             )
         return PySparkExprTranslator().translate(
-            expr, scope=scope, timecontext=timecontext
+            expr.op(), scope=scope, timecontext=timecontext
         )
 
     def execute(

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1,7 +1,6 @@
 import collections
 import enum
 import functools
-import operator
 
 import pandas as pd
 import pyspark
@@ -51,7 +50,7 @@ class PySparkExprTranslator:
 
         return decorator
 
-    def translate(self, expr, scope, timecontext, **kwargs):
+    def translate(self, op, *, scope, timecontext, **kwargs):
         """
         Translate Ibis expression into a PySpark object.
 
@@ -65,15 +64,14 @@ class PySparkExprTranslator:
         :param kwargs: parameters passed as keyword args (e.g. window)
         :return: translated PySpark DataFrame or Column object
         """
-        # The operation node type the typed expression wraps
-        op = expr.op()
-
         result = scope.get_value(op, timecontext)
         if result is not None:
             return result
         elif type(op) in self._registry:
             formatter = self._registry[type(op)]
-            result = formatter(self, expr, scope, timecontext, **kwargs)
+            result = formatter(
+                self, op, scope=scope, timecontext=timecontext, **kwargs
+            )
             scope.set_value(op, timecontext, result)
             return result
         else:
@@ -85,21 +83,23 @@ class PySparkExprTranslator:
 compiles = PySparkExprTranslator.compiles
 
 
+# TODO(kszucs): there are plenty of repetitions in this file which should be
+# reduced at some point
+
+
 @compiles(PySparkDatabaseTable)
-def compile_datasource(t, expr, scope, timecontext):
-    op = expr.op()
-    name, _, client = op.args
-    return filter_by_time_context(client._session.table(name), timecontext)
+def compile_datasource(t, op, *, timecontext, **kwargs):
+    df = op.source._session.table(op.name)
+    return filter_by_time_context(df, timecontext)
 
 
 @compiles(ops.SQLQueryResult)
-def compile_sql_query_result(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
+def compile_sql_query_result(t, op, **kwargs):
     query, _, client = op.args
     return client._session.sql(query)
 
 
-def _can_be_replaced_by_column_name(column_expr, table):
+def _can_be_replaced_by_column_name(column, table):
     """
     Return whether the given column_expr can be replaced by its literal
     name, which is True when column_expr and table[column_expr.get_name()]
@@ -109,30 +109,29 @@ def _can_be_replaced_by_column_name(column_expr, table):
     # other valid selections, such as a mutation that assigns a new column
     # or changes the value of an existing column.
     return (
-        isinstance(column_expr.op(), ops.TableColumn)
-        and column_expr.op().table == table
-        and column_expr.get_name() in table.schema()
-        and column_expr.op() == table[column_expr.get_name()].op()
+        isinstance(column, ops.TableColumn)
+        and column.table == table
+        and column.resolve_name() in table.schema
+        # TODO(kszucs): do we really need this condition?
+        and column == table.to_expr()[column.resolve_name()].op()
     )
 
 
 @compiles(ops.Alias)
-def compile_alias(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    arg = t.translate(op.arg, scope, timecontext, **kwargs)
+def compile_alias(t, op, **kwargs):
+    arg = t.translate(op.arg, **kwargs)
     return arg.alias(op.name)
 
 
 @compiles(ops.Selection)
-def compile_selection(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
+def compile_selection(t, op, *, scope, timecontext, **kwargs):
     # In selection, there could be multiple children that point to the
     # same root table. e.g. window with different sizes on a table.
     # We need to get the 'combined' time range that is a superset of every
     # time context among child nodes, and pass this as context to
     # source table to get all data within time context loaded.
     arg_timecontexts = [
-        adjust_context(node.op(), scope, timecontext)
+        adjust_context(node, scope=scope, timecontext=timecontext, **kwargs)
         for node in op.selections
         if timecontext
     ]
@@ -141,25 +140,30 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
     # in this case, we use the original timecontext
     if not adjusted_timecontext:
         adjusted_timecontext = timecontext
-    src_table = t.translate(op.table, scope, adjusted_timecontext)
+    src_table = t.translate(
+        op.table, scope=scope, timecontext=adjusted_timecontext, **kwargs
+    )
 
     col_in_selection_order = []
     col_to_drop = []
     result_table = src_table
     for selection in op.selections:
-        if isinstance(selection, ir.Table):
-            # TODO(kszucs): avoid converting to expr
-            col_in_selection_order.extend(selection.columns)
-        elif isinstance(selection, ir.Value):
+        if isinstance(selection, ops.TableNode):
+            col_in_selection_order.extend(selection.schema.names)
+        elif isinstance(selection, ops.Value):
             # If the selection is a straightforward projection of a table
             # column from the root table itself (i.e. excluding mutations and
             # renames), we can get the selection name directly.
             if _can_be_replaced_by_column_name(selection, op.table):
-                col_in_selection_order.append(selection.get_name())
+                col_in_selection_order.append(selection.resolve_name())
             else:
                 col = t.translate(
-                    selection, scope, adjusted_timecontext
-                ).alias(selection.get_name())
+                    selection,
+                    scope=scope,
+                    timecontext=adjusted_timecontext,
+                    **kwargs,
+                )
+                col = col.alias(selection.resolve_name())
                 col_in_selection_order.append(col)
         else:
             raise NotImplementedError(
@@ -172,7 +176,9 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
         result_table = result_table.drop(*col_to_drop)
 
     for predicate in op.predicates:
-        col = t.translate(predicate, scope, timecontext)
+        col = t.translate(
+            predicate, scope=scope, timecontext=timecontext, **kwargs
+        )
         # Due to an upstream Spark issue (SPARK-33057) we cannot
         # directly use filter with a window operation. The workaround
         # here is to assign a temporary column for the filter predicate,
@@ -184,7 +190,8 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
 
     if op.sort_keys:
         sort_cols = [
-            t.translate(key, scope, timecontext) for key in op.sort_keys
+            t.translate(key, scope=scope, timecontext=timecontext, **kwargs)
+            for key in op.sort_keys
         ]
         result_table = result_table.sort(*sort_cols)
 
@@ -194,9 +201,8 @@ def compile_selection(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.SortKey)
-def compile_sort_key(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    col = t.translate(op.expr, scope, timecontext)
+def compile_sort_key(t, op, **kwargs):
+    col = t.translate(op.expr, **kwargs)
 
     if op.ascending:
         return col.asc()
@@ -206,10 +212,10 @@ def compile_sort_key(t, expr, scope, timecontext, **kwargs):
 
 def compile_nan_as_null(compile_func):
     @functools.wraps(compile_func)
-    def wrapper(t, expr, *args, **kwargs):
-        compiled = compile_func(t, expr, *args, **kwargs)
+    def wrapper(t, op, *args, **kwargs):
+        compiled = compile_func(t, op, *args, **kwargs)
         if options.pyspark.treat_nan_as_null and isinstance(
-            expr.type(), dt.Floating
+            op.output_dtype, dt.Floating
         ):
             return F.nanvl(compiled, F.lit(None))
         else:
@@ -220,32 +226,27 @@ def compile_nan_as_null(compile_func):
 
 @compiles(ops.TableColumn)
 @compile_nan_as_null
-def compile_column(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    table = t.translate(op.table, scope, timecontext)
+def compile_column(t, op, **kwargs):
+    table = t.translate(op.table, **kwargs)
     return table[op.name]
 
 
 @compiles(ops.StructField)
-def compile_struct_field(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    arg = t.translate(op.arg, scope, timecontext)
+def compile_struct_field(t, op, **kwargs):
+    arg = t.translate(op.arg, **kwargs)
     return arg[op.field]
 
 
 @compiles(ops.SelfReference)
-def compile_self_reference(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.table, scope, timecontext)
+def compile_self_reference(t, op, **kwargs):
+    return t.translate(op.table, **kwargs)
 
 
 @compiles(ops.Cast)
-def compile_cast(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
+def compile_cast(t, op, **kwargs):
     if isinstance(op.to, dt.Interval):
-        if isinstance(op.arg.op(), ops.Literal):
-            return interval(op.arg.op().value, op.to.unit)
+        if isinstance(op.arg, ops.Literal):
+            return interval(op.arg.value, op.to.unit).op()
         else:
             raise com.UnsupportedArgumentError(
                 'Casting to intervals is only supported for literals '
@@ -257,129 +258,96 @@ def compile_cast(t, expr, scope, timecontext, **kwargs):
     else:
         cast_type = ibis_dtype_to_spark_dtype(op.to)
 
-    src_column = t.translate(op.arg, scope, timecontext)
+    src_column = t.translate(op.arg, **kwargs)
     return src_column.cast(cast_type)
 
 
 @compiles(ops.Limit)
-def compile_limit(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
+def compile_limit(t, op, **kwargs):
     if op.offset != 0:
         raise com.UnsupportedArgumentError(
             'PySpark backend does not support non-zero offset is for '
             'limit operation. Got offset {}.'.format(op.offset)
         )
-    df = t.translate(op.table, scope, timecontext)
+    df = t.translate(op.table, **kwargs)
     return df.limit(op.n)
 
 
 @compiles(ops.And)
-def compile_and(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) & t.translate(
-        op.right, scope, timecontext
-    )
+def compile_and(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) & t.translate(op.right, **kwargs)
 
 
 @compiles(ops.Or)
-def compile_or(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) | t.translate(
-        op.right, scope, timecontext
-    )
+def compile_or(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) | t.translate(op.right, **kwargs)
 
 
 @compiles(ops.Xor)
-def compile_xor(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    left = t.translate(op.left, scope, timecontext)
-    right = t.translate(op.right, scope, timecontext)
+def compile_xor(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     return (left | right) & ~(left & right)
 
 
 @compiles(ops.Equals)
-def compile_equals(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) == t.translate(
-        op.right, scope, timecontext
-    )
+def compile_equals(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) == t.translate(op.right, **kwargs)
 
 
 @compiles(ops.Not)
-def compile_not(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return ~t.translate(op.arg, scope, timecontext)
+def compile_not(t, op, **kwargs):
+    return ~t.translate(op.arg, **kwargs)
 
 
 @compiles(ops.NotEquals)
-def compile_not_equals(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) != t.translate(
-        op.right, scope, timecontext
-    )
+def compile_not_equals(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) != t.translate(op.right, **kwargs)
 
 
 @compiles(ops.Greater)
-def compile_greater(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) > t.translate(
-        op.right, scope, timecontext
-    )
+def compile_greater(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) > t.translate(op.right, **kwargs)
 
 
 @compiles(ops.GreaterEqual)
-def compile_greater_equal(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) >= t.translate(
-        op.right, scope, timecontext
-    )
+def compile_greater_equal(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) >= t.translate(op.right, **kwargs)
 
 
 @compiles(ops.Less)
-def compile_less(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) < t.translate(
-        op.right, scope, timecontext
-    )
+def compile_less(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) < t.translate(op.right, **kwargs)
 
 
 @compiles(ops.LessEqual)
-def compile_less_equal(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) <= t.translate(
-        op.right, scope, timecontext
-    )
+def compile_less_equal(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) <= t.translate(op.right, **kwargs)
 
 
 @compiles(ops.Multiply)
-def compile_multiply(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) * t.translate(
-        op.right, scope, timecontext
-    )
+def compile_multiply(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) * t.translate(op.right, **kwargs)
 
 
 @compiles(ops.Subtract)
-def compile_subtract(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return t.translate(op.left, scope, timecontext) - t.translate(
-        op.right, scope, timecontext
-    )
+def compile_subtract(t, op, **kwargs):
+    return t.translate(op.left, **kwargs) - t.translate(op.right, **kwargs)
 
 
 @compiles(ops.Literal)
 @compile_nan_as_null
-def compile_literal(t, expr, scope, timecontext, raw=False, **kwargs):
+def compile_literal(t, op, *, raw=False, **kwargs):
     """If raw is True, don't wrap the result with F.lit()"""
-    value = expr.op().value
-    dtype = expr.op().dtype
+    value = op.value
+    dtype = op.dtype
 
     if raw:
         return value
 
     if isinstance(dtype, dt.Interval):
         # execute returns a Timedelta and value is nanoseconds
-        return execute(expr).value
+        return execute(op).value
 
     if isinstance(value, collections.abc.Set):
         # Don't wrap set with F.lit
@@ -396,115 +364,91 @@ def compile_literal(t, expr, scope, timecontext, raw=False, **kwargs):
         return F.lit(value)
 
 
-def _compile_agg(t, agg_expr, scope, timecontext, *, context, **kwargs):
-    agg = t.translate(agg_expr, scope, timecontext, context=context)
-    if agg_expr.has_name():
-        return agg.alias(agg_expr.get_name())
-    return agg
-
-
 @compiles(ops.Aggregation)
-def compile_aggregation(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_table = t.translate(op.table, scope, timecontext)
+def compile_aggregation(t, op, **kwargs):
+    src_table = t.translate(op.table, **kwargs)
 
     if op.predicates:
-        src_table = src_table.filter(
-            t.translate(
-                functools.reduce(operator.and_, op.predicates),
-                scope,
-                timecontext,
-            )
-        )
+        predicate = functools.reduce(ops.And, op.predicates)
+        src_table = src_table.filter(t.translate(predicate, **kwargs))
 
     if op.by:
-        context = AggregationContext.GROUP
-        bys = [t.translate(b, scope, timecontext) for b in op.by]
+        aggcontext = AggregationContext.GROUP
+        bys = [t.translate(b, **kwargs) for b in op.by]
         src_table = src_table.groupby(*bys)
     else:
-        context = AggregationContext.ENTIRE
+        aggcontext = AggregationContext.ENTIRE
 
     aggs = [
-        _compile_agg(t, m, scope, timecontext, context=context)
-        for m in op.metrics
+        t.translate(m, aggcontext=aggcontext, **kwargs) for m in op.metrics
     ]
     return src_table.agg(*aggs)
 
 
 @compiles(ops.Union)
-def compile_union(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    left = t.translate(op.left, scope, timecontext, **kwargs)
-    right = t.translate(op.right, scope, timecontext, **kwargs)
+def compile_union(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     result = left.union(right)
     return result.distinct() if op.distinct else result
 
 
 @compiles(ops.Intersection)
-def compile_intersection(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    left = t.translate(op.left, scope, timecontext, **kwargs)
-    right = t.translate(op.right, scope, timecontext, **kwargs)
+def compile_intersection(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     return left.intersect(right) if op.distinct else left.intersectAll(right)
 
 
 @compiles(ops.Difference)
-def compile_difference(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    left = t.translate(op.left, scope, timecontext, **kwargs)
-    right = t.translate(op.right, scope, timecontext, **kwargs)
+def compile_difference(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     return left.subtract(right) if op.distinct else left.exceptAll(right)
 
 
 @compiles(ops.Contains)
-def compile_contains(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    col = t.translate(op.value, scope, timecontext)
-    return col.isin(t.translate(op.options, scope, timecontext))
+def compile_contains(t, op, **kwargs):
+    col = t.translate(op.value, **kwargs)
+    return col.isin(t.translate(op.options, **kwargs))
 
 
 @compiles(ops.NotContains)
-def compile_not_contains(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    col = t.translate(op.value, scope, timecontext)
-    return ~(col.isin(t.translate(op.options, scope, timecontext)))
+def compile_not_contains(t, op, **kwargs):
+    col = t.translate(op.value, **kwargs)
+    return ~(col.isin(t.translate(op.options, **kwargs)))
 
 
 @compiles(ops.StartsWith)
-def compile_startswith(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    col = t.translate(op.arg, scope, timecontext)
-    start = t.translate(op.start, scope, timecontext)
+def compile_startswith(t, op, **kwargs):
+    col = t.translate(op.arg, **kwargs)
+    start = t.translate(op.start, **kwargs)
     return col.startswith(start)
 
 
 @compiles(ops.EndsWith)
-def compile_endswith(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    col = t.translate(op.arg, scope, timecontext)
-    end = t.translate(op.end, scope, timecontext)
+def compile_endswith(t, op, **kwargs):
+    col = t.translate(op.arg, **kwargs)
+    end = t.translate(op.end, **kwargs)
     return col.startswith(end)
 
 
 def _is_table(table):
+    # TODO(kszucs): is has a pretty misleading name, should be removed
     try:
-        return isinstance(table.op().arg, ir.Table)
+        return isinstance(table.arg, ops.TableNode)
     except AttributeError:
         return False
 
 
-def compile_aggregator(
-    t, expr, scope, timecontext, *, fn, context=None, **kwargs
-):
-    op = expr.op()
+def compile_aggregator(t, op, *, fn, aggcontext=None, **kwargs):
     if (where := getattr(op, 'where', None)) is not None:
-        condition = t.translate(where, scope, timecontext)
+        condition = t.translate(where, **kwargs)
     else:
         condition = None
 
     def translate_arg(arg):
-        src_col = t.translate(arg, scope, timecontext)
+        src_col = t.translate(arg, **kwargs)
 
         if condition is not None:
             src_col = F.when(condition, src_col)
@@ -514,11 +458,11 @@ def compile_aggregator(
         arg for arg in op.args if arg is not getattr(op, "where", None)
     )
     src_cols = tuple(
-        translate_arg(arg) for arg in src_inputs if isinstance(arg, ir.Expr)
+        translate_arg(arg) for arg in src_inputs if isinstance(arg, ops.Node)
     )
 
     col = fn(*src_cols)
-    if context:
+    if aggcontext:
         return col
     else:
         # We are trying to compile a expr such as some_col.max()
@@ -526,16 +470,16 @@ def compile_aggregator(
         # Here we get the root table df of that column and compile
         # the expr to:
         # df.select(max(some_col))
-        if _is_table(expr):
+        if _is_table(op):
             (src_col,) = src_cols
             return src_col.select(col)
-        table_op = an.find_first_base_table(expr)
-        return t.translate(table_op.to_expr(), scope, timecontext).select(col)
+        table_op = an.find_first_base_table(op)
+        return t.translate(table_op, **kwargs).select(col)
 
 
 @compiles(ops.GroupConcat)
-def compile_group_concat(t, expr, scope, timecontext, context=None, **kwargs):
-    sep = t.translate(expr.op().sep, scope, timecontext, raw=True)
+def compile_group_concat(t, op, **kwargs):
+    sep = t.translate(op.sep, raw=True, **kwargs)
 
     def fn(col, _):
         collected = F.collect_list(col)
@@ -544,20 +488,16 @@ def compile_group_concat(t, expr, scope, timecontext, context=None, **kwargs):
             sep,
         )
 
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=fn, context=context
-    )
+    return compile_aggregator(t, op, fn=fn, **kwargs)
 
 
 @compiles(ops.Any)
-def compile_any(t, expr, scope, timecontext, context=None, **kwargs):
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=F.max, context=context, **kwargs
-    )
+def compile_any(t, op, *, aggcontext=None, **kwargs):
+    return compile_aggregator(t, op, fn=F.max, aggcontext=aggcontext, **kwargs)
 
 
 @compiles(ops.NotAny)
-def compile_notany(t, expr, scope, timecontext, *, context=None, **kwargs):
+def compile_notany(t, op, *, aggcontext=None, **kwargs):
     # The code here is a little ugly because the translation are different
     # with different context.
     # When translating col.notany() (context is None), we returns the dataframe
@@ -565,52 +505,36 @@ def compile_notany(t, expr, scope, timecontext, *, context=None, **kwargs):
     # When traslating col.notany().over(w), we need to negate the result
     # after the window translation, i.e., ~(F.max(col).over(w))
 
-    if context is None:
+    if aggcontext is None:
 
         def fn(col):
             return ~(F.max(col))
 
         return compile_aggregator(
-            t, expr, scope, timecontext, fn=fn, context=context, **kwargs
+            t, op, fn=fn, aggcontext=aggcontext, **kwargs
         )
     else:
-        return ~compile_any(
-            t,
-            expr,
-            scope,
-            timecontext,
-            context=context,
-            **kwargs,
-        )
+        return ~compile_any(t, op, aggcontext=aggcontext, **kwargs)
 
 
 @compiles(ops.All)
-def compile_all(t, expr, scope, timecontext, context=None, **kwargs):
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=F.min, context=context, **kwargs
-    )
+def compile_all(t, op, **kwargs):
+    return compile_aggregator(t, op, fn=F.min, **kwargs)
 
 
 @compiles(ops.NotAll)
-def compile_notall(t, expr, scope, timecontext, *, context=None, **kwargs):
+def compile_notall(t, op, *, aggcontext=None, **kwargs):
     # See comments for opts.NotAny for reasoning for the if/else
-    if context is None:
+    if aggcontext is None:
 
         def fn(col):
             return ~(F.min(col))
 
         return compile_aggregator(
-            t, expr, scope, timecontext, fn=fn, context=context, **kwargs
+            t, op, fn=fn, aggcontext=aggcontext, **kwargs
         )
     else:
-        return ~compile_all(
-            t,
-            expr,
-            scope,
-            timecontext,
-            context=context,
-            **kwargs,
-        )
+        return ~compile_all(t, op, aggcontext=aggcontext, **kwargs)
 
 
 def _count_star(_):
@@ -618,79 +542,53 @@ def _count_star(_):
 
 
 @compiles(ops.Count)
-def compile_count(t, expr, scope, timecontext, context=None, **kwargs):
-    if _is_table(expr):
+def compile_count(t, op, **kwargs):
+    if _is_table(op):
         fn = _count_star
     else:
         fn = F.count
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=fn, context=context, **kwargs
-    )
+    return compile_aggregator(t, op, fn=fn, **kwargs)
 
 
 @compiles(ops.Max)
 @compiles(ops.CumulativeMax)
-def compile_max(t, expr, scope, timecontext, context=None, **kwargs):
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=F.max, context=context, **kwargs
-    )
+def compile_max(t, op, **kwargs):
+    return compile_aggregator(t, op, fn=F.max, **kwargs)
 
 
 @compiles(ops.Min)
 @compiles(ops.CumulativeMin)
-def compile_min(t, expr, scope, timecontext, context=None, **kwargs):
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=F.min, context=context, **kwargs
-    )
+def compile_min(t, op, **kwargs):
+    return compile_aggregator(t, op, fn=F.min, **kwargs)
 
 
 @compiles(ops.Mean)
 @compiles(ops.CumulativeMean)
-def compile_mean(t, expr, scope, timecontext, context=None, **kwargs):
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=F.mean, context=context, **kwargs
-    )
+def compile_mean(t, op, **kwargs):
+    return compile_aggregator(t, op, fn=F.mean, **kwargs)
 
 
 @compiles(ops.Sum)
 @compiles(ops.CumulativeSum)
-def compile_sum(t, expr, scope, timecontext, context=None, **kwargs):
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=F.sum, context=context, **kwargs
-    )
+def compile_sum(t, op, **kwargs):
+    return compile_aggregator(t, op, fn=F.sum, **kwargs)
 
 
 @compiles(ops.ApproxCountDistinct)
-def compile_approx_count_distinct(
-    t, expr, scope, timecontext, context=None, **kwargs
-):
-    return compile_aggregator(
-        t,
-        expr,
-        scope,
-        timecontext,
-        fn=F.approx_count_distinct,
-        context=context,
-        **kwargs,
-    )
+def compile_approx_count_distinct(t, op, **kwargs):
+    return compile_aggregator(t, op, fn=F.approx_count_distinct, **kwargs)
 
 
 @compiles(ops.ApproxMedian)
-def compile_approx_median(t, expr, scope, timecontext, context=None, **kwargs):
+def compile_approx_median(t, op, **kwargs):
     return compile_aggregator(
-        t,
-        expr,
-        scope,
-        timecontext,
-        fn=lambda arg: F.percentile_approx(arg, 0.5),
-        context=context,
-        **kwargs,
+        t, op, fn=lambda arg: F.percentile_approx(arg, 0.5), **kwargs
     )
 
 
 @compiles(ops.StandardDev)
-def compile_std(t, expr, scope, timecontext, context=None, **kwargs):
-    how = expr.op().how
+def compile_std(t, op, **kwargs):
+    how = op.how
 
     if how == 'sample':
         fn = F.stddev_samp
@@ -699,14 +597,12 @@ def compile_std(t, expr, scope, timecontext, context=None, **kwargs):
     else:
         raise com.TranslationError(f"Unexpected 'how' in translation: {how}")
 
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=fn, context=context
-    )
+    return compile_aggregator(t, op, fn=fn, **kwargs)
 
 
 @compiles(ops.Variance)
-def compile_variance(t, expr, scope, timecontext, context=None, **kwargs):
-    how = expr.op().how
+def compile_variance(t, op, **kwargs):
+    how = op.how
 
     if how == 'sample':
         fn = F.var_samp
@@ -715,52 +611,43 @@ def compile_variance(t, expr, scope, timecontext, context=None, **kwargs):
     else:
         raise com.TranslationError(f"Unexpected 'how' in translation: {how}")
 
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=fn, context=context
-    )
+    return compile_aggregator(t, op, fn=fn, **kwargs)
 
 
 @compiles(ops.Covariance)
-def compile_covariance(t, expr, scope, timecontext, context=None, **kwargs):
-    op = expr.op()
+def compile_covariance(t, op, **kwargs):
     how = op.how
 
     fn = {"sample": F.covar_samp, "pop": F.covar_pop}[how]
 
     pyspark_double_type = ibis_dtype_to_spark_dtype(dt.double)
-    expr = op.__class__(
-        left=op.left.cast(pyspark_double_type),
-        right=op.right.cast(pyspark_double_type),
+    new_op = op.__class__(
+        left=ops.Cast(op.left, to=pyspark_double_type),
+        right=ops.Cast(op.right, to=pyspark_double_type),
         how=how,
         where=op.where,
-    ).to_expr()
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=fn, context=context
     )
+    return compile_aggregator(t, new_op, fn=fn, **kwargs)
 
 
 @compiles(ops.Correlation)
-def compile_correlation(t, expr, scope, timecontext, context=None, **kwargs):
-    op = expr.op()
-
+def compile_correlation(t, op, **kwargs):
     if (how := op.how) == "pop":
         raise ValueError("PySpark only implements sample correlation")
 
     pyspark_double_type = ibis_dtype_to_spark_dtype(dt.double)
-    expr = op.__class__(
-        left=op.left.cast(pyspark_double_type),
-        right=op.right.cast(pyspark_double_type),
+    new_op = op.__class__(
+        left=ops.Cast(op.left, to=pyspark_double_type),
+        right=ops.Cast(op.right, to=pyspark_double_type),
         how=how,
         where=op.where,
-    ).to_expr()
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=F.corr, context=context
     )
+    return compile_aggregator(t, new_op, fn=F.corr, **kwargs)
 
 
 @compiles(ops.Arbitrary)
-def compile_arbitrary(t, expr, scope, timecontext, context=None, **kwargs):
-    how = expr.op().how
+def compile_arbitrary(t, op, **kwargs):
+    how = op.how
 
     if how == 'first':
         fn = functools.partial(F.first, ignorenulls=True)
@@ -769,16 +656,12 @@ def compile_arbitrary(t, expr, scope, timecontext, context=None, **kwargs):
     else:
         raise NotImplementedError(f"Does not support 'how': {how}")
 
-    return compile_aggregator(
-        t, expr, scope, timecontext, fn=fn, context=context
-    )
+    return compile_aggregator(t, op, fn=fn, **kwargs)
 
 
 @compiles(ops.Coalesce)
-def compile_coalesce(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_columns = t.translate(op.arg, scope, timecontext)
+def compile_coalesce(t, op, **kwargs):
+    src_columns = t.translate(op.arg, **kwargs)
     if len(src_columns) == 1:
         return src_columns[0]
     else:
@@ -786,10 +669,8 @@ def compile_coalesce(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.Greatest)
-def compile_greatest(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_columns = t.translate(op.arg, scope, timecontext)
+def compile_greatest(t, op, **kwargs):
+    src_columns = t.translate(op.arg, **kwargs)
     if len(src_columns) == 1:
         return src_columns[0]
     else:
@@ -797,10 +678,8 @@ def compile_greatest(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.Least)
-def compile_least(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_columns = t.translate(op.arg, scope, timecontext)
+def compile_least(t, op, **kwargs):
+    src_columns = t.translate(op.arg, **kwargs)
     if len(src_columns) == 1:
         return src_columns[0]
     else:
@@ -808,25 +687,22 @@ def compile_least(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.Abs)
-def compile_abs(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_abs(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.abs(src_column)
 
 
 @compiles(ops.Clip)
-def compile_clip(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    spark_dtype = ibis_dtype_to_spark_dtype(expr.type())
-    col = t.translate(op.arg, scope, timecontext)
+def compile_clip(t, op, **kwargs):
+    spark_dtype = ibis_dtype_to_spark_dtype(op.output_dtype)
+    col = t.translate(op.arg, **kwargs)
     upper = (
-        t.translate(op.upper, scope, timecontext)
+        t.translate(op.upper, **kwargs)
         if op.upper is not None
         else float('inf')
     )
     lower = (
-        t.translate(op.lower, scope, timecontext)
+        t.translate(op.lower, **kwargs)
         if op.lower is not None
         else float('-inf')
     )
@@ -850,12 +726,10 @@ def compile_clip(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.Round)
-def compile_round(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_round(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     scale = (
-        t.translate(op.digits, scope, timecontext, raw=True)
+        t.translate(op.digits, **kwargs, raw=True)
         if op.digits is not None
         else 0
     )
@@ -866,34 +740,26 @@ def compile_round(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.Ceil)
-def compile_ceil(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_ceil(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.ceil(src_column)
 
 
 @compiles(ops.Floor)
-def compile_floor(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_floor(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.floor(src_column)
 
 
 @compiles(ops.Exp)
-def compile_exp(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_exp(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.exp(src_column)
 
 
 @compiles(ops.Sign)
-def compile_sign(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_sign(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
 
     return F.when(src_column == 0, F.lit(0.0)).otherwise(
         F.when(src_column > 0, F.lit(1.0)).otherwise(-1.0)
@@ -901,19 +767,15 @@ def compile_sign(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.Sqrt)
-def compile_sqrt(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_sqrt(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.sqrt(src_column)
 
 
 @compiles(ops.Log)
-def compile_log(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    raw_base = t.translate(op.base, scope, timecontext, raw=True)
+def compile_log(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    raw_base = t.translate(op.base, **kwargs, raw=True)
     try:
         base = float(raw_base)
     except TypeError:
@@ -923,162 +785,125 @@ def compile_log(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.Ln)
-def compile_ln(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_ln(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.log(src_column)
 
 
 @compiles(ops.Log2)
-def compile_log2(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_log2(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.log2(src_column)
 
 
 @compiles(ops.Log10)
-def compile_log10(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_log10(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.log10(src_column)
 
 
 @compiles(ops.Modulus)
-def compile_modulus(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    left = t.translate(op.left, scope, timecontext)
-    right = t.translate(op.right, scope, timecontext)
+def compile_modulus(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     return left % right
 
 
 @compiles(ops.Negate)
-def compile_negate(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    if expr.type() == dt.boolean:
+def compile_negate(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    if isinstance(op.output_dtype, dt.Boolean):
         return ~src_column
     return -src_column
 
 
 @compiles(ops.Add)
-def compile_add(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    left = t.translate(op.left, scope, timecontext)
-    right = t.translate(op.right, scope, timecontext)
+def compile_add(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     return left + right
 
 
 @compiles(ops.Divide)
-def compile_divide(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    left = t.translate(op.left, scope, timecontext)
-    right = t.translate(op.right, scope, timecontext)
+def compile_divide(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     return left / right
 
 
 @compiles(ops.FloorDivide)
-def compile_floor_divide(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    left = t.translate(op.left, scope, timecontext)
-    right = t.translate(op.right, scope, timecontext)
+def compile_floor_divide(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     return F.floor(left / right)
 
 
 @compiles(ops.Power)
-def compile_power(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    left = t.translate(op.left, scope, timecontext)
-    right = t.translate(op.right, scope, timecontext)
+def compile_power(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     return F.pow(left, right)
 
 
 @compiles(ops.IsNan)
-def compile_isnan(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_isnan(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.isnan(src_column) | F.isnull(src_column)
 
 
 @compiles(ops.IsInf)
-def compile_isinf(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_isinf(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return (src_column == float('inf')) | (src_column == float('-inf'))
 
 
 @compiles(ops.Uppercase)
-def compile_uppercase(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_uppercase(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.upper(src_column)
 
 
 @compiles(ops.Lowercase)
-def compile_lowercase(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_lowercase(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.lower(src_column)
 
 
 @compiles(ops.Reverse)
-def compile_reverse(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_reverse(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.reverse(src_column)
 
 
 @compiles(ops.Strip)
-def compile_strip(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_strip(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.trim(src_column)
 
 
 @compiles(ops.LStrip)
-def compile_lstrip(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_lstrip(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.ltrim(src_column)
 
 
 @compiles(ops.RStrip)
-def compile_rstrip(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_rstrip(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.rtrim(src_column)
 
 
 @compiles(ops.Capitalize)
-def compile_capitalize(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_capitalize(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.initcap(src_column)
 
 
 @compiles(ops.Substring)
-def compile_substring(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    src_column = t.translate(op.arg, scope, timecontext)
-    start = t.translate(op.start, scope, timecontext, raw=True) + 1
-    length = t.translate(op.length, scope, timecontext, raw=True)
+def compile_substring(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    start = t.translate(op.start, **kwargs, raw=True) + 1
+    length = t.translate(op.length, **kwargs, raw=True)
 
     if isinstance(start, pyspark.sql.Column) or isinstance(
         length, pyspark.sql.Column
@@ -1092,297 +917,251 @@ def compile_substring(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.StringLength)
-def compile_string_length(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_string_length(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.length(src_column)
 
 
 @compiles(ops.StrRight)
-def compile_str_right(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
+def compile_str_right(t, op, **kwargs):
     @F.udf('string')
     def str_right(s, nchars):
         return s[-nchars:]
 
-    src_column = t.translate(op.arg, scope, timecontext)
-    nchars_column = t.translate(op.nchars, scope, timecontext)
+    src_column = t.translate(op.arg, **kwargs)
+    nchars_column = t.translate(op.nchars, **kwargs)
     return str_right(src_column, nchars_column)
 
 
 @compiles(ops.Repeat)
-def compile_repeat(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
+def compile_repeat(t, op, **kwargs):
     @F.udf('string')
     def repeat(s, times):
         return s * times
 
-    src_column = t.translate(op.arg, scope, timecontext)
-    times_column = t.translate(op.times, scope, timecontext)
+    src_column = t.translate(op.arg, **kwargs)
+    times_column = t.translate(op.times, **kwargs)
     return repeat(src_column, times_column)
 
 
 @compiles(ops.StringFind)
-def compile_string_find(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
+def compile_string_find(t, op, **kwargs):
     @F.udf('long')
     def str_find(s, substr, start, end):
         return s.find(substr, start, end)
 
-    src_column = t.translate(op.arg, scope, timecontext)
-    substr_column = t.translate(op.substr, scope, timecontext)
-    start_column = (
-        t.translate(op.start, scope, timecontext) if op.start else F.lit(None)
-    )
-    end_column = (
-        t.translate(op.end, scope, timecontext) if op.end else F.lit(None)
-    )
+    src_column = t.translate(op.arg, **kwargs)
+    substr_column = t.translate(op.substr, **kwargs)
+    start_column = t.translate(op.start, **kwargs) if op.start else F.lit(None)
+    end_column = t.translate(op.end, **kwargs) if op.end else F.lit(None)
     return str_find(src_column, substr_column, start_column, end_column)
 
 
 @compiles(ops.Translate)
-def compile_translate(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    from_str = op.from_str.op().value
-    to_str = op.to_str.op().value
+def compile_translate(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    from_str = op.from_str.value
+    to_str = op.to_str.value
     return F.translate(src_column, from_str, to_str)
 
 
 @compiles(ops.LPad)
-def compile_lpad(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    length = op.length.op().value
-    pad = op.pad.op().value
+def compile_lpad(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    length = op.length.value
+    pad = op.pad.value
     return F.lpad(src_column, length, pad)
 
 
 @compiles(ops.RPad)
-def compile_rpad(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    length = op.length.op().value
-    pad = op.pad.op().value
+def compile_rpad(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    length = op.length.value
+    pad = op.pad.value
     return F.rpad(src_column, length, pad)
 
 
 @compiles(ops.StringJoin)
-def compile_string_join(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
+def compile_string_join(t, op, **kwargs):
     @F.udf('string')
     def join(sep, arr):
         return sep.join(arr)
 
-    sep_column = t.translate(op.sep, scope, timecontext)
-    arg = t.translate(op.arg, scope, timecontext)
+    sep_column = t.translate(op.sep, **kwargs)
+    arg = t.translate(op.arg, **kwargs)
     return join(sep_column, F.array(arg))
 
 
 @compiles(ops.RegexSearch)
-def compile_regex_search(t, expr, scope, timecontext, **kwargs):
+def compile_regex_search(t, op, **kwargs):
     import re
-
-    op = expr.op()
 
     @F.udf('boolean')
     def regex_search(s, pattern):
         return True if re.search(pattern, s) else False
 
-    src_column = t.translate(op.arg, scope, timecontext)
-    pattern = t.translate(op.pattern, scope, timecontext)
+    src_column = t.translate(op.arg, **kwargs)
+    pattern = t.translate(op.pattern, **kwargs)
     return regex_search(src_column, pattern)
 
 
 @compiles(ops.RegexExtract)
-def compile_regex_extract(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    pattern = op.pattern.op().value
-    idx = op.index.op().value
+def compile_regex_extract(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    pattern = op.pattern.value
+    idx = op.index.value
     return F.regexp_extract(src_column, pattern, idx)
 
 
 @compiles(ops.RegexReplace)
-def compile_regex_replace(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    pattern = op.pattern.op().value
-    replacement = op.replacement.op().value
+def compile_regex_replace(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    pattern = op.pattern.value
+    replacement = op.replacement.value
     return F.regexp_replace(src_column, pattern, replacement)
 
 
 @compiles(ops.StringReplace)
-def compile_string_replace(t, expr, scope, timecontext, **kwargs):
-    return compile_regex_replace(t, expr)
+def compile_string_replace(t, op, **kwargs):
+    return compile_regex_replace(t, op, **kwargs)
 
 
 @compiles(ops.StringSplit)
-def compile_string_split(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    delimiter = op.delimiter.op().value
+def compile_string_split(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    delimiter = op.delimiter.value
     return F.split(src_column, delimiter)
 
 
 @compiles(ops.StringConcat)
-def compile_string_concat(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_columns = t.translate(op.arg, scope, timecontext)
+def compile_string_concat(t, op, **kwargs):
+    src_columns = t.translate(op.arg, **kwargs)
     return F.concat(*src_columns)
 
 
 @compiles(ops.StringAscii)
-def compile_string_ascii(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_string_ascii(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.ascii(src_column)
 
 
 @compiles(ops.StringSQLLike)
-def compile_string_like(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    pattern = op.pattern.op().value
+def compile_string_like(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    pattern = op.pattern.value
     return src_column.like(pattern)
 
 
 @compiles(ops.ValueList)
-def compile_value_list(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    return [t.translate(col, scope, timecontext) for col in op.values]
+def compile_value_list(t, op, **kwargs):
+    kwargs["raw"] = False  # override to force column literals
+    return [t.translate(col, **kwargs) for col in op.values]
 
 
 @compiles(ops.InnerJoin)
-def compile_inner_join(t, expr, scope, timecontext, **kwargs):
-    return compile_join(t, expr, scope, timecontext, how='inner')
+def compile_inner_join(t, op, **kwargs):
+    return compile_join(t, op, **kwargs, how='inner')
 
 
 @compiles(ops.LeftJoin)
-def compile_left_join(t, expr, scope, timecontext, **kwargs):
-    return compile_join(t, expr, scope, timecontext, how='left')
+def compile_left_join(t, op, **kwargs):
+    return compile_join(t, op, **kwargs, how='left')
 
 
 @compiles(ops.RightJoin)
-def compile_right_join(t, expr, scope, timecontext, **kwargs):
-    return compile_join(t, expr, scope, timecontext, how='right')
+def compile_right_join(t, op, **kwargs):
+    return compile_join(t, op, **kwargs, how='right')
 
 
 @compiles(ops.OuterJoin)
-def compile_outer_join(t, expr, scope, timecontext, **kwargs):
-    return compile_join(t, expr, scope, timecontext, how='outer')
+def compile_outer_join(t, op, **kwargs):
+    return compile_join(t, op, **kwargs, how='outer')
 
 
 @compiles(ops.LeftSemiJoin)
-def compile_left_semi_join(t, expr, scope, timecontext, **kwargs):
-    return compile_join(t, expr, scope, timecontext, how='leftsemi')
+def compile_left_semi_join(t, op, **kwargs):
+    return compile_join(t, op, **kwargs, how='leftsemi')
 
 
 @compiles(ops.LeftAntiJoin)
-def compile_left_anti_join(t, expr, scope, timecontext, **kwargs):
-    return compile_join(t, expr, scope, timecontext, how='leftanti')
+def compile_left_anti_join(t, op, **kwargs):
+    return compile_join(t, op, **kwargs, how='leftanti')
 
 
-def compile_join(t, expr, scope, timecontext, *, how):
-    op = expr.op()
-
-    left_df = t.translate(op.left, scope, timecontext)
-    right_df = t.translate(op.right, scope, timecontext)
+def compile_join(t, op, how, **kwargs):
+    left_df = t.translate(op.left, **kwargs)
+    right_df = t.translate(op.right, **kwargs)
 
     pred_columns = []
     for pred in op.predicates:
-        pred_op = pred.op()
-        if not isinstance(pred_op, ops.Equals):
+        if not isinstance(pred, ops.Equals):
             raise NotImplementedError(
                 "Only equality predicate is supported, but got {}".format(
-                    type(pred_op)
+                    type(pred)
                 )
             )
-        pred_columns.append(pred_op.left.get_name())
+        pred_columns.append(pred.left.resolve_name())
 
     return left_df.join(right_df, pred_columns, how)
 
 
 @compiles(ops.Distinct)
-def compile_distinct(t, expr, scope, timecontext):
-    op = expr.op()
-    return t.translate(op.table, scope, timecontext).distinct()
+def compile_distinct(t, op, **kwargs):
+    return t.translate(op.table, **kwargs).distinct()
 
 
-def _canonicalize_interval(t, interval, scope, timecontext, **kwargs):
+def _canonicalize_interval(t, interval, **kwargs):
     """Convert interval to integer timestamp of second
 
     When pyspark cast timestamp to integer type, it uses the number of seconds
     since epoch. Therefore, we need cast ibis interval correspondingly.
     """
     if isinstance(interval, ir.IntervalScalar):
-        value = t.translate(interval, scope, timecontext, **kwargs)
+        value = t.translate(interval.op(), **kwargs)
         # value is in nanoseconds and spark uses seconds since epoch
         return int(value / 1e9)
     elif isinstance(interval, int):
         return interval
-    raise com.UnsupportedOperationError(
-        f'type {type(interval)} is not supported in preceding /following '
-        'in window.'
-    )
+    else:
+        raise com.UnsupportedOperationError(
+            f'type {type(interval)} is not supported in preceding /following '
+            'in window.'
+        )
 
 
 @compiles(ops.Window)
-def compile_window_op(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
+def compile_window_op(t, op, **kwargs):
     window = op.window
     operand = op.expr
 
-    group_by = window._group_by
     grouping_keys = [
-        key_op.name
-        if isinstance(key_op, ops.TableColumn)
-        else t.translate(key, scope, timecontext)
-        for key, key_op in zip(
-            group_by, map(operator.methodcaller('op'), group_by)
-        )
+        key.name
+        if isinstance(key, ops.TableColumn)
+        else t.translate(key, **kwargs)
+        for key in window._group_by
     ]
 
-    order_by = window._order_by
     # Timestamp needs to be cast to long for window bounds in spark
     ordering_keys = [
-        F.col(sort_expr.get_name()).cast('long')
-        if isinstance(sort_expr.op().expr, ir.TimestampColumn)
-        else sort_expr.get_name()
-        for sort_expr in order_by
+        F.col(sort.resolve_name()).cast('long')
+        if isinstance(sort.expr.output_dtype, dt.Timestamp)
+        else sort.resolve_name()
+        for sort in window._order_by
     ]
-    context = AggregationContext.WINDOW
+    aggcontext = AggregationContext.WINDOW
     pyspark_window = Window.partitionBy(grouping_keys).orderBy(ordering_keys)
 
     # If the operand is a shift op (e.g. lead, lag), Spark will set the window
     # bounds. Only set window bounds here if not a shift operation.
-    if not isinstance(operand.op(), ops.ShiftBase):
+    if not isinstance(operand, ops.ShiftBase):
         if window.preceding is None:
             start = Window.unboundedPreceding
         else:
-            start = -_canonicalize_interval(
-                t, window.preceding, scope, timecontext, **kwargs
-            )
+            start = -_canonicalize_interval(t, window.preceding, **kwargs)
         if window.following is None:
             end = Window.unboundedFollowing
         else:
-            end = _canonicalize_interval(
-                t, window.following, scope, timecontext, **kwargs
-            )
+            end = _canonicalize_interval(t, window.following, **kwargs)
 
         if (
             isinstance(window.preceding, ir.IntervalScalar)
@@ -1393,13 +1172,13 @@ def compile_window_op(t, expr, scope, timecontext, **kwargs):
         else:
             pyspark_window = pyspark_window.rowsBetween(start, end)
 
-    res_op = operand.op()
+    res_op = operand
     if isinstance(res_op, (ops.NotAll, ops.NotAny)):
         # For NotAll and NotAny, negation must be applied after .over(window)
         # Here we rewrite node to be its negation, and negate it back after
         # translation and window operation
-        operand = res_op.negate().to_expr()
-    result = t.translate(operand, scope, timecontext, context=context).over(
+        operand = res_op.negate()
+    result = t.translate(operand, **kwargs, aggcontext=aggcontext).over(
         pyspark_window
     )
 
@@ -1412,12 +1191,10 @@ def compile_window_op(t, expr, scope, timecontext, **kwargs):
         return result
 
 
-def _handle_shift_operation(t, expr, scope, timecontext, *, fn, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    default = op.default.op().value if op.default is not None else op.default
-    offset = op.offset.op().value if op.offset is not None else op.offset
+def _handle_shift_operation(t, op, fn, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    default = op.default.value if op.default is not None else op.default
+    offset = op.offset.value if op.offset is not None else op.offset
 
     if offset:
         return fn(src_column, count=offset, default=default)
@@ -1426,72 +1203,64 @@ def _handle_shift_operation(t, expr, scope, timecontext, *, fn, **kwargs):
 
 
 @compiles(ops.Lag)
-def compile_lag(t, expr, scope, timecontext, **kwargs):
-    return _handle_shift_operation(
-        t, expr, scope, timecontext, fn=F.lag, **kwargs
-    )
+def compile_lag(t, op, **kwargs):
+    return _handle_shift_operation(t, op, fn=F.lag, **kwargs)
 
 
 @compiles(ops.Lead)
-def compile_lead(t, expr, scope, timecontext, **kwargs):
-    return _handle_shift_operation(
-        t, expr, scope, timecontext, fn=F.lead, **kwargs
-    )
+def compile_lead(t, op, **kwargs):
+    return _handle_shift_operation(t, op, fn=F.lead, **kwargs)
 
 
 @compiles(ops.MinRank)
-def compile_rank(t, expr, scope, timecontext, **kwargs):
+def compile_rank(t, op, **kwargs):
     return F.rank()
 
 
 @compiles(ops.DenseRank)
-def compile_dense_rank(t, expr, scope, timecontext, **kwargs):
+def compile_dense_rank(t, op, **kwargs):
     return F.dense_rank()
 
 
 @compiles(ops.PercentRank)
-def compile_percent_rank(t, expr, scope, timecontext, **kwargs):
+def compile_percent_rank(t, op, **kwargs):
     return F.percent_rank()
 
 
 @compiles(ops.CumeDist)
-def compile_cume_dist(t, expr, scope, timecontext, **kwargs):
+def compile_cume_dist(t, op, **kwargs):
     raise com.UnsupportedOperationError(
         'PySpark backend does not support cume_dist with Ibis.'
     )
 
 
 @compiles(ops.NTile)
-def compile_ntile(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    buckets = op.buckets.op().value
+def compile_ntile(t, op, **kwargs):
+    buckets = op.buckets.value
     return F.ntile(buckets)
 
 
 @compiles(ops.FirstValue)
-def compile_first_value(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_first_value(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.first(src_column)
 
 
 @compiles(ops.LastValue)
-def compile_last_value(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_last_value(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.last(src_column)
 
 
 @compiles(ops.NthValue)
-def compile_nth_value(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    src_column = t.translate(op.arg, scope, timecontext)
-    nth = t.translate(op.nth, scope, timecontext, raw=True)
+def compile_nth_value(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    nth = t.translate(op.nth, **kwargs, raw=True)
     return F.nth_value(src_column, nth + 1)
 
 
 @compiles(ops.RowNumber)
-def compile_row_number(t, expr, scope, timecontext, **kwargs):
+def compile_row_number(t, op, **kwargs):
     return F.row_number()
 
 
@@ -1511,101 +1280,91 @@ _time_unit_mapping = {
 
 
 @compiles(ops.Date)
-def compile_date(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_date(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.to_date(src_column).cast('timestamp')
 
 
-def _extract_component_from_datetime(
-    t, expr, scope, timecontext, *, extract_fn, **kwargs
-):
-    op = expr.op()
-    date_col = t.translate(op.arg, scope, timecontext)
+def _extract_component_from_datetime(t, op, extract_fn, **kwargs):
+    date_col = t.translate(op.arg, **kwargs)
     return extract_fn(date_col).cast('integer')
 
 
 @compiles(ops.ExtractYear)
-def compile_extract_year(t, expr, scope, timecontext, **kwargs):
-    return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.year, **kwargs
-    )
+def compile_extract_year(t, op, **kwargs):
+    return _extract_component_from_datetime(t, op, extract_fn=F.year, **kwargs)
 
 
 @compiles(ops.ExtractMonth)
-def compile_extract_month(t, expr, scope, timecontext, **kwargs):
+def compile_extract_month(t, op, **kwargs):
     return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.month, **kwargs
+        t, op, extract_fn=F.month, **kwargs
     )
 
 
 @compiles(ops.ExtractDay)
-def compile_extract_day(t, expr, scope, timecontext, **kwargs):
+def compile_extract_day(t, op, **kwargs):
     return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.dayofmonth, **kwargs
+        t, op, extract_fn=F.dayofmonth, **kwargs
     )
 
 
 @compiles(ops.ExtractDayOfYear)
-def compile_extract_day_of_year(t, expr, scope, timecontext, **kwargs):
+def compile_extract_day_of_year(t, op, **kwargs):
     return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.dayofyear, **kwargs
+        t, op, extract_fn=F.dayofyear, **kwargs
     )
 
 
 @compiles(ops.ExtractQuarter)
-def compile_extract_quarter(t, expr, scope, timecontext, **kwargs):
+def compile_extract_quarter(t, op, **kwargs):
     return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.quarter, **kwargs
+        t, op, extract_fn=F.quarter, **kwargs
     )
 
 
 @compiles(ops.ExtractEpochSeconds)
-def compile_extract_epoch_seconds(t, expr, scope, timecontext, **kwargs):
+def compile_extract_epoch_seconds(t, op, **kwargs):
     return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.unix_timestamp, **kwargs
+        t, op, extract_fn=F.unix_timestamp, **kwargs
     )
 
 
 @compiles(ops.ExtractWeekOfYear)
-def compile_extract_week_of_year(t, expr, scope, timecontext, **kwargs):
+def compile_extract_week_of_year(t, op, **kwargs):
     return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.weekofyear, **kwargs
+        t, op, extract_fn=F.weekofyear, **kwargs
     )
 
 
 @compiles(ops.ExtractHour)
-def compile_extract_hour(t, expr, scope, timecontext, **kwargs):
-    return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.hour, **kwargs
-    )
+def compile_extract_hour(t, op, **kwargs):
+    return _extract_component_from_datetime(t, op, extract_fn=F.hour, **kwargs)
 
 
 @compiles(ops.ExtractMinute)
-def compile_extract_minute(t, expr, scope, timecontext, **kwargs):
+def compile_extract_minute(t, op, **kwargs):
     return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.minute, **kwargs
+        t, op, extract_fn=F.minute, **kwargs
     )
 
 
 @compiles(ops.ExtractSecond)
-def compile_extract_second(t, expr, scope, timecontext, **kwargs):
+def compile_extract_second(t, op, **kwargs):
     return _extract_component_from_datetime(
-        t, expr, scope, timecontext, extract_fn=F.second, **kwargs
+        t, op, extract_fn=F.second, **kwargs
     )
 
 
 @compiles(ops.ExtractMillisecond)
-def compile_extract_millisecond(t, expr, scope, timecontext, **kwargs):
+def compile_extract_millisecond(t, op, **kwargs):
     raise com.UnsupportedOperationError(
         'PySpark backend does not support extracting milliseconds.'
     )
 
 
 @compiles(ops.DateTruncate)
-def compile_date_truncate(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
+def compile_date_truncate(t, op, **kwargs):
     try:
         unit = _time_unit_mapping[op.unit]
     except KeyError:
@@ -1613,32 +1372,30 @@ def compile_date_truncate(t, expr, scope, timecontext, **kwargs):
             f'{op.unit!r} unit is not supported in timestamp truncate'
         )
 
-    src_column = t.translate(op.arg, scope, timecontext)
+    src_column = t.translate(op.arg, **kwargs)
     return F.date_trunc(unit, src_column)
 
 
 @compiles(ops.TimestampTruncate)
-def compile_timestamp_truncate(t, expr, scope, timecontext, **kwargs):
-    return compile_date_truncate(t, expr, scope, timecontext, **kwargs)
+def compile_timestamp_truncate(t, op, **kwargs):
+    return compile_date_truncate(t, op, **kwargs)
 
 
 @compiles(ops.Strftime)
-def compile_strftime(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    format_str = op.format_str.op().value
+def compile_strftime(t, op, **kwargs):
+    format_str = op.format_str.value
 
     @pandas_udf('string', PandasUDFType.SCALAR)
     def strftime(timestamps):
         return timestamps.dt.strftime(format_str)
 
-    src_column = t.translate(op.arg, scope, timecontext)
+    src_column = t.translate(op.arg, **kwargs)
     return strftime(src_column)
 
 
 @compiles(ops.TimestampFromUNIX)
-def compile_timestamp_from_unix(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    unixtime = t.translate(op.arg, scope, timecontext)
+def compile_timestamp_from_unix(t, op, **kwargs):
+    unixtime = t.translate(op.arg, **kwargs)
     if not op.unit:
         return F.to_timestamp(F.from_unixtime(unixtime))
     elif op.unit == 's':
@@ -1652,18 +1409,16 @@ def compile_timestamp_from_unix(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.TimestampNow)
-def compile_timestamp_now(t, expr, scope, timecontext, **kwargs):
+def compile_timestamp_now(t, op, **kwargs):
     return F.current_timestamp()
 
 
 @compiles(ops.StringToTimestamp)
-def compile_string_to_timestamp(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
+def compile_string_to_timestamp(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    fmt = op.format_str.value
 
-    src_column = t.translate(op.arg, scope, timecontext)
-    fmt = op.format_str.op().value
-
-    if op.timezone is not None and op.timezone.op().value != "UTC":
+    if op.timezone is not None and op.timezone.value != "UTC":
         raise com.UnsupportedArgumentError(
             'PySpark backend only supports timezone UTC for converting string '
             'to timestamp.'
@@ -1673,43 +1428,35 @@ def compile_string_to_timestamp(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.DayOfWeekIndex)
-def compile_day_of_week_index(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
+def compile_day_of_week_index(t, op, **kwargs):
     @pandas_udf('short', PandasUDFType.SCALAR)
     def day_of_week(s):
         return s.dt.dayofweek
 
-    src_column = t.translate(op.arg, scope, timecontext)
+    src_column = t.translate(op.arg, **kwargs)
     return day_of_week(src_column.cast('timestamp'))
 
 
 @compiles(ops.DayOfWeekName)
-def compiles_day_of_week_name(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
+def compiles_day_of_week_name(t, op, **kwargs):
     @pandas_udf('string', PandasUDFType.SCALAR)
     def day_name(s):
         return s.dt.day_name()
 
-    src_column = t.translate(op.arg, scope, timecontext)
+    src_column = t.translate(op.arg, **kwargs)
     return day_name(src_column.cast('timestamp'))
 
 
-def _get_interval_col(
-    t, interval_ibis_expr, scope, timecontext, allowed_units=None
-):
+def _get_interval_col(t, op, allowed_units=None, **kwargs):
     # if interval expression is a binary op, translate expression into
     # an interval column and return
-    if isinstance(interval_ibis_expr.op(), ops.IntervalBinary):
-        return t.translate(interval_ibis_expr, scope, timecontext)
+    if isinstance(op, ops.IntervalBinary):
+        return t.translate(op, **kwargs)
 
     # otherwise, translate expression into a literal op and construct
     # interval column from literal value and dtype
-    if isinstance(interval_ibis_expr.op(), ops.Literal):
-        op = interval_ibis_expr.op()
-    else:
-        op = t.translate(interval_ibis_expr, scope, timecontext).op()
+    if not isinstance(op, ops.Literal):
+        op = t.translate(op, **kwargs)
 
     dtype = op.dtype
     if not isinstance(dtype, dt.Interval):
@@ -1736,25 +1483,18 @@ def _get_interval_col(
         return F.expr(f'INTERVAL {op.value} {_time_unit_mapping[dtype.unit]}')
 
 
-def _compile_datetime_binop(
-    t, expr, scope, timecontext, *, fn, allowed_units, **kwargs
-):
-    op = expr.op()
-
-    left = t.translate(op.left, scope, timecontext)
-    right = _get_interval_col(t, op.right, scope, timecontext, allowed_units)
-
+def _compile_datetime_binop(t, op, *, fn, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = _get_interval_col(t, op.right, **kwargs)
     return fn(left, right)
 
 
 @compiles(ops.DateAdd)
-def compile_date_add(t, expr, scope, timecontext, **kwargs):
+def compile_date_add(t, op, **kwargs):
     allowed_units = ['Y', 'W', 'M', 'D']
     return _compile_datetime_binop(
         t,
-        expr,
-        scope,
-        timecontext,
+        op,
         fn=(lambda l, r: (l + r).cast('timestamp')),
         allowed_units=allowed_units,
         **kwargs,
@@ -1762,13 +1502,11 @@ def compile_date_add(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.DateSub)
-def compile_date_sub(t, expr, scope, timecontext, **kwargs):
+def compile_date_sub(t, op, **kwargs):
     allowed_units = ['Y', 'W', 'M', 'D']
     return _compile_datetime_binop(
         t,
-        expr,
-        scope,
-        timecontext,
+        op,
         fn=(lambda l, r: (l - r).cast('timestamp')),
         allowed_units=allowed_units,
         **kwargs,
@@ -1776,7 +1514,7 @@ def compile_date_sub(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.DateDiff)
-def compile_date_diff(t, expr, scope, timecontext, **kwargs):
+def compile_date_diff(t, op, **kwargs):
     raise com.UnsupportedOperationError(
         'PySpark backend does not support DateDiff as there is no '
         'timedelta type.'
@@ -1784,13 +1522,11 @@ def compile_date_diff(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.TimestampAdd)
-def compile_timestamp_add(t, expr, scope, timecontext, **kwargs):
+def compile_timestamp_add(t, op, **kwargs):
     allowed_units = ['Y', 'W', 'M', 'D', 'h', 'm', 's']
     return _compile_datetime_binop(
         t,
-        expr,
-        scope,
-        timecontext,
+        op,
         fn=(lambda l, r: (l + r).cast('timestamp')),
         allowed_units=allowed_units,
         **kwargs,
@@ -1798,13 +1534,11 @@ def compile_timestamp_add(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.TimestampSub)
-def compile_timestamp_sub(t, expr, scope, timecontext, **kwargs):
+def compile_timestamp_sub(t, op, **kwargs):
     allowed_units = ['Y', 'W', 'M', 'D', 'h', 'm', 's']
     return _compile_datetime_binop(
         t,
-        expr,
-        scope,
-        timecontext,
+        op,
         fn=(lambda l, r: (l - r).cast('timestamp')),
         allowed_units=allowed_units,
         **kwargs,
@@ -1812,38 +1546,32 @@ def compile_timestamp_sub(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.TimestampDiff)
-def compile_timestamp_diff(t, expr, scope, timecontext, **kwargs):
+def compile_timestamp_diff(t, op, **kwargs):
     raise com.UnsupportedOperationError(
         'PySpark backend does not support TimestampDiff as there is no '
         'timedelta type.'
     )
 
 
-def _compile_interval_binop(t, expr, scope, timecontext, *, fn, **kwargs):
-    op = expr.op()
-
-    left = _get_interval_col(t, op.left, scope, timecontext)
-    right = _get_interval_col(t, op.right, scope, timecontext)
+def _compile_interval_binop(t, op, fn, **kwargs):
+    left = _get_interval_col(t, op.left, **kwargs)
+    right = _get_interval_col(t, op.right, **kwargs)
 
     return fn(left, right)
 
 
 @compiles(ops.IntervalAdd)
-def compile_interval_add(t, expr, scope, timecontext, **kwargs):
-    return _compile_interval_binop(
-        t, expr, scope, timecontext, fn=(lambda l, r: l + r), **kwargs
-    )
+def compile_interval_add(t, op, **kwargs):
+    return _compile_interval_binop(t, op, fn=(lambda l, r: l + r), **kwargs)
 
 
 @compiles(ops.IntervalSubtract)
-def compile_interval_subtract(t, expr, scope, timecontext, **kwargs):
-    return _compile_interval_binop(
-        t, expr, scope, timecontext, fn=(lambda l, r: l - r), **kwargs
-    )
+def compile_interval_subtract(t, op, **kwargs):
+    return _compile_interval_binop(t, op, fn=(lambda l, r: l - r), **kwargs)
 
 
 @compiles(ops.IntervalFromInteger)
-def compile_interval_from_integer(t, expr, scope, timecontext, **kwargs):
+def compile_interval_from_integer(t, op, **kwargs):
     raise com.UnsupportedOperationError(
         'Interval from integer column is unsupported for the PySpark backend.'
     )
@@ -1853,68 +1581,55 @@ def compile_interval_from_integer(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.ArrayColumn)
-def compile_array_column(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    cols = t.translate(op.cols, scope, timecontext)
+def compile_array_column(t, op, **kwargs):
+    cols = t.translate(op.cols, **kwargs)
     return F.array(cols)
 
 
 @compiles(ops.ArrayLength)
-def compile_array_length(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_array_length(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.size(src_column)
 
 
 @compiles(ops.ArraySlice)
-def compile_array_slice(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    start = op.start.op().value if op.start is not None else op.start
-    stop = op.stop.op().value if op.stop is not None else op.stop
-    spark_type = ibis_array_dtype_to_spark_dtype(op.arg.type())
+def compile_array_slice(t, op, **kwargs):
+    start = op.start.value if op.start is not None else op.start
+    stop = op.stop.value if op.stop is not None else op.stop
+    spark_type = ibis_array_dtype_to_spark_dtype(op.arg.output_dtype)
 
     @F.udf(spark_type)
     def array_slice(array):
         return array[start:stop]
 
-    src_column = t.translate(op.arg, scope, timecontext)
+    src_column = t.translate(op.arg, **kwargs)
     return array_slice(src_column)
 
 
 @compiles(ops.ArrayIndex)
-def compile_array_index(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    index = op.index.op().value + 1
+def compile_array_index(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    index = op.index.value + 1
     return F.element_at(src_column, index)
 
 
 @compiles(ops.ArrayConcat)
-def compile_array_concat(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    left = t.translate(op.left, scope, timecontext)
-    right = t.translate(op.right, scope, timecontext)
+def compile_array_concat(t, op, **kwargs):
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
     return F.concat(left, right)
 
 
 @compiles(ops.ArrayRepeat)
-def compile_array_repeat(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
-    times = op.times.op().value
+def compile_array_repeat(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    times = op.times.value
     return F.flatten(F.array_repeat(src_column, times))
 
 
 @compiles(ops.ArrayCollect)
-def compile_array_collect(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
-    src_column = t.translate(op.arg, scope, timecontext)
+def compile_array_collect(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
     return F.collect_list(src_column)
 
 
@@ -1922,57 +1637,51 @@ def compile_array_collect(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.NullLiteral)
-def compile_null_literal(t, expr, scope, timecontext, **kwargs):
+def compile_null_literal(t, op, **kwargs):
     return F.lit(None)
 
 
 @compiles(ops.IfNull)
-def compile_if_null(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    col = t.translate(op.arg, scope, timecontext)
-    ifnull_col = t.translate(op.ifnull_expr, scope, timecontext)
+def compile_if_null(t, op, **kwargs):
+    col = t.translate(op.arg, **kwargs)
+    ifnull_col = t.translate(op.ifnull_expr, **kwargs)
     return F.when(col.isNull() | F.isnan(col), ifnull_col).otherwise(col)
 
 
 @compiles(ops.NullIf)
-def compile_null_if(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    col = t.translate(op.arg, scope, timecontext)
-    nullif_col = t.translate(op.null_if_expr, scope, timecontext)
+def compile_null_if(t, op, **kwargs):
+    col = t.translate(op.arg, **kwargs)
+    nullif_col = t.translate(op.null_if_expr, **kwargs)
     return F.when(col == nullif_col, F.lit(None)).otherwise(col)
 
 
 @compiles(ops.IsNull)
-def compile_is_null(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    col = t.translate(op.arg, scope, timecontext)
+def compile_is_null(t, op, **kwargs):
+    col = t.translate(op.arg, **kwargs)
     return F.isnull(col) | F.isnan(col)
 
 
 @compiles(ops.NotNull)
-def compile_not_null(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    col = t.translate(op.arg, scope, timecontext)
+def compile_not_null(t, op, **kwargs):
+    col = t.translate(op.arg, **kwargs)
     return ~F.isnull(col) & ~F.isnan(col)
 
 
 @compiles(ops.DropNa)
-def compile_dropna_table(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    table = t.translate(op.table, scope, timecontext)
-    subset = [col.get_name() for col in op.subset] if op.subset else None
+def compile_dropna_table(t, op, **kwargs):
+    table = t.translate(op.table, **kwargs)
+    subset = [col.resolve_name() for col in op.subset] if op.subset else None
     return table.dropna(how=op.how, subset=subset)
 
 
 @compiles(ops.FillNa)
-def compile_fillna_table(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    table = t.translate(op.table, scope, timecontext)
+def compile_fillna_table(t, op, **kwargs):
+    table = t.translate(op.table, **kwargs)
     raw_replacements = op.replacements
     replacements = (
         dict(raw_replacements)
         if isinstance(raw_replacements, frozendict)
-        else raw_replacements.op().value
+        else raw_replacements.value
     )
     return table.fillna(replacements)
 
@@ -1981,39 +1690,35 @@ def compile_fillna_table(t, expr, scope, timecontext, **kwargs):
 
 
 @compiles(ops.ElementWiseVectorizedUDF)
-def compile_elementwise_udf(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
+def compile_elementwise_udf(t, op, **kwargs):
     spark_output_type = spark_dtype(op.return_type)
     func = op.func
     spark_udf = pandas_udf(func, spark_output_type, PandasUDFType.SCALAR)
-    func_args = (t.translate(arg, scope, timecontext) for arg in op.func_args)
+    func_args = (t.translate(arg, **kwargs) for arg in op.func_args)
     return spark_udf(*func_args)
 
 
 @compiles(ops.ReductionVectorizedUDF)
-def compile_reduction_udf(t, expr, scope, timecontext, context=None, **kwargs):
-    op = expr.op()
-
+def compile_reduction_udf(t, op, *, aggcontext=None, **kwargs):
     spark_output_type = spark_dtype(op.return_type)
     spark_udf = pandas_udf(
         op.func, spark_output_type, PandasUDFType.GROUPED_AGG
     )
-    func_args = (t.translate(arg, scope, timecontext) for arg in op.func_args)
+    func_args = (t.translate(arg, **kwargs) for arg in op.func_args)
 
     col = spark_udf(*func_args)
-    if context:
+    if aggcontext:
         return col
     else:
-        src_table = t.translate(op.func_args[0].op().table, scope, timecontext)
+        src_table = t.translate(op.func_args[0].table, **kwargs)
         return src_table.agg(col)
 
 
 @compiles(ops.SearchedCase)
-def compile_searched_case(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
+def compile_searched_case(t, op, **kwargs):
     existing_when = None
 
-    for case, result in zip(op.cases, op.results):
+    for case, result in zip(op.cases.values, op.results.values):
         if existing_when is not None:
             # Spark allowed chained when statement
             when = existing_when.when
@@ -2021,59 +1726,54 @@ def compile_searched_case(t, expr, scope, timecontext, **kwargs):
             when = F.when
 
         existing_when = when(
-            t.translate(case, scope, timecontext, **kwargs),
-            t.translate(result, scope, timecontext, **kwargs),
+            t.translate(case, **kwargs),
+            t.translate(result, **kwargs),
         )
 
-    return existing_when.otherwise(
-        t.translate(op.default, scope, timecontext, **kwargs)
-    )
+    return existing_when.otherwise(t.translate(op.default, **kwargs))
 
 
 @compiles(ops.View)
-def compile_view(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
+def compile_view(t, op, **kwargs):
     name = op.name
     child = op.child
-    backend = child._find_backend()
+    # TODO(kszucs): avoid converting to expr
+    backend = child.to_expr()._find_backend()
     tables = backend._session.catalog.listTables()
     if any(name == table.name and not table.isTemporary for table in tables):
         raise ValueError(
             f"table or non-temporary view `{name}` already exists"
         )
-    result = t.translate(child, scope, timecontext, **kwargs)
+    result = t.translate(child, **kwargs)
     result.createOrReplaceTempView(name)
     return result
 
 
 @compiles(ops.SQLStringView)
-def compile_sql_view(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    backend = op.child._find_backend()
+def compile_sql_view(t, op, **kwargs):
+    # TODO(kszucs): avoid converting to expr
+    backend = op.child.to_expr()._find_backend()
     result = backend._session.sql(op.query)
     result.createOrReplaceTempView(op.name)
     return result
 
 
 @compiles(ops.StringContains)
-def compile_string_contains(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    haystack = t.translate(op.haystack, scope, timecontext, **kwargs)
-    needle = t.translate(op.needle, scope, timecontext, **kwargs)
+def compile_string_contains(t, op, **kwargs):
+    haystack = t.translate(op.haystack, **kwargs)
+    needle = t.translate(op.needle, **kwargs)
     return haystack.contains(needle)
 
 
 @compiles(ops.Unnest)
-def compile_unnest(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    column = t.translate(op.arg, scope, timecontext, **kwargs)
+def compile_unnest(t, op, **kwargs):
+    column = t.translate(op.arg, **kwargs)
     return F.explode(column)
 
 
 @compiles(ops.NullIfZero)
-def compile_null_if_zero(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    arg = t.translate(op.arg, scope, timecontext, **kwargs)
+def compile_null_if_zero(t, op, **kwargs):
+    arg = t.translate(op.arg, **kwargs)
     return F.when(arg == 0, F.lit(None)).otherwise(arg)
 
 
@@ -2083,52 +1783,47 @@ def compile_null_if_zero(t, expr, scope, timecontext, **kwargs):
 @compiles(ops.Cos)
 @compiles(ops.Sin)
 @compiles(ops.Tan)
-def compile_trig(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    arg = t.translate(op.arg, scope, timecontext, **kwargs)
+def compile_trig(t, op, **kwargs):
+    arg = t.translate(op.arg, **kwargs)
     func_name = op.__class__.__name__.lower()
     func = getattr(F, func_name)
     return func(arg)
 
 
 @compiles(ops.Cot)
-def compile_cot(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    arg = t.translate(op.arg, scope, timecontext, **kwargs)
+def compile_cot(t, op, **kwargs):
+    arg = t.translate(op.arg, **kwargs)
     return F.cos(arg) / F.sin(arg)
 
 
 @compiles(ops.Atan2)
-def compile_atan2(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-    y, x = (t.translate(arg, scope, timecontext, **kwargs) for arg in op.args)
+def compile_atan2(t, op, **kwargs):
+    y, x = (t.translate(arg, **kwargs) for arg in op.args)
     return F.atan2(y, x)
 
 
 @compiles(ops.Degrees)
-def compile_degrees(t, expr, scope, timecontext, **kwargs):
-    return F.degrees(t.translate(expr.op().arg, scope, timecontext, **kwargs))
+def compile_degrees(t, op, **kwargs):
+    return F.degrees(t.translate(op.arg, **kwargs))
 
 
 @compiles(ops.Radians)
-def compile_radians(t, expr, scope, timecontext, **kwargs):
-    return F.radians(t.translate(expr.op().arg, scope, timecontext, **kwargs))
+def compile_radians(t, op, **kwargs):
+    return F.radians(t.translate(op.arg, **kwargs))
 
 
 @compiles(ops.ZeroIfNull)
-def compile_zero_if_null(t, expr, scope, timecontext, **kwargs):
-    col = t.translate(expr.op().arg, scope, timecontext, **kwargs)
+def compile_zero_if_null(t, op, **kwargs):
+    col = t.translate(op.arg, **kwargs)
     return F.when(col.isNull() | F.isnan(col), F.lit(0)).otherwise(col)
 
 
 @compiles(ops.Where)
-def compile_where(t, expr, scope, timecontext, **kwargs):
-    op = expr.op()
-
+def compile_where(t, op, **kwargs):
     return F.when(
-        t.translate(op.bool_expr, scope, timecontext, **kwargs),
-        t.translate(op.true_expr, scope, timecontext, **kwargs),
-    ).otherwise(t.translate(op.false_null_expr, scope, timecontext, **kwargs))
+        t.translate(op.bool_expr, **kwargs),
+        t.translate(op.true_expr, **kwargs),
+    ).otherwise(t.translate(op.false_null_expr, **kwargs))
 
 
 @compiles(ops.RandomScalar)

--- a/ibis/backends/sqlite/compiler.py
+++ b/ibis/backends/sqlite/compiler.py
@@ -41,17 +41,19 @@ rewrites = SQLiteExprTranslator.rewrites
 
 
 @rewrites(ops.DayOfWeekIndex)
-def day_of_week_index(expr):
-    return ((expr.op().arg.strftime('%w').cast(dt.int16) + 6) % 7).cast(
-        dt.int16
-    )
+def day_of_week_index(op):
+    # TODO(kszucs): avoid expr roundtrip
+    expr = op.arg.to_expr()
+    new_expr = ((expr.strftime('%w').cast(dt.int16) + 6) % 7).cast(dt.int16)
+    return new_expr.op()
 
 
 @rewrites(ops.DayOfWeekName)
-def day_of_week_name(expr):
-    return (
-        expr.op()
-        .arg.day_of_week.index()
+def day_of_week_name(op):
+    # TODO(kszucs): avoid expr roundtrip
+    expr = op.arg.to_expr()
+    new_expr = (
+        expr.day_of_week.index()
         .case()
         .when(0, 'Monday')
         .when(1, 'Tuesday')
@@ -63,6 +65,7 @@ def day_of_week_name(expr):
         .else_(ibis.NA)
         .end()
     )
+    return new_expr.op()
 
 
 class SQLiteCompiler(AlchemyCompiler):

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -24,9 +24,10 @@ sa = pytest.importorskip("sqlalchemy")
             lambda t: t.double_col.cast(dt.int8),
             lambda at: sa.cast(at.c.double_col, sa.SMALLINT),
         ),
+        # TODO(kszucs): double check the validity of this test case
         (
             lambda t: t.string_col.cast(dt.float64),
-            lambda at: sa.cast(at.c.string_col, sa.REAL),
+            lambda at: sa.cast(at.c.string_col, sa.FLOAT),
         ),
         (
             lambda t: t.string_col.cast(dt.float32),
@@ -35,7 +36,8 @@ sa = pytest.importorskip("sqlalchemy")
     ],
 )
 def test_cast(alltypes, alltypes_sqla, translate, func, expected):
-    assert translate(func(alltypes)) == str(expected(alltypes_sqla))
+    expr = func(alltypes)
+    assert translate(expr.op()) == str(expected(alltypes_sqla))
 
 
 @pytest.mark.parametrize(
@@ -59,7 +61,7 @@ def test_timestamp_cast_noop(
     # See GH #592
     result = func(alltypes)
     expected = expected_func(alltypes_sqla)
-    assert translate(result) == sqla_compile(expected)
+    assert translate(result.op()) == sqla_compile(expected)
 
 
 def test_timestamp_functions(con):
@@ -231,7 +233,7 @@ def test_str_replace(con):
     ],
 )
 def test_math_functions(con, expr, expected):
-    assert con.execute(expr) == expected
+    assert con.execute(expr.op()) == expected
 
 
 NULL_STRING = L(None).cast(dt.string)

--- a/ibis/common/geospatial.py
+++ b/ibis/common/geospatial.py
@@ -1,8 +1,9 @@
 from typing import Iterable, List, TypeVar
 
 import ibis.expr.datatypes as dt
-import ibis.expr.types as ir
 from ibis.common import exceptions as ex
+
+# TODO(kszucs): move this module to the base sql backend
 
 NumberType = TypeVar('NumberType', int, float)
 # Geometry primitives (2D)
@@ -126,23 +127,23 @@ def translate_multipolygon(value: List) -> str:
     return f"MULTIPOLYGON ({_format_multipolygon_value(value)})"
 
 
-def translate_literal(expr, inline_metadata: bool = False) -> str:
-    op = expr.op()
+def translate_literal(op, inline_metadata: bool = False) -> str:
     value = op.value
+    dtype = op.output_dtype
 
     if isinstance(value, dt._WellKnownText):
         result = value.text
-    elif isinstance(expr, ir.PointScalar):
+    elif isinstance(dtype, dt.Point):
         result = translate_point(value)
-    elif isinstance(expr, ir.LineStringScalar):
+    elif isinstance(dtype, dt.LineString):
         result = translate_linestring(value)
-    elif isinstance(expr, ir.PolygonScalar):
+    elif isinstance(dtype, dt.Polygon):
         result = translate_polygon(value)
-    elif isinstance(expr, ir.MultiLineStringScalar):
+    elif isinstance(dtype, dt.MultiLineString):
         result = translate_multilinestring(value)
-    elif isinstance(expr, ir.MultiPointScalar):
+    elif isinstance(dtype, dt.MultiPoint):
         result = translate_multipoint(value)
-    elif isinstance(expr, ir.MultiPolygonScalar):
+    elif isinstance(dtype, dt.MultiPolygon):
         result = translate_multipolygon(value)
     else:
         raise ex.UnboundExpressionError('Geo Spatial type not supported.')

--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod
 from typing import Any, Hashable
 from weakref import WeakValueDictionary
 
@@ -36,6 +36,17 @@ class Base(metaclass=BaseMeta):
     @classmethod
     def __create__(cls, *args, **kwargs):
         return type.__call__(cls, *args, **kwargs)
+
+
+class Immutable(Hashable):
+
+    __slots__ = ()
+
+    def __setattr__(self, name: str, _: Any) -> None:
+        raise TypeError(
+            f"Attribute {name!r} cannot be assigned to immutable instance of "
+            f"type {type(self)}"
+        )
 
 
 class AnnotableMeta(BaseMeta):
@@ -100,11 +111,12 @@ class AnnotableMeta(BaseMeta):
         attribs["__slots__"] = tuple(slots)
         attribs["__signature__"] = signature
         attribs["__properties__"] = properties
+        # TODO(kszucs): rename to __argnames__
         attribs["argnames"] = tuple(signature.parameters.keys())
         return super().__new__(metacls, clsname, bases, attribs)
 
 
-class Annotable(Base, Hashable, metaclass=AnnotableMeta):
+class Annotable(Base, Immutable, metaclass=AnnotableMeta):
     """Base class for objects with custom validation rules."""
 
     __slots__ = ("args", "_hash")
@@ -123,7 +135,9 @@ class Annotable(Base, Hashable, metaclass=AnnotableMeta):
 
         # optimizations to store frequently accessed generic properties
         args = tuple(kwargs[name] for name in self.argnames)
+        # TODO(kszucs): rename to __args__
         object.__setattr__(self, "args", args)
+        # TODO(kszucs): rename to __precomputed_hash__
         object.__setattr__(self, "_hash", hash((self.__class__, args)))
 
         # calculate special property-like objects only once due to the
@@ -143,12 +157,6 @@ class Annotable(Base, Hashable, metaclass=AnnotableMeta):
     def __eq__(self, other):
         return super().__eq__(other)
 
-    def __setattr__(self, name: str, _: Any) -> None:
-        raise TypeError(
-            f"Attribute {name!r} cannot be assigned to immutable instance of "
-            f"type {type(self)}"
-        )
-
     def __repr__(self) -> str:
         args = ", ".join(
             f"{name}={value!r}"
@@ -167,10 +175,23 @@ class Annotable(Base, Hashable, metaclass=AnnotableMeta):
         kwargs = dict(zip(self.argnames, self.args))
         return (self._reconstruct, (kwargs,))
 
+    # TODO(kszucs): consider to make a separate mixin class for this
+    def copy(self, **overrides):
+        kwargs = dict(zip(self.argnames, self.args))
+        newargs = {**kwargs, **overrides}
+        return self.__class__(**newargs)
 
-class Singleton(Base):
+
+class Weakrefable(Base):
 
     __slots__ = ('__weakref__',)
+
+
+class Singleton(Weakrefable):
+    # NOTE: this only considers the input arguments, when combined with
+    # Annotable base class Singleton must come after in the MRO
+
+    __slots__ = ()
     __instances__ = WeakValueDictionary()
 
     @classmethod
@@ -184,9 +205,9 @@ class Singleton(Base):
             return instance
 
 
-class Comparable(ABC):
+class Comparable(Weakrefable):
 
-    __slots__ = ('__weakref__',)
+    __slots__ = ()
     __cache__ = WeakCache()
 
     def __hash__(self):

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-import collections
 import functools
 import operator
 from collections import Counter
-from typing import Sequence
 
 import toolz
 
+import ibis.expr.datatypes as dt
 import ibis.expr.lineage as lin
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common.exceptions import IbisTypeError
+from ibis.expr.rules import Shape
 from ibis.expr.window import window
 
 # ---------------------------------------------------------------------
@@ -20,7 +20,7 @@ from ibis.expr.window import window
 # compilation later
 
 
-def sub_for(expr, substitutions):
+def sub_for(node, substitutions):
     """Substitute subexpressions in `expr` with expression to expression
     mapping `substitutions`.
 
@@ -38,22 +38,22 @@ def sub_for(expr, substitutions):
     ibis.expr.types.Expr
         An Ibis expression
     """
-
-    mapping = {k.op(): v for k, v in substitutions}
+    assert isinstance(node, ops.Node), type(node)
 
     def fn(node):
         try:
-            return mapping[node]
+            return substitutions[node]
         except KeyError:
             if node.blocks():
-                return node.to_expr()
+                return node
             return lin.proceed
 
-    return substitute(fn, expr)
+    return substitute(fn, node)
 
 
 class ScalarAggregate:
     def __init__(self, expr):
+        assert isinstance(expr, ir.Expr)
         self.expr = expr
         self.tables = []
 
@@ -68,41 +68,54 @@ class ScalarAggregate:
         return table.projection([subbed_expr])
 
     def _visit(self, expr):
-        if is_scalar_reduction(expr) and not has_multiple_bases(expr):
+        assert isinstance(expr, ir.Expr), type(expr)
+
+        if is_scalar_reduction(expr.op()) and not has_multiple_bases(
+            expr.op()
+        ):
             # An aggregation unit
             if not expr.has_name():
                 expr = expr.name('tmp')
-            agg_expr = reduction_to_aggregation(expr)
+            agg_expr = reduction_to_aggregation(expr.op())
             self.tables.append(agg_expr)
             return agg_expr[expr.get_name()]
         elif not isinstance(expr, ir.Expr):
             return expr
 
         node = expr.op()
-        new_expr = node.__class__(*map(self._visit, node.args)).to_expr()
+        # TODO(kszucs): use the substitute() utility instead
+        new_args = (
+            self._visit(arg.to_expr()) if isinstance(arg, ops.Node) else arg
+            for arg in node.args
+        )
+        new_node = node.__class__(*new_args)
+        new_expr = new_node.to_expr()
+
         if expr.has_name():
             new_expr = new_expr.name(name=expr.get_name())
 
         return new_expr
 
 
-def has_multiple_bases(expr):
-    return len(find_immediate_parent_tables(expr)) > 1
+def has_multiple_bases(node):
+    assert isinstance(node, ops.Node), type(node)
+    return len(find_immediate_parent_tables(node)) > 1
 
 
-def reduction_to_aggregation(expr):
-    tables = find_immediate_parent_tables(expr)
+def reduction_to_aggregation(node):
+    tables = find_immediate_parent_tables(node)
 
+    # TODO(kszucs): avoid the expression roundtrip
     if len(tables) == 1:
         (table,) = tables
-        agg = table.to_expr().aggregate([expr])
+        agg = table.to_expr().aggregate([node.to_expr()])
     else:
-        agg = ScalarAggregate(expr).get_result()
+        agg = ScalarAggregate(node.to_expr()).get_result()
 
     return agg
 
 
-def find_immediate_parent_tables(expr):
+def find_immediate_parent_tables(node):
     """Find every first occurrence of a :class:`ibis.expr.types.Table`
     object in `expr`.
 
@@ -135,58 +148,54 @@ def find_immediate_parent_tables(expr):
         r0
         foo: r0.a + 1
     """
+    assert all(isinstance(arg, ops.Node) for arg in util.promote_list(node))
 
-    def finder(expr):
-        op = expr.op()
-        if isinstance(op, ops.TableNode):
-            return lin.halt, op
+    def finder(node):
+        if isinstance(node, ops.TableNode):
+            return lin.halt, node
         else:
             return lin.proceed, None
 
-    return list(toolz.unique(lin.traverse(finder, expr)))
+    return list(toolz.unique(lin.traverse(finder, node)))
 
 
-def substitute(fn, expr):
+def substitute(fn, node):
     """Substitute expressions with other expressions."""
-    node = expr.op()
+
+    assert isinstance(node, ops.Node), type(node)
 
     result = fn(node)
     if result is lin.halt:
-        return expr
+        return node
     elif result is not lin.proceed:
-        assert isinstance(result, ir.Expr), type(result)
+        assert isinstance(result, ops.Node), type(result)
         return result
 
     new_args = []
     for arg in node.args:
         if isinstance(arg, tuple):
             arg = tuple(
-                substitute(fn, expr) if isinstance(arg, ir.Expr) else expr
-                for expr in arg
+                substitute(fn, x) if isinstance(arg, ops.Node) else x
+                for x in arg
             )
-        elif isinstance(arg, ir.Expr):
+        elif isinstance(arg, ops.Node):
             arg = substitute(fn, arg)
         new_args.append(arg)
 
     try:
-        new_node = node.__class__(*new_args)
+        return node.__class__(*new_args)
     except IbisTypeError:
-        return expr
-    else:
-        # unfortunately we can't use `.to_expr()` here because it's not backend
-        # aware, and some backends have their own ir.Table subclasses, like
-        # impala. There's probably a design flaw in the modeling of
-        # backend-specific expressions.
-        return type(expr)(new_node)
+        return node
 
 
-def substitute_parents(expr):
+def substitute_parents(node):
     """
     Rewrite the input expression by replacing any table expressions part of a
     "commutative table operation unit" (for lack of scientific term, a set of
     operations that can be written down in any order and still yield the same
     semantic result)
     """
+    assert isinstance(node, ops.Node), type(node)
 
     def fn(node):
         if isinstance(node, ops.Selection):
@@ -198,20 +207,20 @@ def substitute_parents(expr):
             # table schema or is a derived field. If we've projected out of
             # something other than a physical table, then lifting should not
             # occur
-            table = node.table.op()
+            table = node.table
 
             if isinstance(table, ops.Selection):
                 for val in table.selections:
                     if (
-                        isinstance(val.op(), ops.PhysicalTable)
-                        and node.name in val.schema()
+                        isinstance(val, ops.PhysicalTable)
+                        and node.name in val.schema
                     ):
-                        return ops.TableColumn(val, node.name).to_expr()
+                        return ops.TableColumn(val, node.name)
 
         # keep looking for nodes to substitute
         return lin.proceed
 
-    return substitute(fn, expr)
+    return substitute(fn, node)
 
 
 def get_mutation_exprs(
@@ -259,7 +268,6 @@ def apply_filter(expr, predicates):
     # This will attempt predicate pushdown in the cases where we can do it
     # easily and safely, to make both cleaner SQL and fewer referential errors
     # for users
-
     op = expr.op()
 
     if isinstance(op, ops.Selection):
@@ -273,7 +281,7 @@ def apply_filter(expr, predicates):
             # after aggregations.
             #
             # See https://github.com/ibis-project/ibis/pull/3341 for details
-            sub_for(predicate, [(op.table, expr)])
+            sub_for(predicate, {op.table: op})
             if not is_reduction(predicate)
             else predicate
             for predicate in predicates
@@ -317,7 +325,7 @@ def _filter_selection(expr, predicates):
         # rewritten in terms of the child table. This prevents the broken
         # ref issue (described in more detail in #59)
         simplified_predicates = tuple(
-            sub_for(predicate, [(expr, op.table)])
+            sub_for(predicate, {op: op.table})
             if not is_reduction(predicate)
             else predicate
             for predicate in predicates
@@ -366,6 +374,8 @@ def _can_pushdown(op, predicates):
     #    the entire tables or a single column selection)
 
     for pred in predicates:
+        if isinstance(pred, ir.Expr):
+            pred = pred.op()
         validator = _PushdownValidate(op, pred)
         predicate_is_valid = validator.get_result()
         if not predicate_is_valid:
@@ -373,92 +383,81 @@ def _can_pushdown(op, predicates):
     return True
 
 
+# TODO(kszucs): rewrite to only work with operation objects
 class _PushdownValidate:
     def __init__(self, parent, predicate):
         self.parent = parent
         self.pred = predicate
 
     def get_result(self):
-        def validate(expr):
-            op = expr.op()
-            if isinstance(op, ops.TableColumn):
-                return lin.proceed, self._validate_projection(expr)
+        assert isinstance(self.pred, ops.Node), type(self.pred)
+
+        def validate(node):
+            if isinstance(node, ops.TableColumn):
+                return lin.proceed, self._validate_projection(node)
             return lin.proceed, None
 
-        return all(lin.traverse(validate, self.pred, type=ir.Value))
+        return all(lin.traverse(validate, self.pred))  # , type=ir.Value))
 
-    def _validate_projection(self, expr):
+    def _validate_projection(self, node):
         is_valid = False
-        node = expr.op()
 
         for val in self.parent.selections:
-            if (
-                isinstance(val.op(), ops.PhysicalTable)
-                and node.name in val.schema()
-            ):
+            if isinstance(val, ops.PhysicalTable) and node.name in val.schema:
                 is_valid = True
             elif (
-                isinstance(val.op(), ops.TableColumn)
-                and node.name == val.get_name()
+                isinstance(val, ops.TableColumn)
+                and node.name == val.resolve_name()
             ):
                 # Aliased table columns are no good
-                col_table = val.op().table.op()
-                is_valid = col_table.equals(node.table.op())
+                col_table = val.table
+                is_valid = col_table.equals(node.table)
 
         return is_valid
 
 
+# TODO(kszucs): rewrite to receive and return an ops.Node
 def windowize_function(expr, w=None):
-    def _windowize(x, w):
-        if not isinstance(x.op(), ops.Window):
-            walked = _walk(x, w)
+    assert isinstance(expr, ir.Expr), type(expr)
+
+    def _windowize(op, w):
+        if not isinstance(op, ops.Window):
+            walked = _walk(op, w)
         else:
-            window_arg, window_w = x.op().args
+            window_arg, window_w = op.args
             walked_child = _walk(window_arg, w)
 
             if walked_child is not window_arg:
-                op = ops.Window(walked_child, window_w)
-                walked = op.to_expr().name(x.get_name())
+                walked = ops.Window(walked_child, window_w)
             else:
-                walked = x
+                walked = op
 
-        op = walked.op()
-        if isinstance(op, (ops.Analytic, ops.Reduction)):
+        if isinstance(walked, (ops.Analytic, ops.Reduction)):
             if w is None:
                 w = window()
-            return walked.over(w)
-        elif isinstance(op, ops.Window):
+            return walked.to_expr().over(w).op()
+        elif isinstance(walked, ops.Window):
             if w is not None:
-                return walked.over(w.combine(op.window))
+                return walked.to_expr().over(w.combine(walked.window)).op()
             else:
                 return walked
         else:
             return walked
 
-    def _walk(x, w):
-        op = x.op()
-
-        unchanged = True
+    def _walk(op, w):
+        # TODO(kszucs): rewrite to use the substitute utility
         windowed_args = []
         for arg in op.args:
-            if not isinstance(arg, ir.Value):
+            if not isinstance(arg, ops.Value):
                 windowed_args.append(arg)
                 continue
 
             new_arg = _windowize(arg, w)
-            unchanged = unchanged and arg is new_arg
             windowed_args.append(new_arg)
 
-        if not unchanged:
-            new_op = type(op)(*windowed_args)
-            expr = new_op.to_expr()
-            if x.has_name():
-                expr = expr.name(x.get_name())
-            return expr
-        else:
-            return x
+        return type(op)(*windowed_args)
 
-    return _windowize(expr, w)
+    return _windowize(expr.op(), w).to_expr()
 
 
 class Projector:
@@ -472,6 +471,7 @@ class Projector:
     """
 
     def __init__(self, parent, proj_exprs):
+        # TODO(kszucs): rewrite projector to work with operations exclusively
         proj_exprs = util.promote_list(proj_exprs)
         self.parent = parent
         self.input_exprs = proj_exprs
@@ -479,7 +479,7 @@ class Projector:
         self.clean_exprs = list(map(windowize_function, self.resolved_exprs))
 
     def get_result(self):
-        roots = find_immediate_parent_tables(self.parent)
+        roots = find_immediate_parent_tables(self.parent.op())
         first_root = roots[0]
 
         if len(roots) == 1 and isinstance(first_root, ops.Selection):
@@ -493,15 +493,16 @@ class Projector:
         assert self.parent.op() == root
 
         root_table = root.table
+        root_table_expr = root_table.to_expr()
         roots = find_immediate_parent_tables(root_table)
         fused_exprs = []
         clean_exprs = self.clean_exprs
 
-        if not isinstance(root_table.op(), ops.Join):
+        if not isinstance(root_table, ops.Join):
             try:
                 resolved = [
-                    root_table._ensure_expr(expr)
-                    for expr in util.promote_list(self.input_exprs)
+                    root_table_expr._ensure_expr(expr)
+                    for expr in self.input_exprs
                 ]
             except (AttributeError, IbisTypeError):
                 resolved = clean_exprs
@@ -529,7 +530,7 @@ class Projector:
                 # gross we share the same table root. Better way to
                 # detect?
                 or len(roots) == 1
-                and find_immediate_parent_tables(val)[0] is roots[0]
+                and find_immediate_parent_tables(val.op())[0] == roots[0]
             ):
                 have_root = False
                 for root_sel in root_selections:
@@ -543,7 +544,7 @@ class Projector:
                 # This was a filter, so implicitly a select *
                 if not have_root and not root_selections:
                     fused_exprs = [root_table, *fused_exprs]
-            elif shares_all_roots(val, root_table):
+            elif shares_all_roots(val.op(), root_table):
                 fused_exprs.append(val)
             else:
                 return None
@@ -556,29 +557,28 @@ class Projector:
         )
 
 
-def find_first_base_table(expr):
-    def predicate(expr):
-        op = expr.op()
-        if isinstance(op, ops.TableNode):
-            return lin.halt, op
+def find_first_base_table(node):
+    def predicate(node):
+        if isinstance(node, ops.TableNode):
+            return lin.halt, node
         else:
             return lin.proceed, None
 
     try:
-        return next(lin.traverse(predicate, expr))
+        return next(lin.traverse(predicate, node))
     except StopIteration:
         return None
 
 
-def _find_projections(expr):
-    op = expr.op()
-
-    if isinstance(op, ops.Selection):
+def _find_projections(node):
+    if isinstance(node, ops.Selection):
         # remove predicates and sort_keys, so that child tables are considered
         # equivalent even if their predicates and sort_keys are not
-        return lin.proceed, op._projection
-    elif op.blocks():
-        return lin.halt, op
+        return lin.proceed, node._projection
+    elif isinstance(node, ops.SelfReference):
+        return lin.proceed, node
+    elif node.blocks():
+        return lin.halt, node
     else:
         return lin.proceed, None
 
@@ -597,7 +597,7 @@ def shares_some_roots(exprs, parents):
     return bool(exprs_deps & parents_deps)
 
 
-def flatten_predicate(expr):
+def flatten_predicate(node):
     """Yield the expressions corresponding to the `And` nodes of a predicate.
 
     Parameters
@@ -628,49 +628,26 @@ def flatten_predicate(expr):
     r0.b == 'foo'
     """
 
-    def predicate(expr):
-        if isinstance(expr.op(), ops.And):
+    def predicate(node):
+        if isinstance(node, ops.And):
             return lin.proceed, None
         else:
-            return lin.halt, expr
+            return lin.halt, node
 
-    return list(lin.traverse(predicate, expr))
+    return list(lin.traverse(predicate, node))
 
 
-def _is_ancestor(parent, child):  # pragma: no cover
-    """
-    Check whether an operation is an ancestor node of another.
-
-    Parameters
-    ----------
-    parent : ops.Node
-    child : ops.Node
-
-    Returns
-    -------
-    check output : bool
-    """
-
-    def predicate(expr):
-        if expr.op() == child:
+def is_analytic(node):
+    def predicate(node):
+        if isinstance(node, (ops.Reduction, ops.Analytic)):
             return lin.halt, True
         else:
             return lin.proceed, None
 
-    return any(lin.traverse(predicate, parent.to_expr()))
+    return any(lin.traverse(predicate, node))
 
 
-def is_analytic(expr):
-    def predicate(expr):
-        if isinstance(expr.op(), (ops.Reduction, ops.Analytic)):
-            return lin.halt, True
-        else:
-            return lin.proceed, None
-
-    return any(lin.traverse(predicate, expr))
-
-
-def is_reduction(expr):
+def is_reduction(node):
     """
     Check whether an expression contains a reduction or not
 
@@ -699,20 +676,21 @@ def is_reduction(expr):
     check output : bool
     """
 
-    def predicate(expr):
-        if isinstance(expr.op(), ops.Reduction):
+    def predicate(node):
+        if isinstance(node, ops.Reduction):
             return lin.halt, True
-        elif isinstance(expr.op(), ops.TableNode):
+        elif isinstance(node, ops.TableNode):
             # don't go below any table nodes
             return lin.halt, None
         else:
             return lin.proceed, None
 
-    return any(lin.traverse(predicate, expr))
+    return any(lin.traverse(predicate, node))
 
 
-def is_scalar_reduction(expr):
-    return isinstance(expr, ir.Scalar) and is_reduction(expr)
+def is_scalar_reduction(node):
+    assert isinstance(node, ops.Node), type(node)
+    return node.output_shape is Shape.SCALAR and is_reduction(node)
 
 
 _ANY_OP_MAPPING = {
@@ -721,60 +699,60 @@ _ANY_OP_MAPPING = {
 }
 
 
-def find_predicates(expr, flatten=True):
-    def predicate(expr):
-        if isinstance(expr, ir.BooleanColumn):
-            if flatten and isinstance(expr.op(), ops.And):
+def find_predicates(node, flatten=True):
+    # TODO(kszucs): consider to remove flatten argument and compose with
+    # flatten_predicates instead
+    def predicate(node):
+        assert isinstance(node, ops.Node), type(node)
+        if isinstance(node, ops.Value) and isinstance(
+            node.output_dtype, dt.Boolean
+        ):
+            if flatten and isinstance(node, ops.And):
                 return lin.proceed, None
             else:
-                return lin.halt, expr
+                return lin.halt, node
         return lin.proceed, None
 
-    return list(lin.traverse(predicate, expr))
+    return list(lin.traverse(predicate, node))
 
 
-def find_subqueries(expr: ir.Expr) -> Counter:
-    def predicate(
-        counts: Counter, expr: ir.Expr
-    ) -> tuple[Sequence[ir.Table] | bool, None]:
-        op = expr.op()
+def find_subqueries(node: ops.Node) -> Counter:
+    counts = Counter()
 
-        if isinstance(op, ops.Join):
-            return [op.left, op.right], None
-        elif isinstance(op, ops.PhysicalTable):
+    def finder(node: ops.Node):
+        if isinstance(node, ops.Join):
+            return [node.left, node.right], None
+        elif isinstance(node, ops.PhysicalTable):
             return lin.halt, None
-        elif isinstance(op, ops.SelfReference):
+        elif isinstance(node, ops.SelfReference):
             return lin.proceed, None
-        elif isinstance(op, (ops.Selection, ops.Aggregation)):
-            counts[op] += 1
-            return [op.table], None
-        elif isinstance(op, ops.TableNode):
-            counts[op] += 1
+        elif isinstance(node, (ops.Selection, ops.Aggregation)):
+            counts[node] += 1
+            return [node.table], None
+        elif isinstance(node, ops.TableNode):
+            counts[node] += 1
             return lin.proceed, None
-        elif isinstance(op, ops.TableColumn):
-            return op.table.op() not in counts, None
+        elif isinstance(node, ops.TableColumn):
+            return node.table not in counts, None
         else:
             return lin.proceed, None
 
-    counts = Counter()
-    iterator = lin.traverse(
-        functools.partial(predicate, counts),
-        expr,
-        # keep duplicates so we can determine where an expression is used
-        # more than once
-        dedup=False,
-    )
-    # consume the iterator
-    collections.deque(iterator, maxlen=0)
+    # keep duplicates so we can determine where an expression is used
+    # more than once
+    list(lin.traverse(finder, node, dedup=False))
+
     return counts
 
 
+# TODO(kszucs): move to types/logical.py
 def _make_any(
     expr,
     any_op_class: type[ops.Any] | type[ops.NotAny],
 ):
-    tables = find_immediate_parent_tables(expr)
-    predicates = find_predicates(expr, flatten=True)
+    assert isinstance(expr, ir.Expr)
+
+    tables = find_immediate_parent_tables(expr.op())
+    predicates = find_predicates(expr.op(), flatten=True)
 
     if len(tables) > 1:
         op = _ANY_OP_MAPPING[any_op_class](
@@ -786,21 +764,25 @@ def _make_any(
     return op.to_expr()
 
 
+# TODO(kszucs): use substitute instead
 @functools.singledispatch
-def _rewrite_filter(op, _, **kwargs):
+def _rewrite_filter(op, **kwargs):
     raise NotImplementedError(type(op))
 
 
 @_rewrite_filter.register(ops.Reduction)
-def _rewrite_filter_reduction(_, expr, name: str | None = None, **kwargs):
+def _rewrite_filter_reduction(op, name: str | None = None, **kwargs):
     """Turn a reduction inside of a filter into an aggregate."""
     # TODO: what about reductions that reference a join that isn't visible at
     # this level? Means we probably have the wrong design, but will have to
     # revisit when it becomes a problem.
+
+    # TODO(kszucs): may need to wrap with Alias
     if name is not None:
-        expr = expr.name(name)
-    aggregation = reduction_to_aggregation(expr)
-    return aggregation.to_array()
+        # expr = expr.name(name)
+        op = ops.Alias(op, name=name)
+    aggregation = reduction_to_aggregation(op)
+    return ops.TableArrayView(aggregation)
 
 
 @_rewrite_filter.register(ops.Any)
@@ -809,34 +791,34 @@ def _rewrite_filter_reduction(_, expr, name: str | None = None, **kwargs):
 @_rewrite_filter.register(ops.ExistsSubquery)
 @_rewrite_filter.register(ops.NotExistsSubquery)
 @_rewrite_filter.register(ops.Window)
-def _rewrite_filter_subqueries(_, expr, **kwargs):
+def _rewrite_filter_subqueries(op, **kwargs):
     """Don't rewrite any of these operations in filters."""
-    return expr
+    return op
 
 
 @_rewrite_filter.register(ops.Alias)
-def _rewrite_filter_alias(op, _, name: str | None = None, **kwargs):
+def _rewrite_filter_alias(op, name: str | None = None, **kwargs):
     """Rewrite filters on aliases."""
-    arg = op.arg
     return _rewrite_filter(
-        arg.op(),
-        arg,
+        op.arg,
         name=name if name is not None else op.name,
         **kwargs,
     )
 
 
 @_rewrite_filter.register(ops.Value)
-def _rewrite_filter_value(op, expr, **kwargs):
+def _rewrite_filter_value(op, name: str | None = None, **kwargs):
     """Recursively apply filter rewriting on operations."""
-    args = op.args
+
     visited = [
-        _rewrite_filter(arg.op(), arg, **kwargs)
-        if isinstance(arg, ir.Expr)
-        else arg
-        for arg in args
+        _rewrite_filter(arg, **kwargs) if isinstance(arg, ops.Node) else arg
+        for arg in op.args
     ]
-    if all(map(operator.is_, visited, args)):
-        return expr
+    if all(map(operator.is_, visited, op.args)):
+        return op
+
+    new_op = op.__class__(*visited)
+    if op.has_resolved_name():
+        return ops.Alias(new_op, name=op.resolve_name())
     else:
-        return op.__class__(*visited).to_expr()
+        return ops.Alias(new_op, name="tmp")

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -7,16 +7,17 @@ import enum
 import functools
 import numbers
 import re
-import typing
 import uuid as _uuid
 from decimal import Decimal as PythonDecimal
 from typing import (
     AbstractSet,
+    Any,
     Iterable,
     Iterator,
     Mapping,
     NamedTuple,
     Sequence,
+    SupportsFloat,
     TypeVar,
 )
 
@@ -68,7 +69,7 @@ def from_string(value: str) -> DataType:
 
 
 @dtype.register(list)
-def from_list(values: list[typing.Any]) -> Array:
+def from_list(values: list[Any]) -> Array:
     if not values:
         return Array(null)
     return Array(highest_precedence(map(dtype, values)))
@@ -96,6 +97,7 @@ class DataType(Annotable, Comparable):
 
     nullable = optional(instance_of(bool), default=True)
 
+    # TODO(kszucs): remove it
     def __call__(self, nullable: bool = True) -> DataType:
         if nullable is not True and nullable is not False:
             raise TypeError(
@@ -120,10 +122,7 @@ class DataType(Annotable, Comparable):
         prefix = "!" * (not self.nullable)
         return f"{prefix}{self.name.lower()}{self._pretty_piece}"
 
-    def __equals__(
-        self,
-        other: typing.Any,
-    ) -> bool:
+    def __equals__(self, other: Any) -> bool:
         return self.args == other.args
 
     def equals(self, other):
@@ -149,17 +148,12 @@ def from_ibis_dtype(value: DataType) -> DataType:
 
 
 @public
-class Any(DataType):
-    """Values of any type."""
-
-
-@public
-class Primitive(Singleton, DataType):
+class Primitive(DataType, Singleton):
     """Values with known size."""
 
 
 @public
-class Null(Singleton, DataType):
+class Null(DataType, Singleton):
     """Null values."""
 
     scalar = ir.NullScalar
@@ -203,7 +197,7 @@ class Integer(Primitive):
 
 
 @public
-class String(Singleton, Variadic):
+class String(Variadic, Singleton):
     """A type representing a string.
 
     Notes
@@ -217,7 +211,7 @@ class String(Singleton, Variadic):
 
 
 @public
-class Binary(Singleton, Variadic):
+class Binary(Variadic, Singleton):
     """A type representing a sequence of bytes.
 
     Notes
@@ -854,7 +848,6 @@ castable = Dispatcher('castable')
 
 # ---------------------------------------------------------------------
 
-any = Any()
 null = Null()
 boolean = Boolean()
 int8 = Int8()
@@ -894,7 +887,6 @@ inet = INET()
 decimal = Decimal()
 
 public(
-    any=any,
     null=null,
     boolean=boolean,
     int8=int8,
@@ -1223,6 +1215,7 @@ def _get_timedelta_units(
     return [field for field in unit_fields if getattr(base_object, field) > 0]
 
 
+@public
 def higher_precedence(left: DataType, right: DataType) -> DataType:
     nullable = left.nullable or right.nullable
 
@@ -1239,17 +1232,20 @@ def higher_precedence(left: DataType, right: DataType) -> DataType:
 @public
 def highest_precedence(dtypes: Iterator[DataType]) -> DataType:
     """Compute the highest precedence of `dtypes`."""
-    return functools.reduce(higher_precedence, dtypes)
+    if collected := list(dtypes):
+        return functools.reduce(higher_precedence, collected)
+    else:
+        return null
 
 
 @infer.register(object)
-def infer_dtype_default(value: typing.Any) -> DataType:
+def infer_dtype_default(value: Any) -> DataType:
     """Default implementation of :func:`~ibis.expr.datatypes.infer`."""
     raise InputTypeError(value)
 
 
 @infer.register(collections.OrderedDict)
-def infer_struct(value: Mapping[str, typing.Any]) -> Struct:
+def infer_struct(value: Mapping[str, Any]) -> Struct:
     """Infer the [`Struct`][ibis.expr.datatypes.Struct] type of `value`."""
     if not value:
         raise TypeError('Empty struct type not supported')
@@ -1257,7 +1253,7 @@ def infer_struct(value: Mapping[str, typing.Any]) -> Struct:
 
 
 @infer.register(collections.abc.Mapping)
-def infer_map(value: Mapping[typing.Any, typing.Any]) -> Map:
+def infer_map(value: Mapping[Any, Any]) -> Map:
     """Infer the [`Map`][ibis.expr.datatypes.Map] type of `value`."""
     if not value:
         return Map(null, null)
@@ -1273,7 +1269,7 @@ def infer_map(value: Mapping[typing.Any, typing.Any]) -> Map:
 
 
 @infer.register((list, tuple))
-def infer_list(values: typing.Sequence[typing.Any]) -> Array:
+def infer_list(values: Sequence[Any]) -> Array:
     """Infer the [`Array`][ibis.expr.datatypes.Array] type of `value`."""
     if not values:
         return Array(null)
@@ -1345,10 +1341,7 @@ def infer_integer(value: int, prefer_unsigned: bool = False) -> Integer:
 
 @infer.register(enum.Enum)
 def infer_enum(value: enum.Enum) -> Enum:
-    return Enum(
-        infer(value.name),
-        infer(value.value),
-    )
+    return Enum(infer(value.name), infer(value.value))
 
 
 @infer.register(bool)
@@ -1401,10 +1394,6 @@ def can_cast_subtype(source: DataType, target: DataType, **kwargs) -> bool:
     return isinstance(target, source.__class__)
 
 
-@castable.register(Any, DataType)
-@castable.register(DataType, Any)
-@castable.register(Any, Any)
-@castable.register(Null, Any)
 @castable.register(Integer, Category)
 @castable.register(Integer, (Floating, Decimal))
 @castable.register(Floating, Decimal)
@@ -1675,7 +1664,7 @@ def _int(typ: Integer, value: float) -> float:
 
 
 @_normalize.register(
-    Floating, (int, float, np.integer, np.floating, typing.SupportsFloat)
+    Floating, (int, float, np.integer, np.floating, SupportsFloat)
 )
 def _float(typ: Floating, value: float) -> float:
     return float(value)

--- a/ibis/expr/lineage.py
+++ b/ibis/expr/lineage.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 from typing import Any, Callable, Iterable, Iterator
 
-import ibis.expr.types as ir
+import ibis.expr.operations as ops
 
 
 class Container:
@@ -60,9 +60,8 @@ halt = False
 
 
 def traverse(
-    fn: Callable[[ir.Expr], tuple[bool | Iterable, Any]],
-    expr: ir.Expr | Iterable[ir.Expr],
-    type: type = ir.Expr,
+    fn: Callable[[ops.Node], tuple[bool | Iterable, Any]],
+    node: ops.Node | Iterable[ops.Node],
     container: Container = Stack,
     dedup: bool = True,
 ) -> Iterator[Any]:
@@ -75,35 +74,33 @@ def traverse(
         controls the traversal, and the second is the result if its not `None`.
     expr
         The traversable expression or a list of expressions.
-    type
-        Only the instances if this type are traversed.
     container
         Defines the traversal order. Use `Stack` for depth-first order and
         `Queue` for breadth-first order.
     dedup
         Whether to allow expression traversal more than once
     """
-    args = expr if isinstance(expr, collections.abc.Iterable) else [expr]
-    todo = container(arg for arg in args if isinstance(arg, type))
+    args = node if isinstance(node, collections.abc.Iterable) else [node]
+    todo = container(arg for arg in args if isinstance(arg, ops.Node))
     seen = set()
 
     while todo:
-        expr = todo.get()
-        op = expr.op()
+        node = todo.get()
+        assert isinstance(node, ops.Node), type(node)
 
         if dedup:
-            if op in seen:
+            if node in seen:
                 continue
             else:
-                seen.add(op)
+                seen.add(node)
 
-        control, result = fn(expr)
+        control, result = fn(node)
         if result is not None:
             yield result
 
         if control is not halt:
             if control is proceed:
-                args = op.flat_args()
+                args = node.flat_args()
             elif isinstance(control, collections.abc.Iterable):
                 args = control
             else:
@@ -113,5 +110,5 @@ def traverse(
                 )
 
             todo.extend(
-                arg for arg in todo.visitor(args) if isinstance(arg, type)
+                arg for arg in todo.visitor(args) if isinstance(arg, ops.Node)
             )

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -18,7 +18,7 @@ import ibis.expr.types as ir
 from ibis.common import exceptions as com
 from ibis.common.grounds import Singleton
 from ibis.common.validators import immutable_property
-from ibis.expr.operations.core import Node, Unary, Value
+from ibis.expr.operations.core import Unary, Value
 from ibis.util import frozendict
 
 try:
@@ -39,14 +39,12 @@ class TableColumn(Value):
     output_shape = rlz.Shape.COLUMNAR
 
     def __init__(self, table, name):
-        schema = table.schema()
-
         if isinstance(name, int):
-            name = schema.name_at_position(name)
+            name = table.schema.name_at_position(name)
 
-        if name not in schema:
+        if name not in table.schema:
             raise com.IbisTypeError(
-                f"value {name!r} is not a field in {table.columns}"
+                f"value {name!r} is not a field in {table.schema}"
             )
 
         super().__init__(table=table, name=name)
@@ -59,8 +57,7 @@ class TableColumn(Value):
 
     @property
     def output_dtype(self):
-        schema = self.table.schema()
-        return schema[self.name]
+        return self.table.schema[self.name]
 
 
 @public
@@ -91,12 +88,11 @@ class TableArrayView(Value):
 
     @property
     def output_dtype(self):
-        schema = self.table.schema()
-        return schema[self.name]
+        return self.table.schema[self.name]
 
     @property
     def name(self):
-        return self.table.schema().names[0]
+        return self.table.schema.names[0]
 
 
 @public
@@ -187,12 +183,7 @@ class CoalesceLike(Value):
 
     @immutable_property
     def output_dtype(self):
-        # filter out null types
-        non_null_exprs = [arg for arg in self.arg if arg.type() != dt.null]
-        if non_null_exprs:
-            return rlz.highest_precedence_dtype(non_null_exprs)
-        else:
-            return dt.null
+        return rlz.highest_precedence_dtype(self.arg.values)
 
 
 @public
@@ -341,19 +332,6 @@ class HashBytes(Value):
     output_shape = rlz.shape_like("arg")
 
 
-# TODO(kszucs): shouldn't we move this operation to either
-# analytic.py or reductions.py?
-@public
-class TopK(Node):
-    arg = rlz.column(rlz.any)
-    k = rlz.non_negative_integer
-    by = rlz.one_of((rlz.function_of(rlz.base_table_of("arg")), rlz.any))
-    output_type = ir.TopK
-
-    def blocks(self):  # pragma: no cover
-        return True
-
-
 # TODO(kszucs): we should merge the case operations by making the
 # cases, results and default optional arguments like they are in
 # api.py
@@ -367,7 +345,7 @@ class SimpleCase(Value):
     output_shape = rlz.shape_like("base")
 
     def __init__(self, cases, results, **kwargs):
-        assert len(cases) == len(results)
+        assert len(cases.values) == len(results.values)
         super().__init__(cases=cases, results=results, **kwargs)
 
     @immutable_property
@@ -375,7 +353,7 @@ class SimpleCase(Value):
         # TODO(kszucs): we could extend the functionality of
         # rlz.shape_like to support varargs with .flat_args()
         # to define a subset of input arguments
-        values = [*self.results, self.default]
+        values = [*self.results.values, self.default]
         return rlz.highest_precedence_dtype(values)
 
 
@@ -388,12 +366,12 @@ class SearchedCase(Value):
     output_shape = rlz.shape_like("cases")
 
     def __init__(self, cases, results, default):
-        assert len(cases) == len(results)
+        assert len(cases.values) == len(results.values)
         super().__init__(cases=cases, results=results, default=default)
 
     @immutable_property
     def output_dtype(self):
-        exprs = [*self.results, self.default]
+        exprs = [*self.results.values, self.default]
         return rlz.highest_precedence_dtype(exprs)
 
 

--- a/ibis/expr/operations/histograms.py
+++ b/ibis/expr/operations/histograms.py
@@ -81,7 +81,7 @@ class CategoryLabel(Value):
     output_shape = rlz.shape_like("arg")
 
     def __init__(self, arg, labels, **kwargs):
-        cardinality = arg.type().cardinality
+        cardinality = arg.output_dtype.cardinality
         if len(labels) != cardinality:
             raise ValueError(
                 'Number of labels must match number of '

--- a/ibis/expr/operations/maps.py
+++ b/ibis/expr/operations/maps.py
@@ -22,7 +22,7 @@ class MapValueForKey(Value):
 
     @immutable_property
     def output_dtype(self):
-        return self.arg.type().value_type
+        return self.arg.output_dtype.value_type
 
 
 @public
@@ -35,8 +35,8 @@ class MapValueOrDefaultForKey(Value):
 
     @property
     def output_dtype(self):
-        value_type = self.arg.type().value_type
-        default_type = self.default.type()
+        value_type = self.arg.output_dtype.value_type
+        default_type = self.default.output_dtype
 
         if not dt.same_kind(default_type, value_type):
             raise com.IbisTypeError(
@@ -53,7 +53,7 @@ class MapKeys(Unary):
 
     @immutable_property
     def output_dtype(self):
-        return dt.Array(self.arg.type().key_type)
+        return dt.Array(self.arg.output_dtype.key_type)
 
 
 @public
@@ -62,7 +62,7 @@ class MapValues(Unary):
 
     @immutable_property
     def output_dtype(self):
-        return dt.Array(self.arg.type().value_type)
+        return dt.Array(self.arg.output_dtype.value_type)
 
 
 @public

--- a/ibis/expr/operations/numeric.py
+++ b/ibis/expr/operations/numeric.py
@@ -2,11 +2,10 @@ import operator
 
 from public import public
 
+import ibis.expr.datatypes as dt
+import ibis.expr.rules as rlz
 from ibis import util
 from ibis.common.validators import immutable_property
-from ibis.expr import datatypes as dt
-from ibis.expr import rules as rlz
-from ibis.expr import types as ir
 from ibis.expr.operations.core import Binary, Unary, Value
 
 
@@ -30,7 +29,8 @@ class Multiply(NumericBinary):
 class Power(NumericBinary):
     @property
     def output_dtype(self):
-        if util.all_of(self.args, ir.IntegerValue):
+        dtypes = (arg.output_dtype for arg in self.args)
+        if util.all_of(dtypes, dt.Integer):
             return dt.float64
         else:
             return rlz.highest_precedence_dtype(self.args)
@@ -122,8 +122,8 @@ class Ceil(Unary):
 
     @property
     def output_dtype(self):
-        if isinstance(self.arg.type(), dt.Decimal):
-            return self.arg.type()
+        if isinstance(self.arg.output_dtype, dt.Decimal):
+            return self.arg.output_dtype
         else:
             return dt.int64
 
@@ -144,8 +144,8 @@ class Floor(Unary):
 
     @property
     def output_dtype(self):
-        if isinstance(self.arg.type(), dt.Decimal):
-            return self.arg.type()
+        if isinstance(self.arg.output_dtype, dt.Decimal):
+            return self.arg.output_dtype
         else:
             return dt.int64
 
@@ -159,8 +159,8 @@ class Round(Value):
 
     @property
     def output_dtype(self):
-        if isinstance(self.arg.type(), dt.Decimal):
-            return self.arg.type()
+        if isinstance(self.arg.output_dtype, dt.Decimal):
+            return self.arg.output_dtype
         elif self.digits is None:
             return dt.int64
         else:
@@ -193,20 +193,14 @@ class MathUnary(Unary):
 
     @immutable_property
     def output_dtype(self):
-        if isinstance(self.arg.type(), dt.Decimal):
-            return self.arg.type()
-        else:
-            return dt.double
+        return dt.higher_precedence(self.arg.output_dtype, dt.double)
 
 
 @public
 class ExpandingMathUnary(MathUnary):
     @immutable_property
     def output_dtype(self):
-        if isinstance(self.arg.type(), dt.Decimal):
-            return self.arg.type().largest
-        else:
-            return dt.double
+        return dt.higher_precedence(self.arg.output_dtype.largest, dt.double)
 
 
 @public

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -6,12 +6,13 @@ from functools import cached_property
 
 from public import public
 
+import ibis.expr.operations as ops
 from ibis import util
 from ibis.common import exceptions as com
 from ibis.expr import rules as rlz
 from ibis.expr import schema as sch
 from ibis.expr import types as ir
-from ibis.expr.operations.core import Node
+from ibis.expr.operations.core import Node, Value
 from ibis.expr.operations.logical import ExistsSubquery, NotExistsSubquery
 from ibis.expr.operations.sortkeys import _maybe_convert_sort_keys
 
@@ -81,33 +82,11 @@ class SQLQueryResult(TableNode, sch.HasSchema):
         return True
 
 
-def _make_distinct_join_predicates(left, right, predicates):
-    import ibis.expr.analysis as L
-
-    if left.equals(right):
-        # GH #667: If left and right table have a common parent expression,
-        # e.g. they have different filters, we need to add a self-reference and
-        # make the appropriate substitution in the join predicates
-        right = right.view()
-    elif isinstance(right.op(), Join):
-        # for joins with joins on the right side we turn the right side into a
-        # view, otherwise the join tree is incorrectly flattened and tables on
-        # the right are incorrectly scoped
-        old = right
-        new = right = right.view()
-        predicates = [
-            L.sub_for(pred, [(old, new)])
-            if isinstance(pred, ir.Expr)
-            else pred
-            for pred in predicates
-        ]
-
-    predicates = _clean_join_predicates(left, right, predicates)
-    return left, right, predicates
-
-
+# TODO(kszucs): desperately need to clean this up, the majority of this
+# functionality should be handled by input rules for the Join class
 def _clean_join_predicates(left, right, predicates):
     import ibis.expr.analysis as L
+    from ibis.expr.analysis import shares_all_roots
 
     result = []
 
@@ -116,30 +95,25 @@ def _clean_join_predicates(left, right, predicates):
             if len(pred) != 2:
                 raise com.ExpressionError('Join key tuple must be ' 'length 2')
             lk, rk = pred
-            lk = left._ensure_expr(lk)
-            rk = right._ensure_expr(rk)
+            lk = left.to_expr()._ensure_expr(lk)
+            rk = right.to_expr()._ensure_expr(rk)
             pred = lk == rk
         elif isinstance(pred, str):
-            pred = left[pred] == right[pred]
+            pred = left.to_expr()[pred] == right.to_expr()[pred]
+        elif isinstance(pred, Value):
+            pred = pred.to_expr()
         elif not isinstance(pred, ir.Expr):
             raise NotImplementedError
 
         if not isinstance(pred, ir.BooleanColumn):
             raise com.ExpressionError('Join predicate must be comparison')
 
-        preds = L.flatten_predicate(pred)
+        preds = L.flatten_predicate(pred.op())
         result.extend(preds)
-
-    _validate_join_predicates(left, right, result)
-    return tuple(result)
-
-
-def _validate_join_predicates(left, right, predicates):
-    from ibis.expr.analysis import shares_all_roots
 
     # Validate join predicates. Each predicate must be valid jointly when
     # considering the roots of each input table
-    for predicate in predicates:
+    for predicate in result:
         if not shares_all_roots(predicate, [left, right]):
             raise com.RelationError(
                 'The expression {!r} does not fully '
@@ -147,18 +121,51 @@ def _validate_join_predicates(left, right, predicates):
                 'expression.'.format(predicate)
             )
 
+    assert all(isinstance(pred, ops.Node) for pred in result)
+
+    return tuple(result)
+
 
 @public
 class Join(TableNode):
     left = rlz.table
     right = rlz.table
-    # TODO(kszucs): convert to proper predicate rules
     predicates = rlz.optional(lambda x, this: x, default=())
 
     def __init__(self, left, right, predicates, **kwargs):
-        left, right, predicates = _make_distinct_join_predicates(
-            left, right, util.promote_list(predicates)
-        )
+        # TODO(kszucs): predicates should be already a list of operations, need
+        # to update the validation rule for the Join classes which is a noop
+        # currently
+        import ibis.expr.analysis as L
+        import ibis.expr.operations as ops
+
+        # TODO(kszucs): need to factor this out to appropiate join predicate
+        # rules
+        predicates = [
+            pred.op() if isinstance(pred, ir.Expr) else pred
+            for pred in util.promote_list(predicates)
+        ]
+
+        if left.equals(right):
+            # GH #667: If left and right table have a common parent expression,
+            # e.g. they have different filters, we need to add a self-reference
+            # and make the appropriate substitution in the join predicates
+            right = ops.SelfReference(right)
+        elif isinstance(right, Join):
+            # for joins with joins on the right side we turn the right side
+            # into a view, otherwise the join tree is incorrectly flattened
+            # and tables on the right are incorrectly scoped
+            old = right
+            new = right = ops.SelfReference(right)
+            predicates = [
+                L.sub_for(pred, {old: new})
+                if isinstance(pred, ops.Node)
+                else pred
+                for pred in predicates
+            ]
+
+        predicates = _clean_join_predicates(left, right, predicates)
+
         super().__init__(
             left=left, right=right, predicates=predicates, **kwargs
         )
@@ -166,7 +173,7 @@ class Join(TableNode):
     @property
     def schema(self):
         # For joins retaining both table schemas, merge them together here
-        return self.left.schema().append(self.right.schema())
+        return self.left.schema.append(self.right.schema)
 
 
 @public
@@ -203,14 +210,14 @@ class AnyLeftJoin(Join):
 class LeftSemiJoin(Join):
     @property
     def schema(self):
-        return self.left.schema()
+        return self.left.schema
 
 
 @public
 class LeftAntiJoin(Join):
     @property
     def schema(self):
-        return self.left.schema()
+        return self.left.schema
 
 
 @public
@@ -237,16 +244,16 @@ class SetOp(TableNode, sch.HasSchema):
     right = rlz.table
     distinct = rlz.optional(rlz.instance_of(bool), default=False)
 
-    def __init__(self, left, right, distinct: bool, **kwargs):
-        if not left.schema().equals(right.schema()):
+    def __init__(self, left, right, **kwargs):
+        if not left.schema == right.schema:
             raise com.RelationError(
                 'Table schemas must be equal for set operations'
             )
-        super().__init__(left=left, right=right, distinct=distinct, **kwargs)
+        super().__init__(left=left, right=right, **kwargs)
 
     @property
     def schema(self):
-        return self.left.schema()
+        return self.left.schema
 
     def blocks(self):
         return True
@@ -278,7 +285,7 @@ class Limit(TableNode):
 
     @property
     def schema(self):
-        return self.table.schema()
+        return self.table.schema
 
 
 @public
@@ -287,7 +294,7 @@ class SelfReference(TableNode, sch.HasSchema):
 
     @property
     def schema(self):
-        return self.table.schema()
+        return self.table.schema
 
     def blocks(self):
         return True
@@ -377,18 +384,19 @@ class Selection(TableNode, sch.HasSchema):
     @cached_property
     def schema(self):
         # Resolve schema and initialize
+
         if not self.selections:
-            return self.table.schema()
+            return self.table.schema
 
         types = []
         names = []
 
         for projection in self.selections:
-            if isinstance(projection, ir.Value):
-                names.append(projection.get_name())
-                types.append(projection.type())
-            elif isinstance(projection, ir.Table):
-                schema = projection.schema()
+            if isinstance(projection, Value):
+                names.append(projection.resolve_name())
+                types.append(projection.output_dtype)
+            elif isinstance(projection, TableNode):
+                schema = projection.schema
                 names.extend(schema.names)
                 types.extend(schema.types)
 
@@ -467,12 +475,14 @@ class AggregateSelection:
 
         subbed_exprs = []
         for expr in util.promote_list(exprs):
-            expr = self.op.table._ensure_expr(expr)
-            subbed = sub_for(expr, [(self.parent, self.op.table)])
-            subbed_exprs.append(subbed)
+            # TODO(kszucs): factor out _ensure_expr to bind_expr
+            expr = self.op.table.to_expr()._ensure_expr(expr)
+            subbed = sub_for(expr.op(), {self.op: self.op.table})
+            subbed_exprs.append(subbed.to_expr())
 
         if subbed_exprs:
-            valid = shares_all_roots(subbed_exprs, self.op.table)
+            subbed_ops = [expr.op() for expr in subbed_exprs]
+            valid = shares_all_roots(subbed_ops, self.op.table)
         else:
             valid = True
 
@@ -610,8 +620,8 @@ class Aggregation(TableNode, sch.HasSchema):
         types = []
 
         for e in self.by + self.metrics:
-            names.append(e.get_name())
-            types.append(e.type())
+            names.append(e.resolve_name())
+            types.append(e.output_dtype)
 
         return sch.Schema(names, types)
 
@@ -652,12 +662,12 @@ class Distinct(TableNode, sch.HasSchema):
 
     def __init__(self, table):
         # check whether schema has overlapping columns or not
-        assert table.schema()
+        assert table.schema
         super().__init__(table=table)
 
     @property
     def schema(self):
-        return self.table.schema()
+        return self.table.schema
 
     def blocks(self):
         return True
@@ -689,7 +699,7 @@ class FillNa(TableNode, sch.HasSchema):
 
     @property
     def schema(self):
-        return self.table.schema()
+        return self.table.schema
 
 
 @public
@@ -702,7 +712,7 @@ class DropNa(TableNode, sch.HasSchema):
 
     @property
     def schema(self):
-        return self.table.schema()
+        return self.table.schema
 
 
 @public
@@ -714,7 +724,7 @@ class View(PhysicalTable):
 
     @property
     def schema(self):
-        return self.child.schema()
+        return self.child.schema
 
 
 @public
@@ -727,7 +737,8 @@ class SQLStringView(PhysicalTable):
 
     @cached_property
     def schema(self):
-        backend = self.child._find_backend()
+        # TODO(kszucs): avoid converting to expression
+        backend = self.child.to_expr()._find_backend()
         return backend._get_schema_using_query(self.query)
 
 

--- a/ibis/expr/operations/structs.py
+++ b/ibis/expr/operations/structs.py
@@ -17,7 +17,7 @@ class StructField(Value):
 
     @immutable_property
     def output_dtype(self) -> dt.DataType:
-        struct_dtype = self.arg.type()
+        struct_dtype = self.arg.output_dtype
         value_dtype = struct_dtype[self.field]
         return value_dtype
 
@@ -37,6 +37,5 @@ class StructColumn(Value):
 
     @immutable_property
     def output_dtype(self) -> dt.DataType:
-        return dt.Struct.from_tuples(
-            zip(self.names, (value.type() for value in self.values))
-        )
+        dtypes = (value.output_dtype for value in self.values)
+        return dt.Struct.from_tuples(zip(self.names, dtypes))

--- a/ibis/expr/operations/vectorized.py
+++ b/ibis/expr/operations/vectorized.py
@@ -16,6 +16,7 @@ class VectorizedUDF(Value):
     input_type = rlz.tuple_of(rlz.datatype)
     return_type = rlz.datatype
 
+    # TODO(kszucs): remove this property
     @property
     def inputs(self):
         return self.func_args

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -2,6 +2,8 @@ import enum
 import operator
 from itertools import product, starmap
 
+import toolz
+
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
@@ -20,13 +22,14 @@ from ibis.common.validators import (  # noqa: F401
 )
 
 
+# TODO(kszucs): consider to rename to datashape
 class Shape(enum.IntEnum):
     SCALAR = 0
     COLUMNAR = 1
     # TABULAR = 2
 
 
-def highest_precedence_dtype(exprs):
+def highest_precedence_dtype(args):
     """Return the highest precedence type from the passed expressions
 
     Also verifies that there are valid implicit casts between any of the types
@@ -43,10 +46,7 @@ def highest_precedence_dtype(exprs):
     dtype: DataType
       The highest precedence datatype
     """
-    if not exprs:
-        return dt.null
-
-    return dt.highest_precedence(expr.type() for expr in exprs)
+    return dt.highest_precedence(arg.output_dtype for arg in args)
 
 
 def castable(source, target):
@@ -54,36 +54,36 @@ def castable(source, target):
 
     Based on the underlying datatypes and the value in case of Literals
     """
-    op = source.op()
-    value = getattr(op, 'value', None)
-    return dt.castable(source.type(), target.type(), value=value)
+    value = getattr(source, 'value', None)
+    return dt.castable(source.output_dtype, target.output_dtype, value=value)
 
 
 def comparable(left, right):
     return castable(left, right) or castable(right, left)
 
 
+class rule(validator):
+    def _erase_expr(self, value):
+        if isinstance(value, ir.Expr):
+            return value.op()
+        elif isinstance(value, tuple):
+            return tuple(map(self._erase_expr, value))
+        else:
+            return value
+
+    def __call__(self, *args, **kwargs):
+        args = map(self._erase_expr, args)
+        kwargs = toolz.valmap(self._erase_expr, kwargs)
+        result = super().__call__(*args, **kwargs)
+        assert not isinstance(result, ir.Expr)
+        return result
+
+
 # ---------------------------------------------------------------------
 # Input type validators / coercion functions
 
 
-# TODO(kszucs): deprecate then remove
-@validator
-def member_of(obj, arg, **kwargs):
-    if isinstance(arg, ir.EnumValue):
-        arg = arg.op().value
-    if isinstance(arg, enum.Enum):
-        enum.unique(obj)  # check that enum has unique values
-        arg = arg.name
-
-    if not hasattr(obj, arg):
-        raise com.IbisTypeError(
-            f'Value with type {type(arg)} is not a member of {obj}'
-        )
-    return getattr(obj, arg)
-
-
-@validator
+@rule
 def value_list_of(inner, arg, **kwargs):
     # TODO(kszucs): would be nice to remove ops.ValueList
     # the main blocker is that some of the backends execution
@@ -91,24 +91,82 @@ def value_list_of(inner, arg, **kwargs):
     # the dispatcher in pandas requires operation objects
     import ibis.expr.operations as ops
 
-    values = tuple_of(inner, arg, **kwargs)
-    return ops.ValueList(values).to_expr()
+    # TODO(kszucs): should jut probably make ValueList iterable
+    if isinstance(arg, ops.ValueList):
+        values = arg.values
+    else:
+        values = arg
+
+    values = tuple_of(inner, values, **kwargs)
+    return ops.ValueList(values)
 
 
-@validator
+@rule
 def sort_key(key, *, from_=None, this):
     import ibis.expr.operations as ops
 
     table = this[from_] if from_ is not None else None
-    return ops.sortkeys._to_sort_key(key, table=table)
+    key = ops.sortkeys._to_sort_key(key, table=table)
+    return key.op()
 
 
-@validator
+@rule
 def datatype(arg, **kwargs):
     return dt.dtype(arg)
 
 
-@validator
+# TODO(kszucs): make type argument the first and mandatory, similarly to the
+# value rule, move out the type inference to `ir.literal()` method
+# TODO(kszucs): may not make sense to support an explicit datatype here, we
+# could do the coercion in the API function ibis.literal()
+@rule
+def literal(dtype, value, **kwargs):
+    import ibis.expr.operations as ops
+
+    if isinstance(value, ops.Literal):
+        return value
+
+    try:
+        inferred_dtype = dt.infer(value)
+    except com.InputTypeError:
+        has_inferred = False
+    else:
+        has_inferred = True
+
+    if dtype is None:
+        has_explicit = False
+    else:
+        has_explicit = True
+        # TODO(kszucs): handle class-like dtype definitions here explicitly
+        explicit_dtype = dt.dtype(dtype)
+
+    if has_explicit and has_inferred:
+        try:
+            # ensure type correctness: check that the inferred dtype is
+            # implicitly castable to the explicitly given dtype and value
+            dtype = inferred_dtype.cast(explicit_dtype, value=value)
+        except com.IbisTypeError:
+            raise TypeError(
+                f'Value {value!r} cannot be safely coerced to {type}'
+            )
+    elif has_explicit:
+        dtype = explicit_dtype
+    elif has_inferred:
+        dtype = inferred_dtype
+    else:
+        raise com.IbisTypeError(
+            'The datatype of value {!r} cannot be inferred, try '
+            'passing it explicitly with the `type` keyword.'.format(value)
+        )
+
+    if isinstance(dtype, dt.Null):
+        return ops.NullLiteral()
+
+    value = dt._normalize(dtype, value)
+    return ops.Literal(value, dtype=dtype)
+
+
+@rule
 def value(dtype, arg, **kwargs):
     """Validates that the given argument is a Value with a particular datatype
 
@@ -124,58 +182,64 @@ def value(dtype, arg, **kwargs):
     arg : Value
       An ibis value expression with the specified datatype
     """
-    if not isinstance(arg, ir.Expr):
+    import ibis.expr.operations as ops
+
+    if not isinstance(arg, ops.Value):
         # coerce python literal to ibis literal
-        arg = ir.literal(arg)
+        arg = literal(None, arg)
 
-    if not isinstance(arg, ir.Value):
-        raise com.IbisTypeError(
-            f'Given argument with type {type(arg)} is not a value '
-            'expression'
-        )
-
-    # retrieve literal values for implicit cast check
-    value = getattr(arg.op(), 'value', None)
-
-    if isinstance(dtype, type) and isinstance(arg.type(), dtype):
-        # dtype class has been specified like dt.Interval or dt.Decimal
+    if dtype is None:
+        # no datatype restriction
         return arg
-    elif dt.castable(arg.type(), dt.dtype(dtype), value=value):
+    elif isinstance(dtype, type):
+        # dtype class has been specified like dt.Interval or dt.Decimal
+        if not issubclass(dtype, dt.DataType):
+            raise com.IbisTypeError(
+                f"Datatype specification {dtype} is not a subclass dt.DataType"
+            )
+        elif isinstance(arg.output_dtype, dtype):
+            return arg
+        else:
+            raise com.IbisTypeError(
+                f'Given argument with datatype {arg.output_dtype} is not '
+                f'subtype of {dtype}'
+            )
+    elif isinstance(dtype, (dt.DataType, str)):
         # dtype instance or string has been specified and arg's dtype is
         # implicitly castable to it, like dt.int8 is castable to dt.int64
+        dtype = dt.dtype(dtype)
+        # retrieve literal values for implicit cast check
+        value = getattr(arg, 'value', None)
+        if dt.castable(arg.output_dtype, dtype, value=value):
+            return arg
+        else:
+            raise com.IbisTypeError(
+                f'Given argument with datatype {arg.output_dtype} is not '
+                f'implicitly castable to {dtype}'
+            )
+    else:
+        raise com.IbisTypeError(f'Invalid datatype specification {dtype}')
+
+
+@rule
+def scalar(inner, arg, **kwargs):
+    arg = inner(arg, **kwargs)
+    if arg.output_shape is Shape.SCALAR:
         return arg
     else:
-        raise com.IbisTypeError(
-            f'Given argument with datatype {arg.type()} is not '
-            f'subtype of {dtype} nor implicitly castable to it'
-        )
+        raise com.IbisTypeError(f"{arg} it not a scalar")
 
 
-@validator
-def scalar(inner, arg, **kwargs):
-    return instance_of(ir.Scalar, inner(arg, **kwargs))
-
-
-@validator
+@rule
 def column(inner, arg, **kwargs):
-    return instance_of(ir.Column, inner(arg, **kwargs))
+    arg = inner(arg, **kwargs)
+    if arg.output_shape is Shape.COLUMNAR:
+        return arg
+    else:
+        raise com.IbisTypeError(f"{arg} it not a column")
 
 
-@validator
-def array_of(inner, arg, **kwargs):
-    val = arg if isinstance(arg, ir.Expr) else ir.literal(arg)
-    argtype = val.type()
-    if not isinstance(argtype, dt.Array):
-        raise com.IbisTypeError(
-            'Argument must be an array, '
-            f'got expression which is of type {val.type()}'
-        )
-    value_dtype = inner(val[0], **kwargs).type()
-    array_dtype = dt.Array(value_dtype)
-    return value(array_dtype, val, **kwargs)
-
-
-any = value(dt.any)
+any = value(None)
 double = value(dt.double)
 string = value(dt.string)
 boolean = value(dt.boolean)
@@ -195,7 +259,7 @@ numeric = soft_numeric
 set_ = value(dt.Set)
 array = value(dt.Array)
 struct = value(dt.Struct)
-mapping = value(dt.Map(dt.any, dt.any))
+mapping = value(dt.Map)
 
 geospatial = value(dt.GeoSpatial)
 point = value(dt.Point)
@@ -206,10 +270,10 @@ multipoint = value(dt.MultiPoint)
 multipolygon = value(dt.MultiPolygon)
 
 
-@validator
+@rule
 def interval(arg, units=None, **kwargs):
     arg = value(dt.Interval, arg)
-    unit = arg.type().unit
+    unit = arg.output_dtype.unit
     if units is not None and unit not in units:
         msg = 'Interval unit `{}` is not among the allowed ones {}'
         raise com.IbisTypeError(msg.format(unit, units))
@@ -234,7 +298,7 @@ def dtype_like(name):
         if util.is_iterable(arg):
             return highest_precedence_dtype(arg)
         else:
-            return arg.type()
+            return arg.output_dtype
 
     return output_dtype
 
@@ -244,16 +308,15 @@ def shape_like(name):
     def output_shape(self):
         arg = getattr(self, name)
         if util.is_iterable(arg):
-            for expr in arg:
+            for op in arg:
                 try:
-                    op = expr.op()
+                    if op.output_shape is Shape.COLUMNAR:
+                        return Shape.COLUMNAR
                 except AttributeError:
                     continue
-                if op.output_shape is Shape.COLUMNAR:
-                    return Shape.COLUMNAR
             return Shape.SCALAR
         else:
-            return arg.op().output_shape
+            return arg.output_shape
 
     return output_shape
 
@@ -261,15 +324,17 @@ def shape_like(name):
 # TODO(kszucs): might just use bounds instead of actual literal values
 # that could simplify interval binop output_type methods
 # TODO(kszucs): pre-generate mapping?
+
+
 def _promote_integral_binop(exprs, op):
-    dtypes = []
-    bounds = []
-    for expr in exprs:
-        try:
-            bounds.append([expr.op().value])
-        except AttributeError:
-            dtypes.append(expr.type())
-            bounds.append(expr.type().bounds)
+    bounds, dtypes = [], []
+    for arg in exprs:
+        dtypes.append(arg.output_dtype)
+        if hasattr(arg, 'value'):
+            # arg.op() is a literal
+            bounds.append([arg.value])
+        else:
+            bounds.append(arg.output_dtype.bounds)
 
     all_unsigned = dtypes and util.all_of(dtypes, dt.UnsignedInteger)
     # In some cases, the bounding type might be int8, even though neither
@@ -280,48 +345,48 @@ def _promote_integral_binop(exprs, op):
     return dt.highest_precedence(dtypes)
 
 
-def _promote_decimal_dtype(args, op):
-
+def _promote_decimal_binop(args, op):
     if len(args) != 2:
         return highest_precedence_dtype(args)
 
     # TODO: Add support for setting the maximum precision and maximum scale
-    lhs_prec = args[0].type().precision
-    lhs_scale = args[0].type().scale
-    rhs_prec = args[1].type().precision
-    rhs_scale = args[1].type().scale
-    max_prec = 31 if lhs_prec <= 31 and rhs_prec <= 31 else 63
+    left = args[0].output_dtype
+    right = args[1].output_dtype
+
+    max_prec = 31 if left.precision <= 31 and right.precision <= 31 else 63
     max_scale = 31
 
     if op is operator.mul:
         return dt.Decimal(
-            min(max_prec, lhs_prec + rhs_prec),
-            min(max_scale, lhs_scale + rhs_scale),
+            min(max_prec, left.precision + right.precision),
+            min(max_scale, left.scale + right.scale),
         )
-    if op is operator.add or op is operator.sub:
+    elif op is operator.add or op is operator.sub:
         return dt.Decimal(
             min(
                 max_prec,
                 max(
-                    lhs_prec - lhs_scale,
-                    rhs_prec - rhs_scale,
+                    left.precision - left.scale,
+                    right.precision - right.scale,
                 )
-                + max(lhs_scale, rhs_scale)
+                + max(left.scale, right.scale)
                 + 1,
             ),
-            max(lhs_scale, rhs_scale),
+            max(left.scale, right.scale),
         )
-    return highest_precedence_dtype(args)
+    else:
+        return highest_precedence_dtype(args)
 
 
 def numeric_like(name, op):
     @immutable_property
     def output_dtype(self):
         args = getattr(self, name)
-        if util.all_of(args, ir.IntegerValue):
+        dtypes = [arg.output_dtype for arg in args]
+        if util.all_of(dtypes, dt.Integer):
             result = _promote_integral_binop(args, op)
-        elif util.all_of(args, ir.DecimalValue):
-            result = _promote_decimal_dtype(args, op)
+        elif util.all_of(dtypes, dt.Decimal):
+            result = _promote_decimal_binop(args, op)
         else:
             result = highest_precedence_dtype(args)
 
@@ -330,7 +395,7 @@ def numeric_like(name, op):
     return output_dtype
 
 
-@validator
+@rule
 def table(arg, *, schema=None, **kwargs):
     """A table argument.
 
@@ -351,13 +416,15 @@ def table(arg, *, schema=None, **kwargs):
     present it must be of the specified type. The table may have extra columns
     not specified in the schema.
     """
-    if not isinstance(arg, ir.Table):
+    import ibis.expr.operations as ops
+
+    if not isinstance(arg, ops.TableNode):
         raise com.IbisTypeError(
             f'Argument is not a table; got type {type(arg).__name__}'
         )
 
     if schema is not None:
-        if arg.schema() >= sch.schema(schema):
+        if arg.schema >= sch.schema(schema):
             return arg
 
         raise com.IbisTypeError(
@@ -366,7 +433,7 @@ def table(arg, *, schema=None, **kwargs):
     return arg
 
 
-@validator
+@rule
 def column_from(name, column, *, this):
     """A column from a named table.
 
@@ -377,34 +444,40 @@ def column_from(name, column, *, this):
     """
     if name not in this:
         raise com.IbisTypeError(f"Could not get table {name} from {this}")
-    table = this[name]
+
+    # TODO(kszucs): should avoid converting to TableExpr
+    table = this[name].to_expr()
 
     if isinstance(column, (str, int)):
-        return table[column]
-    elif isinstance(column, ir.Column):
-        if not column.has_name():
-            raise com.IbisTypeError(f"Passed column {column} has no name")
+        return table[column].op()
 
-        maybe_column = column.get_name()
-        try:
-            if column.equals(table[maybe_column]):
-                return column
-            else:
-                raise com.IbisTypeError(
-                    f"Passed column is not a column in {type(table)}"
-                )
-        except com.IbisError:
+    # TODO(kszucs): should avoid converting to a ColumnExpr
+    column = column.to_expr()
+    if not isinstance(column, ir.Column):
+        raise com.IbisTypeError(
+            "value must be an int or str or Column, got "
+            f"{type(column).__name__}"
+        )
+
+    if not column.has_name():
+        raise com.IbisTypeError(f"Passed column {column} has no name")
+
+    maybe_column = column.get_name()
+    try:
+        if column.equals(table[maybe_column]):
+            return column.op()
+        else:
             raise com.IbisTypeError(
-                f"Cannot get column {maybe_column} from {type(table)}"
+                f"Passed column is not a column in {type(table)}"
             )
+    except com.IbisError:
+        raise com.IbisTypeError(
+            f"Cannot get column {maybe_column} from {type(table)}"
+        )
 
-    raise com.IbisTypeError(
-        "value must be an int or str or Column, got "
-        f"{type(column).__name__}"
-    )
 
-
-@validator
+# TODO(kszucs): consider to remove since it's only used by TopK
+@rule
 def base_table_of(name, *, this):
     from ibis.expr.analysis import find_first_base_table
 
@@ -412,11 +485,11 @@ def base_table_of(name, *, this):
     base = find_first_base_table(arg)
     if base is None:
         raise com.IbisTypeError(f"`{arg}` doesn't have a base table")
-    else:
-        return base.to_expr()
+
+    return base
 
 
-@validator
+@rule
 def function_of(
     arg,
     fn,
@@ -434,20 +507,20 @@ def function_of(
     elif callable(arg):
         arg = arg(this=this)
 
-    return output_rule(fn(arg), this=this)
+    return output_rule(fn(arg.to_expr()), this=this)
 
 
-@validator
-def reduction(argument, **kwargs):
+@rule
+def reduction(arg, **kwargs):
     from ibis.expr.analysis import is_reduction
 
-    if not is_reduction(argument):
+    if not is_reduction(arg):
         raise com.IbisTypeError("`argument` must be a reduction")
 
-    return argument
+    return arg
 
 
-@validator
+@rule
 def non_negative_integer(arg, **kwargs):
     if not isinstance(arg, int):
         raise com.IbisTypeError(
@@ -458,26 +531,12 @@ def non_negative_integer(arg, **kwargs):
     return arg
 
 
-@validator
-def python_literal(value, arg, **kwargs):
-    if (
-        not isinstance(arg, type(value))
-        or not isinstance(value, type(arg))
-        or arg != value
-    ):
-        raise ValueError(
-            "arg must be a literal exactly equal in type and value to value "
-            f"{value} with type {type(value)}, got `arg` with type {type(arg)}"
-        )
-    return arg
-
-
-@validator
+@rule
 def pair(inner_left, inner_right, a, b, **kwargs):
     return inner_left(a, **kwargs), inner_right(b, **kwargs)
 
 
-@validator
+@rule
 def analytic(arg, **kwargs):
     from ibis.expr.analysis import is_analytic
 
@@ -509,7 +568,7 @@ def window(win, *, from_base_table_of, this):
         )
         if len(win._order_by) != 1:
             raise com.IbisInputError(error_msg)
-        order_var = win._order_by[0].op().args[0]
-        if not isinstance(order_var.type(), dt.Timestamp):
+        order_var = win._order_by[0].args[0]
+        if not isinstance(order_var.output_dtype, dt.Timestamp):
             raise com.IbisInputError(error_msg)
     return win

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -95,12 +95,8 @@ class Schema(Annotable, Comparable):
     def __getitem__(self, name: str) -> dt.DataType:
         return self.types[self._name_locs[name]]
 
-    def __equals__(self, other: Schema) -> bool:
-        return (
-            self._hash == other._hash
-            and self.names == other.names
-            and self.types == other.types
-        )
+    def __equals__(self, other):
+        return self.args == other.args
 
     def equals(self, other: Schema) -> bool:
         """Return whether `other` is equal to `self`.

--- a/ibis/expr/timecontext.py
+++ b/ibis/expr/timecontext.py
@@ -286,7 +286,7 @@ def adjust_context_alias(
     op: ops.Node, scope: 'Scope', timecontext: TimeContext
 ) -> TimeContext:
     # For any node, by default, do not adjust time context
-    return adjust_context(op.arg.op(), scope, timecontext)
+    return adjust_context(op.arg, scope, timecontext)
 
 
 @adjust_context.register(ops.AsOfJoin)
@@ -311,12 +311,15 @@ def adjust_context_window(
     # adjust time context by preceding and following
     begin, end = timecontext
 
+    # TODO(kszucs): rewrite op.window.preceding to be an ops.Node
     preceding = op.window.preceding
     if preceding is not None:
         if isinstance(preceding, ir.IntervalScalar):
+            # TODO(kszucs): this file should be really moved to the pandas
+            # backend instead of the current central placement
             from ibis.backends.pandas.execution import execute
 
-            preceding = execute(preceding)
+            preceding = execute(preceding.op())
         if preceding and not isinstance(preceding, (int, np.integer)):
             begin = begin - preceding
 
@@ -325,7 +328,7 @@ def adjust_context_window(
         if isinstance(following, ir.IntervalScalar):
             from ibis.backends.pandas.execution import execute
 
-            following = execute(following)
+            following = execute(following.op())
         if following and not isinstance(following, (int, np.integer)):
             end = end + following
 

--- a/ibis/expr/types/analytic.py
+++ b/ibis/expr/types/analytic.py
@@ -21,7 +21,7 @@ class TopK(Analytic):
 
     def _semi_join_components(self):
         predicate = self._to_filter()
-        right = predicate.op().right.op().table
+        right = predicate.op().right.table
         return predicate, right
 
     def _to_semi_join(self, left):
@@ -36,7 +36,7 @@ class TopK(Analytic):
         # GH 1393: previously because of GH667 we were substituting parents,
         # but that introduced a bug when comparing reductions to columns on the
         # same relation, so we leave this alone.
-        arg = op.arg
+        arg = op.arg.to_expr()
         return arg == getattr(rank_set, arg.get_name())
 
     def to_aggregation(
@@ -45,6 +45,7 @@ class TopK(Analytic):
         """
         Convert the TopK operation to a table aggregation
         """
+        import ibis.expr.operations as ops
         from ibis.expr.analysis import find_first_base_table
 
         op = self.op()
@@ -52,28 +53,32 @@ class TopK(Analytic):
         arg_table = find_first_base_table(op.arg).to_expr()
 
         by = op.by
-        if isinstance(by, Expr):
-            by_table = find_first_base_table(op.by).to_expr()
-        else:
+        if callable(by):
             by = by(arg_table)
             by_table = arg_table
+        elif isinstance(by, ops.Value):
+            by_table = find_first_base_table(op.by).to_expr()
+        else:
+            raise com.IbisTypeError(
+                f"Invalid `by` argument with type {type(by)}"
+            )
 
         if metric_name is None:
-            if by.get_name() == op.arg.get_name():
+            if by.resolve_name() == op.arg.resolve_name():
                 by = by.name(backup_metric_name)
         else:
             by = by.name(metric_name)
 
         if arg_table.equals(by_table):
-            agg = arg_table.aggregate(by, by=[op.arg])
+            agg = arg_table.aggregate(by.to_expr(), by=[op.arg.to_expr()])
         elif parent_table is not None:
-            agg = parent_table.aggregate(by, by=[op.arg])
+            agg = parent_table.aggregate(by.to_expr(), by=[op.arg.to_expr()])
         else:
             raise com.IbisError(
                 'Cross-table TopK; must provide a parent joined table'
             )
 
-        return agg.sort_by([(by.get_name(), False)]).limit(op.k)
+        return agg.sort_by([(by.resolve_name(), False)]).limit(op.k)
 
 
 public(AnalyticExpr=Analytic, TopKExpr=TopK)

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -372,7 +372,7 @@ class Value(Expr):
 
         # TODO(kszucs): fix this ugly hack
         if isinstance(prior_op, ops.Alias):
-            return prior_op.arg.over(window).name(prior_op.name)
+            return prior_op.arg.to_expr().over(window).name(prior_op.name)
 
         if isinstance(prior_op, ops.Window):
             op = prior_op.over(window)
@@ -425,7 +425,7 @@ class Value(Expr):
         """  # noqa: E501
         import ibis.expr.builders as bl
 
-        return bl.SimpleCaseBuilder(self)
+        return bl.SimpleCaseBuilder(self.op())
 
     def cases(
         self,
@@ -551,7 +551,7 @@ class Scalar(Value):
         from ibis.expr.analysis import find_immediate_parent_tables
         from ibis.expr.types.relations import Table
 
-        roots = find_immediate_parent_tables(self)
+        roots = find_immediate_parent_tables(self.op())
         if len(roots) > 1:
             raise com.RelationError(
                 'Cannot convert scalar expression '
@@ -573,7 +573,7 @@ class Column(Value):
         from ibis.expr.analysis import find_immediate_parent_tables
         from ibis.expr.types.relations import Table
 
-        roots = find_immediate_parent_tables(self)
+        roots = find_immediate_parent_tables(self.op())
         if len(roots) > 1:
             raise com.RelationError(
                 'Cannot convert array expression involving multiple base '
@@ -800,7 +800,7 @@ class Column(Value):
         """
         from ibis.expr.analysis import find_first_base_table
 
-        base = find_first_base_table(self).to_expr()
+        base = find_first_base_table(self.op()).to_expr()
         metric = base.count().name(metric_name)
 
         if not self.has_name():
@@ -1030,7 +1030,7 @@ def literal(value: Any, type: dt.DataType | str | None = None) -> Scalar:
             'passing it explicitly with the `type` keyword.'.format(value)
         )
 
-    if dtype is dt.null:
+    if isinstance(dtype, dt.Null):
         return null().cast(dtype)
     else:
         value = dt._normalize(dtype, value)

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -61,8 +61,7 @@ class GroupedTable:
     ):
         self.table = table
         self.by = [
-            _get_group_by_key(table, v)
-            for v in util.promote_list(by if by is not None else [])
+            _get_group_by_key(table, v) for v in util.promote_list(by)
         ] + [
             _get_group_by_key(table, v).name(k)
             for k, v in sorted(expressions.items(), key=toolz.first)

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -14,8 +14,8 @@ import rich.table
 from public import public
 
 import ibis
+import ibis.common.exceptions as com
 from ibis import util
-from ibis.common import exceptions as com
 from ibis.common.grounds import console
 from ibis.expr.deferred import Deferred
 from ibis.expr.types.core import Expr
@@ -131,9 +131,6 @@ class Table(Expr):
     def __len__(self):
         raise com.ExpressionError('Use .count() instead')
 
-    def __setstate__(self, instance_dictionary):
-        self.__dict__ = instance_dictionary
-
     def __getattr__(self, key):
         try:
             schema = self.schema()
@@ -151,7 +148,6 @@ class Table(Expr):
     def __dir__(self):
         return sorted(frozenset(dir(type(self)) + self.columns))
 
-    # TODO(kszucs): should be removed
     def _ensure_expr(self, expr):
         if isinstance(expr, str):
             return self[expr]
@@ -355,31 +351,21 @@ class Table(Expr):
         Table
             An aggregate table expression
         """
-        metrics = [] if metrics is None else util.promote_list(metrics)
+        metrics = [
+            self._ensure_expr(item)
+            for item in util.flatten_iterable(util.promote_list(metrics))
+        ]
         metrics.extend(
             self._ensure_expr(expr).name(name) for name, expr in kwargs.items()
         )
 
         op = self.op().aggregate(
             self,
-            [
-                metric
-                if util.is_iterable(metric)
-                else self._ensure_expr(metric)
-                for metric in metrics
+            metrics=metrics,
+            by=[self._ensure_expr(item) for item in util.promote_list(by)],
+            having=[
+                self._ensure_expr(item) for item in util.promote_list(having)
             ],
-            by=list(
-                map(
-                    self._ensure_expr,
-                    util.promote_list(by if by is not None else []),
-                )
-            ),
-            having=list(
-                map(
-                    self._ensure_expr,
-                    util.promote_list(having if having is not None else []),
-                )
-            ),
         )
         return op.to_expr()
 
@@ -594,7 +580,7 @@ class Table(Expr):
             elif isinstance(expr, Deferred):
                 value = expr.resolve(self)
             else:
-                value = rlz.any(expr)
+                value = rlz.any(expr).to_expr()
             exprs.append(value.name(name))
 
         mutation_exprs = an.get_mutation_exprs(exprs, self)
@@ -770,8 +756,10 @@ class Table(Expr):
         for predicate, right in top_ks:
             table = table.semi_join(right, predicate)[table]
 
+        # FIXME(kszucs): handle operations here only
         predicates = [
-            an._rewrite_filter(pred.op(), pred) for pred in resolved_predicates
+            an._rewrite_filter(pred.op() if isinstance(pred, Expr) else pred)
+            for pred in resolved_predicates
         ]
         return an.apply_filter(table, predicates)
 
@@ -785,7 +773,7 @@ class Table(Expr):
         """
         from ibis.expr import operations as ops
 
-        return ops.Count(self, None).to_expr().name("count")
+        return ops.Count(self).to_expr().name("count")
 
     def dropna(
         self,
@@ -1052,9 +1040,8 @@ class Table(Expr):
             Left and right suffixes that will be used to rename overlapping
             columns.
         """
-        from ibis.expr import analysis as an
+
         from ibis.expr import operations as ops
-        from ibis.expr import types as ir
 
         _join_classes = {
             'inner': ops.InnerJoin,
@@ -1070,9 +1057,6 @@ class Table(Expr):
         }
 
         klass = _join_classes[how.lower()]
-        if isinstance(predicates, ir.Expr):
-            predicates = an.flatten_predicate(predicates)
-
         expr = klass(left, right, predicates).to_expr()
 
         # semi/anti join only give access to the left table's fields, so
@@ -1321,7 +1305,7 @@ def _resolve_predicates(
     from ibis.expr import types as ir
 
     predicates = [
-        ir.relations.bind_expr(table, pred)
+        ir.relations.bind_expr(table, pred).op()
         for pred in util.promote_list(predicates)
     ]
     predicates = an.flatten_predicate(predicates)
@@ -1329,10 +1313,10 @@ def _resolve_predicates(
     resolved_predicates = []
     top_ks = []
     for pred in predicates:
-        if isinstance(pred, ir.TopK):
-            top_ks.append(pred._semi_join_components())
-        elif isinstance(pred_op := pred.op(), ops.logical._UnresolvedSubquery):
-            resolved_predicates.append(pred_op._resolve(table))
+        if isinstance(pred, ops.TopK):
+            top_ks.append(pred.to_expr()._semi_join_components())
+        elif isinstance(pred, ops.logical._UnresolvedSubquery):
+            resolved_predicates.append(pred._resolve(table.op()))
         else:
             resolved_predicates.append(pred)
 

--- a/ibis/expr/types/sortkeys.py
+++ b/ibis/expr/types/sortkeys.py
@@ -1,16 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from public import public
 
-if TYPE_CHECKING:
-    import ibis.expr.datatypes as dt
-
-from ibis.expr.types.generic import Expr
+from ibis.expr.types.generic import Value
 
 
 @public
-class SortExpr(Expr):
-    def type(self) -> dt.DataType:
-        return self.op().expr.type()
+class SortExpr(Value):
+    pass

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -826,7 +826,9 @@ class StringValue(Value):
         StringValue
             All strings concatenated
         """
-        return self.concat(other)
+        import ibis.expr.operations as ops
+
+        return ops.StringConcat([self, other]).to_expr()
 
     def __radd__(self, other: str | StringValue) -> StringValue:
         """Concatenate strings.
@@ -841,9 +843,9 @@ class StringValue(Value):
         StringValue
             All strings concatenated
         """
-        import ibis.expr.rules as rlz
+        import ibis.expr.operations as ops
 
-        return rlz.string(other).concat(self)
+        return ops.StringConcat([other, self]).to_expr()
 
     def convert_base(
         self,

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -146,7 +146,8 @@ class StructValue(Value):
         """
         import ibis.expr.analysis as an
 
-        table = an.find_first_base_table(self).to_expr()
+        # TODO(kszucs): avoid expression roundtripping
+        table = an.find_first_base_table(self.op()).to_expr()
         return table[[self[name] for name in self.names]]
 
     def destructure(self) -> list[ir.ValueExpr]:

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     import pandas as pd
     from ibis.expr import types as ir
 
+import ibis.expr.datatypes as dt
 from ibis.expr.types.core import Expr, _binop
 from ibis.expr.types.generic import Column, Scalar, Value
 
@@ -194,7 +195,7 @@ class _TimeComponentMixin:
             # triggered when creating expressions like
             # t.column.distinct().count(), which is turned into
             # t.column.nunique().
-            arg = op.arg
+            arg = op.arg.to_expr()
             if timezone is not None:
                 arg = arg.cast(dt.Timestamp(timezone=timezone))
             op_cls = ops.BetweenTime
@@ -250,7 +251,7 @@ class TimeValue(_TimeComponentMixin, TemporalValue):
 
         other = rlz.any(other)
 
-        if isinstance(other, TimeValue):
+        if isinstance(other.output_dtype, dt.Time):
             op = ops.TimeDiff
         else:
             op = ops.TimeSub  # let the operation validate
@@ -269,7 +270,7 @@ class TimeValue(_TimeComponentMixin, TemporalValue):
 
         other = rlz.any(other)
 
-        if isinstance(other, TimeValue):
+        if isinstance(other.output_dtype, dt.Time):
             op = ops.TimeDiff
         else:
             op = ops.TimeSub  # let the operation validate
@@ -333,7 +334,7 @@ class DateValue(TemporalValue, _DateComponentMixin):
 
         other = rlz.one_of([rlz.date, rlz.interval], other)
 
-        if isinstance(other, DateValue):
+        if isinstance(other.output_dtype, dt.Date):
             op = ops.DateDiff
         else:
             op = ops.DateSub  # let the operation validate
@@ -356,7 +357,7 @@ class DateValue(TemporalValue, _DateComponentMixin):
 
         other = rlz.one_of([rlz.date, rlz.interval], other)
 
-        if isinstance(other, DateValue):
+        if isinstance(other.output_dtype, dt.Date):
             op = ops.DateDiff
         else:
             op = ops.DateSub  # let the operation validate
@@ -438,7 +439,7 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, TemporalValue):
 
         right = rlz.any(other)
 
-        if isinstance(right, TimestampValue):
+        if isinstance(right.output_dtype, dt.Timestamp):
             op = ops.TimestampDiff
         else:
             op = ops.TimestampSub  # let the operation validate
@@ -462,7 +463,7 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, TemporalValue):
 
         right = rlz.any(other)
 
-        if isinstance(right, TimestampValue):
+        if isinstance(right.output_dtype, dt.Timestamp):
             op = ops.TimestampDiff
         else:
             op = ops.TimestampSub  # let the operation validate

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -37,10 +37,9 @@ def test_rewrite_join_projection_without_other_ops(con):
     ex_pred2 = table['bar_id'] == table3['bar_id']
     ex_expr = table.left_join(table2, [pred1]).inner_join(table3, [ex_pred2])
 
-    rewritten_proj = L.substitute_parents(view)
-    op = rewritten_proj.op()
+    rewritten_proj = L.substitute_parents(view.op())
 
-    assert not op.table.equals(ex_expr)
+    assert not rewritten_proj.table.equals(ex_expr.op())
 
 
 def test_multiple_join_deeper_reference():
@@ -94,7 +93,7 @@ def test_filter_on_projected_field(con):
     # Now then! Predicate pushdown here is inappropriate, so we check that
     # it didn't occur.
     assert isinstance(result.op(), ops.Selection)
-    assert result.op().table is tpch
+    assert result.op().table == tpch.op()
 
 
 def test_join_predicate_from_derived_raises():
@@ -155,15 +154,15 @@ def test_filter_self_join():
     proj_exprs = projected.op().selections
 
     # proj exprs unaffected by analysis
-    assert_equal(proj_exprs[0], left.region)
-    assert_equal(proj_exprs[1], metric)
+    assert_equal(proj_exprs[0], left.region.op())
+    assert_equal(proj_exprs[1], metric.op())
 
 
 def test_no_rewrite(con):
     table = con.table('test1')
     table4 = table[['c', (table['c'] * 2).name('foo')]]
     expr = table4['c'] == table4['foo']
-    result = L.substitute_parents(expr)
+    result = L.substitute_parents(expr.op()).to_expr()
     expected = expr
     assert result.equals(expected)
 
@@ -173,7 +172,9 @@ def test_join_table_choice():
     x = ibis.table(ibis.schema([('n', 'int64')]), 'x')
     t = x.aggregate(cnt=x.n.count())
     predicate = t.cnt > 0
-    assert L.sub_for(predicate, [(t, t.op().table)]).equals(predicate)
+
+    result = L.sub_for(predicate.op(), {t.op(): t.op().table})
+    assert result == predicate.op()
 
 
 def test_is_ancestor_analytic():
@@ -200,19 +201,20 @@ def test_mutation_fusion_no_overwrite():
     result = result.mutate(col1=t['col'] + 1)
     result = result.mutate(col2=t['col'] + 2)
     result = result.mutate(col3=t['col'] + 3)
+    result = result.op()
 
     first_selection = result
 
-    assert len(result.op().selections) == 4
-    assert (
-        first_selection.op().selections[1].equals((t['col'] + 1).name('col1'))
-    )
-    assert (
-        first_selection.op().selections[2].equals((t['col'] + 2).name('col2'))
-    )
-    assert (
-        first_selection.op().selections[3].equals((t['col'] + 3).name('col3'))
-    )
+    assert len(result.selections) == 4
+
+    col1 = (t['col'] + 1).name('col1')
+    assert first_selection.selections[1] == col1.op()
+
+    col2 = (t['col'] + 2).name('col2')
+    assert first_selection.selections[2] == col2.op()
+
+    col3 = (t['col'] + 3).name('col3')
+    assert first_selection.selections[3] == col3.op()
 
 
 # Pr 2635
@@ -228,32 +230,37 @@ def test_mutation_fusion_overwrite():
     result = result.mutate(col=t['col'] - 1)
     result = result.mutate(col4=t['col'] + 4)
 
-    second_selection = result
-    first_selection = second_selection.op().table
+    second_selection = result.op()
+    first_selection = second_selection.table
 
-    assert len(first_selection.op().selections) == 4
-    assert (
-        first_selection.op().selections[1].equals((t['col'] + 1).name('col1'))
-    )
-    assert (
-        first_selection.op().selections[2].equals((t['col'] + 2).name('col2'))
-    )
-    assert (
-        first_selection.op().selections[3].equals((t['col'] + 3).name('col3'))
-    )
+    assert len(first_selection.selections) == 4
+    col1 = (t['col'] + 1).name('col1').op()
+    assert first_selection.selections[1] == col1
+
+    col2 = (t['col'] + 2).name('col2').op()
+    assert first_selection.selections[2] == col2
+
+    col3 = (t['col'] + 3).name('col3').op()
+    assert first_selection.selections[3] == col3
 
     # Since the second selection overwrites existing columns, it will
     # not have the Table as the first selection
-    assert len(second_selection.op().selections) == 5
-    assert (
-        second_selection.op().selections[0].equals((t['col'] - 1).name('col'))
-    )
-    assert second_selection.op().selections[1].equals(first_selection['col1'])
-    assert second_selection.op().selections[2].equals(first_selection['col2'])
-    assert second_selection.op().selections[3].equals(first_selection['col3'])
-    assert (
-        second_selection.op().selections[4].equals((t['col'] + 4).name('col4'))
-    )
+    assert len(second_selection.selections) == 5
+
+    col = (t['col'] - 1).name('col').op()
+    assert second_selection.selections[0] == col
+
+    col1 = first_selection.to_expr()['col1'].op()
+    assert second_selection.selections[1] == col1
+
+    col2 = first_selection.to_expr()['col2'].op()
+    assert second_selection.selections[2] == col2
+
+    col3 = first_selection.to_expr()['col3'].op()
+    assert second_selection.selections[3] == col3
+
+    col4 = (t['col'] + 4).name('col4').op()
+    assert second_selection.selections[4] == col4
 
 
 # Pr 2635
@@ -266,15 +273,13 @@ def test_select_filter_mutate_fusion():
     result = result[result['col'].isnan()]
     result = result.mutate(col=result['col'].cast('int32'))
 
-    second_selection = result
-    first_selection = second_selection.op().table
+    second_selection = result.op()
+    first_selection = second_selection.table
 
-    assert len(second_selection.op().selections) == 1
-    assert (
-        second_selection.op()
-        .selections[0]
-        .equals(first_selection['col'].cast('int32').name('col'))
-    )
+    assert len(second_selection.selections) == 1
+
+    col = first_selection.to_expr()['col'].cast('int32').name('col').op()
+    assert second_selection.selections[0] == col
 
     # we don't look past the projection when a filter is encountered, so the
     # number of selections in the first projection (`first_selection`) is 0
@@ -284,8 +289,8 @@ def test_select_filter_mutate_fusion():
     #
     # eventually we will bring this back, but we're trading off the ability
     # to remove materialize for some performance in the short term
-    assert len(first_selection.op().selections) == 0
-    assert len(first_selection.op().predicates) == 1
+    assert len(first_selection.selections) == 0
+    assert len(first_selection.predicates) == 1
 
 
 def test_no_filter_means_no_selection():
@@ -297,9 +302,9 @@ def test_no_filter_means_no_selection():
 def test_mutate_overwrites_existing_column():
     t = ibis.table(dict(a="string"))
     mut = t.mutate(a=42).select(["a"])
-    sel = mut.op().selections[0].op().table.op().selections[0].op().arg
-    assert isinstance(sel.op(), ops.Literal)
-    assert sel.op().value == 42
+    sel = mut.op().selections[0].table.selections[0].arg
+    assert isinstance(sel, ops.Literal)
+    assert sel.value == 42
 
 
 def test_agg_selection_does_not_share_roots():

--- a/ibis/tests/expr/test_case.py
+++ b/ibis/tests/expr/test_case.py
@@ -56,7 +56,7 @@ def test_multiple_case_expr(table):
     op = expr.op()
     assert isinstance(expr, ir.FloatingColumn)
     assert isinstance(op, ops.SearchedCase)
-    assert op.default is default
+    assert op.default == default.op()
 
 
 def test_pickle_multiple_case_node(table):
@@ -87,9 +87,9 @@ def test_simple_case_null_else(table):
     op = expr.op()
 
     assert isinstance(expr, ir.StringColumn)
-    assert isinstance(op.default, ir.Value)
-    assert isinstance(op.default.op(), ops.Cast)
-    assert op.default.op().to == dt.string
+    assert isinstance(op.default.to_expr(), ir.Value)
+    assert isinstance(op.default, ops.Cast)
+    assert op.default.to == dt.string
 
 
 def test_multiple_case_null_else(table):
@@ -97,9 +97,9 @@ def test_multiple_case_null_else(table):
     op = expr.op()
 
     assert isinstance(expr, ir.StringColumn)
-    assert isinstance(op.default, ir.Value)
-    assert isinstance(op.default.op(), ops.Cast)
-    assert op.default.op().to == dt.string
+    assert isinstance(op.default.to_expr(), ir.Value)
+    assert isinstance(op.default, ops.Cast)
+    assert op.default.to == dt.string
 
 
 def test_case_mixed_type():

--- a/ibis/tests/expr/test_datatypes.py
+++ b/ibis/tests/expr/test_datatypes.py
@@ -216,6 +216,15 @@ def test_primitive_from_string(spec, expected):
     assert dt.dtype(spec) == expected
 
 
+def test_singleton_classes():
+    assert dt.Boolean() is dt.boolean
+    assert dt.Boolean(nullable=True) is dt.boolean
+    assert dt.Boolean(nullable=False) is not dt.boolean
+    assert dt.Boolean(nullable=False) is dt.Boolean(nullable=False)
+    assert dt.Boolean(nullable=True) is dt.Boolean(nullable=True)
+    assert dt.Boolean(nullable=True) is not dt.Boolean(nullable=False)
+
+
 def test_literal_mixed_type_fails():
     data = [1, 'a']
     with pytest.raises(TypeError):
@@ -440,11 +449,9 @@ def test_infer_dtype(value, expected_dtype):
 @pytest.mark.parametrize(
     ('source', 'target'),
     [
-        (dt.any, dt.string),
         (dt.string, dt.uuid),
         (dt.uuid, dt.string),
         (dt.null, dt.date),
-        (dt.null, dt.any),
         (dt.int8, dt.int64),
         (dt.int8, dt.Decimal(12, 2)),
         (dt.int32, dt.int32),

--- a/ibis/tests/expr/test_format.py
+++ b/ibis/tests/expr/test_format.py
@@ -129,6 +129,7 @@ def test_memoize_insert_sort_key(con):
     worst = expr[expr.dev.notnull()].sort_by(ibis.desc('dev')).limit(10)
 
     result = repr(worst)
+
     assert result.count('airlines') == 1
 
 
@@ -284,6 +285,7 @@ def test_window_no_group_by():
 def test_window_group_by():
     t = ibis.table(dict(a="int64", b="string"), name="t")
     expr = t.a.mean().over(ibis.window(group_by=t.b))
+
     result = repr(expr)
     assert "preceding=0" not in result
     assert "group_by=[r0.b]" in result
@@ -343,4 +345,7 @@ def test_destruct_selection():
         return v.sum(), v.mean()
 
     expr = table.aggregate(multi_output_udf(table['col']).destructure())
-    assert repr(expr)
+    result = repr(expr)
+
+    assert "sum:  StructField(ReductionVectorizedUDF" in result
+    assert "mean: StructField(ReductionVectorizedUDF" in result

--- a/ibis/tests/expr/test_operations.py
+++ b/ibis/tests/expr/test_operations.py
@@ -115,9 +115,9 @@ def test_array_input():
 
     raw_value = [1.0, 2.0, 3.0]
     op = MyOp(raw_value)
-    result = op.value
+
     expected = ibis.literal(raw_value)
-    assert result.equals(expected)
+    assert op.value == expected.op()
 
 
 def test_custom_table_expr():

--- a/ibis/tests/expr/test_sql_builtins.py
+++ b/ibis/tests/expr/test_sql_builtins.py
@@ -70,12 +70,12 @@ def test_group_concat(functional_alltypes):
     expr = col.group_concat()
     assert isinstance(expr.op(), ops.GroupConcat)
     op = expr.op()
-    assert op.sep.equals(ibis.literal(','))
+    assert op.sep == ibis.literal(',').op()
     assert op.where is None
 
     expr = col.group_concat('|')
     op = expr.op()
-    assert op.sep.equals(ibis.literal('|'))
+    assert op.sep == ibis.literal('|').op()
     assert op.where is None
 
 
@@ -147,7 +147,7 @@ def test_round(functional_alltypes, lineitem):
 
     result = functional_alltypes.double_col.round(2)
     assert isinstance(result, ir.FloatingColumn)
-    assert result.op().args[1].equals(ibis.literal(2))
+    assert result.op().args[1] == ibis.literal(2).op()
 
     # Even integers are double (at least in Impala, check with other DB
     # implementations)

--- a/ibis/tests/expr/test_string.py
+++ b/ibis/tests/expr/test_string.py
@@ -52,8 +52,8 @@ def test_substr(table):
 
     start, length = op.args[1:]
 
-    assert start.equals(literal(2))
-    assert length.equals(literal(4))
+    assert start == literal(2).op()
+    assert length == literal(4).op()
 
 
 def test_left_right(table):
@@ -64,7 +64,7 @@ def test_left_right(table):
     result = table.g.right(5)
     op = result.op()
     assert isinstance(op, ops.StrRight)
-    assert op.args[1].equals(literal(5))
+    assert op.args[1] == literal(5).op()
 
 
 def test_length(table):

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -71,7 +71,7 @@ def test_view_new_relation(table):
     # meaning when it comes to execution
     tview = table.view()
 
-    roots = L.find_immediate_parent_tables(tview)
+    roots = L.find_immediate_parent_tables(tview.op())
     assert len(roots) == 1
     assert roots[0] is tview.op()
 
@@ -341,24 +341,24 @@ def test_sort_by(table):
     #
     # Default is ascending for anything coercable to an expression,
     # and we'll have ascending/descending wrappers to help.
-    result = table.sort_by(['f'])
+    result = table.sort_by(['f']).op()
 
-    sort_key = result.op().sort_keys[0].op()
+    sort_key = result.sort_keys[0]
 
-    assert_equal(sort_key.expr, table.f)
+    assert_equal(sort_key.expr, table.f.op())
     assert sort_key.ascending
 
     # non-list input. per #150
-    result2 = table.sort_by('f')
+    result2 = table.sort_by('f').op()
     assert_equal(result, result2)
 
     result2 = table.sort_by([('f', False)])
     result3 = table.sort_by([('f', 'descending')])
     result4 = table.sort_by([('f', 0)])
 
-    key2 = result2.op().sort_keys[0].op()
-    key3 = result3.op().sort_keys[0].op()
-    key4 = result4.op().sort_keys[0].op()
+    key2 = result2.op().sort_keys[0]
+    key3 = result3.op().sort_keys[0]
+    key4 = result4.op().sort_keys[0]
 
     assert not key2.ascending
     assert not key3.ascending
@@ -416,7 +416,7 @@ def test_table_count(table):
     result = table.count()
     assert isinstance(result, ir.IntegerScalar)
     assert isinstance(result.op(), ops.Alias)
-    assert isinstance(result.op().arg.op(), ops.Count)
+    assert isinstance(result.op().arg, ops.Count)
     assert result.get_name() == 'count'
 
 
@@ -430,7 +430,7 @@ def test_sum_expr_basics(table, int_col):
     result = table[int_col].sum()
     assert isinstance(result, ir.IntegerScalar)
     assert isinstance(result.op(), ops.Alias)
-    assert isinstance(result.op().arg.op(), ops.Sum)
+    assert isinstance(result.op().arg, ops.Sum)
     assert result.get_name() == "sum"
 
 
@@ -439,7 +439,7 @@ def test_sum_expr_basics_floats(table, float_col):
     result = table[float_col].sum()
     assert isinstance(result, ir.FloatingScalar)
     assert isinstance(result.op(), ops.Alias)
-    assert isinstance(result.op().arg.op(), ops.Sum)
+    assert isinstance(result.op().arg, ops.Sum)
     assert result.get_name() == "sum"
 
 
@@ -447,7 +447,7 @@ def test_mean_expr_basics(table, numeric_col):
     result = table[numeric_col].mean()
     assert isinstance(result, ir.FloatingScalar)
     assert isinstance(result.op(), ops.Alias)
-    assert isinstance(result.op().arg.op(), ops.Mean)
+    assert isinstance(result.op().arg, ops.Mean)
     assert result.get_name() == "mean"
 
 
@@ -619,7 +619,7 @@ def test_group_by_kwargs(table):
 def test_compound_aggregate_expr(table):
     # See ibis #24
     compound_expr = (table['a'].sum() / table['a'].mean()).name('foo')
-    assert L.is_reduction(compound_expr)
+    assert L.is_reduction(compound_expr.op())
 
     # Validates internally
     table.aggregate([compound_expr])
@@ -735,8 +735,8 @@ def test_asof_join():
         "time_y",
         "value2",
     ]
-    pred = joined.op().table.op().predicates[0].op()
-    assert pred.left.op().name == pred.right.op().name == 'time'
+    pred = joined.op().table.predicates[0]
+    assert pred.left.name == pred.right.name == 'time'
 
 
 def test_asof_join_with_by():
@@ -755,8 +755,8 @@ def test_asof_join_with_by():
         "key_y",
         "value2",
     ]
-    by = joined.op().table.op().by[0].op()
-    assert by.left.op().name == by.right.op().name == 'key'
+    by = joined.op().table.by[0]
+    assert by.left.name == by.right.name == 'key'
 
 
 @pytest.mark.parametrize(
@@ -785,14 +785,16 @@ def test_asof_join_with_tolerance(ibis_interval, timedelta_interval):
         [('time', 'int32'), ('key', 'int32'), ('value2', 'double')]
     )
 
-    joined = api.asof_join(left, right, 'time', tolerance=ibis_interval)
-    tolerance = joined.op().table.op().tolerance
-    assert_equal(tolerance, ibis_interval)
+    joined = api.asof_join(left, right, 'time', tolerance=ibis_interval).op()
+    tolerance = joined.table.tolerance
+    assert_equal(tolerance, ibis_interval.op())
 
-    joined = api.asof_join(left, right, 'time', tolerance=timedelta_interval)
-    tolerance = joined.op().table.op().tolerance
-    assert isinstance(tolerance, ir.IntervalScalar)
-    assert isinstance(tolerance.op(), ops.Literal)
+    joined = api.asof_join(
+        left, right, 'time', tolerance=timedelta_interval
+    ).op()
+    tolerance = joined.table.tolerance
+    assert isinstance(tolerance.to_expr(), ir.IntervalScalar)
+    assert isinstance(tolerance, ops.Literal)
 
 
 def test_equijoin_schema_merge():
@@ -1203,7 +1205,7 @@ def test_resolve_existence_predicate(
     op = expr.op()
     assert isinstance(op, ops.Selection)
 
-    pred = op.predicates[0]
+    pred = op.predicates[0].to_expr()
     assert isinstance(pred.op(), expected_type)
     assert isinstance((-pred).op(), expected_negated_type)
 
@@ -1403,15 +1405,17 @@ def test_mutate_chain():
     a, b = three.op().selections
 
     # we can't fuse these correctly yet
-    assert isinstance(a.op(), ops.Alias)
-    assert isinstance(a.op().arg.op(), ops.IfNull)
-    assert isinstance(b.op(), ops.TableColumn)
+    assert isinstance(a, ops.Alias)
+    assert isinstance(a.arg, ops.IfNull)
+    assert isinstance(b, ops.TableColumn)
 
-    expr = b.op().table.op().selections[1]
-    assert isinstance(expr.op(), ops.Alias)
-    assert isinstance(expr.op().arg.op(), ops.IfNull)
+    expr = b.table.selections[1]
+    assert isinstance(expr, ops.Alias)
+    assert isinstance(expr.arg, ops.IfNull)
 
 
+# TODO(kszucs): move this test case to ibis/tests/sql since it requires the
+# sql backend to be executed
 def test_multiple_dbcon():
     """
     Expr from multiple connections to same DB should be compatible.

--- a/ibis/tests/expr/test_timestamp.py
+++ b/ibis/tests/expr/test_timestamp.py
@@ -43,7 +43,7 @@ def test_extract_fields(field, expected_operation, expected_type, alltypes):
     assert result.get_name() == field
     assert isinstance(result, expected_type)
     assert isinstance(result.op(), ops.Alias)
-    assert isinstance(result.op().arg.op(), expected_operation)
+    assert isinstance(result.op().arg, expected_operation)
 
 
 def test_now():
@@ -78,19 +78,20 @@ def test_comparisons_string(alltypes):
     val = '2015-01-01 00:00:00'
     expr = alltypes.i > val
     op = expr.op()
-    assert isinstance(op.right, ir.StringScalar)
+    assert op.right.output_dtype is dt.string
 
     expr2 = val < alltypes.i
     op = expr2.op()
     assert isinstance(op, ops.Greater)
-    assert isinstance(op.right, ir.StringScalar)
+    assert op.right.output_dtype is dt.string
 
 
 def test_comparisons_pandas_timestamp(alltypes):
     val = pd.Timestamp('2015-01-01 00:00:00')
     expr = alltypes.i > val
     op = expr.op()
-    assert isinstance(op.right, ir.TimestampScalar)
+    assert isinstance(op.right, ops.Literal)
+    assert isinstance(op.right.output_dtype, dt.Timestamp)
 
 
 def test_greater_comparison_pandas_timestamp(alltypes):
@@ -98,12 +99,13 @@ def test_greater_comparison_pandas_timestamp(alltypes):
     expr2 = val < alltypes.i
     op = expr2.op()
     assert isinstance(op, ops.Greater)
-    assert isinstance(op.right, ir.TimestampScalar)
+    assert isinstance(op.right, ops.Literal)
+    assert isinstance(op.right.output_dtype, dt.Timestamp)
 
 
 def test_timestamp_precedence():
     ts = ibis.literal(datetime.now())
-    highest_type = rlz.highest_precedence_dtype([ibis.NA, ts])
+    highest_type = rlz.highest_precedence_dtype([ibis.NA.op(), ts.op()])
     assert highest_type == dt.timestamp
 
 
@@ -123,7 +125,7 @@ def test_timestamp_field_access_on_date(
     assert result.get_name() == field
     assert isinstance(result, expected_type)
     assert isinstance(result.op(), ops.Alias)
-    assert isinstance(result.op().arg.op(), expected_operation)
+    assert isinstance(result.op().arg, expected_operation)
 
 
 @pytest.mark.parametrize(
@@ -160,7 +162,7 @@ def test_timestamp_field_access_on_time(
     assert result.get_name() == field
     assert isinstance(result, expected_type)
     assert isinstance(result.op(), ops.Alias)
-    assert isinstance(result.op().arg.op(), expected_operation)
+    assert isinstance(result.op().arg, expected_operation)
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/expr/test_udf.py
+++ b/ibis/tests/expr/test_udf.py
@@ -34,9 +34,9 @@ def test_vectorized_udf_operations(table, klass, output_type):
         input_type=[dt.int8(), dt.string(), dt.boolean()],
         return_type=dt.int8(),
     )
-    assert udf.func_args[0].equals(table.a)
-    assert udf.func_args[1].equals(table.b)
-    assert udf.func_args[2].equals(table.c)
+    assert udf.func_args[0] == table.a.op()
+    assert udf.func_args[1] == table.b.op()
+    assert udf.func_args[2] == table.c.op()
     assert udf.input_type == tuple([dt.int8(), dt.string(), dt.boolean()])
     assert udf.return_type == dt.int8()
 

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -265,7 +265,7 @@ def test_mixed_arity(table):
     expr = api.sequence(what)
 
     values = expr.op().values
-    assert isinstance(values[1], ir.StringColumn)
+    assert isinstance(values[1], ops.TableColumn)
 
     # it works!
     repr(expr)
@@ -317,13 +317,13 @@ def test_distinct_table(functional_alltypes):
     expr = functional_alltypes.distinct()
     assert isinstance(expr.op(), ops.Distinct)
     assert isinstance(expr, ir.Table)
-    assert expr.op().table is functional_alltypes
+    assert expr.op().table == functional_alltypes.op()
 
 
 def test_nunique(functional_alltypes):
     expr = functional_alltypes.string_col.nunique()
     assert isinstance(expr.op(), ops.Alias)
-    assert isinstance(expr.op().arg.op(), ops.CountDistinct)
+    assert isinstance(expr.op().arg, ops.CountDistinct)
 
 
 def test_isnull(table):
@@ -498,7 +498,7 @@ def test_arbitrary(table, column, how, condition_fn):
     expr = col.arbitrary(how=how, where=where)
     assert expr.type() == col.type()
     assert isinstance(expr, ir.Scalar)
-    assert L.is_reduction(expr)
+    assert L.is_reduction(expr.op())
 
 
 @pytest.mark.parametrize(
@@ -514,7 +514,7 @@ def test_arbitrary(table, column, how, condition_fn):
 def test_any_all_notany(table, column, operation):
     expr = operation(table[column])
     assert isinstance(expr, ir.BooleanScalar)
-    assert L.is_reduction(expr)
+    assert L.is_reduction(expr.op())
 
 
 @pytest.mark.parametrize(
@@ -1060,10 +1060,10 @@ def test_empty_array_as_argument():
 
     node = FooNode([])
     value = node.value
-    expected = literal([]).cast(dt.Array(dt.int64))
+    expected = literal([]).cast(dt.Array(dt.int64)).op()
 
-    assert value.type().equals(dt.Array(dt.null))
-    assert value.cast(dt.Array(dt.int64)).equals(expected)
+    assert value.output_dtype.equals(dt.Array(dt.null))
+    assert ops.Cast(value, dt.Array(dt.int64)).equals(expected)
 
 
 def test_nullable_column_propagated():
@@ -1358,6 +1358,8 @@ def test_repr_list_of_lists_in_table():
     repr(expr)
 
 
+# TODO(kszucs): should be marked as a pandas test case hence should be moved to
+# the pandas testing backend
 def test_repr_html():
     con = ibis.pandas.connect({"t": pd.DataFrame({"a": [1, 2, 3]})})
     t = con.table("t")
@@ -1502,9 +1504,9 @@ def test_deferred_r_ops(op_name, expected_left, expected_right):
     op = getattr(operator, op_name)
     expr = t[op(left, right).name("b")]
 
-    op = expr.op().selections[0].op().arg.op()
-    assert op.left.equals(expected_left(t))
-    assert op.right.equals(expected_right(t))
+    op = expr.op().selections[0].arg
+    assert op.left.equals(expected_left(t).op())
+    assert op.right.equals(expected_right(t).op())
 
 
 @pytest.mark.parametrize(
@@ -1557,7 +1559,7 @@ def test_struct_names_types_fields(name, expected):
 )
 def test_array_literal(arg, typestr, type):
     x = ibis.literal(arg, type=typestr)
-    assert x._arg.value == tuple(arg)
+    assert x.op().value == tuple(arg)
     assert x.type() == type
 
 

--- a/ibis/tests/expr/test_visualize.py
+++ b/ibis/tests/expr/test_visualize.py
@@ -17,10 +17,8 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def key(expr, name=None):
-    if name is None:
-        name = expr._safe_name
-    return str(hash((expr._key, name)))
+def key(node):
+    return str(hash(node))
 
 
 @pytest.mark.parametrize(
@@ -38,8 +36,8 @@ def key(expr, name=None):
 def test_exprs(table, expr_func):
     expr = expr_func(table)
     graph = viz.to_graph(expr)
-    assert key(table, 'table') in graph.source
-    assert key(expr) in graph.source
+    assert key(table.op()) in graph.source
+    assert key(expr.op()) in graph.source
 
 
 def test_custom_expr():
@@ -54,7 +52,7 @@ def test_custom_expr():
     op = MyExprNode('Hello!', 42.3)
     expr = op.to_expr()
     graph = viz.to_graph(expr)
-    assert key(expr) in graph.source
+    assert key(expr.op()) in graph.source
 
 
 def test_custom_expr_with_not_implemented_type():
@@ -76,7 +74,7 @@ def test_custom_expr_with_not_implemented_type():
     op = MyExprNode('Hello!', 42.3)
     expr = op.to_expr()
     graph = viz.to_graph(expr)
-    assert key(expr) in graph.source
+    assert key(expr.op()) in graph.source
 
 
 @pytest.fixture
@@ -96,7 +94,7 @@ def test_join(how):
     joined = left.join(right, left.b == right.b, how=how)
     result = joined[left.a, right.c]
     graph = viz.to_graph(result)
-    assert key(result) in graph.source
+    assert key(result.op()) in graph.source
 
 
 def test_sort_by():
@@ -105,7 +103,7 @@ def test_sort_by():
         t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).sort_by('b')
     )
     graph = viz.to_graph(expr)
-    assert key(expr) in graph.source
+    assert key(expr.op()) in graph.source
 
 
 @pytest.mark.skipif(
@@ -138,8 +136,8 @@ def test_between():
     source = graph.source
 
     # one for the node itself and one for the edge to between
-    assert key(lower_bound, 'lower_bound') in source
-    assert key(upper_bound, 'upper_bound') in source
+    assert key(lower_bound) in source
+    assert key(upper_bound) in source
 
 
 def test_asof_join():
@@ -150,7 +148,7 @@ def test_asof_join():
     joined = api.asof_join(left, right, 'time')
     result = joined[left, right.foo]
     graph = viz.to_graph(result)
-    assert key(result) in graph.source
+    assert key(result.op()) in graph.source
 
 
 def test_html_escape(with_graphviz):

--- a/ibis/tests/expr/test_window_functions.py
+++ b/ibis/tests/expr/test_window_functions.py
@@ -340,7 +340,7 @@ def test_combine_preserves_existing_window():
     w = ibis.cumulative_window(order_by=t.one)
     mut = t.group_by(t.three).mutate(four=t.two.sum().over(w))
 
-    assert mut.op().selections[1].op().arg.op().window.following == 0
+    assert mut.op().selections[1].arg.window.following == 0
 
 
 def test_quantile_shape():
@@ -353,6 +353,4 @@ def test_quantile_shape():
     expr = t.projection(projs)
     (b1,) = expr.op().selections
 
-    assert b1.op().output_shape == rlz.Shape.COLUMNAR
-
-    assert isinstance(b1, ir.Column)
+    assert b1.output_shape == rlz.Shape.COLUMNAR

--- a/ibis/tests/sql/test_ast_builder.py
+++ b/ibis/tests/sql/test_ast_builder.py
@@ -33,11 +33,10 @@ def test_ast_with_projection_join_filter(con):
     assert len(stmt.where) == 0
 
     # Check that the joined tables are not altered
-    tbl = stmt.table_set
-    tbl_node = tbl.op()
+    tbl_node = stmt.table_set
     assert isinstance(tbl_node, ops.InnerJoin)
-    assert tbl_node.left is table2
-    assert tbl_node.right is table3
+    assert tbl_node.left == table2.op()
+    assert tbl_node.right == table3.op()
 
 
 def test_ast_with_aggregation_join_filter(con):
@@ -61,7 +60,7 @@ def test_ast_with_aggregation_join_filter(con):
     # #790, this behavior was different before
     ex_pred = [table3['g'] == table2['key']]
     expected_table_set = table2.inner_join(table3, ex_pred)
-    assert stmt.table_set.equals(expected_table_set)
+    assert stmt.table_set == expected_table_set.op()
 
     # Check various exprs
     ex_metrics = [
@@ -70,10 +69,10 @@ def test_ast_with_aggregation_join_filter(con):
     ]
     ex_by = [table3['g'], table2['key']]
     for res, ex in zip(stmt.select_set, ex_by + ex_metrics):
-        assert res.equals(ex)
+        assert res == ex.op()
 
     for res, ex in zip(stmt.group_by, ex_by):
-        assert stmt.select_set[res].equals(ex)
+        assert stmt.select_set[res] == ex.op()
 
     # The filter is in the joined subtable
     assert len(stmt.where) == 0

--- a/ibis/tests/sql/test_select_sql.py
+++ b/ibis/tests/sql/test_select_sql.py
@@ -1394,11 +1394,11 @@ def test_join_filtered_tables_no_pushdown():
     )
 
     joined = tbl_a_filter.left_join(tbl_b_filter, ['year', 'month', 'day'])
-    result = joined[tbl_a_filter.value_a, tbl_b_filter.value_b]
+    result = joined[tbl_a_filter.value_a, tbl_b_filter.value_b].op()
 
-    join_op = result.op().table.op()
-    assert join_op.left.equals(tbl_a_filter)
-    assert join_op.right.equals(tbl_b_filter)
+    join_op = result.table
+    assert join_op.left == tbl_a_filter.op()
+    assert join_op.right == tbl_b_filter.op()
 
     result_sql = Compiler.to_sql(result)
     expected_sql = """\

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -887,9 +887,9 @@ def test_no_cross_join(person, visited, survey):
     context = AlchemyContext(compiler=AlchemyCompiler)
     _ = AlchemyCompiler.to_sql(expr, context)
 
-    t0 = context.get_ref(person)
-    t1 = context.get_ref(survey)
-    t2 = context.get_ref(visited)
+    t0 = context.get_ref(person.op())
+    t1 = context.get_ref(survey.op())
+    t2 = context.get_ref(visited.op())
 
     from_ = t0.join(t1, t0.c.id == t1.c.person).join(t2, t2.c.id == t1.c.taken)
     ex = sa.select(

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -27,8 +27,7 @@ import toolz
 from ibis.config import options
 
 if TYPE_CHECKING:
-    from ibis.expr import operations as ops
-    from ibis.expr import types as ir
+    import ibis.expr.operations as ops
 
     Graph = Mapping[ops.Node, Sequence[ops.Node]]
 
@@ -134,8 +133,10 @@ def promote_list(val: V | Sequence[V]) -> list[V]:
     """
     if isinstance(val, list):
         return val
-    elif isinstance(val, tuple):
+    elif is_iterable(val):
         return list(val)
+    elif val is None:
+        return []
     else:
         return [val]
 
@@ -305,13 +306,11 @@ def convert_unit(value, unit, to, floor=True):
     assert factor > 1
 
     if i < j:
-        return value * factor
-
-    assert i > j
-    if floor:
-        return value // factor
+        op = operator.mul
     else:
-        return value / factor
+        assert i > j
+        op = operator.floordiv if floor else operator.truediv
+    return op(value.to_expr(), factor).op()
 
 
 def get_logger(
@@ -431,7 +430,7 @@ def deprecated(*, instead, version=''):
     return decorator
 
 
-def to_op_dag(expr: ir.Expr) -> Graph:
+def to_op_dag(node: ops.Node) -> Graph:
     """Convert `expr` into a directed acyclic graph.
 
     Parameters
@@ -444,12 +443,21 @@ def to_op_dag(expr: ir.Expr) -> Graph:
     Graph
         A directed acyclic graph of ibis operations
     """
-    stack = [expr.op()]
+    import ibis.expr.operations as ops
+
+    assert isinstance(node, ops.Node), type(node)
+
+    stack = [node]
     dag = {}
 
     while stack:
         if (node := stack.pop()) not in dag:
-            dag[node] = children = node._flat_ops
+            # TODO(kszucs): use a more generic approach without filtering out
+            # node instances
+            children = [
+                arg for arg in node.flat_args() if isinstance(arg, ops.Node)
+            ]
+            dag[node] = children
             stack.extend(children)
     return dag
 

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ clean:
 lock:
     poetry lock --no-update
     poetry export --dev --extras all --without-hashes --no-ansi > requirements.txt
-    python dev/poetry2setup.py -o setup.py
+    PYTHONHASHSEED=0 python dev/poetry2setup.py -o setup.py
 
 # show all backends
 @list-backends:

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,7 +23,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-test = ["wheel", "pexpect", "flake8", "coverage"]
+test = ["coverage", "flake8", "pexpect", "wheel"]
 
 [[package]]
 name = "asttokens"
@@ -37,7 +37,7 @@ python-versions = "*"
 six = "*"
 
 [package.extras]
-test = ["pytest", "astroid (<=2.5.3)"]
+test = ["astroid (<=2.5.3)", "pytest"]
 
 [[package]]
 name = "astunparse"
@@ -75,10 +75,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
-docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
-dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "babel"
@@ -122,8 +122,8 @@ python-versions = ">=3.6.0"
 soupsieve = ">1.2"
 
 [package.extras]
-lxml = ["lxml"]
 html5lib = ["html5lib"]
+lxml = ["lxml"]
 
 [[package]]
 name = "bitarray"
@@ -150,10 +150,10 @@ tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
 typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-uvloop = ["uvloop (>=0.15.2)"]
-jupyter = ["tokenize-rt (>=3.2.0)", "ipython (>=7.8.0)"]
-d = ["aiohttp (>=3.7.4)"]
 colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bleach"
@@ -168,8 +168,8 @@ six = ">=1.9.0"
 webencodings = "*"
 
 [package.extras]
-dev = ["mypy (==0.961)", "black (==22.3.0)", "wheel (==0.37.1)", "twine (==4.0.1)", "tox (==3.25.0)", "Sphinx (==4.3.2)", "pytest (==7.1.2)", "pip-tools (==6.6.2)", "hashin (==0.17.0)", "flake8 (==4.0.1)", "build (==0.8.0)"]
 css = ["tinycss2 (>=1.1.0,<1.2)"]
+dev = ["build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "pip-tools (==6.6.2)", "pytest (==7.1.2)", "Sphinx (==4.3.2)", "tox (==3.25.0)", "twine (==4.0.1)", "wheel (==0.37.1)", "black (==22.3.0)", "mypy (==0.961)"]
 
 [[package]]
 name = "certifi"
@@ -340,7 +340,7 @@ python-versions = ">=3.8"
 [package.dependencies]
 cloudpickle = ">=1.1.1"
 fsspec = ">=0.6.0"
-numpy = {version = ">=1.18", optional = true, markers = "extra == \"dataframe\""}
+numpy = {version = ">=1.18", optional = true, markers = "extra == \"array\""}
 packaging = ">=20.0"
 pandas = {version = ">=1.0", optional = true, markers = "extra == \"dataframe\""}
 partd = ">=0.3.10"
@@ -348,12 +348,12 @@ pyyaml = ">=5.3.1"
 toolz = ">=0.8.2"
 
 [package.extras]
-test = ["pre-commit", "pytest-xdist", "pytest-rerunfailures", "pytest"]
-distributed = ["distributed (==2022.7.1)"]
-diagnostics = ["jinja2", "bokeh (>=2.4.2)"]
-dataframe = ["pandas (>=1.0)", "numpy (>=1.18)"]
-complete = ["pandas (>=1.0)", "numpy (>=1.18)", "jinja2", "distributed (==2022.7.1)", "bokeh (>=2.4.2)"]
 array = ["numpy (>=1.18)"]
+complete = ["bokeh (>=2.4.2)", "distributed (==2022.7.1)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
+dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
+diagnostics = ["bokeh (>=2.4.2)", "jinja2"]
+distributed = ["distributed (==2022.7.1)"]
+test = ["pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
 
 [[package]]
 name = "datafusion"
@@ -491,8 +491,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-testing = ["pytest-timeout (>=2.1)", "pytest-cov (>=3)", "pytest (>=7.1.2)", "coverage (>=6.4.2)", "covdefaults (>=2.2)"]
-docs = ["sphinx-autodoc-typehints (>=1.19.1)", "sphinx (>=5.1.1)", "furo (>=2022.6.21)"]
+docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
+testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "fiona"
@@ -512,10 +512,10 @@ munch = "*"
 six = ">=1.7"
 
 [package.extras]
-test = ["mock", "boto3 (>=1.2.4)", "pytest-cov", "pytest (>=3)"]
-s3 = ["boto3 (>=1.2.4)"]
+all = ["boto3 (>=1.2.4)", "pytest-cov", "shapely", "pytest (>=3)", "mock"]
 calc = ["shapely"]
-all = ["mock", "pytest (>=3)", "shapely", "pytest-cov", "boto3 (>=1.2.4)"]
+s3 = ["boto3 (>=1.2.4)"]
+test = ["pytest (>=3)", "pytest-cov", "boto3 (>=1.2.4)", "mock"]
 
 [[package]]
 name = "flake8"
@@ -539,27 +539,27 @@ optional = true
 python-versions = ">=3.7"
 
 [package.extras]
-tqdm = ["tqdm"]
-ssh = ["paramiko"]
-smb = ["smbprotocol"]
-sftp = ["paramiko"]
-s3 = ["s3fs"]
-oci = ["ocifs"]
-libarchive = ["libarchive-c"]
-http = ["aiohttp", "requests"]
-hdfs = ["pyarrow (>=1)"]
-gui = ["panel"]
-gs = ["gcsfs"]
-github = ["requests"]
-git = ["pygit2"]
-gcs = ["gcsfs"]
-fuse = ["fusepy"]
-entrypoints = ["importlib-metadata"]
-dropbox = ["dropbox", "requests", "dropboxdrivefs"]
-dask = ["distributed", "dask"]
-arrow = ["pyarrow (>=1)"]
-adl = ["adlfs"]
 abfs = ["adlfs"]
+adl = ["adlfs"]
+arrow = ["pyarrow (>=1)"]
+dask = ["dask", "distributed"]
+dropbox = ["dropboxdrivefs", "requests", "dropbox"]
+entrypoints = ["importlib-metadata"]
+fuse = ["fusepy"]
+gcs = ["gcsfs"]
+git = ["pygit2"]
+github = ["requests"]
+gs = ["gcsfs"]
+gui = ["panel"]
+hdfs = ["pyarrow (>=1)"]
+http = ["requests", "aiohttp"]
+libarchive = ["libarchive-c"]
+oci = ["ocifs"]
+s3 = ["s3fs"]
+sftp = ["paramiko"]
+smb = ["smbprotocol"]
+ssh = ["paramiko"]
+tqdm = ["tqdm"]
 
 [[package]]
 name = "geoalchemy2"
@@ -676,9 +676,9 @@ python-versions = ">=3.7"
 zipp = ">=0.5"
 
 [package.extras]
-testing = ["importlib-resources (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "pytest-perf (>=0.9.2)", "flufl.flake8", "pyfakefs", "packaging", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-docs = ["rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
@@ -692,8 +692,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
-docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "impyla"
@@ -756,7 +756,7 @@ tornado = ">=6.1"
 traitlets = ">=5.1.0"
 
 [package.extras]
-test = ["pytest (>=6.0)", "pytest-timeout", "pytest-cov", "pre-commit", "ipyparallel", "flaky"]
+test = ["flaky", "ipyparallel", "pre-commit", "pytest-cov", "pytest-timeout", "pytest (>=6.0)"]
 
 [[package]]
 name = "ipython"
@@ -781,17 +781,17 @@ stack-data = "*"
 traitlets = ">=5"
 
 [package.extras]
-test_extra = ["trio", "pandas", "numpy (>=1.19)", "nbformat", "matplotlib (!=3.2.0)", "curio", "testpath", "pytest-asyncio", "pytest (<7.1)"]
-test = ["testpath", "pytest-asyncio", "pytest (<7.1)"]
-qtconsole = ["qtconsole"]
-parallel = ["ipyparallel"]
-notebook = ["notebook", "ipywidgets"]
-nbformat = ["nbformat"]
-nbconvert = ["nbconvert"]
-kernel = ["ipykernel"]
-doc = ["Sphinx (>=1.3)"]
+all = ["black", "Sphinx (>=1.3)", "ipykernel", "nbconvert", "nbformat", "ipywidgets", "notebook", "ipyparallel", "qtconsole", "pytest (<7.1)", "pytest-asyncio", "testpath", "curio", "matplotlib (!=3.2.0)", "numpy (>=1.19)", "pandas", "trio"]
 black = ["black"]
-all = ["trio", "pandas", "numpy (>=1.19)", "matplotlib (!=3.2.0)", "curio", "testpath", "pytest-asyncio", "pytest (<7.1)", "qtconsole", "ipyparallel", "notebook", "ipywidgets", "nbformat", "nbconvert", "ipykernel", "Sphinx (>=1.3)", "black"]
+doc = ["Sphinx (>=1.3)"]
+kernel = ["ipykernel"]
+nbconvert = ["nbconvert"]
+nbformat = ["nbformat"]
+notebook = ["ipywidgets", "notebook"]
+parallel = ["ipyparallel"]
+qtconsole = ["qtconsole"]
+test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
+test_extra = ["pytest (<7.1)", "pytest-asyncio", "testpath", "curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "trio"]
 
 [[package]]
 name = "isort"
@@ -802,10 +802,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-plugins = ["setuptools"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-requirements_deprecated_finder = ["pip-api", "pipreqs"]
-pipfile_deprecated_finder = ["requirementslib", "pipreqs"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "jedi"
@@ -872,8 +872,8 @@ tornado = ">=6.0"
 traitlets = "*"
 
 [package.extras]
-test = ["pytest-timeout", "pytest-cov", "pytest-asyncio (>=0.18)", "pytest", "pre-commit", "mypy", "ipython", "ipykernel (>=6.5)", "coverage", "codecov"]
-doc = ["sphinxcontrib-github-alt", "sphinx (>=1.3.6)", "sphinx-rtd-theme", "myst-parser", "ipykernel"]
+doc = ["ipykernel", "myst-parser", "sphinx-rtd-theme", "sphinx (>=1.3.6)", "sphinxcontrib-github-alt"]
+test = ["codecov", "coverage", "ipykernel (>=6.5)", "ipython", "mypy", "pre-commit", "pytest", "pytest-asyncio (>=0.18)", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyter-core"
@@ -888,7 +888,7 @@ pywin32 = {version = ">=1.0", markers = "sys_platform == \"win32\" and platform_
 traitlets = "*"
 
 [package.extras]
-test = ["pytest-timeout", "pytest-cov", "pytest", "pre-commit", "ipykernel"]
+test = ["ipykernel", "pre-commit", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
 name = "jupyterlab-pygments"
@@ -914,8 +914,8 @@ pyyaml = "*"
 toml = "*"
 
 [package.extras]
-toml = ["toml"]
 rst2md = ["sphinx-gallery (>=0.7.0,<0.8.0)"]
+toml = ["toml"]
 
 [[package]]
 name = "kerberos"
@@ -942,10 +942,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
 
 [package.extras]
-source = ["Cython (>=0.29.7)"]
-htmlsoup = ["beautifulsoup4"]
-html5 = ["html5lib"]
 cssselect = ["cssselect (>=0.7)"]
+html5 = ["html5lib"]
+htmlsoup = ["beautifulsoup4"]
+source = ["Cython (>=0.29.7)"]
 
 [[package]]
 name = "lz4"
@@ -956,9 +956,9 @@ optional = true
 python-versions = ">=3.7"
 
 [package.extras]
-tests = ["pytest-cov", "psutil", "pytest (!=3.3.0)"]
+docs = ["sphinx (>=1.6.0)", "sphinx-bootstrap-theme"]
 flake8 = ["flake8"]
-docs = ["sphinx-bootstrap-theme", "sphinx (>=1.6.0)"]
+tests = ["pytest (!=3.3.0)", "psutil", "pytest-cov"]
 
 [[package]]
 name = "markdown"
@@ -1272,8 +1272,8 @@ python-versions = "*"
 six = "*"
 
 [package.extras]
+testing = ["pytest", "coverage", "astroid (>=1.5.3,<1.6.0)", "pylint (>=1.7.2,<1.8.0)", "astroid (>=2.0)", "pylint (>=2.3.1,<2.4.0)"]
 yaml = ["PyYAML (>=5.1.0)"]
-testing = ["pylint (>=2.3.1,<2.4.0)", "astroid (>=2.0)", "pylint (>=1.7.2,<1.8.0)", "astroid (>=1.5.3,<1.6.0)", "coverage", "pytest"]
 
 [[package]]
 name = "mypy"
@@ -1289,9 +1289,9 @@ tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
-reports = ["lxml"]
-python2 = ["typed-ast (>=1.4.0,<2)"]
 dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
@@ -1347,11 +1347,11 @@ tinycss2 = "*"
 traitlets = ">=5.0"
 
 [package.extras]
-webpdf = ["pyppeteer (>=1,<1.1)"]
-test = ["pyppeteer (>=1,<1.1)", "pre-commit", "ipywidgets (>=7)", "ipykernel", "pytest-dependency", "pytest-cov", "pytest"]
+all = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pre-commit", "pyppeteer (>=1,<1.1)", "tornado (>=6.1)", "sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
+docs = ["sphinx (>=1.5.1)", "sphinx-rtd-theme", "nbsphinx (>=0.2.12)", "ipython"]
 serve = ["tornado (>=6.1)"]
-docs = ["ipython", "nbsphinx (>=0.2.12)", "sphinx-rtd-theme", "sphinx (>=1.5.1)"]
-all = ["ipython", "nbsphinx (>=0.2.12)", "sphinx-rtd-theme", "sphinx (>=1.5.1)", "tornado (>=6.1)", "pyppeteer (>=1,<1.1)", "pre-commit", "ipywidgets (>=7)", "ipykernel", "pytest-dependency", "pytest-cov", "pytest"]
+test = ["pytest", "pytest-cov", "pytest-dependency", "ipykernel", "ipywidgets (>=7)", "pre-commit", "pyppeteer (>=1,<1.1)"]
+webpdf = ["pyppeteer (>=1,<1.1)"]
 
 [[package]]
 name = "nbformat"
@@ -1368,7 +1368,7 @@ jupyter-core = "*"
 traitlets = ">=5.1"
 
 [package.extras]
-test = ["pre-commit", "pytest", "testpath", "check-manifest"]
+test = ["check-manifest", "testpath", "pytest", "pre-commit"]
 
 [[package]]
 name = "nest-asyncio"
@@ -1407,16 +1407,16 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
-    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
-    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
     {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
+    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
 [package.extras]
-test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "pandocfilters"
@@ -1435,8 +1435,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest (<6.0.0)", "docopt"]
-qa = ["mypy (==0.782)", "flake8 (==3.8.3)"]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
+testing = ["docopt", "pytest (<6.0.0)"]
 
 [[package]]
 name = "parsy"
@@ -1505,8 +1505,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-test = ["pytest (>=6)", "pytest-mock (>=3.6)", "pytest-cov (>=2.7)", "appdirs (==1.4.4)"]
-docs = ["sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)", "proselint (>=0.10.2)", "furo (>=2021.7.5b38)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
 
 [[package]]
 name = "pluggy"
@@ -1561,7 +1561,7 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-test = ["wmi", "pywin32", "enum34", "mock", "ipaddress"]
+test = ["ipaddress", "mock", "enum34", "pywin32", "wmi"]
 
 [[package]]
 name = "psycopg2"
@@ -1664,8 +1664,8 @@ python-versions = ">=3.6.1"
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
-email = ["email-validator (>=1.0.3)"]
 dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydocstyle"
@@ -1732,7 +1732,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pyproj"
@@ -1789,7 +1789,7 @@ py = ">=1.8.2"
 tomli = ">=1.0.0"
 
 [package.extras]
-testing = ["xmlschema", "requests", "pygments (>=2.7.2)", "nose", "mock", "hypothesis (>=3.56)", "argcomplete"]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "pytest-benchmark"
@@ -1804,9 +1804,9 @@ py-cpuinfo = "*"
 pytest = ">=3.8"
 
 [package.extras]
-histogram = ["pygaljs", "pygal"]
-elasticsearch = ["elasticsearch"]
 aspect = ["aspectlib"]
+elasticsearch = ["elasticsearch"]
+histogram = ["pygal", "pygaljs"]
 
 [[package]]
 name = "pytest-clarity"
@@ -1860,7 +1860,7 @@ python-versions = ">=3.7"
 pytest = ">=5.0"
 
 [package.extras]
-dev = ["pytest-asyncio", "tox", "pre-commit"]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
 
 [[package]]
 name = "pytest-profiling"
@@ -2027,7 +2027,7 @@ python-versions = ">=3.6,<4.0"
 prompt_toolkit = ">=2.0,<4.0"
 
 [package.extras]
-docs = ["sphinx-autodoc-typehints (>=1.11.1,<2.0.0)", "sphinx-copybutton (>=0.3.1,<0.4.0)", "sphinx-autobuild (>=2020.9.1,<2021.0.0)", "sphinx-rtd-theme (>=0.5.0,<0.6.0)", "Sphinx (>=3.3,<4.0)"]
+docs = ["Sphinx (>=3.3,<4.0)", "sphinx-rtd-theme (>=0.5.0,<0.6.0)", "sphinx-autobuild (>=2020.9.1,<2021.0.0)", "sphinx-copybutton (>=0.3.1,<0.4.0)", "sphinx-autodoc-typehints (>=1.11.1,<2.0.0)"]
 
 [[package]]
 name = "regex"
@@ -2052,8 +2052,8 @@ idna = ">=2.5,<4"
 urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "rich"
@@ -2080,9 +2080,9 @@ optional = true
 python-versions = ">=3.6"
 
 [package.extras]
+all = ["pytest", "pytest-cov", "numpy"]
+test = ["pytest", "pytest-cov"]
 vectorized = ["numpy"]
-test = ["pytest-cov", "pytest"]
-all = ["numpy", "pytest-cov", "pytest"]
 
 [[package]]
 name = "six"
@@ -2293,7 +2293,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-test = ["pytest", "pre-commit"]
+test = ["pre-commit", "pytest"]
 
 [[package]]
 name = "typing-extensions"
@@ -2325,8 +2325,8 @@ pytz-deprecation-shim = "*"
 tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
-test = ["pytest (>=4.3)", "pytest-mock (>=3.3)"]
-devenv = ["zest.releaser", "pytest-cov", "pyroma", "black"]
+devenv = ["black", "pyroma", "pytest-cov", "zest.releaser"]
+test = ["pytest-mock (>=3.3)", "pytest (>=4.3)"]
 
 [[package]]
 name = "urllib3"
@@ -2388,8 +2388,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-testing = ["pytest-mypy (>=0.9.1)", "pytest-black (>=0.3.7)", "func-timeout", "jaraco.itertools", "pytest-enabler (>=1.3)", "pytest-cov", "pytest-flake8", "pytest-checkdocs (>=2.4)", "pytest (>=6)"]
-docs = ["jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "jaraco.packaging (>=9)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
 all = ["clickhouse-cityhash", "clickhouse-driver", "dask", "datafusion", "duckdb", "duckdb-engine", "fsspec", "GeoAlchemy2", "geopandas", "graphviz", "impyla", "lz4", "psycopg2", "pyarrow", "pymysql", "pyspark", "requests", "Shapely", "sqlalchemy", "sqlglot"]


### PR DESCRIPTION
The accumulated technical dept in ibis's internals caused several bugs and slow development velocity making it harder to implement new features and blocking more advanced query optimizations. 

Currently the ibis internal representation is built up using operation nodes and expressions where the operations hold data and expressions provide user facing API by wrapping operations. 
Historically this distinction wasn't that clear though, since expressions also held name and datatype information, but we managed to remove all data  members by introducing an Alias node in earlier refactors (#3276). 

From the development perspective of `ibis's internals` the bipartie representation has disadvantages:
- since an `Expression` wraps an `Operation` but nothing else, it is a redundant abstraction
- confusing when to work with `Expression`s and/or with `Operation`s
- requires more complex utilities, hard or rather impossible to generalize `ir` manupulation due to special branches introduced earlier into the codebase

The objective of this refactor is to achieve a simpler, stricter and more generic internal representation by removing intermediate Expression objects so there is a single `Expression` object wrapping an `Operation` tree only to provide 
the user-facing API but all the internals work with homogeneous `Operation` trees. 

Simbolically turn `Expr(Op(Expr(Op(Expr(Op)))))` into `Expr(Op(Op(Op)))`

