### PR TITLE
feat: add extract functionality to trino backend

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -482,6 +482,13 @@ def _count_star(t, op):
     return sa.func.count(t.translate(ops.Where(where, 1, None)))
 
 
+def _extract(fmt: str):
+    def translator(t, op: ops.Node):
+        return sa.cast(sa.extract(fmt, t.translate(op.arg)), sa.SMALLINT)
+
+    return translator
+
+
 sqlalchemy_operation_registry: Dict[Any, Any] = {
     ops.Alias: _alias,
     ops.And: fixed_arity(operator.and_, 2),
@@ -612,6 +619,13 @@ sqlalchemy_operation_registry: Dict[Any, Any] = {
     ops.BitwiseRightShift: _bitwise_op(">>"),
     ops.BitwiseNot: _bitwise_not,
     ops.JSONGetItem: fixed_arity(lambda x, y: x.op("->")(y), 2),
+    ops.ExtractYear: _extract('year'),
+    ops.ExtractQuarter: _extract('quarter'),
+    ops.ExtractMonth: _extract('month'),
+    ops.ExtractDay: _extract('day'),
+    ops.ExtractHour: _extract('hour'),
+    ops.ExtractMinute: _extract('minute'),
+    ops.ExtractSecond: _extract('second'),
 }
 
 

--- a/ibis/backends/tests/test_column.py
+++ b/ibis/backends/tests/test_column.py
@@ -83,7 +83,7 @@ def test_distinct_column(alltypes, df, column):
         ("day", set(range(1, 32))),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "trino"])
+@pytest.mark.notimpl(["datafusion"])
 @pytest.mark.notyet(["impala"])
 def test_date_extract_field(con, opname, expected):
     op = operator.methodcaller(opname)

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -27,7 +27,7 @@ from ibis.backends.pandas.execution.temporal import day_name
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "trino"])
+@pytest.mark.notimpl(["datafusion"])
 def test_date_extract(backend, alltypes, df, attr, expr_fn):
     expr = getattr(expr_fn(alltypes.timestamp_col), attr)()
     expected = getattr(df.timestamp_col.dt, attr).astype('int32')
@@ -44,7 +44,8 @@ def test_date_extract(backend, alltypes, df, attr, expr_fn):
         'month',
         'day',
         param(
-            'day_of_year', marks=pytest.mark.notimpl(["bigquery", "impala", "mssql"])
+            'day_of_year',
+            marks=pytest.mark.notimpl(["bigquery", "impala", "mssql", "trino"]),
         ),
         param('quarter', marks=pytest.mark.notimpl(["mssql"])),
         'hour',
@@ -52,7 +53,7 @@ def test_date_extract(backend, alltypes, df, attr, expr_fn):
         'second',
     ],
 )
-@pytest.mark.notimpl(["datafusion", "trino"])
+@pytest.mark.notimpl(["datafusion"])
 def test_timestamp_extract(backend, alltypes, df, attr):
     method = getattr(alltypes.timestamp_col, attr)
     expr = method().name(attr)
@@ -77,7 +78,7 @@ def test_timestamp_extract(backend, alltypes, df, attr):
             359,
             id='millisecond',
             marks=[
-                pytest.mark.notimpl(["clickhouse", "pyspark"]),
+                pytest.mark.notimpl(["clickhouse", "pyspark", "trino"]),
                 pytest.mark.broken(
                     ["mysql"],
                     reason="MySQL implementation of milliseconds is broken",
@@ -88,17 +89,17 @@ def test_timestamp_extract(backend, alltypes, df, attr):
             lambda x: x.day_of_week.index(),
             1,
             id='day_of_week_index',
-            marks=pytest.mark.notimpl(["mssql"]),
+            marks=pytest.mark.notimpl(["mssql", "trino"]),
         ),
         param(
             lambda x: x.day_of_week.full_name(),
             'Tuesday',
             id='day_of_week_full_name',
-            marks=pytest.mark.notimpl(["mssql"]),
+            marks=pytest.mark.notimpl(["mssql", "trino"]),
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "snowflake", "trino"])
+@pytest.mark.notimpl(["datafusion", "snowflake"])
 def test_timestamp_extract_literal(con, func, expected):
     value = ibis.timestamp('2015-09-01 14:48:05.359')
     assert con.execute(func(value).name("tmp")) == expected

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -47,7 +47,7 @@ def test_date_extract(backend, alltypes, df, attr, expr_fn):
             'day_of_year',
             marks=pytest.mark.notimpl(["bigquery", "impala", "mssql", "trino"]),
         ),
-        param('quarter', marks=pytest.mark.notimpl(["mssql"])),
+        'quarter',
         'hour',
         'minute',
         'second',


### PR DESCRIPTION
This PR adds generic extract rules so that they can be shared between the sqlalchemy backends where possible. This fixes failing benchmark tests on master.