### PR TITLE
fix: support negative string indices

### DIFF
--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -260,11 +260,16 @@ def _substring(op, **kw):
     # Clickhouse is 1-indexed
     arg = translate_val(op.arg, **kw)
     start = translate_val(op.start, **kw)
-    if (length := op.length) is None:
-        return f"substring({arg}, {start} + 1)"
+    arg_length = f"length({arg})"
+    if op.length is not None:
+        length = translate_val(op.length, **kw)
+        suffix = f", {length}"
+    else:
+        suffix = ""
 
-    length = translate_val(length, **kw)
-    return f"substring({arg}, {start} + 1, {length})"
+    if_pos = f"substring({arg}, {start} + 1{suffix})"
+    if_neg = f"substring({arg}, {arg_length} + {start} + 1{suffix})"
+    return f"if({start} >= 0, {if_pos}, {if_neg})"
 
 
 @translate_val.register(ops.StringFind)

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_string_column_substring/out1.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_string_column_substring/out1.sql
@@ -1,1 +1,1 @@
-substring(string_col, 2 + 1)
+if(2 >= 0, substring(string_col, 2 + 1), substring(string_col, length(string_col) + 2 + 1))

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_string_column_substring/out2.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_string_column_substring/out2.sql
@@ -1,1 +1,1 @@
-substring(string_col, 0 + 1, 3)
+if(0 >= 0, substring(string_col, 0 + 1, 3), substring(string_col, length(string_col) + 0 + 1, 3))

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -941,6 +941,9 @@ def compile_substring(t, op, raw: bool = False, **kwargs):
             "Specifiying `start` or `length` with column expressions is not supported."
         )
 
+    if start < 0:
+        raise NotImplementedError("`start < 0` is not supported.")
+
     return src_column.substr(start, length)
 
 

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -526,6 +526,16 @@ def test_string_col_is_unicode(alltypes, df):
             id='slice',
         ),
         param(
+            lambda t: t.date_string_col[-2],
+            lambda t: t.date_string_col.str[-2],
+            id='negative-index',
+            marks=[
+                pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError),
+                pytest.mark.broken(["datafusion", "impala"], raises=AssertionError),
+                pytest.mark.notimpl(["pyspark"], raises=NotImplementedError),
+            ],
+        ),
+        param(
             lambda t: t.date_string_col[t.date_string_col.length() - 1 :],
             lambda t: t.date_string_col.str[-1:],
             id='expr_slice_begin',


### PR DESCRIPTION
This fixes `substr` to support negative string indices properly (e.g. `t.string_col[-2]`). Fixes #5037.

The current implementation includes a branch for handling the case where the index is a literal (meaning we can avoid using a case statement to branch at runtime), and a fallback for using a case statement to branch at runtime. I've tested that this logic is valid (and included a kinda weird test for it here). However, we currently have expr-level checks that basically mandate that string indexes are literal ints only (can't do `t.string_col[t.int_col]`), so this extra complication is unlikely to be hit by users as is. I haven't taken steps to relax these checks here, but I suppose that could also be done.