### PR TITLE
fix(snowflake): always use pyarrow for memtables

### DIFF
--- a/ibis/backends/pyarrow/__init__.py
+++ b/ibis/backends/pyarrow/__init__.py
@@ -17,7 +17,7 @@ class PyArrowTableProxy(TableProxy):
     def to_frame(self) -> pd.DataFrame:
         return self._data.to_pandas()
 
-    def to_pyarrow(self, _: sch.Schema) -> pa.Table:
+    def to_pyarrow(self, schema: sch.Schema) -> pa.Table:
         return self._data
 
 


### PR DESCRIPTION
Fixes the failing Snowflake backend tests against `master`.

Originally, I implemented just the quoting fixes, but this turned out to expose
some annoyances with quoting in `write_pandas` that were a pain to workaround.

`write_pandas` is overkill for our needs, so I went ahead implemented similar
functionality directly in the Snowflake backend's `_register_in_memory_table`
method. The result is relatively easy to understand compared to what is going
on in `write_pandas`.

It also turned out that we can use this code path regardless of whether a
version of PyArrow is installed that is compatible with bringing back results
from Snowflake in pandas/arrow format. This is because we're only using pyarrow
to write parquet
