### PR TITLE
chore(dev-deps): add nbstripout pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,11 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.0
+    hooks:
+      - id: nbstripout
+        exclude: .+/rendered/.+
   - repo: local
     hooks:
       - id: ruff

--- a/docs/ibis-for-sql-programmers.ipynb
+++ b/docs/ibis-for-sql-programmers.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bd23750c-bc6b-46db-a6d3-017f73a1d436",
    "metadata": {},
    "outputs": [],
@@ -56,31 +56,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "11770743-e66f-4001-988d-d5c7a5b40cd6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">UnboundTable: my_data\n",
-       "  one   string\n",
-       "  two   float64\n",
-       "  three int32\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "UnboundTable: my_data\n",
-       "  one   string\n",
-       "  two   float64\n",
-       "  three int32"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "t = ibis.table(\n",
     "    [('one', 'string'), ('two', 'float'), ('three', 'int32')], 'my_data'\n",
@@ -105,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "aa3fad0b-7f40-420e-80bc-34649c72ec72",
    "metadata": {},
    "outputs": [],
@@ -123,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "2ccca9e5-8cc8-451a-9bd1-1e1a0b521358",
    "metadata": {},
    "outputs": [],
@@ -141,21 +120,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "33015a45-9f8d-4c43-83c8-8fec5915f5b5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.two,\n",
-      "  t0.one\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ibis.show_sql(proj)"
    ]
@@ -178,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "b9ed5b53-88ba-4a1b-93ce-52c364ee6fd7",
    "metadata": {},
    "outputs": [],
@@ -196,22 +164,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "534c848f-96d7-4e63-8524-ac037a8314e5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.two,\n",
-      "  t0.one,\n",
-      "  t0.three * CAST(2 AS SMALLINT) AS new_col\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj = t['two', 'one', new_col]\n",
     "ibis.show_sql(proj)"
@@ -230,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "17e443f6-26b1-4d89-87da-501f3ca6db26",
    "metadata": {},
    "outputs": [],
@@ -249,23 +205,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "d48b4d6d-c72e-484e-a1d7-01ec59883d2f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  t0.three * CAST(2 AS SMALLINT) AS new_col\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ibis.show_sql(mutated)"
    ]
@@ -281,22 +224,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "740e3186-8179-4dc0-9940-0b8885d4712a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two * CAST(2 AS SMALLINT) AS two,\n",
-      "  t0.three\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "mutated = t.mutate(two=t.two * 2)\n",
     "ibis.show_sql(mutated)"
@@ -316,22 +247,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "ab0233b9-eba0-4d94-bfd1-ada40ce1c3a1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj = t[t]\n",
     "ibis.show_sql(proj)"
@@ -348,23 +267,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "ef6125c7-fcb3-482b-a594-13e7637718fc",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  t0.three * CAST(2 AS SMALLINT) AS new_col\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj = t[t, new_col]\n",
     "ibis.show_sql(proj)"
@@ -380,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "45468b42-bdee-4a8b-b2b7-5ef438e30b69",
    "metadata": {},
    "outputs": [],
@@ -407,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "651feee9-1cd3-4b6f-9fb9-0d4389341cc2",
    "metadata": {},
    "outputs": [],
@@ -426,25 +332,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "dccb0052-c6a9-47b3-a495-4fc03627b378",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  t0.two - t1.value AS diff\n",
-      "FROM my_data AS t0\n",
-      "JOIN dim_table AS t1\n",
-      "  ON t0.one = t1.key\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ibis.show_sql(joined)"
    ]
@@ -476,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "84f52fc9-7eda-418e-aab6-efedc1ba3412",
    "metadata": {},
    "outputs": [],
@@ -499,32 +390,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "507c2351-ec7d-4ea0-b48f-184d221052cd",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  AVG(ABS(t0.the_sum)) AS mad\n",
-      "FROM (\n",
-      "  SELECT\n",
-      "    t1.one AS one,\n",
-      "    t1.three AS three,\n",
-      "    SUM(t1.two) AS the_sum\n",
-      "  FROM my_data AS t1\n",
-      "  GROUP BY\n",
-      "    t1.one,\n",
-      "    t1.three\n",
-      ") AS t0\n",
-      "GROUP BY\n",
-      "  t0.one\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ibis.show_sql(expr)"
    ]
