### PR TITLE
feat(trino): add `approx_median`, math ops and `ifnull`-like operations

### DIFF
--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -473,9 +473,9 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             id='bit_xor',
             marks=[
                 pytest.mark.notimpl(
-                    ["dask", "snowflake", "polars", "datafusion", "mssql", "trino"]
+                    ["dask", "snowflake", "polars", "datafusion", "mssql"]
                 ),
-                pytest.mark.notyet(["impala", "pyspark"]),
+                pytest.mark.notyet(["impala", "pyspark", "trino"]),
             ],
         ),
         param(
@@ -826,13 +826,7 @@ def test_topk_filter_op(alltypes, df, result_fn, expected_fn):
     assert result.shape[0] == expected.shape[0]
 
 
-@pytest.mark.parametrize(
-    'agg_fn',
-    [
-        param(lambda s: list(s), id='agg_to_list'),
-        param(lambda s: np.array(s), id='agg_to_ndarray'),
-    ],
-)
+@pytest.mark.parametrize('agg_fn', [list, np.array])
 @mark.notimpl(
     [
         "bigquery",

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -475,7 +475,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                 pytest.mark.notimpl(
                     ["dask", "snowflake", "polars", "datafusion", "mssql"]
                 ),
-                pytest.mark.notyet(["impala", "pyspark", "trino"]),
+                pytest.mark.notyet(["impala", "pyspark"]),
             ],
         ),
         param(
@@ -826,7 +826,9 @@ def test_topk_filter_op(alltypes, df, result_fn, expected_fn):
     assert result.shape[0] == expected.shape[0]
 
 
-@pytest.mark.parametrize('agg_fn', [list, np.array])
+@pytest.mark.parametrize(
+    'agg_fn', [lambda s: list(s), lambda s: np.array(s)], ids=lambda obj: obj.__name__
+)
 @mark.notimpl(
     [
         "bigquery",

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -691,7 +691,6 @@ def test_corr_cov(
         "sqlite",
         "snowflake",
         "mssql",
-        "trino",
     ]
 )
 def test_approx_median(alltypes):

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -22,13 +22,13 @@ from ibis import literal as L
         param(
             ibis.NA.fillna(5),
             5,
-            marks=pytest.mark.notimpl(["mssql", "trino"]),
+            marks=pytest.mark.notimpl(["mssql"]),
             id="na_fillna",
         ),
         param(
             L(5).fillna(10),
             5,
-            marks=pytest.mark.notimpl(["mssql", "trino"]),
+            marks=pytest.mark.notimpl(["mssql"]),
             id="non_na_fillna",
         ),
         param(L(5).nullif(5), None, id="nullif_null"),
@@ -54,7 +54,7 @@ def test_scalar_fillna_nullif(con, expr, expected):
         param(
             "nan_col",
             _.nan_col.isnan(),
-            marks=pytest.mark.notimpl(["datafusion", "mysql", "sqlite", "trino"]),
+            marks=pytest.mark.notimpl(["datafusion", "mysql", "sqlite"]),
             id="nan_col",
         ),
         param(
@@ -94,6 +94,7 @@ def test_isna(backend, alltypes, col, filt):
                     "mysql",
                     "snowflake",
                     "polars",
+                    "trino",
                 ],
                 reason="NaN != NULL for these backends",
             ),
@@ -101,7 +102,7 @@ def test_isna(backend, alltypes, col, filt):
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "mssql", "trino"])
+@pytest.mark.notimpl(["datafusion", "mssql"])
 def test_column_fillna(backend, alltypes, value):
     table = alltypes.mutate(missing=ibis.literal(value).cast("float64"))
     pd_table = table.execute()
@@ -312,7 +313,7 @@ def test_case_where(backend, alltypes, df):
 
 
 # TODO: some of these are notimpl (datafusion) others are probably never
