### PR TITLE
chore: remove reference to ibis-bigquery package

### DIFF
--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -14,7 +14,7 @@ __all__ += api.__all__
 
 __version__ = "4.0.0"
 
-_KNOWN_BACKENDS = ['bigquery', 'heavyai']
+_KNOWN_BACKENDS = ['heavyai']
 
 
 def __dir__() -> list[str]:

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -18,7 +18,6 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.backends.base.sql import BaseSQLBackend
-from ibis.backends.bigquery import version as ibis_bigquery_version
 from ibis.backends.bigquery.client import (
     BigQueryCursor,
     BigQueryDatabase,
@@ -35,8 +34,6 @@ with contextlib.suppress(ImportError):
 
 if TYPE_CHECKING:
     import pyarrow as pa
-
-__version__: str = ibis_bigquery_version.__version__
 
 SCOPES = ["https://www.googleapis.com/auth/bigquery"]
 EXTERNAL_DATA_SCOPES = [

--- a/ibis/backends/bigquery/version.py
+++ b/ibis/backends/bigquery/version.py
@@ -1,3 +1,0 @@
-from __future__ import annotations
-
-__version__ = "2.2.0"


### PR DESCRIPTION
Hello,

I checked and we still had some references from ibis-bigquery which is no longer maintained.

Now we still have one reference, but it's only in tests, so it's okay.
```
git ls-files -z | xargs -0 grep 'ibis.bigquery' | grep -v "ibis\.bigquery\.\(connect\|compile\)"
docs/release_notes.md:* Move BigQuery backend to a `separate repository <https://github.com/ibis-project/ibis-bigquery>`_. The backend will be released separately, use `pip install ibis-bigquery` or `conda install ibis-bigquery` to install it, and then use as before. ([#2665](https://github.com/ibis-project/ibis/issues/2665))
ibis/backends/bigquery/tests/conftest.py:    # https://github.com/ibis-project/ibis-bigquery/issues/30
```

Best regards