### PR TITLE
fix(backends): fix pyspark `has_operation` definition; test that `has_operation` doesn't return `True` spuriously

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -513,7 +513,7 @@ class Backend(BaseBackend):
     def has_operation(cls, operation: type[ops.Value]) -> bool:
         from ibis.backends.clickhouse.compiler.values import translate_val
 
-        return operation in translate_val.registry
+        return translate_val.dispatch(operation) is not translate_val.dispatch(object)
 
     def create_database(
         self, name: str, *, force: bool = False, engine: str = "Atomic"

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -397,9 +397,9 @@ def _log(op, **kw):
 
 
 @translate_val.register(tuple)
-def _node_list(op, punct="()", **kw):
+def _node_list(op, **kw):
     values = ", ".join(map(_sql, map(partial(translate_val, **kw), op)))
-    return f"{punct[0]}{values}{punct[1]}"
+    return f"({values})"
 
 
 def _interval_format(op):

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -561,6 +561,7 @@ class Backend(BaseSQLBackend):
         name = self._fully_qualified_name(name, database)
         return self.raw_sql(f"ANALYZE TABLE {name} COMPUTE STATISTICS{maybe_noscan}")
 
+    @classmethod
     def has_operation(cls, operation: type[ops.Value]) -> bool:
         return operation in PySparkExprTranslator._registry
 


### PR DESCRIPTION
This PR fixes a few issues with `has_operation`:

1. The PySpark backend implementation didn't have a `@classmethod` decorator, so it didn't follow the base class definition and every other backend's implementation.
1. The ClickHouse backend was looking up operands using the mapping that backs the singledispatch registry, so `Backend.has_operation(object)` returned `True`.

Tests are included.
