### PR TITLE
feat(api): add `concat` and `repeat` methods for easier array operation discovery

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -124,7 +124,7 @@ def _struct_column(translator, op):
 
 
 def _array_concat(translator, op):
-    return "ARRAY_CONCAT({})".format(", ".join(map(translator.translate, op.args)))
+    return "ARRAY_CONCAT({})".format(", ".join(map(translator.translate, op.arg)))
 
 
 def _array_column(translator, op):

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -924,6 +924,12 @@ def _map_get(op, **kw):
     return f"if(mapContains({arg}, {key}), {arg}[{key}], {default})"
 
 
+@translate_val.register(ops.ArrayConcat)
+def _array_concat(op, **kw):
+    args = ", ".join(map(_sql, map(partial(translate_val, **kw), op.arg)))
+    return f"arrayConcat({args})"
+
+
 def _binary_infix(symbol: str):
     def formatter(op, **kw):
         left = translate_val(op_left := op.left, **kw)
@@ -1056,7 +1062,6 @@ _simple_ops = {
     # because clickhouse"s greatest and least doesn"t support varargs
     ops.Where: "if",
     ops.ArrayLength: "length",
-    ops.ArrayConcat: "arrayConcat",
     ops.Unnest: "arrayJoin",
     ops.Degrees: "degrees",
     ops.Radians: "radians",
@@ -1395,7 +1400,7 @@ def _array_remove(op, **kw):
 
 @translate_val.register(ops.ArrayUnion)
 def _array_union(op, **kw):
-    return translate_val(ops.ArrayDistinct(ops.ArrayConcat(op.left, op.right)), **kw)
+    return translate_val(ops.ArrayDistinct(ops.ArrayConcat((op.left, op.right))), **kw)
 
 
 @translate_val.register(ops.ArrayZip)

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+from functools import partial
 
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
@@ -51,3 +52,8 @@ def execute_array_collect(op, data, where, aggcontext=None, **kwargs):
 @execute_node.register(ops.ArrayCollect, ddgb.SeriesGroupBy, type(None))
 def execute_array_collect_grouped_series(op, data, where, **kwargs):
     return data.agg(collect_list)
+
+
+@execute_node.register(ops.ArrayConcat, tuple)
+def execute_array_concat(op, args, **kwargs):
+    return execute_node(op, *map(partial(execute, **kwargs), args), **kwargs)

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -353,7 +353,6 @@ operation_registry.update(
             )
         ),
         ops.TryCast: _try_cast,
