### PR TITLE
docs: add platform comment in conda env creation

### DIFF
--- a/docs/community/contribute/01_environment.md
+++ b/docs/community/contribute/01_environment.md
@@ -51,6 +51,7 @@ hide:
             === "{{ os }}"
 
                 ```sh
+                # Create a dev environment for {{platform}}
                 cd ibis
                 {{ manager }} create -n ibis-dev --file=conda-lock/{{ platform }}-3.10.lock
                 ```


### PR DESCRIPTION
Fixes #5985.

I could go either way on this one, but think something like this is the most we should change. The tabs above are maybe not the most obvious, so reiterating that the code is for a specific platform seems maybe useful.