### PR TITLE
test(backend): add xfail test for memtable with null strings

### DIFF
--- a/ibis/backends/base/sql/registry/literal.py
+++ b/ibis/backends/base/sql/registry/literal.py
@@ -21,7 +21,14 @@ def _boolean_literal_format(translator, op):
 
 
 def _string_literal_format(translator, op):
-    return "'{}'".format(op.value.replace("'", "\\'"))
+    import pandas as pd
+
+    value = op.value
+    if pd.isna(value):
+        return "NULL"
+
+    value = value.replace("'", "\\'")
+    return f"'{value}'"
 
 
 def _number_literal_format(translator, op):

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -923,6 +923,17 @@ def test_memtable_bool_column(backend, con, monkeypatch):
     backend.assert_series_equal(t.a.execute(), pd.Series([True, False, True], name="a"))
 
 
+@pytest.mark.parametrize("dtype", [None, "string"])
+def test_memtable_null_str(backend, con, monkeypatch, dtype):
+    """Ensure that null strings are translated to null, not string literal '<NA>'"""
+    monkeypatch.setattr(ibis.options, "default_backend", con)
+
+    strings = ["a", None, "c"]
+    df = pd.DataFrame({"a": strings}, dtype=dtype)
+    t = ibis.memtable(df)
+    assert t.a.execute().tolist() == strings
+
+
 @pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 @pytest.mark.broken(
     ["druid"],

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -951,7 +951,7 @@ def test_memtable_null_str_default_dtype(con):
     ["postgres"], reason="NA not supported", raises=sa.exc.ProgrammingError
 )
 @pytest.mark.notyet(
-    ["trino"], reason="NA not supported", raises=sa.exc.NotSupportedError
+    ["oracle", "trino"], reason="NA not supported", raises=sa.exc.NotSupportedError
 )
 @pytest.mark.notyet(["druid"], reason="NA not supported", raises=sa.exc.CompileError)
 def test_memtable_null_string_dtype(con):

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -240,11 +240,11 @@ class _WellKnownText(NamedTuple):
 
 def normalize(typ, value):
     """Ensure that the Python type underlying a literal resolves to a single type."""
-
     dtype = dt.dtype(typ)
-    if value is None:
+    # checking __name__ is a hack to avoid importing pandas _just_ to check for NA
+    if value is None or type(value).__name__ == "NAType":
         if not dtype.nullable:
-            raise TypeError("Cannot convert `None` to non-nullable type {typ!r}")
+            raise TypeError(f"Cannot convert `{value!s}` to non-nullable type {typ!r}")
         return None
 
     if dtype.is_boolean():

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -207,6 +207,7 @@ class Literal(Value):
                     "shapely.geometry.BaseGeometry",
                     "numpy.generic",
                     "numpy.ndarray",
+                    "pandas._libs.missing.NAType",
                 )
             ),
         )

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -4,6 +4,7 @@ import hypothesis as h
 import hypothesis.extra.pandas as past
 import hypothesis.extra.pytz as tzst
 import hypothesis.strategies as st
+import pandas as pd
 
 import ibis
 import ibis.expr.datatypes as dt
@@ -179,3 +180,6 @@ def memtable(draw, schema=schema(primitive_dtypes)):  # noqa: B008
 
     df = draw(dataframe)
     return ibis.memtable(df)
+
+
+null_values = st.sampled_from([None, pd.NA])

--- a/ibis/tests/test_strategies.py
+++ b/ibis/tests/test_strategies.py
@@ -1,6 +1,8 @@
 import hypothesis as h
 import numpy as np
+import pytest
 
+import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
@@ -146,6 +148,22 @@ def test_schema_to_pandas(schema):
 def test_memtable(memtable):
     assert isinstance(memtable, ir.TableExpr)
     assert isinstance(memtable.schema(), sch.Schema)
+
+
+@h.given(its.all_dtypes, its.null_values)
+def test_typed_null_underlying_value(dtype, null_value):
+    h.assume(dtype.nullable)
+
+    expr = ibis.literal(null_value, type=dtype)
+    assert expr.op().value is None
+
+
+@h.given(its.all_dtypes, its.null_values)
+def test_null_not_nullable(dtype, null_value):
+    h.assume(not dtype.nullable)
+
+    with pytest.raises(TypeError):
+        ibis.literal(null_value, type=dtype)
 
 
 # TODO(kszucs): we enforce field name uniqueness in the schema, but we don't for Struct datatype


### PR DESCRIPTION
The nulls are parsed into `"<NA>"`:

```
AssertionError: assert ['a', '<NA>', 'c'] == ['a', None, 'c']
```

run with

```
pytest ibis/backends/tests/test_generic.py -m duckdb -k test_memtable_null_str
```