### PR TITLE
feat: implement dropna for SQL backends

### DIFF
--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -117,7 +117,10 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
             execute_difference_dataframe_dataframe,
         )
     ],
-    ops.DropNa: [((dd.DataFrame, tuple), execute_node_dropna_dataframe)],
+    ops.DropNa: [
+        ((dd.DataFrame, tuple), execute_node_dropna_dataframe),
+        ((dd.DataFrame, type(None)), execute_node_dropna_dataframe),
+    ],
     ops.FillNa: [
         ((dd.DataFrame, simple_types), execute_node_fillna_dataframe_scalar),
         ((dd.DataFrame,), execute_node_fillna_dataframe_dict),

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -1144,9 +1144,11 @@ def execute_node_log_number_number(op, value, base, **kwargs):
     return math.log(value, base)
 
 
+@execute_node.register(ops.DropNa, pd.DataFrame, type(None))
 @execute_node.register(ops.DropNa, pd.DataFrame, tuple)
 def execute_node_dropna_dataframe(op, df, subset, **kwargs):
-    subset = [col.get_name() for col in subset] if subset else None
+    if subset is not None:
+        subset = [col.get_name() for col in subset]
     return df.dropna(how=op.how, subset=subset)
 
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1986,7 +1986,9 @@ def compile_not_null(t, expr, scope, timecontext, **kwargs):
 def compile_dropna_table(t, expr, scope, timecontext, **kwargs):
     op = expr.op()
     table = t.translate(op.table, scope, timecontext, **kwargs)
-    subset = [col.get_name() for col in op.subset] if op.subset else None
+    subset = op.subset
+    if subset is not None:
+        subset = [col.get_name() for col in subset]
     return table.dropna(how=op.how, subset=subset)
 
 

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -794,7 +794,7 @@ class DropNa(TableNode, sch.HasSchema):
 
     table = rlz.table
     how = rlz.isin({'any', 'all'})
-    subset = rlz.optional(rlz.tuple_of(rlz.column_from("table")), default=())
+    subset = rlz.optional(rlz.tuple_of(rlz.column_from("table")), default=None)
 
     @property
     def schema(self):

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -874,9 +874,8 @@ class Table(Expr):
         """
         from ibis.expr import operations as ops
 
-        if subset is None:
-            subset = []
-        subset = util.promote_list(subset)
+        if subset is not None:
+            subset = util.promote_list(subset)
         return ops.DropNa(self, how, subset).to_expr()
 
     def fillna(


### PR DESCRIPTION
Also fixes a bug where `table.dropna(subset=())` would be treated the same as `table.dropna(subset=None)` for some backends.

Fixes #3110.