### PR TITLE
fix(bigquery): respect the fully qualified table name at the init

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -234,8 +234,8 @@ class Backend(BaseSQLBackend):
     def table(self, name: str, database: str | None = None) -> ir.TableExpr:
         if database is None:
             database = f"{self.data_project}.{self.current_database}"
-        t = super().table(name, database=database)
         table_id = self._fully_qualified_name(name, database)
+        t = super().table(table_id)
         bq_table = self.client.get_table(table_id)
         return rename_partitioned_column(t, bq_table, self.partition_column)
 

--- a/ibis/backends/bigquery/tests/system/snapshots/test_client/test_cross_project_query/out.sql
+++ b/ibis/backends/bigquery/tests/system/snapshots/test_client/test_cross_project_query/out.sql
@@ -1,6 +1,6 @@
 SELECT t0.`title`, t0.`tags`
 FROM (
   SELECT t1.*
-  FROM `bigquery-public-data.stackoverflow`.posts_questions t1
+  FROM `bigquery-public-data.stackoverflow.posts_questions` t1
   WHERE STRPOS(t1.`tags`, 'ibis') - 1 >= 0
 ) t0

--- a/ibis/backends/bigquery/tests/system/snapshots/test_client/test_subquery_scalar_params/out.sql
+++ b/ibis/backends/bigquery/tests/system/snapshots/test_client/test_subquery_scalar_params/out.sql
@@ -1,6 +1,6 @@
 WITH t0 AS (
   SELECT t2.`float_col`, t2.`timestamp_col`, t2.`int_col`, t2.`string_col`
-  FROM `ibis-gbq.ibis_gbq_testing`.functional_alltypes t2
+  FROM `ibis-gbq.ibis_gbq_testing.functional_alltypes` t2
   WHERE t2.`timestamp_col` < @param_0
 )
 SELECT count(t1.`foo`) AS `count`

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -387,3 +387,9 @@ def test_timestamp_table(con, temp_table):
             ("timestamp_col", dt.Timestamp(timezone="UTC")),
         ]
     )
+
+
+def test_fully_qualified_table_creation(con, project_id, dataset_id, temp_table):
+    schema = ibis.schema({'col1': dt.GeoSpatial(geotype="geography", srid=4326)})
+    t = con.create_table(f"{project_id}.{dataset_id}.{temp_table}", schema=schema)
+    assert t.get_name() == f"{project_id}.{dataset_id}.{temp_table}"

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -254,8 +254,8 @@ def test_multiple_project_queries(con):
     result = join.compile()
     expected = """\
 SELECT t0.`title`
-FROM `bigquery-public-data.stackoverflow`.posts_questions t0
-  INNER JOIN `nyc-tlc.yellow`.trips t1
+FROM `bigquery-public-data.stackoverflow.posts_questions` t0
+  INNER JOIN `nyc-tlc.yellow.trips` t1
     ON t0.`tags` = t1.`rate_code`"""
     assert result == expected
 
@@ -270,8 +270,8 @@ def test_multiple_project_queries_database_api(con):
     result = join.compile()
     expected = """\
 SELECT t0.`title`
-FROM `bigquery-public-data.stackoverflow`.posts_questions t0
-  INNER JOIN `nyc-tlc.yellow`.trips t1
+FROM `bigquery-public-data.stackoverflow.posts_questions` t0
+  INNER JOIN `nyc-tlc.yellow.trips` t1
     ON t0.`tags` = t1.`rate_code`"""
     assert result == expected
 


### PR DESCRIPTION
Dear maintainers

This PR is a simple fix to the https://github.com/ibis-project/ibis/issues/6715 opened by myself.  To be detailed it adds a check on the input table name while initing a Bigquery Table object. If the input name is a fully qualified one, it will use it as it is w/o bothering add the connection default proj and dataset.

To simplify the fix, this PR reused the `_full_qualified_name` method and compare its return with the input name to confirm if the input is fully qualified or not.

Please kindly have a review if it is good to fix #6715 

Thanks

Closes #6715.