### PR TITLE
fix(api): ensure that window functions are propagated

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -65,7 +65,7 @@ def _varargs_call(sa_func, t, args):
 
 def varargs(sa_func):
     def formatter(t, op):
-        return _varargs_call(sa_func, t, op.arg.values)
+        return _varargs_call(sa_func, t, op.args)
 
     return formatter
 

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -131,7 +131,7 @@ def cast(translator, op):
 
 def varargs(func_name):
     def varargs_formatter(translator, op):
-        return helpers.format_call(translator, func_name, *op.arg.values)
+        return helpers.format_call(translator, func_name, *op.args)
 
     return varargs_formatter
 
@@ -218,7 +218,7 @@ def hash(translator, op):
 
 
 def concat(translator, op):
-    joined_args = ', '.join(map(translator.translate, op.arg.values))
+    joined_args = ', '.join(map(translator.translate, op.args))
     return f"concat({joined_args})"
 
 

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -314,19 +314,19 @@ def searched_case(op):
 
 @translate.register(ops.Coalesce)
 def coalesce(op):
-    arg = translate(op.arg)
+    arg = translate(ops.NodeList(*op.args))
     return pl.coalesce(arg)
 
 
 @translate.register(ops.Least)
 def least(op):
-    arg = [translate(arg) for arg in op.arg]
+    arg = [translate(arg) for arg in op.args]
     return pl.min(arg)
 
 
 @translate.register(ops.Greatest)
 def greatest(op):
-    arg = [translate(arg) for arg in op.arg]
+    arg = [translate(arg) for arg in op.args]
     return pl.max(arg)
 
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -649,7 +649,7 @@ def compile_arbitrary(t, op, **kwargs):
 
 @compiles(ops.Coalesce)
 def compile_coalesce(t, op, **kwargs):
-    src_columns = t.translate(op.arg, **kwargs)
+    src_columns = t.translate(ops.NodeList(*op.args), **kwargs)
     if len(src_columns) == 1:
         return src_columns[0]
     else:
@@ -658,7 +658,7 @@ def compile_coalesce(t, op, **kwargs):
 
 @compiles(ops.Greatest)
 def compile_greatest(t, op, **kwargs):
-    src_columns = t.translate(op.arg, **kwargs)
+    src_columns = t.translate(ops.NodeList(*op.args), **kwargs)
     if len(src_columns) == 1:
         return src_columns[0]
     else:
@@ -667,7 +667,7 @@ def compile_greatest(t, op, **kwargs):
 
 @compiles(ops.Least)
 def compile_least(t, op, **kwargs):
-    src_columns = t.translate(op.arg, **kwargs)
+    src_columns = t.translate(ops.NodeList(*op.args), **kwargs)
     if len(src_columns) == 1:
         return src_columns[0]
     else:
@@ -1006,7 +1006,7 @@ def compile_string_split(t, op, **kwargs):
 
 @compiles(ops.StringConcat)
 def compile_string_concat(t, op, **kwargs):
-    src_columns = t.translate(op.arg, **kwargs)
+    src_columns = [t.translate(arg, **kwargs) for arg in op.args]
     return F.concat(*src_columns)
 
 

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -238,11 +238,7 @@ def _string_join(t, op):
 
 
 def _string_concat(t, op):
-    # yes, `arg`. for variadic functions `arg` is the list of arguments.
-    #
-    # `args` is always the list of values of the fields declared in the
-    # operation
-    return functools.reduce(operator.add, map(t.translate, op.arg.values))
+    return functools.reduce(operator.add, map(t.translate, op.args))
 
 
 def _date_from_ymd(t, op):

--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -6,6 +6,7 @@ from typing import Sequence
 from public import public
 
 import ibis.expr.rules as rlz
+from ibis.common.annotations import attribute
 from ibis.common.grounds import Concrete
 from ibis.expr.rules import Shape
 from ibis.util import UnnamedMarker, deprecated
@@ -86,6 +87,20 @@ class Value(Node, Named):
 
 
 @public
+class Variadic(Value):
+    output_shape = rlz.shape_like('arg')
+    output_dtype = rlz.dtype_like('arg')
+
+    @attribute.default
+    def output_shape(self):
+        return rlz.highest_precedence_shape(self.args)
+
+    @property
+    def args(self):
+        return self.arg
+
+
+@public
 class Alias(Value):
     arg = rlz.any
     name = rlz.instance_of((str, UnnamedMarker))
@@ -146,6 +161,10 @@ class NodeList(Node, Sequence[Node]):
         import ibis.expr.types as ir
 
         return ir.List(self)
+
+    @property
+    def args(self):
+        return self.values
 
 
 public(ValueOp=Value, UnaryOp=Unary, BinaryOp=Binary, ValueList=NodeList)

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -18,7 +18,7 @@ import ibis.expr.rules as rlz
 from ibis.common import exceptions as com
 from ibis.common.annotations import attribute
 from ibis.common.grounds import Singleton
