### PR TITLE
feat/fix(mssql): fix and implement some operations

### DIFF
--- a/ibis/backends/mssql/registry.py
+++ b/ibis/backends/mssql/registry.py
@@ -165,7 +165,7 @@ operation_registry.update(
             6,
         ),
         ops.TimeFromHMS: fixed_arity(
-            lambda h, m, s: sa.func.timefromparts(h, m, s, 0), 3
+            lambda h, m, s: sa.func.timefromparts(h, m, s, 0, 0), 3
         ),
     }
 )

--- a/ibis/backends/mssql/registry.py
+++ b/ibis/backends/mssql/registry.py
@@ -83,8 +83,12 @@ def _round(t, op):
         return sa.func.round(sa_arg, 0)
 
 
-def _timestamp_from_unix(x):
-    return sa.func.dateadd(sa.text('s'), x, '1970-01-01 00:00:00')
+def _timestamp_from_unix(x, unit='s'):
+    if unit == 's':
+        return sa.func.dateadd(sa.text('s'), x, '1970-01-01 00:00:00')
+    if unit == 'ms':
+        return sa.func.dateadd(sa.text('s'), x / 1_000, '1970-01-01 00:00:00')
+    raise ValueError(f"{unit!r} unit is not supported!")
 
 
 operation_registry = sqlalchemy_operation_registry.copy()
@@ -152,7 +156,9 @@ operation_registry.update(
             ),
             1,
         ),
-        ops.TimestampFromUNIX: fixed_arity(_timestamp_from_unix, 1),
+        ops.TimestampFromUNIX: lambda t, op: _timestamp_from_unix(
+            t.translate(op.arg), op.unit
+        ),
         ops.DateFromYMD: fixed_arity(sa.func.datefromparts, 3),
         ops.TimestampFromYMDHMS: fixed_arity(
             lambda y, m, d, h, min, s: sa.func.datetimefromparts(y, m, d, h, min, s, 0),

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -177,13 +177,14 @@ PANDAS_UNITS = {
                     "snowflake",
                     "polars",
                     "trino",
+                    "mssql",
                 ]
             ),
         ),
     ],
 )
 @pytest.mark.broken(["polars"], reason="snaps to the UNIX epoch")
-@pytest.mark.notimpl(["datafusion", "mssql"])
+@pytest.mark.notimpl(["datafusion"])
 def test_timestamp_truncate(backend, alltypes, df, unit):
     expr = alltypes.timestamp_col.truncate(unit).name('tmp')
 
@@ -215,7 +216,7 @@ def test_timestamp_truncate(backend, alltypes, df, unit):
     ],
 )
 @pytest.mark.broken(["polars"], reason="snaps to the UNIX epoch")
-@pytest.mark.notimpl(["datafusion", "mssql"])
+@pytest.mark.notimpl(["datafusion"])
 def test_date_truncate(backend, alltypes, df, unit):
     expr = alltypes.timestamp_col.date().truncate(unit).name('tmp')
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -767,7 +767,6 @@ def test_timestamp_literal(con):
         "dask",
         "pyspark",
         "polars",
-        "mssql",
     ]
 )
 @pytest.mark.notyet(["clickhouse", "impala"])

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -552,7 +552,7 @@ def test_strftime(backend, alltypes, df, expr_fn, pandas_pattern):
     backend.assert_series_equal(result, expected)
 
 
-unit_factors = {'s': int(1e9), 'ms': int(1e6), 'us': int(1e3), 'ns': 1}
+unit_factors = {'s': 10**9, 'ms': 10**6, 'us': 10**3, 'ns': 1}
 
 
 @pytest.mark.parametrize(
@@ -565,17 +565,15 @@ unit_factors = {'s': int(1e9), 'ms': int(1e6), 'us': int(1e3), 'ns': 1}
         ),
         param(
             'us',
-            marks=pytest.mark.notimpl(["clickhouse", "duckdb", "pyspark"]),
+            marks=pytest.mark.notimpl(["clickhouse", "duckdb", "pyspark", "mssql"]),
         ),
         param(
             'ns',
-            marks=pytest.mark.notimpl(["clickhouse", "duckdb", "pyspark"]),
+            marks=pytest.mark.notimpl(["clickhouse", "duckdb", "pyspark", "mssql"]),
         ),
     ],
 )
-@pytest.mark.notimpl(
-    ["datafusion", "mysql", "postgres", "sqlite", "snowflake", "mssql"]
-)
+@pytest.mark.notimpl(["datafusion", "mysql", "postgres", "sqlite", "snowflake"])
 def test_integer_to_timestamp(backend, con, unit):
     backend_unit = backend.returned_timestamp_unit
     factor = unit_factors[unit]


### PR DESCRIPTION
Hello,

In PR: https://github.com/ibis-project/ibis/pull/5089/files I implemented `ops.TimeFromHMS` and  `ops.TimestampFromUNIX:` but when I looked at it again in the morning I saw that it wasn't working.

I also added `ops.TimestampTruncate` and `ops.DateTruncate`.

Now I want to add dot_sql support. For now I found that the metadata about the query can be fetched like below:
```python
result = bind.execute(
    f"DECLARE @query nvarchar(max) = 'SELECT 1 as tmp'; "
    f"EXEC sp_describe_first_result_set @query, null, 0; "
)
```
Best regards,