### PR TITLE
chore: disable snowflake for memtable test

### DIFF
--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -43,6 +43,9 @@ class TestConf(BackendTest, RoundAwayFromZero):
         stage = "ibis_testing_stage"
         con = TestConf.connect(data_dir)
         with con.con.connect() as con:
+            con.execute("DROP SCHEMA IF EXISTS ibis_testing")
+            con.execute("CREATE SCHEMA IF NOT EXISTS ibis_testing")
+            con.execute("USE SCHEMA ibis_testing")
             con.execute(
                 """\
 CREATE OR REPLACE FILE FORMAT ibis_csv_fmt

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -349,6 +349,10 @@ def test_insert_overwrite_from_list(
     assert len(alchemy_con.table(employee_data_1_temp_table).execute()) == 3
 
 
+@pytest.mark.broken(
+    ["snowflake"],
+    reason="quoting is incorrect because pandas doesn't expose sqlalchemy column quoting",
+)
 def test_insert_from_memtable(alchemy_con):
     df = pd.DataFrame({"x": range(3)})
     table_name = "memtable_test"


### PR DESCRIPTION
This PR disables a failing snowflake test case due to the way that pandas to_sql works.