### PR TITLE
chore(ux): let the transaction error bubble up to avoid nested useless tracebacks

### DIFF
--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -43,12 +43,10 @@ class Backend(BaseAlchemyBackend):
     @contextlib.contextmanager
     def begin(self):
         with super().begin() as bind:
-            previous_datefirst = bind.execute(sa.text('SELECT @@DATEFIRST')).scalar()
+            prev = bind.execute(sa.text('SELECT @@DATEFIRST')).scalar()
             bind.execute(sa.text('SET DATEFIRST 1'))
-            try:
-                yield bind
-            finally:
-                bind.execute(sa.text(f"SET DATEFIRST {previous_datefirst}"))
+            yield bind
+            bind.execute(sa.text("SET DATEFIRST :prev").bindparams(prev=prev))
 
     def _metadata(self, query):
         if query in self.list_tables():

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -119,12 +119,10 @@ class Backend(BaseAlchemyBackend):
     @contextlib.contextmanager
     def begin(self):
         with super().begin() as bind:
-            previous_timezone = bind.execute(sa.text('SHOW TIMEZONE')).scalar()
+            prev = bind.execute(sa.text('SHOW TIMEZONE')).scalar()
             bind.execute(sa.text('SET TIMEZONE = UTC'))
-            try:
-                yield bind
-            finally:
-                bind.execute(sa.text(f"SET TIMEZONE = '{previous_timezone}'"))
+            yield bind
+            bind.execute(sa.text("SET TIMEZONE = :prev").bindparams(prev=prev))
 
     def udf(
         self,

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -93,19 +93,17 @@ class Backend(BaseAlchemyBackend):
     @contextlib.contextmanager
     def begin(self):
         with super().begin() as bind:
-            previous_timezone = (
+            prev = (
                 bind.execute(sa.text("SHOW PARAMETERS LIKE 'TIMEZONE' IN SESSION"))
                 .mappings()
                 .fetchone()
                 .value
             )
             bind.execute(sa.text("ALTER SESSION SET TIMEZONE = 'UTC'"))
-            try:
-                yield bind
-            finally:
-                bind.execute(
-                    sa.text(f"ALTER SESSION SET TIMEZONE = {previous_timezone!r}")
-                )
+            yield bind
+            bind.execute(
+                sa.text("ALTER SESSION SET TIMEZONE = :prev").bindparams(prev=prev)
+            )
 
     def _get_sqla_table(
         self, name: str, schema: str | None = None, **_: Any


### PR DESCRIPTION
This PR removes `finally:` block that tries to reset the session time zone. This is mostly useless since the entire block is happening inside of a transaction and will be rolleed back if an exception is thrown.