### PR TITLE
feat(api): add JSON getitem support

### DIFF
--- a/ci/schema/duckdb.sql
+++ b/ci/schema/duckdb.sql
@@ -93,3 +93,13 @@ INSERT INTO struct VALUES
     ({'a': 2.0, 'b': NULL, 'c': 3}),
     (NULL),
     ({'a': 3.0, 'b': 'orange', 'c': NULL});
+
+CREATE OR REPLACE TABLE json_t (js JSON);
+
+INSERT INTO json_t VALUES
+    ('{"a": [1,2,3,4], "b": 1}'),
+    ('{"a":null,"b":2}'),
+    ('{"a":"foo", "c":null}'),
+    ('null'),
+    ('[42,47,55]'),
+    ('[]');

--- a/ci/schema/mysql.sql
+++ b/ci/schema/mysql.sql
@@ -72,3 +72,15 @@ CREATE TABLE functional_alltypes (
 ) DEFAULT CHARACTER SET = utf8;
 
 CREATE INDEX `ix_functional_alltypes_index` ON functional_alltypes (`index`);
+
+DROP TABLE IF EXISTS json_t CASCADE;
+
+CREATE TABLE IF NOT EXISTS json_t (js JSON);
+
+INSERT INTO json_t VALUES
+    ('{"a": [1,2,3,4], "b": 1}'),
+    ('{"a":null,"b":2}'),
+    ('{"a":"foo", "c":null}'),
+    ('null'),
+    ('[42,47,55]'),
+    ('[]');

