### PR TITLE
docs: fix the inline example for ibis.dask.do_connect

### DIFF
--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -41,7 +41,11 @@ class Backend(BasePandasBackend):
         Examples
         --------
         >>> import ibis
-        >>> data = {"t": "path/to/file.parquet", "s": "path/to/file.csv"}
+        >>> import dask.dataframe as dd
+        >>> data = {
+        ...     "t": dd.read_parquet("path/to/file.parquet"),
+        ...     "s": dd.read_csv("path/to/file.csv"),
+        ... }
         >>> ibis.dask.connect(data)
         """
         # register dispatchers


### PR DESCRIPTION
Passing `str` values of parquet or CSV files to `ibis.dask.connect` does not work as currently documented in the example of the docstring. Instead, it raises a very confusing error message:

```python-traceback
Traceback (most recent call last):
  File "/Users/ogrisel/tmp/ibis_sandbox.py", line 34, in <module>
    t_dask = ibis.dask.connect({"t": "test.parquet"}).table("t")
  File "/Users/ogrisel/code/ibis/ibis/backends/pandas/__init__.py", line 102, in table
    schema = sch.infer(df, schema=schema or self.schemas.get(name, None))
  File "/Users/ogrisel/mambaforge/envs/dev/lib/python3.10/site-packages/multipledispatch/dispatcher.py", line 273, in __call__
    raise NotImplementedError(
NotImplementedError: Could not find signature for infer: <str>
```

This PR documents how to create a dask connection with tables defined from dask dataframe instances instead.

I think this `ibis.dask.do_connect` should check the values passed in the `dictionnary` parameter to check that they are `dask.dataframe.DataFrame` (or `pandas.DataFrame` which are apparently also accepted by the dask backend, probably for convenience) and raise a `ValueError` otherwise. I can do a follow-up PR for this if you wish.