### PR TITLE
test(bigquery): xfail `levenshtein` implementation

### DIFF
--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1027,6 +1027,7 @@ def test_multiple_subs(con):
 
 @pytest.mark.notimpl(
     [
+        "bigquery",
         "clickhouse",
         "dask",
         "datafusion",


### PR DESCRIPTION
Follow up to #6773.