### PR TITLE
test: remove use of specific now comparisons in tests

### DIFF
--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+import time
 from operator import floordiv, methodcaller, truediv
 
 import pandas as pd
@@ -260,10 +261,10 @@ def test_large_compile():
         table = table.mutate(dummy=ibis.literal(""))
         table = table.left_join(table, ["dummy"])[[table]]
 
-    start = datetime.datetime.now()
+    start = time.time()
     table.compile()
-    delta = datetime.datetime.now() - start
-    assert delta.total_seconds() < 10
+    delta = time.time() - start
+    assert delta < 10
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/sqlite/tests/test_functions.py
+++ b/ibis/backends/sqlite/tests/test_functions.py
@@ -1,4 +1,3 @@
-import datetime
 import math
 import sqlite3
 import uuid
@@ -69,13 +68,6 @@ def test_timestamp_functions(con):
     expr = value.strftime('%Y%m%d')
     expected = '20150901'
     assert con.execute(expr) == expected
-
-
-def test_now(con):
-    expr = ibis.now().strftime('%Y%m%d %H')
-    result = con.execute(expr)
-    expected = datetime.datetime.utcnow().strftime('%Y%m%d %H')
-    assert result == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Small PR to remove use of explicit values of `datetime.now` to avoid test flakiness.