### PR TITLE
 refactor(ir): rename `.output_dtype` and `.output_shape` to `.dtype` and `.shape` respectively  

### DIFF
--- a/docs/concept/design.md
+++ b/docs/concept/design.md
@@ -82,9 +82,9 @@ class Log(Value):
    # Optional argument, defaults to None
    base = rlz.optional(rlz.double)
    # Output expression's datatype will correspond to arg's datatype
-   output_dtype = rlz.dtype_like('arg')
+   dtype = rlz.dtype_like('arg')
    # Output expression will be scalar if arg is scalar, column otherwise
-   output_shape = rlz.shape_like('arg')
+   shape = rlz.shape_like('arg')
 ```
 
 This class describes an operation called `Log` that takes one required

--- a/docs/how_to/extending/elementwise.ipynb
+++ b/docs/how_to/extending/elementwise.ipynb
@@ -52,8 +52,8 @@
     "class JulianDay(Value):\n",
     "    arg: Value[dt.String, ds.Any]\n",
     "\n",
-    "    output_dtype = dt.float32\n",
-    "    output_shape = rlz.shape_like('arg')"
+    "    dtype = dt.float32\n",
+    "    shape = rlz.shape_like('arg')"
    ]
   },
   {

--- a/docs/how_to/extending/reduction.ipynb
+++ b/docs/how_to/extending/reduction.ipynb
@@ -64,8 +64,8 @@
     "    arg: Value[dt.Date, ds.Any]\n",
     "    where: Optional[Value[dt.Boolean, ds.Any]] = None\n",
     "\n",
-    "    output_dtype = rlz.dtype_like('arg')\n",
-    "    output_shape = ds.scalar"
+    "    dtype = rlz.dtype_like('arg')\n",
+    "    shape = ds.scalar"
    ]
   },
   {

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -32,7 +32,7 @@ def variance_reduction(func_name, suffix=None):
     def variance_compiler(t, op):
         arg = op.arg
 
-        if arg.output_dtype.is_boolean():
+        if arg.dtype.is_boolean():
             arg = ops.Cast(op.arg, to=dt.int32)
 
         func = getattr(sa.func, f'{func_name}{suffix[op.how]}')
@@ -166,7 +166,7 @@ def _exists_subquery(t, op):
 def _cast(t, op):
     arg = op.arg
     typ = op.to
-    arg_dtype = arg.output_dtype
+    arg_dtype = arg.dtype
 
     sa_arg = t.translate(arg)
 
@@ -195,7 +195,7 @@ def _contains(func):
         options = op.options
         if isinstance(options, tuple):
             right = [t.translate(x) for x in op.options]
-        elif options.output_shape.is_columnar():
+        elif options.shape.is_columnar():
             right = t.translate(ops.TableArrayView(options.to_expr().as_table()))
             if not isinstance(right, sa.sql.Selectable):
                 right = sa.select(right)
@@ -214,7 +214,7 @@ def _alias(t, op):
 
 
 def _literal(_, op):
-    dtype = op.output_dtype
+    dtype = op.dtype
     value = op.value
 
     if value is None:
@@ -272,7 +272,7 @@ def _translate_case(t, op, *, value):
 
 def _negate(t, op):
     arg = t.translate(op.arg)
-    return sa.not_(arg) if op.arg.output_dtype.is_boolean() else -arg
+    return sa.not_(arg) if op.arg.dtype.is_boolean() else -arg
 
 
 def unary(sa_func):
@@ -416,7 +416,7 @@ def reduction(sa_func):
 def _zero_if_null(t, op):
     sa_arg = t.translate(op.arg)
     return sa.case(
-        (sa_arg.is_(None), sa.cast(0, t.get_sqla_type(op.output_dtype))),
+        (sa_arg.is_(None), sa.cast(0, t.get_sqla_type(op.dtype))),
         else_=sa_arg,
     )
 

--- a/ibis/backends/base/sql/alchemy/translator.py
+++ b/ibis/backends/base/sql/alchemy/translator.py
@@ -102,7 +102,7 @@ class AlchemyExprTranslator(ExprTranslator):
         if (
             self._bool_aggs_need_cast_to_int32
             and isinstance(op, (ops.Sum, ops.Mean, ops.Min, ops.Max))
-            and (dtype := arg.output_dtype).is_boolean()
+            and (dtype := arg.dtype).is_boolean()
         ):
             return ops.Cast(arg, dt.Int32(nullable=dtype.nullable))
         return arg
@@ -133,7 +133,7 @@ rewrites = AlchemyExprTranslator.rewrites
 @rewrites(ops.NullIfZero)
 def _nullifzero(op):
     arg = op.arg
-    condition = ops.Equals(arg, ops.Literal(0, dtype=op.arg.output_dtype))
+    condition = ops.Equals(arg, ops.Literal(0, dtype=op.arg.dtype))
     return ops.Where(condition, ibis.NA, arg)
 
 
@@ -142,7 +142,7 @@ def _nullifzero(op):
 # on that things fail if it's not defined here (and in the registry
 # `operator.truediv` is used.
 def _true_divide(t, op):
-    if all(arg.output_dtype.is_integer() for arg in op.args):
+    if all(arg.dtype.is_integer() for arg in op.args):
         # TODO(kszucs): this should be done in the rewrite phase
         right, left = op.right.to_expr(), op.left.to_expr()
         new_expr = left.div(right.cast(dt.double))

--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -87,9 +87,9 @@ class SelectBuilder:
             return node, toolz.identity
 
         elif isinstance(node, ops.Value):
-            if node.output_shape.is_scalar():
+            if node.shape.is_scalar():
                 result_handler = _get_scalar(node.name)
-            elif node.output_shape.is_columnar():
+            elif node.shape.is_columnar():
                 result_handler = _get_column(node.name)
             else:
                 raise com.TranslationError(f"Unexpected shape {node.output_shape}")

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -248,7 +248,7 @@ class ExprTranslator:
 
     def _trans_param(self, op):
         raw_value = self.context.params[op]
-        dtype = op.output_dtype
+        dtype = op.dtype
         if dtype.is_struct():
             literal = ibis.struct(raw_value, type=dtype)
         elif dtype.is_map():
@@ -335,7 +335,7 @@ def _any_expand(op):
 
 @rewrites(ops.NotAny)
 def _notany_expand(op):
-    zero = ops.Literal(0, dtype=op.arg.output_dtype)
+    zero = ops.Literal(0, dtype=op.arg.dtype)
     return ops.Min(ops.Equals(op.arg, zero), where=op.where)
 
 
@@ -346,14 +346,14 @@ def _all_expand(op):
 
 @rewrites(ops.NotAll)
 def _notall_expand(op):
-    zero = ops.Literal(0, dtype=op.arg.output_dtype)
+    zero = ops.Literal(0, dtype=op.arg.dtype)
     return ops.Max(ops.Equals(op.arg, zero), where=op.where)
 
 
 @rewrites(ops.Cast)
 def _rewrite_cast(op):
     # TODO(kszucs): avoid the expression roundtrip
-    if op.to.is_interval() and op.arg.output_dtype.is_integer():
+    if op.to.is_interval() and op.arg.dtype.is_integer():
         return op.arg.to_expr().to_interval(unit=op.to.unit).op()
     return op
 
@@ -365,12 +365,12 @@ def _rewrite_string_contains(op):
 
 @rewrites(ops.Clip)
 def _rewrite_clip(op):
-    arg = ops.Cast(op.arg, op.output_dtype)
+    arg = ops.Cast(op.arg, op.dtype)
 
     if (upper := op.upper) is not None:
-        arg = ops.Least((arg, ops.Cast(upper, op.output_dtype)))
+        arg = ops.Least((arg, ops.Cast(upper, op.dtype)))
 
     if (lower := op.lower) is not None:
-        arg = ops.Greatest((arg, ops.Cast(lower, op.output_dtype)))
+        arg = ops.Greatest((arg, ops.Cast(lower, op.dtype)))
 
     return arg

--- a/ibis/backends/base/sql/registry/binary_infix.py
+++ b/ibis/backends/base/sql/registry/binary_infix.py
@@ -66,7 +66,7 @@ def contains(op_string: Literal["IN", "NOT IN"]) -> str:
         if isinstance(op.options, tuple):
             values = [translator.translate(x) for x in op.options]
             right = helpers.parenthesize(', '.join(values))
-        elif op.options.output_shape.is_columnar():
+        elif op.options.shape.is_columnar():
             right = translator.translate(op.options)
             if not any(
                 ctx.is_foreign_expr(leaf)

--- a/ibis/backends/base/sql/registry/geospatial.py
+++ b/ibis/backends/base/sql/registry/geospatial.py
@@ -126,7 +126,7 @@ def translate_multipolygon(value: list) -> str:
 
 def translate_literal(op: ops.Literal, inline_metadata: bool = False) -> str:
     value = op.value
-    dtype = op.output_dtype
+    dtype = op.dtype
 
     if isinstance(value, dt._WellKnownText):
         result = value.text

--- a/ibis/backends/base/sql/registry/literal.py
+++ b/ibis/backends/base/sql/registry/literal.py
@@ -41,7 +41,7 @@ def _number_literal_format(translator, op):
 
 
 def _interval_literal_format(translator, op):
-    return f'INTERVAL {op.value} {op.output_dtype.resolution.upper()}'
+    return f'INTERVAL {op.value} {op.dtype.resolution.upper()}'
 
 
 def _date_literal_format(translator, op):
@@ -74,7 +74,7 @@ literal_formatters = {
 def literal(translator, op):
     """Return the expression as its literal value."""
 
-    dtype = op.output_dtype
+    dtype = op.dtype
 
     if op.value is None:
         return "NULL"

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -57,7 +57,7 @@ def not_(translator, op):
 def negate(translator, op):
     arg = op.args[0]
     formatted_arg = translator.translate(arg)
-    if op.output_dtype.is_boolean():
+    if op.dtype.is_boolean():
         return not_(translator, op)
     else:
         if helpers.needs_parens(arg):
@@ -77,7 +77,7 @@ def ifnull_workaround(translator, op):
 
 def sign(translator, op):
     translated_arg = translator.translate(op.arg)
-    dtype = op.output_dtype
+    dtype = op.dtype
     translated_type = helpers.type_to_sql_string(dtype)
     if not dtype.is_float32():
         return f'CAST(sign({translated_arg}) AS {translated_type})'
@@ -114,7 +114,7 @@ def log(translator, op):
 def cast(translator, op):
     arg_formatted = translator.translate(op.arg)
 
-    if op.arg.output_dtype.is_temporal() and op.to.is_int64():
+    if op.arg.dtype.is_temporal() and op.to.is_int64():
         return f'1000000 * unix_timestamp({arg_formatted})'
     else:
         sql_type = helpers.type_to_sql_string(op.to)

--- a/ibis/backends/base/sql/registry/timestamp.py
+++ b/ibis/backends/base/sql/registry/timestamp.py
@@ -47,7 +47,7 @@ def truncate(translator, op):
 def interval_from_integer(translator, op):
     # interval cannot be selected from impala
     arg = translator.translate(op.arg)
-    return f'INTERVAL {arg} {op.output_dtype.resolution.upper()}'
+    return f'INTERVAL {arg} {op.dtype.resolution.upper()}'
 
 
 def timestamp_op(func):
@@ -55,11 +55,11 @@ def timestamp_op(func):
         formatted_left = translator.translate(op.left)
         formatted_right = translator.translate(op.right)
 
-        left_dtype = op.left.output_dtype
+        left_dtype = op.left.dtype
         if left_dtype.is_timestamp() or left_dtype.is_date():
             formatted_left = f'cast({formatted_left} as timestamp)'
 
-        right_dtype = op.right.output_dtype
+        right_dtype = op.right.dtype
         if right_dtype.is_timestamp() or right_dtype.is_date():
             formatted_right = f'cast({formatted_right} as timestamp)'
 

--- a/ibis/backends/base/sql/registry/window.py
+++ b/ibis/backends/base/sql/registry/window.py
@@ -45,16 +45,14 @@ def cumulative_to_window(translator, func, frame):
 def interval_boundary_to_integer(boundary):
     if boundary is None:
         return None
-    elif boundary.output_dtype.is_numeric():
+    elif boundary.dtype.is_numeric():
         return boundary
 
     value = boundary.value
     try:
-        multiplier = _map_interval_to_microseconds[value.output_dtype.unit.short]
+        multiplier = _map_interval_to_microseconds[value.dtype.unit.short]
     except KeyError:
-        raise com.IbisInputError(
-            f"Unsupported interval unit: {value.output_dtype.unit}"
-        )
+        raise com.IbisInputError(f"Unsupported interval unit: {value.dtype.unit}")
 
     if isinstance(value, ops.Literal):
         value = ops.Literal(value.value * multiplier, dt.int64)
@@ -143,7 +141,7 @@ def window(translator, op):
 
     # Time ranges need to be converted to microseconds.
     if isinstance(frame, ops.RangeWindowFrame):
-        if any(c.output_dtype.is_temporal() for c in frame.order_by):
+        if any(c.dtype.is_temporal() for c in frame.order_by):
             frame = time_range_to_range_window(frame)
     elif isinstance(frame, ops.RowsWindowFrame):
         if frame.max_lookback is not None:

--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -86,7 +86,7 @@ def bigquery_cast_generate_simple(compiled_arg, to):
 def _cast(translator, op):
     arg, target_type = op.args
     arg_formatted = translator.translate(arg)
-    input_dtype = arg.output_dtype
+    input_dtype = arg.dtype
     return bigquery_cast(arg_formatted, input_dtype, target_type)
 
 
@@ -247,7 +247,7 @@ def _log(translator, op):
 
 
 def _literal(translator, op):
-    dtype = op.output_dtype
+    dtype = op.dtype
     value = op.value
 
     if value is None:
@@ -342,7 +342,7 @@ def _truncate(kind, units):
         trans_arg = translator.translate(arg)
         if unit not in units:
             raise com.UnsupportedOperationError(
-                f"BigQuery does not support truncating {arg.output_dtype} values to unit {unit!r}"
+                f"BigQuery does not support truncating {arg.dtype} values to unit {unit!r}"
             )
         if unit.name == "WEEK":
             unit = "WEEK(MONDAY)"
@@ -365,7 +365,7 @@ def _date_binary(func):
     def _formatter(translator, op):
         arg, offset = op.left, op.right
 
-        unit = offset.output_dtype.unit
+        unit = offset.dtype.unit
         if not unit.is_date():
             raise com.UnsupportedOperationError(
                 f"BigQuery does not allow binary operation {func} with INTERVAL offset {unit}"
@@ -382,7 +382,7 @@ def _timestamp_binary(func):
     def _formatter(translator, op):
         arg, offset = op.left, op.right
 
-        unit = offset.output_dtype.unit
+        unit = offset.dtype.unit
         if unit == IntervalUnit.NANOSECOND:
             raise com.UnsupportedOperationError(
                 f"BigQuery does not allow binary operation {func} with INTERVAL offset {unit}"
@@ -452,7 +452,7 @@ def compiles_strftime(translator, op):
     """Timestamp formatting."""
     arg = op.arg
     format_str = op.format_str
-    arg_type = arg.output_dtype
+    arg_type = arg.dtype
     strftime_format_func_name = STRFTIME_FORMAT_FUNCTIONS[arg_type]
     fmt_string = translator.translate(format_str)
     arg_formatted = translator.translate(arg)
@@ -483,7 +483,7 @@ def compiles_string_to_timestamp(translator, op):
 
 
 def compiles_floor(t, op):
-    bigquery_type = BigQueryType.from_ibis(op.output_dtype)
+    bigquery_type = BigQueryType.from_ibis(op.dtype)
     arg = op.arg
     return f"CAST(FLOOR({t.translate(arg)}) AS {bigquery_type})"
 
@@ -508,10 +508,10 @@ def compiles_covar_corr(func):
             right = ops.Where(where, right, None)
 
         left = translator.translate(
-            ops.Cast(left, dt.int64) if left.output_dtype.is_boolean() else left
+            ops.Cast(left, dt.int64) if left.dtype.is_boolean() else left
         )
         right = translator.translate(
-            ops.Cast(right, dt.int64) if right.output_dtype.is_boolean() else right
+            ops.Cast(right, dt.int64) if right.dtype.is_boolean() else right
         )
         return f"{func}({left}, {right})"
 
@@ -539,7 +539,7 @@ def _identical_to(t, op):
 def _floor_divide(t, op):
     left = t.translate(op.left)
     right = t.translate(op.right)
-    return bigquery_cast(f"FLOOR(IEEE_DIVIDE({left}, {right}))", op.output_dtype)
+    return bigquery_cast(f"FLOOR(IEEE_DIVIDE({left}, {right}))", op.dtype)
 
 
 def _log2(t, op):
@@ -555,12 +555,12 @@ def _is_inf(t, op):
 
 
 def _nullifzero(t, op):
-    casted = bigquery_cast('0', op.output_dtype)
+    casted = bigquery_cast('0', op.dtype)
     return f"NULLIF({t.translate(op.arg)}, {casted})"
 
 
 def _zeroifnull(t, op):
-    casted = bigquery_cast('0', op.output_dtype)
+    casted = bigquery_cast('0', op.dtype)
     return f"COALESCE({t.translate(op.arg)}, {casted})"
 
 
@@ -629,11 +629,11 @@ def _nth_value(t, op):
 def _interval_multiply(t, op):
     if isinstance(op.left, ops.Literal) and isinstance(op.right, ops.Literal):
         value = op.left.value * op.right.value
-        literal = ops.Literal(value, op.left.output_dtype)
+        literal = ops.Literal(value, op.left.dtype)
         return t.translate(literal)
 
     left, right = t.translate(op.left), t.translate(op.right)
-    unit = op.left.output_dtype.resolution.upper()
+    unit = op.left.dtype.resolution.upper()
     return f"INTERVAL EXTRACT({unit} from {left}) * {right} {unit}"
 
 

--- a/ibis/backends/bigquery/rewrites.py
+++ b/ibis/backends/bigquery/rewrites.py
@@ -10,14 +10,14 @@ from ibis.backends.base.sql import compiler as sql_compiler
 
 
 def bq_sum(op):
-    if isinstance((arg := op.arg).output_dtype, dt.Boolean):
+    if isinstance((arg := op.arg).dtype, dt.Boolean):
         return ops.Sum(ops.Cast(arg, dt.int64), where=op.where)
     else:
         return op
 
 
 def bq_mean(op):
-    if isinstance((arg := op.arg).output_dtype, dt.Boolean):
+    if isinstance((arg := op.arg).dtype, dt.Boolean):
         return ops.Mean(ops.Cast(arg, dt.int64), where=op.where)
     else:
         return op

--- a/ibis/backends/bigquery/udf/__init__.py
+++ b/ibis/backends/bigquery/udf/__init__.py
@@ -273,8 +273,8 @@ return {f.__name__}({args});\
             for name, type_ in params.items()
         }
 
-        udf_node_fields["output_dtype"] = output_type
-        udf_node_fields["output_shape"] = rlz.shape_like("args")
+        udf_node_fields["dtype"] = output_type
+        udf_node_fields["shape"] = rlz.shape_like("args")
         udf_node_fields["__slots__"] = ("sql",)
 
         udf_node = _create_udf_node(name, udf_node_fields)
@@ -373,8 +373,8 @@ RETURNS {return_type}
         }
         return_type = BigQueryType.from_ibis(dt.dtype(output_type))
 
-        udf_node_fields["output_dtype"] = output_type
-        udf_node_fields["output_shape"] = rlz.shape_like("args")
+        udf_node_fields["dtype"] = output_type
+        udf_node_fields["shape"] = rlz.shape_like("args")
         udf_node_fields["__slots__"] = ("sql",)
 
         udf_node = _create_udf_node(name, udf_node_fields)

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -400,7 +400,7 @@ def _node_list(op, punct="()", **kw):
 
 
 def _interval_format(op):
-    dtype = op.output_dtype
+    dtype = op.dtype
     if dtype.unit.short in {"ms", "us", "ns"}:
         raise com.UnsupportedOperationError(
             "Clickhouse doesn't support subsecond interval resolutions"
@@ -411,7 +411,7 @@ def _interval_format(op):
 
 @translate_val.register(ops.IntervalFromInteger)
 def _interval_from_integer(op, **kw):
-    dtype = op.output_dtype
+    dtype = op.dtype
     if dtype.unit.short in {"ms", "us", "ns"}:
         raise com.UnsupportedOperationError(
             "Clickhouse doesn't support subsecond interval resolutions"
@@ -424,7 +424,7 @@ def _interval_from_integer(op, **kw):
 @translate_val.register(ops.Literal)
 def _literal(op, **kw):
     value = op.value
-    dtype = op.output_dtype
+    dtype = op.dtype
     if value is None and dtype.nullable:
         if dtype.is_null():
             return "Null"
@@ -611,7 +611,7 @@ def _timestamp_from_ymdhms(op, **kw):
         f"leftPad(toString({s}), 2, '0')"
         "))"
     )
-    if timezone := op.output_dtype.timezone:
+    if timezone := op.dtype.timezone:
         return f"toTimeZone({to_datetime}, {timezone})"
     return to_datetime
 
@@ -712,7 +712,7 @@ def _cotangent(op, **kw):
 def _bit_agg(func):
     def _translate(op, **kw):
         arg = translate_val(op.arg, **kw)
-        if not isinstance((type := op.arg.output_dtype), dt.UnsignedInteger):
+        if not isinstance((type := op.arg.dtype), dt.UnsignedInteger):
             nbits = type.nbytes * 8
             arg = f"reinterpretAsUInt{nbits}({arg})"
 
@@ -736,7 +736,7 @@ def _struct_column(op, **kw):
     # ClickHouse struct types cannot be nullable
     # (non-nested fields can be nullable)
     values = translate_val(op.values, **kw)
-    struct_type = serialize(op.output_dtype.copy(nullable=False))
+    struct_type = serialize(op.dtype.copy(nullable=False))
     return f"CAST({values} AS {struct_type})"
 
 
@@ -755,7 +755,7 @@ def _clip(op, **kw):
 @translate_val.register(ops.StructField)
 def _struct_field(op, render_aliases: bool = False, **kw):
     arg = op.arg
-    arg_dtype = arg.output_dtype
+    arg_dtype = arg.dtype
     arg = translate_val(op.arg, render_aliases=render_aliases, **kw)
     idx = arg_dtype.names.index(op.field)
     typ = arg_dtype.types[idx]
@@ -805,7 +805,7 @@ def _floor_divide(op, **kw):
 @translate_val.register(ops.ScalarParameter)
 def _scalar_param(op, params: Mapping[ops.Node, Any], **kw):
     raw_value = params[op]
-    dtype = op.output_dtype
+    dtype = op.dtype
     if isinstance(dtype, dt.Struct):
         literal = ibis.struct(raw_value, type=dtype)
     elif isinstance(dtype, dt.Map):
@@ -836,7 +836,7 @@ def contains(op_string: Literal["IN", "NOT IN"]) -> str:
             left_arg = helpers.parenthesize(left_arg)
 
         # special case non-foreign isin/notin expressions
-        if not isinstance(options, tuple) and options.output_shape.is_columnar():
+        if not isinstance(options, tuple) and options.shape.is_columnar():
             # this will fail to execute if there's a correlation, but it's too
             # annoying to detect so we let it through to enable the
             # uncorrelated use case (pandas-style `.isin`)
@@ -868,7 +868,7 @@ def day_of_week_name(op, **kw):
     #
     # We test against 20 in CI, so we implement day_of_week_name as follows
     arg = op.arg
-    nullable = arg.output_dtype.nullable
+    nullable = arg.dtype.nullable
     empty_string = ops.Literal("", dtype=dt.String(nullable=nullable))
     weekdays = range(7)
     return translate_val(
@@ -906,7 +906,7 @@ def _vararg_func(op, **kw):
 def _map(op, **kw):
     keys = translate_val(op.keys, **kw)
     values = translate_val(op.values, **kw)
-    typ = serialize(op.output_dtype)
+    typ = serialize(op.dtype)
     return f"CAST(({keys}, {values}) AS {typ})"
 
 
@@ -1097,10 +1097,10 @@ del _fmt, _name, _op
 @translate_val.register(ops.ExtractMicrosecond)
 def _extract_microsecond(op, **kw):
     arg = translate_val(op.arg, **kw)
-    dtype = serialize(op.output_dtype)
+    dtype = serialize(op.dtype)
 
     datetime_type_args = ["6"]
-    if (tz := op.arg.output_dtype.timezone) is not None:
+    if (tz := op.arg.dtype.timezone) is not None:
         datetime_type_args.append(f"'{tz}'")
 
     datetime_type = f"DateTime64({', '.join(datetime_type_args)})"
@@ -1110,10 +1110,10 @@ def _extract_microsecond(op, **kw):
 @translate_val.register(ops.ExtractMillisecond)
 def _extract_millisecond(op, **kw):
     arg = translate_val(op.arg, **kw)
-    dtype = serialize(op.output_dtype)
+    dtype = serialize(op.dtype)
 
     datetime_type_args = ["3"]
-    if (tz := op.arg.output_dtype.timezone) is not None:
+    if (tz := op.arg.dtype.timezone) is not None:
         datetime_type_args.append(f"'{tz}'")
 
     datetime_type = f"DateTime64({', '.join(datetime_type_args)})"

--- a/ibis/backends/dask/aggcontext.py
+++ b/ibis/backends/dask/aggcontext.py
@@ -199,7 +199,7 @@ class Moving(Window):
     __slots__ = ()
 
     def __init__(self, start, max_lookback, *args, **kwargs):
-        start = compute_window_spec(start.output_dtype, start.value)
+        start = compute_window_spec(start.dtype, start.value)
 
         super().__init__(
             'rolling',

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -238,7 +238,7 @@ def execute_until_in_scope(
                 node: execute_literal(
                     node,
                     node.value,
-                    node.output_dtype,
+                    node.dtype,
                     aggcontext=aggcontext,
                     **kwargs,
                 )

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -284,7 +284,7 @@ def cast_series_to_timestamp(data, tz):
 @execute_node.register(ops.Cast, dd.Series, dt.Timestamp)
 def execute_cast_series_timestamp(op, data, type, **kwargs):
     arg = op.arg
-    from_type = arg.output_dtype
+    from_type = arg.dtype
 
     if from_type.equals(type):  # noop cast
         return data
@@ -315,7 +315,7 @@ def execute_cast_series_timestamp(op, data, type, **kwargs):
 @execute_node.register(ops.Cast, dd.Series, dt.Date)
 def execute_cast_series_date(op, data, type, **kwargs):
     arg = op.args[0]
-    from_type = arg.output_dtype
+    from_type = arg.dtype
 
     if from_type.equals(type):
         return data

--- a/ibis/backends/dask/execution/selection.py
+++ b/ibis/backends/dask/execution/selection.py
@@ -65,7 +65,7 @@ def compute_projection(
         name = node.name
         assert name is not None, 'Value selection name is None'
 
-        if node.output_shape.is_scalar():
+        if node.shape.is_scalar():
             data_columns = frozenset(data.columns)
 
             if scope is None:

--- a/ibis/backends/dask/execution/window.py
+++ b/ibis/backends/dask/execution/window.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 def _check_valid_window_frame(frame):
     # TODO consolidate this with pandas
     if frame.how == "range" and any(
-        not col.output_dtype.is_temporal() for col in frame.order_by
+        not col.dtype.is_temporal() for col in frame.order_by
     ):
         raise NotImplementedError(
             "The Dask backend only implements range windows with temporal "
@@ -112,7 +112,7 @@ def get_aggcontext_window(
     # expand or roll.
     #
     # otherwise we're transforming
-    output_type = operand.output_dtype
+    output_type = operand.dtype
 
     if not group_by and not order_by:
         aggcontext = agg_ctx.Summarize(parent=parent, output_type=output_type)

--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -359,7 +359,7 @@ def count_star(_):
 @translate.register(ops.Sum)
 def sum(op):
     arg = translate(op.arg)
-    if op.arg.output_dtype.is_boolean():
+    if op.arg.dtype.is_boolean():
         arg = arg.cast(pa.int64())
     return df.functions.sum(arg)
 
@@ -472,8 +472,8 @@ def scalar_udf(op):
         )
     udf = df.udf(
         op.__func__,
-        input_types=[PyArrowType.from_ibis(arg.output_dtype) for arg in op.args],
-        return_type=PyArrowType.from_ibis(op.output_dtype),
+        input_types=[PyArrowType.from_ibis(arg.dtype) for arg in op.args],
+        return_type=PyArrowType.from_ibis(op.dtype),
         volatility="volatile",
     )
     args = map(translate, op.args)

--- a/ibis/backends/druid/compiler.py
+++ b/ibis/backends/druid/compiler.py
@@ -20,7 +20,7 @@ class DruidExprTranslator(AlchemyExprTranslator):
         result = super().translate(op)
         with contextlib.suppress(AttributeError):
             result = result.scalar_subquery()
-        return sa.type_coerce(result, self.type_mapper.from_ibis(op.output_dtype))
+        return sa.type_coerce(result, self.type_mapper.from_ibis(op.dtype))
 
 
 rewrites = DruidExprTranslator.rewrites

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -977,8 +977,8 @@ class Backend(BaseAlchemyBackend):
     def _compile_udf(self, udf_node: ops.ScalarUDF) -> None:
         func = udf_node.__func__
         name = func.__name__
-        input_types = [DuckDBType.to_string(arg.output_dtype) for arg in udf_node.args]
-        output_type = DuckDBType.to_string(udf_node.output_dtype)
+        input_types = [DuckDBType.to_string(arg.dtype) for arg in udf_node.args]
+        output_type = DuckDBType.to_string(udf_node.dtype)
 
         def register_udf(con):
             return con.connection.create_function(

--- a/ibis/backends/flink/compiler/core.py
+++ b/ibis/backends/flink/compiler/core.py
@@ -64,7 +64,7 @@ def translate_op(op: ops.TableNode) -> str:
 @translate_op.register(ops.Literal)
 def _literal(op: ops.Literal) -> str:
     value = op.value
-    dtype = op.output_dtype
+    dtype = op.dtype
 
     if dtype.is_boolean():
         # TODO(chloeh13q): Flink supports a third boolean called "UNKNOWN"

--- a/ibis/backends/impala/udf.py
+++ b/ibis/backends/impala/udf.py
@@ -68,15 +68,15 @@ class Function(metaclass=abc.ABCMeta):
 class ScalarFunction(Function):
     def _create_operation_class(self):
         fields = {f'_{i}': rlz.ValueOf(dtype) for i, dtype in enumerate(self.inputs)}
-        fields['output_dtype'] = self.output
-        fields['output_shape'] = rlz.shape_like('args')
+        fields['dtype'] = self.output
+        fields['shape'] = rlz.shape_like('args')
         return type(f"UDF_{self.name}", (ops.Value,), fields)
 
 
 class AggregateFunction(Function):
     def _create_operation_class(self):
         fields = {f'_{i}': rlz.ValueOf(dtype) for i, dtype in enumerate(self.inputs)}
-        fields['output_dtype'] = self.output
+        fields['dtype'] = self.output
         return type(f"UDA_{self.name}", (ops.Reduction,), fields)
 
 

--- a/ibis/backends/mssql/registry.py
+++ b/ibis/backends/mssql/registry.py
@@ -19,9 +19,9 @@ def _reduction(func, cast_type='int32'):
     def reduction_compiler(t, op):
         arg, where = op.args
 
-        if arg.output_dtype.is_boolean():
+        if arg.dtype.is_boolean():
             if isinstance(arg, ops.TableColumn):
-                nullable = arg.output_dtype.nullable
+                nullable = arg.dtype.nullable
                 arg = ops.Cast(arg, dt.dtype(cast_type)(nullable=nullable))
             else:
                 arg = ops.Where(arg, 1, 0)

--- a/ibis/backends/mysql/registry.py
+++ b/ibis/backends/mysql/registry.py
@@ -69,7 +69,7 @@ def _interval_from_integer(t, op):
         )
 
     sa_arg = t.translate(op.arg)
-    text_unit = op.output_dtype.resolution.upper()
+    text_unit = op.dtype.resolution.upper()
 
     # XXX: Is there a better way to handle this? I.e. can we somehow use
     # the existing bind parameter produced by translate and reuse its name in
@@ -80,16 +80,16 @@ def _interval_from_integer(t, op):
 
 
 def _literal(_, op):
-    if op.output_dtype.is_interval():
-        if op.output_dtype.unit.short in {'ms', 'ns'}:
+    if op.dtype.is_interval():
+        if op.dtype.unit.short in {'ms', 'ns'}:
             raise com.UnsupportedOperationError(
                 'MySQL does not allow operation '
-                f'with INTERVAL offset {op.output_dtype.unit}'
+                f'with INTERVAL offset {op.dtype.unit}'
             )
-        text_unit = op.output_dtype.resolution.upper()
+        text_unit = op.dtype.resolution.upper()
         sa_text = sa.text(f'INTERVAL :value {text_unit}')
         return sa_text.bindparams(value=op.value)
-    elif op.output_dtype.is_binary():
+    elif op.dtype.is_binary():
         # the cast to BINARY is necessary here, otherwise the data come back as
         # Python strings
         #
@@ -115,7 +115,7 @@ def _group_concat(t, op):
 def _json_get_item(t, op):
     arg = t.translate(op.arg)
     index = t.translate(op.index)
-    if op.index.output_dtype.is_integer():
+    if op.index.dtype.is_integer():
         path = "$[" + sa.cast(index, sa.TEXT) + "]"
     else:
         path = "$." + index

--- a/ibis/backends/oracle/registry.py
+++ b/ibis/backends/oracle/registry.py
@@ -26,7 +26,7 @@ operation_registry.update(sqlalchemy_window_functions_registry)
 
 def _cot(t, op):
     arg = t.translate(op.arg)
-    return 1.0 / sa.func.tan(arg, type_=t.get_sqla_type(op.arg.output_dtype))
+    return 1.0 / sa.func.tan(arg, type_=t.get_sqla_type(op.arg.dtype))
 
 
 def _cov(t, op):
@@ -46,7 +46,7 @@ def _literal(t, op):
     if (
         # handle UUIDs in sqlalchemy < 2
         vparse(sa.__version__) < vparse("2")
-        and (dtype := op.output_dtype).is_uuid()
+        and (dtype := op.dtype).is_uuid()
         and (value := op.value) is not None
     ):
         return sa.literal(str(value), type_=t.get_sqla_type(dtype))

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -679,7 +679,7 @@ class Moving(Window):
     def __init__(self, start, max_lookback, *args, **kwargs):
         from ibis.backends.pandas.core import timedelta_types
 
-        start = compute_window_spec(start.output_dtype, start.value)
+        start = compute_window_spec(start.dtype, start.value)
         if isinstance(start, timedelta_types + (pd.offsets.DateOffset,)):
             closed = 'both'
         else:

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -265,7 +265,7 @@ def execute_until_in_scope(
                 node: execute_literal(
                     node,
                     node.value,
-                    node.output_dtype,
+                    node.dtype,
                     aggcontext=aggcontext,
                     **kwargs,
                 )

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -111,9 +111,9 @@ def execute_cast_series_group_by(op, data, type, **kwargs):
 def execute_cast_series_generic(op, data, type, **kwargs):
     out = data.astype(constants.IBIS_TYPE_TO_PANDAS_TYPE[type])
     if type.is_integer():
-        if op.arg.output_dtype.is_timestamp():
+        if op.arg.dtype.is_timestamp():
             return out.floordiv(int(1e9))
-        elif op.arg.output_dtype.is_date():
+        elif op.arg.dtype.is_date():
             return out.floordiv(int(24 * 60 * 60 * 1e9))
     return out
 
@@ -143,7 +143,7 @@ def execute_cast_series_array(op, data, type, **kwargs):
 @execute_node.register(ops.Cast, pd.Series, dt.Timestamp)
 def execute_cast_series_timestamp(op, data, type, **kwargs):
     arg = op.arg
-    from_type = arg.output_dtype
+    from_type = arg.dtype
 
     if from_type.equals(type):  # noop cast
         return data
@@ -185,7 +185,7 @@ def _normalize(values, original_index, name, timezone=None):
 @execute_node.register(ops.Cast, pd.Series, dt.Date)
 def execute_cast_series_date(op, data, type, **kwargs):
     arg = op.args[0]
-    from_type = arg.output_dtype
+    from_type = arg.dtype
 
     if from_type.equals(type):
         return data
@@ -1533,7 +1533,7 @@ def execute_table_array_view(op, _, **kwargs):
 
 @execute_node.register(ops.ZeroIfNull, pd.Series)
 def execute_zero_if_null_series(op, data, **kwargs):
-    zero = op.arg.output_dtype.to_pandas().type(0)
+    zero = op.arg.dtype.to_pandas().type(0)
     return data.replace({np.nan: zero, None: zero, pd.NA: zero})
 
 
@@ -1548,5 +1548,5 @@ def execute_in_memory_table(op, **kwargs):
 )
 def execute_zero_if_null_scalar(op, data, **kwargs):
     if data is None or pd.isna(data) or math.isnan(data) or np.isnan(data):
-        return op.arg.output_dtype.to_pandas().type(0)
+        return op.arg.dtype.to_pandas().type(0)
     return data

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -53,7 +53,7 @@ def compute_projection(
         name = node.name
         assert name is not None, 'Value selection name is None'
 
-        if node.output_shape.is_scalar():
+        if node.shape.is_scalar():
             data_columns = frozenset(data.columns)
 
             if scope is None:

--- a/ibis/backends/pandas/execution/window.py
+++ b/ibis/backends/pandas/execution/window.py
@@ -162,7 +162,7 @@ def get_aggcontext_window(
     # expand or roll.
     #
     # otherwise we're transforming
-    output_type = operand.output_dtype
+    output_type = operand.dtype
 
     if not group_by and not order_by:
         aggcontext = agg_ctx.Summarize(parent=parent, output_type=output_type)
@@ -269,7 +269,7 @@ def execute_window_op(
     func, frame = op.func, op.frame
 
     if frame.how == "range" and any(
-        not col.output_dtype.is_temporal() for col in frame.order_by
+        not col.dtype.is_temporal() for col in frame.order_by
     ):
         raise NotImplementedError(
             "The pandas backend only implements range windows with temporal "

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -357,7 +357,7 @@ class Backend(BaseBackend):
             replacements = {}
             for p, v in params.items():
                 op = p.op() if isinstance(p, ir.Expr) else p
-                replacements[op] = ibis.literal(v, type=op.output_dtype).op()
+                replacements[op] = ibis.literal(v, type=op.dtype).op()
             node = node.replace(replacements)
             expr = node.to_expr()
 

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -133,7 +133,7 @@ def try_cast(op, **kwargs):
 
 def _cast(op, strict=True, **kwargs):
     arg = translate(op.arg, **kwargs)
-    dtype = op.arg.output_dtype
+    dtype = op.arg.dtype
     to = op.to
 
     if to.is_interval():
@@ -450,7 +450,7 @@ _string_unary = {
 @translate.register(ops.StringLength)
 def string_length(op, **kw):
     arg = translate(op.arg, **kw)
-    typ = dtype_to_polars(op.output_dtype)
+    typ = dtype_to_polars(op.dtype)
     return arg.str.lengths().cast(typ)
 
 
@@ -587,7 +587,7 @@ def str_right(op, **kw):
 @translate.register(ops.Round)
 def round(op, **kw):
     arg = translate(op.arg, **kw)
-    typ = dtype_to_polars(op.output_dtype)
+    typ = dtype_to_polars(op.dtype)
     if op.digits is not None:
         _assert_literal(op.digits)
         digits = op.digits.value
@@ -643,7 +643,7 @@ def repeat(op, **kw):
 @translate.register(ops.Sign)
 def sign(op, **kw):
     arg = translate(op.arg, **kw)
-    typ = dtype_to_polars(op.output_dtype)
+    typ = dtype_to_polars(op.dtype)
     return arg.sign().cast(typ)
 
 
@@ -706,11 +706,11 @@ def mode(op, **kw):
 @translate.register(ops.Correlation)
 def correlation(op, **kw):
     x = op.left
-    if (x_type := x.output_dtype).is_boolean():
+    if (x_type := x.dtype).is_boolean():
         x = ops.Cast(x, dt.Int32(nullable=x_type.nullable))
 
     y = op.right
-    if (y_type := y.output_dtype).is_boolean():
+    if (y_type := y.dtype).is_boolean():
         y = ops.Cast(y, dt.Int32(nullable=y_type.nullable))
 
     if (where := op.where) is not None:
@@ -993,7 +993,7 @@ def comparison(op, **kw):
 def between(op, **kw):
     op_arg = op.arg
     arg = translate(op_arg, **kw)
-    dtype = op_arg.output_dtype
+    dtype = op_arg.dtype
     lower = translate(ops.Cast(op.lower_bound, dtype), **kw)
     upper = translate(ops.Cast(op.upper_bound, dtype), **kw)
     return arg.is_between(lower, upper, closed="both")
@@ -1023,7 +1023,7 @@ def bitwise_binops(op, **kw):
     else:
         result = pl.map([left, right], lambda cols: ufunc(cols[0], cols[1]))
 
-    return result.cast(dtype_to_polars(op.output_dtype))
+    return result.cast(dtype_to_polars(op.dtype))
 
 
 @translate.register(ops.BitwiseNot)
@@ -1077,7 +1077,7 @@ def execute_pi(op, **_):
 @translate.register(ops.Time)
 def execute_time(op, **kw):
     arg = translate(op.arg, **kw)
-    if op.arg.output_dtype.is_timestamp():
+    if op.arg.dtype.is_timestamp():
         return arg.dt.truncate("1us").cast(pl.Time)
     return arg
 

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -210,10 +210,10 @@ WHERE p.proname = :name
             name=name,
             ident=ident,
             signature=", ".join(
-                f"{name} {self._compile_type(arg.output_dtype)}"
+                f"{name} {self._compile_type(arg.dtype)}"
                 for name, arg in zip(udf_node.argnames, udf_node.args)
             ),
-            return_type=self._compile_type(udf_node.output_dtype),
+            return_type=self._compile_type(udf_node.dtype),
             language=config.get("language", "plpython3u"),
             source="\n".join(
                 _verify_source_line(func_name, line)

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -8,7 +8,7 @@ from ibis.backends.postgres.registry import operation_registry
 
 
 class PostgresUDFNode(ops.Value):
-    output_shape = rlz.shape_like("args")
+    shape = rlz.shape_like("args")
 
 
 class PostgreSQLExprTranslator(AlchemyExprTranslator):

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -73,8 +73,8 @@ def _typeof(t, op):
     # select pg_typeof('thing') returns unknown so we have to check the child's
     # type for nullness
     return sa.case(
-        ((typ == 'unknown') & (op.arg.output_dtype != dt.null), 'text'),
-        ((typ == 'unknown') & (op.arg.output_dtype == dt.null), 'null'),
+        ((typ == 'unknown') & (op.arg.dtype != dt.null), 'text'),
+        ((typ == 'unknown') & (op.arg.dtype == dt.null), 'null'),
         else_=typ,
     )
 
@@ -255,7 +255,7 @@ def _log(t, op):
         sa_base = t.translate(base)
         return sa.cast(
             sa.func.log(sa.cast(sa_base, sa.NUMERIC), sa.cast(sa_arg, sa.NUMERIC)),
-            t.get_sqla_type(op.output_dtype),
+            t.get_sqla_type(op.dtype),
         )
     return sa.func.ln(sa_arg)
 
@@ -298,8 +298,8 @@ def _table_column(t, op):
     sa_table = get_sqla_table(ctx, table)
     out_expr = get_col(sa_table, op)
 
-    if op.output_dtype.is_timestamp():
-        timezone = op.output_dtype.timezone
+    if op.dtype.is_timestamp():
+        timezone = op.dtype.timezone
         if timezone is not None:
             out_expr = out_expr.op('AT TIME ZONE')(timezone).label(op.name)
 
@@ -322,7 +322,7 @@ def _round(t, op):
     # number of digits (though simple truncation on doubles is allowed) so
     # we cast to numeric and then cast back if necessary
     result = sa.func.round(sa.cast(sa_arg, sa.NUMERIC), t.translate(digits))
-    if digits is not None and arg.output_dtype.is_decimal():
+    if digits is not None and arg.dtype.is_decimal():
         return result
     result = sa.cast(result, pg.DOUBLE_PRECISION())
     return result
@@ -333,12 +333,12 @@ def _mod(t, op):
 
     # postgres doesn't allow modulus of double precision values, so upcast and
     # then downcast later if necessary
-    if not op.output_dtype.is_integer():
+    if not op.dtype.is_integer():
         left = sa.cast(left, sa.NUMERIC)
         right = sa.cast(right, sa.NUMERIC)
 
     result = left % right
-    if op.output_dtype.is_float64():
+    if op.dtype.is_float64():
         return sa.cast(result, pg.DOUBLE_PRECISION())
     else:
         return result
@@ -382,7 +382,7 @@ def _array_index(*, index_converter, func):
 
 
 def _literal(t, op):
-    dtype = op.output_dtype
+    dtype = op.dtype
     value = op.value
 
     if dtype.is_interval():
@@ -453,11 +453,11 @@ def _median(t, op):
 def _binary_variance_reduction(func):
     def variance_compiler(t, op):
         x = op.left
-        if (x_type := x.output_dtype).is_boolean():
+        if (x_type := x.dtype).is_boolean():
             x = ops.Cast(x, dt.Int32(nullable=x_type.nullable))
 
         y = op.right
-        if (y_type := y.output_dtype).is_boolean():
+        if (y_type := y.dtype).is_boolean():
             y = ops.Cast(y, dt.Int32(nullable=y_type.nullable))
 
         if t._has_reduction_filter_syntax:
@@ -512,15 +512,13 @@ def compile_struct_field_postgresql(element, compiler, **kw):
 
 def _struct_field(t, op):
     arg = op.arg
-    idx = arg.output_dtype.names.index(op.field) + 1
+    idx = arg.dtype.names.index(op.field) + 1
     field_name = sa.literal_column(f"f{idx:d}")
-    return struct_field(
-        t.translate(arg), field_name, type_=t.get_sqla_type(op.output_dtype)
-    )
+    return struct_field(t.translate(arg), field_name, type_=t.get_sqla_type(op.dtype))
 
 
 def _struct_column(t, op):
-    types = op.output_dtype.types
+    types = op.dtype.types
     return sa.func.row(
         # we have to cast here, otherwise postgres refuses to allow the statement
         *map(t.translate, map(ops.Cast, op.values, types)),
@@ -532,7 +530,7 @@ def _struct_column(t, op):
 
 def _unnest(t, op):
     arg = op.arg
-    row_type = arg.output_dtype.value_type
+    row_type = arg.dtype.value_type
 
     types = getattr(row_type, "types", (row_type,))
 
@@ -605,7 +603,7 @@ operation_registry.update(
         ops.TimestampTruncate: _timestamp_truncate,
         ops.IntervalFromInteger: (
             lambda t, op: t.translate(op.arg)
-            * sa.text(f"INTERVAL '1 {op.output_dtype.resolution}'")
+            * sa.text(f"INTERVAL '1 {op.dtype.resolution}'")
         ),
         ops.DateAdd: fixed_arity(operator.add, 2),
         ops.DateSub: fixed_arity(operator.sub, 2),
@@ -670,7 +668,7 @@ operation_registry.update(
         ops.Quantile: _quantile,
         ops.MultiQuantile: _quantile,
         ops.TimestampNow: lambda t, op: sa.literal_column(
-            "CURRENT_TIMESTAMP", type_=t.get_sqla_type(op.output_dtype)
+            "CURRENT_TIMESTAMP", type_=t.get_sqla_type(op.dtype)
         ),
         ops.MapGet: fixed_arity(
             lambda arg, key, default: sa.case(

--- a/ibis/backends/postgres/udf.py
+++ b/ibis/backends/postgres/udf.py
@@ -76,7 +76,7 @@ def existing_udf(name, input_types, output_type, schema=None, parameters=None):
         name: rlz.ValueOf(type_) for name, type_ in zip(parameters, input_types)
     }
     udf_node_fields['name'] = name
-    udf_node_fields['output_dtype'] = output_type
+    udf_node_fields['dtype'] = output_type
 
     udf_node = _create_udf_node(name, udf_node_fields)
 

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -254,10 +254,10 @@ $$ {defn["source"]} $$"""
     def _get_udf_source(self, udf_node: ops.ScalarUDF):
         name = type(udf_node).__name__
         signature = ", ".join(
-            f"{name} {self._compile_type(arg.output_dtype)}"
+            f"{name} {self._compile_type(arg.dtype)}"
             for name, arg in zip(udf_node.argnames, udf_node.args)
         )
-        return_type = self._compile_type(udf_node.output_dtype)
+        return_type = self._compile_type(udf_node.dtype)
         source = textwrap.dedent(inspect.getsource(udf_node.__func__)).strip()
         source = "\n".join(
             line for line in source.splitlines() if not line.startswith("@udf")

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -217,7 +217,7 @@ class Backend(BaseAlchemyBackend):
         name = func.__name__
 
         for argname, arg in zip(udf_node.argnames, udf_node.args):
-            dtype = arg.output_dtype
+            dtype = arg.dtype
             if not (
                 dtype.is_string()
                 or dtype.is_binary()

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -194,7 +194,7 @@ def _string_join(t, op):
 
 
 def _literal(t, op):
-    dtype = op.output_dtype
+    dtype = op.dtype
     if dtype.is_array():
         raise NotImplementedError(f"Unsupported type: {dtype!r}")
     if dtype.is_uuid():
@@ -220,7 +220,7 @@ def _timestamp_op(func, sign, units):
     def _formatter(translator, op):
         arg, offset = op.args
 
-        unit = offset.output_dtype.unit
+        unit = offset.dtype.unit
         if unit not in units:
             raise com.UnsupportedOperationError(
                 "SQLite does not allow binary operation "
@@ -244,7 +244,7 @@ def _date_diff(t, op):
 def _mode(t, op):
     sa_arg = op.arg
 
-    if sa_arg.output_dtype.is_boolean():
+    if sa_arg.dtype.is_boolean():
         sa_arg = ops.Cast(op.arg, to=dt.int32)
 
     if op.where is not None:
@@ -288,7 +288,7 @@ operation_registry.update(
         # instance of ops.Value
         ops.Cast: (
             lambda t, op: sqlite_cast(
-                t.translate(op.arg), op.arg.output_dtype, op.to, translator=t
+                t.translate(op.arg), op.arg.dtype, op.to, translator=t
             )
         ),
         ops.StrRight: fixed_arity(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -722,7 +722,7 @@ def test_integer_to_interval_timestamp(
     expr = (alltypes.timestamp_col + interval).name('tmp')
 
     def convert_to_offset(offset, displacement_type=displacement_type):
-        resolution = f'{interval.op().output_dtype.resolution}s'
+        resolution = f'{interval.op().dtype.resolution}s'
         return displacement_type(**{resolution: offset})
 
     with warnings.catch_warnings():

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -34,7 +34,7 @@ def _array(t, elements):
 
 def _literal(t, op):
     value = op.value
-    dtype = op.output_dtype
+    dtype = op.dtype
 
     if value is None:
         return sa.null()
@@ -61,7 +61,7 @@ def _arbitrary(t, op):
 def _json_get_item(t, op):
     arg = t.translate(op.arg)
     index = t.translate(op.index)
-    fmt = "%d" if op.index.output_dtype.is_integer() else '"%s"'
+    fmt = "%d" if op.index.dtype.is_integer() else '"%s"'
     return sa.func.json_extract(arg, sa.func.format(f"$[{fmt}]", index))
 
 
@@ -82,7 +82,7 @@ def _array_column(t, op):
         str(t.translate(arg).compile(compile_kwargs={"literal_binds": True}))
         for arg in op.cols
     )
-    return sa.literal_column(f"ARRAY[{args}]", type_=t.get_sqla_type(op.output_dtype))
+    return sa.literal_column(f"ARRAY[{args}]", type_=t.get_sqla_type(op.dtype))
 
 
 _truncate_precisions = {
@@ -128,7 +128,7 @@ def _timestamp_from_unix(t, op):
         res = sa.func.from_unixtime_nanos(arg - arg % 1_000_000_000)
     else:
         raise com.UnsupportedOperationError(f"{unit!r} unit is not supported")
-    return sa.cast(res, t.get_sqla_type(op.output_dtype))
+    return sa.cast(res, t.get_sqla_type(op.dtype))
 
 
 if_ = getattr(sa.func, "if")
@@ -178,7 +178,7 @@ def _round(t, op):
 def _unnest(t, op):
     arg = op.arg
     name = arg.name
-    row_type = op.arg.output_dtype.value_type
+    row_type = op.arg.dtype.value_type
     names = getattr(row_type, "names", (name,))
     rd = sa.func.unnest(t.translate(arg)).table_valued(*names).render_derived()
     # wrap in a row column so that we can return a single column from this rule
@@ -193,13 +193,13 @@ def _where(t, op):
         t.translate(op.bool_expr),
         t.translate(op.true_expr),
         t.translate(op.false_null_expr),
-        type_=t.get_sqla_type(op.output_dtype),
+        type_=t.get_sqla_type(op.dtype),
     )
 
 
 def _cot(t, op):
     arg = t.translate(op.arg)
-    return 1.0 / sa.func.tan(arg, type_=t.get_sqla_type(op.arg.output_dtype))
+    return 1.0 / sa.func.tan(arg, type_=t.get_sqla_type(op.arg.dtype))
 
 
 @compiles(array_map, "trino")
@@ -265,7 +265,7 @@ def _zip(t, op):
 
     all_n, chunk = reduce(combine_zipped, chunks)
 
-    dtype = op.output_dtype
+    dtype = op.dtype
 
     assert all_n == len(dtype.value_type)
 
@@ -398,7 +398,7 @@ operation_registry.update(
         ops.TimestampFromUNIX: _timestamp_from_unix,
         ops.StructField: lambda t, op: t.translate(op.arg).op(".")(sa.text(op.field)),
         ops.StructColumn: lambda t, op: sa.cast(
-            sa.func.row(*map(t.translate, op.values)), t.get_sqla_type(op.output_dtype)
+            sa.func.row(*map(t.translate, op.values)), t.get_sqla_type(op.dtype)
         ),
         ops.Literal: _literal,
         ops.IfNull: fixed_arity(sa.func.coalesce, 2),

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -895,31 +895,31 @@ def test_initialized_attribute_mixed_with_classvar():
     class Value(Annotable):
         arg = is_int
 
-        output_shape = "like-arg"
-        output_dtype = "like-arg"
+        shape = "like-arg"
+        dtype = "like-arg"
 
     class Reduction(Value):
-        output_shape = "scalar"
+        shape = "scalar"
 
     class Variadic(Value):
         @attribute.default
-        def output_shape(self):
+        def shape(self):
             if self.arg > 10:
                 return "columnar"
             else:
                 return "scalar"
 
     r = Reduction(1)
-    assert r.output_shape == "scalar"
-    assert "output_shape" not in r.__slots__
+    assert r.shape == "scalar"
+    assert "shape" not in r.__slots__
 
     v = Variadic(1)
-    assert v.output_shape == "scalar"
-    assert "output_shape" in v.__slots__
+    assert v.shape == "scalar"
+    assert "shape" in v.__slots__
 
     v = Variadic(100)
-    assert v.output_shape == "columnar"
-    assert "output_shape" in v.__slots__
+    assert v.shape == "columnar"
+    assert "shape" in v.__slots__
 
 
 class Node(Comparable):

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -255,10 +255,10 @@ def test_generic_coerced_to():
         def __coerce__(cls, value, T=..., S=...):
             return cls(value, Scalar())
 
-        def output_dtype(self) -> T:
+        def dtype(self) -> T:
             ...
 
-        def output_shape(self) -> S:
+        def shape(self) -> S:
             ...
 
     class Literal(Value[T, Scalar]):
@@ -266,10 +266,10 @@ def test_generic_coerced_to():
             self.value = value
             self.dtype = dtype
 
-        def output_dtype(self) -> T:
+        def dtype(self) -> T:
             return self.dtype
 
-        def output_shape(self) -> DataShape:
+        def shape(self) -> DataShape:
             return Scalar()
 
         def __eq__(self, other):

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -675,7 +675,7 @@ def find_predicates(node, flatten=True):
     # flatten_predicates instead
     def predicate(node):
         assert isinstance(node, ops.Node), type(node)
-        if isinstance(node, ops.Value) and node.output_dtype.is_boolean():
+        if isinstance(node, ops.Value) and node.dtype.is_boolean():
             if flatten and isinstance(node, ops.And):
                 return g.proceed, None
             else:

--- a/ibis/expr/builders.py
+++ b/ibis/expr/builders.py
@@ -114,22 +114,22 @@ class WindowBuilder(Builder):
     max_lookback: Optional[Value[dt.Interval]] = None
 
     def _maybe_cast_boundary(self, boundary, dtype):
-        if boundary.output_dtype == dtype:
+        if boundary.dtype == dtype:
             return boundary
         value = ops.Cast(boundary.value, dtype)
         return boundary.copy(value=value)
 
     def _maybe_cast_boundaries(self, start, end):
         if start and end:
-            dtype = dt.higher_precedence(start.output_dtype, end.output_dtype)
+            dtype = dt.higher_precedence(start.dtype, end.dtype)
             start = self._maybe_cast_boundary(start, dtype)
             end = self._maybe_cast_boundary(end, dtype)
         return start, end
 
     def _determine_how(self, start, end):
-        if start and not start.output_dtype.is_integer():
+        if start and not start.dtype.is_integer():
             return self.range
-        elif end and not end.output_dtype.is_integer():
+        elif end and not end.dtype.is_integer():
             return self.range
         else:
             return self.rows

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -463,7 +463,7 @@ def _fmt_selection_column_value_expr(
     # the additional 1 is for the colon
     aligned_name = f"{name:<{maxlen + 1}}"
     value = fmt_value(node, aliases=aliases)
-    dtype = type_info(node.output_dtype)
+    dtype = type_info(node.dtype)
     return f"{aligned_name} {value}{dtype}"
 
 
@@ -560,7 +560,7 @@ def _fmt_value_binary_op(op: ops.Binary, *, aliases: Aliases) -> str:
 
 @fmt_value.register
 def _fmt_value_negate(op: ops.Negate, *, aliases: Aliases) -> str:
-    op_name = "Not" if op.output_dtype.is_boolean() else "Negate"
+    op_name = "Not" if op.dtype.is_boolean() else "Negate"
     operand = fmt_value(op.arg, aliases=aliases)
     return f"{op_name}({operand})"
 

--- a/ibis/expr/operations/analytic.py
+++ b/ibis/expr/operations/analytic.py
@@ -13,7 +13,7 @@ from ibis.expr.operations.core import Column, Scalar, Value
 
 @public
 class Analytic(Value):
-    output_shape = ds.columnar
+    shape = ds.columnar
 
     @property
     def __window_op__(self):
@@ -26,7 +26,7 @@ class ShiftBase(Analytic):
     offset: Optional[Value[dt.Integer | dt.Interval]] = None
     default: Optional[Value] = None
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
@@ -41,7 +41,7 @@ class Lead(ShiftBase):
 
 @public
 class RankBase(Analytic):
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
@@ -90,8 +90,8 @@ class CumulativeSum(Cumulative):
     arg: Column[dt.Numeric]
 
     @attribute.default
-    def output_dtype(self):
-        return dt.higher_precedence(self.arg.output_dtype.largest, dt.int64)
+    def dtype(self):
+        return dt.higher_precedence(self.arg.dtype.largest, dt.int64)
 
 
 @public
@@ -104,15 +104,15 @@ class CumulativeMean(Cumulative):
     arg: Column[dt.Numeric]
 
     @attribute.default
-    def output_dtype(self):
-        return dt.higher_precedence(self.arg.output_dtype.largest, dt.float64)
+    def dtype(self):
+        return dt.higher_precedence(self.arg.dtype.largest, dt.float64)
 
 
 @public
 class CumulativeMax(Cumulative):
     arg: Column[dt.Any]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
@@ -124,34 +124,34 @@ class CumulativeMin(Cumulative):
 
     arg: Column[dt.Any]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
 class CumulativeAny(Cumulative):
     arg: Column[dt.Boolean]
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
 class CumulativeAll(Cumulative):
     arg: Column[dt.Boolean]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
 class PercentRank(Analytic):
     arg: Column[dt.Any]
 
-    output_dtype = dt.double
+    dtype = dt.double
 
 
 @public
 class CumeDist(Analytic):
     arg: Column[dt.Any]
 
-    output_dtype = dt.double
+    dtype = dt.double
 
 
 @public
@@ -159,7 +159,7 @@ class NTile(Analytic):
     arg: Column[dt.Any]
     buckets: Scalar[dt.Integer]
 
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
@@ -168,7 +168,7 @@ class FirstValue(Analytic):
 
     arg: Column[dt.Any]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
@@ -177,7 +177,7 @@ class LastValue(Analytic):
 
     arg: Column[dt.Any]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
@@ -187,7 +187,7 @@ class NthValue(Analytic):
     arg: Column[dt.Any]
     nth: Value[dt.Integer]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 public(AnalyticOp=Analytic, CumulativeOp=Cumulative)

--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -17,10 +17,10 @@ from ibis.expr.operations.core import Argument, Unary, Value
 class ArrayColumn(Value):
     cols: VarTuple[Value]
 
-    output_shape = ds.columnar
+    shape = ds.columnar
 
     @attribute.default
-    def output_dtype(self):
+    def dtype(self):
         return dt.Array(rlz.highest_precedence_dtype(self.cols))
 
 
@@ -28,8 +28,8 @@ class ArrayColumn(Value):
 class ArrayLength(Unary):
     arg: Value[dt.Array]
 
-    output_dtype = dt.int64
-    output_shape = rlz.shape_like("args")
+    dtype = dt.int64
+    shape = rlz.shape_like("args")
 
 
 @public
@@ -38,8 +38,8 @@ class ArraySlice(Value):
     start: Value[dt.Integer]
     stop: Optional[Value[dt.Integer]] = None
 
-    output_dtype = rlz.dtype_like("arg")
-    output_shape = rlz.shape_like("arg")
+    dtype = rlz.dtype_like("arg")
+    shape = rlz.shape_like("arg")
 
 
 @public
@@ -47,11 +47,11 @@ class ArrayIndex(Value):
     arg: Value[dt.Array]
     index: Value[dt.Integer]
 
-    output_shape = rlz.shape_like("args")
+    shape = rlz.shape_like("args")
 
     @attribute.default
-    def output_dtype(self):
-        return self.arg.output_dtype.value_type
+    def dtype(self):
+        return self.arg.dtype.value_type
 
 
 @public
@@ -59,15 +59,15 @@ class ArrayConcat(Value):
     left: Value[dt.Array]
     right: Value[dt.Array]
 
-    output_dtype = rlz.dtype_like("left")
-    output_shape = rlz.shape_like("args")
+    dtype = rlz.dtype_like("left")
+    shape = rlz.shape_like("args")
 
     def __init__(self, left, right):
-        if left.output_dtype != right.output_dtype:
+        if left.dtype != right.dtype:
             raise com.IbisTypeError(
                 'Array types must match exactly in a {} operation. '
                 'Left type {} != Right type {}'.format(
-                    type(self).__name__, left.output_dtype, right.output_dtype
+                    type(self).__name__, left.dtype, right.dtype
                 )
             )
         super().__init__(left=left, right=right)
@@ -78,8 +78,8 @@ class ArrayRepeat(Value):
     arg: Value[dt.Array]
     times: Value[dt.Integer]
 
-    output_dtype = rlz.dtype_like("arg")
-    output_shape = rlz.shape_like("args")
+    dtype = rlz.dtype_like("arg")
+    shape = rlz.shape_like("args")
 
 
 class ArrayApply(Value):
@@ -94,14 +94,14 @@ class ArrayApply(Value):
     def result(self):
         arg = Argument(
             name=self.parameter,
-            shape=self.arg.output_shape,
-            dtype=self.arg.output_dtype.value_type,
+            shape=self.arg.shape,
+            dtype=self.arg.dtype.value_type,
         )
         return self.func(arg)
 
     @attribute.default
-    def output_shape(self):
-        return self.arg.output_shape
+    def shape(self):
+        return self.arg.shape
 
 
 @public
@@ -109,26 +109,26 @@ class ArrayMap(ArrayApply):
     func: Callable[[Value], Value]
 
     @attribute.default
-    def output_dtype(self) -> dt.DataType:
-        return dt.Array(self.result.output_dtype)
+    def dtype(self) -> dt.DataType:
+        return dt.Array(self.result.dtype)
 
 
 @public
 class ArrayFilter(ArrayApply):
     func: Callable[[Value], Value[dt.Boolean]]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
 class Unnest(Value):
     arg: Value[dt.Array]
 
-    output_shape = ds.columnar
+    shape = ds.columnar
 
     @attribute.default
-    def output_dtype(self):
-        return self.arg.output_dtype.value_type
+    def dtype(self):
+        return self.arg.dtype.value_type
 
 
 @public
@@ -136,8 +136,8 @@ class ArrayContains(Value):
     arg: Value[dt.Array]
     other: Value
 
-    output_dtype = dt.boolean
-    output_shape = rlz.shape_like("args")
+    dtype = dt.boolean
+    shape = rlz.shape_like("args")
 
 
 @public
@@ -145,8 +145,8 @@ class ArrayPosition(Value):
     arg: Value[dt.Array]
     other: Value
 
-    output_dtype = dt.int64
-    output_shape = rlz.shape_like("args")
+    dtype = dt.int64
+    shape = rlz.shape_like("args")
 
 
 @public
@@ -154,24 +154,24 @@ class ArrayRemove(Value):
     arg: Value[dt.Array]
     other: Value
 
-    output_dtype = rlz.dtype_like("arg")
-    output_shape = rlz.shape_like("args")
+    dtype = rlz.dtype_like("arg")
+    shape = rlz.shape_like("args")
 
 
 @public
 class ArrayDistinct(Value):
     arg: Value[dt.Array]
 
-    output_dtype = rlz.dtype_like("arg")
-    output_shape = rlz.shape_like("arg")
+    dtype = rlz.dtype_like("arg")
+    shape = rlz.shape_like("arg")
 
 
 @public
 class ArraySort(Value):
     arg: Value[dt.Array]
 
-    output_dtype = rlz.dtype_like("arg")
-    output_shape = rlz.shape_like("arg")
+    dtype = rlz.dtype_like("arg")
+    shape = rlz.shape_like("arg")
 
 
 @public
@@ -179,22 +179,22 @@ class ArrayUnion(Value):
     left: Value[dt.Array]
     right: Value[dt.Array]
 
-    output_dtype = rlz.dtype_like("args")
-    output_shape = rlz.shape_like("args")
+    dtype = rlz.dtype_like("args")
+    shape = rlz.shape_like("args")
 
 
 @public
 class ArrayZip(Value):
     arg: VarTuple[Value[dt.Array]]
 
-    output_shape = rlz.shape_like("arg")
+    shape = rlz.shape_like("arg")
 
     @attribute.default
-    def output_dtype(self):
+    def dtype(self):
         return dt.Array(
             dt.Struct(
                 {
-                    f"f{i:d}": array.output_dtype.value_type
+                    f"f{i:d}": array.dtype.value_type
                     for i, array in enumerate(self.arg, start=1)
                 }
             )

--- a/ibis/expr/operations/geospatial.py
+++ b/ibis/expr/operations/geospatial.py
@@ -26,56 +26,56 @@ class GeoSpatialUnOp(Unary):
 class GeoDistance(GeoSpatialBinOp):
     """Returns minimum distance between two geospatial operands."""
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class GeoContains(GeoSpatialBinOp):
     """Check if the first geo spatial data contains the second one."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoContainsProperly(GeoSpatialBinOp):
     """Check if the left value contains the right one, with no shared no boundary points."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoCovers(GeoSpatialBinOp):
     """Check if no point in the right operand is outside that of the left."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoCoveredBy(GeoSpatialBinOp):
     """Check if no point in the left operand is outside that of the right."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoCrosses(GeoSpatialBinOp):
     """Check if the inputs have some but not all interior points in common."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoDisjoint(GeoSpatialBinOp):
     """Check if the Geometries do not spatially intersect."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoEquals(GeoSpatialBinOp):
     """Returns True if the given geometries represent the same geometry."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
@@ -83,14 +83,14 @@ class GeoGeometryN(GeoSpatialUnOp):
     """Returns the Nth Geometry of a Multi geometry."""
 
     n: Value[dt.Integer]
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
 class GeoGeometryType(GeoSpatialUnOp):
     """Returns the type of the geometry."""
 
-    output_dtype = dt.string
+    dtype = dt.string
 
 
 @public
@@ -100,14 +100,14 @@ class GeoIntersects(GeoSpatialBinOp):
     - (share any portion of space) and False if they don`t (they are Disjoint).
     """
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoIsValid(GeoSpatialUnOp):
     """Returns true if the geometry is well-formed."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
