### PR TITLE
fix(sql): ensure that expressions are traversed in dependency order

### DIFF
--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -144,13 +144,10 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
                 # Was put elsewhere, e.g. WITH block, we just need to grab
                 # its alias
                 alias = ctx.get_ref(op)
+                if not hasattr(alias, "name"):
+                    alias = ctx.get_ref(ref_op).alias(alias)
 
-                # hack
-                if isinstance(op, ops.SelfReference):
-                    table = ctx.get_ref(ref_op)
-                    self_ref = alias if hasattr(alias, "name") else table.alias(alias)
-                    ctx.set_ref(op, self_ref)
-                    return self_ref
+                ctx.top_context.set_ref(op, alias)
                 return alias
 
             alias = ctx.get_ref(op)

--- a/ibis/backends/base/sql/alchemy/translator.py
+++ b/ibis/backends/base/sql/alchemy/translator.py
@@ -35,6 +35,9 @@ class AlchemyContext(QueryContext):
             params=self.params,
         )
 
+    def _compile_subquery(self, op):
+        return self._to_sql(op, self.subcontext())
+
 
 class AlchemyExprTranslator(ExprTranslator):
     _registry = sqlalchemy_operation_registry

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -381,7 +381,6 @@ class SelectBuilder:
 
         self.subqueries = []
         for node in subqueries:
-            # See #173. Might have been extracted already in a parent context.
             if not self.context.is_extracted(node):
                 self.subqueries.append(node)
                 self.context.set_extracted(node)

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -127,6 +127,7 @@ class QueryContext:
         return None
 
     def is_extracted(self, node):
+        # See #173. Might have been extracted already in a parent context.
         return node in self.top_context.extracted_subexprs
 
     def set_extracted(self, node):

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -29,8 +29,11 @@ class QueryContext:
         self.params = params if params is not None else {}
 
     def _compile_subquery(self, op):
-        sub_ctx = self.subcontext()
-        return self._to_sql(op, sub_ctx)
+        if isinstance(op, (ops.SQLQueryResult, ops.SQLStringView)):
+            return op.query
+        else:
+            sub_ctx = self.subcontext()
+            return self._to_sql(op, sub_ctx)
 
     def _to_sql(self, expr, ctx):
         return self.compiler.to_sql(expr, ctx)
@@ -64,10 +67,7 @@ class QueryContext:
         with contextlib.suppress(KeyError):
             return self.top_context.subquery_memo[node]
 
