### PR TITLE
depr: deprecate `Table.sort_by` in favor of `Table.order_by`

### DIFF
--- a/docs/example.py
+++ b/docs/example.py
@@ -17,5 +17,5 @@ expr = (
         ),
     )
     .mutate(acq_rate=lambda t: t.acq_ipos / t.num_investments)
-    .sort_by(ibis.desc(2))
+    .order_by(ibis.desc(2))
 )

--- a/docs/ibis-for-sql-programmers.ipynb
+++ b/docs/ibis-for-sql-programmers.ipynb
@@ -1016,7 +1016,7 @@
    "source": [
     "## Sorting / `ORDER BY`\n",
     "\n",
-    "To sort a table, use the `sort_by` method along with either column names\n",
+    "To sort a table, use the `order_by` method along with either column names\n",
     "or expressions that indicate the sorting keys:"
    ]
   },
@@ -1037,7 +1037,7 @@
     }
    ],
    "source": [
-    "sorted = events.sort_by([events.ts.year(), events.ts.month()])\n",
+    "sorted = events.order_by([events.ts.year(), events.ts.month()])\n",
     "\n",
     "print(ibis.impala.compile(sorted))"
    ]
@@ -1070,7 +1070,7 @@
     }
    ],
    "source": [
-    "sorted = events.sort_by(\n",
+    "sorted = events.order_by(\n",
     "    [ibis.desc('event_type'), (events.ts.month(), False)]\n",
     ").limit(100)\n",
     "\n",

--- a/docs/tutorial/01-Introduction-to-Ibis.ipynb
+++ b/docs/tutorial/01-Introduction-to-Ibis.ipynb
@@ -472,7 +472,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we want to find the most populated countries in Asia. To obtain them, we are going to sort the countries by the column `population`, and just fetch the first 10. To sort by a column in Ibis, we can use the `.sort_by()` method:"
+    "Next, we want to find the most populated countries in Asia. To obtain them, we are going to sort the countries by the column `population`, and just fetch the first 10. To sort by a column in Ibis, we can use the `.order_by()` method:"
    ]
   },
   {
@@ -502,14 +502,14 @@
     }
    ],
    "source": [
-    "asian_countries.sort_by('population').limit(10)"
+    "asian_countries.order_by('population').limit(10)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This will return the least populated countries, since `.sort_by` will by default order in ascending order (ascending order like in `1, 2, 3, 4`). This behavior is consistent with SQL `ORDER BY`.\n",
+    "This will return the least populated countries, since `.order_by` will by default order in ascending order (ascending order like in `1, 2, 3, 4`). This behavior is consistent with SQL `ORDER BY`.\n",
     "\n",
     "To order in descending order we can use `ibis.desc()`:"
    ]
@@ -541,7 +541,7 @@
     }
    ],
    "source": [
-    "asian_countries.sort_by(ibis.desc('population')).limit(10)"
+    "asian_countries.order_by(ibis.desc('population')).limit(10)"
    ]
   },
   {

--- a/docs/tutorial/04-More-Value-Expressions.ipynb
+++ b/docs/tutorial/04-More-Value-Expressions.ipynb
@@ -365,7 +365,7 @@
    "outputs": [],
    "source": [
     "expr = countries.name.lower().left(1).name('first_letter')\n",
-    "expr.value_counts().sort_by(('count', False)).limit(10)"
+    "expr.value_counts().order_by(('count', False)).limit(10)"
    ]
   },
   {

--- a/docs/tutorial/07-Analytics-Tools.ipynb
+++ b/docs/tutorial/07-Analytics-Tools.ipynb
@@ -200,7 +200,7 @@
     "    ['< 1M', '> 1M', '> 10M', '> 100M', '> 1B']\n",
     ").name('bucket_name')\n",
     "\n",
-    "expr = bucket_counts[labeled_bucket, bucket_counts].sort_by('bucket')\n",
+    "expr = bucket_counts[labeled_bucket, bucket_counts].order_by('bucket')\n",
     "expr"
    ]
   },

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -141,7 +141,7 @@ class SelectBuilder:
         self.having = None
         self.filters = []
         self.limit = None
-        self.sort_by = []
+        self.order_by = []
         self.subqueries = []
         self.distinct = False
 
@@ -213,7 +213,7 @@ class SelectBuilder:
             group_by=self.group_by,
             having=self.having,
             limit=self.limit,
-            order_by=self.sort_by,
+            order_by=self.order_by,
             distinct=self.distinct,
             result_handler=self.result_handler,
             parent_op=self.op,
@@ -424,7 +424,7 @@ class SelectBuilder:
             self.select_set = sub_op.by + sub_op.metrics
             self.table_set = sub_op.table
             self.filters = sub_op.predicates
-            self.sort_by = sub_op.sort_keys
+            self.order_by = sub_op.sort_keys
 
             self._collect(op.table)
 
@@ -445,7 +445,7 @@ class SelectBuilder:
                 # select *
                 selections = [table]
 
-            self.sort_by = sort_keys
+            self.order_by = sort_keys
             self.select_set = selections
             self.table_set = table
             self.filters = filters

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -581,7 +581,7 @@ def struct(backend):
 
 @pytest.fixture(scope='session')
 def sorted_alltypes(alltypes):
