### PR TITLE
[WIP] feat: support `con.create_table(name, expr)` where `expr` is from another backend

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -360,6 +360,10 @@ class Backend(BaseAlchemyBackend):
         df = table_op.data.to_frame()
         self.con.execute("register", (table_op.name, df))
 
+    def _insert_from_other_backend(self, bind, table, expr):
+        batches = expr.to_pyarrow_batches()
+        bind.connection.connection.c.append(table.name, batches)
+
     def _get_sqla_table(
         self,
         name: str,


### PR DESCRIPTION
Fixes #4800.

Still needs tests and `insert` support.