### PR TITLE
refactor: use snapshot testing in `test_sqlalchemy.py`

### DIFF
--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/having_count/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/having_count/out.sql
@@ -1,3 +1,8 @@
-SELECT t0.foo_id, sum(t0.f) AS total 
-FROM star1 AS t0 GROUP BY 1 
-HAVING count(*) > 100
+SELECT
+  t0.foo_id,
+  SUM(t0.f) AS total
+FROM star1 AS t0
+GROUP BY
+  1
+HAVING
+  COUNT(*) > 100

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/having_sum/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/having_sum/out.sql
@@ -1,3 +1,8 @@
-SELECT t0.foo_id, sum(t0.f) AS total 
-FROM star1 AS t0 GROUP BY 1 
-HAVING sum(t0.f) > 10
+SELECT
+  t0.foo_id,
+  SUM(t0.f) AS total
+FROM star1 AS t0
+GROUP BY
+  1
+HAVING
+  SUM(t0.f) > 10

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/single/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/single/out.sql
@@ -1,0 +1,6 @@
+SELECT
+  t0.foo_id,
+  SUM(t0.f) AS total
+FROM star1 AS t0
+GROUP BY
+  1

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/single_key/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/single_key/out.sql
@@ -1,2 +1,0 @@
-SELECT t0.foo_id, sum(t0.f) AS total 
-FROM star1 AS t0 GROUP BY 1

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/two/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/two/out.sql
@@ -1,0 +1,8 @@
+SELECT
+  t0.foo_id,
+  t0.bar_id,
+  SUM(t0.f) AS total
+FROM star1 AS t0
+GROUP BY
+  1,
+  2

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/two_keys/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_aggregate/two_keys/out.sql
@@ -1,2 +1,0 @@
-SELECT t0.foo_id, t0.bar_id, sum(t0.f) AS total 
-FROM star1 AS t0 GROUP BY 1, 2

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_between/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_between/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col BETWEEN 5 AND 10 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_boolean_conjunction/and/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_boolean_conjunction/and/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col > 0 AND t0.double_col < 5 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_boolean_conjunction/or/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_boolean_conjunction/or/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col < 0 OR t0.double_col > 5 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_coalesce/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_coalesce/out.sql
@@ -1,0 +1,9 @@
+SELECT
+  COALESCE(
+    CASE WHEN (
+      t0.double_col > 30
+    ) THEN t0.double_col ELSE NULL END,
+    NULL,
+    t0.float_col
+  ) AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/eq/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/eq/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col = 5 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/ge/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/ge/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col >= 5 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/gt/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/gt/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col > 5 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/le/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/le/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col <= 5 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/lt/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/lt/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col < 5 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/ne/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_comparisons/ne/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col <> 5 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_cte_factor_distinct_but_equal/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_cte_factor_distinct_but_equal/out.sql
@@ -1,5 +1,14 @@
-WITH t0 AS 
-(SELECT t2.g AS g, sum(t2.f) AS metric 
-FROM alltypes AS t2 GROUP BY 1)
- SELECT t0.g, t0.metric 
-FROM t0 JOIN t0 AS t1 ON t0.g = t1.g
+WITH t0 AS (
+  SELECT
+    t2.g AS g,
+    SUM(t2.f) AS metric
+  FROM alltypes AS t2
+  GROUP BY
+    1
+)
+SELECT
+  t0.g,
+  t0.metric
+FROM t0
+JOIN t0 AS t1
+  ON t0.g = t1.g

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/count_distinct/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/count_distinct/out.sql
@@ -1,2 +1,3 @@
-SELECT count(DISTINCT t0.int_col) AS nunique 
+SELECT
+  COUNT(DISTINCT t0.int_col) AS nunique
 FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/group_by_count_distinct/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/group_by_count_distinct/out.sql
