### PR TITLE
perf(ux): remove pandas import overhead from `import ibis`

### DIFF
--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -1,16 +1,12 @@
 """Initialize Ibis module."""
 from __future__ import annotations
 
-# Converting an Ibis schema to a pandas DataFrame requires registering
-# some type conversions that are currently registered in the pandas backend
-import ibis.backends.pandas
-import ibis.config
-import ibis.expr.types as ir
 from ibis import util
 from ibis.backends.base import BaseBackend
 from ibis.common.exceptions import IbisError
 from ibis.config import options
 from ibis.expr import api
+from ibis.expr import types as ir
 from ibis.expr.api import *  # noqa: F401,F403
 
 __all__ = ['api', 'ir', 'util', 'BaseBackend', 'IbisError', 'options']
@@ -23,6 +19,7 @@ _KNOWN_BACKENDS = ['bigquery', 'heavyai']
 
 def __dir__() -> list[str]:
     """Adds tab completion for ibis backends to the top-level module."""
+
     out = set(__all__)
     out.update(ep.name for ep in util.backend_entry_points())
     return sorted(out)
@@ -67,6 +64,8 @@ def __getattr__(name: str) -> BaseBackend:
     # The first time a backend is loaded, we register its options, and we set
     # it as an attribute of `ibis`, so `__getattr__` is not called again for it
     backend.register_options()
+
+    import ibis
 
     setattr(ibis, name, backend)
     return backend

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -15,10 +15,11 @@ import ibis.expr.types as ir
 import ibis.util as util
 from ibis.backends.base import BaseBackend
 from ibis.backends.base.sql.compiler import Compiler
-from ibis.expr.typing import TimeContext
 
 if TYPE_CHECKING:
     import pyarrow as pa
