### PR TITLE
feat(postgres): parse tsvector columns as strings

### DIFF
--- a/ci/schema/postgresql.sql
+++ b/ci/schema/postgresql.sql
@@ -208,3 +208,9 @@ CREATE TABLE map (kv HSTORE);
 INSERT INTO map VALUES
     ('a=>1,b=>2,c=>3'),
     ('d=>4,e=>5,c=>6');
+
+ALTER TABLE awards_players
+ADD search tsvector
+GENERATED always AS (
+  setweight(to_tsvector('simple', notes), 'A') :: tsvector
+) stored;

--- a/ibis/backends/postgres/datatypes.py
+++ b/ibis/backends/postgres/datatypes.py
@@ -170,3 +170,8 @@ def sa_pg_array(dialect, satype, nullable=True):
 
     value_dtype = dt.dtype(dialect, satype.item_type)
     return dt.Array(value_dtype, nullable=nullable)
+
+
+@dt.dtype.register(PGDialect, postgresql.TSVECTOR)
+def sa_postgres_tsvector(_, satype, nullable=True):
+    return dt.String(nullable=nullable)

--- a/ibis/backends/postgres/tests/test_string.py
+++ b/ibis/backends/postgres/tests/test_string.py
@@ -4,6 +4,7 @@ import pytest
 from pytest import param
 
 import ibis
+import ibis.expr.datatypes as dt
 
 
 @pytest.mark.parametrize(
@@ -16,3 +17,9 @@ def test_special_strings(alltypes, data, data_type):
     expr = alltypes[[alltypes.id, lit]].head(1)
     df = expr.execute()
     assert df['tmp'].iloc[0] == uuid.UUID(data)
+
+
+def test_load_tsvector_table(con):
+    awards_players = con.table("awards_players")
+    assert "search" in awards_players.columns
+    assert awards_players.schema()["search"] == dt.String(nullable=True)


### PR DESCRIPTION
Fixes #5402

The `tsvector` type is a postgres-specific type for fast text search --
this doesn't add support for using any of the specific features
associated with `tsvector` but it will let a user load a table that
contains them, instead of erroring out.