### PR TITLE
fix(sql): fix generated cartesian join

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import operator
 from collections import Counter
+from typing import Mapping
 
 import toolz
 
@@ -19,22 +20,21 @@ from ibis.expr.window import window
 # compilation later
 
 
-def sub_for(node, substitutions):
-    """Substitute subexpressions in `expr` with expression to expression
-    mapping `substitutions`.
+def sub_for(node: ops.Node, substitutions: Mapping[ops.node, ops.Node]) -> ops.Node:
+    """Substitute operations in `node` with nodes in `substitutions`.
 
     Parameters
     ----------
-    expr : ibis.expr.types.Expr
-        An Ibis expression
-    substitutions : List[Tuple[ibis.expr.types.Expr, ibis.expr.types.Expr]]
-        A mapping from expression to expression. If any subexpression of `expr`
-        is equal to any of the keys in `substitutions`, the value for that key
-        will replace the corresponding expression in `expr`.
+    node
+        An Ibis operation
+    substitutions
+        A mapping from node to node. If any subnode of `node` is equal to any
+        of the keys in `substitutions`, the value for that key will replace the
+        corresponding node in `node`.
 
     Returns
     -------
-    ibis.expr.types.Expr
+    Node
         An Ibis expression
     """
     assert isinstance(node, ops.Node), type(node)
@@ -48,6 +48,11 @@ def sub_for(node, substitutions):
             return g.proceed
 
     return substitute(fn, node)
+
+
+def sub_immediate_parents(op: ops.Node, table: ops.TableNode) -> ops.Node:
+    """Replace immediate parent tables in `op` with `table`."""
+    return sub_for(op, {base: table for base in find_immediate_parent_tables(op)})
 
 
 class ScalarAggregate:

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cart_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cart_join/out.sql
@@ -1,0 +1,3 @@
+SELECT ancestor_node_sort_order, 1 AS n 
+FROM facts AS t0 JOIN (SELECT t2.ancestor_level_name AS ancestor_level_name, t2.ancestor_level_number AS ancestor_level_number, t2.ancestor_node_sort_order AS ancestor_node_sort_order, t2.descendant_node_natural_key AS descendant_node_natural_key, concat(lpad('-', (t2.ancestor_level_number - 1) * 7, '-'), t2.ancestor_level_name) AS product_level_name 
+FROM products AS t2) AS t1 ON t0.product_id = t1.descendant_node_natural_key GROUP BY ancestor_node_sort_order ORDER BY ancestor_node_sort_order ASC


### PR DESCRIPTION
This fixes a bug where we allow users to pass in non-immediate-child group by keys but then do not correctly substitute the immediate child in. There are probably other places where this can happen. Fixes #4854.