### PR TITLE
test(snowflake): catch the right error when accessing tables in view test

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -220,7 +220,7 @@ def test_create_drop_view(ddl_con, temp_view):
     table_name = 'functional_alltypes'
     try:
         expr = ddl_con.table(table_name)
-    except KeyError:
+    except (KeyError, sa.exc.NoSuchTableError):
         table_name = table_name.upper()
         expr = ddl_con.table(table_name)
 


### PR DESCRIPTION
This PR fixes an issue with snowflake testing where the exception raised is incorrect.