### PR TITLE
feat(schema): implement `Mapping` abstract base class for `Schema`

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -671,12 +671,12 @@ class Struct(DataType, Mapping):
     @attribute.default
     def names(self) -> tuple[str, ...]:
         """Return the names of the struct's fields."""
-        return tuple(self.fields.keys())
+        return tuple(self.keys())
 
     @attribute.default
     def types(self) -> tuple[DataType, ...]:
         """Return the types of the struct's fields."""
-        return tuple(self.fields.values())
+        return tuple(self.values())
 
     def __len__(self) -> int:
         return len(self.fields)
@@ -688,9 +688,7 @@ class Struct(DataType, Mapping):
         return self.fields[key]
 
     def __repr__(self) -> str:
-        return '{}({}, nullable={})'.format(
-            self.name, list(self.fields.items()), self.nullable
-        )
+        return f"'{self.name}({list(self.items())}, nullable={self.nullable})"
 
     @property
     def _pretty_piece(self) -> str:

--- a/ibis/tests/expr/test_schema.py
+++ b/ibis/tests/expr/test_schema.py
@@ -212,3 +212,27 @@ def test_api_accepts_schema_objects():
 def test_names_types():
     s = ibis.schema(names=["a"], types=["array<float64>"])
     assert s == ibis.schema(dict(a="array<float64>"))
+
+
+def test_schema_mapping_api():
+    s = sch.Schema(
+        {
+            'a': 'map<double, string>',
+            'b': 'array<map<string, array<int32>>>',
+            'c': 'array<string>',
+            'd': 'int8',
+        }
+    )
+
+    assert s['a'] == dt.Map(dt.double, dt.string)
+    assert s['b'] == dt.Array(dt.Map(dt.string, dt.Array(dt.int32)))
+    assert s['c'] == dt.Array(dt.string)
+    assert s['d'] == dt.int8
+
+    assert 'a' in s
+    assert 'e' not in s
+    assert len(s) == 4
+    assert tuple(s) == s.names
+    assert tuple(s.keys()) == s.names
+    assert tuple(s.values()) == s.types
+    assert tuple(s.items()) == tuple(zip(s.names, s.types))


### PR DESCRIPTION
- refactor(schema): remove deprecated `Schema.from_dict()`, `.delete()` and `.append()` methods
- feat(datatype): implement `Mapping` abstract base class for `StructType`
- feat(schema): implement `Mapping` abstract base class for `Schema`
