### PR TITLE
feat(common): match and replace graph nodes

### DIFF
--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -14,6 +14,7 @@ import ibis.expr.types as ir
 from ibis.backends.base import BaseBackend, Database
 from ibis.backends.polars.compiler import translate
 from ibis.backends.polars.datatypes import dtype_to_polars, schema_from_polars
+from ibis.common.patterns import Replace
 from ibis.util import gen_name, normalize_filename
 
 if TYPE_CHECKING:
@@ -353,12 +354,14 @@ class Backend(BaseBackend):
     ):
         node = expr.op()
         ctx = self._context
+
         if params:
-            replacements = {}
-            for p, v in params.items():
-                op = p.op() if isinstance(p, ir.Expr) else p
-                replacements[op] = ibis.literal(v, type=op.dtype).op()
-            node = node.replace(replacements)
+            params = {param.op(): value for param, value in params.items()}
+            rule = Replace(
+                ops.ScalarParameter,
+                lambda op, ctx: ops.Literal(value=params[op], dtype=op.dtype),
+            )
+            node = node.replace(rule)
             expr = node.to_expr()
 
         node = expr.as_table().op()

--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -104,55 +104,6 @@ class Node(Hashable):
         """Support for rich reprerentation of the node."""
         return zip(self.__argnames__, self.__args__)
 
-    @experimental
-    def branches(self) -> Iterator[Sequence[Node]]:
-        """Yield all branches of the graph.
-
-        A branch is a path from the root to a leaf node. This method is primarily
-        used to implement the `path` method supporting `XPath`-like queries.
-
-        Yields
-        ------
-        A sequence of nodes representing a branch.
-        """
-        stack = [(self, [])]
-
-        while stack:
-            node, path = stack.pop()
-
-            if children := node.__children__():
-                for child in reversed(children):
-                    stack.append((child, path + [node]))
-            else:
-                yield path + [node]
-
-    @experimental
-    def path(
-        self, *pats: Any, context: Optional[dict] = None
-    ) -> Iterator[Sequence[Node]]:
-        """Return the first tree branch matching a given sequence pattern.
-
-        This method provides a way to query the graph using `XPath`-like expressions.
-        The following XPath expression "//Alias//Value[dtype==int64]" would roughly
-        translate to the following Python code:
-
-            node.path(..., Alias, ..., Object(Value, dtype=dt.Int64), ...)
-
-        Parameters
-        ----------
-        pats
-            Sequence which is coerced to a sequence pattern. See `ibis.common.patterns`
-            for more details.
-        context
-            Optional context to use for the pattern matching.
-        """
-        pat = pattern(list(pats))
-        for branch in self.branches():
-            result = pat.match(branch, context)
-            if result is not NoMatch:
-                return result
-        return NoMatch
-
     def map(self, fn: Callable, filter: Optional[type] = None) -> dict[Node, Any]:
         """Apply a function to all nodes in the graph.
 

--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -4,66 +4,19 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections import deque
 from collections.abc import Hashable, Iterable, Iterator, Mapping
-from typing import Any, Callable, Dict, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence
 
-from ibis.util import recursive_get
+from ibis.common.patterns import NoMatch, pattern
+from ibis.util import experimental
 
-
-class Node(Hashable):
-    __slots__ = ()
-
-    @property
-    @abstractmethod
-    def __args__(self) -> Sequence:
-        ...
-
-    @property
-    @abstractmethod
-    def __argnames__(self) -> Sequence:
-        ...
-
-    def __children__(self, filter=None):
-        return tuple(_flatten_collections(self.__args__, filter or Node))
-
-    def __rich_repr__(self):
-        return zip(self.__argnames__, self.__args__)
-
-    def map(self, fn, filter=None):
-        results = {}
-        for node in Graph.from_bfs(self, filter=filter).toposort():
-            kwargs = dict(zip(node.__argnames__, node.__args__))
-            kwargs = recursive_get(kwargs, results)
-            results[node] = fn(node, results, **kwargs)
-
-        return results
-
-    def find(self, type, filter=None):
-        def fn(node, _, **kwargs):
-            if isinstance(node, type):
-                return node
-            return None
-
-        result = self.map(fn, filter=filter)
-
-        return {node for node in result.values() if node is not None}
-
-    def substitute(self, fn, filter=None):
-        return self.map(fn, filter=filter)[self]
-
-    def replace(self, subs, filter=None):
-        def fn(node, _, **kwargs):
-            try:
-                return subs[node]
-            except KeyError:
-                return node.__class__(**kwargs)
-
-        return self.substitute(fn, filter=filter)
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
-def _flatten_collections(node, filter=Node):
+def _flatten_collections(node: Node, filter: type) -> Iterator[Node]:
     """Flatten collections of nodes into a single iterator.
 
