### PR TITLE
feat(datatype): add support for optional timestamp scale parameter

### DIFF
--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -242,7 +242,9 @@ class BaseAlchemyBackend(BaseSQLBackend):
 
     def _columns_from_schema(self, name: str, schema: sch.Schema) -> list[sa.Column]:
         return [
-            sa.Column(colname, to_sqla_type(dtype), nullable=dtype.nullable)
+            sa.Column(
+                colname, to_sqla_type(self.con.dialect, dtype), nullable=dtype.nullable
+            )
             for colname, dtype in zip(schema.names, schema.types)
         ]
 

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -402,14 +402,17 @@ class BaseAlchemyBackend(BaseSQLBackend):
         """Handle cases where SQLAlchemy cannot infer the column types of `table`."""
 
         self.inspector.reflect_table(table, table.columns)
-        quoted_name = self.con.dialect.identifier_preparer.quote(table.name)
+        dialect = self.con.dialect
+        quoted_name = dialect.identifier_preparer.quote(table.name)
 
         for colname, type in self._metadata(quoted_name):
             if colname in nulltype_cols:
                 # replace null types discovered by sqlalchemy with non null
                 # types
                 table.append_column(
-                    sa.Column(colname, to_sqla_type(type), nullable=type.nullable),
+                    sa.Column(
+                        colname, to_sqla_type(dialect, type), nullable=type.nullable
+                    ),
                     replace_existing=True,
                 )
         return table

--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -426,6 +426,20 @@ def sa_datetime(_, satype, nullable=True, default_timezone='UTC'):
     return dt.Timestamp(timezone=timezone, nullable=nullable)
 
 
+@dt.dtype.register(MSDialect, mssql.DATETIMEOFFSET)
+def _datetimeoffset(_, sa_type, nullable=True):
+    if (prec := sa_type.precision) is None:
+        prec = 7
+    return dt.Timestamp(scale=prec, timezone="UTC", nullable=nullable)
+
+
+@dt.dtype.register(MSDialect, mssql.DATETIME2)
+def _datetime2(_, sa_type, nullable=True):
+    if (prec := sa_type.precision) is None:
+        prec = 7
+    return dt.Timestamp(scale=prec, nullable=nullable)
+
+
 @dt.dtype.register(PGDialect, sa.ARRAY)
 def sa_pg_array(dialect, satype, nullable=True):
     dimensions = satype.dimensions

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -185,7 +185,7 @@ def _cast(t, op):
     if typ.is_json() and not t.native_json_type:
         return sa_arg
 
-    return t.cast(sa_arg, typ)
+    return sa.cast(sa_arg, t.get_sqla_type(typ))
 
 
 def _contains(func):

--- a/ibis/backends/base/sql/alchemy/translator.py
+++ b/ibis/backends/base/sql/alchemy/translator.py
@@ -5,7 +5,8 @@ import sqlalchemy as sa
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.base.sql.alchemy.datatypes import ibis_type_to_sqla, to_sqla_type
+from ibis.backends.base.sql.alchemy import to_sqla_type
+from ibis.backends.base.sql.alchemy.datatypes import _DEFAULT_DIALECT
 from ibis.backends.base.sql.alchemy.registry import (
     fixed_arity,
     sqlalchemy_operation_registry,
@@ -35,7 +36,6 @@ class AlchemyContext(QueryContext):
 class AlchemyExprTranslator(ExprTranslator):
     _registry = sqlalchemy_operation_registry
     _rewrites = ExprTranslator._rewrites.copy()
-    _type_map = ibis_type_to_sqla
 
     context_class = AlchemyContext
 
@@ -54,11 +54,26 @@ class AlchemyExprTranslator(ExprTranslator):
         ops.CumeDist,
     )
 
+    _dialect_name = "default"
+
+    @property
+    def dialect(self) -> sa.engine.interfaces.Dialect:
+        if (name := self._dialect_name) == "default":
+            return _DEFAULT_DIALECT
+        dialect_cls = sa.dialects.registry.load(name)
+        return dialect_cls()
+
+    def _schema_to_sqlalchemy_columns(self, schema):
+        return [
+            sa.column(name, to_sqla_type(self.dialect, dtype))
+            for name, dtype in schema.items()
+        ]
+
     def name(self, translated, name, force=True):
         return translated.label(name)
 
     def get_sqla_type(self, data_type):
