### PR TITLE
test: relax the assertion on `list_tables` content vs accessor

### DIFF
--- a/ibis/backends/dask/tests/conftest.py
+++ b/ibis/backends/dask/tests/conftest.py
@@ -46,6 +46,10 @@ class TestConf(PandasTest):
                     pd.read_csv(str(data_directory / 'awards_players.csv')),
                     npartitions=NPARTITIONS,
                 ),
+                'diamonds': dd.from_pandas(
+                    pd.read_csv(str(data_directory / 'diamonds.csv')),
+                    npartitions=NPARTITIONS,
+                ),
                 'json_t': pd.DataFrame(
                     {
                         "js": [

--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -52,6 +52,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
         client.register(
             data_directory / 'awards_players.csv', table_name='awards_players'
         )
+        client.register(data_directory / 'diamonds.csv', table_name='diamonds')
         return client
 
     @property

--- a/ibis/backends/pandas/tests/conftest.py
+++ b/ibis/backends/pandas/tests/conftest.py
@@ -31,6 +31,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                 'awards_players': pd.read_csv(
                     str(data_directory / 'awards_players.csv')
                 ),
+                'diamonds': pd.read_csv(str(data_directory / 'diamonds.csv')),
                 'struct': struct_types,
                 'json_t': json_types,
                 'array_types': array_types,

--- a/ibis/backends/polars/tests/conftest.py
+++ b/ibis/backends/polars/tests/conftest.py
@@ -43,6 +43,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
         client.register(
             data_directory / 'awards_players.csv', table_name='awards_players'
         )
+        client.register(data_directory / 'diamonds.csv', table_name='diamonds')
         client.register(array_types, table_name='array_types')
         client.register(struct_types, table_name='struct')
 

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -2,6 +2,7 @@ import pytest
 from pytest import param
 
 import ibis.expr.types as ir
+from ibis.backends.conftest import TEST_TABLES
 
 
 def test_backend_name(backend):
@@ -49,11 +50,10 @@ def test_tables_accessor_mapping(con):
     with pytest.raises(KeyError, match="doesnt_exist"):
         con.tables["doesnt_exist"]
 
-    tables = con.list_tables()
-    con_tables = list(con.tables)
-
-    assert len(con_tables) == len(tables)
-    assert sorted(con_tables) == sorted(tables)
+    # temporary might pop into existence in parallel test runs, in between the
+    # first `list_tables` call and the second, so we check a subset relationship
+    assert TEST_TABLES.keys() <= set(con.list_tables())
+    assert TEST_TABLES.keys() <= set(con.tables)
 
 
 def test_tables_accessor_getattr(con):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,7 @@ filterwarnings = [
   "ignore: PY_SSIZE_T_CLEAN will be required for '#' formats:DeprecationWarning",
   # spark
   "ignore:In Python .*, it is preferred .* type hints .* UDF:UserWarning",
+  "ignore:`np.object` is a deprecated alias for the builtin `object`:DeprecationWarning",
   # windows
   "ignore:getargs.* The 'u' format is deprecated:DeprecationWarning",
   # findspec


### PR DESCRIPTION
Occasionally a CI job fails because of a temporary table popping into existence in between one call to `con.list_tables()` and a second call to `con.list_tables()`, making the assertion that the list of tables in the second is equal to the first fail.

This test fails often enough that it annoys me, so I am relaxing the check.
