### PR TITLE
fix(bigquery): regenerate negative string index sql snapshots

### DIFF
--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_substring/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_substring/out.sql
@@ -1,2 +1,2 @@
-SELECT substr(t0.`value`, 3 + 1, 1) AS `tmp`
+SELECT IF(3 >= 0, SUBSTR(t0.`value`, 3 + 1, 1), SUBSTR(t0.`value`, LENGTH(t0.`value`) + 3 + 1, 1)) AS `tmp`
 FROM t t0


### PR DESCRIPTION
Fix the generated SQL for bigquery negative string indexing