### PR TITLE
docs(tutorial): remove impala from sql tutorial

### DIFF
--- a/docs/ibis-for-sql-programmers.ipynb
+++ b/docs/ibis-for-sql-programmers.ipynb
@@ -25,10 +25,6 @@
     "Coverage of other DDL statements (e.g. `CREATE TABLE` or `INSERT`) may\n",
     "vary from engine to engine.\n",
     "\n",
-    "This document will use the Impala SQL compiler (i.e.\n",
-    "`ibis.impala.compile`) for convenience, but the code here is portable to\n",
-    "whichever system you are using Ibis with.\n",
-    "\n",
     "> **Note**: If you find any SQL idioms or use cases in your work that\n",
     "> are not represented here, please reach out so we can add more to this\n",
     "> guide!"
@@ -66,9 +62,15 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAQkAAABgCAIAAACBhhAVAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO2dd0AUx9vHn9ndqxy9iyCggPRmARsW7GLFCGrUaPBn7y1qRI0au/E1iUYl9q4Ra2JDVDR26QqIqCCI0jt3tzvvH0c54JA7QUGzn7+U25uyN8/OzLPPdx6EMQYWFpYaEI3dABaWJgprGywsimFtg4VFMZT8f1JSUu7cudNYTWFhaVxMTU09PT0r/4/lOHbsWOM1jIWlkfH19ZU3B6rmFazniuU/yPDhw6v9hd1vsLAohrUNFhbFfGG2IY0IdOJwbH94IG3slnwuxJcCDEiEEK/br8lMYzemgtK//EUEQojff29Wg6zA6+gmTt3hzUdy8Hv+8fZTL/2/MNsoiIpIpPn2LjYK9km1kn9suDqhNvhg9idrVm0UHh0mQAghfr8/M8p/ydLzY3UIhBCvw6bEpjPY64M0ItCJg2qBNAi4JG7sFn4cqoyxxkfyNDy6lLJycVBT4UvSp0+iSsiWTg7qn6xdLJ8YpOez4WKrTAYkd372XR5S9Fm8RV+UbeDMyMgUrD7C2ZJU4UtZkeGvaLXBLlZfVF+/IMiWY3dd6pzPAIAkbPXQlaElmOM8bd+GQfoIAHFNXDn1r4Nr4trdBABKC/ao8NvXj49ZU0nvL2rNNRq5dssoVyORulnPn2+GH5naqYWGUNtu1L4EKQCUXp5oRPK6bntdZdFQen+xA5fUG7w/Vcm1BM6POrxwsLuZlprIyGnwT9dSIsOjJZStiz0PAABnRxxfP8uvm0urZjpCHl/b1KX/rL0ReeWPlNzDQ9QIhBBhGHCpBOceHSaSTfKE+jfHC8rK/3AJZTCvj09w0tM0815zt+Aj7lYdXXz7R08+QojX5ZeohzsDurTUEQp1rLznnHohqX4lk3l7y+j2ZppCkZFDvwUnEkrkPix5cWHN2K62Ruo8rkCnhfvA2bvvZ5bfZOnjHx04CCGOzcL7UgAAyd0F1hRCiOO4LFyqZBvot9fX+rcz0xSKjJwGBf6dLJG7SUhk2b67t7e3t7d3dycjEgAAadt06uHt7e3t3aOLrQ4CAMmbsKBlE3w6OrZqpiPkctV0zV37Ttp64y2tSjfrvJv5sSeWj/aya6bJ5/A0jO29J/4SmvrxW9Oa7/5wHTDv/+zHR6TQqs+k6cMcRAgJtAxse/9vuq+jOqJaL7ovwZhO+a07l9D77mJJ5dfo17v6ahL8tqujxHXVIKsm4+o8VxFB6bkMmTx/weQBrTW0Xd1bUUSzSVdLMcYY5x0briE0ceszcvLcH5YsmDzUTZ9ChOHwI2mMrJU3/1gZGBi4bJq3CYk02o79MVDGiv+7nExjJUqo6G5QXx4AAGk5J0y5pldQcGQoHwCA1zfofXmZJefGaCMA4HpufE5jJm2HNw8ACH0X1xYUqhhual22JEgxxrj0n+/1CQCgzJ0dtSqfZIhj+b+/s2RllkRt7alPoCo/KxLYTf1bVqfk0VJ7CgAo6wX3JBhjLP53vhUJAJTDj08kGNfdBlzyeFV7EZIr3N7FhosAgNdvT6b8zSo55aeGAIDbddtrWv5O0K+3deXWGHyI77DwdqGS3ZRVcHqkOgIAnveOKr8SxpjJvDrXRYSq1cBp4X/klVSJ38rX17fau7+PsA3xjRktSKr1wrulGOfs9+ED5bj0USnGOfsH8kmLWbfEGGPxrVkWJKfNmqcVrcq/NtWSJC0mX8lTop0YM+kn/I0J0szvUJJsPNJv/hygieRuCpOXGJmYK/cDlEatastFwiGHc+ULKrkUYEhwO29JqvJTYRVKoF8eGWevrW7S9afb+Uq1vRLlbQOA0PKYvuvUkZX9mpEAANyOm1/QuHLQABAa7hN/PfnXzhmeOgQAIJ7nhngpxtKEX7qoIQAg9DvP3nn6zIEVA805CABIy+nXC7EKtlFbG5jMI77aCACQ0P7bX04E713U3bBs+KpiG73NXAdOXrZpx4FT586d3LPG316IAJD2iBO5ynSzvIJabaMwZJoFCYBI/Y5Ttx49//fZ/Wv87IQIgDAcdSqzmh0poCFsg075rTuXtJwdJi57GlB2ix9KMKZfbu3CLf9Fmcy9AwRIY8SJstEkjdvUSUjo+OxJqTlEFSF5tNSBInQGH3hb0Sk66ZfOXCBbzr1d28O78JSfOuL13yv/nJEmbPDgECZTrpUqU62iEuqDCrZBOS57IsEYS+4usKYAgDSdFirGlYMGcdv9LHvS0M83deQhAMTrsT2VkUatdOUAAKEz5GDZzSoImWZJAgBhMP5ikSq2UUsbis6O0UEAQFnNvV2CMcbM232DtJBKtoFpsZjGTNH7l0+f3L0ZcvXq5SPTXTgAQNksvC+pu5sVFdRmG4XnxuoRAEhj0P535R8UX53cnARA6kMP1f2L1rQN1fcb0tiIWFro7unEAZA+i3pGa7i3t6MAJE8jn9GarW2bEQCANBydLciiqPB4KQDgrHOrNv3LuM1eNcpEqQolDw4ffcpo9xs32LByihcIBQjxHFxsZVs7nP8seO3E/m1bGajzKIJACKkNO5qP9M3N5OdVcUxEnJRj7+KgYD+oXAmfByRwcGlNAQBhaGxIAAAWl5bKb3xI6969W5EAAESLbt1akQBYmpSQJC2MfPxMCoC4Hj59DGTNVuswoLsuAcBkR0cmV1/Pq94GJi0hsQADEFqderjzAACQQc8+bWqukD4Ezgvf9b2HiY6Bha2rR5fu3t69/LeFSwCAycnKltt+1tbNusqnEx9H5DIAOO/MGAOizH8s8N6eQgPg4mexSSrch3JU9t0wyVHRWURrN0chAJMcGZ1F2rk58gDoVxFR2aSds71sEFLWLo5C+mxEdB52U4/YtuJYevNxf85wUs5jwby5f/81zenSqb2cr5Z+++YtXe6KZd6cntRr9O54vp33AL/JplpCioCSyCObTr9q7dhark/084joAsLM2Umn+mhXtoR6gT5kY6jKpxSHI/svQSj8EqGtq132XCE0tDQIAMDFhUVMQW4ejQEQT1e3wqJJbV1tAt4xuCC/QBVvp+I24KLCQgwASF1WLQAgbV1tAgEoWziTduT7AdNPvVPkg6laRi3drLMiJi8nt1YPj1Il1ETlUVAaG/GM1hrsbEECFMeEP6X1/ZxMCIDC6PA4xmiMk1FZzwT2ztbUyZgnseKeSSu2Ran1+WNpTw0l62DSU9MZQt3MTG5EM29v34ovc8XirNPzJwXFNxt/6uYfA43LfHqlN2fu20g2d3bUk/tdC2Min0v5PV2qj3blS6gXpECNh6AEg1RS8eTDEtm/kVBNoEI9THZmDiPzKzJZGdkMACChSEioaaiTCABKMzMLMPAQAACdnSm7QENLo7IKjDEjGyFyrVECJFQTIgBgcjKyaAAOAODsrGxG+dGGsy8dvvieAUDqHnP27ZjV1cpQi/9ma1eb2bfEQFR5RNTSzcpLys0W4yqmgIQi2abLaOimPZMdqv7cSGDm+BGPO1XXVHRSZHQ+ae/qwAGgn4dHF1D2rvYcAGl8eHQhx97FvrwNpKWzoyZ+E3E3eP2q8wVOM1d9a6p8XSRJVosHLg3fuTOslLJxceADSO7/fTWDsBs1o1/5sAb8/tyO46+ZyiUXAABI4yNjS8iWTjXeFSpdAtTLh0uamZuSACAJvxb6Xtabgn+vPyjCAIRGFdOvEzrhypUXNACANOHK1UQaAFEWrSwoNUdXaxIAi++e/6esisI750MyGQBC39nZlATE43ERADCZqW/FAIDfx8S8VeGNPGHcqqUaAsB5ty7dKQIAwO+v/fNQhZfdOF82uQFl7TNhoHNzbSEH3t8KjZIAABCE/LiorZvln5fbAJ2WnCa/TKJaOtmLEADOSik28/KWp4uDuVkzjY943KlqTsUxkQlMs/HORgRAbnR4Ajbr6aiDAOdHR7wA8wGOWhVt4Ni72FH7HqybejfbePTZmc4qrE9Jc2tLLk54cDtS3K8NF4BOv/zDhE2RYqTn6NyCBKABMODstLQScBIBAJP94JdxM46nM6SDs6P822865VUyTTiKhArMUrkSAHDW1b2HojJLITToRMR8j46qvMiibL27m66JTqLfnwzo3C/Ex5GbdPnImUQaAGl08W6nypIdl95bOSKAu6g/L3Tt+scSDIjn1ruHAaIM/Ea3Wxd5pzgrePbweUWzuwqjgn7cmUQDolr5j+nMAwATixZc9ESCc86vW7wHe6QErQopUWWJwe/Yp5vmwb9y6Fe7J483XzXSMOLXhedyVSiB0DdvISJuZTHSyF2L1ph+7y5Kvbx56bkcDACAqqwha+tm+edUq9atKJQmlj4LWvCj9ezuJnyE+KZuHW20e40ZZnIyKEX8YEV/n8w5Y72stVHem2f3Q4KPX2CmP7w1r5Xq7wzlN+Z1+6kkj5bYU4IBezMZjCV351tRaoMP5WCMxWGzLSmR71F5B634+jRTEgBp9trxUjnvVAVM+rERBgTitegeMH/epKFuBhq2jq24qNz7wWSeGmVIIMqgrd/MhXMChrYzUbca6OPMQZr+pwrkyxHfntuSRKSh5+jZi5cFBi5fF1zmDlS6BFwvHy7G9Mu9g43I6g8tpO65+nExxpU+IqQ95lwJxhjTr7Z24QIAYRhwqRRXOHAQx6Fje3nHP2URcLHMRVT0ZGM33WrWj9Sc54WUOWeY9MPD9Co/J7QdnMwU+alqbQMufrDcXW5dg/gOHdpoEaC8n6rw1nw7nvxdQEJbZ2seqqhUiW6W3dCk7b00q9xPwmRKSCnGmEm/OMNZXcH8wPHYkFD3G476+nCZrP0DhZT9kkcSjJn0Xb35HOflERKMmTfbe/A4bqti5JtAp/zWnYs49ovuFdfZsJo1Zd7ePLJtcxGPr23ZadyWm4kHhvBJs+mh4oqPt4xub6rO5akb2fec9OvttLiNHbic9uviqt4E5v3NDaM6WBtr8ggEwHGvbKGyJdSf4sTza77r4dhcS0CRHDX9Vh7D5u99nF32eytrG2SLGddTQtcOd2sm4gn1bXvPOfqsSK6OovjgFSM7WekJKYqn1aLN4HmVNWCMMf32ynIfOz0+R6Bv77P8ctzBIUKkim1gLH1z+SdfNxMRT6hv23dh8POote04KtgGxuLXf/80on0LLR5XqGftNX7zjZTI1e4cAOC4rIiUKNlNWWfSQtaO9LTUEVCynUq5bWCMmbynp9d838fdQk/E4/A1Dc3tPAZ8H7jzWpISI7CmbSAst6o/fvz4iBEjcMPo/pgX27ydZ8f0Pxx95Bv9z+4TZWFRDZnu78SJExV/+VTxd/TrQwvW3ESdNq4cVt0wcNadP3+7XIvjndD2GDe9j9kXFjrP8jXS0LbBpN/8c9/NpISQgwdviL02/zbFusYWiMm6s/unFXerx9LJIM1ndZ/C2gZLE6ChbaPk9o55i46VaLZoM3Lblk2T7RW4YshW8/4Vz2vgellYGpqGfkALhx7OYeiS7BdhQVPaav13thnSzIizl2JUiaeuBn67s5eA4HXc/JWIAb8C2MVLQ1B85jsrtxG/PaqPbdBSKYMxLaXZE5CaCKwWriFgiouK6/m4J5qNORTdI19o/BHvqFg+CaxtNBWQyNjKxrixW8FSSWOvqYoTgleO9mptrCngi4xsvSf98SCnck1R+s/3hpT22HNZz44vGuTaXFMgNHAYvDo0o8qqg864FzRvaDtLPTW+yNCu17Q94Q0rapW+ubZxfA8HE00+V6Bl3NK117gfT8XJnGzMi82deAghJPL/qwRKzo3VLguOpsymh1b44aT3F9pw+AP2ZhbEHJzd18FIjcsVGVh7zT6TJptqyjWrCCHEbb8urppzW/poiT2H3y/oTWLw4oHOJhoCoZ6198yj8aVVuph5Z9v4Llb6IoFGc/dvfr7+8rifOmUyJeQLPeGjadCo80bB/dV9ey+7XdzMY9BoHzNx+KlDO6f0TaEenZ3QggAA+lVkdDbmvAoa2v+5qEffMd87XD909GzgmB/bx233FgAAQGH41m/6z/8nr0XXQf5TTej4i0e2f98zSXr/XIBFhdXXJyAKiu8s7dN/fZyW+6BRM63Ui9ISo24Hb97vPW+YjSYA0vYcvzTQmwZJ9PH1pxIsh8z1d+IDABCa7cyrLo1wZuTvYxavf2I96JvpA3lZMVfO347KxIOMAYAw7jblR/Kd9NU/2/Y/rqUZdOLxCf0j3toNHT3FK/Hvg6e3jR2uZf1whZusLyXha316L72HrHuPmu7ETw7dNtzHQEOlkCkWRci/JFdOE9tAMLlXprSkCP2eGx7mysIOJHEbOvBRpZK28PRILQSE8aBdcWW68+xjw7UQx311rBRjjJm3p0abUgKH/518UR4TkH97vj1Ftpp3R14bWI+AKPH1aaYkZbfoXqXwnc6Je5pSTXpYcGQoH/g++7IVlSG5t8CaQnyhUbf1TypiteiM54nZVbRo4hszWpCcdmufVYtZkTxcbEcBUuv4c6Ssl0zW6W+NCNJq/r+yVshUeBzbWaE5sgJLn272EiEgmk1WTu3IgnHD6P4aCDp+x9KgJPX+6/bMcS8LIKYsu3ezJKXPnz2XAgBIn4dHF4Cox7Jt461lcmYQamvzULnwoTBk5dwj6Y4L9m8dZsEvK1XU1se7OSQ/CX8v99QkWvjtic7KS7m+tINIxVbikuISjLh8fuUsQGhatzZR+VQZLDUfv36WS0WsPKHb0lIFFzdS6zn5fw6yXiLtbr3ac5nkZwmFAAA451pwSC6nfcCMzmUxeFybcRN7fn7p4ldHY62ppOH79z2SGH03bYScShbxhQIE5VKwwpjIRJrfecSQ5uVXMG+fxWWDprWNMQE4I/i3Q6+wtnn66Z+Xn6kogk66k8lgc5rGAA0wOjjtB/U33rtv7YDuL0YN7dm5fRt3FxtDVSRJ5RC6Hb2UVD0qgmxm3aoyxJSvocEDXFRQhEEL0YnRz4qRroNj5Y1E6naO5uSZzI+ujgWg0WyDSbl16znN79e1vVD+r+mp6QxpKtMDSePCY0rJlm3cdCvGhCTmSYyUcnCx5wCI71+7lY+Z3NAdP4VWKxxpGJvoNcyEiLR9frt2vMWKzQfPbpqzfy1GhMiy7/w/gpb2MFStAkJHv3oYuUpwuPKGhaBs6QuAcH5ePkZqMslP+ecidTUErG3Uj0ZaU9Epr5JppG1sJJD/Y1zYnXRs2LFzawoAZ0dHvaaF9i7WFeZLJ0VE5yJjJycjAnBWcnI+Fgw9omAHweQeHiJQUOnHIbQZuvxw2PPMnDeRl4MW9tFPubhi5NwzOarudGuRgdcfpK6hjnB+br5ci3BBnkpCcRZFNNZ+AyECoKRE3pmSf337nkjGfPjIznwAkMaGx0goGxd7fsUFJTHhcVKOvYsdBQBcLhcApFIlzo9okIMJCaGxY8/xP5/aPcEUZT24W9XTShAEQphhVNBQ14TL4wKUlqrqdiVb2tvwcVZkxKuKJuG8mKiXH3GwBksVGsk2qJa2VlyceyfkUbHsDyWJh6f8b9crjT6L53TkAQCTHh31Fms5OltU7IKlceHRRaSFs6MWAkCaTi6WZOmNffvj5AeT5F146JP0qq+oy3y4ecmhQSciFEf/1or4xYN7b+TeJNAZL1/nY0LfSL/KjSN19bQR/Tw2XsXi5aHMrSw40sS799JVMzCk1WNQNw3po12/XM+WfVMcu3v7lUJ23qgvjbTfQIZDJg1fefXA//l6v/PvrJv15OKpKwlSm4Cju7+THbkgiQmPlVJ2LvYVy2ycFx3xghYMcJXlF6BcA+b12RVwYban2z9D+7gYcYreJjy5Hfrvy7a/v/ZyrVKXTo8x/vZ3T+U4fzfMWcXtcPGdVV3Hh7Xo2MPLrZUBNz8h9K/ge/nN/Gb6mVexDU6bPt4GOw9s8+uTObyjqRpJaLYbM7OfuUoPHmToM7b/kqun5/cbEetjp0GSpr2mju+gxHELyGhE4JzfQ5ZvH9L+hf9gF2HytWMhtK0l9bhYtb6yVEd+of5Z32/gguiDs/s5GqtzuSJ9y/bDFuyTk3FK49d7cEjTadcrXySIw2ZbkBXvNmQlxB5bPNyzlb4alyvUbW7l5j1q/pa/IhrqUEKMMRbHnQoMGNzZwVRHyKG46katvb5dfeFFSc0Lmfe3No/pbKWvxiEQQJWWS+4tsKYo+6WPJHXVxmSEbfRvYyLiIFSpcpY8XGxX7eslZ7/VRNzuv1UeEkm/u7l5TAdLHQFfw7St/6abd9d5cMrPX2VRis+piWVpPCS3Zll1226y/umtOZaNHRX0pVBTE8veua8BcXZGXuXeG2de2hucgmx6dGf1k/WBjcP9CmBS9w9zXl/QobOrjbkhJ+PRmWNX3piM2jzVmf116wN7974CkHabocOcDt66+deN00WklpnzwGWbVi70MWTDRuoFO+kqB34Xus7fw0JHQBGEXH7H0lMjhOWndiNe51+SPqGgtXbZLdLsOPPPvx8kpGYVlZbkp8eHHQr0aclXcCGLKjQF22i8PK7KgrNOzfpm8YlEvT6TFy1bFrhsvk+ZOo+yG74kMDAwcOm3bRSdqNeA1CW7LU48t2ZcDwcTbSGPr2ls4zl06QWFqeMk0es6iAiEBEMON3yGtq+LJrCm+gLyuEoeXg7JpDw2Hj8426LqSz9b3yWBvgDiq+lBhyI/ZRM+KLstfLi2f+8lN4uatffxm9ZKm85KuHfl0t205f2bVXv2SeN+m7bmQemnil/5umh82/gS8rgyudm5DKGrr9MUptkaiJ9smLj8FnitDTsz3718+qJLSpjqN5RO2j3jp2iP7/1e7T746rM384uj8X7sD+ZxZRI3deBRFrPDFARhMElbvQSknt+JLAxQh6pW9oWPjadiEjd14CGEkOCbkyVQcvZbrY/KJy9Nu7ElwNu+mYaAL9K36uC/PPi53CtrJjVsV+DEgR0dLQ01+HyNZnZeowJPxJaHCiohuy0J2/1nJHab++scd7l1HcnnV4sBYJIPzFr2r/3ijePM2OMalKHRntVYYtp30TJnGmfeDtp+Ld+tIsaC0O3YQYgIobCWeZ9+dvjAvxLTgIkDdFBdqlpZTR+tiUU6HSYsDexFgzT2xLoT8S2HzPNz4gEAUnNT+jQQnPnPjK6DdzwX2vuMnmHLSb5+/ORK3xvhu2+fGicLFZPc+33OuqtmHp6eg3ua6aKMyEt/rfY7f3X1jZBFLjwlZLfSp6E30wj7gIFWxc9Dzv7zKLlErYVbz/5drTSqPPdw2vF5P1wxmX1rii38pPQd+G8j/5L888aMyKglj2v2vgF80lxB0IP4wQ+2FOXw42OJEqpaGfVKEoAxxrjomC8f+AMP5NR2QemVScYEt9OWF9WTKYgfLrajkNBj1ZOy88AlL3YP0CMIo7Fny/Ix0MkRT97Kd7M4YmUbLqE/7nyhfEG1ym4Ljw9XQ4JBa3aMsKw4xR9xjHuuvZtbGTzDvDs9pjnXasb1vHKRLX/woY+8GV8pTUgTWwadHBmVBfqOTtV2jXy1inwyTOIvXYSExqjgUgAoubP/SDynQ8B3zlTdqtoy6qGJrS/SmDNn42mN/rOmupQpSiiL0fNGmqJ3F4PDZPG9RHMnF0P5uYxv6+1linKexr5RJswc5+fkSkEaun7RQ/eNN17llRSmPdw3wSb36tKRS64Xll2TfWnpnKPgv3GZV9P1dzQ9Gts2asvjSgiEfNl4L73/x477UlKclZmHoSBk/8lk9T4T/c2JMlWt7wdUtY2POP7pC5qycnWWG5M8Z3dHDpMbH1d2Bg/Ojz25YlxvN0t9dT5FEAhxO2xKpHGhcvIkLJVIMZYUqA3bFjSts5k6T2jkPmbrlrGmOOnwn1cKAQDyQgNn7i3ov2b1AF3WP6UCjewbqjWPKxLIEjDinIu/HijyHdvrQmRGFp0duS/4vZHvxEH6iHlZp6q28cFFBYU0RuoaVU42EKirkwgXFhRgABBHburvtTCsSM/Zu+/oIc0N1LmISb22PeguTSulTiLUREICEOXRs3Ol/QnbdXDl7Lj4NOYVPbjlo7XTd77ttPHCSOXyV7OU08i2UVseV0BCoQAB0K8P/3becPwVv6w7NzMy0oL3/Z3XakpAdxGA5AOq2gGdGywLcv1AQpEagXBeVcFqUV6+FCM1NTUEUHrz9823883G/XVv90CDsrEruZ6xJ+iusnUIm5vqEFCkJpSfeblCAQm4tKQU48LYiOeleTHTrajpVb4XPEodjbVZdCf657ZN42Y1ORr3ttSax7Vs3hCH79r+2HPmPhfjvbo5ceHHHoaI264c784F+JCqdrpMVVsB8/p4wIApJ3NcFh4PXuzxSbYciMPhICwulVRbBnFb2ViS0oTH4XnYVrts7hBHPoqSEhqtrI0JwAXJr7Mwf8iAXgYVD3U66f6DdAbUmCqv+uRlt1XmWI59G2c+XHuRmMZAuZqKSX2VLMGEobEBgfi2PpOmWsjtv/D7e0dPPswz7zW+r01zTxXPhPhPIb8x/+x+qpLTI0WI67khoUauTDphgydPz9ra0HTChTzMpO/qrWZlZ83V6P9nWlmCx7SdvQWIspl7u8wBVPz80GhLDqHdf3e1THPM+6C+PAAA0nJO2MeJfer0U9Evt3bhIq3BB9KrCavEdxfaUEjQbuXjcj9V0u4BegRhMPp0DsYYF1/4To+gHH+4X376nCT5qL8pCUA2nxoi39jSq5OaEZTN/H9rHMfGpO7x0SI4tjOvl2vDCu4tceUhbpvVMYpyF7J+KoXU9FM17rxBGBgbEpL7G8eMTe1mqcEhhK4j5w6yIgEABEIBzkhIcvrxWE91QFwDffL5pecGYzYMM5I9NetU1VZQH02s0h0xHTK214qAszP7jnzS30adIM16T/vOUxsBp93cDeNO+gYt79HukV8/W25K6PET97L0+u4I9NEEAOB7jRtjfWjLhn4d4kb0thXlx107ef5dh2+8so8+SE0rlmW6B4APyW6Rsf+qJXtuLUKs93wAAAaySURBVPw/n3bP/Aa56xbGXDhyLgasJ6+aZNs0tl1fKvKG8vnfb9Sax5XJ2juAh9R7/5FMY4yxOGyOJUm2nH2rihz1Q6raBqXOeQNjTL8LXfuNWzOZoJXbcVNixewlTr66/rturQ1FPK5Ax6L98CUnnsrnaS5NOhc4zL25Bo+nbmTXffzav18WJW7uyCVbTLtepbcfkN1iJid8z8y+Ts3UOSRX3diux4RN11Nry3fLzhsKYTWxLCyKYTWxLCzKwtoGC4timrhtSCOXO3M4NgvvSeu+tqnTANku651xk0UFmoJtfED3VxgdkUjz7JybyLu8elHvbJe1S/+YtKsbJg/3bmNjqq/B5wq0TR29x60OjiusuECceu/o+mlDOjrIAuGNbDqN+OFQRC67sfwQTWDMfUD3J3kaHlNCtnS2r/Fu8Auk3tkua5f+MclXgvbf5Hh49Rk91FCNzoq/eeboj8POXd0QemmOIxeAfr5nypgfo7XsungP62uuKX4Vdvqvdd9euBT1d+jPnTXYIKtakHdaNUaMOmbSd/XmI02/UwUKPtrZi4c0/RV89F/kA9mhCt+n51cJy089OEyfIHS/Dc7HGGP61dmtf4S+Lq74nHl/foIFiXjt1sbW5ur9r9GUYtQ/qPuTXSKJCY+RUDZO5i9rz4WZf2y4Osdyzu3itBvbpvRxNNES8ESGdv02PapQDNaZLLPubJpQv8PY65ftUpmMm0I9A5H8bEQYdu3uQDH5L5MyGAAgzHxmTPQyrYykQXq9vh1gQogjwx7kq9qb/wxNVPcHAABMamTUe8w1ujZr4EENuVyYyzzifu9RFmIojYuIKUFapSEBnTfe0O/tM2pK37zYS6cTMhjZSqHOZJnKZNOEeibUrF+2SxUyblaWlnr1SpSUNHJ0Mqrl6YclYgkGSsBvAqvqpor8JNKEdH8YY1x8fpwuoSAXZps1FQsBJnPvAAFCAnUb351RFSsv8ZuEpEKsRLJMZbNp4oYQD358tssyPphxE2NMv760dUXgsiVzAwa5GnC4xl5LrlQP76os69pUCxKJ+ux6U/O+/zepuaZqbNuQJmzw4BAmUxRkNJXGrnbnIFHP7ZWxg6WXJxoR3M6/VBiS+NZsCxJR1rNCFQzYgqtTzEmua+Bj+dAL8c2Z5iSvx+9vmLouaJgOypf8IdtAosEHK0+AzzkwiI/4PvurmEFdtiG+Padl2TyCRLb+W26l1XZye17YIhc+4rssuVtYyxX/PZparGG57q9tDd0fABRHh8dL+Z3kc2GmPX2WVZYLEwAAcEZ0VCrD6zhtVucaoed1Jsus64KG7WhdfCDbpbJFcDpsei7dxIhzkh+f3zpv9tzuno8Ohe0bXl3SRL8+MnHkhkiR9y+HllURhrFUpanq/mS5MIur5sIUxzyJLc+FCQAAktjIWAll38u7ec1VdZ3JMsXXP3xB/XqmMrVnu1StHIKr1cJj9KbTZLLt6COLNk8avEl+c4TfX57j8/3xTMc5Z49Os+M2RMO/Whr53Z9M9+dQU/cHOC86Mqn2XJgAAMCkRkVlgLaLm2XNLWmdyTI/XzbNxgDpduriQNEpj5+8rXwlgvP+XTnom1/jTL87cH5tdyVSQv23aVzbqF33B9KYJ9Hiqrkwi2Mi4ityYQIAiGMinlZNfCZHnckyVcimCQ2TUPMjs12Wo1LGTSYzI4sBxOVxy02gOPrXbwb/9Ehv5N5/tg8xYZUdddK4tkGnvEqmZacBVIN5FxWVWi0XZrxcLkwAAPplVEweMnJ0VOSnrDNZpgrZNKF+CTXL+dhsl+XUmnGTfnk3NEFekg6SV8fX7YmleU5dO+ohAABx/J5v+825LvLbc+VPP/NPpPD6ymiquj9JTHhMjVyYkXK5MAGgJCYiTsrp6GKvsBN1JstUPpsmNIx48KOzXZZRq/RPGvPHsEEnRe5du7azba5FFSY/vnz26rMcofsPm6bYkgBAR633n/zXG6Grv1n8vtXLK4skjbr9739eBuzqSiHyy+ymo/uTJmyoMxem5MkyR4pqveh+7Tkm60yW+emzaVbl47Ndyr6uWPpHJ11YPdm3m2tLQw0eSVICbVPHHmOWn4jJL+9H6ZVJxgpXCByXFZFs0AjGmNX9sbDUBqv7Y2FRFtY2WFgUw9oGC4tiWNtgYVEMaxssLIphbYOFRTGsbbCwKIa1DRYWxbC2wcKiGAWhSAix4TUs/0V8fX3l/1slZiQlJeXOnTufvUksLE0CU1NTT0/Piv8iNnqKhUUh7H6DhUUxrG2wsCiGtQ0WFsX8Pyg5ihYtaaSjAAAAAElFTkSuQmCC\n",
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">UnboundTable: my_data\n",
+       "  one   string\n",
+       "  two   float64\n",
+       "  three int32\n",
+       "</pre>\n"
+      ],
       "text/plain": [
-       "UnboundTable[r0, name=my_data]\n",
+       "UnboundTable: my_data\n",
        "  one   string\n",
        "  two   float64\n",
        "  three int32"
@@ -147,13 +149,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT `two`, `one`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.two,\n",
+      "  t0.one\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
-    "print(ibis.impala.compile(proj))"
+    "ibis.show_sql(proj)"
    ]
   },
   {
@@ -200,14 +204,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT `two`, `one`, `three` * 2 AS `new_col`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.two,\n",
+      "  t0.one,\n",
+      "  t0.three * CAST(2 AS SMALLINT) AS new_col\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "proj = t['two', 'one', new_col]\n",
-    "print(ibis.impala.compile(proj))"
+    "ibis.show_sql(proj)"
    ]
   },
   {
@@ -250,13 +257,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *, `three` * 2 AS `new_col`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  t0.three * CAST(2 AS SMALLINT) AS new_col\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
-    "print(ibis.impala.compile(mutated))"
+    "ibis.show_sql(mutated)"
    ]
   },
   {
@@ -278,14 +289,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT `one`, `two` * 2 AS `two`, `three`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two * CAST(2 AS SMALLINT) AS two,\n",
+      "  t0.three\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "mutated = t.mutate(two=t.two * 2)\n",
-    "print(ibis.impala.compile(mutated))"
+    "ibis.show_sql(mutated)"
    ]
   },
   {
@@ -310,14 +324,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "proj = t[t]\n",
-    "print(ibis.impala.compile(proj))"
+    "ibis.show_sql(proj)"
    ]
   },
   {
@@ -339,14 +356,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *, `three` * 2 AS `new_col`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  t0.three * CAST(2 AS SMALLINT) AS new_col\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "proj = t[t, new_col]\n",
-    "print(ibis.impala.compile(proj))"
+    "ibis.show_sql(proj)"
    ]
   },
   {
@@ -413,15 +434,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.*, t0.`two` - t1.`value` AS `diff`\n",
-      "FROM my_data t0\n",
-      "  INNER JOIN dim_table t1\n",
-      "    ON t0.`one` = t1.`key`\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  t0.two - t1.value AS diff\n",
+      "FROM my_data AS t0\n",
+      "JOIN dim_table AS t1\n",
+      "  ON t0.one = t1.key\n"
      ]
     }
    ],
    "source": [
-    "print(ibis.impala.compile(joined))"
+    "ibis.show_sql(joined)"
    ]
   },
   {
@@ -482,18 +507,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT `one`, avg(abs(`the_sum`)) AS `mad`\n",
+      "SELECT\n",
+      "  t0.one,\n",
+      "  AVG(ABS(t0.the_sum)) AS mad\n",
       "FROM (\n",
-      "  SELECT `one`, `three`, sum(`two`) AS `the_sum`\n",
-      "  FROM my_data\n",
-      "  GROUP BY 1, 2\n",
-      ") t0\n",
-      "GROUP BY 1\n"
+      "  SELECT\n",
+      "    t1.one AS one,\n",
+      "    t1.three AS three,\n",
+      "    SUM(t1.two) AS the_sum\n",
+      "  FROM my_data AS t1\n",
+      "  GROUP BY\n",
+      "    t1.one,\n",
+      "    t1.three\n",
+      ") AS t0\n",
+      "GROUP BY\n",
+      "  t0.one\n"
      ]
     }
    ],
    "source": [
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -517,15 +550,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM my_data\n",
-      "WHERE `two` > 0\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three\n",
+      "FROM my_data AS t0\n",
+      "WHERE\n",
+      "  t0.two > CAST(0 AS SMALLINT)\n"
      ]
     }
    ],
    "source": [
     "filtered = t[t.two > 0]\n",
-    "print(ibis.impala.compile(filtered))"
+    "ibis.show_sql(filtered)"
    ]
   },
   {
@@ -547,16 +584,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM my_data\n",
-      "WHERE (`two` > 0) AND\n",
-      "      (`one` IN ('A', 'B'))\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three\n",
+      "FROM my_data AS t0\n",
+      "WHERE\n",
+      "  t0.two > CAST(0 AS SMALLINT) AND t0.one IN (CAST('A' AS TEXT), CAST('B' AS TEXT))\n"
      ]
     }
    ],
    "source": [
     "filtered = t.filter([t.two > 0, t.one.isin(['A', 'B'])])\n",
-    "print(ibis.impala.compile(filtered))"
+    "ibis.show_sql(filtered)"
    ]
   },
   {
@@ -578,16 +618,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM my_data\n",
-      "WHERE (`two` < 0) OR ((`two` > 0) OR `one` IN ('A', 'B'))\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three\n",
+      "FROM my_data AS t0\n",
+      "WHERE\n",
+      "  t0.two < CAST(0 AS SMALLINT)\n",
+      "  OR t0.two > CAST(0 AS SMALLINT)\n",
+      "  OR t0.one IN (CAST('A' AS TEXT), CAST('B' AS TEXT))\n"
      ]
     }
    ],
    "source": [
     "cond = (t.two < 0) | ((t.two > 0) | t.one.isin(['A', 'B']))\n",
     "filtered = t[cond]\n",
-    "print(ibis.impala.compile(filtered))"
+    "ibis.show_sql(filtered)"
    ]
   },
   {
@@ -634,7 +680,7 @@
     {
      "data": {
       "text/plain": [
-       "ibis.Schema {  \n",
+       "ibis.Schema {\n",
        "  total_two  float64\n",
        "  avg_three  float64\n",
        "}"
@@ -659,13 +705,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT sum(`two`) AS `total_two`, avg(`three`) AS `avg_three`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  SUM(t0.two) AS total_two,\n",
+      "  AVG(t0.three) AS avg_three\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
-    "print(ibis.impala.compile(agged))"
+    "ibis.show_sql(agged)"
    ]
   },
   {
@@ -687,16 +735,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT `one`, sum(`two`) AS `total_two`, avg(`three`) AS `avg_three`\n",
-      "FROM my_data\n",
-      "GROUP BY 1\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  SUM(t0.two) AS total_two,\n",
+      "  AVG(t0.three) AS avg_three\n",
+      "FROM my_data AS t0\n",
+      "GROUP BY\n",
+      "  t0.one\n"
      ]
     }
    ],
    "source": [
     "agged2 = t.aggregate(stats, by='one')\n",
     "agged3 = t.group_by('one').aggregate(stats)\n",
-    "print(ibis.impala.compile(agged3))"
+    "ibis.show_sql(agged3)"
    ]
   },
   {
@@ -765,15 +817,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT extract(`ts`, 'year') AS `year`, extract(`ts`, 'month') AS `month`,\n",
-      "       count(DISTINCT `session_id`) AS `sessions`, count(*) AS `total`\n",
-      "FROM web_events\n",
-      "GROUP BY 1, 2\n"
+      "SELECT\n",
+      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT) AS year,\n",
+      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT) AS month,\n",
+      "  COUNT(*) AS total,\n",
+      "  COUNT(DISTINCT t0.session_id) AS sessions\n",
+      "FROM web_events AS t0\n",
+      "GROUP BY\n",
+      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT),\n",
+      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT)\n"
      ]
     }
    ],
    "source": [
-    "print(ibis.impala.compile(stats))"
+    "ibis.show_sql(stats)"
    ]
   },
   {
@@ -875,17 +932,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT `country`, avg(`age`) AS `avg_age`,\n",
-      "       avg(CASE WHEN `gender` = 'F' THEN `age` ELSE NULL END) AS `avg_female`,\n",
-      "       avg(CASE WHEN `gender` = 'M' THEN `age` ELSE NULL END) AS `avg_male`,\n",
-      "       count(*) AS `num_persons`\n",
-      "FROM population\n",
-      "GROUP BY 1\n"
+      "SELECT\n",
+      "  t0.country,\n",
+      "  COUNT(*) AS num_persons,\n",
+      "  AVG(t0.age) AS avg_age,\n",
+      "  AVG(t0.age) FILTER(WHERE\n",
+      "    t0.gender = CAST('M' AS TEXT)) AS avg_male,\n",
+      "  AVG(t0.age) FILTER(WHERE\n",
+      "    t0.gender = CAST('F' AS TEXT)) AS avg_female\n",
+      "FROM population AS t0\n",
+      "GROUP BY\n",
+      "  t0.country\n"
      ]
     }
    ],
    "source": [
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -909,16 +971,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT extract(`ts`, 'year') AS `year`, extract(`ts`, 'month') AS `month`,\n",
-      "       count(*) AS `count`\n",
-      "FROM web_events\n",
-      "GROUP BY 1, 2\n"
+      "SELECT\n",
+      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT) AS year,\n",
+      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT) AS month,\n",
+      "  COUNT(*) AS count\n",
+      "FROM web_events AS t0\n",
+      "GROUP BY\n",
+      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT),\n",
+      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT)\n"
      ]
     }
    ],
    "source": [
     "freqs = events.group_by(keys).size()\n",
-    "print(ibis.impala.compile(freqs))"
+    "ibis.show_sql(freqs)"
    ]
   },
   {
@@ -950,15 +1016,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT extract(`ts`, 'year') AS `year`, count(*) AS `count`\n",
-      "FROM web_events\n",
-      "GROUP BY 1\n"
+      "SELECT\n",
+      "  t0.\"ExtractYear(ts)\",\n",
+      "  COUNT(*) AS count\n",
+      "FROM (\n",
+      "  SELECT\n",
+      "    CAST(EXTRACT(year FROM t1.ts) AS SMALLINT) AS \"ExtractYear(ts)\"\n",
+      "  FROM web_events AS t1\n",
+      ") AS t0\n",
+      "GROUP BY\n",
+      "  t0.\"ExtractYear(ts)\"\n"
      ]
     }
    ],
    "source": [
     "expr = events.ts.year().value_counts()\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -993,10 +1066,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT `one`, sum(`two`) AS `total`\n",
-      "FROM my_data\n",
-      "GROUP BY 1\n",
-      "HAVING count(*) >= 1000\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  SUM(t0.two) AS total\n",
+      "FROM my_data AS t0\n",
+      "GROUP BY\n",
+      "  t0.one\n",
+      "HAVING\n",
+      "  COUNT(*) >= CAST(1000 AS SMALLINT)\n"
      ]
     }
    ],
