### PR TITLE
feat(api): better repr and pickle support for deferred expressions

### DIFF
--- a/ibis/expr/deferred.py
+++ b/ibis/expr/deferred.py
@@ -1,142 +1,275 @@
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
-import toolz
+_BINARY_OPS: dict[str, Callable[[Any, Any], Any]] = {
+    "+": operator.add,
+    "-": operator.sub,
+    "*": operator.mul,
+    "/": operator.truediv,
+    "//": operator.floordiv,
+    "**": operator.pow,
+    "%": operator.mod,
+    "==": operator.eq,
+    "!=": operator.ne,
+    "<": operator.lt,
+    "<=": operator.le,
+    ">": operator.gt,
+    ">=": operator.ge,
+    "&": operator.and_,
+    "|": operator.or_,
+    "^": operator.xor,
+    ">>": operator.rshift,
+    "<<": operator.lshift,
+}
 
-if TYPE_CHECKING:
-    import ibis.expr.types as ir
+_UNARY_OPS: dict[str, Callable[[Any], Any]] = {
+    "~": operator.inv,
+    "-": operator.neg,
+}
 
 
 class Deferred:
     """A deferred expression."""
 
-    __slots__ = ("resolve",)
+    __slots__ = ()
 
-    def __init__(self, resolve: Callable = toolz.identity) -> None:
-        assert callable(
-            resolve
-        ), f"resolve argument is not callable, got {type(resolve)}"
-        self.resolve = resolve
+    def resolve(self, param: Any) -> Any:
+        """Resolve the deferred expression against an argument.
+
+        Parameters
+        ----------
+        param
+            The argument to use in place of `_` in the expression.
+
+        Returns
+        -------
+        Any
+            The result of resolving the deferred expression.
+        """
+        return self._resolve(param)
+
+    def __repr__(self) -> str:
+        return "_"
 
     def __hash__(self) -> int:
-        # every new instance can potentially be referring to something
-        # different so treat each instance as unique
         return id(self)
 
-    def _defer(self, func: Callable, *args: Any, **kwargs: Any) -> Deferred:
-        """Wrap `func` in a `Deferred` instance."""
+    def _resolve(self, param: Any) -> Any:
+        return param
 
-        def resolve(expr, func=func, self=self, args=args, kwargs=kwargs):
-            resolved_expr = self.resolve(expr)
-            resolved_args = [_resolve(arg, expr=expr) for arg in args]
-            resolved_kwargs = {
-                name: _resolve(arg, expr=expr) for name, arg in kwargs.items()
-            }
-            return func(resolved_expr, *resolved_args, **resolved_kwargs)
-
-        return self.__class__(resolve)
-
-    def __getattr__(self, name: str) -> Deferred:
-        return self._defer(getattr, name)
+    def __getattr__(self, attr: str) -> Deferred:
+        if attr.startswith("__"):
+            raise AttributeError(f"'Deferred' object has no attribute {attr!r}")
+        return DeferredAttr(self, attr)
 
     def __getitem__(self, key: Any) -> Deferred:
-        return self._defer(operator.itemgetter(key))
+        return DeferredItem(self, key)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Deferred:
-        return self._defer(
-            lambda expr, *args, **kwargs: expr(*args, **kwargs),
-            *args,
-            **kwargs,
-        )
+        return DeferredCall(self, *args, **kwargs)
 
     def __add__(self, other: Any) -> Deferred:
-        return self._defer(operator.add, other)
+        return DeferredBinaryOp("+", self, other)
 
     def __radd__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.add), other)
+        return DeferredBinaryOp("+", other, self)
 
     def __sub__(self, other: Any) -> Deferred:
-        return self._defer(operator.sub, other)
+        return DeferredBinaryOp("-", self, other)
 
     def __rsub__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.sub), other)
+        return DeferredBinaryOp("-", other, self)
 
     def __mul__(self, other: Any) -> Deferred:
-        return self._defer(operator.mul, other)
+        return DeferredBinaryOp("*", self, other)
 
     def __rmul__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.mul), other)
+        return DeferredBinaryOp("*", other, self)
 
     def __truediv__(self, other: Any) -> Deferred:
-        return self._defer(operator.truediv, other)
+        return DeferredBinaryOp("/", self, other)
 
     def __rtruediv__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.truediv), other)
+        return DeferredBinaryOp("/", other, self)
 
     def __floordiv__(self, other: Any) -> Deferred:
-        return self._defer(operator.floordiv, other)
+        return DeferredBinaryOp("//", self, other)
 
     def __rfloordiv__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.floordiv), other)
