### PR TITLE
ci: load data into bigquery native tables

### DIFF
--- a/.github/workflows/ci-data.yml
+++ b/.github/workflows/ci-data.yml
@@ -56,4 +56,9 @@ jobs:
           for table in workflows jobs; do
             gsuri="gs://ibis-workflow-data/${yesterday}/${table}.json"
             gsutil cp -Z "${table}.json" "${gsuri}"
+            bq load \
+              --autodetect=true \
+              --source_format=NEWLINE_DELIMITED_JSON \
+              "workflows_native.${table}" \
+              "${gsuri}"
           done


### PR DESCRIPTION
This PR uploads our CI data into a bigquery native table instead of relying on the external JSON (which will still be available). This should make querying the data faster.