### PR TITLE
fix(duckdb): load httpfs with read_csv from s3

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -427,7 +427,10 @@ WHERE catalog_name = :database"""
 
         # auto_detect and columns collide, so we set auto_detect=True
         # unless COLUMNS has been specified
-        if any(source.startswith(("http://", "https://")) for source in source_list):
+        if any(
+            source.startswith(("http://", "https://", "s3://"))
+            for source in source_list
+        ):
             self._load_extensions(["httpfs"])
 
         kwargs.setdefault("header", True)


### PR DESCRIPTION
Enhanced source list protocol checking for `read_csv` with DuckDB to include s3:// alongside existing http:// and https://. This behavior is currently available with parquet. 

I was using Ibis with DuckDB to perform this operation and was able to work around it by using `ddb_con.raw_sql("INSTALL httpfs;")` before realizing s3 wasn't included in this section. 

Here's what was happening before:
```
OperationalError: (duckdb.IOException) IO Error: Extension "/home/user/.duckdb/extensions/v0.8.1/linux_amd64_gcc4/httpfs.duckdb_extension" not found.
Extension "httpfs" is an existing extension.

Install it first using "INSTALL httpfs".
[SQL: CREATE OR REPLACE TEMPORARY VIEW "_ibis_read_csv_ptgbbnh6dnca3dgsx3ec7elmam" AS SELECT * 
FROM read_csv(list_value('s3://path/campaign_spend.csv'), header = true, auto_detect = true)]
(Background on this error at: https://sqlalche.me/e/14/e3q8)
```