### PR TITLE
feat(types): support unknown types in sqlalchemy backends

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -99,6 +99,16 @@ jobs:
               - postgres
             sys-deps:
               - libgeos-dev
+          - name: postgres
+            title: PostgreSQL + PyArrow
+            extras:
+              - postgres
+              - geospatial
+              - pyarrow
+            services:
+              - postgres
+            sys-deps:
+              - libgeos-dev
           - name: impala
             title: Impala
             serial: true
@@ -184,6 +194,18 @@ jobs:
               extras:
                 - postgres
                 - geospatial
+              services:
+                - postgres
+              sys-deps:
+                - libgeos-dev
+          - os: windows-latest
+            backend:
+              name: postgres
+              title: PostgreSQL + PyArrow
+              extras:
+                - postgres
+                - geospatial
+                - pyarrow
               services:
                 - postgres
               sys-deps:

--- a/ci/schema/postgresql.sql
+++ b/ci/schema/postgresql.sql
@@ -53,7 +53,11 @@ CREATE TABLE awards_players (
     "yearID" BIGINT,
     "lgID" TEXT,
     tie TEXT,
-    notes TEXT
+    notes TEXT,
+    search TSVECTOR GENERATED ALWAYS AS (
+      setweight(to_tsvector('simple', notes), 'A')::TSVECTOR
+    ) STORED,
+    simvec VECTOR GENERATED always AS ('[1,2,3]'::VECTOR) STORED
 );
 
 DROP TABLE IF EXISTS functional_alltypes CASCADE;
@@ -209,13 +213,3 @@ CREATE TABLE map (kv HSTORE);
 INSERT INTO map VALUES
     ('a=>1,b=>2,c=>3'),
     ('d=>4,e=>5,c=>6');
-
-ALTER TABLE awards_players
-ADD search tsvector
-GENERATED always AS (
-  setweight(to_tsvector('simple', notes), 'A') :: tsvector
-) stored;
-
-ALTER TABLE awards_players
-ADD simvec vector
-GENERATED always AS ('[1,2,3]' :: vector) stored;

--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -115,6 +115,10 @@ else:
         return "UUID"
 
 