-    return alltypes.sort_by('id')
+    return alltypes.order_by('id')
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/dask/tests/execution/conftest.py
+++ b/ibis/backends/dask/tests/execution/conftest.py
@@ -293,7 +293,7 @@ def sel_cols(batting):
 
 @pytest.fixture(scope='module')
 def players_base(batting, sel_cols):
-    return batting[sel_cols].sort_by(sel_cols[:3])
+    return batting[sel_cols].order_by(sel_cols[:3])
 
 
 @pytest.fixture(scope='module')

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -506,8 +506,8 @@ def test_series_limit(t, df, offset):
     'column',
     ['plain_datetimes_naive', 'plain_datetimes_ny', 'plain_datetimes_utc'],
 )
-def test_sort_by(t, df, column, key, dask_by, dask_ascending):
-    expr = t.sort_by(key(t, column))
+def test_order_by(t, df, column, key, dask_by, dask_ascending):
+    expr = t.order_by(key(t, column))
     result = expr.compile()
     expected = (
         df.compute()
@@ -518,8 +518,8 @@ def test_sort_by(t, df, column, key, dask_by, dask_ascending):
 
 
 @pytest.mark.xfail(reason="TODO - sorting - #2553")
-def test_complex_sort_by(t, df):
-    expr = t.sort_by(
+def test_complex_order_by(t, df):
+    expr = t.order_by(
         [ibis.desc(t.plain_int64 * t.plain_float64), t.plain_float64]
     )
     result = expr.compile()

--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -382,7 +382,7 @@ def test_temp_table_concurrency(con, test_data_dir):
 
     def limit(con, hdfs_path, offset):
         t = con.parquet_file(hdfs_path)
-        return t.sort_by(t.r_regionkey).limit(1, offset=offset).execute()
+        return t.order_by(t.r_regionkey).limit(1, offset=offset).execute()
 
     nthreads = multiprocessing.cpu_count()
     hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')

--- a/ibis/backends/pandas/tests/execution/conftest.py
+++ b/ibis/backends/pandas/tests/execution/conftest.py
@@ -296,7 +296,7 @@ def sel_cols(batting):
 
 @pytest.fixture(scope='module')
 def players_base(batting, sel_cols):
-    return batting[sel_cols].sort_by(sel_cols[:3])
+    return batting[sel_cols].order_by(sel_cols[:3])
 
 
 @pytest.fixture(scope='module')

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -371,8 +371,8 @@ def test_series_limit(t, df, offset):
     'column',
     ['plain_datetimes_naive', 'plain_datetimes_ny', 'plain_datetimes_utc'],
 )
-def test_sort_by(t, df, column, key, pandas_by, pandas_ascending):
-    expr = t.sort_by(key(t, column))
+def test_order_by(t, df, column, key, pandas_by, pandas_ascending):
+    expr = t.order_by(key(t, column))
     result = expr.execute()
     expected = df.sort_values(
         pandas_by(column), ascending=pandas_ascending
@@ -380,8 +380,8 @@ def test_sort_by(t, df, column, key, pandas_by, pandas_ascending):
     tm.assert_frame_equal(result[expected.columns], expected)
 
 
-def test_complex_sort_by(t, df):
-    expr = t.sort_by(
+def test_complex_order_by(t, df):
+    expr = t.order_by(
         [ibis.desc(t.plain_int64 * t.plain_float64), t.plain_float64]
     )
     result = expr.execute()

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -305,7 +305,7 @@ def test_batting_quantile(players, players_df):
 @pytest.mark.parametrize('op', ['sum', 'mean', 'min', 'max'])
 def test_batting_specific_cumulative(batting, batting_df, op, sort_kind):
     ibis_method = methodcaller(f'cum{op}')
-    expr = ibis_method(batting.sort_by([batting.yearID]).G)
+    expr = ibis_method(batting.order_by([batting.yearID]).G)
     result = expr.execute().astype('float64')
 
     pandas_method = methodcaller(op)
@@ -816,7 +816,7 @@ def test_bfill(events):
     expr = (
         grouped.group_by([grouped.event_id, grouped.grouper])
         .mutate(bfill=grouped.measurement.max())
-        .sort_by("measured_on")
+        .order_by("measured_on")
     )
     result = expr.execute().reset_index(drop=True)
 

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -916,7 +916,7 @@ def test_analytic_shift_functions(alltypes, df, func, shift_amount):
     ('func', 'expected_index'), [('first', -1), ('last', 0)]
 )
 def test_first_last_value(alltypes, df, func, expected_index):
-    col = alltypes.sort_by(ibis.desc(alltypes.string_col)).double_col
+    col = alltypes.order_by(ibis.desc(alltypes.string_col)).double_col
     method = getattr(col, func)
     expr = method()
     result = expr.execute().rename('double_col')

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -409,7 +409,7 @@ def test_union(alltypes):
     expr = (
         t.group_by('string_col')
         .aggregate(t.double_col.sum().name('foo'))
-        .sort_by('string_col')
+        .order_by('string_col')
     )
 
     t1 = expr.limit(4)
@@ -585,7 +585,7 @@ def test_filter(alltypes, df):
     'column', [lambda t: 'float_col', lambda t: t['float_col']]
 )
 def test_column_access_after_sort(alltypes, df, column):
-    expr = alltypes.sort_by(column(alltypes)).head(10).string_col
+    expr = alltypes.order_by(column(alltypes)).head(10).string_col
     result = expr.execute()
     expected = (
         df.sort_values('float_col').string_col.head(10).reset_index(drop=True)
@@ -750,13 +750,13 @@ def test_compile_twice(dbpath):
     con1 = ibis.sqlite.connect(dbpath)
     t1 = con1.table('batting')
     sort_key1 = ibis.desc(t1.playerID)
-    sorted_table1 = t1.sort_by(sort_key1)
+    sorted_table1 = t1.order_by(sort_key1)
     expr1 = sorted_table1.count()
 
     con2 = ibis.sqlite.connect(dbpath)
     t2 = con2.table('batting')
     sort_key2 = ibis.desc(t2.playerID)
-    sorted_table2 = t2.sort_by(sort_key2)
+    sorted_table2 = t2.order_by(sort_key2)
     expr2 = sorted_table2.count()
 
     result1 = str(expr1.compile())
@@ -768,7 +768,7 @@ def test_compile_twice(dbpath):
 def test_count_on_order_by(con):
     t = con.table("batting")
     sort_key = ibis.desc(t.playerID)
-    sorted_table = t.sort_by(sort_key)
+    sorted_table = t.order_by(sort_key)
     expr = sorted_table.count()
     result = str(
         expr.compile().compile(compile_kwargs={'literal_binds': True})

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -546,7 +546,7 @@ def test_approx_median(alltypes):
                 .aggregate(
                     tmp=lambda t: t.string_col.group_concat(sep, where=where)
                 )
-                .sort_by('bigint_col')
+                .order_by('bigint_col')
             ),
             lambda t, where, sep: (
                 (
@@ -634,7 +634,7 @@ def test_topk_op(alltypes, df, result_fn, expected_fn):
     # can have different result for that.
     # Note: Maybe would be good if TopK could order by "count"
     # and the field used by TopK
-    t = alltypes.sort_by(alltypes.string_col)
+    t = alltypes.order_by(alltypes.string_col)
     df = df.sort_values('string_col')
     result = result_fn(t).execute()
     expected = expected_fn(df)
@@ -661,7 +661,7 @@ def test_topk_filter_op(alltypes, df, result_fn, expected_fn):
     # can have different result for that.
     # Note: Maybe would be good if TopK could order by "count"
     # and the field used by TopK
-    t = alltypes.sort_by(alltypes.string_col)
+    t = alltypes.order_by(alltypes.string_col)
     df = df.sort_values('string_col')
     expr = result_fn(t)
     result = expr.execute()
@@ -765,7 +765,7 @@ def test_binds_are_cast(alltypes):
 
 def test_agg_sort(alltypes):
     query = alltypes.aggregate(count=alltypes.count())
-    query = query.sort_by(alltypes.year)
+    query = query.order_by(alltypes.year)
     query.execute()
 
 

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -245,7 +245,7 @@ def test_unnest_complex(con):
         .mutate(x=lambda t: t.x.unnest())
         .groupby("grouper")
         .aggregate(count_flat=lambda t: t.x.count())
-        .sort_by("grouper")
+        .order_by("grouper")
     )
     expected = (
         df[["grouper", "x"]]
@@ -277,7 +277,7 @@ def test_unnest_idempotent(con):
         array_types.select(["scalar_column", array_types.x.unnest().name("x")])
         .group_by("scalar_column")
         .aggregate(x=lambda t: t.x.collect())
-        .sort_by("scalar_column")
+        .order_by("scalar_column")
     )
     result = expr.execute()
     expected = df[["scalar_column", "x"]]
@@ -293,7 +293,7 @@ def test_unnest_no_nulls(con):
         .filter(lambda t: t.y.notnull())
         .group_by("scalar_column")
         .aggregate(x=lambda t: t.y.collect())
-        .sort_by("scalar_column")
+        .order_by("scalar_column")
     )
     result = expr.execute()
     expected = (

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -737,7 +737,7 @@ FROM \\w+ AS \\1"""
 
 
 def test_dunder_array_table(alltypes, df):
-    expr = alltypes.group_by("string_col").int_col.sum().sort_by("string_col")
+    expr = alltypes.group_by("string_col").int_col.sum().order_by("string_col")
     result = np.array(expr)
     expected = np.array(
         df.groupby("string_col")
@@ -750,7 +750,7 @@ def test_dunder_array_table(alltypes, df):
 
 @pytest.mark.broken(["dask"], reason="Dask backend duplicates data")
 def test_dunder_array_column(alltypes, df):
-    expr = alltypes.sort_by("id").head(10).int_col
+    expr = alltypes.order_by("id").head(10).int_col
     result = np.array(expr)
     expected = df.sort_values(["id"]).head(10).int_col
     np.testing.assert_array_equal(result, expected)

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -82,7 +82,7 @@ def test_dot_sql_with_join(backend, con):
             ON l.s = r.s
             """
         )
-        .sort_by(["s", "yas"])
+        .order_by(["s", "yas"])
     )
 
     alltypes_df = alltypes.execute()

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -138,14 +138,14 @@ def test_coalesce(con, expr, expected):
 # TODO(dask) - identicalTo - #2553
 @pytest.mark.notimpl(["clickhouse", "datafusion", "dask", "pyspark"])
 def test_identical_to(backend, alltypes, sorted_df):
-    sorted_alltypes = alltypes.sort_by('id')
+    sorted_alltypes = alltypes.order_by('id')
     df = sorted_df
     dt = df[['tinyint_col', 'double_col']]
 
     ident = sorted_alltypes.tinyint_col.identical_to(
         sorted_alltypes.double_col
     )
-    expr = sorted_alltypes['id', ident.name('tmp')].sort_by('id')
+    expr = sorted_alltypes['id', ident.name('tmp')].order_by('id')
     result = expr.execute().tmp
 
     expected = (dt.tinyint_col.isnull() & dt.double_col.isnull()) | (
@@ -168,10 +168,10 @@ def test_identical_to(backend, alltypes, sorted_df):
     ],
 )
 def test_isin(backend, alltypes, sorted_df, column, elements):
