### PR TITLE
perf(sqlalchemy): register DataFrames cheaply where possible

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -186,9 +186,7 @@ class BaseSQLBackend(BaseBackend):
 
         # register all in memory tables if the backend supports cheap access
         # to them
-        if self.compiler.cheap_in_memory_tables:
-            for memtable in lin.traverse(_find_memtables, expr):
-                self._register_in_memory_table(memtable)
+        self._register_in_memory_tables(expr)
 
         with self._safe_raw_sql(sql, **kwargs) as cursor:
             result = self.fetch_from_cursor(cursor, schema)
@@ -200,6 +198,11 @@ class BaseSQLBackend(BaseBackend):
 
     def _register_in_memory_table(self, table_op):
         raise NotImplementedError
+
+    def _register_in_memory_tables(self, expr):
+        if self.compiler.cheap_in_memory_tables:
+            for memtable in lin.traverse(_find_memtables, expr):
+                self._register_in_memory_table(memtable)
 
     @abc.abstractmethod
     def fetch_from_cursor(self, cursor, schema):

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -535,6 +535,8 @@ class Compiler:
     intersect_class = Intersection
     difference_class = Difference
 
+    cheap_in_memory_tables = False
+
     @classmethod
     def make_context(cls, params=None):
         params = params or {}

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -75,6 +75,11 @@ class ClickhouseTableSetFormatter(TableSetFormatter):
 
     _non_equijoin_supported = False
 
+    def _format_in_memory_table(self, op):
+        # We register in memory tables as external tables because clickhouse
+        # doesn't implement a generic VALUES statement
+        return op.name
+
 
 class ClickhouseExprTranslator(ExprTranslator):
     _registry = operation_registry
@@ -118,6 +123,7 @@ def day_of_week_name(expr):
 
 
 class ClickhouseCompiler(Compiler):
+    cheap_in_memory_tables = True
     translator_class = ClickhouseExprTranslator
     table_set_formatter_class = ClickhouseTableSetFormatter
     select_builder_class = ClickhouseSelectBuilder

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -191,6 +191,10 @@ class Backend(BaseAlchemyBackend):
         """Return an ibis Schema from a DuckDB SQL string."""
         return sch.Schema.from_tuples(self._metadata(query))
 
+    def _register_in_memory_table(self, table_op):
+        df = table_op.data.to_frame()
+        self.con.execute("register", (table_op.name, df))
+
     def _get_sqla_table(
         self,
         name: str,

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -57,4 +57,5 @@ def _no_op(expr):
 
 
 class DuckDBSQLCompiler(AlchemyCompiler):
+    cheap_in_memory_tables = True
     translator_class = DuckDBSQLExprTranslator

--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -306,15 +306,12 @@ dt.DataType.to_pandas = ibis_dtype_to_pandas  # type: ignore
 sch.Schema.to_pandas = ibis_schema_to_pandas  # type: ignore
 
 
-class DataFrameProxy(Immutable):
+class DataFrameProxy(Immutable, util.ToFrame):
     __slots__ = ('_df', '_hash')
 
     def __init__(self, df):
         object.__setattr__(self, "_df", df)
         object.__setattr__(self, "_hash", hash((type(df), id(df))))
-
-    def __getattr__(self, name):
-        return getattr(self._df, name)
 
     def __hash__(self):
         return self._hash
@@ -322,6 +319,9 @@ class DataFrameProxy(Immutable):
     def __repr__(self):
         df_repr = util.indent(repr(self._df), spaces=2)
         return f"{self.__class__.__name__}:\n{df_repr}"
+
+    def to_frame(self):
+        return self._df
 
 
 class PandasInMemoryTable(ops.InMemoryTable):

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -2168,6 +2168,7 @@ def compile_random(*args, **kwargs):
     return F.rand()
 
 
+@compiles(ops.InMemoryTable)
 @compiles(PandasInMemoryTable)
 def compile_in_memory_table(t, expr, scope, timecontext, session, **kwargs):
     op = expr.op()
@@ -2175,10 +2176,8 @@ def compile_in_memory_table(t, expr, scope, timecontext, session, **kwargs):
         pt.StructField(name, ibis_dtype_to_spark_dtype(dtype), dtype.nullable)
         for name, dtype in op.schema.items()
     ]
