### PR TITLE
feat(ux): improve error message when column is not found

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -345,7 +345,9 @@ def test_select_filter_mutate(backend, alltypes, df):
 
 
 def test_table_fillna_invalid(alltypes):
-    with pytest.raises(com.IbisTypeError, match=r"'invalid_col' is not a field in.*"):
+    with pytest.raises(
+        com.IbisTypeError, match=r"Column 'invalid_col' is not found in table"
+    ):
         alltypes.fillna({'invalid_col': 0.0})
 
     with pytest.raises(
@@ -412,7 +414,9 @@ def test_mutate_rename(alltypes):
 
 
 def test_dropna_invalid(alltypes):
-    with pytest.raises(com.IbisTypeError, match=r"'invalid_col' is not a field in.*"):
+    with pytest.raises(
+        com.IbisTypeError, match=r"Column 'invalid_col' is not found in table"
+    ):
         alltypes.dropna(subset=['invalid_col'])
 
     with pytest.raises(ValueError, match=r".*is not in.*"):

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -35,7 +35,11 @@ class TableColumn(Value, Named):
             name = table.schema.name_at_position(name)
 
         if name not in table.schema:
-            raise com.IbisTypeError(f"value {name!r} is not a field in {table.schema}")
+            columns_formatted = ', '.join(map(repr, table.schema.names))
+            raise com.IbisTypeError(
+                f"Column {name!r} is not found in table. "
+                f"Existing columns: {columns_formatted}."
+            )
 
         super().__init__(table=table, name=name)
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -956,12 +956,14 @@ class Table(Expr, JupyterMixin):
 
         if isinstance(replacements, collections.abc.Mapping):
             for col, val in replacements.items():
-                try:
-                    col_type = schema[col]
-                except KeyError:
+                if col not in schema:
+                    columns_formatted = ', '.join(map(repr, schema.names))
                     raise com.IbisTypeError(
-                        f'{col!r} is not a field in {schema}.'
+                        f"Column {col!r} is not found in table. "
+                        f"Existing columns: {columns_formatted}."
                     ) from None
+
+                col_type = schema[col]
                 val_type = val.type() if isinstance(val, Expr) else dt.infer(val)
                 if not dt.castable(val_type, col_type):
                     raise com.IbisTypeError(


### PR DESCRIPTION
Hello,

Now, the complete schema is unreadable if the exception content is displayed on one line.
Now I'm just displaying the column names so it's easier to read in one line context.

Best regards