### PR TITLE
chore(bigquery): remove deprecated `struct` API usage

### DIFF
--- a/ibis/backends/bigquery/client.py
+++ b/ibis/backends/bigquery/client.py
@@ -48,7 +48,7 @@ def bigquery_field_to_ibis_dtype(field):
         assert fields, "RECORD fields are empty"
         names = [el.name for el in fields]
         ibis_types = list(map(dt.dtype, fields))
-        ibis_type = dt.Struct(names, ibis_types)
+        ibis_type = dt.Struct(dict(zip(names, ibis_types)))
     else:
         ibis_type = _LEGACY_TO_STANDARD.get(typ, typ)
         ibis_type = _DTYPE_TO_IBIS_TYPE.get(ibis_type, ibis_type)
@@ -119,7 +119,7 @@ def bigquery_param(dtype, value, name):
 
 @bigquery_param.register
 def bq_param_struct(dtype: dt.Struct, value, name):
-    fields = dtype.pairs
+    fields = dtype.fields
     field_params = [bigquery_param(fields[k], v, k) for k, v in value.items()]
     result = bq.StructQueryParameter(name, *field_params)
     return result

--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -49,7 +49,7 @@ def _(typ: dt.Struct) -> Mapping[str, Any]:
     return {
         "field_type": "RECORD",
         "mode": "NULLABLE" if typ.nullable else "REQUIRED",
-        "fields": ibis_schema_to_bq_schema(ibis.schema(typ.pairs)),
+        "fields": ibis_schema_to_bq_schema(ibis.schema(typ.fields)),
     }
 
 

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -1101,7 +1101,7 @@ def test_tpc_h11(h11):
 
 def test_to_sqla_type_array_of_non_primitive():
     result = to_sqla_type(DefaultDialect(), dt.Array(dt.Struct(dict(a="int"))))
-    [(result_name, result_type)] = result.value_type.pairs
+    [(result_name, result_type)] = result.value_type.fields
     expected_name = "a"
     expected_type = sa.BigInteger()
     assert result_name == expected_name


### PR DESCRIPTION
This PR fixes a small issue where the BigQuery backend was using now-deprecated struct APIs.