### PR TITLE
refactor(pandas): solve and remove stale TODOs

### DIFF
--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -119,7 +119,6 @@ from multipledispatch import Dispatcher
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-import ibis.expr.types as ir
 import ibis.util
 from ibis.backends.base import BaseBackend
 from ibis.backends.base.df.scope import Scope
@@ -425,9 +424,6 @@ def main_execute(
     if cache is None:
         cache = {}
 
-    # TODO: make expresions hashable so that we can get rid of these .op()
-    # calls everywhere
-    params = {k.op() if isinstance(k, ir.Expr) else k: v for k, v in params.items()}
     scope = scope.merge_scope(Scope(params, timecontext))
     return execute_with_scope(
         node,

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -196,8 +196,7 @@ def execute_cast_series_date(op, data, type, **kwargs):
             data.values, data.index, data.name, timezone=from_type.timezone
         )
 
-    # TODO: remove String as subclass of JSON
-    if from_type.is_string() and not from_type.is_json():
+    if from_type.is_string():
         values = data.values
         datetimes = pd.to_datetime(values)
         with contextlib.suppress(TypeError):

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -262,8 +262,8 @@ def build_df_from_projection(
     #
     # If cardinality changes (e.g. unnest/explode), trying to do this
     # won't work so don't try?
-    for i in range(len(new_pieces)):
-        new_pieces[i] = new_pieces[i].sort_index()
+    for i, piece in enumerate(new_pieces):
+        new_pieces[i] = piece.sort_index()
         if len(new_pieces[i].index) == len(data.index):
             new_pieces[i].index = data.index
 

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -132,17 +132,6 @@ def test_aggregation_group_by(t, df, where, ibis_func, pandas_func):
             }
         )
     )
-    # TODO(phillipc): Why does pandas not return floating point values here?
-    expected['avg_plain_int64'] = expected.avg_plain_int64.astype('float64')
-    result['avg_plain_int64'] = result.avg_plain_int64.astype('float64')
-    expected['neg_mean_int64_with_zeros'] = expected.neg_mean_int64_with_zeros.astype(
-        'float64'
-    )
-    result['neg_mean_int64_with_zeros'] = result.neg_mean_int64_with_zeros.astype(
-        'float64'
-    )
-    expected['mean_float64_positive'] = expected.mean_float64_positive.astype('float64')
-    result['mean_float64_positive'] = result.mean_float64_positive.astype('float64')
     lhs = result[expected.columns]
     rhs = expected
     tm.assert_frame_equal(lhs, rhs)


### PR DESCRIPTION
`Expr` are hashable, introduced in the commit c6fb0c040 
`JSON` is no longer a child from `String`, introduced in the commit 34f389825
pandas now return `float64` columns
