### PR TITLE
fix(duckdb): fix bind param usage in `regexp_replace`

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -249,7 +249,7 @@ operation_registry.update(
         ),
         ops.RegexExtract: fixed_arity(_regex_extract, 3),
         ops.RegexReplace: fixed_arity(
-            lambda *args: sa.func.regexp_replace(*args, "g"), 3
+            lambda *args: sa.func.regexp_replace(*args, sa.text("'g'")), 3
         ),
         ops.StringContains: fixed_arity(sa.func.contains, 2),
         ops.ApproxMedian: reduction(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -554,3 +554,10 @@ def test_array_string_join(con):
 
     expr = s.join(",")
     assert con.execute(expr) == expected
+
+
+@pytest.mark.notimpl(["dask", "datafusion", "mssql", "mysql", "pandas", "pyspark"])
+def test_subs_with_re_replace(con):
+    expr = ibis.literal("hi").re_replace("i", "a").substitute({"d": "b"}, else_="k")
+    result = con.execute(expr)
+    assert result == "k"


### PR DESCRIPTION
Fixes an issue where parameter substitution occurs in the wrong order when using the numeric bindparam style. Closes #5522.