-        if isinstance(node, (ops.SQLQueryResult, ops.SQLStringView)):
-            result = node.query
-        else:
-            result = self._compile_subquery(node)
+        result = self._compile_subquery(node)
 
         self.top_context.subquery_memo[node] = result
         return result

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_multiple_filters/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_multiple_filters/out.sql
@@ -1,9 +1,10 @@
-SELECT t0.*
-FROM (
+WITH t0 AS (
   SELECT t1.*
   FROM t0 t1
   WHERE t1.`a` < 100
-) t0
+)
+SELECT t0.*
+FROM t0
 WHERE t0.`a` = (
   SELECT max(t1.`a`) AS `Max(a)`
   FROM t0 t1

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_multiple_filters2/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_multiple_filters2/out.sql
@@ -1,9 +1,10 @@
-SELECT t0.*
-FROM (
+WITH t0 AS (
   SELECT t1.*
   FROM t0 t1
   WHERE t1.`a` < 100
-) t0
+)
+SELECT t0.*
+FROM t0
 WHERE (t0.`a` = (
   SELECT max(t1.`a`) AS `Max(a)`
   FROM t0 t1

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/bigquery/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.*
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+  INNER JOIN t1
+    ON t0.`key` = t1.`key`
+)
+SELECT
+  t2.`key`
+FROM t2
+INNER JOIN t2 AS t3
+  ON t2.`key` = t3.`key`

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/clickhouse/out.sql
@@ -1,0 +1,49 @@
+SELECT
+  t4.key
+FROM (
+  SELECT
+    t1.key
+  FROM (
+    SELECT
+      *
+    FROM leaf AS t0
+    WHERE
+      1
+  ) AS t1
+  INNER JOIN (
+    SELECT
+      t1.key
+    FROM (
+      SELECT
+        *
+      FROM leaf AS t0
+      WHERE
+        1
+    ) AS t1
+  ) AS t2
+    ON t1.key = t2.key
+) AS t4
+INNER JOIN (
+  SELECT
+    t1.key
+  FROM (
+    SELECT
+      *
+    FROM leaf AS t0
+    WHERE
+      1
+  ) AS t1
+  INNER JOIN (
+    SELECT
+      t1.key
+    FROM (
+      SELECT
+        *
+      FROM leaf AS t0
+      WHERE
+        1
+    ) AS t1
+  ) AS t2
+    ON t1.key = t2.key
+) AS t5
+  ON t4.key = t5.key

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/duckdb/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.key AS key
+  FROM leaf AS t4
+  WHERE
+    CAST(TRUE AS BOOLEAN)
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+)
+SELECT
+  t2.key
+FROM t2
+JOIN t2 AS t3
+  ON t2.key = t3.key

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/impala/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/impala/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.*
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+  INNER JOIN t1
+    ON t0.`key` = t1.`key`
+)
+SELECT
+  t2.`key`
+FROM t2
+INNER JOIN t2 AS t3
+  ON t2.`key` = t3.`key`

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/mysql/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.`key` AS `key`
+  FROM leaf AS t4
+  WHERE
+    TRUE = 1
+), t1 AS (
+  SELECT
+    t0.`key` AS `key`
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.`key` AS `key`
+  FROM t0
+  INNER JOIN t1
+    ON t0.`key` = t1.`key`
+)
+SELECT
+  t2.`key`
+FROM t2
+INNER JOIN t2 AS t3
+  ON t2.`key` = t3.`key`

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/postgres/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.key AS key
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+)
+SELECT
+  t2.key
+FROM t2
+JOIN t2 AS t3
+  ON t2.key = t3.key

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/snowflake/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.key AS key
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+)
+SELECT
+  t2.key
+FROM t2
+JOIN t2 AS t3
+  ON t2.key = t3.key

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/sqlite/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4."key" AS "key"
+  FROM leaf AS t4
+  WHERE
+    1 = 1
+), t1 AS (
+  SELECT
+    t0."key" AS "key"
+  FROM t0
+), t2 AS (
+  SELECT
+    t0."key" AS "key"
+  FROM t0
+  JOIN t1
+    ON t0."key" = t1."key"
+)
+SELECT
+  t2."key"
+FROM t2
+JOIN t2 AS t3
+  ON t2."key" = t3."key"

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/trino/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.key AS key
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+)
+SELECT
+  t2.key
+FROM t2
+JOIN t2 AS t3
+  ON t2.key = t3.key

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -119,6 +119,9 @@ def test_group_by_has_index(backend, snapshot):
 @pytest.mark.never(
     ["pandas", "dask", "datafusion", "polars", "pyspark"], reason="not SQL"
 )
+@pytest.mark.notimpl(
+    ["mssql"], reason="sqlglot dialect not yet implemented", raises=ValueError
+)
 def test_cte_refs_in_topo_order(backend, snapshot):
     mr0 = ibis.table(schema=ibis.schema(dict(key="int")), name='leaf')
 

--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -166,10 +166,7 @@ halt = False
 
 
 def traverse(
-    fn: Callable[[Node], tuple[bool | Iterable, Any]],
-    node: Iterable[Node],
-    dedup: bool = True,
-    filter=Node,
+    fn: Callable[[Node], tuple[bool | Iterable, Any]], node: Iterable[Node], filter=Node
 ) -> Iterator[Any]:
     """Utility for generic expression tree traversal.
 
@@ -180,27 +177,20 @@ def traverse(
         controls the traversal, and the second is the result if its not `None`.
     node
         The Node expression or a list of expressions.
-    dedup
-        Whether to allow expression traversal more than once
     filter
         Restrict initial traversal to this kind of node
     """
-    args = reversed(node) if isinstance(node, Iterable) else [node]
-    todo = deque(arg for arg in args if isinstance(arg, filter))
-    seen = set()
+    args = node if isinstance(node, Iterable) else [node]
+    todo = [arg for arg in args if isinstance(arg, filter)]
+
+    out = []
 
     while todo:
         node = todo.pop()
 
-        if dedup:
-            if node in seen:
-                continue
-            else:
-                seen.add(node)
-
         control, result = fn(node)
         if result is not None:
-            yield result
+            out.append(result)
 
         if control is not halt:
             if control is proceed:
@@ -213,4 +203,7 @@ def traverse(
                     'an instance of boolean or iterable'
                 )
 
-            todo.extend(reversed(args))
+            todo.extend(args)
+
+    while out:
+        yield out.pop()

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -795,7 +795,7 @@ def find_subqueries(node: ops.Node) -> Counter:
 
     # keep duplicates so we can determine where an expression is used
     # more than once
-    list(g.traverse(finder, node, dedup=False))
+    util.consume(g.traverse(finder, node))
 
     return counts
 