@@ -122,7 +122,7 @@ class GeoLineLocatePoint(GeoSpatialBinOp):
     left: Value[dt.LineString]
     right: Value[dt.Point]
 
-    output_dtype = dt.halffloat
+    dtype = dt.halffloat
 
 
 @public
@@ -135,7 +135,7 @@ class GeoLineMerge(GeoSpatialUnOp):
     geometry collection.
     """
 
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
@@ -152,7 +152,7 @@ class GeoLineSubstring(GeoSpatialUnOp):
     start: Value[dt.Floating]
     end: Value[dt.Floating]
 
-    output_dtype = dt.linestring
+    dtype = dt.linestring
 
 
 @public
@@ -163,56 +163,56 @@ class GeoOrderingEquals(GeoSpatialBinOp):
     in the same order.
     """
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoOverlaps(GeoSpatialBinOp):
     """Check if the inputs are of the same dimension but are not completely contained by each other."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoTouches(GeoSpatialBinOp):
     """Check if the inputs have at least one point in common but their interiors do not intersect."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoUnaryUnion(Reduction, GeoSpatialUnOp):
     """Returns the pointwise union of the geometries in the column."""
 
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
 class GeoUnion(GeoSpatialBinOp):
     """Returns the pointwise union of the two geometries."""
 
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
 class GeoArea(GeoSpatialUnOp):
     """Area of the geo spatial data."""
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class GeoPerimeter(GeoSpatialUnOp):
     """Perimeter of the geo spatial data."""
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class GeoLength(GeoSpatialUnOp):
     """Length of geo spatial data."""
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
@@ -224,7 +224,7 @@ class GeoMaxDistance(GeoSpatialBinOp):
     geometry
     """
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
@@ -234,7 +234,7 @@ class GeoX(GeoSpatialUnOp):
     Input must be a point
     """
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
@@ -244,35 +244,35 @@ class GeoY(GeoSpatialUnOp):
     Input must be a point
     """
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class GeoXMin(GeoSpatialUnOp):
     """Returns Y minima of a bounding box 2d or 3d or a geometry."""
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class GeoXMax(GeoSpatialUnOp):
     """Returns X maxima of a bounding box 2d or 3d or a geometry."""
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class GeoYMin(GeoSpatialUnOp):
     """Returns Y minima of a bounding box 2d or 3d or a geometry."""
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class GeoYMax(GeoSpatialUnOp):
     """Returns Y maxima of a bounding box 2d or 3d or a geometry."""
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
@@ -282,7 +282,7 @@ class GeoStartPoint(GeoSpatialUnOp):
     Returns `NULL` if the input is not a LINESTRING.
     """
 
