### PR TITLE
feat(duckdb): support motherduck

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -138,7 +138,7 @@ class Backend(BaseAlchemyBackend):
         self,
         database: str | Path = ":memory:",
         read_only: bool = False,
-        temp_directory: Path | str | None = None,
+        temp_directory: str | Path | None = None,
         **config: Any,
     ) -> None:
         """Create an Ibis client connected to a DuckDB database.
@@ -163,16 +163,20 @@ class Backend(BaseAlchemyBackend):
         >>> ibis.duckdb.connect("database.ddb", threads=4, memory_limit="1GB")
         <ibis.backends.duckdb.Backend object at ...>
         """
-        if database != ":memory:":
+        if (
+            not isinstance(database, Path)
+            and database != ":memory:"
+            and not database.startswith(("md:", "motherduck:"))
+        ):
             database = Path(database).absolute()
-        elif temp_directory is None:
+
+        if temp_directory is None:
             temp_directory = (
                 Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
                 / "ibis-duckdb"
                 / str(os.getpid())
             )
-
-        if temp_directory is not None:
+        else:
             Path(temp_directory).mkdir(parents=True, exist_ok=True)
             config["temp_directory"] = str(temp_directory)
 


### PR DESCRIPTION
This PR adds support for connecting to motherduck. Not sure if adding a secret just to test motherduck connection is worth it given the small amount of code.

```
In [1]: from ibis.interactive import *

In [2]: con = ibis.duckdb.connect("md:")

In [3]: con.list_tables()
Out[3]: ['tpc_h01_lineitem']

In [4]: con2 = ibis.duckdb.connect("motherduck:")

In [5]: con2.list_tables()
Out[5]: ['tpc_h01_lineitem']
```