### PR TITLE
refactor: make `Any`/`All`/`Quantile` subclass from `Filterable`

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -35,9 +35,6 @@ def variance_reduction(func_name):
 
 
 def fixed_arity(sa_func, arity):
-    if isinstance(sa_func, str):
-        sa_func = getattr(sa.func, sa_func)
-
     def formatter(t, op):
         arg_count = len(op.args)
         if arity != arg_count:

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -180,16 +180,6 @@ def _not_all(op, **kw):
     return translate_val(ops.Not(ops.All(op.arg)), **kw)
 
 
-@translate_val.register(ops.Any)
-def _any(op, **kw):
-    return f"max({translate_val(op.arg, **kw)})"
-
-
-@translate_val.register(ops.All)
-def _all(op, **kw):
-    return f"min({translate_val(op.arg, **kw)})"
-
-
 def _agg_variance_like(func):
     variants = {"sample": f"{func}Samp", "pop": f"{func}Pop"}
 
@@ -930,6 +920,8 @@ _simple_ops = {
     ops.Sum: "sum",
     ops.Max: "max",
     ops.Min: "min",
+    ops.Any: "max",
+    ops.All: "min",
     ops.ArgMin: "argMin",
     ops.ArgMax: "argMax",
     ops.ArrayCollect: "groupArray",

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -473,10 +473,10 @@ operation_registry.update(
         # null handling
         ops.IfNull: fixed_arity(sa.func.coalesce, 2),
         # boolean reductions
-        ops.Any: unary(sa.func.bool_or),
-        ops.All: unary(sa.func.bool_and),
-        ops.NotAny: unary(lambda x: sa.not_(sa.func.bool_or(x))),
-        ops.NotAll: unary(lambda x: sa.not_(sa.func.bool_and(x))),
+        ops.Any: reduction(sa.func.bool_or),
+        ops.All: reduction(sa.func.bool_and),
+        ops.NotAny: reduction(lambda x: sa.not_(sa.func.bool_or(x))),
+        ops.NotAll: reduction(lambda x: sa.not_(sa.func.bool_and(x))),
         # strings
         ops.GroupConcat: _string_agg,
         ops.Capitalize: unary(sa.func.initcap),
@@ -488,7 +488,7 @@ operation_registry.update(
             ),
             3,
         ),
-        ops.Translate: fixed_arity('translate', 3),
+        ops.Translate: fixed_arity(sa.func.translate, 3),
         ops.RegexExtract: fixed_arity(_regex_extract, 3),
         ops.StringSplit: fixed_arity(
             lambda col, sep: sa.func.string_to_array(

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -501,6 +501,31 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                 )
             ],
         ),
