### PR TITLE
fix: make sure that `array1.union(array2)` null handling matches across backends

### DIFF
--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -1092,7 +1092,6 @@ _simple_ops = {
     ops.BitwiseLeftShift: "bitShiftLeft",
     ops.BitwiseRightShift: "bitShiftRight",
     ops.BitwiseNot: "bitNot",
-    ops.ArrayDistinct: "arrayDistinct",
     ops.ArraySort: "arraySort",
     ops.ArrayContains: "has",
     ops.FirstValue: "first_value",
@@ -1114,6 +1113,13 @@ for _op, _name in _simple_ops.items():
 
 
 del _fmt, _name, _op
+
+
+@translate_val.register(ops.ArrayDistinct)
+def _array_distinct(op, **kw):
+    arg = translate_val(op.arg, **kw)
+    null_element = f"if(countEqual({arg}, NULL) > 0, [NULL], [])"
+    return f"arrayConcat(arrayDistinct({arg}), {null_element})"
 
 
 @translate_val.register(ops.ExtractMicrosecond)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -617,6 +617,11 @@ def test_array_remove(backend, con):
     raises=com.IbisTypeError,
     reason="argument passes none of the following rules:....",
 )
+@pytest.mark.notyet(
+    ["clickhouse"],
+    raises=TypeError,
+    reason="clickhouse doesn't support nullable array types",
+)
 def test_array_unique(backend, con):
     t = ibis.memtable({"a": [[1, 3, 3], [], [42, 42], [], [None], None]})
     expr = t.a.unique()

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -648,7 +648,7 @@ def test_array_sort(backend, con):
 
 
 @pytest.mark.notimpl(
-    ["dask", "datafusion", "impala", "mssql", "pandas", "polars", "postgres"],
+    ["dask", "datafusion", "impala", "mssql", "pandas", "polars"],
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -618,10 +618,10 @@ def test_array_remove(backend, con):
     reason="argument passes none of the following rules:....",
 )
 def test_array_unique(backend, con):
-    t = ibis.memtable({"a": [[1, 3, 3], [], [42, 42], []]})
+    t = ibis.memtable({"a": [[1, 3, 3], [], [42, 42], [], [None], None]})
     expr = t.a.unique()
     result = con.execute(expr).map(set, na_action="ignore")
-    expected = pd.Series([{3, 1}, set(), {42}, set()], dtype="object")
+    expected = pd.Series([{3, 1}, set(), {42}, set(), {None}, None], dtype="object")
     backend.assert_series_equal(result, expected, check_names=False)
 
 
@@ -646,11 +646,6 @@ def test_array_sort(backend, con):
     ["dask", "datafusion", "impala", "mssql", "pandas", "polars", "postgres"],
     raises=com.OperationNotDefinedError,
 )
-@pytest.mark.broken(
-    ["snowflake", "trino", "pyspark"],
-    raises=AssertionError,
-    reason="array_distinct([NULL]) seems to differ from other backends",
-)
 @pytest.mark.notyet(
     ["bigquery"],
     raises=BadRequest,
@@ -665,7 +660,7 @@ def test_array_union(con):
     t = ibis.memtable({"a": [[3, 2], [], []], "b": [[1, 3], [None], [5]]})
     expr = t.a.union(t.b)
     result = con.execute(expr).map(set, na_action="ignore")
-    expected = pd.Series([{1, 2, 3}, set(), {5}], dtype="object")
+    expected = pd.Series([{1, 2, 3}, {None}, {5}], dtype="object")
     assert len(result) == len(expected)
 
     for i, (lhs, rhs) in enumerate(zip(result, expected)):

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -709,7 +709,7 @@ class ArrayValue(Value):
         │ array<int64>           │
         ├────────────────────────┤
         │ [1, 2, ... +1]         │
-        │ []                     │
+        │ [None]                 │
         │ [5]                    │
         └────────────────────────┘
         >>> t.arr1.union(t.arr2).contains(3)


### PR DESCRIPTION
Fixes an inconsistency regarding null handling in computing distinct array elements. In this PR, NULL is treated as a unique value instead of being disarded.