### PR TITLE
fix(ir): make `find_subqueries` return in topological order

### DIFF
--- a/ibis/backends/bigquery/tests/system/snapshots/test_client/test_cross_project_query/out.sql
+++ b/ibis/backends/bigquery/tests/system/snapshots/test_client/test_cross_project_query/out.sql
@@ -1,0 +1,6 @@
+SELECT t0.`title`, t0.`tags`
+FROM (
+  SELECT t1.*
+  FROM `bigquery-public-data.stackoverflow.posts_questions` t1
+  WHERE STRPOS(t1.`tags`, 'ibis') - 1 >= 0
+) t0

--- a/ibis/backends/bigquery/tests/system/snapshots/test_client/test_subquery_scalar_params/out.sql
+++ b/ibis/backends/bigquery/tests/system/snapshots/test_client/test_subquery_scalar_params/out.sql
@@ -1,0 +1,11 @@
+WITH t0 AS (
+  SELECT t2.`float_col`, t2.`timestamp_col`, t2.`int_col`, t2.`string_col`
+  FROM `ibis-gbq.ibis_gbq_testing.functional_alltypes` t2
+  WHERE t2.`timestamp_col` < @param_0
+)
+SELECT count(t1.`foo`) AS `count`
+FROM (
+  SELECT t0.`string_col`, sum(t0.`float_col`) AS `foo`
+  FROM t0
+  GROUP BY 1
+) t1

