### PR TITLE
fix(pandas): use the correct aggregation context for window functions

### DIFF
--- a/ci/schema/clickhouse.sql
+++ b/ci/schema/clickhouse.sql
@@ -111,3 +111,11 @@ CREATE OR REPLACE TABLE map (kv Map(String, Nullable(Int64))) ENGINE = Memory;
 INSERT INTO map VALUES
     (map('a', 1, 'b', 2, 'c', 3)),
     (map('d', 4, 'e', 5, 'c', 6));
+
+CREATE OR REPLACE TABLE win (g String, x Int64, y Int64) ENGINE = Memory;
+INSERT INTO win VALUES
+    ('a', 0, 3),
+    ('a', 1, 2),
+    ('a', 2, 0),
+    ('a', 3, 1),
+    ('a', 4, 1);

--- a/ci/schema/duckdb.sql
+++ b/ci/schema/duckdb.sql
@@ -103,3 +103,11 @@ INSERT INTO json_t VALUES
     ('null'),
     ('[42,47,55]'),
     ('[]');
+
+CREATE OR REPLACE TABLE win (g TEXT, x BIGINT, y BIGINT);
+INSERT INTO win VALUES
+    ('a', 0, 3),
+    ('a', 1, 2),
+    ('a', 2, 0),
+    ('a', 3, 1),
+    ('a', 4, 1);

--- a/ci/schema/mssql.sql
+++ b/ci/schema/mssql.sql
@@ -72,3 +72,13 @@ CREATE TABLE functional_alltypes (
 );
 
 CREATE INDEX "ix_functional_alltypes_index" ON functional_alltypes ("index");
+
+DROP TABLE IF EXISTS win;
+
+CREATE TABLE win (g VARCHAR(MAX), x BIGINT, y BIGINT);
+INSERT INTO win VALUES
+    ('a', 0, 3),
+    ('a', 1, 2),
+    ('a', 2, 0),
+    ('a', 3, 1),
+    ('a', 4, 1);

--- a/ci/schema/mysql.sql
+++ b/ci/schema/mysql.sql
@@ -84,3 +84,13 @@ INSERT INTO json_t VALUES
     ('null'),
     ('[42,47,55]'),
     ('[]');
+
+DROP TABLE IF EXISTS win CASCADE;
+
+CREATE TABLE win (g TEXT, x BIGINT, y BIGINT);
+INSERT INTO win VALUES
+    ('a', 0, 3),
+    ('a', 1, 2),
+    ('a', 2, 0),
+    ('a', 3, 1),
+    ('a', 4, 1);

--- a/ci/schema/postgresql.sql
+++ b/ci/schema/postgresql.sql
@@ -195,3 +195,12 @@ INSERT INTO json_t VALUES
     ('null'),
     ('[42,47,55]'),
     ('[]');
+
+DROP TABLE IF EXISTS win CASCADE;
+CREATE TABLE win (g TEXT, x BIGINT, y BIGINT);
+INSERT INTO win VALUES
+    ('a', 0, 3),
+    ('a', 1, 2),
+    ('a', 2, 0),
+    ('a', 3, 1),
+    ('a', 4, 1);

--- a/ci/schema/snowflake.sql
+++ b/ci/schema/snowflake.sql
@@ -100,3 +100,11 @@ INSERT INTO json_t ("js")
     SELECT parse_json('null') UNION
     SELECT parse_json('[42,47,55]') UNION
     SELECT parse_json('[]');
+
+CREATE OR REPLACE TABLE win (g TEXT, x BIGINT, y BIGINT);
+INSERT INTO win VALUES
+    ('a', 0, 3),
+    ('a', 1, 2),
+    ('a', 2, 0),
+    ('a', 3, 1),
+    ('a', 4, 1);

