### PR TITLE
fix(type hints): improve type hints in ibis.common

### DIFF
--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import inspect
 from typing import Any as AnyType
+from typing import Callable
 
 from ibis.common.patterns import (
     Any,
@@ -43,6 +44,9 @@ class Annotation:
     """
 
     __slots__ = ("_pattern", "_default", "_typehint")
+    _pattern: Pattern | Callable | None
+    _default: AnyType
+    _typehint: AnyType
 
     def __init__(self, pattern=None, default=EMPTY, typehint=EMPTY):
         if pattern is None or isinstance(pattern, Pattern):
@@ -127,6 +131,7 @@ class Argument(Annotation):
     """
 
     __slots__ = ("_kind",)
+    _kind: int
 
     def __init__(
         self,
@@ -331,7 +336,8 @@ class Signature(inspect.Signature):
             Tuple of positional and keyword arguments.
         """
         # does the reverse of bind, but doesn't apply defaults
-        args, kwargs = [], {}
+        args: list = []
+        kwargs: dict = {}
         for name, param in self.parameters.items():
             value = this[name]
             if param.kind is POSITIONAL_OR_KEYWORD:

--- a/ibis/common/bases.py
+++ b/ibis/common/bases.py
@@ -161,8 +161,9 @@ class Slotted(Base):
     """
 
     __slots__ = ("__precomputed_hash__",)
+    __precomputed_hash__: int
 
-    def __init__(self, **kwargs) -> Self:
+    def __init__(self, **kwargs) -> None:
         for name, value in kwargs.items():
             object.__setattr__(self, name, value)
         hashvalue = hash(tuple(kwargs.values()))

--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 def memoize(func: Callable) -> Callable:
     """Memoize a function."""
-    cache = {}
+    cache: dict = {}
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
@@ -34,6 +34,7 @@ def memoize(func: Callable) -> Callable:
 
 class WeakCache(MutableMapping):
     __slots__ = ("_data",)
+    _data: dict
 
     def __init__(self):
         object.__setattr__(self, "_data", {})
@@ -95,11 +96,13 @@ class RefCountedCache:
         key: Callable[[Any], Any],
     ) -> None:
         self.cache = bidict()
-        self.refs = Counter()
+        # Somehow mypy needs a type hint here
+        self.refs: Counter = Counter()
         self.populate = populate
         self.lookup = lookup
         self.finalize = finalize
-        self.names = defaultdict(generate_name)
+        # Somehow mypy needs a type hint here
+        self.names: defaultdict = defaultdict(generate_name)
         self.key = key or (lambda x: x)
 
     def get(self, key, default=None):

--- a/ibis/common/collections.py
+++ b/ibis/common/collections.py
@@ -141,6 +141,8 @@ class FrozenDict(Mapping[K, V], Hashable):
     """Immutable dictionary with a precomputed hash value."""
 
     __slots__ = ("__view__", "__precomputed_hash__")
+    __view__: MappingProxyType
+    __precomputed_hash__: int
 
     def __init__(self, *args, **kwargs):
         dictview = MappingProxyType(dict(*args, **kwargs))
@@ -215,4 +217,7 @@ class RewindableIterator(Iterator):
         self._iterator, self._checkpoint = tee(self._iterator)
 
 
+# Need to provide type hint as else a static type checker does not recognize
+# that frozendict exists in this module
+frozendict: type[FrozenDict]
 public(frozendict=FrozenDict)

--- a/ibis/common/patterns.py
+++ b/ibis/common/patterns.py
@@ -24,16 +24,17 @@ import toolz
 from typing_extensions import GenericMeta, Self, get_args, get_origin
 
 from ibis.common.bases import Singleton, Slotted
-from ibis.common.collections import RewindableIterator, frozendict
+from ibis.common.collections import FrozenDict, RewindableIterator, frozendict
 from ibis.common.dispatch import lazy_singledispatch
-from ibis.common.typing import Sentinel, get_bound_typevars, get_type_params
+from ibis.common.typing import (
+    ModuleType,
+    Sentinel,
+    UnionType,
+    _ClassInfo,
+    get_bound_typevars,
+    get_type_params,
+)
 from ibis.util import is_iterable, promote_tuple
-
-try:
-    from types import UnionType
-except ImportError:
-    UnionType = object()
-
 
 T_co = TypeVar("T_co", covariant=True)
 
@@ -92,8 +93,7 @@ class Pattern(Hashable):
 
         Returns
         -------
-        pattern
-            A pattern that matches the given type annotation.
+        A pattern that matches the given type annotation.
         """
         # TODO(kszucs): cache the result of this function
         # TODO(kszucs): explore issubclass(typ, SupportsInt) etc.
@@ -219,9 +219,8 @@ class Pattern(Hashable):
 
         Returns
         -------
-        match
-            The result of the pattern matching. If the pattern doesn't match
-            the value, then it must return the `NoMatch` sentinel value.
+        The result of the pattern matching. If the pattern doesn't match
+        the value, then it must return the `NoMatch` sentinel value.
         """
         ...
 
@@ -237,8 +236,7 @@ class Pattern(Hashable):
 
         Returns
         -------
-        bool
-            Whether the value matches the pattern.
+        Whether the value matches the pattern.
         """
         return self.match(value, context) is not NoMatch
 
@@ -382,6 +380,7 @@ class Variable(Slotted, Builder):
     """
 
     __slots__ = ("name",)
+    name: AnyType
 
     def __init__(self, name):
         super().__init__(name=name)
@@ -406,6 +405,7 @@ class Just(Slotted, Builder):
     """
 
     __slots__ = ("value",)
+    value: AnyType
 
     def __init__(self, value):
         assert not isinstance(value, (Pattern, Builder))
@@ -431,6 +431,7 @@ class Factory(Slotted, Builder):
     """
 
     __slots__ = ("func",)
+    func: Callable
 
     def __init__(self, func):
         assert callable(func)
@@ -457,6 +458,9 @@ class Call(Slotted, Builder):
     """
 
     __slots__ = ("func", "args", "kwargs")
+    func: Callable
+    args: tuple
+    kwargs: FrozenDict
 
     def __init__(self, func, *args, **kwargs):
         assert callable(func)
@@ -527,6 +531,7 @@ class Is(Slotted, Pattern):
     """
 
     __slots__ = ("value",)
+    value: AnyType
 
     def match(self, value, context):
         if value is self.value:
@@ -557,6 +562,8 @@ class Capture(Slotted, Pattern):
     """
 
     __slots__ = ("key", "pattern")
+    key: AnyType
+    pattern: Pattern
 
     def __init__(self, key, pat=_any):
         super().__init__(key=key, pattern=pattern(pat))
@@ -581,6 +588,8 @@ class Replace(Slotted, Pattern):
     """
 
     __slots__ = ("pattern", "builder")
+    pattern: Pattern
+    builder: Builder
 
     def __init__(self, matcher, replacer):
         super().__init__(pattern=pattern(matcher), builder=builder(replacer))
@@ -605,6 +614,7 @@ class Check(Slotted, Pattern):
     """
 
     __slots__ = ("predicate",)
+    predicate: Callable
 
     def __init__(self, predicate):
         assert callable(predicate)
@@ -627,6 +637,7 @@ class Function(Slotted, Pattern):
     """
 
     __slots__ = ("func",)
+    func: Callable
 
     def __init__(self, func):
         assert callable(func)
@@ -663,6 +674,8 @@ class Namespace:
     """
 
     __slots__ = ("module", "pattern")
+    module: ModuleType
+    pattern: Pattern
 
     def __init__(self, pattern, module):
         if isinstance(module, str):
@@ -693,6 +706,7 @@ class Apply(Slotted, Pattern):
     """
 
     __slots__ = ("func",)
+    func: Callable
 
     def __init__(self, func):
         assert callable(func)
@@ -716,6 +730,7 @@ class EqualTo(Slotted, Pattern):
     """
 
     __slots__ = ("value",)
+    value: AnyType
 
     def __init__(self, value):
         super().__init__(value=value)
@@ -737,6 +752,8 @@ class Option(Slotted, Pattern):
     """
 
     __slots__ = ("pattern", "default")
+    pattern: Pattern
+    default: AnyType
 
     def __init__(self, pat, default=None):
         super().__init__(pattern=pattern(pat), default=default)
@@ -755,6 +772,7 @@ class TypeOf(Slotted, Pattern):
     """Pattern that matches a value that is of a given type."""
 
     __slots__ = ("type",)
+    type: type
 
     def __init__(self, typ):
         super().__init__(type=typ)
@@ -797,6 +815,7 @@ class InstanceOf(Slotted, Singleton, Pattern):
     """
 
     __slots__ = ("type",)
+    type: _ClassInfo
 
     def __init__(self, typ):
         super().__init__(type=typ)
@@ -840,6 +859,8 @@ class GenericInstanceOf(Slotted, Pattern):
     """
 
     __slots__ = ("origin", "fields")
+    origin: type
+    fields: FrozenDict[str, Pattern]
 
     def __init__(self, typ):
         origin = get_origin(typ)
@@ -879,6 +900,8 @@ class LazyInstanceOf(Slotted, Pattern):
     """
 
     __slots__ = ("types", "check")
+    types: tuple[type, ...]
+    check: Callable
 
     def __init__(self, types):
         types = promote_tuple(types)
@@ -908,6 +931,7 @@ class CoercedTo(Slotted, Pattern):
     """
 
     __slots__ = ("target",)
+    target: type
 
     def __new__(cls, target):
         if issubclass(target, Coercible):
@@ -974,6 +998,9 @@ class GenericCoercedTo(Slotted, Pattern):
     """
 
     __slots__ = ("origin", "params", "checker")
+    origin: type
+    params: FrozenDict[str, type]
+    checker: GenericInstanceOf
 
     def __init__(self, target):
         origin = get_origin(target)
@@ -1003,6 +1030,7 @@ class Not(Slotted, Pattern):
     """
 
     __slots__ = ("pattern",)
+    pattern: Pattern
 
     def __init__(self, inner):
         super().__init__(pattern=pattern(inner))
@@ -1025,6 +1053,7 @@ class AnyOf(Slotted, Pattern):
     """
 
     __slots__ = ("patterns",)
+    patterns: tuple[Pattern, ...]
 
     def __init__(self, *pats):
         patterns = tuple(map(pattern, pats))
@@ -1050,6 +1079,7 @@ class AllOf(Slotted, Pattern):
     """
 
     __slots__ = ("patterns",)
+    patterns: tuple[Pattern, ...]
 
     def __init__(self, *pats):
         patterns = tuple(map(pattern, pats))
@@ -1078,6 +1108,8 @@ class Length(Slotted, Pattern):
     """
 
     __slots__ = ("at_least", "at_most")
+    at_least: int
+    at_most: int
 
     def __init__(
         self,
@@ -1111,6 +1143,7 @@ class Contains(Slotted, Pattern):
     """
 
     __slots__ = ("needle",)
+    needle: AnyType
 
     def __init__(self, needle):
         super().__init__(needle=needle)
@@ -1132,6 +1165,7 @@ class IsIn(Slotted, Pattern):
     """
 
     __slots__ = ("haystack",)
+    haystack: frozenset
 
     def __init__(self, haystack):
         super().__init__(haystack=frozenset(haystack))
@@ -1164,6 +1198,9 @@ class SequenceOf(Slotted, Pattern):
     """
 
     __slots__ = ("item", "type", "length")
+    item: Pattern
+    type: CoercedTo
+    length: Length
 
     def __init__(
         self,
@@ -1206,6 +1243,7 @@ class TupleOf(Slotted, Pattern):
     """
 
     __slots__ = ("fields",)
+    fields: tuple[Pattern, ...]
 
     def __new__(cls, fields):
         if isinstance(fields, tuple):
@@ -1248,6 +1286,9 @@ class MappingOf(Slotted, Pattern):
     """
 
     __slots__ = ("key", "value", "type")
+    key: Pattern
+    value: Pattern
+    type: CoercedTo
 
     def __init__(self, key: Pattern, value: Pattern, type: type = dict):
         super().__init__(key=pattern(key), value=pattern(value), type=CoercedTo(type))
@@ -1273,6 +1314,7 @@ class MappingOf(Slotted, Pattern):
 
 class Attrs(Slotted, Pattern):
     __slots__ = ("fields",)
+    fields: FrozenDict[str, Pattern]
 
     def __init__(self, **fields):
         fields = frozendict(toolz.valmap(pattern, fields))
@@ -1307,6 +1349,9 @@ class Object(Slotted, Pattern):
     """
 
     __slots__ = ("type", "args", "kwargs")
+    type: Pattern
+    args: tuple[Pattern, ...]
+    kwargs: FrozenDict[str, Pattern]
 
     def __new__(cls, type, *args, **kwargs):
         if not args and not kwargs:
@@ -1355,6 +1400,7 @@ class Object(Slotted, Pattern):
 
 class Node(Slotted, Pattern):
     __slots__ = ("type", "each_arg")
+    type: Pattern
 
     def __init__(self, type, each_arg):
         super().__init__(type=pattern(type), each_arg=pattern(each_arg))
@@ -1381,6 +1427,8 @@ class Node(Slotted, Pattern):
 
 class CallableWith(Slotted, Pattern):
     __slots__ = ("args", "return_")
+    args: tuple
+    return_: AnyType
 
     def __init__(self, args, return_=_any):
         super().__init__(args=tuple(args), return_=return_)
@@ -1422,6 +1470,7 @@ class PatternSequence(Slotted, Pattern):
     # length of the sequence is lower than the length of the pattern sequence
 
     __slots__ = ("pattern_window",)
+    pattern_window: tuple[tuple[Pattern, Pattern], ...]
 
     def __init__(self, patterns):
         current_patterns = [
@@ -1495,6 +1544,8 @@ class PatternSequence(Slotted, Pattern):
 
 class PatternMapping(Slotted, Pattern):
     __slots__ = ("keys", "values")
+    keys: PatternSequence
+    values: PatternSequence
 
     def __init__(self, patterns):
         keys = PatternSequence(list(map(pattern, patterns.keys())))
@@ -1528,6 +1579,8 @@ class Between(Slotted, Pattern):
     """
 
     __slots__ = ("lower", "upper")
+    lower: float
+    upper: float
 
     def __init__(self, lower: float = -math.inf, upper: float = math.inf):
         super().__init__(lower=lower, upper=upper)
@@ -1581,8 +1634,7 @@ def pattern(obj: AnyType) -> Pattern:
 
     Returns
     -------
-    pattern
-        The constructed pattern.
+    The constructed pattern.
     """
     if obj is Ellipsis:
         return _any
@@ -1647,6 +1699,8 @@ class Topmost(Slotted, Pattern):
     """Traverse the value tree topmost first and match the first value that matches."""
 
     __slots__ = ("pattern", "filter")
+    pattern: Pattern
+    filter: AnyType
 
     def __init__(self, searcher, filter=None):
         super().__init__(pattern=pattern(searcher), filter=filter)
@@ -1669,6 +1723,8 @@ class Innermost(Slotted, Pattern):
     """Traverse the value tree innermost first and match the first value that matches."""
 
     __slots__ = ("pattern", "filter")
+    pattern: Pattern
+    filter: AnyType
 
     def __init__(self, searcher, filter=None):
         super().__init__(pattern=pattern(searcher), filter=filter)

--- a/ibis/common/tests/conftest.py
+++ b/ibis/common/tests/conftest.py
@@ -2,6 +2,6 @@ from __future__ import annotations
 
 import sys
 
-collect_ignore = []
+collect_ignore: list[str] = []
 if sys.version_info < (3, 10):
     collect_ignore.append("test_grounds_py310.py")


### PR DESCRIPTION
As suggested by @kszucs in https://github.com/ibis-project/ibis/pull/6862#issuecomment-1676799118, I copied all type hint changes from #6852 into this PR. I also fixed a few more mypy errors but this PR does not yet fix all in `ibis.common`. I think I'm not familiar enough with Ibis to suggest changes for the remaining ones but happy to brainstorm and review!

Some but not all outstanding points:

- [ ] Subclasses of `Annotable` create `Attributes without a default cannot follow attributes with one` errors. See https://github.com/ibis-project/ibis/issues/6844#issuecomment-1676403220
- [ ] `MapSet` does not take any input arguments but methods such as `__and__` pass arguments to class (`self.__class__(intersection)`) which gives `error: Too many arguments for "MapSet"  [call-arg]` errors. Should `MapSet` be an abstract base class with abstract methods and/or define `__init__`?