-    We treat common collection types inherently Node (e.g. list, tuple, dict)
+    We treat common collection types inherently traversable (e.g. list, tuple, dict)
     but as undesired in a graph representation, so we traverse them implicitly.
 
     Parameters
@@ -90,14 +43,263 @@ def _flatten_collections(node, filter=Node):
             yield from _flatten_collections(value, filter)
 
 
+def _recursive_get(obj: Any, dct: dict[Node, Any]) -> Any:
+    """Recursively replace objects in a nested structure with values from a dict.
+
+    Since we treat collection types inherently traversable (e.g. list, tuple, dict) we
+    need to traverse them implicitly and replace the values given a result mapping.
+
+    Parameters
+    ----------
+    obj : Any
+        Object to replace.
+    dct : dict[Node, Any]
+        Mapping of objects to replace with their values.
+
+    Returns
+    -------
+    Object with replaced values.
+    """
+    if isinstance(obj, tuple):
+        return tuple(_recursive_get(o, dct) for o in obj)
+    elif isinstance(obj, dict):
+        return {k: _recursive_get(v, dct) for k, v in obj.items()}
+    else:
+        return dct.get(obj, obj)
+
+
+class Node(Hashable):
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def __args__(self) -> tuple[Any, ...]:
+        """Sequence of arguments to traverse."""
+
+    @property
+    @abstractmethod
+    def __argnames__(self) -> tuple[str, ...]:
+        """Sequence of argument names."""
+
+    def __children__(self, filter: Optional[type] = None) -> tuple[Node, ...]:
+        """Return the children of this node.
+
+        This method is used to traverse the Node so it returns the children of the node
+        in the order they should be traversed. We treat common collection types
+        inherently traversable (e.g. list, tuple, dict), so this method flattens and
+        optionally filters the arguments of the node.
+
+        Parameters
+        ----------
+        filter : type, default Node
+            Type to filter out for the traversal, Node is used by default.
+
+        Returns
+        -------
+        Child nodes of this node.
+        """
+        return tuple(_flatten_collections(self.__args__, filter or Node))
+
+    def __rich_repr__(self):
+        """Support for rich reprerentation of the node."""
+        return zip(self.__argnames__, self.__args__)
+
+    @experimental
+    def branches(self) -> Iterator[Sequence[Node]]:
+        """Yield all branches of the graph.
+
+        A branch is a path from the root to a leaf node. This method is primarily
+        used to implement the `path` method supporting `XPath`-like queries.
+
+        Yields
+        ------
+        A sequence of nodes representing a branch.
+        """
+        stack = [(self, [])]
+
+        while stack:
+            node, path = stack.pop()
+
+            if children := node.__children__():
+                for child in reversed(children):
+                    stack.append((child, path + [node]))
+            else:
+                yield path + [node]
+
+    @experimental
+    def path(
+        self, *pats: Any, context: Optional[dict] = None
+    ) -> Iterator[Sequence[Node]]:
+        """Return the first tree branch matching a given sequence pattern.
+
+        This method provides a way to query the graph using `XPath`-like expressions.
+        The following XPath expression "//Alias//Value[dtype==int64]" would roughly
+        translate to the following Python code:
+
+            node.path(..., Alias, ..., Object(Value, dtype=dt.Int64), ...)
+
+        Parameters
+        ----------
+        pats
+            Sequence which is coerced to a sequence pattern. See `ibis.common.patterns`
+            for more details.
+        context
+            Optional context to use for the pattern matching.
+        """
+        pat = pattern(list(pats))
+        for branch in self.branches():
+            result = pat.match(branch, context)
+            if result is not NoMatch:
+                return result
+        return NoMatch
+
+    def map(self, fn: Callable, filter: Optional[type] = None) -> dict[Node, Any]:
+        """Apply a function to all nodes in the graph.
+
+        The traversal is done in a topological order, so the function receives the
+        results of its immediate children as keyword arguments.
+
+        Parameters
+        ----------
+        fn : Callable
+            Function to apply to each node. It receives the node as the first argument,
+            the results as the second and the results of the children as keyword
+            arguments.
+        filter : Optional[type], default None
+            Type to filter out for the traversal, Node is filtered out by default.
+
+        Returns
+        -------
+        A mapping of nodes to their results.
+        """
+        results = {}
+        for node in Graph.from_bfs(self, filter=filter).toposort():
+            kwargs = dict(zip(node.__argnames__, node.__args__))
+            kwargs = _recursive_get(kwargs, results)
+            results[node] = fn(node, results, **kwargs)
+        return results
+
+    def find(
+        self, type: type | tuple[type], filter: Optional[type] = None
+    ) -> set[Node]:
+        """Find all nodes of a given type in the graph.
+
+        Parameters
+        ----------
+        type : type | tuple[type]
+            Type or tuple of types to find.
+        filter : Optional[type], default None
+            Type to filter out for the traversal, Node is filtered out by default.
+
+        Returns
+        -------
+        The set of nodes matching the given type.
+        """
+        nodes = Graph.from_bfs(self, filter=filter).nodes()
+        return {node for node in nodes if isinstance(node, type)}
+
+    @experimental
+    def match(
+        self, pat: Any, filter: Optional[type] = None, context: Optional[dict] = None
+    ) -> set[Node]:
+        """Find all nodes matching a given pattern in the graph.
+
+        A more advanced version of find, this method allows to match nodes based on
+        the more flexible pattern matching system implemented in the pattern module.
+
+        Parameters
+        ----------
+        pat : Any
+            Pattern to match. `ibis.common.pattern()` function is used to coerce the
+            input value into a pattern. See the pattern module for more details.
+        filter : Optional[type], default None
+            Type to filter out for the traversal, Node is filtered out by default.
+        context : Optional[dict], default None
+            Optional context to use for the pattern matching.
+
+        Returns
+        -------
+        The set of nodes matching the given pattern.
+        """
+        pat = pattern(pat)
+        ctx = context or {}
+        nodes = Graph.from_bfs(self, filter=filter).nodes()
+        return {node for node in nodes if pat.is_match(node, ctx)}
+
+    @experimental
+    def replace(
+        self, pat: Any, filter: Optional[type] = None, context: Optional[dict] = None
+    ) -> Any:
+        """Match and replace nodes in the graph according to a given pattern.
+
+        The pattern matching system is used to match nodes in the graph and replace them
+        with the results of the pattern.
+
+        Parameters
+        ----------
+        pat : Any
+            Pattern to match. `ibis.common.pattern()` function is used to coerce the
+            input value into a pattern. See the pattern module for more details.
+            Actual replacement is done by the `ibis.common.pattern.Replace` pattern.
+        filter : Optional[type], default None
+            Type to filter out for the traversal, Node is filtered out by default.
+        context : Optional[dict], default None
+            Optional context to use for the pattern matching.
+
+        Returns
+        -------
+        The root node of the graph with the replaced nodes.
+        """
+        pat = pattern(pat)
+        ctx = context or {}
+
+        def fn(node, _, **kwargs):
+            # TODO(kszucs): pass the reconstructed node from the results provided by the
+            # kwargs to the pattern rather than the original one node object, this way
+            # we can match on already replaced nodes
+            if (result := pat.match(node, ctx)) is NoMatch:
+                return node.__class__(**kwargs)
+            else:
+                return result
+
+        return self.map(fn, filter=filter)[self]
+
+
 class Graph(Dict[Node, Sequence[Node]]):
