### PR TITLE
feat(create_table): support pyarrow Table in table creation

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -818,7 +818,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
     def create_table(
         self,
         name: str,
-        obj: pd.DataFrame | ir.Table | None = None,
+        obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: ibis.Schema | None = None,
         database: str | None = None,

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -41,6 +41,7 @@ from ibis.formats.pandas import PandasData
 
 if TYPE_CHECKING:
     import pandas as pd
+    import pyarrow as pa
 
 
 __all__ = (
@@ -218,7 +219,7 @@ class BaseAlchemyBackend(BaseSQLBackend):
     def create_table(
         self,
         name: str,
-        obj: pd.DataFrame | ir.Table | None = None,
+        obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: sch.Schema | None = None,
         database: str | None = None,
@@ -255,8 +256,9 @@ class BaseAlchemyBackend(BaseSQLBackend):
             raise com.IbisError("The schema or obj parameter is required")
 
         import pandas as pd
+        import pyarrow as pa
 
-        if isinstance(obj, pd.DataFrame):
+        if isinstance(obj, (pd.DataFrame, pa.Table)):
             obj = ibis.memtable(obj)
 
         if database == self.current_database:

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -440,7 +440,7 @@ class Backend(BaseSQLBackend):
     def create_table(
         self,
         name: str,
-        obj: pd.DataFrame | ir.Table | None = None,
+        obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: ibis.Schema | None = None,
         database: str | None = None,
@@ -457,19 +457,29 @@ class Backend(BaseSQLBackend):
             raise NotImplementedError(
                 "BigQuery backend does not yet support overwriting tables"
             )
-        if schema is not None:
-            table_id = self._fully_qualified_name(name, database)
-            table = bq.Table(table_id, schema=BigQuerySchema.from_ibis(schema))
-            self.client.create_table(table)
-        else:
+
+        if isinstance(obj, ir.Table) and schema is not None:
+            if not schema.equals(obj.schema()):
+                raise com.IbisTypeError(
+                    """Provided schema and Ibis table schema are incompatible.
+Please align the two schemas, or provide only one of the two arguments."""
+                )
+
+        if obj is not None:
+            import pyarrow as pa
+
             project_id, dataset = self._parse_project_and_dataset(database)
-            if isinstance(obj, pd.DataFrame):
-                table = ibis.memtable(obj)
+            if isinstance(obj, (pd.DataFrame, pa.Table)):
+                table = ibis.memtable(obj, schema=schema)
             else:
                 table = obj
             sql_select = self.compile(table)
             table_ref = f"`{project_id}`.`{dataset}`.`{name}`"
             self.raw_sql(f'CREATE TABLE {table_ref} AS ({sql_select})')
+        elif schema is not None:
+            table_id = self._fully_qualified_name(name, database)
+            table = bq.Table(table_id, schema=BigQuerySchema.from_ibis(schema))
+            self.client.create_table(table)
         return self.table(name, database=database)
 
     def drop_table(

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -551,7 +551,7 @@ class Backend(BaseBackend):
     def create_table(
         self,
         name: str,
-        obj: pd.DataFrame | ir.Table | None = None,
+        obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: ibis.Schema | None = None,
         database: str | None = None,

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pandas.testing as tm
+import pyarrow as pa
 import pytest
 from pytest import param
 
@@ -219,8 +220,9 @@ def test_create_table_no_data(con, temp, temp_table):
     [
         {"a": [1, 2, 3], "b": [None, "b", "c"]},
         pd.DataFrame({"a": [1, 2, 3], "b": [None, "b", "c"]}),
+        pa.Table.from_pydict({"a": [1, 2, 3], "b": [None, "b", "c"]}),
     ],
-    ids=["dict", "dataframe"],
+    ids=["dict", "dataframe", "pyarrow table"],
 )
 @pytest.mark.parametrize(
     "engine",

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -114,7 +114,7 @@ class BasePandasBackend(BaseBackend):
     def create_table(
         self,
         name: str,
-        obj: pd.DataFrame | ir.Table | None = None,
+        obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: sch.Schema | None = None,
         database: str | None = None,
@@ -189,10 +189,14 @@ class BasePandasBackend(BaseBackend):
 
     @classmethod
     def _convert_object(cls, obj: Any) -> Any:
+        import pyarrow as pa
+
         if isinstance(obj, ir.Table):
             # Support memtables
             assert isinstance(obj.op(), ops.InMemoryTable)
             return obj.op().data.to_frame()
+        elif isinstance(obj, pa.Table):
+            return obj.to_pandas()
         return cls.backend_table_type(obj)
 
     @classmethod

--- a/ibis/backends/pandas/tests/test_client.py
+++ b/ibis/backends/pandas/tests/test_client.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pandas.testing as tm
+import pyarrow as pa
 import pytest
 from pytest import param
 
@@ -38,7 +39,13 @@ def test_client_table(table):
     assert isinstance(table.op(), ops.DatabaseTable)
 
 
-def test_create_table(client, test_data):
+@pytest.mark.parametrize(
+    "lamduh",
+    [(lambda df: df), (lambda df: pa.Table.from_pandas(df))],
+    ids=["dataframe", "pyarrow table"],
+)
+def test_create_table(client, test_data, lamduh):
+    test_data = lamduh(test_data)
     client.create_table('testing', obj=test_data)
     assert 'testing' in client.list_tables()
     client.create_table('testingschema', schema=client.get_schema('testing'))

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -19,6 +19,7 @@ from ibis.util import gen_name, normalize_filename
 
 if TYPE_CHECKING:
     import pandas as pd
+    import pyarrow as pa
 
 
 class Backend(BaseBackend):
@@ -270,7 +271,7 @@ class Backend(BaseBackend):
     def create_table(
         self,
         name: str,
-        obj: pd.DataFrame | ir.Table | None = None,
+        obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: ibis.Schema | None = None,
         database: str | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -371,7 +371,7 @@ show_deps = true
 # notebooks are skipped because there's no straightforward way to ignore base64
 # encoded strings
 skip = "*.lock,.direnv,.git,*.ipynb"
-ignore-regex = '\b(DOUB|i[if]f|I[IF]F)\b'
+ignore-regex = '\b(DOUB|i[if]f|I[IF]F|lamduh)\b'
 builtin = "clear,rare,names"
 
 [tool.ruff]


### PR DESCRIPTION
Some backends already supported this, but a bunch didn't only because of `isinstance` checks.

The remaining backends that don't have support for pyarrow tables in `create_table` are `dask`, `datafusion`, `druid`, and `impala`.  
I also ran into a big in the bigquery backend, where passing both `obj` and `schema` to `create_table` led to `obj` being ignored entirely.  

Also there's probably some import cost to this, although it should all be inlined and will only hit at the `create_table` call.