### PR TITLE
fix(snowflake): ensure that laterals joins with newlines are also rewritten

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -779,7 +779,7 @@ def compile_join(element, compiler, **kw):
     result = compiler.visit_join(element, **kw)
 
     if element.right._is_lateral:
-        return re.sub(r"^(.+) ON true$", r"\1", result, flags=re.IGNORECASE)
+        return re.sub(r"^(.+) ON true$", r"\1", result, flags=re.IGNORECASE | re.DOTALL)
     return result
 
 

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -244,3 +244,9 @@ def test_map_create_table(con, temp_table):
 def test_map_length(con):
     expr = ibis.literal(dict(a="A", b="B")).length()
     assert con.execute(expr) == 2
+
+
+def test_map_keys_unnest(backend):
+    expr = backend.map.head(1).kv.keys().unnest()
+    result = expr.to_pandas()
+    assert frozenset(result) == frozenset("abc")


### PR DESCRIPTION
Fixes a bug in snowflake lateral join rewriting where we were not accounting for newlines. Discovered fiddling around with #6851.