### PR TITLE
feat(snowflake): implement proper approx median

### DIFF
--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -389,6 +389,7 @@ operation_registry.update(
         ops.EndsWith: fixed_arity(sa.func.endswith, 2),
         ops.GroupConcat: _group_concat,
         ops.Hash: unary(sa.func.hash),
+        ops.ApproxMedian: reduction(lambda x: sa.func.approx_percentile(x, 0.5)),
     }
 )
 

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1010,7 +1010,7 @@ def test_corr_cov(
 
 
 @pytest.mark.notimpl(
-    ["datafusion", "mysql", "sqlite", "snowflake", "mssql", "druid"],
+    ["datafusion", "mysql", "sqlite", "mssql", "druid"],
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.broken(


### PR DESCRIPTION
After #6081, the Snowflake backend test for `approx_median` is passing, but returns the exact median. This PR changes that API to use the proper approximate version.