### PR TITLE
feat(snowflake): add struct column operation

### DIFF
--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -260,6 +260,9 @@ operation_registry.update(
         ),
         ops.NthValue: _nth_value,
         ops.Arbitrary: _arbitrary,
+        ops.StructColumn: lambda t, op: sa.func.object_construct_keep_null(
+            *itertools.chain.from_iterable(zip(op.names, map(t.translate, op.values)))
+        ),
     }
 )
 

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -75,7 +75,7 @@ def test_null_literal(con, field):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["dask", "pandas", "postgres", "snowflake"])
+@pytest.mark.notimpl(["dask", "pandas", "postgres"])
 def test_struct_column(alltypes, df):
     t = alltypes
     expr = ibis.struct(dict(a=t.string_col, b=1, c=t.bigint_col)).name("s")


### PR DESCRIPTION
This PR implements the `ops.StructColumn` and `ops.Time` operations for the Snowflake backend.