### PR TITLE
fix(trino): ensure that nested array types are inferred correctly

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -186,7 +186,7 @@ unnest = toolz.compose(
 
 @builtin_array
 @pytest.mark.never(
-    ["clickhouse", "duckdb", "pandas", "pyspark", "snowflake", "polars"],
+    ["clickhouse", "duckdb", "pandas", "pyspark", "snowflake", "polars", "trino"],
     reason="backend does not flatten array types",
     raises=AssertionError,
 )
@@ -253,11 +253,6 @@ def test_array_discovery_clickhouse(backend):
 @pytest.mark.notyet(
     ["clickhouse", "postgres"],
     reason="backend does not support nullable nested types",
-    raises=AssertionError,
-)
-@pytest.mark.notimpl(
-    ["trino"],
-    reason="trino supports nested arrays, but not with the postgres connector",
     raises=AssertionError,
 )
 @pytest.mark.never(

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -12,6 +12,7 @@ from trino.sqlalchemy.datatype import ROW as _ROW
 import ibis.expr.datatypes as dt
 from ibis import util
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
+from ibis.backends.base.sql.alchemy.datatypes import ArrayType
 from ibis.backends.trino.compiler import TrinoSQLCompiler
 from ibis.backends.trino.datatypes import ROW, parse
 
@@ -85,6 +86,10 @@ class Backend(BaseAlchemyBackend):
         def column_reflect(inspector, table, column_info):
             if isinstance(typ := column_info["type"], _ROW):
                 column_info["type"] = ROW(typ.attr_types)
+            elif isinstance(typ, sa.ARRAY):
+                column_info["type"] = toolz.nth(
+                    typ.dimensions or 1, toolz.iterate(ArrayType, typ.item_type)
+                )
 
         return meta
 


### PR DESCRIPTION
Fixes an issue with trino array types where we were not inferring the number of dimensions