### PR TITLE
build(docs): allow warnings in doc builds; disallow in CI

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -137,7 +137,7 @@ jobs:
           fetch-depth: 0
 
       - name: build docs
-        run: nix run -f nix ibisDocsEnv310 -- -m mkdocs build
+        run: nix run -f nix ibisDocsEnv310 -- -m mkdocs build --strict
 
       - name: verify internal links
         run: nix shell -f nix --ignore-environment bash findutils just lychee -c just checklinks --offline --no-progress

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Ibis Project
 site_url: https://ibis-project.org
-strict: true
+strict: false # check for strictness when building the docs in CI
 repo_url: https://github.com/ibis-project/ibis
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
This PR makes it slightly more convenient to iterate on doc builds: the build will no longer fail locally, but will fail if any warnings are generated when built in CI.