### PR TITLE
perf(node): give `Node`s the default Python repr

### DIFF
--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -31,9 +31,8 @@ class Node(Concrete):
     def to_expr(self):
         ...
 
-    def __repr__(self) -> str:
-        cls = self.__class__
-        return f"<{cls.__module__}.{cls.__name__} at 0x{hex(id(self))}>"
+    # Avoid custom repr for performance reasons
+    __repr__ = object.__repr__
 
 
 @public

--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -31,6 +31,10 @@ class Node(Concrete):
     def to_expr(self):
         ...
 
+    def __repr__(self) -> str:
+        cls = self.__class__
+        return f"<{cls.__module__}.{cls.__name__} at 0x{hex(id(self))}>"
+
 
 @public
 class Named(ABC):

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -700,8 +700,6 @@ def test_repr_join(benchmark, customers, orders, orders_items, products):
         .join(orders_items, "orderid")
         .join(products, "sku")
         .drop("customerid", "qty", "total", "items")
-        .drop("dims_cm", "cost")
-        .mutate(o_date=lambda t: t.shipped.date())
     )
     op = expr.op()
     benchmark(repr, op)

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ down:
 
 # run the benchmark suite
 bench +args='ibis/tests/benchmarks':
-    pytest --benchmark-only --benchmark-autosave {{ args }}
+    pytest --benchmark-only --benchmark-enable --benchmark-autosave {{ args }}
 
 # check for invalid links in a locally built version of the docs
 checklinks *args:


### PR DESCRIPTION
This PR removes the Node repr to alleviate performance problems when validation fails.