### PR TITLE
refactor: split up custom nix code; remove unused derivations

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -60,7 +60,7 @@ jobs:
 
       # run against the full shell.nix on push so it gets pushed to cachix
       - name: pre-commit checks
-        run: nix develop --ignore-environment --keep-going -c pre-commit run --all-files
+        run: nix develop '.#preCommit' --ignore-environment --keep-going -c pre-commit run --all-files
 
   benchmarks:
     runs-on: ubuntu-latest
@@ -139,10 +139,10 @@ jobs:
           fetch-depth: 0
 
       - name: build docs
-        run: nix develop -c mkdocs build --strict
+        run: nix develop '.#docs' -c mkdocs build --strict
 
       - name: verify internal links
-        run: nix develop -c just checklinks --offline --no-progress
+        run: nix develop --ignore-environment '.#links' -c just checklinks --offline --no-progress
 
   docs_push:
     runs-on: ubuntu-latest
@@ -188,7 +188,8 @@ jobs:
 
       - name: build and push dev docs
         run: |
-          nix develop -c mike deploy --push --rebase --prefix docs --message 'docs(dev): ibis@${{ github.sha }}' dev
+          nix develop '.#docs' -c \
+            mike deploy --push --rebase --prefix docs --message 'docs(dev): ibis@${{ github.sha }}' dev
 
   simulate_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/ibis-docs-release.yml
+++ b/.github/workflows/ibis-docs-release.yml
@@ -48,4 +48,5 @@ jobs:
 
       - name: build and push docs on tag
         run: |
-          nix develop -c mike deploy --push --rebase --update-aliases --prefix docs --message "docs(release): ibis@${GITHUB_REF_NAME}" "${GITHUB_REF_NAME}" latest
+          nix develop '.#docs' -c \
+            mike deploy --push --rebase --update-aliases --prefix docs --message "docs(release): ibis@${GITHUB_REF_NAME}" "${GITHUB_REF_NAME}" latest

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -49,6 +49,10 @@ jobs:
 
       - name: install nix
         uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable-small
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: setup cachix
         uses: cachix/cachix-action@v12
@@ -62,3 +66,14 @@ jobs:
 
           version='${{ matrix.python-version }}'
           nix build ".#ibis${version//./}" --fallback --keep-going --print-build-logs
+
+      # build the whole dev shell when pushing to upstream, so that the cachix cache is populated
+      - name: nix build devShell
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+
+          version='${{ matrix.python-version }}'
+          host_system="$(nix eval --raw 'nixpkgs#stdenv.hostPlatform.system')"
+          flake=".#devShells.${host_system}.ibis${version//./}"
+          nix build "$flake" --fallback --keep-going --print-build-logs

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: cachix/install-nix-action@v18
         with:
           extra_nix_config: |
-            access-tokens = github.com=${{ secrets.github_token }}
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: setup cachix
         uses: cachix/cachix-action@v12

--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -6,31 +6,35 @@ curdir="$PWD"
 worktree="$(mktemp -d)"
 branch="$(basename "$worktree")"
 
-nix develop -c git worktree add "$worktree"
+nix develop '.#release' -c git worktree add "$worktree"
 
 function cleanup() {
   cd "$curdir" || exit 1
-  nix develop -c git worktree remove --force "$worktree"
-  nix develop -c git worktree prune
-  nix develop -c git branch -D "$branch"
+  nix develop '.#release' -c git worktree remove --force "$worktree"
+  nix develop '.#release' -c git worktree prune
+  nix develop '.#release' -c git branch -D "$branch"
 }
 
 trap cleanup EXIT ERR
 
 cd "$worktree" || exit 1
 
-nix develop -c node <<< 'console.log(JSON.stringify(require("./.releaserc.js")))' |
-  jq '.plugins |= [.[] | select(.[0] != "@semantic-release/github")]' > .releaserc.json
+nix develop '.#release' -c node <<< 'console.log(JSON.stringify(require("./.releaserc.js")))' |
+  nix develop '.#release' -c jq '.plugins |= [.[] | select(.[0] != "@semantic-release/github")]' > .releaserc.json
 
