### PR TITLE
feat(sqlite): add scalar python UDF support

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -971,9 +971,7 @@ class Backend(BaseAlchemyBackend):
                     self, f"_compile_{udf_node.__input_type__.name.lower()}_udf"
                 )
                 with contextlib.suppress(duckdb.InvalidInputException):
-                    con.connection.driver_connection.remove_function(
-                        udf_node.__class__.__name__
-                    )
+                    con.connection.remove_function(udf_node.__class__.__name__)
 
                 registration_func = compile_func(udf_node)
                 registration_func(con)
@@ -985,7 +983,7 @@ class Backend(BaseAlchemyBackend):
         output_type = DuckDBType.to_string(udf_node.output_dtype)
 
         def register_udf(con):
-            return con.connection.driver_connection.create_function(
+            return con.connection.create_function(
                 name,
                 func,
                 input_types,

--- a/ibis/backends/sqlite/udf.py
+++ b/ibis/backends/sqlite/udf.py
@@ -17,6 +17,16 @@ _SQLITE_UDF_REGISTRY = set()
 _SQLITE_UDAF_REGISTRY = set()
 
 
+def ignore_nulls(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        if any(arg is None for arg in args):
+            return None
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
 def udf(f):
     """Create a SQLite scalar UDF from `f`.
 
@@ -31,13 +41,7 @@ def udf(f):
         A callable object that returns ``None`` if any of its inputs are
         ``None``.
     """
-
-    @functools.wraps(f)
-    def wrapper(*args):
-        if any(arg is None for arg in args):
-            return None
-        return f(*args)
-
+    wrapper = ignore_nulls(f)
     _SQLITE_UDF_REGISTRY.add(wrapper)
     return wrapper
 

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas.testing as tm
+import sqlalchemy as sa
 from pytest import mark, param
 
 from ibis import _, udf
@@ -18,7 +19,6 @@ no_python_udfs = mark.notimpl(
         "pandas",
         "polars",
         "pyspark",
-        "sqlite",
         "trino",
     ]
 )
@@ -47,6 +47,11 @@ def test_udf(batting):
     ["postgres"], raises=TypeError, reason="postgres only supports map<string, string>"
 )
 @mark.notyet(["datafusion"], raises=NotImplementedError)
+@mark.notyet(
+    ["sqlite"],
+    raises=sa.exc.OperationalError,
+    reason="sqlite doesn't support map types",
+)
 def test_map_udf(batting):
     @udf.scalar.python
     def num_vowels_map(s: str, include_y: bool = False) -> dict[str, int]:
@@ -69,6 +74,7 @@ def test_map_udf(batting):
     ["postgres"], raises=TypeError, reason="postgres only supports map<string, string>"
 )
 @mark.notyet(["datafusion"], raises=NotImplementedError)
+@mark.notyet(["sqlite"], raises=TypeError, reason="sqlite doesn't support map types")
 def test_map_merge_udf(batting):
     @udf.scalar.python
     def vowels_map(s: str) -> dict[str, int]:
@@ -134,7 +140,7 @@ def add_one_pyarrow(s: int) -> int:  # s is series, int is the element type
             add_one_pandas,
             marks=[
                 mark.notyet(
-                    ["duckdb", "datafusion"],
+                    ["duckdb", "datafusion", "sqlite"],
                     raises=NotImplementedError,
                     reason="backend doesn't support pandas UDFs",
                 ),
@@ -144,7 +150,7 @@ def add_one_pyarrow(s: int) -> int:  # s is series, int is the element type
             add_one_pyarrow,
             marks=[
                 mark.notyet(
-                    ["snowflake"],
+                    ["snowflake", "sqlite"],
                     raises=NotImplementedError,
                     reason="backend doesn't support pyarrow UDFs",
                 )


### PR DESCRIPTION
This PR adds support for scalar Python UDFs to the SQLite backend using the new UDF API.