### PR TITLE
ci: remove use of `autorebase:opt-in` label

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -92,7 +92,6 @@ jobs:
           body: "Relock conda-lock environment files"
           labels: |
             dependencies
-            autorebase:opt-in
 
       - uses: juliangruber/approve-pull-request-action@v2.0.3
         if: steps.create_pr.outputs.pull-request-operation == 'created'

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -99,7 +99,7 @@ jobs:
           author: "ibis-squawk-bot[bot] <ibis-squawk-bot[bot]@users.noreply.github.com>"
           title: "chore(flake/${{ matrix.flake }}): `${{ steps.get_current_commit.outputs.short-rev }}` -> `${{ steps.get_new_commit.outputs.short-rev }}`"
           body: ${{ steps.compare_commits.outputs.differences }}
-          labels: dependencies,nix,autorebase:opt-in
+          labels: dependencies,nix
 
       - uses: juliangruber/approve-pull-request-action@v2.0.3
         if: fromJSON(steps.needs_pr.outputs.did_change)


### PR DESCRIPTION
We removed the autorebase action a while ago. This removes the use of it
in CI.
