### PR TITLE
depr(api): deprecate `Table.set_column` in favor of `Table.mutate`

### DIFF
--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -21,8 +21,7 @@ def test_embedded_identifier_quoting(alltypes):
 def test_summary_execute(alltypes):
     table = alltypes
 
-    # also test set_column while we're at it
-    table = table.set_column('double_col', table.double_col * 2)
+    table = table.mutate(double_col=table.double_col * 2)
 
     with pytest.warns(FutureWarning, match="is deprecated"):
         metrics = table.double_col.summary()

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2329,6 +2329,9 @@ class Table(Expr, _FixedTextJupyterMixin):
             aggs.append(agg)
         return ibis.union(*aggs).order_by(ibis.asc("pos"))
 
+    @util.deprecated(
+        instead="use `table.mutate(name=expr)`", as_of="5.1", removed_in="6.0"
+    )
     def set_column(self, name: str, expr: ir.Value) -> Table:
         """Replace an existing column with a new expression.
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -299,11 +299,11 @@ def test_mutate_alter_existing_columns(table):
     assert_equal(expr, expected)
 
 
-def test_replace_column(table):
+def test_replace_column():
     tb = api.table([('a', 'int32'), ('b', 'double'), ('c', 'string')])
 
     expr = tb.b.cast('int32')
-    tb2 = tb.set_column('b', expr)
+    tb2 = tb.mutate(b=expr)
     expected = tb[tb.a, expr.name('b'), tb.c]
 
     assert_equal(tb2, expected)
@@ -1465,8 +1465,10 @@ def test_set_column(table):
     def g(x):
         return x.f * 2
 
-    result = table.set_column('f', g)
-    expected = table.set_column('f', table.f * 2)
+    with pytest.warns(FutureWarning, match=r"5\.1"):
+        result = table.set_column('f', g)
+    with pytest.warns(FutureWarning, match=r"6\.0"):
+        expected = table.set_column('f', table.f * 2)
     assert_equal(result, expected)
 
 


### PR DESCRIPTION
Deprecate `Table.set_column`