### PR TITLE
ci(snowflake): don't set the random seed for snowflake tests

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -39,7 +39,7 @@ jobs:
 
           - name: snowflake
             title: Snowflake
-            randomly-seed: true
+            randomly-seed: false
 
           - name: snowflake
             key: snowflake-pyarrow


### PR DESCRIPTION
It looks like the imports are now further delayed when calling `write_pandas`, so the call makes it all the way to creating a stage and triggers the error that was previously triggered only by the `pyarrow` run.