### PR TITLE
feat(oracle): support temporary tables

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -154,7 +154,12 @@ def tmpcon(alchemy_con):
     return alchemy_con._from_url(alchemy_con.con.url)
 
 
-@mark.notimpl(["trino", "druid", "oracle"])
+@mark.notimpl(["trino", "druid"], reason="doesn't implement temporary tables")
+@mark.notimpl(
+    ["oracle"],
+    reason="temporary tables are tied to all existing sessions so reconnect doesn't trigger a cleanup",
+    raises=AssertionError,
+)
 @mark.notyet(
     ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
 )
@@ -1052,9 +1057,7 @@ def test_create_table_timestamp(con, temp_table):
     assert result == schema
 
 
-@mark.notimpl(
-    ["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid", "oracle"]
-)
+@mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
 @mark.notyet(
     ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
 )
@@ -1074,9 +1077,7 @@ def test_persist_expression_ref_count(con, alltypes):
     assert con._query_cache.refs[op] == 1
 
 
-@mark.notimpl(
-    ["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid", "oracle"]
-)
+@mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
 @mark.notyet(
     ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
 )
@@ -1090,9 +1091,7 @@ def test_persist_expression(alltypes):
     tm.assert_frame_equal(non_persisted_table.to_pandas(), persisted_table.to_pandas())
 
 
-@mark.notimpl(
-    ["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid", "oracle"]
-)
+@mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
 @mark.notyet(
     ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
 )
@@ -1108,9 +1107,7 @@ def test_persist_expression_contextmanager(alltypes):
         tm.assert_frame_equal(non_cached_table.to_pandas(), cached_table.to_pandas())
 
 
-@mark.notimpl(
-    ["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid", "oracle"]
-)
+@mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
 @mark.notyet(
     ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
 )
@@ -1129,9 +1126,7 @@ def test_persist_expression_contextmanager_ref_count(con, alltypes):
     assert con._query_cache.refs[op] == 0
 
 
-@mark.notimpl(
-    ["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid", "oracle"]
-)
+@mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
 @mark.notyet(
     ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
 )
@@ -1167,9 +1162,7 @@ def test_persist_expression_multiple_refs(con, alltypes):
     assert name2 not in con.list_tables()
 
 
-@mark.notimpl(
-    ["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid", "oracle"]
-)
+@mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
 @mark.notyet(
     ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
 )
@@ -1186,9 +1179,7 @@ def test_persist_expression_repeated_cache(alltypes):
             assert not nested_cached_table.to_pandas().empty
 
 
-@mark.notimpl(
-    ["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid", "oracle"]
-)
+@mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
 @mark.notyet(
     ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
 )


### PR DESCRIPTION
This PR adds support for temporary tables to the oracle backend.

The implementation uses Oracle's [`GLOBAL TEMPORARY`] tables because they have
fewer restrictions than and work with many older versions of oracle than
private temporary tables.

For example, private temporary tables cannot hold `CLOB` or `BLOB` columns.

Unfortunately that means they come with some caveats that require some annoying hacks.

* Global temporary tables cannot be `DROP`ed with first `TRUNCATE`ing them. Oracle documentts this as

> A session becomes unbound to a temporary table with a TRUNCATE statement or at session termination...

* Global temporary tables' **data** are removed when a session ends, but the
  table's definition (its name and schema) are still visible to all users. I'm
  using `atexit` to handle this, but it's not ideal. I looked into using some
  of the SQLAlchemy pool events (`close`, `reset`, `invalidate`, and
  `soft_invalidate`) but none of them seemed to fire in concert with a session
  ending.
