### PR TITLE
fix: support dtype in `__array__` methods

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -514,8 +514,8 @@ class Column(Value, JupyterMixin):
 
     __array_ufunc__ = None
 
-    def __array__(self):
-        return self.execute().__array__()
+    def __array__(self, dtype=None):
+        return self.execute().__array__(dtype)
 
     def __rich_console__(self, console, options):
         named = self.name(self.op().name)

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -90,8 +90,8 @@ class Table(Expr, JupyterMixin):
 
     __array_ufunc__ = None
 
-    def __array__(self):
-        return self.execute().__array__()
+    def __array__(self, dtype=None):
+        return self.execute().__array__(dtype)
 
     def __contains__(self, name):
         return name in self.schema()


### PR DESCRIPTION
Previously the `__array__` methods were missing this parameter, causing `np.asarray(table, dtype="some_dtype")` to fail.

Also changes up the `__array__` test a bit so it works on all backends.