### PR TITLE
Add optional 'connect_args' to Snowflake connection method

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import json
 import warnings
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 import sqlalchemy as sa
 import toolz
@@ -150,7 +150,7 @@ class Backend(BaseAlchemyBackend):
         password: str,
         account: str,
         database: str,
-        connect_args: dict[str, Any] = None,
+        connect_args: Mapping[str, Any] | None = None,
         **kwargs: Any,
     ):
         dbparams = dict(zip(("database", "schema"), database.split("/", 1)))


### PR DESCRIPTION
This allows for example the specifying of a private key.

See example on https://github.com/snowflakedb/snowflake-sqlalchemy.