### PR TITLE
chore: add `just view-changelog` command

### DIFF
--- a/justfile
+++ b/justfile
@@ -84,3 +84,10 @@ checklinks *args:
                         -or -wholename 'site/overrides/main.html' \
                         -or -wholename 'site/blog/Ibis-version-3.1.0-release/index.html' \) \))
     lychee "${files[@]}" --base site --require-https {{ args }}
+
+# view the changelog for upcoming release (use --pretty to format with glow)
+view-changelog flags="":
+    #!/usr/bin/env bash
+    npx -y -p conventional-changelog-cli \
+        -- conventional-changelog --config ./.conventionalcommits.js \
+        | ([ "{{ flags }}" = "--pretty" ] && glow -p - || cat -)


### PR DESCRIPTION
Adds a command to the justfile to view the changelog for the upcoming release. Helpful when trying to remember what the highlights are for an upcoming release.

```
# dump the changelog as markdown
just view-changelog

# pass in `--pretty` to format with glow
just view-changelog --pretty
```