### PR TITLE
feat(sql): allow any SQL dialect accepted by sqlglot in `Table.sql` and `Backend.sql`

### DIFF
--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -109,8 +109,8 @@ def __getattr__(name: str) -> BaseBackend:
     proxy.name = name
     proxy._from_url = backend._from_url
     proxy._to_sql = backend._to_sql
-    if hasattr(backend, "_sqlglot_dialect"):
-        proxy._sqlglot_dialect = backend._sqlglot_dialect
+    if (dialect := getattr(backend, "_sqlglot_dialect", None)) is not None:
+        proxy._sqlglot_dialect = dialect
     # Add any additional methods that should be exposed at the top level
     for name in getattr(backend, "_top_level_methods", ()):
         setattr(proxy, name, getattr(backend, name))

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -182,10 +182,10 @@ def _column_batches_to_dataframe(names, batches):
 
 class Backend(BaseSQLBackend):
     name = 'impala'
-    # not 100% accurate, but very close
-    _sqlglot_dialect = "hive"
-    _top_level_methods = ("hdfs_connect",)
     compiler = ImpalaCompiler
+
+    _sqlglot_dialect = "hive"  # not 100% accurate, but very close
+    _top_level_methods = ("hdfs_connect",)
 
     class Options(ibis.config.Config):
         """Impala specific options.

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -15,8 +15,9 @@ from ibis.backends.mssql.datatypes import _type_from_result_set_info
 class Backend(BaseAlchemyBackend):
     name = "mssql"
     compiler = MsSqlCompiler
-    _sqlglot_dialect = "tsql"
     supports_create_or_replace = False
+
+    _sqlglot_dialect = "tsql"
 
     def do_connect(
         self,

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -108,7 +108,8 @@ class PySparkCompiler(Compiler):
 
 class Backend(BaseSQLBackend):
     compiler = PySparkCompiler
-    name = 'pyspark'
+    name = "pyspark"
+    _sqlglot_dialect = "spark"
 
     class Options(ibis.config.Config):
         """PySpark options.

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -1,9 +1,11 @@
 import pandas as pd
 import pytest
+import sqlglot as sg
 from pytest import param
 
 import ibis
 from ibis import _
+from ibis.backends.base import _IBIS_TO_SQLGLOT_DIALECT, _get_backend_names
 
 table_dot_sql_notimpl = pytest.mark.notimpl(
     ["bigquery", "clickhouse", "impala", "druid"]
@@ -23,6 +25,11 @@ pytestmark = [pytest.mark.xdist_group("dot_sql")]
 _NAMES = {
     "bigquery": "ibis_gbq_testing.functional_alltypes",
 }
+
+try:
+    from clickhouse_connect.driver.exceptions import DatabaseError
+except ImportError:
+    DatabaseError = None
 
 
 @dot_sql_notimpl
@@ -214,3 +221,59 @@ def test_dot_sql_reuse_alias_with_different_types(backend, alltypes, df):
     expected2 = df.bigint_col.rename("x")
     backend.assert_series_equal(foo1.x.execute(), expected1)
     backend.assert_series_equal(foo2.x.execute(), expected2)
+
+
+_NO_SQLGLOT_DIALECT = {"pandas", "dask", "datafusion", "polars", "druid"}
+no_sqlglot_dialect = sorted(
+    param(backend, marks=pytest.mark.xfail) for backend in _NO_SQLGLOT_DIALECT
+)
+
+
+@pytest.mark.parametrize(
+    "dialect",
+    [
+        *sorted(_get_backend_names() - _NO_SQLGLOT_DIALECT),
+        *no_sqlglot_dialect,
+    ],
+)
+@pytest.mark.broken(["clickhouse"], raises=DatabaseError)
+@pytest.mark.notyet(["trino"], raises=NotImplementedError)
+@table_dot_sql_notimpl
+@dot_sql_notimpl
+@dot_sql_notyet
+@dot_sql_never
+def test_table_dot_sql_transpile(backend, alltypes, dialect, df):
+    name = "foo2"
+    foo = alltypes.select(x=_.int_col + 1).alias(name)
+    expr = sg.select("x").from_(sg.table(name, quoted=True))
+    dialect = _IBIS_TO_SQLGLOT_DIALECT.get(dialect, dialect)
+    sqlstr = expr.sql(dialect=dialect, pretty=True)
+    dot_sql_expr = foo.sql(sqlstr, dialect=dialect)
+    result = dot_sql_expr.execute()
+    expected = df.int_col.add(1).rename("x")
+    backend.assert_series_equal(result.x, expected)
+
+
+@pytest.mark.parametrize(
+    "dialect",
+    [
+        *sorted(_get_backend_names() - {"pyspark", *_NO_SQLGLOT_DIALECT}),
+        *no_sqlglot_dialect,
+    ],
+)
+@pytest.mark.notyet(["druid"], raises=ValueError)
+@pytest.mark.notyet(["snowflake", "bigquery"])
+@pytest.mark.notyet(
+    ["oracle"], strict=False, reason="only works with backends that quote everything"
+)
+@dot_sql_notimpl
+@dot_sql_never
+def test_con_dot_sql_transpile(backend, con, dialect, df):
+    t = sg.table("functional_alltypes")
+    foo = sg.select(sg.alias(sg.column("int_col") + 1, "x")).from_(t)
+    dialect = _IBIS_TO_SQLGLOT_DIALECT.get(dialect, dialect)
+    sqlstr = foo.sql(dialect=dialect, pretty=True)
+    expr = con.sql(sqlstr, dialect=dialect)
+    result = expr.execute()
+    expected = df.int_col.add(1).rename("x")
+    backend.assert_series_equal(result.x, expected)


### PR DESCRIPTION
This PR adds support for passing SQL with any sqlglot-supported dialect to the `con.sql` and `Table.sql` methods.