-    output_dtype = dt.point
+    dtype = dt.point
 
 
 @public
@@ -292,7 +292,7 @@ class GeoEndPoint(GeoSpatialUnOp):
     Returns `NULL` if the input is not a LINESTRING.
     """
 
-    output_dtype = dt.point
+    dtype = dt.point
 
 
 @public
@@ -305,7 +305,7 @@ class GeoPoint(GeoSpatialBinOp):
     left: Value[dt.Numeric]
     right: Value[dt.Numeric]
 
-    output_dtype = dt.point
+    dtype = dt.point
 
 
 @public
@@ -318,14 +318,14 @@ class GeoPointN(GeoSpatialUnOp):
     """
 
     n: Value[dt.Integer]
-    output_dtype = dt.point
+    dtype = dt.point
 
 
 @public
 class GeoNPoints(GeoSpatialUnOp):
     """Return the number of points in a geometry."""
 
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
@@ -335,14 +335,14 @@ class GeoNRings(GeoSpatialUnOp):
     Outer rings are counted.
     """
 
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
 class GeoSRID(GeoSpatialUnOp):
     """Returns the spatial reference identifier for the ST_Geometry."""
 
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
@@ -351,7 +351,7 @@ class GeoSetSRID(GeoSpatialUnOp):
 
     srid: Value[dt.Integer]
 
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
@@ -362,14 +362,14 @@ class GeoBuffer(GeoSpatialUnOp):
     """
 
     radius: Value[dt.Floating]
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
 class GeoCentroid(GeoSpatialUnOp):
     """Returns the geometric center of a geometry."""
 
