### PR TITLE
feat(api): make create_table uniform

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -769,16 +769,18 @@ class BaseBackend(abc.ABC, _FileIOHandler):
             f'Backend "{self.name}" does not implement "create_database"'
         )
 
+    @abc.abstractmethod
     def create_table(
         self,
         name: str,
         obj: pd.DataFrame | ir.Table | None = None,
+        *,
         schema: ibis.Schema | None = None,
         database: str | None = None,
+        temp: bool = False,
+        overwrite: bool = False,
     ) -> ir.Table:
         """Create a new table.
-
-        Not all backends implement this method.
 
         Parameters
         ----------
@@ -794,19 +796,22 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         database
             Name of the database where the table will be created, if not the
             default.
+        temp
+            Whether a table is temporary or not
+        overwrite
+            Whether to clobber existing data
 
         Returns
         -------
         Table
             The table that was created.
         """
-        raise NotImplementedError(
-            f'Backend "{self.name}" does not implement "create_table"'
-        )
 
+    @abc.abstractmethod
     def drop_table(
         self,
         name: str,
+        *,
         database: str | None = None,
         force: bool = False,
     ) -> None:
@@ -825,36 +830,38 @@ class BaseBackend(abc.ABC, _FileIOHandler):
             f'Backend "{self.name}" does not implement "drop_table"'
         )
 
+    @abc.abstractmethod
     def create_view(
         self,
         name: str,
-        expr: ir.Table,
+        obj: ir.Table,
+        *,
         database: str | None = None,
+        overwrite: bool = False,
     ) -> ir.Table:
-        """Create a view.
+        """Create a new view from an expression.
 
         Parameters
         ----------
         name
-            Name for the new view.
-        expr
-            An Ibis table expression that will be used to extract the query
-            of the view.
+            Name of the new view.
+        obj
+            An Ibis table expression that will be used to create the view.
         database
-            Name of the database where the view will be created, if not the
-            default.
+            Name of the database where the view will be created, if not
+            provided the database's default is used.
+        overwrite
+            Whether to clobber an existing view with the same name
 
         Returns
         -------
         Table
             The view that was created.
         """
-        raise NotImplementedError(
-            f'Backend "{self.name}" does not implement "create_view"'
-        )
 
+    @abc.abstractmethod
     def drop_view(
-        self, name: str, database: str | None = None, force: bool = False
+        self, name: str, *, database: str | None = None, force: bool = False
     ) -> None:
         """Drop a view.
 
