### PR TITLE
fix(pandas): fix string translate function

### DIFF
--- a/ibis/backends/pandas/tests/execution/conftest.py
+++ b/ibis/backends/pandas/tests/execution/conftest.py
@@ -32,6 +32,8 @@ def df():
             'float64_as_strings': ['100.01', '234.23', '-999.34'],
             'int64_as_strings': list(map(str, range(1, 4))),
             'strings_with_space': [' ', 'abab', 'ddeeffgg'],
+            'translate_from_strings': ['rmz', 'abc', 'ghj'],
+            'translate_to_strings': ['lns', 'ovk', 'jfr'],
             'int64_with_zeros': [0, 1, 0],
             'float64_with_zeros': [1.0, 0.0, 1.0],
             'float64_positive': [1.0, 2.0, 1.0],

--- a/ibis/backends/pandas/tests/execution/test_strings.py
+++ b/ibis/backends/pandas/tests/execution/test_strings.py
@@ -128,3 +128,38 @@ def test_string_ops(t, df, case_func, expected_func):
 def test_sql_like_to_regex(pattern, expected):
     result = sql_like_to_regex(pattern, escape='^')
     assert result == f'^{expected}$'
+
+
+@pytest.mark.parametrize(
+    ('from_func', 'to_func', 'from_str', 'to_str'),
+    [
+        param(
+            lambda s: s.translate_from_strings,
+            lambda s: s.translate_to_strings,
+            "rmzabcghj",
+            "lnsovkjfr",
+            id='from_series_to_series',
+        ),
+        param(
+            lambda s: "abc",
+            lambda s: s.translate_to_strings,
+            "abc",
+            "ovk",
+            id='from_string_to_series',
+        ),
+        param(
+            lambda s: s.translate_from_strings,
+            lambda s: "ovk",
+            "abcg",
+            "ovko",
+            id='from_series_to_string',
+        ),
+    ],
+)
+def test_translate(
+    t, df, from_func: callable, to_func: callable, from_str: str, to_str: str
+):
+    result = t.strings_with_space.translate(from_func(t), to_func(t)).execute()
+    table = str.maketrans(from_str, to_str)
+    series = df.strings_with_space.str.translate(table)
+    tm.assert_series_equal(result, series, check_names=False)


### PR DESCRIPTION
- use list comprehension in execute_substring_series_series, which is slightly faster and removes the use of the stateful function
- use str.contains in execute_string_like_series_string, which is supported by pandas
- remove the duplicated implementation of EndsWith and StartsWith
fixes #6157 