### PR TITLE
feat(pyspark): to_csv and to_parquet

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -707,3 +708,47 @@ class Backend(BaseSQLBackend):
 
     def _to_sql(self, expr: ir.Expr, **kwargs) -> str:
         raise NotImplementedError(f"Backend '{self.name}' backend doesn't support SQL")
+
+    @util.experimental
+    def to_parquet(
+        self,
+        expr: ir.Table,
+        path: str | Path,
+        **kwargs: Any,
+    ) -> None:
+        """Write the results of executing the given expression to parquet files.
+
+        This method is eager and will execute the associated expression immediately.
+
+        Parameters
+        ----------
+        expr
+            The ibis expression to execute and persist to CSV.
+        path
+            The data source. A string or Path to the  file.
+        **kwargs
+            PySpark Parquet write arguments. https://spark.apache.org/docs/3.1.1/api/python/reference/api/pyspark.sql.DataFrameWriter.parquet.html
+        """
+        expr.compile().write.parquet(os.fspath(path), **kwargs)
+
+    @util.experimental
+    def to_csv(
+        self,
+        expr: ir.Table,
+        path: str | Path,
+        **kwargs: Any,
+    ) -> None:
+        """Write the results of executing the given expression to a CSV file.
+
+        This method is eager and will execute the associated expression immediately.
+
+        Parameters
+        ----------
+        expr
+            The ibis expression to execute and persist to CSV.
+        path
+            The data source. A string or Path to the CSV.
+        **kwargs
+            PySpark CSV write arguments. https://spark.apache.org/docs/3.1.1/api/python/reference/api/pyspark.sql.DataFrameWriter.csv.html
+        """
+        expr.compile().write.csv(os.fspath(path), **kwargs)

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -210,7 +210,7 @@ def test_to_pyarrow_batches_memtable(con):
     assert n == 3
 
 
-@pytest.mark.notimpl(["dask", "impala", "pyspark"])
+@pytest.mark.notimpl(["dask", "impala"])
 def test_table_to_parquet(tmp_path, backend, awards_players):
     outparquet = tmp_path / "out.parquet"
     awards_players.to_parquet(outparquet)
@@ -237,12 +237,14 @@ def test_table_to_parquet(tmp_path, backend, awards_players):
     ],
     reason="no partitioning support",
 )
-@pytest.mark.notimpl(
-    ["dask", "impala", "pyspark", "druid"], reason="No to_parquet support"
-)
+@pytest.mark.notimpl(["dask", "impala", "druid"], reason="No to_parquet support")
 def test_roundtrip_partitioned_parquet(tmp_path, con, backend, awards_players):
     outparquet = tmp_path / "outhive.parquet"
-    awards_players.to_parquet(outparquet, partition_by="yearID")
+
+    if con.name == "pyspark":
+        awards_players.to_parquet(outparquet, partitionBy="yearID")
+    else:
+        awards_players.to_parquet(outparquet, partition_by="yearID")
 
     assert outparquet.is_dir()
 
@@ -259,7 +261,7 @@ def test_roundtrip_partitioned_parquet(tmp_path, con, backend, awards_players):
     backend.assert_frame_equal(awards_players.execute(), awards_players.execute())
 
 
-@pytest.mark.notimpl(["dask", "impala", "pyspark"])
+@pytest.mark.notimpl(["dask", "impala"])
 def test_table_to_csv(tmp_path, backend, awards_players):
     outcsv = tmp_path / "out.csv"
 


### PR DESCRIPTION
implements `to_csv` and `to_parquet` for the pyspark backend

example: https://gist.github.com/lostmygithubaccount/2d2ab5f70e8afda643c600e98c3989a8
