### PR TITLE
ci: increase GH API rate limit for nix updates and don't `fail-fast`

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -29,11 +29,15 @@ jobs:
     needs:
       - get-flakes
     strategy:
+      fail-fast: false
       matrix: ${{ fromJSON(needs.get-flakes.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
 
       - uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.github_token }}
 
       - name: setup cachix
         uses: cachix/cachix-action@v12


### PR DESCRIPTION
This PR gives the nix updates workflow a higher GH API rate limit, which typically is not necessary, but a recent failure indicate an API limit likely due to a bunch of other concurrent jobs and workflows also hitting the GH API at the same time. Since it is easy to increase the limit we might as well do it.