### PR TITLE
fix(snowflake): make sure ephemeral tables following backend quoting rules

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -117,7 +117,7 @@ def _table_column(t, op):
     sa_table = get_sqla_table(ctx, table)
 
     out_expr = get_col(sa_table, op)
-    out_expr.quote = t._always_quote_columns
+    out_expr.quote = t._quote_column_names
 
     # If the column does not originate from the table set in the current SELECT
     # context, we should format as a subquery

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -79,7 +79,8 @@ class SnowflakeExprTranslator(AlchemyExprTranslator):
     )
     _require_order_by = (*AlchemyExprTranslator._require_order_by, ops.Reduction)
     _dialect_name = "snowflake"
-    _always_quote_columns = True
+    _quote_column_names = True
+    _quote_table_names = True
     supports_unnest_in_select = False
 
 
@@ -144,7 +145,6 @@ $$ {defn["source"]} $$"""
 class Backend(BaseAlchemyBackend):
     name = "snowflake"
     compiler = SnowflakeCompiler
-    quote_table_names = True
 
     @property
     def _current_schema(self) -> str:
@@ -368,14 +368,15 @@ class Backend(BaseAlchemyBackend):
         return self._filter_with_like(databases, like)
 
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
+        df = op.data.to_frame()
         with self.begin() as con:
             write_pandas(
                 conn=con.connection.connection,
-                df=op.data.to_frame(),
+                df=df,
                 table_name=op.name,
                 table_type="temp",
                 auto_create_table=True,
-                quote_identifiers=False,
+                quote_identifiers=True,
             )
 
     def _get_temp_view_definition(

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/snowflake/out.sql
@@ -1,32 +1,32 @@
 WITH t0 AS (
   SELECT
-    t5.street AS street,
-    ROW_NUMBER() OVER (ORDER BY t5.street) - 1 AS key
-  FROM data AS t5
+    t5."street" AS "street",
+    ROW_NUMBER() OVER (ORDER BY t5."street") - 1 AS "key"
+  FROM "data" AS t5
 ), t1 AS (
   SELECT
-    t0.key AS key
+    t0."key" AS "key"
   FROM t0
 ), t2 AS (
   SELECT
-    t0.street AS street,
-    t0.key AS key
+    t0."street" AS "street",
+    t0."key" AS "key"
   FROM t0
   JOIN t1
-    ON t0.key = t1.key
+    ON t0."key" = t1."key"
 ), t3 AS (
   SELECT
-    t2.street AS street,
-    ROW_NUMBER() OVER (ORDER BY t2.street) - 1 AS key
+    t2."street" AS "street",
+    ROW_NUMBER() OVER (ORDER BY t2."street") - 1 AS "key"
   FROM t2
 ), t4 AS (
   SELECT
-    t3.key AS key
+    t3."key" AS "key"
   FROM t3
 )
 SELECT
-  t3.street,
-  t3.key
+  t3."street",
+  t3."key"
 FROM t3
 JOIN t4
-  ON t3.key = t4.key
+  ON t3."key" = t4."key"

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/snowflake/out.sql
@@ -1,22 +1,22 @@
 WITH t0 AS (
   SELECT
-    t4.key AS key
-  FROM leaf AS t4
+    t4."key" AS "key"
+  FROM "leaf" AS t4
   WHERE
     TRUE
 ), t1 AS (
   SELECT
-    t0.key AS key
+    t0."key" AS "key"
   FROM t0
 ), t2 AS (
   SELECT
-    t0.key AS key
+    t0."key" AS "key"
   FROM t0
   JOIN t1
-    ON t0.key = t1.key
+    ON t0."key" = t1."key"
 )
 SELECT
-  t2.key
+  t2."key"
 FROM t2
 JOIN t2 AS t3
-  ON t2.key = t3.key
+  ON t2."key" = t3."key"

--- a/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/snowflake/out.sql
@@ -1,5 +1,5 @@
 SELECT
-  CASE t0.continent
+  CASE t0."continent"
     WHEN 'NA'
     THEN 'North America'
     WHEN 'SA'
@@ -15,8 +15,8 @@ SELECT
     WHEN 'AN'
     THEN 'Antarctica'
     ELSE 'Unknown continent'
-  END AS cont,
-  SUM(t0.population) AS total_pop
-FROM countries AS t0
+  END AS "cont",
+  SUM(t0."population") AS "total_pop"
+FROM "countries" AS t0
 GROUP BY
   1

--- a/ibis/backends/tests/snapshots/test_sql/test_isin_bug/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_isin_bug/snowflake/out.sql
@@ -1,13 +1,13 @@
 SELECT
-  t0.x IN (
+  t0."x" IN (
     SELECT
-      t1.x
+      t1."x"
     FROM (
       SELECT
-        t0.x AS x
-      FROM t AS t0
+        t0."x" AS "x"
+      FROM "t" AS t0
       WHERE
-        t0.x > 2
+        t0."x" > 2
     ) AS t1
   ) AS "Contains(x, x)"
-FROM t AS t0
+FROM "t" AS t0


### PR DESCRIPTION
This PR fixes an issue where we were not threading the quoting parameters through to the various places where ephemeral tables are being created. This manifests mostly in the snowflake backend due to broken quoting behavior in `snowflake-sqlalchemy`.