-    sorted_alltypes = alltypes.sort_by('id')
+    sorted_alltypes = alltypes.order_by('id')
     expr = sorted_alltypes[
         'id', sorted_alltypes[column].isin(elements).name('tmp')
-    ].sort_by('id')
+    ].order_by('id')
     result = expr.execute().tmp
 
     expected = sorted_df[column].isin(elements)
@@ -191,10 +191,10 @@ def test_isin(backend, alltypes, sorted_df, column, elements):
     ],
 )
 def test_notin(backend, alltypes, sorted_df, column, elements):
-    sorted_alltypes = alltypes.sort_by('id')
+    sorted_alltypes = alltypes.order_by('id')
     expr = sorted_alltypes[
         'id', sorted_alltypes[column].notin(elements).name('tmp')
-    ].sort_by('id')
+    ].order_by('id')
     result = expr.execute().tmp
 
     expected = ~sorted_df[column].isin(elements)
@@ -233,8 +233,8 @@ def test_notin(backend, alltypes, sorted_df, column, elements):
     ],
 )
 def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
-    sorted_alltypes = alltypes.sort_by('id')
-    table = sorted_alltypes[predicate_fn(sorted_alltypes)].sort_by('id')
+    sorted_alltypes = alltypes.order_by('id')
+    table = sorted_alltypes[predicate_fn(sorted_alltypes)].order_by('id')
     result = table.execute()
     expected = sorted_df[expected_fn(sorted_df)]
 
