### PR TITLE
fix(sqlalchemy): ensure that arbitrary expressions are valid sort keys

### DIFF
--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by_expr/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by_expr/out.sql
@@ -1,0 +1,4 @@
+SELECT t0.a, t0.b 
+FROM (SELECT t1.a AS a, t1.b AS b 
+FROM t AS t1 
+WHERE t1.a = 1) AS t0 ORDER BY concat(t0.b, 'a') ASC

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -1169,3 +1169,12 @@ def test_no_cart_join(con, snapshot):
 
     out = str(con.compile(ob).compile(compile_kwargs=dict(literal_binds=True)))
     snapshot.assert_match(out, "out.sql")
+
+
+def test_order_by_expr(con, snapshot):
+    from ibis import _
+
+    t = ibis.table(dict(a="int", b="string"), name="t")
+    expr = t[_.a == 1].order_by(_.b + "a")
+    out = str(con.compile(expr).compile(compile_kwargs=dict(literal_binds=True)))
+    snapshot.assert_match(out, "out.sql")


### PR DESCRIPTION
This PR fixes an issue where arbitrary expressions failed to compile with the sqlalchemy backend because we were incorrectly lowering sort keys.

Closes #4886.