### PR TITLE
fix(docs): typo in snowflake do_connect kwargs

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -160,7 +160,7 @@ $$ {defn["source"]} $$"""
         connect_args
             Additional arguments passed to the SQLAlchemy engine creation call.
         kwargs:
-            Additiional arguments passed to the SQLAlchemy URL constructor.
+            Additional arguments passed to the SQLAlchemy URL constructor.
             See https://docs.snowflake.com/en/developer-guide/python-connector/sqlalchemy#additional-connection-parameters
             for more details
         """


### PR DESCRIPTION
Correcting the spelling of the word "additional" in Snowflake `do_connect` docs. 

```
Additiional ==> Additional
```

![image](https://github.com/ibis-project/ibis/assets/50381805/dfd30117-8f67-412b-a6d7-9d91998c3e2e)

This is actually what caught my original attention with https://github.com/ibis-project/ibis/pull/6398 to look into spelling fixes. It seems as if this correction isn't available in codespell's [dictionary](https://github.com/codespell-project/codespell/blob/master/codespell_lib/data/dictionary.txt). 