### PR TITLE
ci: bring back service spec to relevant backends

### DIFF
--- a/ci/schema/oracle/awards_players.ctl
+++ b/ci/schema/oracle/awards_players.ctl
@@ -1,6 +1,6 @@
 options (SKIP=1)
 load data
-  infile '/opt/oracle/csv/awards_players.csv'
+  infile '/opt/oracle/data/awards_players.csv'
   into table "awards_players"
   fields terminated by "," optionally enclosed by '"'
   TRAILING NULLCOLS

--- a/ci/schema/oracle/batting.ctl
+++ b/ci/schema/oracle/batting.ctl
@@ -1,6 +1,6 @@
 options (SKIP=1)
 load data
-  infile '/opt/oracle/csv/batting.csv'
+  infile '/opt/oracle/data/batting.csv'
   into table "batting"
   fields terminated by "," optionally enclosed by '"'
   TRAILING NULLCOLS

--- a/ci/schema/oracle/diamonds.ctl
+++ b/ci/schema/oracle/diamonds.ctl
@@ -1,6 +1,6 @@
 options (SKIP=1)
 load data
-  infile '/opt/oracle/csv/diamonds.csv'
+  infile '/opt/oracle/data/diamonds.csv'
   into table "diamonds"
   fields terminated by "," optionally enclosed by '"'
   ( "carat", "cut", "color", "clarity", "depth", "table", "price", "x", "y", "z" )

--- a/ci/schema/oracle/functional_alltypes.ctl
+++ b/ci/schema/oracle/functional_alltypes.ctl
@@ -1,6 +1,6 @@
 options (SKIP=1)
 load data
-  infile '/opt/oracle/csv/functional_alltypes.csv'
+  infile '/opt/oracle/data/functional_alltypes.csv'
   into table "functional_alltypes"
   fields terminated by "," optionally enclosed by '"'
   TRAILING NULLCOLS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,8 @@ services:
       - 3306:3306
     networks:
       - mysql
+    volumes:
+      - mysql:/data
   postgres:
     user: postgres
     environment:
@@ -136,7 +138,7 @@ services:
     networks:
       - postgres
     volumes:
-      - $PWD/ci/ibis-testing-data/csv:/data:ro
+      - postgres:/data
   mssql:
     image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
@@ -152,7 +154,7 @@ services:
     ports:
       - 1433:1433
     volumes:
-      - $PWD/ci/ibis-testing-data/csv:/data:ro
+      - mssql:/data
     networks:
       - mssql
   trino-postgres:
@@ -175,7 +177,7 @@ services:
     networks:
       - trino
     volumes:
-      - $PWD/ci/ibis-testing-data/csv:/data:ro
+      - trino-postgres:/data
   trino:
     depends_on:
       - trino-postgres
@@ -312,7 +314,7 @@ services:
     volumes:
       - druid:/opt/shared
       - middle_var:/opt/druid/var
-      - $PWD/ci/ibis-testing-data/parquet:/data:ro
+      - druid-data:/data
     depends_on:
       - druid-zookeeper
       - druid-postgres
@@ -380,8 +382,7 @@ services:
     networks:
       - oracle
     volumes:
-      - $PWD/ci/ibis-testing-data/csv:/opt/oracle/csv:ro
-      - $PWD/ci/schema/oracle:/opt/oracle/ctl:ro
+      - oracle:/opt/oracle/data
 
 networks:
   impala:
@@ -394,10 +395,17 @@ networks:
   oracle:
 
 volumes:
-  middle_var:
-  historical_var:
   broker_var:
   coordinator_var:
-  router_var:
-  clickhouse:
   druid:
+  historical_var:
+  middle_var:
+  router_var:
+  # test data volumes
+  clickhouse:
+  druid-data:
+  mssql:
+  mysql:
+  oracle:
+  postgres:
+  trino-postgres:

