### PR TITLE
fix(snowflake): ensure that the fully qualified name is compiled into `sa.Table`s

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -805,6 +805,23 @@ $$""".format(
 
         return self.table(table)
 
+    def _get_schema_for_table(self, *, qualname: str, schema: str) -> str:
+        return qualname
+
+
+@compiles(sa.Table, "snowflake")
+def compile_table(element, compiler, **kw):
+    """Override compilation of leaf tables.
+
+    The override is necessary because snowflake-sqlalchemy does not handle
+    quoting databases and schemas correctly.
+    """
+    schema = element.schema
+    name = compiler.preparer.quote_identifier(element.name)
+    if schema is not None:
+        return f"{schema}.{name}"
+    return name
+
 
 @compiles(sa.sql.Join, "snowflake")
 def compile_join(element, compiler, **kw):

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -363,3 +363,11 @@ class Backend(AlchemyCrossSchemaBackend, AlchemyCanCreateSchema, CanListDatabase
             trino_catalog=database or self.current_database,
             **kwargs,
         )
+
+    def _get_schema_for_table(self, *, qualname: str, schema: str) -> str:
+        """Trino compiles the `trino_catalog` argument into `sa.Table`.
+
+        This means we only need the schema and not the fully qualified
+        $catalog.$schema identifier.
+        """
+        return schema

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -76,3 +76,19 @@ def test_con_source(source, expected):
         source=source,
     )
     assert con.con.url.query["source"] == expected
+
+
+@pytest.mark.parametrize(
+    ("schema", "table"),
+    [
+        # tables known to exist
+        ("memory.default", "diamonds"),
+        ("postgresql.public", "map"),
+        ("system.metadata", "table_comments"),
+        ("tpcds.sf1", "store"),
+        ("tpch.sf1", "nation"),
+    ],
+)
+def test_cross_schema_table_access(con, schema, table):
+    t = con.table(table, schema=schema)
+    assert t.count().execute()


### PR DESCRIPTION
Fixes an issue where the full identifier for snowflake tables was not compiled for `sa.Table` objects.