### PR TITLE
refactor(backend): simplify pyarrow batching code

### DIFF
--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -215,6 +215,9 @@ class Schema(Concrete):
 
         return ibis_to_pyarrow_schema(self)
 
+    def as_struct(self) -> dt.Struct:
+        return dt.Struct(self.names, self.types)
+
     def __gt__(self, other: Schema) -> bool:
         """Return whether `self` is a strict superset of `other`."""
         return set(self.items()) > set(other.items())


### PR DESCRIPTION
This PR simplifies a bit of the code around getting schemas for pyarrow batching, and adds a new `Schema.as_struct` method to convert `Schema` objects into `Struct` types.