### PR TITLE
fix(ux): improve error messages for rlz.comparable failures

### DIFF
--- a/ibis/expr/builders.py
+++ b/ibis/expr/builders.py
@@ -66,7 +66,10 @@ class SimpleCaseBuilder(TypedCaseBuilder):
         result_expr = rlz.any(result_expr)
 
         if not rlz.comparable(self.base, case_expr):
-            raise TypeError('Base expression and passed case are not ' 'comparable')
+            raise TypeError(
+                f'Base expression {rlz._arg_type_error_format(self.base)} and '
+                f'case {rlz._arg_type_error_format(case_expr)} are not comparable'
+            )
 
         cases = list(self.cases)
         cases.append(case_expr)

--- a/ibis/expr/operations/logical.py
+++ b/ibis/expr/operations/logical.py
@@ -63,8 +63,8 @@ class Comparison(Binary):
         """
         if not rlz.comparable(left, right):
             raise TypeError(
-                f'Arguments with datatype {left.output_dtype} and '
-                f'{right.output_dtype} are not comparable'
+                f'Arguments {rlz._arg_type_error_format(left)} and '
+                f'{rlz._arg_type_error_format(right)} are not comparable'
             )
         super().__init__(left=left, right=right)
 
@@ -116,13 +116,13 @@ class Between(Value):
     def __init__(self, arg, lower_bound, upper_bound):
         if not rlz.comparable(arg, lower_bound):
             raise TypeError(
-                f'Argument with datatype {arg.output_dtype} and lower bound '
-                f'with datatype {lower_bound.output_dtype} are not comparable'
+                f'Arguments {rlz._arg_type_error_format(arg)} and '
+                f'{rlz._arg_type_error_format(lower_bound)} are not comparable'
             )
         if not rlz.comparable(arg, upper_bound):
             raise TypeError(
-                f'Argument with datatype {arg.output_dtype} and upper bound '
-                f'with datatype {upper_bound.output_dtype} are not comparable'
+                f'Arguments {rlz._arg_type_error_format(arg)} and '
+                f'{rlz._arg_type_error_format(upper_bound)} are not comparable'
             )
         super().__init__(arg=arg, lower_bound=lower_bound, upper_bound=upper_bound)
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -585,3 +585,12 @@ def window_from(table_ref, win, **kwargs):
         if not isinstance(order_var.output_dtype, dt.Timestamp):
             raise com.IbisInputError(error_msg)
     return win
+
+
+def _arg_type_error_format(op):
+    from ibis.expr.operations.generic import Literal
+
+    if isinstance(op, Literal):
+        return f"Literal({op.value}):{op.output_dtype}"
+    else:
+        return f"{op.name}:{op.output_dtype}"

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1623,3 +1623,29 @@ def test_numpy_ufuncs_dont_cast_columns():
     x = np.int64(1)
     for expr in [t.a + x, x + t.a]:
         assert expr.equals(t.a + ibis.literal(x))
+
+
+@pytest.mark.parametrize(
+    'operation',
+    [
+        operator.lt,
+        operator.gt,
+        operator.ge,
+        operator.le,
+        operator.eq,
+        operator.ne,
+    ],
+)
+def test_logical_comparison_rlz_incompatible_error(table, operation):
+    with pytest.raises(TypeError) as exc_info:
+        operation(table.b, "foo")
+
+    assert "b:int16 and Literal(foo):string" in str(exc_info.value)
+
+
+def test_case_rlz_incompatible_error(table):
+    case, result = "foo", table.a
+    with pytest.raises(TypeError) as exc_info:
+        table.g.case().when(case == result, result).end()
+
+    assert "a:int8 and Literal(foo):string" in str(exc_info.value)


### PR DESCRIPTION
Provides a little more information to the user about which expressions are causing the rule failure in logical comparisons and the Simple and Searched case builders.

Resolves #4710