### PR TITLE
feat(snowflake): create an ibis backend from a snowpark session

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -39,6 +39,7 @@ jobs:
             backend:
               name: snowflake
               title: Snowflake + Snowpark
+              snowpark: 1
               deps:
                 - "snowflake-snowpark-python"
                 - "--optional"
@@ -48,6 +49,7 @@ jobs:
             backend:
               name: snowflake
               title: Snowflake
+              snowpark: 0
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -100,6 +102,7 @@ jobs:
             echo "SNOWFLAKE_DATABASE=${SNOWFLAKE_DATABASE}"
             echo "SNOWFLAKE_SCHEMA=${SNOWFLAKE_SCHEMA}_python${pyversion//./}"
             echo "SNOWFLAKE_WAREHOUSE=${SNOWFLAKE_WAREHOUSE}"
+            echo "IBIS_USE_SNOWPARK=${{ matrix.backend.snowpark }}"
           } >> "$GITHUB_ENV"
         env:
           SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}

--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -34,8 +34,20 @@ jobs:
         backend:
           - name: bigquery
             title: BigQuery
-          - name: snowflake
-            title: Snowflake
+        include:
+          - python-version: "3.8"
+            backend:
+              name: snowflake
+              title: Snowflake + Snowpark
+              deps:
+                - "snowflake-snowpark-python"
+                - "--optional"
+                - "--python"
+                - "~3.8"
+          - python-version: "3.11"
+            backend:
+              name: snowflake
+              title: Snowflake
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -52,6 +64,10 @@ jobs:
           custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
 
       - run: python -m pip install --upgrade pip 'poetry<1.4'
+
+      - name: install additional deps
+        if: matrix.backend.deps != null
+        run: poetry add ${{ join(matrix.backend.deps, ' ') }}
 
       - uses: syphar/restore-pip-download-cache@v1
         with:

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -33,6 +33,7 @@ from ibis.backends.snowflake.registry import operation_registry
 
 if TYPE_CHECKING:
     import pandas as pd
+    import snowflake.snowpark as sp
 
     import ibis.expr.schema as sch
 
@@ -269,7 +270,7 @@ $$ {defn["source"]} $$"""
         self._default_schema = dbparams["schema"]
 
     @classmethod
-    def from_snowpark(cls, session) -> Backend:
+    def from_snowpark(cls, session: sp.Session) -> Backend:
         """Create an Ibis Snowflake backend from a Snowpark session.
 
         Parameters

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -252,7 +252,7 @@ $$ {defn["source"]} $$"""
                         f"Unable to create map UDFs, some functionality will not work: {e}"
                     )
 
-        eng = super().do_connect(engine)
+        super().do_connect(engine)
 
         def normalize_name(name):
             if name is None:
@@ -267,7 +267,6 @@ $$ {defn["source"]} $$"""
         self.con.dialect.normalize_name = normalize_name
         self.database_name = self._default_database = dbparams["database"]
         self._default_schema = dbparams["schema"]
-        return eng
 
     @classmethod
     def from_snowpark(cls, session) -> Backend:

--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -149,6 +149,21 @@ class TestConf(BackendTest, RoundAwayFromZero):
     @staticmethod
     @functools.lru_cache(maxsize=None)
     def connect(data_directory: Path) -> BaseBackend:
+        if int(os.environ.get("IBIS_USE_SNOWPARK", "0")):
+            sp = pytest.importorskip("snowflake.snowpark")
+
+            return ibis.snowflake.from_snowpark(
+                sp.Session.builder.configs(
+                    dict(
+                        user=os.environ["SNOWFLAKE_USER"],
+                        account=os.environ["SNOWFLAKE_ACCOUNT"],
+                        password=os.environ["SNOWFLAKE_PASSWORD"],
+                        warehouse=os.environ["SNOWFLAKE_WAREHOUSE"],
+                        database=os.environ["SNOWFLAKE_DATABASE"],
+                        schema=os.environ["SNOWFLAKE_SCHEMA"],
+                    )
+                ).create()
+            )
         return ibis.connect(_get_url())
 
 

--- a/ibis/formats/tests/test_pyarrow.py
+++ b/ibis/formats/tests/test_pyarrow.py
@@ -1,7 +1,6 @@
 import hypothesis as h
 import hypothesis.strategies as st
 import pyarrow as pa
-import pyarrow.tests.strategies as past
 import pytest
 
 import ibis.expr.datatypes as dt
@@ -12,6 +11,8 @@ from ibis.formats.pyarrow import (
     schema_from_pyarrow,
     schema_to_pyarrow,
 )
+
+past = pytest.importorskip("pyarrow.tests.strategies")
 
 
 def assert_dtype_roundtrip(arrow_type, ibis_type=None, restored_type=None):


### PR DESCRIPTION
This PR implements the ability to connect to snowflake using an existing snowpark session.

Closes #6153.
