### PR TITLE
build(nix): fix nix tests

### DIFF
--- a/nix/ibis.nix
+++ b/nix/ibis.nix
@@ -31,6 +31,9 @@ poetry2nix.mkPoetryApplication rec {
   preCheck = ''
     set -euo pipefail
 
+    HOME="$(mktemp -d)"
+    export HOME
+
     ${rsync}/bin/rsync \
       --chmod=Du+rwx,Fu+rw --archive --delete \
       "${ibisTestingData}/" $PWD/ci/ibis-testing-data
@@ -44,8 +47,7 @@ poetry2nix.mkPoetryApplication rec {
     # the sqlite-on-duckdb tests try to download the sqlite_scanner extension
     # but network usage is not allowed in the sandbox
     pytest -m '${markers}' --numprocesses "$NIX_BUILD_CORES" --dist loadgroup \
-      --deselect=ibis/backends/duckdb/tests/test_register.py::test_read_sqlite \
-      --deselect=ibis/backends/duckdb/tests/test_register.py::test_register_sqlite \
+      --deselect=ibis/backends/duckdb/tests/test_register.py::test_{read,register}_sqlite \
 
     runHook postCheck
   '';


### PR DESCRIPTION
This PR fixes an issue where `$HOME` needs to be writable but is not by default in nix builds. We use a temporary directory as `$HOME` to make it writable.