### PR TITLE
chore(deps): drop invalid `|` constraint on shapely in `pyproject.toml`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5219,4 +5219,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "ccd7c5796a7fb50030ed61b620a0c43f058aaf352bec70a98b2dec72d1bdb681"
+content-hash = "05c783f9295fc61be5c60e871d47f7ee95e6e0cc5072c72cd804669e267e50ee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ pyspark = { version = ">=3,<4", optional = true }
 # used to support posix regexen in the pandas, dask and sqlite backends
 regex = { version = ">=2021.7.6", optional = true }
 requests = { version = ">=2,<3", optional = true }
-shapely = { version = ">=1.6,<1.8|>=1.9,<3", optional = true }
+shapely = { version = ">=1.9,<3", optional = true }
 # include an explicit dependency on `snowflake-connector-python` because the
 # lack of lower bound on this dependency as specified in `snowflake-sqlalchemy`
 # appears to cause poetry's solver to get stuck


### PR DESCRIPTION
The recent `poetry-core` release dropped support for `|` constraints, which from the docs appears to have never been explicitly supported. Since `shapely` 2.0 has been out for a while now, we just drop support the `|` constraint entirely.