### PR TITLE
feat: add unbind method to expressions

### DIFF
--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -89,3 +89,19 @@ def test_limit_chain(alltypes, expr_fn):
     expr = expr_fn(alltypes)
     result = expr.execute()
     assert len(result) == 5
+
+
+@pytest.mark.parametrize(
+    "expr_fn",
+    [
+        param(lambda t: t, id="alltypes table"),
+        param(lambda t: t.join(t.view(), t.id == t.view().int_col), id="self join"),
+    ],
+)
+def test_unbind(alltypes, expr_fn):
+    expr = expr_fn(alltypes)
+    assert expr.unbind() != expr
+    assert expr.unbind().schema() == expr.schema()
+
+    assert "Unbound" not in repr(expr)
+    assert "Unbound" in repr(expr.unbind())

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -371,6 +371,13 @@ class Expr(Immutable):
             self, params=params, limit=limit, **kwargs
         )
 
+    def unbind(self) -> ir.Table:
+        """Return equivalent expression built on `UnboundTable` instead of
+        backend-specific table objects."""
+        from ibis.expr.analysis import substitute_unbound
+
+        return substitute_unbound(self.op()).to_expr()
+
 
 unnamed = UnnamedMarker()
 


### PR DESCRIPTION
Calling `unbind()` on an expression returns an equivalent expression but
with all references to backend-specific tables, e.g. `AlchemyTable`,
`PandasTable`... translated into `UnboundTable`.

Should help with serialization of expressions and ease execution of
expressions across backends.

Resolves #4536

``` python
[ins] In [2]: topfilms
Out[2]: 
r0 := AlchemyTable: ratings
  tconst        string
  averageRating string
  numVotes      string

r1 := AlchemyTable: basics
  tconst         string
  titleType      string
  primaryTitle   string
  originalTitle  string
  isAdult        string
  startYear      string
  endYear        string
  runtimeMinutes string
  genres         string

r2 := Selection[r1]
  predicates:
    Contains(value=r1.titleType, options=['movie', 'tvMovie'])
    r1.isAdult == '0'

r3 := Selection[r0]
  selections:
    tconst:     r0.tconst
    avg_rating: Cast(r0.averageRating, to=float64)
    num_votes:  Cast(r0.numVotes, to=int64)

r4 := Selection[r2]
  selections:
    tconst:       r2.tconst
    primaryTitle: r2.primaryTitle

r5 := InnerJoin[r4, r3] r4.tconst == r3.tconst

r6 := Selection[r5]
  selections:
    tconst:       r4.tconst
    primaryTitle: r4.primaryTitle
    avg_rating:   r3.avg_rating
    num_votes:    r3.num_votes

Selection[r6]
  predicates:
    r6.num_votes > 100000
  sort_keys:
    desc r6.avg_rating
```

``` python
[ins] In [3]: topfilms.unbind()
Out[3]: 
r0 := UnboundTable: ratings
  tconst        string
  averageRating string
  numVotes      string

r1 := UnboundTable: basics
  tconst         string
  titleType      string
  primaryTitle   string
  originalTitle  string
  isAdult        string
  startYear      string
  endYear        string
  runtimeMinutes string
  genres         string

r2 := Selection[r1]
  predicates:
    Contains(value=r1.titleType, options=['movie', 'tvMovie'])
    r1.isAdult == '0'

r3 := Selection[r0]
  selections:
    tconst:     r0.tconst
    avg_rating: Cast(r0.averageRating, to=float64)
    num_votes:  Cast(r0.numVotes, to=int64)

r4 := Selection[r2]
  selections:
    tconst:       r2.tconst
    primaryTitle: r2.primaryTitle

r5 := InnerJoin[r4, r3] r4.tconst == r3.tconst

r6 := Selection[r5]
  selections:
    tconst:       r4.tconst
    primaryTitle: r4.primaryTitle
    avg_rating:   r3.avg_rating
    num_votes:    r3.num_votes

Selection[r6]
  predicates:
    r6.num_votes > 100000
  sort_keys:
    desc r6.avg_rating
```