### PR TITLE
docs: use teal for primary & accent colors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,8 @@ theme:
     # light mode toggle
     - media: "(prefers-color-scheme: light)"
       scheme: default
+      primary: teal
+      accent: teal
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
@@ -38,7 +40,7 @@ theme:
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       primary: teal
-      accent: lime
+      accent: teal
       toggle:
         icon: material/brightness-4
         name: Switch to light mode


### PR DESCRIPTION
This makes the header the same color for both light and dark themes. It also uses `teal` for the accent color as well. mkdocs-material adjusts this to be a slightly lighter teal, which I think looks better than the previous lime green on both dark & light backgrounds.