### PR TITLE
ci: run nix macos jobs on macos-13 to try and avoid SIP

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels: [macos-13]
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables: null

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,7 +37,7 @@ jobs:
           - "3.10"
           - "3.11"
         include:
-          - os: macos-latest
+          - os: macos-13
             python-version: "3.10"
     steps:
       - name: checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autofix_prs: false
   autoupdate_commit_msg: "chore(deps): pre-commit.ci autoupdate"
   skip:
-    - actionlint
+    - actionlint-system
     - deadnix
     - just
     - nixpkgs-fmt
@@ -17,9 +17,9 @@ default_stages:
   - commit
 repos:
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.24
+    rev: v1.6.25
     hooks:
-      - id: actionlint
+      - id: actionlint-system
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
@@ -30,7 +30,7 @@ repos:
       - id: nbstripout
         exclude: .+/rendered/.+
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.5
     hooks:
       - id: codespell
         additional_dependencies:


### PR DESCRIPTION
Fixes an issue with GitHub changing their macos deployments to include SIP on macos and nix failing to work with that. xref https://github.com/cachix/install-nix-action/issues/183