### PR TITLE
fix: avoid renaming known equal columns for inner joins with equality predicates

### DIFF
--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -86,19 +86,27 @@ def test_mutating_join(backend, batting, awards_players, how):
     result_order = ['playerID', 'yearID', 'lgID', 'stint']
 
     expr = left.join(right, predicate, how=how)
-    result = (
-        expr.execute()
-        .fillna(np.nan)
-        .assign(
-            playerID=lambda df: df.playerID_x.where(
-                df.playerID_x.notnull(),
-                df.playerID_y,
-            )
+    if how == "inner":
+        result = (
+            expr.execute()
+            .fillna(np.nan)[left.columns]
+            .sort_values(result_order)
+            .reset_index(drop=True)
         )
-        .drop(['playerID_x', 'playerID_y'], axis=1)[left.columns]
-        .sort_values(result_order)
-        .reset_index(drop=True)
-    )
+    else:
+        result = (
+            expr.execute()
+            .fillna(np.nan)
+            .assign(
+                playerID=lambda df: df.playerID_x.where(
+                    df.playerID_x.notnull(),
+                    df.playerID_y,
+                )
+            )
+            .drop(['playerID_x', 'playerID_y'], axis=1)[left.columns]
+            .sort_values(result_order)
+            .reset_index(drop=True)
+        )
 
     expected = (
         check_eq(


### PR DESCRIPTION
Previously all column names that collided between `left` and `right` tables were renamed with an appended suffix. Now for the case of inner joins with only equality predicates, colliding columns that are known to be equal due to the join predicates aren't renamed.

Fixes #4618.

```python
In [1]: import ibis

In [2]: t = ibis.table({"id": "int", "name": "string"})

In [3]: t2 = ibis.table({"id": "int", "a": "double", "b": "double"})

In [4]: result = t.join(t2, "id")

In [5]: result.columns  # previously this would be ["id_x", "name", "id_y", "a", "b"]
Out[5]: ['id', 'name', 'a', 'b']
```