### PR TITLE
fix(snowflake): ensure unnest works for nested struct/object types

### DIFF
--- a/ibis/backends/dask/tests/conftest.py
+++ b/ibis/backends/dask/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 
 import ibis
 from ibis.backends.pandas.tests.conftest import TestConf as PandasTest
-from ibis.backends.tests.data import win
+from ibis.backends.tests.data import array_types, win
 
 dd = pytest.importorskip("dask.dataframe")
 
@@ -67,6 +67,7 @@ class TestConf(PandasTest):
                     npartitions=NPARTITIONS,
                 ),
                 "win": dd.from_pandas(win, npartitions=NPARTITIONS),
+                "array_types": dd.from_pandas(array_types, npartitions=NPARTITIONS),
             }
         )
 


### PR DESCRIPTION
This PR fixes a bug in snowflake where we were not calling `parse_json` when unnesting a struct. I also managed to simplify the flatten implementation by removing our custom flatten sqlalchemy operator entirely.

Fixing this exposed a bug in the clickhouse backend where external tables were being propagated across queries. That is fixed by clearing external tables before discovering them.