### PR TITLE
feat(bigquery): add JS UDF support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: ruff
         # exclude a file (if configured to do so), even if it's passed in explicitly
-        args: ["--force-exclude"]
+        args: ["--force-exclude", "--fix"]
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.28.0
     hooks:

--- a/ibis/backends/bigquery/datatypes.py
+++ b/ibis/backends/bigquery/datatypes.py
@@ -20,6 +20,8 @@ class UDFContext(TypeTranslationContext):
     __slots__ = ()
 
 
+UDF_CONTEXT = UDFContext()
+
 ibis_type_to_bigquery_type = Dispatcher("ibis_type_to_bigquery_type")
 
 

--- a/ibis/backends/bigquery/tests/system/udf/test_udf_execute.py
+++ b/ibis/backends/bigquery/tests/system/udf/test_udf_execute.py
@@ -25,7 +25,11 @@ def df(alltypes):
 
 
 def test_udf(alltypes, df):
-    @udf(input_type=[dt.double, dt.double], output_type=dt.double)
+    @udf(
+        input_type=[dt.double, dt.double],
+        output_type=dt.double,
+        determinism=True,
+    )
     def my_add(a, b):
         return a + b
 

--- a/ibis/backends/bigquery/tests/unit/test_datatypes.py
+++ b/ibis/backends/bigquery/tests/unit/test_datatypes.py
@@ -4,8 +4,7 @@ from pytest import param
 
 import ibis.expr.datatypes as dt
 from ibis.backends.bigquery.datatypes import (
-    TypeTranslationContext,
-    UDFContext,
+    UDF_CONTEXT,
     ibis_type_to_bigquery_type,
 )
 
@@ -54,8 +53,7 @@ def test_no_ambiguities():
     ],
 )
 def test_simple(datatype, expected):
-    context = TypeTranslationContext()
-    assert ibis_type_to_bigquery_type(datatype, context) == expected
+    assert ibis_type_to_bigquery_type(datatype) == expected
 
 
 @pytest.mark.parametrize("datatype", [dt.uint64, dt.Decimal(8, 3)])
@@ -81,5 +79,4 @@ def test_simple_failure_mode(datatype):
     ],
 )
 def test_ibis_type_to_bigquery_type_udf(type, expected):
-    context = UDFContext()
-    assert ibis_type_to_bigquery_type(type, context) == expected
+    assert ibis_type_to_bigquery_type(type, UDF_CONTEXT) == expected

