### PR TITLE
Strict validate exceptions in xfail tests

### DIFF
--- a/ibis/backends/tests/test_column.py
+++ b/ibis/backends/tests/test_column.py
@@ -2,6 +2,8 @@ import operator
 
 import pytest
 
+from ibis.common.exceptions import OperationNotDefinedError
+
 
 @pytest.mark.notimpl(
     [
@@ -18,7 +20,8 @@ import pytest
         "pyspark",
         "snowflake",
         "trino",
-    ]
+    ],
+    raises=OperationNotDefinedError,
 )
 def test_rowid(con):
     t = con.table('functional_alltypes')
@@ -36,7 +39,7 @@ def test_rowid(con):
     "column",
     ["string_col", "double_col", "date_string_col", "timestamp_col"],
 )
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=OperationNotDefinedError)
 def test_distinct_column(alltypes, df, column):
     expr = alltypes[[column]].distinct()
     result = expr.execute()
@@ -52,8 +55,8 @@ def test_distinct_column(alltypes, df, column):
         ("day", set(range(1, 32))),
     ],
 )
-@pytest.mark.notimpl(["datafusion"])
-@pytest.mark.notyet(["impala"])
+@pytest.mark.notimpl(["datafusion"], raises=OperationNotDefinedError)
+@pytest.mark.notyet(["impala"], raises=OperationNotDefinedError)
 def test_date_extract_field(con, opname, expected):
     op = operator.methodcaller(opname)
     t = con.table("functional_alltypes")

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -6,6 +6,7 @@ from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
+from ibis.common.exceptions import OperationNotDefinedError
 from ibis.util import guid
 
 pytestmark = [
@@ -47,8 +48,8 @@ def test_literal_map_values(con):
     assert np.array_equal(result, ['a', 'b'])
 
 
-@pytest.mark.notimpl(["trino", "postgres"])
-@pytest.mark.notyet(["snowflake"])
+@pytest.mark.notimpl(["trino", "postgres"], raises=OperationNotDefinedError)
+@pytest.mark.notyet(["snowflake"], raises=OperationNotDefinedError)
 def test_scalar_isin_literal_map_keys(con):
     mapping = ibis.literal({'a': 1, 'b': 2})
     a = ibis.literal('a')
@@ -59,7 +60,11 @@ def test_scalar_isin_literal_map_keys(con):
     assert con.execute(false) == False  # noqa: E712
 
 
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_map_scalar_contains_key_scalar(con):
     mapping = ibis.literal({'a': 1, 'b': 2})
     a = ibis.literal('a')
@@ -79,7 +84,11 @@ def test_map_scalar_contains_key_column(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_map_column_contains_key_scalar(backend, alltypes, df):
     expr = ibis.map(ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col]))
     series = df.apply(lambda row: {row['string_col']: row['int_col']}, axis=1)
@@ -90,14 +99,22 @@ def test_map_column_contains_key_scalar(backend, alltypes, df):
     backend.assert_series_equal(result, series)
 
 
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_map_column_contains_key_column(alltypes):
     expr = ibis.map(ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col]))
     result = expr.contains(alltypes.string_col).name('tmp').execute()
     assert result.all()
 
 
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_literal_map_merge(con):
     a = ibis.literal({'a': 0, 'b': 2})
     b = ibis.literal({'a': 1, 'c': 3})
@@ -138,7 +155,9 @@ def test_literal_map_get_broadcast(backend, alltypes, df):
             [1, 2],
             id="string",
             marks=pytest.mark.notyet(
-                ["postgres"], reason="only support maps of string -> string"
+                ["postgres"],
+                reason="only support maps of string -> string",
+                raises=OperationNotDefinedError,
             ),
         ),
         param(["a", "b"], ["1", "2"], id="int"),
@@ -150,7 +169,11 @@ def test_map_construct_dict(con, keys, values):
     assert result == dict(zip(keys, values))
 
 
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_map_construct_array_column(con, alltypes, df):
     expr = ibis.map(ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col]))
     result = con.execute(expr)
@@ -159,21 +182,33 @@ def test_map_construct_array_column(con, alltypes, df):
     assert result.to_list() == expected.to_list()
 
 
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_map_get_with_compatible_value_smaller(con):
     value = ibis.literal({'A': 1000, 'B': 2000})
     expr = value.get('C', 3)
     assert con.execute(expr) == 3
 
 
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_map_get_with_compatible_value_bigger(con):
     value = ibis.literal({'A': 1, 'B': 2})
     expr = value.get('C', 3000)
     assert con.execute(expr) == 3000
 
 
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_map_get_with_incompatible_value_different_kind(con):
     value = ibis.literal({'A': 1000, 'B': 2000})
     expr = value.get('C', 3.0)
@@ -181,7 +216,11 @@ def test_map_get_with_incompatible_value_different_kind(con):
 
 
 @pytest.mark.parametrize('null_value', [None, ibis.NA])
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_map_get_with_null_on_not_nullable(con, null_value):
     map_type = dt.Map(dt.string, dt.Int16(nullable=False))
     value = ibis.literal({'A': 1000, 'B': 2000}).cast(map_type)
@@ -196,7 +235,11 @@ def test_map_get_with_null_on_null_type_with_null(con, null_value):
     assert con.execute(expr) is None
 
 
-@pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notyet(
+    ["postgres"],
+    reason="only support maps of string -> string",
+    raises=OperationNotDefinedError,
+)
 def test_map_get_with_null_on_null_type_with_non_null(con):
     value = ibis.literal({'A': None, 'B': None})
     expr = value.get('C', 1)
@@ -213,7 +256,11 @@ def tmptable(con):
         con.drop_table(name)
 
 
-@pytest.mark.notimpl(["clickhouse"], reason=".create_table not yet implemented in ibis")
+@pytest.mark.notimpl(
+    ["clickhouse"],
+    reason=".create_table not yet implemented in ibis",
+    raises=OperationNotDefinedError,
+)
 def test_map_create_table(con, tmptable):
     con.create_table(tmptable, schema=ibis.schema(dict(xyz="map<string, string>")))
     t = con.table(tmptable)

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -614,7 +614,9 @@ def test_decimal_literal(con, backend, expr, expected_types, expected_result):
         param(operator.methodcaller('isinf'), np.isinf, id='isinf'),
     ],
 )
-@pytest.mark.notimpl(["mysql", "sqlite", "datafusion", "mssql"])
+@pytest.mark.notimpl(
+    ["mysql", "sqlite", "datafusion", "mssql"], raises=com.OperationNotDefinedError
+)
 @pytest.mark.xfail(
     duckdb is not None and vparse(duckdb.__version__) < vparse("0.3.3"),
     reason="<0.3.3 does not support isnan/isinf properly",
@@ -653,13 +655,17 @@ def test_isnan_isinf(
             ibis.least(L(10), L(1)),
             1,
             id='least',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             ibis.greatest(L(10), L(1)),
             10,
             id='greatest',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             L(5.5).round(),
@@ -670,7 +676,9 @@ def test_isnan_isinf(
             L(5.556).round(2),
             5.56,
             id='round-digits',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(L(5.556).ceil(), 6.0, id='ceil'),
         param(L(5.556).floor(), 5.0, id='floor'),
@@ -678,32 +686,42 @@ def test_isnan_isinf(
             L(5.556).exp(),
             math.exp(5.556),
             id='expr',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             L(5.556).sign(),
             1,
             id='sign-pos',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             L(-5.556).sign(),
             -1,
             id='sign-neg',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             L(0).sign(),
             0,
             id='sign-zero',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(L(5.556).sqrt(), math.sqrt(5.556), id='sqrt'),
         param(
             L(5.556).log(2),
             math.log(5.556, 2),
             id='log-base',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             L(5.556).ln(),
@@ -724,13 +742,17 @@ def test_isnan_isinf(
             L(5.556).radians(),
             math.radians(5.556),
             id='radians',
-            marks=pytest.mark.notimpl(["datafusion", "impala"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion", "impala"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             L(5.556).degrees(),
             math.degrees(5.556),
             id='degrees',
-            marks=pytest.mark.notimpl(["datafusion", "impala"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion", "impala"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(L(11) % 3, 11 % 3, id='mod'),
     ],
@@ -783,6 +805,7 @@ def test_trig_functions_literals(con, expr, expected):
         "datafusion implements trig functions but can't easily test them due"
         " to missing NullIfZero"
     ),
+    raises=com.OperationNotDefinedError,
 )
 def test_trig_functions_columns(backend, expr, alltypes, df, expected_fn):
     dc_max = df.double_col.max()
@@ -819,13 +842,17 @@ def test_trig_functions_columns(backend, expr, alltypes, df, expected_fn):
             lambda t: t.double_col.sign(),
             lambda t: np.sign(t.double_col),
             id='sign',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: (-t.double_col).sign(),
             lambda t: np.sign(-t.double_col),
             id='sign-negative',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
     ],
 )
@@ -855,13 +882,17 @@ def test_simple_math_functions_columns(
             lambda t: t.double_col.add(1).exp(),
             lambda t: np.exp(t.double_col + 1),
             id='exp',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.double_col.add(1).log(2),
             lambda t: np.log2(t.double_col + 1),
             id='log2',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.double_col.add(1).ln(),
@@ -884,7 +915,10 @@ def test_simple_math_functions_columns(
                 np.log(t.double_col + 1) / np.log(np.maximum(9_000, t.bigint_col))
             ),
             id="log_base_bigint",
-            marks=pytest.mark.notimpl(["clickhouse", "datafusion", "polars"]),
+            marks=pytest.mark.notimpl(
+                ["clickhouse", "datafusion", "polars"],
+                raises=com.OperationNotDefinedError,
+            ),
         ),
     ],
 )
@@ -904,19 +938,23 @@ def test_complex_math_functions_columns(
             lambda be, t: t.double_col.round(),
             lambda be, t: be.round(t.double_col),
             id='round',
-            marks=pytest.mark.notimpl(["mssql"]),
+            marks=pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError),
         ),
         param(
             lambda be, t: t.double_col.add(0.05).round(3),
             lambda be, t: be.round(t.double_col + 0.05, 3),
             id='round-with-param',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda be, t: ibis.least(t.bigint_col, t.int_col),
             lambda be, t: pd.Series(list(map(min, t.bigint_col, t.int_col))),
             id='least-all-columns',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda be, t: ibis.least(t.bigint_col, t.int_col, -2),
@@ -924,13 +962,17 @@ def test_complex_math_functions_columns(
                 list(map(min, t.bigint_col, t.int_col, [-2] * len(t)))
             ),
             id='least-scalar',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda be, t: ibis.greatest(t.bigint_col, t.int_col),
             lambda be, t: pd.Series(list(map(max, t.bigint_col, t.int_col))),
             id='greatest-all-columns',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda be, t: ibis.greatest(t.bigint_col, t.int_col, -2),
@@ -938,7 +980,9 @@ def test_complex_math_functions_columns(
                 list(map(max, t.bigint_col, t.int_col, [-2] * len(t)))
             ),
             id='greatest-scalar',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
     ],
 )
@@ -958,7 +1002,12 @@ def test_backend_specific_numerics(backend, con, df, alltypes, expr_fn, expected
         operator.mul,
         operator.truediv,
         operator.floordiv,
-        param(operator.pow, marks=pytest.mark.notimpl(["datafusion"])),
+        param(
+            operator.pow,
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
+        ),
     ],
     ids=lambda op: op.__name__,
 )
