### PR TITLE
fix(api): add a `name` attribute to backend proxy modules

### DIFF
--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -105,6 +105,7 @@ def __getattr__(name: str) -> BaseBackend:
     proxy.compile = backend.compile
     proxy.has_operation = backend.has_operation
     proxy.add_operation = backend.add_operation
+    proxy.name = name
     proxy._from_url = backend._from_url
     proxy._to_sql = backend._to_sql
     if hasattr(backend, "_sqlglot_dialect"):

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -744,6 +744,7 @@ def test_create_from_in_memory_table(backend, con, t):
         assert tmp_name not in con.list_tables()
 
 
+@pytest.mark.usefixtures("backend")
 def test_default_backend_option():
     orig = ibis.options.default_backend
     ibis.options.default_backend = ibis.pandas

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -26,7 +26,7 @@ def test_backends_tab_completion():
 
 def test_public_backend_methods():
     public = {m for m in dir(ibis.sqlite) if not m.startswith("_")}
-    assert public == {"connect", "compile", "has_operation", "add_operation"}
+    assert public == {"connect", "compile", "has_operation", "add_operation", "name"}
 
 
 def test_missing_backend():


### PR DESCRIPTION
Fixes a small bug where the `name` attribute on backend modules was expected to exist.