### PR TITLE
test(snowflake/datafusion): add multi-statement support and move datafusion test tables all to parquet

### DIFF
--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 import ibis
-import ibis.expr.types as ir
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 
 if TYPE_CHECKING:
@@ -18,38 +17,16 @@ class TestConf(BackendTest, RoundAwayFromZero):
     # check_names = False
     # supports_divide_by_zero = True
     # returned_timestamp_unit = 'ns'
-    native_bool = False
     supports_structs = False
     supports_json = False
     supports_arrays = False
 
     @staticmethod
     def connect(data_directory: Path):
-        # can be various types:
-        #   pyarrow.RecordBatch
-        #   parquet file path
-        #   csv file path
         client = ibis.datafusion.connect({})
         client.register(
-            data_directory / "csv" / 'functional_alltypes.csv',
+            data_directory / "parquet" / 'functional_alltypes.parquet',
             table_name='functional_alltypes',
-            schema=pa.schema(
-                [
-                    ('id', 'int64'),
-                    ('bool_col', 'int8'),
-                    ('tinyint_col', 'int8'),
-                    ('smallint_col', 'int16'),
-                    ('int_col', 'int32'),
-                    ('bigint_col', 'int64'),
-                    ('float_col', 'float32'),
-                    ('double_col', 'float64'),
-                    ('date_string_col', 'string'),
-                    ('string_col', 'string'),
-                    ('timestamp_col', 'string'),
-                    ('year', 'int64'),
-                    ('month', 'int64'),
-                ]
-            ),
         )
         client.register(
             data_directory / "parquet" / 'batting.parquet', table_name='batting'
@@ -62,14 +39,6 @@ class TestConf(BackendTest, RoundAwayFromZero):
             data_directory / "parquet" / 'diamonds.parquet', table_name='diamonds'
         )
         return client
-
-    @property
-    def functional_alltypes(self) -> ir.Table:
-        t = self.connection.table('functional_alltypes')
-        return t.mutate(
-            bool_col=t.bool_col == 1,
-            timestamp_col=t.timestamp_col.cast('timestamp'),
-        )
 
 
 @pytest.fixture(scope='session')

--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -16,7 +16,6 @@ pa = pytest.importorskip("pyarrow")
 
 class TestConf(BackendTest, RoundAwayFromZero):
     # check_names = False
-    # additional_skipped_operations = frozenset({ops.StringSQLLike})
     # supports_divide_by_zero = True
     # returned_timestamp_unit = 'ns'
     native_bool = False

--- a/ibis/backends/pandas/tests/conftest.py
+++ b/ibis/backends/pandas/tests/conftest.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import pandas as pd
 
 import ibis
-import ibis.expr.operations as ops
 from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundHalfToEven
 from ibis.backends.tests.data import array_types, json_types, struct_types, win
@@ -16,7 +15,6 @@ if TYPE_CHECKING:
 
 class TestConf(BackendTest, RoundHalfToEven):
     check_names = False
-    additional_skipped_operations = frozenset({ops.StringSQLLike})
     supported_to_timestamp_units = BackendTest.supported_to_timestamp_units | {'ns'}
     supports_divide_by_zero = True
     returned_timestamp_unit = 'ns'

--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -15,7 +15,6 @@ from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import ibis.expr.types as ir
     from ibis.backends.base import BaseBackend
 
 
@@ -55,6 +54,7 @@ def copy_into(con, data_dir: Path, table: str) -> None:
 
 class TestConf(BackendTest, RoundAwayFromZero):
     supports_map = True
+    default_identifier_case_fn = staticmethod(str.upper)
 
     def __init__(self, data_directory: Path) -> None:
         self.connection = self.connect(data_directory)
@@ -90,8 +90,9 @@ class TestConf(BackendTest, RoundAwayFromZero):
             c.exec_driver_sql(
                 f"""\
 CREATE DATABASE IF NOT EXISTS ibis_testing;
-CREATE SCHEMA IF NOT EXISTS ibis_testing.{dbschema};
-USE ibis_testing.{dbschema};
+USE DATABASE ibis_testing;
+CREATE SCHEMA IF NOT EXISTS {dbschema};
+USE SCHEMA {dbschema};
 {script_dir.joinpath("schema", "snowflake.sql").read_text()}"""
             )
 
@@ -104,46 +105,6 @@ USE ibis_testing.{dbschema};
                     for table in TEST_TABLES.keys()
                 ):
                     future.result()
-
-    @property
-    def functional_alltypes(self) -> ir.Table:
-        return self.connection.table('FUNCTIONAL_ALLTYPES')
-
-    @property
-    def batting(self) -> ir.Table:
-        return self.connection.table('BATTING')
-
-    @property
-    def awards_players(self) -> ir.Table:
-        return self.connection.table('AWARDS_PLAYERS')
-
-    @property
-    def diamonds(self) -> ir.Table:
-        return self.connection.table('DIAMONDS')
-
-    @property
-    def array_types(self) -> ir.Table:
-        return self.connection.table('ARRAY_TYPES')
-
-    @property
-    def geo(self) -> ir.Table | None:
-        return None
-
-    @property
-    def struct(self) -> ir.Table | None:
-        return self.connection.table("STRUCT")
-
-    @property
-    def json_t(self) -> ir.Table | None:
-        return self.connection.table("JSON_T")
-
-    @property
-    def map(self) -> ir.Table | None:
-        return self.connection.table("MAP")
-
-    @property
-    def win(self) -> ir.Table | None:
-        return self.connection.table("WIN")
 
     @staticmethod
     @functools.lru_cache(maxsize=None)


### PR DESCRIPTION
This PR cleans up a bit of testing code for datafusion and enables multi statement execution for the snowflake backend.
