### PR TITLE
docs: fix tutorial button link

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,3 +1,10 @@
+---
+hide:
+  - toc
+  - navigation
+  - footer
+---
+
 # Install Ibis
 
 === "pip"
@@ -32,4 +39,6 @@
 
 After you've successfully installed Ibis, try going through the tutorial:
 
-[Go to the Tutorial](/tutorial){ .md-button }
+<div class="install-tutorial-button" markdown>
+[Go to the Tutorial](./tutorial/index.md){ .md-button .md-button--primary }
+</div>


### PR DESCRIPTION
This PR fixes the link to the tutorial and centers and primary-izes the button. I also removed the nav and toc from the install page since neither of those sidebars is providing any value there. Fixes #4814.