### PR TITLE
feat: improved error messages when missing backend dependencies

### DIFF
--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -72,7 +72,15 @@ def __getattr__(name: str) -> BaseBackend:
     import ibis
 
     (entry_point,) = entry_points
-    module = entry_point.load()
+    try:
+        module = entry_point.load()
+    except ImportError as exc:
+        raise ImportError(
+            f"Failed to import the {name} backend due to missing dependencies.\n\n"
+            f"You can pip or conda install the {name} backend as follows:\n\n"
+            f'  python -m pip install -U "ibis-framework[{name}]"  # pip install\n'
+            f"  conda install -c conda-forge ibis-{name}           # or conda install"
+        ) from exc
     backend = module.Backend()
     # The first time a backend is loaded, we register its options, and we set
     # it as an attribute of `ibis`, so `__getattr__` is not called again for it


### PR DESCRIPTION
This catches import errors when loading an ibis backend and raises a nicer error message to the user telling them how they may resolve the issue.

Fixes #6695.