### PR TITLE
ci(mssql): dont recreate database in MSSQL

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -60,7 +60,7 @@ jobs:
 
       # run against the full shell.nix on push so it gets pushed to cachix
       - name: pre-commit checks
-        run: nix develop '.#preCommit' --ignore-environment --keep-going -c pre-commit run --all-files
+        run: nix develop '.#preCommit' --ignore-environment --keep-going -c pre-commit run --all-files --show-diff-on-failure --color=always
 
   benchmarks:
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
       retries: 3
       test:
         - CMD-SHELL
-        - /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -Q "SELECT 1 AS one"
+        - /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -Q "DROP DATABASE IF EXISTS [ibis_testing]; CREATE DATABASE [ibis_testing]"
       timeout: 10s
     build:
       context: .

--- a/ibis/backends/mssql/tests/conftest.py
+++ b/ibis/backends/mssql/tests/conftest.py
@@ -60,6 +60,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                 database=database,
                 schema=schema,
                 isolation_level="AUTOCOMMIT",
+                recreate=False,
             )
 
     @staticmethod


### PR DESCRIPTION
I'm not sure, but I suspect that MSSQL sometimes performs some maintenance operations after creating the database, which makes the database unavailable.


Let's analyze the log.

At the beginning, we see that the user cannot log and we even have an error code
```
2023-01-11 22:29:11.77 Logon       Error: 18456, Severity: 14, State: 38.
2023-01-11 22:29:11.77 Logon       Login failed for user 'sa'. Reason: Failed to open the explicitly specified database 'ibis_testing'. [CLIENT: 172.23.0.1]
```
According to [Stackoverflow](https://dba.stackexchange.com/questions/29613/login-failed-for-user-error-18456-severity-14-state-38), this error mens:
```
38     'Login valid but database unavailable (or login not permissioned)'
```
After 32 seconds, we have next entries:
```
2023-01-11 22:29:43.03 spid60      [5]. Feature Status: PVS: 0. CTR: 0. ConcurrentPFSUpdate: 1. ConcurrentGAMUpdate: 1. ConcurrentSGAMUpdate: 1, CleanupUnderUserTransaction: 0. TranLevelPVS: 0
2023-01-11 22:29:43.03 spid60      Starting up database 'ibis_testing'.
```
I don't fully understand the first lines, but I guess it's some kind of maintenance operation.
The next line means that the database is starting up, which suggests that it was not available before. Probably only from this moment we can send queries to the database.

I have now moved the database creation to the init container, so this will be done right after the database starts. And it is also done only once.

Best regards