### PR TITLE
feat(api): add a `console_width` configuration option to explicitly set the width of the interactive repr

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -890,7 +890,7 @@ def test_interactive_repr_max_columns(alltypes, is_jupyter, monkeypatch):
     cols = {f"c_{i}": ibis._.id + i for i in range(50)}
     expr = alltypes.mutate(**cols).select(*cols)
 
-    console = rich.console.Console(force_jupyter=is_jupyter, width=80)
+    console = rich.console.Console(force_jupyter=is_jupyter)
     options = console.options.copy()
 
     # max_columns = 0

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -97,6 +97,7 @@ class Interactive(Config):
     max_string: int = 80
     max_depth: int = 1
     show_types: bool = True
+    console_width: Optional[int] = None
 
 
 class Repr(Config):

--- a/ibis/conftest.py
+++ b/ibis/conftest.py
@@ -13,7 +13,8 @@ def add_ibis(monkeypatch, doctest_namespace):
     monkeypatch.setitem(os.environ, "NO_COLOR", "1")
     # reset interactive mode to False for doctests that don't execute
     # expressions
-    ibis.options.interactive = False
+    monkeypatch.setattr(ibis.options, "interactive", False)
+    monkeypatch.setattr(ibis.options.repr.interactive, "console_width", 80)
     # workaround the fact that doctests include everything in the tested module
     # for selectors we have an `all` function
     #

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -257,8 +257,11 @@ class Table(Expr, _FixedTextJupyterMixin):
             # also needs to be forwarded to `console.render`.
             options = options.update(max_width=1_000_000)
             width = None
-        else:
+        elif ibis.options.repr.interactive.console_width is None:
             width = options.max_width
+        else:
+            width = ibis.options.repr.interactive.console_width
+            options = options.update(max_width=width)
 
         table = to_rich_table(self, width)
         return console.render(table, options=options)


### PR DESCRIPTION
Depends on #5974 

I wasn't able to properly run the doctests because all the tables were pretty printed in the full width of my console. 
In order to have reproducible builds I added a configuration option to hardcode the console width when we execute the doctests. 