### PR TITLE
fix(backend): provide useful error if default backend is unavailable

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -4,6 +4,7 @@ import contextlib
 import importlib
 import importlib.metadata
 import platform
+import sys
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, TextIO
@@ -730,3 +731,13 @@ def test_employee_data_2():
     )
 
     return df2
+
+
+@pytest.fixture
+def no_duckdb(backend, monkeypatch):
+    monkeypatch.setitem(sys.modules, "duckdb", None)
+
+
+@pytest.fixture
+def no_pyarrow(backend, monkeypatch):
+    monkeypatch.setitem(sys.modules, "pyarrow", None)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -770,8 +770,19 @@ def test_default_backend_no_duckdb(backend):
     # run this twice to ensure that we hit the optimizations in
     # `_default_backend`
     for _ in range(2):
-        with pytest.raises(com.IbisError, match="Expression depends on no backends"):
+        with pytest.raises(
+            com.IbisError,
+            match="You have used a function that relies on the default backend",
+        ):
             expr.execute()
+
+
+def test_default_backend_no_duckdb_read_parquet(no_duckdb):
+    with pytest.raises(
+        com.IbisError,
+        match="You have used a function that relies on the default backend",
+    ):
+        ibis.read_parquet("foo.parquet")
 
 
 @pytest.mark.duckdb

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 from pytest import param
 
@@ -7,29 +5,6 @@ pa = pytest.importorskip("pyarrow")
 
 # Adds `to_pyarrow` to created schema objects
 from ibis.backends.pyarrow.datatypes import sch as _  # noqa: F401, E402
-
-
-class PackageDiscarder:
-    def __init__(self):
-        self.pkgnames = []
-
-    def find_spec(self, fullname, path, target=None):
-        if fullname in self.pkgnames:
-            raise ImportError(fullname)
-
-
-@pytest.fixture
-@pytest.mark.usefixtures("backend")
-def no_pyarrow():
-    _pyarrow = sys.modules.pop('pyarrow', None)
-    d = PackageDiscarder()
-    d.pkgnames.append('pyarrow')
-    sys.meta_path.insert(0, d)
-    yield
-    sys.meta_path.remove(d)
-    if _pyarrow is not None:
-        sys.modules["pyarrow"] = _pyarrow
-
 
 limit = [
     param(

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Optional
 from public import public
 from typing_extensions import Annotated
 
+import ibis.common.exceptions as com
 from ibis.common.grounds import Annotable
 from ibis.common.validators import min_
 
@@ -174,7 +175,26 @@ def _default_backend() -> Any:
     try:
         import duckdb as _  # noqa: F401
     except ImportError:
-        return None
+        raise com.IbisError(
+            """\
+You have used a function that relies on the default backend, but the default
+backend (DuckDB) is not installed.
+
+You may specify an alternate backend to use, e.g.
+
+ibis.set_backend("polars")
+
+or to install the DuckDB backend, run:
+
+    pip install 'ibis-framework[duckdb]'
+
+or
+
+    conda install -c conda-forge ibis-framework
+
+For more information on available backends, visit https://ibis-project.org/install
+"""
+        )
 
     import ibis
 


### PR DESCRIPTION
If a user installs only `ibis-framework` and then tries to run `ibis.read_parquet` or similar, they get an unhelpful error message. This tries to guide them in a helpful direction.