### PR TITLE
style(js): set trailing comma style config to new default

### DIFF
--- a/.conventionalcommits.js
+++ b/.conventionalcommits.js
@@ -5,7 +5,7 @@ const releaseConfig = require("./.releaserc.js");
 function extractConventionalCommitsConfig(config) {
   return config.plugins
     .filter(
-      ([plugin, _]) => plugin == "@semantic-release/release-notes-generator"
+      ([plugin, _]) => plugin == "@semantic-release/release-notes-generator",
     )
     .map(([_, config]) => config)[0].presetConfig.types;
 }

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -3,3 +3,4 @@ semi = true
 singleQuote = false
 arrowParens = "avoid"
 useTabs = false
+trailingComma = "all"


### PR DESCRIPTION
Small PR to set the trailing comma style for JS code to the new `prettier` default.