### PR TITLE
chore: refresh cache after 1 hour in backend matrix app

### DIFF
--- a/docs/backends/app/backend_info_app.py
+++ b/docs/backends/app/backend_info_app.py
@@ -10,7 +10,7 @@ import streamlit as st
 st.set_page_config(layout='wide')
 
 
-@st.cache
+@st.cache(ttl=3600)
 def load_ops_data():
     response = requests.get(
         'https://ibis-project.org/docs/dev/backends/raw_support_matrix.csv'


### PR DESCRIPTION
This data never refreshes now, so I set the cache TTL to 1h so that we don't have old data.