### PR TITLE
fix: fix bug when disabling `show_types` in interactive repr

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -804,6 +804,22 @@ def test_repr(alltypes, interactive):
         ibis.options.interactive = old
 
 
+@pytest.mark.parametrize("show_types", [True, False])
+def test_interactive_repr_show_types(alltypes, show_types):
+    expr = alltypes.select("id")
+    old = ibis.options.interactive
+    ibis.options.interactive = True
+    ibis.options.repr.interactive.show_types = show_types
+    try:
+        s = repr(expr)
+        if show_types:
+            assert "int" in s
+        else:
+            assert "int" not in s
+    finally:
+        ibis.options.interactive = old
+
+
 @pytest.mark.parametrize("expr_type", ["table", "column"])
 @pytest.mark.parametrize("interactive", [True, False])
 def test_repr_mimebundle(alltypes, interactive, expr_type):

--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -320,7 +320,7 @@ def to_rich_table(table, console_width=None):
     else:
         add_row = rich_table.add_row
 
-    if formatted_dtypes:
+    if ibis.options.repr.interactive.show_types:
         add_row(
             *(Align(s, align="left") for s in formatted_dtypes),
             end_section=True,


### PR DESCRIPTION
Previously this option was accidentally ignored. This fixes the bug and adds a test.