### PR TITLE
docs(parquet): add docstring examples for to_parquet incl. partitioning

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -584,6 +584,24 @@ class Backend(BaseAlchemyBackend):
             DuckDB Parquet writer arguments. See
             https://duckdb.org/docs/data/parquet#writing-to-parquet-files for
             details
+
+        Examples
+        --------
+        Write out an expression to a single parquet file.
+
+        >>> import ibis
+        >>> penguins = ibis.examples.penguins.fetch()
+        >>> con = ibis.get_backend(penguins)
+        >>> con.to_parquet(penguins, "penguins.parquet")
+
+        Write out an expression to a hive-partitioned parquet file.
+
+        >>> import ibis
+        >>> penguins = ibis.examples.penguins.fetch()
+        >>> con = ibis.get_backend(penguins)
+        >>> con.to_parquet(penguins, "penguins_hive_dir", partition_by="year")  # doctest: +SKIP
+        >>> # partition on multiple columns
+        >>> con.to_parquet(penguins, "penguins_hive_dir", partition_by=("year", "island"))  # doctest: +SKIP
         """
         query = self._to_sql(expr, params=params)
         args = ["FORMAT 'parquet'", *(f"{k.upper()} {v!r}" for k, v in kwargs.items())]

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -117,6 +117,7 @@ class Backend(BaseAlchemyBackend):
         --------
         >>> import ibis
         >>> ibis.duckdb.connect("database.ddb", threads=4, memory_limit="1GB")
+        <ibis.backends.duckdb.Backend object at ...>
         """
         if path is not None:
             warnings.warn(
@@ -471,8 +472,14 @@ class Backend(BaseAlchemyBackend):
         --------
         >>> import ibis
         >>> con = ibis.connect("duckdb://")
-        >>> t = con.read_sqlite("ci/ibis-testing-data/ibis_testing.db")
+        >>> t = con.read_sqlite("ci/ibis-testing-data/ibis_testing.db", table_name="diamonds")
         >>> t.head().execute()
+                carat      cut color clarity  depth  table  price     x     y     z
+            0   0.23    Ideal     E     SI2   61.5   55.0    326  3.95  3.98  2.43
+            1   0.21  Premium     E     SI1   59.8   61.0    326  3.89  3.84  2.31
+            2   0.23     Good     E     VS1   56.9   65.0    327  4.05  4.07  2.31
+            3   0.29  Premium     I     VS2   62.4   58.0    334  4.20  4.23  2.63
+            4   0.31     Good     J     SI2   63.3   58.0    335  4.34  4.35  2.75
         """
         if table_name is None:
             raise ValueError("`table_name` is required when registering a sqlite table")

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -426,6 +426,25 @@ class Expr(Immutable):
             Additional keyword arguments passed to pyarrow.parquet.ParquetWriter
 
         https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html
+
+        Examples
+        --------
+        Write out an expression to a single parquet file.
+
+        >>> import ibis
+        >>> penguins = ibis.examples.penguins.fetch()
+        >>> penguins.to_parquet("penguins.parquet")  # doctest: +SKIP
+
+        Write out an expression to a hive-partitioned parquet file.
+
+        >>> import ibis
+        >>> penguins = ibis.examples.penguins.fetch()
+        >>> # partition on single column
+        >>> penguins.to_parquet("penguins_hive_dir", partition_by="year")  # doctest: +SKIP
+        >>> # partition on multiple columns
+        >>> penguins.to_parquet("penguins_hive_dir", partition_by=("year", "island"))  # doctest: +SKIP
+
+        !!! note "Hive-partitioned output is currently only supported when using DuckDB"
         """
         self._find_backend(use_default=True).to_parquet(self, path, **kwargs)
 


### PR DESCRIPTION
Following up on some comments in #5532 

Skipping the doctests that generate output since they don't clean up after themselves, but I've verified that they run.