@@ -542,24 +411,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "64888cad-1024-4b2d-be76-eb856d086286",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three\n",
-      "FROM my_data AS t0\n",
-      "WHERE\n",
-      "  t0.two > CAST(0 AS SMALLINT)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "filtered = t[t.two > 0]\n",
     "ibis.show_sql(filtered)"
@@ -576,24 +431,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "92421d3c-a871-4d95-9a9c-5297b0c49942",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three\n",
-      "FROM my_data AS t0\n",
-      "WHERE\n",
-      "  t0.two > CAST(0 AS SMALLINT) AND t0.one IN (CAST('A' AS TEXT), CAST('B' AS TEXT))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "filtered = t.filter([t.two > 0, t.one.isin(['A', 'B'])])\n",
     "ibis.show_sql(filtered)"
@@ -610,26 +451,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "557aa73a-eca2-4245-a32f-26d5aaca59eb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three\n",
-      "FROM my_data AS t0\n",
-      "WHERE\n",
-      "  t0.two < CAST(0 AS SMALLINT)\n",
-      "  OR t0.two > CAST(0 AS SMALLINT)\n",
-      "  OR t0.one IN (CAST('A' AS TEXT), CAST('B' AS TEXT))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cond = (t.two < 0) | ((t.two > 0) | t.one.isin(['A', 'B']))\n",
     "filtered = t[cond]\n",
@@ -653,7 +478,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "f8484260-7738-436f-b820-93d95f209861",
    "metadata": {},
    "outputs": [],
@@ -673,45 +498,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "26fb0202-ece7-4c73-8a4f-d41af36fe296",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ibis.Schema {\n",
-       "  total_two  float64\n",
-       "  avg_three  float64\n",
-       "}"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "agged.schema()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "69fb5629-64d3-4b79-8f0c-a91f6833c8be",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  SUM(t0.two) AS total_two,\n",
-      "  AVG(t0.three) AS avg_three\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ibis.show_sql(agged)"
    ]
@@ -727,24 +527,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "fbb11d08-d500-4873-a87b-a20b915978f3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  SUM(t0.two) AS total_two,\n",
-      "  AVG(t0.three) AS avg_three\n",
-      "FROM my_data AS t0\n",
-      "GROUP BY\n",
-      "  t0.one\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "agged2 = t.aggregate(stats, by='one')\n",
     "agged3 = t.group_by('one').aggregate(stats)\n",
@@ -765,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "c6c5f306-9310-48ff-8116-9902561fa84c",
    "metadata": {},
    "outputs": [],
@@ -786,7 +572,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "012505a5-8df1-49c0-adf3-5db7ad8f1b15",
    "metadata": {},
    "outputs": [],
@@ -809,26 +595,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "134857a1-b597-4188-96f4-a6180e559089",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT) AS year,\n",
-      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT) AS month,\n",
-      "  COUNT(*) AS total,\n",
-      "  COUNT(DISTINCT t0.session_id) AS sessions\n",
-      "FROM web_events AS t0\n",
-      "GROUP BY\n",
-      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT),\n",
-      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ibis.show_sql(stats)"
    ]
@@ -847,7 +617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "2ad4ad94-9f60-4424-800d-1f8f353e3c3e",
    "metadata": {},
    "outputs": [],
@@ -899,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "d162f950-0c64-4461-8e6c-f67c61f0b0d4",
    "metadata": {},
    "outputs": [],
@@ -924,28 +694,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "23e75b52-6367-4ce0-945f-3bfcecdd47df",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.country,\n",
-      "  COUNT(*) AS num_persons,\n",
-      "  AVG(t0.age) AS avg_age,\n",
-      "  AVG(t0.age) FILTER(WHERE\n",
-      "    t0.gender = CAST('M' AS TEXT)) AS avg_male,\n",
-      "  AVG(t0.age) FILTER(WHERE\n",
-      "    t0.gender = CAST('F' AS TEXT)) AS avg_female\n",
-      "FROM population AS t0\n",
-      "GROUP BY\n",
-      "  t0.country\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ibis.show_sql(expr)"
    ]
@@ -963,25 +715,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "3608e7d6-6b79-4519-b0b9-7dde99fccda7",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT) AS year,\n",
-      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT) AS month,\n",
-      "  COUNT(*) AS count\n",
-      "FROM web_events AS t0\n",
-      "GROUP BY\n",
-      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT),\n",
-      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "freqs = events.group_by(keys).size()\n",
     "ibis.show_sql(freqs)"
