### PR TITLE
test: prevent clickhouse test `list_tables` flakiness

### DIFF
--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -53,6 +53,10 @@ class TestConf(UnorderedComparator, BackendTest, RoundHalfToEven):
 
         client.execute(f"DROP DATABASE IF EXISTS {database}")
         client.execute(f"CREATE DATABASE {database} ENGINE = Atomic")
+
+        client.execute("DROP DATABASE IF EXISTS tmptables")
+        client.execute("CREATE DATABASE tmptables ENGINE = Atomic")
+
         client.execute(f"USE {database}")
         client.execute("SET allow_experimental_object_type = 1")
         client.execute("SET output_format_json_named_tuples_as_objects = 1")


### PR DESCRIPTION
Apparently it is possible for clickhouse parallel testing to trigger a case where occasionally between two `list_tables` calls a fixture that creates a temporary table in the same database as the `list_tables` calls is called and is not dropped before the second `list_tables` calls leading to the occasional (and common enough to warrant this PR) failure.