### PR TITLE
docs(api): document more public expression APIs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: ruff
         # exclude a file (if configured to do so), even if it's passed in explicitly
-        args: ["--force-exclude", "--fix"]
+        args: ["--force-exclude"]
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.29.0
     hooks:

--- a/ibis/expr/operations/analytic.py
+++ b/ibis/expr/operations/analytic.py
@@ -62,53 +62,11 @@ class RankBase(Analytic):
 
 @public
 class MinRank(RankBase):
-    """Compute position of first element within each equal-value group in sorted order.
-
-    Equivalent to SQL's `RANK()`.
-
-    Examples
-    --------
-    values   ranks
-    1        0
-    1        0
-    2        2
-    2        2
-    2        2
-    3        5
-
-    Returns
-    -------
-    Int64Column
-        The min rank
-    """
-
     arg = rlz.column(rlz.any)
 
 
 @public
 class DenseRank(RankBase):
-    """Position of first element within each group of equal values.
-
-    Values are returned in sorted order and duplicate values are ignored.
-
-    Equivalent to SQL's `DENSE_RANK()`.
-
-    Examples
-    --------
-    values   ranks
-    1        0
-    1        0
-    2        1
-    2        1
-    2        1
-    3        2
-
-    Returns
-    -------
-    IntegerColumn
-        The rank
-    """
-
     arg = rlz.column(rlz.any)
 
 
@@ -168,11 +126,6 @@ class CumulativeMean(CumulativeOp):
 
 @public
 class CumulativeMax(CumulativeOp):
-    """Cumulative max.
-
-    Requires an order window.
-    """
-
     arg = rlz.column(rlz.any)
     output_dtype = rlz.dtype_like("arg")
 

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -64,6 +64,25 @@ class Expr(Immutable):
         return fmt(self)
 
     def equals(self, other):
