### PR TITLE
docs(io): doc/ux improvements for read_parquet and friends

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -10,10 +10,12 @@ hide:
 === "pip"
 
     ```sh
-    pip install ibis-framework # (1)
+    pip install 'ibis-framework[duckdb]' # (1) (2)
     ```
 
-    1. Note that the `ibis-framework` package is *not* the same as the `ibis` package in PyPI.  These two libraries cannot coexist in the same Python environment, as they are both imported with the `ibis` module name.
+    1. We suggest starting with the DuckDB backend.  It's performant and fully featured.  If you would like to use a different backend, all of the available options are listed below.
+
+    2. Note that the `ibis-framework` package is *not* the same as the `ibis` package in PyPI.  These two libraries cannot coexist in the same Python environment, as they are both imported with the `ibis` module name.
 
 {% for mgr in ["conda", "mamba"] %}
 === "{{ mgr }}"

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -133,7 +133,7 @@ class Options(Config):
         A callable to use when logging.
     graphviz_repr : bool
         Render expressions as GraphViz PNGs when running in a Jupyter notebook.
-    default_backend : Optional[str], default None
+    default_backend : Optional[ibis.backends.base.BaseBackend], default None
         The default backend to use for execution, defaults to DuckDB if not
         set.
     context_adjustment : ContextAdjustment

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -826,12 +826,16 @@ def row_number() -> ir.IntegerColumn:
 def read_csv(sources: str | Path | Sequence[str | Path], **kwargs: Any) -> ir.Table:
     """Lazily load a CSV or set of CSVs.
 
+    This function delegates to the `read_csv` method on the current default
+    backend (DuckDB or `ibis.config.default_backend`).
+
     Parameters
     ----------
     sources
         A filesystem path or URL or list of same.  Supports CSV and TSV files.
     kwargs
-        DuckDB-specific keyword arguments for the file type.
+        Backend-specific keyword arguments for the file type. For the DuckDB
+        backend used by default, please refer to:
 
         * CSV/TSV: https://duckdb.org/docs/data/csv#parameters.
 
@@ -854,12 +858,16 @@ def read_csv(sources: str | Path | Sequence[str | Path], **kwargs: Any) -> ir.Ta
 def read_json(sources: str | Path | Sequence[str | Path], **kwargs: Any) -> ir.Table:
     """Lazily load newline-delimited JSON data.
 
+    This function delegates to the `read_json` method on the current default
+    backend (DuckDB or `ibis.config.default_backend`).
+
     Parameters
     ----------
     sources
         A filesystem path or URL or list of same.
     kwargs
-        DuckDB-specific keyword arguments for the file type.
+        Backend-specific keyword arguments for the file type. For the DuckDB
+        backend used by default, there are no valid keywork arguments.
 
     Returns
     -------
@@ -879,12 +887,16 @@ def read_json(sources: str | Path | Sequence[str | Path], **kwargs: Any) -> ir.T
 def read_parquet(sources: str | Path | Sequence[str | Path], **kwargs: Any) -> ir.Table:
     """Lazily load a parquet file or set of parquet files.
 
+    This function delegates to the `read_parquet` method on the current default
+    backend (DuckDB or `ibis.config.default_backend`).
+
     Parameters
     ----------
     sources
         A filesystem path or URL or list of same.
     kwargs
-        DuckDB-specific keyword arguments for the file type.
+        Backend-specific keyword arguments for the file type. For the DuckDB
+        backend used by default, please refer to:
 
         * Parquet: https://duckdb.org/docs/data/parquet
 


### PR DESCRIPTION
xref #5420

Default to `duckdb` in the install doc, fix the API doc of
`default_backend`, and note that the `read_*` functions passthrough to
the default backend.