### PR TITLE
refactor: clean up timezone support in ops.TimestampFromYMDHMS

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -573,7 +573,7 @@ sqlalchemy_operation_registry: Dict[Any, Any] = {
     ops.DateFromYMD: fixed_arity(sa.func.date, 3),
     ops.TimeFromHMS: fixed_arity(sa.func.time, 3),
     ops.TimestampFromYMDHMS: lambda t, op: sa.func.make_timestamp(
-        *map(t.translate, op.args[:6])  # ignore timezone
+        *map(t.translate, op.args)
     ),
     ops.Degrees: unary(sa.func.degrees),
     ops.Radians: unary(sa.func.radians),

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -250,11 +250,8 @@ def _date_from_ymd(t, op):
 
 
 def _timestamp_from_ymdhms(t, op):
-    y, mo, d, h, m, s, *rest = (
-        t.translate(x) if x is not None else None for x in op.args
-    )
-    tz = rest[0] if rest else ''
-    timestr = sa.func.printf('%04d-%02d-%02d %02d:%02d:%02d%s', y, mo, d, h, m, s, tz)
+    y, mo, d, h, m, s = (t.translate(x) for x in op.args)
+    timestr = sa.func.printf('%04d-%02d-%02d %02d:%02d:%02d%s', y, mo, d, h, m, s)
     return sa.func.datetime(timestr)
 
 

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -140,7 +140,7 @@ def _time_from_hms(t, op):
 
 
 def _timestamp_from_ymdhms(t, op):
-    y, mo, d, h, m, s = (t.translate(x) if x is not None else None for x in op.args)
+    y, mo, d, h, m, s = (t.translate(x) for x in op.args)
     timestr = sa.func.format('%04d-%02d-%02dT%02d:%02d:%02d', y, mo, d, h, m, s)
     return sa.func.from_iso8601_timestamp(timestr)
 


### PR DESCRIPTION
ops.TimestampFromYMDHMS doesn't have timezone field, so these checks are redundant.
https://github.com/ibis-project/ibis/blob/26ca1e4f3160de594c8bb3047a3588e607385ad1/ibis/expr/operations/temporal.py#L239-L249 