### PR TITLE
test(snowflake): use an always-valid identifier in testing map table creation

### DIFF
--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -212,7 +212,7 @@ def test_map_get_with_null_on_null_type_with_non_null(con):
 
 @pytest.fixture
 def tmptable(con):
-    name = guid()
+    name = f"tmp_{guid()}"
     yield name
 
     # some backends don't implement drop


### PR DESCRIPTION
This PR fixes an issue with creating a test table that doesn't get automatically quoted when using `con.create_table`

Test run looks good:

```
…/ibis on  fix-snowflake-create-map-table is 📦 v4.0.0 via 🐍 v3.10.9 via ❄️  impure (ibis-3.10.9) took 21s
❯ pytest ibis/backends/tests/test_map.py::test_map_create_table -m snowflake
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.10.9, pytest-7.2.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
Using --randomly-seed=574689024
rootdir: /home/cloud/src/ibis, configfile: pyproject.toml
plugins: mock-3.10.0, repeat-0.9.1, benchmark-4.0.0, xdist-3.1.0, hypothesis-6.62.1, snapshot-0.9.0, clarity-1.0.1, profiling-1.7.0, randomly-3.12.0, cov-4.0.0
collected 15 items / 14 deselected / 1 selected

ibis/backends/tests/test_map.py .                                                                                                                                                              [100%]

================================================================================= 1 passed, 14 deselected in 16.97s ==================================================================================
```