--- a/ibis/backends/bigquery/tests/unit/udf/snapshots/test_usage/test_multiple_calls_redefinition/out.sql
+++ b/ibis/backends/bigquery/tests/unit/udf/snapshots/test_usage/test_multiple_calls_redefinition/out.sql
@@ -1,0 +1,21 @@
+CREATE TEMPORARY FUNCTION my_len_0(s STRING)
+RETURNS FLOAT64
+LANGUAGE js AS """
+'use strict';
+function my_len(s) {
+    return s.length;
+}
+return my_len(s);
+""";
+
+CREATE TEMPORARY FUNCTION my_len_1(s STRING)
+RETURNS FLOAT64
+LANGUAGE js AS """
+'use strict';
+function my_len(s) {
+    return (s.length + 1);
+}
+return my_len(s);
+""";
+
+SELECT (my_len_0('abcd') + my_len_0('abcd')) + my_len_1('abcd') AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/udf/snapshots/test_usage/test_udf_determinism/False/out.sql
+++ b/ibis/backends/bigquery/tests/unit/udf/snapshots/test_usage/test_udf_determinism/False/out.sql
@@ -1,0 +1,12 @@
+CREATE TEMPORARY FUNCTION my_len_0(s STRING)
+RETURNS FLOAT64
+NOT DETERMINISTIC
+LANGUAGE js AS """
+'use strict';
+function my_len(s) {
+    return s.length;
+}
+return my_len(s);
+""";
+
+SELECT my_len_0('abcd') AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/udf/snapshots/test_usage/test_udf_determinism/None/out.sql
+++ b/ibis/backends/bigquery/tests/unit/udf/snapshots/test_usage/test_udf_determinism/None/out.sql
@@ -1,0 +1,11 @@
+CREATE TEMPORARY FUNCTION my_len_0(s STRING)
+RETURNS FLOAT64
+LANGUAGE js AS """
+'use strict';
+function my_len(s) {
+    return s.length;
+}
+return my_len(s);
+""";
+
+SELECT my_len_0('abcd') AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/udf/snapshots/test_usage/test_udf_determinism/True/out.sql
+++ b/ibis/backends/bigquery/tests/unit/udf/snapshots/test_usage/test_udf_determinism/True/out.sql
@@ -1,0 +1,12 @@
+CREATE TEMPORARY FUNCTION my_len_0(s STRING)
+RETURNS FLOAT64
+DETERMINISTIC
+LANGUAGE js AS """
+'use strict';
+function my_len(s) {
+    return s.length;
+}
+return my_len(s);
+""";
+
+SELECT my_len_0('abcd') AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/udf/test_usage.py
+++ b/ibis/backends/bigquery/tests/unit/udf/test_usage.py
@@ -4,46 +4,49 @@ from pytest import param
 import ibis
 import ibis.expr.datatypes as dt
 from ibis.backends.bigquery import udf
+from ibis.backends.bigquery.udf import _udf_name_cache
 
 
-def test_multiple_calls_redefinition():
-    @udf([dt.string], dt.double)
+def test_multiple_calls_redefinition(snapshot):
+    _udf_name_cache.clear()
+
+    @udf.python([dt.string], dt.double)
     def my_len(s):
         return s.length
 
     s = ibis.literal("abcd")
     expr = my_len(s) + my_len(s)
 
-    @udf([dt.string], dt.double)
+    @udf.python([dt.string], dt.double)
     def my_len(s):
         return s.length + 1
 
     expr = expr + my_len(s)
 
     sql = ibis.bigquery.compile(expr)
