### PR TITLE
ci(impala): remove special casing of python version in CI

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -68,6 +68,16 @@ jobs:
               - postgres
             sys-deps:
               - libgeos-dev
+          - name: impala
+            title: Impala
+            services:
+              - impala
+              - kudu
+            sys-deps:
+              - cmake
+              - ninja-build
+              - krb5-config
+              - libkrb5-dev
         exclude:
           - os: windows-latest
             backend:
@@ -81,33 +91,9 @@ jobs:
           - os: windows-latest
             backend:
               name: postgres
-        include:
-          - os: ubuntu-latest
-            python-version: "3.8"
+          - os: windows-latest
             backend:
               name: impala
-              title: Impala
-              services:
-                - impala
-                - kudu
-              sys-deps:
-                - cmake
-                - ninja-build
-                - krb5-config
-                - libkrb5-dev
-          - os: ubuntu-latest
-            python-version: "3.9"
-            backend:
-              name: impala
-              title: Impala
-              services:
-                - impala
-                - kudu
-              sys-deps:
-                - cmake
-                - ninja-build
-                - krb5-config
-                - libkrb5-dev
     steps:
       - name: update and install system dependencies
         if: ${{ matrix.os == 'ubuntu-latest' && matrix.backend.sys-deps != null }}


### PR DESCRIPTION
Impyla now supports python 3.10, so we can remove the special case in CI and run the impala tests with python 3.10 same as the other backends.