### PR TITLE
chore: run pyspark tests in parallel

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -202,11 +202,11 @@ jobs:
         run: poetry install --without dev --without docs --extras ${{ matrix.backend.name }} --extras geospatial
 
       - name: "run parallel tests: ${{ matrix.backend.name }}"
-        if: matrix.backend.name != 'pyspark' && matrix.backend.name != 'impala'
+        if: matrix.backend.name != 'impala'
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
 
       - name: "run serial tests: ${{ matrix.backend.name }}"
-        if: matrix.backend.name == 'pyspark' || matrix.backend.name == 'impala'
+        if: matrix.backend.name == 'impala'
         run: just ci-check -m ${{ matrix.backend.name }}
         env:
           IBIS_TEST_NN_HOST: localhost


### PR DESCRIPTION
Runs the pyspark backend tests in parallel in CI. This works locally now.