@@ -1006,7 +1083,7 @@
     "    .having(t.count() >= 1000)\n",
     "    .aggregate(t.two.sum().name('total'))\n",
     ")\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1030,16 +1107,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM web_events\n",
-      "ORDER BY extract(`ts`, 'year'), extract(`ts`, 'month')\n"
+      "SELECT\n",
+      "  t0.ts,\n",
+      "  t0.event_type,\n",
+      "  t0.session_id\n",
+      "FROM web_events AS t0\n",
+      "ORDER BY\n",
+      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT),\n",
+      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT)\n"
      ]
     }
    ],
    "source": [
     "sorted = events.order_by([events.ts.year(), events.ts.month()])\n",
     "\n",
-    "print(ibis.impala.compile(sorted))"
+    "ibis.show_sql(sorted)"
    ]
   },
   {
@@ -1062,9 +1144,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM web_events\n",
-      "ORDER BY `event_type` DESC, extract(`ts`, 'month') DESC\n",
+      "SELECT\n",
+      "  t0.ts,\n",
+      "  t0.event_type,\n",
+      "  t0.session_id\n",
+      "FROM web_events AS t0\n",
+      "ORDER BY\n",
+      "  t0.event_type DESC,\n",
+      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT) DESC\n",
       "LIMIT 100\n"
      ]
     }
