### PR TITLE
feat(common): add pattern matchers

### DIFF
--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -9,7 +9,7 @@ from weakref import WeakValueDictionary
 from ibis.common.annotations import EMPTY, Argument, Attribute, Signature, attribute
 from ibis.common.caching import WeakCache
 from ibis.common.collections import FrozenDict
-from ibis.common.typing import evaluate_typehint
+from ibis.common.typing import evaluate_annotations
 from ibis.common.validators import Validator
 
 
@@ -48,10 +48,10 @@ class AnnotableMeta(BaseMeta):
                 signatures.append(parent.__signature__)
 
         # collection type annotations and convert them to validators
-        module = dct.get('__module__')
-        annots = dct.get('__annotations__', {})
-        for name, typehint in annots.items():
-            typehint = evaluate_typehint(typehint, module)
+        module_name = dct.get('__module__')
+        annotations = dct.get('__annotations__', {})
+        typehints = evaluate_annotations(annotations, module_name)
+        for name, typehint in typehints.items():
             validator = Validator.from_typehint(typehint)
             if name in dct:
                 dct[name] = Argument.default(dct[name], validator, typehint=typehint)

--- a/ibis/common/patterns.py
+++ b/ibis/common/patterns.py
@@ -1,0 +1,1196 @@
+from __future__ import annotations
+
+import inspect
+import math
+import numbers
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Hashable, Mapping, Sequence
+from enum import Enum
+from inspect import Parameter
+from itertools import chain, zip_longest
+from typing import Any as AnyType
+from typing import (
+    Generic,  # noqa: F401
+    Literal,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+from typing_extensions import Annotated, Self, get_args, get_origin
+
+from ibis.common.collections import RewindableIterator, frozendict
+from ibis.common.dispatch import lazy_singledispatch
+from ibis.common.typing import get_bound_typevars, get_type_params
+from ibis.util import is_iterable, promote_tuple
+
+try:
+    from types import UnionType
+except ImportError:
+    UnionType = object()
+
+
+T = TypeVar("T")
+
+
+class CoercionError(Exception):
+    ...
+
+
+class Coercible(ABC):
+    """Protocol for defining coercible types.
+
+    Coercible types define a special ``__coerce__`` method that accepts an object
+    with an instance of the type. Used in conjunction with the ``coerced_to``
+    pattern to coerce arguments to a specific type.
+    """
+
+    __slots__ = ()
+
+    @classmethod
+    @abstractmethod
+    def __coerce__(cls, value: Any, **kwargs: Any) -> Self:
+        ...
+
+
+class ValidationError(Exception):
+    ...
+
+
+class Validator(ABC):
+    __slots__ = ()
+
+    @abstractmethod
+    def validate(self, value, context):
+        ...
+
+
+class MatchError(Exception):
+    ...
+
+
+class NoMatch:
+    """Sentinel value for when a pattern doesn't match."""
+
+
+# TODO(kszucs): have an As[int] or Coerced[int] type in ibis.common.typing which
+# would be used to annotate an argument as coercible to int or to a certain type
+# without needing for the type to inherit from Coercible
+# TODO(kszucs): enforce typevars to be invariant otherwise raise an error
+class Pattern(Validator, Hashable):
+    # TODO(kszucs): may need a flag to set preference for coercion over instance check
+
+    @classmethod
+    def from_typehint(cls, annot: type) -> Pattern:
+        """Construct a pattern from a python type annotation.
+
+        Parameters
+        ----------
+        annot
+            The typehint annotation to construct the pattern from. This must be
+            an already evaluated type annotation.
+
+        Returns
+        -------
+        pattern
+            A pattern that matches the given type annotation.
+        """
+        # TODO(kszucs): cache the result of this function
+        origin, args = get_origin(annot), get_args(annot)
+
+        if origin is None:
+            if annot is Ellipsis or annot is AnyType:
+                return Any()
+            elif annot is None:
+                return Is(None)
+            elif isinstance(annot, TypeVar):
+                # TODO(kszucs): only use coerced_to if annot.__covariant__ is True
+                if annot.__bound__ is None:
+                    return Any()
+                else:
+                    return cls.from_typehint(annot.__bound__)
+            elif isinstance(annot, Enum):
+                return EqualTo(annot)
+            elif issubclass(annot, Coercible):
+                return CoercedTo(annot)
+            else:
+                return InstanceOf(annot)
+        elif origin is Literal:
+            return IsIn(args)
+        elif origin is UnionType or origin is Union:
+            if len(args) == 2 and args[1] is type(None):
+                return Option(cls.from_typehint(args[0]))
+            inners = map(cls.from_typehint, args)
+            return AnyOf(*inners)
+        elif origin is Annotated:
+            annot, *extras = args
+            return AllOf(cls.from_typehint(annot), *extras)
+        elif origin is Callable:
+            if args:
+                arg_hints, return_hint = args
+                arg_patterns = tuple(map(cls.from_typehint, arg_hints))
+                return_pattern = cls.from_typehint(return_hint)
+                return CallableWith(arg_patterns, return_pattern)
+            else:
+                return InstanceOf(Callable)
+        elif issubclass(origin, Tuple):
+            first, *rest = args
+            # TODO(kszucs): consider to support the same SequenceOf path if args
+            # has a single element, e.g. tuple[int] since annotation a single
+            # element tuple is not common OR use typing.Sequence for annotating
+            # instead of tuple[T, ...] OR have a VarTupleOf pattern
+            if rest == [Ellipsis]:
+                inners = cls.from_typehint(first)
+            else:
+                inners = tuple(map(cls.from_typehint, args))
+            return TupleOf(inners)
+        elif issubclass(origin, Sequence):
+            (value_inner,) = map(cls.from_typehint, args)
+            return SequenceOf(value_inner, type=origin)
+        elif issubclass(origin, Mapping):
+            key_inner, value_inner = map(cls.from_typehint, args)
+            return MappingOf(key_inner, value_inner, type=origin)
+        elif issubclass(origin, Coercible) and args:
+            return GenericCoercedTo(annot)
+        elif isinstance(origin, type) and args:
+            return GenericInstanceOf(annot)
+        else:
+            raise NotImplementedError(
+                f"Cannot create validator from annotation {annot} {origin}"
+            )
+
+    @abstractmethod
+    def match(self, value: AnyType, context: dict[str, AnyType]) -> AnyType:
+        """Match a value against the pattern.
+
+        Parameters
+        ----------
+        value
+            The value to match the pattern against.
+        context
+            A dictionary providing arbitrary context for the pattern matching.
+
+        Returns
+        -------
+        match
+            The result of the pattern matching. If the pattern doesn't match
+            the value, then it must return the `NoMatch` sentinel value.
+        """
+        ...
+
+    @abstractmethod
+    def __eq__(self, other: Pattern) -> bool:
+        ...
+
+    def __invert__(self) -> Pattern:
+        return Not(self)
+
+    def __or__(self, other: Pattern) -> Pattern:
+        return AnyOf(self, other)
+
+    def __and__(self, other: Pattern) -> Pattern:
+        return AllOf(self, other)
+
+    def __rshift__(self, name: str) -> Pattern:
+        return Capture(self, name)
+
+    def __rmatmul__(self, name: str) -> Pattern:
+        return Capture(self, name)
+
+    def validate(
+        self, value: AnyType, context: Optional[dict[str, AnyType]] = None
+    ) -> Any:
+        """Validate a value against the pattern.
+
+        If the pattern doesn't match the value, then it raises a `ValidationError`.
+
+        Parameters
+        ----------
+        value
+            The value to match the pattern against.
+        context
+            A dictionary providing arbitrary context for the pattern matching.
+
+        Returns
+        -------
+        match
+            The matched / validated value.
+        """
+        result = self.match(value, context=context)
+        if result is NoMatch:
+            raise ValidationError(f"{value!r} doesn't match {self}")
+        return result
+
+
+class Matcher(Pattern):
+    """A lightweight alternative to `ibis.common.grounds.Concrete`.
+
+    This class is used to create immutable dataclasses with slots and a precomputed
+    hash value for quicker dictionary lookups.
+    """
+
+    __slots__ = ("__precomputed_hash__",)
+
+    def __init__(self, *args) -> Self:
+        for name, value in zip_longest(self.__slots__, args):
+            object.__setattr__(self, name, value)
+        object.__setattr__(self, "__precomputed_hash__", hash(args))
+
+    def __eq__(self, other) -> bool:
+        if self is other:
+            return True
+        if type(self) is not type(other):
+            return NotImplemented
+        return all(
+            getattr(self, name) == getattr(other, name) for name in self.__slots__
+        )
+
+    def __hash__(self) -> int:
+        return self.__precomputed_hash__
+
+    def __setattr__(self, name, value) -> None:
+        raise AttributeError("Can't set attributes on immutable ENode instance")
+
+    def __repr__(self):
+        fields = {k: getattr(self, k) for k in self.__slots__}
+        fieldstring = ", ".join(f"{k}={v!r}" for k, v in fields.items())
+        return f"{self.__class__.__name__}({fieldstring})"
+
+    def __rich_repr__(self):
+        for name in self.__slots__:
+            yield name, getattr(self, name)
+
+
+class Is(Matcher):
+    """Pattern that matches a value against a reference value.
+
+    Parameters
+    ----------
+    value
+        The reference value to match against.
+    """
+
+    __slots__ = ("value",)
+
+    def match(self, value, context):
+        if value is self.value:
+            return value
+        else:
+            return NoMatch
+
+
+class Any(Matcher):
+    """Pattern that accepts any value, basically a no-op."""
+
+    __slots__ = ()
+
+    def match(self, value, context):
+        return value
+
+
+class Capture(Matcher):
+    """Pattern that captures a value in the context.
+
+    Parameters
+    ----------
+    pattern
+        The pattern to match against.
+    name
+        The name to use in the context if the pattern matches.
+    """
+
+    __slots__ = ("pattern", "name")
+
+    def match(self, value, context):
+        value = self.pattern.match(value, context=context)
+        if value is NoMatch:
+            return NoMatch
+        context[self.name] = value
+        return value
+
+
+class Reference(Matcher):
+    """Retrieve a value from the context.
+
+    Parameters
+    ----------
+    key
+        The key to retrieve from the state.
+    """
+
+    __slots__ = ("key",)
+
+    def match(self, context):
+        return context[self.key]
+
+
+class Check(Matcher):
+    """Pattern that checks a value against a predicate.
+
+    Parameters
+    ----------
+    predicate
+        The predicate to use.
+    """
+
+    __slots__ = ("predicate",)
+
+    def match(self, value, context):
+        if self.predicate(value):
+            return value
+        else:
+            return NoMatch
+
+
+class Apply(Matcher):
+    """Pattern that applies a function to the value.
+
+    Parameters
+    ----------
+    func
+        The function to apply.
+    """
+
+    __slots__ = ("func",)
+
+    def match(self, value, context):
+        return self.func(value)
+
+
+class Function(Matcher):
+    """Pattern that checks a value against a function.
+
+    Parameters
+    ----------
+    func
+        The function to use.
+    """
+
+    __slots__ = ("func",)
+
+    def match(self, value, context):
+        return self.func(value, context)
+
+
+class EqualTo(Matcher):
+    """Pattern that checks a value equals to the given value.
+
+    Parameters
+    ----------
+    value
+        The value to check against.
+    """
+
+    __slots__ = ("value",)
+
+    def match(self, value, context):
+        if value == self.value:
+            return value
+        else:
+            return NoMatch
+
+
+class Option(Matcher):
+    """Pattern that matches `None` or a value that passes the inner validator.
+
+    Parameters
+    ----------
+    pattern
+        The inner pattern to use.
+    """
+
+    __slots__ = ("pattern", "default")
+
+    def __init__(self, pattern, default=None):
+        super().__init__(pattern, default)
+
+    def match(self, value, context):
+        if value is None:
+            if self.default is None:
+                return None
+            else:
+                return self.default
+        else:
+            return self.pattern.match(value, context=context)
+
+
+class TypeOf(Matcher):
+    """Pattern that matches a value that is of a given type."""
+
+    __slots__ = ("type",)
+
+    def match(self, value, context):
+        if type(value) is self.type:
+            return value
+        else:
+            return NoMatch
+
+
+class SubclassOf(Matcher):
+    """Pattern that matches a value that is a subclass of a given type.
+
+    Parameters
+    ----------
+    type
+        The type to check against.
+    """
+
+    __slots__ = ("type",)
+
+    def match(self, value, context):
+        if issubclass(value, self.type):
+            return value
+        else:
+            return NoMatch
+
+
+class InstanceOf(Matcher):
+    """Pattern that matches a value that is an instance of a given type.
+
+    Parameters
+    ----------
+    types
+        The type to check against.
+    """
+
+    __slots__ = ("type",)
+
+    def match(self, value, context):
+        if isinstance(value, self.type):
+            return value
+        else:
+            return NoMatch
+
+
+class GenericInstanceOf(Matcher):
+    """Pattern that matches a value that is an instance of a given generic type.
+
+    Parameters
+    ----------
+    typ
+        The type to check against (must be a generic type).
+
+    Examples
+    --------
+    >>> class MyNumber(Generic[T]):
+    ...    value: T
+    ...
+    ...    def __init__(self, value: T):
+    ...        self.value = value
+    ...
+    ...    def __eq__(self, other):
+    ...        return type(self) is type(other) and self.value == other.value
+    ...
+    >>> p = GenericInstanceOf(MyNumber[int])
+    >>> assert p.match(MyNumber(1), {}) == MyNumber(1)
+    >>> assert p.match(MyNumber(1.0), {}) is NoMatch
+    >>>
+    >>> p = GenericInstanceOf(MyNumber[float])
+    >>> assert p.match(MyNumber(1.0), {}) == MyNumber(1.0)
+    >>> assert p.match(MyNumber(1), {}) is NoMatch
+    """
+
+    __slots__ = ("origin", "field_patterns")
+
+    def __init__(self, typ):
+        origin = get_origin(typ)
+        fields = get_bound_typevars(typ)
+        field_inners = {k: Pattern.from_typehint(v) for k, v in fields.items()}
+        super().__init__(origin, frozendict(field_inners))
+
+    def match(self, value, context):
+        if not isinstance(value, self.origin):
+            return NoMatch
+
+        for field, pattern in self.field_patterns.items():
+            attr = getattr(value, field)
+            if pattern.match(attr, context) is NoMatch:
+                return NoMatch
+
+        return value
+
+
+class LazyInstanceOf(Matcher):
+    """A version of `InstanceOf` that accepts qualnames instead of imported classes.
+
+    Useful for delaying imports.
+
+    Parameters
+    ----------
+    types
+        The types to check against.
+    """
+
+    __slots__ = ("types", "check")
+
+    def __init__(self, types):
+        types = promote_tuple(types)
+        check = lazy_singledispatch(lambda x: False)
+        check.register(types, lambda x: True)
+        super().__init__(promote_tuple(types), check)
+
+    def match(self, value, *, context):
+        if self.check(value):
+            return value
+        else:
+            return NoMatch
+
+
+class CoercedTo(Matcher):
+    """Force a value to have a particular Python type.
+
+    If a Coercible subclass is passed, the `__coerce__` method will be used to
+    coerce the value. Otherwise, the type will be called with the value as the
+    only argument.
+
+    Parameters
+    ----------
+    type
+        The type to coerce to.
+    """
+
+    __slots__ = ("target",)
+
+    def __new__(cls, target):
+        if issubclass(target, Coercible):
+            return super().__new__(cls)
+        else:
+            return Apply(target)
+
+    def match(self, value, context):
+        try:
+            value = self.target.__coerce__(value)
+        except CoercionError:
+            return NoMatch
+
+        if isinstance(value, self.target):
+            return value
+        else:
+            return NoMatch
+
+    def __repr__(self):
+        return f"CoercedTo({self.target.__name__!r})"
+
+
+class GenericCoercedTo(Matcher):
+    """Force a value to have a particular generic Python type.
+
+    Parameters
+    ----------
+    typ
+        The type to coerce to. Must be a generic type with bound typevars.
+
+    Examples
+    --------
+    >>> from typing import Generic, TypeVar
+    >>>
+    >>> T = TypeVar("T")
+    >>>
+    >>> class MyNumber(Coercible, Generic[T]):
+    ...     def __init__(self, value):
+    ...         self.value = value
+    ...
+    ...     def __eq__(self, other):
+    ...         return type(self) is type(other) and self.value == other.value
+    ...
+    ...     @classmethod
+    ...     def __coerce__(cls, value, T=None):
+    ...         if issubclass(T, int):
+    ...             return cls(int(value))
+    ...         elif issubclass(T, float):
+    ...             return cls(float(value))
+    ...         else:
+    ...             raise CoercionError(f"Cannot coerce to {T}")
+    ...
+    >>> p = GenericCoercedTo(MyNumber[int])
+    >>> assert p.match(3.14, {}) == MyNumber(3)
+    >>> assert p.match("15", {}) == MyNumber(15)
+    >>>
+    >>> p = GenericCoercedTo(MyNumber[float])
+    >>> assert p.match(3.14, {}) == MyNumber(3.14)
+    >>> assert p.match("15", {}) == MyNumber(15.0)
+    """
+
+    __slots__ = ("origin", "params", "checker")
+
+    def __init__(self, target):
+        # TODO(kszucs): when constructing the checker we shouldn't allow
+        # coercions, only type checks
+        origin = get_origin(target)
+        checker = GenericInstanceOf(target)
+        params = frozendict(get_type_params(target))
+        super().__init__(origin, params, checker)
+
+    def match(self, value, context):
+        try:
+            value = self.origin.__coerce__(value, **self.params)
+        except CoercionError:
+            return NoMatch
+
+        if self.checker.match(value, context) is NoMatch:
+            return NoMatch
+
+        return value
+
+
+class Not(Matcher):
+    """Pattern that matches a value that does not match a given pattern.
+
+    Parameters
+    ----------
+    pattern
+        The pattern which the value should not match.
+    """
+
+    __slots__ = ("pattern",)
+
+    def match(self, value, context):
+        if self.pattern.match(value, context=context) is NoMatch:
+            return value
+        else:
+            return NoMatch
+
+
+class AnyOf(Matcher):
+    """Pattern that if any of the given patterns match.
+
+    Parameters
+    ----------
+    patterns
+        The patterns to match against. The first pattern that matches will be
+        returned.
+    """
+
+    __slots__ = ("patterns",)
+
+    def __init__(self, *patterns):
+        super().__init__(patterns)
+
+    def match(self, value, context):
+        for pattern in self.patterns:
+            result = pattern.match(value, context=context)
+            if result is not NoMatch:
+                return result
+        return NoMatch
+
+
+class AllOf(Matcher):
+    """Pattern that matches if all of the given patterns match.
+
+    Parameters
+    ----------
+    patterns
+        The patterns to match against. The value will be passed through each
+        pattern in order. The changes applied to the value propagate through the
+        patterns.
+    """
+
+    __slots__ = ("patterns",)
+
+    def __init__(self, *patterns):
+        super().__init__(patterns)
+
+    def match(self, value, context):
+        for pattern in self.patterns:
+            value = pattern.match(value, context=context)
+            if value is NoMatch:
+                return NoMatch
+        return value
+
+
+class Length(Matcher):
+    """Pattern that matches if the length of a value is within a given range.
+
+    Parameters
+    ----------
+    exactly
+        The exact length of the value. If specified, `at_least` and `at_most`
+        must be None.
+    at_least
+        The minimum length of the value.
+    at_most
+        The maximum length of the value.
+    """
+
+    __slots__ = ("at_least", "at_most")
+
+    def __init__(
+        self,
+        exactly: Optional[int] = None,
+        at_least: Optional[int] = None,
+        at_most: Optional[int] = None,
+    ):
+        if exactly is not None:
+            if at_least is not None or at_most is not None:
+                raise ValueError("Can't specify both exactly and at_least/at_most")
+            at_least = exactly
+            at_most = exactly
+        super().__init__(at_least, at_most)
+
+    def match(self, value, *, context):
+        length = len(value)
+        if self.at_least is not None and length < self.at_least:
+            return NoMatch
+        if self.at_most is not None and length > self.at_most:
+            return NoMatch
+        return value
+
+
+class Contains(Matcher):
+    """Pattern that matches if a value contains a given value.
+
+    Parameters
+    ----------
+    needle
+        The item that the passed value should contain.
+    """
+
+    __slots__ = ("needle",)
+
+    def match(self, value, context):
+        if self.needle in value:
+            return value
+        else:
+            return NoMatch
+
+
+class IsIn(Matcher):
+    """Pattern that matches if a value is in a given set.
+
+    Parameters
+    ----------
+    haystack
+        The set of values that the passed value should be in.
+    """
+
+    __slots__ = ("haystack",)
+
+    def __init__(self, haystack):
+        super().__init__(frozenset(haystack))
+
+    def match(self, value, context):
+        if value in self.haystack:
+            return value
+        else:
+            return NoMatch
+
+
+class SequenceOf(Matcher):
+    """Pattern that matches if all of the items in a sequence match a given pattern.
+
+    Parameters
+    ----------
+    item
+        The pattern to match against each item in the sequence.
+    type
+        The type to coerce the sequence to. Defaults to tuple.
+    exactly
+        The exact length of the sequence.
+    at_least
+        The minimum length of the sequence.
+    at_most
+        The maximum length of the sequence.
+    """
+
+    __slots__ = ("item_pattern", "type_pattern", "length_pattern")
+
+    def __init__(
+        self,
+        item: Pattern,
+        type: type = tuple,
+        exactly: Optional[int] = None,
+        at_least: Optional[int] = None,
+        at_most: Optional[int] = None,
+    ):
+        item_pattern = pattern(item)
+        type_pattern = CoercedTo(type)
+        length_pattern = Length(at_least=at_least, at_most=at_most)
+        super().__init__(item_pattern, type_pattern, length_pattern)
+
+    def match(self, values, context):
+        if not is_iterable(values):
+            return NoMatch
+
+        result = []
+        for value in values:
+            value = self.item_pattern.match(value, context=context)
+            if value is NoMatch:
+                return NoMatch
+            result.append(value)
+
+        result = self.type_pattern.match(result, context=context)
+        if result is NoMatch:
+            return NoMatch
+
+        return self.length_pattern.match(result, context=context)
+
+
+class TupleOf(Matcher):
+    """Pattern that matches if the respective items in a tuple match the given patterns.
+
+    Parameters
+    ----------
+    fields
+        The patterns to match the respective items in the tuple.
+    """
+
+    __slots__ = ("field_patterns",)
+
+    def __new__(cls, fields):
+        if isinstance(fields, tuple):
+            return super().__new__(cls)
+        else:
+            return SequenceOf(fields, tuple)
+
+    def match(self, values, context):
+        if not is_iterable(values):
+            return NoMatch
+
+        if len(values) != len(self.field_patterns):
+            return NoMatch
+
+        result = []
+        for pattern, value in zip(self.field_patterns, values):
+            value = pattern.match(value, context=context)
+            if value is NoMatch:
+                return NoMatch
+            result.append(value)
+
+        return tuple(result)
+
+
+class MappingOf(Matcher):
+    """Pattern that matches if all of the keys and values match the given patterns.
+
+    Parameters
+    ----------
+    key
+        The pattern to match the keys against.
+    value
+        The pattern to match the values against.
+    type
+        The type to coerce the mapping to. Defaults to dict.
+    """
+
+    __slots__ = ("key_pattern", "value_pattern", "type_pattern")
+
+    def __init__(self, key: Pattern, value: Pattern, type: type = dict):
+        super().__init__(pattern(key), pattern(value), CoercedTo(type))
+
+    def match(self, value, context):
+        if not isinstance(value, Mapping):
+            return NoMatch
+
+        result = {}
+        for k, v in value.items():
+            if (k := self.key_pattern.match(k, context=context)) is NoMatch:
+                return NoMatch
+            if (v := self.value_pattern.match(v, context=context)) is NoMatch:
+                return NoMatch
+            result[k] = v
+
+        result = self.type_pattern.match(result, context=context)
+        if result is NoMatch:
+            return NoMatch
+
+        return result
+
+
+class Object(Matcher):
+    """Pattern that matches if the object has the given attributes and they match the given patterns.
+
+    The type must conform the structural pattern matching protocol, e.g. it must have a
+    __match_args__ attribute that is a tuple of the names of the attributes to match.
+
+    Parameters
+    ----------
+    type
+        The type of the object.
+    *args
+        The positional arguments to match against the attributes of the object.
+    **kwargs
+        The keyword arguments to match against the attributes of the object.
+    """
+
+    __slots__ = ("type", "field_patterns")
+
+    def __init__(self, type, *args, **kwargs):
+        match_args = getattr(type, "__match_args__", tuple())
+        kwargs.update(dict(zip(args, match_args)))
+        super().__init__(type, frozendict(kwargs))
+
+    def match(self, value, context):
+        if not isinstance(value, self.type):
+            return NoMatch
+
+        for attr, pattern in self.field_patterns.items():
+            if not hasattr(value, attr):
+                return NoMatch
+
+            if match(pattern, getattr(value, attr), context=context) is NoMatch:
+                return NoMatch
+
+        return value
+
+
+class CallableWith(Matcher):
+    __slots__ = ("arg_patterns", "return_pattern")
+
+    def __init__(self, args, return_=None):
+        super().__init__(tuple(args), return_ or Any())
+
+    def match(self, value, context):
+        if not callable(value):
+            return NoMatch
+
+        fn = value
+        sig = inspect.signature(fn)
+        # TODO(kszucs): once the validators get replaced with matchers the
+        # following should be re-enabled
+        # from ibis.common.annotations import annotated
+        # fn = annotated(self.arg_patterns, self.return_pattern, value)
+
+        has_varargs = False
+        positional, keyword_only = [], []
+        for p in sig.parameters.values():
+            if p.kind in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD):
+                positional.append(p)
+            elif p.kind is Parameter.KEYWORD_ONLY:
+                keyword_only.append(p)
+            elif p.kind is Parameter.VAR_POSITIONAL:
+                has_varargs = True
+
+        if keyword_only:
+            raise MatchError(
+                "Callable has mandatory keyword-only arguments which cannot be specified"
+            )
+        elif len(positional) > len(self.arg_patterns):
+            # Callable has more positional arguments than expected")
+            return NoMatch
+        elif len(positional) < len(self.arg_patterns) and not has_varargs:
+            # Callable has less positional arguments than expected")
+            return NoMatch
+        else:
+            return fn
+
+
+class PatternSequence(Matcher):
+    __slots__ = ("pattern_window",)
+
+    def __init__(self, patterns):
+        current_patterns = [
+            SequenceOf(Any()) if p is Ellipsis else pattern(p) for p in patterns
+        ]
+        following_patterns = chain(current_patterns[1:], [Not(Any())])
+        pattern_window = tuple(zip(current_patterns, following_patterns))
+        super().__init__(pattern_window)
+
+    @property
+    def first_pattern(self):
+        return self.pattern_window[0][0]
+
+    def match(self, value, context):
+        it = RewindableIterator(value)
+        result = []
+
+        if not self.pattern_window:
+            try:
+                next(it)
+            except StopIteration:
+                return result
+            else:
+                return NoMatch
+
+        for current, following in self.pattern_window:
+            original = current
+
+            if isinstance(current, Capture):
+                current = current.pattern
+            if isinstance(following, Capture):
+                following = following.pattern
+
+            if isinstance(current, (SequenceOf, PatternSequence)):
+                if isinstance(following, SequenceOf):
+                    following = following.item_pattern
+                elif isinstance(following, PatternSequence):
+                    following = following.first_pattern
+
+                matches = []
+                while True:
+                    it.checkpoint()
+                    try:
+                        item = next(it)
+                    except StopIteration:
+                        break
+
+                    if match(following, item, context) is NoMatch:
+                        matches.append(item)
+                    else:
+                        it.rewind()
+                        break
+
+                res = original.match(matches, context=context)
+                if res is NoMatch:
+                    return NoMatch
+                else:
+                    result.extend(res)
+            else:
+                try:
+                    item = next(it)
+                except StopIteration:
+                    return NoMatch
+
+                res = original.match(item, context=context)
+                if res is NoMatch:
+                    return NoMatch
+                else:
+                    result.append(res)
+
+        return result
+
+
+class PatternMapping(Matcher):
+    __slots__ = ("keys_pattern", "values_pattern")
+
+    def __init__(self, patterns):
+        keys_pattern = PatternSequence(list(map(pattern, patterns.keys())))
+        values_pattern = PatternSequence(list(map(pattern, patterns.values())))
+        super().__init__(keys_pattern, values_pattern)
+
+    def match(self, value, context):
+        if not isinstance(value, Mapping):
+            return NoMatch
+
+        keys = value.keys()
+        if (keys := self.keys_pattern.match(keys, context=context)) is NoMatch:
+            return NoMatch
+
+        values = value.values()
+        if (values := self.values_pattern.match(values, context=context)) is NoMatch:
+            return NoMatch
+
+        return dict(zip(keys, values))
+
+
+class Between(Matcher):
+    """Match a value between two bounds.
+
+    Parameters
+    ----------
+    lower
+        The lower bound.
+    upper
+        The upper bound.
+    """
+
+    __slots__ = ("lower", "upper")
+
+    def __init__(self, lower: float = -math.inf, upper: float = math.inf):
+        super().__init__(lower, upper)
+
+    def match(self, value, context):
+        if self.lower <= value <= self.upper:
+            return value
+        else:
+            return NoMatch
+
+
+IsTruish = Check(lambda x: bool(x))
+IsNumber = InstanceOf(numbers.Number) & ~InstanceOf(bool)
+IsString = InstanceOf(str)
+
+
+def NoneOf(*args) -> Pattern:
+    """Match none of the passed patterns."""
+    return Not(AnyOf(*args))
+
+
+def ListOf(pattern):
+    """Match a list of items matching the given pattern."""
+    return SequenceOf(pattern, type=list)
+
+
+def DictOf(key_pattern, value_pattern):
+    """Match a dictionary with keys and values matching the given patterns."""
+    return MappingOf(key_pattern, value_pattern, type=dict)
+
+
+def FrozenDictOf(key_pattern, value_pattern):
+    """Match a frozendict with keys and values matching the given patterns."""
+    return MappingOf(key_pattern, value_pattern, type=frozendict)
+
+
+def pattern(obj: AnyType) -> Pattern:
+    """Create a pattern from various types.
+
+    Parameters
+    ----------
+    obj
+        The object to create a pattern from. Can be a pattern, a type, a callable,
+        a mapping, an iterable or a value.
+
+    Examples
+    --------
+    >>> assert pattern(Any()) == Any()
+    >>> assert pattern(int) == InstanceOf(int)
+    >>>
+    >>> @pattern
+    ... def as_int(x, context):
+    ...     return int(x)
+    >>>
+    >>> assert as_int.match(1, {}) == 1
+
+    Returns
+    -------
+    pattern
+        The constructed pattern.
+    """
+    if obj is Ellipsis:
+        return Any()
+    elif isinstance(obj, Pattern):
+        return obj
+    elif isinstance(obj, Mapping):
+        return PatternMapping(obj)
+    elif isinstance(obj, type):
+        return InstanceOf(obj)
+    elif get_origin(obj):
+        return Pattern.from_typehint(obj)
+    elif is_iterable(obj):
+        return PatternSequence(obj)
+    elif callable(obj):
+        return Function(obj)
+    else:
+        return EqualTo(obj)
+
+
+def match(pat: Pattern, value: AnyType, context: dict[str, AnyType] = None):
+    """Match a value against a pattern.
+
+    Parameters
+    ----------
+    pat
+        The pattern to match against.
+    value
+        The value to match.
+    context
+        Arbitrary mapping of values to be used while matching.
+
+    Examples
+    --------
+    >>> assert match(Any(), 1) == {}
+    >>> assert match(1, 1) == {}
+    >>> assert match(1, 2) is NoMatch
+    >>> assert match(1, 1, context={"x": 1}) == {"x": 1}
+    >>> assert match(1, 2, context={"x": 1}) is NoMatch
+    >>> assert match([1, int], [1, 2]) == {}
+    >>> assert match([1, int, "a" @ InstanceOf(str)], [1, 2, "three"]) == {"a": "three"}
+    """
+    if context is None:
+        context = {}
+
+    pat = pattern(pat)
+    if pat.match(value, context=context) is NoMatch:
+        return NoMatch
+
+    return context

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -1,0 +1,793 @@
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Callable as CallableABC
+from dataclasses import dataclass
+from typing import (
+    Any as AnyType,
+)
+from typing import (
+    Callable,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
+
+import pytest
+from typing_extensions import Annotated
+
+from ibis.common.collections import FrozenDict
+from ibis.common.patterns import (
+    AllOf,
+    Any,
+    AnyOf,
+    Between,
+    CallableWith,
+    Capture,
+    Check,
+    CoercedTo,
+    Coercible,
+    Contains,
+    DictOf,
+    EqualTo,
+    FrozenDictOf,
+    Function,
+    InstanceOf,
+    IsIn,
+    LazyInstanceOf,
+    Length,
+    ListOf,
+    MappingOf,
+    MatchError,
+    NoMatch,
+    NoneOf,
+    Not,
+    Object,
+    Option,
+    Pattern,
+    PatternMapping,
+    PatternSequence,
+    Reference,
+    SequenceOf,
+    SubclassOf,
+    TupleOf,
+    TypeOf,
+    ValidationError,
+    match,
+    pattern,
+)
+
+
+class Double(Pattern):
+    def match(self, value, *, context):
+        return value * 2
+
+    def __eq__(self, other):
+        return type(self) == type(other)
+
+    def __hash__(self):
+        return hash(type(self))
+
+
+class Min(Pattern):
+    def __init__(self, min):
+        self.min = min
+
+    def match(self, value, context):
+        if value >= self.min:
+            return value
+        else:
+            return NoMatch
+
+    def __hash__(self):
+        return hash((self.__class__, self.min))
+
+    def __eq__(self, other):
+        return self.__class__ == other.__class__ and self.min == other.min
+
+
+def test_min():
+    p = Min(10)
+    assert p.match(10, context={}) == 10
+    assert p.match(9, context={}) is NoMatch
+
+
+def test_double():
+    p = Double()
+    assert p.match(10, context={}) == 20
+
+
+def test_any():
+    p = Any()
+    assert p.match(1, context={}) == 1
+    assert p.match("foo", context={}) == "foo"
+
+
+def test_reference():
+    p = Reference("other")
+    context = {"other": 10}
+    assert p.match(context=context) == 10
+
+
+def test_capture():
+    ctx = {}
+
+    p = Capture(Min(11), "result")
+    assert p.match(10, context=ctx) is NoMatch
+    assert ctx == {}
+
+    assert p.match(12, context=ctx) == 12
+    assert ctx == {"result": 12}
+
+
+def test_option():
+    p = Option(InstanceOf(str))
+    assert p.match(None, context={}) is None
+    assert p.match("foo", context={}) == "foo"
+    assert p.match(1, context={}) is NoMatch
+
+
+def test_check():
+    p = Check(lambda x: x == 10)
+    assert p.match(10, context={}) == 10
+    assert p.match(11, context={}) is NoMatch
+
+
+def test_equal_to():
+    p = EqualTo(10)
+    assert p.match(10, context={}) == 10
+    assert p.match(11, context={}) is NoMatch
+
+
+def test_type_of():
+    p = TypeOf(int)
+    assert p.match(1, context={}) == 1
+    assert p.match("foo", context={}) is NoMatch
+
+
+def test_subclass_of():
+    p = SubclassOf(Pattern)
+    assert p.match(Double, context={}) == Double
+    assert p.match(int, context={}) is NoMatch
+
+
+def test_instance_of():
+    p = InstanceOf(int)
+    assert p.match(1, context={}) == 1
+    assert p.match("foo", context={}) is NoMatch
+
+
+def test_lazy_instance_of():
+    p = LazyInstanceOf("re.Pattern")
+    assert p.match(re.compile("foo"), context={}) == re.compile("foo")
+    assert p.match("foo", context={}) is NoMatch
+
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+@dataclass
+class My(Generic[T, S]):
+    a: T
+    b: S
+    c: str
+
+
+def test_generic_instance_of():
+    p = Pattern.from_typehint(My[int, AnyType])
+    assert p.match(My(1, 2, "3"), context={}) == My(1, 2, "3")
+
+    assert match(My[int, AnyType], My(1, 2, "3"), context={}) == {}
+    assert match(My[int, int], My(1, 2, "3"), context={}) == {}
+    assert match(My[int, float], My(1, 2, "3"), context={}) is NoMatch
+    assert match(My[int, float], My(1, 2.0, "3"), context={}) == {}
+
+
+def test_coerced_to():
+    class MyInt(int, Coercible):
+        @classmethod
+        def __coerce__(cls, other):
+            return MyInt(MyInt(other) + 1)
+
+    p = CoercedTo(int)
+    assert p.match(1, context={}) == 1
+    assert p.match("1", context={}) == 1
+    with pytest.raises(ValueError):
+        p.match("foo", context={})
+
+    p = CoercedTo(MyInt)
+    assert p.match(1, context={}) == 2
+    assert p.match("1", context={}) == 2
+    with pytest.raises(ValueError):
+        p.match("foo", context={})
+
+
+def test_generic_coerced_to():
+    T = TypeVar("T")
+    S = TypeVar("S")
+
+    class DataType:
+        def __eq__(self, other):
+            return type(self) == type(other)
+
+    class Integer(DataType):
+        pass
+
+    class String(DataType):
+        pass
+
+    class DataShape:
+        def __eq__(self, other):
+            return type(self) == type(other)
+
+    class Scalar(DataShape):
+        pass
+
+    class Array(DataShape):
+        pass
+
+    class Value(Generic[T, S], Coercible):
+        @classmethod
+        def __coerce__(cls, value, T=..., S=...):
+            return cls(value, Scalar())
+
+        def output_dtype(self) -> T:
+            ...
+
+        def output_shape(self) -> S:
+            ...
+
+    class Literal(Value[T, Scalar]):
+        def __init__(self, value, dtype):
+            self.value = value
+            self.dtype = dtype
+
+        def output_dtype(self) -> T:
+            return self.dtype
+
+        def output_shape(self) -> DataShape:
+            return Scalar()
+
+        def __eq__(self, other):
+            return (
+                type(self) == type(other)
+                and self.value == other.value
+                and self.dtype == other.dtype
+            )
+
+    p = Pattern.from_typehint(Literal[String])
+    r = p.match("foo", context={})
+    assert r == Literal("foo", Scalar())
+
+
+def test_not():
+    p = Not(InstanceOf(int))
+    p1 = ~InstanceOf(int)
+
+    assert p == p1
+    assert p.match(1, context={}) is NoMatch
+    assert p.match("foo", context={}) == "foo"
+
+
+def test_any_of():
+    p = AnyOf(InstanceOf(int), InstanceOf(str))
+    p1 = InstanceOf(int) | InstanceOf(str)
+
+    assert p == p1
+    assert p.match(1, context={}) == 1
+    assert p.match("foo", context={}) == "foo"
+    assert p.match(1.0, context={}) is NoMatch
+
+
+def test_all_of():
+    def negative(x):
+        return x < 0
+
+    p = AllOf(InstanceOf(int), Check(negative))
+    p1 = InstanceOf(int) & Check(negative)
+
+    assert p == p1
+    assert p.match(1, context={}) is NoMatch
+    assert p.match(-1, context={}) == -1
+
+
+def test_none_of():
+    def negative(x):
+        return x < 0
+
+    p = NoneOf(InstanceOf(int), Check(negative))
+    assert p.match(1.0, context={}) == 1.0
+    assert p.match(-1.0, context={}) is NoMatch
+    assert p.match(1, context={}) is NoMatch
+
+
+def test_length():
+    with pytest.raises(ValueError):
+        Length(exactly=3, at_least=3)
+    with pytest.raises(ValueError):
+        Length(exactly=3, at_most=3)
+
+    p = Length(exactly=3)
+    assert p.match([1, 2, 3], context={}) == [1, 2, 3]
+    assert p.match([1, 2], context={}) is NoMatch
+
+    p = Length(at_least=3)
+    assert p.match([1, 2, 3], context={}) == [1, 2, 3]
+    assert p.match([1, 2], context={}) is NoMatch
+
+    p = Length(at_most=3)
+    assert p.match([1, 2, 3], context={}) == [1, 2, 3]
+    assert p.match([1, 2, 3, 4], context={}) is NoMatch
+
+    p = Length(at_least=3, at_most=5)
+    assert p.match([1, 2], context={}) is NoMatch
+    assert p.match([1, 2, 3], context={}) == [1, 2, 3]
+    assert p.match([1, 2, 3, 4], context={}) == [1, 2, 3, 4]
+    assert p.match([1, 2, 3, 4, 5], context={}) == [1, 2, 3, 4, 5]
+    assert p.match([1, 2, 3, 4, 5, 6], context={}) is NoMatch
+
+
+def test_contains():
+    p = Contains(1)
+    assert p.match([1, 2, 3], context={}) == [1, 2, 3]
+    assert p.match([2, 3], context={}) is NoMatch
+
+
+def test_isin():
+    p = IsIn([1, 2, 3])
+    assert p.match(1, context={}) == 1
+    assert p.match(4, context={}) is NoMatch
+
+
+def test_sequence_of():
+    p = SequenceOf(InstanceOf(str), list)
+    assert p.match(["foo", "bar"], context={}) == ["foo", "bar"]
+    assert p.match([1, 2], context={}) is NoMatch
+    assert p.match(1, context={}) is NoMatch
+
+
+def test_list_of():
+    p = ListOf(InstanceOf(str))
+    assert p.match(["foo", "bar"], context={}) == ["foo", "bar"]
+    assert p.match([1, 2], context={}) is NoMatch
+    assert p.match(1, context={}) is NoMatch
+
+
+def test_tuple_of():
+    p = TupleOf((InstanceOf(str), InstanceOf(int), InstanceOf(float)))
+    assert p.match(("foo", 1, 1.0), context={}) == ("foo", 1, 1.0)
+    assert p.match(["foo", 1, 1.0], context={}) == ("foo", 1, 1.0)
+    assert p.match(1, context={}) is NoMatch
+
+    p = TupleOf(InstanceOf(str))
+    assert p == SequenceOf(InstanceOf(str), tuple)
+    assert p.match(("foo", "bar"), context={}) == ("foo", "bar")
+    assert p.match(["foo"], context={}) == ("foo",)
+    assert p.match(1, context={}) is NoMatch
+
+
+def test_mapping_of():
+    p = MappingOf(InstanceOf(str), InstanceOf(int))
+    assert p.match({"foo": 1, "bar": 2}, context={}) == {"foo": 1, "bar": 2}
+    assert p.match({"foo": 1, "bar": "baz"}, context={}) is NoMatch
+    assert p.match(1, context={}) is NoMatch
+
+    p = MappingOf(InstanceOf(str), InstanceOf(str), FrozenDict)
+    assert p.match({"foo": "bar"}, context={}) == FrozenDict({"foo": "bar"})
+    assert p.match({"foo": 1}, context={}) is NoMatch
+
+
+def test_object_pattern():
+    class Foo:
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+    assert match(Object(Foo, 1, b=2), Foo(1, 2)) == {}
+
+
+def test_callable_with():
+    def func(a, b):
+        return str(a) + b
+
+    def func_with_args(a, b, *args):
+        return sum((a, b) + args)
+
+    def func_with_kwargs(a, b, c=1, **kwargs):
+        return str(a) + b + str(c)
+
+    def func_with_mandatory_kwargs(*, c):
+        return c
+
+    p = CallableWith([InstanceOf(int), InstanceOf(str)])
+    assert p.match(10, context={}) is NoMatch
+
+    msg = "Callable has mandatory keyword-only arguments which cannot be specified"
+    with pytest.raises(MatchError, match=msg):
+        p.match(func_with_mandatory_kwargs, context={})
+
+    # Callable has more positional arguments than expected
+    p = CallableWith([InstanceOf(int)] * 2)
+    assert p.match(func_with_kwargs, context={}) is NoMatch
+
+    # Callable has less positional arguments than expected
+    p = CallableWith([InstanceOf(int)] * 4)
+    assert p.match(func_with_kwargs, context={}) is NoMatch
+
+    p = CallableWith([InstanceOf(int)] * 4, InstanceOf(int))
+    assert p.match(func_with_args, context={}) == func_with_args
+
+
+def test_pattern_list():
+    p = PatternSequence([1, 2, InstanceOf(int), ...])
+    assert p.match([1, 2, 3, 4, 5], context={}) == [1, 2, 3, 4, 5]
+    assert p.match([1, 2, 3, 4, 5, 6], context={}) == [1, 2, 3, 4, 5, 6]
+    assert p.match([1, 2, 3, 4], context={}) == [1, 2, 3, 4]
+    assert p.match([1, 2, "3", 4], context={}) is NoMatch
+
+    # subpattern is a simple pattern
+    p = PatternSequence([1, 2, CoercedTo(int), ...])
+    assert p.match([1, 2, 3.0, 4.0, 5.0], context={}) == [1, 2, 3, 4.0, 5.0]
+
+    # subpattern is a sequence
+    p = PatternSequence([1, 2, 3, SequenceOf(CoercedTo(int), at_least=1)])
+    assert p.match([1, 2, 3, 4.0, 5.0], context={}) == [1, 2, 3, 4, 5]
+
+
+def test_matching():
+    assert match("foo", "foo") == {}
+    assert match("foo", "bar") is NoMatch
+
+    assert match(InstanceOf(int), 1) == {}
+    assert match(InstanceOf(int), "foo") is NoMatch
+
+    assert Capture(InstanceOf(float), "pi") == "pi" @ InstanceOf(float)
+    assert Capture(InstanceOf(float), "pi") == InstanceOf(float) >> "pi"
+
+    assert match(Capture(InstanceOf(float), "pi"), 3.14) == {"pi": 3.14}
+    assert match("pi" @ InstanceOf(float), 3.14) == {"pi": 3.14}
+
+    assert match(InstanceOf(int) | InstanceOf(float), 3) == {}
+    assert match(InstanceOf(object) & InstanceOf(float), 3.14) == {}
+
+
+def test_matching_sequence_pattern():
+    assert match([], []) == {}
+    assert match([], [1]) is NoMatch
+
+    assert match([1, 2, 3, 4, ...], list(range(1, 9))) == {}
+    assert match([1, 2, 3, 4, ...], list(range(1, 3))) is NoMatch
+    assert match([1, 2, 3, 4, ...], list(range(1, 5))) == {}
+    assert match([1, 2, 3, 4, ...], list(range(1, 6))) == {}
+
+    assert match([..., 3, 4], list(range(5))) == {}
+    assert match([..., 3, 4], list(range(3))) is NoMatch
+
+    assert match([0, 1, ..., 4], list(range(5))) == {}
+    assert match([0, 1, ..., 4], list(range(4))) is NoMatch
+
+    assert match([...], list(range(5))) == {}
+    assert match([..., 2, 3, 4, ...], list(range(8))) == {}
+
+
+def test_matching_sequence_with_captures():
+    assert match([1, 2, 3, 4, SequenceOf(...)], list(range(1, 9))) == {}
+    assert match([1, 2, 3, 4, "rest" @ SequenceOf(...)], list(range(1, 9))) == {
+        "rest": (5, 6, 7, 8)
+    }
+
+    assert match([0, 1, "var" @ SequenceOf(...), 4], list(range(5))) == {"var": (2, 3)}
+    assert match([0, 1, SequenceOf(...) >> "var", 4], list(range(5))) == {"var": (2, 3)}
+
+    p = [
+        0,
+        1,
+        "ints" @ SequenceOf(InstanceOf(int)),
+        "floats" @ SequenceOf(InstanceOf(float)),
+        6,
+    ]
+    assert match(p, [0, 1, 2, 3, 4.0, 5.0, 6]) == {"ints": (2, 3), "floats": (4.0, 5.0)}
+
+
+def test_matching_sequence_remaining():
+    Seq = SequenceOf
+    IsInt = InstanceOf(int)
+
+    assert match([1, 2, 3, Seq(IsInt, at_least=1)], [1, 2, 3, 4]) == {}
+    assert match([1, 2, 3, Seq(IsInt, at_least=1)], [1, 2, 3]) is NoMatch
+    assert match([1, 2, 3, Seq(IsInt)], [1, 2, 3]) == {}
+    assert match([1, 2, 3, Seq(IsInt, at_most=1)], [1, 2, 3]) == {}
+    assert match([1, 2, 3, Seq(IsInt & Between(0, 10))], [1, 2, 3, 4, 5]) == {}
+    assert match([1, 2, 3, Seq(IsInt & Between(0, 4))], [1, 2, 3, 4, 5]) is NoMatch
+    assert match([1, 2, 3, Seq(IsInt, at_least=2)], [1, 2, 3, 4]) is NoMatch
+    assert match([1, 2, 3, Seq(IsInt, at_least=2) >> "res"], [1, 2, 3, 4, 5]) == {
+        "res": (4, 5)
+    }
+
+
+def test_matching_sequence_complicated():
+    pattern = [
+        1,
+        'a' @ ListOf(InstanceOf(int) & Check(lambda x: x < 10)),
+        4,
+        'b' @ SequenceOf(...),
+        8,
+        9,
+    ]
+    expected = {
+        "a": [2, 3],
+        "b": (5, 6, 7),
+    }
+    assert match(pattern, range(1, 10)) == expected
+
+    pattern = [0, PatternSequence([1, 2]) >> "pairs", 3]
+    expected = {"pairs": [1, 2]}
+    assert match(pattern, [0, 1, 2, 1, 2, 3]) == expected
+
+    pattern = [
+        0,
+        PatternSequence([1, 2]) >> "first",
+        PatternSequence([4, 5]) >> "second",
+        3,
+    ]
+    expected = {"first": [1, 2], "second": [4, 5]}
+    assert match(pattern, [0, 1, 2, 4, 5, 3]) == expected
+
+    pattern = [1, 2, 'remaining' @ SequenceOf(...)]
+    expected = {'remaining': (3, 4, 5, 6, 7, 8, 9)}
+    assert match(pattern, range(1, 10)) == expected
+
+    assert match([0, SequenceOf([1, 2]), 3], [0, [1, 2], [1, 2], 3]) == {}
+
+
+def test_pattern_map():
+    assert PatternMapping({}).match({}, context={}) == {}
+    assert PatternMapping({}).match({1: 2}, context={}) is NoMatch
+
+
+def test_matching_mapping():
+    assert match({}, {}) == {}
+    assert match({}, {1: 2}) is NoMatch
+
+    assert match({1: 2}, {1: 2}) == {}
+    assert match({1: 2}, {1: 3}) is NoMatch
+
+    assert match({}, 3) is NoMatch
+    assert match({'a': "capture" @ InstanceOf(int)}, {'a': 1}) == {"capture": 1}
+
+    p = {
+        "a": "capture" @ InstanceOf(int),
+        "b": InstanceOf(float),
+        ...: InstanceOf(str),
+    }
+    assert match(p, {"a": 1, "b": 2.0, "c": "foo"}) == {"capture": 1}
+    assert match(p, {"a": 1, "b": 2.0, "c": 3}) is NoMatch
+
+    p = {
+        "a": "capture" @ InstanceOf(int),
+        "b": InstanceOf(float),
+        "rest" @ SequenceOf(...): InstanceOf(str),
+    }
+    assert match(p, {"a": 1, "b": 2.0, "c": "foo"}) == {"capture": 1, "rest": ("c",)}
+
+
+@pytest.mark.parametrize(
+    ("pattern", "value", "expected"),
+    [
+        (InstanceOf(bool), True, True),
+        (InstanceOf(str), "foo", "foo"),
+        (InstanceOf(int), 8, 8),
+        (InstanceOf(int), 1, 1),
+        (InstanceOf(float), 1.0, 1.0),
+        (IsIn({"a", "b"}), "a", "a"),
+        (IsIn({"a": 1, "b": 2}), "a", "a"),
+        (IsIn(['a', 'b']), 'a', 'a'),
+        (IsIn(('a', 'b')), 'b', 'b'),
+        (IsIn({'a', 'b', 'c'}), 'c', 'c'),
+        (TupleOf(InstanceOf(int)), (1, 2, 3), (1, 2, 3)),
+        (TupleOf((InstanceOf(int), InstanceOf(str))), (1, "a"), (1, "a")),
+        (ListOf(InstanceOf(str)), ["a", "b"], ["a", "b"]),
+        (AnyOf(InstanceOf(str), InstanceOf(int)), "foo", "foo"),
+        (AnyOf(InstanceOf(str), InstanceOf(int)), 7, 7),
+        (
+            AllOf(InstanceOf(int), Check(lambda v: v >= 3), Check(lambda v: v >= 8)),
+            10,
+            10,
+        ),
+        (
+            MappingOf(InstanceOf(str), InstanceOf(int)),
+            {"a": 1, "b": 2},
+            {"a": 1, "b": 2},
+        ),
+    ],
+)
+def test_various_patterns(pattern, value, expected):
+    assert pattern.match(value, context={}) == expected
+    assert pattern.validate(value, context={}) == expected
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'value'),
+    [
+        (InstanceOf(bool), "foo"),
+        (InstanceOf(str), True),
+        (InstanceOf(int), 8.1),
+        (Min(3), 2),
+        (InstanceOf(int), None),
+        (InstanceOf(float), 1),
+        (IsIn(["a", "b"]), "c"),
+        (IsIn({"a", "b"}), "c"),
+        (IsIn({"a": 1, "b": 2}), "d"),
+        (TupleOf(InstanceOf(int)), (1, 2.0, 3)),
+        (ListOf(InstanceOf(str)), ["a", "b", None]),
+        (AnyOf(InstanceOf(str), Min(4)), 3.14),
+        (AnyOf(InstanceOf(str), Min(10)), 9),
+        (AllOf(InstanceOf(int), Min(3), Min(8)), 7),
+        (DictOf(InstanceOf(int), InstanceOf(str)), {"a": 1, "b": 2}),
+    ],
+)
+def test_various_not_matching_patterns(pattern, value):
+    assert pattern.match(value, context={}) is NoMatch
+    with pytest.raises(ValidationError):
+        pattern.validate(value, context={})
+
+
+@pattern
+def endswith_d(s, context):
+    if not s.endswith("d"):
+        return NoMatch
+    return s
+
+
+def test_pattern_decorator():
+    assert endswith_d.match("abcd", context={}) == "abcd"
+    assert endswith_d.match("abc", context={}) is NoMatch
+
+
+@pytest.mark.parametrize(
+    ("annot", "expected"),
+    [
+        (int, InstanceOf(int)),
+        (str, InstanceOf(str)),
+        (bool, InstanceOf(bool)),
+        (Optional[int], Option(InstanceOf(int))),
+        (Union[int, str], AnyOf(InstanceOf(int), InstanceOf(str))),
+        (Annotated[int, Min(3)], AllOf(InstanceOf(int), Min(3))),
+        (List[int], SequenceOf(InstanceOf(int), list)),
+        (
+            Tuple[int, float, str],
+            TupleOf((InstanceOf(int), InstanceOf(float), InstanceOf(str))),
+        ),
+        (Tuple[int, ...], TupleOf(InstanceOf(int))),
+        (
+            Dict[str, float],
+            DictOf(InstanceOf(str), InstanceOf(float)),
+        ),
+        (FrozenDict[str, int], FrozenDictOf(InstanceOf(str), InstanceOf(int))),
+        (Literal["alpha", "beta", "gamma"], IsIn(("alpha", "beta", "gamma"))),
+        (
+            Callable[[str, int], str],
+            CallableWith((InstanceOf(str), InstanceOf(int)), InstanceOf(str)),
+        ),
+        (Callable, InstanceOf(CallableABC)),
+    ],
+)
+def test_pattern_from_typehint(annot, expected):
+    assert Pattern.from_typehint(annot) == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python3.10 or higher")
+def test_pattern_from_typehint_uniontype():
+    # uniontype marks `type1 | type2` annotations and it's different from
+    # Union[type1, type2]
+    validator = Pattern.from_typehint(str | int | float)
+    assert validator == AnyOf(InstanceOf(str), InstanceOf(int), InstanceOf(float))
+
+
+class PlusOne(Coercible):
+    def __init__(self, value):
+        self.value = value
+
+    @classmethod
+    def __coerce__(cls, obj):
+        return cls(obj + 1)
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.value == other.value
+
+
+class PlusOneRaise(PlusOne):
+    @classmethod
+    def __coerce__(cls, obj):
+        if isinstance(obj, cls):
+            return obj
+        else:
+            raise TypeError("raise on coercion")
+
+
+class PlusOneChild(PlusOne):
+    pass
+
+
+class PlusTwo(PlusOne):
+    @classmethod
+    def __coerce__(cls, obj):
+        return obj + 2
+
+
+def test_pattern_from_coercible_protocol():
+    s = Pattern.from_typehint(PlusOne)
+    assert s.match(1, context={}) == PlusOne(2)
+    assert s.match(10, context={}) == PlusOne(11)
+
+
+def test_pattern_coercible_bypass_coercion():
+    s = Pattern.from_typehint(PlusOneRaise)
+    # bypass coercion since it's already an instance of SomethingRaise
+    assert s.match(PlusOneRaise(10), context={}) == PlusOneRaise(10)
+    # but actually call __coerce__ if it's not an instance
+    with pytest.raises(TypeError, match="raise on coercion"):
+        s.match(10, context={})
+
+
+def test_pattern_coercible_checks_type():
+    s = Pattern.from_typehint(PlusOneChild)
+    v = Pattern.from_typehint(PlusTwo)
+
+    assert s.match(1, context={}) == PlusOneChild(2)
+
+    assert PlusTwo.__coerce__(1) == 3
+    assert v.match(1, context={}) is NoMatch
+
+
+T = TypeVar("T")
+
+
+class DoubledList(Coercible, List[T]):
+    @classmethod
+    def __coerce__(cls, obj):
+        return cls(list(obj) * 2)
+
+
+def test_pattern_coercible_sequence_type():
+    s = Pattern.from_typehint(Sequence[PlusOne])
+    with pytest.raises(TypeError, match=r"Sequence\(\) takes no arguments"):
+        s.match([1, 2, 3], context={})
+
+    s = Pattern.from_typehint(List[PlusOne])
+    assert s == SequenceOf(CoercedTo(PlusOne), type=list)
+    assert s.match([1, 2, 3], context={}) == [PlusOne(2), PlusOne(3), PlusOne(4)]
+
+    s = Pattern.from_typehint(Tuple[PlusOne, ...])
+    assert s == TupleOf(CoercedTo(PlusOne))
+    assert s.match([1, 2, 3], context={}) == (PlusOne(2), PlusOne(3), PlusOne(4))
+
+    s = Pattern.from_typehint(DoubledList[PlusOne])
+    assert s == SequenceOf(CoercedTo(PlusOne), type=DoubledList)
+    assert s.match([1, 2, 3], context={}) == DoubledList(
+        [PlusOne(2), PlusOne(3), PlusOne(4), PlusOne(2), PlusOne(3), PlusOne(4)]
+    )
+
+
+def test_pattern_function():
+    assert pattern(...) == Any()
+    assert pattern(Any()) == Any()
+    assert pattern(int) == InstanceOf(int)
+    assert pattern(List[int]) == ListOf(InstanceOf(int))
+    assert pattern([int, str, 1]) == PatternSequence(
+        [InstanceOf(int), InstanceOf(str), EqualTo(1)]
+    )
+    assert pattern(True) == EqualTo(True)
+
+    def f(x):
+        return x > 0
+
+    assert pattern(f) == Function(f)