+        return DeferredBinaryOp("//", other, self)
 
     def __pow__(self, other: Any) -> Deferred:
-        return self._defer(operator.pow, other)
+        return DeferredBinaryOp("**", self, other)
 
     def __rpow__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.pow), other)
+        return DeferredBinaryOp("**", other, self)
 
     def __mod__(self, other: Any) -> Deferred:
-        return self._defer(operator.mod, other)
+        return DeferredBinaryOp("%", self, other)
 
     def __rmod__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.mod), other)
+        return DeferredBinaryOp("%", other, self)
+
+    def __rshift__(self, other: Any) -> Deferred:
+        return DeferredBinaryOp(">>", self, other)
+
+    def __rrshift__(self, other: Any) -> Deferred:
+        return DeferredBinaryOp(">>", other, self)
+
+    def __lshift__(self, other: Any) -> Deferred:
+        return DeferredBinaryOp("<<", self, other)
+
+    def __rlshift__(self, other: Any) -> Deferred:
+        return DeferredBinaryOp("<<", other, self)
 
     def __eq__(self, other: Any) -> Deferred:  # type: ignore
-        return self._defer(operator.eq, other)
+        return DeferredBinaryOp("==", self, other)
 
     def __ne__(self, other: Any) -> Deferred:  # type: ignore
-        return self._defer(operator.ne, other)
+        return DeferredBinaryOp("!=", self, other)
 
     def __lt__(self, other: Any) -> Deferred:
-        return self._defer(operator.lt, other)
+        return DeferredBinaryOp("<", self, other)
 
     def __le__(self, other: Any) -> Deferred:
-        return self._defer(operator.le, other)
+        return DeferredBinaryOp("<=", self, other)
 
     def __gt__(self, other: Any) -> Deferred:
-        return self._defer(operator.gt, other)
+        return DeferredBinaryOp(">", self, other)
 
     def __ge__(self, other: Any) -> Deferred:
-        return self._defer(operator.ge, other)
-
-    def __or__(self, other: Any) -> Deferred:
-        return self._defer(operator.or_, other)
-
-    def __ror__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.or_), other)
+        return DeferredBinaryOp(">=", self, other)
 
     def __and__(self, other: Any) -> Deferred:
-        return self._defer(operator.and_, other)
+        return DeferredBinaryOp("&", self, other)
 
     def __rand__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.and_), other)
+        return DeferredBinaryOp("&", other, self)
+
+    def __or__(self, other: Any) -> Deferred:
+        return DeferredBinaryOp("|", self, other)
+
+    def __ror__(self, other: Any) -> Deferred:
+        return DeferredBinaryOp("|", other, self)
 
     def __xor__(self, other: Any) -> Deferred:
-        return self._defer(operator.xor, other)
+        return DeferredBinaryOp("^", self, other)
 
     def __rxor__(self, other: Any) -> Deferred:
-        return self._defer(toolz.flip(operator.xor), other)
+        return DeferredBinaryOp("^", other, self)
 
     def __invert__(self) -> Deferred:
-        return self._defer(operator.invert)
+        return DeferredUnaryOp("~", self)
 
     def __neg__(self) -> Deferred:
