### PR TITLE
ci: fix flaky example tests

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -311,6 +311,7 @@ jobs:
           IBIS_TEST_IMPALA_PORT: 21050
           IBIS_TEST_WEBHDFS_PORT: 50070
           IBIS_TEST_WEBHDFS_USER: hdfs
+          IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples
 
       - name: upload code coverage
         if: success()

--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -65,6 +65,7 @@ def __getattr__(name: str) -> Example:
             # the trailing slash matters here
             base_url="https://storage.googleapis.com/ibis-examples/data/",
             version=ibis.__version__,
+            env="IBIS_EXAMPLES_DATA",
         )
         with resources.files(__name__).joinpath("registry.txt").open(mode="r") as _f:
             _EXAMPLES.load_registry(_f)


### PR DESCRIPTION
This PR tries to address the occasional but persistent flakiness of the examples tests.

The issue appears to be that there's some kind of race condition between
example tests that run on different python versions, but on the same host where
a view from an example's file is created in one test suite, and then recreated
from the same file in another test suite, while the other test is still
running.

I can't reproduce this locally, but at least we'll know that if the flakiness
continues it should be reproducible within in a single job (and therefore locally).
