### PR TITLE
fix: don't expose backend methods on `ibis.<backend>` directly

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -705,6 +705,14 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         """Compile an expression."""
         return self.compiler.to_sql(expr, params=params)
 
+    def _to_sql(self, expr: ir.Expr) -> str:
+        """Convert an expression to a SQL string.
+
+        Called by `ibis.to_sql`/`ibis.show_sql`, gives the backend an
+        opportunity to generate nicer SQL for human consumption.
+        """
+        raise NotImplementedError(f"Backend '{self.name}' backend doesn't support SQL")
+
     def execute(self, expr: ir.Expr) -> Any:
         """Execute an expression."""
 

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -330,6 +330,9 @@ class BaseSQLBackend(BaseBackend):
         """
         return self.compiler.to_ast_ensure_limit(expr, limit, params=params).compile()
 
+    def _to_sql(self, expr: ir.Expr) -> str:
+        return str(self.compile(expr))
+
     def explain(
         self,
         expr: ir.Expr | str,

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -114,6 +114,17 @@ class BaseAlchemyBackend(BaseSQLBackend):
         self._inspector.info_cache.clear()
         return self._inspector
 
+    def _to_sql(self, expr: ir.Expr) -> str:
+        # For `ibis.to_sql` calls we render with literal binds and qmark params
+        dialect_class = sa.dialects.registry.load(
+            self.compiler.translator_class._dialect_name
+        )
+        sql = self.compile(expr).compile(
+            dialect=dialect_class(paramstyle="qmark"),
+            compile_kwargs=dict(literal_binds=True),
+        )
+        return str(sql)
+
     @contextlib.contextmanager
     def _safe_raw_sql(self, *args, **kwargs):
         with self.begin() as con:

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -377,6 +377,9 @@ class Backend(BaseBackend):
         assert not isinstance(sql, sg.exp.Subquery)
         return sql.sql(dialect="clickhouse", pretty=True)
 
+    def _to_sql(self, expr: ir.Expr) -> str:
+        return str(self.compile(expr))
+
     def table(self, name: str, database: str | None = None) -> ir.Table:
         """Construct a table expression.
 

--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -132,5 +132,6 @@ def test_invalid_connection_parameter_types(npartitions):
         "Expected an instance of 'dask.dataframe.DataFrame' for 'df', "
         "got an instance of 'str' instead."
     )
+    con = ibis.dask.connect()
     with pytest.raises(TypeError, match=expeced_msg):
