### PR TITLE
docs: render dunder methods

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ plugins:
             docstring_style: numpy
             filters:
               - "!^_"
-              - "^__init__$"
+              - "__.+"
               - "!^ast_schema"
               - "!^backend_table_type"
               - "!^column$"


### PR DESCRIPTION
This PR enables rendering dunder methods in API documentation.

Closes #5424.