### PR TITLE
refactor(conversion): replace adhoc result handling with dunder methods specific to the `Expr` subclass

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -420,7 +420,7 @@ jobs:
               - "psycopg2@2.8.4"
               - "GeoAlchemy2@0.6.3"
               - "geopandas@0.6"
-              - "Shapely@1.6"
+              - "Shapely@2"
             services:
               - postgres
             extras:
@@ -435,7 +435,7 @@ jobs:
                 - "psycopg2@2.8.4"
                 - "GeoAlchemy2@0.6.3"
                 - "geopandas@0.6"
-                - "Shapely@1.6"
+                - "Shapely@2"
               services:
                 - postgres
               extras:
@@ -449,7 +449,7 @@ jobs:
                 - "psycopg2@2.8.4"
                 - "GeoAlchemy2@0.6.3"
                 - "geopandas@0.6"
-                - "Shapely@1.6"
+                - "Shapely@2"
               services:
                 - postgres
               extras:

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -262,10 +262,7 @@ class BaseSQLBackend(BaseBackend):
         with self._safe_raw_sql(sql, **kwargs) as cursor:
             result = self.fetch_from_cursor(cursor, schema)
 
-        if hasattr(getattr(query_ast, 'dml', query_ast), 'result_handler'):
-            result = query_ast.dml.result_handler(result)
-
-        return result
+        return expr.__pandas_result__(result)
 
     def _register_in_memory_table(self, _: ops.InMemoryTable) -> None:
         raise NotImplementedError(self.name)

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -185,10 +185,9 @@ class BaseAlchemyBackend(BaseSQLBackend):
         geom_col = None
         for name, dtype in schema.items():
             if dtype.is_geospatial():
-                geom_col = geom_col or name
-                df[name] = df[name].map(
-                    lambda row: None if row is None else shape.to_shape(row)
-                )
+                if not geom_col:
+                    geom_col = name
+                df[name] = df[name].map(shape.to_shape, na_action="ignore")
         if geom_col:
             df[geom_col] = gpd.array.GeometryArray(df[geom_col].values)
             df = gpd.GeoDataFrame(df, geometry=geom_col)

--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -121,6 +121,13 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
             backend._create_temp_view(view=result, definition=definition)
         elif isinstance(ref_op, ops.InMemoryTable):
             result = self._format_in_memory_table(op, ref_op, translator)
+        elif isinstance(ref_op, ops.DummyTable):
+            result = sa.select(
+                *(
+                    translator.translate(value).label(name)
+                    for name, value in zip(ref_op.schema.names, ref_op.values)
+                )
+            )
         else:
             # A subquery
             if ctx.is_extracted(ref_op):

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -189,7 +189,6 @@ class Select(DML, Comparable):
         limit=None,
         distinct=False,
         indent=2,
-        result_handler=None,
         parent_op=None,
     ):
         self.translator_class = translator_class
@@ -213,8 +212,6 @@ class Select(DML, Comparable):
         self.subqueries = subqueries or []
 
         self.indent = indent