--- a/ci/schema/postgresql.sql
+++ b/ci/schema/postgresql.sql
@@ -183,3 +183,15 @@ CREATE INDEX IF NOT EXISTS idx_geo_geo_linestring ON geo USING GIST (geo_linestr
 CREATE INDEX IF NOT EXISTS idx_geo_geo_multipolygon ON geo USING GIST (geo_multipolygon);
 CREATE INDEX IF NOT EXISTS idx_geo_geo_point ON geo USING GIST (geo_point);
 CREATE INDEX IF NOT EXISTS idx_geo_geo_polygon ON geo USING GIST (geo_polygon);
+
+DROP TABLE IF EXISTS json_t CASCADE;
+
+CREATE TABLE IF NOT EXISTS json_t (js JSON);
+
+INSERT INTO json_t VALUES
+    ('{"a": [1,2,3,4], "b": 1}'),
+    ('{"a":null,"b":2}'),
+    ('{"a":"foo", "c":null}'),
+    ('null'),
+    ('[42,47,55]'),
+    ('[]');

--- a/ci/schema/sqlite.sql
+++ b/ci/schema/sqlite.sql
@@ -73,3 +73,15 @@ CREATE TABLE diamonds (
     y FLOAT,
     z FLOAT
 );
+
+DROP TABLE IF EXISTS json_t;
+
+CREATE TABLE IF NOT EXISTS json_t (js JSON);
+
+INSERT INTO json_t VALUES
+    ('{"a": [1,2,3,4], "b": 1}'),
+    ('{"a":null,"b":2}'),
+    ('{"a":"foo", "c":null}'),
+    ('null'),
+    ('[42,47,55]'),
+    ('[]');

--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -256,7 +256,7 @@ def sa_inet(_, satype, nullable=True):
     return dt.INET(nullable=nullable)
 
 
-@dt.dtype.register(PGDialect, postgresql.JSON)
+@dt.dtype.register(Dialect, sa.types.JSON)
 def sa_json(_, satype, nullable=True):
     return dt.JSON(nullable=nullable)
 

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -179,6 +179,8 @@ def _cast(t, op):
         # in pandas. CAST(expr AS BYTEA) is correct and returns byte strings.
         return sa.cast(sa_arg, sa.LargeBinary())
 
+    if isinstance(typ, dt.JSON) and not t.native_json_type:
+        return sa_arg
     return sa.cast(sa_arg, sa_type)
 
 
@@ -646,6 +648,7 @@ sqlalchemy_operation_registry: Dict[Any, Any] = {
     ops.BitwiseLeftShift: _bitwise_op("<<"),
     ops.BitwiseRightShift: _bitwise_op(">>"),
     ops.BitwiseNot: _bitwise_not,
+    ops.JSONGetItem: fixed_arity(lambda x, y: x.op("->")(y), 2),
 }
 
 

--- a/ibis/backends/base/sql/alchemy/translator.py
+++ b/ibis/backends/base/sql/alchemy/translator.py
@@ -47,6 +47,7 @@ class AlchemyExprTranslator(ExprTranslator):
     _has_reduction_filter_syntax = False
 
     integer_to_timestamp = sa.func.to_timestamp
+    native_json_type = True
 
     def name(self, translated, name, force=True):
         return translated.label(name)

--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -27,6 +27,7 @@ class TestConf(UnorderedComparator, BackendTest, RoundHalfToEven):
     supported_to_timestamp_units = {'s'}
     supports_floating_modulus = False
     bool_is_int = True
+    supports_json = False
 
     @staticmethod
     def _load_data(
@@ -60,6 +61,8 @@ class TestConf(UnorderedComparator, BackendTest, RoundHalfToEven):
         client.execute(f"DROP DATABASE IF EXISTS {database}")
         client.execute(f"CREATE DATABASE {database} ENGINE = Atomic")
         client.execute(f"USE {database}")
+        client.execute("SET allow_experimental_object_type = 1")
+        client.execute("SET output_format_json_named_tuples_as_objects = 1")
 
         with open(script_dir / 'schema' / 'clickhouse.sql') as schema:
             for stmt in filter(None, map(str.strip, schema.read().split(";"))):

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -576,6 +576,11 @@ def alltypes(backend):
     return backend.functional_alltypes
 
 
+@pytest.fixture(scope="session")
+def json_t(backend):
+    return backend.json_t
+
+
 @pytest.fixture(scope='session')
 def struct(backend):
     return backend.struct

--- a/ibis/backends/dask/execution/strings.py
+++ b/ibis/backends/dask/execution/strings.py
@@ -17,6 +17,8 @@ from ibis.backends.dask.execution.util import (
 )
 from ibis.backends.pandas.core import integer_types, scalar_types
 from ibis.backends.pandas.execution.strings import (
+    execute_json_getitem_series_series,
+    execute_json_getitem_series_str_int,
     execute_series_join_scalar_sep,
     execute_series_regex_extract,
     execute_series_regex_replace,
@@ -160,6 +162,10 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ops.StrRight: [((dd.Series, integer_types), execute_series_right)],
     ops.StringJoin: [
         (((dd.Series, str), list), execute_series_join_scalar_sep),
+    ],
+    ops.JSONGetItem: [
+        ((dd.Series, (str, int)), execute_json_getitem_series_str_int),
+        ((dd.Series, dd.Series), execute_json_getitem_series_series),
     ],
 }
 register_types_to_dispatcher(execute_node, DASK_DISPATCH_TYPES)

--- a/ibis/backends/dask/tests/conftest.py
+++ b/ibis/backends/dask/tests/conftest.py
@@ -46,6 +46,18 @@ class TestConf(PandasTest):
                     pd.read_csv(str(data_directory / 'awards_players.csv')),
                     npartitions=NPARTITIONS,
                 ),
+                'json_t': pd.DataFrame(
+                    {
+                        "js": [
+                            '{"a": [1,2,3,4], "b": 1}',
+                            '{"a":null,"b":2}',
+                            '{"a":"foo", "c":null}',
+                            "null",
+                            "[42,47,55]",
+                            "[]",
+                        ]
+                    }
+                ),
             }
         )
 

--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -16,6 +16,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
     # returned_timestamp_unit = 'ns'
     bool_is_int = True
     supports_structs = False
+    supports_json = False
 
     @staticmethod
     def connect(data_directory: Path):

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -33,6 +33,7 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
     supports_divide_by_zero = True
     returned_timestamp_unit = 's'
     supports_structs = False
