### PR TITLE
feat(duckdb): use `read_json_auto` when reading json

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -870,8 +870,8 @@ def read_json(sources: str | Path | Sequence[str | Path], **kwargs: Any) -> ir.T
     sources
         A filesystem path or URL or list of same.
     kwargs
-        Backend-specific keyword arguments for the file type. For the DuckDB
-        backend used by default, there are no valid keywork arguments.
+        Backend-specific keyword arguments for the file type. See
+        https://duckdb.org/docs/extensions/json.html for details.
 
     Returns
     -------
@@ -880,7 +880,26 @@ def read_json(sources: str | Path | Sequence[str | Path], **kwargs: Any) -> ir.T
 
     Examples
     --------
-    >>> t = ibis.read_json("data.json")
+    >>> import ibis
+    >>> ibis.options.interactive = True
+    >>> lines = '''
+    ... {"a": 1, "b": "d"}
+    ... {"a": 2, "b": null}
+    ... {"a": null, "b": "f"}
+    ... '''
+    >>> with open("lines.json", mode="w") as f:
+    ...     f.write(lines)
+    >>> t = ibis.read_json("lines.json")
+    >>> t
+    ┏━━━━━━━━┳━━━━━━━━┓
+    ┃ a      ┃ b      ┃
+    ┡━━━━━━━━╇━━━━━━━━┩
+    │ uint64 │ string │
+    ├────────┼────────┤
+    │      1 │ d      │
+    │      2 │ ∅      │
+    │      ∅ │ f      │
+    └────────┴────────┘
     """
     from ibis.config import _default_backend
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -5201,13 +5201,13 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-all = ["black", "clickhouse-cityhash", "clickhouse-driver", "dask", "datafusion", "db-dtypes", "duckdb", "duckdb-engine", "fsspec", "GeoAlchemy2", "geopandas", "google-cloud-bigquery", "google-cloud-bigquery-storage", "graphviz", "impyla", "lz4", "polars", "psycopg2", "pyarrow", "pydata-google-auth", "pymssql", "pymysql", "pyspark", "regex", "requests", "shapely", "snowflake-connector-python", "snowflake-sqlalchemy", "sqlalchemy", "sqlalchemy-views", "trino"]
+all = ["black", "clickhouse-cityhash", "clickhouse-driver", "dask", "datafusion", "db-dtypes", "duckdb", "duckdb-engine", "fsspec", "GeoAlchemy2", "geopandas", "google-cloud-bigquery", "google-cloud-bigquery-storage", "graphviz", "impyla", "lz4", "packaging", "polars", "psycopg2", "pyarrow", "pydata-google-auth", "pymssql", "pymysql", "pyspark", "regex", "requests", "shapely", "snowflake-connector-python", "snowflake-sqlalchemy", "sqlalchemy", "sqlalchemy-views", "trino"]
 bigquery = ["db-dtypes", "google-cloud-bigquery", "google-cloud-bigquery-storage", "pydata-google-auth"]
 clickhouse = ["clickhouse-driver", "clickhouse-cityhash", "lz4"]
 dask = ["dask", "pyarrow", "regex"]
 datafusion = ["datafusion"]
 decompiler = ["black"]
-duckdb = ["duckdb", "duckdb-engine", "pyarrow", "sqlalchemy", "sqlalchemy-views"]
+duckdb = ["duckdb", "duckdb-engine", "packaging", "pyarrow", "sqlalchemy", "sqlalchemy-views"]
 geospatial = ["GeoAlchemy2", "geopandas", "shapely"]
 impala = ["fsspec", "impyla", "requests", "sqlalchemy"]
 mssql = ["sqlalchemy", "pymssql"]
@@ -5224,4 +5224,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "8bd0032d30f28e8cdd2b58cefb02d933085db48834bd7fd2e2fd2ac11a2a1157"
+content-hash = "79fc387df2018664ac856b1c21033d5397efe49fe1ab217db7c775205ae3d8c2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ google-cloud-bigquery-storage = { version = ">=2,<3", optional = true }
 graphviz = { version = ">=0.16,<1", optional = true }
 impyla = { version = ">=0.17,<1", optional = true }
 lz4 = { version = ">=3.1.10,<5", optional = true }
+packaging = { version = ">=21.3,<24", optional = true }
 polars = { version = ">=0.14.18,<1", optional = true }
 psycopg2 = { version = ">=2.8.4,<3", optional = true }
 pyarrow = { version = ">=2,<12", optional = true }
@@ -136,6 +137,7 @@ all = [
   "graphviz",
   "impyla",
   "lz4",
+  "packaging",
   "polars",
   "psycopg2",
   "pyarrow",
@@ -164,6 +166,7 @@ datafusion = ["datafusion"]
 duckdb = [
   "duckdb",
   "duckdb-engine",
+  "packaging",
   "pyarrow",
   "sqlalchemy",
   "sqlalchemy-views"


### PR DESCRIPTION
This PR changes the duckdb read_json implementation to use the new-in-duckdb-0.7.0 function `read_json_auto`. Depends on #5545.