### PR TITLE
perf(sqlalchemy): lazily construct the inspector object

### DIFF
--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -121,7 +121,7 @@ class BaseAlchemyBackend(BaseSQLBackend):
 
     def do_connect(self, con: sa.engine.Engine) -> None:
         self.con = con
-        self._inspector = sa.inspect(self.con)
+        self._inspector = None
         self._schemas: dict[str, sch.Schema] = {}
         self._temp_views: set[str] = set()
 
@@ -141,6 +141,8 @@ class BaseAlchemyBackend(BaseSQLBackend):
 
     @property
     def inspector(self):
+        if self._inspector is None:
+            self._inspector = sa.inspect(self.con)
         self._inspector.info_cache.clear()
         return self._inspector
 

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -127,6 +127,8 @@ class BaseAlchemyBackend(BaseSQLBackend):
 
     @property
     def version(self):
+        if self._inspector is None:
+            self._inspector = sa.inspect(self.con)
         return '.'.join(map(str, self.con.dialect.server_version_info))
 
     def list_tables(self, like=None, database=None):
@@ -143,7 +145,8 @@ class BaseAlchemyBackend(BaseSQLBackend):
     def inspector(self):
         if self._inspector is None:
             self._inspector = sa.inspect(self.con)
-        self._inspector.info_cache.clear()
+        else:
+            self._inspector.info_cache.clear()
         return self._inspector
 
     def _to_sql(self, expr: ir.Expr, **kwargs) -> str:

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -39,26 +39,16 @@ class TestConf(ServiceBackendTest, RoundHalfToEven):
 
     def __init__(self, data_directory: Path) -> None:
         super().__init__(data_directory)
-        # mariadb supports window operations after version 10.2
-        # but the sqlalchemy version string looks like:
-        # 5.5.5.10.2.12.MariaDB.10.2.12+maria~jessie
-        # or 10.4.12.MariaDB.1:10.4.12+maria~bionic
-        # example of possible results:
-        # https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_3/
-        # test/dialect/mysql/test_dialect.py#L244-L268
         con = self.connection
-        if 'MariaDB' in str(con.version):
-            # we might move this parsing step to the mysql client
-            version_detail = con.con.dialect._parse_server_version(str(con.version))
-            version = (
-                version_detail[:3]
-                if version_detail[3] == 'MariaDB'
-                else version_detail[3:6]
-            )
-            self.__class__.supports_window_operations = version >= (10, 2)
-        elif parse_version(con.version) >= parse_version('8.0'):
-            # mysql supports window operations after version 8
-            self.__class__.supports_window_operations = True
+        with con.begin() as c:
+            version = c.exec_driver_sql("SELECT VERSION()").scalar()
+
+        # mariadb supports window operations after version 10.2
+        # mysql supports window operations after version 8
+        min_version = "10.2" if "MariaDB" in version else "8.0"
+        self.__class__.supports_window_operations = parse_version(
+            con.version
+        ) >= parse_version(min_version)
 
     @staticmethod
     def _load_data(

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -60,23 +60,11 @@ class Backend(BaseAlchemyBackend):
                 message=r"The dbapi\(\) classmethod on dialect classes has been renamed",
                 category=sa.exc.SADeprecationWarning,
             )
-            try:
-                super().do_connect(
-                    sa.create_engine(
-                        url,
-                        connect_args={
-                            **connect_args,
-                            "experimental_python_types": True,
-                        },
-                        poolclass=sa.pool.StaticPool,
-                    )
+            super().do_connect(
+                sa.create_engine(
+                    url, connect_args=connect_args, poolclass=sa.pool.StaticPool
                 )
-            except TypeError:
-                super().do_connect(
-                    sa.create_engine(
-                        url, connect_args=connect_args, poolclass=sa.pool.StaticPool
-                    )
-                )
+            )
 
     @staticmethod
     def _new_sa_metadata():

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import warnings
+from functools import cached_property
 from typing import Iterator
 
 import sqlalchemy as sa
@@ -26,12 +27,10 @@ class Backend(BaseAlchemyBackend):
     def current_database(self) -> str:
         raise NotImplementedError(type(self))
 
-    @property
+    @cached_property
     def version(self) -> str:
-        # TODO: there is a `PRAGMA version` we could use instead
-        import importlib.metadata
-
-        return importlib.metadata.version("trino")
+        with self.begin() as con:
+            return con.execute(sa.select(sa.func.version())).scalar()
 
     def do_connect(
         self,

--- a/poetry.lock
+++ b/poetry.lock
@@ -5386,4 +5386,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d32110130aba8fd41cd3d339cec14b8694b7980cfd738ff8799a82d94cdbc700"
+content-hash = "f36570c34d38949ce899063b64fa2dfe675f79475781be2abc6974afe21e1f26"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ snowflake-connector-python = { version = ">=2.7.10,<4", optional = true }
 snowflake-sqlalchemy = { version = ">=1.4.1,<2", optional = true }
 sqlalchemy = { version = ">=1.4,<3", optional = true }
 sqlalchemy-views = { version = ">=0.3.1,<1", optional = true }
-trino = { version = ">=0.319,<1", optional = true, extras = ["sqlalchemy"] }
+trino = { version = ">=0.321,<1", optional = true, extras = ["sqlalchemy"] }
 
 [tool.poetry.group.dev.dependencies]
 black = ">=22.1.0,<24"


### PR DESCRIPTION
This PR speeds up connecting to backends where `sqlalchemy.inspect` executes a
significant amount of code/traverses the network.

Snowflake is one such backend.

Before:

```
In [1]: from ibis.interactive import *

In [2]: import os

In [3]: %time con = ibis.connect(os.environ["SNOWFLAKE_URL"])
CPU times: user 574 ms, sys: 56.6 ms, total: 630 ms
Wall time: 1.88 s
```

After:

```
In [1]: from ibis.interactive import *

In [2]: import os

In [3]: %time con = ibis.connect(os.environ["SNOWFLAKE_URL"])
CPU times: user 475 ms, sys: 36.9 ms, total: 512 ms
Wall time: 514 ms
```
