### PR TITLE
feat(bigquery): implement `isin` in select position

### DIFF
--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -300,7 +300,7 @@ class Select(DML, Comparable):
         formatted = []
         for node in self.select_set:
             if isinstance(node, ops.Value):
-                expr_str = self._translate(node, named=True)
+                expr_str = self._translate(node, named=True, permit_subquery=True)
             elif isinstance(node, ops.TableNode):
                 alias = context.get_ref(node)
                 expr_str = f'{alias}.*' if alias else '*'

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -842,7 +842,8 @@ def test_typeof(backend, con):
 
 
 @pytest.mark.broken(["polars"], reason="incorrect answer")
-@pytest.mark.notimpl(["datafusion", "bigquery", "impala", "pyspark"])
+@pytest.mark.notyet(["impala"], reason="can't find table in subquery")
+@pytest.mark.notimpl(["datafusion", "pyspark"])
 @pytest.mark.notyet(["dask", "mssql"], reason="not supported by the backend")
 def test_isin_uncorrelated(
     backend, batting, awards_players, batting_df, awards_players_df
@@ -850,14 +851,14 @@ def test_isin_uncorrelated(
     expr = batting.select(
         "playerID",
         "yearID",
-        x=batting.yearID.isin(awards_players.yearID),
+        has_year_id=batting.yearID.isin(awards_players.yearID),
     ).order_by(["playerID", "yearID"])
-    result = expr.execute().x
+    result = expr.execute().has_year_id
     expected = (
         batting_df.sort_values(["playerID", "yearID"])
         .reset_index(drop=True)
         .yearID.isin(awards_players_df.yearID)
-        .rename("x")
+        .rename("has_year_id")
     )
     backend.assert_series_equal(result, expected)
 


### PR DESCRIPTION
Implement isin-in-select-position for BigQuery