### PR TITLE
ci: bring back `macos-latest`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,0 @@
-self-hosted-runner:
-  # Labels of self-hosted runner in array of strings.
-  labels: [macos-13]
-# Configuration variables in array of strings defined in your repository or
-# organization. `null` means disabling configuration variables check.
-# Empty array means no configuration variable is allowed.
-config-variables: null

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,7 +37,7 @@ jobs:
           - "3.10"
           - "3.11"
         include:
-          - os: macos-13
+          - os: macos-latest
             python-version: "3.10"
     steps:
       - name: checkout


### PR DESCRIPTION
macOS nix build is fixed by updating cachix-install-action (https://github.com/cachix/install-nix-action/pull/184)