@@ -1,2 +1,6 @@
-SELECT t0.string_col, count(DISTINCT t0.int_col) AS nunique 
-FROM functional_alltypes AS t0 GROUP BY 1
+SELECT
+  t0.string_col,
+  COUNT(DISTINCT t0.int_col) AS nunique
+FROM functional_alltypes AS t0
+GROUP BY
+  1

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/projection_distinct/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/projection_distinct/out.sql
@@ -1,2 +1,4 @@
-SELECT DISTINCT t0.string_col, t0.int_col 
+SELECT DISTINCT
+  t0.string_col,
+  t0.int_col
 FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/single_column_projection_distinct/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/single_column_projection_distinct/out.sql
@@ -1,2 +1,3 @@
-SELECT DISTINCT t0.string_col 
+SELECT DISTINCT
+  t0.string_col
 FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/table_distinct/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_distinct/table_distinct/out.sql
@@ -1,2 +1,15 @@
-SELECT DISTINCT t0.id, t0.bool_col, t0.tinyint_col, t0.smallint_col, t0.int_col, t0.bigint_col, t0.float_col, t0.double_col, t0.date_string_col, t0.string_col, t0.timestamp_col, t0.year, t0.month 
+SELECT DISTINCT
+  t0.id,
+  t0.bool_col,
+  t0.tinyint_col,
+  t0.smallint_col,
+  t0.int_col,
+  t0.bigint_col,
+  t0.float_col,
+  t0.double_col,
+  t0.date_string_col,
+  t0.string_col,
+  t0.timestamp_col,
+  t0.year,
+  t0.month
 FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_exists/e1.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_exists/e1.sql
