### PR TITLE
test: remove most try/finally blocks in favor of plain yields

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -571,7 +571,9 @@ class Backend(BaseBackend):
             The new table
         """
         if temp:
-            raise com.IbisError("ClickHouse temporary tables are not yet supported")
+            raise com.IbisError(
+                "ClickHouse temporary tables are not yet supported due to a bug in `clickhouse_driver`"
+            )
 
         tmp = "TEMPORARY " * temp
         replace = "OR REPLACE " * overwrite

--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -78,9 +78,6 @@ class TestConf(UnorderedComparator, ServiceBackendTest, RoundHalfToEven):
         with contextlib.suppress(clickhouse_driver.errors.ServerException):
             client.execute(f"CREATE DATABASE {database} ENGINE = Atomic")
 
-        client.execute("DROP DATABASE IF EXISTS tmptables")
-        client.execute("CREATE DATABASE tmptables ENGINE = Atomic")
-
         client.execute(f"USE {database}")
         client.execute("SET allow_experimental_object_type = 1")
         client.execute("SET output_format_json_named_tuples_as_objects = 1")

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -225,10 +225,6 @@ def init_database(
     return engine
 
 
-def _random_identifier(suffix: str) -> str:
-    return f"__ibis_test_{suffix}_{util.guid()}"
-
-
 def _get_backend_conf(backend_str: str):
     """Convert a backend string to the test class for the backend."""
     conftest = importlib.import_module(f"ibis.backends.{backend_str}.tests.conftest")
@@ -702,7 +698,7 @@ def alchemy_temp_table(alchemy_con) -> str:
     name : string
         Random table name for a temporary usage.
     """
-    name = _random_identifier('table')
+    name = util.gen_name('alchemy_table')
     yield name
     with contextlib.suppress(NotImplementedError):
         alchemy_con.drop_table(name, force=True)
@@ -721,7 +717,23 @@ def temp_table(con) -> str:
     name : string
         Random table name for a temporary usage.
     """
-    name = _random_identifier('table')
+    name = util.gen_name('temp_table')
+    yield name
+    with contextlib.suppress(NotImplementedError):
+        con.drop_table(name, force=True)
+
+
+@pytest.fixture
+def temp_table2(con) -> str:
+    name = util.gen_name('temp_table2')
+    yield name
+    with contextlib.suppress(NotImplementedError):
+        con.drop_table(name, force=True)
+
+
+@pytest.fixture
+def temp_table_orig(con, temp_table):
+    name = f"{temp_table}_orig"
     yield name
     with contextlib.suppress(NotImplementedError):
         con.drop_table(name, force=True)
@@ -740,7 +752,7 @@ def temp_view(ddl_con) -> str:
     name : string
         Random view name for a temporary usage.
     """
-    name = _random_identifier('view')
+    name = util.gen_name('view')
     yield name
     with contextlib.suppress(NotImplementedError):
         ddl_con.drop_view(name, force=True)
