### PR TITLE
depr(api): deprecate `.to_projection` in favor of `.as_table`

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -99,7 +99,7 @@ class SelectBuilder:
                     table_expr = node.table.to_expr()[[node.name]]
                     result_handler = _get_column(node.name)
                 else:
-                    table_expr = node.to_expr().to_projection()
+                    table_expr = node.to_expr().as_table()
                     result_handler = _get_column(node.name)
 
                 return table_expr.op(), result_handler

--- a/ibis/backends/base/sql/registry/binary_infix.py
+++ b/ibis/backends/base/sql/registry/binary_infix.py
@@ -72,7 +72,7 @@ def contains(op_string: Literal["IN", "NOT IN"]) -> str:
                 ctx.is_foreign_expr(leaf)
                 for leaf in an.find_immediate_parent_tables(op.options)
             ):
-                array = op.options.to_expr().to_projection().to_array().op()
+                array = op.options.to_expr().as_table().to_array().op()
                 right = table_array_view(translator, array)
             else:
                 right = translator.translate(op.options)

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -213,14 +213,14 @@ class Backend(BaseBackend):
             return self.compile(expr, params, **kwargs)
         elif isinstance(expr, ir.Column):
             # expression must be named for the projection
-            expr = expr.name('tmp').to_projection()
+            expr = expr.name('tmp').as_table()
             return self.compile(expr, params, **kwargs)
         elif isinstance(expr, ir.Scalar):
             if an.find_immediate_parent_tables(expr.op()):
                 # there are associated datafusion tables so convert the expr
                 # to a selection which we can directly convert to a datafusion
                 # plan
-                expr = expr.name('tmp').to_projection()
+                expr = expr.name('tmp').as_table()
                 frame = self.compile(expr, params, **kwargs)
             else:
                 # doesn't have any tables associated so create a plan from a

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -505,7 +505,7 @@ def _apply_schema(op: ops.Node, result: pd.DataFrame | pd.Series):
         schema = op.schema
         return schema.apply_to(df.loc[:, list(schema.names)])
     elif isinstance(result, pd.Series):
-        schema = op.to_expr().to_projection().schema()
+        schema = op.to_expr().as_table().schema()
         return schema.apply_to(result.to_frame()).iloc[:, 0].reset_index(drop=True)
     return result
 

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -252,7 +252,7 @@ class Backend(BaseBackend):
             return translate(node)
         elif isinstance(expr, ir.Column):
             # expression must be named for the projection
-            node = expr.to_projection().op()
+            node = expr.as_table().op()
             return translate(node)
         elif isinstance(expr, ir.Scalar):
             if an.is_scalar_reduction(node):

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -9,6 +9,7 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+from ibis import util
 from ibis.common.grounds import Singleton
 from ibis.expr.types.core import Expr, _binop
 
@@ -480,7 +481,11 @@ class Value(Expr):
         """Sort an expression descending."""
         return ops.SortKey(self, ascending=False).to_expr()
 
+    @util.deprecated(version="5.0", instead="use `.as_table()`")
     def to_projection(self) -> ir.Table:
+        return self.as_table()
+
+    def as_table(self) -> ir.Table:
         """Promote this value expression to a projection."""
         from ibis.expr.analysis import find_immediate_parent_tables
 
@@ -492,7 +497,7 @@ class Value(Expr):
                 'to a projection'
             )
         table = roots[0].to_expr()
-        return table.projection([self])
+        return table.select(self)
 
 
 @public
@@ -535,9 +540,6 @@ class Column(Value, JupyterMixin):
 
     def __array__(self, dtype=None):
         return self.execute().__array__(dtype)
-
-    def as_table(self):
-        return self.to_projection()
 
     def __rich_console__(self, console, options):
         named = self.name(self.op().name)

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -395,7 +395,7 @@ class MockBackend(BaseSQLBackend):
         try:
             schema = expr.schema()
         except AttributeError:
-            schema = expr.to_projection().schema()
+            schema = expr.as_table().schema()
         df = schema.apply_to(pd.DataFrame([], columns=schema.names))
         if isinstance(expr, ir.Scalar):
             return None


### PR DESCRIPTION
Deprecate the `.to_projection()` API in favor of the more concise and descriptive `.as_table()` API.