### PR TITLE
ci: include only a single macos nix job

### DIFF
--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -30,11 +30,13 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
         python-version:
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+        include:
+          - os: macos-latest
+            python-version: "3.10"
     steps:
       - run: echo "No build required"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -31,12 +31,14 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
         python-version:
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+        include:
+          - os: macos-latest
+            python-version: "3.10"
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR cuts our nix CI jobs for macos down to one. These jobs are good for catching issues on osx, but we only need one of those to do that right now. The other jobs would be useful for caching packages, but I do not think anyone is taking advantage of that at the moment.