### PR TITLE
refactor(cache): pull out ref counted cache into a separate class

### DIFF
--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -129,6 +129,3 @@ class Backend(BasePandasBackend):
 
     def _load_into_cache(self, name, expr):
         self.create_table(name, self.compile(expr).persist())
-
-    def _clean_up_cached_table(self, op):
-        del self.dictionary[op.name]

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -238,6 +238,9 @@ class BasePandasBackend(BaseBackend):
             issubclass(operation, op_impl) for op_impl in op_classes
         )
 
+    def _clean_up_cached_table(self, op):
+        del self.dictionary[op.name]
+
 
 class Backend(BasePandasBackend):
     name = 'pandas'
@@ -303,9 +306,5 @@ class Backend(BasePandasBackend):
 
         return execute_and_reset(node, params=params, **kwargs)
 
-    def _cached(self, expr):
-        """No-op. The expression is already in memory."""
-        return ir.CachedTable(expr.op())
-
-    def _release_cached(self, _):
-        """No-op."""
+    def _load_into_cache(self, name, expr):
+        self.create_table(name, expr.execute())

--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 import weakref
-from typing import MutableMapping
+from collections import Counter, defaultdict
+from typing import Any, Callable, MutableMapping
+
+import toolz
+from bidict import bidict
+
+from ibis.common.exceptions import IbisError
 
 
 class WeakCache(MutableMapping):
@@ -46,3 +52,74 @@ class WeakCache(MutableMapping):
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self._data})"
+
+
+class RefCountedCache:
+    """A cache with reference-counted keys.
+
+    We could implement `MutableMapping`, but the `__setitem__` implementation
+    doesn't make sense and the `len` and `__iter__` methods aren't used.
+
+    We can implement that interface if and when we need to.
+    """
+
+    def __init__(
+        self,
+        *,
+        populate: Callable[[str, Any], None],
+        lookup: Callable[[str], Any],
+        finalize: Callable[[Any], None],
+        generate_name: Callable[[], str],
+        key: Callable[[Any], Any],
+    ) -> None:
+        self.cache = bidict()
+        self.refs = Counter()
+        self.populate = populate
+        self.lookup = lookup
+        self.finalize = finalize
+        self.names = defaultdict(generate_name)
+        self.key = key or toolz.identity
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __getitem__(self, key):
+        result = self.cache[key]
+        self.refs[key] += 1
+        return result
+
+    def store(self, input) -> None:
+        """Compute and store a reference to `key`."""
+        key = self.key(input)
+        name = self.names[key]
+        self.populate(name, input)
+        self.cache[key] = self.lookup(name)
+        # nothing outside of this instance has referenced this key yet, so the
+        # refcount is zero
+        #
+        # in theory it's possible to call store -> delitem which would raise an
+        # exception, but in practice this doesn't happen because the only call
+        # to store is immediately followed by a call to getitem.
+        self.refs[key] = 0
+
+    def __delitem__(self, key) -> None:
+        # we need to remove the expression representing the computed physical
+        # table as well as the expression that was used to create that table
+        #
+        # bidict automatically handles this for us; without it we'd have to do
+        # to the bookkeeping ourselves with two dicts
+        if (inv_key := self.cache.inverse.get(key)) is None:
+            raise IbisError(
+                "Key has already been released. Did you call "
+                "`.release()` twice on the same expression?"
+            )
+
+        self.refs[inv_key] -= 1
+        assert self.refs[inv_key] >= 0, f"refcount is negative: {self.refs[inv_key]:d}"
+
+        if not self.refs[inv_key]:
+            del self.cache[inv_key], self.refs[inv_key]
+            self.finalize(key)

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -424,6 +424,12 @@ class MockBackend(BaseSQLBackend):
     def drop_view(self, *_, **__) -> ir.Table:
         raise NotImplementedError(self.name)
 
+    def _load_into_cache(self, *_):
+        raise NotImplementedError(self.name)
+
+    def _clean_up_cached_table(self, _):
+        raise NotImplementedError(self.name)
+
 
 def table_from_schema(name, meta, schema, *, database: str | None = None):
     # Convert Ibis schema to SQLA table


### PR DESCRIPTION
This PR is a follow up to #5699 to refactor the query cache out into a separate class for easier maintenance and code clarity.