### PR TITLE
fix(bigquery): regenerate sql for predicate pushdown fix

### DIFF
--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_projection_fusion_only_peeks_at_immediate_parent/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_projection_fusion_only_peeks_at_immediate_parent/out.sql
@@ -1,18 +1,22 @@
 WITH t0 AS (
-  SELECT t4.*
-  FROM unbound_table t4
-  WHERE t4.`PARTITIONTIME` < DATE '2017-01-01'
+  SELECT t5.*
+  FROM unbound_table t5
+  WHERE t5.`PARTITIONTIME` < DATE '2017-01-01'
 ),
 t1 AS (
   SELECT CAST(t0.`file_date` AS DATE) AS `file_date`, t0.`PARTITIONTIME`,
          t0.`val`
   FROM t0
-  WHERE t0.`file_date` < DATE '2017-01-01'
 ),
 t2 AS (
-  SELECT t1.*, t1.`val` * 2 AS `XYZ`
+  SELECT t1.*
   FROM t1
+  WHERE t1.`file_date` < DATE '2017-01-01'
+),
+t3 AS (
+  SELECT t2.*, t2.`val` * 2 AS `XYZ`
+  FROM t2
 )
-SELECT t2.*
-FROM t2
-  INNER JOIN t2 t3
+SELECT t3.*
+FROM t3
+  INNER JOIN t3 t4


### PR DESCRIPTION
Quick follow up to the recent predicate pushdown fix to regenerate some test SQL for the BigQuery backend.