### PR TITLE
chore(dev-deps): bump JDK and move to supported JDK docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,7 +234,7 @@ services:
       retries: 10
       test:
         - CMD-SHELL
-        - trino --execute 'SELECT 1 AS one'
+        - trino --output-format null --execute 'show schemas in postgresql; show schemas in hive; show schemas in memory'
       timeout: 30s
     image: trinodb/trino:423
     ports:

--- a/docker/trino/Dockerfile
+++ b/docker/trino/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u342-jre
+FROM eclipse-temurin:8u342-b07-jre-jammy
 
 WORKDIR /opt
 

--- a/docker/trino/entrypoint.sh
+++ b/docker/trino/entrypoint.sh
@@ -2,7 +2,7 @@
 
 export HADOOP_HOME=/opt/hadoop-3.2.0
 export HADOOP_CLASSPATH=${HADOOP_HOME}/share/hadoop/tools/lib/aws-java-sdk-bundle-1.11.375.jar:${HADOOP_HOME}/share/hadoop/tools/lib/hadoop-aws-3.2.0.jar
-export JAVA_HOME=/usr/local/openjdk-8
+export JAVA_HOME=/opt/java/openjdk
 
 # Make sure mariadb is ready
 MAX_TRIES=8


### PR DESCRIPTION
This PR moves our `hive-metastore` docker image to use a supported JDK, as well as bumps its version.