### PR TITLE
fix(postgres): ensure that `alias` method overwrites view even if types are different

### DIFF
--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -258,4 +258,5 @@ ORDER BY attnum"""
     def _get_temp_view_definition(
         self, name: str, definition: sa.sql.compiler.Compiled
     ) -> str:
-        yield f"CREATE OR REPLACE TEMPORARY VIEW {name} AS {definition}"
+        yield f"DROP VIEW IF EXISTS {name}"
+        yield f"CREATE TEMPORARY VIEW {name} AS {definition}"

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -201,3 +201,16 @@ def test_dot_sql_alias_with_params(backend, alltypes, df):
     result = x.execute()
     expected = df.string_col.add(" abc").rename("x")
     backend.assert_series_equal(result.x, expected)
+
+
+@table_dot_sql_notimpl
+@dot_sql_notimpl
+@dot_sql_never
+@pytest.mark.notimpl(["trino", "oracle"])
+def test_dot_sql_reuse_alias_with_different_types(backend, alltypes, df):
+    foo1 = alltypes.select(x=alltypes.string_col).alias("foo")
+    foo2 = alltypes.select(x=alltypes.bigint_col).alias("foo")
+    expected1 = df.string_col.rename("x")
+    expected2 = df.bigint_col.rename("x")
+    backend.assert_series_equal(foo1.x.execute(), expected1)
+    backend.assert_series_equal(foo2.x.execute(), expected2)


### PR DESCRIPTION
This PR fixes an issue with our use of `CREATE OR REPLACE VIEW` in the postgres backend, which requires that a replacement for an existing view match the schema of the existing view.