### PR TITLE
perf(duckdb): improve `to_pyarrow` performance

### DIFF
--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -323,6 +323,7 @@ def test_table_to_csv(tmp_path, backend, awards_players):
             id="decimal256",
             marks=[
                 pytest.mark.notyet(["impala"], reason="precision not supported"),
+                pytest.mark.notyet(["duckdb"], reason="precision is out of range"),
                 pytest.mark.notyet(
                     ["druid", "duckdb", "snowflake", "trino"],
                     raises=sa.exc.ProgrammingError,


### PR DESCRIPTION
Given the feedback [here](https://github.com/duckdb/duckdb/discussions/8582#discussioncomment-6737173) this switches `to_pyarrow` to use `.sql(...).to_arrow_table()` instead of `.execute(...)`. This has a measurable impact on performance on some queries (up to 4x faster on my machine) as it allows duckdb to include the result conversion to pyarrow in the physical plan.

With this fix ibis & duckdb vs duckdb alone perform ~the same on the workload described in #6874.

Fixes #6874.