### PR TITLE
docs: add read_delta and related to backends docs

### DIFF
--- a/docs/backends/Datafusion.md
+++ b/docs/backends/Datafusion.md
@@ -3,8 +3,8 @@ backend_name: Datafusion
 backend_url: https://arrow.apache.org/datafusion/
 backend_module: datafusion
 version_added: "2.1"
-exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
-imports: ["CSV", "Parquet"]
+exports: ["PyArrow", "Parquet", "Delta Lake", "CSV", "Pandas"]
+imports: ["CSV", "Parquet", "Delta Lake"]
 ---
 
 {% include 'backends/badges.md' %}
@@ -63,6 +63,10 @@ con = ibis.datafusion.connect(
       heading_level: 4
       show_docstring_returns: false
 ::: ibis.backends.datafusion.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.datafusion.Backend.read_delta
     options:
       heading_level: 4
       show_docstring_returns: false

--- a/docs/backends/DuckDB.md
+++ b/docs/backends/DuckDB.md
@@ -2,8 +2,18 @@
 backend_name: DuckDB
 backend_url: https://duckdb.org/
 backend_module: duckdb
-exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
-imports: ["CSV", "Parquet", "JSON", "PyArrow", "Pandas", "SQLite", "Postgres"]
+exports: ["PyArrow", "Parquet", "Delta Lake", "CSV", "Pandas"]
+imports:
+  [
+    "CSV",
+    "Parquet",
+    "Delta Lake",
+    "JSON",
+    "PyArrow",
+    "Pandas",
+    "SQLite",
+    "Postgres",
+  ]
 ---
 
 {% include 'backends/badges.md' %}
@@ -86,6 +96,10 @@ con = ibis.connect("duckdb://") # (1)
       heading_level: 4
       show_docstring_returns: false
 ::: ibis.backends.duckdb.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.duckdb.Backend.read_delta
     options:
       heading_level: 4
       show_docstring_returns: false

--- a/docs/backends/Polars.md
+++ b/docs/backends/Polars.md
@@ -4,8 +4,8 @@ backend_url: https://pola-rs.github.io/polars-book/user-guide/index.html
 backend_module: polars
 is_experimental: true
 version_added: "4.0"
-exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
-imports: ["CSV", "Parquet", "Pandas"]
+exports: ["PyArrow", "Parquet", "Delta Lake", "CSV", "Pandas"]
+imports: ["CSV", "Parquet", "Delta Lake", "Pandas"]
 ---
 
 {% include 'backends/badges.md' %}
@@ -61,6 +61,10 @@ con = ibis.polars.connect()
       heading_level: 4
       show_docstring_returns: false
 ::: ibis.backends.polars.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.polars.Backend.read_delta
     options:
       heading_level: 4
       show_docstring_returns: false

--- a/docs/backends/badges.md
+++ b/docs/backends/badges.md
@@ -1,3 +1,3 @@
-{% if imports %} ![filebadge](https://img.shields.io/badge/Reads-{{ "%20|%20".join(imports) }}-blue?style=flat-square) {% endif %}
+{% if imports %} ![filebadge](https://img.shields.io/badge/Reads-{{ "%20|%20".join(sorted(imports)) }}-blue?style=flat-square) {% endif %}
 
-{% if exports %} ![exportbadge](https://img.shields.io/badge/Exports-{{ "%20|%20".join(exports) }}-orange?style=flat-square) {% endif %}
+{% if exports %} ![exportbadge](https://img.shields.io/badge/Exports-{{ "%20|%20".join(sorted(exports)) }}-orange?style=flat-square) {% endif %}

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -293,7 +293,7 @@ class Backend(BaseAlchemyBackend):
             File or list of files
         table_name
             Optional table name
-        kwargs
+        **kwargs
             Additional keyword arguments passed to DuckDB's `read_json_auto` function
 
         Returns
@@ -336,7 +336,7 @@ class Backend(BaseAlchemyBackend):
         table_name
             An optional name to use for the created table. This defaults to
             a sequentially generated name.
-        kwargs
+        **kwargs
             Additional keyword arguments passed to DuckDB loading function.
             See https://duckdb.org/docs/data/csv for more information.
 
@@ -382,7 +382,7 @@ class Backend(BaseAlchemyBackend):
         table_name
             An optional name to use for the created table. This defaults to
             a sequentially generated name.
-        kwargs
+        **kwargs
             Additional keyword arguments passed to DuckDB loading function.
             See https://duckdb.org/docs/data/parquet for more information.
 
@@ -754,7 +754,7 @@ class Backend(BaseAlchemyBackend):
             The data source. A string or Path to the parquet file.
         params
             Mapping of scalar parameter expressions to value.
-        kwargs
+        **kwargs
             DuckDB Parquet writer arguments. See
             https://duckdb.org/docs/data/parquet#writing-to-parquet-files for
             details
@@ -808,7 +808,7 @@ class Backend(BaseAlchemyBackend):
             Mapping of scalar parameter expressions to value.
         header
             Whether to write the column names as the first line of the CSV file.
-        kwargs
+        **kwargs
             DuckDB CSV writer arguments. https://duckdb.org/docs/data/csv.html#parameters
         """
         query = self._to_sql(expr, params=params)


### PR DESCRIPTION
adds the `read_delta` docstrings to the relevant backend docs and add in the badges

minor consistency in DuckDB docstrings with `**kwargs` instead of `kwargs`

~~in the top-level API doc, move `read_delta` to after `read_parquet` for consistency~~