@@ -1,5 +1,13 @@
-SELECT t0.key1, t0.key2, t0.value1 
-FROM foo_t AS t0 
-WHERE EXISTS (SELECT 1 AS anon_1 
-FROM bar_t AS t1 
-WHERE t0.key1 = t1.key1)
+SELECT
+  t0.key1,
+  t0.key2,
+  t0.value1
+FROM foo_t AS t0
+WHERE
+  EXISTS(
+    SELECT
+      1 AS anon_1
+    FROM bar_t AS t1
+    WHERE
+      t0.key1 = t1.key1
+  )

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_exists/e2.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_exists/e2.sql
@@ -1,5 +1,13 @@
-SELECT t0.key1, t0.key2, t0.value1 
-FROM foo_t AS t0 
-WHERE EXISTS (SELECT 1 AS anon_1 
-FROM bar_t AS t1 
-WHERE t0.key1 = t1.key1 AND t1.key2 = 'foo')
+SELECT
+  t0.key1,
+  t0.key2,
+  t0.value1
+FROM foo_t AS t0
+WHERE
+  EXISTS(
+    SELECT
+      1 AS anon_1
+    FROM bar_t AS t1
+    WHERE
+      t0.key1 = t1.key1 AND t1.key2 = 'foo'
+  )

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_filter_group_by_agg_with_same_name/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_filter_group_by_agg_with_same_name/out.sql
@@ -1,4 +1,13 @@
-SELECT t0.int_col, t0.bigint_col 
-FROM (SELECT t1.int_col AS int_col, sum(t1.bigint_col) AS bigint_col 
-FROM t AS t1 GROUP BY 1) AS t0 
-WHERE t0.bigint_col = 60
+SELECT
+  t0.int_col,
+  t0.bigint_col
+FROM (
+  SELECT
+    t1.int_col AS int_col,
+    SUM(t1.bigint_col) AS bigint_col
+  FROM t AS t1
+  GROUP BY
+    1
+) AS t0
+WHERE
+  t0.bigint_col = 60

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_gh_1045/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_gh_1045/out.sql
@@ -1,0 +1,40 @@
+SELECT
+  t0.t1_id1,
+  t0.t1_val1,
+  t1.dt,
+  t1.id3,
+  t1.t3_val2,
+  t1.id2a,
+  t1.id2b,
+  t1.val2
+FROM (
+  SELECT
+    t2.id1 AS t1_id1,
+    t2.val1 AS t1_val1
+  FROM test1 AS t2
+) AS t0
+LEFT OUTER JOIN (
+  SELECT
+    t2.dt AS dt,
+    t2.id3 AS id3,
+    t2.t3_val2 AS t3_val2,
+    t3.id2a AS id2a,
+    t3.id2b AS id2b,
+    t3.val2 AS val2
+  FROM (
+    SELECT
+      t4.dt AS dt,
+      t4.id3 AS id3,
+      t4.id3 AS t3_val2
+    FROM (
+      SELECT
+        t5.val2 AS val2,
+        t5.dt AS dt,
+        CAST(t5.id3 AS BIGINT) AS id3
+      FROM test3 AS t5
+    ) AS t4
+  ) AS t2
+  JOIN test2 AS t3
+    ON t3.id2b = t2.id3
+) AS t1
+  ON t0.t1_id1 = t1.id2a

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_isnull_notnull/isnull/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_isnull_notnull/isnull/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col IS NULL AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_isnull_notnull/notnull/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_isnull_notnull/notnull/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  NOT t0.double_col IS NULL AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_join_just_materialized/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_join_just_materialized/out.sql
@@ -1,0 +1,21 @@
+SELECT
+  t0.n_nationkey,
+  t0.n_name,
+  t0.n_regionkey,
+  t0.n_comment,
+  t1.r_regionkey,
+  t1.r_name,
+  t1.r_comment,
+  t2.c_custkey,
+  t2.c_name,
+  t2.c_address,
+  t2.c_nationkey,
+  t2.c_phone,
+  t2.c_acctbal,
+  t2.c_mktsegment,
+  t2.c_comment
+FROM tpch_nation AS t0
+JOIN tpch_region AS t1
+  ON t0.n_regionkey = t1.r_regionkey
+JOIN tpch_customer AS t2
+  ON t0.n_nationkey = t2.c_nationkey

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/inner/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/inner/out.sql
@@ -1,0 +1,11 @@
+SELECT
+  t0.r_regionkey,
+  t0.r_name,
+  t0.r_comment,
+  t1.n_nationkey,
+  t1.n_name,
+  t1.n_regionkey,
+  t1.n_comment
+FROM tpch_region AS t0
+JOIN tpch_nation AS t1
+  ON t0.r_regionkey = t1.n_regionkey

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/inner_select/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/inner_select/out.sql
@@ -1,0 +1,8 @@
+SELECT
+  t1.n_nationkey,
+  t1.n_name,
+  t1.n_regionkey,
+  t1.n_comment
+FROM tpch_region AS t0
+JOIN tpch_nation AS t1
+  ON t0.r_regionkey = t1.n_regionkey

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/left/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/left/out.sql
@@ -1,0 +1,11 @@
+SELECT
+  t0.r_regionkey,
+  t0.r_name,
+  t0.r_comment,
+  t1.n_nationkey,
+  t1.n_name,
+  t1.n_regionkey,
+  t1.n_comment
+FROM tpch_region AS t0
+LEFT OUTER JOIN tpch_nation AS t1
+  ON t0.r_regionkey = t1.n_regionkey

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/left_select/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/left_select/out.sql
@@ -1,0 +1,8 @@
+SELECT
+  t1.n_nationkey,
+  t1.n_name,
+  t1.n_regionkey,
+  t1.n_comment
+FROM tpch_region AS t0
+LEFT OUTER JOIN tpch_nation AS t1
+  ON t0.r_regionkey = t1.n_regionkey

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/outer/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/outer/out.sql
@@ -1,0 +1,11 @@
+SELECT
+  t0.r_regionkey,
+  t0.r_name,
+  t0.r_comment,
+  t1.n_nationkey,
+  t1.n_name,
+  t1.n_regionkey,
+  t1.n_comment
+FROM tpch_region AS t0
+FULL OUTER JOIN tpch_nation AS t1
+  ON t0.r_regionkey = t1.n_regionkey

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/outer_select/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_joins/outer_select/out.sql
@@ -1,0 +1,8 @@
+SELECT
+  t1.n_nationkey,
+  t1.n_name,
+  t1.n_regionkey,
+  t1.n_comment
+FROM tpch_region AS t0
+FULL OUTER JOIN tpch_nation AS t1
+  ON t0.r_regionkey = t1.n_regionkey

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit/expr_fn0/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit/expr_fn0/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM star1 AS t0
+LIMIT 10

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit/expr_fn1/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit/expr_fn1/out.sql
@@ -1,0 +1,8 @@
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM star1 AS t0
+LIMIT 10
+OFFSET 5

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit_filter/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit_filter/out.sql
@@ -1,0 +1,9 @@
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM star1 AS t0
+WHERE
+  t0.f > 0
+LIMIT 10

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit_subquery/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_limit_subquery/out.sql
@@ -1,0 +1,16 @@
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM (
+  SELECT
+    t1.c AS c,
+    t1.f AS f,
+    t1.foo_id AS foo_id,
+    t1.bar_id AS bar_id
+  FROM star1 AS t1
+  LIMIT 10
+) AS t0
+WHERE
+  t0.f > 0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_lower_projection_sort_key/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_lower_projection_sort_key/out.sql
@@ -1,6 +1,30 @@
-SELECT t0.foo_id, t0.total, t0.value1 
-FROM (SELECT t1.foo_id AS foo_id, t1.total AS total, t1.value1 AS value1 
-FROM (SELECT t2.foo_id AS foo_id, t2.total AS total, t3.value1 AS value1 
-FROM (SELECT t4.foo_id AS foo_id, sum(t4.f) AS total 
-FROM star1 AS t4 GROUP BY 1) AS t2 JOIN star2 AS t3 ON t2.foo_id = t3.foo_id) AS t1 
-WHERE t1.total > 100) AS t0 ORDER BY t0.total DESC
+SELECT
+  t0.foo_id,
+  t0.total,
+  t0.value1
+FROM (
+  SELECT
+    t1.foo_id AS foo_id,
+    t1.total AS total,
+    t1.value1 AS value1
+  FROM (
+    SELECT
+      t2.foo_id AS foo_id,
+      t2.total AS total,
+      t3.value1 AS value1
+    FROM (
+      SELECT
+        t4.foo_id AS foo_id,
+        SUM(t4.f) AS total
+      FROM star1 AS t4
+      GROUP BY
+        1
+    ) AS t2
+    JOIN star2 AS t3
+      ON t2.foo_id = t3.foo_id
+  ) AS t1
+  WHERE
+    t1.total > 100
+) AS t0
+ORDER BY
+  t0.total DESC

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_multi_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_multi_join/out.sql
@@ -1,0 +1,20 @@
+SELECT
+  t0.x1,
+  t0.y1,
+  t1.x2,
+  t2.x3,
+  t2.y2,
+  t2.x4
+FROM t1 AS t0
+JOIN t2 AS t1
+  ON t0.x1 = t1.x2
+JOIN (
+  SELECT
+    t3.x3 AS x3,
+    t3.y2 AS y2,
+    t4.x4 AS x4
+  FROM t3 AS t3
+  JOIN t4 AS t4
+    ON t3.x3 = t4.x4
+) AS t2
+  ON t0.y1 = t2.y2

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_mutate_filter_join_no_cross_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_mutate_filter_join_no_cross_join/out.sql
@@ -1,0 +1,11 @@
+SELECT
+  t0.person_id
+FROM (
+  SELECT
+    t1.person_id AS person_id,
+    t1.birth_datetime AS birth_datetime,
+    400 AS age
+  FROM person AS t1
+) AS t0
+WHERE
+  t0.age <= 40

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_named_expr/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_named_expr/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col * 2 AS foo
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_negate/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_negate/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  t0.double_col <= 0 AS tmp
+FROM functional_alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cart_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cart_join/out.sql
@@ -1,3 +1,20 @@
-SELECT t1.ancestor_node_sort_order, 1 AS n 
-FROM facts AS t0 JOIN (SELECT t2.ancestor_level_name AS ancestor_level_name, t2.ancestor_level_number AS ancestor_level_number, t2.ancestor_node_sort_order AS ancestor_node_sort_order, t2.descendant_node_natural_key AS descendant_node_natural_key, concat(lpad('-', (t2.ancestor_level_number - 1) * 7, '-'), t2.ancestor_level_name) AS product_level_name 
-FROM products AS t2) AS t1 ON t0.product_id = t1.descendant_node_natural_key GROUP BY 1 ORDER BY t1.ancestor_node_sort_order ASC
+SELECT
+  t1.ancestor_node_sort_order,
+  1 AS n
+FROM facts AS t0
+JOIN (
+  SELECT
+    t2.ancestor_level_name AS ancestor_level_name,
+    t2.ancestor_level_number AS ancestor_level_number,
+    t2.ancestor_node_sort_order AS ancestor_node_sort_order,
+    t2.descendant_node_natural_key AS descendant_node_natural_key,
+    CONCAT(LPAD('-', (
+      t2.ancestor_level_number - 1
+    ) * 7, '-'), t2.ancestor_level_name) AS product_level_name
+  FROM products AS t2
+) AS t1
+  ON t0.product_id = t1.descendant_node_natural_key
+GROUP BY
+  1
+ORDER BY
+  t1.ancestor_node_sort_order

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cross_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cross_join/out.sql
@@ -1,0 +1,16 @@
+SELECT
+  t0.id AS id_x,
+  t0.personal,
+  t0.family,
+  t1.taken,
+  t1.person,
+  t1.quant,
+  t1.reading,
+  t2.id AS id_y,
+  t2.site,
+  t2.dated
+FROM person AS t0
+JOIN survey AS t1
+  ON t0.id = t1.person
+JOIN visited AS t2
+  ON t2.id = t1.taken

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_not_exists/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_not_exists/out.sql
@@ -1,5 +1,15 @@
-SELECT t0.key1, t0.key2, t0.value1 
-FROM foo_t AS t0 
-WHERE NOT (EXISTS (SELECT 1 AS anon_1 
-FROM bar_t AS t1 
-WHERE t0.key1 = t1.key1))
+SELECT
+  t0.key1,
+  t0.key2,
+  t0.value1
+FROM foo_t AS t0
+WHERE
+  NOT (
+    EXISTS(
+      SELECT
+        1 AS anon_1
+      FROM bar_t AS t1
+      WHERE
+        t0.key1 = t1.key1
+    )
+  )

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by/ascending/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by/ascending/out.sql
@@ -1,0 +1,8 @@
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM star1 AS t0
+ORDER BY
+  t0.f DESC

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by/column/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by/column/out.sql
@@ -1,0 +1,8 @@
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM star1 AS t0
+ORDER BY
+  t0.f

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by/mixed/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by/mixed/out.sql
@@ -1,0 +1,9 @@
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM star1 AS t0
+ORDER BY
+  t0.c,
+  t0.f DESC

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by/random/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by/random/out.sql
@@ -1,0 +1,8 @@
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM star1 AS t0
+ORDER BY
+  RANDOM()

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by_expr/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_order_by_expr/out.sql
@@ -1,4 +1,13 @@
-SELECT t0.a, t0.b 
-FROM (SELECT t1.a AS a, t1.b AS b 
-FROM t AS t1 
-WHERE t1.a = 1) AS t0 ORDER BY concat(t0.b, 'a') ASC
+SELECT
+  t0.a,
+  t0.b
+FROM (
+  SELECT
+    t1.a AS a,
+    t1.b AS b
+  FROM t AS t1
+  WHERE
+    t1.a = 1
+) AS t0
+ORDER BY
+  CONCAT(t0.b, 'a')

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_searched_case/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_searched_case/out.sql
@@ -1,0 +1,13 @@
+SELECT
+  CASE
+    WHEN (
+      t0.f > 0
+    )
+    THEN t0.d * 2
+    WHEN (
+      t0.c < 0
+    )
+    THEN t0.a * 2
+    ELSE CAST(NULL AS BIGINT)
+  END AS tmp
+FROM alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_self_reference_in_not_exists/anti.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_self_reference_in_not_exists/anti.sql
@@ -1,5 +1,25 @@
-SELECT t0.id, t0.bool_col, t0.tinyint_col, t0.smallint_col, t0.int_col, t0.bigint_col, t0.float_col, t0.double_col, t0.date_string_col, t0.string_col, t0.timestamp_col, t0.year, t0.month 
-FROM functional_alltypes AS t0 
-WHERE NOT (EXISTS (SELECT 1 AS anon_1 
-FROM functional_alltypes AS t1 
-WHERE t0.string_col = t1.string_col))
+SELECT
+  t0.id,
+  t0.bool_col,
+  t0.tinyint_col,
+  t0.smallint_col,
+  t0.int_col,
+  t0.bigint_col,
+  t0.float_col,
+  t0.double_col,
+  t0.date_string_col,
+  t0.string_col,
+  t0.timestamp_col,
+  t0.year,
+  t0.month
+FROM functional_alltypes AS t0
+WHERE
+  NOT (
+    EXISTS(
+      SELECT
+        1 AS anon_1
+      FROM functional_alltypes AS t1
+      WHERE
+        t0.string_col = t1.string_col
+    )
+  )

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_self_reference_in_not_exists/semi.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_self_reference_in_not_exists/semi.sql
@@ -1,5 +1,23 @@
-SELECT t0.id, t0.bool_col, t0.tinyint_col, t0.smallint_col, t0.int_col, t0.bigint_col, t0.float_col, t0.double_col, t0.date_string_col, t0.string_col, t0.timestamp_col, t0.year, t0.month 
-FROM functional_alltypes AS t0 
-WHERE EXISTS (SELECT 1 AS anon_1 
-FROM functional_alltypes AS t1 
-WHERE t0.string_col = t1.string_col)
+SELECT
+  t0.id,
+  t0.bool_col,
+  t0.tinyint_col,
+  t0.smallint_col,
+  t0.int_col,
+  t0.bigint_col,
+  t0.float_col,
+  t0.double_col,
+  t0.date_string_col,
+  t0.string_col,
+  t0.timestamp_col,
+  t0.year,
+  t0.month
+FROM functional_alltypes AS t0
+WHERE
+  EXISTS(
+    SELECT
+      1 AS anon_1
+    FROM functional_alltypes AS t1
+    WHERE
+      t0.string_col = t1.string_col
+  )

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_self_reference_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_self_reference_join/out.sql
@@ -1,2 +1,8 @@
-SELECT t0.c, t0.f, t0.foo_id, t0.bar_id 
-FROM star1 AS t0 JOIN star1 AS t1 ON t0.foo_id = t1.bar_id
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM star1 AS t0
+JOIN star1 AS t1
+  ON t0.foo_id = t1.bar_id

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_simple_case/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_simple_case/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  CASE t0.g WHEN 'foo' THEN 'bar' WHEN 'baz' THEN 'qux' ELSE 'default' END AS tmp
+FROM alltypes AS t0

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_sort_aggregation_translation_failure/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_sort_aggregation_translation_failure/out.sql
@@ -1,0 +1,13 @@
+SELECT
+  t0.string_col,
+  t0.foo
+FROM (
+  SELECT
+    t1.string_col AS string_col,
+    MAX(t1.double_col) AS foo
+  FROM functional_alltypes AS t1
+  GROUP BY
+    1
+) AS t0
+ORDER BY
+  t0.foo DESC

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_subquery_aliased/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_subquery_aliased/out.sql
@@ -1,3 +1,14 @@
-SELECT t0.foo_id, t0.total, t1.value1 
-FROM (SELECT t2.foo_id AS foo_id, sum(t2.f) AS total 
-FROM star1 AS t2 GROUP BY 1) AS t0 JOIN star2 AS t1 ON t0.foo_id = t1.foo_id
+SELECT
+  t0.foo_id,
+  t0.total,
+  t1.value1
+FROM (
+  SELECT
+    t2.foo_id AS foo_id,
+    SUM(t2.f) AS total
+  FROM star1 AS t2
+  GROUP BY
+    1
+) AS t0
+JOIN star2 AS t1
+  ON t0.foo_id = t1.foo_id

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_tpc_h11/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_tpc_h11/out.sql
@@ -1,0 +1,40 @@
+SELECT
+  t0.ps_partkey,
+  t0.value
+FROM (
+  SELECT
+    t1.ps_partkey AS ps_partkey,
+    t1.value AS value
+  FROM (
+    SELECT
+      t2.ps_partkey AS ps_partkey,
+      SUM(t2.ps_supplycost * t2.ps_availqty) AS value
+    FROM partsupp AS t2
+    JOIN supplier AS t3
+      ON t2.ps_suppkey = t3.s_suppkey
+    JOIN nation AS t4
+      ON t4.n_nationkey = t3.s_nationkey
+    WHERE
+      t4.n_name = 'GERMANY'
+    GROUP BY
+      1
+  ) AS t1
+  WHERE
+    t1.value > (
+      SELECT
+        anon_1.total
+      FROM (
+        SELECT
+          SUM(t2.ps_supplycost * t2.ps_availqty) AS total
+        FROM partsupp AS t2
+        JOIN supplier AS t3
+          ON t2.ps_suppkey = t3.s_suppkey
+        JOIN nation AS t4
+          ON t4.n_nationkey = t3.s_nationkey
+        WHERE
+          t4.n_name = 'GERMANY'
+      ) AS anon_1
+    ) * 0.0001
+) AS t0
+ORDER BY
+  t0.value DESC

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_correlated_subquery/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_correlated_subquery/out.sql
@@ -1,5 +1,14 @@
-SELECT t0.job, t0.dept_id, t0.year, t0.y 
-FROM foo AS t0 
-WHERE t0.y > (SELECT avg(t1.y) AS "Mean(y)" 
-FROM foo AS t1 
-WHERE t0.dept_id = t1.dept_id)
+SELECT
+  t0.job,
+  t0.dept_id,
+  t0.year,
+  t0.y
+FROM foo AS t0
+WHERE
+  t0.y > (
+    SELECT
+      AVG(t1.y) AS "Mean(y)"
+    FROM foo AS t1
+    WHERE
+      t0.dept_id = t1.dept_id
+  )

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_correlated_subquery_with_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_correlated_subquery_with_join/out.sql
@@ -1,0 +1,26 @@
+SELECT
+  t0.p_partkey,
+  t0.ps_supplycost
+FROM (
+  SELECT
+    t1.p_partkey AS p_partkey,
+    t2.ps_supplycost AS ps_supplycost
+  FROM part AS t1
+  JOIN partsupp AS t2
+    ON t1.p_partkey = t2.ps_partkey
+) AS t0
+WHERE
+  t0.ps_supplycost = (
+    SELECT
+      MIN(t1.ps_supplycost) AS "Min(ps_supplycost)"
+    FROM (
+      SELECT
+        t2.ps_partkey AS ps_partkey,
+        t2.ps_supplycost AS ps_supplycost
+      FROM partsupp AS t2
+      JOIN supplier AS t3
+        ON t3.s_suppkey = t2.ps_suppkey
+    ) AS t1
+    WHERE
+      t1.ps_partkey = t0.p_partkey
+  )

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_simple_comparisons/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_simple_comparisons/out.sql
@@ -1,3 +1,8 @@
-SELECT t0.c, t0.f, t0.foo_id, t0.bar_id 
-FROM star1 AS t0 
-WHERE t0.f > 0 AND t0.c < t0.f * 2
+SELECT
+  t0.c,
+  t0.f,
+  t0.foo_id,
+  t0.bar_id
+FROM star1 AS t0
+WHERE
+  t0.f > 0 AND t0.c < t0.f * 2

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_uncorrelated_subquery/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_uncorrelated_subquery/out.sql
@@ -1,4 +1,12 @@
-SELECT t0.job, t0.dept_id, t0.year, t0.y 
-FROM foo AS t0 
-WHERE t0.job IN (SELECT bar.job 
-FROM bar)
+SELECT
+  t0.job,
+  t0.dept_id,
+  t0.year,
+  t0.y
+FROM foo AS t0
+WHERE
+  t0.job IN (
+    SELECT
+      bar.job
+    FROM bar
+  )


### PR DESCRIPTION
This PR moves the tests in `test_sqlalchemy.py` to use snapshot testing.