### PR TITLE
feat(table): implement `pivot_wider` API

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -637,6 +637,7 @@ _reductions = {
     ops.StandardDev: 'std',
     ops.Sum: 'sum',
     ops.Variance: 'var',
+    ops.CountDistinct: 'n_unique',
 }
 
 for reduction in _reductions.keys():

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -579,6 +579,11 @@ def compile_count(t, op, **kwargs):
     return compile_aggregator(t, op, fn=F.count, **kwargs)
 
 
+@compiles(ops.CountDistinct)
+def compile_count_distinct(t, op, **kwargs):
+    return compile_aggregator(t, op, fn=F.count_distinct, **kwargs)
+
+
 @compiles(ops.CountStar)
 def compile_count_star(t, op, aggcontext=None, **kwargs):
     src_table = t.translate(op.arg, **kwargs)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -282,7 +282,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.bool_col[where].dropna().nunique(),
             id='nunique',
             marks=pytest.mark.notimpl(
-                ["polars", "pyspark", "datafusion"], raises=com.OperationNotDefinedError
+                ["pyspark", "datafusion"], raises=com.OperationNotDefinedError
             ),
         ),
         param(

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -282,7 +282,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.bool_col[where].dropna().nunique(),
             id='nunique',
             marks=pytest.mark.notimpl(
-                ["pyspark", "datafusion"], raises=com.OperationNotDefinedError
+                ["datafusion"], raises=com.OperationNotDefinedError
             ),
         ),
         param(

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1003,6 +1003,23 @@ def test_pivot_longer(backend):
     assert not df.empty
 
 
+@pytest.mark.notyet(["datafusion"], raises=com.OperationNotDefinedError)
+def test_pivot_wider(backend):
+    diamonds = backend.diamonds
+    expr = (
+        diamonds.group_by(["cut", "color"])
+        .agg(carat=_.carat.mean())
+        .pivot_wider(
+            names_from="cut", values_from="carat", names_sort=True, values_agg="mean"
+        )
+    )
+    df = expr.execute()
+    assert set(df.columns) == {"color"} | set(
+        diamonds[["cut"]].distinct().cut.execute()
+    )
+    assert len(df) == diamonds.color.nunique().execute()
+
+
 @pytest.mark.parametrize(
     "on",
     [

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -846,3 +846,13 @@ def find_toplevel_unnest_children(nodes: Iterable[ops.Node]) -> Iterator[ops.Tab
         )
 
     return g.traverse(finder, nodes, filter=ops.Node)
+
+
+def find_toplevel_aggs(nodes: Iterable[ops.Node]) -> Iterator[ops.Table]:
+    def finder(node):
+        return (
+            isinstance(node, ops.Value),
+            node if isinstance(node, ops.Reduction) else None,
+        )
+
+    return g.traverse(finder, nodes, filter=ops.Node)

--- a/ibis/expr/selectors.py
+++ b/ibis/expr/selectors.py
@@ -94,7 +94,7 @@ class Predicate(Selector):
         return [col for column in table.columns if self.predicate(col := table[column])]
 
     def __and__(self, other: Selector) -> Predicate:
-        """Compute the conjunction of two `Selectors`.
+        """Compute the conjunction of two `Selector`s.
 
         Parameters
         ----------
@@ -104,7 +104,7 @@ class Predicate(Selector):
         return self.__class__(lambda col: self.predicate(col) and other.predicate(col))
 
     def __or__(self, other: Selector) -> Predicate:
-        """Compute the disjunction of two `Selectors`.
+        """Compute the disjunction of two `Selector`s.
 
         Parameters
         ----------
@@ -114,7 +114,7 @@ class Predicate(Selector):
         return self.__class__(lambda col: self.predicate(col) or other.predicate(col))
 
     def __invert__(self) -> Predicate:
-        """Compute the logical negation of two `Selectors`."""
+        """Compute the logical negation of two `Selector`s."""
         return self.__class__(lambda col: not self.predicate(col))
 
 
@@ -457,3 +457,8 @@ def last() -> Predicate:
 def all() -> Predicate:
     """Return every column from a table."""
     return r[:]
+
+
+def _to_selector(obj: str | Selector) -> Selector:
+    """Convert an object to a `Selector`."""
+    return c(obj) if isinstance(obj, str) else obj

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1811,6 +1811,18 @@ def test_pivot_longer_no_match():
         )
 
 
+def test_pivot_wider():
+    fish = ibis.table({"fish": "int", "station": "string", "seen": "int"}, name="fish")
+    res = fish.pivot_wider(
+        names=["Release", "Lisbon"], names_from="station", values_from="seen"
+    )
+    assert res.schema().names == ("fish", "Release", "Lisbon")
+    with pytest.raises(
+        com.IbisInputError, match="No matching names columns in `names_from`"
+    ):
+        fish.pivot_wider(names=["Release", "Lisbon"], values_from="seen")
+
+
 def test_invalid_deferred():
     t = ibis.table(dict(value="int", lagged_value="int"), name="t")
 


### PR DESCRIPTION
This PR implements `pivot_wider`, sometimes referred to as just "pivot" in other systems such as SQL.

The fundamental operation here is turning column values into column names.

This cannot be done without computation, to retrieve the new column names by
computing the distinct values of the to-pivot columns.

To that end, to get this information ibis *does* incur the overhead of computing these values.

While this behavior does deviate from other APIs in that it is not fully lazy,
I believe that the ability to express this computation concisely outweighs the
API deviance. There's _some_ precedent from `.cache()` as well which computes immediately.

However, if a user decides that they cannot live with this overhead then
another argument, `names` exists to allow someone to specify the specific
values that they would like to use as new columns and that will be used in
pivoting.

Another thing that is worth noting is that the default aggregate is `arbitrary`.

This may or may not be desirable, we can certainly change this to enforce passing an
aggregate function explicitly if folks think that's better.
