### PR TITLE
ci: ignore `poetry-check`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ci:
   autofix_commit_msg: "style: auto fixes from pre-commit.ci hooks"
   autofix_prs: false
-  autoupdate_commit_msg: "style: pre-commit.ci autoupdate"
+  autoupdate_commit_msg: "chore(deps): pre-commit.ci autoupdate"
   skip:
     - prettier
     - shellcheck
@@ -9,11 +9,12 @@ ci:
     - just
     - nixpkgs-fmt
     - nix-linter
+    - poetry-check
 default_stages:
   - commit
 repos:
   - repo: https://github.com/python-poetry/poetry
-    rev: 1.2.1
+    rev: 1.2.2
     hooks:
       - id: poetry-check
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
Ignores poetry check in ci so that we do not have to deal with broken upgrades. See https://github.com/pre-commit/pre-commit/issues/2507 for details.