### PR TITLE
docs(dplyr): small fixes to the dplyr getting started guide

### DIFF
--- a/docs/tutorial/ibis-for-dplyr-users.ipynb
+++ b/docs/tutorial/ibis-for-dplyr-users.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[R](https://www.r-project.org/) users familiar with [dplyr](https://dplyr.tidyverse.org/) and other packages in the [Tidyverse](https://www.tidyverse.org/) are likely to find Ibis familiar.\n",
+    "[R](https://www.r-project.org/) users familiar with [dplyr](https://dplyr.tidyverse.org/), [tidyr](https://tidyr.tidyverse.org/), and other packages in the [Tidyverse](https://www.tidyverse.org/) are likely to find Ibis familiar.\n",
     "In fact, some Ibis features were even inspired by similar features in the [Tidyverse](https://www.tidyverse.org/).\n",
     "\n",
     "However, due to differences between Python and R and the design and goals of Ibis itself, you may notice some big differences right away:\n",
@@ -27,7 +27,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the same example data and similar operations as in [Introduction to dplyr](https://dplyr.tidyverse.org/articles/dplyr.html), below you will find some examples of the more common dplyr operations and their Ibis equivalents."
+    "Using the same example data and similar operations as in [Introduction to dplyr](https://dplyr.tidyverse.org/articles/dplyr.html), below you will find some examples of the more common dplyr and tidyr operations and their Ibis equivalents."
    ]
   },
   {
@@ -242,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ibis, like dplyr, has the `filter` method to select rows based on conditions.\n",
+    "Ibis, like dplyr, has `filter` to select rows based on conditions.\n",
     "\n",
     "With dplyr:\n",
     "\n",
@@ -348,7 +348,7 @@
     "   arrange(height)\n",
     "```\n",
     "\n",
-    "In Ibis:"
+    "Ibis has the `order_by` method, so to perform the same operation:"
    ]
   },
   {
@@ -649,6 +649,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: Throughout this guide, where dplyr uses R generics, Ibis uses Python methods.  In the previous code cell, `aggregate` is a method on a _table_ and `mean` is a method on a _column_.  If you want to perform aggregations on multiple columns, you can call the method that you want on the column you want to apply it to."
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -813,9 +820,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
* Removing the use of the word `method` w.r.t. R generics
* Calling out tidyr in the intro
* Added in a bit more explanation around aggregate function methods
* Added a missing snippet about ibis `order_by` vs. dplyr `arrange`