### PR TITLE
test(postgres): move special types to their own view

### DIFF
--- a/ci/schema/postgresql.sql
+++ b/ci/schema/postgresql.sql
@@ -57,14 +57,18 @@ CREATE TABLE awards_players (
     "yearID" BIGINT,
     "lgID" TEXT,
     tie TEXT,
-    notes TEXT,
-    search TSVECTOR GENERATED ALWAYS AS (
-      setweight(to_tsvector('simple', notes), 'A')::TSVECTOR
-    ) STORED,
-    simvec VECTOR GENERATED always AS ('[1,2,3]'::VECTOR) STORED
+    notes TEXT
 );
 
 COPY awards_players FROM '/data/awards_players.csv' WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',');
+
+DROP VIEW IF EXISTS awards_players_special_types CASCADE;
+CREATE VIEW awards_players_special_types AS
+SELECT
+    *,
+    setweight(to_tsvector('simple', notes), 'A')::TSVECTOR AS search,
+    '[1,2,3]'::VECTOR AS simvec
+FROM awards_players;
 
 DROP TABLE IF EXISTS functional_alltypes CASCADE;
 

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -211,5 +211,5 @@ def test_get_schema_from_query(con, pg_type, expected_type):
 
 @pytest.mark.parametrize("col", ["search", "simvec"])
 def test_unknown_column_type(con, col):
-    awards_players = con.table("awards_players")
+    awards_players = con.table("awards_players_special_types")
     assert awards_players[col].type().is_unknown()


### PR DESCRIPTION
This PR moves the two special types we test in postgres to their own view, to avoid polluting the `awards_players` table.