### PR TITLE
feat(trino): add support for cross-schema and cross-catalog table operations

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -786,10 +786,11 @@ class BaseBackend(abc.ABC, _FileIOHandler):
 
         Parameters
         ----------
-        like : str, optional
+        like
             A pattern in Python's regex format.
-        database : str, optional
-            The database to list tables of, if not the current one.
+        database
+            The database from which to list tables. If not provided, the
+            current database is used.
 
         Returns
         -------


### PR DESCRIPTION
This PR adds support for cross-schema and cross-catalog table operations to the trino backend. I pulled out the logic to access metadata into a specialized SQLAlchemy backend that is shared with the Snowflake backend due to their near-identical logic for achieving the same result.