### PR TITLE
bug: `re_extract` behavior differs between backends

### DIFF
--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_column_regexp_extract/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_column_regexp_extract/out.sql
@@ -1,1 +1,1 @@
-extractAll(CAST(`string_col` AS String), '[\d]+')[3 + 1]
+if(match(CAST(`string_col` AS String), '[\d]+'), if(CAST(nullIf(3, 0) AS Nullable(Int64)) IS NULL, CAST(`string_col` AS String), CAST(extractAll(CAST(`string_col` AS String), '[\d]+') AS Array(Nullable(String)))[CAST(nullIf(3, 0) AS Nullable(Int64))]), NULL)

--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -417,12 +417,12 @@ def test_regexp(con, expr, expected):
 @pytest.mark.parametrize(
     ('expr', 'expected'),
     [
-        (L('abcd').re_extract('([a-z]+)', 0), 'abcd'),
+        param(L('abcd').re_extract('([a-z]+)', 0), 'abcd', id="simple"),
         # (L('abcd').re_extract('(ab)(cd)', 1), 'cd'),
-        # valid group number but no match => empty string
-        (L('abcd').re_extract(r'(\\d)', 0), ''),
+        # valid group number but no match => None
+        param(L('abcd').re_extract(r'(\\d)', 0), None, id="valid_group_no_match"),
         # match but not a valid group number => NULL
-        # (L('abcd').re_extract('abcd', 3), None),
+        param(L('abcd').re_extract('abcd', 3), None, id="invalid_group_match"),
     ],
 )
 def test_regexp_extract(con, expr, expected):

--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -442,3 +442,8 @@ def elementwise_udf(op):
     args = map(translate, op.func_args)
 
     return udf(*args)
