### PR TITLE
refactor(sqlalchemy): split data type dispatches into backend specific modules

### DIFF
--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -3,16 +3,11 @@ from __future__ import annotations
 from typing import Iterable
 
 import sqlalchemy as sa
+import sqlalchemy.types as sat
 from multipledispatch import Dispatcher
-from sqlalchemy.dialects import mssql, mysql, postgresql, sqlite
-from sqlalchemy.dialects.mssql.base import MSDialect
-from sqlalchemy.dialects.mysql.base import MySQLDialect
-from sqlalchemy.dialects.postgresql.base import PGDialect
-from sqlalchemy.dialects.sqlite.base import SQLiteDialect
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.types import UserDefinedType
 
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
@@ -22,9 +17,9 @@ if geospatial_supported:
     import geoalchemy2 as ga
 
 
-class ArrayType(UserDefinedType):
-    def __init__(self, value_type: sa.types.TypeEngine):
-        self.value_type = sa.types.to_instance(value_type)
+class ArrayType(sat.UserDefinedType):
+    def __init__(self, value_type: sat.TypeEngine):
+        self.value_type = sat.to_instance(value_type)
 
 
 @compiles(ArrayType, "default")
@@ -32,12 +27,12 @@ def compiles_array(element, compiler, **kw):
     return f"ARRAY({compiler.process(element.value_type, **kw)})"
 
 
-class StructType(UserDefinedType):
+class StructType(sat.UserDefinedType):
     def __init__(
         self,
-        pairs: Iterable[tuple[str, sa.types.TypeEngine]],
+        pairs: Iterable[tuple[str, sat.TypeEngine]],
     ):
-        self.pairs = [(name, sa.types.to_instance(type)) for name, type in pairs]
+        self.pairs = [(name, sat.to_instance(type)) for name, type in pairs]
 
 
 @compiles(StructType, "default")
@@ -48,10 +43,10 @@ def compiles_struct(element, compiler, **kw):
     return f"STRUCT({content})"
 
 
-class MapType(UserDefinedType):
-    def __init__(self, key_type: sa.types.TypeEngine, value_type: sa.types.TypeEngine):
-        self.key_type = sa.types.to_instance(key_type)
-        self.value_type = sa.types.to_instance(value_type)
+class MapType(sat.UserDefinedType):
+    def __init__(self, key_type: sat.TypeEngine, value_type: sat.TypeEngine):
+        self.key_type = sat.to_instance(key_type)
+        self.value_type = sat.to_instance(value_type)
 
 
 @compiles(MapType, "default")
@@ -61,19 +56,19 @@ def compiles_map(element, compiler, **kw):
     return f"MAP({key_type}, {value_type})"
 
 
-class UInt64(sa.types.Integer):
+class UInt64(sat.Integer):
     pass
 
 
-class UInt32(sa.types.Integer):
+class UInt32(sat.Integer):
     pass
 
 
-class UInt16(sa.types.Integer):
+class UInt16(sat.Integer):
     pass
 
 
-class UInt8(sa.types.Integer):
+class UInt8(sat.Integer):
     pass
 
 
@@ -81,14 +76,26 @@ class UInt8(sa.types.Integer):
 @compiles(UInt32, "postgresql")
 @compiles(UInt16, "postgresql")
 @compiles(UInt8, "postgresql")
+@compiles(UInt64, "mssql")
+@compiles(UInt32, "mssql")
+@compiles(UInt16, "mssql")
+@compiles(UInt8, "mssql")
 @compiles(UInt64, "mysql")
 @compiles(UInt32, "mysql")
 @compiles(UInt16, "mysql")
 @compiles(UInt8, "mysql")
+@compiles(UInt64, "snowflake")
+@compiles(UInt32, "snowflake")
+@compiles(UInt16, "snowflake")
+@compiles(UInt8, "snowflake")
 @compiles(UInt64, "sqlite")
 @compiles(UInt32, "sqlite")
 @compiles(UInt16, "sqlite")
 @compiles(UInt8, "sqlite")