@@ -765,7 +777,7 @@ def alternate_current_database(ddl_con, ddl_backend) -> str:
     -------
     str
     """
-    name = _random_identifier('database')
+    name = util.gen_name('database')
     try:
         ddl_con.create_database(name)
     except NotImplementedError:

--- a/ibis/backends/impala/tests/test_udf.py
+++ b/ibis/backends/impala/tests/test_udf.py
@@ -252,12 +252,9 @@ def _register_uda(inputs, output, name):
 
 
 @pytest.fixture
-def udfcon(con):
-    con.disable_codegen(False)
-    try:
-        yield con
-    finally:
-        con.disable_codegen(True)
+def udfcon(con, monkeypatch):
+    monkeypatch.setitem(con.con.options, "DISABLE_CODEGEN", "0")
+    return con
 
 
 @pytest.fixture

--- a/ibis/backends/mysql/tests/test_client.py
+++ b/ibis/backends/mysql/tests/test_client.py
@@ -64,15 +64,11 @@ def test_get_schema_from_query(con, mysql_type, expected_type):
     # don't need to explicitly drop the table
     with con.begin() as c:
         c.exec_driver_sql(f"CREATE TEMPORARY TABLE {name} (x {mysql_type})")
-    try:
-        expected_schema = ibis.schema(dict(x=expected_type))
-        t = con.table(raw_name)
-        result_schema = con._get_schema_using_query(f"SELECT * FROM {name}")
-        assert t.schema() == expected_schema
-        assert result_schema == expected_schema
-    finally:
-        with con.begin() as c:
-            c.exec_driver_sql(f"DROP TABLE {name}")
+    expected_schema = ibis.schema(dict(x=expected_type))
+    t = con.table(raw_name)
+    result_schema = con._get_schema_using_query(f"SELECT * FROM {name}")
+    assert t.schema() == expected_schema
+    assert result_schema == expected_schema
 
 
 @pytest.mark.parametrize("coltype", ["TINYBLOB", "MEDIUMBLOB", "BLOB", "LONGBLOB"])
@@ -80,12 +76,8 @@ def test_blob_type(con, coltype):
     tmp = f"tmp_{ibis.util.guid()}"
     with con.begin() as c:
         c.exec_driver_sql(f"CREATE TEMPORARY TABLE {tmp} (a {coltype})")
-    try:
-        t = con.table(tmp)
-        assert t.schema() == ibis.schema({"a": dt.binary})
-    finally:
-        with con.begin() as c:
-            c.exec_driver_sql(f"DROP TABLE {tmp}")
+    t = con.table(tmp)
+    assert t.schema() == ibis.schema({"a": dt.binary})
 
 
 @pytest.fixture(scope="session")

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -244,7 +244,7 @@ class Backend(BaseBackend):
             )
 
         if isinstance(obj, ir.Table):
-            obj = obj.to_pyarrow()
+            obj = self.to_pyarrow(obj)
 
         if not isinstance(obj, (pl.DataFrame, pl.LazyFrame)):
             obj = pl.LazyFrame(obj)

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -15,13 +15,13 @@ from __future__ import annotations
 # limitations under the License.
 import os
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import pytest
 import sqlalchemy as sa
 
 import ibis
-from ibis.backends.conftest import TEST_TABLES, _random_identifier, init_database
+from ibis.backends.conftest import TEST_TABLES, init_database
 from ibis.backends.tests.base import BackendTest, RoundHalfToEven
 
 PG_USER = os.environ.get(
@@ -152,24 +152,4 @@ def translate():
     from ibis.backends.postgres import Backend
 
     context = Backend.compiler.make_context()
-    return lambda expr: (Backend.compiler.translator_class(expr, context).get_result())
-
-
-@pytest.fixture
-def temp_table(con) -> Generator[str, None, None]:
-    """Return a temporary table name.
-
-    Parameters
-    ----------
-    con : ibis.postgres.PostgreSQLClient
-
-    Yields
-    ------
-    name : string
-        Random table name for a temporary usage.
-    """
-    name = _random_identifier('table')
-    try:
-        yield name
-    finally:
-        con.drop_table(name, force=True)
+    return lambda expr: Backend.compiler.translator_class(expr, context).get_result()

--- a/ibis/backends/pyspark/tests/test_aggregation.py
+++ b/ibis/backends/pyspark/tests/test_aggregation.py
@@ -1,43 +1,22 @@
 import pytest
-from pytest import param
 
 import ibis
 
 pytest.importorskip("pyspark")
 
 
-@pytest.fixture
-def treat_nan_as_null():
-    treat_nan_as_null = ibis.options.pyspark.treat_nan_as_null
-    ibis.options.pyspark.treat_nan_as_null = True
-    try:
-        yield
-    finally:
-        ibis.options.pyspark.treat_nan_as_null = treat_nan_as_null
-
-
 @pytest.mark.parametrize(
     ('result_fn', 'expected_fn'),
     [
-        param(
-            lambda t: t.age.count(),
-            lambda t: len(t.age.dropna()),
-            id='count',
-        ),
-        param(
-            lambda t: t.age.sum(),
-            lambda t: t.age.sum(),
-            id='sum',
-        ),
+        (lambda t: t.age.count(), lambda t: len(t.age.dropna())),
+        (lambda t: t.age.sum(), lambda t: t.age.sum()),
     ],
+    ids=["count", "sum"],
 )
-def test_aggregation_float_nulls(
-    client,
-    result_fn,
-    expected_fn,
-    treat_nan_as_null,
-):
-    table = client.table('null_table')
+def test_aggregation_float_nulls(con, result_fn, expected_fn, monkeypatch):
+    monkeypatch.setattr(ibis.options.pyspark, "treat_nan_as_null", True)
+
+    table = con.table('null_table')
     df = table.compile().toPandas()
 
     expr = result_fn(table)

--- a/ibis/backends/pyspark/tests/test_null.py
+++ b/ibis/backends/pyspark/tests/test_null.py
@@ -4,8 +4,8 @@ import pytest
 pytest.importorskip("pyspark")
 
 
-def test_isnull(client):
-    table = client.table('null_table')
+def test_isnull(con):
+    table = con.table('null_table')
     table_pandas = table.compile().toPandas()
 
     for col, _ in table_pandas.items():
@@ -14,8 +14,8 @@ def test_isnull(client):
         tm.assert_frame_equal(result, expected)
 
 
-def test_notnull(client):
-    table = client.table('null_table')
+def test_notnull(con):
+    table = con.table('null_table')
     table_pandas = table.compile().toPandas()
 
     for col, _ in table_pandas.items():

--- a/ibis/backends/pyspark/tests/test_timecontext.py
+++ b/ibis/backends/pyspark/tests/test_timecontext.py
@@ -17,8 +17,8 @@ from ibis.backends.pyspark.compiler import (  # noqa: E402
 from ibis.backends.pyspark.timecontext import combine_time_context  # noqa: E402
 
 
-def test_table_with_timecontext(client):
-    table = client.table('time_indexed_table')
+def test_table_with_timecontext(con):
+    table = con.table('time_indexed_table')
     context = (pd.Timestamp('20170102'), pd.Timestamp('20170103'))
     result = table.execute(timecontext=context)
     expected = table.execute()
@@ -69,9 +69,9 @@ def test_combine_time_context(contexts, expected):
     assert combine_time_context(contexts) == expected
 
 
-def test_adjust_context_scope(client):
+def test_adjust_context_scope(con):
     """Test that `adjust_context` has access to `scope` by default."""
-    table = client.table('time_indexed_table')
+    table = con.table('time_indexed_table')
 
     # Window is the only context-adjusted node that the PySpark backend
     # can compile. Ideally we would test the context adjustment logic for

--- a/ibis/backends/pyspark/tests/test_window.py
+++ b/ibis/backends/pyspark/tests/test_window.py
@@ -21,8 +21,8 @@ from pyspark.sql.window import Window  # noqa: E402
     ],
     indirect=['ibis_windows'],
 )
-def test_time_indexed_window(client, ibis_windows, spark_range):
-    table = client.table('time_indexed_table')
+def test_time_indexed_window(con, ibis_windows, spark_range):
+    table = con.table('time_indexed_table')
     result = table.mutate(mean=table['value'].mean().over(ibis_windows[0])).compile()
     result_pd = result.toPandas()
     spark_table = table.compile()
@@ -48,8 +48,8 @@ def test_time_indexed_window(client, ibis_windows, spark_range):
     ],
     indirect=['ibis_windows'],
 )
-def test_multiple_windows(client, ibis_windows, spark_range):
-    table = client.table('time_indexed_table')
+def test_multiple_windows(con, ibis_windows, spark_range):
+    table = con.table('time_indexed_table')
     result = table.mutate(
         mean_1h=table['value'].mean().over(ibis_windows[0]),
         mean_2h=table['value'].mean().over(ibis_windows[1]),

--- a/ibis/backends/pyspark/tests/test_window_context_adjustment.py
+++ b/ibis/backends/pyspark/tests/test_window_context_adjustment.py
@@ -26,7 +26,7 @@ from pyspark.sql.window import Window  # noqa: E402
     ],
     indirect=['ibis_windows'],
 )
-def test_window_with_timecontext(client, ibis_windows, spark_range):
+def test_window_with_timecontext(con, ibis_windows, spark_range):
     """Test context adjustment for trailing / range window.
 
     We expand context according to window sizes, for example, for a table of:
