### PR TITLE
refactor(schema): remove deprecated `Schema.from_dict()`, `.delete()` and `.append()` methods

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -20,7 +20,6 @@ from ibis.common.validators import (
     map_to,
     validator,
 )
-from ibis.util import deprecated, warn_deprecated
 
 dtype = Dispatcher('dtype')
 

--- a/ibis/tests/expr/test_schema.py
+++ b/ibis/tests/expr/test_schema.py
@@ -137,11 +137,10 @@ def test_whole_schema():
 
 
 def test_schema_names_and_types_length_must_match():
-    with pytest.raises(IntegrityError), pytest.warns(FutureWarning):
-        sch.Schema(names=["a", "b"], types=["int", "str", "float"])
+    with pytest.raises(IntegrityError):
+        sch.schema(["a", "b"], ["int", "str", "float"])
 
-    with pytest.warns(FutureWarning):
-        schema = sch.Schema(names=["a", "b"], types=["int", "str"])
+    schema = sch.schema(["a", "b"], ["int", "str"])
 
     assert isinstance(schema, sch.Schema)
     assert schema.names == ("a", "b")
@@ -213,11 +212,3 @@ def test_api_accepts_schema_objects():
 def test_names_types():
     s = ibis.schema(names=["a"], types=["array<float64>"])
     assert s == ibis.schema(dict(a="array<float64>"))
-
-
-def test_schema_delete():
-    s1 = ibis.schema({"a": "int64", "b": "string", "c": "float64", "d": "int64"})
-    with pytest.warns(FutureWarning):
-        s2 = s1.delete(["b", "d"])
-
-    assert s2 == ibis.schema({"a": "int64", "c": "float64"})


### PR DESCRIPTION
BREAKING CHANGE: `Schema.from_dict()`, `.delete()` and `.append()` methods are removed
