### PR TITLE
fix(bigquery): resolve deprecation warnings for `StructType` and `Schema`

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -216,8 +216,8 @@ class Backend(BaseSQLBackend):
     def _get_schema_using_query(self, query):
         job_config = bq.QueryJobConfig(dry_run=True, use_query_cache=False)
         job = self.client.query(query, job_config=job_config)
-        names, ibis_types = self._adapt_types(job.schema)
-        return sch.Schema(names, ibis_types)
+        fields = self._adapt_types(job.schema)
+        return sch.Schema(fields)
 
     def _get_table_schema(self, qualified_name):
         dataset, table = qualified_name.rsplit(".", 1)
@@ -225,13 +225,7 @@ class Backend(BaseSQLBackend):
         return self.get_schema(table, database=dataset)
 
     def _adapt_types(self, descr):
-        names = []
-        adapted_types = []
-        for col in descr:
-            names.append(col.name)
-            typename = bigquery_field_to_ibis_dtype(col)
-            adapted_types.append(typename)
-        return names, adapted_types
+        return {col.name: bigquery_field_to_ibis_dtype(col) for col in descr}
 
     def _execute(self, stmt, results=True, query_parameters=None):
         job_config = bq.job.QueryJobConfig()

--- a/ibis/backends/bigquery/client.py
+++ b/ibis/backends/bigquery/client.py
@@ -119,7 +119,7 @@ def bigquery_param(dtype, value, name):
 
 @bigquery_param.register
 def bq_param_struct(dtype: dt.Struct, value, name):
-    fields = dtype.pairs
+    fields = dtype.fields
     field_params = [bigquery_param(fields[k], v, k) for k, v in value.items()]
     result = bq.StructQueryParameter(name, *field_params)
     return result

--- a/ibis/backends/bigquery/datatypes.py
+++ b/ibis/backends/bigquery/datatypes.py
@@ -42,7 +42,7 @@ def trans_struct(t):
     return "STRUCT<{}>".format(
         ", ".join(
             f"{name} {ibis_type_to_bigquery_type(dt.dtype(type_))}"
-            for name, type_ in zip(t.names, t.types)
+            for name, type_ in t.fields.items()
         )
     )
 

--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -49,7 +49,7 @@ def _(typ: dt.Struct) -> Mapping[str, Any]:
     return {
         "field_type": "RECORD",
         "mode": "NULLABLE" if typ.nullable else "REQUIRED",
-        "fields": ibis_schema_to_bq_schema(ibis.schema(typ.pairs)),
+        "fields": ibis_schema_to_bq_schema(ibis.schema(typ.fields)),
     }
 
 


### PR DESCRIPTION
depends on #5308 