### PR TITLE
feat(trino): add support for table properties

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - clickhouse:/var/lib/clickhouse/user_files/ibis
     networks:
       - clickhouse
+
   impala:
     depends_on:
       - impala-postgres
@@ -45,6 +46,7 @@ services:
       - 25020:25020
     networks:
       - impala
+
   impala-postgres:
     user: postgres
     hostname: postgres
@@ -60,6 +62,7 @@ services:
     image: postgres:13.11-alpine
     networks:
       - impala
+
   kudu:
     cap_add:
       - SYS_TIME
@@ -80,6 +83,7 @@ services:
         - CMD-SHELL
         - kudu cluster ksck kudu:7051
       timeout: 10s
+
   kudu-tserver:
     cap_add:
       - SYS_TIME
@@ -98,6 +102,7 @@ services:
         - CMD-SHELL
         - kudu cluster ksck kudu:7051
       timeout: 10s
+
   mysql:
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -120,6 +125,7 @@ services:
     volumes:
       - mysql:/data
       - $PWD/docker/mysql:/docker-entrypoint-initdb.d:ro
+
   postgres:
     user: postgres
     environment:
@@ -159,6 +165,7 @@ services:
       - mssql:/data
     networks:
       - mssql
+
   trino-postgres:
     user: postgres
     environment:
@@ -180,9 +187,48 @@ services:
       - trino
     volumes:
       - trino-postgres:/data
+
+  hive-metastore-mariadb:
+    image: mariadb:10.11.4
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+      MYSQL_USER: admin
+      MYSQL_PASSWORD: admin
+      MYSQL_DATABASE: metastore_db
+    healthcheck:
+      interval: 1s
+      retries: 30
+      test:
+        - CMD
+        - mariadb-admin
+        - ping
+      timeout: 5s
+    networks:
+      - trino
+
+  hive-metastore-minio:
+    image: minio/minio:latest
+    environment:
+      - MINIO_ACCESS_KEY=accesskey
+      - MINIO_SECRET_KEY=secretkey
+    entrypoint: sh
+    command: -c 'mkdir -p /data/warehouse && /opt/bin/minio server /data'
+    networks:
+      - trino
+
+  hive-metastore:
+    build: ./docker/trino
+    image: ibis-hive-metastore
+    depends_on:
+      - hive-metastore-mariadb
+      - hive-metastore-minio
+    networks:
+      - trino
+
   trino:
     depends_on:
       - trino-postgres
+      - hive-metastore
     healthcheck:
       interval: 5s
       retries: 10
@@ -198,6 +244,7 @@ services:
     volumes:
       - $PWD/docker/trino/catalog/postgresql.properties:/etc/trino/catalog/postgresql.properties:ro
       - $PWD/docker/trino/catalog/memory.properties:/etc/trino/catalog/memory.properties:ro
+      - $PWD/docker/trino/catalog/hive.properties:/etc/trino/catalog/hive.properties:ro
       - $PWD/docker/trino/jvm.config:/etc/trino/jvm.config:ro
 
   druid-postgres:

--- a/docker/trino/Dockerfile
+++ b/docker/trino/Dockerfile
@@ -1,0 +1,31 @@
+FROM openjdk:8u342-jre
+
+WORKDIR /opt
+
+ENV HADOOP_VERSION=3.2.0
+ENV METASTORE_VERSION=3.0.0
+
+ENV HADOOP_HOME=/opt/hadoop-${HADOOP_VERSION}
+ENV HIVE_HOME=/opt/apache-hive-metastore-${METASTORE_VERSION}-bin
+
+RUN apt-get update \
+ && apt-get install --assume-yes procps telnet \
+ && apt-get clean \
+ && curl -L https://apache.org/dist/hive/hive-standalone-metastore-${METASTORE_VERSION}/hive-standalone-metastore-${METASTORE_VERSION}-bin.tar.gz | tar zxf - && \
+    curl -L https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar zxf - && \
+    curl -L https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.19.tar.gz | tar zxf - && \
+    cp mysql-connector-java-8.0.19/mysql-connector-java-8.0.19.jar ${HIVE_HOME}/lib/ && \
+    rm -rf mysql-connector-java-8.0.19
+
+COPY ./metastore-site.xml ${HIVE_HOME}/conf
+COPY ./entrypoint.sh /entrypoint.sh
+
+RUN groupadd -r hive --gid=1000 && \
+    useradd -r -g hive --uid=1000 -d ${HIVE_HOME} hive && \
+    chown hive:hive -R ${HIVE_HOME} && \
+    chown hive:hive /entrypoint.sh && chmod +x /entrypoint.sh
+
+USER hive
+EXPOSE 9083
+
+ENTRYPOINT ["sh", "-c", "/entrypoint.sh"]

--- a/docker/trino/catalog/hive.properties
+++ b/docker/trino/catalog/hive.properties
@@ -1,0 +1,15 @@
+connector.name=hive
+
+hive.allow-drop-table=true
+hive.ignore-absent-partitions=true
+hive.metastore.thrift.delete-files-on-drop=true
+hive.metastore.uri=thrift://hive-metastore:9083
+hive.metastore.username=admin
+hive.non-managed-table-writes-enabled=true
+hive.s3.aws-access-key=accesskey
+hive.s3.aws-secret-key=secretkey
+hive.s3.endpoint=http://hive-metastore-minio:9000
+hive.s3.path-style-access=true
+hive.s3select-pushdown.enabled=true
+hive.storage-format=PARQUET
+hive.timestamp-precision=MICROSECONDS