@@ -49,7 +49,7 @@ def test_window_with_timecontext(client, ibis_windows, spark_range):
     2020-01-01   a      2
     2020-01-02   b      2
     """
-    table = client.table('time_indexed_table')
+    table = con.table('time_indexed_table')
     context = (
         pd.Timestamp('20170102 07:00:00', tz='UTC'),
         pd.Timestamp('20170103', tz='UTC'),
@@ -78,7 +78,7 @@ def test_window_with_timecontext(client, ibis_windows, spark_range):
     [([(None, 0)], (Window.unboundedPreceding, 0))],
     indirect=['ibis_windows'],
 )
-def test_cumulative_window(client, ibis_windows, spark_range):
+def test_cumulative_window(con, ibis_windows, spark_range):
     """Test context adjustment for cumulative window.
 
     For cumulative window, by defination we should look back infinately.
@@ -94,7 +94,7 @@ def test_cumulative_window(client, ibis_windows, spark_range):
     2020-01-02   b      1
     2020-01-03   c      2
     """
-    table = client.table('time_indexed_table')
+    table = con.table('time_indexed_table')
     context = (
         pd.Timestamp('20170102 07:00:00', tz='UTC'),
         pd.Timestamp('20170105', tz='UTC'),
@@ -129,14 +129,14 @@ def test_cumulative_window(client, ibis_windows, spark_range):
     ],
     indirect=['ibis_windows'],
 )
-def test_multiple_trailing_window(client, ibis_windows, spark_range):
+def test_multiple_trailing_window(con, ibis_windows, spark_range):
     """Test context adjustment for multiple trailing window.
 
     When there are multiple window ops, we need to verify contexts are
     adjusted correctly for all windows. In this tests we are constucting
     one trailing window for 1h and another trailng window for 2h
     """
-    table = client.table('time_indexed_table')
+    table = con.table('time_indexed_table')
     context = (
         pd.Timestamp('20170102 07:00:00', tz='UTC'),
         pd.Timestamp('20170105', tz='UTC'),
@@ -180,7 +180,7 @@ def test_multiple_trailing_window(client, ibis_windows, spark_range):
     ],
     indirect=['ibis_windows'],
 )
-def test_chained_trailing_window(client, ibis_windows, spark_range):
+def test_chained_trailing_window(con, ibis_windows, spark_range):
     """Test context adjustment for chained windows.
 
     When there are chained window ops, we need to verify contexts are
