### PR TITLE
docs(python-versions): document how we decide to drop support for Python versions

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -4,6 +4,7 @@
     * [Getting Started](getting_started.md)
     * [How To Guides](how_to/)
     * [Execution Backends](backends/)
+    * [Supported Python Versions](supported_python_versions.md)
     * [User Guide](user_guide/)
     * [Ibis for SQL Programmers](ibis-for-sql-programmers.ipynb)
     * [Ibis for pandas Users](ibis-for-pandas-users.ipynb)

--- a/docs/supported_python_versions.md
+++ b/docs/supported_python_versions.md
@@ -1,0 +1,13 @@
+# Supported Python Versions
+
+Ibis follows [NEP29](https://numpy.org/neps/nep-0029-deprecation_policy.html)
+with respect to supported Python versions.
+
+This has been in-place [since Ibis version 3.0.0](https://github.com/ibis-project/ibis/blob/5015677d78909473014a61725d371b4bf772cdff/docs/blog/Ibis-version-3.0.0-release.md?plain=1#L83).
+
+The [support
+table](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table)
+shows the schedule for dropping support for Python versions.
+
+The next major release of Ibis that occurs on or after the NEP29 drop date
+removes support for the specified Python version.


### PR DESCRIPTION
Adds docs that reference NEP29 to loudly document how we deal with Python versions support.