--- a/ibis/backends/impala/tests/snapshots/test_exprs/test_filter_with_analytic/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_exprs/test_filter_with_analytic/out.sql
@@ -1,15 +1,18 @@
-SELECT t0.`col`, t0.`analytic`
+WITH t0 AS (
+  SELECT t4.`col`, NULL AS `filter`
+  FROM x t4
+),
+t1 AS (
+  SELECT t0.*
+  FROM t0
+  WHERE t0.`filter` IS NULL
+),
+t2 AS (
+  SELECT t1.`col`, t1.`filter`
+  FROM t1
+)
+SELECT t3.`col`, t3.`analytic`
 FROM (
-  SELECT t1.`col`, count(1) OVER () AS `analytic`
-  FROM (
-    SELECT t2.`col`, t2.`filter`
-    FROM (
-      SELECT t3.*
-      FROM (
-        SELECT t4.`col`, NULL AS `filter`
-        FROM x t4
-      ) t3
-      WHERE t3.`filter` IS NULL
-    ) t2
-  ) t1
-) t0
+  SELECT t2.`col`, count(1) OVER () AS `analytic`
+  FROM t2
+) t3

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_join_aliasing/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_join_aliasing/out.sql
@@ -1,36 +1,39 @@
 WITH t0 AS (
-  SELECT t2.`d`, t2.`c`
-  FROM t2
+  SELECT t7.*, t7.`a` + 20 AS `d`
+  FROM test_table t7
 ),
 t1 AS (
-  SELECT t0.`d`, CAST(t0.`d` / 15 AS bigint) AS `idx`, t0.`c`,
-         count(1) AS `row_count`
+  SELECT t0.`d`, t0.`c`
   FROM t0
-  GROUP BY 1, 2, 3
 ),
 t2 AS (
-  SELECT t5.*, t5.`a` + 20 AS `d`
-  FROM test_table t5
-)
-SELECT t3.*, t4.`total`
-FROM (
-  SELECT t2.`d`, t2.`b`, count(1) AS `count`,
-         count(DISTINCT t2.`c`) AS `unique`
+  SELECT t1.`d`, CAST(t1.`d` / 15 AS bigint) AS `idx`, t1.`c`,
+         count(1) AS `row_count`
+  FROM t1
+  GROUP BY 1, 2, 3
+),
+t3 AS (
+  SELECT t2.`d`, sum(t2.`row_count`) AS `total`
   FROM t2
+  GROUP BY 1
+),
+t4 AS (
+  SELECT t2.*, t3.`total`
+  FROM t2
+    INNER JOIN t3
+      ON t2.`d` = t3.`d`
+),
+t5 AS (
+  SELECT t4.*
+  FROM t4
+  WHERE t4.`row_count` < (t4.`total` / 2)
+)
+SELECT t6.*, t5.`total`
+FROM (
+  SELECT t0.`d`, t0.`b`, count(1) AS `count`,
+         count(DISTINCT t0.`c`) AS `unique`
+  FROM t0
   GROUP BY 1, 2
-) t3
-  INNER JOIN (
-    SELECT t5.*
-    FROM (
-      SELECT t1.*, t7.`total`
-      FROM t1
-        INNER JOIN (
-          SELECT t1.`d`, sum(t1.`row_count`) AS `total`
-          FROM t1
-          GROUP BY 1
-        ) t7
-          ON t1.`d` = t7.`d`
-    ) t5
-    WHERE t5.`row_count` < (t5.`total` / 2)
-  ) t4
-    ON t3.`d` = t4.`d`
+) t6
+  INNER JOIN t5
+    ON t6.`d` = t5.`d`

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_limit_cte_extract/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_limit_cte_extract/out.sql
@@ -1,8 +1,11 @@
-WITH t0 AS (
+SELECT t0.*
+FROM (
   SELECT t2.*
   FROM functional_alltypes t2
   LIMIT 100
-)
-SELECT t0.*
-FROM t0
-  CROSS JOIN t0 t1
+) t0
+  CROSS JOIN (
+    SELECT t2.*
+    FROM functional_alltypes t2
+    LIMIT 100
+  ) t1

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_multiple_filters2/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_multiple_filters2/out.sql
@@ -1,9 +1,10 @@
-SELECT t0.*
-FROM (
+WITH t0 AS (
   SELECT t1.*
   FROM t0 t1
   WHERE t1.`a` < 100
-) t0
+)
+SELECT t0.*
+FROM t0
 WHERE (t0.`a` = (
   SELECT max(t1.`a`) AS `Max(a)`
   FROM t0 t1

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_nested_join_base/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_nested_join_base/out.sql
@@ -2,12 +2,13 @@ WITH t0 AS (
   SELECT t2.`uuid`, count(1) AS `count`
   FROM t t2
   GROUP BY 1
-)
-SELECT t0.*
-FROM (
+),
+t1 AS (
   SELECT t0.`uuid`, max(t0.`count`) AS `max_count`
   FROM t0
   GROUP BY 1
-) t1
+)
+SELECT t0.*
+FROM t1
   LEFT OUTER JOIN t0
     ON t1.`uuid` = t0.`uuid`

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_nested_join_multiple_ctes/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_nested_join_multiple_ctes/out.sql
@@ -1,29 +1,30 @@
 WITH t0 AS (
-  SELECT t2.`userid`, t2.`movieid`, t2.`rating`,
-         CAST(t2.`timestamp` AS timestamp) AS `datetime`
-  FROM ratings t2
+  SELECT t2.*
+  FROM t2
+  WHERE (t2.`userid` = 118205) AND
+        (extract(t2.`datetime`, 'year') > 2001) AND
+        (t2.`userid` = 118205) AND
+        (extract(t2.`datetime`, 'year') < 2009)
 ),
 t1 AS (
-  SELECT t0.*, t3.`title`
-  FROM t0
-    INNER JOIN movies t3
-      ON t0.`movieid` = t3.`movieid`
+  SELECT t3.`userid`, t3.`movieid`, t3.`rating`,
+         CAST(t3.`timestamp` AS timestamp) AS `datetime`
+  FROM ratings t3
+),
+t2 AS (
+  SELECT t1.*, t4.`title`
+  FROM t1
+    INNER JOIN movies t4
+      ON t1.`movieid` = t4.`movieid`
 )
-SELECT t1.*
-FROM t1
-WHERE (t1.`userid` = 118205) AND
-      (extract(t1.`datetime`, 'year') > 2001) AND
-      (t1.`movieid` IN (
-  SELECT t2.`movieid`
+SELECT t2.*
+FROM t2
+WHERE (t2.`userid` = 118205) AND
+      (extract(t2.`datetime`, 'year') > 2001) AND
+      (t2.`movieid` IN (
+  SELECT t3.`movieid`
   FROM (
-    SELECT t3.`movieid`
-    FROM (
-      SELECT t1.*
-      FROM t1
-      WHERE (t1.`userid` = 118205) AND
-            (extract(t1.`datetime`, 'year') > 2001) AND
-            (t1.`userid` = 118205) AND
-            (extract(t1.`datetime`, 'year') < 2009)
-    ) t3
-  ) t2
+    SELECT t0.`movieid`
+    FROM t0
+  ) t3
 ))

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_nested_joins_single_cte/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_nested_joins_single_cte/out.sql
@@ -1,23 +1,26 @@
 WITH t0 AS (
-  SELECT t3.`uuid`, count(1) AS `count`
-  FROM t t3
+  SELECT t4.`uuid`, count(1) AS `count`
+  FROM t t4
   GROUP BY 1
-)
-SELECT t1.*, t2.`last_visit`
-FROM (
+),
+t1 AS (
+  SELECT t0.`uuid`, max(t0.`count`) AS `max_count`
+  FROM t0
+  GROUP BY 1
+),
+t2 AS (
+  SELECT t4.`uuid`, max(t4.`ts`) AS `last_visit`
+  FROM t t4
+  GROUP BY 1
+),
+t3 AS (
   SELECT t0.*
-  FROM (
-    SELECT t0.`uuid`, max(t0.`count`) AS `max_count`
-    FROM t0
-    GROUP BY 1
-  ) t3
+  FROM t1
     LEFT OUTER JOIN t0
-      ON (t3.`uuid` = t0.`uuid`) AND
-         (t3.`max_count` = t0.`count`)
-) t1
-  LEFT OUTER JOIN (
-    SELECT t3.`uuid`, max(t3.`ts`) AS `last_visit`
-    FROM t t3
-    GROUP BY 1
-  ) t2
-    ON t1.`uuid` = t2.`uuid`
+      ON (t1.`uuid` = t0.`uuid`) AND
+         (t1.`max_count` = t0.`count`)
+)
+SELECT t3.*, t2.`last_visit`
+FROM t3
+  LEFT OUTER JOIN t2
+    ON t3.`uuid` = t2.`uuid`

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -195,7 +195,7 @@ class Backend(BaseSQLBackend):
             expr.op(),
             scope=scope,
             timecontext=timecontext,
-            session=self._session,
+            session=getattr(self, "_session", None),
         )
 
     def execute(self, expr: ir.Expr, **kwargs: Any) -> Any:

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/bigquery/out.sql
@@ -1,0 +1,36 @@
+WITH t0 AS (
+  SELECT
+    t5.*,
+    (
+      ROW_NUMBER() OVER (ORDER BY t5.`street`) - 1
+    ) AS `key`
+  FROM data AS t5
+), t1 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.`street`,
+    t0.`key`
+  FROM t0
+  INNER JOIN t1
+    ON t0.`key` = t1.`key`
+), t3 AS (
+  SELECT
+    t2.`street`,
+    (
+      ROW_NUMBER() OVER (ORDER BY t2.`street`) - 1
+    ) AS `key`
+  FROM t2
+), t4 AS (
+  SELECT
+    t3.`key`
+  FROM t3
+)
+SELECT
+  t3.`street`,
+  t3.`key`
+FROM t3
+INNER JOIN t4
+  ON t3.`key` = t4.`key`

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/clickhouse/out.sql
@@ -1,0 +1,74 @@
+SELECT
+  t5.street,
+  t5.key
+FROM (
+  SELECT
+    t4.street,
+    (
+      ROW_NUMBER() OVER (ORDER BY t4.street) - 1
+    ) AS key
+  FROM (
+    SELECT
+      t1.street,
+      t1.key
+    FROM (
+      SELECT
+        t0.*,
+        (
+          ROW_NUMBER() OVER (ORDER BY t0.street) - 1
+        ) AS key
+      FROM data AS t0
+    ) AS t1
+    INNER JOIN (
+      SELECT
+        t1.key
+      FROM (
+        SELECT
+          t0.*,
+          (
+            ROW_NUMBER() OVER (ORDER BY t0.street) - 1
+          ) AS key
+        FROM data AS t0
+      ) AS t1
+    ) AS t2
+      ON t1.key = t2.key
+  ) AS t4
+) AS t5
+INNER JOIN (
+  SELECT
+    t5.key
+  FROM (
+    SELECT
+      t4.street,
+      (
+        ROW_NUMBER() OVER (ORDER BY t4.street) - 1
+      ) AS key
+    FROM (
+      SELECT
+        t1.street,
+        t1.key
+      FROM (
+        SELECT
+          t0.*,
+          (
+            ROW_NUMBER() OVER (ORDER BY t0.street) - 1
+          ) AS key
+        FROM data AS t0
+      ) AS t1
+      INNER JOIN (
+        SELECT
+          t1.key
+        FROM (
+          SELECT
+            t0.*,
+            (
+              ROW_NUMBER() OVER (ORDER BY t0.street) - 1
+            ) AS key
+          FROM data AS t0
+        ) AS t1
+      ) AS t2
+        ON t1.key = t2.key
+    ) AS t4
+  ) AS t5
+) AS t6
+  ON t5.key = t6.key

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/duckdb/out.sql
@@ -1,0 +1,32 @@
+WITH t0 AS (
+  SELECT
+    t5.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t5.street) - 1 AS key
+  FROM data AS t5
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.street AS street,
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+), t3 AS (
+  SELECT
+    t2.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t2.street) - 1 AS key
+  FROM t2
+), t4 AS (
+  SELECT
+    t3.key AS key
+  FROM t3
+)
+SELECT
+  t3.street,
+  t3.key
+FROM t3
+JOIN t4
+  ON t3.key = t4.key

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/impala/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/impala/out.sql
@@ -1,0 +1,36 @@
+WITH t0 AS (
+  SELECT
+    t5.*,
+    (
+      ROW_NUMBER() OVER (ORDER BY t5.`street`) - 1
+    ) AS `key`
+  FROM `data` AS t5
+), t1 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.`street`,
+    t0.`key`
+  FROM t0
+  INNER JOIN t1
+    ON t0.`key` = t1.`key`
+), t3 AS (
+  SELECT
+    t2.`street`,
+    (
+      ROW_NUMBER() OVER (ORDER BY t2.`street`) - 1
+    ) AS `key`
+  FROM t2
+), t4 AS (
+  SELECT
+    t3.`key`
+  FROM t3
+)
+SELECT
+  t3.`street`,
+  t3.`key`
+FROM t3
+INNER JOIN t4
+  ON t3.`key` = t4.`key`

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/mssql/out.sql
@@ -1,0 +1,32 @@
+WITH t0 AS (
+  SELECT
+    t5.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t5.street) - 1 AS "key"
+  FROM data AS t5
+), t1 AS (
+  SELECT
+    t0."key" AS "key"
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.street AS street,
+    t0."key" AS "key"
+  FROM t0
+  JOIN t1
+    ON t0."key" = t1."key"
+), t3 AS (
+  SELECT
+    t2.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t2.street) - 1 AS "key"
+  FROM t2
+), t4 AS (
+  SELECT
+    t3."key" AS "key"
+  FROM t3
+)
+SELECT
+  t3.street,
+  t3."key"
+FROM t3
+JOIN t4
+  ON t3."key" = t4."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/mysql/out.sql
@@ -1,0 +1,32 @@
+WITH t0 AS (
+  SELECT
+    t5.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t5.street) - 1 AS `key`
+  FROM data AS t5
+), t1 AS (
+  SELECT
+    t0.`key` AS `key`
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.street AS street,
+    t0.`key` AS `key`
+  FROM t0
+  INNER JOIN t1
+    ON t0.`key` = t1.`key`
+), t3 AS (
+  SELECT
+    t2.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t2.street) - 1 AS `key`
+  FROM t2
+), t4 AS (
+  SELECT
+    t3.`key` AS `key`
+  FROM t3
+)
+SELECT
+  t3.street,
+  t3.`key`
+FROM t3
+INNER JOIN t4
+  ON t3.`key` = t4.`key`

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/postgres/out.sql
@@ -1,0 +1,32 @@
+WITH t0 AS (
+  SELECT
+    t5.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t5.street) - 1 AS key
+  FROM data AS t5
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.street AS street,
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+), t3 AS (
+  SELECT
+    t2.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t2.street) - 1 AS key
+  FROM t2
+), t4 AS (
+  SELECT
+    t3.key AS key
+  FROM t3
+)
+SELECT
+  t3.street,
+  t3.key
+FROM t3
+JOIN t4
+  ON t3.key = t4.key

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/sqlite/out.sql
@@ -1,0 +1,32 @@
+WITH t0 AS (
+  SELECT
+    t5.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t5.street) - 1 AS "key"
+  FROM data AS t5
+), t1 AS (
+  SELECT
+    t0."key" AS "key"
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.street AS street,
+    t0."key" AS "key"
+  FROM t0
+  JOIN t1
+    ON t0."key" = t1."key"
+), t3 AS (
+  SELECT
+    t2.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t2.street) - 1 AS "key"
+  FROM t2
+), t4 AS (
+  SELECT
+    t3."key" AS "key"
+  FROM t3
+)
+SELECT
+  t3.street,
+  t3."key"
+FROM t3
+JOIN t4
+  ON t3."key" = t4."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/trino/out.sql
@@ -1,0 +1,32 @@
+WITH t0 AS (
+  SELECT
+    t5.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t5.street) - 1 AS key
+  FROM data AS t5
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.street AS street,
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+), t3 AS (
+  SELECT
+    t2.street AS street,
+    ROW_NUMBER() OVER (ORDER BY t2.street) - 1 AS key
+  FROM t2
+), t4 AS (
+  SELECT
+    t3.key AS key
+  FROM t3
+)
+SELECT
+  t3.street,
+  t3.key
+FROM t3
+JOIN t4
+  ON t3.key = t4.key

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/bigquery/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.*
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+  INNER JOIN t1
+    ON t0.`key` = t1.`key`
+)
+SELECT
+  t2.`key`
+FROM t2
+INNER JOIN t2 AS t3
+  ON t2.`key` = t3.`key`

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/clickhouse/out.sql
@@ -1,0 +1,49 @@
+SELECT
+  t4.key
+FROM (
+  SELECT
+    t1.key
+  FROM (
+    SELECT
+      *
+    FROM leaf AS t0
+    WHERE
+      1
+  ) AS t1
+  INNER JOIN (
+    SELECT
+      t1.key
+    FROM (
+      SELECT
+        *
+      FROM leaf AS t0
+      WHERE
+        1
+    ) AS t1
+  ) AS t2
+    ON t1.key = t2.key
+) AS t4
+INNER JOIN (
+  SELECT
+    t1.key
+  FROM (
+    SELECT
+      *
+    FROM leaf AS t0
+    WHERE
+      1
+  ) AS t1
+  INNER JOIN (
+    SELECT
+      t1.key
+    FROM (
+      SELECT
+        *
+      FROM leaf AS t0
+      WHERE
+        1
+    ) AS t1
+  ) AS t2
+    ON t1.key = t2.key
+) AS t5
+  ON t4.key = t5.key

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/duckdb/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.key AS key
+  FROM leaf AS t4
+  WHERE
+    CAST(TRUE AS BOOLEAN)
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+)
+SELECT
+  t2.key
+FROM t2
+JOIN t2 AS t3
+  ON t2.key = t3.key

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/impala/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/impala/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.*
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.`key`
+  FROM t0
+  INNER JOIN t1
+    ON t0.`key` = t1.`key`
+)
+SELECT
+  t2.`key`
+FROM t2
+INNER JOIN t2 AS t3
+  ON t2.`key` = t3.`key`

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/mssql/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4."key" AS "key"
+  FROM leaf AS t4
+  WHERE
+    1 = 1
+), t1 AS (
+  SELECT
+    t0."key" AS "key"
+  FROM t0
+), t2 AS (
+  SELECT
+    t0."key" AS "key"
+  FROM t0
+  JOIN t1
+    ON t0."key" = t1."key"
+)
+SELECT
+  t2."key"
+FROM t2
+JOIN t2 AS t3
+  ON t2."key" = t3."key"

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/mysql/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.`key` AS `key`
+  FROM leaf AS t4
+  WHERE
+    TRUE = 1
+), t1 AS (
+  SELECT
+    t0.`key` AS `key`
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.`key` AS `key`
+  FROM t0
+  INNER JOIN t1
+    ON t0.`key` = t1.`key`
+)
+SELECT
+  t2.`key`
+FROM t2
+INNER JOIN t2 AS t3
+  ON t2.`key` = t3.`key`

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/postgres/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.key AS key
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+)
+SELECT
+  t2.key
+FROM t2
+JOIN t2 AS t3
+  ON t2.key = t3.key

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/snowflake/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.key AS key
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+)
+SELECT
+  t2.key
+FROM t2
+JOIN t2 AS t3
+  ON t2.key = t3.key

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/sqlite/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4."key" AS "key"
+  FROM leaf AS t4
+  WHERE
+    1 = 1
+), t1 AS (
+  SELECT
+    t0."key" AS "key"
+  FROM t0
+), t2 AS (
+  SELECT
+    t0."key" AS "key"
+  FROM t0
+  JOIN t1
+    ON t0."key" = t1."key"
+)
+SELECT
+  t2."key"
+FROM t2
+JOIN t2 AS t3
+  ON t2."key" = t3."key"

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/trino/out.sql
@@ -1,0 +1,22 @@
+WITH t0 AS (
+  SELECT
+    t4.key AS key
+  FROM leaf AS t4
+  WHERE
+    TRUE
+), t1 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+), t2 AS (
+  SELECT
+    t0.key AS key
+  FROM t0
+  JOIN t1
+    ON t0.key = t1.key
+)
+SELECT
+  t2.key
+FROM t2
+JOIN t2 AS t3
+  ON t2.key = t3.key

