### PR TITLE
build: revert poetry version in nix setup and enforce it

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -50,6 +50,9 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
+      - name: check poetry version
+        run: nix run '.#check-poetry-version' -- "1.3"
+
       - name: setup cachix
         uses: cachix/cachix-action@v12
         with:

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679741409,
-        "narHash": "sha256-KJ7FkVcGJEJimBocxRlo3zAVxSuJo21XS5/pn4VfU9s=",
+        "lastModified": 1679696568,
+        "narHash": "sha256-pfbvTixGYq/w3paC8T8/dMfnc+BCHwdGzr9PzWBRY8M=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "c56b6590ae65fcfdf91fa08ad19eb4ab4f0424ca",
+        "rev": "4e45611b62f7500665d1803bd33d178f2f9fa1f7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1679696568,
-        "narHash": "sha256-pfbvTixGYq/w3paC8T8/dMfnc+BCHwdGzr9PzWBRY8M=",
+        "lastModified": 1679287389,
+        "narHash": "sha256-VMFWpjeFXyDWcQ9/iucsZZC3vBlTut01mwFJrppKgXE=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "4e45611b62f7500665d1803bd33d178f2f9fa1f7",
+        "rev": "4e91056ff17e5fae2e789e61d921b5419d000a1a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -121,7 +121,7 @@
 
         default = pkgs.ibis311;
 
-        inherit (pkgs) update-lock-files gen-all-extras gen-examples;
+        inherit (pkgs) update-lock-files gen-all-extras gen-examples check-poetry-version;
       };
 
       devShells = rec {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -95,4 +95,25 @@ in
       yj -tj < pyproject.toml | jq -rM '.tool.poetry.extras | with_entries(select(.key != "all")) | [.[]] | add | unique | sort'
     '';
   };
+
+  check-poetry-version = pkgs.writeShellApplication {
+    name = "check-poetry-version";
+    runtimeInputs = [
+      (
+        mkPoetryEnv {
+          python = pkgs.python311;
+          groups = [ ];
+          extras = [ ];
+        }
+      ).pkgs.poetry
+    ];
+    text = ''
+      expected="$1"
+      out="$(poetry --version --no-ansi)"
+      if [[ "$out" != *"$expected"* ]]; then
+        >&2 echo "error: expected version $expected; got: $out"
+        exit 1
+      fi
+    '';
+  };
 }


### PR DESCRIPTION
This PR reverts two `poetry2nix` bumps that upgrade our poetry version to 1.4.1
and break lockfile parsing because of an issue in poetry2nix itself.

See https://github.com/nix-community/poetry2nix/pull/1082 for details.
