### PR TITLE
fix: support filters on InMemoryTable exprs

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -616,6 +616,24 @@ def test_in_memory_table(backend, con, expr, expected):
     backend.assert_frame_equal(result, expected)
 
 
+@pytest.mark.notyet(
+    ["clickhouse"],
+    reason="ClickHouse doesn't support a VALUES construct",
+)
+@pytest.mark.notyet(
+    ["mysql", "sqlite"],
+    reason="SQLAlchemy generates incorrect code for `VALUES` projections.",
+    raises=(sa.exc.ProgrammingError, sa.exc.OperationalError),
+)
+@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+def test_filter_memory_table(backend, con):
+    t = ibis.memtable([(1, 2), (3, 4), (5, 6)], columns=["x", "y"])
+    expr = t.filter(t.x > 1)
+    expected = pd.DataFrame({"x": [3, 5], "y": [4, 6]})
+    result = con.execute(expr)
+    backend.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "t",
     [

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -107,6 +107,9 @@ class InMemoryTable(TableNode, sch.HasSchema):
     def data(self):
         """Return the data of an in-memory table."""
 
+    def blocks(self):
+        return True
+
 
 def _make_distinct_join_predicates(left, right, predicates):
     import ibis.expr.analysis as L

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1544,3 +1544,10 @@ def test_python_table_ambiguous():
             schema=ibis.schema(dict(a="int8")),
             columns=["a"],
         )
+
+
+def test_memtable_filter():
+    # Mostly just a smoketest, this used to error on construction
+    t = ibis.memtable([(1, 2), (3, 4), (5, 6)], columns=["x", "y"])
+    expr = t.filter(t.x > 1)
+    assert expr.columns == ["x", "y"]


### PR DESCRIPTION
Allows calling `filter` on `memtable` expressions. Wasn't sure how best to test this, may be overkill here. The bug was just a missing `blocks` implementation.