### PR TITLE
fix(clickhouse): fix `create_table` implementation

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -511,7 +511,7 @@ class Backend(BaseBackend):
 
     def truncate_table(self, name: str, database: str | None = None) -> None:
         ident = self._fully_qualified_name(name, database)
-        self.raw_sql(f"DELETE FROM {ident}")
+        self.raw_sql(f"TRUNCATE TABLE {ident}")
 
     def drop_table(
         self, name: str, database: str | None = None, force: bool = False

--- a/ibis/backends/clickhouse/compiler/relations.py
+++ b/ibis/backends/clickhouse/compiler/relations.py
@@ -26,7 +26,7 @@ def _dummy(op: ops.DummyTable, **kw):
 
 @translate_rel.register(ops.PhysicalTable)
 def _physical_table(op: ops.PhysicalTable, **_):
-    return sg.table(op.name)
+    return sg.parse_one(op.name, into=sg.exp.Table)
 
 
 @translate_rel.register(ops.Selection)

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_complex_array_expr_projection/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_complex_array_expr_projection/out.sql
@@ -4,7 +4,7 @@ FROM (
   SELECT
     t0.string_col,
     COUNT(*) AS count
-  FROM functional_alltypes AS t0
+  FROM ibis_testing.functional_alltypes AS t0
   GROUP BY
     1
 ) AS t1

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_isin_notin_in_select/out1.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_isin_notin_in_select/out1.sql
@@ -1,5 +1,5 @@
 SELECT
   *
-FROM functional_alltypes AS t0
+FROM ibis_testing.functional_alltypes AS t0
 WHERE
   t0.string_col IN ('foo', 'bar')

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_isin_notin_in_select/out2.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_isin_notin_in_select/out2.sql
@@ -1,5 +1,5 @@
 SELECT
   *
-FROM functional_alltypes AS t0
+FROM ibis_testing.functional_alltypes AS t0
 WHERE
   NOT t0.string_col IN ('foo', 'bar')

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_isnull_case_expr_rewrite_failure/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_isnull_case_expr_rewrite_failure/out.sql
@@ -1,3 +1,3 @@
 SELECT
   SUM(CASE WHEN isNull(t0.string_col) THEN 1 ELSE 0 END) AS "Sum(Where(IsNull(string_col), 1, 0))"
-FROM functional_alltypes AS t0
+FROM ibis_testing.functional_alltypes AS t0

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_join_self_reference/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_join_self_reference/out.sql
@@ -1,5 +1,5 @@
 SELECT
   t0.*
-FROM functional_alltypes AS t0
-INNER JOIN functional_alltypes AS t1
+FROM ibis_testing.functional_alltypes AS t0
+INNER JOIN ibis_testing.functional_alltypes AS t1
   ON t0.id = t1.id

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_physical_table_reference_translate/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_physical_table_reference_translate/out.sql
@@ -1,3 +1,3 @@
 SELECT
   *
-FROM functional_alltypes
+FROM ibis_testing.functional_alltypes

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_self_reference_simple/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_self_reference_simple/out.sql
@@ -1,3 +1,3 @@
 SELECT
   *
-FROM functional_alltypes AS t0
+FROM ibis_testing.functional_alltypes AS t0

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-awardID-any_inner_join/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-awardID-any_inner_join/out.sql
@@ -1,5 +1,5 @@
 SELECT
   t0.*
-FROM batting AS t0
-ANY JOIN awards_players AS t1
+FROM ibis_testing.batting AS t0
+ANY JOIN ibis_testing.awards_players AS t1
   ON t0.playerID = t1.awardID

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-awardID-any_left_join/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-awardID-any_left_join/out.sql
@@ -1,5 +1,5 @@
 SELECT
   t0.*
-FROM batting AS t0
-LEFT ANY JOIN awards_players AS t1
+FROM ibis_testing.batting AS t0
+LEFT ANY JOIN ibis_testing.awards_players AS t1
   ON t0.playerID = t1.awardID

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-awardID-inner_join/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-awardID-inner_join/out.sql
@@ -1,5 +1,5 @@
 SELECT
   t0.*
-FROM batting AS t0
-INNER JOIN awards_players AS t1
+FROM ibis_testing.batting AS t0
+INNER JOIN ibis_testing.awards_players AS t1
   ON t0.playerID = t1.awardID

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-awardID-left_join/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-awardID-left_join/out.sql
@@ -1,5 +1,5 @@
 SELECT
   t0.*
-FROM batting AS t0
-LEFT OUTER JOIN awards_players AS t1
+FROM ibis_testing.batting AS t0
+LEFT OUTER JOIN ibis_testing.awards_players AS t1
   ON t0.playerID = t1.awardID

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-playerID-any_inner_join/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-playerID-any_inner_join/out.sql
@@ -1,5 +1,5 @@
 SELECT
   t0.*
-FROM batting AS t0
-ANY JOIN awards_players AS t1
+FROM ibis_testing.batting AS t0
+ANY JOIN ibis_testing.awards_players AS t1
   ON t0.playerID = t1.playerID

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-playerID-any_left_join/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-playerID-any_left_join/out.sql
@@ -1,5 +1,5 @@
 SELECT
   t0.*
-FROM batting AS t0
-LEFT ANY JOIN awards_players AS t1
+FROM ibis_testing.batting AS t0
+LEFT ANY JOIN ibis_testing.awards_players AS t1
   ON t0.playerID = t1.playerID

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-playerID-inner_join/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-playerID-inner_join/out.sql
@@ -1,5 +1,5 @@
 SELECT
   t0.*
-FROM batting AS t0
-INNER JOIN awards_players AS t1
+FROM ibis_testing.batting AS t0
+INNER JOIN ibis_testing.awards_players AS t1
   ON t0.playerID = t1.playerID

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-playerID-left_join/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_joins/playerID-playerID-left_join/out.sql
@@ -1,5 +1,5 @@
 SELECT
   t0.*
-FROM batting AS t0
-LEFT OUTER JOIN awards_players AS t1
+FROM ibis_testing.batting AS t0
+LEFT OUTER JOIN ibis_testing.awards_players AS t1
   ON t0.playerID = t1.playerID

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_scalar_aggregates/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_simple_scalar_aggregates/out.sql
@@ -1,5 +1,5 @@
 SELECT
   SUM(t0.float_col) AS "Sum(float_col)"
-FROM functional_alltypes AS t0
+FROM ibis_testing.functional_alltypes AS t0
 WHERE
   t0.int_col > 0

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_table_column_unbox/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_table_column_unbox/out.sql
@@ -4,7 +4,7 @@ FROM (
   SELECT
     t0.string_col,
     SUM(t0.float_col) AS total
-  FROM functional_alltypes AS t0
+  FROM ibis_testing.functional_alltypes AS t0
   WHERE
     t0.int_col > 0
   GROUP BY

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_timestamp_extract_field/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_timestamp_extract_field/out.sql
@@ -5,4 +5,4 @@ SELECT
   toHour(t0.timestamp_col) AS hour,
   toMinute(t0.timestamp_col) AS minute,
   toSecond(t0.timestamp_col) AS second
-FROM functional_alltypes AS t0
+FROM ibis_testing.functional_alltypes AS t0

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_where_simple_comparisons/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_where_simple_comparisons/out.sql
@@ -1,6 +1,6 @@
 SELECT
   *
-FROM functional_alltypes AS t0
+FROM ibis_testing.functional_alltypes AS t0
 WHERE
   t0.float_col > 0 AND t0.int_col < (
     t0.float_col * 2

--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_where_with_between/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_where_with_between/out.sql
@@ -1,5 +1,5 @@
 SELECT
   *
-FROM functional_alltypes AS t0
+FROM ibis_testing.functional_alltypes AS t0
 WHERE
   t0.int_col > 0 AND t0.float_col BETWEEN 0 AND 1

--- a/ibis/backends/tests/snapshots/test_string/test_rlike/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_string/test_rlike/clickhouse/out.sql
@@ -1,5 +1,5 @@
 SELECT
   *
-FROM functional_alltypes AS t0
+FROM ibis_testing.functional_alltypes AS t0
 WHERE
   multiMatchAny(t0.string_col, [  '0'])


### PR DESCRIPTION
This PR fixes a number of issues with the ClickHouse backend's new-in-5.0
`create_table` method.

1. Usage of `pd` without importing it. This is fixed by changing the
   `isinstance` to check for objects that aren't expressions.
1. CTAS (create-table-as-select queries) had the `SELECT` query in the wrong position
1. Temporary tables don't work due to their lack of persistence across cursor instances. I think this is a bug in how ibis is using `clickhouse_driver`. For now, I'm going to disable `temp=True` until we can figure out what's going on there.
1. `truncate_table` was also broken, since clickhouse requires a predicate for `DELETE FROM`, which we were using to implement `truncate_table`. However, ClickHouse supports `TRUNCATE TABLE`, so I switched to that.

Closes #5937.
