### PR TITLE
feat(snowflake): implement ops.GroupConcat

### DIFF
--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -829,7 +829,7 @@ def test_approx_median(alltypes):
         ),
     ],
 )
-@mark.notimpl(["datafusion", "snowflake", "polars", "mssql", "druid"])
+@mark.notimpl(["datafusion", "polars", "mssql", "druid"])
 def test_group_concat(
     backend,
     alltypes,


### PR DESCRIPTION
```
$ pytest -m 'snowflake' ibis/backends/tests/ --numprocesses 6 --dist=loadgroup
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.10.7, pytest-7.2.1, pluggy-1.0.0
Using --randomly-seed=2765027542
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /ibis/ibis, configfile: pyproject.toml
plugins: snapshot-0.9.0, xdist-3.1.0, mock-3.10.0, clarity-1.0.1, randomly-3.12.0, profiling-1.7.0, cov-4.0.0, repeat-0.9.1, benchmark-4.0.0, hypothesis-6.65.2
gw0 [871] / gw1 [871] / gw2 [871] / gw3 [871] / gw4 [871] / gw5 [871]
.........x.x..x...x...xx.......x....x...x....s....s.......................x..s..x................x.xxxx.x.x.....x......xxxx.x.........x.....xxx....xxx...x.........x.x......x........x.x..x...x... [ 22%]
..x..xx.x..x..x...xx.xxx....xx.....x.xx......xx..xxx.x.xx......x.x.......x.......xx.xx...x......x......xxx......x.......x.............xx..............x.......x...............x................... [ 44%]
.s...................x.....xx..xxxxxxxx..xxxxx..x..xxx.x.................................................x..................................................x...........x..........x.......x...... [ 66%]
x........x...x.x..x....x.....x..x......x................x.....x............xx....x..x..x..x.....................x.........................x.x.x..........................x.........x...........x.x [ 88%]
.x.......................................xx................x................ss.ss..xxxxssx...xx.                                                                                                   [100%]
======================================================================== 718 passed, 10 skipped, 144 xfailed in 114.50s (0:01:54) ========================================================================

```