### PR TITLE
refactor(analysis): remove `find_phyisical_tables()` function in favor of `node.find()`

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -59,18 +59,6 @@ def sub_immediate_parents(op: ops.Node, table: ops.TableNode) -> ops.Node:
     return sub_for(op, {base: table for base in find_immediate_parent_tables(op)})
 
 
-def find_physical_tables(node):
-    """Find every first occurrence of a `ir.PhysicalTable` object in `node`."""
-
-    def finder(node):
-        if isinstance(node, ops.PhysicalTable):
-            return g.halt, node
-        else:
-            return g.proceed, None
-
-    return list(toolz.unique(g.traverse(finder, node)))
-
-
 def find_immediate_parent_tables(input_node, keep_input=True):
     """Find every first occurrence of a `ir.Table` object in `input_node`.
 


### PR DESCRIPTION
The `ibis.expr.analysis.find_phyisical_tables(node)` function is semantically equivalent with `node.find(ops.PhyisicalTable)`