### PR TITLE
feat(polars): implement `.sql` methods

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -128,7 +128,7 @@ backend_type_mapping = {
 }
 
 
-@mark.notimpl(["datafusion", "polars", "druid"])
+@mark.notimpl(["datafusion", "druid"])
 def test_create_table_from_schema(con, new_schema, temp_table):
     new_table = con.create_table(temp_table, schema=new_schema)
     backend_mapping = backend_type_mapping.get(con.name, {})


### PR DESCRIPTION
This PR implements `con.sql` and `Table.sql` support for the polars backends. ~A lot of functionality~ subqueries are not implemented yet (and we generate a lot of them), but the various `test_dot_sql.py` tests should start to `XPASS` once support is implemented upstream.