### PR TITLE
feat(snowflake): implement `rowid` scalar

### DIFF
--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -69,5 +69,7 @@ operation_registry.update(
         ops.RandomScalar: _random,
         # time and dates
         ops.TimeFromHMS: fixed_arity(sa.func.time_from_parts, 3),
+        # columns
+        ops.RowID: (lambda *_: sa.func.seq8() + 1),
     }
 )

--- a/ibis/backends/tests/test_column.py
+++ b/ibis/backends/tests/test_column.py
@@ -16,7 +16,6 @@ import pytest
         "pandas",
         "postgres",
         "pyspark",
-        "snowflake",
         "polars",
     ]
 )
@@ -43,7 +42,6 @@ def test_rowid(con):
         "pandas",
         "postgres",
         "pyspark",
-        "snowflake",
         "polars",
     ]
 )


### PR DESCRIPTION
Hello,

The follwoing code:
```python
t = con.table('functional_alltypes')
result = t[t.rowid()].execute()
```
io translated to the following SQL:
```sql
SELECT seq8() + 1 AS number 
FROM functional_alltypes AS t0
```