### PR TITLE
fix(api): ensure that normalization of boolean, ints and floats fail with readable error message

### DIFF
--- a/ibis/expr/datatypes/tests/test_value.py
+++ b/ibis/expr/datatypes/tests/test_value.py
@@ -342,3 +342,31 @@ def test_normalize_json():
 
     with pytest.raises(TypeError):
         dt.normalize(dt.json, "invalid")
+
+
+def test_normalize_none_with_non_nullable_type():
+    typ = dt.Int64(nullable=False)
+    with pytest.raises(TypeError, match="Cannot convert `None` to non-nullable type"):
+        dt.normalize(typ, None)
+
+
+def test_normalize_non_convertible_boolean():
+    typ = dt.boolean
+    value = np.array([1, 2, 3])
+    with pytest.raises(TypeError, match="Unable to normalize .+ to Boolean"):
+        dt.normalize(typ, value)
+
+
+@pytest.mark.parametrize("bits", [8, 16, 32, 64])
+@pytest.mark.parametrize("kind", ["uint", "int"])
+def test_normalize_non_convertible_int(kind, bits):
+    typ = getattr(dt, f"{kind}{bits:d}")
+    with pytest.raises(TypeError, match="Unable to normalize .+ to U?Int"):
+        dt.normalize(typ, "not convertible")
+
+
+@pytest.mark.parametrize("typename", ["float32", "float64"])
+def test_normalize_non_convertible_float(typename):
+    typ = getattr(dt, typename)
+    with pytest.raises(TypeError, match="Unable to normalize .+ to Float"):
+        dt.normalize(typ, "not convertible")

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -248,19 +248,19 @@ def normalize(typ, value):
     dtype = dt.dtype(typ)
     if value is None:
         if not dtype.nullable:
-            raise TypeError("Cannot convert `None` to non-nullable type {typ!r}")
+            raise TypeError(f"Cannot convert `None` to non-nullable type {typ!r}")
         return None
 
     if dtype.is_boolean():
         try:
             return bool(value)
         except ValueError:
-            raise TypeError("Unable to normalize {value!r} to {dtype!r}")
+            raise TypeError(f"Unable to normalize {value!r} to {dtype!r}")
     elif dtype.is_integer():
         try:
             value = int(value)
         except ValueError:
-            raise TypeError("Unable to normalize {value!r} to {dtype!r}")
+            raise TypeError(f"Unable to normalize {value!r} to {dtype!r}")
         if value not in dtype.bounds:
             raise TypeError(
                 f"Value {value} is out of bounds for type {dtype!r} "
@@ -272,7 +272,7 @@ def normalize(typ, value):
         try:
             return float(value)
         except ValueError:
-            raise TypeError("Unable to normalize {value!r} to {dtype!r}")
+            raise TypeError(f"Unable to normalize {value!r} to {dtype!r}")
     elif dtype.is_json():
         if isinstance(value, str):
             try:


### PR DESCRIPTION
Fixes an issue where error messages normalizing certains kinds of literals was not readable due to missing to f-string sigil.