### PR TITLE
chore(pre-commit): add hook to check for leftover breakpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,3 +109,7 @@ repos:
           - file
         types_or:
           - file
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: debug-statements


### PR DESCRIPTION
h/t to @ncclementi for telling me about this thing I wish I had a year ago.