### PR TITLE
refactor(common): improve error messages raised during validation

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -482,7 +482,7 @@ def test_dropna_invalid(alltypes):
     ):
         alltypes.dropna(subset=["invalid_col"])
 
-    with pytest.raises(ValidationError, match=r"'invalid' doesn't match"):
+    with pytest.raises(ValidationError):
         alltypes.dropna(how="invalid")
 
 

--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import inspect
 import types
+from typing import TYPE_CHECKING, Callable
 from typing import Any as AnyType
 
 from ibis.common.bases import Immutable, Slotted
@@ -15,7 +16,10 @@ from ibis.common.patterns import (
     TupleOf,
 )
 from ibis.common.patterns import pattern as ensure_pattern
-from ibis.common.typing import get_type_hints
+from ibis.common.typing import format_typehint, get_type_hints
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 EMPTY = inspect.Parameter.empty  # marker for missing argument
 KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
@@ -29,7 +33,65 @@ _any = Any()
 
 
 class ValidationError(Exception):
-    ...
+    __slots__ = ()
+
+
+class AttributeValidationError(ValidationError):
+    __slots__ = ("name", "value", "pattern")
+
+    def __init__(self, name: str, value: AnyType, pattern: Pattern):
+        self.name = name
+        self.value = value
+        self.pattern = pattern
+
+    def __str__(self):
+        return f"Failed to validate attribute `{self.name}`: {self.value!r} is not {self.pattern.describe()}"
+
+
+class ReturnValidationError(ValidationError):
+    __slots__ = ("func", "value", "pattern")
+
+    def __init__(self, func: Callable, value: AnyType, pattern: Pattern):
+        self.func = func
+        self.value = value
+        self.pattern = pattern
+
+    def __str__(self):
+        return f"Failed to validate return value of `{self.func.__name__}`: {self.value!r} is not {self.pattern.describe()}"
+
+
+class SignatureValidationError(ValidationError):
+    __slots__ = ("msg", "sig", "func", "args", "kwargs", "errors")
+
+    def __init__(
+        self,
+        msg: str,
+        sig: Signature,
+        func: Callable,
+        args: tuple[AnyType, ...],
+        kwargs: dict[str, AnyType],
+        errors: Sequence[tuple[str, AnyType, Pattern]] = (),
+    ):
+        self.msg = msg
+        self.sig = sig
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+        self.errors = errors
+
+    def __str__(self):
+        args = tuple(repr(arg) for arg in self.args)
+        args += tuple(f"{k}={v!r}" for k, v in self.kwargs.items())
+        call = f"{self.func.__name__}({', '.join(args)})"
+
+        errors = ""
+        for name, value, pattern in self.errors:
+            errors += f"\n  `{name}`: {value!r} is not {pattern.describe()}"
+
+        sig = f"{self.func.__name__}{self.sig}"
+        cause = str(self.__cause__) if self.__cause__ else ""
+
+        return self.msg.format(sig=sig, call=call, cause=cause, errors=errors)
 
 
 class Annotation(Slotted, Immutable):
@@ -40,11 +102,29 @@ class Annotation(Slotted, Immutable):
 
     __slots__ = ()
 
-    def validate(self, arg, context=None):
-        result = self.pattern.match(arg, context)
-        if result is NoMatch:
-            raise ValidationError(f"{arg!r} doesn't match {self.pattern!r}")
+    def validate(self, name: str, value: AnyType, this: AnyType) -> AnyType:
+        """Validate the field.
 
+        Parameters
+        ----------
+        name
+            The name of the attribute.
+        value
+            The value of the attribute.
+        this
+            The instance of the class the attribute is defined on.
+
+        Returns
+        -------
+        The validated value for the field.
+        """
+        result = self.pattern.match(value, this)
+        if result is NoMatch:
+            raise AttributeValidationError(
+                name=name,
+                value=value,
+                pattern=self.pattern,
+            )
         return result
 
 
@@ -69,11 +149,22 @@ class Attribute(Annotation):
     def __init__(self, pattern: Pattern = _any, default: AnyType = EMPTY):
         super().__init__(pattern=ensure_pattern(pattern), default=default)
 
-    def initialize(self, this: AnyType) -> AnyType:
-        """Compute the default value of the field.
+    def has_default(self):
+        """Check if the field has a default value.
+
+        Returns
+        -------
+        bool
+        """
+        return self.default is not EMPTY
+
+    def get_default(self, name: str, this: AnyType) -> AnyType:
+        """Get the default value of the field.
 
         Parameters
         ----------
