### PR TITLE
test(sqlalchemy): fix previously-untested failing unsigned integer test

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -441,7 +441,7 @@ def test_in_memory(alchemy_backend):
 
 
 @pytest.mark.notyet(
-    ["postgres", "mysql", "sqlite"],
+    ["mssql", "mysql", "postgres", "snowflake", "sqlite", "trino"],
     raises=TypeError,
     reason="postgres, mysql and sqlite do not support unsigned integer types",
 )


### PR DESCRIPTION
Fixes a failing upstream test.