### PR TITLE
ci(pyspark): disable parallel test runs

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -498,7 +498,7 @@ jobs:
         run: poetry install --without dev --without docs --extras pyspark
 
       - name: run tests
-        run: just ci-check -m pyspark --numprocesses auto --dist=loadgroup
+        run: just ci-check -m pyspark
 
       - name: upload code coverage
         if: success()


### PR DESCRIPTION
These seem to be a source of flakiness
