### PR TITLE
fix(snowflake): bring back `cache` and always quote column names in expressions

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -879,6 +879,37 @@ class BaseBackend(abc.ABC, _FileIOHandler):
             f"{cls.name} backend has not implemented `has_operation` API"
         )
 
+    def _cache(self, expr):
+        """Cache the provided expression. All subsequent operations on the returned expression will be performed on the cached data.
+
+        Parameters
+        ----------
+        expr
+            Table expression to cache
+
+        Returns
+        -------
+        Expr
+            Cached table
+
+        """
+        raise NotImplementedError(
+            f"{self.name} backend has not implemented `cache` API"
+        )
+
+    def _release_cache(self, expr):
+        """Releases the provided cached expression.
+
+        Parameters
+        ----------
+        expr
+            Cached expression to release
+
+        """
+        raise NotImplementedError(
+            f"{self.name} backend has not implemented `release_cache` API"
+        )
+
 
 @functools.lru_cache(maxsize=None)
 def _get_backend_names() -> frozenset[str]:

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -257,7 +257,12 @@ class BaseAlchemyBackend(BaseSQLBackend):
     def _columns_from_schema(self, name: str, schema: sch.Schema) -> list[sa.Column]:
         dialect = self.con.dialect
         return [
-            sa.Column(colname, to_sqla_type(dialect, dtype), nullable=dtype.nullable)
+            sa.Column(
+                colname,
+                to_sqla_type(dialect, dtype),
+                nullable=dtype.nullable,
+                quote=self.compiler.translator_class._always_quote_columns,
+            )
             for colname, dtype in zip(schema.names, schema.types)
         ]
 
@@ -437,7 +442,10 @@ class BaseAlchemyBackend(BaseSQLBackend):
                 # types
                 table.append_column(
                     sa.Column(
-                        colname, to_sqla_type(dialect, type), nullable=type.nullable
+                        colname,
+                        to_sqla_type(dialect, type),
+                        nullable=type.nullable,
+                        quote=self.compiler.translator_class._always_quote_columns,
                     ),
                     replace_existing=True,
                 )

--- a/ibis/backends/base/sql/alchemy/translator.py
+++ b/ibis/backends/base/sql/alchemy/translator.py
@@ -47,7 +47,7 @@ class AlchemyExprTranslator(ExprTranslator):
 
     integer_to_timestamp = sa.func.to_timestamp
     native_json_type = True
-    _always_quote_columns = False
+    _always_quote_columns = None  # let the dialect decide how to quote
 
     _require_order_by = (
         ops.DenseRank,

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -13,6 +13,7 @@ import ibis.backends.pandas.execution
 import ibis.config
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+from ibis import util
 from ibis.backends.dask.client import DaskDatabase, DaskTable, ibis_schema_to_dask
 from ibis.backends.dask.core import execute_and_reset
 from ibis.backends.pandas import BasePandasBackend
@@ -135,3 +136,15 @@ class Backend(BasePandasBackend):
     ):
         """Create a table."""
         super().create_table(table_name, obj=obj, schema=schema)
+
+    def _cache(self, expr):
+        persisted_table_name = util.generate_unique_table_name("cache")
+        df = self.compile(expr).persist()
+        self.load_data(persisted_table_name, df)
+        return self.table(persisted_table_name)
+
+    def _release_cache(self, expr):
+        if isinstance(expr._arg, DaskTable):
+            del self.dictionary[expr._arg.name]
+        else:
+            raise NotImplementedError(f"{expr.arg} is not releasable.")

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -253,3 +253,9 @@ class Backend(BasePandasBackend):
             }
 
         return execute_and_reset(node, params=params, **kwargs)
+
+    def _cache(self, expr):
+        return expr
+
+    def _release_cache(self, expr):
+        return

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -13,8 +13,10 @@ import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+from ibis import util
 from ibis.backends.base import BaseBackend
 from ibis.backends.polars.compiler import translate
+from ibis.expr.operations import DatabaseTable
 from ibis.util import normalize_filename
 
 if TYPE_CHECKING:
@@ -350,3 +352,15 @@ class Backend(BaseBackend):
         self._import_pyarrow()
         table = self._to_pyarrow_table(expr, params=params, limit=limit, **kwargs)
         return table.to_reader(chunk_size)