@@ -989,8 +1038,12 @@ def test_mod(backend, alltypes, df):
     backend.assert_series_equal(result, expected, check_dtype=False)
 
 
-@pytest.mark.notimpl(["mssql"])
-@pytest.mark.notyet(["bigquery"], reason="bigquery doesn't support floating modulus")
+@pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(
+    ["bigquery"],
+    reason="bigquery doesn't support floating modulus",
+    raises=com.OperationNotDefinedError,
+)
 def test_floating_mod(backend, alltypes, df):
     expr = operator.mod(alltypes.double_col, alltypes.smallint_col + 1).name('tmp')
 
@@ -1029,7 +1082,8 @@ def test_floating_mod(backend, alltypes, df):
         "sqlite",
         "snowflake",
         "mssql",
-    ]
+    ],
+    raises=com.OperationNotDefinedError,
 )
 @pytest.mark.parametrize('denominator', [0, 0.0])
 def test_divide_by_zero(backend, alltypes, df, column, denominator):
@@ -1051,7 +1105,7 @@ def test_divide_by_zero(backend, alltypes, df, column, denominator):
         )
     ],
 )
-@pytest.mark.notimpl(["sqlite", "duckdb", "mssql"])
+@pytest.mark.notimpl(["sqlite", "duckdb", "mssql"], raises=com.OperationNotDefinedError)
 @pytest.mark.never(
     [
         "bigquery",
@@ -1064,6 +1118,7 @@ def test_divide_by_zero(backend, alltypes, df, column, denominator):
         "polars",
     ],
     reason="Not SQLAlchemy backends",
+    raises=com.OperationNotDefinedError,
 )
 def test_sa_default_numeric_precision_and_scale(
     con, backend, default_precisions, default_scales
@@ -1105,7 +1160,10 @@ def test_sa_default_numeric_precision_and_scale(
         con.drop_table(table_name, force=True)
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "impala", "pandas", "sqlite", "polars"])
+@pytest.mark.notimpl(
+    ["dask", "datafusion", "impala", "pandas", "sqlite", "polars"],
+    raises=com.OperationNotDefinedError,
+)
 def test_random(con):
     expr = ibis.random()
     result = con.execute(expr)
@@ -1134,7 +1192,7 @@ def test_random(con):
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_clip(backend, alltypes, df, ibis_func, pandas_func):
     result = ibis_func(alltypes.int_col).execute()
     expected = pandas_func(df.int_col).astype(result.dtype)
@@ -1143,14 +1201,18 @@ def test_clip(backend, alltypes, df, ibis_func, pandas_func):
     backend.assert_series_equal(result, expected, check_names=False)
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "polars"])
+@pytest.mark.notimpl(
+    ["dask", "datafusion", "polars"], raises=com.OperationNotDefinedError
+)
 def test_histogram(con, alltypes):
     n = 10
     results = con.execute(alltypes.int_col.histogram(n).name("tmp"))
     assert len(results.value_counts()) == n
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pandas", "polars"])
+@pytest.mark.notimpl(
+    ["dask", "datafusion", "pandas", "polars"], raises=com.OperationNotDefinedError
+)
 @pytest.mark.parametrize("const", ["e", "pi"])
 def test_constants(con, const):
     expr = getattr(ibis, const)
@@ -1159,7 +1221,9 @@ def test_constants(con, const):
 
 
 pyspark_no_bitshift = pytest.mark.notyet(
-    ["pyspark"], reason="pyspark doesn't implement bitshift operators"
+    ["pyspark"],
+    reason="pyspark doesn't implement bitshift operators",
+    raises=com.OperationNotDefinedError,
 )
 
 
@@ -1172,7 +1236,9 @@ pyspark_no_bitshift = pytest.mark.notyet(
         param(lambda t: t.int_col, lambda _: 3, id="col_scalar"),
     ],
 )
-@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+@pytest.mark.notimpl(
+    ["dask", "datafusion", "pandas"], raises=com.OperationNotDefinedError
+)
 def test_bitwise_columns(backend, con, alltypes, df, op, left_fn, right_fn):
     expr = op(left_fn(alltypes), right_fn(alltypes)).name("tmp")
     result = con.execute(expr)
@@ -1197,6 +1263,7 @@ def test_bitwise_columns(backend, con, alltypes, df, op, left_fn, right_fn):
             marks=pytest.mark.broken(
                 ["impala"],
                 reason="impala's behavior differs from every other backend",
+                raises=com.OperationNotDefinedError,
             ),
             id="lshift_scalar_col",
         ),
@@ -1206,7 +1273,9 @@ def test_bitwise_columns(backend, con, alltypes, df, op, left_fn, right_fn):
         param(rshift, lambda t: t.int_col, lambda _: 3, id="rshift_col_scalar"),
     ],
 )
-@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+@pytest.mark.notimpl(
+    ["dask", "datafusion", "pandas"], raises=com.OperationNotDefinedError
+)
 @pyspark_no_bitshift
 def test_bitwise_shift(backend, alltypes, df, op, left_fn, right_fn):
     expr = op(left_fn(alltypes), right_fn(alltypes)).name("tmp")
@@ -1236,7 +1305,9 @@ def test_bitwise_shift(backend, alltypes, df, op, left_fn, right_fn):
     ("left", "right"),
     [param(4, L(2), id="int_col"), param(L(4), 2, id="col_int")],
 )
-@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+@pytest.mark.notimpl(
+    ["dask", "datafusion", "pandas"], raises=com.OperationNotDefinedError
+)
 def test_bitwise_scalars(con, op, left, right):
     expr = op(left, right)
     result = con.execute(expr)
@@ -1244,7 +1315,9 @@ def test_bitwise_scalars(con, op, left, right):
     assert result == expected
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+@pytest.mark.notimpl(
+    ["dask", "datafusion", "pandas"], raises=com.OperationNotDefinedError
+)
 def test_bitwise_not_scalar(con):
     expr = ~L(2)
     result = con.execute(expr)
@@ -1252,7 +1325,9 @@ def test_bitwise_not_scalar(con):
     assert result == expected
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "pandas"])
+@pytest.mark.notimpl(
+    ["dask", "datafusion", "pandas"], raises=com.OperationNotDefinedError
+)
 def test_bitwise_not_col(backend, alltypes, df):
     expr = (~alltypes.int_col).name("tmp")
     result = expr.execute()

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -10,6 +10,7 @@ from pytest import param
 import ibis
 import ibis.expr.datatypes as dt
 from ibis import _
+from ibis.common.exceptions import OperationNotDefinedError
 
 
 @pytest.mark.parametrize(
@@ -21,7 +22,7 @@ from ibis import _
         ('float_col', 2.2),
     ],
 )
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=OperationNotDefinedError)
 def test_floating_scalar_parameter(backend, alltypes, df, column, raw_value):
     value = ibis.param(dt.double)
     expr = (alltypes[column] + value).name('tmp')
@@ -35,7 +36,9 @@ def test_floating_scalar_parameter(backend, alltypes, df, column, raw_value):
     ('start_string', 'end_string'),
     [('2009-03-01', '2010-07-03'), ('2014-12-01', '2017-01-05')],
 )
-@pytest.mark.notimpl(["datafusion", "pyspark", "mssql", "trino"])
+@pytest.mark.notimpl(
+    ["datafusion", "pyspark", "mssql", "trino"], raises=OperationNotDefinedError
+)
 def test_date_scalar_parameter(backend, alltypes, start_string, end_string):
     start, end = ibis.param(dt.date), ibis.param(dt.date)
 
