### PR TITLE
ci: drop coverage from tpch tests

### DIFF
--- a/.github/workflows/ibis-tpch-queries.yml
+++ b/.github/workflows/ibis-tpch-queries.yml
@@ -35,8 +35,6 @@ jobs:
         with:
           python-version: "3.10"
 
-      - run: python -m pip install --upgrade pip 'coverage[toml]'
-
       - name: install tpc-queries dependencies
         working-directory: tpc-queries
         run: |
@@ -52,16 +50,4 @@ jobs:
 
       - name: run tpc-h queries
         working-directory: tpc-queries
-        run: coverage run --rcfile=../pyproject.toml ./runtpc -i ibis -i duckdb -d 'tpch.ddb' -b 'duckdb'
-
-      - name: generate coverage report
-        working-directory: tpc-queries
-        run: coverage xml --rcfile=../pyproject.toml -o ./junit.xml
-
-      - name: upload code coverage
-        if: success()
-        uses: codecov/codecov-action@v3
-        with:
-          files: ./tpc-queries/junit.xml
-          fail_ci_if_error: true
-          flags: tpc,tpch,duckdb,${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}
+        run: ./runtpc -i ibis -i duckdb -d 'tpch.ddb' -b 'duckdb'


### PR DESCRIPTION
The tpch tests have been failing *very* frequently lately during the codecov upload step. Since these tests are extra and shouldn't be testing any specific functionality, I don't feel like we really need coverage here - dropping coverage entirely for tpch rather than debugging the cause of the failures.