### PR TITLE
ci(docs): fix warnings coming from new version of mkdocs

### DIFF
--- a/docs/concept/backends.md
+++ b/docs/concept/backends.md
@@ -1,6 +1,6 @@
 # Backends
 
-A backend is where execution of Ibis table expressions occur after compiling into some intermediate representation. A backend is often a database and the intermediate representation often SQL, but several types of backends exist. See the [backends page](/backends/) for specific documentation on each.
+A backend is where execution of Ibis table expressions occur after compiling into some intermediate representation. A backend is often a database and the intermediate representation often SQL, but several types of backends exist. See the [backends page](../backends/index.md) for specific documentation on each.
 
 ## String generating backends
 
@@ -9,9 +9,9 @@ The first category of backends translate Ibis table expressions into query strin
 The compiler turns each table expression into a query string and passes that query
 to the database through a driver API for execution.
 
-- [Apache Impala](/backends/impala/)
-- [ClickHouse](/backends/clickhouse/)
-- [Google BigQuery](/backends/bigquery/)
+- [Apache Impala](../backends/impala.md)
+- [ClickHouse](../backends/clickhouse.md)
+- [Google BigQuery](../backends/bigquery.md)
 - [HeavyAI](https://github.com/heavyai/ibis-heavyai)
 
 ## Expression generating backends
@@ -23,19 +23,19 @@ Instead of generating a query string for each table expression, these backends
 produce another kind of table expression object and typically have high-level APIs
 for execution.
 
-- [Apache Arrow Datafusion](/backends/datafusion/)
-- [Apache Druid](/backends/druid/)
-- [Apache PySpark](/backends/pyspark/)
-- [Dask](/backends/dask/)
-- [DuckDB](/backends/duckdb/)
-- [MS SQL Server](/backends/mssql/)
-- [MySQL](/backends/mysql/)
-- [Oracle](/backends/oracle/)
-- [Polars](/backends/polars/)
-- [PostgreSQL](/backends/postgresql/)
-- [SQLite](/backends/sqlite/)
-- [Snowflake](/backends/snowflake/)
-- [Trino](/backends/trino/)
+- [Apache Arrow Datafusion](../backends/datafusion.md)
+- [Apache Druid](../backends/druid.md)
+- [Apache PySpark](../backends/pyspark.md)
+- [Dask](../backends/dask.md)
+- [DuckDB](../backends/duckdb.md)
+- [MS SQL Server](../backends/mssql.md)
+- [MySQL](../backends/mysql.md)
+- [Oracle](../backends/oracle.md)
+- [Polars](../backends/polars.md)
+- [PostgreSQL](../backends/postgresql.md)
+- [SQLite](../backends/sqlite.md)
+- [Snowflake](../backends/snowflake.md)
+- [Trino](../backends/trino.md)
 
 ## Direct execution backends
 
@@ -43,4 +43,4 @@ The pandas backend is the only direct execution backend. A full description
 of the implementation can be found in the module docstring of the pandas
 backend located in `ibis/backends/pandas/core.py`.
 
-- [pandas](/backends/pandas/)
+- [pandas](../backends/pandas.md)

--- a/docs/concept/why_ibis.md
+++ b/docs/concept/why_ibis.md
@@ -1,11 +1,11 @@
 # Why Ibis?
 
-Ibis is a dataframe interface to execution engines with support for [15+
-backends](/backends/). Ibis doesn't replace your existing execution
+Ibis is a dataframe interface to execution engines with support for [17+
+backends](../backends/index.md). Ibis doesn't replace your existing execution
 engine, it _extends_ it with powerful abstractions and intuitive syntax.
 
 Ibis works with what you already have, so why not check out our [getting started
-guide](/tutorial/getting_started/)?
+guide](../tutorial/getting_started.md)?
 
 # How does Ibis compare to...
 
@@ -34,7 +34,7 @@ we can summarize some key points:
 - Ibis lets you use SQL when you want to (for our SQL-based backends)
 
 If your SQL-fu is strong, we might not convince you to leave it all behind, but
-check out our [Ibis for SQL users guide](/tutorial/ibis-for-sql-users/)
+check out our [Ibis for SQL users guide](../tutorial/ibis-for-sql-users.ipynb)
 and see if it whets your appetite.
 
 ## `pandas`
@@ -53,7 +53,7 @@ Ibis to quickly and easily switch to a different backend that supports
 out-of-core execution.
 
 Ibis syntax is similar to `pandas` syntax, but it isn't a drop-in replacement.
-Check out our [Ibis for pandas Users guide](/tutorial/ibis-for-pandas-users/) if
+Check out our [Ibis for pandas Users guide](../tutorial/ibis-for-pandas-users.ipynb) if
 you'd like to give Ibis a try!
 
 ## `sqlalchemy` and `sqlglot`