+    """A mapping-like graph data structure for easier graph traversal and manipulation.
+
+    The data structure is a mapping of nodes to their children. The children are
+    represented as a sequence of nodes. The graph can be constructed from a root node
+    using the `from_bfs` or `from_dfs` class methods.
+
+    Parameters
+    ----------
+    mapping : Node or Mapping[Node, Sequence[Node]], default ()
+        Either a root node or a mapping of nodes to their children.
+    """
+
     def __init__(self, mapping=(), /, **kwargs):
         if isinstance(mapping, Node):
             mapping = self.from_bfs(mapping)
         super().__init__(mapping, **kwargs)
 
     @classmethod
-    def from_bfs(cls, root: Node, filter=Node) -> Graph:
+    def from_bfs(cls, root: Node, filter=Node) -> Self:
+        """Construct a graph from a root node using a breadth-first search.
+
+        The traversal is implemented in an iterative fashion using a queue.
+
+        Parameters
+        ----------
+        root : Node
+            Root node of the graph.
+        filter : Optional[type], default None
+            Type to filter out for the traversal, Node is filtered out by default.
+
+        Returns
+        -------
+        A graph constructed from the root node.
+        """
         if not isinstance(root, Node):
             raise TypeError("node must be an instance of ibis.common.graph.Node")
 
