### PR TITLE
fix(sql): ensure that overwrite is valid when clobbering an existing table

### DIFF
--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -20,6 +20,7 @@ from ibis.backends.druid.compiler import DruidCompiler
 class Backend(BaseAlchemyBackend):
     name = 'druid'
     compiler = DruidCompiler
+    supports_create_or_replace = False
 
     def do_connect(
         self,

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -49,6 +49,7 @@ def _format_kwargs(kwargs: Mapping[str, Any]):
 class Backend(BaseAlchemyBackend):
     name = "duckdb"
     compiler = DuckDBSQLCompiler
+    supports_create_or_replace = True
 
     def current_database(self) -> str:
         return "main"

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -16,6 +16,7 @@ class Backend(BaseAlchemyBackend):
     name = "mssql"
     compiler = MsSqlCompiler
     _sqlglot_dialect = "tsql"
+    supports_create_or_replace = False
 
     def do_connect(
         self,

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -17,6 +17,7 @@ from ibis.backends.mysql.datatypes import _type_from_cursor_info
 class Backend(BaseAlchemyBackend):
     name = 'mysql'
     compiler = MySQLCompiler
+    supports_create_or_replace = False
 
     def do_connect(
         self,

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -49,6 +49,7 @@ DROP FUNCTION IF EXISTS public._ibis_first_agg(anyelement, anyelement), public._
 class Backend(BaseAlchemyBackend):
     name = 'postgres'
     compiler = PostgreSQLCompiler
+    supports_create_or_replace = False
 
     def do_connect(
         self,

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -139,6 +139,7 @@ _SNOWFLAKE_MAP_UDFS = {
 class Backend(BaseAlchemyBackend):
     name = "snowflake"
     compiler = SnowflakeCompiler
+    supports_create_or_replace = True
 
     @property
     def _current_schema(self) -> str:

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -75,6 +75,7 @@ class Backend(BaseAlchemyBackend):
     # if there is technical debt that makes this required
     database_class = Database
     compiler = SQLiteCompiler
+    supports_create_or_replace = False
 
     def __getstate__(self) -> dict:
         r = super().__getstate__()

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -18,6 +18,8 @@ from ibis.backends.trino.datatypes import parse
 class Backend(BaseAlchemyBackend):
     name = "trino"
     compiler = TrinoSQLCompiler
+    supports_create_or_replace = False
+    supports_temporary_tables = False
 
     def current_database(self) -> str:
         raise NotImplementedError(type(self))

--- a/ibis/tests/conftest.py
+++ b/ibis/tests/conftest.py
@@ -6,16 +6,23 @@ import hypothesis as h
 
 # setup hypothesis profiles
 h.settings.register_profile(
-    'ci', max_examples=1000, suppress_health_check=[h.HealthCheck.too_slow]
+    'ci',
+    max_examples=1000,
+    suppress_health_check=[h.HealthCheck.too_slow],
+    deadline=None,
 )
 h.settings.register_profile(
-    'dev', max_examples=50, suppress_health_check=[h.HealthCheck.too_slow]
+    'dev',
+    max_examples=50,
+    suppress_health_check=[h.HealthCheck.too_slow],
+    deadline=None,
 )
 h.settings.register_profile(
     'debug',
     max_examples=10,
     verbosity=h.Verbosity.verbose,
     suppress_health_check=[h.HealthCheck.too_slow],
+    deadline=None,
 )
 
 # load default hypothesis profile, either set HYPOTHESIS_PROFILE environment


### PR DESCRIPTION
This PR fixes an issue where we are currently deleting an existing table when
asked to overwrite that table, before executing an expression that may depend
on that table.

The solution is a bit complex, but is robust and takes advantage of `CREATE OR REPLACE` syntax
in backends that support it.

The way the backends that don't support `CREATE OR REPLACE` work is that they:

1. create a temporary table with the input expression's data
1. recreate the target table
1. insert the temp table's data into the target table
1. drop the temp table

Fixes #6014.
