### PR TITLE
fix(ir): use static connection pooling to prevent dropping temporary state

### DIFF
--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -43,7 +43,7 @@ class Backend(BaseAlchemyBackend):
 
         self.database_name = "default"  # not sure what should go here
 
-        engine = sa.create_engine(url)
+        engine = sa.create_engine(url, poolclass=sa.pool.StaticPool)
 
         super().do_connect(engine)
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -124,7 +124,7 @@ class Backend(BaseAlchemyBackend):
                 "instead."
             )
             database = path
-        if not (in_memory := database == ":memory:"):
+        if database != ":memory:":
             database = Path(database).absolute()
         elif temp_directory is None:
             temp_directory = (
@@ -142,7 +142,7 @@ class Backend(BaseAlchemyBackend):
         engine = sa.create_engine(
             f"duckdb:///{database}",
             connect_args=dict(read_only=read_only, config=config),
-            poolclass=sa.pool.SingletonThreadPool if in_memory else None,
+            poolclass=sa.pool.StaticPool,
         )
 
         @sa.event.listens_for(engine, "connect")

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -40,7 +40,7 @@ class Backend(BaseAlchemyBackend):
         )
         self.database_name = alchemy_url.database
 
-        engine = sa.create_engine(alchemy_url)
+        engine = sa.create_engine(alchemy_url, poolclass=sa.pool.StaticPool)
 
         @sa.event.listens_for(engine, "connect")
         def connect(dbapi_connection, connection_record):

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -99,7 +99,7 @@ class Backend(BaseAlchemyBackend):
 
         self.database_name = alchemy_url.database
 
-        engine = sa.create_engine(alchemy_url)
+        engine = sa.create_engine(alchemy_url, poolclass=sa.pool.StaticPool)
 
         @sa.event.listens_for(engine, "connect")
         def connect(dbapi_connection, connection_record):

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -111,7 +111,9 @@ class Backend(BaseAlchemyBackend):
         if schema is not None:
             connect_args["options"] = f"-csearch_path={schema}"
 
-        engine = sa.create_engine(alchemy_url, connect_args=connect_args)
+        engine = sa.create_engine(
+            alchemy_url, connect_args=connect_args, poolclass=sa.pool.StaticPool
+        )
 
         @sa.event.listens_for(engine, "connect")
         def connect(dbapi_connection, connection_record):

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -150,6 +150,7 @@ class Backend(BaseAlchemyBackend):
                     "STRICT_JSON_OUTPUT": "TRUE",
                 },
             },
+            poolclass=sa.pool.StaticPool,
         )
 
         @sa.event.listens_for(engine, "connect")

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -129,7 +129,8 @@ class Backend(BaseAlchemyBackend):
         self.database_name = "main"
 
         engine = sa.create_engine(
-            f"sqlite:///{database if database is not None else ':memory:'}"
+            f"sqlite:///{database if database is not None else ':memory:'}",
+            poolclass=sa.pool.StaticPool,
         )
 
         if type_map:

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -64,10 +64,15 @@ class Backend(BaseAlchemyBackend):
                             **connect_args,
                             "experimental_python_types": True,
                         },
+                        poolclass=sa.pool.StaticPool,
                     )
                 )
             except TypeError:
-                super().do_connect(sa.create_engine(url, connect_args=connect_args))
+                super().do_connect(
+                    sa.create_engine(
+                        url, connect_args=connect_args, poolclass=sa.pool.StaticPool
+                    )
+                )
         self._meta = sa.MetaData(schema=schema)
 
     def _metadata(self, query: str) -> Iterator[tuple[str, dt.DataType]]:


### PR DESCRIPTION
This PR changes all SQLAlchemy engines to use the [`StaticPool`](https://docs.sqlalchemy.org/en/20/core/pooling.html#sqlalchemy.pool.StaticPool) connection pool.

`StaticPool` uses one connection for all operations.

The reason this is desirable--and necessary if we ever want to have predictably
accessible `TEMP` tables--is that we don't want a new connection created from the connection pool
to appear to discard the state associated with a user's session. It doesn't actually do that, but the new connection lacks any session-specific state from the previous one.

It's not clear to me what the downsides are here except perhaps that a use case
where ibis is part of a server application that fields a large number of
concurrent requests can be bottlenecked by any long running queries.
