### PR TITLE
feat(ux): promote lists of strings to `any_of` selectors

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1069,8 +1069,7 @@ class Table(Expr, _FixedTextJupyterMixin):
                 )
             return ops.Distinct(self).to_expr()
 
-        if not isinstance(on, s.Selector):
-            on = s.c(*util.promote_list(on))
+        on = s._to_selector(on)
 
         if keep is None:
             having = lambda t: t.count() == 1
@@ -1936,8 +1935,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         ):
             raise KeyError(f"Fields not in table: {sorted(missing_fields)}")
 
-        sels = (s.c(f) if isinstance(f, str) else f for f in fields)
-        return self.select(~s.any_of(*sels))
+        return self.select(~s._to_selector(fields))
 
     def filter(
         self,
@@ -3111,7 +3109,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         """
         import ibis.selectors as s
 
-        pivot_sel = s.c(col) if isinstance(col, str) else col
+        pivot_sel = s._to_selector(col)
 
         pivot_cols = pivot_sel.expand(self)
         if not pivot_cols:
@@ -3334,7 +3332,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         >>> us_rent_income.pivot_wider(
         ...     names_from="variable",
         ...     names_sep=".",
-        ...     values_from=s.c("estimate", "moe"),
+        ...     values_from=("estimate", "moe"),
         ... )
         ┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━┓
         ┃ geoid  ┃ name                 ┃ estimate.income ┃ moe.income ┃ … ┃
@@ -3540,8 +3538,8 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         orig_names_from = util.promote_list(names_from)
 
-        names_from = s.any_of(*map(s._to_selector, orig_names_from))
-        values_from = s.any_of(*map(s._to_selector, util.promote_list(values_from)))
+        names_from = s._to_selector(orig_names_from)
+        values_from = s._to_selector(values_from)
 
         if id_cols is None:
             id_cols = ~(names_from | values_from)

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -351,15 +351,15 @@ def matches(regex: str | re.Pattern) -> Selector:
 
 
 @public
-def any_of(*predicates: Predicate) -> Predicate:
+def any_of(*predicates: str | Predicate) -> Predicate:
     """Include columns satisfying any of `predicates`."""
-    return functools.reduce(operator.or_, predicates)
+    return functools.reduce(operator.or_, map(_to_selector, predicates))
 
 
 @public
-def all_of(*predicates: Predicate) -> Predicate:
+def all_of(*predicates: str | Predicate) -> Predicate:
     """Include columns satisfying all of `predicates`."""
-    return functools.reduce(operator.and_, predicates)
+    return functools.reduce(operator.and_, map(_to_selector, predicates))
 
 
 @public
@@ -653,6 +653,11 @@ def all() -> Predicate:
     return r[:]
 
 
-def _to_selector(obj: str | Selector) -> Selector:
+def _to_selector(obj: str | Selector | Sequence[str | Selector]) -> Selector:
     """Convert an object to a `Selector`."""
-    return c(obj) if isinstance(obj, str) else obj
+    if isinstance(obj, Selector):
+        return obj
+    elif isinstance(obj, str):
+        return c(obj)
+    else:
+        return any_of(*obj)

--- a/ibis/tests/expr/test_selectors.py
+++ b/ibis/tests/expr/test_selectors.py
@@ -451,3 +451,23 @@ def test_any_of_string_list(penguins):
         "bill_length_mm", "flipper_length_mm", "body_mass_g", "year"
     )
     assert expr.equals(expected)
+
+
+def test_c_error_on_misspelled_column(penguins):
+    match = "Columns .+ are not present"
+
+    sel = s.c("inland")
+    with pytest.raises(exc.IbisInputError, match=match):
+        penguins.select(sel)
+
+    sel = s.any_of(s.c("inland"), s.c("island"))
+    with pytest.raises(exc.IbisInputError, match=match):
+        penguins.select(sel)
+
+    sel = s.any_of(s.c("island"), s.c("inland"))
+    with pytest.raises(exc.IbisInputError, match=match):
+        penguins.select(sel)
+
+    sel = s.any_of(s.c("island", "inland"))
+    with pytest.raises(exc.IbisInputError, match=match):
+        penguins.select(sel)

--- a/ibis/tests/expr/test_selectors.py
+++ b/ibis/tests/expr/test_selectors.py
@@ -432,7 +432,22 @@ def test_all_of(penguins):
     assert expr.equals(expected)
 
 
+def test_all_of_string_list(penguins):
+    # a bit silly, but robust nonetheless
+    expr = penguins.select(s.all_of("year", "year"))
+    expected = penguins.select("year")
+    assert expr.equals(expected)
+
+
 def test_any_of(penguins):
     expr = penguins.select(s.any_of(s.startswith("bill"), s.c("year")))
     expected = penguins.select("bill_length_mm", "bill_depth_mm", "year")
+    assert expr.equals(expected)
+
+
+def test_any_of_string_list(penguins):
+    expr = penguins.select(s.any_of("year", "body_mass_g", s.matches("length")))
+    expected = penguins.select(
+        "bill_length_mm", "flipper_length_mm", "body_mass_g", "year"
+    )
     assert expr.equals(expected)

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1798,9 +1798,7 @@ def test_pivot_wider():
         names=["Release", "Lisbon"], names_from="station", values_from="seen"
     )
     assert res.schema().names == ("fish", "Release", "Lisbon")
-    with pytest.raises(
-        com.IbisInputError, match="No matching names columns in `names_from`"
-    ):
+    with pytest.raises(com.IbisInputError, match="Columns .+ are not present in"):
         fish.pivot_wider(names=["Release", "Lisbon"], values_from="seen")
 
 


### PR DESCRIPTION
This PR adds promotion of lists of column names to `s.any_of(s.c(col0), s.c(col1), ...)` selectors, which allows specifying them wherever you can specifyc `s.c(...)`.