### PR TITLE
test(dot-sql): make `dot_sql` tests less flaky

### DIFF
--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -581,9 +581,7 @@ class BaseAlchemyBackend(BaseSQLBackend):
         return self.con.dialect.identifier_preparer.quote(name)
 
     def _get_temp_view_definition(
-        self,
-        name: str,
-        definition: sa.sql.compiler.Compiled,
+        self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
         raise NotImplementedError(
             f"The {self.name} backend does not implement temporary view creation"
@@ -593,8 +591,8 @@ class BaseAlchemyBackend(BaseSQLBackend):
         query = f"DROP VIEW IF EXISTS {name}"
 
         def drop(self, raw_name: str, query: str):
-            with self.con.begin() as con:
-                con.execute(query)
+            with self.begin() as con:
+                con.exec_driver_sql(query)
             self._temp_views.discard(raw_name)
 
         atexit.register(drop, self, raw_name, query)

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -474,9 +474,7 @@ SELECT * FROM read_csv({', '.join(args)})"""
             return super()._get_sqla_table(name, schema, **kwargs)
 
     def _get_temp_view_definition(
-        self,
-        name: str,
-        definition: sa.sql.compiler.Compiled,
+        self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
         yield f"CREATE OR REPLACE TEMPORARY VIEW {name} AS {definition}"
 

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -59,8 +59,6 @@ class Backend(BaseAlchemyBackend):
                 yield column["name"], _type_from_result_set_info(column)
 
     def _get_temp_view_definition(
-        self,
-        name: str,
-        definition: sa.sql.compiler.Compiled,
+        self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
         yield f"CREATE OR ALTER VIEW {name} AS {definition}"

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -136,9 +136,7 @@ class Backend(BaseAlchemyBackend):
             )
 
     def _get_temp_view_definition(
-        self,
-        name: str,
-        definition: sa.sql.compiler.Compiled,
+        self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
         yield f"CREATE OR REPLACE VIEW {name} AS {definition}"
 

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -176,7 +176,7 @@ class Backend(BaseAlchemyBackend):
     def _metadata(self, query: str) -> Iterable[tuple[str, dt.DataType]]:
         raw_name = util.guid()
         name = self._quote(raw_name)
-        type_info_sql = f"""\
+        type_info_sql = """\
 SELECT
   attname,
   format_type(atttypid, atttypmod) AS type
@@ -194,8 +194,6 @@ ORDER BY attnum"""
             con.execute(sa.text(f"DROP VIEW IF EXISTS {name}"))
 
     def _get_temp_view_definition(
-        self,
-        name: str,
-        definition: sa.sql.compiler.Compiled,
+        self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
         yield f"CREATE OR REPLACE VIEW {name} AS {definition}"

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -198,4 +198,4 @@ ORDER BY attnum"""
         name: str,
         definition: sa.sql.compiler.Compiled,
     ) -> str:
-        yield f"CREATE OR REPLACE TEMPORARY VIEW {name} AS {definition}"
+        yield f"CREATE OR REPLACE VIEW {name} AS {definition}"

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -181,14 +181,15 @@ SELECT
   attname,
   format_type(atttypid, atttypmod) AS type
 FROM pg_attribute
-WHERE attrelid = {raw_name!r}::regclass
+WHERE attrelid = CAST(:raw_name AS regclass)
   AND attnum > 0
   AND NOT attisdropped
-ORDER BY attnum
-"""
+ORDER BY attnum"""
         with self.begin() as con:
             con.execute(sa.text(f"CREATE TEMPORARY VIEW {name} AS {query}"))
-            type_info = con.execute(sa.text(type_info_sql))
+            type_info = con.execute(
+                sa.text(type_info_sql).bindparams(raw_name=raw_name)
+            )
             yield from ((col, _get_type(typestr)) for col, typestr in type_info)
             con.execute(sa.text(f"DROP VIEW IF EXISTS {name}"))
 

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -256,9 +256,7 @@ class Backend(BaseAlchemyBackend):
         return sch.Schema.from_tuples(self._metadata(query))
 
     def _get_temp_view_definition(
-        self,
-        name: str,
-        definition: sa.sql.compiler.Compiled,
+        self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
         yield f"DROP VIEW IF EXISTS {name}"
         yield f"CREATE VIEW {name} AS {definition}"


### PR DESCRIPTION
This PR seems to fix the current flakiness in `test_dot_sql.py`.

While I'm not 100% sure it does, I was able to reproduce the [current flakiness](https://github.com/ibis-project/ibis/actions/runs/3968820831/jobs/6802496984)
by running the tests locally like so:

```
pytest -n 4 -m postgres -x --dist=loadgroup
```

When I run the tests without `--dist=loadgroup` I cannot reproduce the issue. This isn't viable generally because 
some backends cannot run queries across processes (which is the concurrency model for `pytest-xdist`).

This change moves the `xdist_group` marker to decorate each test instead of being a module level marker, which doesn't seem to work.

Things I tried:

1. A larger number of processes seems cause fewer failures, much to my surprise.
2. Running the `dot_sql` tests in isolation (either alone or running all the tests from `test_dot_sql.py` doesn't fail

I am going to keep running the tests locally to see if I can reproduce it and will report back either way.
