### PR TITLE
fix(examples): move lockfile creation to data directory

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -378,6 +378,10 @@ jobs:
           IBIS_TEST_WEBHDFS_USER: hdfs
           IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
 
+      - name: check that no untracked files were produced
+        shell: bash
+        run: git checkout poetry.lock pyproject.toml && ! git status --porcelain | tee /dev/stderr | grep .
+
       - name: upload code coverage
         if: success()
         uses: codecov/codecov-action@v3
@@ -504,6 +508,10 @@ jobs:
       - name: run tests
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
 
+      - name: check that no untracked files were produced
+        shell: bash
+        run: git checkout poetry.lock pyproject.toml && ! git status --porcelain | tee /dev/stderr | grep .
+
       - name: upload code coverage
         if: success()
         uses: codecov/codecov-action@v3
@@ -595,6 +603,10 @@ jobs:
 
       - name: run tests
         run: just ci-check -m pyspark
+
+      - name: check that no untracked files were produced
+        shell: bash
+        run: git checkout poetry.lock pyproject.toml && ! git status --porcelain | tee /dev/stderr | grep .
 
       - name: upload code coverage
         if: success()
@@ -760,6 +772,10 @@ jobs:
       - name: run tests
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
 
+      - name: check that no untracked files were produced
+        shell: bash
+        run: git checkout poetry.lock pyproject.toml && ! git status --porcelain | tee /dev/stderr | grep .
+
       - name: upload code coverage
         if: success()
         uses: codecov/codecov-action@v3
@@ -836,6 +852,10 @@ jobs:
 
       - name: "run parallel tests: flink"
         run: poetry run pytest --junitxml=junit.xml --cov=ibis --cov-report=xml:coverage.xml ibis/backends/flink/tests --numprocesses auto --dist=loadgroup
+
+      - name: check that no untracked files were produced
+        shell: bash
+        run: git checkout poetry.lock pyproject.toml && ! git status --porcelain | tee /dev/stderr | grep .
 
       - name: upload code coverage
         if: success()

--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -41,7 +41,8 @@ class Example(Concrete):
         key = self.key
         # lock to ensure we don't clobber the file if fetched in another
         # process
-        with filelock.FileLock(f"{key}.lock"):
+        _EXAMPLES.abspath.mkdir(parents=True, exist_ok=True)
+        with filelock.FileLock(_EXAMPLES.abspath / f"{key}.lock"):
             path = _EXAMPLES.fetch(key, progressbar=True)
 
         if backend is None:

--- a/ibis/examples/tests/test_examples.py
+++ b/ibis/examples/tests/test_examples.py
@@ -59,9 +59,8 @@ def test_examples(example, tmp_path):
 
     # initiate an new connection for every test case for isolation
     con = ibis.duckdb.connect(extension_directory=str(tmp_path))
-    ibis.set_backend(con)
 
-    df = ex.fetch().limit(1).execute()
+    df = ex.fetch(backend=con).limit(1).execute()
     assert len(df) == 1
 
 


### PR DESCRIPTION
This PR makes sure that examples lock files are created next to the data instead of in `$PWD`.