### PR TITLE
fix(snowflake): handle databases and schemas when quoting tables

### DIFF
--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -409,6 +409,7 @@ class BaseAlchemyBackend(BaseSQLBackend):
             *columns,
             prefixes=[self._temporary_prefix] if temp else [],
             quote=self.compiler.translator_class._quote_table_names,
+            schema=database,
             **kwargs,
         )
 

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -312,7 +312,15 @@ class BaseAlchemyBackend(BaseSQLBackend):
             self._run_pre_execute_hooks(obj)
 
         table = self._table_from_schema(
-            name, schema, database=database or self.current_database, temp=temp
+            name,
+            schema,
+            # most databases don't allow temporary tables in a specific
+            # database so let the backend decide
+            #
+            # the ones that do (e.g., snowflake) should implement their own
+            # `create_table`
+            database=None if temp else (database or self.current_database),
+            temp=temp,
         )
 
         if has_expr:
@@ -409,7 +417,6 @@ class BaseAlchemyBackend(BaseSQLBackend):
             *columns,
             prefixes=[self._temporary_prefix] if temp else [],
             quote=self.compiler.translator_class._quote_table_names,
-            schema=database,
             **kwargs,
         )
 

--- a/ibis/backends/snowflake/datatypes.py
+++ b/ibis/backends/snowflake/datatypes.py
@@ -26,7 +26,7 @@ _SNOWFLAKE_TYPES = {
     "DATE": dt.date,
     "TIMESTAMP": dt.timestamp,
     "VARIANT": dt.json,
-    "TIMESTAMP_LTZ": dt.timestamp,
+    "TIMESTAMP_LTZ": dt.Timestamp("UTC"),
     "TIMESTAMP_TZ": dt.Timestamp("UTC"),
     "TIMESTAMP_NTZ": dt.timestamp,
     "OBJECT": dt.Map(dt.string, dt.json),

--- a/ibis/backends/snowflake/tests/test_datatypes.py
+++ b/ibis/backends/snowflake/tests/test_datatypes.py
@@ -16,7 +16,7 @@ dtypes = [
     ("DATE", dt.date),
     ("TIMESTAMP", dt.Timestamp(scale=9)),
     ("VARIANT", dt.json),
-    ("TIMESTAMP_LTZ", dt.Timestamp(scale=9)),
+    ("TIMESTAMP_LTZ", dt.Timestamp(timezone="UTC", scale=9)),
     ("TIMESTAMP_TZ", dt.Timestamp(timezone="UTC", scale=9)),
     ("TIMESTAMP_NTZ", dt.Timestamp(scale=9)),
     ("OBJECT", dt.Map(dt.string, dt.json)),

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -224,9 +224,6 @@ def tmpcon(alchemy_con):
     "be switched from using atexit to weakref.finalize",
 )
 @mark.notimpl(["trino", "druid"], reason="doesn't implement temporary tables")
-@mark.notyet(
-    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
-)
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1144,9 +1141,6 @@ def test_create_table_timestamp(con, temp_table):
 
 
 @mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
-@mark.notyet(
-    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
-)
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1164,9 +1158,6 @@ def test_persist_expression_ref_count(con, alltypes):
 
 
 @mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
-@mark.notyet(
-    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
-)
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1178,9 +1169,6 @@ def test_persist_expression(alltypes):
 
 
 @mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
-@mark.notyet(
-    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
-)
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1194,9 +1182,6 @@ def test_persist_expression_contextmanager(alltypes):
 
 
 @mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
-@mark.notyet(
-    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
-)
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1213,9 +1198,6 @@ def test_persist_expression_contextmanager_ref_count(con, alltypes):
 
 
 @mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
-@mark.notyet(
-    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
-)
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1249,9 +1231,6 @@ def test_persist_expression_multiple_refs(con, alltypes):
 
 
 @mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
-@mark.notyet(
-    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
-)
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1266,9 +1245,6 @@ def test_persist_expression_repeated_cache(alltypes):
 
 
 @mark.notimpl(["clickhouse", "datafusion", "bigquery", "impala", "trino", "druid"])
-@mark.notyet(
-    ["sqlite"], reason="sqlite only support temporary tables in temporary databases"
-)
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",

--- a/ibis/backends/tests/test_examples.py
+++ b/ibis/backends/tests/test_examples.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.examples
     reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
     raises=OSError,
 )
-@pytest.mark.notimpl(["dask", "datafusion", "pyspark", "sqlite"])
+@pytest.mark.notimpl(["dask", "datafusion", "pyspark"])
 @pytest.mark.notyet(["bigquery", "clickhouse", "druid", "impala", "mssql", "trino"])
 @pytest.mark.parametrize(
     ("example", "columns"),

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -738,7 +738,7 @@ def test_snowflake_medium_sized_to_pandas(benchmark):
     # LINEITEM at scale factor 1 is around 6MM rows, but we limit to 1,000,000
     # to make the benchmark fast enough for development, yet large enough to show a
     # difference if there's a performance hit
-    lineitem = con.table("LINEITEM", schema="snowflake_sample_data.tpch_sf1").limit(
+    lineitem = con.table("LINEITEM", schema="SNOWFLAKE_SAMPLE_DATA.TPCH_SF1").limit(
         1_000_000
     )
 


### PR DESCRIPTION
~Depends on #6792.~

This is another set of workarounds to support consistent quoting behavior
in the presence of tables from different schemas and/or databases.

As part of this PR I moved away from using SQLAlchemy autoloading (in favor of
`Backend._metadata`).

Anecdotally, this appears to be a bit snappier than what we're currently doing.