@@ -49,7 +52,7 @@ def test_date_scalar_parameter(backend, alltypes, start_string, end_string):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=OperationNotDefinedError)
 def test_timestamp_accepts_date_literals(alltypes):
     date_string = '2009-03-01'
     param = ibis.param(dt.timestamp)
@@ -58,9 +61,14 @@ def test_timestamp_accepts_date_literals(alltypes):
     assert expr.compile(params=params) is not None
 
 
-@pytest.mark.notimpl(["dask", "datafusion", "impala", "pandas", "pyspark"])
+@pytest.mark.notimpl(
+    ["dask", "datafusion", "impala", "pandas", "pyspark"],
+    raises=OperationNotDefinedError,
+)
 @pytest.mark.never(
-    ["mysql", "sqlite", "mssql"], reason="backend will never implement array types"
+    ["mysql", "sqlite", "mssql"],
+    reason="backend will never implement array types",
+    raises=OperationNotDefinedError,
 )
 def test_scalar_param_array(con):
     value = [1, 2, 3]
@@ -69,10 +77,14 @@ def test_scalar_param_array(con):
     assert result == len(value)
 
 
-@pytest.mark.notimpl(["clickhouse", "datafusion", "impala", "postgres", "pyspark"])
+@pytest.mark.notimpl(
+    ["clickhouse", "datafusion", "impala", "postgres", "pyspark"],
+    raises=OperationNotDefinedError,
+)
 @pytest.mark.never(
     ["mysql", "sqlite", "mssql"],
     reason="mysql and sqlite will never implement struct types",
+    raises=OperationNotDefinedError,
 )
 def test_scalar_param_struct(con):
     value = dict(a=1, b="abc", c=3.0)
@@ -82,13 +94,15 @@ def test_scalar_param_struct(con):
 
 
 @pytest.mark.notimpl(
-    ["clickhouse", "datafusion", "duckdb", "impala", "pyspark", "polars"]
+    ["clickhouse", "datafusion", "duckdb", "impala", "pyspark", "polars"],
+    raises=OperationNotDefinedError,
 )
 @pytest.mark.never(
     ["mysql", "sqlite", "mssql"],
     reason="mysql and sqlite will never implement map types",
+    raises=OperationNotDefinedError,
 )
-@pytest.mark.notyet(["bigquery"])
+@pytest.mark.notyet(["bigquery"], raises=OperationNotDefinedError)
 def test_scalar_param_map(con):
     value = {'a': 'ghi', 'b': 'def', 'c': 'abc'}
     param = ibis.param(dt.Map(dt.string, dt.string))
@@ -120,7 +134,7 @@ def test_scalar_param_map(con):
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=OperationNotDefinedError)
 def test_scalar_param(alltypes, df, value, dtype, col):
     param = ibis.param(dtype)
     expr = alltypes.filter([_[col] == param])
@@ -137,8 +151,10 @@ def test_scalar_param(alltypes, df, value, dtype, col):
     ["2009-01-20", datetime.date(2009, 1, 20), datetime.datetime(2009, 1, 20)],
     ids=["string", "date", "datetime"],
 )
-@pytest.mark.notimpl(["datafusion"])
-@pytest.mark.notyet(["impala"], reason="impala doesn't support dates")
+@pytest.mark.notimpl(["datafusion"], raises=OperationNotDefinedError)
+@pytest.mark.notyet(
+    ["impala"], reason="impala doesn't support dates", raises=OperationNotDefinedError
+)
 def test_scalar_param_date(backend, alltypes, value):
     param = ibis.param("date")
     ds_col = alltypes.date_string_col
@@ -167,7 +183,9 @@ def test_scalar_param_date(backend, alltypes, value):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notyet(["mysql"], reason="no struct support")
+@pytest.mark.notyet(
+    ["mysql"], reason="no struct support", raises=OperationNotDefinedError
+)
 @pytest.mark.notimpl(
     [
         "postgres",
@@ -181,7 +199,8 @@ def test_scalar_param_date(backend, alltypes, value):
         "pyspark",
         "mssql",
         "trino",
-    ]
+    ],
+    raises=OperationNotDefinedError,
 )
 def test_scalar_param_nested(con):
     param = ibis.param("struct<x: array<struct<y: array<double>>>>")

--- a/ibis/backends/tests/test_set_ops.py
+++ b/ibis/backends/tests/test_set_ops.py
@@ -24,7 +24,7 @@ def union_subsets(alltypes, df):
     "distinct",
     [param(False, id="all"), param(True, id="distinct")],
 )
-@pytest.mark.notimpl(["datafusion", "polars"])
+@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
 def test_union(backend, union_subsets, distinct):
     (a, b, c), (da, db, dc) = union_subsets
 
@@ -38,8 +38,8 @@ def test_union(backend, union_subsets, distinct):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["datafusion", "polars"])
-@pytest.mark.notyet(["bigquery"])
+@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(["bigquery"], raises=com.OperationNotDefinedError)
 def test_union_mixed_distinct(backend, union_subsets):
     (a, b, c), (da, db, dc) = union_subsets
 
@@ -60,14 +60,15 @@ def test_union_mixed_distinct(backend, union_subsets):
             marks=pytest.mark.notyet(
                 ["bigquery", "dask", "pandas", "sqlite", "snowflake", "mssql"],
                 reason="backend doesn't support INTERSECT ALL",
+                raises=com.OperationNotDefinedError,
             ),
             id="all",
         ),
         param(True, id="distinct"),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "polars"])
-@pytest.mark.notyet(["impala"])
+@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(["impala"], raises=com.OperationNotDefinedError)
 def test_intersect(backend, alltypes, df, distinct):
     a = alltypes.filter((_.id >= 5200) & (_.id <= 5210))
     b = alltypes.filter((_.id >= 5205) & (_.id <= 5215))
@@ -98,14 +99,15 @@ def test_intersect(backend, alltypes, df, distinct):
             marks=pytest.mark.notyet(
                 ["bigquery", "dask", "pandas", "sqlite", "snowflake", "mssql"],
                 reason="backend doesn't support EXCEPT ALL",
+                raises=com.OperationNotDefinedError,
             ),
             id="all",
         ),
         param(True, id="distinct"),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "polars"])
-@pytest.mark.notyet(["impala"])
+@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(["impala"], raises=com.OperationNotDefinedError)
 def test_difference(backend, alltypes, df, distinct):
     a = alltypes.filter((_.id >= 5200) & (_.id <= 5210))
     b = alltypes.filter((_.id >= 5205) & (_.id <= 5215))

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -85,16 +85,22 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.contains('6'),
             lambda t: t.string_col.str.contains('6'),
             id='contains',
-            marks=pytest.mark.notimpl(["datafusion", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion", "mssql"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.string_col.like('6%'),
             lambda t: t.string_col.str.contains('6.*'),
             id='like',
             marks=[
-                pytest.mark.notimpl(["datafusion", "polars"]),
+                pytest.mark.notimpl(
+                    ["datafusion", "polars"], raises=com.OperationNotDefinedError
+                ),
                 pytest.mark.notyet(
-                    ["mssql"], reason="mssql doesn't allow like outside of filters"
+                    ["mssql"],
+                    reason="mssql doesn't allow like outside of filters",
+                    raises=com.OperationNotDefinedError,
                 ),
             ],
         ),
@@ -103,9 +109,13 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.str.contains('6%'),
             id='complex_like_escape',
             marks=[
-                pytest.mark.notimpl(["datafusion", "polars"]),
+                pytest.mark.notimpl(
+                    ["datafusion", "polars"], raises=com.OperationNotDefinedError
+                ),
                 pytest.mark.notyet(
-                    ["mssql"], reason="mssql doesn't allow like outside of filters"
+                    ["mssql"],
+                    reason="mssql doesn't allow like outside of filters",
+                    raises=com.OperationNotDefinedError,
                 ),
             ],
         ),
@@ -114,9 +124,13 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.str.contains('6%.*'),
             id='complex_like_escape_match',
             marks=[
-                pytest.mark.notimpl(["datafusion", "polars"]),
+                pytest.mark.notimpl(
+                    ["datafusion", "polars"], raises=com.OperationNotDefinedError
+                ),
                 pytest.mark.notyet(
-                    ["mssql"], reason="mssql doesn't allow like outside of filters"
+                    ["mssql"],
+                    reason="mssql doesn't allow like outside of filters",
+                    raises=com.OperationNotDefinedError,
                 ),
             ],
         ),
@@ -125,9 +139,14 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.str.contains('6.*'),
             id='ilike',
             marks=[
-                pytest.mark.notimpl(["datafusion", "pyspark", "polars"]),
+                pytest.mark.notimpl(
+                    ["datafusion", "pyspark", "polars"],
+                    raises=com.OperationNotDefinedError,
+                ),
                 pytest.mark.notyet(
-                    ["mssql"], reason="mssql doesn't allow like outside of filters"
+                    ["mssql"],
+                    reason="mssql doesn't allow like outside of filters",
+                    raises=com.OperationNotDefinedError,
                 ),
             ],
         ),
