### PR TITLE
test(bigquery): return the client instead of a bogus SQL result

### DIFF
--- a/ibis/backends/bigquery/tests/system/conftest.py
+++ b/ibis/backends/bigquery/tests/system/conftest.py
@@ -65,9 +65,11 @@ def client(credentials, project_id, dataset_id):
         project_id=project_id, dataset_id=dataset_id, credentials=credentials
     )
     try:
-        return con.sql("SELECT 1")
+        con.sql("SELECT 1")
     except gexc.Forbidden:
         pytest.skip("Cannot access BigQuery")
+    else:
+        return con
 
 
 @pytest.fixture(scope="session")
@@ -76,9 +78,11 @@ def client2(credentials, project_id, dataset_id):
         project_id=project_id, dataset_id=dataset_id, credentials=credentials
     )
     try:
-        return con.sql("SELECT 1")
+        con.sql("SELECT 1")
     except gexc.Forbidden:
         pytest.skip("Cannot access BigQuery")
+    else:
+        return con
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This PR fixes the failing BigQuery CI.