### PR TITLE
docs: Correct small typo in aggregates-joins

### DIFF
--- a/docs/tutorial/02-Aggregates-Joins.ipynb
+++ b/docs/tutorial/02-Aggregates-Joins.ipynb
@@ -521,7 +521,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `country_code` in `gdp` corresponds to `iso_alpha2` in the `countries` table. We can also see\n",
+    "The `country_code` in `gdp` corresponds to `iso_alpha3` in the `countries` table. We can also see\n",
     "how the `gdp` table has `10,000` rows, while `countries` has `252`. We will start joining the\n",
     "two tables by the codes that match, discarding the codes that do not exist in both tables.\n",
     "This is called an inner join."


### PR DESCRIPTION
In the joining data section, the prose claims that the GDP country code corresponds to iso_alpha2, when it actually corresponds to iso_alpha3, which is reflected in the code. This PR fixes that.