--- a/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/mssql/out.sql
@@ -1,0 +1,38 @@
+SELECT
+  CASE t0.continent
+    WHEN N'NA'
+    THEN N'North America'
+    WHEN N'SA'
+    THEN N'South America'
+    WHEN N'EU'
+    THEN N'Europe'
+    WHEN N'AF'
+    THEN N'Africa'
+    WHEN N'AS'
+    THEN N'Asia'
+    WHEN N'OC'
+    THEN N'Oceania'
+    WHEN N'AN'
+    THEN N'Antarctica'
+    ELSE N'Unknown continent'
+  END AS cont,
+  SUM(t0.population) AS total_pop
+FROM countries AS t0
+GROUP BY
+  CASE t0.continent
+    WHEN N'NA'
+    THEN N'North America'
+    WHEN N'SA'
+    THEN N'South America'
+    WHEN N'EU'
+    THEN N'Europe'
+    WHEN N'AF'
+    THEN N'Africa'
+    WHEN N'AS'
+    THEN N'Asia'
+    WHEN N'OC'
+    THEN N'Oceania'
+    WHEN N'AN'
+    THEN N'Antarctica'
+    ELSE N'Unknown continent'
+  END

--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -166,10 +166,7 @@ halt = False
 
 
 def traverse(
-    fn: Callable[[Node], tuple[bool | Iterable, Any]],
-    node: Iterable[Node],
-    dedup: bool = True,
-    filter=Node,
+    fn: Callable[[Node], tuple[bool | Iterable, Any]], node: Iterable[Node], filter=Node
 ) -> Iterator[Any]:
     """Utility for generic expression tree traversal.
 
@@ -180,8 +177,6 @@ def traverse(
         controls the traversal, and the second is the result if its not `None`.
     node
         The Node expression or a list of expressions.
-    dedup
-        Whether to allow expression traversal more than once
     filter
         Restrict initial traversal to this kind of node
     """
