### PR TITLE
refactor(api): enforce at least one argument for `Table` set operations

### DIFF
--- a/ibis/backends/tests/test_set_ops.py
+++ b/ibis/backends/tests/test_set_ops.py
@@ -141,10 +141,16 @@ def test_difference(backend, alltypes, df, distinct):
 
 
 @pytest.mark.parametrize("method", ["intersect", "difference", "union"])
-@pytest.mark.parametrize("source", [ibis, ir.Table], ids=["top_level", "method"])
-def test_empty_set_op(alltypes, method, source):
-    result = getattr(source, method)(alltypes)
+def test_table_set_operations_api(alltypes, method):
+    # top level variadic
+    result = getattr(ibis, method)(alltypes)
     assert result.equals(alltypes)
+
+    # table level methods require at least one argument
+    with pytest.raises(
+        TypeError, match="missing 1 required positional argument: 'table'"
+    ):
+        getattr(ir.Table, method)(alltypes)
 
 
 @pytest.mark.parametrize(

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1274,6 +1274,21 @@ def trailing_range_window(preceding, order_by, group_by=None):
     )
 
 
+@functools.wraps(ir.Table.union)
+def union(table: ir.Table, *rest: ir.Table, distinct: bool = False):
+    return table.union(*rest, distinct=distinct) if rest else table
+
+
+@functools.wraps(ir.Table.intersect)
+def intersect(table: ir.Table, *rest: ir.Table, distinct: bool = True):
+    return table.intersect(*rest, distinct=distinct) if rest else table
+
+
+@functools.wraps(ir.Table.difference)
+def difference(table: ir.Table, *rest: ir.Table, distinct: bool = True):
+    return table.difference(*rest, distinct=distinct) if rest else table
+
+
 e = ops.E().to_expr()
 pi = ops.Pi().to_expr()
 
@@ -1341,10 +1356,6 @@ aggregate = ir.Table.aggregate
 cross_join = ir.Table.cross_join
 join = ir.Table.join
 asof_join = ir.Table.asof_join
-
-union = ir.Table.union
-intersect = ir.Table.intersect
-difference = ir.Table.difference
 
 _ = deferred = Deferred()
 """Deferred expression object.


### PR DESCRIPTION
Previously it was possible to call: `table.difference|union|intersect()` without any argument which doesn't make sense.