### PR TITLE
ci: stop running `bq load` in gcs insert job

### DIFF
--- a/.github/workflows/ci-data.yml
+++ b/.github/workflows/ci-data.yml
@@ -55,15 +55,3 @@ jobs:
 
           bucket="gs://ibis-workflow-data/${yesterday}"
           gsutil cp -Z workflows.json jobs.json "${bucket}"
-
-          set +e
-
-          exit_code=0
-          for table in workflows jobs; do
-            if ! bq load --autodetect=true --source_format=NEWLINE_DELIMITED_JSON \
-              "workflows_native.${table}" "${bucket}/${table}.json"; then
-              ((++exit_code))
-            fi
-          done
-
-          exit "$exit_code"


### PR DESCRIPTION
This PR removes the `bq load` invocation in our GCS nightly CI data upload because it is not robust to schema changes, whereas querying a bucket directly is.