### PR TITLE
feat: implement try_cast for a few backends

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -22,6 +22,10 @@ class substr(GenericFunction):
     inherit_cache = True
 
 
+class try_cast(GenericFunction):
+    pass
+
+
 def variance_reduction(func_name, suffix=None):
     suffix = suffix or {'sample': '_samp', 'pop': '_pop'}
 

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -85,6 +85,11 @@ def _cast(op, **kw):
     return result
 
 
+@translate_val.register(ops.TryCast)
+def _try_cast(op, **kw):
+    return f"accurateCastOrNull({translate_val(op.arg, **kw)}, '{serialize(op.to)}')"
+
+
 @translate_val.register(ops.Between)
 def _between(op, **kw):
     arg = translate_val(op.arg, **kw)

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -90,6 +90,17 @@ class Cast(Value):
 
 
 @public
+class TryCast(Value):
+    """Explicitly try cast value to a specific data type."""
+
+    arg = rlz.any
+    to = rlz.datatype
+
+    output_shape = rlz.shape_like("arg")
+    output_dtype = property(attrgetter("to"))
+
+
+@public
 class TypeOf(Unary):
     output_dtype = dt.string
 


### PR DESCRIPTION
closes #6009 

this is an attempt at impelementing try_cast in a few backends. PR needs some feedback, particularly around:

- varying behavior between try_cast (and cast) between backends
- how to test properly

as you can see in the tests, I started branching based off the connection. some of the differences in behavior were unexepected -- for instance, in clickhouse cast seems to behave like try_cast by default (e.g. `ibis.literal("a").cast("date").execute` returns `NaT` of type `pandas._libs.tslibs.nattype.NatType`). also in clickhouse, it seems there is no interval type (see message inline with the test)

some other observed behavior that could be confusing:

