### PR TITLE
perf(duckdb): fix dataframe insertion performance

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -399,8 +399,10 @@ def test_insert_overwrite_from_list(
 def test_insert_from_memtable(alchemy_con):
     df = pd.DataFrame({"x": range(3)})
     table_name = "memtable_test"
-    alchemy_con.insert(table_name, ibis.memtable(df))
-    alchemy_con.insert(table_name, ibis.memtable(df))
+    mt = ibis.memtable(df)
+    alchemy_con.create_table(table_name, schema=mt.schema())
+    alchemy_con.insert(table_name, mt)
+    alchemy_con.insert(table_name, mt)
 
     try:
         table = alchemy_con.tables[table_name]

--- a/justfile
+++ b/justfile
@@ -84,6 +84,10 @@ down *backends:
 bench +args='ibis/tests/benchmarks':
     pytest --benchmark-only --benchmark-enable --benchmark-autosave {{ args }}
 
+# run benchmarks and compare with a previous run
+benchcmp *args:
+    just bench {{ args }} --benchmark-compare
+
 # check for invalid links in a locally built version of the docs
 checklinks *args:
     #!/usr/bin/env bash


### PR DESCRIPTION
This PR fixes a performance issue with duckdb insert-from-dataframe. Previously we used the base class implementation which is generic and uses `DataFrame.to_sql` to insert and is very slow compared to using the DuckDB directly.

Fixes #5638.

There's still a little bit of performance left to eek out here, but we're very close to parity with duckdb:

**ibis**:

```
❯ time python /tmp/ddb_ibis.py
...
inserted_rows: 9700000, mem_usage: 0.242 GB, wal_size: 0.000 MB, db_size: 5.779 MB, throughput: 3685.7 krows/s
inserted_rows: 9800000, mem_usage: 0.242 GB, wal_size: 2.403 MB, db_size: 5.779 MB, throughput: 17497.0 krows/s
inserted_rows: 9900000, mem_usage: 0.242 GB, wal_size: 4.807 MB, db_size: 5.779 MB, throughput: 17703.5 krows/s
inserted_rows: 10000000, mem_usage: 0.242 GB, wal_size: 7.210 MB, db_size: 5.779 MB, throughput: 16922.1 krows/s
python /tmp/ddb_ibis.py  1.70s user 2.24s system 236% cpu 1.665 total
```

**duckdb**:

```
❯ time python /tmp/ddb_duckdb.py
...
inserted_rows: 9700000, mem_usage: 0.219 GB, wal_size: 0.000 MB, db_size: 5.779 MB, throughput: 3602.7 krows/s
inserted_rows: 9800000, mem_usage: 0.219 GB, wal_size: 2.403 MB, db_size: 5.779 MB, throughput: 18004.0 krows/s
inserted_rows: 9900000, mem_usage: 0.219 GB, wal_size: 4.807 MB, db_size: 5.779 MB, throughput: 17511.5 krows/s
inserted_rows: 10000000, mem_usage: 0.219 GB, wal_size: 7.210 MB, db_size: 5.779 MB, throughput: 18078.8 krows/s
python /tmp/ddb_duckdb.py  1.45s user 2.24s system 260% cpu 1.417 total
```
