### PR TITLE
feat(datatype/schema): support datatype and schema declaration using type annotated classes

### DIFF
--- a/ibis/expr/datatypes/cast.py
+++ b/ibis/expr/datatypes/cast.py
@@ -168,7 +168,7 @@ def can_cast_struct(source, target, **kwargs):
 
 @castable.register(dt.Array, dt.Array)
 @castable.register(dt.Set, dt.Set)
-def can_cast_variadic(
+def can_cast_array_or_set(
     source: dt.Array | dt.Set, target: dt.Array | dt.Set, **kwargs
 ) -> bool:
     return castable(source.value_type, target.value_type)

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -333,6 +333,11 @@ def schema_from_pairs(lst):
     return Schema.from_tuples(lst)
 
 
+@schema.register(type)
+def schema_from_class(cls):
+    return Schema(dt.dtype(cls))
+
+
 @schema.register(Iterable, Iterable)
 def schema_from_names_types(names, types):
     # validate lengths of names and types are the same

--- a/ibis/tests/expr/test_datatypes.py
+++ b/ibis/tests/expr/test_datatypes.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+
 import datetime
+import decimal
 import enum
+import sys
+import uuid
 from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Dict, List, NamedTuple, Set, Tuple
 
 import pandas as pd
 import parsy
@@ -50,6 +57,291 @@ def test_validate_type():
 )
 def test_dtype(spec, expected):
     assert dt.dtype(spec) == expected
