### PR TITLE
fix(pyspark): make sure `ibis.connect` works with pyspark

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -706,7 +706,7 @@ def _get_backend_names() -> frozenset[str]:
 
 
 _PATTERN = "|".join(
-    sorted(_get_backend_names().difference(("duckdb", "sqlite")))
+    sorted(_get_backend_names().difference(("duckdb", "sqlite", "pyspark")))
 )
 
 
@@ -726,7 +726,10 @@ def _(url: str, *, backend: str, **kwargs: Any) -> BaseBackend:
     return instance._from_url(url)
 
 
-@_connect.register(r"(?P<backend>duckdb|sqlite)://(?P<path>.*)", priority=12)
+@_connect.register(
+    r"(?P<backend>duckdb|sqlite|pyspark)://(?P<path>.*)",
+    priority=12,
+)
 def _(_: str, *, backend: str, path: str, **kwargs: Any) -> BaseBackend:
     """Connect to given `backend` with `path`.
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -432,6 +432,11 @@ def test_unsigned_integer_type(alchemy_con, coltype):
             marks=mark.pyspark,
             id="pyspark_with_warehouse",
         ),
+        param(
+            "pyspark://my-warehouse-dir",
+            marks=mark.pyspark,
+            id="pyspark_with_warehouse_no_params",
+        ),
     ],
 )
 def test_connect_url(url):


### PR DESCRIPTION
Fixes a bug so that ibis.connect can be used with pyspark.