### PR TITLE
refactor: use backend specific startswith/endswith implementations where possible

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -724,6 +724,8 @@ OPERATION_REGISTRY = {
     ops.NthValue: _nth_value,
     ops.JSONGetItem: lambda t, op: f"{t.translate(op.arg)}[{t.translate(op.index)}]",
     ops.ArrayStringJoin: lambda t, op: f"ARRAY_TO_STRING({t.translate(op.arg)}, {t.translate(op.sep)})",
+    ops.StartsWith: fixed_arity("STARTS_WITH", 2),
+    ops.EndsWith: fixed_arity("ENDS_WITH", 2),
 }
 
 _invalid_operations = {

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -278,6 +278,8 @@ operation_registry.update(
         ops.ArrayStringJoin: fixed_arity(
             lambda sep, arr: sa.func.array_aggr(arr, sa.text("'string_agg'"), sep), 2
         ),
+        ops.StartsWith: fixed_arity(sa.func.prefix, 2),
+        ops.EndsWith: fixed_arity(sa.func.suffix, 2),
     }
 )
 

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -623,5 +623,6 @@ operation_registry.update(
         ops.Strip: unary(lambda arg: sa.func.trim(arg, string.whitespace)),
         ops.LStrip: unary(lambda arg: sa.func.ltrim(arg, string.whitespace)),
         ops.RStrip: unary(lambda arg: sa.func.rtrim(arg, string.whitespace)),
+        ops.StartsWith: fixed_arity(lambda arg, prefix: arg.op("^@")(prefix), 2),
     }
 )

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -445,7 +445,7 @@ def compile_startswith(t, op, **kwargs):
 def compile_endswith(t, op, **kwargs):
     col = t.translate(op.arg, **kwargs)
     end = t.translate(op.end, **kwargs)
-    return col.startswith(end)
+    return col.endswith(end)
 
 
 def _is_table(table):

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -352,6 +352,8 @@ operation_registry.update(
         ops.ArgMax: reduction(sa.func.max_by),
         ops.ToJSONArray: lambda t, op: t.translate(ops.Cast(op.arg, op.output_dtype)),
         ops.ToJSONMap: lambda t, op: t.translate(ops.Cast(op.arg, op.output_dtype)),
+        ops.StartsWith: fixed_arity(sa.func.startswith, 2),
+        ops.EndsWith: fixed_arity(sa.func.endswith, 2),
     }
 )
 

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -441,8 +441,8 @@ def test_string_col_is_unicode(alltypes, df):
             ],
         ),
         param(
-            lambda t: t.date_string_col.endswith("100"),
-            lambda t: t.date_string_col.str.endswith("100"),
+            lambda t: t.date_string_col.endswith("/10"),
+            lambda t: t.date_string_col.str.endswith("/10"),
             id='endswith-simple',
             marks=[
                 pytest.mark.notimpl(

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -329,6 +329,7 @@ operation_registry.update(
         ops.ArrayStringJoin: fixed_arity(
             lambda sep, arr: sa.func.array_join(arr, sep), 2
         ),
+        ops.StartsWith: fixed_arity(sa.func.starts_with, 2),
     }
 )
 


### PR DESCRIPTION
This PR uses backend specific implementations of startswith/endswith operations, which generates cleaner SQL. I also fixed a bug in the pyspark backend where we were translating endswith to startswith.