@@ -1074,7 +1161,7 @@
     "    [ibis.desc('event_type'), (events.ts.month(), False)]\n",
     ").limit(100)\n",
     "\n",
-    "print(ibis.impala.compile(sorted))"
+    "ibis.show_sql(sorted)"
    ]
   },
   {
@@ -1099,15 +1186,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM my_data\n",
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three\n",
+      "FROM my_data AS t0\n",
       "LIMIT 1000\n"
      ]
     }
    ],
    "source": [
     "limited = t.limit(1000)\n",
-    "print(ibis.impala.compile(limited))"
+    "ibis.show_sql(limited)"
    ]
   },
   {
@@ -1129,15 +1219,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM my_data\n",
-      "LIMIT 10 OFFSET 10\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three\n",
+      "FROM my_data AS t0\n",
+      "LIMIT 10\n",
+      "OFFSET 10\n"
      ]
     }
    ],
    "source": [
     "limited = t.limit(10, offset=10)\n",
-    "print(ibis.impala.compile(limited))"
+    "ibis.show_sql(limited)"
    ]
   },
   {
@@ -1168,16 +1262,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *, CAST(`one` AS timestamp) AS `date`,\n",
-      "       CAST(`three` AS double) AS `four`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  CAST(t0.one AS TIMESTAMP) AS date,\n",
+      "  CAST(t0.three AS FLOAT) AS four\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
-    "expr = t.mutate(date=t.one.cast('timestamp'), four=t.three.cast('float'))\n",
+    "expr = t.mutate(date=t.one.cast('timestamp'), four=t.three.cast('float32'))\n",
     "\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1213,13 +1311,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *,\n",
-      "  CASE extract(CAST(`one` AS timestamp), 'year')\n",
-      "    WHEN 2015 THEN 'This year'\n",
-      "    WHEN 2014 THEN 'Last year'\n",
-      "    ELSE 'Earlier'\n",
-      "  END AS `year_group`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  CASE\n",
+      "    WHEN (\n",
+      "      CAST(EXTRACT(year FROM CAST(t0.one AS TIMESTAMP)) AS SMALLINT) = CAST(2015 AS SMALLINT)\n",
+      "    )\n",
+      "    THEN CAST('This year' AS TEXT)\n",
+      "    WHEN (\n",
+      "      CAST(EXTRACT(year FROM CAST(t0.one AS TIMESTAMP)) AS SMALLINT) = CAST(2014 AS SMALLINT)\n",
+      "    )\n",
+      "    THEN CAST('Last year' AS TEXT)\n",
+      "    ELSE CAST('Earlier' AS TEXT)\n",
+      "  END AS year_group\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
@@ -1235,7 +1342,7 @@
     ")\n",
     "\n",
     "expr = t.mutate(year_group=case)\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1268,13 +1375,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *,\n",
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
       "  CASE\n",
-      "    WHEN `two` < 0 THEN `three` * 2\n",
-      "    WHEN `two` > 1 THEN `three`\n",
-      "    ELSE `two`\n",
-      "  END AS `cond_value`\n",
-      "FROM my_data\n"
+      "    WHEN (\n",
+      "      t0.two < CAST(0 AS SMALLINT)\n",
+      "    )\n",
+      "    THEN t0.three * CAST(2 AS SMALLINT)\n",
+      "    WHEN (\n",
+      "      t0.two > CAST(1 AS SMALLINT)\n",
+      "    )\n",
+      "    THEN t0.three\n",
+      "    ELSE t0.two\n",
+      "  END AS cond_value\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
@@ -1288,7 +1404,7 @@
     ")\n",
     "\n",
     "expr = t.mutate(cond_value=case)\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1310,16 +1426,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *,\n",
-      "       CASE WHEN `two` < 0 THEN 'Negative' ELSE 'Non-Negative' END AS `group`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  CASE\n",
+      "    WHEN (\n",
+      "      t0.two < CAST(0 AS SMALLINT)\n",
+      "    )\n",
+      "    THEN CAST('Negative' AS TEXT)\n",
+      "    ELSE CAST('Non-Negative' AS TEXT)\n",
+      "  END AS \"group\"\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "switch = (t.two < 0).ifelse('Negative', 'Non-Negative')\n",
     "expr = t.mutate(group=switch)\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1343,15 +1468,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *, CASE WHEN `two` > 0 THEN `two` ELSE NULL END AS `two_positive`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  CASE WHEN (\n",
+      "    t0.two > CAST(0 AS SMALLINT)\n",
+      "  ) THEN t0.two ELSE NULL END AS two_positive\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "pos_two = (t.two > 0).ifelse(t.two, ibis.NA)\n",
     "expr = t.mutate(two_positive=pos_two)\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1386,9 +1517,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *,\n",
-      "       CASE WHEN upper(`country`) IN ('UNITED STATES', 'CANADA') THEN 'North America' ELSE `country` END AS `refined_group`\n",
-      "FROM population\n"
+      "SELECT\n",
+      "  t0.name,\n",
+      "  t0.country,\n",
+      "  t0.gender,\n",
+      "  t0.age,\n",
+      "  CASE\n",
+      "    WHEN (\n",
+      "      UPPER(t0.country) IN (CAST('UNITED STATES' AS TEXT), CAST('CANADA' AS TEXT))\n",
+      "    )\n",
+      "    THEN CAST('North America' AS TEXT)\n",
+      "    ELSE t0.country\n",
+      "  END AS refined_group\n",
+      "FROM population AS t0\n"
      ]
     }
    ],
