### PR TITLE
docs: move blog to sidebar; style attribution the same for all blog posts.

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,4 +1,5 @@
 * [Home](index.md)
+* [Blog](blog/)
 * Tutorial
     * [Introduction to Ibis](tutorial/01-Introduction-to-Ibis.ipynb)
     * [Aggregating and Joining](tutorial/02-Aggregates-Joins.ipynb)
@@ -15,7 +16,6 @@
 * [Contribute](contribute/)
 * [Code of Conduct](CODE_OF_CONDUCT.md)
 * Community
-    * [Blog](blog/)
     * [About](about/)
     * [Ask a question (StackOverflow)](https://stackoverflow.com/questions/tagged/ibis)
     * [Chat (Gitter)](https://gitter.im/ibis-dev/Lobby)

--- a/docs/blog/Ibis-version-3.0.0-release.md
+++ b/docs/blog/Ibis-version-3.0.0-release.md
@@ -1,6 +1,6 @@
 # Ibis v3.0.0
 
-#### by: Marlene Mhangami
+**by Marlene Mhangami**
 
 The latest version of Ibis, version 3.0.0, has just been released! This post highlights some of the new features, breaking changes, and performance improvements that come with the new release. 3.0.0 is a major release and includes more changes than those listed in this post. A full list of the changes can be found in the project release notes [here](https://ibis-project.org/docs/dev/release_notes/).
 

--- a/docs/blog/Ibis-version-3.1.0-release.md
+++ b/docs/blog/Ibis-version-3.1.0-release.md
@@ -1,6 +1,6 @@
 # Ibis v3.1.0
 
-Marlene Mhangami
+**by Marlene Mhangami**
 
 25 July 2022
 

--- a/docs/blog/ffill-and-bfill-using-ibis.md
+++ b/docs/blog/ffill-and-bfill-using-ibis.md
@@ -1,6 +1,6 @@
 # `ffill` and `bfill` using Ibis
 
-#### by: Patrick Clarke
+**by Patrick Clarke**
 
 Suppose you have a table of data mapping events and dates to values, and that this data contains gaps in values.
 


### PR DESCRIPTION
This PR moves the blog up to the top level sidebar, underneath `Home`.