### PR TITLE
docs: add druid to the backends index docs page

### DIFF
--- a/docs/backends/index.md
+++ b/docs/backends/index.md
@@ -23,14 +23,15 @@ system's expressions, for example, SQLAlchemy.
 Instead of generating strings for each expression these backends produce
 another kind of expression and typically have high-level APIs for execution.
 
+- [Apache Arrow Datafusion](Datafusion.md)
+- [Apache Druid](Druid.md)
+- [Apache PySpark](PySpark.md)
 - [Dask](Dask.md)
-- [Datafusion](Datafusion.md)
 - [DuckDB](DuckDB.md)
-- [MySQL](MySQL.md)
 - [MS SQL Server](MSSQL.md)
+- [MySQL](MySQL.md)
 - [Polars](Polars.md)
 - [PostgreSQL](PostgreSQL.md)
-- [PySpark](PySpark.md)
 - [SQLite](SQLite.md)
 - [Snowflake](Snowflake.md)
 - [Trino](Trino.md)


### PR DESCRIPTION
This PR adds the druid backend to the backends index page, and also sorts the backends in the index by name.