### PR TITLE
ci: avoid building macos nix devShell

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -67,7 +67,7 @@ jobs:
           nix build ".#ibis${version//./}" --fallback --keep-going --print-build-logs
 
       - name: nix build devShell
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && matrix.os != 'macos-latest'
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Avoid build the nix macos devShell so that CI finishes faster. Right now the job is building duckdb, and it is not clear that anyone is using the nix setup for macos. The devShell step is intended to populate the environment cache, so we do not need it for macos, but we should keep the previous test step so that we have some coverage of macos.