### PR TITLE
ci: remove reach section of codecov report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ codecov:
 
 comment:
   after_n_builds: 32
-  layout: "reach, diff, files"
+  layout: "diff, files"
   behavior: default
   require_changes: true # if true: only post the comment if coverage changes
   require_base: false # [yes :: must have a base report to post]


### PR DESCRIPTION
This PR removes the reach part of the codecov report. I personally never click on it and when I do it does not take me to anything useful. If others like it, I am happy to leave it as is.