### PR TITLE
ci: constrain duckdb in tpc-queries for now

### DIFF
--- a/.github/workflows/ibis-tpch-queries.yml
+++ b/.github/workflows/ibis-tpch-queries.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: tpc-queries
         run: |
           python -m pip install -r requirements.txt
-          python -m pip install -U duckdb>=0.4
+          python -m pip install -U 'duckdb>=0.4,<0.5'
 
       - name: install ibis
         run: python -m pip install ".[sqlite,duckdb]"


### PR DESCRIPTION
Hopefully this fixes the failing master branch until we can figure out what is happening.