### PR TITLE
chore(dev-deps): dedup nix code for locking dependencies

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -49,11 +49,8 @@ in
 
   update-lock-files = pkgs.writeShellApplication {
     name = "update-lock-files";
-    runtimeInputs = [ pkgs.poetry ];
-    text = ''
-      poetry lock --no-update
-      poetry export --extras all --with dev --with test --with docs --without-hashes --no-ansi > requirements.txt
-    '';
+    runtimeInputs = with pkgs; [ just poetry ];
+    text = "just lock";
   };
 
   gen-examples = pkgs.writeShellApplication {


### PR DESCRIPTION
Small PR to reuse the logic in our justfile for relocking files with nix.