### PR TITLE
feat(common): add support for variadic positional and variadic keyword annotations

### DIFF
--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -103,7 +103,7 @@ class Argument(Annotation):
         return cls(validator, kind=VAR_POSITIONAL)
 
     @classmethod
-    def varkwds(cls, validator=None):
+    def varkwargs(cls, validator=None):
         validator = None if validator is None else frozendict_of(any_, validator)
         return cls(validator, kind=VAR_KEYWORD)
 
@@ -240,7 +240,7 @@ class Signature(inspect.Signature):
             if param.kind is VAR_POSITIONAL:
                 annot = Argument.varargs(validator)
             elif param.kind is VAR_KEYWORD:
-                annot = Argument.varkwds(validator)
+                annot = Argument.varkwargs(validator)
             elif param.default is EMPTY:
                 annot = Argument.required(validator, kind=param.kind)
             else:
@@ -350,13 +350,13 @@ class Signature(inspect.Signature):
 
 
 # aliases for convenience
-attribute = Attribute
 argument = Argument
-required = Argument.required
-optional = Argument.optional
-varargs = Argument.varargs
-varkwds = Argument.varkwds
+attribute = Attribute
 default = Argument.default
+optional = Argument.optional
+required = Argument.required
+varargs = Argument.varargs
+varkwargs = Argument.varkwargs
 
 
 # TODO(kszucs): try to cache validator objects

--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -78,23 +78,23 @@ class Argument(Annotation):
         self._validator = validator
 
     @classmethod
-    def required(cls, validator=None):
+    def required(cls, validator=None, kind=POSITIONAL_OR_KEYWORD):
         """Annotation to mark a mandatory argument."""
-        return cls(validator)
+        return cls(validator=validator, kind=kind)
 
     @classmethod
-    def default(cls, default, validator=None):
+    def default(cls, default, validator=None, kind=POSITIONAL_OR_KEYWORD):
         """Annotation to allow missing arguments with a default value."""
-        return cls(validator, default=default)
+        return cls(validator=validator, default=default, kind=kind)
 
     @classmethod
-    def optional(cls, validator=None, default=None):
+    def optional(cls, validator=None, default=None, kind=POSITIONAL_OR_KEYWORD):
         """Annotation to allow and treat `None` values as missing arguments."""
         if validator is None:
             validator = option(any_, default=default)
         else:
             validator = option(validator, default=default)
-        return cls(validator, default=None)
+        return cls(validator=validator, default=None, kind=kind)
 
     @classmethod
     def varargs(cls, validator=None):
@@ -174,8 +174,12 @@ class Signature(inspect.Signature):
 
         for name, param in params.items():
             if param.kind == VAR_POSITIONAL:
+                if var_args:
+                    raise TypeError('only one variadic *args parameter is allowed')
                 var_args.append(param)
             elif param.kind == VAR_KEYWORD:
+                if var_kwargs:
+                    raise TypeError('only one variadic **kwargs parameter is allowed')
                 var_kwargs.append(param)
             elif name in inherited:
                 if param.default is EMPTY:
@@ -187,11 +191,6 @@ class Signature(inspect.Signature):
                     new_args.append(param)
                 else:
                     new_kwargs.append(param)
