### PR TITLE
feat(pandas): support more pandas extension dtypes

### DIFF
--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -56,9 +56,16 @@ def from_pandas_categorical(_):
     return dt.Category()
 
 
-@dt.dtype.register(pd.core.arrays.string_.StringDtype)
-def from_pandas_string(_):
-    return dt.String()
+@dt.dtype.register(pd.core.dtypes.base.ExtensionDtype)
+def from_pandas_extension_dtype(t):
+    return getattr(dt, t.__class__.__name__.replace("Dtype", "").lower())
+
+
+@dt.dtype.register(pd.core.arrays.arrow.dtype.ArrowDtype)
+def from_pandas_arrow_extension_dtype(t):
+    import ibis.backends.pyarrow.datatypes as _  # noqa: F401
+
+    return dt.dtype(t.pyarrow_dtype)
 
 
 @sch.schema.register(pd.Series)

--- a/ibis/backends/pandas/tests/test_client.py
+++ b/ibis/backends/pandas/tests/test_client.py
@@ -5,6 +5,7 @@ import pytest
 from pytest import param
 
 import ibis
+import ibis.expr.datatypes as dt
 from ibis.backends.pandas.client import PandasTable
 
 
@@ -98,3 +99,61 @@ def test_datetime64_infer(client, unit):
     expr = ibis.literal(value, type='timestamp')
     result = client.execute(expr)
     assert result == pd.Timestamp(value).to_pydatetime()
+
+
+@pytest.mark.parametrize(
+    ("ext_dtype", "expected"),
+    [
+        (pd.StringDtype(), dt.string),
+        (pd.Int8Dtype(), dt.int8),
+        (pd.Int16Dtype(), dt.int16),
+        (pd.Int32Dtype(), dt.int32),
+        (pd.Int64Dtype(), dt.int64),
+        (pd.UInt8Dtype(), dt.uint8),
+        (pd.UInt16Dtype(), dt.uint16),
+        (pd.UInt32Dtype(), dt.uint32),
+        (pd.UInt64Dtype(), dt.uint64),
+        (pd.BooleanDtype(), dt.boolean),
+    ],
+    ids=str,
+)
+def test_infer_nullable_dtypes(ext_dtype, expected):
+    assert dt.dtype(ext_dtype) == expected
+
+
+@pytest.mark.parametrize(
+    ("arrow_dtype", "expected"),
+    [
+        ("string", dt.string),
+        ("int8", dt.int8),
+        ("int16", dt.int16),
+        ("int32", dt.int32),
+        ("int64", dt.int64),
+        ("uint8", dt.uint8),
+        ("uint16", dt.uint16),
+        ("uint32", dt.uint32),
+        ("uint64", dt.uint64),
+        param(
+            "list<item: string>",
+            dt.Array(dt.string),
+            marks=pytest.mark.xfail(
+                reason="list repr in dtype Series argument doesn't work",
+                raises=TypeError,
+            ),
+            id="list_string",
+        ),
+    ],
+    ids=str,
+)
+def test_infer_pandas_arrow_dtype(arrow_dtype, expected):
+    pytest.importorskip("pyarrow")
+    ser = pd.Series([], dtype=f"{arrow_dtype}[pyarrow]")
+    dtype = ser.dtype
+    assert dt.dtype(dtype) == expected
+
+
+def test_infer_pandas_arrow_list_dtype():
+    pa = pytest.importorskip("pyarrow")
+    ser = pd.Series([], dtype=pd.ArrowDtype(pa.list_(pa.string())))
+    dtype = ser.dtype
+    assert dt.dtype(dtype) == dt.Array(dt.string)


### PR DESCRIPTION
This PR adds support for inferring ibis data types from pandas nullable types as well as pandas wrapper around arrow types. Execution is supported only for the pandas types, not the arrow ones and the returned types remain unchanged. This feature allows users to be unblocked from consuming these pandas types.

Closes #5343.