### PR TITLE
feat(memtable): allow creating memtable from RecordBatchReader

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -949,6 +949,29 @@ def test_memtable_construct(backend, con, monkeypatch):
     backend.assert_frame_equal(t.execute(), pa_t.to_pandas())
 
 
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
+@pytest.mark.broken(
+    ["druid"],
+    raises=AssertionError,
+    reason="result contains empty strings instead of None",
+)
+def test_memtable_construct_rbr(backend, con, monkeypatch):
+    pa = pytest.importorskip("pyarrow")
+    monkeypatch.setattr(ibis.options, "default_backend", con)
+
+    pa_t = pa.Table.from_pydict(
+        {
+            "a": list("abc"),
+            "b": [1, 2, 3],
+            "c": [1.0, 2.0, 3.0],
+            "d": [None, "b", None],
+        }
+    )
+    pa_rbr = pa.RecordBatchReader.from_batches(pa_t.schema, pa_t.to_batches())
+    t = ibis.memtable(pa_rbr)
+    backend.assert_frame_equal(t.execute(), pa_pyarrow objects.invt.to_pandas())
+
+
 @pytest.mark.notimpl(
     ["dask", "datafusion", "pandas", "polars"],
     raises=NotImplementedError,

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -126,6 +126,16 @@ class PyArrowTableProxy(TableProxy):
         return self._data
 
 
+class PyArrowRBRProxy(TableProxy):
+    __slots__ = ()
+
+    def to_frame(self):
+        return self._data.read_pandas()
+
+    def to_pyarrow(self, schema: Schema) -> pa.Table:
+        return self._data.read_all()
+
+
 class PandasDataFrameProxy(TableProxy):
     __slots__ = ()
 

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -269,6 +269,7 @@ def infer_pandas_dataframe(df, schema=None):
 
 # TODO(kszucs): do we really need the schema kwarg?
 @infer.register("pyarrow.Table")
+@infer.register("pyarrow.RecordBatchReader")
 def infer_pyarrow_table(table, schema=None):
     from ibis.formats.pyarrow import PyArrowSchema
 


### PR DESCRIPTION
xref #5941 

Adding support for other objects in `create_table` is (usually) about making them available as `memtable`able objects.  
This adds naive support for feeding a `RecordBatchReader` into `memtable` -- I say naive because it will load all the batches into memory at creation time.