### PR TITLE
test(clickhouse): fix code to avoid snapshot regeneration

### DIFF
--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -409,7 +409,8 @@ def _log(op, **kw):
 @translate_val.register(tuple)
 def _node_list(op, **kw):
     values = ", ".join(map(_sql, map(partial(translate_val, **kw), op)))
-    return f"tuple({values})"
+    prefix = "tuple" * (len(op) == 1)
+    return f"{prefix}({values})"
 
 
 def _interval_format(op):


### PR DESCRIPTION
Only generate a `tuple` prefix if there's a single element.