### PR TITLE
fix(core): interval resolution should upcast to smallest unit

### DIFF
--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -831,6 +831,38 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
             ],
         ),
         param(
+            lambda t, _: t.timestamp_col
+            + (ibis.interval(days=4) + ibis.interval(hours=2)),
+            lambda t, _: t.timestamp_col
+            + (pd.Timedelta(days=4) + pd.Timedelta(hours=2)),
+            id='timestamp-add-interval-binop-different-units',
+            marks=[
+                pytest.mark.notimpl(
+                    [
+                        "clickhouse",
+                        "sqlite",
+                        "postgres",
+                        "polars",
+                        "mysql",
+                        "impala",
+                        "snowflake",
+                    ],
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notimpl(
+                    [
+                        "bigquery",
+                    ],
+                    raises=com.UnsupportedOperationError,
+                ),
+                pytest.mark.notimpl(
+                    ["druid"],
+                    raises=com.IbisTypeError,
+                    reason="Given argument with datatype interval(<IntervalUnit.HOUR: 'h'>) is not implicitly castable to string",
+                ),
+            ],
+        ),
+        param(
             lambda t, _: t.timestamp_col - ibis.interval(days=17),
             lambda t, _: t.timestamp_col - pd.Timedelta(days=17),
             id='timestamp-subtract-interval',

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -301,9 +301,17 @@ class IntervalBinary(Binary):
             else arg
             for arg in (self.left, self.right)
         ]
-        value_dtype = rlz._promote_integral_binop(integer_args, self.op)
 
-        return self.left.output_dtype.copy(value_type=value_dtype)
+        interval_unit_args = [
+            arg.output_dtype.unit
+            for arg in (self.left, self.right)
+            if arg.output_dtype.is_interval()
+        ]
+
+        value_dtype = rlz._promote_integral_binop(integer_args, self.op)
+        unit = rlz._promote_interval_resolution(interval_unit_args)
+
+        return self.left.output_dtype.copy(value_type=value_dtype, unit=unit)
 
 
 @public

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -12,6 +12,7 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common.annotations import attribute, optional
+from ibis.common.enums import IntervalUnit
 from ibis.common.validators import (
     bool_,
     callable_with,  # noqa: F401
@@ -429,6 +430,14 @@ def numeric_like(name, op):
         return result
 
     return output_dtype
+
+
+def _promote_interval_resolution(units: list[IntervalUnit]) -> IntervalUnit:
+    # Find the smallest unit present in units
+    for unit in reversed(IntervalUnit):
+        if unit in units:
+            return unit
+    raise AssertionError('unreachable')
 
 
 # TODO(kszucs): it could be as simple as rlz.instance_of(ops.TableNode)

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -144,27 +144,47 @@ def test_multiply(expr):
 
 
 @pytest.mark.parametrize(
-    'expr',
+    ('expr', 'expected_unit'),
     [
-        api.interval(days=1) + api.interval(days=1),
-        api.interval(days=2) + api.interval(hours=4),
+        (
+            api.interval(days=1) + api.interval(days=1),
+            IntervalUnit('D'),
+        ),
+        (
+            api.interval(days=2) + api.interval(hours=4),
+            IntervalUnit('h'),
+        ),
+        (
+            api.interval(seconds=1) + ibis.interval(minutes=2),
+            IntervalUnit('s'),
+        ),
     ],
 )
-def test_add(expr):
+def test_add(expr, expected_unit):
     assert isinstance(expr, ir.IntervalScalar)
-    assert expr.type().unit == IntervalUnit('D')
+    assert expr.type().unit == expected_unit
 
 
 @pytest.mark.parametrize(
-    'expr',
+    ('expr', 'expected_unit'),
     [
-        api.interval(days=3) - api.interval(days=1),
-        api.interval(days=2) - api.interval(hours=4),
+        (
+            api.interval(days=3) - api.interval(days=1),
+            IntervalUnit('D'),
+        ),
+        (
+            api.interval(days=2) - api.interval(hours=4),
+            IntervalUnit('h'),
+        ),
+        (
+            api.interval(minutes=2) - api.interval(seconds=1),
+            IntervalUnit('s'),
+        ),
     ],
 )
-def test_subtract(expr):
+def test_subtract(expr, expected_unit):
     assert isinstance(expr, ir.IntervalScalar)
-    assert expr.type().unit == IntervalUnit('D')
+    assert expr.type().unit == expected_unit
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Inspired by pandas [resolution_string](https://github.com/pandas-dev/pandas/blob/e19ceb76a4c5903469fea93040c174633c84b9b9/pandas/_libs/tslibs/timedeltas.pyx#L1383)

fixes #6139