### PR TITLE
fix(duckdb): ensure that `temp_directory` exists

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -130,10 +130,12 @@ class Backend(BaseAlchemyBackend):
             if temp_directory is None:
                 temp_directory = (
                     Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
-                    / "duckdb"
+                    / "ibis-duckdb"
+                    / str(os.getpid())
                 )
 
         if temp_directory is not None:
+            Path(temp_directory).mkdir(parents=True, exist_ok=True)
             config["temp_directory"] = str(temp_directory)
 
         super().do_connect(

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -158,3 +158,9 @@ def test_memtable_with_nullable_pyarrow_not_string():
     expr = ibis.memtable(data)
     res = expr.execute()
     assert len(res) == len(data)
+
+
+def test_set_temp_dir(tmp_path):
+    path = tmp_path / "foo" / "bar"
+    ibis.duckdb.connect(temp_directory=path)
+    assert path.exists()


### PR DESCRIPTION
This PR fixes an issue where a non-existent directory can be used for out of core processing. The solution is to create the directory and its parents.