### PR TITLE
docs(api): manually add inherited mixin methods to timey classes

### DIFF
--- a/docs/api/expressions/timestamps.md
+++ b/docs/api/expressions/timestamps.md
@@ -6,15 +6,164 @@ All temporal operations are valid for both scalars and columns.
 ::: ibis.expr.types.temporal.TemporalValue
     options:
       show_source: true
+
+
 ::: ibis.expr.types.temporal.TimestampValue
     options:
       show_source: true
+      members: false
+<!-- prettier-ignore-end -->
+
+### Functions
+
+<!-- prettier-ignore-start -->
+::: ibis.expr.types.temporal.TimestampValue.add
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.between
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.TimestampValue.date
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.day
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.day_of_week
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.day_of_year
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.epoch_seconds
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.hour
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.millisecond
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.minute
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.month
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.second
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.TemporalValue.strftime
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.TimestampValue.sub
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.time
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.TimestampValue.truncate
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.quarter
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.week_of_year
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.year
+    options:
+      heading_level: 4
+
+
 ::: ibis.expr.types.temporal.DateValue
     options:
       show_source: true
+      members: false
+<!-- prettier-ignore-end -->
+
+### Functions
+
+<!-- prettier-ignore-start -->
+::: ibis.expr.types.temporal.DateValue.add
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.day
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.day_of_week
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.day_of_year
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.epoch_seconds
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.month
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.TemporalValue.strftime
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.DateValue.sub
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.DateValue.truncate
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.quarter
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.week_of_year
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._DateComponentMixin.year
+    options:
+      heading_level: 4
+
+
 ::: ibis.expr.types.temporal.TimeValue
     options:
       show_source: true
+      members: false
+<!-- prettier-ignore-end -->
+
+### Functions
+
+<!-- prettier-ignore-start -->
+::: ibis.expr.types.temporal.TimeValue.add
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.between
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.hour
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.millisecond
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.minute
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.second
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.TemporalValue.strftime
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.TimeValue.sub
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal._TimeComponentMixin.time
+    options:
+      heading_level: 4
+::: ibis.expr.types.temporal.TimeValue.truncate
+    options:
+      heading_level: 4
+
+
 ::: ibis.expr.types.temporal.IntervalValue
     options:
       show_source: true

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -207,6 +207,17 @@ class TimeValue(_TimeComponentMixin, TemporalValue):
         return _binop(ops.TimeAdd, self, other)
 
     add = radd = __radd__ = __add__
+    """Add an interval to a time expression.
+
+    Parameters
+    ----------
+    other : datetime.timedelta | pd.Timedelta | IntervalValue
+        Interval to add to time expression
+
+    Returns
+    -------
+    Value : TimeValue | NotImplemented
+    """
 
     def __sub__(
         self,
@@ -225,6 +236,17 @@ class TimeValue(_TimeComponentMixin, TemporalValue):
         return _binop(op, self, other)
 
     sub = __sub__
+    """Subtract a time or an interval from a time expression.
+
+    Parameters
+    ----------
+    other : TimeValue | IntervalValue
+        Interval to subtract from time expression
+
+    Returns
+    -------
+    Value : IntervalValue | TimeValue | NotImplemented
+    """
 
     def __rsub__(
         self,
@@ -280,6 +302,17 @@ class DateValue(TemporalValue, _DateComponentMixin):
         return _binop(ops.DateAdd, self, other)
 
     add = radd = __radd__ = __add__
+    """Add an interval to a date.
+
+    Parameters
+    ----------
+    other : datetime.timedelta | pd.Timedelta | IntervalValue
+        Interval to add to DateValue
+
+    Returns
+    -------
+    Value : DateValue | NotImplemented
+    """
 
     def __sub__(
         self,
@@ -302,6 +335,17 @@ class DateValue(TemporalValue, _DateComponentMixin):
         return _binop(op, self, other)
 
     sub = __sub__
+    """Subtract a date or an interval from a date.
+
+    Parameters
+    ----------
+    other : datetime.date | DateValue | datetime.timedelta | pd.Timedelta | IntervalValue
+        Interval to subtract from DateValue
+
+    Returns
+    -------
+    Value : DateValue | NotImplemented
+    """
 
     def __rsub__(
         self,
@@ -374,6 +418,17 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, TemporalValue):
         return _binop(ops.TimestampAdd, self, other)
 
     add = radd = __radd__ = __add__
+    """Add an interval to a timestamp.
+
+    Parameters
+    ----------
+    other : datetime.timedelta | pd.Timedelta | IntervalValue
+        Interval to subtract from timestamp
+
+    Returns
+    -------
+    Value : TimestampValue | NotImplemented
+    """
 
     def __sub__(
         self,
@@ -397,6 +452,17 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, TemporalValue):
         return _binop(op, self, other)
 
     sub = __sub__
+    """Subtract a timestamp or an interval from a timestamp.
+
+    Parameters
+    ----------
+    other : datetime.datetime | pd.Timestamp | TimestampValue | datetime.timedelta | pd.Timedelta | IntervalValue
+        Timestamp or interval to subtract from timestamp
+
+    Returns
+    -------
+    Value : IntervalValue | TimestampValue | NotImplemented
+    """
 
     def __rsub__(
         self,


### PR DESCRIPTION
This wasn't exactly fun and it isn't the MOST maintainable thing, but
until mkdocstrings has support for rendering inherited class members,
this will at least give users something to look at / refer to.

Fixes #6428