### PR TITLE
docs: drop `docker-compose` install for conda dev env setup

### DIFF
--- a/docs/community/contribute/01_environment.md
+++ b/docs/community/contribute/01_environment.md
@@ -70,12 +70,6 @@ hide:
             pip install -e .
             ```
 
-        1. If you want to run the backend test suite you'll need to install `docker-compose`:
-
-            ```sh
-            {{ manager }} install docker-compose -c conda-forge
-            ```
-
     {% endfor %}
 
 === "pip"


### PR DESCRIPTION
This is no longer needed with the builtin `docker compose` command.