+
+    def _cache(self, expr):
+        persisted_table_name = util.generate_unique_table_name("cache")
+        lf = self.compile(expr).cache()
+        self.load_data(persisted_table_name, lf)
+        return self.table(persisted_table_name, expr.schema)
+
+    def _release_cache(self, expr):
+        if isinstance(expr._arg, DatabaseTable):
+            del self._tables[expr._arg.name]
+        else:
+            raise NotImplementedError(f"{expr._arg} is not releasable.")

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -70,6 +70,7 @@ class SnowflakeExprTranslator(AlchemyExprTranslator):
     )
     _require_order_by = (*AlchemyExprTranslator._require_order_by, ops.Reduction)
     _dialect_name = "snowflake"
+    _always_quote_columns = True
     supports_unnest_in_select = False
 
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1095,3 +1095,52 @@ def test_create_table_timestamp(con):
         assert result == schema
     finally:
         con.drop_table(name, force=True)
+
+
+@mark.notimpl(
+    [
+        "clickhouse",
+        "datafusion",
+        "bigquery",
+        "impala",
+        "pyspark",
+        "trino",
+        "druid",
+    ]
+)
+@mark.notyet(
+    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
+)
+@mark.never(
+    ["mssql"],
+    reason="mssql supports support temporary tables through naming conventions",
+)
+def test_persist_expression(con, alltypes):
+    non_persisted_table = alltypes.mutate(test_column="calculation")
+    persisted_table = non_persisted_table.cache()
+
+    tm.assert_frame_equal(non_persisted_table.to_pandas(), persisted_table.to_pandas())
+
+
+@mark.notimpl(
+    [
+        "clickhouse",
+        "datafusion",
+        "bigquery",
+        "impala",
+        "pyspark",
+        "trino",
+        "druid",
+    ]
+)
+@mark.notyet(
+    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
+)
+@mark.never(
+    ["mssql"],
+    reason="mssql supports support temporary tables through naming conventions",
+)
+def test_persist_expression_contextmanager(con, alltypes):
+    non_cached_table = alltypes.mutate(test_column="calculation")
+    with non_cached_table.cache() as cached_table:
+        tm.assert_frame_equal(non_cached_table.to_pandas(), cached_table.to_pandas())

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import datetime
 import functools
 import operator
-import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Sequence, TypeVar
 from typing import Tuple as _Tuple
@@ -20,6 +19,7 @@ import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
+from ibis import util
 from ibis.backends.base import BaseBackend, connect
 from ibis.common.exceptions import IbisInputError
 from ibis.expr import selectors
@@ -420,12 +420,8 @@ def _memtable_from_dataframe(
 ) -> Table:
     from ibis.backends.pandas.client import DataFrameProxy, PandasInMemoryTable
 
-    def _generate_unique_table_name():
-        # create case-insensitive uuid4 unique table name
-        return f"_ibis_memtable_{np.base_repr(uuid.uuid4().int, 36).lower()}"
-
     op = PandasInMemoryTable(
-        name=name if name is not None else _generate_unique_table_name(),
+        name=name if name is not None else util.generate_unique_table_name("memtable"),
         schema=sch.infer(df) if schema is None else schema,
         data=DataFrameProxy(df),
     )

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -12,6 +12,7 @@ import os
 import sys
 import textwrap
 import types
+import uuid
 import warnings
 from numbers import Real
 from typing import (
@@ -25,6 +26,7 @@ from typing import (
 )
 from uuid import uuid4
 
+import numpy as np
 import toolz
 
 if TYPE_CHECKING:
@@ -555,3 +557,8 @@ def normalize_filename(source: str | Path) -> str:
 
     source = _absolufy_paths(source)
     return source
+
+
+def generate_unique_table_name(namespace: str) -> str:
+    """Creates case-insensitive uuid4 unique table name."""
+    return f"_ibis_{namespace}_{np.base_repr(uuid.uuid4().int, 36)}".lower()


### PR DESCRIPTION
This PR reverts the revert of the `cache()` PR and adds a second commit that fixes the snowflake backend implementation.