### PR TITLE
chore(deps): bump lower bound of ipython in dev dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5601,4 +5601,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "5bf935d506a564924115be89d2ce0f9394fccd7e402f1f17423392b18c38affa"
+content-hash = "7a87ac977cd36bba771483a6c69945ce98214bee37317f9eb98aa6338ca73611"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ trino = { version = ">=0.319,<1", optional = true, extras = ["sqlalchemy"] }
 [tool.poetry.group.dev.dependencies]
 black = ">=22.1.0,<24"
 google-cloud-storage = ">=2.7.0,<3"
-ipython = ">=7.27.0,<9"
+ipython = ">=8.7.0,<9"
 poetry-dynamic-versioning = ">=0.18.0,<1"
 pre-commit = ">=3.1,<4"
 ruff = ">=0.0.205,<1"


### PR DESCRIPTION
We had a contributor run into issues with a very old version of
`prompt_toolkit` (3.0.4, ~3 years old) in the conda-lock files cause
trouble.

This bumps the lower bound of `ipython` (which is the package that pulls
in `prompt_toolkit`) so that we get a less-old version.

I don't think this counts as a breaking change in that it only impacts
dev dependencies.
