### PR TITLE
feat(api): implement pyarrow memtables

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -306,6 +306,11 @@ class SelectBuilder:
             self.select_set = [node]
             self.table_set = node
 
+    def _collect_PyArrowInMemoryTable(self, node, toplevel=False):
+        if toplevel:
+            self.select_set = [node]
+            self.table_set = node
+
     def _convert_group_by(self, nodes):
         return list(range(len(nodes)))
 

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -301,12 +301,7 @@ class SelectBuilder:
             self.table_set = table
             self.filters = filters
 
-    def _collect_PandasInMemoryTable(self, node, toplevel=False):
-        if toplevel:
-            self.select_set = [node]
-            self.table_set = node
-
-    def _collect_PyArrowInMemoryTable(self, node, toplevel=False):
+    def _collect_InMemoryTable(self, node, toplevel=False):
         if toplevel:
             self.select_set = [node]
             self.table_set = node

--- a/ibis/backends/pyarrow/__init__.py
+++ b/ibis/backends/pyarrow/__init__.py
@@ -4,39 +4,21 @@ from typing import TYPE_CHECKING
 
 import pyarrow as pa
 
-import ibis.expr.operations as ops
-import ibis.expr.rules as rlz
 import ibis.expr.schema as sch
-from ibis import util
-from ibis.common.grounds import Immutable
+from ibis.expr.operations.relations import TableProxy
 
 if TYPE_CHECKING:
     import pandas as pd
 
 
-class PyArrowTableProxy(Immutable, util.ToFrame):
-    __slots__ = ('_t', '_hash')
-
-    def __init__(self, t: pa.Table) -> None:
-        object.__setattr__(self, "_t", t)
-        object.__setattr__(self, "_hash", hash((type(t), id(t))))
-
-    def __hash__(self) -> int:
-        return self._hash
-
-    def __repr__(self) -> str:
-        df_repr = util.indent(repr(self._t), spaces=2)
-        return f"{self.__class__.__name__}:\n{df_repr}"
+class PyArrowTableProxy(TableProxy):
+    __slots__ = ()
 
     def to_frame(self) -> pd.DataFrame:
-        return self._t.to_pandas()
+        return self._data.to_pandas()
 
     def to_pyarrow(self, _: sch.Schema) -> pa.Table:
-        return self._t
-
-
-class PyArrowInMemoryTable(ops.InMemoryTable):
-    data = rlz.instance_of(PyArrowTableProxy)
+        return self._data
 
 
 @sch.infer.register(pa.Table)

--- a/ibis/backends/pyarrow/__init__.py
+++ b/ibis/backends/pyarrow/__init__.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+
+import ibis.expr.operations as ops
+import ibis.expr.rules as rlz
+import ibis.expr.schema as sch
+from ibis import util
+from ibis.common.grounds import Immutable
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class PyArrowTableProxy(Immutable, util.ToFrame):
+    __slots__ = ('_t', '_hash')
+
+    def __init__(self, t: pa.Table) -> None:
+        object.__setattr__(self, "_t", t)
+        object.__setattr__(self, "_hash", hash((type(t), id(t))))
+
+    def __hash__(self) -> int:
+        return self._hash
+
+    def __repr__(self) -> str:
+        df_repr = util.indent(repr(self._t), spaces=2)
+        return f"{self.__class__.__name__}:\n{df_repr}"
+
+    def to_frame(self) -> pd.DataFrame:
+        return self._t.to_pandas()
+
+    def to_pyarrow(self, _: sch.Schema) -> pa.Table:
+        return self._t
+
+
+class PyArrowInMemoryTable(ops.InMemoryTable):
+    data = rlz.instance_of(PyArrowTableProxy)
+
+
+@sch.infer.register(pa.Table)
+def infer_pyarrow_table_schema(t: pa.Table, schema=None):
+    import ibis.backends.pyarrow.datatypes  # noqa: F401
+
+    return sch.schema(schema if schema is not None else t.schema)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -18,9 +18,7 @@ import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import interval
 from ibis.backends.base.df.timecontext import adjust_context
-from ibis.backends.pandas.client import PandasInMemoryTable
 from ibis.backends.pandas.execution import execute
