### PR TITLE
chore(deps): clean up the nix setup a bit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
 
       backendDevDeps = with pkgs; [
         # impala UDFs
-        clang_12
+        clang_15
         cmake
         ninja
         # snowflake
@@ -122,7 +122,7 @@
       packages = {
         inherit (pkgs) ibis38 ibis39 ibis310 ibis311;
 
-        default = pkgs.ibis311;
+        default = pkgs.ibis310;
 
         inherit (pkgs) update-lock-files gen-all-extras gen-examples check-poetry-version;
       };

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -92,6 +92,11 @@ def test_read_postgres(con, pgurl):  # pragma: no cover
     assert table.count().execute()
 
 
+@pytest.mark.xfail(
+    LINUX and SANDBOXED,
+    reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
+    raises=duckdb.IOException,
+)
 def test_read_sqlite(con, tmp_path):
     path = tmp_path / "test.db"
 
@@ -116,6 +121,11 @@ def test_read_sqlite_no_table_name(con, tmp_path):
         con.read_sqlite(path)
 
 
+@pytest.mark.xfail(
+    LINUX and SANDBOXED,
+    reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
+    raises=duckdb.IOException,
+)
 def test_register_sqlite(con, tmp_path):
     path = tmp_path / "test.db"
 

--- a/nix/ibis.nix
+++ b/nix/ibis.nix
@@ -45,16 +45,12 @@ poetry2nix.mkPoetryApplication rec {
 
     runHook preCheck
 
-    # the sqlite-on-duckdb tests try to download the sqlite_scanner extension
-    # but network usage is not allowed in the sandbox
-    pytest -m '${markers}' --numprocesses "$NIX_BUILD_CORES" --dist loadgroup \
-      --deselect=ibis/backends/duckdb/tests/test_register.py::test_read_sqlite \
-      --deselect=ibis/backends/duckdb/tests/test_register.py::test_register_sqlite
+    pytest -m '${markers}' --numprocesses "$NIX_BUILD_CORES" --dist loadgroup
 
     runHook postCheck
   '';
 
   doCheck = true;
 
-  pythonImportsCheck = [ "ibis" ] ++ (map (backend: "ibis.backends.${backend}") backends);
+  pythonImportsCheck = [ "ibis" ] ++ map (backend: "ibis.backends.${backend}") backends;
 }


### PR DESCRIPTION
This PR cleans up the nix setup a bit, making a couple tests sandbox aware and bumping the version of clang we use.