+    supports_json = False
 
     @staticmethod
     def _load_data(data_dir: Path, script_dir: Path, **_: Any) -> None:

--- a/ibis/backends/mysql/compiler.py
+++ b/ibis/backends/mysql/compiler.py
@@ -31,6 +31,7 @@ class MySQLExprTranslator(AlchemyExprTranslator):
     )
     _bool_aggs_need_cast_to_int32 = False
     integer_to_timestamp = sa.func.from_unixtime
+    native_json_type = False
 
 
 rewrites = MySQLExprTranslator.rewrites

--- a/ibis/backends/mysql/registry.py
+++ b/ibis/backends/mysql/registry.py
@@ -169,6 +169,16 @@ def _find_in_set(t, op):
     )
 
 
+def _json_get_item(t, op):
+    arg = t.translate(op.arg)
+    index = t.translate(op.index)
+    if isinstance(op.index.output_dtype, dt.Integer):
+        path = "$[" + sa.cast(index, sa.TEXT) + "]"
+    else:
+        path = "$." + index
+    return sa.func.json_extract(arg, path)
+
+
 operation_registry.update(
     {
         ops.Literal: _literal,
@@ -211,5 +221,6 @@ operation_registry.update(
         ops.GroupConcat: _group_concat,
         ops.DayOfWeekIndex: _day_of_week_index,
         ops.DayOfWeekName: _day_of_week_name,
+        ops.JSONGetItem: _json_get_item,
     }
 )

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from typing import Any

--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -1,5 +1,6 @@
 """The pandas client implementation."""
 
+import json
 from collections.abc import Mapping, Sequence
 
 import numpy as np
@@ -300,6 +301,19 @@ def convert_struct_to_dict(_, out_dtype, column):
 @sch.convert.register(np.dtype, dt.Array, pd.Series)
 def convert_array_to_series(in_dtype, out_dtype, column):
     return column.map(lambda x: x if x is None else list(x))
+
+
+@sch.convert.register(np.dtype, dt.JSON, pd.Series)
+def convert_json_to_series(in_, out, col: pd.Series):
+    def try_json(x):
+        if x is None:
+            return x
+        try:
+            return json.loads(x)
+        except (TypeError, json.JSONDecodeError):
+            return x
+
+    return pd.Series(list(map(try_json, col)), dtype="object")
 
 
 dt.DataType.to_pandas = ibis_dtype_to_pandas  # type: ignore

--- a/ibis/backends/pandas/execution/constants.py
+++ b/ibis/backends/pandas/execution/constants.py
@@ -42,6 +42,7 @@ IBIS_TYPE_TO_PANDAS_TYPE: Dict[dt.DataType, Union[Type, str]] = {
     dt.timestamp: 'datetime64[ns]',
     dt.boolean: np.bool_,
     dt.category: 'category',
+    dt.json: str,
 }
 
 

--- a/ibis/backends/pandas/tests/conftest.py
+++ b/ibis/backends/pandas/tests/conftest.py
@@ -46,6 +46,18 @@ class TestConf(BackendTest, RoundHalfToEven):
                         ]
                     }
                 ),