@@ -112,7 +314,22 @@ class Graph(Dict[Node, Sequence[Node]]):
         return graph
 
     @classmethod
-    def from_dfs(cls, root: Node, filter=Node) -> Graph:
+    def from_dfs(cls, root: Node, filter=Node) -> Self:
+        """Construct a graph from a root node using a depth-first search.
+
+        The traversal is implemented in an iterative fashion using a stack.
+
+        Parameters
+        ----------
+        root : Node
+            Root node of the graph.
+        filter : Optional[type], default None
+            Type to filter out for the traversal, Node is filtered out by default.
+
+        Returns
+        -------
+        A graph constructed from the root node.
+        """
         if not isinstance(root, Node):
             raise TypeError("node must be an instance of ibis.common.graph.Node")
 
@@ -129,17 +346,38 @@ class Graph(Dict[Node, Sequence[Node]]):
     def __repr__(self):
         return f"{self.__class__.__name__}({super().__repr__()})"
 
-    def nodes(self):
+    def nodes(self) -> set[Node]:
+        """Return all unique nodes in the graph."""
         return self.keys()
 
-    def invert(self) -> Graph:
+    def invert(self) -> Self:
+        """Invert the data structure.
+
+        The graph originally maps nodes to their children, this method inverts the
+        mapping to map nodes to their parents.
+
+        Returns
+        -------
+        The inverted graph.
+        """
         result = {node: [] for node in self}
         for node, dependencies in self.items():
             for dependency in dependencies:
                 result[dependency].append(node)
         return self.__class__({k: tuple(v) for k, v in result.items()})
 
-    def toposort(self) -> Graph:
+    def toposort(self) -> Self:
+        """Topologically sort the graph using Kahn's algorithm.
+
+        The graph is sorted in a way that all the dependencies of a node are placed
+        before the node itself. The graph must not contain any cycles. Especially useful
+        for mutating the graph in a way that the dependencies of a node are mutated
+        before the node itself.
+
+        Returns
+        -------
+        The topologically sorted graph.
+        """
         dependents = self.invert()
         in_degree = {k: len(v) for k, v in self.items()}
 
@@ -162,14 +400,47 @@ class Graph(Dict[Node, Sequence[Node]]):
 
 
 def bfs(node: Node) -> Graph:
+    """Construct a graph from a root node using a breadth-first search.
+
+    Parameters
+    ----------
+    node : Node
+        Root node of the graph.
+
+    Returns
+    -------
+    A graph constructed from the root node.
+    """
     return Graph.from_bfs(node)
 
 
 def dfs(node: Node) -> Graph:
+    """Construct a graph from a root node using a depth-first search.
+
+    Parameters
+    ----------
+    node : Node
+        Root node of the graph.
+
+    Returns
+    -------
+    A graph constructed from the root node.
+    """
     return Graph.from_dfs(node)
 
 
 def toposort(node: Node) -> Graph:
+    """Construct a graph from a root node then topologically sort it.
+
+    Parameters
+    ----------
+    node : Node
+        Root node of the graph.
+
+    Returns
+    -------
+    A topologically sorted graph constructed from the root node.
+    """
     return Graph(node).toposort()
 
 

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -1044,19 +1044,6 @@ def test_topmost_innermost():
     assert context == {"a": Lit(2), "b": one}
 
 
