### PR TITLE
feat(ux): `rich` interactive table

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -791,3 +791,18 @@ def test_bitwise_not_col(backend, alltypes, df):
     result = expr.execute()
     expected = ~df.int_col
     backend.assert_series_equal(result, expected.rename("tmp"))
+
+
+def test_interactive(alltypes):
+    expr = alltypes.mutate(
+        str_col=_.string_col.replace("1", "").nullif("2"),
+        date_col=_.timestamp_col.date(),
+        delta_col=lambda t: ibis.now() - t.timestamp_col,
+    )
+
+    orig = ibis.options.interactive
+    ibis.options.interactive = True
+    try:
+        repr(expr)
+    finally:
+        ibis.options.interactive = orig

--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -5,8 +5,6 @@ from abc import ABCMeta, abstractmethod
 from typing import Any
 from weakref import WeakValueDictionary
 
-from rich.console import Console
-
 from ibis.common.caching import WeakCache
 from ibis.common.validators import (
     ImmutableProperty,
@@ -17,8 +15,6 @@ from ibis.common.validators import (
 from ibis.util import frozendict
 
 EMPTY = inspect.Parameter.empty  # marker for missing argument
-
-console = Console()
 
 
 class BaseMeta(ABCMeta):

--- a/ibis/common/pretty.py
+++ b/ibis/common/pretty.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import datetime
+import decimal
 from typing import IO
+
+import rich
+from rich.console import Console
 
 import ibis
 import ibis.common.exceptions as com
+import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
+
+console = Console()
 
 _IBIS_TO_SQLGLOT_NAME_MAP = {
     # not 100% accurate, but very close
@@ -106,3 +114,73 @@ def to_sql(expr: ir.Expr, dialect: str | None = None) -> str:
         pretty=True,
     )
     return pretty
+
+
+def _pretty_value(v, dtype: dt.DataType):
+    if isinstance(v, str):
+        return v
+
+    if isinstance(v, decimal.Decimal):
+        return f"[bold][light_salmon1]{v}[/][/]"
+
+    if isinstance(v, datetime.datetime):
+        if isinstance(dtype, dt.Date):
+            return f"[magenta]{v.date()}[/]"
+
+        fmt = v.isoformat(timespec='milliseconds').replace("T", " ")
+        return f"[magenta]{fmt}[/]"
+
+    if isinstance(v, datetime.timedelta):
+        return f"[magenta]{v}[/]"
+
+    interactive = ibis.options.repr.interactive
+    return rich.pretty.Pretty(
+        v,
+        max_length=interactive.max_length,
+        max_string=interactive.max_string,
+        max_depth=interactive.max_depth,
+    )
+
+
+def _format_value(v) -> str:
+    if v is None:
+        # render NULL values as the empty set
+        return "[dim][yellow]∅[/][/]"
+
+    if isinstance(v, str):
+        if not v:
+            return "[dim][yellow]~[/][/]"
+
+        v = (
+            # replace spaces with dots
+            v.replace(" ", "[dim]·[/]")
+            # tab
+            .replace("\t", r"[dim]\t[/]")
+            # carriage return
+            .replace("\r", r"[dim]\r[/]")
+            # line feed
+            .replace("\n", r"[dim]\n[/]")
+            # vertical tab
+            .replace("\v", r"[dim]\v[/]")
+            # form feed (page break)
+            .replace("\f", r"[dim]\f[/]")
+        )
+        # display all unprintable characters as a dimmed version of their repr
+        return "".join(
+            f"[dim]{repr(c)[1:-1]}[/]" if not c.isprintable() else c for c in v
+        )
+    return v
+
+
+def _format_dtype(dtype):
+    strtyp = str(dtype)
+    max_string = ibis.options.repr.interactive.max_string
+    return (
+        ("[bold][dark_orange]![/][/]" * (not dtype.nullable))
+        + "[bold][blue]"
+        + (
+            strtyp[(not dtype.nullable) : max_string]
+            + "[orange1]…[/]" * (len(strtyp) > max_string)
+        )
+        + "[/][/]"
+    )

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -68,6 +68,30 @@ class SQL(Config):
     default_dialect = rlz.optional(rlz.str_, default="duckdb")
 
 
+class Interactive(Config):
+    """Options controlling the interactive repr.
+
+    Attributes
+    ----------
+    max_rows
+        Maximum rows to pretty print.
+    max_length
+        Maximum length for pretty-printed arrays and maps.
+    max_string
+        Maximum length for pretty-printed strings.
+    max_depth
+        Maximum depth for nested data types.
+    show_types
+        Show the inferred type of value expressions in the interactive repr.
+    """
+
+    max_rows = rlz.optional(rlz.int_, default=10)
+    max_length = rlz.optional(rlz.int_, default=5)
+    max_string = rlz.optional(rlz.int_, default=80)
+    max_depth = rlz.optional(rlz.int_, default=2)
+    show_types = rlz.optional(rlz.bool_, default=True)
+
+
 class Repr(Config):
     """Expression printing options.
 
@@ -82,12 +106,18 @@ class Repr(Config):
         SQLQueryResult operations.
     show_types : bool
         Show the inferred type of value expressions in the repr.
+    interactive
+        Options controlling the interactive repr.
     """
 
     depth = rlz.optional(rlz.int_(min=0))
     table_columns = rlz.optional(rlz.int_(min=0))
     query_text_length = rlz.optional(rlz.int_(min=0), default=80)
     show_types = rlz.optional(rlz.bool_, default=False)
+    interactive = rlz.optional(
+        rlz.instance_of(Interactive),
+        default=Interactive(),
+    )
 
 
 config_ = rlz.instance_of(Config)

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -121,7 +121,12 @@ class Bounds(NamedTuple):
 
 
 @public
-class Integer(Primitive):
+class Numeric(DataType):
+    """Numeric types."""
+
+
+@public
+class Integer(Primitive, Numeric):
     """Integer values."""
 
     scalar = ir.IntegerScalar
@@ -232,7 +237,7 @@ class UnsignedInteger(Integer):
 
 
 @public
-class Floating(Primitive):
+class Floating(Primitive, Numeric):
     """Floating point values."""
 
     scalar = ir.FloatingScalar
@@ -329,7 +334,7 @@ class Float64(Floating):
 
 
 @public
-class Decimal(DataType):
+class Decimal(Numeric):
     """Fixed-precision decimal values."""
 
     precision = optional(instance_of(int))
@@ -386,10 +391,10 @@ class Decimal(DataType):
         args = []
 
         if (precision := self.precision) is not None:
-            args.append(f"prec={precision:d}")
+            args.append(str(precision))
 
         if (scale := self.scale) is not None:
-            args.append(f"scale={scale:d}")
+            args.append(str(scale))
 
         if not args:
             return ""
@@ -465,7 +470,7 @@ class Interval(DataType):
 
     @property
     def _pretty_piece(self) -> str:
-        return f"<{self.value_type}>(unit={self.unit!r})"
+        return f"({self.unit!r})"
 
 
 @public

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -454,7 +454,7 @@ def fmt_selection_column(value_expr: object, **_: Any) -> str:
 
 def type_info(datatype: dt.DataType) -> str:
     """Format `datatype` for display next to a column."""
-    return f"  # {datatype}" if ibis.options.repr.show_types else ""
+    return f"  # {datatype}" * ibis.options.repr.show_types
 
 
 @fmt_selection_column.register

--- a/ibis/expr/types/analytic.py
+++ b/ibis/expr/types/analytic.py
@@ -40,6 +40,9 @@ class TopK(Analytic):
         arg = op.arg.to_expr()
         return arg == getattr(rank_set, arg.get_name())
 
+    def __rich_console__(self, console, options):
+        return self.to_aggregation().__rich_console__(console, options)
+
     def to_aggregation(
         self, metric_name=None, parent_table=None, backup_metric_name=None
     ):

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -17,6 +17,7 @@ from ibis.common.exceptions import (
     TranslationError,
 )
 from ibis.common.grounds import Immutable
+from ibis.common.pretty import console
 from ibis.config import _default_backend, options
 from ibis.expr.typing import TimeContext
 from ibis.util import UnnamedMarker
@@ -40,17 +41,18 @@ class Expr(Immutable):
         if not options.interactive:
             return self._repr()
 
-        try:
-            result = self.execute()
-        except TranslationError as e:
-            lines = [
-                "Translation to backend failed",
-                f"Error message: {e.args[0]}",
-                "Expression repr follows:",
-                self._repr(),
-            ]
-            return "\n".join(lines)
-        return repr(result)
+        with console.capture() as capture:
+            try:
+                console.print(self)
+            except TranslationError as e:
+                lines = [
+                    "Translation to backend failed",
+                    f"Error message: {e.args[0]}",
+                    "Expression repr follows:",
+                    self._repr(),
+                ]
+                return "\n".join(lines)
+        return capture.get()
 
     def __reduce__(self):
         return (self.__class__, (self._arg,))

--- a/ibis/tests/expr/test_decimal.py
+++ b/ibis/tests/expr/test_decimal.py
@@ -156,7 +156,7 @@ def test_invalid_precision_scale_type(precision, scale):
 def test_decimal_str(lineitem):
     col = lineitem.l_extendedprice
     t = col.type()
-    assert str(t) == f'decimal(prec={t.precision:d}, scale={t.scale:d})'
+    assert str(t) == f'decimal({t.precision:d}, {t.scale:d})'
 
 
 def test_decimal_repr(lineitem):

--- a/ibis/tests/expr/test_interactive.py
+++ b/ibis/tests/expr/test_interactive.py
@@ -59,9 +59,7 @@ def test_default_limit(con):
     expected = """\
 SELECT *
 FROM functional_alltypes
-LIMIT {}""".format(
-        config.options.sql.default_limit
-    )
+LIMIT 11"""
 
     assert con.executed_queries[0] == expected
 
@@ -89,7 +87,8 @@ def test_disable_query_limit(con):
 
     expected = """\
 SELECT *
-FROM functional_alltypes"""
+FROM functional_alltypes
+LIMIT 11"""
 
     assert con.executed_queries[0] == expected
 


### PR DESCRIPTION
This PR adds a new interactive repr for Table expressions using rich.

## Examples

### movielens `movies` table, simple structure

![image](https://user-images.githubusercontent.com/417981/189640160-d11b94be-a426-425f-8f2d-d639f847f09c.png)

### 2020 election data, highly nested

![image](https://user-images.githubusercontent.com/417981/189640262-d5b1b5d3-8a53-48a2-9400-f5e5fff1b248.png)