### PR TITLE
fix(backend): ensure that limit chains respect inner limits

### DIFF
--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -330,11 +330,9 @@ class AlchemySelect(Select):
         if self.limit is None:
             return fragment
 
-        n, offset = self.limit['n'], self.limit['offset']
-        fragment = fragment.limit(n)
-        if offset is not None and offset != 0:
+        fragment = fragment.limit(self.limit.n)
+        if offset := self.limit.offset:
             fragment = fragment.offset(offset)
-
         return fragment
 
 

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -50,8 +50,8 @@ class ClickhouseSelect(Select):
 
         buf = StringIO()
 
-        n, offset = self.limit['n'], self.limit['offset']
-        if offset is not None and offset != 0:
+        n = self.limit.n
+        if offset := self.limit.offset:
             buf.write(f'LIMIT {offset}, {n}')
         else:
             buf.write(f'LIMIT {n}')

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -290,7 +290,7 @@ def execute_cast_series_date(op, data, type, **kwargs):
 @execute_node.register(ops.Limit, dd.DataFrame, integer_types, integer_types)
 def execute_limit_frame(op, data, nrows, offset, **kwargs):
     # NOTE: Dask Dataframes do not support iloc row based indexing
-    return data.loc[offset : offset + nrows]
+    return data.loc[offset : (offset + nrows) - 1]
 
 
 @execute_node.register(ops.Not, (dd.core.Scalar, dd.Series))

--- a/ibis/tests/sql/test_select_sql.py
+++ b/ibis/tests/sql/test_select_sql.py
@@ -1335,7 +1335,7 @@ def test_multiple_limits(functional_alltypes):
     expr = t.limit(20).limit(10)
     stmt = get_query(expr)
 
-    assert stmt.limit['n'] == 10
+    assert stmt.limit.n == 10
 
 
 def test_self_join_filter_analysis_bug(filter_self_join_analysis_bug):


### PR DESCRIPTION
Our current behavior with chained limits is questionable. IMO it qualifies as a
bug even though it appears to have been intentional (see the deleted
comment):

```python
t.limit(5).limit(10)
```

is currently equivalent to

```python
t.limit(10)
```

and

```python
t.limit(10).limit(5)
```

is currently equivalent to

```python
t.limit(5)
```

Both of these behaviors are inconsistent with every other relational operation
we implement in that these chains-of-limits are sensitive to the fact that
there's a specific relational operation underneath. Instead, limits should be
"dumb" and just do whatever the user asks for.

Yes, it may be ultimately pointless to chain a limit in some cases, but we
should strive hard to not second guess the user.

This PR removes the special casing of chained limits.
