### PR TITLE
refactor(test): cleanup test data

### DIFF
--- a/ci/schema/druid.sql
+++ b/ci/schema/druid.sql
@@ -41,7 +41,7 @@ FROM TABLE(
   EXTERN(
     '{"type":"local","files":["/opt/shared/functional_alltypes.parquet"]}',
     '{"type":"parquet"}',
-    '[{"name":"index","type":"long"},{"name":"Unnamed: 0","type":"long"},{"name":"id","type":"long"},{"name":"bool_col","type":"long"},{"name":"tinyint_col","type":"long"},{"name":"smallint_col","type":"long"},{"name":"int_col","type":"long"},{"name":"bigint_col","type":"long"},{"name":"float_col","type":"double"},{"name":"double_col","type":"double"},{"name":"date_string_col","type":"string"},{"name":"string_col","type":"string"},{"name":"timestamp_col","type":"string"},{"name":"year","type":"long"},{"name":"month","type":"long"}]'
+    '[{"name":"id","type":"long"},{"name":"bool_col","type":"long"},{"name":"tinyint_col","type":"long"},{"name":"smallint_col","type":"long"},{"name":"int_col","type":"long"},{"name":"bigint_col","type":"long"},{"name":"float_col","type":"double"},{"name":"double_col","type":"double"},{"name":"date_string_col","type":"string"},{"name":"string_col","type":"string"},{"name":"timestamp_col","type":"string"},{"name":"year","type":"long"},{"name":"month","type":"long"}]'
   )
 )
 PARTITIONED BY ALL TIME;

