### PR TITLE
feat(dataset): add to_dataset for fine-grained file outputs

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -403,6 +403,55 @@ class Expr(Immutable):
         )
 
     @experimental
+    def to_dataset(
+        self,
+        path: str | Path,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Write results to a directory, optionally partitioning or splitting.
+
+        This method is eager and will execute the associated expression
+        immediately.
+
+        Parameters
+        ----------
+        path
+            The data source. A string or Path to the output directory.
+        params
+            Mapping of scalar parameter expressions to value.
+        **kwargs
+            Additional keyword arguments passed to pyarrow.dataset.write_dataset
+
+        https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html
+
+        Example
+        -------
+        >>> penguins = ibis.examples.penguins.fetch()
+        >>> # Write to parquet, partitioned on two columns
+        >>> penguins.to_dataset("tmp/penguins",
+                                format="parquet",
+                                partitioning=["species", "island"],
+                                )
+        >>> # Write to parquet, partitioned on two columns, using hive naming scheme
+        >>> penguins.to_dataset("tmp/penguins",
+                                format="parquet",
+                                partitioning=["species", "island"],
+                                partitioning_flavor="hive",
+                                )
+        >>> # Write to CSV, partitioned on one columns, using hive naming scheme
+        >>> penguins.to_dataset("tmp/penguins",
+                                format="csv",
+                                partitioning=["island"],
+                                partitioning_flavor="hive",
+                                )
+        """
+        self._find_backend(use_default=True).to_dataset(
+            self, path, params=params, **kwargs
+        )
+
+    @experimental
     def to_parquet(
         self,
         path: str | Path,
@@ -426,7 +475,9 @@ class Expr(Immutable):
 
         https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html
         """
-        self._find_backend(use_default=True).to_parquet(self, path, **kwargs)
+        self._find_backend(use_default=True).to_parquet(
+            self, path, params=params, **kwargs
+        )
 
     @experimental
     def to_csv(
@@ -452,7 +503,7 @@ class Expr(Immutable):
 
         https://arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html
         """
-        self._find_backend(use_default=True).to_csv(self, path, **kwargs)
+        self._find_backend(use_default=True).to_csv(self, path, params=params, **kwargs)
 
     def unbind(self) -> ir.Table:
         """Return an expression built on `UnboundTable` instead of backend-specific objects."""


### PR DESCRIPTION
Opening this as a draft because I think there are several unanswered questions.

This is a potential solution for #5532.

As mentioned there, `pyarrow.dataset.write_dataset` will take a `RecordBatchReader` and write it out to a directory, optionally partitioning the files on column value(s), and supports both `directory` and `hive` naming conventions for those directories.

I was replacing `to_parquet` with this approach, when I realized that `write_dataset` also supports `csv` (and `feather`).
Do we also want to rewrite `to_csv` to allow for partitioned outputs?  Maybe?  But I think for CSV the behavior of always writing to a directory and not a single file is much less expected than for parquet.  I think that isn't a good idea.

But to force `format="parquet"` in a call to `write_dataset` seems unnecessarily constraining.

So, one proposal (contained herein), is to offer a `to_dataset` option alongside `to_csv` and `to_parquet`.  The file-specific methods write out a single file (for now) and `to_dataset` is there for users who need more control over the outputs.

On the plus side
- this keeps the "simple" behavior available, but opens up the "advanced" behavior.
- if we dispatch to backends to handle the writing and they have specialized but less-fully-featured options, we can use both, so `to_parquet` would call out to e.g. `clickhouse` specialized parquet writer but `to_dataset` is available if you need hive naming
- we avoid an explosion of keyword arguments to handle partitioning in `to_parquet` and `to_csv` (maybe)

On the down side:
- I would wager 95+% of users will want `format="parquet"` and I'm making them type that every time (we could default to `parquet`)
- there's more potential for splintering of behavior across backends between what `to_dataset(..., format="parquet")` does and what `to_parquet(...)` does (and `csv`, mutatis mutandis)
- it's probably not immediately clear that `to_dataset` is an option for writing out files