### PR TITLE
fix(mssql): use double-dollar sign to prevent from interpolating a value

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -35,8 +35,6 @@ jobs:
   test_backends:
     name: ${{ matrix.backend.title }} ${{ matrix.os }} python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    env:
-      MSSQL_SA_PASSWORD: "1bis_Testing!"
     strategy:
       fail-fast: false
       matrix:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       retries: 3
       test:
         - CMD-SHELL
-        - /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$MSSQL_SA_PASSWORD" -Q "SELECT 1 AS one"
+        - /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -Q "SELECT 1 AS one"
       timeout: 10s
     build:
       context: .


### PR DESCRIPTION
Hello,

We have a password set as an environment variable in the container, so we need to use a double-dollar sign. Otherwise, the password is read from the host.

Best regards,
Kamil Breguła
