### PR TITLE
fix(deps): prevent vulnerable snowflake-connector-python versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5363,4 +5363,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "de298252f963b9ba073c0639b35e3f5805a79e432691a0e7e9f827aad3bc16d4"
+content-hash = "189b4358c885d57d358b784754a2cde5bf5573c930be64a4792e4603653e4fd8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ shapely = { version = ">=1.9,<3", optional = true }
 # appears to cause poetry's solver to get stuck
 #
 # also, we don't support arbitrarily old versions of this library
-snowflake-connector-python = { version = ">=2.7.10,<4", optional = true, extras = [
+snowflake-connector-python = { version = ">=3.0.2,<4", optional = true, extras = [
   "pandas",
 ] }
 snowflake-sqlalchemy = { version = ">=1.4.1,<2", optional = true, extras = [


### PR DESCRIPTION
There is a vulnerability in snowflake-connector-python in versions below v3.0.2: <https://github.com/advisories/GHSA-5w5m-pfw9-c8fp>

I'm not so sure what are the considerations going into this lower pin, so if this isn't viable, feel free to just close. I mainly wanted to bring attention to this vulnerability.