@@ -1400,7 +1541,7 @@
     ")\n",
     "\n",
     "expr = pop.mutate(refined_group=refined)\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1463,8 +1604,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *, 'foo' IN (`column1`, `column2`) AS `has_foo`\n",
-      "FROM `data`\n"
+      "SELECT\n",
+      "  t0.column1,\n",
+      "  t0.column2,\n",
+      "  t0.column3,\n",
+      "  CAST('foo' AS TEXT) IN (t0.column1, t0.column2) AS has_foo\n",
+      "FROM data AS t0\n"
      ]
     }
    ],
@@ -1472,7 +1617,7 @@
     "has_foo = value.isin([t3.column1, t3.column2])\n",
     "\n",
     "expr = t3.mutate(has_foo=has_foo)\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1495,14 +1640,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *, 5 AS `number5`\n",
-      "FROM `data`\n"
+      "SELECT\n",
+      "  t0.column1,\n",
+      "  t0.column2,\n",
+      "  t0.column3,\n",
+      "  CAST(5 AS SMALLINT) AS number5\n",
+      "FROM data AS t0\n"
      ]
     }
    ],
    "source": [
     "expr = t3.mutate(number5=5)\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1519,39 +1668,76 @@
   {
    "cell_type": "code",
    "execution_count": 47,
-   "id": "51117af9-fc7b-4266-8cd1-9e081bda435f",
+   "id": "b7d010f1-ee8a-43a8-8cc1-3a43d59c35d1",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *,\n",
-      "       CASE WHEN `two` IS NULL THEN 'valid' ELSE 'invalid' END AS `is_valid`\n",
-      "FROM my_data\n",
-      "SELECT `is_valid`, sum(`three` IS NOT NULL) AS `three_count`\n",
-      "FROM (\n",
-      "  SELECT *,\n",
-      "         CASE WHEN `two` IS NULL THEN 'valid' ELSE 'invalid' END AS `is_valid`\n",
-      "  FROM my_data\n",
-      "  WHERE `one` IS NOT NULL\n",
-      ") t0\n",
-      "GROUP BY 1\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  CASE\n",
+      "    WHEN (\n",
+      "      t0.two IS NULL\n",
+      "    )\n",
+      "    THEN CAST('valid' AS TEXT)\n",
+      "    ELSE CAST('invalid' AS TEXT)\n",
+      "  END AS is_valid\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "indic = t.two.isnull().ifelse('valid', 'invalid')\n",
     "expr = t.mutate(is_valid=indic)\n",
-    "print(ibis.impala.compile(expr))\n",
-    "\n",
+    "ibis.show_sql(expr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "c0f2b9f7-e136-42e2-bdfb-fdd28ff56687",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SELECT\n",
+      "  t0.is_valid,\n",
+      "  SUM(CAST(NOT t0.three IS NULL AS INT)) AS three_count\n",
+      "FROM (\n",
+      "  SELECT\n",
+      "    t1.one AS one,\n",
+      "    t1.two AS two,\n",
+      "    t1.three AS three,\n",
+      "    CASE\n",
+      "      WHEN (\n",
+      "        t1.two IS NULL\n",
+      "      )\n",
+      "      THEN CAST('valid' AS TEXT)\n",
+      "      ELSE CAST('invalid' AS TEXT)\n",
+      "    END AS is_valid\n",
+      "  FROM my_data AS t1\n",
+      "  WHERE\n",
+      "    NOT t1.one IS NULL\n",
+      ") AS t0\n",
+      "GROUP BY\n",
+      "  t0.is_valid\n"
+     ]
+    }
+   ],
+   "source": [
     "agged = (\n",
     "    expr[expr.one.notnull()]\n",
     "    .group_by('is_valid')\n",
     "    .aggregate(three_count=lambda t: t.three.notnull().sum())\n",
     ")\n",
     "\n",
-    "print(ibis.impala.compile(agged))"
+    "ibis.show_sql(agged)"
    ]
   },
   {
@@ -1568,7 +1754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 49,
    "id": "bd9cdf2d-c3a3-4166-8402-f0a07a8adb48",
    "metadata": {},
    "outputs": [
@@ -1576,15 +1762,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM my_data\n",
-      "WHERE `two` BETWEEN 10 AND 50 AND (`one` IS NOT NULL)\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three\n",
+      "FROM my_data AS t0\n",
+      "WHERE\n",
+      "  t0.two BETWEEN CAST(10 AS SMALLINT) AND CAST(50 AS SMALLINT) AND NOT t0.one IS NULL\n"
      ]
     }
    ],
    "source": [
     "expr = t[t.two.between(10, 50) & t.one.notnull()]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1613,7 +1803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 50,
    "id": "53d7fbe6-c6c6-40c4-a0ff-cca51736ab8d",
    "metadata": {},
    "outputs": [],
@@ -1637,7 +1827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 51,
    "id": "539f284a-a525-4faa-bde9-1d4a96a2fb7d",
    "metadata": {},
    "outputs": [],
@@ -1671,7 +1861,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 52,
    "id": "184ee220-b881-4410-8163-192215be5fb5",
    "metadata": {},
    "outputs": [
@@ -1679,16 +1869,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.*, t1.`value2`\n",
-      "FROM table1 t0\n",
-      "  LEFT OUTER JOIN table2 t1\n",
-      "    ON t0.`key1` = t1.`key3`\n"
+      "SELECT\n",
+      "  t0.value1,\n",
+      "  t0.key1,\n",
+      "  t0.key2,\n",
+      "  t1.value2\n",
+      "FROM table1 AS t0\n",
+      "LEFT OUTER JOIN table2 AS t1\n",
+      "  ON t0.key1 = t1.key3\n"
      ]
     }
    ],
    "source": [
     "expr = joined[t1, t2.value2]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1702,7 +1896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 53,
    "id": "4e01f510-b48f-4ee7-84cc-03042f8989f0",
    "metadata": {},
    "outputs": [
@@ -1710,16 +1904,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.`key1`, t0.`value1` - t1.`value2` AS `diff`\n",
-      "FROM table1 t0\n",
-      "  LEFT OUTER JOIN table2 t1\n",
-      "    ON t0.`key1` = t1.`key3`\n"
+      "SELECT\n",
+      "  t0.key1,\n",
+      "  t0.value1 - t1.value2 AS diff\n",
+      "FROM table1 AS t0\n",
+      "LEFT OUTER JOIN table2 AS t1\n",
+      "  ON t0.key1 = t1.key3\n"
      ]
     }
    ],
    "source": [
     "expr = joined[t1.key1, (t1.value1 - t2.value2).name('diff')]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1748,7 +1944,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 54,
    "id": "f8288597-27d0-4936-a63e-1da23f3c1fc4",
    "metadata": {},
    "outputs": [
@@ -1756,11 +1952,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.`key1`, avg(t0.`value1` - t1.`value2`) AS `avg_diff`\n",
-      "FROM table1 t0\n",
-      "  LEFT OUTER JOIN table2 t1\n",
-      "    ON t0.`key1` = t1.`key3`\n",
-      "GROUP BY 1\n"
+      "SELECT\n",
+      "  t0.key1,\n",
+      "  AVG(t0.value1 - t1.value2) AS avg_diff\n",
+      "FROM table1 AS t0\n",
+      "LEFT OUTER JOIN table2 AS t1\n",
+      "  ON t0.key1 = t1.key3\n",
+      "GROUP BY\n",
+      "  t0.key1\n"
      ]
     }
    ],
