### PR TITLE
fix(polars): ensure that `pivot_longer` works with more than one column

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -888,7 +888,7 @@ def array_concat(op, **kw):
 
 @translate.register(ops.ArrayColumn)
 def array_column(op, **kw):
-    cols = list(map(translate, op.cols))
+    cols = [translate(col, **kw) for col in op.cols]
     return pl.concat_list(cols)
 
 
@@ -897,10 +897,7 @@ def array_collect(op, **kw):
     arg = translate(op.arg, **kw)
     if (where := op.where) is not None:
         arg = arg.filter(translate(where, **kw))
-    try:
-        return arg.implode()
-    except AttributeError:  # pragma: no cover
-        return arg.list()  # pragma: no cover
+    return arg
 
 
 _date_methods = {

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -369,9 +369,6 @@ def test_unnest_complex(backend):
     reason="clickhouse throws away nulls in groupArray",
     raises=AssertionError,
 )
-@pytest.mark.notyet(
-    "polars", raises=AssertionError, reason="polars implode returns the wrong shape"
-)
 @pytest.mark.notimpl(["dask"], raises=ValueError)
 def test_unnest_idempotent(backend):
     array_types = backend.array_types
@@ -392,9 +389,6 @@ def test_unnest_idempotent(backend):
 
 
 @unnest
-@pytest.mark.notimpl(
-    "polars", raises=TypeError, reason="polars implode returns the wrong shape"
-)
 @pytest.mark.notimpl("dask", raises=ValueError)
 def test_unnest_no_nulls(backend):
     array_types = backend.array_types

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -333,7 +333,6 @@ def test_unnest_simple(backend):
 
 
 @unnest
-@pytest.mark.notimpl("polars", raises=PolarsComputeError, reason="Series shape: (6,)")
 @pytest.mark.notimpl("dask", raises=com.OperationNotDefinedError)
 def test_unnest_complex(backend):
     array_types = backend.array_types
@@ -370,7 +369,9 @@ def test_unnest_complex(backend):
     reason="clickhouse throws away nulls in groupArray",
     raises=AssertionError,
 )
-@pytest.mark.notimpl("polars", raises=PolarsComputeError, reason="Series shape: (6,)")
+@pytest.mark.notyet(
+    "polars", raises=AssertionError, reason="polars implode returns the wrong shape"
+)
 @pytest.mark.notimpl(["dask"], raises=ValueError)
 def test_unnest_idempotent(backend):
     array_types = backend.array_types
@@ -391,8 +392,10 @@ def test_unnest_idempotent(backend):
 
 
 @unnest
-@pytest.mark.notimpl("polars", raises=PolarsComputeError, reason="Series shape: (6,)")
-@pytest.mark.notimpl(["dask"], raises=ValueError)
+@pytest.mark.notimpl(
+    "polars", raises=TypeError, reason="polars implode returns the wrong shape"
+)
+@pytest.mark.notimpl("dask", raises=ValueError)
 def test_unnest_no_nulls(backend):
     array_types = backend.array_types
     df = array_types.execute()

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -970,7 +970,6 @@ def test_many_subqueries(con, snapshot):
 
 
 @pytest.mark.notimpl(["dask", "pandas", "oracle"], raises=com.OperationNotDefinedError)
-@pytest.mark.notyet(["polars"], reason="polars doesn't expand > 1 explode")
 @pytest.mark.notimpl(["druid"], raises=AssertionError)
 @pytest.mark.notyet(
     ["bigquery"],


### PR DESCRIPTION
This PR addresses an issue where the polars backend was not able to handle pivoting on more than one column, due to its `explode()` idiosyncracies, namely that there are some hoops to jump through to get it to do a pairwise unnest. Fixes #5795.

Additionally, this appears to have exposed https://github.com/pola-rs/polars/issues/10017.