### PR TITLE
fix: auto-register csv and parquet with duckdb using `ibis.connect`

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -760,4 +760,6 @@ def _(filename: str, **kwargs: Any) -> BaseBackend:
     >>> con = ibis.connect("relative/path/to/data.csv")
     >>> con = ibis.connect("relative/path/to/more/data.parquet")
     """
-    return _connect(f"duckdb:///{filename}", **kwargs)
+    con = ibis.duckdb.connect()
+    con.register(filename)
+    return con

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -499,6 +499,22 @@ def test_connect_file_url(url, tmp_db):
 
 @pytest.mark.duckdb
 @pytest.mark.parametrize(
+    "out_method, extension",
+    [
+        ("to_csv", "csv"),
+        ("to_parquet", "parquet"),
+    ],
+)
+def test_connect_local_file(
+    out_method, extension, test_employee_data_1, tmp_path
+):
+    getattr(test_employee_data_1, out_method)(tmp_path / f"out.{extension}")
+    con = ibis.connect(tmp_path / f"out.{extension}")
+    assert con.list_tables()
+
+
+@pytest.mark.duckdb
+@pytest.mark.parametrize(
     "read_only",
     [
         param("True", marks=[not_windows], id="duckdb_read_only_upper"),


### PR DESCRIPTION
Need to add some tests and this is less elegant, but works.

Fix #4548 