### PR TITLE
chore(deps): squash sqlalchemy 2.0 warnings coming from 1.4.45

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,3 +2,4 @@ use flake
 watch_file poetry.lock
 
 export CLOUDSDK_ACTIVE_CONFIG_NAME=ibis-gbq
+export SQLALCHEMY_WARN_20=1

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -35,6 +35,8 @@ jobs:
   test_backends:
     name: ${{ matrix.backend.title }} ${{ matrix.os }} python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    env:
+      SQLALCHEMY_WARN_20: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -286,6 +288,8 @@ jobs:
   test_backends_min_version:
     name: ${{ matrix.backend.title }} Min Version ${{ matrix.os }} python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    env:
+      SQLALCHEMY_WARN_20: "1"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -30,6 +30,8 @@ concurrency:
 jobs:
   test_no_backends:
     name: Test ${{ matrix.os }} python-${{ matrix.python-version }}
+    env:
+      SQLALCHEMY_WARN_20: "1"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/docs/sqlalchemy_example.py
+++ b/docs/sqlalchemy_example.py
@@ -7,16 +7,14 @@ i = sa.table("investments")
 
 a = (
     sa.select(
-        [
-            sa.case(
-                [(i.c.investor_name.is_(None), "NO INVESTOR")],
-                else_=i.c.investor_name,
-            ).label("investor_name"),
-            sa.func.count(c.c.permalink.distinct()).label("num_investments"),
-            sa.func.count(
-                sa.case([(c.status.in_(("ipo", "acquired")), c.c.permalink)]).distinct()
-            ).label("acq_ipos"),
-        ]
+        sa.case(
+            [(i.c.investor_name.is_(None), "NO INVESTOR")],
+            else_=i.c.investor_name,
+        ).label("investor_name"),
+        sa.func.count(c.c.permalink.distinct()).label("num_investments"),
+        sa.func.count(
+            sa.case([(c.status.in_(("ipo", "acquired")), c.c.permalink)]).distinct()
+        ).label("acq_ipos"),
     )
     .select_from(
         c.join(i, onclause=c.c.permalink == i.c.company_permalink, isouter=True)
@@ -24,4 +22,4 @@ a = (
     .group_by(1)
     .order_by(sa.desc(2))
 )
-expr = sa.select([(a.c.acq_ipos / a.c.num_investments).label("acq_rate")])
+expr = sa.select((a.c.acq_ipos / a.c.num_investments).label("acq_rate"))

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -112,26 +112,17 @@ class BaseSQLBackend(BaseBackend):
     def _get_schema_using_query(self, query):
         raise NotImplementedError(f"Backend {self.name} does not support .sql()")
 
-    def raw_sql(self, query: str) -> Any:
+    def raw_sql(self, query: str):
         """Execute a query string.
 
-        Could have unexpected results if the query modifies the behavior of
-        the session in a way unknown to Ibis; be careful.
+        !!! warning "The returned cursor object must be **manually** released if results are returned."
 
         Parameters
         ----------
         query
-            DML or DDL statement
-
-        Returns
-        -------
-        Any
-            Backend cursor
+            DDL or DML statement
         """
-        # TODO `self.con` is assumed to be defined in subclasses, but there
-        # is nothing that enforces it. We should find a way to make sure
-        # `self.con` is always a DBAPI2 connection, or raise an error
-        cursor = self.con.execute(query)  # type: ignore
+        cursor = self.con.execute(query)
         if cursor:
             return cursor
         cursor.release()

--- a/ibis/backends/base/sql/alchemy/database.py
+++ b/ibis/backends/base/sql/alchemy/database.py
@@ -22,7 +22,7 @@ class AlchemyTable(ops.DatabaseTable):
         if name is None:
             name = sqla_table.name
         if schema is None:
-            schema = sch.infer(sqla_table, schema=schema)
+            schema = sch.infer(sqla_table, schema=schema, dialect=source.con.dialect)
         super().__init__(name=name, schema=schema, sqla_table=sqla_table, source=source)
 
     # TODO(kszucs): remove this

--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -9,6 +9,7 @@ from sqlalchemy.dialects.mssql.base import MSDialect
 from sqlalchemy.dialects.mysql.base import MySQLDialect
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.dialects.sqlite.base import SQLiteDialect
+from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.types import UserDefinedType
@@ -424,8 +425,12 @@ def sa_struct(dialect, satype, nullable=True):
 
 
 @sch.infer.register((sa.Table, sa.sql.TableClause))
-def schema_from_table(table: sa.Table, schema: sch.Schema | None = None) -> sch.Schema:
-    """Retrieve an ibis schema from a SQLAlchemy ``Table``.
+def schema_from_table(
+    table: sa.Table,
+    schema: sch.Schema | None = None,
+    dialect: sa.engine.interfaces.Dialect | None = None,
+) -> sch.Schema:
+    """Retrieve an ibis schema from a SQLAlchemy `Table`.
 
     Parameters
     ----------
@@ -433,6 +438,8 @@ def schema_from_table(table: sa.Table, schema: sch.Schema | None = None) -> sch.
         Table whose schema to infer
     schema
         Schema to pull types from
+    dialect
+        Optional sqlalchemy dialect
 
     Returns
     -------
@@ -446,7 +453,7 @@ def schema_from_table(table: sa.Table, schema: sch.Schema | None = None) -> sch.
             dtype = dt.dtype(schema[name])
         else:
             dtype = dt.dtype(
-                getattr(table.bind, 'dialect', Dialect()),
+                dialect or getattr(table.bind, "dialect", DefaultDialect()),
                 column.type,
                 nullable=column.nullable,
             )

--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -228,10 +228,8 @@ class AlchemySelect(Select):
         else:
             clauses = to_select
 
-        if self.exists:
-            result = sa.exists(clauses)
-        else:
-            result = sa.select(clauses)
+        result_func = sa.exists if self.exists else sa.select
+        result = result_func(*clauses)
 
         if self.distinct:
             result = result.distinct()

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -267,7 +267,7 @@ def _translate_case(t, cases, results, default):
     whens = zip(case_args, result_args)
     default = t.translate(default)
 
-    return sa.case(list(whens), else_=default)
+    return sa.case(*whens, else_=default)
 
 
 def _negate(t, op):
@@ -410,7 +410,7 @@ def reduction(sa_func):
 def _zero_if_null(t, op):
     sa_arg = t.translate(op.arg)
     return sa.case(
-        [(sa_arg.is_(None), sa.cast(0, t.get_sqla_type(op.output_dtype)))],
+        (sa_arg.is_(None), sa.cast(0, t.get_sqla_type(op.output_dtype))),
         else_=sa_arg,
     )
 
@@ -606,7 +606,7 @@ sqlalchemy_operation_registry: dict[Any, Any] = {
     ops.Clip: _clip(min_func=sa.func.least, max_func=sa.func.greatest),
     ops.Where: fixed_arity(
         lambda predicate, value_if_true, value_if_false: sa.case(
-            [(predicate, value_if_true)],
+            (predicate, value_if_true),
             else_=value_if_false,
         ),
         3,

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -138,8 +138,8 @@ def recreate_database(
 
     if url.database is not None:
         with engine.begin() as conn:
-            conn.execute(f'DROP DATABASE IF EXISTS {database}')
-            conn.execute(f'CREATE DATABASE {database}')
+            conn.execute(sa.text(f'DROP DATABASE IF EXISTS {database}'))
+            conn.execute(sa.text(f'CREATE DATABASE {database}'))
 
 
 def init_database(
@@ -181,7 +181,7 @@ def init_database(
     if schema:
         with engine.begin() as conn:
             for stmt in filter(None, map(str.strip, schema.read().split(';'))):
-                conn.execute(stmt)
+                conn.exec_driver_sql(stmt)
 
     return engine
 

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -117,20 +117,16 @@ def _neg_idx_to_pos(array, idx):
 
 def _regex_extract(string, pattern, index):
     result = sa.case(
-        [
-            (
-                sa.func.regexp_matches(string, pattern),
-                sa.func.regexp_extract(
-                    string,
-                    pattern,
-                    # DuckDB requires the index to be a constant so we compile
-                    # the value and inline it using sa.text
-                    sa.text(
-                        str(index.compile(compile_kwargs=dict(literal_binds=True)))
-                    ),
-                ),
-            )
-        ],
+        (
+            sa.func.regexp_matches(string, pattern),
+            sa.func.regexp_extract(
+                string,
+                pattern,
+                # DuckDB requires the index to be a constant so we compile
+                # the value and inline it using sa.text
+                sa.text(str(index.compile(compile_kwargs=dict(literal_binds=True)))),
+            ),
+        ),
         else_="",
     )
     return result

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+import sqlalchemy as sa
 
 import ibis
 
@@ -18,18 +19,22 @@ def test_read_parquet(data_directory):
 
 
 def test_temp_directory(tmp_path):
-    query = "SELECT value FROM duckdb_settings() WHERE name = 'temp_directory'"
+    query = sa.text("SELECT value FROM duckdb_settings() WHERE name = 'temp_directory'")
 
     # 1. in-memory + no temp_directory specified
     con = ibis.duckdb.connect()
-    [(value,)] = con.con.execute(query).fetchall()
-    assert value  # we don't care what the specific value is
+    with con.begin() as c:
+        cur = c.execute(query)
+        value = cur.scalar()
+        assert value  # we don't care what the specific value is
 
     temp_directory = Path(tempfile.gettempdir()) / "duckdb"
 
     # 2. in-memory + temp_directory specified
     con = ibis.duckdb.connect(temp_directory=temp_directory)
-    [(value,)] = con.con.execute(query).fetchall()
+    with con.begin() as c:
+        cur = c.execute(query)
+        value = cur.scalar()
     assert value == str(temp_directory)
 
     # 3. on-disk + no temp_directory specified
@@ -38,7 +43,9 @@ def test_temp_directory(tmp_path):
 
     # 4. on-disk + temp_directory specified
     con = ibis.duckdb.connect(tmp_path / "test2.ddb", temp_directory=temp_directory)
-    [(value,)] = con.con.execute(query).fetchall()
+    with con.begin() as c:
+        cur = c.execute(query)
+        value = cur.scalar()
     assert value == str(temp_directory)
 
 

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -92,7 +92,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                         "LINES TERMINATED BY '\\n'",
                         "IGNORE 1 LINES",
                     ]
-                    con.execute("\n".join(lines))
+                    con.execute(sa.text("\n".join(lines)))
 
     @staticmethod
     def connect(_: Path):

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -72,10 +72,8 @@ def _typeof(t, op):
     # select pg_typeof('thing') returns unknown so we have to check the child's
     # type for nullness
     return sa.case(
-        [
-            ((typ == 'unknown') & (op.arg.output_dtype != dt.null), 'text'),
-            ((typ == 'unknown') & (op.arg.output_dtype == dt.null), 'null'),
-        ],
+        ((typ == 'unknown') & (op.arg.output_dtype != dt.null), 'text'),
+        ((typ == 'unknown') & (op.arg.output_dtype == dt.null), 'null'),
         else_=typ,
     )
 
@@ -264,7 +262,7 @@ def _regex_extract(arg, pattern, index):
     index = index + 1
     does_match = sa.func.textregexeq(arg, pattern)
     matches = sa.func.regexp_match(arg, pattern, type_=pg.ARRAY(sa.TEXT))
-    return sa.case([(does_match, matches[index])], else_=None)
+    return sa.case((does_match, matches[index]), else_=None)
 
 
 def _array_repeat(t, op):
@@ -351,7 +349,7 @@ def _mod(t, op):
 
 
 def _neg_idx_to_pos(array, idx):
-    return sa.case([(idx < 0, sa.func.cardinality(array) + idx)], else_=idx)
+    return sa.case((idx < 0, sa.func.cardinality(array) + idx), else_=idx)
 
 
 def _array_slice(*, index_converter, array_length):

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -90,7 +90,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                 with data_dir.joinpath(f'{table}.csv').open('r') as file:
                     cur.copy_expert(sql=sql, file=file)
 
-        engine.execute('VACUUM FULL ANALYZE')
+            con.execute(sa.text("VACUUM FULL ANALYZE"))
 
     @staticmethod
     def connect(data_directory: Path):

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -114,12 +114,11 @@ def test_schema_type_conversion():
         ibis_types.append((name, ibis_type(nullable=nullable)))
 
     # Create a table with placeholder stubs for JSON, JSONB, and UUID.
-    engine = sa.create_engine('postgresql://')
-    table = sa.Table('tname', sa.MetaData(bind=engine), *sqla_types)
+    table = sa.Table('tname', sa.MetaData(), *sqla_types)
 
     # Check that we can correctly create a schema with dt.any for the
     # missing types.
-    schema = schema_from_table(table)
+    schema = schema_from_table(table, dialect=postgresql.dialect())
     expected = ibis.schema(ibis_types)
 
     assert_equal(schema, expected)
@@ -135,40 +134,16 @@ def test_interval_films_schema(con):
     ("column", "expected_dtype"),
     [
         # a, b and g are variable length intervals, like YEAR TO MONTH
-        ("c", dt.Interval("D")),
-        ("d", dt.Interval("h")),
-        ("e", dt.Interval("m")),
-        ("f", dt.Interval("s")),
-        ("h", dt.Interval("h")),
-        ("i", dt.Interval("m")),
-        ("j", dt.Interval("s")),
-        ("k", dt.Interval("m")),
-        ("l", dt.Interval("s")),
-        ("m", dt.Interval("s")),
-    ],
-)
-def test_all_interval_types_schema(intervals, column, expected_dtype):
-    assert intervals[column].type() == expected_dtype
-
-
-@pytest.mark.parametrize(
-    ("column", "expected_dtype"),
-    [
-        # a, b and g are variable length intervals, like YEAR TO MONTH
-        ("c", dt.Interval("D")),
-        ("d", dt.Interval("h")),
-        ("e", dt.Interval("m")),
-        ("f", dt.Interval("s")),
-        ("h", dt.Interval("h")),
-        ("i", dt.Interval("m")),
-        ("j", dt.Interval("s")),
-        ("k", dt.Interval("m")),
-        ("l", dt.Interval("s")),
-        ("m", dt.Interval("s")),
+        param("c", dt.Interval("D"), id="day"),
+        param("d", dt.Interval("h"), id="hour"),
+        param("e", dt.Interval("m"), id="minute"),
+        param("f", dt.Interval("s"), id="second"),
     ],
 )
 def test_all_interval_types_execute(intervals, column, expected_dtype):
     expr = intervals[column]
+    assert expr.type() == expected_dtype
+
     series = expr.execute()
     assert series.dtype == np.dtype("timedelta64[ns]")
 
@@ -244,7 +219,10 @@ def test_create_and_drop_table(con, temp_table, params):
 def test_get_schema_from_query(con, pg_type, expected_type):
     raw_name = ibis.util.guid()
     name = con.con.dialect.identifier_preparer.quote_identifier(raw_name)
-    con.raw_sql(f"CREATE TEMPORARY TABLE {name} (x {pg_type}, y {pg_type}[])")
+    with con.begin() as c:
+        c.execute(
+            sa.text(f"CREATE TEMPORARY TABLE {name} (x {pg_type}, y {pg_type}[])")
+        )
     expected_schema = ibis.schema(dict(x=expected_type, y=dt.Array(expected_type)))
     result_schema = con._get_schema_using_query(f"SELECT x, y FROM {name}")
     assert result_schema == expected_schema

--- a/ibis/backends/postgres/udf.py
+++ b/ibis/backends/postgres/udf.py
@@ -194,7 +194,8 @@ $$;
         internal_name=python_func.__name__,
         args=', '.join(parameter_names),
     )
-    client.con.execute(formatted_sql)
+    with client.begin() as con:
+        con.execute(sa.text(formatted_sql))
     return existing_udf(
         name=internal_name,
         input_types=in_types,

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -65,16 +65,14 @@ def _round(t, op):
 
 def _day_of_week_name(arg):
     return sa.case(
+        ("Sun", "Sunday"),
+        ("Mon", "Monday"),
+        ("Tue", "Tuesday"),
+        ("Wed", "Wednesday"),
+        ("Thu", "Thursday"),
+        ("Fri", "Friday"),
+        ("Sat", "Saturday"),
         value=sa.func.dayname(arg),
-        whens=[
-            ("Sun", "Sunday"),
-            ("Mon", "Monday"),
-            ("Tue", "Tuesday"),
-            ("Wed", "Wednesday"),
-            ("Thu", "Thursday"),
-            ("Fri", "Friday"),
-            ("Sat", "Saturday"),
-        ],
         else_=None,
     )
 

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -665,14 +665,14 @@ def test_compile_with_named_table():
     t = ibis.table([('a', 'string')], name='t')
     result = ibis.sqlite.compile(t.a)
     st = sa.table('t', sa.column('a', sa.String)).alias('t0')
-    assert str(result) == str(sa.select([st.c.a]))
+    assert str(result) == str(sa.select(st.c.a))
 
 
 def test_compile_with_unnamed_table():
     t = ibis.table([('a', 'string')])
     result = ibis.sqlite.compile(t.a)
     st = sa.table(t.op().name, sa.column('a', sa.String)).alias('t0')
-    assert str(result) == str(sa.select([st.c.a]))
+    assert str(result) == str(sa.select(st.c.a))
 
 
 def test_compile_with_multiple_unnamed_tables():
@@ -683,7 +683,7 @@ def test_compile_with_multiple_unnamed_tables():
     sqla_t = sa.table(t.op().name, sa.column('a', sa.String)).alias('t0')
     sqla_s = sa.table(s.op().name, sa.column('b', sa.String)).alias('t1')
     sqla_join = sqla_t.join(sqla_s, sqla_t.c.a == sqla_s.c.b)
-    expected = sa.select([sqla_t.c.a, sqla_s.c.b]).select_from(sqla_join)
+    expected = sa.select(sqla_t.c.a, sqla_s.c.b).select_from(sqla_join)
     assert str(result) == str(expected)
 
 
@@ -695,7 +695,7 @@ def test_compile_with_one_unnamed_table():
     sqla_t = sa.table(t.op().name, sa.column('a', sa.String)).alias('t0')
     sqla_s = sa.table('s', sa.column('b', sa.String)).alias('t1')
     sqla_join = sqla_t.join(sqla_s, sqla_t.c.a == sqla_s.c.b)
-    expected = sa.select([sqla_t.c.a, sqla_s.c.b]).select_from(sqla_join)
+    expected = sa.select(sqla_t.c.a, sqla_s.c.b).select_from(sqla_join)
     assert str(result) == str(expected)
 
 

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -524,19 +524,18 @@ def test_sa_default_numeric_precision_and_scale(
     sqla_types = []
     ibis_types = []
     for name, t, ibis_type in typespec:
-        sqla_type = sa.Column(name, t, nullable=True)
-        sqla_types.append(sqla_type)
+        sqla_types.append(sa.Column(name, t, nullable=True))
         ibis_types.append((name, ibis_type(nullable=True)))
 
     # Create a table with the numeric types.
     table_name = 'test_sa_default_param_decimal'
-    engine = con.con
-    table = sa.Table(table_name, sa.MetaData(bind=engine), *sqla_types)
-    table.create(bind=engine, checkfirst=True)
+    table = sa.Table(table_name, sa.MetaData(), *sqla_types)
+    with con.begin() as bind:
+        table.create(bind=bind, checkfirst=True)
 
     try:
         # Check that we can correctly recover the default precision and scale.
-        schema = schema_from_table(table)
+        schema = schema_from_table(table, dialect=con.con.dialect)
         expected = ibis.schema(ibis_types)
 
         assert_equal(schema, expected)

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -27,6 +27,8 @@ IBIS_TEST_TRINO_DB = os.environ.get(
     os.environ.get('TRINO_DATABASE', 'memory'),
 )
 
+sa = pytest.importorskip("sqlalchemy")
+
 
 class TestConf(BackendTest, RoundAwayFromZero):
     # trino rounds half to even for double precision and half away from zero
@@ -72,8 +74,8 @@ class TestConf(BackendTest, RoundAwayFromZero):
                 source = f"postgresql.public.{table}"
                 dest = f"memory.default.{table}"
                 with con.begin() as c:
-                    c.execute(f"DROP TABLE IF EXISTS {dest}")
-                    c.execute(f"CREATE TABLE {dest} AS SELECT * FROM {source}")
+                    c.execute(sa.text(f"DROP TABLE IF EXISTS {dest}"))
+                    c.execute(sa.text(f"CREATE TABLE {dest} AS SELECT * FROM {source}"))
 
         selects = []
         for row in struct_types.abc:
@@ -87,15 +89,19 @@ class TestConf(BackendTest, RoundAwayFromZero):
             selects.append(f"SELECT {datarow} AS abc")
 
         with con.begin() as c:
-            c.execute("DROP TABLE IF EXISTS struct")
-            c.execute(f"CREATE TABLE struct AS {' UNION ALL '.join(selects)}")
-            c.execute("DROP TABLE IF EXISTS map")
-            c.execute("CREATE TABLE map (kv MAP<VARCHAR, BIGINT>)")
+            c.execute(sa.text("DROP TABLE IF EXISTS struct"))
+            c.execute(sa.text(f"CREATE TABLE struct AS {' UNION ALL '.join(selects)}"))
+            c.execute(sa.text("DROP TABLE IF EXISTS map"))
+            c.execute(sa.text("CREATE TABLE map (kv MAP<VARCHAR, BIGINT>)"))
             c.execute(
-                "INSERT INTO map VALUES (MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]))"
+                sa.text(
+                    "INSERT INTO map VALUES (MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]))"
+                )
             )
             c.execute(
-                "INSERT INTO map VALUES (MAP(ARRAY['d', 'e', 'f'], ARRAY[4, 5, 6]))"
+                sa.text(
+                    "INSERT INTO map VALUES (MAP(ARRAY['d', 'e', 'f'], ARRAY[4, 5, 6]))"
+                )
             )
 
     @staticmethod


### PR DESCRIPTION
This PR updates our code to squash all sqlalchemy 2.0 warnings. This gives us a better chance at 1.x and 2.x compatibility when 2 comes out.

I flipped on the `SQLALCHEMY_WARN_20` environment variable, which allows us to catch any regressions in CI.

Closes #5048.