### PR TITLE
feat(pandas): add unnest support

### DIFF
--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -195,7 +195,7 @@ def convert_struct_to_dict(_, out_dtype, column):
 
 @sch.convert.register(np.dtype, dt.Array, pd.Series)
 def convert_array_to_series(in_dtype, out_dtype, column):
-    return column.map(lambda x: x if x is None else list(x))
+    return column.map(lambda x: list(x) if util.is_iterable(x) else x)
 
 
 @sch.convert.register(np.dtype, dt.JSON, pd.Series)

--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -125,3 +125,8 @@ def execute_array_collect_groupby(op, data, where, aggcontext=None, **kwargs):
         ),
         np.array,
     )
+
+
+@execute_node.register(ops.Unnest, pd.Series)
+def execute_unnest(op, data, **kwargs):
+    return data.explode()

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -129,7 +129,17 @@ def execute_cast_series_array(op, data, type, **kwargs):
             'Array value type must be a primitive type '
             '(e.g., number, string, or timestamp)'
         )
-    return data.map(lambda array, numpy_type=numpy_type: array.astype(numpy_type))
+
+    def cast_to_array(array, numpy_type=numpy_type):
+        elems = [
+            el if el is None else np.array(el, dtype=numpy_type).item() for el in array
+        ]
+        try:
+            return np.array(elems, dtype=numpy_type)
+        except TypeError:
+            return np.array(elems)
+
+    return data.map(cast_to_array)
 
 
 @execute_node.register(ops.Cast, pd.Series, dt.Timestamp)

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -259,10 +259,13 @@ def build_df_from_projection(
     # Result series might be trimmed by time context, thus index may
     # have changed. To concat rows properly, we first `sort_index` on
     # each pieces then assign data index manually to series
+    #
+    # If cardinality changes (e.g. unnest/explode), trying to do this
+    # won't work so don't try?
     for i in range(len(new_pieces)):
-        assert len(new_pieces[i].index) == len(data.index)
         new_pieces[i] = new_pieces[i].sort_index()
-        new_pieces[i].index = data.index
+        if len(new_pieces[i].index) == len(data.index):
+            new_pieces[i].index = data.index
 
     return pd.concat(new_pieces, axis=1)
 

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -156,7 +156,6 @@ builtin_array = toolz.compose(
 
 unnest = toolz.compose(
     builtin_array,
-    pytest.mark.notimpl(["pandas"]),
     pytest.mark.notyet(
         ["bigquery"], reason="doesn't support unnest in SELECT position"
     ),
@@ -377,7 +376,7 @@ def test_unnest_default_name(con):
 
     result = expr.name("x").execute()
     expected = df.x.map(lambda x: x + [1]).explode("x")
-    tm.assert_series_equal(result, expected.astype("float64"))
+    tm.assert_series_equal(result, expected, check_dtype=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
~This will not pass the basic unnest test for reasons discussed in #5478~ (this now passes!), but I wanted to share the initial progress. For simpler cases, it worked for me. Also not sure if the changes to `build_df_from_projection` will cause problems.

Closes #5478.