### PR TITLE
feat(api): implement `__array__`

### DIFF
--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -107,6 +107,13 @@ def selection(op):
     return plan
 
 
+@translate.register(ops.Limit)
+def limit(op):
+    if op.offset:
+        raise NotImplementedError("DataFusion does not support offset")
+    return translate(op.table).limit(op.n)
+
+
 @translate.register(ops.Aggregation)
 def aggregation(op):
     table = translate(op.table)

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -2,7 +2,6 @@ import pytest
 from pytest import param
 
 import ibis
-import ibis.common.exceptions as exc
 
 
 def test_backend_name(backend):
@@ -73,7 +72,6 @@ def test_tables_accessor_tab_completion(con):
     assert 'functional_alltypes' in keys
 
 
-@pytest.mark.notimpl(["datafusion"], raises=exc.OperationNotDefinedError)
 @pytest.mark.parametrize(
     "expr_fn",
     [

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -513,6 +513,9 @@ class Scalar(Value):
 
 @public
 class Column(Value):
+    def __array__(self):
+        return self.execute().__array__()
+
     def _repr_html_(self) -> str | None:
         if not ibis.options.interactive:
             return None

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -83,6 +83,9 @@ def _regular_join_method(
 
 @public
 class Table(Expr):
+    def __array__(self):
+        return self.execute().__array__()
+
     def __contains__(self, name):
         return name in self.schema()
 


### PR DESCRIPTION
This PR adds an implementation of `__array__` for `Column` and `Table` expressions.

There's hardly any code here, but this gives the ability to plot ibis expressions **out of the box**.

Here's an example:

![image](https://user-images.githubusercontent.com/417981/191493230-dd4762b5-e025-4ce1-943a-ed47c02e3336.png)

which yields this plot:

![image](https://user-images.githubusercontent.com/417981/191493253-949f1370-32ae-43b7-9b0a-5959c11c1722.png)