### PR TITLE
feat(sql): add `database` argument to `list_schemas`

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -605,7 +605,9 @@ class CanCreateSchema(abc.ABC):
         """
 
     @abc.abstractmethod
-    def list_schemas(self, like: str | None = None) -> list[str]:
+    def list_schemas(
+        self, like: str | None = None, database: str | None = None
+    ) -> list[str]:
         """List existing schemas in the current connection.
 
         Parameters
@@ -613,6 +615,9 @@ class CanCreateSchema(abc.ABC):
         like
             A pattern in Python's regex format to filter returned schema
             names.
+        database
+            The database to list schemas from. If `None`, the current database
+            is searched.
 
         Returns
         -------
@@ -745,10 +750,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         return Database(name=name or self.current_database, client=self)
 
     @staticmethod
-    def _filter_with_like(
-        values: Iterable[str],
-        like: str | None = None,
-    ) -> list[str]:
+    def _filter_with_like(values: Iterable[str], like: str | None = None) -> list[str]:
         """Filter names with a `like` pattern (regex).
 
         The methods `list_databases` and `list_tables` accept a `like`
@@ -771,10 +773,10 @@ class BaseBackend(abc.ABC, _FileIOHandler):
             Names filtered by the `like` pattern.
         """
         if like is None:
-            return list(values)
+            return sorted(values)
 
         pattern = re.compile(like)
-        return sorted(filter(lambda t: pattern.findall(t), values))
+        return sorted(filter(pattern.findall, values))
 
     @abc.abstractmethod
     def list_tables(

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -459,10 +459,14 @@ class Backend(BaseSQLBackend, CanCreateSchema, CanListDatabases):
         table = self.client.get_table(table_ref)
         return schema_from_bigquery_table(table)
 
-    def list_schemas(self, like=None):
+    def list_schemas(
+        self, like: str | None = None, database: str | None = None
+    ) -> list[str]:
         results = [
             dataset.dataset_id
-            for dataset in self.client.list_datasets(project=self.data_project)
+            for dataset in self.client.list_datasets(
+                project=database if database is not None else self.data_project
+            )
         ]
         return self._filter_with_like(results, like)
 
@@ -472,7 +476,9 @@ class Backend(BaseSQLBackend, CanCreateSchema, CanListDatabases):
     def list_databases(self, like=None):
         return self.list_schemas(like=like)
 
-    def list_tables(self, like=None, database=None):
+    def list_tables(
+        self, like: str | None = None, database: str | None = None
+    ) -> list[str]:
         project, dataset = self._parse_project_and_dataset(database)
         dataset_ref = bq.DatasetReference(project, dataset)
         result = [table.table_id for table in self.client.list_tables(dataset_ref)]

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -99,8 +99,15 @@ class Backend(BaseBackend, CanCreateDatabase, CanCreateSchema):
             "DataFusion does not support dropping databases"
         )
 
-    def list_schemas(self, like: str | None = None) -> list[str]:
-        return self._filter_with_like(self._context.catalog().names(), like=like)
+    def list_schemas(
+        self, like: str | None = None, database: str | None = None
+    ) -> list[str]:
+        return self._filter_with_like(
+            self._context.catalog(
+                database if database is not None else "datafusion"
+            ).names(),
+            like=like,
+        )
 
     def create_schema(
         self, name: str, database: str | None = None, force: bool = False

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -72,7 +72,7 @@ class Backend(BaseAlchemyBackend, CanCreateDatabase, AlchemyCanCreateSchema):
 
     def list_databases(self, like: str | None = None) -> list[str]:
         s = sa.table("databases", sa.column("name", sa.VARCHAR()), schema="sys")
-        query = sa.select(sa.distinct(s.c.name)).select_from(s).order_by(s.c.name)
+        query = sa.select(s.c.name)
 
         with self.begin() as con:
             results = list(con.execute(query).scalars())

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -139,6 +139,11 @@ class Backend(BaseAlchemyBackend, CanCreateDatabase):
 
         return meta
 
+    def list_databases(self, like: str | None = None) -> list[str]:
+        # In MySQL, "database" and "schema" are synonymous
+        databases = self.inspector.get_schema_names()
+        return self._filter_with_like(databases, like)
+
     def _metadata(self, query: str) -> Iterable[tuple[str, dt.DataType]]:
         if (
             re.search(r"^\s*SELECT\s", query, flags=re.MULTILINE | re.IGNORECASE)

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -172,11 +172,13 @@ class Backend(BaseSQLBackend, CanCreateDatabase):
     def current_database(self) -> str:
         return self._catalog.currentDatabase()
 
-    def list_databases(self, like=None):
+    def list_databases(self, like: str | None = None) -> list[str]:
         databases = [db.name for db in self._catalog.listDatabases()]
         return self._filter_with_like(databases, like)
 
-    def list_tables(self, like=None, database=None):
+    def list_tables(
+        self, like: str | None = None, database: str | None = None
+    ) -> list[str]:
         tables = [
             t.name
             for t in self._catalog.listTables(dbName=database or self.current_database)

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -23,6 +23,7 @@ def temp_db(con):
 def temp_schema(con, temp_db):
     schema = gen_name("tmp_schema")
     con.raw_sql(f"CREATE SCHEMA {temp_db}.{schema}")
+    assert schema in con.list_schemas(database=temp_db)
     yield schema
     con.raw_sql(f"DROP SCHEMA {temp_db}.{schema}")
 

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -21,11 +21,10 @@ def test_version(backend):
 
 # 1. `current_database` returns '.', but isn't listed in list_databases()
 @pytest.mark.never(
-    ["polars", "dask", "pandas"],
+    ["polars", "dask", "pandas", "druid", "oracle"],
     reason="backend does not support databases",
     raises=AttributeError,
 )
-@pytest.mark.notimpl(["oracle"], raises=AssertionError)
 @pytest.mark.notimpl(
     ["datafusion"],
     raises=NotImplementedError,

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -503,6 +503,11 @@ def test_insert_from_memtable(alchemy_con, alchemy_temp_table):
     assert alchemy_con.tables[table_name].schema() == ibis.schema({"x": "int64"})
 
 
+@pytest.mark.notyet(
+    ["oracle"],
+    raises=AttributeError,
+    reason="oracle doesn't support the common notion of a database",
+)
 def test_list_databases(alchemy_con):
     # Every backend has its own databases
     test_databases = {
@@ -1354,5 +1359,21 @@ def test_create_database_schema(con_create_database_schema):
         schema = gen_name("test_create_database_schema")
         con_create_database_schema.create_schema(schema, database=database)
         con_create_database_schema.drop_schema(schema, database=database)
+    finally:
+        con_create_database_schema.drop_database(database)
+
+
+@pytest.mark.notyet(["datafusion"], reason="cannot list or drop databases")
+def test_list_databases_schemas(con_create_database_schema):
+    database = gen_name("test_create_database")
+    con_create_database_schema.create_database(database)
+    try:
+        schema = gen_name("test_create_database_schema")
+        con_create_database_schema.create_schema(schema, database=database)
+
+        try:
+            assert schema in con_create_database_schema.list_schemas(database=database)
+        finally:
+            con_create_database_schema.drop_schema(schema, database=database)
     finally:
         con_create_database_schema.drop_database(database)


### PR DESCRIPTION
This PR adds a `database` argument to  `list_schemas` for listing schemas in databases other than the currently active one.