### PR TITLE
chore: remove spark alias to pyspark and associated cruft

### DIFF
--- a/gen_matrix.py
+++ b/gen_matrix.py
@@ -10,9 +10,7 @@ import ibis.expr.operations as ops
 
 
 def get_backends():
-    entry_points = sorted(
-        name for ep in ibis.util.backend_entry_points() if (name := ep.name) != "spark"
-    )
+    entry_points = sorted(ep.name for ep in ibis.util.backend_entry_points())
     return [(backend, getattr(ibis, backend)) for backend in entry_points]
 
 

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -295,9 +295,6 @@ def _get_backends_to_test(
     if keep:
         backends = backends.intersection(keep)
 
-    # spark is an alias for pyspark
-    backends = backends.difference(("spark",))
-
     return [
         pytest.param(
             backend,

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -154,8 +154,6 @@ def test_builtins(benchmark, expr_fn, builtin, t, base, large_expr):
 
 
 _backends = set(_get_backend_names())
-# spark is a duplicate of pyspark
-_backends.remove("spark")
 # compile is a no-op
 _backends.remove("pandas")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,6 @@ polars = "ibis.backends.polars"
 postgres = "ibis.backends.postgres"
 pyspark = "ibis.backends.pyspark"
 snowflake = "ibis.backends.snowflake"
-spark = "ibis.backends.pyspark"
 sqlite = "ibis.backends.sqlite"
 trino = "ibis.backends.trino"
 


### PR DESCRIPTION
This PR removes the spark plugin alias and associated workarounds and cruft.