### PR TITLE
docs: Create Ibis for dplyr users document

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,6 +22,7 @@
         * [Configuration](api/config.md)
     * [Ibis for SQL Programmers](ibis-for-sql-programmers.ipynb)
     * [Ibis for pandas Users](ibis-for-pandas-users.ipynb)
+    * [Ibis for dplyr Users](ibis-for-dplyr-users.ipynb)
     * [Backend Operations Matrix](backends/support_matrix.md)
     * [Why Ibis?](why_ibis.md)
 * [Releases](release_notes.md)

--- a/docs/ibis-for-dplyr-users.ipynb
+++ b/docs/ibis-for-dplyr-users.ipynb
@@ -1,0 +1,288 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ibis for dplyr Users"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[R](https://www.r-project.org/) users familiar with [dplyr](https://dplyr.tidyverse.org/) are likely to find some parts of Ibis familiar.\n",
+    "In fact, some Ibis verbs have been named to match their corresponding dplyr verbs.\n",
+    "\n",
+    "However, due to constraints of the Python programming language and the design and goals of Ibis itself, analysts familiar with dplyr may notice some big between the two right away:\n",
+    "\n",
+    "TODO: Fill this list in more.\n",
+    "\n",
+    "- No pipe syntax but you do have chaining\n",
+    "- mutate can't do internal references, you have to chain mutates\n",
+    "- ibis has more similar to dplyr+dbplyr (TODO: expand on this)\n",
+    "- `_` as a helper\n",
+    "- NULL ordering. ibis sorts NULLs differently than dplyr/R. TODO:\n",
+    "    - Figure out why this is and explain it well\n",
+    "- There are multiple ways to reference columns (by string or by \"reference\")\n",
+    "- Wrapping complex expressions in parens to make the evaluate correctly"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparison\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading Ibis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ibis\n",
+    "import ibis.examples as ex\n",
+    "import ibis.selectors as s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ibis import _"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ibis.options.interactive = True"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading example data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars = ex.starwars.fetch()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.head()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### filter()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.filter([_.skin_color == \"light\", _.eye_color == \"brown\"])"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### arrange()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.order_by(_.height)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.order_by(_.height.desc())"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### slice()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.limit(5, offset = 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.select([\"hair_color\", \"skin_color\", \"eye_color\"])"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### select()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.select(s.endswith(\"color\"))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### rename()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.relabel({\"homeworld\": \"home_world\"})"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### mutate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.mutate(height_m = _.height / 100).select(\"height_m\", \"height\", ~s.contains(\"height\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(starwars\n",
+    "    .mutate(\n",
+    "        height_m = _.height / 100\n",
+    "    )\n",
+    "    .mutate(        \n",
+    "        BMI = _.mass / (_.height_m**2)\n",
+    "    )\n",
+    "    .select(\"BMI\", ~s.matches(\"BMI\"))\n",
+    ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### summarize() / summarise()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "starwars.aggregate(height = _.height.mean())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ibis-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Addresses https://github.com/ibis-project/ibis/issues/5922.

@fmichonneau and I paired up on https://github.com/ibis-project/ibis/issues/5922 during the recent Ibis doc-a-thon. To keep the work in scope for the doc-a-thon, we decided to start small and base the content on https://dplyr.tidyverse.org/articles/dplyr.html. @fmichonneau brought that content in and developed Ibis equivalents for each bit. I then extended that by adding a section at the top highlighting major differences and also added in joins and pivoting to make it more comprehensive.

@fmichonneau could you take a look, especially at the content I added?

After that, I think it'd be good to get @ianmcook to review and also a core Ibis dev.

Specific bits of feedback I'm interested in are:

- Is the size/scope of this enough? The other Ibis for X guides are more comprehensive.
- Does the section at the top about major differences work? Is it accurate and complete?