### PR TITLE
test(bigquery): remove unnecessary use of `s.c` selector in tests

### DIFF
--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -14,7 +14,6 @@ from google.cloud import bigquery as bq
 
 import ibis
 import ibis.expr.datatypes as dt
-import ibis.selectors as s
 from ibis.backends.bigquery import EXTERNAL_DATA_SCOPES, Backend
 from ibis.backends.bigquery.datatypes import BigQueryType
 from ibis.backends.conftest import TEST_TABLES
@@ -23,8 +22,6 @@ from ibis.backends.tests.data import json_types, non_null_array_types, struct_ty
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-
-    import ibis.expr.types as ir
 
 DATASET_ID = "ibis_gbq_testing"
 DATASET_ID_TOKYO = "ibis_gbq_testing_tokyo"
@@ -301,11 +298,6 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
 
             for fut in concurrent.futures.as_completed(futures):
                 fut.result()
-
-    @property
-    def functional_alltypes(self) -> ir.Table:
-        t = super().functional_alltypes
-        return t.select(~s.c("index", "Unnamed_0"))
 
     @staticmethod
     def connect(*, tmpdir, worker_id, **kw) -> Backend:

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_union/False/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_union/False/out.sql
@@ -1,7 +1,7 @@
-SELECT t0.`index`, t0.`Unnamed_0`, t0.`id`, t0.`bool_col`, t0.`tinyint_col`,
-       t0.`smallint_col`, t0.`int_col`, t0.`bigint_col`, t0.`float_col`,
-       t0.`double_col`, t0.`date_string_col`, t0.`string_col`,
-       t0.`timestamp_col`, t0.`year`, t0.`month`
+SELECT t0.`id`, t0.`bool_col`, t0.`tinyint_col`, t0.`smallint_col`,
+       t0.`int_col`, t0.`bigint_col`, t0.`float_col`, t0.`double_col`,
+       t0.`date_string_col`, t0.`string_col`, t0.`timestamp_col`,
+       t0.`year`, t0.`month`
 FROM (
   SELECT t1.*
   FROM functional_alltypes t1

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_union/True/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_union/True/out.sql
@@ -1,7 +1,7 @@
-SELECT t0.`index`, t0.`Unnamed_0`, t0.`id`, t0.`bool_col`, t0.`tinyint_col`,
-       t0.`smallint_col`, t0.`int_col`, t0.`bigint_col`, t0.`float_col`,
-       t0.`double_col`, t0.`date_string_col`, t0.`string_col`,
-       t0.`timestamp_col`, t0.`year`, t0.`month`
+SELECT t0.`id`, t0.`bool_col`, t0.`tinyint_col`, t0.`smallint_col`,
+       t0.`int_col`, t0.`bigint_col`, t0.`float_col`, t0.`double_col`,
+       t0.`date_string_col`, t0.`string_col`, t0.`timestamp_col`,
+       t0.`year`, t0.`month`
 FROM (
   SELECT t1.*
   FROM functional_alltypes t1

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -23,8 +23,6 @@ def alltypes():
     return ibis.table(
         ibis.schema(
             dict(
-                index="int64",
-                Unnamed_0="int64",
                 id="int32",
                 bool_col="boolean",
                 tinyint_col="int8",


### PR DESCRIPTION
Fixes failing bigquery tests that were unnecessarily using a negated `s.c` selector to select columns that do not exist.