### PR TITLE
feat(common): make frozendict truly immutable 

### DIFF
--- a/ibis/common/tests/test_validators.py
+++ b/ibis/common/tests/test_validators.py
@@ -9,6 +9,7 @@ from ibis.common.validators import (
     any_of,
     bool_,
     dict_of,
+    frozendict_of,
     instance_of,
     int_,
     isin,
@@ -17,6 +18,7 @@ from ibis.common.validators import (
     str_,
     tuple_of,
 )
+from ibis.util import frozendict
 
 
 @pytest.mark.parametrize(
@@ -36,6 +38,7 @@ from ibis.common.validators import (
         (any_of((str_, int_(max=8))), "foo", "foo"),
         (any_of((str_, int_(max=8))), 7, 7),
         (all_of((int_, min_(3), min_(8))), 10, 10),
+        (dict_of(str_, int_), {"a": 1, "b": 2}, {"a": 1, "b": 2}),
     ],
 )
 def test_validators_passing(validator, value, expected):
@@ -59,6 +62,7 @@ def test_validators_passing(validator, value, expected):
         (any_of((str_, int_(max=8))), 3.14),
         (any_of((str_, int_(max=8))), 9),
         (all_of((int_, min_(3), min_(8))), 7),
+        (dict_of(int_, str_), {"a": 1, "b": 2}),
     ],
 )
 def test_validators_failing(validator, value):
@@ -90,6 +94,7 @@ def endswith_d(x, this):
         (List[int], list_of(instance_of(int))),
         (Tuple[int], tuple_of(instance_of(int))),
         (Dict[str, float], dict_of(instance_of(str), instance_of(float))),
+        (frozendict[str, int], frozendict_of(instance_of(str), instance_of(int))),
     ],
 )
 def test_validator_from_annotation(annot, expected):

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -10,11 +10,14 @@ import toolz
 if sys.version_info >= (3, 9):
 
     @toolz.memoize
-    def evaluate_typehint(hint, module_name) -> Any:
+    def evaluate_typehint(hint, module_name=None) -> Any:
         if isinstance(hint, str):
             hint = ForwardRef(hint)
         if isinstance(hint, ForwardRef):
-            globalns = sys.modules[module_name].__dict__
+            if module_name is None:
+                globalns = {}
+            else:
+                globalns = sys.modules[module_name].__dict__
             return hint._evaluate(globalns, locals(), frozenset())
         else:
             return hint
@@ -26,7 +29,10 @@ else:
         if isinstance(hint, str):
             hint = ForwardRef(hint)
         if isinstance(hint, ForwardRef):
-            globalns = sys.modules[module_name].__dict__
+            if module_name is None:
+                globalns = {}
+            else:
+                globalns = sys.modules[module_name].__dict__
             return hint._evaluate(globalns, locals())
         else:
             return hint

--- a/ibis/tests/test_util.py
+++ b/ibis/tests/test_util.py
@@ -4,6 +4,7 @@
 import pytest
 
 from ibis import util
+from ibis.tests.util import assert_pickle_roundtrip
 
 
 @pytest.mark.parametrize(
@@ -56,6 +57,28 @@ def test_dotdict():
         assert d['x']
     with pytest.raises(AttributeError):
         assert d.x
+
+
+def test_frozendict():
+    d = util.frozendict({"a": 1, "b": 2, "c": 3})
+    e = util.frozendict(a=1, b=2, c=3)
+    assert d == e
+    assert d["a"] == 1
+    assert d["b"] == 2
+
+    msg = "'frozendict' object does not support item assignment"
+    with pytest.raises(TypeError, match=msg):
+        d["a"] = 2
+    with pytest.raises(TypeError, match=msg):
+        d["d"] = 4
+
+    with pytest.raises(TypeError):
+        d.__view__["a"] = 2
+    with pytest.raises(TypeError):
+        d.__view__ = {"a": 2}
+
+    assert hash(d)
+    assert_pickle_roundtrip(d)
 
 
 def test_import_object():

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", covariant=True)
 U = TypeVar("U", covariant=True)
+K = TypeVar("K")
 V = TypeVar("V")
 
 # https://www.compart.com/en/unicode/U+22EE
@@ -47,7 +48,7 @@ VERTICAL_ELLIPSIS = "\u22EE"
 HORIZONTAL_ELLIPSIS = "\u2026"
 
 
-class frozendict(Mapping, Hashable):
+class frozendict(Mapping[K, V], Hashable):
     __slots__ = ("__view__", "__precomputed_hash__")
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
- now frozendict instances are truly immutable using the builtin dictproxy which only provides a read-only view to the underlying mapping
- support validator construction from `UnionType` (`type1 | type2 | ...`) which is different from `typing.Union`
- add a `Coercible` abstract base class for marking types which can be constructed from differently typed object, this makes type annotation based validations more flexible