### PR TITLE
docs(backends): fix typo in pip install command

### DIFF
--- a/docs/backends/BigQuery.md
+++ b/docs/backends/BigQuery.md
@@ -13,7 +13,7 @@ Install `ibis` and dependencies for the BigQuery backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[bigquery]`
+    pip install 'ibis-framework[bigquery]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/ClickHouse.md
+++ b/docs/backends/ClickHouse.md
@@ -14,7 +14,7 @@ Install `ibis` and dependencies for the ClickHouse backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[clickhouse]`
+    pip install 'ibis-framework[clickhouse]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/Datafusion.md
+++ b/docs/backends/Datafusion.md
@@ -16,7 +16,7 @@ Install `ibis` and dependencies for the Apache Datafusion backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[datafusion]`
+    pip install 'ibis-framework[datafusion]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/Druid.md
+++ b/docs/backends/Druid.md
@@ -18,7 +18,7 @@ Install `ibis` and dependencies for the Druid backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[druid]`
+    pip install 'ibis-framework[druid]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/DuckDB.md
+++ b/docs/backends/DuckDB.md
@@ -23,7 +23,7 @@ Install `ibis` and dependencies for the DuckDB backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[duckdb]`
+    pip install 'ibis-framework[duckdb]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/MSSQL.md
+++ b/docs/backends/MSSQL.md
@@ -16,7 +16,7 @@ Install `ibis` and dependencies for the MSSQL backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[mssql]`
+    pip install 'ibis-framework[mssql]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/MySQL.md
+++ b/docs/backends/MySQL.md
@@ -15,7 +15,7 @@ Install `ibis` and dependencies for the MySQL backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[mysql]`
+    pip install 'ibis-framework[mysql]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/Oracle.md
+++ b/docs/backends/Oracle.md
@@ -22,7 +22,7 @@ Install `ibis` and dependencies for the Oracle backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[oracle]`
+    pip install 'ibis-framework[oracle]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/PostgreSQL.md
+++ b/docs/backends/PostgreSQL.md
@@ -15,7 +15,7 @@ Install `ibis` and dependencies for the Postgres backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[postgres]`
+    pip install 'ibis-framework[postgres]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/PySpark.md
+++ b/docs/backends/PySpark.md
@@ -16,7 +16,7 @@ Install `ibis` and dependencies for the PySpark backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[pyspark]`
+    pip install 'ibis-framework[pyspark]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}

--- a/docs/backends/SQLite.md
+++ b/docs/backends/SQLite.md
@@ -14,7 +14,7 @@ Install `ibis` and dependencies for the SQLite backend:
 === "pip"
 
     ```sh
-    pip install 'ibis-framework[sqlite]`
+    pip install 'ibis-framework[sqlite]'
     ```
 
 {% for mgr in ["conda", "mamba"] %}


### PR DESCRIPTION
Hi,

I'm not sure if PRs like this are welcome or not, feel free to ignore if not. While installing ibis with a duckdb backend I had an issue using the provided command [here](https://ibis-project.org/backends/DuckDB/): `` pip install 'ibis-framework[duckdb]` ``, the closing tilde is wrong. I found the same in a lot of the other backend documentation, so I changed it for all of them.