### PR TITLE
test(common, sqlite): make tests pandas<2 compatible

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -4,8 +4,6 @@ import contextlib
 import importlib
 import importlib.metadata
 import itertools
-import os
-import platform
 import sys
 from functools import lru_cache
 from pathlib import Path
@@ -22,15 +20,7 @@ from packaging.version import parse as vparse
 import ibis
 from ibis import util
 from ibis.backends.base import _get_backend_names
-
-SANDBOXED = (
-    any(key.startswith("NIX_") for key in os.environ)
-    and os.environ.get("IN_NIX_SHELL") != "impure"
-)
-LINUX = platform.system() == "Linux"
-MACOS = platform.system() == "Darwin"
-WINDOWS = platform.system() == "Windows"
-CI = os.environ.get("CI") is not None
+from ibis.conftest import WINDOWS
 
 TEST_TABLES = {
     "functional_alltypes": ibis.schema(
@@ -528,7 +518,7 @@ def con(backend):
 
 
 def _setup_backend(request, data_dir, tmp_path_factory, worker_id):
-    if (backend := request.param) == "duckdb" and platform.system() == "Windows":
+    if (backend := request.param) == "duckdb" and WINDOWS:
         pytest.xfail(
             "windows prevents two connections to the same duckdb file "
             "even in the same process"

--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING, Iterator
 import pytest
 
 import ibis
-from ibis.backends.conftest import SANDBOXED, TEST_TABLES
+from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
+from ibis.conftest import SANDBOXED
 
 if TYPE_CHECKING:
     from ibis.backends.base import BaseBackend

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -15,7 +15,7 @@ import pytest
 import ibis
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
-from ibis.backends.conftest import LINUX, SANDBOXED
+from ibis.conftest import LINUX, SANDBOXED
 
 
 def test_read_csv(data_dir):

--- a/ibis/backends/sqlite/tests/test_types.py
+++ b/ibis/backends/sqlite/tests/test_types.py
@@ -4,6 +4,7 @@ import sqlite3
 
 import pandas as pd
 import pytest
+from packaging.version import parse as vparse
 
 import ibis
 import ibis.expr.datatypes as dt
@@ -66,7 +67,9 @@ def test_timestamps(db, table, data):
     t = con.table(table)
     assert t.ts.type() == dt.timestamp
     res = t.ts.execute()
-    stamps = pd.to_datetime(data, format="mixed", utc=True)
+    # the "mixed" format was added in pandas 2.0.0
+    format = "mixed" if vparse(pd.__version__) >= vparse("2.0.0") else None
+    stamps = pd.to_datetime(data, format=format, utc=True)
     # we're casting to timestamp without a timezone, so remove it in the
     # expected output
     localized = stamps.tz_localize(None)

--- a/ibis/backends/tests/test_examples.py
+++ b/ibis/backends/tests/test_examples.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 import ibis
-from ibis.backends.conftest import LINUX, SANDBOXED
+from ibis.conftest import LINUX, SANDBOXED
 
 pytestmark = pytest.mark.examples
 

--- a/ibis/conftest.py
+++ b/ibis/conftest.py
@@ -2,10 +2,20 @@ from __future__ import annotations
 
 import builtins
 import os
+import platform
 
 import pytest
 
 import ibis
+
+SANDBOXED = (
+    any(key.startswith("NIX_") for key in os.environ)
+    and os.environ.get("IN_NIX_SHELL") != "impure"
+)
+LINUX = platform.system() == "Linux"
+MACOS = platform.system() == "Darwin"
+WINDOWS = platform.system() == "Windows"
+CI = os.environ.get("CI") is not None
 
 
 @pytest.fixture(autouse=True)

--- a/ibis/examples/tests/test_examples.py
+++ b/ibis/examples/tests/test_examples.py
@@ -6,7 +6,7 @@ import pytest
 
 import ibis.examples
 import ibis.util
-from ibis.backends.conftest import CI, LINUX, SANDBOXED
+from ibis.conftest import CI, LINUX, SANDBOXED
 
 pytestmark = pytest.mark.examples
 


### PR DESCRIPTION
This PR makes a couple of tests compatible with pandas < 2, for package managers that have not yet upgraded to pandas >= 2.