### PR TITLE
feat: add dtype to top level api

### DIFF
--- a/docs/reference/expressions/top_level.md
+++ b/docs/reference/expressions/top_level.md
@@ -13,6 +13,7 @@ These methods and objects are available directly in the `ibis` module.
 ::: ibis.deferred
 ::: ibis.desc
 ::: ibis.difference
+::: ibis.dtype
 ::: ibis.get_backend
 ::: ibis.expr.types.Value.greatest
 ::: ibis.ifelse

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -59,6 +59,7 @@ __all__ = (
     'decompile',
     'deferred',
     'difference',
+    'dtype',
     'e',
     'Expr',
     'geo_area',
@@ -163,6 +164,7 @@ __all__ = (
 )
 
 
+dtype = dt.dtype
 infer_dtype = dt.infer
 infer_schema = sch.infer
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -41,6 +41,19 @@ def dtype(value: Any, nullable: bool = True) -> DataType:
     Int32(nullable=True)
     >>> ibis.dtype("array<float>")
     Array(value_type=Float64(nullable=True), nullable=True)
+
+    DataType objects may also be created from Python types:
+
+    >>> ibis.dtype(int)
+    Int64(nullable=True)
+    >>> ibis.dtype(list[float])
+    Array(value_type=Float64(nullable=True), nullable=True)
+
+    Or other type systems, like numpy/pandas/pyarrow types:
+
+    >>> import pyarrow as pa
+    >>> ibis.dtype(pa.int32())
+    Int32(nullable=True)
     """
     if isinstance(value, DataType):
         return value

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -22,8 +22,26 @@ from ibis.common.validators import Coercible
 
 
 @lazy_singledispatch
-def dtype(value, nullable=True) -> DataType:
-    """Construct an ibis datatype from a python type."""
+def dtype(value: Any, nullable: bool = True) -> DataType:
+    """Create a DataType object.
+
+    Parameters
+    ----------
+    value
+        The object to coerce to an Ibis DataType. Supported inputs include
+        strings, python type annotations, numpy dtypes, pandas dtypes, and
+        pyarrow types.
+    nullable
+        Whether the type should be nullable. Defaults to True.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> ibis.dtype("int32")
+    Int32(nullable=True)
+    >>> ibis.dtype("array<float>")
+    Array(value_type=Float64(nullable=True), nullable=True)
+    """
     if isinstance(value, DataType):
         return value
     else:


### PR DESCRIPTION
This:

- improves the docstring for the `dtype` function
- Adds `dtype` to the public top-level API

Since we already expose `ibis.schema`, having `ibis.dtype` makes sense. It can also be useful when building larger APIs based on ibis, where you might want to coerce something to a `DataType` alone, rather than as part of a schema.