### PR TITLE
[WIP] feat: improve error message when Table methods shadow column names

### DIFF
--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -17,6 +17,7 @@ from ibis.common.validators import str_  # noqa: F401
 from ibis.common.validators import tuple_of  # noqa: F401
 from ibis.common.validators import instance_of, map_to, one_of, validator
 from ibis.expr.deferred import Deferred
+from ibis.expr.table_method import bound_table_method
 
 
 # TODO(kszucs): consider to rename to datashape
@@ -148,6 +149,9 @@ def literal(dtype, value, **kwargs):
 
     if isinstance(value, ops.Literal):
         return value
+
+    if isinstance(value, bound_table_method):
+        raise TypeError(value._errmsg())
 
     try:
         inferred_dtype = dt.infer(value)

--- a/ibis/expr/table_method.py
+++ b/ibis/expr/table_method.py
@@ -1,0 +1,75 @@
+import functools
+import inspect
+
+
+class bound_table_method:
+    """A bound method on a table."""
+
+    __slots__ = ("_func", "_obj")
+
+    def __init__(self, func, obj):
+        self._func = func
+        self._obj = obj
+
+    @property
+    def __doc__(self):
+        return self._func.__doc__
+
+    @property
+    def __name__(self):
+        return self._func.__name__
+
+    @property
+    def __signature__(self):
+        sig = inspect.signature(self._func)
+        return sig.replace(parameters=list(sig.parameters.values())[1:])
+
+    def __call__(self, *args, **kwargs):
+        return self._func(self._obj, *args, **kwargs)
+
+    def _errmsg(self, prefix="Got method `Table.{name}`.", **kwargs):
+        return (
+            prefix
+            + (
+                " If you meant to access a column named {name!r} use "
+                "`table[{name!r}]` syntax instead."
+            )
+        ).format(name=self._func.__name__, **kwargs)
+
+    def __getattr__(self, key):
+        try:
+            return getattr(self._func, key)
+        except AttributeError:
+            pass
+        raise AttributeError(
+            self._errmsg("Method `Table.{name}` has no attribute {key!r}.", key=key)
+        )
+
+    def _compare(self, other, sym):
+        raise TypeError(
+            self._errmsg("{sym!r} not supported for method `Table.{name}`.", sym=sym)
+        )
+
+    __eq__ = functools.partialmethod(_compare, sym="=")
+    __ne__ = functools.partialmethod(_compare, sym="!=")
+    __lt__ = functools.partialmethod(_compare, sym="<")
+    __le__ = functools.partialmethod(_compare, sym="<=")
+    __gt__ = functools.partialmethod(_compare, sym=">")
+    __ge__ = functools.partialmethod(_compare, sym=">=")
+
+
+class table_method:
+    """A method on an `ibis.expr.types.Table`.
+
+    This decorator adds extra features for erroring nicely if a Table
+    method is used somewhere a column is expected.
+    """
+
+    def __init__(self, func):
+        self._func = func
+
+    def __getattr__(self, key):
+        return getattr(self._func, key)
+
+    def __get__(self, obj, objtype=None):
+        return bound_table_method(self._func, obj)

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -25,6 +25,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis import util
 from ibis.expr.deferred import Deferred
+from ibis.expr.table_method import bound_table_method, table_method
 from ibis.expr.types.core import Expr
 
 if TYPE_CHECKING:
@@ -206,6 +207,8 @@ class Table(Expr, JupyterMixin):
         elif isinstance(expr, Deferred):
             # resolve deferred expressions
             return expr.resolve(self)
+        elif isinstance(expr, bound_table_method):
+            raise TypeError(expr._errmsg())
         elif callable(expr):
             return expr(self)
         else:
@@ -797,6 +800,7 @@ class Table(Expr, JupyterMixin):
         ]
         return an.apply_filter(self.op(), predicates).to_expr()
 
+    @table_method
     def count(self, where: ir.BooleanValue | None = None) -> ir.IntegerScalar:
         """Compute the number of rows in the table.
 


### PR DESCRIPTION
This adds a method decorator to be used on `Table` methods. The intent is to provide nicer error messages when the user tries to use attribute-access to get a column, but a method on the table shadows the column. Previously you'd get a cryptic error, we now try to provide a nicer error message.

For now this is only applied to `Table.count`, but could be used elsewhere. Just putting this up for discussion for now.

```python
In [1]: import ibis                                                                           
                                                                                              
In [2]: from ibis import _                                                                    
                                                                                              
In [3]: t = ibis.table({"x": "int", "count": "int"})                                          
                                                                                              
In [4]: t.filter(_.count > 10)
---------------------------------------------------------------------------                                                                                                                  
TypeError                                 Traceback (most recent call last)                                                                                                                  
Input In [4], in <cell line: 1>()                                                                                                                                                            
----> 1 t.filter(_.count > 10)                                                                                                                                                               
...
TypeError: '>' not supported for method `Table.count`. If you meant to access a column named 'count' use `table['count']` syntax instead.
```

Fixes #5062.