@@ -1008,27 +745,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "b3eaf481-f4cf-4f42-9249-8bebb28dd316",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.\"ExtractYear(ts)\",\n",
-      "  COUNT(*) AS count\n",
-      "FROM (\n",
-      "  SELECT\n",
-      "    CAST(EXTRACT(year FROM t1.ts) AS SMALLINT) AS \"ExtractYear(ts)\"\n",
-      "  FROM web_events AS t1\n",
-      ") AS t0\n",
-      "GROUP BY\n",
-      "  t0.\"ExtractYear(ts)\"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = events.ts.year().value_counts()\n",
     "ibis.show_sql(expr)"
@@ -1058,25 +778,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "6f927c7d-0c4a-4d5d-abd7-475a983407ab",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  SUM(t0.two) AS total\n",
-      "FROM my_data AS t0\n",
-      "GROUP BY\n",
-      "  t0.one\n",
-      "HAVING\n",
-      "  COUNT(*) >= CAST(1000 AS SMALLINT)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = (\n",
     "    t.group_by('one')\n",
@@ -1099,25 +804,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "67be17b3-169e-4330-9d3b-eb030401e5cb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.ts,\n",
-      "  t0.event_type,\n",
-      "  t0.session_id\n",
-      "FROM web_events AS t0\n",
-      "ORDER BY\n",
-      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT),\n",
-      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sorted = events.order_by([events.ts.year(), events.ts.month()])\n",
     "\n",
