### PR TITLE
ci: relax codecov checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -22,9 +22,11 @@ coverage:
       default:
         # Allow for slight decreases in code coverage, makes
         # the coverage status checks a little less finicky
-        threshold: 0.5%
+        target: auto
+        threshold: 1%
         only_pulls: true
     patch:
       default:
-        threshold: 0.5%
+        target: auto
+        threshold: 1%
         only_pulls: true

--- a/dev/update-lock-files.sh
+++ b/dev/update-lock-files.sh
@@ -8,6 +8,6 @@ export PYTHONHASHSEED=0
 TOP="${1:-$(dirname "$(dirname "$(readlink -f "$0")")")}"
 
 pushd "${TOP}" > /dev/null || exit 1
-poetry lock --no-update --no-cache
+poetry lock --no-update
 poetry export --with dev --with test --with docs --without-hashes --no-ansi > "${TOP}/requirements.txt"
 popd > /dev/null || exit 1


### PR DESCRIPTION
The current codecov checks have a lot of false positives (one recent PR for example failed because it resulted in a large decrease in lines of code, yielding a net decrease in codecov even though all the touched lines were covered). This PR loosens the codecov checks in the following ways:

- Loosen the threshold for the `project` check. Failures recently that we deemed fine were all below a 1% threshold but slightly above a 0.5% threshold.
- ~Disables the `patch` check completely. Sometimes a patch won't hit 90-some-percent coverage (the current threshold), due to either math oddness (as detailed above) or testing restrictions. Several other projects I interact with have completely disabled this check, we do so here as well.~ *edit: disabling `patch` checks disable coverage annotations, which some devs like. Instead we relax the patch check to a 1% threshold to match the project check*

Personally the main benefit I find in services like `codecov` is viewing what lines are covered, not the CI checks themselves. I'm fine with looser restrictions if it leads to fewer unnecessarily failed PRs.