### PR TITLE
chore(ci): set a silly threshold for codecov to avoid spurious failures

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,7 @@ coverage:
     patch:
       default:
         target: auto
-        threshold: 1%
+        threshold: 92%
         only_pulls: true
     project:
       default:


### PR DESCRIPTION
codecov patch coverage fails all the time because we don't run all
backends on CI (and lots of other reasons, too), but we don't want to
kill the patch job entirely because we want the coverage annotations.

but codecov won't provide those annotations if you turn off patch
coverage, so instead, we'll make it so loose it will never fail.

xref #5601
xref #4693