-        return self._defer(operator.neg)
+        return DeferredUnaryOp("-", self)
 
 
-def _resolve(arg: Any, *, expr: ir.Expr) -> Any:
-    if (func := getattr(arg, "resolve", None)) is not None:
-        return func(expr)
-    return arg
+class DeferredAttr(Deferred):
+    __slots__ = ("_value", "_attr")
+
+    def __init__(self, value: Any, attr: str) -> None:
+        self._value = value
+        self._attr = attr
+
+    def __repr__(self) -> str:
+        return f"{self._value!r}.{self._attr}"
+
+    def _resolve(self, param: Any) -> Any:
+        obj = _resolve(self._value, param)
+        return getattr(obj, self._attr)
+
+
+class DeferredItem(Deferred):
+    __slots__ = ("_value", "_key")
+
+    def __init__(self, value: Any, key: Any) -> None:
+        self._value = value
+        self._key = key
+
+    def __repr__(self) -> str:
+        return f"{self._value!r}[{self._key!r}]"
+
+    def _resolve(self, param: Any) -> Any:
+        obj = _resolve(self._value, param)
+        return obj[self._key]
+
+
+class DeferredCall(Deferred):
+    __slots__ = ("_func", "_args", "_kwargs")
+
+    def __init__(self, func: Any, *args: Any, **kwargs: Any) -> None:
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+
+    def __repr__(self) -> str:
+        params = [repr(a) for a in self._args]
+        params.extend(f"{k}={v!r}" for k, v in self._kwargs.items())
+        return f"{self._func!r}({', '.join(params)})"
+
+    def _resolve(self, param: Any) -> Any:
+        func = _resolve(self._func, param)
+        args = [_resolve(a, param) for a in self._args]
+        kwargs = {k: _resolve(v, param) for k, v in self._kwargs.items()}
+        return func(*args, **kwargs)
+
+
+class DeferredBinaryOp(Deferred):
+    __slots__ = ("_symbol", "_left", "_right")
+
+    def __init__(self, symbol: str, left: Any, right: Any) -> None:
+        self._symbol = symbol
+        self._left = left
+        self._right = right
+
+    def __repr__(self) -> str:
+        return f"({self._left!r} {self._symbol} {self._right!r})"
+
+    def _resolve(self, param: Any) -> Any:
+        left = _resolve(self._left, param)
+        right = _resolve(self._right, param)
+        return _BINARY_OPS[self._symbol](left, right)
+
+
+class DeferredUnaryOp(Deferred):
+    __slots__ = ("_symbol", "_value")
+
+    def __init__(self, symbol: str, value: Any) -> None:
+        self._symbol = symbol
+        self._value = value
+
+    def __repr__(self) -> str:
+        return f"{self._symbol}{self._value!r}"
+
+    def _resolve(self, param: Any) -> Any:
+        value = _resolve(self._value, param)
+        return _UNARY_OPS[self._symbol](value)
+
+
+def _resolve(expr: Deferred, param: Any) -> Any:
+    if isinstance(expr, Deferred):
+        return expr._resolve(param)
+    return expr
+
+
+def deferred_apply(func: Callable, *args: Any, **kwargs: Any) -> Deferred:
+    """Construct a deferred call from a callable and arguments.
+
+    Parameters
+    ----------
+    func
+        The callable to defer
+    args
+        Positional arguments, possibly composed of deferred expressions.
+    kwargs
+        Keyword arguments, possible composed of deferred expressions.
+
+    Returns
+    -------
+    expr
+        A deferred expression representing the call.
+    """
+    return DeferredCall(func, *args, **kwargs)

--- a/ibis/expr/tests/test_deferred.py
+++ b/ibis/expr/tests/test_deferred.py
@@ -1,12 +1,166 @@
+import operator
+import pickle
+
 import pytest
+from pytest import param
 
 import ibis
+from ibis import _
 
 
-def test_invalid_attribute():
-    from ibis import _
+@pytest.fixture
+def table():
+    return ibis.table({"a": "int", "b": "int", "c": "str"})
 
