### PR TITLE
fix: fix pandas & dask where implementations

### DIFF
--- a/ibis/backends/dask/execution/indexing.py
+++ b/ibis/backends/dask/execution/indexing.py
@@ -21,7 +21,12 @@ from ibis.backends.pandas.execution.generic import pd_where
     ops.Where, (dd.Series, *boolean_types), type(None), type(None)
 )
 def execute_node_where(op, cond, true, false, **kwargs):
-    return dd.map_partitions(pd_where, cond, true, false)
+    if any(
+        isinstance(x, (dd.Series, dd.core.Scalar)) for x in (cond, true, false)
+    ):
+        return dd.map_partitions(pd_where, cond, true, false)
+    # All are immediate scalars, handle locally
+    return true if cond else false
 
 
 # For true/false as scalars, we only support identical type pairs + None to

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -743,14 +743,26 @@ def test_left_binary_op_gb(t, df, op, argfunc):
     tm.assert_frame_equal(result.compute(), expected.compute())
 
 
-def test_where_series(t, df):
+@pytest.mark.parametrize(
+    "left_f", [lambda e: e - 1, lambda e: 0.0, lambda e: None]
+)
+@pytest.mark.parametrize(
+    "right_f", [lambda e: e + 1, lambda e: 1.0, lambda e: None]
+)
+def test_where_series(t, df, left_f, right_f):
     col_expr = t['plain_int64']
-    result = ibis.where(col_expr > col_expr.mean(), col_expr, 0.0).compile()
+    result = ibis.where(
+        col_expr > col_expr.mean(), left_f(col_expr), right_f(col_expr)
+    ).execute()
 
-    ser = df['plain_int64']
-    expected = ser.where(ser > ser.mean(), other=0.0)
+    ser = df['plain_int64'].compute()
+    cond = ser > ser.mean()
+    left = left_f(ser)
+    if not isinstance(left, pd.Series):
+        left = pd.Series(np.repeat(left, len(cond)), name=cond.name)
+    expected = left.where(cond, right_f(ser))
 
-    tm.assert_series_equal(result.compute(), expected.compute())
+    tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -1048,7 +1048,9 @@ def pd_where(cond, true, false):
     """Execute `where` following ibis's intended semantics"""
     if isinstance(cond, pd.Series):
         if not isinstance(true, pd.Series):
-            true = pd.Series(np.repeat(true, len(cond)), name=cond.name)
+            true = pd.Series(
+                np.repeat(true, len(cond)), name=cond.name, index=cond.index
+            )
         return true.where(cond, other=false)
     if cond:
         if isinstance(false, pd.Series) and not isinstance(true, pd.Series):

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -623,7 +623,6 @@ def test_zeroifnull_column(backend, alltypes, df):
 
 
 @pytest.mark.notimpl(["datafusion"])
-@pytest.mark.broken(["dask"], reason="dask selection with ops.Where is broken")
 def test_where_select(backend, alltypes, df):
     table = alltypes
     table = table.select(


### PR DESCRIPTION
This fixes a few issues with the pandas and dask `where` implementations:

- Neither implementation supported scalars for the `true` case, only the `false` case. This was most likely an oversight made difficult to see due to multiple functions being used to handle each case. We now use a single function for all cases, making the logic easier to understand.
- Neither implementation supported `None` or `str` values for `true` or `false`
- The dask implementation was _highly_ inefficient, resulting in unnecessary computation. This is now handled through dask-native mechanisms, resulting in major speedups.

