### PR TITLE
feat(api): add first/last reduction APIs

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -292,6 +292,28 @@ def _arbitrary(translator, op):
     return f"ANY_VALUE({translator.translate(arg)})"
 
 
+def _first(translator, op):
+    arg = op.arg
+    where = op.where
+
+    if where is not None:
+        arg = ops.Where(where, arg, ibis.NA)
+
+    arg = translator.translate(arg)
+    return f"ARRAY_AGG({arg} IGNORE NULLS)[SAFE_OFFSET(0)]"
+
+
+def _last(translator, op):
+    arg = op.arg
+    where = op.where
+
+    if where is not None:
+        arg = ops.Where(where, arg, ibis.NA)
+
+    arg = translator.translate(arg)
+    return f"ARRAY_REVERSE(ARRAY_AGG({arg} IGNORE NULLS))[SAFE_OFFSET(0)]"
+
+
 def _truncate(kind, units):
     def truncator(translator, op):
         arg, unit = op.args
@@ -656,6 +678,8 @@ OPERATION_REGISTRY = {
     ops.Log: _log,
     ops.Log2: _log2,
     ops.Arbitrary: _arbitrary,
+    ops.First: _first,
+    ops.Last: _last,
     # Geospatial Columnar
     ops.GeoUnaryUnion: unary("ST_UNION_AGG"),
     # Geospatial

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -1031,6 +1031,8 @@ _simple_ops = {
     ops.ArrayCollect: "groupArray",
     ops.Count: "count",
     ops.CountDistinct: "uniq",
+    ops.First: "any",
+    ops.Last: "anyLast",
     # string operations
     ops.StringLength: "length",
     ops.Lowercase: "lower",
@@ -1240,10 +1242,11 @@ def _window(op: ops.WindowFunction, **kw: Any):
         return translate_val(arg, **kw)
 
     window_formatted = format_window_frame(op, op.frame, **kw)
-    func_formatted = translate_val(op.func, **kw)
+    func = op.func.__window_op__
+    func_formatted = translate_val(func, **kw)
     result = f'{func_formatted} {window_formatted}'
 
-    if isinstance(op.func, ops.RankBase):
+    if isinstance(func, ops.RankBase):
         return f"({result} - 1)"
 
     return result

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -419,6 +419,8 @@ operation_registry.update(
         ops.MapMerge: _map_merge,
         ops.Hash: unary(sa.func.hash),
         ops.Median: reduction(sa.func.median),
+        ops.First: reduction(sa.func.first),
+        ops.Last: reduction(sa.func.last),
     }
 )
 

--- a/ibis/backends/impala/tests/snapshots/test_analytic_functions/test_analytic_exprs/first/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_analytic_functions/test_analytic_exprs/first/out.sql
@@ -1,1 +1,1 @@
-first_value(`double_col`)
+first_value(`double_col`) OVER (ORDER BY `id` ASC)

--- a/ibis/backends/impala/tests/snapshots/test_analytic_functions/test_analytic_exprs/last/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_analytic_functions/test_analytic_exprs/last/out.sql
@@ -1,1 +1,1 @@
-last_value(`double_col`)
+last_value(`double_col`) OVER (ORDER BY `id` ASC)

--- a/ibis/backends/impala/tests/test_analytic_functions.py
+++ b/ibis/backends/impala/tests/test_analytic_functions.py
@@ -19,9 +19,8 @@ def table(mockcon):
         pytest.param(
             lambda t: t.string_col.lead(default=0), id="lead_explicit_default"
         ),
-        pytest.param(lambda t: t.double_col.first(), id="first"),
-        pytest.param(lambda t: t.double_col.last(), id="last"),
-        # (t.double_col.nth(4), 'first_value(lag(double_col, 4 - 1))')
+        pytest.param(lambda t: t.double_col.first().over(order_by="id"), id="first"),
+        pytest.param(lambda t: t.double_col.last().over(order_by="id"), id="last"),
         pytest.param(lambda t: t.double_col.ntile(3), id="ntile"),
         pytest.param(lambda t: t.double_col.percent_rank(), id="percent_rank"),
     ],

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -636,6 +636,16 @@ def execute_reduction_series_groupby(op, data, mask, aggcontext=None, **kwargs):
     return aggcontext.agg(data, type(op).__name__.lower())
 
 
+@execute_node.register(ops.First, SeriesGroupBy, type(None))
+def execute_first_series_groupby(op, data, mask, aggcontext=None, **kwargs):
+    return aggcontext.agg(data, lambda x: getattr(x, "iat", x)[0])
+
+
+@execute_node.register(ops.Last, SeriesGroupBy, type(None))
+def execute_last_series_groupby(op, data, mask, aggcontext=None, **kwargs):
+    return aggcontext.agg(data, lambda x: getattr(x, "iat", x)[-1])
+
+
 variance_ddof = {'pop': 0, 'sample': 1}
 
 
