### PR TITLE
refactor(ir): remove `rlz.column_from`, `rlz.base_table_of` and `rlz.function_of` rules

### DIFF
--- a/ibis/expr/operations/window.py
+++ b/ibis/expr/operations/window.py
@@ -30,18 +30,7 @@ class WindowFrame(Value):
     """A window frame operation bound to a table."""
 
     table = rlz.table
-    group_by = rlz.optional(
-        rlz.tuple_of(
-            rlz.one_of(
-                [
-                    rlz.column_from(rlz.ref("table")),
-                    rlz.function_of(rlz.ref("table")),
-                    rlz.any,
-                ]
-            )
-        ),
-        default=(),
-    )
+    group_by = rlz.optional(rlz.tuple_of(rlz.any), default=())
     order_by = rlz.optional(
         rlz.tuple_of(rlz.sort_key_from(rlz.ref("table"))), default=()
     )

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -27,6 +27,7 @@ import ibis.expr.types as ir
 from ibis import util
 from ibis.expr.deferred import Deferred
 from ibis.selectors import Selector
+from ibis.expr.types.relations import bind_expr
 
 _function_types = tuple(
     filter(
@@ -238,12 +239,12 @@ class GroupedTable:
             return ops.RowsWindowFrame(
                 table=self.table,
                 group_by=self.by,
-                order_by=self._order_by,
+                order_by=bind_expr(self.table, self._order_by),
             )
         else:
             return self._window.copy(
-                groupy_by=self._window.group_by + self.by,
-                order_by=self._window.order_by + self._order_by,
+                groupy_by=bind_expr(self.table, self._window.group_by + self.by),
+                order_by=bind_expr(self.table, self._window.order_by + self._order_by),
             )
 
     def over(

--- a/ibis/tests/expr/test_set_operations.py
+++ b/ibis/tests/expr/test_set_operations.py
@@ -59,4 +59,6 @@ def test_operation_supports_schemas_with_different_field_order(method):
     u2 = u2.op().table
     assert u2.schema == a.schema()
     assert u2.left == a.op()
-    assert u2.right == ops.Selection(c.op(), ['a', 'b', 'c'])
+
+    columns = [ops.TableColumn(c, name) for name in 'abc']
+    assert u2.right == ops.Selection(c.op(), columns)


### PR DESCRIPTION
Simplify relational operations by enforcing input arguments already bound to the parent relation using `bind_expr()`

This change is pulled out from https://github.com/ibis-project/ibis/pull/5899