### PR TITLE
feat(selectors): support ranges

### DIFF
--- a/ibis/tests/expr/test_selectors.py
+++ b/ibis/tests/expr/test_selectors.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+from pytest import param
 
 import ibis
 import ibis.common.exceptions as exc
@@ -321,6 +322,21 @@ def test_last(penguins):
 
 def test_all(penguins):
     assert penguins.select(s.all()).equals(penguins.select(penguins.columns))
+
+
+@pytest.mark.parametrize(
+    ("seq", "expected"),
+    [
+        param([0, 1, 2], (0, 1, 2), id="int_tuple"),
+        param(~s.r[[3, 4, 5]], sorted(set(range(8)) - {3, 4, 5}), id="neg_int_list"),
+        param(~s.r[3, 4, 5], sorted(set(range(8)) - {3, 4, 5}), id="neg_int_list"),
+        param(s.r["island", "year"], ("island", "year"), id="string_tuple"),
+        param(s.r[["island", "year"]], ("island", "year"), id="string_list"),
+        param(iter(["island", 4, "year"]), ("island", 4, "year"), id="mixed_iterable"),
+    ],
+)
+def test_sequence(penguins, seq, expected):
+    assert penguins.select(seq).equals(penguins.select(*expected))
 
 
 def test_names_callable(penguins):


### PR DESCRIPTION
This PR adds support for passing sequences to range selectors.