+        """Return whether this expression is _structurally_ equivalent to `other`.
+
+        If you want to produce an equality expression, use `==` syntax.
+
+        Parameters
+        ----------
+        other
+            Another expression
+
+        Examples
+        --------
+        >>> t1 = ibis.table(dict(a="int"), name="t")
+        >>> t2 = ibis.table(dict(a="int"), name="t")
+        >>> t1.equals(t2)
+        True
+        >>> v = ibis.table(dict(a="string"), name="v")
+        >>> t1.equals(v)
+        False
+        """
         if not isinstance(other, Expr):
             raise TypeError(
                 f"invalid equality comparison between Expr and {type(other)}"
@@ -76,9 +95,11 @@ class Expr(Immutable):
     __nonzero__ = __bool__
 
     def has_name(self):
+        """Check whether this expression has an explicit name."""
         return isinstance(self._arg, ops.Named)
 
     def get_name(self):
+        """Return the name of this expression."""
         return self._arg.name
 
     def _repr_png_(self) -> bytes | None:
@@ -172,7 +193,7 @@ class Expr(Immutable):
         else:
             return f(self, *args, **kwargs)
 
-    def op(self) -> ops.Node:
+    def op(self) -> ops.Node:  # noqa: D102
         return self._arg
 
     def _find_backends(self) -> tuple[list[BaseBackend], bool]:

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -85,6 +85,7 @@ class GroupedTable:
             return GroupedArray(col, self)
 
     def aggregate(self, metrics=None, **kwds):
+        """Compute aggregates over a group by."""
         return self.table.aggregate(metrics, by=self.by, having=self._having, **kwds)
 
     agg = aggregate
@@ -290,6 +291,13 @@ class GroupedArray:
     group_concat = _group_agg_dispatch('group_concat')
 
     def summary(self, exact_nunique=False):
+        """Summarize a column.
+
+        Parameters
+        ----------
+        exact_nunique
+            Whether to compute an exact count distinct.
+        """
         metric = self.arr.summary(exact_nunique=exact_nunique)
         return self.parent.aggregate(metric)
 
@@ -297,7 +305,3 @@ class GroupedArray:
 class GroupedNumbers(GroupedArray):
     mean = _group_agg_dispatch('mean')
     sum = _group_agg_dispatch('sum')
-
-    def summary(self, exact_nunique=False):
-        metric = self.arr.summary(exact_nunique=exact_nunique)
-        return self.parent.aggregate(metric)

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -78,23 +78,35 @@ class BooleanScalar(NumericScalar, BooleanValue):
 @public
 class BooleanColumn(NumericColumn, BooleanValue):
     def any(self, where: BooleanValue | None = None) -> BooleanValue:
+        """Return whether at least one element is `True`.
+
+        Parameters
+        ----------
+        where
+            Optional filter for the aggregation
+        """
         import ibis.expr.analysis as an
 
         return an._make_any(self, ops.Any, where=where)
 
     def notany(self, where: BooleanValue | None = None) -> BooleanValue:
+        """Return whether no elements are `True`."""
         import ibis.expr.analysis as an
 
         return an._make_any(self, ops.NotAny, where=where)
 
     def all(self, where: BooleanValue | None = None) -> BooleanScalar:
+        """Return whether all elements are `True`."""
         return ops.All(self, where=where).to_expr()
 
     def notall(self, where: BooleanValue | None = None) -> BooleanScalar:
+        """Return whether not all elements are `True`."""
         return ops.NotAll(self, where=where).to_expr()
 
     def cumany(self) -> BooleanColumn:
+        """Accumulate the `any` aggregate."""
         return ops.CumulativeAny(self).to_expr()
 
     def cumall(self) -> BooleanColumn:
+        """Accumulate the `all` aggregate."""
         return ops.CumulativeAll(self).to_expr()

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -466,6 +466,7 @@ class NumericColumn(Column, NumericValue):
         return ops.Mean(self, where=where).to_expr()
 
     def cummean(self) -> NumericColumn:
+        """Return the cumulative mean of the input."""
         return ops.CumulativeMean(self).to_expr()
 
     def sum(
@@ -487,6 +488,7 @@ class NumericColumn(Column, NumericValue):
         return ops.Sum(self, where=where).to_expr()
 
     def cumsum(self) -> NumericColumn:
+        """Return the cumulative sum of the input."""
         return ops.CumulativeSum(self).to_expr()
 
     def bucket(

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -93,7 +93,23 @@ class Table(Expr, JupyterMixin):
     def __array__(self, dtype=None):
         return self.execute().__array__(dtype)
 
-    def as_table(self):
+    def as_table(self) -> Table:
+        """Promote the expression to a table.
+
+        This method is a no-op for table expressions.
+
+        Returns
+        -------
+        Table
+            A table expression
+
+        Examples
+        --------
+        >>> t = ibis.table(dict(a="int"), name="t")
+        >>> s = t.as_table()
+        >>> t is s
+        True
+        """
         return self
 
     def __contains__(self, name):
@@ -254,6 +270,7 @@ class Table(Expr, JupyterMixin):
 
     @property
     def columns(self):
+        """The list of columns in this table."""
         return list(self._arg.schema.names)
 
     def schema(self) -> sch.Schema:

--- a/ibis/expr/types/ruff.toml
+++ b/ibis/expr/types/ruff.toml
@@ -1,0 +1,2 @@
+select = ["D102"]
+show-source = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -391,6 +391,12 @@ ignore = [
 ]
 exclude = ["*_py310.py", "ibis/tests/*/snapshots/*"]
 target-version = "py38"
+show-source = true
+fix = true
+# don't delete print statements
+# don't remove unused imports
+# don't remove unused noqa
+unfixable = ["T201", "F401", "RUF100"]
 
 [tool.ruff.per-file-ignores]
 "*test*.py" = ["D"] # ignore all docstring lints in tests


### PR DESCRIPTION
This PR documents more public expression APIs. I did not document deprecated methods (`to_projection`) or methods that are public but not typically used by analytics end users (`op`). Closes #5263.