+        param(
+            lambda t, where: t.double_col.quantile(0.5, where=where),
+            lambda t, where: t.double_col[where].quantile(0.5),
+            id="quantile",
+            marks=[
+                mark.notimpl(
+                    [
+                        "bigquery",
+                        "clickhouse",
+                        "dask",
+                        "datafusion",
+                        "duckdb",
+                        "impala",
+                        "mssql",
+                        "mysql",
+                        "polars",
+                        "postgres",
+                        "pyspark",
+                        "snowflake",
+                        "sqlite",
+                        "trino",
+                    ]
+                )
+            ],
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -154,10 +154,10 @@ operation_registry.update(
         # static checks are not happy with using "if" as a property
         ops.Where: fixed_arity(getattr(sa.func, 'if'), 3),
         # boolean reductions
-        ops.Any: unary(sa.func.bool_or),
-        ops.All: unary(sa.func.bool_and),
-        ops.NotAny: unary(lambda x: sa.not_(sa.func.bool_or(x))),
-        ops.NotAll: unary(lambda x: sa.not_(sa.func.bool_and(x))),
+        ops.Any: reduction(sa.func.bool_or),
+        ops.All: reduction(sa.func.bool_and),
+        ops.NotAny: reduction(lambda x: sa.not_(sa.func.bool_or(x))),
+        ops.NotAll: reduction(lambda x: sa.not_(sa.func.bool_and(x))),
         ops.ArgMin: reduction(sa.func.min_by),
         ops.ArgMax: reduction(sa.func.max_by),
         # array ops

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -772,8 +772,13 @@ def find_subqueries(node: ops.Node) -> Counter:
 
 
 # TODO(kszucs): move to types/logical.py
-def _make_any(expr, any_op_class: type[ops.Any] | type[ops.NotAny]):
-    assert isinstance(expr, ir.Expr)
+def _make_any(
+    expr,
+    any_op_class: type[ops.Any] | type[ops.NotAny],
+    *,
+    where: ir.BooleanValue | None = None,
+):
+    assert isinstance(expr, ir.Expr), type(expr)
 
     tables = find_immediate_parent_tables(expr.op())
     predicates = find_predicates(expr.op(), flatten=True)
@@ -784,7 +789,7 @@ def _make_any(expr, any_op_class: type[ops.Any] | type[ops.NotAny]):
             predicates=predicates,
         )
     else:
-        op = any_op_class(expr)
+        op = any_op_class(expr, where=where)
     return op.to_expr()
 
 

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import ibis.expr.types as ir
-
 from public import public
 
 import ibis.expr.operations as ops
 from ibis.expr.types.core import _binop
 from ibis.expr.types.numeric import NumericColumn, NumericScalar, NumericValue
+
+if TYPE_CHECKING:
+    import ibis.expr.types as ir
 
 
 @public
@@ -77,21 +77,21 @@ class BooleanScalar(NumericScalar, BooleanValue):
 
 @public
 class BooleanColumn(NumericColumn, BooleanValue):
-    def any(self) -> BooleanValue:
+    def any(self, where: BooleanValue | None = None) -> BooleanValue:
         import ibis.expr.analysis as an
 
-        return an._make_any(self, ops.Any)
+        return an._make_any(self, ops.Any, where=where)
 
-    def notany(self) -> BooleanValue:
+    def notany(self, where: BooleanValue | None = None) -> BooleanValue:
         import ibis.expr.analysis as an
 
-        return an._make_any(self, ops.NotAny)
+        return an._make_any(self, ops.NotAny, where=where)
 
-    def all(self) -> BooleanScalar:
-        return ops.All(self).to_expr()
+    def all(self, where: BooleanValue | None = None) -> BooleanScalar:
+        return ops.All(self, where=where).to_expr()
 
-    def notall(self) -> BooleanScalar:
-        return ops.NotAll(self).to_expr()
+    def notall(self, where: BooleanValue | None = None) -> BooleanScalar:
+        return ops.NotAll(self, where=where).to_expr()
 
     def cumany(self) -> BooleanColumn:
         return ops.CumulativeAny(self).to_expr()

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -320,6 +320,7 @@ class NumericColumn(Column, NumericValue):
             "midpoint",
             "nearest",
         ] = "linear",
+        where: ir.BooleanValue | None = None,
     ) -> NumericScalar:
         """Return value at the given quantile.
 
@@ -328,8 +329,10 @@ class NumericColumn(Column, NumericValue):
         quantile
             `0 <= quantile <= 1`, the quantile(s) to compute
         interpolation
-            This optional parameter specifies the interpolation method to use,
-            when the desired quantile lies between two data points `i` and `j`:
+            !!! warning "This parameter is backend dependent and may have no effect"
+
+            This parameter specifies the interpolation method to use, when the
+            desired quantile lies between two data points `i` and `j`:
 
             * linear: `i + (j - i) * fraction`, where `fraction` is the
               fractional part of the index surrounded by `i` and `j`.
@@ -337,6 +340,8 @@ class NumericColumn(Column, NumericValue):
             * higher: `j`.
             * nearest: `i` or `j` whichever is nearest.
             * midpoint: (`i` + `j`) / 2.
+        where
+            Boolean filter for input values
 
         Returns
         -------
@@ -347,7 +352,7 @@ class NumericColumn(Column, NumericValue):
             op = ops.MultiQuantile
         else:
             op = ops.Quantile
-        return op(self, quantile, interpolation).to_expr()
+        return op(self, quantile, interpolation, where=where).to_expr()
 
     def std(
         self,


### PR DESCRIPTION
This PR makes the remaining not filterable reductions filterable. I still need to add tests that hit the filtering branches of these aggs.