### PR TITLE
feat(api): add array zip method and implementations

### DIFF
--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -24,6 +24,17 @@ class ArrayType(sat.UserDefinedType):
     def __init__(self, value_type: sat.TypeEngine):
         self.value_type = sat.to_instance(value_type)
 
+    def result_processor(self, dialect, coltype) -> None:
+        if not coltype.lower().startswith("array"):
+            return None
+
+        inner_processor = (
+            self.value_type.result_processor(dialect, coltype[len("array(") : -1])
+            or toolz.identity
+        )
+
+        return lambda v: v if v is None else list(map(inner_processor, v))
+
 
 @compiles(ArrayType, "default")
 def compiles_array(element, compiler, **kw):

--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -4,6 +4,7 @@ from typing import Mapping
 
 import sqlalchemy as sa
 import sqlalchemy.types as sat
+import toolz
 from multipledispatch import Dispatcher
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.engine.default import DefaultDialect

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import calendar
+import contextlib
 import functools
 from functools import partial
 from operator import add, mul, sub
@@ -1386,3 +1387,14 @@ def _array_remove(op, **kw):
 @translate_val.register(ops.ArrayUnion)
 def _array_union(op, **kw):
     return translate_val(ops.ArrayDistinct(ops.ArrayConcat(op.left, op.right)), **kw)
+
+
+@translate_val.register(ops.Zip)
+def _array_zip(op: ops.Zip, **kw: Any) -> str:
+    arglist = []
+    for arg in op.arg:
+        sql_arg = translate_val(arg, **kw)
+        with contextlib.suppress(AttributeError):
+            sql_arg = sql_arg.sql(dialect="clickhouse")
+        arglist.append(sql_arg)
+    return f"arrayZip({', '.join(arglist)})"

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -1389,8 +1389,8 @@ def _array_union(op, **kw):
     return translate_val(ops.ArrayDistinct(ops.ArrayConcat(op.left, op.right)), **kw)
 
 
-@translate_val.register(ops.Zip)
-def _array_zip(op: ops.Zip, **kw: Any) -> str:
+@translate_val.register(ops.ArrayZip)
+def _array_zip(op: ops.ArrayZip, **kw: Any) -> str:
     arglist = []
     for arg in op.arg:
         sql_arg = translate_val(arg, **kw)

--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -19,6 +19,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
     native_bool = False
     supports_structs = False
     supports_json = False
+    supports_arrays = False
 
     @staticmethod
     def connect(data_directory: Path):

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -2041,3 +2041,8 @@ def compile_array_union(t, op, **kwargs):
 @compiles(ops.Hash)
 def compile_hash_column(t, op, **kwargs):
     return F.hash(t.translate(op.arg, **kwargs))
+
+
+@compiles(ops.Zip)
+def compile_zip(t, op, **kwargs):
+    return F.arrays_zip(*map(partial(t.translate, **kwargs), op.arg))

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -2043,6 +2043,6 @@ def compile_hash_column(t, op, **kwargs):
     return F.hash(t.translate(op.arg, **kwargs))
 
 
-@compiles(ops.Zip)
+@compiles(ops.ArrayZip)
 def compile_zip(t, op, **kwargs):
     return F.arrays_zip(*map(partial(t.translate, **kwargs), op.arg))

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -702,3 +702,19 @@ def test_unnest_struct(con):
     result = con.execute(expr)
     expected = pd.DataFrame(data).explode("value").iloc[:, 0].reset_index(drop=True)
     tm.assert_series_equal(result, expected)
+
+
+def test_zip6(con):
+    t = con.tables.array_types
+
+    res = t.x.zip(t.z, t.z, t.z, t.z, t.z, t.z)
+    df = res.execute()
+    assert not df.empty
+
+
+def test_zip2(con):
+    t = con.tables.array_types
+
+    res = t.x.zip(t.z)
+    df = res.execute()
+    assert not df.empty

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -704,17 +704,35 @@ def test_unnest_struct(con):
     tm.assert_series_equal(result, expected)
 
 
