### PR TITLE
chore(dev-deps): remove poetry check pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,14 +9,9 @@ ci:
     - just
     - nixpkgs-fmt
     - nix-linter
-    - poetry-check
 default_stages:
   - commit
 repos:
-  - repo: https://github.com/python-poetry/poetry
-    rev: 1.2.2
-    hooks:
-      - id: poetry-check
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:


### PR DESCRIPTION
There's an ideological divide that prevents poetry and pre-commit from
collaborating effectively to allow poetry pre-commit hooks to be updated
by pre-commit. This check isn't that useful so I'm removing it.
