### PR TITLE
feat: support `Table.fillna` for SQL backends

### DIFF
--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -132,14 +132,10 @@ class ZeroIfNull(Unary):
 
 @public
 class IfNull(Value):
-    """Equivalent to (but perhaps implemented differently):
-
-    case().when(expr.notnull(), expr)       .else_(null_substitute_expr)
-    """
+    """Set values to ifnull_expr if they are equal to NULL."""
 
     arg = rlz.any
     ifnull_expr = rlz.any
-
     output_dtype = rlz.dtype_like("args")
     output_shape = rlz.shape_like("args")
 

--- a/ibis/tests/expr/test_format.py
+++ b/ibis/tests/expr/test_format.py
@@ -313,10 +313,10 @@ def test_fillna():
     expr = t.fillna({"a": 3})
     repr(expr)
 
-    expr = t.fillna(3)
+    expr = t[["a"]].fillna(3)
     repr(expr)
 
-    expr = t.fillna("foo")
+    expr = t[["b"]].fillna("foo")
     repr(expr)
 
 


### PR DESCRIPTION
This also fixes an incompatibility bug when passing in incompatibly typed scalars to `Table.fillna` (e.g. `table.fillna(0)` in a table containing string columns). Previously the output was backend defined - pandas, for example, would happily return a column mixing strings and integers.

We now allow casting of the fill value, but only between different numeric types. All other fill values must be of the proper column type, otherwise a nice error message is raised explaining the issue.