### PR TITLE
ci: pin nix version to workaround upstream bug

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -34,6 +34,7 @@ jobs:
         uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixos-unstable-small
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
@@ -49,6 +50,7 @@ jobs:
       - name: install nix
         uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
@@ -124,6 +126,7 @@ jobs:
       - name: install nix
         uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
@@ -157,6 +160,7 @@ jobs:
       - name: install nix
         uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
@@ -201,6 +205,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ibis-docs-release.yml
+++ b/.github/workflows/ibis-docs-release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: install nix
         uses: cachix/install-nix-action@v19
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
 
       - name: setup cachix
         uses: cachix/cachix-action@v12

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -45,6 +45,7 @@ jobs:
         uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixos-unstable-small
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: generate flake matrix
@@ -36,6 +37,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR works around https://github.com/cachix/cachix-action/issues/138.