### PR TITLE
fix: forward arguments through `__dataframe__` protocol

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -109,8 +109,8 @@ class Table(Expr, _FixedTextJupyterMixin):
     def __array__(self, dtype=None):
         return self.execute().__array__(dtype)
 
-    def __dataframe__(self):
-        return self.to_pyarrow().__dataframe__()
+    def __dataframe__(self, *args: Any, **kwargs: Any):
+        return self.to_pyarrow().__dataframe__(*args, **kwargs)
 
     def as_table(self) -> Table:
         """Promote the expression to a table.


### PR DESCRIPTION
The `__dataframe__` method takes a few keyword arguments (see [here](https://data-apis.org/dataframe-protocol/latest/API.html)). Rather than list them out, I went with a `*args, **kwargs` approach in case the protocol is updated later.