@@ -135,43 +154,60 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search',
-            marks=pytest.mark.notimpl(["impala", "datafusion", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["impala", "datafusion", "mssql"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.string_col.re_search(r'[[:digit:]]+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search_posix',
-            marks=pytest.mark.notimpl(["datafusion", "pyspark", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion", "pyspark", "mssql"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.string_col.re_extract(r'(\d+)', 1),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract',
-            marks=pytest.mark.notimpl(["impala", "mysql", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["impala", "mysql", "mssql"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.string_col.re_extract(r'([[:digit:]]+)', 1),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract_posix',
-            marks=pytest.mark.notimpl(["mysql", "pyspark", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["mysql", "pyspark", "mssql"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: (t.string_col + "1").re_extract(r'\d(\d+)', 0),
             lambda t: (t.string_col + "1").str.extract(r'(\d+)', expand=False),
             id='re_extract_whole_group',
-            marks=pytest.mark.notimpl(["impala", "mysql", "snowflake", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["impala", "mysql", "snowflake", "mssql"],
+                raises=com.OperationNotDefinedError,
+            ),
         ),
         param(
             lambda t: t.string_col.re_replace(r'[[:digit:]]+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
             id='re_replace_posix',
-            marks=pytest.mark.notimpl(['datafusion', "mysql", "pyspark", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ['datafusion', "mysql", "pyspark", "mssql"],
+                raises=com.OperationNotDefinedError,
+            ),
         ),
         param(
             lambda t: t.string_col.re_replace(r'\d+', 'a'),
             lambda t: t.string_col.str.replace(r'\d+', 'a', regex=True),
             id='re_replace',
-            marks=pytest.mark.notimpl(["impala", "datafusion", "mysql", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["impala", "datafusion", "mysql", "mssql"],
+                raises=com.OperationNotDefinedError,
+            ),
         ),
         param(
             lambda t: t.string_col.repeat(2),
@@ -194,26 +230,29 @@ def test_string_col_is_unicode(alltypes, df):
                     "mssql",
                     "mysql",
                     "polars",
-                ]
+                ],
+                raises=com.OperationNotDefinedError,
             ),
         ),
         param(
             lambda t: t.string_col.find('a'),
             lambda t: t.string_col.str.find('a'),
             id='find',
-            marks=pytest.mark.notimpl(["datafusion", "polars"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion", "polars"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.string_col.lpad(10, 'a'),
             lambda t: t.string_col.str.pad(10, fillchar='a', side='left'),
             id='lpad',
-            marks=pytest.mark.notimpl(["mssql"]),
+            marks=pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError),
         ),
         param(
             lambda t: t.string_col.rpad(10, 'a'),
             lambda t: t.string_col.str.pad(10, fillchar='a', side='right'),
             id='rpad',
-            marks=pytest.mark.notimpl(["mssql"]),
+            marks=pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError),
         ),
         param(
             lambda t: t.string_col.find_in_set(['1']),
@@ -229,7 +268,8 @@ def test_string_col_is_unicode(alltypes, df):
                     "polars",
                     "mssql",
                     "trino",
-                ]
+                ],
+                raises=com.OperationNotDefinedError,
             ),
         ),
         param(
@@ -246,7 +286,8 @@ def test_string_col_is_unicode(alltypes, df):
                     "polars",
                     "mssql",
                     "trino",
-                ]
+                ],
+                raises=com.OperationNotDefinedError,
             ),
         ),
         param(
@@ -268,7 +309,9 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.ascii_str(),
             lambda t: t.string_col.map(ord).astype('int32'),
             id='ascii_str',
-            marks=pytest.mark.notimpl(["datafusion", "polars"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion", "polars"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.string_col.length(),
@@ -283,7 +326,8 @@ def test_string_col_is_unicode(alltypes, df):
             id='startswith',
             # pyspark doesn't support `cases` yet
             marks=pytest.mark.notimpl(
-                ["dask", "datafusion", "pyspark", "pandas", "mssql"]
+                ["dask", "datafusion", "pyspark", "pandas", "mssql"],
+                raises=com.OperationNotDefinedError,
             ),
         ),
         param(
@@ -294,20 +338,27 @@ def test_string_col_is_unicode(alltypes, df):
             id='endswith',
             # pyspark doesn't support `cases` yet
             marks=pytest.mark.notimpl(
-                ["dask", "datafusion", "pyspark", "pandas", "mssql"]
+                ["dask", "datafusion", "pyspark", "pandas", "mssql"],
+                raises=com.OperationNotDefinedError,
             ),
         ),
         param(
             lambda t: t.date_string_col.startswith("2010-01"),
             lambda t: t.date_string_col.str.startswith("2010-01"),
             id='startswith-simple',
-            marks=pytest.mark.notimpl(["dask", "datafusion", "pandas", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["dask", "datafusion", "pandas", "mssql"],
+                raises=com.OperationNotDefinedError,
+            ),
         ),
         param(
             lambda t: t.date_string_col.endswith("100"),
             lambda t: t.date_string_col.str.endswith("100"),
             id='endswith-simple',
-            marks=pytest.mark.notimpl(["dask", "datafusion", "pandas", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["dask", "datafusion", "pandas", "mssql"],
+                raises=com.OperationNotDefinedError,
+            ),
         ),
         param(
             lambda t: t.string_col.strip(),
@@ -328,7 +379,7 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.capitalize(),
             lambda t: t.string_col.str.capitalize(),
             id='capitalize',
-            marks=pytest.mark.notimpl(["mssql"]),
+            marks=pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError),
         ),
         param(
             lambda t: t.date_string_col.substr(2, 3),
@@ -340,8 +391,15 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.date_string_col.str[2:],
             id='substr-start-only',
             marks=[
-                pytest.mark.notimpl(["datafusion", "polars", "pyspark"]),
-                pytest.mark.notyet(["mssql"], reason="substr requires 3 arguments"),
+                pytest.mark.notimpl(
+                    ["datafusion", "polars", "pyspark"],
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notyet(
+                    ["mssql"],
+                    reason="substr requires 3 arguments",
+                    raises=com.OperationNotDefinedError,
+                ),
             ],
         ),
         param(
@@ -353,7 +411,9 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.date_string_col.right(2),
             lambda t: t.date_string_col.str[-2:],
             id="right",
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.date_string_col[1:3],
@@ -365,21 +425,27 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.date_string_col.str[-1:],
             id='expr_slice_begin',
             # TODO: substring #2553
-            marks=pytest.mark.notimpl(["dask", "pyspark", "polars"]),
+            marks=pytest.mark.notimpl(
+                ["dask", "pyspark", "polars"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.date_string_col[: t.date_string_col.length()],
             lambda t: t.date_string_col,
             id='expr_slice_end',
             # TODO: substring #2553
-            marks=pytest.mark.notimpl(["dask", "pyspark", "polars"]),
+            marks=pytest.mark.notimpl(
+                ["dask", "pyspark", "polars"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.date_string_col[:],
             lambda t: t.date_string_col,
             id='expr_empty_slice',
             # TODO: substring #2553
-            marks=pytest.mark.notimpl(["dask", "pyspark", "polars"]),
+            marks=pytest.mark.notimpl(
+                ["dask", "pyspark", "polars"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.date_string_col[
@@ -388,21 +454,26 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.date_string_col.str[-2:-1],
             id='expr_slice_begin_end',
             # TODO: substring #2553
-            marks=pytest.mark.notimpl(["dask", "pyspark", "polars"]),
+            marks=pytest.mark.notimpl(
+                ["dask", "pyspark", "polars"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.date_string_col.split('/'),
             lambda t: t.date_string_col.str.split('/'),
             id='split',
             marks=pytest.mark.notimpl(
-                ["dask", "datafusion", "impala", "mysql", "sqlite", "mssql"]
+                ["dask", "datafusion", "impala", "mysql", "sqlite", "mssql"],
+                raises=com.OperationNotDefinedError,
             ),
         ),
         param(
             lambda t: ibis.literal('-').join(['a', t.string_col, 'c']),
             lambda t: 'a-' + t.string_col + '-c',
             id='join',
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t: t.string_col + t.date_string_col,
@@ -423,7 +494,9 @@ def test_string_col_is_unicode(alltypes, df):
             lambda t: t.string_col.replace("1", "42"),
             lambda t: t.string_col.str.replace("1", "42"),
             id="replace",
-            marks=pytest.mark.notimpl(["datafusion"]),
+            marks=pytest.mark.notimpl(
+                ["datafusion"], raises=com.OperationNotDefinedError
+            ),
         ),
     ],
 )
@@ -435,14 +508,16 @@ def test_string(backend, alltypes, df, result_func, expected_func):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["datafusion", "mysql", "mssql"])
+@pytest.mark.notimpl(
+    ["datafusion", "mysql", "mssql"], raises=com.OperationNotDefinedError
+)
 def test_re_replace_global(con):
     expr = ibis.literal("aba").re_replace("a", "c")
     result = con.execute(expr)
     assert result == "cbc"
 
 
-@pytest.mark.notimpl(["datafusion", "mssql"])
+@pytest.mark.notimpl(["datafusion", "mssql"], raises=com.OperationNotDefinedError)
 def test_substr_with_null_values(backend, alltypes, df):
     table = alltypes.mutate(
         substr_col_null=ibis.case()
@@ -470,7 +545,7 @@ def test_substr_with_null_values(backend, alltypes, df):
             lambda d: d.authority(),
             "user:pass@example.com:80",
             id="authority",
-            marks=[pytest.mark.notyet(["trino"])],
+            marks=[pytest.mark.notyet(["trino"], raises=com.OperationNotDefinedError)],
         ),
         param(
             lambda d: d.userinfo(),
@@ -478,7 +553,7 @@ def test_substr_with_null_values(backend, alltypes, df):
             marks=[
                 pytest.mark.notyet(
                     ["clickhouse", "snowflake", "trino"],
-                    raises=(NotImplementedError, OperationNotDefinedError),
+                    raises=OperationNotDefinedError,
                     reason="doesn't support `USERINFO`",
                 )
             ],
@@ -495,7 +570,7 @@ def test_substr_with_null_values(backend, alltypes, df):
                 ),
                 pytest.mark.notyet(
                     ["snowflake"],
-                    raises=(NotImplementedError, OperationNotDefinedError),
+                    raises=OperationNotDefinedError,
                     reason="host is netloc",
                 ),
             ],
@@ -529,7 +604,8 @@ def test_substr_with_null_values(backend, alltypes, df):
         "postgres",
         "pyspark",
         "sqlite",
-    ]
+    ],
+    raises=com.OperationNotDefinedError,
 )
 def test_parse_url(con, result_func, expected):
     url = "http://user:pass@example.com:80/docs/books/tutorial/index.html?name=networking#DOWNLOADING"

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -7,6 +7,7 @@ import pytest
 
 import ibis
 import ibis.expr.datatypes as dt
+from ibis.common.exceptions import OperationNotDefinedError
 
 pytestmark = [
     pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
@@ -15,7 +16,7 @@ pytestmark = [
 ]
 
 
-@pytest.mark.notimpl(["dask", "snowflake"])
+@pytest.mark.notimpl(["dask", "snowflake"], raises=OperationNotDefinedError)
 @pytest.mark.parametrize("field", ["a", "b", "c"])
 def test_single_field(backend, struct, struct_df, field):
     expr = struct.abc[field]
@@ -31,7 +32,7 @@ def test_single_field(backend, struct, struct_df, field):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["dask"])
+@pytest.mark.notimpl(["dask"], raises=OperationNotDefinedError)
 def test_all_fields(struct, struct_df):
     result = struct.abc.execute()
     expected = struct_df.abc
@@ -51,7 +52,7 @@ _STRUCT_LITERAL = ibis.struct(
 _NULL_STRUCT_LITERAL = ibis.NA.cast("struct<a: int64, b: string, c: float64>")
 
 
-@pytest.mark.notimpl(["postgres"])
+@pytest.mark.notimpl(["postgres"], raises=OperationNotDefinedError)
 @pytest.mark.parametrize("field", ["a", "b", "c"])
 def test_literal(con, field):
     query = _STRUCT_LITERAL[field]
@@ -62,10 +63,12 @@ def test_literal(con, field):
     tm.assert_series_equal(result, expected.astype(dtype))
 
 
-@pytest.mark.notimpl(["postgres"])
+@pytest.mark.notimpl(["postgres"], raises=OperationNotDefinedError)
 @pytest.mark.parametrize("field", ["a", "b", "c"])
 @pytest.mark.notyet(
-    ["clickhouse"], reason="clickhouse doesn't support nullable nested types"
+    ["clickhouse"],
+    reason="clickhouse doesn't support nullable nested types",
+    raises=OperationNotDefinedError,
 )
 def test_null_literal(con, field):
     query = _NULL_STRUCT_LITERAL[field]
@@ -75,7 +78,7 @@ def test_null_literal(con, field):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["dask", "pandas", "postgres"])
+@pytest.mark.notimpl(["dask", "pandas", "postgres"], raises=OperationNotDefinedError)
 def test_struct_column(alltypes, df):
     t = alltypes
     expr = ibis.struct(dict(a=t.string_col, b=1, c=t.bigint_col)).name("s")

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -29,7 +29,7 @@ from ibis.backends.pandas.execution.temporal import day_name
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_date_extract(backend, alltypes, df, attr, expr_fn):
     expr = getattr(expr_fn(alltypes.timestamp_col), attr)()
     expected = getattr(df.timestamp_col.dt, attr).astype('int32')
@@ -47,7 +47,7 @@ def test_date_extract(backend, alltypes, df, attr, expr_fn):
         'day',
         param(
             'day_of_year',
-            marks=pytest.mark.notimpl(["impala"]),
+            marks=pytest.mark.notimpl(["impala"], raises=com.OperationNotDefinedError),
         ),
         'quarter',
         'hour',
@@ -55,7 +55,7 @@ def test_date_extract(backend, alltypes, df, attr, expr_fn):
         'second',
     ],
 )
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract(backend, alltypes, df, attr):
     method = getattr(alltypes.timestamp_col, attr)
     expr = method().name(attr)
@@ -79,7 +79,9 @@ def test_timestamp_extract(backend, alltypes, df, attr):
             methodcaller('millisecond'),
             359,
             id='millisecond',
-            marks=[pytest.mark.notimpl(["pyspark"])],
+            marks=[
+                pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
+            ],
         ),
         param(
             lambda x: x.day_of_week.index(),
@@ -90,18 +92,18 @@ def test_timestamp_extract(backend, alltypes, df, attr):
             lambda x: x.day_of_week.full_name(),
             'Tuesday',
             id='day_of_week_full_name',
-            marks=pytest.mark.notimpl(["mssql"]),
+            marks=pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError),
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract_literal(con, func, expected):
     value = ibis.timestamp('2015-09-01 14:48:05.359')
     assert con.execute(func(value).name("tmp")) == expected
 
 
-@pytest.mark.notimpl(["datafusion"])
-@pytest.mark.notyet(["sqlite", "pyspark"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(["sqlite", "pyspark"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract_milliseconds(backend, alltypes, df):
     expr = alltypes.timestamp_col.millisecond().name("millisecond")
     result = expr.execute()
@@ -111,7 +113,7 @@ def test_timestamp_extract_milliseconds(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract_epoch_seconds(backend, alltypes, df):
     expr = alltypes.timestamp_col.epoch_seconds().name('tmp')
     result = expr.execute()
@@ -122,7 +124,7 @@ def test_timestamp_extract_epoch_seconds(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract_week_of_year(backend, alltypes, df):
     expr = alltypes.timestamp_col.week_of_year().name('tmp')
     result = expr.execute()
@@ -147,22 +149,37 @@ PANDAS_UNITS = {
         param(
             'W',
             marks=[
-                pytest.mark.notimpl(["impala", "mysql", "sqlite"]),
+                pytest.mark.notimpl(
+                    ["impala", "mysql", "sqlite"], raises=com.OperationNotDefinedError
+                ),
             ],
         ),
-        param('h', marks=pytest.mark.notimpl(["sqlite"])),
-        param('m', marks=pytest.mark.notimpl(["sqlite"])),
-        param('s', marks=pytest.mark.notimpl(["impala", "sqlite"])),
+        param(
+            'h',
+            marks=pytest.mark.notimpl(["sqlite"], raises=com.OperationNotDefinedError),
+        ),
+        param(
+            'm',
+            marks=pytest.mark.notimpl(["sqlite"], raises=com.OperationNotDefinedError),
+        ),
+        param(
+            's',
+            marks=pytest.mark.notimpl(
+                ["impala", "sqlite"], raises=com.OperationNotDefinedError
+            ),
+        ),
         param(
             'ms',
             marks=pytest.mark.notimpl(
-                ["clickhouse", "impala", "mysql", "pyspark", "sqlite"]
+                ["clickhouse", "impala", "mysql", "pyspark", "sqlite"],
+                raises=com.OperationNotDefinedError,
             ),
         ),
         param(
             'us',
             marks=pytest.mark.notimpl(
-                ["clickhouse", "impala", "mysql", "pyspark", "sqlite", "trino"]
+                ["clickhouse", "impala", "mysql", "pyspark", "sqlite", "trino"],
+                raises=com.OperationNotDefinedError,
             ),
         ),
         param(
@@ -181,13 +198,16 @@ PANDAS_UNITS = {
                     "polars",
                     "trino",
                     "mssql",
-                ]
+                ],
+                raises=com.OperationNotDefinedError,
             ),
         ),
     ],
 )
-@pytest.mark.broken(["polars"], reason="snaps to the UNIX epoch")
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.broken(
+    ["polars"], reason="snaps to the UNIX epoch", raises=com.OperationNotDefinedError
+)
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_timestamp_truncate(backend, alltypes, df, unit):
     expr = alltypes.timestamp_col.truncate(unit).name('tmp')
 
@@ -213,13 +233,17 @@ def test_timestamp_truncate(backend, alltypes, df, unit):
         param(
             'W',
             marks=[
-                pytest.mark.notimpl(["impala", "mysql", "sqlite"]),
+                pytest.mark.notimpl(
+                    ["impala", "mysql", "sqlite"], raises=com.OperationNotDefinedError
+                ),
             ],
         ),
     ],
 )
-@pytest.mark.broken(["polars"], reason="snaps to the UNIX epoch")
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.broken(
+    ["polars"], reason="snaps to the UNIX epoch", raises=com.OperationNotDefinedError
+)
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_date_truncate(backend, alltypes, df, unit):
     expr = alltypes.timestamp_col.date().truncate(unit).name('tmp')
 
@@ -243,38 +267,57 @@ def test_date_truncate(backend, alltypes, df, unit):
             'Y',
             pd.offsets.DateOffset,
             # TODO - DateOffset - #2553
-            marks=pytest.mark.notimpl(["bigquery", 'dask', 'polars']),
+            marks=pytest.mark.notimpl(
+                ["bigquery", 'dask', 'polars'], raises=com.UnsupportedOperationError
+            ),
         ),
         param('Q', pd.offsets.DateOffset, marks=pytest.mark.xfail),
         param(
             'M',
             pd.offsets.DateOffset,
             # TODO - DateOffset - #2553
-            marks=pytest.mark.notimpl(["bigquery", 'dask', 'polars']),
+            marks=pytest.mark.notimpl(
+                ["bigquery", 'dask', 'polars'], raises=com.UnsupportedOperationError
+            ),
         ),
         param(
             'W',
             pd.offsets.DateOffset,
             # TODO - DateOffset - #2553
-            marks=pytest.mark.notimpl(['bigquery', 'dask']),
+            marks=pytest.mark.notimpl(
+                ['bigquery', 'dask'], raises=com.UnsupportedOperationError
+            ),
         ),
-        param('D', pd.offsets.DateOffset, marks=pytest.mark.notimpl(["bigquery"])),
+        param(
+            'D',
+            pd.offsets.DateOffset,
+            marks=pytest.mark.notimpl(
+                ["bigquery"], raises=com.UnsupportedOperationError
+            ),
+        ),
         param('h', pd.Timedelta),
         param('m', pd.Timedelta),
         param('s', pd.Timedelta),
         param(
             'ms',
             pd.Timedelta,
-            marks=pytest.mark.notimpl(["clickhouse", "mysql"]),
+            marks=pytest.mark.notimpl(
+                ["clickhouse", "mysql"], raises=com.UnsupportedOperationError
+            ),
         ),
         param(
             'us',
             pd.Timedelta,
-            marks=pytest.mark.notimpl(["clickhouse"]),
+            marks=pytest.mark.notimpl(
+                ["clickhouse"], raises=com.UnsupportedOperationError
+            ),
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "pyspark", "sqlite", "snowflake", "mssql", "trino"])
+@pytest.mark.notimpl(
+    ["datafusion", "pyspark", "sqlite", "snowflake", "mssql", "trino"],
+    raises=com.OperationNotDefinedError,
+)
 def test_integer_to_interval_timestamp(
     backend, con, alltypes, df, unit, displacement_type
 ):
@@ -313,7 +356,8 @@ def test_integer_to_interval_timestamp(
         "polars",
         "mssql",
         "trino",
-    ]
+    ],
+    raises=com.OperationNotDefinedError,
 )
 def test_integer_to_interval_date(backend, con, alltypes, df, unit):
     interval = alltypes.int_col.to_interval(unit=unit)
@@ -349,7 +393,9 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
             lambda t, _: t.timestamp_col + ibis.interval(days=4),
             lambda t, _: t.timestamp_col + pd.Timedelta(days=4),
             id='timestamp-add-interval',
-            marks=pytest.mark.notimpl(["bigquery"]),
+            marks=pytest.mark.notimpl(
+                ["bigquery"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t, _: t.timestamp_col
@@ -367,14 +413,17 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
                     "pandas",
                     "postgres",
                     "snowflake",
-                ]
+                ],
+                raises=com.OperationNotDefinedError,
             ),
         ),
         param(
             lambda t, _: t.timestamp_col - ibis.interval(days=17),
             lambda t, _: t.timestamp_col - pd.Timedelta(days=17),
             id='timestamp-subtract-interval',
-            marks=pytest.mark.notimpl(["bigquery"]),
+            marks=pytest.mark.notimpl(
+                ["bigquery"], raises=com.OperationNotDefinedError
+            ),
         ),
         param(
             lambda t, _: t.timestamp_col.date() + ibis.interval(days=4),
@@ -394,17 +443,24 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
                 )
             ).dt.floor("s"),
             id='timestamp-subtract-timestamp',
-            marks=pytest.mark.notimpl(["bigquery", "pyspark", "snowflake"]),
+            marks=pytest.mark.notimpl(
+                ["bigquery", "pyspark", "snowflake"],
+                raises=com.OperationNotDefinedError,
+            ),
         ),
         param(
             lambda t, _: t.timestamp_col.date() - ibis.date(date_value),
             lambda t, _: t.timestamp_col.dt.floor('d') - date_value,
             id='date-subtract-date',
-            marks=pytest.mark.notimpl(["bigquery", "pyspark"]),
+            marks=pytest.mark.notimpl(
+                ["bigquery", "pyspark"], raises=com.OperationNotDefinedError
+            ),
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "sqlite", "mssql", "trino"])
+@pytest.mark.notimpl(
+    ["datafusion", "sqlite", "mssql", "trino"], raises=com.OperationNotDefinedError
+)
 def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
     expr = expr_fn(alltypes, backend).name('tmp')
     expected = expected_fn(df, backend)
@@ -425,17 +481,49 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
         ('36500d', plus),
         ('5W', plus),
         ('3d', plus),
-        param('1.5d', plus, marks=pytest.mark.notimpl(["mysql"])),
-        param('2h', plus, marks=pytest.mark.notimpl(["mysql"])),
-        param('3m', plus, marks=pytest.mark.notimpl(["mysql"])),
-        param('10s', plus, marks=pytest.mark.notimpl(["mysql"])),
+        param(
+            '1.5d',
+            plus,
+            marks=pytest.mark.notimpl(["mysql"], raises=com.UnsupportedOperationError),
+        ),
+        param(
+            '2h',
+            plus,
+            marks=pytest.mark.notimpl(["mysql"], raises=com.UnsupportedOperationError),
+        ),
+        param(
+            '3m',
+            plus,
+            marks=pytest.mark.notimpl(["mysql"], raises=com.UnsupportedOperationError),
+        ),
+        param(
+            '10s',
+            plus,
+            marks=pytest.mark.notimpl(["mysql"], raises=com.UnsupportedOperationError),
+        ),
         ('36500d', minus),
         ('5W', minus),
         ('3d', minus),
-        param('1.5d', minus, marks=pytest.mark.notimpl(["mysql"])),
-        param('2h', minus, marks=pytest.mark.notimpl(["mysql"])),
-        param('3m', minus, marks=pytest.mark.notimpl(["mysql"])),
-        param('10s', minus, marks=pytest.mark.notimpl(["mysql"])),
+        param(
+            '1.5d',
+            minus,
+            marks=pytest.mark.notimpl(["mysql"], raises=com.UnsupportedOperationError),
+        ),
+        param(
+            '2h',
+            minus,
+            marks=pytest.mark.notimpl(["mysql"], raises=com.UnsupportedOperationError),
+        ),
+        param(
+            '3m',
+            minus,
+            marks=pytest.mark.notimpl(["mysql"], raises=com.UnsupportedOperationError),
+        ),
+        param(
+            '10s',
+            minus,
+            marks=pytest.mark.notimpl(["mysql"], raises=com.UnsupportedOperationError),
+        ),
     ],
 )
 @pytest.mark.notimpl(
@@ -449,7 +537,8 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
         "polars",
         "mssql",
         "trino",
-    ]
+    ],
+    raises=com.OperationNotDefinedError,
 )
 def test_temporal_binop_pandas_timedelta(
     backend, con, alltypes, df, timedelta, temporal_fn
@@ -464,7 +553,7 @@ def test_temporal_binop_pandas_timedelta(
 
 
 @pytest.mark.parametrize("func_name", ["gt", "ge", "lt", "le", "eq", "ne"])
-@pytest.mark.notimpl(["bigquery"])
+@pytest.mark.notimpl(["bigquery"], raises=com.OperationNotDefinedError)
 def test_timestamp_comparison_filter(backend, con, alltypes, df, func_name):
     ts = pd.Timestamp('20100302', tz="UTC").to_pydatetime()
 
@@ -483,15 +572,35 @@ def test_timestamp_comparison_filter(backend, con, alltypes, df, func_name):
 @pytest.mark.parametrize(
     "func_name",
     [
-        param("gt", marks=pytest.mark.notimpl(["dask", "pandas"])),
-        param("ge", marks=pytest.mark.notimpl(["dask", "pandas"])),
-        param("lt", marks=pytest.mark.notimpl(["dask", "pandas"])),
-        param("le", marks=pytest.mark.notimpl(["dask", "pandas"])),
+        param(
+            "gt",
+            marks=pytest.mark.notimpl(
+                ["dask", "pandas"], raises=com.OperationNotDefinedError
+            ),
+        ),
+        param(
+            "ge",
+            marks=pytest.mark.notimpl(
+                ["dask", "pandas"], raises=com.OperationNotDefinedError
+            ),
+        ),
+        param(
+            "lt",
+            marks=pytest.mark.notimpl(
+                ["dask", "pandas"], raises=com.OperationNotDefinedError
+            ),
+        ),
+        param(
+            "le",
+            marks=pytest.mark.notimpl(
+                ["dask", "pandas"], raises=com.OperationNotDefinedError
+            ),
+        ),
         "eq",
         "ne",
     ],
 )
-@pytest.mark.notimpl(["bigquery"])
+@pytest.mark.notimpl(["bigquery"], raises=com.OperationNotDefinedError)
 def test_timestamp_comparison_filter_numpy(backend, con, alltypes, df, func_name):
     ts = np.datetime64('2010-03-02 00:00:00.000123')
 
@@ -509,7 +618,10 @@ def test_timestamp_comparison_filter_numpy(backend, con, alltypes, df, func_name
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["datafusion", "sqlite", "snowflake", "mssql", "trino"])
+@pytest.mark.notimpl(
+    ["datafusion", "sqlite", "snowflake", "mssql", "trino"],
+    raises=com.OperationNotDefinedError,
+)
 def test_interval_add_cast_scalar(backend, alltypes):
     timestamp_date = alltypes.timestamp_col.date()
     delta = ibis.literal(10).cast("interval('D')")
@@ -522,7 +634,10 @@ def test_interval_add_cast_scalar(backend, alltypes):
 @pytest.mark.never(
     ['pyspark'], reason="PySpark does not support casting columns to intervals"
 )
-@pytest.mark.notimpl(["datafusion", "sqlite", "snowflake", "mssql", "trino"])
+@pytest.mark.notimpl(
+    ["datafusion", "sqlite", "snowflake", "mssql", "trino"],
+    raises=com.OperationNotDefinedError,
+)
 def test_interval_add_cast_column(backend, alltypes, df):
     timestamp_date = alltypes.timestamp_col.date()
     delta = alltypes.bigint_col.cast("interval('D')")
@@ -568,7 +683,8 @@ def test_interval_add_cast_column(backend, alltypes, df):
                         "pyspark",
                         "snowflake",
                         "polars",
-                    ]
+                    ],
+                    raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(["duckdb", "impala"]),
             ],
