### PR TITLE
feat(trino): add array slicing support

### DIFF
--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -985,30 +985,6 @@ def test_array_collect(array_types):
     tm.assert_frame_equal(result, expected, check_column_type=False)
 
 
-@pytest.mark.parametrize(
-    ['start', 'stop'],
-    [
-        (1, 3),
-        (1, 1),
-        (2, 3),
-        (2, 5),
-        (None, 3),
-        (None, None),
-        (3, None),
-        (-3, None),
-        (None, -3),
-        (-3, -1),
-    ],
-)
-def test_array_slice(array_types, start, stop):
-    expr = array_types[array_types.y[start:stop].name('sliced')]
-    result = expr.execute()
-    expected = pd.DataFrame(
-        {'sliced': array_types.y.execute().map(lambda x: x[start:stop])}
-    )
-    tm.assert_frame_equal(result, expected)
-
-
 @pytest.mark.parametrize('index', [0, 1, 3, 4, 11, -1, -3, -4, -11])
 def test_array_index(array_types, index):
     expr = array_types[array_types.y[index].name('indexed')]

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -161,6 +161,31 @@ def _struct_column(t, op):
     )
 
 
+def _neg_idx_to_pos(array, idx):
+    if_ = getattr(sa.func, "if")
+    arg_length = sa.func.cardinality(array)
+    return if_(idx < 0, arg_length + sa.func.greatest(idx, -arg_length), idx)
+
+
+def _array_slice(t, op):
+    arg = t.translate(op.arg)
+
+    arg_length = sa.func.cardinality(arg)
+
+    if (start := op.start) is None:
+        start = 0
+    else:
+        start = sa.func.least(arg_length, _neg_idx_to_pos(arg, t.translate(start)))
+
+    if (stop := op.stop) is None:
+        stop = arg_length
+    else:
+        stop = _neg_idx_to_pos(arg, t.translate(stop))
+
+    length = stop - start
+    return sa.func.slice(arg, start + 1, length, type_=arg.type)
+
+
 operation_registry.update(
     {
         # conditional expressions
@@ -193,6 +218,10 @@ operation_registry.update(
         ops.ArrayLength: unary(sa.func.cardinality),
         ops.ArrayIndex: _array_index,
         ops.ArrayColumn: _array_column,
+        ops.ArrayRepeat: fixed_arity(
+            lambda arg, times: sa.func.flatten(sa.func.repeat(arg, times)), 2
+        ),
+        ops.ArraySlice: _array_slice,
         ops.JSONGetItem: _json_get_item,
         ops.ExtractDayOfYear: unary(sa.func.day_of_year),
         ops.ExtractWeekOfYear: unary(sa.func.week_of_year),
@@ -208,9 +237,6 @@ operation_registry.update(
         ),
         ops.DateTruncate: _timestamp_truncate,
         ops.TimestampTruncate: _timestamp_truncate,
-        ops.ArrayRepeat: fixed_arity(
-            lambda arg, times: sa.func.flatten(sa.func.repeat(arg, times)), 2
-        ),
         ops.DateFromYMD: _date_from_ymd,
         ops.TimeFromHMS: _time_from_hms,
         ops.TimestampFromYMDHMS: _timestamp_from_ymdhms,


### PR DESCRIPTION
This PR adds support for array slicing to the Trino backend, and fixes a bug in negative slicing in the postgres and duckdb backends.