### PR TITLE
ci: run nix builds nightly to populate the cachix cache

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,4 +1,3 @@
-# vim: filetype=yaml
 name: Nix
 
 on:
@@ -20,6 +19,9 @@ on:
     branches:
       - master
       - "*.x.x"
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
@@ -54,6 +56,14 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           extraPullNames: nix-community,poetry2nix
 
-      - name: nix build and run tests
-        continue-on-error: ${{ matrix.os == 'macos-latest' && matrix.python-version == '3.8' }}
-        run: nix build --fallback --keep-going --print-build-logs --file . --argstr python ${{ matrix.python-version }}
+      - name: set target path for build
+        run: |
+          event_name="${{ github.event_name }}"
+          target="$PWD"
+          if [ "$event_name" == "schedule" ] || [ "$event_name" == "workflow_dispatch" ]; then
+            target+="/shell.nix"
+          fi
+          echo "TARGET_PATH=$target" >> "$GITHUB_ENV"
+
+      - name: nix build
+        run: nix build --fallback --keep-going --print-build-logs --file "$TARGET_PATH" --argstr python ${{ matrix.python-version }}

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,8 @@
 let
   pkgs = import ./nix { };
 
+  pythonShortVersion = builtins.replaceStrings [ "." ] [ "" ] python;
+
   pythonEnv = pkgs."ibisFullDevEnv${pythonShortVersion}";
 
   devDeps = with pkgs; [
@@ -13,16 +15,11 @@ let
     # linting
     commitlint
     lychee
-    # packaging
+    # external nix dependencies
     niv
-    pythonEnv.pkgs.poetry
   ];
 
-  impalaUdfDeps = with pkgs; [
-    clang_12
-    cmake
-    ninja
-  ];
+  impalaUdfDeps = with pkgs; [ clang_12 cmake ninja ];
   snowflakeDeps = [ pkgs.openssl ];
   backendTestDeps = [ pkgs.docker-compose ];
   vizDeps = [ pkgs.graphviz-nox ];
@@ -31,7 +28,7 @@ let
   pysparkDeps = [ pkgs.openjdk11_headless ];
 
   postgresDeps = [ pkgs.postgresql ];
-  geospatialDeps = [ pkgs.gdal pkgs.proj ];
+  geospatialDeps = with pkgs; [ gdal proj ];
   sqliteDeps = [ pkgs.sqlite-interactive ];
 
   libraryDevDeps = impalaUdfDeps
@@ -44,15 +41,6 @@ let
     ++ duckdbDeps
     ++ mysqlDeps
     ++ snowflakeDeps;
-
-  pythonShortVersion = builtins.replaceStrings [ "." ] [ "" ] python;
-
-  updateLockFiles = pkgs.writeShellApplication {
-    name = "update-lock-files";
-    text = ''
-      ${./dev/update-lock-files.sh} "$PWD"
-    '';
-  };
 in
 pkgs.mkShell {
   name = "ibis${pythonShortVersion}";
@@ -71,7 +59,6 @@ pkgs.mkShell {
 
   nativeBuildInputs = devDeps ++ libraryDevDeps ++ [
     pythonEnv
-    updateLockFiles
   ] ++ pkgs.preCommitShell.buildInputs ++ (with pkgs; [
     changelog
     mic


### PR DESCRIPTION
This PR adds a branch to the nix workflow that builds the nix shell environment nightly so that the
full development environment for 3.8, 3.9 and 3.10 is in cache.
