### PR TITLE
fix(duckdb): ensure that quoted struct field names work

### DIFF
--- a/ibis/backends/duckdb/datatypes.py
+++ b/ibis/backends/duckdb/datatypes.py
@@ -14,6 +14,7 @@ from ibis.common.parsing import (
     LBRACKET,
     LPAREN,
     PRECISION,
+    RAW_STRING,
     RBRACKET,
     RPAREN,
     SCALE,
@@ -80,10 +81,12 @@ def parse(text: str, default_decimal_parameters=(18, 3)) -> dt.DataType:
         .skip(RPAREN)
     )
 
+    field = spaceless(parsy.alt(FIELD, RAW_STRING))
+
     struct = (
         spaceless_string("struct")
         .then(LPAREN)
-        .then(parsy.seq(spaceless(FIELD), ty).sep_by(COMMA).map(dt.Struct.from_tuples))
+        .then(parsy.seq(field, ty).sep_by(COMMA).map(dt.Struct.from_tuples))
         .skip(RPAREN)
     )
 

--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -111,3 +111,11 @@ def test_null_dtype():
         match="DuckDB cannot yet reliably handle `null` typed columns",
     ):
         con.execute(t)
+
+
+def test_parse_quoted_struct_field():
+    import ibis.backends.duckdb.datatypes as ddt
+
+    assert ddt.parse('STRUCT("a" INT, "a b c" INT)') == dt.Struct(
+        {"a": dt.int32, "a b c": dt.int32}
+    )


### PR DESCRIPTION
Fixes #6232.