+        name
+            The name of the attribute.
         this
             The instance of the class the attribute is defined on.
 
@@ -81,13 +172,11 @@ class Attribute(Annotation):
         -------
         The default value for the field.
         """
-        if self.default is EMPTY:
-            return EMPTY
-        elif callable(self.default):
+        if callable(self.default):
             value = self.default(this)
         else:
             value = self.default
-        return self.validate(value, this)
+        return self.validate(name, value, this)
 
     def __call__(self, default):
         """Needed to support the decorator syntax."""
@@ -179,6 +268,26 @@ class Parameter(inspect.Parameter):
             default=annotation.default,
             annotation=annotation,
         )
+
+    def __str__(self):
+        formatted = self._name
+
+        if self._annotation is not EMPTY:
+            typehint = format_typehint(self._annotation.typehint)
+            formatted = f"{formatted}: {typehint}"
+
+        if self._default is not EMPTY:
+            if self._annotation is not EMPTY:
+                formatted = f"{formatted} = {self._default!r}"
+            else:
+                formatted = f"{formatted}={self._default!r}"
+
+        if self._kind == VAR_POSITIONAL:
+            formatted = "*" + formatted
+        elif self._kind == VAR_KEYWORD:
+            formatted = "**" + formatted
+
+        return formatted
 
 
 class Signature(inspect.Signature):
@@ -339,11 +448,13 @@ class Signature(inspect.Signature):
                 raise TypeError(f"unsupported parameter kind {param.kind}")
         return tuple(args), kwargs
 
-    def validate(self, *args, **kwargs):
+    def validate(self, func, args, kwargs):
         """Validate the arguments against the signature.
 
         Parameters
         ----------
+        func : Callable
+            Callable to validate the arguments for.
         args : tuple
             Positional arguments.
         kwargs : dict
@@ -354,39 +465,77 @@ class Signature(inspect.Signature):
         validated : dict
             Dictionary of validated arguments.
         """
-        # bind the signature to the passed arguments and apply the patterns
-        # before passing the arguments, so self.__init__() receives already
-        # validated arguments as keywords
-        bound = self.bind(*args, **kwargs)
-        bound.apply_defaults()
+        try:
+            bound = self.bind(*args, **kwargs)
+            bound.apply_defaults()
+        except TypeError as err:
+            raise SignatureValidationError(
+                "{call} {cause}\n\nExpected signature: {sig}",
+                sig=self,
+                func=func,
+                args=args,
+                kwargs=kwargs,
+            ) from err
 
-        this = {}
+        this, errors = {}, []
         for name, value in bound.arguments.items():
             param = self.parameters[name]
-            # TODO(kszucs): provide more error context on failure
-            this[name] = param.annotation.validate(value, this)
+            pattern = param.annotation.pattern
+
+            result = pattern.match(value, this)
+            if result is NoMatch:
+                errors.append((name, value, pattern))
+            else:
+                this[name] = result
+
+        if errors:
+            raise SignatureValidationError(
+                "{call} has failed due to the following errors:{errors}\n\nExpected signature: {sig}",
+                sig=self,
+                func=func,
+                args=args,
+                kwargs=kwargs,
+                errors=errors,
+            )
 
         return this
 
-    def validate_nobind(self, **kwargs):
+    def validate_nobind(self, func, kwargs):
         """Validate the arguments against the signature without binding."""
-        this = {}
+        this, errors = {}, []
         for name, param in self.parameters.items():
             value = kwargs.get(name, param.default)
             if value is EMPTY:
                 raise TypeError(f"missing required argument `{name!r}`")
-            this[name] = param.annotation.validate(value, kwargs)
+
+            pattern = param.annotation.pattern
+            result = pattern.match(value, this)
+            if result is NoMatch:
+                errors.append((name, value, pattern))
+            else:
+                this[name] = result
+
+        if errors:
+            raise SignatureValidationError(
+                "{call} has failed due to the following errors:{errors}\n\nExpected signature: {sig}",
+                sig=self,
+                func=func,
+                args=(),
+                kwargs=kwargs,
+                errors=errors,
+            )
+
         return this
 
-    def validate_return(self, value, context):
+    def validate_return(self, func, value):
         """Validate the return value of a function.
 
         Parameters
         ----------
+        func : Callable
+            Callable to validate the return value for.
         value : Any
             Return value of the function.
-        context : dict
-            Context dictionary.
 
         Returns
         -------
@@ -396,9 +545,13 @@ class Signature(inspect.Signature):
         if self.return_annotation is EMPTY:
             return value
 
