### PR TITLE
refactor(common): remove `Validator` mixin for better clarity

### DIFF
--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -13,7 +13,7 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis import _
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 
 to_sql = ibis.bigquery.compile
 

--- a/ibis/backends/clickhouse/tests/test_aggregations.py
+++ b/ibis/backends/clickhouse/tests/test_aggregations.py
@@ -7,7 +7,7 @@ import pandas.testing as tm
 import pytest
 
 import ibis
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 
 pytest.importorskip("clickhouse_connect")
 

--- a/ibis/backends/dask/tests/execution/test_functions.py
+++ b/ibis/backends/dask/tests/execution/test_functions.py
@@ -13,8 +13,8 @@ from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
+from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import OperationNotDefinedError
-from ibis.common.patterns import ValidationError
 
 dd = pytest.importorskip("dask.dataframe")
 from dask.dataframe.utils import tm  # noqa: E402

--- a/ibis/backends/impala/tests/test_udf.py
+++ b/ibis/backends/impala/tests/test_udf.py
@@ -14,7 +14,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis import util
 from ibis.backends.impala import ddl
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 from ibis.expr import rules
 
 pytest.importorskip("impala")

--- a/ibis/backends/impala/tests/test_unary_builtins.py
+++ b/ibis/backends/impala/tests/test_unary_builtins.py
@@ -5,7 +5,7 @@ import pytest
 import ibis
 import ibis.expr.types as ir
 from ibis.backends.impala.tests.conftest import translate
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 
 
 @pytest.fixture(scope="module")

--- a/ibis/backends/pandas/tests/execution/test_functions.py
+++ b/ibis/backends/pandas/tests/execution/test_functions.py
@@ -16,7 +16,7 @@ import ibis.expr.datatypes as dt
 from ibis.backends.pandas.execution import execute
 from ibis.backends.pandas.tests.conftest import TestConf as tm
 from ibis.backends.pandas.udf import udf
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/pandas/tests/execution/test_window.py
+++ b/ibis/backends/pandas/tests/execution/test_window.py
@@ -17,7 +17,7 @@ from ibis.backends.pandas import Backend
 from ibis.backends.pandas.dispatch import pre_execute
 from ibis.backends.pandas.execution import execute
 from ibis.backends.pandas.tests.conftest import TestConf as tm
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 from ibis.legacy.udf.vectorized import reduction
 
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -18,7 +18,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.selectors as s
 from ibis import _
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 
 try:
     import duckdb

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -9,8 +9,8 @@ from pytest import param
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
+from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import OperationNotDefinedError
-from ibis.common.patterns import ValidationError
 
 try:
     from google.api_core.exceptions import BadRequest

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -17,7 +17,7 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.backends.pandas.execution.temporal import day_name
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 
 try:
     from duckdb import InvalidInputException as DuckDBInvalidInputException

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -6,7 +6,14 @@ from typing import Union
 import pytest
 from typing_extensions import Annotated  # noqa: TCH002
 
