### PR TITLE
feat(formats): support timestamps in delta output; default to micros for pyarrow conversion

### DIFF
--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -2310,7 +2310,6 @@ def test_integer_cast_to_timestamp_scalar(alltypes, df):
     reason="bigquery returns a datetime with a timezone",
     raises=AssertionError,
 )
-@pytest.mark.notimpl(["datafusion"], raises=ArrowInvalid)
 def test_big_timestamp(con):
     # TODO: test with a timezone
     value = ibis.timestamp("2419-10-11 10:10:25")
@@ -2390,7 +2389,6 @@ def test_timestamp_date_comparison(backend, alltypes, df, left_fn, right_fn):
     reason='No literal value renderer is available for literal value "datetime.datetime(4567, 1, 1, 0, 0)" with datatype DATETIME',
 )
 @pytest.mark.notimpl(["pyspark"], raises=pd.errors.OutOfBoundsDatetime)
-@pytest.mark.notimpl(["datafusion"], raises=ArrowInvalid)
 @pytest.mark.notimpl(
     ["polars"],
     raises=PolarsPanicException,

--- a/ibis/expr/datatypes/tests/test_value.py
+++ b/ibis/expr/datatypes/tests/test_value.py
@@ -271,7 +271,7 @@ def test_from_numpy_timedelta():
                     pd.Timestamp('2015-01-03 12:00:00'),
                 ]
             ),
-            (dt.Array(dt.Timestamp()), dt.Array(dt.Timestamp(scale=9))),
+            (dt.Array(dt.Timestamp()), dt.Array(dt.Timestamp(scale=6))),
         ),
         # Implied from object dtype
         (np.array([1, 2, 3], dtype=object), (dt.Array(dt.int64),)),
@@ -287,7 +287,7 @@ def test_from_numpy_timedelta():
                 ],
                 dtype=object,
             ),
-            (dt.Array(dt.Timestamp()), dt.Array(dt.Timestamp(scale=9))),
+            (dt.Array(dt.Timestamp()), dt.Array(dt.Timestamp(scale=6))),
         ),
     ],
 )

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -63,11 +63,7 @@ def dtype_from_pyarrow(typ: pa.DataType, nullable=True) -> dt.DataType:
     elif pa.types.is_decimal(typ):
         return dt.Decimal(typ.precision, typ.scale, nullable=nullable)
     elif pa.types.is_timestamp(typ):
-        # TODO(kszucs): the following code provedes proper timestamp roundtrips
-        # between ibis and pyarrow but breaks the test suite at several
-        # places, we should revisit this later
-        # return dt.Timestamp.from_unit(typ.unit, typ.tz, nullable=nullable)
-        return dt.Timestamp(timezone=typ.tz, nullable=nullable)
+        return dt.Timestamp.from_unit(typ.unit, timezone=typ.tz, nullable=nullable)
     elif pa.types.is_time(typ):
         return dt.Time(nullable=nullable)
     elif pa.types.is_duration(typ):
@@ -110,11 +106,9 @@ def dtype_to_pyarrow(dtype: dt.DataType) -> pa.DataType:
         else:
             return pa.decimal128(precision, scale)
     elif dtype.is_timestamp():
-        # TODO(kszucs): the following code provedes proper timestamp roundtrips
-        # between ibis and pyarrow but breaks the test suite at several
-        # places, we should revisit this later
-        # return pa.timestamp(dtype.unit.short, tz=dtype.timezone)
-        return pa.timestamp('ns', tz=dtype.timezone)
+        return pa.timestamp(
+            dtype.unit.short if dtype.scale is not None else "us", tz=dtype.timezone
+        )
     elif dtype.is_interval():
         return pa.duration(dtype.unit.short)
     elif dtype.is_time():

--- a/ibis/formats/tests/test_pyarrow.py
+++ b/ibis/formats/tests/test_pyarrow.py
@@ -34,6 +34,7 @@ roundtripable_types = st.deferred(
         | past.duration_types
         | past.string_type
         | past.binary_type
+        | past.timestamp_types
         | st.builds(pa.list_, roundtripable_types)
         | past.struct_types(roundtripable_types)
         | past.map_types(roundtripable_types, roundtripable_types)
@@ -62,10 +63,6 @@ def test_roundtripable_types(arrow_type):
         (pa.time32("ms"), dt.Time(nullable=False), pa.time64("ns")),
         (pa.time64("us"), dt.Time(nullable=False), pa.time64("ns")),
         (pa.time64("ns"), dt.Time(nullable=False), pa.time64("ns")),
-        (pa.timestamp("s"), dt.Timestamp(nullable=False), pa.timestamp("ns")),
-        (pa.timestamp("ms"), dt.Timestamp(nullable=False), pa.timestamp("ns")),
-        (pa.timestamp("us"), dt.Timestamp(nullable=False), pa.timestamp("ns")),
-        (pa.timestamp("ns"), dt.Timestamp(nullable=False), pa.timestamp("ns")),
         (pa.large_binary(), dt.Binary(nullable=False), pa.binary()),
         (pa.large_string(), dt.String(nullable=False), pa.string()),
         (
@@ -82,6 +79,13 @@ def test_roundtripable_types(arrow_type):
 )
 def test_non_roundtripable_types(arrow_type, ibis_type, restored_type):
     assert_dtype_roundtrip(arrow_type, ibis_type, restored_type)
+
+
+@pytest.mark.parametrize("timezone", [None, "UTC"])
+@pytest.mark.parametrize("nullable", [True, False])
+def test_timestamp_no_scale(timezone, nullable):
+    dtype = dt.Timestamp(scale=None, timezone=timezone, nullable=nullable)
+    assert dtype.to_pyarrow() == pa.timestamp("us", tz=timezone)
 
 
 def test_month_day_nano_type_unsupported():


### PR DESCRIPTION
This PR brings back timestamp scale round tripping, which allows delta timestamp writing, and gives a couple new xpasses from datafusion. Huzzah!