### PR TITLE
fix(duckdb): fix memtable `to_pyarrow`/`to_pyarrow_batches`

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -502,6 +502,7 @@ class Backend(BaseAlchemyBackend):
 
         from ibis.backends.duckdb.pyarrow import IbisRecordBatchReader
 
+        self._register_in_memory_tables(expr)
         query_ast = self.compiler.to_ast_ensure_limit(expr, limit, params=params)
         sql = query_ast.compile()
 
@@ -519,6 +520,8 @@ class Backend(BaseAlchemyBackend):
         **_: Any,
     ) -> pa.Table:
         pa = self._import_pyarrow()
+
+        self._register_in_memory_tables(expr)
         query_ast = self.compiler.to_ast_ensure_limit(expr, limit, params=params)
         sql = query_ast.compile()
 

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -4,6 +4,8 @@ import pandas as pd
 import pytest
 from pytest import param
 
+import ibis
+
 pa = pytest.importorskip("pyarrow")
 
 limit = [
@@ -145,6 +147,24 @@ def test_to_pyarrow_batches_borked_types(batting):
     batch = batch_reader.read_next_batch()
     assert isinstance(batch, pa.RecordBatch)
     assert len(batch) == 42
+
+
+@pytest.mark.notimpl(["dask", "datafusion", "impala", "pandas", "pyspark"])
+def test_to_pyarrow_memtable(con):
+    expr = ibis.memtable({"x": [1, 2, 3]})
+    table = con.to_pyarrow(expr)
+    assert isinstance(table, pa.Table)
+    assert len(table) == 3
+
+
+@pytest.mark.notimpl(["dask", "datafusion", "impala", "pandas", "pyspark"])
+def test_to_pyarrow_batches_memtable(con):
+    expr = ibis.memtable({"x": [1, 2, 3]})
+    n = 0
+    for batch in con.to_pyarrow_batches(expr):
+        assert isinstance(batch, pa.RecordBatch)
+        n += len(batch)
+    assert n == 3
 
 
 def test_no_pyarrow_message(awards_players, monkeypatch):


### PR DESCRIPTION
Previously memtables weren't being properly registered for `to_pyarrow`/`to_pyarrow_batches` for `duckdb`. This adds a test for that and fixes the issue. Fixes #5471.