### PR TITLE
refactor: clean up `cot` implementations to have one less function call

### DIFF
--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -610,7 +610,7 @@ def _string_right(op, **kw):
 @translate_val.register(ops.Cot)
 def _cotangent(op, **kw):
     arg = translate_val(op.arg, **kw)
-    return f"cos({arg}) / sin({arg})"
+    return f"1.0 / tan({arg})"
 
 
 def _bit_agg(func):

--- a/ibis/backends/dask/execution/numeric.py
+++ b/ibis/backends/dask/execution/numeric.py
@@ -60,7 +60,7 @@ def execute_series_atan(_, data, **kwargs):
 
 @execute_node.register(ops.Cot, dd.Series)
 def execute_series_cot(_, data, **kwargs):
-    return np.cos(data) / np.sin(data)
+    return 1.0 / np.tan(data)
 
 
 @execute_node.register(ops.Atan2, dd.Series, dd.Series)

--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -420,7 +420,7 @@ def atan2(op):
 @translate.register(ops.Cot)
 def cot(op):
     x = translate(op.arg)
-    return df.functions.cos(x) / df.functions.sin(x)
+    return df.lit(1.0) / df.functions.tan(x)
 
 
 @translate.register(ops.ElementWiseVectorizedUDF)

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -243,7 +243,7 @@ def execute_series_atan(_, data, **kwargs):
 
 @execute_node.register(ops.Cot, (pd.Series, *numeric_types))
 def execute_series_cot(_, data, **kwargs):
-    return np.cos(data) / np.sin(data)
+    return 1.0 / np.tan(data)
 
 
 @execute_node.register(

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -805,7 +805,7 @@ _unary = {
     ops.Atan: operator.methodcaller('arctan'),
     ops.Ceil: lambda arg: arg.ceil().cast(pl.Int64),
     ops.Cos: operator.methodcaller('cos'),
-    ops.Cot: lambda arg: arg.cos() / arg.sin(),
+    ops.Cot: lambda arg: 1.0 / arg.tan(),
     ops.DayOfWeekIndex: (
         lambda arg: arg.dt.weekday().cast(pl.Int16) - _day_of_week_offset
     ),

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1783,7 +1783,7 @@ def compile_trig(t, op, **kwargs):
 @compiles(ops.Cot)
 def compile_cot(t, op, **kwargs):
     arg = t.translate(op.arg, **kwargs)
-    return F.cos(arg) / F.sin(arg)
+    return 1.0 / F.tan(arg)
 
 
 @compiles(ops.Atan2)

--- a/ibis/backends/sqlite/udf.py
+++ b/ibis/backends/sqlite/udf.py
@@ -212,8 +212,7 @@ def _trig_func_binary(func, arg1, arg2):
 @udf
 def _ibis_sqlite_cot(arg):
     return _trig_func_unary(
-        lambda arg: float("inf") if not arg else math.cos(arg) / math.sin(arg),
-        arg,
+        lambda arg: float("inf") if not arg else 1.0 / math.tan(arg), arg
     )
 
 

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -193,7 +193,7 @@ def test_math_functions_literals(con, expr, expected):
         param(L(0.0).atan(), math.atan(0.0), id="atan"),
         param(L(0.0).atan2(1.0), math.atan2(0.0, 1.0), id="atan2"),
         param(L(0.0).cos(), math.cos(0.0), id="cos"),
-        param(L(1.0).cot(), math.cos(1.0) / math.sin(1.0), id="cot"),
+        param(L(1.0).cot(), 1.0 / math.tan(1.0), id="cot"),
         param(L(0.0).sin(), math.sin(0.0), id="sin"),
         param(L(0.0).tan(), math.tan(0.0), id="tan"),
     ],


### PR DESCRIPTION
This PR makes all cotangent implementations use `1 / tan(x)` instead of wasting a function call by using `cos(x) / sin(x)`.