+
+
+@pytest.mark.parametrize(
+    ('klass', 'expected'),
+    [
+        (dt.Int16, dt.int16),
+        (dt.Int32, dt.int32),
+        (dt.Int64, dt.int64),
+        (dt.UInt8, dt.uint8),
+        (dt.UInt16, dt.uint16),
+        (dt.UInt32, dt.uint32),
+        (dt.UInt64, dt.uint64),
+        (dt.Float32, dt.float32),
+        (dt.Float64, dt.float64),
+        (dt.String, dt.string),
+        (dt.Binary, dt.binary),
+        (dt.Boolean, dt.boolean),
+        (dt.Date, dt.date),
+        (dt.Time, dt.time),
+        (dt.Timestamp, dt.timestamp),
+        (dt.Interval, dt.interval),
+        (dt.Decimal, dt.decimal),
+    ],
+)
+def test_dtype_from_classes(klass, expected):
+    assert dt.dtype(klass) == expected
+
+
+class FooStruct:
+    a: dt.int16
+    b: dt.int32
+    c: dt.int64
+    d: dt.uint8
+    e: dt.uint16
+    f: dt.uint32
+    g: dt.uint64
+    h: dt.float32
+    i: dt.float64
+    j: dt.string
+    k: dt.binary
+    l: dt.boolean  # noqa: E741
+    m: dt.date
+    n: dt.time
+    o: dt.timestamp
+    oa: dt.Timestamp('UTC')  # noqa: F821
+    ob: dt.Timestamp('UTC', 6)  # noqa: F821
+    p: dt.interval
+    pa: dt.Interval('s')
+    pb: dt.Interval('s', dt.int16)
+    q: dt.decimal
+    qa: dt.Decimal(12, 2)
+    r: dt.Array(dt.int16)
+    s: dt.Map(dt.string, dt.int16)
+    t: dt.Set(dt.int16)
+
+
+class BarStruct:
+    a: dt.Int16
+    b: dt.Int32
+    c: dt.Int64
+    d: dt.UInt8
+    e: dt.UInt16
+    f: dt.UInt32
+    g: dt.UInt64
+    h: dt.Float32
+    i: dt.Float64
+    j: dt.String
+    k: dt.Binary
+    l: dt.Boolean  # noqa: E741
+    m: dt.Date
+    n: dt.Time
+    o: dt.Timestamp
+    oa: dt.Timestamp['UTC']  # noqa: F821
+    ob: dt.Timestamp['UTC', 6]  # noqa: F821
+    p: dt.Interval
+    pa: dt.Interval['s']
+    pb: dt.Interval['s', dt.Int16]
+    q: dt.Decimal
+    qa: dt.Decimal[12, 2]
+    r: dt.Array[dt.Int16]
+    s: dt.Map[dt.String, dt.Int16]
+    t: dt.Set[dt.Int16]
+
+
+baz_struct = dt.Struct(
+    {
+        'a': dt.int16,
+        'b': dt.int32,
+        'c': dt.int64,
+        'd': dt.uint8,
+        'e': dt.uint16,
+        'f': dt.uint32,
+        'g': dt.uint64,
+        'h': dt.float32,
+        'i': dt.float64,
+        'j': dt.string,
+        'k': dt.binary,
+        'l': dt.boolean,
+        'm': dt.date,
+        'n': dt.time,
+        'o': dt.timestamp,
+        'oa': dt.Timestamp('UTC'),
+        'ob': dt.Timestamp('UTC', 6),
+        'p': dt.interval,
+        'pa': dt.Interval('s'),
+        'pb': dt.Interval('s', dt.int16),
+        'q': dt.decimal,
+        'qa': dt.Decimal(12, 2),
+        'r': dt.Array(dt.int16),
+        's': dt.Map(dt.string, dt.int16),
+        't': dt.Set(dt.int16),
+    }
+)
+
+
+class MyInt(int):
+    pass
+
+
+class MyFloat(float):
+    pass
+
+
+class MyStr(str):
+    pass
+
+
+class MyBytes(bytes):
+    pass
+
+
+class MyList(list):
+    pass
+
+
+class MyTuple(list):
+    pass
+
+
+class MySet(set):
+    pass
+
+
+class MyDict(dict):
+    pass
+
+
+class MyStruct:
+    a: str
+    b: int
+    c: float
+
+
+class PyStruct:
+    a: int
+    b: float
+    c: str
+    ca: MyStr
+    d: bytes
+    da: MyBytes
+    e: bool
+    f: datetime.date
+    g: datetime.time
+    h: datetime.datetime
+    i: datetime.timedelta
+    j: decimal.Decimal
+    k: List[int]  # noqa: UP006
+    l: Dict[str, int]  # noqa: UP006, E741
+    m: Set[int]  # noqa: UP006
+    n: Tuple[str]  # noqa: UP006
+    o: uuid.UUID
+    p: type(None)
+    q: MyStruct
+
+
+class PyStruct2:
+    ka: list[int]
+    kb: MyList[int]
+    la: dict[str, int]
+    lb: MyDict[str, int]
+    ma: set[int]
+    mb: MySet[int]
+    na: tuple[str]
+    nb: MyTuple[str]
+
+
+py_struct = dt.Struct(
+    {
+        'a': dt.int64,
+        'b': dt.float64,
+        'c': dt.string,
+        'ca': dt.string,
+        'd': dt.binary,
+        'da': dt.binary,
+        'e': dt.boolean,
+        'f': dt.date,
+        'g': dt.time,
+        'h': dt.timestamp,
+        'i': dt.interval,
+        'j': dt.decimal,
+        'k': dt.Array(dt.int64),
+        'l': dt.Map(dt.string, dt.int64),
+        'm': dt.Set(dt.int64),
+        'n': dt.Array(dt.string),
+        'o': dt.UUID,
+        'p': dt.null,
+        'q': dt.Struct(
+            {
+                'a': dt.string,
+                'b': dt.int64,
+                'c': dt.float64,
+            }
+        ),
+    }
+)
+py_struct_2 = dt.Struct(
+    {
+        'ka': dt.Array(dt.int64),
+        'kb': dt.Array(dt.int64),
+        'la': dt.Map(dt.string, dt.int64),
+        'lb': dt.Map(dt.string, dt.int64),
+        'ma': dt.Set(dt.int64),
+        'mb': dt.Set(dt.int64),
+        'na': dt.Array(dt.string),
+        'nb': dt.Array(dt.string),
+    }
+)
+
+
+class FooNamedTuple(NamedTuple):
+    a: str
+    b: int
+    c: float
+
+
+@dataclass
+class FooDataClass:
+    a: str
+    b: int
+    c: float = 0.1
+
+
+@pytest.mark.parametrize(
+    ('hint', 'expected'),
+    [
+        (dt.Interval, dt.Interval()),
+        (dt.Array[dt.Null], dt.Array(dt.Null())),
+        (dt.Set[dt.Null], dt.Set(dt.Null())),
+        (dt.Map[dt.Null, dt.Null], dt.Map(dt.Null(), dt.Null())),
+        (dt.Timestamp['UTC'], dt.Timestamp(timezone='UTC')),
+        (dt.Timestamp['UTC', 6], dt.Timestamp(timezone='UTC', scale=6)),
+        (dt.Interval['s'], dt.Interval('s')),
+        (dt.Interval['s', dt.Int16], dt.Interval('s', dt.Int16())),
+        (dt.Decimal[12, 2], dt.Decimal(12, 2)),
+        (
+            dt.Struct['a' : dt.Int16, 'b' : dt.Int32],
+            dt.Struct({'a': dt.Int16(), 'b': dt.Int32()}),
+        ),
+        (FooStruct, baz_struct),
+        (BarStruct, baz_struct),
+        (PyStruct, py_struct),
+        (FooNamedTuple, dt.Struct({'a': dt.string, 'b': dt.int64, 'c': dt.float64})),
+        (FooDataClass, dt.Struct({'a': dt.string, 'b': dt.int64, 'c': dt.float64})),
+    ],
+)
+def test_dtype_from_typehints(hint, expected):
+    assert dt.dtype(hint) == expected
+
+
+@pytest.mark.parametrize(('hint', 'expected'), [(PyStruct2, py_struct_2)])
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
+def test_dtype_from_newer_typehints(hint, expected):
+    assert dt.dtype(hint) == expected
+
+
+def test_dtype_from_additional_struct_typehints():
+    class A:
+        nested: dt.Struct({'a': dt.Int16, 'b': dt.Int32})  # noqa: F821
+
+    class B:
+        nested: dt.Struct['a' : dt.Int16, 'b' : dt.Int32]  # noqa: F821
+
+    expected = dt.Struct({'nested': dt.Struct({'a': dt.Int16(), 'b': dt.Int32()})})
+    assert dt.dtype(A) == expected
+    assert dt.dtype(B) == expected
 
 
 def test_array_with_string_value_type():
