### PR TITLE
fix(snowflake): fix snowflake list_databases

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -114,3 +114,12 @@ class Backend(BaseAlchemyBackend):
             typ = parse(raw_type)
             schema[name] = typ(nullable=null.upper() == "Y")
         return sch.Schema.from_dict(schema)
+
+    def list_databases(self, like=None) -> list[str]:
+        databases = [
+            row.database_name
+            for row in self.con.execute(
+                'select database_name from information_schema.databases'
+            )
+        ]
+        return self._filter_with_like(databases, like)


### PR DESCRIPTION
The current implementation relies on the base sqlalchemy backend implementation which returns schemas, instead of databases. This PR fixes this by implementing a custom function for the Snowflake backend, which utilizes the `information_schema.databases` view ([docs](https://docs.snowflake.com/en/sql-reference/info-schema/databases.html))