-        result = self.return_annotation.match(value, context)
+        result = self.return_annotation.match(value, {})
         if result is NoMatch:
-            raise ValidationError(f"{value!r} doesn't match {self}")
+            raise ReturnValidationError(
+                func=func,
+                value=value,
+                pattern=self.return_annotation,
+            )
 
         return result
 
@@ -476,13 +629,13 @@ def annotated(_1=None, _2=None, _3=None, **kwargs):
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         # 1. Validate the passed arguments
-        values = sig.validate(*args, **kwargs)
+        values = sig.validate(func, args, kwargs)
         # 2. Reconstruction of the original arguments
         args, kwargs = sig.unbind(values)
         # 3. Call the function with the validated arguments
         result = func(*args, **kwargs)
         # 4. Validate the return value
-        return sig.validate_return(result, {})
+        return sig.validate_return(func, result)
 
     wrapped.__signature__ = sig
 

--- a/ibis/common/tests/snapshots/test_annotations/test_annotated_function_without_decoration/error.txt
+++ b/ibis/common/tests/snapshots/test_annotations/test_annotated_function_without_decoration/error.txt
@@ -1,0 +1,3 @@
+test(1, 2) missing a required argument: 'c'
+
+Expected signature: test(a: None, b: None, c: None)

--- a/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_keyword_only_arguments/missing_a_required_argument.txt
+++ b/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_keyword_only_arguments/missing_a_required_argument.txt
@@ -1,0 +1,3 @@
+test(2, 3) missing a required argument: 'c'
+
+Expected signature: test(a: int, b: int, *, c: float, d: float = 0.0)

--- a/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_keyword_only_arguments/too_many_positional_arguments.txt
+++ b/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_keyword_only_arguments/too_many_positional_arguments.txt
@@ -1,0 +1,3 @@
+test(2, 3, 4) too many positional arguments
+
+Expected signature: test(a: int, b: int, *, c: float, d: float = 0.0)

--- a/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_positional_only_arguments/parameter_is_positional_only.txt
+++ b/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_positional_only_arguments/parameter_is_positional_only.txt
@@ -1,0 +1,3 @@
+test(1, b=2) 'b' parameter is positional only, but was passed as a keyword
+
+Expected signature: test(a: int, b: int, /, c: int = 1)

--- a/ibis/common/tests/snapshots/test_grounds/test_error_message/error_message.txt
+++ b/ibis/common/tests/snapshots/test_grounds/test_error_message/error_message.txt
@@ -1,0 +1,8 @@
+Example('1', '2', '3', '4', '5', []) has failed due to the following errors:
+  `a`: '1' is not an int
+  `b`: '2' is not an int
+  `d`: '4' is not either None or a float
+  `e`: '5' is not a tuple of ints
+  `f`: [] is not coercible to an int
+
+Expected signature: Example(a: int, b: int = 0, c: str = 'foo', d: Optional[float] = None, e: tuple = (1, 2, 3), f: CoercedTo[int] = 1)

--- a/ibis/common/tests/snapshots/test_grounds/test_error_message/error_message_py311.txt
+++ b/ibis/common/tests/snapshots/test_grounds/test_error_message/error_message_py311.txt
@@ -1,0 +1,8 @@
+Example('1', '2', '3', '4', '5', []) has failed due to the following errors:
+  `a`: '1' is not an int
+  `b`: '2' is not an int
+  `d`: '4' is not either None or a float
+  `e`: '5' is not a tuple of ints
+  `f`: [] is not coercible to an int
+
+Expected signature: Example(a: int, b: int = 0, c: str = 'foo', d: Optional[float] = None, e: tuple[int, ...] = (1, 2, 3), f: CoercedTo[int] = 1)

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 from itertools import zip_longest
 from types import ModuleType  # noqa: F401
@@ -192,6 +193,19 @@ def evaluate_annotations(
         k: eval(v, globalns, localns) if isinstance(v, str) else v  # noqa: PGH001
         for k, v in annots.items()
     }
+
+
+def format_typehint(typ: Any) -> str:
+    if isinstance(typ, type):
+        return typ.__name__
+    elif isinstance(typ, TypeVar):
+        if typ.__bound__ is None:
+            return str(typ)
+        else:
+            return format_typehint(typ.__bound__)
+    else:
+        # remove the module name from the typehint, including generics
+        return re.sub(r"(\w+\.)+", "", str(typ))
 
 
 class DefaultTypeVars:

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -121,7 +121,7 @@ class DataType(Concrete, Coercible):
             return value
         try:
             return dtype(value)
