### PR TITLE
docs(dev): python-duckdb now available for windows with conda

### DIFF
--- a/docs/community/contribute/01_environment.md
+++ b/docs/community/contribute/01_environment.md
@@ -60,7 +60,6 @@ hide:
 
     !!! info "Some optional dependencies for Windows are not available through `conda`/`mamba`"
 
-        1. `python-duckdb` and `duckdb-engine`. Required for the DuckDB backend.
         1. `clickhouse-cityhash`. Required for compression support in the ClickHouse backend.
 
     #### Support Matrix


### PR DESCRIPTION
`duckdb-engine` is a `noarch`, so with the recent addition of a windows
build for `python-duckdb`, this warning no longer applies.