@@ -576,7 +692,7 @@ def test_interval_add_cast_column(backend, alltypes, df):
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "mssql"])
+@pytest.mark.notimpl(["datafusion", "mssql"], raises=com.OperationNotDefinedError)
 def test_strftime(backend, alltypes, df, expr_fn, pandas_pattern):
     expr = expr_fn(alltypes)
     expected = df.timestamp_col.dt.strftime(pandas_pattern).rename("formatted")
@@ -594,19 +710,29 @@ unit_factors = {'s': 10**9, 'ms': 10**6, 'us': 10**3, 'ns': 1}
         's',
         param(
             'ms',
-            marks=pytest.mark.notimpl(["clickhouse", "pyspark"]),
+            marks=pytest.mark.notimpl(
+                ["clickhouse", "pyspark"], raises=com.UnsupportedOperationError
+            ),
         ),
         param(
             'us',
-            marks=pytest.mark.notimpl(["clickhouse", "duckdb", "pyspark", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["clickhouse", "duckdb", "pyspark", "mssql"],
+                raises=com.UnsupportedOperationError,
+            ),
         ),
         param(
             'ns',
-            marks=pytest.mark.notimpl(["clickhouse", "duckdb", "pyspark", "mssql"]),
+            marks=pytest.mark.notimpl(
+                ["clickhouse", "duckdb", "pyspark", "mssql"],
+                raises=com.UnsupportedOperationError,
+            ),
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "mysql", "postgres", "sqlite"])
+@pytest.mark.notimpl(
+    ["datafusion", "mysql", "postgres", "sqlite"], raises=com.OperationNotDefinedError
+)
 def test_integer_to_timestamp(backend, con, unit):
     backend_unit = backend.returned_timestamp_unit
     factor = unit_factors[unit]
