### PR TITLE
fix(duckdb): avoid double escaping backslashes for bind parameters

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -53,9 +53,10 @@ def _format_kwargs(kwargs: Mapping[str, Any]):
     bindparams, pieces = [], []
     for name, value in kwargs.items():
         bindparam = sa.bindparam(name, value)
-        if not isinstance(
-            bindparam.type, sa.sql.sqltypes.NullType
-        ):  # the parameter type is not null
+        if isinstance(paramtype := bindparam.type, sa.String):
+            # special case strings to avoid double escaping backslashes
+            pieces.append(f"{name} = '{value!s}'")
+        elif not isinstance(paramtype, sa.types.NullType):
             bindparams.append(bindparam)
             pieces.append(f"{name} = :{name}")
         else:  # fallback to string strategy

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -333,3 +333,11 @@ def test_register_recordbatchreader_warns(con):
     t = con.read_in_memory(reader, table_name=t.get_name())
     res = t.execute()
     tm.assert_frame_equal(res, sol)
+
+
+def test_csv_with_slash_n_null(con, tmp_path):
+    data_path = tmp_path / "data.csv"
+    data_path.write_text("a\n1\n3\n\\N\n")
+    t = con.read_csv(data_path, nullstr="\\N")
+    col = t.a.execute()
+    assert pd.isna(col.iat[-1])


### PR DESCRIPTION
This PR fixes an issue with bind parameter escaping, where backslashes are doubly escaped which results in a minimum of two backslashes in any bind parameter that has them.