-    output_dtype = dt.point
+    dtype = dt.point
 
 
 @public
@@ -378,7 +378,7 @@ class GeoDFullyWithin(GeoSpatialBinOp):
 
     distance: Value[dt.Floating]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
@@ -387,14 +387,14 @@ class GeoDWithin(GeoSpatialBinOp):
 
     distance: Value[dt.Floating]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoEnvelope(GeoSpatialUnOp):
     """The bounding box of the supplied geometry."""
 
-    output_dtype = dt.polygon
+    dtype = dt.polygon
 
 
 @public
@@ -408,28 +408,28 @@ class GeoAzimuth(GeoSpatialBinOp):
     left: Value[dt.Point]
     right: Value[dt.Point]
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class GeoWithin(GeoSpatialBinOp):
     """Returns True if the geometry A is completely inside geometry B."""
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class GeoIntersection(GeoSpatialBinOp):
     """Return a geometry that represents the point-set intersection of the inputs."""
 
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
 class GeoDifference(GeoSpatialBinOp):
     """Return a geometry that is the delta between the left and right inputs."""
 
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
@@ -439,7 +439,7 @@ class GeoSimplify(GeoSpatialUnOp):
     tolerance: Value[dt.Floating]
     preserve_collapsed: Value[dt.Boolean]
 
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
@@ -448,32 +448,32 @@ class GeoTransform(GeoSpatialUnOp):
 
     srid: Value[dt.Integer]
 
