### PR TITLE
feat(clickhouse): enable support for working window functions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:22-alpine
+    image: clickhouse/clickhouse-server:22.6.6.16-alpine
     ports:
       - 8123:8123
       - 9000:9000

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -692,6 +692,13 @@ def _nth_value(translator, expr):
     return f"nth_value({arg}, ({nth}) + 1)"
 
 
+def _repeat(translator, expr):
+    op = expr.op()
+    arg = translator.translate(op.arg)
+    times = translator.translate(op.times)
+    return f"repeat({arg}, CAST({times} AS UInt64))"
+
+
 # TODO: clickhouse uses different string functions
 #       for ascii and utf-8 encodings,
 
@@ -789,7 +796,7 @@ operation_registry = {
     ops.LStrip: _unary('trimLeft'),
     ops.RStrip: _unary('trimRight'),
     ops.Strip: _unary('trimBoth'),
-    ops.Repeat: _fixed_arity("repeat", 2),
+    ops.Repeat: _repeat,
     ops.StringConcat: _string_concat,
     ops.RegexSearch: _fixed_arity('match', 2),
     ops.RegexExtract: _regex_extract,

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -64,13 +64,19 @@ def calc_zscore(s):
                 )
             ).reset_index(drop=True, level=[0]),
             id='percent_rank',
-            marks=pytest.mark.notyet(["clickhouse"]),
+            marks=pytest.mark.notyet(
+                ["clickhouse"],
+                reason="clickhouse doesn't implement percent_rank",
+            ),
         ),
         param(
             lambda t, win: t.id.cume_dist().over(win),
             lambda t: t.id.rank(method='min') / t.id.transform(len),
             id='cume_dist',
-            marks=pytest.mark.notimpl(["clickhouse", "pyspark"]),
+            marks=[
+                pytest.mark.notimpl(["pyspark"]),
+                pytest.mark.notyet(["clickhouse"]),
+            ],
         ),
         param(
             lambda t, win: t.float_col.ntile(buckets=7).over(win),
@@ -667,6 +673,9 @@ def test_grouped_bounded_range_window(backend, alltypes, df):
 
 
 @pytest.mark.notimpl(["clickhouse", "dask", "datafusion", "pyspark"])
+@pytest.mark.notyet(
+    ["clickhouse"], reason="clickhouse doesn't implement percent_rank"
+)
 def test_percent_rank_whole_table_no_order_by(backend, alltypes, df):
     expr = alltypes.mutate(val=lambda t: t.id.percent_rank())
 


### PR DESCRIPTION
This PR enables support for window functions that behave
out of the box like the rest of the SQL world does.

Issues:

1. A few window functions appear broken entirely when an `ORDER BY` statement
   is added. 
1. ~Some "working" functions cause the resulting query to return zero rows when the window function expression
   is part of another expression, e.g., `rank() over () - 1`.~ Fixed upstream already, waiting on release.
1. Some window functions just don't exist upstream, `percent_rank` and `cume_dist`

Otherwise, the basic aggregates work as expected.
