### PR TITLE
test(impala): xfail with additional error type

### DIFF
--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -267,7 +267,7 @@ def test_timestamp_extract_literal(con, func, expected):
 )
 @pytest.mark.notyet(
     ["impala"],
-    raises=ImpalaOperationalError,
+    raises=(ImpalaHiveServer2Error, ImpalaOperationalError),
     reason='Impala backend does not support extracting microseconds.',
 )
 @pytest.mark.broken(["sqlite"], raises=AssertionError)


### PR DESCRIPTION
It seems extracting microseconds from a timestamp column using the impala backend can [fail with multiple exception types](https://github.com/ibis-project/ibis/actions/runs/5428150874/jobs/9872172582). This PR adds `HiveServer2Error` to the list of xfail exception types.