--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -41,7 +41,7 @@ class TestConf(UnorderedComparator, ServiceBackendTest, RoundHalfToEven):
         return ServiceSpec(
             name=cls.name(),
             data_volume="/var/lib/clickhouse/user_files/ibis",
-            files=list(data_dir.joinpath("parquet").glob("*.parquet")),
+            files=data_dir.joinpath("parquet").glob("*.parquet"),
         )
 
     @staticmethod

--- a/ibis/backends/druid/tests/conftest.py
+++ b/ibis/backends/druid/tests/conftest.py
@@ -13,7 +13,11 @@ import pytest
 from requests import Session
 
 import ibis
-from ibis.backends.tests.base import BackendTest, RoundHalfToEven
+from ibis.backends.tests.base import (
+    RoundHalfToEven,
+    ServiceBackendTest,
+    ServiceSpec,
+)
 
 DRUID_URL = os.environ.get(
     "DRUID_URL", "druid://localhost:8082/druid/v2/sql?header=true"
@@ -86,7 +90,7 @@ def run_query(session: Session, query: str) -> None:
         time.sleep(REQUEST_INTERVAL)
 
 
-class TestConf(BackendTest, RoundHalfToEven):
+class TestConf(ServiceBackendTest, RoundHalfToEven):
     # druid has the same rounding behavior as postgres
     check_dtype = False
     supports_window_operations = False
@@ -96,6 +100,14 @@ class TestConf(BackendTest, RoundHalfToEven):
     native_bool = True
     supports_structs = False
     supports_json = False  # it does, but we haven't implemented it
+
+    @classmethod
+    def service_spec(cls, data_dir: Path) -> ServiceSpec:
+        return ServiceSpec(
+            name="druid-middlemanager",
+            data_volume="/data",
+            files=data_dir.joinpath("parquet").glob("*.parquet"),
+        )
 
     @staticmethod
     def _load_data(data_dir: Path, script_dir: Path, **_: Any) -> None:

--- a/ibis/backends/mssql/tests/conftest.py
+++ b/ibis/backends/mssql/tests/conftest.py
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 
 import ibis
 from ibis.backends.conftest import init_database
-from ibis.backends.tests.base import BackendTest, RoundHalfToEven
+from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest, ServiceSpec
 
 MSSQL_USER = os.environ.get('IBIS_TEST_MSSQL_USER', 'sa')
 MSSQL_PASS = os.environ.get('IBIS_TEST_MSSQL_PASSWORD', '1bis_Testing!')
@@ -18,7 +18,7 @@ MSSQL_PORT = int(os.environ.get('IBIS_TEST_MSSQL_PORT', 1433))
 IBIS_TEST_MSSQL_DB = os.environ.get('IBIS_TEST_MSSQL_DATABASE', 'ibis_testing')
 
 
-class TestConf(BackendTest, RoundHalfToEven):
+class TestConf(ServiceBackendTest, RoundHalfToEven):
     # MSSQL has the same rounding behavior as postgres
     check_dtype = False
     supports_window_operations = False
@@ -28,6 +28,14 @@ class TestConf(BackendTest, RoundHalfToEven):
     supports_structs = False
     supports_arrays = False
     supports_json = False
+
+    @classmethod
+    def service_spec(cls, data_dir: Path) -> ServiceSpec:
+        return ServiceSpec(
+            name=cls.name(),
+            data_volume="/data",
+            files=data_dir.joinpath("csv").glob("*.csv"),
+        )
 
     @staticmethod
     def _load_data(

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -10,7 +10,7 @@ from packaging.version import parse as parse_version
 
 import ibis
 from ibis.backends.conftest import TEST_TABLES, init_database
-from ibis.backends.tests.base import BackendTest, RoundHalfToEven
+from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest, ServiceSpec
 
 MYSQL_USER = os.environ.get('IBIS_TEST_MYSQL_USER', 'ibis')
 MYSQL_PASS = os.environ.get('IBIS_TEST_MYSQL_PASSWORD', 'ibis')
@@ -19,7 +19,7 @@ MYSQL_PORT = int(os.environ.get('IBIS_TEST_MYSQL_PORT', 3306))
 IBIS_TEST_MYSQL_DB = os.environ.get('IBIS_TEST_MYSQL_DATABASE', 'ibis_testing')
 
 
-class TestConf(BackendTest, RoundHalfToEven):
+class TestConf(ServiceBackendTest, RoundHalfToEven):
     # mysql has the same rounding behavior as postgres
     check_dtype = False
     supports_window_operations = False
@@ -28,6 +28,14 @@ class TestConf(BackendTest, RoundHalfToEven):
     supports_arrays_outside_of_select = supports_arrays
     native_bool = False
     supports_structs = False
+
+    @classmethod
+    def service_spec(cls, data_dir: Path) -> ServiceSpec:
+        return ServiceSpec(
+            name=cls.name(),
+            data_volume="/data",
+            files=data_dir.joinpath("csv").glob("*.csv"),
+        )
 
     def __init__(self, data_directory: Path) -> None:
         super().__init__(data_directory)

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -22,7 +22,7 @@ import sqlalchemy as sa
 
 import ibis
 from ibis.backends.conftest import init_database
-from ibis.backends.tests.base import BackendTest, RoundHalfToEven
+from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest, ServiceSpec
 
 PG_USER = os.environ.get(
     'IBIS_TEST_POSTGRES_USER', os.environ.get('PGUSER', 'postgres')
@@ -39,12 +39,20 @@ IBIS_TEST_POSTGRES_DB = os.environ.get(
 )
 
 
-class TestConf(BackendTest, RoundHalfToEven):
+class TestConf(ServiceBackendTest, RoundHalfToEven):
     # postgres rounds half to even for double precision and half away from zero
     # for numeric and decimal
 
     returned_timestamp_unit = 's'
     supports_structs = False
+
+    @classmethod
+    def service_spec(cls, data_dir: Path) -> ServiceSpec:
+        return ServiceSpec(
+            name=cls.name(),
+            data_volume="/data",
+            files=data_dir.joinpath("csv").glob("*.csv"),
+        )
 
     @staticmethod
     def _load_data(

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -5,7 +5,7 @@ import concurrent.futures
 import inspect
 import subprocess
 from pathlib import Path
-from typing import Any, Mapping, NamedTuple
+from typing import Any, Iterable, Mapping, NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -225,7 +225,7 @@ class BackendTest(abc.ABC):
 class ServiceSpec(NamedTuple):
     name: str
     data_volume: str
-    files: list[Path]
+    files: Iterable[Path]
 
 
 class ServiceBackendTest(BackendTest):

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 
 import ibis
 from ibis.backends.conftest import TEST_TABLES
-from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
+from ibis.backends.tests.base import RoundAwayFromZero, ServiceBackendTest, ServiceSpec
 from ibis.backends.tests.data import struct_types
 from ibis.util import consume
 
@@ -32,13 +32,21 @@ IBIS_TEST_TRINO_DB = os.environ.get(
 sa = pytest.importorskip("sqlalchemy")
 
 
-class TestConf(BackendTest, RoundAwayFromZero):
+class TestConf(ServiceBackendTest, RoundAwayFromZero):
     # trino rounds half to even for double precision and half away from zero
     # for numeric and decimal
 
     returned_timestamp_unit = 's'
     supports_structs = True
     supports_map = True
+
+    @classmethod
+    def service_spec(cls, data_dir: Path) -> ServiceSpec:
+        return ServiceSpec(
+            name="trino-postgres",
+            data_volume="/data",
+            files=data_dir.joinpath("csv").glob("*.csv"),
+        )
 
     @staticmethod
     def _load_data(data_dir: Path, script_dir: Path, **_: Any) -> None:


### PR DESCRIPTION
Previously I changed our compose services to use a volume mount in an effort to simplify data loading.

While in some ways the result was simplier, data loading became more difficult to understand because a
`git clean -fdx` would remove the mounted files from the containers, and they would start to fail.

The `ServiceSpec` test functionality addresses this by copying the data files
into the running containers at test suite startup.

This has some overhead but not much (it's a local -> local filesystem copy),
and is robust to cleanup of untracked files in the repo.
