### PR TITLE
feat(backend): make `ArrayCollect` filterable

### DIFF
--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -134,6 +134,17 @@ def _agg(func):
     return formatter
 
 
+def _array_collect(translator, op):
+    func_name = "groupArray"
+    args = [translator.translate(op.arg)]
+
+    if (where := op.where) is not None:
+        args.append(translator.translate(where))
+        func_name += "If"
+
+    return f"{func_name}({', '.join(args)})"
+
+
 def _count_star(translator, op):
     # zero argument count == count(*), countIf when `where` is not None
     return _aggregate(translator, "count", where=op.where)
@@ -717,7 +728,7 @@ operation_registry = {
     ops.Min: _agg('min'),
     ops.ArgMin: _agg('argMin'),
     ops.ArgMax: _agg('argMax'),
-    ops.ArrayCollect: _agg('groupArray'),
+    ops.ArrayCollect: _array_collect,
     ops.StandardDev: _agg_variance_like('stddev'),
     ops.Variance: _agg_variance_like('var'),
     ops.Covariance: _agg_variance_like('covar'),

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -39,11 +39,11 @@ def execute_array_column(op, cols, **kwargs):
 
 
 # TODO - aggregations - #2553
-@execute_node.register(ops.ArrayCollect, dd.Series)
-def execute_array_collect(op, data, aggcontext=None, **kwargs):
+@execute_node.register(ops.ArrayCollect, dd.Series, type(None))
+def execute_array_collect(op, data, where, aggcontext=None, **kwargs):
     return aggcontext.agg(data, collect_list)
 
 
-@execute_node.register(ops.ArrayCollect, ddgb.SeriesGroupBy)
-def execute_array_collect_grouped_series(op, data, aggcontext=None, **kwargs):
+@execute_node.register(ops.ArrayCollect, ddgb.SeriesGroupBy, type(None))
+def execute_array_collect_grouped_series(op, data, where, **kwargs):
     return data.agg(collect_list)

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -746,6 +746,8 @@ def array_column(op):
 @translate.register(ops.ArrayCollect)
 def array_collect(op):
     arg = translate(op.arg)
+    if (where := op.where) is not None:
+        arg = arg.filter(translate(where))
     return arg.list()
 
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1587,6 +1587,8 @@ def compile_array_repeat(t, op, **kwargs):
 @compiles(ops.ArrayCollect)
 def compile_array_collect(t, op, **kwargs):
     src_column = t.translate(op.arg, **kwargs)
+    if (where := op.where) is not None:
+        src_column = F.when(t.translate(where, **kwargs), src_column)
     return F.collect_list(src_column)
 
 

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -211,37 +211,37 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
             lambda t, _: t.bool_col.any(),
             lambda t, _: t.bool_col.any(),
             id='any',
-            marks=pytest.mark.notimpl(["polars"]),
+            marks=pytest.mark.notimpl(["polars", "datafusion"]),
         ),
         param(
             lambda t, _: t.bool_col.notany(),
             lambda t, _: ~t.bool_col.any(),
             id='notany',
-            marks=pytest.mark.notimpl(["polars"]),
+            marks=pytest.mark.notimpl(["polars", "datafusion"]),
         ),
         param(
             lambda t, _: -t.bool_col.any(),
             lambda t, _: ~t.bool_col.any(),
             id='any_negate',
-            marks=pytest.mark.notimpl(["polars"]),
+            marks=pytest.mark.notimpl(["polars", "datafusion"]),
         ),
         param(
             lambda t, _: t.bool_col.all(),
             lambda t, _: t.bool_col.all(),
             id='all',
-            marks=pytest.mark.notimpl(["polars"]),
+            marks=pytest.mark.notimpl(["polars", "datafusion"]),
         ),
         param(
             lambda t, _: t.bool_col.notall(),
             lambda t, _: ~t.bool_col.all(),
             id='notall',
-            marks=pytest.mark.notimpl(["polars"]),
+            marks=pytest.mark.notimpl(["polars", "datafusion"]),
         ),
         param(
             lambda t, _: -t.bool_col.all(),
             lambda t, _: ~t.bool_col.all(),
             id='all_negate',
-            marks=pytest.mark.notimpl(["polars"]),
+            marks=pytest.mark.notimpl(["polars", "datafusion"]),
         ),
         param(
             lambda t, where: t.double_col.sum(where=where),
@@ -292,6 +292,7 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
                     "sqlite",
                     "snowflake",
                     "polars",
+                    "datafusion",
                 ]
             ),
         ),
@@ -308,6 +309,7 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
                     "sqlite",
                     "snowflake",
                     "polars",
+                    "datafusion",
                 ]
             ),
         ),
@@ -315,27 +317,31 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
             lambda t, where: t.double_col.std(how='sample', where=where),
             lambda t, where: t.double_col[where].std(ddof=1),
             id='std',
