### PR TITLE
ci: reduce pyspark flakiness by running tests serially

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -249,11 +249,11 @@ jobs:
         run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"
 
       - name: "run parallel tests: ${{ matrix.backend.name }}"
-        if: matrix.backend.name != 'impala'
+        if: matrix.backend.name != 'impala' && matrix.backend.name != 'pyspark'
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
 
       - name: "run serial tests: ${{ matrix.backend.name }}"
-        if: matrix.backend.name == 'impala'
+        if: matrix.backend.name == 'impala' || matrix.backend.name == 'pyspark'
         run: just ci-check -m ${{ matrix.backend.name }}
         env:
           IBIS_TEST_NN_HOST: localhost


### PR DESCRIPTION
It seems like running pyspark tests in parallel in CI is flaky, so this PR reverts back to serial tests for pyspark.