### PR TITLE
feat(api): support boolean literals in join API

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1149,3 +1149,8 @@ def execute_view(op, *, ctx: pl.SQLContext, **kw):
     child = translate(op.child, ctx=ctx, **kw)
     ctx.register(op.name, child)
     return child
+
+
+@translate.register(ops.SelfReference)
+def execute_self_reference(op, **kw):
+    return translate(op.table, **kw)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -276,12 +276,7 @@ def test_notin(backend, alltypes, sorted_df, column, elements):
 @pytest.mark.parametrize(
     ('predicate_fn', 'expected_fn'),
     [
-        param(
-            lambda t: t['bool_col'],
-            lambda df: df['bool_col'],
-            id="no_op",
-            marks=pytest.mark.min_version(datafusion="0.5.0"),
-        ),
+        param(lambda t: t['bool_col'], lambda df: df['bool_col'], id="no_op"),
         param(lambda t: ~t['bool_col'], lambda df: ~df['bool_col'], id="negate"),
         param(
             lambda t: t.bool_col & t.bool_col,
@@ -372,7 +367,6 @@ def test_case_where(backend, alltypes, df):
 
 # TODO: some of these are notimpl (datafusion) others are probably never
 @pytest.mark.notimpl(["datafusion", "mysql", "sqlite", "mssql", "druid", "oracle"])
-@pytest.mark.min_version(duckdb="0.3.3", reason="isnan/isinf unsupported")
 def test_select_filter_mutate(backend, alltypes, df):
     """Test that select, filter and mutate are executed in right order.
 
@@ -688,10 +682,6 @@ def test_zeroifnull_literals(con, dtype, zero, expected):
 
 
 @pytest.mark.notimpl(["datafusion"])
-@pytest.mark.min_version(
-    dask="2022.01.1",
-    reason="unsupported operation with later versions of pandas",
-)
 def test_zeroifnull_column(backend, alltypes, df):
     expr = alltypes.int_col.nullif(1).zeroifnull().name('tmp')
     result = expr.execute().astype("int32")

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -58,7 +58,7 @@ def ctx_col():
 
 
 @pytest.mark.notimpl(["dask", "duckdb"])
-@pytest.mark.min_version(pyspark="3.1")
+@pytest.mark.xfail_version(pyspark=["pyspark<3.1"])
 @pytest.mark.parametrize(
     'window',
     [

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -491,11 +491,8 @@ def test_elementwise_udf_overwrite_destruct_and_assign(udf_backend, udf_alltypes
     udf_backend.assert_frame_equal(result, expected, check_like=True)
 
 
-@pytest.mark.min_version(pyspark="3.1")
-@pytest.mark.parametrize(
-    'method',
-    ['destructure', 'unpack'],
-)
+@pytest.mark.xfail_version(pyspark=["pyspark<3.1"])
+@pytest.mark.parametrize('method', ['destructure', 'unpack'])
 @pytest.mark.skip("dask")
 def test_elementwise_udf_destructure_exact_once(
     udf_backend, udf_alltypes, method, tmp_path

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -80,19 +80,13 @@ def calc_zscore(s):
             lambda t, win: t.id.rank().over(win),
             lambda t: t.id.rank(method='min').astype('int64') - 1,
             id='rank',
-            marks=[
-                pytest.mark.min_server_version(clickhouse="22.8"),
-                pytest.mark.notimpl(["dask"], raises=NotImplementedError),
-            ],
+            marks=[pytest.mark.notimpl(["dask"], raises=NotImplementedError)],
         ),
         param(
             lambda t, win: t.id.dense_rank().over(win),
             lambda t: t.id.rank(method='dense').astype('int64') - 1,
             id='dense_rank',
-            marks=[
-                pytest.mark.min_server_version(clickhouse="22.8"),
-                pytest.mark.notimpl(["dask"], raises=NotImplementedError),
-            ],
+            marks=[pytest.mark.notimpl(["dask"], raises=NotImplementedError)],
         ),
         param(
             lambda t, win: t.id.percent_rank().over(win),
@@ -163,9 +157,9 @@ def calc_zscore(s):
             lambda t: t.cumcount(),
             id='row_number',
             marks=[
-                pytest.mark.notimpl(["pandas"], raises=com.OperationNotDefinedError),
-                pytest.mark.notimpl(["dask"], raises=com.OperationNotDefinedError),
-                pytest.mark.min_server_version(clickhouse="22.8"),
+                pytest.mark.notimpl(
+                    ["dask", "pandas"], raises=com.OperationNotDefinedError
+                )
             ],
         ),
         param(

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -169,6 +169,8 @@ def _clean_join_predicates(left, right, predicates):
             pred = lk == rk
         elif isinstance(pred, str):
             pred = left.to_expr()[pred] == right.to_expr()[pred]
+        elif pred is True or pred is False:
+            pred = ops.Literal(pred, dtype="bool").to_expr()
         elif isinstance(pred, Value):
             pred = pred.to_expr()
         elif isinstance(pred, Deferred):
@@ -177,8 +179,8 @@ def _clean_join_predicates(left, right, predicates):
         elif not isinstance(pred, ir.Expr):
             raise NotImplementedError
 
-        if not isinstance(pred, ir.BooleanColumn):
-            raise com.ExpressionError('Join predicate must be comparison')
+        if not isinstance(pred, ir.BooleanValue):
+            raise com.ExpressionError('Join predicate must be a boolean expression')
 
         preds = an.flatten_predicate(pred.op())
         result.extend(preds)

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -362,9 +362,11 @@ class Limit(TableNode):
 class SelfReference(TableNode):
     table = rlz.table
 
-    @property
+    @attribute.default
     def name(self) -> str:
-        return f"{self.table.name}_ref"
+        if (name := getattr(self.table, "name", None)) is not None:
+            return f"{name}_ref"
+        return util.gen_name("self_ref")
 
     @property
     def schema(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,8 +334,6 @@ markers = [
   "examples: tests that exercise examples",
   "geospatial: tests for geospatial functionality",
   "hdfs: Hadoop file system tests",
-  "min_version: backend tests that require a specific version of a dependency to pass",
-  "min_server_version: backend tests that require a specific version of a backend's server to pass",
   "xfail_version: backend tests that for a specific version of a dependency",
   "notimpl: functionality that isn't implemented in ibis",
   "notyet: for functionality that isn't implemented in a backend",


### PR DESCRIPTION
This PR adds support for literal `True` and `False` join predicates, which are supported across most backends. Closes #6696.