### PR TITLE
feat(api): add `agg` alias for `aggregate`

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -400,6 +400,8 @@ class Table(Expr, JupyterMixin):
 
         return agg.to_expr()
 
+    agg = aggregate
+
     def distinct(self) -> Table:
         """Compute the set of unique rows in the table."""
         return ops.Distinct(self).to_expr()


### PR DESCRIPTION
Add an `agg` alias for `aggregate`. I am really tired of typing out the entire word.