@@ -698,6 +708,20 @@ def execute_reduction_series_gb_mask(op, data, mask, aggcontext=None, **kwargs):
     )
 
 
+@execute_node.register(ops.First, SeriesGroupBy, SeriesGroupBy)
+def execute_first_series_gb_mask(op, data, mask, aggcontext=None, **kwargs):
+    return aggcontext.agg(
+        data, functools.partial(_filtered_reduction, mask.obj, lambda x: x.iloc[0])
+    )
+
+
+@execute_node.register(ops.Last, SeriesGroupBy, SeriesGroupBy)
+def execute_last_series_gb_mask(op, data, mask, aggcontext=None, **kwargs):
+    return aggcontext.agg(
+        data, functools.partial(_filtered_reduction, mask.obj, lambda x: x.iloc[-1])
+    )
+
+
 @execute_node.register(
     (ops.CountDistinct, ops.ApproxCountDistinct),
     SeriesGroupBy,
@@ -744,6 +768,18 @@ def execute_count_star_frame_groupby(op, data, _, **kwargs):
 def execute_reduction_series_mask(op, data, mask, aggcontext=None, **kwargs):
     operand = data[mask] if mask is not None else data
     return aggcontext.agg(operand, type(op).__name__.lower())
+
+
+@execute_node.register(ops.First, pd.Series, (pd.Series, type(None)))
+def execute_first_series_mask(op, data, mask, aggcontext=None, **kwargs):
+    operand = data[mask] if mask is not None else data
+    return aggcontext.agg(operand, lambda x: x.iloc[0])
+
+
+@execute_node.register(ops.Last, pd.Series, (pd.Series, type(None)))
+def execute_last_series_mask(op, data, mask, aggcontext=None, **kwargs):
+    operand = data[mask] if mask is not None else data
+    return aggcontext.agg(operand, lambda x: x.iloc[-1])
 
 
 @execute_node.register(

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -107,15 +107,15 @@ def test_lag_delta(t, df, range_offset, default, range_window):
 def test_first(t, df):
     expr = t.dup_strings.first()
     result = expr.execute()
-    expected = df.dup_strings.iloc[np.repeat(0, len(df))].reset_index(drop=True)
-    tm.assert_series_equal(result, expected)
+    expected = df.dup_strings.iat[0]
+    assert result == expected
 
 
 def test_last(t, df):
     expr = t.dup_strings.last()
     result = expr.execute()
-    expected = df.dup_strings.iloc[np.repeat(-1, len(df))].reset_index(drop=True)
-    tm.assert_series_equal(result, expected)
+    expected = df.dup_strings.iat[-1]
+    assert result == expected
 
 
 def test_group_by_mutate_analytic(t, df):

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -643,6 +643,8 @@ _reductions = {
     ops.Variance: 'var',
     ops.CountDistinct: 'n_unique',
     ops.Median: 'median',
+    ops.First: 'first',
+    ops.Last: 'last',
 }
 
 for reduction in _reductions.keys():

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -711,5 +711,7 @@ operation_registry.update(
         ops.Arbitrary: _arbitrary,
         ops.StructColumn: _struct_column,
         ops.StructField: _struct_field,
+        ops.First: reduction(sa.func.public._ibis_first),
+        ops.Last: reduction(sa.func.public._ibis_last),
     }
 )

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -539,21 +539,7 @@ def compile_any(t, op, *, aggcontext=None, **kwargs):
 
 @compiles(ops.NotAny)
 def compile_notany(t, op, *args, aggcontext=None, **kwargs):
-    # The code here is a little ugly because the translation are different
-    # with different context.
-    # When translating col.notany() (context is None), we returns the dataframe
-    # so we need to negate the aggregator, i.e., df.select(~F.max(col))
-    # When traslating col.notany().over(w), we need to negate the result
-    # after the window translation, i.e., ~(F.max(col).over(w))
-
-    if aggcontext is None:
-
-        def fn(col):
-            return ~F.max(col)
-
-        return compile_aggregator(t, op, *args, fn=fn, aggcontext=aggcontext, **kwargs)
-    else:
-        return ~compile_any(t, op, *args, aggcontext=aggcontext, **kwargs)
+    return ~compile_any(t, op, *args, aggcontext=aggcontext, **kwargs)
 
 
 @compiles(ops.All)
@@ -563,15 +549,7 @@ def compile_all(t, op, *args, **kwargs):
 
 @compiles(ops.NotAll)
 def compile_notall(t, op, *, aggcontext=None, **kwargs):
-    # See comments for opts.NotAny for reasoning for the if/else
-    if aggcontext is None:
-
-        def fn(col):
-            return ~F.min(col)
-
-        return compile_aggregator(t, op, fn=fn, aggcontext=aggcontext, **kwargs)
-    else:
-        return ~compile_all(t, op, aggcontext=aggcontext, **kwargs)
+    return ~compile_all(t, op, aggcontext=aggcontext, **kwargs)
 
 
 @compiles(ops.Count)

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -418,5 +418,11 @@ operation_registry.update(
             lambda: 0.5 + sa.func.random() / sa.cast(-1 << 64, sa.REAL), 0
         ),
         ops.Arbitrary: _arbitrary,
+        ops.First: lambda t, op: t.translate(
+            ops.Arbitrary(op.arg, where=op.where, how="first")
+        ),
+        ops.Last: lambda t, op: t.translate(
+            ops.Arbitrary(op.arg, where=op.where, how="last")
+        ),
     }
 )

