### PR TITLE
fix(pandas): solve problem with first and last window function

### DIFF
--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -500,7 +500,7 @@ def execute_series_lead_lag_timedelta(
 
 @execute_node.register(ops.FirstValue, pd.Series)
 def execute_series_first_value(op, data, **kwargs):
-    return data.values[0]
+    return data.iloc[np.repeat(0, len(data))]
 
 
 def _getter(x: pd.Series | np.ndarray, idx: int):
@@ -514,7 +514,7 @@ def execute_series_group_by_first_value(op, data, aggcontext=None, **kwargs):
 
 @execute_node.register(ops.LastValue, pd.Series)
 def execute_series_last_value(op, data, **kwargs):
-    return data.values[-1]
+    return data.iloc[np.repeat(-1, len(data))]
 
 
 @execute_node.register(ops.LastValue, SeriesGroupBy)

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -107,13 +107,15 @@ def test_lag_delta(t, df, range_offset, default, range_window):
 def test_first(t, df):
     expr = t.dup_strings.first()
     result = expr.execute()
-    assert result == df.dup_strings.iloc[0]
+    expected = df.dup_strings.iloc[np.repeat(0, len(df))].reset_index(drop=True)
+    tm.assert_series_equal(result, expected)
 
 
 def test_last(t, df):
     expr = t.dup_strings.last()
     result = expr.execute()
-    assert result == df.dup_strings.iloc[-1]
+    expected = df.dup_strings.iloc[np.repeat(-1, len(df))].reset_index(drop=True)
+    tm.assert_series_equal(result, expected)
 
 
 def test_group_by_mutate_analytic(t, df):


### PR DESCRIPTION
### Implementation 
In the case of the first function, I chose to implement it with np.repeat as opposed to np.zeros for two reasons:

1. To use the same function as for the last.
2. Using repeat avoids the need for specifying a dtype.

fixes #4918