### PR TITLE
fix: remove kerberos extra for impala dialect

### DIFF
--- a/docs/backends/Impala.md
+++ b/docs/backends/Impala.md
@@ -1345,10 +1345,17 @@ your Ibis session to plug in all your own functions.
 ## Working with secure clusters (Kerberos)
 
 Ibis is compatible with Hadoop clusters that are secured with Kerberos (as well
-as SSL and LDAP). Just like the Impala shell and ODBC/JDBC connectors, Ibis
-connects to Impala through the HiveServer2 interface (using the impyla client).
-Therefore, the connection semantics are similar to the other access methods for
-working with secure clusters.
+as SSL and LDAP). Note that to enable this support, you'll also need to install
+the `kerberos` package.
+
+```sh
+$ pip install kerberos
+```
+
+Just like the Impala shell and ODBC/JDBC connectors, Ibis connects to Impala
+through the HiveServer2 interface (using the impyla client). Therefore, the
+connection semantics are similar to the other access methods for working with
+secure clusters.
 
 Specifically, after authenticating yourself against Kerberos (e.g., by issuing
 the appropriate `kinit` commmand), simply pass `auth_mechanism='GSSAPI'` or

--- a/poetry.lock
+++ b/poetry.lock
@@ -739,7 +739,6 @@ python-versions = "*"
 
 [package.dependencies]
 bitarray = "*"
-kerberos = {version = ">=1.3.0", optional = true, markers = "extra == \"kerberos\""}
 six = "*"
 thrift = "0.16.0"
 thrift-sasl = "0.4.3"
@@ -937,14 +936,6 @@ toml = "*"
 [package.extras]
 rst2md = ["sphinx-gallery (>=0.7.0,<0.8.0)"]
 toml = ["toml"]
-
-[[package]]
-name = "kerberos"
-version = "1.3.1"
-description = "Kerberos high-level interface"
-category = "main"
-optional = true
-python-versions = "*"
 
 [[package]]
 name = "locket"
@@ -2227,8 +2218,8 @@ snowflake-connector-python = "<3.0.0"
 sqlalchemy = ">=1.4.0,<2.0.0"
 
 [package.extras]
-development = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout", "mock", "pytz", "numpy"]
 pandas = ["snowflake-connector-python[pandas] (<3.0.0)"]
+development = ["numpy", "pytz", "mock", "pytest-timeout", "pytest-rerunfailures", "pytest-cov", "pytest"]
 
 [[package]]
 name = "soupsieve"
@@ -2543,7 +2534,7 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "d1d02dfb26297f259ca547c6d850b9ded49fced6044c32cf1a8c97c1cdccb8f7"
+content-hash = "8bd20b06e781b8f62f0293033a932af74050130b6b772e12dc9143be65ccbaae"
 
 [metadata.files]
 absolufy-imports = [
@@ -3343,12 +3334,6 @@ jupyterlab-pygments = [
 jupytext = [
     {file = "jupytext-1.14.1-py3-none-any.whl", hash = "sha256:216bddba8bbb9355831ba17fd8d45cfe5d1355e7152bc8980f39175fc2584875"},
     {file = "jupytext-1.14.1.tar.gz", hash = "sha256:314fa0e732b1d14764271843b676938ef8a7b9d53c3575ade636b45d13f341c8"},
-]
-kerberos = [
-    {file = "kerberos-1.3.1-cp27-cp27m-macosx_11_1_x86_64.whl", hash = "sha256:98a695c072efef535cb2b5f98e474d00671588859a94ec96c2c1508a113ff3aa"},
-    {file = "kerberos-1.3.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:2e03c6a9d201d4aab5f899bfb8150de15335955bfce8ca43bfe9a41d7aae54dc"},
-    {file = "kerberos-1.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2002b3b1541fc51e2c081ee7048f55e5d9ca63dd09f0d7b951c263920db3a0bb"},
-    {file = "kerberos-1.3.1.tar.gz", hash = "sha256:cdd046142a4e0060f96a00eb13d82a5d9ebc0f2d7934393ed559bac773460a2c"},
 ]
 locket = [
     {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ fsspec = { version = ">=2022.1.0", optional = true }
 GeoAlchemy2 = { version = ">=0.6.3,<0.13", optional = true }
 geopandas = { version = ">=0.6,<0.12", optional = true }
 graphviz = { version = ">=0.16,<0.21", optional = true }
-impyla = { version = ">=0.17,<0.19", optional = true, extras = ["kerberos"] }
+impyla = { version = ">=0.17,<0.19", optional = true }
 lz4 = { version = ">=3.1.10,<5", optional = true }
 polars = { version = ">=0.14.18,<1", optional = true }
 psycopg2 = { version = ">=2.8.4,<3", optional = true }

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,6 @@ jupyter-client==7.3.5; python_full_version >= "3.7.1" and python_version < "4" a
 jupyter-core==4.11.1; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
 jupyterlab-pygments==0.2.2; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
 jupytext==1.14.1; python_version >= "3.6" and python_version < "4.0" and python_full_version >= "3.7.1"
-kerberos==1.3.1
 locket==1.0.0; python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.8"
 lxml==4.9.1; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.7"
 lz4==4.0.2; python_version >= "3.7"


### PR DESCRIPTION
BREAKING CHANGE: kerberos support is no longer installed by default for the `impala` backend. To add support you'll need to install the `kerberos` package separately.

Fixes #4666.