@@ -655,7 +781,8 @@ def test_integer_to_timestamp(backend, con, unit):
         'impala',
         'datafusion',
         'mssql',
-    ]
+    ],
+    raises=com.OperationNotDefinedError,
 )
 def test_string_to_timestamp(alltypes, fmt):
     table = alltypes
@@ -679,7 +806,9 @@ def test_string_to_timestamp(alltypes, fmt):
         param('2017-01-07', 5, 'Saturday', id="saturday"),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "impala", "mssql"])
+@pytest.mark.notimpl(
+    ["datafusion", "impala", "mssql"], raises=com.OperationNotDefinedError
+)
 def test_day_of_week_scalar(con, date, expected_index, expected_day):
     expr = ibis.literal(date).cast(dt.date)
     result_index = con.execute(expr.day_of_week.index().name("tmp"))
@@ -689,7 +818,7 @@ def test_day_of_week_scalar(con, date, expected_index, expected_day):
     assert result_day.lower() == expected_day.lower()
 
 
-@pytest.mark.notimpl(["datafusion", "mssql"])
+@pytest.mark.notimpl(["datafusion", "mssql"], raises=com.OperationNotDefinedError)
 def test_day_of_week_column(backend, alltypes, df):
     expr = alltypes.timestamp_col.day_of_week
 
