### PR TITLE
docs: remove duplicate spark backend in install docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -29,12 +29,14 @@ hide:
 ## Install backend dependencies
 
 {% for backend in sorted(ibis.backends.base._get_backend_names()) %}
+{% if backend != "spark" %}
 === "{{ backend }}"
 
     ```sh
     pip install 'ibis-framework[{{ backend }}]'
     ```
 
+{% endif %}
 {% endfor %}
 
 ---


### PR DESCRIPTION
This PR removes the `pip install ibis-framework[spark]` instructions since it is redundant with pyspark.