### PR TITLE
feat(backends): support globbing in existing file-reading backends

### DIFF
--- a/docs/backends/clickhouse.md
+++ b/docs/backends/clickhouse.md
@@ -3,6 +3,7 @@ backend_name: ClickHouse
 backend_url: https://clickhouse.yandex/
 backend_module: clickhouse
 exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
+imports: ["CSV", "Parquet"]
 memtable_impl: native
 ---
 
@@ -83,3 +84,16 @@ or
 ```python
 con = ibis.connect("clickhouse://play:clickhouse@play.clickhouse.com:443?secure=True")
 ```
+
+## File Support
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.clickhouse.Backend.read_csv
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.clickhouse.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+<!-- prettier-ignore-end -->

--- a/docs/backends/polars.md
+++ b/docs/backends/polars.md
@@ -5,7 +5,7 @@ backend_module: polars
 is_experimental: true
 version_added: "4.0"
 exports: ["PyArrow", "Parquet", "Delta Lake", "CSV", "Pandas"]
-imports: ["CSV", "Parquet", "Delta Lake", "Pandas"]
+imports: ["CSV", "Parquet", "Delta Lake", "Pandas", "JSON"]
 memtable_impl: native
 ---
 
@@ -70,6 +70,10 @@ con = ibis.polars.connect()
       heading_level: 4
       show_docstring_returns: false
 ::: ibis.backends.polars.Backend.read_delta
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.polars.Backend.read_json
     options:
       heading_level: 4
       show_docstring_returns: false

--- a/docs/backends/pyspark.md
+++ b/docs/backends/pyspark.md
@@ -4,7 +4,7 @@ backend_url: https://spark.apache.org/docs/latest/api/python/
 backend_module: pyspark
 backend_param_style: PySpark things
 exports: ["PyArrow", "Parquet", "Delta Lake", "Pandas"]
-imports: ["CSV", "Parquet", "Delta Lake"]
+imports: ["CSV", "Parquet", "Delta Lake", "JSON"]
 memtable_impl: native
 ---
 
@@ -65,6 +65,10 @@ con = ibis.pyspark.connect(session=session)
       heading_level: 4
       show_docstring_returns: false
 ::: ibis.backends.pyspark.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.pyspark.Backend.read_json
     options:
       heading_level: 4
       show_docstring_returns: false

--- a/docs/backends/snowflake.md
+++ b/docs/backends/snowflake.md
@@ -1,7 +1,7 @@
 ---
 backend_name: Snowflake
 backend_url: https://snowflake.com/
-imports: ["CSV"]
+imports: ["CSV", "Parquet", "JSON"]
 exports: ["PyArrow", "Parquet", "CSV", "Pandas"]
 memtable_impl: native
 ---
@@ -123,3 +123,20 @@ available databases and schema in the "Data" sidebar item in the Snowflake web
 app.
 
 ![Snowflake Database](./images/snowflake_database.png)
+
+## File Support
+
+<!-- prettier-ignore-start -->
+::: ibis.backends.snowflake.Backend.read_csv
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.snowflake.Backend.read_parquet
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+::: ibis.backends.snowflake.Backend.read_json
+    options:
+      heading_level: 4
+      show_docstring_returns: false
+<!-- prettier-ignore-end -->

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -407,6 +407,30 @@ class _FileIOHandler:
             f"{self.name} does not support direct registration of CSV data."
         )
 
+    def read_json(
+        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+    ) -> ir.Table:
+        """Register a JSON file as a table in the current backend.
+
+        Parameters
+        ----------
+        path
+            The data source. A string or Path to the JSON file.
+        table_name
+            An optional name to use for the created table. This defaults to
+            a sequentially generated name.
+        **kwargs
+            Additional keyword arguments passed to the backend loading function.
+
+        Returns
+        -------
+        ir.Table
+            The just-registered table
+        """
+        raise NotImplementedError(
+            f"{self.name} does not support direct registration of JSON data."
+        )
+
     @util.experimental
     def to_parquet(
         self,

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -144,7 +144,7 @@ class Backend(BaseBackend):
     def read_csv(
         self, path: str | Path, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
-        """Register a CSV file as a table in the current database.
+        """Register a CSV file as a table.
 
         Parameters
         ----------
@@ -170,6 +170,37 @@ class Backend(BaseBackend):
         except pl.exceptions.ComputeError:
             # handles compressed csvs
             self._add_table(table_name, pl.read_csv(path, **kwargs))
+        return self.table(table_name)
+
+    def read_json(
+        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+    ) -> ir.Table:
+        """Register a JSON file as a table.
+
+        Parameters
+        ----------
+        path
+            A string or Path to a JSON file; globs are supported
+        table_name
+            An optional name to use for the created table. This defaults to
+            a sequentially generated name.
+        **kwargs
+            Additional keyword arguments passed to Polars loading function.
+            See https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.scan_ndjson.html
+            for more information.
+
+        Returns
+        -------
+        ir.Table
+            The just-registered table
+        """
+        path = normalize_filename(path)
+        table_name = table_name or gen_name("read_json")
+        try:
+            self._add_table(table_name, pl.scan_ndjson(path, **kwargs))
+        except pl.exceptions.ComputeError:
+            # handles compressed json files
+            self._add_table(table_name, pl.read_ndjson(path, **kwargs))
         return self.table(table_name)
 
     def read_delta(

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -615,7 +615,7 @@ $$""".format(
         Parameters
         ----------
         path
-            Path to the CSV file
+            A string or Path to a CSV file; globs are supported
         table_name
             Optional name for the table; if not passed, a random name will be generated
         kwargs
@@ -711,7 +711,7 @@ $$""".format(
         Parameters
         ----------
         path
-            File or list of files
+            A string or Path to a JSON file; globs are supported
         table_name
             Optional table name
         kwargs
@@ -786,7 +786,7 @@ $$""".format(
         Parameters
         ----------
         path
-            Path to a Parquet file
+            A string or Path to a Parquet file; globs are supported
         table_name
             Optional table name
         kwargs

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -455,7 +455,6 @@ def ft_data(data_dir):
         "mysql",
         "pandas",
         "postgres",
-        "pyspark",
         "sqlite",
         "trino",
     ]
@@ -485,7 +484,6 @@ def test_read_parquet_glob(con, tmp_path, ft_data):
         "mysql",
         "pandas",
         "postgres",
-        "pyspark",
         "sqlite",
         "trino",
     ]
@@ -517,7 +515,6 @@ def test_read_csv_glob(con, tmp_path, ft_data):
         "mysql",
         "pandas",
         "postgres",
-        "pyspark",
         "sqlite",
         "trino",
     ]

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -509,7 +509,9 @@ def test_read_csv_glob(con, tmp_path, ft_data):
 @pytest.mark.notyet(
     [
         "bigquery",
+        "clickhouse",
         "dask",
+        "datafusion",
         "impala",
         "mssql",
         "mysql",


### PR DESCRIPTION
This PR adds support for reading globs to existing file-supporting backends with a few exceptions. The clickhouse backend does not support reading JSON (no way to infer the schema), and I simply did not implement datafusion json reading.