-    output_dtype = dt.geometry
+    dtype = dt.geometry
 
 
 @public
 class GeoAsBinary(GeoSpatialUnOp):
     """Return the Well-Known Binary (WKB) representation of the input, without SRID meta data."""
 
-    output_dtype = dt.binary
+    dtype = dt.binary
 
 
 @public
 class GeoAsEWKB(GeoSpatialUnOp):
     """Return the Well-Known Binary representation of the input, with SRID meta data."""
 
-    output_dtype = dt.binary
+    dtype = dt.binary
 
 
 @public
 class GeoAsEWKT(GeoSpatialUnOp):
     """Return the Well-Known Text representation of the input, with SRID meta data."""
 
-    output_dtype = dt.string
+    dtype = dt.string
 
 
 @public
 class GeoAsText(GeoSpatialUnOp):
     """Return the Well-Known Text (WKT) representation of the input, without SRID metadata."""
 
-    output_dtype = dt.string
+    dtype = dt.string

--- a/ibis/expr/operations/histograms.py
+++ b/ibis/expr/operations/histograms.py
@@ -22,10 +22,10 @@ class Bucket(Value):
     include_under: bool = False
     include_over: bool = False
 
-    output_shape = ds.columnar
+    shape = ds.columnar
 
     @attribute.default
-    def output_dtype(self):
+    def dtype(self):
         return dt.infer(self.nbuckets)
 
     def __init__(self, buckets, include_under, include_over, **kwargs):

--- a/ibis/expr/operations/json.py
+++ b/ibis/expr/operations/json.py
@@ -12,21 +12,21 @@ class JSONGetItem(Value):
     arg: Value[dt.JSON]
     index: Value[dt.String | dt.Integer]
 
