### PR TITLE
fix(snowflake): ensure that quoting matches snowflake behavior, not sqlalchemy

### DIFF
--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -16,6 +16,7 @@ from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 from ibis.util import consume
 
 if TYPE_CHECKING:
+    import ibis.expr.types as ir
     from ibis.backends.base import BaseBackend
 
 
@@ -31,6 +32,8 @@ def copy_into(con, data_dir: Path, table: str) -> None:
 
 
 class TestConf(BackendTest, RoundAwayFromZero):
+    supports_map = True
+
     def __init__(self, data_directory: Path) -> None:
         self.connection = self.connect(data_directory)
 
@@ -81,6 +84,46 @@ class TestConf(BackendTest, RoundAwayFromZero):
                     )
                 ):
                     result.result()
+
+    @property
+    def functional_alltypes(self) -> ir.Table:
+        return self.connection.table('FUNCTIONAL_ALLTYPES')
+
+    @property
+    def batting(self) -> ir.Table:
+        return self.connection.table('BATTING')
+
+    @property
+    def awards_players(self) -> ir.Table:
+        return self.connection.table('AWARDS_PLAYERS')
+
+    @property
+    def diamonds(self) -> ir.Table:
+        return self.connection.table('DIAMONDS')
+
+    @property
+    def array_types(self) -> ir.Table:
+        return self.connection.table('ARRAY_TYPES')
+
+    @property
+    def geo(self) -> ir.Table | None:
+        return None
+
+    @property
+    def struct(self) -> ir.Table | None:
+        return self.connection.table("STRUCT")
+
+    @property
+    def json_t(self) -> ir.Table | None:
+        return self.connection.table("JSON_T")
+
+    @property
+    def map(self) -> ir.Table | None:
+        return self.connection.table("MAP")
+
+    @property
+    def win(self) -> ir.Table | None:
+        return self.connection.table("WIN")
 
     @staticmethod
     @functools.lru_cache(maxsize=None)

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -1,33 +1,25 @@
 from __future__ import annotations
 
-import pytest
-
 import ibis
 from ibis.util import guid
 
 
-@pytest.mark.parametrize(
-    ("db", "schema", "cleanup"),
-    [
-        (f"tmp_db_{guid()}", f"tmp_schema_{guid()}", True),
-        ("ibis_testing", f"tmp_schema_{guid()}", False),
-    ],
-    ids=["temp", "perm"],
-)
-def test_cross_db_access(con, db, schema, cleanup):
+def test_cross_db_access(con):
+    db, schema = f"tmp_db_{guid()}", f"tmp_schema_{guid()}"
     schema = f"{db}.{schema}"
     table = f"tmp_table_{guid()}"
     con.raw_sql(f"CREATE DATABASE IF NOT EXISTS {db}")
     try:
         con.raw_sql(f"CREATE SCHEMA IF NOT EXISTS {schema}")
         try:
-            con.raw_sql(f'CREATE TEMP TABLE {schema}.{table} ("x" INT)')
-            t = con.table(table, schema=f"{schema}")
-            assert t.schema() == ibis.schema(dict(x="int"))
-            assert t.execute().empty
+            con.raw_sql(f'CREATE TEMP TABLE {schema}."{table}" ("x" INT)')
+            try:
+                t = con.table(table, schema=schema)
+                assert t.schema() == ibis.schema(dict(x="int"))
+                assert t.execute().empty
+            finally:
+                con.raw_sql(f'DROP TABLE {schema}."{table}"')
         finally:
-            if cleanup:
-                con.raw_sql(f"DROP SCHEMA {schema}")
+            con.raw_sql(f"DROP SCHEMA {schema}")
     finally:
-        if cleanup:
-            con.raw_sql(f"DROP DATABASE {db}")
+        con.raw_sql(f"DROP DATABASE {db}")

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -77,6 +77,7 @@ class BackendTest(abc.ABC):
     native_bool = True
     supports_structs = True
     supports_json = True
+    supports_map = False  # basically nothing does except trino and snowflake
     reduction_tolerance = 1e-7
 
     @staticmethod
@@ -170,6 +171,10 @@ class BackendTest(abc.ABC):
         return self.connection.table('awards_players')
 
     @property
+    def diamonds(self) -> ir.Table:
+        return self.connection.table('diamonds')
+
+    @property
     def geo(self) -> ir.Table | None:
         if 'geo' in self.connection.list_tables():
             return self.connection.table('geo')
@@ -183,6 +188,13 @@ class BackendTest(abc.ABC):
             pytest.xfail(f"{self.name()} backend does not support struct types")
 
     @property
+    def array_types(self) -> ir.Table | None:
+        if self.supports_arrays:
+            return self.connection.table("array_types")
+        else:
+            pytest.xfail(f"{self.name()} backend does not support array types")
+
+    @property
     def json_t(self) -> ir.Table | None:
         from ibis import _
 
@@ -190,6 +202,17 @@ class BackendTest(abc.ABC):
             return self.connection.table("json_t").mutate(js=_.js.cast("json"))
         else:
             pytest.xfail(f"{self.name()} backend does not support json types")
