### PR TITLE
refactor(datatypes): normalize interval values to integers

### DIFF
--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -478,7 +478,7 @@ def test_range_window_function(alltypes, window, snapshot):
         param(ibis.interval(hours=1), id="hours"),
         param(ibis.interval(days=1), id="days"),
         param(2 * ibis.interval(days=1), id="two_days"),
-        param(ibis.interval(weeks=1), id="week"),
+        param(ibis.interval(weeks=1), id="week", marks=pytest.mark.xfail),
     ],
 )
 def test_trailing_range_window(alltypes, preceding, snapshot):

--- a/ibis/backends/duckdb/datatypes.py
+++ b/ibis/backends/duckdb/datatypes.py
@@ -25,7 +25,7 @@ from ibis.common.parsing import (
 def parse(text: str, default_decimal_parameters=(18, 3)) -> dt.DataType:
     """Parse a DuckDB type into an ibis data type."""
     primitive = (
-        spaceless_string("interval").result(dt.Interval())
+        spaceless_string("interval").result(dt.Interval('us'))
         | spaceless_string("bigint", "int8", "long").result(dt.int64)
         | spaceless_string("boolean", "bool", "logical").result(dt.boolean)
         | spaceless_string("blob", "bytea", "binary", "varbinary").result(dt.binary)

--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -36,7 +36,7 @@ from ibis.backends.duckdb.datatypes import parse
             ("INT4", dt.int32),
             ("INT", dt.int32),
             ("SIGNED", dt.int32),
-            ("INTERVAL", dt.interval),
+            ("INTERVAL", dt.Interval('us')),
             ("REAL", dt.float32),
             ("FLOAT4", dt.float32),
             ("FLOAT", dt.float32),

--- a/ibis/backends/postgres/datatypes.py
+++ b/ibis/backends/postgres/datatypes.py
@@ -67,7 +67,7 @@ _type_mapping = {
     "geometry": dt.geometry,
     "inet": dt.inet,
     "integer": dt.int32,
-    "interval": dt.interval,
+    "interval": dt.Interval('s'),
     "json": dt.json,
     "jsonb": dt.json,
     "line": dt.linestring,

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -188,7 +188,7 @@ def test_create_and_drop_table(con, temp_table, params):
             ("time without time zone", dt.time),
             ("timestamp without time zone", dt.timestamp),
             ("timestamp with time zone", dt.Timestamp("UTC")),
-            ("interval", dt.interval),
+            ("interval", dt.Interval("s")),
             ("numeric", dt.decimal),
             ("numeric(3, 2)", dt.Decimal(3, 2)),
             ("uuid", dt.uuid),

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pandas.testing as tm
 import pytest
 import sqlalchemy as sa
-import sqlglot
 from pytest import param
 
 import ibis
@@ -973,6 +972,11 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     raises=com.UnsupportedOperationError,
                     reason='BigQuery does not allow binary operation TIMESTAMP_ADD with INTERVAL offset D',
                 ),
+                pytest.mark.broken(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="DateTime column overflows, should use DateTime64",
+                ),
             ],
         ),
         param(
@@ -1008,27 +1012,9 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
             ],
         ),
         param(
-            '1.5d',
-            plus,
-            marks=[
-                pytest.mark.broken(["mysql"], raises=AssertionError),
-                pytest.mark.broken(
-                    ['druid'],
-                    raises=com.IbisTypeError,
-                    reason="Given argument with datatype interval('s') is not implicitly castable to string",
-                ),
-                pytest.mark.broken(
-                    ["bigquery"],
-                    raises=GoogleBadRequest,
-                    reason='400 Syntax error: Expected ")" but got integer literal "12" at [1:58]',
-                ),
-            ],
-        ),
-        param(
             '2h',
             plus,
             marks=[
-                pytest.mark.broken(["mysql"], raises=AssertionError),
                 pytest.mark.broken(
                     ['druid'],
                     raises=com.IbisTypeError,
@@ -1045,7 +1031,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
             '3m',
             plus,
             marks=[
-                pytest.mark.broken(["mysql"], raises=AssertionError),
                 pytest.mark.broken(
                     ['druid'],
                     raises=com.IbisTypeError,
@@ -1062,7 +1047,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
             '10s',
             plus,
             marks=[
-                pytest.mark.broken(["mysql"], raises=AssertionError),
                 pytest.mark.broken(
                     ['druid'],
                     raises=com.IbisTypeError,
@@ -1089,6 +1073,11 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     raises=com.UnsupportedOperationError,
                     reason='BigQuery does not allow binary operation TIMESTAMP_SUB with INTERVAL offset D',
                 ),
+                pytest.mark.broken(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="DateTime column overflows, should use DateTime64",
+                ),
             ],
         ),
         param(
@@ -1124,27 +1113,9 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
             ],
         ),
         param(
-            '1.5d',
-            minus,
-            marks=[
-                pytest.mark.broken(["mysql"], raises=AssertionError),
-                pytest.mark.broken(
-                    ["druid"],
-                    raises=TypeError,
-                    reason="unsupported operand type(s) for -: 'StringColumn' and 'Timedelta'",
-                ),
-                pytest.mark.broken(
-                    ["bigquery"],
-                    raises=GoogleBadRequest,
-                    reason='400 Syntax error: Expected ")" but got integer literal "12" at [1:58]',
-                ),
-            ],
-        ),
-        param(
             '2h',
             minus,
             marks=[
-                pytest.mark.broken(["mysql"], raises=AssertionError),
                 pytest.mark.broken(
                     ["druid"],
                     raises=TypeError,
@@ -1161,7 +1132,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
             '3m',
             minus,
             marks=[
-                pytest.mark.broken(["mysql"], raises=AssertionError),
                 pytest.mark.broken(
                     ["druid"],
                     raises=TypeError,
@@ -1178,7 +1148,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
             '10s',
             minus,
             marks=[
-                pytest.mark.broken(["mysql"], raises=AssertionError),
                 pytest.mark.broken(
                     ["druid"],
                     raises=TypeError,
@@ -1194,25 +1163,8 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
     ],
 )
 @pytest.mark.notimpl(
-    ["datafusion", "impala", "sqlite", "mssql", "trino", "oracle"],
+    ["datafusion", "sqlite", "mssql", "trino", "oracle"],
     raises=com.OperationNotDefinedError,
-)
-@pytest.mark.notimpl(
-    ["impala"],
-    raises=ImpalaHiveServer2Error,
-)
-@pytest.mark.notimpl(
-    ["clickhouse"],
-    raises=sqlglot.errors.ParseError,
-    reason="Invalid expression / Unexpected token.",
-)
-@pytest.mark.notimpl(
-    ["snowflake"],
-    raises=sa.exc.ProgrammingError,
-)
-@pytest.mark.broken(
-    ["polars"],
-    raises=AssertionError,
 )
 def test_temporal_binop_pandas_timedelta(
     backend, con, alltypes, df, timedelta, temporal_fn

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -584,7 +584,7 @@ def test_date_truncate(backend, alltypes, df, unit):
                 pytest.mark.notimpl(
                     ['bigquery'],
                     raises=com.UnsupportedOperationError,
-                    reason="BigQuery does not allow binary operation TIMESTAMP_ADD with INTERVAL offset W",
+                    reason="BigQuery does not allow extracting date part `IntervalUnit.WEEK` from intervals",
                 ),
                 pytest.mark.notimpl(
                     ['dask'],
@@ -602,13 +602,6 @@ def test_date_truncate(backend, alltypes, df, unit):
             'D',
             pd.offsets.DateOffset,
             marks=[
-                pytest.mark.notimpl(
-                    ["bigquery"],
-                    raises=com.UnsupportedOperationError,
-                    reason=(
-                        "BigQuery does not allow binary operation TIMESTAMP_ADD with INTERVAL offset D"
-                    ),
-                ),
                 pytest.mark.notimpl(
                     ["pyspark"],
                     raises=com.UnsupportedOperationError,
@@ -782,10 +775,6 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
             id='timestamp-add-interval',
             marks=[
                 pytest.mark.notimpl(
-                    ["bigquery"],
-                    raises=com.UnsupportedOperationError,
-                ),
-                pytest.mark.notimpl(
                     ["sqlite"],
                     raises=com.OperationNotDefinedError,
                 ),
@@ -856,7 +845,6 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
             lambda t, _: t.timestamp_col - pd.Timedelta(days=17),
             id='timestamp-subtract-interval',
             marks=[
-                pytest.mark.notimpl(["bigquery"], raises=com.UnsupportedOperationError),
                 pytest.mark.notimpl(
                     ["druid"],
                     raises=TypeError,
@@ -967,11 +955,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     raises=com.IbisTypeError,
                     reason="Given argument with datatype interval('D') is not implicitly castable to string",
                 ),
-                pytest.mark.notimpl(
-                    ["bigquery"],
-                    raises=com.UnsupportedOperationError,
-                    reason='BigQuery does not allow binary operation TIMESTAMP_ADD with INTERVAL offset D',
-                ),
                 pytest.mark.broken(
                     ["clickhouse"],
                     raises=AssertionError,
@@ -988,11 +971,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     raises=com.IbisTypeError,
                     reason="Given argument with datatype interval('D') is not implicitly castable to string",
                 ),
-                pytest.mark.notimpl(
-                    ["bigquery"],
-                    raises=com.UnsupportedOperationError,
-                    reason='BigQuery does not allow binary operation TIMESTAMP_ADD with INTERVAL offset D',
-                ),
             ],
         ),
         param(
@@ -1003,11 +981,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     ['druid'],
                     raises=com.IbisTypeError,
                     reason="Given argument with datatype interval('D') is not implicitly castable to string",
-                ),
-                pytest.mark.notimpl(
-                    ["bigquery"],
-                    raises=com.UnsupportedOperationError,
-                    reason='BigQuery does not allow binary operation TIMESTAMP_ADD with INTERVAL offset D',
                 ),
             ],
         ),
@@ -1020,11 +993,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     raises=com.IbisTypeError,
                     reason="Given argument with datatype interval('h') is not implicitly castable to string",
                 ),
-                pytest.mark.broken(
-                    ["bigquery"],
-                    raises=GoogleBadRequest,
-                    reason='400 Syntax error: Expected ")" but got integer literal "02" at [1:58]',
-                ),
             ],
         ),
         param(
@@ -1035,11 +1003,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     ['druid'],
                     raises=com.IbisTypeError,
                     reason="Given argument with datatype interval('m') is not implicitly castable to string",
-                ),
-                pytest.mark.broken(
-                    ["bigquery"],
-                    raises=GoogleBadRequest,
-                    reason='400 Syntax error: Expected ")" but got integer literal "00" at [1:58]',
                 ),
             ],
         ),
@@ -1052,11 +1015,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     raises=com.IbisTypeError,
                     reason="Given argument with datatype interval('s') is not implicitly castable to string",
                 ),
-                pytest.mark.broken(
-                    ["bigquery"],
-                    raises=GoogleBadRequest,
-                    reason='400 Syntax error: Expected ")" but got integer literal "00" at [1:58]',
-                ),
             ],
         ),
         param(
@@ -1067,11 +1025,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     ["druid"],
                     raises=TypeError,
                     reason="unsupported operand type(s) for -: 'StringColumn' and 'Timedelta'",
-                ),
-                pytest.mark.notimpl(
-                    ["bigquery"],
-                    raises=com.UnsupportedOperationError,
-                    reason='BigQuery does not allow binary operation TIMESTAMP_SUB with INTERVAL offset D',
                 ),
                 pytest.mark.broken(
                     ["clickhouse"],
@@ -1089,11 +1042,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     raises=TypeError,
                     reason="unsupported operand type(s) for -: 'StringColumn' and 'Timedelta'",
                 ),
-                pytest.mark.notimpl(
-                    ["bigquery"],
-                    raises=com.UnsupportedOperationError,
-                    reason='BigQuery does not allow binary operation TIMESTAMP_SUB with INTERVAL offset D',
-                ),
             ],
         ),
         param(
@@ -1104,11 +1052,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     ["druid"],
                     raises=TypeError,
                     reason="unsupported operand type(s) for -: 'StringColumn' and 'Timedelta'",
-                ),
-                pytest.mark.notimpl(
-                    ["bigquery"],
-                    raises=com.UnsupportedOperationError,
-                    reason='BigQuery does not allow binary operation TIMESTAMP_SUB with INTERVAL offset D',
                 ),
             ],
         ),
