### PR TITLE
fix(bigquery): remove invalid operations from registry

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -712,6 +712,14 @@ _invalid_operations = {
     ops.FindInSet,
     ops.DateDiff,
     ops.TimestampDiff,
+    ops.ExtractAuthority,
+    ops.ExtractFile,
+    ops.ExtractFragment,
+    ops.ExtractHost,
+    ops.ExtractPath,
+    ops.ExtractProtocol,
+    ops.ExtractQuery,
+    ops.ExtractUserInfo,
 }
 
 OPERATION_REGISTRY = {


### PR DESCRIPTION
We should add support for these operations, but we can do it later. For now, I'd like the operation matrix to have real coverage.

If someone is interested in implementing it, they can do it based on this code.
https://github.com/GoogleCloudPlatform/bigquery-utils/blob/master/udfs/community/url_parse.sqlx