+
+    @property
+    def map(self) -> ir.Table | None:
+        if self.supports_map:
+            return self.connection.table("map")
+        else:
+            pytest.xfail(f"{self.name()} backend does not support map types")
+
+    @property
+    def win(self) -> ir.Table | None:
+        return self.connection.table("win")
 
     @property
     def api(self):

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -38,7 +38,8 @@ def test_list_tables(con):
     tables = con.list_tables()
     assert isinstance(tables, list)
     # only table that is guaranteed to be in all backends
-    assert 'functional_alltypes' in tables
+    key = 'functional_alltypes'
+    assert key in tables or key.upper() in tables
     assert all(isinstance(table, str) for table in tables)
 
 
@@ -58,7 +59,14 @@ def test_tables_accessor_mapping(con):
 
 
 def test_tables_accessor_getattr(con):
-    assert isinstance(con.tables.functional_alltypes, ir.Table)
+    assert isinstance(
+        getattr(
+            con.tables,
+            "functional_alltypes",
+            getattr(con.tables, "FUNCTIONAL_ALLTYPES", None),
+        ),
+        ir.Table,
+    )
 
     with pytest.raises(AttributeError, match="doesnt_exist"):
         con.tables.doesnt_exist
@@ -71,16 +79,16 @@ def test_tables_accessor_getattr(con):
 
 def test_tables_accessor_tab_completion(con):
     attrs = dir(con.tables)
-    assert 'functional_alltypes' in attrs
+    assert 'functional_alltypes' in attrs or "FUNCTIONAL_ALLTYPES" in attrs
     assert 'keys' in attrs  # type methods also present
 
     keys = con.tables._ipython_key_completions_()
-    assert 'functional_alltypes' in keys
+    assert 'functional_alltypes' in keys or "FUNCTIONAL_ALLTYPES" in keys
 
 
 def test_tables_accessor_repr(con):
     result = repr(con.tables)
-    assert '- functional_alltypes' in result
+    assert '- functional_alltypes' in result or '- FUNCTIONAL_ALLTYPES' in result
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -173,8 +173,8 @@ unnest = toolz.compose(
     reason="snowflake has an extremely specialized way of implementing arrays",
 )
 @pytest.mark.never(["bigquery"], reason="doesn't support arrays of arrays")