@@ -254,10 +254,10 @@ def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
     ]
 )
 def test_filter_with_window_op(backend, alltypes, sorted_df):
-    sorted_alltypes = alltypes.sort_by('id')
+    sorted_alltypes = alltypes.order_by('id')
     table = sorted_alltypes
     window = ibis.window(group_by=table.id)
-    table = table.filter(lambda t: t['id'].mean().over(window) > 3).sort_by(
+    table = table.filter(lambda t: t['id'].mean().over(window) > 3).order_by(
         'id'
     )
     result = table.execute()
@@ -428,7 +428,7 @@ def test_dropna_table(backend, alltypes, how, subset):
 
 def test_select_sort_sort(alltypes):
     query = alltypes[alltypes.year, alltypes.bool_col]
-    query = query.sort_by(query.year).sort_by(query.bool_col)
+    query = query.order_by(query.year).order_by(query.bool_col)
 
 
 @pytest.mark.parametrize(
@@ -459,8 +459,8 @@ def test_select_sort_sort(alltypes):
         ),
     ],
 )
-def test_sort_by(backend, alltypes, df, key, df_kwargs):
-    result = alltypes.filter(_.id < 100).sort_by(key).execute()
+def test_order_by(backend, alltypes, df, key, df_kwargs):
+    result = alltypes.filter(_.id < 100).order_by(key).execute()
     expected = df.loc[df.id < 100].sort_values(**df_kwargs)
     backend.assert_frame_equal(result, expected)
 
@@ -470,8 +470,8 @@ def test_sort_by(backend, alltypes, df, key, df_kwargs):
     ["clickhouse"],
     reason="clickhouse doesn't have a [0.0, 1.0) random implementation",
 )
-def test_sort_by_random(alltypes):
-    expr = alltypes.filter(_.id < 100).sort_by(ibis.random()).limit(5)
+def test_order_by_random(alltypes):
+    expr = alltypes.filter(_.id < 100).order_by(ibis.random()).limit(5)
     r1 = expr.execute()
     r2 = expr.execute()
     assert len(r1) == 5
@@ -569,7 +569,7 @@ def test_isin_notin(backend, alltypes, df, ibis_op, pandas_op):
     ],
 )
 def test_isin_notin_column_expr(backend, alltypes, df, ibis_op, pandas_op):
-    expr = alltypes[ibis_op].sort_by("id")
+    expr = alltypes[ibis_op].order_by("id")
     expected = df[pandas_op(df)].sort_values(["id"]).reset_index(drop=True)
     result = expr.execute()
     backend.assert_frame_equal(result, expected)