-        return to_sqla_type(data_type, type_map=self._type_map)
+        return to_sqla_type(self.dialect, data_type)
 
     def _maybe_cast_bool(self, op, arg):
         if (

--- a/ibis/backends/clickhouse/datatypes.py
+++ b/ibis/backends/clickhouse/datatypes.py
@@ -257,4 +257,9 @@ def _(ty: dt.Struct) -> str:
 
 @serialize_raw.register(dt.Timestamp)
 def _(ty: dt.Timestamp) -> str:
-    return "DateTime64(6)" if ty.timezone is None else f"DateTime64(6, {ty.timezone!r})"
+    if (scale := ty.scale) is None:
+        scale = 3
+
+    if (timezone := ty.timezone) is not None:
+        return f"DateTime64({scale:d}, {timezone})"
+    return f"DateTime64({scale:d})"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_cast_string_col/timestamp/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_cast_string_col/timestamp/out.sql
@@ -1,1 +1,1 @@
-CAST(string_col AS Nullable(DateTime64(6)))
+CAST(string_col AS Nullable(DateTime64(3)))

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_cast/out1.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_cast/out1.sql
@@ -1,1 +1,1 @@
-CAST(timestamp_col AS DateTime64(6))
+CAST(timestamp_col AS DateTime64(3))

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_cast/out2.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_cast/out2.sql
@@ -1,1 +1,1 @@
-CAST(int_col AS DateTime64(6))
+CAST(int_col AS DateTime64(3))

--- a/ibis/backends/clickhouse/tests/test_types.py
+++ b/ibis/backends/clickhouse/tests/test_types.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest import param
 
 import ibis.expr.datatypes as dt
 from ibis.backends.clickhouse.datatypes import parse
@@ -30,55 +31,104 @@ def test_columns_types_with_additional_argument(con):
 @pytest.mark.parametrize(
     ('ch_type', 'ibis_type'),
     [
-        (
+        param(
             "Enum8('' = 0, 'CDMA' = 1, 'GSM' = 2, 'LTE' = 3, 'NR' = 4)",
             dt.String(nullable=False),
+            id="enum",
         ),
-        ('IPv4', dt.inet(nullable=False)),
-        ('IPv6', dt.inet(nullable=False)),
-        ('JSON', dt.json(nullable=False)),
-        ("Object('json')", dt.json(nullable=False)),
-        ('LowCardinality(String)', dt.String(nullable=False)),
-        ('Array(Int8)', dt.Array(dt.Int8(nullable=False), nullable=False)),
-        ('Array(Int16)', dt.Array(dt.Int16(nullable=False), nullable=False)),
-        ('Array(Int32)', dt.Array(dt.Int32(nullable=False), nullable=False)),
-        ('Array(Int64)', dt.Array(dt.Int64(nullable=False), nullable=False)),
-        ('Array(UInt8)', dt.Array(dt.UInt8(nullable=False), nullable=False)),
-        ('Array(UInt16)', dt.Array(dt.UInt16(nullable=False), nullable=False)),
-        ('Array(UInt32)', dt.Array(dt.UInt32(nullable=False), nullable=False)),
-        ('Array(UInt64)', dt.Array(dt.UInt64(nullable=False), nullable=False)),
-        (
+        param('IPv4', dt.inet(nullable=False), id="ipv4"),
+        param('IPv6', dt.inet(nullable=False), id="ipv6"),
+        param('JSON', dt.json(nullable=False), id="json"),
+        param("Object('json')", dt.json(nullable=False), id="object_json"),
+        param(
+            'LowCardinality(String)', dt.String(nullable=False), id="low_card_string"
+        ),
+        param(
+            'Array(Int8)',
+            dt.Array(dt.Int8(nullable=False), nullable=False),
+            id="array_int8",
+        ),
+        param(
+            'Array(Int16)',
+            dt.Array(dt.Int16(nullable=False), nullable=False),
+            id="array_int16",
+        ),
+        param(
+            'Array(Int32)',
+            dt.Array(dt.Int32(nullable=False), nullable=False),
+            id="array_int32",
+        ),
+        param(
+            'Array(Int64)',
+            dt.Array(dt.Int64(nullable=False), nullable=False),
+            id="array_int64",
+        ),
+        param(
+            'Array(UInt8)',
+            dt.Array(dt.UInt8(nullable=False), nullable=False),
+            id="array_uint8",
+        ),
+        param(
+            'Array(UInt16)',
+            dt.Array(dt.UInt16(nullable=False), nullable=False),
+            id="array_uint16",
+        ),
+        param(
+            'Array(UInt32)',
+            dt.Array(dt.UInt32(nullable=False), nullable=False),
+            id="array_uint32",
+        ),
+        param(
+            'Array(UInt64)',
+            dt.Array(dt.UInt64(nullable=False), nullable=False),
+            id="array_uint64",
+        ),
+        param(
             'Array(Float32)',
             dt.Array(dt.Float32(nullable=False), nullable=False),
+            id="array_float32",
         ),
-        (
+        param(
             'Array(Float64)',
             dt.Array(dt.Float64(nullable=False), nullable=False),
+            id="array_float64",
         ),
-        ('Array(String)', dt.Array(dt.String(nullable=False), nullable=False)),
-        (
+        param(
+            'Array(String)',
+            dt.Array(dt.String(nullable=False), nullable=False),
+            id="array_string",
+        ),
+        param(
             'Array(FixedString(32))',
             dt.Array(dt.String(nullable=False), nullable=False),
+            id="array_fixed_string",
         ),
-        ('Array(Date)', dt.Array(dt.Date(nullable=False), nullable=False)),
-        (
+        param(
+            'Array(Date)',
+            dt.Array(dt.Date(nullable=False), nullable=False),
+            id="array_date",
+        ),
+        param(
             'Array(DateTime)',
             dt.Array(dt.Timestamp(nullable=False), nullable=False),
+            id="array_datetime",
         ),
-        (
+        param(
             'Array(DateTime64)',
             dt.Array(dt.Timestamp(nullable=False), nullable=False),
+            id="array_datetime64",
         ),
-        ('Array(Nothing)', dt.Array(dt.null, nullable=False)),
-        ('Array(Null)', dt.Array(dt.null, nullable=False)),
-        (
+        param('Array(Nothing)', dt.Array(dt.null, nullable=False), id="array_nothing"),
+        param('Array(Null)', dt.Array(dt.null, nullable=False), id="array_null"),
+        param(
             'Array(Array(Int8))',
             dt.Array(
                 dt.Array(dt.Int8(nullable=False), nullable=False),
                 nullable=False,
             ),
+            id="double_array",
         ),
-        (
+        param(
             'Array(Array(Array(Int8)))',
             dt.Array(
                 dt.Array(
@@ -87,8 +137,9 @@ def test_columns_types_with_additional_argument(con):
                 ),
                 nullable=False,
             ),
+            id="triple_array",
         ),
-        (
+        param(
             'Array(Array(Array(Array(Int8))))',
             dt.Array(
                 dt.Array(
@@ -100,13 +151,15 @@ def test_columns_types_with_additional_argument(con):
                 ),
                 nullable=False,
             ),
+            id="quad_array",
         ),
-        (
+        param(
             "Map(Nullable(String), Nullable(UInt64))",
             dt.Map(dt.string, dt.uint64, nullable=False),
+            id="map",
         ),
-        ("Decimal(10, 3)", dt.Decimal(10, 3, nullable=False)),
-        (
+        param("Decimal(10, 3)", dt.Decimal(10, 3, nullable=False), id="decimal"),
+        param(
             "Tuple(a String, b Array(Nullable(Float64)))",
             dt.Struct.from_dict(
                 dict(
@@ -115,8 +168,9 @@ def test_columns_types_with_additional_argument(con):
                 ),
                 nullable=False,
             ),
+            id="named_tuple",
         ),
-        (
+        param(
             "Tuple(String, Array(Nullable(Float64)))",
             dt.Struct.from_dict(
                 dict(
@@ -125,8 +179,9 @@ def test_columns_types_with_additional_argument(con):
                 ),
                 nullable=False,
             ),
+            id="unnamed_tuple",
         ),
-        (
+        param(
             "Tuple(a String, Array(Nullable(Float64)))",
             dt.Struct.from_dict(
                 dict(
@@ -135,8 +190,9 @@ def test_columns_types_with_additional_argument(con):
                 ),
                 nullable=False,
             ),
+            id="partially_named",
         ),
-        (
+        param(
             "Nested(a String, b Array(Nullable(Float64)))",
             dt.Struct.from_dict(
                 dict(
@@ -145,7 +201,24 @@ def test_columns_types_with_additional_argument(con):
                 ),
                 nullable=False,
             ),
+            id="nested",
         ),
+        param(
+            "DateTime64(0)", dt.Timestamp(scale=0, nullable=False), id="datetime64_zero"
+        ),
+        param(
+            "DateTime64(1)", dt.Timestamp(scale=1, nullable=False), id="datetime64_one"
+        ),
+        param("DateTime64", dt.Timestamp(nullable=False), id="datetime64"),
+    ]
+    + [
+        param(
+            f"DateTime64({scale}, '{tz}')",
+            dt.Timestamp(scale=scale, timezone=tz, nullable=False),
+            id=f"datetime64_{scale}_{tz}",
+        )
+        for scale in range(10)
+        for tz in ("UTC", "America/New_York", "America/Chicago", "America/Los_Angeles")
     ],
 )
 def test_parse_type(ch_type, ibis_type):

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -12,11 +12,8 @@ from ibis.backends.duckdb.registry import operation_registry
 class DuckDBSQLExprTranslator(AlchemyExprTranslator):
     _registry = operation_registry
     _rewrites = AlchemyExprTranslator._rewrites.copy()
-    # The PostgreSQLExprTranslater maps to a `DOUBLE_PRECISION`
-    # type that duckdb doesn't understand, but we probably still want
-    # the updated `operation_registry` from postgres
-    _type_map = AlchemyExprTranslator._type_map.copy()
     _has_reduction_filter_syntax = True
+    _dialect_name = "duckdb"
 
 
 @compiles(sat.UInt64, "duckdb")

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -5,7 +5,11 @@ from sqlalchemy.ext.compiler import compiles
 import ibis.backends.base.sql.alchemy.datatypes as sat
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.base.sql.alchemy import AlchemyCompiler, AlchemyExprTranslator
+from ibis.backends.base.sql.alchemy import (
+    AlchemyCompiler,
+    AlchemyExprTranslator,
+    to_sqla_type,
+)
 from ibis.backends.duckdb.registry import operation_registry
 
 
@@ -24,6 +28,11 @@ def compile_uint(element, compiler, **kw):
     return element.__class__.__name__.upper()
 
 
+@compiles(sat.ArrayType, "duckdb")
+def compile_array(element, compiler, **kw):
+    return f"{compiler.process(element.value_type, **kw)}[]"
+
+
 try:
     import duckdb_engine
 except ImportError:
@@ -36,6 +45,14 @@ else:
     @dt.dtype.register(duckdb_engine.Dialect, sat.UInt8)
     def dtype_uint(_, satype, nullable=True):
         return getattr(dt, satype.__class__.__name__)(nullable=nullable)
+
+    @dt.dtype.register(duckdb_engine.Dialect, sat.ArrayType)
+    def _(dialect, satype, nullable=True):
+        return dt.Array(dt.dtype(dialect, satype.value_type), nullable=nullable)
+
+    @to_sqla_type.register(duckdb_engine.Dialect, dt.Array)
+    def _(dialect, itype):
+        return sat.ArrayType(to_sqla_type(dialect, itype.value_type))
 
 
 rewrites = DuckDBSQLExprTranslator.rewrites

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -3,16 +3,13 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 import sqlalchemy as sa
 
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.mssql.compiler import MsSqlCompiler
 from ibis.backends.mssql.datatypes import _type_from_result_set_info
-
-if TYPE_CHECKING:
-    pass
 
 
 class Backend(BaseAlchemyBackend):

--- a/ibis/backends/mssql/compiler.py
+++ b/ibis/backends/mssql/compiler.py
@@ -1,30 +1,16 @@
 from __future__ import annotations
 
-from sqlalchemy.dialects import mssql
-
-import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.base.sql.alchemy import AlchemyCompiler, AlchemyExprTranslator
+from ibis.backends.base.sql.alchemy import (
+    AlchemyCompiler,
+    AlchemyExprTranslator,
+)
 from ibis.backends.mssql.registry import _timestamp_from_unix, operation_registry
 
 
 class MsSqlExprTranslator(AlchemyExprTranslator):
     _registry = operation_registry
     _rewrites = AlchemyExprTranslator._rewrites.copy()
-    _type_map = AlchemyExprTranslator._type_map.copy()
-    _type_map.update(
-        {
-            dt.Boolean: mssql.BIT,
-            dt.Int8: mssql.TINYINT,
-            dt.Int16: mssql.SMALLINT,
-            dt.Int32: mssql.INTEGER,
-            dt.Int64: mssql.BIGINT,
-            dt.Float16: mssql.FLOAT,
-            dt.Float32: mssql.FLOAT,
-            dt.Float64: mssql.REAL,
-            dt.String: mssql.NVARCHAR,
-        }
-    )
     _bool_aggs_need_cast_to_int32 = True
     integer_to_timestamp = staticmethod(_timestamp_from_unix)
     native_json_type = False
@@ -34,6 +20,7 @@ class MsSqlExprTranslator(AlchemyExprTranslator):
         ops.Lead,
     )
     _require_order_by = AlchemyExprTranslator._require_order_by + (ops.Reduction,)
+    _dialect_name = "mssql"
 
 
 rewrites = MsSqlExprTranslator.rewrites

--- a/ibis/backends/mssql/datatypes.py
+++ b/ibis/backends/mssql/datatypes.py
@@ -1,7 +1,10 @@
 from functools import partial
 from typing import Optional, TypedDict
 
+from sqlalchemy.dialects import mssql
+
 import ibis.expr.datatypes as dt
+from ibis.backends.base.sql.alchemy import to_sqla_type
 
 
 class _FieldDescription(TypedDict):
@@ -77,3 +80,21 @@ _type_mapping = {
     # https://learn.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-ver16
     'TIMESTAMP': dt.Binary,
 }
+
+
+_MSSQL_TYPE_MAP = {
+    dt.Boolean: mssql.BIT,
+    dt.Int8: mssql.TINYINT,
+    dt.Int16: mssql.SMALLINT,
+    dt.Int32: mssql.INTEGER,
+    dt.Int64: mssql.BIGINT,
+    dt.Float16: mssql.FLOAT,
+    dt.Float32: mssql.FLOAT,
+    dt.Float64: mssql.REAL,
+    dt.String: mssql.NVARCHAR,
+}
+
+
+@to_sqla_type.register(mssql.dialect, tuple(_MSSQL_TYPE_MAP.keys()))
+def _simple_types(_, itype):
+    return _MSSQL_TYPE_MAP[type(itype)]

--- a/ibis/backends/postgres/udf.py
+++ b/ibis/backends/postgres/udf.py
@@ -19,6 +19,8 @@ from ibis.backends.postgres.compiler import PostgreSQLExprTranslator, PostgresUD
 
 _udf_name_cache: MutableMapping[str, Any] = collections.defaultdict(itertools.count)
 
+_postgres_dialect = dialect()
+
 
 class PostgresUDFError(IbisError):
     pass
@@ -26,14 +28,14 @@ class PostgresUDFError(IbisError):
 
 def _ibis_to_pg_sa_type(ibis_type):
     """Map an ibis DataType to a Postgres-compatible sqlalchemy type."""
-    return to_sqla_type(ibis_type, type_map=PostgreSQLExprTranslator._type_map)
+    return to_sqla_type(_postgres_dialect, ibis_type)
 
 
 def _sa_type_to_postgres_str(sa_type):
     """Map a postgres-compatible sqlalchemy type to a postgres string."""
     if callable(sa_type):
         sa_type = sa_type()
-    return sa_type.compile(dialect=dialect())
+    return sa_type.compile(dialect=_postgres_dialect)
 
 
 def _ibis_to_postgres_str(ibis_type):

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -41,11 +41,6 @@ class SnowflakeExprTranslator(AlchemyExprTranslator):
     _require_order_by = (*AlchemyExprTranslator._require_order_by, ops.Reduction)
     _dialect_name = "snowflake"
 
-    def cast(self, sa_expr, ibis_type: dt.DataType):
-        if ibis_type.is_array() or ibis_type.is_map() or ibis_type.is_struct():
-            return sa.type_coerce(sa_expr, self.get_sqla_type(ibis_type))
-        return super().cast(sa_expr, ibis_type)
-
 
 class SnowflakeCompiler(AlchemyCompiler):
     translator_class = SnowflakeExprTranslator

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -32,7 +32,6 @@ _NATIVE_ARROW = True
 class SnowflakeExprTranslator(AlchemyExprTranslator):
     _registry = operation_registry
     _rewrites = AlchemyExprTranslator._rewrites.copy()
-    _type_map = AlchemyExprTranslator._type_map.copy()
     _has_reduction_filter_syntax = False
     _forbids_frame_clause = (
         *AlchemyExprTranslator._forbids_frame_clause,
@@ -40,6 +39,7 @@ class SnowflakeExprTranslator(AlchemyExprTranslator):
         ops.Lead,
     )
     _require_order_by = (*AlchemyExprTranslator._require_order_by, ops.Reduction)
+    _dialect_name = "snowflake"
 
     def cast(self, sa_expr, ibis_type: dt.DataType):
         if ibis_type.is_array() or ibis_type.is_map() or ibis_type.is_struct():

--- a/ibis/backends/snowflake/datatypes.py
+++ b/ibis/backends/snowflake/datatypes.py
@@ -15,6 +15,7 @@ from snowflake.sqlalchemy import (
 from snowflake.sqlalchemy.snowdialect import SnowflakeDialect
 
 import ibis.expr.datatypes as dt
+from ibis.backends.base.sql.alchemy import to_sqla_type
 
 if TYPE_CHECKING:
     from ibis.expr.datatypes import DataType
@@ -177,3 +178,18 @@ def sa_sf_numeric(_, satype, nullable=True):
 @dt.dtype.register(SnowflakeDialect, (sa.REAL, sa.FLOAT, sa.Float))
 def sa_sf_real_float(_, satype, nullable=True):
     return dt.Float64(nullable=nullable)
+
+
+@to_sqla_type.register(SnowflakeDialect, dt.Array)
+def _sf_array(_, itype):
+    return ARRAY
+
+
+@to_sqla_type.register(SnowflakeDialect, (dt.Map, dt.Struct))
+def _sf_map_struct(_, itype):
+    return OBJECT
+
+
+@to_sqla_type.register(SnowflakeDialect, dt.JSON)
+def _sf_json(_, itype):
+    return VARIANT

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -139,7 +139,7 @@ class Backend(BaseAlchemyBackend):
             # easier than subclassing the builtin SQLite dialect, and achieves
             # the same desired behavior.
             def _to_ischema_val(t):
-                sa_type = to_sqla_type(datatype(t))
+                sa_type = to_sqla_type(engine.dialect, datatype(t))
                 if isinstance(sa_type, sa.types.TypeEngine):
                     # SQLAlchemy expects a callable here, rather than an
                     # instance. Use a lambda to work around this.

--- a/ibis/backends/sqlite/compiler.py
+++ b/ibis/backends/sqlite/compiler.py
@@ -14,25 +14,23 @@ from __future__ import annotations
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sqlalchemy as sa
+from sqlalchemy.dialects import sqlite
 
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.base.sql.alchemy import AlchemyCompiler, AlchemyExprTranslator
+from ibis.backends.base.sql.alchemy import (
+    AlchemyCompiler,
+    AlchemyExprTranslator,
+    to_sqla_type,
+)
 from ibis.backends.sqlite.registry import operation_registry
 
 
 class SQLiteExprTranslator(AlchemyExprTranslator):
     _registry = operation_registry
     _rewrites = AlchemyExprTranslator._rewrites.copy()
-    _type_map = AlchemyExprTranslator._type_map.copy()
-    _type_map.update(
-        {
-            dt.Float64: sa.types.REAL,
-            dt.Float16: sa.types.REAL,
-            dt.Float32: sa.types.REAL,
-        }
-    )
+    _dialect_name = "sqlite"
 
 
 rewrites = SQLiteExprTranslator.rewrites
@@ -68,3 +66,8 @@ def day_of_week_name(op):
 
 class SQLiteCompiler(AlchemyCompiler):
     translator_class = SQLiteExprTranslator
+
+
+@to_sqla_type.register(sqlite.dialect, (dt.Float32, dt.Float64))
+def _floating_point(_, itype):
+    return sa.REAL

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -20,7 +20,6 @@ from ibis.backends.base.sql.alchemy import (
     varargs,
     variance_reduction,
 )
-from ibis.backends.base.sql.alchemy.datatypes import to_sqla_type
 from ibis.backends.base.sql.alchemy.registry import _clip, _gen_string_find
 
 operation_registry = sqlalchemy_operation_registry.copy()
@@ -31,38 +30,39 @@ sqlite_cast = Dispatcher("sqlite_cast")
 
 
 @sqlite_cast.register(object, dt.Integer, dt.Timestamp)
-def _unixepoch(arg, from_, to):
+def _unixepoch(arg, from_, to, **_):
     return sa.func.datetime(arg, "unixepoch")
 
 
 @sqlite_cast.register(object, dt.String, dt.Timestamp)
-def _string_to_timestamp(arg, from_, to):
+def _string_to_timestamp(arg, from_, to, **_):
     return sa.func.strftime('%Y-%m-%d %H:%M:%f', arg)
 
 
 @sqlite_cast.register(object, dt.Integer, dt.Date)
-def _integer_to_date(arg, from_, to):
+def _integer_to_date(arg, from_, to, **_):
     return sa.func.date(sa.func.datetime(arg, "unixepoch"))
 
 
 @sqlite_cast.register(object, (dt.String, dt.Timestamp), dt.Date)
-def _string_or_timestamp_to_date(arg, from_, to):
+def _string_or_timestamp_to_date(arg, from_, to, **_):
     return sa.func.date(arg)
 
 
 @sqlite_cast.register(object, dt.DataType, (dt.Date, dt.Timestamp))
-def _value_to_temporal(arg, from_, to):
+def _value_to_temporal(arg, from_, to, **_):
     raise com.UnsupportedOperationError(type(arg))
 
 
 @sqlite_cast.register(object, dt.Category, dt.Int32)
-def _category_to_int(arg, from_, to):
+def _category_to_int(arg, from_, to, **_):
     return arg
 
 
 @sqlite_cast.register(object, dt.DataType, dt.DataType)
-def _default_cast_impl(arg, from_, to):
-    return sa.cast(arg, to_sqla_type(to))
+def _default_cast_impl(arg, from_, to, translator=None):
+    assert translator is not None, "translator is None"
+    return sa.cast(arg, translator.get_sqla_type(to))
 
 
 def _strftime_int(fmt):
@@ -190,7 +190,9 @@ operation_registry.update(
         # TODO(kszucs): don't dispatch on op.arg since that should be always an
         # instance of ops.Value
         ops.Cast: (
-            lambda t, op: sqlite_cast(t.translate(op.arg), op.arg.output_dtype, op.to)
+            lambda t, op: sqlite_cast(
+                t.translate(op.arg), op.arg.output_dtype, op.to, translator=t
+            )
         ),
         ops.StrRight: fixed_arity(
             lambda arg, nchars: sa.func.substr(arg, -nchars, nchars), 2

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -24,10 +24,9 @@ sa = pytest.importorskip("sqlalchemy")
             lambda t: t.double_col.cast(dt.int8),
             lambda at: sa.cast(at.c.double_col, sa.SMALLINT),
         ),
-        # TODO(kszucs): double check the validity of this test case
         (
             lambda t: t.string_col.cast(dt.float64),
-            lambda at: sa.cast(at.c.string_col, sa.FLOAT),
+            lambda at: sa.cast(at.c.string_col, sa.REAL),
         ),
         (
             lambda t: t.string_col.cast(dt.float32),

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -150,11 +150,11 @@ unnest = toolz.compose(
 
 @builtin_array
 @pytest.mark.never(
-    ["clickhouse", "pandas", "pyspark", "snowflake", "polars"],
+    ["clickhouse", "duckdb", "pandas", "pyspark", "snowflake", "polars"],
     reason="backend does not flatten array types",
 )
 @pytest.mark.never(["bigquery"], reason="doesn't support arrays of arrays")
-def test_array_discovery_postgres_duckdb(con):
+def test_array_discovery_postgres(con):
     t = con.table("array_types")
     expected = ibis.schema(
         dict(
@@ -195,8 +195,7 @@ def test_array_discovery_clickhouse(con):
 
 @builtin_array
 @pytest.mark.notyet(
-    ["clickhouse", "duckdb", "postgres"],
-    reason="backend does not support nullable nested types",
+    ["clickhouse", "postgres"], reason="backend does not support nullable nested types"
 )
 @pytest.mark.notimpl(
     ["trino"],

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -463,7 +463,7 @@ def test_temporal_binop_pandas_timedelta(
 
 
 @pytest.mark.parametrize("func_name", ["gt", "ge", "lt", "le", "eq", "ne"])
-@pytest.mark.notimpl(["bigquery", "mssql"])
+@pytest.mark.notimpl(["bigquery"])
 def test_timestamp_comparison_filter(backend, con, alltypes, df, func_name):
     ts = pd.Timestamp('20100302', tz="UTC").to_pydatetime()
 
@@ -490,7 +490,7 @@ def test_timestamp_comparison_filter(backend, con, alltypes, df, func_name):
         "ne",
     ],
 )
-@pytest.mark.notimpl(["bigquery", "mssql"])
+@pytest.mark.notimpl(["bigquery"])
 def test_timestamp_comparison_filter_numpy(backend, con, alltypes, df, func_name):
     ts = np.datetime64('2010-03-02 00:00:00.000123')
 
@@ -993,21 +993,12 @@ def test_large_timestamp(con):
             id="ns",
             marks=[
                 pytest.mark.broken(
-                    [
-                        "clickhouse",
-                        "duckdb",
-                        "impala",
-                        "mssql",
-                        "postgres",
-                        "pyspark",
-                        "sqlite",
-                        "trino",
-                    ],
+                    ["clickhouse", "duckdb", "impala", "pyspark", "trino"],
                     reason="drivers appear to truncate nanos",
                 ),
                 pytest.mark.notyet(
-                    ["bigquery"],
-                    reason="bigquery doesn't support nanosecond timestamps",
+                    ["bigquery", "mssql", "postgres", "sqlite"],
+                    reason="doesn't support nanoseconds",
                 ),
             ],
         ),

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -10,7 +10,6 @@ from ibis.backends.trino.registry import operation_registry
 class TrinoSQLExprTranslator(AlchemyExprTranslator):
     _registry = operation_registry.copy()
     _rewrites = AlchemyExprTranslator._rewrites.copy()
-    _type_map = AlchemyExprTranslator._type_map.copy()
     _has_reduction_filter_syntax = True
     integer_to_timestamp = sa.func.from_unixtime
     _forbids_frame_clause = (
@@ -23,6 +22,7 @@ class TrinoSQLExprTranslator(AlchemyExprTranslator):
         ops.Lag,
         ops.Lead,
     )
+    _dialect_name = "trino"
 
 
 rewrites = TrinoSQLExprTranslator.rewrites

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -103,6 +103,20 @@ class TestConf(BackendTest, RoundAwayFromZero):
                     "INSERT INTO map VALUES (MAP(ARRAY['d', 'e', 'f'], ARRAY[4, 5, 6]))"
                 )
             )
+            c.execute(sa.text("DROP TABLE IF EXISTS ts"))
+            c.execute(
+                sa.text(
+                    "CREATE TABLE ts (x TIMESTAMP(3), y TIMESTAMP(6), z TIMESTAMP(9))"
+                )
+            )
+            c.execute(
+                sa.text(
+                    "INSERT INTO ts VALUES "
+                    "(TIMESTAMP '2023-01-07 13:20:05.561', "
+                    " TIMESTAMP '2023-01-07 13:20:05.561021', "
+                    " TIMESTAMP '2023-01-07 13:20:05.561000231')"
+                )
+            )
 
     @staticmethod
     def connect(data_directory: Path):

--- a/ibis/common/parsing.py
+++ b/ibis/common/parsing.py
@@ -23,6 +23,7 @@ def spaceless_string(*strings: str):
 
 
 RAW_NUMBER = parsy.decimal_digit.at_least(1).concat()
+SINGLE_DIGIT = parsy.decimal_digit
 PRECISION = SCALE = NUMBER = RAW_NUMBER.map(int)
 
 LPAREN = spaceless_string("(")

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -344,14 +344,18 @@ class Timestamp(Temporal):
     timezone = optional(instance_of(str))
     """The timezone of values of this type."""
 
+    scale = optional(isin(range(10)))
+    """The scale of the timestamp if known."""
+
     scalar = ir.TimestampScalar
     column = ir.TimestampColumn
 
     @property
     def _pretty_piece(self) -> str:
-        if (timezone := self.timezone) is not None:
-            return f"({timezone!r})"
-        return ""
+        pieces = [
+            repr(piece) for piece in (self.scale, self.timezone) if piece is not None
+        ]
+        return f"({', '.join(pieces)})" * bool(pieces)
 
 
 @public

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -7,6 +7,7 @@ import string
 import numpy as np
 import pandas as pd
 import pytest
+import sqlalchemy as sa
 from packaging.version import parse as vparse
 
 import ibis
@@ -188,7 +189,10 @@ def test_compile(benchmark, module, expr_fn, t, base, large_expr):
         pytest.skip(str(e))
     else:
         expr = expr_fn(t, base, large_expr)
-        benchmark(mod.compile, expr)
+        try:
+            benchmark(mod.compile, expr)
+        except sa.exc.NoSuchModuleError as e:
+            pytest.skip(str(e))
 
 
 @pytest.fixture(scope="module")
@@ -691,7 +695,10 @@ def test_compile_with_drops(
     except (AttributeError, ImportError) as e:
         pytest.skip(str(e))
     else:
-        benchmark(mod.compile, expr)
+        try:
+            benchmark(mod.compile, expr)
+        except sa.exc.NoSuchModuleError as e:
+            pytest.skip(str(e))
 
 
 def test_repr_join(benchmark, customers, orders, orders_items, products):

--- a/ibis/tests/expr/test_datatypes.py
+++ b/ibis/tests/expr/test_datatypes.py
@@ -364,7 +364,7 @@ def test_timestamp_with_invalid_timezone():
 
 def test_timestamp_with_timezone_repr():
     ts = dt.Timestamp('UTC')
-    assert repr(ts) == "Timestamp(timezone='UTC', nullable=True)"
+    assert repr(ts) == "Timestamp(timezone='UTC', scale=None, nullable=True)"
 
 
 def test_timestamp_with_timezone_str():
@@ -530,6 +530,19 @@ def test_struct_datatype_subclass_from_tuples():
 
 def test_parse_null():
     assert dt.parse("null") == dt.null
+
+
+@pytest.mark.parametrize("scale", range(10))
+@pytest.mark.parametrize("tz", ["UTC", "America/New_York"])
+def test_timestamp_with_scale(scale, tz):
+    assert dt.parse(f"timestamp({tz!r}, {scale:d})") == dt.Timestamp(
+        timezone=tz, scale=scale
+    )
+
+
+@pytest.mark.parametrize("scale", range(10))
+def test_timestamp_with_scale_no_tz(scale):
+    assert dt.parse(f"timestamp({scale:d})") == dt.Timestamp(scale=scale)
 
 
 def get_leaf_classes(op):

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -29,6 +29,7 @@ from ibis.backends.base.sql.alchemy import (
     schema_from_table,
     to_sqla_type,
 )
+from ibis.backends.base.sql.alchemy.datatypes import ArrayType
 from ibis.tests.expr.mocks import MockAlchemyBackend
 from ibis.tests.util import assert_decompile_roundtrip, assert_equal
 
@@ -1107,7 +1108,7 @@ def test_to_sqla_type_array_of_non_primitive():
     expected_type = sa.BigInteger()
     assert result_name == expected_name
     assert type(result_type) == type(expected_type)
-    assert isinstance(result, sa.ARRAY)
+    assert isinstance(result, ArrayType)
 
 
 def test_no_cart_join(con, snapshot):

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -19,6 +19,7 @@ from pytest import param
 from sqlalchemy import func as F
 from sqlalchemy import sql
 from sqlalchemy import types as sat
+from sqlalchemy.engine.default import DefaultDialect
 
 import ibis
 import ibis.expr.datatypes as dt
@@ -1098,8 +1099,10 @@ def test_tpc_h11(h11):
 
 
 def test_to_sqla_type_array_of_non_primitive():
-    result = to_sqla_type(dt.Array(dt.Struct.from_dict(dict(a="int"))))
-    [(result_name, result_type)] = result.item_type.pairs
+    result = to_sqla_type(
+        DefaultDialect(), dt.Array(dt.Struct.from_dict(dict(a="int")))
+    )
+    [(result_name, result_type)] = result.value_type.pairs
     expected_name = "a"
     expected_type = sa.BigInteger()
     assert result_name == expected_name


### PR DESCRIPTION
This PR adds a `scale` parameter to the `Timestamp` type.

The need for this has come up a few times, so I took the nerd bait and implemented it.

The primary reason to support these is for more precise inference to and from the backend
as well as in the case of #5143, where it's simply not possible to choose a default timestamp precision.

Since some backends don't support precision we need to be able to convert ibis types to sqlalchemy types
based on the dialect *and* the type.

As part of supporting that, it unlocked the ability to properly infer nested array
types (arrays of arrays) for the postgres-based backends that support arrays.

Previously we depended on the SQLAlchemy `postgresql.ARRAY` behavior which collapses everything into a single dimensional array.

Fixes #5143.
