### PR TITLE
feat(clickhouse): support `read_csv` and `read_parquet`

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -557,7 +557,7 @@ class Backend(BaseBackend, CanCreateDatabase):
 
         schema = PyArrowSchema.to_ibis(pq.read_metadata(path).schema.to_arrow_schema())
 
-        name = table_name or util.gen_name("clickhouse_read_parquet")
+        name = table_name or util.gen_name("read_parquet")
         table = self.create_table(name, engine=engine, schema=schema, temp=True)
 
         insert_file(
@@ -580,7 +580,7 @@ class Backend(BaseBackend, CanCreateDatabase):
         with pac.open_csv(path) as f:
             schema = PyArrowSchema.to_ibis(f.schema)
 
-        name = table_name or util.gen_name("clickhouse_read_csv")
+        name = table_name or util.gen_name("read_csv")
         table = self.create_table(name, engine=engine, schema=schema, temp=True)
 
         insert_file(client=self.con, table=name, file_path=str(path), **kwargs)

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -211,7 +211,15 @@ class Backend(BaseBackend, CanCreateDatabase):
     def list_tables(
         self, like: str | None = None, database: str | None = None
     ) -> list[str]:
-        query = "SHOW TABLES" + (f" FROM `{database}`" * (database is not None))
+        query = "SELECT name FROM system.tables WHERE"
+
+        if database is None:
+            database = "currentDatabase()"
+        else:
+            database = f"'{database}'"
+
+        query += f" database = {database} OR is_temporary"
+
         with closing(self.raw_sql(query)) as result:
             results = result.result_columns
 

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -405,7 +405,6 @@ def test_register_garbage(con, monkeypatch):
 @pytest.mark.notyet(
     [
         "bigquery",
-        "clickhouse",
         "dask",
         "impala",
         "mssql",
@@ -470,7 +469,6 @@ DIAMONDS_COLUMN_TYPES = {
 @pytest.mark.notyet(
     [
         "bigquery",
-        "clickhouse",
         "dask",
         "impala",
         "mssql",


### PR DESCRIPTION
Add support for reading parquet and csv files from local disk.

Depends on #6860.