### PR TITLE
test(sqlite): use `ISODATETIME` type for now output to avoid pandas flaky format inference

### DIFF
--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -14,13 +14,12 @@
 
 from __future__ import annotations
 
-import datetime
 import sqlite3
 from typing import TYPE_CHECKING, Iterator
 
 import sqlalchemy as sa
 import toolz
-from sqlalchemy.dialects.sqlite import DATETIME, TIMESTAMP
+from sqlalchemy.dialects.sqlite import TIMESTAMP
 
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
@@ -28,43 +27,10 @@ from ibis import util
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.sqlite import udf
 from ibis.backends.sqlite.compiler import SQLiteCompiler
-from ibis.backends.sqlite.datatypes import SqliteType, parse
+from ibis.backends.sqlite.datatypes import ISODATETIME, SqliteType, parse
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-def to_datetime(value: str | None) -> datetime.datetime | None:
-    """Convert a `str` to a `datetime` according to SQLite's rules.
-
-    This function ignores `None` values.
-    """
-    if value is None:
-        return None
-    if value.endswith("Z"):
-        # Parse and set the timezone as UTC
-        o = datetime.datetime.fromisoformat(value[:-1]).replace(
-            tzinfo=datetime.timezone.utc
-        )
-    else:
-        o = datetime.datetime.fromisoformat(value)
-        if o.tzinfo:
-            # Convert any aware datetime to UTC
-            return o.astimezone(datetime.timezone.utc)
-    return o
-
-
-class ISODATETIME(DATETIME):
-    """A thin `datetime` type to override sqlalchemy's datetime parsing.
-
-    This is to support a wider range of timestamp formats accepted by SQLite.
-
-    See https://sqlite.org/lang_datefunc.html#time_values for the full
-    list of datetime formats SQLite accepts.
-    """
-
-    def result_processor(self, *_):
-        return to_datetime
 
 
 class Backend(BaseAlchemyBackend):

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -22,6 +22,7 @@ from ibis.backends.base.sql.alchemy import (
 )
 from ibis.backends.base.sql.alchemy.registry import _gen_string_find
 from ibis.backends.base.sql.alchemy.registry import _literal as base_literal
+from ibis.backends.sqlite.datatypes import ISODATETIME
 from ibis.common.temporal import DateUnit, IntervalUnit
 
 operation_registry = sqlalchemy_operation_registry.copy()
@@ -349,7 +350,9 @@ operation_registry.update(
             1,
         ),
         ops.DayOfWeekName: fixed_arity(_day_of_the_week_name, 1),
-        ops.TimestampNow: fixed_arity(lambda: sa.func.datetime("now"), 0),
+        ops.TimestampNow: fixed_arity(
+            lambda: sa.func.datetime("now", type_=ISODATETIME()), 0
+        ),
         ops.RegexSearch: fixed_arity(sa.func._ibis_sqlite_regex_search, 2),
         ops.RegexReplace: fixed_arity(sa.func._ibis_sqlite_regex_replace, 3),
         ops.RegexExtract: fixed_arity(sa.func._ibis_sqlite_regex_extract, 3),

--- a/ibis/backends/sqlite/tests/test_types.py
+++ b/ibis/backends/sqlite/tests/test_types.py
@@ -5,7 +5,6 @@ import pytest
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.backends.sqlite import to_datetime
 
 # Test with formats 1-7 (with T, Z, and offset modifiers) from:
 # https://sqlite.org/lang_datefunc.html#time_values
@@ -65,9 +64,11 @@ def test_timestamps(db, table, data):
     t = con.table(table)
     assert t.ts.type() == dt.timestamp
     res = t.ts.execute()
+    stamps = pd.to_datetime(data, format="mixed", utc=True)
     # we're casting to timestamp without a timezone, so remove it in the
     # expected output
-    sol = pd.Series(to_datetime(s) for s in data).dt.tz_localize(None)
+    localized = stamps.tz_localize(None)
+    sol = pd.Series(localized)
     assert res.equals(sol)
 
 


### PR DESCRIPTION
Fixes a flaky sqlite test observed in [this CI run](https://github.com/ibis-project/ibis/actions/runs/5283213529/jobs/9559162456?pr=6456).