-        ibis.dask.from_dataframe("file.csv")
+        con.from_dataframe("file.csv")

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -20,17 +20,17 @@ from ibis.backends.dask.dispatch import (  # noqa: E402
 
 
 def test_from_dataframe(dataframe, ibis_table, core_client):
-    t = ibis.dask.from_dataframe(dataframe)
+    t = core_client.from_dataframe(dataframe)
     result = t.execute()
     expected = ibis_table.execute()
     tm.assert_frame_equal(result, expected)
 
-    t = ibis.dask.from_dataframe(dataframe, name='foo')
+    t = core_client.from_dataframe(dataframe, name='foo')
     expected = ibis_table.execute()
     tm.assert_frame_equal(result, expected)
 
     client = core_client
-    t = ibis.dask.from_dataframe(dataframe, name='foo', client=client)
+    t = core_client.from_dataframe(dataframe, name='foo', client=client)
     expected = ibis_table.execute()
     tm.assert_frame_equal(result, expected)
 

--- a/ibis/backends/pandas/tests/execution/test_functions.py
+++ b/ibis/backends/pandas/tests/execution/test_functions.py
@@ -224,7 +224,7 @@ def test_execute_with_same_hash_value_in_scope(
         return x
 
     df = pd.DataFrame({"left": [left], "right": [right]})
-    table = ibis.pandas.from_dataframe(df)
+    table = ibis.pandas.connect().from_dataframe(df)
 
     expr = my_func(table.left, table.right)
     result = execute(expr.op())
@@ -262,7 +262,7 @@ def test_signature_does_not_match_input_type(dtype, value):
         return x
 
     df = pd.DataFrame({"col": [value]})
-    table = ibis.pandas.from_dataframe(df)
+    table = ibis.pandas.connect().from_dataframe(df)
 
     result = execute(table.col.op())
     assert isinstance(result, pd.Series)

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -611,10 +611,9 @@ def test_integer_to_timestamp(backend, con, unit):
     backend_unit = backend.returned_timestamp_unit
     factor = unit_factors[unit]
 
-    ts = ibis.timestamp('2018-04-13 09:54:11.872832')
-    pandas_ts = pd.Timestamp(ibis.pandas.execute(ts)).floor(unit).value
+    pandas_ts = pd.Timestamp('2018-04-13 09:54:11.872832').floor(unit).value
 
-    # convert the now timestamp to the input unit being tested
+    # convert the timestamp to the input unit being tested
     int_expr = ibis.literal(pandas_ts // factor)
     expr = int_expr.to_timestamp(unit)
     result = con.execute(expr.name("tmp"))

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -382,25 +382,6 @@ def to_sql(expr: ir.Expr, dialect: str | None = None) -> SQLString:
         else:
             read = write = getattr(backend, "_sqlglot_dialect", dialect)
 
-    compiled = backend.compile(expr)
-    try:
-        import sqlalchemy as sa
-
-        dialect_class = sa.dialects.registry.load(
-            backend.compiler.translator_class._dialect_name
-        )
-        # translate using question-mark-style bound parameter syntax for all
-        # backends, since sqlglot only supports qmark style
-        sql = compiled.compile(
-            dialect=dialect_class(paramstyle="qmark"),
-            compile_kwargs=dict(literal_binds=True),
-        )
-    except (ImportError, AttributeError, TypeError):
-        # ImportError is caught in case the dialect isn't installed. While it's
-        # probably rare that someone is trying to compile an X-backend
-        # expression and doesn't have the driver installed, we don't need to
-        # fail when showing its SQL
-        sql = compiled
-
-    (pretty,) = sg.transpile(str(sql), read=read, write=write, pretty=True)
+    sql = backend._to_sql(expr)
+    (pretty,) = sg.transpile(sql, read=read, write=write, pretty=True)
     return SQLString(pretty)

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -8,22 +8,25 @@ from typing import NamedTuple
 import pytest
 
 import ibis
-from ibis.backends.base import BaseBackend
 
 
 def test_backends_are_cached():
-    assert isinstance(ibis.sqlite, BaseBackend)
+    assert ibis.sqlite is ibis.sqlite
     del ibis.sqlite  # delete to force recreation
-    assert isinstance(ibis.sqlite, BaseBackend)
     assert ibis.sqlite is ibis.sqlite
 
 
 def test_backends_tab_completion():
-    assert isinstance(ibis.sqlite, BaseBackend)
+    assert hasattr(ibis, "sqlite")
     del ibis.sqlite  # delete to ensure not real attr
     assert "sqlite" in dir(ibis)
-    assert isinstance(ibis.sqlite, BaseBackend)
+    assert ibis.sqlite is ibis.sqlite
     assert "sqlite" in dir(ibis)  # in dir even if already created
+
+
+def test_public_backend_methods():
+    public = {m for m in dir(ibis.sqlite) if not m.startswith("_")}
+    assert public == {"connect", "compile", "has_operation", "add_operation"}
 
 
 def test_missing_backend():


### PR DESCRIPTION
Previously all methods on a backend were also exposed via the backend's pseudomodule (i.e. `ibis.<backend>.<method>` instead of `ibis.<backend>.connect().<method>`). This was an implementation detail of how backends were registered, most of these methods didn't work without an explicit `connect` call beforehand, and should not (and could not) work properly when called on the `ibis.<backend>` directly.

We now expose only `connect`, `compile`, `add_operation`, and `has_operation` on the backend module namespace, all other methods require a connected backend to work.

Fixes #5436.