### PR TITLE
depr: deprecate `Table.groupby` alias in favor of `Table.group_by`

### DIFF
--- a/docs/tutorial/06-ComplexFiltering.ipynb
+++ b/docs/tutorial/06-ComplexFiltering.ipynb
@@ -199,7 +199,7 @@
     "    countries.population.sum(where=arctic).name('population arctic countries'),\n",
     "]\n",
     "\n",
-    "(countries.groupby(countries.continent).aggregate(metrics))"
+    "(countries.group_by(countries.continent).aggregate(metrics))"
    ]
   }
  ],

--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -182,7 +182,7 @@ class AlchemySelect(Select):
         frag = self._compile_table_set()
         steps = [
             self._add_select,
-            self._add_groupby,
+            self._add_group_by,
             self._add_where,
             self._add_order_by,
             self._add_limit,
@@ -285,7 +285,7 @@ class AlchemySelect(Select):
         assert num_froms == 1, f"num_froms == {num_froms:d}"
         return replaced
 
-    def _add_groupby(self, fragment):
+    def _add_group_by(self, fragment):
         # GROUP BY and HAVING
         if not len(self.group_by):
             return fragment

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -399,7 +399,7 @@ def test_timestamp_scalar_in_filter(alltypes, translate):
 
 def test_named_from_filter_groupby():
     t = ibis.table([('key', 'string'), ('value', 'double')], name='t0')
-    gb = t.filter(t.value == 42).groupby(t.key)
+    gb = t.filter(t.value == 42).group_by(t.key)
     sum_expr = lambda t: (t.value + 1 + 2 + 3).sum()  # noqa: E731
     expr = gb.aggregate(abc=sum_expr)
     expected = """\

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -254,8 +254,8 @@ def compute_sorted_frame(
 
 def assert_identical_grouping_keys(*args):
     indices = [arg.index for arg in args]
-    # Depending on whether groupby was called like groupby("col") or
-    # groupby(["cold"]) index will be a string or a list
+    # Depending on whether group_by was called like group_by("col") or
+    # group_by(["cold"]) index will be a string or a list
     if isinstance(indices[0], list):
         indices = [tuple(index) for index in indices]
     grouping_keys = set(indices)

--- a/ibis/backends/dask/tests/execution/test_join.py
+++ b/ibis/backends/dask/tests/execution/test_join.py
@@ -318,7 +318,7 @@ def test_join_with_window_function(
     # this should be semi_join
     tbl = batting.left_join(players, ['playerID'])
     t = tbl[batting.G, batting.playerID, batting.teamID]
-    expr = t.groupby(t.teamID).mutate(
+    expr = t.group_by(t.teamID).mutate(
         team_avg=lambda d: d.G.mean(),
         demeaned_by_player=lambda d: d.G - d.G.mean(),
     )

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -224,7 +224,7 @@ def test_group_by_with_having(t, df):
 
 
 def test_group_by_rename_key(t, df):
-    expr = t.groupby(t.dup_strings.name('foo')).aggregate(
+    expr = t.group_by(t.dup_strings.name('foo')).aggregate(
         dup_string_count=t.dup_strings.count()
     )
 
@@ -442,7 +442,7 @@ def test_nullif_inf(npartitions):
 
 
 def test_group_concat(t, df):
-    expr = t.groupby(t.dup_strings).aggregate(
+    expr = t.group_by(t.dup_strings).aggregate(
         foo=t.plain_int64.group_concat(',')
     )
     result = expr.compile()
@@ -565,7 +565,7 @@ def test_table_count(t, df):
 
 
 def test_weighted_average(t, df):
-    expr = t.groupby(t.dup_strings).aggregate(
+    expr = t.group_by(t.dup_strings).aggregate(
         avg=(t.plain_float64 * t.plain_int64).sum() / t.plain_int64.sum()
     )
     result = expr.compile()
@@ -584,7 +584,7 @@ def test_weighted_average(t, df):
 
 
 def test_group_by_multiple_keys(t, df):
-    expr = t.groupby([t.dup_strings, t.dup_ints]).aggregate(
+    expr = t.group_by([t.dup_strings, t.dup_ints]).aggregate(
         avg_plain_float64=t.plain_float64.mean()
     )
     result = expr.compile()
@@ -600,7 +600,7 @@ def test_group_by_multiple_keys(t, df):
 
 
 def test_mutate_after_group_by(t, df):
-    gb = t.groupby(t.dup_strings).aggregate(
+    gb = t.group_by(t.dup_strings).aggregate(
         avg_plain_float64=t.plain_float64.mean()
     )
     expr = gb.mutate(x=gb.avg_plain_float64)
@@ -617,8 +617,8 @@ def test_mutate_after_group_by(t, df):
     )
 
 
-def test_groupby_with_unnamed_arithmetic(t, df):
-    expr = t.groupby(t.dup_strings).aggregate(
+def test_group_by_with_unnamed_arithmetic(t, df):
+    expr = t.group_by(t.dup_strings).aggregate(
         naive_variance=(
             (t.plain_float64**2).sum() - t.plain_float64.mean() ** 2
         )
@@ -680,7 +680,7 @@ def test_notin(t, df, elements):
 
 
 def test_cast_on_group_by(t, df):
-    expr = t.groupby(t.dup_strings).aggregate(
+    expr = t.group_by(t.dup_strings).aggregate(
         casted=(t.float64_with_zeros == 0).cast('int64').sum()
     )
 
@@ -730,7 +730,7 @@ def test_left_binary_op(t, df, op, args):
 )
 @pytest.mark.parametrize('argfunc', [lambda c: (1.0, c), lambda c: (c, 1.0)])
 def test_left_binary_op_gb(t, df, op, argfunc):
-    expr = t.groupby('dup_strings').aggregate(
+    expr = t.group_by('dup_strings').aggregate(
         foo=op(*argfunc(t.float64_with_zeros)).sum()
     )
     result = expr.compile()
@@ -801,7 +801,7 @@ def test_round(t, df):
     raises=NotImplementedError,
     reason="MultiQuantile is not implemented for the dask backend",
 )
-def test_quantile_groupby(batting, batting_df):
+def test_quantile_group_by(batting, batting_df):
     def q_fun(x, quantile, interpolation):
         res = x.quantile(quantile, interpolation=interpolation).tolist()
         return [res for _ in range(len(x))]
@@ -809,7 +809,7 @@ def test_quantile_groupby(batting, batting_df):
     frac = 0.2
     intp = 'linear'
     result = (
-        batting.groupby('teamID')
+        batting.group_by('teamID')
         .mutate(res=lambda x: x.RBI.quantile([frac, 1 - frac], intp))
         .res.compile()
     )
@@ -840,7 +840,7 @@ def test_summary_numeric(batting, batting_df):
 
 
 def test_summary_numeric_group_by(batting, batting_df):
-    expr = batting.groupby('teamID').G.summary()
+    expr = batting.group_by('teamID').G.summary()
     result = expr.execute()
     expected = (
         batting_df.groupby('teamID')
@@ -881,7 +881,7 @@ def test_summary_non_numeric(batting, batting_df):
 
 
 def test_summary_non_numeric_group_by(batting, batting_df):
-    expr = batting.groupby('teamID').playerID.summary()
+    expr = batting.group_by('teamID').playerID.summary()
     result = expr.execute()
     expected = (
         batting_df.groupby('teamID')

--- a/ibis/backends/dask/tests/execution/test_strings.py
+++ b/ibis/backends/dask/tests/execution/test_strings.py
@@ -109,7 +109,7 @@ def test_string_ops(t, df, case_func, expected_func):
 
 
 def test_grouped_string_re_search(t, df):
-    expr = t.groupby(t.dup_strings).aggregate(
+    expr = t.group_by(t.dup_strings).aggregate(
         sum=t.strings_with_space.re_search('(ab)+').cast('int64').sum()
     )
 

--- a/ibis/backends/dask/tests/execution/test_structs.py
+++ b/ibis/backends/dask/tests/execution/test_structs.py
@@ -77,7 +77,7 @@ def test_struct_field_series(struct_table):
 
 def test_struct_field_series_group_by_key(struct_table):
     t = struct_table
-    expr = t.groupby(t.s['fruit']).aggregate(total=t.value.sum())
+    expr = t.group_by(t.s['fruit']).aggregate(total=t.value.sum())
     result = expr.compile()
     expected = dd.from_pandas(
         pd.DataFrame([("apple", 1), ("pear", 5)], columns=["fruit", "total"]),
@@ -88,7 +88,7 @@ def test_struct_field_series_group_by_key(struct_table):
 
 def test_struct_field_series_group_by_value(struct_table):
     t = struct_table
-    expr = t.groupby(t.key).aggregate(total=t.s['weight'].sum())
+    expr = t.group_by(t.key).aggregate(total=t.s['weight'].sum())
     result = expr.compile()
     # these are floats because we have a NULL value in the input data
     expected = dd.from_pandas(

--- a/ibis/backends/dask/tests/test_udf.py
+++ b/ibis/backends/dask/tests/test_udf.py
@@ -183,7 +183,7 @@ def test_multiple_argument_udf(con, t, df):
 
 
 def test_multiple_argument_udf_group_by(con, t, df):
-    expr = t.groupby(t.key).aggregate(my_add=my_add(t.b, t.c).sum())
+    expr = t.group_by(t.key).aggregate(my_add=my_add(t.b, t.c).sum())
 
     assert isinstance(expr, ir.Table)
     assert isinstance(expr.my_add, ir.Column)
@@ -239,7 +239,7 @@ def test_udaf_analytic(con, t, df):
     tm.assert_series_equal(result, expected)
 
 
-def test_udaf_analytic_groupby(con, t, df):
+def test_udaf_analytic_group_by(con, t, df):
     expr = zscore(t.c).over(ibis.window(group_by=t.key))
 
     assert isinstance(expr, ir.Column)
@@ -256,8 +256,8 @@ def test_udaf_analytic_groupby(con, t, df):
     tm.assert_series_equal(result, expected, check_names=False)
 
 
-def test_udaf_groupby(t2, df2):
-    expr = t2.groupby(t2.key).aggregate(my_corr=my_corr(t2.a, t2.b))
+def test_udaf_group_by(t2, df2):
+    expr = t2.group_by(t2.key).aggregate(my_corr=my_corr(t2.a, t2.b))
 
     result = expr.execute().sort_values('key').reset_index(drop=True)
 
@@ -275,8 +275,8 @@ def test_udaf_groupby(t2, df2):
     tm.assert_frame_equal(result, expected)
 
 
-def test_udaf_groupby_multikey(t2, df2):
-    expr = t2.groupby([t2.key, t2.d]).aggregate(my_corr=my_corr(t2.a, t2.b))
+def test_udaf_group_by_multikey(t2, df2):
+    expr = t2.group_by([t2.key, t2.d]).aggregate(my_corr=my_corr(t2.a, t2.b))
 
     result = expr.execute().sort_values('key').reset_index(drop=True)
 
@@ -294,8 +294,8 @@ def test_udaf_groupby_multikey(t2, df2):
     tm.assert_frame_equal(result, expected)
 
 
-def test_udaf_groupby_multikey_tzcol(t_timestamp, df_timestamp):
-    expr = t_timestamp.groupby([t_timestamp.b, t_timestamp.c]).aggregate(
+def test_udaf_group_by_multikey_tzcol(t_timestamp, df_timestamp):
+    expr = t_timestamp.group_by([t_timestamp.b, t_timestamp.c]).aggregate(
         my_min_time=my_tz_min(t_timestamp.a)
     )
 
@@ -485,7 +485,7 @@ def test_array_return_type_reduction_window(con, t, df, qs):
 
 def test_array_return_type_reduction_group_by(con, t, df, qs):
     """Tests reduction UDF returning an array, used in a grouped agg."""
-    expr = t.groupby(t.key).aggregate(
+    expr = t.group_by(t.key).aggregate(
         quantiles_col=quantiles(t.b, quantiles=qs)
     )
     result = expr.execute()

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -740,9 +740,9 @@ FROM (
     assert result == expected
 
 
-def test_named_from_filter_groupby():
+def test_named_from_filter_group_by():
     t = ibis.table([('key', 'string'), ('value', 'double')], name='t0')
-    gb = t.filter(t.value == 42).groupby(t.key)
+    gb = t.filter(t.value == 42).group_by(t.key)
     sum_expr = lambda t: (t.value + 1 + 2 + 3).sum()  # noqa: E731
     expr = gb.aggregate(abc=sum_expr)
     expected = """\

--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -297,10 +297,10 @@ def test_join_aliasing():
     test = test.mutate(d=test.a + 20)
     test2 = test[test.d, test.c]
     idx = (test2.d / 15).cast('int64').name('idx')
-    test3 = test2.groupby([test2.d, idx, test2.c]).aggregate(
+    test3 = test2.group_by([test2.d, idx, test2.c]).aggregate(
         row_count=test2.count()
     )
-    test3_totals = test3.groupby(test3.d).aggregate(
+    test3_totals = test3.group_by(test3.d).aggregate(
         total=test3.row_count.sum()
     )
     test4 = test3.join(test3_totals, test3.d == test3_totals.d)[
@@ -308,7 +308,7 @@ def test_join_aliasing():
     ]
     test5 = test4[test4.row_count < test4.total / 2]
     agg = (
-        test.groupby([test.d, test.b])
+        test.group_by([test.d, test.b])
         .aggregate(count=test.count(), unique=test.c.nunique())
         .view()
     )

--- a/ibis/backends/pandas/tests/execution/conftest.py
+++ b/ibis/backends/pandas/tests/execution/conftest.py
@@ -301,7 +301,7 @@ def players_base(batting, sel_cols):
 
 @pytest.fixture(scope='module')
 def players(players_base):
-    return players_base.groupby('playerID')
+    return players_base.group_by('playerID')
 
 
 @pytest.fixture(scope='module')

--- a/ibis/backends/pandas/tests/execution/test_join.py
+++ b/ibis/backends/pandas/tests/execution/test_join.py
@@ -245,7 +245,7 @@ def test_join_with_window_function(
     # this should be semi_join
     tbl = batting.left_join(players, ['playerID'])
     t = tbl[batting.G, batting.playerID, batting.teamID]
-    expr = t.groupby(t.teamID).mutate(
+    expr = t.group_by(t.teamID).mutate(
         team_avg=lambda d: d.G.mean(),
         demeaned_by_player=lambda d: d.G - d.G.mean(),
     )

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -197,7 +197,7 @@ def test_group_by_with_having(t, df):
 
 
 def test_group_by_rename_key(t, df):
-    expr = t.groupby(t.dup_strings.name('foo')).aggregate(
+    expr = t.group_by(t.dup_strings.name('foo')).aggregate(
         dup_string_count=t.dup_strings.count()
     )
 
@@ -323,7 +323,7 @@ def test_nullif_inf():
 
 
 def test_group_concat(t, df):
-    expr = t.groupby(t.dup_strings).aggregate(
+    expr = t.group_by(t.dup_strings).aggregate(
         foo=t.plain_int64.group_concat(',')
     )
     result = expr.execute()
@@ -424,7 +424,7 @@ def test_table_count(t, df):
 
 
 def test_weighted_average(t, df):
-    expr = t.groupby(t.dup_strings).aggregate(
+    expr = t.group_by(t.dup_strings).aggregate(
         avg=(t.plain_float64 * t.plain_int64).sum() / t.plain_int64.sum()
     )
     result = expr.execute()
@@ -441,7 +441,7 @@ def test_weighted_average(t, df):
 
 
 def test_group_by_multiple_keys(t, df):
-    expr = t.groupby([t.dup_strings, t.dup_ints]).aggregate(
+    expr = t.group_by([t.dup_strings, t.dup_ints]).aggregate(
         avg_plain_float64=t.plain_float64.mean()
     )
     result = expr.execute()
@@ -455,7 +455,7 @@ def test_group_by_multiple_keys(t, df):
 
 
 def test_mutate_after_group_by(t, df):
-    gb = t.groupby(t.dup_strings).aggregate(
+    gb = t.group_by(t.dup_strings).aggregate(
         avg_plain_float64=t.plain_float64.mean()
     )
     expr = gb.mutate(x=gb.avg_plain_float64)
@@ -471,7 +471,7 @@ def test_mutate_after_group_by(t, df):
 
 
 def test_groupby_with_unnamed_arithmetic(t, df):
-    expr = t.groupby(t.dup_strings).aggregate(
+    expr = t.group_by(t.dup_strings).aggregate(
         naive_variance=(
             (t.plain_float64**2).sum() - t.plain_float64.mean() ** 2
         )
@@ -532,7 +532,7 @@ def test_notin(t, df, elements):
 
 
 def test_cast_on_group_by(t, df):
-    expr = t.groupby(t.dup_strings).aggregate(
+    expr = t.group_by(t.dup_strings).aggregate(
         casted=(t.float64_with_zeros == 0).cast('int64').sum()
     )
     result = expr.execute()
@@ -581,7 +581,7 @@ def test_left_binary_op(t, df, op, args):
 )
 @pytest.mark.parametrize('argfunc', [lambda c: (1.0, c), lambda c: (c, 1.0)])
 def test_left_binary_op_gb(t, df, op, argfunc):
-    expr = t.groupby('dup_strings').aggregate(
+    expr = t.group_by('dup_strings').aggregate(
         foo=op(*argfunc(t.float64_with_zeros)).sum()
     )
     result = expr.execute()
@@ -656,7 +656,7 @@ def test_quantile_groupby(batting, batting_df):
     frac = 0.2
     intp = 'linear'
     result = (
-        batting.groupby('teamID')
+        batting.group_by('teamID')
         .mutate(res=lambda x: x.RBI.quantile([frac, 1 - frac], intp))
         .res.execute()
     )
@@ -700,7 +700,7 @@ def test_summary_numeric(batting, batting_df):
 
 
 def test_summary_numeric_group_by(batting, batting_df):
-    expr = batting.groupby('teamID').G.summary()
+    expr = batting.group_by('teamID').G.summary()
     result = expr.execute()
     expected = (
         batting_df.groupby('teamID')
@@ -741,7 +741,7 @@ def test_summary_non_numeric(batting, batting_df):
 
 
 def test_summary_non_numeric_group_by(batting, batting_df):
-    expr = batting.groupby('teamID').playerID.summary()
+    expr = batting.group_by('teamID').playerID.summary()
     result = expr.execute()
     expected = (
         batting_df.groupby('teamID')

--- a/ibis/backends/pandas/tests/execution/test_structs.py
+++ b/ibis/backends/pandas/tests/execution/test_structs.py
@@ -68,7 +68,7 @@ def test_struct_field_series(struct_table):
 
 def test_struct_field_series_group_by_key(struct_table):
     t = struct_table
-    expr = t.groupby(t.s['fruit']).aggregate(total=t.value.sum())
+    expr = t.group_by(t.s['fruit']).aggregate(total=t.value.sum())
     result = expr.execute()
     expected = pd.DataFrame(
         [("apple", 1), ("pear", 5)], columns=["fruit", "total"]
@@ -78,7 +78,7 @@ def test_struct_field_series_group_by_key(struct_table):
 
 def test_struct_field_series_group_by_value(struct_table):
     t = struct_table
-    expr = t.groupby(t.key).aggregate(total=t.s['weight'].sum())
+    expr = t.group_by(t.key).aggregate(total=t.s['weight'].sum())
     result = expr.execute()
     # these are floats because we have a NULL value in the input data
     expected = pd.DataFrame([("a", 0.0), ("b", 1.0)], columns=["key", "total"])

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -205,7 +205,7 @@ def test_last(t, df):
 
 
 def test_group_by_mutate_analytic(t, df):
-    gb = t.groupby(t.dup_strings)
+    gb = t.group_by(t.dup_strings)
     expr = gb.mutate(
         first_value=t.plain_int64.first(),
         last_value=t.plain_strings.last(),
@@ -450,7 +450,7 @@ def test_mutate_with_window_after_join(sort_kind):
 
     joined = left.outer_join(right, left.ints == right.group)
     proj = joined[left, right.value]
-    expr = proj.groupby('ints').mutate(sum=proj.value.sum())
+    expr = proj.group_by('ints').mutate(sum=proj.value.sum())
     result = expr.execute()
     expected = pd.DataFrame(
         {

--- a/ibis/backends/pandas/tests/test_udf.py
+++ b/ibis/backends/pandas/tests/test_udf.py
@@ -125,7 +125,7 @@ def test_multiple_argument_udf(con, t, df):
 
 
 def test_multiple_argument_udf_group_by(con, t, df):
-    expr = t.groupby(t.key).aggregate(my_add=my_add(t.b, t.c).sum())
+    expr = t.group_by(t.key).aggregate(my_add=my_add(t.b, t.c).sum())
 
     assert isinstance(expr, ir.Table)
     assert isinstance(expr.my_add, ir.Column)
@@ -191,7 +191,7 @@ def test_udaf_groupby():
     con = Backend().connect({'df': df})
     t = con.table('df')
 
-    expr = t.groupby(t.key).aggregate(my_corr=my_corr(t.a, t.b))
+    expr = t.group_by(t.key).aggregate(my_corr=my_corr(t.a, t.b))
 
     assert isinstance(expr, ir.Table)
 
@@ -422,7 +422,7 @@ def test_array_return_type_reduction_group_by(con, t, df, qs):
     `SeriesGroupBy.agg` in the `Summarize` aggcontext implementation
     (#2768).
     """
-    expr = t.groupby(t.key).aggregate(
+    expr = t.group_by(t.key).aggregate(
         quantiles_col=quantiles(t.b, quantiles=qs)
     )
     result = expr.execute()

--- a/ibis/backends/pyspark/tests/test_basic.py
+++ b/ibis/backends/pyspark/tests/test_basic.py
@@ -65,9 +65,9 @@ def test_aggregation(client):
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())
 
 
-def test_groupby(client):
+def test_group_by(client):
     table = client.table('basic_table')
-    result = table.groupby('id').aggregate(table['id'].max()).compile()
+    result = table.group_by('id').aggregate(table['id'].max()).compile()
     expected = table.compile().groupby('id').agg(F.max('id').alias('max'))
 
     tm.assert_frame_equal(result.toPandas(), expected.toPandas())

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -113,9 +113,9 @@ def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
     grouping_key_col = 'bigint_col'
 
     # Two (equivalent) variations:
-    #  1) `groupby` then `aggregate`
+    #  1) `group_by` then `aggregate`
     #  2) `aggregate` with `by`
-    expr1 = alltypes.groupby(grouping_key_col).aggregate(tmp=result_fn)
+    expr1 = alltypes.group_by(grouping_key_col).aggregate(tmp=result_fn)
     expr2 = alltypes.aggregate(tmp=result_fn, by=grouping_key_col)
     result1 = expr1.execute()
     result2 = expr2.execute()
@@ -152,7 +152,8 @@ def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
     ]
 )
 def test_aggregate_multikey_group_reduction(backend, alltypes, df):
-    """Tests .aggregate() on a multi-key groupby with a reduction operation."""
+    """Tests .aggregate() on a multi-key group_by with a reduction
+    operation."""
 
     @reduction(
         input_type=[dt.double],
@@ -163,7 +164,7 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
 
     grouping_key_cols = ['bigint_col', 'int_col']
 
-    expr1 = alltypes.groupby(grouping_key_cols).aggregate(
+    expr1 = alltypes.group_by(grouping_key_cols).aggregate(
         mean_and_std(alltypes['double_col']).destructure()
     )
 
@@ -493,7 +494,9 @@ def test_reduction_ops(
             marks=[
                 pytest.mark.broken(
                     ["snowflake"],
-                    reason="snowflake doesn't allow quoted columns in groupby",
+                    reason=(
+                        "snowflake doesn't allow quoted columns in group_by"
+                    ),
                 ),
             ],
         ),
@@ -542,7 +545,7 @@ def test_approx_median(alltypes):
     [
         param(
             lambda t, where, sep: (
-                t.groupby('bigint_col')
+                t.group_by('bigint_col')
                 .aggregate(
                     tmp=lambda t: t.string_col.group_concat(sep, where=where)
                 )

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -243,7 +243,7 @@ def test_unnest_complex(con):
     expr = (
         array_types.select(["grouper", "x"])
         .mutate(x=lambda t: t.x.unnest())
-        .groupby("grouper")
+        .group_by("grouper")
         .aggregate(count_flat=lambda t: t.x.count())
         .order_by("grouper")
     )

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -723,7 +723,7 @@ def test_day_of_week_column(backend, alltypes, df):
 def test_day_of_week_column_group_by(
     backend, alltypes, df, day_of_week_expr, day_of_week_pandas
 ):
-    expr = alltypes.groupby('string_col').aggregate(
+    expr = alltypes.group_by('string_col').aggregate(
         day_of_week_result=day_of_week_expr
     )
     schema = expr.schema()

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -296,7 +296,7 @@ def test_reduction_udf_on_empty_data(udf_backend, udf_alltypes):
     # First filter down to zero rows
     t = udf_alltypes[udf_alltypes['int_col'] > np.inf]
     result = (
-        t.groupby('year').aggregate(mean=calc_mean(t['int_col'])).execute()
+        t.group_by('year').aggregate(mean=calc_mean(t['int_col'])).execute()
     )
     expected = pd.DataFrame({'year': [], 'mean': []})
     # We check that the result is an empty DataFrame,
@@ -603,7 +603,7 @@ def test_analytic_udf_destruct(udf_backend, udf_alltypes, udf):
 
 
 @pytest.mark.notimpl(["pyspark"])
-def test_analytic_udf_destruct_no_groupby(udf_backend, udf_alltypes):
+def test_analytic_udf_destruct_no_group_by(udf_backend, udf_alltypes):
     w = window(preceding=None, following=None)
 
     demean_struct_udf = create_demean_struct_udf(
@@ -655,9 +655,9 @@ def test_analytic_udf_destruct_overwrite(udf_backend, udf_alltypes):
 
 @pytest.mark.parametrize('udf', mean_struct_udfs)
 @pytest.mark.notimpl(["pyspark"])
-def test_reduction_udf_destruct_groupby(udf_backend, udf_alltypes, udf):
+def test_reduction_udf_destruct_group_by(udf_backend, udf_alltypes, udf):
     result = (
-        udf_alltypes.groupby('year')
+        udf_alltypes.group_by('year')
         .aggregate(
             udf(
                 udf_alltypes['double_col'], udf_alltypes['int_col']
@@ -667,7 +667,7 @@ def test_reduction_udf_destruct_groupby(udf_backend, udf_alltypes, udf):
     ).sort_values('year')
 
     expected = (
-        udf_alltypes.groupby('year')
+        udf_alltypes.group_by('year')
         .aggregate(
             mean=udf_alltypes['double_col'].mean(),
             mean_weight=udf_alltypes['int_col'].mean(),
@@ -679,7 +679,7 @@ def test_reduction_udf_destruct_groupby(udf_backend, udf_alltypes, udf):
 
 
 @pytest.mark.notimpl(["pyspark"])
-def test_reduction_udf_destruct_no_groupby(udf_backend, udf_alltypes):
+def test_reduction_udf_destruct_no_group_by(udf_backend, udf_alltypes):
     mean_struct_udf = create_mean_struct_udf(
         result_formatter=lambda v1, v2: (v1, v2)
     )
@@ -697,7 +697,7 @@ def test_reduction_udf_destruct_no_groupby(udf_backend, udf_alltypes):
 
 
 @pytest.mark.notimpl(["pyspark"])
-def test_reduction_udf_destruct_no_groupby_overwrite(
+def test_reduction_udf_destruct_no_group_by_overwrite(
     udf_backend, udf_alltypes
 ):
     result = udf_alltypes.aggregate(

--- a/ibis/expr/visualize.py
+++ b/ibis/expr/visualize.py
@@ -176,7 +176,7 @@ if __name__ == '__main__':
         left.inner_join(right, "b")
         .select(left.a, b=right.c, c=right.d)
         .filter((_.a + _.b * 2 * _.b / _.b**3 > 4) & (_.b > 5))
-        .groupby(_.c)
+        .group_by(_.c)
         .having(_.a.mean() > 0.0)
         .aggregate(a_mean=_.a.mean(), b_sum=_.b.sum())
     )

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -218,7 +218,7 @@ def pt():
 
 
 def high_card_group_by(t):
-    return t.groupby(t.key).aggregate(avg_value=t.value.mean())
+    return t.group_by(t.key).aggregate(avg_value=t.value.mean())
 
 
 def cast_to_dates(t):
@@ -232,7 +232,7 @@ def cast_to_dates_from_strings(t):
 def multikey_group_by_with_mutate(t):
     return (
         t.mutate(dates=t.timestamps.cast('date'))
-        .groupby(['low_card_key', 'dates'])
+        .group_by(['low_card_key', 'dates'])
         .aggregate(avg_value=lambda t: t.value.mean())
     )
 

--- a/ibis/tests/expr/test_visualize.py
+++ b/ibis/tests/expr/test_visualize.py
@@ -101,7 +101,7 @@ def test_join(how):
 def test_order_by():
     t = ibis.table([('a', 'int64'), ('b', 'string'), ('c', 'int32')])
     expr = (
-        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).order_by('b')
+        t.group_by(t.b).aggregate(sum_a=t.a.sum().cast('double')).order_by('b')
     )
     graph = viz.to_graph(expr)
     assert key(expr.op()) in graph.source
@@ -114,7 +114,7 @@ def test_order_by():
 def test_optional_graphviz_repr(with_graphviz):
     t = ibis.table([('a', 'int64'), ('b', 'string'), ('c', 'int32')])
     expr = (
-        t.groupby(t.b).aggregate(sum_a=t.a.sum().cast('double')).order_by('b')
+        t.group_by(t.b).aggregate(sum_a=t.a.sum().cast('double')).order_by('b')
     )
 
     # default behavior

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -188,7 +188,7 @@ def test_subquery_where_location():
         t[["float_col", "timestamp_col", "int_col", "string_col"]][
             lambda t: t.timestamp_col < param
         ]
-        .groupby("string_col")
+        .group_by("string_col")
         .aggregate(foo=lambda t: t.float_col.sum())
         .foo.count()
     )

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -372,7 +372,7 @@ def reduction(input_type, output_type):
     ...     return v.mean(), v.std()
     >>>
     >>> # create aggregation columns "mean" and "std"
-    >>> table = table.groupby('key').aggregate(
+    >>> table = table.group_by('key').aggregate(
     ...     mean_and_std(table['v']).destructure()
     ... )
     """


### PR DESCRIPTION
Follow up from #4600.

- Deprecates `Table.groupby` in favor of `Table.group_by`. Previously both versions existed.
- Adds a nicer error message for users trying to access methods on `Table` using common misspellings. For example

```python
In [1]: import ibis

In [2]: t = ibis.table({"x": "int", "y": "float"})

In [3]: t.sort()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Input In [3], in <cell line: 1>()
----> 1 t.sort()

File ~/Code/ibis/ibis/expr/types/relations.py:187, in Table.__getattr__(self, key)
    185 if key in common_typos:
    186     hint = common_typos[key]
--> 187     raise AttributeError(
    188         f"'Table' object has no attribute {key!r},"
    189         f"did you mean '{hint}'"
    190     )
    191 raise AttributeError(f"'Table' object has no attribute {key!r}")

AttributeError: 'Table' object has no attribute 'sort',did you mean 'order_by'
```