### PR TITLE
feat(polars): add support for `identical_to`

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -328,6 +328,13 @@ def fillna(op, **kw):
     return table.select(columns)
 
 
+@translate.register(ops.IdenticalTo)
+def identical_to(op, **kw):
+    left = translate(op.left, **kw)
+    right = translate(op.right, **kw)
+    return left.eq_missing(right)
+
+
 @translate.register(ops.IfNull)
 def ifnull(op, **kw):
     arg = translate(op.arg, **kw)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -205,9 +205,7 @@ def test_coalesce(con, expr, expected):
 
 
 # TODO(dask) - identicalTo - #2553
-@pytest.mark.notimpl(
-    ["clickhouse", "datafusion", "polars", "dask", "pyspark", "mssql", "druid"]
-)
+@pytest.mark.notimpl(["clickhouse", "datafusion", "dask", "pyspark", "mssql", "druid"])
 def test_identical_to(backend, alltypes, sorted_df):
     sorted_alltypes = alltypes.order_by('id')
     df = sorted_df
@@ -1075,12 +1073,12 @@ def test_pivot_wider(backend):
     reason="arbitrary not implemented in the backend",
 )
 @pytest.mark.notimpl(
-    ["dask", "datafusion", "polars"],
+    ["dask", "datafusion"],
     raises=com.OperationNotDefinedError,
     reason="backend doesn't implement window functions",
 )
 @pytest.mark.notimpl(
-    ["pandas"],
+    ["pandas", "polars"],
     raises=com.OperationNotDefinedError,
     reason="backend doesn't implement ops.WindowFunction",
 )
@@ -1135,12 +1133,12 @@ def test_distinct_on_keep(backend, on, keep):
     reason="arbitrary not implemented in the backend",
 )
 @pytest.mark.notimpl(
-    ["dask", "datafusion", "polars"],
+    ["dask", "datafusion"],
     raises=com.OperationNotDefinedError,
     reason="backend doesn't implement window functions",
 )
 @pytest.mark.notimpl(
-    ["pandas"],
+    ["pandas", "polars"],
     raises=com.OperationNotDefinedError,
     reason="backend doesn't implement ops.WindowFunction",
 )


### PR DESCRIPTION
Added polars support for `identical_to`, and tweaked some `@pytest.mark` designations relating to window functions; polars has support for these, but `ops.WindowFunction` hasn't been implemented yet (I might have a crack at that later), so I moved the label into the more appropriate message.