### PR TITLE
refactor(pyspark): align datatype conversion functions with the new convention

### DIFF
--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -2,25 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
-import pyspark as ps
-
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
-import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.backends.base.sql.ddl import fully_qualified_re
 from ibis.backends.pyspark import ddl
 
 if TYPE_CHECKING:
     import pandas as pd
-
-
-@sch.infer.register(ps.sql.dataframe.DataFrame)
-def spark_dataframe_schema(df):
-    """Infer the schema of a Spark SQL `DataFrame` object."""
-    # df.schema is a pt.StructType
-    struct_dtype = dt.dtype(df.schema)
-    return sch.Schema(struct_dtype)
 
 
 class PySparkTable(ir.Table):

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -20,7 +20,7 @@ import ibis.expr.types as ir
 from ibis import interval
 from ibis.backends.base.df.timecontext import adjust_context
 from ibis.backends.pandas.execution import execute
-from ibis.backends.pyspark.datatypes import spark_dtype
+from ibis.backends.pyspark.datatypes import dtype_to_pyspark
 from ibis.backends.pyspark.timecontext import (
     combine_time_context,
     filter_by_time_context,
@@ -266,7 +266,7 @@ def compile_cast(t, op, **kwargs):
                 'in the PySpark backend. {} not allowed.'.format(type(op.arg))
             )
 
-    cast_type = spark_dtype(op.to)
+    cast_type = dtype_to_pyspark(op.to)
 
     src_column = t.translate(op.arg, **kwargs)
     return src_column.cast(cast_type)
@@ -652,10 +652,9 @@ def compile_covariance(t, op, **kwargs):
 
     fn = {"sample": F.covar_samp, "pop": F.covar_pop}[how]
 
-    pyspark_double_type = spark_dtype(dt.double)
     new_op = op.__class__(
-        left=ops.Cast(op.left, to=pyspark_double_type),
-        right=ops.Cast(op.right, to=pyspark_double_type),
+        left=ops.Cast(op.left, to=dt.float64),
+        right=ops.Cast(op.right, to=dt.float64),
         how=how,
         where=op.where,
     )
@@ -667,10 +666,9 @@ def compile_correlation(t, op, **kwargs):
     if (how := op.how) == "pop":
         raise ValueError("PySpark only implements sample correlation")
 
-    pyspark_double_type = spark_dtype(dt.double)
     new_op = op.__class__(
-        left=ops.Cast(op.left, to=pyspark_double_type),
-        right=ops.Cast(op.right, to=pyspark_double_type),
+        left=ops.Cast(op.left, to=dt.float64),
+        right=ops.Cast(op.right, to=dt.float64),
         how=how,
         where=op.where,
     )
@@ -758,7 +756,7 @@ def compile_clip(t, op, **kwargs):
     def clip(column, lower_value, upper_value):
         return column_max(column_min(column, F.lit(lower_value)), F.lit(upper_value))
 
-    return clip(col, lower, upper).cast(spark_dtype(op.output_dtype))
+    return clip(col, lower, upper).cast(dtype_to_pyspark(op.output_dtype))
 
 
 @compiles(ops.Round)
@@ -1616,7 +1614,7 @@ def compile_array_length(t, op, **kwargs):
 def compile_array_slice(t, op, **kwargs):
     start = op.start.value if op.start is not None else op.start
     stop = op.stop.value if op.stop is not None else op.stop
-    spark_type = spark_dtype(op.arg.output_dtype)
+    spark_type = dtype_to_pyspark(op.arg.output_dtype)
 
     @F.udf(spark_type)
     def array_slice(array):
@@ -1753,7 +1751,7 @@ def compile_fillna_table(t, op, **kwargs):
 
 @compiles(ops.ElementWiseVectorizedUDF)
 def compile_elementwise_udf(t, op, **kwargs):
-    spark_output_type = spark_dtype(op.return_type)
+    spark_output_type = dtype_to_pyspark(op.return_type)
     func = op.func
     spark_udf = pandas_udf(func, spark_output_type, PandasUDFType.SCALAR)
     func_args = (t.translate(arg, **kwargs) for arg in op.func_args)
@@ -1762,7 +1760,7 @@ def compile_elementwise_udf(t, op, **kwargs):
 
 @compiles(ops.ReductionVectorizedUDF)
 def compile_reduction_udf(t, op, *, aggcontext=None, **kwargs):
-    spark_output_type = spark_dtype(op.return_type)
+    spark_output_type = dtype_to_pyspark(op.return_type)
     spark_udf = pandas_udf(op.func, spark_output_type, PandasUDFType.GROUPED_AGG)
     func_args = (t.translate(arg, **kwargs) for arg in op.func_args)
 
@@ -1897,7 +1895,7 @@ def compile_random(*args, **kwargs):
 @compiles(ops.InMemoryTable)
 def compile_in_memory_table(t, op, session, **kwargs):
     fields = [
-        pt.StructField(name, spark_dtype(dtype), dtype.nullable)
+        pt.StructField(name, dtype_to_pyspark(dtype), dtype.nullable)
         for name, dtype in op.schema.items()
     ]
     schema = pt.StructType(fields)
@@ -1958,7 +1956,7 @@ def compile_dummy_table(t, op, session=None, **kwargs):
 def compile_scalar_parameter(t, op, timecontext=None, scope=None, **kwargs):
     assert scope is not None, "scope is None"
     raw_value = scope.get_value(op, timecontext)
-    return F.lit(raw_value).cast(spark_dtype(op.output_dtype))
+    return F.lit(raw_value).cast(dtype_to_pyspark(op.output_dtype))
 
 
 @compiles(ops.E)

--- a/ibis/backends/pyspark/tests/test_basic.py
+++ b/ibis/backends/pyspark/tests/test_basic.py
@@ -238,7 +238,6 @@ def test_interval_columns(con):
 
 
 def test_interval_columns_invalid(con):
-    with pytest.raises(
-        IbisTypeError, match="DayTimeIntervalType couldn't be converted to Interval"
-    ):
+    msg = r"DayTimeIntervalType\(0, 1\) couldn't be converted to Interval"
+    with pytest.raises(IbisTypeError, match=msg):
         con.table('invalid_interval_table')


### PR DESCRIPTION
The new convention for datatype conversions is to have to simple functions:
- `dtype_from_<target>(typ, nullable=True)`
- `dtype_to_<target>(dtype)`

depends on #6184 