### PR TITLE
fix(histogram): ensure that the bin width calculation matches numpy

### DIFF
--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -34,6 +34,7 @@ from ibis.backends.pandas.core import (
     date_types,
     integer_types,
     numeric_types,
+    scalar_types,
     simple_types,
     timestamp_types,
 )
@@ -361,6 +362,9 @@ def execute_not_scalar_or_series(op, data, **kwargs):
 @execute_node.register(ops.Binary, dd.Series, dd.Series)
 @execute_node.register(ops.Binary, dd.Series, dd.core.Scalar)
 @execute_node.register(ops.Binary, dd.core.Scalar, dd.Series)
+@execute_node.register(ops.Binary, dd.core.Scalar, scalar_types)
+@execute_node.register(ops.Binary, scalar_types, dd.core.Scalar)
+@execute_node.register(ops.Binary, dd.core.Scalar, dd.core.Scalar)
 @execute_node.register(
     (ops.NumericBinary, ops.LogicalBinary, ops.Comparison),
     numeric_types,

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -1371,8 +1371,10 @@ def test_clip(backend, alltypes, df, ibis_func, pandas_func):
 )
 def test_histogram(con, alltypes):
     n = 10
-    results = con.execute(alltypes.int_col.histogram(n).name("tmp"))
-    assert len(results.value_counts()) == n
+    hist = con.execute(alltypes.int_col.histogram(n).name("hist"))
+    vc = hist.value_counts().sort_index()
+    vc_np, _bin_edges = np.histogram(alltypes.int_col.execute(), bins=n)
+    assert vc.tolist() == vc_np.tolist()
 
 
 @pytest.mark.parametrize("const", ["pi", "e"])

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -1032,17 +1032,13 @@ class NumericColumn(Column, NumericValue):
             )
 
         if binwidth is None or base is None:
-            import ibis
-
             if nbins is None:
                 raise ValueError("`nbins` is required if `binwidth` is not provided")
 
-            empty_window = ibis.window()
-
             if base is None:
-                base = self.min().over(empty_window) - eps
+                base = self.min() - eps
 
-            binwidth = (self.max().over(empty_window) - base) / (nbins - 1)
+            binwidth = (self.max() - base) / nbins
 
         return ((self - base) / binwidth).floor()
 


### PR DESCRIPTION
.histogram has a serious bug, where the bin width is calculated wrong. If you do the same calculation with np.histogram(), you get very different results. I added a fix for this.

But this still doesn't solve another bug:

`ibis.examples.penguins.fetch().bill_depth_mm.histogram(5).name("hist").value_counts().order_by("hist")`

gives 
```
┏━━━━━━━┳━━━━━━━━━━━━┓
┃ hist  ┃ hist_count ┃
┡━━━━━━━╇━━━━━━━━━━━━┩
│ int64 │ int64      │
├───────┼────────────┤
│     0 │         56 │
│     1 │         66 │
│     2 │         99 │
│     3 │         95 │
│     4 │         25 │
│     5 │          1 │
│  NULL │          2 │
└───────┴────────────┘
```

Note how the max value is assigned the bin `5`. That isn't right, the bins should only be labeled 0 to 4.

Seeing as how no one is noticing that this is broken, can we just totally update this API? Can we make it the same as numpy's? eg it returns bin edges, and supports many other nice arguments. Or just delete it or merge it with bucket()?
