### PR TITLE
fix: don't fuse filters & selections that contain window functions

### DIFF
--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -284,6 +284,7 @@ operation_registry.update(
         ops.TimestampFromYMDHMS: _timestamp_from_ymdhms,
         ops.DateTruncate: _truncate(sa.func.date),
         ops.Date: unary(sa.func.date),
+        ops.Time: unary(sa.func.time),
         ops.TimestampTruncate: _truncate(sa.func.datetime),
         ops.Strftime: _strftime,
         ops.ExtractYear: _strftime_int('%Y'),


### PR DESCRIPTION
Since window functions act on multiple rows, fusing a `filter` operation with a prior selection that contained a window function can result in incorrect results.

This came up when doing today's [Hanukkah of Data](https://hanukkah.bluebird.sh/5783/) puzzle.