### PR TITLE
chore: skip flake8 and isort checks on python files generated by the decompiler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,7 +294,7 @@ multi_line_output = 3
 include_trailing_comma = true
 profile = "black"
 extend_skip = [".direnv"]
-extend_skip_glob = ["result*"]
+extend_skip_glob = ["result*", "ibis/tests/*/snapshots/*"]
 skip_gitignore = true
 
 [tool.pydocstyle]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
 [flake8]
 ignore = D202,D203,W503,E203,E501
 max-line-length = 88
+exclude =
+    ibis/tests/*/snapshots/*


### PR DESCRIPTION
- `just fmt`: isort updated the generated python files
- `just lint`: flake8 complained about a couple of generated python files