### PR TITLE
fix(mysql): do not fail when we cannot set the session timezone

### DIFF
--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from typing import Iterable, Literal
 
 import sqlalchemy as sa
@@ -104,7 +105,10 @@ class Backend(BaseAlchemyBackend):
         @sa.event.listens_for(engine, "connect")
         def connect(dbapi_connection, connection_record):
             with dbapi_connection.cursor() as cur:
-                cur.execute("SET @@session.time_zone = 'UTC'")
+                try:
+                    cur.execute("SET @@session.time_zone = 'UTC'")
+                except sa.exc.OperationalError:
+                    warnings.warn("Unable to set session timezone to UTC.")
 
         super().do_connect(engine)
 


### PR DESCRIPTION
Apparently you can initialize a mysql server without populating time zone tables. Such setups cannot set the session timezone to UTC, or anything else but SYSTEM. This PR simply warns about not being able to set the session time zone instead of failing. Closes #6010.