### PR TITLE
test(backend): add tests for ops.DecimalPrecision, ops.DecimalScale

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -686,6 +686,8 @@ _invalid_operations = {
     ops.FindInSet,
     ops.DateDiff,
     ops.TimestampDiff,
+    ops.DecimalPrecision,
+    ops.DecimalScale
 }
 
 OPERATION_REGISTRY = {

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -184,6 +184,11 @@ class BasePandasBackend(BaseBackend):
         # exclude these operations.
         if issubclass(operation, (ops.GeoSpatialUnOp, ops.GeoSpatialBinOp)):
             return False
+        # Pandas doesn't support ops.DecimalPrecision, ops.DecimalScale ops,
+        # but the dispatcher implements a common base class (ops.Unary) that
+        # makes it appear that it does. Explicitly exclude these operations.
+        if issubclass(operation, (ops.DecimalPrecision, ops.DecimalScale)):
+            return False
         op_classes = cls._get_operations()
         return operation in op_classes or any(
             issubclass(operation, op_impl) for op_impl in op_classes

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -221,6 +221,13 @@ def execute_series_group_by_negate(op, data, **kwargs):
     )
 
 
+@execute_node.register((ops.DecimalPrecision, ops.DecimalScale), pd.Series)
+def execute_decision(op, **kwargs):
+    raise NotImplementedError(
+        f"Operation {type(op).__name__!r} is not implemented for this backend"
+    )
+
+
 @execute_node.register(ops.Unary, pd.Series)
 def execute_series_unary_op(op, data, **kwargs):
     function = getattr(np, type(op).__name__.lower())

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -837,11 +837,14 @@ def day_of_week_name(op):
     return arg
 
 
-@translate.register(ops.Unary)
 def unary(op):
     arg = translate(op.arg)
     func = _unary[type(op)]
     return func(arg)
+
+
+for op_type in _unary:
+    translate.register(op_type, unary)
 
 
 _comparisons = {

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -174,7 +174,7 @@ def test_isnan_isinf(
         param(L(11) % 3, 11 % 3, id='mod'),
         param(
             L(12.3).cast(dt.Decimal(30, 8)).precision(),
-            30,
+            8,
             id='scale',
             marks=[
                 # Only impala support .scale()
@@ -200,7 +200,7 @@ def test_isnan_isinf(
         ),
         param(
             L(12.3).cast(dt.Decimal(30, 8)).precision(),
-            8,
+            30,
             id='precision',
             marks=[
                 # Only impala support .precision()

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -172,6 +172,58 @@ def test_isnan_isinf(
             marks=pytest.mark.notimpl(["datafusion", "impala"]),
         ),
         param(L(11) % 3, 11 % 3, id='mod'),
+        param(
+            L(12.3).cast(dt.Decimal(30, 8)).precision(),
+            30,
+            id='scale',
+            marks=[
+                # Only impala support .scale()
+                pytest.mark.notimpl(
+                    [
+                        "bigquery",
+                        "clickhouse",
+                        "dask",
+                        "datafusion",
+                        "duckdb",
+                        "mssql",
+                        "mysql",
+                        "pandas",
+                        "polars",
+                        "postgres",
+                        "pyspark",
+                        "snowflake",
+                        "sqlite",
+                        "trino",
+                    ]
+                )
+            ],
+        ),
+        param(
+            L(12.3).cast(dt.Decimal(30, 8)).precision(),
+            8,
+            id='precision',
+            marks=[
+                # Only impala support .precision()
+                pytest.mark.notimpl(
+                    [
+                        "bigquery",
+                        "clickhouse",
+                        "dask",
+                        "datafusion",
+                        "duckdb",
+                        "mssql",
+                        "mysql",
+                        "pandas",
+                        "polars",
+                        "postgres",
+                        "pyspark",
+                        "snowflake",
+                        "sqlite",
+                        "trino",
+                    ]
+                )
+            ],
+        ),
     ],
 )
 def test_math_functions_literals(con, expr, expected):


### PR DESCRIPTION
Hello,

I am not convinced that this is implemented in any backend, but I want to check it on CI.