+class Unknown(sa.Text):
+    pass
+
+
 # TODO(cleanup)
 ibis_type_to_sqla = {
     dt.Null: sat.NullType,
@@ -141,6 +145,7 @@ ibis_type_to_sqla = {
     dt.UInt64: UInt64,
     dt.JSON: sa.JSON,
     dt.Interval: sa.Interval,
+    dt.Unknown: Unknown,
 }
 
 
@@ -260,6 +265,11 @@ def sa_double(_, satype, nullable=True):
 @dt.dtype.register(Dialect, sa.types.JSON)
 def sa_json(_, satype, nullable=True):
     return dt.JSON(nullable=nullable)
+
+
+@dt.dtype.register(Dialect, Unknown)
+def sa_unknown(_, satype, nullable=True):
+    return dt.Unknown(nullable=nullable)
 
 
 if geospatial_supported:

--- a/ibis/backends/postgres/datatypes.py
+++ b/ibis/backends/postgres/datatypes.py
@@ -49,11 +49,8 @@ def _get_type(typestr: str) -> dt.DataType:
     try:
         return _parse_numeric(typestr)
     except parsy.ParseError:
-        # postgres can have arbitrary types unknown to ibis, so we just
-        # consider them null since we can't know what to do with them without
-        # explicit support, return null to effectively give no public API to
-        # such columns
-        return dt.null
+        # postgres can have arbitrary types unknown to ibis
+        return dt.unknown
 
 
 _type_mapping = {
@@ -181,4 +178,4 @@ def sa_pg_array(dialect, satype, nullable=True):
 
 @dt.dtype.register(PGDialect, postgresql.TSVECTOR)
 def sa_postgres_tsvector(_, satype, nullable=True):
-    return dt.String(nullable=nullable)
+    return dt.Unknown(nullable=nullable)

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -209,9 +209,7 @@ def test_get_schema_from_query(con, pg_type, expected_type):
     assert result_schema == expected_schema
 
 
-@pytest.mark.parametrize(
-    ("col", "expected_type"), [("search", dt.string), ("simvec", dt.null)]
-)
-def test_unknown_column_type(con, col, expected_type):
+@pytest.mark.parametrize("col", ["search", "simvec"])
+def test_unknown_column_type(con, col):
     awards_players = con.table("awards_players")
-    assert awards_players[col].type() == expected_type
+    assert awards_players[col].type().is_unknown()

--- a/ibis/backends/pyarrow/datatypes.py
+++ b/ibis/backends/pyarrow/datatypes.py
@@ -28,6 +28,8 @@ _to_pyarrow_types = {
     dt.Date: pa.date64(),
     dt.JSON: pa.string(),
     dt.Null: pa.null(),
+    # assume unknown types can be converted into strings
+    dt.Unknown: pa.string(),
 }
 
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -269,6 +269,9 @@ class DataType(Concrete):
     def is_uint8(self) -> bool:
         return isinstance(self, UInt8)
 
+    def is_unknown(self) -> bool:
+        return isinstance(self, Unknown)
+
     def is_unsigned_integer(self) -> bool:
         return isinstance(self, UnsignedInteger)
 
@@ -282,6 +285,14 @@ class DataType(Concrete):
 @dtype.register(DataType)
 def from_ibis_dtype(value: DataType) -> DataType:
     return value
+
+
+@public
+class Unknown(DataType, Singleton):
+    """An unknown type."""
+
+    scalar = ir.UnknownScalar
+    column = ir.UnknownColumn
 
 
 @public
@@ -922,6 +933,7 @@ uuid = UUID()
 macaddr = MACADDR()
 inet = INET()
 decimal = Decimal()
+unknown = Unknown()
 
 Enum = String
 
@@ -1023,6 +1035,7 @@ public(
     macaddr=macaddr,
     inet=inet,
     decimal=decimal,
+    unknown=unknown,
     Enum=Enum,
     Geography=GeoSpatial,
     Geometry=GeoSpatial,

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence
 from public import public
 
 import ibis
-from ibis import util
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+from ibis import util
 from ibis.common.grounds import Singleton
 from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin
 
@@ -1111,6 +1111,21 @@ class Column(Value, _FixedTextJupyterMixin):
             The nth value over a window
         """
         return ops.NthValue(self, n).to_expr()
+
+
+@public
+class UnknownValue(Value):
+    pass
+
+
+@public
+class UnknownScalar(Scalar):
+    pass
+
+
+@public
+class UnknownColumn(Column):
+    pass
 
 
 @public

--- a/poetry.lock
+++ b/poetry.lock
@@ -5578,6 +5578,7 @@ mysql = ["sqlalchemy", "pymysql", "sqlalchemy-views"]
 pandas = ["regex"]
 polars = ["polars", "pyarrow"]
 postgres = ["psycopg2", "sqlalchemy", "sqlalchemy-views"]
+pyarrow = ["pyarrow"]
 pyspark = ["pyarrow", "pyspark", "sqlalchemy"]
 snowflake = ["snowflake-connector-python", "snowflake-sqlalchemy", "sqlalchemy-views"]
 sqlite = ["regex", "sqlalchemy", "sqlalchemy-views"]
@@ -5587,4 +5588,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "8a2e51fb531b6150707c76b9d202aaa0ecf6b7ad7a4ee1f16d913856a08e7334"
+content-hash = "1ddc5d070ca573ccedd3ae97bf8d136372d604c15579b2924d7f432ce893c9c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,7 @@ mysql = ["sqlalchemy", "pymysql", "sqlalchemy-views"]
 pandas = ["regex"]
 polars = ["polars", "pyarrow"]
 postgres = ["psycopg2", "sqlalchemy", "sqlalchemy-views"]
+pyarrow = ["pyarrow"]
 pyspark = ["pyarrow", "pyspark", "sqlalchemy"]
 snowflake = [
   "snowflake-connector-python",


### PR DESCRIPTION
This PR unifies handling of unknown types into a single `Unknown` type and
corresponding expression classes. These are user facing, but have extremely limited value.

The primary use case is to allow people to access known-type column in tables
that contain columns whose type we can't map into ibis. We shouldn't fail in
that case, and this PR addresses that more uniformly. Previously we had
tsvectors returning as strings and vectors returning as null types, which
causes problems when converting these data to arrow objects.

~I factored out the API I think these should have into `MinimalValue` et al base
classes, to allow only accessing valid APIs on expressions with unknown type.~

~The idea is to limit all unknown type operations to only pass through, and to treat
these passed-through values as strings in `.execute()`, `.to_pyarrow()`, and
`.to_pyarrow_batches()`.~

Kept the `Value` API as is.