### PR TITLE
feat(snowflake): support binary variance reduction with filters

### DIFF
--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -722,12 +722,6 @@ def test_quantile(
             lambda t: t.yearID.isin([2009, 2015]),
             lambda t: t.yearID.isin([2009, 2015]),
             id='cond',
-            marks=[
-                pytest.mark.broken(
-                    ["snowflake"],
-                    reason=("snowflake doesn't allow quoted columns in group_by"),
-                ),
-            ],
         ),
     ],
 )


### PR DESCRIPTION
```
$ pytest -m 'snowflake' ibis/backends/tests/test_aggregation.py --numprocesses 6 --dist=loadgroup
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.10.7, pytest-7.2.1, pluggy-1.0.0
Using --randomly-seed=3146864476
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /ibis/ibis, configfile: pyproject.toml
plugins: snapshot-0.9.0, xdist-3.1.0, mock-3.10.0, clarity-1.0.1, randomly-3.12.0, profiling-1.7.0, cov-4.0.0, repeat-0.9.1, benchmark-4.0.0, hypothesis-6.65.2
gw0 [112] / gw1 [112] / gw2 [112] / gw3 [112] / gw4 [112] / gw5 [112]
..xx..xxx.........xx...........x.......x.x.x..x...x.x.......xx............xxx..x.........x......................                                                                                   [100%]
=============================================================================== 91 passed, 21 xfailed in 66.71s (0:01:06) ================================================================================
```