### PR TITLE
ci: constrain mamba because later versions are broken

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -28,15 +28,15 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          mamba-version: "*"
+          mamba-version: "1.1.0"
           miniforge-version: latest
           miniforge-variant: Mambaforge
           activate-environment: conda-lock
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           condarc-file: ci/conda-lock/condarc
 
       - name: install conda-lock
-        run: mamba install 'conda-lock>=1.4'
+        run: mamba install 'conda-lock=1.4'
 
       - name: generate lock file
         run: ./ci/conda-lock/generate.sh "${{ matrix.python-version }}"


### PR DESCRIPTION
This PR constrains mamba to a version that works for me to generate lock files. The current version running in CI seems to be broken.