### PR TITLE
feat(api): add support for `table_expr.nunique(where=...)`

### DIFF
--- a/ci/udf/CMakeLists.txt
+++ b/ci/udf/CMakeLists.txt
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project(impala_test_udfs LANGUAGES CXX)
 cmake_minimum_required(VERSION 3.22)
+
+project(impala_test_udfs LANGUAGES CXX)
 set(CMAKE_CXX_COMPILER clang++)
 
 # where to put generated libraries and binaries

--- a/ibis/backends/base/sql/alchemy/translator.py
+++ b/ibis/backends/base/sql/alchemy/translator.py
@@ -47,6 +47,7 @@ class AlchemyExprTranslator(ExprTranslator):
 
     _bool_aggs_need_cast_to_int32 = True
     _has_reduction_filter_syntax = False
+    _supports_tuple_syntax = False
     _integer_to_timestamp = staticmethod(sa.func.to_timestamp)
     _timestamp_type = sa.TIMESTAMP
 

--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -653,6 +653,12 @@ def table_column(translator, op):
     return quoted_name
 
 
+def _count_distinct_star(t, op):
+    raise com.UnsupportedOperationError(
+        "BigQuery doesn't support COUNT(DISTINCT ...) with multiple columns"
+    )
+
+
 OPERATION_REGISTRY = {
     **operation_registry,
     # Literal
@@ -800,6 +806,7 @@ OPERATION_REGISTRY = {
     ops.StartsWith: fixed_arity("STARTS_WITH", 2),
     ops.EndsWith: fixed_arity("ENDS_WITH", 2),
     ops.TableColumn: table_column,
+    ops.CountDistinctStar: _count_distinct_star,
 }
 
 _invalid_operations = {

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -1412,3 +1412,12 @@ def _array_zip(op: ops.ArrayZip, **kw: Any) -> str:
             sql_arg = sql_arg.sql(dialect="clickhouse")
         arglist.append(sql_arg)
     return f"arrayZip({', '.join(arglist)})"
+
+
+@translate_val.register(ops.CountDistinctStar)
+def _count_distinct_star(op: ops.CountDistinctStar, **kw: Any) -> str:
+    column_list = ", ".join(map(_sql, map(sg.column, op.arg.schema.names)))
+    if op.where is not None:
+        return f"countDistinctIf(({column_list}), {translate_val(op.where, **kw)})"
+    else:
+        return f"countDistinct(({column_list}))"

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -45,6 +45,8 @@ from ibis.backends.pandas.execution.generic import (
     execute_between,
     execute_cast_series_array,
     execute_cast_series_generic,
+    execute_count_distinct_star_frame,
+    execute_count_distinct_star_frame_filter,
     execute_count_star_frame,
     execute_count_star_frame_filter,
     execute_count_star_frame_groupby,
@@ -106,6 +108,14 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
         ),
         ((dd.DataFrame, type(None)), execute_count_star_frame),
         ((dd.DataFrame, dd.Series), execute_count_star_frame_filter),
+    ],
+    ops.CountDistinctStar: [
+        (
+            (ddgb.DataFrameGroupBy, type(None)),
+            execute_count_star_frame_groupby,
+        ),
+        ((dd.DataFrame, type(None)), execute_count_distinct_star_frame),
+        ((dd.DataFrame, dd.Series), execute_count_distinct_star_frame_filter),
     ],
     ops.NullIfZero: [((dd.Series,), execute_null_if_zero_series)],
     ops.Between: [

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -14,7 +14,9 @@ class DuckDBSQLExprTranslator(AlchemyExprTranslator):
     _registry = operation_registry
     _rewrites = AlchemyExprTranslator._rewrites.copy()
     _has_reduction_filter_syntax = True
+    _supports_tuple_syntax = True
     _dialect_name = "duckdb"
+
     type_mapper = DuckDBType
 
 

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1157,3 +1157,11 @@ def execute_view(op, *, ctx: pl.SQLContext, **kw):
 @translate.register(ops.SelfReference)
 def execute_self_reference(op, **kw):
     return translate(op.table, **kw)
+
+
+@translate.register(ops.CountDistinctStar)
+def execute_count_distinct_star(op, **kw):
+    arg = pl.struct(*op.arg.schema.names)
+    if op.where is not None:
+        arg = arg.filter(translate(op.where, **kw))
+    return arg.n_unique()

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -15,6 +15,7 @@ class PostgreSQLExprTranslator(AlchemyExprTranslator):
     _registry = operation_registry.copy()
     _rewrites = AlchemyExprTranslator._rewrites.copy()
     _has_reduction_filter_syntax = True
+    _supports_tuple_syntax = True
     _dialect_name = "postgresql"
 
     # it does support it, but we can't use it because of support for pivot

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -582,6 +582,21 @@ def compile_count_star(t, op, aggcontext=None, **kwargs):
         return src_table.select(col)
 
 
+@compiles(ops.CountDistinctStar)
+def compile_count_distinct_star(t, op, aggcontext=None, **kwargs):
+    src_table = t.translate(op.arg, **kwargs)
+    src_col = F.struct(*map(F.col, op.arg.schema.names))
+
+    if (where := op.where) is not None:
+        src_col = F.when(t.translate(where, **kwargs), src_col)
+
+    src_col = F.countDistinct(src_col)
+    if aggcontext is not None:
+        return src_col
+    else:
+        return src_table.select(src_col)
+
+
 @compiles(ops.Max)
 @compiles(ops.CumulativeMax)
 def compile_max(t, op, **kwargs):

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -12,6 +12,7 @@ class TrinoSQLExprTranslator(AlchemyExprTranslator):
     _registry = operation_registry.copy()
     _rewrites = AlchemyExprTranslator._rewrites.copy()
     _has_reduction_filter_syntax = True
+    _supports_tuple_syntax = True
     _integer_to_timestamp = staticmethod(sa.func.from_unixtime)
 
     _forbids_frame_clause = (

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -38,6 +38,13 @@ class CountStar(Filterable, Reduction):
 
 
 @public
+class CountDistinctStar(Filterable, Reduction):
+    arg = rlz.table
+
+    output_dtype = dt.int64
+
+
+@public
 class Arbitrary(Filterable, Reduction):
     arg = rlz.column(rlz.any)
     how = rlz.isin({'first', 'last', 'heavy'})

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2012,6 +2012,41 @@ class Table(Expr, _FixedTextJupyterMixin):
         ]
         return an.apply_filter(self.op(), predicates).to_expr()
 
+    def nunique(self, where: ir.BooleanValue | None = None) -> ir.IntegerScalar:
+        """Compute the number of unique rows in the table.
+
+        Parameters
+        ----------
+        where
+            Optional boolean expression to filter rows when counting.
+
+        Returns
+        -------
+        IntegerScalar
+            Number of unique rows in the table
+
+        Examples
+        --------
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.memtable({"a": ["foo", "bar", "bar"]})
+        >>> t
+        ┏━━━━━━━━┓
+        ┃ a      ┃
+        ┡━━━━━━━━┩
+        │ string │
+        ├────────┤
+        │ foo    │
+        │ bar    │
+        │ bar    │
+        └────────┘
+        >>> t.nunique()
+        2
+        >>> t.nunique(t.a != "foo")
+        1
+        """
+        return ops.CountDistinctStar(self, where=where).to_expr()
+
     def count(self, where: ir.BooleanValue | None = None) -> ir.IntegerScalar:
         """Compute the number of rows in the table.
 


### PR DESCRIPTION
Add support for `table_expr.nunique(where=...)`. Closes #6683.