-nix develop -c git rm .releaserc.js
+nix develop '.#release' -c git rm .releaserc.js
+nix develop '.#release' -c git add .releaserc.json
+nix develop '.#release' -c git commit -m 'test: semantic-release dry run' --no-verify --no-gpg-sign
 
-nix develop -c git add .releaserc.json
-
-nix develop -c git commit -m 'test: semantic-release dry run' --no-verify --no-gpg-sign
-
+# If this is set then semantic-release will assume the release is running
+# against a PR.
+#
+# Normally this would be fine, except that most of the release process that is
+# useful to test is prevented from running, even in dry-run mode, so we `unset`
+# this variable here and pass `--dry-run` ourselves
 unset GITHUB_ACTIONS
 
-nix develop -c npx --yes \
+nix develop '.#release' -c npx --yes \
   -p semantic-release \
   -p "@semantic-release/commit-analyzer" \
   -p "@semantic-release/release-notes-generator" \

--- a/ci/release/prepare.sh
+++ b/ci/release/prepare.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 version="${1}"
 
 # set version
-nix develop -c poetry version "$version"
+nix develop '.#release' -c poetry version "$version"
 
 # build artifacts
-nix develop -c poetry build
+nix develop '.#release' -c poetry build
 
 # ensure that the built wheel has the correct version number
-nix develop -c unzip -p "dist/ibis_framework-${version}-py3-none-any.whl" ibis/__init__.py | grep -q "__version__ = \"$version\""
+nix develop '.#release' -c unzip -p "dist/ibis_framework-${version}-py3-none-any.whl" ibis/__init__.py | \
+  nix develop '.#release' -c grep -q "__version__ = \"$version\""

--- a/ci/release/publish.sh
+++ b/ci/release/publish.sh
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-nix develop -c poetry publish
+nix develop '.#release' -c poetry publish

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-nix develop -c npx --yes \
+nix develop '.#release' -c npx --yes \
   -p semantic-release \
   -p "@semantic-release/commit-analyzer" \
   -p "@semantic-release/release-notes-generator" \

--- a/ci/release/verify.sh
+++ b/ci/release/verify.sh
@@ -5,13 +5,13 @@ set -euo pipefail
 dry_run="${1:-false}"
 
 # verify pyproject.toml
-nix develop -c poetry check
+nix develop '.#release' -c poetry check
 
 # verify that the lock file matches pyproject.toml
 #
 # the lock file might not be the most fresh, but that's okay: it need only be
 # consistent with pyproject.toml
-nix develop -c poetry lock --check
+nix develop '.#release' -c poetry lock --check
 
 # verify that we have a token available to push to pypi using set -u
 if [ "${dry_run}" = "false" ]; then

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671547822,
-        "narHash": "sha256-bSYKAFg4kCZqobqAmM6CYZgiOz6dNyCRp4rqLFXjzTE=",
+        "lastModified": 1671550109,
+        "narHash": "sha256-4Iixlro1t75ze8TqXvfz0HTZ9TOBav3vMTuwuYqsxRE=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "6ae0cf69896dbd52c0ffd72f460c773367238e48",
+        "rev": "f18984f99c67654a1f9fbde463c88a319a2c843e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,255 +18,149 @@
 
     poetry2nix = {
       url = "github:nix-community/poetry2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
     };
   };
 
-  outputs =
-    { self
-    , flake-utils
-    , gitignore
-    , nixpkgs
-    , poetry2nix
-    , ...
-    }:
+  outputs = { self, flake-utils, gitignore, nixpkgs, poetry2nix, ... }: {
+    overlays.default = nixpkgs.lib.composeManyExtensions [
+      gitignore.overlay
+      poetry2nix.overlay
+      (import ./nix/overlay.nix)
+    ];
+  } // flake-utils.lib.eachDefaultSystem (
+    localSystem:
     let
