### PR TITLE
fix(snowflake): use `convert_timezone` for timezone conversion instead of invalid postgres `AT TIME ZONE` syntax

### DIFF
--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -74,3 +74,13 @@ def test_repeated_memtable_registration(simple_con, mocker):
 
     # assert that we called _register_in_memory_table exactly n times
     assert spy.call_count == n
+
+
+def test_timestamp_tz_column(simple_con):
+    t = simple_con.create_table(
+        ibis.util.gen_name("snowflake_timestamp_tz_column"),
+        schema=ibis.schema({"ts": "string"}),
+        temp=True,
+    ).mutate(ts=lambda t: t.ts.to_timestamp("YYYY-MM-DD HH24-MI-SS"))
+    expr = t.ts
+    assert expr.execute().empty


### PR DESCRIPTION
Partially addresses #6292 by using the correct syntax for timezone conversion.