### PR TITLE
fix(datafusion): always quote column names to prevent datafusion from normalizing case

### DIFF
--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -59,12 +59,8 @@ def cast(op):
 
 @translate.register(ops.TableColumn)
 def column(op):
-    table_op = op.table
-
-    if hasattr(table_op, "name"):
-        return df.column(f'{table_op.name}."{op.name}"')
-    else:
-        return df.column(op.name)
+    id_parts = [getattr(op.table, "name", None), op.name]
+    return df.column(".".join(f'"{id}"' for id in id_parts if id))
 
 
 @translate.register(ops.SortKey)

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -90,7 +90,6 @@ def test_column_to_pyarrow_array(limit, awards_players):
 
 
 @pytest.mark.parametrize("limit", no_limit)
-@pytest.mark.xfail_version(datafusion=["datafusion>=21"])
 def test_empty_column_to_pyarrow(limit, awards_players):
     expr = awards_players.filter(awards_players.awardID == "DEADBEEF").awardID
     array = expr.to_pyarrow(limit=limit)


### PR DESCRIPTION
DataFusion normalizes unquoted identifiers to lowercase. This PR quotes all `TableColumn` references during compilation to avoid normalizing names that are case sensitive.