### PR TITLE
chore(deps): bump ruff version in pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.249
+    rev: v0.0.252
     hooks:
       - id: ruff
         args: ["--show-source", "--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,6 +368,7 @@ ignore = [
   "PLR0913", # too many arguments
   "PLR0915", # too many statements
   "PLR2004", # forces everything to be a constant
+  "PLW2901", # overwriting loop variable
   "RET504",
   "RET505",
   "RET506",
@@ -377,6 +378,7 @@ ignore = [
   "SIM102", # nested ifs
   "SIM108", # convert everything to ternary operator
   "SIM114", # combine `if` branches using logical `or` operator
+  "SIM116", # dictionary instead of `if` statements
   "SIM117", # nested withs
   "SIM118", # remove .keys() calls from dictionaries
   "SIM300", # yoda conditions


### PR DESCRIPTION
This PR bumps ruff in pre-commit and fixes the resulting issues, mostly by ignoring the new lints.