### PR TITLE
chore(duckdb): remove use of cursor in `to_pyarrow` and remove duplicate test marker

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -874,8 +874,7 @@ WHERE catalog_name = :database"""
         )
 
         with self.begin() as con:
-            cursor = con.connection.cursor()
-            table = cursor.sql(sql).to_arrow_table()
+            table = con.connection.sql(sql).to_arrow_table()
 
         return expr.__pyarrow_result__(table)
 

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -325,8 +325,7 @@ def test_table_to_csv(tmp_path, backend, awards_players):
                 pytest.mark.notyet(["impala"], reason="precision not supported"),
                 pytest.mark.notyet(["duckdb"], reason="precision is out of range"),
                 pytest.mark.notyet(
-                    ["druid", "duckdb", "snowflake", "trino"],
-                    raises=sa.exc.ProgrammingError,
+                    ["druid", "snowflake", "trino"], raises=sa.exc.ProgrammingError
                 ),
                 pytest.mark.notyet(["oracle"], raises=sa.exc.DatabaseError),
                 pytest.mark.notyet(["dask"], raises=NotImplementedError),


### PR DESCRIPTION
Follow up to #6875.