### PR TITLE
fix(type hints): various improvements to type hints

### DIFF
--- a/ibis/backends/dask/aggcontext.py
+++ b/ibis/backends/dask/aggcontext.py
@@ -76,6 +76,7 @@ def dask_window_agg_built_in(
 
 class Window(AggregationContext):
     __slots__ = ("construct_window",)
+    construct_window: operator.methodcaller
 
     def __init__(self, kind, *args, **kwargs):
         super().__init__(

--- a/ibis/backends/impala/metadata.py
+++ b/ibis/backends/impala/metadata.py
@@ -235,7 +235,7 @@ class MetadataParser:
         params = self._parse_nested_params(self._storage_param_cleaners)
         self.storage["Desc Params"] = params
 
-    _storage_param_cleaners = {}
+    _storage_param_cleaners: dict = {}
 
     def _parse_nested_params(self, cleaners):
         import pandas as pd

--- a/ibis/backends/mysql/datatypes.py
+++ b/ibis/backends/mysql/datatypes.py
@@ -148,6 +148,7 @@ class _FieldFlags:
     NUM = 1 << 15
 
     __slots__ = ("value",)
+    value: int
 
     def __init__(self, value: int) -> None:
         self.value = value

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -557,6 +557,7 @@ def window_agg_udf(
 
 class Window(AggregationContext):
     __slots__ = ("construct_window",)
+    construct_window: operator.methodcaller
 
     def __init__(self, kind, *args, **kwargs):
         super().__init__(

--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -43,6 +43,9 @@ class Annotation:
     """
 
     __slots__ = ("_pattern", "_default", "_typehint")
+    _pattern: Pattern | callable | None
+    _default: Any
+    _typehint: Any
 
     def __init__(self, pattern=None, default=EMPTY, typehint=EMPTY):
         if pattern is None or isinstance(pattern, Pattern):
@@ -127,6 +130,7 @@ class Argument(Annotation):
     """
 
     __slots__ = ("_kind",)
+    _kind: int
 
     def __init__(
         self,

--- a/ibis/common/bases.py
+++ b/ibis/common/bases.py
@@ -159,6 +159,7 @@ class Slotted(Base):
     """
 
     __slots__ = ("__precomputed_hash__",)
+    __precomputed_hash__: int
 
     def __init__(self, **kwargs) -> Self:
         for name, value in kwargs.items():

--- a/ibis/common/bases.py
+++ b/ibis/common/bases.py
@@ -161,7 +161,7 @@ class Slotted(Base):
     __slots__ = ("__precomputed_hash__",)
     __precomputed_hash__: int
 
-    def __init__(self, **kwargs) -> Self:
+    def __init__(self, **kwargs) -> None:
         for name, value in kwargs.items():
             object.__setattr__(self, name, value)
         hashvalue = hash(tuple(kwargs.values()))

--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 def memoize(func: Callable) -> Callable:
     """Memoize a function."""
-    cache = {}
+    cache: dict = {}
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -94,11 +94,11 @@ class RefCountedCache:
         key: Callable[[Any], Any],
     ) -> None:
         self.cache = bidict()
-        self.refs = Counter()
+        self.refs: Counter = Counter()
         self.populate = populate
         self.lookup = lookup
         self.finalize = finalize
-        self.names = defaultdict(generate_name)
+        self.names: defaultdict = defaultdict(generate_name)
         self.key = key or (lambda x: x)
 
     def get(self, key, default=None):

--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -33,6 +33,7 @@ def memoize(func: Callable) -> Callable:
 
 class WeakCache(MutableMapping):
     __slots__ = ("_data",)
+    _data: dict
 
     def __init__(self):
         object.__setattr__(self, "_data", {})

--- a/ibis/common/collections.py
+++ b/ibis/common/collections.py
@@ -141,6 +141,8 @@ class FrozenDict(Mapping[K, V], Hashable):
     """Immutable dictionary with a precomputed hash value."""
 
     __slots__ = ("__view__", "__precomputed_hash__")
+    __view__: MappingProxyType
+    __precomputed_hash__: int
 
     def __init__(self, *args, **kwargs):
         dictview = MappingProxyType(dict(*args, **kwargs))

--- a/ibis/common/collections.py
+++ b/ibis/common/collections.py
@@ -215,4 +215,5 @@ class RewindableIterator(Iterator):
         self._iterator, self._checkpoint = tee(self._iterator)
 
 
+frozendict: FrozenDict
 public(frozendict=FrozenDict)

--- a/ibis/common/patterns.py
+++ b/ibis/common/patterns.py
@@ -29,9 +29,9 @@ from ibis.common.dispatch import lazy_singledispatch
 from ibis.common.typing import Sentinel, get_bound_typevars, get_type_params
 from ibis.util import is_iterable, promote_tuple
 
-try:
+if sys.version_info >= (3, 10):
     from types import UnionType
-except ImportError:
+else:
     UnionType = object()
 
 

--- a/ibis/common/tests/conftest.py
+++ b/ibis/common/tests/conftest.py
@@ -2,6 +2,6 @@ from __future__ import annotations
 
 import sys
 
-collect_ignore = []
+collect_ignore: list[str] = []
 if sys.version_info < (3, 10):
     collect_ignore.append("test_grounds_py310.py")

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -17,9 +17,9 @@ from typing_extensions import get_type_hints as _get_type_hints
 
 from ibis.common.caching import memoize
 
-try:
+if sys.version_info >= (3, 10):
     from types import UnionType
-except ImportError:
+else:
     UnionType = object()
 
 

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -27,7 +27,7 @@ y = Variable("y")
 # compilation later
 
 
-def sub_for(node: ops.Node, substitutions: Mapping[ops.node, ops.Node]) -> ops.Node:
+def sub_for(node: ops.Node, substitutions: Mapping[ops.Node, ops.Node]) -> ops.Node:
     """Substitute operations in `node` with nodes in `substitutions`.
 
     Parameters

--- a/ibis/expr/deferred.py
+++ b/ibis/expr/deferred.py
@@ -174,6 +174,8 @@ class Deferred:
 
 class DeferredAttr(Deferred):
     __slots__ = ("_value", "_attr")
+    _value: Any
+    _attr: str
 
     def __init__(self, value: Any, attr: str) -> None:
         self._value = value
@@ -189,6 +191,8 @@ class DeferredAttr(Deferred):
 
 class DeferredItem(Deferred):
     __slots__ = ("_value", "_key")
+    _value: Any
+    _key: Any
 
     def __init__(self, value: Any, key: Any) -> None:
         self._value = value
@@ -204,6 +208,9 @@ class DeferredItem(Deferred):
 
 class DeferredCall(Deferred):
     __slots__ = ("_func", "_args", "_kwargs")
+    _func: Callable
+    _args: tuple[Any, ...]
+    _kwargs: dict[str, Any]
 
     def __init__(self, func: Any, *args: Any, **kwargs: Any) -> None:
         self._func = func
@@ -224,6 +231,9 @@ class DeferredCall(Deferred):
 
 class DeferredBinaryOp(Deferred):
     __slots__ = ("_symbol", "_left", "_right")
+    _symbol: str
+    _left: Any
+    _right: Any
 
     def __init__(self, symbol: str, left: Any, right: Any) -> None:
         self._symbol = symbol
@@ -241,6 +251,8 @@ class DeferredBinaryOp(Deferred):
 
 class DeferredUnaryOp(Deferred):
     __slots__ = ("_symbol", "_value")
+    _symbol: str
+    _value: Any
 
     def __init__(self, symbol: str, value: Any) -> None:
         self._symbol = symbol

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -110,6 +110,9 @@ class SQLQueryResult(TableNode):
 
 class TableProxy(Immutable):
     __slots__ = ("_data", "_hash")
+    # Used Any as not sure how to type this
+    _data: Any
+    _hash: int
 
     def __init__(self, data) -> None:
         object.__setattr__(self, "_data", data)

--- a/ibis/expr/operations/tests/conftest.py
+++ b/ibis/expr/operations/tests/conftest.py
@@ -2,6 +2,6 @@ from __future__ import annotations
 
 import sys
 
-collect_ignore = []
+collect_ignore: list[str] = []
 if sys.version_info < (3, 10):
     collect_ignore.append("test_core_py310.py")

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -17,8 +17,11 @@ from rich.jupyter import JupyterMixin
 from ibis.common.patterns import Coercible, CoercionError
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pandas as pd
     import pyarrow as pa
+    import torch
 
     import ibis.expr.types as ir
     from ibis.backends.base import BaseBackend

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -44,6 +44,7 @@ class Expr(Immutable, Coercible):
     """Base expression class."""
 
     __slots__ = ("_arg",)
+    _arg: ops.Node
 
     def __init__(self, arg: ops.Node) -> None:
         object.__setattr__(self, "_arg", arg)

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1245,7 +1245,7 @@ class Column(Value, _FixedTextJupyterMixin):
         self,
         k: int,
         by: ir.Value | None = None,
-    ) -> ir.TopK:
+    ) -> ir.Table:
         """Return a "top k" expression.
 
         Parameters

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -338,7 +338,7 @@ class StructValue(Value):
         table = an.find_first_base_table(self.op()).to_expr()
         return table[[self[name] for name in self.names]]
 
-    def destructure(self) -> list[ir.ValueExpr]:
+    def destructure(self) -> list[ir.Value]:
         """Destructure a ``StructValue`` into the corresponding struct fields.
 
         When assigned, a destruct value will be destructured and assigned to

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -60,7 +60,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common.annotations import attribute
-from ibis.common.collections import frozendict, FrozenDict
+from ibis.common.collections import FrozenDict, frozendict
 from ibis.common.grounds import Concrete, Singleton
 from ibis.common.patterns import Coercible
 from ibis.expr.deferred import Deferred

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -60,7 +60,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common.annotations import attribute
-from ibis.common.collections import frozendict
+from ibis.common.collections import frozendict, FrozenDict
 from ibis.common.grounds import Concrete, Singleton
 from ibis.common.patterns import Coercible
 from ibis.expr.deferred import Deferred
@@ -374,7 +374,7 @@ class Across(Selector):
     funcs: Union[
         Deferred,
         Callable[[ir.Value], ir.Value],
-        frozendict[Optional[str], Union[Deferred, Callable[[ir.Value], ir.Value]]],
+        FrozenDict[Optional[str], Union[Deferred, Callable[[ir.Value], ir.Value]]],
     ]
     names: Union[str, Callable[[str, Optional[str]], str]]
 


### PR DESCRIPTION
Related to the discussion in #6844. See the individual commits for the details but let me know if something is unclear. In 1b8d1f12fc6672718c79bcef6526ec2f40253ce2 I added type hints to all attributes which are defined in `__slots__` as mypy struggled to infer it for some classes and reported that the class does not have a certain attribute.

Running `mypy ibis --ignore-missing-imports` on master:
```
Found 126 errors in 37 files (checked 558 source files)
```

With this PR:
```
Found 114 errors in 31 files (checked 558 source files)
```