### PR TITLE
fix: exclude geospatial ops from pandas/dask/polars `has_operation`

### DIFF
--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -1,16 +1,14 @@
 import re
 
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
+from dask.dataframe.utils import tm
 from pytest import param
 
 import ibis
-
-dd = pytest.importorskip("dask.dataframe")
-from dask.dataframe.utils import tm  # noqa: E402
-
-from ibis.backends.dask.client import DaskTable  # noqa: E402
+from ibis.backends.dask.client import DaskTable
 
 
 def make_dask_data_frame(npartitions):

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -180,6 +180,11 @@ class BasePandasBackend(BaseBackend):
 
     @classmethod
     def has_operation(cls, operation: type[ops.Value]) -> bool:
+        # Pandas doesn't support geospatial ops, but the dispatcher implements
+        # a common base class that makes it appear that it does. Explicitly
+        # exclude these operations.
+        if issubclass(operation, (ops.GeoSpatialUnOp, ops.GeoSpatialBinOp)):
+            return False
         op_classes = cls._get_operations()
         return operation in op_classes or any(
             issubclass(operation, op_impl) for op_impl in op_classes

--- a/ibis/backends/pandas/tests/test_client.py
+++ b/ibis/backends/pandas/tests/test_client.py
@@ -5,7 +5,7 @@ import pytest
 from pytest import param
 
 import ibis
-from ibis.backends.pandas.client import PandasTable  # noqa: E402
+from ibis.backends.pandas.client import PandasTable
 
 
 @pytest.fixture

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -125,6 +125,11 @@ class Backend(BaseBackend):
 
     @classmethod
     def has_operation(cls, operation: type[ops.Value]) -> bool:
+        # Polars doesn't support geospatial ops, but the dispatcher implements
+        # a common base class that makes it appear that it does. Explicitly
+        # exclude these operations.
+        if issubclass(operation, (ops.GeoSpatialUnOp, ops.GeoSpatialBinOp)):
+            return False
         op_classes = cls._get_operations()
         return operation in op_classes or any(
             issubclass(operation, op_impl) for op_impl in op_classes

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -12,6 +12,7 @@ from pytest import mark, param
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.util import guid
 
@@ -812,3 +813,19 @@ def test_repr_mimebundle(alltypes, interactive, expr_type):
                 assert val not in reprs[format]
     finally:
         ibis.options.interactive = old
+
+
+@pytest.mark.never(
+    ["postgres", "mysql"],
+    reason="These backends explicitly do support Geo operations",
+)
+def test_has_operation_no_geo(con):
+    """Previously some backends mistakenly reported Geo operations as
+    supported.
+
+    Since most backends don't support Geo operations, we test that
+    they're excluded here, skipping the few backends that explicitly do
+    support them.
+    """
+    for op in [ops.GeoDistance, ops.GeoAsText, ops.GeoUnaryUnion]:
+        assert not con.has_operation(op)


### PR DESCRIPTION
Fixes #4699.