### PR TITLE
chore: remove warning in extending tutorial

### DIFF
--- a/docs/user_guide/extending/elementwise.ipynb
+++ b/docs/user_guide/extending/elementwise.ipynb
@@ -138,7 +138,7 @@
     "@ibis.sqlite.add_operation(JulianDay)\n",
     "def _julianday(translator, expr):\n",
     "    # pull out the arguments to the expression\n",
-    "    (arg,) = expr.op().args\n",
+    "    (arg,) = expr.args\n",
     "\n",
     "    # compile the argument\n",
     "    compiled_arg = translator.translate(arg)\n",


### PR DESCRIPTION
It was easier for me to just make a new PR from #5151 than to actuall pull locally and `git commit --amend`.

Before, I would get

```
/var/folders/nz/wfwcn6md1796t48tx9dhf0v40000gn/T/ipykernel_98244/3752312616.py:26: FutureWarning: `Node.op` is deprecated as of v4.0; remove intermediate .op() calls
  (arg,) = expr.op().args
```

After this change, I don't.