@@ -1121,11 +1064,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     raises=TypeError,
                     reason="unsupported operand type(s) for -: 'StringColumn' and 'Timedelta'",
                 ),
-                pytest.mark.broken(
-                    ["bigquery"],
-                    raises=GoogleBadRequest,
-                    reason='400 Syntax error: Expected ")" but got integer literal "02" at [1:58]',
-                ),
             ],
         ),
         param(
@@ -1137,11 +1075,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     raises=TypeError,
                     reason="unsupported operand type(s) for -: 'StringColumn' and 'Timedelta'",
                 ),
-                pytest.mark.broken(
-                    ["bigquery"],
-                    raises=GoogleBadRequest,
-                    reason='400 Syntax error: Expected ")" but got integer literal "00" at [1:58]',
-                ),
             ],
         ),
         param(
@@ -1152,11 +1085,6 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     ["druid"],
                     raises=TypeError,
                     reason="unsupported operand type(s) for -: 'StringColumn' and 'Timedelta'",
-                ),
-                pytest.mark.broken(
-                    ["bigquery"],
-                    raises=GoogleBadRequest,
-                    reason='400 Syntax error: Expected ")" but got integer literal "00" at [1:58]',
                 ),
             ],
         ),

--- a/ibis/backends/trino/datatypes.py
+++ b/ibis/backends/trino/datatypes.py
@@ -93,7 +93,7 @@ def parse(text: str, default_decimal_parameters=(18, 3)) -> dt.DataType:
     )
 
     primitive = (
-        spaceless_string("interval").result(dt.Interval())
+        spaceless_string("interval").result(dt.Interval(unit='s'))
         | spaceless_string("bigint").result(dt.int64)
         | spaceless_string("boolean").result(dt.boolean)
         | spaceless_string("varbinary").result(dt.binary)

--- a/ibis/common/temporal.py
+++ b/ibis/common/temporal.py
@@ -23,7 +23,11 @@ class Unit(Coercible, Enum, metaclass=ABCEnumMeta):
     def __coerce__(cls, value):
         if isinstance(value, cls):
             return value
+        else:
+            return cls.from_string(value)
 
+    @classmethod
+    def from_string(cls, value):
         # first look for aliases
         value = cls.aliases().get(value, value)
 
@@ -117,6 +121,12 @@ class IntervalUnit(TemporalUnit):
     MILLISECOND = "ms"
     MICROSECOND = "us"
     NANOSECOND = "ns"
+
+    def is_date(self) -> bool:
+        return self.name in DateUnit.__members__
+
+    def is_time(self) -> bool:
+        return self.name in TimeUnit.__members__
 
 
 def normalize_timedelta(

--- a/ibis/common/tests/test_temporal.py
+++ b/ibis/common/tests/test_temporal.py
@@ -80,8 +80,8 @@ def test_interval_unit_aliases(alias, expected):
         (timedelta(seconds=1), IntervalUnit.SECOND, 1),
         (timedelta(milliseconds=1), IntervalUnit.MILLISECOND, 1),
         (timedelta(microseconds=1), IntervalUnit.MICROSECOND, 1),
-        (timedelta(days=1, milliseconds=100), IntervalUnit.MILLISECOND, 86400100),
-        (timedelta(days=1, milliseconds=21), IntervalUnit.MICROSECOND, 86400021000),
+        (timedelta(seconds=1, milliseconds=100), IntervalUnit.MILLISECOND, 1100),
+        (timedelta(seconds=1, milliseconds=21), IntervalUnit.MICROSECOND, 1021000),
     ],
 )
 def test_normalize_timedelta(value, unit, expected):

