### PR TITLE
fix(bigquery): truncate when casting float to int

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -56,6 +56,12 @@ def bigquery_cast_interval_to_integer(compiled_arg, from_, to):
     return f"EXTRACT({from_.resolution.upper()} from {compiled_arg})"
 
 
+@bigquery_cast.register(str, dt.Floating, dt.Integer)
+def bigquery_cast_floating_to_integer(compiled_arg, from_, to):
+    """Convert FLOAT64 to INT64 without rounding."""
+    return f"CAST(TRUNC({compiled_arg}) AS INT64)"
+
+
 @bigquery_cast.register(str, dt.DataType, dt.DataType)
 def bigquery_cast_generate(compiled_arg, from_, to):
     """Cast to desired type."""

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -96,6 +96,12 @@ def test_cast_string_to_date(alltypes, df):
     tm.assert_series_equal(result, expected)
 
 
+def test_cast_float_to_int(alltypes, df):
+    result = (alltypes.float_col - 2.55).cast("int64").to_pandas().sort_values()
+    expected = (df.float_col - 2.55).astype("int64").sort_values()
+    tm.assert_series_equal(result, expected, check_names=False)
+
+
 def test_has_partitions(alltypes, parted_alltypes, con):
     col = con.partition_column
     assert col not in alltypes.columns

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_float_to_int/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_cast_float_to_int/out.sql
@@ -1,0 +1,2 @@
+SELECT CAST(TRUNC(t0.`double_col`) AS INT64) AS `tmp`
+FROM functional_alltypes t0

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -575,3 +575,9 @@ def test_scalar_param_scope(alltypes):
 SELECT t\\d+\\.\\*, @param_\\d+ AS `param`
 FROM functional_alltypes t\\d+"""
     assert re.match(expected, result) is not None
+
+
+def test_cast_float_to_int(alltypes, snapshot):
+    expr = alltypes.double_col.cast("int64")
+    result = to_sql(expr)
+    snapshot.assert_match(result, "out.sql")


### PR DESCRIPTION
BREAKING CHANGE: when using the bigquery backend, floats will be truncated instead of rounded to the nearest integer