### PR TITLE
chore: enforce raises in xfail tests

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -92,6 +92,20 @@ TEST_TABLES = {
     ),
 }
 
+# We want to check for exceptions in xfail tests for two reasons:
+# * xfail tests without exception checking may hide problems.
+#   For example, the implementation may work, but we may have an error in the test that needs to be fixed.
+# * facilitates code reviews
+# For now, many of our tests don't do this, and we're working to change this situation
+# by improving all tests file by file. All files that have already been improved are
+# added to this list to prevent regression.
+FIlES_WITH_STRICT_EXCEPTION_CHECK = [
+    'ibis/backends/tests/test_binary.py',
+    'ibis/backends/tests/test_numeric.py',
+    'ibis/backends/tests/test_string.py',
+    'ibis/backends/tests/test_uuid.py',
+]
+
 
 @pytest.fixture(scope='session')
 def script_directory() -> Path:
@@ -380,6 +394,11 @@ def pytest_runtest_call(item):
     # This xfails so that you know when it starts to pass
     for marker in item.iter_markers(name="notimpl"):
         if backend in marker.args[0]:
+            if (
+                item.location[0] in FIlES_WITH_STRICT_EXCEPTION_CHECK
+                and "raises" not in marker.kwargs.keys()
+            ):
+                raise ValueError("notimpl requires a raises")
             reason = marker.kwargs.get("reason")
             item.add_marker(
                 pytest.mark.xfail(
@@ -392,6 +411,11 @@ def pytest_runtest_call(item):
     # This xfails so that you know when it starts to pass
     for marker in item.iter_markers(name="notyet"):
         if backend in marker.args[0]:
+            if (
+                item.location[0] in FIlES_WITH_STRICT_EXCEPTION_CHECK
+                and "raises" not in marker.kwargs.keys()
+            ):
+                raise ValueError("notyet requires a raises")
             reason = marker.kwargs.get("reason")
             item.add_marker(
                 pytest.mark.xfail(
@@ -415,6 +439,11 @@ def pytest_runtest_call(item):
     # bring it to attention  -- USE SPARINGLY
     for marker in item.iter_markers(name="broken"):
         if backend in marker.args[0]:
+            if (
+                item.location[0] in FIlES_WITH_STRICT_EXCEPTION_CHECK
+                and "raises" not in marker.kwargs.keys()
+            ):
+                raise ValueError("broken requires a raises")
             reason = marker.kwargs.get("reason")
             item.add_marker(
                 pytest.mark.xfail(

--- a/ibis/backends/tests/test_binary.py
+++ b/ibis/backends/tests/test_binary.py
@@ -16,20 +16,16 @@ BINARY_BACKEND_TYPES = {
     "postgres": "bytea",
 }
 
-pytestmark = pytest.mark.notimpl(["druid"])
+pytestmark = pytest.mark.broken(["druid"], raises=AssertionError)
 
 
-@pytest.mark.broken(
-    ['polars'],
-    "ValueError: could not convert value \"b'A'\" as a Literal",
-)
 @pytest.mark.broken(
     ['trino'],
     "(builtins.AttributeError) 'bytes' object has no attribute 'encode'",
     raises=sqlalchemy.exc.StatementError,
 )
 @pytest.mark.broken(
-    ['clickhouse', 'impala'],
+    ['clickhouse', 'impala', 'polars'],
     "Unsupported type: Binary(nullable=True)",
     raises=NotImplementedError,
 )

--- a/ibis/backends/tests/test_set_ops.py
+++ b/ibis/backends/tests/test_set_ops.py
@@ -33,7 +33,7 @@ def union_subsets(alltypes, df):
 
 @pytest.mark.parametrize("distinct", [False, True], ids=["all", "distinct"])
 @pytest.mark.notimpl(["datafusion", "polars"])
-@pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError)
+@pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError)
 def test_union(backend, union_subsets, distinct):
     (a, b, c), (da, db, dc) = union_subsets
 
@@ -49,7 +49,7 @@ def test_union(backend, union_subsets, distinct):
 
 @pytest.mark.notimpl(["datafusion", "polars"])
 @pytest.mark.notyet(["bigquery"])
-@pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError)
+@pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError)
 def test_union_mixed_distinct(backend, union_subsets):
     (a, b, c), (da, db, dc) = union_subsets
 
@@ -78,7 +78,7 @@ def test_union_mixed_distinct(backend, union_subsets):
 )
 @pytest.mark.notimpl(["datafusion", "polars"])
 @pytest.mark.notyet(["impala"])
-@pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError)
+@pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError)
 def test_intersect(backend, alltypes, df, distinct):
     a = alltypes.filter((_.id >= 5200) & (_.id <= 5210))
     b = alltypes.filter((_.id >= 5205) & (_.id <= 5215))
