### PR TITLE
fix(ux): fix infinite loop in interactive repr

### DIFF
--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -56,7 +56,7 @@ def _(dtype, values):
     floats = [float(v) for v in values]
     # Extract and format all finite floats
     finites = [f for f in floats if isfinite(f)]
-    if all(f == 0 or 1e-6 < abs(f) < 1e6 for f in finites):
+    if finites and all(f == 0 or 1e-6 < abs(f) < 1e6 for f in finites):
         strs = [f"{f:f}" for f in finites]
         # Trim matching trailing zeros
         while all(s.endswith("0") for s in strs):
@@ -65,8 +65,8 @@ def _(dtype, values):
     else:
         strs = [f"{f:e}" for f in finites]
     # Merge together the formatted finite floats with non-finite values
-    next_f = iter(strs).__next__
-    strs2 = [next_f() if isfinite(f) else str(f) for f in floats]
+    iterstrs = iter(strs)
+    strs2 = (next(iterstrs) if isfinite(f) else str(f) for f in floats)
     return [Text.styled(s, "bold cyan") for s in strs2]
 
 

--- a/ibis/tests/expr/test_pretty.py
+++ b/ibis/tests/expr/test_pretty.py
@@ -154,6 +154,13 @@ def test_format_nested_column():
 
 def test_format_fully_null_column():
     values = [None, None, None]
-    fmts, min_len, max_len = format_column(dt.int64, values)
+    fmts, *_ = format_column(dt.int64, values)
     strs = [str(f) for f in fmts]
     assert strs == [null, null, null]
+
+
+def test_all_empty_groups_repr():
+    values = [float("nan"), float("nan")]
+    dtype = dt.float64
+    fmts, *_ = format_column(dtype, values)
+    assert list(map(str, fmts)) == ["nan", "nan"]


### PR DESCRIPTION
This PR fixes an issue with the interactive repr that manifests as an infinite loop when printing a column whose values are all non-finite.

The issue was the use of `all` on an empty sequence in a `while` loop to check whether a list contained only elements whose values end with `"0"`.
That condition was based on a variable whose value is a list of finite values, which is empty (thus causing the infinite loop) because `nan` is the value
of an aggregate (when printing) with no elements.

The solution was to check whether the list of finites values is non-empty.
