### PR TITLE
fix(set ops): raise if no tables passed to set operations

### DIFF
--- a/ibis/backends/tests/test_set_ops.py
+++ b/ibis/backends/tests/test_set_ops.py
@@ -3,6 +3,7 @@ import pytest
 from pytest import param
 
 import ibis
+import ibis.common.exceptions as com
 from ibis import _
 
 
@@ -125,3 +126,9 @@ def test_difference(backend, alltypes, df, distinct):
         expected = expected.drop_duplicates()
 
     backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("method", ["intersect", "difference", "union"])
+def test_empty_set_op(backend, alltypes, method):
+    with pytest.raises(com.IbisTypeError, match="requires a table or tables"):
+        getattr(alltypes, method)()

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -349,6 +349,10 @@ class Table(Expr, JupyterMixin):
             The rows present in `self` that are not present in `tables`.
         """
         left = self
+        if not tables:
+            raise com.IbisTypeError(
+                "difference requires a table or tables to compare against"
+            )
         for right in tables:
             left = ops.Difference(left, right, distinct=distinct)
         return left.to_expr()
@@ -493,6 +497,10 @@ class Table(Expr, JupyterMixin):
             A new table containing the union of all input tables.
         """
         left = self
+        if not tables:
+            raise com.IbisTypeError(
+                "union requires a table or tables to compare against"
+            )
         for right in tables:
             left = ops.Union(left, right, distinct=distinct)
         return left.to_expr()
@@ -515,6 +523,10 @@ class Table(Expr, JupyterMixin):
             A new table containing the intersection of all input tables.
         """
         left = self
+        if not tables:
+            raise com.IbisTypeError(
+                "intersect requires a table or tables to compare against"
+            )
         for right in tables:
             left = ops.Intersection(left, right, distinct=distinct)
         return left.to_expr()


### PR DESCRIPTION
Raises if no tables are passed to set operations that require tables to execute against (`union`, `intersect`, `difference`)