### PR TITLE
feat: change Rich repr of dtypes from blue to dim

### DIFF
--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -188,7 +188,7 @@ def format_dtype(dtype):
     strtyp = str(dtype)
     if len(strtyp) > max_string:
         strtyp = strtyp[: max_string - 1] + "…"
-    return Text.styled(strtyp, "bold blue")
+    return Text.styled(strtyp, "dim")
 
 
 def to_rich_table(table, console_width=None):


### PR DESCRIPTION
On dark theme screens it was very hard to read the dtype text. The `dim`
style is what is used by the null symbol
"∅", and that looks great in both
white and dark mode
on my machine.