### PR TITLE
fix(duckdb): run pre-execute-hooks in duckdb before file export

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -821,6 +821,7 @@ class Backend(BaseAlchemyBackend):
         >>> # partition on multiple columns
         >>> con.to_parquet(penguins, "penguins_hive_dir", partition_by=("year", "island"))  # doctest: +SKIP
         """
+        self._run_pre_execute_hooks(expr)
         query = self._to_sql(expr, params=params)
         args = ["FORMAT 'parquet'", *(f"{k.upper()} {v!r}" for k, v in kwargs.items())]
         copy_cmd = f"COPY ({query}) TO {str(path)!r} ({', '.join(args)})"
@@ -855,6 +856,7 @@ class Backend(BaseAlchemyBackend):
         **kwargs
             DuckDB CSV writer arguments. https://duckdb.org/docs/data/csv.html#parameters
         """
+        self._run_pre_execute_hooks(expr)
         query = self._to_sql(expr, params=params)
         args = [
             "FORMAT 'csv'",

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -266,14 +266,14 @@ def test_roundtrip_partitioned_parquet(tmp_path, con, backend, awards_players):
 
 
 @pytest.mark.notimpl(
-    ["dask", "druid", "impala", "pyspark"], reason="No support for exporting files"
+    ["dask", "impala", "pyspark"], reason="No support for exporting files"
 )
 @pytest.mark.notimpl(
     ["datafusion"],
     reason="No memtable support",
 )
 @pytest.mark.parametrize("ftype", ["csv", "parquet"])
-def test_memtable_to_file(tmp_path, con, ftype):
+def test_memtable_to_file(tmp_path, con, ftype, monkeypatch):
     """
     Tests against a regression spotted in #6091 where a `memtable` that is
     created and then immediately exported to `parquet` (or csv) will error
@@ -283,15 +283,13 @@ def test_memtable_to_file(tmp_path, con, ftype):
     outfile = tmp_path / f"memtable.{ftype}"
     assert not outfile.is_file()
 
-    ibis.set_backend(con)
+    monkeypatch.setattr(ibis.options, "default_backend", con)
 
     memtable = ibis.memtable({"col": [1, 2, 3, 4]})
 
     getattr(con, f"to_{ftype}")(memtable, outfile)
 
     assert outfile.is_file()
-
-    ibis.options.default_backend = None
 
 
 @pytest.mark.notimpl(["dask", "impala", "pyspark"])

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -254,11 +254,15 @@ def test_roundtrip_partitioned_parquet(tmp_path, con, backend, awards_players):
 
     # Reingest and compare schema
     reingest = con.read_parquet(outparquet / "*" / "*")
+    reingest = reingest.cast({"yearID": "int64"})
 
     # avoid type comparison to appease duckdb: as of 0.8.0 it returns large_string
     assert reingest.schema().names == awards_players.schema().names
 
-    backend.assert_frame_equal(awards_players.to_pandas(), awards_players.to_pandas())
+    reingest = reingest.order_by(["yearID", "playerID", "awardID", "lgID"])
+    awards_players = awards_players.order_by(["yearID", "playerID", "awardID", "lgID"])
+
+    backend.assert_frame_equal(reingest.to_pandas(), awards_players.to_pandas())
 
 
 @pytest.mark.notimpl(


### PR DESCRIPTION
We weren't running these hooks before, which meant that a `memtable`
that hadn't been executed yet (via interactive mode or otherwise) would
not be registered with DuckDB at export time.

Fixes #6091 

While I was adding a test, I noticed that the partitioned parquet roundtripping test was comparing the same table to itself.  Made a few tweaks there.