### PR TITLE
refactor(datatypes): remove `Set()` in favor of `Array()` datatype

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -223,9 +223,7 @@ def _literal(_, op):
     if value is None:
         return sa.null()
 
-    if dtype.is_set():
-        return list(map(sa.literal, value))
-    elif dtype.is_array():
+    if dtype.is_array():
         value = list(value)
 
     return sa.literal(value)

--- a/ibis/backends/base/sql/registry/literal.py
+++ b/ibis/backends/base/sql/registry/literal.py
@@ -91,8 +91,6 @@ def literal(translator, op):
         typeclass = 'timestamp'
     elif dtype.is_interval():
         typeclass = 'interval'
-    elif dtype.is_set():
-        typeclass = 'set'
     else:
         raise NotImplementedError(f'Unsupported type: {dtype!r}')
 

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -488,9 +488,6 @@ def _literal(op, **kw):
     elif isinstance(op.output_dtype, dt.Map):
         values = ", ".join(_map_literal_values(op))
         return f"map({values})"
-    elif isinstance(op.output_dtype, dt.Set):
-        args = ", ".join(map(repr, value))
-        return f"({args})"
     elif isinstance(op.output_dtype, dt.Struct):
         fields = ", ".join(f"{value} as `{key}`" for key, value in op.value.items())
         return f"tuple({fields})"

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -114,7 +114,7 @@ def _literal(t, op):
 
     if dtype.is_interval():
         return sa.literal_column(f"INTERVAL '{value} {dtype.resolution}'")
-    elif dtype.is_set() or dtype.is_array():
+    elif dtype.is_array():
         values = value.tolist() if isinstance(value, np.ndarray) else value
         return sa.cast(sa.func.list_value(*values), sqla_type)
     elif dtype.is_floating():

--- a/ibis/backends/mysql/datatypes.py
+++ b/ibis/backends/mysql/datatypes.py
@@ -54,7 +54,7 @@ def _type_from_cursor_info(descr, field) -> dt.DataType:
             raise AssertionError('invalid field length for BIT type')
     elif flags.is_set:
         # sets are limited to strings
-        typ = dt.Set(dt.string)
+        typ = dt.Array(dt.string)
     elif flags.is_unsigned and flags.is_num:
         typ = getattr(dt, f"U{typ.__name__}")
     elif type_code in TEXT_TYPES:
