### PR TITLE
feat(sql): create temp table

### DIFF
--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 import sqlalchemy as sa
 
+import ibis.expr.schema as sch
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.mssql.compiler import MsSqlCompiler
 from ibis.backends.mssql.datatypes import _type_from_result_set_info
@@ -63,3 +64,18 @@ class Backend(BaseAlchemyBackend):
         self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
         yield f"CREATE OR ALTER VIEW {name} AS {definition}"
+
+    def _table_from_schema(
+        self,
+        name: str,
+        schema: sch.Schema,
+        database: str | None = None,
+        temp: bool = False,
+    ) -> sa.Table:
+        prefixes = []
+        if temp:
+            raise ValueError(
+                'MSSQL supports temporary table declaration through placing hash before the table name'
+            )
+        columns = self._columns_from_schema(name, schema)
+        return sa.Table(name, self.meta, *columns, prefixes=prefixes)

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -214,9 +214,14 @@ class Backend(BaseAlchemyBackend):
         node = self.table_class(source=self, sqla_table=alch_table)
         return self.table_expr_class(node)
 
-    def _table_from_schema(self, name, schema, database: str | None = None) -> sa.Table:
+    def _table_from_schema(
+        self, name, schema, database: str | None = None, temp: bool = True
+    ) -> sa.Table:
+        prefixes = []
+        if temp:
+            prefixes.append('TEMPORARY')
         columns = self._columns_from_schema(name, schema)
-        return sa.Table(name, self.meta, *columns, schema=database)
+        return sa.Table(name, self.meta, *columns, schema=database, prefixes=prefixes)
 
     @property
     def _current_schema(self) -> str | None:


### PR DESCRIPTION
Initial commit for allowing to create temp table which is a first step towards ` .persist()` https://github.com/ibis-project/ibis/issues/5393 

My current dilemmas -
* Still looking for a way to prove a table is temporary in tests without performing introspection on schemas. my first thought is opening two connections one after the other. not sure how it works with transactions.
* sqlite limits temp tables to temp databases only, I wonder what is the best approach to handle this limitation, one approach can be to transfer the responsibility for that to the end user, or to block this capability all together with a nice error. 

Will be happy for your thoughts. 