### PR TITLE
feat: implement map length for trino/clickhouse

### DIFF
--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -1048,6 +1048,7 @@ _simple_ops = {
     ops.IfNull: "ifNull",
     ops.NullIf: "nullIf",
     ops.MapContains: "mapContains",
+    ops.MapLength: "length",
     ops.MapKeys: "mapKeys",
     ops.MapValues: "mapValues",
     ops.MapMerge: "mapUpdate",

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -218,3 +218,8 @@ def test_map_create_table(con, tmptable):
     con.create_table(tmptable, schema=ibis.schema(dict(xyz="map<string, string>")))
     t = con.table(tmptable)
     assert t.schema()["xyz"].is_map()
+
+
+def test_map_length(con):
+    expr = ibis.literal(dict(a="A", b="B")).length()
+    assert con.execute(expr) == 2

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -336,8 +336,6 @@ _invalid_operations = {
     # ibis.expr.operations.analytic
     ops.CumulativeOp,
     ops.NTile,
-    # ibis.expr.operations.logical
-    ops.Between,
     # ibis.expr.operations.maps
     ops.MapLength,
     # ibis.expr.operations.reductions

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -336,8 +336,6 @@ _invalid_operations = {
     # ibis.expr.operations.analytic
     ops.CumulativeOp,
     ops.NTile,
-    # ibis.expr.operations.maps
-    ops.MapLength,
     # ibis.expr.operations.reductions
     ops.MultiQuantile,
     ops.Quantile,


### PR DESCRIPTION
Removes some implemented operations from the invalid ops registry. Adds a test for map length and implements it for clickhouse.