### PR TITLE
feat(duckdb): expand map support to `.values()` and map concatenation

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -4,8 +4,10 @@ import operator
 from functools import partial
 from typing import Any, Mapping
 
+import duckdb
 import numpy as np
 import sqlalchemy as sa
+from packaging.version import parse as vparse
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.functions import GenericFunction
 from toolz.curried import flip
@@ -36,6 +38,8 @@ operation_registry = {
     op: operation_registry[op]
     for op in operation_registry.keys() - geospatial_functions.keys()
 }
+
+_SUPPORTS_MAPS = vparse(duckdb.__version__) >= vparse("0.8.0")
 
 
 def _round(t, op):
@@ -414,9 +418,11 @@ operation_registry.update(
             lambda arg, key: sa.func.array_length(sa.func.element_at(arg, key)) != 0, 2
         ),
         ops.MapLength: unary(sa.func.cardinality),
-        ops.MapKeys: _map_keys,
-        ops.MapValues: _map_values,
-        ops.MapMerge: _map_merge,
+        ops.MapKeys: unary(sa.func.map_keys) if _SUPPORTS_MAPS else _map_keys,
+        ops.MapValues: unary(sa.func.map_values) if _SUPPORTS_MAPS else _map_values,
+        ops.MapMerge: (
+            fixed_arity(sa.func.map_concat, 2) if _SUPPORTS_MAPS else _map_merge
+        ),
         ops.Hash: unary(sa.func.hash),
         ops.Median: reduction(sa.func.median),
         ops.First: reduction(sa.func.first),

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -30,7 +30,9 @@ def test_map_table(backend):
 
 
 @pytest.mark.notimpl(["pandas", "dask"])
-@pytest.mark.notyet(["duckdb"], raises=exc.UnsupportedOperationError)
+@pytest.mark.xfail_version(
+    duckdb=["duckdb<0.8.0"], raises=exc.UnsupportedOperationError
+)
 def test_column_map_values(backend):
     table = backend.map
     result = table.kv.values().name("values").execute().map(sorted)
@@ -39,7 +41,9 @@ def test_column_map_values(backend):
 
 
 @pytest.mark.notimpl(["pandas", "dask"])
-@pytest.mark.notyet(["duckdb"], raises=exc.UnsupportedOperationError)
+@pytest.mark.xfail_version(
+    duckdb=["duckdb<0.8.0"], raises=exc.UnsupportedOperationError
+)
 def test_column_map_merge(backend):
     table = backend.map
     expr = (table.kv.cast("map<string, int8>") + ibis.map({"d": 1})).name("merged")

--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -352,7 +352,7 @@ class MapValue(Value):
         >>> m1 = ibis.map({"a": 1, "b": 2})
         >>> m2 = ibis.map({"c": 3, "d": 4})
         >>> m1 + m2
-        {'c': 3, 'd': 4, 'a': 1, 'b': 2}
+        {'a': 1, 'b': 2, 'c': 3, 'd': 4}
         """
         return ops.MapMerge(self, other).to_expr()
 
@@ -376,7 +376,7 @@ class MapValue(Value):
         >>> m1 = ibis.map({"a": 1, "b": 2})
         >>> m2 = ibis.map({"c": 3, "d": 4})
         >>> m1 + m2
-        {'c': 3, 'd': 4, 'a': 1, 'b': 2}
+        {'a': 1, 'b': 2, 'c': 3, 'd': 4}
         """
         return ops.MapMerge(self, other).to_expr()
 


### PR DESCRIPTION
Expands support for map operations that landed in DuckDB 0.8.0.