@@ -192,11 +187,10 @@ def traverse(
     while todo:
         node = todo.pop()
 
-        if dedup:
-            if node in seen:
-                continue
-            else:
-                seen.add(node)
+        if node in seen:
+            continue
+        else:
+            seen.add(node)
 
         control, result = fn(node)
         if result is not None:

--- a/ibis/tests/sql/snapshots/test_compiler/test_agg_and_non_agg_filter/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_agg_and_non_agg_filter/out.sql
@@ -1,9 +1,10 @@
-SELECT t0.*
-FROM (
+WITH t0 AS (
   SELECT t1.*
   FROM my_table t1
   WHERE t1.`a` < 100
-) t0
+)
+SELECT t0.*
+FROM t0
 WHERE (t0.`a` = (
   SELECT max(t1.`a`) AS `Max(a)`
   FROM my_table t1

--- a/ibis/tests/sql/snapshots/test_compiler/test_subquery_where_location/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_subquery_where_location/out.sql
@@ -1,10 +1,11 @@
-SELECT count(t0.`foo`) AS `Count(foo)`
+WITH t0 AS (
+  SELECT t2.`float_col`, t2.`timestamp_col`, t2.`int_col`, t2.`string_col`
+  FROM alltypes t2
+  WHERE t2.`timestamp_col` < '2014-01-01T00:00:00'
+)
+SELECT count(t1.`foo`) AS `Count(foo)`
 FROM (
-  SELECT t1.`string_col`, sum(t1.`float_col`) AS `foo`
-  FROM (
-    SELECT t2.`float_col`, t2.`timestamp_col`, t2.`int_col`, t2.`string_col`
-    FROM alltypes t2
-    WHERE t2.`timestamp_col` < '2014-01-01T00:00:00'
-  ) t1
+  SELECT t0.`string_col`, sum(t0.`float_col`) AS `foo`
+  FROM t0
   GROUP BY 1
-) t0
+) t1

--- a/ibis/tests/sql/snapshots/test_compiler/test_table_drop_with_filter/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_table_drop_with_filter/out.sql
@@ -1,18 +1,21 @@
-SELECT t0.*
+WITH t0 AS (
+  SELECT t4.`a`, t4.`b`, t4.`c` AS `C`
+  FROM t t4
+),
+t1 AS (
+  SELECT t0.*
+  FROM t0
+  WHERE t0.`C` = '2018-01-01T00:00:00'
+),
+t2 AS (
+  SELECT t1.`a`, t1.`b`, '2018-01-01T00:00:00' AS `the_date`
+  FROM t1
+)
+SELECT t3.*
 FROM (
-  SELECT t1.`a`
-  FROM (
-    SELECT t3.`a`, t3.`b`, '2018-01-01T00:00:00' AS `the_date`
-    FROM (
-      SELECT t4.*
-      FROM (
-        SELECT t5.`a`, t5.`b`, t5.`c` AS `C`
-        FROM t t5
-      ) t4
-      WHERE t4.`C` = '2018-01-01T00:00:00'
-    ) t3
-  ) t1
-    INNER JOIN s t2
-      ON t1.`b` = t2.`b`
-) t0
-WHERE t0.`a` < 1.0
+  SELECT t2.`a`
+  FROM t2
+    INNER JOIN s t5
+      ON t2.`b` = t5.`b`
+) t3
+WHERE t3.`a` < 1.0

--- a/ibis/tests/sql/snapshots/test_select_sql/test_bug_duplicated_where/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_bug_duplicated_where/out.sql
@@ -1,15 +1,17 @@
-SELECT t0.*
+WITH t0 AS (
+  SELECT t3.`arrdelay`, t3.`dest`
+  FROM airlines t3
+),
+t1 AS (
+  SELECT t0.*, avg(t0.`arrdelay`) OVER (PARTITION BY t0.`dest`) AS `dest_avg`,
+         t0.`arrdelay` - avg(t0.`arrdelay`) OVER (PARTITION BY t0.`dest`) AS `dev`
+  FROM t0
+)
+SELECT t2.*
 FROM (
   SELECT t1.*
-  FROM (
-    SELECT t2.*, avg(t2.`arrdelay`) OVER (PARTITION BY t2.`dest`) AS `dest_avg`,
-           t2.`arrdelay` - avg(t2.`arrdelay`) OVER (PARTITION BY t2.`dest`) AS `dev`
-    FROM (
-      SELECT t3.`arrdelay`, t3.`dest`
-      FROM airlines t3
-    ) t2
-  ) t1
+  FROM t1
   WHERE t1.`dev` IS NOT NULL
-) t0
-ORDER BY t0.`dev` DESC
+) t2
+ORDER BY t2.`dev` DESC
 LIMIT 10

