### PR TITLE
feat(sql): move to temporary views for `con.read_x` APIs to avoid view proliferation

### DIFF
--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -259,4 +259,4 @@ ORDER BY attnum"""
     def _get_temp_view_definition(
         self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
-        yield f"CREATE OR REPLACE VIEW {name} AS {definition}"
+        yield f"CREATE OR REPLACE TEMPORARY VIEW {name} AS {definition}"

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -270,7 +270,7 @@ class Backend(BaseAlchemyBackend):
         self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
         yield f"DROP VIEW IF EXISTS {name}"
-        yield f"CREATE VIEW {name} AS {definition}"
+        yield f"CREATE TEMPORARY VIEW {name} AS {definition}"
 
     def _get_compiled_statement(self, view: sa.Table, definition: sa.sql.Selectable):
         return super()._get_compiled_statement(


### PR DESCRIPTION
Fixes #5881.