### PR TITLE
fix(docs): spellcheck various docstrings

### DIFF
--- a/ibis/backends/base/df/scope.py
+++ b/ibis/backends/base/df/scope.py
@@ -8,7 +8,7 @@ with it (if any).
 
 When there are no time contexts associate with the cached result, getting
 and setting values in Scope would be as simple as get and set in a normal
-dictonary. With time contexts, we need the following logic for getting
+dictionary. With time contexts, we need the following logic for getting
 and setting items in scope:
 
 Before setting the value op in scope we need to perform the following
@@ -133,7 +133,7 @@ class Scope:
         if timecontext is None:
             return self._items[op].value
         else:
-            # For op with timecontext, ther are some ops cannot use cached
+            # For op with timecontext, there are some ops cannot use cached
             # result with a different (larger) timecontext to get the
             # correct result.
             # For example, a groupby followed by count, if we use a larger or
@@ -142,7 +142,7 @@ class Scope:
             # depending on other rows in result Dataframe, cannot use cached
             # result with different time context to optimize calculation.
             # These are time context sensitive operations. Since these cases
-            # are rare in acutal use case, we just enable optimization for
+            # are rare in actual use case, we just enable optimization for
             # all nodes for now.
             cached_timecontext = self._items[op].timecontext
             if cached_timecontext:

--- a/ibis/backends/base/df/timecontext.py
+++ b/ibis/backends/base/df/timecontext.py
@@ -34,7 +34,7 @@ Time context adjustment algorithm
     require extra data outside of the global time context that user defines.
     For example, in asof_join, we need to look back extra `tolerance` daays
     for the right table to get the data for joining. Similarly for window
-    operation with preceeding and following.
+    operation with preceding and following.
     Algorithm to calculate context adjustment are defined in this module
     and could be used by multiple backends.
 """

--- a/ibis/backends/bigquery/client.py
+++ b/ibis/backends/bigquery/client.py
@@ -144,7 +144,7 @@ def rename_partitioned_column(table_expr, bq_table, partition_col):
     """Rename native partition column to user-defined name."""
     partition_info = bq_table._properties.get("timePartitioning", None)
 
-    # If we don't have any partiton information, the table isn't partitioned
+    # If we don't have any partition information, the table isn't partitioned
     if partition_info is None:
         return table_expr
 

--- a/ibis/backends/bigquery/udf/core.py
+++ b/ibis/backends/bigquery/udf/core.py
@@ -163,7 +163,7 @@ class PythonToJavaScriptTranslator:
 
         if not isinstance(target, (ast.Name, ast.Subscript, ast.Attribute)):
             raise NotImplementedError(
-                "Only index, attribute, and variable name assigment "
+                "Only index, attribute, and variable name assignment "
                 "supported, got {}".format(type(target).__name__)
             )
 

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -157,7 +157,7 @@ class Backend(BaseBackend):
         password
             Password to authenticate with
         client_name
-            Name of client that wil appear in clickhouse server logs
+            Name of client that will appear in clickhouse server logs
         secure
             Whether or not to use an authenticated endpoint
         compression

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -1203,7 +1203,7 @@ _map_interval_to_microseconds = {
 _map_interval_op_to_op = {
     # Literal Intervals have two args, i.e.
     # Literal(1, Interval(value_type=int8, unit='D', nullable=True))
-    # Parse both args and multipy 1 * _map_interval_to_microseconds['D']
+    # Parse both args and multiply 1 * _map_interval_to_microseconds['D']
     ops.Literal: mul,
     ops.IntervalMultiply: mul,
     ops.IntervalAdd: add,

--- a/ibis/backends/dask/aggcontext.py
+++ b/ibis/backends/dask/aggcontext.py
@@ -128,7 +128,7 @@ class Window(AggregationContext):
         grouped = grouped_frame[name]
 
         if callable(function):
-            # To compute the window_size, we need to contruct a
+            # To compute the window_size, we need to construct a
             # RollingGroupby and compute count using construct_window.
             # However, if the RollingGroupby is not numeric, e.g.,
             # we are calling window UDF on a timestamp column, we

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -106,7 +106,7 @@ And scope value is another key-value map:
 - timecontext: of type TimeContext, the time context associated with the data
 stored in value
 
-See ibis.common.scope for details about the implementaion.
+See ibis.common.scope for details about the implementation.
 """
 from __future__ import annotations
 