-    output_dtype = dt.json
-    output_shape = rlz.shape_like("args")
+    dtype = dt.json
+    shape = rlz.shape_like("args")
 
 
 @public
 class ToJSONArray(Value):
     arg: Value[dt.JSON]
 
-    output_dtype = dt.Array(dt.json)
-    output_shape = rlz.shape_like("arg")
+    dtype = dt.Array(dt.json)
+    shape = rlz.shape_like("arg")
 
 
 @public
 class ToJSONMap(Value):
     arg: Value[dt.JSON]
 
-    output_dtype = dt.Map(dt.string, dt.json)
-    output_shape = rlz.shape_like("arg")
+    dtype = dt.Map(dt.string, dt.json)
+    shape = rlz.shape_like("arg")

--- a/ibis/expr/operations/logical.py
+++ b/ibis/expr/operations/logical.py
@@ -22,14 +22,14 @@ class LogicalBinary(Binary):
     left: Value[dt.Boolean]
     right: Value[dt.Boolean]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class Not(Unary):
     arg: Value[dt.Boolean]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
@@ -52,7 +52,7 @@ class Comparison(Binary):
     left: Value
     right: Value
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
     def __init__(self, left, right):
         """Construct a comparison operation between `left` and `right`.
@@ -112,8 +112,8 @@ class Between(Value):
     lower_bound: Value
     upper_bound: Value
 
-    output_dtype = dt.boolean
-    output_shape = rlz.shape_like("args")
+    dtype = dt.boolean
+    shape = rlz.shape_like("args")
 
     def __init__(self, arg, lower_bound, upper_bound):
         if not rlz.comparable(arg, lower_bound):
@@ -139,10 +139,10 @@ class Contains(Value):
         Value[dt.Array],
     ]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
     @attribute.default
-    def output_shape(self):
+    def shape(self):
         if isinstance(self.options, tuple):
             args = [self.value, *self.options]
         else:
@@ -168,10 +168,10 @@ class Where(Value):
     true_expr: Value
     false_null_expr: Value
 
-    output_shape = rlz.shape_like("args")
+    shape = rlz.shape_like("args")
 
     @attribute.default
-    def output_dtype(self):
+    def dtype(self):
         return rlz.highest_precedence_dtype([self.true_expr, self.false_null_expr])
 
 
@@ -180,8 +180,8 @@ class ExistsSubquery(Value, _Negatable):
     foreign_table: Relation
     predicates: VarTuple[Value[dt.Boolean]]
 
-    output_dtype = dt.boolean
-    output_shape = ds.columnar
+    dtype = dt.boolean
+    shape = ds.columnar
 
     def negate(self) -> NotExistsSubquery:
         return NotExistsSubquery(*self.args)
@@ -192,8 +192,8 @@ class NotExistsSubquery(Value, _Negatable):
     foreign_table: Relation
     predicates: VarTuple[Value[dt.Boolean]]
 
-    output_dtype = dt.boolean
-    output_shape = ds.columnar
+    dtype = dt.boolean
+    shape = ds.columnar
 
     def negate(self) -> ExistsSubquery:
         return ExistsSubquery(*self.args)
@@ -240,8 +240,8 @@ class _UnresolvedSubquery(Value, _Negatable):
     tables: VarTuple[Relation]
     predicates: VarTuple[Value[dt.Boolean]]
 
-    output_dtype = dt.boolean
-    output_shape = ds.columnar
+    dtype = dt.boolean
+    shape = ds.columnar
 
     @abc.abstractmethod
     def _resolve(

--- a/ibis/expr/operations/maps.py
+++ b/ibis/expr/operations/maps.py
@@ -13,20 +13,20 @@ class Map(Value):
     keys: Value[dt.Array]
     values: Value[dt.Array]
 
-    output_shape = rlz.shape_like("args")
+    shape = rlz.shape_like("args")
 
     @attribute.default
-    def output_dtype(self):
+    def dtype(self):
         return dt.Map(
-            self.keys.output_dtype.value_type,
-            self.values.output_dtype.value_type,
+            self.keys.dtype.value_type,
+            self.values.dtype.value_type,
         )
 
 
 @public
 class MapLength(Unary):
     arg: Value[dt.Map]
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
@@ -35,13 +35,11 @@ class MapGet(Value):
     key: Value[dt.String | dt.Integer]
     default: Value = None
 
-    output_shape = rlz.shape_like("args")
+    shape = rlz.shape_like("args")
 
     @attribute.default
-    def output_dtype(self):
-        return dt.higher_precedence(
-            self.default.output_dtype, self.arg.output_dtype.value_type
-        )
+    def dtype(self):
+        return dt.higher_precedence(self.default.dtype, self.arg.dtype.value_type)
 
 
 @public
@@ -49,8 +47,8 @@ class MapContains(Value):
     arg: Value[dt.Map]
     key: Value[dt.String | dt.Integer]
 
-    output_shape = rlz.shape_like("args")
-    output_dtype = dt.bool
+    shape = rlz.shape_like("args")
+    dtype = dt.bool
 
 
 @public
@@ -58,8 +56,8 @@ class MapKeys(Unary):
     arg: Value[dt.Map]
 
     @attribute.default
-    def output_dtype(self):
-        return dt.Array(self.arg.output_dtype.key_type)
+    def dtype(self):
+        return dt.Array(self.arg.dtype.key_type)
 
 
 @public
@@ -67,8 +65,8 @@ class MapValues(Unary):
     arg: Value[dt.Map]
 
     @attribute.default
-    def output_dtype(self):
-        return dt.Array(self.arg.output_dtype.value_type)
+    def dtype(self):
+        return dt.Array(self.arg.dtype.value_type)
 
 
 @public
@@ -76,8 +74,8 @@ class MapMerge(Value):
     left: Value[dt.Map]
     right: Value[dt.Map]
 
-    output_shape = rlz.shape_like("args")
-    output_dtype = rlz.dtype_like("args")
+    shape = rlz.shape_like("args")
+    dtype = rlz.dtype_like("args")
 
 
 public(MapValueForKey=MapGet, MapValueOrDefaultForKey=MapGet, MapConcat=MapMerge)

--- a/ibis/expr/operations/numeric.py
+++ b/ibis/expr/operations/numeric.py
@@ -24,19 +24,19 @@ class NumericBinary(Binary):
 
 @public
 class Add(NumericBinary):
-    output_dtype = rlz.numeric_like("args", operator.add)
+    dtype = rlz.numeric_like("args", operator.add)
 
 
 @public
 class Multiply(NumericBinary):
-    output_dtype = rlz.numeric_like("args", operator.mul)
+    dtype = rlz.numeric_like("args", operator.mul)
 
 
 @public
 class Power(NumericBinary):
     @property
-    def output_dtype(self):
-        dtypes = (arg.output_dtype for arg in self.args)
+    def dtype(self):
+        dtypes = (arg.dtype for arg in self.args)
         if util.all_of(dtypes, dt.Integer):
             return dt.float64
         else:
@@ -45,29 +45,29 @@ class Power(NumericBinary):
 
 @public
 class Subtract(NumericBinary):
-    output_dtype = rlz.numeric_like("args", operator.sub)
+    dtype = rlz.numeric_like("args", operator.sub)
 
 
 @public
 class Divide(NumericBinary):
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class FloorDivide(Divide):
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
 class Modulus(NumericBinary):
-    output_dtype = rlz.numeric_like("args", operator.mod)
+    dtype = rlz.numeric_like("args", operator.mod)
 
 
 @public
 class Negate(Unary):
     arg: Value[dt.Numeric | dt.Interval]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
@@ -91,21 +91,21 @@ class NullIfZero(Unary):
 
     arg: SoftNumeric
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
 class IsNan(Unary):
     arg: Value[dt.Floating]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
 class IsInf(Unary):
     arg: Value[dt.Floating]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
 
 @public
@@ -114,7 +114,7 @@ class Abs(Unary):
 
     arg: SoftNumeric
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
@@ -131,9 +131,9 @@ class Ceil(Unary):
     arg: SoftNumeric
 
     @property
-    def output_dtype(self):
-        if self.arg.output_dtype.is_decimal():
-            return self.arg.output_dtype
+    def dtype(self):
+        if self.arg.dtype.is_decimal():
+            return self.arg.dtype
         else:
             return dt.int64
 
@@ -152,9 +152,9 @@ class Floor(Unary):
     arg: SoftNumeric
 
     @property
-    def output_dtype(self):
-        if self.arg.output_dtype.is_decimal():
-            return self.arg.output_dtype
+    def dtype(self):
+        if self.arg.dtype.is_decimal():
+            return self.arg.dtype
         else:
             return dt.int64
 
@@ -165,12 +165,12 @@ class Round(Value):
     # TODO(kszucs): the default should be 0 instead of being None
     digits: Optional[Integer] = None
 
-    output_shape = rlz.shape_like("arg")
+    shape = rlz.shape_like("arg")
 
     @property
-    def output_dtype(self):
-        if self.arg.output_dtype.is_decimal():
-            return self.arg.output_dtype
+    def dtype(self):
+        if self.arg.dtype.is_decimal():
+            return self.arg.dtype
         elif self.digits is None:
             return dt.int64
         else:
@@ -183,8 +183,8 @@ class Clip(Value):
     lower: Optional[StrictNumeric] = None
     upper: Optional[StrictNumeric] = None
 
-    output_dtype = rlz.dtype_like("arg")
-    output_shape = rlz.shape_like("arg")
+    dtype = rlz.dtype_like("arg")
+    shape = rlz.shape_like("arg")
 
 
 @public
@@ -194,8 +194,8 @@ class BaseConvert(Value):
     from_base: Integer
     to_base: Integer
 
-    output_dtype = dt.string
-    output_shape = rlz.shape_like("args")
+    dtype = dt.string
+    shape = rlz.shape_like("args")
 
 
 @public
@@ -203,15 +203,15 @@ class MathUnary(Unary):
     arg: SoftNumeric
 
     @attribute.default
-    def output_dtype(self):
-        return dt.higher_precedence(self.arg.output_dtype, dt.double)
+    def dtype(self):
+        return dt.higher_precedence(self.arg.dtype, dt.double)
 
 
 @public
 class ExpandingMathUnary(MathUnary):
     @attribute.default
-    def output_dtype(self):
-        return dt.higher_precedence(self.arg.output_dtype.largest, dt.double)
+    def dtype(self):
+        return dt.higher_precedence(self.arg.dtype.largest, dt.double)
 
 
 @public
@@ -223,7 +223,7 @@ class Exp(ExpandingMathUnary):
 class Sign(Unary):
     arg: SoftNumeric
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
@@ -281,7 +281,7 @@ class TrigonometricBinary(Binary):
     left: SoftNumeric
     right: SoftNumeric
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
@@ -328,7 +328,7 @@ class Tan(TrigonometricUnary):
 class BitwiseNot(Unary):
     arg: Integer
 
-    output_dtype = rlz.numeric_like("args", operator.invert)
+    dtype = rlz.numeric_like("args", operator.invert)
 
 
 @public
@@ -339,26 +339,26 @@ class BitwiseBinary(Binary):
 
 @public
 class BitwiseAnd(BitwiseBinary):
-    output_dtype = rlz.numeric_like("args", operator.and_)
+    dtype = rlz.numeric_like("args", operator.and_)
 
 
 @public
 class BitwiseOr(BitwiseBinary):
-    output_dtype = rlz.numeric_like("args", operator.or_)
+    dtype = rlz.numeric_like("args", operator.or_)
 
 
 @public
 class BitwiseXor(BitwiseBinary):
-    output_dtype = rlz.numeric_like("args", operator.xor)
+    dtype = rlz.numeric_like("args", operator.xor)
 
 
 @public
 class BitwiseLeftShift(BitwiseBinary):
-    output_shape = rlz.shape_like("args")
-    output_dtype = dt.int64
+    shape = rlz.shape_like("args")
+    dtype = dt.int64
 
 
 @public
 class BitwiseRightShift(BitwiseBinary):
-    output_shape = rlz.shape_like("args")
-    output_dtype = dt.int64
+    shape = rlz.shape_like("args")
+    dtype = dt.int64

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -16,7 +16,7 @@ from ibis.expr.operations.relations import Relation  # noqa: TCH001
 
 @public
 class Reduction(Value):
-    output_shape = ds.scalar
+    shape = ds.scalar
 
     @property
     def __window_op__(self):
@@ -31,14 +31,14 @@ class Filterable(Value):
 class Count(Filterable, Reduction):
     arg: Column[dt.Any]
 
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
 class CountStar(Filterable, Reduction):
     arg: Relation
 
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
@@ -46,7 +46,7 @@ class Arbitrary(Filterable, Reduction):
     arg: Column[dt.Any]
     how: Literal["first", "last", "heavy"]
 
-    output_dtype = rlz.dtype_like('arg')
+    dtype = rlz.dtype_like('arg')
 
 
 @public
@@ -55,7 +55,7 @@ class First(Filterable, Reduction):
 
     arg: Column[dt.Any]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
     @property
     def __window_op__(self):
@@ -74,7 +74,7 @@ class Last(Filterable, Reduction):
 
     arg: Column[dt.Any]
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
     @property
     def __window_op__(self):
@@ -103,7 +103,7 @@ class BitAnd(Filterable, Reduction):
 
     arg: Column[dt.Integer]
 
-    output_dtype = rlz.dtype_like('arg')
+    dtype = rlz.dtype_like('arg')
 
 
 @public
@@ -121,7 +121,7 @@ class BitOr(Filterable, Reduction):
 
     arg: Column[dt.Integer]
 
-    output_dtype = rlz.dtype_like('arg')
+    dtype = rlz.dtype_like('arg')
 
 
 @public
@@ -139,7 +139,7 @@ class BitXor(Filterable, Reduction):
 
     arg: Column[dt.Integer]
 
-    output_dtype = rlz.dtype_like('arg')
+    dtype = rlz.dtype_like('arg')
 
 
 @public
@@ -147,11 +147,11 @@ class Sum(Filterable, Reduction):
     arg: Column[dt.Numeric | dt.Boolean]
 
     @attribute.default
-    def output_dtype(self):
-        if self.arg.output_dtype.is_boolean():
+    def dtype(self):
+        if self.arg.dtype.is_boolean():
             return dt.int64
         else:
-            return self.arg.output_dtype.largest
+            return self.arg.dtype.largest
 
 
 @public
@@ -159,8 +159,8 @@ class Mean(Filterable, Reduction):
     arg: Column[dt.Numeric | dt.Boolean]
 
     @attribute.default
-    def output_dtype(self):
-        if (dtype := self.arg.output_dtype).is_boolean():
+    def dtype(self):
+        if (dtype := self.arg.dtype).is_boolean():
             return dt.float64
         else:
             return dt.higher_precedence(dtype, dt.float64)
@@ -171,8 +171,8 @@ class Median(Filterable, Reduction):
     arg: Column[dt.Numeric | dt.Boolean]
 
     @attribute.default
-    def output_dtype(self):
-        return dt.higher_precedence(self.arg.output_dtype, dt.float64)
+    def dtype(self):
+        return dt.higher_precedence(self.arg.dtype, dt.float64)
 
 
 @public
@@ -183,7 +183,7 @@ class Quantile(Filterable, Reduction):
         Literal['linear', 'lower', 'higher', 'midpoint', 'nearest']
     ] = None
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
@@ -194,7 +194,7 @@ class MultiQuantile(Filterable, Reduction):
         Literal['linear', 'lower', 'higher', 'midpoint', 'nearest']
     ] = None
 
-    output_dtype = dt.Array(dt.float64)
+    dtype = dt.Array(dt.float64)
 
 
 @public
@@ -203,8 +203,8 @@ class VarianceBase(Filterable, Reduction):
     how: Literal["sample", "pop"]
 
     @attribute.default
-    def output_dtype(self):
-        if (dtype := self.arg.output_dtype).is_decimal():
+    def dtype(self):
+        if (dtype := self.arg.dtype).is_decimal():
             return dtype.largest
         else:
             return dt.float64
@@ -228,7 +228,7 @@ class Correlation(Filterable, Reduction):
     right: Column[dt.Numeric | dt.Boolean]
     how: Literal['sample', 'pop'] = 'sample'
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
@@ -239,28 +239,28 @@ class Covariance(Filterable, Reduction):
     right: Column[dt.Numeric | dt.Boolean]
     how: Literal['sample', 'pop']
 
-    output_dtype = dt.float64
+    dtype = dt.float64
 
 
 @public
 class Mode(Filterable, Reduction):
     arg: Column
 
-    output_dtype = rlz.dtype_like('arg')
+    dtype = rlz.dtype_like('arg')
 
 
 @public
 class Max(Filterable, Reduction):
     arg: Column
 
-    output_dtype = rlz.dtype_like('arg')
+    dtype = rlz.dtype_like('arg')
 
 
 @public
 class Min(Filterable, Reduction):
     arg: Column
 
-    output_dtype = rlz.dtype_like('arg')
+    dtype = rlz.dtype_like('arg')
 
 
 @public
@@ -268,7 +268,7 @@ class ArgMax(Filterable, Reduction):
     arg: Column
     key: Column
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
@@ -276,7 +276,7 @@ class ArgMin(Filterable, Reduction):
     arg: Column
     key: Column
 
-    output_dtype = rlz.dtype_like("arg")
+    dtype = rlz.dtype_like("arg")
 
 
 @public
@@ -289,7 +289,7 @@ class ApproxCountDistinct(Filterable, Reduction):
     arg: Column
 
     # Impala 2.0 and higher returns a DOUBLE
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
@@ -298,7 +298,7 @@ class ApproxMedian(Filterable, Reduction):
 
     arg: Column
 
-    output_dtype = rlz.dtype_like('arg')
+    dtype = rlz.dtype_like('arg')
 
 
 @public
@@ -306,14 +306,14 @@ class GroupConcat(Filterable, Reduction):
     arg: Column
     sep: Value[dt.String]
 
-    output_dtype = dt.string
+    dtype = dt.string
 
 
 @public
 class CountDistinct(Filterable, Reduction):
     arg: Column
 
-    output_dtype = dt.int64
+    dtype = dt.int64
 
 
 @public
@@ -321,15 +321,15 @@ class ArrayCollect(Filterable, Reduction):
     arg: Column
 
     @attribute.default
-    def output_dtype(self):
-        return dt.Array(self.arg.output_dtype)
+    def dtype(self):
+        return dt.Array(self.arg.dtype)
 
 
 @public
 class All(Filterable, Reduction, _Negatable):
     arg: Column[dt.Boolean]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
     def negate(self):
         return NotAll(self.arg)
@@ -339,7 +339,7 @@ class All(Filterable, Reduction, _Negatable):
 class NotAll(Filterable, Reduction, _Negatable):
     arg: Column[dt.Boolean]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
     def negate(self) -> Any:
         return All(*self.args)
@@ -349,7 +349,7 @@ class NotAll(Filterable, Reduction, _Negatable):
 class Any(Filterable, Reduction, _Negatable):
     arg: Column[dt.Boolean]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
     def negate(self) -> NotAny:
         return NotAny(*self.args)
@@ -359,7 +359,7 @@ class Any(Filterable, Reduction, _Negatable):
 class NotAny(Filterable, Reduction, _Negatable):
     arg: Column[dt.Boolean]
 
-    output_dtype = dt.boolean
+    dtype = dt.boolean
 
     def negate(self) -> Any:
         return Any(*self.args)

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -405,7 +405,7 @@ class Projection(Relation):
         for projection in self.selections:
             if isinstance(projection, Value):
                 names.append(projection.name)
-                types.append(projection.output_dtype)
+                types.append(projection.dtype)
             elif isinstance(projection, TableNode):
                 schema = projection.schema
                 names.extend(schema.names)
@@ -438,7 +438,7 @@ class Selection(Projection):
 
         for predicate in predicates:
             if isinstance(predicate, ops.Literal):
-                if not (dtype := predicate.output_dtype).is_boolean():
+                if not (dtype := predicate.dtype).is_boolean():
                     raise com.IbisTypeError(f"Invalid predicate dtype: {dtype}")
             elif not shares_some_roots(predicate, table):
                 raise com.RelationError("Predicate doesn't share any roots with table")
@@ -483,7 +483,7 @@ class DummyTable(Relation):
 
     @property
     def schema(self):
-        return Schema({op.name: op.output_dtype for op in self.values})
+        return Schema({op.name: op.dtype for op in self.values})
 
 
 @public
@@ -526,7 +526,7 @@ class Aggregation(Relation):
         names, types = [], []
         for value in self.by + self.metrics:
             names.append(value.name)
-            types.append(value.output_dtype)
+            types.append(value.dtype)
         return Schema.from_tuples(zip(names, types))
 
     def order_by(self, sort_exprs):

--- a/ibis/expr/operations/sortkeys.py
+++ b/ibis/expr/operations/sortkeys.py
@@ -31,8 +31,8 @@ class SortKey(Value):
     expr: Value
     ascending: bool = True
 
-    output_dtype = rlz.dtype_like("expr")
-    output_shape = rlz.shape_like("expr")
+    dtype = rlz.dtype_like("expr")
+    shape = rlz.shape_like("expr")
 
     @classmethod
     def __coerce__(cls, value, T=None, S=None):

--- a/ibis/expr/operations/strings.py
+++ b/ibis/expr/operations/strings.py
@@ -16,7 +16,7 @@ from ibis.expr.operations.core import Unary, Value
 class StringUnary(Unary):
     arg: Value[dt.String]
 
-    output_dtype = dt.string
+    dtype = dt.string
 
 
 @public
@@ -60,8 +60,8 @@ class Substring(Value):
     start: Value[dt.Integer]
     length: Optional[Value[dt.Integer]] = None
 
-    output_dtype = dt.string
-    output_shape = rlz.shape_like('arg')
+    dtype = dt.string
+    shape = rlz.shape_like('arg')
 
 
 @public
@@ -69,8 +69,8 @@ class StrRight(Value):
     arg: Value[dt.String]
     nchars: Value[dt.Integer]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -78,8 +78,8 @@ class Repeat(Value):
     arg: Value[dt.String]
     times: Value[dt.Integer]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -89,8 +89,8 @@ class StringFind(Value):
     start: Optional[Value[dt.Integer]] = None
     end: Optional[Value[dt.Integer]] = None
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.int64
+    shape = rlz.shape_like("arg")
+    dtype = dt.int64
 
 
 @public
@@ -99,8 +99,8 @@ class Translate(Value):
     from_str: Value[dt.String]
     to_str: Value[dt.String]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -109,8 +109,8 @@ class LPad(Value):
     length: Value[dt.Integer]
     pad: Optional[Value[dt.String]] = None
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -119,8 +119,8 @@ class RPad(Value):
     length: Value[dt.Integer]
     pad: Optional[Value[dt.String]] = None
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -128,8 +128,8 @@ class FindInSet(Value):
     needle: Value[dt.String]
     values: VarTuple[Value[dt.String]]
 
-    output_shape = rlz.shape_like("needle")
-    output_dtype = dt.int64
+    shape = rlz.shape_like("needle")
+    dtype = dt.int64
 
 
 @public
@@ -137,10 +137,10 @@ class StringJoin(Value):
     sep: Value[dt.String]
     arg: VarTuple[Value[dt.String]]
 
-    output_dtype = dt.string
+    dtype = dt.string
 
     @attribute.default
-    def output_shape(self):
+    def shape(self):
         return rlz.highest_precedence_shape(self.arg)
 
 
@@ -149,8 +149,8 @@ class ArrayStringJoin(Value):
     sep: Value[dt.String]
     arg: Value[dt.Array[dt.String]]
 
-    output_dtype = dt.string
-    output_shape = rlz.shape_like("args")
+    dtype = dt.string
+    shape = rlz.shape_like("args")
 
 
 @public
@@ -158,8 +158,8 @@ class StartsWith(Value):
     arg: Value[dt.String]
     start: Value[dt.String, ds.Scalar]
 
-    output_dtype = dt.boolean
-    output_shape = rlz.shape_like("arg")
+    dtype = dt.boolean
+    shape = rlz.shape_like("arg")
 
 
 @public
@@ -167,8 +167,8 @@ class EndsWith(Value):
     arg: Value[dt.String]
     end: Value[dt.String, ds.Scalar]
 
-    output_dtype = dt.boolean
-    output_shape = rlz.shape_like("arg")
+    dtype = dt.boolean
+    shape = rlz.shape_like("arg")
 
 
 @public
@@ -176,8 +176,8 @@ class FuzzySearch(Value):
     arg: Value[dt.String]
     pattern: Value[dt.String]
 
-    output_dtype = dt.boolean
-    output_shape = rlz.shape_like('arg')
+    dtype = dt.boolean
+    shape = rlz.shape_like('arg')
 
 
 @public
@@ -203,8 +203,8 @@ class RegexExtract(Value):
     pattern: Value[dt.String]
     index: Value[dt.Integer]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -213,8 +213,8 @@ class RegexReplace(Value):
     pattern: Value[dt.String]
     replacement: Value[dt.String]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -223,8 +223,8 @@ class StringReplace(Value):
     pattern: Value[dt.String]
     replacement: Value[dt.String]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -232,24 +232,24 @@ class StringSplit(Value):
     arg: Value[dt.String]
     delimiter: Value[dt.String]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.Array(dt.string)
+    shape = rlz.shape_like("arg")
+    dtype = dt.Array(dt.string)
 
 
 @public
 class StringConcat(Value):
     arg: VarTuple[Value[dt.String]]
 
-    output_shape = rlz.shape_like('arg')
-    output_dtype = rlz.dtype_like('arg')
+    shape = rlz.shape_like('arg')
+    dtype = rlz.dtype_like('arg')
 
 
 @public
 class ExtractURLField(Value):
     arg: Value[dt.String]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -294,12 +294,12 @@ class ExtractFragment(ExtractURLField):
 
 @public
 class StringLength(StringUnary):
-    output_dtype = dt.int32
+    dtype = dt.int32
 
 
 @public
 class StringAscii(StringUnary):
-    output_dtype = dt.int32
+    dtype = dt.int32
 
 
 @public
@@ -307,5 +307,5 @@ class StringContains(Value):
     haystack: Value[dt.String]
     needle: Value[dt.String]
 
-    output_shape = rlz.shape_like("args")
-    output_dtype = dt.bool
+    shape = rlz.shape_like("args")
+    dtype = dt.bool

--- a/ibis/expr/operations/structs.py
+++ b/ibis/expr/operations/structs.py
@@ -15,11 +15,11 @@ class StructField(Value):
     arg: Value[dt.Struct]
     field: str
 
-    output_shape = rlz.shape_like("arg")
+    shape = rlz.shape_like("arg")
 
     @attribute.default
-    def output_dtype(self) -> dt.DataType:
-        struct_dtype = self.arg.output_dtype
+    def dtype(self) -> dt.DataType:
+        struct_dtype = self.arg.dtype
         value_dtype = struct_dtype[self.field]
         return value_dtype
 
@@ -33,9 +33,9 @@ class StructColumn(Value):
     names: VarTuple[str]
     values: VarTuple[Value]
 
-    output_shape = ds.columnar
+    shape = ds.columnar
 
     @attribute.default
-    def output_dtype(self) -> dt.DataType:
-        dtypes = (value.output_dtype for value in self.values)
+    def dtype(self) -> dt.DataType:
+        dtypes = (value.dtype for value in self.values)
         return dt.Struct.from_tuples(zip(self.names, dtypes))

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -29,8 +29,8 @@ class TimestampTruncate(Value):
     arg: Value[dt.Timestamp]
     unit: IntervalUnit
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.timestamp
+    shape = rlz.shape_like("arg")
+    dtype = dt.timestamp
 
 
 @public
@@ -38,8 +38,8 @@ class DateTruncate(Value):
     arg: Value[dt.Date]
     unit: DateUnit
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.date
+    shape = rlz.shape_like("arg")
+    dtype = dt.date
 
 
 @public
@@ -47,8 +47,8 @@ class TimeTruncate(Value):
     arg: Value[dt.Time]
     unit: TimeUnit
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.time
+    shape = rlz.shape_like("arg")
+    dtype = dt.time
 
 
 @public
@@ -56,8 +56,8 @@ class Strftime(Value):
     arg: Value[dt.Temporal]
     format_str: Value[dt.String]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.string
+    shape = rlz.shape_like("arg")
+    dtype = dt.string
 
 
 @public
@@ -65,13 +65,13 @@ class StringToTimestamp(Value):
     arg: Value[dt.String]
     format_str: Value[dt.String]
 
-    output_shape = rlz.shape_like("arg")
-    output_dtype = dt.Timestamp(timezone='UTC')
+    shape = rlz.shape_like("arg")
+    dtype = dt.Timestamp(timezone='UTC')
 
 
 @public
 class ExtractTemporalField(TemporalUnary):
-    output_dtype = dt.int32
+    dtype = dt.int32
 
 
 @public
@@ -148,24 +148,24 @@ class ExtractMillisecond(ExtractTimeField):
 class DayOfWeekIndex(Unary):
     arg: Value[dt.Date | dt.Timestamp]
 
-    output_dtype = dt.int16
+    dtype = dt.int16
 
 
 @public
 class DayOfWeekName(Unary):
     arg: Value[dt.Date | dt.Timestamp]
 
-    output_dtype = dt.string
+    dtype = dt.string
 
 
 @public
 class Time(Unary):
-    output_dtype = dt.time
+    dtype = dt.time
 
 
 @public
 class Date(Unary):
-    output_dtype = dt.date
+    dtype = dt.date
 
 
 @public
@@ -174,8 +174,8 @@ class DateFromYMD(Value):
     month: Value[dt.Integer]
     day: Value[dt.Integer]
 
-    output_dtype = dt.date
-    output_shape = rlz.shape_like("args")
+    dtype = dt.date
+    shape = rlz.shape_like("args")
 
 
 @public
@@ -184,8 +184,8 @@ class TimeFromHMS(Value):
     minutes: Value[dt.Integer]
     seconds: Value[dt.Integer]
 
-    output_dtype = dt.time
-    output_shape = rlz.shape_like("args")
+    dtype = dt.time
+    shape = rlz.shape_like("args")
 
 
 @public
@@ -197,8 +197,8 @@ class TimestampFromYMDHMS(Value):
     minutes: Value[dt.Integer]
     seconds: Value[dt.Integer]
 
-    output_dtype = dt.timestamp
-    output_shape = rlz.shape_like("args")
+    dtype = dt.timestamp
+    shape = rlz.shape_like("args")
 
 
 @public
@@ -206,8 +206,8 @@ class TimestampFromUNIX(Value):
     arg: Value
     unit: TimestampUnit
 
-    output_dtype = dt.timestamp
-    output_shape = rlz.shape_like('arg')
+    dtype = dt.timestamp
+    shape = rlz.shape_like('arg')
 
 
 TimeInterval = Annotated[dt.Interval, Attrs(unit=As(TimeUnit))]
@@ -219,7 +219,7 @@ class DateAdd(Binary):
     left: Value[dt.Date]
     right: Value[DateInterval]
 
-    output_dtype = rlz.dtype_like('left')
+    dtype = rlz.dtype_like('left')
 
 
 @public
@@ -227,7 +227,7 @@ class DateSub(Binary):
     left: Value[dt.Date]
     right: Value[DateInterval]
 
-    output_dtype = rlz.dtype_like('left')
+    dtype = rlz.dtype_like('left')
 
 
 @public
@@ -235,7 +235,7 @@ class DateDiff(Binary):
     left: Value[dt.Date]
     right: Value[dt.Date]
 
-    output_dtype = dt.Interval('D')
+    dtype = dt.Interval('D')
 
 
 @public
@@ -243,7 +243,7 @@ class TimeAdd(Binary):
     left: Value[dt.Time]
     right: Value[TimeInterval]
 
-    output_dtype = rlz.dtype_like('left')
+    dtype = rlz.dtype_like('left')
 
 
 @public
@@ -251,7 +251,7 @@ class TimeSub(Binary):
     left: Value[dt.Time]
     right: Value[TimeInterval]
 
-    output_dtype = rlz.dtype_like('left')
+    dtype = rlz.dtype_like('left')
 
 
 @public
@@ -259,7 +259,7 @@ class TimeDiff(Binary):
     left: Value[dt.Time]
     right: Value[dt.Time]
 
-    output_dtype = dt.Interval('s')
+    dtype = dt.Interval('s')
 
 
 @public
@@ -267,7 +267,7 @@ class TimestampAdd(Binary):
     left: Value[dt.Timestamp]
     right: Value[dt.Interval]
 
-    output_dtype = rlz.dtype_like('left')
+    dtype = rlz.dtype_like('left')
 
 
 @public
@@ -275,7 +275,7 @@ class TimestampSub(Binary):
     left: Value[dt.Timestamp]
     right: Value[dt.Interval]
 
-    output_dtype = rlz.dtype_like('left')
+    dtype = rlz.dtype_like('left')
 
 
 @public
@@ -283,21 +283,19 @@ class TimestampDiff(Binary):
     left: Value[dt.Timestamp]
     right: Value[dt.Timestamp]
 
-    output_dtype = dt.Interval('s')
+    dtype = dt.Interval('s')
 
 
 @public
 class IntervalBinary(Binary):
     @attribute.default
-    def output_dtype(self):
+    def dtype(self):
         interval_unit_args = [
-            arg.output_dtype.unit
-            for arg in (self.left, self.right)
-            if arg.output_dtype.is_interval()
+            arg.dtype.unit for arg in (self.left, self.right) if arg.dtype.is_interval()
         ]
         unit = rlz._promote_interval_resolution(interval_unit_args)
 
-        return self.left.output_dtype.copy(unit=unit)
+        return self.left.dtype.copy(unit=unit)
 
 
 @public
@@ -333,15 +331,15 @@ class IntervalFromInteger(Value):
     arg: Value[dt.Integer]
     unit: IntervalUnit
 
-    output_shape = rlz.shape_like("arg")
+    shape = rlz.shape_like("arg")
 
     @attribute.default
-    def output_dtype(self):
+    def dtype(self):
         return dt.Interval(self.unit)
 
     @property
     def resolution(self):
-        return self.output_dtype.resolution
+        return self.dtype.resolution
 
 
 @public

--- a/ibis/expr/operations/tests/test_generic.py
+++ b/ibis/expr/operations/tests/test_generic.py
@@ -44,7 +44,7 @@ def test_coerced_to_literal():
 
     one = ops.Literal(1, dt.int16)
     with pytest.raises(ValidationError):
-        p.validate(ops.Literal(1, dt.int16), {})
+        p.validate(one, {})
 
 
 def test_coerced_to_value():

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -33,7 +33,7 @@ class InputType(enum.Enum):
 
 @public
 class ScalarUDF(ops.Value):
-    output_shape = rlz.shape_like("args")
+    shape = rlz.shape_like("args")
 
 
 def _wrap(
@@ -132,7 +132,7 @@ class ScalarUDFBuilder:
             else:
                 fields[name] = Argument.default(validator=arg, default=default)
 
-        fields["output_dtype"] = dt.dtype(return_annotation)
+        fields["dtype"] = dt.dtype(return_annotation)
 
         fields["__input_type__"] = input_type
         # can't be just `fn` otherwise `fn` is assumed to be a method

--- a/ibis/expr/operations/vectorized.py
+++ b/ibis/expr/operations/vectorized.py
@@ -21,7 +21,7 @@ class VectorizedUDF(Value):
     return_type: dt.DataType
 
     @property
-    def output_dtype(self):
+    def dtype(self):
         return self.return_type
 
 
@@ -29,14 +29,14 @@ class VectorizedUDF(Value):
 class ElementWiseVectorizedUDF(VectorizedUDF):
     """Node for element wise UDF."""
 
-    output_shape = ds.columnar
+    shape = ds.columnar
 
 
 @public
 class ReductionVectorizedUDF(VectorizedUDF, Reduction):
     """Node for reduction UDF."""
 
-    output_shape = ds.scalar
+    shape = ds.scalar
 
 
 # TODO(kszucs): revisit
@@ -44,4 +44,4 @@ class ReductionVectorizedUDF(VectorizedUDF, Reduction):
 class AnalyticVectorizedUDF(VectorizedUDF, Analytic):
     """Node for analytics UDF."""
 
-    output_shape = ds.columnar
+    shape = ds.columnar

--- a/ibis/expr/operations/window.py
+++ b/ibis/expr/operations/window.py
@@ -34,12 +34,12 @@ class WindowBoundary(Value[T, S]):
         return not self.preceding
 
     @property
-    def output_shape(self) -> S:
-        return self.value.output_shape
+    def shape(self) -> S:
+        return self.value.shape
 
     @property
-    def output_dtype(self) -> T:
-        return self.value.output_dtype
+    def dtype(self) -> T:
+        return self.value.dtype
 
     @classmethod
     def __coerce__(cls, value, **kwargs):
@@ -66,16 +66,16 @@ class WindowFrame(Value):
     group_by: VarTuple[Column] = ()
     order_by: VarTuple[SortKey] = ()
 
-    output_shape = ds.columnar
+    shape = ds.columnar
 
     def __init__(self, start, end, **kwargs):
-        if start and end and start.output_dtype != end.output_dtype:
+        if start and end and start.dtype != end.dtype:
             raise com.IbisTypeError(
                 "Window frame start and end boundaries must have the same datatype"
             )
         super().__init__(start=start, end=end, **kwargs)
 
-    def output_dtype(self) -> dt.DataType:
+    def dtype(self) -> dt.DataType:
         return dt.Array(dt.Struct.from_tuples(self.table.schema.items()))
 
     @property
@@ -104,7 +104,7 @@ class RowsWindowFrame(WindowFrame):
                 raise com.IbisTypeError(
                     "`max_lookback` window must be ordered by a single column"
                 )
-            if not order_by[0].output_dtype.is_timestamp():
+            if not order_by[0].dtype.is_timestamp():
                 raise com.IbisTypeError(
                     "`max_lookback` window must be ordered by a timestamp column"
                 )
@@ -123,8 +123,8 @@ class WindowFunction(Value):
     func: Value
     frame: WindowFrame
 
-    output_dtype = rlz.dtype_like("func")
-    output_shape = ds.columnar
+    dtype = rlz.dtype_like("func")
+    shape = ds.columnar
 
     def __init__(self, func, frame):
         from ibis.expr.analysis import (

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -60,7 +60,7 @@ class Value(Expr):
     # TODO(kszucs): should rename to dtype
     def type(self) -> dt.DataType:
         """Return the [DataType] of this expression."""
-        return self.op().output_dtype
+        return self.op().dtype
 
     def hash(self) -> ir.IntegerValue:
         """Compute an integer hash value.
