### PR TITLE
ci: don't exit with non-zero code always [skip ci]

### DIFF
--- a/.github/workflows/ci-data.yml
+++ b/.github/workflows/ci-data.yml
@@ -60,9 +60,8 @@ jobs:
 
           exit_code=0
           for table in workflows jobs; do
-            bq load --autodetect=true --source_format=NEWLINE_DELIMITED_JSON \
-              "workflows_native.${table}" "${bucket}/${table}.json"
-            if [ -n "$?" ]; then
+            if ! bq load --autodetect=true --source_format=NEWLINE_DELIMITED_JSON \
+              "workflows_native.${table}" "${bucket}/${table}.json"; then
               ((++exit_code))
             fi
           done


### PR DESCRIPTION
This PR fixes GCS insert to only exit when an actual error occurs