### PR TITLE
fix(sqlalchemy): ensure that union_all-generated memtables use the correct column names

### DIFF
--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -160,8 +160,8 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
             raw_rows = (
                 sa.select(
                     *(
-                        translator.translate(ops.Literal(val, dtype=type_))
-                        for val, type_ in zip(row, op.schema.types)
+                        translator.translate(ops.Literal(val, dtype=type_)).label(name)
+                        for val, (name, type_) in zip(row, op.schema.items())
                     )
                 )
                 for row in op.data.to_frame().itertuples(index=False)

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -713,3 +713,9 @@ def test_count_on_order_by(con, snapshot):
     expr = sorted_table.count()
     result = str(ibis.to_sql(expr, dialect="sqlite"))
     snapshot.assert_match(result, "out.sql")
+
+
+def test_memtable_compilation(con):
+    expr = ibis.memtable({"a": [1, 2, 3]})
+    t = con.compile(expr)
+    assert t.exported_columns[0].name == "a"


### PR DESCRIPTION
This PR fixes a small bug where the names of columns generated for a `union_all`-style memtable did not match the memtable schema.