### PR TITLE
fix(pandas): support `substr` with no `length`

### DIFF
--- a/ibis/backends/dask/execution/strings.py
+++ b/ibis/backends/dask/execution/strings.py
@@ -54,7 +54,7 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
             (
                 dd.Series,
                 integer_types,
-                integer_types,
+                (type(None), *integer_types),
             ),
             execute_substring_int_int,
         ),

--- a/ibis/backends/pandas/execution/strings.py
+++ b/ibis/backends/pandas/execution/strings.py
@@ -21,9 +21,14 @@ def execute_string_length_series(op, data, **kwargs):
     return data.str.len().astype('int32')
 
 
-@execute_node.register(ops.Substring, pd.Series, integer_types, integer_types)
+@execute_node.register(
+    ops.Substring, pd.Series, integer_types, (type(None), *integer_types)
+)
 def execute_substring_int_int(op, data, start, length, **kwargs):
-    return data.str[start : start + length]
+    if length is None:
+        return data.str[start:]
+    else:
+        return data.str[start : start + length]
 
 
 @execute_node.register(ops.Substring, pd.Series, pd.Series, integer_types)

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -208,6 +208,7 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.date_string_col.substr(2),
             lambda t: t.date_string_col.str[2:],
             id='substr-start-only',
+            marks=pytest.mark.notimpl(["datafusion", "polars"]),
         ),
         param(
             lambda t: t.date_string_col.left(2),

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -205,6 +205,11 @@ def test_string_col_is_unicode(alltypes, df):
             id='substr',
         ),
         param(
+            lambda t: t.date_string_col.substr(2),
+            lambda t: t.date_string_col.str[2:],
+            id='substr-start-only',
+        ),
+        param(
             lambda t: t.date_string_col.left(2),
             lambda t: t.date_string_col.str[:2],
             id='left',


### PR DESCRIPTION
Fixes #4668.