### PR TITLE
ci(examples): address flakiness in `test_examples`

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -30,6 +30,7 @@ SANDBOXED = (
 LINUX = platform.system() == "Linux"
 MACOS = platform.system() == "Darwin"
 WINDOWS = platform.system() == "Windows"
+CI = os.environ.get("CI") is not None
 
 TEST_TABLES = {
     "functional_alltypes": ibis.schema(

--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -4,6 +4,8 @@ import json
 import os
 from typing import TYPE_CHECKING, Optional
 
+import filelock
+
 import ibis
 from ibis.common.grounds import Concrete
 
@@ -36,7 +38,11 @@ class Example(Concrete):
         table_name: str | None = None,
         backend: BaseBackend | None = None,
     ) -> ir.Table:
-        path = _EXAMPLES.fetch(self.key, progressbar=True)
+        key = self.key
+        # lock to ensure we don't clobber the file if fetched in another
+        # process
+        with filelock.FileLock(f"{key}.lock"):
+            path = _EXAMPLES.fetch(key, progressbar=True)
 
         if backend is None:
             backend = ibis.get_backend()

--- a/ibis/examples/tests/test_examples.py
+++ b/ibis/examples/tests/test_examples.py
@@ -1,20 +1,20 @@
-import os
 import uuid
 
 import pytest
 
 import ibis.examples
 import ibis.util
-from ibis.backends.conftest import LINUX, SANDBOXED
+from ibis.backends.conftest import CI, LINUX, SANDBOXED
 
 pytestmark = pytest.mark.examples
 
 duckdb = pytest.importorskip("duckdb")
 pytest.importorskip("pooch")
 
-# large files
+# large files or files that are used elsewhere
 ignored = frozenset(
     (
+        # large
         "imdb_name_basics",
         "imdb_title_akas",
         "imdb_title_basics",
@@ -24,7 +24,21 @@ ignored = frozenset(
         "imdb_title_ratings",
         "wowah_data_raw",
     )
-    * (os.environ.get("CI") is None)
+    * (not CI)  # ignore locally, but not in CI
+    + (
+        # use in doctests, avoid possible simultaneous use of the downloaded file
+        "Aids2",
+        "billboard",
+        "fish_encounters",
+        "penguins",
+        "penguins_raw_raw",
+        "relig_income_raw",
+        "us_rent_income",
+        "warpbreaks",
+        "who",
+        "world_bank_pop_raw",
+    )
+    * CI  # ignore in CI, but not locally
 )
 
 xfail_linux_nix = pytest.mark.xfail(

--- a/poetry.lock
+++ b/poetry.lock
@@ -5355,4 +5355,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "df89469431118150e8ccca75e5621532196879ba74ebdcd90cefda192148ae33"
+content-hash = "baaba98717d204af4c0613f070e640f9ddf5dc24148e1ee073f04e3f1c1e3ae5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 python = "^3.8"
 atpublic = ">=2.3,<5"
 bidict = ">=0.22.1,<1"
+filelock = ">=3.7.0,<4"
 importlib-resources = { version = ">=5,<6", python = "<3.9" }
 multipledispatch = ">=0.6,<1"
 numpy = ">=1,<2"
@@ -110,7 +111,6 @@ ruff = ">=0.0.271,<0.273"
 
 [tool.poetry.group.test.dependencies]
 black = ">=22.1.0,<24"
-filelock = ">=3.7.0,<4"
 hypothesis = ">=6.58.0,<7"
 packaging = ">=21.3,<24"
 pytest = ">=7.0.0,<8"


### PR DESCRIPTION
This PR addresses recentish test flakiness with examples that are used in both doctests and the `test_examples` test. The solution here is to avoid testing the shared tables in both doctests and `test_examples`. This may seem fragile, but in practice the number of unique example tables used in doctests does not vary much at all. Fixes #6533.