### PR TITLE
perf(duckdb): speed up performance with wide tables

### DIFF
--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -700,13 +700,12 @@ class BaseAlchemyBackend(BaseSQLBackend):
 
             from_table_expr = obj
 
-            with self.begin() as bind:
-                if from_table_expr is not None:
-                    compiled = from_table_expr.compile()
-                    columns = [
-                        self.con.dialect.normalize_name(c)
-                        for c in from_table_expr.columns
-                    ]
+            if from_table_expr is not None:
+                compiled = from_table_expr.compile()
+                columns = [
+                    self.con.dialect.normalize_name(c) for c in from_table_expr.columns
+                ]
+                with self.begin() as bind:
                     bind.execute(to_table.insert().from_select(columns, compiled))
         elif isinstance(obj, (list, dict)):
             to_table = self._get_sqla_table(table_name, schema=database)

--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -95,17 +95,17 @@ def test_null_dtype():
 def test_parse_quoted_struct_field():
     import ibis.backends.duckdb.datatypes as ddt
 
-    assert ddt.parse('STRUCT("a" INT, "a b c" INT)') == dt.Struct(
+    assert ddt.parse('STRUCT("a" INTEGER, "a b c" INTEGER)') == dt.Struct(
         {"a": dt.int32, "a b c": dt.int32}
     )
 
 
 def test_generate_quoted_struct():
     typ = sat.StructType(
-        {"in come": sa.TEXT(), "my count": sa.BIGINT(), "thing": sa.INT()}
+        {"in come": sa.VARCHAR(), "my count": sa.BIGINT(), "thing": sa.INTEGER()}
     )
     result = typ.compile(dialect=duckdb_engine.Dialect())
-    expected = 'STRUCT("in come" TEXT, "my count" BIGINT, thing INTEGER)'
+    expected = 'STRUCT("in come" VARCHAR, "my count" BIGINT, thing INTEGER)'
     assert result == expected
 
 

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -743,3 +743,13 @@ def test_snowflake_medium_sized_to_pandas(benchmark):
     )
 
     benchmark.pedantic(lineitem.to_pandas, rounds=5, iterations=1, warmup_rounds=1)
+
+
+def test_parse_many_duckdb_types(benchmark):
+    parse = pytest.importorskip("ibis.backends.duckdb.datatypes").parse
+
+    def parse_many(types):
+        list(map(parse, types))
+
+    types = ["VARCHAR", "INTEGER", "DOUBLE", "BIGINT"] * 1000
+    benchmark(parse_many, types)


### PR DESCRIPTION
This PR implements some performance improvements to the duckdb backend in support
of making one of the more difficult-to-make-usable use cases workable.

That use case is CSV files with lots of columns.

The primary part of the duckdb backend that's faster here is table metadata handling.

This is made up of a few components, and process is roughly:

1. Run a `DESCRIBE SELECT * FROM table` query to get the names and types from duckdb
1. Parse the type strings into ibis types
1. Construct a `sqlalchemy.Table` object from the resulting list of column
   names and types

It turns out that **all three** of these steps were very slow in "lots of columns" case.

### `DESCRIBE` has slightly surprising behavior (to me)

`DESCRIBE SELECT * FROM table` seems to be **slower** than `DESCRIBE table` if
`table` is a view of CSV file. I'm not sure why, but this PR moves everything
to use plain `DESCRIBE table`

### `parsy` is much slower than `sqlglot`

`parsy` was extremely to parse that many type strings. I measured about 6
seconds to parse them all versus the new sqlglot-based implementation takes
less than a second to parse them all.

**parsy**:

```
In [1]: from ibis.backends.duckdb.datatypes import parse

In [2]: %time res = list(map(parse, ['VARCHAR'] * 3220))  # 3220 is the number of columns
CPU times: user 5.76 s, sys: 0 ns, total: 5.76 s
Wall time: 5.76 s
```

**sqlglot**:

```
In [3]: import sqlglot as sg

In [4]: def parse(s):
   ...:     return sg.parse_one(s, into=sg.exp.DataType, read="duckdb")
   ...:

In [5]: %time res = list(map(parse, ['VARCHAR'] * 3220))
CPU times: user 82.1 ms, sys: 15 µs, total: 82.1 ms
Wall time: 81.6 ms
```

These aren't equivalent, because we're constructing ibis datatype objects after parsing, but the times are effectively the same for the scalar types:

```
cloud in 🌐 falcon in …/ibis on  duckdb-metadata-speedup is 📦 v6.1.0 via 🐍 v3.10.12 via ❄️  impure (ibis-3.10.12-env) took 19s
❯ ipython

In [1]: from ibis.backends.duckdb.datatypes import parse

In [2]: %time res = list(map(parse, ['VARCHAR'] * 3220))
CPU times: user 82.1 ms, sys: 1.24 ms, total: 83.4 ms
Wall time: 81.4 ms
```

That's a nice 70x (!) win for type parsing.

### Getting metadata in arrow is much faster; constructing `sa.Table`s is very expensive

The first part of this heading is not suprprising: I changed the implementation
to bring back the metadata from `DESCRIBE` as an arrow table instead of a list
of tuples. This saved a bit of time, but not that much.

The real win was avoiding `sa.Table`, which appears to do a lot of work on construction.

I tried the lighter weight `sa.table`, which does a lot less work on construction.

Using `pyinstrument`, it was actually hard to tell how much time was saved, because the `sa.table`
construction doesn't even show up!

Maybe there's a way to continue to use `sa.Table`, but I didn't really feel
like going down that rabbit hole.

### Wide-table CSVs are now usable in ibis

After this PR the CSV from the #6832 is now usable in ibis in an interactive shell session.

Closes #6832.
