### PR TITLE
test(bigquery): make `list_tables` test using a guaranteed subset of tables

### DIFF
--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -34,9 +34,12 @@ def test_list_tables(con):
 
 
 def test_current_database(con, dataset_id):
-    assert con.current_database == dataset_id
-    assert con.current_database == con.dataset_id
-    assert con.list_tables(database=con.current_database) == con.list_tables()
+    db = con.current_database
+    assert db == dataset_id
+    assert db == con.dataset_id
+    assert con.list_tables(database=db, like="alltypes") == con.list_tables(
+        like="alltypes"
+    )
 
 
 def test_database(con):

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1223,14 +1223,16 @@ def gen_test_name(con: BaseBackend) -> str:
 def test_overwrite(ddl_con):
     t0 = ibis.memtable({"a": [1, 2, 3]})
 
-    with gen_test_name(ddl_con) as x, gen_test_name(ddl_con) as y:
+    with gen_test_name(ddl_con) as x:
         t1 = ddl_con.create_table(x, t0)
-
         t2 = t1.filter(t1.a < 3)
         expected_count = 2
 
         assert t2.count().execute() == expected_count
-        assert ddl_con.create_table(y, t2).count().execute() == expected_count
+
+        with gen_test_name(ddl_con) as y:
+            assert ddl_con.create_table(y, t2).count().execute() == expected_count
+
         assert (
             ddl_con.create_table(x, t2, overwrite=True).count().execute()
             == expected_count


### PR DESCRIPTION
Avoids failing a test due to temp tables being created by another process in between assertions