### PR TITLE
fix(ux): give the `value_counts` aggregate column a better name

### DIFF
--- a/docs/tutorial/04-More-Value-Expressions.ipynb
+++ b/docs/tutorial/04-More-Value-Expressions.ipynb
@@ -365,7 +365,7 @@
    "outputs": [],
    "source": [
     "expr = countries.name.lower().left(1).name('first_letter')\n",
-    "expr.value_counts().order_by(('count', False)).limit(10)"
+    "expr.value_counts().order_by(ibis.desc('first_letter_count')).limit(10)"
    ]
   },
   {

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -548,7 +548,7 @@ def test_value_counts(t, df):
         df.compute()
         .dup_strings.value_counts()
         .reset_index()
-        .rename(columns={'dup_strings': 'count'})
+        .rename(columns={'dup_strings': 'dup_strings_count'})
         .rename(columns={'index': 'dup_strings'})
         .sort_values(['dup_strings'])
         .reset_index(drop=True)

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -393,7 +393,7 @@ def test_value_counts(t, df):
     expected = (
         df.dup_strings.value_counts()
         .reset_index()
-        .rename(columns={'dup_strings': 'count'})
+        .rename(columns={'dup_strings': 'dup_strings_count'})
         .rename(columns={'index': 'dup_strings'})
         .sort_values(['dup_strings'])
         .reset_index(drop=True)

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -781,7 +781,7 @@ def test_group_by_column_select_api(table):
 def test_value_counts_convenience(table):
     # #152
     result = table.g.value_counts()
-    expected = table.select('g').group_by('g').aggregate(count=lambda t: t.count())
+    expected = table.select('g').group_by('g').aggregate(g_count=lambda t: t.count())
 
     assert_equal(result, expected)
 

--- a/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result1.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result1.sql
@@ -1,4 +1,4 @@
-SELECT t0.`b`, count(1) AS `count`
+SELECT t0.`b`, count(1) AS `b_count`
 FROM (
   SELECT t1.`b`
   FROM (

--- a/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result2.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result2.sql
@@ -1,4 +1,4 @@
-SELECT t0.`b`, count(1) AS `count`
+SELECT t0.`b`, count(1) AS `b_count`
 FROM (
   SELECT t1.`b`
   FROM (


### PR DESCRIPTION
This PR gives a name to the aggregation in the result of `value_counts` a name that doesn't conflict with any existing method names, making the output a bit mroe join friendly.

Closes #5062.
