### PR TITLE
refactor(analysis): remove `find_memtables` function in favor of `node.find()`

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping
 import toolz
 
 import ibis.common.exceptions as exc
-import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
@@ -269,7 +268,7 @@ class BaseSQLBackend(BaseBackend):
 
     def _register_in_memory_tables(self, expr: ir.Expr) -> None:
         if self.compiler.cheap_in_memory_tables:
-            for memtable in an.find_memtables(expr.op()):
+            for memtable in expr.op().find(ops.InMemoryTable):
                 self._register_in_memory_table(memtable)
 
     @abc.abstractmethod

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -797,15 +797,6 @@ def _rewrite_filter_value_list(op, **kwargs):
     return op.__class__(*visited)
 
 
-def find_memtables(node: ops.Node) -> Iterator[ops.InMemoryTable]:
-    """Find all in-memory tables in `node`."""
-
-    def finder(node):
-        return g.proceed, node if isinstance(node, ops.InMemoryTable) else None
-
-    return g.traverse(finder, node, filter=ops.Node)
-
-
 def find_toplevel_unnest_children(nodes: Iterable[ops.Node]) -> Iterator[ops.Table]:
     def finder(node):
         return (


### PR DESCRIPTION
The `ibis.expr.analysis.find_memtables(node)` function is semantically equivalent with `node.find(ops.InMemoryTable)`