### PR TITLE
fix(pandas): drop `RowID` implementation

### DIFF
--- a/ibis/backends/pandas/dispatch.py
+++ b/ibis/backends/pandas/dispatch.py
@@ -19,7 +19,14 @@ execute_node = TraceTwoLevelDispatcher(
 
 
 @execute_node.register(ops.Node)
-def execute_node_without_scope(node, **kwargs):
+def raise_unknown_op(node, **kwargs):
+    raise NotImplementedError(
+        f"Operation {type(node).__name__!r} is not implemented " f"for this backend"
+    )
+
+
+@execute_node.register(ops.TableNode)
+def raise_unknown_table_node(node, **kwargs):
     raise com.UnboundExpressionError(
         (
             'Node of type {!r} has no data bound to it. '

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -1303,11 +1303,6 @@ def execute_distinct_dataframe(op, df, **kwargs):
     return df.drop_duplicates()
 
 
-@execute_node.register(ops.RowID)
-def execute_rowid(op, *args, **kwargs):
-    raise com.UnsupportedOperationError('rowid is not supported in pandas backends')
-
-
 @execute_node.register(ops.TableArrayView, pd.DataFrame)
 def execute_table_array_view(op, _, **kwargs):
     return execute(op.table).squeeze()

--- a/ibis/backends/pandas/tests/test_core.py
+++ b/ibis/backends/pandas/tests/test_core.py
@@ -100,9 +100,7 @@ def test_missing_data_on_custom_client():
     t = con.table('t')
     with pytest.raises(
         NotImplementedError,
-        match=(
-            'Could not find signature for execute_node: ' '<DatabaseTable, MyBackend>'
-        ),
+        match=('Could not find signature for execute_node: <DatabaseTable, MyBackend>'),
     ):
         con.execute(t)
 


### PR DESCRIPTION
The previous dispatch just raised an error saying it wasn't implemented, better to do this as the base implementation of `execute_node`.

Fixes #4945.