### PR TITLE
refactor(api): remove explicit use of `.projection` in favor of the shorter `.select`

### DIFF
--- a/docs/ibis-for-sql-programmers.ipynb
+++ b/docs/ibis-for-sql-programmers.ipynb
@@ -128,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "proj = t.projection(['two', 'one'])"
+    "proj = t.select(['two', 'one'])"
    ]
   },
   {

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -154,7 +154,7 @@ def _exists_subquery(t, op):
     filtered = (
         op.foreign_table.to_expr()
         .filter([pred.to_expr() for pred in op.predicates])
-        .projection([ir.literal(1).name("")])
+        .select(ir.literal(1).name(""))
     )
 
     sub_ctx = ctx.subcontext()

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -150,7 +150,7 @@ def table_column(translator, op):
     # context, we should format as a subquery
     if translator.permit_subquery and ctx.is_foreign_expr(op.table):
         # TODO(kszucs): avoid the expression roundtrip
-        proj_expr = op.table.to_expr().projection([op.name]).to_array().op()
+        proj_expr = op.table.to_expr().select([op.name]).to_array().op()
         return table_array_view(translator, proj_expr)
 
     alias = ctx.get_ref(op.table, search_parents=True)
@@ -168,7 +168,7 @@ def exists_subquery(translator, op):
     filtered = op.foreign_table.to_expr().filter(
         [pred.to_expr() for pred in op.predicates]
     )
-    node = filtered.projection([dummy]).op()
+    node = filtered.select(dummy).op()
 
     subquery = ctx.get_compiled_expr(node)
 

--- a/ibis/backends/clickhouse/tests/test_operators.py
+++ b/ibis/backends/clickhouse/tests/test_operators.py
@@ -186,7 +186,7 @@ def test_negate(con, alltypes, translate, column, operator):
 )
 def test_negate_non_boolean(alltypes, field, df):
     t = alltypes.limit(10)
-    expr = t.projection([(-t[field]).name(field)])
+    expr = t.select((-t[field]).name(field))
     result = expr.execute()[field]
     expected = -df.head(10)[field]
     tm.assert_series_equal(result, expected)

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -283,7 +283,7 @@ def test_filter_predicates(diamonds):
 
     expr = diamonds
     for pred in predicates:
-        expr = expr[pred(expr)].projection([expr])
+        expr = expr[pred(expr)].select(expr)
 
     expr.execute()
 

--- a/ibis/backends/dask/tests/execution/test_arrays.py
+++ b/ibis/backends/dask/tests/execution/test_arrays.py
@@ -12,12 +12,10 @@ from dask.dataframe.utils import tm  # noqa: E402
 
 
 def test_array_length(t):
