### PR TITLE
Use try_cast() from sqlalchemy and duckdb-engine

### DIFF
--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -22,10 +22,6 @@ class substr(GenericFunction):
     inherit_cache = True
 
 
-class try_cast(GenericFunction):
-    pass
-
-
 def variance_reduction(func_name, suffix=None):
     suffix = suffix or {'sample': '_samp', 'pop': '_pop'}
 

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -329,14 +329,6 @@ def _array_zip(t, op):
     )
 
 
-@compiles(try_cast, "duckdb")
-def compiles_try_cast(element, compiler, **kw):
-    return "TRY_CAST({} AS {})".format(
-        compiler.process(element.clauses.clauses[0], **kw),
-        compiler.visit_typeclause(element),
-    )
-
-
 def _try_cast(t, op):
     arg = t.translate(op.arg)
     to = t.get_sqla_type(op.to)

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -21,7 +21,6 @@ from ibis.backends.base.sql.alchemy.registry import (
     array_map,
     geospatial_functions,
     reduction,
-    try_cast,
 )
 from ibis.backends.base.sql.alchemy.registry import (
     _translate_case as _base_translate_case,
@@ -341,7 +340,7 @@ def compiles_try_cast(element, compiler, **kw):
 def _try_cast(t, op):
     arg = t.translate(op.arg)
     to = t.get_sqla_type(op.to)
-    return try_cast(arg, type_=to)
+    return sa.try_cast(arg, type_=to)
 
 
 operation_registry.update(

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -19,7 +19,6 @@ from ibis.backends.base.sql.alchemy.registry import (
     reduction,
     sqlalchemy_operation_registry,
     sqlalchemy_window_functions_registry,
-    try_cast,
     unary,
 )
 from ibis.backends.postgres.registry import _corr, _covar
@@ -272,7 +271,7 @@ def _zip(t, op):
     return sa.type_coerce(chunk, t.get_sqla_type(dtype))
 
 
-@compiles(try_cast, "trino")
+@compiles(sa.try_cast, "trino")
 def compiles_try_cast(element, compiler, **kw):
     return "TRY_CAST({} AS {})".format(
         compiler.process(element.clauses.clauses[0], **kw),
@@ -283,7 +282,7 @@ def compiles_try_cast(element, compiler, **kw):
 def _try_cast(t, op):
     arg = t.translate(op.arg)
     to = t.get_sqla_type(op.to)
-    return try_cast(arg, type_=to)
+    return sa.try_cast(arg, type_=to)
 
 
 operation_registry.update(


### PR DESCRIPTION
Fixes https://github.com/ibis-project/ibis/issues/6492.

I'm not exactly sure how all these pieces fit together, feel free to take this over as needed.

I don't think this will work quite yet, because we need [sqlalchemy>=2.0.14](https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_2_0_14), which isn't in requirements.txt yet.

But once that is upgraded, then this should be good to merge?

requirements.txt already has the new version of duckdb-engine>=0.9.0 that we need.