### PR TITLE
feat(api): add `agg` alias to `group_by`

### DIFF
--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -88,6 +88,8 @@ class GroupedTable:
     def aggregate(self, metrics=None, **kwds):
         return self.table.aggregate(metrics, by=self.by, having=self._having, **kwds)
 
+    agg = aggregate
+
     def having(self, expr: ir.BooleanScalar) -> GroupedTable:
         """Add a post-aggregation result filter `expr`.
 


### PR DESCRIPTION
Follow up to the previous PR (#4765) that added agg to `Table`.