--- a/ibis/common/validators.py
+++ b/ibis/common/validators.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-from abc import ABC, abstractmethod
 from contextlib import suppress
 from inspect import Parameter
 from typing import (
@@ -23,6 +22,7 @@ from typing_extensions import Annotated, get_args, get_origin
 from ibis.common.collections import FrozenDict
 from ibis.common.dispatch import lazy_singledispatch
 from ibis.common.exceptions import IbisTypeError
+from ibis.common.patterns import Coercible
 from ibis.util import flatten_iterable, is_function, is_iterable
 
 try:
@@ -33,22 +33,6 @@ except ImportError:
 K = TypeVar('K')
 V = TypeVar('V')
 T = TypeVar('T')
-
-
-class Coercible(ABC):
-    """Protocol for defining coercible types.
-
-    Coercible types define a special ``__coerce__`` method that accepts an object
-    with an instance of the type. Used in conjunction with the ``coerced_to`` validator
-    to coerce arguments to a specific type.
-    """
-
-    __slots__ = ()
-
-    @classmethod
-    @abstractmethod
-    def __coerce__(cls, obj):
-        ...
 
 
 class Validator(Callable):

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -141,7 +141,7 @@ class DataType(Concrete, Coercible):
                 elif issubclass(typ, pydatetime.time):
                     return Time(nullable=nullable)
                 elif issubclass(typ, pydatetime.timedelta):
-                    return Interval(nullable=nullable)
+                    return Interval(unit='us', nullable=nullable)
                 elif issubclass(typ, pyuuid.UUID):
                     return UUID(nullable=nullable)
                 elif annots := get_type_hints(typ):
@@ -715,7 +715,7 @@ class Decimal(Numeric, Parametric):
 class Interval(Parametric):
     """Interval values."""
 
-    unit: IntervalUnit = 's'
+    unit: IntervalUnit
     """The time unit of the interval."""
 
     scalar = "IntervalScalar"
@@ -947,7 +947,6 @@ binary = Binary()
 date = Date()
 time = Time()
 timestamp = Timestamp()
-interval = Interval()
 # geo spatial data type
 geometry = GeoSpatial(geotype="geometry")
 geography = GeoSpatial(geotype="geography")
@@ -989,7 +988,6 @@ public(
     time=time,
     timestamp=timestamp,
     dtype=dtype,
-    interval=interval,
     geometry=geometry,
     geography=geography,
     point=point,

--- a/ibis/expr/datatypes/tests/test_cast.py
+++ b/ibis/expr/datatypes/tests/test_cast.py
@@ -37,7 +37,6 @@ def test_implicitly_castable_primitives(source, target):
         (dt.uint64, dt.uint16),
         (dt.Decimal(12, 2), dt.int32),
         (dt.timestamp, dt.boolean),
-        (dt.boolean, dt.interval),
         (dt.Interval('s'), dt.Interval('ns')),
     ],
 )

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -68,7 +68,6 @@ def test_dtype(spec, expected):
         (dt.Date, dt.date),
         (dt.Time, dt.time),
         (dt.Timestamp, dt.timestamp),
