### PR TITLE
fix(sql): generate consistent `pivot_longer` semantics in the presence of multiple `unnest`s

### DIFF
--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.compiler import compiles
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 from ibis.backends.base.sql.alchemy.geospatial import geospatial_supported
+from ibis.common.collections import FrozenDict
 
 if geospatial_supported:
     import geoalchemy2 as ga
@@ -29,10 +30,12 @@ def compiles_array(element, compiler, **kw):
 
 
 class StructType(sat.UserDefinedType):
+    cache_ok = True
+
     def __init__(self, fields: Mapping[str, sat.TypeEngine]) -> None:
-        self.fields = {
-            name: sat.to_instance(type) for name, type in dict(fields).items()
-        }
+        self.fields = FrozenDict(
+            {name: sat.to_instance(typ) for name, typ in fields.items()}
+        )
 
 
 @compiles(StructType, "default")

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -348,6 +348,7 @@ operation_registry.update(
         ops.ArrayMap: _array_map,
         ops.ArrayFilter: _array_filter,
         ops.Argument: lambda _, op: sa.literal_column(op.name),
+        ops.Unnest: unary(sa.func.unnest),
     }
 )
 

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -23,6 +23,9 @@ class PostgreSQLExprTranslator(AlchemyExprTranslator):
     _has_reduction_filter_syntax = True
     _dialect_name = "postgresql"
 
+    # it does support it, but we can't use it because of support for pivot
+    supports_unnest_in_select = False
+
 
 rewrites = PostgreSQLExprTranslator.rewrites
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -987,6 +987,7 @@ def test_many_subqueries(con, snapshot):
 )
 def test_pivot_longer(backend):
     diamonds = backend.diamonds
+    df = diamonds.execute()
     res = diamonds.pivot_longer(s.c("x", "y", "z"), names_to="pos", values_to="xyz")
     assert res.schema().names == (
         "carat",
@@ -999,8 +1000,22 @@ def test_pivot_longer(backend):
         "pos",
         "xyz",
     )
-    df = res.limit(5).execute()
-    assert not df.empty
+    expected = pd.melt(
+        df,
+        id_vars=[
+            "carat",
+            "cut",
+            "color",
+            "clarity",
+            "depth",
+            "table",
+            "price",
+        ],
+        value_vars=list('xyz'),
+        var_name="pos",
+        value_name="xyz",
+    )
+    assert len(res.execute()) == len(expected)
 
 
 @pytest.mark.notyet(["datafusion"], raises=com.OperationNotDefinedError)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -973,9 +973,6 @@ def test_many_subqueries(con, snapshot):
 @pytest.mark.notyet(["polars"], reason="polars doesn't expand > 1 explode")
 @pytest.mark.notimpl(["druid"], raises=AssertionError)
 @pytest.mark.notyet(
-    ["pyspark"], reason="pyspark doesn't allow more than one explode in a select"
-)
-@pytest.mark.notyet(
     ["bigquery"],
     reason="backend doesn't implement unnest",
     raises=com.OperationNotDefinedError,

--- a/ibis/backends/trino/datatypes.py
+++ b/ibis/backends/trino/datatypes.py
@@ -137,7 +137,7 @@ def _timestamp(_, itype):
     return TIMESTAMP(precision=itype.scale, timezone=bool(itype.timezone))
 
 
-@compiles(TIMESTAMP, "trino")
+@compiles(TIMESTAMP)
 def compiles_timestamp(typ, compiler, **kw):
     result = "TIMESTAMP"
 
@@ -150,7 +150,7 @@ def compiles_timestamp(typ, compiler, **kw):
     return result
 
 
-@compiles(ROW, "trino")
+@compiles(ROW)
 def _compiles_row(element, compiler, **kw):
     # TODO: @compiles should live in the dialect
     quote = compiler.dialect.identifier_preparer.quote
@@ -168,7 +168,7 @@ def _map(dialect, itype):
     )
 
 
-@compiles(MAP, "trino")
+@compiles(MAP)
 def compiles_map(typ, compiler, **kw):
     # TODO: @compiles should live in the dialect
     key_type = compiler.process(typ.key_type, **kw)
@@ -191,7 +191,7 @@ def _real(*_):
     return sa.REAL()
 
 
-@compiles(DOUBLE, "trino")
+@compiles(DOUBLE)
 @compiles(sa.REAL, "trino")
 def _floating(element, compiler, **kw):
     return type(element).__name__.upper()


### PR DESCRIPTION
Fixes #5855.

This PR fixes an issue caused by the difference in behavior between multiple
unnest calls in a projection.

In the duckdb and postgres backends

```
t.select(t.x.unnest(), t.y.unnest())
```

is analogous to Python's zip, and will perform a pairwise unnest.

In the snowflake and trino backends, we desugar that into a series of cross joins
which generates the Cartesian product of the unnest calls.

This PR doesn't take a position on that, but fixes `pivot_longer` to have the
desired pairwise behavior regardless of backend.

We **do** need to address the difference in behavior I mention, but that should
be done in 6.0.

I created https://github.com/ibis-project/ibis/issues/5913 to discuss options.