--- a/ci/schema/duckdb.sql
+++ b/ci/schema/duckdb.sql
@@ -46,8 +46,6 @@ CREATE OR REPLACE TABLE awards_players (
 );
 
 CREATE OR REPLACE TABLE functional_alltypes (
-    "index" BIGINT,
-    "Unnamed: 0" BIGINT,
     id INTEGER,
     bool_col BOOLEAN,
     tinyint_col SMALLINT,

--- a/ci/schema/mssql.sql
+++ b/ci/schema/mssql.sql
@@ -70,8 +70,6 @@ WITH (FORMAT = 'CSV', FIELDTERMINATOR = ',', ROWTERMINATOR = '\n', FIRSTROW = 2)
 DROP TABLE IF EXISTS functional_alltypes;
 
 CREATE TABLE functional_alltypes (
-    "index" BIGINT,
-    "Unnamed: 0" BIGINT,
     id INTEGER,
     bool_col BIT,
     tinyint_col SMALLINT,
@@ -90,8 +88,6 @@ CREATE TABLE functional_alltypes (
 BULK INSERT functional_alltypes
 FROM '/data/functional_alltypes.csv'
 WITH (FORMAT = 'CSV', FIELDTERMINATOR = ',', ROWTERMINATOR = '\n', FIRSTROW = 2)
-
-CREATE INDEX "ix_functional_alltypes_index" ON functional_alltypes ("index");
 
 DROP TABLE IF EXISTS win;
 

--- a/ci/schema/mysql.sql
+++ b/ci/schema/mysql.sql
@@ -54,8 +54,6 @@ CREATE TABLE awards_players (
 DROP TABLE IF EXISTS functional_alltypes;
 
 CREATE TABLE functional_alltypes (
-    `index` BIGINT,
-    `Unnamed: 0` BIGINT,
     id INTEGER,
     bool_col BOOLEAN,
     tinyint_col TINYINT,
@@ -70,8 +68,6 @@ CREATE TABLE functional_alltypes (
     year INTEGER,
     month INTEGER
 ) DEFAULT CHARACTER SET = utf8;
-
-CREATE INDEX `ix_functional_alltypes_index` ON functional_alltypes (`index`);
 
 DROP TABLE IF EXISTS json_t CASCADE;
 

--- a/ci/schema/postgresql.sql
+++ b/ci/schema/postgresql.sql
@@ -63,8 +63,6 @@ CREATE TABLE awards_players (
 DROP TABLE IF EXISTS functional_alltypes CASCADE;
 
 CREATE TABLE functional_alltypes (
-    "index" BIGINT,
-    "Unnamed: 0" BIGINT,
     id INTEGER,
     bool_col BOOLEAN,
     tinyint_col SMALLINT,
@@ -79,8 +77,6 @@ CREATE TABLE functional_alltypes (
     year INTEGER,
     month INTEGER
 );
-
-CREATE INDEX "ix_functional_alltypes_index" ON functional_alltypes ("index");
 
 DROP TABLE IF EXISTS tzone CASCADE;
 

--- a/ci/schema/snowflake.sql
+++ b/ci/schema/snowflake.sql
@@ -54,8 +54,6 @@ CREATE OR REPLACE TABLE awards_players (
 );
 
 CREATE OR REPLACE TABLE functional_alltypes (
-    "index" BIGINT,
-    "Unnamed: 0" BIGINT,
     "id" INTEGER,
     "bool_col" BOOLEAN,
     "tinyint_col" SMALLINT,

--- a/ci/schema/sqlite.sql
+++ b/ci/schema/sqlite.sql
@@ -1,8 +1,6 @@
 DROP TABLE IF EXISTS functional_alltypes;
 
 CREATE TABLE functional_alltypes (
-    "index" BIGINT,
-    "Unnamed: 0" BIGINT,
     id BIGINT,
     bool_col BOOLEAN,
     tinyint_col BIGINT,
@@ -18,8 +16,6 @@ CREATE TABLE functional_alltypes (
     month BIGINT,
     CHECK (bool_col IN (0, 1))
 );
-
-CREATE INDEX ix_functional_alltypes_index ON "functional_alltypes" ("index");
 
 DROP TABLE IF EXISTS awards_players;
 

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -456,6 +456,8 @@ class BaseBackend(abc.ABC, _FileIOHandler):
     table_class: type[ops.DatabaseTable] = ops.DatabaseTable
     name: ClassVar[str]
 
+    supports_temporary_tables = False
+
     def __init__(self, *args, **kwargs):
         self._con_args: tuple[Any] = args
         self._con_kwargs: dict[str, Any] = kwargs

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -74,6 +74,9 @@ class ClickhouseTable(ir.Table):
 class Backend(BaseBackend):
     name = 'clickhouse'
 
+    # ClickHouse itself does, but the client driver does not
+    supports_temporary_tables = False
+
     class Options(ibis.config.Config):
         """Clickhouse options.
 

--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -38,15 +38,18 @@ class TestConf(UnorderedComparator, ServiceBackendTest, RoundHalfToEven):
 
     @classmethod
     def service_spec(cls, data_dir: Path) -> ServiceSpec:
-        files = [data_dir.joinpath("functional_alltypes.parquet")]
-        files.extend(
-            data_dir.joinpath("parquet", name, f"{name}.parquet")
-            for name in ("diamonds", "batting", "awards_players")
-        )
         return ServiceSpec(
             name=cls.name(),
             data_volume="/var/lib/clickhouse/user_files/ibis",
-            files=files,
+            files=[
+                data_dir.joinpath("parquet", f"{name}.parquet")
+                for name in (
+                    "diamonds",
+                    "batting",
+                    "awards_players",
+                    "functional_alltypes",
+                )
+            ],
         )
 
     @staticmethod

--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -42,7 +42,6 @@ def test_cast_string_col(alltypes, translate, to_type, snapshot):
 @pytest.mark.parametrize(
     'column',
     [
-        'index',
         'id',
         'bool_col',
         'tinyint_col',

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -34,8 +34,6 @@ WINDOWS = platform.system() == "Windows"
 TEST_TABLES = {
     "functional_alltypes": ibis.schema(
         {
-            "index": "int64",
-            "Unnamed: 0": "int64",
             "id": "int32",
             "bool_col": "boolean",
             "tinyint_col": "int8",

--- a/ibis/backends/dask/tests/conftest.py
+++ b/ibis/backends/dask/tests/conftest.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
@@ -33,34 +32,23 @@ class TestConf(PandasTest):
         return ibis.dask.connect(
             {
                 "functional_alltypes": dd.from_pandas(
-                    pd.read_csv(
-                        data_directory / "functional_alltypes.csv",
-                        index_col=None,
-                        dtype={
-                            "bool_col": bool,
-                            "string_col": str,
-                            "tinyint_col": np.int8,
-                            "smallint_col": np.int16,
-                            "int_col": np.int32,
-                            "bigint_col": np.int64,
-                            "float_col": np.float32,
-                            "double_col": np.float64,
-                        },
-                        parse_dates=["timestamp_col"],
-                        encoding="utf-8",
+                    pd.read_parquet(
+                        data_directory / "parquet" / "functional_alltypes.parquet"
                     ),
                     npartitions=NPARTITIONS,
                 ),
                 "batting": dd.from_pandas(
-                    pd.read_csv(data_directory / "batting.csv"),
+                    pd.read_parquet(data_directory / "parquet" / "batting.parquet"),
                     npartitions=NPARTITIONS,
                 ),
                 "awards_players": dd.from_pandas(
-                    pd.read_csv(data_directory / "awards_players.csv"),
+                    pd.read_parquet(
+                        data_directory / "parquet" / "awards_players.parquet"
+                    ),
                     npartitions=NPARTITIONS,
                 ),
                 'diamonds': dd.from_pandas(
-                    pd.read_csv(str(data_directory / 'diamonds.csv')),
+                    pd.read_parquet(data_directory / "parquet" / "diamonds.parquet"),
                     npartitions=NPARTITIONS,
                 ),
                 'json_t': dd.from_pandas(

--- a/ibis/backends/dask/tests/execution/conftest.py
+++ b/ibis/backends/dask/tests/execution/conftest.py
@@ -63,20 +63,13 @@ def df(npartitions):
 
 @pytest.fixture(scope='module')
 def batting_df(data_directory):
-    df = dd.read_csv(
-        data_directory / 'batting.csv',
-        assume_missing=True,
-        dtype={"lgID": "object"},
-    )
+    df = dd.read_parquet(data_directory / 'parquet' / 'batting.parquet')
     return df.sample(frac=0.01).reset_index(drop=True)
 
 
 @pytest.fixture(scope='module')
 def awards_players_df(data_directory):
-    return dd.read_csv(
-        data_directory / 'awards_players.csv',
-        assume_missing=True,
-    )
+    return dd.read_parquet(data_directory / 'parquet' / 'awards_players.parquet')
 
 
 @pytest.fixture(scope='module')

--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -28,12 +28,10 @@ class TestConf(BackendTest, RoundAwayFromZero):
         #   csv file path
         client = ibis.datafusion.connect({})
         client.register(
-            data_directory / 'functional_alltypes.csv',
+            data_directory / "csv" / 'functional_alltypes.csv',
             table_name='functional_alltypes',
             schema=pa.schema(
                 [
-                    ('index', 'int64'),
-                    ('Unnamed 0', 'int64'),
                     ('id', 'int64'),
                     ('bool_col', 'int8'),
                     ('tinyint_col', 'int8'),
@@ -50,11 +48,16 @@ class TestConf(BackendTest, RoundAwayFromZero):
                 ]
             ),
         )
-        client.register(data_directory / 'batting.csv', table_name='batting')
         client.register(
-            data_directory / 'awards_players.csv', table_name='awards_players'
+            data_directory / "parquet" / 'batting.parquet', table_name='batting'
         )
-        client.register(data_directory / 'diamonds.csv', table_name='diamonds')
+        client.register(
+            data_directory / "parquet" / 'awards_players.parquet',
+            table_name='awards_players',
+        )
+        client.register(
+            data_directory / "parquet" / 'diamonds.parquet', table_name='diamonds'
+        )
         return client
 
     @property

--- a/ibis/backends/druid/tests/conftest.py
+++ b/ibis/backends/druid/tests/conftest.py
@@ -99,11 +99,10 @@ class TestConf(ServiceBackendTest, RoundHalfToEven):
 
     @classmethod
     def service_spec(cls, data_dir: Path):
-        files = [data_dir.joinpath("functional_alltypes.parquet")]
-        files.extend(
-            data_dir.joinpath("parquet", name, f"{name}.parquet")
-            for name in ("diamonds", "batting", "awards_players")
-        )
+        files = [
+            data_dir.joinpath("parquet", f"{name}.parquet")
+            for name in ("diamonds", "batting", "awards_players", "functional_alltypes")
+        ]
         return ServiceSpec(
             name="druid-coordinator", data_volume="/opt/shared", files=files
         )

--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -19,23 +19,22 @@ class TestConf(BackendTest, RoundAwayFromZero):
     def __init__(self, data_directory: Path, **kwargs: Any) -> None:
         self.connection = self.connect(data_directory, **kwargs)
 
-        script_dir = data_directory.parent
-
-        schema = (script_dir / 'schema' / 'duckdb.sql').read_text()
-
         if not SANDBOXED:
             self.connection._load_extensions(
                 ["httpfs", "postgres_scanner", "sqlite_scanner"]
             )
 
+        script_dir = data_directory.parent
+        schema = script_dir.joinpath("schema", "duckdb.sql").read_text()
+
         with self.connection.begin() as con:
-            for stmt in filter(None, map(str.strip, schema.split(';'))):
+            for stmt in filter(None, map(str.strip, schema.split(";"))):
                 con.exec_driver_sql(stmt)
 
             for table in TEST_TABLES:
-                src = data_directory / f'{table}.csv'
+                src = data_directory / "csv" / f"{table}.csv"
                 con.exec_driver_sql(
-                    f"COPY {table} FROM {str(src)!r} (DELIMITER ',', HEADER, SAMPLE_SIZE 1)"
+                    f"COPY {table} FROM {str(src)!r} (DELIMITER ',', HEADER)"
                 )
 
     @staticmethod

--- a/ibis/backends/impala/tests/test_client.py
+++ b/ibis/backends/impala/tests/test_client.py
@@ -43,9 +43,9 @@ def test_get_table_ref(db):
 
 
 def test_run_sql(con, test_data_db):
-    table = con.sql(f"SELECT li.* FROM {test_data_db}.tpch_lineitem li")
+    table = con.sql(f"SELECT li.* FROM {test_data_db}.lineitem li")
 
-    li = con.table('tpch_lineitem')
+    li = con.table('lineitem')
     assert isinstance(table, ir.Table)
     assert_equal(table.schema(), li.schema())
 
@@ -76,8 +76,8 @@ def test_explain(con):
 
 
 def test_get_schema(con, test_data_db):
-    t = con.table('tpch_lineitem')
-    schema = con.get_schema('tpch_lineitem', database=test_data_db)
+    t = con.table('lineitem')
+    schema = con.get_schema('lineitem', database=test_data_db)
     assert_equal(t.schema(), schema)
 
 
@@ -112,7 +112,7 @@ def test_adapt_scalar_array_results(con, alltypes):
 
 
 def test_interactive_repr_call_failure(con):
-    t = con.table('tpch_lineitem').limit(100000)
+    t = con.table('lineitem').limit(100000)
 
     t = t[t, t.l_receiptdate.cast('timestamp').name('date')]
 
@@ -155,17 +155,17 @@ def test_verbose_log_queries(con, test_data_db):
 
     with config.option_context('verbose', True):
         with config.option_context('verbose_log', queries.append):
-            con.table('tpch_orders', database=test_data_db)
+            con.table('orders', database=test_data_db)
 
     # we can't make assertions about the length of queries, since the Python GC
     # could've collected a temporary pandas table any time between construction
     # of `queries` and the assertion
-    expected = f'DESCRIBE {test_data_db}.`tpch_orders`'
+    expected = f'DESCRIBE {test_data_db}.`orders`'
     assert expected in queries
 
 
 def test_sql_query_limits(con, test_data_db):
-    table = con.table('tpch_nation', database=test_data_db)
+    table = con.table('nation', database=test_data_db)
     with config.option_context('sql.default_limit', 100000):
         # table has 25 rows
         assert len(table.execute()) == 25
@@ -206,7 +206,7 @@ def test_database_default_current_database(con):
 
 
 def test_close_drops_temp_tables(con, test_data_dir):
-    hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
+    hdfs_path = pjoin(test_data_dir, 'impala/parquet/region')
 
     table = con.parquet_file(hdfs_path)
 

--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -208,7 +208,7 @@ def test_rename_table(con, temp_database):
     tmp_db = temp_database
 
     orig_name = 'tmp_rename_test'
-    con.create_table(orig_name, con.table('tpch_region'))
+    con.create_table(orig_name, con.table('region'))
     table = con.table(orig_name)
 
     old_name = table.name
@@ -277,7 +277,7 @@ def test_change_format(con, table):
 
 
 def test_query_avro(con, test_data_dir, tmp_db):
-    hdfs_path = pjoin(test_data_dir, 'avro/tpch_region_avro')
+    hdfs_path = pjoin(test_data_dir, 'impala/avro/tpch/region')
 
     avro_schema = {
         "fields": [
@@ -372,7 +372,7 @@ def test_temp_table_concurrency(con, test_data_dir):
         return t.order_by(t.r_regionkey).limit(1, offset=offset).execute()
 
     nthreads = multiprocessing.cpu_count()
-    hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
+    hdfs_path = pjoin(test_data_dir, 'impala/parquet/region')
 
     num_rows = int(con.parquet_file(hdfs_path).count().execute())
     with concurrent.futures.ThreadPoolExecutor(max_workers=nthreads) as e:

--- a/ibis/backends/impala/tests/test_parquet_ddl.py
+++ b/ibis/backends/impala/tests/test_parquet_ddl.py
@@ -12,7 +12,7 @@ from ibis.backends.impala.compat import HS2Error  # noqa: E402
 
 
 def test_cleanup_tmp_table_on_gc(con, test_data_dir):
-    hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
+    hdfs_path = pjoin(test_data_dir, 'impala/parquet/region')
     table = con.parquet_file(hdfs_path)
     name = table.op().name
     table = None
@@ -21,7 +21,7 @@ def test_cleanup_tmp_table_on_gc(con, test_data_dir):
 
 
 def test_persist_parquet_file_with_name(con, test_data_dir, temp_table_db):
-    hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
+    hdfs_path = pjoin(test_data_dir, 'impala/parquet/region')
 
     tmp_db, name = temp_table_db
     schema = ibis.schema(
@@ -39,7 +39,7 @@ def test_persist_parquet_file_with_name(con, test_data_dir, temp_table_db):
 
 
 def test_query_parquet_file_with_schema(con, test_data_dir):
-    hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
+    hdfs_path = pjoin(test_data_dir, 'impala/parquet/region')
 
     schema = ibis.schema(
         [
@@ -63,23 +63,23 @@ def test_query_parquet_file_with_schema(con, test_data_dir):
 
 
 def test_query_parquet_file_like_table(con, test_data_dir):
-    hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
+    hdfs_path = pjoin(test_data_dir, 'impala/parquet/region')
 
     ex_schema = ibis.schema(
         [
-            ('r_regionkey', 'int16'),
+            ('r_regionkey', 'int32'),
             ('r_name', 'string'),
             ('r_comment', 'string'),
         ]
     )
 
-    table = con.parquet_file(hdfs_path, like_table='tpch_region')
+    table = con.parquet_file(hdfs_path, like_table='region')
 
     assert_equal(table.schema(), ex_schema)
 
 
 def test_query_parquet_infer_schema(con, test_data_dir):
-    hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
+    hdfs_path = pjoin(test_data_dir, 'impala/parquet/region')
     table = con.parquet_file(hdfs_path)
 
     # NOTE: the actual schema should have an int16, but bc this is being
@@ -99,7 +99,7 @@ def test_query_parquet_infer_schema(con, test_data_dir):
 def test_create_table_persist_fails_if_called_twice(con, temp_table_db, test_data_dir):
     tmp_db, tname = temp_table_db
 
-    hdfs_path = pjoin(test_data_dir, 'parquet/tpch_region')
+    hdfs_path = pjoin(test_data_dir, 'impala/parquet/region')
     con.parquet_file(hdfs_path, name=tname, persist=True, database=tmp_db)
 
     with pytest.raises(HS2Error):

--- a/ibis/backends/impala/tests/test_udf.py
+++ b/ibis/backends/impala/tests/test_udf.py
@@ -70,7 +70,7 @@ def t(table):
 
 @pytest.fixture
 def tpch_customer(con):
-    return con.table("tpch_customer")
+    return con.table("customer")
 
 
 @pytest.fixture
@@ -320,7 +320,7 @@ def test_identity_primitive_types(
     reason='Unknown reason. xfailing to restore the CI for udf tests. #2358'
 )
 def test_decimal_fail(udfcon, test_data_db, udf_ll):
-    col = udfcon.table('tpch_customer').c_acctbal
+    col = udfcon.table('customer').c_acctbal
     literal = ibis.literal(1).cast('decimal(12,2)')
     name = '__tmp_udf_' + util.guid()
 

--- a/ibis/backends/mssql/tests/conftest.py
+++ b/ibis/backends/mssql/tests/conftest.py
@@ -35,7 +35,7 @@ class TestConf(ServiceBackendTest, RoundHalfToEven):
             name=cls.name(),
             data_volume="/data",
             files=[
-                data_dir.joinpath(f"{name}.csv")
+                data_dir.joinpath("csv", f"{name}.csv")
                 for name in (
                     "diamonds",
                     "batting",

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -71,8 +71,6 @@ class Backend(BaseAlchemyBackend):
         MySQLTable[table]
           name: functional_alltypes
           schema:
-            index : int64
-            Unnamed: 0 : int64
             id : int32
             bool_col : int8
             tinyint_col : int8

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -84,7 +84,7 @@ class TestConf(BackendTest, RoundHalfToEven):
             )
             with engine.begin() as con:
                 for table in TEST_TABLES:
-                    csv_path = data_dir / f"{table}.csv"
+                    csv_path = data_dir / "csv" / f"{table}.csv"
                     lines = [
                         f"LOAD DATA LOCAL INFILE {str(csv_path)!r}",
                         f"INTO TABLE {table}",

--- a/ibis/backends/pandas/tests/conftest.py
+++ b/ibis/backends/pandas/tests/conftest.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import numpy as np
 import pandas as pd
 
 import ibis
 import ibis.expr.operations as ops
-import ibis.expr.types as ir
+from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundHalfToEven
 from ibis.backends.tests.data import array_types, json_types, struct_types, win
 
@@ -23,40 +22,15 @@ class TestConf(BackendTest, RoundHalfToEven):
     def connect(data_directory: Path):
         return ibis.pandas.connect(
             dictionary={
-                "functional_alltypes": pd.read_csv(
-                    data_directory / "functional_alltypes.csv",
-                    index_col=None,
-                    dtype={
-                        "bool_col": bool,
-                        "string_col": str,
-                        "tinyint_col": np.int8,
-                        "smallint_col": np.int16,
-                        "int_col": np.int32,
-                        "bigint_col": np.int64,
-                        "float_col": np.float32,
-                        "double_col": np.float64,
-                    },
-                    parse_dates=["timestamp_col"],
-                    encoding="utf-8",
-                ),
-                "batting": pd.read_csv(data_directory / "batting.csv"),
-                "awards_players": pd.read_csv(data_directory / "awards_players.csv"),
-                'diamonds': pd.read_csv(str(data_directory / 'diamonds.csv')),
+                **{
+                    table: pd.read_parquet(
+                        data_directory / "parquet" / f"{table}.parquet"
+                    )
+                    for table in TEST_TABLES.keys()
+                },
                 'struct': struct_types,
                 'json_t': json_types,
                 'array_types': array_types,
                 'win': win,
             }
         )
-
-    @property
-    def functional_alltypes(self) -> ir.Table:
-        return self.connection.table("functional_alltypes")
-
-    @property
-    def batting(self) -> ir.Table:
-        return self.connection.table("batting")
-
-    @property
-    def awards_players(self) -> ir.Table:
-        return self.connection.table("awards_players")

--- a/ibis/backends/pandas/tests/execution/conftest.py
+++ b/ibis/backends/pandas/tests/execution/conftest.py
@@ -76,24 +76,15 @@ def df():
 def batting_df(data_directory):
     num_rows = 1000
     start_index = 30
-    df = pd.read_csv(
-        data_directory / 'batting.csv',
-        index_col=None,
-        sep=',',
-        header=0,
-        skiprows=range(1, start_index + 1),
-        nrows=num_rows,
-    )
+    df = pd.read_parquet(data_directory / 'parquet' / 'batting.parquet').iloc[
+        start_index : start_index + num_rows
+    ]
     return df.reset_index(drop=True)
 
 
 @pytest.fixture(scope='module')
 def awards_players_df(data_directory):
-    return pd.read_csv(
-        data_directory / 'awards_players.csv',
-        index_col=None,
-        sep=',',
-    )
+    return pd.read_parquet(data_directory / 'parquet' / 'awards_players.parquet')
 
 
 @pytest.fixture(scope='module')

--- a/ibis/backends/polars/tests/conftest.py
+++ b/ibis/backends/polars/tests/conftest.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 
 import ibis
-import ibis.expr.types as ir
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 from ibis.backends.tests.data import array_types, struct_types, win
 
@@ -21,45 +20,24 @@ class TestConf(BackendTest, RoundAwayFromZero):
     def connect(data_directory: Path):
         client = ibis.polars.connect({})
         client.register(
-            data_directory / 'functional_alltypes.csv',
+            data_directory / 'parquet' / 'functional_alltypes.parquet',
             table_name='functional_alltypes',
-            dtypes={
-                'index': pl.Int64,
-                'Unnamed 0': pl.Int64,
-                'id': pl.Int64,
-                'bool_col': pl.Int64,
-                'tinyint_col': pl.Int64,
-                'smallint_col': pl.Int64,
-                'int_col': pl.Int32,
-                'bigint_col': pl.Int64,
-                'float_col': pl.Float32,
-                'double_col': pl.Float64,
-                'date_string_col': pl.Utf8,
-                'string_col': pl.Utf8,
-                'timestamp_col': pl.Datetime,
-                'year': pl.Int64,
-                'month': pl.Int64,
-            },
         )
-        client.register(data_directory / 'batting.csv', table_name='batting')
         client.register(
-            data_directory / 'awards_players.csv', table_name='awards_players'
+            data_directory / "parquet" / 'batting.parquet', table_name='batting'
         )
-        client.register(data_directory / 'diamonds.csv', table_name='diamonds')
+        client.register(
+            data_directory / "parquet" / 'awards_players.parquet',
+            table_name='awards_players',
+        )
+        client.register(
+            data_directory / "parquet" / 'diamonds.parquet', table_name='diamonds'
+        )
         client.register(array_types, table_name='array_types')
         client.register(struct_types, table_name='struct')
         client.register(win, table_name="win")
 
         return client
-
-    @property
-    def functional_alltypes(self) -> ir.Table:
-        table = self.connection.table('functional_alltypes')
-        return table.mutate(
-            bool_col=table.bool_col.cast('bool'),
-            tinyint_col=table.tinyint_col.cast('int8'),
-            smallint_col=table.smallint_col.cast('int16'),
-        )
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/polars/tests/test_udf.py
+++ b/ibis/backends/polars/tests/test_udf.py
@@ -43,6 +43,6 @@ def test_multiple_argument_udf(alltypes):
     result = expr.execute()
 
     df = alltypes[['smallint_col', 'int_col']].execute()
-    expected = (df.smallint_col + df.int_col).astype('int64')
+    expected = (df.smallint_col + df.int_col).astype('int32')
 
     tm.assert_series_equal(result, expected.rename('tmp'))

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -108,8 +108,6 @@ class Backend(BaseAlchemyBackend):
         PostgreSQLTable[table]
           name: functional_alltypes
           schema:
-            index : int64
-            Unnamed: 0 : int64
             id : int32
             bool_col : boolean
             tinyint_col : int16

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -88,7 +88,7 @@ class TestConf(BackendTest, RoundHalfToEven):
                 # `data_iter` argument would have to be turned back into a CSV
                 # before being passed to `copy_expert`.
                 sql = f"COPY {table} FROM STDIN WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',')"
-                with data_dir.joinpath(f'{table}.csv').open('r') as file:
+                with data_dir.joinpath("csv", f'{table}.csv').open('r') as file:
                     cur.copy_expert(sql=sql, file=file)
 
     @staticmethod

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -73,8 +73,6 @@ def test_date_cast(alltypes, at, translate):
 @pytest.mark.parametrize(
     'column',
     [
-        'index',
-        'Unnamed: 0',
         'id',
         'bool_col',
         'tinyint_col',

--- a/ibis/backends/pyspark/tests/test_ddl.py
+++ b/ibis/backends/pyspark/tests/test_ddl.py
@@ -40,8 +40,8 @@ def test_drop_non_empty_database(con, alltypes, temp_table_db):
 
 
 @pytest.fixture
-def temp_base(tmp_dir):
-    base = pjoin(tmp_dir, util.gen_name("temp_base"))
+def temp_base():
+    base = pjoin(f"/tmp/{util.gen_name('pyspark_testing')}", util.gen_name("temp_base"))
     yield base
     shutil.rmtree(base, ignore_errors=True)
 

--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -24,7 +24,7 @@ def copy_into(con, data_dir: Path, table: str) -> None:
     stage = "ibis_testing"
     csv = f"{table}.csv"
     con.exec_driver_sql(
-        f"PUT file://{data_dir.joinpath(csv).absolute()} @{stage}/{csv}"
+        f"PUT file://{data_dir.joinpath('csv', csv).absolute()} @{stage}/{csv}"
     )
     con.exec_driver_sql(
         f"COPY INTO {table} FROM @{stage}/{csv} FILE_FORMAT = (FORMAT_NAME = ibis_testing)"

--- a/ibis/backends/sqlite/tests/conftest.py
+++ b/ibis/backends/sqlite/tests/conftest.py
@@ -36,7 +36,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
 
             for table in TEST_TABLES:
                 basename = f"{table}.csv"
-                with data_directory.joinpath(basename).open("r") as f:
+                with data_directory.joinpath("csv", basename).open("r") as f:
                     reader = csv.reader(f)
                     header = next(reader)
                     assert header, f"empty header for table: `{table}`"

--- a/ibis/backends/tests/snapshots/test_string/test_rlike/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_string/test_rlike/duckdb/out.sql
@@ -1,6 +1,4 @@
 SELECT
-  t0.index,
-  t0."Unnamed: 0",
   t0.id,
   t0.bool_col,
   t0.tinyint_col,

--- a/ibis/backends/tests/snapshots/test_string/test_rlike/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_string/test_rlike/mysql/out.sql
@@ -1,6 +1,4 @@
 SELECT
-  t0.`index`,
-  t0.`Unnamed: 0`,
   t0.id,
   t0.bool_col = 1 AS bool_col,
   t0.tinyint_col,

--- a/ibis/backends/tests/snapshots/test_string/test_rlike/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_string/test_rlike/postgres/out.sql
@@ -1,6 +1,4 @@
 SELECT
-  t0.index,
-  t0."Unnamed: 0",
   t0.id,
   t0.bool_col,
   t0.tinyint_col,

--- a/ibis/backends/tests/snapshots/test_string/test_rlike/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_string/test_rlike/sqlite/out.sql
@@ -1,6 +1,4 @@
 SELECT
-  t0."index",
-  t0."Unnamed: 0",
   t0.id,
   t0.bool_col,
   t0.tinyint_col,

--- a/ibis/backends/tests/snapshots/test_string/test_rlike/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_string/test_rlike/trino/out.sql
@@ -1,6 +1,4 @@
 SELECT
-  t0.index,
-  t0."unnamed: 0",
   t0.id,
   t0.bool_col,
   t0.tinyint_col,

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -32,7 +32,7 @@ def pushd(new_dir):
 def gzip_csv(data_directory, tmp_path):
     basename = "diamonds.csv"
     f = tmp_path.joinpath(f"{basename}.gz")
-    data = data_directory.joinpath(basename).read_bytes()
+    data = data_directory.joinpath("csv", basename).read_bytes()
     f.write_bytes(gzip.compress(data))
     return str(f.absolute())
 
@@ -93,7 +93,7 @@ def gzip_csv(data_directory, tmp_path):
     ]
 )
 def test_register_csv(con, data_directory, fname, in_table_name, out_table_name):
-    with pushd(data_directory):
+    with pushd(data_directory / "csv"):
         table = con.register(fname, table_name=in_table_name)
 
     assert any(out_table_name in t for t in con.list_tables())
@@ -143,7 +143,7 @@ def test_register_with_dotted_name(con, data_directory, tmp_path):
     basename = "foo.bar.baz/diamonds.csv"
     f = tmp_path.joinpath(basename)
     f.parent.mkdir()
-    data = data_directory.joinpath("diamonds.csv").read_bytes()
+    data = data_directory.joinpath("csv", "diamonds.csv").read_bytes()
     f.write_bytes(data)
     table = con.register(str(f.absolute()))
 
@@ -200,7 +200,7 @@ def test_register_parquet(
     pq = pytest.importorskip("pyarrow.parquet")
 
     fname = Path(fname)
-    table = read_table(data_directory / fname.name)
+    table = read_table(data_directory / "csv" / fname.name)
 
     pq.write_table(table, tmp_path / fname.name)
 
@@ -238,7 +238,7 @@ def test_register_iterator_parquet(
 ):
     pq = pytest.importorskip("pyarrow.parquet")
 
-    table = read_table(data_directory / "functional_alltypes.csv")
+    table = read_table(data_directory / "csv" / "functional_alltypes.csv")
 
     pq.write_table(table, tmp_path / "functional_alltypes.parquet")
 
@@ -424,7 +424,8 @@ def test_read_parquet(
     pq = pytest.importorskip("pyarrow.parquet")
 
     fname = Path(fname)
-    table = read_table(data_directory / fname.name)
+    fname = Path(data_directory) / "parquet" / fname.name
+    table = pq.read_table(fname)
 
     pq.write_table(table, tmp_path / fname.name)
 
@@ -468,7 +469,7 @@ def test_read_parquet(
     ]
 )
 def test_read_csv(con, data_directory, fname, in_table_name, out_table_name):
-    with pushd(data_directory):
+    with pushd(data_directory / "csv"):
         if con.name == "pyspark":
             # pyspark doesn't respect CWD
             fname = str(Path(fname).absolute())

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -505,7 +505,7 @@ def test_elementwise_udf_destructure_exact_once(
         path.touch()
         return v + 1, v + 2
 
-    struct = add_one_struct_exact_once(udf_alltypes['index'])
+    struct = add_one_struct_exact_once(udf_alltypes['id'])
 
     if method == "destructure":
         expr = udf_alltypes.mutate(struct.destructure())

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -910,7 +910,7 @@ def test_grouped_ordered_window_coalesce(backend, alltypes, df):
         return df
 
     expected = (
-        df.groupby("month")
+        df.groupby("month", group_keys=False)
         .apply(agg)
         .sort_values(["id"])
         .reset_index(drop=True)

--- a/justfile
+++ b/justfile
@@ -64,7 +64,7 @@ doctest *args:
     pytest --doctest-modules {{ args }} "${doctest_modules[@]}"
 
 # download testing data
-download-data owner="ibis-project" repo="testing-data" rev="master":
+download-data owner="cpcloud" repo="testing-data" rev="cleanup":
     #!/usr/bin/env bash
     outdir="{{ justfile_directory() }}/ci/ibis-testing-data"
     rm -rf "$outdir"
@@ -74,8 +74,13 @@ download-data owner="ibis-project" repo="testing-data" rev="master":
     if [ "{{ rev }}" = "master" ]; then
         args+=("--depth" "1")
     fi
+
     args+=("$outdir")
     git clone "${args[@]}"
+
+    if [ "{{ rev }}" != "master" ]; then
+        git -C "${outdir}" checkout "{{ rev }}"
+    fi
 
 # start backends using docker compose; no arguments starts all backends
 up *backends:

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -18,13 +18,12 @@ let
 in
 {
   ibisTestingData = pkgs.fetchFromGitHub {
-    owner = "ibis-project";
+    name = "ibis-testing-data";
+    owner = "cpcloud";
     repo = "testing-data";
-    rev = "master";
-    sha256 = "sha256-NbgEe0w/qf9hCr9rRfIpyaH9pv25I8x0ykY7EJxDOuk=";
+    rev = "cleanup";
+    sha256 = "sha256-q1b5IcOl5oIFXP7/P5RufncjHEVrWp4NjoU2uo/BE9U=";
   };
-
-  rustNightly = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.minimal);
 
   ibis38 = pkgs.callPackage ./ibis.nix { python3 = pkgs.python38; };
   ibis39 = pkgs.callPackage ./ibis.nix { python3 = pkgs.python39; };


### PR DESCRIPTION
This PR cleans up our data loading, moving many backends to use parquet files and removing a bunch of unused junk from the ibis-testing-data repo. I am currently running against a branch (`cleanup` of `ibis-project/testing-data`), and I will merge my changes there to `master` once this PR is merged. I will then follow up with a PR to update the ibis-testing data ref here.