### PR TITLE
refactor(common): remove `ibis.collections.DotDict`

### DIFF
--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -4,7 +4,6 @@ import functools
 import inspect
 from typing import Any as AnyType
 
-from ibis.common.collections import DotDict
 from ibis.common.patterns import (
     Any,
     FrozenDictOf,
@@ -326,7 +325,7 @@ class Signature(inspect.Signature):
         # does the reverse of bind, but doesn't apply defaults
         args, kwargs = [], {}
         for name, param in self.parameters.items():
-            value = getattr(this, name)
+            value = this[name]
             if param.kind is POSITIONAL_OR_KEYWORD:
                 args.append(value)
             elif param.kind is VAR_POSITIONAL:
@@ -362,7 +361,7 @@ class Signature(inspect.Signature):
         bound = self.bind(*args, **kwargs)
         bound.apply_defaults()
 
-        this = DotDict()
+        this = {}
         for name, value in bound.arguments.items():
             param = self.parameters[name]
             # TODO(kszucs): provide more error context on failure
@@ -372,7 +371,7 @@ class Signature(inspect.Signature):
 
     def validate_nobind(self, **kwargs):
         """Validate the arguments against the signature without binding."""
-        this = DotDict()
+        this = {}
         for name, param in self.parameters.items():
             value = kwargs.get(name, param.default)
             if value is EMPTY:

--- a/ibis/common/collections.py
+++ b/ibis/common/collections.py
@@ -173,45 +173,6 @@ class FrozenDict(Mapping[K, V], Hashable):
         return self.__precomputed_hash__
 
 
-@public
-class DotDict(dict):
-    """Dictionary that allows access to keys as attributes using the dot notation.
-
-    Note, that this is not recursive, so nested access is not supported.
-
-    Examples
-    --------
-    >>> d = DotDict({'a': 1, 'b': 2})
-    >>> d.a
-    1
-    >>> d.b
-    2
-    >>> d['a']
-    1
-    >>> d['b']
-    2
-    >>> d.c = 3
-    >>> d['c']
-    3
-    >>> d.c
-    3
-    """
-
-    __slots__ = ()
-
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
-
-    def __getattr__(self, key):
-        try:
-            return self[key]
-        except KeyError:
-            raise AttributeError(key)
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}({super().__repr__()})"
-
-
 class RewindableIterator(Iterator):
     """Iterator that can be rewound to a checkpoint.
 
@@ -254,4 +215,4 @@ class RewindableIterator(Iterator):
         self._iterator, self._checkpoint = tee(self._iterator)
 
 
-public(frozendict=FrozenDict, dotdict=DotDict)
+public(frozendict=FrozenDict)

--- a/ibis/common/tests/test_collections.py
+++ b/ibis/common/tests/test_collections.py
@@ -4,7 +4,7 @@ from collections.abc import ItemsView, Iterator, KeysView, ValuesView
 
 import pytest
 
-from ibis.common.collections import DotDict, FrozenDict, MapSet, RewindableIterator
+from ibis.common.collections import FrozenDict, MapSet, RewindableIterator
 from ibis.tests.util import assert_pickle_roundtrip
 
 
@@ -177,27 +177,6 @@ def test_mapset_set_api():
     assert (b ^ a).identical(MySchema(c=3))
     assert (a ^ f).identical(MySchema(a=1, b=2, d=4, e=5))
     assert (f ^ a).identical(MySchema(d=4, e=5, a=1, b=2))
-
-
-def test_dotdict():
-    d = DotDict({"a": 1, "b": 2, "c": 3})
-    assert d["a"] == d.a == 1
-    assert d["b"] == d.b == 2
-
-    d.b = 3
-    assert d.b == 3
-    assert d["b"] == 3
-
-    del d.c
-    assert not hasattr(d, "c")
-    assert "c" not in d
-
-    assert repr(d) == "DotDict({'a': 1, 'b': 3})"
-
-    with pytest.raises(KeyError):
-        assert d["x"]
-    with pytest.raises(AttributeError):
-        assert d.x
 
 
 def test_frozendict():


### PR DESCRIPTION
The hybrid getitem/getattr access to the validation context is not
necessary since the move from the previous rule-based validation
to the current pattern matching system.