-    t = ibis.table(dict(a="int"), name="t")
-    d = _.a + _.b
-    with pytest.raises(AttributeError):
-        d.resolve(t)
+
+def test_hash():
+    """Deferred expressions must be hashable"""
+    expr1 = _.a
+    expr2 = _.a + 1
+    assert hash(expr1) == hash(expr1)
+    assert hash(expr1) != hash(expr2)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        param(lambda _: _, id="root"),
+        param(lambda _: _.a, id="getattr"),
+        param(lambda _: _["a"], id="getitem"),
+        param(lambda _: _.a.log(), id="method"),
+        param(lambda _: _.a.log(_.b), id="method-with-args"),
+        param(lambda _: _.a.log(base=_.b), id="method-with-kwargs"),
+        param(lambda _: _.a + _.b, id="binary-op"),
+        param(lambda _: ~_.a, id="unary-op"),
+    ],
+)
+def test_pickle(func, table):
+    expr1 = func(_)
+    expr2 = pickle.loads(pickle.dumps(expr1))
+
+    r1 = expr1.resolve(table)
+    r2 = expr2.resolve(table)
+    assert r1.equals(r2)
+
+
+def test_magic_methods_not_deferred():
+    with pytest.raises(AttributeError, match="__fizzbuzz__"):
+        _.__fizzbuzz__()
+
+
+def test_getattr(table):
+    expr = _.a
+    sol = table.a
+    res = expr.resolve(table)
+    assert res.equals(sol)
+    assert repr(expr) == "_.a"
+
+
+def test_getitem(table):
+    expr = _["a"]
+    sol = table["a"]
+    res = expr.resolve(table)
+    assert res.equals(sol)
+    assert repr(expr) == "_['a']"
+
+
+def test_method(table):
+    expr = _.a.log()
+    res = expr.resolve(table)
+    assert res.equals(table.a.log())
+    assert repr(expr) == "_.a.log()"
+
+
+def test_method_args(table):
+    expr = _.a.log(1)
+    res = expr.resolve(table)
+    assert res.equals(table.a.log(1))
+    assert repr(expr) == "_.a.log(1)"
+
+    expr = _.a.log(_.b)
+    res = expr.resolve(table)
+    assert res.equals(table.a.log(table.b))
+    assert repr(expr) == "_.a.log(_.b)"
+
+
+def test_method_kwargs(table):
+    expr = _.a.log(base=1)
+    res = expr.resolve(table)
+    assert res.equals(table.a.log(base=1))
+    assert repr(expr) == "_.a.log(base=1)"
+
+    expr = _.a.log(base=_.b)
+    res = expr.resolve(table)
+    assert res.equals(table.a.log(base=table.b))
+    assert repr(expr) == "_.a.log(base=_.b)"
+
+
+@pytest.mark.parametrize(
+    "symbol, op",
+    [
+        ("+", operator.add),
+        ("-", operator.sub),
+        ("*", operator.mul),
+        ("/", operator.truediv),
+        ("//", operator.floordiv),
+        ("**", operator.pow),
+        ("%", operator.mod),
+        ("&", operator.and_),
+        ("|", operator.or_),
+        ("^", operator.xor),
+        (">>", operator.rshift),
+        ("<<", operator.lshift),
+    ],
+)
+def test_binary_ops(symbol, op, table):
+    expr = op(_.a, _.b)
+    sol = op(table.a, table.b)
+    res = expr.resolve(table)
+    assert res.equals(sol)
+    assert repr(expr) == f"(_.a {symbol} _.b)"
+
+    expr = op(1, _.a)
+    sol = op(1, table.a)
+    res = expr.resolve(table)
+    assert res.equals(sol)
+    assert repr(expr) == f"(1 {symbol} _.a)"
+
+
+@pytest.mark.parametrize(
+    "sym, rsym, op",
+    [
+        ("==", "==", operator.eq),
+        ("!=", "!=", operator.ne),
+        ("<", ">", operator.lt),
+        ("<=", ">=", operator.le),
+        (">", "<", operator.gt),
+        (">=", "<=", operator.ge),
+    ],
+)
+def test_compare_ops(sym, rsym, op, table):
+    expr = op(_.a, _.b)
+    sol = op(table.a, table.b)
+    res = expr.resolve(table)
+    assert res.equals(sol)
+    assert repr(expr) == f"(_.a {sym} _.b)"
+
+    expr = op(1, _.a)
+    sol = op(1, table.a)
+    res = expr.resolve(table)
+    assert res.equals(sol)
+    assert repr(expr) == f"(_.a {rsym} 1)"
+
+
+@pytest.mark.parametrize(
+    "symbol, op",
+    [
+        ("-", operator.neg),
+        ("~", operator.invert),
+    ],
+)
+def test_unary_ops(symbol, op, table):
+    expr = op(_.a)
+    sol = op(table.a)
+    res = expr.resolve(table)
+    assert res.equals(sol)
+    assert repr(expr) == f"{symbol}_.a"

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -8,7 +8,6 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis import util
 from ibis.common.grounds import Singleton
 from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin
 
@@ -505,6 +504,7 @@ class Value(Expr):
         import ibis.expr.analysis as an
         import ibis.expr.builders as bl
         import ibis.expr.deferred as de
+        from ibis import _
 
         if window is None:
             window = ibis.window(
@@ -527,7 +527,7 @@ class Value(Expr):
             if table := an.find_first_base_table(self.op()):
                 return bind(table)
             else:
-                return de.Deferred(bind)
+                return de.deferred_apply(bind, _)
         else:
             return ops.WindowFunction(self, window).to_expr()
 


### PR DESCRIPTION
This is a major refactor of the `Deferred` implementation, with the following goals:

- Better repr. The previous repr was just the default python object repr, making it impossible to see what the underlying deferred expression represented. The new repr attempts to mimic the python syntax used to generate the deferred expression.
- Pickleability. The previous expressions weren't pickleable, which prevented using them in place of lambdas for certain workflows. They now are pickleable.

```python
In [1]: from ibis import _

In [2]: _.x.log(1)
Out[2]: _.x.log(1)

In [3]: _.x.log(1) + _.y
Out[3]: (_.x.log(1) + _.y)
```