### PR TITLE
fix(duckdb): use regexp_matches to ensure that matching checks containment instead of a full match

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -413,7 +413,7 @@ operation_registry.update(
         ops.RegexReplace: fixed_arity(
             lambda *args: sa.func.regexp_replace(*args, sa.text("'g'")), 3
         ),
-        ops.RegexSearch: fixed_arity(lambda x, y: x.op("SIMILAR TO")(y), 2),
+        ops.RegexSearch: fixed_arity(sa.func.regexp_matches, 2),
         ops.StringContains: fixed_arity(sa.func.contains, 2),
         ops.ApproxMedian: reduction(
             # without inline text, duckdb fails with

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -192,6 +192,18 @@ def test_string_col_is_unicode(alltypes, df):
             ],
         ),
         param(
+            lambda t: ("a" + t.string_col + "a").re_search(r"\d+"),
+            lambda t: t.string_col.str.contains(r"\d+"),
+            id="re_search_substring",
+            marks=[
+                pytest.mark.notimpl(
+                    ["datafusion", "mssql", "oracle"],
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notimpl(["impala"], raises=AssertionError),
+            ],
+        ),
+        param(
             lambda t: t.string_col.re_search(r'\d+'),
             lambda t: t.string_col.str.contains(r'\d+'),
             id='re_search',


### PR DESCRIPTION
Fixes #6604.