-    expected = '''\
-CREATE TEMPORARY FUNCTION my_len_0(s STRING)
-RETURNS FLOAT64
-LANGUAGE js AS """
-'use strict';
-function my_len(s) {
-    return s.length;
-}
-return my_len(s);
-""";
+    snapshot.assert_match(sql, "out.sql")
 
-CREATE TEMPORARY FUNCTION my_len_1(s STRING)
-RETURNS FLOAT64
-LANGUAGE js AS """
-'use strict';
-function my_len(s) {
-    return (s.length + 1);
-}
-return my_len(s);
-""";
 
-SELECT (my_len_0('abcd') + my_len_0('abcd')) + my_len_1('abcd') AS `tmp`'''
-    assert sql == expected
+@pytest.mark.parametrize(
+    ("determinism",),
+    [
+        param(True),
+        param(False),
+        param(None),
+    ],
+)
+def test_udf_determinism(snapshot, determinism):
+    _udf_name_cache.clear()
+
+    @udf.python([dt.string], dt.double, determinism=determinism)
+    def my_len(s):
+        return s.length
+
+    s = ibis.literal("abcd")
+    expr = my_len(s)
+
+    sql = ibis.bigquery.compile(expr)
+    snapshot.assert_match(sql, "out.sql")
 
 
 @pytest.mark.parametrize(
@@ -93,6 +96,6 @@ SELECT (my_len_0('abcd') + my_len_0('abcd')) + my_len_1('abcd') AS `tmp`'''
 )
 def test_udf_int64(argument_type, return_type):
     # invalid argument type, valid return type
-    @udf([argument_type], return_type)
+    @udf.python([argument_type], return_type)
     def my_int64_add(x):
         return 1.0

--- a/ibis/backends/bigquery/udf/__init__.py
+++ b/ibis/backends/bigquery/udf/__init__.py
@@ -1,25 +1,23 @@
 from __future__ import annotations
 
 import collections
-import functools
 import inspect
 import itertools
 from typing import Callable, Iterable, Mapping
 
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
-from ibis.backends.bigquery.compiler import compiles
-from ibis.backends.bigquery.datatypes import UDFContext, ibis_type_to_bigquery_type
+from ibis.backends.bigquery.datatypes import UDF_CONTEXT, ibis_type_to_bigquery_type
 from ibis.backends.bigquery.operations import BigQueryUDFNode
 from ibis.backends.bigquery.udf.core import PythonToJavaScriptTranslator
 from ibis.udf.validate import validate_output_type
 
 __all__ = ("udf",)
 
-_udf_name_cache: Mapping[str, Iterable[int]] = collections.defaultdict(itertools.count)
+_udf_name_cache: dict[str, Iterable[int]] = collections.defaultdict(itertools.count)
 
 
-def create_udf_node(name, fields):
+def _create_udf_node(name, fields):
     """Create a new UDF node type.
 
     Parameters
@@ -39,191 +37,281 @@ def create_udf_node(name, fields):
     return type(external_name, (BigQueryUDFNode,), fields)
 
 
-def udf(
-    input_type: Iterable[dt.DataType],
-    output_type: dt.DataType,
-    strict: bool = True,
-    libraries: Iterable[str] | None = None,
-) -> Callable:
-    '''Define a UDF for BigQuery.
+class _BigQueryUDF:
+    def __call__(self, *args, **kwargs):
+        return self.python(*args, **kwargs)
 
-    `INT64` is not supported as an argument type or a return type, as per
-    [the BigQuery documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#sql-type-encodings-in-javascript).
+    def python(
+        self,
+        input_type: Iterable[dt.DataType],
+        output_type: dt.DataType,
+        strict: bool = True,
+        libraries: Iterable[str] | None = None,
+        determinism: bool | None = None,
+    ) -> Callable:
+        '''Define a UDF for BigQuery.
 
-    Parameters
-    ----------
-    input_type
-        Iterable of types, one per argument.
-    output_type
-        Return type of the UDF.
-    strict
-        Whether or not to put a ``'use strict';`` string at the beginning of
-        the UDF. Setting to ``False`` is probably a bad idea.
-    libraries
-        An iterable of Google Cloud Storage URIs containing to JavaScript source
-        code. Note that any symbols (functions, classes, variables, etc.) that
-        are exposed in these JavaScript files will be visible inside the UDF.
+        The function is transpiled to JS.
 
-    Returns
-    -------
-    Callable
-        The wrapped user-defined function.
+        `INT64` is not supported as an argument type or a return type, as per
+        [the BigQuery documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#sql-type-encodings-in-javascript).
 
-    Examples
-    --------
-    >>> from ibis.backends.bigquery import udf
-    >>> import ibis.expr.datatypes as dt
-    >>> @udf(input_type=[dt.double], output_type=dt.double)
-    ... def add_one(x):
-    ...     return x + 1
-    >>> print(add_one.js)
-    CREATE TEMPORARY FUNCTION add_one_0(x FLOAT64)
-    RETURNS FLOAT64
-    LANGUAGE js AS """
-    'use strict';
-    function add_one(x) {
-        return (x + 1);
-    }
-    return add_one(x);
-    """;
-    >>> @udf(input_type=[dt.double, dt.double],
-    ...      output_type=dt.Array(dt.double))
-    ... def my_range(start, stop):
-    ...     def gen(start, stop):
-    ...         curr = start
-    ...         while curr < stop:
-    ...             yield curr
-    ...             curr += 1
-    ...     result = []
-    ...     for value in gen(start, stop):
-    ...         result.append(value)
-    ...     return result
-    >>> print(my_range.js)
-    CREATE TEMPORARY FUNCTION my_range_0(start FLOAT64, stop FLOAT64)
-    RETURNS ARRAY<FLOAT64>
-    LANGUAGE js AS """
-    'use strict';
-    function my_range(start, stop) {
-        function* gen(start, stop) {
-            let curr = start;
-            while ((curr < stop)) {
-                yield curr;
-                curr += 1;
-            }
+        Parameters
+        ----------
+        input_type
+            Iterable of types, one per argument.
+        output_type
+            Return type of the UDF.
+        strict
+            Whether or not to put a ``'use strict';`` string at the beginning of
+            the UDF. Setting to ``False`` is probably a bad idea.
+        libraries
+            An iterable of Google Cloud Storage URIs containing to JavaScript source
+            code. Note that any symbols (functions, classes, variables, etc.) that
+            are exposed in these JavaScript files will be visible inside the UDF.
+        determinism
+            Provides a hint to BigQuery as to whether the query result can be cached.
+
+        Returns
+        -------
+        Callable
+            The wrapped user-defined function.
+
+        Examples
+        --------
+        >>> from ibis.backends.bigquery import udf
+        >>> import ibis.expr.datatypes as dt
+        >>> @udf.python(input_type=[dt.double], output_type=dt.double)
+        ... def add_one(x):
+        ...     return x + 1
+        >>> print(add_one.js)
+        CREATE TEMPORARY FUNCTION add_one_0(x FLOAT64)
+        RETURNS FLOAT64
+        LANGUAGE js AS """
+        'use strict';
+        function add_one(x) {
+            return (x + 1);
         }
-        let result = [];
-        for (let value of gen(start, stop)) {
-            result.push(value);
-        }
-        return result;
-    }
-    return my_range(start, stop);
-    """;
-    >>> @udf(
-    ...     input_type=[dt.double, dt.double],
-    ...     output_type=dt.Struct.from_tuples([
-    ...         ('width', 'double'), ('height', 'double')
-    ...     ])
-    ... )
-    ... def my_rectangle(width, height):
-    ...     class Rectangle:
-    ...         def __init__(self, width, height):
-    ...             self.width = width
-    ...             self.height = height
-    ...
-    ...         @property
-    ...         def area(self):
-    ...             return self.width * self.height
-    ...
-    ...         def perimeter(self):
-    ...             return 2 * (self.width + self.height)
-    ...
-    ...     return Rectangle(width, height)
-    >>> print(my_rectangle.js)
-    CREATE TEMPORARY FUNCTION my_rectangle_0(width FLOAT64, height FLOAT64)
-    RETURNS STRUCT<width FLOAT64, height FLOAT64>
-    LANGUAGE js AS """
-    'use strict';
-    function my_rectangle(width, height) {
-        class Rectangle {
-            constructor(width, height) {
-                this.width = width;
-                this.height = height;
+        return add_one(x);
+        """;
+        >>> @udf.python(input_type=[dt.double, dt.double],
+        ...      output_type=dt.Array(dt.double))
+        ... def my_range(start, stop):
+        ...     def gen(start, stop):
+        ...         curr = start
+        ...         while curr < stop:
+        ...             yield curr
+        ...             curr += 1
+        ...     result = []
+        ...     for value in gen(start, stop):
+        ...         result.append(value)
+        ...     return result
+        >>> print(my_range.js)
+        CREATE TEMPORARY FUNCTION my_range_0(start FLOAT64, stop FLOAT64)
+        RETURNS ARRAY<FLOAT64>
+        LANGUAGE js AS """
+        'use strict';
+        function my_range(start, stop) {
+            function* gen(start, stop) {
+                let curr = start;
+                while ((curr < stop)) {
+                    yield curr;
+                    curr += 1;
+                }
             }
-            get area() {
-                return (this.width * this.height);
+            let result = [];
+            for (let value of gen(start, stop)) {
+                result.push(value);
             }
-            perimeter() {
-                return (2 * (this.width + this.height));
+            return result;
+        }
+        return my_range(start, stop);
+        """;
+        >>> @udf.python(
+        ...     input_type=[dt.double, dt.double],
+        ...     output_type=dt.Struct.from_tuples([
+        ...         ('width', 'double'), ('height', 'double')
+        ...     ])
+        ... )
+        ... def my_rectangle(width, height):
+        ...     class Rectangle:
+        ...         def __init__(self, width, height):
+        ...             self.width = width
+        ...             self.height = height
+        ...
+        ...         @property
+        ...         def area(self):
+        ...             return self.width * self.height
+        ...
+        ...         def perimeter(self):
+        ...             return 2 * (self.width + self.height)
+        ...
+        ...     return Rectangle(width, height)
+        >>> print(my_rectangle.js)
+        CREATE TEMPORARY FUNCTION my_rectangle_0(width FLOAT64, height FLOAT64)
+        RETURNS STRUCT<width FLOAT64, height FLOAT64>
+        LANGUAGE js AS """
+        'use strict';
+        function my_rectangle(width, height) {
+            class Rectangle {
+                constructor(width, height) {
+                    this.width = width;
+                    this.height = height;
+                }
+                get area() {
+                    return (this.width * this.height);
+                }
+                perimeter() {
+                    return (2 * (this.width + this.height));
+                }
             }
+            return (new Rectangle(width, height));
         }
-        return (new Rectangle(width, height));
-    }
-    return my_rectangle(width, height);
-    """;
-    '''
-    validate_output_type(output_type)
+        return my_rectangle(width, height);
+        """;
+        '''
+        validate_output_type(output_type)
 
-    if libraries is None:
-        libraries = []
+        if libraries is None:
+            libraries = []
 
-    def wrapper(f):
-        if not callable(f):
-            raise TypeError(f"f must be callable, got {f}")
+        def wrapper(f):
+            if not callable(f):
+                raise TypeError(f"f must be callable, got {f}")
 
-        signature = inspect.signature(f)
-        parameter_names = signature.parameters.keys()
+            signature = inspect.signature(f)
+            parameter_names = signature.parameters.keys()
+            source = PythonToJavaScriptTranslator(f).compile()
+            args = ", ".join(parameter_names)
+            strict_str = repr("use strict") + ";\n" if strict else ""
+            function_body = f"""\
+{strict_str}{source}
+return {f.__name__}({args});\
+"""
 
-        udf_node_fields = {
-            name: rlz.value(type) for name, type in zip(parameter_names, input_type)
-        }
+            return self.js(
+                name=f.__name__,
+                params=(dict(zip(parameter_names, input_type))),
+                output_type=output_type,
+                body=function_body,
+                libraries=libraries,
+                determinism=determinism,
+            )
+
+        return wrapper
+
+    @staticmethod
+    def js(
+        name: str,
+        params: Mapping[str, dt.DataType],
+        output_type: dt.DataType,
+        body: str,
+        libraries: Iterable[str] | None = None,
+        determinism: bool | None = None,
+    ) -> Callable:
+        '''Define a Javascript UDF for BigQuery.
+
+        `INT64` is not supported as an argument type or a return type, as per
+        [the BigQuery documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/user-defined-functions#sql-type-encodings-in-javascript).
+
+        Parameters
+        ----------
+        name:
+            The name of the function.
+        params
+            Mapping of names and types of parameters
+        output_type
+            Return type of the UDF.
+        body:
+            The code of the function.
+        libraries
+            An iterable of Google Cloud Storage URIs containing to JavaScript source
+            code. Note that any symbols (functions, classes, variables, etc.) that
+            are exposed in these JavaScript files will be visible inside the UDF.
+        determinism
+            Provides a hint to BigQuery as to whether the query result can be cached.
+
+        Returns
+        -------
+        Callable
+            The user-defined function.
+
+        Examples
+        --------
+        >>> from ibis.backends.bigquery import udf
+        >>> import ibis.expr.datatypes as dt
+        >>> add_one = udf.js(
+        ...     name="add_one",
+        ...     params={"a": dt.double},
+        ...     output_type=dt.double,
+        ...     body="return x + 1"
+        ... )
+        >>> print(add_one.js)
+        CREATE TEMPORARY FUNCTION add_one_0(x FLOAT64)
+        RETURNS FLOAT64
+        LANGUAGE js AS """
+        return x + 1
+        """;
+        '''
+        validate_output_type(output_type)
+
+        if libraries is None:
+            libraries = []
+
+        udf_node_fields = {name: rlz.value(type_) for name, type_ in params.items()}
 
         udf_node_fields["output_dtype"] = output_type
         udf_node_fields["output_shape"] = rlz.shape_like("args")
         udf_node_fields["__slots__"] = ("js",)
 
-        udf_node = create_udf_node(f.__name__, udf_node_fields)
+        udf_node = _create_udf_node(name, udf_node_fields)
+
+        from ibis.backends.bigquery.compiler import compiles
 
         @compiles(udf_node)
         def compiles_udf_node(t, op):
             args = ", ".join(map(t.translate, op.args))
             return f"{udf_node.__name__}({args})"
 
-        type_translation_context = UDFContext()
-        return_type = ibis_type_to_bigquery_type(
-            dt.dtype(output_type), type_translation_context
-        )
         bigquery_signature = ", ".join(
             "{name} {type}".format(
                 name=name,
-                type=ibis_type_to_bigquery_type(
-                    dt.dtype(type), type_translation_context
-                ),
+                type=ibis_type_to_bigquery_type(dt.dtype(type_), UDF_CONTEXT),
             )
-            for name, type in zip(parameter_names, input_type)
+            for name, type_ in params.items()
         )
-        source = PythonToJavaScriptTranslator(f).compile()
-        args = ", ".join(parameter_names)
-        strict_str = repr("use strict") + ";\n" if strict else ""
+        return_type = ibis_type_to_bigquery_type(dt.dtype(output_type), UDF_CONTEXT)
         libraries_opts = (
             f"\nOPTIONS (\n    library={repr(list(libraries))}\n)" if libraries else ""
         )
+        determinism_formatted = {
+            True: 'DETERMINISTIC\n',
+            False: 'NOT DETERMINISTIC\n',
+            None: '',
+        }.get(determinism)
         js = f'''\
 CREATE TEMPORARY FUNCTION {udf_node.__name__}({bigquery_signature})
 RETURNS {return_type}
-LANGUAGE js AS """
-{strict_str}{source}
-return {f.__name__}({args});
+{determinism_formatted}LANGUAGE js AS """
+{body}
 """{libraries_opts};'''
 
-        @functools.wraps(f)
         def wrapped(*args, **kwargs):
             node = udf_node(*args, **kwargs)
             object.__setattr__(node, "js", js)
             return node.to_expr()
 
-        wrapped.__signature__ = signature
+        wrapped.__signature__ = inspect.Signature(
+            parameters=[
+                inspect.Parameter(
+                    name=param, kind=inspect.Parameter.POSITIONAL_OR_KEYWORD
+                )
+                for param in params.keys()
+            ]
+        )
+        wrapped.__name__ = name
         wrapped.js = js
         return wrapped
 
-    return wrapper
+
+udf = _BigQueryUDF()


### PR DESCRIPTION
Hello,

Our Python to Javascript translation is awesome, but I'm sure there are users who have existing Javascript functions that they would like to use, so I'm adding a new `udf_js` function that adds Javascript functions.

As the next step, I will want to add support for SQL functions, which may be easier to use than adding new operations to add custom business logic.

Best regards,
Kamil Breguła