--- a/ibis/backends/tests/test_set_ops.py
+++ b/ibis/backends/tests/test_set_ops.py
@@ -27,7 +27,7 @@ def union_subsets(alltypes, df):
 def test_union(backend, union_subsets, distinct):
     (a, b, c), (da, db, dc) = union_subsets
 
-    expr = ibis.union(a, b, c, distinct=distinct).sort_by("id")
+    expr = ibis.union(a, b, c, distinct=distinct).order_by("id")
     result = expr.execute()
 
     expected = (
@@ -45,7 +45,7 @@ def test_union(backend, union_subsets, distinct):
 def test_union_mixed_distinct(backend, union_subsets):
     (a, b, c), (da, db, dc) = union_subsets
 
-    expr = a.union(b, distinct=True).union(c, distinct=False).sort_by("id")
+    expr = a.union(b, distinct=True).union(c, distinct=False).order_by("id")
     result = expr.execute()
     expected = pd.concat(
         [pd.concat([da, db], axis=0).drop_duplicates("id"), dc], axis=0
@@ -81,7 +81,7 @@ def test_intersect(backend, alltypes, df, distinct):
     db = df[(5205 <= df.id) & (df.id <= 5215)]
     dc = df[(5195 <= df.id) & (df.id <= 5208)]
 
-    expr = ibis.intersect(a, b, c, distinct=distinct).sort_by("id")
+    expr = ibis.intersect(a, b, c, distinct=distinct).order_by("id")
     result = expr.execute()
 
     index = da.index.intersection(db.index).intersection(dc.index)
@@ -119,7 +119,7 @@ def test_difference(backend, alltypes, df, distinct):
     db = df[(5205 <= df.id) & (df.id <= 5215)]
     dc = df[(5195 <= df.id) & (df.id <= 5202)]
 
-    expr = ibis.difference(a, b, c, distinct=distinct).sort_by("id")
+    expr = ibis.difference(a, b, c, distinct=distinct).order_by("id")
     result = expr.execute()
 
     index = da.index.difference(db.index).difference(dc.index)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -493,7 +493,7 @@ def desc(expr: ir.Column | str) -> ir.Value:
     --------
     >>> import ibis
     >>> t = ibis.table(dict(g='string'), name='t')
-    >>> t.group_by('g').size('count').sort_by(ibis.desc('count'))
+    >>> t.group_by('g').size('count').order_by(ibis.desc('count'))
     r0 := UnboundTable: t
       g string
     r1 := Aggregation[r0]
@@ -530,7 +530,7 @@ def asc(expr: ir.Column | str) -> ir.Value:
     --------
     >>> import ibis
     >>> t = ibis.table(dict(g='string'), name='t')
-    >>> t.group_by('g').size('count').sort_by(ibis.asc('count'))
+    >>> t.group_by('g').size('count').order_by(ibis.asc('count'))
     r0 := UnboundTable: t
       g string
     r1 := Aggregation[r0]

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -26,7 +26,7 @@ def genname():
 
 @public
 class TableNode(Node):
-    def sort_by(self, sort_exprs):
+    def order_by(self, sort_exprs):
         return Selection(self, [], sort_keys=sort_exprs)
 
     @property
@@ -362,7 +362,7 @@ class Selection(Projection):
             **kwargs,
         )
 
-    def sort_by(self, sort_exprs):
+    def order_by(self, sort_exprs):
         from ibis.expr.analysis import shares_all_roots
 
         keys = rlz.tuple_of(rlz.sort_key_from(rlz.just(self)), sort_exprs)
@@ -484,7 +484,7 @@ class Aggregation(TableNode):
 
         return sch.Schema(names, types)
 
-    def sort_by(self, sort_exprs):
+    def order_by(self, sort_exprs):
         from ibis.expr.analysis import shares_all_roots
 
         keys = rlz.tuple_of(rlz.sort_key_from(rlz.just(self)), sort_exprs)

--- a/ibis/expr/types/analytic.py
+++ b/ibis/expr/types/analytic.py
@@ -79,7 +79,7 @@ class TopK(Analytic):
                 'Cross-table TopK; must provide a parent joined table'
             )
 
-        return agg.sort_by([(by.name, False)]).limit(op.k)
+        return agg.order_by([(by.name, False)]).limit(op.k)
 
 
 public(AnalyticExpr=Analytic, TopKExpr=TopK)

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -513,18 +513,36 @@ class Table(Expr):
         | tuple[str | ir.Column, bool]
         | Sequence[tuple[str | ir.Column, bool]],
     ) -> Table:
-        """Sort table by `sort_exprs`
+        """Deprecated.
+
+        Use `order_by` instead.
+        """
+        warnings.warn(
+            "`Table.sort_by` is deprecated and will be removed in version "
+            "5.0, use `Table.order_by` instead",
+            FutureWarning,
+        )
+        return self.order_by(sort_exprs)
+
+    def order_by(
+        self,
+        by: str
+        | ir.Column
+        | tuple[str | ir.Column, bool]
+        | Sequence[tuple[str | ir.Column, bool]],
+    ) -> Table:
+        """Sort a table by one or more expressions.
 
         Parameters
         ----------
