### PR TITLE
fix(analysis): only propagate sort keys that are in an agg's output

### DIFF
--- a/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result1.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result1.sql
@@ -1,0 +1,3 @@
+SELECT `b`, count(1) AS `count`
+FROM t
+GROUP BY 1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result2.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result2.sql
@@ -1,0 +1,4 @@
+SELECT `b`, count(1) AS `count`
+FROM t
+GROUP BY 1
+ORDER BY `b` ASC

--- a/ibis/tests/sql/test_select_sql.py
+++ b/ibis/tests/sql/test_select_sql.py
@@ -809,3 +809,15 @@ def test_filter_self_join_analysis_bug(snapshot):
     result = joined[left.region, (left.total - right.total).name('diff')]
 
     snapshot.assert_match(to_sql(result), "result.sql")
+
+
+def test_sort_then_group_by_propagates_keys(snapshot):
+    t = ibis.table(schema={"a": "string", "b": "int64"}, name="t")
+
+    # a IS NOT in the output's order by clause
+    result = t.order_by("a").b.value_counts()
+    snapshot.assert_match(to_sql(result), "result1.sql")
+
+    # b IS in the output's order by clause
+    result = t.order_by("b").b.value_counts()
+    snapshot.assert_match(to_sql(result), "result2.sql")


### PR DESCRIPTION
This PR fixes a bug where we incorrectly aggressively push sort keys into aggregations even if the aggregation output schema does not contain the sort keys.