### PR TITLE
fix(common): fix bug in re_extract

### DIFF
--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_column_regexp_extract/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_column_regexp_extract/out.sql
@@ -1,1 +1,1 @@
-if(multiMatchAny(CAST(string_col AS String), ['[\\d]+']), if(CAST(nullIf(3, 0) AS Nullable(Int64)) IS NULL, CAST(string_col AS String), CAST(extractAll(CAST(string_col AS String), '[\\d]+') AS Array(Nullable(String)))[CAST(nullIf(3, 0) AS Nullable(Int64))]), NULL)
+if(notEmpty(extractGroups(CAST(string_col AS String), '([\\d]+)')[3 + 1]), extractGroups(CAST(string_col AS String), '([\\d]+)')[3 + 1], NULL)

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -153,20 +153,13 @@ def _neg_idx_to_pos(array, idx):
 
 
 def _regex_extract(string, pattern, index):
-    result = sa.case(
-        (
-            sa.func.regexp_matches(string, pattern),
-            sa.func.regexp_extract(
-                string,
-                pattern,
-                # DuckDB requires the index to be a constant so we compile
-                # the value and inline it using sa.text
-                sa.text(str(index.compile(compile_kwargs=dict(literal_binds=True)))),
-            ),
-        ),
-        else_="",
+    return sa.func.regexp_extract(
+        string,
+        pattern,
+        # DuckDB requires the index to be a constant, so we compile
+        # the value and inline it by using sa.text
+        sa.text(str(index.compile(compile_kwargs=dict(literal_binds=True)))),
     )
-    return result
 
 
 def _json_get_item(left, path):

--- a/ibis/backends/pandas/execution/strings.py
+++ b/ibis/backends/pandas/execution/strings.py
@@ -277,15 +277,14 @@ def execute_series_ends_with(op, data, pattern, **kwargs):
 @execute_node.register(ops.RegexExtract, pd.Series, str, integer_types)
 def execute_series_regex_extract(op, data, pattern, index, **kwargs):
     pattern = re.compile(pattern)
-
-    def extract(x, pattern=pattern, index=index):
-        match = pattern.match(x)
-        if match is not None:
-            return match.group(index) or np.nan
-        return np.nan
-
-    extracted = data.apply(extract)
-    return extracted
+    return pd.Series(
+        [
+            None if (match is None or index > match.lastindex) else match[index]
+            for match in map(pattern.search, data)
+        ],
+        dtype=data.dtype,
+        name=data.name,
+    )
 
 
 @execute_node.register(ops.RegexExtract, SeriesGroupBy, str, integer_types)

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -211,9 +211,21 @@ def test_string_col_is_unicode(alltypes, df):
             ],
         ),
         param(
-            lambda t: t.string_col.re_extract(r'(\d+)', 1),
+            lambda t: ("xyz" + t.string_col + "abcd").re_extract(r'(\d+)', 0),
             lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
             id='re_extract',
+            marks=[
+                pytest.mark.notimpl(
+                    ["mssql", "druid", "oracle"],
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.broken(["impala"], raises=AssertionError),
+            ],
+        ),
+        param(
+            lambda t: ("xyz" + t.string_col + "abcd").re_extract(r'(\d+)abc', 1),
+            lambda t: t.string_col.str.extract(r'(\d+)', expand=False),
+            id='re_extract_group',
             marks=[
                 pytest.mark.notimpl(
                     ["mssql", "druid", "oracle"],
@@ -283,9 +295,7 @@ def test_string_col_is_unicode(alltypes, df):
                     ["mssql", "druid", "oracle"],
                     raises=com.OperationNotDefinedError,
                 ),
-                pytest.mark.broken(
-                    ["impala", "clickhouse", "snowflake"], raises=AssertionError
-                ),
+                pytest.mark.broken(["impala", "snowflake"], raises=AssertionError),
                 pytest.mark.notyet(["bigquery"], raises=BadRequest),
             ],
         ),
@@ -300,9 +310,7 @@ def test_string_col_is_unicode(alltypes, df):
                     ["mssql", "druid", "oracle"],
                     raises=com.OperationNotDefinedError,
                 ),
-                pytest.mark.broken(
-                    ["impala", "clickhouse", "snowflake"], raises=AssertionError
-                ),
+                pytest.mark.broken(["impala", "snowflake"], raises=AssertionError),
                 pytest.mark.notyet(["bigquery"], raises=BadRequest),
             ],
         ),
@@ -327,7 +335,7 @@ def test_string_col_is_unicode(alltypes, df):
                     ["mssql", "druid", "oracle"],
                     raises=com.OperationNotDefinedError,
                 ),
-                pytest.mark.broken(["impala", "dask", "pandas"], raises=AssertionError),
+                pytest.mark.broken(["impala"], raises=AssertionError),
             ],
         ),
         param(

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -1030,13 +1030,13 @@ class StringValue(Value):
         Parameters
         ----------
         pattern
-            Reguar expression pattern string
+            Regular expression pattern string
         index
             The index of the match group to return.
 
             The behavior of this function follows the behavior of Python's
-            [`re.match`](https://docs.python.org/3/library/re.html#match-objects):
-            when `index` is zero and there's a match, return the entire string,
+            [`match objects`](https://docs.python.org/3/library/re.html#match-objects):
+            when `index` is zero and there's a match, return the entire match,
             otherwise return the content of the `index`-th match group.
 
         Returns


### PR DESCRIPTION
### Background
The current definition of `re_extract` needs to be clarified. The documentation
claims that it works as `re.match`, but it works differently:

> when index is zero and there's a match, return the entire string, otherwise
> return the content of the index-th match group.

A Python's Match Object returns the entire **match**, not the entire **string**, from the [documentation](https://docs.python.org/3/library/re.html#re.Match.group) (**emphasis mine**):

> Without arguments, group1 defaults to zero (the whole match is returned). If a groupN argument is zero, the corresponding return value is the entire **matching string**;

 
For example:

```python
>>> import re
>>> pattern = re.compile("a(bc)d")
>>> match = pattern.match("abcd foo bar")
>>> match.group(0)
Out[5]: 'abcd'
>>> match.group(1)
Out[6]: 'bc'
```

### Implementation
This PR updates the documentation and the implementation of some of the backends
to actually work as a Match Object, note that some backends were already
returning the whole match, not the whole string: pandas, sqlite, duckdb, postgres.

1. pandas: use `re.search` instead of `re.match` to match anywhere on the string (`re.match` only works at the beginning)
2. clickhouse: use the [regexpExtract](https://clickhouse.com/docs/en/sql-reference/functions/string-search-functions#regexpextract) method that offers the expected functionality
3. bigquery: the index parameter makes no sense because it returns either the whole match or the first capturing group that matches.

fixes #6167 
