### PR TITLE
feat(snowflake/postgres): implement argmin/argmax operations

### DIFF
--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -294,6 +294,8 @@ operation_registry.update(
             *itertools.chain.from_iterable(zip(op.names, map(t.translate, op.values)))
         ),
         ops.Unnest: _unnest,
+        ops.ArgMin: reduction(sa.func.min_by),
+        ops.ArgMax: reduction(sa.func.max_by),
     }
 )
 

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -89,7 +89,6 @@ argidx_not_grouped_marks = [
     "mysql",
     "postgres",
     "sqlite",
-    "snowflake",
     "polars",
     "mssql",
 ]
@@ -317,7 +316,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     "mysql",
                     "postgres",
                     "sqlite",
-                    "snowflake",
                     "polars",
                     "datafusion",
                     "mssql",
@@ -334,7 +332,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     "mysql",
                     "postgres",
                     "sqlite",
-                    "snowflake",
                     "polars",
                     "datafusion",
                     "mssql",

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -87,7 +87,6 @@ argidx_not_grouped_marks = [
     "datafusion",
     "impala",
     "mysql",
-    "postgres",
     "sqlite",
     "polars",
     "mssql",
@@ -311,15 +310,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.double_col[where].iloc[t.int_col[where].argmin()],
             id='argmin',
             marks=pytest.mark.notyet(
-                [
-                    "impala",
-                    "mysql",
-                    "postgres",
-                    "sqlite",
-                    "polars",
-                    "datafusion",
-                    "mssql",
-                ]
+                ["impala", "mysql", "sqlite", "polars", "datafusion", "mssql"]
             ),
         ),
         param(
@@ -327,15 +318,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.double_col[where].iloc[t.int_col[where].argmax()],
             id='argmax',
             marks=pytest.mark.notyet(
-                [
-                    "impala",
-                    "mysql",
-                    "postgres",
-                    "sqlite",
-                    "polars",
-                    "datafusion",
-                    "mssql",
-                ]
+                ["impala", "mysql", "sqlite", "polars", "datafusion", "mssql"]
             ),
         ),
         param(


### PR DESCRIPTION
This PR adds argmin and argmax implementations for th snowflake and postgres backends.