### PR TITLE
refactor(datatypes): remove `value_type` parametrization of the `Interval` datatype

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -774,10 +774,7 @@ def interval(
     if not components:
         components.append((0, "s"))
 
-    intervals = [
-        literal(v, type=dt.Interval(u, value_type=literal(v).type()))
-        for v, u in components
-    ]
+    intervals = [literal(v, type=dt.Interval(u)) for v, u in components]
     return functools.reduce(operator.add, intervals)
 
 

--- a/ibis/expr/datatypes/cast.py
+++ b/ibis/expr/datatypes/cast.py
@@ -129,7 +129,7 @@ def can_cast_decimals(source: dt.Decimal, target: dt.Decimal, **kwargs) -> bool:
 
 @castable.register(dt.Interval, dt.Interval)
 def can_cast_intervals(source: dt.Interval, target: dt.Interval, **kwargs) -> bool:
-    return source.unit == target.unit and castable(source.value_type, target.value_type)
+    return source.unit == target.unit
 
 
 @castable.register(dt.Integer, dt.Boolean)
@@ -143,7 +143,7 @@ def can_cast_integer_to_boolean(
 def can_cast_integer_to_interval(
     source: dt.Integer, target: dt.Interval, **kwargs
 ) -> bool:
-    return castable(source, target.value_type)
+    return True
 
 
 @castable.register(dt.String, (dt.Date, dt.Time, dt.Timestamp))

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -703,18 +703,8 @@ class Interval(Parametric):
     unit: IntervalUnit = 's'
     """The time unit of the interval."""
 
-    value_type: Integer = Int32()
-    """The underlying type of the stored values."""
-
     scalar = "IntervalScalar"
     column = "IntervalColumn"
-
-    # TODO(kszucs): assert that the nullability if the value_type is equal
-    # to the interval's nullability
-
-    @property
-    def bounds(self):
-        return self.value_type.bounds
 
     @property
     def resolution(self):

--- a/ibis/expr/datatypes/parse.py
+++ b/ibis/expr/datatypes/parse.py
@@ -142,16 +142,12 @@ def parse(
         .combine_dict(dt.Timestamp)
     )
 
-    ty = parsy.forward_declaration()
-
-    angle_type = LANGLE.then(ty).skip(RANGLE)
-
     interval = spaceless_string("interval").then(
-        parsy.seq(
-            value_type=angle_type.optional(dt.int32), unit=parened_string.optional("s")
-        ).combine_dict(dt.Interval)
+        parsy.seq(unit=parened_string.optional("s")).combine_dict(dt.Interval)
     )
 
+    ty = parsy.forward_declaration()
+    angle_type = LANGLE.then(ty).skip(RANGLE)
     array = spaceless_string("array").then(angle_type).map(dt.Array)
 
     map = (

--- a/ibis/expr/datatypes/tests/test_cast.py
+++ b/ibis/expr/datatypes/tests/test_cast.py
@@ -20,7 +20,7 @@ import ibis.expr.datatypes as dt
         (dt.uint32, dt.float32),
         (dt.uint32, dt.float64),
         (dt.uint64, dt.int64),
-        (dt.Interval('s', dt.int16), dt.Interval('s', dt.int32)),
+        (dt.Interval('s'), dt.Interval('s')),
     ],
 )
 def test_implicitly_castable_primitives(source, target):
@@ -38,7 +38,7 @@ def test_implicitly_castable_primitives(source, target):
         (dt.Decimal(12, 2), dt.int32),
         (dt.timestamp, dt.boolean),
         (dt.boolean, dt.interval),
-        (dt.Interval('s', dt.int64), dt.Interval('s', dt.int16)),
+        (dt.Interval('s'), dt.Interval('ns')),
     ],
 )
 def test_implicitly_uncastable_primitives(source, target):

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -98,7 +98,6 @@ class FooStruct:
     ob: dt.Timestamp('UTC', 6)
     p: dt.interval
     pa: dt.Interval('s')
-    pb: dt.Interval('s', dt.int16)
     q: dt.decimal
     qa: dt.Decimal(12, 2)
     r: dt.Array(dt.int16)
