### PR TITLE
feat(pyspark): add DateDiff operation

### DIFF
--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1536,8 +1536,11 @@ def compile_date_sub(t, op, **kwargs):
 
 @compiles(ops.DateDiff)
 def compile_date_diff(t, op, **kwargs):
-    raise com.UnsupportedOperationError(
-        'PySpark backend does not support DateDiff as there is no timedelta type.'
+    left = t.translate(op.left, **kwargs)
+    right = t.translate(op.right, **kwargs)
+
+    return F.concat(F.lit("INTERVAL '"), F.datediff(left, right), F.lit("' DAY")).cast(
+        pt.DayTimeIntervalType(pt.DayTimeIntervalType.DAY, pt.DayTimeIntervalType.DAY)
     )
 
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -855,11 +855,6 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
             lambda t, _: t.timestamp_col.dt.floor('d') - date_value,
             id='date-subtract-date',
             marks=[
-                pytest.mark.notimpl(
-                    ["pyspark"],
-                    raises=com.UnsupportedOperationError,
-                    reason="PySpark backend does not support DateDiff as there is no timedelta type.",
-                ),
                 pytest.mark.notimpl(["bigquery"], raises=com.OperationNotDefinedError),
                 pytest.mark.notimpl(
                     ["druid"],


### PR DESCRIPTION
This PR adds support for `ops.DateDiff` in pyspark backend. Wraps the function with the same name in pyspark, but returns `Interval('D')` type instead of an integer.