### PR TITLE
fix(sql): make set operations produce valid sql in the presence of sort keys

### DIFF
--- a/ibis/backends/base/sql/compiler/base.py
+++ b/ibis/backends/base/sql/compiler/base.py
@@ -68,8 +68,12 @@ class SetOp(DML):
         return map(self.keyword, self.distincts)
 
     def _extract_subqueries(self):
+        # extract any subquery to avoid generating incorrect sql when at least
+        # one of the set operands is invalid outside of being a subquery
+        #
+        # for example: SELECT * FROM t ORDER BY x UNION ...
         self.subqueries = an.find_subqueries(
-            [self.table_set, *self.filters], min_dependents=2
+            [self.table_set, *self.filters], min_dependents=1
         )
         for subquery in self.subqueries:
             self.context.set_extracted(subquery)

--- a/ibis/tests/sql/snapshots/test_compiler/test_difference_project_column/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_difference_project_column/out.sql
@@ -1,10 +1,18 @@
 SELECT t0.`key`
 FROM (
-  SELECT t1.`string_col` AS `key`, CAST(t1.`float_col` AS double) AS `value`
-  FROM functional_alltypes t1
-  WHERE t1.`int_col` > 0
+  WITH t1 AS (
+    SELECT t3.`string_col` AS `key`, t3.`double_col` AS `value`
+    FROM functional_alltypes t3
+    WHERE t3.`int_col` <= 0
+  ),
+  t2 AS (
+    SELECT t3.`string_col` AS `key`, CAST(t3.`float_col` AS double) AS `value`
+    FROM functional_alltypes t3
+    WHERE t3.`int_col` > 0
+  )
+  SELECT *
+  FROM t2
   EXCEPT
-  SELECT t1.`string_col` AS `key`, t1.`double_col` AS `value`
-  FROM functional_alltypes t1
-  WHERE t1.`int_col` <= 0
+  SELECT *
+  FROM t1
 ) t0

--- a/ibis/tests/sql/snapshots/test_compiler/test_intersect_project_column/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_intersect_project_column/out.sql
@@ -1,10 +1,18 @@
 SELECT t0.`key`
 FROM (
-  SELECT t1.`string_col` AS `key`, CAST(t1.`float_col` AS double) AS `value`
-  FROM functional_alltypes t1
-  WHERE t1.`int_col` > 0
+  WITH t1 AS (
+    SELECT t3.`string_col` AS `key`, t3.`double_col` AS `value`
+    FROM functional_alltypes t3
+    WHERE t3.`int_col` <= 0
+  ),
+  t2 AS (
+    SELECT t3.`string_col` AS `key`, CAST(t3.`float_col` AS double) AS `value`
+    FROM functional_alltypes t3
+    WHERE t3.`int_col` > 0
+  )
+  SELECT *
+  FROM t2
   INTERSECT
-  SELECT t1.`string_col` AS `key`, t1.`double_col` AS `value`
-  FROM functional_alltypes t1
-  WHERE t1.`int_col` <= 0
+  SELECT *
+  FROM t1
 ) t0

--- a/ibis/tests/sql/snapshots/test_compiler/test_table_difference/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_table_difference/out.sql
@@ -1,7 +1,15 @@
-SELECT t0.`string_col` AS `key`, CAST(t0.`float_col` AS double) AS `value`
-FROM functional_alltypes t0
-WHERE t0.`int_col` > 0
+WITH t0 AS (
+  SELECT t2.`string_col` AS `key`, t2.`double_col` AS `value`
+  FROM functional_alltypes t2
+  WHERE t2.`int_col` <= 0
+),
+t1 AS (
+  SELECT t2.`string_col` AS `key`, CAST(t2.`float_col` AS double) AS `value`
+  FROM functional_alltypes t2
+  WHERE t2.`int_col` > 0
+)
+SELECT *
+FROM t1
 EXCEPT
-SELECT t0.`string_col` AS `key`, t0.`double_col` AS `value`
-FROM functional_alltypes t0
-WHERE t0.`int_col` <= 0
+SELECT *
+FROM t0

