### PR TITLE
docs(guides): add brief installation instructions at top of notebooks

### DIFF
--- a/docs/ibis-for-pandas-users.ipynb
+++ b/docs/ibis-for-pandas-users.ipynb
@@ -2,6 +2,36 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "fbde06fb-efb6-4444-8dbc-553628da1db4",
+   "metadata": {},
+   "source": [
+    "## Install"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccced4b3-5216-4394-bfe7-8dc206431b50",
+   "metadata": {},
+   "source": [
+    "If you don't have `ibis` installed, you can install it from:\n",
+    "\n",
+    "### PyPI\n",
+    "\n",
+    "```\n",
+    "python -m pip install 'ibis-framework[duckdb]'\n",
+    "```\n",
+    "\n",
+    "### conda-forge\n",
+    "\n",
+    "```\n",
+    "conda install -c conda-forge ibis-framework\n",
+    "```\n",
+    "\n",
+    "You can check out [the install page](https://ibis-project.org/install/) for more detailed instructions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "641af053-e938-4384-8ccd-6eff5b31833d",
    "metadata": {
     "tags": []
@@ -10,7 +40,7 @@
     "# Ibis for pandas Users\n",
     "\n",
     "Much of the syntax and many of the operations in Ibis are inspired\n",
-    "by the pandas DataFrame, however, the primary domain of Ibis is\n",
+    "by the pandas `DataFrame` but the primary domain of Ibis is\n",
     "SQL so there are some differences in how they operate. \n",
     "\n",
     "One primary\n",

--- a/docs/ibis-for-sql-programmers.ipynb
+++ b/docs/ibis-for-sql-programmers.ipynb
@@ -2,6 +2,36 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "75b5d5fe-e647-4bff-ac58-1269d0c6bd22",
+   "metadata": {},
+   "source": [
+    "## Install"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9ecf091-78c0-4f35-bb2d-17a6f98109db",
+   "metadata": {},
+   "source": [
+    "If you don't have `ibis` installed, you can install it from:\n",
+    "\n",
+    "### PyPI\n",
+    "\n",
+    "```\n",
+    "python -m pip install 'ibis-framework[duckdb]'\n",
+    "```\n",
+    "\n",
+    "### conda-forge\n",
+    "\n",
+    "```\n",
+    "conda install -c conda-forge ibis-framework\n",
+    "```\n",
+    "\n",
+    "You can check out [the install page](https://ibis-project.org/install/) for more detailed instructions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "641af053-e938-4384-8ccd-6eff5b31833d",
    "metadata": {
     "tags": []
@@ -2239,7 +2269,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We got a bit of feedback from a user who landed on the Ibis for Pandas
page via a deep link, and then ran into an issue because they tried to
install `ibis` from PyPI.