### PR TITLE
feat: support both `postgresql://` and `postgres://` in `ibis.connect`

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -31,7 +31,6 @@ import ibis.config
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 import ibis.util as util
-from ibis.common.dispatch import RegexDispatcher
 
 __all__ = ('BaseBackend', 'Database', 'connect')
 
@@ -734,9 +733,6 @@ class BaseBackend(abc.ABC, ResultHandler):
         )
 
 
-_connect = RegexDispatcher("_connect")
-
-
 @functools.lru_cache(maxsize=None)
 def _get_backend_names() -> frozenset[str]:
     """Return the set of known backend names.
@@ -756,125 +752,83 @@ def _get_backend_names() -> frozenset[str]:
     return frozenset(ep.name for ep in entrypoints)
 
 
-_PATTERN = "|".join(
-    sorted(_get_backend_names().difference(("duckdb", "sqlite", "pyspark")))
-)
+def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
+    """Connect to `resource`, inferring the backend automatically.
 
-
-@_connect.register(rf"(?P<backend>{_PATTERN})://.+", priority=12)
-def _(url: str, *, backend: str, **kwargs: Any) -> BaseBackend:
-    """Connect to given `backend` with `path`.
-
-    Examples
-    --------
-    >>> con = ibis.connect("postgres://user:pass@hostname:port/database")
-    >>> con = ibis.connect("mysql://user:pass@hostname:port/database")
-    """
-    instance: BaseBackend = getattr(ibis, backend)
-    backend += (backend == "postgres") * "ql"
-    params = "?" * bool(kwargs) + urllib.parse.urlencode(kwargs)
-    url += params
-    return instance._from_url(url)
-
-
-@_connect.register(
-    r"(?P<backend>duckdb|sqlite|pyspark)://(?P<path>.*)",
-    priority=12,
-)
-def _(_: str, *, backend: str, path: str, **kwargs: Any) -> BaseBackend:
-    """Connect to given `backend` with `path`.
+    Parameters
+    ----------
+    resource
+        A URL or path to the resource to be connected to.
 
     Examples
     --------
-    >>> con = ibis.connect("duckdb://relative/path/to/data.db")
+    Connect to an on-disk parquet or csv file (uses duckdb by default):
+    >>> con = ibis.connect("/path/to/data.parquet")
+    >>> con = ibis.connect("/path/to/data.csv")
+
+    Connect to an in-memory duckdb database:
+    >>> con = ibis.connect("duckdb://")
+
+    Connect to an on-disk sqlite database:
+    >>> con = ibis.connect("sqlite://relative/path/to/data.db")
     >>> con = ibis.connect("sqlite:///absolute/path/to/data.db")
+
+    Connect to a postgres server:
+    >>> con = ibis.connect("postgres://user:password@hostname:5432")
     """
-    instance: BaseBackend = getattr(ibis, backend)
-    params = "?" * bool(kwargs) + urllib.parse.urlencode(kwargs)
-    path += params
-    # extra slash for sqlalchemy
-    return instance._from_url(f"{backend}:///{path}")
+    url = resource = str(resource)
 
+    if re.match("[A-Za-z]:", url):
+        # windows path with drive, treat it as a file
+        url = f"file://{url}"
 
-@_connect.register(r"file://(?P<path>.*)", priority=10)
-def _(_: str, *, path: str, **kwargs: Any) -> BaseBackend:
-    """Connect to file located at `path`."""
-    return _connect(path, **kwargs)
+    parsed = urllib.parse.urlparse(url)
+    scheme = parsed.scheme or "file"
 
+    # Merge explicit kwargs with query string, explicit kwargs
+    # taking precedence
+    kwargs = dict(urllib.parse.parse_qsl(parsed.query), **kwargs)
 
-@_connect.register(r".+\.(?P<backend>.+)", priority=1)
-def _(path: str, *, backend: str, **kwargs: Any) -> BaseBackend:
-    """Connect to given path.
+    if scheme == "file":
+        path = parsed.netloc + parsed.path
+        if path.endswith(".duckdb"):
+            return ibis.duckdb.connect(path, **kwargs)
+        elif path.endswith(".sqlite"):
+            return ibis.sqlite.connect(path, **kwargs)
+        elif path.endswith((".parquet", ".csv", ".csv.gz")):
+            # Load parquet/csv/csv.gz files with duckdb by default
+            con = ibis.duckdb.connect(**kwargs)
+            return con.register(path)
+        else:
+            raise ValueError(f"Don't know how to connect to {resource!r}")
 
-    The extension is assumed to be the name of an ibis backend.
+    if kwargs:
+        # If there are kwargs (either explicit or from the query string),
+        # re-add them to the parsed URL
+        query = urllib.parse.urlencode(kwargs)
+        parsed = parsed._replace(query=query)
 
-    Examples
-    --------
-    >>> con = ibis.connect("file://relative/path/to/data.duckdb")
-    """
-    return getattr(ibis, backend).connect(path, **kwargs)
+    if scheme in ("postgres", "postgresql"):
+        # Treat `postgres://` and `postgresql://` the same, just as postgres
+        # does. We normalize to `postgresql` since that's what SQLAlchemy
+        # accepts.
+        scheme = "postgres"
+        parsed = parsed._replace(scheme="postgresql")
 
