### PR TITLE
chore(nix): override duckdb to respect NIX_BUILD_CORES

### DIFF
--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -136,4 +136,12 @@ in
       nativeBuildInputs = attrs.nativeBuildInputs or [ ] ++ [ self.setuptools ];
     }
   );
+
+  duckdb = super.duckdb.overridePythonAttrs (
+    _: {
+      prePatch = ''
+        substituteInPlace setup.py --replace "multiprocessing.cpu_count()" "int(os.getenv('NIX_BUILD_CORES', multiprocessing.cpu_count()))"
+      '';
+    }
+  );
 }


### PR DESCRIPTION
DuckDB makes use of `multiprocessing.cpu_count()` and it locks up my machine whenever it has to build by very efficiently consuming all my cores.  This hack-patch makes it respect `NIX_BUILD_CORES` so that doesn't happen.