### PR TITLE
chore(dev): remove dead warning handlers

### DIFF
--- a/ibis/backends/bigquery/tests/system/udf/test_udf_execute.py
+++ b/ibis/backends/bigquery/tests/system/udf/test_udf_execute.py
@@ -109,7 +109,7 @@ def test_multiple_calls_has_one_definition(client):
     add = expr.op()
 
     # generated javascript is identical
-    assert add.left.op().sql == add.right.op().sql
+    assert add.left.sql == add.right.sql
     assert client.execute(expr) == 8.0
 
 

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -105,7 +105,7 @@ class Backend(BasePandasBackend):
             Dask graph.
         """
         params = {
-            k.op() if hasattr(k, "op") else k: v
+            k.op() if isinstance(k, ir.Expr) else k: v
             for k, v in ({} if params is None else params).items()
         }
 

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -380,6 +380,7 @@ def main_execute(
     ValueError
         * If no data are bound to the input expression
     """
+    import ibis.expr.types as ir
 
     if scope is None:
         scope = Scope()
@@ -396,7 +397,7 @@ def main_execute(
 
     # TODO: make expresions hashable so that we can get rid of these .op()
     # calls everywhere
-    params = {k.op() if hasattr(k, 'op') else k: v for k, v in params.items()}
+    params = {k.op() if isinstance(k, ir.Expr) else k: v for k, v in params.items()}
     scope = scope.merge_scope(Scope(params, timecontext))
     return execute_with_scope(
         node,

--- a/ibis/backends/dask/tests/execution/test_strings.py
+++ b/ibis/backends/dask/tests/execution/test_strings.py
@@ -75,13 +75,13 @@ from dask.dataframe.utils import tm  # noqa: E402
         ),
         param(
             lambda s: s.re_search('(ab)+'),
-            lambda s: s.str.contains('(ab)+', regex=True),
+            lambda s: s.str.contains('(?:ab)+', regex=True),
             id='re_search',
         ),
         param(
             lambda s: s.re_search('(ab)+') | s.re_search('d{1,2}ee'),
             lambda s: (
-                s.str.contains('(ab)+', regex=True) | s.str.contains('d{1,2}ee')
+                s.str.contains('(?:ab)+', regex=True) | s.str.contains('d{1,2}ee')
             ),
             id='re_search_or',
         ),
@@ -115,7 +115,7 @@ def test_grouped_string_re_search(t, df):
     result = expr.compile()
     expected = (
         df.groupby('dup_strings')
-        .strings_with_space.apply(lambda s: s.str.contains('(ab)+', regex=True).sum())
+        .strings_with_space.apply(lambda s: s.str.contains('(?:ab)+', regex=True).sum())
         .reset_index()
         .rename(columns={'strings_with_space': 'sum'})
     )

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -233,6 +233,8 @@ class Backend(BasePandasBackend):
         if params is None:
             params = {}
         else:
-            params = {k.op() if hasattr(k, 'op') else k: v for k, v in params.items()}
+            params = {
+                k.op() if isinstance(k, ir.Expr) else k: v for k, v in params.items()
+            }
 
         return execute_and_reset(node, params=params, **kwargs)

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -119,6 +119,7 @@ from multipledispatch import Dispatcher
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+import ibis.expr.types as ir
 import ibis.expr.window as win
 import ibis.util
 from ibis.backends.base import BaseBackend
@@ -431,7 +432,7 @@ def main_execute(
 
     # TODO: make expresions hashable so that we can get rid of these .op()
     # calls everywhere
-    params = {k.op() if hasattr(k, 'op') else k: v for k, v in params.items()}
+    params = {k.op() if isinstance(k, ir.Expr) else k: v for k, v in params.items()}
     scope = scope.merge_scope(Scope(params, timecontext))
     return execute_with_scope(
         node,

--- a/ibis/backends/pandas/tests/execution/test_strings.py
+++ b/ibis/backends/pandas/tests/execution/test_strings.py
@@ -68,13 +68,13 @@ from ibis.backends.pandas.execution.strings import sql_like_to_regex
         ),
         param(
             lambda s: s.re_search('(ab)+'),
-            lambda s: s.str.contains('(ab)+', regex=True),
+            lambda s: s.str.contains('(?:ab)+', regex=True),
             id='re_search',
         ),
         param(
             lambda s: s.re_search('(ab)+') | s.re_search('d{1,2}ee'),
             lambda s: (
-                s.str.contains('(ab)+', regex=True) | s.str.contains('d{1,2}ee')
+                s.str.contains('(?:ab)+', regex=True) | s.str.contains('d{1,2}ee')
             ),
             id='re_search_or',
         ),

--- a/ibis/backends/postgres/tests/test_postgis.py
+++ b/ibis/backends/postgres/tests/test_postgis.py
@@ -82,9 +82,7 @@ def test_geo_buffer(geotable, gdf):
     expected = pd.Series(
         [linestring.buffer(1.0).area for linestring in gdf.geo_linestring]
     )
-    tm.assert_series_equal(
-        result.area, expected, check_names=False, check_less_precise=2
-    )
+    assert pytest.approx(result.area, abs=1e-1) == expected
 
 
 def test_geo_contains(geotable):
@@ -273,7 +271,7 @@ def test_geo_difference(geotable, gdf):
             for linestring, point in zip(gdf.geo_linestring, gdf.geo_point)
         ]
     )
