### PR TITLE
refactor(ux): return expression from `Table.info`

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1007,3 +1007,11 @@ def execute_time(op, **kwargs):
     if op.arg.output_dtype.is_timestamp():
         return arg.dt.truncate("1us").cast(pl.Time)
     return arg
+
+
+@translate.register(ops.Union)
+def execute_union(op, **kwargs):
+    result = pl.concat([translate(op.left, **kwargs), translate(op.right, **kwargs)])
+    if op.distinct:
+        return result.unique()
+    return result

--- a/ibis/backends/tests/test_set_ops.py
+++ b/ibis/backends/tests/test_set_ops.py
@@ -32,7 +32,7 @@ def union_subsets(alltypes, df):
 
 
 @pytest.mark.parametrize("distinct", [False, True], ids=["all", "distinct"])
-@pytest.mark.notimpl(["datafusion", "polars"])
+@pytest.mark.notimpl(["datafusion"])
 @pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError)
 def test_union(backend, union_subsets, distinct):
     (a, b, c), (da, db, dc) = union_subsets
@@ -47,7 +47,7 @@ def test_union(backend, union_subsets, distinct):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["datafusion", "polars"])
+@pytest.mark.notimpl(["datafusion"])
 @pytest.mark.notyet(["bigquery"])
 @pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError)
 def test_union_mixed_distinct(backend, union_subsets):
@@ -155,7 +155,7 @@ def test_empty_set_op(alltypes, method):
         False,
     ],
 )
-@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 @pytest.mark.broken(["dask"], raises=AssertionError, reason="results are incorrect")
 def test_top_level_union(backend, con, alltypes, distinct):
     t1 = alltypes.select(a="bigint_col").filter(lambda t: t.a == 10).distinct()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,6 +300,10 @@ filterwarnings = [
   "ignore:'cgi' is deprecated and slated for removal in Python 3\\.13:DeprecationWarning",
   # warnings from google's use of pkg_resources
   "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+  # sqlalchemy warns about mysql's inability to cast to bool;
+  # this has no effect on ibis's output because we convert types after
+  # execution
+  "ignore:Datatype BOOL does not support CAST on MySQL/MariaDB; the cast will be skipped:sqlalchemy.exc.SAWarning"
 ]
 empty_parameter_set_mark = "fail_at_collect"
 markers = [


### PR DESCRIPTION
This PR changes the `Table.info` method to be just a regular old expression like everything else.