### PR TITLE
feat(api): add `__dataframe__` implementation

### DIFF
--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -396,3 +396,19 @@ def test_arrow_timestamp_with_time_zone(alltypes):
 
     (batch,) = t.to_pyarrow_batches()
     assert batch.schema.types == expected
+
+
+@pytest.mark.notimpl(["dask", "druid"])
+@pytest.mark.notimpl(
+    ["mysql"],
+    raises=pa.ArrowInvalid,
+    reason="attempted conversion from decimal to double",
+)
+@pytest.mark.notimpl(
+    ["impala"], raises=AttributeError, reason="missing `fetchmany` on the cursor"
+)
+def test_dataframe_protocol(alltypes):
+    pytest.importorskip("pyarrow", minversion="12")
+    output = alltypes.__dataframe__()
+    assert list(output.column_names()) == alltypes.columns
+    assert alltypes.count().execute() == output.num_rows()

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -109,6 +109,9 @@ class Table(Expr, _FixedTextJupyterMixin):
     def __array__(self, dtype=None):
         return self.execute().__array__(dtype)
 
+    def __dataframe__(self):
+        return self.to_pyarrow().__dataframe__()
+
     def as_table(self) -> Table:
         """Promote the expression to a table.
 


### PR DESCRIPTION
This PR adds support for the `__dataframe__` interchange protocol. Closes #6343.