### PR TITLE
test(clickhouse): avoid running tests that depend on `ibis_testing` existing

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -480,7 +480,7 @@ def test_unsigned_integer_type(alchemy_con, alchemy_temp_table):
     "url",
     [
         param(
-            "clickhouse://default@localhost:8123/ibis_testing",
+            "clickhouse://default@localhost:8123/default",
             marks=mark.clickhouse,
             id="clickhouse",
         ),
@@ -495,12 +495,12 @@ def test_unsigned_integer_type(alchemy_con, alchemy_temp_table):
             id="datafusion",
         ),
         param(
-            "impala://localhost:21050/ibis_testing",
+            "impala://localhost:21050/default",
             marks=mark.impala,
             id="impala",
         ),
         param(
-            "mysql://ibis:ibis@localhost:3306/ibis_testing",
+            "mysql://ibis:ibis@localhost:3306",
             marks=mark.mysql,
             id="mysql",
         ),
@@ -510,12 +510,12 @@ def test_unsigned_integer_type(alchemy_con, alchemy_temp_table):
             id="pandas",
         ),
         param(
-            "postgres://postgres:postgres@localhost:5432/ibis_testing",
+            "postgres://postgres:postgres@localhost:5432",
             marks=mark.postgres,
             id="postgres",
         ),
         param(
-            "postgresql://postgres:postgres@localhost:5432/ibis_testing",
+            "postgresql://postgres:postgres@localhost:5432/postgres",
             marks=mark.postgres,
             id="postgresql",
         ),
@@ -992,17 +992,17 @@ def test_set_backend_name(name, monkeypatch):
     "url",
     [
         param(
-            "clickhouse://default@localhost:8123/ibis_testing",
+            "clickhouse://default@localhost:8123",
             marks=mark.clickhouse,
             id="clickhouse",
         ),
         param(
-            "mysql://ibis:ibis@localhost:3306/ibis_testing",
+            "mysql://ibis:ibis@localhost:3306",
             marks=mark.mysql,
             id="mysql",
         ),
         param(
-            "postgres://postgres:postgres@localhost:5432/ibis_testing",
+            "postgres://postgres:postgres@localhost:5432",
             marks=mark.postgres,
             id="postgres",
         ),


### PR DESCRIPTION
This PR fixes an issue with a ClickHouse backend test that assumes the `ibis_testing` database exists when in fact it might not. Test failure observed in the wild here: https://github.com/ibis-project/ibis/actions/runs/5093340617/jobs/9155829965?pr=6298. There may be similar issues with other backends. We can fix those as they arise.