### PR TITLE
chore(deps): make the `regex` dep optional

### DIFF
--- a/ibis/backends/pandas/execution/strings.py
+++ b/ibis/backends/pandas/execution/strings.py
@@ -5,9 +5,13 @@ from functools import partial, reduce
 
 import numpy as np
 import pandas as pd
-import regex as re
 import toolz
 from pandas.core.groupby import SeriesGroupBy
+
+try:
+    import regex as re
+except ImportError:
+    import re
 
 import ibis.expr.operations as ops
 import ibis.util

--- a/ibis/backends/sqlite/udf.py
+++ b/ibis/backends/sqlite/udf.py
@@ -6,7 +6,10 @@ import math
 import operator
 from typing import Callable
 
-import regex as re
+try:
+    import regex as re
+except ImportError:
+    import re
 
 _SQLITE_UDF_REGISTRY = set()
 _SQLITE_UDAF_REGISTRY = set()

--- a/poetry.lock
+++ b/poetry.lock
@@ -4243,7 +4243,7 @@ name = "regex"
 version = "2022.10.31"
 description = "Alternative regular expression module, to replace re."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "regex-2022.10.31-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a8ff454ef0bb061e37df03557afda9d785c905dab15584860f982e88be73015f"},
@@ -5078,7 +5078,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [extras]
 bigquery = ["db-dtypes", "google-cloud-bigquery", "google-cloud-bigquery-storage", "pydata-google-auth", "sqlglot"]
 clickhouse = ["clickhouse-driver", "clickhouse-cityhash", "lz4", "sqlglot"]
-dask = ["dask", "pyarrow"]
+dask = ["dask", "pyarrow", "regex"]
 datafusion = ["datafusion"]
 decompiler = ["black"]
 duckdb = ["duckdb", "duckdb-engine", "packaging", "pyarrow", "sqlalchemy", "sqlglot"]
@@ -5086,16 +5086,16 @@ geospatial = ["GeoAlchemy2", "geopandas", "Shapely"]
 impala = ["fsspec", "impyla", "requests", "sqlglot", "sqlalchemy"]
 mssql = ["sqlalchemy", "pymssql", "sqlglot"]
 mysql = ["sqlalchemy", "pymysql", "sqlglot"]
-pandas = []
+pandas = ["regex"]
 polars = ["polars", "pyarrow"]
 postgres = ["psycopg2", "sqlalchemy", "sqlglot"]
 pyspark = ["pyarrow", "pyspark"]
 snowflake = ["snowflake-sqlalchemy", "sqlglot"]
-sqlite = ["sqlalchemy", "sqlglot"]
+sqlite = ["regex", "sqlalchemy", "sqlglot"]
 trino = ["trino", "sqlalchemy", "sqlglot"]
 visualization = ["graphviz"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "37cf7ca2e76772917db7633d6bb3807d6ab543aef028030ae220ebf5eff1a68e"
+content-hash = "e74b18ef3e7c58e1260dc64ebfeee010d94942a094c19e9267d89a55d91e8292"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ multipledispatch = ">=0.6,<1"
 numpy = ">=1,<2"
 pandas = ">=1.2.5,<2"
 parsy = ">=1.3.0,<3"
-regex = ">=2021.7.6"
 rich = ">=12.4.4,<13"
 toolz = ">=0.11,<1"
 typing-extensions = ">=4.3.0,<5"
@@ -62,6 +61,8 @@ pymssql = { version = ">=2.2.7,<3", optional = true }
 pydata-google-auth = { version = "^1.4.0", optional = true }
 pymysql = { version = ">=1,<2", optional = true }
 pyspark = { version = ">=3,<4", optional = true }
+# used to support posix regexen in the pandas, dask and sqlite backends
+regex = { version = ">=2021.7.6", optional = true }
 requests = { version = ">=2,<3", optional = true }
 Shapely = { version = ">=1.6,<1.8|>=1.9,<2", optional = true }
 snowflake-sqlalchemy = { version = ">=1.4.1,<2", optional = true }
@@ -126,7 +127,7 @@ bigquery = [
   "sqlglot"
 ]
 clickhouse = ["clickhouse-driver", "clickhouse-cityhash", "lz4", "sqlglot"]
-dask = ["dask", "pyarrow"]
+dask = ["dask", "pyarrow", "regex"]
 datafusion = ["datafusion"]
 duckdb = [
   "duckdb",
@@ -140,12 +141,12 @@ geospatial = ["geoalchemy2", "geopandas", "shapely"]
 impala = ["fsspec", "impyla", "requests", "sqlglot", "sqlalchemy"]
 mssql = ["sqlalchemy", "pymssql", "sqlglot"]
 mysql = ["sqlalchemy", "pymysql", "sqlglot"]
-pandas = []
+pandas = ["regex"]
 polars = ["polars", "pyarrow"]
 postgres = ["psycopg2", "sqlalchemy", "sqlglot"]
 pyspark = ["pyarrow", "pyspark"]
 snowflake = ["snowflake-sqlalchemy", "sqlglot"]
-sqlite = ["sqlalchemy", "sqlglot"]
+sqlite = ["regex", "sqlalchemy", "sqlglot"]
 trino = ["trino", "sqlalchemy", "sqlglot"]
 # non-backend extras
 visualization = ["graphviz"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -127,7 +127,6 @@ pywin32==305 ; sys_platform == "win32" and platform_python_implementation != "Py
 pyyaml-env-tag==0.1 ; python_version >= "3.8" and python_version < "4.0"
 pyyaml==6.0 ; python_version >= "3.8" and python_version < "4.0"
 pyzmq==24.0.1 ; python_version >= "3.8" and python_version < "4.0"
-regex==2022.10.31 ; python_version >= "3.8" and python_version < "4.0"
 requests==2.28.1 ; python_version >= "3.8" and python_version < "4"
 rich==12.6.0 ; python_version >= "3.8" and python_version < "4.0"
 six==1.16.0 ; python_version >= "3.8" and python_version < "4.0"


### PR DESCRIPTION
This PR moves the `regex` package to an optional dependency, since only the sqlite, pandas and dask backends require it (for posix regexen support).