--- a/ci/schema/sqlite.sql
+++ b/ci/schema/sqlite.sql
@@ -76,7 +76,7 @@ CREATE TABLE diamonds (
 
 DROP TABLE IF EXISTS json_t;
 
-CREATE TABLE IF NOT EXISTS json_t (js JSON);
+CREATE TABLE json_t (js JSON);
 
 INSERT INTO json_t VALUES
     ('{"a": [1,2,3,4], "b": 1}'),
@@ -85,3 +85,12 @@ INSERT INTO json_t VALUES
     ('null'),
     ('[42,47,55]'),
     ('[]');
+
+DROP TABLE IF EXISTS win;
+CREATE TABLE win (g TEXT, x BIGINT, y BIGINT);
+INSERT INTO win VALUES
+    ('a', 0, 3),
+    ('a', 1, 2),
+    ('a', 2, 0),
+    ('a', 3, 1),
+    ('a', 4, 1);

--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -129,7 +129,7 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
         client.create_table(date_table, exists_ok=True)
 
         write_disposition = bq.WriteDisposition.WRITE_TRUNCATE
-        make_job = lambda func, *a, **kw: func(*a, **kw).result()  # noqa: E731
+        make_job = lambda func, *a, **kw: func(*a, **kw).result()
 
         futures = []
         with concurrent.futures.ThreadPoolExecutor() as e:

--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -16,7 +16,7 @@ from ibis.backends.bigquery import EXTERNAL_DATA_SCOPES, Backend
 from ibis.backends.bigquery.datatypes import ibis_type_to_bigquery_type
 from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero, UnorderedComparator
-from ibis.backends.tests.data import non_null_array_types, struct_types
+from ibis.backends.tests.data import non_null_array_types, struct_types, win
 
 DATASET_ID = "ibis_gbq_testing"
 DEFAULT_PROJECT_ID = "ibis-gbq"
@@ -168,6 +168,7 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
                     ),
                 )
             )
+
             futures.append(
                 e.submit(
                     make_job,
@@ -219,6 +220,21 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
                             dict(string_col="string", numeric_col="decimal(38, 9)")
                         ),
                         source_format=bq.SourceFormat.NEWLINE_DELIMITED_JSON,
+                    ),
+                )
+            )
+
+            futures.append(
+                e.submit(
+                    make_job,
+                    client.load_table_from_dataframe,
+                    win,
+                    bq.TableReference(testing_dataset, "win"),
+                    job_config=bq.LoadJobConfig(
+                        write_disposition=write_disposition,
+                        schema=ibis_schema_to_bq_schema(
+                            dict(g="string", x="int64", y="int64")
+                        ),
                     ),
                 )
             )

--- a/ibis/backends/bigquery/tests/unit/udf/test_core.py
+++ b/ibis/backends/bigquery/tests/unit/udf/test_core.py
@@ -187,7 +187,7 @@ def test_lambda_with_splat(snapshot):
                 total += value
             return total
 
-        splat_sum = lambda *args: sum(args)  # noqa: E731
+        splat_sum = lambda *args: sum(args)
         return splat_sum(1, 2, 3)
 
     js = compile(f)

--- a/ibis/backends/bigquery/udf/core.py
+++ b/ibis/backends/bigquery/udf/core.py
@@ -569,8 +569,8 @@ if __name__ == "__main__":
 
         i = 0
         foo = 2
-        bar = lambda x: x  # noqa: E731
-        bazel = lambda x: y  # noqa: E731
+        bar = lambda x: x
+        bazel = lambda x: y
         while i < n:
             foo = bar(bazel(10))
             i += 1

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -304,7 +304,7 @@ def test_timestamp_scalar_in_filter(alltypes):
 def test_named_from_filter_groupby(snapshot):
     t = ibis.table([('key', 'string'), ('value', 'double')], name='t0')
     gb = t.filter(t.value == 42).group_by(t.key)
-    sum_expr = lambda t: (t.value + 1 + 2 + 3).sum()  # noqa: E731
+    sum_expr = lambda t: (t.value + 1 + 2 + 3).sum()
     expr = gb.aggregate(abc=sum_expr)
     result = ibis.clickhouse.compile(expr)
     snapshot.assert_match(result, "out1.sql")

--- a/ibis/backends/dask/tests/conftest.py
+++ b/ibis/backends/dask/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 import ibis
 from ibis.backends.pandas.tests.conftest import TestConf as PandasTest
+from ibis.backends.tests.data import win
 
 dd = pytest.importorskip("dask.dataframe")
 
