### PR TITLE
feat: return Table from `create_table()` and `create_view()`

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -766,7 +766,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         obj: pd.DataFrame | ir.Table | None = None,
         schema: ibis.Schema | None = None,
         database: str | None = None,
-    ) -> None:
+    ) -> ir.Table:
         """Create a new table.
 
         Not all backends implement this method.
@@ -785,6 +785,11 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         database
             Name of the database where the table will be created, if not the
             default.
+
+        Returns
+        -------
+        Table
+            The table that was created.
         """
         raise NotImplementedError(
             f'Backend "{self.name}" does not implement "create_table"'
@@ -816,7 +821,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         name: str,
         expr: ir.Table,
         database: str | None = None,
-    ) -> None:
+    ) -> ir.Table:
         """Create a view.
 
         Parameters
@@ -829,6 +834,11 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         database
             Name of the database where the view will be created, if not the
             default.
+
+        Returns
+        -------
+        Table
+            The view that was created.
         """
         raise NotImplementedError(
             f'Backend "{self.name}" does not implement "create_view"'

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -174,23 +174,32 @@ class BaseAlchemyBackend(BaseSQLBackend):
         database: str | None = None,
         force: bool = False,
         temp: bool = False,
-    ) -> None:
+    ) -> ir.Table:
         """Create a table.
 
         Parameters
         ----------
         name
-            Table name to create
+            Name of the new table.
         expr
-            DataFrame or table expression to use as the data source
+            An Ibis table expression or pandas table that will be used to
+            extract the schema and the data of the new table. If not provided,
+            `schema` must be given.
         schema
-            An ibis schema
+            The schema for the new table. Only one of `schema` or `obj` can be
+            provided.
         database
-            A database
+            Name of the database where the table will be created, if not the
+            default.
         force
             Check whether a table exists before creating it
         temp
             Should the table be temporary for the session.
+
+        Returns
+        -------
+        Table
+            The table that was created.
         """
         import pandas as pd
 
@@ -236,6 +245,7 @@ class BaseAlchemyBackend(BaseSQLBackend):
             if has_expr:
                 method = self._get_insert_method(expr)
                 bind.execute(method(table.insert()))
+        return self.table(name, database=database)
 
     def _get_insert_method(self, expr):
         compiled = self.compile(expr)

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -443,7 +443,7 @@ class Backend(BaseSQLBackend):
         obj: pd.DataFrame | ir.Table | None = None,
         schema: ibis.Schema | None = None,
         database: str | None = None,
-    ) -> None:
+    ) -> ir.Table:
         if obj is None and schema is None:
             raise ValueError("The schema or obj parameter is required")
         if schema is not None:
@@ -460,6 +460,7 @@ class Backend(BaseSQLBackend):
             sql_select = self.compile(table)
             table_ref = f"`{project_id}`.`{dataset}`.`{name}`"
             self.raw_sql(f'CREATE TABLE {table_ref} AS ({sql_select})')
+        return self.table(name, database=database)
 
     def drop_table(
         self, name: str, database: str | None = None, force: bool = False
@@ -469,12 +470,13 @@ class Backend(BaseSQLBackend):
 
     def create_view(
         self, name: str, expr: ir.Table, database: str | None = None
-    ) -> None:
+    ) -> ir.Table:
         table_id = self._fully_qualified_name(name, database)
         sql_select = self.compile(expr)
         table = bq.Table(table_id)
         table.view_query = sql_select
         self.client.create_table(table)
+        return self.table(name, database=database)
 
     def drop_view(
         self, name: str, database: str | None = None, force: bool = False

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -128,15 +128,6 @@ class Backend(BasePandasBackend):
     def _convert_object(cls, obj: dd.DataFrame) -> dd.DataFrame:
         return obj
 
-    def create_table(
-        self,
-        table_name: str,
-        obj: dd.DataFrame | None = None,
-        schema: sch.Schema | None = None,
-    ):
-        """Create a table."""
-        super().create_table(table_name, obj=obj, schema=schema)
-
     def _cache(self, expr):
         persisted_table_name = util.generate_unique_table_name("cache")
         df = self.compile(expr).persist()

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -691,11 +691,12 @@ class Backend(BaseAlchemyBackend):
 
     def create_view(
         self, name: str, expr: ir.Table, database: str | None = None
-    ) -> None:
+    ) -> ir.Table:
         source = self.compile(expr)
         view = _create_view(sa.table(name), source, or_replace=True)
         with self.begin() as con:
             con.execute(view)