-    tm.assert_series_equal(result, expected, check_names=False, check_less_precise=2)
+    assert pytest.approx(result, abs=1e-1) == expected
 
 
 def test_geo_intersection(geotable, gdf):
@@ -289,7 +287,7 @@ def test_geo_intersection(geotable, gdf):
             for linestring, point in zip(gdf.geo_linestring, gdf.geo_point)
         ]
     )
-    tm.assert_series_equal(result, expected, check_names=False, check_less_precise=2)
+    assert pytest.approx(result, abs=1e-1) == expected
 
 
 def test_geo_unary_union(geotable, gdf):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,64 +223,42 @@ filterwarnings = [
   "error",
   # pyspark and impala leave sockets open
   "ignore:Exception ignored in:",
-  # poetry
-  "ignore:distutils Version classes are deprecated:DeprecationWarning",
-  # geopandas warning
-  "ignore:The distutils package is deprecated:DeprecationWarning",
   # dask
   "ignore:index is deprecated and will be removed in a future release:FutureWarning",
-  "ignore:Concatenating dataframes with unknown divisions:UserWarning",
-  'ignore:The Index\._get_attributes_dict method is deprecated:DeprecationWarning',
-  'ignore:\nYou did not provide metadata:UserWarning',
   "ignore:`meta` is not specified:UserWarning",
+  "ignore:Concatenating dataframes with unknown divisions:UserWarning",
+  "ignore:Possible nested set at position:FutureWarning",
+  'ignore:\s+You did not provide metadata:UserWarning',
   # pandas
   "ignore:Boolean Series key will be reindexed:UserWarning",
   'ignore:Using \.astype to convert from timezone-(naive|aware) dtype:FutureWarning',
-  "ignore:This pattern is interpreted as a regular expression, and has match groups:UserWarning",
   "ignore:The default dtype for empty Series will be 'object':FutureWarning",
-  "ignore:the `interpolation=` argument to percentile was renamed to `method=`:DeprecationWarning",
-  "ignore:Explicitly passing `name=None`:FutureWarning",
   # pandas 1.5.x
   "ignore:iteritems is deprecated and will be removed in a future version:FutureWarning",
   'ignore:Passing unit-less datetime64 dtype to \.astype is deprecated:FutureWarning',
   'ignore:The default value of numeric_only in DataFrameGroupBy\.sum is deprecated:FutureWarning',
-  # the warning suggestion to simply remove the argument in the call isn't correct
-  "ignore:The 'check_less_precise' keyword in testing:FutureWarning",
   # numpy
   "ignore:Creating an ndarray from ragged nested sequences:",
   'ignore:`np\.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning',
   # numpy, coming from a pandas call
   'ignore:In the future `np\.bool` will be defined as the corresponding NumPy scalar:FutureWarning',
-  # sqlalchemy: most of these can be removed once we have a lower bound of sqlalchemy 1.4
-  'ignore:Dialect .+ does \*not\* support Decimal:',
-  "ignore:Class (_regex_extract|_array_search|ST_.*) will not make use of SQL compilation caching:",
-  'ignore:Dialect .+ will not make use of SQL compilation caching:',
-  "ignore:UserDefinedType .* will not produce a cache key because:",
   # duckdb-engine
-  'ignore:The URL\.__to_string__ method is deprecated:',
+  'ignore:Dialect .+ does \*not\* support Decimal:',
+  "ignore:duckdb-engine doesn't yet support reflection on indices:",
   # ibis
-  "ignore:`BaseBackend.database` is deprecated:FutureWarning",
-  "ignore:`Backend.database` is deprecated:FutureWarning",
+  'ignore:`(Base)?Backend.database` is deprecated:FutureWarning',
   # ibis on postgres + windows
   "ignore:locale specific date formats:UserWarning",
-  # shapely
-  "ignore:The array interface is deprecated:",
-  "ignore:Iteration over multi-part geometries is deprecated:",
-  "ignore:__len__ for multi-part geometries is deprecated:",
-  "ignore:An exception was ignored while fetching the attribute `__array_interface__`:DeprecationWarning",
-  # thrift by way of impyla
-  "ignore: PY_SSIZE_T_CLEAN will be required for '#' formats:DeprecationWarning",
   # spark
+  "ignore:distutils Version classes are deprecated:DeprecationWarning",
+  "ignore:The distutils package is deprecated and slated for removal:DeprecationWarning",
   "ignore:In Python .*, it is preferred .* type hints .* UDF:UserWarning",
   "ignore:`np.object` is a deprecated alias for the builtin `object`:DeprecationWarning",
   # windows
   "ignore:getargs.* The 'u' format is deprecated:DeprecationWarning",
-  # findspec
-  "ignore: _SixMetaPathImporter.find_spec()",
-  # duckdb-engine
-  "ignore:duckdb-engine doesn't yet support reflection on indices:",
-  # snowflake
-  "ignore:`Node.op` is deprecated:FutureWarning",
+  # sqlalchemy
+  "ignore:Class ST_.+ will not make use of SQL compilation caching:",
+  "ignore:UserDefinedType Geometry:",
 ]
 empty_parameter_set_mark = "fail_at_collect"
 norecursedirs = [


### PR DESCRIPTION
This PR removes some defunct warning handlers from `pyproject.toml` and updates our codebase to avoid internal APIs that trigger them.