### PR TITLE
ci: allow `bq load` to fail

### DIFF
--- a/.github/workflows/ci-data.yml
+++ b/.github/workflows/ci-data.yml
@@ -53,12 +53,18 @@ jobs:
 
           yesterday="${{ steps.set_date.outputs.yesterday }}"
 
+          bucket="gs://ibis-workflow-data/${yesterday}"
+          gsutil cp -Z workflows.json jobs.json "${bucket}"
+
+          set +e
+
+          exit_code=0
           for table in workflows jobs; do
-            gsuri="gs://ibis-workflow-data/${yesterday}/${table}.json"
-            gsutil cp -Z "${table}.json" "${gsuri}"
-            bq load \
-              --autodetect=true \
-              --source_format=NEWLINE_DELIMITED_JSON \
-              "workflows_native.${table}" \
-              "${gsuri}"
+            bq load --autodetect=true --source_format=NEWLINE_DELIMITED_JSON \
+              "workflows_native.${table}" "${bucket}/${table}.json"
+            if [ -n "$?" ]; then
+              ((++exit_code))
+            fi
           done
+
+          exit "$exit_code"


### PR DESCRIPTION
The GCS Insert workflow is currently failing due to a bigquery schema mismatch. The way the shell script is written does not allow the data to be inserted into gcs regardless of whether it can be successfully inserted into BigQuery. This PR allows for that.