### PR TITLE
feat(ux): expose `rows` and `range` keyword arguments in `value.over()`

### DIFF
--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import types
 from typing import Iterable, Sequence
 
+import ibis
 import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
@@ -222,19 +223,43 @@ class GroupedTable:
                 order_by=self._window.order_by + self._order_by,
             )
 
-    def over(self, window) -> GroupedTable:
+    def over(
+        self,
+        window=None,
+        *,
+        rows=None,
+        range=None,
+        group_by=None,
+        order_by=None,
+    ) -> GroupedTable:
         """Apply a window over the input expressions.
 
         Parameters
         ----------
         window
             Window to add to the input
+        rows
+            Whether to use the `ROWS` window clause
+        range
+            Whether to use the `RANGE` window clause
+        group_by
+            Grouping key
+        order_by
+            Ordering key
 
         Returns
         -------
         GroupedTable
             A new grouped table expression
         """
+        if window is None:
+            window = ibis.window(
+                rows=rows,
+                range=range,
+                group_by=group_by,
+                order_by=order_by,
+            )
+
         return self.__class__(
             self.table,
             self.by,

--- a/ibis/tests/expr/test_window_functions.py
+++ b/ibis/tests/expr/test_window_functions.py
@@ -38,3 +38,18 @@ def test_mutate_with_analytic_functions(alltypes):
     for field in proj.op().selections[1:]:
         assert isinstance(field, ops.Alias)
         assert isinstance(field.arg, ops.WindowFunction)
+
+
+def test_value_over_api(alltypes):
+    t = alltypes
+
+    w1 = ibis.window(rows=(0, 1), group_by=t.g, order_by=[t.f, t.h])
+    w2 = ibis.window(range=(-1, 1), group_by=[t.g, t.a], order_by=[t.f])
+
+    expr = t.f.cumsum().over(rows=(0, 1), group_by=t.g, order_by=[t.f, t.h])
+    expected = t.f.cumsum().over(w1)
+    assert expr.equals(expected)
+
+    expr = t.f.cumsum().over(range=(-1, 1), group_by=[t.g, t.a], order_by=[t.f])
+    expected = t.f.cumsum().over(w2)
+    assert expr.equals(expected)


### PR DESCRIPTION
depends on #5014 