@@ -1771,7 +1970,7 @@
     "    .group_by(t1.key1)\n",
     "    .aggregate(avg_diff=avg_diff)\n",
     ")\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1787,7 +1986,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 55,
    "id": "a3b7fe80-80f9-438c-b08e-242fdc8593fb",
    "metadata": {},
    "outputs": [
@@ -1795,16 +1994,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM table1 t0\n",
-      "  LEFT OUTER JOIN table2 t1\n",
-      "    ON t0.`key1` = t1.`key3`\n"
+      "SELECT\n",
+      "  t0.value1,\n",
+      "  t0.key1,\n",
+      "  t0.key2,\n",
+      "  t1.value2,\n",
+      "  t1.key3,\n",
+      "  t1.key4\n",
+      "FROM table1 AS t0\n",
+      "LEFT OUTER JOIN table2 AS t1\n",
+      "  ON t0.key1 = t1.key3\n"
      ]
     }
    ],
    "source": [
     "joined = t1.left_join(t2, t1.key1 == t2.key3)\n",
-    "print(ibis.impala.compile(joined))"
+    "ibis.show_sql(joined)"
    ]
   },
   {
@@ -1820,7 +2025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 56,
    "id": "06d624d7-a57e-4715-a596-b9b9522d8c51",
    "metadata": {},
    "outputs": [
@@ -1828,15 +2033,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t1.`key4`, t2.`key5`,\n",
-      "       sum((t0.`value1` + t1.`value2`) + t2.`value3`) AS `total`\n",
-      "FROM table1 t0\n",
-      "  INNER JOIN table2 t1\n",
-      "    ON (t0.`key1` = t1.`key3`) AND\n",
-      "       (t0.`key2` = t1.`key4`)\n",
-      "  INNER JOIN table3 t2\n",
-      "    ON t0.`key1` = t2.`key5`\n",
-      "GROUP BY 1, 2\n"
+      "SELECT\n",
+      "  t1.key4,\n",
+      "  t2.key5,\n",
+      "  SUM(t0.value1 + t1.value2 + t2.value3) AS total\n",
+      "FROM table1 AS t0\n",
+      "JOIN table2 AS t1\n",
+      "  ON t0.key1 = t1.key3 AND t0.key2 = t1.key4\n",
+      "JOIN table3 AS t2\n",
+      "  ON t0.key1 = t2.key5\n",
+      "GROUP BY\n",
+      "  t1.key4,\n",
+      "  t2.key5\n"
      ]
     }
    ],