-        except TypeError as e:
+        except (TypeError, RuntimeError) as e:
             raise CoercionError("Unable to coerce to a DataType") from e
 
     def __call__(self, **kwargs):
@@ -165,7 +165,12 @@ class DataType(Concrete, Coercible):
 
         if origin_type is None:
             if isinstance(typ, type):
-                if issubclass(typ, DataType):
+                if issubclass(typ, Parametric):
+                    raise TypeError(
+                        f"Cannot construct a parametric {typ.__name__} datatype based "
+                        "on the type itself"
+                    )
+                elif issubclass(typ, DataType):
                     return typ(nullable=nullable)
                 elif typ is type(None):
                     return null

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -69,8 +69,6 @@ def test_dtype(spec, expected):
         (dt.Boolean, dt.boolean),
         (dt.Date, dt.date),
         (dt.Time, dt.time),
-        (dt.Decimal, dt.decimal),
-        (dt.Timestamp, dt.timestamp),
     ],
 )
 def test_dtype_from_classes(klass, expected):
@@ -145,8 +143,6 @@ class BarStruct:
     l: dt.Boolean  # noqa: E741
     m: dt.Date
     n: dt.Time
-    o: dt.Timestamp
-    q: dt.Decimal
     r: dt.Array[dt.Int16]
     s: dt.Map[dt.String, dt.Int16]
 
@@ -167,8 +163,6 @@ bar_struct = dt.Struct(
         "l": dt.boolean,
         "m": dt.date,
         "n": dt.time,
-        "o": dt.timestamp,
-        "q": dt.decimal,
         "r": dt.Array(dt.int16),
         "s": dt.Map(dt.string, dt.int16),
     }

--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -75,7 +75,7 @@ class Value(Node, Named, Coercible, DefaultTypeVars, Generic[T, S]):
 
         try:
             try:
-                dtype = dt.dtype(T)
+                dtype = dt.DataType.from_typehint(T)
             except TypeError:
                 dtype = dt.infer(value)
             return Literal(value, dtype=dtype)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call0-missing_a_required_argument/missing_a_required_argument.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call0-missing_a_required_argument/missing_a_required_argument.txt
@@ -1,3 +1,3 @@
 Literal(1) missing a required argument: 'dtype'
 
