### PR TITLE
fix(duckdb): better types for null literals

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -742,7 +742,13 @@ class Backend(BaseAlchemyBackend):
             {
                 name: (
                     col.to_pylist()
-                    if pat.is_nested(col.type)
+                    if (
+                        pat.is_nested(col.type)
+                        or
+                        # pyarrow / duckdb type null literals columns as int32?
+                        # but calling `to_pylist()` will render it as None
+                        col.null_count
+                    )
                     else col.to_pandas(timestamp_as_object=True)
                 )
                 for name, col in zip(table.column_names, table.columns)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -45,7 +45,7 @@ NULL_BACKEND_TYPES = {
 }
 
 
-@pytest.mark.broken(["duckdb", "impala", "bigquery"], 'assert nan is None')
+@pytest.mark.broken(["impala", "bigquery"], 'assert nan is None')
 def test_null_literal(con, backend):
     expr = ibis.null()
     result = con.execute(expr)


### PR DESCRIPTION
xref #6148 

This is a DuckDB-specific fix, and I'm not entirely certain it's without side-effects, but I like this:

```python
[ins] In [1]: import ibis

[ins] In [2]: ibis.literal(None, type="string").execute() is None
Out[2]: True

[ins] In [3]: ibis.literal(None, type="float").execute()
Out[3]: nan
```

much more than this:

```python
[ins] In [1]: import ibis

[ins] In [2]: ibis.literal(None, type="string").execute()
Out[2]: nan

[ins] In [3]: ibis.literal(None, type="float").execute()
Out[3]: nan
```

Note that `is_null` is a pre-populated attribute, so I think this is a fairly cheap check to perform, and it has the benefit of fixing a broken test.