### PR TITLE
test(snowflake): use parquet for data loading in the test suite

### DIFF
--- a/ci/schema/snowflake.sql
+++ b/ci/schema/snowflake.sql
@@ -1,11 +1,3 @@
-CREATE OR REPLACE TEMP FILE FORMAT ibis_testing
-    type = 'CSV'
-    field_delimiter = ','
-    skip_header = 1
-    field_optionally_enclosed_by = '"';
-
-CREATE OR REPLACE TEMP STAGE ibis_testing file_format = ibis_testing;
-
 CREATE OR REPLACE TABLE diamonds (
     "carat" FLOAT,
     "cut" TEXT,


### PR DESCRIPTION
This PR refactors Snowflake test data loading to use Parquet files instead of CSV, which should save slightly on storage and bandwidth usage as well as be robust to any particular schema inference and/or parser changes on the server side.