### PR TITLE
feat(api): use `create_table` to load example data

### DIFF
--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -179,6 +179,8 @@ class BasePandasBackend(BaseBackend):
 
     @classmethod
     def _supports_conversion(cls, obj: Any) -> bool:
+        if isinstance(obj, ir.Table):
+            return isinstance(obj.op(), ops.InMemoryTable)
         return True
 
     @staticmethod
@@ -187,6 +189,10 @@ class BasePandasBackend(BaseBackend):
 
     @classmethod
     def _convert_object(cls, obj: Any) -> Any:
+        if isinstance(obj, ir.Table):
+            # Support memtables
+            assert isinstance(obj.op(), ops.InMemoryTable)
+            return obj.op().data.to_frame()
         return cls.backend_table_type(obj)
 
     @classmethod

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -750,12 +750,10 @@ def test_agg_memory_table(con):
     [
         param(
             ibis.memtable([("a", 1.0)], columns=["a", "b"]),
-            marks=pytest.mark.notimpl(["pandas"]),
             id="python",
         ),
         param(
             ibis.memtable(pd.DataFrame([("a", 1.0)], columns=["a", "b"])),
-            marks=pytest.mark.notimpl(["pandas"]),
             id="pandas-memtable",
         ),
         param(pd.DataFrame([("a", 1.0)], columns=["a", "b"]), id="pandas"),

--- a/ibis/backends/tests/test_examples.py
+++ b/ibis/backends/tests/test_examples.py
@@ -1,0 +1,34 @@
+import pytest
+
+import ibis
+from ibis.backends.conftest import LINUX, SANDBOXED
+
+pytestmark = pytest.mark.examples
+
+
+@pytest.mark.xfail(
+    LINUX and SANDBOXED,
+    reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
+    raises=OSError,
+)
+@pytest.mark.notimpl(["dask", "datafusion", "pyspark", "sqlite"])
+@pytest.mark.notyet(["bigquery", "clickhouse", "druid", "impala", "mssql", "trino"])
+@pytest.mark.parametrize(
+    ("example", "columns"),
+    [
+        (
+            "wowah_locations_raw",
+            ["Map_ID", "Location_Type", "Location_Name", "Game_Version"],
+        ),
+        ("band_instruments", ["name", "plays"]),
+        (
+            "AwardsManagers",
+            ["player_id", "award_id", "year_id", "lg_id", "tie", "notes"],
+        ),
+    ],
+    ids=["parquet", "csv", "csv-all-null"],
+)
+def test_load_examples(con, example, columns):
+    t = getattr(ibis.examples, example).fetch(backend=con)
+    assert t.columns == columns
+    assert t.count().execute() > 0

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -850,26 +850,7 @@ def read_csv(sources: str | Path | Sequence[str | Path], **kwargs: Any) -> ir.Ta
     Examples
     --------
     >>> import ibis
-    >>> ibis.options.interactive = True
-    >>> t = ibis.examples.Batting_raw.fetch()
-    >>> t
-    ┏━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━┓
-    ┃ playerID  ┃ yearID ┃ stint ┃ teamID ┃ lgID   ┃ G     ┃ AB    ┃ R     ┃ … ┃
-    ┡━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━┩
-    │ string    │ int64  │ int64 │ string │ string │ int64 │ int64 │ int64 │ … │
-    ├───────────┼────────┼───────┼────────┼────────┼───────┼───────┼───────┼───┤
-    │ abercda01 │   1871 │     1 │ TRO    │ NA     │     1 │     4 │     0 │ … │
-    │ addybo01  │   1871 │     1 │ RC1    │ NA     │    25 │   118 │    30 │ … │
-    │ allisar01 │   1871 │     1 │ CL1    │ NA     │    29 │   137 │    28 │ … │
-    │ allisdo01 │   1871 │     1 │ WS3    │ NA     │    27 │   133 │    28 │ … │
-    │ ansonca01 │   1871 │     1 │ RC1    │ NA     │    25 │   120 │    29 │ … │
-    │ armstbo01 │   1871 │     1 │ FW1    │ NA     │    12 │    49 │     9 │ … │
-    │ barkeal01 │   1871 │     1 │ RC1    │ NA     │     1 │     4 │     0 │ … │
-    │ barnero01 │   1871 │     1 │ BS1    │ NA     │    31 │   157 │    66 │ … │
-    │ barrebi01 │   1871 │     1 │ FW1    │ NA     │     1 │     5 │     1 │ … │
-    │ barrofr01 │   1871 │     1 │ BS1    │ NA     │    18 │    86 │    13 │ … │
-    │ …         │      … │     … │ …      │ …      │     … │     … │     … │ … │
-    └───────────┴────────┴───────┴────────┴────────┴───────┴───────┴───────┴───┘
+    >>> t = ibis.read_csv("path/to/data.csv")  # doctest: +SKIP
     """
     from ibis.config import _default_backend
 
@@ -950,26 +931,7 @@ def read_parquet(sources: str | Path | Sequence[str | Path], **kwargs: Any) -> i
     Examples
     --------
     >>> import ibis
-    >>> ibis.options.interactive = True
-    >>> t = ibis.examples.Batting_raw.fetch()
-    >>> t
-    ┏━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━┓
-    ┃ playerID  ┃ yearID ┃ stint ┃ teamID ┃ lgID   ┃ G     ┃ AB    ┃ R     ┃ … ┃
-    ┡━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━┩
-    │ string    │ int64  │ int64 │ string │ string │ int64 │ int64 │ int64 │ … │
-    ├───────────┼────────┼───────┼────────┼────────┼───────┼───────┼───────┼───┤
-    │ abercda01 │   1871 │     1 │ TRO    │ NA     │     1 │     4 │     0 │ … │
-    │ addybo01  │   1871 │     1 │ RC1    │ NA     │    25 │   118 │    30 │ … │
-    │ allisar01 │   1871 │     1 │ CL1    │ NA     │    29 │   137 │    28 │ … │
-    │ allisdo01 │   1871 │     1 │ WS3    │ NA     │    27 │   133 │    28 │ … │
-    │ ansonca01 │   1871 │     1 │ RC1    │ NA     │    25 │   120 │    29 │ … │
-    │ armstbo01 │   1871 │     1 │ FW1    │ NA     │    12 │    49 │     9 │ … │
-    │ barkeal01 │   1871 │     1 │ RC1    │ NA     │     1 │     4 │     0 │ … │
-    │ barnero01 │   1871 │     1 │ BS1    │ NA     │    31 │   157 │    66 │ … │
-    │ barrebi01 │   1871 │     1 │ FW1    │ NA     │     1 │     5 │     1 │ … │
-    │ barrofr01 │   1871 │     1 │ BS1    │ NA     │    18 │    86 │    13 │ … │
-    │ …         │      … │     … │ …      │ …      │     … │     … │     … │ … │
-    └───────────┴────────┴───────┴────────┴────────┴───────┴───────┴───────┴───┘
+    >>> t = ibis.read_parquet("path/to/data.parquet")  # doctest: +SKIP
     """
     from ibis.config import _default_backend
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -598,22 +598,16 @@ class Table(Expr, _FixedTextJupyterMixin):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.examples.starwars.fetch()
+        >>> t = ibis.examples.penguins.fetch()
         >>> t.columns
-        ['name',
-         'height',
-         'mass',
-         'hair_color',
-         'skin_color',
-         'eye_color',
-         'birth_year',
+        ['species',
+         'island',
+         'bill_length_mm',
+         'bill_depth_mm',
+         'flipper_length_mm',
+         'body_mass_g',
          'sex',
-         'gender',
-         'homeworld',
-         'species',
-         'films',
-         'vehicles',
-         'starships']
+         'year']
         """
         return list(self.schema().names)
 
@@ -629,23 +623,17 @@ class Table(Expr, _FixedTextJupyterMixin):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.examples.starwars.fetch()
+        >>> t = ibis.examples.penguins.fetch()
         >>> t.schema()
         ibis.Schema {
-          name        string
-          height      int64
-          mass        float64
-          hair_color  string
-          skin_color  string
-          eye_color   string
-          birth_year  float64
-          sex         string
-          gender      string
-          homeworld   string
-          species     string
-          films       string
-          vehicles    string
-          starships   string
+          species            string
+          island             string
+          bill_length_mm     float64
+          bill_depth_mm      float64
+          flipper_length_mm  int64
+          body_mass_g        int64
+          sex                string
+          year               int64
         }
         """
         return self.op().schema
@@ -2298,7 +2286,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.examples.penguins.fetch(table_name="penguins")
+        >>> t = ibis.examples.penguins.fetch()
         >>> t.info()
         ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━┓
         ┃ name              ┃ type    ┃ nullable ┃ nulls ┃ non_nulls ┃ null_frac ┃ … ┃
@@ -2752,7 +2740,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.examples.penguins.fetch(table_name="penguins")
+        >>> t = ibis.examples.penguins.fetch()
         >>> cached_penguins = t.mutate(computation="Heavy Computation").cache()
         >>> cached_penguins
         ┏━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━┓
@@ -2889,7 +2877,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         Simliarly for a different example dataset, we convert names to values
         but using a different selector and the default `values_to` value.
 
-        >>> world_bank_pop = ibis.examples.world_bank_pop_raw.fetch(header=1)
+        >>> world_bank_pop = ibis.examples.world_bank_pop_raw.fetch()
         >>> world_bank_pop.head()
         ┏━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━┓
         ┃ country ┃ indicator   ┃ 2000         ┃ 2001         ┃ 2002         ┃ … ┃


### PR DESCRIPTION
This changes the loading of examples data to use `pyarrow.csv`/`pyarrow.parquet` to read the local data files, and `Backend.create_table(..., temp=True)` to create a table in the backend with this data for *most* backends. This lets our examples data work with most of our backends, making it easier to demo/try out ibis on a specific backend.

Some backends (duckdb & polars) will continue to read from the source files directly. We do this because these backends are local *and* support creating tables from views of source files (avoiding the need to store the data in memory). Since we have a few larger example datasets (e.g. IMDB) we want to use the `read_csv`/`read_parquet` methods for these backends to reduce memory usage, and make working with these larger example datasets smoother.