### PR TITLE
chore(ir): remove unused time unit mappings

### DIFF
--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -24,58 +24,6 @@ class TimestampUnary(Unary):
     arg = rlz.timestamp
 
 
-_date_units = {
-    'Y': 'Y',
-    'y': 'Y',
-    'year': 'Y',
-    'YEAR': 'Y',
-    'YYYY': 'Y',
-    'SYYYY': 'Y',
-    'YYY': 'Y',
-    'YY': 'Y',
-    'Q': 'Q',
-    'q': 'Q',
-    'quarter': 'Q',
-    'QUARTER': 'Q',
-    'M': 'M',
-    'month': 'M',
-    'MONTH': 'M',
-    'w': 'W',
-    'W': 'W',
-    'week': 'W',
-    'WEEK': 'W',
-    'd': 'D',
-    'D': 'D',
-    'J': 'D',
-    'day': 'D',
-    'DAY': 'D',
-}
-
-_time_units = {
-    'h': 'h',
-    'H': 'h',
-    'HH24': 'h',
-    'hour': 'h',
-    'HOUR': 'h',
-    'm': 'm',
-    'MI': 'm',
-    'minute': 'm',
-    'MINUTE': 'm',
-    's': 's',
-    'second': 's',
-    'SECOND': 's',
-    'ms': 'ms',
-    'millisecond': 'ms',
-    'MILLISECOND': 'ms',
-    'us': 'us',
-    'microsecond': 'ms',
-    'MICROSECOND': 'ms',
-    'ns': 'ns',
-    'nanosecond': 'ns',
-    'NANOSECOND': 'ns',
-}
-
-
 @public
 class TimestampTruncate(Value):
     arg = rlz.timestamp


### PR DESCRIPTION
These are leftovers from a previous refactor.