### PR TITLE
fix(bigquery): fix integer to timestamp casting

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -44,6 +44,12 @@ def bigquery_cast_timestamp_to_integer(compiled_arg, from_, to):
     return f"UNIX_MICROS({compiled_arg})"
 
 
+@bigquery_cast.register(str, dt.Integer, dt.Timestamp)
+def bigquery_cast_integer_to_timestamp(compiled_arg, from_, to):
+    """Convert INT64 (seconds since Unix epoch) to Timestamp."""
+    return f"TIMESTAMP_SECONDS({compiled_arg})"
+
+
 @bigquery_cast.register(str, dt.DataType, dt.DataType)
 def bigquery_cast_generate(compiled_arg, from_, to):
     """Cast to desired type."""

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -874,7 +874,7 @@ def test_timestamp_extract_milliseconds_with_big_value(con):
     assert result == 333
 
 
-@pytest.mark.notimpl(["bigquery", "datafusion"])
+@pytest.mark.notimpl(["datafusion"])
 def test_integer_cast_to_timestamp_column(backend, alltypes, df):
     expr = alltypes.int_col.cast("timestamp")
     expected = pd.to_datetime(df.int_col, unit="s").rename(expr.get_name())
@@ -882,7 +882,7 @@ def test_integer_cast_to_timestamp_column(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["bigquery", "datafusion"])
+@pytest.mark.notimpl(["datafusion"])
 def test_integer_cast_to_timestamp_scalar(alltypes, df):
     expr = alltypes.int_col.min().cast("timestamp")
     result = expr.execute()


### PR DESCRIPTION
Hello,

Fix for two tests. 

I'm still working on other things related to the interval support in BigQuery, but I don't know what the final outcome will be, so I'm pushing it for now.

Best regards, 
Kamil Breguła