### PR TITLE
fix(trino): fix `list_databases` to show all catalogs and `list_schemas` to allow the `database` argument

### DIFF
--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -50,9 +50,17 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema, CanListDatabases):
             catalogs = list(con.exec_driver_sql(query).scalars())
         return self._filter_with_like(catalogs, like=like)
 
+    def list_schemas(
+        self, like: str | None = None, database: str | None = None
+    ) -> list[str]:
+        query = "SHOW SCHEMAS"
+
+        if database is not None:
+            query += f" IN {self._quote(database)}"
+
         with self.begin() as con:
-            results = list(con.execute(query).scalars())
-        return self._filter_with_like(results, like=like)
+            schemata = list(con.exec_driver_sql(query).scalars())
+        return self._filter_with_like(schemata, like)
 
     @property
     def current_schema(self) -> str:
@@ -108,7 +116,7 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema, CanListDatabases):
 
     @contextlib.contextmanager
     def _prepare_metadata(self, query: str) -> Iterator[dict[str, str]]:
-        name = util.gen_name("ibis_trino_metadata")
+        name = util.gen_name("trino_metadata")
         with self.begin() as con:
             con.exec_driver_sql(f"PREPARE {name} FROM {query}")
             try:

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -46,3 +46,13 @@ def test_hive_table_overwrite(tmp_name):
     t = con.create_table(tmp_name, schema=schema, overwrite=True)
     assert tmp_name in con.list_tables()
     assert t.schema() == schema
+
+
+def test_list_catalogs(con):
+    assert {"hive", "postgresql", "memory", "system", "tpch", "tpcds"}.issubset(
+        con.list_databases()
+    )
+
+
+def test_list_schemas(con):
+    assert {"information_schema", "sf1"}.issubset(con.list_schemas(database="tpch"))


### PR DESCRIPTION
This PR fixes the trino implementations of `list_databases` (only lists the current catalog instead of all available catalogs), and `list_schemas` (incorrect quoting of the schema in the base sqlalchemy implementation).