### PR TITLE
fix: a few `startswith`/`endswith` fixes

### DIFF
--- a/ibis/backends/mysql/registry.py
+++ b/ibis/backends/mysql/registry.py
@@ -29,6 +29,19 @@ def _capitalize(t, op):
     )
 
 
+def _startswith(t, op):
+    arg = t.translate(op.arg)
+    start = t.translate(op.start)
+    # LIKE in mysql is case insensitive
+    return arg.op("LIKE BINARY")(sa.func.concat(start, "%"))
+
+
+def _endswith(t, op):
+    arg = t.translate(op.arg)
+    end = t.translate(op.end)
+    return arg.op("LIKE BINARY")(sa.func.concat("%", end))
+
+
 def _extract(fmt):
     def translator(t, op):
         sa_arg = t.translate(op.arg)
@@ -181,6 +194,8 @@ operation_registry.update(
         # strings
         ops.StringFind: _gen_string_find(sa.func.locate),
         ops.FindInSet: _find_in_set,
+        ops.StartsWith: _startswith,
+        ops.EndsWith: _endswith,
         ops.Capitalize: _capitalize,
         ops.RegexSearch: fixed_arity(lambda x, y: x.op('REGEXP')(y), 2),
         # math

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -405,7 +405,7 @@ def string_replace(op):
 def string_startswith(op):
     arg = translate(op.arg)
     _assert_literal(op.start)
-    return arg.str.ends_with(op.start.value)
+    return arg.str.starts_with(op.start.value)
 
 
 @translate.register(ops.EndsWith)

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -146,6 +146,7 @@ class Backend(BaseAlchemyBackend):
         def connect(dbapi_connection, connection_record):
             """Register UDFs on connection."""
             udf.register_all(dbapi_connection)
+            dbapi_connection.execute("PRAGMA case_sensitive_like=ON")
 
         super().do_connect(engine)
 

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -167,15 +167,33 @@ def test_string_col_is_unicode(alltypes, df):
             id='length',
         ),
         param(
-            lambda t: t.string_col.startswith('foo'),
-            lambda t: t.string_col.str.startswith('foo'),
+            lambda t: t.int_col.cases([(1, "abcd"), (2, "ABCD")], "dabc").startswith(
+                "abc"
+            ),
+            lambda t: t.int_col == 1,
             id='startswith',
+            # pyspark doesn't support `cases` yet
+            marks=pytest.mark.notimpl(["dask", "datafusion", "pyspark", "pandas"]),
+        ),
+        param(
+            lambda t: t.int_col.cases([(1, "abcd"), (2, "ABCD")], "dabc").endswith(
+                "bcd"
+            ),
+            lambda t: t.int_col == 1,
+            id='endswith',
+            # pyspark doesn't support `cases` yet
+            marks=pytest.mark.notimpl(["dask", "datafusion", "pyspark", "pandas"]),
+        ),
+        param(
+            lambda t: t.date_string_col.startswith("2010-01"),
+            lambda t: t.date_string_col.str.startswith("2010-01"),
+            id='startswith-simple',
             marks=pytest.mark.notimpl(["dask", "datafusion", "pandas"]),
         ),
         param(
-            lambda t: t.string_col.endswith('foo'),
-            lambda t: t.string_col.str.endswith('foo'),
-            id='endswith',
+            lambda t: t.date_string_col.endswith("100"),
+            lambda t: t.date_string_col.str.endswith("100"),
+            id='endswith-simple',
             marks=pytest.mark.notimpl(["dask", "datafusion", "pandas"]),
         ),
         param(


### PR DESCRIPTION
- Improve the tests for `startswith`/`endswith`; previously the test case resulted in a fully `False` series, letting several bugs slip through.
- Fix `sqlite` and `mysql` implementations of `startswith`/`endswith` to be case sensitive
- Fix bug in `polars` implementation of `startswith` to call the proper method