### PR TITLE
ci: re-enable release notes in `simulate_release`

### DIFF
--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -28,6 +28,8 @@ nix develop -c git add .releaserc.json
 
 nix develop -c git commit -m 'test: semantic-release dry run' --no-verify --no-gpg-sign
 
+unset GITHUB_ACTIONS
+
 nix develop -c npx --yes \
   -p semantic-release \
   -p "@semantic-release/commit-analyzer" \


### PR DESCRIPTION
When this was ported to use `nix develop` we had to remove `--pure`,
since we removed `nix-shell` usage here, and the `GITHUB_ACTIONS`
variable used by `semantic-release` crept in. We `unset` it so that it
has no effect.
