### PR TITLE
chore(deps): remove ruff pin for conda lock files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,10 +19,6 @@
       "autoApprove": true
     },
     {
-      "matchPackagePatterns": ["ruff"],
-      "rangeStrategy": "pin"
-    },
-    {
       "matchPackagePatterns": ["clickhouse-connect"],
       "labels": ["clickhouse"]
     },

--- a/poetry.lock
+++ b/poetry.lock
@@ -5377,4 +5377,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "5aad14a904276eaa231dd95992d976fc9e25db0a557908a3be566c5f0aa59655"
+content-hash = "cef676148d3e684dabcbd2d71093720c5124938ded69098d97c9b628495aef3c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ ipython = ">=8.7.0,<9"
 poetry-dynamic-versioning = ">=0.18.0,<1"
 pre-commit = ">=3.1,<4"
 pydeps = ">=1.12.7,<2"
-ruff = "0.0.272"
+ruff = ">=0.0.271,<0.273"
 
 [tool.poetry.group.test.dependencies]
 black = ">=22.1.0,<24"


### PR DESCRIPTION
This PR partially reverts the specific ruff pin, so that conda has time to catch up and we can still generate conda lock files.