@@ -50,18 +51,22 @@ class TestConf(PandasTest):
                     pd.read_csv(str(data_directory / 'diamonds.csv')),
                     npartitions=NPARTITIONS,
                 ),
-                'json_t': pd.DataFrame(
-                    {
-                        "js": [
-                            '{"a": [1,2,3,4], "b": 1}',
-                            '{"a":null,"b":2}',
-                            '{"a":"foo", "c":null}',
-                            "null",
-                            "[42,47,55]",
-                            "[]",
-                        ]
-                    }
+                'json_t': dd.from_pandas(
+                    pd.DataFrame(
+                        {
+                            "js": [
+                                '{"a": [1,2,3,4], "b": 1}',
+                                '{"a":null,"b":2}',
+                                '{"a":"foo", "c":null}',
+                                "null",
+                                "[42,47,55]",
+                                "[]",
+                            ]
+                        }
+                    ),
+                    npartitions=NPARTITIONS,
                 ),
+                "win": dd.from_pandas(win, npartitions=NPARTITIONS),
             }
         )
 

--- a/ibis/backends/impala/pandas_interop.py
+++ b/ibis/backends/impala/pandas_interop.py
@@ -18,6 +18,7 @@ import os
 import tempfile
 from posixpath import join as pjoin
 
+import ibis.backends.pandas.client  # noqa: F401
 import ibis.common.exceptions as com
 import ibis.expr.schema as sch
 import ibis.util as util

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -19,6 +19,7 @@ from ibis.backends.base import BaseBackend
 from ibis.backends.conftest import TEST_TABLES, _random_identifier
 from ibis.backends.impala.compiler import ImpalaCompiler, ImpalaExprTranslator
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero, UnorderedComparator
+from ibis.backends.tests.data import win
 from ibis.tests.expr.mocks import MockBackend
 
 
@@ -493,6 +494,12 @@ def impala_create_test_database(con, env):
         ),
         database=env.test_data_db,
     )
+    con.create_table(
+        "win",
+        schema=ibis.schema(dict(g="string", x="int64", y="int64")),
+        database=env.test_data_db,
+    )
+    con.table("win", database=env.test_data_db).insert(win, overwrite=True)
 
 
 PARQUET_SCHEMAS = {

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -711,7 +711,7 @@ def test_filter_with_analytic(snapshot):
 def test_named_from_filter_group_by(snapshot):
     t = ibis.table([('key', 'string'), ('value', 'double')], name='t0')
     gb = t.filter(t.value == 42).group_by(t.key)
-    sum_expr = lambda t: (t.value + 1 + 2 + 3).sum()  # noqa: E731
+    sum_expr = lambda t: (t.value + 1 + 2 + 3).sum()
     expr = gb.aggregate(abc=sum_expr)
     snapshot.assert_match(ibis.impala.compile(expr), "abc.sql")
 

--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -6,6 +6,7 @@ import operator
 import re
 from typing import TYPE_CHECKING, Any, Callable, NoReturn
 
+import numpy as np
 import pandas as pd
 import toolz
 from multipledispatch import Dispatcher
@@ -155,12 +156,18 @@ def get_aggcontext_window(
     output_type = operand.output_dtype
 
     aggcontext: agg_ctx.AggregationContext
+
     if not group_by and not order_by:
         aggcontext = agg_ctx.Summarize(parent=parent, output_type=output_type)
-    elif (
-        isinstance(operand, (ops.Reduction, ops.CumulativeOp, ops.Any, ops.All))
-        and order_by
-    ):
+    elif group_by and not order_by:
+        # groupby transform (window with a partition by clause in SQL parlance)
+        aggcontext = agg_ctx.Transform(
+            parent=parent,
+            group_by=group_by,
+            order_by=order_by,
+            output_type=output_type,
+        )
+    else:
         # XXX(phillipc): What a horror show
         preceding = window.preceding
         if preceding is not None:
@@ -182,14 +189,6 @@ def get_aggcontext_window(
                 order_by=order_by,
                 output_type=output_type,
             )
-    else:
-        # groupby transform (window with a partition by clause in SQL parlance)
-        aggcontext = agg_ctx.Transform(
-            parent=parent,
-            group_by=group_by,
-            order_by=order_by,
-            output_type=output_type,
-        )
 
     return aggcontext
 
@@ -514,9 +513,13 @@ def execute_series_first_value(op, data, **kwargs):
     return data.values[0]
 
 
+def _getter(x: pd.Series | np.ndarray, idx: int):
+    return getattr(x, "values", x)[idx]
+
+
 @execute_node.register(ops.FirstValue, SeriesGroupBy)
 def execute_series_group_by_first_value(op, data, aggcontext=None, **kwargs):
-    return aggcontext.agg(data, 'first')
+    return aggcontext.agg(data, lambda x: _getter(x, 0))
 
 
 @execute_node.register(ops.LastValue, pd.Series)
@@ -526,7 +529,7 @@ def execute_series_last_value(op, data, **kwargs):
 
 @execute_node.register(ops.LastValue, SeriesGroupBy)
 def execute_series_group_by_last_value(op, data, aggcontext=None, **kwargs):
-    return aggcontext.agg(data, 'last')
+    return aggcontext.agg(data, lambda x: _getter(x, -1))
 
 
 @execute_node.register(ops.MinRank, (pd.Series, SeriesGroupBy))

--- a/ibis/backends/pandas/tests/conftest.py
+++ b/ibis/backends/pandas/tests/conftest.py
@@ -6,7 +6,7 @@ import ibis
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.backends.tests.base import BackendTest, RoundHalfToEven
-from ibis.backends.tests.data import array_types, json_types, struct_types
+from ibis.backends.tests.data import array_types, json_types, struct_types, win
 
 
 class TestConf(BackendTest, RoundHalfToEven):
@@ -35,6 +35,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                 'struct': struct_types,
                 'json_t': json_types,
                 'array_types': array_types,
+                'win': win,
             }
         )
 