-        sort_exprs
-            Sort specifications
+        by:
+            An expression (or expressions) to sort the table by.
 
         Examples
         --------
         >>> import ibis
         >>> t = ibis.table(dict(a='int64', b='string'))
-        >>> t.sort_by(['a', ibis.desc('b')])
+        >>> t.order_by(['a', ibis.desc('b')])
         r0 := UnboundTable: unbound_table_0
           a int64
           b string
@@ -538,13 +556,13 @@ class Table(Expr):
         Table
             Sorted table
         """
-        if isinstance(sort_exprs, tuple):
-            sort_exprs = [sort_exprs]
-        elif sort_exprs is None:
-            sort_exprs = []
+        if isinstance(by, tuple):
+            by = [by]
+        elif by is None:
+            by = []
         else:
-            sort_exprs = util.promote_list(sort_exprs)
-        return self.op().sort_by(sort_exprs).to_expr()
+            by = util.promote_list(by)
+        return self.op().order_by(by).to_expr()
 
     def union(self, *tables: Table, distinct: bool = False) -> Table:
         """Compute the set union of multiple table expressions.

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -238,19 +238,21 @@ def multikey_group_by_with_mutate(t):
 
 
 def simple_sort(t):
-    return t.sort_by([t.key])
+    return t.order_by([t.key])
 
 
 def simple_sort_projection(t):
-    return t[['key', 'value']].sort_by(['key'])
+    return t[['key', 'value']].order_by(['key'])
 
 
 def multikey_sort(t):
-    return t.sort_by(['low_card_key', 'key'])
+    return t.order_by(['low_card_key', 'key'])
 
 
 def multikey_sort_projection(t):
-    return t[['low_card_key', 'key', 'value']].sort_by(['low_card_key', 'key'])
+    return t[['low_card_key', 'key', 'value']].order_by(
+        ['low_card_key', 'key']
+    )
 
 
 def low_card_rolling_window(t):
@@ -490,7 +492,7 @@ def tpc_h02(part, supplier, partsupp, nation, region):
         ]
     )
 
-    return q.sort_by(
+    return q.order_by(
         [
             ibis.desc(q.s_acctbal),
             q.n_name,

--- a/ibis/tests/expr/test_format.py
+++ b/ibis/tests/expr/test_format.py
@@ -127,7 +127,7 @@ def test_memoize_insert_sort_key(con):
         dest_avg=t.arrdelay.mean(), dev=t.arrdelay - t.arrdelay.mean()
     )
 
-    worst = expr[expr.dev.notnull()].sort_by(ibis.desc('dev')).limit(10)
+    worst = expr[expr.dev.notnull()].order_by(ibis.desc('dev')).limit(10)
 
     result = repr(worst)
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -344,14 +344,15 @@ def test_limit(table):
     assert limited.op().offset == 5
 
 
-def test_sort_by(table):
-    # Commit to some API for ascending and descending
-    #
-    # table.sort_by(['g', expr1, desc(expr2), desc(expr3)])
-    #
-    # Default is ascending for anything coercable to an expression,
-    # and we'll have ascending/descending wrappers to help.
-    result = table.sort_by(['f']).op()
+def test_sort_by_deprecated(table):
+    with pytest.warns(FutureWarning):
+        x = table.sort_by("f")
+    y = table.order_by("f")
+    assert x.equals(y)
+
+
+def test_order_by(table):
+    result = table.order_by(['f']).op()
 
     sort_key = result.sort_keys[0]
 
@@ -359,12 +360,12 @@ def test_sort_by(table):
     assert sort_key.ascending
 
     # non-list input. per #150
-    result2 = table.sort_by('f').op()
+    result2 = table.order_by('f').op()
     assert_equal(result, result2)
 
-    result2 = table.sort_by([('f', False)])
-    result3 = table.sort_by([('f', 'descending')])
-    result4 = table.sort_by([('f', 0)])
+    result2 = table.order_by([('f', False)])
+    result3 = table.order_by([('f', 'descending')])
+    result4 = table.order_by([('f', 0)])
 
     key2 = result2.op().sort_keys[0]
     key3 = result3.op().sort_keys[0]
@@ -376,23 +377,23 @@ def test_sort_by(table):
     assert_equal(result2, result3)
 
 
-def test_sort_by_desc_deferred_sort_key(table):
-    result = table.group_by('g').size().sort_by(ibis.desc('count'))
+def test_order_by_desc_deferred_sort_key(table):
+    result = table.group_by('g').size().order_by(ibis.desc('count'))
 
     tmp = table.group_by('g').size()
-    expected = tmp.sort_by((tmp['count'], False))
-    expected2 = tmp.sort_by(ibis.desc(tmp['count']))
+    expected = tmp.order_by((tmp['count'], False))
+    expected2 = tmp.order_by(ibis.desc(tmp['count']))
 
     assert_equal(result, expected)
     assert_equal(result, expected2)
 
 
-def test_sort_by_asc_deferred_sort_key(table):
-    result = table.group_by('g').size().sort_by(ibis.asc('count'))
+def test_order_by_asc_deferred_sort_key(table):
+    result = table.group_by('g').size().order_by(ibis.asc('count'))
 
     tmp = table.group_by('g').size()
-    expected = tmp.sort_by(tmp['count'])
-    expected2 = tmp.sort_by(ibis.asc(tmp['count']))
+    expected = tmp.order_by(tmp['count'])
+    expected2 = tmp.order_by(ibis.asc(tmp['count']))
 
     assert_equal(result, expected)
     assert_equal(result, expected2)
@@ -408,8 +409,8 @@ def test_sort_by_asc_deferred_sort_key(table):
         param(L([1, 2, 3]), L([1, 2, 3]).op(), id="array"),
     ],
 )
