### PR TITLE
test(bigquery): fix struct/schema deprecation warnings

### DIFF
--- a/ibis/backends/bigquery/client.py
+++ b/ibis/backends/bigquery/client.py
@@ -48,7 +48,7 @@ def bigquery_field_to_ibis_dtype(field):
         assert fields, "RECORD fields are empty"
         names = [el.name for el in fields]
         ibis_types = list(map(dt.dtype, fields))
-        ibis_type = dt.Struct(names, ibis_types)
+        ibis_type = dt.Struct(dict(zip(names, ibis_types)))
     else:
         ibis_type = _LEGACY_TO_STANDARD.get(typ, typ)
         ibis_type = _DTYPE_TO_IBIS_TYPE.get(ibis_type, ibis_type)

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -253,7 +253,7 @@ def test_large_compile():
         pass
 
     names = [f"col_{i}" for i in range(num_columns)]
-    schema = ibis.Schema(names, ["string"] * num_columns)
+    schema = ibis.Schema(dict.fromkeys(names, "string"))
     ibis_client = MockBackend()
     table = ops.SQLQueryResult("select * from t", schema, ibis_client).to_expr()
     for _ in range(num_joins):  # noqa: F402

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -56,7 +56,7 @@ class Schema(Concrete):
             return super().__create__(fields=names)
         else:
             warn_deprecated(
-                "Struct(names, types)",
+                "Schema(names, types)",
                 as_of="4.1",
                 removed_in="5.0",
                 instead=(


### PR DESCRIPTION
This fixes a few remaing fail-on-warning errors for the BigQuery backend and corrects a misspelling in the warning for Schema.