### PR TITLE
test(snowflake): skip local test of schema-dependent database

### DIFF
--- a/ibis/backends/tests/snapshots/test_string/test_rlike/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_string/test_rlike/snowflake/out.sql
@@ -14,6 +14,6 @@ SELECT
   t0."timestamp_col",
   t0."year",
   t0."month"
-FROM ibis_testing.voltrondataphillip."FUNCTIONAL_ALLTYPES" AS t0
+FROM ibis_testing.ibis_testing."FUNCTIONAL_ALLTYPES" AS t0
 WHERE
   REGEXP_LIKE(t0."string_col", '0')

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 
 import pytest
 import sqlalchemy as sa
@@ -882,6 +883,8 @@ def test_multiple_subs(con):
     raises=ValueError,
     reason="sqlglot doesn't support a druid dialect",
 )
-def test_rlike(snapshot, alltypes):
+def test_rlike(backend, snapshot, alltypes):
+    if backend.name() == "snowflake" and not os.environ.get("CI"):  # pragma: no cover
+        pytest.skip("snowflake test database is segmented per-user and different in CI")
     expr = alltypes[alltypes.string_col.rlike('0')]
     snapshot.assert_match(str(ibis.to_sql(expr)), "out.sql")


### PR DESCRIPTION
This PR fixes a failing snowflake test that is sensitive to the database and schema used for testing.