### PR TITLE
docs: use to_pandas instead of execute

### DIFF
--- a/docs/backends/Impala.md
+++ b/docs/backends/Impala.md
@@ -192,7 +192,7 @@ table.drop()
 
 ## Expression execution
 
-Ibis expressions have an `execute` method with compiles and runs the
+Ibis expressions have execution methods like `to_pandas` that compile and run the
 expressions on Impala or whichever backend is being referenced.
 
 For example:
@@ -200,7 +200,7 @@ For example:
 ```python
 >>> fa = db.functional_alltypes
 >>> expr = fa.double_col.sum()
->>> expr.execute()
+>>> expr.to_pandas()
 331785.00000000006
 ```
 
@@ -235,7 +235,7 @@ If you pass an Ibis expression to `create_table`, Ibis issues a
 >>> db.create_table('string_freqs', expr, format='parquet')
 
 >>> freqs = db.table('string_freqs')
->>> freqs.execute()
+>>> freqs.to_pandas()
   string_col  count
 0          9    730
 1          3    730
@@ -387,7 +387,7 @@ an Ibis table expression:
 >>> target.insert(t[:3])
 >>> target.insert(t[:3])
 
->>> target.execute()
+>>> target.to_pandas()
      id  bool_col  tinyint_col  ...           timestamp_col  year  month
 0  5770      True            0  ... 2010-08-01 00:00:00.000  2010      8
 1  5771     False            1  ... 2010-08-01 00:01:00.000  2010      8
@@ -824,7 +824,7 @@ a major part of the Ibis roadmap).
 Ibis's Impala tools currently interoperate with pandas in these ways:
 
 - Ibis expressions return pandas objects (i.e. DataFrame or Series)
-  for non-scalar expressions when calling their `execute` method
+  for non-scalar expressions when calling their `to_pandas` method
 - The `create_table` and `insert` methods can accept pandas objects.
   This includes inserting into partitioned tables. It currently uses
   CSV as the ingest route.
@@ -838,7 +838,7 @@ For example:
 
 >>> db.create_table('pandas_table', data)
 >>> t = db.pandas_table
->>> t.execute()
+>>> t.to_pandas()
   bar  foo
 0   a    1
 1   b    2
@@ -851,7 +851,7 @@ For example:
 
 >>> to_insert = db.empty_for_insert
 >>> to_insert.insert(data)
->>> to_insert.execute()
+>>> to_insert.to_pandas()
   bar  foo
 0   a    1
 1   b    2
@@ -868,7 +868,7 @@ For example:
 
 >>> db.create_table('pandas_table', data)
 >>> t = db.pandas_table
->>> t.execute()
+>>> t.to_pandas()
    foo bar
 0    1   a
 1    2   b
@@ -879,7 +879,7 @@ For example:
 >>> db.create_table('empty_for_insert', schema=t.schema())
 >>> to_insert = db.empty_for_insert
 >>> to_insert.insert(data)
->>> to_insert.execute()
+>>> to_insert.to_pandas()
    foo bar
 0    1   a
 1    2   b
@@ -1215,7 +1215,7 @@ may significantly speed up queries on smaller datasets:
 ```
 
 ```bash
-$ time python -c "(t.double_col + rand()).sum().execute()"
+$ time python -c "(t.double_col + rand()).sum().to_pandas()"
 27.7 ms ± 996 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
 ```
 
@@ -1225,7 +1225,7 @@ con.disable_codegen(False)
 ```
 
 ```bash
-$ time python -c "(t.double_col + rand()).sum().execute()"
+$ time python -c "(t.double_col + rand()).sum().to_pandas()"
 27 ms ± 1.62 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
 ```
 
@@ -1303,7 +1303,7 @@ The object `fuzzy_equals` is callable and works with Ibis expressions:
 
 >>> expr = fuzzy_equals(t.float_col, t.double_col / 10)
 
->>> expr.execute()[:10]
+>>> expr.to_pandas()[:10]
 0     True
 1    False
 2    False

--- a/docs/backends/app/backend_info_app.py
+++ b/docs/backends/app/backend_info_app.py
@@ -35,7 +35,7 @@ def support_matrix_df():
                 short_operation=_.full_operation.split(".")[-1],
                 operation_category=_.full_operation.split(".")[-2],
             )
-            .execute()
+            .to_pandas()
         )
 
 
@@ -75,7 +75,7 @@ def get_all_backend_categories():
         backend_info_table.select(category=_.categories.unnest())
         .distinct()
         .order_by('category')['category']
-        .execute()
+        .to_pandas()
         .tolist()
     )
 
@@ -85,7 +85,7 @@ def get_all_operation_categories():
     return (
         support_matrix_table.select(_.operation_category)
         .distinct()['operation_category']
-        .execute()
+        .to_pandas()
         .tolist()
     )
 
@@ -96,7 +96,7 @@ def get_backend_names(categories: Optional[List[str]] = None):
     if categories:
         backend_expr = backend_expr.filter(_.category.isin(categories))
     return (
-        backend_expr.select(_.backend_name).distinct().backend_name.execute().tolist()
+        backend_expr.select(_.backend_name).distinct().backend_name.to_pandas().tolist()
     )
 
 