@@ -1850,7 +2058,7 @@
     "    .group_by([t2.key4, t3.key5])\n",
     "    .aggregate(total=total)\n",
     ")\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1876,7 +2084,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 57,
    "id": "4fb52d34-263c-4528-9906-6149d8fae223",
    "metadata": {},
    "outputs": [
@@ -1884,15 +2092,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT `one`, avg(`two` - `three`) AS `metric`\n",
-      "FROM (\n",
-      "  SELECT t1.`one` AS `one_x`, t1.`two` AS `two_x`, t1.`three` AS `three_x`,\n",
-      "         t2.`one` AS `one_y`, t2.`two` AS `two_y`, t2.`three` AS `three_y`\n",
-      "  FROM my_data t1\n",
-      "    INNER JOIN my_data t2\n",
-      "      ON CAST(t1.`three` AS string) = t2.`one`\n",
-      ") t0\n",
-      "GROUP BY 1\n"
+      "SELECT\n",
+      "  t1.one,\n",
+      "  AVG(t1.two - t1.three) AS metric\n",
+      "FROM my_data AS t1, my_data AS t1, (\n",
+      "  SELECT\n",
+      "    t1.one AS one_x,\n",
+      "    t1.two AS two_x,\n",
+      "    t1.three AS three_x,\n",
+      "    t2.one AS one_y,\n",
+      "    t2.two AS two_y,\n",
+      "    t2.three AS three_y\n",
+      "  FROM my_data AS t1\n",
+      "  JOIN my_data AS t2\n",
+      "    ON CAST(t1.three AS TEXT) = t2.one\n",
+      ") AS t0\n",
+      "GROUP BY\n",
+      "  t1.one\n"
      ]
     }
    ],
