### PR TITLE
perf(expr): traverse nodes only once during compilation

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -30,12 +30,16 @@ class _CorrelatedRefCheck:
         )
         self.has_foreign_root = False
         self.has_query_root = False
+        self.seen = set()
 
     def get_result(self):
         self.visit(self.node, in_subquery=False)
         return self.has_query_root and self.has_foreign_root
 
     def visit(self, node, in_subquery):
+        if node in self.seen:
+            return
+
         in_subquery |= self.is_subquery(node)
 
         args = node if isinstance(node, ops.NodeList) else node.args
@@ -45,6 +49,7 @@ class _CorrelatedRefCheck:
                 self.visit_table(arg, in_subquery=in_subquery)
             elif isinstance(arg, ops.Node):
                 self.visit(arg, in_subquery=in_subquery)
+        self.seen.add(node)
 
     def is_subquery(self, node):
         return isinstance(


### PR DESCRIPTION
This PR addresses the performance issue in #4911. The issue is repeated traversal of the same node in an expression during the correlated ref check. For example, if two columns share the same child table that table will be traversed twice. Let's wait until #4911 is merged before merging this one.