+    # Convert all arguments back to a single URL string
+    url = parsed.geturl()
+    if "://" not in url:
+        # SQLAlchemy requires a `://`, while urllib may roundtrip
+        # `duckdb://` to `duckdb:`. Here we re-add the missing `//`.
+        url = url.replace(":", "://", 1)
+    if scheme in ("duckdb", "sqlite", "pyspark"):
+        # SQLAlchemy wants an extra slash for URLs where the path
+        # maps to a relative/absolute location on the filesystem
+        url = url.replace(":", ":/", 1)
 
-@functools.singledispatch
-def connect(resource: Path | str, **_: Any) -> BaseBackend:
-    """Connect to `resource`.
+    try:
+        backend = getattr(ibis, scheme)
+    except AttributeError:
+        raise ValueError(f"Don't know how to connect to {resource!r}") from None
 
-    `resource` can be a `pathlib.Path` or a `str` specifying a URL or path.
-
-    Examples
-    --------
-    >>> con = ibis.connect("duckdb:///absolute/path/to/data.db")
-    >>> con = ibis.connect("relative/path/to/data.duckdb")
-    """
-    raise NotImplementedError(type(resource))
-
-
-@connect.register
-def _(path: Path, **kwargs: Any) -> BaseBackend:
-    return _connect(str(path), **kwargs)
-
-
-@connect.register
-def _(url: str, **kwargs: Any) -> BaseBackend:
-    return _connect(url, **kwargs)
-
-
-@_connect.register(
-    r"(?P<backend>.+)://(?P<filename>.+\.(?P<extension>.+))",
-    priority=11,
-)
-def _(
-    _: str,
-    *,
-    backend: str,
-    filename: str,
-    extension: str,
-    **kwargs: Any,
-) -> BaseBackend:
-    """Connect to `backend` and register a file.
-
-    The extension of the file will be used to register the file with
-    the backend.
-
-    Examples
-    --------
-    >>> con = ibis.connect("duckdb://relative/path/to/data.csv")
-    >>> con = ibis.connect("duckdb:///absolute/path/to/more/data.parquet")
-    """
-    con = getattr(ibis, backend).connect(**kwargs)
-    con.register(f"{extension}://{filename}")
-    return con
-
-
-@_connect.register(r".+\.(?:parquet|csv(?:\.gz)?)", priority=8)
-def _(filename: str, **_: Any) -> BaseBackend:
-    """Connect to the default backend (DuckDB) and return a table.
-
-    Examples
-    --------
-    >>> table1 = ibis.connect("relative/path/to/file1.csv")
-    >>> table2 = ibis.connect("relative/path/to/file2.parquet")
-    >>> table3 = ibis.connect("relative/path/to/file3.csv.gz")
-    """
-    con = ibis.duckdb.connect()
-    return con.register(filename)
+    return backend._from_url(url)

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -793,7 +793,7 @@ def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
         path = parsed.netloc + parsed.path
         if path.endswith(".duckdb"):
             return ibis.duckdb.connect(path, **kwargs)
-        elif path.endswith(".sqlite"):
+        elif path.endswith((".sqlite", ".db")):
             return ibis.sqlite.connect(path, **kwargs)
         elif path.endswith((".parquet", ".csv", ".csv.gz")):
             # Load parquet/csv/csv.gz files with duckdb by default

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -501,25 +501,27 @@ def test_connect_duckdb(url, tmp_path):
 
 @pytest.mark.sqlite
 @pytest.mark.parametrize(
-    "url",
+    "url, ext",
     [
-        param(lambda p: p, id="no-scheme-sqlite-ext"),
-        param(lambda p: f"sqlite://{p}", id="absolute-path"),
+        param(lambda p: p, "sqlite", id="no-scheme-sqlite-ext"),
+        param(lambda p: p, "db", id="no-scheme-db-ext"),
+        param(lambda p: f"sqlite://{p}", "db", id="absolute-path"),
         param(
             lambda p: f"sqlite://{os.path.relpath(p)}",
+            "db",
             marks=[
                 not_windows
             ],  # hard to test in CI since tmpdir & cwd are on different drives
             id="relative-path",
         ),
-        param(lambda p: "sqlite://", id="in-memory-empty"),
-        param(lambda p: "sqlite://:memory:", id="in-memory-explicit"),
+        param(lambda p: "sqlite://", "db", id="in-memory-empty"),
+        param(lambda p: "sqlite://:memory:", "db", id="in-memory-explicit"),
     ],
 )
-def test_connect_sqlite(url, tmp_path):
+def test_connect_sqlite(url, ext, tmp_path):
     import sqlite3
 
-    path = os.path.abspath(tmp_path / "test.sqlite")
+    path = os.path.abspath(tmp_path / f"test.{ext}")
     with sqlite3.connect(path):
         pass
     con = ibis.connect(url(path))


### PR DESCRIPTION
This PR does a few things:

- Enables support for using `ibis.connect` to connect to postgres URLs starting with either `postgres://` or `postgresql://`, since postgres itself accepts both forms.
- Simplifies the implementation of `ibis.connect`. The previous tiered dispatch system was hard to read IMO and hid several bugs ("ravioli code").
- Expands the test suite for `ibis.connect` to better cover the functionality here.

I recognize the removal of the dispatch system may not be desired, since it forces external backends to only work with a standardized URL scheme (which honestly may be fine). I'm fine with reverting that change, but would like us to then be clear about which parts of `ibis.connect`'s dispatch system are intended to be a public extension interface rather than just an implementation detail.