### PR TITLE
fix(mysql): fix UUID type reflection for sqlalchemy 2.0.18

### DIFF
--- a/ibis/backends/mysql/datatypes.py
+++ b/ibis/backends/mysql/datatypes.py
@@ -6,7 +6,7 @@ import sqlalchemy.types as sat
 from sqlalchemy.dialects import mysql
 
 import ibis.expr.datatypes as dt
-from ibis.backends.base.sql.alchemy.datatypes import AlchemyType
+from ibis.backends.base.sql.alchemy.datatypes import UUID, AlchemyType
 
 # binary character set
 # used to distinguish blob binary vs blob text
@@ -214,6 +214,7 @@ _from_mysql_types = {
     mysql.TIME: dt.Time,
     mysql.YEAR: dt.Int8,
     MySQLDateTime: dt.Timestamp,
+    UUID: dt.String,
 }
 
 
@@ -247,7 +248,7 @@ class MySQLType(AlchemyType):
             return dt.Timestamp(timezone="UTC", nullable=nullable)
         elif isinstance(typ, mysql.SET):
             return dt.Set(dt.string, nullable=nullable)
-        elif dtype := _from_mysql_types[type(typ)]:
+        elif dtype := _from_mysql_types.get(type(typ)):
             return dtype(nullable=nullable)
         else:
             return super().to_ibis(typ, nullable=nullable)


### PR DESCRIPTION
The recent sqlalchemy 2.0.18 release added reflection support for UUID types for mysql, which broke a test for us.

This also turned up a bug in the type mapping refactor where the `super().to_ibis` call could never be called (which is intended to handle fallback cases like this). That fix should definitely go in.

The `mysql uuid <-> ibis str` type fix here I'm less sure about. Only mysql 2.0.18+ supports properly reflecting these types, and a bit of rudimentary testing seems to indicate that swapping to `mysql uuid <-> ibis uuid` may not fully work yet. I opted for the fix that keeps the same behavior for now.