+@compiles(UInt64, "trino")
+@compiles(UInt32, "trino")
+@compiles(UInt16, "trino")
+@compiles(UInt8, "trino")
 def compile_uint(element, compiler, **kw):
     dialect_name = compiler.dialect.name
     raise TypeError(
@@ -111,7 +118,7 @@ def table_from_schema(name, meta, schema, database: str | None = None):
 
 # TODO(cleanup)
 ibis_type_to_sqla = {
-    dt.Null: sa.types.NullType,
+    dt.Null: sat.NullType,
     dt.Date: sa.Date,
     dt.Time: sa.Time,
     dt.Boolean: sa.Boolean,
@@ -150,7 +157,7 @@ def _default(_, itype):
 
 @to_sqla_type.register(Dialect, dt.Decimal)
 def _decimal(_, itype):
-    return sa.types.NUMERIC(itype.precision, itype.scale)
+    return sat.NUMERIC(itype.precision, itype.scale)
 
 
 @to_sqla_type.register(Dialect, dt.Timestamp)
@@ -161,22 +168,6 @@ def _timestamp(_, itype):
 @to_sqla_type.register(Dialect, dt.Array)
 def _array(dialect, itype):
     return ArrayType(to_sqla_type(dialect, itype.value_type))
-
-
-@to_sqla_type.register(PGDialect, dt.Array)
-def _pg_array(dialect, itype):
-    # Unwrap the array element type because sqlalchemy doesn't allow arrays of
-    # arrays. This doesn't affect the underlying data.
-    while itype.is_array():
-        itype = itype.value_type
-    return sa.ARRAY(to_sqla_type(dialect, itype))
-
-
-@to_sqla_type.register(PGDialect, dt.Map)
-def _pg_map(dialect, itype):
-    if not (itype.key_type.is_string() and itype.value_type.is_string()):
-        raise TypeError(f"PostgreSQL only supports map<string, string>, got: {itype}")
-    return postgresql.HSTORE
 
 
 @to_sqla_type.register(Dialect, dt.Struct)
@@ -193,20 +184,14 @@ def _map(dialect, itype):
     )
 
 
-@dt.dtype.register(Dialect, sa.types.NullType)
+@dt.dtype.register(Dialect, sat.NullType)
 def sa_null(_, satype, nullable=True):
     return dt.null
 
 
-@dt.dtype.register(Dialect, sa.types.Boolean)
+@dt.dtype.register(Dialect, sat.Boolean)
 def sa_boolean(_, satype, nullable=True):
     return dt.Boolean(nullable=nullable)
-
-
-@dt.dtype.register(MySQLDialect, (sa.NUMERIC, mysql.NUMERIC))
-def sa_mysql_numeric(_, satype, nullable=True):
-    # https://dev.mysql.com/doc/refman/8.0/en/fixed-point-types.html
-    return dt.Decimal(satype.precision or 10, satype.scale or 0, nullable=nullable)
 
 
 _FLOAT_PREC_TO_TYPE = {
@@ -216,7 +201,7 @@ _FLOAT_PREC_TO_TYPE = {
 }
 
 
-@dt.dtype.register(Dialect, sa.types.Float)
+@dt.dtype.register(Dialect, sat.Float)
 def sa_float(_, satype, nullable=True):
     precision = satype.precision
     if (typ := _FLOAT_PREC_TO_TYPE.get(precision)) is not None:
@@ -224,112 +209,39 @@ def sa_float(_, satype, nullable=True):
     return dt.Decimal(precision, satype.scale, nullable=nullable)
 
 
-@dt.dtype.register(Dialect, sa.types.Numeric)
-@dt.dtype.register(SQLiteDialect, sqlite.NUMERIC)
+@dt.dtype.register(Dialect, sat.Numeric)
 def sa_numeric(_, satype, nullable=True):
     return dt.Decimal(satype.precision, satype.scale, nullable=nullable)
 
 
-@dt.dtype.register(Dialect, sa.types.SmallInteger)
+@dt.dtype.register(Dialect, sat.SmallInteger)
 def sa_smallint(_, satype, nullable=True):
     return dt.Int16(nullable=nullable)
 
 
-@dt.dtype.register(Dialect, sa.types.Integer)
+@dt.dtype.register(Dialect, sat.Integer)
 def sa_integer(_, satype, nullable=True):
     return dt.Int32(nullable=nullable)
 
 
-@dt.dtype.register(Dialect, mysql.TINYINT)
-@dt.dtype.register(MSDialect, mssql.TINYINT)
-@dt.dtype.register(MySQLDialect, mysql.YEAR)
-def sa_mysql_tinyint(_, satype, nullable=True):
-    return dt.Int8(nullable=nullable)
-
-
-@dt.dtype.register(MSDialect, mssql.BIT)
-def sa_mssql_bit(_, satype, nullable=True):
-    return dt.Boolean(nullable=nullable)
-
-
-@dt.dtype.register(MySQLDialect, mysql.BIT)
-def sa_mysql_bit(_, satype, nullable=True):
-    if 1 <= (length := satype.length) <= 8:
-        return dt.Int8(nullable=nullable)
-    elif 9 <= length <= 16:
-        return dt.Int16(nullable=nullable)
-    elif 17 <= length <= 32:
-        return dt.Int32(nullable=nullable)
-    elif 33 <= length <= 64:
-        return dt.Int64(nullable=nullable)
-    else:
-        raise ValueError(f"Invalid MySQL BIT length: {length:d}")
-
-
-@dt.dtype.register(Dialect, sa.types.BigInteger)
-@dt.dtype.register(MSDialect, mssql.MONEY)
+@dt.dtype.register(Dialect, sat.BigInteger)
 def sa_bigint(_, satype, nullable=True):
     return dt.Int64(nullable=nullable)
 
 
-@dt.dtype.register(MSDialect, mssql.SMALLMONEY)
-def sa_mssql_smallmoney(_, satype, nullable=True):
-    return dt.Int32(nullable=nullable)
-
-
 @dt.dtype.register(Dialect, sa.REAL)
-@dt.dtype.register(MySQLDialect, mysql.FLOAT)
 def sa_real(_, satype, nullable=True):
     return dt.Float32(nullable=nullable)
 
 
 @dt.dtype.register(Dialect, sa.FLOAT)
-@dt.dtype.register(SQLiteDialect, sa.REAL)
-@dt.dtype.register(PGDialect, postgresql.DOUBLE_PRECISION)
 def sa_double(_, satype, nullable=True):
     return dt.Float64(nullable=nullable)
 
 
-@dt.dtype.register(PGDialect, postgresql.UUID)
-@dt.dtype.register(MSDialect, mssql.UNIQUEIDENTIFIER)
-def sa_uuid(_, satype, nullable=True):
-    return dt.UUID(nullable=nullable)
-
-
-@dt.dtype.register(PGDialect, postgresql.MACADDR)
-def sa_macaddr(_, satype, nullable=True):
-    return dt.MACADDR(nullable=nullable)
-
-
-@dt.dtype.register(PGDialect, postgresql.HSTORE)
-def sa_hstore(_, satype, nullable=True):
-    return dt.Map(dt.string, dt.string, nullable=nullable)
-
-
-@dt.dtype.register(PGDialect, postgresql.INET)
-def sa_inet(_, satype, nullable=True):
-    return dt.INET(nullable=nullable)
-
-
 @dt.dtype.register(Dialect, sa.types.JSON)
-@dt.dtype.register(PGDialect, postgresql.JSONB)
 def sa_json(_, satype, nullable=True):
     return dt.JSON(nullable=nullable)
-
-
-@dt.dtype.register(MySQLDialect, mysql.TIMESTAMP)
-def sa_mysql_timestamp(_, satype, nullable=True):
-    return dt.Timestamp(timezone="UTC", nullable=nullable)
-
-
-@dt.dtype.register(MySQLDialect, mysql.DATETIME)
-def sa_mysql_datetime(_, satype, nullable=True):
-    return dt.Timestamp(nullable=nullable)
-
-
-@dt.dtype.register(MySQLDialect, mysql.SET)
-def sa_mysql_set(_, satype, nullable=True):
-    return dt.Set(dt.string, nullable=nullable)
 
 
 if geospatial_supported:
@@ -364,60 +276,12 @@ if geospatial_supported:
             return ga.types._GISType
 
 
-POSTGRES_FIELD_TO_IBIS_UNIT = {
-    "YEAR": "Y",
-    "MONTH": "M",
-    "DAY": "D",
-    "HOUR": "h",
-    "MINUTE": "m",
-    "SECOND": "s",
-    "YEAR TO MONTH": "M",
-    "DAY TO HOUR": "h",
-    "DAY TO MINUTE": "m",
-    "DAY TO SECOND": "s",
-    "HOUR TO MINUTE": "m",
-    "HOUR TO SECOND": "s",
-    "MINUTE TO SECOND": "s",
-}
-
-
-@dt.dtype.register(PGDialect, postgresql.INTERVAL)
-def sa_postgres_interval(_, satype, nullable=True):
-    field = satype.fields.upper()
-    unit = POSTGRES_FIELD_TO_IBIS_UNIT.get(field, None)
-    if unit is None:
-        raise ValueError(f"Unknown PostgreSQL interval field {field!r}")
-    elif unit in {"Y", "M"}:
-        raise ValueError(
-            "Variable length timedeltas are not yet supported with PostgreSQL"
-        )
-    return dt.Interval(unit=unit, nullable=nullable)
-
-
-@dt.dtype.register(MySQLDialect, mysql.DOUBLE)
-def sa_mysql_double(_, satype, nullable=True):
-    # TODO: handle asdecimal=True
-    return dt.Float64(nullable=nullable)
-
-
-@dt.dtype.register(Dialect, sa.types.String)
+@dt.dtype.register(Dialect, sa.String)
 def sa_string(_, satype, nullable=True):
     return dt.String(nullable=nullable)
 
 
 @dt.dtype.register(Dialect, sa.LargeBinary)
-@dt.dtype.register(MSDialect, (mssql.BINARY, mssql.TIMESTAMP))
-@dt.dtype.register(
-    MySQLDialect,
-    (
-        mysql.TINYBLOB,
-        mysql.MEDIUMBLOB,
-        mysql.BLOB,
-        mysql.LONGBLOB,
-        mysql.BINARY,
-        mysql.VARBINARY,
-    ),
-)
 def sa_binary(_, satype, nullable=True):
     return dt.Binary(nullable=nullable)
 
@@ -438,32 +302,6 @@ def sa_datetime(_, satype, nullable=True, default_timezone='UTC'):
     return dt.Timestamp(timezone=timezone, nullable=nullable)
 
 
-@dt.dtype.register(MSDialect, mssql.DATETIMEOFFSET)
-def _datetimeoffset(_, sa_type, nullable=True):
-    if (prec := sa_type.precision) is None:
-        prec = 7
-    return dt.Timestamp(scale=prec, timezone="UTC", nullable=nullable)
-
-
-@dt.dtype.register(MSDialect, mssql.DATETIME2)
-def _datetime2(_, sa_type, nullable=True):
-    if (prec := sa_type.precision) is None:
-        prec = 7
-    return dt.Timestamp(scale=prec, nullable=nullable)
-
-
-@dt.dtype.register(PGDialect, sa.ARRAY)
-def sa_pg_array(dialect, satype, nullable=True):
-    dimensions = satype.dimensions
-    if dimensions is not None and dimensions != 1:
-        raise NotImplementedError(
-            f"Nested array types not yet supported for {dialect.name} dialect"
-        )
-
-    value_dtype = dt.dtype(dialect, satype.item_type)
-    return dt.Array(value_dtype, nullable=nullable)
-
-
 @dt.dtype.register(Dialect, StructType)
 def sa_struct(dialect, satype, nullable=True):
     pairs = [(name, dt.dtype(dialect, typ)) for name, typ in satype.pairs]
@@ -475,9 +313,9 @@ def sa_array(dialect, satype, nullable=True):
     return dt.Array(dt.dtype(dialect, satype.value_type), nullable=nullable)
 
 
-@sch.infer.register((sa.Table, sa.sql.TableClause))
+@sch.infer.register(sa.sql.TableClause)
 def schema_from_table(
-    table: sa.Table,
+    table: sa.sql.TableClause,
     schema: sch.Schema | None = None,
     dialect: sa.engine.interfaces.Dialect | None = None,
 ) -> sch.Schema:

--- a/ibis/backends/mssql/datatypes.py
+++ b/ibis/backends/mssql/datatypes.py
@@ -2,6 +2,7 @@ from functools import partial
 from typing import Optional, TypedDict
 
 from sqlalchemy.dialects import mssql
+from sqlalchemy.dialects.mssql.base import MSDialect
 
 import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy import to_sqla_type
@@ -112,3 +113,47 @@ def _datetime(_, itype):
         return mssql.DATETIMEOFFSET(precision=precision)
     else:
         return mssql.DATETIME2(precision=precision)
+
+
+@dt.dtype.register(MSDialect, mssql.TINYINT)
+def sa_mysql_tinyint(_, satype, nullable=True):
+    return dt.Int8(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect, mssql.BIT)
+def sa_mssql_bit(_, satype, nullable=True):
+    return dt.Boolean(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect, mssql.MONEY)
+def sa_bigint(_, satype, nullable=True):
+    return dt.Int64(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect, mssql.SMALLMONEY)
+def sa_mssql_smallmoney(_, satype, nullable=True):
+    return dt.Int32(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect, mssql.UNIQUEIDENTIFIER)
+def sa_mssql_uuid(_, satype, nullable=True):
+    return dt.UUID(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect, (mssql.BINARY, mssql.TIMESTAMP))
+def sa_mssql_binary(_, satype, nullable=True):
+    return dt.Binary(nullable=nullable)
+
+
+@dt.dtype.register(MSDialect, mssql.DATETIMEOFFSET)
+def _datetimeoffset(_, sa_type, nullable=True):
+    if (prec := sa_type.precision) is None:
+        prec = 7
+    return dt.Timestamp(scale=prec, timezone="UTC", nullable=nullable)
+
+
+@dt.dtype.register(MSDialect, mssql.DATETIME2)
+def _datetime2(_, sa_type, nullable=True):
+    if (prec := sa_type.precision) is None:
+        prec = 7
+    return dt.Timestamp(scale=prec, nullable=nullable)

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -8,7 +8,6 @@ import warnings
 from typing import Iterable, Literal
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import mysql
 
 import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
@@ -138,26 +137,3 @@ class Backend(BaseAlchemyBackend):
         self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
         yield f"CREATE OR REPLACE VIEW {name} AS {definition}"
-
-
-# TODO(kszucs): unsigned integers
-
-
-@dt.dtype.register((mysql.DOUBLE, mysql.REAL))
-def mysql_double(satype, nullable=True):
-    return dt.Float64(nullable=nullable)
-
-
-@dt.dtype.register(mysql.FLOAT)
-def mysql_float(satype, nullable=True):
-    return dt.Float32(nullable=nullable)
-
-
-@dt.dtype.register(mysql.TINYINT)
-def mysql_tinyint(satype, nullable=True):
-    return dt.Int8(nullable=nullable)
-
-
-@dt.dtype.register(mysql.BLOB)
-def mysql_blob(satype, nullable=True):
-    return dt.Binary(nullable=nullable)

--- a/ibis/backends/sqlite/datatypes.py
+++ b/ibis/backends/sqlite/datatypes.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import sqlalchemy as sa
+from sqlalchemy.dialects import sqlite
+from sqlalchemy.dialects.sqlite.base import SQLiteDialect
+
 import ibis.expr.datatypes as dt
 
 
@@ -36,3 +40,13 @@ def parse(text: str) -> dt.DataType:
 
     # 5. Otherwise, the affinity is NUMERIC.
     return dt.decimal
+
+
+@dt.dtype.register(SQLiteDialect, sqlite.NUMERIC)
+def sa_numeric(_, satype, nullable=True):
+    return dt.Decimal(satype.precision, satype.scale, nullable=nullable)
+
+
+@dt.dtype.register(SQLiteDialect, sa.REAL)
+def sa_double(_, satype, nullable=True):
+    return dt.Float64(nullable=nullable)


### PR DESCRIPTION
This PR moves the respective backend data type dispatch to individual `backends/<backend>/datatypes.py` modules.