+
+
+@translate.register(ops.StringConcat)
+def string_concat(op):
+    return df.functions.concat(*map(translate, op.args))

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -131,9 +131,7 @@ def _regex_extract(t, op):
                     # DuckDB requires the index to be a constant so we compile
                     # the value and inline it using sa.text
                     sa.text(
-                        str(
-                            (index + 1).compile(compile_kwargs=dict(literal_binds=True))
-                        )
+                        str(index.compile(compile_kwargs=dict(literal_binds=True)))
                     ),
                 ),
             )

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -367,9 +367,10 @@ def test_regexp(con, expr, expected):
     ('expr', 'expected'),
     [
         param(L('abcd').re_extract('([a-z]+)', 0), 'abcd', id='re_extract_whole'),
-        param(L('abcd').re_extract('(ab)(cd)', 1), 'cd', id='re_extract_first'),
+        param(L('abcd').re_extract('(ab)(cd)', 1), 'ab', id='re_extract_first'),
+        param(L('abcd').re_extract('(ab)(cd)', 2), 'cd', id='re_extract_second'),
         # valid group number but no match => empty string
-        param(L('abcd').re_extract(r'(\d)', 0), '', id='re_extract_no_match'),
+        param(L('abcd').re_extract(r'(\d)', 0), None, id='re_extract_no_match'),
         # match but not a valid group number => NULL
         param(L('abcd').re_extract('abcd', 3), None, id='re_extract_match'),
     ],

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -81,6 +81,12 @@ def test_string_col_is_unicode(alltypes, df):
             marks=pytest.mark.notimpl(["impala", "mysql", "snowflake"]),
         ),
         param(
+            lambda t: (t.string_col + "1").re_extract(r'\d(\d+)', 0),
+            lambda t: (t.string_col + "1").str.extract(r'(\d+)', expand=False),
+            id='re_extract_whole_group',
+            marks=pytest.mark.notimpl(["impala", "mysql", "snowflake"]),
+        ),
+        param(
             lambda t: t.string_col.re_replace(r'\d+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
             id='re_replace',

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -51,28 +51,16 @@ def test_string_col_is_unicode(alltypes, df):
             marks=pytest.mark.notimpl(["datafusion", "impala", "pyspark", "polars"]),
         ),
         param(
-            lambda t: t.string_col.re_search(r'[[:digit:]]+'),
-            lambda t: t.string_col.str.contains(r'\d+'),
-            id='re_search_posix',
-            marks=pytest.mark.notimpl(["datafusion", "pyspark", "snowflake"]),
-        ),
-        param(
-            lambda t: t.string_col.re_extract(r'([[:digit:]]+)', 1),
-            lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
-            id='re_extract_posix',
-            marks=pytest.mark.notimpl(["mysql", "pyspark", "snowflake"]),
-        ),
-        param(
-            lambda t: t.string_col.re_replace(r'[[:digit:]]+', 'a'),
-            lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
-            id='re_replace_posix',
-            marks=pytest.mark.notimpl(['datafusion', "mysql", "pyspark", "snowflake"]),
-        ),
-        param(
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search',
             marks=pytest.mark.notimpl(["impala", "datafusion", "snowflake"]),
+        ),
+        param(
+            lambda t: t.string_col.re_search(r'[[:digit:]]+'),
+            lambda t: t.string_col.str.contains(r'\d+'),
+            id='re_search_posix',
+            marks=pytest.mark.notimpl(["datafusion", "pyspark", "snowflake"]),
         ),
         param(
             lambda t: t.string_col.re_extract(r'(\d+)', 1),
@@ -81,10 +69,22 @@ def test_string_col_is_unicode(alltypes, df):
             marks=pytest.mark.notimpl(["impala", "mysql", "snowflake"]),
         ),
         param(
+            lambda t: t.string_col.re_extract(r'([[:digit:]]+)', 1),
+            lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
+            id='re_extract_posix',
+            marks=pytest.mark.notimpl(["mysql", "pyspark", "snowflake"]),
+        ),
+        param(
             lambda t: (t.string_col + "1").re_extract(r'\d(\d+)', 0),
             lambda t: (t.string_col + "1").str.extract(r'(\d+)', expand=False),
             id='re_extract_whole_group',
             marks=pytest.mark.notimpl(["impala", "mysql", "snowflake"]),
+        ),
+        param(
+            lambda t: t.string_col.re_replace(r'[[:digit:]]+', 'a'),
+            lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
+            id='re_replace_posix',
+            marks=pytest.mark.notimpl(['datafusion', "mysql", "pyspark", "snowflake"]),
         ),
         param(
             lambda t: t.string_col.re_replace(r'\d+', 'a'),

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -305,19 +305,16 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col + t.date_string_col,
             lambda t: t.string_col + t.date_string_col,
             id='concat_columns',
-            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             lambda t: t.string_col + 'a',
             lambda t: t.string_col + 'a',
             id='concat_column_scalar',
-            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             lambda t: 'a' + t.string_col,
             lambda t: 'a' + t.string_col,
             id='concat_scalar_column',
-            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             lambda t: t.string_col.replace("1", "42"),

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -57,7 +57,7 @@ def test_string_col_is_unicode(alltypes, df):
             marks=pytest.mark.notimpl(["datafusion", "pyspark", "snowflake"]),
         ),
         param(
-            lambda t: t.string_col.re_extract(r'([[:digit:]]+)', 0),
+            lambda t: t.string_col.re_extract(r'([[:digit:]]+)', 1),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract_posix',
             marks=pytest.mark.notimpl(["mysql", "pyspark", "snowflake"]),
@@ -75,7 +75,7 @@ def test_string_col_is_unicode(alltypes, df):
             marks=pytest.mark.notimpl(["impala", "datafusion", "snowflake"]),
         ),
         param(
-            lambda t: t.string_col.re_extract(r'(\d+)', 0),
+            lambda t: t.string_col.re_extract(r'(\d+)', 1),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract',
             marks=pytest.mark.notimpl(["impala", "mysql", "snowflake"]),

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -535,14 +535,19 @@ class StringValue(Value):
         Parameters
         ----------
         pattern
-            Reguar expression string
+            Reguar expression pattern string
         index
-            Zero-based index of match to return
+            The index of the match group to return.
+
+            The behavior of this function follows the behavior of Python's
+            [`re.match`](https://docs.python.org/3/library/re.html#match-objects):
+            when `index` is zero and there's a match, return the entire string,
+            otherwise return the content of the `index`-th match group.
 
         Returns
         -------
         StringValue
-            Extracted match
+            Extracted match or whole string if `index` is zero
         """
         return ops.RegexExtract(self, pattern, index).to_expr()
 


### PR DESCRIPTION
This PR makes `StringValue.re_extract` conform to the semantics of `re.match` in the Python standard library.

Fixes #4593.
