### PR TITLE
refactor(ir): remove DecimalValue.precision(), DecimalValue.scale() method

### DIFF
--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -297,8 +297,6 @@ operation_registry = {
     ops.Tan: unary("tan"),
     ops.Pi: fixed_arity("pi", 0),
     ops.E: fixed_arity("exp(1)", 0),
-    ops.DecimalPrecision: unary('precision'),
-    ops.DecimalScale: unary('scale'),
     # Unary aggregates
     ops.ApproxMedian: aggregate.reduction('appx_median'),
     ops.ApproxCountDistinct: aggregate.reduction('ndv'),

--- a/ibis/backends/impala/tests/test_value_exprs.py
+++ b/ibis/backends/impala/tests/test_value_exprs.py
@@ -31,16 +31,6 @@ def test_literals(value, snapshot):
     snapshot.assert_match(result, "out.sql")
 
 
-@pytest.mark.parametrize("method_name", ["precision", "scale"])
-def test_decimal_builtins(mockcon, method_name, snapshot):
-    t = mockcon.table('tpch_lineitem')
-    col = t.l_extendedprice
-    method = getattr(col, method_name)
-    expr = method()
-    result = translate(expr)
-    snapshot.assert_match(result, "out.sql")
-
-
 def test_column_ref_table_aliases(snapshot):
     context = ImpalaCompiler.make_context()
 

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -258,18 +258,6 @@ class Pi(Constant):
 
 
 @public
-class DecimalPrecision(Unary):
-    arg = rlz.decimal
-    output_dtype = dt.int32
-
-
-@public
-class DecimalScale(Unary):
-    arg = rlz.decimal
-    output_dtype = dt.int32
-
-
-@public
 class Hash(Value):
     arg = rlz.any
     how = rlz.isin({'fnv', 'farm_fingerprint'})

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -786,25 +786,7 @@ class FloatingColumn(NumericColumn, FloatingValue):
 
 @public
 class DecimalValue(NumericValue):
-    def precision(self) -> IntegerValue:
-        """Return the precision of `arg`.
-
-        Returns
-        -------
-        IntegerValue
-            The precision of the expression.
-        """
-        return ops.DecimalPrecision(self).to_expr()
-
-    def scale(self) -> IntegerValue:
-        """Return the scale of `arg`.
-
-        Returns
-        -------
-        IntegerValue
-            The scale of the expression.
-        """
-        return ops.DecimalScale(self).to_expr()
+    pass
 
 
 @public

--- a/ibis/tests/expr/test_decimal.py
+++ b/ibis/tests/expr/test_decimal.py
@@ -4,7 +4,6 @@ import pytest
 
 import ibis
 import ibis.expr.datatypes as dt
-import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.expr import api
 

--- a/ibis/tests/expr/test_decimal.py
+++ b/ibis/tests/expr/test_decimal.py
@@ -113,19 +113,6 @@ def test_fillna(lineitem):
     assert isinstance(expr, ir.DecimalColumn)
 
 
-def test_precision_scale(lineitem):
-    col = lineitem.l_extendedprice
-
-    p = col.precision()
-    s = col.scale()
-
-    assert isinstance(p, ir.IntegerValue)
-    assert isinstance(p.op(), ops.DecimalPrecision)
-
-    assert isinstance(s, ir.IntegerValue)
-    assert isinstance(s.op(), ops.DecimalScale)
-
-
 @pytest.mark.parametrize(
     ('precision', 'scale'),
     [


### PR DESCRIPTION
Hello,

This API is only implemented by one backend, and there is an alternative method to obtain this information.
See: https://github.com/ibis-project/ibis/pull/5156#discussion_r1064000868

Best regards,