### PR TITLE
feat(sqlalchemy): generalize unnest to work on backends that don't currently support it

### DIFF
--- a/ibis/backends/base/sql/alchemy/translator.py
+++ b/ibis/backends/base/sql/alchemy/translator.py
@@ -58,6 +58,8 @@ class AlchemyExprTranslator(ExprTranslator):
 
     _dialect_name = "default"
 
+    supports_unnest_in_select = True
+
     @functools.cached_property
     def dialect(self) -> sa.engine.interfaces.Dialect:
         if (name := self._dialect_name) == "default":

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -71,6 +71,7 @@ class SnowflakeExprTranslator(AlchemyExprTranslator):
     )
     _require_order_by = (*AlchemyExprTranslator._require_order_by, ops.Reduction)
     _dialect_name = "snowflake"
+    supports_unnest_in_select = False
 
 
 class SnowflakeCompiler(AlchemyCompiler):

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -4,8 +4,13 @@ import itertools
 
 import numpy as np
 import sqlalchemy as sa
+from snowflake.sqlalchemy import ARRAY
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql import sqltypes
+from sqlalchemy.sql.functions import GenericFunction
 
 import ibis.expr.operations as ops
+from ibis import util
 from ibis.backends.base.sql.alchemy.registry import (
     fixed_arity,
     geospatial_functions,
@@ -260,7 +265,11 @@ operation_registry.update(
             *map(t.translate, op.cols)
         ),
         ops.ArraySlice: _array_slice,
-        ops.ArrayCollect: reduction(sa.func.array_agg),
+        ops.ArrayCollect: reduction(
+            lambda arg: sa.func.array_agg(
+                sa.func.ifnull(arg, sa.func.parse_json("null")), type_=ARRAY
+            )
+        ),
         ops.StringSplit: fixed_arity(sa.func.split, 2),
         ops.Map: _map,
         ops.TypeOf: unary(lambda arg: sa.func.typeof(sa.func.to_variant(arg))),
@@ -294,13 +303,7 @@ operation_registry.update(
         ops.StructColumn: lambda t, op: sa.func.object_construct_keep_null(
             *itertools.chain.from_iterable(zip(op.names, map(t.translate, op.values)))
         ),
-        ops.Unnest: unary(
-            lambda arg: (
-                sa.func.table(sa.func.flatten(arg))
-                .table_valued("value")
-                .columns["value"]
-            )
-        ),
+        ops.Unnest: _unnest,
     }
 )
 

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -143,6 +143,31 @@ def _arbitrary(t, op):
     return t._reduction(sa.func.min, op)
 
 
+class flatten(GenericFunction):
+    def __init__(self, arg, *, type: sa.types.TypeEngine) -> None:
+        super().__init__(arg)
+        self.type = sqltypes.TableValueType(sa.Column("value", type))
+
+
+@compiles(flatten, "snowflake")
+def compiles_flatten(element, compiler, **kw):
+    arg = compiler.function_argspec(element, **kw)
+    return f"FLATTEN(INPUT => {arg}, MODE => 'ARRAY')"
+
+
+def _unnest(t, op):
+    arg = t.translate(op.arg)
+    # HACK: https://community.snowflake.com/s/question/0D50Z000086MVhnSAG/has-anyone-found-a-way-to-unnest-an-array-without-loosing-the-null-values
+    sep = util.guid()
+    sqla_type = t.get_sqla_type(op.output_dtype)
+    col = (
+        flatten(sa.func.split(sa.func.array_to_string(arg, sep), sep), type=sqla_type)
+        .lateral()
+        .c["value"]
+    )
+    return sa.cast(sa.func.nullif(col, ""), type_=sqla_type)
+
+
 _TIMESTAMP_UNITS_TO_SCALE = {"s": 0, "ms": 3, "us": 6, "ns": 9}
 
 _SF_POS_INF = sa.func.to_double("Inf")
@@ -269,6 +294,13 @@ operation_registry.update(
         ops.StructColumn: lambda t, op: sa.func.object_construct_keep_null(
             *itertools.chain.from_iterable(zip(op.names, map(t.translate, op.values)))
         ),
+        ops.Unnest: unary(
+            lambda arg: (
+                sa.func.table(sa.func.flatten(arg))
+                .table_valued("value")
+                .columns["value"]
+            )
+        ),
     }
 )
 
@@ -280,7 +312,6 @@ _invalid_operations = {
     ops.NTile,
     # ibis.expr.operations.array
     ops.ArrayRepeat,
-    ops.Unnest,
     # ibis.expr.operations.reductions
     ops.MultiQuantile,
     # ibis.expr.operations.strings

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -23,6 +23,7 @@ class TrinoSQLExprTranslator(AlchemyExprTranslator):
         ops.Lead,
     )
     _dialect_name = "trino"
+    supports_unnest_in_select = False
 
 
 rewrites = TrinoSQLExprTranslator.rewrites

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -147,6 +147,12 @@ def _round(t, op):
     return sa.func.round(arg)
 
 
+def _unnest(t, op):
+    arg = op.arg
+    name = arg.name
+    return sa.func.unnest(t.translate(arg)).table_valued(name).render_derived().c[name]
+
+
 operation_registry.update(
     {
         # conditional expressions
@@ -300,6 +306,7 @@ operation_registry.update(
             )
         ),
         ops.TypeOf: unary(sa.func.typeof),
+        ops.Unnest: _unnest,
     }
 )
 

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import operator
 from collections import Counter
-from typing import Iterator, Mapping
+from typing import Iterable, Iterator, Mapping
 
 import toolz
 
@@ -867,3 +867,13 @@ def find_memtables(node: ops.Node) -> Iterator[ops.InMemoryTable]:
         return g.proceed, node if isinstance(node, ops.InMemoryTable) else None
 
     return g.traverse(finder, node, filter=ops.Node)
+
+
+def find_toplevel_unnest_children(nodes: Iterable[ops.Node]) -> Iterator[ops.Table]:
+    def finder(node):
+        return (
+            isinstance(node, ops.Value),
+            find_first_base_table(node) if isinstance(node, ops.Unnest) else None,
+        )
+
+    return g.traverse(finder, nodes, filter=ops.Node)


### PR DESCRIPTION
This PR (finally) generalizes the unnest implementation to handle the case where unnest is not supported in a `SELECT` statement, but must come after a cross join in a `FROM` clause.