### PR TITLE
build: remove no longer necessary pydruid poetry2nix override

### DIFF
--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -11,10 +11,6 @@ in
   # `wheel` cannot be used as a wheel to unpack itself, since that would
   # require itself (infinite recursion)
   wheel = super.wheel.override { preferWheel = false; };
-
-  pydruid = super.pydruid.overridePythonAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs or [ ] ++ [ self.setuptools ];
-  });
 } // super.lib.listToAttrs (
   map
     (name: {


### PR DESCRIPTION
Deletes some dead poetry2nix code.