### PR TITLE
test(snowflake): revert db/schema prepending; run tests in series

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -34,8 +34,10 @@ jobs:
         backend:
           - name: bigquery
             title: BigQuery
+            serial: false
           - name: snowflake
             title: Snowflake
+            serial: true
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -94,7 +96,12 @@ jobs:
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
 
       - name: "run parallel tests: ${{ matrix.backend.name }}"
+        if: ${{ !matrix.backend.serial }}
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup
+
+      - name: "run serial tests: ${{ matrix.backend.name }}"
+        if: matrix.backend.serial
+        run: just ci-check -m ${{ matrix.backend.name }}
 
       - name: upload code coverage
         if: success()

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -446,15 +446,9 @@ $$""".format(
 
         with self.begin() as con:
             if con.exec_driver_sql(f"SHOW TABLES LIKE '{raw_name}'").scalar() is None:
-                pieces = con.execute(
-                    sa.select(sa.func.current_database(), sa.func.current_schema())
-                ).one()
-                namespace = ".".join(map(quote, filter(None, pieces)))
-
                 # 1. create a temporary stage for holding parquet files
                 stage = util.gen_name("stage")
-
-                con.exec_driver_sql(f"CREATE TEMP STAGE {namespace}.{stage}")
+                con.exec_driver_sql(f"CREATE TEMP STAGE {stage}")
 
                 tmpdir = tempfile.TemporaryDirectory()
                 try:


### PR DESCRIPTION
I'm not sure what's going on here, but occasionally the snowflake test suite fails due to `SELECT current_database()` returning `None`.

Since we never test without first connecting to a database with a specific schema, this is extremely strange.

Running the tests in series, while frustratingly slow, doesn't seem to have this problem.