### PR TITLE
docs: make firefox render the proper iframe height

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -48,7 +48,7 @@
 }
 
 #streamlit-app {
-  height: 100%;
+  height: 1000px;
   width: 100%;
   border: none;
   overflow: hidden;


### PR DESCRIPTION
This PR fixes an issue showing up on Firefox where the streamlit app does not expand to the space of the containing div.