@@ -188,7 +188,7 @@ def test_chained_trailing_window(client, ibis_windows, spark_range):
     one trailing window for 1h and trailng window on the new column for
     2h
     """
-    table = client.table('time_indexed_table')
+    table = con.table('time_indexed_table')
     context = (
         pd.Timestamp('20170102 07:00:00', tz='UTC'),
         pd.Timestamp('20170105', tz='UTC'),
@@ -238,7 +238,7 @@ def test_chained_trailing_window(client, ibis_windows, spark_range):
     ],
     indirect=['ibis_windows'],
 )
-def test_rolling_with_cumulative_window(client, ibis_windows, spark_range):
+def test_rolling_with_cumulative_window(con, ibis_windows, spark_range):
     """Test context adjustment for rolling window and cumulative window.
 
     cumulative window should calculate only with in user's context,
@@ -254,7 +254,7 @@ def test_rolling_with_cumulative_window(client, ibis_windows, spark_range):
     2020-01-02   b      2            1
     2020-01-03   c      2            2
     """
-    table = client.table('time_indexed_table')
+    table = con.table('time_indexed_table')
     context = (
         pd.Timestamp('20170102 07:00:00', tz='UTC'),
         pd.Timestamp('20170105', tz='UTC'),
@@ -298,7 +298,7 @@ def test_rolling_with_cumulative_window(client, ibis_windows, spark_range):
     [([(ibis.interval(hours=1), 0)], [(-3600, 0)])],
     indirect=['ibis_windows'],
 )
-def test_rolling_with_non_window_op(client, ibis_windows, spark_range):
+def test_rolling_with_non_window_op(con, ibis_windows, spark_range):
     """Test context adjustment for rolling window and non window ops.
 
     non window ops should calculate only with in user's context,
