### PR TITLE
fix(api): fail on trying to construct an iterable of a deferred object

### DIFF
--- a/ibis/expr/deferred.py
+++ b/ibis/expr/deferred.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import operator
-from typing import Any, Callable
+from typing import Any, Callable, NoReturn
 
 _BINARY_OPS: dict[str, Callable[[Any, Any], Any]] = {
     "+": operator.add,
@@ -59,9 +59,14 @@ class Deferred:
     def _resolve(self, param: Any) -> Any:
         return param
 
+    def __iter__(self) -> NoReturn:
+        raise TypeError(f"{self.__class__.__name__!r} object is not iterable")
+
     def __getattr__(self, attr: str) -> Deferred:
         if attr.startswith("__"):
-            raise AttributeError(f"'Deferred' object has no attribute {attr!r}")
+            raise AttributeError(
+                f"{self.__class__.__name__!r} object has no attribute {attr!r}"
+            )
         return DeferredAttr(self, attr)
 
     def __getitem__(self, key: Any) -> Deferred:

--- a/ibis/expr/tests/test_deferred.py
+++ b/ibis/expr/tests/test_deferred.py
@@ -49,6 +49,9 @@ def test_magic_methods_not_deferred():
     with pytest.raises(AttributeError, match="__fizzbuzz__"):
         _.__fizzbuzz__()
 
+    with pytest.raises(AttributeError, match="DeferredAttr.+__fizzbuzz__"):
+        _.a.__fizzbuzz__()
+
 
 def test_getattr(table):
     expr = _.a
@@ -166,3 +169,15 @@ def test_unary_ops(symbol, op, table):
     res = expr.resolve(table)
     assert res.equals(sol)
     assert repr(expr) == f"{symbol}_.a"
+
+
+@pytest.mark.parametrize("obj", [_, _.a, _.a.b[0]])
+def test_deferred_is_not_iterable(obj):
+    with pytest.raises(TypeError, match="object is not iterable"):
+        sorted(obj)
+
+    with pytest.raises(TypeError, match="object is not iterable"):
+        iter(obj)
+
+    with pytest.raises(TypeError, match="is not an iterator"):
+        next(obj)

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import contextlib
 import os
 import webbrowser
-from typing import TYPE_CHECKING, Any, Mapping, Tuple
+from typing import TYPE_CHECKING, Any, Mapping, NoReturn, Tuple
 
 from public import public
 
 import ibis.expr.operations as ops
-from ibis.common.exceptions import IbisError, IbisTypeError, TranslationError
+from ibis.common.exceptions import IbisError, TranslationError
 from ibis.common.grounds import Immutable
 from ibis.config import _default_backend, options
 from ibis.util import experimental
@@ -44,6 +44,9 @@ class Expr(Immutable, Coercible):
 
     def __init__(self, arg: ops.Node) -> None:
         object.__setattr__(self, "_arg", arg)
+
+    def __iter__(self) -> NoReturn:
+        raise TypeError(f"{self.__class__.__name__!r} object is not iterable")
 
     @classmethod
     def __coerce__(cls, value):

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -217,7 +217,15 @@ def is_iterable(o: Any) -> bool:
     >>> is_iterable([])
     True
     """
-    return not isinstance(o, (str, bytes)) and isinstance(o, collections.abc.Iterable)
+    if isinstance(o, (str, bytes)):
+        return False
+
+    try:
+        iter(o)
+    except TypeError:
+        return False
+    else:
+        return True
 
 
 def convert_unit(value, unit, to, floor: bool = True):


### PR DESCRIPTION
This PR fixes an issue where non-ibis APIs that depend on implicit
implementations of `__iter__` that use `__getitem__` would never terminate due
to `Deferred` instances implementing an always-succeeding version of
`__getitem__`.

The main downside is that because `Deferred` now implements `__iter__` it
appears to be iterable, so we have to exclude it from `is_iterable` instances
checks explicitly.