-from ibis.expr.operations.core import Named, Unary, Value
+from ibis.expr.operations.core import Named, Unary, Value, Variadic
 from ibis.util import frozendict
 
 try:
@@ -155,31 +155,18 @@ class NullIf(Value):
 
 
 @public
-class CoalesceLike(Value):
-
-    # According to Impala documentation:
-    # Return type: same as the initial argument value, except that integer
-    # values are promoted to BIGINT and floating-point values are promoted to
-    # DOUBLE; use CAST() when inserting into a smaller numeric column
-    arg = rlz.nodes_of(rlz.any)
-
-    output_shape = rlz.shape_like('arg')
-    output_dtype = rlz.dtype_like('arg')
+class Coalesce(Variadic):
+    arg = rlz.variadic(rlz.any)
 
 
 @public
-class Coalesce(CoalesceLike):
-    pass
+class Greatest(Variadic):
+    arg = rlz.variadic(rlz.any)
 
 
 @public
-class Greatest(CoalesceLike):
-    pass
-
-
-@public
-class Least(CoalesceLike):
-    pass
+class Least(Variadic):
+    arg = rlz.variadic(rlz.any)
 
 
 @public

--- a/ibis/expr/operations/strings.py
+++ b/ibis/expr/operations/strings.py
@@ -3,7 +3,7 @@ from public import public
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
-from ibis.expr.operations.core import Unary, Value
+from ibis.expr.operations.core import Unary, Value, Variadic
 
 
 @public
@@ -216,15 +216,8 @@ class StringSplit(Value):
 
 
 @public
-class StringConcat(Value):
-    arg = rlz.nodes_of(rlz.string)
-
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
-
-    @attribute.default
-    def output_shape(self):
-        return rlz.highest_precedence_shape(self.arg.values)
+class StringConcat(Variadic):
+    arg = rlz.variadic(rlz.string)
 
 
 @public

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -123,7 +123,7 @@ class Value(Expr):
         >>> ibis.coalesce(None, 4, 5)
         Coalesce([ValueList(values=[None, 4, 5])])
         """
-        return ops.Coalesce([self, *args]).to_expr()
+        return ops.Coalesce(self, *args).to_expr()
 
     def greatest(self, *args: ir.Value) -> ir.Value:
         """Compute the largest value among the supplied arguments.
@@ -138,7 +138,7 @@ class Value(Expr):
         Value
             Maximum of the passed arguments
         """
-        return ops.Greatest([self, *args]).to_expr()
+        return ops.Greatest(self, *args).to_expr()
 
     def least(self, *args: ir.Value) -> ir.Value:
         """Compute the smallest value among the supplied arguments.
@@ -153,7 +153,7 @@ class Value(Expr):
         Value
             Minimum of the passed arguments
         """
-        return ops.Least([self, *args]).to_expr()
+        return ops.Least(self, *args).to_expr()
 
     def typeof(self) -> ir.StringValue:
         """Return the data type of the expression.

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -697,7 +697,7 @@ class StringValue(Value):
         StringValue
             All strings concatenated
         """
-        return ops.StringConcat([self, other, *args]).to_expr()
+        return ops.StringConcat(self, other, *args).to_expr()
 
     def __add__(self, other: str | StringValue) -> StringValue:
         """Concatenate strings.
@@ -712,7 +712,7 @@ class StringValue(Value):
         StringValue
             All strings concatenated
         """
-        return ops.StringConcat([self, other]).to_expr()
+        return ops.StringConcat(self, other).to_expr()
 
     def __radd__(self, other: str | StringValue) -> StringValue:
         """Concatenate strings.
@@ -727,7 +727,7 @@ class StringValue(Value):
         StringValue
             All strings concatenated
         """
-        return ops.StringConcat([other, self]).to_expr()
+        return ops.StringConcat(other, self).to_expr()
 
     def convert_base(
         self,

--- a/ibis/tests/expr/test_operations.py
+++ b/ibis/tests/expr/test_operations.py
@@ -66,7 +66,7 @@ operations = [
     ops.RegexReplace('asd', 'as', 'a'),
     ops.StringReplace('asd', 'as', 'a'),
     ops.StringSplit('asd', 's'),
-    ops.StringConcat(['s', 'e']),
+    ops.StringConcat('s', 'e'),
     ops.StartsWith('asd', 'as'),
     ops.EndsWith('asd', 'xyz'),
     ops.Not(false),


### PR DESCRIPTION
This PR fixes window function propagation.

I had to refactor some of the operations to be variadic, so that I didn't have
to hack in support for `NodeList` inside of `propagate_down_window`.

Resolves #4722.
