### PR TITLE
fix: always display at least one column in the table repr

### DIFF
--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -193,21 +193,23 @@ def to_rich_table(table, console_width=None):
     if console_width is None:
         console_width = float("inf")
 
+    orig_ncols = len(table.columns)
+
     # First determine the maximum subset of columns that *might* fit in the
     # current console. Note that not every column here may actually fit later
     # on once we know the repr'd width of the data.
-    columns_truncated = False
     if console_width:
         computed_cols = []
         remaining = console_width - 1  # 1 char for left boundary
         for c in table.columns:
             needed = len(c) + 3  # padding + 1 char for right boundary
-            if needed < remaining:
+            if (
+                needed < remaining or not computed_cols
+            ):  # always select at least one col
                 computed_cols.append(c)
                 remaining -= needed
             else:
                 table = table.select(*computed_cols)
-                columns_truncated = True
                 break
 
     # Compute the data and return a pandas dataframe
@@ -230,6 +232,7 @@ def to_rich_table(table, console_width=None):
         ):
             # Don't truncate non-nested dtypes
             min_width = max(min_width, len(dtype_str))
+
         min_width = max(min_width, len(name))
         if max_width is not None:
             max_width = max(min_width, max_width)
@@ -239,19 +242,30 @@ def to_rich_table(table, console_width=None):
             col_data.append(formatted)
             formatted_dtypes.append(dtype_str)
             remaining -= needed
+        elif not col_info:
+            # Always pretty print at least one column. If only one column, we
+            # truncate to fill the available space, leaving room for the
+            # ellipsis & framing.
+            min_width = remaining - 3  # 3 for framing
+            if orig_ncols > 1:
+                min_width -= 4  # 4 for ellipsis
+            col_info.append((name, dtype, min_width, min_width))
+            col_data.append(formatted)
+            formatted_dtypes.append(dtype_str)
+            break
         else:
             if remaining < 4:
                 # Not enough space for ellipsis column, drop previous column
                 col_info.pop()
                 col_data.pop()
                 formatted_dtypes.pop()
-            columns_truncated = True
             break
 
     # rich's column width computations are super buggy and can result in tables
     # that are much wider than the available console space. To work around this
     # for now we manually compute all column widths rather than letting rich
     # figure it out for us.
+    columns_truncated = orig_ncols > len(col_info)
     col_widths = {}
     flex_cols = []
     remaining = console_width - 1


### PR DESCRIPTION
Previously the pretty printer would never truncate column names. This meant that if a column had a name that exceeded the width of the terminal, the repr would call `table.select([])` then try to repr that (leading to weirdness sometimes).

This PR amends the rules to be:

- Always display at least one column
- If more than one column is displayed, the column names will never be truncated
- If only a single column is displayed, that column name may be truncated to fill the available space

We currently have no tests for the complete repr. In lieu of figuring out a good way to test this, I have manually confirmed this fixes the issue:

```python
In [1]: import ibis                            
   ...: import pandas as pd                                                                   
   ...:                                        
   ...: ibis.options.interactive = True                                                       
   ...: con = ibis.duckdb.connect()                                                           
   ...: df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [1, 2, 3, 4, 5]})                                                                                                                      
   ...: t = con.register(df)                                                                  
   ...: t2 = (t.x + 1).name("a-very-long-name-" * 100)                                                                                                                                       


In [2]:                                        

In [2]: t2                                     
Out[2]:                                        
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                                                                                            
┃ a-very-long-name-a-very-long-name-a-very-long-name-a-very-long-name-a-very-long-name-a-very-… ┃                                                                                            
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩                                                                                            
│ int64                                                                                         │                                                                                            
├───────────────────────────────────────────────────────────────────────────────────────────────┤                                                                                            
│                                                                                             2 │                                                                                            
│                                                                                             3 │                                                                                            
│                                                                                             4 │                                                                                            
│                                                                                             5 │                                                                                            
│                                                                                             6 │                                                                                            
└───────────────────────────────────────────────────────────────────────────────────────────────┘                                                                                            


In [3]: t2.as_table().mutate(x=t2 + 2)  # Instead of a column, repr a table                                                                                                                  
Out[3]:                                        
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━┓                                                                                            
┃ a-very-long-name-a-very-long-name-a-very-long-name-a-very-long-name-a-very-long-name-a-v… ┃ … ┃                                                                                            
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━┩                                                                                            
│ int64                                                                                     │ … │                                                                                            
├───────────────────────────────────────────────────────────────────────────────────────────┼───┤                                                                                            
│                                                                                         2 │ … │                                                                                            
│                                                                                         3 │ … │                                                                                            
│                                                                                         4 │ … │                                                                                            
│                                                                                         5 │ … │                                                                                            
│                                                                                         6 │ … │                                                                                            
└───────────────────────────────────────────────────────────────────────────────────────────┴───┘
```

Fixes #5044.