### PR TITLE
perf: fix join performance by avoiding Projection construction

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -12,7 +12,6 @@ import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common.exceptions import IbisTypeError, IntegrityError
-from ibis.expr.operations.relations import Projection
 from ibis.expr.rules import Shape
 from ibis.expr.window import window
 
@@ -612,7 +611,7 @@ def _find_projections(node):
     if isinstance(node, ops.Selection):
         # remove predicates and sort_keys, so that child tables are considered
         # equivalent even if their predicates and sort_keys are not
-        return lin.proceed, Projection(node.table, node.selections)
+        return lin.proceed, node._projection
     elif isinstance(node, ops.SelfReference):
         return lin.proceed, node
     elif isinstance(node, ops.Join):

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -378,6 +378,10 @@ class Selection(Projection):
 
         return Selection(self, [], sort_keys=keys)
 
+    @immutable_property
+    def _projection(self):
+        return Projection(self.table, self.selections)
+
 
 @public
 class Aggregation(TableNode):


### PR DESCRIPTION
This avoids the large number of repeated traversals on construction.
