### PR TITLE
feat: add to_pyarrow and to_pyarrow_batches

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -231,6 +231,7 @@ class ResultHandler:
             # ColumnExpr has no schema method, define single-column schema
             return sch.schema([(expr.get_name(), expr.type())])
 
+    @util.experimental
     def to_pyarrow(
         self,
         expr: ir.Expr,
@@ -239,6 +240,26 @@ class ResultHandler:
         limit: int | str | None = None,
         **kwargs: Any,
     ) -> pa.Table:
+        """Execute expression and return results in as a pyarrow table.
+
+        This method is eager and will execute the associated expression
+        immediately.
+
+        Parameters
+        ----------
+        expr
+            Ibis expression to export to pyarrow
+        params
+            Mapping of scalar parameter expressions to value.
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
+
+        Returns
+        -------
+        Table
+            A pyarrow table holding the results of the executed expression.
+        """
         pa = self._import_pyarrow()
         try:
             # Can't construct an array from record batches
@@ -269,6 +290,7 @@ class ResultHandler:
         else:
             raise ValueError
 
+    @util.experimental
     def to_pyarrow_batches(
         self,
         expr: ir.Expr,
@@ -278,6 +300,29 @@ class ResultHandler:
         chunk_size: int = 1_000_000,
         **kwargs: Any,
     ) -> pa.RecordBatchReader:
+        """Execute expression and return results in an iterator of pyarrow
+        record batches.
+
+        This method is eager and will execute the associated expression
+        immediately.
+
+        Parameters
+        ----------
+        expr
+            Ibis expression to export to pyarrow
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
+        params
+            Mapping of scalar parameter expressions to value.
+        chunk_size
+            Number of rows in each returned record batch.
+
+        Returns
+        -------
+        record_batches
+            An iterator of pyarrow record batches.
+        """
         raise NotImplementedError
 
 

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -245,7 +245,7 @@ class ResultHandler:
                 # flatten it
                 return table.columns[0].combine_chunks()
             elif isinstance(expr, ir.Scalar):
-                return table.columns[0].combine_chunks()[0]
+                return table.columns[0][0]
             else:
                 raise ValueError
         except ValueError:

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -171,11 +171,7 @@ class BaseSQLBackend(BaseBackend):
 
         from ibis.backends.pyarrow.datatypes import ibis_to_pyarrow_struct
 
