### PR TITLE
fix(snowflake): ensure that null comparisons are correct

### DIFF
--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -195,7 +195,7 @@ def _group_concat(t, op):
     arg_sa = sa.func.iff(where_sa, t.translate(op.arg), None)
 
     return sa.func.iff(
-        sa.func.count_if(arg_sa is not None) != 0,
+        sa.func.count_if(arg_sa != sa.null()) != 0,
         sa.func.listagg(arg_sa, t.translate(op.sep)),
         None,
     )


### PR DESCRIPTION
This PR fixes an issue in group concat for snowflake where the comparison to null was done in Python, and not in SQLAlchemy.