### PR TITLE
refactor(sqlalchemy): get out of transactions earlier

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -516,13 +516,12 @@ class Backend(BaseAlchemyBackend):
 
     def _metadata(self, query: str) -> Iterator[tuple[str, dt.DataType]]:
         with self.begin() as con:
-            rows = con.exec_driver_sql(f"DESCRIBE {query}")
-
-            for name, type, null in toolz.pluck(
-                ["column_name", "column_type", "null"], rows.mappings()
-            ):
-                ibis_type = parse(type)
-                yield name, ibis_type.copy(nullable=null.lower() == "yes")
+            type_info = con.exec_driver_sql(f"DESCRIBE {query}").mappings().fetchall()
+        for name, type, null in toolz.pluck(
+            ["column_name", "column_type", "null"], type_info
+        ):
+            ibis_type = parse(type)
+            yield name, ibis_type.copy(nullable=null.lower() == "yes")
 
     def _register_in_memory_table(self, table_op):
         df = table_op.data.to_frame()

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -56,8 +56,10 @@ class Backend(BaseAlchemyBackend):
             query=query
         )
         with self.begin() as bind:
-            for column in bind.execute(query).mappings():
-                yield column["name"], _type_from_result_set_info(column)
+            columns = bind.execute(query).mappings().fetchall()
+
+        for column in columns:
+            yield column["name"], _type_from_result_set_info(column)
 
     def _get_temp_view_definition(
         self, name: str, definition: sa.sql.compiler.Compiled

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -129,9 +129,10 @@ class Backend(BaseAlchemyBackend):
         with self.begin() as con:
             result = con.exec_driver_sql(f"SELECT * FROM {query} _ LIMIT 0")
             cursor = result.cursor
+            fields = cursor._result.fields
             yield from (
                 (field.name, _type_from_cursor_info(descr, field))
-                for descr, field in zip(cursor.description, cursor._result.fields)
+                for descr, field in zip(cursor.description, fields)
             )
 
     def _get_temp_view_definition(


### PR DESCRIPTION
This PR is a small refactor that tries to get in and out of transactions from metadata queries as early as possible, preferring to materialize results immediately instead of yielding to the caller.