@@ -1619,7 +1619,7 @@ def literal(value: Any, type: dt.DataType | str | None = None) -> Scalar:
         node = value.op()
         if not isinstance(node, ops.Literal):
             raise TypeError(f"Ibis expression {value!r} is not a Literal")
-        if type is None or node.output_dtype.castable(dt.dtype(type)):
+        if type is None or node.dtype.castable(dt.dtype(type)):
             return value
         else:
             raise TypeError(

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -231,7 +231,7 @@ class TimeValue(_TimeComponentMixin, TemporalValue):
     def __sub__(self, other: ops.Value[dt.Interval | dt.Time, ds.Any]):
         """Subtract a time or an interval from a time expression."""
 
-        if other.output_dtype.is_time():
+        if other.dtype.is_time():
             op = ops.TimeDiff
         else:
             op = ops.TimeSub  # let the operation validate
@@ -255,7 +255,7 @@ class TimeValue(_TimeComponentMixin, TemporalValue):
     def __rsub__(self, other: ops.Value[dt.Interval | dt.Time, ds.Any]):
         """Subtract a time or an interval from a time expression."""
 
-        if other.output_dtype.is_time():
+        if other.dtype.is_time():
             op = ops.TimeDiff
         else:
             op = ops.TimeSub  # let the operation validate
@@ -316,7 +316,7 @@ class DateValue(TemporalValue, _DateComponentMixin):
     def __sub__(self, other: ops.Value[dt.Date | dt.Interval, ds.Any]):
         """Subtract a date or an interval from a date."""
 
-        if other.output_dtype.is_date():
+        if other.dtype.is_date():
             op = ops.DateDiff
         else:
             op = ops.DateSub  # let the operation validate
@@ -340,7 +340,7 @@ class DateValue(TemporalValue, _DateComponentMixin):
     def __rsub__(self, other: ops.Value[dt.Date | dt.Interval, ds.Any]):
         """Subtract a date or an interval from a date."""
 
-        if other.output_dtype.is_date():
+        if other.dtype.is_date():
             op = ops.DateDiff
         else:
             op = ops.DateSub  # let the operation validate
@@ -414,7 +414,7 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, TemporalValue):
     def __sub__(self, other: ops.Value[dt.Timestamp | dt.Interval, ds.Any]):
         """Subtract a timestamp or an interval from a timestamp."""
 
