### PR TITLE
fix(impala): clean up internal cursor usage

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -131,11 +131,7 @@ class BaseSQLBackend(BaseBackend):
         query
             DDL or DML statement
         """
-        cursor = self.con.execute(query)
-        if cursor:
-            return cursor
-        cursor.release()
-        return None
+        return self.con.execute(query)
 
     @contextlib.contextmanager
     def _safe_raw_sql(self, *args, **kwargs):

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -305,7 +305,8 @@ class ImpalaTable(ir.Table):
                 partition_schema=partition_schema,
                 overwrite=overwrite,
             )
-            return self._client.raw_sql(statement.compile())
+            self._client._safe_exec_sql(statement.compile())
+            return self
 
     def load_data(self, path, overwrite=False, partition=None):
         """Load data into an Impala table.
@@ -333,7 +334,8 @@ class ImpalaTable(ir.Table):
             overwrite=overwrite,
         )
 
-        return self._client.raw_sql(stmt.compile())
+        self._client._safe_exec_sql(stmt.compile())
+        return self
 
     @property
     def name(self):
@@ -348,7 +350,7 @@ class ImpalaTable(ir.Table):
         if not m and database is None:
             database = self._database
         statement = RenameTable(self._qualified_name, new_name, new_database=database)
-        self._client.raw_sql(statement)
+        self._client._safe_exec_sql(statement)
 
         op = self.op().copy(name=statement.new_qualified_name)
         return type(self)(op)
@@ -385,7 +387,8 @@ class ImpalaTable(ir.Table):
         stmt = ddl.AddPartition(
             self._qualified_name, spec, part_schema, location=location
         )
-        return self._client.raw_sql(stmt)
+        self._client._safe_exec_sql(stmt)
+        return self
 
     def alter(
         self,
@@ -410,7 +413,8 @@ class ImpalaTable(ir.Table):
 
         def _run_ddl(**kwds):
             stmt = AlterTable(self._qualified_name, **kwds)
-            return self._client.raw_sql(stmt)
+            self._client._safe_exec_sql(stmt)
+            return self
 
         return self._alter_table_helper(
             _run_ddl,
@@ -451,7 +455,8 @@ class ImpalaTable(ir.Table):
 
         def _run_ddl(**kwds):
             stmt = ddl.AlterPartition(self._qualified_name, spec, part_schema, **kwds)
-            return self._client.raw_sql(stmt)
+            self._client._safe_exec_sql(stmt)
+            return self
 
         return self._alter_table_helper(
             _run_ddl,
@@ -474,7 +479,8 @@ class ImpalaTable(ir.Table):
         """Drop an existing table partition."""
         part_schema = self.partition_schema()
         stmt = ddl.DropPartition(self._qualified_name, spec, part_schema)
-        return self._client.raw_sql(stmt)
+        self._client._safe_exec_sql(stmt)
+        return self
 
     def partitions(self):
         """Return information about the table's partitions.

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -395,7 +395,7 @@ def mockcon():
 @pytest.fixture(scope="module")
 def kudu_table(con, test_data_db):
     name = 'kudu_backed_table'
-    con.raw_sql(
+    cur = con.raw_sql(
         f"""\
 CREATE TABLE {test_data_db}.{name} (
   a STRING,
@@ -408,6 +408,7 @@ TBLPROPERTIES (
   'kudu.num_tablet_replicas' = '1'
 )"""
     )
+    cur.close()
     yield con.table(name)
     con.drop_table(name, database=test_data_db)
 

--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import closing
 from posixpath import join as pjoin
 
 import pytest
@@ -346,13 +347,16 @@ def test_query_delimited_file_directory(con, test_data_dir, tmp_db):
 @pytest.fixture
 def temp_char_table(con):
     name = "testing_varchar_support"
-    con.raw_sql(
-        f"""\
+    with closing(
+        con.raw_sql(
+            f"""\
 CREATE TABLE IF NOT EXISTS {name} (
   group1 VARCHAR(10),
   group2 CHAR(10)
 )"""
-    )
+        )
+    ):
+        pass
     assert name in con.list_tables(), name
     yield con.table(name)
     con.drop_table(name, force=True)


### PR DESCRIPTION
This PR tries to address #6128 by more aggressively cleaning up our use of raw_sql internally. Closes #6128.