### PR TITLE
chore(dev-deps): remove upstreamed cairocffi poetry2nix overrides

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688440303,
-        "narHash": "sha256-hFfOyityHdVFI0HNM+sqZfpi9Fbvjvy0N9O7FjuqPWY=",
+        "lastModified": 1688688124,
+        "narHash": "sha256-FFIkDUBo4z9j15e1VXzgc5M9HQoTbZvJ41dQ8ISg2IM=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "04714155bae013fb9b207e54d1faf9f0c3d08706",
+        "rev": "6bafd968790d919d809d810dd57d9776ab3831eb",
         "type": "github"
       },
       "original": {

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -11,16 +11,6 @@ in
   # `wheel` cannot be used as a wheel to unpack itself, since that would
   # require itself (infinite recursion)
   wheel = super.wheel.override { preferWheel = false; };
-  cairocffi = (super.cairocffi.override {
-    # FIXME(cpcloud): fix upstream in poetry2nix by ignoring patches when
-    # preferWheel = true wheel can't be patched with upstream nixpkgs patch, so
-    # build from source
-    preferWheel = false;
-  }).overridePythonAttrs (attrs: {
-    # FIXME(cpcloud): this can be fixed upstream in poetry2nix by adding
-    # flit-core to build-systems.json
-    nativeBuildInputs = attrs.nativeBuildInputs or [ ] ++ [ self.flit-core ];
-  });
 } // super.lib.listToAttrs (
   map
     (name: {


### PR DESCRIPTION
Per the FIXMEs in the deleted code, the necessary changes are now upstream in poetry2nix.