<details>
```ipython
[ins] In [2]: import ibis

[ins] In [3]: ibis.set_backend("duckdb")

[ins] In [4]: type(ibis.literal("a").try_cast("string").execute())
Out[4]: str

[ins] In [5]: type(ibis.literal("a").try_cast("bignumeric").execute())
---------------------------------------------------------------------------
ParserException                           Traceback (most recent call last)
File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1905, in Connection._execute_context(self, dialect, constructor, statement, parameters, execution_options, *args, **kw)
   1904     if not evt_handled:
-> 1905         self.dialect.do_execute(
   1906             cursor, statement, parameters, context
   1907         )
   1909 if self._has_events or self.engine._has_events:

File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/engine/default.py:736, in DefaultDialect.do_execute(self, cursor, statement, parameters, context)
    735 def do_execute(self, cursor, statement, parameters, context=None):
--> 736     cursor.execute(statement, parameters)

File ~/repos/ibis/venv/lib/python3.11/site-packages/duckdb_engine/__init__.py:142, in ConnectionWrapper.execute(self, statement, parameters, context)
    141     else:
--> 142         self.__c.execute(statement, parameters)
    143 except RuntimeError as e:

ParserException: Parser Error: Width must be between 1 and 38!

The above exception was the direct cause of the following exception:

ProgrammingError                          Traceback (most recent call last)
Cell In[5], line 1
----> 1 type(ibis.literal("a").try_cast("bignumeric").execute())

File ~/repos/ibis/ibis/expr/types/core.py:296, in Expr.execute(self, limit, timecontext, params, **kwargs)
    269 def execute(
    270     self,
    271     limit: int | str | None = 'default',
   (...)
    274     **kwargs: Any,
    275 ):
    276     """Execute an expression against its backend if one exists.
    277
    278     Parameters
   (...)
    294         Keyword arguments
    295     """
--> 296     return self._find_backend(use_default=True).execute(
    297         self, limit=limit, timecontext=timecontext, params=params, **kwargs
    298     )

File ~/repos/ibis/ibis/backends/base/sql/__init__.py:245, in BaseSQLBackend.execute(self, expr, params, limit, **kwargs)
    241 schema = self.ast_schema(query_ast, **kwargs)
    243 self._run_pre_execute_hooks(expr)
--> 245 with self._safe_raw_sql(sql, **kwargs) as cursor:
    246     result = self.fetch_from_cursor(cursor, schema)
    248 if hasattr(getattr(query_ast, 'dml', query_ast), 'result_handler'):

File ~/.local/share/rtx/installs/python/3.11.3/lib/python3.11/contextlib.py:137, in _GeneratorContextManager.__enter__(self)
    135 del self.args, self.kwds, self.func
    136 try:
--> 137     return next(self.gen)
    138 except StopIteration:
    139     raise RuntimeError("generator didn't yield") from None

File ~/repos/ibis/ibis/backends/base/sql/alchemy/__init__.py:164, in BaseAlchemyBackend._safe_raw_sql(self, *args, **kwargs)
    161 @contextlib.contextmanager
    162 def _safe_raw_sql(self, *args, **kwargs):
    163     with self.begin() as con:
--> 164         yield con.execute(*args, **kwargs)

File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1385, in Connection.execute(self, statement, *multiparams, **params)
   1381     util.raise_(
   1382         exc.ObjectNotExecutableError(statement), replace_context=err
   1383     )
   1384 else:
-> 1385     return meth(self, multiparams, params, _EMPTY_EXECUTION_OPTS)

File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/sql/elements.py:334, in ClauseElement._execute_on_connection(self, connection, multiparams, params, execution_options, _force)
    330 def _execute_on_connection(
    331     self, connection, multiparams, params, execution_options, _force=False
    332 ):
    333     if _force or self.supports_execution:
--> 334         return connection._execute_clauseelement(
    335             self, multiparams, params, execution_options
    336         )
    337     else:
    338         raise exc.ObjectNotExecutableError(self)

File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1577, in Connection._execute_clauseelement(self, elem, multiparams, params, execution_options)
   1565 compiled_cache = execution_options.get(
   1566     "compiled_cache", self.engine._compiled_cache
   1567 )
   1569 compiled_sql, extracted_params, cache_hit = elem._compile_w_cache(
   1570     dialect=dialect,
   1571     compiled_cache=compiled_cache,
   (...)
   1575     linting=self.dialect.compiler_linting | compiler.WARN_LINTING,
   1576 )
-> 1577 ret = self._execute_context(
   1578     dialect,
   1579     dialect.execution_ctx_cls._init_compiled,
   1580     compiled_sql,
   1581     distilled_params,
   1582     execution_options,
   1583     compiled_sql,
   1584     distilled_params,
   1585     elem,
   1586     extracted_params,
   1587     cache_hit=cache_hit,
   1588 )
   1589 if has_events:
   1590     self.dispatch.after_execute(
   1591         self,
   1592         elem,
   (...)
   1596         ret,
   1597     )

File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1948, in Connection._execute_context(self, dialect, constructor, statement, parameters, execution_options, *args, **kw)
   1945             branched.close()
   1947 except BaseException as e:
-> 1948     self._handle_dbapi_exception(
   1949         e, statement, parameters, cursor, context
   1950     )
   1952 return result

File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py:2129, in Connection._handle_dbapi_exception(self, e, statement, parameters, cursor, context)
   2127     util.raise_(newraise, with_traceback=exc_info[2], from_=e)
   2128 elif should_wrap:
-> 2129     util.raise_(
   2130         sqlalchemy_exception, with_traceback=exc_info[2], from_=e
   2131     )
   2132 else:
   2133     util.raise_(exc_info[1], with_traceback=exc_info[2])

File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/util/compat.py:211, in raise_(***failed resolving arguments***)
    208     exception.__cause__ = replace_context
    210 try:
--> 211     raise exception
    212 finally:
    213     # credit to
    214     # https://cosmicpercolator.com/2016/01/13/exception-leaks-in-python-2-and-3/
    215     # as the __traceback__ object creates a cycle
    216     del exception, replace_context, from_, with_traceback

File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/engine/base.py:1905, in Connection._execute_context(self, dialect, constructor, statement, parameters, execution_options, *args, **kw)
   1903                 break
   1904     if not evt_handled:
-> 1905         self.dialect.do_execute(
   1906             cursor, statement, parameters, context
   1907         )
   1909 if self._has_events or self.engine._has_events:
   1910     self.dispatch.after_cursor_execute(
   1911         self,
   1912         cursor,
   (...)
   1916         context.executemany,
   1917     )

File ~/repos/ibis/venv/lib/python3.11/site-packages/sqlalchemy/engine/default.py:736, in DefaultDialect.do_execute(self, cursor, statement, parameters, context)
    735 def do_execute(self, cursor, statement, parameters, context=None):
--> 736     cursor.execute(statement, parameters)

File ~/repos/ibis/venv/lib/python3.11/site-packages/duckdb_engine/__init__.py:142, in ConnectionWrapper.execute(self, statement, parameters, context)
    140         self.__c.execute(statement)
    141     else:
--> 142         self.__c.execute(statement, parameters)
    143 except RuntimeError as e:
    144     if e.args[0].startswith("Not implemented Error"):

ProgrammingError: (duckdb.ParserException) Parser Error: Width must be between 1 and 38!
[SQL: SELECT TRY_CAST(? AS NUMERIC(76, 38)) AS "TryCast('a')"]
[parameters: ('a',)]
(Background on this error at: https://sqlalche.me/e/14/f405)

[ins] In [6]: type(ibis.literal("0").try_cast("timestamp").execute())
Out[6]: pandas._libs.tslibs.nattype.NaTType

[ins] In [7]: ibis.set_backend("polars")

[ins] In [8]: type(ibis.literal("0").try_cast("timestamp").execute())
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
Cell In[8], line 1
----> 1 type(ibis.literal("0").try_cast("timestamp").execute())

File ~/repos/ibis/ibis/expr/types/core.py:296, in Expr.execute(self, limit, timecontext, params, **kwargs)
    269 def execute(
    270     self,
    271     limit: int | str | None = 'default',
   (...)
    274     **kwargs: Any,
    275 ):
    276     """Execute an expression against its backend if one exists.
    277
    278     Parameters
   (...)
    294         Keyword arguments
    295     """
--> 296     return self._find_backend(use_default=True).execute(
    297         self, limit=limit, timecontext=timecontext, params=params, **kwargs
    298     )

File ~/repos/ibis/ibis/backends/polars/__init__.py:310, in Backend.execute(self, expr, params, limit, **kwargs)
    303 def execute(
    304     self,
    305     expr: ir.Expr,
   (...)
    308     **kwargs: Any,
    309 ):
--> 310     lf = self.compile(expr, params=params, **kwargs)
    311     if limit == "default":
    312         limit = ibis.options.sql.default_limit

File ~/repos/ibis/ibis/backends/polars/__init__.py:299, in Backend.compile(self, expr, params, **_)
    295         return translate(node)
    296     else:
    297         # doesn't have any _tables associated so create projection
    298         # based off of an empty table
--> 299         return pl.DataFrame().lazy().select(translate(node))
    300 else:
    301     raise com.IbisError(f"Cannot compile expression of type: {type(expr)}")

File ~/.local/share/rtx/installs/python/3.11.3/lib/python3.11/functools.py:909, in singledispatch.<locals>.wrapper(*args, **kw)
    905 if not args:
    906     raise TypeError(f'{funcname} requires at least '
    907                     '1 positional argument')
--> 909 return dispatch(args[0].__class__)(*args, **kw)

File ~/repos/ibis/ibis/backends/polars/compiler.py:124, in try_cast(op)
    122 @translate.register(ops.TryCast)
    123 def try_cast(op):
--> 124     return _cast(op, strict=False)

File ~/repos/ibis/ibis/backends/polars/compiler.py:143, in _cast(op, strict)
    141 elif to.is_timestamp():
    142     if not strict:
--> 143         raise NotImplementedError(f"Unsupported try_cast to type: {to!r}")
    145     time_zone = to.timezone
    146     time_unit = _TIMESTAMP_SCALE_TO_UNITS.get(to.scale, "us")

NotImplementedError: Unsupported try_cast to type: Timestamp(timezone=None, scale=None, nullable=True)

[ins] In [9]: type(ibis.literal("a").try_cast("bignumeric").execute())
---------------------------------------------------------------------------
ArrowErrorException                       Traceback (most recent call last)
Cell In[9], line 1
----> 1 type(ibis.literal("a").try_cast("bignumeric").execute())

File ~/repos/ibis/ibis/expr/types/core.py:296, in Expr.execute(self, limit, timecontext, params, **kwargs)
    269 def execute(
    270     self,
    271     limit: int | str | None = 'default',
   (...)
    274     **kwargs: Any,
    275 ):
    276     """Execute an expression against its backend if one exists.
    277
    278     Parameters
   (...)
    294         Keyword arguments
    295     """
--> 296     return self._find_backend(use_default=True).execute(
    297         self, limit=limit, timecontext=timecontext, params=params, **kwargs
    298     )

File ~/repos/ibis/ibis/backends/polars/__init__.py:316, in Backend.execute(self, expr, params, limit, **kwargs)
    314     df = lf.fetch(limit)
    315 else:
--> 316     df = lf.collect()
    318 if isinstance(expr, ir.Table):
    319     return df.to_pandas()

File ~/repos/ibis/venv/lib/python3.11/site-packages/polars/lazyframe/frame.py:1602, in LazyFrame.collect(self, type_coercion, predicate_pushdown, projection_pushdown, simplify_expression, no_optimization, slice_pushdown, common_subplan_elimination, streaming)
   1591     common_subplan_elimination = False
   1593 ldf = self._ldf.optimization_toggle(
   1594     type_coercion,
   1595     predicate_pushdown,
   (...)
   1600     streaming,
   1601 )
-> 1602 return wrap_df(ldf.collect())

ArrowErrorException: NotYetImplemented("Casting from LargeUtf8 to Decimal(76, 38) not supported")

[ins] In [10]: type(ibis.literal("a").try_cast("int").execute())
Out[10]: numpy.float64

[ins] In [11]: type(ibis.literal("a").try_cast("float").execute())
Out[11]: numpy.float64

[ins] In [12]: ibis.literal("a").try_cast("float").execute()
Out[12]: nan
```
</details>
