### PR TITLE
perf(duckdb): faster `to_parquet`/`to_csv` implementations

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -427,7 +427,7 @@ class _FileIOHandler:
             The data source. A string or Path to the CSV file.
         params
             Mapping of scalar parameter expressions to value.
-        **kwargs
+        kwargs
             Additional keyword arguments passed to pyarrow.csv.CSVWriter
 
         https://arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html
@@ -708,7 +708,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         """Compile an expression."""
         return self.compiler.to_sql(expr, params=params)
 
-    def _to_sql(self, expr: ir.Expr) -> str:
+    def _to_sql(self, expr: ir.Expr, **kwargs) -> str:
         """Convert an expression to a SQL string.
 
         Called by `ibis.to_sql`/`ibis.show_sql`, gives the backend an

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -330,8 +330,8 @@ class BaseSQLBackend(BaseBackend):
         """
         return self.compiler.to_ast_ensure_limit(expr, limit, params=params).compile()
 
-    def _to_sql(self, expr: ir.Expr) -> str:
-        return str(self.compile(expr))
+    def _to_sql(self, expr: ir.Expr, **kwargs) -> str:
+        return str(self.compile(expr, **kwargs))
 
     def explain(
         self,

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -114,12 +114,12 @@ class BaseAlchemyBackend(BaseSQLBackend):
         self._inspector.info_cache.clear()
         return self._inspector
 
-    def _to_sql(self, expr: ir.Expr) -> str:
+    def _to_sql(self, expr: ir.Expr, **kwargs) -> str:
         # For `ibis.to_sql` calls we render with literal binds and qmark params
         dialect_class = sa.dialects.registry.load(
             self.compiler.translator_class._dialect_name
         )
-        sql = self.compile(expr).compile(
+        sql = self.compile(expr, **kwargs).compile(
             dialect=dialect_class(paramstyle="qmark"),
             compile_kwargs=dict(literal_binds=True),
         )

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -378,8 +378,8 @@ class Backend(BaseBackend):
         assert not isinstance(sql, sg.exp.Subquery)
         return sql.sql(dialect="clickhouse", pretty=True)
 
-    def _to_sql(self, expr: ir.Expr) -> str:
-        return str(self.compile(expr))
+    def _to_sql(self, expr: ir.Expr, **kwargs) -> str:
+        return str(self.compile(expr, **kwargs))
 
     def table(self, name: str, database: str | None = None) -> ir.Table:
         """Construct a table expression.

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -346,7 +346,7 @@ class SQLString:
 
 
 @public
-def to_sql(expr: ir.Expr, dialect: str | None = None) -> SQLString:
+def to_sql(expr: ir.Expr, dialect: str | None = None, **kwargs) -> SQLString:
     """Return the formatted SQL string for an expression.
 
     Parameters
@@ -355,6 +355,8 @@ def to_sql(expr: ir.Expr, dialect: str | None = None) -> SQLString:
         Ibis expression.
     dialect
         SQL dialect to use for compilation.
+    kwargs
+        Scalar parameters
 
     Returns
     -------
@@ -382,6 +384,6 @@ def to_sql(expr: ir.Expr, dialect: str | None = None) -> SQLString:
         else:
             read = write = getattr(backend, "_sqlglot_dialect", dialect)
 
-    sql = backend._to_sql(expr)
+    sql = backend._to_sql(expr, **kwargs)
     (pretty,) = sg.transpile(sql, read=read, write=write, pretty=True)
     return SQLString(pretty)


### PR DESCRIPTION
This PR uses the native parquet and csv writing functionality built into duckdb for some nice speedups.