### PR TITLE
test(ir): fix maximum console width

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -890,8 +890,7 @@ def test_interactive_repr_max_columns(alltypes, is_jupyter, monkeypatch):
     cols = {f"c_{i}": ibis._.id + i for i in range(50)}
     expr = alltypes.mutate(**cols).select(*cols)
 
-    console = rich.console.Console(force_jupyter=is_jupyter)
-    console.options.max_width = 80
+    console = rich.console.Console(force_jupyter=is_jupyter, width=80)
     options = console.options.copy()
 
     # max_columns = 0


### PR DESCRIPTION
`ibis/backends/tests/test_client.py::test_interactive_repr_max_columns[duckdb-False] ` has been consistently failing for me locally on macOS with alacritty terminal. Rich used the inferred console width.

The following patch resolved the issue for me. 