@@ -318,7 +318,7 @@ def test_rolling_with_non_window_op(client, ibis_windows, spark_range):
     count should return 3 for every row, rather 4, based on the
     adjusted context (01-01, 01-04).
     """
-    table = client.table('time_indexed_table')
+    table = con.table('time_indexed_table')
     context = (
         pd.Timestamp('20170102 07:00:00', tz='UTC'),
         pd.Timestamp('20170105', tz='UTC'),
@@ -347,11 +347,11 @@ def test_rolling_with_non_window_op(client, ibis_windows, spark_range):
     tm.assert_frame_equal(result_pd, expected)
 
 
-def test_complex_window(client):
+def test_complex_window(con):
     """Test window with different sizes mix context adjustment for window op
     that require context adjustment and non window op that doesn't adjust
     context."""
-    table = client.table('time_indexed_table')
+    table = con.table('time_indexed_table')
     context = (
         pd.Timestamp('20170102 07:00:00', tz='UTC'),
         pd.Timestamp('20170105', tz='UTC'),

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -574,33 +574,21 @@ def test_column_access_after_sort(alltypes, df, column):
 
 
 @pytest.fixture
-def mj1(con):
-    con.create_table(
-        "mj1",
-        schema=ibis.schema(dict(id1="int32", val1="float64")),
-        overwrite=True,
+def mj1(con, temp_table):
+    return con.create_table(
+        temp_table,
+        pd.DataFrame(dict(id1=[1, 2], val1=[10.0, 20.0])),
+        schema=ibis.schema(dict(id1="int64", val1="float64")),
     )
-    try:
-        con.insert(
-            "mj1",
-            pd.DataFrame(dict(id1=[1, 2], val1=[10, 20])),
-            overwrite=True,
-        )
-        yield con.table("mj1")
-    finally:
-        con.drop_table("mj1", force=True)
 
 
 @pytest.fixture
-def mj2(con):
-    con.create_table(
-        "mj2", schema=ibis.schema(dict(id2="int32", val2="float64")), overwrite=True
+def mj2(con, temp_table_orig):
+    return con.create_table(
+        temp_table_orig,
+        pd.DataFrame(dict(id2=[1, 2], val2=[15.0, 25.0])),
+        schema=ibis.schema(dict(id2="int64", val2="float64")),
     )
-    try:
-        con.insert("mj2", pd.DataFrame(dict(id2=[1, 2], val2=[15, 25])), overwrite=True)
-        yield con.table("mj2")
-    finally:
-        con.drop_table("mj2", force=True)
 
 
 def test_simple_join(mj1, mj2):

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -3,7 +3,7 @@ import pytest
 from pytest import param
 
 import ibis
-from ibis import _, util
+from ibis import _
 
 table_dot_sql_notimpl = pytest.mark.notimpl(
     ["bigquery", "clickhouse", "impala", "druid"]
@@ -179,16 +179,11 @@ def test_table_dot_sql_repr(con):
 @table_dot_sql_notimpl
 @dot_sql_notimpl
 @dot_sql_never
-def test_table_dot_sql_does_not_clobber_existing_tables(con):
-    name = f"ibis_{util.guid()}"
-    t = con.create_table(name, schema=ibis.schema(dict(a="string")))
-    try:
-        expr = t.sql("SELECT 1 as x FROM functional_alltypes")
-        with pytest.raises(ValueError):
-            expr.alias(name)
-    finally:
-        con.drop_table(name, force=True)
-        assert name not in con.list_tables()
+def test_table_dot_sql_does_not_clobber_existing_tables(con, temp_table):
+    t = con.create_table(temp_table, schema=ibis.schema(dict(a="string")))
+    expr = t.sql("SELECT 1 as x FROM functional_alltypes")
+    with pytest.raises(ValueError):
+        expr.alias(temp_table)
 
 
 @table_dot_sql_notimpl

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -761,19 +761,16 @@ def test_between(backend, alltypes, df):
 
 
 @pytest.mark.notimpl(["druid"])
-def test_interactive(alltypes):
+def test_interactive(alltypes, monkeypatch):
+    monkeypatch.setattr(ibis.options, "interactive", True)
+
     expr = alltypes.mutate(
         str_col=_.string_col.replace("1", "").nullif("2"),
         date_col=_.timestamp_col.date(),
         delta_col=lambda t: ibis.now() - t.timestamp_col,
     )
 
-    orig = ibis.options.interactive
-    ibis.options.interactive = True
-    try:
-        repr(expr)
-    finally:
-        ibis.options.interactive = orig
+    repr(expr)
 
 
 def test_correlated_subquery(alltypes):

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -1,5 +1,3 @@
-import contextlib
-
 import numpy as np
 import pandas as pd
 import pandas.testing as tm
@@ -9,7 +7,6 @@ from pytest import param
 import ibis
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
-from ibis.util import guid
 
 pytestmark = [
     pytest.mark.never(
@@ -233,18 +230,10 @@ def test_map_get_with_null_on_null_type_with_non_null(con):
     assert con.execute(expr) == 1
 
 
-@pytest.fixture
-def tmptable(con):
-    name = f"tmp_{guid()}"
-    yield name
-
-    # some backends don't implement drop
-    with contextlib.suppress(NotImplementedError):
-        con.drop_table(name, force=True)
-
-
-def test_map_create_table(con, tmptable):
-    t = con.create_table(tmptable, schema=ibis.schema(dict(xyz="map<string, string>")))
+def test_map_create_table(con, temp_table):
+    t = con.create_table(
+        temp_table, schema=ibis.schema(dict(xyz="map<string, string>"))
+    )
     assert t.schema()["xyz"].is_map()
 
 

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import itertools
 import os
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 
 import pandas as pd
 import pytest
 
 import ibis
-from ibis.backends.conftest import TEST_TABLES, _random_identifier
+from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 from ibis.backends.tests.data import struct_types
 from ibis.util import consume
@@ -184,13 +184,3 @@ def translate():
 
     context = Backend.compiler.make_context()
     return lambda expr: (Backend.compiler.translator_class(expr, context).get_result())
-
-
-@pytest.fixture
-def temp_table(con) -> Generator[str, None, None]:
-    """Return a temporary table name."""
-    name = _random_identifier('table')
-    try:
-        yield name
-    finally:
-        con.drop_table(name, force=True)

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -880,10 +880,8 @@ class Node(Comparable):
 def cache():
     Node.num_equal_calls = 0
     cache = Node.__cache__
-    try:
-        yield cache
-    finally:
-        assert len(cache) == 0
+    yield cache
+    assert not cache
 
 
 def pair(a, b):

--- a/ibis/tests/expr/test_format.py
+++ b/ibis/tests/expr/test_format.py
@@ -247,17 +247,9 @@ def test_value_exprs_repr():
     assert "Sum(r0.a)" in repr(t.a.sum())
 
 
-@pytest.fixture
-def show_types():
-    old = ibis.options.repr.show_types
-    ibis.options.repr.show_types = True
-    try:
-        yield
-    finally:
-        ibis.options.repr.show_types = old
+def test_show_types(monkeypatch):
+    monkeypatch.setattr(ibis.options.repr, "show_types", True)
 
-
-def test_show_types(show_types):
     t = ibis.table(dict(a="int64", b="string"), name="t")
     expr = t.a / 1.0
     assert "# int64" in repr(t.a)
@@ -278,7 +270,7 @@ def test_tables_have_format_value_rules(cls):
 @pytest.mark.parametrize(
     "f",
     [
-        lambda t1, t2: t1.count(),
+        lambda t1, _: t1.count(),
         lambda t1, t2: t1.join(t2, t1.a == t2.a).count(),
         lambda t1, t2: ibis.union(t1, t2).count(),
     ],

--- a/ibis/tests/expr/test_visualize.py
+++ b/ibis/tests/expr/test_visualize.py
@@ -78,16 +78,6 @@ def test_custom_expr_with_not_implemented_type():
     assert key(expr.op()) in graph.source
 
 
-@pytest.fixture
-def with_graphviz():
-    old = ibis.options.graphviz_repr
-    ibis.options.graphviz_repr = True
-    try:
-        yield
-    finally:
-        ibis.options.graphviz_repr = old
-
-
 @pytest.mark.parametrize('how', ['inner', 'left', 'right', 'outer'])
 def test_join(how):
     left = ibis.table([('a', 'int64'), ('b', 'string')])
@@ -109,7 +99,9 @@ def test_order_by():
     bool(os.environ.get('APPVEYOR', None)),
     reason='Not sure what the prerequisites for running this on Windows are',
 )
-def test_optional_graphviz_repr(with_graphviz):
+def test_optional_graphviz_repr(monkeypatch):
+    monkeypatch.setattr(ibis.options, 'graphviz_repr', True)
+
     t = ibis.table([('a', 'int64'), ('b', 'string'), ('c', 'int32')])
     expr = t.group_by(t.b).aggregate(sum_a=t.a.sum().cast('double')).order_by('b')
 
@@ -157,7 +149,8 @@ def test_filter():
     assert "predicates[1]" in graph.source
 
 
-def test_html_escape(with_graphviz):
+def test_html_escape(monkeypatch):
+    monkeypatch.setattr(ibis.options, 'graphviz_repr', True)
     # Check that we correctly escape HTML <> characters in the graphviz
     # representation. If an error is thrown, _repr_png_ returns None.
     expr = ibis.table([('<a & b>', ibis.expr.datatypes.Array('string'))])

--- a/ibis/tests/test_config.py
+++ b/ibis/tests/test_config.py
@@ -3,14 +3,11 @@ import pytest
 from ibis.config import options
 
 
-def test_sql_config():
-    try:
-        assert options.sql.default_limit is None
+def test_sql_config(monkeypatch):
+    assert options.sql.default_limit is None
 
-        with pytest.raises(TypeError):
-            options.sql.default_limit = -1
+    with pytest.raises(TypeError):
+        options.sql.default_limit = -1
 
-        options.sql.default_limit = 100
-        assert options.sql.default_limit == 100
-    finally:
-        options.sql.default_limit = None
+    monkeypatch.setattr(options.sql, 'default_limit', 100)
+    assert options.sql.default_limit == 100


### PR DESCRIPTION
This PR refactors our test suite to remove most of the unnecessary try/finally blocks in favor of automatic pytest handling or monkeypatch use.