### PR TITLE
fix(clickhouse): use a bool type that is compatible with `clickhouse_driver`

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -86,7 +86,7 @@ class Backend(BaseBackend):
         """
 
         temp_db: str = "__ibis_tmp"
-        bool_type: str = "Boolean"
+        bool_type: Literal["Bool", "UInt8", "Int8"] = "Bool"
 
     def __init__(self, *args, external_tables=None, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ibis/backends/clickhouse/datatypes.py
+++ b/ibis/backends/clickhouse/datatypes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 from functools import partial
+from typing import Literal
 
 import parsy
 
@@ -22,8 +23,8 @@ from ibis.common.parsing import (
 )
 
 
-def _bool_type():
-    return getattr(getattr(ibis.options, "clickhouse", None), "bool_type", "Boolean")
+def _bool_type() -> Literal["Bool", "UInt8", "Int8"]:
+    return getattr(getattr(ibis.options, "clickhouse", None), "bool_type", "Bool")
 
 
 def parse(text: str) -> dt.DataType:
@@ -57,9 +58,7 @@ def parse(text: str) -> dt.DataType:
         | spaceless_string("date32", "date").result(dt.Date(nullable=False))
         | spaceless_string("time").result(dt.Time(nullable=False))
         | spaceless_string("tinyint", "int8", "int1").result(dt.Int8(nullable=False))
-        | spaceless_string("boolean", "bool").result(
-            getattr(dt, _bool_type())(nullable=False)
-        )
+        | spaceless_string("boolean", "bool").result(dt.Boolean(nullable=False))
         | spaceless_string("integer", "int32", "int4", "int").result(
             dt.Int32(nullable=False)
         )

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -919,3 +919,12 @@ def test_literal_na(con, dtype):
     expr = ibis.literal(None, type=dtype)
     result = con.execute(expr)
     assert pd.isna(result)
+
+
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["dask", "pandas"], raises=com.UnboundExpressionError)
+def test_memtable_bool_column(backend, con, monkeypatch):
+    monkeypatch.setattr(ibis.options, "default_backend", con)
+
+    t = ibis.memtable({"a": [True, False, True]})
+    backend.assert_series_equal(t.a.execute(), pd.Series([True, False, True], name="a"))


### PR DESCRIPTION
This PR fixes an issue where the bool type we are currently using is not compatible with the `clickhouse_driver` library. We use `Bool` (which is the only supported spelling) instead of the others that are supported by ClickHouse server.