-        (dt.Interval, dt.interval),
         (dt.Decimal, dt.decimal),
     ],
 )
@@ -94,7 +93,6 @@ class FooStruct:
     o: dt.timestamp
     oa: dt.Timestamp('UTC')
     ob: dt.Timestamp('UTC', 6)
-    p: dt.interval
     pa: dt.Interval('s')
     q: dt.decimal
     qa: dt.Decimal(12, 2)
@@ -120,7 +118,6 @@ class BarStruct:
     o: dt.Timestamp
     oa: dt.Timestamp['UTC']  # noqa: F821
     ob: dt.Timestamp['UTC', 6]  # noqa: F821
-    p: dt.Interval
     pa: dt.Interval['s']
     q: dt.Decimal
     qa: dt.Decimal[12, 2]
@@ -147,7 +144,6 @@ baz_struct = dt.Struct(
         'o': dt.timestamp,
         'oa': dt.Timestamp('UTC'),
         'ob': dt.Timestamp('UTC', 6),
-        'p': dt.interval,
         'pa': dt.Interval('s'),
         'q': dt.decimal,
         'qa': dt.Decimal(12, 2),
@@ -233,7 +229,7 @@ py_struct = dt.Struct(
         'f': dt.date,
         'g': dt.time,
         'h': dt.timestamp,
-        'i': dt.interval,
+        'i': dt.Interval('us'),
         'j': dt.decimal,
         'k': dt.Array(dt.int64),
         'l': dt.Map(dt.string, dt.int64),
@@ -277,7 +273,6 @@ class FooDataClass:
 @pytest.mark.parametrize(
     ('hint', 'expected'),
     [
-        (dt.Interval, dt.Interval()),
         (dt.Array[dt.Null], dt.Array(dt.Null())),
         (dt.Map[dt.Null, dt.Null], dt.Map(dt.Null(), dt.Null())),
         (dt.Timestamp['UTC'], dt.Timestamp(timezone='UTC')),
@@ -545,6 +540,7 @@ def get_leaf_classes(op):
         dt.UnsignedInteger,
         dt.Variadic,
         dt.Parametric,
+        dt.Interval,
     },
 )
 def test_is_methods(dtype_class):

--- a/ibis/expr/datatypes/tests/test_parse.py
+++ b/ibis/expr/datatypes/tests/test_parse.py
@@ -26,7 +26,6 @@ import ibis.expr.datatypes as dt
         ('date', dt.date),
         ('time', dt.time),
         ('timestamp', dt.timestamp),
-        ('interval', dt.interval),
         ('point', dt.point),
         ('linestring', dt.linestring),
         ('polygon', dt.polygon),

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -86,7 +86,10 @@ def infer_interval(value: datetime.timedelta) -> dt.Interval:
     # datetime.timedelta only stores days, seconds, and microseconds internally
     if value.days:
         if value.seconds or value.microseconds:
-            raise ValueError("Unable to infer interval type from mixed units")
+            raise ValueError(
+                "Unable to infer interval type from mixed units, "
+                "use ibis.interval(timedelta) instead"
+            )
         else:
             return dt.Interval(IntervalUnit.DAY)
     elif value.seconds:

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -6,7 +6,6 @@ from public import public
 
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
-from ibis import util
 from ibis.common.annotations import attribute
 from ibis.common.temporal import DateUnit, IntervalUnit, TimestampUnit, TimeUnit
 from ibis.expr.operations.core import Binary, Unary, Value
@@ -267,27 +266,6 @@ class TimestampDiff(Binary):
     left = rlz.timestamp
     right = rlz.timestamp
     output_dtype = dt.Interval('s')
-
-
-@public
-class ToIntervalUnit(Value):
-    arg = rlz.interval
-    unit = rlz.coerced_to(IntervalUnit)
-
-    output_shape = rlz.shape_like("arg")
-
-    def __init__(self, arg, unit):
-        dtype = arg.output_dtype
-
-        # TODO(kszucs): remove the expression wrapping required for arithmetic
-        # overloads
-        if dtype.unit != unit:
-            arg = util.convert_unit(arg, dtype.unit.short, unit.short)
-        super().__init__(arg=arg, unit=unit)
-
-    @attribute.default
-    def output_dtype(self):
-        return self.arg.output_dtype.copy(unit=self.unit)
 
 
 @public

--- a/ibis/formats/tests/test_numpy.py
+++ b/ibis/formats/tests/test_numpy.py
@@ -131,4 +131,4 @@ def test_dtype_from_numpy_dtype_timedelta():
     if vparse(pytest.importorskip("pyarrow").__version__) < vparse("9"):
         pytest.skip("pyarrow < 9 globally mutates the timedelta64 numpy dtype")
 
-    assert NumpyType.to_ibis(np.dtype(np.timedelta64)) == dt.interval
+    assert NumpyType.to_ibis(np.dtype(np.timedelta64)) == dt.Interval("s")

--- a/ibis/tests/expr/test_pretty_repr.py
+++ b/ibis/tests/expr/test_pretty_repr.py
@@ -113,7 +113,7 @@ def test_format_date_column(is_date):
 
 def test_format_interval_column():
     values = [datetime.timedelta(seconds=1)]
-    fmts, _, _ = format_column(dt.interval, values)
+    fmts, _, _ = format_column(dt.Interval('s'), values)
     strs = [str(f) for f in fmts]
     assert strs == [str(v) for v in values]
 

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -105,9 +105,7 @@ def test_interval_function_invalid():
 )
 def test_upconvert(interval, unit, expected):
     result = interval.to_unit(unit)
-
-    assert isinstance(result, ir.IntervalScalar)
-    assert result.type().unit == expected.type().unit
+    assert result.equals(expected)
 
 
 @pytest.mark.parametrize('target', ['Y', 'Q', 'M'])

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -263,7 +263,7 @@ def convert_unit(value, unit, to, floor: bool = True):
     >>> x = convert_unit(one_second, 's', 'M')
     Traceback (most recent call last):
         ...
-    ValueError: Cannot convert to or from variable length interval
+    ValueError: Cannot convert to or from unit ... to unit ...
     """
     # Don't do anything if from and to units are equivalent
     if unit == to:

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -282,7 +282,9 @@ def convert_unit(value, unit, to, floor: bool = True):
             i, j = monthly_units.index(unit), monthly_units.index(to)
             factors = monthly_factors
         except ValueError:
-            raise ValueError('Cannot convert to or from variable length interval')
+            raise ValueError(
+                f"Cannot convert interval value from unit {unit} to unit {to}"
+            )
 
     factor = functools.reduce(operator.mul, factors[min(i, j) : max(i, j)], 1)
     assert factor > 1


### PR DESCRIPTION
BREAKING CHANGE: `dt.Interval` has no longer a default unit, `dt.interval` is removed

Xpassing tests for:
- Clickhouse
- BigQuery
- Snowflake
- Polars
- Impala
- MySQL

Should resolve https://github.com/ibis-project/ibis/issues/6457 