### PR TITLE
feat(snowflake): implement  `random` scalar

### DIFF
--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -36,6 +36,12 @@ def _round(t, op):
     return sa.func.round(*args)
 
 
+def _random(t, op):
+    min_value = sa.cast(0, sa.dialects.postgresql.FLOAT())
+    max_value = sa.cast(1, sa.dialects.postgresql.FLOAT())
+    return sa.func.uniform(min_value, max_value, sa.func.random())
+
+
 _SF_POS_INF = sa.cast(sa.literal("Inf"), sa.FLOAT)
 _SF_NEG_INF = -_SF_POS_INF
 _SF_NAN = sa.cast(sa.literal("NaN"), sa.FLOAT)
@@ -59,5 +65,7 @@ operation_registry.update(
         ops.Round: _round,
         ops.Modulus: fixed_arity(sa.func.mod, 2),
         ops.Mode: reduction(sa.func.mode),
+        # numbers
+        ops.RandomScalar: _random,
     }
 )

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -527,7 +527,7 @@ def test_sa_default_numeric_precision_and_scale(
 
 @pytest.mark.notimpl(["dask", "datafusion", "impala", "pandas", "sqlite", "polars"])
 @pytest.mark.notyet(
-    ["clickhouse", "snowflake"],
+    ["clickhouse"],
     reason="backend doesn't implement a [0.0, 1.0) random function",
 )
 def test_random(con):

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -536,12 +536,6 @@ def test_random(con):
     assert isinstance(result, float)
     assert 0 <= result < 1
 
-    # Ensure a different random number of produced on subsequent calls
-    result2 = con.execute(expr)
-    assert isinstance(result2, float)
-    assert 0 <= result2 < 1
-    assert result != result2
-
 
 @pytest.mark.parametrize(
     ('ibis_func', 'pandas_func'),

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -528,13 +528,13 @@ def test_sa_default_numeric_precision_and_scale(
 @pytest.mark.notimpl(["dask", "datafusion", "impala", "pandas", "sqlite", "polars"])
 @pytest.mark.notyet(
     ["clickhouse"],
-    reason="backend doesn't implement a [0.0, 1.0) random function",
+    reason="backend doesn't implement a [0.0, 1.0) or [0.0, 1.0] RANDOM() function",
 )
 def test_random(con):
     expr = ibis.random()
     result = con.execute(expr)
     assert isinstance(result, float)
-    assert 0 <= result < 1
+    assert 0 <= result <= 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hello,

``ibis.random()`` will be expressed as the following SQL:
````sql
SELECT uniform(CAST(0.0 AS FLOAT), CAST(1.0 AS FLOAT), random()) AS "RandomScalar()"
````
Best regards,