### PR TITLE
fix(mysql): ensure that floats and double do not come back as Python Decimal objects

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -275,14 +275,14 @@ class Backend(BaseBackend):
         #
         # the extra code to make this dance work without first converting to
         # record batches isn't worth it without some benchmarking
-        reader = self.to_pyarrow_batches(
+        with self.to_pyarrow_batches(
             expr=expr,
             params=params,
             limit=limit,
             external_tables=external_tables,
             **kwargs,
-        )
-        t = reader.read_all()
+        ) as reader:
+            t = reader.read_all()
 
         if isinstance(expr, ir.Scalar):
             return t[0][0]

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -122,6 +122,10 @@ class Backend(BaseAlchemyBackend):
         def column_reflect(inspector, table, column_info):
             if isinstance(column_info["type"], mysql.DATETIME):
                 column_info["type"] = MySQLDateTime()
+            if isinstance(column_info["type"], mysql.DOUBLE):
+                column_info["type"] = mysql.DOUBLE(asdecimal=False)
+            if isinstance(column_info["type"], mysql.FLOAT):
+                column_info["type"] = mysql.FLOAT(asdecimal=False)
 
         return meta
 

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -265,7 +265,9 @@ class Backend(BasePandasBackend):
         **kwargs: Any,
     ) -> pa.ipc.RecordBatchReader:
         pa = self._import_pyarrow()
-        pa_table = self.to_pyarrow(expr, params=params, limit=limit)
+        pa_table = self.to_pyarrow(
+            expr.as_table(), params=params, limit=limit, **kwargs
+        )
         return pa.RecordBatchReader.from_batches(
             pa_table.schema, pa_table.to_batches(max_chunksize=chunk_size)
         )

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -61,9 +61,6 @@ def test_table_to_pyarrow_batches(limit, awards_players):
         util.consume(batch_reader)
 
 
-@pytest.mark.notyet(
-    ["pandas"], reason="DataFrames have no option for outputting in batches"
-)
 @pytest.mark.parametrize("limit", limit_no_limit)
 def test_column_to_pyarrow_batches(limit, awards_players):
     with awards_players.awardID.to_pyarrow_batches(limit=limit) as batch_reader:
@@ -330,6 +327,7 @@ def test_to_pyarrow_decimal(backend, dtype, pyarrow_dtype):
         "bigquery",
         "clickhouse",
         "impala",
+        "mysql",
         "oracle",
         "postgres",
         "pyspark",
@@ -342,7 +340,6 @@ def test_to_pyarrow_decimal(backend, dtype, pyarrow_dtype):
 )
 @pytest.mark.notyet(["mssql", "pandas"], raises=PyDeltaTableError)
 @pytest.mark.notyet(["dask"], raises=NotImplementedError)
-@pytest.mark.notyet(["mysql"], raises=pa.ArrowInvalid)
 @pytest.mark.notyet(
     ["druid"],
     raises=pa.lib.ArrowTypeError,
@@ -402,11 +399,6 @@ def test_arrow_timestamp_with_time_zone(alltypes):
 
 @pytest.mark.notimpl(["dask", "druid"])
 @pytest.mark.notimpl(
-    ["mysql"],
-    raises=pa.ArrowInvalid,
-    reason="attempted conversion from decimal to double",
-)
-@pytest.mark.notimpl(
     ["impala"], raises=AttributeError, reason="missing `fetchmany` on the cursor"
 )
 def test_dataframe_protocol(alltypes):
@@ -417,11 +409,6 @@ def test_dataframe_protocol(alltypes):
 
 
 @pytest.mark.notimpl(["dask", "druid"])
-@pytest.mark.notimpl(
-    ["mysql"],
-    raises=pa.ArrowInvalid,
-    reason="attempted conversion from decimal to double",
-)
 @pytest.mark.notimpl(
     ["impala"], raises=AttributeError, reason="missing `fetchmany` on the cursor"
 )


### PR DESCRIPTION
This PR addresses the recent test flakiness seen in the MySQL backend.

The manifestation of the flakiness (dropped connection) was a bit of a red
herring.

The dropped connection was ultimately due to a connection that was
indeterminately closed, usually at some point later during interpreter GC but
not always (leading to the flakiness) because the batch producer for the
`RecordBatchReader` uses a connection in a context manager and it was left open
because of the **failure during the attempt by pyarrow to cast Python
`decimal.Decimal` objects to `float`s**.

The cast itself was the result of SQLAlchemy automatically returning
`decimal.Decimal` objects by default for columns whose type was
`mysql.DOUBLE`/`mysql.FLOAT`. The solution was to prevent that automatic
conversion during table column reflection.

Still, this PR **does not** address potential the footguns of using
`to_pyarrow_batches`, which may only be possible to address through better
documentation, but that is for another PR.
