### PR TITLE
style: add flake8-type-checking to ruff config

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -8,7 +8,6 @@ import keyword
 import re
 import sys
 import urllib.parse
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -29,6 +28,8 @@ from ibis import util
 from ibis.common.caching import RefCountedCache
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pandas as pd
     import pyarrow as pa
 

--- a/ibis/backends/base/df/scope.py
+++ b/ibis/backends/base/df/scope.py
@@ -37,12 +37,14 @@ different time contexts.
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import Any, Iterable, Tuple
+from typing import TYPE_CHECKING, Any, Iterable, Tuple
 
 import pandas as pd
 
 from ibis.backends.base.df.timecontext import TimeContextRelation, compare_timecontext
-from ibis.expr.operations import Node
+
+if TYPE_CHECKING:
+    from ibis.expr.operations import Node
 
 TimeContext = Tuple[pd.Timestamp, pd.Timestamp]
 

--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import datetime
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from multipledispatch import Dispatcher
@@ -13,7 +13,6 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.base.sql import compiler
 from ibis.backends.base.sql.registry import (
     fixed_arity,
     literal,
@@ -23,6 +22,9 @@ from ibis.backends.base.sql.registry import (
 )
 from ibis.backends.bigquery.datatypes import dtype_to_bigquery
 from ibis.common.temporal import DateUnit, IntervalUnit, TimeUnit
+
+if TYPE_CHECKING:
+    from ibis.backends.base.sql import compiler
 
 
 def _extract_field(sql_attr):

--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -5,8 +5,6 @@ import contextlib
 import functools
 import io
 import os
-import pathlib
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping
 
 import google.api_core.exceptions as gexc
@@ -24,6 +22,9 @@ from ibis.backends.tests.base import BackendTest, RoundAwayFromZero, UnorderedCo
 from ibis.backends.tests.data import json_types, non_null_array_types, struct_types, win
 
 if TYPE_CHECKING:
+    import pathlib
+    from pathlib import Path
+
     import ibis.expr.types as ir
 
 DATASET_ID = "ibis_gbq_testing"

--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
-from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import pytest
 
@@ -15,6 +14,9 @@ from ibis.backends.tests.base import (
     ServiceSpec,
     UnorderedComparator,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 CLICKHOUSE_HOST = os.environ.get('IBIS_TEST_CLICKHOUSE_HOST', 'localhost')
 CLICKHOUSE_PORT = int(os.environ.get('IBIS_TEST_CLICKHOUSE_PORT', 8123))

--- a/ibis/backends/dask/execution/aggregations.py
+++ b/ibis/backends/dask/execution/aggregations.py
@@ -12,17 +12,20 @@ from __future__ import annotations
 
 import functools
 import operator
+from typing import TYPE_CHECKING
 
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
 
 import ibis.expr.operations as ops
 from ibis.backends.base.df.scope import Scope
-from ibis.backends.base.df.timecontext import TimeContext
 from ibis.backends.dask import aggcontext as agg_ctx
 from ibis.backends.dask.core import execute
 from ibis.backends.dask.dispatch import execute_node
 from ibis.backends.dask.execution.util import coerce_to_output, safe_concat
+
+if TYPE_CHECKING:
+    from ibis.backends.base.df.timecontext import TimeContext
 
 
 # TODO - aggregations - #2553

--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import operator
+from typing import TYPE_CHECKING
 
 import dask.dataframe as dd
 import pandas as pd
@@ -12,7 +13,6 @@ from toolz import concatv
 import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 from ibis.backends.base.df.scope import Scope
-from ibis.backends.base.df.timecontext import TimeContext
 from ibis.backends.dask.core import execute
 from ibis.backends.dask.dispatch import execute_node
 from ibis.backends.dask.execution.util import (
@@ -28,6 +28,9 @@ from ibis.backends.pandas.execution.selection import (
     remap_overlapping_column_names,
 )
 from ibis.backends.pandas.execution.util import get_join_suffix_for_op
+
+if TYPE_CHECKING:
+    from ibis.backends.base.df.timecontext import TimeContext
 
 
 # TODO(kszucs): deduplicate with pandas.compute_projection() since it is almost

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -1,22 +1,25 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Type, Union
 
 import dask.dataframe as dd
 import dask.delayed
-import numpy as np
 import pandas as pd
-from dask.dataframe.groupby import SeriesGroupBy
 
 import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 import ibis.util
 from ibis.backends.base.df.scope import Scope
-from ibis.backends.base.df.timecontext import TimeContext
 from ibis.backends.dask.core import execute
-from ibis.backends.pandas.trace import TraceTwoLevelDispatcher
 from ibis.common import graph
-from ibis.expr.operations.sortkeys import SortKey
+
+if TYPE_CHECKING:
+    import numpy as np
+    from dask.dataframe.groupby import SeriesGroupBy
+
+    from ibis.backends.base.df.timecontext import TimeContext
+    from ibis.backends.pandas.trace import TraceTwoLevelDispatcher
+    from ibis.expr.operations.sortkeys import SortKey
 
 DispatchRule = Tuple[Tuple[Union[Type, Tuple], ...], Callable]
 

--- a/ibis/backends/dask/execution/window.py
+++ b/ibis/backends/dask/execution/window.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import operator
 import re
-from typing import Any, Callable, NoReturn
+from typing import TYPE_CHECKING, Any, Callable, NoReturn
 
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
@@ -15,9 +15,6 @@ from multipledispatch import Dispatcher
 import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 from ibis.backends.base.df.scope import Scope
-from ibis.backends.base.df.timecontext import (
-    TimeContext,
-)
 from ibis.backends.dask import aggcontext as agg_ctx
 from ibis.backends.dask.core import compute_time_context, execute
 from ibis.backends.dask.dispatch import execute_node
@@ -28,7 +25,6 @@ from ibis.backends.dask.execution.util import (
     compute_sorted_frame,
     make_meta_series,
 )
-from ibis.backends.pandas.aggcontext import AggregationContext
 from ibis.backends.pandas.core import (
     date_types,
     integer_types,
@@ -37,6 +33,12 @@ from ibis.backends.pandas.core import (
     timestamp_types,
 )
 from ibis.backends.pandas.execution.window import _post_process_group_by_order_by
+
+if TYPE_CHECKING:
+    from ibis.backends.base.df.timecontext import (
+        TimeContext,
+    )
+    from ibis.backends.pandas.aggcontext import AggregationContext
 
 
 def _check_valid_window_frame(frame):

--- a/ibis/backends/dask/tests/conftest.py
+++ b/ibis/backends/dask/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import dask
 import pandas as pd
@@ -11,6 +10,9 @@ import pytest
 import ibis
 from ibis.backends.pandas.tests.conftest import TestConf as PandasTest
 from ibis.backends.tests.data import array_types, win
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 dd = pytest.importorskip("dask.dataframe")
 

--- a/ibis/backends/dask/tests/execution/test_timecontext.py
+++ b/ibis/backends/dask/tests/execution/test_timecontext.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from pandas import Timedelta, Timestamp
 
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
-from ibis.backends.base.df.scope import Scope
 from ibis.backends.base.df.timecontext import (
     TimeContext,
     TimeContextRelation,
@@ -16,7 +17,11 @@ from ibis.backends.base.df.timecontext import (
 from ibis.backends.pandas.execution import execute
 
 dd = pytest.importorskip("dask.dataframe")
+
 from dask.dataframe.utils import tm  # noqa: E402
+
+if TYPE_CHECKING:
+    from ibis.backends.base.df.scope import Scope
 
 
 class CustomAsOfJoin(ops.AsOfJoin):

--- a/ibis/backends/dask/udf.py
+++ b/ibis/backends/dask/udf.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import contextlib
 import itertools
+from typing import TYPE_CHECKING
 
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
 import dask.delayed
-import numpy as np
 import pandas as pd
 
 import ibis.expr.operations as ops
@@ -20,6 +20,9 @@ from ibis.backends.dask.execution.util import (
     make_selected_obj,
 )
 from ibis.backends.pandas.udf import create_gens_from_args_groupby
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 def make_struct_op_meta(op: ir.Expr) -> list[tuple[str, np.dtype]]:

--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 import ibis
 import ibis.expr.types as ir
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 pa = pytest.importorskip("pyarrow")
 

--- a/ibis/backends/druid/tests/conftest.py
+++ b/ibis/backends/druid/tests/conftest.py
@@ -6,8 +6,7 @@ import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from itertools import chain, repeat
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from requests import Session
@@ -18,6 +17,9 @@ from ibis.backends.tests.base import (
     ServiceBackendTest,
     ServiceSpec,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 DRUID_URL = os.environ.get(
     "DRUID_URL", "druid://localhost:8082/druid/v2/sql?header=true"

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 from functools import partial
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
 import duckdb
 import numpy as np
@@ -15,7 +15,6 @@ from toolz.curried import flip
 import ibis.expr.operations as ops
 from ibis.backends.base.sql import alchemy
 from ibis.backends.base.sql.alchemy import unary
-from ibis.backends.base.sql.alchemy.datatypes import StructType
 from ibis.backends.base.sql.alchemy.registry import (
     _table_column,
     array_filter,
@@ -33,6 +32,9 @@ from ibis.backends.postgres.registry import (
     operation_registry,
 )
 from ibis.common.exceptions import UnsupportedOperationError
+
+if TYPE_CHECKING:
+    from ibis.backends.base.sql.alchemy.datatypes import StructType
 
 operation_registry = {
     op: operation_registry[op]

--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -10,6 +9,8 @@ from ibis.backends.conftest import SANDBOXED, TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ibis.backends.base import BaseBackend
 
 

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -9,7 +9,6 @@ import os
 import re
 import weakref
 from functools import cached_property
-from pathlib import Path
 from posixpath import join as pjoin
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -51,6 +50,8 @@ from ibis.backends.impala.udf import (
 from ibis.config import options
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pandas as pd
 
 

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import sqlalchemy as sa
 
-import ibis.expr.schema as sch
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.mssql.compiler import MsSqlCompiler
 from ibis.backends.mssql.datatypes import _type_from_result_set_info
+
+if TYPE_CHECKING:
+    import ibis.expr.schema as sch
 
 
 class Backend(BaseAlchemyBackend):

--- a/ibis/backends/mssql/tests/conftest.py
+++ b/ibis/backends/mssql/tests/conftest.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import sqlalchemy as sa
@@ -10,6 +9,9 @@ import sqlalchemy as sa
 import ibis
 from ibis.backends.conftest import init_database
 from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest, ServiceSpec
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 MSSQL_USER = os.environ.get('IBIS_TEST_MSSQL_USER', 'sa')
 MSSQL_PASS = os.environ.get('IBIS_TEST_MSSQL_PASSWORD', '1bis_Testing!')

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import Iterable, Literal
+from typing import TYPE_CHECKING, Iterable, Literal
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
 
-import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.mysql.compiler import MySQLCompiler
 from ibis.backends.mysql.datatypes import MySQLDateTime, _type_from_cursor_info
+
+if TYPE_CHECKING:
+    import ibis.expr.datatypes as dt
 
 
 class Backend(BaseAlchemyBackend):

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import sqlalchemy as sa
@@ -11,6 +10,9 @@ from packaging.version import parse as parse_version
 import ibis
 from ibis.backends.conftest import TEST_TABLES, init_database
 from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest, ServiceSpec
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 MYSQL_USER = os.environ.get('IBIS_TEST_MYSQL_USER', 'ibis')
 MYSQL_PASS = os.environ.get('IBIS_TEST_MYSQL_PASSWORD', 'ibis')

--- a/ibis/backends/oracle/tests/conftest.py
+++ b/ibis/backends/oracle/tests/conftest.py
@@ -5,14 +5,16 @@ import contextlib
 import itertools
 import os
 import subprocess
-from pathlib import Path
-from typing import Any, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
 
 import pytest
 import sqlalchemy as sa
 
 import ibis
 from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest, ServiceSpec
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 ORACLE_USER = os.environ.get('IBIS_TEST_ORACLE_USER', 'ibis')
 ORACLE_PASS = os.environ.get('IBIS_TEST_ORACLE_PASSWORD', 'ibis')

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -220,9 +220,8 @@ import abc
 import functools
 import itertools
 import operator
-from typing import Any, Callable, Iterator
+from typing import TYPE_CHECKING, Any, Callable, Iterator
 
-import numpy as np
 import pandas as pd
 from pandas.core.groupby import SeriesGroupBy
 
@@ -235,6 +234,9 @@ from ibis.backends.base.df.timecontext import (
     construct_time_context_aware_series,
     get_time_col,
 )
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class AggregationContext(abc.ABC):

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import operator
 from collections import defaultdict
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 
 import pandas as pd
 from toolz import concatv, first
@@ -14,11 +14,13 @@ import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.backends.base.df.scope import Scope
-from ibis.backends.base.df.timecontext import TimeContext
 from ibis.backends.pandas.core import execute
 from ibis.backends.pandas.dispatch import execute_node
 from ibis.backends.pandas.execution import constants, util
 from ibis.backends.pandas.execution.util import coerce_to_output
+
+if TYPE_CHECKING:
+    from ibis.backends.base.df.timecontext import TimeContext
 
 
 def compute_projection(

--- a/ibis/backends/pandas/execution/timecontext.py
+++ b/ibis/backends/pandas/execution/timecontext.py
@@ -31,15 +31,19 @@ time context.
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import ibis.expr.operations as ops
-from ibis.backends.base import BaseBackend
-from ibis.backends.base.df.scope import Scope
 from ibis.backends.base.df.timecontext import TimeContext, adjust_context
 from ibis.backends.pandas.core import (
     compute_time_context,
     get_node_arguments,
     is_computable_input,
 )
+
+if TYPE_CHECKING:
+    from ibis.backends.base import BaseBackend
+    from ibis.backends.base.df.scope import Scope
 
 
 @compute_time_context.register(ops.AsOfJoin)

--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import operator
 import re
-from typing import Any, Callable, NoReturn
+from typing import TYPE_CHECKING, Any, Callable, NoReturn
 
 import numpy as np
 import pandas as pd
@@ -21,7 +21,6 @@ from ibis.backends.base.df.timecontext import (
     get_time_col,
 )
 from ibis.backends.pandas import aggcontext as agg_ctx
-from ibis.backends.pandas.aggcontext import AggregationContext
 from ibis.backends.pandas.core import (
     compute_time_context,
     date_types,
@@ -33,6 +32,9 @@ from ibis.backends.pandas.core import (
 )
 from ibis.backends.pandas.dispatch import execute_node, pre_execute
 from ibis.backends.pandas.execution import util
+
+if TYPE_CHECKING:
+    from ibis.backends.pandas.aggcontext import AggregationContext
 
 
 def _post_process_empty(

--- a/ibis/backends/pandas/tests/conftest.py
+++ b/ibis/backends/pandas/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
@@ -9,6 +9,9 @@ import ibis.expr.operations as ops
 from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundHalfToEven
 from ibis.backends.tests.data import array_types, json_types, struct_types, win
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestConf(BackendTest, RoundHalfToEven):

--- a/ibis/backends/polars/tests/conftest.py
+++ b/ibis/backends/polars/tests/conftest.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 import ibis
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 from ibis.backends.tests.data import array_types, struct_types, win
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 pl = pytest.importorskip("polars")
 

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -14,8 +14,7 @@ from __future__ import annotations
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import sqlalchemy as sa
@@ -23,6 +22,9 @@ import sqlalchemy as sa
 import ibis
 from ibis.backends.conftest import init_database
 from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest, ServiceSpec
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 PG_USER = os.environ.get(
     'IBIS_TEST_POSTGRES_USER', os.environ.get('PGUSER', 'postgres')

--- a/ibis/backends/pyspark/timecontext.py
+++ b/ibis/backends/pyspark/timecontext.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pyspark.sql.functions as F
-from pyspark.sql.dataframe import DataFrame
 
 import ibis.common.exceptions as com
 from ibis.backends.base.df.timecontext import TimeContext, get_time_col
+
+if TYPE_CHECKING:
+    from pyspark.sql.dataframe import DataFrame
 
 
 def filter_by_time_context(

--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -4,7 +4,6 @@ import concurrent.futures
 import functools
 import os
 from functools import partial
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -16,6 +15,8 @@ from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 from ibis.util import consume
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import ibis.expr.types as ir
     from ibis.backends.base import BaseBackend
 

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 import datetime
 import sqlite3
-from pathlib import Path
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 import sqlalchemy as sa
 import toolz
@@ -30,6 +29,9 @@ from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.sqlite import udf
 from ibis.backends.sqlite.compiler import SQLiteCompiler
 from ibis.backends.sqlite.datatypes import dtype_to_sqlite, parse
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def to_datetime(value: str | None) -> datetime.datetime | None:

--- a/ibis/backends/sqlite/tests/conftest.py
+++ b/ibis/backends/sqlite/tests/conftest.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import csv
 import sqlite3
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -14,6 +13,8 @@ from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ibis.backends.base import BaseBackend
 
 

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -5,7 +5,7 @@ import concurrent.futures
 import inspect
 import subprocess
 from pathlib import Path
-from typing import Any, Iterable, Mapping, NamedTuple
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -13,7 +13,8 @@ import pandas.testing as tm
 import pytest
 from filelock import FileLock
 
-import ibis.expr.types as ir
+if TYPE_CHECKING:
+    import ibis.expr.types as ir
 
 
 # TODO: Merge into BackendTest, #2564

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 
 import pytest

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -7,6 +7,7 @@ import re
 import string
 import subprocess
 import sys
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -21,8 +22,10 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.base import BaseBackend
 from ibis.util import gen_name, guid
+
+if TYPE_CHECKING:
+    from ibis.backends.base import BaseBackend
 
 
 @pytest.fixture

--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import functools
 import weakref
 from collections import Counter, defaultdict
-from collections.abc import Iterator
-from typing import Any, Callable, MutableMapping
+from typing import TYPE_CHECKING, Any, Callable, MutableMapping
 
 from bidict import bidict
 
 from ibis.common.collections import FrozenDict
 from ibis.common.exceptions import IbisError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def memoize(func: Callable) -> Callable:

--- a/ibis/common/collections.py
+++ b/ibis/common/collections.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from collections.abc import Iterator
 from itertools import tee
 from types import MappingProxyType
-from typing import Any, Hashable, Mapping, TypeVar
+from typing import TYPE_CHECKING, Any, Hashable, Mapping, TypeVar
 
 from public import public
-from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")

--- a/ibis/common/egraph.py
+++ b/ibis/common/egraph.py
@@ -3,12 +3,22 @@ from __future__ import annotations
 import collections
 import itertools
 import math
-from typing import Any, Hashable, Iterable, Iterator, Mapping, Set, TypeVar
-
-from typing_extensions import Self
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Hashable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Set,
+    TypeVar,
+)
 
 from ibis.common.graph import Node
 from ibis.util import promote_list
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 K = TypeVar("K", bound=Hashable)
 

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 import inspect
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import pytest
 from toolz import identity
-from typing_extensions import Annotated
 
 from ibis.common.annotations import Argument, Attribute, Parameter, Signature, annotated
 from ibis.common.validators import instance_of, option
+
+if TYPE_CHECKING:
+    from typing_extensions import Annotated
 
 is_int = instance_of(int)
 

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Union
+from typing import Union
 
 import pytest
 from toolz import identity
+from typing_extensions import Annotated  # noqa: TCH002
 
 from ibis.common.annotations import Argument, Attribute, Parameter, Signature, annotated
 from ibis.common.validators import instance_of, option
-
-if TYPE_CHECKING:
-    from typing_extensions import Annotated
 
 is_int = instance_of(int)
 

--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -5,7 +5,6 @@ import os
 from typing import TYPE_CHECKING, Optional
 
 import ibis
-from ibis.backends.base import BaseBackend
 from ibis.common.grounds import Concrete
 
 try:
@@ -15,6 +14,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir
+    from ibis.backends.base import BaseBackend
 
 _EXAMPLES = None
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -6,10 +6,7 @@ import datetime
 import functools
 import numbers
 import operator
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterable, NamedTuple, Sequence, TypeVar
-
-import numpy as np
 
 import ibis.expr.builders as bl
 import ibis.expr.datatypes as dt
@@ -39,6 +36,9 @@ from ibis.expr.types import (
 from ibis.util import experimental
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
+    import numpy as np
     import pandas as pd
     import pyarrow as pa
 

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
+import datetime  # noqa: TCH003
+import decimal  # noqa: TCH003
 import sys
+import uuid  # noqa: TCH003
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Tuple
+from typing import Dict, List, NamedTuple, Tuple
 
 import pytest
 
 import ibis.expr.datatypes as dt
 from ibis.common.temporal import TimestampUnit
-
-if TYPE_CHECKING:
-    import datetime
-    import decimal
-    import uuid
 
 
 def test_validate_type():
@@ -210,7 +208,7 @@ class PyStruct:
     l: Dict[str, int]  # noqa: UP006, E741
     n: Tuple[str]  # noqa: UP006
     o: uuid.UUID
-    p: type(None)
+    p: None
     q: MyStruct
 
 

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-import datetime
-import decimal
 import sys
-import uuid
 from dataclasses import dataclass
-from typing import Dict, List, NamedTuple, Tuple
+from typing import TYPE_CHECKING, Dict, List, NamedTuple, Tuple
 
 import pytest
 
 import ibis.expr.datatypes as dt
 from ibis.common.temporal import TimestampUnit
+
+if TYPE_CHECKING:
+    import datetime
+    import decimal
+    import uuid
 
 
 def test_validate_type():

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import collections
 import functools
 import textwrap
-import types
-from typing import Any, Callable, Deque, Iterable, Mapping, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Deque, Iterable, Mapping, Tuple
 
 import rich.pretty
 
@@ -15,6 +14,9 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common import graph
+
+if TYPE_CHECKING:
+    import types
 
 Aliases = Mapping[ops.TableNode, int]
 Deps = Deque[Tuple[int, ops.TableNode]]

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import collections
 import functools
 import textwrap
-from typing import TYPE_CHECKING, Any, Callable, Deque, Iterable, Mapping, Tuple
+import types  # noqa: TCH003
+from typing import Any, Callable, Deque, Iterable, Mapping, Tuple
 
 import rich.pretty
 
@@ -14,9 +15,6 @@ import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common import graph
-
-if TYPE_CHECKING:
-    import types
 
 Aliases = Mapping[ops.TableNode, int]
 Deps = Deque[Tuple[int, ops.TableNode]]

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import pyarrow as pa
 
 import ibis.expr.datatypes as dt
 from ibis.expr.schema import Schema
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 _from_pyarrow_types = {
     pa.int8(): dt.Int8,

--- a/ibis/tests/expr/test_format.py
+++ b/ibis/tests/expr/test_format.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 import pytest

--- a/ibis/udf/validate.py
+++ b/ibis/udf/validate.py
@@ -8,10 +8,12 @@ DO NOT USE DIRECTLY.
 from __future__ import annotations
 
 from inspect import Parameter, Signature, signature
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import ibis.common.exceptions as com
-from ibis.expr.datatypes import DataType
+
+if TYPE_CHECKING:
+    from ibis.expr.datatypes import DataType
 
 
 def _parameter_count(funcsig: Signature) -> int:

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -14,7 +14,6 @@ import textwrap
 import types
 import uuid
 import warnings
-from numbers import Real
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -29,6 +28,7 @@ from uuid import uuid4
 import toolz
 
 if TYPE_CHECKING:
+    from numbers import Real
     from pathlib import Path
 
     import ibis.expr.operations as ops

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -394,6 +394,7 @@ select = [
   "SIM", # flake8-simplify
   "T10", # flake8-debugger
   "T20", # flake8-print
+  "TCH", # flake8-type-checking
   "TID", # flake8-tidy-imports
   "UP",  # pyupgrade
   "W",   # pycodestyle


### PR DESCRIPTION
This PR enables `flake8-type-checking` which is nice ruff lint that detects which imports are only used for type checking and then moves them under a `TYPE_CHECKING` guard. This apparently shaves off about 100 milliseconds from `import ibis`.