### PR TITLE
fix(snowflake): use ibis-defined `array_sort` until upstream lands

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -91,6 +91,11 @@ return longest.map((_, i) => {
     return Object.assign(...keys.map((key, j) => ({[key]: arrays[j][i]})));
 })""",
     },
+    "ibis_udfs.public.array_sort": {
+        "inputs": {"array": ARRAY},
+        "returns": ARRAY,
+        "source": """return array.sort();""",
+    },
 }
 
 

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -460,7 +460,7 @@ operation_registry.update(
         ops.Median: reduction(sa.func.median),
         ops.TableColumn: _table_column,
         ops.Levenshtein: fixed_arity(sa.func.editdistance, 2),
-        ops.ArraySort: fixed_arity(sa.func.array_sort, 1),
+        ops.ArraySort: unary(sa.func.ibis_udfs.public.array_sort),
     }
 )
 


### PR DESCRIPTION
Looks like `array_sort` is not actually release upstream. I define `array_sort` here as a JavaScript UDF in the meantime.