--- a/ibis/tests/sql/snapshots/test_select_sql/test_bug_project_multiple_times/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_bug_project_multiple_times/out.sql
@@ -1,22 +1,23 @@
 WITH t0 AS (
-  SELECT t2.*, t3.`n_name`, t4.`r_name`
-  FROM tpch_customer t2
-    INNER JOIN tpch_nation t3
-      ON t2.`c_nationkey` = t3.`n_nationkey`
-    INNER JOIN tpch_region t4
-      ON t3.`n_regionkey` = t4.`r_regionkey`
+  SELECT t3.*, t4.`n_name`, t5.`r_name`
+  FROM tpch_customer t3
+    INNER JOIN tpch_nation t4
+      ON t3.`c_nationkey` = t4.`n_nationkey`
+    INNER JOIN tpch_region t5
+      ON t4.`n_regionkey` = t5.`r_regionkey`
+),
+t1 AS (
+  SELECT t0.`n_name`,
+         sum(CAST(t0.`c_acctbal` AS double)) AS `Sum(Cast(c_acctbal, float64))`
+  FROM t0
+  GROUP BY 1
 )
 SELECT t0.`c_name`, t0.`r_name`, t0.`n_name`
 FROM t0
   LEFT SEMI JOIN (
-    SELECT t2.*
-    FROM (
-      SELECT t0.`n_name`,
-             sum(CAST(t0.`c_acctbal` AS double)) AS `Sum(Cast(c_acctbal, float64))`
-      FROM t0
-      GROUP BY 1
-    ) t2
-    ORDER BY t2.`Sum(Cast(c_acctbal, float64))` DESC
+    SELECT t1.*
+    FROM t1
+    ORDER BY t1.`Sum(Cast(c_acctbal, float64))` DESC
     LIMIT 10
-  ) t1
-    ON t0.`n_name` = t1.`n_name`
+  ) t2
+    ON t0.`n_name` = t2.`n_name`

--- a/ibis/tests/sql/snapshots/test_select_sql/test_double_nested_subquery_no_aliases/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_double_nested_subquery_no_aliases/out.sql
@@ -1,11 +1,12 @@
-SELECT t0.`key1`, sum(t0.`total`) AS `total`
+WITH t0 AS (
+  SELECT t2.`key1`, t2.`key2`, t2.`key3`, sum(t2.`value`) AS `total`
+  FROM foo_table t2
+  GROUP BY 1, 2, 3
+)
+SELECT t1.`key1`, sum(t1.`total`) AS `total`
 FROM (
-  SELECT t1.`key1`, t1.`key2`, sum(t1.`total`) AS `total`
-  FROM (
-    SELECT t2.`key1`, t2.`key2`, t2.`key3`, sum(t2.`value`) AS `total`
-    FROM foo_table t2
-    GROUP BY 1, 2, 3
-  ) t1
+  SELECT t0.`key1`, t0.`key2`, sum(t0.`total`) AS `total`
+  FROM t0
   GROUP BY 1, 2
-) t0
+) t1
 GROUP BY 1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_filter_inside_exists/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_filter_inside_exists/out.sql
@@ -1,11 +1,12 @@
-SELECT t0.*
-FROM events t0
+WITH t0 AS (
+  SELECT t2.*
+  FROM purchases t2
+  WHERE t2.`ts` > '2015-08-15'
+)
+SELECT t1.*
+FROM events t1
 WHERE EXISTS (
   SELECT 1
-  FROM (
-    SELECT t2.*
-    FROM purchases t2
-    WHERE t2.`ts` > '2015-08-15'
-  ) t1
-  WHERE t0.`user_id` = t1.`user_id`
+  FROM t0
+  WHERE t1.`user_id` = t0.`user_id`
 )

--- a/ibis/tests/sql/snapshots/test_select_sql/test_filter_predicates/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_filter_predicates/out.sql
@@ -1,11 +1,12 @@
+WITH t0 AS (
+  SELECT t2.*
+  FROM t t2
+  WHERE (lower(t2.`color`) LIKE '%de%') AND
+        (locate('de', lower(t2.`color`)) - 1 >= 0)
+)
 SELECT *
 FROM (
   SELECT *
-  FROM (
-    SELECT t2.*
-    FROM t t2
-    WHERE (lower(t2.`color`) LIKE '%de%') AND
-          (locate('de', lower(t2.`color`)) - 1 >= 0)
-  ) t1
-  WHERE regexp_like(lower(t1.`color`), '.*ge.*')
-) t0
+  FROM t0
+  WHERE regexp_like(lower(t0.`color`), '.*ge.*')
+) t1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_filter_self_join_analysis_bug/result.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_filter_self_join_analysis_bug/result.sql
@@ -2,16 +2,18 @@ WITH t0 AS (
   SELECT t3.`region`, t3.`kind`, sum(t3.`amount`) AS `total`
   FROM purchases t3
   GROUP BY 1, 2
-)
-SELECT t1.`region`, t1.`total` - t2.`total` AS `diff`
-FROM (
+),
+t1 AS (
+  SELECT t0.*
+  FROM t0
+  WHERE t0.`kind` = 'bar'
+),
+t2 AS (
   SELECT t0.*
   FROM t0
   WHERE t0.`kind` = 'foo'
-) t1
-  INNER JOIN (
-    SELECT t0.*
-    FROM t0
-    WHERE t0.`kind` = 'bar'
-  ) t2
-    ON t1.`region` = t2.`region`
+)
+SELECT t2.`region`, t2.`total` - t1.`total` AS `diff`
+FROM t2
+  INNER JOIN t1
+    ON t2.`region` = t1.`region`

--- a/ibis/tests/sql/snapshots/test_select_sql/test_join_between_joins/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_join_between_joins/out.sql
@@ -1,14 +1,16 @@
-SELECT t0.*, t1.`value3`, t1.`value4`
-FROM (
+WITH t0 AS (
+  SELECT t2.*, t3.`value4`
+  FROM third t2
+    INNER JOIN fourth t3
+      ON t2.`key3` = t3.`key3`
+),
+t1 AS (
   SELECT t2.*, t3.`value2`
   FROM `first` t2
     INNER JOIN second t3
       ON t2.`key1` = t3.`key1`
-) t0
-  INNER JOIN (
-    SELECT t2.*, t3.`value4`
-    FROM third t2
-      INNER JOIN fourth t3
-        ON t2.`key3` = t3.`key3`
-  ) t1
-    ON t0.`key2` = t1.`key2`
+)
+SELECT t1.*, t0.`value3`, t0.`value4`
+FROM t1
+  INNER JOIN t0
+    ON t1.`key2` = t0.`key2`

