### PR TITLE
refactor: remove jupyter text workaround

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -14,7 +14,6 @@ from ibis.common.exceptions import IbisError, IbisTypeError, TranslationError
 from ibis.common.grounds import Immutable
 from ibis.config import _default_backend, options
 from ibis.util import experimental
-from rich.jupyter import JupyterMixin
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -22,15 +21,6 @@ if TYPE_CHECKING:
     import ibis.expr.types as ir
     from ibis.backends.base import BaseBackend
     from ibis.expr.typing import TimeContext
-
-
-class _FixedTextJupyterMixin(JupyterMixin):
-    """JupyterMixin adds a spurious newline to text, this fixes the issue."""
-
-    def _repr_mimebundle_(self, *args, **kwargs):
-        bundle = super()._repr_mimebundle_(*args, **kwargs)
-        bundle["text/plain"] = bundle["text/plain"].rstrip()
-        return bundle
 
 
 # TODO(kszucs): consider to subclass from Annotable with a single _arg field

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence
 
 from public import public
+from rich.jupyter import JupyterMixin
 
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.common.grounds import Singleton
-from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin
+from ibis.expr.types.core import Expr, _binop
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -622,7 +623,7 @@ class Scalar(Value):
         from rich.text import Text
 
         if not ibis.options.interactive:
-            return console.render(Text(self._repr()), options=options)
+            return Text(self._repr())
         return console.render(repr(self.execute()), options=options)
 
     def as_table(self) -> ir.Table:
@@ -671,7 +672,7 @@ class Scalar(Value):
 
 
 @public
-class Column(Value, _FixedTextJupyterMixin):
+class Column(Value, JupyterMixin):
     # Higher than numpy & dask objects
     __array_priority__ = 20
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -20,6 +20,7 @@ from typing import (
 )
 
 from public import public
+from rich.jupyter import JupyterMixin
 
 import ibis
 import ibis.common.exceptions as com
@@ -28,7 +29,7 @@ import ibis.expr.operations as ops
 from ibis import util
 from ibis.expr.deferred import Deferred
 from ibis.expr.selectors import Selector
-from ibis.expr.types.core import Expr, _FixedTextJupyterMixin
+from ibis.expr.types.core import Expr
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -87,7 +88,7 @@ def _regular_join_method(
 
 
 @public
-class Table(Expr, _FixedTextJupyterMixin):
+class Table(Expr, JupyterMixin):
     # Higher than numpy & dask objects
     __array_priority__ = 20
 
@@ -124,7 +125,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         from ibis.expr.types.pretty import to_rich_table
 
         if not ibis.options.interactive:
-            return console.render(Text(self._repr()), options=options)
+            return Text(self._repr())
 
         if console.is_jupyter:
             # Rich infers a console width in jupyter notebooks, but since


### PR DESCRIPTION
This PR removes the jupyter text/plain workaround based on [a conversation on the `rich` issue tracker](https://github.com/Textualize/rich/issues/2793).