--- a/docker/trino/entrypoint.sh
+++ b/docker/trino/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+export HADOOP_HOME=/opt/hadoop-3.2.0
+export HADOOP_CLASSPATH=${HADOOP_HOME}/share/hadoop/tools/lib/aws-java-sdk-bundle-1.11.375.jar:${HADOOP_HOME}/share/hadoop/tools/lib/hadoop-aws-3.2.0.jar
+export JAVA_HOME=/usr/local/openjdk-8
+
+# Make sure mariadb is ready
+MAX_TRIES=8
+CURRENT_TRY=1
+SLEEP_BETWEEN_TRY=4
+MARIADB_HOSTNAME="hive-metastore-mariadb"
+until [ "$(telnet "$MARIADB_HOSTNAME" 3306 | sed -n 2p)" = "Connected to ${MARIADB_HOSTNAME}." ] || [ "$CURRENT_TRY" -gt "$MAX_TRIES" ]; do
+  echo "Waiting for mariadb server..."
+  sleep "$SLEEP_BETWEEN_TRY"
+  CURRENT_TRY=$((CURRENT_TRY + 1))
+done
+
+if [ "$CURRENT_TRY" -gt "$MAX_TRIES" ]; then
+  echo "WARNING: Timeout when waiting for mariadb."
+fi
+
+# Check if schema exists
+/opt/apache-hive-metastore-3.0.0-bin/bin/schematool -dbType mysql -info
+
+if [ $? -eq 1 ]; then
+  echo "Getting schema info failed. Probably not initialized. Initializing..."
+  /opt/apache-hive-metastore-3.0.0-bin/bin/schematool -initSchema -dbType mysql
+fi
+
+/opt/apache-hive-metastore-3.0.0-bin/bin/start-metastore

--- a/docker/trino/metastore-site.xml
+++ b/docker/trino/metastore-site.xml
@@ -1,0 +1,56 @@
+<configuration>
+    <property>
+        <name>metastore.thrift.uris</name>
+        <value>thrift://0.0.0.0:9083</value>
+        <description>Thrift URI for the remote metastore. Used by metastore client to connect to remote metastore.</description>
+    </property>
+    <property>
+        <name>metastore.task.threads.always</name>
+        <value>org.apache.hadoop.hive.metastore.events.EventCleanerTask,org.apache.hadoop.hive.metastore.MaterializationsCacheCleanerTask</value>
+    </property>
+    <property>
+        <name>metastore.expression.proxy</name>
+        <value>org.apache.hadoop.hive.metastore.DefaultPartitionExpressionProxy</value>
+    </property>
+    <property>
+        <name>metastore.warehouse.dir</name>
+        <value>s3a://warehouse/</value>
+    </property>
+    <property>
+        <name>javax.jdo.option.ConnectionDriverName</name>
+        <value>com.mysql.cj.jdbc.Driver</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:mysql://hive-metastore-mariadb:3306/metastore_db</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionUserName</name>
+        <value>admin</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionPassword</name>
+        <value>admin</value>
+    </property>
+
+    <property>
+        <name>fs.s3a.access.key</name>
+        <value>accesskey</value>
+    </property>
+    <property>
+        <name>fs.s3a.secret.key</name>
+        <value>secretkey</value>
+    </property>
+    <property>
+        <name>fs.s3a.endpoint</name>
+        <value>http://hive-metastore-minio:9000</value>
+    </property>
+    <property>
+        <name>fs.s3a.path.style.access</name>
+        <value>true</value>
+    </property>
+
+</configuration>

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+import ibis
+
+
+@pytest.fixture
+def tmp_name(con):
+    name = ibis.util.gen_name("test_trino_table_properties")
+    yield name
+    con.drop_table(name, force=True)
+
+
+def test_table_properties(tmp_name):
+    con = ibis.trino.connect(database="hive", schema="default")
+    schema = ibis.schema(dict(a="int"))
+    t = con.create_table(
+        tmp_name,
+        schema=schema,
+        properties={
+            "format": "ORC",
+            "bucketed_by": ["a"],
+            "bucket_count": 42,
+            "extra_properties": {
+                "any": "property",
+                "you": "want",
+            },
+        },
+    )
+    assert t.schema() == schema
+    with con.begin() as c:
+        ddl = c.exec_driver_sql(f"SHOW CREATE TABLE {tmp_name}").scalar()
+    assert "ORC" in ddl
+    assert "bucketed_by" in ddl


### PR DESCRIPTION
This PR adds support for `create_table` with table properties to the Trino backend.

I don't like that for just a single test, I'm having to add three new containers
to our CI setup.

However, as far as I can tell Hive is only connector that has table properties.
If there are other connectors that are easier to setup that have any table
properties, I'm all ears.

There's some additional utility in having a functioning Hive connector around
which is that I plan to use it to test the cross-schema functionality as a
follow-up to this PR.

Ideally we can also get rid of our additional `trino-postgres` container but
after trying that locally it's going to be a bit more work and worth a separate PR.

Closes #6488.