-    expr = t.projection(
-        [
-            t.array_of_float64.length().name('array_of_float64_length'),
-            t.array_of_int64.length().name('array_of_int64_length'),
-            t.array_of_strings.length().name('array_of_strings_length'),
-        ]
+    expr = t.select(
+        t.array_of_float64.length().name('array_of_float64_length'),
+        t.array_of_int64.length().name('array_of_int64_length'),
+        t.array_of_strings.length().name('array_of_strings_length'),
     )
     result = expr.compile()
     expected = dd.from_pandas(
@@ -173,7 +171,7 @@ def test_array_index_scalar(client, index):
 @pytest.mark.parametrize('n', [1, 3, 4, 7, -2])  # negative returns empty list
 @pytest.mark.parametrize('mul', [lambda x, n: x * n, lambda x, n: n * x])
 def test_array_repeat(t, df, n, mul):
-    expr = t.projection([mul(t.array_of_strings, n).name('repeated')])
+    expr = t.select(repeated=mul(t.array_of_strings, n))
     result = expr.execute()
     expected = pd.DataFrame({'repeated': df.array_of_strings * n})
     tm.assert_frame_equal(result, expected)

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -310,7 +310,7 @@ class ImpalaTable(ir.Table):
             if partition is not None:
                 partition_schema = self.partition_schema()
                 partition_schema_names = frozenset(partition_schema.names)
-                expr = expr.projection(
+                expr = expr.select(
                     [
                         column
                         for column in expr.columns

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -373,7 +373,7 @@ def test_filter_predicates(con):
 
     expr = t
     for pred in predicates:
-        expr = expr[pred(expr)].projection([expr])
+        expr = expr[pred(expr)].select(expr)
 
     expr.execute()
 
@@ -672,7 +672,7 @@ def test_identical_to(con, left, right, expected):
 
 def test_not(alltypes):
     t = alltypes.limit(10)
-    expr = t.projection([(~t.double_col.isnull()).name('double_col')])
+    expr = t.select(double_col=~t.double_col.isnull())
     result = expr.execute().double_col
     expected = ~t.execute().double_col.isnull()
     tm.assert_series_equal(result, expected)

--- a/ibis/backends/pandas/tests/execution/test_arrays.py
+++ b/ibis/backends/pandas/tests/execution/test_arrays.py
@@ -17,12 +17,10 @@ def test_array_literal(client, arr, create_arr_expr):
 
 
 def test_array_length(t):
-    expr = t.projection(
-        [
-            t.array_of_float64.length().name('array_of_float64_length'),
-            t.array_of_int64.length().name('array_of_int64_length'),
-            t.array_of_strings.length().name('array_of_strings_length'),
-        ]
+    expr = t.select(
+        t.array_of_float64.length().name('array_of_float64_length'),
+        t.array_of_int64.length().name('array_of_int64_length'),
+        t.array_of_strings.length().name('array_of_strings_length'),
     )
     result = expr.execute()
     expected = pd.DataFrame(

--- a/ibis/backends/pyspark/tests/test_array.py
+++ b/ibis/backends/pyspark/tests/test_array.py
@@ -134,7 +134,7 @@ def test_array_concat_scalar(client, op):
 def test_array_repeat(client, n, mul):
     table = client.table('array_table')
 
-    expr = table.projection([mul(table.array_int, n).name('repeated')])
+    expr = table.select(mul(table.array_int, n).name('repeated'))
     result = expr.execute()
 
     df = table.compile().toPandas()

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -659,7 +659,7 @@ def test_truncate_from_connection(con, alltypes):
 
 def test_not(alltypes):
     t = alltypes.limit(10)
-    expr = t.projection([(~t.double_col.isnull()).name('double_col')])
+    expr = t.select([(~t.double_col.isnull()).name('double_col')])
     result = expr.execute().double_col
     expected = ~t.execute().double_col.isnull()
     tm.assert_series_equal(result, expected)

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -68,7 +68,7 @@ class ScalarAggregate:
         for other in self.tables[1:]:
             table = table.cross_join(other)
 
-        return table.projection([subbed_expr])
+        return table.select(subbed_expr)
 
     def _visit(self, expr):
         assert isinstance(expr, ir.Expr), type(expr)

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -659,7 +659,7 @@ def _dedup_join_columns(expr, suffixes: tuple[str, str]):
         for column in right.columns
         if column not in equal
     ]
-    return expr.projection(left_projections + right_projections)
+    return expr.select(left_projections + right_projections)
 
 
 public(ExistsSubquery=ExistsSubquery, NotExistsSubquery=NotExistsSubquery)

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -84,7 +84,7 @@ class GroupedTable:
 
     def __getitem__(self, args):
         # Shortcut for projection with window functions
-        return self.projection(list(args))
+        return self.select(*args)
 
     def __getattr__(self, attr):
         if hasattr(self.table, attr):

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -141,7 +141,7 @@ def test_filter_self_join():
 
     metric = (left.total - right.total).name('diff')
     what = [left.region, metric]
-    projected = joined.projection(what)
+    projected = joined.select(what)
 
     proj_exprs = projected.op().selections
 

--- a/ibis/tests/expr/test_window_frames.py
+++ b/ibis/tests/expr/test_window_frames.py
@@ -423,7 +423,7 @@ def test_window_analysis_combine_group_by(alltypes):
     expr3 = grouped.mutate([diff.name('diff')])
 
     window_expr = (t.d - t.d.lag().over(w)).name('diff')
-    expected = t.projection([t, window_expr])
+    expected = t.select([t, window_expr])
 
     assert expr.equals(expected)
     assert expr.equals(expr2)

--- a/ibis/tests/sql/conftest.py
+++ b/ibis/tests/sql/conftest.py
@@ -209,7 +209,7 @@ def projection_fuse_filter():
     filtered = t[t.a > 0]
 
     expr2 = filtered[t.a, t.b, t.c]
-    expr3 = filtered.projection(['a', 'b', 'c'])
+    expr3 = filtered.select(['a', 'b', 'c'])
 
     return expr1, expr2, expr3
 

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -174,7 +174,7 @@ def test_table_drop_consistency():
     # GH2829
     t = ibis.table([('a', 'int64'), ('b', 'string'), ('c', 'timestamp')], name='t')
 
-    expected = t.projection(["a", "c"])
+    expected = t.select(["a", "c"])
     result = t.drop("b")
 
     assert expected.schema() == result.schema()

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -392,7 +392,7 @@ def test_where_correlated_subquery_with_join(snapshot):
         partsupp.ps_supplycost,
     ]
     subq = partsupp.join(supplier, supplier.s_suppkey == partsupp.ps_suppkey)
-    subq = subq.projection([partsupp.ps_partkey, partsupp.ps_supplycost])
+    subq = subq.select(partsupp.ps_partkey, partsupp.ps_supplycost)
     subq = subq[subq.ps_partkey == q.p_partkey]
 
     expr = q[q.ps_supplycost == subq.ps_supplycost.min()]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ plugins:
               - "!^column$"
               - "!^option_context$"
               - "!Selector$"
+              - "!^projection$"
             show_category_heading: true
             show_root_full_path: false
             show_root_heading: true


### PR DESCRIPTION
Remove internal use of `.projection` in favor of `.select`. `.projection` has been around forever, so I do not think we should ever deprecate it, but making it mostly invisible should serve the purpose of emphasizing select instead.