### PR TITLE
build: give `mkdocs` program access to the local ibis path

### DIFF
--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -123,6 +123,12 @@ in
       };
     });
 
+  mkdocs = super.mkdocs.overrideAttrs (_: {
+    postFixup = ''
+      wrapProgram $out/bin/mkdocs --prefix PYTHONPATH : ${builtins.toPath ./.}
+    '';
+  });
+
   mkdocs-table-reader-plugin = super.mkdocs-table-reader-plugin.overridePythonAttrs (_: {
     postPatch = ''
       substituteInPlace setup.py --replace "tabulate>=0.8.7" "tabulate"


### PR DESCRIPTION
This PR gives the mkdocs program access to the ibis path for development.