### PR TITLE
ci: remove krb5 system dependency installs from ci

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -37,7 +37,7 @@ jobs:
         run: sudo apt-get update -y -q
 
       - name: install system dependencies
-        run: sudo apt-get install -y -q build-essential graphviz krb5-config libkrb5-dev libgeos-dev
+        run: sudo apt-get install -y -q build-essential graphviz libgeos-dev
 
       - name: install poetry
         run: pip install 'poetry>=1.2' 'poetry-core>=1.1'

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -78,8 +78,6 @@ jobs:
             sys-deps:
               - cmake
               - ninja-build
-              - krb5-config
-              - libkrb5-dev
         exclude:
           - os: windows-latest
             backend:

--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -75,7 +75,7 @@ jobs:
           python-version: "3.10"
 
       - name: install system dependencies
-        run: sudo apt-get install -qq -y build-essential krb5-config libkrb5-dev libgeos-dev
+        run: sudo apt-get install -qq -y build-essential libgeos-dev
 
       - uses: syphar/restore-virtualenv@v1
         with:

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -66,7 +66,7 @@ jobs:
           set -euo pipefail
 
           sudo apt-get update -y -q
-          sudo apt-get install -y -q build-essential graphviz krb5-config libkrb5-dev libgeos-dev
+          sudo apt-get install -y -q build-essential graphviz libgeos-dev
 
       - name: install ${{ matrix.os }} system dependencies
         if: ${{ matrix.os == 'windows-latest' }}


### PR DESCRIPTION
This PR removes the install of krb5 system dependencies which should buy back a bit of our CI time.