### PR TITLE
fix(pandas): preserve RHS values in asof join when column names collide

### DIFF
--- a/ibis/backends/pandas/tests/execution/test_join.py
+++ b/ibis/backends/pandas/tests/execution/test_join.py
@@ -256,32 +256,36 @@ merge_asof_minversion = pytest.mark.skipif(
 
 @merge_asof_minversion
 def test_asof_join(time_left, time_right, time_df1, time_df2):
-    expr = time_left.asof_join(time_right, 'time')[time_left, time_right.other_value]
+    expr = time_left.asof_join(time_right, 'time')
     result = expr.execute()
     expected = pd.merge_asof(time_df1, time_df2, on='time')
     tm.assert_frame_equal(result[expected.columns], expected)
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(result["time"], result["time_right"])
 
 
 @merge_asof_minversion
 def test_asof_join_predicate(time_left, time_right, time_df1, time_df2):
-    expr = time_left.asof_join(time_right, time_left.time == time_right.time)[
-        time_left, time_right.other_value
-    ]
+    expr = time_left.asof_join(time_right, time_left.time == time_right.time)
     result = expr.execute()
     expected = pd.merge_asof(time_df1, time_df2, on='time')
     tm.assert_frame_equal(result[expected.columns], expected)
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(result["time"], result["time_right"])
 
 
 @merge_asof_minversion
 def test_keyed_asof_join(
     time_keyed_left, time_keyed_right, time_keyed_df1, time_keyed_df2
 ):
-    expr = time_keyed_left.asof_join(time_keyed_right, 'time', by='key')[
-        time_keyed_left, time_keyed_right.other_value
-    ]
+    expr = time_keyed_left.asof_join(time_keyed_right, 'time', by='key')
     result = expr.execute()
     expected = pd.merge_asof(time_keyed_df1, time_keyed_df2, on='time', by='key')
     tm.assert_frame_equal(result[expected.columns], expected)
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(result["time"], result["time_right"])
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(result["key"], result["key_right"])
 
 
 @merge_asof_minversion
@@ -290,7 +294,7 @@ def test_keyed_asof_join_with_tolerance(
 ):
     expr = time_keyed_left.asof_join(
         time_keyed_right, 'time', by='key', tolerance=2 * ibis.interval(days=1)
-    )[time_keyed_left, time_keyed_right.other_value]
+    )
     result = expr.execute()
     expected = pd.merge_asof(
         time_keyed_df1,
@@ -300,6 +304,10 @@ def test_keyed_asof_join_with_tolerance(
         tolerance=pd.Timedelta('2D'),
     )
     tm.assert_frame_equal(result[expected.columns], expected)
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(result["time"], result["time_right"])
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(result["key"], result["key_right"])
 
 
 @merge_asof_minversion


### PR DESCRIPTION
Fixes #6080 

`pandas.merge_asof` loses information when any of the grouping or predicate columns share the same name.  It outputs a single column (e.g. `time`) instead of two columns (`time`, `time_right`).

Ibis attempts to recover the now "missing" column, but previously, we were simply creating a copy of the LHS `time` column and then renaming it to be `time_right`.

This behavior also occurred in grouping columns if the names match.

Now, we add default join suffixes to predicates and groups and rename the corresponding columns before the `merge_asof`.


Before:

```python
[ins] In [10]: left_df
Out[10]: 
                 time  cc_num
0 2023-04-16 09:30:00       1
1 2023-04-16 10:30:00       1
2 2023-04-16 11:30:00       2
3 2023-04-16 12:30:00       3

[ins] In [11]: right_df
Out[11]: 
                 time  value1  cc_num
0 2023-04-16 09:00:00    10.0       1
1 2023-04-16 10:00:00    20.0       1
2 2023-04-16 11:00:00    30.0       2
3 2023-04-16 12:00:00    40.0       3

[nav] In [12]: backend = ibis.pandas.connect({"left_df": left_df, "right_df": right_df})
          ...: l_expr = backend.table("left_df")
          ...: r_expr = backend.table("right_df")

[ins] In [13]: expr = l_expr.asof_join(r_expr, [("time", "time")], by=["cc_num"])

[ins] In [14]: expr.execute()
Out[14]: 
                 time  cc_num          time_right  value1  cc_num_right
0 2023-04-16 09:30:00       1 2023-04-16 09:00:00    10.0             1
1 2023-04-16 10:30:00       1 2023-04-16 10:00:00    20.0             1
2 2023-04-16 11:30:00       2 2023-04-16 11:00:00    30.0             2
3 2023-04-16 12:30:00       3 2023-04-16 12:00:00    40.0             3
```


With this PR:

Note that `time_right` reflects the correct values

```python
[ins] In [10]: left_df
Out[10]: 
                 time  cc_num
0 2023-04-16 09:30:00       1
1 2023-04-16 10:30:00       1
2 2023-04-16 11:30:00       2
3 2023-04-16 12:30:00       3

[ins] In [11]: right_df
Out[11]: 
                 time  value1  cc_num
0 2023-04-16 09:00:00    10.0       1
1 2023-04-16 10:00:00    20.0       1
2 2023-04-16 11:00:00    30.0       2
3 2023-04-16 12:00:00    40.0       3

[nav] In [12]: backend = ibis.pandas.connect({"left_df": left_df, "right_df": right_df})
          ...: l_expr = backend.table("left_df")
          ...: r_expr = backend.table("right_df")

[ins] In [13]: expr = l_expr.asof_join(r_expr, [("time", "time")], by=["cc_num"])

[ins] In [14]: expr.execute()
Out[14]: 
                 time  cc_num          time_right  value1  cc_num_right
0 2023-04-16 09:30:00       1 2023-04-16 09:00:00    10.0             1
1 2023-04-16 10:30:00       1 2023-04-16 10:00:00    20.0             1
2 2023-04-16 11:30:00       2 2023-04-16 11:00:00    30.0             2
3 2023-04-16 12:30:00       3 2023-04-16 12:00:00    40.0             3
```