### PR TITLE
ci: re-enable snowflake tests

### DIFF
--- a/.github/workflows/ibis-snowflake.yml
+++ b/.github/workflows/ibis-snowflake.yml
@@ -59,7 +59,19 @@ jobs:
         run: just download-data
 
       - name: "run parallel tests: ${{ matrix.backend.name }}"
-        continue-on-error: true
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
         env:
           SNOWFLAKE_URL: ${{ secrets.SNOWFLAKE_URL }}
+
+      - name: upload code coverage
+        if: success()
+        uses: codecov/codecov-action@v3
+        with:
+          flags: backend,${{ matrix.backend.name }},${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}
+
+      - name: publish test report
+        uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: ${{ matrix.backend.name }}-${{ matrix.os }}-${{ matrix.python-version }}
+          path: junit.xml

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -513,7 +513,7 @@ def test_sa_default_numeric_precision_and_scale(
     table_name = 'test_sa_default_param_decimal'
     engine = con.con
     table = sa.Table(table_name, sa.MetaData(bind=engine), *sqla_types)
-    table.create(bind=engine)
+    table.create(bind=engine, checkfirst=True)
 
     try:
         # Check that we can correctly recover the default precision and scale.


### PR DESCRIPTION
Our snowflake credits are re-upd, so can now run these tests in CI again. Also fixed a bug when running tests in parallel where an existing table was recreated without first checking if it exists.