### PR TITLE
chore(deps): allow wider range of `deltalake` versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5363,4 +5363,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "189b4358c885d57d358b784754a2cde5bf5573c930be64a4792e4603653e4fd8"
+content-hash = "5aad14a904276eaa231dd95992d976fc9e25db0a557908a3be566c5f0aa59655"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dask = { version = ">=2022.9.1", optional = true, extras = [
 ] }
 datafusion = { version = ">=0.6,<26", optional = true }
 db-dtypes = { version = ">=0.3,<2", optional = true }
-deltalake = { version = ">=0.9.0,<0.11.0", optional = true }
+deltalake = { version = ">=0.9.0,<1", optional = true }
 duckdb = { version = ">=0.3.3,<1", optional = true }
 duckdb-engine = { version = ">=0.1.8,<1", optional = true }
 fsspec = { version = ">=2022.1.0", optional = true }


### PR DESCRIPTION
Looks like deltalake is released at least once a month, and since we are using a small number of APIs in deltalake we should allow users to upgrade to versions that will almost certtainly work without having to cut a new release of ibis to pick up the deltalake version bumps.