### PR TITLE
ci: publish pre-release dists to pypi

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -55,3 +55,9 @@ jobs:
         run: poetry publish -r test-pypi
         env:
           POETRY_PYPI_TOKEN_TEST_PYPI: ${{ secrets.TEST_PYPI_TOKEN }}
+
+      - name: publish pre-release wheel to pypi
+        if: contains(steps.get_version.outputs.value, '.dev')
+        run: poetry publish
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Turns on publishing pre-releases to pypi proper.