### PR TITLE
fix(sqlalchemy): allow passing pd.DataFrame to create

### DIFF
--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -178,6 +178,9 @@ class BaseAlchemyBackend(BaseSQLBackend):
         force
             Check whether a table exists before creating it
         """
+        if isinstance(expr, pd.DataFrame):
+            expr = ibis.memtable(expr)
+
         if database == self.current_database:
             # avoid fully qualified name
             database = None

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -661,6 +661,10 @@ def test_agg_memory_table(con):
         ),
         param(
             ibis.memtable(pd.DataFrame([("a", 1.0)], columns=["a", "b"])),
+            id="pandas-memtable",
+        ),
+        param(
+            pd.DataFrame([("a", 1.0)], columns=["a", "b"]),
             id="pandas",
         ),
     ],


### PR DESCRIPTION
The docstring of `create` indicates this should work but it relies on
there being a `schema` method, which isn't true of dataframes.

If it's a dataframe, we wrap it in a `memtable` and then continue.

xref #4683 -- although this doesn't handle the other inconsistency raised there