### PR TITLE
feat: add new `ibis.get_backend` function

### DIFF
--- a/docs/api/expressions/top_level.md
+++ b/docs/api/expressions/top_level.md
@@ -15,6 +15,7 @@ These methods and objects are available directly in the `ibis` module.
 ::: ibis.date
 ::: ibis.desc
 ::: ibis.difference
+::: ibis.get_backend
 ::: ibis.greatest
 ::: ibis.ifelse
 ::: ibis.intersect

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -862,3 +862,16 @@ def test_has_operation_no_geo(con):
     """
     for op in [ops.GeoDistance, ops.GeoAsText, ops.GeoUnaryUnion]:
         assert not con.has_operation(op)
+
+
+def test_get_backend(con, alltypes, monkeypatch):
+    assert ibis.get_backend(alltypes) is con
+    assert ibis.get_backend(alltypes.id.min()) is con
+
+    with pytest.raises(com.IbisError, match="contains unbound tables"):
+        ibis.get_backend(ibis.table({"x": "int"}))
+
+    monkeypatch.setattr(ibis.options, "default_backend", con)
+    assert ibis.get_backend() is con
+    expr = ibis.literal(1) + 2
+    assert ibis.get_backend(expr) is con

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -20,7 +20,7 @@ import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
-from ibis.backends.base import connect
+from ibis.backends.base import BaseBackend, connect
 from ibis.expr.decompile import decompile
 from ibis.expr.deferred import Deferred
 from ibis.expr.schema import Schema
@@ -118,6 +118,7 @@ __all__ = (
     'geo_y',
     'geo_y_max',
     'geo_y_min',
+    'get_backend',
     'greatest',
     'ifelse',
     'infer_dtype',
@@ -867,6 +868,27 @@ def read_parquet(sources: str | Path, **kwargs: Any) -> ir.Table:
 
     con = _default_backend()
     return con.read_parquet(sources, **kwargs)
+
+
+def get_backend(expr: Expr | None = None) -> BaseBackend:
+    """Get the current Ibis backend to use for a given expression.
+
+    Parameters
+    ----------
+    expr
+        An expression to get the backend from. If not passed, the default
+        backend is returned.
+
+    Returns
+    -------
+    BaseBackend
+        The Ibis backend.
+    """
+    if expr is None:
+        from ibis.config import _default_backend
+
+        return _default_backend()
+    return expr._find_backend(use_default=True)
 
 
 e = ops.E().to_expr()

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -329,7 +329,7 @@ class Expr(Immutable):
         results
             RecordBatchReader
         """
-        return self._find_backend().to_pyarrow_batches(
+        return self._find_backend(use_default=True).to_pyarrow_batches(
             self,
             params=params,
             limit=limit,
@@ -365,7 +365,7 @@ class Expr(Immutable):
         Table
             A pyarrow table holding the results of the executed expression.
         """
-        return self._find_backend().to_pyarrow(
+        return self._find_backend(use_default=True).to_pyarrow(
             self, params=params, limit=limit, **kwargs
         )
 

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -227,8 +227,7 @@ class Expr(Immutable):
                     "assign a backend instance to "
                     "`ibis.options.default_backend`."
                 )
-            if (default := options.default_backend) is None and use_default:
-                default = _default_backend()
+            default = _default_backend() if use_default else None
             if default is None:
                 raise IbisError(
                     'Expression depends on no backends, and found no default'
@@ -236,7 +235,7 @@ class Expr(Immutable):
             return default
 
         if len(backends) > 1:
-            raise ValueError('Multiple backends found')
+            raise IbisError('Multiple backends found for this expression')
 
         return backends[0]
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1473,10 +1473,7 @@ def test_multiple_db_different_backends():
     backend2_table = con2.table('alltypes')
 
     expr = backend1_table.union(backend2_table)
-    with pytest.raises(
-        ValueError,
-        match=re.compile("multiple backends", flags=re.IGNORECASE),
-    ):
+    with pytest.raises(com.IbisError, match="Multiple backends"):
         expr.compile()
 
 


### PR DESCRIPTION
This PR adds a new `ibis.get_backend` function for finding the current execution backend for an expression, or the default backend if no expression is provided.

```python
# returns the default backend
ibis.get_backend() 

# returns the backend for a given bound expression. An error is raised if unbound tables are
# present, or if multiple backends are found
ibis.get_backend(some_expr)
```

Also fixes a small bug where `to_pyarrow`/`to_pyarrow_batches` wouldn't fallback to using the default backend if no bound tables were found (while `.execute` would).

Fixes #5064.