### PR TITLE
fix: add issue write permission to assign.yml

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,4 +1,6 @@
 name: Assign Issue
+permissions:
+  issues: write
 on:
   issue_comment:
     types:


### PR DESCRIPTION
workflow is failing for `/take` in comments, e.g.: https://github.com/ibis-project/ibis/actions/runs/5084258325

this simply adds the write issue permission, hopefully fixing

not 100% sure this is the problem
