### PR TITLE
feat(io): add to_parquet, to_csv to backends

### DIFF
--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -212,6 +212,21 @@ class Backend(BasePandasBackend):
         else:
             return pa.scalar(output)
 
+    def to_pyarrow_batches(
+        self,
+        expr: ir.Expr,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
+        chunk_size: int = 1000000,
+        **kwargs: Any,
+    ) -> pa.ipc.RecordBatchReader:
+        pa = self._import_pyarrow()
+        pa_table = self.to_pyarrow(expr, params=params, limit=limit)
+        return pa.RecordBatchReader.from_batches(
+            pa_table.schema, pa_table.to_batches(max_chunksize=chunk_size)
+        )
+
     def execute(self, query, params=None, limit='default', **kwargs):
         from ibis.backends.pandas.core import execute_and_reset
 

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -273,10 +273,17 @@ class Backend(BaseBackend):
         self,
         expr: ir.Expr,
         params: Mapping[ir.Expr, object] = None,
-        limit: str = 'default',
+        limit: int | None = None,
         **kwargs: Any,
     ):
-        df = self.compile(expr, params=params).collect()
+        lf = self.compile(expr, params=params, **kwargs)
+        if limit == "default":
+            limit = ibis.options.sql.default_limit
+        if limit is not None:
+            df = lf.fetch(limit)
+        else:
+            df = lf.collect()
+
         if isinstance(expr, ir.Table):
             return df.to_pandas()
         elif isinstance(expr, ir.Column):

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -400,6 +400,68 @@ class Expr(Immutable):
             self, params=params, limit=limit, **kwargs
         )
 
+    @experimental
+    def to_parquet(
+        self,
+        path: str | Path,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Write the results of executing the given expression to a parquet file
+
+        This method is eager and will execute the associated expression
+        immediately.
+
+        Parameters
+        ----------
+        path
+            The data source. A string or Path to the parquet file.
+        params
+            Mapping of scalar parameter expressions to value.
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
+        **kwargs
+            Additional keyword arguments passed to pyarrow.parquet.ParquetWriter
+
+        https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html
+        """
+        self._find_backend(use_default=True).to_parquet(
+            self, path, limit=limit, **kwargs
+        )
+
+    @experimental
+    def to_csv(
+        self,
+        path: str | Path,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Write the results of executing the given expression to a CSV file
+
+        This method is eager and will execute the associated expression
+        immediately.
+
+        Parameters
+        ----------
+        path
+            The data source. A string or Path to the CSV file.
+        params
+            Mapping of scalar parameter expressions to value.
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
+        **kwargs
+            Additional keyword arguments passed to pyarrow.csv.CSVWriter
+
+        https://arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html
+        """
+        self._find_backend(use_default=True).to_csv(self, path, limit=limit, **kwargs)
+
     def unbind(self) -> ir.Table:
         """Return an expression built on `UnboundTable` instead of backend-specific objects."""
         from ibis.expr.analysis import substitute_unbound


### PR DESCRIPTION
`to_csv` and `to_parquet` seem self-evidently necessary.  ~PyArrow makes adding `to_orc` very easy, so I thought why not?~  because of windows, that's why not.

Also adding in a slightly silly `to_pyarrow_batches` method for the Pandas backend -- for CSV and parquet, I'm writing out the results of an expression as batches so we don't blow up memory.  I can either override `to_csv` and `to_parquet` in the pandas backend, or add in the slightly roundabout recordbatch producer.