-      backends = [
-        "dask"
-        "datafusion"
-        "duckdb"
-        "pandas"
-        "polars"
-        "sqlite"
+      pkgs = import nixpkgs {
+        inherit localSystem;
+        overlays = [ self.overlays.default ];
+      };
+      inherit (pkgs) lib;
+
+      backendDevDeps = with pkgs; [
+        # impala UDFs
+        clang_12
+        cmake
+        ninja
+        # snowflake
+        openssl
+        # backend test suite
+        docker-compose
+        # visualization
+        graphviz-nox
+        # duckdb
+        duckdb
+        # mysql
+        mariadb-client
+        # pyspark
+        openjdk17_headless
+        # postgres
+        postgresql
+        # sqlite
+        sqlite-interactive
       ];
-      drv =
-        { poetry2nix
-        , python
-        , lib
-        , gitignoreSource
-        , graphviz-nox
-        , sqlite
-        , rsync
-        , ibisTestingData
-        }: poetry2nix.mkPoetryApplication rec {
-          inherit python;
+      shellHook = ''
+        export IBIS_TEST_DATA_DIRECTORY="$PWD/ci/ibis-testing-data"
 
-          groups = [ ];
-          checkGroups = [ "test" ];
-          projectDir = gitignoreSource ./.;
-          preferWheels = true;
-          src = gitignoreSource ./.;
+        ${pkgs.rsync}/bin/rsync \
+          --chmod=Du+rwx,Fu+rw --archive --delete \
+          "${pkgs.ibisTestingData}/" \
+          "$IBIS_TEST_DATA_DIRECTORY"
 
-          overrides = [
-            (import ./poetry-overrides.nix)
-            poetry2nix.defaultPoetryOverrides
-          ];
+        export TEMPDIR
+        TEMPDIR="$(python -c 'import tempfile; print(tempfile.gettempdir())')"
 
-          buildInputs = [ graphviz-nox sqlite ];
+        # necessary for mkdocs
+        export PYTHONPATH=''${PWD}''${PYTHONPATH:+:}''${PYTHONPATH}
+      '';
 
-          checkInputs = buildInputs;
+      preCommitDeps = with pkgs; [
+        actionlint
+        git
+        just
+        nix-linter
+        nixpkgs-fmt
+        pre-commit
+        prettier
+        shellcheck
+        shfmt
+      ];
 
-          preCheck = ''
-            set -euo pipefail
+      mkDevShell = name: env: pkgs.mkShell {
+        inherit name;
+        nativeBuildInputs = (with pkgs; [
+          # python dev environment
+          env
+          # rendering release notes
+          changelog
+          glow
+          # used in the justfile
+          jq
+          yj
+          # linting
+          commitlint
+          lychee
+          # release automation
+          nodejs
+          # poetry executable
+          env.pkgs.poetry
+        ])
+        ++ preCommitDeps
+        ++ backendDevDeps;
 
-            export IBIS_TEST_DATA_DIRECTORY="$PWD/ci/ibis-testing-data"
+        inherit shellHook;
 
-            ${rsync}/bin/rsync \
-              --chmod=Du+rwx,Fu+rw --archive --delete \
-              "${ibisTestingData}/" \
-              "$IBIS_TEST_DATA_DIRECTORY"
-          '';
-
-          checkPhase = ''
-            set -euo pipefail
-
-            runHook preCheck
-
-            pytest \
-              --numprocesses "$NIX_BUILD_CORES" \
-              --dist loadgroup \
-              -m '${lib.concatStringsSep " or " backends} or core'
-
-            runHook postCheck
-          '';
-
-          doCheck = true;
-
-          pythonImportsCheck = [ "ibis" ] ++ map (backend: "ibis.backends.${backend}") backends;
-        };
+        PGPASSWORD = "postgres";
+        MYSQL_PWD = "ibis";
+        MSSQL_SA_PASSWORD = "1bis_Testing!";
+      };
     in
-    {
-      overlays.default = nixpkgs.lib.composeManyExtensions [
-        gitignore.overlay
-        poetry2nix.overlay
-        (pkgs: _: {
-          ibisTestingData = pkgs.fetchFromGitHub {
-            owner = "ibis-project";
-            repo = "testing-data";
-            rev = "master";
-            sha256 = "sha256-BZWi4kEumZemQeYoAtlUSw922p+R6opSWp/bmX0DjAo=";
-          };
+    rec {
+      packages = {
+        inherit (pkgs) ibis38 ibis39 ibis310;
 
-          mkPoetryEnv = groups: python: pkgs.poetry2nix.mkPoetryEnv {
-            inherit python groups;
-            preferWheels = true;
-            projectDir = pkgs.gitignoreSource ./.;
-            editablePackageSources = { ibis = pkgs.gitignoreSource ./ibis; };
-            overrides = [
-              (import ./poetry-overrides.nix)
-              pkgs.poetry2nix.defaultPoetryOverrides
-            ];
-          };
+        default = pkgs.ibis310;
 
-          mkPoetryDocsEnv = pkgs.mkPoetryEnv [ "docs" ];
-          mkPoetryDevEnv = pkgs.mkPoetryEnv [ "dev" "test" ];
-          mkPoetryFullDevEnv = pkgs.mkPoetryEnv [ "dev" "docs" "test" ];
+        inherit (pkgs) update-lock-files;
+      };
 
-          prettierTOML = pkgs.writeShellScriptBin "prettier" ''
-            ${pkgs.nodePackages.prettier}/bin/prettier \
-            --plugin-search-dir "${pkgs.nodePackages.prettier-plugin-toml}/lib" "$@"
-          '';
+      devShells = rec {
+        ibis38 = mkDevShell "ibis38" pkgs.ibisDevEnv38;
+        ibis39 = mkDevShell "ibis39" pkgs.ibisDevEnv39;
+        ibis310 = mkDevShell "ibis310" pkgs.ibisDevEnv310;
 
-          ibis38 = pkgs.callPackage drv { python = pkgs.python38; };
-          ibis39 = pkgs.callPackage drv { python = pkgs.python39; };
-          ibis310 = pkgs.callPackage drv { python = pkgs.python310; };
+        default = ibis310;
 
-          ibisDevEnv38 = pkgs.mkPoetryDevEnv pkgs.python38;
-          ibisDevEnv39 = pkgs.mkPoetryDevEnv pkgs.python39;
-          ibisDevEnv310 = pkgs.mkPoetryDevEnv pkgs.python310;
-
-          ibisDevEnv = pkgs.ibisDevEnv310;
-
-          ibisDocsEnv38 = pkgs.mkPoetryDocsEnv pkgs.python38;
-          ibisDocsEnv39 = pkgs.mkPoetryDocsEnv pkgs.python39;
-          ibisDocsEnv310 = pkgs.mkPoetryDocsEnv pkgs.python310;
-
-          ibisDocsEnv = pkgs.ibisDocsEnv310;
-
-          ibisFullDevEnv38 = pkgs.mkPoetryFullDevEnv pkgs.python38;
-          ibisFullDevEnv39 = pkgs.mkPoetryFullDevEnv pkgs.python39;
-          ibisFullDevEnv310 = pkgs.mkPoetryFullDevEnv pkgs.python310;
-
-          ibisFullDevEnv = pkgs.ibisFullDevEnv310;
-
-          changelog = pkgs.writeShellApplication {
-            name = "changelog";
-            runtimeInputs = [ pkgs.nodePackages.conventional-changelog-cli ];
-            text = "conventional-changelog --config ./.conventionalcommits.js";
-          };
-        })
-      ];
-    } // flake-utils.lib.eachDefaultSystem (
-      localSystem:
-      let
-        pkgs = import nixpkgs {
-          inherit localSystem;
-          overlays = [ self.overlays.default ];
+        docs = pkgs.mkShell {
+          name = "docs";
+          nativeBuildInputs = [ pkgs.ibisDocsEnv ];
+          inherit shellHook;
         };
-        inherit (pkgs) lib;
 
-        backendDevDeps = with pkgs; [
-          # impala UDFs
-          clang_12
-          cmake
-          ninja
-          # snowflake
-          openssl
-          # backend test suite
-          docker-compose
-          # visualization
-          graphviz-nox
-          # duckdb
-          duckdb
-          # mysql
-          mariadb-client
-          # pyspark
-          openjdk17_headless
-          # postgres
-          postgresql
-          # sqlite
-          sqlite-interactive
-        ];
-        mkDevShell = env: pkgs.mkShell {
-          nativeBuildInputs = (with pkgs; [
-            # python dev environment
-            env
-            # rendering release notes
-            changelog
-            glow
-            # used in the justfile
-            jq
-            yj
-            # linting
-            commitlint
-            lychee
-            # release automation
-            nodejs
-            # poetry executable
-            env.pkgs.poetry
-            # pre-commit deps
-            actionlint
+        preCommit = pkgs.mkShell {
+          name = "preCommit";
+          nativeBuildInputs = [ pkgs.ibisSmallDevEnv ] ++ preCommitDeps;
+        };
+
+        links = pkgs.mkShell {
+          name = "links";
+          nativeBuildInputs = with pkgs; [ just lychee ];
+        };
+
+        release = pkgs.mkShell {
+          name = "release";
+          nativeBuildInputs = with pkgs; [
             git
-            just
-            nix-linter
-            nixpkgs-fmt
-            pre-commit
-            prettierTOML
-            shellcheck
-            shfmt
-          ])
-          # backend development dependencies
-          ++ backendDevDeps;
-
-          shellHook = ''
-            export IBIS_TEST_DATA_DIRECTORY="$PWD/ci/ibis-testing-data"
-
-            ${pkgs.rsync}/bin/rsync \
-              --chmod=Du+rwx,Fu+rw --archive --delete \
-              "${pkgs.ibisTestingData}/" \
-              "$IBIS_TEST_DATA_DIRECTORY"
-
-            export TEMPDIR
-            TEMPDIR="$(python -c 'import tempfile; print(tempfile.gettempdir())')"
-
-            # necessary for mkdocs
-            export PYTHONPATH=''${PWD}''${PYTHONPATH:+:}''${PYTHONPATH}
-          '';
-
-          PGPASSWORD = "postgres";
-          MYSQL_PWD = "ibis";
-          MSSQL_SA_PASSWORD = "1bis_Testing!";
+            ibisSmallDevEnv.pkgs.poetry
+            nodejs
+            unzip
+            gnugrep
+          ];
         };
-      in
-      rec {
-        packages = rec {
-          ibis38 = pkgs.ibis38;
-          ibis39 = pkgs.ibis39;
-          ibis310 = pkgs.ibis310;
-          default = ibis310;
-
-          update-lock-files = pkgs.writeShellApplication {
-            name = "update-lock-files";
-            runtimeInputs = with pkgs; [ poetry ];
-
-            text = ''
-              export PYTHONHASHSEED=0
-
-              TOP="''${PWD}"
-
-              poetry lock --no-update
-              poetry export --with dev --with test --with docs --without-hashes --no-ansi > "''${TOP}/requirements.txt"
-            '';
-          };
-        };
-
-        devShells = rec {
-          ibis38 = mkDevShell pkgs.ibisFullDevEnv38;
-          ibis39 = mkDevShell pkgs.ibisFullDevEnv39;
-          ibis310 = mkDevShell pkgs.ibisFullDevEnv310;
-          default = ibis310;
-        };
-      }
-    );
+      };
+    }
+  );
 }

