### PR TITLE
ci: remove snowsql, clickhouse from shell.nix; remove venv caching in snowflake CI

### DIFF
--- a/.github/workflows/ibis-snowflake.yml
+++ b/.github/workflows/ibis-snowflake.yml
@@ -43,22 +43,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
-
-      - uses: syphar/restore-pip-download-cache@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
-
       - run: python -m pip install --upgrade pip 'poetry<1.2'
 
-      - name: install ibis with a compatible pyarrow version
-        run: |
-          poetry add pyarrow@'>=8.0.0,<8.1.0' --optional
-          poetry install --extras ${{ matrix.backend.name }}
+      - name: set a compatible pyarrow version
+        run: poetry add pyarrow@'>=8.0.0,<8.1.0' --optional
+
+      - name: install ibis
+        run: poetry install --extras ${{ matrix.backend.name }}
 
       - uses: extractions/setup-just@v1
         env:

--- a/.github/workflows/ibis-snowflake.yml
+++ b/.github/workflows/ibis-snowflake.yml
@@ -9,7 +9,6 @@ on:
       - "mkdocs.yml"
     branches:
       - master
-      - "*.x.x"
 
 permissions:
   # this allows extractions/setup-just to list releases for `just` at a higher

--- a/shell.nix
+++ b/shell.nix
@@ -25,8 +25,7 @@ let
     cmake
     ninja
   ];
-  clickhouseDeps = [ pkgs.clickhouse ];
-  snowflakeDeps = [ pkgs.snowsql pkgs.openssl ];
+  snowflakeDeps = [ pkgs.openssl ];
   backendTestDeps = [ pkgs.docker-compose ];
   vizDeps = [ pkgs.graphviz-nox ];
   duckdbDeps = [ pkgs.duckdb ];
@@ -46,8 +45,7 @@ let
     ++ sqliteDeps
     ++ duckdbDeps
     ++ mysqlDeps
-    ++ snowflakeDeps
-    ++ clickhouseDeps;
+    ++ snowflakeDeps;
 
   pythonShortVersion = builtins.replaceStrings [ "." ] [ "" ] python;
 


### PR DESCRIPTION
This PR removes snowsql from shell.nix. There is no point in dealing with the unfree nature of it in CI since it is meant only for debugging convenience. The clickhouse cli is also removed, because it is huge and never used in CI. To use either or both you can always run `nix-shell -p snowsql -p clickhouse`, even if you are already in a nix-shell. Finally, the virtualenv caching is removed from the snowflake unit tests: since the poetry lockfile must be modified (by installing an older version of pyarrow), there is no point in caching.