### PR TITLE
fix(bigquery): raise `OperationNotDefinedError` for `IntervalAdd` and `IntervalSubtract`

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -341,14 +341,16 @@ def _timestamp_op(func, units):
     def _formatter(translator, op):
         arg, offset = op.args
 
+        formatted_arg = translator.translate(arg)
+        formatted_offset = translator.translate(offset)
+
         unit = offset.output_dtype.unit
         if unit not in units:
             raise com.UnsupportedOperationError(
                 "BigQuery does not allow binary operation "
                 f"{func} with INTERVAL offset {unit}"
             )
-        formatted_arg = translator.translate(arg)
-        formatted_offset = translator.translate(offset)
+
         result = f"{func}({formatted_arg}, {formatted_offset})"
         return result
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -814,14 +814,9 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
                         "postgres",
                         "snowflake",
                         "sqlite",
-                    ],
-                    raises=com.OperationNotDefinedError,
-                ),
-                pytest.mark.notimpl(
-                    [
                         "bigquery",
                     ],
-                    raises=com.UnsupportedOperationError,
+                    raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notimpl(
                     ["druid"],
@@ -846,14 +841,9 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
                         "mysql",
                         "impala",
                         "snowflake",
-                    ],
-                    raises=com.OperationNotDefinedError,
-                ),
-                pytest.mark.notimpl(
-                    [
                         "bigquery",
                     ],
-                    raises=com.UnsupportedOperationError,
+                    raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notimpl(
                     ["druid"],


### PR DESCRIPTION
Fixes the recently introduced bigquery build error: https://github.com/ibis-project/ibis/actions/runs/4982484931/jobs/8918214842