### PR TITLE
test(pyspark): `notimpl` substr test

### DIFF
--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -208,7 +208,7 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.date_string_col.substr(2),
             lambda t: t.date_string_col.str[2:],
             id='substr-start-only',
-            marks=pytest.mark.notimpl(["datafusion", "polars"]),
+            marks=pytest.mark.notimpl(["datafusion", "polars", "pyspark"]),
         ),
         param(
             lambda t: t.date_string_col.left(2),


### PR DESCRIPTION
Fixes failing master pyspark tests.