-        ops.ArrayConcat: fixed_arity(sa.func.array_concat, 2),
         ops.ArrayRepeat: fixed_arity(
             lambda arg, times: sa.func.flatten(
                 sa.func.array(

--- a/ibis/backends/pandas/dispatch.py
+++ b/ibis/backends/pandas/dispatch.py
@@ -22,8 +22,10 @@ execute_node = TraceTwoLevelDispatcher(
 
 @execute_node.register(ops.Node, [object])
 def raise_unknown_op(node, *args, **kwargs):
+    signature = ", ".join(type(arg).__name__ for arg in args)
     raise com.OperationNotDefinedError(
-        f"Operation {type(node).__name__!r} is not implemented for this backend"
+        "Operation is not implemented for this backend with "
+        f"signature: execute_node({type(node).__name__}, {signature})"
     )
 
 

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -862,12 +862,15 @@ def array_length(op, **kw):
 
 @translate.register(ops.ArrayConcat)
 def array_concat(op, **kw):
-    left = translate(op.left, **kw)
-    right = translate(op.right, **kw)
-    try:
-        return left.arr.concat(right)
-    except AttributeError:
-        return left.list.concat(right)
+    result, *rest = map(partial(translate, **kw), op.arg)
+
+    for arg in rest:
+        try:
+            result = result.arr.concat(arg)
+        except AttributeError:
+            result = result.list.concat(arg)
+
+    return result
 
 
 @translate.register(ops.ArrayColumn)

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -27,6 +27,7 @@ from ibis.backends.base.sql.alchemy import (
     sqlalchemy_operation_registry,
     sqlalchemy_window_functions_registry,
     unary,
+    varargs,
 )
 from ibis.backends.base.sql.alchemy.geospatial import geospatial_supported
 from ibis.backends.base.sql.alchemy.registry import (
@@ -658,7 +659,7 @@ operation_registry.update(
         ops.ArrayIndex: _array_index(
             index_converter=_neg_idx_to_pos, func=lambda arg, index: arg[index]
         ),
-        ops.ArrayConcat: fixed_arity(sa.sql.expression.ColumnElement.concat, 2),
+        ops.ArrayConcat: varargs(lambda *args: functools.reduce(operator.add, args)),
         ops.ArrayRepeat: _array_repeat,
         ops.Unnest: _unnest,
         ops.Covariance: _covar,

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -1008,7 +1008,7 @@ def test_array_concat(array_types, catop):
 
 def test_array_concat_mixed_types(array_types):
     with pytest.raises(TypeError):
-        array_types.x + array_types.x.cast('array<double>')
+        array_types.y + array_types.x.cast('array<double>')
 
 
 @pytest.fixture

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1640,9 +1640,7 @@ def compile_array_index(t, op, **kwargs):
 
 @compiles(ops.ArrayConcat)
 def compile_array_concat(t, op, **kwargs):
-    left = t.translate(op.left, **kwargs)
-    right = t.translate(op.right, **kwargs)
-    return F.concat(left, right)
+    return F.concat(*map(partial(t.translate, **kwargs), op.arg))
 
 
 @compiles(ops.ArrayRepeat)

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import itertools
 
 import numpy as np
@@ -18,6 +19,7 @@ from ibis.backends.base.sql.alchemy.registry import (
     get_sqla_table,
     reduction,
     unary,
+    varargs,
 )
 from ibis.backends.postgres.registry import _literal as _postgres_literal
 from ibis.backends.postgres.registry import operation_registry as _operation_registry
@@ -370,7 +372,9 @@ operation_registry.update(
         ),
         ops.ArrayIndex: fixed_arity(sa.func.get, 2),
         ops.ArrayLength: fixed_arity(sa.func.array_size, 1),
-        ops.ArrayConcat: fixed_arity(sa.func.array_cat, 2),
+        ops.ArrayConcat: varargs(
+            lambda *args: functools.reduce(sa.func.array_cat, args)
+        ),
         ops.ArrayColumn: lambda t, op: sa.func.array_construct(
             *map(t.translate, op.cols)
         ),

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -107,6 +107,33 @@ def test_array_concat(con):
     assert np.array_equal(result, expected)
 
 
+# Issues #2370
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
+def test_array_concat_variadic(con):
+    left = ibis.literal([1, 2, 3])
+    right = ibis.literal([2, 1])
+    expr = left.concat(right, right, right)
+    result = con.execute(expr.name("tmp"))
+    expected = np.array([1, 2, 3, 2, 1, 2, 1, 2, 1])
+    assert np.array_equal(result, expected)
+
+
+# Issues #2370
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(
+    ["postgres", "trino"],
+    raises=sa.exc.ProgrammingError,
+    reason="postgres can't infer the type of an empty array",
+)
+def test_array_concat_some_empty(con):
+    left = ibis.literal([])
+    right = ibis.literal([2, 1])
+    expr = left.concat(right)
+    result = con.execute(expr.name("tmp"))
+    expected = np.array([2, 1])
+    assert np.array_equal(result, expected)
+
+
 @pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_array_radd_concat(con):
     left = [1]

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -11,7 +11,9 @@ from trino.sqlalchemy.datatype import DOUBLE
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
-from ibis.backends.base.sql.alchemy.registry import _literal as _alchemy_literal
+from ibis.backends.base.sql.alchemy.registry import (
+    _literal as _alchemy_literal,
+)
 from ibis.backends.base.sql.alchemy.registry import (
     array_filter,
     array_map,
@@ -21,6 +23,7 @@ from ibis.backends.base.sql.alchemy.registry import (
     sqlalchemy_window_functions_registry,
     try_cast,
     unary,
+    varargs,
 )
 from ibis.backends.postgres.registry import _corr, _covar
 
@@ -328,7 +331,7 @@ operation_registry.update(
         ops.BitwiseRightShift: fixed_arity(sa.func.bitwise_right_shift, 2),
         ops.BitwiseNot: unary(sa.func.bitwise_not),
         ops.ArrayCollect: reduction(sa.func.array_agg),
-        ops.ArrayConcat: fixed_arity(sa.func.concat, 2),
+        ops.ArrayConcat: varargs(sa.func.concat),
         ops.ArrayLength: unary(sa.func.cardinality),
         ops.ArrayIndex: fixed_arity(
             lambda arg, index: sa.func.element_at(arg, index + 1), 2

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -207,7 +207,7 @@ class ArrayValue(Value):
     def __radd__(self, other: ArrayValue) -> ArrayValue:
         return ops.ArrayConcat((other, self)).to_expr()
 
-    def __mul__(self, n: int | ir.IntegerValue) -> ArrayValue:
+    def repeat(self, n: int | ir.IntegerValue) -> ArrayValue:
         """Repeat this array `n` times.
 
         Parameters
@@ -235,7 +235,7 @@ class ArrayValue(Value):
         │ [3]                  │
         │ NULL                 │
         └──────────────────────┘
-        >>> t.a * 2
+        >>> t.a.repeat(2)
         ┏━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ ArrayRepeat(a, 2)    ┃
         ┡━━━━━━━━━━━━━━━━━━━━━━┩
@@ -245,37 +245,9 @@ class ArrayValue(Value):
         │ [3, 3]               │
         │ []                   │
         └──────────────────────┘
-        """
-        return ops.ArrayRepeat(self, n).to_expr()
 
-    def __rmul__(self, n: int | ir.IntegerValue) -> ArrayValue:
-        """Repeat this array `n` times.
+        `repeat` is also available using the `*` operator
 
-        Parameters
-        ----------
-        n
-            Number of times to repeat `self`.
-
-        Returns
-        -------
-        ArrayValue
-            `self` repeated `n` times
-
-        Examples
-        --------
-        >>> import ibis
-        >>> ibis.options.interactive = True
-        >>> t = ibis.memtable({"a": [[7], [3] , None]})
-        >>> t
-        ┏━━━━━━━━━━━━━━━━━━━━━━┓
-        ┃ a                    ┃
-        ┡━━━━━━━━━━━━━━━━━━━━━━┩
-        │ array<int64>         │
-        ├──────────────────────┤
-        │ [7]                  │
-        │ [3]                  │
-        │ NULL                 │
-        └──────────────────────┘
         >>> 2 * t.a
         ┏━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ ArrayRepeat(a, 2)    ┃
@@ -288,6 +260,8 @@ class ArrayValue(Value):
         └──────────────────────┘
         """
         return ops.ArrayRepeat(self, n).to_expr()
+
+    __mul__ = __rmul__ = repeat
 
     def unnest(self) -> ir.Value:
         """Flatten an array into a column.


### PR DESCRIPTION
Make array concatenation and repetition easier to discover.

Closes #6720.