### PR TITLE
ci: remove `project` coverage from CI status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,13 +18,6 @@ ignore:
 
 coverage:
   status:
-    project:
-      default:
-        # Allow for slight decreases in code coverage, makes
-        # the coverage status checks a little less finicky
-        target: auto
-        threshold: 1%
-        only_pulls: true
     patch:
       default:
         target: auto


### PR DESCRIPTION
This PR removes the GH status check for project code coverage. After merging in the bigquery backend which requires creds to run its backend suite, PRs will always appear to decrease coverage. I think we really only care about the patch status check, namely that the code that was changed has coverage. Coverage should still show up in the readme badge with the full set of backends covered, as that is published on every merge to master.