### PR TITLE
docs(file support): add badge and docstrings for read_* methods

### DIFF
--- a/docs/backends/BigQuery.md
+++ b/docs/backends/BigQuery.md
@@ -1,7 +1,10 @@
 ---
 backend_name: Google BigQuery
 backend_url: https://cloud.google.com/bigquery
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 ---
+
+{% include 'backends/badges.md' %}
 
 ## Install
 
@@ -22,7 +25,7 @@ Install `ibis` and dependencies for the BigQuery backend:
 
 {% endfor %}
 
-## Usage
+## Connect
 
 ### `ibis.bigquery.connect`
 

--- a/docs/backends/ClickHouse.md
+++ b/docs/backends/ClickHouse.md
@@ -2,7 +2,79 @@
 backend_name: ClickHouse
 backend_url: https://clickhouse.yandex/
 backend_module: clickhouse
-backend_param_style: connection parameters
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+## Install
+
+Install `ibis` and dependencies for the ClickHouse backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[clickhouse]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-clickhouse
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.clickhouse.connect`
+
+```python
+con = ibis.clickhouse.connect(
+    user="username",
+    password="password",
+    host="hostname",
+)
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.clickhouse.connect` is a thin wrapper around [`ibis.backends.clickhouse.Backend.do_connect`][ibis.backends.clickhouse.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.clickhouse.Backend.do_connect
+    options:
+      heading_level: 4
+      show_docstring_examples: false
+<!-- prettier-ignore-end -->
+
+### `ibis.connect` URL format
+
+In addition to `ibis.clickhouse.connect`, you can also connect to ClickHouse by
+passing a properly formatted ClickHouse connection URL to `ibis.connect`
+
+```python
+con = ibis.connect(f"clickhouse://{user}:{password}@{host}:{port}?secure={secure}")
+```
+
+## ClickHouse playground
+
+ClickHouse provides a free playground with several datasets that you can connect to using `ibis`:
+
+```python
+con = ibis.clickhouse.connect(
+    host="play.clickhouse.com",
+    secure=True,
+    user="play",
+    password="clickhouse",
+)
+```
+
+or
+
+```python
+con = ibis.connect("clickhouse://play:clickhouse@play.clickhouse.com:443?secure=True")
+```

--- a/docs/backends/Datafusion.md
+++ b/docs/backends/Datafusion.md
@@ -2,8 +2,68 @@
 backend_name: Datafusion
 backend_url: https://arrow.apache.org/datafusion/
 backend_module: datafusion
-backend_param_style: a dictionary of paths
 version_added: "2.1"
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
+imports: ["CSV", "Parquet"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+## Install
+
+Install `ibis` and dependencies for the Apache Datafusion backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[datafusion]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-datafusion
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.datafusion.connect`
+
+```python
+con = ibis.datafusion.connect()
+```
+
+```python
+con = ibis.datafusion.connect(
+    config={"table1": "path/to/file.parquet", "table2": "path/to/file.csv"}
+)
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.datafusion.connect` is a thin wrapper around [`ibis.backends.datafusion.Backend.do_connect`][ibis.backends.datafusion.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.datafusion.Backend.do_connect
+    options:
+      heading_level: 4
+      show_docstring_examples: false
+<!-- prettier-ignore-end -->
+
+## File Support
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.datafusion.Backend.read_csv
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.datafusion.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+<!-- prettier-ignore-end -->

--- a/docs/backends/Druid.md
+++ b/docs/backends/Druid.md
@@ -2,10 +2,64 @@
 backend_name: Druid
 backend_url: https://druid.apache.org/
 backend_module: druid
-backend_param_style: a SQLAlchemy connection string
-backend_connection_example: ibis.connect("druid://localhost:8082/druid/v2/sql")
-is_experimental: true
-version_added: "5.0"
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+!!! experimental "Introduced in v5.0"
+
+    The Druid backend is experimental and is subject to backwards incompatible changes.
+
+## Install
+
+Install `ibis` and dependencies for the Druid backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[druid]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-druid
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.druid.connect`
+
+```python
+con = ibis.druid.connect(
+    host="hostname",
+    port=8082,
+    database="druid/v2/sql",
+)
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.druid.connect` is a thin wrapper around [`ibis.backends.druid.Backend.do_connect`][ibis.backends.druid.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.druid.Backend.do_connect
+    options:
+      heading_level: 4
+      show_docstring_examples: false
+<!-- prettier-ignore-end -->
+
+### `ibis.connect` URL format
+
+In addition to `ibis.druid.connect`, you can also connect to Druid by
+passing a properly formatted Druid connection URL to `ibis.connect`
+
+```python
+con = ibis.connect("druid://localhost:8082/druid/v2/sql")
+```

--- a/docs/backends/DuckDB.md
+++ b/docs/backends/DuckDB.md
@@ -63,6 +63,21 @@ con = ibis.duckdb.connect("mydb.duckdb")  # (1)
       heading_level: 4
 <!-- prettier-ignore-end -->
 
+### `ibis.connect` URL format
+
+In addition to `ibis.duckdb.connect`, you can also connect to DuckDB by
+passing a properly formatted DuckDB connection URL to `ibis.connect`
+
+```python
+con = ibis.connect("duckdb:///path/to/local/file")
+```
+
+```python
+con = ibis.connect("duckdb://") # (1)
+```
+
+1. ephemeral, in-memory database
+
 ## File Support
 
 <!-- prettier-ignore-start -->

--- a/docs/backends/DuckDB.md
+++ b/docs/backends/DuckDB.md
@@ -2,17 +2,93 @@
 backend_name: DuckDB
 backend_url: https://duckdb.org/
 backend_module: duckdb
-backend_param_style: a path to a DuckDB database
-backend_connection_example: ibis.duckdb.connect("path/to/my.duckdb")
-version_added: "3.0"
-intro: |
-  !!! danger "`duckdb` >= 0.5.0 requires `duckdb-engine` >= 0.6.2"
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
+imports: ["CSV", "Parquet", "JSON", "PyArrow", "Pandas", "SQLite", "Postgres"]
+---
+
+{% include 'backends/badges.md' %}
+
+??? danger "`duckdb` >= 0.5.0 requires `duckdb-engine` >= 0.6.2"
 
       If you encounter problems when using `duckdb` >= **0.5.0** you may need to
       upgrade `duckdb-engine` to at least version **0.6.2**.
 
       See [this issue](https://github.com/ibis-project/ibis/issues/4503) for
       more details.
----
 
-{% include 'backends/template.md' %}
+## Install
+
+Install `ibis` and dependencies for the DuckDB backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[duckdb]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-duckdb
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.duckdb.connect`
+
+```python
+con = ibis.duckdb.connect()  # (1)
+```
+
+1. Use an ephemeral, in-memory database
+
+```python
+con = ibis.duckdb.connect("mydb.duckdb")  # (1)
+```
+
+1. Connect to, or create, a local DuckDB file
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.duckdb.connect` is a thin wrapper around [`ibis.backends.duckdb.Backend.do_connect`][ibis.backends.duckdb.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.duckdb.Backend.do_connect
+    options:
+      heading_level: 4
+<!-- prettier-ignore-end -->
+
+## File Support
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.duckdb.Backend.read_csv
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.duckdb.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.duckdb.Backend.read_json
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.duckdb.Backend.read_in_memory
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.duckdb.Backend.read_sqlite
+    options:
+      heading_level: 4
+      show_docstring_examples: false
+      show_docstring_returns: false
+::: ibis.backends.duckdb.Backend.read_postgres
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+<!-- prettier-ignore-end -->

--- a/docs/backends/MSSQL.md
+++ b/docs/backends/MSSQL.md
@@ -4,6 +4,60 @@ backend_url: https://www.microsoft.com/en-us/evalcenter/evaluate-sql-server-2022
 backend_module: mssql
 backend_param_style: connection parameters
 version_added: "4.0"
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+## Install
+
+Install `ibis` and dependencies for the MSSQL backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[mssql]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-mssql
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.mssql.connect`
+
+```python
+con = ibis.mssql.connect(
+    user="username",
+    password="password",
+    host="hostname",
+)
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.mssql.connect` is a thin wrapper around [`ibis.backends.mssql.Backend.do_connect`][ibis.backends.mssql.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.mssql.Backend.do_connect
+    options:
+      heading_level: 4
+      show_docstring_examples: false
+<!-- prettier-ignore-end -->
+
+### `ibis.connect` URL format
+
+In addition to `ibis.mssql.connect`, you can also connect to MSSQL by
+passing a properly formatted MSSQL connection URL to `ibis.connect`
+
+```python
+con = ibis.connect(f"mssql://{user}:{password}@{host}:{port}")
+```

--- a/docs/backends/MySQL.md
+++ b/docs/backends/MySQL.md
@@ -3,6 +3,62 @@ backend_name: MySQL
 backend_url: https://www.mysql.com/
 backend_module: mysql
 backend_param_style: a SQLAlchemy-style URI
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+## Install
+
+Install `ibis` and dependencies for the MySQL backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[mysql]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-mysql
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.mysql.connect`
+
+```python
+con = ibis.mysql.connect(
+    user="username",
+    password="password",
+    host="hostname",
+    port=3306,
+    database="database",
+)
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.mysql.connect` is a thin wrapper around [`ibis.backends.mysql.Backend.do_connect`][ibis.backends.mysql.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.mysql.Backend.do_connect
+    options:
+      heading_level: 4
+      show_docstring_examples: false
+<!-- prettier-ignore-end -->
+
+### `ibis.connect` URL format
+
+In addition to `ibis.mysql.connect`, you can also connect to MySQL by
+passing a properly formatted MySQL connection URL to `ibis.connect`
+
+```python
+con = ibis.connect(f"mysql://{user}:{password}@{host}:{port}/{database}")
+```

--- a/docs/backends/Oracle.md
+++ b/docs/backends/Oracle.md
@@ -6,6 +6,66 @@ backend_param_style: a SQLAlchemy connection string
 backend_connection_example: ibis.connect("oracle://user:pass@host:port/service_name")
 is_experimental: true
 version_added: "6.0"
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+!!! experimental "Introduced in v6.0"
+
+    The Oracle backend is experimental and is subject to backwards incompatible changes.
+
+## Install
+
+Install `ibis` and dependencies for the Oracle backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[oracle]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-oracle
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.oracle.connect`
+
+```python
+con = ibis.oracle.connect(
+    user="username",
+    password="password",
+    host="hostname",
+    port=1521,
+    database="database",
+)
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.oracle.connect` is a thin wrapper around [`ibis.backends.oracle.Backend.do_connect`][ibis.backends.oracle.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.oracle.Backend.do_connect
+    options:
+      heading_level: 4
+      show_docstring_examples: false
+<!-- prettier-ignore-end -->
+
+### `ibis.connect` URL format
+
+In addition to `ibis.oracle.connect`, you can also connect to Oracle by
+passing a properly formatted Oracle connection URL to `ibis.connect`
+
+```python
+con = ibis.connect(f"oracle://{user}:{password}@{host}:{port}/{database}")
+```

--- a/docs/backends/Polars.md
+++ b/docs/backends/Polars.md
@@ -2,9 +2,66 @@
 backend_name: Polars
 backend_url: https://pola-rs.github.io/polars-book/user-guide/index.html
 backend_module: polars
-backend_param_style: connection parameters
 is_experimental: true
 version_added: "4.0"
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
+imports: ["CSV", "Parquet", "Pandas"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+!!! experimental "Introduced in v4.0"
+
+    The Polars backend is experimental and is subject to backwards incompatible changes.
+
+## Install
+
+Install `ibis` and dependencies for the Polars backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[polars]'
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-polars
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.polars.connect`
+
+```python
+con = ibis.polars.connect()
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.polars.connect` is a thin wrapper around [`ibis.backends.polars.Backend.do_connect`][ibis.backends.polars.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.polars.Backend.do_connect
+    options:
+      heading_level: 4
+<!-- prettier-ignore-end -->
+
+## File Support
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.polars.Backend.read_csv
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.polars.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+<!-- prettier-ignore-end -->

--- a/docs/backends/PostgreSQL.md
+++ b/docs/backends/PostgreSQL.md
@@ -3,6 +3,62 @@ backend_name: PostgreSQL
 backend_url: https://www.postgresql.org/
 backend_module: postgres
 backend_param_style: a SQLAlchemy-style URI
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+## Install
+
+Install `ibis` and dependencies for the Postgres backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[postgres]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-postgres
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.postgres.connect`
+
+```python
+con = ibis.postgres.connect(
+    user="username",
+    password="password",
+    host="hostname",
+    port=5432,
+    database="database",
+)
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.postgres.connect` is a thin wrapper around [`ibis.backends.postgres.Backend.do_connect`][ibis.backends.postgres.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.postgres.Backend.do_connect
+    options:
+      heading_level: 4
+      show_docstring_examples: false
+<!-- prettier-ignore-end -->
+
+### `ibis.connect` URL format
+
+In addition to `ibis.postgres.connect`, you can also connect to Postgres by
+passing a properly formatted Postgres connection URL to `ibis.connect`
+
+```python
+con = ibis.connect(f"postgres://{user}:{password}@{host}:{port}/{database}")
+```

--- a/docs/backends/PySpark.md
+++ b/docs/backends/PySpark.md
@@ -3,6 +3,64 @@ backend_name: PySpark
 backend_url: https://spark.apache.org/docs/latest/api/python/
 backend_module: pyspark
 backend_param_style: PySpark things
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
+imports: ["CSV", "Parquet"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+## Install
+
+Install `ibis` and dependencies for the PySpark backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[pyspark]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-pyspark
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.pyspark.connect`
+
+```python
+con = ibis.pyspark.connect(session=session)
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.pyspark.connect` is a thin wrapper around [`ibis.backends.pyspark.Backend.do_connect`][ibis.backends.pyspark.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+<!-- prettier-ignore-start -->
+!!! info "The `pyspark` backend does not create `SparkSession` objects, you must create a `SparkSession` and pass that to `ibis.pyspark.connect`."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.pyspark.Backend.do_connect
+    options:
+      heading_level: 4
+<!-- prettier-ignore-end -->
+
+## File Support
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.pyspark.Backend.read_csv
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.pyspark.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+<!-- prettier-ignore-end -->

--- a/docs/backends/SQLite.md
+++ b/docs/backends/SQLite.md
@@ -2,40 +2,69 @@
 backend_name: SQLite
 backend_url: https://www.sqlite.org/
 backend_module: sqlite
-backend_param_style: a path to a SQLite database
-exclude_backend_api: true
+imports: ["CSV", "Parquet", "JSON", "PyArrow", "Pandas", "SQLite", "Postgres"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
 
-## Backend API
+## Install
+
+Install `ibis` and dependencies for the SQLite backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[sqlite]`
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-sqlite
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.sqlite.connect`
+
+```python
+con = ibis.sqlite.connect()  # (1)
+```
+
+1. Use an ephemeral, in-memory database
+
+```python
+con = ibis.sqlite.connect("mydb.sqlite")  # (1)
+```
+
+1. Connect to, or create, a local SQLite file
 
 <!-- prettier-ignore-start -->
-::: ibis.backends.sqlite.Backend
-    options:
-      heading_level: 3
-      inherited_members: true
-      members:
-        - add_operation
-        - attach
-        - compile
-        - connect
-        - create_database
-        - create_table
-        - create_view
-        - database
-        - drop_table
-        - drop_view
-        - execute
-        - exists_database
-        - exists_table
-        - explain
-        - insert
-        - list_databases
-        - list_tables
-        - load_data
-        - raw_sql
-        - schema
-        - table
-        - verify
+!!! info "`ibis.sqlite.connect` is a thin wrapper around [`ibis.backends.sqlite.Backend.do_connect`][ibis.backends.sqlite.Backend.do_connect]."
 <!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.sqlite.Backend.do_connect
+    options:
+      heading_level: 4
+<!-- prettier-ignore-end -->
+
+### `ibis.connect` URL format
+
+In addition to `ibis.sqlite.connect`, you can also connect to SQLite by
+passing a properly formatted SQLite connection URL to `ibis.connect`
+
+```python
+con = ibis.connect("sqlite:///path/to/local/file")
+```
+
+```python
+con = ibis.connect("sqlite://") # (1)
+```
+
+1. ephemeral, in-memory database

--- a/docs/backends/Snowflake.md
+++ b/docs/backends/Snowflake.md
@@ -1,7 +1,10 @@
 ---
 backend_name: Snowflake
 backend_url: https://snowflake.com/
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 ---
+
+{% include 'backends/badges.md' %}
 
 !!! experimental "Introduced in v4.0"
 
@@ -26,7 +29,7 @@ Install `ibis` and dependencies for the Snowflake backend:
 
 {% endfor %}
 
-## Usage
+## Connect
 
 ### `ibis.snowflake.connect`
 
@@ -42,6 +45,8 @@ con = ibis.snowflake.connect(
 <!-- prettier-ignore-start -->
 !!! info "`ibis.snowflake.connect` is a thin wrapper around [`ibis.backends.snowflake.Backend.do_connect`][ibis.backends.snowflake.Backend.do_connect]."
 <!-- prettier-ignore-end -->
+
+### Connection Parameters
 
 <!-- prettier-ignore-start -->
 ::: ibis.backends.snowflake.Backend.do_connect

--- a/docs/backends/Trino.md
+++ b/docs/backends/Trino.md
@@ -2,9 +2,56 @@
 backend_name: Trino
 backend_url: https://trino.io
 backend_module: trino
-backend_param_style: a SQLAlchemy connection string
-is_experimental: true
-version_added: "4.0"
+exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 ---
 
-{% include 'backends/template.md' %}
+{% include 'backends/badges.md' %}
+
+!!! experimental "Introduced in v4.0"
+
+    The Trino backend is experimental and is subject to backwards incompatible changes.
+
+## Install
+
+Install `ibis` and dependencies for the Trino backend:
+
+=== "pip"
+
+    ```sh
+    pip install 'ibis-framework[trino]'
+    ```
+
+{% for mgr in ["conda", "mamba"] %}
+=== "{{ mgr }}"
+
+    ```sh
+    {{ mgr }} install -c conda-forge ibis-trino
+    ```
+
+{% endfor %}
+
+## Connect
+
+### `ibis.trino.connect`
+
+```python
+con = ibis.trino.connect(
+    user="user",
+    password="password",
+    port=8080,
+    database="database",
+    schema="default",
+)
+```
+
+<!-- prettier-ignore-start -->
+!!! info "`ibis.trino.connect` is a thin wrapper around [`ibis.backends.trino.Backend.do_connect`][ibis.backends.trino.Backend.do_connect]."
+<!-- prettier-ignore-end -->
+
+### Connection Parameters
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.trino.Backend.do_connect
+    options:
+      heading_level: 4
+<!-- prettier-ignore-end -->

--- a/docs/backends/badges.md
+++ b/docs/backends/badges.md
@@ -1,0 +1,3 @@
+{% if imports %} ![filebadge](https://img.shields.io/badge/Reads-{{ "%20|%20".join(imports) }}-blue?style=flat-square) {% endif %}
+
+{% if exports %} ![exportbadge](https://img.shields.io/badge/Exports-{{ "%20|%20".join(exports) }}-orange?style=flat-square) {% endif %}

--- a/docs/how_to/duckdb_register.md
+++ b/docs/how_to/duckdb_register.md
@@ -1,7 +1,7 @@
 # How to Use `register` to load external data files with the DuckDB backend
 
 <!-- prettier-ignore-start -->
-Here we use the [`register`][ibis.backends.duckdb.Backend.register] method to load external data files and join them.
+Here we use the `register` method to load external data files and join them.
 <!-- prettier-ignore-end -->
 
 We're going to download one month of [NYC Taxi

--- a/docs/stylesheets/code_select.css
+++ b/docs/stylesheets/code_select.css
@@ -1,0 +1,7 @@
+.language-pycon .gp, .language-pycon .go { /* Generic.Prompt, Generic.Output */
+    user-select: none;
+}
+
+.language-console .gp, .language-console .go { /* Generic.Prompt, Generic.Output */
+    user-select: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ edit_uri: ""
 repo_url: https://github.com/ibis-project/ibis
 extra_css:
   - stylesheets/extra.css
+  - stylesheets/code_select.css
 extra_javascript:
   - javascripts/mathjax.js
   - https://polyfill.io/v3/polyfill.min.js?features=es6
@@ -16,6 +17,7 @@ theme:
     - navigation.tabs.sticky
     - content.code.annotate
     - content.tabs.link
+    - content.code.copy
     - header.autohide
     - navigation.indexes
     - navigation.instant
@@ -120,7 +122,9 @@ markdown_extensions:
         custom_icons:
           - docs/static/icons
   - pymdownx.details
-  - pymdownx.highlight
+  - pymdownx.highlight:
+      use_pygments: true
+      pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.magiclink:
       provider: github

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ plugins:
   - exclude:
       glob:
         - backends/template.md
+        - backends/badges.md
         - backends/*_support_matrix.csv
         - backends/app/*
         - CONTRIBUTING.md


### PR DESCRIPTION
xref #5923 

Adding non-templated backend doc pages for Datafusion, DuckDB, Polars, and PySpark.

What do y'all think of having a few badges at the top of each backend page?  I added the ones here for the backends that have some notion of local file support.  It could also get crowded very quickly.