### PR TITLE
refactor(sqlalchemy): move `_get_schema_using_query` to base class

### DIFF
--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import abc
 import contextlib
 import getpass
 from operator import methodcaller
-from typing import TYPE_CHECKING, Any, Literal, Mapping
+from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping
 
 import sqlalchemy as sa
 
@@ -38,6 +39,8 @@ from ibis.backends.base.sql.alchemy.translator import (
 
 if TYPE_CHECKING:
     import pandas as pd
+
+    import ibis.expr.datatypes as dt
 
 
 __all__ = (
@@ -554,3 +557,11 @@ class BaseAlchemyBackend(BaseSQLBackend):
             con.execute(compiled, **params)
         self._temp_views.add(raw_name)
         self._register_temp_view_cleanup(name, raw_name)
+
+    @abc.abstractmethod
+    def _metadata(self, query: str) -> Iterable[tuple[str, dt.DataType]]:
+        ...
+
+    def _get_schema_using_query(self, query: str) -> sch.Schema:
+        """Return an ibis Schema from a backend-specific SQL string."""
+        return sch.Schema.from_tuples(self._metadata(query))

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -471,10 +471,6 @@ SELECT * FROM read_csv({', '.join(args)})"""
             ibis_type = parse(type)
             yield name, ibis_type(nullable=null.lower() == "yes")
 
-    def _get_schema_using_query(self, query: str) -> sch.Schema:
-        """Return an ibis Schema from a DuckDB SQL string."""
-        return sch.Schema.from_tuples(self._metadata(query))
-
     def _register_in_memory_table(self, table_op):
         df = table_op.data.to_frame()
         self.con.execute("register", (table_op.name, df))

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -18,21 +18,20 @@ import datetime
 import sqlite3
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.sqlite import DATETIME, TIMESTAMP
 
-if TYPE_CHECKING:
-    import ibis.expr.datatypes as dt
-    import ibis.expr.types as ir
-
-import ibis.expr.schema as sch
 from ibis.backends.base import Database
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend, to_sqla_type
 from ibis.backends.sqlite import udf
 from ibis.backends.sqlite.compiler import SQLiteCompiler
 from ibis.expr.schema import datatype
+
+if TYPE_CHECKING:
+    import ibis.expr.datatypes as dt
+    import ibis.expr.types as ir
 
 
 def to_datetime(value: str | None) -> datetime.datetime | None:
@@ -214,7 +213,7 @@ class Backend(BaseAlchemyBackend):
     def _current_schema(self) -> str | None:
         return self.current_database
 
-    def _get_schema_using_query(self, query: str) -> sch.Schema:
+    def _metadata(self, _: str) -> Iterable[tuple[str, dt.DataType]]:
         raise ValueError(
             "The SQLite backend cannot infer schemas from raw SQL - "
             "please specify the schema directly when calling `.sql` "

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -8,7 +8,6 @@ import sqlalchemy as sa
 import toolz
 
 import ibis.expr.datatypes as dt
-import ibis.expr.schema as sch
 from ibis import util
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.trino.compiler import TrinoSQLCompiler
@@ -61,8 +60,3 @@ class Backend(BaseAlchemyBackend):
             for name, type in toolz.pluck(["Column Name", "Type"], rows):
                 ibis_type = parse(type)
                 yield name, ibis_type(nullable=True)
-
-    def _get_schema_using_query(self, query: str) -> sch.Schema:
-        """Return an ibis Schema from a DuckDB SQL string."""
-        pairs = self._metadata(query)
-        return sch.Schema.from_tuples(pairs)


### PR DESCRIPTION
This PR moves `_get_schema_using_query` to the base sqlalchemy backend class.