### PR TITLE
refactor(ir/backends): remove various deprecated functions and methods

### DIFF
--- a/docs/backends/Impala.md
+++ b/docs/backends/Impala.md
@@ -29,7 +29,6 @@ backend.
     options:
       heading_level: 3
       members:
-        - set_database
         - create_database
         - drop_database
         - list_databases

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -375,24 +375,3 @@ def _rewrite_cast(op):
 @rewrites(ops.StringContains)
 def _rewrite_string_contains(op):
     return ops.GreaterEqual(ops.StringFind(op.haystack, op.needle), 0)
-
-
-NEW_EXTRACT_URL_OPERATION = {
-    "PROTOCOL": ops.ExtractProtocol,
-    "AUTHORITY": ops.ExtractAuthority,
-    "USERINFO": ops.ExtractUserInfo,
-    "HOST": ops.ExtractHost,
-    "FILE": ops.ExtractFile,
-    "PATH": ops.ExtractPath,
-    "REF": ops.ExtractFragment,
-}
-
-
-@rewrites(ops.ParseURL)
-def _rewrite_string_contains(op):
-    extract = op.extract
-    if extract == 'QUERY':
-        return ops.ExtractQuery(op.arg, op.key)
-    if (new_op := NEW_EXTRACT_URL_OPERATION.get(extract)) is not None:
-        return new_op(op.arg)
-    raise ValueError(f"{extract!r} is not supported")

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -673,7 +673,7 @@ def current_data_db(ddl_con) -> str:
 
 
 @pytest.fixture
