### PR TITLE
docs: patch docs build to fix anchor links

### DIFF
--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -17,6 +17,21 @@ in
   });
 
   ipython-genutils = self.ipython_genutils;
+
+  mkdocs-jupyter =
+    let
+      linksPatch = self.pkgs.fetchpatch {
+        name = "fix-mkdocs-jupyter-heading-links.patch";
+        url = "https://github.com/danielfrg/mkdocs-jupyter/commit/f3b517580132fc743a34e5d9947731bc4f3c2143.patch";
+        sha256 = "sha256-qcNobdcIziX3pFfnm6vxnhTqow/2VGI/+jbBs9jXkUo=";
+      };
+    in
+    super.mkdocs-jupyter.overridePythonAttrs (_: {
+      postFixup = ''
+        cd $out/${self.python.sitePackages}
+        patch -p1 < "${linksPatch}"
+      '';
+    });
 } // super.lib.listToAttrs (
   map
     (name: {


### PR DESCRIPTION
This is a temporary workaround to get our docs anchor links working. We can remove it once a new version of mkdocs-jupyter is released.

Closes #5776.