### PR TITLE
feat(sqlalchemy): in-memory tables have name in generated SQL

### DIFF
--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -113,7 +113,7 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
                 # this has horrendous performance for medium to large tables
                 # should we warn?
                 rows = list(ref_op.data.to_frame().itertuples(index=False))
-                result = sa.values(*columns).data(rows)
+                result = sa.values(*columns, name=ref_op.name).data(rows)
         else:
             # A subquery
             if ctx.is_extracted(ref_op):


### PR DESCRIPTION
Hello,

This doesn't change the behavior, but it does make the SQL a bit more readable because the column names are explicitly specified in the VALUES clause.
```python
import sqlalchemy as sa

value_expr_before = sa.values(
    sa.column('id', sa.Integer),
    sa.column('name', sa.String),
    name=None
).data(
    [(1, 'name1'), (2, 'name2'), (3, 'name3')]
)
value_expr_after = sa.values(
    sa.column('id', sa.Integer),
    sa.column('name', sa.String),
    name='my_values'
).data(
    [(1, 'name1'), (2, 'name2'), (3, 'name3')]
)

print("Before:")
print(str(sa.select(value_expr_before)))
print("After:")
print(str(sa.select(value_expr_after)))
```
Output:
```
Before:
SELECT id, name 
FROM (VALUES (:param_1, :param_2), (:param_3, :param_4), (:param_5, :param_6))
After:
SELECT my_values.id, my_values.name 
FROM (VALUES (:param_1, :param_2), (:param_3, :param_4), (:param_5, :param_6)) AS my_values (id, name)
```
Best regards