@@ -722,7 +851,7 @@ def test_day_of_week_column(backend, alltypes, df):
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_day_of_week_column_group_by(
     backend, alltypes, df, day_of_week_expr, day_of_week_pandas
 ):
@@ -744,7 +873,7 @@ def test_day_of_week_column_group_by(
     backend.assert_frame_equal(result, expected, check_dtype=False)
 
 
-@pytest.mark.notimpl(["datafusion", "mssql"])
+@pytest.mark.notimpl(["datafusion", "mssql"], raises=com.OperationNotDefinedError)
 def test_now(con):
     expr = ibis.now()
     result = con.execute(expr.name("tmp"))
@@ -756,8 +885,10 @@ def test_now(con):
     assert result_strftime == expected_strftime
 
 
-@pytest.mark.notimpl(["dask"], reason="Limit #2553")
-@pytest.mark.notimpl(["datafusion", "polars"])
+@pytest.mark.notimpl(
+    ["dask"], reason="Limit #2553", raises=com.OperationNotDefinedError
+)
+@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
 def test_now_from_projection(alltypes):
     n = 5
     expr = alltypes[[ibis.now().name('ts')]].limit(n)
@@ -785,8 +916,11 @@ DATE_BACKEND_TYPES = {
 }
 
 
-@pytest.mark.notimpl(["pandas", "datafusion", "mysql", "dask", "pyspark"])
-@pytest.mark.notyet(["impala"])
+@pytest.mark.notimpl(
+    ["pandas", "datafusion", "mysql", "dask", "pyspark"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(["impala"], raises=com.OperationNotDefinedError)
 def test_date_literal(con, backend):
     expr = ibis.date(2022, 2, 4)
     result = con.execute(expr)
@@ -809,8 +943,11 @@ TIMESTAMP_BACKEND_TYPES = {
 }
 
 
-@pytest.mark.notimpl(["pandas", "datafusion", "mysql", "dask", "pyspark"])
-@pytest.mark.notyet(["impala"])
+@pytest.mark.notimpl(
+    ["pandas", "datafusion", "mysql", "dask", "pyspark"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(["impala"], raises=com.OperationNotDefinedError)
 def test_timestamp_literal(con, backend):
     expr = ibis.timestamp(2022, 2, 4, 16, 20, 0)
     result = con.execute(expr)
@@ -836,9 +973,10 @@ TIMESTAMP_TIMEZONE_BACKEND_TYPES = {
 
 
 @pytest.mark.notimpl(
-    ["pandas", "datafusion", "mysql", "dask", "pyspark", 'duckdb', 'sqlite']
+    ["pandas", "datafusion", "mysql", "dask", "pyspark", 'duckdb', 'sqlite'],
+    raises=com.OperationNotDefinedError,
 )
-@pytest.mark.notyet(["impala"])
+@pytest.mark.notyet(["impala"], raises=com.OperationNotDefinedError)
 @pytest.mark.parametrize(
     ('timezone', 'expected_result'),
     [
@@ -914,7 +1052,7 @@ TIME_BACKEND_TYPES = {
         "polars",
     ]
 )
-@pytest.mark.notyet(["clickhouse", "impala"])
+@pytest.mark.notyet(["clickhouse", "impala"], raises=com.OperationNotDefinedError)
 def test_time_literal(con, backend):
     expr = ibis.time(16, 20, 0)
     result = con.execute(expr)
@@ -980,8 +1118,11 @@ def test_interval_literal(con, backend):
         assert con.execute(expr.typeof()) == INTERVAL_BACKEND_TYPES[backend_name]
 
 
-@pytest.mark.notimpl(["pandas", "datafusion", "mysql", "dask", "pyspark"])
-@pytest.mark.notyet(["impala"])
+@pytest.mark.notimpl(
+    ["pandas", "datafusion", "mysql", "dask", "pyspark"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(["impala"], raises=com.OperationNotDefinedError)
 def test_date_column_from_ymd(con, alltypes, df):
     c = alltypes.timestamp_col
     expr = ibis.date(c.year(), c.month(), c.day())
@@ -992,8 +1133,11 @@ def test_date_column_from_ymd(con, alltypes, df):
     tm.assert_series_equal(golden, result.timestamp_col)
 
 
-@pytest.mark.notimpl(["pandas", "datafusion", "mysql", "dask", "pyspark"])
-@pytest.mark.notyet(["impala"])
+@pytest.mark.notimpl(
+    ["pandas", "datafusion", "mysql", "dask", "pyspark"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(["impala"], raises=com.OperationNotDefinedError)
 def test_timestamp_column_from_ymdhms(con, alltypes, df):
     c = alltypes.timestamp_col
     expr = ibis.timestamp(
@@ -1006,7 +1150,7 @@ def test_timestamp_column_from_ymdhms(con, alltypes, df):
     tm.assert_series_equal(golden, result.timestamp_col)
 
 
-@pytest.mark.notimpl(["datafusion", "impala"])
+@pytest.mark.notimpl(["datafusion", "impala"], raises=com.OperationNotDefinedError)
 def test_date_scalar_from_iso(con):
     expr = ibis.literal('2022-02-24')
     expr2 = ibis.date(expr)
@@ -1015,7 +1159,9 @@ def test_date_scalar_from_iso(con):
     assert result.strftime('%Y-%m-%d') == '2022-02-24'
 
 
-@pytest.mark.notimpl(["datafusion", "impala", "mssql"])
+@pytest.mark.notimpl(
+    ["datafusion", "impala", "mssql"], raises=com.OperationNotDefinedError
+)
 def test_date_column_from_iso(con, alltypes, df):
     expr = (
         alltypes.year.cast('string')
@@ -1031,8 +1177,8 @@ def test_date_column_from_iso(con, alltypes, df):
     tm.assert_series_equal(golden.rename('tmp'), actual.rename('tmp'))
 
 
-@pytest.mark.notimpl(["datafusion"])
-@pytest.mark.notyet(["pyspark"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(["pyspark"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract_milliseconds_with_big_value(con):
     timestamp = ibis.timestamp("2021-01-01 01:30:59.333456")
     millis = timestamp.millisecond()
@@ -1040,7 +1186,7 @@ def test_timestamp_extract_milliseconds_with_big_value(con):
     assert result == 333
 
 
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_integer_cast_to_timestamp_column(backend, alltypes, df):
     expr = alltypes.int_col.cast("timestamp")
     expected = pd.to_datetime(df.int_col, unit="s").rename(expr.get_name())
@@ -1048,7 +1194,7 @@ def test_integer_cast_to_timestamp_column(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_integer_cast_to_timestamp_scalar(alltypes, df):
     expr = alltypes.int_col.min().cast("timestamp")
     result = expr.execute()
@@ -1093,8 +1239,12 @@ def build_date_col(t):
     ).cast("date")
 
 
-@pytest.mark.notimpl(["datafusion", "mssql"])
-@pytest.mark.notyet(["impala"], reason="impala doesn't support dates")
+@pytest.mark.notimpl(["datafusion", "mssql"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(
+    ["impala"],
+    reason="impala doesn't support dates",
+    raises=com.OperationNotDefinedError,
+)
 @pytest.mark.parametrize(
     ("left_fn", "right_fn"),
     [
@@ -1125,8 +1275,14 @@ def test_timestamp_date_comparison(backend, alltypes, df, left_fn, right_fn):
     backend.assert_series_equal(result, expected)
 
 
-@pytest.mark.broken(["clickhouse"], reason="returns incorrect results")
-@pytest.mark.notimpl(["polars", "datafusion", "pyspark"])
+@pytest.mark.broken(
+    ["clickhouse"],
+    reason="returns incorrect results",
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notimpl(
+    ["polars", "datafusion", "pyspark"], raises=com.OperationNotDefinedError
+)
 def test_large_timestamp(con):
     huge_timestamp = datetime.datetime(year=4567, month=1, day=1)
     expr = ibis.timestamp("4567-01-01 00:00:00")
@@ -1142,7 +1298,11 @@ def test_large_timestamp(con):
             3,
             "ms",
             id="ms",
-            marks=pytest.mark.broken(["mssql"], reason="incorrect result"),
+            marks=pytest.mark.broken(
+                ["mssql"],
+                reason="incorrect result",
+                raises=com.OperationNotDefinedError,
+            ),
         ),
         param(
             '2023-01-07 13:20:05.561021',
@@ -1150,8 +1310,16 @@ def test_large_timestamp(con):
             "us",
             id="us",
             marks=[
-                pytest.mark.broken(["mssql"], reason="incorrect result"),
-                pytest.mark.notyet(["sqlite"], reason="doesn't support microseconds"),
+                pytest.mark.broken(
+                    ["mssql"],
+                    reason="incorrect result",
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notyet(
+                    ["sqlite"],
+                    reason="doesn't support microseconds",
+                    raises=com.OperationNotDefinedError,
+                ),
             ],
         ),
         param(
@@ -1172,7 +1340,7 @@ def test_large_timestamp(con):
         ),
     ],
 )
-@pytest.mark.notyet(["mysql"])
+@pytest.mark.notyet(["mysql"], raises=com.OperationNotDefinedError)
 def test_timestamp_precision_output(con, ts, scale, unit):
     dtype = dt.Timestamp(scale=scale)
     expr = ibis.literal(ts).cast(dtype)

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -6,6 +6,7 @@ from pytest import param
 
 import ibis
 from ibis.backends.tests.test_vectorized_udf import calc_mean, create_demean_struct_udf
+from ibis.common.exceptions import OperationNotDefinedError
 from ibis.config import option_context
 
 pytestmark = pytest.mark.notimpl(
@@ -53,7 +54,7 @@ def ctx_col():
         yield
 
 
-@pytest.mark.notimpl(["dask", "duckdb"])
+@pytest.mark.notimpl(["dask", "duckdb"], raises=OperationNotDefinedError)
 @pytest.mark.min_version(pyspark="3.1")
 @pytest.mark.parametrize(
     'window',
@@ -85,7 +86,7 @@ def test_context_adjustment_window_udf(alltypes, context, window, ctx_col):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["dask", "duckdb"])
+@pytest.mark.notimpl(["dask", "duckdb"], raises=OperationNotDefinedError)
 def test_context_adjustment_filter_before_window(alltypes, context, ctx_col):
     window = ibis.trailing_window(ibis.interval(days=3), order_by=ORDER_BY_COL)
 
@@ -101,7 +102,7 @@ def test_context_adjustment_filter_before_window(alltypes, context, ctx_col):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["duckdb", "pyspark"])
+@pytest.mark.notimpl(["duckdb", "pyspark"], raises=OperationNotDefinedError)
 def test_context_adjustment_multi_col_udf_non_grouped(
     alltypes,
     context,

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -252,7 +252,7 @@ def test_elementwise_udf_mutate(udf_backend, udf_alltypes, udf_df, udf):
     udf_backend.assert_series_equal(result['incremented'], expected['incremented'])
 
 
-@pytest.mark.notimpl(["pyspark"])
+@pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
 def test_analytic_udf(udf_backend, udf_alltypes, udf_df):
     calc_zscore_udf = create_calc_zscore_udf(result_formatter=lambda v: v)
     result = calc_zscore_udf(udf_alltypes['double_col']).execute()
@@ -261,7 +261,7 @@ def test_analytic_udf(udf_backend, udf_alltypes, udf_df):
 
 
 @pytest.mark.parametrize('udf', calc_zscore_udfs)
-@pytest.mark.notimpl(["pyspark"])
+@pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
 def test_analytic_udf_mutate(udf_backend, udf_alltypes, udf_df, udf):
     expr = udf_alltypes.mutate(zscore=udf(udf_alltypes['double_col']))
     result = expr.execute()
@@ -488,7 +488,9 @@ def test_elementwise_udf_overwrite_destruct_and_assign(udf_backend, udf_alltypes
 
 
 @pytest.mark.min_version(pyspark="3.1")
-@pytest.mark.parametrize('method', ['destructure', 'unpack'])
+@pytest.mark.parametrize(
+    'method', ['destructure', 'unpack'], raises=com.OperationNotDefinedError
+)
 def test_elementwise_udf_destructure_exact_once(
     udf_backend, udf_alltypes, method, tmp_path
 ):
@@ -570,7 +572,7 @@ def test_elementwise_udf_struct(udf_backend, udf_alltypes):
 
 
 @pytest.mark.parametrize('udf', demean_struct_udfs)
-@pytest.mark.notimpl(["pyspark"])
+@pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
 def test_analytic_udf_destruct(udf_backend, udf_alltypes, udf):
     w = ibis.window(preceding=None, following=None, group_by='year')
 
@@ -585,7 +587,7 @@ def test_analytic_udf_destruct(udf_backend, udf_alltypes, udf):
     udf_backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["pyspark"])
+@pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
 def test_analytic_udf_destruct_no_group_by(udf_backend, udf_alltypes):
     w = ibis.window(preceding=None, following=None)
 
@@ -606,7 +608,7 @@ def test_analytic_udf_destruct_no_group_by(udf_backend, udf_alltypes):
     udf_backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["pyspark"])
+@pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
 def test_analytic_udf_destruct_overwrite(udf_backend, udf_alltypes):
     w = ibis.window(preceding=None, following=None, group_by='year')
 
@@ -632,7 +634,7 @@ def test_analytic_udf_destruct_overwrite(udf_backend, udf_alltypes):
 
 
 @pytest.mark.parametrize('udf', mean_struct_udfs)
-@pytest.mark.notimpl(["pyspark"])
+@pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
 def test_reduction_udf_destruct_group_by(udf_backend, udf_alltypes, udf):
     result = (
         udf_alltypes.group_by('year')
@@ -654,7 +656,7 @@ def test_reduction_udf_destruct_group_by(udf_backend, udf_alltypes, udf):
     udf_backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["pyspark"])
+@pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
 def test_reduction_udf_destruct_no_group_by(udf_backend, udf_alltypes):
     mean_struct_udf = create_mean_struct_udf(result_formatter=lambda v1, v2: (v1, v2))
     result = udf_alltypes.aggregate(
@@ -670,7 +672,7 @@ def test_reduction_udf_destruct_no_group_by(udf_backend, udf_alltypes):
     udf_backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["pyspark"])
+@pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
 def test_reduction_udf_destruct_no_group_by_overwrite(udf_backend, udf_alltypes):
     result = udf_alltypes.aggregate(
         overwrite_struct_reduction(
@@ -692,7 +694,7 @@ def test_reduction_udf_destruct_no_group_by_overwrite(udf_backend, udf_alltypes)
 
 
 # TODO - windowing - #2553
-@pytest.mark.notimpl(["dask", "pyspark"])
+@pytest.mark.notimpl(["dask", "pyspark"], raises=com.OperationNotDefinedError)
 def test_reduction_udf_destruct_window(udf_backend, udf_alltypes):
     win = ibis.window(
         preceding=ibis.interval(hours=2),


### PR DESCRIPTION
Tests that do not check the type of exceptions are dangerous because they can be false negatives.

For example, `test_sa_default_numeric_precision_and_scale` was marked as xfail, but all we had to do was add the default scale and precision information for the test to pass.

Additionally, it forces the behavior of backends to be unified even for negative cases. Now the backends throw different exceptions if the backend doesn't support the operation. Sometimes it's `ValueError`, and sometimes `TypeError`, and sometimes `NotImplemented`, sometimes `UnsupportedOperationError` (prefered), and sometimes other types yet.