### PR TITLE
perf: add drop compilation benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ docs/backends/support_matrix.csv
 __pycache__
 tags
 .DS_Store
+prof/


### PR DESCRIPTION
This PR adds a benchmark for a known-slow-to-compile expression. I have the fix in another branch, but want to get a benchmark run in to have a record of the change from the subsequent PR.