### PR TITLE
fix(postgres): by default use domain socket

### DIFF
--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -34,7 +34,7 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema):
 
     def do_connect(
         self,
-        host: str = 'localhost',
+        host: str | None = None,
         user: str | None = None,
         password: str | None = None,
         port: int = 5432,

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -218,3 +218,8 @@ def test_insert_with_cte(con):
     expr = X.join(X.mutate(a=X["id"] + 1), ["id"])
     Y = con.create_table("Y", expr, temp=True)
     assert Y.execute().empty
+
+
+def test_connect_url_with_empty_host():
+    con = ibis.connect("postgres:///ibis_testing")
+    assert con.con.url.host is None


### PR DESCRIPTION
  postgres:///dbname tries to connect via localhost, which may not be
  allowed.  With localhost as the default parameter, there is no way to
  force it to use the local unix domain socket.  This would make the
  default using the domain socket, and then connecting via localhost
  can be used via "postgres://localhost/dbname".
