### PR TITLE
fix(cache): do not pass invalid arguments to table method

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -918,7 +918,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         if (result := self._query_cache.get(op)) is None:
             name = util.generate_unique_table_name("cache")
             self._load_into_cache(name, expr)
-            self._query_cache[op] = result = self.table(name, expr.schema()).op()
+            self._query_cache[op] = result = self.table(name).op()
         self._refs[op] += 1
         return ir.CachedTable(result)
 

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -6,6 +6,7 @@ import os
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
+import ibis.common.exceptions as exc
 import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
@@ -77,6 +78,10 @@ class BaseSQLBackend(BaseBackend):
         Table
             Table expression
         """
+        if database is not None and not isinstance(database, str):
+            raise exc.IbisTypeError(
+                f"`database` must be a string; got {type(database)}"
+            )
         qualified_name = self._fully_qualified_name(name, database)
         schema = self.get_schema(qualified_name)
         node = self.table_class(qualified_name, schema, self)

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -512,8 +512,13 @@ class BaseAlchemyBackend(BaseSQLBackend):
         Table
             Table expression
         """
-        if database is not None and database != self.current_database:
-            return self.database(name=database).table(name=name, schema=schema)
+        if database is not None:
+            if not isinstance(database, str):
+                raise exc.IbisTypeError(
+                    f"`database` must be a string; got {type(database)}"
+                )
+            if database != self.current_database:
+                return self.database(name=database).table(name=name, schema=schema)
         sqla_table = self._get_sqla_table(name, database=database, schema=schema)
         return self._sqla_table_to_expr(sqla_table)
 


### PR DESCRIPTION
Fixes an invalid call to self.table when looking up a cached expression.