@@ -170,7 +170,7 @@ elif hide_supported_by_all_backends == 'Hide supported by all backends':
 table_expr = table_expr[current_backend_names + ["index"]]
 
 # Execute query
-df = table_expr.execute()
+df = table_expr.to_pandas()
 df = df.set_index('index')
 
 # Display result

--- a/docs/example_streamlit_app/example_streamlit_app.py
+++ b/docs/example_streamlit_app/example_streamlit_app.py
@@ -28,7 +28,7 @@ def query():
         .mutate(ner=_.ner.map(lambda n: n.lower()).unnest())
         .ner.topk(max(options))
         .relabel(dict(ner="ingredient"))
-        .execute()
+        .to_pandas()
         .assign(
             emoji=lambda df: df.ingredient.map(
                 lambda emoji: f"{emojis.get(emoji, '-')}"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -66,11 +66,11 @@ AlchemyTable: penguins
 ```
 
 Ibis is lazily evaluated, so instead of seeing the data, we see the schema of
-the table, instead. To peek at the data, we can call `head` and then `execute`
+the table, instead. To peek at the data, we can call `head` and then `to_pandas`
 to get the first few rows of the table as a pandas DataFrame.
 
 ```python
->>> penguins.head().execute()
+>>> penguins.head().to_pandas()
   species     island  bill_length_mm  bill_depth_mm  flipper_length_mm  body_mass_g     sex  year
 0  Adelie  Torgersen            39.1           18.7              181.0       3750.0    male  2007
 1  Adelie  Torgersen            39.5           17.4              186.0       3800.0  female  2007
@@ -79,9 +79,9 @@ to get the first few rows of the table as a pandas DataFrame.
 4  Adelie  Torgersen            36.7           19.3              193.0       3450.0  female  2007
 ```
 
-`execute` takes the existing lazy table expression and evaluates it. If we
+`to_pandas` takes the existing lazy table expression and evaluates it. If we
 leave it off, you'll see the Ibis representation of the table expression that
-`execute` will evaluate (when you're ready!).
+`to_pandas` will evaluate (when you're ready!).
 
 ```python
 >>> penguins.head()
@@ -100,9 +100,9 @@ Limit[r0, n=5]
 
 !!! note "Results in pandas DataFrame"
 
-    Ibis returns results as a pandas DataFrame by default. It isn't using pandas to
+    Ibis returns results as a pandas DataFrame using `to_pandas`, but isn't using pandas to
     perform any of the computation. The query is executed by the backend (DuckDB in
-    this case). Only when the query is executed does Ibis then pull back the results
+    this case). Only when `to_pandas` is called does Ibis then pull back the results
     and convert them into a DataFrame.
 
 ## Interactive Mode
@@ -110,7 +110,7 @@ Limit[r0, n=5]
 For the rest of this intro, we'll turn on interactive mode, which partially
 executes queries to give users a preview of the results. There is a small
 difference in the way the output is formatted, but otherwise this is the same
-as calling `execute()` on the table expression with a limit of 10 result rows
+as calling `to_pandas` on the table expression with a limit of 10 result rows
 returned.
 
 ```python

--- a/docs/how_to/memtable-join.md
+++ b/docs/how_to/memtable-join.md
@@ -89,7 +89,7 @@ and joining is the same as joining any two TableExpressions:
         ...: measures.join(
         ...:     mem_events,
         ...:     measures['event_id'] == mem_events['event_id']
-        ...: ).execute()
+        ...: ).to_pandas()
     Out[11]:
         event_id measured_on  measurement  event_name
     0          0  2021-06-01          NaN          e0
@@ -106,4 +106,4 @@ and joining is the same as joining any two TableExpressions:
     11         3  2021-07-12          NaN          e3
 ```
 
-Note that the return result of the `join` is a TableExpression and that `execute` returns a pandas DataFrame.
+Note that the return result of the `join` is a TableExpression and that `to_pandas` returns a pandas DataFrame.

--- a/docs/how_to/sessionize.md
+++ b/docs/how_to/sessionize.md
@@ -76,4 +76,4 @@ sessionized = (
 
 Calling `ibis.show_sql(sessionized)` displays the SQL query and can be used to confirm that this Ibis table expression does not rely on any join operations.
 
-Calling `sessionized.execute()` should complete in less than a minute, depending on the speed of the internet connection to download the data and the number of CPU cores available to parallelize the processing of this nested query.
+Calling `sessionized.to_pandas()` should complete in less than a minute, depending on the speed of the internet connection to download the data and the number of CPU cores available to parallelize the processing of this nested query.

--- a/docs/ibis-for-dplyr-users.ipynb
+++ b/docs/ibis-for-dplyr-users.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "- **No pipe:** The handy [magrittr pipe](https://magrittr.tidyverse.org/) (`%>%`) or R's newer native pipe (`|>`) don't exist in Python so you instead have to chain sequences of operations together with a period (`.`). The `.` in Python is analogous to R's `$` which lets you access attributes and methods on objects.\n",
     "- **No unquoted column names:** Non-standard evaluation is common in R but not present in Python. To reference a column in Ibis, you can pass a string, property on a table (e.g., `tbl.some_column`), or you can make use of [selectors](https://ibis-project.org/api/selectors/).\n",
-    "- **Ibis is lazy by default:** Similar to [dbplyr](https://dbplyr.tidyverse.org/) and its `collect()` method, Ibis does not evaluate our queries until we call `.execute()`. For the purposes of this document, we set `ibis.options.interactive = True` which limits results to 10 rows, calls `execute` automatically, and prints a nicely-formatted table."
+    "- **Ibis is lazy by default:** Similar to [dbplyr](https://dbplyr.tidyverse.org/) and its `collect()` method, Ibis does not evaluate our queries until we call `.to_pandas()`. For the purposes of this document, we set `ibis.options.interactive = True` which limits results to 10 rows, executes automatically, and prints a nicely-formatted table."
    ]
   },
   {
@@ -142,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition to printing a nicely-formatted table and automatically calling `execute()`, setting `ibis.options.interactive` to `True` also causes our query to be limited to 10 rows. To get Ibis to give us all rows, we can directly call `execute()` and even save the result as a pandas DataFrame:"
+    "In addition to printing a nicely-formatted table and automatically executing, setting `ibis.options.interactive` to `True` also causes our query to be limited to 10 rows. To get Ibis to give us all rows, we can directly call `to_pandas` and save the result as a pandas DataFrame:"
    ]
   },
   {
@@ -151,7 +151,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "starwars_df = starwars.execute()"
+    "starwars_df = starwars.to_pandas()"
    ]
   },
   {
@@ -176,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Directly calling `execute()` and saving the result to a variable is useful for passing the results of Ibis table expressions to other packages (e.g., matplotlib)."
+    "Directly calling `to_pandas` and saving the result to a variable is useful for passing the results of Ibis table expressions to other packages (e.g., matplotlib)."
    ]
   },
   {

--- a/docs/ibis-for-pandas-users.ipynb
+++ b/docs/ibis-for-pandas-users.ipynb
@@ -50,11 +50,11 @@
     "\n",
     "Another difference is that Ibis table expressions are lazy, meaning\n",
     "that as you build up a table expression, no computation is actually performed\n",
-    "until you call an action method such as `execute`. Only then does Ibis\n",
+    "until you call an action method such as `to_pandas`. Only then does Ibis\n",
     "compile the table expression into SQL and send it to the backend.\n",
     "(Note that we'll be using Ibis' interactive mode to automatically execute queries at\n",
     "the end of each cell in this notebook. If you are using similar code in a program,\n",
-    "you will have to add `.execute()` to each operation that you want to evaluate.)"
+    "you will have to add `.to_pandas()` to each operation that you want to evaluate.)"
    ]
   },
   {
@@ -218,7 +218,7 @@
    "id": "6b7753f1-fd33-41f0-bff5-c34f2eb3ffe2",
    "metadata": {},
    "source": [
-    "To mimic pandas' behavior, you would use the following code. Note that you need to use the `execute` method\n",
+    "To mimic pandas' behavior, you would use the following code. Note that you need to use the `to_pandas` method\n",
     "after `count` to evaluate the expression returned by `count`."
    ]
   },
