### PR TITLE
fix(ir): reorder the right schema of set operations to align with the left schema

### DIFF
--- a/ibis/backends/tests/test_set_ops.py
+++ b/ibis/backends/tests/test_set_ops.py
@@ -1,3 +1,5 @@
+import random
+
 import pandas as pd
 import pytest
 from pytest import param
@@ -9,13 +11,21 @@ from ibis import _
 
 @pytest.fixture
 def union_subsets(alltypes, df):
-    a = alltypes.filter((_.id >= 5200) & (_.id <= 5210))
-    b = alltypes.filter((_.id >= 5205) & (_.id <= 5215))
-    c = alltypes.filter((_.id >= 5213) & (_.id <= 5220))
+    cols_a, cols_b, cols_c = (alltypes.columns.copy() for _ in range(3))
 
-    da = df[(df.id >= 5200) & (df.id <= 5210)]
-    db = df[(df.id >= 5205) & (df.id <= 5215)]
-    dc = df[(df.id >= 5213) & (df.id <= 5220)]
+    random.seed(89)
+    random.shuffle(cols_a)
+    random.shuffle(cols_b)
+    random.shuffle(cols_c)
+    assert cols_a != cols_b != cols_c
+
+    a = alltypes.filter((_.id >= 5200) & (_.id <= 5210))[cols_a]
+    b = alltypes.filter((_.id >= 5205) & (_.id <= 5215))[cols_b]
+    c = alltypes.filter((_.id >= 5213) & (_.id <= 5220))[cols_c]
+
+    da = df[(df.id >= 5200) & (df.id <= 5210)][cols_a]
+    db = df[(df.id >= 5205) & (df.id <= 5215)][cols_b]
+    dc = df[(df.id >= 5213) & (df.id <= 5220)][cols_c]
 
     return (a, b, c), (da, db, dc)
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -44,25 +44,30 @@ def dtype_from_object(value, **kwargs) -> DataType:
     # Validator.from_annotation
     origin_type = get_origin(value)
     if origin_type is None:
-        if issubclass(value, DataType):
-            return value()
-        elif result := _python_dtypes.get(value):
-            return result
-        elif annots := get_type_hints(value):
-            return Struct(toolz.valmap(dtype, annots))
-        elif issubclass(value, bytes):
-            return bytes
-        elif issubclass(value, str):
-            return string
-        elif issubclass(value, Integral):
-            return int64
-        elif issubclass(value, Real):
-            return float64
-        elif value is type(None):
-            return null
+        if isinstance(value, type):
+            if issubclass(value, DataType):
+                return value()
+            elif result := _python_dtypes.get(value):
+                return result
+            elif annots := get_type_hints(value):
+                return Struct(toolz.valmap(dtype, annots))
+            elif issubclass(value, bytes):
+                return bytes
+            elif issubclass(value, str):
+                return string
+            elif issubclass(value, Integral):
+                return int64
+            elif issubclass(value, Real):
+                return float64
+            elif value is type(None):
+                return null
+            else:
+                raise TypeError(
+                    f"Cannot construct an ibis datatype from python type `{value!r}`"
+                )
         else:
             raise TypeError(
-                f"Cannot construct an ibis datatype from python type {value!r}"
+                f"Cannot construct an ibis datatype from python value `{value!r}`"
             )
     elif issubclass(origin_type, Sequence):
         (value_type,) = map(dtype, get_args(value))

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -326,6 +326,21 @@ def test_dtype_from_newer_typehints(hint, expected):
     assert dt.dtype(hint) == expected
 
 
+def test_dtype_from_invalid_python_value():
+    msg = "Cannot construct an ibis datatype from python value `1.0`"
+    with pytest.raises(TypeError, match=msg):
+        dt.dtype(1.0)
+
+
+def test_dtype_from_invalid_python_type():
+    class Something:
+        pass
+
+    msg = "Cannot construct an ibis datatype from python type `<class '.*Something'>`"
+    with pytest.raises(TypeError, match=msg):
+        dt.dtype(Something)
+
+
 def test_dtype_from_additional_struct_typehints():
     class A:
         nested: dt.Struct({'a': dt.Int16, 'b': dt.Int32})  # noqa: F821

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -247,8 +247,12 @@ class SetOp(TableNode):
     distinct = rlz.optional(rlz.instance_of(bool), default=False)
 
     def __init__(self, left, right, **kwargs):
-        if not left.schema == right.schema:
+        if left.schema != right.schema:
             raise com.RelationError('Table schemas must be equal for set operations')