--- a/ibis/tests/sql/snapshots/test_select_sql/test_join_filtered_tables_no_pushdown/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_join_filtered_tables_no_pushdown/out.sql
@@ -1,18 +1,20 @@
-SELECT t0.`value_a`, t1.`value_b`
-FROM (
+WITH t0 AS (
+  SELECT t2.*
+  FROM b t2
+  WHERE (t2.`year` = 2016) AND
+        (t2.`month` = 2) AND
+        (t2.`day` = 29)
+),
+t1 AS (
   SELECT t2.*
   FROM a t2
   WHERE (t2.`year` = 2016) AND
         (t2.`month` = 2) AND
         (t2.`day` = 29)
-) t0
-  LEFT OUTER JOIN (
-    SELECT t2.*
-    FROM b t2
-    WHERE (t2.`year` = 2016) AND
-          (t2.`month` = 2) AND
-          (t2.`day` = 29)
-  ) t1
-    ON (t0.`year` = t1.`year`) AND
-       (t0.`month` = t1.`month`) AND
-       (t0.`day` = t1.`day`)
+)
+SELECT t1.`value_a`, t0.`value_b`
+FROM t1
+  LEFT OUTER JOIN t0
+    ON (t1.`year` = t0.`year`) AND
+       (t1.`month` = t0.`month`) AND
+       (t1.`day` = t0.`day`)

--- a/ibis/tests/sql/snapshots/test_select_sql/test_join_projection_subquery_bug/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_join_projection_subquery_bug/out.sql
@@ -1,9 +1,10 @@
-SELECT t1.*, t0.*
-FROM (
+WITH t0 AS (
   SELECT t2.`n_nationkey`, t2.`n_name` AS `nation`, t3.`r_name` AS `region`
   FROM tpch_nation t2
     INNER JOIN tpch_region t3
       ON t2.`n_regionkey` = t3.`r_regionkey`
-) t0
+)
+SELECT t1.*, t0.*
+FROM t0
   INNER JOIN tpch_customer t1
     ON t0.`n_nationkey` = t1.`c_nationkey`

--- a/ibis/tests/sql/snapshots/test_select_sql/test_limit_cte_extract/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_limit_cte_extract/out.sql
@@ -1,8 +1,11 @@
-WITH t0 AS (
+SELECT t0.*
+FROM (
   SELECT t2.*
   FROM functional_alltypes t2
   LIMIT 100
-)
-SELECT t0.*
-FROM t0
-  INNER JOIN t0 t1
+) t0
+  INNER JOIN (
+    SELECT t2.*
+    FROM functional_alltypes t2
+    LIMIT 100
+  ) t1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_loj_subquery_filter_handling/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_loj_subquery_filter_handling/out.sql
@@ -1,14 +1,16 @@
-SELECT t0.`id` AS `left_id`, t0.`desc` AS `left_desc`, t1.`id` AS `right_id`,
-       t1.`desc` AS `right_desc`
-FROM (
+WITH t0 AS (
+  SELECT t2.*
+  FROM bar t2
+  WHERE t2.`id` < 3
+),
+t1 AS (
   SELECT t2.*
   FROM foo t2
   WHERE t2.`id` < 2
-) t0
-  LEFT OUTER JOIN (
-    SELECT t2.*
-    FROM bar t2
-    WHERE t2.`id` < 3
-  ) t1
-    ON (t0.`id` = t1.`id`) AND
-       (t0.`desc` = t1.`desc`)
+)
+SELECT t1.`id` AS `left_id`, t1.`desc` AS `left_desc`, t0.`id` AS `right_id`,
+       t0.`desc` AS `right_desc`
+FROM t1
+  LEFT OUTER JOIN t0
+    ON (t1.`id` = t0.`id`) AND
+       (t1.`desc` = t0.`desc`)

--- a/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result1.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result1.sql
@@ -1,10 +1,11 @@
-SELECT t0.`b`, count(1) AS `b_count`
+WITH t0 AS (
+  SELECT t2.*
+  FROM t t2
+  ORDER BY t2.`a` ASC
+)
+SELECT t1.`b`, count(1) AS `b_count`
 FROM (
-  SELECT t1.`b`
-  FROM (
-    SELECT t2.*
-    FROM t t2
-    ORDER BY t2.`a` ASC
-  ) t1
-) t0
+  SELECT t0.`b`
+  FROM t0
+) t1
 GROUP BY 1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result2.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_sort_then_group_by_propagates_keys/result2.sql
@@ -1,10 +1,11 @@
-SELECT t0.`b`, count(1) AS `b_count`
+WITH t0 AS (
+  SELECT t2.*
+  FROM t t2
+  ORDER BY t2.`b` ASC
+)
+SELECT t1.`b`, count(1) AS `b_count`
 FROM (
-  SELECT t1.`b`
-  FROM (
-    SELECT t2.*
-    FROM t t2
-    ORDER BY t2.`b` ASC
-  ) t1
-) t0
+  SELECT t0.`b`
+  FROM t0
+) t1
 GROUP BY 1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_topk_analysis_bug/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_topk_analysis_bug/out.sql
@@ -1,19 +1,21 @@
+WITH t0 AS (
+  SELECT t3.`dest`, avg(t3.`arrdelay`) AS `Mean(arrdelay)`
+  FROM airlines t3
+  WHERE t3.`dest` IN ('ORD', 'JFK', 'SFO')
+  GROUP BY 1
+),
+t1 AS (
+  SELECT t3.*
+  FROM airlines t3
+  WHERE t3.`dest` IN ('ORD', 'JFK', 'SFO')
+)
 SELECT `origin`, count(1) AS `count`
-FROM (
-  SELECT t2.*
-  FROM airlines t2
-  WHERE t2.`dest` IN ('ORD', 'JFK', 'SFO')
-) t0
+FROM t1
   LEFT SEMI JOIN (
-    SELECT t2.*
-    FROM (
-      SELECT t3.`dest`, avg(t3.`arrdelay`) AS `Mean(arrdelay)`
-      FROM airlines t3
-      WHERE t3.`dest` IN ('ORD', 'JFK', 'SFO')
-      GROUP BY 1
-    ) t2
-    ORDER BY t2.`Mean(arrdelay)` DESC
+    SELECT t0.*
+    FROM t0
+    ORDER BY t0.`Mean(arrdelay)` DESC
     LIMIT 10
-  ) t1
-    ON t0.`dest` = t1.`dest`
+  ) t2
+    ON t1.`dest` = t2.`dest`
 GROUP BY 1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_topk_operation/e1.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_topk_operation/e1.sql
