### PR TITLE
refactor: reimplement `histogram` API in terms of window functions

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -33,6 +33,7 @@ class SnowflakeExprTranslator(AlchemyExprTranslator):
         ops.Lag,
         ops.Lead,
     )
+    _require_order_by = (*AlchemyExprTranslator._require_order_by, ops.Reduction)
 
 
 class SnowflakeCompiler(AlchemyCompiler):

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -596,7 +596,7 @@ def test_clip(alltypes, df, ibis_func, pandas_func):
     tm.assert_series_equal(result, expected, check_names=False)
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pandas", "pyspark", "polars"])
+@pytest.mark.notimpl(["dask", "datafusion", "pyspark", "polars"])
 def test_histogram(con, alltypes):
     n = 10
     results = con.execute(alltypes.int_col.histogram(n).name("tmp"))

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -596,7 +596,7 @@ def test_clip(alltypes, df, ibis_func, pandas_func):
     tm.assert_series_equal(result, expected, check_names=False)
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pyspark", "polars"])
+@pytest.mark.notimpl(["dask", "datafusion", "polars"])
 def test_histogram(con, alltypes):
     n = 10
     results = con.execute(alltypes.int_col.histogram(n).name("tmp"))

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -424,13 +424,7 @@ def test_grouped_bounded_preceding_window(backend, alltypes, df, window_fn):
     ('ordered'),
     [
         param(True, id='ordered', marks=pytest.mark.notimpl(["dask", "pandas"])),
-        param(
-            False,
-            id='unordered',
-            marks=[
-                pytest.mark.notyet(["snowflake"], reason="backend requires ordering")
-            ],
-        ),
+        param(False, id='unordered'),
     ],
 )
 @pytest.mark.notimpl(["datafusion", "polars"])
@@ -486,9 +480,6 @@ def test_grouped_unbounded_window(
             lambda df: pd.Series([df.double_col.mean()] * len(df.double_col)),
             False,
             id='unordered-mean',
-            marks=[
-                pytest.mark.notyet(["snowflake"], reason="backend requires ordering")
-            ],
         ),
         param(
             lambda t, win: mean_udf(t.double_col).over(win),

--- a/ibis/expr/operations/histograms.py
+++ b/ibis/expr/operations/histograms.py
@@ -6,26 +6,18 @@ from ibis.expr.operations.core import Value
 
 
 @public
-class BucketLike(Value):
-    output_shape = rlz.Shape.COLUMNAR
-
-    @property
-    def nbuckets(self):
-        return None
-
-    @property
-    def output_dtype(self):
-        return dt.Category(self.nbuckets)
-
-
-@public
-class Bucket(BucketLike):
+class Bucket(Value):
     arg = rlz.column(rlz.any)
     buckets = rlz.tuple_of(rlz.scalar(rlz.any))
     closed = rlz.optional(rlz.isin({'left', 'right'}), default='left')
     close_extreme = rlz.optional(rlz.instance_of(bool), default=True)
     include_under = rlz.optional(rlz.instance_of(bool), default=False)
     include_over = rlz.optional(rlz.instance_of(bool), default=False)
+    output_shape = rlz.Shape.COLUMNAR
+
+    @property
+    def output_dtype(self):
+        return dt.Category(self.nbuckets)
 
     def __init__(self, buckets, include_under, include_over, **kwargs):
         if not len(buckets):
@@ -46,29 +38,6 @@ class Bucket(BucketLike):
     @property
     def nbuckets(self):
         return len(self.buckets) - 1 + self.include_over + self.include_under
-
-
-@public
-class Histogram(BucketLike):
-    arg = rlz.numeric
-    nbins = rlz.optional(rlz.instance_of(int))
-    binwidth = rlz.optional(rlz.scalar(rlz.numeric))
-    base = rlz.optional(rlz.scalar(rlz.numeric))
-    closed = rlz.optional(rlz.isin({'left', 'right'}), default='left')
-    aux_hash = rlz.optional(rlz.instance_of(str))
-
-    def __init__(self, nbins, binwidth, **kwargs):
-        if nbins is None:
-            if binwidth is None:
-                raise ValueError('Must indicate nbins or binwidth')
-        elif binwidth is not None:
-            raise ValueError('nbins and binwidth are mutually exclusive')
-        super().__init__(nbins=nbins, binwidth=binwidth, **kwargs)
-
-    @property
-    def output_dtype(self):
-        # always undefined cardinality (for now)
-        return dt.category
 
 
 @public

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -729,10 +729,13 @@ class Column(Value, JupyterMixin):
         """
         from ibis.expr.analysis import find_first_base_table
 
-        base = find_first_base_table(self.op()).to_expr()
-        metric = base.count().name(metric_name)
-
-        return base.group_by(self).aggregate(metric)
+        return (
+            find_first_base_table(self.op())
+            .to_expr()
+            .select(self)
+            .group_by(self.get_name())
+            .agg(**{metric_name: lambda t: t.count()})
+        )
 
     def first(self) -> Column:
         return ops.FirstValue(self).to_expr()

--- a/ibis/tests/expr/test_analytics.py
+++ b/ibis/tests/expr/test_analytics.py
@@ -93,9 +93,6 @@ def test_histogram(alltypes):
     with pytest.raises(ValueError):
         d.histogram()
 
-    with pytest.raises(ValueError):
-        d.histogram(10, closed="foo")
-
 
 def test_topk_analysis_bug(airlines):
     # GH #398

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -738,7 +738,7 @@ def test_group_by_column_select_api(table):
 def test_value_counts_convenience(table):
     # #152
     result = table.g.value_counts()
-    expected = table.group_by('g').aggregate(table.count().name('count'))
+    expected = table.select('g').group_by('g').aggregate(count=lambda t: t.count())
 
     assert_equal(result, expected)
 

--- a/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result1.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result1.sql
@@ -1,3 +1,10 @@
 SELECT `b`, count(1) AS `count`
-FROM t
+FROM (
+  SELECT `b`
+  FROM (
+    SELECT *
+    FROM t
+    ORDER BY `a` ASC
+  ) t1
+) t0
 GROUP BY 1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result2.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result2.sql
@@ -1,4 +1,10 @@
 SELECT `b`, count(1) AS `count`
-FROM t
+FROM (
+  SELECT `b`
+  FROM (
+    SELECT *
+    FROM t
+    ORDER BY `b` ASC
+  ) t1
+) t0
 GROUP BY 1
-ORDER BY `b` ASC


### PR DESCRIPTION
This PR rewrites the current histogram API to use window functions instead of a cross join, in an effort to further simplify the compiler and avoid having expressions or their construction tied to the internal details of the compiler. Depends on #4962.