### PR TITLE
docs: clarify map refers to Python Mapping container

### DIFF
--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -396,7 +396,7 @@ def map(
     keys: Iterable[Any] | Mapping[Any, Any] | ArrayColumn,
     values: Iterable[Any] | ArrayColumn | None = None,
 ) -> MapValue:
-    """Create a map expression.
+    """Create a [map container object](https://docs.python.org/3/glossary.html#term-mapping).
 
     If the `keys` and `values` are Python literals, then the output will be a
     `MapScalar`. If the `keys` and `values` are expressions (`ArrayColumn`),


### PR DESCRIPTION
This is a proposed docstring change, and I am very much open to this PR being rejected.

While working on this: https://github.com/ibis-project/ibis/issues/5982 it took me a bit of time to understand the behaviour of `ibis.map` because there exists an [expr.types.ArrayValue.map](https://ibis-project.org/api/expressions/collections/?h=map#ibis.expr.types.arrays.ArrayValue.map) that has different behaviour.

The [docstring for ibis.map](https://ibis-project.org/api/expressions/top_level/?h=mapscalar#ibis.map) confused me more. Where was the lambda?

Speaking with a colleague, I learned about `mapping` being used as a concept to describe an object where there is a mapping between keys and values: https://docs.python.org/3/glossary.html#term-mapping. I have only been familiar with the functional definition, and not the object-category definition. I think because this colleague is familiar with `C++ std::map<>` they grokked it faster.

I am proposing we just add a small link in the docstring to the object-category definition. It would have helped me realise my confusion a lot sooner. I am not sure if this is the proper way to add a link, or if it would be better to add a definition instead of a link. I am also open to it being rare that somebody else would be confused by this, and the PR not being merged in.