@@ -594,6 +886,7 @@ def get_leaf_classes(op):
         dt.Temporal,
         dt.UnsignedInteger,
         dt.Variadic,
+        dt.Parametric,
     },
 )
 def test_is_methods(dtype_class):

--- a/ibis/tests/expr/test_rules.py
+++ b/ibis/tests/expr/test_rules.py
@@ -27,6 +27,9 @@ similar_table = ibis.table(
         (dt.int32, dt.int32),
         ('int64', dt.int64),
         ('array<string>', dt.Array(dt.string)),
+        (int, dt.int64),
+        (float, dt.float64),
+        ([float], dt.Array(dt.float64)),
     ],
 )
 def test_valid_datatype(value, expected):
@@ -38,8 +41,6 @@ def test_valid_datatype(value, expected):
     [
         ('exception', parsy.ParseError),
         ('array<cat>', parsy.ParseError),
-        (int, IbisTypeError),
-        ([float], IbisTypeError),
     ],
 )
 def test_invalid_datatype(value, expected):

--- a/ibis/tests/expr/test_schema.py
+++ b/ibis/tests/expr/test_schema.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, NamedTuple, Tuple
+
 import pandas as pd
 import pandas.testing as tm
 import pytest
@@ -236,3 +241,109 @@ def test_schema_mapping_api():
     assert tuple(s.keys()) == s.names
     assert tuple(s.values()) == s.types
     assert tuple(s.items()) == tuple(zip(s.names, s.types))
