### PR TITLE
tests(pyspark): xfail pyspark on python311

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -71,11 +71,6 @@ jobs:
             title: Datafusion
             extras:
               - datafusion
-          - name: pyspark
-            title: PySpark
-            serial: true
-            extras:
-              - pyspark
           - name: polars
             title: Polars
             extras:
@@ -140,11 +135,26 @@ jobs:
               - druid
         include:
           - os: ubuntu-latest
+            python-version: "3.8"
+            backend:
+              name: pyspark
+              title: PySpark
+              serial: true
+              extras:
+                - pyspark
+          - os: ubuntu-latest
             python-version: "3.10"
             backend:
               name: pyspark
               title: PySpark
               serial: true
+              extras:
+                - pyspark
+          - os: ubuntu-latest
+            python-version: "3.11"
+            backend:
+              name: pyspark
+              title: PySpark
               extras:
                 - pyspark
         exclude:
@@ -167,21 +177,6 @@ jobs:
                 - clickhouse
               services:
                 - clickhouse
-          - os: ubuntu-latest
-            python-version: "3.11"
-            backend:
-              name: pyspark
-              title: PySpark
-              serial: true
-              extras:
-                - pyspark
-          - os: windows-latest
-            backend:
-              name: pyspark
-              title: PySpark
-              serial: true
-              extras:
-                - pyspark
           - os: windows-latest
             backend:
               name: postgres

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -553,17 +553,35 @@ def test_unsigned_integer_type(alchemy_con):
         ),
         param(
             "pyspark://?spark.app.name=test-pyspark",
-            marks=mark.pyspark,
+            marks=[
+                mark.pyspark,
+                pytest.mark.skipif(
+                    sys.version_info >= (3, 11),
+                    reason="passes on 3.11, but no other pyspark tests do",
+                ),
+            ],
             id="pyspark",
         ),
         param(
             "pyspark://my-warehouse-dir?spark.app.name=test-pyspark",
-            marks=mark.pyspark,
+            marks=[
+                mark.pyspark,
+                pytest.mark.skipif(
+                    sys.version_info >= (3, 11),
+                    reason="passes on 3.11, but no other pyspark tests do",
+                ),
+            ],
             id="pyspark_with_warehouse",
         ),
         param(
             "pyspark://my-warehouse-dir",
-            marks=mark.pyspark,
+            marks=[
+                mark.pyspark,
+                pytest.mark.skipif(
+                    sys.version_info >= (3, 11),
+                    reason="passes on 3.11, but no other pyspark tests do",
+                ),
+            ],
             id="pyspark_with_warehouse_no_params",
         ),
     ],


### PR DESCRIPTION
This PR adds xfails and CI back for Python 3.11 on PySpark so that when pyspark 3.4.0 is released we will know. This also lets devs run tests locally without having to attach `not pyspark` to every backend test suite invocation that might pyspark tests.