### PR TITLE
chore: update plugin

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -40,7 +40,7 @@ module.exports = {
       },
     ],
     [
-      "@google/semantic-release-replace-plugin",
+      "semantic-release-replace-plugin",
       {
         replacements: [
           {

--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -41,7 +41,7 @@ nix develop '.#release' -c npx --yes \
   -p "@semantic-release/changelog" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "@google/semantic-release-replace-plugin@1.2.0" \
+  -p "semantic-release-replace-plugin@1.2.0" \
   -p "conventional-changelog-conventionalcommits" \
   semantic-release \
   --ci \

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -10,6 +10,6 @@ nix develop '.#release' -c npx --yes \
   -p "@semantic-release/github" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "@google/semantic-release-replace-plugin@1.2.0" \
+  -p "semantic-release-replace-plugin@1.2.0" \
   -p "conventional-changelog-conventionalcommits" \
   semantic-release --ci


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).