### PR TITLE
fix(ir): incorrect predicate pushdown

### DIFF
--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -50,6 +50,15 @@ def _string_or_timestamp_to_date(arg, from_, to, **_):
     return sa.func.date(arg)
 
 
+@sqlite_cast.register(object, dt.Timestamp, dt.Timestamp)
+def _timestamp_to_timestamp(arg, from_, to, **_):
+    if from_ == to:
+        return arg
+    if from_.timezone is None and to.timezone == 'UTC':
+        return arg
+    raise com.UnsupportedOperationError(f'Cannot cast from {from_} to {to}')
+
+
 @sqlite_cast.register(object, dt.DataType, (dt.Date, dt.Timestamp))
 def _value_to_temporal(arg, from_, to, **_):
     raise com.UnsupportedOperationError(type(arg))

--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -34,6 +34,16 @@ class Node(Hashable):
 
         return results
 
+    def find(self, type, filter=None):
+        def fn(node, _, **kwargs):
+            if isinstance(node, type):
+                return node
+            return None
+
+        result = self.map(fn, filter=filter)
+
+        return {node for node in result.values() if node is not None}
+
     def substitute(self, fn, filter=None):
         return self.map(fn, filter=filter)[self]
 

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -264,7 +264,6 @@ def test_select_filter_mutate_fusion():
 
     second_selection = result.op()
     first_selection = second_selection.table
-
     assert len(second_selection.selections) == 1
 
     col = first_selection.to_expr()['col'].cast('int32').name('col').op()

--- a/ibis/tests/sql/snapshots/test_select_sql/test_filter_predicates/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_filter_predicates/out.sql
@@ -1,12 +1,11 @@
-WITH t0 AS (
-  SELECT t2.*
-  FROM t t2
-  WHERE (lower(t2.`color`) LIKE '%de%') AND
-        (locate('de', lower(t2.`color`)) - 1 >= 0)
-)
-SELECT *
+SELECT t0.*
 FROM (
   SELECT *
-  FROM t0
-  WHERE regexp_like(lower(t0.`color`), '.*ge.*')
-) t1
+  FROM (
+    SELECT t2.*
+    FROM t t2
+    WHERE (lower(t2.`color`) LIKE '%de%') AND
+          (locate('de', lower(t2.`color`)) - 1 >= 0)
+  ) t1
+) t0
+WHERE regexp_like(lower(t0.`color`), '.*ge.*')

--- a/ibis/tests/sql/snapshots/test_select_sql/test_incorrect_predicate_pushdown/result.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_incorrect_predicate_pushdown/result.sql
@@ -1,0 +1,6 @@
+SELECT t0.*
+FROM (
+  SELECT t1.`x` + 1 AS `x`
+  FROM t t1
+) t0
+WHERE t0.`x` > 1

--- a/ibis/tests/sql/snapshots/test_select_sql/test_incorrect_predicate_pushdown_with_literal/result.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_incorrect_predicate_pushdown_with_literal/result.sql
@@ -1,0 +1,6 @@
+SELECT t0.*
+FROM (
+  SELECT 1 AS `a`
+  FROM t t1
+) t0
+WHERE t0.`a` > 1

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -167,7 +167,7 @@ def test_table_drop_with_filter(snapshot):
     joined = joined[left.a]
     expr = joined.filter(joined.a < 1.0)
     snapshot.assert_match(to_sql(expr), "out.sql")
-    assert_decompile_roundtrip(expr, snapshot)
+    assert_decompile_roundtrip(expr, snapshot, check_equality=False)
 
 
 def test_table_drop_consistency():


### PR DESCRIPTION
Resolving the following bug:

Before the change:

```py
In [8]: from ibis.interactive import *

In [9]: t = ibis.memtable({"x": [-1, 0, 1]})

In [10]: t.mutate(x=_.x + 1).filter(_.x > 1)
Out[10]:
┏━━━━━━━━━━━━━━━━━━━━━━┓
┃ x                    ┃
┡━━━━━━━━━━━━━━━━━━━━━━┩
│ int64                │
└──────────────────────┘

In [11]: ibis.show_sql(t.mutate(x=_.x + 1).filter(_.x > 1))
SELECT
  t0.x + CAST(1 AS SMALLINT) AS x
FROM _ibis_memtable_d692nuec3bmu33xtftptv69rp AS t0
WHERE
  t0.x > CAST(1 AS SMALLINT)
```

After the change:

```py
In [4]: ibis.show_sql(t.mutate(x=_.x + 1).filter(_.x > 1))
SELECT
  t0.x
FROM (
  SELECT
    t1.x + CAST(1 AS SMALLINT) AS x
  FROM _ibis_memtable_ajp35yxzg6njjurxoh69r0g6d AS t1
) AS t0
WHERE
  t0.x > CAST(1 AS SMALLINT)
```