+            marks=[mark.notimpl(["datafusion"])],
         ),
         param(
             lambda t, where: t.double_col.var(how='sample', where=where),
             lambda t, where: t.double_col[where].var(ddof=1),
             id='var',
+            marks=[mark.notimpl(["datafusion"])],
         ),
         param(
             lambda t, where: t.double_col.std(how='pop', where=where),
             lambda t, where: t.double_col[where].std(ddof=0),
             id='std_pop',
+            marks=[mark.notimpl(["datafusion"])],
         ),
         param(
             lambda t, where: t.double_col.var(how='pop', where=where),
             lambda t, where: t.double_col[where].var(ddof=0),
             id='var_pop',
+            marks=[mark.notimpl(["datafusion"])],
         ),
         param(
             lambda t, where: t.string_col.approx_nunique(where=where),
             lambda t, where: t.string_col[where].nunique(),
             id='approx_nunique',
-            marks=pytest.mark.notimpl(['polars']),
+            marks=pytest.mark.notimpl(['polars', "datafusion"]),
         ),
         param(
             lambda t, where: t.double_col.arbitrary(how='first', where=where),
@@ -349,6 +355,7 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
                     'sqlite',
                     'snowflake',
                     'polars',
+                    'datafusion',
                 ]
             ),
         ),
@@ -364,6 +371,7 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
                     'sqlite',
                     'snowflake',
                     'polars',
+                    'datafusion',
                 ]
             ),
         ),
@@ -393,7 +401,7 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
             lambda t, where: np.bitwise_and.reduce(t.bigint_col[where].values),
             id='bit_and',
             marks=[
-                pytest.mark.notimpl(["dask", "snowflake", "polars"]),
+                pytest.mark.notimpl(["dask", "snowflake", "polars", "datafusion"]),
                 pytest.mark.notyet(["impala", "pyspark"]),
             ],
         ),
@@ -402,7 +410,7 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
             lambda t, where: np.bitwise_or.reduce(t.bigint_col[where].values),
             id='bit_or',
             marks=[
-                pytest.mark.notimpl(["dask", "snowflake", "polars"]),
+                pytest.mark.notimpl(["dask", "snowflake", "polars", "datafusion"]),
                 pytest.mark.notyet(["impala", "pyspark"]),
             ],
         ),
@@ -411,7 +419,7 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
             lambda t, where: np.bitwise_xor.reduce(t.bigint_col[where].values),
             id='bit_xor',
             marks=[
-                pytest.mark.notimpl(["dask", "snowflake", "polars"]),
+                pytest.mark.notimpl(["dask", "snowflake", "polars", "datafusion"]),
                 pytest.mark.notyet(["impala", "pyspark"]),
             ],
         ),
@@ -422,11 +430,11 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
         ),
         param(
             lambda t, where: t.string_col.collect(where=where),
-            lambda t, where: list(t.string_col[where]),
+            lambda t, where: t.string_col[where].tolist(),
             id="collect",
             marks=[
-                pytest.mark.notimpl(
-                    ["impala", "datafusion", "snowflake", "dask", "polars"]
+                mark.notimpl(
+                    ["dask", "impala", "mysql", "snowflake", "sqlite", "datafusion"]
                 )
             ],
         ),
@@ -440,10 +448,10 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
             lambda t: t.string_col.isin(['1', '7']),
             lambda t: t.string_col.isin(['1', '7']),
             id='is_in',
+            marks=[mark.notimpl(["datafusion"])],
         ),
     ],
 )
-@mark.notimpl(["datafusion"])
 def test_reduction_ops(
     backend,
     alltypes,
@@ -453,10 +461,14 @@ def test_reduction_ops(
     ibis_cond,
     pandas_cond,
 ):
-    expr = result_fn(alltypes, ibis_cond(alltypes))
-    result = expr.execute()
+    expr = alltypes.agg(tmp=result_fn(alltypes, ibis_cond(alltypes))).tmp
+    result = expr.execute().squeeze()
     expected = expected_fn(df, pandas_cond(df))
-    np.testing.assert_allclose(result, expected, rtol=backend.reduction_tolerance)
+    try:
+        np.testing.assert_allclose(result, expected, rtol=backend.reduction_tolerance)
+    except TypeError:  # assert_allclose only handles numerics
+        # if we're not testing numerics, then the arrays should be exactly equal
+        np.testing.assert_array_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -420,6 +420,16 @@ def test_aggregate_multikey_group_reduction(backend, alltypes, df):
             lambda t, where: len(t[where]),
             id='count_star',
         ),
+        param(
+            lambda t, where: t.string_col.collect(where=where),
+            lambda t, where: list(t.string_col[where]),
+            id="collect",
+            marks=[
+                pytest.mark.notimpl(
+                    ["impala", "datafusion", "snowflake", "dask", "polars"]
+                )
+            ],
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -277,7 +277,7 @@ class CountDistinct(Filterable, Reduction):
 
 
 @public
-class ArrayCollect(Reduction):
+class ArrayCollect(Filterable, Reduction):
     arg = rlz.column(rlz.any)
 
     @attribute.default

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -407,9 +407,9 @@ class Value(Expr):
             builder = builder.when(case, result)
         return builder.else_(default).end()
 
-    def collect(self) -> ir.ArrayValue:
+    def collect(self, where: ir.BooleanValue | None = None) -> ir.ArrayValue:
         """Return an array of the elements of this expression."""
-        return ops.ArrayCollect(self).to_expr()
+        return ops.ArrayCollect(self, where=where).to_expr()
 
     def identical_to(self, other: Value) -> ir.BooleanValue:
         """Return whether this expression is identical to other.


### PR DESCRIPTION
This PR makes `ArrayCollect` a filterable reduction, which adds support for the `where` argument similar to other reductions.