### PR TITLE
test(graphviz): make graphviz CLI optional for tests

### DIFF
--- a/ibis/tests/expr/conftest.py
+++ b/ibis/tests/expr/conftest.py
@@ -107,3 +107,14 @@ def pytest_pyfunc_call(pyfuncitem):
             len(markers) == 1
         ), f"More than one xfail_unsupported marker found on test {pyfuncitem}"
         pytest.xfail(reason=repr(e))
+
+
+@pytest.fixture
+def graphviz():
+    """A fixture to ensure the graphviz library and CLI are installed"""
+    graphviz = pytest.importorskip("graphviz")
+    try:
+        graphviz.version()
+    except graphviz.ExecutableNotFound:
+        pytest.skip("graphviz CLI not installed")
+    return graphviz

--- a/ibis/tests/expr/test_interactive.py
+++ b/ibis/tests/expr/test_interactive.py
@@ -32,7 +32,7 @@ def test_interactive_execute_on_repr(con):
     assert len(con.executed_queries) > 0
 
 
-def test_repr_png_is_none_in_interactive(con):
+def test_repr_png_is_none_in_interactive(con, graphviz):
     table = con.table('functional_alltypes')
 
     with config.option_context('interactive', True):

--- a/ibis/tests/expr/test_visualize.py
+++ b/ibis/tests/expr/test_visualize.py
@@ -95,11 +95,7 @@ def test_order_by():
     assert key(expr.op()) in graph.source
 
 
-@pytest.mark.skipif(
-    bool(os.environ.get('APPVEYOR', None)),
-    reason='Not sure what the prerequisites for running this on Windows are',
-)
-def test_optional_graphviz_repr(monkeypatch):
+def test_optional_graphviz_repr(monkeypatch, graphviz):
     monkeypatch.setattr(ibis.options, 'graphviz_repr', True)
 
     t = ibis.table([('a', 'int64'), ('b', 'string'), ('c', 'int32')])
@@ -149,7 +145,7 @@ def test_filter():
     assert "predicates[1]" in graph.source
 
 
-def test_html_escape(monkeypatch):
+def test_html_escape(monkeypatch, graphviz):
     monkeypatch.setattr(ibis.options, 'graphviz_repr', True)
     # Check that we correctly escape HTML <> characters in the graphviz
     # representation. If an error is thrown, _repr_png_ returns None.


### PR DESCRIPTION
Previously these tests would fail if `graphviz` or the corresponding CLI weren't installed.