-
-        if len(var_args) > 1:
-            raise TypeError('only one variadic positional *args parameter is allowed')
-        if len(var_kwargs) > 1:
-            raise TypeError('only one variadic keywords **kwargs parameter is allowed')
 
         return cls(
             old_args + new_args + var_args + new_kwargs + old_kwargs + var_kwargs
@@ -229,9 +228,6 @@ class Signature(inspect.Signature):
 
         parameters = []
         for param in sig.parameters.values():
-            if param.kind in {POSITIONAL_ONLY, KEYWORD_ONLY}:
-                raise TypeError(f"unsupported parameter kind {param.kind} in {fn}")
-
             if param.name in validators:
                 validator = validators[param.name]
             elif param.annotation is not EMPTY:
@@ -246,9 +242,9 @@ class Signature(inspect.Signature):
             elif param.kind is VAR_KEYWORD:
                 annot = Argument.varkwds(validator)
             elif param.default is EMPTY:
-                annot = Argument.required(validator)
+                annot = Argument.required(validator, kind=param.kind)
             else:
-                annot = Argument.default(param.default, validator)
+                annot = Argument.default(param.default, validator, kind=param.kind)
 
             parameters.append(Parameter(param.name, annot))
 
@@ -288,6 +284,10 @@ class Signature(inspect.Signature):
                 args.extend(value)
             elif param.kind is VAR_KEYWORD:
                 kwargs.update(value)
+            elif param.kind is KEYWORD_ONLY:
+                kwargs[name] = value
+            elif param.kind is POSITIONAL_ONLY:
+                args.append(value)
             else:
                 raise TypeError(f"unsupported parameter kind {param.kind}")
         return tuple(args), kwargs
@@ -435,9 +435,13 @@ def annotated(_1=None, _2=None, _3=None, **kwargs):
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
+        # 1. Validate the passed arguments
         values = sig.validate(*args, **kwargs)
+        # 2. Reconstruction of the original arguments
         args, kwargs = sig.unbind(values)
+        # 3. Call the function with the validated arguments
         result = func(*args, **kwargs)
+        # 4. Validate the return value
         return sig.validate_return(result)
 
     wrapped.__signature__ = sig

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -115,7 +115,7 @@ def test_signature():
 
 def test_signature_from_callable():
     def test(a: int, b: int, c: int = 1):
-        return a + b + c
+        ...
 
     sig = Signature.from_callable(test)
     assert sig.validate(2, 3) == {'a': 2, 'b': 3, 'c': 1}
@@ -130,7 +130,7 @@ def test_signature_from_callable():
 
 def test_signature_from_callable_with_varargs():
     def test(a: int, b: int, *args: int):
-        return a + b + sum(args)
+        ...
 
     sig = Signature.from_callable(test)
     assert sig.validate(2, 3) == {'a': 2, 'b': 3, 'args': ()}
@@ -147,7 +147,7 @@ def test_signature_from_callable_with_varargs():
 
 def test_signature_from_callable_with_positional_only_arguments():
     def test(a: int, b: int, /, c: int = 1):
-        return a + b + c
+        ...
 
     sig = Signature.from_callable(test)
     assert sig.validate(2, 3) == {'a': 2, 'b': 3, 'c': 1}
@@ -165,7 +165,7 @@ def test_signature_from_callable_with_positional_only_arguments():
 
 def test_signature_from_callable_with_keyword_only_arguments():
     def test(a: int, b: int, *, c: float, d: float = 0.0):
-        return a + b + c
+        ...
 
     sig = Signature.from_callable(test)
     assert sig.validate(2, 3, c=4.0) == {'a': 2, 'b': 3, 'c': 4.0, 'd': 0.0}
@@ -380,7 +380,7 @@ def test_annotated_function_with_varargs():
         test(1.0, 2.0, 3, 4, 5, 6.0)
 
 
-def test_annotated_function_with_varkwds():
+def test_annotated_function_with_varkwargs():
     @annotated
     def test(a: float, b: float, **kwargs: int):
         return sum((a, b) + tuple(kwargs.values()))

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -12,7 +12,7 @@ from ibis.common.annotations import (
     optional,
     required,
     varargs,
-    varkwds,
+    varkwargs,
 )
 from ibis.common.caching import WeakCache
 from ibis.common.grounds import (
@@ -75,12 +75,12 @@ class VariadicArgs(Concrete):
 
 
 class VariadicKeywords(Concrete):
-    kwargs = varkwds(is_int)
+    kwargs = varkwargs(is_int)
 
 
 class VariadicArgsAndKeywords(Concrete):
     args = varargs(is_int)
-    kwargs = varkwds(is_int)
+    kwargs = varkwargs(is_int)
 
 
 def test_annotable():
@@ -354,11 +354,11 @@ def test_variadic_keyword_argument_reordering():
     class Test(Annotable):
         a = is_int
         b = is_int
-        options = varkwds(is_int)
+        options = varkwargs(is_int)
 
     class Test2(Test):
         c = is_int
-        options = varkwds(is_int)
+        options = varkwargs(is_int)
 
     with pytest.raises(TypeError, match="missing a required argument: 'c'"):
         Test2(1, 2)
@@ -379,7 +379,7 @@ def test_variadic_keyword_argument_reordering():
     with pytest.raises(TypeError, match=msg):
 
         class Test3(Test):
-            another_options = varkwds(is_int)
+            another_options = varkwargs(is_int)
 
 
 def test_variadic_argument():
@@ -397,7 +397,7 @@ def test_variadic_keyword_argument():
     class Test(Annotable):
         first = is_int
         second = is_int
-        options = varkwds(is_int)
+        options = varkwargs(is_int)
 
     assert Test(1, 2).options == {}
     assert Test(1, 2, a=3).options == {'a': 3}

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -343,7 +343,7 @@ def test_variadic_argument_reordering():
     assert b.c == 2
     assert b.args == (3, 4)
 
-    msg = "only one variadic positional \\*args parameter is allowed"
+    msg = "only one variadic \\*args parameter is allowed"
     with pytest.raises(TypeError, match=msg):
 
         class Test3(Test):
@@ -375,7 +375,7 @@ def test_variadic_keyword_argument_reordering():
     assert b.c == 3
     assert b.options == {'d': 4, 'e': 5}
 
-    msg = "only one variadic keywords \\*\\*kwargs parameter is allowed"
+    msg = "only one variadic \\*\\*kwargs parameter is allowed"
     with pytest.raises(TypeError, match=msg):
 
         class Test3(Test):

--- a/ibis/common/tests/test_validators.py
+++ b/ibis/common/tests/test_validators.py
@@ -181,7 +181,10 @@ def test_callable_with():
     def func(a, b):
         return str(a) + b
 
-    def func_with_kwargs(a, b, c=1):
+    def func_with_args(a, b, *args):
+        return sum((a, b) + args)
+
+    def func_with_kwargs(a, b, c=1, **kwargs):
         return str(a) + b + str(c)
 
     def func_with_mandatory_kwargs(*, c):
@@ -200,6 +203,9 @@ def test_callable_with():
     msg = "Callable has less positional arguments than expected"
     with pytest.raises(TypeError, match=msg):
         callable_with([instance_of(int)] * 4, instance_of(str), func_with_kwargs)
+
+    wrapped = callable_with([instance_of(int)] * 4, instance_of(int), func_with_args)
+    assert wrapped(1, 2, 3, 4) == 10
 
     wrapped = callable_with(
         [instance_of(int), instance_of(str)], instance_of(str), func

--- a/ibis/common/tests/test_validators.py
+++ b/ibis/common/tests/test_validators.py
@@ -190,10 +190,12 @@ def test_callable_with():
     def func_with_mandatory_kwargs(*, c):
         return c
 
-    with pytest.raises(TypeError, match="Argument must be a callable"):
+    msg = "Argument must be a callable"
+    with pytest.raises(TypeError, match=msg):
         callable_with([instance_of(int), instance_of(str)], 10, "string")
 
-    with pytest.raises(TypeError, match="unsupported parameter kind KEYWORD_ONLY"):
+    msg = "Callable has mandatory keyword-only arguments which cannot be specified"
+    with pytest.raises(TypeError, match=msg):
         callable_with([instance_of(int)], instance_of(str), func_with_mandatory_kwargs)
 
     msg = "Callable has more positional arguments than expected"


### PR DESCRIPTION
The main motivation for this change was to not limit `callable_with` support for functions with either variadic positional or variadic keyword arguments. `callable_with` converts the passed callable into an `@annotated` function which hasn't been supporting variadic arguments. 

To be precise, the annotation system used to support variadic arguments but we removed it due to implementation complications around node traversal (e.g. `NodeList`) and confusion when reconstructing annotable nodes. This time I managed to come up with a simpler and more complete implementation supporting variadic arguments for both function annotations via `@annotated`, variadic arguments for `Annotable` using `rlz.varargs()` and `rlz.varkwds()`. 