### PR TITLE
ci: renable nix builds

### DIFF
--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -5,22 +5,18 @@ name: Nix
 
 on:
   push:
-    paths-ignore:
-      - "**/*.nix"
-      - "pyproject.toml"
-      - "poetry.lock"
-      - "flake.lock"
-      - "nix/**"
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "**/*.md"
     branches:
       - master
       - "*.x.x"
   pull_request:
-    paths-ignore:
-      - "**/*.nix"
-      - "pyproject.toml"
-      - "poetry.lock"
-      - "flake.lock"
-      - "nix/**"
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "**/*.md"
     branches:
       - master
       - "*.x.x"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,28 +2,18 @@ name: Nix
 
 on:
   push:
-    paths:
-      - "**/*.nix"
-      - "pyproject.toml"
-      - "poetry.lock"
-      - "flake.lock"
-      - "nix/**"
-      - "!docs/**"
-      - "!mkdocs.yml"
-      - "!**/*.md"
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "**/*.md"
     branches:
       - master
       - "*.x.x"
   pull_request:
-    paths:
-      - "**/*.nix"
-      - "pyproject.toml"
-      - "poetry.lock"
-      - "flake.lock"
-      - "nix/**"
-      - "!docs/**"
-      - "!mkdocs.yml"
-      - "!**/*.md"
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "**/*.md"
     branches:
       - master
       - "*.x.x"
@@ -69,7 +59,6 @@ jobs:
           version='${{ matrix.python-version }}'
           nix build ".#ibis${version//./}" --fallback --keep-going --print-build-logs
 
-      # build the whole dev shell when pushing to upstream, so that the cachix cache is populated
       - name: nix build devShell
         if: github.event_name == 'push'
         run: |

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -4,7 +4,6 @@ import contextlib
 import importlib
 import importlib.metadata
 import platform
-import sys
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, TextIO
@@ -731,13 +730,3 @@ def test_employee_data_2():
     )
 
     return df2
-
-
-@pytest.fixture
-def no_duckdb(backend, monkeypatch):
-    monkeypatch.setitem(sys.modules, "duckdb", None)
-
-
-@pytest.fixture
-def no_pyarrow(backend, monkeypatch):
-    monkeypatch.setitem(sys.modules, "pyarrow", None)

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from pytest import param
 
@@ -150,6 +152,7 @@ def test_to_pyarrow_batches_borked_types(batting):
     assert len(batch) == 42
 
 
-def test_no_pyarrow_message(awards_players, no_pyarrow):
+def test_no_pyarrow_message(awards_players, monkeypatch):
+    monkeypatch.setitem(sys.modules, "pyarrow", None)
     with pytest.raises(ModuleNotFoundError, match="requires `pyarrow` but"):
         awards_players.to_pyarrow()

--- a/nix/ibis.nix
+++ b/nix/ibis.nix
@@ -47,7 +47,8 @@ poetry2nix.mkPoetryApplication rec {
     # the sqlite-on-duckdb tests try to download the sqlite_scanner extension
     # but network usage is not allowed in the sandbox
     pytest -m '${markers}' --numprocesses "$NIX_BUILD_CORES" --dist loadgroup \
-      --deselect=ibis/backends/duckdb/tests/test_register.py::test_{read,register}_sqlite \
+      --deselect=ibis/backends/duckdb/tests/test_register.py::test_read_sqlite \
+      --deselect=ibis/backends/duckdb/tests/test_register.py::test_register_sqlite
 
     runHook postCheck
   '';


### PR DESCRIPTION
Enable nix builds in CI again. Previously we disabled them because they built things from source, but now that they are using wheels they are well within reasonable CI times.