### PR TITLE
feat(polars): support table registration from multiple parquet files

### DIFF
--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -223,7 +223,6 @@ def test_register_parquet(
         "mssql",
         "mysql",
         "pandas",
-        "polars",  # polars supports parquet dirs, not lists of files
         "postgres",
         "pyspark",
         "snowflake",
@@ -249,7 +248,6 @@ def test_register_iterator_parquet(
         )
 
     assert any("ibis_read_parquet" in t for t in con.list_tables())
-
     assert table.count().execute()
 
 


### PR DESCRIPTION
Added support for registering a single table from multiple parquet files (when passed as an iterable of individual paths - It already handles a directory or file path glob).