@@ -1136,26 +826,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "c93d8fe9-0940-40ae-b215-26b1274abf6d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.ts,\n",
-      "  t0.event_type,\n",
-      "  t0.session_id\n",
-      "FROM web_events AS t0\n",
-      "ORDER BY\n",
-      "  t0.event_type DESC,\n",
-      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT) DESC\n",
-      "LIMIT 100\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "sorted = events.order_by(\n",
     "    [ibis.desc('event_type'), (events.ts.month(), False)]\n",
@@ -1178,23 +852,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "5039e497-2bd2-409c-99f6-5b6a5d17b05e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three\n",
-      "FROM my_data AS t0\n",
-      "LIMIT 1000\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "limited = t.limit(1000)\n",
     "ibis.show_sql(limited)"
@@ -1211,24 +872,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "b2debe4e-3bc8-409b-abec-aee57d7d6a1e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three\n",
-      "FROM my_data AS t0\n",
-      "LIMIT 10\n",
-      "OFFSET 10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "limited = t.limit(10, offset=10)\n",
     "ibis.show_sql(limited)"
@@ -1254,24 +901,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "id": "27cf5bb1-6aa8-4a43-a972-820134dd13b3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  CAST(t0.one AS TIMESTAMP) AS date,\n",
-      "  CAST(t0.three AS FLOAT) AS four\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = t.mutate(date=t.one.cast('timestamp'), four=t.three.cast('float32'))\n",
     "\n",
@@ -1303,33 +936,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "501a2361-8776-4d01-9c22-6823b196b183",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  CASE\n",
-      "    WHEN (\n",
-      "      CAST(EXTRACT(year FROM CAST(t0.one AS TIMESTAMP)) AS SMALLINT) = CAST(2015 AS SMALLINT)\n",
-      "    )\n",
-      "    THEN CAST('This year' AS TEXT)\n",
-      "    WHEN (\n",
-      "      CAST(EXTRACT(year FROM CAST(t0.one AS TIMESTAMP)) AS SMALLINT) = CAST(2014 AS SMALLINT)\n",
-      "    )\n",
-      "    THEN CAST('Last year' AS TEXT)\n",
-      "    ELSE CAST('Earlier' AS TEXT)\n",
-      "  END AS year_group\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "case = (\n",
     "    t.one.cast('timestamp')\n",
@@ -1367,33 +977,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "2b899af6-1e73-4206-a8eb-d84192cf7031",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  CASE\n",
-      "    WHEN (\n",
-      "      t0.two < CAST(0 AS SMALLINT)\n",
-      "    )\n",
-      "    THEN t0.three * CAST(2 AS SMALLINT)\n",
-      "    WHEN (\n",
-      "      t0.two > CAST(1 AS SMALLINT)\n",
-      "    )\n",
-      "    THEN t0.three\n",
-      "    ELSE t0.two\n",
-      "  END AS cond_value\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "case = (\n",
     "    ibis.case()\n",
@@ -1418,29 +1005,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "657997c0-acdf-4c99-b5b7-ff952bda422c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  CASE\n",
-      "    WHEN (\n",
-      "      t0.two < CAST(0 AS SMALLINT)\n",
-      "    )\n",
-      "    THEN CAST('Negative' AS TEXT)\n",
-      "    ELSE CAST('Non-Negative' AS TEXT)\n",
-      "  END AS \"group\"\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "switch = (t.two < 0).ifelse('Negative', 'Non-Negative')\n",
     "expr = t.mutate(group=switch)\n",
@@ -1460,25 +1028,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "7247163e-3039-411a-9cc5-30f489c7f467",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  CASE WHEN (\n",
-      "    t0.two > CAST(0 AS SMALLINT)\n",
-      "  ) THEN t0.two ELSE NULL END AS two_positive\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pos_two = (t.two > 0).ifelse(t.two, ibis.NA)\n",
     "expr = t.mutate(two_positive=pos_two)\n",
@@ -1509,30 +1062,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "b652f2dc-fe0d-4922-bb89-83dd1e58cfeb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.name,\n",
-      "  t0.country,\n",
-      "  t0.gender,\n",
-      "  t0.age,\n",
-      "  CASE\n",
-      "    WHEN (\n",
-      "      UPPER(t0.country) IN (CAST('UNITED STATES' AS TEXT), CAST('CANADA' AS TEXT))\n",
-      "    )\n",
-      "    THEN CAST('North America' AS TEXT)\n",
-      "    ELSE t0.country\n",
-      "  END AS refined_group\n",
-      "FROM population AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "refined = (\n",
     "    pop.country.upper()\n",
@@ -1572,7 +1105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "id": "d74e4b3f-156f-4911-94c9-d6d0aa73400d",
    "metadata": {},
    "outputs": [],
@@ -1596,23 +1129,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "id": "d8f6b90e-13dd-4844-be81-15a33474e22f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.column1,\n",
-      "  t0.column2,\n",
-      "  t0.column3,\n",
-      "  CAST('foo' AS TEXT) IN (t0.column1, t0.column2) AS has_foo\n",
-      "FROM data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "has_foo = value.isin([t3.column1, t3.column2])\n",
     "\n",
@@ -1632,23 +1152,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "id": "f1dc9ffd-668a-4e0c-9a93-e37540fbb7e8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.column1,\n",
-      "  t0.column2,\n",
-      "  t0.column3,\n",
-      "  CAST(5 AS SMALLINT) AS number5\n",
-      "FROM data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = t3.mutate(number5=5)\n",
     "ibis.show_sql(expr)"
@@ -1667,29 +1174,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "id": "b7d010f1-ee8a-43a8-8cc1-3a43d59c35d1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  CASE\n",
-      "    WHEN (\n",
-      "      t0.two IS NULL\n",
-      "    )\n",
-      "    THEN CAST('valid' AS TEXT)\n",
-      "    ELSE CAST('invalid' AS TEXT)\n",
-      "  END AS is_valid\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "indic = t.two.isnull().ifelse('valid', 'invalid')\n",
     "expr = t.mutate(is_valid=indic)\n",
@@ -1698,38 +1186,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "id": "c0f2b9f7-e136-42e2-bdfb-fdd28ff56687",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.is_valid,\n",
-      "  SUM(CAST(NOT t0.three IS NULL AS INT)) AS three_count\n",
-      "FROM (\n",
-      "  SELECT\n",
-      "    t1.one AS one,\n",
-      "    t1.two AS two,\n",
-      "    t1.three AS three,\n",
-      "    CASE\n",
-      "      WHEN (\n",
-      "        t1.two IS NULL\n",
-      "      )\n",
-      "      THEN CAST('valid' AS TEXT)\n",
-      "      ELSE CAST('invalid' AS TEXT)\n",
-      "    END AS is_valid\n",
-      "  FROM my_data AS t1\n",
-      "  WHERE\n",
-      "    NOT t1.one IS NULL\n",
-      ") AS t0\n",
-      "GROUP BY\n",
-      "  t0.is_valid\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "agged = (\n",
     "    expr[expr.one.notnull()]\n",
@@ -1754,24 +1214,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "id": "bd9cdf2d-c3a3-4166-8402-f0a07a8adb48",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three\n",
-      "FROM my_data AS t0\n",
-      "WHERE\n",
-      "  t0.two BETWEEN CAST(10 AS SMALLINT) AND CAST(50 AS SMALLINT) AND NOT t0.one IS NULL\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = t[t.two.between(10, 50) & t.one.notnull()]\n",
     "ibis.show_sql(expr)"
@@ -1803,7 +1249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "id": "53d7fbe6-c6c6-40c4-a0ff-cca51736ab8d",
    "metadata": {},
    "outputs": [],
@@ -1827,7 +1273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "id": "539f284a-a525-4faa-bde9-1d4a96a2fb7d",
    "metadata": {},
    "outputs": [],
@@ -1861,25 +1307,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "id": "184ee220-b881-4410-8163-192215be5fb5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.value1,\n",
-      "  t0.key1,\n",
-      "  t0.key2,\n",
-      "  t1.value2\n",
-      "FROM table1 AS t0\n",
-      "LEFT OUTER JOIN table2 AS t1\n",
-      "  ON t0.key1 = t1.key3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = joined[t1, t2.value2]\n",
     "ibis.show_sql(expr)"
@@ -1896,23 +1327,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "id": "4e01f510-b48f-4ee7-84cc-03042f8989f0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.key1,\n",
-      "  t0.value1 - t1.value2 AS diff\n",
-      "FROM table1 AS t0\n",
-      "LEFT OUTER JOIN table2 AS t1\n",
-      "  ON t0.key1 = t1.key3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = joined[t1.key1, (t1.value1 - t2.value2).name('diff')]\n",
     "ibis.show_sql(expr)"
@@ -1944,25 +1362,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "id": "f8288597-27d0-4936-a63e-1da23f3c1fc4",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.key1,\n",
-      "  AVG(t0.value1 - t1.value2) AS avg_diff\n",
-      "FROM table1 AS t0\n",
-      "LEFT OUTER JOIN table2 AS t1\n",
-      "  ON t0.key1 = t1.key3\n",
-      "GROUP BY\n",
-      "  t0.key1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "avg_diff = (t1.value1 - t2.value2).mean()\n",
     "expr = (\n",
@@ -1986,27 +1389,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "id": "a3b7fe80-80f9-438c-b08e-242fdc8593fb",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.value1,\n",
-      "  t0.key1,\n",
-      "  t0.key2,\n",
-      "  t1.value2,\n",
-      "  t1.key3,\n",
-      "  t1.key4\n",
-      "FROM table1 AS t0\n",
-      "LEFT OUTER JOIN table2 AS t1\n",
-      "  ON t0.key1 = t1.key3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "joined = t1.left_join(t2, t1.key1 == t2.key3)\n",
     "ibis.show_sql(joined)"
@@ -2025,29 +1411,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "id": "06d624d7-a57e-4715-a596-b9b9522d8c51",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t1.key4,\n",
-      "  t2.key5,\n",
-      "  SUM(t0.value1 + t1.value2 + t2.value3) AS total\n",
-      "FROM table1 AS t0\n",
-      "JOIN table2 AS t1\n",
-      "  ON t0.key1 = t1.key3 AND t0.key2 = t1.key4\n",
-      "JOIN table3 AS t2\n",
-      "  ON t0.key1 = t2.key5\n",
-      "GROUP BY\n",
-      "  t1.key4,\n",
-      "  t2.key5\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "t3 = ibis.table([('value3', 'float'), ('key5', 'string')], 'table3')\n",
     "\n",
@@ -2084,34 +1451,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "id": "4fb52d34-263c-4528-9906-6149d8fae223",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t1.one,\n",
-      "  AVG(t1.two - t1.three) AS metric\n",
-      "FROM my_data AS t1, my_data AS t1, (\n",
-      "  SELECT\n",
-      "    t1.one AS one_x,\n",
-      "    t1.two AS two_x,\n",
-      "    t1.three AS three_x,\n",
-      "    t2.one AS one_y,\n",
-      "    t2.two AS two_y,\n",
-      "    t2.three AS three_y\n",
-      "  FROM my_data AS t1\n",
-      "  JOIN my_data AS t2\n",
-      "    ON CAST(t1.three AS TEXT) = t2.one\n",
-      ") AS t0\n",
-      "GROUP BY\n",
-      "  t1.one\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "t_view = t.view()\n",
     "\n",
@@ -2137,7 +1480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "d0e462ea-1393-4fbe-b30c-da08708d1d2c",
    "metadata": {},
    "outputs": [],
@@ -2173,26 +1516,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "dcf11c30-363e-45f8-a6fb-3106b012fedc",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.key1,\n",
-      "  t0.key2,\n",
-      "  t0.key3,\n",
-      "  t0.value1,\n",
-      "  t1.value2\n",
-      "FROM table4 AS t0\n",
-      "JOIN table5 AS t1\n",
-      "  ON t0.key1 = t1.key1 AND t0.key2 = t1.key2 AND t0.key3 = t1.key3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "joined = t4.join(t5, ['key1', 'key2', 'key3'])\n",
     "expr = joined[t4, t5.value2]\n",
@@ -2209,28 +1536,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "id": "b135e88e-1547-4d00-aa85-f85abea9a319",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.key1,\n",
-      "  t0.key2,\n",
-      "  t0.key3,\n",
-      "  t0.value1,\n",
-      "  t1.value2\n",
-      "FROM table4 AS t0\n",
-      "JOIN table5 AS t1\n",
-      "  ON t0.key1 = t1.key1\n",
-      "  AND t0.key2 = t1.key2\n",
-      "  AND SUBSTR(t0.key3, CAST(0 AS SMALLINT) + 1, CAST(4 AS SMALLINT)) = SUBSTR(t0.key3, CAST(0 AS SMALLINT) + 1, CAST(4 AS SMALLINT))\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "joined = t4.join(t5, ['key1', 'key2', t4.key3.left(4) == t4.key3.left(4)])\n",
     "expr = joined[t4, t5.value2]\n",
@@ -2252,25 +1561,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "id": "f0951d14-0962-4144-ac81-3b626a37d8da",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.key1,\n",
-      "  COUNT(*) AS count\n",
-      "FROM table1 AS t0\n",
-      "JOIN table2 AS t1\n",
-      "  ON t0.value1 < t1.value2\n",
-      "GROUP BY\n",
-      "  t0.key1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = t1.join(t2, t1.value1 < t2.value2).group_by(t1.key1).size()\n",
     "ibis.show_sql(expr)"
@@ -2289,7 +1583,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "id": "81c7fee1-f2d2-4cee-aa00-25fd3cacbc93",
    "metadata": {},
    "outputs": [],
@@ -2319,7 +1613,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "id": "c1b8e918-a222-4ebe-8aee-41dce6a99d30",
    "metadata": {},
    "outputs": [],
@@ -2372,7 +1666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "id": "640d3015-4005-41b1-b432-1d99fa3c3b09",
    "metadata": {},
    "outputs": [],
@@ -2390,31 +1684,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "id": "a5be1cbf-a636-4400-924d-873796068d69",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.session_id,\n",
-      "  t0.user_id,\n",
-      "  t0.event_type,\n",
-      "  t0.ts\n",
-      "FROM events AS t0\n",
-      "WHERE\n",
-      "  EXISTS(\n",
-      "    SELECT\n",
-      "      CAST(1 AS SMALLINT) AS anon_1\n",
-      "    FROM purchases AS t1\n",
-      "    WHERE\n",
-      "      t0.user_id = t1.user_id\n",
-      "  )\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = events[cond]\n",
     "ibis.show_sql(expr)"
@@ -2431,33 +1704,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "id": "36789da6-983a-48bb-829d-32da129afec9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.session_id,\n",
-      "  t0.user_id,\n",
-      "  t0.event_type,\n",
-      "  t0.ts\n",
-      "FROM events AS t0\n",
-      "WHERE\n",
-      "  NOT (\n",
-      "    EXISTS(\n",
-      "      SELECT\n",
-      "        CAST(1 AS SMALLINT) AS anon_1\n",
-      "      FROM purchases AS t1\n",
-      "      WHERE\n",
-      "        t0.user_id = t1.user_id\n",
-      "    )\n",
-      "  )\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = events[-cond]\n",
     "ibis.show_sql(expr)"
@@ -2488,36 +1738,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": null,
    "id": "7f8c5b77-5068-4d3a-9df6-e44d9b9f84a6",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.session_id,\n",
-      "  t0.user_id,\n",
-      "  t0.event_type,\n",
-      "  t0.ts\n",
-      "FROM events AS t0\n",
-      "WHERE\n",
-      "  t0.user_id IN (\n",
-      "    SELECT\n",
-      "      anon_1.user_id\n",
-      "    FROM (\n",
-      "      SELECT\n",
-      "        t1.item_id AS item_id,\n",
-      "        t1.user_id AS user_id,\n",
-      "        t1.price AS price,\n",
-      "        t1.ts AS ts\n",
-      "      FROM purchases AS t1\n",
-      "    ) AS anon_1\n",
-      "  )\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "cond = events.user_id.isin(purchases.user_id)\n",
     "expr = events[cond]\n",
@@ -2552,28 +1776,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "id": "98620369-6df2-42aa-9db6-d089795c66ea",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.value1,\n",
-      "  t0.key1,\n",
-      "  t0.key2\n",
-      "FROM table1 AS t0\n",
-      "WHERE\n",
-      "  t0.value1 > (\n",
-      "    SELECT\n",
-      "      MAX(t1.value2) AS \"Max(value2)\"\n",
-      "    FROM table2 AS t1\n",
-      "  )\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = t1[t1.value1 > t2.value2.max()]\n",
     "ibis.show_sql(expr)"
@@ -2609,30 +1815,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": null,
    "id": "821ead6b-1401-45ef-8521-9f2e85b6cea1",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.value1,\n",
-      "  t0.key1,\n",
-      "  t0.key2\n",
-      "FROM table1 AS t0\n",
-      "WHERE\n",
-      "  t0.value1 > (\n",
-      "    SELECT\n",
-      "      AVG(t1.value2) AS \"Mean(value2)\"\n",
-      "    FROM table2 AS t1\n",
-      "    WHERE\n",
-      "      t0.key1 = t1.key3\n",
-      "  )\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "stat = t2[t1.key1 == t2.key3].value2.mean()\n",
     "expr = t1[t1.value1 > stat]\n",
@@ -2665,22 +1851,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "id": "7afe45dd-1540-42cd-992d-2e09cd9f97ba",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT DISTINCT\n",
-      "  t0.value1,\n",
-      "  t0.key1,\n",
-      "  t0.key2\n",
-      "FROM table1 AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = t1.distinct()\n",
     "ibis.show_sql(expr)"
@@ -2707,23 +1881,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "id": "63644b0f-ca38-4019-99ea-fa3ac7b9968f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.user_id,\n",
-      "  COUNT(DISTINCT t0.event_type) AS unique_events\n",
-      "FROM events AS t0\n",
-      "GROUP BY\n",
-      "  t0.user_id\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "metric = events.event_type.nunique()\n",
     "expr = events.group_by('user_id').aggregate(unique_events=metric)\n",
@@ -2767,23 +1928,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "id": "a3dd8aaa-2320-4be9-8c99-f821c1c6ff4f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  t0.two - AVG(t0.two) OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS two_demean\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = t.mutate(two_demean=t.two - t.two.mean())\n",
     "ibis.show_sql(expr)"
@@ -2800,23 +1948,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "id": "b5f13aee-01fa-402f-bc8b-4d2de1c74726",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  t0.two - AVG(t0.two) OVER (PARTITION BY t0.one ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS two_demean\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = t.group_by('one').mutate(two_demean=t.two - t.two.mean())\n",
     "\n",
@@ -2834,23 +1969,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": null,
    "id": "e5b6871b-a220-4ea7-a6ec-b66ebe7796da",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  t0.two - LAG(t0.two, 1) OVER (PARTITION BY t0.one ORDER BY t0.two ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS two_first_diff\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = (\n",
     "    t.group_by('one')\n",
@@ -2872,23 +1994,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": null,
    "id": "6da1f124-5d3b-42b1-93ee-a3accb65a900",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.one,\n",
-      "  t0.two,\n",
-      "  t0.three,\n",
-      "  t0.two - AVG(t0.two) OVER (PARTITION BY t0.one ROWS BETWEEN 5 PRECEDING AND 5 FOLLOWING) AS group_demeaned\n",
-      "FROM my_data AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "w = ibis.window(group_by='one', preceding=5, following=5)\n",
     "expr = t.mutate(group_demeaned=t.two - t.two.mean().over(w))\n",
@@ -2918,7 +2027,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": null,
    "id": "20d8f28b-0a04-4539-8085-b15d1ca7ad71",
    "metadata": {},
    "outputs": [],
@@ -2936,31 +2045,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": null,
    "id": "85da70b8-f7b9-4c42-b8e9-e67303925c91",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.key1,\n",
-      "  t0.count\n",
-      "FROM (\n",
-      "  SELECT\n",
-      "    t1.key1 AS key1,\n",
-      "    COUNT(t1.key1) AS count\n",
-      "  FROM table1 AS t1\n",
-      "  GROUP BY\n",
-      "    t1.key1\n",
-      ") AS t0\n",
-      "ORDER BY\n",
-      "  t0.count DESC\n",
-      "LIMIT 10\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ibis.show_sql(expr)"
    ]
@@ -2980,25 +2068,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
    "id": "608a2a7f-2354-4b3a-986a-031cb8f82855",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.session_id,\n",
-      "  t0.user_id,\n",
-      "  t0.event_type,\n",
-      "  t0.ts,\n",
-      "  CAST(EXTRACT(year FROM t0.ts) AS SMALLINT) AS year,\n",
-      "  CAST(EXTRACT(month FROM t0.ts) AS SMALLINT) AS month\n",
-      "FROM events AS t0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = events.mutate(year=events.ts.year(), month=events.ts.month())\n",
     "\n",
@@ -3024,25 +2097,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": null,
    "id": "6d5849d3-4fc7-4d2f-8996-9582bb693f0a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SELECT\n",
-      "  t0.session_id,\n",
-      "  t0.user_id,\n",
-      "  t0.event_type,\n",
-      "  t0.ts\n",
-      "FROM events AS t0\n",
-      "WHERE\n",
-      "  t0.ts > CAST(NOW() AS TIMESTAMP) - INTERVAL '1 year'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr = events[events.ts > (ibis.now() - ibis.interval(years=1))]\n",
     "ibis.show_sql(expr)"
@@ -3074,44 +2132,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": null,
    "id": "030adc92-f51c-4b51-8505-ef63a78b890d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WITH anon_1 AS (\n",
-      "  SELECT\n",
-      "    t0.value1 AS value1,\n",
-      "    t0.key1 AS key1,\n",
-      "    t0.key2 AS key2\n",
-      "  FROM table1 AS t0\n",
-      "  LIMIT 10\n",
-      "), anon_2 AS (\n",
-      "  SELECT\n",
-      "    t0.value1 AS value1,\n",
-      "    t0.key1 AS key1,\n",
-      "    t0.key2 AS key2\n",
-      "  FROM table1 AS t0\n",
-      "  LIMIT 10\n",
-      "  OFFSET 10\n",
-      ")\n",
-      "SELECT\n",
-      "  anon_1.value1,\n",
-      "  anon_1.key1,\n",
-      "  anon_1.key2\n",
-      "FROM anon_1\n",
-      "UNION ALL\n",
-      "SELECT\n",
-      "  anon_2.value1,\n",
-      "  anon_2.key1,\n",
-      "  anon_2.key2\n",
-      "FROM anon_2\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "expr1 = t1.limit(10)\n",
     "expr2 = t1.limit(10, offset=10)\n",
@@ -3154,7 +2178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "id": "670acd4b-6b77-4c1f-a863-1e19580226d7",
    "metadata": {},
    "outputs": [],
@@ -3190,49 +2214,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": null,
    "id": "a3288564-fc33-4001-b692-86cce9f32919",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WITH t0 AS (\n",
-      "  SELECT\n",
-      "    t3.region AS region,\n",
-      "    t3.kind AS kind,\n",
-      "    SUM(t3.amount) AS total\n",
-      "  FROM purchases AS t3\n",
-      "  GROUP BY\n",
-      "    t3.region,\n",
-      "    t3.kind\n",
-      ")\n",
-      "SELECT\n",
-      "  t1.region,\n",
-      "  t1.total - t2.total AS diff\n",
-      "FROM (\n",
-      "  SELECT\n",
-      "    t0.region AS region,\n",
-      "    t0.kind AS kind,\n",
-      "    t0.total AS total\n",
-      "  FROM t0\n",
-      "  WHERE\n",
-      "    t0.kind = CAST('foo' AS TEXT)\n",
-      ") AS t1\n",
-      "JOIN (\n",
-      "  SELECT\n",
-      "    t0.region AS region,\n",
-      "    t0.kind AS kind,\n",
-      "    t0.total AS total\n",
-      "  FROM t0\n",
-      "  WHERE\n",
-      "    t0.kind = CAST('bar' AS TEXT)\n",
-      ") AS t2\n",
-      "  ON t1.region = t2.region\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ibis.show_sql(result)"
    ]


### PR DESCRIPTION
This ensures we don't commit notebooks in their already-run state. Any notebook in a `*/rendered/*` directory will be ignored.