### PR TITLE
feat: make Backend.tables.__repr__ look like list

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -204,6 +204,12 @@ class TablesAccessor(collections.abc.Mapping):
         )
         return list(o)
 
+    def __repr__(self) -> str:
+        tables = self._backend.list_tables()
+        rows = ["Tables", "------"]
+        rows.extend(f"- {name}" for name in sorted(tables))
+        return "\n".join(rows)
+
     def _ipython_key_completions_(self) -> list[str]:
         return self._backend.list_tables()
 

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -77,6 +77,11 @@ def test_tables_accessor_tab_completion(con):
     assert 'functional_alltypes' in keys
 
 
+def test_tables_accessor_repr(con):
+    result = repr(con.tables)
+    assert '- functional_alltypes' in result
+
+
 @pytest.mark.parametrize(
     "expr_fn",
     [


### PR DESCRIPTION
In a notebook I want to see the names of the tables in the database.
Before I would get
'<ibis.backends.base.TablesAccessor object at 0x118321c90>'

Now I get

```
[
    "df",
    "df0",
    "df1",
    "df10",
    "df11",
    "df12"
]
```


I considered just doing `return repr(list(self))`,
but I wanted the tables to be in sorted order,
and I wanted them to be indented so they'd be
easier to scan with your eyes.

The test is a bit lax, but I wanted it to be future-proof.