### PR TITLE
fix(polars): workaround failing cast of null to struct

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -84,6 +84,8 @@ def literal(op):
         return pl.struct(values)
     elif op.dtype.is_interval():
         return _make_duration(op.value, op.dtype)
+    elif op.dtype.is_null():
+        return pl.lit(op.value)
     else:
         typ = to_polars_type(op.dtype)
         return pl.lit(op.value, dtype=typ)
@@ -865,7 +867,7 @@ def between(op):
     arg = translate(op.arg)
     lower = translate(op.lower_bound)
     upper = translate(op.upper_bound)
-    return arg.is_between(lower, upper)
+    return arg.is_between(lower, upper, closed="both")
 
 
 _bitwise_binops = {

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -114,7 +114,17 @@ def test_column_fillna(backend, alltypes, value):
 @pytest.mark.parametrize(
     ('expr', 'expected'),
     [
-        param(ibis.coalesce(5, None, 4), 5, id="generic"),
+        param(
+            ibis.coalesce(5, None, 4),
+            5,
+            id="generic",
+            marks=[
+                pytest.mark.broken(
+                    "polars",
+                    reason="implementation error, cannot get ref Int8 from Boolean",
+                ),
+            ],
+        ),
         param(ibis.coalesce(ibis.NA, 4, ibis.NA), 4, id="null_start_end"),
         param(
             ibis.coalesce(ibis.NA, ibis.NA, 3.14),

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
-from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
@@ -64,18 +63,7 @@ def test_literal(con, field):
 
 
 @pytest.mark.notimpl(["postgres", "snowflake"])
-@pytest.mark.parametrize(
-    "field",
-    [
-        "a",
-        param(
-            "b", marks=pytest.mark.broken(["polars"], reason="polars incorrectly fails")
-        ),
-        param(
-            "c", marks=pytest.mark.broken(["polars"], reason="polars incorrectly fails")
-        ),
-    ],
-)
+@pytest.mark.parametrize("field", ["a", "b", "c"])
 @pytest.mark.notyet(
     ["clickhouse"], reason="clickhouse doesn't support nullable nested types"
 )

--- a/poetry.lock
+++ b/poetry.lock
@@ -3140,18 +3140,18 @@ plugin = ["poetry (>=1.2.0,<2.0.0)"]
 
 [[package]]
 name = "polars"
-version = "0.15.8"
+version = "0.15.13"
 description = "Blazingly fast DataFrame library"
 category = "main"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "polars-0.15.8-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:52fe1ad725574b03643c1f9da6a68c7dd5391da885fd4cc4bd15dead94558620"},
-    {file = "polars-0.15.8-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:50a68a13c9567b8196eb66a0e1c76697f2005299e4ca1301007a69fb6cd13a4c"},
-    {file = "polars-0.15.8-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20722c1e6395a547abb83166e2f8bef3bed925e9737922e95baa634f6405343e"},
-    {file = "polars-0.15.8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:224437629ddadf8ac96569fc10514eb41dceb35b8973858b711e402fd819641f"},
-    {file = "polars-0.15.8-cp37-abi3-win_amd64.whl", hash = "sha256:9277ef3e619382575af6a60c8083ce41cb53b999acbd9a1bddd4666c88d7abc7"},
-    {file = "polars-0.15.8.tar.gz", hash = "sha256:379babe82b67982964ed3002ec4742dcfc2616d1da85582214cfe9d68f8068b0"},
+    {file = "polars-0.15.13-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:db5432ff0ab753e21d9b3f4c483015f1dd82410cadd56d11e9862beb10b2ce00"},
+    {file = "polars-0.15.13-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:b098cb93b3ca7509a9e8b3abe56c6e27077ddbf88f69b5320c722cbe3bf8e1f2"},
+    {file = "polars-0.15.13-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a054f57b2d7f5efc0aba751b5c7d607ce9bb45cca5a02a1745a91dff50a4ed9a"},
+    {file = "polars-0.15.13-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3df64485cc143ffe98c6941e7b2ae9ae25e4efa2044f4115bb99ab8ec7ccea0c"},
+    {file = "polars-0.15.13-cp37-abi3-win_amd64.whl", hash = "sha256:cb4edfd07c1ea53643656cd792519d26870520e8f7b3162f32d300023f2007cb"},
+    {file = "polars-0.15.13.tar.gz", hash = "sha256:14b6c64283b5804ff78c30f04c331b901adefe4a834b416cadd6c52b81da3afd"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Fixes a bug with newer versions of polars that are currently segfaulting when casting a null literal to struct.