### PR TITLE
feat(snowflake): support cross-database table access

### DIFF
--- a/ci/schema/snowflake.sql
+++ b/ci/schema/snowflake.sql
@@ -1,10 +1,10 @@
-CREATE OR REPLACE FILE FORMAT ibis_testing
+CREATE OR REPLACE TEMP FILE FORMAT ibis_testing
     type = 'CSV'
     field_delimiter = ','
     skip_header = 1
     field_optionally_enclosed_by = '"';
 
-CREATE OR REPLACE STAGE ibis_testing file_format = ibis_testing;
+CREATE OR REPLACE TEMP STAGE ibis_testing file_format = ibis_testing;
 
 CREATE OR REPLACE TABLE diamonds (
     "carat" FLOAT,

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -478,16 +478,8 @@ class BaseAlchemyBackend(BaseSQLBackend):
             Table expression
         """
         if database is not None and database != self.current_database:
-            return self.database(database=database).table(
-                name=name,
-                database=database,
-                schema=schema,
-            )
-        sqla_table = self._get_sqla_table(
-            name,
-            database=database,
-            schema=schema,
-        )
+            return self.database(name=database).table(name=name, schema=schema)
+        sqla_table = self._get_sqla_table(name, database=database, schema=schema)
         return self._sqla_table_to_expr(sqla_table)
 
     def insert(

--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -88,3 +88,8 @@ class TestConf(BackendTest, RoundAwayFromZero):
         if snowflake_url := os.environ.get("SNOWFLAKE_URL"):
             return ibis.connect(snowflake_url)  # type: ignore
         pytest.skip("SNOWFLAKE_URL environment variable is not defined")
+
+
+@pytest.fixture(scope="session")
+def con(data_directory):
+    return TestConf.connect(data_directory)

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+import ibis
+from ibis.util import guid
+
+
+@pytest.mark.parametrize(
+    ("db", "schema", "cleanup"),
+    [
+        (f"tmp_db_{guid()}", f"tmp_schema_{guid()}", True),
+        ("ibis_testing", f"tmp_schema_{guid()}", False),
+    ],
+    ids=["temp", "perm"],
+)
+def test_cross_db_access(con, db, schema, cleanup):
+    schema = f"{db}.{schema}"
+    table = f"tmp_table_{guid()}"
+    con.raw_sql(f"CREATE DATABASE IF NOT EXISTS {db}")
+    try:
+        con.raw_sql(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+        try:
+            con.raw_sql(f'CREATE TEMP TABLE {schema}.{table} ("x" INT)')
+            t = con.table(table, schema=f"{schema}")
+            assert t.schema() == ibis.schema(dict(x="int"))
+            assert t.execute().empty
+        finally:
+            if cleanup:
+                con.raw_sql(f"DROP SCHEMA {schema}")
+    finally:
+        if cleanup:
+            con.raw_sql(f"DROP DATABASE {db}")


### PR DESCRIPTION
Adds support for working across databases/schemas to the snowflake backend. Closes #5566.