### PR TITLE
feat(common): hold typehint in the annotation objects

### DIFF
--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -46,6 +46,12 @@ class Annotation:
             and self._validator == other._validator
         )
 
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(validator={self._validator!r}, "
+            f"default={self._default!r}, typehint={self._typehint!r})"
+        )
+
     def validate(self, arg, **kwargs):
         if self._validator is None:
             return arg

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -80,18 +80,18 @@ def test_parameter():
     annot = Argument.required(fn)
     p = Parameter('test', annotation=annot)
 
-    assert p.annotation is fn
+    assert p.annotation is annot
     assert p.default is inspect.Parameter.empty
-    assert p.validate('2', this={'other': 1}) == 3
+    assert p.annotation.validate('2', this={'other': 1}) == 3
 
     with pytest.raises(TypeError):
-        p.validate({}, valid=inspect.Parameter.empty)
+        p.annotation.validate({}, valid=inspect.Parameter.empty)
 
     ofn = Argument.optional(fn)
     op = Parameter('test', annotation=ofn)
-    assert op.annotation == option(fn, default=None)
+    assert op.annotation._validator == option(fn, default=None)
     assert op.default is None
-    assert op.validate(None, this={'other': 1}) is None
+    assert op.annotation.validate(None, this={'other': 1}) is None
 
     with pytest.raises(TypeError, match="annotation must be an instance of Argument"):
         Parameter("wrong", annotation=Attribute("a"))
@@ -136,6 +136,9 @@ def test_signature_from_callable_with_varargs():
     assert sig.validate(2, 3) == {'a': 2, 'b': 3, 'args': ()}
     assert sig.validate(2, 3, 4) == {'a': 2, 'b': 3, 'args': (4,)}
     assert sig.validate(2, 3, 4, 5) == {'a': 2, 'b': 3, 'args': (4, 5)}
+    assert sig.parameters['a'].annotation._typehint is int
+    assert sig.parameters['b'].annotation._typehint is int
+    assert sig.parameters['args'].annotation._typehint is int
 
     with pytest.raises(TypeError):
         sig.validate(2, 3, 4, "5")

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -13,6 +13,14 @@ from ibis.common.validators import instance_of, option
 is_int = instance_of(int)
 
 
+def test_argument_repr():
+    argument = Argument(is_int, typehint=int, default=None)
+    assert repr(argument) == (
+        "Argument(validator=instance_of(<class 'int'>,), default=None, "
+        "typehint=<class 'int'>)"
+    )
+
+
 def test_default_argument():
     annotation = Argument.default(validator=int, default=3)
     assert annotation.validate(1) == 1

--- a/ibis/common/tests/test_validators.py
+++ b/ibis/common/tests/test_validators.py
@@ -134,8 +134,16 @@ def endswith_d(x, this):
             ),
         ),
         (Tuple[int, ...], tuple_of(instance_of(int), type=coerced_to(tuple))),
-        (Dict[str, float], dict_of(instance_of(str), instance_of(float))),
-        (frozendict[str, int], frozendict_of(instance_of(str), instance_of(int))),
+        (
+            Dict[str, float],
+            dict_of(instance_of(str), instance_of(float), type=coerced_to(dict)),
+        ),
+        (
+            frozendict[str, int],
+            frozendict_of(
+                instance_of(str), instance_of(int), type=coerced_to(frozendict)
+            ),
+        ),
         (Literal["alpha", "beta", "gamma"], isin(("alpha", "beta", "gamma"))),
         (
             Callable[[str, int], str],

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -81,7 +81,7 @@ _timestamp_units = toolz.merge(_date_units, _time_units)
 @public
 class TimestampTruncate(Value):
     arg = rlz.timestamp
-    unit = rlz.isin(_timestamp_units)
+    unit = rlz.map_to(_timestamp_units)
 
     output_shape = rlz.shape_like("arg")
     output_dtype = dt.timestamp
@@ -90,7 +90,7 @@ class TimestampTruncate(Value):
 @public
 class DateTruncate(Value):
     arg = rlz.date
-    unit = rlz.isin(_date_units)
+    unit = rlz.map_to(_date_units)
 
     output_shape = rlz.shape_like("arg")
     output_dtype = dt.date
@@ -99,7 +99,7 @@ class DateTruncate(Value):
 @public
 class TimeTruncate(Value):
     arg = rlz.time
-    unit = rlz.isin(_time_units)
+    unit = rlz.map_to(_time_units)
 
     output_shape = rlz.shape_like("arg")
     output_dtype = dt.time

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -128,9 +128,6 @@ class ExtractTemporalField(TemporalUnary):
     output_dtype = dt.int32
 
 
-ExtractTimestampField = ExtractTemporalField
-
-
 @public
 class ExtractDateField(ExtractTemporalField):
     arg = rlz.one_of([rlz.date, rlz.timestamp])
@@ -412,3 +409,6 @@ class BetweenTime(Between):
     arg = rlz.one_of([rlz.timestamp, rlz.time])
     lower_bound = rlz.one_of([rlz.time, rlz.string])
     upper_bound = rlz.one_of([rlz.time, rlz.string])
+
+
+public(ExtractTimestampField=ExtractTemporalField)

--- a/ibis/expr/tests/test_rules.py
+++ b/ibis/expr/tests/test_rules.py
@@ -136,34 +136,6 @@ def test_invalid_value(dtype, value, expected):
 
 
 @pytest.mark.parametrize(
-    ('values', 'value', 'expected'),
-    [
-        (['a', 'b'], 'a', 'a'),
-        (('a', 'b'), 'b', 'b'),
-        ({'a', 'b', 'c'}, 'c', 'c'),
-        ([1, 2, 'f'], 'f', 'f'),
-        ({'a': 1, 'b': 2}, 'a', 1),
-        ({'a': 1, 'b': 2}, 'b', 2),
-    ],
-)
-def test_valid_isin(values, value, expected):
-    assert rlz.isin(values, value) == expected
-
-
-@pytest.mark.parametrize(
-    ('values', 'value', 'expected'),
-    [
-        (['a', 'b'], 'c', ValueError),
-        ({'a', 'b', 'c'}, 'd', ValueError),
-        ({'a': 1, 'b': 2}, 'c', ValueError),
-    ],
-)
-def test_invalid_isin(values, value, expected):
-    with pytest.raises(expected):
-        rlz.isin(values, value)
-
-
-@pytest.mark.parametrize(
     ('validator', 'values', 'expected'),
     [
         param(


### PR DESCRIPTION
The argument annotation hasn't been holding the passed typehint, just the validator created from it. While experimenting with `egg-smol` I had to create a parallel type system to feed the library with but I didn't want to repeat every definitions. 
In order to do that I needed the actual types, not the validators. In addition to that discovered that we haven't been properly supporting generic type coercions.