+
+
+class BarSchema:
+    a: int
+    b: str
+
+
+class FooSchema:
+    a: int
+    b: str
+    c: float
+    d: Tuple[str]  # noqa: UP006
+    e: List[int]  # noqa: UP006
+    f: Dict[str, int]  # noqa: UP006
+    g: BarSchema
+    h: List[BarSchema]  # noqa: UP006
+    j: Dict[str, BarSchema]  # noqa: UP006
+
+
+foo_schema = sch.Schema(
+    {
+        'a': 'int64',
+        'b': 'string',
+        'c': 'float64',
+        'd': 'array<string>',
+        'e': 'array<int64>',
+        'f': 'map<string, int64>',
+        'g': 'struct<a: int64, b: string>',
+        'h': 'array<struct<a: int64, b: string>>',
+        'j': 'map<string, struct<a: int64, b: string>>',
+    }
+)
+
+
+def test_schema_from_annotated_class():
+    assert sch.schema(FooSchema) == foo_schema
+
+
+class NamedBar(NamedTuple):
+    a: int
+    b: str
+
+
+class NamedFoo(NamedTuple):
+    a: int
+    b: str
+    c: float
+    d: Tuple[str]  # noqa: UP006
+    e: List[int]  # noqa: UP006
+    f: Dict[str, int]  # noqa: UP006
+    g: NamedBar
+    h: List[NamedBar]  # noqa: UP006
+    j: Dict[str, NamedBar]  # noqa: UP006
+
+
+def test_schema_from_namedtuple():
+    assert sch.schema(NamedFoo) == foo_schema
+
+
+@dataclass
+class DataBar:
+    a: int
+    b: str
+
+
+@dataclass
+class DataFooBase:
+    a: int
+    b: str
+    c: float
+    d: Tuple[str]  # noqa: UP006
+
+
+@dataclass
+class DataFoo(DataFooBase):
+    e: List[int]  # noqa: UP006
+    f: Dict[str, int]  # noqa: UP006
+    g: DataBar
+    h: List[DataBar]  # noqa: UP006
+    j: Dict[str, DataBar]  # noqa: UP006
+
+
+def test_schema_from_dataclass():
+    assert sch.schema(DataFoo) == foo_schema
+
+
+class PreferenceA:
+    a: dt.int64
+    b: dt.Array(dt.int64)
+
+
+class PreferenceB:
+    a: dt.int64
+    b: dt.Array[dt.int64]
+
+
+class PreferenceC:
+    a: dt.Int64
+    b: dt.Array[dt.Int64]
+
+
+def test_preferences():
+    a = sch.schema(PreferenceA)
+    b = sch.schema(PreferenceB)
+    c = sch.schema(PreferenceC)
+    assert a == b == c


### PR DESCRIPTION
The point here is to support more declarative schema and table definitions, example:

```py
import datetime

import ibis
import ibis.expr.datatypes as dt


class FooSchema:
     a: int
     b: str
     c: float
     d: tuple[str]
     e: list[int]
     f: dict[str, int]
     g: datetime.date


class BarSchema:
     a: dt.int64
     b: dt.string
     c: dt.float64
     d: dt.Array(dt.string)
     e: dt.Array(dt.int64)
     f: dt.Map(dt.string, dt.string)
     g: dt.Date


class BazSchema:
     a: dt.Int64
     b: dt.String
     c: dt.Float64
     d: dt.Array[dt.String]
     e: dt.Array[dt.Int64]
     f: dt.Map[dt.String, dt.String]
     g: dt.Date


foo = ibis.table(name="foo", schema=FooSchema)
# perhaps a `table()` overload could be useful here to support `ibis.table(FooSchema)`
```

Nested types and annotations are also supported, tested for plain classes, dataclasses and namedtuples.

`NamedTuple` and various `dataclasses` are gaining tractions with more recent python versions so we should enable tighter integration without too much boilerplate.
