### PR TITLE
fix(duckdb): replace all in `re_replace`

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -212,7 +212,9 @@ operation_registry.update(
             0,
         ),
         ops.RegexExtract: _regex_extract,
-        ops.RegexReplace: fixed_arity(sa.func.regexp_replace, 3),
+        ops.RegexReplace: fixed_arity(
+            lambda *args: sa.func.regexp_replace(*args, "g"), 3
+        ),
         ops.StringContains: fixed_arity(sa.func.contains, 2),
         ops.CMSMedian: reduction(
             lambda arg: sa.func.approx_quantile(arg, sa.text(str(0.5)))

--- a/ibis/backends/pandas/execution/strings.py
+++ b/ibis/backends/pandas/execution/strings.py
@@ -293,6 +293,11 @@ def execute_series_regex_replace(op, data, pattern, replacement, **kwargs):
     return data.apply(replacer)
 
 
+@execute_node.register(ops.RegexReplace, str, str, str)
+def execute_str_regex_replace(_, arg, pattern, replacement, **kwargs):
+    return re.sub(pattern, replacement, arg)
+
+
 @execute_node.register(ops.RegexReplace, SeriesGroupBy, str, str)
 def execute_series_regex_replace_gb(op, data, pattern, replacement, **kwargs):
     return execute_series_regex_replace(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -386,6 +386,13 @@ def test_string(backend, alltypes, df, result_func, expected_func):
     backend.assert_series_equal(result, expected)
 
 
+@pytest.mark.notimpl(["datafusion", "mysql", "snowflake", "mssql"])
+def test_re_replace_global(con):
+    expr = ibis.literal("aba").re_replace("a", "c")
+    result = con.execute(expr)
+    assert result == "cbc"
+
+
 @pytest.mark.notimpl(["datafusion", "mssql"])
 def test_substr_with_null_values(backend, alltypes, df):
     table = alltypes.mutate(


### PR DESCRIPTION
This PR fixes an issue where the DuckDB backend was not using global regex replacement behavior. I also added an implementation of `RegexReplace` for `str` for the pandas backend.