### PR TITLE
fix(imports): remove top-level import of sqlalchemy from base backend

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -6,8 +6,6 @@ import os
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
-import sqlalchemy as sa
-
 import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
@@ -46,6 +44,8 @@ class BaseSQLBackend(BaseBackend):
         BaseBackend
             A backend instance
         """
+        import sqlalchemy as sa
+
         url = sa.engine.make_url(url)
 
         kwargs = {}


### PR DESCRIPTION
I noticed that the `bigquery` extra didn't require `sqlalchemy` but I
hit an import error for `sqlalchemy` via `base/sql/__init__.py`.

Most of our sql backends make use of sqlalchemy, but not all, and so it
seems odd to require it.  Moving it inside the single function call that
makes use of it.