### PR TITLE
fix: define `to_pandas`/`to_pyarrow` on DataType/Schema classes directly

### DIFF
--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -308,10 +308,6 @@ def convert_json_to_series(in_, out, col: pd.Series):
     return pd.Series(list(map(try_json, col)), dtype="object")
 
 
-dt.DataType.to_pandas = ibis_dtype_to_pandas  # type: ignore
-sch.Schema.to_pandas = ibis_schema_to_pandas  # type: ignore
-
-
 class DataFrameProxy(Immutable, util.ToFrame):
     __slots__ = ('_df', '_hash')
 

--- a/ibis/backends/pyarrow/datatypes.py
+++ b/ibis/backends/pyarrow/datatypes.py
@@ -138,7 +138,3 @@ def ibis_to_pyarrow_struct(schema: sch.Schema) -> pa.StructType:
 
 def ibis_to_pyarrow_schema(schema: sch.Schema) -> pa.Schema:
     return pa.schema(_schema_to_pyarrow_schema_fields(schema))
-
-
-dt.DataType.to_pyarrow = to_pyarrow_type  # type: ignore
-sch.Schema.to_pyarrow = ibis_to_pyarrow_schema  # type: ignore

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -78,6 +78,18 @@ class DataType(Concrete):
 
         return castable(self, other, **kwargs)
 
+    def to_pandas(self):
+        """Return the equivalent pandas datatype."""
+        from ibis.backends.pandas.client import ibis_dtype_to_pandas
+
+        return ibis_dtype_to_pandas(self)
+
+    def to_pyarrow(self):
+        """Return the equivalent pyarrow datatype."""
+        from ibis.backends.pyarrow.datatypes import to_pyarrow_type
+
+        return to_pyarrow_type(self)
+
     def is_array(self) -> bool:
         return isinstance(self, Array)
 

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -197,6 +197,18 @@ class Schema(Concrete):
         names, types = zip(*dictionary.items()) if dictionary else ([], [])
         return cls(names, types)
 
+    def to_pandas(self):
+        """Return the equivalent pandas datatypes."""
+        from ibis.backends.pandas.client import ibis_schema_to_pandas
+
+        return ibis_schema_to_pandas(self)
+
+    def to_pyarrow(self):
+        """Return the equivalent pyarrow schema."""
+        from ibis.backends.pyarrow.datatypes import ibis_to_pyarrow_schema
+
+        return ibis_to_pyarrow_schema(self)
+
     def __gt__(self, other: Schema) -> bool:
         """Return whether `self` is a strict superset of `other`."""
         return set(self.items()) > set(other.items())


### PR DESCRIPTION
Previously these were being monkeypatched onto the classes only if the submodules were imported. This leads to these methods not always existing (the pandas ones were always added, the pyarrow ones were only added if the user ever imported `ibis.backends.pyarrow.datatypes` themselves). Better to define them directly on the classes and avoid this complication.