### PR TITLE
fix(sql): handle aliases when parsing sql into ibis code

### DIFF
--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -60,6 +60,13 @@ class Catalog(Dict[str, sch.Schema]):
 
     def overlay(self, step):
         updates = {dep.name: convert(dep, catalog=self) for dep in step.dependencies}
+
+        # handle scan aliases: FROM foo AS bar
+        source = getattr(step, "source", None)
+        alias = getattr(source, "args", {}).get("alias")
+        if alias is not None and (source_name := self.get(source.name)) is not None:
+            self[alias.name] = source_name
+
         return Catalog({**self, **updates})
 
 

--- a/ibis/tests/expr/test_sql.py
+++ b/ibis/tests/expr/test_sql.py
@@ -112,3 +112,9 @@ def test_parse_sql_simple_select_count():
     sql = """SELECT COUNT(first_name) FROM employee"""
     expr = ibis.parse_sql(sql, catalog)
     code = ibis.decompile(expr, format=True)  # noqa: F841
+
+
+def test_parse_sql_table_alias():
+    sql = """SELECT e.* FROM employee AS e"""
+    expr = ibis.parse_sql(sql, catalog)
+    code = ibis.decompile(expr, format=True)  # noqa: F841


### PR DESCRIPTION
Fixes #6723.