### PR TITLE
feat(ux): add duckdb as the default backend

### DIFF
--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -169,7 +169,7 @@ def execute_with_scope(
     # computing anything *and* before associating leaf nodes with data. This
     # allows clients to provide their own data for each leaf.
     if clients is None:
-        clients = expr._find_backends()
+        clients, _ = expr._find_backends()
 
     if aggcontext is None:
         aggcontext = agg_ctx.Summarize()

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -205,7 +205,7 @@ def execute_with_scope(
     # computing anything *and* before associating leaf nodes with data. This
     # allows clients to provide their own data for each leaf.
     if clients is None:
-        clients = expr._find_backends()
+        clients, _ = expr._find_backends()
 
     if aggcontext is None:
         aggcontext = agg_ctx.Summarize()

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1551,3 +1551,14 @@ def test_memtable_filter():
     t = ibis.memtable([(1, 2), (3, 4), (5, 6)], columns=["x", "y"])
     expr = t.filter(t.x > 1)
     assert expr.columns == ["x", "y"]
+
+
+def test_default_backend_with_unbound_table():
+    t = ibis.table(dict(a="int"), name="t")
+    expr = t.a.sum()
+
+    with pytest.raises(
+        com.IbisError,
+        match="Expression contains unbound tables",
+    ):
+        assert expr.execute()


### PR DESCRIPTION
This PR adds DuckDB as the default backend to use for things that don't have a backend.

Right now, those things are:

1. `ops.Literal`s
2. `ops.InMemoryTable`s

This is useful for doing analysis on in-memory things without having to think too hard about
how to do it. The workflow is one call to `ibis.memtable` on the object and you're off to
the races.
