### PR TITLE
chore(benchmarks): require a benchmark run number when invoking `just benchcmp`

### DIFF
--- a/justfile
+++ b/justfile
@@ -105,8 +105,8 @@ bench +args='ibis/tests/benchmarks':
     pytest --benchmark-only --benchmark-enable --benchmark-autosave {{ args }}
 
 # run benchmarks and compare with a previous run
-benchcmp *args:
-    just bench {{ args }} --benchmark-compare
+benchcmp number *args:
+    just bench --benchmark-compare {{ number }} {{ args }}
 
 # check for invalid links in a locally built version of the docs
 checklinks *args:


### PR DESCRIPTION
Require a benchmark run number when running `just benchcmp` to avoid spurious comparisons to benchmark runs on the same commit.