### PR TITLE
refactor(api): move `histogram` method to `Table` expressions

### DIFF
--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -596,8 +596,8 @@ def test_clip(alltypes, df, ibis_func, pandas_func):
     tm.assert_series_equal(result, expected, check_names=False)
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pandas", "pyspark", "polars"])
+@pytest.mark.notimpl(["datafusion", "pyspark", "polars"])
 def test_histogram(con, alltypes):
     n = 10
-    results = con.execute(alltypes.int_col.histogram(n).name("tmp"))
-    assert len(results.value_counts()) == n
+    results = con.execute(alltypes.histogram("int_col", n))
+    assert len(results.int_col_bucket.value_counts()) == n

--- a/ibis/expr/operations/histograms.py
+++ b/ibis/expr/operations/histograms.py
@@ -49,29 +49,6 @@ class Bucket(BucketLike):
 
 
 @public
-class Histogram(BucketLike):
-    arg = rlz.numeric
-    nbins = rlz.optional(rlz.instance_of(int))
-    binwidth = rlz.optional(rlz.scalar(rlz.numeric))
-    base = rlz.optional(rlz.scalar(rlz.numeric))
-    closed = rlz.optional(rlz.isin({'left', 'right'}), default='left')
-    aux_hash = rlz.optional(rlz.instance_of(str))
-
-    def __init__(self, nbins, binwidth, **kwargs):
-        if nbins is None:
-            if binwidth is None:
-                raise ValueError('Must indicate nbins or binwidth')
-        elif binwidth is not None:
-            raise ValueError('nbins and binwidth are mutually exclusive')
-        super().__init__(nbins=nbins, binwidth=binwidth, **kwargs)
-
-    @property
-    def output_dtype(self):
-        # always undefined cardinality (for now)
-        return dt.category
-
-
-@public
 class CategoryLabel(Value):
     arg = rlz.category
     labels = rlz.tuple_of(rlz.instance_of(str))

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -526,38 +526,6 @@ class NumericColumn(Column, NumericValue):
             include_over=include_over,
         ).to_expr()
 
-    def histogram(
-        self,
-        nbins: int | None = None,
-        binwidth: float | None = None,
-        base: float | None = None,
-        closed: Literal["left", "right"] = "left",
-        aux_hash: str | None = None,
-    ) -> ir.CategoryColumn:
-        """Compute a histogram with fixed width bins.
-
-        Parameters
-        ----------
-        nbins
-            If supplied, will be used to compute the binwidth
-        binwidth
-            If not supplied, computed from the data (actual max and min values)
-        base
-            Histogram base
-        closed
-            Which side of each interval is closed
-        aux_hash
-            Auxiliary hash value to add to bucket names
-
-        Returns
-        -------
-        CategoryColumn
-            Coded value expression
-        """
-        return ops.Histogram(
-            self, nbins, binwidth, base, closed=closed, aux_hash=aux_hash
-        ).to_expr()
-
     def summary(
         self,
         exact_nunique: bool = False,

--- a/ibis/tests/expr/test_analytics.py
+++ b/ibis/tests/expr/test_analytics.py
@@ -85,16 +85,11 @@ def test_bucket_error_cases(alltypes):
 
 
 def test_histogram(alltypes):
-    d = alltypes.double_col
-
     with pytest.raises(ValueError):
-        d.histogram(nbins=10, binwidth=5)
+        alltypes.histogram("double_col", nbins=10, binwidth=5)
 
-    with pytest.raises(ValueError):
-        d.histogram()
-
-    with pytest.raises(ValueError):
-        d.histogram(10, closed="foo")
+    with pytest.raises(ValueError, match="`nbins` is required"):
+        alltypes.histogram("double_col")
 
 
 def test_topk_analysis_bug(airlines):

--- a/ibis/tests/expr/test_interactive.py
+++ b/ibis/tests/expr/test_interactive.py
@@ -106,8 +106,8 @@ def test_interactive_non_compilable_repr_not_fail(con):
 
 def test_histogram_repr_no_query_execute(con):
     t = con.table('functional_alltypes')
-    tier = t.double_col.histogram(10).name('bucket')
-    expr = t.group_by(tier).size()
+    tier = t.histogram("double_col", 10)
+    expr = tier.group_by("double_col_bucket").size()
     with config.option_context('interactive', True):
         expr._repr()
     assert con.executed_queries == []


### PR DESCRIPTION
This PR moves the histogram method to table expressions in an effort to further simplify the compiler and avoid having expressions or their construction tied to the internal details of the compiler.