### PR TITLE
refactor: remove deprecated approximate aggregation classes

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -508,7 +508,6 @@ sqlalchemy_operation_registry: dict[Any, Any] = {
     ops.BitOr: reduction(sa.func.bit_or),
     ops.BitXor: reduction(sa.func.bit_xor),
     ops.CountDistinct: reduction(lambda arg: sa.func.count(arg.distinct())),
-    ops.HLLCardinality: reduction(lambda arg: sa.func.count(arg.distinct())),
     ops.ApproxCountDistinct: reduction(lambda arg: sa.func.count(arg.distinct())),
     ops.GroupConcat: reduction(sa.func.group_concat),
     ops.Between: fixed_arity(sa.between, 3),

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -300,8 +300,6 @@ operation_registry = {
     ops.DecimalPrecision: unary('precision'),
     ops.DecimalScale: unary('scale'),
     # Unary aggregates
-    ops.CMSMedian: aggregate.reduction('appx_median'),
-    ops.HLLCardinality: aggregate.reduction('ndv'),
     ops.ApproxMedian: aggregate.reduction('appx_median'),
     ops.ApproxCountDistinct: aggregate.reduction('ndv'),
     ops.Mean: aggregate.reduction('avg'),

--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -502,10 +502,11 @@ OPERATION_REGISTRY = {
     ops.NullIfZero: _nullifzero,
     ops.NotAny: bigquery_compile_notany,
     ops.NotAll: bigquery_compile_notall,
-    # Math
-    ops.CMSMedian: compiles_approx,
+    # Reductions
+    ops.ApproxMedian: compiles_approx,
     ops.Covariance: _covar,
     ops.Correlation: _corr,
+    # Math
     ops.Divide: bigquery_compiles_divide,
     ops.Floor: compiles_floor,
     ops.Modulus: fixed_arity("MOD", 2),
@@ -560,7 +561,6 @@ OPERATION_REGISTRY = {
     ops.ArrayIndex: _array_index,
     ops.ArrayLength: unary("ARRAY_LENGTH"),
     ops.ArrayRepeat: _array_repeat,
-    ops.HLLCardinality: reduction("APPROX_COUNT_DISTINCT"),
     ops.Log: _log,
     ops.Log2: _log2,
     ops.Arbitrary: _arbitrary,

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -927,11 +927,9 @@ _simple_ops = {
     ops.Pi: "pi",
     ops.E: "e",
     # Unary aggregates
-    ops.CMSMedian: "median",
     ops.ApproxMedian: "median",
     # TODO: there is also a `uniq` function which is the
     #       recommended way to approximate cardinality
-    ops.HLLCardinality: "uniqHLL12",
     ops.ApproxCountDistinct: "uniqHLL12",
     ops.Mean: "avg",
     ops.Sum: "sum",

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -234,15 +234,11 @@ operation_registry.update(
             lambda *args: sa.func.regexp_replace(*args, "g"), 3
         ),
         ops.StringContains: fixed_arity(sa.func.contains, 2),
-        ops.CMSMedian: reduction(
-            lambda arg: sa.func.approx_quantile(arg, sa.text(str(0.5)))
-        ),
         ops.ApproxMedian: reduction(
             # without inline text, duckdb fails with
             # RuntimeError: INTERNAL Error: Invalid PhysicalType for GetTypeIdSize
             lambda arg: sa.func.approx_quantile(arg, sa.text(str(0.5)))
         ),
-        ops.HLLCardinality: reduction(sa.func.approx_count_distinct),
         ops.ApproxCountDistinct: reduction(sa.func.approx_count_distinct),
         ops.Mode: reduction(sa.func.mode),
         ops.Strftime: _strftime,

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -7,7 +7,6 @@ import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
 from ibis.expr.operations.core import Value
 from ibis.expr.operations.generic import _Negatable
-from ibis.util import deprecated
 
 
 @public
@@ -223,21 +222,6 @@ class ApproxCountDistinct(Filterable, Reduction):
 
 
 @public
-class HLLCardinality(ApproxCountDistinct):
-    @deprecated(version="4.0", instead="use ApproxCountDistinct")
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-
-@public
-class GroupConcat(Filterable, Reduction):
-    arg = rlz.column(rlz.any)
-    sep = rlz.string
-
-    output_dtype = dt.string
-
-
-@public
 class ApproxMedian(Filterable, Reduction):
     """Compute the approximate median of a set of comparable values."""
 
@@ -246,10 +230,11 @@ class ApproxMedian(Filterable, Reduction):
 
 
 @public
-class CMSMedian(ApproxMedian):
-    @deprecated(version="4.0", instead="use ApproxMedian")
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+class GroupConcat(Filterable, Reduction):
+    arg = rlz.column(rlz.any)
+    sep = rlz.string
+
+    output_dtype = dt.string
 
 
 @public


### PR DESCRIPTION
This PR removes some deprecated aliases for `ApproxCountDistinct` and `ApproxMedian`.