-def alternate_current_database(ddl_con, ddl_backend, current_data_db: str) -> str:
+def alternate_current_database(ddl_con, ddl_backend) -> str:
     """Create a temporary database and yield its name. Drops the created
     database upon completion.
 
@@ -693,7 +693,6 @@ def alternate_current_database(ddl_con, ddl_backend, current_data_db: str) -> st
     try:
         yield name
     finally:
-        ddl_con.set_database(current_data_db)
         ddl_con.drop_database(name, force=True)
 
 

--- a/ibis/backends/duckdb/datatypes.py
+++ b/ibis/backends/duckdb/datatypes.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import parsy as p
 import toolz
 
-from ibis import util
 from ibis.common.parsing import (
     COMMA,
     FIELD,
@@ -152,10 +151,3 @@ def parse(text: str, default_decimal_parameters=(18, 3)) -> DataType:
     non_pg_array_type = primitive | decimal | list_array | map | struct
     ty = pg_array | non_pg_array_type
     return ty.parse(text)
-
-
-@util.deprecated(
-    instead=f"use {parse.__module__}.{parse.__name__}", as_of="4.0", removed_in="5.0"
-)
-def parse_type(*args, **kwargs):
-    return parse(*args, **kwargs)

--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -2,7 +2,7 @@ import pytest
 from pytest import param
 
 import ibis.expr.datatypes as dt
-from ibis.backends.duckdb.datatypes import parse, parse_type
+from ibis.backends.duckdb.datatypes import parse
 
 EXPECTED_SCHEMA = dict(
     a=dt.int64,
@@ -129,8 +129,3 @@ EXPECTED_SCHEMA = dict(
 def test_parser(column, type):
     ty = parse(type)
     assert ty == EXPECTED_SCHEMA[column]
-
-
-def test_parse_type_warns():
-    with pytest.warns(FutureWarning):
-        parse_type("BIGINT")

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -380,15 +380,6 @@ class Backend(BaseSQLBackend):
         tuples = cur.fetchall()
         return list(map(operator.itemgetter(0), tuples))
 
-    @util.deprecated(
-        as_of="2.0", removed_in="5.0", instead="use a new connection to the database"
-    )
-    def set_database(self, name):
-        # XXX The parent `Client` has a generic method that calls this same
-        # method in the backend. But for whatever reason calling this code from
-        # that method doesn't seem to work. Maybe `con` is a copy?
-        self.con.set_database(name)
-
     @property
     def current_database(self):
         # XXX The parent `Client` has a generic method that calls this same

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -73,9 +73,6 @@ class ImpalaConnection:
         """Close all idle Impyla connections."""
         self.pool.dispose()
 
-    def set_database(self, name):
-        self.database = name
-
     def disable_codegen(self, disabled=True):
         self.options["DISABLE_CODEGEN"] = str(int(disabled))
 
@@ -114,10 +111,6 @@ class ImpalaConnection:
         wrapper = ImpalaCursor(cursor, con, self.database, self.options.copy())
         wrapper.set_options()
         return wrapper
-
-    @util.deprecated(instead="", as_of="4.0", removed_in="5.0")
-    def ping(self):  # pragma: no cover
-        self.pool.connect()._cursor.ping()
 
     def release(self, cur):  # pragma: no cover
         pass

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -313,7 +313,6 @@ def tmp_db(env, con, test_data_db):
     try:
         yield tmp_db
     finally:
-        con.set_database(test_data_db)
         with contextlib.suppress(impala.error.HiveServer2Error):
             # The database can be dropped by another process during tear down
             # in the middle of dropping this one if tests are running in
@@ -353,7 +352,6 @@ def temp_database(con, test_data_db):
     try:
         yield name
     finally:
-        con.set_database(test_data_db)
         con.drop_database(name, force=True)
 
 

--- a/ibis/backends/impala/tests/test_client.py
+++ b/ibis/backends/impala/tests/test_client.py
@@ -302,23 +302,3 @@ def test_list_databases(con):
 def test_list_tables(con, test_data_db):
     assert con.list_tables(database=test_data_db)
     assert con.list_tables(like='*nat*', database=test_data_db)
-
-
-def test_set_database(con_no_db, test_data_db):
-    # create new connection with no default db set
-    # TODO: set test_data_db to None
-    with pytest.raises(Exception):
-        con_no_db.table('functional_alltypes')
-    con_no_db.set_database(test_data_db)
-    assert con_no_db.table('functional_alltypes') is not None
-
-
-def test_tables_robust_to_set_database(con, test_data_db, temp_database):
-    table = con.table('functional_alltypes', database=test_data_db)
-    con.set_database(temp_database)
-    assert con.current_database == temp_database
-
-    # it still works!
-    n = 10
-    df = table.limit(n).execute()
-    assert len(df) == n

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -13,7 +13,6 @@ import ibis.config
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
-from ibis import util
 from ibis.backends.base.sql import BaseSQLBackend
 from ibis.backends.base.sql.compiler import Compiler, TableSetFormatter
 from ibis.backends.base.sql.ddl import (
@@ -157,12 +156,6 @@ class Backend(BaseSQLBackend):
     @property
     def version(self):
         return pyspark.__version__
-
-    @util.deprecated(
-        as_of="2.0", removed_in="5.0", instead="use a new connection to the database"
-    )
-    def set_database(self, name):
-        self._catalog.setCurrentDatabase(name)
 
     @property
     def current_database(self):

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -212,6 +212,10 @@ def get_pyspark_testing_client(data_directory):
     return get_common_spark_testing_client(data_directory, ibis.pyspark.connect)
 
 
+def set_pyspark_database(client, database):
+    client._session.catalog.setCurrentDatabase(database)
+
+
 class TestConf(BackendTest, RoundAwayFromZero):
     supported_to_timestamp_units = {'s'}
 
@@ -303,7 +307,7 @@ def test_data_db(client):
     name = os.environ.get('IBIS_TEST_DATA_DB', 'ibis_testing')
     client.create_database(name)
     try:
-        client.set_database(name)
+        set_pyspark_database(client, name)
         yield name
     finally:
         client.drop_database(name, force=True)
@@ -316,7 +320,7 @@ def temp_database(client, test_data_db):
     try:
         yield name
     finally:
-        client.set_database(test_data_db)
+        set_pyspark_database(client, test_data_db)
         client.drop_database(name, force=True)
 
 

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -59,10 +59,6 @@ class DatabaseTable(PhysicalTable):
     schema = rlz.instance_of(sch.Schema)
     source = rlz.client
 
-    @util.deprecated(instead=".copy(name=new_name)", as_of="4.1", removed_in="5.0")
-    def change_name(self, new_name):
-        return self.copy(name=new_name)
-
 
 @public
 class SQLQueryResult(TableNode):

--- a/ibis/expr/operations/strings.py
+++ b/ibis/expr/operations/strings.py
@@ -4,7 +4,6 @@ from public import public
 
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
-from ibis import util
 from ibis.common.annotations import attribute
 from ibis.expr.operations.core import Unary, Value
 
@@ -223,33 +222,6 @@ class StringConcat(Value):
     arg = rlz.tuple_of(rlz.string)
     output_shape = rlz.shape_like('arg')
     output_dtype = rlz.dtype_like('arg')
-
-
-@public
-class ParseURL(Value):
-    arg = rlz.string
-    extract = rlz.isin(
-        {
-            'PROTOCOL',
-            'AUTHORITY',
-            'USERINFO',
-            'HOST',
-            'FILE',
-            'PATH',
-            'QUERY',
-            'REF',
-        }
-    )
-    key = rlz.optional(rlz.string)
-
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
-
-    @util.deprecated(
-        as_of="4.0", removed_in="5.0", instead="use ExtractURLField and its subclasses"
-    )
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
 
 @public

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -481,10 +481,6 @@ class Value(Expr):
         """Sort an expression descending."""
         return ops.SortKey(self, ascending=False).to_expr()
 
-    @util.deprecated(as_of="4.1", removed_in="5.0", instead="use `.as_table()`")
-    def to_projection(self) -> ir.Table:  # noqa: D102
-        return self.as_table()
-
     def as_table(self) -> ir.Table:
         """Promote the expression to a table.
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -226,48 +226,6 @@ class Table(Expr, _FixedTextJupyterMixin):
         else:
             return expr
 
