### PR TITLE
chore(deps): bump duckdb lower bound

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -235,20 +235,3 @@ operation_registry.update(
         ops.RowID: lambda *_: sa.literal_column('rowid'),
     }
 )
-
-try:
-    import duckdb
-except ImportError:  # pragma: no cover
-    pass
-else:
-    from packaging.version import parse as vparse
-
-    # 0.3.2 has zero-based array indexing, 0.3.3 has one-based array indexing
-    #
-    # 0.3.2: we pass in the user's arguments unchanged
-    # 0.3.3: use the postgres implementation which is also one-based
-    if vparse(duckdb.__version__) < vparse("0.3.3"):  # pragma: no cover
-        operation_registry[ops.ArrayIndex] = fixed_arity("list_element", 2)
-
-    # don't export these
-    del duckdb, vparse  # pragma: no cover

--- a/poetry.lock
+++ b/poetry.lock
@@ -5100,7 +5100,7 @@ clickhouse = ["clickhouse-driver", "clickhouse-cityhash", "lz4", "sqlglot"]
 dask = ["dask", "pyarrow", "regex"]
 datafusion = ["datafusion"]
 decompiler = ["black"]
-duckdb = ["duckdb", "duckdb-engine", "packaging", "pyarrow", "sqlalchemy", "sqlglot"]
+duckdb = ["duckdb", "duckdb-engine", "pyarrow", "sqlalchemy", "sqlglot"]
 geospatial = ["GeoAlchemy2", "geopandas", "Shapely"]
 impala = ["fsspec", "impyla", "requests", "sqlglot", "sqlalchemy"]
 mssql = ["sqlalchemy", "pymssql", "sqlglot"]
@@ -5117,4 +5117,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "36fb1d2c4a9f5302394a52a1b4153289d4ed1f285bc9b362b9cbee9b19db2c75"
+content-hash = "8e21172452a303c245bc9963a14dade196bb49db32cd0154d1f53ad7050c8155"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dask = { version = ">=2022.9.1", optional = true, extras = [
 ] }
 datafusion = { version = ">=0.6,<0.8", optional = true }
 db-dtypes = { version = ">=0.3,<2", optional = true }
-duckdb = { version = ">=0.3.2,<1", optional = true }
+duckdb = { version = ">=0.3.3,<1", optional = true }
 duckdb-engine = { version = ">=0.1.8,<1", optional = true }
 fsspec = { version = ">=2022.1.0", optional = true }
 GeoAlchemy2 = { version = ">=0.6.3,<1", optional = true }
@@ -53,7 +53,6 @@ google-cloud-bigquery-storage = { version = ">=2,<3", optional = true }
 graphviz = { version = ">=0.16,<1", optional = true }
 impyla = { version = ">=0.17,<1", optional = true }
 lz4 = { version = ">=3.1.10,<5", optional = true }
-packaging = { version = ">=21.3,<23", optional = true }
 polars = { version = ">=0.14.18,<1", optional = true }
 psycopg2 = { version = ">=2.8.4,<3", optional = true }
 pyarrow = { version = ">=1,<11", optional = true }
@@ -130,14 +129,7 @@ bigquery = [
 clickhouse = ["clickhouse-driver", "clickhouse-cityhash", "lz4", "sqlglot"]
 dask = ["dask", "pyarrow", "regex"]
 datafusion = ["datafusion"]
-duckdb = [
-  "duckdb",
-  "duckdb-engine",
-  "packaging",
-  "pyarrow",
-  "sqlalchemy",
-  "sqlglot"
-]
+duckdb = ["duckdb", "duckdb-engine", "pyarrow", "sqlalchemy", "sqlglot"]
 geospatial = ["geoalchemy2", "geopandas", "shapely"]
 impala = ["fsspec", "impyla", "requests", "sqlglot", "sqlalchemy"]
 mssql = ["sqlalchemy", "pymssql", "sqlglot"]


### PR DESCRIPTION
This PR bumps the minimum duckdb version to 0.3.3 so we can remove a dependency and some old compatibility code.