--- a/ibis/backends/sqlite/tests/snapshots/test_functions/test_count_on_order_by/out.sql
+++ b/ibis/backends/sqlite/tests/snapshots/test_functions/test_count_on_order_by/out.sql
@@ -1,0 +1,30 @@
+SELECT
+  COUNT(*) AS count
+FROM (
+  SELECT
+    t1."playerID" AS "playerID",
+    t1."yearID" AS "yearID",
+    t1.stint AS stint,
+    t1."teamID" AS "teamID",
+    t1."lgID" AS "lgID",
+    t1."G" AS "G",
+    t1."AB" AS "AB",
+    t1."R" AS "R",
+    t1."H" AS "H",
+    t1."X2B" AS "X2B",
+    t1."X3B" AS "X3B",
+    t1."HR" AS "HR",
+    t1."RBI" AS "RBI",
+    t1."SB" AS "SB",
+    t1."CS" AS "CS",
+    t1."BB" AS "BB",
+    t1."SO" AS "SO",
+    t1."IBB" AS "IBB",
+    t1."HBP" AS "HBP",
+    t1."SH" AS "SH",
+    t1."SF" AS "SF",
+    t1."GIDP" AS "GIDP"
+  FROM batting AS t1
+  ORDER BY
+    t1."playerID" DESC
+) AS t0

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -706,11 +706,10 @@ def test_scalar_parameter(alltypes):
     tm.assert_series_equal(result, expected)
 
 
-def test_count_on_order_by(con):
+def test_count_on_order_by(con, snapshot):
     t = con.table("batting")
     sort_key = ibis.desc(t.playerID)
     sorted_table = t.order_by(sort_key)
     expr = sorted_table.count()
-    result = str(expr.compile().compile(compile_kwargs={'literal_binds': True}))
-    expected = "SELECT count(*) AS count \nFROM batting AS t0"
-    assert result == expected
+    result = str(ibis.to_sql(expr, dialect="sqlite"))
+    snapshot.assert_match(result, "out.sql")

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -591,7 +591,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notimpl(
-                    ["bigquery", "snowflake", "trino"],
+                    ["bigquery", "trino"],
                     raises=com.UnsupportedOperationError,
                     reason="backend only supports the `first` option for `.arbitrary()",
                 ),
@@ -628,6 +628,24 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     reason="Snowflake only supports the `first` option for `.arbitrary()",
                 ),
             ],
+        ),
+        param(
+            lambda t, where: t.double_col.first(where=where),
+            lambda t, where: t.double_col[where].iloc[0],
+            id='first',
+            marks=pytest.mark.notimpl(
+                ["dask", "datafusion", "druid", "impala", "mssql", "mysql"],
+                raises=com.OperationNotDefinedError,
+            ),
+        ),
+        param(
+            lambda t, where: t.double_col.last(where=where),
+            lambda t, where: t.double_col[where].iloc[-1],
+            id='last',
+            marks=pytest.mark.notimpl(
+                ["dask", "datafusion", "druid", "impala", "mssql", "mysql"],
+                raises=com.OperationNotDefinedError,
+            ),
         ),
         param(
             lambda t, where: t.bigint_col.bit_and(where=where),
@@ -1171,7 +1189,7 @@ def test_group_concat(
     ],
 )
 @mark.notimpl(
-    ["pandas", "dask"],
+    ["dask"],
     raises=NotImplementedError,
     reason="sorting on aggregations not yet implemented",
 )
@@ -1201,7 +1219,7 @@ def test_topk_op(alltypes, df, result_fn, expected_fn):
         )
     ],
 )
