### PR TITLE
fix(pandas, dask): allow overlapping non-predicate columns in asof join

### DIFF
--- a/ibis/backends/dask/execution/join.py
+++ b/ibis/backends/dask/execution/join.py
@@ -10,7 +10,6 @@ from ibis.backends.dask.execution import constants
 from ibis.backends.pandas.execution.join import (
     _compute_join_column,
     _extract_predicate_names,
-    _validate_columns,
 )
 
 
@@ -23,10 +22,8 @@ from ibis.backends.pandas.execution.join import (
     tuple,
 )
 def execute_asof_join(op, left, right, by, tolerance, predicates, **kwargs):
-    overlapping_columns = frozenset(left.columns) & frozenset(right.columns)
     left_on, right_on = _extract_predicate_names(predicates)
     left_by, right_by = _extract_predicate_names(by)
-    _validate_columns(overlapping_columns, left_on, right_on, left_by, right_by)
 
     assert 0 <= len(left_on) <= 1, f"len(left_on) == {len(left_on)}"
     assert 0 <= len(right_on) <= 1, f"len(right_on) == {len(right_on)}"
@@ -45,6 +42,7 @@ def execute_asof_join(op, left, right, by, tolerance, predicates, **kwargs):
         left_by=left_by or None,
         right_by=right_by or None,
         tolerance=tolerance,
+        suffixes=constants.JOIN_SUFFIXES,
     )
 
 

--- a/ibis/backends/pandas/execution/join.py
+++ b/ibis/backends/pandas/execution/join.py
@@ -127,10 +127,8 @@ def execute_join(op, left, right, predicates, **kwargs):
     tuple,
 )
 def execute_asof_join(op, left, right, by, tolerance, predicates, **kwargs):
-    overlapping_columns = frozenset(left.columns) & frozenset(right.columns)
     left_on, right_on = _extract_predicate_names(predicates)
     left_by, right_by = _extract_predicate_names(by)
-    _validate_columns(overlapping_columns, left_on, right_on, left_by, right_by)
 
     return pd.merge_asof(
         left=left,
@@ -140,6 +138,7 @@ def execute_asof_join(op, left, right, by, tolerance, predicates, **kwargs):
         left_by=left_by or None,
         right_by=right_by or None,
         tolerance=tolerance,
+        suffixes=constants.JOIN_SUFFIXES,
     )
 
 
@@ -154,15 +153,3 @@ def _extract_predicate_names(predicates):
         lefts.append(left_name)
         rights.append(right_name)
     return lefts, rights
-
-
-def _validate_columns(orig_columns, *key_lists):
-    overlapping_columns = orig_columns.difference(
-        item for sublist in key_lists for item in sublist
-    )
-    if overlapping_columns:
-        raise ValueError(
-            'left and right DataFrame columns overlap on {} in a join. '
-            'Please specify the columns you want to select from the join, '
-            'e.g., join[left.column1, right.column2, ...]'.format(overlapping_columns)
-        )

--- a/ibis/backends/pandas/tests/execution/test_join.py
+++ b/ibis/backends/pandas/tests/execution/test_join.py
@@ -302,6 +302,30 @@ def test_keyed_asof_join_with_tolerance(
     tm.assert_frame_equal(result[expected.columns], expected)
 
 
+@merge_asof_minversion
+def test_asof_join_overlapping_non_predicate(
+    time_keyed_left, time_keyed_right, time_keyed_df1, time_keyed_df2
+):
+    # Add a junk column with a colliding name
+    time_keyed_left = time_keyed_left.mutate(
+        collide=time_keyed_left.key + time_keyed_left.value
+    )
+    time_keyed_right = time_keyed_right.mutate(
+        collide=time_keyed_right.key + time_keyed_right.other_value
+    )
+    time_keyed_df1.assign(collide=time_keyed_df1["key"] + time_keyed_df1["value"])
+    time_keyed_df2.assign(collide=time_keyed_df2["key"] + time_keyed_df2["other_value"])
+
+    expr = time_keyed_left.asof_join(
+        time_keyed_right, predicates=[("time", "time")], by=[("key", "key")]
+    )
+    result = expr.execute()
+    expected = pd.merge_asof(
+        time_keyed_df1, time_keyed_df2, on='time', by='key', suffixes=("", "_right")
+    )
+    tm.assert_frame_equal(result[expected.columns], expected)
+
+
 @pytest.mark.parametrize(
     "how",
     [


### PR DESCRIPTION
Fixes #6360

In the example in #6360, the columns in the predicates aren't sorted, which
isn't supported by pandas, so the example as written in that issue still won't
work, but it should throw an error that the columns need to be sorted.

I duplicated the test except for the execution in the `dask` backend test suite, which I'm not thrilled with, but this isn't the time to refactor the entire `dask` test suite.