@@ -125,7 +125,7 @@ _type_mapping = {
     "JSON": dt.JSON,
     "NEWDECIMAL": dt.Decimal,
     "ENUM": dt.String,
-    "SET": lambda nullable: dt.Set(dt.string, nullable=nullable),
+    "SET": lambda nullable: dt.Array(dt.string, nullable=nullable),
     "TINY_BLOB": dt.Binary,
     "MEDIUM_BLOB": dt.Binary,
     "LONG_BLOB": dt.Binary,
@@ -209,7 +209,7 @@ def sa_mysql_datetime(_, satype, nullable=True):
 
 @dt.dtype.register(MySQLDialect, mysql.SET)
 def sa_mysql_set(_, satype, nullable=True):
-    return dt.Set(dt.string, nullable=nullable)
+    return dt.Array(dt.string, nullable=nullable)
 
 
 @dt.dtype.register(MySQLDialect, mysql.DOUBLE)

--- a/ibis/backends/mysql/registry.py
+++ b/ibis/backends/mysql/registry.py
@@ -91,8 +91,6 @@ def _literal(_, op):
         text_unit = op.output_dtype.resolution.upper()
         sa_text = sa.text(f'INTERVAL :value {text_unit}')
         return sa_text.bindparams(value=op.value)
-    elif op.output_dtype.is_set():
-        return list(map(sa.literal, op.value))
     elif op.output_dtype.is_binary():
         # the cast to BINARY is necessary here, otherwise the data come back as
         # Python strings

--- a/ibis/backends/mysql/tests/test_client.py
+++ b/ibis/backends/mysql/tests/test_client.py
@@ -47,7 +47,7 @@ MYSQL_TYPES = [
     ("json", dt.string),
     ("enum('small', 'medium', 'large')", dt.string),
     ("inet6", dt.string),
-    ("set('a', 'b', 'c', 'd')", dt.Set(dt.string)),
+    ("set('a', 'b', 'c', 'd')", dt.Array(dt.string)),
     ("mediumblob", dt.binary),
     ("blob", dt.binary),
     ("uuid", dt.string),

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -387,8 +387,6 @@ def _literal(t, op):
 
     if dtype.is_interval():
         return sa.literal_column(f"INTERVAL '{value} {dtype.resolution}'")
-    elif dtype.is_set():
-        return list(map(sa.literal, value))
     elif dtype.is_geospatial():
         # inline_metadata ex: 'SRID=4326;POINT( ... )'
         return sa.literal_column(geo.translate_literal(op, inline_metadata=True))

--- a/ibis/backends/pyarrow/datatypes.py
+++ b/ibis/backends/pyarrow/datatypes.py
@@ -44,8 +44,7 @@ def to_pyarrow_type(dtype: dt.DataType) -> pa.DataType:
 
 
 @to_pyarrow_type.register(dt.Array)
-@to_pyarrow_type.register(dt.Set)
-def from_ibis_collection(dtype: dt.Array | dt.Set) -> pa.ListType:
+def from_ibis_collection(dtype: dt.Array) -> pa.ListType:
     return pa.list_(to_pyarrow_type(dtype.value_type))
 
 

--- a/ibis/expr/datatypes/cast.py
+++ b/ibis/expr/datatypes/cast.py
@@ -178,10 +178,7 @@ def can_cast_struct(source, target, **kwargs):
 
 
 @castable.register(dt.Array, dt.Array)
-@castable.register(dt.Set, dt.Set)
-def can_cast_array_or_set(
-    source: dt.Array | dt.Set, target: dt.Array | dt.Set, **kwargs
-) -> bool:
+def can_cast_array_or_set(source: dt.Array, target: dt.Array, **kwargs) -> bool:
     return castable(source.value_type, target.value_type)
 
 
@@ -204,18 +201,11 @@ def can_cast_special_string(source, target, **kwargs):
     return True
 
 
-@dt.dtype.register(list)
+@dt.dtype.register((list, collections.abc.Set))
 def from_list(values: list[Any]) -> dt.Array:
     if not values:
         return dt.Array(dt.null)
     return dt.Array(highest_precedence(map(dt.dtype, values)))
-
-
-@dt.dtype.register(collections.abc.Set)
-def from_set(values: collections.abc.Set) -> dt.Set:
-    if not values:
-        return dt.Set(dt.null)
-    return dt.Set(highest_precedence(map(dt.dtype, values)))
 
 
 public(castable=castable)

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -6,7 +6,6 @@ import numbers
 import uuid as pyuuid
 from abc import abstractmethod
 from collections.abc import Iterator, Mapping, Sequence
-from collections.abc import Set as PySet
 from numbers import Integral, Real
 from typing import Any, Iterable, Literal, NamedTuple, Optional
 
@@ -69,9 +68,6 @@ def dtype_from_object(value, **kwargs) -> DataType:
     elif issubclass(origin_type, Mapping):
         key_type, value_type = map(dtype, get_args(value))
         return Map(key_type, value_type)
-    elif issubclass(origin_type, PySet):
-        (value_type,) = map(dtype, get_args(value))
-        return Set(value_type)
     else:
         raise TypeError(f'Value {value!r} is not a valid datatype')
 
@@ -214,7 +210,7 @@ class DataType(Concrete, Coercible):
         return isinstance(self, MultiPolygon)
 
     def is_nested(self) -> bool:
-        return isinstance(self, (Array, Map, Struct, Set))
+        return isinstance(self, (Array, Map, Struct))
 
     def is_null(self) -> bool:
         return isinstance(self, Null)
@@ -230,9 +226,6 @@ class DataType(Concrete, Coercible):
 
     def is_primitive(self) -> bool:
         return isinstance(self, Primitive)
-
-    def is_set(self) -> bool:
-        return isinstance(self, Set)
 
     def is_signed_integer(self) -> bool:
         return isinstance(self, SignedInteger)
@@ -721,20 +714,6 @@ class Array(Variadic, Parametric):
 
 
 @public
-class Set(Variadic, Parametric):
-    """Set values."""
-
-    value_type: DataType
-
-    scalar = "SetScalar"
-    column = "SetColumn"
-
-    @property
-    def _pretty_piece(self) -> str:
-        return f"<{self.value_type}>"
-
-
-@public
 class Map(Variadic, Parametric):
     """Associative array values."""
 
@@ -999,4 +978,5 @@ public(
     Enum=Enum,
     Geography=GeoSpatial,
     Geometry=GeoSpatial,
+    Set=Array,
 )

--- a/ibis/expr/datatypes/parse.py
+++ b/ibis/expr/datatypes/parse.py
@@ -153,7 +153,6 @@ def parse(
     )
 
     array = spaceless_string("array").then(angle_type).map(dt.Array)
-    set = spaceless_string("set").then(angle_type).map(dt.Set)
 
     map = (
         spaceless_string("map")
@@ -181,7 +180,6 @@ def parse(
         | varchar_or_char
         | interval
         | array
-        | set
         | map
         | struct
         | spaceless_string("json", "uuid", "macaddr", "inet").map(

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -5,7 +5,7 @@ import decimal
 import sys
 import uuid
 from dataclasses import dataclass
-from typing import Dict, List, NamedTuple, Set, Tuple
+from typing import Dict, List, NamedTuple, Tuple
 
 import pytest
 
@@ -26,10 +26,8 @@ def test_validate_type():
             'map<int64, array<map<string, int8>>>',
             dt.Map(dt.int64, dt.Array(dt.Map(dt.string, dt.int8))),
         ),
-        ('set<uint8>', dt.Set(dt.uint8)),
         ([dt.uint8], dt.Array(dt.uint8)),
         ([dt.float32, dt.float64], dt.Array(dt.float64)),
-        ({dt.string}, dt.Set(dt.string)),
     ]
     + [
         (f"{cls.__name__.lower()}{suffix}", expected)
@@ -104,7 +102,6 @@ class FooStruct:
     qa: dt.Decimal(12, 2)
     r: dt.Array(dt.int16)
     s: dt.Map(dt.string, dt.int16)
-    t: dt.Set(dt.int16)
 
 
 class BarStruct:
@@ -132,7 +129,6 @@ class BarStruct:
     qa: dt.Decimal[12, 2]
     r: dt.Array[dt.Int16]
     s: dt.Map[dt.String, dt.Int16]
-    t: dt.Set[dt.Int16]
 
 
 baz_struct = dt.Struct(
@@ -161,7 +157,6 @@ baz_struct = dt.Struct(
         'qa': dt.Decimal(12, 2),
         'r': dt.Array(dt.int16),
         's': dt.Map(dt.string, dt.int16),
-        't': dt.Set(dt.int16),
     }
 )
 
@@ -190,10 +185,6 @@ class MyTuple(list):
     pass
 
 
-class MySet(set):
-    pass
-
-
 class MyDict(dict):
     pass
 
@@ -219,7 +210,6 @@ class PyStruct:
     j: decimal.Decimal
     k: List[int]  # noqa: UP006
     l: Dict[str, int]  # noqa: UP006, E741
-    m: Set[int]  # noqa: UP006
     n: Tuple[str]  # noqa: UP006
     o: uuid.UUID
     p: type(None)
@@ -231,8 +221,6 @@ class PyStruct2:
     kb: MyList[int]
     la: dict[str, int]
     lb: MyDict[str, int]
-    ma: set[int]
-    mb: MySet[int]
     na: tuple[str]
     nb: MyTuple[str]
 
@@ -253,7 +241,6 @@ py_struct = dt.Struct(
         'j': dt.decimal,
         'k': dt.Array(dt.int64),
         'l': dt.Map(dt.string, dt.int64),
-        'm': dt.Set(dt.int64),
         'n': dt.Array(dt.string),
         'o': dt.UUID,
         'p': dt.null,
@@ -272,8 +259,6 @@ py_struct_2 = dt.Struct(
         'kb': dt.Array(dt.int64),
         'la': dt.Map(dt.string, dt.int64),
         'lb': dt.Map(dt.string, dt.int64),
-        'ma': dt.Set(dt.int64),
-        'mb': dt.Set(dt.int64),
         'na': dt.Array(dt.string),
         'nb': dt.Array(dt.string),
     }
@@ -298,7 +283,6 @@ class FooDataClass:
     [
         (dt.Interval, dt.Interval()),
         (dt.Array[dt.Null], dt.Array(dt.Null())),
-        (dt.Set[dt.Null], dt.Set(dt.Null())),
         (dt.Map[dt.Null, dt.Null], dt.Map(dt.Null(), dt.Null())),
         (dt.Timestamp['UTC'], dt.Timestamp(timezone='UTC')),
         (dt.Timestamp['UTC', 6], dt.Timestamp(timezone='UTC', scale=6)),
@@ -536,7 +520,6 @@ def get_leaf_classes(op):
         dt.Map,
         dt.Numeric,
         dt.Primitive,
-        dt.Set,
         dt.SignedInteger,
         dt.Struct,
         dt.Temporal,
@@ -610,3 +593,7 @@ def test_is_temporal():
     assert dt.date.is_temporal()
     assert dt.timestamp.is_temporal()
     assert not dt.Array(dt.Map(dt.string, dt.string)).is_temporal()
+
+
+def test_set_is_an_alias_of_array():
+    assert dt.Set is dt.Array

--- a/ibis/expr/datatypes/tests/test_value.py
+++ b/ibis/expr/datatypes/tests/test_value.py
@@ -50,9 +50,9 @@ class Foo(enum.Enum):
         (decimal.Decimal(1.5), dt.decimal),
         # parametric types
         (list('abc'), dt.Array(dt.string)),
-        (set('abc'), dt.Set(dt.string)),
-        ({1, 5, 5, 6}, dt.Set(dt.int8)),
-        (frozenset(list('abc')), dt.Set(dt.string)),
+        (set('abc'), dt.Array(dt.string)),
+        ({1, 5, 5, 6}, dt.Array(dt.int8)),
+        (frozenset(list('abc')), dt.Array(dt.string)),
         ([1, 2, 3], dt.Array(dt.int8)),
         ([1, 128], dt.Array(dt.int16)),
         ([1, 128, 32768], dt.Array(dt.int32)),

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -57,20 +57,12 @@ def infer_map(value: Mapping[Any, Any]) -> dt.Map:
         return dt.Struct(toolz.valmap(infer, value, factory=type(value)))
 
 
-@infer.register((list, tuple))
+@infer.register((list, tuple, set, frozenset))
 def infer_list(values: Sequence[Any]) -> dt.Array:
     """Infer the [`Array`][ibis.expr.datatypes.Array] type of `value`."""
     if not values:
         return dt.Array(dt.null)
     return dt.Array(highest_precedence(map(infer, values)))
-
-
-@infer.register((set, frozenset))
-def infer_set(values: set) -> dt.Set:
-    """Infer the [`Set`][ibis.expr.datatypes.Set] type of `value`."""
-    if not values:
-        return dt.Set(dt.null)
-    return dt.Set(highest_precedence(map(infer, values)))
 
 
 @infer.register(datetime.time)
@@ -289,8 +281,6 @@ def normalize(typ, value):
         return value if isinstance(value, uuid.UUID) else uuid.UUID(value)
     elif typ.is_array():
         return tuple(normalize(typ.value_type, item) for item in value)
-    elif typ.is_set():
-        return frozenset(normalize(typ.value_type, item) for item in value)
     elif typ.is_map():
         return frozendict({k: normalize(typ.value_type, v) for k, v in value.items()})
     elif typ.is_struct():

--- a/ibis/expr/operations/logical.py
+++ b/ibis/expr/operations/logical.py
@@ -136,7 +136,6 @@ class Contains(Value):
             rlz.tuple_of(rlz.any),
             rlz.column(rlz.any),
             rlz.array,
-            rlz.set_,
         ]
     )
 

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -296,7 +296,6 @@ strict_numeric = one_of([integer, floating, decimal])
 soft_numeric = one_of([integer, floating, decimal, boolean])
 numeric = soft_numeric
 
-set_ = value(dt.Set)
 array = value(dt.Array)
 struct = value(dt.Struct)
 mapping = value(dt.Map)
@@ -559,7 +558,6 @@ public(
     point=point,
     polygon=polygon,
     ref=ref,
-    set_=set_,
     soft_numeric=soft_numeric,
     str_=str_,
     strict_numeric=strict_numeric,

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -978,7 +978,7 @@ def test_scalar_parameter_set():
     value = ibis.param({dt.int64})
 
     assert isinstance(value.op(), ops.ScalarParameter)
-    assert value.type().equals(dt.Set(dt.int64))
+    assert value.type().equals(dt.Array(dt.int64))
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -78,10 +78,6 @@ def array_dtypes(item_strategy=primitive_dtypes):
     return st.builds(dt.Array, value_type=item_strategy, nullable=nullable)
 
 
-def set_dtypes(item_strategy=primitive_dtypes):
-    return st.builds(dt.Set, value_type=item_strategy, nullable=nullable)
-
-
 def map_dtypes(key_strategy=primitive_dtypes, value_strategy=primitive_dtypes):
     return st.builds(
         dt.Map, key_type=key_strategy, value_type=value_strategy, nullable=nullable
@@ -138,7 +134,6 @@ variadic_dtypes = st.one_of(
     inet_dtype,
     macaddr_dtype,
     array_dtypes(),
-    set_dtypes(),
     map_dtypes(),
 )
 
@@ -151,7 +146,6 @@ all_dtypes = st.deferred(
         | variadic_dtypes
         | struct_dtypes()
         | array_dtypes(all_dtypes)
-        | set_dtypes(all_dtypes)
         | map_dtypes(all_dtypes, all_dtypes)
         | struct_dtypes(all_dtypes)
     )

--- a/ibis/tests/test_strategies.py
+++ b/ibis/tests/test_strategies.py
@@ -83,20 +83,6 @@ def test_array_array_dtype(dtype):
     assert isinstance(dtype.value_type.value_type, dt.Primitive)
 
 
-@h.given(its.set_dtypes(its.primitive_dtypes))
-def test_set_dtype(dtype):
-    assert isinstance(dtype, dt.Set)
-    assert isinstance(dtype.value_type, dt.Primitive)
-    assert dtype.is_set() is True
-
-
-@h.given(its.set_dtypes(its.array_dtypes(its.numeric_dtypes)))
-def test_set_array_dtype(dtype):
-    assert isinstance(dtype, dt.Set)
-    assert isinstance(dtype.value_type, dt.Array)
-    assert isinstance(dtype.value_type.value_type, dt.Numeric)
-
-
 @h.given(its.map_dtypes(its.primitive_dtypes, its.boolean_dtype))
 def test_map_dtype(dtype):
     assert isinstance(dtype, dt.Map)


### PR DESCRIPTION
BREAKING CHANGE: `dt.Set` is now an alias for `dt.Array`
