### PR TITLE
fix(sqlalchemy): fix view creation with select stmts that have bind parameters

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -527,3 +527,9 @@ SELECT * FROM read_csv({', '.join(args)})"""
         definition: sa.sql.compiler.Compiled,
     ) -> str:
         return f"CREATE OR REPLACE TEMPORARY VIEW {name} AS {definition}"
+
+    def _get_compiled_statement(self, view: sa.Table, definition: sa.sql.Selectable):
+        # TODO: remove this once duckdb supports CTAS prepared statements
+        return super()._get_compiled_statement(
+            view, definition, compile_kwargs={"literal_binds": True}
+        )

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -192,3 +192,16 @@ def test_table_dot_sql_does_not_clobber_existing_tables(con):
     finally:
         con.drop_table(name, force=True)
         assert name not in con.list_tables()
+
+
+@table_dot_sql_notimpl
+@dot_sql_notimpl
+@dot_sql_notyet
+@dot_sql_never
+@pytest.mark.notimpl(["trino"])
+def test_dot_sql_alias_with_params(backend, alltypes, df):
+    t = alltypes
+    x = t.select(x=t.string_col + " abc").alias("foo")
+    result = x.execute()
+    expected = df.string_col.add(" abc").rename("x")
+    backend.assert_series_equal(result.x, expected)


### PR DESCRIPTION
This PR fixes an issue where expressions that generate code with bind parameters flat out did not work. We were incorrectly using text + bindparams and then calling execute, when we should have been doing what I am doing here, which is passing the compiled params to an execute call.

Closes #5216.