### PR TITLE
ci: remove impala and pyspark special case testing

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -154,12 +154,7 @@ jobs:
         run: just download-data
 
       - name: "run parallel tests: ${{ matrix.backend.name }}"
-        if: ${{ matrix.backend.name != 'pyspark' && matrix.backend.name != 'impala' }}
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
-
-      - name: "run serial tests: ${{ matrix.backend.name }}"
-        if: ${{ matrix.backend.name == 'pyspark' || matrix.backend.name == 'impala' }}
-        run: just ci-check -m ${{ matrix.backend.name }}
         env:
           IBIS_TEST_NN_HOST: localhost
           IBIS_TEST_IMPALA_HOST: localhost

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -289,7 +289,7 @@ def pytest_collection_modifyitems(session, config, items):
             if not any(item.iter_markers(name="benchmark")):
                 item.add_marker(pytest.mark.core)
 
-        for name in ("duckdb", "sqlite"):
+        for name in ("duckdb", "sqlite", "impala", "pyspark"):
             # build a list of markers so we're don't invalidate the item's
             # marker iterator
             for _ in item.iter_markers(name=name):


### PR DESCRIPTION
The latest impala driver appears to be much more robust in the face of multiple processes running. This PR cleans up some CI configuration to avoid special casing the test runs in CI.

After this PR it should be possible to run `pytest -n auto --dist=loadgroup` verbatim and get parallel testing for things that support it and serial testing for things that don't.
