### PR TITLE
fix(trino,duckdb,postgres): make cumulative `notany`/`notall` aggregations work

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -369,8 +369,8 @@ def _window_function(t, window):
         end = _translate_window_boundary(window.frame.end)
         additional_params = {how: (start, end)}
 
-    result = reduction.over(
-        partition_by=partition_by, order_by=order_by, **additional_params
+    result = sa.over(
+        reduction, partition_by=partition_by, order_by=order_by, **additional_params
     )
 
     if isinstance(window.func, (ops.RowNumber, ops.DenseRank, ops.MinRank, ops.NTile)):

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -156,14 +156,11 @@ def calc_zscore(s):
             id='cumnotany',
             marks=pytest.mark.notyet(
                 (
-                    "duckdb",
                     'impala',
-                    'postgres',
                     'mssql',
                     'mysql',
                     'sqlite',
                     'snowflake',
-                    'trino',
                 ),
                 reason="notany() over window not supported",
             ),
@@ -190,14 +187,11 @@ def calc_zscore(s):
             id='cumnotall',
             marks=pytest.mark.notyet(
                 (
-                    "duckdb",
                     'impala',
-                    'postgres',
                     'mssql',
                     'mysql',
                     'sqlite',
                     'snowflake',
-                    'trino',
                 ),
                 reason="notall() over window not supported",
             ),


### PR DESCRIPTION
This PR is a small fix to enable a few backend implementations of cumulative `notany`/`notall`. The SQL generated is accepted by the backend but we were hitting an inconsistency in SQLAlchemy that prevented the SQL from ever getting to the backend.