### PR TITLE
fix(api): make sure column names that are already inferred are not overwritten

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -594,6 +594,11 @@ def test_deprecated_path_argument(backend, tmp_path):
             ),
             id="dataframe",
         ),
+        param(
+            ibis.memtable([dict(a=1), dict(a=2)]),
+            pd.DataFrame({"a": [1, 2]}),
+            id="list_of_dicts",
+        ),
     ],
 )
 @pytest.mark.notyet(

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -431,8 +431,10 @@ def memtable(
             "pass one or the other but not both"
         )
     df = pd.DataFrame(data, columns=columns)
-    if isinstance(data, (list, tuple)) and columns is None:
-        df = df.rename(columns={col: f"col{col:d}" for col in df.columns})
+    if df.columns.inferred_type != "string":
+        df = df.rename(
+            columns={col: f"col{i:d}" for i, col in enumerate(df.columns)}
+        )
     return memtable(df, name=name, schema=schema)
 
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -403,15 +403,21 @@ def memtable(
     >>> import ibis
     >>> t = ibis.memtable([{"a": 1}, {"a": 2}])
     >>> t
+    PandasInMemoryTable
+      data:
+        DataFrameProxy:
+             a
+          0  1
+          1  2
 
     >>> t = ibis.memtable([{"a": 1, "b": "foo"}, {"a": 2, "b": "baz"}])
     >>> t
     PandasInMemoryTable
       data:
-        ((1, 'foo'), (2, 'baz'))
-      schema:
-        a int8
-        b string
+        DataFrameProxy:
+             a    b
+          0  1  foo
+          1  2  baz
 
     Create a table literal without column names embedded in the data and pass
     `columns`
@@ -420,10 +426,22 @@ def memtable(
     >>> t
     PandasInMemoryTable
       data:
-        ((1, 'foo'), (2, 'baz'))
-      schema:
-        a int8
-        b string
+        DataFrameProxy:
+             a    b
+          0  1  foo
+          1  2  baz
+
+    Create a table literal without column names embedded in the data. Ibis
+    generates column names if none are provided.
+
+    >>> t = ibis.memtable([(1, "foo"), (2, "baz")])
+    >>> t
+    PandasInMemoryTable
+      data:
+        DataFrameProxy:
+             col0 col1
+          0     1  foo
+          1     2  baz
     """
     if columns is not None and schema is not None:
         raise NotImplementedError(

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -669,23 +669,6 @@ def _fmt_value_table_node(
     return f"{aliases[op.table.op()]}"
 
 
-_JOIN_SYMS = {
-    ops.InnerJoin: "⋈",
-    ops.LeftJoin: "⟕",
-    ops.RightJoin: "⟖",
-    ops.OuterJoin: "⟗",
-    ops.CrossJoin: "×",
-}
-
-
-@fmt_value.register
-def _fmt_value_join(op: ops.Join, *, aliases: Aliases, **_: Any) -> str:
-    """Format a join as value."""
-    left = aliases[op.left.op()]
-    right = aliases[op.right.op()]
-    return f"{left} {_JOIN_SYMS[type(op)]} {right}"
-
-
 @fmt_value.register
 def _fmt_value_string_sql_like(
     op: ops.StringSQLLike, *, aliases: Aliases


### PR DESCRIPTION
This PR fixes passing in a list of dicts to `ibis.memtable`

Previously we assumed that if `columns` was `None` that meant that the columns
couldn't have been inferred, but the DataFrame constructor handles this for us.
After this change we only generated column names if the inferred column index
type isn't `string`.

Additionally some code to format joins using their mathematical symbols snuck
in, so I removed that here. Thanks for finding this @jcrist!