+        return self.table(name, database=database)
 
     def drop_view(
         self, name: str, database: str | None = None, force: bool = False

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -27,14 +27,12 @@ if TYPE_CHECKING:
 
 
 class ImpalaDatabase(Database):
-    def create_table(self, table_name, obj=None, **kwargs):
+    def create_table(self, name: str, obj=None, **kwargs) -> ir.Table:
         """Dispatch to ImpalaClient.create_table.
 
         See that function's docstring for more
         """
-        return self.client.create_table(
-            table_name, obj=obj, database=self.name, **kwargs
-        )
+        return self.client.create_table(name, obj=obj, database=self.name, **kwargs)
 
     def list_udfs(self, like=None):
         return self.client.list_udfs(like=like, database=self.name)

--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -18,14 +18,12 @@ def test_create_exists_view(con, temp_view):
     tmp_name = temp_view
     assert tmp_name not in con.list_tables()
 
-    expr = con.table('functional_alltypes').group_by('string_col').size()
+    t1 = con.table('functional_alltypes').group_by('string_col').size()
+    t2 = con.create_view(tmp_name, t1)
 
-    con.create_view(tmp_name, expr)
     assert tmp_name in con.list_tables()
-
     # just check it works for now
-    expr2 = con.table(tmp_name)
-    assert expr2.execute() is not None
+    assert t2.execute() is not None
 
 
 def test_drop_non_empty_database(con, alltypes, temp_table_db):

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -119,7 +119,9 @@ class BasePandasBackend(BaseBackend):
     def compile(self, expr, *args, **kwargs):
         return expr
 
-    def create_table(self, table_name, obj=None, schema=None):
+    def create_table(
+        self, table_name: str, obj=None, schema: sch.Schema | None = None
+    ) -> ir.Table:
         """Create a table."""
         if obj is None and schema is None:
             raise com.IbisError('Must pass expr or schema')
@@ -140,6 +142,7 @@ class BasePandasBackend(BaseBackend):
 
         if schema is not None:
             self.schemas[table_name] = schema
+        return self.table(table_name)
 
     @classmethod
     def _supports_conversion(cls, obj: Any) -> bool:

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -402,13 +402,13 @@ class Backend(BaseSQLBackend):
         force: bool = False,
         # HDFS options
         format: str = 'parquet',
-    ):
+    ) -> ir.Table:
         """Create a new table in Spark.
 
         Parameters
         ----------
         table_name
-            Table name
+            Name of the new table.
         obj
             If passed, creates table from select statement results
         schema
@@ -420,6 +420,11 @@ class Backend(BaseSQLBackend):
             If true, create table if table with indicated name already exists
         format
             Table format
+
+        Returns
+        -------
+        Table
+            The newly created table.
 
         Examples
         --------
@@ -459,7 +464,8 @@ class Backend(BaseSQLBackend):
         else:
             raise com.IbisError('Must pass expr or schema')
 
-        return self.raw_sql(statement.compile())
+        self.raw_sql(statement.compile())
+        return self.table(table_name, database=database)
 
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         self.compile(op.to_expr()).createOrReplaceTempView(op.name)
@@ -471,7 +477,7 @@ class Backend(BaseSQLBackend):
         database: str | None = None,
         can_exist: bool = False,
         temporary: bool = False,
-    ):
+    ) -> ir.Table:
         """Create a Spark view from a table expression.
 
         Parameters
@@ -486,6 +492,11 @@ class Backend(BaseSQLBackend):
             Replace an existing view of the same name if it exists
         temporary
             Whether the table is temporary