--- a/ibis/backends/polars/tests/conftest.py
+++ b/ibis/backends/polars/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import ibis
 import ibis.expr.types as ir
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
-from ibis.backends.tests.data import array_types, struct_types
+from ibis.backends.tests.data import array_types, struct_types, win
 
 pl = pytest.importorskip("polars")
 
@@ -46,6 +46,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
         client.register(data_directory / 'diamonds.csv', table_name='diamonds')
         client.register(array_types, table_name='array_types')
         client.register(struct_types, table_name='struct')
+        client.register(win, table_name="win")
 
         return client
 

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -12,6 +12,7 @@ from ibis import util
 from ibis.backends.conftest import TEST_TABLES, _random_identifier
 from ibis.backends.pyspark.datatypes import spark_dtype
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
+from ibis.backends.tests.data import win
 
 pytest.importorskip("pyspark")
 
@@ -200,6 +201,9 @@ def get_common_spark_testing_client(data_directory, connect):
         )
     )
     df_json_t.createOrReplaceTempView("json_t")
+
+    win_t = s.createDataFrame(win)
+    win_t.createOrReplaceTempView("win")
 
     return _spark_testing_client
 

--- a/ibis/backends/tests/data.py
+++ b/ibis/backends/tests/data.py
@@ -114,3 +114,11 @@ struct_types = pd.DataFrame(
         ]
     }
 )
+
+win = pd.DataFrame(
+    {
+        "g": ["a", "a", "a", "a", "a"],
+        "x": [0, 1, 2, 3, 4],
+        "y": [3, 2, 0, 1, 1],
+    }
+)

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -413,8 +413,8 @@ def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
     backend.assert_series_equal(result, expected)
 
 
-plus = lambda t, td: t.timestamp_col + pd.Timedelta(td)  # noqa: E731
-minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)  # noqa: E731
+plus = lambda t, td: t.timestamp_col + pd.Timedelta(td)
+minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
 
 
 @pytest.mark.parametrize(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,6 +320,7 @@ select = [
 respect-gitignore = true
 ignore = [
   "E501",
+  "E731",
   "PGH003",
   "RET504",
   "RET505",


### PR DESCRIPTION
This PR fixes an issue with the pandas backend where the `Transform`
aggregation context was being used instead of the `Moving` context. `Transform`
should only be used when there's a `group_by` present, and no `order_by`.

A backend test and associated data was is also added to catch regressions.

Closes #4676.
