### PR TITLE
feat(sqlite): support `con.sql` with explicit schema specified

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -90,23 +90,26 @@ class BaseSQLBackend(BaseBackend):
         # XXX
         return name
 
-    def sql(self, query: str) -> ir.Table:
+    def sql(self, query: str, schema: sch.Schema | None = None) -> ir.Table:
         """Convert a SQL query to an Ibis table expression.
 
         Parameters
         ----------
         query
             SQL string
+        schema
+            The expected schema for this query. If not provided, will be
+            inferred automatically if possible.
 
         Returns
         -------
         Table
             Table expression
         """
-        # Get the schema by adding a LIMIT 0 on to the end of the query. If
-        # there is already a limit in the query, we find and remove it
-        limited_query = f'SELECT * FROM ({query}) t0 LIMIT 0'
-        schema = self._get_schema_using_query(limited_query)
+        if schema is None:
+            schema = self._get_schema_using_query(query)
+        else:
+            schema = sch.schema(schema)
         return ops.SQLQueryResult(query, schema, self).to_expr()
 
     def _get_schema_using_query(self, query):
@@ -387,5 +390,5 @@ class BaseSQLBackend(BaseBackend):
 
     def _create_temp_view(self, view, definition):
         raise NotImplementedError(
-            f"The {self.name} backend does not implement temporary view " "creation"
+            f"The {self.name} backend does not implement temporary view creation"
         )

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -981,7 +981,7 @@ class Backend(BaseSQLBackend):
         self.raw_sql(statement)
 
     def _get_schema_using_query(self, query):
-        cur = self.raw_sql(query)
+        cur = self.raw_sql(f"SELECT * FROM ({query}) t0 LIMIT 0")
         # resets the state of the cursor and closes operation
         cur.fetchall()
         names, ibis_types = self._adapt_types(cur.description)

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -255,7 +255,7 @@ class Backend(BaseSQLBackend):
         return _PySparkCursor(query)
 
     def _get_schema_using_query(self, query):
-        cur = self.raw_sql(query)
+        cur = self.raw_sql(f"SELECT * FROM ({query}) t0 LIMIT 0")
         return spark_dataframe_schema(cur.query)
 
     def _get_jtable(self, name, database=None):

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -106,7 +106,7 @@ class Backend(BaseAlchemyBackend):
 
     def _get_schema_using_query(self, query):
         with self.begin() as bind:
-            result = bind.execute(query)
+            result = bind.execute(f"SELECT * FROM ({query}) t0 LIMIT 0")
             info_rows = bind.execute(f"DESCRIBE RESULT {result.cursor.sfqid!r}")
 
         schema = {}

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     import ibis.expr.types as ir
     import ibis.expr.datatypes as dt
 
+import ibis.expr.schema as sch
 from ibis.backends.base import Database
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend, to_sqla_type
 from ibis.backends.sqlite import udf
@@ -205,3 +206,10 @@ class Backend(BaseAlchemyBackend):
     @property
     def _current_schema(self) -> str | None:
         return self.current_database
+
+    def _get_schema_using_query(self, query: str) -> sch.Schema:
+        raise ValueError(
+            "The SQLite backend cannot infer schemas from raw SQL - "
+            "please specify the schema directly when calling `.sql` "
+            "using the `schema` keyword argument"
+        )

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -4,15 +4,15 @@ import pytest
 import ibis
 from ibis import util
 
-dot_sql_notimpl = pytest.mark.notimpl(
-    ["clickhouse", "datafusion", "impala", "sqlite", "polars"]
-)
+REQUIRES_EXPLICIT_SCHEMA = {"sqlite"}
+table_dot_sql_notimpl = pytest.mark.notimpl(["sqlite", "clickhouse", "impala"])
+dot_sql_notimpl = pytest.mark.notimpl(["datafusion"])
 dot_sql_notyet = pytest.mark.notyet(
     ["snowflake"],
     reason="snowflake column names are case insensitive",
 )
 dot_sql_never = pytest.mark.never(
-    ["dask", "pandas"],
+    ["dask", "pandas", "polars"],
     reason="dask and pandas do not accept SQL",
 )
 
