### PR TITLE
refactor(datatype): remove `Category.to_integer_type()` method

### DIFF
--- a/ibis/backends/pyspark/tests/test_null.py
+++ b/ibis/backends/pyspark/tests/test_null.py
@@ -8,7 +8,7 @@ def test_isnull(client):
     table = client.table('null_table')
     table_pandas = table.compile().toPandas()
 
-    for (col, _) in table_pandas.items():
+    for col, _ in table_pandas.items():
         result = table[table[col].isnull()].compile().toPandas().reset_index(drop=True)
         expected = table_pandas[table_pandas[col].isnull()].reset_index(drop=True)
         tm.assert_frame_equal(result, expected)
@@ -18,7 +18,7 @@ def test_notnull(client):
     table = client.table('null_table')
     table_pandas = table.compile().toPandas()
 
-    for (col, _) in table_pandas.items():
+    for col, _ in table_pandas.items():
         result = table[table[col].notnull()].compile().toPandas().reset_index(drop=True)
         expected = table_pandas[table_pandas[col].notnull()].reset_index(drop=True)
         tm.assert_frame_equal(result, expected)

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -318,7 +318,6 @@ def test_register_pyarrow_tables(con):
     ]
 )
 def test_csv_reregister_schema(con, tmp_path):
-
     foo = tmp_path / "foo.csv"
     with open(foo, "w", newline="") as csvfile:
         foowriter = csv.writer(

--- a/ibis/common/exceptions.py
+++ b/ibis/common/exceptions.py
@@ -94,6 +94,7 @@ class BackendConfigurationNotRegistered(IbisError):
 
 def mark_as_unsupported(f: Callable) -> Callable:
     """Decorate an unsupported method."""
+
     # function that raises UnsupportedOperationError
     def _mark_as_unsupported(self):
         raise UnsupportedOperationError(

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -686,14 +686,6 @@ class Category(Parametric):
             cardinality = "unknown"
         return f"{self.name}(cardinality={cardinality})"
 
-    def to_integer_type(self):
-        from ibis.expr.datatypes.value import infer
-
-        if self.cardinality is None:
-            return int64
-        else:
-            return infer(self.cardinality)
-
 
 @public
 class Struct(Parametric, Mapping):


### PR DESCRIPTION
BREAKING CHANGE: Category.to_inteder_type() method is removed
