### PR TITLE
chore: include refactoring in release notes

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -24,7 +24,7 @@ module.exports = {
             { type: "chore", hidden: true },
             { type: "docs", section: "Documentation" },
             { type: "style", hidden: true },
-            { type: "refactor", hidden: true },
+            { type: "refactor", section: "Refactors" },
             { type: "perf", section: "Performance" },
             { type: "test", hidden: true },
             { type: "depr", section: "Deprecations" },


### PR DESCRIPTION
This PR adds a `# Refactors` section to the release notes, at least for 4.0.0, since there are a number of important changes there that should be categorized and shown publicly for maximum visibility
