### PR TITLE
refactor(sqlalchemy): remove use of deprecated `isnot`

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -220,7 +220,7 @@ def _is_null(t, op):
 
 def _not_null(t, op):
     arg = t.translate(op.arg)
-    return arg.isnot(sa.null())
+    return arg.is_not(sa.null())
 
 
 def _round(t, op):

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -15,6 +15,7 @@
 import operator
 
 import pytest
+from pytest import param
 from sqlalchemy import func as F
 from sqlalchemy import sql
 from sqlalchemy import types as sat
@@ -163,8 +164,8 @@ def test_between(con, functional_alltypes, sa_functional_alltypes):
 @pytest.mark.parametrize(
     ("expr_fn", "expected_fn"),
     [
-        (lambda d: d.isnull(), lambda sd: sd.is_(sa.null())),
-        (lambda d: d.notnull(), lambda sd: sd.isnot(sa.null())),
+        param(lambda d: d.isnull(), lambda sd: sd.is_(sa.null()), id="isnull"),
+        param(lambda d: d.notnull(), lambda sd: sd.is_not(sa.null()), id="notnull"),
     ],
 )
 def test_isnull_notnull(


### PR DESCRIPTION
Removes use of `is_not`, based on https://github.com/ibis-project/ibis/issues/5202#issuecomment-1379472037.