### PR TITLE
fix(exprs): ensure that `how="left_semi"` and `how="semi"` are equivalent

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2442,7 +2442,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         # semi/anti join only give access to the left table's fields, so
         # there's never overlap
-        if how in ("semi", "anti"):
+        if how in ("left_semi", "semi", "anti"):
             return expr
 
         return ops.relations._dedup_join_columns(expr, lname=lname, rname=rname)


### PR DESCRIPTION
This PR fixes an issue where we were not treating `how="semi"` and `how="left_semi"` the same WRT deduplicating columns.