### PR TITLE
refactor(api): consolidate `ibis.date()`, `ibis.time()` and `ibis.timestamp()` functions

### DIFF
--- a/ibis/common/temporal.py
+++ b/ibis/common/temporal.py
@@ -5,6 +5,7 @@ from enum import Enum, EnumMeta
 
 import dateutil.parser
 import dateutil.tz
+import pytz
 from public import public
 
 from ibis.common.dispatch import lazy_singledispatch
@@ -123,7 +124,7 @@ def normalize_timezone(tz):
             return dateutil.tz.gettz(tz)
     elif isinstance(tz, (int, float)):
         return datetime.timezone(datetime.timedelta(hours=tz))
-    elif isinstance(tz, dateutil.tz.tzoffset):
+    elif isinstance(tz, (dateutil.tz.tzoffset, pytz._FixedOffset)):
         # this way we have a proper tzname() output, e.g. "UTC+01:00"
         return datetime.timezone(tz.utcoffset(None))
     elif isinstance(tz, datetime.tzinfo):

--- a/ibis/expr/tests/test_api.py
+++ b/ibis/expr/tests/test_api.py
@@ -1,4 +1,9 @@
+from datetime import datetime
+
+import pandas as pd
 import pytest
+from dateutil.tz import tzoffset, tzutc
+from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
@@ -27,3 +32,70 @@ def test_schema_from_names_and_typesield_names():
     msg = "Duplicate column name"
     with pytest.raises(IntegrityError, match=msg):
         ibis.schema(names=["a", "a"], types=["int", "str"])
+
+
+@pytest.mark.parametrize(
+    ('string', 'expected_value', 'expected_timezone'),
+    [
+        param(
+            '2015-01-01 12:34:56.789',
+            datetime(2015, 1, 1, 12, 34, 56, 789000),
+            None,
+            id="from_string_millis",
+        ),
+        param(
+            '2015-01-01 12:34:56.789321',
+            datetime(2015, 1, 1, 12, 34, 56, 789321),
+            None,
+            id="from_string_micros",
+        ),
+        param(
+            '2015-01-01 12:34:56.789 UTC',
+            datetime(2015, 1, 1, 12, 34, 56, 789000, tzinfo=tzutc()),
+            'UTC',
+            id="from_string_millis_utc",
+        ),
+        param(
+            '2015-01-01 12:34:56.789321 UTC',
+            datetime(2015, 1, 1, 12, 34, 56, 789321, tzinfo=tzutc()),
+            'UTC',
+            id="from_string_micros_utc",
+        ),
+        param(
+            '2015-01-01 12:34:56.789+00:00',
+            datetime(2015, 1, 1, 12, 34, 56, 789000, tzinfo=tzutc()),
+            'UTC',
+            id="from_string_millis_utc_offset",
+        ),
+        param(
+            '2015-01-01 12:34:56.789+01:00',
+            datetime(2015, 1, 1, 12, 34, 56, 789000, tzinfo=tzoffset(None, 3600)),
+            'UTC+01:00',
+            id="from_string_millis_utc_+1_offset",
+        ),
+        param(
+            pd.Timestamp('2015-01-01 12:34:56.789'),
+            datetime(2015, 1, 1, 12, 34, 56, 789000),
+            None,
+            id="from_pandas_millis",
+        ),
+        param(
+            pd.Timestamp('2015-01-01 12:34:56.789', tz='UTC'),
+            datetime(2015, 1, 1, 12, 34, 56, 789000, tzinfo=tzutc()),
+            'UTC',
+            id="from_pandas_millis_utc",
+        ),
+        param(
+            pd.Timestamp('2015-01-01 12:34:56.789+03:00'),
+            datetime(2015, 1, 1, 12, 34, 56, 789000, tzinfo=tzoffset(None, 10800)),
+            'UTC+03:00',
+            id="from_pandas_millis_+3_offset",
+        ),
+    ],
+)
+def test_timestamp(string, expected_value, expected_timezone):
+    expr = ibis.timestamp(string)
+    op = expr.op()
+    assert isinstance(expr, ibis.expr.types.TimestampScalar)
+    assert op.value == expected_value
+    assert op.dtype == dt.Timestamp(timezone=expected_timezone)

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -511,7 +511,7 @@ def _binop(
     >>> import ibis.expr.operations as ops
     >>> expr = _binop(ops.TimeAdd, ibis.time("01:00"), ibis.interval(hours=1))
     >>> expr
-    TimeAdd(datetime.time(1, 0), 1): datetime.time(1, 0) + 1 h
+    TimeAdd('01:00', 1): '01:00' + 1 h
     >>> _binop(ops.TimeAdd, 1, ibis.interval(hours=1))
     NotImplemented
     """

--- a/ibis/tests/expr/test_timestamp.py
+++ b/ibis/tests/expr/test_timestamp.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import dateutil.parser
 import numpy as np
 import pandas as pd
 import pytest
@@ -63,7 +64,7 @@ def test_timestamp_literals(function, value):
 
 
 def test_invalid_timestamp_literal():
-    with pytest.raises(ValueError):
+    with pytest.raises(dateutil.parser.ParserError):
         ibis.timestamp('2015-01-01 00:71')
 
 

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -7,8 +7,8 @@ from decimal import Decimal
 from operator import attrgetter, methodcaller
 
 import numpy as np
-import pandas as pd
 import pytest
+import pytz
 import toolz
 from pytest import param
 
@@ -1141,12 +1141,14 @@ def test_large_timestamp():
     assert result == expected
 
 
-@pytest.mark.parametrize('tz', [None, 'UTC'])
-def test_timestamp_with_timezone(tz):
-    expr = ibis.timestamp('2017-01-01', timezone=tz)
-    expected = pd.Timestamp('2017-01-01', tz=tz)
-    result = expr.op().value
-    assert expected == result
+def test_timestamp_with_timezone():
+    expr = ibis.timestamp('2017-01-01', timezone=None)
+    expected = datetime(2017, 1, 1, tzinfo=None)
+    assert expr.op().value == expected
+
+    expr = ibis.timestamp('2017-01-01', timezone='UTC')
+    expected = datetime(2017, 1, 1, tzinfo=pytz.timezone('UTC'))
+    assert expr.op().value == expected
 
 
 @pytest.mark.parametrize('tz', [None, 'UTC'])


### PR DESCRIPTION
Prefer using simpler functions over dispatched ones with just a few branches. 