### PR TITLE
fix(sql): add `typeof` test and bring back implementations

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -521,7 +521,6 @@ sqlalchemy_operation_registry: dict[Any, Any] = {
     ops.NotNull: _not_null,
     ops.Negate: _negate,
     ops.Round: _round,
-    ops.TypeOf: unary(sa.func.typeof),
     ops.Literal: _literal,
     ops.NullLiteral: lambda *_: sa.null(),
     ops.SimpleCase: _simple_case,

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -396,5 +396,6 @@ operation_registry = {
     ops.DayOfWeekName: timestamp.day_of_week_name,
     ops.Strftime: timestamp.strftime,
     ops.SortKey: sort_key,
+    ops.TypeOf: unary('typeof'),
     **binary_infix_ops,
 }

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -253,6 +253,7 @@ operation_registry.update(
         ops.StringToTimestamp: fixed_arity(sa.func.strptime, 2),
         ops.Quantile: reduction(sa.func.quantile_cont),
         ops.MultiQuantile: reduction(sa.func.quantile_cont),
+        ops.TypeOf: unary(sa.func.typeof),
     }
 )
 
@@ -263,8 +264,6 @@ _invalid_operations = {
     ops.CumulativeAny,
     ops.CumulativeOp,
     ops.NTile,
-    # ibis.expr.operations.generic
-    ops.TypeOf,
     # ibis.expr.operations.strings
     ops.Capitalize,
     ops.Translate,

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -302,5 +302,6 @@ operation_registry.update(
         ops.Where: fixed_arity(sa.func.iif, 3),
         ops.Pi: fixed_arity(sa.func._ibis_sqlite_pi, 0),
         ops.E: fixed_arity(sa.func._ibis_sqlite_e, 0),
+        ops.TypeOf: unary(sa.func.typeof),
     }
 )

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -106,19 +106,6 @@ def test_div_floordiv(con, expr, expected):
 
 @pytest.mark.parametrize(
     ('expr', 'expected'),
-    [
-        (L('foo_bar').typeof(), 'text'),
-        (L(5).typeof(), 'integer'),
-        (ibis.NA.typeof(), 'null'),
-        (L(1.2345).typeof(), 'real'),
-    ],
-)
-def test_typeof(con, expr, expected):
-    assert con.execute(expr) == expected
-
-
-@pytest.mark.parametrize(
-    ('expr', 'expected'),
     [(L(0).nullifzero(), None), (L(5.5).nullifzero(), 5.5)],
 )
 def test_nullifzero(con, expr, expected):

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -758,3 +758,11 @@ def test_exists(batting, awards_players, method_name):
     expr = batting[method(batting.yearID == awards_players.yearID)]
     result = expr.execute()
     assert not result.empty
+
+
+@pytest.mark.notimpl(["dask", "datafusion", "pandas", "polars", "pyspark"])
+@pytest.mark.notyet(["bigquery", "mysql", "mssql"])
+def test_typeof(alltypes):
+    x = alltypes.string_col.typeof()
+    res = x.execute()
+    assert len(res) == alltypes.count().execute()

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -300,6 +300,7 @@ operation_registry.update(
                 sa.func.cast(sa.func.substr(d, 1, 2), sa.VARCHAR(1))
             )
         ),
+        ops.TypeOf: unary(sa.func.typeof),
     }
 )
 
@@ -307,8 +308,6 @@ _invalid_operations = {
     # ibis.expr.operations.analytic
     ops.CumulativeOp,
     ops.NTile,
-    # ibis.expr.operations.generic
-    ops.TypeOf,
     # ibis.expr.operations.logical
     ops.Between,
     # ibis.expr.operations.maps


### PR DESCRIPTION
Bring back the `typeof` method. Closes #5231.