-@pytest.mark.notimpl(["datafusion", "mysql", "sqlite", "mssql", "trino"])
+@pytest.mark.notimpl(["datafusion", "mysql", "sqlite", "mssql"])
 @pytest.mark.min_version(duckdb="0.3.3", reason="isnan/isinf unsupported")
 def test_select_filter_mutate(backend, alltypes, df):
     """Test that select, filter and mutate are executed in right order.
@@ -366,7 +367,7 @@ def test_table_fillna_invalid(alltypes):
         {"double_col": -1.5, "string_col": "missing"},
     ],
 )
-@pytest.mark.notimpl(["datafusion", "mssql", "trino", "clickhouse"])
+@pytest.mark.notimpl(["datafusion", "mssql", "clickhouse"])
 def test_table_fillna_mapping(backend, alltypes, replacements):
     table = alltypes.mutate(
         int_col=alltypes.int_col.nullif(1),
@@ -381,7 +382,7 @@ def test_table_fillna_mapping(backend, alltypes, replacements):
     backend.assert_frame_equal(result, expected, check_dtype=False)
 
 
-@pytest.mark.notimpl(["datafusion", "mssql", "trino", "clickhouse"])
+@pytest.mark.notimpl(["datafusion", "mssql", "clickhouse"])
 def test_table_fillna_scalar(backend, alltypes):
     table = alltypes.mutate(
         int_col=alltypes.int_col.nullif(1),

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -51,7 +51,7 @@ except ImportError:
         param(operator.methodcaller('isinf'), np.isinf, id='isinf'),
     ],
 )
-@pytest.mark.notimpl(["mysql", "sqlite", "datafusion", "mssql", "trino"])
+@pytest.mark.notimpl(["mysql", "sqlite", "datafusion", "mssql"])
 @pytest.mark.xfail(
     duckdb is not None and vparse(duckdb.__version__) < vparse("0.3.3"),
     reason="<0.3.3 does not support isnan/isinf properly",
@@ -140,7 +140,7 @@ def test_isnan_isinf(
             L(5.556).log(2),
             math.log(5.556, 2),
             id='log-base',
-            marks=pytest.mark.notimpl(["datafusion", "trino"]),
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             L(5.556).ln(),
@@ -151,13 +151,11 @@ def test_isnan_isinf(
             L(5.556).log2(),
             math.log(5.556, 2),
             id='log2',
-            marks=pytest.mark.notimpl(["trino"]),
         ),
         param(
             L(5.556).log10(),
             math.log10(5.556),
             id='log10',
-            marks=pytest.mark.notimpl(["trino"]),
         ),
         param(
             L(5.556).radians(),
@@ -300,7 +298,7 @@ def test_simple_math_functions_columns(
             lambda t: t.double_col.add(1).log(2),
             lambda t: np.log2(t.double_col + 1),
             id='log2',
-            marks=pytest.mark.notimpl(["datafusion", "trino"]),
+            marks=pytest.mark.notimpl(["datafusion"]),
         ),
         param(
             lambda t: t.double_col.add(1).ln(),
@@ -311,7 +309,6 @@ def test_simple_math_functions_columns(
             lambda t: t.double_col.add(1).log10(),
             lambda t: np.log10(t.double_col + 1),
             id='log10',
-            marks=pytest.mark.notimpl(["trino"]),
         ),
         param(
             lambda t: (t.double_col + 1).log(
@@ -324,7 +321,7 @@ def test_simple_math_functions_columns(
                 np.log(t.double_col + 1) / np.log(np.maximum(9_000, t.bigint_col))
             ),
             id="log_base_bigint",
-            marks=pytest.mark.notimpl(["clickhouse", "datafusion", "polars", "trino"]),
+            marks=pytest.mark.notimpl(["clickhouse", "datafusion", "polars"]),
         ),
     ],
 )
@@ -450,13 +447,11 @@ def test_floating_mod(backend, alltypes, df):
         'bigint_col',
         pytest.param(
             'float_col',
-            marks=[
-                pytest.mark.broken(
-                    "polars",
-                    strict=False,
-                    reason="output types is float64 instead of the expected float32",
-                )
-            ],
+            marks=pytest.mark.broken(
+                "polars",
+                strict=False,
+                reason="output type is float64 instead of the expected float32",
+            ),
         ),
         'double_col',
     ],

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -483,12 +483,12 @@ def test_divide_by_zero(backend, alltypes, df, column, denominator):
     ("default_precisions", "default_scales"),
     [
         (
-            {'postgres': None, 'mysql': 10, 'snowflake': 38},
-            {'postgres': None, 'mysql': 0, 'snowflake': 0},
+            {'postgres': None, 'mysql': 10, 'snowflake': 38, 'trino': 18},
+            {'postgres': None, 'mysql': 0, 'snowflake': 0, 'trino': 3},
         )
     ],
 )
-@pytest.mark.notimpl(["sqlite", "duckdb", "mssql", "trino"])
+@pytest.mark.notimpl(["sqlite", "duckdb", "mssql"])
 @pytest.mark.never(
     [
         "bigquery",

--- a/ibis/backends/trino/datatypes.py
+++ b/ibis/backends/trino/datatypes.py
@@ -175,3 +175,8 @@ def compiles_map(typ, compiler, **kw):
     key_type = compiler.process(typ.key_type, **kw)
     value_type = compiler.process(typ.value_type, **kw)
     return f"MAP({key_type}, {value_type})"
+
+
+@dt.dtype.register(TrinoDialect, sa.NUMERIC)
+def sa_trino_numeric(_, satype, nullable=True):
+    return dt.Decimal(satype.precision or 18, satype.scale or 3, nullable=nullable)

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -175,6 +175,14 @@ operation_registry.update(
         ops.GroupConcat: _group_concat,
         ops.BitAnd: reduction(sa.func.bitwise_and_agg),
         ops.BitOr: reduction(sa.func.bitwise_or_agg),
+        ops.BitXor: reduction(
+            lambda arg: sa.func.reduce_agg(
+                arg,
+                0,
+                sa.text("(a, b) -> bitwise_xor(a, b)"),
+                sa.text("(a, b) -> bitwise_xor(a, b)"),
+            )
+        ),
         ops.BitwiseAnd: fixed_arity(sa.func.bitwise_and, 2),
         ops.BitwiseOr: fixed_arity(sa.func.bitwise_or, 2),
         ops.BitwiseXor: fixed_arity(sa.func.bitwise_xor, 2),

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -240,6 +240,13 @@ operation_registry.update(
             sa.func.row(*map(t.translate, op.values)), to_sqla_type(op.output_dtype)
         ),
         ops.Literal: _literal,
+        ops.IfNull: fixed_arity(sa.func.coalesce, 2),
+        ops.ZeroIfNull: unary(lambda value: sa.func.coalesce(value, 0)),
+        ops.IsNan: unary(sa.func.is_nan),
+        ops.IsInf: unary(sa.func.is_infinite),
+        ops.Log: fixed_arity(lambda arg, base: sa.func.log(base, arg), 2),
+        ops.Log2: unary(sa.func.log2),
+        ops.Log10: unary(sa.func.log10),
         ops.MapLength: unary(sa.func.cardinality),
         ops.MapGet: fixed_arity(
             lambda arg, key, default: sa.func.coalesce(

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -166,6 +166,7 @@ operation_registry.update(
         ops.ExtractMillisecond: unary(sa.func.millisecond),
         ops.Arbitrary: _arbitrary,
         ops.ApproxCountDistinct: reduction(sa.func.approx_distinct),
+        ops.ApproxMedian: reduction(lambda arg: sa.func.approx_percentile(arg, 0.5)),
         ops.RegexExtract: fixed_arity(sa.func.regexp_extract, 3),
         ops.RegexReplace: fixed_arity(sa.func.regexp_replace, 3),
         ops.RegexSearch: fixed_arity(


### PR DESCRIPTION
Add some more missing operations for the trino backend.