### PR TITLE
test(mssql): simplify test data setup

### DIFF
--- a/ci/schema/mssql.sql
+++ b/ci/schema/mssql.sql
@@ -13,6 +13,14 @@ CREATE TABLE diamonds (
     z FLOAT
 );
 
+
+-- /data is a volume mount to the ibis testing data
+-- used for snappy test data loading
+-- DataFrame.to_sql is unusably slow for loading CSVs
+BULK INSERT diamonds
+FROM '/data/diamonds.csv'
+WITH (FORMAT = 'CSV', FIELDTERMINATOR = ',', ROWTERMINATOR = '\n', FIRSTROW = 2)
+
 DROP TABLE IF EXISTS batting;
 
 CREATE TABLE batting (
@@ -40,6 +48,10 @@ CREATE TABLE batting (
     "GIDP" BIGINT
 );
 
+BULK INSERT batting
+FROM '/data/batting.csv'
+WITH (FORMAT = 'CSV', FIELDTERMINATOR = ',', ROWTERMINATOR = '\n', FIRSTROW = 2)
+
 DROP TABLE IF EXISTS awards_players;
 
 CREATE TABLE awards_players (
@@ -50,6 +62,10 @@ CREATE TABLE awards_players (
     tie VARCHAR(MAX),
     notes VARCHAR(MAX)
 );
+
+BULK INSERT awards_players
+FROM '/data/awards_players.csv'
+WITH (FORMAT = 'CSV', FIELDTERMINATOR = ',', ROWTERMINATOR = '\n', FIRSTROW = 2)
 
 DROP TABLE IF EXISTS functional_alltypes;
 
@@ -70,6 +86,10 @@ CREATE TABLE functional_alltypes (
     year INTEGER,
     month INTEGER
 );
+
+BULK INSERT functional_alltypes
+FROM '/data/functional_alltypes.csv'
+WITH (FORMAT = 'CSV', FIELDTERMINATOR = ',', ROWTERMINATOR = '\n', FIRSTROW = 2)
 
 CREATE INDEX "ix_functional_alltypes_index" ON functional_alltypes ("index");
 

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -137,7 +137,7 @@ def recreate_database(
     engine = sa.create_engine(url.set(database=""), **kwargs)
 
     if url.database is not None:
-        with engine.connect() as conn:
+        with engine.begin() as conn:
             conn.execute(f'DROP DATABASE IF EXISTS {database}')
             conn.execute(f'CREATE DATABASE {database}')
 
@@ -179,7 +179,7 @@ def init_database(
     engine = sa.create_engine(url, **kwargs)
 
     if schema:
-        with engine.connect() as conn:
+        with engine.begin() as conn:
             for stmt in filter(None, map(str.strip, schema.read().split(';'))):
                 conn.execute(stmt)
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -139,7 +139,7 @@ class Backend(BaseAlchemyBackend):
     def _load_extensions(self, extensions):
         for extension in extensions:
             if extension not in self._extensions:
-                with self.con.connect() as con:
+                with self.begin() as con:
                     con.execute(f"INSTALL '{extension}'")
                     con.execute(f"LOAD '{extension}'")
                 self._extensions.add(extension)

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -185,7 +185,7 @@ WHERE attrelid = {raw_name!r}::regclass
   AND NOT attisdropped
 ORDER BY attnum
 """
-        with self.con.connect() as con:
+        with self.begin() as con:
             con.execute(f"CREATE TEMPORARY VIEW {name} AS {query}")
             try:
                 type_info = con.execute(type_info_sql).fetchall()

--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -42,7 +42,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
 
         stage = "ibis_testing_stage"
         con = TestConf.connect(data_dir)
-        with con.con.connect() as con:
+        with con.con.begin() as con:
             con.execute("DROP SCHEMA IF EXISTS ibis_testing")
             con.execute("CREATE SCHEMA IF NOT EXISTS ibis_testing")
             con.execute("USE SCHEMA ibis_testing")


### PR DESCRIPTION
This PR removes the use of concurrent.futures for data loading in the mssql backend, in an attempt simplify debugging the flaky schema-getting test. I also moved some things that should be in transactions but are not to be so.