### PR TITLE
fix(snowflake): Remove invalid operations from registry

### DIFF
--- a/docs/backends/support_matrix.md
+++ b/docs/backends/support_matrix.md
@@ -7,12 +7,12 @@ hide:
 
 Backends are shown in descending order of the number of supported operations.
 
-!!! tip "The Snowflake backend coverage is an overestimate"
+!!! tip "Backends with low coverage are good places to start contributing!"
 
-    The Snowflake backend translation functions are reused from the PostgreSQL backend
-    and some operations that claim coverage may not work.
-
-    The Snowflake backend is a good place to start contributing!
+    Each backend implements operations differently, but this is usually very similar
+    to other backends.
+    If you want to start contributing to ibis, it's a good idea to start by adding missing operations
+    to backends that have low operation coverage.
 
 ## Core Operations
 

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -96,3 +96,65 @@ operation_registry.update(
         ops.DayOfWeekName: _day_of_week_name,
     }
 )
+
+_invalid_operations = {
+    # ibis.expr.operations.analytic
+    ops.CumulativeAll,
+    ops.CumulativeAny,
+    ops.CumulativeOp,
+    ops.NTile,
+    ops.NthValue,
+    # ibis.expr.operations.array
+    ops.ArrayColumn,
+    ops.ArrayConcat,
+    ops.ArrayIndex,
+    ops.ArrayLength,
+    ops.ArrayRepeat,
+    ops.ArraySlice,
+    ops.Unnest,
+    # ibis.expr.operations.generic
+    ops.TableArrayView,
+    ops.TypeOf,
+    # ibis.expr.operations.logical
+    ops.ExistsSubquery,
+    ops.NotExistsSubquery,
+    # ibis.expr.operations.maps
+    ops.MapKeys,
+    # ibis.expr.operations.numeric
+    ops.BitwiseAnd,
+    ops.BitwiseLeftShift,
+    ops.BitwiseNot,
+    ops.BitwiseOr,
+    ops.BitwiseRightShift,
+    ops.BitwiseXor,
+    # ibis.expr.operations.reductions
+    ops.All,
+    ops.Any,
+    ops.ArrayCollect,
+    ops.BitAnd,
+    ops.BitOr,
+    ops.BitXor,
+    ops.MultiQuantile,
+    ops.NotAll,
+    ops.NotAny,
+    # ibis.expr.operations.strings
+    ops.FindInSet,
+    ops.RegexExtract,
+    ops.RegexReplace,
+    ops.RegexSearch,
+    ops.StringSplit,
+    # ibis.expr.operations.structs
+    ops.StructField,
+    # ibis.expr.operations.temporal
+    ops.DateFromYMD,
+    ops.ExtractMillisecond,
+    ops.IntervalFromInteger,
+    ops.StringToTimestamp,
+    ops.TimestampDiff,
+    ops.TimestampFromUNIX,
+    ops.TimestampFromYMDHMS,
+}
+
+operation_registry = {
+    k: v for k, v in operation_registry.items() if k not in _invalid_operations
+}


### PR DESCRIPTION
Hello,

Deleting these operations does not affect the result of the tests, so it looks like they are invalid. When we exclude them from the register, the operation matrix will show a more realistic coverage and we will also know where a contribution is needed.

