### PR TITLE
feat: rethink join column deduplication

### DIFF
--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -81,7 +81,11 @@ def test_context_adjustment_asof_join(
     time_keyed_left, time_keyed_right, time_keyed_df1, time_keyed_df2
 ):
     expr = time_keyed_left.asof_join(
-        time_keyed_right, 'time', by='key', tolerance=4 * ibis.interval(days=1)
+        time_keyed_right,
+        'time',
+        by='key',
+        tolerance=4 * ibis.interval(days=1),
+        rname="{name}_y",
     )[time_keyed_left, time_keyed_right.other_value]
     context = (Timestamp('20170105'), Timestamp('20170111'))
     result = expr.execute(timecontext=context)

--- a/ibis/backends/dask/tests/test_core.py
+++ b/ibis/backends/dask/tests/test_core.py
@@ -92,7 +92,7 @@ def test_post_execute_called_on_joins(dataframe, core_client, ibis_table):
 
     left = ibis_table
     right = left.view()
-    join = left.join(right, 'plain_strings')[left.plain_int64]
+    join = left.join(right, 'plain_strings', rname="{name}_y")[left.plain_int64]
     result = join.execute()
     assert result is not None
     assert len(result.index) > 0

--- a/ibis/backends/pandas/tests/execution/test_join.py
+++ b/ibis/backends/pandas/tests/execution/test_join.py
@@ -10,10 +10,12 @@ mutating_join_type = pytest.mark.parametrize(
     ['inner', 'left', 'right', 'outer'],
 )
 
+kws = {"lname": "{name}_x", "rname": "{name}_y"}
+
 
 @mutating_join_type
 def test_join(how, left, right, df1, df2):
