### PR TITLE
docs: update imports/exports for pyspark backend

### DIFF
--- a/docs/backends/pyspark.md
+++ b/docs/backends/pyspark.md
@@ -3,8 +3,8 @@ backend_name: PySpark
 backend_url: https://spark.apache.org/docs/latest/api/python/
 backend_module: pyspark
 backend_param_style: PySpark things
-exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
-imports: ["CSV", "Parquet"]
+exports: ["PyArrow", "Parquet", "Delta Lake", "Pandas"]
+imports: ["CSV", "Parquet", "Delta Lake"]
 ---
 
 # PySpark


### PR DESCRIPTION
removes "CSV" which isn't actually supported; adds "Delta Lake" for import and export per #6603
