### PR TITLE
feat(api): allow `isin` to work across expressions that don't share a table

### DIFF
--- a/ibis/backends/impala/tests/snapshots/test_sql/test_nested_join_multiple_ctes/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_nested_join_multiple_ctes/out.sql
@@ -1,25 +1,22 @@
 WITH t0 AS (
-  SELECT t3.`userid`, t3.`movieid`, t3.`rating`,
-         CAST(t3.`timestamp` AS timestamp) AS `datetime`
-  FROM ratings t3
+  SELECT t2.`userid`, t2.`movieid`, t2.`rating`,
+         CAST(t2.`timestamp` AS timestamp) AS `datetime`
+  FROM ratings t2
 ),
 t1 AS (
-  SELECT t0.*, t4.`title`
+  SELECT t0.*, t3.`title`
   FROM t0
-    INNER JOIN movies t4
-      ON t0.`movieid` = t4.`movieid`
+    INNER JOIN movies t3
+      ON t0.`movieid` = t3.`movieid`
 )
-SELECT t2.*
-FROM (
-  SELECT t1.*
-  FROM t1
-  WHERE (t1.`userid` = 118205) AND
-        (extract(t1.`datetime`, 'year') > 2001)
-) t2
-WHERE t2.`movieid` IN (
-  SELECT t3.`movieid`
+SELECT t1.*
+FROM t1
+WHERE (t1.`userid` = 118205) AND
+      (extract(t1.`datetime`, 'year') > 2001) AND
+      (t1.`movieid` IN (
+  SELECT t2.`movieid`
   FROM (
-    SELECT t4.`movieid`
+    SELECT t3.`movieid`
     FROM (
       SELECT t1.*
       FROM t1
@@ -27,6 +24,6 @@ WHERE t2.`movieid` IN (
             (extract(t1.`datetime`, 'year') > 2001) AND
             (t1.`userid` = 118205) AND
             (extract(t1.`datetime`, 'year') < 2009)
-    ) t4
-  ) t3
-)
+    ) t3
+  ) t2
+))

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -159,6 +159,12 @@ def find_immediate_parent_tables(input_node, keep_input=True):
                 return g.halt, node
             else:
                 return g.proceed, None
+
+        # HACK: special case ops.Contains to only consider the needle's base
+        # table, since that's the only expression that matters for determining
+        # cardinality
+        elif isinstance(node, ops.Contains):
+            return [node.value], None
         else:
             return g.proceed, None
 
@@ -646,6 +652,8 @@ def _find_projections(node):
         return g.proceed, None
     elif isinstance(node, ops.TableNode):
         return g.halt, node
+    elif isinstance(node, ops.Contains):
+        return [node.value], None
     else:
         return g.proceed, None
 


### PR DESCRIPTION
This PR allows `isin` to work for column expressions that do not share a child table. Closes #5228.