### PR TITLE
feat(api): upcast pandas DataFrames to memtables in `rlz.table` rule

### DIFF
--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -228,10 +228,12 @@ class DataFrameProxy(Immutable, util.ToFrame):
     def to_frame(self) -> pd.DataFrame:
         return self._df
 
-    def to_pyarrow(self) -> pa.Table:
+    def to_pyarrow(self, schema: sch.Schema) -> pa.Table:
         import pyarrow as pa
 
-        return pa.Table.from_pandas(self._df)
+        from ibis.backends.pyarrow.datatypes import ibis_to_pyarrow_schema
+
+        return pa.Table.from_pandas(self._df, schema=ibis_to_pyarrow_schema(schema))
 
 
 class PandasInMemoryTable(ops.InMemoryTable):

--- a/ibis/backends/pandas/tests/test_datatypes.py
+++ b/ibis/backends/pandas/tests/test_datatypes.py
@@ -208,7 +208,7 @@ def test_pandas_dtype(pandas_dtype, ibis_dtype):
         # mixed
         (pd.Series([b'1', '2', 3.0]), dt.binary),
         # empty
-        (pd.Series([], dtype='object'), dt.binary),
+        (pd.Series([], dtype='object'), dt.null),
         (pd.Series([], dtype="string"), dt.string),
     ],
 )

--- a/ibis/backends/pyarrow/datatypes.py
+++ b/ibis/backends/pyarrow/datatypes.py
@@ -26,6 +26,8 @@ _to_pyarrow_types = {
     dt.Boolean: pa.bool_(),
     dt.Timestamp: pa.timestamp('ns'),
     dt.Date: pa.date64(),
+    dt.JSON: pa.string(),
+    dt.Null: pa.null(),
 }
 
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -44,7 +44,7 @@ NULL_BACKEND_TYPES = {
 
 
 @pytest.mark.broken(["duckdb", "impala", "bigquery"], 'assert nan is None')
-@pytest.mark.notimpl(["datafusion"], raises=NotImplementedError)
+@pytest.mark.notimpl(["datafusion"])
 def test_null_literal(con, backend):
     expr = ibis.null()
     result = con.execute(expr)

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -195,7 +195,7 @@ def _infer_object_array_dtype(x):
             'timedelta': dt.interval,
             'time': dt.time,
             'period': dt.binary,
-            'empty': dt.binary,
+            'empty': dt.null,
             'unicode': dt.string,
         }[classifier]
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -466,7 +466,13 @@ def table(arg, schema=None, **kwargs):
     it must be of the specified type. The table may have extra columns not
     specified in the schema.
     """
+    import pandas as pd
+
+    import ibis
     import ibis.expr.operations as ops
+
+    if isinstance(arg, pd.DataFrame):
+        arg = ibis.memtable(arg).op()
 
     if not isinstance(arg, ops.TableNode):
         raise com.IbisTypeError(

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     import ibis.expr.operations as ops
+    import ibis.expr.schema as sch
 
     Graph = Mapping[ops.Node, Sequence[ops.Node]]
 
@@ -493,11 +494,11 @@ class ToFrame(abc.ABC):
 
     @abc.abstractmethod
     def to_frame(self) -> pd.DataFrame:  # pragma: no cover
-        ...
+        """Convert this input to a pandas DataFrame."""
 
     @abc.abstractmethod
-    def to_pyarrow(self) -> pa.Table:  # pragma: no cover
-        ...
+    def to_pyarrow(self, schema: sch.Schema) -> pa.Table:  # pragma: no cover
+        """Convert this input to a PyArrow Table."""
 
 
 def backend_entry_points() -> list[importlib.metadata.EntryPoint]:


### PR DESCRIPTION
This PR allows using a DataFrame wherever an operation accepts a table via `ibis.expr.rules.table`.