### PR TITLE
fix: pandas/dask now cast int<->timestamp as seconds since epoch

### DIFF
--- a/ibis/backends/dask/tests/execution/test_cast.py
+++ b/ibis/backends/dask/tests/execution/test_cast.py
@@ -77,7 +77,7 @@ def test_cast_timestamp_column(t, df, column, to, expected):
     ('to', 'expected'),
     [
         ('string', str),
-        ('int64', lambda x: x.value),
+        ('int64', lambda x: x.value // int(1e9)),
         param(
             'double',
             float,
@@ -101,7 +101,7 @@ def test_cast_timestamp_scalar_naive(to, expected):
     ('to', 'expected'),
     [
         ('string', str),
-        ('int64', lambda x: x.value),
+        ('int64', lambda x: x.value // int(1e9)),
         param('double', float, marks=pytest.mark.notimpl(["dask"])),
         (
             dt.Timestamp('America/Los_Angeles'),

--- a/ibis/backends/dask/tests/execution/test_temporal.py
+++ b/ibis/backends/dask/tests/execution/test_temporal.py
@@ -105,7 +105,7 @@ def test_cast_integer_to_temporal_type(t, df, column):
     df_computed = df.compute()
     expected = dd.from_pandas(
         pd.Series(
-            pd.to_datetime(df_computed.plain_int64.values, unit='ns').values,
+            pd.to_datetime(df_computed.plain_int64.values, unit='s').values,
             index=df_computed.index,
             name='plain_int64',
         ).dt.tz_localize(column_type.timezone),

--- a/ibis/backends/pandas/tests/execution/test_cast.py
+++ b/ibis/backends/pandas/tests/execution/test_cast.py
@@ -89,7 +89,7 @@ def test_cast_timestamp_column(t, df, column, to, expected):
     ('to', 'expected'),
     [
         ('string', str),
-        ('int64', lambda x: x.value),
+        ('int64', lambda x: x.value // int(1e9)),
         param(
             'double',
             float,
@@ -113,7 +113,7 @@ def test_cast_timestamp_scalar_naive(to, expected):
     ('to', 'expected'),
     [
         ('string', str),
-        ('int64', lambda x: x.value),
+        ('int64', lambda x: x.value // int(1e9)),
         param(
             'double',
             float,

--- a/ibis/backends/pandas/tests/execution/test_temporal.py
+++ b/ibis/backends/pandas/tests/execution/test_temporal.py
@@ -93,7 +93,7 @@ def test_cast_integer_to_temporal_type(t, df, column):
     expr = t.plain_int64.cast(column_type)
     result = expr.execute()
     expected = pd.Series(
-        pd.to_datetime(df.plain_int64.values, unit='ns').values,
+        pd.to_datetime(df.plain_int64.values, unit='s').values,
         index=df.index,
         name='plain_int64',
     ).dt.tz_localize(column_type.timezone)

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -922,15 +922,19 @@ def test_timestamp_extract_milliseconds_with_big_value(con):
 
 
 @pytest.mark.notimpl(["bigquery", "datafusion", "mssql"])
-@pytest.mark.broken(
-    ["dask", "pandas"],
-    reason="Pandas and Dask interpret integers as nanoseconds since epoch",
-)
-def test_integer_cast_to_timestamp(backend, alltypes, df):
+def test_integer_cast_to_timestamp_column(backend, alltypes, df):
     expr = alltypes.int_col.cast("timestamp")
     expected = pd.to_datetime(df.int_col, unit="s").rename(expr.get_name())
     result = expr.execute()
     backend.assert_series_equal(result, expected)
+
+
+@pytest.mark.notimpl(["datafusion", "pyspark", "mssql"])
+def test_integer_cast_to_timestamp_scalar(backend, alltypes, df):
+    expr = alltypes.int_col.min().cast("timestamp")
+    result = expr.execute()
+    expected = pd.to_datetime(df.int_col.min(), unit="s")
+    assert result == expected
 
 
 @pytest.mark.broken(


### PR DESCRIPTION
The Pandas and Dask backends now interpret casting ints to/from timestamps as seconds since the unix epoch, matching other backends.

Fixes #4062.