@@ -125,7 +124,6 @@ class BarStruct:
     ob: dt.Timestamp['UTC', 6]  # noqa: F821
     p: dt.Interval
     pa: dt.Interval['s']
-    pb: dt.Interval['s', dt.Int16]
     q: dt.Decimal
     qa: dt.Decimal[12, 2]
     r: dt.Array[dt.Int16]
@@ -153,7 +151,6 @@ baz_struct = dt.Struct(
         'ob': dt.Timestamp('UTC', 6),
         'p': dt.interval,
         'pa': dt.Interval('s'),
-        'pb': dt.Interval('s', dt.int16),
         'q': dt.decimal,
         'qa': dt.Decimal(12, 2),
         'r': dt.Array(dt.int16),
@@ -288,7 +285,6 @@ class FooDataClass:
         (dt.Timestamp['UTC'], dt.Timestamp(timezone='UTC')),
         (dt.Timestamp['UTC', 6], dt.Timestamp(timezone='UTC', scale=6)),
         (dt.Interval['s'], dt.Interval('s')),
-        (dt.Interval['s', dt.Int16], dt.Interval('s', dt.Int16())),
         (dt.Decimal[12, 2], dt.Decimal(12, 2)),
         (
             dt.Struct['a' : dt.Int16, 'b' : dt.Int32],

--- a/ibis/expr/datatypes/tests/test_parse.py
+++ b/ibis/expr/datatypes/tests/test_parse.py
@@ -220,18 +220,7 @@ def test_parse_timestamp_with_scale_no_tz(scale):
 )
 def test_parse_interval(unit):
     definition = f"interval('{unit}')"
-    assert dt.Interval(unit, dt.int32) == dt.dtype(definition)
-
-    definition = f"interval<uint16>('{unit}')"
-    assert dt.Interval(unit, dt.uint16) == dt.dtype(definition)
-
-    definition = f"interval<int64>('{unit}')"
-    assert dt.Interval(unit, dt.int64) == dt.dtype(definition)
-
-
-def test_parse_interval_with_invalid_value_type():
-    with pytest.raises(TypeError):
-        dt.dtype("interval<float>('s')")
+    assert dt.Interval(unit) == dt.dtype(definition)
 
 
 @pytest.mark.parametrize('unit', ['X', 'unsupported'])

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -10,7 +10,6 @@ from ibis import util
 from ibis.common.annotations import attribute
 from ibis.common.temporal import DateUnit, IntervalUnit, TimestampUnit, TimeUnit
 from ibis.expr.operations.core import Binary, Unary, Value
-from ibis.expr.operations.generic import Cast
 from ibis.expr.operations.logical import Between
 
 
@@ -295,23 +294,14 @@ class ToIntervalUnit(Value):
 class IntervalBinary(Binary):
     @attribute.default
     def output_dtype(self):
-        integer_args = [
-            Cast(arg, to=arg.output_dtype.value_type)
-            if arg.output_dtype.is_interval()
-            else arg
-            for arg in (self.left, self.right)
-        ]
-
         interval_unit_args = [
             arg.output_dtype.unit
             for arg in (self.left, self.right)
             if arg.output_dtype.is_interval()
         ]
-
-        value_dtype = rlz._promote_integral_binop(integer_args, self.op)
         unit = rlz._promote_interval_resolution(interval_unit_args)
 
-        return self.left.output_dtype.copy(value_type=value_dtype, unit=unit)
+        return self.left.output_dtype.copy(unit=unit)
 
 
 @public
@@ -351,7 +341,7 @@ class IntervalFromInteger(Value):
 
     @attribute.default
     def output_dtype(self):
-        return dt.Interval(self.unit, value_type=self.arg.output_dtype)
+        return dt.Interval(self.unit)
 
     @property
     def resolution(self):

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -30,7 +30,7 @@ def test_interval_function_integers():
 
     # unit is used if provided
     res = ibis.interval(1, "D")
-    sol = ibis.literal(1, type=dt.Interval("D", value_type=ibis.literal(1).type()))
+    sol = ibis.literal(1, type=dt.Interval("D"))
     assert_equal(res, sol)
 
 
@@ -486,7 +486,7 @@ def test_timestamp_arithmetics():
     for expr in [ts2 - ts1, ts1 - ts2]:
         assert isinstance(expr, ir.IntervalScalar)
         assert isinstance(expr.op(), ops.TimestampDiff)
-        assert expr.type() == dt.Interval('s', dt.int32)
+        assert expr.type() == dt.Interval('s')
 
     for expr in [ts1 - i1, ts2 - i1]:
         assert isinstance(expr, ir.TimestampScalar)
@@ -505,7 +505,7 @@ def test_date_arithmetics():
     for expr in [d1 - d2, d2 - d1]:
         assert isinstance(expr, ir.IntervalScalar)
         assert isinstance(expr.op(), ops.DateDiff)
-        assert expr.type() == dt.Interval('D', dt.int32)
+        assert expr.type() == dt.Interval('D')
 
     for expr in [d1 - i1, d2 - i1]:
         assert isinstance(expr, ir.DateScalar)
@@ -524,7 +524,7 @@ def test_time_arithmetics():
     for expr in [t1 - t2, t2 - t1]:
         assert isinstance(expr, ir.IntervalScalar)
         assert isinstance(expr.op(), ops.TimeDiff)
-        assert expr.type() == dt.Interval('s', dt.int32)
+        assert expr.type() == dt.Interval('s')
 
     for expr in [t1 - i1, t2 - i1]:
         assert isinstance(expr, ir.TimeScalar)
@@ -599,7 +599,6 @@ def test_integer_to_interval(column, unit, table):
     c = table[column]
     i = c.to_interval(unit)
     assert isinstance(i, ir.IntervalColumn)
-    assert i.type().value_type == c.type()
     assert i.type().unit == IntervalUnit(unit)
 
 

--- a/ibis/tests/expr/test_window_frames.py
+++ b/ibis/tests/expr/test_window_frames.py
@@ -111,12 +111,12 @@ def test_window_builder_range():
 
     w9 = w0.range(-ibis.interval(days=1), 10)
     assert w9.start == ops.WindowBoundary(ibis.interval(days=1), preceding=True)
-    value = ibis.literal(10).cast("interval<int8>('D')")
+    value = ibis.literal(10).cast("interval('D')")
     assert w9.end == ops.WindowBoundary(value, preceding=False)
     assert w9.how == 'range'
 
     w10 = w0.range(5, ibis.interval(seconds=11))
-    value = ibis.literal(5).cast("interval<int8>('s')")
+    value = ibis.literal(5).cast("interval('s')")
     assert w10.start == ops.WindowBoundary(value, preceding=False)
     assert w10.end == ops.WindowBoundary(ibis.interval(seconds=11), preceding=False)
     assert w10.how == 'range'
@@ -157,12 +157,12 @@ def test_window_builder_between():
 
     w7 = w0.between(-ibis.interval(days=1), 10)
     assert w7.start == ops.WindowBoundary(ibis.interval(days=1), preceding=True)
-    value = ibis.literal(10).cast("interval<int8>('D')")
+    value = ibis.literal(10).cast("interval('D')")
     assert w7.end == ops.WindowBoundary(value, preceding=False)
     assert w7.how == 'range'
 
     w8 = w0.between(5, ibis.interval(seconds=11))
-    value = ibis.literal(5).cast("interval<int8>('s')")
+    value = ibis.literal(5).cast("interval('s')")
     assert w8.start == ops.WindowBoundary(value, preceding=False)
     assert w8.end == ops.WindowBoundary(ibis.interval(seconds=11), preceding=False)
     assert w8.how == 'range'

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -54,9 +54,7 @@ timestamp_dtype = st.builds(
     dt.Timestamp, timezone=st.none() | tzst.timezones().map(str), nullable=nullable
 )
 interval_unit = st.sampled_from(list(IntervalUnit))
-interval_dtype = st.builds(
-    dt.Interval, unit=interval_unit, value_type=integer_dtypes, nullable=nullable
-)
+interval_dtype = st.builds(dt.Interval, unit=interval_unit, nullable=nullable)
 temporal_dtypes = st.one_of(
     date_dtype,
     time_dtype,


### PR DESCRIPTION
none of the backends support the definition of the underlying phyisical type

BREAKING CHANGE: `dt.Interval.value_type` attribute is removed
