### PR TITLE
feat(polars): lower-latency column return for non-temporal results

### DIFF
--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -382,7 +382,11 @@ class Backend(BaseBackend):
         if isinstance(expr, ir.Table):
             return df.to_pandas()
         elif isinstance(expr, ir.Column):
-            return df.to_pandas().iloc[:, 0]
+            if expr.type().is_temporal():
+                return df.to_pandas().iloc[:, 0]
+            else:
+                # note: skip frame-construction overhead
+                return df.to_series().to_pandas()
         elif isinstance(expr, ir.Scalar):
             return df.to_pandas().iat[0, 0]
         else:


### PR DESCRIPTION
Micro-optimisation; no need to eat the frame-construction overhead on `Column` return (except for temporal results, where polars can return py-native datetimes instead of Timestamp).

### Example
To illustrate the difference:
```python
from datetime import datetime
import polars as pl

df = pl.DataFrame( {"colx":range(1_000_000)} )
```
_Before_
```python
start = datetime.now()    
for i in range(50):
    x = df.to_pandas().iloc[:, 0]

print( datetime.now() - start )
# 0.035302
```
_After_
```python
start = datetime.now()        
for i in range(50):
    y = df.to_series().to_pandas()

print( datetime.now() - start )
# 0.001335
```
While ~20x faster in the above example it's not a lot of "real" time saved, but why not... ;)