### PR TITLE
feat(ux): allow creating unbound tables using annotated class definitions

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -311,8 +311,8 @@ def table(
       a int64
       b string
     """
-    if schema is not None:
-        schema = sch.schema(schema)
+    if isinstance(schema, type) and name is None:
+        name = schema.__name__
     return ops.UnboundTable(schema=schema, name=name).to_expr()
 
 

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -49,7 +49,7 @@ class PhysicalTable(TableNode, Named):
 
 @public
 class UnboundTable(PhysicalTable):
-    schema = rlz.instance_of(sch.Schema)
+    schema = rlz.coerced_to(sch.Schema)
     name = rlz.optional(rlz.instance_of(str), default=genname)
 
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -14,6 +14,7 @@ from ibis import util
 from ibis.common.annotations import attribute, optional
 from ibis.common.validators import (
     bool_,
+    coerced_to,  # noqa: F401
     equal_to,  # noqa: F401
     instance_of,
     isin,

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -9,7 +9,7 @@ import ibis.expr.datatypes as dt
 from ibis.common.annotations import attribute
 from ibis.common.exceptions import IntegrityError
 from ibis.common.grounds import Concrete
-from ibis.common.validators import frozendict_of, instance_of, validator
+from ibis.common.validators import Coercible, frozendict_of, instance_of, validator
 from ibis.util import indent
 
 if TYPE_CHECKING:
@@ -43,7 +43,7 @@ def datatype(arg, **kwargs):
     return dt.dtype(arg)
 
 
-class Schema(Concrete, Mapping):
+class Schema(Concrete, Mapping, Coercible):
     """An object for holding table schema information."""
 
     fields = frozendict_of(instance_of(str), datatype)
@@ -69,6 +69,10 @@ class Schema(Concrete, Mapping):
 
     def __getitem__(self, name: str) -> dt.DataType:
         return self.fields[name]
+
+    @classmethod
+    def __coerce__(cls, value) -> Schema:
+        return schema(value)
 
     @attribute.default
     def names(self):

--- a/ibis/tests/expr/test_schema.py
+++ b/ibis/tests/expr/test_schema.py
@@ -9,8 +9,10 @@ import pytest
 
 import ibis
 import ibis.expr.datatypes as dt
+import ibis.expr.rules as rlz
 import ibis.expr.schema as sch
 from ibis.common.exceptions import IntegrityError
+from ibis.common.grounds import Annotable
 
 
 def test_whole_schema():
@@ -347,3 +349,15 @@ def test_preferences():
     b = sch.schema(PreferenceB)
     c = sch.schema(PreferenceC)
     assert a == b == c
+
+
+class ObjectWithSchema(Annotable):
+    schema: sch.Schema
+
+
+def test_schema_is_coercible():
+    s = sch.Schema({'a': dt.int64, 'b': dt.Array(dt.int64)})
+    assert rlz.coerced_to(sch.Schema, PreferenceA) == s
+
+    o = ObjectWithSchema(schema=PreferenceA)
+    assert o.schema == s

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1,6 +1,7 @@
 import datetime
 import pickle
 import re
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -1493,6 +1494,26 @@ def test_unbound_table_name():
     name = t.op().name
     match = re.match(r'^unbound_table_\d+$', name)
     assert match is not None
+
+
+class MyTable:
+    a: int
+    b: str
+    c: List[float]
+
+
+def test_unbound_table_using_class_definition():
+    expected_schema = ibis.schema({'a': 'int64', 'b': 'string', 'c': 'array<double>'})
+
+    t1 = ibis.table(MyTable)
+    t2 = ibis.table(MyTable, name="MyNamedTable")
+
+    cases = {t1: "MyTable", t2: "MyNamedTable"}
+    for t, name in cases.items():
+        assert isinstance(t, ir.TableExpr)
+        assert isinstance(t.op(), ops.UnboundTable)
+        assert t.schema() == expected_schema
+        assert t.get_name() == name
 
 
 def test_mutate_chain():


### PR DESCRIPTION
Examples:

```python

class MyTable:
    a: int
    b: str
    c: list[float]


t = ibis.table(MyTable, name="MyCustomName")
```

As an extra implemented the `Coercible` interface for `Schema`, so `Annotable` supports it as type annotation:

```py
class ObjectWithSchema(Annotable):
    schema: sch.Schema
```
