### PR TITLE
ci: add github actions helper hack to satisfy the required tpch check

### DIFF
--- a/.github/workflows/ibis-backends-skip-helper.yml
+++ b/.github/workflows/ibis-backends-skip-helper.yml
@@ -22,7 +22,19 @@ on:
       - master
       - "*.x.x"
 jobs:
-  backends:
+  test_backends:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No build required"
+  test_backends_min_version:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"
+  backends:
+    # this job exists so that we can use a single job from this workflow to gate merging
+    runs-on: ubuntu-latest
+    needs:
+      - test_backends_min_version
+      - test_backends
+    steps:
+      - run: exit 0

--- a/.github/workflows/ibis-main-skip-helper.yml
+++ b/.github/workflows/ibis-main-skip-helper.yml
@@ -20,7 +20,11 @@ on:
       - master
       - "*.x.x"
 jobs:
-  nix-lint:
+  test_no_backends:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"
+  test_shapely_duckdb_import:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No build required"

--- a/.github/workflows/ibis-tpch-queries-skip-helper.yml
+++ b/.github/workflows/ibis-tpch-queries-skip-helper.yml
@@ -1,0 +1,29 @@
+name: TPC-H
+
+on:
+  push:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "**/*.md"
+    branches:
+      - master
+      - "*.x.x"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "**/*.md"
+    branches:
+      - master
+      - "*.x.x"
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  tpch:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"


### PR DESCRIPTION
Follow up from #5414. This is a hack that we have in a couple other places, [endorsed by GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks), to allow workflows that allow required status checks to be "skipped" when none of their files match. It is not pretty, but it works.