### PR TITLE
fix(repr): fix off by one in repr

### DIFF
--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -220,7 +220,9 @@ def to_rich_table(table, console_width=None):
     formatted_dtypes = []
     remaining = console_width - 1  # 1 char for left boundary
     for name, dtype in table.schema().items():
-        formatted, min_width, max_width = format_column(dtype, result[name].to_list())
+        formatted, min_width, max_width = format_column(
+            dtype, result[name].iloc[:nrows].to_list()
+        )
         dtype_str = format_dtype(dtype)
         if ibis.options.repr.interactive.show_types and not isinstance(
             dtype, (dt.Struct, dt.Map, dt.Array)


### PR DESCRIPTION
The repr is currently including the "test" row that we use to determine whether an ellipsis is necessary. This PR fixes that.

### Before
```
In [5]: import ibis, pandas as pd, numpy as np; ibis.options.interactive = True; from ibis import _

In [6]: t = ibis.memtable(pd.DataFrame({'a': list(range(1, 16))}))

In [7]: t
Out[7]:
┏━━━━━━━┓
┃ a     ┃
┡━━━━━━━┩
│ int64 │
├───────┤
│     1 │
│     2 │
│     3 │
│     4 │
│     5 │
│     6 │
│     7 │
│     8 │
│     9 │
│    10 │
│    11 │
│     … │
└───────┘
```

### After
```
In [1]: import ibis, pandas as pd, numpy as np; ibis.options.interactive = True; from ibis import _

In [2]: t = ibis.memtable(pd.DataFrame({'a': list(range(1, 16))}))

In [3]: t
Out[3]:
┏━━━━━━━┓
┃ a     ┃
┡━━━━━━━┩
│ int64 │
├───────┤
│     1 │
│     2 │
│     3 │
│     4 │
│     5 │
│     6 │
│     7 │
│     8 │
│     9 │
│    10 │
│     … │
└───────┘
```