-
-        self.result_handler = result_handler
 
     def _translate(self, expr, named=False, permit_subquery=False):
         translator = self.translator_class(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -736,14 +736,7 @@ class Backend(BaseAlchemyBackend):
             cursor = con.execute(sql)
             table = cursor.cursor.fetch_arrow_table()
 
-        if isinstance(expr, ir.Table):
-            return table
-        elif isinstance(expr, ir.Column):
-            return table[0]
-        elif isinstance(expr, ir.Scalar):
-            return table[0][0]
-        else:
-            raise ValueError
+        return expr.__pyarrow_result__(table)
 
     @util.experimental
     def to_torch(

--- a/ibis/backends/polars/tests/conftest.py
+++ b/ibis/backends/polars/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 import pytest
 
 import ibis
@@ -29,6 +30,16 @@ class TestConf(BackendTest, RoundAwayFromZero):
     @staticmethod
     def connect(*, tmpdir, worker_id, **kw):
         return ibis.polars.connect(**kw)
+
+    @classmethod
+    def assert_series_equal(cls, left, right, *args, **kwargs) -> None:
+        check_dtype = not (
+            issubclass(left.dtype.type, np.timedelta64)
+            and issubclass(right.dtype.type, np.timedelta64)
+        ) and kwargs.pop("check_dtype", True)
+        return super().assert_series_equal(
+            left, right, *args, **kwargs, check_dtype=check_dtype
+        )
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -340,12 +340,7 @@ $$""".format(
 
         res = res.rename_columns(target_schema.names).cast(target_schema)
 
-        if isinstance(expr, ir.Column):
-            return res[0]
-        elif isinstance(expr, ir.Scalar):
-            return res[0][0]
-        else:
-            return res
+        return expr.__pyarrow_result__(res)
 
     def fetch_from_cursor(self, cursor, schema: sch.Schema) -> pd.DataFrame:
         if (table := cursor.cursor.fetch_arrow_all()) is None:

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -415,7 +415,6 @@ def test_unnest_no_nulls(backend):
 
 
 @unnest
-@pytest.mark.notimpl("polars", raises=AssertionError, reason="Series are different")
 @pytest.mark.notimpl("dask", raises=ValueError)
 def test_unnest_default_name(backend):
     array_types = backend.array_types

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -327,7 +327,6 @@ def test_table_to_csv(tmp_path, backend, awards_players):
             pa.Decimal256Type,
             id="decimal256",
             marks=[
-                pytest.mark.broken(["pandas"], raises=AssertionError),
                 pytest.mark.notyet(["impala"], reason="precision not supported"),
                 pytest.mark.notyet(
                     ["druid", "duckdb", "snowflake", "trino"],
@@ -394,11 +393,6 @@ def test_roundtrip_delta(con, alltypes, tmp_path, monkeypatch):
 
 @pytest.mark.xfail_version(
     duckdb=["duckdb<0.8.1"], raises=AssertionError, reason="bug in duckdb"
-)
-@pytest.mark.notimpl(
-    ["pandas"],
-    raises=AssertionError,
-    reason="pandas returns nanosecond timestamp types",
 )
 @pytest.mark.notimpl(["dask"], raises=NotImplementedError)
 @pytest.mark.notimpl(["druid"], raises=sa.exc.ProgrammingError)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -798,7 +798,7 @@ def test_int_column(alltypes):
     assert result.dtype == np.int8
 
 
-@pytest.mark.notimpl(["datafusion", "druid", "oracle"])
+@pytest.mark.notimpl(["druid", "oracle"])
 @pytest.mark.never(
     ["bigquery", "sqlite", "snowflake"], reason="backend only implements int64"
 )

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -141,6 +141,11 @@ def test_filtering_join(backend, batting, awards_players, how):
 
 
 @pytest.mark.notimpl(["datafusion"])
+@pytest.mark.broken(
+    ["polars"],
+    raises=ValueError,
+    reason="https://github.com/pola-rs/polars/issues/9335",
+)
 def test_join_then_filter_no_column_overlap(awards_players, batting):
     left = batting[batting.yearID == 2015]
     year = left.yearID.name("year")
@@ -154,6 +159,11 @@ def test_join_then_filter_no_column_overlap(awards_players, batting):
 
 
 @pytest.mark.notimpl(["datafusion"])
+@pytest.mark.broken(
+    ["polars"],
+    raises=ValueError,
+    reason="https://github.com/pola-rs/polars/issues/9335",
+)
 def test_mutate_then_join_no_column_overlap(batting, awards_players):
     left = batting.mutate(year=batting.yearID).filter(lambda t: t.year == 2015)
     left = left["year", "RBI"]
@@ -164,6 +174,11 @@ def test_mutate_then_join_no_column_overlap(batting, awards_players):
 
 @pytest.mark.notimpl(["datafusion", "bigquery", "druid"])
 @pytest.mark.notyet(["dask"], reason="dask doesn't support descending order by")
+@pytest.mark.broken(
+    ["polars"],
+    raises=ValueError,
+    reason="https://github.com/pola-rs/polars/issues/9335",
+)
 @pytest.mark.parametrize(
     "func",
     [

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -915,10 +915,8 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
         ),
         param(
             lambda t, _: t.timestamp_col - ibis.timestamp(timestamp_value),
-            lambda t, be: pd.Series(
-                t.timestamp_col.sub(timestamp_value).values.astype(
-                    f'timedelta64[{be.returned_timestamp_unit}]'
-                )
+            lambda t, _: pd.Series(
+                t.timestamp_col.sub(timestamp_value).values.astype("timedelta64[s]")
             ).dt.floor("s"),
             id='timestamp-subtract-timestamp',
             marks=[
@@ -945,7 +943,11 @@ timestamp_value = pd.Timestamp('2018-01-01 18:18:18')
         ),
         param(
             lambda t, _: t.timestamp_col.date() - ibis.date(date_value),
-            lambda t, _: t.timestamp_col.dt.floor('d') - date_value,
+            lambda t, _: pd.Series(
+                (t.timestamp_col.dt.floor('d') - date_value).values.astype(
+                    "timedelta64[D]"
+                )
+            ),
             id='date-subtract-date',
             marks=[
                 pytest.mark.notimpl(["bigquery"], raises=com.OperationNotDefinedError),
@@ -969,7 +971,7 @@ def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
     result = con.execute(expr)
     expected = backend.default_series_rename(expected)
 
-    backend.assert_series_equal(result, expected.astype(result.dtype))
+    backend.assert_series_equal(result, expected)
 
 
 plus = lambda t, td: t.timestamp_col + pd.Timedelta(td)

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -5,10 +5,8 @@ import os
 import webbrowser
 from typing import TYPE_CHECKING, Any, Mapping, Tuple
 
-import toolz
 from public import public
 
-import ibis.common.graph as g
 import ibis.expr.operations as ops
 from ibis.common.exceptions import IbisError, IbisTypeError, TranslationError
 from ibis.common.grounds import Immutable

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -23,6 +23,7 @@ from ibis.expr.types.core import Expr, _FixedTextJupyterMixin
 
 if TYPE_CHECKING:
     import pandas as pd
+    import pyarrow as pa
 
     import ibis.selectors as s
     import ibis.expr.types as ir
@@ -111,6 +112,16 @@ class Table(Expr, _FixedTextJupyterMixin):
 
     def __dataframe__(self, *args: Any, **kwargs: Any):
         return self.to_pyarrow().__dataframe__(*args, **kwargs)
+
+    def __pyarrow_result__(self, table: pa.Table) -> pa.Table:
+        from ibis.formats.pyarrow import PyArrowData
+
+        return PyArrowData.convert_table(table, self.schema())
+
+    def __pandas_result__(self, df: pd.DataFrame) -> pd.DataFrame:
+        from ibis.formats.pandas import PandasData
+
+        return PandasData.convert_table(df, self.schema())
 
     def as_table(self) -> Table:
         """Promote the expression to a table.

--- a/poetry.lock
+++ b/poetry.lock
@@ -5501,4 +5501,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "b994a1395f025aa335bbd9d0f12e233054763342443e5dd970afdfe209356c72"
+content-hash = "3ed9cbea371b92c4177542c610adb5101897a292329d1834cdea226f3eef287a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ pyspark = { version = ">=3,<4", optional = true }
 # used to support posix regexen in the pandas, dask and sqlite backends
 regex = { version = ">=2021.7.6", optional = true }
 requests = { version = ">=2,<3", optional = true }
-shapely = { version = ">=1.9,<3", optional = true }
+shapely = { version = ">=2,<3", optional = true }
 # include an explicit dependency on `snowflake-connector-python` because the
 # lack of lower bound on this dependency as specified in `snowflake-sqlalchemy`
 # appears to cause poetry's solver to get stuck


### PR DESCRIPTION
This PR removes our ad-hoc `result_handler`-based shape reconciliation (Table
-> DataFrame | PyArrow Table, etc) in favor of two new methods:

* `__pandas_result__`
* `__pyarrow_result__`

each implemented on `ir.Table`, `ir.Column` and `ir.Scalar`. This has the benefit of removing quite a bit
of duplicated handling of expression-shape-to-in-memory-result-shape conversion.
