### PR TITLE
refactor(sqlalchemy): remove unused `_meta` instance attributes

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -136,8 +136,6 @@ class Backend(BaseAlchemyBackend):
 
         super().do_connect(engine)
 
-        self._meta = sa.MetaData()
-
     def _load_extensions(self, extensions):
         extension_name = sa.column("extension_name")
         loaded = sa.column("loaded")

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -73,7 +73,6 @@ class Backend(BaseAlchemyBackend):
                         url, connect_args=connect_args, poolclass=sa.pool.StaticPool
                     )
                 )
-        self._meta = sa.MetaData(schema=schema)
 
     def _metadata(self, query: str) -> Iterator[tuple[str, dt.DataType]]:
         tmpname = f"_ibis_trino_output_{util.guid()[:6]}"


### PR DESCRIPTION
This PR removes a small amount of dead code.