### PR TITLE
fix(sqlalchemy): fix correlated subqueries on projections

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -81,22 +81,13 @@ def get_sqla_table(ctx, table):
     return sa_table
 
 
-def get_col_or_deferred_col(sa_table, colname):
-    """Get a `Column`, or create a "deferred" column.
+def get_col(sa_table, op: ops.TableColumn):
+    """Get a `Column`."""
+    cols = sa_table.exported_columns
+    colname = op.name
 
-    This is to handle the case when selecting a column from a join, which
-    happens when a join expression is cached during join traversal
-
-    We'd like to avoid generating a subquery just for selection but in
-    sqlalchemy the Join object is not selectable. However, at this point
-    know that the column can be referred to unambiguously
-
-    Later the expression is assembled into
-    `sa.select([sa.column(colname)]).select_from(table_set)` (roughly)
-    where `table_set` is `sa_table` above.
-    """
     try:
-        return sa_table.exported_columns[colname]
+        return cols[colname]
     except KeyError:
         # cols is a sqlalchemy column collection which contains column
         # names that are secretly prefixed by their containing table
@@ -116,7 +107,7 @@ def _table_column(t, op):
 
     sa_table = get_sqla_table(ctx, table)
 
-    out_expr = get_col_or_deferred_col(sa_table, op.name)
+    out_expr = get_col(sa_table, op)
     out_expr.quote = t._always_quote_columns
 
     # If the column does not originate from the table set in the current SELECT

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -129,8 +129,6 @@ def _table_array_view(t, op):
 
 
 def _exists_subquery(t, op):
-    from ibis.backends.base.sql.alchemy.query_builder import AlchemyCompiler
-
     ctx = t.context
 
     # TODO(kszucs): avoid converting the predicates to expressions
@@ -142,7 +140,7 @@ def _exists_subquery(t, op):
     )
 
     sub_ctx = ctx.subcontext()
-    clause = AlchemyCompiler.to_sql(filtered, sub_ctx, exists=True)
+    clause = ctx.compiler.to_sql(filtered, sub_ctx, exists=True)
 
     if isinstance(op, ops.NotExistsSubquery):
         clause = sa.not_(clause)

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -32,7 +32,7 @@ from ibis.backends.base.sql.alchemy.registry import (
     _bitwise_op,
     _extract,
     geospatial_functions,
-    get_col_or_deferred_col,
+    get_col,
 )
 
 operation_registry = sqlalchemy_operation_registry.copy()
@@ -302,7 +302,7 @@ def _table_column(t, op):
     table = op.table
 
     sa_table = get_sqla_table(ctx, table)
-    out_expr = get_col_or_deferred_col(sa_table, op.name)
+    out_expr = get_col(sa_table, op)
 
     if op.output_dtype.is_timestamp():
         timezone = op.output_dtype.timezone

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -181,9 +181,6 @@ _invalid_operations = {
     ops.Unnest,
     # ibis.expr.operations.generic
     ops.TypeOf,
-    # ibis.expr.operations.logical
-    ops.ExistsSubquery,
-    ops.NotExistsSubquery,
     # ibis.expr.operations.maps
     ops.MapKeys,
     # ibis.expr.operations.reductions

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -311,8 +311,6 @@ _invalid_operations = {
     ops.TypeOf,
     # ibis.expr.operations.logical
     ops.Between,
-    ops.ExistsSubquery,
-    ops.NotExistsSubquery,
     # ibis.expr.operations.maps
     ops.MapLength,
     # ibis.expr.operations.reductions

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cart_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cart_join/out.sql
@@ -1,3 +1,3 @@
-SELECT ancestor_node_sort_order, 1 AS n 
+SELECT t1.ancestor_node_sort_order, 1 AS n 
 FROM facts AS t0 JOIN (SELECT t2.ancestor_level_name AS ancestor_level_name, t2.ancestor_level_number AS ancestor_level_number, t2.ancestor_node_sort_order AS ancestor_node_sort_order, t2.descendant_node_natural_key AS descendant_node_natural_key, concat(lpad('-', (t2.ancestor_level_number - 1) * 7, '-'), t2.ancestor_level_name) AS product_level_name 
-FROM products AS t2) AS t1 ON t0.product_id = t1.descendant_node_natural_key GROUP BY ancestor_node_sort_order ORDER BY ancestor_node_sort_order ASC
+FROM products AS t2) AS t1 ON t0.product_id = t1.descendant_node_natural_key GROUP BY t1.ancestor_node_sort_order ORDER BY t1.ancestor_node_sort_order ASC

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -1095,32 +1095,26 @@ def test_tpc_h11(h11):
     t4 = supplier.alias("t4")
     t1 = (
         sa.select(
-            sa.column("ps_partkey"),
-            sa.func.sum(sa.column("ps_supplycost") * sa.column("ps_availqty")).label(
-                "value"
-            ),
+            t3.c.ps_partkey,
+            sa.func.sum(t3.c.ps_supplycost * t3.c.ps_availqty).label("value"),
         )
         .select_from(
             t3.join(t4, onclause=t3.c.ps_suppkey == t4.c.s_suppkey).join(
                 t2, onclause=t2.c.n_nationkey == t4.c.s_nationkey
             )
         )
-        .where(sa.column("n_name") == NATION)
-        .group_by(sa.column("ps_partkey"))
+        .where(t2.c.n_name == NATION)
+        .group_by(t3.c.ps_partkey)
     ).alias("t1")
 
     anon_1 = (
-        sa.select(
-            sa.func.sum(sa.column("ps_supplycost") * sa.column("ps_availqty")).label(
-                "total"
-            )
-        )
+        sa.select(sa.func.sum(t3.c.ps_supplycost * t3.c.ps_availqty).label("total"))
         .select_from(
             t3.join(t4, onclause=t3.c.ps_suppkey == t4.c.s_suppkey).join(
                 t2, onclause=t2.c.n_nationkey == t4.c.s_nationkey
             )
         )
-        .where(sa.column("n_name") == NATION)
+        .where(t2.c.n_name == NATION)
         .alias("anon_1")
     )
 


### PR DESCRIPTION
While adding test coverage for ExistsSubquery and NotExistsSubquery I discovered that basic execution of correlated subqueries does not work. This PR fixes that. A couple of tests are still failing, hence the draft.