### PR TITLE
test: ignore all DeprecatedWarning calls for pkg_resources.declare_namespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,7 +299,7 @@ filterwarnings = [
   "ignore:Class ST_.+ will not make use of SQL compilation caching:",
   "ignore:UserDefinedType Geometry:",
   # google
-  "ignore:Deprecated call to `pkg_resources\\.declare_namespace\\('google.*'\\):DeprecationWarning",
+  "ignore:Deprecated call to `pkg_resources\\.declare_namespace\\('.*'\\):DeprecationWarning",
   # pyspark on python 3.11
   "ignore:typing\\.io is deprecated:DeprecationWarning",
   # warnings from google's use of the cgi module


### PR DESCRIPTION
A lot of third party dependencies (e.g.
https://github.com/matplotlib/matplotlib/issues/25244) are still using it. Helpful to ignore for now.