### PR TITLE
fix: truncate columns in repr for wide tables

### DIFF
--- a/ibis/tests/expr/test_interactive.py
+++ b/ibis/tests/expr/test_interactive.py
@@ -51,13 +51,13 @@ def test_repr_png_is_not_none_in_not_interactive(con):
 
 
 def test_default_limit(con):
-    table = con.table('functional_alltypes')
+    table = con.table('functional_alltypes').select("id", "bool_col")
 
     with config.option_context('interactive', True):
         repr(table)
 
     expected = """\
-SELECT *
+SELECT `id`, `bool_col`
 FROM functional_alltypes
 LIMIT 11"""
 
@@ -65,13 +65,13 @@ LIMIT 11"""
 
 
 def test_respect_set_limit(con):
-    table = con.table('functional_alltypes').limit(10)
+    table = con.table('functional_alltypes').select("id", "bool_col").limit(10)
 
     with config.option_context('interactive', True):
         repr(table)
 
     expected = """\
-SELECT *
+SELECT `id`, `bool_col`
 FROM functional_alltypes
 LIMIT 10"""
 
@@ -79,14 +79,14 @@ LIMIT 10"""
 
 
 def test_disable_query_limit(con):
-    table = con.table('functional_alltypes')
+    table = con.table('functional_alltypes').select("id", "bool_col")
 
     with config.option_context('interactive', True):
         with config.option_context('sql.default_limit', None):
             repr(table)
 
     expected = """\
-SELECT *
+SELECT `id`, `bool_col`
 FROM functional_alltypes
 LIMIT 11"""
 


### PR DESCRIPTION
By default `rich` will decrease the size of columns until they're unreadable to make all columns fit in repr. This PR attempts to fix that by adding a trailing `...` column to indicate there are more columns to the right, and truncating the number of columns displayed to only those whose column names can be completely rendered (we set `min_width=len(column_name)` for every column).

This also switches to using horizontal ellipsis (`…`) everywhere instead of vertical ellipsis. Vertical ellipsis mess with the alignment in non-terminal rendering (e.g. copy-paste the output into a code block comment in github), while horizontal ellipsis don't have this problem.

Example:

```python
In [1]: import ibis

In [2]: con = ibis.duckdb.connect()

In [3]: ibis.options.interactive = True

In [4]: import numpy as np, pandas as pd

In [5]: df = pd.DataFrame({f"col_{i}": np.random.normal(size=100) for i in range(20)})

In [6]: t = con.register(df)

In [7]: t
Out[7]: 
┏━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━┓
┃ col_0 ┃ col_1 ┃ col_2 ┃ col_3 ┃ col_4 ┃ col_5 ┃ col_6 ┃ col_7 ┃ col_8 ┃ col_9 ┃ col_10 ┃ … ┃
┡━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━┩
│ floa… │ floa… │ floa… │ floa… │ floa… │ floa… │ floa… │ floa… │ floa… │ floa… │ float… │ … │
├───────┼───────┼───────┼───────┼───────┼───────┼───────┼───────┼───────┼───────┼────────┼───┤
│ -0.0… │ 0.87… │ 0.23… │ -2.9… │ 0.69… │ 0.89… │ -0.4… │ -0.7… │ 0.37… │ 0.46… │ 1.474… │ … │
│ 0.10… │ -0.3… │ -0.8… │ 0.13… │ -1.1… │ 1.73… │ -0.3… │ -0.7… │ 1.38… │ 0.31… │ -0.73… │ … │
│ 0.63… │ 1.87… │ 1.29… │ 0.32… │ -0.9… │ -0.3… │ -0.9… │ -1.2… │ -0.2… │ 0.21… │ 1.146… │ … │
│ 0.77… │ 2.04… │ 0.93… │ 0.73… │ 0.63… │ 0.52… │ 0.01… │ -0.5… │ -1.6… │ 1.94… │ -0.37… │ … │
│ -0.3… │ 1.22… │ 0.61… │ -0.1… │ 0.06… │ -0.6… │ 0.63… │ 0.26… │ -0.0… │ 0.26… │ -0.79… │ … │
│ 0.08… │ -0.5… │ 1.24… │ 1.68… │ -0.7… │ -1.2… │ -0.3… │ -0.2… │ -2.3… │ -0.9… │ -0.92… │ … │
│ -1.3… │ 1.44… │ 0.44… │ 1.29… │ -0.9… │ 0.55… │ -0.2… │ 1.26… │ 2.35… │ 1.96… │ -0.88… │ … │
│ 0.42… │ -1.8… │ 1.54… │ 0.20… │ -1.0… │ -0.2… │ -1.3… │ 0.04… │ 1.05… │ 0.23… │ -1.19… │ … │
│ 0.14… │ 0.36… │ -1.3… │ 1.84… │ -0.4… │ 0.52… │ -0.8… │ 0.70… │ -0.4… │ -0.1… │ 0.160… │ … │
│ -0.6… │ -0.6… │ 0.12… │ -1.5… │ 0.09… │ 1.74… │ 0.77… │ -0.0… │ -1.0… │ -0.1… │ -0.69… │ … │
│   …   │   …   │   …   │   …   │   …   │   …   │   …   │   …   │   …   │   …   │   …    │ … │
└───────┴───────┴───────┴───────┴───────┴───────┴───────┴───────┴───────┴───────┴────────┴───┘
```