### PR TITLE
feat(duckdb): register tables from pandas/pyarrow objects

### DIFF
--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -107,3 +107,27 @@ def test_register_parquet(
 
     table = con.table(out_table_name)
     assert table.count().execute()
+
+
+def test_register_pandas():
+    pd = pytest.importorskip("pandas")
+    df = pd.DataFrame({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+
+    con = ibis.duckdb.connect()
+
+    t = con.register(df)
+    assert t.x.sum().execute() == 6
+
+    t = con.register(df, "my_table")
+    assert t.op().name == "my_table"
+    assert t.x.sum().execute() == 6
+
+
+def test_register_pyarrow_tables():
+    pa = pytest.importorskip("pyarrow")
+    pa_t = pa.Table.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+
+    con = ibis.duckdb.connect()
+
+    t = con.register(pa_t)
+    assert t.x.sum().execute() == 6


### PR DESCRIPTION
This lets you create a table automatically by passing an in-memory pandas or pyarrow table/dataset to `con.register`.

```python
In [1]: import ibis

In [2]: con = ibis.duckdb.connect()

In [3]: import pyarrow as pa

In [4]: table = pa.Table.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})

In [5]: t = con.register(table)  # register with duckdb

In [6]: t.x.sum().execute()
Out[6]: 6
```

Fixes part of #4481.