### PR TITLE
feat(api): add `distinct` arg to `ArrayCollect`

### DIFF
--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -134,6 +134,17 @@ def _agg(func):
     return formatter
 
 
+def _array_collect(translator, op):
+    func_name = "groupArray"
+    args = ["DISTINCT " * op.distinct + translator.translate(op.arg)]
+
+    if (where := op.where) is not None:
+        args.append(translator.translate(where))
+        func_name += "If"
+
+    return f"{func_name}({', '.join(args)})"
+
+
 def _count_star(translator, op):
     # zero argument count == count(*), countIf when `where` is not None
     return _aggregate(translator, "count", where=op.where)
@@ -717,7 +728,7 @@ operation_registry = {
     ops.Min: _agg('min'),
     ops.ArgMin: _agg('argMin'),
     ops.ArgMax: _agg('argMax'),
-    ops.ArrayCollect: _agg('groupArray'),
+    ops.ArrayCollect: _array_collect,
     ops.StandardDev: _agg_variance_like('stddev'),
     ops.Variance: _agg_variance_like('var'),
     ops.Covariance: _agg_variance_like('covar'),

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -39,11 +39,19 @@ def execute_array_column(op, cols, **kwargs):
 
 
 # TODO - aggregations - #2553
-@execute_node.register(ops.ArrayCollect, dd.Series)
-def execute_array_collect(op, data, aggcontext=None, **kwargs):
+@execute_node.register(ops.ArrayCollect, dd.Series, bool, type(None))
+def execute_array_collect(op, data, distinct, where, aggcontext=None, **kwargs):
+    if distinct:
+        raise NotImplementedError(
+            "dask backend doesn't implement the `distinct` argument for .collect()"
+        )
     return aggcontext.agg(data, collect_list)
 
 
-@execute_node.register(ops.ArrayCollect, ddgb.SeriesGroupBy)
-def execute_array_collect_grouped_series(op, data, aggcontext=None, **kwargs):
+@execute_node.register(ops.ArrayCollect, ddgb.SeriesGroupBy, bool, type(None))
+def execute_array_collect_grouped_series(op, data, distinct, where, **kwargs):
+    if distinct:
+        raise NotImplementedError(
+            "dask backend doesn't implement the `distinct` argument for .collect()"
+        )
     return data.agg(collect_list)

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -745,7 +745,11 @@ def array_column(op):
 
 @translate.register(ops.ArrayCollect)
 def array_collect(op):
+    if op.distinct:
+        raise NotImplementedError("polars doesn't implement unique collect")
     arg = translate(op.arg)
+    if (where := op.where) is not None:
+        arg = arg.filter(translate(where))
     return arg.list()
 
 

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -488,8 +488,8 @@ def _covar(t, op):
 
 def _mode(t, op):
     arg = op.arg
-    if op.where is not None:
-        arg = op.where.to_expr().ifelse(arg, None).op()
+    if (where := op.where) is not None:
+        arg = ops.Where(where, arg, None)
     return sa.func.mode().within_group(t.translate(arg))
 
 
@@ -506,14 +506,23 @@ def _binary_variance_reduction(func):
         result = func(t.translate(x), t.translate(y))
 
         if (where := op.where) is not None:
-            if t._has_reduction_filter_syntax:
-                result = result.filter(t.translate(where))
-            else:
-                result = sa.case((t.translate(where), result), else_=sa.null())
+            return result.filter(t.translate(where))
 
         return result
 
     return variance_compiler
+
+
+def _array_agg(t, op):
+    arg = t.translate(op.arg)
+    if op.distinct:
+        arg = sa.distinct(arg)
+
+    result = sa.func.array_agg(arg)
+
+    if (where := op.where) is not None:
+        return result.filter(t.translate(where))
+    return result
 
 
 operation_registry.update(
@@ -585,7 +594,7 @@ operation_registry.update(
         ops.CumulativeAny: unary(sa.func.bool_or),
         # array operations
         ops.ArrayLength: unary(_cardinality),
-        ops.ArrayCollect: unary(sa.func.array_agg),
+        ops.ArrayCollect: _array_agg,
         ops.ArrayColumn: _array_column,
         ops.ArraySlice: _array_slice,
         ops.ArrayIndex: fixed_arity(

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1587,7 +1587,10 @@ def compile_array_repeat(t, op, **kwargs):
 @compiles(ops.ArrayCollect)
 def compile_array_collect(t, op, **kwargs):
     src_column = t.translate(op.arg, **kwargs)
-    return F.collect_list(src_column)
+    if (where := op.where) is not None:
+        src_column = F.when(t.translate(where, **kwargs), src_column)
+    func = F.collect_set if op.distinct else F.collect_list
+    return func(src_column)
 
 
 # --------------------------- Null Operations -----------------------------

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -277,8 +277,9 @@ class CountDistinct(Filterable, Reduction):
 
 
 @public
-class ArrayCollect(Reduction):
+class ArrayCollect(Filterable, Reduction):
     arg = rlz.column(rlz.any)
+    distinct = rlz.instance_of(bool)
 
     @attribute.default
     def output_dtype(self):

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -407,9 +407,11 @@ class Value(Expr):
             builder = builder.when(case, result)
         return builder.else_(default).end()
 
-    def collect(self) -> ir.ArrayValue:
+    def collect(
+        self, where: ir.BooleanValue | None = None, *, distinct: bool = False
+    ) -> ir.ArrayValue:
         """Return an array of the elements of this expression."""
-        return ops.ArrayCollect(self).to_expr()
+        return ops.ArrayCollect(self, where=where, distinct=distinct).to_expr()
 
     def identical_to(self, other: Value) -> ir.BooleanValue:
         """Return whether this expression is identical to other.


### PR DESCRIPTION
This PR adds a `distinct` boolean argument to `ArrayCollect` and also makes it a subclass of `Filterable` allowing the `where` argument.