### PR TITLE
build(nix): replace `rsync` with `ln`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,15 +56,13 @@
         mariadb-client
         # pyspark
         openjdk17_headless
-        # postgres
+        # postgres client
         postgresql
-        # sqlite
+        # sqlite with readline
         sqlite-interactive
       ];
       shellHook = ''
-        ${pkgs.rsync}/bin/rsync \
-          --chmod=Du+rwx,Fu+rw --archive --delete \
-          "${pkgs.ibisTestingData}/" "$PWD/ci/ibis-testing-data"
+        ln -sf "${pkgs.ibisTestingData}" "$PWD/ci/ibis-testing-data"
 
         # necessary for mkdocs
         export PYTHONPATH=''${PWD}''${PYTHONPATH:+:}''${PYTHONPATH}

--- a/nix/ibis.nix
+++ b/nix/ibis.nix
@@ -4,7 +4,6 @@
 , gitignoreSource
 , graphviz-nox
 , sqlite
-, rsync
 , ibisTestingData
 }:
 let
@@ -37,9 +36,7 @@ poetry2nix.mkPoetryApplication rec {
     HOME="$(mktemp -d)"
     export HOME
 
-    ${rsync}/bin/rsync \
-      --chmod=Du+rwx,Fu+rw --archive --delete \
-      "${ibisTestingData}/" $PWD/ci/ibis-testing-data
+    ln -s "${ibisTestingData}" $PWD/ci/ibis-testing-data
   '';
 
   checkPhase = ''

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -91,7 +91,7 @@ in
     runtimeInputs = [
       (
         mkPoetryEnv {
-          python = pkgs.python311;
+          python = pkgs.python3;
           groups = [ ];
           extras = [ ];
         }


### PR DESCRIPTION
This PR removes the local rsync-ing of data from the nix store, which was done to allow writing to the data directory which we do not do anymore. Instead of `rsync`, a symlink directly to the nix store is created.