### PR TITLE
ci: skip sqlalchemy 2.0.11 to workaround broken ci

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -543,7 +543,7 @@ jobs:
         run: poetry remove snowflake-sqlalchemy
 
       - name: add sqlalchemy 2
-        run: poetry add --lock --optional 'sqlalchemy>=2,<3'
+        run: poetry add --lock --optional 'sqlalchemy>=2,<3,!=2.0.11'
 
       - name: checkout the lock file
         run: git checkout poetry.lock


### PR DESCRIPTION
This PR works around failing CI while we figure out what the issue is with MySQL. For duckdb I opened https://github.com/Mause/duckdb_engine/issues/632.