--- a/nix/ibis.nix
+++ b/nix/ibis.nix
@@ -1,0 +1,56 @@
+{ poetry2nix
+, python3
+, lib
+, gitignoreSource
+, graphviz-nox
+, sqlite
+, rsync
+, ibisTestingData
+}:
+let
+  backends = [ "dask" "datafusion" "duckdb" "pandas" "polars" "sqlite" ];
+in
+poetry2nix.mkPoetryApplication rec {
+  python = python3;
+  groups = [ ];
+  checkGroups = [ "test" ];
+  projectDir = gitignoreSource ../.;
+  src = gitignoreSource ../.;
+  extras = backends;
+  overrides = [
+    (import ../poetry-overrides.nix)
+    poetry2nix.defaultPoetryOverrides
+  ];
+  preferWheels = true;
+
+  buildInputs = [ graphviz-nox sqlite ];
+  checkInputs = buildInputs;
+
+  preCheck = ''
+    set -euo pipefail
+
+    export IBIS_TEST_DATA_DIRECTORY="$PWD/ci/ibis-testing-data"
+
+    ${rsync}/bin/rsync \
+      --chmod=Du+rwx,Fu+rw --archive --delete \
+      "${ibisTestingData}/" \
+      "$IBIS_TEST_DATA_DIRECTORY"
+  '';
+
+  checkPhase = ''
+    set -euo pipefail
+
+    runHook preCheck
+
+    pytest \
+      --numprocesses "$NIX_BUILD_CORES" \
+      --dist loadgroup \
+      -m '${lib.concatStringsSep " or " backends} or core'
+
+    runHook postCheck
+  '';
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "ibis" ] ++ (map (backend: "ibis.backends.${backend}") backends);
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,71 @@
+pkgs: _:
+let
+  mkPoetryEnv = { groups, python, extras ? [ "*" ] }: pkgs.poetry2nix.mkPoetryEnv {
+    inherit python groups extras;
+    projectDir = pkgs.gitignoreSource ../.;
+    editablePackageSources = { ibis = pkgs.gitignoreSource ../ibis; };
+    overrides = [
+      (import ../poetry-overrides.nix)
+      pkgs.poetry2nix.defaultPoetryOverrides
+    ];
+    preferWheels = true;
+  };
+
+  mkPoetryDevEnv = python: mkPoetryEnv {
+    inherit python;
+    groups = [ "dev" "docs" "test" ];
+  };
+in
+{
+  ibisTestingData = pkgs.fetchFromGitHub {
+    owner = "ibis-project";
+    repo = "testing-data";
+    rev = "master";
+    sha256 = "sha256-BZWi4kEumZemQeYoAtlUSw922p+R6opSWp/bmX0DjAo=";
+  };
+
+  rustNightly = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal);
+
+  prettier = pkgs.writeShellApplication {
+    name = "prettier";
+    runtimeInputs = [ ];
+    text = ''
+      ${pkgs.nodePackages.prettier}/bin/prettier \
+      --plugin-search-dir "${pkgs.nodePackages.prettier-plugin-toml}/lib" "$@"
+    '';
+  };
+
+  ibis38 = pkgs.python38Packages.callPackage ./ibis.nix { };
+  ibis39 = pkgs.python39Packages.callPackage ./ibis.nix { };
+  ibis310 = pkgs.python310Packages.callPackage ./ibis.nix { };
+
+  ibisDevEnv38 = mkPoetryDevEnv pkgs.python38;
+  ibisDevEnv39 = mkPoetryDevEnv pkgs.python39;
+  ibisDevEnv310 = mkPoetryDevEnv pkgs.python310;
+
+  ibisSmallDevEnv = mkPoetryEnv {
+    python = pkgs.python310;
+    groups = [ "dev" ];
+    extras = [ ];
+  };
+
+  ibisDocsEnv = mkPoetryEnv {
+    python = pkgs.python310;
+    groups = [ "docs" ];
+  };
+
+  changelog = pkgs.writeShellApplication {
+    name = "changelog";
+    runtimeInputs = [ pkgs.nodePackages.conventional-changelog-cli ];
+    text = "conventional-changelog --config ./.conventionalcommits.js";
+  };
+
+  update-lock-files = pkgs.writeShellApplication {
+    name = "update-lock-files";
+    runtimeInputs = [ pkgs.poetry ];
+    text = ''
+      poetry lock --no-update
+      poetry export --with dev --with test --with docs --without-hashes --no-ansi > requirements.txt
+    '';
+  };
+}


### PR DESCRIPTION
This PR splits up some of our code in `flake.nix` to a few distinct files under `nix/`.

The upshot here is that we will spend much less time downloading/building dependencies that are never used for certain tasks, for example, building pyarrow before running `pre-commit`.

The new shells `.#release`, `.#docs`, etc only contain the dependencies needed to perform the specific task.

This PR is in draft mode until https://github.com/nix-community/poetry2nix/pull/867 is merged.
