### PR TITLE
test(backends): strict validate exception in test_column

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -103,6 +103,7 @@ TEST_TABLES = {
 FIlES_WITH_STRICT_EXCEPTION_CHECK = [
     'ibis/backends/tests/test_binary.py',
     'ibis/backends/tests/test_numeric.py',
+    'ibis/backends/tests/test_column.py',
     'ibis/backends/tests/test_string.py',
     'ibis/backends/tests/test_temporal.py',
     'ibis/backends/tests/test_uuid.py',

--- a/ibis/backends/tests/test_column.py
+++ b/ibis/backends/tests/test_column.py
@@ -1,5 +1,7 @@
 import pytest
 
+import ibis.common.exceptions as com
+
 
 @pytest.mark.notimpl(
     [
@@ -17,7 +19,8 @@ import pytest
         "snowflake",
         "trino",
         "druid",
-    ]
+    ],
+    raises=com.OperationNotDefinedError,
 )
 def test_rowid(con):
     t = con.table('functional_alltypes')
@@ -35,7 +38,7 @@ def test_rowid(con):
     "column",
     ["string_col", "double_col", "date_string_col", "timestamp_col"],
 )
-@pytest.mark.notimpl(["datafusion"])
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_distinct_column(alltypes, df, column):
     expr = alltypes[[column]].distinct()
     result = expr.execute()


### PR DESCRIPTION
```
$ pytest -m 'bigquery or dask or datafusion or pandas or polars or snowflake' ibis/backends/tests/test_column.py
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.10.7, pytest-7.2.1, pluggy-1.0.0
Using --randomly-seed=1769460373
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /ibis/ibis, configfile: pyproject.toml
plugins: snapshot-0.9.0, xdist-3.1.0, mock-3.10.0, clarity-1.0.1, randomly-3.12.0, profiling-1.7.0, cov-4.0.0, repeat-0.9.1, benchmark-4.0.0, hypothesis-6.65.2
collected 80 items / 50 deselected / 30 selected

ibis/backends/tests/test_column.py x....xxxxxx........x....x..x..                                                                                                                                  [100%]

============================================================================= 20 passed, 50 deselected, 10 xfailed in 46.27s =============================================================================
```