### PR TITLE
fix(ux): remove extra trailing newline in expression repr

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -14,6 +14,7 @@ from ibis.common.exceptions import IbisError, IbisTypeError, TranslationError
 from ibis.common.grounds import Immutable
 from ibis.config import _default_backend, options
 from ibis.util import experimental
+from rich.jupyter import JupyterMixin
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -21,6 +22,15 @@ if TYPE_CHECKING:
     import ibis.expr.types as ir
     from ibis.backends.base import BaseBackend
     from ibis.expr.typing import TimeContext
+
+
+class _FixedTextJupyterMixin(JupyterMixin):
+    """JupyterMixin adds a spurious newline to text, this fixes the issue."""
+
+    def _repr_mimebundle_(self, *args, **kwargs):
+        bundle = super()._repr_mimebundle_(*args, **kwargs)
+        bundle["text/plain"] = bundle["text/plain"].rstrip()
+        return bundle
 
 
 # TODO(kszucs): consider to subclass from Annotable with a single _arg field

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence
 
 from public import public
-from rich.jupyter import JupyterMixin
 
 import ibis
 import ibis.common.exceptions as com
@@ -11,7 +10,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis import util
 from ibis.common.grounds import Singleton
-from ibis.expr.types.core import Expr, _binop
+from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir
@@ -570,7 +569,7 @@ class Scalar(Value):
 
 
 @public
-class Column(Value, JupyterMixin):
+class Column(Value, _FixedTextJupyterMixin):
     # Higher than numpy & dask objects
     __array_priority__ = 20
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -18,7 +18,6 @@ from typing import (
 )
 
 from public import public
-from rich.jupyter import JupyterMixin
 
 import ibis
 import ibis.common.exceptions as com
@@ -27,7 +26,7 @@ import ibis.expr.operations as ops
 from ibis import util
 from ibis.expr.deferred import Deferred
 from ibis.expr.selectors import Selector
-from ibis.expr.types.core import Expr
+from ibis.expr.types.core import Expr, _FixedTextJupyterMixin
 
 if TYPE_CHECKING:
     import ibis.expr.schema as sch
@@ -85,7 +84,7 @@ def _regular_join_method(
 
 
 @public
-class Table(Expr, JupyterMixin):
+class Table(Expr, _FixedTextJupyterMixin):
     # Higher than numpy & dask objects
     __array_priority__ = 20
 


### PR DESCRIPTION
This PR fixes an issue where the plain text repr has an additional newline. It appears to be coming from rich, and this is a workaround until upstream can be fixed.