### PR TITLE
ci(snowflake): don't reset the random number seed for every test

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -35,13 +35,16 @@ jobs:
         backend:
           - name: bigquery
             title: BigQuery
+            randomly-seed: true
 
           - name: snowflake
             title: Snowflake
+            randomly-seed: true
 
           - name: snowflake
             key: snowflake-pyarrow
             title: Snowflake + PyArrow
+            randomly-seed: false
             deps:
               - "'snowflake-connector-python[pandas]<3'"
               - "--optional"
@@ -84,8 +87,13 @@ jobs:
         env:
           SNOWFLAKE_URL: ${{ secrets.SNOWFLAKE_URL }}
 
-      - name: "run parallel tests: ${{ matrix.backend.name }}"
+      - name: "run parallel tests: ${{ matrix.backend.name }}; reset random seed"
+        if: matrix.backend.randomly-seed
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
+
+      - name: "run parallel tests: ${{ matrix.backend.name }}; don't reset random seed"
+        if: ${{ !matrix.backend.randomly-seed }}
+        run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup --randomly-dont-reset-seed
 
       - name: upload code coverage
         if: success()


### PR DESCRIPTION
Snowflake uses the `random` module to generate temporary stage names.
When the random seed is reset to a fixed value for each test, the
`CREATE TEMP STAGE` step that is part of the `write_pandas` call will
fail because a duplicate stage is being created. In practice this is not
a huge problem because most users aren't setting the random seed and
this is also a `snowflake-connector-python` problem: they should
probably be generating names using UUIDs instead of an arbitrary length
string.
