### PR TITLE
refactor: replace deprecated classes of type hints

### DIFF
--- a/ci/make_geography_db.py
+++ b/ci/make_geography_db.py
@@ -19,11 +19,14 @@ import argparse
 import datetime
 import tempfile
 from pathlib import Path
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 import requests
 import sqlalchemy as sa
 import toolz
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 SCHEMAS = {
     "countries": [

--- a/docs/backends/app/backend_info_app.py
+++ b/docs/backends/app/backend_info_app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import tempfile
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import pandas as pd
 import requests
@@ -93,7 +93,7 @@ def get_all_operation_categories():
 
 
 @st.cache_data(ttl=ONE_HOUR_IN_SECONDS)
-def get_backend_names(categories: Optional[List[str]] = None):
+def get_backend_names(categories: Optional[list[str]] = None):
     backend_expr = backend_info_table.mutate(category=_.categories.unnest())
     if categories:
         backend_expr = backend_expr.filter(_.category.isin(categories))

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -13,10 +13,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Iterable,
-    Iterator,
-    Mapping,
-    MutableMapping,
 )
 
 import ibis
@@ -28,6 +24,7 @@ from ibis import util
 from ibis.common.caching import RefCountedCache
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping, MutableMapping
     from pathlib import Path
 
     import pandas as pd
@@ -1109,7 +1106,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         return query
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _get_backend_names() -> frozenset[str]:
     """Return the set of known backend names.
 

--- a/ibis/backends/base/df/scope.py
+++ b/ibis/backends/base/df/scope.py
@@ -37,16 +37,18 @@ different time contexts.
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import TYPE_CHECKING, Any, Iterable, Tuple
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
 from ibis.backends.base.df.timecontext import TimeContextRelation, compare_timecontext
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from ibis.expr.operations import Node
 
-TimeContext = Tuple[pd.Timestamp, pd.Timestamp]
+TimeContext = tuple[pd.Timestamp, pd.Timestamp]
 
 ScopeItem = namedtuple("ScopeItem", ["timecontext", "value"])
 

--- a/ibis/backends/base/df/timecontext.py
+++ b/ibis/backends/base/df/timecontext.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 
 import enum
 import functools
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
@@ -51,7 +51,7 @@ import ibis.common.exceptions as com
 import ibis.expr.operations as ops
 from ibis import config
 
-TimeContext = Tuple[pd.Timestamp, pd.Timestamp]
+TimeContext = tuple[pd.Timestamp, pd.Timestamp]
 
 
 if TYPE_CHECKING:

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -4,7 +4,7 @@ import abc
 import contextlib
 import os
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any
 
 import toolz
 
@@ -17,6 +17,8 @@ from ibis.backends.base import BaseBackend
 from ibis.backends.base.sql.compiler import Compiler
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     import pandas as pd
     import pyarrow as pa
 

--- a/ibis/backends/base/sql/alchemy/__init__.py
+++ b/ibis/backends/base/sql/alchemy/__init__.py
@@ -6,7 +6,7 @@ import contextlib
 import getpass
 import warnings
 from operator import methodcaller
-from typing import TYPE_CHECKING, Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 from sqlalchemy.ext.compiler import compiles
@@ -41,6 +41,8 @@ from ibis.backends.base.sql.alchemy.translator import (
 from ibis.formats.pandas import PandasData
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     import pandas as pd
     import pyarrow as pa
 

--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 import sqlalchemy.types as sat
@@ -11,6 +11,9 @@ import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy.geospatial import geospatial_supported
 from ibis.common.collections import FrozenDict
 from ibis.formats import TypeMapper
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 if geospatial_supported:
     import geoalchemy2 as ga

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from io import StringIO
-from typing import Iterable
+from typing import TYPE_CHECKING
 
 import sqlglot as sg
 import toolz
@@ -16,6 +16,9 @@ from ibis.backends.base.sql.compiler.translator import ExprTranslator, QueryCont
 from ibis.backends.base.sql.registry import quote_identifier
 from ibis.common.grounds import Comparable
 from ibis.config import options
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class TableSetFormatter:

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import contextlib
 import itertools
-from typing import Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Callable
 
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
 from ibis.backends.base.sql.registry import operation_registry, quote_identifier
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
 
 
 class QueryContext:

--- a/ibis/backends/base/sql/registry/geospatial.py
+++ b/ibis/backends/base/sql/registry/geospatial.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, List, TypeVar
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, TypeVar
 
 import ibis.expr.datatypes as dt
 from ibis.common import exceptions as ex
@@ -13,12 +14,12 @@ if TYPE_CHECKING:
 NumberType = TypeVar("NumberType", int, float)
 # Geometry primitives (2D)
 PointType = Iterable[NumberType]
-LineStringType = List[PointType]
-PolygonType = List[LineStringType]
+LineStringType = list[PointType]
+PolygonType = list[LineStringType]
 # Multipart geometries (2D)
-MultiPointType = List[PointType]
-MultiLineStringType = List[LineStringType]
-MultiPolygonType = List[PolygonType]
+MultiPointType = list[PointType]
+MultiLineStringType = list[LineStringType]
+MultiPolygonType = list[PolygonType]
 
 
 def _format_point_value(value: PointType) -> str:

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import parse_qs, urlparse
 
 import google.auth.credentials
@@ -35,6 +35,8 @@ with contextlib.suppress(ImportError):
     from ibis.backends.bigquery.udf import udf  # noqa: F401
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     import pyarrow as pa
     from google.cloud.bigquery.table import RowIterator
 

--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -5,7 +5,7 @@ import contextlib
 import functools
 import io
 import os
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 import google.api_core.exceptions as gexc
 import google.auth
@@ -22,6 +22,8 @@ from ibis.backends.tests.base import BackendTest, RoundAwayFromZero, UnorderedCo
 from ibis.backends.tests.data import json_types, non_null_array_types, struct_types, win
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import ibis.expr.types as ir
 
 DATASET_ID = "ibis_gbq_testing"

--- a/ibis/backends/bigquery/udf/__init__.py
+++ b/ibis/backends/bigquery/udf/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import inspect
 import itertools
-from typing import Callable, Iterable, Literal, Mapping
+from typing import TYPE_CHECKING, Callable, Literal
 
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
@@ -11,6 +11,9 @@ from ibis.backends.bigquery.datatypes import BigQueryType, spread_type
 from ibis.backends.bigquery.operations import BigQueryUDFNode
 from ibis.backends.bigquery.udf.core import PythonToJavaScriptTranslator
 from ibis.legacy.udf.validate import validate_output_type
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
 
 __all__ = ("udf",)
 

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -4,7 +4,7 @@ import ast
 import json
 from contextlib import closing, suppress
 from functools import partial
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Literal, Mapping
+from typing import TYPE_CHECKING, Any, Literal
 
 import clickhouse_connect as cc
 import pyarrow as pa
@@ -25,6 +25,7 @@ from ibis.backends.clickhouse.compiler import translate
 from ibis.backends.clickhouse.datatypes import parse, serialize
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
     from pathlib import Path
 
     import pandas as pd

--- a/ibis/backends/clickhouse/compiler/core.py
+++ b/ibis/backends/clickhouse/compiler/core.py
@@ -41,13 +41,16 @@ those as input to construct the output.
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 import sqlglot as sg
 
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.backends.clickhouse.compiler.relations import translate_rel
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 def translate(op: ops.TableNode, params: Mapping[ir.Value, Any]) -> sg.exp.Expression:

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -5,7 +5,7 @@ import contextlib
 import functools
 from functools import partial
 from operator import add, mul, sub
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 import sqlglot as sg
 from sqlglot.dialects.dialect import rename_func
@@ -18,6 +18,9 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.backends.base.sql.registry import helpers
 from ibis.backends.clickhouse.datatypes import serialize
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 # TODO: Ideally we can translate bottom up a la `relations.py`
 # TODO: Find a way to remove all the dialect="clickhouse" kwargs

--- a/ibis/backends/clickhouse/datatypes.py
+++ b/ibis/backends/clickhouse/datatypes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING, Literal, Mapping
+from typing import TYPE_CHECKING, Literal
 
 import sqlglot as sg
 from sqlglot.expressions import ColumnDef, DataType
@@ -12,6 +12,8 @@ from ibis.common.collections import FrozenDict
 from ibis.formats.parser import TypeParser
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from sqlglot.expressions import DataTypeSize, Expression
 
 

--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
-from typing import TYPE_CHECKING, Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Callable
 
 import pytest
 
@@ -16,6 +16,7 @@ from ibis.backends.tests.base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 CLICKHOUSE_HOST = os.environ.get("IBIS_TEST_CLICKHOUSE_HOST", "localhost")

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -5,9 +5,9 @@ import importlib
 import importlib.metadata
 import itertools
 import sys
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import _pytest
 import numpy as np
@@ -22,6 +22,9 @@ import ibis.common.exceptions as com
 from ibis import util
 from ibis.backends.base import CanCreateDatabase, CanCreateSchema, _get_backend_names
 from ibis.conftest import WINDOWS
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 TEST_TABLES = {
     "functional_alltypes": ibis.schema(
@@ -327,7 +330,7 @@ def pytest_collection_modifyitems(session, config, items):
             item.add_marker(marker)
 
 
-@lru_cache(maxsize=None)
+@cache
 def _get_backends_to_test(
     keep: tuple[str, ...] = (),
     discard: tuple[str, ...] = (),

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, MutableMapping
+from typing import TYPE_CHECKING, Any
 
 import dask
 import dask.dataframe as dd
@@ -18,6 +18,9 @@ from ibis.backends.dask.core import execute_and_reset
 from ibis.backends.pandas import BasePandasBackend
 from ibis.backends.pandas.core import _apply_schema
 from ibis.formats.pandas import DaskData
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, MutableMapping
 
 # Make sure that the pandas backend options have been loaded
 ibis.pandas  # noqa: B018

--- a/ibis/backends/dask/aggcontext.py
+++ b/ibis/backends/dask/aggcontext.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING, Any, Callable, Dict, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Union
 
 import dask.dataframe as dd
 
@@ -53,8 +53,8 @@ def dask_window_agg_built_in(
     windowed: dd.rolling.Rolling,
     function: str,
     max_lookback: int,
-    *args: Tuple[Any],
-    **kwargs: Dict[str, Any],
+    *args: tuple[Any],
+    **kwargs: dict[str, Any],
 ) -> dd.Series:
     """Apply window aggregation with built-in aggregators."""
     assert isinstance(function, str)

--- a/ibis/backends/dask/core.py
+++ b/ibis/backends/dask/core.py
@@ -111,7 +111,7 @@ See ibis.common.scope for details about the implementation.
 from __future__ import annotations
 
 import functools
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 import dask.dataframe as dd
 from multipledispatch import Dispatcher
@@ -134,6 +134,9 @@ from ibis.backends.pandas.core import (
     is_computable_input,
     is_computable_input_arg,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 is_computable_input.register(dd.core.Scalar)(is_computable_input_arg)
 

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Union
 
 import dask.dataframe as dd
 import dask.delayed
@@ -21,10 +21,10 @@ if TYPE_CHECKING:
     from ibis.backends.pandas.trace import TraceTwoLevelDispatcher
     from ibis.expr.operations.sortkeys import SortKey
 
-DispatchRule = Tuple[Tuple[Union[Type, Tuple], ...], Callable]
+DispatchRule = tuple[tuple[Union[type, tuple], ...], Callable]
 
-TypeRegistrationDict = Dict[
-    Union[Type[ops.Node], Tuple[Type[ops.Node], ...]], List[DispatchRule]
+TypeRegistrationDict = dict[
+    Union[type[ops.Node], tuple[type[ops.Node], ...]], list[DispatchRule]
 ]
 
 

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 import datafusion
 import pyarrow as pa
@@ -27,6 +27,8 @@ except ImportError:
     SessionConfig = None
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import pandas as pd
 
 

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import warnings
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy as sa
 
@@ -13,6 +13,9 @@ import ibis.backends.druid.datatypes as ddt
 import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy import BaseAlchemyBackend
 from ibis.backends.druid.compiler import DruidCompiler
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class Backend(BaseAlchemyBackend):

--- a/ibis/backends/druid/datatypes.py
+++ b/ibis/backends/druid/datatypes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 import sqlalchemy.types as sat
@@ -11,6 +11,9 @@ import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy.datatypes import AlchemyType
 from ibis.common.collections import FrozenDict
 from ibis.formats.parser import TypeParser
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 class DruidDateTime(sat.TypeDecorator):

--- a/ibis/backends/druid/tests/conftest.py
+++ b/ibis/backends/druid/tests/conftest.py
@@ -6,7 +6,7 @@ import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from itertools import chain, repeat
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from requests import Session
@@ -15,6 +15,7 @@ import ibis
 from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 DRUID_URL = os.environ.get(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -11,10 +11,6 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
-    Iterable,
-    Iterator,
-    Mapping,
-    MutableMapping,
 )
 
 import duckdb
@@ -38,6 +34,8 @@ from ibis.expr.operations.udf import InputType
 from ibis.formats.pandas import PandasData
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping, MutableMapping
+
     import pandas as pd
     import torch
 

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 from functools import partial
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 import duckdb
 import numpy as np
@@ -35,6 +35,8 @@ from ibis.backends.postgres.registry import (
 from ibis.common.exceptions import UnsupportedOperationError
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from ibis.backends.base.sql.alchemy.datatypes import StructType
 
 operation_registry = {

--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -10,6 +10,8 @@ from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 from ibis.conftest import SANDBOXED
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from ibis.backends.base import BaseBackend
 
 

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping
+from typing import TYPE_CHECKING, Any, Literal
 
 import sqlalchemy as sa
 import toolz
@@ -13,6 +13,8 @@ from ibis.backends.mssql.compiler import MsSqlCompiler
 from ibis.backends.mssql.datatypes import _type_from_result_set_info
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     import ibis.expr.schema as sch
     import ibis.expr.types as ir
 

--- a/ibis/backends/mssql/tests/conftest.py
+++ b/ibis/backends/mssql/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import sqlalchemy as sa
@@ -11,6 +11,7 @@ from ibis.backends.conftest import init_database
 from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 MSSQL_USER = os.environ.get("IBIS_TEST_MSSQL_USER", "sa")

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import warnings
-from typing import TYPE_CHECKING, Iterable, Literal
+from typing import TYPE_CHECKING, Literal
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
@@ -15,6 +15,8 @@ from ibis.backends.mysql.compiler import MySQLCompiler
 from ibis.backends.mysql.datatypes import MySQLDateTime, _type_from_cursor_info
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import ibis.expr.datatypes as dt
 
 

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import sqlalchemy as sa
@@ -12,6 +12,7 @@ from ibis.backends.conftest import TEST_TABLES, init_database
 from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 MYSQL_USER = os.environ.get("IBIS_TEST_MYSQL_USER", "ibis")

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import atexit
 import contextlib
 import sys
+from typing import TYPE_CHECKING, Any
 
 import oracledb
 
@@ -20,8 +21,6 @@ import oracledb
 oracledb.__version__ = oracledb.version = "7"
 
 sys.modules["cx_Oracle"] = oracledb
-
-from typing import TYPE_CHECKING, Any, Iterable  # noqa: E402
 
 import sqlalchemy as sa  # noqa: E402
 
@@ -39,6 +38,8 @@ from ibis.backends.oracle.datatypes import (  # noqa: E402
 from ibis.backends.oracle.registry import operation_registry  # noqa: E402
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import ibis.expr.schema as sch
 
 

--- a/ibis/backends/oracle/tests/conftest.py
+++ b/ibis/backends/oracle/tests/conftest.py
@@ -5,7 +5,7 @@ import contextlib
 import itertools
 import os
 import subprocess
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import sqlalchemy as sa
@@ -14,6 +14,7 @@ import ibis
 from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 ORACLE_USER = os.environ.get("IBIS_TEST_ORACLE_USER", "ibis")

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib
 from functools import lru_cache
-from typing import Any, Mapping, MutableMapping
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import pyarrow as pa
@@ -15,6 +15,9 @@ import ibis.expr.types as ir
 from ibis.backends.base import BaseBackend
 from ibis.formats.pandas import PandasData, PandasSchema
 from ibis.formats.pyarrow import PyArrowData
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, MutableMapping
 
 
 class BasePandasBackend(BaseBackend):

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -220,7 +220,7 @@ import abc
 import functools
 import itertools
 import operator
-from typing import TYPE_CHECKING, Any, Callable, Iterator
+from typing import TYPE_CHECKING, Any, Callable
 
 import pandas as pd
 from pandas.core.groupby import SeriesGroupBy
@@ -236,6 +236,8 @@ from ibis.backends.base.df.timecontext import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     import numpy as np
 
 

--- a/ibis/backends/pandas/core.py
+++ b/ibis/backends/pandas/core.py
@@ -110,7 +110,7 @@ from __future__ import annotations
 import datetime
 import functools
 import numbers
-from typing import Any, Callable, Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
 import pandas as pd
@@ -131,6 +131,9 @@ from ibis.backends.pandas.dispatch import (
     pre_execute,
 )
 from ibis.backends.pandas.trace import trace
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
 
 integer_types = np.integer, int
 floating_types = (numbers.Real,)

--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 from functools import partial
-from typing import Any, Collection
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -11,6 +11,9 @@ from pandas.core.groupby import SeriesGroupBy
 import ibis.expr.operations as ops
 from ibis.backends.pandas.core import execute
 from ibis.backends.pandas.dispatch import execute_node
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 
 @execute_node.register(ops.ArrayColumn, tuple)

--- a/ibis/backends/pandas/execution/selection.py
+++ b/ibis/backends/pandas/execution/selection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import operator
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 from toolz import concatv, first
@@ -20,6 +20,8 @@ from ibis.backends.pandas.execution import constants, util
 from ibis.backends.pandas.execution.util import coerce_to_output
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from ibis.backends.base.df.timecontext import TimeContext
 
 

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping
+from typing import TYPE_CHECKING, Any
 
 import polars as pl
 
@@ -18,6 +18,8 @@ from ibis.common.patterns import Replace
 from ibis.util import gen_name, normalize_filename
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, MutableMapping
+
     import pandas as pd
     import pyarrow as pa
 

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -4,8 +4,8 @@ import calendar
 import functools
 import math
 import operator
+from collections.abc import Mapping
 from functools import partial
-from typing import Mapping
 
 import numpy as np
 import pandas as pd

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 import textwrap
-from typing import TYPE_CHECKING, Callable, Iterable, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
 import sqlalchemy as sa
 
@@ -17,6 +17,8 @@ from ibis.backends.postgres.datatypes import parse
 from ibis.common.exceptions import InvalidDecoratorError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import ibis.expr.datatypes as dt
 
 

--- a/ibis/backends/postgres/datatypes.py
+++ b/ibis/backends/postgres/datatypes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 import sqlalchemy.dialects.postgresql as psql
@@ -10,6 +10,9 @@ import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy.datatypes import AlchemyType
 from ibis.common.collections import FrozenDict
 from ibis.formats.parser import TypeParser
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 class PostgresTypeParser(TypeParser):

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import sqlalchemy as sa
@@ -24,6 +24,7 @@ from ibis.backends.conftest import init_database
 from ibis.backends.tests.base import RoundHalfToEven, ServiceBackendTest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
 PG_USER = os.environ.get(

--- a/ibis/backends/postgres/udf.py
+++ b/ibis/backends/postgres/udf.py
@@ -4,7 +4,7 @@ import collections
 import inspect
 import itertools
 from textwrap import dedent
-from typing import Any, Callable, MutableMapping, Sequence
+from typing import TYPE_CHECKING, Any, Callable
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import dialect
@@ -16,6 +16,9 @@ from ibis import IbisError
 from ibis.backends.postgres.compiler import PostgreSQLExprTranslator, PostgresUDFNode
 from ibis.backends.postgres.datatypes import PostgresType
 from ibis.legacy.udf.validate import validate_output_type
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping, Sequence
 
 _udf_name_cache: MutableMapping[str, Any] = collections.defaultdict(itertools.count)
 

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any
 
 import sqlglot as sg
 
@@ -10,6 +10,8 @@ import ibis.expr.types as ir
 from ibis.backends.pyspark import ddl
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     import pandas as pd
 
 

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -12,7 +12,7 @@ import tempfile
 import textwrap
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping
+from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
 import sqlalchemy as sa
@@ -38,6 +38,8 @@ from ibis.backends.snowflake.datatypes import SnowflakeType, parse
 from ibis.backends.snowflake.registry import operation_registry
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
+
     import pandas as pd
 
     import ibis.expr.schema as sch

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import inspect
 import sqlite3
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 import toolz
@@ -33,6 +33,7 @@ from ibis.backends.sqlite.compiler import SQLiteCompiler
 from ibis.backends.sqlite.datatypes import ISODATETIME, SqliteType, parse
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     import ibis.expr.operations as ops

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -5,7 +5,7 @@ import concurrent.futures
 import inspect
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -15,6 +15,8 @@ import toolz
 from filelock import FileLock
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
+
     import ibis.expr.types as ir
 
 

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -5,7 +5,7 @@ import csv
 import gzip
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 import pytest
 from pytest import param
@@ -14,6 +14,8 @@ import ibis
 from ibis.backends.conftest import TEST_TABLES
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     import pyarrow as pa
 
 pytestmark = pytest.mark.notimpl(["druid", "oracle"])

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -6,7 +6,7 @@ import collections
 import contextlib
 import warnings
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Iterator, Mapping
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import sqlalchemy as sa
@@ -25,6 +25,8 @@ from ibis.backends.trino.compiler import TrinoSQLCompiler
 from ibis.backends.trino.datatypes import ROW, TrinoType, parse
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
     import pyarrow as pa
 
     import ibis.expr.schema as sch

--- a/ibis/backends/trino/datatypes.py
+++ b/ibis/backends/trino/datatypes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 import sqlalchemy.types as sat
 import trino.client
@@ -12,6 +12,9 @@ import ibis.expr.datatypes as dt
 from ibis.backends.base.sql.alchemy.datatypes import AlchemyType
 from ibis.common.collections import FrozenDict
 from ibis.formats.parser import TypeParser
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 class ROW(_ROW):

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Iterable, Iterator
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import pytest
@@ -13,6 +13,7 @@ from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
 from ibis.backends.tests.data import struct_types
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
     from pathlib import Path
 
 TRINO_USER = os.environ.get(

--- a/ibis/common/bases.py
+++ b/ibis/common/bases.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 from weakref import WeakValueDictionary
 
 from ibis.common.caching import WeakCache
 from ibis.common.collections import FrozenDict
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from typing_extensions import Self
 
 

--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import functools
 import weakref
 from collections import Counter, defaultdict
-from typing import TYPE_CHECKING, Any, Callable, MutableMapping
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, Any, Callable
 
 from bidict import bidict
 

--- a/ibis/common/collections.py
+++ b/ibis/common/collections.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Hashable, Iterator, Mapping
 from itertools import tee
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Hashable, Mapping, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from public import public
 

--- a/ibis/common/egraph.py
+++ b/ibis/common/egraph.py
@@ -3,15 +3,8 @@ from __future__ import annotations
 import collections
 import itertools
 import math
-from typing import (
-    Any,
-    Hashable,
-    Iterable,
-    Iterator,
-    Mapping,
-    Set,
-    TypeVar,
-)
+from collections.abc import Hashable, Iterable, Iterator, Mapping
+from typing import Any, TypeVar
 
 from ibis.common.graph import Node
 from ibis.util import promote_list
@@ -19,7 +12,7 @@ from ibis.util import promote_list
 K = TypeVar("K", bound=Hashable)
 
 
-class DisjointSet(Mapping[K, Set[K]]):
+class DisjointSet(Mapping[K, set[K]]):
     """Disjoint set data structure.
 
     Also known as union-find data structure. It is a data structure that keeps

--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections import deque
-from collections.abc import Hashable, Iterable, Iterator
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence
+from collections.abc import Hashable, Iterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from ibis.common.collections import frozendict
 from ibis.common.patterns import NoMatch, pattern
@@ -256,7 +256,7 @@ class Node(Hashable):
         return self.map(fn, filter=filter)[self]
 
 
-class Graph(Dict[Node, Sequence[Node]]):
+class Graph(dict[Node, Sequence[Node]]):
     """A mapping-like graph data structure for easier graph traversal and manipulation.
 
     The data structure is a mapping of nodes to their children. The children are

--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -5,7 +5,6 @@ from copy import copy
 from typing import (
     Any,
     ClassVar,
-    Tuple,
     Union,
     get_origin,
 )
@@ -104,9 +103,9 @@ class AnnotableMeta(BaseMeta):
 class Annotable(Base, metaclass=AnnotableMeta):
     """Base class for objects with custom validation rules."""
 
-    __argnames__: ClassVar[Tuple[str, ...]]
+    __argnames__: ClassVar[tuple[str, ...]]
     __attributes__: ClassVar[FrozenDict[str, Annotation]]
-    __match_args__: ClassVar[Tuple[str, ...]]
+    __match_args__: ClassVar[tuple[str, ...]]
     __signature__: ClassVar[Signature]
 
     @classmethod
@@ -152,7 +151,7 @@ class Annotable(Base, metaclass=AnnotableMeta):
         )
 
     @property
-    def __args__(self) -> Tuple[Any, ...]:
+    def __args__(self) -> tuple[Any, ...]:
         return tuple(getattr(self, name) for name in self.__argnames__)
 
     def copy(self, **overrides: Any) -> Annotable:
@@ -202,7 +201,7 @@ class Concrete(Immutable, Comparable, Annotable):
         return self.__args__
 
     @property
-    def argnames(self) -> Tuple[str, ...]:
+    def argnames(self) -> tuple[str, ...]:
         return self.__argnames__
 
     def copy(self, **overrides) -> Self:

--- a/ibis/common/patterns.py
+++ b/ibis/common/patterns.py
@@ -9,19 +9,19 @@ from collections.abc import Callable, Hashable, Mapping, Sequence
 from enum import Enum
 from inspect import Parameter
 from itertools import chain
-from typing import Any as AnyType
 from typing import (
+    Annotated,
     ForwardRef,
     Generic,  # noqa: F401
     Literal,
     Optional,
-    Tuple,
     TypeVar,
     Union,
 )
+from typing import Any as AnyType
 
 import toolz
-from typing_extensions import Annotated, GenericMeta, Self, get_args, get_origin
+from typing_extensions import GenericMeta, Self, get_args, get_origin
 
 from ibis.common.bases import Singleton, Slotted
 from ibis.common.collections import RewindableIterator, frozendict
@@ -170,7 +170,7 @@ class Pattern(Hashable):
                 # in case of Callable without args we check for the Callable
                 # protocol only
                 return InstanceOf(Callable)
-        elif issubclass(origin, Tuple):
+        elif issubclass(origin, tuple):
             # construct validators for the tuple elements, but need to treat
             # variadic tuples differently, e.g. tuple[int, ...] is a variadic
             # tuple of integers, while tuple[int] is a tuple with a single int

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import inspect
-from typing import Union
+from typing import Annotated, Union
 
 import pytest
-from typing_extensions import Annotated  # noqa: TCH002
 
 from ibis.common.annotations import (
     Argument,

--- a/ibis/common/tests/test_egraph.py
+++ b/ibis/common/tests/test_egraph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import Any, Tuple
+from typing import Any
 
 import pytest
 
@@ -167,7 +167,7 @@ def test_enode_roundtrip():
 
 class MySecondNode(Concrete, Node):
     a: int
-    b: Tuple[int, ...]
+    b: tuple[int, ...]
 
 
 def test_enode_roundtrip_with_variadic_arg():
@@ -187,7 +187,7 @@ class MyInt(Concrete, Node):
 
 class MyThirdNode(Concrete, Node):
     a: int
-    b: Tuple[MyInt, ...]
+    b: tuple[MyInt, ...]
 
 
 def test_enode_roundtrip_with_nested_arg():

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import copy
 import pickle
 import weakref
-from typing import Callable, Generic, Mapping, Optional, Sequence, Tuple, TypeVar, Union
+from collections.abc import Mapping, Sequence
+from typing import Callable, Generic, Optional, TypeVar, Union
 
 import pytest
 
@@ -156,7 +157,7 @@ class EmptyMap(Map[K, V]):
 
 
 class ConsMap(Map[K, V]):
-    head: Tuple[K, V]
+    head: tuple[K, V]
     rest: Map[K, V]
 
     def __getitem__(self, key):
@@ -1000,12 +1001,12 @@ def test_init_subclass_keyword_arguments():
 
 def test_argument_order_using_optional_annotations():
     class Case1(Annotable):
-        results: Optional[Tuple[int]] = ()
+        results: Optional[tuple[int]] = ()
         default: Optional[int] = None
 
     class SimpleCase1(Case1):
         base: int
-        cases: Optional[Tuple[int]] = ()
+        cases: Optional[tuple[int]] = ()
 
     class Case2(Annotable):
         results = optional(TupleOf(is_int), default=())

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -3,25 +3,23 @@ from __future__ import annotations
 import re
 import sys
 from collections.abc import Callable as CallableABC
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import (
-    Any as AnyType,
-)
-from typing import (
+from typing import (  # noqa: UP035
+    Annotated,
     Callable,
-    Dict,
     Generic,
     List,
     Literal,
     Optional,
-    Sequence,
-    Tuple,
     TypeVar,
     Union,
 )
+from typing import (
+    Any as AnyType,
+)
 
 import pytest
-from typing_extensions import Annotated
 
 from ibis.common.annotations import ValidationError
 from ibis.common.collections import FrozenDict
@@ -849,14 +847,14 @@ def test_pattern_decorator():
         (Optional[Union[str, int]], Option(AnyOf(InstanceOf(str), InstanceOf(int)))),
         (Union[int, str], AnyOf(InstanceOf(int), InstanceOf(str))),
         (Annotated[int, Min(3)], AllOf(InstanceOf(int), Min(3))),
-        (List[int], SequenceOf(InstanceOf(int), list)),
+        (list[int], SequenceOf(InstanceOf(int), list)),
         (
-            Tuple[int, float, str],
+            tuple[int, float, str],
             TupleOf((InstanceOf(int), InstanceOf(float), InstanceOf(str))),
         ),
-        (Tuple[int, ...], TupleOf(InstanceOf(int))),
+        (tuple[int, ...], TupleOf(InstanceOf(int))),
         (
-            Dict[str, float],
+            dict[str, float],
             DictOf(InstanceOf(str), InstanceOf(float)),
         ),
         (FrozenDict[str, int], FrozenDictOf(InstanceOf(str), InstanceOf(int))),
@@ -949,7 +947,7 @@ def test_pattern_coercible_checks_type():
     assert v.match(1, context={}) is NoMatch
 
 
-class DoubledList(Coercible, List[T]):
+class DoubledList(Coercible, list[T]):
     @classmethod
     def __coerce__(cls, obj):
         return cls(list(obj) * 2)
@@ -960,11 +958,11 @@ def test_pattern_coercible_sequence_type():
     with pytest.raises(TypeError, match=r"Sequence\(\) takes no arguments"):
         s.match([1, 2, 3], context={})
 
-    s = Pattern.from_typehint(List[PlusOne])
+    s = Pattern.from_typehint(list[PlusOne])
     assert s == SequenceOf(CoercedTo(PlusOne), type=list)
     assert s.match([1, 2, 3], context={}) == [PlusOne(2), PlusOne(3), PlusOne(4)]
 
-    s = Pattern.from_typehint(Tuple[PlusOne, ...])
+    s = Pattern.from_typehint(tuple[PlusOne, ...])
     assert s == TupleOf(CoercedTo(PlusOne))
     assert s.match([1, 2, 3], context={}) == (PlusOne(2), PlusOne(3), PlusOne(4))
 
@@ -985,7 +983,7 @@ def test_pattern_function():
     assert pattern(Any()) == Any()
     assert pattern(int) == InstanceOf(int)
     assert pattern(MyNegativeInt) == CoercedTo(MyNegativeInt)
-    assert pattern(List[int]) == ListOf(InstanceOf(int))
+    assert pattern(List[int]) == ListOf(InstanceOf(int))  # noqa: UP006
     assert pattern([int, str, 1]) == PatternSequence(
         [InstanceOf(int), InstanceOf(str), EqualTo(1)]
     )

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -4,16 +4,13 @@ import sys
 from itertools import zip_longest
 from typing import (
     Any,
-    Dict,
     Generic,  # noqa: F401
     Optional,
-    Tuple,
     TypeVar,
     get_args,
     get_origin,
 )
-
-from typing_extensions import get_type_hints as _get_type_hints
+from typing import get_type_hints as _get_type_hints
 
 from ibis.common.caching import memoize
 
@@ -26,8 +23,8 @@ except ImportError:
 T = TypeVar("T")
 U = TypeVar("U")
 
-Namespace = Dict[str, Any]
-VarTuple = Tuple[T, ...]
+Namespace = dict[str, Any]
+VarTuple = tuple[T, ...]
 
 
 @memoize
@@ -180,9 +177,9 @@ def evaluate_annotations(
 
     Examples
     --------
-    >>> annots = {'a': 'Dict[str, float]', 'b': 'int'}
+    >>> annots = {'a': 'dict[str, float]', 'b': 'int'}
     >>> evaluate_annotations(annots, __name__)
-    {'a': typing.Dict[str, float], 'b': <class 'int'>}
+    {'a': dict[str, float], 'b': <class 'int'>}
     """
     module = sys.modules.get(module_name, None)
     globalns = getattr(module, "__dict__", None)

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import contextlib
-from typing import Any, Callable, Optional
+from typing import Annotated, Any, Callable, Optional
 
 from public import public
-from typing_extensions import Annotated
 
 import ibis.common.exceptions as com
 from ibis.common.grounds import Annotable

--- a/ibis/examples/gen_registry.py
+++ b/ibis/examples/gen_registry.py
@@ -11,13 +11,16 @@ import tempfile
 import zipfile
 from collections import Counter, defaultdict
 from pathlib import Path
-from typing import Iterable, Mapping
+from typing import TYPE_CHECKING
 
 import pooch
 import requests
 from google.cloud import storage
 
 import ibis
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
 
 EXAMPLES_DIRECTORY = Path(__file__).parent
 

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import operator
 from collections import defaultdict
-from typing import Iterable, Iterator, Mapping
+from typing import TYPE_CHECKING
 
 import toolz
 
@@ -15,6 +15,9 @@ from ibis import util
 from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import IbisTypeError, IntegrityError
 from ibis.common.patterns import Call, Object, Variable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
 
 p = Object.namespace(ops)
 c = Call.namespace(ops)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -6,7 +6,7 @@ import datetime
 import functools
 import numbers
 import operator
-from typing import TYPE_CHECKING, Any, Iterable, NamedTuple, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import ibis.expr.builders as bl
 import ibis.expr.datatypes as dt
@@ -36,6 +36,7 @@ from ibis.expr.types import (
 from ibis.util import experimental
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
     from pathlib import Path
 
     import numpy as np

--- a/ibis/expr/datatypes/cast.py
+++ b/ibis/expr/datatypes/cast.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import functools
-from typing import Iterator
+from typing import TYPE_CHECKING
 
 from multipledispatch import Dispatcher
 from public import public
 
 import ibis.expr.datatypes.core as dt
 from ibis.common.exceptions import IbisTypeError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 castable = Dispatcher("castable")
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -5,13 +5,13 @@ import decimal as pydecimal
 import numbers
 import uuid as pyuuid
 from abc import abstractmethod
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from numbers import Integral, Real
-from typing import Any, Generic, Iterable, Literal, NamedTuple, Optional, TypeVar
+from typing import Any, Generic, Literal, NamedTuple, Optional, TypeVar, get_type_hints
 
 import toolz
 from public import public
-from typing_extensions import Self, get_args, get_origin, get_type_hints
+from typing_extensions import Self, get_args, get_origin
 
 from ibis.common.annotations import attribute
 from ibis.common.collections import FrozenDict, MapSet

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -5,10 +5,9 @@ import decimal  # noqa: TCH003
 import sys
 import uuid  # noqa: TCH003
 from dataclasses import dataclass
-from typing import Dict, List, NamedTuple, Tuple
+from typing import Annotated, NamedTuple
 
 import pytest
-from typing_extensions import Annotated
 
 import ibis.expr.datatypes as dt
 from ibis.common.annotations import ValidationError
@@ -223,9 +222,9 @@ class PyStruct:
     h: datetime.datetime
     i: datetime.timedelta
     j: decimal.Decimal
-    k: List[int]
-    l: Dict[str, int]  # noqa: E741
-    n: Tuple[str]
+    k: list[int]
+    l: dict[str, int]  # noqa: E741
+    n: tuple[str]
     o: uuid.UUID
     p: None
     q: MyStruct

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -7,7 +7,8 @@ import enum
 import ipaddress
 import json
 import uuid
-from typing import Any, Mapping, NamedTuple, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any, NamedTuple
 
 import toolz
 from public import public

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -4,7 +4,7 @@ import functools
 import itertools
 import textwrap
 import types
-from typing import Mapping, Sequence
+from collections.abc import Mapping, Sequence
 
 from public import public
 

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import operator
+from typing import Annotated
 
 from public import public
-from typing_extensions import Annotated
 
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz

--- a/ibis/expr/operations/tests/test_core.py
+++ b/ibis/expr/operations/tests/test_core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import pytest
 
@@ -41,7 +41,7 @@ class NamedValue(Base):
 
 
 class Values(Base):
-    lst: Tuple[ops.Node, ...]
+    lst: tuple[ops.Node, ...]
 
 
 one = NamedValue(value=1, name=Name("one"))

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 from functools import singledispatch
-from typing import IO, Dict
+from typing import IO
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -18,7 +18,7 @@ import ibis.expr.types as ir
 from ibis.util import experimental
 
 
-class Catalog(Dict[str, sch.Schema]):
+class Catalog(dict[str, sch.Schema]):
     """A catalog of tables and their schemas."""
 
     typemap = {

--- a/ibis/expr/tests/test_schema.py
+++ b/ibis/expr/tests/test_schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
-from typing import Dict, List, NamedTuple, Tuple
+from typing import NamedTuple
 
 import numpy as np
 import pandas.testing as tm
@@ -235,12 +235,12 @@ class FooSchema:
     a: int
     b: str
     c: float
-    d: Tuple[str]
-    e: List[int]
-    f: Dict[str, int]
+    d: tuple[str]
+    e: list[int]
+    f: dict[str, int]
     g: BarSchema
-    h: List[BarSchema]
-    j: Dict[str, BarSchema]
+    h: list[BarSchema]
+    j: dict[str, BarSchema]
 
 
 foo_schema = sch.Schema(
@@ -271,12 +271,12 @@ class NamedFoo(NamedTuple):
     a: int
     b: str
     c: float
-    d: Tuple[str]
-    e: List[int]
-    f: Dict[str, int]
+    d: tuple[str]
+    e: list[int]
+    f: dict[str, int]
     g: NamedBar
-    h: List[NamedBar]
-    j: Dict[str, NamedBar]
+    h: list[NamedBar]
+    j: dict[str, NamedBar]
 
 
 def test_schema_from_namedtuple():
@@ -294,16 +294,16 @@ class DataFooBase:
     a: int
     b: str
     c: float
-    d: Tuple[str]
+    d: tuple[str]
 
 
 @dataclass
 class DataFoo(DataFooBase):
-    e: List[int]
-    f: Dict[str, int]
+    e: list[int]
+    f: dict[str, int]
     g: DataBar
-    h: List[DataBar]
-    j: Dict[str, DataBar]
+    h: list[DataBar]
+    j: dict[str, DataBar]
 
 
 def test_schema_from_dataclass():

--- a/ibis/formats/parser.py
+++ b/ibis/formats/parser.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Mapping
+from typing import TYPE_CHECKING
 
 import sqlglot as sg
 from sqlglot.expressions import ColumnDef, DataType, DataTypeSize
@@ -9,6 +9,9 @@ from sqlglot.expressions import ColumnDef, DataType, DataTypeSize
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
 from ibis.common.collections import FrozenDict
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 SQLGLOT_TYPE_TO_IBIS_TYPE = {
     DataType.Type.BIGDECIMAL: dt.Decimal(76, 38),

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -52,7 +52,8 @@ import functools
 import inspect
 import operator
 import re
-from typing import Callable, Iterable, Mapping, Optional, Sequence, Union
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Callable, Optional, Union
 
 from public import public
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import pickle
 import re
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -1467,7 +1466,7 @@ def test_unbound_table_name():
 class MyTable:
     a: int
     b: str
-    c: List[float]
+    c: list[float]
 
 
 def test_unbound_table_using_class_definition():

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -18,8 +18,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Iterator,
-    Sequence,
     TypeVar,
 )
 from uuid import uuid4
@@ -27,6 +25,7 @@ from uuid import uuid4
 import toolz
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
     from numbers import Real
     from pathlib import Path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -452,7 +452,7 @@ ignore = [
   "UP007",   # Optional[str] -> str | None
 ]
 exclude = ["*_py310.py", "ibis/tests/*/snapshots/*"]
-target-version = "py38"
+target-version = "py39"
 # none of these codes will be automatically fixed by ruff
 unfixable = [
   "T201",   # print statements


### PR DESCRIPTION
When working on the Flink backend/referencing other backends, I noticed the use of some typing classes (`Mapping`) that can now be used directly from `collections.abc`, which led me to realize that the `--py39-plus` pyupgrade equivalent rules weren't being leveraged.

I'm not sure why https://github.com/ibis-project/ibis/pull/6856/commits/567c2caa98bb9b705fdd4477cefbccf11bce85cb doesn't work (and haven't looked into it much), so I made an exception for it (as it's just in tests).