### PR TITLE
chore(dev): don't try to drop databases that are automatically created

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
       retries: 3
       test:
         - CMD-SHELL
-        - /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -Q "DROP DATABASE IF EXISTS [ibis_testing]; CREATE DATABASE [ibis_testing]"
+        - /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -Q "IF DB_ID('ibis_testing') IS NULL BEGIN CREATE DATABASE [ibis_testing] END"
       timeout: 10s
     build:
       context: .
@@ -139,6 +139,8 @@ services:
     user: postgres
     environment:
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ibis_testing
+      POSTGRES_USER: postgres
     healthcheck:
       interval: 10s
       retries: 3

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -80,6 +80,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                 database=database,
                 schema=schema,
                 isolation_level="AUTOCOMMIT",
+                recreate=False,
             )
             with engine.begin() as con:
                 for table in TEST_TABLES:

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -74,6 +74,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                 database=database,
                 schema=schema,
                 isolation_level='AUTOCOMMIT',
+                recreate=False,
             )
 
         tables = list(TEST_TABLES) + ['geo']


### PR DESCRIPTION
This PR tries to address an issue observed in [this comment](https://github.com/ibis-project/ibis/pull/5297#issuecomment-1400400732) where the ibis_testing database is trying to be dropped while another process is using it. The approach here is to simply not try to drop databases that are created by the container on startup.