### PR TITLE
ci(mysql): revert the mariadb image version to see if it results in less flaky tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
         - mariadb-admin
         - ping
       timeout: 5s
-    image: mariadb:11.0.2
+    image: mariadb:10.11.4
     ports:
       - 3306:3306
     networks:


### PR DESCRIPTION
[Some flaky tests due to dropped connections](https://github.com/ibis-project/ibis/actions/runs/5347300828/jobs/9695717144?pr=6500) are are popping up in the mysql CI suite more often than usual. This PR moves us back to MariaDB 10.11, which is an LTS release and hopefully much less flaky.