### PR TITLE
feat(bigquery): enable group_concat over windows

### DIFF
--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -177,6 +177,11 @@ class ExprTranslator:
         ops.CumeDist,
         ops.NTile,
     )
+    _unsupported_reductions = (
+        ops.ApproxMedian,
+        ops.GroupConcat,
+        ops.ApproxCountDistinct,
+    )
 
     def __init__(self, node, context, named=False, permit_subquery=False):
         self.node = node

--- a/ibis/backends/base/sql/registry/window.py
+++ b/ibis/backends/base/sql/registry/window.py
@@ -122,11 +122,7 @@ def format_window_frame(translator, func, frame):
 
 
 def window(translator, op):
-    _unsupported_reductions = (
-        ops.ApproxMedian,
-        ops.GroupConcat,
-        ops.ApproxCountDistinct,
-    )
+    _unsupported_reductions = translator._unsupported_reductions
 
     func = op.func.__window_op__
 

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -76,6 +76,8 @@ class BigQueryExprTranslator(sql_compiler.ExprTranslator):
         ops.Lead,
     )
 
+    _unsupported_reductions = (ops.ApproxMedian, ops.ApproxCountDistinct)
+
     def name(self, translated: str, name: str):
         # replace invalid characters in automatically generated names
         if self._valid_name_pattern.match(name) is None:

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -29,6 +29,11 @@ class ImpalaExprTranslator(ExprTranslator):
         ops.FirstValue,
         ops.LastValue,
     )
+    _unsupported_reductions = (
+        ops.ApproxMedian,
+        ops.ApproxCountDistinct,
+        ops.GroupConcat,
+    )
 
 
 rewrites = ImpalaExprTranslator.rewrites

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1458,3 +1458,35 @@ def test_grouped_case(backend, con):
     result = con.execute(expr)
     expected = pd.DataFrame({"key": [1, 2], "mx": [10, 20]})
     backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.notimpl(
+    ["datafusion", "mssql", "polars"], raises=com.OperationNotDefinedError
+)
+@pytest.mark.broken(
+    ["dask", "pandas"],
+    reason="Dask and Pandas do not windowize this operation correctly",
+    raises=AssertionError,
+)
+@pytest.mark.notyet(["clickhouse", "impala"], raises=com.UnsupportedOperationError)
+@pytest.mark.notyet(["druid", "trino", "snowflake"], raises=sa.exc.ProgrammingError)
+@pytest.mark.notyet("mysql", raises=sa.exc.NotSupportedError)
+@pytest.mark.notyet("oracle", raises=sa.exc.DatabaseError)
+@pytest.mark.notyet("pyspark", raises=PysparkAnalysisException)
+def test_group_concat_over_window(backend, con):
+    input_df = pd.DataFrame(
+        {
+            "s": ["a|b|c", "b|a|c", "b|b|b|c|a"],
+            "token": ["a", "b", "c"],
+            "pk": [1, 1, 2],
+        }
+    )
+    expected = input_df.assign(test=["a|b|c|b|a|c", "b|a|c", "b|b|b|c|a"])
+
+    table = ibis.memtable(input_df)
+    w = ibis.window(group_by="pk", preceding=0, following=None)
+    expr = table.mutate(test=table.s.group_concat(sep="|").over(w)).order_by("pk")
+
+    result = con.execute(expr)
+
+    backend.assert_frame_equal(result, expected)


### PR DESCRIPTION
This "just worked" once I removed `ops.GroupConcat` from the list of
unsupported reductions in the base sql window registry.

Fixes #6272