-def test_array_discovery_postgres(con):
-    t = con.table("array_types")
+def test_array_discovery_postgres(backend):
+    t = backend.array_types
     expected = ibis.schema(
         dict(
             x=dt.Array(dt.int64),
@@ -198,8 +198,8 @@ def test_array_discovery_postgres(con):
     reason="backend supports nullable nested types",
 )
 @pytest.mark.never(["bigquery"], reason="doesn't support arrays of arrays")
-def test_array_discovery_clickhouse(con):
-    t = con.table("array_types")
+def test_array_discovery_clickhouse(backend):
+    t = backend.array_types
     expected = ibis.schema(
         dict(
             x=dt.Array(dt.int64, nullable=False),
@@ -229,8 +229,8 @@ def test_array_discovery_clickhouse(con):
     ["snowflake"],
     reason="snowflake has an extremely specialized way of implementing arrays",
 )
-def test_array_discovery_desired(con):
-    t = con.table("array_types")
+def test_array_discovery_desired(backend):
+    t = backend.array_types
     expected = ibis.schema(
         dict(
             x=dt.Array(dt.int64),
@@ -261,8 +261,8 @@ def test_array_discovery_desired(con):
     ],
     reason="backend does not implement arrays like snowflake",
 )
-def test_array_discovery_snowflake(con):
-    t = con.table("array_types")
+def test_array_discovery_snowflake(backend):
+    t = backend.array_types
     expected = ibis.schema(
         dict(
             x=dt.Array(dt.json),
@@ -277,8 +277,8 @@ def test_array_discovery_snowflake(con):
 
 
 @unnest
-def test_unnest_simple(con):
-    array_types = con.table("array_types")
+def test_unnest_simple(backend):
+    array_types = backend.array_types
     expected = (
         array_types.execute()
         .x.explode()
@@ -293,8 +293,8 @@ def test_unnest_simple(con):
 
 @unnest
 @pytest.mark.notimpl("polars")
-def test_unnest_complex(con):
-    array_types = con.table("array_types")
+def test_unnest_complex(backend):
+    array_types = backend.array_types
     df = array_types.execute()
     expr = (
         array_types.select(["grouper", "x"])
@@ -321,8 +321,8 @@ def test_unnest_complex(con):
 @pytest.mark.never("pyspark", reason="pyspark throws away nulls in collect_list")
 @pytest.mark.never("clickhouse", reason="clickhouse throws away nulls in groupArray")
 @pytest.mark.notimpl("polars")
-def test_unnest_idempotent(con):
-    array_types = con.table("array_types")
+def test_unnest_idempotent(backend):
+    array_types = backend.array_types
     df = array_types.execute()
     expr = (
         array_types.select(
@@ -341,8 +341,8 @@ def test_unnest_idempotent(con):
 
 @unnest
 @pytest.mark.notimpl("polars")
-def test_unnest_no_nulls(con):
-    array_types = con.table("array_types")
+def test_unnest_no_nulls(backend):
+    array_types = backend.array_types
     df = array_types.execute()
     expr = (
         array_types.select(
@@ -367,8 +367,8 @@ def test_unnest_no_nulls(con):
 
 @unnest
 @pytest.mark.notimpl("polars")
-def test_unnest_default_name(con):
-    array_types = con.table("array_types")
+def test_unnest_default_name(backend):
+    array_types = backend.array_types
     df = array_types.execute()
     expr = (
         array_types.x.cast("!array<int64>") + ibis.array([1], type="!array<int64>")
@@ -396,8 +396,8 @@ def test_unnest_default_name(con):
     ],
 )
 @pytest.mark.notimpl(["dask", "datafusion", "polars"])
-def test_array_slice(con, start, stop):
-    array_types = con.tables.array_types
+def test_array_slice(backend, start, stop):
+    array_types = backend.array_types
     expr = array_types.select(sliced=array_types.y[start:stop])
     result = expr.execute()
     expected = pd.DataFrame(

--- a/ibis/backends/tests/test_column.py
+++ b/ibis/backends/tests/test_column.py
@@ -22,8 +22,8 @@ import ibis.common.exceptions as com
     ],
     raises=com.OperationNotDefinedError,
 )
-def test_rowid(con):
-    t = con.table('functional_alltypes')
+def test_rowid(backend):
+    t = backend.diamonds
     result = t.rowid().execute()
     # Only guarantee is that the values are unique integers
     assert result.is_unique

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -956,8 +956,8 @@ def test_many_subqueries(con, snapshot):
     reason="backend doesn't support arrays and we don't implement pivot_longer with unions yet",
     raises=com.OperationNotDefinedError,
 )
-def test_pivot_longer(con):
-    diamonds = con.tables.diamonds
+def test_pivot_longer(backend):
+    diamonds = backend.diamonds
     res = diamonds.pivot_longer(s.c("x", "y", "z"), names_to="pos", values_to="xyz")
     assert res.schema().names == (
         "carat",

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -23,8 +23,8 @@ pytestmark = [
 
 
 @pytest.mark.notimpl(["pandas", "dask"])
-def test_map_table(con):
-    table = con.table("map")
+def test_map_table(backend):
+    table = backend.map
     assert table.kv.type().is_map()
     assert not table.limit(1).execute().empty
 

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -1281,7 +1281,9 @@ def test_sa_default_numeric_precision_and_scale(
 
     # Create a table with the numeric types.
     table_name = 'test_sa_default_param_decimal'
-    table = sa.Table(table_name, sa.MetaData(), *sqla_types)
+
+    is_snowflake = con.name == "snowflake"
+    table = sa.Table(table_name, sa.MetaData(), *sqla_types, quote=is_snowflake)
     with con.begin() as bind:
         table.create(bind=bind, checkfirst=True)
 
@@ -1292,7 +1294,7 @@ def test_sa_default_numeric_precision_and_scale(
 
         assert_equal(schema, expected)
     finally:
-        con.drop_table(table_name, force=True)
+        con.drop_table(f'{table_name}' if is_snowflake else table_name, force=True)
 
 
 @pytest.mark.notimpl(

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -23,8 +23,8 @@ pytestmark = pytest.mark.notimpl(["druid"])
     reason="Not clear how to extract SQL from the backend",
     raises=(exc.OperationNotDefinedError, NotImplementedError, ValueError),
 )
-def test_table(con):
-    expr = con.tables.functional_alltypes.select(c=_.int_col + 1)
+def test_table(backend):
+    expr = backend.functional_alltypes.select(c=_.int_col + 1)
     buf = io.StringIO()
     ibis.show_sql(expr, file=buf)
     assert buf.getvalue()

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -821,8 +821,8 @@ def test_mutate_window_filter(backend, alltypes, df):
 
 @pytest.mark.notimpl(["dask", "datafusion", "polars"])
 @pytest.mark.broken(["impala"], reason="the database returns incorrect results")
-def test_first_last(con):
-    t = con.table("win")
+def test_first_last(backend):
+    t = backend.win
     w = ibis.window(group_by=t.g, order_by=[t.x, t.y], preceding=1, following=0)
     expr = t.mutate(
         x_first=t.x.first().over(w),

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -38,6 +38,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
 
     returned_timestamp_unit = 's'
     supports_structs = True
+    supports_map = True
 
     @staticmethod
     def _load_data(data_dir: Path, script_dir: Path, **_: Any) -> None:


### PR DESCRIPTION
This PR addresses broken snowflake-sqlalchemy behavior that appears to have been stuck in open source limbo
for over three years. Numerous issues related to the snowflake-sqlalchemy dialect's broken quoting behavior exist:

- https://github.com/snowflakedb/snowflake-sqlalchemy/issues/157
- https://github.com/snowflakedb/snowflake-sqlalchemy/issues/276
- https://github.com/snowflakedb/snowflake-sqlalchemy/issues/388

with no obvious traction or clear effort towards addressing them.

So, in this PR I just disable snowflake-sqlalchemy's broken case-guessing and
let snowflake do what it will, and return what it will.
