### PR TITLE
ci: skip test that segfaults on Windows

### DIFF
--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import tempfile
 from pathlib import Path
 
@@ -132,6 +133,7 @@ def test_memtable_with_nullable_dtypes():
     assert len(res) == len(data)
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Test segfaults on windows")
 def test_memtable_with_nullable_pyarrow_string():
     pytest.importorskip("pyarrow")
     data = pd.DataFrame({"a": pd.Series(["a", None, "c"], dtype="string[pyarrow]")})


### PR DESCRIPTION
This PR skips a sporadically segfaulting test on windows. Observed in https://github.com/ibis-project/ibis/actions/runs/4036343394/jobs/6938876498. This segfault does not seem to be reproducible.