### PR TITLE
fix(type hints): remove notimplemented as type hints as not valid

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -544,9 +544,7 @@ class Expr(Immutable, Coercible):
         raise NotImplementedError(type(self))
 
 
-def _binop(
-    op_class: type[ops.Binary], left: ir.Value, right: ir.Value
-) -> ir.Value | NotImplemented:
+def _binop(op_class: type[ops.Binary], left: ir.Value, right: ir.Value) -> ir.Value:
     """Try to construct a binary operation.
 
     Parameters

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -654,25 +654,25 @@ class NumericValue(Value):
         """
         return ops.Tan(self).to_expr()
 
-    def __add__(self, other: NumericValue) -> NumericValue | NotImplemented:
+    def __add__(self, other: NumericValue) -> NumericValue:
         """Add `self` with `other`."""
         return _binop(ops.Add, self, other)
 
     add = radd = __radd__ = __add__
 
-    def __sub__(self, other: NumericValue) -> NumericValue | NotImplemented:
+    def __sub__(self, other: NumericValue) -> NumericValue:
         """Subtract `other` from `self`."""
         return _binop(ops.Subtract, self, other)
 
     sub = __sub__
 
-    def __rsub__(self, other: NumericValue) -> NumericValue | NotImplemented:
+    def __rsub__(self, other: NumericValue) -> NumericValue:
         """Subtract `self` from `other`."""
         return _binop(ops.Subtract, other, self)
 
     rsub = __rsub__
 
-    def __mul__(self, other: NumericValue) -> NumericValue | NotImplemented:
+    def __mul__(self, other: NumericValue) -> NumericValue:
         """Multiply `self` and `other`."""
         return _binop(ops.Multiply, self, other)
 
@@ -684,7 +684,7 @@ class NumericValue(Value):
 
     div = __div__ = __truediv__
 
-    def __rtruediv__(self, other: NumericValue) -> NumericValue | NotImplemented:
+    def __rtruediv__(self, other: NumericValue) -> NumericValue:
         """Divide `other` by `self`."""
         return _binop(ops.Divide, other, self)
 
@@ -693,7 +693,7 @@ class NumericValue(Value):
     def __floordiv__(
         self,
         other: NumericValue,
-    ) -> NumericValue | NotImplemented:
+    ) -> NumericValue:
         """Floor divide `self` by `other`."""
         return _binop(ops.FloorDivide, self, other)
 
@@ -702,31 +702,31 @@ class NumericValue(Value):
     def __rfloordiv__(
         self,
         other: NumericValue,
-    ) -> NumericValue | NotImplemented:
+    ) -> NumericValue:
         """Floor divide `other` by `self`."""
         return _binop(ops.FloorDivide, other, self)
 
     rfloordiv = __rfloordiv__
 
-    def __pow__(self, other: NumericValue) -> NumericValue | NotImplemented:
+    def __pow__(self, other: NumericValue) -> NumericValue:
         """Raise `self` to the `other`th power."""
         return _binop(ops.Power, self, other)
 
     pow = __pow__
 
-    def __rpow__(self, other: NumericValue) -> NumericValue | NotImplemented:
+    def __rpow__(self, other: NumericValue) -> NumericValue:
         """Raise `other` to the `self`th power."""
         return _binop(ops.Power, other, self)
 
     rpow = __rpow__
 
-    def __mod__(self, other: NumericValue) -> NumericValue | NotImplemented:
+    def __mod__(self, other: NumericValue) -> NumericValue:
         """Compute `self` modulo `other`."""
         return _binop(ops.Modulus, self, other)
 
     mod = __mod__
 
-    def __rmod__(self, other: NumericValue) -> NumericValue | NotImplemented:
+    def __rmod__(self, other: NumericValue) -> NumericValue:
         """Compute `other` modulo `self`."""
 
         return _binop(ops.Modulus, other, self)
@@ -1102,37 +1102,37 @@ class IntegerValue(NumericValue):
         """
         return ops.BaseConvert(self, from_base, to_base).to_expr()
 
-    def __and__(self, other: IntegerValue) -> IntegerValue | NotImplemented:
+    def __and__(self, other: IntegerValue) -> IntegerValue:
         """Bitwise and `self` with `other`."""
         return _binop(ops.BitwiseAnd, self, other)
 
     __rand__ = __and__
 
-    def __or__(self, other: IntegerValue) -> IntegerValue | NotImplemented:
+    def __or__(self, other: IntegerValue) -> IntegerValue:
         """Bitwise or `self` with `other`."""
         return _binop(ops.BitwiseOr, self, other)
 
     __ror__ = __or__
 
-    def __xor__(self, other: IntegerValue) -> IntegerValue | NotImplemented:
+    def __xor__(self, other: IntegerValue) -> IntegerValue:
         """Bitwise xor `self` with `other`."""
         return _binop(ops.BitwiseXor, self, other)
 
     __rxor__ = __xor__
 
-    def __lshift__(self, other: IntegerValue) -> IntegerValue | NotImplemented:
+    def __lshift__(self, other: IntegerValue) -> IntegerValue:
         """Bitwise left shift `self` with `other`."""
         return _binop(ops.BitwiseLeftShift, self, other)
 
-    def __rlshift__(self, other: IntegerValue) -> IntegerValue | NotImplemented:
+    def __rlshift__(self, other: IntegerValue) -> IntegerValue:
         """Bitwise left shift `self` with `other`."""
         return _binop(ops.BitwiseLeftShift, other, self)
 
-    def __rshift__(self, other: IntegerValue) -> IntegerValue | NotImplemented:
+    def __rshift__(self, other: IntegerValue) -> IntegerValue:
         """Bitwise right shift `self` with `other`."""
         return _binop(ops.BitwiseRightShift, self, other)
 
-    def __rrshift__(self, other: IntegerValue) -> IntegerValue | NotImplemented:
+    def __rrshift__(self, other: IntegerValue) -> IntegerValue:
         """Bitwise right shift `self` with `other`."""
         return _binop(ops.BitwiseRightShift, other, self)
 

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -1510,7 +1510,7 @@ class StringValue(Value):
         """
         return ops.BaseConvert(self, from_base, to_base).to_expr()
 
