### PR TITLE
feat: support `connect()` with no arguments for dask and pandas

### DIFF
--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -30,14 +30,14 @@ class Backend(BasePandasBackend):
 
     def do_connect(
         self,
-        dictionary: MutableMapping[str, dd.DataFrame],
+        dictionary: MutableMapping[str, dd.DataFrame] | None = None,
     ) -> None:
         """Construct a Dask backend client from a dictionary of data sources.
 
         Parameters
         ----------
         dictionary
-            Mapping from `str` table names to Dask DataFrames.
+            An optional mapping from `str` table names to Dask DataFrames.
 
         Examples
         --------
@@ -51,6 +51,9 @@ class Backend(BasePandasBackend):
         """
         # register dispatchers
         from ibis.backends.dask import udf  # noqa: F401
+
+        if dictionary is None:
+            dictionary = {}
 
         for k, v in dictionary.items():
             if not isinstance(v, (dd.DataFrame, pd.DataFrame)):

--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -37,6 +37,11 @@ def table(client):
     return client.table('df')
 
 
+def test_connect_no_args():
+    con = ibis.dask.connect()
+    assert dict(con.tables) == {}
+
+
 def test_client_table(table):
     assert isinstance(table.op(), ibis.expr.operations.DatabaseTable)
     assert isinstance(table.op(), DaskTable)

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -33,14 +33,14 @@ class BasePandasBackend(BaseBackend):
 
     def do_connect(
         self,
-        dictionary: MutableMapping[str, pd.DataFrame],
+        dictionary: MutableMapping[str, pd.DataFrame] | None = None,
     ) -> None:
         """Construct a client from a dictionary of pandas DataFrames.
 
         Parameters
         ----------
         dictionary
-            Mutable mapping of string table names to pandas DataFrames.
+            An optional mapping of string table names to pandas DataFrames.
 
         Examples
         --------
@@ -51,7 +51,7 @@ class BasePandasBackend(BaseBackend):
         # register dispatchers
         from ibis.backends.pandas import execution, udf  # noqa: F401
 
-        self.dictionary = dictionary
+        self.dictionary = dictionary or {}
         self.schemas: MutableMapping[str, sch.Schema] = {}
 
     def from_dataframe(

--- a/ibis/backends/pandas/tests/test_client.py
+++ b/ibis/backends/pandas/tests/test_client.py
@@ -29,6 +29,11 @@ def test_data():
     return test_data
 
 
+def test_connect_no_args():
+    con = ibis.pandas.connect()
+    assert dict(con.tables) == {}
+
+
 def test_client_table(table):
     assert isinstance(table.op(), ibis.expr.operations.DatabaseTable)
     assert isinstance(table.op(), PandasTable)

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -42,7 +42,7 @@ class Backend(BaseBackend):
         Parameters
         ----------
         tables
-            Mutable mapping of string table names to polars LazyFrames.
+            An optional mapping of string table names to polars LazyFrames.
         """
         if not tables:
             tables = {}


### PR DESCRIPTION
A minor UX improvement, following up from #5275.