-@mark.notimpl(["datafusion", "pandas"], raises=com.OperationNotDefinedError)
+@mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 @mark.broken(
     ["bigquery"],
     raises=GoogleBadRequest,
@@ -1216,7 +1234,7 @@ def test_topk_op(alltypes, df, result_fn, expected_fn):
     ),
 )
 @mark.notimpl(
-    ["pandas", "dask"],
+    ["dask"],
     raises=NotImplementedError,
     reason="sorting on aggregations not yet implemented",
 )

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1053,7 +1053,7 @@ def test_pivot_wider(backend):
         param(
             "last",
             marks=pytest.mark.notimpl(
-                ["bigquery", "snowflake", "trino"],
+                ["bigquery", "trino"],
                 raises=com.UnsupportedOperationError,
                 reason="backend doesn't support how='last'",
             ),

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import partial
+from typing import Literal
 
 import sqlalchemy as sa
 from sqlalchemy.ext.compiler import compiles
@@ -227,6 +228,10 @@ def _array_filter(t, op):
     )
 
 
+def _first_last(t, op, *, offset: Literal[-1, 1]):
+    return sa.func.element_at(t._reduction(sa.func.array_agg, op), offset)
+
+
 operation_registry.update(
     {
         # conditional expressions
@@ -401,6 +406,8 @@ operation_registry.update(
         ),
         ops.StartsWith: fixed_arity(sa.func.starts_with, 2),
         ops.Argument: lambda _, op: sa.literal_column(op.name),
+        ops.First: partial(_first_last, offset=1),
+        ops.Last: partial(_first_last, offset=-1),
     }
 )
 

--- a/ibis/expr/operations/analytic.py
+++ b/ibis/expr/operations/analytic.py
@@ -12,6 +12,10 @@ from ibis.expr.operations.core import Value
 class Analytic(Value):
     output_shape = rlz.Shape.COLUMNAR
 
+    @property
+    def __window_op__(self):
+        return self
+
 
 @public
 class ShiftBase(Analytic):

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1287,19 +1287,57 @@ class Column(Value, _FixedTextJupyterMixin):
             .agg(**{f"{name}_count": lambda t: t.count()})
         )
 
-    def first(self) -> Column:
+    def first(self, where: ir.BooleanValue | None = None) -> Value:
         """Return the first value of a column.
 
-        Equivalent to SQL's `FIRST_VALUE` window function.
+        Examples
+        --------
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.memtable({"chars": ["a", "b", "c", "d"]})
+        >>> t
+        ┏━━━━━━━━┓
+        ┃ chars  ┃
+        ┡━━━━━━━━┩
+        │ string │
+        ├────────┤
+        │ a      │
+        │ b      │
+        │ c      │
+        │ d      │
+        └────────┘
+        >>> t.chars.first()
+        'a'
+        >>> t.chars.first(where=t.chars != 'a')
+        'b'
         """
-        return ops.FirstValue(self).to_expr()
+        return ops.First(self, where=where).to_expr()
 
-    def last(self) -> Column:
+    def last(self, where: ir.BooleanValue | None = None) -> Value:
         """Return the last value of a column.
 
-        Equivalent to SQL's `LAST_VALUE` window function.
+        Examples
+        --------
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.memtable({"chars": ["a", "b", "c", "d"]})
+        >>> t
+        ┏━━━━━━━━┓
+        ┃ chars  ┃
+        ┡━━━━━━━━┩
+        │ string │
+        ├────────┤
+        │ a      │
+        │ b      │
+        │ c      │
+        │ d      │
+        └────────┘
+        >>> t.chars.last()
+        'd'
+        >>> t.chars.last(where=t.chars != 'd')
+        'c'
         """
-        return ops.LastValue(self).to_expr()
+        return ops.Last(self, where=where).to_expr()
 
     def rank(self) -> ir.IntegerColumn:
         """Compute position of first element within each equal-value group in sorted order.


### PR DESCRIPTION
This PR extends the `first` and `last` methods to operate in a reduction
context, as well as their existing window context.

**BREAKING CHANGE:** All `Column.first()`/`Column.last()` expressions are now reductions and return a single value, where previously they would return the first value replicated over the number of rows of the child table.

Notes:

- Performance likely varies a lot between backends. Some have native first/last
  support and some don't. For the ones that don't, I've implemented the
  operations as an array agg followed by an array index of the first or last
  element. If the query planner isn't smart enough to realize it doesn't
  actually need to aggregate the entire array then for large columns we'll see a performance hit.

- To support the reduction API I added a `where` argument to `first`/`last`.
  This isn't compatible with `first_value`/`last_value` (the window cousins).
  I raise an error during compilation, since we don't know whether a window
  context is in use until then. We could later address this by transforming
  `ops.First`/`ops.Last` into the appropriate `ops.*Value` operation in the
  `.over()` call. That's a lot more (and more fragile) code than what I do
  here.

Closes #4149.
