### PR TITLE
fix(ir): fail union when schemas are not equal

### DIFF
--- a/ibis/tests/expr/test_schema.py
+++ b/ibis/tests/expr/test_schema.py
@@ -361,3 +361,9 @@ def test_schema_is_coercible():
 
     o = ObjectWithSchema(schema=PreferenceA)
     assert o.schema == s
+
+
+def test_schema_with_different_orders_not_equal():
+    s1 = ibis.schema(dict(a="string", b="int"))
+    s2 = ibis.schema(dict(b="int", a="string"))
+    assert s1 != s2

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -82,6 +82,12 @@ class frozendict(Mapping[K, V], Hashable):
     def __hash__(self):
         return self.__precomputed_hash__
 
+    def __eq__(self, other):
+        return len(self) == len(other) and all(
+            k1 == k2 and v1 == v2
+            for (k1, v1), (k2, v2) in zip(self.items(), other.items())
+        )
+
 
 class DotDict(dict):
     __slots__ = ()


### PR DESCRIPTION
Fail to construct operations that are sensitive to schema ordering by making schema comparison ordered, instead of only depending on mapping comparison. Closes #5519.