### PR TITLE
chore(versioning): use poetry dynamic versioning as build backend

### DIFF
--- a/nix/ibis.nix
+++ b/nix/ibis.nix
@@ -25,6 +25,8 @@ poetry2nix.mkPoetryApplication rec {
   preferWheels = true;
   __darwinAllowLocalNetworking = true;
 
+  POETRY_DYNAMIC_VERSIONING_BYPASS = "1";
+
   buildInputs = [ graphviz-nox sqlite ];
   checkInputs = buildInputs;
   nativeCheckInputs = checkInputs;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -500,4 +500,4 @@ pattern = '^(?P<base>\d+(\.\d+)*)'
 
 [build-system]
 requires = ["poetry-core>=1.1.0", "poetry-dynamic-versioning"]
-build-backend = "poetry.core.masonry.api"
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
This should, hopefully, enable more detailed versions when installing from git / github.

Fixes #6346 