### PR TITLE
feat(pyspark): add partial support for interval types

### DIFF
--- a/ibis/backends/pyspark/datatypes.py
+++ b/ibis/backends/pyspark/datatypes.py
@@ -79,6 +79,28 @@ def _spark_struct(spark_dtype_obj, nullable=True):
     return dt.Struct(fields, nullable=nullable)
 
 
+_SPARK_INTERVAL_TO_IBIS_INTERVAL = {
+    pt.DayTimeIntervalType.SECOND: 's',
+    pt.DayTimeIntervalType.MINUTE: 'm',
+    pt.DayTimeIntervalType.HOUR: 'h',
+    pt.DayTimeIntervalType.DAY: 'D',
+}
+
+
+@dt.dtype.register(pt.DayTimeIntervalType)
+def _spark_struct(spark_dtype_obj, nullable=True):
+    if (
+        spark_dtype_obj.startField == spark_dtype_obj.endField
+        and spark_dtype_obj.startField in _SPARK_INTERVAL_TO_IBIS_INTERVAL
+    ):
+        return dt.Interval(
+            _SPARK_INTERVAL_TO_IBIS_INTERVAL[spark_dtype_obj.startField],
+            nullable=nullable,
+        )
+    else:
+        raise com.IbisTypeError("DayTimeIntervalType couldn't be converted to Interval")
+
+
 _IBIS_DTYPE_TO_SPARK_DTYPE = {v: k for k, v in _SPARK_DTYPE_TO_IBIS_DTYPE.items()}
 _IBIS_DTYPE_TO_SPARK_DTYPE[dt.JSON] = pt.StringType
 

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import pandas as pd

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 import numpy as np
 import pandas as pd
@@ -275,6 +275,63 @@ def client(data_directory):
     )
 
     df_time_indexed.createTempView('time_indexed_table')
+
+    df_interval = client._session.createDataFrame(
+        [
+            [
+                timedelta(days=10),
+                timedelta(hours=10),
+                timedelta(minutes=10),
+                timedelta(seconds=10),
+            ]
+        ],
+        pt.StructType(
+            [
+                pt.StructField(
+                    "interval_day",
+                    pt.DayTimeIntervalType(
+                        pt.DayTimeIntervalType.DAY, pt.DayTimeIntervalType.DAY
+                    ),
+                ),
+                pt.StructField(
+                    "interval_hour",
+                    pt.DayTimeIntervalType(
+                        pt.DayTimeIntervalType.HOUR, pt.DayTimeIntervalType.HOUR
+                    ),
+                ),
+                pt.StructField(
+                    "interval_minute",
+                    pt.DayTimeIntervalType(
+                        pt.DayTimeIntervalType.MINUTE, pt.DayTimeIntervalType.MINUTE
+                    ),
+                ),
+                pt.StructField(
+                    "interval_second",
+                    pt.DayTimeIntervalType(
+                        pt.DayTimeIntervalType.SECOND, pt.DayTimeIntervalType.SECOND
+                    ),
+                ),
+            ]
+        ),
+    )
+
+    df_interval.createTempView('interval_table')
+
+    df_interval_invalid = client._session.createDataFrame(
+        [[timedelta(days=10, hours=10, minutes=10, seconds=10)]],
+        pt.StructType(
+            [
+                pt.StructField(
+                    "interval_day_hour",
+                    pt.DayTimeIntervalType(
+                        pt.DayTimeIntervalType.DAY, pt.DayTimeIntervalType.HOUR
+                    ),
+                )
+            ]
+        ),
+    )
+
+    df_interval_invalid.createTempView('invalid_interval_table')
 
     return client
 

--- a/ibis/backends/pyspark/tests/test_basic.py
+++ b/ibis/backends/pyspark/tests/test_basic.py
@@ -226,6 +226,16 @@ def test_interval_columns(client):
         ]
     )
 
+    expected = pd.DataFrame(
+        {
+            "interval_day": [pd.Timedelta("10d")],
+            "interval_hour": [pd.Timedelta("10h")],
+            "interval_minute": [pd.Timedelta("10m")],
+            "interval_second": [pd.Timedelta("10s")],
+        }
+    )
+    tm.assert_frame_equal(table.execute(), expected)
+
 
 def test_interval_columns_invalid(client):
     with pytest.raises(

--- a/ibis/backends/pyspark/tests/test_basic.py
+++ b/ibis/backends/pyspark/tests/test_basic.py
@@ -4,14 +4,14 @@ import pytest
 from pytest import param
 
 import ibis
+from ibis.common.exceptions import IbisTypeError
+from ibis.expr import datatypes as dt
 
 pyspark = pytest.importorskip("pyspark")
 
 import pyspark.sql.functions as F  # noqa: E402
 
 from ibis.backends.pyspark.compiler import _can_be_replaced_by_column_name  # noqa: E402
-from ibis.expr import datatypes as dt
-from ibis.common.exceptions import IbisTypeError
 
 
 def test_basic(client):


### PR DESCRIPTION
This PR adds partial support for Ibis `Interval` types by mapping pyspark `DayTimeIntervalType` to appropriate Ibis types. Only four `DayTimeIntervalType` interval types are supported as part of this PR:

- INTERVAL DAY
- INTERVAL HOUR
- INTERVAL MINUTE
- INTERVAL SECOND

types with several units at once (e.g. `INTERVAL DAY TO HOUR`) still lead to an error, as well as types with a different time unit.

P.S. Spark also has a `YearMonthIntervalType`, but it's not yet exposed in pyspark.