### PR TITLE
test(perf): speed up extremely slow join test

### DIFF
--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -189,9 +189,9 @@ def test_join_then_filter_no_column_overlap(awards_players, batting):
 def test_mutate_then_join_no_column_overlap(batting, awards_players):
     left = batting.mutate(year=batting.yearID).filter(lambda t: t.year == 2015)
     left = left["year", "RBI"]
-    right = awards_players.filter(lambda t: t.yearID == 2015)
+    right = awards_players
     expr = left.join(right, left.year == right.yearID)
-    assert not expr.execute().empty
+    assert not expr.limit(5).execute().empty
 
 
 @pytest.mark.notimpl(["datafusion", "bigquery"])


### PR DESCRIPTION
This PR speeds up a very slow test (~100s for the execute call for the MySQL backend alone) likely introduced when the default limit of execute was set to `None`, since this expression returns a large number of rows (around 5.5MM).