### PR TITLE
fix: support `arbitrary` with no arguments

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -233,7 +233,7 @@ def _arbitrary(translator, op):
     if where is not None:
         arg = ops.Where(where, arg, ibis.NA)
 
-    if how not in (None, "first"):
+    if how != "first":
         raise com.UnsupportedOperationError(
             f"{how!r} value not supported for arbitrary in BigQuery"
         )

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -233,7 +233,6 @@ def _xor(op, **kw):
 @translate_val.register(ops.Arbitrary)
 def _arbitrary(op, **kw):
     functions = {
-        None: "any",
         "first": "any",
         "last": "anyLast",
         "heavy": "anyHeavy",

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -368,6 +368,24 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             marks=pytest.mark.notimpl(['polars', "datafusion"]),
         ),
         param(
+            lambda t, where: t.double_col.arbitrary(where=where),
+            lambda t, where: t.double_col[where].iloc[0],
+            id='arbitrary_default',
+            marks=pytest.mark.notimpl(
+                [
+                    'impala',
+                    'postgres',
+                    'mysql',
+                    'sqlite',
+                    'snowflake',
+                    'polars',
+                    'datafusion',
+                    "mssql",
+                    "trino",
+                ]
+            ),
+        ),
+        param(
             lambda t, where: t.double_col.arbitrary(how='first', where=where),
             lambda t, where: t.double_col[where].iloc[0],
             id='arbitrary_first',

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -34,7 +34,7 @@ class CountStar(Filterable, Reduction):
 @public
 class Arbitrary(Filterable, Reduction):
     arg = rlz.column(rlz.any)
-    how = rlz.optional(rlz.isin({'first', 'last', 'heavy'}))
+    how = rlz.isin({'first', 'last', 'heavy'})
     output_dtype = rlz.dtype_like('arg')
 
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -704,7 +704,7 @@ class Column(Value, JupyterMixin):
     def arbitrary(
         self,
         where: ir.BooleanValue | None = None,
-        how: Literal["first", "last", "heavy"] | None = None,
+        how: Literal["first", "last", "heavy"] = "first",
     ) -> Scalar:
         """Select an arbitrary value in a column.
 

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -492,7 +492,7 @@ def test_negate_boolean_column(table, op):
 
 
 @pytest.mark.parametrize('column', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'])
-@pytest.mark.parametrize('how', [None, 'first', 'last', 'heavy'])
+@pytest.mark.parametrize('how', ['first', 'last', 'heavy'])
 @pytest.mark.parametrize('condition_fn', [lambda t: None, lambda t: t.a > 8])
 def test_arbitrary(table, column, how, condition_fn):
     col = table[column]


### PR DESCRIPTION
Previously the default value for `how` was `None`, which was appears to have been intended to mean `"first"`. The test suite always specified `how` explicitly though, which meant most backends failed to supported the default `how=None`. This PR changes the default to `"first"`, and updates the test suite to include a no-args version of `arbitrary`.