-def test_zip6(con):
-    t = con.tables.array_types
+@pytest.mark.never(
+    ["impala", "mssql", "mysql", "sqlite"],
+    raises=com.OperationNotDefinedError,
+    reason="no array support",
+)
+@pytest.mark.notyet(["bigquery"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(
+    [
+        "dask",
+        "datafusion",
+        "druid",
+        "duckdb",
+        "oracle",
+        "pandas",
+        "polars",
+        "postgres",
+        "snowflake",
+    ],
+    raises=com.OperationNotDefinedError,
+)
+def test_zip(backend):
+    t = backend.array_types
 
-    res = t.x.zip(t.z, t.z, t.z, t.z, t.z, t.z)
-    df = res.execute()
-    assert not df.empty
+    x = t.x.execute()
+    res = t.x.zip(t.x)
+    s = res.execute()
+    assert len(x[0]) == len(s[0])
 
-
-def test_zip2(con):
-    t = con.tables.array_types
-
-    res = t.x.zip(t.z)
-    df = res.execute()
-    assert not df.empty
+    x = t.x.execute()
+    res = t.x.zip(t.x, t.x, t.x, t.x, t.x, t.x)
+    s = res.execute()
+    assert len(x[0]) == len(s[0])

--- a/ibis/backends/trino/datatypes.py
+++ b/ibis/backends/trino/datatypes.py
@@ -85,24 +85,10 @@ def parse(text: str, default_decimal_parameters=(18, 3)) -> dt.DataType:
         parsy.seq(LPAREN.then(ty).skip(COMMA), ty.skip(RPAREN)).combine(dt.Map)
     )
 
-    def make_tuple(pairs):
-        result = []
-        for i, typ in enumerate(pairs, start=1):
-            if len(typ) == 2:
-                name, typ = typ
-            else:
-                name = f"f{i:d}"
-            result.append((name, typ))
-        return dt.Struct.from_tuples(result)
-
     struct = (
         spaceless_string("row")
         .then(LPAREN)
-        .then(
-            parsy.seq(parsy.alt(parsy.seq(spaceless(FIELD), ty), ty))
-            .sep_by(COMMA)
-            .map(make_tuple)
-        )
+        .then(parsy.seq(spaceless(FIELD), ty).sep_by(COMMA).map(dt.Struct.from_tuples))
         .skip(RPAREN)
     )
 

--- a/ibis/backends/trino/datatypes.py
+++ b/ibis/backends/trino/datatypes.py
@@ -85,10 +85,24 @@ def parse(text: str, default_decimal_parameters=(18, 3)) -> dt.DataType:
         parsy.seq(LPAREN.then(ty).skip(COMMA), ty.skip(RPAREN)).combine(dt.Map)
     )
 
+    def make_tuple(pairs):
+        result = []
+        for i, typ in enumerate(pairs, start=1):
+            if len(typ) == 2:
+                name, typ = typ
+            else:
+                name = f"f{i:d}"
+            result.append((name, typ))
+        return dt.Struct.from_tuples(result)
+
     struct = (
         spaceless_string("row")
         .then(LPAREN)
-        .then(parsy.seq(spaceless(FIELD), ty).sep_by(COMMA).map(dt.Struct.from_tuples))
+        .then(
+            parsy.seq(parsy.alt(parsy.seq(spaceless(FIELD), ty), ty))
+            .sep_by(COMMA)
+            .map(make_tuple)
+        )
         .skip(RPAREN)
     )
 

--- a/ibis/backends/trino/datatypes.py
+++ b/ibis/backends/trino/datatypes.py
@@ -34,12 +34,14 @@ class ROW(_ROW):
             return None
 
         def process(
-            value, result_is_tuple: bool = self._result_is_tuple
+            value,
+            result_is_tuple: bool = self._result_is_tuple,
+            names: tuple[str, ...] = tuple(name for name, _ in self.attr_types),
         ) -> dict[str, Any] | None:
             if value is None or not result_is_tuple:
                 return value
             else:
-                return dict(zip(value._names, value))
+                return dict(zip(names, value))
 
         return process
 

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -447,7 +447,7 @@ operation_registry.update(
         ops.Argument: lambda _, op: sa.literal_column(op.name),
         ops.First: partial(_first_last, offset=1),
         ops.Last: partial(_first_last, offset=-1),
-        ops.Zip: _zip,
+        ops.ArrayZip: _zip,
     }
 )
 

--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -189,7 +189,7 @@ class ArrayUnion(Value):
 
 
 @public
-class Zip(Value):
+class ArrayZip(Value):
     arg = rlz.tuple_of(rlz.array, min_length=2)
 
     output_shape = rlz.shape_like("arg")

--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -186,3 +186,21 @@ class ArrayUnion(Value):
 
     output_dtype = rlz.dtype_like("args")
     output_shape = rlz.shape_like("args")
+
+
+@public
+class Zip(Value):
+    arg = rlz.tuple_of(rlz.array, min_length=2)
+
+    output_shape = rlz.shape_like("arg")
+
+    @attribute.default
+    def output_dtype(self):
+        return dt.Array(
+            dt.Struct(
+                {
+                    f"f{i:d}": array.output_dtype.value_type
+                    for i, array in enumerate(self.arg, start=1)
+                }
+            )
+        )

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -759,6 +759,24 @@ class ArrayValue(Value):
         """
         return ops.ArrayUnion(self, other).to_expr()
 
+    def zip(self, other: ir.Array, *others: ir.Array) -> ir.Array:
+        """Zip two or more arrays together.
+
+        Parameters
+        ----------
+        other
+            Another array to zip with `self`
+        others
+            Additional arrays to zip with `self`
+
+        Returns
+        -------
+        Array
+            Array of structs where each struct field is an element of each input
+            array.
+        """
+        return ops.Zip((self, other, *others)).to_expr()
+
 
 @public
 class ArrayScalar(Scalar, ArrayValue):

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -775,7 +775,8 @@ class ArrayValue(Value):
             Array of structs where each struct field is an element of each input
             array.
         """
-        return ops.Zip((self, other, *others)).to_expr()
+
+        return ops.ArrayZip((self, other, *others)).to_expr()
 
 
 @public


### PR DESCRIPTION
This PR implements a `.zip` method for array expressions and adds implementations for:

* clickhouse
* pyspark
* trino