### PR TITLE
refactor(api): remove deprecated `Table.sort_by()` and `Table.groupby()` methods

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -25,7 +25,6 @@ from ibis.expr.types.core import Expr, _FixedTextJupyterMixin
 if TYPE_CHECKING:
     import pandas as pd
 
-    import ibis.expr.schema as sch
     import ibis.expr.selectors as s
     import ibis.expr.types as ir
     from ibis.common.typing import SupportsSchema
@@ -542,22 +541,6 @@ class Table(Expr, _FixedTextJupyterMixin):
         """
         with contextlib.suppress(com.IbisTypeError):
             return ops.TableColumn(self, key).to_expr()
-
-        # Handle deprecated `groupby` and `sort_by` methods
-        if key == "groupby":
-            warnings.warn(
-                "`Table.groupby` is deprecated and will be removed in 5.0, "
-                "use `Table.group_by` instead",
-                FutureWarning,
-            )
-            return self.group_by
-        elif key == "sort_by":
-            warnings.warn(
-                "`Table.sort_by` is deprecated and will be removed in 5.0, "
-                "use `Table.order_by` instead",
-                FutureWarning,
-            )
-            return self.order_by
 
         # A mapping of common attribute typos, mapping them to the proper name
         common_typos = {

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -412,13 +412,6 @@ def test_limit(table):
     assert limited.op().offset == 5
 
 
-def test_sort_by_deprecated(table):
-    with pytest.warns(FutureWarning):
-        x = table.sort_by("f")
-    y = table.order_by("f")
-    assert x.equals(y)
-
-
 def test_order_by(table):
     result = table.order_by(['f']).op()
 
@@ -616,13 +609,6 @@ def test_aggregate_keywords(table):
 
     assert_equal(expr, expected)
     assert_equal(expr2, expected)
-
-
-def test_groupby_alias(table):
-    expected = table.group_by('g').size()
-    with pytest.warns(FutureWarning, match="deprecated"):
-        result = table.groupby('g').size()
-    assert_equal(result, expected)
 
 
 def test_filter_aggregate_pushdown_predicate(table):


### PR DESCRIPTION
BREAKING CHANGE: removed `Table.sort_by()` and `Table.groupby()`, use `.order_by()` and `.group_by()` respectively
