### PR TITLE
feat(duckdb): set `header=True` by default

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -306,6 +306,7 @@ class Backend(BaseAlchemyBackend):
         if any(source.startswith(("http://", "https://")) for source in source_list):
             self._load_extensions(["httpfs"])
 
+        kwargs.setdefault("header", True)
         kwargs["auto_detect"] = kwargs.pop("auto_detect", "columns" not in kwargs)
         source = sa.select(sa.literal_column("*")).select_from(
             sa.func.read_csv(sa.func.list_value(*source_list), _format_kwargs(kwargs))

--- a/ibis/examples/tests/test_examples.py
+++ b/ibis/examples/tests/test_examples.py
@@ -51,3 +51,23 @@ def test_non_example():
     gobbledygook = f"{ibis.util.guid()}"
     with pytest.raises(AttributeError, match=gobbledygook):
         getattr(ibis.examples, gobbledygook)
+
+
+@pytest.mark.duckdb
+@pytest.mark.backend
+@pytest.mark.xfail(
+    LINUX and SANDBOXED,
+    reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
+    raises=OSError,
+)
+@pytest.mark.parametrize(
+    ("example", "expected"),
+    [
+        ("band_members", ["name", "band"]),
+        ("band_instruments", ["name", "plays"]),
+        ("band_instruments2", ["artist", "plays"]),
+    ],
+    ids=["members", "instruments", "instruments2"],
+)
+def test_band(example, expected):
+    assert getattr(ibis.examples, example).fetch().columns == expected


### PR DESCRIPTION
This PR changes the default value of `header` to be `True` for the DuckDB
backend's `read_csv` API.
