### PR TITLE
chore(devtools): remove special case `mic` tool

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -187,7 +187,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          nix run -f nix mic -- \
+          nix run -f nix ibisDocsEnv.pkgs.mike -- \
             deploy \
               --push \
               --rebase \

--- a/.github/workflows/ibis-docs-release.yml
+++ b/.github/workflows/ibis-docs-release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          nix run -f nix mic -- \
+          nix run -f nix ibisDocsEnv.pkgs.mike -- \
             deploy \
               --push \
               --rebase \

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -59,24 +59,6 @@ in
 
       ibisFullDevEnv = pkgs.ibisFullDevEnv310;
 
-      mic = pkgs.writeShellApplication {
-        name = "mic";
-        runtimeInputs = [ pkgs.ibisDocsEnv pkgs.coreutils ];
-        # The immediate reason setting PYTHONPATH is necessary is to allow the
-        # subprocess invocations of `mkdocs` by `mike` to see Python dependencies.
-        #
-        # This shouldn't be necessary, but I think the nix wrappers may be
-        # inadvertently preventing this.
-        text = ''
-          export PYTHONPATH TEMPDIR
-
-          PYTHONPATH="$(python -c 'import os, sys; print(os.pathsep.join(sys.path))')"
-          TEMPDIR="$(python -c 'import tempfile; print(tempfile.gettempdir())')"
-
-          mike "$@"
-        '';
-      };
-
       changelog = pkgs.writeShellApplication {
         name = "changelog";
         runtimeInputs = [ pkgs.nodePackages.conventional-changelog-cli ];

--- a/shell.nix
+++ b/shell.nix
@@ -17,6 +17,7 @@ let
     lychee
     # external nix dependencies
     niv
+    pythonEnv.pkgs.poetry
   ];
 
   impalaUdfDeps = with pkgs; [ clang_12 cmake ninja ];
@@ -57,12 +58,10 @@ pkgs.mkShell {
     TEMPDIR="$(python -c 'import tempfile; print(tempfile.gettempdir())')"
   '';
 
-  nativeBuildInputs = devDeps ++ libraryDevDeps ++ [
-    pythonEnv
-  ] ++ pkgs.preCommitShell.buildInputs ++ (with pkgs; [
-    changelog
-    mic
-  ]);
+  nativeBuildInputs = devDeps
+    ++ libraryDevDeps
+    ++ [ pythonEnv pkgs.changelog ]
+    ++ pkgs.preCommitShell.buildInputs;
 
   PGPASSWORD = "postgres";
   MYSQL_PWD = "ibis";


### PR DESCRIPTION
This PR attempts to remove a workaround for `mike` failing to work out of the box in the isolation of the nix environment. Locally at least, I am able to run mike deploy without any failures.