### PR TITLE
feat(api): add `and_` and `or_` helpers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ result
 result-*
 docs/release_notes.md
 docs/overrides/*.html
+docs/api/expressions/top_level.md
 docs/SUMMARY.md
 site
 ci/udf/CMakeFiles

--- a/docs/api/expressions/top_level.md
+++ b/docs/api/expressions/top_level.md
@@ -6,7 +6,7 @@ These methods and objects are available directly in the `ibis` module.
 
 `NA` is the null scalar.
 
-::: ibis.and*
+::: ibis.and_
 ::: ibis.array
 ::: ibis.asc
 ::: ibis.case
@@ -25,7 +25,7 @@ These methods and objects are available directly in the `ibis` module.
 ::: ibis.negate
 ::: ibis.now
 ::: ibis.null
-::: ibis.or*
+::: ibis.or_
 ::: ibis.param
 ::: ibis.show_sql
 ::: ibis.random

--- a/docs/api/expressions/top_level.md
+++ b/docs/api/expressions/top_level.md
@@ -6,6 +6,7 @@ These methods and objects are available directly in the `ibis` module.
 
 `NA` is the null scalar.
 
+::: ibis.and*
 ::: ibis.array
 ::: ibis.asc
 ::: ibis.case
@@ -24,6 +25,7 @@ These methods and objects are available directly in the `ibis` module.
 ::: ibis.negate
 ::: ibis.now
 ::: ibis.null
+::: ibis.or*
 ::: ibis.param
 ::: ibis.show_sql
 ::: ibis.random

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import functools
 import itertools
+import operator
 from typing import Iterable, Mapping, Sequence
 from typing import Tuple as _Tuple
 from typing import TypeVar
@@ -115,7 +116,9 @@ from ibis.expr.window import (
 
 __all__ = (
     'aggregate',
+    'and_',
     'array',
+    'asc',
     'case',
     'coalesce',
     'connect',
@@ -124,7 +127,6 @@ __all__ = (
     'date',
     'desc',
     'difference',
-    'asc',
     'e',
     'Expr',
     'geo_area',
@@ -194,6 +196,7 @@ __all__ = (
     'negate',
     'now',
     'null',
+    'or_',
     'param',
     'pi',
     'prevent_rewrite',
@@ -549,6 +552,44 @@ def asc(expr: ir.Column | str) -> ir.SortExpr | ops.DeferredSortKey:
         return ops.DeferredSortKey(expr)
     else:
         return ops.SortKey(expr).to_expr()
+
+
+def and_(*predicates: ir.BooleanValue) -> ir.BooleanValue:
+    """Combine multiple predicates using `&`.
+
+    Parameters
+    ----------
+    predicates
+        Boolean value expressions
+
+    Returns
+    -------
+    BooleanValue
+        A new predicate that evaluates to True if all composing predicates are
+        True. If no predicates were provided, returns True.
+    """
+    if not predicates:
+        return literal(True)
+    return functools.reduce(operator.and_, predicates)
+
+
+def or_(*predicates: ir.BooleanValue) -> ir.BooleanValue:
+    """Combine multiple predicates using `|`.
+
+    Parameters
+    ----------
+    predicates
+        Boolean value expressions
+
+    Returns
+    -------
+    BooleanValue
+        A new predicate that evaluates to True if any composing predicates are
+        True. If no predicates were provided, returns False.
+    """
+    if not predicates:
+        return literal(False)
+    return functools.reduce(operator.or_, predicates)
 
 
 @functools.singledispatch

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -600,6 +600,26 @@ def test_boolean_logical_ops(table, operation):
     assert isinstance(result, ir.BooleanScalar)
 
 
+def test_and_(table):
+    p1 = table.a > 1
+    p2 = table.b > 1
+    p3 = table.c > 1
+    assert ibis.and_().equals(ibis.literal(True))
+    assert ibis.and_(p1).equals(p1)
+    assert ibis.and_(p1, p2).equals(p1 & p2)
+    assert ibis.and_(p1, p2, p3).equals(p1 & p2 & p3)
+
+
+def test_or_(table):
+    p1 = table.a > 1
+    p2 = table.b > 1
+    p3 = table.c > 1
+    assert ibis.or_().equals(ibis.literal(False))
+    assert ibis.or_(p1).equals(p1)
+    assert ibis.or_(p1, p2).equals(p1 | p2)
+    assert ibis.or_(p1, p2, p3).equals(p1 | p2 | p3)
+
+
 def test_null_column():
     t = ibis.table([('a', 'string')], name='t')
     s = t.mutate(b=ibis.NA)


### PR DESCRIPTION
This adds some helper methods for composing multiple predicates together using boolean logic. I think these methods are useful when programmatically combining expressions, but I'm not sold on the names/variadic nature.

- Should these be called `and_`/`or_` or `all`/`any`?
- Should these be variadic or take an iterable?

I went with `and_`/`or_` and variadic for now, but happy to change if others feel strongly.

I do think it's important that these helpers work with 0 or more elements to make it easier to programmatically combine predicates - this lets the caller not worry about the 0 or 1 element case. For no predicates I went with the behavior of python's `all`/`any` methods:

- `and_()` returns `literal(True)`
- `or_()` returns `literal(False)`