### PR TITLE
build: use `./nix` as the source of nixpkgs instead of `nixos-unstable`

### DIFF
--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=channel:nixos-unstable --pure -p git jq nodejs nix -i bash
+#!nix-shell -I nixpkgs=./nix --pure -p git jq nodejs nix -i bash
 # shellcheck shell=bash
 
 set -euo pipefail

--- a/ci/release/prepare.sh
+++ b/ci/release/prepare.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p gnugrep unzip poetry nix -i bash
+#!nix-shell -I nixpkgs=./nix -p gnugrep unzip poetry-cli nix -i bash
 # shellcheck shell=bash
 
 set -euo pipefail

--- a/ci/release/publish.sh
+++ b/ci/release/publish.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure --keep POETRY_PYPI_TOKEN_PYPI -p poetry -i bash
+#!nix-shell -I nixpkgs=./nix --pure --keep POETRY_PYPI_TOKEN_PYPI -p poetry-cli -i bash
 # shellcheck shell=bash
 
 set -euo pipefail

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p cacert poetry git nodejs nix -i bash
+#!nix-shell -I nixpkgs=./nix -p cacert poetry-cli git nodejs nix -i bash
 # shellcheck shell=bash
 
 set -euo pipefail

--- a/ci/release/verify.sh
+++ b/ci/release/verify.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=channel:nixos-unstable --pure --keep POETRY_PYPI_TOKEN_PYPI -p dyff git poetry yj -i bash
+#!nix-shell -I nixpkgs=./nix --pure --keep POETRY_PYPI_TOKEN_PYPI -p dyff git poetry-cli yj -i bash
 # shellcheck shell=bash
 
 set -euo pipefail

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
   ]
 }:
 let
-  pkgs = import ./nix;
+  pkgs = import ./nix { };
   drv =
     { poetry2nix
     , python

--- a/dev/lockfile_diff.sh
+++ b/dev/lockfile_diff.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=channel:nixos-unstable --pure -p dyff git poetry yj -i bash
+#!nix-shell -I nixpkgs=./nix --pure -p dyff git poetry-cli yj -i bash
 # shellcheck shell=bash
 
 set -euo pipefail

--- a/dev/update-lock-files.sh
+++ b/dev/update-lock-files.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=channel:nixos-unstable --pure -p poetry nix -i bash
+#!nix-shell -I nixpkgs=./nix --pure -p poetry-cli nix -i bash
 # shellcheck shell=bash
 set -euo pipefail
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,7 +1,7 @@
 let
   sources = import ./sources.nix;
 in
-import sources.nixpkgs {
+{ ... }@args: import sources.nixpkgs ({
   overlays = [
     (pkgs: _: {
       inherit (import sources."gitignore.nix" {
@@ -16,6 +16,8 @@ import sources.nixpkgs {
         rev = "master";
         sha256 = "sha256-BZWi4kEumZemQeYoAtlUSw922p+R6opSWp/bmX0DjAo=";
       };
+
+      poetry-cli = pkgs.python3Packages.poetry;
 
       mkPoetryEnv = python: pkgs.poetry2nix.mkPoetryEnv {
         inherit python;
@@ -84,4 +86,4 @@ import sources.nixpkgs {
       };
     })
   ];
-}
+} // args)

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { python ? "3.10" }:
 let
-  pkgs = import ./nix;
+  pkgs = import ./nix { };
 
   pythonEnv = pkgs."ibisDevEnv${pythonShortVersion}";
 
@@ -17,7 +17,6 @@ let
     lychee
     # packaging
     niv
-    pythonEnv.pkgs.poetry
   ];
 
   impalaUdfDeps = with pkgs; [
@@ -62,7 +61,7 @@ pkgs.mkShell {
   shellHook = ''
     export IBIS_TEST_DATA_DIRECTORY="$PWD/ci/ibis-testing-data"
 
-    rsync \
+    ${pkgs.rsync}/bin/rsync \
       --chmod=Du+rwx,Fu+rw --archive --delete \
       "${pkgs.ibisTestingData}/" \
       "$IBIS_TEST_DATA_DIRECTORY"
@@ -71,13 +70,13 @@ pkgs.mkShell {
     TEMPDIR="$(python -c 'import tempfile; print(tempfile.gettempdir())')"
   '';
 
-  buildInputs = devDeps ++ libraryDevDeps ++ [
+  nativeBuildInputs = devDeps ++ libraryDevDeps ++ [
     pythonEnv
     updateLockFiles
   ] ++ pkgs.preCommitShell.buildInputs ++ (with pkgs; [
     changelog
     mic
-    rsync
+    poetry-cli
   ]);
 
   PYTHONPATH = builtins.toPath ./.;


### PR DESCRIPTION
This PR should fix the failing `simulate_release` GHA job.