### PR TITLE
fix(struct-column): make `ops.StructColumn` dshape depend on its input

### DIFF
--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -409,7 +409,7 @@ def _log(op, **kw):
 @translate_val.register(tuple)
 def _node_list(op, **kw):
     values = ", ".join(map(_sql, map(partial(translate_val, **kw), op)))
-    return f"({values})"
+    return f"tuple({values})"
 
 
 def _interval_format(op):

--- a/ibis/expr/operations/structs.py
+++ b/ibis/expr/operations/structs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from public import public
 
-import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
@@ -33,7 +32,7 @@ class StructColumn(Value):
     names: VarTuple[str]
     values: VarTuple[Value]
 
-    shape = ds.columnar
+    shape = rlz.shape_like("values")
 
     @attribute.default
     def dtype(self) -> dt.DataType:

--- a/ibis/expr/operations/tests/test_structs.py
+++ b/ibis/expr/operations/tests/test_structs.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import ibis
+import ibis.expr.datashape as ds
+import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
+
+
+def test_struct_column_shape():
+    one = ops.Literal(1, dtype=dt.int64)
+    op = ops.StructColumn(names=("a",), values=(one,))
+
+    assert op.shape == ds.scalar
+
+    col = ops.TableColumn(
+        ops.UnboundTable(schema=ibis.schema(dict(a="int64")), name="t"), "a"
+    )
+    op = ops.StructColumn(names=("a",), values=(col,))
+    assert op.shape == ds.columnar


### PR DESCRIPTION
Fixes an incorrect modeling of the `StructColumn` operation dshape: it should depend on the dshape of the inputs.