### PR TITLE
fix(duckdb): disable the progress bar by default

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -135,8 +135,10 @@ class Backend(BaseAlchemyBackend):
         )
 
         @sa.event.listens_for(engine, "connect")
-        def set_time_zone(dbapi_connection, connection_record):
+        def configure_connection(dbapi_connection, connection_record):
             dbapi_connection.execute("SET TimeZone = 'UTC'")
+            # the progress bar causes kernel crashes in jupyterlab ¯\_(ツ)_/¯
+            dbapi_connection.execute("SET enable_progress_bar = false")
 
         super().do_connect(engine)
 


### PR DESCRIPTION
This PR fixes an issue where the progress bar enabled by default in duckdb causes jupyter lab kernels to crash. I am not sure why this happens, but disabling the progress bar by default serves as a viable temporary workaround.