-    return session.createDataFrame(
-        data=op.data._df,
-        schema=pt.StructType(fields),
-    )
+    schema = pt.StructType(fields)
+    return session.createDataFrame(data=op.data.to_frame(), schema=schema)
 
 
 @compiles(ops.BitwiseAnd)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -634,6 +634,23 @@ def test_filter_memory_table(backend, con):
     backend.assert_frame_equal(result, expected)
 
 
+@pytest.mark.notyet(
+    ["clickhouse"],
+    reason="ClickHouse doesn't support a VALUES construct",
+)
+@pytest.mark.notyet(
+    ["mysql", "sqlite"],
+    reason="SQLAlchemy generates incorrect code for `VALUES` projections.",
+    raises=(sa.exc.ProgrammingError, sa.exc.OperationalError),
+)
+@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+def test_agg_memory_table(con):
+    t = ibis.memtable([(1, 2), (3, 4), (5, 6)], columns=["x", "y"])
+    expr = t.x.count()
+    result = con.execute(expr)
+    assert result == 3
+
+
 @pytest.mark.parametrize(
     "t",
     [

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -602,10 +602,6 @@ def test_deprecated_path_argument(backend, tmp_path):
     ],
 )
 @pytest.mark.notyet(
-    ["clickhouse"],
-    reason="ClickHouse doesn't support a VALUES construct",
-)
-@pytest.mark.notyet(
     ["mysql", "sqlite"],
     reason="SQLAlchemy generates incorrect code for `VALUES` projections.",
     raises=(sa.exc.ProgrammingError, sa.exc.OperationalError),
@@ -616,10 +612,6 @@ def test_in_memory_table(backend, con, expr, expected):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notyet(
-    ["clickhouse"],
-    reason="ClickHouse doesn't support a VALUES construct",
-)
 @pytest.mark.notyet(
     ["mysql", "sqlite"],
     reason="SQLAlchemy generates incorrect code for `VALUES` projections.",
@@ -634,10 +626,6 @@ def test_filter_memory_table(backend, con):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notyet(
-    ["clickhouse"],
-    reason="ClickHouse doesn't support a VALUES construct",
-)
 @pytest.mark.notyet(
     ["mysql", "sqlite"],
     reason="SQLAlchemy generates incorrect code for `VALUES` projections.",

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -98,17 +98,20 @@ class SQLQueryResult(TableNode, sch.HasSchema):
 
 
 @public
-class InMemoryTable(TableNode, sch.HasSchema):
-    name = rlz.optional(rlz.instance_of(str))
+class InMemoryTable(PhysicalTable):
+    name = rlz.instance_of(str)
     schema = rlz.instance_of(sch.Schema)
 
     @property
     @abstractmethod
-    def data(self):
+    def data(self) -> util.ToFrame:
         """Return the data of an in-memory table."""
 
-    def blocks(self):
+    def has_resolved_name(self):
         return True
+
+    def resolve_name(self):
+        return self.name
 
 
 def _make_distinct_join_predicates(left, right, predicates):

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -1,6 +1,7 @@
 """Ibis utility functions."""
 from __future__ import annotations
 
+import abc
 import collections
 import functools
 import itertools
@@ -27,6 +28,8 @@ import toolz
 from ibis.config import options
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     from ibis.expr import operations as ops
     from ibis.expr import types as ir
 
@@ -510,3 +513,13 @@ def toposort(graph: Graph) -> Iterator[ops.Node]:
 
     if any(in_degree.values()):
         raise ValueError("cycle in expression graph")
+
+
+class ToFrame(abc.ABC):
+    """Interface for in-memory objects that can be converted to a DataFrame."""
+
+    __slots__ = ()
+
+    @abc.abstractmethod
+    def to_frame(self) -> pd.DataFrame:
+        ...


### PR DESCRIPTION
This PR registers in-memory tables directly to a backend where native support for it
exists in the backend.

### Backend Support

* DuckDB, new in this PR
* PySpark, already worked
* ClickHouse, works but could be more efficient if we set `use_numpy=True` in the driver settings.
