### PR TITLE
feat(trino): add application source to the trino client by default

### DIFF
--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -74,6 +74,7 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema, CanListDatabases):
         port: int = 8080,
         database: str | None = None,
         schema: str | None = None,
+        source: str | None = None,
         **connect_args,
     ) -> None:
         """Create an Ibis client connected to a Trino database."""
@@ -85,6 +86,7 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema, CanListDatabases):
             host=host,
             port=port,
             database=database,
+            query=dict(source="ibis" if source is None else source),
         )
         connect_args.setdefault("timezone", "UTC")
         with warnings.catch_warnings():

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -77,7 +77,46 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema, CanListDatabases):
         source: str | None = None,
         **connect_args,
     ) -> None:
-        """Create an Ibis client connected to a Trino database."""
+        """Connect to Trino.
+
+        Parameters
+        ----------
+        user
+            Username to connect with
+        password
+            Password to connect with
+        host
+            Hostname of the Trino server
+        port
+            Port of the Trino server
+        database
+            Catalog to use on the Trino server
+        schema
+            Schema to use on the Trino server
+        source
+            Application name passed to Trino
+        connect_args
+            Additional keyword arguments passed directly to SQLAlchemy's
+            `create_engine`
+
+        Examples
+        --------
+        >>> catalog = "hive"
+        >>> schema = "default"
+
+        Connect using a URL, with the default user, password, host and port
+
+        >>> con = ibis.connect(f"trino:///{catalog}/{schema}")
+
+        Connect using a URL
+
+        >>> con = ibis.connect(f"trino://user:password@host:port/{catalog}/{schema}")
+
+        Connect using keyword arguments
+
+        >>> con = ibis.trino.connect(database=catalog, schema=schema)
+        >>> con = ibis.trino.connect(database=catalog, schema=schema, source="my-app")
+        """
         database = "/".join(filter(None, (database, schema)))
         url = sa.engine.URL.create(
             drivername="trino",

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import pytest
 
 import ibis
+from ibis.backends.trino.tests.conftest import (
+    TRINO_HOST,
+    TRINO_PASS,
+    TRINO_PORT,
+    TRINO_USER,
+)
 
 
 @pytest.fixture
@@ -56,3 +62,17 @@ def test_list_catalogs(con):
 
 def test_list_schemas(con):
     assert {"information_schema", "sf1"}.issubset(con.list_schemas(database="tpch"))
+
+
+@pytest.mark.parametrize(("source", "expected"), [(None, "ibis"), ("foo", "foo")])
+def test_con_source(source, expected):
+    con = ibis.trino.connect(
+        user=TRINO_USER,
+        host=TRINO_HOST,
+        port=TRINO_PORT,
+        password=TRINO_PASS,
+        database="hive",
+        schema="default",
+        source=source,
+    )
+    assert con.con.url.query["source"] == expected


### PR DESCRIPTION
- feat(trino): add source application to trino backend
- docs(trino): add connection docstring
