### PR TITLE
feat(api): make `Table.drop` variadic

### DIFF
--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -79,7 +79,7 @@ def test_read_with_undiscoverable_type(client):
 
 def test_drop(table):
     table = table.mutate(c=table.a)
-    expr = table.drop(['a'])
+    expr = table.drop('a')
     result = expr.execute()
     expected = table[['b', 'c']].execute()
     tm.assert_frame_equal(result, expected)

--- a/ibis/backends/pandas/tests/test_client.py
+++ b/ibis/backends/pandas/tests/test_client.py
@@ -70,7 +70,7 @@ def test_list_tables(client):
 
 def test_drop(table):
     table = table.mutate(c=table.a)
-    expr = table.drop(['a'])
+    expr = table.drop('a')
     result = expr.execute()
     expected = table[['b', 'c']].execute()
     tm.assert_frame_equal(result, expected)

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -81,9 +81,7 @@ def check_eq(left, right, how, **kwargs):
 @pytest.mark.notimpl(["datafusion"])
 def test_mutating_join(backend, batting, awards_players, how):
     left = batting[batting.yearID == 2015]
-    right = awards_players[awards_players.lgID == 'NL'].drop(
-        ['yearID', 'lgID']
-    )
+    right = awards_players[awards_players.lgID == 'NL'].drop('yearID', 'lgID')
 
     left_df = left.execute()
     right_df = right.execute()
@@ -135,9 +133,7 @@ def test_mutating_join(backend, batting, awards_players, how):
 )
 def test_filtering_join(backend, batting, awards_players, how):
     left = batting[batting.yearID == 2015]
-    right = awards_players[awards_players.lgID == 'NL'].drop(
-        ['yearID', 'lgID']
-    )
+    right = awards_players[awards_players.lgID == 'NL'].drop('yearID', 'lgID')
 
     left_df = left.execute()
     right_df = right.execute()

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -5,6 +5,7 @@ import functools
 import itertools
 import operator
 import sys
+import warnings
 from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any, Iterable, Literal, Mapping, Sequence
 
@@ -685,7 +686,7 @@ class Table(Expr):
 
         return self.select(exprs)
 
-    def drop(self, fields: str | Sequence[str]) -> Table:
+    def drop(self, *fields: str) -> Table:
         """Remove fields from a table.
 
         Parameters
@@ -696,13 +697,19 @@ class Table(Expr):
         Returns
         -------
         Table
-            Expression without `fields`
+            A table with all columns in `fields` removed.
         """
         if not fields:
             # no-op if nothing to be dropped
             return self
 
-        fields = util.promote_list(fields)
+        if len(fields) == 1 and not isinstance(fields[0], str):
+            fields = util.promote_list(fields[0])
+            warnings.warn(
+                "Passing a sequence of fields to `drop` is deprecated and "
+                "will be removed in version 5.0, use `drop(*fields)` instead",
+                FutureWarning,
+            )
 
         schema = self.schema()
         field_set = frozenset(fields)

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1520,6 +1520,25 @@ def test_join_suffixes(how):
     assert expr.columns == ["id_left", "first_name", "id_right", "last_name"]
 
 
+def test_drop():
+    t = ibis.table(dict.fromkeys("abcd", "int"))
+
+    assert t.drop() is t
+
+    res = t.drop("a")
+    assert res.equals(t.select("b", "c", "d"))
+
+    res = t.drop("a", "b")
+    assert res.equals(t.select("c", "d"))
+
+    with pytest.raises(KeyError, match="Fields not in table"):
+        t.drop("missing")
+
+    with pytest.warns(FutureWarning, match="a sequence of fields"):
+        res = t.drop(["a", "b"])
+    assert res.equals(t.select("c", "d"))
+
+
 def test_python_table_ambiguous():
     with pytest.raises(NotImplementedError):
         ibis.memtable(

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -274,7 +274,7 @@ def test_table_drop_with_filter():
         [('a', 'int64'), ('b', 'string'), ('c', 'timestamp')], name='t'
     ).relabel({'c': 'C'})
     left = left.filter(left.C == datetime.datetime(2018, 1, 1))
-    left = left.drop(['C'])
+    left = left.drop('C')
     left = left.mutate(the_date=datetime.datetime(2018, 1, 1))
 
     right = ibis.table([('b', 'string')], name='s')
@@ -311,17 +311,10 @@ def test_table_drop_consistency():
     )
 
     expected = t.projection(["a", "c"])
-    result_1 = t.drop(["b"])
-    result_2 = t.drop("b")
+    result = t.drop("b")
 
-    assert expected.schema() == result_1.schema()
-    assert expected.schema() == result_2.schema()
-
-    assert expected.schema() != t.schema()
-
-    assert "b" not in expected.columns
-    assert "a" in result_1.columns
-    assert "c" in result_2.columns
+    assert expected.schema() == result.schema()
+    assert set(result.columns) == {"a", "c"}
 
 
 def test_subquery_where_location():


### PR DESCRIPTION
This was a minor rough edge found while using `ibis`. I kept calling `drop` incorrectly since I expected it to be variadic like `select` (viewing it as the inverse of select for column subsetting).

This PR isn't a breaking change, the old calling style is deprecated in favor of a variadic call.

```python
In [1]: import ibis

In [2]: t = ibis.table(dict.fromkeys("abcd", "int"))

In [3]: t.select("a", "b").columns
Out[3]: ['a', 'b']

In [4]: t.drop("c", "d").columns
Out[4]: ['a', 'b']
```