### PR TITLE
fix(backends): make notany/notall work with the `where` argument

### DIFF
--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -323,22 +323,24 @@ def _bucket(op):
 
 @rewrites(ops.Any)
 def _any_expand(op):
-    return ops.Max(op.arg)
+    return ops.Max(op.arg, where=op.where)
 
 
 @rewrites(ops.NotAny)
 def _notany_expand(op):
-    return ops.Equals(ops.Max(op.arg), ops.Literal(0, dtype=op.arg.output_dtype))
+    zero = ops.Literal(0, dtype=op.arg.output_dtype)
+    return ops.Min(ops.Equals(op.arg, zero), where=op.where)
 
 
 @rewrites(ops.All)
 def _all_expand(op):
-    return ops.Min(op.arg)
+    return ops.Min(op.arg, where=op.where)
 
 
 @rewrites(ops.NotAll)
 def _notall_expand(op):
-    return ops.Equals(ops.Min(op.arg), ops.Literal(0, dtype=op.arg.output_dtype))
+    zero = ops.Literal(0, dtype=op.arg.output_dtype)
+    return ops.Max(ops.Equals(op.arg, zero), where=op.where)
 
 
 @rewrites(ops.Cast)

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -99,6 +99,16 @@ class BigQueryExprTranslator(sql_compiler.ExprTranslator):
 compiles = BigQueryExprTranslator.compiles
 
 
+@BigQueryExprTranslator.rewrites(ops.NotAll)
+def _rewrite_notall(op):
+    return ops.Any(ops.Not(op.arg), where=op.where)
+
+
+@BigQueryExprTranslator.rewrites(ops.NotAny)
+def _rewrite_notany(op):
+    return ops.All(ops.Not(op.arg), where=op.where)
+
+
 class BigQueryTableSetFormatter(sql_compiler.TableSetFormatter):
     def _quote_identifier(self, name):
         if re.match(r"^[A-Za-z][A-Za-z_0-9]*$", name):

--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -468,22 +468,6 @@ def _corr(translator, op):
     return compiles_covar_corr("CORR")(translator, op)
 
 
-def bigquery_compile_any(translator, op):
-    return f"LOGICAL_OR({translator.translate(op.arg)})"
-
-
-def bigquery_compile_notany(translator, op):
-    return f"LOGICAL_AND(NOT ({translator.translate(op.arg)}))"
-
-
-def bigquery_compile_all(translator, op):
-    return f"LOGICAL_AND({translator.translate(op.arg)})"
-
-
-def bigquery_compile_notall(translator, op):
-    return f"LOGICAL_OR(NOT ({translator.translate(op.arg)}))"
-
-
 def _identical_to(t, op):
     left = t.translate(op.left)
     right = t.translate(op.right)
