### PR TITLE
feat: add way to specify sqlglot dialect on backend

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -29,6 +29,8 @@ except ImportError:
 
 class Backend(BaseSQLBackend):
     name = 'clickhouse'
+    # for now map clickhouse to mysql so that _something_ works
+    _sqlglot_dialect = "mysql"
     table_expr_class = ClickhouseTable
     compiler = ClickhouseCompiler
 

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -167,6 +167,8 @@ def _column_batches_to_dataframe(names, batches):
 
 class Backend(BaseSQLBackend):
     name = 'impala'
+    # not 100% accurate, but very close
+    _sqlglot_dialect = "hive"
     database_class = ImpalaDatabase
     table_expr_class = ImpalaTable
     compiler = ImpalaCompiler


### PR DESCRIPTION
We use `sqlglot` for pretty-printing SQL. Not all backends are directly supported by sqlglot, but most have a dialect that sqlglot supports that's close enough.

Instead of hardcoding a mapping in the `pretty.py` module, we now add a private optional attribute on the backend, and check there first.