### PR TITLE
fix: change default limit to None

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -144,6 +144,15 @@ def _regex_extract(t, op):
     return result
 
 
+def _json_get_item(t, op):
+    left, path = map(t.translate, op.args)
+    # Workaround for https://github.com/duckdb/duckdb/issues/5063
+    # In some situations duckdb silently does the wrong thing if
+    # the path is parametrized.
+    sa_path = sa.text(str(path.compile(compile_kwargs=dict(literal_binds=True))))
+    return left.op("->")(sa_path)
+
+
 def _strftime(t, op):
     format_str = op.format_str
     if not isinstance(format_str_op := format_str, ops.Literal):
@@ -220,6 +229,7 @@ operation_registry.update(
         ops.ArgMin: reduction(sa.func.min_by),
         ops.ArgMax: reduction(sa.func.max_by),
         ops.BitwiseXor: fixed_arity(sa.func.xor, 2),
+        ops.JSONGetItem: _json_get_item,
     }
 )
 

--- a/ibis/backends/sqlite/tests/test_client.py
+++ b/ibis/backends/sqlite/tests/test_client.py
@@ -83,10 +83,7 @@ def test_verbose_log_queries(con):
 
     assert len(queries) == 1
     (query,) = queries
-    expected = 'SELECT t0.year \n'
-    expected += 'FROM main.functional_alltypes AS t0\n'
-    expected += ' LIMIT ? OFFSET ?'
-    assert query == expected
+    assert "SELECT t0.year" in query
 
 
 def test_table_equality(dbpath):

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -67,7 +67,7 @@ class SQL(Config):
         Dialect to use for printing SQL when the backend cannot be determined.
     """
 
-    default_limit: Optional[PosInt] = 10_000
+    default_limit: Optional[PosInt] = None
     default_dialect: str = "duckdb"
 
 

--- a/ibis/tests/test_config.py
+++ b/ibis/tests/test_config.py
@@ -4,11 +4,13 @@ from ibis.config import options
 
 
 def test_sql_config():
-    assert options.sql.default_limit == 10_000
+    try:
+        assert options.sql.default_limit is None
 
-    with pytest.raises(TypeError):
-        options.sql.default_limit = -1
+        with pytest.raises(TypeError):
+            options.sql.default_limit = -1
 
-    options.sql.default_limit = 100
-    assert options.sql.default_limit == 100
-    options.sql.default_limit = 10_000
+        options.sql.default_limit = 100
+        assert options.sql.default_limit == 100
+    finally:
+        options.sql.default_limit = None


### PR DESCRIPTION
Previously Table/Column expressions had a default limit of 10,000 rows applied when `execute` was called. The existence of this limit was easy for users to miss (it's not obvious that it's applied, and the effects won't be seen for small data), leading to results sometimes being silently truncated to the first 10,000 rows.

We now change the default limit to `None`, meaning no limit. This seems like a safer default value, as it won't result in silent truncation. With the new support for streaming results back (e.g. `to_pyarrow_batches`) we also expect users will want to pull back larger result sets, the presence of a limit seems to harm more than help.

**This doesn't remove the presence of a default limit, just changes the default value**. Downstream systems relying on the presence of this limit to stop users from shooting themselves in the foot can still make use of it by manually configuring a new default value:

```python
# Restore the old default limit
ibis.options.sql.default_limit = 10_000
```

Fixes #2017