@@ -1,13 +1,14 @@
+WITH t0 AS (
+  SELECT t1.`city`, avg(t1.`v2`) AS `Mean(v2)`
+  FROM tbl t1
+  GROUP BY 1
+)
 SELECT *
-FROM tbl t0
+FROM tbl t1
   LEFT SEMI JOIN (
-    SELECT t2.*
-    FROM (
-      SELECT t0.`city`, avg(t0.`v2`) AS `Mean(v2)`
-      FROM tbl t0
-      GROUP BY 1
-    ) t2
-    ORDER BY t2.`Mean(v2)` DESC
+    SELECT t0.*
+    FROM t0
+    ORDER BY t0.`Mean(v2)` DESC
     LIMIT 10
-  ) t1
-    ON t0.`city` = t1.`city`
+  ) t2
+    ON t1.`city` = t2.`city`

--- a/ibis/tests/sql/snapshots/test_select_sql/test_topk_operation/e2.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_topk_operation/e2.sql
@@ -1,13 +1,14 @@
+WITH t0 AS (
+  SELECT t1.`city`, count(t1.`city`) AS `count`
+  FROM tbl t1
+  GROUP BY 1
+)
 SELECT *
-FROM tbl t0
+FROM tbl t1
   LEFT SEMI JOIN (
-    SELECT t2.*
-    FROM (
-      SELECT t0.`city`, count(t0.`city`) AS `count`
-      FROM tbl t0
-      GROUP BY 1
-    ) t2
-    ORDER BY t2.`count` DESC
+    SELECT t0.*
+    FROM t0
+    ORDER BY t0.`count` DESC
     LIMIT 10
-  ) t1
-    ON t0.`city` = t1.`city`
+  ) t2
+    ON t1.`city` = t2.`city`

--- a/ibis/tests/sql/snapshots/test_select_sql/test_topk_predicate_pushdown_bug/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_topk_predicate_pushdown_bug/out.sql
@@ -1,21 +1,22 @@
 WITH t0 AS (
-  SELECT t2.*, t3.`n_name`, t4.`r_name`
-  FROM tpch_customer t2
-    INNER JOIN tpch_nation t3
-      ON t2.`c_nationkey` = t3.`n_nationkey`
-    INNER JOIN tpch_region t4
-      ON t3.`n_regionkey` = t4.`r_regionkey`
+  SELECT t3.*, t4.`n_name`, t5.`r_name`
+  FROM tpch_customer t3
+    INNER JOIN tpch_nation t4
+      ON t3.`c_nationkey` = t4.`n_nationkey`
+    INNER JOIN tpch_region t5
+      ON t4.`n_regionkey` = t5.`r_regionkey`
+),
+t1 AS (
+  SELECT t0.`n_name`, sum(t0.`c_acctbal`) AS `Sum(c_acctbal)`
+  FROM t0
+  GROUP BY 1
 )
 SELECT *
 FROM t0
   LEFT SEMI JOIN (
-    SELECT t2.*
-    FROM (
-      SELECT t0.`n_name`, sum(t0.`c_acctbal`) AS `Sum(c_acctbal)`
-      FROM t0
-      GROUP BY 1
-    ) t2
-    ORDER BY t2.`Sum(c_acctbal)` DESC
+    SELECT t1.*
+    FROM t1
+    ORDER BY t1.`Sum(c_acctbal)` DESC
     LIMIT 10
-  ) t1
-    ON t0.`n_name` = t1.`n_name`
+  ) t2
+    ON t0.`n_name` = t2.`n_name`

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_gh_1045/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_gh_1045/out.sql
@@ -1,40 +1,41 @@
-SELECT
-  t0.t1_id1,
-  t0.t1_val1,
-  t1.dt,
-  t1.id3,
-  t1.t3_val2,
-  t1.id2a,
-  t1.id2b,
-  t1.val2
-FROM (
+WITH t2 AS (
   SELECT
-    t2.id1 AS t1_id1,
-    t2.val1 AS t1_val1
-  FROM test1 AS t2
-) AS t0
+    t4.id1 AS t1_id1,
+    t4.val1 AS t1_val1
+  FROM test1 AS t4
+), t0 AS (
+  SELECT
+    t4.val2 AS val2,
+    t4.dt AS dt,
+    CAST(t4.id3 AS BIGINT) AS id3
+  FROM test3 AS t4
+), t1 AS (
+  SELECT
+    t0.dt AS dt,
+    t0.id3 AS id3,
+    t0.id3 AS t3_val2
+  FROM t0
+)
+SELECT
+  t2.t1_id1,
+  t2.t1_val1,
+  t3.dt,
+  t3.id3,
+  t3.t3_val2,
+  t3.id2a,
+  t3.id2b,
+  t3.val2
+FROM t2
 LEFT OUTER JOIN (
   SELECT
-    t2.dt AS dt,
-    t2.id3 AS id3,
-    t2.t3_val2 AS t3_val2,
-    t3.id2a AS id2a,
-    t3.id2b AS id2b,
-    t3.val2 AS val2
-  FROM (
-    SELECT
-      t4.dt AS dt,
-      t4.id3 AS id3,
-      t4.id3 AS t3_val2
-    FROM (
-      SELECT
-        t5.val2 AS val2,
-        t5.dt AS dt,
-        CAST(t5.id3 AS BIGINT) AS id3
-      FROM test3 AS t5
-    ) AS t4
-  ) AS t2
-  JOIN test2 AS t3
-    ON t3.id2b = t2.id3
-) AS t1
-  ON t0.t1_id1 = t1.id2a
+    t1.dt AS dt,
+    t1.id3 AS id3,
+    t1.t3_val2 AS t3_val2,
+    t5.id2a AS id2a,
+    t5.id2b AS id2b,
+    t5.val2 AS val2
+  FROM t1
+  JOIN test2 AS t5
+    ON t5.id2b = t1.id3
+) AS t3
+  ON t2.t1_id1 = t3.id2a

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_lower_projection_sort_key/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_lower_projection_sort_key/out.sql
@@ -1,30 +1,31 @@
+WITH t0 AS (
+  SELECT
+    t3.foo_id AS foo_id,
+    SUM(t3.f) AS total
+  FROM star1 AS t3
+  GROUP BY
+    1
+), t1 AS (
+  SELECT
+    t0.foo_id AS foo_id,
+    t0.total AS total,
+    t4.value1 AS value1
+  FROM t0
+  JOIN star2 AS t4
+    ON t0.foo_id = t4.foo_id
+)
 SELECT
-  t0.foo_id,
-  t0.total,
-  t0.value1
+  t2.foo_id,
+  t2.total,
+  t2.value1
 FROM (
   SELECT
     t1.foo_id AS foo_id,
     t1.total AS total,
     t1.value1 AS value1
-  FROM (
-    SELECT
-      t2.foo_id AS foo_id,
-      t2.total AS total,
-      t3.value1 AS value1
-    FROM (
-      SELECT
-        t4.foo_id AS foo_id,
-        SUM(t4.f) AS total
-      FROM star1 AS t4
-      GROUP BY
-        1
-    ) AS t2
-    JOIN star2 AS t3
-      ON t2.foo_id = t3.foo_id
-  ) AS t1
+  FROM t1
   WHERE
     t1.total > 100
-) AS t0
+) AS t2
 ORDER BY
