### PR TITLE
fix(sqlalchemy): ensure that a table's schema is threaded through type inference

### DIFF
--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -467,8 +467,15 @@ class BaseAlchemyBackend(BaseSQLBackend):
         """Handle cases where SQLAlchemy cannot infer the column types of `table`."""
 
         self.inspector.reflect_table(table, table.columns)
+
         dialect = self.con.dialect
-        quoted_name = dialect.identifier_preparer.quote(table.name)
+
+        quoted_name = ".".join(
+            map(
+                dialect.identifier_preparer.quote,
+                filter(None, [table.schema, table.name]),
+            )
+        )
 
         for colname, type in self._metadata(quoted_name):
             if colname in nulltype_cols:

--- a/ibis/backends/mysql/tests/test_client.py
+++ b/ibis/backends/mysql/tests/test_client.py
@@ -86,3 +86,18 @@ def test_blob_type(con, coltype):
     finally:
         with con.begin() as c:
             c.exec_driver_sql(f"DROP TABLE {tmp}")
+
+
+@pytest.fixture(scope="session")
+def tmp_t(con_nodb):
+    with con_nodb.begin() as c:
+        c.exec_driver_sql("CREATE TABLE IF NOT EXISTS test_schema.t (x INET6)")
+    yield
+    with con_nodb.begin() as c:
+        c.exec_driver_sql("DROP TABLE IF EXISTS test_schema.t")
+
+
+@pytest.mark.usefixtures("setup_privs", "tmp_t")
+def test_get_schema_from_query_other_schema(con_nodb):
+    t = con_nodb.table("t", schema="test_schema")
+    assert t.schema() == ibis.schema({"x": dt.string})


### PR DESCRIPTION
Fixes a bug in the sqlalchemy backends where the schema was not prepended to a table in metadata queries. Fixes #6054.