-def test_sort_by_scalar(table, key, expected):
-    result = table.sort_by(key)
+def test_order_by_scalar(table, key, expected):
+    result = table.order_by(key)
     assert result.op().sort_keys == ops.NodeList(ops.SortKey(expected))
 
 
@@ -1289,23 +1290,23 @@ def test_filter(table):
     assert_equal(result, expected)
 
 
-def test_sort_by2(table):
+def test_order_by2(table):
     m = table.mutate(foo=table.e + table.f)
 
-    result = m.sort_by(lambda x: -x.foo)
-    expected = m.sort_by(-m.foo)
+    result = m.order_by(lambda x: -x.foo)
+    expected = m.order_by(-m.foo)
     assert_equal(result, expected)
 
-    result = m.sort_by(lambda x: ibis.desc(x.foo))
-    expected = m.sort_by(ibis.desc('foo'))
+    result = m.order_by(lambda x: ibis.desc(x.foo))
+    expected = m.order_by(ibis.desc('foo'))
     assert_equal(result, expected)
 
-    result = m.sort_by(ibis.desc(lambda x: x.foo))
-    expected = m.sort_by(ibis.desc('foo'))
+    result = m.order_by(ibis.desc(lambda x: x.foo))
+    expected = m.order_by(ibis.desc('foo'))
     assert_equal(result, expected)
 
-    result = m.sort_by(ibis.asc(lambda x: x.foo))
-    expected = m.sort_by('foo')
+    result = m.order_by(ibis.asc(lambda x: x.foo))
+    expected = m.order_by('foo')
     assert_equal(result, expected)
 
 

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -884,7 +884,7 @@ def test_bitwise_exprs(fn, expected_op):
     'expr_func',
     [
         lambda t, args: t[args],
-        lambda t, args: t.sort_by(args),
+        lambda t, args: t.order_by(args),
         lambda t, args: t.group_by(args).aggregate(bar_avg=t.bar.mean()),
     ],
 )

--- a/ibis/tests/expr/test_visualize.py
+++ b/ibis/tests/expr/test_visualize.py
@@ -98,10 +98,10 @@ def test_join(how):
     assert key(result.op()) in graph.source
 
 
-def test_sort_by():
+def test_order_by():
     t = ibis.table([('a', 'int64'), ('b', 'string'), ('c', 'int32')])
     expr = (
-        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).sort_by('b')
+        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).order_by('b')
     )
     graph = viz.to_graph(expr)
     assert key(expr.op()) in graph.source
@@ -114,7 +114,7 @@ def test_sort_by():
 def test_optional_graphviz_repr(with_graphviz):
     t = ibis.table([('a', 'int64'), ('b', 'string'), ('c', 'int32')])
     expr = (
-        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).sort_by('b')
+        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).order_by('b')
     )
 
     # default behavior

--- a/ibis/tests/sql/test_select_sql.py
+++ b/ibis/tests/sql/test_select_sql.py
@@ -16,8 +16,8 @@ def test_select_sql(alltypes, star1, star2):
         agg_string_columns=lambda t=star1: t.aggregate(
             [t['f'].sum().name('total')], ['foo_id', 'bar_id']
         ),
-        single_column=lambda t=star1: t.sort_by("f"),
-        mixed_columns_ascending=lambda t=star1: t.sort_by(["c", ("f", 0)]),
+        single_column=lambda t=star1: t.order_by("f"),
+        mixed_columns_ascending=lambda t=star1: t.order_by(["c", ("f", 0)]),
         limit_simple=lambda t=star1: t.limit(10),
         limit_with_offset=lambda t=star1: t.limit(10, offset=5),
         filter_then_limit=lambda t=star1: t[t.f > 0].limit(10),
@@ -56,7 +56,7 @@ def test_simple_joins(star1, star2):
 
 
 @sqlgolden
-def multiple_joins(con, star1, star2, star3):
+def test_multiple_joins(con, star1, star2, star3):
     t1 = star1
     t2 = star2
     t3 = star3
@@ -161,7 +161,7 @@ def test_bug_duplicated_where(airlines):
     )
 
     tmp1 = expr[expr.dev.notnull()]
-    tmp2 = tmp1.sort_by(ibis.desc('dev'))
+    tmp2 = tmp1.order_by(ibis.desc('dev'))
     return tmp2.limit(10)
 
 
@@ -446,22 +446,22 @@ def test_filter_inside_exists():
 
 
 @sqlgolden