-        if hasattr(expr, "schema"):
-            schema = expr.schema()
-        else:
-            # ColumnExpr has no schema method, define single-column schema
-            schema = sch.schema([(expr.get_name(), expr.type())])
+        schema = self._table_or_column_schema(expr)
 
         def _batches():
             for batch in self._cursor_batches(

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -158,6 +158,7 @@ class BaseSQLBackend(BaseBackend):
             while batch := cursor.fetchmany(chunk_size):
                 yield batch
 
+    @util.experimental
     def to_pyarrow_batches(
         self,
         expr: ir.Expr,
@@ -167,6 +168,29 @@ class BaseSQLBackend(BaseBackend):
         chunk_size: int = 1_000_000,
         **kwargs: Any,
     ) -> pa.RecordBatchReader:
+        """Execute expression and return results in an iterator of pyarrow
+        record batches.
+
+        This method is eager and will execute the associated expression
+        immediately.
+
+        Parameters
+        ----------
+        expr
+            Ibis expression to export to pyarrow
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
+        params
+            Mapping of scalar parameter expressions to value.
+        chunk_size
+            Number of rows in each returned record batch.
+
+        Returns
+        -------
+        record_batches
+            An iterator of pyarrow record batches.
+        """
         pa = self._import_pyarrow()
 
         from ibis.backends.pyarrow.datatypes import ibis_to_pyarrow_struct

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -215,7 +215,7 @@ class Backend(BaseBackend):
             return output.to_pandas()
         elif isinstance(expr, ir.Column):
             series = output.to_pandas()
-            series.name = "tmp"
+            series.name = expr.get_name()
             return series
         elif isinstance(expr, ir.Scalar):
             return output.as_py()

--- a/ibis/backends/datafusion/tests/test_udf.py
+++ b/ibis/backends/datafusion/tests/test_udf.py
@@ -37,7 +37,7 @@ def test_udf(alltypes):
 
 
 def test_multiple_argument_udf(alltypes):
-    expr = my_add(alltypes.smallint_col, alltypes.int_col)
+    expr = my_add(alltypes.smallint_col, alltypes.int_col).name("tmp")
     result = expr.execute()
 
     df = alltypes[['smallint_col', 'int_col']].execute()

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -260,7 +260,7 @@ class Backend(BaseAlchemyBackend):
             # flatten it
             return table.columns[0].combine_chunks()
         elif isinstance(expr, ir.Scalar):
-            return table.columns[0].combine_chunks()[0]
+            return table.columns[0][0]
         else:
             raise ValueError
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -258,7 +258,10 @@ class Backend(BaseAlchemyBackend):
         elif isinstance(expr, ir.Column):
             # Column will be a ChunkedArray, `combine_chunks` will
             # flatten it
-            return table.columns[0].combine_chunks()
+            if len(table.columns[0]):
+                return table.columns[0].combine_chunks()
+            else:
+                return pa.array(table.columns[0])
         elif isinstance(expr, ir.Scalar):
             return table.columns[0][0]
         else:

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -1,0 +1,195 @@
+import sys
+
+import pyarrow as pa
+import pytest
+from pytest import param
+
+# Adds `to_pyarrow` to created schema objects
+from ibis.backends.pyarrow.datatypes import sch  # noqa: F401
+
+
+class PackageDiscarder:
+    def __init__(self):
+        self.pkgnames = []
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.pkgnames:
+            raise ImportError()
+
+
+@pytest.fixture
+def no_pyarrow(backend):
+    _pyarrow = sys.modules.pop('pyarrow', None)
+    d = PackageDiscarder()
+    d.pkgnames.append('pyarrow')
+    sys.meta_path.insert(0, d)
+    yield
+    sys.meta_path.remove(d)
+    if _pyarrow is not None:
+        sys.modules["pyarrow"] = _pyarrow
+
+
+limit = [
+    param(
+        42,
+        id='limit',
+        marks=[
+            pytest.mark.notimpl(
+                [
+                    # limit not implemented for pandas backend execution
+                    "clickhouse",
+                    "dask",
+                    "datafusion",
+                    "impala",
+                    "pandas",
+                    "pyspark",
+                    "snowflake",
+                ]
+            ),
+        ],
+    ),
+]
+
+no_limit = [
+    param(
+        None,
+        id='nolimit',
+        marks=[
+            pytest.mark.notimpl(
+                [
+                    "clickhouse",
+                    "dask",
+                    "impala",
+                    "pyspark",
+                    "snowflake",
+                ]
+            ),
+        ],
+    ),
+]
+
+limit_no_limit = limit + no_limit
+
+
+@pytest.mark.notyet(
+    ["pandas"], reason="DataFrames have no option for outputting in batches"
+)
+@pytest.mark.parametrize("limit", limit_no_limit)
+def test_table_to_pyarrow_batches(limit, backend, awards_players):
+    batch_reader = awards_players.to_pyarrow_batches(limit=limit)
+    assert isinstance(batch_reader, pa.RecordBatchReader)
+    batch = batch_reader.read_next_batch()
+    assert isinstance(batch, pa.RecordBatch)
+    if limit is not None:
+        assert len(batch) == limit
+
+
+@pytest.mark.notyet(
+    ["pandas"], reason="DataFrames have no option for outputting in batches"
+)
+@pytest.mark.parametrize("limit", limit_no_limit)
+def test_column_to_pyarrow_batches(limit, backend, awards_players):
+    batch_reader = awards_players.awardID.to_pyarrow_batches(limit=limit)
+    assert isinstance(batch_reader, pa.RecordBatchReader)
+    batch = batch_reader.read_next_batch()
+    assert isinstance(batch, pa.RecordBatch)
+    if limit is not None:
+        assert len(batch) == limit
+
+
+@pytest.mark.parametrize("limit", limit_no_limit)
+def test_table_to_pyarrow_table(limit, backend, awards_players):
+    table = awards_players.to_pyarrow(limit=limit)
+    assert isinstance(table, pa.Table)
+    if limit is not None:
+        assert len(table) == limit
+
+
+@pytest.mark.parametrize("limit", limit_no_limit)
+def test_column_to_pyarrow_array(limit, backend, awards_players):
+    array = awards_players.awardID.to_pyarrow(limit=limit)
+    assert isinstance(array, pa.Array)
+    if limit is not None:
+        assert len(array) == limit
+
+
+@pytest.mark.notyet(
+    ["datafusion"], reason="DataFusion backend doesn't support sum"
+)
+@pytest.mark.parametrize("limit", no_limit)
+def test_scalar_to_pyarrow_scalar(limit, backend, awards_players):
+    scalar = awards_players.yearID.sum().to_pyarrow(limit=limit)
+    assert isinstance(scalar, pa.Scalar)
+
+
+@pytest.mark.notimpl(["dask", "clickhouse", "impala", "pyspark"])
+@pytest.mark.notyet(
+    ["datafusion"],
+    reason="""
+        fields' nullability from frame.schema() is not always consistent with
+        the first record batch's schema
+""",
+)
+def test_table_to_pyarrow_table_schema(backend, awards_players):
+    table = awards_players.to_pyarrow()
+    assert isinstance(table, pa.Table)
+    assert table.schema == awards_players.schema().to_pyarrow()
+
+
+@pytest.mark.notimpl(["dask", "clickhouse", "impala", "pyspark"])
+def test_column_to_pyarrow_table_schema(backend, awards_players):
+    expr = awards_players.awardID
+    array = expr.to_pyarrow()
+    assert isinstance(array, pa.Array)
+    assert array.type == expr.type().to_pyarrow()
+
+
+@pytest.mark.notimpl(
+    ["pandas", "dask", "clickhouse", "impala", "pyspark", "datafusion"]
+)
+def test_table_pyarrow_batch_chunk_size(backend, awards_players):
+    batch_reader = awards_players.to_pyarrow_batches(
+        limit=2050, chunk_size=2048
+    )
+    assert isinstance(batch_reader, pa.RecordBatchReader)
+    batch = batch_reader.read_next_batch()
+    assert isinstance(batch, pa.RecordBatch)
+    assert len(batch) == 2048
+
+
+@pytest.mark.notimpl(
+    ["pandas", "dask", "clickhouse", "impala", "pyspark", "datafusion"]
+)
+def test_column_pyarrow_batch_chunk_size(backend, awards_players):
+    batch_reader = awards_players.awardID.to_pyarrow_batches(
+        limit=2050, chunk_size=2048
+    )
+    assert isinstance(batch_reader, pa.RecordBatchReader)
+    batch = batch_reader.read_next_batch()
+    assert isinstance(batch, pa.RecordBatch)
+    assert len(batch) == 2048
+
+
+@pytest.mark.notimpl(
+    ["pandas", "dask", "clickhouse", "impala", "pyspark", "datafusion"]
+)
+@pytest.mark.broken(
+    ["sqlite"],
+    raises=pa.ArrowException,
+    reason="Test data has empty strings in columns typed as int64",
+)
+def test_to_pyarrow_batches_borked_types(backend, batting):
+    """This is a temporary test to expose an(other) issue with sqlite typing
+    shenanigans."""
+    batch_reader = batting.to_pyarrow_batches(limit=42)
+    assert isinstance(batch_reader, pa.RecordBatchReader)
+    batch = batch_reader.read_next_batch()
+    assert isinstance(batch, pa.RecordBatch)
+    assert len(batch) == 42
+
+
+def test_no_pyarrow_message(backend, awards_players, no_pyarrow):
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        awards_players.to_pyarrow()
+
+        assert "requires `pyarrow` but" in str(excinfo.value)

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -113,6 +113,28 @@ def test_column_to_pyarrow_array(limit, backend, awards_players):
         assert len(array) == limit
 
 
+@pytest.mark.parametrize("limit", no_limit)
+def test_empty_column_to_pyarrow(limit, backend, awards_players):
+    array = awards_players.filter(
+        awards_players.awardID == "DEADBEEF"
+    ).awardID.to_pyarrow(limit=limit)
+    assert isinstance(array, pa.Array)
+    assert len(array) == 0
+
+
+@pytest.mark.notyet(
+    ["datafusion"], reason="DataFusion backend doesn't support sum"
+)
+@pytest.mark.parametrize("limit", no_limit)
+def test_empty_scalar_to_pyarrow(limit, backend, awards_players):
+    array = (
+        awards_players.filter(awards_players.awardID == "DEADBEEF")
+        .yearID.sum()
+        .to_pyarrow(limit=limit)
+    )
+    assert isinstance(array, pa.Scalar)
+
+
 @pytest.mark.notyet(
     ["datafusion"], reason="DataFusion backend doesn't support sum"
 )

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import webbrowser
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
 import toolz
 from public import public
@@ -17,6 +17,8 @@ from ibis.expr.typing import TimeContext
 from ibis.util import UnnamedMarker
 
 if TYPE_CHECKING:
+    import pyarrow as pa
+
     import ibis.expr.types as ir
     from ibis.backends.base import BaseBackend
 
@@ -303,6 +305,73 @@ class Expr(Immutable):
         """
         return self._find_backend().compile(
             self, limit=limit, timecontext=timecontext, params=params
+        )
+
+    def to_pyarrow_batches(
+        self,
+        *,
+        limit: int | str | None = None,
+        params: Mapping[ir.Value, Any] | None = None,
+        chunk_size: int = 1_000_000,
+        **kwargs: Any,
+    ) -> Iterable[pa.RecordBatch]:
+        """Execute expression and return results in an iterator of pyarrow
+        record batches.
+
+        **Warning**: This method is eager and will execute the associated
+        expression immediately. This API is experimental and subject to change.
+
+        Parameters
+        ----------
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
+        params
+            Mapping of scalar parameter expressions to value.
+        chunk_size
+            Number of rows in each returned record batch.
+
+        Returns
+        -------
+        record_batches
+            An iterator of pyarrow record batches.
+        """
+        return self._find_backend().to_pyarrow_batches(
+            self,
+            params=params,
+            limit=limit,
+            chunk_size=chunk_size,
+            **kwargs,
+        )
+
+    def to_pyarrow(
+        self,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
+        **kwargs: Any,
+    ) -> pa.Table:
+        """Execute expression and return results in as a pyarrow table.
+
+        **Warning**: This method is eager and will execute the associated
+        expression immediately. This API is experimental and subject to change.
+
+
+        Parameters
+        ----------
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
+        params
+            Mapping of scalar parameter expressions to value.
+
+        Returns
+        -------
+        Table
+            A pyarrow table holding the results of the executed expression.
+        """
+        return self._find_backend().to_pyarrow(
+            self, params=params, limit=limit, **kwargs
         )
 
 

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -14,7 +14,7 @@ from ibis.common.grounds import Immutable
 from ibis.common.pretty import console
 from ibis.config import _default_backend, options
 from ibis.expr.typing import TimeContext
-from ibis.util import UnnamedMarker
+from ibis.util import UnnamedMarker, experimental
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -307,6 +307,7 @@ class Expr(Immutable):
             self, limit=limit, timecontext=timecontext, params=params
         )
 
+    @experimental
     def to_pyarrow_batches(
         self,
         *,
@@ -318,8 +319,8 @@ class Expr(Immutable):
         """Execute expression and return results in an iterator of pyarrow
         record batches.
 
-        **Warning**: This method is eager and will execute the associated
-        expression immediately. This API is experimental and subject to change.
+        This method is eager and will execute the associated expression
+        immediately.
 
         Parameters
         ----------
@@ -344,6 +345,7 @@ class Expr(Immutable):
             **kwargs,
         )
 