-def test_graph_path():
-    p = Object(Mul, left="lit" @ Object(Lit))
-    ctx = {}
-    r = p.match(two, ctx)
-    assert r == two
-    assert ctx["lit"] == Lit(2)
-
-    ctx = {}
-    r = six.path(..., Object(Mul, left="lit" @ Object(Lit)), ..., context=ctx)
-    assert ctx["lit"] == Lit(2)
-    assert r == [six, two, Lit(2)]
-
-
 def test_node():
     pat = Node(
         InstanceOf(Add),

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -14,6 +14,10 @@ import ibis.expr.types as ir
 from ibis import util
 from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import IbisTypeError, IntegrityError
+from ibis.common.patterns import Call, Object
+
+p = Object.namespace(ops)
+c = Call.namespace(ops)
 
 # ---------------------------------------------------------------------
 # Some expression metaprogramming / graph transformations to support
@@ -177,13 +181,13 @@ def substitute_unbound(node):
     """Rewrite `node` by replacing table expressions with an equivalent unbound table."""
     assert isinstance(node, ops.Node), type(node)
 
-    def fn(node, _, *args, **kwargs):
+    def fn(node, _, **kwargs):
         if isinstance(node, ops.DatabaseTable):
             return ops.UnboundTable(name=node.name, schema=node.schema)
         else:
-            return node.__class__(*args, **kwargs)
+            return node.__class__(**kwargs)
 
-    return node.substitute(fn)
+    return node.map(fn)[node]
 
 
 def get_mutation_exprs(exprs: list[ir.Expr], table: ir.Table) -> list[ir.Expr | None]:

--- a/ibis/tests/expr/test_operations.py
+++ b/ibis/tests/expr/test_operations.py
@@ -12,6 +12,7 @@ import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
 import ibis.expr.types as ir
 from ibis.common.annotations import ValidationError
+from ibis.common.patterns import EqualTo
 
 t = ibis.table([("a", "int64")], name="t")
 
@@ -162,9 +163,11 @@ def test_node_subtitution():
         name: str
 
     ketto = Aliased(one, "ketto")
-    subs = {Name("one"): Name("zero"), two: ketto}
 
-    new_values = values.replace(subs)
+    first_rule = EqualTo(Name("one")) >> Name("zero")
+    second_rule = EqualTo(two) >> ketto
+
+    new_values = values.replace(first_rule | second_rule)
     expected = Values((NamedValue(value=1, name=Name("zero")), ketto, three))
 
     assert expected == new_values

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -351,16 +351,6 @@ def consume(iterator: Iterator[T], n: int | None = None) -> None:
         next(itertools.islice(iterator, n, n), None)
 
 
-# TODO(kszucs): make it a more robust to better align with graph._flatten_collections()
-def recursive_get(obj, mapping):
-    if isinstance(obj, tuple):
-        return tuple(recursive_get(o, mapping) for o in obj)
-    elif isinstance(obj, dict):
-        return {k: recursive_get(v, mapping) for k, v in obj.items()}
-    else:
-        return mapping.get(obj, obj)
-
-
 def flatten_iterable(iterable):
     """Recursively flatten the iterable `iterable`."""
     if not is_iterable(iterable):


### PR DESCRIPTION
This PR adds a `Node.match()` and `Node.replace()` methods to do search and replace tasks on node/operation trees. 

While `Node.match()` can return with nodes rewritten by the pattern, `Node.replace()` actually rebuilds the whole expression so the first is suitable for matching tasks while the latter is to rewrite operation trees.

Examples:

```py
# replace scalar parameters with the provided values prior to execution
from ibis.common.patterns import Replace

rule = Replace(
    ops.ScalarParameter,
    lambda op, ctx: ops.Literal(value=params[op], dtype=op.dtype),
)
node = node.replace(rule)
```

```py
# compose two replace rules
from ibis.common.patterns import EqualTo

class Aliased: ...
class Name: ...

ketto = Aliased(one, "ketto")

first_rule = EqualTo(Name("one")) >> Name("zero")
second_rule = EqualTo(two) >> ketto

new_values = values.replace(first_rule | second_rule)
```

```py
# propagate windows down in the expression tree
from ibis.common.patterns import Variable, Object, Call

col = ...
expected_frame = ...

func = Variable("func")
frame = Variable("frame")

p = Object.namespace(ops)
c = Call.namespace(ops)

pattern = Node(
    p.Value & ~p.WindowFunction,
    each_arg=func @ p.Analytic >> c.WindowFunction(func, frame),
)
result = col.replace(pattern, context={frame: expected_frame})
```

Also:
- move `util.recursive_get()` to `ibis.common.graph`
- add docstrings to `ibis.common.graph`
- improve docstrings for `ibis.common.patterns`