--- a/ibis/common/tests/test_typing.py
+++ b/ibis/common/tests/test_typing.py
@@ -1,11 +1,97 @@
-from typing import Optional, Union
+from typing import Generic, Optional, TypeVar, Union
 
-from ibis.common.typing import evaluate_typehint
+from ibis.common.typing import (
+    evaluate_annotations,
+    get_bound_typevars,
+    get_type_hints,
+    get_type_params,
+)
+
+T = TypeVar("T")
+S = TypeVar("S")
+U = TypeVar("U")
 
 
-def test_evaluate_typehint():
-    hint = evaluate_typehint("Union[int, str]", module_name=__name__)
-    assert hint == Union[int, str]
+class My(Generic[T, S, U]):
+    a: T
+    b: S
+    c: str
 
-    hint = evaluate_typehint(Optional[str], module_name=__name__)
-    assert hint == Optional[str]
+    @property
+    def d(self) -> Optional[str]:
+        ...
+
+    @property
+    def e(self) -> U:  # type: ignore
+        ...
+
+
+class MyChild(My):
+    ...
+
+
+def example(a: int, b: str) -> str:  # type: ignore
+    ...
+
+
+def test_evaluate_annotations() -> None:
+    annotations = {"a": "Union[int, str]", "b": "Optional[str]"}
+    hints = evaluate_annotations(annotations, module_name=__name__)
+    assert hints == {"a": Union[int, str], "b": Optional[str]}
+
+
+def test_get_type_hints() -> None:
+    hints = get_type_hints(My)
+    assert hints == {"a": T, "b": S, "c": str}
+
+    hints = get_type_hints(My, include_properties=True)
+    assert hints == {"a": T, "b": S, "c": str, "d": Optional[str], "e": U}
+
+    hints = get_type_hints(MyChild, include_properties=True)
+    assert hints == {"a": T, "b": S, "c": str, "d": Optional[str], "e": U}
+
+    # test that we don't actually mutate the My.__annotations__
+    hints = get_type_hints(My)
+    assert hints == {"a": T, "b": S, "c": str}
+
+    hints = get_type_hints(example)
+    assert hints == {"a": int, "b": str, "return": str}
+
+    hints = get_type_hints(example, include_properties=True)
+    assert hints == {"a": int, "b": str, "return": str}
+
+
+class A(Generic[T, S, U]):
+    a: int
+    b: str
+
+    t: T
+    s: S
+
+    @property
+    def u(self) -> U:  # type: ignore
+        ...
+
+
+class B(A[T, S, bytes]):
+    ...
+
+
+class C(B[T, str]):
+    ...
+
+
+class D(C[bool]):
+    ...
+
+
+def test_get_type_params() -> None:
+    assert get_type_params(A[int, float, str]) == {'T': int, 'S': float, 'U': str}
+    assert get_type_params(B[int, bool]) == {'T': int, 'S': bool, 'U': bytes}
+    assert get_type_params(C[int]) == {'T': int, 'S': str, 'U': bytes}
+    assert get_type_params(D) == {'T': bool, 'S': str, 'U': bytes}
+
+
+def test_get_bound_typevars() -> None:
+    assert get_bound_typevars(A[int, float, str]) == {'t': int, 's': float, 'u': str}
+    assert get_bound_typevars(B[int, bool]) == {'t': int, 's': bool, 'u': bytes}

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -2,58 +2,182 @@ from __future__ import annotations
 
 import sys
 from typing import (
-    TYPE_CHECKING,
     Any,
-    ForwardRef,
-    Iterable,
-    Mapping,
-    Tuple,
+    Dict,
+    Generic,  # noqa: F401
+    Optional,
     TypeVar,
-    Union,
+    get_args,
+    get_origin,
 )
 
