### PR TITLE
ci: disable hypothesis too-slow healthcheck

### DIFF
--- a/ibis/tests/conftest.py
+++ b/ibis/tests/conftest.py
@@ -3,9 +3,18 @@ import os
 import hypothesis as h
 
 # setup hypothesis profiles
-h.settings.register_profile('ci', max_examples=1000)
-h.settings.register_profile('dev', max_examples=50)
-h.settings.register_profile('debug', max_examples=10, verbosity=h.Verbosity.verbose)
+h.settings.register_profile(
+    'ci', max_examples=1000, suppress_health_check=[h.HealthCheck.too_slow]
+)
+h.settings.register_profile(
+    'dev', max_examples=50, suppress_health_check=[h.HealthCheck.too_slow]
+)
+h.settings.register_profile(
+    'debug',
+    max_examples=10,
+    verbosity=h.Verbosity.verbose,
+    suppress_health_check=[h.HealthCheck.too_slow],
+)
 
 # load default hypothesis profile, either set HYPOTHESIS_PROFILE environment
 # variable or pass --hypothesis-profile option to pytest, to see the generated


### PR DESCRIPTION
This seems to make tests flaky in some cases, in particular the macos
nix builds. We only test macos on nix, so that's likely why we don't see
it in the non-nix builds.