@@ -596,14 +580,12 @@ OPERATION_REGISTRY = {
     # Literal
     ops.Literal: _literal,
     # Logical
-    ops.Any: bigquery_compile_any,
-    ops.All: bigquery_compile_all,
+    ops.Any: reduction("LOGICAL_OR"),
+    ops.All: reduction("LOGICAL_AND"),
     ops.IfNull: fixed_arity("IFNULL", 2),
     ops.NullIf: fixed_arity("NULLIF", 2),
     ops.NullIfZero: _nullifzero,
     ops.ZeroIfNull: _zeroifnull,
-    ops.NotAny: bigquery_compile_notany,
-    ops.NotAll: bigquery_compile_notall,
     # Reductions
     ops.ApproxMedian: compiles_approx,
     ops.Covariance: _covar,

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -177,12 +177,12 @@ def _count_star(op, **kw):
 
 @translate_val.register(ops.NotAny)
 def _not_any(op, **kw):
-    return translate_val(ops.Not(ops.Any(op.arg)), **kw)
+    return translate_val(ops.All(ops.Not(op.arg), where=op.where), **kw)
 
 
 @translate_val.register(ops.NotAll)
 def _not_all(op, **kw):
-    return translate_val(ops.Not(ops.All(op.arg)), **kw)
+    return translate_val(ops.Any(ops.Not(op.arg), where=op.where), **kw)
 
 
 def _quantile_like(func_name: str, op: ops.Node, quantile: str, **kw):

--- a/ibis/backends/impala/tests/snapshots/test_value_exprs/test_any_all/not_all/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_value_exprs/test_any_all/not_all/out.sql
@@ -1,1 +1,1 @@
-min(`f` = 0) = FALSE
+max((`f` = 0) = FALSE)

--- a/ibis/backends/impala/tests/snapshots/test_value_exprs/test_any_all/not_any/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_value_exprs/test_any_all/not_any/out.sql
@@ -1,1 +1,1 @@
-max(`f` = 0) = FALSE
+min((`f` = 0) = FALSE)

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -804,6 +804,8 @@ def execute_any_all_series(op, data, mask, aggcontext=None, **kwargs):
 
 @execute_node.register((ops.Any, ops.All), SeriesGroupBy, type(None))
 def execute_any_all_series_group_by(op, data, mask, aggcontext=None, **kwargs):
+    if mask is not None:
+        data = data.obj.loc[mask].groupby(get_grouping(data.grouper.groupings))
     if isinstance(aggcontext, (agg_ctx.Summarize, agg_ctx.Transform)):
         result = aggcontext.agg(data, type(op).__name__.lower())
     else:
@@ -819,6 +821,8 @@ def execute_any_all_series_group_by(op, data, mask, aggcontext=None, **kwargs):
 @execute_node.register((ops.NotAny, ops.NotAll), pd.Series, (pd.Series, type(None)))
 def execute_notany_notall_series(op, data, mask, aggcontext=None, **kwargs):
     name = type(op).__name__.lower()[len("Not") :]
+    if mask is not None:
+        data = data.loc[mask]
     if isinstance(aggcontext, (agg_ctx.Summarize, agg_ctx.Transform)):
         result = ~aggcontext.agg(data, name)
     else:
@@ -833,6 +837,8 @@ def execute_notany_notall_series(op, data, mask, aggcontext=None, **kwargs):
 @execute_node.register((ops.NotAny, ops.NotAll), SeriesGroupBy, type(None))
 def execute_notany_notall_series_group_by(op, data, mask, aggcontext=None, **kwargs):
     name = type(op).__name__.lower()[len("Not") :]
+    if mask is not None:
+        data = data.obj.loc[mask].groupby(get_grouping(data.grouper.groupings))
     if isinstance(aggcontext, (agg_ctx.Summarize, agg_ctx.Transform)):
         result = ~aggcontext.agg(data, name)
     else:

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -561,8 +561,8 @@ operation_registry.update(
         # boolean reductions
         ops.Any: reduction(sa.func.bool_or),
         ops.All: reduction(sa.func.bool_and),
-        ops.NotAny: reduction(lambda x: sa.not_(sa.func.bool_or(x))),
-        ops.NotAll: reduction(lambda x: sa.not_(sa.func.bool_and(x))),
+        ops.NotAny: reduction(lambda x: sa.func.bool_and(~x)),
+        ops.NotAll: reduction(lambda x: sa.func.bool_or(~x)),
         # strings
         ops.GroupConcat: _string_agg,
         ops.Capitalize: unary(sa.func.initcap),

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -351,9 +351,9 @@ operation_registry.update(
         # snowflake typeof only accepts VARIANT, so we cast
         ops.TypeOf: unary(lambda arg: sa.func.typeof(sa.func.to_variant(arg))),
         ops.All: reduction(sa.func.booland_agg),
-        ops.NotAll: reduction(lambda arg: ~sa.func.booland_agg(arg)),
         ops.Any: reduction(sa.func.boolor_agg),
-        ops.NotAny: reduction(lambda arg: ~sa.func.boolor_agg(arg)),
+        ops.NotAll: reduction(lambda arg: sa.func.boolor_agg(~arg)),
+        ops.NotAny: reduction(lambda arg: sa.func.booland_agg(~arg)),
         ops.BitAnd: reduction(sa.func.bitand_agg),
         ops.BitOr: reduction(sa.func.bitor_agg),
         ops.BitXor: reduction(sa.func.bitxor_agg),

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -286,8 +286,8 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             ),
         ),
         param(
-            lambda t, _: t.bool_col.any(),
-            lambda t, _: t.bool_col.any(),
+            lambda t, where: t.bool_col.any(where=where),
+            lambda t, where: t.bool_col[where].any(),
             id='any',
             marks=[
                 pytest.mark.notimpl(
@@ -302,17 +302,13 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             ],
         ),
         param(
-            lambda t, _: t.bool_col.notany(),
-            lambda t, _: ~t.bool_col.any(),
+            lambda t, where: t.bool_col.notany(where=where),
+            lambda t, where: ~t.bool_col[where].any(),
             id='notany',
             marks=[
                 pytest.mark.notimpl(
                     ["polars", "datafusion"],
                     raises=com.OperationNotDefinedError,
-                ),
-                pytest.mark.notimpl(
-                    ['mssql'],
-                    raises=sa.exc.ProgrammingError,
                 ),
                 pytest.mark.broken(
                     ["druid"],
@@ -322,18 +318,13 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             ],
         ),
         param(
-            lambda t, _: -t.bool_col.any(),
-            lambda t, _: ~t.bool_col.any(),
+            lambda t, where: -t.bool_col.any(where=where),
+            lambda t, where: ~t.bool_col[where].any(),
             id='any_negate',
             marks=[
                 pytest.mark.notimpl(
                     ["polars", "datafusion"],
                     raises=com.OperationNotDefinedError,
-                ),
-                pytest.mark.broken(
-                    ['mssql'],
-                    raises=sa.exc.ProgrammingError,
-                    reason="Incorrect syntax near '='",
                 ),
                 pytest.mark.broken(
                     ["druid"],
@@ -343,8 +334,8 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             ],
         ),
         param(
-            lambda t, _: t.bool_col.all(),
-            lambda t, _: t.bool_col.all(),
+            lambda t, where: t.bool_col.all(where=where),
+            lambda t, where: t.bool_col[where].all(),
             id='all',
             marks=[
                 pytest.mark.notimpl(
@@ -359,8 +350,8 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             ],
         ),
         param(
-            lambda t, _: t.bool_col.notall(),
-            lambda t, _: ~t.bool_col.all(),
+            lambda t, where: t.bool_col.notall(where=where),
+            lambda t, where: ~t.bool_col[where].all(),
             id='notall',
             marks=[
                 pytest.mark.notimpl(
@@ -372,26 +363,16 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     raises=AttributeError,
                     reason="'IntegerColumn' object has no attribute 'notall'",
                 ),
-                pytest.mark.broken(
-                    ['mssql'],
-                    raises=sa.exc.ProgrammingError,
-                    reason="Incorrect syntax near '='",
-                ),
             ],
         ),
         param(
-            lambda t, _: -t.bool_col.all(),
-            lambda t, _: ~t.bool_col.all(),
+            lambda t, where: -t.bool_col.all(where=where),
+            lambda t, where: ~t.bool_col[where].all(),
             id='all_negate',
             marks=[
                 pytest.mark.notimpl(
                     ["polars", "datafusion"],
                     raises=com.OperationNotDefinedError,
-                ),
-                pytest.mark.broken(
-                    ['mssql'],
-                    raises=sa.exc.ProgrammingError,
-                    reason="Incorrect syntax near '='",
                 ),
                 pytest.mark.broken(
                     ["druid"],

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -211,19 +211,7 @@ def calc_zscore(s):
             ),
             id='cumnotany',
             marks=[
-                pytest.mark.notyet(
-                    ["sqlite"],
-                    reason="notany() over window not supported",
-                    raises=sa.exc.OperationalError,
-                ),
-                pytest.mark.notyet(
-                    ["impala"],
-                    reason="notany() over window not supported",
-                    raises=HiveServer2Error,
-                ),
-                pytest.mark.broken(
-                    ["mssql", "mysql", "snowflake"], raises=sa.exc.ProgrammingError
-                ),
+                pytest.mark.broken(["mssql"], raises=sa.exc.ProgrammingError),
                 pytest.mark.notimpl(["dask"], raises=NotImplementedError),
             ],
         ),
@@ -248,19 +236,7 @@ def calc_zscore(s):
             ),
             id='cumnotall',
             marks=[
-                pytest.mark.notyet(
-                    ["sqlite"],
-                    reason="notall() over window not supported",
-                    raises=sa.exc.OperationalError,
-                ),
-                pytest.mark.notyet(
-                    ["impala"],
-                    reason="notall() over window not supported",
-                    raises=HiveServer2Error,
-                ),
-                pytest.mark.broken(
-                    ["mssql", "mysql", "snowflake"], raises=sa.exc.ProgrammingError
-                ),
+                pytest.mark.broken(["mssql"], raises=sa.exc.ProgrammingError),
                 pytest.mark.notimpl(["dask"], raises=NotImplementedError),
             ],
         ),

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -235,8 +235,8 @@ operation_registry.update(
         # boolean reductions
         ops.Any: reduction(sa.func.bool_or),
         ops.All: reduction(sa.func.bool_and),
-        ops.NotAny: reduction(lambda x: sa.not_(sa.func.bool_or(x))),
-        ops.NotAll: reduction(lambda x: sa.not_(sa.func.bool_and(x))),
+        ops.NotAny: reduction(lambda x: sa.func.bool_and(~x)),
+        ops.NotAll: reduction(lambda x: sa.func.bool_or(~x)),
         ops.ArgMin: reduction(sa.func.min_by),
         ops.ArgMax: reduction(sa.func.max_by),
         # array ops


### PR DESCRIPTION
Fixes #5988. There were multiple issues here, but the primary problem was that we needed to thread the `where` argument through to a few places and enable tests for these APIs.