### PR TITLE
docs: fix typo in first example of the homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ python -c 'import ibis; print(ibis.__version__)'
     ##### Ibis
 
     ```python
-    t.group_by("f").aggregate(d=t.a + t.b.sum())
+    t.group_by("f").aggregate(d=(t.a + t.b).sum())
     ```
 
 === "Join"


### PR DESCRIPTION
Missing parens.