### PR TITLE
fix(clickhouse): ensure that correlated subqueries' columns can be referenced

### DIFF
--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -532,8 +532,13 @@ def _table_column(translator, op):
     # If the column does not originate from the table set in the current SELECT
     # context, we should format as a subquery
     if translator.permit_subquery and ctx.is_foreign_expr(table):
-        proj_expr = table.projection([field_name]).to_array()
-        return _table_array_view(translator, proj_expr)
+        proj = ops.TableArrayView(
+            ops.Selection(
+                table=table,
+                selections=[field_name],
+            )
+        )
+        return _table_array_view(translator, proj)
 
     if ctx.need_aliases():
         alias = ctx.get_ref(table)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -806,3 +806,8 @@ def test_interactive(alltypes):
         repr(expr)
     finally:
         ibis.options.interactive = orig
+
+
+def test_correlated_subquery(alltypes):
+    expr = alltypes[_.double_col > _.view().double_col]
+    assert expr.compile() is not None


### PR DESCRIPTION
This PR fixes a bug in the clickhouse compiler leftover from The Great Refactor.