### PR TITLE
fix(api): fix broken `__radd__` array concat operation

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -23,6 +23,10 @@ pytestmark = [
     pytest.mark.notyet(["impala"], reason="No array support"),
 ]
 
+# NB: We don't check whether results are numpy arrays or lists because this
+# varies across backends. At some point we should unify the result type to be
+# list.
+
 
 @pytest.mark.notimpl(["datafusion"])
 def test_array_column(backend, alltypes, df):
@@ -54,8 +58,6 @@ def test_array_scalar(con, backend):
     result = con.execute(expr.name("tmp"))
     expected = np.array([1.0, 2.0, 3.0])
 
-    # This does not check whether `result` is an np.array or a list,
-    # because it varies across backends and backend configurations
     assert np.array_equal(result, expected)
 
     with contextlib.suppress(com.OperationNotDefinedError):
@@ -70,8 +72,6 @@ def test_array_repeat(con):
     result = con.execute(expr.name("tmp"))
     expected = np.array([1.0, 2.0, 1.0, 2.0])
 
-    # This does not check whether `result` is an np.array or a list,
-    # because it varies across backends and backend configurations
     assert np.array_equal(result, expected)
 
 
@@ -83,9 +83,17 @@ def test_array_concat(con):
     expr = left + right
     result = con.execute(expr.name("tmp"))
     expected = np.array([1, 2, 3, 2, 1])
+    assert np.array_equal(result, expected)
 
-    # This does not check whether `result` is an np.array or a list,
-    # because it varies across backends and backend configurations
+
+@pytest.mark.notimpl(["datafusion"])
+def test_array_radd_concat(con):
+    left = [1]
+    right = ibis.literal([2])
+    expr = left + right
+    result = con.execute(expr.name("tmp"))
+    expected = np.array([1, 2])
+
     assert np.array_equal(result, expected)
 
 
@@ -100,8 +108,6 @@ def test_list_literal(con):
     expr = ibis.literal(arr)
     result = con.execute(expr.name("tmp"))
 
-    # This does not check whether `result` is an np.array or a list,
-    # because it varies across backends and backend configurations
     assert np.array_equal(result, arr)
 
 
@@ -110,8 +116,6 @@ def test_np_array_literal(con):
     expr = ibis.literal(arr)
     result = con.execute(expr.name("tmp"))
 
-    # This does not check whether `result` is an np.array or a list,
-    # because it varies across backends and backend configurations
     assert np.array_equal(result, arr)
 
 

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -127,7 +127,7 @@ class ArrayValue(Value):
         >>> b + a
         ArrayConcat(left=(3, 4, 5), right=(1, 2))
         """
-        return ops.ArrayConcat(self, other).to_expr()
+        return ops.ArrayConcat(other, self).to_expr()
 
     def __mul__(self, n: int | ir.IntegerValue) -> ArrayValue:
         """Repeat this array `n` times.


### PR DESCRIPTION
This PR fixes a broken implementation of `__radd__` array concatenation.
