### PR TITLE
fix(ir): error for `order_by` on nonexistent column

### DIFF
--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -134,11 +134,16 @@ def sort_key_from(table_ref, key, **kwargs):
     else:
         key, order = key, True
 
-    key = one_of(
-        (function_of(table_ref), column_from(table_ref), any),
-        key,
-        **kwargs,
-    )
+    if isinstance(key, (str, int)):
+        # Actual str/int keys must refer to columns in the table, we don't want
+        # to fallback to converting them to expressions with ibis.literal
+        key = column_from(table_ref, key, **kwargs)
+    else:
+        key = one_of(
+            (function_of(table_ref), column_from(table_ref), any),
+            key,
+            **kwargs,
+        )
 
     if isinstance(order, str):
         order = order.lower()

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -454,6 +454,36 @@ def test_order_by_scalar(table, key, expected):
     assert result.op().sort_keys == (ops.SortKey(expected),)
 
 
+@pytest.mark.parametrize(
+    "key",
+    [
+        "bogus",
+        ("bogus", False),
+        ibis.desc("bogus"),
+        1000,
+        (1000, False),
+        _.bogus,
+        _.bogus.desc(),
+    ],
+)
+@pytest.mark.parametrize(
+    "expr_func",
+    [
+        param(lambda t: t, id="table"),
+        param(lambda t: t.select("a", "b"), id="selection"),
+        param(lambda t: t.group_by("a").agg(new=_.b.sum()), id="aggregation"),
+    ],
+)
+def test_order_by_nonexistent_column_errors(table, expr_func, key):
+    # `order_by` is implemented on a few different operations, we check them
+    # all in turn here.
+    expr = expr_func(table)
+    # Depending on the expression, this can raise a few different errors.
+    # For now just check that an exception is raised.
+    with pytest.raises(Exception):
+        expr.order_by(key)
+
+
 def test_slice(table):
     expr = table[:5]
     expr2 = table[:5:1]


### PR DESCRIPTION
Fixes #5214 