-    @util.deprecated(
-        as_of="4.1",
-        removed_in="5.0",
-        instead="use a list comprehension and attribute/getitem syntax",
-    )
-    def get_columns(self, iterable: Iterable[str]) -> list[Column]:
-        """Get multiple columns from the table.
-
-        Parameters
-        ----------
-        iterable
-            An iterable of column names
-
-        Examples
-        --------
-        >>> import ibis
-        >>> table = ibis.table(dict(a='int64', b='string', c='timestamp', d='float'))
-        >>> a, b, c = table.get_columns(['a', 'b', 'c'])
-
-        Returns
-        -------
-        list[ir.Column]
-            List of column expressions
-        """
-        return list(map(self.get_column, iterable))
-
-    @util.deprecated(as_of="4.1", removed_in="5.0", instead="use t.<name> or t[name]")
-    def get_column(self, name: str) -> Column:
-        """Get a reference to a single column from the table.
-
-        Parameters
-        ----------
-        name
-            A column name
-
-        Returns
-        -------
-        Column
-            A column named `name`.
-        """
-        return ops.TableColumn(self, name).to_expr()
-
     @property
     def columns(self):
         """The list of columns in this table."""

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -635,51 +635,6 @@ class StringValue(Value):
         """
         return ops.StringToTimestamp(self, format_str).to_expr()
 
-    @util.deprecated(
-        as_of='4.0',
-        removed_in='5.0',
-        instead=(
-            'use .protocol(), .authroity(), .userinfo(), .host(), .file(), .path(), .query(), or .fragment().'
-        ),
-    )
-    def parse_url(
-        self,
-        extract: Literal[
-            "PROTOCOL",
-            "AUTHORITY",
-            "USERINFO",
-            "HOST",
-            "FILE",
-            "PATH",
-            "QUERY",
-            "REF",
-        ],
-        key: str | None = None,
-    ) -> StringValue:
-        """Parse a URL and extract its components.
-
-        `key` can be used to extract query values when `extract == 'QUERY'`
-
-        Parameters
-        ----------
-        extract
-            Component of URL to extract
-        key
-            Query component to extract
-
-        Examples
-        --------
-        >>> import ibis
-        >>> url = ibis.literal("https://www.youtube.com/watch?v=kEuEcWfewf8&t=10")
-        >>> result = url.parse_url('QUERY', 'v')  # kEuEcWfewf
-
-        Returns
-        -------
-        StringValue
-            Extracted string value
-        """
-        return ops.ParseURL(self, extract, key).to_expr()
-
     def protocol(self):
         """Parse a URL and extract protocol.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,7 +269,6 @@ filterwarnings = [
   # ibis
   "ignore:`BaseBackend.database` is deprecated:FutureWarning",
   "ignore:`Backend.database` is deprecated:FutureWarning",
-  "ignore:`Backend.set_database` is deprecated:FutureWarning",
   # ibis on postgres + windows
   "ignore:locale specific date formats:UserWarning",
   # shapely


### PR DESCRIPTION
BREAKING CHANGE: removed the following symbols:
- `ibis.backends.duckdb.parse_type()` function
- `ibis.backends.impala.Backend.set_database()` method
- `ibis.backends.pyspark.Backend.set_database()` method
- `ibis.backends.impala.ImpalaConnection.ping()` method
- `ibis.expr.operations.DatabaseTable.change_name()` method
- `ibis.expr.operations.ParseURL` class
- `ibis.expr.operations.Value.to_projection()` method
- `ibis.expr.types.Table.get_column()` method
- `ibis.expr.types.Table.get_columns()` method
- `ibis.expr.types.StringValue.parse_url()` method
