### PR TITLE
chore: tell renovate to also look at `Dockerfile`s

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,12 @@
   "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
   "semanticCommits": "enabled",
   "lockFileMaintenance": { "enabled": true },
-  "enabledManagers": ["docker-compose", "github-actions", "poetry"],
+  "enabledManagers": [
+    "docker-compose",
+    "dockerfile",
+    "github-actions",
+    "poetry"
+  ],
   "automerge": false,
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
Before this PR renovate was not looking at Dockerfiles. Now that we have a few, we should let try to submit update PRs for those as well.