### PR TITLE
ci: only show docker compose logs if job requires services

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -310,7 +310,7 @@ jobs:
           path: junit.xml
 
       - name: Show docker compose logs on fail
-        if: ${{ failure() }}
+        if: matrix.backend.services != null && failure()
         run: docker compose logs
 
   test_backends_min_version:
@@ -435,7 +435,7 @@ jobs:
           path: junit.xml
 
       - name: Show docker compose logs on fail
-        if: ${{ failure() }}
+        if: matrix.backend.services != null && failure()
         run: docker compose logs
 
   test_pyspark:
@@ -670,7 +670,7 @@ jobs:
           path: junit.xml
 
       - name: Show docker compose logs on fail
-        if: ${{ failure() }}
+        if: matrix.backend.services != null && failure()
         run: docker compose logs
 
   backends:


### PR DESCRIPTION
This PR ensures that we do not try to look at docker compose logs when no services are running.

Example failure: https://github.com/ibis-project/ibis/actions/runs/4685649902/jobs/8302958023?pr=5990