+
+    from ibis.expr.typing import TimeContext
 
 __all__ = [
     'BaseSQLBackend',

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import contextlib
 import getpass
 from operator import methodcaller
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
-import pandas as pd
 import sqlalchemy as sa
 
 import ibis
@@ -36,6 +35,10 @@ from ibis.backends.base.sql.alchemy.translator import (
     AlchemyContext,
     AlchemyExprTranslator,
 )
+
+if TYPE_CHECKING:
+    import pandas as pd
+
 
 __all__ = (
     'BaseAlchemyBackend',
@@ -139,6 +142,9 @@ class BaseAlchemyBackend(BaseSQLBackend):
         return df
 
     def fetch_from_cursor(self, cursor, schema: sch.Schema) -> pd.DataFrame:
+
+        import pandas as pd
+
         df = pd.DataFrame.from_records(
             cursor,
             columns=cursor.keys(),
@@ -177,6 +183,8 @@ class BaseAlchemyBackend(BaseSQLBackend):
         force
             Check whether a table exists before creating it
         """
+        import pandas as pd
+
         if isinstance(expr, pd.DataFrame):
             expr = ibis.memtable(expr)
 
@@ -452,6 +460,8 @@ class BaseAlchemyBackend(BaseSQLBackend):
         ValueError
             If the type of `obj` isn't supported
         """
+
+        import pandas as pd
 
         if database == self.current_database:
             # avoid fully qualified name

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Literal, Mapping
+from typing import TYPE_CHECKING, Any, Literal, Mapping
 
-import pandas as pd
 import toolz
 from clickhouse_driver.client import Client as _DriverClient
 
@@ -15,6 +14,9 @@ from ibis.backends.clickhouse.client import ClickhouseTable, fully_qualified_re
 from ibis.backends.clickhouse.compiler import ClickhouseCompiler
 from ibis.backends.clickhouse.datatypes import parse, serialize
 from ibis.config import options
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 _default_compression: str | bool
 
@@ -158,6 +160,8 @@ class Backend(BaseSQLBackend):
         Any
             The resutls of executing the query
         """
+        import pandas as pd
+
         external_tables_list = []
         if external_tables is None:
             external_tables = {}
@@ -183,6 +187,8 @@ class Backend(BaseSQLBackend):
             )
 
     def fetch_from_cursor(self, cursor, schema):
+        import pandas as pd
+
         data, _ = cursor
         names = schema.names
         if not data:

--- a/ibis/backends/clickhouse/client.py
+++ b/ibis/backends/clickhouse/client.py
@@ -1,9 +1,6 @@
 import re
 from typing import Any
 
-import numpy as np
-import pandas as pd
-
 import ibis.expr.types as ir
 
 fully_qualified_re = re.compile(r"(.*)\.(?:`(.*)`|(.*))")
@@ -40,6 +37,9 @@ class ClickhouseTable(ir.Table):
         return self.op().name
 
     def insert(self, obj, **kwargs):
+        import numpy as np
+        import pandas as pd
+
         from ibis.backends.clickhouse.identifiers import quote_identifier
 
         schema = self.schema()

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -106,8 +106,10 @@ stored in value
 
 See ibis.common.scope for details about the implementaion.
 """
+from __future__ import annotations
+
 import functools
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import dask.dataframe as dd
 from multipledispatch import Dispatcher
@@ -130,7 +132,9 @@ from ibis.backends.pandas.core import (
 )
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import canonicalize_context
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 is_computable_input.register(dd.core.Scalar)(is_computable_input_arg)
 
@@ -140,7 +144,7 @@ is_computable_input.register(dd.core.Scalar)(is_computable_input_arg)
 def execute_with_scope(
     node,
     scope: Scope,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     aggcontext=None,
     clients=None,
     **kwargs,
@@ -211,7 +215,7 @@ def execute_with_scope(
 def execute_until_in_scope(
     node,
     scope: Scope,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     aggcontext=None,
     clients=None,
     post_execute_=None,
@@ -350,7 +354,7 @@ def main_execute(
     node,
     params=None,
     scope=None,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     aggcontext=None,
     cache=None,
     **kwargs,
@@ -419,7 +423,7 @@ def execute_and_reset(
     node,
     params=None,
     scope=None,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     aggcontext=None,
     **kwargs,
 ):

--- a/ibis/backends/dask/execution/aggregations.py
+++ b/ibis/backends/dask/execution/aggregations.py
@@ -8,9 +8,11 @@
 
 """
 
+from __future__ import annotations
+
 import functools
 import operator
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
@@ -21,14 +23,16 @@ from ibis.backends.dask.dispatch import execute_node
 from ibis.backends.dask.execution.util import coerce_to_output, safe_concat
 from ibis.backends.pandas.execution.generic import agg_ctx
 from ibis.expr.scope import Scope
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 
 # TODO - aggregations - #2553
 # Not all code paths work cleanly here
 @execute_node.register(ops.Aggregation, dd.DataFrame)
 def execute_aggregation_dataframe(
-    op, data, scope=None, timecontext: Optional[TimeContext] = None, **kwargs
+    op, data, scope=None, timecontext: TimeContext | None = None, **kwargs
 ):
     assert op.metrics, 'no metrics found during aggregation execution'
 

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -1,5 +1,7 @@
 """Execution rules for generic ibis operations."""
 
+from __future__ import annotations
+
 import collections
 import datetime
 import decimal

--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -1,9 +1,10 @@
 """Dispatching code for Selection operations."""
 
+from __future__ import annotations
 
 import functools
 import operator
-from typing import List, Optional
+from typing import TYPE_CHECKING
 
 import dask.dataframe as dd
 import pandas
@@ -27,7 +28,9 @@ from ibis.backends.pandas.execution.selection import (
 from ibis.backends.pandas.execution.util import get_join_suffix_for_op
 from ibis.expr.rules import Shape
 from ibis.expr.scope import Scope
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 
 # TODO(kszucs): deduplicate with pandas.compute_projection() since it is almost
@@ -37,7 +40,7 @@ def compute_projection(
     parent,
     data,
     scope: Scope = None,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     **kwargs,
 ):
     """Compute a projection.
@@ -133,7 +136,7 @@ def compute_projection(
 
 
 def build_df_from_projection(
-    selections: List[ops.Node],
+    selections: list[ops.Node],
     op: ops.Selection,
     data: dd.DataFrame,
     **kwargs,
@@ -164,7 +167,7 @@ def execute_selection_dataframe(
     op,
     data,
     scope: Scope,
-    timecontext: Optional[TimeContext],
+    timecontext: TimeContext | None,
     **kwargs,
 ):
     result = data
@@ -238,7 +241,7 @@ def _compute_predicates(
     predicates,
     data,
     scope: Scope,
-    timecontext: Optional[TimeContext],
+    timecontext: TimeContext | None,
     **kwargs,
 ):
     """Compute the predicates for a table operation.

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Type, Union
 
 import dask.dataframe as dd
 import dask.delayed
@@ -17,7 +17,9 @@ import ibis.util
 from ibis.backends.dask.core import execute
 from ibis.backends.pandas.trace import TraceTwoLevelDispatcher
 from ibis.expr.scope import Scope
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 DispatchRule = Tuple[Tuple[Union[Type, Tuple], ...], Callable]
 

--- a/ibis/backends/dask/execution/window.py
+++ b/ibis/backends/dask/execution/window.py
@@ -1,6 +1,8 @@
 """Code for computing window functions in the dask backend."""
 
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import dask.dataframe as dd
 
@@ -16,13 +18,15 @@ from ibis.backends.dask.execution.util import (
     make_meta_series,
 )
 from ibis.expr.scope import Scope
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 
 def _post_process_empty(
     result: Any,
-    parent: Union[dd.Series, dd.DataFrame],
-    timecontext: Optional[TimeContext],
+    parent: dd.Series | dd.DataFrame,
+    timecontext: TimeContext | None,
 ) -> dd.Series:
     """Post process non grouped, non ordered windows.
 
@@ -57,7 +61,7 @@ def execute_window_op(
     data,
     window,
     scope: Scope,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     aggcontext=None,
     clients=None,
     **kwargs,

--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 from pandas import Timedelta, Timestamp
 
@@ -11,7 +15,9 @@ from ibis.expr.timecontext import (
     adjust_context,
     compare_timecontext,
 )
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 dd = pytest.importorskip("dask.dataframe")
 from dask.dataframe.utils import tm  # noqa: E402

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -9,7 +9,6 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator, Mapping, MutableMapping
 
-import pandas as pd
 import pyarrow as pa
 import pyarrow.types as pat
 import sqlalchemy as sa
@@ -331,7 +330,10 @@ class Backend(BaseAlchemyBackend):
         cursor: duckdb.DuckDBPyConnection,
         schema: sch.Schema,
     ):
+        import pandas as pd
+
         table = cursor.cursor.fetch_arrow_table()
+
         df = pd.DataFrame(
             {
                 name: (

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -10,11 +10,10 @@ import re
 import weakref
 from pathlib import Path
 from posixpath import join as pjoin
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import fsspec
 import numpy as np
-import pandas as pd
 
 import ibis.common.exceptions as com
 import ibis.config
@@ -47,6 +46,10 @@ from ibis.backends.impala.udf import (  # noqa F408
     wrap_udf,
 )
 from ibis.config import options
+
+if TYPE_CHECKING:
+    import pandas as pd
+
 
 _HS2_TTypeId_to_dtype = {
     'BOOLEAN': 'bool',
@@ -159,6 +162,8 @@ def _chunks_to_pandas_array(chunks):
 
 
 def _column_batches_to_dataframe(names, batches):
+    import pandas as pd
+
     cols = {}
     for name, chunks in zip(names, zip(*(b.columns for b in batches))):
         cols[name] = _chunks_to_pandas_array(chunks)
@@ -539,6 +544,9 @@ class Backend(BaseSQLBackend):
 
     @contextlib.contextmanager
     def _setup_insert(self, obj):
+
+        import pandas as pd
+
         if isinstance(obj, pd.DataFrame):
             with DataFrameWriter(self, obj) as writer:
                 yield writer.delimited_table(writer.write_temp_csv())

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import time
 import traceback
+from typing import TYPE_CHECKING
 
-import pandas as pd
 import sqlalchemy as sa
 
 import ibis.common.exceptions as com
@@ -18,6 +20,9 @@ from ibis.backends.base.sql.ddl import (
 )
 from ibis.backends.impala import ddl
 from ibis.backends.impala.compat import HS2Error, impyla
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 class ImpalaDatabase(Database):

--- a/ibis/backends/impala/metadata.py
+++ b/ibis/backends/impala/metadata.py
@@ -14,8 +14,6 @@
 
 from io import StringIO
 
-import pandas as pd
-
 
 def parse_metadata(descr_table):
     parser = MetadataParser(descr_table)
@@ -44,6 +42,8 @@ _get_comment = _item_converter(2)
 
 
 def _try_timestamp(x):
+    import pandas as pd
+
     try:
         ts = pd.Timestamp(x, tz='UTC')
         return ts.to_pydatetime().replace(tzinfo=None)
@@ -57,6 +57,8 @@ def _try_unix_timestamp(x):
     except (ValueError, TypeError):
         return x
     else:
+        import pandas as pd
+
         return (
             pd.Timestamp.fromtimestamp(value, tz="UTC")
             .tz_localize(None)
@@ -237,6 +239,8 @@ class MetadataParser:
     _storage_param_cleaners = {}
 
     def _parse_nested_params(self, cleaners):
+        import pandas as pd
+
         params = {}
         while True:
             try:

--- a/ibis/backends/mysql/registry.py
+++ b/ibis/backends/mysql/registry.py
@@ -1,6 +1,5 @@
 import operator
 
-import pandas as pd
 import sqlalchemy as sa
 
 import ibis
@@ -136,8 +135,10 @@ def _literal(_, op):
         return list(map(sa.literal, op.value))
     else:
         value = op.value
-        if isinstance(value, pd.Timestamp):
+        try:
             value = value.to_pydatetime()
+        except AttributeError:
+            pass
 
         lit = sa.literal(value)
         if op.output_dtype.is_timestamp():

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -103,11 +103,12 @@ stored in value
 See ibis.common.scope for details about the implementaion.
 """
 
+from __future__ import annotations
 
 import datetime
 import functools
 import numbers
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -129,7 +130,9 @@ from ibis.backends.pandas.dispatch import (
 from ibis.backends.pandas.trace import trace
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import canonicalize_context
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 integer_types = np.integer, int
 floating_types = (numbers.Real,)
@@ -172,7 +175,7 @@ ibis.util.consume(
 def execute_with_scope(
     node,
     scope: Scope,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     aggcontext=None,
     clients=None,
     **kwargs,
@@ -241,7 +244,7 @@ def execute_with_scope(
 def execute_until_in_scope(
     node,
     scope: Scope,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     aggcontext=None,
     clients=None,
     post_execute_=None,
@@ -381,7 +384,7 @@ def main_execute(
     node,
     params=None,
     scope=None,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     aggcontext=None,
     cache=None,
     **kwargs,
@@ -449,7 +452,7 @@ def execute_and_reset(
     node,
     params=None,
     scope=None,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     aggcontext=None,
     **kwargs,
 ):
@@ -547,7 +550,7 @@ See ``computable_args`` in ``execute_until_in_scope``
 def compute_time_context_default(
     node: ops.Node,
     scope: Scope,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     **kwargs,
 ):
     return [timecontext for arg in get_node_arguments(node) if is_computable_input(arg)]

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -1,5 +1,7 @@
 """Execution rules for generic ibis operations."""
 
+from __future__ import annotations
+
 import collections
 import datetime
 import decimal
@@ -8,7 +10,7 @@ import math
 import numbers
 import operator
 from collections.abc import Mapping, Sized
-from typing import Dict, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -41,7 +43,9 @@ from ibis.backends.pandas.execution import constants
 from ibis.backends.pandas.execution.util import coerce_to_output, get_grouping
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import get_time_col
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 
 # By default return the literal value
@@ -437,7 +441,7 @@ def execute_aggregation_dataframe(
     op,
     data,
     scope=None,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     **kwargs,
 ):
     assert op.metrics, 'no metrics found during aggregation execution'
@@ -455,7 +459,7 @@ def execute_aggregation_dataframe(
         )
         data = data.loc[predicate]
 
-    columns: Dict[str, str] = {}
+    columns: dict[str, str] = {}
 
     if op.by:
         grouping_keys = [
@@ -1077,7 +1081,7 @@ for typ in (str, *scalar_types):
 
 @execute_node.register(PandasTable, PandasBackend)
 def execute_database_table_client(
-    op, client, timecontext: Optional[TimeContext], **kwargs
+    op, client, timecontext: TimeContext | None, **kwargs
 ):
     df = client.dictionary[op.name]
     if timecontext:

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -1,9 +1,11 @@
 """Dispatching code for Selection operations."""
 
+from __future__ import annotations
+
 import functools
 import operator
 from collections import defaultdict
-from typing import List, Optional
+from typing import TYPE_CHECKING
 
 import pandas as pd
 from toolz import concatv, first
@@ -17,7 +19,9 @@ from ibis.backends.pandas.execution import constants, util
 from ibis.backends.pandas.execution.util import coerce_to_output
 from ibis.expr.rules import Shape
 from ibis.expr.scope import Scope
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 
 def compute_projection(
@@ -25,7 +29,7 @@ def compute_projection(
     parent,
     data,
     scope: Scope = None,
-    timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None = None,
     **kwargs,
 ):
     """Compute a projection.
@@ -183,7 +187,7 @@ def _compute_predicates(
     predicates,
     data,
     scope: Scope,
-    timecontext: Optional[TimeContext],
+    timecontext: TimeContext | None,
     **kwargs,
 ):
     """Compute the predicates for a table operation.
@@ -230,7 +234,7 @@ def _compute_predicates(
 
 
 def build_df_from_selection(
-    selections: List[ops.Value],
+    selections: list[ops.Value],
     data: pd.DataFrame,
     table: ops.Node,
 ) -> pd.DataFrame:
@@ -271,7 +275,7 @@ def build_df_from_selection(
 
 
 def build_df_from_projection(
-    selection_exprs: List[ir.Expr],
+    selection_exprs: list[ir.Expr],
     op: ops.Selection,
     data: pd.DataFrame,
     **kwargs,
@@ -302,7 +306,7 @@ def execute_selection_dataframe(
     op,
     data,
     scope: Scope,
-    timecontext: Optional[TimeContext],
+    timecontext: TimeContext | None,
     **kwargs,
 ):
     result = data

--- a/ibis/backends/pandas/execution/timecontext.py
+++ b/ibis/backends/pandas/execution/timecontext.py
@@ -29,7 +29,9 @@ This is an optional feature. The result of executing an expression without time
 context is conceptually the same as executing an expression with (-inf, inf)
 time context.
 """
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import ibis.expr.operations as ops
 from ibis.backends.base import BaseBackend
@@ -40,16 +42,18 @@ from ibis.backends.pandas.core import (
 )
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import adjust_context
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 
 @compute_time_context.register(ops.AsOfJoin)
 def compute_time_context_asof_join(
     op: ops.AsOfJoin,
     scope: Scope,
-    clients: List[BaseBackend],
-    timecontext: Optional[TimeContext] = None,
-    **kwargs
+    clients: list[BaseBackend],
+    timecontext: TimeContext | None = None,
+    **kwargs,
 ):
     new_timecontexts = [
         timecontext for arg in get_node_arguments(op) if is_computable_input(arg)
@@ -71,9 +75,9 @@ def compute_time_context_asof_join(
 def compute_time_context_window(
     op: ops.Window,
     scope: Scope,
-    clients: List[BaseBackend],
-    timecontext: Optional[TimeContext] = None,
-    **kwargs
+    clients: list[BaseBackend],
+    timecontext: TimeContext | None = None,
+    **kwargs,
 ):
     new_timecontexts = [
         timecontext for arg in get_node_arguments(op) if is_computable_input(arg)

--- a/ibis/backends/pandas/tests/execution/test_timecontext.py
+++ b/ibis/backends/pandas/tests/execution/test_timecontext.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pandas as pd
 import pandas.testing as tm
 import pytest
@@ -15,7 +19,9 @@ from ibis.expr.timecontext import (
     compare_timecontext,
     construct_time_context_aware_series,
 )
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 
 class CustomAsOfJoin(ops.AsOfJoin):

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
-import pandas as pd
 import pyspark
 import sqlalchemy as sa
 from pyspark import SparkConf
@@ -31,6 +30,9 @@ from ibis.backends.pyspark.compiler import PySparkDatabaseTable, PySparkExprTran
 from ibis.backends.pyspark.datatypes import spark_dtype
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import canonicalize_context, localize_context
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 _read_csv_defaults = {
     'header': True,
@@ -442,6 +444,8 @@ class Backend(BaseSQLBackend):
         --------
         >>> con.create_table('new_table_name', table_expr)  # doctest: +SKIP
         """
+        import pandas as pd
+
         if obj is not None:
             if isinstance(obj, pd.DataFrame):
                 spark_df = self._session.createDataFrame(obj)

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
-import pandas as pd
 import pyspark as ps
 
 import ibis.common.exceptions as com
@@ -11,6 +10,9 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.backends.base.sql.ddl import fully_qualified_re
 from ibis.backends.pyspark import ddl
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 @sch.infer.register(ps.sql.dataframe.DataFrame)
@@ -105,6 +107,8 @@ class PySparkTable(ir.Table):
         # Completely overwrite contents
         >>> t.insert(table_expr, overwrite=True)  # doctest: +SKIP
         """
+        import pandas as pd
+
         if isinstance(obj, pd.DataFrame):
             spark_df = self._session.createDataFrame(obj)
             spark_df.insertInto(self.name, overwrite=overwrite)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -2,7 +2,6 @@ import collections
 import enum
 import functools
 
-import pandas as pd
 import pyspark
 import pyspark.sql.functions as F
 import pyspark.sql.types as pt
@@ -327,6 +326,8 @@ def compile_subtract(t, op, **kwargs):
 @compile_nan_as_null
 def compile_literal(t, op, *, raw=False, **kwargs):
     """If raw is True, don't wrap the result with F.lit()"""
+    import pandas as pd
+
     value = op.value
     dtype = op.dtype
 
@@ -1398,6 +1399,8 @@ def compiles_day_of_week_name(t, op, **kwargs):
 
 
 def _get_interval_col(t, op, allowed_units=None, **kwargs):
+    import pandas as pd
+
     dtype = op.output_dtype
     if not dtype.is_interval():
         raise com.UnsupportedArgumentError(

--- a/ibis/backends/pyspark/tests/test_timecontext.py
+++ b/ibis/backends/pyspark/tests/test_timecontext.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pandas as pd
 import pandas.testing as tm
 import pytest
@@ -6,7 +10,9 @@ import ibis
 import ibis.expr.operations as ops
 from ibis.expr.scope import Scope
 from ibis.expr.timecontext import adjust_context
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 pytest.importorskip("pyspark")
 

--- a/ibis/backends/pyspark/timecontext.py
+++ b/ibis/backends/pyspark/timecontext.py
@@ -1,17 +1,21 @@
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pyspark.sql.functions as F
 from pyspark.sql.dataframe import DataFrame
 
 import ibis.common.exceptions as com
 from ibis.expr.timecontext import get_time_col
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 
 def filter_by_time_context(
     df: DataFrame,
-    timecontext: Optional[TimeContext],
-    adjusted_timecontext: Optional[TimeContext] = None,
+    timecontext: TimeContext | None,
+    adjusted_timecontext: TimeContext | None = None,
 ) -> DataFrame:
     """Filter a Dataframe by given time context
     Parameters
@@ -52,8 +56,8 @@ def filter_by_time_context(
 
 
 def combine_time_context(
-    timecontexts: List[TimeContext],
-) -> Optional[TimeContext]:
+    timecontexts: list[TimeContext],
+) -> TimeContext | None:
     """Return a combined time context of `timecontexts`
 
     The combined time context starts from the earliest begin time

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -20,7 +20,6 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import pandas as pd
 import sqlalchemy as sa
 from sqlalchemy.dialects.sqlite import DATETIME, TIMESTAMP
 
@@ -111,6 +110,8 @@ class Backend(BaseAlchemyBackend):
         >>> import ibis
         >>> ibis.sqlite.connect("path/to/my/sqlite.db")
         """
+        import pandas as pd
+
         if path is not None:
             warnings.warn(
                 "The `path` argument is deprecated in 4.0. Use `database=...`"

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest import param
 
-import ibis
+import ibis.expr.types as ir
 
 
 def test_backend_name(backend):
@@ -46,7 +46,7 @@ def test_tables_accessor_mapping(con):
     if con.name == "snowflake":
         pytest.skip("snowflake sometimes counts more tables than are around")
 
-    assert isinstance(con.tables["functional_alltypes"], ibis.ir.Table)
+    assert isinstance(con.tables["functional_alltypes"], ir.Table)
 
     with pytest.raises(KeyError, match="doesnt_exist"):
         con.tables["doesnt_exist"]
@@ -58,7 +58,7 @@ def test_tables_accessor_mapping(con):
 
 
 def test_tables_accessor_getattr(con):
-    assert isinstance(con.tables.functional_alltypes, ibis.ir.Table)
+    assert isinstance(con.tables.functional_alltypes, ir.Table)
 
     with pytest.raises(AttributeError, match="doesnt_exist"):
         getattr(con.tables, "doesnt_exist")

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import contextlib
 from typing import Any, Callable, Optional
 

--- a/ibis/expr/datatypes/cast.py
+++ b/ibis/expr/datatypes/cast.py
@@ -4,7 +4,6 @@ import collections
 import functools
 from typing import Any, Iterator
 
-import pandas as pd
 from multipledispatch import Dispatcher
 from public import public
 
@@ -143,6 +142,8 @@ def can_cast_string_to_temporal(
     value: str | None = None,
     **kwargs,
 ) -> bool:
+    import pandas as pd
+
     if value is None:
         return False
     try:

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -6,10 +6,17 @@ import decimal
 import enum
 import ipaddress
 import uuid
-from typing import AbstractSet, Any, Mapping, NamedTuple, Sequence, SupportsFloat
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Mapping,
+    NamedTuple,
+    Sequence,
+    SupportsFloat,
+)
 
 import numpy as np
-import pandas as pd
 import toolz
 from multipledispatch import Dispatcher
 from public import public
@@ -18,6 +25,9 @@ import ibis.expr.datatypes.core as dt
 from ibis.common.exceptions import IbisTypeError, InputTypeError
 from ibis.expr.datatypes.cast import highest_precedence
 from ibis.util import frozendict
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 try:
     import shapely.geometry as geo
@@ -113,6 +123,8 @@ def infer_timestamp(value: datetime.datetime) -> dt.Timestamp:
 def _get_timedelta_units(
     timedelta: datetime.timedelta | pd.Timedelta,
 ) -> list[str]:
+    import pandas as pd
+
     # pandas Timedelta has more granularity
     if isinstance(timedelta, pd.Timedelta):
         unit_fields = timedelta.components._fields

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -10,7 +10,6 @@ import uuid
 from operator import attrgetter
 
 import numpy as np
-import pandas as pd
 from public import public
 
 import ibis.expr.datatypes as dt
@@ -185,8 +184,6 @@ class Literal(Value):
             ipaddress.IPv6Address,
             np.generic,
             np.ndarray,
-            pd.Timedelta,
-            pd.Timestamp,
             str,
             tuple,
             type(None),

--- a/ibis/expr/scope.py
+++ b/ibis/expr/scope.py
@@ -33,12 +33,16 @@ the data stored in scope doesn't cover the current time context.
 For simplicity, we update cache in this case, instead of merge data of
 different time contexts.
 """
+from __future__ import annotations
+
 from collections import namedtuple
-from typing import Any, Dict, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Iterable
 
 from ibis.expr.operations import Node
 from ibis.expr.timecontext import TimeContextRelation, compare_timecontext
-from ibis.expr.typing import TimeContext
+
+if TYPE_CHECKING:
+    from ibis.expr.typing import TimeContext
 
 ScopeItem = namedtuple('ScopeItem', ['timecontext', 'value'])
 
@@ -46,8 +50,8 @@ ScopeItem = namedtuple('ScopeItem', ['timecontext', 'value'])
 class Scope:
     def __init__(
         self,
-        param: Dict[Node, Any] = None,
-        timecontext: Optional[TimeContext] = None,
+        param: dict[Node, Any] = None,
+        timecontext: TimeContext | None = None,
     ):
         """Take a dict of `op`, `result`, create a new scope and save those
         pairs in scope.
@@ -79,9 +83,7 @@ class Scope:
     def __iter__(self):
         return iter(self._items.keys())
 
-    def set_value(
-        self, op: Node, timecontext: Optional[TimeContext], value: Any
-    ) -> None:
+    def set_value(self, op: Node, timecontext: TimeContext | None, value: Any) -> None:
         """Set values in scope.
 
             Given an `op`, `timecontext` and `value`, set `op` and
@@ -109,7 +111,7 @@ class Scope:
         if self.get_value(op, timecontext) is None:
             self._items[op] = ScopeItem(timecontext, value)
 
-    def get_value(self, op: Node, timecontext: Optional[TimeContext] = None) -> Any:
+    def get_value(self, op: Node, timecontext: TimeContext | None = None) -> Any:
         """Given a op and timecontext, get the result from scope.
 
         Parameters
@@ -154,7 +156,7 @@ class Scope:
                 return self._items[op].value
         return None
 
-    def merge_scope(self, other_scope: 'Scope', overwrite=False) -> 'Scope':
+    def merge_scope(self, other_scope: Scope, overwrite=False) -> Scope:
         """merge items in other_scope into this scope.
 
         Parameters
@@ -185,7 +187,7 @@ class Scope:
                 result._items[op] = v
         return result
 
-    def merge_scopes(self, other_scopes: Iterable['Scope'], overwrite=False) -> 'Scope':
+    def merge_scopes(self, other_scopes: Iterable[Scope], overwrite=False) -> Scope:
         """merge items in other_scopes into this scope.
 
         Parameters

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -12,7 +12,6 @@ import ibis.expr.operations as ops
 from ibis.common.exceptions import IbisError, IbisTypeError, TranslationError
 from ibis.common.grounds import Immutable
 from ibis.config import _default_backend, options
-from ibis.expr.typing import TimeContext
 from ibis.util import UnnamedMarker, experimental
 
 if TYPE_CHECKING:
@@ -20,6 +19,7 @@ if TYPE_CHECKING:
 
     import ibis.expr.types as ir
     from ibis.backends.base import BaseBackend
+    from ibis.expr.typing import TimeContext
 
 
 # TODO(kszucs): consider to subclass from Annotable with a single _arg field

--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -2,7 +2,6 @@ import datetime
 from functools import singledispatch
 from math import isfinite
 
-import pandas as pd
 import rich
 from rich.align import Align
 from rich.console import Console
@@ -145,6 +144,8 @@ def _(dtype, values):
 
 
 def format_column(dtype, values):
+    import pandas as pd
+
     null_str = Text.styled("∅", "dim")
     if dtype.is_floating():
         # We don't want to treat `nan` as `NULL` for floating point types

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -16,7 +16,6 @@ from typing import (
     Sequence,
 )
 
-import numpy as np
 from public import public
 from rich.jupyter import JupyterMixin
 
@@ -196,6 +195,8 @@ class Table(Expr, JupyterMixin):
         return self.columns
 
     def _ensure_expr(self, expr):
+        import numpy as np
+
         if isinstance(expr, str):
             # treat strings as column names
             return self[expr]

--- a/ibis/expr/typing.py
+++ b/ibis/expr/typing.py
@@ -1,8 +1,9 @@
 """Define types for annotation."""
 
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
 
-import pandas as pd
+if TYPE_CHECKING:
+    import pandas as pd
 
-# Time context types
-TimeContext = Tuple[pd.Timestamp, pd.Timestamp]
+    # Time context types
+    TimeContext = Tuple[pd.Timestamp, pd.Timestamp]

--- a/ibis/expr/window.py
+++ b/ibis/expr/window.py
@@ -6,7 +6,6 @@ import functools
 from typing import NamedTuple
 
 import numpy as np
-import pandas as pd
 import toolz
 
 import ibis.expr.operations as ops
@@ -224,6 +223,8 @@ class Window(Comparable):
             raise IbisInputError(f"'how' must be 'rows' or 'range', got {self.how}")
 
         if self.max_lookback is not None:
+            import pandas as pd
+
             if not isinstance(self.preceding, (ir.IntervalValue, pd.Timedelta)):
                 raise IbisInputError(
                     "'max_lookback' must be specified as an interval "

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from __future__ import annotations
 
 import pytest
 
@@ -24,7 +24,6 @@ from ibis.backends.base.sql.alchemy import (
     table_from_schema,
 )
 from ibis.expr.schema import Schema
-from ibis.expr.typing import TimeContext
 
 MOCK_TABLES = {
     'alltypes': [
@@ -409,7 +408,7 @@ class MockBackend(BaseSQLBackend):
         expr,
         limit=None,
         params=None,
-        timecontext: Optional[TimeContext] = None,
+        timecontext=None,
     ):
         ast = self.compiler.to_ast_ensure_limit(expr, limit, params=params)
         queries = [q.compile() for q in ast.queries]

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import sys
 from importlib.metadata import EntryPoint
 from typing import NamedTuple
@@ -57,3 +58,13 @@ def test_multiple_backends(mocker):
     msg = r"\d+ packages found for backend 'foo'"
     with pytest.raises(RuntimeError, match=msg):
         ibis.foo
+
+
+def test_no_import_pandas():
+    script = """\
+import ibis
+import sys
+
+assert "pandas" not in sys.modules"""
+
+    subprocess.check_call([sys.executable], text=script)

--- a/ibis/udf/vectorized.py
+++ b/ibis/udf/vectorized.py
@@ -5,11 +5,12 @@ Warning: This is an experimental module and API here can change without notice.
 DO NOT USE DIRECTLY.
 """
 
+from __future__ import annotations
+
 import functools
-from typing import Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import pandas as pd
 
 import ibis.expr.datatypes as dt
 import ibis.udf.validate as v
@@ -19,12 +20,15 @@ from ibis.expr.operations import (
     ReductionVectorizedUDF,
 )
 
+if TYPE_CHECKING:
+    import pandas as pd
+
 
 def _coerce_to_dict(
-    data: Union[List, np.ndarray, pd.Series],
+    data: list | np.ndarray | pd.Series,
     output_type: dt.Struct,
-    index: Optional[pd.Index] = None,
-) -> Tuple:
+    index: pd.Index | None = None,
+) -> tuple:
     """Coerce the following shapes to a tuple.
 
     - [`list`][list]
@@ -35,9 +39,9 @@ def _coerce_to_dict(
 
 
 def _coerce_to_np_array(
-    data: Union[List, np.ndarray, pd.Series],
+    data: list | np.ndarray | pd.Series,
     output_type: dt.Struct,
-    index: Optional[pd.Index] = None,
+    index: pd.Index | None = None,
 ) -> np.ndarray:
     """Coerce the following shapes to an np.ndarray.
 
@@ -49,9 +53,9 @@ def _coerce_to_np_array(
 
 
 def _coerce_to_series(
-    data: Union[List, np.ndarray, pd.Series],
+    data: list | np.ndarray | pd.Series,
     output_type: dt.DataType,
-    original_index: Optional[pd.Index] = None,
+    original_index: pd.Index | None = None,
 ) -> pd.Series:
     """Coerce the following shapes to a Series.
 
@@ -78,6 +82,8 @@ def _coerce_to_series(
     pd.Series
         Output Series
     """
+    import pandas as pd
+
     if isinstance(data, (list, np.ndarray)):
         result = pd.Series(data)
     elif isinstance(data, pd.Series):
@@ -94,7 +100,7 @@ def _coerce_to_series(
 def _coerce_to_dataframe(
     data: Any,
     output_type: dt.Struct,
-    original_index: Optional[pd.Index] = None,
+    original_index: pd.Index | None = None,
 ) -> pd.DataFrame:
     """Coerce the following shapes to a DataFrame.
 
@@ -150,6 +156,8 @@ def _coerce_to_dataframe(
     0  1  2  3
     dtypes: [int32, int32, int32]
     """
+    import pandas as pd
+
     if isinstance(data, pd.DataFrame):
         result = data
     elif isinstance(data, pd.Series):


### PR DESCRIPTION
This PR moves pandas imports around to speed up `import ibis` by about 2x. In my local tests I see import times on `master` at about 500 ms, and after this PR I see import times at around 250 ms.