### PR TITLE
feat(selectors): support column references in column selector

### DIFF
--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -365,9 +365,9 @@ def all_of(*predicates: str | Predicate) -> Predicate:
 
 
 @public
-def c(*names: str) -> Predicate:
+def c(*names: str | ir.Column) -> Predicate:
     """Select specific column names."""
-    names = frozenset(names)
+    names = frozenset(col if isinstance(col, str) else col.get_name() for col in names)
 
     def func(col: ir.Value) -> bool:
         schema = col.op().table.schema
@@ -664,10 +664,14 @@ def all() -> Predicate:
     return r[:]
 
 
-def _to_selector(obj: str | Selector | Sequence[str | Selector]) -> Selector:
+def _to_selector(
+    obj: str | Selector | ir.Column | Sequence[str | Selector | ir.Column],
+) -> Selector:
     """Convert an object to a `Selector`."""
     if isinstance(obj, Selector):
         return obj
+    elif isinstance(obj, ir.Column):
+        return c(obj.get_name())
     elif isinstance(obj, str):
         return c(obj)
     else:

--- a/ibis/tests/expr/test_selectors.py
+++ b/ibis/tests/expr/test_selectors.py
@@ -157,8 +157,12 @@ def zscore(c):
             s.across(s.numeric() & ~s.c("year"), (_ - _.mean()) / _.std())
         ),
         lambda t: t.select(s.across(s.numeric() & ~s.c("year"), zscore)),
+        lambda t: t.select(
+            s.across(s.numeric() & ~s.c(t.year), (_ - _.mean()) / _.std())
+        ),
+        lambda t: t.select(s.across(s.numeric() & ~s.c(t.year), zscore)),
     ],
-    ids=["deferred", "func"],
+    ids=["deferred", "func", "deferred-column-ref", "func-column-ref"],
 )
 def test_across_select(penguins, expr_func):
     expr = expr_func(penguins)


### PR DESCRIPTION
Resolves #6872

There are other ways to accomplish supporting column references in `drop`, but I think it makes sense to also support column references in the named column selector.