### PR TITLE
fix(snowflake): re-enable `ops.TableArrayView`

### DIFF
--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -180,7 +180,6 @@ _invalid_operations = {
     ops.ArraySlice,
     ops.Unnest,
     # ibis.expr.operations.generic
-    ops.TableArrayView,
     ops.TypeOf,
     # ibis.expr.operations.logical
     ops.ExistsSubquery,


### PR DESCRIPTION
This PR re-enables `ops.TableArrayView` for the snowflake backend.