### PR TITLE
fix: ensure numpy ops dont accidentally cast ibis types

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -513,6 +513,11 @@ class Scalar(Value):
 
 @public
 class Column(Value):
+    # Higher than numpy & dask objects
+    __array_priority__ = 20
+
+    __array_ufunc__ = None
+
     def __array__(self):
         return self.execute().__array__()
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -83,6 +83,11 @@ def _regular_join_method(
 
 @public
 class Table(Expr):
+    # Higher than numpy & dask objects
+    __array_priority__ = 20
+
+    __array_ufunc__ = None
+
     def __array__(self):
         return self.execute().__array__()
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -2,6 +2,7 @@ import datetime
 import pickle
 import re
 
+import numpy as np
 import pandas as pd
 import pytest
 from pytest import param
@@ -1580,3 +1581,11 @@ def test_default_backend_with_unbound_table():
         match="Expression contains unbound tables",
     ):
         assert expr.execute()
+
+
+def test_numpy_ufuncs_dont_cast_tables():
+    t = ibis.table(dict.fromkeys("abcd", "int"))
+    for arg in [np.int64(1), np.array([1, 2, 3])]:
+        for left, right in [(t, arg), (arg, t)]:
+            with pytest.raises(TypeError):
+                left + right


### PR DESCRIPTION
This fixes a small bug introduced in #4547. That PR added an `__array__` method, which lets users pass ibis columns and tables to functions expecting array-like objects, and have those implicitly work.

However, defining only `__array__` means that `numpy` will happily convert ibis types to numpy types when used in larger arithmetic expressions. We _could_ make this work by properly defining `__array_ufunc__`, but that's a bit tricky. Instead we define:

- `__array_priority__` to something higher than numpy (0) & dask priorities (11)
- `__array_ufunc__ = None` to disable the array-ufunc protocol.

Doing this means that:

- numpy scalar + ibis type works as before, no accidental computation
- numpy array + ibis type errors with a `TypeError`, rather than implicitly computing