### PR TITLE
feat(api): allow mixing literals and columns in `ibis.array`

### DIFF
--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -11,23 +11,13 @@ from ibis.expr.operations.core import Argument, Unary, Value
 
 @public
 class ArrayColumn(Value):
-    cols = rlz.tuple_of(rlz.column(rlz.any), min_length=1)
+    cols = rlz.tuple_of(rlz.any, min_length=1)
 
     output_shape = rlz.Shape.COLUMNAR
 
-    def __init__(self, cols):
-        unique_dtypes = {col.output_dtype for col in cols}
-        if len(unique_dtypes) > 1:
-            raise com.IbisTypeError(
-                f'The types of all input columns must match exactly in a '
-                f'{type(self).__name__} operation.'
-            )
-        super().__init__(cols=cols)
-
     @attribute.default
     def output_dtype(self):
-        first_dtype = self.cols[0].output_dtype
-        return dt.Array(first_dtype)
+        return dt.Array(rlz.highest_precedence_dtype(self.cols))
 
 
 @public

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -430,7 +430,9 @@ class ArrayValue(Value):
         """
         return ops.ArrayMap(self, func=func).to_expr()
 
-    def filter(self, predicate: Callable[[ir.Value], ir.BooleanValue]) -> ir.ArrayValue:
+    def filter(
+        self, predicate: Callable[[ir.Value], bool | ir.BooleanValue]
+    ) -> ir.ArrayValue:
         """Filter array elements using `predicate`.
 
         Parameters

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -882,20 +882,21 @@ def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayVa
     >>> ibis.array([1.0, 2.0, 3.0])
     [1.0, 2.0, 3.0]
 
-    Mixing scalar and column expressions is not allowed
+    Mixing scalar and column expressions is allowed
 
-    >>> ibis.array([t.a, 1.0])
-    Traceback (most recent call last):
-        ...
-    ibis.common.exceptions.IbisTypeError: To create an array column using `array`, all input values must be column expressions.
+    >>> ibis.array([t.a, 42])
+    ┏━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ ArrayColumn()        ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━┩
+    │ array<int64>         │
+    ├──────────────────────┤
+    │ [1, 42]              │
+    │ [2, 42]              │
+    │ [3, 42]              │
+    └──────────────────────┘
     """
-    if all(isinstance(value, Column) for value in values):
+    if any(isinstance(value, Column) for value in values):
         return ops.ArrayColumn(values).to_expr()
-    elif any(isinstance(value, Column) for value in values):
-        raise com.IbisTypeError(
-            'To create an array column using `array`, all input values must '
-            'be column expressions.'
-        )
     else:
         try:
             return literal(list(values), type=type)


### PR DESCRIPTION
This PR is a small feature addition to allow constructing array columns that are a mix of literal and other column expressions.