### PR TITLE
ci: check release notes spelling in ci

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -63,6 +63,30 @@ jobs:
       - name: pre-commit checks
         run: nix develop '.#preCommit' --ignore-environment --keep-going -c pre-commit run --all-files --show-diff-on-failure --color=always
 
+  release_notes_spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: install nix
+        uses: cachix/install-nix-action@v22
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: setup cachix
+        uses: cachix/cachix-action@v12
+        with:
+          name: ibis
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: nix-community,poetry2nix
+
+      - name: check generated release notes spelling
+        run: nix run '.#check-release-notes-spelling'
+
   benchmarks:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
 
         default = pkgs.ibis310;
 
-        inherit (pkgs) update-lock-files gen-all-extras gen-examples check-poetry-version;
+        inherit (pkgs) update-lock-files gen-all-extras gen-examples check-poetry-version check-release-notes-spelling;
       };
 
       devShells = rec {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -42,7 +42,23 @@ in
   changelog = pkgs.writeShellApplication {
     name = "changelog";
     runtimeInputs = [ pkgs.nodePackages.conventional-changelog-cli ];
-    text = "conventional-changelog --config ./.conventionalcommits.js";
+    text = ''
+      conventional-changelog --config ./.conventionalcommits.js "$@"
+    '';
+  };
+
+  check-release-notes-spelling = pkgs.writeShellApplication {
+    name = "check-release-notes-spelling";
+    runtimeInputs = [ pkgs.changelog pkgs.coreutils pkgs.ibisSmallDevEnv ];
+    text = ''
+      tmp="$(mktemp)"
+      changelog --release-count 1 --output-unreleased --outfile "$tmp"
+      if ! codespell "$tmp"; then
+        # cat -n to output line numbers
+        cat -n "$tmp"
+        exit 1
+      fi
+    '';
   };
 
   update-lock-files = pkgs.writeShellApplication {


### PR DESCRIPTION
Adds a CI check for spelling in release notes. This will only check commits that are as-of-the-PR unreleased.