### PR TITLE
chore(testing-data): use a specific to allow reliable checkouts in the past

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -21,7 +21,7 @@ in
     name = "ibis-testing-data";
     owner = "ibis-project";
     repo = "testing-data";
-    rev = "master";
+    rev = "2b3968deaa1a28791b2901dbbcc9bfd3d2f23e9b";
     sha256 = "sha256-q1b5IcOl5oIFXP7/P5RufncjHEVrWp4NjoU2uo/BE9U=";
   };
 


### PR DESCRIPTION
This PR sets the ibis-testing-data commit hash to the specific commit of the `master` branch so that in the future when devs need to checkout a past version of ibis, this derivation is still valid. Without this, if `master` changes, the derivation will produce a different output hash and fail to build.