### PR TITLE
ci: remove pep8speaks

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,9 +1,0 @@
-# File : .pep8speaks.yml
-
-scanner:
-  diff_only: True # If True, errors caused by only the patch are shown
-  linter: flake8
-
-flake8:
-  exclude:
-    - setup.py


### PR DESCRIPTION
`pep8speaks` doesn't understand some modern python constructs like `:=`, causing it to unnecessarily flag some PRs. Since we don't let it actually fail PRs or fix issues, it's just a noisy bot. Lets remove it and rely on the precommit linters instead.