@@ -1905,7 +2121,7 @@
     "    .group_by(t.one)\n",
     "    .aggregate(metric=stat)\n",
     ")\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1921,7 +2137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 58,
    "id": "d0e462ea-1393-4fbe-b30c-da08708d1d2c",
    "metadata": {},
    "outputs": [],
@@ -1957,7 +2173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 59,
    "id": "dcf11c30-363e-45f8-a6fb-3106b012fedc",
    "metadata": {},
    "outputs": [
@@ -1965,19 +2181,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.*, t1.`value2`\n",
-      "FROM table4 t0\n",
-      "  INNER JOIN table5 t1\n",
-      "    ON (t0.`key1` = t1.`key1`) AND\n",
-      "       (t0.`key2` = t1.`key2`) AND\n",
-      "       (t0.`key3` = t1.`key3`)\n"
+      "SELECT\n",
+      "  t0.key1,\n",
+      "  t0.key2,\n",
+      "  t0.key3,\n",
+      "  t0.value1,\n",
+      "  t1.value2\n",
+      "FROM table4 AS t0\n",
+      "JOIN table5 AS t1\n",
+      "  ON t0.key1 = t1.key1 AND t0.key2 = t1.key2 AND t0.key3 = t1.key3\n"
      ]
     }
    ],
    "source": [
     "joined = t4.join(t5, ['key1', 'key2', 'key3'])\n",
     "expr = joined[t4, t5.value2]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -1990,7 +2209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 60,
    "id": "b135e88e-1547-4d00-aa85-f85abea9a319",
    "metadata": {},
    "outputs": [
@@ -1998,19 +2217,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.*, t1.`value2`\n",
-      "FROM table4 t0\n",
-      "  INNER JOIN table5 t1\n",
-      "    ON (t0.`key1` = t1.`key1`) AND\n",
-      "       (t0.`key2` = t1.`key2`) AND\n",
-      "       (substr(t0.`key3`, 0 + 1, 4) = substr(t0.`key3`, 0 + 1, 4))\n"
+      "SELECT\n",
+      "  t0.key1,\n",
+      "  t0.key2,\n",
+      "  t0.key3,\n",
+      "  t0.value1,\n",
+      "  t1.value2\n",
+      "FROM table4 AS t0\n",
+      "JOIN table5 AS t1\n",
+      "  ON t0.key1 = t1.key1\n",
+      "  AND t0.key2 = t1.key2\n",
+      "  AND SUBSTR(t0.key3, CAST(0 AS SMALLINT) + 1, CAST(4 AS SMALLINT)) = SUBSTR(t0.key3, CAST(0 AS SMALLINT) + 1, CAST(4 AS SMALLINT))\n"
      ]
     }
    ],
    "source": [
     "joined = t4.join(t5, ['key1', 'key2', t4.key3.left(4) == t4.key3.left(4)])\n",
     "expr = joined[t4, t5.value2]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2028,7 +2252,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 61,
    "id": "f0951d14-0962-4144-ac81-3b626a37d8da",
    "metadata": {},
    "outputs": [
@@ -2036,17 +2260,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.`key1`, count(*) AS `count`\n",
-      "FROM table1 t0\n",
-      "  INNER JOIN table2 t1\n",
-      "    ON t0.`value1` < t1.`value2`\n",
-      "GROUP BY 1\n"
+      "SELECT\n",
+      "  t0.key1,\n",
+      "  COUNT(*) AS count\n",
+      "FROM table1 AS t0\n",
+      "JOIN table2 AS t1\n",
+      "  ON t0.value1 < t1.value2\n",
+      "GROUP BY\n",
+      "  t0.key1\n"
      ]
     }
    ],
    "source": [
     "expr = t1.join(t2, t1.value1 < t2.value2).group_by(t1.key1).size()\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2062,7 +2289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 62,
    "id": "81c7fee1-f2d2-4cee-aa00-25fd3cacbc93",
    "metadata": {},
    "outputs": [],
@@ -2092,7 +2319,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 63,
    "id": "c1b8e918-a222-4ebe-8aee-41dce6a99d30",
    "metadata": {},
    "outputs": [],
@@ -2145,7 +2372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 64,
    "id": "640d3015-4005-41b1-b432-1d99fa3c3b09",
    "metadata": {},
    "outputs": [],
@@ -2163,7 +2390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 65,
    "id": "a5be1cbf-a636-4400-924d-873796068d69",
    "metadata": {},
    "outputs": [
@@ -2171,19 +2398,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.*\n",
-      "FROM events t0\n",
-      "WHERE EXISTS (\n",
-      "  SELECT 1\n",
-      "  FROM purchases t1\n",
-      "  WHERE t0.`user_id` = t1.`user_id`\n",
-      ")\n"
+      "SELECT\n",
+      "  t0.session_id,\n",
+      "  t0.user_id,\n",
+      "  t0.event_type,\n",
+      "  t0.ts\n",
+      "FROM events AS t0\n",
+      "WHERE\n",
+      "  EXISTS(\n",
+      "    SELECT\n",
+      "      CAST(1 AS SMALLINT) AS anon_1\n",
+      "    FROM purchases AS t1\n",
+      "    WHERE\n",
+      "      t0.user_id = t1.user_id\n",
+      "  )\n"
      ]
     }
    ],
    "source": [
     "expr = events[cond]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2197,7 +2431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 66,
    "id": "36789da6-983a-48bb-829d-32da129afec9",
    "metadata": {},
    "outputs": [
@@ -2205,19 +2439,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.*\n",
-      "FROM events t0\n",
-      "WHERE NOT EXISTS (\n",
-      "  SELECT 1\n",
-      "  FROM purchases t1\n",
-      "  WHERE t0.`user_id` = t1.`user_id`\n",
-      ")\n"
+      "SELECT\n",
+      "  t0.session_id,\n",
+      "  t0.user_id,\n",
+      "  t0.event_type,\n",
+      "  t0.ts\n",
+      "FROM events AS t0\n",
+      "WHERE\n",
+      "  NOT (\n",
+      "    EXISTS(\n",
+      "      SELECT\n",
+      "        CAST(1 AS SMALLINT) AS anon_1\n",
+      "      FROM purchases AS t1\n",
+      "      WHERE\n",
+      "        t0.user_id = t1.user_id\n",
+      "    )\n",
+      "  )\n"
      ]
     }
    ],
    "source": [
     "expr = events[-cond]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2245,7 +2488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 67,
    "id": "7f8c5b77-5068-4d3a-9df6-e44d9b9f84a6",
    "metadata": {},
    "outputs": [
@@ -2253,19 +2496,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM events\n",
-      "WHERE `user_id` IN (\n",
-      "  SELECT `user_id`\n",
-      "  FROM purchases\n",
-      ")\n"
+      "SELECT\n",
+      "  t0.session_id,\n",
+      "  t0.user_id,\n",
+      "  t0.event_type,\n",
+      "  t0.ts\n",
+      "FROM events AS t0\n",
+      "WHERE\n",
+      "  t0.user_id IN (\n",
+      "    SELECT\n",
+      "      anon_1.user_id\n",
+      "    FROM (\n",
+      "      SELECT\n",
+      "        t1.item_id AS item_id,\n",
+      "        t1.user_id AS user_id,\n",
+      "        t1.price AS price,\n",
+      "        t1.ts AS ts\n",
+      "      FROM purchases AS t1\n",
+      "    ) AS anon_1\n",
+      "  )\n"
      ]
     }
    ],
    "source": [
     "cond = events.user_id.isin(purchases.user_id)\n",
     "expr = events[cond]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2296,7 +2552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 68,
    "id": "98620369-6df2-42aa-9db6-d089795c66ea",
    "metadata": {},
    "outputs": [
@@ -2304,18 +2560,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM table1\n",
-      "WHERE `value1` > (\n",
-      "  SELECT max(`value2`) AS `max`\n",
-      "  FROM table2\n",
-      ")\n"
+      "SELECT\n",
+      "  t0.value1,\n",
+      "  t0.key1,\n",
+      "  t0.key2\n",
+      "FROM table1 AS t0\n",
+      "WHERE\n",
+      "  t0.value1 > (\n",
+      "    SELECT\n",
+      "      MAX(t1.value2) AS \"Max(value2)\"\n",
+      "    FROM table2 AS t1\n",
+      "  )\n"
      ]
     }
    ],
    "source": [
     "expr = t1[t1.value1 > t2.value2.max()]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2348,7 +2609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 69,
    "id": "821ead6b-1401-45ef-8521-9f2e85b6cea1",
    "metadata": {},
    "outputs": [
@@ -2356,20 +2617,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT t0.*\n",
-      "FROM table1 t0\n",
-      "WHERE t0.`value1` > (\n",
-      "  SELECT avg(t1.`value2`) AS `mean`\n",
-      "  FROM table2 t1\n",
-      "  WHERE t0.`key1` = t1.`key3`\n",
-      ")\n"
+      "SELECT\n",
+      "  t0.value1,\n",
+      "  t0.key1,\n",
+      "  t0.key2\n",
+      "FROM table1 AS t0\n",
+      "WHERE\n",
+      "  t0.value1 > (\n",
+      "    SELECT\n",
+      "      AVG(t1.value2) AS \"Mean(value2)\"\n",
+      "    FROM table2 AS t1\n",
+      "    WHERE\n",
+      "      t0.key1 = t1.key3\n",
+      "  )\n"
      ]
     }
    ],
    "source": [
     "stat = t2[t1.key1 == t2.key3].value2.mean()\n",
     "expr = t1[t1.value1 > stat]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2398,7 +2665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 70,
    "id": "7afe45dd-1540-42cd-992d-2e09cd9f97ba",
    "metadata": {},
    "outputs": [
@@ -2406,14 +2673,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT DISTINCT *\n",
-      "FROM table1\n"
+      "SELECT DISTINCT\n",
+      "  t0.value1,\n",
+      "  t0.key1,\n",
+      "  t0.key2\n",
+      "FROM table1 AS t0\n"
      ]
     }
    ],
    "source": [
     "expr = t1.distinct()\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2437,7 +2707,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 71,
    "id": "63644b0f-ca38-4019-99ea-fa3ac7b9968f",
    "metadata": {},
    "outputs": [
@@ -2445,16 +2715,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT `user_id`, count(DISTINCT `event_type`) AS `unique_events`\n",
-      "FROM events\n",
-      "GROUP BY 1\n"
+      "SELECT\n",
+      "  t0.user_id,\n",
+      "  COUNT(DISTINCT t0.event_type) AS unique_events\n",
+      "FROM events AS t0\n",
+      "GROUP BY\n",
+      "  t0.user_id\n"
      ]
     }
    ],
    "source": [
     "metric = events.event_type.nunique()\n",
     "expr = events.group_by('user_id').aggregate(unique_events=metric)\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2494,7 +2767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 72,
    "id": "a3dd8aaa-2320-4be9-8c99-f821c1c6ff4f",
    "metadata": {},
    "outputs": [
@@ -2502,14 +2775,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *, `two` - avg(`two`) OVER () AS `two_demean`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  t0.two - AVG(t0.two) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS two_demean\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "expr = t.mutate(two_demean=t.two - t.two.mean())\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2523,7 +2800,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 73,
    "id": "b5f13aee-01fa-402f-bc8b-4d2de1c74726",
    "metadata": {},
    "outputs": [
@@ -2531,15 +2808,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *, `two` - avg(`two`) OVER (PARTITION BY `one`) AS `two_demean`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  t0.two - AVG(t0.two) OVER (PARTITION BY t0.one ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS two_demean\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "expr = t.group_by('one').mutate(two_demean=t.two - t.two.mean())\n",
     "\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2553,7 +2834,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 74,
    "id": "e5b6871b-a220-4ea7-a6ec-b66ebe7796da",
    "metadata": {},
    "outputs": [
@@ -2561,9 +2842,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *,\n",
-      "       `two` - lag(`two`) OVER (PARTITION BY `one` ORDER BY `two`) AS `two_first_diff`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  t0.two - LAG(t0.two, 1) OVER (PARTITION BY t0.one ORDER BY t0.two ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS two_first_diff\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
@@ -2574,7 +2858,7 @@
     "    .mutate(two_first_diff=t.two - t.two.lag())\n",
     ")\n",
     "\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2588,7 +2872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 75,
    "id": "6da1f124-5d3b-42b1-93ee-a3accb65a900",
    "metadata": {},
    "outputs": [
@@ -2596,16 +2880,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *,\n",
-      "       `two` - avg(`two`) OVER (PARTITION BY `one` ROWS BETWEEN 5 PRECEDING AND 5 FOLLOWING) AS `group_demeaned`\n",
-      "FROM my_data\n"
+      "SELECT\n",
+      "  t0.one,\n",
+      "  t0.two,\n",
+      "  t0.three,\n",
+      "  t0.two - AVG(t0.two) OVER (PARTITION BY t0.one ROWS BETWEEN 5 PRECEDING AND 5 FOLLOWING) AS group_demeaned\n",
+      "FROM my_data AS t0\n"
      ]
     }
    ],
    "source": [
     "w = ibis.window(group_by='one', preceding=5, following=5)\n",
     "expr = t.mutate(group_demeaned=t.two - t.two.mean().over(w))\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2631,7 +2918,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 76,
    "id": "20d8f28b-0a04-4539-8085-b15d1ca7ad71",
    "metadata": {},
    "outputs": [],
@@ -2649,7 +2936,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 77,
    "id": "85da70b8-f7b9-4c42-b8e9-e67303925c91",
    "metadata": {},
    "outputs": [
@@ -2657,19 +2944,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
+      "SELECT\n",
+      "  t0.key1,\n",
+      "  t0.count\n",
       "FROM (\n",
-      "  SELECT `key1`, count(`key1`) AS `count`\n",
-      "  FROM table1\n",
-      "  GROUP BY 1\n",
-      ") t0\n",
-      "ORDER BY `count` DESC\n",
+      "  SELECT\n",
+      "    t1.key1 AS key1,\n",
+      "    COUNT(t1.key1) AS count\n",
+      "  FROM table1 AS t1\n",
+      "  GROUP BY\n",
+      "    t1.key1\n",
+      ") AS t0\n",
+      "ORDER BY\n",
+      "  t0.count DESC\n",
       "LIMIT 10\n"
      ]
     }
    ],
    "source": [
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2695,15 +2988,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *, extract(`ts`, 'month') AS `month`, extract(`ts`, 'year') AS `year`\n",
-      "FROM events\n"
+      "SELECT\n",
+      "  t0.session_id,\n",
+      "  t0.user_id,\n",
+      "  t0.event_type,\n",
+      "  t0.ts,\n",
+      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT) AS year,\n",
+      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT) AS month\n",
+      "FROM events AS t0\n"
      ]
     }
    ],
    "source": [
     "expr = events.mutate(year=events.ts.year(), month=events.ts.month())\n",
     "\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2733,15 +3032,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM events\n",
-      "WHERE `ts` > date_sub(cast(now() as timestamp), INTERVAL 1 YEAR)\n"
+      "SELECT\n",
+      "  t0.session_id,\n",
+      "  t0.user_id,\n",
+      "  t0.event_type,\n",
+      "  t0.ts\n",
+      "FROM events AS t0\n",
+      "WHERE\n",
+      "  t0.ts > CAST(NOW() AS TIMESTAMP) - INTERVAL '1 year'\n"
      ]
     }
    ],
    "source": [
     "expr = events[events.ts > (ibis.now() - ibis.interval(years=1))]\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2778,13 +3082,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SELECT *\n",
-      "FROM table1\n",
-      "LIMIT 10\n",
+      "WITH anon_1 AS (\n",
+      "  SELECT\n",
+      "    t0.value1 AS value1,\n",
+      "    t0.key1 AS key1,\n",
+      "    t0.key2 AS key2\n",
+      "  FROM table1 AS t0\n",
+      "  LIMIT 10\n",
+      "), anon_2 AS (\n",
+      "  SELECT\n",
+      "    t0.value1 AS value1,\n",
+      "    t0.key1 AS key1,\n",
+      "    t0.key2 AS key2\n",
+      "  FROM table1 AS t0\n",
+      "  LIMIT 10\n",
+      "  OFFSET 10\n",
+      ")\n",
+      "SELECT\n",
+      "  anon_1.value1,\n",
+      "  anon_1.key1,\n",
+      "  anon_1.key2\n",
+      "FROM anon_1\n",
       "UNION ALL\n",
-      "SELECT *\n",
-      "FROM table1\n",
-      "LIMIT 10 OFFSET 10\n"
+      "SELECT\n",
+      "  anon_2.value1,\n",
+      "  anon_2.key1,\n",
+      "  anon_2.key2\n",
+      "FROM anon_2\n"
      ]
     }
    ],
