### PR TITLE
fix(bigquery): truncate floats before casting, to avoid rounding

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -56,6 +56,12 @@ def bigquery_cast_interval_to_integer(compiled_arg, from_, to):
     return f"EXTRACT({from_.resolution.upper()} from {compiled_arg})"
 
 
+@bigquery_cast.register(str, dt.Floating, dt.Integer)
+def bigquery_cast_floating_to_integer(compiled_arg, from_, to):
+    """Convert FLOAT64 to INT64 without rounding."""
+    return f"CAST(TRUNC({compiled_arg}) AS INT64)"
+
+
 @bigquery_cast.register(str, dt.DataType, dt.DataType)
 def bigquery_cast_generate(compiled_arg, from_, to):
     """Cast to desired type."""

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -97,7 +97,7 @@ def test_cast_string_to_date(alltypes, df):
 
 
 def test_cast_float_to_int(alltypes, df):
-    expr = alltypes.float_col.sub(2.55).cast("int64").sort_values()
+    expr = (alltypes.float_col -2.55).cast("int64").sort_values()
     result = expr.execute()
     expected = (df.float_col - 2.55).astype("Int64").sort_values()
     tm.assert_series_equal(result, expected)

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -97,7 +97,7 @@ def test_cast_string_to_date(alltypes, df):
 
 
 def test_cast_float_to_int(alltypes, df):
-    result = (alltypes.float_col -2.55).cast("int64").to_pandas().sort_values()
+    result = (alltypes.float_col - 2.55).cast("int64").to_pandas().sort_values()
     expected = (df.float_col - 2.55).astype("int64").sort_values()
     tm.assert_series_equal(result, expected, check_names=False)
 

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -96,6 +96,13 @@ def test_cast_string_to_date(alltypes, df):
     tm.assert_series_equal(result, expected)
 
 
+def test_cast_float_to_int(alltypes, df):
+    expr = alltypes.float_col.sub(2.55).cast("int64").sort_values()
+    result = expr.execute()
+    expected = (df.float_col - 2.55).astype("Int64").sort_values()
+    tm.assert_series_equal(result, expected)
+
+
 def test_has_partitions(alltypes, parted_alltypes, con):
     col = con.partition_column
     assert col not in alltypes.columns

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -97,10 +97,9 @@ def test_cast_string_to_date(alltypes, df):
 
 
 def test_cast_float_to_int(alltypes, df):
-    expr = (alltypes.float_col -2.55).cast("int64").sort_values()
-    result = expr.execute()
-    expected = (df.float_col - 2.55).astype("Int64").sort_values()
-    tm.assert_series_equal(result, expected)
+    result = (alltypes.float_col -2.55).cast("int64").to_pandas().sort_values()
+    expected = (df.float_col - 2.55).astype("int64").sort_values()
+    tm.assert_series_equal(result, expected, check_names=False)
 
 
 def test_has_partitions(alltypes, parted_alltypes, con):


### PR DESCRIPTION
When casting a float to an integer, BigQuery will round it ([documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_functions#cast_as_integer)).

Most of the other Ibis backends will truncate it instead, i.e.:
0.4 -> 0
0.8 -> 0 (BigQuery returns 1) 
-0.4 -> 0
-0.8 -> 0 (BigQuery returns -1)

This change will make the BigQuery backend truncate the float before casting it, to match the other Ibis backends.