### PR TITLE
fix(sqlalchemy): implement `SQLQueryResult` translation

### DIFF
--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -96,6 +96,9 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
                 ref_op.name,
                 *_schema_to_sqlalchemy_columns(schema),
             )
+        elif isinstance(ref_op, ops.SQLQueryResult):
+            columns = _schema_to_sqlalchemy_columns(ref_op.schema)
+            result = sa.text(ref_op.query).columns(*columns)
         elif isinstance(ref_op, ops.SQLStringView):
             columns = _schema_to_sqlalchemy_columns(ref_op.schema)
             result = sa.text(ref_op.query).columns(*columns).cte(ref_op.name)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -87,17 +87,17 @@ def test_query_schema(ddl_backend, ddl_con, expr_fn, expected):
     assert schema.equals(expected)
 
 
-@mark.parametrize(
-    'sql',
-    [
-        'select * from functional_alltypes limit 10',
-        'select * from functional_alltypes \nlimit 10\n',
-    ],
+@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notyet(["sqlite"])
+@pytest.mark.never(
+    ["dask", "pandas"],
+    reason="dask and pandas do not support SQL",
 )
-@mark.notimpl(["datafusion", "duckdb", "mysql", "postgres", "sqlite"])
-def test_sql(ddl_con, sql):
+def test_sql(con):
     # execute the expression using SQL query
-    ddl_con.sql(sql).execute()
+    expr = con.sql("SELECT * FROM functional_alltypes LIMIT 10")
+    result = expr.execute()
+    assert len(result) == 10
 
 
 @mark.notimpl(["clickhouse", "datafusion"])


### PR DESCRIPTION
This PR makes SQLQueryResult aka con.sql work for SQLAlchemy backends