-    def __mul__(self, n: int | ir.IntegerValue) -> StringValue | NotImplemented:
+    def __mul__(self, n: int | ir.IntegerValue) -> StringValue:
         return _binop(ops.Repeat, self, n)
 
     __rmul__ = __mul__

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -210,7 +210,7 @@ class TimeValue(_TimeComponentMixin, TemporalValue):
     def __add__(
         self,
         other: datetime.timedelta | pd.Timedelta | IntervalValue,
-    ) -> TimeValue | NotImplemented:
+    ) -> TimeValue:
         """Add an interval to a time expression."""
         return _binop(ops.TimeAdd, self, other)
 
@@ -224,7 +224,7 @@ class TimeValue(_TimeComponentMixin, TemporalValue):
 
     Returns
     -------
-    Value : TimeValue | NotImplemented
+    Value : TimeValue
     """
 
     @annotated
@@ -248,7 +248,7 @@ class TimeValue(_TimeComponentMixin, TemporalValue):
 
     Returns
     -------
-    Value : IntervalValue | TimeValue | NotImplemented
+    Value : IntervalValue | TimeValue
     """
 
     @annotated
@@ -295,7 +295,7 @@ class DateValue(TemporalValue, _DateComponentMixin):
     def __add__(
         self,
         other: datetime.timedelta | pd.Timedelta | IntervalValue,
-    ) -> DateValue | NotImplemented:
+    ) -> DateValue:
         """Add an interval to a date."""
         return _binop(ops.DateAdd, self, other)
 
@@ -309,7 +309,7 @@ class DateValue(TemporalValue, _DateComponentMixin):
 
     Returns
     -------
-    Value : DateValue | NotImplemented
+    Value : DateValue
     """
 
     @annotated
@@ -333,7 +333,7 @@ class DateValue(TemporalValue, _DateComponentMixin):
 
     Returns
     -------
-    Value : DateValue | NotImplemented
+    Value : DateValue
     """
 
     @annotated
@@ -393,7 +393,7 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, TemporalValue):
     def __add__(
         self,
         other: datetime.timedelta | pd.Timedelta | IntervalValue,
-    ) -> TimestampValue | NotImplemented:
+    ) -> TimestampValue:
         """Add an interval to a timestamp."""
         return _binop(ops.TimestampAdd, self, other)
 
@@ -407,7 +407,7 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, TemporalValue):
 
     Returns
     -------
-    Value : TimestampValue | NotImplemented
+    Value : TimestampValue
     """
 
     @annotated
@@ -431,7 +431,7 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, TemporalValue):
 
     Returns
     -------
-    Value : IntervalValue | TimestampValue | NotImplemented
+    Value : IntervalValue | TimestampValue
     """
 
     @annotated
@@ -537,7 +537,7 @@ class IntervalValue(Value):
     def __add__(
         self,
         other: datetime.timedelta | pd.Timedelta | IntervalValue,
-    ) -> IntervalValue | NotImplemented:
+    ) -> IntervalValue:
         """Add this interval to `other`."""
         return _binop(ops.IntervalAdd, self, other)
 
@@ -546,7 +546,7 @@ class IntervalValue(Value):
     def __sub__(
         self,
         other: datetime.timedelta | pd.Timedelta | IntervalValue,
-    ) -> IntervalValue | NotImplemented:
+    ) -> IntervalValue:
         """Subtract `other` from this interval."""
         return _binop(ops.IntervalSubtract, self, other)
 
@@ -555,7 +555,7 @@ class IntervalValue(Value):
     def __rsub__(
         self,
         other: datetime.timedelta | pd.Timedelta | IntervalValue,
-    ) -> IntervalValue | NotImplemented:
+    ) -> IntervalValue:
         """Subtract `other` from this interval."""
         return _binop(ops.IntervalSubtract, other, self)
 
@@ -564,7 +564,7 @@ class IntervalValue(Value):
     def __mul__(
         self,
         other: int | ir.IntegerValue,
-    ) -> IntervalValue | NotImplemented:
+    ) -> IntervalValue:
         """Multiply this interval by `other`."""
         return _binop(ops.IntervalMultiply, self, other)
 
@@ -573,7 +573,7 @@ class IntervalValue(Value):
     def __floordiv__(
         self,
         other: ir.IntegerValue,
-    ) -> IntervalValue | NotImplemented:
+    ) -> IntervalValue:
         """Floor-divide this interval by `other`."""
         return _binop(ops.IntervalFloorDivide, self, other)
 


### PR DESCRIPTION
`NotImplemented` is an instance and the actual type is `NotImplementedType`. The mypy errors which this fixes look like this:
```bash
...
ibis/expr/types/numeric.py:711: error: Variable "builtins.NotImplemented" is not valid as a type  [valid-type]
ibis/expr/types/numeric.py:711: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
...
```

As mentioned in #6844, I can create a few more of these smaller PRs or I can bundle more changes into a single PR. Whatever works best for you.

Edit: NotImplementedType was introduced in Python 3.10 so tests fail for 3.9. I'll look into it.