### PR TITLE
chore(ci): list installed deps in backend tests

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -298,6 +298,9 @@ jobs:
         if: matrix.backend.additional_deps != null
         run: poetry run pip install "${{ join(matrix.backend.additional_deps, ' ') }}"
 
+      - name: show installed deps
+        run: poetry run pip list
+
       - name: "run parallel tests: ${{ matrix.backend.name }}"
         if: ${{ !matrix.backend.serial }}
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup


### PR DESCRIPTION
The backend tests do a `pip install` to update deps after the lockfile is installed. Debugging how this changes the installed deps can be tricky, so we add a `pip list` afterwards to show what's actually installed.