--- a/ibis/tests/sql/snapshots/test_compiler/test_table_intersect/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_table_intersect/out.sql
@@ -1,7 +1,15 @@
-SELECT t0.`string_col` AS `key`, CAST(t0.`float_col` AS double) AS `value`
-FROM functional_alltypes t0
-WHERE t0.`int_col` > 0
+WITH t0 AS (
+  SELECT t2.`string_col` AS `key`, t2.`double_col` AS `value`
+  FROM functional_alltypes t2
+  WHERE t2.`int_col` <= 0
+),
+t1 AS (
+  SELECT t2.`string_col` AS `key`, CAST(t2.`float_col` AS double) AS `value`
+  FROM functional_alltypes t2
+  WHERE t2.`int_col` > 0
+)
+SELECT *
+FROM t1
 INTERSECT
-SELECT t0.`string_col` AS `key`, t0.`double_col` AS `value`
-FROM functional_alltypes t0
-WHERE t0.`int_col` <= 0
+SELECT *
+FROM t0

--- a/ibis/tests/sql/snapshots/test_compiler/test_union/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_union/out.sql
@@ -1,7 +1,15 @@
-SELECT t0.`string_col` AS `key`, CAST(t0.`float_col` AS double) AS `value`
-FROM functional_alltypes t0
-WHERE t0.`int_col` > 0
+WITH t0 AS (
+  SELECT t2.`string_col` AS `key`, t2.`double_col` AS `value`
+  FROM functional_alltypes t2
+  WHERE t2.`int_col` <= 0
+),
+t1 AS (
+  SELECT t2.`string_col` AS `key`, CAST(t2.`float_col` AS double) AS `value`
+  FROM functional_alltypes t2
+  WHERE t2.`int_col` > 0
+)
+SELECT *
+FROM t1
 UNION
-SELECT t0.`string_col` AS `key`, t0.`double_col` AS `value`
-FROM functional_alltypes t0
-WHERE t0.`int_col` <= 0
+SELECT *
+FROM t0

--- a/ibis/tests/sql/snapshots/test_compiler/test_union_order_by/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_compiler/test_union_order_by/decompiled.py
@@ -1,0 +1,7 @@
+import ibis
+
+
+t = ibis.table(name="t", schema={"a": "int64", "b": "string"})
+proj = t.order_by(t.b.asc())
+
+result = proj.union(proj)

--- a/ibis/tests/sql/snapshots/test_compiler/test_union_order_by/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_union_order_by/out.sql
@@ -1,0 +1,10 @@
+WITH t0 AS (
+  SELECT t1.*
+  FROM t t1
+  ORDER BY t1.`b` ASC
+)
+SELECT *
+FROM t0
+UNION ALL
+SELECT *
+FROM t0

--- a/ibis/tests/sql/snapshots/test_compiler/test_union_project_column/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_union_project_column/out.sql
@@ -1,10 +1,18 @@
 SELECT t0.`key`
 FROM (
-  SELECT t1.`string_col` AS `key`, CAST(t1.`float_col` AS double) AS `value`
-  FROM functional_alltypes t1
-  WHERE t1.`int_col` > 0
+  WITH t1 AS (
+    SELECT t3.`string_col` AS `key`, t3.`double_col` AS `value`
+    FROM functional_alltypes t3
+    WHERE t3.`int_col` <= 0
+  ),
+  t2 AS (
+    SELECT t3.`string_col` AS `key`, CAST(t3.`float_col` AS double) AS `value`
+    FROM functional_alltypes t3
+    WHERE t3.`int_col` > 0
+  )
+  SELECT *
+  FROM t2
   UNION ALL
-  SELECT t1.`string_col` AS `key`, t1.`double_col` AS `value`
-  FROM functional_alltypes t1
-  WHERE t1.`int_col` <= 0
+  SELECT *
+  FROM t1
 ) t0

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -218,3 +218,10 @@ def test_column_expr_default_name(snapshot):
     expr = t.int_col + 4
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot)
+
+
+def test_union_order_by(snapshot):
+    t = ibis.table(dict(a="int", b="string"), name="t")
+    expr = t.order_by("b").union(t.order_by("b"))
+    snapshot.assert_match(to_sql(expr), "out.sql")
+    assert_decompile_roundtrip(expr, snapshot)


### PR DESCRIPTION
This PR address an issue with generating invalid SQL when a projection of a set operation contains sort keys. I addressed this by simply treating subqueries of a union as extractable so they become CTEs in the output.

Fixes #5696.