@@ -72,4 +72,4 @@ using SQLGlot.
 
 If you are looking for a dataframe API to construct and execute your analytics
 queries against a large collection of powerful execution engines, then allow us
-point you at the [Ibis Getting Started guide](/tutorial/getting_started/).
+point you at the [Ibis Getting Started guide](../tutorial/getting_started.md).

--- a/docs/how_to/streamlit.md
+++ b/docs/how_to/streamlit.md
@@ -4,7 +4,7 @@ Streamlit + Ibis = :heart:
 
 Ibis supports the [streamlit `experimental_connection` interface](https://blog.streamlit.io/introducing-st-experimental_connection/), making it easier than ever to combine the powers of both tools!
 
-Check out the example application below that shows the top N ingredients from a corpus of recipes using [the ClickHouse backend](/backends/clickhouse/)!
+Check out the example application below that shows the top N ingredients from a corpus of recipes using [the ClickHouse backend](../backends/clickhouse.md)!
 
 <div class="streamlit-app">
   <iframe class="streamlit-app-inner" src="https://ibis-example.streamlit.app/?embedded=true"></iframe>

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@ hide:
 ---
 
 <div class="install-tutorial-button" markdown>
-[Getting Started](/tutorial/getting_started/){ .md-button .md-button--primary }
-[Install](/install/){ .md-button }
+[Getting Started](tutorial/getting_started.md){ .md-button .md-button--primary }
+[Install](install.md){ .md-button }
 </div>
 
 ---
@@ -49,7 +49,7 @@ ORDER BY t1.year DESC
 
 ## Features
 
-- **Consistent syntax across backends**: Enjoy a uniform Python API, whether using [DuckDB](https://duckdb.org), [PostgreSQL](https://postgresql.org), [PySpark](https://spark.apache.org/docs/latest/api/python/index.html), [BigQuery](https://cloud.google.com/bigquery/), or [any other supported backend](/backends/).
+- **Consistent syntax across backends**: Enjoy a uniform Python API, whether using [DuckDB](https://duckdb.org), [PostgreSQL](https://postgresql.org), [PySpark](https://spark.apache.org/docs/latest/api/python/index.html), [BigQuery](https://cloud.google.com/bigquery/), or [any other supported backend](backends/index.md).
 - **Performant**: Execute queries as fast as the database engine itself.
 - **Interactive**: Explore data in a notebook or REPL.
 - **Extensible**: Add new operations, optimizations, and custom APIs.

--- a/docs/tutorial/getting_started.md
+++ b/docs/tutorial/getting_started.md
@@ -5,7 +5,7 @@ This is a quick tour of some basic commands and usage patterns, just to get your
 ## Install `ibis`
 
 This quick-start guide uses the DuckDB backend. You can check out the [Install
-page](/install/) for information on how to install other backends.
+page](../install.md) for information on how to install other backends.
 
 ```shell title="Install Ibis using pip"
 $ pip install 'ibis-framework[duckdb]'
@@ -372,7 +372,7 @@ You can also use a `selector` alongside a column name.
 └───────────┴────────────────┴───────────────┴───────────────────┴─────────────┴───────┘
 ```
 
-You can read more about [`selectors`](/reference/selectors/) in the docs!
+You can read more about [`selectors`](../reference/selectors.md) in the docs!
 
 ### order_by
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -2,8 +2,8 @@
 
 Welcome to the Ibis tutorials!
 
-- **Learning Ibis for the first time?:** Check out the [Ibis getting started tutorial](./getting_started/)!
-- **Coming from SQL?**: Take a look at [Ibis for SQL users](./ibis-for-sql-users/)!
-- **Coming from pandas?**: Check out [Ibis for pandas users](./ibis-for-pandas-users/)!
-- **Coming from R?**: See [Ibis for dplyr users](./ibis-for-dplyr-users/)!
+- **Learning Ibis for the first time?:** Check out the [Ibis getting started tutorial](./getting_started.md)!
+- **Coming from SQL?**: Take a look at [Ibis for SQL users](./ibis-for-sql-users.ipynb)!
+- **Coming from pandas?**: Check out [Ibis for pandas users](./ibis-for-pandas-users.ipynb)!
+- **Coming from R?**: See [Ibis for dplyr users](./ibis-for-dplyr-users.ipynb)!
 - **Want to see some more examples?**: We've got [a repository of examples](https://github.com/ibis-project/ibis-examples) for that!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,9 +139,17 @@ markdown_extensions:
   - toc:
       permalink: true
       permalink_title: "Anchor link to this section for reference"
+validation:
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    absolute_links: warn
+    unrecognized_links: info
 extra:
   project_name: "ibis"
-  # maybe version goes here?
   team:
     - name: "Maintainers"
       members:


### PR DESCRIPTION
This PR fixes some doc build warnings introduced in mkdocs 1.5.0