### PR TITLE
fix(api): allow boolean scalars in predicate APIs

### DIFF
--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -346,7 +346,10 @@ class Selection(Projection):
             )
 
         for predicate in predicates:
-            if not shares_some_roots(predicate, table):
+            if isinstance(predicate, ops.Literal):
+                if not (dtype := predicate.output_dtype).is_boolean():
+                    raise com.IbisTypeError(f"Invalid predicate dtype: {dtype}")
+            elif not shares_some_roots(predicate, table):
                 raise com.RelationError("Predicate doesn't share any roots with table")
 
         super().__init__(

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -108,7 +108,7 @@ class Table(Expr, JupyterMixin):
 
     def __getitem__(self, what):
         from ibis.expr.types.generic import Column
-        from ibis.expr.types.logical import BooleanColumn
+        from ibis.expr.types.logical import BooleanValue
 
         if isinstance(what, (str, int)):
             return self.get_column(what)
@@ -133,7 +133,7 @@ class Table(Expr, JupyterMixin):
         if isinstance(what, (list, tuple, Table)):
             # Projection case
             return self.select(what)
-        elif isinstance(what, BooleanColumn):
+        elif isinstance(what, BooleanValue):
             # Boolean predicate
             return self.filter([what])
         elif isinstance(what, Column):

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1636,3 +1636,22 @@ def test_array_string_compare():
     t = ibis.table(schema=dict(by="string", words="array<string>"), name="t")
     expr = t[t.by == "foo"].mutate(words=_.words.unnest()).filter(_.words == "the")
     assert expr is not None
+
+
+@pytest.mark.parametrize("value", [True, False])
+@pytest.mark.parametrize(
+    "api",
+    [
+        param(lambda t, value: t[value], id="getitem"),
+        param(lambda t, value: t.filter(value), id="filter"),
+    ],
+)
+def test_filter_with_literal(value, api):
+    t = ibis.table(dict(a="string"))
+    filt = api(t, ibis.literal(value))
+    assert filt is not None
+
+    # ints are invalid predicates
+    int_val = ibis.literal(int(value))
+    with pytest.raises((NotImplementedError, com.IbisTypeError)):
+        api(t, int_val)


### PR DESCRIPTION
This PR fixes a bug where we currently do not allow bool literals in `Table.__getitem__` or  `Table.filter` APIs.