### PR TITLE
fix(duckdb): workaround an ownership bug at the interaction of duckdb, pandas and pyarrow

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -248,10 +248,10 @@ class BaseSQLBackend(BaseBackend):
 
         return result
 
-    def _register_in_memory_table(self, table_op):
-        raise NotImplementedError
+    def _register_in_memory_table(self, _: ops.InMemoryTable) -> None:
+        raise NotImplementedError(self.name)
 
-    def _register_in_memory_tables(self, expr):
+    def _register_in_memory_tables(self, expr: ir.Expr) -> None:
         if self.compiler.cheap_in_memory_tables:
             for memtable in an.find_memtables(expr.op()):
                 self._register_in_memory_table(memtable)

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -92,8 +92,8 @@ class Backend(BaseBackend):
         super().__init__(*args, **kwargs)
         self._external_tables = external_tables or {}
 
-    def _register_in_memory_table(self, table_op):
-        self._external_tables[table_op.name] = table_op.data.to_frame()
+    def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
+        self._external_tables[op.name] = op.data.to_frame()
 
     def _log(self, sql: str) -> None:
         """Log the SQL, usually to the standard output.

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 from pathlib import Path
 
-import duckdb
 import pandas as pd
 import pytest
 import sqlalchemy as sa
@@ -140,10 +139,6 @@ def test_memtable_with_nullable_pyarrow_string():
     assert len(res) == len(data)
 
 
-@pytest.mark.xfail(
-    raises=duckdb.NotImplementedException,
-    reason="DuckDB only supports the `string[pyarrow]` pandas dtype",
-)
 def test_memtable_with_nullable_pyarrow_not_string():
     pytest.importorskip("pyarrow")
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -468,9 +468,8 @@ class Backend(BaseSQLBackend):
 
         return self.raw_sql(statement.compile())
 
-    def _register_in_memory_table(self, table_op):
-        spark_df = self.compile(table_op.to_expr())
-        spark_df.createOrReplaceTempView(table_op.name)
+    def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
+        self.compile(op.to_expr()).createOrReplaceTempView(op.name)
 
     def create_view(
         self,

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     import pandas as pd
+    import pyarrow as pa
 
     import ibis.expr.operations as ops
 
@@ -506,12 +507,19 @@ def experimental(func):
 
 
 class ToFrame(abc.ABC):
-    """Interface for in-memory objects that can be converted to a DataFrame."""
+    """Interface for in-memory objects that can be converted to an in-memory structure.
+
+    Supports pandas DataFrames and PyArrow Tables.
+    """
 
     __slots__ = ()
 
     @abc.abstractmethod
-    def to_frame(self) -> pd.DataFrame:
+    def to_frame(self) -> pd.DataFrame:  # pragma: no cover
+        ...
+
+    @abc.abstractmethod
+    def to_pyarrow(self) -> pa.Table:  # pragma: no cover
         ...
 
 


### PR DESCRIPTION
This PR works around an apparent lifetime issue where reads of pandas.DataFrame with pyarrow-dtype columns through duckdb exit with a segmentation fault.

Here's an example CI run that shows the issue: https://github.com/ibis-project/ibis/actions/runs/4036380326/jobs/6938934300.

I was able to reproduce the issue by repeating the failing test case a large-ish number of times:

```shell
pytest ibis/backends/duckdb/tests/test_register.py::test_memtable_with_nullable_pyarrow_string --count=10000
```

I cannot reproduce it with this fix.
