### PR TITLE
fix(duckdb): silence duckdb-engine warnings

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -306,6 +306,11 @@ class Backend(BaseAlchemyBackend):
                 message="Did not recognize type",
                 category=sa.exc.SAWarning,
             )
+            # We don't rely on index reflection, ignore this warning
+            warnings.filterwarnings(
+                "ignore",
+                message="duckdb-engine doesn't yet support reflection on indices",
+            )
 
             table = super()._get_sqla_table(name, schema, **kwargs)
 


### PR DESCRIPTION
`duckdb-engine` version 0.6.4 added a warning when loading tables that indices aren't properly reflected. This warning shouldn't affect our users, this PR silences it.