### PR TITLE
fix(duckdb): handle conversion from duckdb_engine unsigned int aliases

### DIFF
--- a/ibis/backends/duckdb/datatypes.py
+++ b/ibis/backends/duckdb/datatypes.py
@@ -101,9 +101,17 @@ _from_duckdb_types = {
     ducktypes.SmallInteger: dt.Int16,
     ducktypes.Integer: dt.Int32,
     ducktypes.BigInteger: dt.Int64,
+    ducktypes.HugeInteger: dt.Int64,
+    # The following dtypes are present in duckdb_engine and will show up
+    # in _some_ tables, but it isn't clear _why_.
+    # Please don't remove them.
+    ducktypes.UInt8: dt.UInt8,
     ducktypes.UTinyInteger: dt.UInt8,
+    ducktypes.UInt16: dt.UInt16,
     ducktypes.USmallInteger: dt.UInt16,
+    ducktypes.UInt32: dt.UInt32,
     ducktypes.UInteger: dt.UInt32,
+    ducktypes.UInt64: dt.UInt64,
     ducktypes.UBigInteger: dt.UInt64,
 }
 


### PR DESCRIPTION
Fixes #6632 

I'm not sure how to test this because I can't figure out why `duckdb_engine` sometimes gives us a `UInt8` vs a `UTinyInteger`.

@NickCrews -- this should fix up the issue you were running into.  Thanks for providing the "problem" parquet file!