@@ -391,7 +391,7 @@ def main_execute(
     if cache is None:
         cache = {}
 
-    # TODO: make expresions hashable so that we can get rid of these .op()
+    # TODO: make expressions hashable so that we can get rid of these .op()
     # calls everywhere
     params = {k.op() if isinstance(k, ir.Expr) else k: v for k, v in params.items()}
     scope = scope.merge_scope(Scope(params, timecontext))

--- a/ibis/backends/dask/execution/aggregations.py
+++ b/ibis/backends/dask/execution/aggregations.py
@@ -114,7 +114,7 @@ def execute_any_all_series(op, data, mask, aggcontext=None, **kwargs):
         result = aggcontext.agg(data, name)
     else:
         # Note this branch is not currently hit in the dask backend but is
-        # here for future scafolding.
+        # here for future scaffolding.
         result = aggcontext.agg(data, operator.methodcaller(name))
     return result
 
@@ -126,7 +126,7 @@ def execute_any_all_series_group_by(op, data, mask, aggcontext=None, **kwargs):
         result = aggcontext.agg(data, name)
     else:
         # Note this branch is not currently hit in the dask backend but is
-        # here for future scafolding.
+        # here for future scaffolding.
         result = aggcontext.agg(data, operator.methodcaller(name))
     return result
 
@@ -141,7 +141,7 @@ def execute_notany_series(op, data, mask, aggcontext=None, **kwargs):
         result = ~aggcontext.agg(data, name)
     else:
         # Note this branch is not currently hit in the dask backend but is
-        # here for future scafolding.
+        # here for future scaffolding.
         method = operator.methodcaller(name)
         result = aggcontext.agg(data, lambda data: ~method(data))
     return result
@@ -154,7 +154,7 @@ def execute_notany_series_group_by(op, data, mask, aggcontext=None, **kwargs):
         result = ~aggcontext.agg(data, name)
     else:
         # Note this branch is not currently hit in the dask backend but is
-        # here for future scafolding.
+        # here for future scaffolding.
         method = operator.methodcaller(name)
         result = aggcontext.agg(data, lambda data: ~method(data))
 

--- a/ibis/backends/dask/execution/maps.py
+++ b/ibis/backends/dask/execution/maps.py
@@ -50,7 +50,7 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
         ((dd.Series, dd.Series, object), map_get_series_series_scalar),
         ((dd.Series, dd.Series, dd.Series), map_get_series_series_series),
         # This never occurs but we need to register it so multipledispatch
-        # does not see below registrations as ambigious. See NOTE above.
+        # does not see below registrations as ambiguous. See NOTE above.
         (
             (Mapping, (dd.Series, pd.Series), (dd.Series, pd.Series)),
             map_get_dict_series_series,

--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -238,7 +238,7 @@ def _compute_predicates(
     for predicate in predicates:
         # Map each root table of the predicate to the data so that we compute
         # predicates on the result instead of any left or right tables if the
-        # Selection is on a Join. Project data to only inlude columns from
+        # Selection is on a Join. Project data to only include columns from
         # the root table.
         root_tables = an.find_immediate_parent_tables(predicate)
 

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -175,7 +175,7 @@ def safe_concat(dfs: list[dd.Series | dd.DataFrame]) -> dd.DataFrame:
     See https://github.com/dask/dask/blob/2c2e837674895cafdb0612be81250ef2657d947e/dask/dataframe/multi.py#L907.
 
     Note - Repeatedly joining dataframes is likely to be quite slow, but this
-    should be hit rarely in real usage. A situtation that triggeres this slow
+    should be hit rarely in real usage. A situation that triggers this slow
     path is aggregations where aggregations return different numbers of rows
     (see `test_aggregation_group_by` for a specific example).
     TODO - performance.
@@ -307,7 +307,7 @@ def add_globally_consecutive_column(
     - The global index that's added is consecutive in the same order that the rows currently are in.
     - IDs within each partition are already sorted
 
-    We also do not explicity deal with overflow in the bounds.
+    We also do not explicitly deal with overflow in the bounds.
 
     Parameters
     ----------

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -316,7 +316,7 @@ def test_grouped_reduction(t, df, where):
         "var_plain_int64",
         "nunique_plain_int64",
     ]
-    # guarentee ordering
+    # guarantee ordering
     result = result[expected.columns]
     # dask and pandas differ slightly in how they treat groups with no entry
     # we're not testing that so fillna here.
@@ -917,7 +917,7 @@ def test_union(client, df1, distinct):
     result = expr.compile()
     expected = df1 if distinct else dd.concat([df1, df1], axis=0, ignore_index=True)
 
-    # match indicies because of dask reset_index behavior
+    # match indices because of dask reset_index behavior
     result = result.compute().reset_index(drop=True)
     expected = expected.compute().reset_index(drop=True)
 

--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -45,7 +45,7 @@ def test_bad_timecontext(time_table, t):
         context = ('bad', 'context')
         expr.execute(timecontext=context)
 
-    # define context with unsupport type int
+    # define context with unsupported type int
     with pytest.raises(com.IbisError, match=r".*type pd.Timestamp.*"):
         context = (20091010, 20100101)
         expr.execute(timecontext=context)
@@ -143,7 +143,7 @@ def test_setting_timecontext_in_scope(time_table, time_df3):
     get table in context ('20170105', '20170101').
 
     Then in window execution table will be executed again with a larger
-    context adjusted by window preceeding days ('20170102', '20170111').
+    context adjusted by window preceding days ('20170102', '20170111').
     To get the correct result, the cached table result with a smaller
     context must be discard and updated to a larger time range.
     """

--- a/ibis/backends/dask/trace.py
+++ b/ibis/backends/dask/trace.py
@@ -94,7 +94,7 @@ def _log_trace(func, start=None):
             level += 1
 
     # We can assume we have 'args' because we only call _log_trace inside
-    # trace or TraceDispatcher.resgister
+    # trace or TraceDispatcher.register
     current_op = current_frame.f_locals['args'][0]
 
     # If the first argument is a Expr, we print its op because it's more

--- a/ibis/backends/dask/udf.py
+++ b/ibis/backends/dask/udf.py
@@ -102,8 +102,8 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
     # 1) an ungrouped window,
     # 2) an ungrouped Aggregate node, or
     # 3) an ungrouped custom aggregation context
-    # Ungrouped analytic/reduction functions recieve the entire Series at once
-    # This is generally not recommened.
+    # Ungrouped analytic/reduction functions receive the entire Series at once
+    # This is generally not recommended.
     @execute_node.register(type(op), *(itertools.repeat(dd.Series, nargs)))
     def execute_udaf_node_no_groupby(op, *args, aggcontext, **kwargs):
         # This function is in essence fully materializing the dd.Series and
@@ -145,12 +145,12 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
             # lazy_result is a dd.core.Scalar from an ungrouped reduction
             return_type = op.return_type
             if return_type.is_array() or return_type.is_struct():
-                # we're outputing a dt.Struct that will need to be destructured
+                # we're outputting a dt.Struct that will need to be destructured
                 # or an array of an unknown size.
                 # we compute so we can work with items inside downstream.
                 result = lazy_result.compute()
             else:
-                # manully construct a dd.core.Scalar out of the delayed result
+                # manually construct a dd.core.Scalar out of the delayed result
                 result = dd.from_delayed(
                     lazy_result,
                     meta=op.return_type.to_pandas(),
@@ -190,7 +190,7 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
             # that is a SeriesGroupBy.
             iters = create_gens_from_args_groupby(*args[1:])
 
-            # TODO: Unify calling convension here to be more like
+            # TODO: Unify calling convention here to be more like
             # window
             def aggregator(first, *rest):
                 # map(next, *rest) gets the inputs for the next group

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -88,7 +88,7 @@ class Backend(BaseBackend):
         Parameters
         ----------
         name
-            The name of the table to retreive
+            The name of the table to retrieve
         schema
             An optional schema for the table
 

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -376,7 +376,7 @@ operation_registry.update(
         ops.TableColumn: _table_column,
         ops.TimestampFromUNIX: _timestamp_from_unix,
         ops.TimestampNow: fixed_arity(
-            # duckdb 0.6.0 changes now to be a tiemstamp with time zone force
+            # duckdb 0.6.0 changes now to be a timestamp with time zone force
             # it back to the original for backwards compatibility
             lambda *_: sa.cast(sa.func.now(), sa.TIMESTAMP),
             0,

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -404,7 +404,7 @@ class Transform(AggregationContext):
             res = grouped_data.transform(function, *args, **kwargs)
 
         # The result series uses the name of the input. We should
-        # unset it to avoid confusion, when result is not guranteed
+        # unset it to avoid confusion, when result is not guaranteed
         # to be the same series / have the same type after transform
         res.name = None
         return res
@@ -610,7 +610,7 @@ class Window(AggregationContext):
         grouped = grouped_frame[name]
 
         if callable(function):
-            # To compute the window_size, we need to contruct a
+            # To compute the window_size, we need to construct a
             # RollingGroupby and compute count using construct_window.
             # However, if the RollingGroupby is not numeric, e.g.,
             # we are calling window UDF on a timestamp column, we

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -102,7 +102,7 @@ And scope value is another key-value map:
 - timecontext: of type TimeContext, the time context associated with the data
 stored in value
 
-See ibis.common.scope for details about the implementaion.
+See ibis.common.scope for details about the implementation.
 """
 
 from __future__ import annotations

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -180,7 +180,7 @@ def _compute_predicates(
     for predicate in predicates:
         # Map each root table of the predicate to the data so that we compute
         # predicates on the result instead of any left or right tables if the
-        # Selection is on a Join. Project data to only inlude columns from
+        # Selection is on a Join. Project data to only include columns from
         # the root table.
         root_tables = an.find_immediate_parent_tables(predicate)
 

--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -241,7 +241,7 @@ def trim_window_result(data: pd.Series | pd.DataFrame, timecontext: TimeContext 
 
     # Get columns to set for index
     if isinstance(data, pd.Series):
-        # if Series dosen't contain a name, reset_index will assign
+        # if Series doesn't contain a name, reset_index will assign
         # '0' as the column name for the column of value
         name = data.name if data.name else 0
         index_columns = list(subset.columns.difference([name]))

--- a/ibis/backends/pandas/tests/execution/test_timecontext.py
+++ b/ibis/backends/pandas/tests/execution/test_timecontext.py
@@ -46,7 +46,7 @@ def test_bad_timecontext(time_table, t):
         context = ('bad', 'context')
         expr.execute(timecontext=context)
 
-    # define context with unsupport type int
+    # define context with unsupported type int
     with pytest.raises(com.IbisError, match=r".*type pd.Timestamp.*"):
         context = (20091010, 20100101)
         expr.execute(timecontext=context)
@@ -188,7 +188,7 @@ def test_setting_timecontext_in_scope(time_table, time_df3):
     get table in context ('20170105', '20170101').
 
     Then in window execution table will be executed again with a larger
-    context adjusted by window preceeding days ('20170102', '20170111').
+    context adjusted by window preceding days ('20170102', '20170111').
     To get the correct result, the cached table result with a smaller
     context must be discard and updated to a larger time range.
     """

--- a/ibis/backends/pandas/trace.py
+++ b/ibis/backends/pandas/trace.py
@@ -104,7 +104,7 @@ def _log_trace(func, start=None):
             level += 1
 
     # We can assume we have 'args' because we only call _log_trace inside
-    # trace or TraceDispatcher.resgister
+    # trace or TraceDispatcher.register
     current_op = current_frame.f_locals['args'][0]
 
     # If the first argument is a Expr, we print its op because it's more

--- a/ibis/backends/pandas/udf.py
+++ b/ibis/backends/pandas/udf.py
@@ -147,7 +147,7 @@ def pre_execute_analytic_and_reduction_udf(op, *clients, scope=None, **kwargs):
             # that is a SeriesGroupBy.
             iters = create_gens_from_args_groupby(*args[1:])
 
-            # TODO: Unify calling convension here to be more like
+            # TODO: Unify calling convention here to be more like
             # window
             def aggregator(first, *rest):
                 # map(next, *rest) gets the inputs for the next group

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -182,7 +182,7 @@ def compile_selection(t, op, *, scope, timecontext, **kwargs):
                 col_in_selection_order.append(col)
         else:
             raise NotImplementedError(
-                f"Unrecoginized type in selections: {type(selection)}"
+                f"Unrecognized type in selections: {type(selection)}"
             )
     if col_in_selection_order:
         result_table = result_table[col_in_selection_order]
@@ -374,7 +374,7 @@ def compile_literal(t, op, *, raw=False, **kwargs):
     if isinstance(value, collections.abc.Set):
         # Don't wrap set with F.lit
         if isinstance(value, frozenset):
-            # Spark doens't like frozenset
+            # Spark doesn't like frozenset
             return set(value)
         else:
             return value
@@ -943,7 +943,7 @@ def compile_substring(t, op, raw: bool = False, **kwargs):
 
     if any_of((start, length), pyspark.sql.Column):
         raise NotImplementedError(
-            "Specifiying `start` or `length` with column expressions is not supported."
+            "Specifying `start` or `length` with column expressions is not supported."
         )
 
     if start < 0:

--- a/ibis/backends/pyspark/tests/test_window_context_adjustment.py
+++ b/ibis/backends/pyspark/tests/test_window_context_adjustment.py
@@ -81,7 +81,7 @@ def test_window_with_timecontext(con, ibis_windows, spark_range):
 def test_cumulative_window(con, ibis_windows, spark_range):
     """Test context adjustment for cumulative window.
 
-    For cumulative window, by defination we should look back infinately.
+    For cumulative window, by definition we should look back infinitely.
     When data is trimmed by time context, we define the limit of looking
     back is the start time of given time context. Thus for a table of
     time       value
@@ -133,8 +133,8 @@ def test_multiple_trailing_window(con, ibis_windows, spark_range):
     """Test context adjustment for multiple trailing window.
 
     When there are multiple window ops, we need to verify contexts are
-    adjusted correctly for all windows. In this tests we are constucting
-    one trailing window for 1h and another trailng window for 2h
+    adjusted correctly for all windows. In this tests we are constructing
+    one trailing window for 1h and another trailing window for 2h
     """
     table = con.table('time_indexed_table')
     context = (
@@ -184,8 +184,8 @@ def test_chained_trailing_window(con, ibis_windows, spark_range):
     """Test context adjustment for chained windows.
 
     When there are chained window ops, we need to verify contexts are
-    adjusted correctly for all windows. In this tests we are constucting
-    one trailing window for 1h and trailng window on the new column for
+    adjusted correctly for all windows. In this tests we are constructing
+    one trailing window for 1h and trailing window on the new column for
     2h
     """
     table = con.table('time_indexed_table')

--- a/ibis/backends/pyspark/timecontext.py
+++ b/ibis/backends/pyspark/timecontext.py
@@ -23,7 +23,7 @@ def filter_by_time_context(
     time_col = get_time_col()
     if time_col in df.columns:
         # For py3.8, underlying spark type converter calls utctimetuple()
-        # and will throw excpetion for Timestamp type if tz is set.
+        # and will throw exception for Timestamp type if tz is set.
         # See https://github.com/pandas-dev/pandas/issues/32174
         # Dropping tz will cause spark to interpret begin, end with session
         # timezone & os env TZ. We convert Timestamp to pydatetime to

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -384,7 +384,7 @@ operation_registry.update(
             lambda arr, el: sa.func.array_contains(sa.func.to_variant(el), arr), 2
         ),
         ops.ArrayPosition: fixed_arity(
-            # snowflake is zero-based here, so we don't need to substract 1 from the result
+            # snowflake is zero-based here, so we don't need to subtract 1 from the result
             lambda lst, el: sa.func.coalesce(
                 sa.func.array_position(sa.func.to_variant(el), lst), -1
             ),

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -147,7 +147,7 @@ def _extract_week_of_year(t, op):
 
     The implementation gives the same results as `datetime.isocalendar()`.
 
-    The year's week that "wins" the day is the year with more alloted days.
+    The year's week that "wins" the day is the year with more allotted days.
 
     For example:
 
@@ -164,7 +164,7 @@ def _extract_week_of_year(t, op):
     ```
 
     Here the ISO week number is `52` since the day occurs in a week with more
-    days in the week occuring in the _previous_ week's year.
+    days in the week occurring in the _previous_ week's year.
 
     ```
     $ cal '2012-12-31'
@@ -179,7 +179,7 @@ def _extract_week_of_year(t, op):
     ```
 
     Here the ISO week of year is `1` since the day occurs in a week with more
-    days in the week occuring in the _next_ week's year.
+    days in the week occurring in the _next_ week's year.
     """
     date = sa.func.date(t.translate(op.arg), "-3 days", "weekday 4")
     return (sa.func.strftime("%j", date) - 1) / 7 + 1

--- a/ibis/backends/sqlite/udf.py
+++ b/ibis/backends/sqlite/udf.py
@@ -77,7 +77,7 @@ def _ibis_sqlite_regex_search(string, regex):
 
 @udf
 def _ibis_sqlite_regex_replace(string, pattern, replacement):
-    """Replace occurences of `pattern` in `string` with `replacement`."""
+    """Replace occurrences of `pattern` in `string` with `replacement`."""
     return re.sub(pattern, replacement, string)
 
 
@@ -430,7 +430,7 @@ def register_all(dbapi_connection):
     for agg in _SQLITE_UDAF_REGISTRY:
         dbapi_connection.create_aggregate(
             agg.__name__,
-            # substract one to ignore the `self` argument of the step method
+            # subtract one to ignore the `self` argument of the step method
             _number_of_arguments(agg.step) - 1,
             agg,
         )

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -685,7 +685,7 @@ def test_string_col_is_unicode(alltypes, df):
                     ["pyspark"],
                     raises=NotImplementedError,
                     reason=(
-                        "Specifiying `start` or `length` with column expressions is not supported."
+                        "Specifying `start` or `length` with column expressions is not supported."
                     ),
                 ),
                 pytest.mark.notimpl(
@@ -772,7 +772,7 @@ def test_string_col_is_unicode(alltypes, df):
                     ["pyspark"],
                     raises=NotImplementedError,
                     reason=(
-                        "Specifiying `start` or `length` with column expressions is not supported."
+                        "Specifying `start` or `length` with column expressions is not supported."
                     ),
                 ),
                 pytest.mark.notimpl(

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -326,7 +326,7 @@ def test_grouped_bounded_expanding_window(
             marks=[pytest.mark.notimpl(["dask"], raises=NotImplementedError)],
         ),
         param(
-            # Disabled on PySpark and Spark backends becuase in pyspark<3.0.0,
+            # Disabled on PySpark and Spark backends because in pyspark<3.0.0,
             # Pandas UDFs are only supported on unbounded windows
             lambda t, win: mean_udf(t.double_col).over(win),
             lambda df: (df.double_col.expanding().mean()),

--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -168,7 +168,7 @@ class Parameter(inspect.Parameter):
 class Signature(inspect.Signature):
     """Validatable signature.
 
-    Primarly used in the implementation of `ibis.common.grounds.Annotable`.
+    Primarily used in the implementation of `ibis.common.grounds.Annotable`.
     """
 
     __slots__ = ()
@@ -199,7 +199,7 @@ class Signature(inspect.Signature):
         for name, annot in annotations.items():
             params[name] = Parameter(name, annotation=annot)
 
-        # mandatory fields without default values must preceed the optional
+        # mandatory fields without default values must precede the optional
         # ones in the function signature, the partial ordering will be kept
         var_args, var_kwargs = [], []
         new_args, new_kwargs = [], []

--- a/ibis/common/egraph.py
+++ b/ibis/common/egraph.py
@@ -364,7 +364,7 @@ class Pattern(Slotted):
         """Recursively flatten the pattern to a join of selections.
 
         `Pattern(Add, (Pattern(Mul, ($x, 1)), $y))` is turned into a join of
-        selections by introducing auxilary variables where each selection gets
+        selections by introducing auxiliary variables where each selection gets
         executed as a dictionary lookup.
 
         In SQL terms this is equivalent to the following query:
@@ -375,7 +375,7 @@ class Pattern(Slotted):
         var : Variable
             The variable to assign to the flattened pattern.
         counter : Iterator[int]
-            The counter to generate unique variable names for auxilary variables
+            The counter to generate unique variable names for auxiliary variables
             connecting the selections.
 
         Yields
@@ -617,7 +617,7 @@ class EGraph:
             are either enodes or leaf values.
         patargs : tuple
             The arguments of the pattern. Since a pattern is a flat term (flattened
-            using auxilliary variables), the arguments are either variables or leaf
+            using auxiliary variables), the arguments are either variables or leaf
             values.
 
         Returns

--- a/ibis/common/exceptions.py
+++ b/ibis/common/exceptions.py
@@ -79,7 +79,7 @@ class BackendConversionError(IbisError):
 
 
 class BackendConfigurationNotRegistered(IbisError):
-    """A backend has options but isn't regsitered in ibis/config.py."""
+    """A backend has options but isn't registered in ibis/config.py."""
 
     def __init__(self, backend_name: str) -> None:
         super().__init__(backend_name)

--- a/ibis/common/validators.py
+++ b/ibis/common/validators.py
@@ -68,7 +68,7 @@ class Validator(Callable):
         Returns
         -------
         validator
-            A validator that can be used to validate objects, tipically function
+            A validator that can be used to validate objects, typically function
             arguments.
         """
         # TODO(kszucs): cache the result of this function
@@ -298,7 +298,7 @@ def any_of(inners: Iterable[Validator], arg: Any, **kwargs: Any) -> Any:
     Returns
     -------
     arg : Any
-        Value maybe coerced by inner validators to the appropiate types
+        Value maybe coerced by inner validators to the appropriate types
     """
     for inner in inners:
         with suppress(IbisTypeError, ValueError):
@@ -330,7 +330,7 @@ def all_of(inners: Iterable[Validator], arg: Any, **kwargs: Any) -> Any:
     Returns
     -------
     arg : Any
-      Value maybe coerced by inner validators to the appropiate types
+      Value maybe coerced by inner validators to the appropriate types
     """
     for inner in inners:
         arg = inner(arg, **kwargs)
@@ -612,7 +612,7 @@ def int_(arg: Any, min: int = 0, max: int = math.inf, **kwargs: Any) -> int:
     max
         Maximum value of the integer.
     kwargs
-        Omited keyword arguments.
+        Omitted keyword arguments.
 
     Returns
     -------

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -224,7 +224,7 @@ def _fmt_join(op: ops.Join, *, aliases: Aliases) -> tuple[str, str]:
     top = f"{op.__class__.__name__}[{left}, {right}]"
 
     # format the join predicates
-    # if only one, put it directly after the join on thes same line
+    # if only one, put it directly after the join on the same line
     # if more than one put each on a separate line
     preds = op.predicates
     formatted_preds = [fmt_value(pred, aliases=aliases) for pred in preds]
@@ -582,7 +582,7 @@ def _fmt_value_value_op(op: ops.Value, *, aliases: Aliases) -> str:
     args = []
     # loop over argument names and original expression
     for argname, orig_expr in zip(op.argnames, op.args):
-        # promote argument to a list, so that we don't accidentially repr
+        # promote argument to a list, so that we don't accidentally repr
         # entire subtrees when all we want is the formatted argument value
         if exprs := [expr for expr in util.promote_list(orig_expr) if expr is not None]:
             # format the individual argument values

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -208,7 +208,7 @@ class Join(TableNode):
         import ibis.expr.analysis as an
         import ibis.expr.operations as ops
 
-        # TODO(kszucs): need to factor this out to appropiate join predicate
+        # TODO(kszucs): need to factor this out to appropriate join predicate
         # rules
         predicates = [
             pred.op() if isinstance(pred, ir.Expr) else pred

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -330,7 +330,7 @@ def client(arg, **kwargs):
 
 
 # ---------------------------------------------------------------------
-# Ouput type functions
+# Output type functions
 
 
 @public

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -661,13 +661,13 @@ class NumericValue(Value):
     add = radd = __radd__ = __add__
 
     def __sub__(self, other: NumericValue) -> NumericValue | NotImplemented:
-        """Substract `other` from `self`."""
+        """Subtract `other` from `self`."""
         return _binop(ops.Subtract, self, other)
 
     sub = __sub__
 
     def __rsub__(self, other: NumericValue) -> NumericValue | NotImplemented:
-        """Substract `self` from `other`."""
+        """Subtract `self` from `other`."""
         return _binop(ops.Subtract, other, self)
 
     rsub = __rsub__

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2793,7 +2793,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ …        │ …                  │     … │
         └──────────┴────────────────────┴───────┘
 
-        Simliarly for a different example dataset, we convert names to values
+        Similarly for a different example dataset, we convert names to values
         but using a different selector and the default `values_to` value.
 
         >>> world_bank_pop = ibis.examples.world_bank_pop_raw.fetch()

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -630,7 +630,7 @@ class StringValue(Value):
         start: int | ir.IntegerValue | None = None,
         end: int | ir.IntegerValue | None = None,
     ) -> ir.IntegerValue:
-        """Return the position of the first occurence of substring.
+        """Return the position of the first occurrence of substring.
 
         Parameters
         ----------
@@ -754,7 +754,7 @@ class StringValue(Value):
         return ops.RPad(self, length, pad).to_expr()
 
     def find_in_set(self, str_list: Sequence[str]) -> ir.IntegerValue:
-        """Find the first occurence of `str_list` within a list of strings.
+        """Find the first occurrence of `str_list` within a list of strings.
 
         No string in `str_list` can have a comma.
 

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -47,7 +47,7 @@ def test_literal_equality_interval():
 
     assert a != b
 
-    # Currently these does't equal, but perhaps should be?
+    # Currently these don't equal, but perhaps should?
     c = ibis.interval(seconds=60).op()
     d = ibis.interval(minutes=1).op()
 
@@ -145,7 +145,7 @@ def test_map_literal(value):
 @pytest.mark.parametrize(
     'value',
     [
-        dict(key1='value1', key2=6.25),  # heterogenous map values
+        dict(key1='value1', key2=6.25),  # heterogeneous map values
     ],
 )
 def test_map_literal_non_castable(value):


### PR DESCRIPTION
Closes #6390 

I have reviewed and corrected many of the findings from the result of the codespell check. Most of these were in docstrings and comments; however, one error was raised on PySpark `NotImplementedError` reason. 

As mentioned, there were a few false positives here. 

Here are the ones I have noted and have not made changes to:

```
ibis/backends/sqlite/registry.py:412: iif ==> if
ibis/backends/sqlite/datatypes.py:41: DOUB ==> DOUBT, DAUB
ibis/backends/sqlite/datatypes.py:42: DOUB ==> DOUBT, DAUB
ibis/backends/mssql/registry.py:120: iif ==> if
ibis/backends/base/sql/alchemy/query_builder.py:271: froms ==> forms
ibis/backends/base/sql/alchemy/__init__.py:773: sav ==> save
ibis/backends/base/sql/alchemy/__init__.py:776: sav ==> save
ibis/backends/base/sql/alchemy/__init__.py:793: sav ==> save
ibis/backends/base/sql/alchemy/__init__.py:795: sav ==> save
ibis/tests/expr/test_table.py:346: interm ==> interim, intern
ibis/tests/expr/test_table.py:347: interm ==> interim, intern
ibis/tests/expr/test_table.py:347: interm ==> interim, intern
ibis/common/tests/test_grounds.py:206: InBetween ==> between, in between
ibis/common/tests/test_grounds.py:224: InBetween ==> between, in between
ibis/common/tests/test_grounds.py:229: InBetween ==> between, in between
```

At some point down the road, if it's even worthwhile to do, we could explore adding this as a pre-commit hook and adding in these rules for words [Using a config file](https://github.com/codespell-project/codespell#using-a-config-file).