### PR TITLE
fix(snowflake): disable filter and map

### DIFF
--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -472,6 +472,9 @@ _invalid_operations = {
     ops.CumulativeAny,
     ops.CumulativeOp,
     ops.NTile,
+    # ibis.expr.operarions.array
+    ops.ArrayMap,
+    ops.ArrayFilter,
     # ibis.expr.operations.reductions
     ops.MultiQuantile,
     # ibis.expr.operations.strings


### PR DESCRIPTION
Disable array filter and map operations for the snowflake backend.