### PR TITLE
ci: remove unnecessary Python version in custom venv cache key

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: syphar/restore-virtualenv@v1
         with:
           requirement_files: requirements.txt
-          custom_cache_key_element: check-setuptools-install-${{ steps.install_python.outputs.python-version }}
+          custom_cache_key_element: check-setuptools-install
 
       - uses: syphar/restore-pip-download-cache@v1
         with:

--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: syphar/restore-virtualenv@v1
         with:
           requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
+          custom_cache_key_element: ${{ matrix.backend.name }}
 
       - run: python -m pip install --upgrade pip 'poetry<1.4'
 

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -279,7 +279,7 @@ jobs:
       - uses: syphar/restore-virtualenv@v1
         with:
           requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
+          custom_cache_key_element: ${{ matrix.backend.name }}
 
       - name: install ibis
         run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"
@@ -563,7 +563,7 @@ jobs:
       - uses: syphar/restore-virtualenv@v1
         with:
           requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
+          custom_cache_key_element: ${{ matrix.backend.name }}-sqlalchemy2
 
       - uses: syphar/restore-pip-download-cache@v1
         with:

--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: syphar/restore-virtualenv@v1
         with:
           requirement_files: poetry.lock
-          custom_cache_key_element: benchmarks-${{ steps.install_python.outputs.python-version }}
+          custom_cache_key_element: benchmarks
 
       - uses: syphar/restore-pip-download-cache@v1
         with:

--- a/.github/workflows/ibis-main-skip-helper.yml
+++ b/.github/workflows/ibis-main-skip-helper.yml
@@ -21,11 +21,15 @@ on:
       - "*.x.x"
   merge_group:
 jobs:
-  test_no_backends:
+  test_core:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No build required"
   test_shapely_duckdb_import:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"
+  test_doctests:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No build required"

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -32,7 +32,7 @@ env:
   FORCE_COLOR: "1"
 
 jobs:
-  test_no_backends:
+  test_core:
     name: Test ${{ matrix.os }} python-${{ matrix.python-version }}
     env:
       SQLALCHEMY_WARN_20: "1"
@@ -68,7 +68,7 @@ jobs:
       - uses: syphar/restore-virtualenv@v1
         with:
           requirement_files: poetry.lock
-          custom_cache_key_element: no-backends-${{ steps.install_python.outputs.python-version }}
+          custom_cache_key_element: core
 
       - name: install ${{ matrix.os }} system dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -133,7 +133,7 @@ jobs:
       - uses: syphar/restore-virtualenv@v1
         with:
           requirement_files: poetry.lock
-          custom_cache_key_element: shapely-duckdb-${{ steps.install_python.outputs.python-version }}
+          custom_cache_key_element: shapely-duckdb
 
       - uses: syphar/restore-pip-download-cache@v1
         with:
@@ -193,7 +193,7 @@ jobs:
       - uses: syphar/restore-virtualenv@v1
         with:
           requirement_files: poetry.lock
-          custom_cache_key_element: doctests-${{ steps.install_python.outputs.python-version }}
+          custom_cache_key_element: doctests
 
       - name: install ibis with all extras
         run: poetry install --without dev --without docs --extras all


### PR DESCRIPTION
This PR removes an unnecessary cache key element from the key used to refer to a virtualenv cache in CI. Previously we did this because the action did not store the patch version of Python, resulting in a broken environment.. The action is now encoding this information so we no longer need to do it ourselves.