@@ -229,7 +229,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(t.count().execute(), len(t.schema()))"
+    "(t.count().to_pandas(), len(t.schema()))"
    ]
   },
   {

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ ORDER BY t1.year DESC
 ```
 
 ```py title="Execute on multiple backends"
->>> con.execute(q)
+>>> con.to_pandas(q)
 
      year  mean(avg_rating)
 0    2021          2.586362

--- a/docs/user_guide/extending/elementwise.ipynb
+++ b/docs/user_guide/extending/elementwise.ipynb
@@ -232,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = julianday_expr.execute()\n",
+    "result = julianday_expr.to_pandas()\n",
     "result.head()"
    ]
   },

--- a/docs/user_guide/extending/reduction.ipynb
+++ b/docs/user_guide/extending/reduction.ipynb
@@ -267,7 +267,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expr.execute()"
+    "expr.to_pandas()"
    ]
   },
   {
@@ -295,7 +295,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = expr.execute()\n",
+    "result = expr.to_pandas()\n",
     "result"
    ]
   }

--- a/docs/user_guide/self_joins.md
+++ b/docs/user_guide/self_joins.md
@@ -104,7 +104,7 @@ distinct object within Ibis. To do this, use the `view` function:
 >>> results = (current.join(prior, ((current.region == prior.region) &
 ...                                 (current.year == (prior.year - 1))))
 ...            [current.region, current.year, yoy_change])
->>> df = results.execute()
+>>> df = results.to_pandas()
 ```
 
 ```python


### PR DESCRIPTION
fixes #6445 (at least partially)

ignoring blogs, only looking in `docs/` folder