### PR TITLE
refactor(datatypes): use typehints instead of rules

### DIFF
--- a/ibis/backends/base/sql/registry/timestamp.py
+++ b/ibis/backends/base/sql/registry/timestamp.py
@@ -35,7 +35,7 @@ def truncate(translator, op):
 
     arg_formatted = translator.translate(arg)
     try:
-        unit = base_unit_names[unit]
+        unit = base_unit_names[unit.short]
     except KeyError:
         raise com.UnsupportedOperationError(
             f'{unit!r} unit is not supported in timestamp truncate'
@@ -81,7 +81,7 @@ def _from_unixtime(translator, expr):
 
 def timestamp_from_unix(translator, op):
     val, unit = op.args
-    val = util.convert_unit(val, unit, 's').to_expr().cast("int32").op()
+    val = util.convert_unit(val, unit.short, 's').to_expr().cast("int32").op()
     arg = _from_unixtime(translator, val)
     return f'CAST({arg} AS timestamp)'
 

--- a/ibis/backends/base/sql/registry/window.py
+++ b/ibis/backends/base/sql/registry/window.py
@@ -50,7 +50,7 @@ def interval_boundary_to_integer(boundary):
 
     value = boundary.value
     try:
-        multiplier = _map_interval_to_microseconds[value.output_dtype.unit]
+        multiplier = _map_interval_to_microseconds[value.output_dtype.unit.short]
     except KeyError:
         raise com.IbisInputError(
             f"Unsupported interval unit: {value.output_dtype.unit}"

--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -77,7 +77,7 @@ def _cast(translator, op):
 def integer_to_timestamp(translator: compiler.ExprTranslator, op) -> str:
     """Interprets an integer as a timestamp."""
     arg = translator.translate(op.arg)
-    unit = op.unit
+    unit = op.unit.short
 
     if unit == "s":
         return f"TIMESTAMP_SECONDS({arg})"
@@ -91,7 +91,7 @@ def integer_to_timestamp(translator: compiler.ExprTranslator, op) -> str:
         # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#timestamp_type
         return f"TIMESTAMP_MICROS(CAST(ROUND({arg} / 1000) AS INT64))"
 
-    raise NotImplementedError(f"cannot cast unit {unit}")
+    raise NotImplementedError(f"cannot cast unit {op.unit}")
 
 
 def _struct_field(translator, op):

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -73,7 +73,7 @@ def _cast(op, **kw):
     arg = translate_val(op.arg, **kw)
 
     if isinstance(op.to, dt.Interval):
-        suffix = _interval_cast_suffixes[op.to.unit]
+        suffix = _interval_cast_suffixes[op.to.unit.short]
         return f"toInterval{suffix}({arg})"
 
     to = translate_val(op.to, **kw)
@@ -386,7 +386,7 @@ def _node_list(op, punct="()", **kw):
 
 def _interval_format(op):
     dtype = op.output_dtype
-    if dtype.unit in {"ms", "us", "ns"}:
+    if dtype.unit.short in {"ms", "us", "ns"}:
         raise com.UnsupportedOperationError(
             "Clickhouse doesn't support subsecond interval resolutions"
         )
@@ -397,7 +397,7 @@ def _interval_format(op):
 @translate_val.register(ops.IntervalFromInteger)
 def _interval_from_integer(op, **kw):
     dtype = op.output_dtype
-    if dtype.unit in {"ms", "us", "ns"}:
+    if dtype.unit.short in {"ms", "us", "ns"}:
         raise com.UnsupportedOperationError(
             "Clickhouse doesn't support subsecond interval resolutions"
         )
@@ -539,7 +539,7 @@ def _table_array_view(op, *, cache, **kw):
 @translate_val.register(ops.TimestampFromUNIX)
 def _timestamp_from_unix(op, **kw):
     arg = translate_val(op.arg, **kw)
-    if (unit := op.unit) in {"ms", "us", "ns"}:
+    if (unit := op.unit.short) in {"ms", "us", "ns"}:
         raise com.UnsupportedOperationError(f"{unit!r} unit is not supported!")
 
     return f"toDateTime({arg})"
@@ -559,7 +559,7 @@ def _truncate(op, **kw):
         "s": "toDateTime",
     }
 
-    unit = op.unit
+    unit = op.unit.short
     arg = translate_val(op.arg, **kw)
     try:
         converter = converters[unit]

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -77,9 +77,9 @@ def _timestamp_from_unix(t, op):
     arg, unit = op.args
     arg = t.translate(arg)
 
-    if unit == "ms":
+    if unit.short == "ms":
         return sa.func.epoch_ms(arg)
-    elif unit == "s":
+    elif unit.short == "s":
         return sa.func.to_timestamp(arg)
     else:
         raise UnsupportedOperationError(f"{unit!r} unit is not supported!")

--- a/ibis/backends/mssql/registry.py
+++ b/ibis/backends/mssql/registry.py
@@ -99,7 +99,7 @@ _truncate_precisions = {
 
 def _timestamp_truncate(t, op):
     arg = t.translate(op.arg)
-    unit = op.unit
+    unit = op.unit.short
     if unit not in _truncate_precisions:
         raise com.UnsupportedOperationError(f'Unsupported truncate unit {op.unit!r}')
 
@@ -181,7 +181,7 @@ operation_registry.update(
             1,
         ),
         ops.TimestampFromUNIX: lambda t, op: _timestamp_from_unix(
-            t.translate(op.arg), op.unit
+            t.translate(op.arg), op.unit.short
         ),
         ops.DateFromYMD: fixed_arity(sa.func.datefromparts, 3),
         ops.TimestampFromYMDHMS: fixed_arity(

--- a/ibis/backends/mysql/registry.py
+++ b/ibis/backends/mysql/registry.py
@@ -47,7 +47,7 @@ _truncate_formats = {
 def _truncate(t, op):
     sa_arg = t.translate(op.arg)
     try:
-        fmt = _truncate_formats[op.unit]
+        fmt = _truncate_formats[op.unit.short]
     except KeyError:
         raise com.UnsupportedOperationError(f'Unsupported truncate unit {op.unit}')
     return sa.func.date_format(sa_arg, fmt)
@@ -65,7 +65,7 @@ def _round(t, op):
 
 
 def _interval_from_integer(t, op):
-    if op.unit in {'ms', 'ns'}:
+    if op.unit.short in {'ms', 'ns'}:
         raise com.UnsupportedOperationError(
             f'MySQL does not allow operation with INTERVAL offset {op.unit}'
         )
@@ -83,7 +83,7 @@ def _interval_from_integer(t, op):
 
 def _literal(_, op):
     if op.output_dtype.is_interval():
-        if op.output_dtype.unit in {'ms', 'ns'}:
+        if op.output_dtype.unit.short in {'ms', 'ns'}:
             raise com.UnsupportedOperationError(
                 'MySQL does not allow operation '
                 f'with INTERVAL offset {op.output_dtype.unit}'

--- a/ibis/backends/pandas/client.py
+++ b/ibis/backends/pandas/client.py
@@ -113,7 +113,7 @@ def ibis_dtype_to_pandas(ibis_dtype: dt.DataType):
     if ibis_dtype.is_timestamp() and ibis_dtype.timezone:
         return DatetimeTZDtype('ns', ibis_dtype.timezone)
     elif ibis_dtype.is_interval():
-        return np.dtype(f'timedelta64[{ibis_dtype.unit}]')
+        return np.dtype(f'timedelta64[{ibis_dtype.unit.short}]')
     else:
         return _ibis_dtypes.get(type(ibis_dtype), np.dtype(np.object_))
 

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -95,7 +95,7 @@ def execute_node_literal_datatype(op, datatype, **kwargs):
 def execute_interval_literal(op, value, dtype, **kwargs):
     if value is None:
         return pd.NaT
-    return pd.Timedelta(value, dtype.unit)
+    return pd.Timedelta(value, dtype.unit.short)
 
 
 @execute_node.register(ops.Limit, pd.DataFrame, integer_types, integer_types)

--- a/ibis/backends/pandas/execution/temporal.py
+++ b/ibis/backends/pandas/execution/temporal.py
@@ -91,7 +91,7 @@ PANDAS_UNITS = {
 @execute_node.register((ops.TimestampTruncate, ops.DateTruncate), pd.Series)
 def execute_timestamp_truncate(op, data, **kwargs):
     dt = data.dt
-    unit = PANDAS_UNITS.get(op.unit, op.unit)
+    unit = PANDAS_UNITS.get(op.unit.short, op.unit.short)
     try:
         return dt.floor(unit)
     except ValueError:
@@ -109,8 +109,8 @@ OFFSET_CLASS = {
 
 @execute_node.register(ops.IntervalFromInteger, pd.Series)
 def execute_interval_from_integer_series(op, data, **kwargs):
-    unit = op.unit
-    resolution = f"{op.resolution}s"
+    unit = op.unit.short
+    resolution = op.unit.plural
     cls = OFFSET_CLASS.get(unit, None)
 
     # fast path for timedelta conversion
@@ -121,8 +121,8 @@ def execute_interval_from_integer_series(op, data, **kwargs):
 
 @execute_node.register(ops.IntervalFromInteger, integer_types)
 def execute_interval_from_integer_integer_types(op, data, **kwargs):
-    unit = op.unit
-    resolution = f"{op.resolution}s"
+    unit = op.unit.short
+    resolution = op.unit.plural
     cls = OFFSET_CLASS.get(unit, None)
 
     if cls is None:
@@ -133,8 +133,8 @@ def execute_interval_from_integer_integer_types(op, data, **kwargs):
 @execute_node.register(ops.Cast, pd.Series, dt.Interval)
 def execute_cast_integer_to_interval_series(op, data, type, **kwargs):
     to = op.to
-    unit = to.unit
-    resolution = f"{to.resolution}s"
+    unit = to.unit.short
+    resolution = to.unit.plural
     cls = OFFSET_CLASS.get(unit, None)
 
     if cls is None:
@@ -145,8 +145,8 @@ def execute_cast_integer_to_interval_series(op, data, type, **kwargs):
 @execute_node.register(ops.Cast, integer_types, dt.Interval)
 def execute_cast_integer_to_interval_integer_types(op, data, type, **kwargs):
     to = op.to
-    unit = to.unit
-    resolution = f"{to.resolution}s"
+    unit = to.unit.short
+    resolution = to.unit.plural
     cls = OFFSET_CLASS.get(unit, None)
 
     if cls is None:
@@ -235,7 +235,7 @@ def execute_interval_multiply_fdiv_series_numeric(op, left, right, **kwargs):
 
 @execute_node.register(ops.TimestampFromUNIX, (pd.Series,) + integer_types)
 def execute_timestamp_from_unix(op, data, **kwargs):
-    return pd.to_datetime(data, unit=op.unit)
+    return pd.to_datetime(data, unit=op.unit.short)
 
 
 @pre_execute.register(ops.TimestampNow)

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -697,7 +697,7 @@ def date(op):
 @translate.register(ops.TimestampTruncate)
 def temporal_truncate(op):
     arg = translate(op.arg)
-    unit = "mo" if op.unit == "M" else op.unit
+    unit = "mo" if op.unit.short == "M" else op.unit.short
     unit = f"1{unit.lower()}"
     return arg.dt.truncate(unit, "-1w")
 
@@ -740,7 +740,7 @@ def timestamp_from_ymdhms(op):
 @translate.register(ops.TimestampFromUNIX)
 def timestamp_from_unix(op):
     arg = translate(op.arg)
-    unit = op.unit
+    unit = op.unit.short
     if unit == "s":
         arg = arg.cast(pl.Int64) * 1_000
         unit = "ms"

--- a/ibis/backends/polars/datatypes.py
+++ b/ibis/backends/polars/datatypes.py
@@ -46,8 +46,8 @@ def from_ibis_timestamp(dtype):
 
 @to_polars_type.register(dt.Interval)
 def from_ibis_interval(dtype):
-    if dtype.unit in {'us', 'ns', 'ms'}:
-        return pl.Duration(dtype.unit)
+    if dtype.unit.short in {'us', 'ns', 'ms'}:
+        return pl.Duration(dtype.unit.short)
     else:
         raise ValueError(f"Unsupported polars duration unit: {dtype.unit}")
 

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -58,7 +58,7 @@ _truncate_precisions = {
 def _timestamp_truncate(t, op):
     sa_arg = t.translate(op.arg)
     try:
-        precision = _truncate_precisions[op.unit]
+        precision = _truncate_precisions[op.unit.short]
     except KeyError:
         raise com.UnsupportedOperationError(f'Unsupported truncate unit {op.unit!r}')
     return sa.func.date_trunc(precision, sa_arg)

--- a/ibis/backends/pyarrow/datatypes.py
+++ b/ibis/backends/pyarrow/datatypes.py
@@ -50,7 +50,7 @@ def from_ibis_collection(dtype: dt.Array | dt.Set):
 @to_pyarrow_type.register
 def from_ibis_interval(dtype: dt.Interval):
     try:
-        return pa.duration(dtype.unit)
+        return pa.duration(dtype.unit.short)
     except ValueError:
         raise com.IbisTypeError(f"Unsupported interval unit: {dtype.unit}")
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1391,7 +1391,7 @@ def compile_extract_millisecond(t, op, **kwargs):
 @compiles(ops.DateTruncate)
 def compile_date_truncate(t, op, **kwargs):
     try:
-        unit = _time_unit_mapping[op.unit]
+        unit = _time_unit_mapping[op.unit.short]
     except KeyError:
         raise com.UnsupportedOperationError(
             f'{op.unit!r} unit is not supported in timestamp truncate'
@@ -1423,13 +1423,13 @@ def compile_timestamp_from_unix(t, op, **kwargs):
     unixtime = t.translate(op.arg, **kwargs)
     if not op.unit:
         return F.to_timestamp(F.from_unixtime(unixtime))
-    elif op.unit == 's':
+    elif op.unit.short == 's':
         fmt = 'yyyy-MM-dd HH:mm:ss'
         return F.to_timestamp(F.from_unixtime(unixtime, fmt), fmt)
     else:
         raise com.UnsupportedArgumentError(
             'PySpark backend does not support timestamp from unix time with '
-            'unit {}. Supported unit is s.'.format(op.unit)
+            'unit {}. Supported unit is s.'.format(op.unit.short)
         )
 
 
@@ -1474,9 +1474,9 @@ def _get_interval_col(t, op, allowed_units=None, **kwargs):
             f'{dtype} expression cannot be converted to interval column. '
             'Must be Interval dtype.'
         )
-    if allowed_units and dtype.unit not in allowed_units:
+    if allowed_units and dtype.unit.short not in allowed_units:
         raise com.UnsupportedArgumentError(
-            f'Interval unit "{dtype.unit}" is not allowed. Allowed units are: '
+            f'Interval unit "{dtype.unit.short}" is not allowed. Allowed units are: '
             f'{allowed_units}'
         )
 
@@ -1506,7 +1506,7 @@ def _get_interval_col(t, op, allowed_units=None, **kwargs):
         td_micros = td_nanos // 1000
         return F.expr(f'INTERVAL {td_micros} MICROSECOND')
     else:
-        return F.expr(f'INTERVAL {op.value} {_time_unit_mapping[dtype.unit]}')
+        return F.expr(f'INTERVAL {op.value} {_time_unit_mapping[dtype.unit.short]}')
 
 
 def _compile_datetime_binop(t, op, *, fn, **kwargs):

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -355,7 +355,7 @@ operation_registry.update(
         ),
         ops.TimestampFromYMDHMS: fixed_arity(sa.func.timestamp_from_parts, 6),
         ops.TimestampFromUNIX: lambda t, op: sa.func.to_timestamp(
-            t.translate(op.arg), _TIMESTAMP_UNITS_TO_SCALE[op.unit]
+            t.translate(op.arg), _TIMESTAMP_UNITS_TO_SCALE[op.unit.short]
         ),
         ops.StructField: lambda t, op: sa.cast(
             sa.func.get(t.translate(op.arg), op.field), t.get_sqla_type(op.output_dtype)

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -24,6 +24,7 @@ import sqlalchemy as sa
 import toolz
 from sqlalchemy.dialects.sqlite import DATETIME, TIMESTAMP
 
+import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 from ibis import util
 from ibis.backends.base import Database
@@ -31,10 +32,8 @@ from ibis.backends.base.sql.alchemy import BaseAlchemyBackend, to_sqla_type
 from ibis.backends.sqlite import udf
 from ibis.backends.sqlite.compiler import SQLiteCompiler
 from ibis.backends.sqlite.datatypes import parse
-from ibis.expr.schema import datatype
 
 if TYPE_CHECKING:
-    import ibis.expr.datatypes as dt
     import ibis.expr.types as ir
 
 
@@ -140,7 +139,7 @@ class Backend(BaseAlchemyBackend):
             # easier than subclassing the builtin SQLite dialect, and achieves
             # the same desired behavior.
             def _to_ischema_val(t):
-                sa_type = to_sqla_type(engine.dialect, datatype(t))
+                sa_type = to_sqla_type(engine.dialect, dt.dtype(t))
                 if isinstance(sa_type, sa.types.TypeEngine):
                     # SQLAlchemy expects a callable here, rather than an
                     # instance. Use a lambda to work around this.

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -104,7 +104,7 @@ def _truncate(func):
     def translator(t, op):
         sa_arg = t.translate(op.arg)
         try:
-            modifier = _truncate_modifiers[op.unit]
+            modifier = _truncate_modifiers[op.unit.short]
         except KeyError:
             raise com.UnsupportedOperationError(
                 f'Unsupported truncate unit {op.unit!r}'

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -110,17 +110,18 @@ def _timestamp_from_unix(t, op):
     arg, unit = op.args
     arg = t.translate(arg)
 
-    if unit == "ms":
+    unit_short = unit.short
+    if unit_short == "ms":
         try:
             arg //= 1_000
         except TypeError:
             arg = sa.func.floor(arg / 1_000)
         return sa.func.from_unixtime(arg)
-    elif unit == "s":
+    elif unit_short == "s":
         return sa.func.from_unixtime(arg)
-    elif unit == "us":
+    elif unit_short == "us":
         return sa.func.from_unixtime_nanos((arg - arg % 1_000_000) * 1_000)
-    elif unit == "ns":
+    elif unit_short == "ns":
         return sa.func.from_unixtime_nanos(arg - (arg % 1_000_000_000))
     else:
         raise com.UnsupportedOperationError(f"{unit!r} unit is not supported")

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -100,7 +100,7 @@ _truncate_precisions = {
 def _timestamp_truncate(t, op):
     sa_arg = t.translate(op.arg)
     try:
-        precision = _truncate_precisions[op.unit]
+        precision = _truncate_precisions[op.unit.short]
     except KeyError:
         raise com.UnsupportedOperationError(f'Unsupported truncate unit {op.unit!r}')
     return sa.func.date_trunc(precision, sa_arg)

--- a/ibis/common/enums.py
+++ b/ibis/common/enums.py
@@ -1,0 +1,108 @@
+from abc import ABCMeta
+from enum import Enum, EnumMeta
+
+from public import public
+
+from ibis.common.validators import Coercible
+
+
+class ABCEnumMeta(EnumMeta, ABCMeta):
+    pass
+
+
+class Unit(Coercible, Enum, metaclass=ABCEnumMeta):
+    @classmethod
+    def __coerce__(cls, value):
+        # first look for aliases
+        value = cls.aliases().get(value, value)
+
+        # then look for the enum value (unit value)
+        try:
+            return cls(value)
+        except ValueError:
+            pass
+
+        # then look for the enum name (unit name)
+        if value.endswith("s"):
+            value = value[:-1]
+        try:
+            return cls[value.upper()]
+        except KeyError:
+            raise ValueError(f"Unable to coerce {value} to {cls.__name__}")
+
+    @classmethod
+    def aliases(cls):
+        return {}
+
+    @property
+    def singular(self) -> str:
+        return self.name.lower()
+
+    @property
+    def plural(self) -> str:
+        return self.singular + "s"
+
+    @property
+    def short(self) -> str:
+        return self.value
+
+
+class TemporalUnit(Unit):
+    @classmethod
+    def aliases(cls):
+        return {
+            'd': 'D',
+            'H': 'h',
+            'HH24': 'h',
+            'J': 'D',
+            'MI': 'm',
+            'q': 'Q',
+            'SYYYY': 'Y',
+            'w': 'W',
+            'y': 'Y',
+            'YY': 'Y',
+            'YYY': 'Y',
+            'YYYY': 'Y',
+        }
+
+
+@public
+class DateUnit(TemporalUnit):
+    YEAR = "Y"
+    QUARTER = "Q"
+    MONTH = "M"
+    WEEK = "W"
+    DAY = "D"
+
+
+@public
+class TimeUnit(TemporalUnit):
+    HOUR = "h"
+    MINUTE = "m"
+    SECOND = "s"
+    MILLISECOND = "ms"
+    MICROSECOND = "us"
+    NANOSECOND = "ns"
+
+
+@public
+class TimestampUnit(TemporalUnit):
+    SECOND = "s"
+    MILLISECOND = "ms"
+    MICROSECOND = "us"
+    NANOSECOND = "ns"
+
+
+@public
+class IntervalUnit(TemporalUnit):
+    YEAR = "Y"
+    QUARTER = "Q"
+    MONTH = "M"
+    WEEK = "W"
+    DAY = "D"
+    HOUR = "h"
+    MINUTE = "m"
+    SECOND = "s"
+    MILLISECOND = "ms"
+    MICROSECOND = "us"
+    NANOSECOND = "ns"

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -343,9 +343,7 @@ def endswith_d(x, this):
 
 def test_annotated_function_with_complex_type_annotations():
     @annotated
-    def test(
-        a: Annotated[str, short_str, endswith_d], b: Union[int, float]
-    ):
+    def test(a: Annotated[str, short_str, endswith_d], b: Union[int, float]):
         return a, b
 
     assert test("abcd", 1) == ("abcd", 1)

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -344,7 +344,7 @@ def endswith_d(x, this):
 def test_annotated_function_with_complex_type_annotations():
     @annotated
     def test(
-        a: Annotated[str, short_str, endswith_d], b: Union[int, float]  # noqa: UP007
+        a: Annotated[str, short_str, endswith_d], b: Union[int, float]
     ):
         return a, b
 

--- a/ibis/common/tests/test_enums.py
+++ b/ibis/common/tests/test_enums.py
@@ -1,0 +1,55 @@
+import pytest
+
+from ibis.common.enums import IntervalUnit
+from ibis.common.validators import coerced_to
+
+interval_units = pytest.mark.parametrize(
+    ["singular", "plural", "short"],
+    [
+        ("year", "years", "Y"),
+        ("quarter", "quarters", "Q"),
+        ("month", "months", "M"),
+        ("week", "weeks", "W"),
+        ("day", "days", "D"),
+        ("hour", "hours", "h"),
+        ("minute", "minutes", "m"),
+        ("second", "seconds", "s"),
+        ("millisecond", "milliseconds", "ms"),
+        ("microsecond", "microseconds", "us"),
+        ("nanosecond", "nanoseconds", "ns"),
+    ],
+)
+
+
+@interval_units
+def test_interval_units(singular, plural, short):
+    u = IntervalUnit[singular.upper()]
+    assert u.singular == singular
+    assert u.plural == plural
+    assert u.short == short
+
+
+@interval_units
+def test_interval_unit_coercions(singular, plural, short):
+    u = IntervalUnit[singular.upper()]
+    v = coerced_to(IntervalUnit)
+    assert v(singular) == u
+    assert v(plural) == u
+    assert v(short) == u
+
+
+@pytest.mark.parametrize(
+    ("alias", "expected"),
+    [
+        ("HH24", "h"),
+        ("J", "D"),
+        ("MI", "m"),
+        ("SYYYY", "Y"),
+        ("YY", "Y"),
+        ("YYY", "Y"),
+        ("YYYY", "Y"),
+    ],
+)
+def test_interval_unit_aliases(alias, expected):
+    v = coerced_to(IntervalUnit)
+    assert v(alias) == IntervalUnit(expected)

--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -33,7 +33,7 @@ _READER_FUNCS = {"csv": "read_csv", "csv.gz": "read_csv", "parquet": "read_parqu
 
 
 class Example(Concrete):
-    descr: Optional[str]  # noqa: UP007
+    descr: Optional[str]
     key: str
     reader: str
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -16,14 +16,11 @@ from multipledispatch import Dispatcher
 from public import public
 from typing_extensions import get_args, get_origin, get_type_hints
 
-from ibis.common.annotations import attribute, optional
+from ibis.common.annotations import attribute
 from ibis.common.collections import FrozenDict, MapSet
+from ibis.common.enums import IntervalUnit
 from ibis.common.grounds import Concrete, Singleton
-from ibis.common.validators import (
-    Coercible,
-    map_to,
-)
-from enum import Enum
+from ibis.common.validators import Coercible
 
 # TODO(kszucs): we don't support union types yet
 
@@ -616,59 +613,11 @@ class Decimal(Numeric, Parametric):
         return f"({', '.join(args)})"
 
 
-class TemporalUnit(Enum):
-
-    YEAR = "Y"
-    QUARTER = "Q"
-    MONTH = "M"
-    WEEK = "W"
-    DAY = "D"
-    HOUR = "h"
-    MINUTE = "m"
-    SECOND = "s"
-    MILLISECOND = "ms"
-    MICROSECOND = "us"
-    NANOSECOND = "ns"
-
-    @property
-    def singular(self) -> str:
-        return self.name.lower()
-
-    @property
-    def plural(self) -> str:
-        return self.singular + "s"
-
-    @property
-    def short(self) -> str:
-        return self.value
-
-
 @public
 class Interval(Parametric):
     """Interval values."""
 
-    __valid_units__ = {
-        'days': 'D',
-        'hours': 'h',
-        'minutes': 'm',
-        'seconds': 's',
-        'milliseconds': 'ms',
-        'microseconds': 'us',
-        'nanoseconds': 'ns',
-        'Y': 'Y',
-        'Q': 'Q',
-        'M': 'M',
-        'W': 'W',
-        'D': 'D',
-        'h': 'h',
-        'm': 'm',
-        's': 's',
-        'ms': 'ms',
-        'us': 'us',
-        'ns': 'ns',
-    }
-
-    unit = optional(map_to(__valid_units__), default='s')
+    unit: IntervalUnit = 's'
     """The time unit of the interval."""
 
     value_type: Integer = Int32()
@@ -676,21 +625,6 @@ class Interval(Parametric):
 
     scalar = "IntervalScalar"
     column = "IntervalColumn"
-
-    # based on numpy's units
-    _units = {
-        'Y': 'year',
-        'Q': 'quarter',
-        'M': 'month',
-        'W': 'week',
-        'D': 'day',
-        'h': 'hour',
-        'm': 'minute',
-        's': 'second',
-        'ms': 'millisecond',
-        'us': 'microsecond',
-        'ns': 'nanosecond',
-    }
 
     # TODO(kszucs): assert that the nullability if the value_type is equal
     # to the interval's nullability
@@ -702,7 +636,7 @@ class Interval(Parametric):
     @property
     def resolution(self):
         """The interval unit's name."""
-        return self._units[self.unit]
+        return self.unit.singular
 
     @property
     def _pretty_piece(self) -> str:

--- a/ibis/expr/datatypes/parse.py
+++ b/ibis/expr/datatypes/parse.py
@@ -148,7 +148,7 @@ def parse(
 
     interval = spaceless_string("interval").then(
         parsy.seq(
-            value_type=angle_type.optional(), unit=parened_string.optional("s")
+            value_type=angle_type.optional(dt.int32), unit=parened_string.optional("s")
         ).combine_dict(dt.Interval)
     )
 

--- a/ibis/expr/datatypes/tests/test_parse.py
+++ b/ibis/expr/datatypes/tests/test_parse.py
@@ -234,7 +234,7 @@ def test_parse_interval_with_invalid_value_type():
         dt.dtype("interval<float>('s')")
 
 
-@pytest.mark.parametrize('unit', ['H', 'unsupported'])
+@pytest.mark.parametrize('unit', ['X', 'unsupported'])
 def test_parse_interval_with_invalid_unit(unit):
     definition = f"interval('{unit}')"
     with pytest.raises(ValueError):

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -568,7 +568,7 @@ def _fmt_value_negate(op: ops.Negate, *, aliases: Aliases) -> str:
 @fmt_value.register
 def _fmt_value_literal(op: ops.Literal, **_: Any) -> str:
     if op.dtype.is_interval():
-        return f"{op.value} {op.dtype.unit}"
+        return f"{op.value} {op.dtype.unit.short}"
     return repr(op.value)
 
 

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import operator
 
-import toolz
 from public import public
 
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis import util
 from ibis.common.annotations import attribute
+from ibis.common.enums import DateUnit, IntervalUnit, TimestampUnit, TimeUnit
 from ibis.expr.operations.core import Binary, Unary, Value
 from ibis.expr.operations.generic import Cast
 from ibis.expr.operations.logical import Between
@@ -75,13 +75,11 @@ _time_units = {
     'NANOSECOND': 'ns',
 }
 
-_timestamp_units = toolz.merge(_date_units, _time_units)
-
 
 @public
 class TimestampTruncate(Value):
     arg = rlz.timestamp
-    unit = rlz.map_to(_timestamp_units)
+    unit = rlz.coerced_to(IntervalUnit)
 
     output_shape = rlz.shape_like("arg")
     output_dtype = dt.timestamp
@@ -90,7 +88,7 @@ class TimestampTruncate(Value):
 @public
 class DateTruncate(Value):
     arg = rlz.date
-    unit = rlz.map_to(_date_units)
+    unit = rlz.coerced_to(DateUnit)
 
     output_shape = rlz.shape_like("arg")
     output_dtype = dt.date
@@ -99,7 +97,7 @@ class DateTruncate(Value):
 @public
 class TimeTruncate(Value):
     arg = rlz.time
-    unit = rlz.map_to(_time_units)
+    unit = rlz.coerced_to(TimeUnit)
 
     output_shape = rlz.shape_like("arg")
     output_dtype = dt.time
@@ -251,7 +249,7 @@ class TimestampFromYMDHMS(Value):
 @public
 class TimestampFromUNIX(Value):
     arg = rlz.any
-    unit = rlz.isin({'s', 'ms', 'us', 'ns'})
+    unit = rlz.coerced_to(TimestampUnit)
 
     output_dtype = dt.timestamp
     output_shape = rlz.shape_like('arg')
@@ -327,7 +325,7 @@ class TimestampDiff(Binary):
 @public
 class ToIntervalUnit(Value):
     arg = rlz.interval
-    unit = rlz.isin({'Y', 'Q', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'})
+    unit = rlz.coerced_to(IntervalUnit)
 
     output_shape = rlz.shape_like("arg")
 
@@ -337,7 +335,7 @@ class ToIntervalUnit(Value):
         # TODO(kszucs): remove the expression wrapping required for arithmetic
         # overloads
         if dtype.unit != unit:
-            arg = util.convert_unit(arg, dtype.unit, unit)
+            arg = util.convert_unit(arg, dtype.unit.short, unit.short)
         super().__init__(arg=arg, unit=unit)
 
     @attribute.default
@@ -391,7 +389,7 @@ class IntervalFloorDivide(IntervalBinary):
 @public
 class IntervalFromInteger(Value):
     arg = rlz.integer
-    unit = rlz.isin({'Y', 'Q', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', 'ns'})
+    unit = rlz.coerced_to(IntervalUnit)
 
     output_shape = rlz.shape_like("arg")
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -328,7 +328,7 @@ multipolygon = value(dt.MultiPolygon)
 @rule
 def interval(arg, units=None, **kwargs):
     arg = value(dt.Interval, arg)
-    unit = arg.output_dtype.unit
+    unit = arg.output_dtype.unit.short
     if units is not None and unit not in units:
         msg = 'Interval unit `{}` is not among the allowed ones {}'
         raise com.IbisTypeError(msg.format(unit, units))

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -7,10 +7,10 @@ from multipledispatch import Dispatcher
 
 import ibis.expr.datatypes as dt
 from ibis.common.annotations import attribute
-from ibis.common.collections import MapSet
+from ibis.common.collections import FrozenDict, MapSet
 from ibis.common.exceptions import IntegrityError
 from ibis.common.grounds import Concrete
-from ibis.common.validators import Coercible, frozendict_of, instance_of, validator
+from ibis.common.validators import Coercible
 from ibis.util import indent
 
 if TYPE_CHECKING:
@@ -39,15 +39,10 @@ result : pd.Series
 )
 
 
-@validator
-def datatype(arg, **kwargs):
-    return dt.dtype(arg)
-
-
 class Schema(Concrete, Coercible, MapSet):
     """An object for holding table schema information."""
 
-    fields = frozendict_of(instance_of(str), datatype)
+    fields: FrozenDict[str, dt.DataType]
     """A mapping of [`str`][str] to [`DataType`][ibis.expr.datatypes.DataType] objects
     representing the type of each column."""
 

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -8,6 +8,7 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
+from ibis.common.enums import IntervalUnit
 from ibis.expr import api
 
 
@@ -71,7 +72,7 @@ def test_cannot_upconvert(delta, target):
 )
 def test_multiply(expr):
     assert isinstance(expr, ir.IntervalScalar)
-    assert expr.type().unit == 'D'
+    assert expr.type().unit == IntervalUnit('D')
 
 
 @pytest.mark.parametrize(
@@ -83,7 +84,7 @@ def test_multiply(expr):
 )
 def test_add(expr):
     assert isinstance(expr, ir.IntervalScalar)
-    assert expr.type().unit == 'D'
+    assert expr.type().unit == IntervalUnit('D')
 
 
 @pytest.mark.parametrize(
@@ -95,7 +96,7 @@ def test_add(expr):
 )
 def test_subtract(expr):
     assert isinstance(expr, ir.IntervalScalar)
-    assert expr.type().unit == 'D'
+    assert expr.type().unit == IntervalUnit('D')
 
 
 @pytest.mark.parametrize(
@@ -210,7 +211,7 @@ def test_downconvert_day(case, expected):
     ],
 )
 def test_combine_with_different_kinds(a, b, unit):
-    assert (a + b).type().unit == unit
+    assert (a + b).type().unit == IntervalUnit(unit)
 
 
 @pytest.mark.parametrize(
@@ -474,7 +475,7 @@ def test_invalid_date_arithmetics():
 )
 def test_interval_properties(prop, expected_unit):
     i = api.interval(seconds=3600)
-    assert getattr(i, prop).type().unit == expected_unit
+    assert getattr(i, prop).type().unit == IntervalUnit(expected_unit)
 
 
 @pytest.mark.parametrize(
@@ -486,7 +487,7 @@ def test_interval_properties(prop, expected_unit):
     [('months', 'M'), ('quarters', 'Q'), ('years', 'Y')],
 )
 def test_interval_monthly_properties(interval, prop, expected_unit):
-    assert getattr(interval, prop).type().unit == expected_unit
+    assert getattr(interval, prop).type().unit == IntervalUnit(expected_unit)
 
 
 @pytest.mark.parametrize(
@@ -511,7 +512,7 @@ def test_integer_to_interval(column, unit, table):
     i = c.to_interval(unit)
     assert isinstance(i, ir.IntervalColumn)
     assert i.type().value_type == c.type()
-    assert i.type().unit == unit
+    assert i.type().unit == IntervalUnit(unit)
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -8,6 +8,7 @@ import hypothesis.strategies as st
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
+from ibis.common.enums import IntervalUnit
 
 # pyarrow also has hypothesis strategies various pyarrow objects
 
@@ -52,7 +53,7 @@ time_dtype = st.builds(dt.Time, nullable=nullable)
 timestamp_dtype = st.builds(
     dt.Timestamp, timezone=st.none() | tzst.timezones().map(str), nullable=nullable
 )
-interval_unit = st.sampled_from(list(dt.Interval.__valid_units__.keys()))
+interval_unit = st.sampled_from(list(IntervalUnit))
 interval_dtype = st.builds(
     dt.Interval, unit=interval_unit, value_type=integer_dtypes, nullable=nullable
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -371,7 +371,6 @@ select = [
   "UP", # pyupgrade
   "W", # pycodestyle
   "YTT", # flake8-2020
-
 ]
 respect-gitignore = true
 ignore = [
@@ -414,7 +413,7 @@ ignore = [
   "SIM118", # remove .keys() calls from dictionaries
   "SIM300", # yoda conditions
   "UP037", # remove quotes from type annotation
-
+  "UP007", # Optional[str] -> str | None
 ]
 exclude = ["*_py310.py", "ibis/tests/*/snapshots/*"]
 target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -371,6 +371,7 @@ select = [
   "UP", # pyupgrade
   "W", # pycodestyle
   "YTT", # flake8-2020
+
 ]
 respect-gitignore = true
 ignore = [
@@ -414,6 +415,7 @@ ignore = [
   "SIM300", # yoda conditions
   "UP037", # remove quotes from type annotation
   "UP007", # Optional[str] -> str | None
+
 ]
 exclude = ["*_py310.py", "ibis/tests/*/snapshots/*"]
 target-version = "py38"


### PR DESCRIPTION
Depends on #5847

- switched to use type annotations in `datatypes/core.py` and `schema.py` instead of rules
- introduced enum classes to handle temporal units, these enums can be used in annotations to automatically coerce variants of different units