### PR TITLE
fix(backends): make `current_database` implementation and API consistent across all backends

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -734,7 +734,8 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         Returns
         -------
         str | None
-            Name of the current database.
+            Name of the current database or `None` if the backend supports the
+            concept of a database but doesn't support multiple databases.
         """
 
     @staticmethod

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -452,7 +452,7 @@ class BaseAlchemyBackend(BaseSQLBackend):
         return self.database().schema(name)
 
     @property
-    def current_database(self) -> str:
+    def current_database(self) -> str | None:
         """The name of the current database this client is connected to."""
         return self.database_name
 

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -326,7 +326,7 @@ class Backend(BaseSQLBackend, CanCreateSchema):
         return self._execute(query, results=results, query_parameters=query_parameters)
 
     @property
-    def current_database(self) -> str:
+    def current_database(self) -> str | None:
         return self.dataset
 
     def database(self, name=None):

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -192,8 +192,10 @@ class Backend(BaseBackend, CanCreateDatabase):
         return self.con.server_version
 
     @property
-    def current_database(self) -> str:
-        return self.con.database
+    def current_database(self) -> str | None:
+        with closing(self.raw_sql("SELECT currentDatabase()")) as result:
+            [(db,)] = result.result_rows
+        return db
 
     def list_databases(self, like: str | None = None) -> list[str]:
         with closing(self.raw_sql("SELECT name FROM system.databases")) as result:

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -74,8 +74,9 @@ def test_verbose_log_queries(con):
 
     expected = 'DESCRIBE ibis_testing.functional_alltypes'
 
-    assert len(queries) == 1
-    assert queries[0] == expected
+    # might be other queries in there, we only check that a describe table
+    # query was logged
+    assert expected in queries
 
 
 def test_sql_query_limits(alltypes):

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -73,7 +73,7 @@ class Backend(BaseBackend, CanCreateDatabase, CanCreateSchema):
             self.register(path, table_name=name)
 
     @property
-    def current_database(self) -> str:
+    def current_database(self) -> str | None:
         raise NotImplementedError()
 
     def list_databases(self, like: str | None = None) -> list[str]:

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -78,7 +78,7 @@ class Backend(BaseAlchemyBackend, CanCreateSchema):
     supports_create_or_replace = True
 
     @property
-    def current_database(self) -> str:
+    def current_database(self) -> str | None:
         query = sa.select(sa.func.current_database())
         with self.begin() as con:
             return con.execute(query).scalar()

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -414,7 +414,7 @@ class Backend(BaseSQLBackend):
         return list(map(operator.itemgetter(0), tuples))
 
     @property
-    def current_database(self):
+    def current_database(self) -> str | None:
         # XXX The parent `Client` has a generic method that calls this same
         # method in the backend. But for whatever reason calling this code from
         # that method doesn't seem to work. Maybe `con` is a copy?

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -82,7 +82,7 @@ class BasePandasBackend(BaseBackend):
         return pd.__version__
 
     @property
-    def current_database(self):
+    def current_database(self) -> str | None:
         raise NotImplementedError('pandas backend does not support databases')
 
     def list_tables(self, like=None, database=None):

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -50,7 +50,8 @@ class Backend(BaseBackend):
     def version(self) -> str:
         return pl.__version__
 
-    def current_database(self):
+    @property
+    def current_database(self) -> str | None:
         raise NotImplementedError('polars backend does not support databases')
 
     def list_tables(self, like=None, database=None):

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -169,7 +169,7 @@ class Backend(BaseSQLBackend, CanCreateDatabase):
         return pyspark.__version__
 
     @property
-    def current_database(self):
+    def current_database(self) -> str | None:
         return self._catalog.currentDatabase()
 
     def list_databases(self, like=None):

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -35,13 +35,16 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema):
     supports_create_or_replace = False
     supports_temporary_tables = False
 
-    def current_database(self) -> str:
-        raise NotImplementedError(type(self))
-
     @cached_property
     def version(self) -> str:
         with self.begin() as con:
             return con.execute(sa.select(sa.func.version())).scalar()
+
+    @property
+    def current_database(self) -> str | None:
+        query = sa.select(sa.literal_column("current_catalog"))
+        with self.begin() as con:
+            return con.execute(query).scalar()
 
     def do_connect(
         self,


### PR DESCRIPTION
Make all of the `current_database` implementations consistent with each other.