-from ibis.backends.pyarrow import PyArrowInMemoryTable
 from ibis.backends.pyspark.datatypes import spark_dtype
 from ibis.backends.pyspark.timecontext import (
     combine_time_context,
@@ -1863,8 +1861,7 @@ def compile_random(*args, **kwargs):
     return F.rand()
 
 
-@compiles(PandasInMemoryTable)
-@compiles(PyArrowInMemoryTable)
+@compiles(ops.InMemoryTable)
 def compile_in_memory_table(t, op, session, **kwargs):
     fields = [
         pt.StructField(name, spark_dtype(dtype), dtype.nullable)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -20,6 +20,7 @@ from ibis import interval
 from ibis.backends.base.df.timecontext import adjust_context
 from ibis.backends.pandas.client import PandasInMemoryTable
 from ibis.backends.pandas.execution import execute
+from ibis.backends.pyarrow import PyArrowInMemoryTable
 from ibis.backends.pyspark.datatypes import spark_dtype
 from ibis.backends.pyspark.timecontext import (
     combine_time_context,
@@ -1862,8 +1863,8 @@ def compile_random(*args, **kwargs):
     return F.rand()
 
 
-@compiles(ops.InMemoryTable)
 @compiles(PandasInMemoryTable)
+@compiles(PyArrowInMemoryTable)
 def compile_in_memory_table(t, op, session, **kwargs):
     fields = [
         pt.StructField(name, spark_dtype(dtype), dtype.nullable)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -476,7 +476,7 @@ def test_array_slice(con, start, stop):
     ["dask", "pandas"],
     raises=com.UnboundExpressionError,
     reason=(
-        "Node of type 'PandasInMemoryTable' has no data bound to it. "
+        "Node of type 'InMemoryTable' has no data bound to it. "
         "You probably tried to execute an expression without a data source."
     ),
 )
@@ -512,7 +512,7 @@ def test_array_map(backend, con):
     ["dask", "pandas"],
     raises=com.UnboundExpressionError,
     reason=(
-        "Node of type 'PandasInMemoryTable' has no data bound to it. "
+        "Node of type 'InMemoryTable' has no data bound to it. "
         "You probably tried to execute an expression without a data source."
     ),
 )

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -347,7 +347,7 @@ def memtable(
     >>> import ibis
     >>> t = ibis.memtable([{"a": 1}, {"a": 2}])
     >>> t
-    PandasInMemoryTable
+    InMemoryTable
       data:
         DataFrameProxy:
              a
@@ -356,7 +356,7 @@ def memtable(
 
     >>> t = ibis.memtable([{"a": 1, "b": "foo"}, {"a": 2, "b": "baz"}])
     >>> t
-    PandasInMemoryTable
+    InMemoryTable
       data:
         DataFrameProxy:
              a    b
@@ -368,7 +368,7 @@ def memtable(
 
     >>> t = ibis.memtable([(1, "foo"), (2, "baz")], columns=["a", "b"])
     >>> t
-    PandasInMemoryTable
+    InMemoryTable
       data:
         DataFrameProxy:
              a    b
@@ -380,7 +380,7 @@ def memtable(
 
     >>> t = ibis.memtable([(1, "foo"), (2, "baz")])
     >>> t
-    PandasInMemoryTable
+    InMemoryTable
       data:
         DataFrameProxy:
              col0 col1
@@ -421,9 +421,9 @@ def _memtable_from_dataframe(
     name: str | None = None,
     schema: SupportsSchema | None = None,
 ) -> Table:
-    from ibis.backends.pandas.client import DataFrameProxy, PandasInMemoryTable
+    from ibis.backends.pandas.client import DataFrameProxy
 
-    op = PandasInMemoryTable(
+    op = ops.InMemoryTable(
         name=name if name is not None else util.generate_unique_table_name("memtable"),
         schema=sch.infer(df) if schema is None else schema,
         data=DataFrameProxy(df),
@@ -434,9 +434,9 @@ def _memtable_from_dataframe(
 def _memtable_from_pyarrow_table(
     data: pa.Table, *, name: str | None = None, schema: SupportsSchema | None = None
 ):
-    from ibis.backends.pyarrow import PyArrowInMemoryTable, PyArrowTableProxy
+    from ibis.backends.pyarrow import PyArrowTableProxy
 
-    return PyArrowInMemoryTable(
+    return ops.InMemoryTable(
         name=name if name is not None else util.generate_unique_table_name("memtable"),
         schema=sch.infer(data) if schema is None else schema,
         data=PyArrowTableProxy(data),

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -1,7 +1,6 @@
 """Ibis utility functions."""
 from __future__ import annotations
 
-import abc
 import collections
 import functools
 import importlib.metadata
@@ -32,11 +31,7 @@ import toolz
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pandas as pd
-    import pyarrow as pa
-
     import ibis.expr.operations as ops
-    import ibis.expr.schema as sch
 
     Graph = Mapping[ops.Node, Sequence[ops.Node]]
 
@@ -482,23 +477,6 @@ def experimental(func):
         func, msg="This API is experimental and subject to change."
     )
     return func
-
-
-class ToFrame(abc.ABC):
-    """Interface for in-memory objects that can be converted to an in-memory structure.
-
-    Supports pandas DataFrames and PyArrow Tables.
-    """
-
-    __slots__ = ()
-
-    @abc.abstractmethod
-    def to_frame(self) -> pd.DataFrame:  # pragma: no cover
-        """Convert this input to a pandas DataFrame."""
-
-    @abc.abstractmethod
-    def to_pyarrow(self, schema: sch.Schema) -> pa.Table:  # pragma: no cover
-        """Convert this input to a PyArrow Table."""
 
 
 def backend_entry_points() -> list[importlib.metadata.EntryPoint]:


### PR DESCRIPTION
This PR adds support to `ibis.memtable` for pyarrow Table objects. Closes #5782.