### PR TITLE
feat(pyspark): add ArrayMap operation

### DIFF
--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1669,6 +1669,15 @@ def compile_array_filter(t, op, **kwargs):
     )
 
 
+@compiles(ops.ArrayMap)
+def compile_array_map(t, op, **kwargs):
+    src_column = t.translate(op.arg, **kwargs)
+    return F.transform(
+        src_column,
+        lambda x: t.translate(op.result, arg_columns={op.parameter: x}, **kwargs),
+    )
+
+
 # --------------------------- Null Operations -----------------------------
 
 

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -466,7 +466,6 @@ def test_array_slice(con, start, stop):
         "mssql",
         "polars",
         "postgres",
-        "pyspark",
         "snowflake",
         "sqlite",
     ],


### PR DESCRIPTION
This PR adds support for `ops.ArrayMap` operation in pyspark backend, similar approach to #5825.