### PR TITLE
fix(mysql): fix binary literals

### DIFF
--- a/ibis/backends/mysql/registry.py
+++ b/ibis/backends/mysql/registry.py
@@ -93,6 +93,12 @@ def _literal(_, op):
         return sa_text.bindparams(value=op.value)
     elif op.output_dtype.is_set():
         return list(map(sa.literal, op.value))
+    elif op.output_dtype.is_binary():
+        # the cast to BINARY is necessary here, otherwise the data come back as
+        # Python strings
+        #
+        # This lets the database handle encoding rather than ibis
+        return sa.cast(sa.literal(op.value), type_=sa.BINARY())
     else:
         value = op.value
         with contextlib.suppress(AttributeError):

--- a/ibis/backends/tests/test_binary.py
+++ b/ibis/backends/tests/test_binary.py
@@ -29,7 +29,6 @@ pytestmark = pytest.mark.broken(["druid"], raises=AssertionError)
     "Unsupported type: Binary(nullable=True)",
     raises=NotImplementedError,
 )
-@pytest.mark.broken(['mysql'], "string argument without an encoding", raises=TypeError)
 def test_binary_literal(con, backend):
     expr = ibis.literal(b"A")
     result = con.execute(expr)


### PR DESCRIPTION
Fixes binary literals for the MySQL backend. Discovered in #6179. Split out here for ease of review.