@@ -22,7 +22,50 @@ pytestmark = pytest.mark.xdist_group("dot_sql")
 @dot_sql_notimpl
 @dot_sql_notyet
 @dot_sql_never
-def test_dot_sql(backend, con):
+@pytest.mark.parametrize("explicit_schema", [False, True])
+def test_con_dot_sql(backend, con, explicit_schema):
+    if not explicit_schema and con.name in REQUIRES_EXPLICIT_SCHEMA:
+        pytest.xfail(f"{con.name} requires an explicit schema for .sql")
+    if explicit_schema:
+        schema = {"s": "string", "new_col": "double"}
+    else:
+        schema = None
+    alltypes = con.table("functional_alltypes")
+    t = (
+        con.sql(
+            """
+            SELECT
+                string_col as s,
+                double_col + 1.0 AS new_col
+            FROM functional_alltypes
+            """,
+            schema=schema,
+        )
+        .group_by("s")  # group by a column from SQL
+        .aggregate(yas=lambda t: t.new_col.max())
+        .order_by("yas")
+    )
+
+    alltypes_df = alltypes.execute()
+    result = t.execute()["yas"]
+    expected = (
+        alltypes_df.assign(
+            s=alltypes_df.string_col, new_col=alltypes_df.double_col + 1.0
+        )
+        .groupby("s")
+        .new_col.max()
+        .rename("yas")
+        .sort_values()
+        .reset_index(drop=True)
+    )
+    backend.assert_series_equal(result, expected)
+
+
+@table_dot_sql_notimpl
+@dot_sql_notimpl
+@dot_sql_notyet
+@dot_sql_never
+def test_table_dot_sql(backend, con):
     alltypes = con.table("functional_alltypes")
     t = (
         alltypes.sql(
@@ -54,10 +97,11 @@ def test_dot_sql(backend, con):
     backend.assert_series_equal(result, expected)
 
 
+@table_dot_sql_notimpl
 @dot_sql_notimpl
 @dot_sql_notyet
 @dot_sql_never
-def test_dot_sql_with_join(backend, con):
+def test_table_dot_sql_with_join(backend, con):
     alltypes = con.table("functional_alltypes")
     t = (
         alltypes.sql(
@@ -100,10 +144,11 @@ def test_dot_sql_with_join(backend, con):
     backend.assert_frame_equal(result, expected)
 
 
+@table_dot_sql_notimpl
 @dot_sql_notimpl
 @dot_sql_notyet
 @dot_sql_never
-def test_dot_sql_repr(con):
+def test_table_dot_sql_repr(con):
     alltypes = con.table("functional_alltypes")
     t = (
         alltypes.sql(
@@ -123,9 +168,10 @@ def test_dot_sql_repr(con):
     assert repr(t)
 
 
+@table_dot_sql_notimpl
 @dot_sql_notimpl
 @dot_sql_never
-def test_dot_sql_does_not_clobber_existing_tables(con):
+def test_table_dot_sql_does_not_clobber_existing_tables(con):
     name = f"ibis_{util.guid()}"
     con.create_table(name, schema=ibis.schema(dict(a="string")))
     try:


### PR DESCRIPTION
This adds support for `con.sql` to SQLite. It does this by exposing an optional `schema` kwarg to `.sql` for all backends, allowing the query schema to be specified explicitly. This is optional for all backends except SQLite where it is required - if not specified a nice error message is raised.

Note that SQLite still doesn't support `TableExpr.sql`, since that requires temporary view creation.

This also rearranges the `.sql` tests a bit to better test the supported backends. In particular, `clickhouse` and `impala` do support `con.sql` but not `TableExpr.sql`. But since all backend tests were using the latter these backends weren't being tested.