### PR TITLE
chore(dev-deps): set the default nix environment python version to 3.10

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -130,7 +130,7 @@
         ibis310 = mkDevShell pkgs.ibisDevEnv310;
         ibis311 = mkDevShell pkgs.ibisDevEnv311;
 
-        default = ibis311;
+        default = ibis310;
 
         preCommit = pkgs.mkShell {
           name = "preCommit";


### PR DESCRIPTION
Primarily for the ability to test PySpark integration, which is tied to Python 3.10 until PySpark 3.4.
