### PR TITLE
feat(api): return object from `to_sql` to support notebook syntax highlighting

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -737,10 +737,7 @@ def test_default_backend_no_duckdb(backend):
     # run this twice to ensure that we hit the optimizations in
     # `_default_backend`
     for _ in range(2):
-        with pytest.raises(
-            com.IbisError,
-            match="Expression depends on no backends",
-        ):
+        with pytest.raises(com.IbisError, match="Expression depends on no backends"):
             expr.execute()
 
 
@@ -756,7 +753,7 @@ def test_default_backend():
     for _ in range(2):
         assert expr.execute() == df.a.sum()
 
-    sql = ibis.to_sql(expr)
+    sql = str(ibis.to_sql(expr))
     rx = """\
 SELECT
   SUM\\((\\w+)\\.a\\) AS ".+"

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -321,8 +321,29 @@ def show_sql(
     print(to_sql(expr, dialect=dialect), file=file)
 
 
+class SQLString:
+    """Object to hold a formatted SQL string.
+
+    Syntax highlights in Jupyter notebooks.
+    """
+
+    __slots__ = ("sql",)
+
+    def __init__(self, sql: str) -> None:
+        self.sql = sql
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(sql={self.sql!r})"
+
+    def __str__(self) -> str:
+        return self.sql
+
+    def _repr_markdown_(self) -> str:
+        return f"```sql\n{str(self)}\n```"
+
+
 @public
-def to_sql(expr: ir.Expr, dialect: str | None = None) -> str:
+def to_sql(expr: ir.Expr, dialect: str | None = None) -> SQLString:
     """Return the formatted SQL string for an expression.
 
     Parameters
@@ -366,5 +387,4 @@ def to_sql(expr: ir.Expr, dialect: str | None = None) -> str:
 
     assert isinstance(sql, str), f"expected `str`, got `{sql.__class__.__name__}`"
     (pretty,) = sg.transpile(sql, read=read, write=write, pretty=True)
-
-    return pretty
+    return SQLString(pretty)


### PR DESCRIPTION
Add a custom `SQLString` object that formats with syntax highlighting in the notebook.