### PR TITLE
feat(api): implement `to_pandas()` API for ecosystem compatibility

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -27,11 +27,11 @@ def _create_temp_table_with_schema(con, temp_table_name, schema, data=None):
     con.drop_table(temp_table_name, force=True)
     con.create_table(temp_table_name, schema=schema)
     temporary = con.table(temp_table_name)
-    assert temporary.execute().empty
+    assert temporary.to_pandas().empty
 
     if data is not None and isinstance(data, pd.DataFrame):
         con.load_data(temp_table_name, data, if_exists="append")
-        result = temporary.execute()
+        result = temporary.to_pandas()
         assert len(result) == len(data.index)
         tm.assert_frame_equal(
             result.sort_values(result.columns[0]).reset_index(drop=True),

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -224,7 +224,7 @@ def test_trig_functions_literals(con, expr, expected):
 def test_trig_functions_columns(backend, expr, alltypes, df, expected_fn):
     dc_max = df.double_col.max()
     expr = alltypes.mutate(dc=(_.double_col / dc_max).nullifzero()).select(tmp=expr)
-    result = expr.tmp.execute()
+    result = expr.tmp.to_pandas()
     expected = expected_fn((df.double_col / dc_max).replace(0.0, np.nan)).rename("tmp")
     backend.assert_series_equal(result, expected)
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -8,11 +8,12 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis import util
 from ibis.common.grounds import Singleton
 from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     import ibis.expr.types as ir
     import ibis.expr.window as win
 
@@ -508,6 +509,16 @@ class Value(Expr):
             )
         table = roots[0].to_expr()
         return table.select(self)
+
+    def to_pandas(self, **kwargs) -> pd.Series:
+        """Convert a column expression to a pandas Series or scalar object.
+
+        Parameters
+        ----------
+        kwargs
+            Same as keyword arguments to [`execute`][ibis.expr.types.core.Expr.execute]
+        """
+        return self.execute(**kwargs)
 
 
 @public

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -31,9 +31,10 @@ from ibis.expr.selectors import Selector
 from ibis.expr.types.core import Expr, _FixedTextJupyterMixin
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     import ibis.expr.schema as sch
     import ibis.expr.types as ir
-    from ibis.expr.types.generic import Column
     from ibis.expr.types.groupby import GroupedTable
 
 
@@ -1360,6 +1361,16 @@ class Table(Expr, _FixedTextJupyterMixin):
             query=query,
         )
         return op.to_expr()
+
+    def to_pandas(self, **kwargs) -> pd.DataFrame:
+        """Convert a table expression to a pandas DataFrame.
+
+        Parameters
+        ----------
+        kwargs
+            Same as keyword arguments to [`execute`][ibis.expr.types.core.Expr.execute]
+        """
+        return self.execute(**kwargs)
 
 
 def _resolve_predicates(


### PR DESCRIPTION
This PR adds a `to_pandas()`, which the `plotnine` library uses to turn non-DataFrame objects into pandas objects, providing lightweight compatibility with an ecosystem project.