-def sort_by_on_limit_yield_subquery(functional_alltypes):
-    # x.limit(...).sort_by(...)
+def test_order_by_on_limit_yield_subquery(functional_alltypes):
+    # x.limit(...).order_by(...)
     #   is semantically different from
-    # x.sort_by(...).limit(...)
+    # x.order_by(...).limit(...)
     #   and will often yield different results
     t = functional_alltypes
     return (
         t.group_by('string_col')
         .aggregate([t.count().name('nrows')])
         .limit(5)
-        .sort_by('string_col')
+        .order_by('string_col')
     )
 
 
 @sqlgolden
-def join_with_limited_table(star1, star2):
+def test_join_with_limited_table(star1, star2):
     limited = star1.limit(100)
     return limited.inner_join(star2, [limited.foo_id == star2.foo_id])[
         [limited]

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -434,28 +434,28 @@ def test_aggregate(con, star1, sa_star1, expr_fn, expected_fn):
     ("expr_fn", "expected_fn"),
     [
         pytest.param(
-            lambda t: t.sort_by("f"),
+            lambda t: t.order_by("f"),
             lambda b: sa.select([b]).order_by(b.c.f.asc()),
-            id="sort_by",
+            id="order_by",
         ),
         pytest.param(
-            lambda t: t.sort_by(("f", 0)),
+            lambda t: t.order_by(("f", 0)),
             lambda b: sa.select([b]).order_by(b.c.f.desc()),
-            id="sort_by_ascending",
+            id="order_by_ascending",
         ),
         pytest.param(
-            lambda t: t.sort_by(["c", ("f", 0)]),
+            lambda t: t.order_by(["c", ("f", 0)]),
             lambda b: sa.select([b]).order_by(b.c.c.asc(), b.c.f.desc()),
-            id="sort_by_mixed",
+            id="order_by_mixed",
         ),
         pytest.param(
-            lambda t: t.sort_by(ibis.random()),
+            lambda t: t.order_by(ibis.random()),
             lambda b: sa.select([b]).order_by(sa.func.random().asc()),
-            id="sort_by_random",
+            id="order_by_random",
         ),
     ],
 )
-def test_sort_by(con, star1, sa_star1, expr_fn, expected_fn):
+def test_order_by(con, star1, sa_star1, expr_fn, expected_fn):
     st = sa_star1.alias("t0")
     expr = expr_fn(star1)
     expected = expected_fn(st)
@@ -654,7 +654,7 @@ def test_lower_projection_sort_key(con, star1, star2):
         t0.c.total.desc()
     )
 
-    expr2 = expr[expr.total > 100].sort_by(ibis.desc('total'))
+    expr2 = expr[expr.total > 100].order_by(ibis.desc('total'))
     _check(expr2, expected)
     return expr2
 
@@ -756,7 +756,7 @@ def test_sort_aggregation_translation_failure(
     t = functional_alltypes
 
     agg = t.group_by('string_col').aggregate(t.double_col.max().name('foo'))
-    expr = agg.sort_by(ibis.desc('foo'))
+    expr = agg.order_by(ibis.desc('foo'))
 
     sat = sa_functional_alltypes.alias("t1")
     base = (
@@ -1121,7 +1121,7 @@ def h11():
     gq = q.group_by([q.ps_partkey])
     q = gq.aggregate(value=(q.ps_supplycost * q.ps_availqty).sum())
     q = q.filter([q.value > innerq.total * FRACTION])
-    q = q.sort_by(ibis.desc(q.value))
+    q = q.order_by(ibis.desc(q.value))
     return q
 
 

--- a/ibis/tests/sqlgolden/test_join_with_limited_table.sql
+++ b/ibis/tests/sqlgolden/test_join_with_limited_table.sql
@@ -1,0 +1,8 @@
+SELECT t0.*
+FROM (
+  SELECT *
+  FROM star1
+  LIMIT 100
+) t0
+  INNER JOIN star2 t1
+    ON t0.`foo_id` = t1.`foo_id`

--- a/ibis/tests/sqlgolden/test_multiple_joins.sql
+++ b/ibis/tests/sqlgolden/test_multiple_joins.sql
@@ -1,0 +1,10 @@
+SELECT *, `value1`, t1.`value2`
+FROM (
+  SELECT t2.`c`, t2.`f`, t2.`foo_id` AS `foo_id_x`, t2.`bar_id`,
+         t3.`foo_id` AS `foo_id_y`, t3.`value1`, t3.`value3`
+  FROM star1 t2
+    LEFT OUTER JOIN star2 t3
+      ON t2.`foo_id` = t3.`foo_id`
+) t0
+  INNER JOIN star3 t1
+    ON `bar_id` = t1.`bar_id`

--- a/ibis/tests/sqlgolden/test_order_by_on_limit_yield_subquery.sql
+++ b/ibis/tests/sqlgolden/test_order_by_on_limit_yield_subquery.sql
@@ -1,0 +1,8 @@
+SELECT *
+FROM (
+  SELECT `string_col`, count(1) AS `nrows`
+  FROM functional_alltypes
+  GROUP BY 1
+  LIMIT 5
+) t0
+ORDER BY `string_col` ASC


### PR DESCRIPTION
Fixes #4518.