### PR TITLE
feat(cast): add table-level try_cast

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1253,6 +1253,33 @@ def test_try_cast_expected(con, from_val, to_type, expected):
         "sqlite",
     ]
 )
+def test_try_cast_table(con):
+    df = pd.DataFrame({"a": ["1", "2", None], "b": ["1.0", "2.2", "goodbye"]})
+
+    expected = pd.DataFrame({"a": [1.0, 2.0, None], "b": [1.0, 2.2, None]})
+
+    t = ibis.memtable(df)
+
+    tm.assert_frame_equal(con.execute(t.try_cast({"a": "int", "b": "float"})), expected)
+
+
+@pytest.mark.notimpl(
+    [
+        "pandas",
+        "dask",
+        "bigquery",
+        "datafusion",
+        "druid",
+        "impala",
+        "mssql",
+        "mysql",
+        "oracle",
+        "postgres",
+        "pyspark",
+        "snowflake",
+        "sqlite",
+    ]
+)
 @pytest.mark.parametrize(
     ("from_val", "to_type", "func"),
     [


### PR DESCRIPTION
I ran into this the other day and it seems like a nice convenience to also have a table-level `try_cast` -- I'm happy to add it as a separate method (which is probably better for consistency with the column methods).  