### PR TITLE
ci: actually disable project coverage

### DIFF
--- a/.github/workflows/ibis-backends-skip-helper.yml
+++ b/.github/workflows/ibis-backends-skip-helper.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "**/*.md"
+      - "codecov.yml"
     branches:
       - master
       - "*.x.x"
@@ -16,6 +17,7 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "**/*.md"
+      - "codecov.yml"
     branches:
       - master
       - "*.x.x"

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -8,6 +8,7 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "**/*.md"
+      - "codecov.yml"
     branches:
       - master
       - "*.x.x"
@@ -17,6 +18,7 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "**/*.md"
+      - "codecov.yml"
     branches:
       - master
       - "*.x.x"

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,3 +23,6 @@ coverage:
         target: auto
         threshold: 1%
         only_pulls: true
+    project:
+      default:
+        enabled: false


### PR DESCRIPTION
This PR *actually* removes the GH status check for project code coverage. Turns out you need to explicitly disable it.