### PR TITLE
refactor: drop `limit` kwarg from `to_parquet`/`to_csv`

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -376,7 +376,6 @@ class _FileIOHandler:
         path: str | Path,
         *,
         params: Mapping[ir.Scalar, Any] | None = None,
-        limit: int | str | None = None,
         **kwargs: Any,
     ) -> None:
         """Write the results of executing the given expression to a parquet file.
@@ -392,9 +391,6 @@ class _FileIOHandler:
             The data source. A string or Path to the parquet file.
         params
             Mapping of scalar parameter expressions to value.
-        limit
-            An integer to effect a specific row limit. A value of `None` means
-            "no limit". The default is in `ibis/config.py`.
         **kwargs
             Additional keyword arguments passed to pyarrow.parquet.ParquetWriter
 
@@ -403,7 +399,7 @@ class _FileIOHandler:
         self._import_pyarrow()
         import pyarrow.parquet as pq
 
-        batch_reader = expr.to_pyarrow_batches(params=params, limit=limit)
+        batch_reader = expr.to_pyarrow_batches(params=params)
 
         with pq.ParquetWriter(path, batch_reader.schema) as writer:
             for batch in batch_reader:
@@ -416,7 +412,6 @@ class _FileIOHandler:
         path: str | Path,
         *,
         params: Mapping[ir.Scalar, Any] | None = None,
-        limit: int | str | None = None,
         **kwargs: Any,
     ) -> None:
         """Write the results of executing the given expression to a CSV file.
@@ -432,9 +427,6 @@ class _FileIOHandler:
             The data source. A string or Path to the CSV file.
         params
             Mapping of scalar parameter expressions to value.
-        limit
-            An integer to effect a specific row limit. A value of `None` means
-            "no limit". The default is in `ibis/config.py`.
         **kwargs
             Additional keyword arguments passed to pyarrow.csv.CSVWriter
 
@@ -443,7 +435,7 @@ class _FileIOHandler:
         self._import_pyarrow()
         import pyarrow.csv as pcsv
 
-        batch_reader = expr.to_pyarrow_batches(params=params, limit=limit)
+        batch_reader = expr.to_pyarrow_batches(params=params)
 
         with pcsv.CSVWriter(path, batch_reader.schema) as writer:
             for batch in batch_reader:

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -153,31 +153,25 @@ def test_no_pyarrow_message(awards_players, monkeypatch):
         awards_players.to_pyarrow()
 
 
-@pytest.mark.parametrize("limit", limit_no_limit)
-def test_table_to_parquet(tmp_path, backend, limit, awards_players):
+@pytest.mark.notimpl(["dask", "impala", "pyspark"])
+def test_table_to_parquet(tmp_path, backend, awards_players):
     outparquet = tmp_path / "out.parquet"
-    awards_players.to_parquet(outparquet, limit=limit)
+    awards_players.to_parquet(outparquet)
 
     df = pd.read_parquet(outparquet)
 
-    backend.assert_frame_equal(awards_players.execute(limit=limit), df)
-
-    if limit is not None:
-        assert len(df) == limit
+    backend.assert_frame_equal(awards_players.execute(), df)
 
 
-@pytest.mark.parametrize("limit", limit_no_limit)
-def test_table_to_csv(tmp_path, backend, limit, awards_players):
+@pytest.mark.notimpl(["dask", "impala", "pyspark"])
+def test_table_to_csv(tmp_path, backend, awards_players):
     outcsv = tmp_path / "out.csv"
 
     # avoid pandas NaNonense
     awards_players = awards_players.select("playerID", "awardID", "yearID", "lgID")
 
-    awards_players.to_csv(outcsv, limit=limit)
+    awards_players.to_csv(outcsv)
 
     df = pd.read_csv(outcsv, dtype=awards_players.schema().to_pandas())
 
-    backend.assert_frame_equal(awards_players.execute(limit=limit), df)
-
-    if limit is not None:
-        assert len(df) == limit
+    backend.assert_frame_equal(awards_players.execute(), df)

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -406,7 +406,6 @@ class Expr(Immutable):
         path: str | Path,
         *,
         params: Mapping[ir.Scalar, Any] | None = None,
-        limit: int | str | None = None,
         **kwargs: Any,
     ) -> None:
         """Write the results of executing the given expression to a parquet file
@@ -420,17 +419,12 @@ class Expr(Immutable):
             The data source. A string or Path to the parquet file.
         params
             Mapping of scalar parameter expressions to value.
-        limit
-            An integer to effect a specific row limit. A value of `None` means
-            "no limit". The default is in `ibis/config.py`.
         **kwargs
             Additional keyword arguments passed to pyarrow.parquet.ParquetWriter
 
         https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html
         """
-        self._find_backend(use_default=True).to_parquet(
-            self, path, limit=limit, **kwargs
-        )
+        self._find_backend(use_default=True).to_parquet(self, path, **kwargs)
 
     @experimental
     def to_csv(
@@ -438,7 +432,6 @@ class Expr(Immutable):
         path: str | Path,
         *,
         params: Mapping[ir.Scalar, Any] | None = None,
-        limit: int | str | None = None,
         **kwargs: Any,
     ) -> None:
         """Write the results of executing the given expression to a CSV file
@@ -452,15 +445,12 @@ class Expr(Immutable):
             The data source. A string or Path to the CSV file.
         params
             Mapping of scalar parameter expressions to value.
-        limit
-            An integer to effect a specific row limit. A value of `None` means
-            "no limit". The default is in `ibis/config.py`.
         **kwargs
             Additional keyword arguments passed to pyarrow.csv.CSVWriter
 
         https://arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html
         """
-        self._find_backend(use_default=True).to_csv(self, path, limit=limit, **kwargs)
+        self._find_backend(use_default=True).to_csv(self, path, **kwargs)
 
     def unbind(self) -> ir.Table:
         """Return an expression built on `UnboundTable` instead of backend-specific objects."""


### PR DESCRIPTION
Fixes #5470.