### PR TITLE
feat(io): add `to_torch` API

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -103,6 +103,8 @@ jobs:
             extras:
               - duckdb
               - deltalake
+            additional_deps:
+              - torch
           - name: pandas
             title: Pandas
             extras:
@@ -145,12 +147,12 @@ jobs:
             sys-deps:
               - libgeos-dev
           - name: postgres
-            title: PostgreSQL + PyArrow
+            title: PostgreSQL + Torch
             extras:
               - postgres
               - geospatial
             additional_deps:
-              - pyarrow
+              - torch
             services:
               - postgres
             sys-deps:
@@ -230,12 +232,12 @@ jobs:
           - os: windows-latest
             backend:
               name: postgres
-              title: PostgreSQL + PyArrow
+              title: PostgreSQL + Torch
               extras:
                 - postgres
                 - geospatial
               additional_deps:
-                - pyarrow
+                - torch
               services:
                 - postgres
               sys-deps:

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -343,7 +343,7 @@ class _FileIOHandler:
         params: Mapping[ir.Scalar, Any] | None = None,
         limit: int | str | None = None,
         **kwargs: Any,
-    ) -> dict[str, torch.array]:
+    ) -> dict[str, torch.Tensor]:
         """Execute an expression and return results as a dictionary of torch tensors.
 
         Parameters

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -29,6 +29,7 @@ from ibis.formats.pandas import PandasData
 
 if TYPE_CHECKING:
     import pandas as pd
+    import torch
 
     import ibis.expr.operations as ops
 
@@ -629,9 +630,7 @@ class Backend(BaseAlchemyBackend):
         self._load_extensions(["sqlite"])
         with self.begin() as con:
             con.execute(sa.text(f"SET GLOBAL sqlite_all_varchar={all_varchar}"))
-            con.execute(
-                sa.text(f"CALL sqlite_attach('{path!s}', overwrite={overwrite})")
-            )
+            con.execute(sa.text(f"CALL sqlite_attach('{path}', overwrite={overwrite})"))
 
     def _run_pre_execute_hooks(self, expr: ir.Expr) -> None:
         from ibis.expr.analysis import find_physical_tables
@@ -731,6 +730,37 @@ class Backend(BaseAlchemyBackend):
             return table.columns[0][0]
         else:
             raise ValueError
+
+    @util.experimental
+    def to_torch(
+        self,
+        expr: ir.Expr,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, torch.array]:
+        """Execute an expression and return results as a dictionary of torch tensors.
+
+        Parameters
+        ----------
+        expr
+            Ibis expression to execute.
+        params
+            Parameters to substitute into the expression.
+        limit
+            An integer to effect a specific row limit. A value of `None` means no limit.
+        kwargs
+            Keyword arguments passed into the backend's `to_torch` implementation.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            A dictionary of torch tensors, keyed by column name.
+        """
+        compiled = self.compile(expr, limit=limit, params=params, **kwargs)
+        with self._safe_raw_sql(compiled) as cur:
+            return cur.connection.connection.torch()
 
     @util.experimental
     def to_parquet(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -739,7 +739,7 @@ class Backend(BaseAlchemyBackend):
         params: Mapping[ir.Scalar, Any] | None = None,
         limit: int | str | None = None,
         **kwargs: Any,
-    ) -> dict[str, torch.array]:
+    ) -> dict[str, torch.Tensor]:
         """Execute an expression and return results as a dictionary of torch tensors.
 
         Parameters

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -500,7 +500,7 @@ class Expr(Immutable):
         params: Mapping[ir.Scalar, Any] | None = None,
         limit: int | str | None = None,
         **kwargs: Any,
-    ) -> None:
+    ) -> dict[str, torch.Tensor]:
         """Execute an expression and return results as a dictionary of torch tensors.
 
         Parameters

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -493,6 +493,34 @@ class Expr(Immutable):
         """
         self._find_backend(use_default=True).to_delta(self, path, **kwargs)
 
+    @experimental
+    def to_torch(
+        self,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Execute an expression and return results as a dictionary of torch tensors.
+
+        Parameters
+        ----------
+        params
+            Parameters to substitute into the expression.
+        limit
+            An integer to effect a specific row limit. A value of `None` means no limit.
+        kwargs
+            Keyword arguments passed into the backend's `to_torch` implementation.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            A dictionary of torch tensors, keyed by column name.
+        """
+        return self._find_backend(use_default=True).to_torch(
+            self, params=params, limit=limit, **kwargs
+        )
+
     def unbind(self) -> ir.Table:
         """Return an expression built on `UnboundTable` instead of backend-specific objects."""
         from ibis.expr.analysis import substitute_unbound


### PR DESCRIPTION
This PR adds a `to_torch` method that returns a dict of column name to torch tensor. This came up during experimentation with DuckDB pyarrow UDFs where I wanted to pass some training data to a model. I am opening this PR to discuss the API, and am not strongly opinionated about whether this should be merged or not. The API copies what DuckDB does and uses its implementation in the DuckDB backend.