@@ -867,9 +874,6 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         force
             If `False`, an exception is raised if the view does not exist.
         """
-        raise NotImplementedError(
-            f'Backend "{self.name}" does not implement "drop_view"'
-        )
 
     @classmethod
     def has_operation(cls, operation: type[ops.Value]) -> bool:

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -128,7 +128,7 @@ class Backend(BasePandasBackend):
         return obj
 
     def _load_into_cache(self, name, expr):
-        self.load_data(name, self.compile(expr).persist())
+        self.create_table(name, self.compile(expr).persist())
 
     def _clean_up_cached_table(self, op):
         del self.dictionary[op.name]

--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -52,7 +52,8 @@ def test_client_table_repr(table):
 
 
 def test_load_data(client, npartitions):
-    client.load_data('testing', make_dask_data_frame(npartitions))
+    with pytest.warns(FutureWarning):
+        client.load_data('testing', make_dask_data_frame(npartitions))
     assert 'testing' in client.list_tables()
     assert client.get_schema('testing')
 

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -284,3 +284,15 @@ class Backend(BaseBackend):
         return operation in op_classes or any(
             issubclass(operation, op_impl) for op_impl in op_classes
         )
+
+    def create_table(self, *_, **__) -> ir.Table:
+        raise NotImplementedError(self.name)
+
+    def create_view(self, *_, **__) -> ir.Table:
+        raise NotImplementedError(self.name)
+
+    def drop_table(self, *_, **__) -> ir.Table:
+        raise NotImplementedError(self.name)
+
+    def drop_view(self, *_, **__) -> ir.Table:
+        raise NotImplementedError(self.name)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -354,6 +354,7 @@ class ImpalaTable(ir.Table):
             path,
             partition=partition,
             partition_schema=partition_schema,
+            overwrite=overwrite,
         )
 
         return self._client.raw_sql(stmt.compile())

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -72,10 +72,6 @@ class Backend(BaseAlchemyBackend):
         database: str | None = None,
         temp: bool = False,
     ) -> sa.Table:
-        prefixes = []
-        if temp:
-            raise ValueError(
-                'MSSQL supports temporary table declaration through placing hash before the table name'
-            )
-        columns = self._columns_from_schema(name, schema)
-        return sa.Table(name, self.meta, *columns, prefixes=prefixes)
+        return super()._table_from_schema(
+            temp * "#" + name, schema=schema, database=database, temp=False
+        )

--- a/ibis/backends/pandas/tests/test_client.py
+++ b/ibis/backends/pandas/tests/test_client.py
@@ -45,7 +45,8 @@ def test_client_table_repr(table):
 
 
 def test_load_data(client, test_data):
-    client.load_data('testing', test_data)
+    with pytest.warns(FutureWarning):
+        client.load_data('testing', test_data)
     assert 'testing' in client.list_tables()
     assert client.get_schema('testing')
 

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -24,7 +24,6 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis.tests.util import assert_equal
-from ibis.util import guid
 
 pytest.importorskip("psycopg2")
 sa = pytest.importorskip("sqlalchemy")
@@ -80,28 +79,6 @@ def test_compile_toplevel(snapshot):
 def test_list_databases(con):
     assert POSTGRES_TEST_DB is not None
     assert POSTGRES_TEST_DB in con.list_databases()
-
-
-def test_metadata_is_per_table():
-    con = ibis.postgres.connect(
-        host=IBIS_POSTGRES_HOST,
-        database=POSTGRES_TEST_DB,
-        user=IBIS_POSTGRES_USER,
-        password=IBIS_POSTGRES_PASS,
-        port=IBIS_POSTGRES_PORT,
-    )
-
-    name = f"tmp_{guid()}"
-    with con.begin() as c:
-        c.exec_driver_sql(f"CREATE TABLE {name} (x BIGINT)")
-
-    try:
-        assert name not in con.meta.tables
-        con.table(name)
-        assert name in con.meta.tables
-    finally:
-        with con.begin() as c:
-            c.exec_driver_sql(f"DROP TABLE {name}")
 
 
 def test_schema_type_conversion():

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -1088,7 +1088,7 @@ def test_anti_join(t, s):
 
 
 def test_create_table_from_expr(con, trunc, guid2):
-    con.create_table(guid2, expr=trunc)
+    con.create_table(guid2, obj=trunc)
     t = con.table(guid2)
     assert list(t['name'].execute()) == list('abc')
 

--- a/ibis/backends/pyspark/tests/test_ddl.py
+++ b/ibis/backends/pyspark/tests/test_ddl.py
@@ -16,7 +16,7 @@ def test_create_exists_view(client, alltypes, temp_view):
     assert tmp_name not in client.list_tables()
 
     t1 = alltypes.group_by('string_col').size()
-    t2 = client.create_view(tmp_name, t1, temporary=True)
+    t2 = client.create_view(tmp_name, t1)
 
     assert tmp_name in client.list_tables()
     # just check it works for now
@@ -169,7 +169,7 @@ def test_compute_stats(client, alltypes):
 def created_view(client, alltypes):
     name = util.guid()
     expr = alltypes.limit(10)
-    client.create_view(name, expr, temporary=True)
+    client.create_view(name, expr)
     return name
 
 

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -576,7 +576,7 @@ def mj1(con):
     con.create_table(
         "mj1",
         schema=ibis.schema(dict(id1="int32", val1="float64")),
-        force=True,
+        overwrite=True,
     )
     try:
         con.insert(
@@ -592,22 +592,16 @@ def mj1(con):
 @pytest.fixture
 def mj2(con):
     con.create_table(
-        "mj2",
-        schema=ibis.schema(dict(id2="int32", val2="float64")),
-        force=True,
+        "mj2", schema=ibis.schema(dict(id2="int32", val2="float64")), overwrite=True
     )
     try:
-        con.insert(
-            "mj2",
-            pd.DataFrame(dict(id2=[1, 2], val2=[15, 25])),
-            overwrite=True,
-        )
+        con.insert("mj2", pd.DataFrame(dict(id2=[1, 2], val2=[15, 25])), overwrite=True)
         yield con.table("mj2")
     finally:
         con.drop_table("mj2", force=True)
 
 
-def test_simple_join(con, mj1, mj2):
+def test_simple_join(mj1, mj2):
     joined = mj1.join(mj2, mj1.id1 == mj2.id2)
     result = joined.val2.execute()
     assert len(result) == 2

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -210,7 +210,7 @@ def tmptable(con):
 
     # some backends don't implement drop
     with contextlib.suppress(NotImplementedError):
-        con.drop_table(name)
+        con.drop_table(name, force=True)
 
 
 @pytest.mark.notimpl(["clickhouse"], reason=".create_table not yet implemented in ibis")

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -65,7 +65,7 @@ def alltypes(con):
     return con.table('alltypes')
 
 
-def test_sqla_schema_conversion(con):
+def test_sqla_schema_conversion():
     typespec = [
         # name, type, nullable
         ('smallint', sat.SmallInteger, False, dt.int16),
@@ -83,7 +83,7 @@ def test_sqla_schema_conversion(con):
         sqla_types.append(sa.Column(name, t, nullable=nullable))
         ibis_types.append((name, ibis_type(nullable=nullable)))
 
-    table = sa.Table('tname', con.meta, *sqla_types)
+    table = sa.Table('tname', sa.MetaData(), *sqla_types)
 
     schema = schema_from_table(table)
     expected = ibis.schema(ibis_types)

--- a/poetry.lock
+++ b/poetry.lock
@@ -5574,18 +5574,18 @@ druid = ["pydruid", "sqlalchemy"]
 duckdb = ["duckdb", "duckdb-engine", "packaging", "pyarrow", "sqlalchemy", "sqlalchemy-views"]
 geospatial = ["GeoAlchemy2", "geopandas", "shapely"]
 impala = ["fsspec", "impyla", "requests", "sqlalchemy"]
-mssql = ["sqlalchemy", "pymssql"]
-mysql = ["sqlalchemy", "pymysql"]
+mssql = ["sqlalchemy", "pymssql", "sqlalchemy-views"]
+mysql = ["sqlalchemy", "pymysql", "sqlalchemy-views"]
 pandas = ["regex"]
 polars = ["polars", "pyarrow"]
-postgres = ["psycopg2", "sqlalchemy"]
+postgres = ["psycopg2", "sqlalchemy", "sqlalchemy-views"]
 pyspark = ["pyarrow", "pyspark", "sqlalchemy"]
-snowflake = ["snowflake-connector-python", "snowflake-sqlalchemy"]
-sqlite = ["regex", "sqlalchemy"]
-trino = ["trino", "sqlalchemy"]
+snowflake = ["snowflake-connector-python", "snowflake-sqlalchemy", "sqlalchemy-views"]
+sqlite = ["regex", "sqlalchemy", "sqlalchemy-views"]
+trino = ["trino", "sqlalchemy", "sqlalchemy-views"]
 visualization = ["graphviz"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f113527d242423168c146d59aca1fdc1084b171cb11c3ee66bf8c5ba5c62cae8"
+content-hash = "6eaf9b594415cc03edd48afa3c88edfa7b3be36213320c801d87c88233bc19f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,15 +187,19 @@ duckdb = [
 ]
 geospatial = ["geoalchemy2", "geopandas", "shapely"]
 impala = ["fsspec", "impyla", "requests", "sqlalchemy"]
-mssql = ["sqlalchemy", "pymssql"]
-mysql = ["sqlalchemy", "pymysql"]
+mssql = ["sqlalchemy", "pymssql", "sqlalchemy-views"]
+mysql = ["sqlalchemy", "pymysql", "sqlalchemy-views"]
 pandas = ["regex"]
 polars = ["polars", "pyarrow"]
-postgres = ["psycopg2", "sqlalchemy"]
-pyspark = ["pyarrow", "pyspark", "sqlalchemy"] # for make_url
-snowflake = ["snowflake-connector-python", "snowflake-sqlalchemy"]
-sqlite = ["regex", "sqlalchemy"]
-trino = ["trino", "sqlalchemy"]
+postgres = ["psycopg2", "sqlalchemy", "sqlalchemy-views"]
+pyspark = ["pyarrow", "pyspark", "sqlalchemy"]
+snowflake = [
+  "snowflake-connector-python",
+  "snowflake-sqlalchemy",
+  "sqlalchemy-views"
+]
+sqlite = ["regex", "sqlalchemy", "sqlalchemy-views"]
+trino = ["trino", "sqlalchemy", "sqlalchemy-views"]
 # non-backend extras
 visualization = ["graphviz"]
 decompiler = ["black"]


### PR DESCRIPTION
This PR address recent issues created around DDL.

Notes

- I didn't deprecate `ImpalaTable.load_data`. I'm not entirely what should be done with it.
- For clickhouse's `create_table`, since clickhouse itself doesn't have a default
  table engine, I preserved that: you have to pass `engine="Something"` to its
  create_table. It breaks the uniformity, but I'm not sure how else to handle
  it.

TODO

- Implement `create_view` for pandas/dask/polars
- Implement `create_view`/`drop_table`/`truncate_table` for clickhouse
- Review/implement `truncate_table` (I don't think these makes sense for the in-memory backends, so those'll raise an exception)


Closes #5394
Closes #5392
Closes #5390
Closes #4316
Closes #2339