+                'json_t': pd.DataFrame(
+                    {
+                        "js": [
+                            '{"a": [1,2,3,4], "b": 1}',
+                            '{"a":null,"b":2}',
+                            '{"a":"foo", "c":null}',
+                            "null",
+                            "[42,47,55]",
+                            "[]",
+                        ]
+                    }
+                ),
                 'array_types': pd.DataFrame(
                     [
                         (

--- a/ibis/backends/postgres/tests/test_json.py
+++ b/ibis/backends/postgres/tests/test_json.py
@@ -9,11 +9,10 @@ import ibis
 
 @pytest.mark.parametrize('data', [param({'status': True}, id='status')])
 def test_json(data, alltypes):
-    json_value = json.dumps(data)
-    lit = ibis.literal(json_value, type='json').name('tmp')
+    lit = ibis.literal(json.dumps(data), type='json').name('tmp')
     expr = alltypes[[alltypes.id, lit]].head(1)
     df = expr.execute()
-    assert df['tmp'].iloc[0] == json_value
+    assert df['tmp'].iloc[0] == data
 
 
 @pytest.mark.parametrize('data', [param({'status': True}, id='status')])

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1890,3 +1890,14 @@ def compile_bitwise_xor(t, op, **kwargs):
 def compile_bitwise_not(t, op, **kwargs):
     arg = t.translate(op.arg, **kwargs)
     return F.bitwise_not(arg)
+
+
+@compiles(ops.JSONGetItem)
+def compile_json_getitem(t, op, **kwargs):
+    arg = t.translate(op.arg, **kwargs)
+    index = t.translate(op.index, raw=True, **kwargs)
+    if isinstance(op.index.output_dtype, dt.Integer):
+        path = f"$[{index}]"
+    else:
+        path = f"$.{index}"
+    return F.get_json_object(arg, path)

--- a/ibis/backends/pyspark/datatypes.py
+++ b/ibis/backends/pyspark/datatypes.py
@@ -79,6 +79,7 @@ def spark_struct_dtype_to_ibis_dtype(spark_dtype_obj, nullable=True):
 _IBIS_DTYPE_TO_SPARK_DTYPE = {
     v: k for k, v in _SPARK_DTYPE_TO_IBIS_DTYPE.items()
 }
+_IBIS_DTYPE_TO_SPARK_DTYPE[dt.JSON] = pt.StringType
 
 spark_dtype = functools.singledispatch('spark_dtype')
 # from multipledispatch import Dispatcher

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from datetime import datetime, timezone
 
@@ -227,6 +229,22 @@ def get_common_spark_testing_client(data_directory, connect):
         )
     )
     df_udf_random.createOrReplaceTempView('udf_random')
+
+    df_json_t = s.createDataFrame(
+        pd.DataFrame(
+            {
+                "js": [
+                    '{"a": [1,2,3,4], "b": 1}',
+                    '{"a":null,"b":2}',
+                    '{"a":"foo", "c":null}',
+                    "null",
+                    "[42,47,55]",
+                    "[]",
+                ]
+            }
+        )
+    )
+    df_json_t.createOrReplaceTempView("json_t")
 
     return _spark_testing_client
 

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -72,6 +72,7 @@ class BackendTest(abc.ABC):
     supports_floating_modulus = True
     bool_is_int = False
     supports_structs = True
+    supports_json = True
 
     def __init__(self, data_directory: Path) -> None:
         self.connection = self.connect(data_directory)
@@ -180,6 +181,15 @@ class BackendTest(abc.ABC):
             pytest.xfail(
                 f"{self.name()} backend does not support struct types"
             )
+
+    @property
+    def json_t(self) -> Optional[ir.Table]:
+        from ibis import _
+
+        if self.supports_json:
+            return self.connection.table("json_t").mutate(js=_.js.cast("json"))
+        else:
+            pytest.xfail(f"{self.name()} backend does not support json types")
 
     @property
     def api(self):

--- a/ibis/backends/tests/test_json.py
+++ b/ibis/backends/tests/test_json.py
@@ -1,0 +1,39 @@
+"""Tests for JSON operations."""
+
+import pandas as pd
+import pytest
+from pytest import param
+
+
+@pytest.mark.notimpl(["datafusion", "pyspark"])
+@pytest.mark.notyet(["clickhouse"], reason="upstream is broken")
+@pytest.mark.never(["impala"], reason="doesn't support JSON and never will")
+@pytest.mark.parametrize(
+    ("expr_fn", "expected"),
+    [
+        param(
+            lambda t: t.js["a"].name("res"),
+            pd.Series(
+                [[1, 2, 3, 4], None, "foo", None, None, None],
+                name="res",
+                dtype="object",
+            ),
+            id="getitem_object",
+            marks=[pytest.mark.min_server_version(sqlite="3.38.0")],
+        ),
+        param(
+            lambda t: t.js[1].name("res"),
+            pd.Series(
+                [None, None, None, None, 47, None],
+                dtype="object",
+                name="res",
+            ),
+            marks=[pytest.mark.min_server_version(sqlite="3.38.0")],
+            id="getitem_array",
+        ),
+    ],
+)
+def test_json_getitem(backend, json_t, expr_fn, expected):
+    expr = expr_fn(json_t)
+    result = expr.execute()
+    backend.assert_series_equal(result, expected)

--- a/ibis/expr/operations/__init__.py
+++ b/ibis/expr/operations/__init__.py
@@ -4,6 +4,7 @@ from ibis.expr.operations.core import *  # noqa: F401,F403
 from ibis.expr.operations.generic import *  # noqa: F401,F403
 from ibis.expr.operations.geospatial import *  # noqa: F401,F403
 from ibis.expr.operations.histograms import *  # noqa: F401,F403
+from ibis.expr.operations.json import *  # noqa: F401,F403
 from ibis.expr.operations.logical import *  # noqa: F401,F403
 from ibis.expr.operations.maps import *  # noqa: F401,F403
 from ibis.expr.operations.numeric import *  # noqa: F401,F403

--- a/ibis/expr/operations/json.py
+++ b/ibis/expr/operations/json.py
@@ -1,0 +1,15 @@
+from public import public
+
+import ibis.expr.datatypes as dt
+import ibis.expr.rules as rlz
+from ibis.expr.operations import Value
+
+
+@public
+class JSONGetItem(Value):
+    arg = rlz.json
+
+    index = rlz.one_of((rlz.string, rlz.integer))
+
+    output_dtype = dt.json
+    output_shape = rlz.shape_like("args")

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -292,6 +292,7 @@ time = value(dt.time)
 timestamp = value(dt.Timestamp)
 category = value(dt.category)
 temporal = one_of([timestamp, date, time])
+json = value(dt.json)
 
 strict_numeric = one_of([integer, floating, decimal])
 soft_numeric = one_of([integer, floating, decimal, boolean])

--- a/ibis/expr/types/json.py
+++ b/ibis/expr/types/json.py
@@ -1,34 +1,36 @@
 from public import public
 
-from ibis.expr.types.binary import BinaryColumn, BinaryScalar, BinaryValue
-from ibis.expr.types.strings import StringColumn, StringScalar, StringValue
+from ibis.expr.types import Column, Scalar, Value
 
 
 @public
-class JSONValue(StringValue):
+class JSONValue(Value):
+    def __getitem__(self, key):
+        import ibis.expr.operations as ops
+
+        return ops.JSONGetItem(self, key).to_expr()
+
+
+@public
+class JSONScalar(Scalar, JSONValue):
     pass  # noqa: E701,E302
 
 
 @public
-class JSONScalar(StringScalar, JSONValue):
+class JSONColumn(Column, JSONValue):
     pass  # noqa: E701,E302
 
 
 @public
-class JSONColumn(StringColumn, JSONValue):
+class JSONBValue(Value):
     pass  # noqa: E701,E302
 
 
 @public
-class JSONBValue(BinaryValue):
+class JSONBScalar(Scalar, JSONBValue):
     pass  # noqa: E701,E302
 
 
 @public
-class JSONBScalar(BinaryScalar, JSONBValue):
-    pass  # noqa: E701,E302
-
-
-@public
-class JSONBColumn(BinaryColumn, JSONBValue):
+class JSONBColumn(Column, JSONBValue):
     pass  # noqa: E701,E302


### PR DESCRIPTION
This PR adds the ability to extract object values or array elements of a JSON-typed column.

Notable things:

- ClickHouse support for this is experimental, and doesn't seem to work in ClickHouse itself and is also broken/unsupported in `clickhouse_driver`.
- PySpark works, but since we're not handling result conversion at all really the test fails.
- The SQLAlchemy backends basically all "just work", the main differences being how the `JSON` type is return in Python. We handle this here by trying to parse the JSON and if that fails assuming the value is already deserialized.