### PR TITLE
feat(api): add ALL_CAPS option to Table.relabel

### DIFF
--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -420,6 +420,23 @@ def test_relabel_snake_case():
     assert_equal(res, sol)
 
 
+def test_relabel_all_caps():
+    cases = [
+        ("cola", "COLA"),
+        ("ColB", "COL_B"),
+        ("colC", "COL_C"),
+        ("col-d", "COL_D"),
+        ("col_e", "COL_E"),
+        (" Column F ", "COLUMN_F"),
+        ("Column G-with-hyphens", "COLUMN_G_WITH_HYPHENS"),
+        ("Col H notCamelCase", "COL_H_NOTCAMELCASE"),
+    ]
+    t = ibis.table({c: "int" for c, _ in cases})
+    res = t.relabel("ALL_CAPS")
+    sol = t.relabel(dict(cases))
+    assert_equal(res, sol)
+
+
 def test_limit(table):
     limited = table.limit(10, offset=5)
     assert limited.op().n == 10


### PR DESCRIPTION
The intent of the change is to add another shorthand in addition to "snake_case" for relabeling. I wanted to add support for "SCREAMING_SNAKE_CASE". Some systems, such as Snowflake, Oracle SQL, and PL/SQL, follow this convention. This would be a worthwhile addition that might help with different backends or databases that treat double-quoted identifiers as case-insensitive.

https://github.com/ibis-project/ibis/pull/6532 was the original PR for this, but it was closed upon resyncing the fork and discarding changes. After the soft reset and force push of accidentally going back too far, I branched off the fork and redid the changes for ALL_CAPS as the table relabeling option on a separate branch. 