### PR TITLE
fix: `ibis.connect` always returns a backend

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -763,10 +763,6 @@ def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
 
     Examples
     --------
-    Connect to an on-disk parquet or csv file (uses duckdb by default):
-    >>> con = ibis.connect("/path/to/data.parquet")
-    >>> con = ibis.connect("/path/to/data.csv")
-
     Connect to an in-memory duckdb database:
     >>> con = ibis.connect("duckdb://")
 
@@ -799,7 +795,8 @@ def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
         elif path.endswith((".parquet", ".csv", ".csv.gz")):
             # Load parquet/csv/csv.gz files with duckdb by default
             con = ibis.duckdb.connect(**kwargs)
-            return con.register(path)
+            con.register(path)
+            return con
         else:
             raise ValueError(f"Don't know how to connect to {resource!r}")
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -13,7 +13,6 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-import ibis.expr.types as ir
 from ibis.util import guid
 
 
@@ -586,8 +585,8 @@ def test_connect_sqlite(url, ext, tmp_path):
 )
 def test_connect_local_file(out_method, extension, test_employee_data_1, tmp_path):
     getattr(test_employee_data_1, out_method)(tmp_path / f"out.{extension}")
-    t = ibis.connect(tmp_path / f"out.{extension}")
-    assert isinstance(t, ir.Table)
+    con = ibis.connect(tmp_path / f"out.{extension}")
+    t = list(con.tables.values())[0]
     assert not t.head().execute().empty
 
 


### PR DESCRIPTION
Previously `ibis.connect` would return a `Table` object when calling `connect` on a parquet/csv file. This now returns a backend containing a single table created from that file. This fixes an inconsistency with the current interface, where the return type depended on the value of the connection string, making it hard to type check. When possible users may use `ibis.read` instead to read files into ibis tables.

I went with a clean break here rather than a deprecation because:

- This feature hasn't been out that long anyway, I doubt a breaking change now will affect that many users
- 4.0 has other breaking changes

Happy to move to a deprecation if needed.