-  t0.total DESC
+  t2.total DESC

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cart_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_no_cart_join/out.sql
@@ -1,8 +1,4 @@
-SELECT
-  t1.ancestor_node_sort_order,
-  1 AS n
-FROM facts AS t0
-JOIN (
+WITH t0 AS (
   SELECT
     t2.ancestor_level_name AS ancestor_level_name,
     t2.ancestor_level_number AS ancestor_level_number,
@@ -12,9 +8,14 @@ JOIN (
       t2.ancestor_level_number - 1
     ) * 7, '-'), t2.ancestor_level_name) AS product_level_name
   FROM products AS t2
-) AS t1
-  ON t0.product_id = t1.descendant_node_natural_key
+)
+SELECT
+  t0.ancestor_node_sort_order,
+  1 AS n
+FROM facts AS t1
+JOIN t0
+  ON t1.product_id = t0.descendant_node_natural_key
 GROUP BY
   1
 ORDER BY
-  t1.ancestor_node_sort_order
+  t0.ancestor_node_sort_order

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_subquery_aliased/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_subquery_aliased/out.sql
@@ -1,14 +1,15 @@
-SELECT
-  t0.foo_id,
-  t0.total,
-  t1.value1
-FROM (
+WITH t0 AS (
   SELECT
     t2.foo_id AS foo_id,
     SUM(t2.f) AS total
   FROM star1 AS t2
   GROUP BY
     1
-) AS t0
+)
+SELECT
+  t0.foo_id,
+  t0.total,
+  t1.value1
+FROM t0
 JOIN star2 AS t1
   ON t0.foo_id = t1.foo_id

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_tpc_h11/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_tpc_h11/out.sql
@@ -1,40 +1,41 @@
+WITH t0 AS (
+  SELECT
+    t2.ps_partkey AS ps_partkey,
+    SUM(t2.ps_supplycost * t2.ps_availqty) AS value
+  FROM partsupp AS t2
+  JOIN supplier AS t3
+    ON t2.ps_suppkey = t3.s_suppkey
+  JOIN nation AS t4
+    ON t4.n_nationkey = t3.s_nationkey
+  WHERE
+    t4.n_name = 'GERMANY'
+  GROUP BY
+    1
+)
 SELECT
-  t0.ps_partkey,
-  t0.value
+  t1.ps_partkey,
+  t1.value
 FROM (
   SELECT
-    t1.ps_partkey AS ps_partkey,
-    t1.value AS value
-  FROM (
-    SELECT
-      t2.ps_partkey AS ps_partkey,
-      SUM(t2.ps_supplycost * t2.ps_availqty) AS value
-    FROM partsupp AS t2
-    JOIN supplier AS t3
-      ON t2.ps_suppkey = t3.s_suppkey
-    JOIN nation AS t4
-      ON t4.n_nationkey = t3.s_nationkey
-    WHERE
-      t4.n_name = 'GERMANY'
-    GROUP BY
-      1
-  ) AS t1
+    t0.ps_partkey AS ps_partkey,
+    t0.value AS value
+  FROM t0
   WHERE
-    t1.value > (
+    t0.value > (
       SELECT
         anon_1.total
       FROM (
         SELECT
-          SUM(t2.ps_supplycost * t2.ps_availqty) AS total
-        FROM partsupp AS t2
-        JOIN supplier AS t3
-          ON t2.ps_suppkey = t3.s_suppkey
-        JOIN nation AS t4
-          ON t4.n_nationkey = t3.s_nationkey
+          SUM(t3.ps_supplycost * t3.ps_availqty) AS total
+        FROM partsupp AS t3
+        JOIN supplier AS t4
+          ON t3.ps_suppkey = t4.s_suppkey
+        JOIN nation AS t5
+          ON t5.n_nationkey = t4.s_nationkey
         WHERE
-          t4.n_name = 'GERMANY'
+          t5.n_name = 'GERMANY'
       ) AS anon_1
     ) * 0.0001
-) AS t0
+) AS t1
 ORDER BY
-  t0.value DESC
+  t1.value DESC

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_tpc_h17/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_tpc_h17/out.sql
@@ -1,0 +1,15 @@
+SELECT
+  SUM(t0.l_extendedprice) / 7 AS avg_yearly
+FROM lineitem AS t0
+JOIN part AS t1
+  ON t1.p_partkey = t0.l_partkey
+WHERE
+  t1.p_brand = 'Brand#23'
+  AND t1.p_container = 'MED BOX'
+  AND t0.l_quantity < (
+    SELECT
+      AVG(t0.l_quantity) AS "Mean(l_quantity)"
+    FROM lineitem AS t0
+    WHERE
+      t0.l_partkey = t1.p_partkey
+  ) * 0.2

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_correlated_subquery_with_join/out.sql
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_where_correlated_subquery_with_join/out.sql
@@ -1,26 +1,27 @@
+WITH t0 AS (
+  SELECT
+    t2.ps_partkey AS ps_partkey,
+    t2.ps_supplycost AS ps_supplycost
+  FROM partsupp AS t2
+  JOIN supplier AS t3
+    ON t3.s_suppkey = t2.ps_suppkey
+)
 SELECT
-  t0.p_partkey,
-  t0.ps_supplycost
+  t1.p_partkey,
+  t1.ps_supplycost
 FROM (
   SELECT
-    t1.p_partkey AS p_partkey,
-    t2.ps_supplycost AS ps_supplycost
-  FROM part AS t1
-  JOIN partsupp AS t2
-    ON t1.p_partkey = t2.ps_partkey
-) AS t0
+    t2.p_partkey AS p_partkey,
+    t3.ps_supplycost AS ps_supplycost
+  FROM part AS t2
+  JOIN partsupp AS t3
+    ON t2.p_partkey = t3.ps_partkey
+) AS t1
 WHERE
-  t0.ps_supplycost = (
+  t1.ps_supplycost = (
     SELECT
-      MIN(t1.ps_supplycost) AS "Min(ps_supplycost)"
-    FROM (
-      SELECT
-        t2.ps_partkey AS ps_partkey,
-        t2.ps_supplycost AS ps_supplycost
-      FROM partsupp AS t2
-      JOIN supplier AS t3
-        ON t3.s_suppkey = t2.ps_suppkey
-    ) AS t1
+      MIN(t0.ps_supplycost) AS "Min(ps_supplycost)"
+    FROM t0
     WHERE
-      t1.ps_partkey = t0.p_partkey
+      t0.ps_partkey = t1.p_partkey
   )


### PR DESCRIPTION
This PR address an issue where `find_subqueries` would return in pre-order, rather than in dependency order.

Fixes #5215.
Fixes #5555.