### PR TITLE
chore: disable ruff autofixing and revert SIM300 changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     rev: v0.0.238
     hooks:
       - id: ruff
-        args: ["--fix", "--show-source"]
+        args: ["--show-source"]
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.29.0
     hooks:

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -134,7 +134,7 @@ def test_projection_fusion_only_peeks_at_immediate_parent(snapshot):
         ("val", "int64"),
     ]
     table = ibis.table(schema, name="unbound_table")
-    table = table[ibis.date("2017-01-01") > table.PARTITIONTIME]
+    table = table[table.PARTITIONTIME < ibis.date("2017-01-01")]
     table = table.mutate(file_date=table.file_date.cast("date"))
     table = table[table.file_date < ibis.date("2017-01-01")]
     table = table.mutate(XYZ=table.val * 2)

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -238,9 +238,9 @@ def test_players(players, players_df):
 
 
 def test_batting_filter_mean(batting, batting_df):
-    expr = batting[batting.G.mean() < batting.G]
+    expr = batting[batting.G > batting.G.mean()]
     result = expr.execute()
-    expected = batting_df[batting_df.G.mean() < batting_df.G].reset_index(drop=True)
+    expected = batting_df[batting_df.G > batting_df.G.mean()].reset_index(drop=True)
     tm.assert_frame_equal(result[expected.columns], expected)
 
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -158,7 +158,7 @@ def test_table_drop_with_filter(snapshot):
     left = ibis.table(
         [('a', 'int64'), ('b', 'string'), ('c', 'timestamp')], name='t'
     ).relabel({'c': 'C'})
-    left = left.filter(datetime.datetime(2018, 1, 1) == left.C)
+    left = left.filter(left.C == datetime.datetime(2018, 1, 1))
     left = left.drop('C')
     left = left.mutate(the_date=datetime.datetime(2018, 1, 1))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -388,6 +388,7 @@ ignore = [
   "SIM108", # convert everything to ternary operator
   "SIM117", # nested withs
   "SIM118", # remove .keys() calls from dictionaries
+  "SIM300", # yoda conditions
 
 ]
 exclude = ["*_py310.py", "ibis/tests/*/snapshots/*"]


### PR DESCRIPTION
This PR reverts some ruff style changes introduced by our use of `--fix` in pre-commit. I reverted those changes and disable the corresponding rule (SIM300) and removed automatic fixing for now.