### PR TITLE
feat(api): expand `distinct` API to support dropping duplicates based on a column subset

### DIFF
--- a/ibis/backends/clickhouse/compiler/relations.py
+++ b/ibis/backends/clickhouse/compiler/relations.py
@@ -72,6 +72,7 @@ def _selection(op: ops.Selection, *, table, needs_alias=False, **kw):
 @translate_rel.register(ops.Aggregation)
 def _aggregation(op: ops.Aggregation, *, table, **kw):
     tr_val = partial(translate_val, **kw)
+    tr_val_no_alias = partial(translate_val, render_aliases=False, **kw)
 
     by = tuple(map(tr_val, op.by))
     metrics = tuple(map(tr_val, op.metrics))
@@ -82,13 +83,13 @@ def _aggregation(op: ops.Aggregation, *, table, **kw):
         sel = sel.group_by(*map(str, range(1, len(by) + 1)), dialect="clickhouse")
 
     if predicates := op.predicates:
-        sel = sel.where(*map(tr_val, predicates), dialect="clickhouse")
+        sel = sel.where(*map(tr_val_no_alias, predicates), dialect="clickhouse")
 
     if having := op.having:
-        sel = sel.having(*map(tr_val, having), dialect="clickhouse")
+        sel = sel.having(*map(tr_val_no_alias, having), dialect="clickhouse")
 
     if sort_keys := op.sort_keys:
-        sel = sel.order_by(*map(tr_val, sort_keys), dialect="clickhouse")
+        sel = sel.order_by(*map(tr_val_no_alias, sort_keys), dialect="clickhouse")
 
     return sel
 

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -49,9 +49,11 @@ def _column(op, *, aliases, **_):
 
 
 @translate_val.register(ops.Alias)
-def _alias(op, **kw):
-    val = translate_val(op.arg, **kw)
-    return sg.alias(val, op.name, dialect="clickhouse")
+def _alias(op, render_aliases: bool = True, **kw):
+    val = translate_val(op.arg, render_aliases=render_aliases, **kw)
+    if render_aliases:
+        return sg.alias(val, op.name, dialect="clickhouse")
+    return val
 
 
 _interval_cast_suffixes = {

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -388,6 +388,13 @@ def compile_literal(t, op, *, raw=False, **kwargs):
 def compile_aggregation(t, op, **kwargs):
     src_table = t.translate(op.table, **kwargs)
 
+    if op.having:
+        raise com.UnsupportedOperationError(
+            "The PySpark backend does not support `having` because the underlying "
+            "PySpark API does not support it. Use a filter on the aggregation "
+            "expression instead."
+        )
+
     if op.predicates:
         predicate = functools.reduce(ops.And, op.predicates)
         src_table = src_table.filter(t.translate(predicate, **kwargs))

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1125,6 +1125,11 @@ def test_distinct_on_keep(backend, on, keep):
     raises=com.OperationNotDefinedError,
     reason="backend doesn't implement ops.WindowFunction",
 )
+@pytest.mark.notimpl(
+    ["pyspark"],
+    raises=com.UnsupportedOperationError,
+    reason="backend doesn't support `having` filters",
+)
 def test_distinct_on_keep_is_none(backend, on):
     from ibis import _
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1053,6 +1053,10 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         if on is None:
             # dedup everything
+            if keep != "first":
+                raise com.IbisError(
+                    f"Only keep='first' (the default) makes sense when deduplicating all columns; got keep={keep!r}"
+                )
             return ops.Distinct(self).to_expr()
 
         if not isinstance(on, s.Selector):

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1812,9 +1812,20 @@ def test_pivot_longer_no_match():
 
 
 def test_invalid_deferred():
-    import ibis
-
     t = ibis.table(dict(value="int", lagged_value="int"), name="t")
 
     with pytest.raises(com.IbisTypeError, match="Deferred input is not allowed"):
         ibis.greatest(t.value, ibis._.lagged_value)
+
+
+@pytest.mark.parametrize("keep", ["last", None])
+def test_invalid_distinct(keep):
+    t = ibis.table(dict(a="int"), name="t")
+    with pytest.raises(com.IbisError, match="Only keep='first'"):
+        t.distinct(keep=keep)
+
+
+def test_invalid_keep_distinct():
+    t = ibis.table(dict(a="int", b="string"), name="t")
+    with pytest.raises(com.IbisError, match="Invalid value for `keep`:"):
+        t.distinct(on="a", keep="invalid")


### PR DESCRIPTION
This PR expands our existing `distinct` method to support row deduplication based on a subset of columns.

Closes #5509.
