### PR TITLE
docs: update copyright year and add a period (minor docs nits)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,4 +53,4 @@ ORDER BY t1.year DESC
 - **Performant**: Execute queries as fast as the database engine itself.
 - **Interactive**: Explore data in a notebook or REPL.
 - **Extensible**: Add new operations, optimizations, and custom APIs.
-- **Free and open-source**: licensed under Apache 2.0, [available on Github](https://github.com/ibis-project/ibis/blob/master/README.md)
+- **Free and open-source**: licensed under Apache 2.0, [available on Github](https://github.com/ibis-project/ibis/blob/master/README.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,4 +164,4 @@ extra:
       icon: :material-cancel:{ .cancel }
       description: Unlikely to ever be supported or no upstream support.
 
-copyright: "Copyright &copy; 2014-2022"
+copyright: "Copyright &copy; Ibis Maintainers"


### PR DESCRIPTION
- update copyright notice to 2023
- add period for consistency

This PR makes very minor edits on the homepage to update the copyright year and add a period at the end of a sentence in the bullet points for consistency

I'm not sure if there's a way to automatically use the current year in the `mkdocs.yml`?
