### PR TITLE
refactor(ir): remove unnecessary complexity introduced by variadic annotation

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -62,7 +62,7 @@ def _varargs_call(sa_func, t, args):
 
 def varargs(sa_func):
     def formatter(t, op):
-        return _varargs_call(sa_func, t, op.args)
+        return _varargs_call(sa_func, t, op.arg)
 
     return formatter
 

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -123,7 +123,7 @@ def cast(translator, op):
 
 def varargs(func_name):
     def varargs_formatter(translator, op):
-        return helpers.format_call(translator, func_name, *op.args)
+        return helpers.format_call(translator, func_name, *op.arg)
 
     return varargs_formatter
 
@@ -210,7 +210,7 @@ def hash(translator, op):
 
 
 def concat(translator, op):
-    joined_args = ', '.join(map(translator.translate, op.args))
+    joined_args = ', '.join(map(translator.translate, op.arg))
     return f"concat({joined_args})"
 
 

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -505,7 +505,7 @@ def _string_join(translator, op):
 
 
 def _string_concat(translator, op):
-    args_formatted = ", ".join(map(translator.translate, op.args))
+    args_formatted = ", ".join(map(translator.translate, op.arg))
     return f"arrayStringConcat([{args_formatted}])"
 
 

--- a/ibis/backends/clickhouse/registry.py
+++ b/ibis/backends/clickhouse/registry.py
@@ -314,11 +314,6 @@ def _log(translator, op):
     return _call(translator, func, op.arg)
 
 
-def _value_list(translator, op):
-    values_ = map(translator.translate, op.values)
-    return '({})'.format(', '.join(values_))
-
-
 def _interval_format(translator, op):
     dtype = op.output_dtype
     if dtype.unit in {'ms', 'us', 'ns'}:

--- a/ibis/backends/dask/execution/numeric.py
+++ b/ibis/backends/dask/execution/numeric.py
@@ -6,6 +6,7 @@ import numbers
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
 import numpy as np
+import pandas as pd
 
 import ibis.expr.operations as ops
 from ibis.backends.dask.dispatch import execute_node
@@ -83,7 +84,9 @@ def vectorize_object(op, arg, *args, **kwargs):
 
 
 @execute_node.register(
-    ops.Log, dd.Series, (dd.Series, numbers.Real, decimal.Decimal, type(None))
+    ops.Log,
+    dd.Series,
+    (dd.Series, pd.Series, numbers.Real, decimal.Decimal, type(None)),
 )
 def execute_series_log_with_base(op, data, base, **kwargs):
     if data.dtype == np.dtype(np.object_):

--- a/ibis/backends/dask/execution/strings.py
+++ b/ibis/backends/dask/execution/strings.py
@@ -1,5 +1,6 @@
 import functools
 import itertools
+import operator
 
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
@@ -201,6 +202,12 @@ def execute_substring_series_series(op, data, start, length, **kwargs):
         return value[begin:end]
 
     return data.map(iterate)
+
+
+@execute_node.register(ops.StringConcat, tuple)
+def execute_node_string_concat(op, values, **kwargs):
+    values = [execute(arg, **kwargs) for arg in values]
+    return functools.reduce(operator.add, values)
 
 
 @execute_node.register(ops.StringSQLLike, ddgb.SeriesGroupBy, str, str)

--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -436,13 +436,14 @@ def elementwise_udf(op):
 
 @translate.register(ops.StringConcat)
 def string_concat(op):
-    return df.functions.concat(*map(translate, op.args))
+    return df.functions.concat(*map(translate, op.arg))
 
 
 @translate.register(ops.RegexExtract)
 def regex_extract(op):
     arg = translate(op.arg)
