### PR TITLE
test(sqlalchemy): do not attempt to drop the test database

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -138,8 +138,7 @@ def recreate_database(
 
     if url.database is not None:
         with engine.begin() as conn:
-            conn.execute(sa.text(f'DROP DATABASE IF EXISTS {database}'))
-            conn.execute(sa.text(f'CREATE DATABASE {database}'))
+            conn.execute(sa.text(f'CREATE DATABASE IF NOT EXISTS {database}'))
 
 
 def init_database(


### PR DESCRIPTION
This PR tries to address an issue observed in https://github.com/ibis-project/ibis/pull/5297#issuecomment-1400400732 where the `ibis_testing` database is dropped while another process is using it.
