### PR TITLE
ci: allow snowflake to fail

### DIFF
--- a/.github/workflows/ibis-snowflake.yml
+++ b/.github/workflows/ibis-snowflake.yml
@@ -59,19 +59,7 @@ jobs:
         run: just download-data
 
       - name: "run parallel tests: ${{ matrix.backend.name }}"
+        continue-on-error: true
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
         env:
           SNOWFLAKE_URL: ${{ secrets.SNOWFLAKE_URL }}
-
-      - name: upload code coverage
-        if: success()
-        uses: codecov/codecov-action@v3
-        with:
-          flags: backend,${{ matrix.backend.name }},${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}
-
-      - name: publish test report
-        uses: actions/upload-artifact@v3
-        if: success() || failure()
-        with:
-          name: ${{ matrix.backend.name }}-${{ matrix.os }}-${{ matrix.python-version }}
-          path: junit.xml


### PR DESCRIPTION
Our snowflake credits are out, so we cannot successfully run these tests in CI anymore. I've reached out to someone at snowflake to see what we can do about this.