### PR TITLE
fix(duckdb): drop incorrect `translate` implementation

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -204,7 +204,6 @@ operation_registry.update(
         ops.TableColumn: _table_column,
         ops.TimestampDiff: fixed_arity(sa.func.age, 2),
         ops.TimestampFromUNIX: _timestamp_from_unix,
-        ops.Translate: fixed_arity(sa.func.replace, 3),
         ops.TimestampNow: fixed_arity(
             # duckdb 0.6.0 changes now to be a tiemstamp with time zone force
             # it back to the original for backwards compatibility

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -134,11 +134,19 @@ def test_string_col_is_unicode(alltypes, df):
             id="repeat_right",
         ),
         param(
-            lambda t: t.string_col.translate('0', 'a'),
-            lambda t: t.string_col.str.translate(str.maketrans('0', 'a')),
+            lambda t: t.string_col.translate('01', 'ab'),
+            lambda t: t.string_col.str.translate(str.maketrans('01', 'ab')),
             id='translate',
             marks=pytest.mark.notimpl(
-                ["bigquery", "clickhouse", "datafusion", "mysql", "polars", "mssql"]
+                [
+                    "bigquery",
+                    "clickhouse",
+                    "datafusion",
+                    "duckdb",
+                    "mssql",
+                    "mysql",
+                    "polars",
+                ]
             ),
         ),
         param(


### PR DESCRIPTION
The implementation of `translate` for `duckdb` was incorrect, but appeared to work correctly in tests since only a single character string was tested. This PR updates the test to better cover this functionality, and drops the implementation for duckdb. Duckdb doesn't appear to have a way to support this operation natively and efficiently.