@@ -2793,7 +3117,7 @@
     "expr2 = t1.limit(10, offset=10)\n",
     "\n",
     "expr = expr1.union(expr2)\n",
-    "print(ibis.impala.compile(expr))"
+    "ibis.show_sql(expr)"
    ]
   },
   {
@@ -2875,27 +3199,42 @@
      "output_type": "stream",
      "text": [
       "WITH t0 AS (\n",
-      "  SELECT `region`, `kind`, sum(`amount`) AS `total`\n",
-      "  FROM purchases\n",
-      "  GROUP BY 1, 2\n",
+      "  SELECT\n",
+      "    t3.region AS region,\n",
+      "    t3.kind AS kind,\n",
+      "    SUM(t3.amount) AS total\n",
+      "  FROM purchases AS t3\n",
+      "  GROUP BY\n",
+      "    t3.region,\n",
+      "    t3.kind\n",
       ")\n",
-      "SELECT t1.`region`, t1.`total` - t2.`total` AS `diff`\n",
+      "SELECT\n",
+      "  t1.region,\n",
+      "  t1.total - t2.total AS diff\n",
       "FROM (\n",
-      "  SELECT *\n",
+      "  SELECT\n",
+      "    t0.region AS region,\n",
+      "    t0.kind AS kind,\n",
+      "    t0.total AS total\n",
       "  FROM t0\n",
-      "  WHERE `kind` = 'foo'\n",
-      ") t1\n",
-      "  INNER JOIN (\n",
-      "    SELECT *\n",
-      "    FROM t0\n",
-      "    WHERE `kind` = 'bar'\n",
-      "  ) t2\n",
-      "    ON t1.`region` = t2.`region`\n"
+      "  WHERE\n",
+      "    t0.kind = CAST('foo' AS TEXT)\n",
+      ") AS t1\n",
+      "JOIN (\n",
+      "  SELECT\n",
+      "    t0.region AS region,\n",
+      "    t0.kind AS kind,\n",
+      "    t0.total AS total\n",
+      "  FROM t0\n",
+      "  WHERE\n",
+      "    t0.kind = CAST('bar' AS TEXT)\n",
+      ") AS t2\n",
+      "  ON t1.region = t2.region\n"
      ]
     }
    ],
    "source": [
-    "print(ibis.impala.compile(result))"
+    "ibis.show_sql(result)"
    ]
   }
  ],
@@ -2915,7 +3254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Instead of mentioning the Impala SQL compiler, use `ibis.show_sql` to show sql examples.