### PR TITLE
fix(duckdb): use specialized `array_length` implementation

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -231,6 +231,7 @@ operation_registry.update(
         ops.StructColumn: _struct_column,
         ops.ArgMin: reduction(sa.func.min_by),
         ops.ArgMax: reduction(sa.func.max_by),
+        ops.ArrayLength: fixed_arity(sa.func.array_length, 1),
     }
 )
 

--- a/ibis/backends/duckdb/tests/test_compiler.py
+++ b/ibis/backends/duckdb/tests/test_compiler.py
@@ -1,0 +1,24 @@
+import pytest
+
+import ibis
+from ibis.backends.duckdb.compiler import DuckDBSQLCompiler
+
+compiler = DuckDBSQLCompiler()
+
+QUERY = """SELECT array_length(CAST(list_value{} AS ARRAY)) AS n"""
+
+
+@pytest.mark.parametrize(
+    "array",
+    [
+        range(10),
+        range(5),
+        [-1, 0, 1],
+    ],
+)
+def test_compiler_array_length(array):
+    t = ibis.array(array).length().name("n")
+    result = str(
+        compiler.to_sql(t).compile(compile_kwargs={"literal_binds": True})
+    )
+    assert result == QUERY.format(tuple(array))


### PR DESCRIPTION
and avoid the extraneous arguments that are required for postgres arrays
that aren't required/supported in duckdb.

Fixes #4438