-    expr = left.join(right, left.key == right.key, how=how)[
+    expr = left.join(right, left.key == right.key, how=how, **kws)[
         left, right.other_value, right.key3
     ]
     result = expr.execute()
@@ -22,7 +24,7 @@ def test_join(how, left, right, df1, df2):
 
 
 def test_cross_join(left, right, df1, df2):
-    expr = left.cross_join(right)[left, right.other_value, right.key3]
+    expr = left.cross_join(right, **kws)[left, right.other_value, right.key3]
     result = expr.execute()
     expected = pd.merge(
         df1.assign(dummy=1), df2.assign(dummy=1), how='inner', on='dummy'
@@ -33,14 +35,14 @@ def test_cross_join(left, right, df1, df2):
 
 @mutating_join_type
 def test_join_project_left_table(how, left, right, df1, df2):
-    expr = left.join(right, left.key == right.key, how=how)[left, right.key3]
+    expr = left.join(right, left.key == right.key, how=how, **kws)[left, right.key3]
     result = expr.execute()
     expected = pd.merge(df1, df2, how=how, on='key')[list(left.columns) + ['key3']]
     tm.assert_frame_equal(result[expected.columns], expected)
 
 
 def test_cross_join_project_left_table(left, right, df1, df2):
-    expr = left.cross_join(right)[left, right.key3]
+    expr = left.cross_join(right, **kws)[left, right.key3]
     result = expr.execute()
     expected = pd.merge(
         df1.assign(dummy=1), df2.assign(dummy=1), how='inner', on='dummy'
@@ -50,9 +52,9 @@ def test_cross_join_project_left_table(left, right, df1, df2):
 
 @mutating_join_type
 def test_join_with_multiple_predicates(how, left, right, df1, df2):
-    expr = left.join(right, [left.key == right.key, left.key2 == right.key3], how=how)[
-        left, right.key3, right.other_value
-    ]
+    expr = left.join(
+        right, [left.key == right.key, left.key2 == right.key3], how=how, **kws
+    )[left, right.key3, right.other_value]
     result = expr.execute()
     expected = pd.merge(
         df1, df2, how=how, left_on=['key', 'key2'], right_on=['key', 'key3']
@@ -63,7 +65,9 @@ def test_join_with_multiple_predicates(how, left, right, df1, df2):
 @mutating_join_type
 def test_join_with_multiple_predicates_written_as_one(how, left, right, df1, df2):
     predicate = (left.key == right.key) & (left.key2 == right.key3)
-    expr = left.join(right, predicate, how=how)[left, right.key3, right.other_value]
+    expr = left.join(right, predicate, how=how, **kws)[
+        left, right.key3, right.other_value
+    ]
     result = expr.execute()
     expected = pd.merge(
         df1, df2, how=how, left_on=['key', 'key2'], right_on=['key', 'key3']
@@ -74,12 +78,12 @@ def test_join_with_multiple_predicates_written_as_one(how, left, right, df1, df2
 @mutating_join_type
 def test_join_with_invalid_predicates(how, left, right):
     predicate = (left.key == right.key) & (left.key2 <= right.key3)
-    expr = left.join(right, predicate, how=how)
+    expr = left.join(right, predicate, how=how, **kws)
     with pytest.raises(TypeError):
         expr.execute()
 
     predicate = left.key >= right.key
-    expr = left.join(right, predicate, how=how)
+    expr = left.join(right, predicate, how=how, **kws)
     with pytest.raises(TypeError):
         expr.execute()
 
@@ -89,7 +93,7 @@ def test_join_with_invalid_predicates(how, left, right):
 def test_join_with_duplicate_non_key_columns(how, left, right):
     left = left.mutate(x=left.value * 2)
     right = right.mutate(x=right.other_value * 3)
-    expr = left.join(right, left.key == right.key, how=how)
+    expr = left.join(right, left.key == right.key, how=how, **kws)
 
     # This is undefined behavior because `x` is duplicated. This is difficult
     # to detect
@@ -102,7 +106,9 @@ def test_join_with_duplicate_non_key_columns_not_selected(how, left, right, df1,
     left = left.mutate(x=left.value * 2)
     right = right.mutate(x=right.other_value * 3)
     right = right[['key', 'other_value']]
-    expr = left.join(right, left.key == right.key, how=how)[left, right.other_value]
+    expr = left.join(right, left.key == right.key, how=how, **kws)[
+        left, right.other_value
+    ]
     result = expr.execute()
     expected = pd.merge(
         df1.assign(x=df1.value * 2),
@@ -115,7 +121,7 @@ def test_join_with_duplicate_non_key_columns_not_selected(how, left, right, df1,
 
 @mutating_join_type
 def test_join_with_post_expression_selection(how, left, right, df1, df2):
-    join = left.join(right, left.key == right.key, how=how)
+    join = left.join(right, left.key == right.key, how=how, **kws)
     expr = join[left.key, left.value, right.other_value]
     result = expr.execute()
     expected = pd.merge(df1, df2, on='key', how=how)[['key', 'value', 'other_value']]
@@ -127,7 +133,7 @@ def test_join_with_post_expression_filter(how, left):
     lhs = left[['key', 'key2']]
     rhs = left[['key2', 'value']]
 
-    joined = lhs.join(rhs, 'key2', how=how)
+    joined = lhs.join(rhs, 'key2', how=how, **kws)
     projected = joined[lhs, rhs.value]
     expr = projected[projected.value == 4]
     result = expr.execute()
@@ -146,11 +152,11 @@ def test_multi_join_with_post_expression_filter(how, left, df1):
     rhs = left[['key2', 'value']]
     rhs2 = left[['key2', 'value']].relabel({'value': 'value2'})
 
-    joined = lhs.join(rhs, 'key2', how=how)
+    joined = lhs.join(rhs, 'key2', how=how, **kws)
     projected = joined[lhs, rhs.value]
     filtered = projected[projected.value == 4]
 
-    joined2 = filtered.join(rhs2, 'key2')
+    joined2 = filtered.join(rhs2, 'key2', **kws)
     projected2 = joined2[filtered.key, rhs2.value2]
     expr = projected2[projected2.value2 == 3]
 
@@ -170,7 +176,7 @@ def test_multi_join_with_post_expression_filter(how, left, df1):
 @mutating_join_type
 def test_join_with_non_trivial_key(how, left, right, df1, df2):
     # also test that the order of operands in the predicate doesn't matter
-    join = left.join(right, right.key.length() == left.key.length(), how=how)
+    join = left.join(right, right.key.length() == left.key.length(), how=how, **kws)
     expr = join[left.key, left.value, right.other_value]
     result = expr.execute()
 
@@ -190,7 +196,7 @@ def test_join_with_non_trivial_key(how, left, right, df1, df2):
 @mutating_join_type
 def test_join_with_non_trivial_key_project_table(how, left, right, df1, df2):
     # also test that the order of operands in the predicate doesn't matter
-    join = left.join(right, right.key.length() == left.key.length(), how=how)
+    join = left.join(right, right.key.length() == left.key.length(), how=how, **kws)
     expr = join[left, right.other_value]
     expr = expr[expr.key.length() == 1]
     result = expr.execute()
@@ -213,7 +219,7 @@ def test_join_with_non_trivial_key_project_table(how, left, right, df1, df2):
 def test_join_with_project_right_duplicate_column(client, how, left, df1, df3):
     # also test that the order of operands in the predicate doesn't matter
     right = client.table('df3')
-    join = left.join(right, ['key'], how=how)
+    join = left.join(right, ['key'], how=how, **kws)
     expr = join[left.key, right.key2, right.other_value]
     result = expr.execute()
 
@@ -229,7 +235,7 @@ def test_join_with_window_function(players_base, players_df, batting, batting_df
     players = players_base
 
     # this should be semi_join
-    tbl = batting.left_join(players, ['playerID'])
+    tbl = batting.left_join(players, ['playerID'], **kws)
     t = tbl[batting.G, batting.playerID, batting.teamID]
     expr = t.group_by(t.teamID).mutate(
         team_avg=lambda d: d.G.mean(),
@@ -256,7 +262,9 @@ merge_asof_minversion = pytest.mark.skipif(
 
 @merge_asof_minversion
 def test_asof_join(time_left, time_right, time_df1, time_df2):
-    expr = time_left.asof_join(time_right, 'time')[time_left, time_right.other_value]
+    expr = time_left.asof_join(time_right, 'time', **kws)[
+        time_left, time_right.other_value
+    ]
     result = expr.execute()
     expected = pd.merge_asof(time_df1, time_df2, on='time')
     tm.assert_frame_equal(result[expected.columns], expected)
@@ -264,7 +272,7 @@ def test_asof_join(time_left, time_right, time_df1, time_df2):
 
 @merge_asof_minversion
 def test_asof_join_predicate(time_left, time_right, time_df1, time_df2):
-    expr = time_left.asof_join(time_right, time_left.time == time_right.time)[
+    expr = time_left.asof_join(time_right, time_left.time == time_right.time, **kws)[
         time_left, time_right.other_value
     ]
     result = expr.execute()
@@ -276,7 +284,7 @@ def test_asof_join_predicate(time_left, time_right, time_df1, time_df2):
 def test_keyed_asof_join(
     time_keyed_left, time_keyed_right, time_keyed_df1, time_keyed_df2
 ):
-    expr = time_keyed_left.asof_join(time_keyed_right, 'time', by='key')[
+    expr = time_keyed_left.asof_join(time_keyed_right, 'time', by='key', **kws)[
         time_keyed_left, time_keyed_right.other_value
     ]
     result = expr.execute()
@@ -289,7 +297,7 @@ def test_keyed_asof_join_with_tolerance(
     time_keyed_left, time_keyed_right, time_keyed_df1, time_keyed_df2
 ):
     expr = time_keyed_left.asof_join(
-        time_keyed_right, 'time', by='key', tolerance=2 * ibis.interval(days=1)
+        time_keyed_right, 'time', by='key', tolerance=2 * ibis.interval(days=1), **kws
     )[time_keyed_left, time_keyed_right.other_value]
     result = expr.execute()
     expected = pd.merge_asof(
@@ -351,7 +359,7 @@ def test_select_on_unambiguous_asof_join(func):
     con = ibis.pandas.connect({"t": df_t, "s": df_s})
     t = con.table("t")
     s = con.table("s")
-    join = t.asof_join(s, t.b1 == s.b2)
+    join = t.asof_join(s, t.b1 == s.b2, **kws)
     expected = pd.merge_asof(df_t, df_s, left_on=["b1"], right_on=["b2"])[["a0", "a1"]]
     assert not expected.empty
     expr = func(join)
@@ -369,8 +377,7 @@ def test_outer_join():
     ibis_table_2 = conn.table("df_2")
 
     joined = ibis_table_1.outer_join(
-        ibis_table_2,
-        predicates=ibis_table_1["test"] == ibis_table_2["test_2"],
+        ibis_table_2, predicates=ibis_table_1["test"] == ibis_table_2["test_2"], **kws
     )
     result = joined.execute()
     expected = pd.merge(
@@ -410,6 +417,7 @@ def test_mutate_after_join():
         predicates=(
             ibis_table_1["p_Order_Priority"] == ibis_table_2["q_Order_Priority"]
         ),
+        **kws,
     )
 
     joined = joined.mutate(
@@ -538,12 +546,10 @@ def test_multijoin(tracts_df, fields_df, harvest_df):
     tracts, fields, harvest = map(conn.table, "tracts fields harvest".split())
 
     fielded = harvest.inner_join(
-        fields,
-        harvest.harvest_field_id == fields.field_id,
+        fields, harvest.harvest_field_id == fields.field_id, **kws
     )
     tracted = fielded.inner_join(
-        tracts,
-        fielded.field_tract_id == tracts.tract_id,
+        tracts, fielded.field_tract_id == tracts.tract_id, **kws
     )
     result = tracted.execute()
 

--- a/ibis/backends/pandas/tests/execution/test_timecontext.py
+++ b/ibis/backends/pandas/tests/execution/test_timecontext.py
@@ -92,7 +92,11 @@ def test_context_adjustment_asof_join(
     time_keyed_left, time_keyed_right, time_keyed_df1, time_keyed_df2
 ):
     expr = time_keyed_left.asof_join(
-        time_keyed_right, 'time', by='key', tolerance=4 * ibis.interval(days=1)
+        time_keyed_right,
+        'time',
+        by='key',
+        tolerance=4 * ibis.interval(days=1),
+        rname="{name}_y",
     )[time_keyed_left, time_keyed_right.other_value]
     context = (pd.Timestamp('20170105'), pd.Timestamp('20170111'))
     result = expr.execute(timecontext=context)

--- a/ibis/backends/pandas/tests/test_core.py
+++ b/ibis/backends/pandas/tests/test_core.py
@@ -109,7 +109,7 @@ def test_post_execute_called_on_joins(dataframe, core_client, ibis_table):
 
     left = ibis_table
     right = left.view()
-    join = left.join(right, 'plain_strings')[left.plain_int64]
+    join = left.join(right, 'plain_strings', rname="{name}_y")[left.plain_int64]
     result = join.execute()
     assert result is not None
     assert not result.empty

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -121,7 +121,10 @@ def test_limit_chain(alltypes, expr_fn):
     "expr_fn",
     [
         param(lambda t: t, id="alltypes table"),
-        param(lambda t: t.join(t.view(), t.id == t.view().int_col), id="self join"),
+        param(
+            lambda t: t.join(t.view(), t.id == t.view().int_col, rname="{name}_y"),
+            id="self join",
+        ),
     ],
 )
 def test_unbind(alltypes, expr_fn):

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -88,7 +88,7 @@ def test_mutating_join(backend, batting, awards_players, how):
     predicate = ['playerID']
     result_order = ['playerID', 'yearID', 'lgID', 'stint']
 
-    expr = left.join(right, predicate, how=how)
+    expr = left.join(right, predicate, how=how, lname="{name}_x", rname="{name}_y")
     if how == "inner":
         result = (
             expr.execute()
@@ -209,7 +209,7 @@ def test_join_with_pandas(batting, awards_players):
     batting_filt = batting[lambda t: t.yearID < 1900]
     awards_players_filt = awards_players[lambda t: t.yearID < 1900].execute()
     assert isinstance(awards_players_filt, pd.DataFrame)
-    expr = batting_filt.join(awards_players_filt, "yearID")
+    expr = batting_filt.join(awards_players_filt, "yearID", rname="{name}_y")
     df = expr.execute()
     assert df.yearID.nunique() == 7
 

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -66,7 +66,7 @@ class ScalarAggregate:
 
         table = self.tables[0]
         for other in self.tables[1:]:
-            table = table.cross_join(other)
+            table = table.cross_join(other, lname="{name}_x", rname="{name}_y")
 
         return table.projection([subbed_expr])
 

--- a/ibis/expr/decompile.py
+++ b/ibis/expr/decompile.py
@@ -162,7 +162,8 @@ def aggregation(op, table, by, metrics, predicates, having, sort_keys):
 @translate.register(ops.Join)
 def join(op, left, right, predicates):
     method = _get_method_name(op)
-    return f"{left}.{method}({right}, {_try_unwrap(predicates)})"
+    preds = _try_unwrap(predicates)
+    return f"{left}.{method}({right}, {preds}, lname='{{name}}_x', rname='{{name}}_y')"
 
 
 @translate.register(ops.SetOp)

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -637,14 +637,21 @@ def _dedup_join_columns(expr, lname: str, rname: str, suffixes: tuple[str, str] 
             ):
                 equal.add(pred.left.name)
 
-    if (suffixes is not None) or ((overlap - equal) and not lname and not rname):
-        # Warn if `suffixes` is explicitly set, or if the join requires column
-        # deduplication and neither `lname` nor `rname` are set
+    if suffixes is not None:
+        # Warn if old suffixes arg is used
         warnings.warn(
-            "The `suffixes` arg (and corresponding behavior) in `join` methods is "
-            "deprecated and will be removed in 6.0. In 6.0 joins with overlapping "
-            "column names will require passing in `lname` or `rname` to explicitly "
-            "resolve the name conflicts.",
+            "The `suffixes` arg is deprecated and will be removed in 6.0. Please "
+            "use `lname` and `rname` instead. If you want to replicate the existing "
+            "behavior exactly, pass in `lname='{name}_x', rname='{name}_y'`.",
+            FutureWarning,
+        )
+    elif (overlap - equal) and not lname and not rname:
+        # join requires column deduplication and neither `lname` nor `rname` are set
+        warnings.warn(
+            "In 6.0 joins resulting in overlapping column names will require passing "
+            "in `lname` and/or `rname` to explicitly resolve the name conflicts. "
+            "If you want to replicate the existing behavior exactly, pass in "
+            "`lname='{name}_x', rname='{name}_y'`.",
             FutureWarning,
         )
 
@@ -653,9 +660,7 @@ def _dedup_join_columns(expr, lname: str, rname: str, suffixes: tuple[str, str] 
 
     if not lname and not rname:
         # Fallback to old behavior
-        if suffixes is None:
-            suffixes = ("_x", "_y")
-        left_suffix, right_suffix = suffixes
+        left_suffix, right_suffix = suffixes or ("_x", "_y")
         lname = "{name}" + left_suffix if left_suffix else ""
         rname = "{name}" + right_suffix if right_suffix else ""
 

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -132,7 +132,11 @@ def convert_join(join, catalog):
                 predicate &= left_key == right_key
 
         catalog[left_name] = left_table.join(
-            right_table, predicates=predicate, how=join_kind
+            right_table,
+            predicates=predicate,
+            how=join_kind,
+            lname="{name}_x",
+            rname="{name}_y",
         )
 
     return catalog[left_name]

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -591,7 +591,7 @@ def test_eq_datatypes(benchmark, dtypes):
 def multiple_joins(table, num_joins):
     for _ in range(num_joins):
         table = table.mutate(dummy=ibis.literal(""))
-        table = table.left_join(table, ["dummy"])[[table]]
+        table = table.left_join(table, ["dummy"], rname="{name}_y")[[table]]
 
 
 @pytest.mark.parametrize("num_joins", [1, 10])

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -25,15 +25,17 @@ def test_rewrite_join_projection_without_other_ops(con):
     pred1 = table['foo_id'] == table2['foo_id']
     pred2 = filtered['bar_id'] == table3['bar_id']
 
-    j1 = filtered.left_join(table2, [pred1])
-    j2 = j1.inner_join(table3, [pred2])
+    j1 = filtered.left_join(table2, [pred1], rname="{name}_y")
+    j2 = j1.inner_join(table3, [pred2], rname="{name}_y")
 
     # Project out the desired fields
     view = j2[[filtered, table2['value1'], table3['value2']]]
 
     # Construct the thing we expect to obtain
     ex_pred2 = table['bar_id'] == table3['bar_id']
-    ex_expr = table.left_join(table2, [pred1]).inner_join(table3, [ex_pred2])
+    ex_expr = table.left_join(table2, [pred1], rname="{name}_y").inner_join(
+        table3, [ex_pred2], rname="{name}_y"
+    )
 
     rewritten_proj = an.substitute_parents(view.op())
 
@@ -137,7 +139,7 @@ def test_filter_self_join():
     right = agged[agged.kind == 'bar']
 
     cond = left.region == right.region
-    joined = left.join(right, cond)
+    joined = left.join(right, cond, rname="{name}_y")
 
     metric = (left.total - right.total).name('diff')
     what = [left.region, metric]

--- a/ibis/tests/expr/test_format.py
+++ b/ibis/tests/expr/test_format.py
@@ -75,8 +75,8 @@ def test_format_multiple_join_with_projection():
     pred1 = filtered['foo_id'] == table2['foo_id']
     pred2 = filtered['bar_id'] == table3['bar_id']
 
-    j1 = filtered.left_join(table2, [pred1])
-    j2 = j1.inner_join(table3, [pred2])
+    j1 = filtered.left_join(table2, [pred1], rname="{name}_y")
+    j2 = j1.inner_join(table3, [pred2], rname="{name}_y")
 
     # Project out the desired fields
     view = j2[[filtered, table2['value1'], table3['value2']]]
@@ -165,7 +165,9 @@ def test_memoize_filtered_tables_in_join():
     right = agged[agged.kind == 'bar']
 
     cond = left.region == right.region
-    joined = left.join(right, cond)[left, right.total.name('right_total')]
+    joined = left.join(right, cond, rname="{name}_y")[
+        left, right.total.name('right_total')
+    ]
 
     result = repr(joined)
 
@@ -279,7 +281,7 @@ def test_tables_have_format_value_rules(cls):
     "f",
     [
         lambda t1, t2: t1.count(),
-        lambda t1, t2: t1.join(t2, t1.a == t2.a).count(),
+        lambda t1, t2: t1.join(t2, t1.a == t2.a, rname="{name}_y").count(),
         lambda t1, t2: ibis.union(t1, t2).count(),
     ],
 )
@@ -322,8 +324,8 @@ def test_fillna():
 def test_asof_join():
     left = ibis.table([("time1", 'int32'), ('value', 'double')])
     right = ibis.table([("time2", 'int32'), ('value2', 'double')])
-    joined = left.asof_join(right, [("time1", "time2")]).inner_join(
-        right, left.value == right.value2
+    joined = left.asof_join(right, [("time1", "time2")], rname="{name}_y").inner_join(
+        right, left.value == right.value2, rname="{name}_y"
     )
     rep = repr(joined)
     assert rep.count("InnerJoin") == 1
@@ -333,8 +335,8 @@ def test_asof_join():
 def test_two_inner_joins():
     left = ibis.table([("time1", 'int32'), ('value', 'double'), ('a', 'string')])
     right = ibis.table([("time2", 'int32'), ('value2', 'double'), ('b', 'string')])
-    joined = left.inner_join(right, left.a == right.b).inner_join(
-        right, left.value == right.value2
+    joined = left.inner_join(right, left.a == right.b, rname="{name}_y").inner_join(
+        right, left.value == right.value2, rname="{name}_y"
     )
     rep = repr(joined)
     assert rep.count("InnerJoin") == 2

--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -67,16 +67,16 @@ def test_unpack_from_table(t):
 
 
 def test_lift_join(t, s):
-    join = t.join(s, t.d == s.a.g)
+    join = t.join(s, t.d == s.a.g, rname="{name}_y")
     result = join.a_y.lift()
     expected = join[_.a_y.f, _.a_y.g]
     assert result.equals(expected)
 
 
 def test_unpack_join_from_table(t, s):
-    join = t.join(s, t.d == s.a.g)
+    join = t.join(s, t.d == s.a.g, rname="{name}_y")
     result = join.unpack("a_y")
-    expected = join[_.a_x, _.d, _.a_y.f, _.a_y.g]
+    expected = join[_.a, _.d, _.a_y.f, _.a_y.g]
     assert result.equals(expected)
 
 

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1341,7 +1341,7 @@ def test_select_on_unambiguous_join(join_method):
 def test_chained_select_on_join():
     t = ibis.table([("a", dt.int64)], name="t")
     s = ibis.table([("a", dt.int64), ("b", dt.string)], name="s")
-    join = t.join(s)[t.a, s.b]
+    join = t.join(s, rname="{name}_y")[t.a, s.b]
     expr1 = join["a", "b"]
     expr2 = join.select(["a", "b"])
     assert expr1.equals(expr2)

--- a/ibis/tests/expr/test_visualize.py
+++ b/ibis/tests/expr/test_visualize.py
@@ -92,7 +92,7 @@ def with_graphviz():
 def test_join(how):
     left = ibis.table([('a', 'int64'), ('b', 'string')])
     right = ibis.table([('b', 'string'), ('c', 'int64')])
-    joined = left.join(right, left.b == right.b, how=how)
+    joined = left.join(right, left.b == right.b, how=how, rname="{name}_y")
     result = joined[left.a, right.c]
     graph = viz.to_graph(result)
     assert key(result.op()) in graph.source
@@ -142,7 +142,7 @@ def test_asof_join():
     right = ibis.table([('time', 'int32'), ('value2', 'double')])
     right = right.mutate(foo=1)
 
-    joined = api.asof_join(left, right, 'time')
+    joined = api.asof_join(left, right, 'time', rname="{name}_y")
     result = joined[left, right.foo]
     graph = viz.to_graph(result)
     assert key(result.op()) in graph.source

--- a/ibis/tests/sql/snapshots/test_compiler/test_table_drop_with_filter/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_compiler/test_table_drop_with_filter/decompiled.py
@@ -7,6 +7,8 @@ t = ibis.table(name="t", schema={"a": "int64", "b": "string", "c": "timestamp"})
 proj = t.select([t.a, t.b, t.c.name("C")])
 proj1 = proj.filter(proj.C == lit)
 proj2 = proj1.select([proj1.a, proj1.b, lit.name("the_date")])
-proj3 = proj2.inner_join(s, proj2.b == s.b).select(proj2.a)
+proj3 = proj2.inner_join(s, proj2.b == s.b, lname="{name}_x", rname="{name}_y").select(
+    proj2.a
+)
 
 result = proj3.filter(proj3.a < 1.0)

--- a/ibis/tests/sql/snapshots/test_select_sql/test_aggregate_count_joined/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_aggregate_count_joined/decompiled.py
@@ -17,7 +17,10 @@ tpch_region = ibis.table(
 
 result = (
     tpch_region.inner_join(
-        tpch_nation, tpch_region.r_regionkey == tpch_nation.n_regionkey
+        tpch_nation,
+        tpch_region.r_regionkey == tpch_nation.n_regionkey,
+        lname="{name}_x",
+        rname="{name}_y",
     )
     .select([tpch_nation, tpch_region.r_name.name("region")])
     .count()

--- a/ibis/tests/sql/snapshots/test_select_sql/test_anti_join/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_anti_join/decompiled.py
@@ -9,4 +9,6 @@ star2 = ibis.table(
     name="star2", schema={"foo_id": "string", "value1": "float64", "value3": "float64"}
 )
 
-result = star1.anti_join(star2, star1.foo_id == star2.foo_id).select(star1)
+result = star1.anti_join(
+    star2, star1.foo_id == star2.foo_id, lname="{name}_x", rname="{name}_y"
+).select(star1)

--- a/ibis/tests/sql/snapshots/test_select_sql/test_join_between_joins/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_join_between_joins/decompiled.py
@@ -9,13 +9,13 @@ third = ibis.table(
 )
 second = ibis.table(name="second", schema={"key1": "string", "value2": "float64"})
 fourth = ibis.table(name="fourth", schema={"key3": "string", "value4": "float64"})
-proj = first.inner_join(second, first.key1 == second.key1).select(
-    [first, second.value2]
-)
-proj1 = third.inner_join(fourth, third.key3 == fourth.key3).select(
-    [third, fourth.value4]
-)
+proj = first.inner_join(
+    second, first.key1 == second.key1, lname="{name}_x", rname="{name}_y"
+).select([first, second.value2])
+proj1 = third.inner_join(
+    fourth, third.key3 == fourth.key3, lname="{name}_x", rname="{name}_y"
+).select([third, fourth.value4])
 
-result = proj.inner_join(proj1, proj.key2 == proj1.key2).select(
-    [proj, proj1.value3, proj1.value4]
-)
+result = proj.inner_join(
+    proj1, proj.key2 == proj1.key2, lname="{name}_x", rname="{name}_y"
+).select([proj, proj1.value3, proj1.value4])

--- a/ibis/tests/sql/snapshots/test_select_sql/test_join_just_materialized/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_join_just_materialized/decompiled.py
@@ -29,5 +29,13 @@ tpch_region = ibis.table(
 )
 
 result = tpch_nation.inner_join(
-    tpch_region, tpch_nation.n_regionkey == tpch_region.r_regionkey
-).inner_join(tpch_customer, tpch_nation.n_nationkey == tpch_customer.c_nationkey)
+    tpch_region,
+    tpch_nation.n_regionkey == tpch_region.r_regionkey,
+    lname="{name}_x",
+    rname="{name}_y",
+).inner_join(
+    tpch_customer,
+    tpch_nation.n_nationkey == tpch_customer.c_nationkey,
+    lname="{name}_x",
+    rname="{name}_y",
+)

--- a/ibis/tests/sql/snapshots/test_select_sql/test_limit_with_self_join/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_limit_with_self_join/decompiled.py
@@ -25,6 +25,8 @@ result = (
     functional_alltypes.inner_join(
         selfreference,
         functional_alltypes.tinyint_col < selfreference.timestamp_col.minute(),
+        lname="{name}_x",
+        rname="{name}_y",
     )
     .select(
         [

--- a/ibis/tests/sql/snapshots/test_select_sql/test_multiple_joins/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_multiple_joins/decompiled.py
@@ -11,7 +11,9 @@ star2 = ibis.table(
 )
 
 result = (
-    star1.left_join(star2, star1.foo_id == star2.foo_id)
+    star1.left_join(
+        star2, star1.foo_id == star2.foo_id, lname="{name}_x", rname="{name}_y"
+    )
     .select(
         [
             star1.c,
@@ -23,6 +25,6 @@ result = (
             star2.value3,
         ]
     )
-    .inner_join(star3, star1.bar_id == star3.bar_id)
+    .inner_join(star3, star1.bar_id == star3.bar_id, lname="{name}_x", rname="{name}_y")
     .select([star1, star2.value1, star3.value2])
 )

--- a/ibis/tests/sql/snapshots/test_select_sql/test_semi_join/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_semi_join/decompiled.py
@@ -9,4 +9,6 @@ star2 = ibis.table(
     name="star2", schema={"foo_id": "string", "value1": "float64", "value3": "float64"}
 )
 
-result = star1.semi_join(star2, star1.foo_id == star2.foo_id).select(star1)
+result = star1.semi_join(
+    star2, star1.foo_id == star2.foo_id, lname="{name}_x", rname="{name}_y"
+).select(star1)

--- a/ibis/tests/sql/snapshots/test_select_sql/test_simple_joins/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_simple_joins/decompiled.py
@@ -10,5 +10,8 @@ star2 = ibis.table(
 )
 
 result = star1.inner_join(
-    star2, [star1.foo_id == star2.foo_id, star1.bar_id == star2.foo_id]
+    star2,
+    [star1.foo_id == star2.foo_id, star1.bar_id == star2.foo_id],
+    lname="{name}_x",
+    rname="{name}_y",
 ).select(star1)

--- a/ibis/tests/sql/snapshots/test_select_sql/test_subquery_in_union/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_subquery_in_union/decompiled.py
@@ -21,6 +21,8 @@ agg = alltypes.group_by([alltypes.a, alltypes.g]).aggregate(
     alltypes.f.sum().name("metric")
 )
 selfreference = agg.view()
-proj = agg.inner_join(selfreference, agg.g == selfreference.g).select(agg)
+proj = agg.inner_join(
+    selfreference, agg.g == selfreference.g, lname="{name}_x", rname="{name}_y"
+).select(agg)
 
 result = proj.union(proj.view())

--- a/ibis/tests/sql/snapshots/test_select_sql/test_where_no_pushdown_possible/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_where_no_pushdown_possible/decompiled.py
@@ -8,8 +8,8 @@ star1 = ibis.table(
 star2 = ibis.table(
     name="star2", schema={"foo_id": "string", "value1": "float64", "value3": "float64"}
 )
-proj = star1.inner_join(star2, star1.foo_id == star2.foo_id).select(
-    [star1, (star1.f - star2.value1).name("diff")]
-)
+proj = star1.inner_join(
+    star2, star1.foo_id == star2.foo_id, lname="{name}_x", rname="{name}_y"
+).select([star1, (star1.f - star2.value1).name("diff")])
 
 result = proj.filter(proj.diff > 1)

--- a/ibis/tests/sql/snapshots/test_select_sql/test_where_with_join/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_where_with_join/decompiled.py
@@ -10,7 +10,9 @@ star2 = ibis.table(
 )
 
 result = (
-    star1.inner_join(star2, star1.foo_id == star2.foo_id)
+    star1.inner_join(
+        star2, star1.foo_id == star2.foo_id, lname="{name}_x", rname="{name}_y"
+    )
     .select([star1, star2.value1, star2.value3])
     .filter([star1.f > 0, star2.value3 < 1000])
 )

--- a/ibis/tests/sql/snapshots/test_sqlalchemy/test_lower_projection_sort_key/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_sqlalchemy/test_lower_projection_sort_key/decompiled.py
@@ -9,7 +9,9 @@ star1 = ibis.table(
     schema={"c": "int32", "f": "float64", "foo_id": "string", "bar_id": "string"},
 )
 agg = star1.group_by(star1.foo_id).aggregate(star1.f.sum().name("total"))
-proj = agg.inner_join(star2, agg.foo_id == star2.foo_id).select([agg, star2.value1])
+proj = agg.inner_join(
+    star2, agg.foo_id == star2.foo_id, lname="{name}_x", rname="{name}_y"
+).select([agg, star2.value1])
 proj1 = proj.filter(proj.total > 100)
 
 result = proj1.order_by(proj1.total.desc())

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -254,7 +254,7 @@ def test_cte_factor_distinct_but_equal(con, snapshot):
     expr1 = t.group_by('g').aggregate(t.f.sum().name('metric'))
     expr2 = tt.group_by('g').aggregate(tt.f.sum().name('metric')).view()
 
-    expr = expr1.join(expr2, expr1.g == expr2.g)[[expr1]]
+    expr = expr1.join(expr2, expr1.g == expr2.g, rname="{name}_y")[[expr1]]
 
     snapshot.assert_match(to_sql(expr), "out.sql")
 
@@ -262,7 +262,7 @@ def test_cte_factor_distinct_but_equal(con, snapshot):
 def test_self_reference_join(star1, snapshot):
     t1 = star1
     t2 = t1.view()
-    expr = t1.inner_join(t2, [t1.foo_id == t2.bar_id])[[t1]]
+    expr = t1.inner_join(t2, [t1.foo_id == t2.bar_id], rname="{name}_y")[[t1]]
 
     snapshot.assert_match(to_sql(expr), "out.sql")
 
@@ -443,9 +443,9 @@ def survey():
 
 
 def test_no_cross_join(person, visited, survey, snapshot):
-    expr = person.join(survey, person.id == survey.person).join(
-        visited, visited.id == survey.taken
-    )
+    expr = person.join(
+        survey, person.id == survey.person, lname="{name}_x", rname="{name}_y"
+    ).join(visited, visited.id == survey.taken, lname="{name}_x", rname="{name}_y")
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 


### PR DESCRIPTION
This deprecates the existing `suffixes` kwarg in our join methods in favor of `lname`/`rname` kwargs.

```python
# rename any duplicate columns in the right table with a `_right` suffix
t.join(t2, "id", rname="{name}_right")

# rename any duplicate columns in the left table with a `left_` prefix
t.join(t2, "id", lname="left_{name}")
```

It also deprecates the default deduplication behavior; in the future any joins that would require column renaming for deduplication will require the user to explicitly pass in `lname`/`rname` (otherwise they'll get a nice error telling them to do so).

I'm not sold on `lname`/`rname` instead of `lsuffix`/`rsuffix` (as pandas does). I went with the more powerful/flexible option for now, but if this is confusing/verbose we can change it. I'm also not sold on not having a default behavior, as many joins will require the user to pass in a kwarg to resolve duplicate column names. We might instead do as polars does, and only rename duplicate columns in the right table (which is what users commonly want).

Just pushing this up for conversation for now. I've fixed a bunch of tests, but wouldn't be surprised if things fail in lots of places still.

Fixes #5537.