@@ -117,7 +117,7 @@ def test_intersect(backend, alltypes, df, distinct):
 )
 @pytest.mark.notimpl(["datafusion", "polars"])
 @pytest.mark.notyet(["impala"])
-@pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError)
+@pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError)
 def test_difference(backend, alltypes, df, distinct):
     a = alltypes.filter((_.id >= 5200) & (_.id <= 5210))
     b = alltypes.filter((_.id >= 5205) & (_.id <= 5215))
@@ -150,7 +150,7 @@ def test_empty_set_op(alltypes, method):
     "distinct",
     [
         param(
-            True, marks=pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError)
+            True, marks=pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError)
         ),
         False,
     ],
@@ -188,7 +188,7 @@ def test_top_level_union(backend, con, alltypes, distinct):
 )
 @pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notyet(["impala"], reason="doesn't support intersection or difference")
-@pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError)
+@pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError)
 def test_top_level_intersect_difference(
     backend, con, alltypes, distinct, opname, expected
 ):

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -361,7 +361,11 @@ def test_string_col_is_unicode(alltypes, df):
             id='ascii_str',
             marks=[
                 pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError),
-                pytest.mark.notimpl(["druid"]),
+                pytest.mark.broken(
+                    ["druid"],
+                    raises=sa.exc.ProgrammingError,
+                    reason="No match found for function signature ascii(<CHARACTER>)",
+                ),
             ],
         ),
         param(
@@ -381,7 +385,7 @@ def test_string_col_is_unicode(alltypes, df):
                     ["dask", "datafusion", "pyspark"],
                     raises=com.OperationNotDefinedError,
                 ),
-                pytest.mark.notimpl(
+                pytest.mark.broken(
                     ["druid"],
                     raises=sa.exc.ProgrammingError,
                 ),
@@ -411,7 +415,7 @@ def test_string_col_is_unicode(alltypes, df):
                     ["dask", "datafusion", "pyspark"],
                     raises=com.OperationNotDefinedError,
                 ),
-                pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError),
+                pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError),
                 pytest.mark.broken(
                     ["mssql"],
                     reason=(
@@ -606,7 +610,7 @@ def test_string_col_is_unicode(alltypes, df):
                     reason="'Series' object has no attribute 'items'",
                     raises=AttributeError,
                 ),
-                pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError),
+                pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError),
             ],
         ),
         param(
@@ -656,7 +660,7 @@ def test_string_col_is_unicode(alltypes, df):
                 pytest.mark.notimpl(
                     ["datafusion"], raises=com.OperationNotDefinedError
                 ),
-                pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError),
+                pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError),
             ],
         ),
         param(

--- a/ibis/backends/tests/test_uuid.py
+++ b/ibis/backends/tests/test_uuid.py
@@ -36,7 +36,14 @@ UUID_EXPECTED_VALUES = {
     'dask': TEST_UUID,
 }
 
-pytestmark = pytest.mark.notimpl(["druid"])
+pytestmark = pytest.mark.notimpl(
+    ["druid"],
+    raises=sqlalchemy.exc.CompileError,
+    reason=(
+        'No literal value renderer is available for literal value '
+        '"UUID(\'08f48812-7948-4718-96c7-27fa6a398db6\')" with datatype NULL'
+    ),
+)
 
 
 @pytest.mark.broken(


### PR DESCRIPTION
Hello.
We already have 4 files that have all (or almost all) xfail tests with strict exception validation, but it wasn't enforced so that future changes wouldn't cause regression.

What do you think to force this and then iteratively fix all the other tests? Does it make sense? Does it have value?

CC: @cpcloud 