### PR TITLE
fix(postgres): fix array_index operation

### DIFF
--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -431,6 +431,14 @@ def _array_slice(t, op):
     return sa_arg[sa_start + 1 : sa_stop]
 
 
+def _array_index(t, op):
+    sa_array = t.translate(op.arg)
+    sa_index = t.translate(op.index)
+    if isinstance(op.arg, ops.Literal):
+        sa_array = sa.sql.elements.Grouping(sa_array)
+    return sa_array[_neg_idx_to_pos(sa_array, sa_index) + 1]
+
+
 def _literal(_, op):
     dtype = op.output_dtype
     value = op.value
@@ -582,9 +590,7 @@ operation_registry.update(
         ops.ArrayCollect: reduction(sa.func.array_agg),
         ops.ArrayColumn: _array_column,
         ops.ArraySlice: _array_slice,
-        ops.ArrayIndex: fixed_arity(
-            lambda array, index: array[_neg_idx_to_pos(array, index) + 1], 2
-        ),
+        ops.ArrayIndex: _array_index,
         ops.ArrayConcat: fixed_arity(sa.sql.expression.ColumnElement.concat, 2),
         ops.ArrayRepeat: _array_repeat,
         ops.Unnest: unary(sa.func.unnest),

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -90,7 +90,6 @@ def test_np_array_literal(con):
 
 @pytest.mark.parametrize("idx", range(3))
 @pytest.mark.notimpl(["impala", "snowflake", "polars", "datafusion", "trino"])
-@pytest.mark.notyet(["postgres"], reason="generated code is invalid")
 def test_array_index(con, idx):
     arr = [1, 2, 3]
     expr = ibis.literal(arr)


### PR DESCRIPTION
Hi.

Small fix for Postgres backend.
Now the `ibis/backends/tests/test_array.py` tests for Postgres look like below
```
ibis/backends/tests/test_array.py::test_array_discovery_clickhouse[postgres] XFAIL (backend supports nullable nested types)           [  5%]
ibis/backends/tests/test_array.py::test_array_scalar[postgres] PASSED                                                                 [ 11%]
ibis/backends/tests/test_array.py::test_list_literal[postgres] PASSED                                                                 [ 16%]
ibis/backends/tests/test_array.py::test_array_concat[postgres] PASSED                                                                 [ 22%]
ibis/backends/tests/test_array.py::test_unnest_no_nulls[postgres] PASSED                                                              [ 27%]
ibis/backends/tests/test_array.py::test_unnest_default_name[postgres] PASSED                                                          [ 33%]
ibis/backends/tests/test_array.py::test_unnest_simple[postgres] PASSED                                                                [ 38%]
ibis/backends/tests/test_array.py::test_array_index[postgres-2] PASSED                                                                [ 44%]
ibis/backends/tests/test_array.py::test_array_index[postgres-1] PASSED                                                                [ 50%]
ibis/backends/tests/test_array.py::test_unnest_idempotent[postgres] PASSED                                                            [ 55%]
ibis/backends/tests/test_array.py::test_array_index[postgres-0] PASSED                                                                [ 61%]
ibis/backends/tests/test_array.py::test_array_discovery_desired[postgres] XFAIL (backend does not support nullable nested types)      [ 66%]
ibis/backends/tests/test_array.py::test_array_column[postgres] PASSED                                                                 [ 72%]
ibis/backends/tests/test_array.py::test_np_array_literal[postgres] PASSED                                                             [ 77%]
ibis/backends/tests/test_array.py::test_array_discovery_snowflake[postgres] XFAIL (backend does not implement arrays like snowflake)  [ 83%]
ibis/backends/tests/test_array.py::test_unnest_complex[postgres] PASSED                                                               [ 88%]
ibis/backends/tests/test_array.py::test_array_length[postgres] PASSED                                                                 [ 94%]
ibis/backends/tests/test_array.py::test_array_discovery_postgres_duckdb[postgres] PASSED                                              [100%]
```
Best regards,
Kamil