-Expected signature: Literal(value: Any, dtype: DataType)
+Expected signature: Literal(value: Annotated[Any, Not(pattern=InstanceOf(type=<class 'Deferred'>))], dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call0-missing_a_required_argument/missing_a_required_argument.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call0-missing_a_required_argument/missing_a_required_argument.txt
@@ -1,0 +1,3 @@
+Literal(1) missing a required argument: 'dtype'
+
+Expected signature: Literal(value: Any, dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call1-too_many_positional_arguments/too_many_positional_arguments.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call1-too_many_positional_arguments/too_many_positional_arguments.txt
@@ -1,0 +1,3 @@
+Literal(1, Int8(nullable=True), 'foo') too many positional arguments
+
+Expected signature: Literal(value: Any, dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call1-too_many_positional_arguments/too_many_positional_arguments.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call1-too_many_positional_arguments/too_many_positional_arguments.txt
@@ -1,3 +1,3 @@
 Literal(1, Int8(nullable=True), 'foo') too many positional arguments
 
-Expected signature: Literal(value: Any, dtype: DataType)
+Expected signature: Literal(value: Annotated[Any, Not(pattern=InstanceOf(type=<class 'Deferred'>))], dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call2-got_an_unexpected_keyword/got_an_unexpected_keyword.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call2-got_an_unexpected_keyword/got_an_unexpected_keyword.txt
@@ -1,3 +1,3 @@
 Literal(1, Int8(nullable=True), name='foo') got an unexpected keyword argument 'name'
 
-Expected signature: Literal(value: Any, dtype: DataType)
+Expected signature: Literal(value: Annotated[Any, Not(pattern=InstanceOf(type=<class 'Deferred'>))], dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call2-got_an_unexpected_keyword/got_an_unexpected_keyword.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call2-got_an_unexpected_keyword/got_an_unexpected_keyword.txt
@@ -1,0 +1,3 @@
+Literal(1, Int8(nullable=True), name='foo') got an unexpected keyword argument 'name'
+
+Expected signature: Literal(value: Any, dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call3-multiple_values_for_argument/multiple_values_for_argument.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call3-multiple_values_for_argument/multiple_values_for_argument.txt
@@ -1,0 +1,3 @@
+Literal(1, Int8(nullable=True), dtype=Int16(nullable=True)) multiple values for argument 'dtype'
+
+Expected signature: Literal(value: Any, dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call3-multiple_values_for_argument/multiple_values_for_argument.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call3-multiple_values_for_argument/multiple_values_for_argument.txt
@@ -1,3 +1,3 @@
 Literal(1, Int8(nullable=True), dtype=Int16(nullable=True)) multiple values for argument 'dtype'
 
-Expected signature: Literal(value: Any, dtype: DataType)
+Expected signature: Literal(value: Annotated[Any, Not(pattern=InstanceOf(type=<class 'Deferred'>))], dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call4-invalid_dtype/invalid_dtype.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call4-invalid_dtype/invalid_dtype.txt
@@ -1,4 +1,4 @@
 Literal(1, 4) has failed due to the following errors:
   `dtype`: 4 is not coercible to a DataType
 
-Expected signature: Literal(value: Any, dtype: DataType)
+Expected signature: Literal(value: Annotated[Any, Not(pattern=InstanceOf(type=<class 'Deferred'>))], dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call4-invalid_dtype/invalid_dtype.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call4-invalid_dtype/invalid_dtype.txt
@@ -1,0 +1,4 @@
+Literal(1, 4) has failed due to the following errors:
+  `dtype`: 4 is not coercible to a DataType
+
+Expected signature: Literal(value: Any, dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call5-unable_to_normalize/unable_to_normalize.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call5-unable_to_normalize/unable_to_normalize.txt
@@ -1,0 +1,1 @@
+Unable to normalize 'e' to Int8(nullable=True)

--- a/ibis/expr/operations/tests/test_core.py
+++ b/ibis/expr/operations/tests/test_core.py
@@ -198,10 +198,10 @@ def test_too_many_or_too_few_args_not_allowed():
     class DummyOp(ops.Value):
         arg: ops.Value
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         DummyOp(1, 2)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         DummyOp()
 
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1860,7 +1860,7 @@ def test_pivot_wider():
 def test_invalid_deferred():
     t = ibis.table(dict(value="int", lagged_value="int"), name="t")
 
-    with pytest.raises(ValidationError, match="doesn't match"):
+    with pytest.raises(ValidationError):
         ibis.greatest(t.value, ibis._.lagged_value)
 
 

--- a/ibis/tests/expr/test_window_frames.py
+++ b/ibis/tests/expr/test_window_frames.py
@@ -56,7 +56,7 @@ def test_window_builder_rows():
 
     assert w0.start is None
     assert w0.end is None
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         w0.rows(5)
 
     w1 = w0.rows(5, 10)
@@ -104,7 +104,7 @@ def test_window_builder_range():
 
     assert w0.start is None
     assert w0.end is None
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         w0.range(5)
 
     w1 = w0.range(5, 10)


### PR DESCRIPTION
Currently we have really cryptic, hard to interpret error messages:

```py
class Example(Annotable):
    a: int
    b: int = 0
    c: str = "foo"
    d: Optional[float] = None
    e: tuple[int, ...] = (1, 2, 3)
    f: As[int] = 1

Example("1", "2", "3", "4", "5", [])
```

Previously we raised

```
'1' doesn't match InstanceOf(type=<class 'int'>)
```

After this change we have the additional information to construct the error message: 
- pattern used for validation
- mismatched value
- argument/field the validation failed on
- annotable class failed to construct

Currently this PR produces the following error message:

```py
Example('1', '2', '3', '4', '5', []) has failed due to the following errors:
   `a`: '1' is not an int
   `b`: '2' is not an int
   `d`: '4' is not either None or a float
   `e`: '5' is not a tuple of ints
   `f`: [] is not coercible to an int

 Expected signature: Example(a: int, b: int = 0, c: str = 'foo', d: Optional[float] = None, e: tuple = (1, 2, 3), f: CoercedTo[int] = 1)
```

The implementation extends the `ValidationError` with a list of `(name, value, pattern)` triplets and on display it calls `pattern.describe()` for each arguments to provide a more "natural language"-like error message. 

As an extra feature this PR turns `CoercedTo` pattern to a generic class to support explicit annotations for coercions:

```py
In [3]: from ibis.common.patterns import As # alias for CoercedTo
   ...: from ibis.common.annotations import annotated
   ...:
   ...: @annotated
   ...: def inc(a: As[int]) -> int:
   ...:     return a + 1
   ...:
   ...: inc("123")
Out[3]: 124

In [4]: inc("string")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[4], line 1
----> 1 inc("string")
...
ValueError: invalid literal for int() with base 10: 'string'
```

