### PR TITLE
feat: support `sort_by(random())`

### DIFF
--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -143,7 +143,7 @@ def _can_lower_sort_column(table_set, expr):
     # aggregation so they appear in same query. It's generally for
     # cosmetics and doesn't really affect query semantics.
     bases = {op: op.to_expr() for op in expr.op().root_tables()}
-    if len(bases) > 1:
+    if len(bases) != 1:
         return False
 
     base = list(bases.values())[0]

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -2134,3 +2134,8 @@ def compile_where(t, expr, scope, timecontext, **kwargs):
         t.translate(op.bool_expr, scope, timecontext, **kwargs),
         t.translate(op.true_expr, scope, timecontext, **kwargs),
     ).otherwise(t.translate(op.false_null_expr, scope, timecontext, **kwargs))
+
+
+@compiles(ops.RandomScalar)
+def compile_random(*args, **kwargs):
+    return F.rand()

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -465,6 +465,21 @@ def test_sort_by(backend, alltypes, df, key, df_kwargs):
     backend.assert_frame_equal(result, expected)
 
 
+@pytest.mark.notimpl(["dask", "datafusion", "impala", "pandas"])
+@pytest.mark.notyet(
+    ["clickhouse"],
+    reason="clickhouse doesn't have a [0.0, 1.0) random implementation",
+)
+def test_sort_by_random(alltypes):
+    expr = alltypes.filter(_.id < 100).sort_by(ibis.random()).limit(5)
+    r1 = expr.execute()
+    r2 = expr.execute()
+    assert len(r1) == 5
+    assert len(r2) == 5
+    # Ensure that multiple executions returns different results
+    assert not r1.equals(r2)
+
+
 def check_table_info(buf, schema):
     info_str = buf.getvalue()
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -431,6 +431,40 @@ def test_select_sort_sort(alltypes):
     query = query.sort_by(query.year).sort_by(query.bool_col)
 
 
+@pytest.mark.parametrize(
+    "key, df_kwargs",
+    [
+        param("id", {"by": "id"}),
+        param(_.id, {"by": "id"}),
+        param(lambda _: _.id, {"by": "id"}),
+        param(
+            ("id", False),
+            {"by": "id", "ascending": False},
+            marks=pytest.mark.notimpl(["dask"]),
+        ),
+        param(
+            ibis.desc("id"),
+            {"by": "id", "ascending": False},
+            marks=pytest.mark.notimpl(["dask"]),
+        ),
+        param(
+            ["id", "int_col"],
+            {"by": ["id", "int_col"]},
+            marks=pytest.mark.notimpl(["dask"]),
+        ),
+        param(
+            ["id", ("int_col", False)],
+            {"by": ["id", "int_col"], "ascending": [True, False]},
+            marks=pytest.mark.notimpl(["dask"]),
+        ),
+    ],
+)
+def test_sort_by(backend, alltypes, df, key, df_kwargs):
+    result = alltypes.filter(_.id < 100).sort_by(key).execute()
+    expected = df.loc[df.id < 100].sort_values(**df_kwargs)
+    backend.assert_frame_equal(result, expected)
+
+
 def check_table_info(buf, schema):
     info_str = buf.getvalue()
 

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -41,7 +41,7 @@ class TableNode(Node):
             expr,
             [],
             sort_keys=_maybe_convert_sort_keys(
-                [self.to_expr(), expr],
+                [expr],
                 sort_exprs,
             ),
         )

--- a/ibis/expr/operations/sortkeys.py
+++ b/ibis/expr/operations/sortkeys.py
@@ -23,6 +23,10 @@ def _to_sort_key(key, *, table=None):
     else:
         sort_order = True
 
+    # # HACK: support `ORDER BY 1` / `ORDER BY 42.42`
+    # if isinstance(key, (int, float)):
+    # key = ibis.literal(key)
+
     if not isinstance(key, ir.Expr):
         if table is None:
             raise com.IbisTypeError("cannot resolve key with table=None")
@@ -43,8 +47,7 @@ def _maybe_convert_sort_keys(tables, exprs):
     exprs = util.promote_list(exprs)
     keys = exprs[:]
     for i, key in enumerate(exprs):
-        step = -1 if isinstance(key, (str, DeferredSortKey)) else 1
-        for table in tables[::step]:
+        for table in reversed(tables):
             try:
                 sort_key = _to_sort_key(key, table=table)
             except Exception:

--- a/ibis/expr/operations/sortkeys.py
+++ b/ibis/expr/operations/sortkeys.py
@@ -23,10 +23,6 @@ def _to_sort_key(key, *, table=None):
     else:
         sort_order = True
 
-    # # HACK: support `ORDER BY 1` / `ORDER BY 42.42`
-    # if isinstance(key, (int, float)):
-    # key = ibis.literal(key)
-
     if not isinstance(key, ir.Expr):
         if table is None:
             raise com.IbisTypeError("cannot resolve key with table=None")
@@ -60,7 +56,7 @@ def _maybe_convert_sort_keys(tables, exprs):
 
 @public
 class SortKey(Node):
-    expr = rlz.column(rlz.any)
+    expr = rlz.any
     ascending = rlz.optional(
         rlz.map_to(
             {

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -439,6 +439,11 @@ def test_aggregate(con, star1, sa_star1, expr_fn, expected_fn):
             lambda b: sa.select([b]).order_by(b.c.c, b.c.f.desc()),
             id="sort_by_mixed",
         ),
+        pytest.param(
+            lambda t: t.sort_by(ibis.random()),
+            lambda b: sa.select([b]).order_by(sa.func.random()),
+            id="sort_by_random",
+        ),
     ],
 )
 def test_sort_by(con, star1, sa_star1, expr_fn, expected_fn):


### PR DESCRIPTION
This:

- Fixes several bugs in `sort_by` mostly around handling of different ways of representing ascending/descending sort orders
- Expands the test suite to better test `sort_by`
- Loosens the restrictions on sort keys to support `sort_by(random())` for (inefficiently) selecting out a random element from a table.