### PR TITLE
test(pyspark): allow doctests to pass

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -297,7 +297,10 @@ def pytest_collection_modifyitems(session, config, items):
                 (
                     item,
                     pytest.mark.xfail(
-                        sys.version_info >= (3, 11),
+                        (
+                            sys.version_info >= (3, 11)
+                            and not isinstance(item, pytest.DoctestItem)
+                        ),
                         reason="PySpark doesn't support Python 3.11",
                     ),
                 )


### PR DESCRIPTION
This PR fixes an issue where pyspark doctests were marked as xfail but do not actually fail.