### PR TITLE
fix(duckdb): drop use of experimental parallel csv reader

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -120,8 +120,6 @@ class Backend(BaseAlchemyBackend):
             Path(temp_directory).mkdir(parents=True, exist_ok=True)
             config["temp_directory"] = str(temp_directory)
 
-        config.setdefault("experimental_parallel_csv", 1)
-
         engine = sa.create_engine(
             f"duckdb:///{database}",
             connect_args=dict(read_only=read_only, config=config),


### PR DESCRIPTION
I just spent the last 30 minutes debugging why a query would succeed in the duckdb CLI, but fail in ibis - ended up tracking the issue down to the use of the parallel csv reader.

For now I'm removing the use of this option by default. If needed, users can always manually reenable it. We also heard from the duckdb team that this option will be going away next release anyway.