-import toolz
+from typing_extensions import get_type_hints as _get_type_hints
 
-# TODO(kszucs): try to use inspect.get_annotations() backport instead
+from ibis.common.caching import memoize
 
-if sys.version_info >= (3, 9):
+Namespace = Dict[str, Any]
 
-    @toolz.memoize
-    def evaluate_typehint(hint, module_name=None) -> Any:
-        if isinstance(hint, str):
-            hint = ForwardRef(hint)
-        if isinstance(hint, ForwardRef):
-            if module_name is None:
-                globalns = {}
-            else:
-                globalns = sys.modules[module_name].__dict__
-            return hint._evaluate(globalns, locals(), frozenset())
-        else:
-            return hint
-
-else:
-
-    @toolz.memoize
-    def evaluate_typehint(hint, module_name) -> Any:
-        if isinstance(hint, str):
-            hint = ForwardRef(hint)
-        if isinstance(hint, ForwardRef):
-            if module_name is None:
-                globalns = {}
-            else:
-                globalns = sys.modules[module_name].__dict__
-            return hint._evaluate(globalns, locals())
-        else:
-            return hint
+T = TypeVar("T")
+U = TypeVar("U")
 
 
-if TYPE_CHECKING:
-    import ibis.expr.datatypes as dt
-    import ibis.expr.schema as sch
+@memoize
+def get_type_hints(
+    obj: Any,
+    include_extras: bool = True,
+    include_properties: bool = False,
+) -> dict[str, Any]:
+    """Get type hints for a callable or class.
 
-    SupportsSchema = TypeVar(
-        "SupportsSchema",
-        Iterable[Tuple[str, Union[str, dt.DataType]]],
-        Mapping[str, Union[str, dt.DataType]],
-        sch.Schema,
-    )
+    Extension of typing.get_type_hints that supports getting type hints for
+    class properties.
+
+    Parameters
+    ----------
+    obj
+        Callable or class to get type hints for.
+    include_extras
+        Whether to include extra type hints such as Annotated.
+    include_properties
+        Whether to include type hints for class properties.
+
+    Returns
+    -------
+    dict[str, Any]
+        Mapping of parameter or attribute name to type hint.
+    """
+    try:
+        hints = _get_type_hints(obj, include_extras=include_extras)
+    except TypeError:
+        return {}
+
+    if include_properties:
+        for name in dir(obj):
+            attr = getattr(obj, name)
+            if isinstance(attr, property):
+                annots = _get_type_hints(attr.fget, include_extras=include_extras)
+                if return_annot := annots.get("return"):
+                    hints[name] = return_annot
+
+    return hints
+
+
+@memoize
+def get_type_params(obj: Any) -> dict[str, Any]:
+    """Get type parameters for a generic class.
+
+    Parameters
+    ----------
+    obj
+        Generic class to get type parameters for.
+
+    Returns
+    -------
+    dict[str, Any]
+        Mapping of type parameter name to type.
+
+    Examples
+    --------
+    >>> from typing import Dict, List
+    >>>
+    >>> class MyList(List[T]): ...
+    >>>
+    >>> get_type_params(MyList[int])
+    {'T': <class 'int'>}
+    >>>
+    >>> class MyDict(Dict[T, U]): ...
+    >>>
+    >>> get_type_params(MyDict[int, str])
+    {'T': <class 'int'>, 'U': <class 'str'>}
+    """
+    args = get_args(obj)
+    origin = get_origin(obj) or obj
+    bases = getattr(origin, "__orig_bases__", ())
+    params = getattr(origin, "__parameters__", ())
+
+    result = {}
+    for base in bases:
+        result.update(get_type_params(base))
+
+    param_names = (p.__name__ for p in params)
+    result.update(zip(param_names, args))
+
+    return result
+
+
+@memoize
+def get_bound_typevars(obj: Any) -> dict[str, Any]:
+    """Get type variables bound to concrete types for a generic class.
+
+    Parameters
+    ----------
+    obj
+        Generic class to get type variables for.
+
+    Returns
+    -------
+    dict[str, Any]
+        Mapping of type variable name to type.
+
+    Examples
+    --------
+    >>> class MyStruct(Generic[T, U]):
+    ...    a: T
+    ...    b: U
+    ...
+    >>> get_bound_typevars(MyStruct[int, str])
+    {'a': <class 'int'>, 'b': <class 'str'>}
+    >>>
+    >>> class MyStruct(Generic[T, U]):
+    ...    a: T
+    ...
+    ...    @property
+    ...    def myprop(self) -> U:
+    ...        ...
+    ...
+    >>> get_bound_typevars(MyStruct[float, bytes])
+    {'a': <class 'float'>, 'myprop': <class 'bytes'>}
+    """
+    origin = get_origin(obj) or obj
+    hints = get_type_hints(origin, include_properties=True)
+    params = get_type_params(obj)
+
+    result = {}
+    for attr, typ in hints.items():
+        if isinstance(typ, TypeVar):
+            result[attr] = params[typ.__name__]
+    return result
+
+
+def evaluate_annotations(
+    annots: dict[str, str], module_name: str, localns: Optional[Namespace] = None
+) -> dict[str, Any]:
+    """Evaluate type annotations that are strings.
+
+    Parameters
+    ----------
+    annots
+        Type annotations to evaluate.
+    module_name
+        The name of the module that the annotations are defined in, hence
+        providing global scope.
+    localns
+        The local namespace to use for evaluation.
+
+    Returns
+    -------
+    dict[str, Any]
+        Actual type hints.
+
+    Examples
+    --------
+    >>> annots = {'a': 'Dict[str, float]', 'b': 'int'}
+    >>> evaluate_annotations(annots, __name__)
+    {'a': typing.Dict[str, float], 'b': <class 'int'>}
+    """
+    module = sys.modules.get(module_name, None)
+    globalns = getattr(module, '__dict__', None)
+    return {
+        k: eval(v, globalns, localns) if isinstance(v, str) else v  # noqa: PGH001
+        for k, v in annots.items()
+    }

--- a/ibis/common/validators.py
+++ b/ibis/common/validators.py
@@ -63,12 +63,7 @@ class Validator(Callable):
         Parameters
         ----------
         annot
-            The typehint annotation to construct a validator from. If a string is
-            available then it must be evaluated before passing it to this function
-            using the ``evaluate_typehint`` function.
-        module
-            The module to evaluate the type annotation in. This is only used
-            when the first argument is a string (or ForwardRef).
+            The typehint annotation to construct a validator from.
 
         Returns
         -------


### PR DESCRIPTION
Converted the previous validator system into a pattern matching system.

The previously used validator system had the following problems:
- Used curried functions which was error prone to missing arguments and was hard to debug.
- Used exceptions for control flow which raising exceptions from the innermost function call giving cryptic error messages.
- While it was similarly composable it was hard to see whether the validator was fully constructed or not.
- We wasn't able traverse the nested validators due to the curried functions.

In addition to those the new approach has the following advantages:
- The pattern matching system is fully composable.
- Not we support syntax sugar for combining patterns using & and |.
- We can capture values at mutiple levels using either `>>` or `@` syntax.
- Support structural pattern matching for sequences, mappings and objects.