+    @experimental
     def to_pyarrow(
         self,
         *,
@@ -353,17 +355,16 @@ class Expr(Immutable):
     ) -> pa.Table:
         """Execute expression and return results in as a pyarrow table.
 
-        **Warning**: This method is eager and will execute the associated
-        expression immediately. This API is experimental and subject to change.
-
+        This method is eager and will execute the associated expression
+        immediately.
 
         Parameters
         ----------
+        params
+            Mapping of scalar parameter expressions to value.
         limit
             An integer to effect a specific row limit. A value of `None` means
             "no limit". The default is in `ibis/config.py`.
-        params
-            Mapping of scalar parameter expressions to value.
 
         Returns
         -------

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence
 
-if TYPE_CHECKING:
-    import ibis.expr.types as ir
-    import ibis.expr.window as win
-
 from public import public
 
 import ibis
@@ -14,6 +10,10 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.common.pretty import _format_value, _pretty_value
 from ibis.expr.types.core import Expr, _binop
+
+if TYPE_CHECKING:
+    import ibis.expr.types as ir
+    import ibis.expr.window as win
 
 
 @public

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -448,6 +448,34 @@ def deprecated(*, instead, version=''):
     return decorator
 
 
+def experimental(func):
+    """Decorate experimental function to add warning about potential API
+    instability in docstring."""
+
+    msg = "This API is experimental and subject to change."
+
+    if docstr := func.__doc__:
+        preamble, *rest = docstr.split("\n\n", maxsplit=1)
+
+        leading_spaces = " " * sum(
+            1
+            for _ in itertools.takewhile(str.isspace, rest[0] if rest else [])
+        )
+
+        warning_doc = f'{leading_spaces}!!! warning "{msg}"'
+
+        docstr = "\n\n".join([preamble, warning_doc, *rest])
+    else:
+        docstr = f'!!! warning "{msg}"'
+    func.__doc__ = docstr
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
 class ToFrame(abc.ABC):
     """Interface for in-memory objects that can be converted to a DataFrame."""
 


### PR DESCRIPTION
Adds `to_pyarrow` and `to_pyarrow_batches` to the alchemy backends, datafusion, and pandas.  More to come.

Some open questions / issues:
Where should the schema inference stuff live?  The type mapping is already defined in the `pyarrow` backend but it feels weird to import that backend into other backends.

`chunk_size`?  `chunksize`?  `batch_size`?

In this context, are chunks / batches properly defined in terms of rows or is that a conflation?

Datafusion has some slightly wonky behavior when it comes to a consistent schema across recordbatches
DuckDB does not seem to respect their own `chunksize` argument.

xref #4443 