### PR TITLE
fix(api): allow arbitrary sort keys

### DIFF
--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -134,12 +134,7 @@ def sort_key_from(table_ref, key, **kwargs):
         key, order = key, True
 
     key = one_of(
-        (
-            function_of(table_ref),
-            column_from(table_ref),
-            column(any),
-            instance_of(ops.RandomScalar),
-        ),
+        (function_of(table_ref), column_from(table_ref), any),
         key,
         **kwargs,
     )

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -216,12 +216,15 @@ class Table(Expr):
 
     def _ensure_expr(self, expr):
         if isinstance(expr, str):
+            # treat strings as column names
             return self[expr]
         elif isinstance(expr, (int, np.integer)):
+            # treat Python integers as a column index
             return self[self.schema().name_at_position(expr)]
         elif isinstance(expr, Deferred):
+            # resolve deferred expressions
             return expr.resolve(self)
-        elif not isinstance(expr, Expr):
+        elif callable(expr):
             return expr(self)
         else:
             return expr


### PR DESCRIPTION
This PR allows arbitrary expression in sort keys. One use case is working around snowflakes requirement that a window with a frame specification has an order by key even if it is not strictly necessary. These cases will come up in the future and we should just allow any expression instead of arbitrarily restricting things.