### PR TITLE
test(snowflake): fix `test_export` and skip tests if envar isn't defined

### DIFF
--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -43,7 +43,6 @@ limit = [
                     "impala",
                     "pandas",
                     "pyspark",
-                    "snowflake",
                 ]
             ),
         ],
@@ -61,7 +60,6 @@ no_limit = [
                     "dask",
                     "impala",
                     "pyspark",
-                    "snowflake",
                 ]
             ),
         ],


### PR DESCRIPTION
Fixes failing snowflake tests.