+
+        Returns
+        -------
+        Table
+            The created view
         """
         ast = self.compiler.to_ast(expr)
         select = ast.queries[0]
@@ -496,7 +507,8 @@ class Backend(BaseSQLBackend):
             can_exist=can_exist,
             temporary=temporary,
         )
-        return self.raw_sql(statement.compile())
+        self.raw_sql(statement.compile())
+        return self.table(name, database=database)
 
     def drop_table(
         self,

--- a/ibis/backends/sqlite/tests/test_client.py
+++ b/ibis/backends/sqlite/tests/test_client.py
@@ -72,8 +72,7 @@ def test_compile_toplevel(snapshot):
 def test_create_and_drop_table(con):
     t = con.table('functional_alltypes')
     name = str(uuid.uuid4())
-    con.create_table(name, t.limit(5))
-    new_table = con.table(name)
+    new_table = con.create_table(name, t.limit(5))
     tm.assert_frame_equal(new_table.execute(), t.limit(5).execute())
     con.drop_table(name)
     assert name not in con.list_tables()

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -646,8 +646,7 @@ def test_identical_to(alltypes):
 def test_truncate_method(con, alltypes):
     expr = alltypes.limit(5)
     name = str(uuid.uuid4())
-    con.create_table(name, expr)
-    t = con.table(name)
+    t = con.create_table(name, expr)
     assert len(t.execute()) == 5
     t.truncate()
     assert len(t.execute()) == 0
@@ -656,8 +655,7 @@ def test_truncate_method(con, alltypes):
 def test_truncate_from_connection(con, alltypes):
     expr = alltypes.limit(5)
     name = str(uuid.uuid4())
-    con.create_table(name, expr)
-    t = con.table(name)
+    t = con.create_table(name, expr)
     assert len(t.execute()) == 5
     con.truncate_table(name)
     assert len(t.execute()) == 0

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -27,8 +27,7 @@ def new_schema():
 
 def _create_temp_table_with_schema(con, temp_table_name, schema, data=None):
     con.drop_table(temp_table_name, force=True)
-    con.create_table(temp_table_name, schema=schema)
-    temporary = con.table(temp_table_name)
+    temporary = con.create_table(temp_table_name, schema=schema)
     assert temporary.to_pandas().empty
 
     if data is not None and isinstance(data, pd.DataFrame):
@@ -123,9 +122,7 @@ backend_type_mapping = {
 
 @mark.notimpl(["clickhouse", "datafusion", "polars", "druid"])
 def test_create_table_from_schema(con, new_schema, temp_table):
-    con.create_table(temp_table, schema=new_schema)
-
-    new_table = con.table(temp_table)
+    new_table = con.create_table(temp_table, schema=new_schema)
     backend_mapping = backend_type_mapping.get(con.name, dict())
 
     for column_name, column_type in new_table.schema().items():
@@ -158,9 +155,7 @@ def test_create_table_from_schema(con, new_schema, temp_table):
 )
 def test_create_temporary_table_from_schema(con, new_schema):
     temp_table = f"_{guid()}"
-    con.create_table(temp_table, schema=new_schema, temp=True)
-
-    table = con.table(temp_table)
+    table = con.create_table(temp_table, schema=new_schema, temp=True)
 
     # verify table exist in the current session
     backend_mapping = backend_type_mapping.get(con.name, dict())
@@ -216,10 +211,7 @@ def test_nullable_input_output(con, temp_table):
     sch = ibis.schema(
         [('foo', 'int64'), ('bar', dt.int64(nullable=False)), ('baz', 'boolean')]
     )
-
-    con.create_table(temp_table, schema=sch)
-
-    t = con.table(temp_table)
+    t = con.create_table(temp_table, schema=sch)
 
     assert t.schema().types[0].nullable
     assert not t.schema().types[1].nullable

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -181,9 +181,9 @@ def test_table_dot_sql_repr(con):
 @dot_sql_never
 def test_table_dot_sql_does_not_clobber_existing_tables(con):
     name = f"ibis_{util.guid()}"
-    con.create_table(name, schema=ibis.schema(dict(a="string")))
+    t = con.create_table(name, schema=ibis.schema(dict(a="string")))
     try:
-        expr = con.table(name).sql("SELECT 1 as x FROM functional_alltypes")
+        expr = t.sql("SELECT 1 as x FROM functional_alltypes")
         with pytest.raises(ValueError):
             expr.alias(name)
     finally:

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -215,8 +215,7 @@ def tmptable(con):
 
 @pytest.mark.notimpl(["clickhouse"], reason=".create_table not yet implemented in ibis")
 def test_map_create_table(con, tmptable):
-    con.create_table(tmptable, schema=ibis.schema(dict(xyz="map<string, string>")))
-    t = con.table(tmptable)
+    t = con.create_table(tmptable, schema=ibis.schema(dict(xyz="map<string, string>")))
     assert t.schema()["xyz"].is_map()
 
 


### PR DESCRIPTION
Closes https://github.com/ibis-project/ibis/issues/5693

I didn't add any tests sepcific to this,
because I modified some existing tests so that
they relied on this new behavior, so this new
behavior is getting tested as a side benefit.
The tests are also clearer now because of this.
I did NOT adjust some tests that I thought would
more clear to have two separate steps of
creating the table/view and accessing it later.