### PR TITLE
docs: Update links to contributing guides

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,8 +4,7 @@ We love new contributors!
 
 To get started:
 
-1. [Set up a development environment](https://ibis-project.org/docs/latest/contribute/01_environment/)
-1. [Learn about the commit workflow](https://ibis-project.org/docs/latest/contribute/02_workflow/)
-1. [Review the code style guidelines](https://ibis-project.org/docs/latest/contribute/03_style/)
-1. [Learn how to run the backend test suite](https://ibis-project.org/docs/latest/contribute/04_backend_tests/)
-1. [Dig into the nitty gritty of being a maintainer](https://ibis-project.org/docs/latest/contribute/05_maintainers_guide/)
+1. [Set up a development environment](https://ibis-project.org/docs/latest/community/contribute/01_environment/)
+1. [Learn about the commit workflow](https://ibis-project.org/docs/latest/community/contribute/02_workflow/)
+1. [Review the code style guidelines](https://ibis-project.org/docs/latest/community/contribute/03_style/)
+1. [Dig into the nitty gritty of being a maintainer](https://ibis-project.org/docs/latest/community/contribute/05_maintainers_guide/)

--- a/docs/community/contribute/02_workflow.md
+++ b/docs/community/contribute/02_workflow.md
@@ -25,6 +25,12 @@ pytest -m core
     or any specific backends (`ibis/backends`) this material isn't necessary to
     follow to make a pull request.
 
+First, we need to download example data to run the tests successfully:
+
+```sh
+just download-data
+```
+
 To run the tests for a specific backend (e.g. sqlite):
 
 ```sh
@@ -48,14 +54,6 @@ If anything seems amiss with a backend, you can of course test it locally:
 ```sh
 export PGPASSWORD=postgres
 psql -t -A -h localhost -U postgres -d ibis_testing -c "select 'success'"
-```
-
-## Download Test Data
-
-Backends need to be populated with test data to run the tests successfully:
-
-```sh
-just download-data
 ```
 
 ## Writing the commit


### PR DESCRIPTION
First, the worflow and backend_tests guides were merged together,
so delete the link to the one of them.

Second, these links were going to the 3.2.0 docs,
so update to the new path.