-        if other.output_dtype.is_timestamp():
+        if other.dtype.is_timestamp():
             op = ops.TimestampDiff
         else:
             op = ops.TimestampSub  # let the operation validate
@@ -438,7 +438,7 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, TemporalValue):
     def __rsub__(self, other: ops.Value[dt.Timestamp | dt.Interval, ds.Any]):
         """Subtract a timestamp or an interval from a timestamp."""
 
-        if other.output_dtype.is_timestamp():
+        if other.dtype.is_timestamp():
             op = ops.TimestampDiff
         else:
             op = ops.TimestampSub  # let the operation validate
@@ -465,7 +465,7 @@ class IntervalValue(Value):
         # TODO(kszucs): should use a separate operation for unit conversion
         # which we can rewrite/simplify to integer multiplication/division
         op = self.op()
-        current_unit = op.output_dtype.unit
+        current_unit = op.dtype.unit
         target_unit = IntervalUnit.from_string(target_unit)
 
         if current_unit == target_unit:

--- a/ibis/expr/visualize.py
+++ b/ibis/expr/visualize.py
@@ -15,7 +15,7 @@ from ibis.common.graph import Graph
 
 def get_type(node):
     with contextlib.suppress(AttributeError, NotImplementedError):
-        return escape(str(node.output_dtype))
+        return escape(str(node.dtype))
 
     try:
         schema = node.schema

--- a/ibis/tests/expr/test_operations.py
+++ b/ibis/tests/expr/test_operations.py
@@ -174,26 +174,26 @@ def test_value_annotations():
     class Op1(ops.Value):
         arg: ops.Value
 
-        output_dtype = dt.int64
-        output_shape = ds.scalar
+        dtype = dt.int64
+        shape = ds.scalar
 
     class Op2(ops.Value):
         arg: ops.Value[dt.Any, ds.Any]
 
-        output_dtype = dt.int64
-        output_shape = ds.scalar
+        dtype = dt.int64
+        shape = ds.scalar
 
     class Op3(ops.Value):
         arg: ops.Value[dt.Integer, ds.Any]
 
-        output_dtype = dt.int64
-        output_shape = ds.scalar
+        dtype = dt.int64
+        shape = ds.scalar
 
     class Op4(ops.Value):
         arg: ops.Value[dt.Integer, ds.Scalar]
 
-        output_dtype = dt.int64
-        output_shape = ds.scalar
+        dtype = dt.int64
+        shape = ds.scalar
 
     assert Op1(1).arg.dtype == dt.int8
     assert Op2(1).arg.dtype == dt.int8
@@ -241,8 +241,8 @@ def test_instance_of_operation():
 def test_array_input():
     class MyOp(ops.Value):
         value: ops.Value[dt.Array[dt.Float64], ds.Any]
-        output_dtype = rlz.dtype_like('value')
-        output_shape = rlz.shape_like('value')
+        dtype = rlz.dtype_like('value')
+        shape = rlz.shape_like('value')
 
     raw_value = [1.0, 2.0, 3.0]
     op = MyOp(raw_value)

--- a/ibis/tests/expr/test_timestamp.py
+++ b/ibis/tests/expr/test_timestamp.py
@@ -80,12 +80,12 @@ def test_comparisons_string(alltypes):
     val = '2015-01-01 00:00:00'
     expr = alltypes.i > val
     op = expr.op()
-    assert op.right.output_dtype is dt.string
+    assert op.right.dtype is dt.string
 
     expr2 = val < alltypes.i
     op = expr2.op()
     assert isinstance(op, ops.Greater)
-    assert op.right.output_dtype is dt.string
+    assert op.right.dtype is dt.string
 
 
 def test_comparisons_pandas_timestamp(alltypes):
@@ -93,7 +93,7 @@ def test_comparisons_pandas_timestamp(alltypes):
     expr = alltypes.i > val
     op = expr.op()
     assert isinstance(op.right, ops.Literal)
-    assert isinstance(op.right.output_dtype, dt.Timestamp)
+    assert isinstance(op.right.dtype, dt.Timestamp)
 
 
 def test_greater_comparison_pandas_timestamp(alltypes):
@@ -102,7 +102,7 @@ def test_greater_comparison_pandas_timestamp(alltypes):
     op = expr2.op()
     assert isinstance(op, ops.Greater)
     assert isinstance(op.right, ops.Literal)
-    assert isinstance(op.right.output_dtype, dt.Timestamp)
+    assert isinstance(op.right.dtype, dt.Timestamp)
 
 
 def test_timestamp_precedence():

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1604,7 +1604,7 @@ def test_rowid_only_physical_tables():
         table.filter(table.x > 0).rowid()
 
 
-def test_where_output_shape():
+def test_where_shape():
     # GH-5191
     t = ibis.table(dict(a="int64", b="string"), name="t")
     expr = ibis.literal(True).ifelse(t.a, -t.a)
@@ -1622,4 +1622,4 @@ def test_quantile_shape():
     expr = t.select(projs)
     (b1,) = expr.op().selections
 
-    assert b1.output_shape.is_columnar()
+    assert b1.shape.is_columnar()


### PR DESCRIPTION
Depends on #5899 

prefer shorter names for these attributes, aliases are provided for backwards compatibility but they are deprecated