### PR TITLE
refactor: uncouple `MultiQuantile` class from `Quantile`

### DIFF
--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -129,7 +129,7 @@ class Quantile(Filterable, Reduction):
 
 
 @public
-class MultiQuantile(Quantile):
+class MultiQuantile(Filterable, Reduction):
     arg = rlz.any
     quantile = rlz.value(dt.Array(dt.float64))
     interpolation = rlz.isin({'linear', 'lower', 'higher', 'midpoint', 'nearest'})


### PR DESCRIPTION
This PR uncouples `MultiQuantile` from `Quantile`. Since the MultiQuantile class shares nothing with Quantile, there is no reason for it to subclass Quantile.