### PR TITLE
feat: implement read_delta for datafusion

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -489,8 +489,7 @@ class Backend(BaseAlchemyBackend):
         table_name
             An optional name to use for the created table. This defaults to
             a sequentially generated name.
-        kwargs
-            Additional keyword arguments passed to DuckDB loading function.
+        **kwargs
             Additional keyword arguments passed to deltalake.DeltaTable.
 
         Returns

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -325,7 +325,6 @@ def test_to_pyarrow_decimal(backend, dtype, pyarrow_dtype):
     [
         "bigquery",
         "clickhouse",
-        "datafusion",
         "impala",
         "oracle",
         "postgres",


### PR DESCRIPTION
closes #6384

one question is noted in the TODO -- my understanding is for csv and parquet we're using a native datafusion function for de-registering the files from the database, but we can't do that with delta yet?

datafusion has an issue open for native support: https://github.com/apache/arrow-datafusion/issues/2025

also cleaned up a docstring issue I noticed in duckdb