-from ibis.common.annotations import Argument, Attribute, Parameter, Signature, annotated
+from ibis.common.annotations import (
+    Argument,
+    Attribute,
+    Parameter,
+    Signature,
+    ValidationError,
+    annotated,
+)
 from ibis.common.patterns import (
     Any,
     CoercedTo,
@@ -14,7 +21,6 @@ from ibis.common.patterns import (
     NoMatch,
     Option,
     TupleOf,
-    ValidationError,
     pattern,
 )
 
@@ -24,13 +30,13 @@ is_int = InstanceOf(int)
 def test_argument_repr():
     argument = Argument(is_int, typehint=int, default=None)
     assert repr(argument) == (
-        "Argument(validator=InstanceOf(type=<class 'int'>), default=None, "
+        "Argument(pattern=InstanceOf(type=<class 'int'>), default=None, "
         "typehint=<class 'int'>)"
     )
 
 
 def test_default_argument():
-    annotation = Argument.default(validator=lambda x, context: int(x), default=3)
+    annotation = Argument.default(pattern=lambda x, context: int(x), default=3)
     assert annotation.validate(1) == 1
     with pytest.raises(TypeError):
         annotation.validate(None)
@@ -82,7 +88,7 @@ def test_initialized():
 
     assert field.initialize(Foo) == 20
 
-    field2 = Attribute(validator=lambda x, this: str(x), default=lambda self: self.a)
+    field2 = Attribute(pattern=lambda x, this: str(x), default=lambda self: self.a)
     assert field != field2
     assert field2.initialize(Foo) == "10"
 
@@ -103,7 +109,7 @@ def test_parameter():
 
     ofn = Argument.optional(fn)
     op = Parameter("test", annotation=ofn)
-    assert op.annotation._validator == Option(fn, default=None)
+    assert op.annotation._pattern == Option(fn, default=None)
     assert op.default is None
     assert op.annotation.validate(None, {"other": 1}) is None
 
@@ -218,12 +224,12 @@ def test_signature_unbind():
 
 a = Parameter("a", annotation=Argument.required(CoercedTo(float)))
 b = Parameter("b", annotation=Argument.required(CoercedTo(float)))
-c = Parameter("c", annotation=Argument.default(default=0, validator=CoercedTo(float)))
+c = Parameter("c", annotation=Argument.default(default=0, pattern=CoercedTo(float)))
 d = Parameter(
     "d",
-    annotation=Argument.default(default=tuple(), validator=TupleOf(CoercedTo(float))),
+    annotation=Argument.default(default=tuple(), pattern=TupleOf(CoercedTo(float))),
 )
-e = Parameter("e", annotation=Argument.optional(validator=CoercedTo(float)))
+e = Parameter("e", annotation=Argument.optional(pattern=CoercedTo(float)))
 sig = Signature(parameters=[a, b, c, d, e])
 
 

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -10,6 +10,7 @@ import pytest
 from ibis.common.annotations import (
     Parameter,
     Signature,
+    ValidationError,
     argument,
     attribute,
     optional,
@@ -36,7 +37,6 @@ from ibis.common.patterns import (
     Option,
     Pattern,
     TupleOf,
-    ValidationError,
 )
 from ibis.tests.util import assert_pickle_roundtrip
 
@@ -333,7 +333,7 @@ def test_annotable_with_recursive_generic_type_annotations():
     # testing cons list
     pattern = Pattern.from_typehint(List[Integer])
     values = ["1", 2.0, 3]
-    result = pattern.validate(values, {})
+    result = pattern.match(values, {})
     expected = ConsList(1, ConsList(2, ConsList(3, EmptyList())))
     assert result == expected
     assert result[0] == 1
@@ -346,7 +346,7 @@ def test_annotable_with_recursive_generic_type_annotations():
     # testing cons map
     pattern = Pattern.from_typehint(Map[Integer, Float])
     values = {"1": 2, 3: "4.0", 5: 6.0}
-    result = pattern.validate(values, {})
+    result = pattern.match(values, {})
     expected = ConsMap((1, 2.0), ConsMap((3, 4.0), ConsMap((5, 6.0), EmptyMap())))
     assert result == expected
     assert result[1] == 2.0

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -23,6 +23,7 @@ from typing import (
 import pytest
 from typing_extensions import Annotated
 
+from ibis.common.annotations import ValidationError
 from ibis.common.collections import FrozenDict
 from ibis.common.graph import Node
 from ibis.common.patterns import (
@@ -63,7 +64,6 @@ from ibis.common.patterns import (
     Topmost,
     TupleOf,
     TypeOf,
-    ValidationError,
     match,
     pattern,
 )
@@ -638,7 +638,6 @@ def test_matching_mapping():
 )
 def test_various_patterns(pattern, value, expected):
     assert pattern.match(value, context={}) == expected
-    assert pattern.validate(value, context={}) == expected
 
 
 @pytest.mark.parametrize(
@@ -663,8 +662,6 @@ def test_various_patterns(pattern, value, expected):
 )
 def test_various_not_matching_patterns(pattern, value):
     assert pattern.match(value, context={}) is NoMatch
-    with pytest.raises(ValidationError):
-        pattern.validate(value, context={})
 
 
 @pattern

--- a/ibis/common/tests/test_temporal.py
+++ b/ibis/common/tests/test_temporal.py
@@ -48,9 +48,9 @@ def test_interval_units(singular, plural, short):
 def test_interval_unit_coercions(singular, plural, short):
     u = IntervalUnit[singular.upper()]
     v = CoercedTo(IntervalUnit)
-    assert v.validate(singular, {}) == u
-    assert v.validate(plural, {}) == u
-    assert v.validate(short, {}) == u
+    assert v.match(singular, {}) == u
+    assert v.match(plural, {}) == u
+    assert v.match(short, {}) == u
 
 
 @pytest.mark.parametrize(
@@ -67,7 +67,7 @@ def test_interval_unit_coercions(singular, plural, short):
 )
 def test_interval_unit_aliases(alias, expected):
     v = CoercedTo(IntervalUnit)
-    assert v.validate(alias, {}) == IntervalUnit(expected)
+    assert v.match(alias, {}) == IntervalUnit(expected)
 
 
 @pytest.mark.parametrize(
@@ -116,7 +116,7 @@ def test_normalize_timedelta_invalid(value, unit):
 def test_interval_unit_compatibility():
     v = CoercedTo(IntervalUnit)
     for unit in itertools.chain(DateUnit, TimeUnit):
-        interval = v.validate(unit, {})
+        interval = v.match(unit, {})
         assert isinstance(interval, IntervalUnit)
         assert unit.value == interval.value
 

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -12,8 +12,8 @@ import ibis.expr.operations as ops
 import ibis.expr.operations.relations as rels
 import ibis.expr.types as ir
 from ibis import util
+from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import IbisTypeError, IntegrityError
-from ibis.common.patterns import ValidationError
 
 # ---------------------------------------------------------------------
 # Some expression metaprogramming / graph transformations to support

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -11,7 +11,8 @@ import pytest
 from typing_extensions import Annotated
 
 import ibis.expr.datatypes as dt
-from ibis.common.patterns import As, Attrs, NoMatch, Pattern, ValidationError
+from ibis.common.annotations import ValidationError
+from ibis.common.patterns import As, Attrs, NoMatch, Pattern
 from ibis.common.temporal import TimestampUnit, TimeUnit
 
 

--- a/ibis/expr/datatypes/tests/test_parse.py
+++ b/ibis/expr/datatypes/tests/test_parse.py
@@ -4,7 +4,7 @@ import parsy
 import pytest
 
 import ibis.expr.datatypes as dt
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/ibis/expr/operations/histograms.py
+++ b/ibis/expr/operations/histograms.py
@@ -7,8 +7,7 @@ from public import public
 
 import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
-from ibis.common.annotations import attribute
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError, attribute
 from ibis.common.typing import VarTuple  # noqa: TCH001
 from ibis.expr.operations.core import Column, Value
 

--- a/ibis/expr/operations/logical.py
+++ b/ibis/expr/operations/logical.py
@@ -7,9 +7,8 @@ from public import public
 import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
-from ibis.common.annotations import attribute
+from ibis.common.annotations import ValidationError, attribute
 from ibis.common.exceptions import IbisTypeError
-from ibis.common.patterns import ValidationError
 from ibis.common.typing import VarTuple  # noqa: TCH001
 from ibis.expr.operations.core import Binary, Column, Unary, Value
 from ibis.expr.operations.generic import _Negatable

--- a/ibis/expr/operations/tests/test_generic.py
+++ b/ibis/expr/operations/tests/test_generic.py
@@ -5,12 +5,7 @@ import pytest
 import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.common.patterns import (
-    CoercedTo,
-    GenericCoercedTo,
-    Pattern,
-    ValidationError,
-)
+from ibis.common.patterns import CoercedTo, GenericCoercedTo, NoMatch, Pattern
 
 
 @pytest.mark.parametrize(
@@ -32,58 +27,56 @@ def test_literal_coercion_type_inference(value, dtype):
 def test_coerced_to_literal():
     p = CoercedTo(ops.Literal)
     one = ops.Literal(1, dt.int8)
-    assert p.validate(ops.Literal(1, dt.int8), {}) == one
-    assert p.validate(1, {}) == one
-    assert p.validate(False, {}) == ops.Literal(False, dt.boolean)
+    assert p.match(ops.Literal(1, dt.int8), {}) == one
+    assert p.match(1, {}) == one
+    assert p.match(False, {}) == ops.Literal(False, dt.boolean)
 
     p = GenericCoercedTo(ops.Literal[dt.Int8])
-    assert p.validate(ops.Literal(1, dt.int8), {}) == one
+    assert p.match(ops.Literal(1, dt.int8), {}) == one
 
     p = Pattern.from_typehint(ops.Literal[dt.Int8])
     assert p == GenericCoercedTo(ops.Literal[dt.Int8])
 
     one = ops.Literal(1, dt.int16)
-    with pytest.raises(ValidationError):
-        p.validate(one, {})
+    assert p.match(one, {}) is NoMatch
 
 
 def test_coerced_to_value():
     one = ops.Literal(1, dt.int8)
 
     p = Pattern.from_typehint(ops.Value)
-    assert p.validate(1, {}) == one
+    assert p.match(1, {}) == one
 
     p = Pattern.from_typehint(ops.Value[dt.Int8, ds.Any])
-    assert p.validate(1, {}) == one
+    assert p.match(1, {}) == one
 
     p = Pattern.from_typehint(ops.Value[dt.Int8, ds.Scalar])
-    assert p.validate(1, {}) == one
+    assert p.match(1, {}) == one
 
     p = Pattern.from_typehint(ops.Value[dt.Int8, ds.Columnar])
-    with pytest.raises(ValidationError):
-        p.validate(1, {})
+    assert p.match(1, {}) is NoMatch
 
     # dt.Integer is not instantiable so it will be only used for checking
     # that the produced literal has any integer datatype
     p = Pattern.from_typehint(ops.Value[dt.Integer, ds.Any])
-    assert p.validate(1, {}) == one
+    assert p.match(1, {}) == one
 
     # same applies here, the coercion itself will use only the inferred datatype
     # but then the result is checked against the given typehint
     p = Pattern.from_typehint(ops.Value[dt.Int8 | dt.Int16, ds.Any])
-    assert p.validate(1, {}) == one
-    assert p.validate(128, {}) == ops.Literal(128, dt.int16)
+    assert p.match(1, {}) == one
+    assert p.match(128, {}) == ops.Literal(128, dt.int16)
 
     p1 = Pattern.from_typehint(ops.Value[dt.Int8, ds.Any])
     p2 = Pattern.from_typehint(ops.Value[dt.Int16, ds.Scalar])
-    assert p1.validate(1, {}) == one
+    assert p1.match(1, {}) == one
     # this is actually supported by creating an explicit dtype
     # in Value.__coerce__ based on the `T` keyword argument
-    assert p2.validate(1, {}) == ops.Literal(1, dt.int16)
-    assert p2.validate(128, {}) == ops.Literal(128, dt.int16)
+    assert p2.match(1, {}) == ops.Literal(1, dt.int16)
+    assert p2.match(128, {}) == ops.Literal(128, dt.int16)
 
     p = p1 | p2
-    assert p.validate(1, {}) == one
+    assert p.match(1, {}) == one
 
 
 @pytest.mark.pandas

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -128,9 +128,9 @@ class ScalarUDFBuilder:
 
             arg = rlz.ValueOf(dt.dtype(raw_dtype))
             if (default := param.default) is EMPTY:
-                fields[name] = Argument.required(validator=arg)
+                fields[name] = Argument.required(pattern=arg)
             else:
-                fields[name] = Argument.default(validator=arg, default=default)
+                fields[name] = Argument.default(pattern=arg, default=default)
 
         fields["dtype"] = dt.dtype(return_annotation)
 

--- a/ibis/expr/tests/test_schema.py
+++ b/ibis/expr/tests/test_schema.py
@@ -338,7 +338,7 @@ class ObjectWithSchema(Annotable):
 
 def test_schema_is_coercible():
     s = sch.Schema({"a": dt.int64, "b": dt.Array(dt.int64)})
-    assert CoercedTo(sch.Schema).validate(PreferenceA, {}) == s
+    assert CoercedTo(sch.Schema).match(PreferenceA, {}) == s
 
     o = ObjectWithSchema(schema=PreferenceA)
     assert o.schema == s

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -12,7 +12,7 @@ from ibis.common.exceptions import IbisError, IbisTypeError, TranslationError
 from ibis.common.grounds import Immutable
 from ibis.config import _default_backend, options
 from ibis.util import experimental
-from ibis.common.patterns import ValidationError, Coercible, CoercionError
+from ibis.common.annotations import ValidationError
 from rich.jupyter import JupyterMixin
 from ibis.common.patterns import Coercible, CoercionError
 

--- a/ibis/tests/expr/test_analytics.py
+++ b/ibis/tests/expr/test_analytics.py
@@ -17,7 +17,7 @@ import pytest
 
 import ibis
 import ibis.expr.types as ir
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 from ibis.tests.expr.mocks import MockBackend
 from ibis.tests.util import assert_equal
 

--- a/ibis/tests/expr/test_decimal.py
+++ b/ibis/tests/expr/test_decimal.py
@@ -7,7 +7,7 @@ import pytest
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 from ibis.expr import api
 
 

--- a/ibis/tests/expr/test_operations.py
+++ b/ibis/tests/expr/test_operations.py
@@ -11,7 +11,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
 import ibis.expr.types as ir
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 
 t = ibis.table([("a", "int64")], name="t")
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -20,8 +20,8 @@ import ibis.expr.types as ir
 import ibis.selectors as s
 from ibis import _
 from ibis import literal as L
+from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import RelationError
-from ibis.common.patterns import ValidationError
 from ibis.expr import api
 from ibis.expr.types import Column, Table
 from ibis.tests.expr.mocks import MockAlchemyBackend, MockBackend

--- a/ibis/tests/expr/test_udf.py
+++ b/ibis/tests/expr/test_udf.py
@@ -6,7 +6,7 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 
 
 @pytest.fixture

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -22,9 +22,9 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import _, literal
+from ibis.common.annotations import ValidationError
 from ibis.common.collections import frozendict
 from ibis.common.exceptions import IbisTypeError
-from ibis.common.patterns import ValidationError
 from ibis.expr import api
 from ibis.tests.util import assert_equal
 

--- a/ibis/tests/expr/test_window_frames.py
+++ b/ibis/tests/expr/test_window_frames.py
@@ -10,8 +10,9 @@ import ibis.expr.builders as bl
 import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import IbisInputError, IbisTypeError
-from ibis.common.patterns import Pattern, ValidationError
+from ibis.common.patterns import NoMatch, Pattern
 
 
 def test_window_boundary():
@@ -35,21 +36,19 @@ def test_window_boundary_typevars():
 
     p = Pattern.from_typehint(ops.WindowBoundary[dt.Integer, ds.Any])
     b = ops.WindowBoundary(5, preceding=False)
-    assert p.validate(b, {}) == b
-    with pytest.raises(ValidationError):
-        p.validate(ops.WindowBoundary(5.0, preceding=False), {})
-    with pytest.raises(ValidationError):
-        p.validate(ops.WindowBoundary(lit, preceding=True), {})
+    assert p.match(b, {}) == b
+    assert p.match(ops.WindowBoundary(5.0, preceding=False), {}) is NoMatch
+    assert p.match(ops.WindowBoundary(lit, preceding=True), {}) is NoMatch
 
     p = Pattern.from_typehint(ops.WindowBoundary[dt.Interval, ds.Any])
     b = ops.WindowBoundary(lit, preceding=True)
-    assert p.validate(b, {}) == b
+    assert p.match(b, {}) == b
 
 
 def test_window_boundary_coercions():
     RowsWindowBoundary = ops.WindowBoundary[dt.Integer, ds.Any]
     p = Pattern.from_typehint(RowsWindowBoundary)
-    assert p.validate(1, {}) == RowsWindowBoundary(ops.Literal(1, dtype=dt.int8), False)
+    assert p.match(1, {}) == RowsWindowBoundary(ops.Literal(1, dtype=dt.int8), False)
 
 
 def test_window_builder_rows():

--- a/ibis/tests/test_config.py
+++ b/ibis/tests/test_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from ibis.common.patterns import ValidationError
+from ibis.common.annotations import ValidationError
 from ibis.config import options
 
 


### PR DESCRIPTION
Depends on #6744 

Also removes a redundant function call by directly calling the pattern  match API from the annotation classes.
The previous validation logic called the following methods:

```py
1. Argument.validate()
2. Validator.validate()
3. Pattern.match()
```

which is not reduced to `Argument.validate() -> Pattern.match()`
