### PR TITLE
refactor: remove duplicate `_random_identifier` calls

### DIFF
--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -16,7 +16,7 @@ import ibis.expr.types as ir
 import ibis.util as util
 from ibis import options
 from ibis.backends.base import BaseBackend
-from ibis.backends.conftest import TEST_TABLES
+from ibis.backends.conftest import TEST_TABLES, _random_identifier
 from ibis.backends.impala.compiler import ImpalaCompiler, ImpalaExprTranslator
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero, UnorderedComparator
 from ibis.tests.expr.mocks import MockBackend
@@ -349,10 +349,6 @@ def alltypes(con):
 @pytest.fixture(scope="module")
 def alltypes_df(alltypes):
     return alltypes.execute()
-
-
-def _random_identifier(suffix):
-    return f'__ibis_test_{suffix}_{util.guid()}'
 
 
 @pytest.fixture

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -105,10 +105,6 @@ class TestConf(BackendTest, RoundHalfToEven):
         )
 
 
-def _random_identifier(suffix):
-    return f'__ibis_test_{suffix}_{ibis.util.guid()}'
-
-
 @pytest.fixture(scope='session')
 def con():
     return ibis.mysql.connect(

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -21,7 +21,7 @@ import pytest
 import sqlalchemy as sa
 
 import ibis
-from ibis.backends.conftest import TEST_TABLES, init_database
+from ibis.backends.conftest import TEST_TABLES, _random_identifier, init_database
 from ibis.backends.tests.base import BackendTest, RoundHalfToEven
 
 PG_USER = os.environ.get(
@@ -101,10 +101,6 @@ class TestConf(BackendTest, RoundHalfToEven):
             password=PG_PASS,
             database=IBIS_TEST_POSTGRES_DB,
         )
-
-
-def _random_identifier(suffix):
-    return f'__ibis_test_{suffix}_{ibis.util.guid()}'
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -9,6 +9,7 @@ import pytest
 
 import ibis
 from ibis import util
+from ibis.backends.conftest import _random_identifier
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 
 pytest.importorskip("pyspark")
@@ -330,10 +331,6 @@ class IbisWindow:
 @pytest.fixture
 def ibis_windows(request):
     return IbisWindow(request.param).get_windows()
-
-
-def _random_identifier(suffix):
-    return f'__ibis_test_{suffix}_{util.guid()}'
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
This PR removes some duplicate test related code used to generate random identifiers.