--- a/ibis/tests/sql/snapshots/test_compiler/test_agg_and_non_agg_filter/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_agg_and_non_agg_filter/out.sql
@@ -1,9 +1,10 @@
-SELECT t0.*
-FROM (
+WITH t0 AS (
   SELECT t1.*
   FROM my_table t1
   WHERE t1.`a` < 100
-) t0
+)
+SELECT t0.*
+FROM t0
 WHERE (t0.`a` = (
   SELECT max(t1.`a`) AS `Max(a)`
   FROM my_table t1

--- a/ibis/tests/sql/snapshots/test_compiler/test_simple_agg_filter/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_simple_agg_filter/out.sql
@@ -1,9 +1,10 @@
-SELECT t0.*
-FROM (
+WITH t0 AS (
   SELECT t1.*
   FROM my_table t1
   WHERE t1.`a` < 100
-) t0
+)
+SELECT t0.*
+FROM t0
 WHERE t0.`a` = (
   SELECT max(t1.`a`) AS `Max(a)`
   FROM my_table t1

--- a/ibis/tests/sql/snapshots/test_compiler/test_table_drop_with_filter/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_table_drop_with_filter/out.sql
@@ -1,18 +1,22 @@
-SELECT t0.*
-FROM (
-  SELECT t1.`a`
-  FROM (
-    SELECT t3.`a`, t3.`b`, '2018-01-01T00:00:00' AS `the_date`
-    FROM (
-      SELECT t4.*
-      FROM (
-        SELECT t5.`a`, t5.`b`, t5.`c` AS `C`
-        FROM t t5
-      ) t4
-      WHERE t4.`C` = '2018-01-01T00:00:00'
-    ) t3
-  ) t1
-    INNER JOIN s t2
-      ON t1.`b` = t2.`b`
-) t0
-WHERE t0.`a` < 1.0
+WITH t0 AS (
+  SELECT t4.`a`, t4.`b`, t4.`c` AS `C`
+  FROM t t4
+),
+t1 AS (
+  SELECT t0.*
+  FROM t0
+  WHERE t0.`C` = '2018-01-01T00:00:00'
+),
+t2 AS (
+  SELECT t1.`a`, t1.`b`, '2018-01-01T00:00:00' AS `the_date`
+  FROM t1
+),
+t3 AS (
+  SELECT t2.`a`
+  FROM t2
+    INNER JOIN s t5
+      ON t2.`b` = t5.`b`
+)
+SELECT t3.*
+FROM t3
+WHERE t3.`a` < 1.0

--- a/ibis/tests/sql/snapshots/test_select_sql/test_aggregate_projection_subquery/agg_filtered2.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_aggregate_projection_subquery/agg_filtered2.sql
@@ -1,8 +1,9 @@
-SELECT t0.`g`, sum(t0.`foo`) AS `foo total`
-FROM (
+WITH t0 AS (
   SELECT t1.*, t1.`a` + t1.`b` AS `foo`
   FROM alltypes t1
   WHERE t1.`f` > 0
-) t0
+)
+SELECT t0.`g`, sum(t0.`foo`) AS `foo total`
+FROM t0
 WHERE t0.`foo` < 10
 GROUP BY 1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_bug_duplicated_where/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_bug_duplicated_where/out.sql
@@ -1,15 +1,27 @@
 SELECT t0.*
 FROM (
-  SELECT t1.*
-  FROM (
-    SELECT t2.*, avg(t2.`arrdelay`) OVER (PARTITION BY t2.`dest`) AS `dest_avg`,
-           t2.`arrdelay` - avg(t2.`arrdelay`) OVER (PARTITION BY t2.`dest`) AS `dev`
+  WITH t1 AS (
+    SELECT t3.`arrdelay`, t3.`dest`
+    FROM airlines t3
+  ),
+  t3 AS (
+    SELECT t1.*, avg(t1.`arrdelay`) OVER (PARTITION BY t1.`dest`) AS `dest_avg`,
+           t1.`arrdelay` - avg(t1.`arrdelay`) OVER (PARTITION BY t1.`dest`) AS `dev`
     FROM (
       SELECT t3.`arrdelay`, t3.`dest`
       FROM airlines t3
-    ) t2
-  ) t1
-  WHERE t1.`dev` IS NOT NULL
+    ) t1
+  )
+  SELECT t3.*
+  FROM (
+    SELECT t1.*, avg(t1.`arrdelay`) OVER (PARTITION BY t1.`dest`) AS `dest_avg`,
+           t1.`arrdelay` - avg(t1.`arrdelay`) OVER (PARTITION BY t1.`dest`) AS `dev`
+    FROM (
+      SELECT t3.`arrdelay`, t3.`dest`
+      FROM airlines t3
+    ) t1
+  ) t3
+  WHERE t3.`dev` IS NOT NULL
 ) t0
 ORDER BY t0.`dev` DESC
 LIMIT 10

--- a/ibis/tests/sql/snapshots/test_select_sql/test_filter_inside_exists/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_filter_inside_exists/out.sql
@@ -1,11 +1,12 @@
-SELECT t0.*
-FROM events t0
+WITH t0 AS (
+  SELECT t2.*
+  FROM purchases t2
+  WHERE t2.`ts` > '2015-08-15'
+)
+SELECT t1.*
+FROM events t1
 WHERE EXISTS (
   SELECT 1
-  FROM (
-    SELECT t2.*
-    FROM purchases t2
-    WHERE t2.`ts` > '2015-08-15'
-  ) t1
-  WHERE t0.`user_id` = t1.`user_id`
+  FROM t0
+  WHERE t1.`user_id` = t0.`user_id`
 )

--- a/ibis/tests/sql/snapshots/test_select_sql/test_filter_predicates/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_filter_predicates/out.sql
@@ -1,11 +1,17 @@
 SELECT *
 FROM (
+  WITH t2 AS (
+    SELECT t2.*
+    FROM t t2
+    WHERE (lower(t2.`color`) LIKE '%de%') AND
+          (locate('de', lower(t2.`color`)) - 1 >= 0)
+  )
   SELECT *
   FROM (
     SELECT t2.*
     FROM t t2
     WHERE (lower(t2.`color`) LIKE '%de%') AND
           (locate('de', lower(t2.`color`)) - 1 >= 0)
-  ) t1
-  WHERE regexp_like(lower(t1.`color`), '.*ge.*')
+  ) t2
+  WHERE regexp_like(lower(t2.`color`), '.*ge.*')
 ) t0

--- a/ibis/tests/sql/snapshots/test_select_sql/test_select_sql/limit_then_filter/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_select_sql/limit_then_filter/out.sql
@@ -1,7 +1,8 @@
-SELECT t0.*
-FROM (
+WITH t0 AS (
   SELECT t1.*
   FROM star1 t1
   LIMIT 10
-) t0
+)
+SELECT t0.*
+FROM t0
 WHERE t0.`f` > 0

--- a/ibis/tests/sql/snapshots/test_select_sql/test_where_no_pushdown_possible/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_where_no_pushdown_possible/out.sql
@@ -1,8 +1,9 @@
-SELECT t0.*
-FROM (
+WITH t0 AS (
   SELECT t1.*, t1.`f` - t2.`value1` AS `diff`
   FROM star1 t1
     INNER JOIN star2 t2
       ON t1.`foo_id` = t2.`foo_id`
-) t0
+)
+SELECT t0.*
+FROM t0
 WHERE t0.`diff` > 1

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_filter_group_by_agg_with_same_name/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_filter_group_by_agg_with_same_name/out.sql
@@ -1,13 +1,14 @@
-SELECT
-  t0.int_col,
-  t0.bigint_col
-FROM (
+WITH t0 AS (
   SELECT
     t1.int_col AS int_col,
     SUM(t1.bigint_col) AS bigint_col
   FROM t AS t1
   GROUP BY
     1
-) AS t0
+)
+SELECT
+  t0.int_col,
+  t0.bigint_col
+FROM t0
 WHERE
   t0.bigint_col = 60

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit_subquery/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit_subquery/out.sql
@@ -1,9 +1,4 @@
-SELECT
-  t0.c,
-  t0.f,
-  t0.foo_id,
-  t0.bar_id
-FROM (
+WITH t0 AS (
   SELECT
     t1.c AS c,
     t1.f AS f,
@@ -11,6 +6,12 @@ FROM (
     t1.bar_id AS bar_id
   FROM star1 AS t1
   LIMIT 10
-) AS t0
+)
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM t0
 WHERE
   t0.f > 0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_lower_projection_sort_key/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_lower_projection_sort_key/out.sql
@@ -1,30 +1,31 @@
+WITH t1 AS (
+  SELECT
+    t3.foo_id AS foo_id,
+    SUM(t3.f) AS total
+  FROM star1 AS t3
+  GROUP BY
+    1
+), t3 AS (
+  SELECT
+    t1.foo_id AS foo_id,
+    t1.total AS total,
+    t4.value1 AS value1
+  FROM t1
+  JOIN star2 AS t4
+    ON t1.foo_id = t4.foo_id
+)
 SELECT
   t0.foo_id,
   t0.total,
   t0.value1
 FROM (
   SELECT
-    t1.foo_id AS foo_id,
-    t1.total AS total,
-    t1.value1 AS value1
-  FROM (
-    SELECT
-      t2.foo_id AS foo_id,
-      t2.total AS total,
-      t3.value1 AS value1
-    FROM (
-      SELECT
-        t4.foo_id AS foo_id,
-        SUM(t4.f) AS total
-      FROM star1 AS t4
-      GROUP BY
-        1
-    ) AS t2
-    JOIN star2 AS t3
-      ON t2.foo_id = t3.foo_id
-  ) AS t1
+    t3.foo_id AS foo_id,
+    t3.total AS total,
+    t3.value1 AS value1
+  FROM t3
   WHERE
-    t1.total > 100
+    t3.total > 100
 ) AS t0
 ORDER BY
   t0.total DESC

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_mutate_filter_join_no_cross_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_mutate_filter_join_no_cross_join/out.sql
@@ -1,11 +1,12 @@
-SELECT
-  t0.person_id
-FROM (
+WITH t0 AS (
   SELECT
     t1.person_id AS person_id,
     t1.birth_datetime AS birth_datetime,
     400 AS age
   FROM person AS t1
-) AS t0
+)
+SELECT
+  t0.person_id
+FROM t0
 WHERE
   t0.age <= 40

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_tpc_h11/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_tpc_h11/out.sql
@@ -1,26 +1,27 @@
+WITH t2 AS (
+  SELECT
+    t2.ps_partkey AS ps_partkey,
+    SUM(t2.ps_supplycost * t2.ps_availqty) AS value
+  FROM partsupp AS t2
+  JOIN supplier AS t3
+    ON t2.ps_suppkey = t3.s_suppkey
+  JOIN nation AS t4
+    ON t4.n_nationkey = t3.s_nationkey
+  WHERE
+    t4.n_name = 'GERMANY'
+  GROUP BY
+    1
+)
 SELECT
   t0.ps_partkey,
   t0.value
 FROM (
   SELECT
-    t1.ps_partkey AS ps_partkey,
-    t1.value AS value
-  FROM (
-    SELECT
-      t2.ps_partkey AS ps_partkey,
-      SUM(t2.ps_supplycost * t2.ps_availqty) AS value
-    FROM partsupp AS t2
-    JOIN supplier AS t3
-      ON t2.ps_suppkey = t3.s_suppkey
-    JOIN nation AS t4
-      ON t4.n_nationkey = t3.s_nationkey
-    WHERE
-      t4.n_name = 'GERMANY'
-    GROUP BY
-      1
-  ) AS t1
+    t2.ps_partkey AS ps_partkey,
+    t2.value AS value
+  FROM t2
   WHERE
-    t1.value > (
+    t2.value > (
       SELECT
         anon_1.total
       FROM (

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_correlated_subquery_with_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_correlated_subquery_with_join/out.sql
@@ -1,26 +1,27 @@
-SELECT
-  t0.p_partkey,
-  t0.ps_supplycost
-FROM (
+WITH t0 AS (
   SELECT
     t1.p_partkey AS p_partkey,
     t2.ps_supplycost AS ps_supplycost
   FROM part AS t1
   JOIN partsupp AS t2
     ON t1.p_partkey = t2.ps_partkey
-) AS t0
+), t2 AS (
+  SELECT
+    t2.ps_partkey AS ps_partkey,
+    t2.ps_supplycost AS ps_supplycost
+  FROM partsupp AS t2
+  JOIN supplier AS t3
+    ON t3.s_suppkey = t2.ps_suppkey
+)
+SELECT
+  t0.p_partkey,
+  t0.ps_supplycost
+FROM t0
 WHERE
   t0.ps_supplycost = (
     SELECT
-      MIN(t1.ps_supplycost) AS "Min(ps_supplycost)"
-    FROM (
-      SELECT
-        t2.ps_partkey AS ps_partkey,
-        t2.ps_supplycost AS ps_supplycost
-      FROM partsupp AS t2
-      JOIN supplier AS t3
-        ON t3.s_suppkey = t2.ps_suppkey
-    ) AS t1
+      MIN(t2.ps_supplycost) AS "Min(ps_supplycost)"
+    FROM t2
     WHERE
-      t1.ps_partkey = t0.p_partkey
+      t2.ps_partkey = t0.p_partkey
   )


### PR DESCRIPTION
This PR fixes our core traversal algorithm, which only works on trees and not
general DAGs. I take a "two-stacks" approach. This approach is simpler than some alternatives
at the cost of using more memory (a `deque`).

Fixes #5215.

I still need to fix the sqlalchemy tests.