+        elif left.schema.names != right.schema.names:
+            # rewrite so that both sides have the columns in the same order making it
+            # easier for the backends to implement set operations
+            right = ops.Selection(right, left.schema.names)
         super().__init__(left=left, right=right, **kwargs)
 
     @property

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -322,8 +322,13 @@ schema = Dispatcher('schema')
 infer = Dispatcher('infer')
 
 
+@schema.register()
+def schema_from_kwargs(**kwargs):
+    return Schema(kwargs)
+
+
 @schema.register(Schema)
-def identity(s):
+def schema_from_schema(s):
     return s
 
 

--- a/ibis/tests/expr/test_schema.py
+++ b/ibis/tests/expr/test_schema.py
@@ -167,12 +167,15 @@ def test_schema_subset():
 
 
 def test_empty_schema():
-    schema = ibis.schema([])
-    result = repr(schema)
-    expected = """\
-ibis.Schema {
-}"""
-    assert result == expected
+    s1 = sch.Schema({})
+    s2 = sch.schema()
+    s3 = ibis.schema([])
+
+    assert s1 == s2 == s3
+
+    for s in [s1, s2, s3]:
+        assert len(s.items()) == 0
+        assert repr(s) == "ibis.Schema {\n}"
 
 
 def test_nullable_output():
@@ -361,3 +364,8 @@ def test_schema_is_coercible():
 
     o = ObjectWithSchema(schema=PreferenceA)
     assert o.schema == s
+
+
+def test_schema_shorthand_supports_kwargs():
+    s = sch.schema(a=dt.int64, b=dt.Array(dt.int64))
+    assert s == sch.Schema({'a': dt.int64, 'b': dt.Array(dt.int64)})

--- a/ibis/tests/expr/test_set_operations.py
+++ b/ibis/tests/expr/test_set_operations.py
@@ -1,0 +1,59 @@
+import pytest
+
+import ibis
+import ibis.expr.operations as ops
+from ibis.common.exceptions import RelationError
+
+
+class A:
+    a: int
+    b: str
+    c: float
+
+
+# identical to A
+class B:
+    a: int
+    b: str
+    c: float
+
+
+# same as A with different order
+class C:
+    c: float
+    b: str
+    a: int
+
+
+class D:
+    a: str
+    b: str
+    c: str
+
+
+a = ibis.table(A)
+b = ibis.table(B)
+c = ibis.table(C)
+d = ibis.table(D)
+
+
+@pytest.mark.parametrize('method', ['union', 'intersect', 'difference'])
+def test_operation_requires_equal_schemas(method):
+    with pytest.raises(RelationError):
+        getattr(a, method)(d)
+
+
+@pytest.mark.parametrize('method', ['union', 'intersect', 'difference'])
+def test_operation_supports_schemas_with_different_field_order(method):
+    u1 = getattr(a, method)(b)
+    u2 = getattr(a, method)(c)
+
+    assert u1.schema() == a.schema()
+    assert u1.op().left == a.op()
+    assert u1.op().right == b.op()
+
+    # a selection is added to ensure that the field order of the right table
+    # matches the field order of the left table
+    assert u2.schema() == a.schema()
+    assert u2.op().left == a.op()
+    assert u2.op().right == ops.Selection(c.op(), ['a', 'b', 'c'])

--- a/ibis/tests/test_util.py
+++ b/ibis/tests/test_util.py
@@ -62,7 +62,10 @@ def test_dotdict():
 def test_frozendict():
     d = util.frozendict({"a": 1, "b": 2, "c": 3})
     e = util.frozendict(a=1, b=2, c=3)
+    f = util.frozendict(a=1, b=2, c=3, d=4)
     assert d == e
+    assert d != f
+
     assert d["a"] == 1
     assert d["b"] == 2
 


### PR DESCRIPTION
If we consider two schemas equivalent with identical fields but in different order (ref https://github.com/ibis-project/ibis/pull/5526#issuecomment-1427893522), then the set operations just need to ensure that both sides have the same schema - not considering the field order. 

Ideally all backends should ensure to handle set operations properly by adding an extra projection if the backend needs reordered fields. Another option is to do that operation-wise, implemented by this PR which should offload that extra work from the backends. 

While it should fix the problem, I think the internal representation was correct earlier as well since the two schema were *equal*. This fix is a band aid to overcome the semantical difference how ibis' IR and certain backends' implementation treat schema field ordering, so I may prefer offloading that task to the backends in the future (OR considering schemas with different field order inequal?).