### PR TITLE
feat(api): allow slice endpoint to be `None`

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -13,7 +13,7 @@ import ibis.expr.operations as ops
 
 
 class _LimitSpec(NamedTuple):
-    n: int
+    n: int | None
     offset: int
 
 
@@ -240,10 +240,12 @@ class SelectBuilder:
         if self.limit is None:
             self.limit = _LimitSpec(n, offset)
         else:
-            self.limit = _LimitSpec(
-                min(n, self.limit.n),
-                offset + self.limit.offset,
-            )
+            if self.limit.n is not None:
+                n = min(n or self.limit.n, self.limit.n)
+            # else:
+            #     both are None or n is not None and self.limit.n is None
+
+            self.limit = _LimitSpec(n, offset + self.limit.offset)
 
         self._collect(op.table, toplevel=toplevel)
 

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -345,7 +345,9 @@ class Difference(SetOp):
 @public
 class Limit(TableNode):
     table = rlz.table
-    n = rlz.instance_of(int)
+    # optional isn't used here because `None` isn't a default value for `n`,
+    # it's just another _possible_ value
+    n = rlz.instance_of((int, type(None)))
     offset = rlz.instance_of(int)
 
     @property

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -538,27 +538,33 @@ def test_order_by_nonexistent_column_errors(table, expr_func, key, exc_type):
 
 
 def test_slice(table):
-    expr = table[:5]
+    expr1 = table[:5]
     expr2 = table[:5:1]
-    assert_equal(expr, table.limit(5))
-    assert_equal(expr, expr2)
+    expr3 = table[5:]
+    assert_equal(expr1, table.limit(5))
+    assert_equal(expr1, expr2)
+    assert_equal(expr3, table.limit(None, offset=5))
 
-    expr = table[2:7]
+    expr1 = table[2:7]
     expr2 = table[2:7:1]
-    assert_equal(expr, table.limit(5, offset=2))
-    assert_equal(expr, expr2)
+    expr3 = table[2::1]
+    assert_equal(expr1, table.limit(5, offset=2))
+    assert_equal(expr1, expr2)
+    assert_equal(expr3, table.limit(None, offset=2))
 
-    with pytest.raises(ValueError):
-        table[2:15:2]
 
+@pytest.mark.parametrize(
+    "input",
+    [
+        slice(2, 15, 2),
+        slice(None, -5, None),
+        slice(-10, -5, None),
+        slice(-10, None, None),
+    ],
+)
+def test_invalid_slice(table, input):
     with pytest.raises(ValueError):
-        table[5:]
-
-    with pytest.raises(ValueError):
-        table[:-5]
-
-    with pytest.raises(ValueError):
-        table[-10:-5]
+        table[input]
 
 
 def test_table_count(table):


### PR DESCRIPTION
Adds support for a slice endpoint of `None`. Partially addresses #6669.