### PR TITLE
feat: add py.typed to allow mypy to type check packages that use ibis

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -510,6 +510,23 @@ class BaseBackend(abc.ABC, ResultHandler):
             The list of the table names that match the pattern `like`.
         """
 
+    @abc.abstractmethod
+    def table(self, name: str, database: str | None = None) -> ir.Table:
+        """Construct a table expression.
+
+        Parameters
+        ----------
+        name
+            Table name
+        database
+            Database name
+
+        Returns
+        -------
+        Table
+            Table expression
+        """
+
     @functools.cached_property
     def tables(self):
         """An accessor for tables in the database.


### PR DESCRIPTION
In checking a package I am working on, I noticed the BaseBackend.table() method was missing, and it appears this method should be available for all backends, so I added an abc method for it.

Fixes #5279 