### PR TITLE
test(duckdb): run tests in parallel using an in-memory database

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -291,7 +291,7 @@ def pytest_collection_modifyitems(session, config, items):
             if not any(item.iter_markers(name="benchmark")):
                 item.add_marker(pytest.mark.core)
 
-        for name in ("duckdb", "sqlite"):
+        for name in ["sqlite"]:
             # build a list of markers so we're don't invalidate the item's
             # marker iterator
             for _ in item.iter_markers(name=name):

--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -18,38 +17,32 @@ class TestConf(BackendTest, RoundAwayFromZero):
     def __init__(self, data_directory: Path) -> None:
         self.connection = self.connect(data_directory)
 
+        script_dir = data_directory.parent
+
+        schema = (script_dir / 'schema' / 'duckdb.sql').read_text()
+
+        with self.connection.begin() as con:
+            for stmt in filter(None, map(str.strip, schema.split(';'))):
+                con.exec_driver_sql(stmt)
+
+            for table in TEST_TABLES:
+                src = data_directory / f'{table}.csv'
+                con.exec_driver_sql(
+                    f"COPY {table} FROM {str(src)!r} (DELIMITER ',', HEADER, SAMPLE_SIZE 1)"
+                )
+
     @staticmethod
-    def _load_data(
-        data_dir,
-        script_dir,
-        database: str = "ibis_testing",
-        **_: Any,
-    ) -> None:
+    def _load_data(data_dir, script_dir, **_: Any) -> None:
         """Load test data into a DuckDB backend instance.
 
         Parameters
         ----------
         data_dir
             Location of test data
-        script_dir
-            Location of scripts defining schemas
         """
-        duckdb = pytest.importorskip("duckdb")
-
-        schema = (script_dir / 'schema' / 'duckdb.sql').read_text()
-
-        conn = duckdb.connect(str(data_dir / f"{database}.ddb"))
-        for stmt in filter(None, map(str.strip, schema.split(';'))):
-            conn.execute(stmt)
-
-        for table in TEST_TABLES:
-            src = data_dir / f'{table}.csv'
-            conn.execute(
-                f"COPY {table} FROM {str(src)!r} (DELIMITER ',', HEADER, SAMPLE_SIZE 1)"
-            )
+        return TestConf(data_directory=data_dir)
 
     @staticmethod
-    @functools.lru_cache(maxsize=None)
     def connect(data_directory: Path) -> BaseBackend:
-        path = data_directory / "ibis_testing.ddb"
-        return ibis.duckdb.connect(str(path))  # type: ignore
+        pytest.importorskip("duckdb")
+        return ibis.duckdb.connect()  # type: ignore

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -673,14 +673,9 @@ def test_connect_local_file(out_method, extension, test_employee_data_1, tmp_pat
 
 
 @not_windows
-def test_invalid_connect():
+def test_invalid_connect(tmp_path):
     pytest.importorskip("duckdb")
-    url = "?".join(
-        [
-            "duckdb://ci/ibis-testing-data/ibis_testing.ddb",
-            "read_only=invalid_value",
-        ]
-    )
+    url = f"duckdb://{tmp_path}?read_only=invalid_value"
     with pytest.raises(ValueError):
         ibis.connect(url)
 


### PR DESCRIPTION
This PR moves our duckdb test suite to be based entirely on an in-memory database which lets us run the test suite in parallel. On a 16 core machine I see about a 5.7x speed up versus upstream.