### PR TITLE
ci: remove `python-dev`

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -149,7 +149,7 @@ jobs:
           set -euo pipefail
 
           sudo apt-get update -qq -y
-          sudo apt-get install -qq -y build-essential python-dev ${{ join(matrix.backend.sys-deps, ' ') }}
+          sudo apt-get install -qq -y build-essential ${{ join(matrix.backend.sys-deps, ' ') }}
 
       - name: install sqlite
         if: matrix.os == 'windows-latest' && matrix.backend.name == 'sqlite'


### PR DESCRIPTION
This PR removes the no longer extant `python-dev` package from our CI setup. I am not sure if we still need it, buf if we do, apaprently it is merged into the vanilla `python` package.