### PR TITLE
chore(windows): move warning to error on locale-specific format string usage

### DIFF
--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -1,5 +1,4 @@
 import operator
-import os
 import string
 import warnings
 from datetime import date, datetime
@@ -11,10 +10,12 @@ import pytest
 from pytest import param
 
 import ibis
+import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis import config
 from ibis import literal as L
+from ibis.backends.conftest import WINDOWS
 
 pytest.importorskip("psycopg2")
 sa = pytest.importorskip("sqlalchemy")
@@ -144,21 +145,24 @@ def test_timestamp_cast_noop(alltypes, at, translate):
         param(
             'DD BAR "%c" FOO "D',
             marks=pytest.mark.xfail(
-                condition=os.name == 'nt',
+                condition=WINDOWS,
+                raises=exc.UnsupportedOperationError,
                 reason='Locale-specific format specs not available on Windows',
             ),
         ),
         param(
             'DD BAR "%x" FOO "D',
             marks=pytest.mark.xfail(
-                condition=os.name == 'nt',
+                condition=WINDOWS,
+                raises=exc.UnsupportedOperationError,
                 reason='Locale-specific format specs not available on Windows',
             ),
         ),
         param(
             'DD BAR "%X" FOO "D',
             marks=pytest.mark.xfail(
-                condition=os.name == 'nt',
+                condition=WINDOWS,
+                raises=exc.UnsupportedOperationError,
                 reason='Locale-specific format specs not available on Windows',
             ),
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,8 +280,6 @@ filterwarnings = [
   'ignore:Dialect druid.rest will not make use of SQL compilation caching:',
   # ibis
   'ignore:`(Base)?Backend.database` is deprecated:FutureWarning',
-  # ibis on postgres + windows
-  "ignore:locale specific date formats:UserWarning",
   # spark
   "ignore:distutils Version classes are deprecated:DeprecationWarning",
   "ignore:The distutils package is deprecated and slated for removal:DeprecationWarning",


### PR DESCRIPTION
This PR moves a not-so-useful warning to a more informative error message. Previously this would be a `KeyError`.

xref: #6038