-    pattern = translate(ops.StringConcat("(", op.pattern, ")"))
+    concat = ops.StringConcat(("(", op.pattern, ")"))
+    pattern = translate(concat)
     if (index := getattr(op.index, "value", None)) is None:
         raise ValueError(
             "re_extract `index` expressions must be literals. "

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -979,9 +979,10 @@ def execute_alias(op, data, **kwargs):
     return data
 
 
-@execute_node.register(ops.StringConcat, [object])
-def execute_node_string_concat(op, *args, **kwargs):
-    return functools.reduce(operator.add, args)
+@execute_node.register(ops.StringConcat, tuple)
+def execute_node_string_concat(op, values, **kwargs):
+    values = [execute(arg, **kwargs) for arg in values]
+    return functools.reduce(operator.add, values)
 
 
 @execute_node.register(ops.StringJoin, collections.abc.Sequence)
@@ -1215,19 +1216,22 @@ def compute_row_reduction(func, values, **kwargs):
     return pd.Series(raw).squeeze()
 
 
-@execute_node.register(ops.Greatest, [object])
-def execute_node_greatest_list(op, *values, **kwargs):
+@execute_node.register(ops.Greatest, tuple)
+def execute_node_greatest_list(op, values, **kwargs):
+    values = [execute(arg, **kwargs) for arg in values]
     return compute_row_reduction(np.maximum.reduce, values, axis=0)
 
 
-@execute_node.register(ops.Least, [object])
-def execute_node_least_list(op, *values, **kwargs):
+@execute_node.register(ops.Least, tuple)
+def execute_node_least_list(op, values, **kwargs):
+    values = [execute(arg, **kwargs) for arg in values]
     return compute_row_reduction(np.minimum.reduce, values, axis=0)
 
 
-@execute_node.register(ops.Coalesce, [object])
-def execute_node_coalesce(op, *values, **kwargs):
+@execute_node.register(ops.Coalesce, tuple)
+def execute_node_coalesce(op, values, **kwargs):
     # TODO: this is slow
+    values = [execute(arg, **kwargs) for arg in values]
     return compute_row_reduction(coalesce, values)
 
 

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -314,19 +314,19 @@ def searched_case(op):
 
 @translate.register(ops.Coalesce)
 def coalesce(op):
-    arg = list(map(translate, op.args))
+    arg = list(map(translate, op.arg))
     return pl.coalesce(arg)
 
 
 @translate.register(ops.Least)
 def least(op):
-    arg = [translate(arg) for arg in op.args]
+    arg = [translate(arg) for arg in op.arg]
     return pl.min(arg)
 
 
 @translate.register(ops.Greatest)
 def greatest(op):
-    arg = [translate(arg) for arg in op.args]
+    arg = [translate(arg) for arg in op.arg]
     return pl.max(arg)
 
 
@@ -421,7 +421,7 @@ def string_endswith(op):
 
 @translate.register(ops.StringConcat)
 def string_concat(op):
-    args = [translate(arg) for arg in op.args]
+    args = [translate(arg) for arg in op.arg]
     return pl.concat_str(args)
 
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -659,7 +659,7 @@ def compile_arbitrary(t, op, **kwargs):
 @compiles(ops.Coalesce)
 def compile_coalesce(t, op, **kwargs):
     kwargs["raw"] = False  # override to force column literals
-    src_columns = [t.translate(col, **kwargs) for col in op.args]
+    src_columns = [t.translate(col, **kwargs) for col in op.arg]
     if len(src_columns) == 1:
         return src_columns[0]
     else:
@@ -669,7 +669,7 @@ def compile_coalesce(t, op, **kwargs):
 @compiles(ops.Greatest)
 def compile_greatest(t, op, **kwargs):
     kwargs["raw"] = False  # override to force column literals
-    src_columns = [t.translate(col, **kwargs) for col in op.args]
+    src_columns = [t.translate(col, **kwargs) for col in op.arg]
     if len(src_columns) == 1:
         return src_columns[0]
     else:
@@ -679,7 +679,7 @@ def compile_greatest(t, op, **kwargs):
 @compiles(ops.Least)
 def compile_least(t, op, **kwargs):
     kwargs["raw"] = False  # override to force column literals
-    src_columns = [t.translate(col, **kwargs) for col in op.args]
+    src_columns = [t.translate(col, **kwargs) for col in op.arg]
     if len(src_columns) == 1:
         return src_columns[0]
     else:
@@ -1019,7 +1019,7 @@ def compile_string_split(t, op, **kwargs):
 @compiles(ops.StringConcat)
 def compile_string_concat(t, op, **kwargs):
     kwargs["raw"] = False  # override to force column literals
-    src_columns = [t.translate(arg, **kwargs) for arg in op.args]
+    src_columns = [t.translate(arg, **kwargs) for arg in op.arg]
     return F.concat(*src_columns)
 
 

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -236,7 +236,7 @@ def _string_join(t, op):
 
 
 def _string_concat(t, op):
-    return functools.reduce(operator.add, map(t.translate, op.args))
+    return functools.reduce(operator.add, map(t.translate, op.arg))
 
 
 def _date_from_ymd(t, op):

--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -271,10 +271,8 @@ class Concrete(Immutable, Comparable, Annotable, Traversable):
 
         results = {}
         for node in Graph.from_bfs(self, filter=filter).toposort():
-            args, kwargs = node.__signature__.unbind(node)
-            args = recursive_get(args, results)
-            kwargs = recursive_get(kwargs, results)
-            results[node] = fn(node, *args, **kwargs)
+            kwargs = recursive_get(node.__getstate__(), results)
+            results[node] = fn(node, **kwargs)
 
         return results
 
@@ -282,10 +280,10 @@ class Concrete(Immutable, Comparable, Annotable, Traversable):
         return self.map(fn, filter=filter)[self]
 
     def replace(self, subs, filter=None):
-        def fn(node, *args, **kwargs):
+        def fn(node, **kwargs):
             try:
                 return subs[node]
             except KeyError:
-                return node.__class__(*args, **kwargs)
+                return node.__class__(**kwargs)
 
         return self.substitute(fn, filter=filter)

--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -90,18 +90,6 @@ class Value(Node, Named):
             return self.output_dtype.scalar(self)
 
 
-# TODO(kszucs): this base class is not required, using rlz.variadic() rule should be
-# enough once all the analysis code starts to use the traversal functions
-@public
-class Variadic(Value):
-    output_shape = rlz.shape_like('arg')
-    output_dtype = rlz.dtype_like('arg')
-
-    @property
-    def args(self):
-        return self.arg
-
-
 @public
 class Alias(Value):
     arg = rlz.any

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -17,7 +17,7 @@ import ibis.expr.rules as rlz
 from ibis.common import exceptions as com
 from ibis.common.annotations import attribute
 from ibis.common.grounds import Singleton
-from ibis.expr.operations.core import Named, Unary, Value, Variadic
+from ibis.expr.operations.core import Named, Unary, Value
 from ibis.util import frozendict
 
 try:
@@ -150,18 +150,24 @@ class NullIf(Value):
 
 
 @public
-class Coalesce(Variadic):
-    arg = rlz.variadic(rlz.any)
+class Coalesce(Value):
+    arg = rlz.tuple_of(rlz.any)
+    output_shape = rlz.shape_like('arg')
+    output_dtype = rlz.dtype_like('arg')
 
 
 @public
-class Greatest(Variadic):
-    arg = rlz.variadic(rlz.any)
+class Greatest(Value):
+    arg = rlz.tuple_of(rlz.any)
+    output_shape = rlz.shape_like('arg')
+    output_dtype = rlz.dtype_like('arg')
 
 
 @public
-class Least(Variadic):
-    arg = rlz.variadic(rlz.any)
+class Least(Value):
+    arg = rlz.tuple_of(rlz.any)
+    output_shape = rlz.shape_like('arg')
+    output_dtype = rlz.dtype_like('arg')
 
 
 @public

--- a/ibis/expr/operations/strings.py
+++ b/ibis/expr/operations/strings.py
@@ -3,7 +3,7 @@ from public import public
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
-from ibis.expr.operations.core import Unary, Value, Variadic
+from ibis.expr.operations.core import Unary, Value
 
 
 @public
@@ -216,8 +216,10 @@ class StringSplit(Value):
 
 
 @public
-class StringConcat(Variadic):
-    arg = rlz.variadic(rlz.string)
+class StringConcat(Value):
+    arg = rlz.tuple_of(rlz.string)
+    output_shape = rlz.shape_like('arg')
+    output_dtype = rlz.dtype_like('arg')
 
 
 @public

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -8,7 +8,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 import ibis.util as util
-from ibis.common.annotations import attribute, optional, variadic  # noqa: F401
+from ibis.common.annotations import attribute, optional  # noqa: F401
 from ibis.common.validators import (  # noqa: F401
     bool_,
     instance_of,

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -124,7 +124,7 @@ class Value(Expr):
         >>> ibis.coalesce(None, 4, 5)
         Coalesce((None, 4, 5))
         """
-        return ops.Coalesce(self, *args).to_expr()
+        return ops.Coalesce((self, *args)).to_expr()
 
     def greatest(self, *args: ir.Value) -> ir.Value:
         """Compute the largest value among the supplied arguments.
@@ -139,7 +139,7 @@ class Value(Expr):
         Value
             Maximum of the passed arguments
         """
-        return ops.Greatest(self, *args).to_expr()
+        return ops.Greatest((self, *args)).to_expr()
 
     def least(self, *args: ir.Value) -> ir.Value:
         """Compute the smallest value among the supplied arguments.
@@ -154,7 +154,7 @@ class Value(Expr):
         Value
             Minimum of the passed arguments
         """
-        return ops.Least(self, *args).to_expr()
+        return ops.Least((self, *args)).to_expr()
 
     def typeof(self) -> ir.StringValue:
         """Return the data type of the expression.

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -711,7 +711,7 @@ class StringValue(Value):
         StringValue
             All strings concatenated
         """
-        return ops.StringConcat(self, other, *args).to_expr()
+        return ops.StringConcat((self, other, *args)).to_expr()
 
     def __add__(self, other: str | StringValue) -> StringValue:
         """Concatenate strings.
@@ -726,7 +726,7 @@ class StringValue(Value):
         StringValue
             All strings concatenated
         """
-        return ops.StringConcat(self, other).to_expr()
+        return ops.StringConcat((self, other)).to_expr()
 
     def __radd__(self, other: str | StringValue) -> StringValue:
         """Concatenate strings.
@@ -741,7 +741,7 @@ class StringValue(Value):
         StringValue
             All strings concatenated
         """
-        return ops.StringConcat(other, self).to_expr()
+        return ops.StringConcat((other, self)).to_expr()
 
     def convert_base(
         self,

--- a/ibis/tests/expr/test_operations.py
+++ b/ibis/tests/expr/test_operations.py
@@ -66,7 +66,7 @@ operations = [
     ops.RegexReplace('asd', 'as', 'a'),
     ops.StringReplace('asd', 'as', 'a'),
     ops.StringSplit('asd', 's'),
-    ops.StringConcat('s', 'e'),
+    ops.StringConcat(('s', 'e')),
     ops.StartsWith('asd', 'as'),
     ops.EndsWith('asd', 'xyz'),
     ops.Not(false),
@@ -108,13 +108,13 @@ class NamedValue(Base):
 
 
 class Values(Base):
-    lst = rlz.variadic(rlz.instance_of(ops.Node))
+    lst = rlz.tuple_of(rlz.instance_of(ops.Node))
 
 
 one = NamedValue(value=1, name=Name("one"))
 two = NamedValue(value=2, name=Name("two"))
 three = NamedValue(value=3, name=Name("three"))
-values = Values(one, two, three)
+values = Values((one, two, three))
 
 
 def test_node_base():
@@ -151,8 +151,8 @@ def test_node_base():
         (three, (), {"value": 3, "name": "Name_three"}),
         (
             values,
-            ("NamedValue_1_one", "NamedValue_2_two", "NamedValue_3_three"),
-            {},
+            (),
+            {"lst": ("NamedValue_1_one", "NamedValue_2_two", "NamedValue_3_three")},
         ),
     ]
 
@@ -166,7 +166,7 @@ def test_node_subtitution():
     subs = {Name("one"): Name("zero"), two: ketto}
 
     new_values = values.replace(subs)
-    expected = Values(NamedValue(value=1, name=Name("zero")), ketto, three)
+    expected = Values((NamedValue(value=1, name=Name("zero")), ketto, three))
 
     assert expected == new_values
 


### PR DESCRIPTION
Since the removal of `ops.NodeList` where we implicitly traverse tuples, the variadic annotation mostly provides syntax sugar. In addition to that `rlz.variadic` hasn't been released yet, so it's better to prefer a simpler approach to reconstruct nodes using purely keyword arguments rather than tracking both `*args` and `**kwargs`.

depends on #4891 