### PR TITLE
feat(postgres): add ApproxMedian aggregation

### DIFF
--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -444,6 +444,14 @@ def _quantile(t, op):
     )
 
 
+def _approx_median(t, op):
+    arg = op.arg
+    if (where := op.where) is not None:
+        arg = ops.Where(where, arg, None)
+
+    return sa.func.percentile_cont(0.5).within_group(t.translate(arg))
+
+
 def _binary_variance_reduction(func):
     def variance_compiler(t, op):
         x = op.left
@@ -659,6 +667,7 @@ operation_registry.update(
         ops.Correlation: _corr,
         ops.BitwiseXor: _bitwise_op("#"),
         ops.Mode: _mode,
+        ops.ApproxMedian: _approx_median,
         ops.Quantile: _quantile,
         ops.MultiQuantile: _quantile,
         ops.TimestampNow: lambda t, op: sa.literal_column(

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -717,7 +717,7 @@ def test_interactive_repr_shows_error(alltypes):
     # #591. Doing this in PostgreSQL because so many built-in functions are
     # not available
 
-    expr = alltypes.double_col.approx_median()
+    expr = alltypes.int_col.convert_base(10, 2)
 
     with config.option_context('interactive', True):
         result = repr(expr)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1010,7 +1010,7 @@ def test_corr_cov(
 
 
 @pytest.mark.notimpl(
-    ["datafusion", "mysql", "postgres", "sqlite", "snowflake", "mssql", "druid"],
+    ["datafusion", "mysql", "sqlite", "snowflake", "mssql", "druid"],
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.broken(


### PR DESCRIPTION
### Implementation 

Changed the function in `test_interactive_repr_shows_error` from `double_col.approx_median()` to `int_col.convert_base(10, 2)` to keep the error showing. 

