### PR TITLE
fix: only include valid python identifiers in table/struct tab completion

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -6,6 +6,7 @@ import functools
 import itertools
 import sys
 import warnings
+from keyword import iskeyword
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -204,7 +205,9 @@ class Table(Expr, _FixedTextJupyterMixin):
         raise AttributeError(f"'Table' object has no attribute {key!r}")
 
     def __dir__(self):
-        return sorted(frozenset(dir(type(self)) + self.columns))
+        out = set(dir(type(self)))
+        out.update(c for c in self.columns if c.isidentifier() and not iskeyword(c))
+        return sorted(out)
 
     def _ipython_key_completions_(self) -> list[str]:
         return self.columns

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import itertools
+from keyword import iskeyword
 from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
 
 from public import public
@@ -60,7 +61,14 @@ def struct(
 @public
 class StructValue(Value):
     def __dir__(self):
-        return sorted(frozenset(itertools.chain(dir(type(self)), self.type().names)))
+        out = set(dir(type(self)))
+        out.update(
+            c for c in self.type().names if c.isidentifier() and not iskeyword(c)
+        )
+        return sorted(out)
+
+    def _ipython_key_completions_(self) -> list[str]:
+        return sorted(self.type().names)
 
     def __getitem__(self, name: str) -> ir.Value:
         """Extract the `name` field from this struct.

--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -41,10 +41,15 @@ def test_struct_getattr():
         expr.bad
 
 
-def test_struct_field_dir():
-    t = ibis.table([('struct_col', 'struct<my_field: string>')])
-    assert 'struct_col' in dir(t)
-    assert 'my_field' in dir(t.struct_col)
+def test_struct_tab_completion():
+    t = ibis.table([('struct_col', 'struct<my_field: string, for: int64>')])
+    # Only valid python identifiers in getattr completions
+    attrs = dir(t.struct_col)
+    assert "my_field" in attrs
+    assert "for" not in attrs
+    # All fields in getitem completions
+    items = t.struct_col._ipython_key_completions_()
+    assert {"my_field", "for"}.issubset(items)
 
 
 def test_struct_pickle():

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -87,12 +87,20 @@ def test_getitem_column_select(table):
         assert isinstance(col, Column)
 
 
+def test_table_tab_completion():
+    table = ibis.table({"a": "int", "b": "int", "for": "int", "with spaces": "int"})
+    # Only valid python identifiers in getattr tab completion
+    attrs = set(dir(table))
+    assert {"a", "b"}.issubset(attrs)
+    assert {"for", "with spaces"}.isdisjoint(attrs)
+    # All columns in getitem tab completion
+    items = set(table._ipython_key_completions_())
+    assert items.issuperset(table.columns)
+
+
 def test_getitem_attribute(table):
     result = table.a
     assert_equal(result, table['a'])
-
-    assert 'a' in dir(table)
-    assert 'a' in table._ipython_key_completions_()
 
     # Project and add a name that conflicts with a Table built-in
     # attribute


### PR DESCRIPTION
Previously getattr tab completion would include things that weren't valid python identifiers (e.g. column names including spaces/python keywords).

Also adds getitem completion for structs, previously these only supported getattr completion.