### PR TITLE
refactor(bigquery): align datatype conversions with the new convention

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -21,7 +21,7 @@ from ibis.backends.base.sql.registry import (
     reduction,
     unary,
 )
-from ibis.backends.bigquery.datatypes import ibis_type_to_bigquery_type
+from ibis.backends.bigquery.datatypes import dtype_to_bigquery
 from ibis.common.temporal import DateUnit, IntervalUnit, TimeUnit
 
 
@@ -65,7 +65,7 @@ def bigquery_cast_floating_to_integer(compiled_arg, from_, to):
 @bigquery_cast.register(str, dt.DataType, dt.DataType)
 def bigquery_cast_generate(compiled_arg, from_, to):
     """Cast to desired type."""
-    sql_type = ibis_type_to_bigquery_type(to)
+    sql_type = dtype_to_bigquery(to)
     return f"CAST({compiled_arg} AS {sql_type})"
 
 
@@ -251,7 +251,7 @@ def _literal(translator, op):
             prefix = "-" * value.is_signed()
             return f"CAST('{prefix}inf' AS FLOAT64)"
         else:
-            return f"{ibis_type_to_bigquery_type(dtype)} '{value}'"
+            return f"{dtype_to_bigquery(dtype)} '{value}'"
     elif dtype.is_uuid():
         return translator.translate(ops.Literal(str(value), dtype=dt.str))
 
@@ -444,7 +444,7 @@ def compiles_string_to_timestamp(translator, op):
 
 
 def compiles_floor(t, op):
-    bigquery_type = ibis_type_to_bigquery_type(op.output_dtype)
+    bigquery_type = dtype_to_bigquery(op.output_dtype)
     arg = op.arg
     return f"CAST(FLOOR({t.translate(arg)}) AS {bigquery_type})"
 

--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -18,7 +18,7 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.selectors as s
 from ibis.backends.bigquery import EXTERNAL_DATA_SCOPES, Backend
-from ibis.backends.bigquery.datatypes import ibis_type_to_bigquery_type
+from ibis.backends.bigquery.datatypes import dtype_to_bigquery
 from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero, UnorderedComparator
 from ibis.backends.tests.data import json_types, non_null_array_types, struct_types, win
@@ -38,13 +38,13 @@ def ibis_type_to_bq_field(typ: dt.DataType) -> Mapping[str, Any]:
 
 @ibis_type_to_bq_field.register(dt.DataType)
 def _(typ: dt.DataType) -> Mapping[str, Any]:
-    return {"field_type": ibis_type_to_bigquery_type(typ)}
+    return {"field_type": dtype_to_bigquery(typ)}
 
 
 @ibis_type_to_bq_field.register(dt.Array)
 def _(typ: dt.Array) -> Mapping[str, Any]:
     return {
-        "field_type": ibis_type_to_bigquery_type(typ.value_type),
+        "field_type": dtype_to_bigquery(typ.value_type),
         "mode": "REPEATED",
     }
 

--- a/ibis/backends/bigquery/udf/__init__.py
+++ b/ibis/backends/bigquery/udf/__init__.py
@@ -7,7 +7,7 @@ from typing import Callable, Iterable, Literal, Mapping
 
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
-from ibis.backends.bigquery.datatypes import ibis_type_to_bigquery_type, spread_type
+from ibis.backends.bigquery.datatypes import dtype_to_bigquery, spread_type
 from ibis.backends.bigquery.operations import BigQueryUDFNode
 from ibis.backends.bigquery.udf.core import PythonToJavaScriptTranslator
 from ibis.udf.validate import validate_output_type
@@ -286,11 +286,11 @@ return {f.__name__}({args});\
         bigquery_signature = ", ".join(
             "{name} {type}".format(
                 name=name,
-                type=ibis_type_to_bigquery_type(dt.dtype(type_)),
+                type=dtype_to_bigquery(dt.dtype(type_)),
             )
             for name, type_ in params.items()
         )
-        return_type = ibis_type_to_bigquery_type(dt.dtype(output_type))
+        return_type = dtype_to_bigquery(dt.dtype(output_type))
         libraries_opts = (
             f"\nOPTIONS (\n    library={list(libraries)!r}\n)" if libraries else ""
         )
@@ -369,7 +369,7 @@ RETURNS {return_type}
             for name, type_ in params.items()
         }
 
-        return_type = ibis_type_to_bigquery_type(dt.dtype(output_type))
+        return_type = dtype_to_bigquery(dt.dtype(output_type))
 
         udf_node_fields["output_dtype"] = output_type
         udf_node_fields["output_shape"] = rlz.shape_like("args")
@@ -389,7 +389,7 @@ RETURNS {return_type}
                 name=name,
                 type="ANY TYPE"
                 if type_ == "ANY TYPE"
-                else ibis_type_to_bigquery_type(dt.dtype(type_)),
+                else dtype_to_bigquery(dt.dtype(type_)),
             )
             for name, type_ in params.items()
         )

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -207,7 +207,7 @@ def test_rename_table(con, temp_table, temp_table_orig, new_schema):
     assert temp_table in con.list_tables()
 
 
-@mark.notimpl(["bigquery", "datafusion", "polars", "druid"])
+@mark.notimpl(["datafusion", "polars", "druid"])
 @mark.never(["impala", "pyspark"], reason="No non-nullable datatypes")
 @mark.notyet(
     ["trino"], reason="trino doesn't support NOT NULL in its in-memory catalog"

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1905,7 +1905,7 @@ def test_timestamp_literal(con, backend):
 @pytest.mark.notimpl(
     ['bigquery'],
     "BigQuery does not support timestamps with timezones other than 'UTC'",
-    raises=com.UnsupportedOperationError,
+    raises=TypeError,
 )
 @pytest.mark.notimpl(
     ["druid"],


### PR DESCRIPTION
Refactor the bigquery backends to *not* use the overloaded `sch.schema` and `dt.dtype` functions but rather bigquery specific conversion functions.