### PR TITLE
fix(backends): ensure select after filter works

### DIFF
--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -167,27 +167,27 @@ def execute_selection_dataframe(
 ):
     result = data
 
-    if selections:
-        # if we are just performing select operations we can do a direct
-        # selection
-        if all(isinstance(s.op(), ops.TableColumn) for s in selections):
-            result = build_df_from_selection(selections, data, op.table.op())
-        else:
-            result = build_df_from_projection(
-                selections,
-                op,
-                data,
-                scope=scope,
-                timecontext=timecontext,
-                **kwargs,
-            )
-
     if predicates:
         predicates = _compute_predicates(
             op.table.op(), predicates, data, scope, timecontext, **kwargs
         )
         predicate = functools.reduce(operator.and_, predicates)
         result = result.loc[predicate]
+
+    if selections:
+        # if we are just performing select operations we can do a direct
+        # selection
+        if all(isinstance(s.op(), ops.TableColumn) for s in selections):
+            result = build_df_from_selection(selections, result, op.table.op())
+        else:
+            result = build_df_from_projection(
+                selections,
+                op,
+                result,
+                scope=scope,
+                timecontext=timecontext,
+                **kwargs,
+            )
 
     if sort_keys:
         if len(sort_keys) > 1:

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -969,7 +969,10 @@ def execute_series_notnnull(op, data, **kwargs):
 
 @execute_node.register(ops.IsNan, (pd.Series, floating_types))
 def execute_isnan(op, data, **kwargs):
-    return np.isnan(data)
+    try:
+        return np.isnan(data)
+    except (TypeError, ValueError):
+        return data != data
 
 
 @execute_node.register(ops.IsInf, (pd.Series, floating_types))

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -972,6 +972,9 @@ def execute_isnan(op, data, **kwargs):
     try:
         return np.isnan(data)
     except (TypeError, ValueError):
+        # if `data` contains `None` np.isnan will complain
+        # so we take advantage of NaN not equaling itself
+        # to do the correct thing
         return data != data
 
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -662,3 +662,22 @@ def test_where_column(backend, alltypes, df):
     )
 
     backend.assert_series_equal(result, expected)
+
+
+def test_select_filter(backend, alltypes, df):
+    t = alltypes
+
+    expr = t.select("int_col").filter(t.string_col == "4")
+    result = expr.execute()
+
+    expected = df.loc[df.string_col == "4", ["int_col"]].reset_index(drop=True)
+    backend.assert_frame_equal(result, expected)
+
+
+def test_select_filter_select(backend, alltypes, df):
+    t = alltypes
+    expr = t.select("int_col").filter(t.string_col == "4").int_col
+    result = expr.execute().rename("int_col")
+
+    expected = df.loc[df.string_col == "4", "int_col"].reset_index(drop=True)
+    backend.assert_series_equal(result, expected)

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -366,7 +366,12 @@ def _filter_selection(expr, predicates):
             # produce NULLs
             #
             # the getattr shenanigans is to handle Alias
-            isinstance(getattr(sel.op(), "arg", sel).op(), ops.Unnest)
+            isinstance(
+                child_op.arg.op()
+                if isinstance(child_op := sel.op(), ops.Alias)
+                else child_op,
+                ops.Unnest,
+            )
             for sel in op.selections
         ):
             result = ops.Selection(

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -284,7 +284,7 @@ def test_select_filter_mutate_fusion():
     #
     # eventually we will bring this back, but we're trading off the ability
     # to remove materialize for some performance in the short term
-    assert len(first_selection.op().selections) == 0
+    assert len(first_selection.op().selections) == 1
     assert len(first_selection.op().predicates) == 1
 
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -229,19 +229,15 @@ WITH t0 AS (
   FROM my_table
 ),
 t1 AS (
-  SELECT `a`, `b2`
+  SELECT t0.`a`, t0.`b2`
   FROM t0
+  WHERE t0.`a` < 100
 )
-SELECT t2.*
-FROM (
-  SELECT t1.*
+SELECT t1.*
+FROM t1
+WHERE t1.`a` = (
+  SELECT max(`a`) AS `blah`
   FROM t1
-  WHERE t1.`a` < 100
-) t2
-WHERE t2.`a` = (
-  SELECT max(t1.`a`) AS `blah`
-  FROM t1
-  WHERE t1.`a` < 100
 )"""
     assert result == expected
 
@@ -259,19 +255,15 @@ WITH t0 AS (
   FROM my_table
 ),
 t1 AS (
-  SELECT `a`, `b2`
+  SELECT t0.`a`, t0.`b2`
   FROM t0
+  WHERE t0.`a` < 100
 )
-SELECT t2.*
-FROM (
-  SELECT t1.*
+SELECT t1.*
+FROM t1
+WHERE t1.`a` = (
+  SELECT max(`a`) AS `blah`
   FROM t1
-  WHERE t1.`a` < 100
-) t2
-WHERE t2.`a` = (
-  SELECT max(t1.`a`) AS `blah`
-  FROM t1
-  WHERE t1.`a` < 100
 )"""
     assert result == expected
 
@@ -358,8 +350,8 @@ FROM (
   FROM (
     SELECT `float_col`, `timestamp_col`, `int_col`, `string_col`
     FROM alltypes
+    WHERE `timestamp_col` < '20140101'
   ) t1
-  WHERE `timestamp_col` < '20140101'
   GROUP BY 1
 ) t0"""
     assert result == expected

--- a/ibis/tests/sql/test_select_sql.py
+++ b/ibis/tests/sql/test_select_sql.py
@@ -1488,7 +1488,7 @@ def test_filter_predicates():
         expr = projected
 
     expected = """\
-SELECT t0.*
+SELECT *
 FROM (
   SELECT *
   FROM (
@@ -1496,8 +1496,9 @@ FROM (
     FROM t
     WHERE (lower(`color`) LIKE '%de%') AND
           (locate('de', lower(`color`)) - 1 >= 0)
-  ) t2
-) t0
-WHERE regexp_like(lower(t0.`color`), '.*ge.*')"""
+  ) t1
+  WHERE regexp_like(lower(`color`), '.*ge.*')
+) t0"""
 
-    assert Compiler.to_sql(expr) == expected
+    result = Compiler.to_sql(expr)
+    assert result == expected


### PR DESCRIPTION
This PR addresses an issue where filtering after a projection
is incorrectly fused.

Long term, we probably don't want to keep this behavior around, and instead
limit the API to allow only lambdas, strings and deferred instances to be
passed to `select` and `filter`.

However, this behavior is defined in the current version of ibis and therefore
should be considered a bug.

The fix it to try to eagerly simplify predicates by replacing their child table
with the `Selection`'s child, and bail out if anything goes wrong during the
substitution.

If the substitution succeeds the following criteria must be true for fusion to work:

1. The simplified predicates must all derive from the incoming `Selection`'s child table.
1. None of the selection columns can be an `Unnest`. This is because `Unnest`
   can generate `NULL`s, which results in different semantics if a predicate is
   pushed to operate on the underlying unnest's column instead of the unnested
   column. I think Unnest is special here, but it's possible there are other cases.

~Finally, there's one Dask test failing that I'm still trying to debug.~ This is fixed. It's possible the fix allows dask to use less memory since projections no longer need to scan data that'll potentially be thrown away immediately.

Fixes #4428.
