### PR TITLE
test(flink): turn on the common backend test suite

### DIFF
--- a/.github/workflows/ibis-backends-flink.yml
+++ b/.github/workflows/ibis-backends-flink.yml
@@ -60,6 +60,7 @@ jobs:
               - pytest-split
         group:
           [
+            0,
             1,
             2,
             3,
@@ -126,8 +127,20 @@ jobs:
       - name: show installed deps
         run: poetry run pip list
 
-      - name: "run serial tests: ${{ matrix.backend.name }}"
-        run: just ci-check -m ${{ matrix.backend.name }} --splits 20 --group ${{ matrix.group }} --splitting-algorithm least_duration
+      - name: "run serial tests: ${{ matrix.backend.name }} (common)"
+        if: matrix.group > 0
+        run: just ci-check -m ${{ matrix.backend.name }} ibis/backends/tests --splits 20 --group ${{ matrix.group }} --splitting-algorithm least_duration
+        env:
+          IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
+          JVM_ARGS: -XX:CompressedClassSpaceSize=3G
+
+      # FIXME(deepyaman): If some backend-specific test, in test_ddl.py,
+      #   executes before common tests, they will fail with:
+      #   org.apache.flink.table.api.ValidationException: Table `default_catalog`.`default_database`.`functional_alltypes` was not found.
+      #   Therefore, we quarantine backend-specific tests to avoid this.
+      - name: "run serial tests: ${{ matrix.backend.name }} (backend-specific)"
+        if: matrix.group == 0
+        run: just ci-check -m ${{ matrix.backend.name }} ibis/backends/flink/tests
         env:
           IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
           JVM_ARGS: -XX:CompressedClassSpaceSize=3G

--- a/.github/workflows/ibis-backends-flink.yml
+++ b/.github/workflows/ibis-backends-flink.yml
@@ -1,0 +1,217 @@
+name: Flink Backend
+
+on:
+  push:
+    # Skip the backend suite if all changes are docs
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.qmd"
+      - "codecov.yml"
+      - ".envrc"
+    branches:
+      - master
+      - "*.x.x"
+  pull_request:
+    # Skip the backend suite if all changes are docs
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.qmd"
+      - "codecov.yml"
+      - ".envrc"
+    branches:
+      - master
+      - "*.x.x"
+  merge_group:
+
+permissions:
+  # this allows extractions/setup-just to list releases for `just` at a higher
+  # rate limit while restricting GITHUB_TOKEN permissions elsewhere
+  contents: read
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  test_backends:
+    name: ${{ matrix.backend.title }} ${{ matrix.os }} python-${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.9"
+        backend:
+          - name: flink
+            title: Flink
+            serial: true
+            extras:
+              - flink
+            additional_deps:
+              - apache-flink
+              - grpcio-status # FIXME(deepyaman)
+              - pytest-split
+        group:
+          [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+          ]
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - uses: extractions/setup-just@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: download backend data
+        run: just download-data
+
+      - name: install python
+        uses: actions/setup-python@v4
+        id: install_python
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: syphar/restore-pip-download-cache@v1
+        with:
+          requirement_files: poetry.lock
+          custom_cache_key_element: ${{ steps.install_python.outputs.python-version }}
+
+      - name: install poetry
+        run: python -m pip install --upgrade pip 'poetry==1.6.1'
+
+      - uses: syphar/restore-virtualenv@v1
+        with:
+          requirement_files: poetry.lock
+          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
+
+      - name: install ibis
+        run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"
+
+      - name: install other deps
+        run: poetry run pip install ${{ join(matrix.backend.additional_deps, ' ') }}
+
+      # FIXME(deepyaman): We reinstall pandas~=1.5 to get a version with
+      #   ArrowDtype, but this step will be removed once PyFlink relaxes
+      #   its overly-restrictive dependencies (specifying pandas<1.4.0).
+      - name: override overly-restrictive PyFlink requirements
+        run: poetry run pip install pandas~=1.5
+
+      - name: show installed deps
+        run: poetry run pip list
+
+      - name: "run serial tests: ${{ matrix.backend.name }}"
+        run: just ci-check -m ${{ matrix.backend.name }} --splits 20 --group ${{ matrix.group }} --splitting-algorithm least_duration
+        env:
+          IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
+          JVM_ARGS: -XX:CompressedClassSpaceSize=3G
+
+      - name: check that no untracked files were produced
+        shell: bash
+        run: git checkout poetry.lock pyproject.toml && ! git status --porcelain | tee /dev/stderr | grep .
+
+      - name: upload code coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage${{ matrix.group }}
+          path: .coverage
+
+  coverage:
+    needs: test_backends
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - "3.9"
+        backend:
+          - name: flink
+            title: Flink
+            serial: true
+            extras:
+              - flink
+            additional_deps:
+              - apache-flink
+              - grpcio-status # FIXME(deepyaman)
+              - pytest-split
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: install python
+        uses: actions/setup-python@v4
+        id: install_python
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: syphar/restore-pip-download-cache@v1
+        with:
+          requirement_files: poetry.lock
+          custom_cache_key_element: ${{ steps.install_python.outputs.python-version }}
+
+      - name: install poetry
+        run: python -m pip install --upgrade pip 'poetry==1.6.1'
+
+      - uses: syphar/restore-virtualenv@v1
+        with:
+          requirement_files: poetry.lock
+          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
+
+      - name: install ibis
+        run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"
+
+      - name: install other deps
+        run: poetry run pip install ${{ join(matrix.backend.additional_deps, ' ') }}
+
+      # FIXME(deepyaman): We reinstall pandas~=1.5 to get a version with
+      #   ArrowDtype, but this step will be removed once PyFlink relaxes
+      #   its overly-restrictive dependencies (specifying pandas<1.4.0).
+      - name: override overly-restrictive PyFlink requirements
+        run: poetry run pip install pandas~=1.5
+
+      - name: show installed deps
+        run: poetry run pip list
+
+      - name: download all artifacts
+        # Downloads coverage1, coverage2, etc.
+        uses: actions/download-artifact@v3
+
+      - name: run coverage
+        run: |
+          coverage combine coverage*/.coverage*
+          coverage report
+          coverage xml
+
+      - name: upload code coverage
+        if: success()
+        uses: codecov/codecov-action@v3
+        with:
+          flags: backend,${{ matrix.backend.name }},${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -158,15 +158,6 @@ jobs:
               - oracle
             services:
               - oracle
-          - name: flink
-            title: Flink
-            serial: true
-            extras:
-              - flink
-            additional_deps:
-              - apache-flink
-            even_more_deps:
-              - pandas~=1.5
         exclude:
           - os: windows-latest
             backend:
@@ -263,17 +254,6 @@ jobs:
                 - oracle
               services:
                 - oracle
-          - python-version: "3.11"
-            backend:
-              name: flink
-              title: Flink
-              serial: true
-              extras:
-                - flink
-              additional_deps:
-                - apache-flink
-              even_more_deps:
-                - pandas~=1.5
     steps:
       - name: update and install system dependencies
         if: matrix.os == 'ubuntu-latest' && matrix.backend.sys-deps != null
@@ -327,11 +307,6 @@ jobs:
         if: matrix.backend.additional_deps != null
         run: poetry run pip install ${{ join(matrix.backend.additional_deps, ' ') }}
 
-      # FIXME(deepyaman)
-      - name: install even more deps
-        if: matrix.backend.even_more_deps != null
-        run: poetry run pip install ${{ join(matrix.backend.even_more_deps, ' ') }}
-
       - name: show installed deps
         run: poetry run pip list
 
@@ -351,13 +326,7 @@ jobs:
           IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
 
       - name: "run serial tests: ${{ matrix.backend.name }}"
-        if: matrix.backend.serial && matrix.backend.name == 'flink'
-        run: just ci-check -m ${{ matrix.backend.name }} ibis/backends/flink/tests
-        env:
-          IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
-
-      - name: "run serial tests: ${{ matrix.backend.name }}"
-        if: matrix.backend.serial && matrix.backend.name != 'impala' && matrix.backend.name != 'flink'
+        if: matrix.backend.serial && matrix.backend.name != 'impala'
         run: just ci-check -m ${{ matrix.backend.name }}
         env:
           IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}

--- a/ibis/backends/flink/registry.py
+++ b/ibis/backends/flink/registry.py
@@ -50,7 +50,8 @@ def _cast(translator: ExprTranslator, op: ops.generic.Cast) -> str:
             return f"TO_TIMESTAMP(CONVERT_TZ(CAST({arg_translated} AS STRING), 'UTC+0', '{to.timezone}'))"
         else:
             return f"TO_TIMESTAMP({arg_translated})"
-
+    elif to.is_date():
+        return f"CAST({arg_translated} AS date)"
     elif to.is_json():
         return arg_translated
 

--- a/ibis/backends/flink/tests/conftest.py
+++ b/ibis/backends/flink/tests/conftest.py
@@ -28,9 +28,13 @@ class TestConf(BackendTest, RoundAwayFromZero):
     def _load_data(self, **_: Any) -> None:
         import pandas as pd
 
+        from ibis.backends.tests.data import json_types
+
         for table_name in TEST_TABLES:
             path = self.data_dir / "parquet" / f"{table_name}.parquet"
             self.connection.create_table(table_name, pd.read_parquet(path))
+
+        self.connection.create_table("json_t", json_types)
 
 
 class TestConfForStreaming(TestConf):

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -6,12 +6,16 @@ import tempfile
 import pandas as pd
 import pyarrow as pa
 import pytest
-from py4j.protocol import Py4JJavaError
 
 import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 from ibis.backends.conftest import TEST_TABLES
+
+try:
+    from py4j.protocol import Py4JJavaError
+except ImportError:
+    Py4JJavaError = None
 
 
 @pytest.fixture(autouse=True)

--- a/ibis/backends/flink/utils.py
+++ b/ibis/backends/flink/utils.py
@@ -282,6 +282,8 @@ def translate_literal(op: ops.Literal) -> str:
     elif dtype.is_string():
         quoted = value.replace("'", "''")
         return f"'{quoted}'"
+    elif dtype.is_binary():
+        return f"x'{value.hex()}'"
     elif dtype.is_date():
         if isinstance(value, datetime.date):
             value = value.strftime("%Y-%m-%d")
@@ -320,4 +322,7 @@ def translate_literal(op: ops.Literal) -> str:
         return f"INTERVAL {_translate_interval(value, dtype)}"
     elif dtype.is_uuid():
         return translate_literal(ops.Literal(str(value), dtype=dt.str))
+    elif dtype.is_array():
+        return f"ARRAY{list(value)}"
+
     raise NotImplementedError(f"No translation rule for {dtype}")

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import sqlalchemy as sa
-from pytest import mark, param
+from pytest import param
 
 import ibis
 import ibis.common.exceptions as com
@@ -23,7 +23,6 @@ try:
 except ImportError:
     GoogleBadRequest = None
 
-
 try:
     from polars.exceptions import ComputeError
 except ImportError:
@@ -35,6 +34,11 @@ try:
     )
 except ImportError:
     ClickhouseDatabaseError = None
+
+try:
+    from py4j.protocol import Py4JError
+except ImportError:
+    Py4JError = None
 
 
 @reduction(input_type=[dt.double], output_type=dt.double)
@@ -71,6 +75,7 @@ aggregate_test_params = [
                 reason="no udf support",
                 raises=com.OperationNotDefinedError,
             ),
+            pytest.mark.notimpl(["flink"], "WIP", raises=com.OperationNotDefinedError),
         ],
     ),
     param(lambda t: t.double_col.min(), lambda t: t.double_col.min(), id="min"),
@@ -80,21 +85,24 @@ aggregate_test_params = [
         lambda t: (t.int_col % 3).mode(),
         lambda t: (t.int_col % 3).mode().iloc[0],
         id="mode",
-        marks=pytest.mark.notyet(
-            [
-                "bigquery",
-                "clickhouse",
-                "datafusion",
-                "impala",
-                "mysql",
-                "mssql",
-                "pyspark",
-                "trino",
-                "druid",
-                "oracle",
-            ],
-            raises=com.OperationNotDefinedError,
-        ),
+        marks=[
+            pytest.mark.notyet(
+                [
+                    "bigquery",
+                    "clickhouse",
+                    "datafusion",
+                    "impala",
+                    "mysql",
+                    "mssql",
+                    "pyspark",
+                    "trino",
+                    "druid",
+                    "oracle",
+                ],
+                raises=com.OperationNotDefinedError,
+            ),
+            pytest.mark.notimpl(["flink"], "WIP", raises=com.OperationNotDefinedError),
+        ],
     ),
     param(
         lambda t: (t.double_col + 5).sum(),
@@ -129,6 +137,7 @@ argidx_grouped_marks = ["dask"] + argidx_not_grouped_marks
 def make_argidx_params(marks):
     marks = [
         pytest.mark.notyet(marks, raises=com.OperationNotDefinedError),
+        pytest.mark.notimpl(["flink"], "WIP", raises=com.OperationNotDefinedError),
     ]
     return [
         param(
@@ -191,7 +200,7 @@ def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
     backend.assert_frame_equal(result2, expected, check_dtype=False)
 
 
-@mark.notimpl(
+@pytest.mark.notimpl(
     [
         "bigquery",
         "clickhouse",
@@ -207,10 +216,11 @@ def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
         "trino",
         "druid",
         "oracle",
+        "flink",
     ],
     raises=com.OperationNotDefinedError,
 )
-@mark.notimpl(
+@pytest.mark.notimpl(
     ["pyspark"],
     raises=NotImplementedError,
     reason=(
@@ -383,6 +393,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     raises=sa.exc.DatabaseError,
                     reason="ORA-02000: missing AS keyword",
                 ),
+                pytest.mark.notimpl(["flink"], "WIP", raises=Py4JError),
             ],
         ),
         param(
@@ -405,21 +416,26 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: (t.int_col % 3).mode(where=where),
             lambda t, where: (t.int_col % 3)[where].mode().iloc[0],
             id="mode",
-            marks=pytest.mark.notyet(
-                [
-                    "bigquery",
-                    "clickhouse",
-                    "datafusion",
-                    "impala",
-                    "mysql",
-                    "pyspark",
-                    "mssql",
-                    "trino",
-                    "druid",
-                    "oracle",
-                ],
-                raises=com.OperationNotDefinedError,
-            ),
+            marks=[
+                pytest.mark.notyet(
+                    [
+                        "bigquery",
+                        "clickhouse",
+                        "datafusion",
+                        "impala",
+                        "mysql",
+                        "pyspark",
+                        "mssql",
+                        "trino",
+                        "druid",
+                        "oracle",
+                    ],
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
+                ),
+            ],
         ),
         param(
             lambda t, where: t.double_col.argmin(t.int_col, where=where),
@@ -436,6 +452,9 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                         "oracle",
                     ],
                     raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
                 ),
             ],
         ),
@@ -455,6 +474,9 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     ],
                     raises=com.OperationNotDefinedError,
                 ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
+                ),
             ],
         ),
         param(
@@ -462,7 +484,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.double_col[where].std(ddof=1),
             id="std",
             marks=[
-                mark.notimpl(
+                pytest.mark.notimpl(
                     ["druid"],
                     raises=sa.exc.ProgrammingError,
                     reason="No match found for function signature stddev_samp(<NUMERIC>)",
@@ -474,7 +496,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.double_col[where].var(ddof=1),
             id="var",
             marks=[
-                mark.notimpl(
+                pytest.mark.notimpl(
                     ["druid"],
                     raises=sa.exc.ProgrammingError,
                     reason="No match found for function signature var_samp(<NUMERIC>)",
@@ -486,7 +508,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.double_col[where].std(ddof=0),
             id="std_pop",
             marks=[
-                mark.notimpl(
+                pytest.mark.notimpl(
                     ["druid"],
                     raises=sa.exc.ProgrammingError,
                     reason="No match found for function signature stddev_pop(<NUMERIC>)",
@@ -498,7 +520,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.double_col[where].var(ddof=0),
             id="var_pop",
             marks=[
-                mark.notimpl(
+                pytest.mark.notimpl(
                     ["druid"],
                     raises=sa.exc.ProgrammingError,
                     reason="No match found for function signature var_pop(<NUMERIC>)",
@@ -509,14 +531,26 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.string_col.approx_nunique(where=where),
             lambda t, where: t.string_col[where].nunique(),
             id="approx_nunique",
-            marks=pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError),
+            marks=[
+                pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError),
+                pytest.mark.notimpl(["flink"], "WIP", raises=Py4JError),
+            ],
         ),
         param(
             lambda t, where: t.double_col.arbitrary(where=where),
             lambda t, where: t.double_col[where].iloc[0],
             id="arbitrary_default",
             marks=pytest.mark.notimpl(
-                ["impala", "mysql", "polars", "datafusion", "mssql", "druid", "oracle"],
+                [
+                    "impala",
+                    "mysql",
+                    "polars",
+                    "datafusion",
+                    "mssql",
+                    "druid",
+                    "oracle",
+                    "flink",
+                ],
                 raises=com.OperationNotDefinedError,
             ),
         ),
@@ -525,7 +559,16 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.double_col[where].iloc[0],
             id="arbitrary_first",
             marks=pytest.mark.notimpl(
-                ["impala", "mysql", "polars", "datafusion", "mssql", "druid", "oracle"],
+                [
+                    "impala",
+                    "mysql",
+                    "polars",
+                    "datafusion",
+                    "mssql",
+                    "druid",
+                    "oracle",
+                    "flink",
+                ],
                 raises=com.OperationNotDefinedError,
             ),
         ),
@@ -543,6 +586,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                         "mssql",
                         "druid",
                         "oracle",
+                        "flink",
                     ],
                     raises=com.OperationNotDefinedError,
                 ),
@@ -571,6 +615,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                         "pandas",
                         "polars",
                         "sqlite",
+                        "flink",
                     ],
                     raises=com.OperationNotDefinedError,
                 ),
@@ -591,7 +636,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.double_col[where].iloc[0],
             id="first",
             marks=pytest.mark.notimpl(
-                ["dask", "druid", "impala", "mssql", "mysql", "oracle"],
+                ["dask", "druid", "impala", "mssql", "mysql", "oracle", "flink"],
                 raises=com.OperationNotDefinedError,
             ),
         ),
@@ -600,7 +645,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.double_col[where].iloc[-1],
             id="last",
             marks=pytest.mark.notimpl(
-                ["dask", "druid", "impala", "mssql", "mysql", "oracle"],
+                ["dask", "druid", "impala", "mssql", "mysql", "oracle", "flink"],
                 raises=com.OperationNotDefinedError,
             ),
         ),
@@ -615,7 +660,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                 ),
                 pytest.mark.notimpl(["druid"], strict=False, raises=AssertionError),
                 pytest.mark.notyet(
-                    ["impala", "pyspark"], raises=com.OperationNotDefinedError
+                    ["impala", "pyspark", "flink"], raises=com.OperationNotDefinedError
                 ),
                 pytest.mark.broken(
                     ["dask"],
@@ -638,7 +683,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(
-                    ["impala", "pyspark"], raises=com.OperationNotDefinedError
+                    ["impala", "pyspark", "flink"], raises=com.OperationNotDefinedError
                 ),
                 pytest.mark.broken(
                     ["dask"],
@@ -662,7 +707,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(
-                    ["impala", "pyspark"], raises=com.OperationNotDefinedError
+                    ["impala", "pyspark", "flink"], raises=com.OperationNotDefinedError
                 ),
                 pytest.mark.broken(
                     ["dask"],
@@ -686,7 +731,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             lambda t, where: t.string_col[where].tolist(),
             id="collect",
             marks=[
-                mark.notimpl(
+                pytest.mark.notimpl(
                     [
                         "impala",
                         "mysql",
@@ -707,6 +752,9 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                         "<dask.dataframe.groupby.Aggregation object at 0x124569840> is not "
                         "callable or a string"
                     ),
+                ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
                 ),
             ],
         ),
@@ -757,7 +805,7 @@ def test_reduction_ops(
             lambda t: t.string_col.isin(["1", "7"]),
             id="cond",
             marks=[
-                mark.notyet(
+                pytest.mark.notyet(
                     ["snowflake", "mysql"],
                     raises=com.UnsupportedOperationError,
                     reason="backend does not support filtered count distinct with more than one column",
@@ -766,16 +814,17 @@ def test_reduction_ops(
         ),
     ],
 )
-@mark.notyet(
-    ["bigquery", "druid", "mssql", "oracle", "sqlite"],
+@pytest.mark.notyet(
+    ["bigquery", "druid", "mssql", "oracle", "sqlite", "flink"],
     raises=(
         sa.exc.OperationalError,
         sa.exc.DatabaseError,
         com.UnsupportedOperationError,
+        com.OperationNotDefinedError,
     ),
     reason="backend doesn't support count distinct with multiple columns",
 )
-@mark.notyet(
+@pytest.mark.notyet(
     ["datafusion", "impala"],
     raises=com.OperationNotDefinedError,
     reason="no one has attempted implementation yet",
@@ -797,7 +846,7 @@ def test_count_distinct_star(alltypes, df, ibis_cond, pandas_cond):
             lambda t, where: t.double_col[where].quantile(0.5),
             id="quantile",
             marks=[
-                mark.notimpl(
+                pytest.mark.notimpl(
                     [
                         "bigquery",
                         "datafusion",
@@ -811,20 +860,23 @@ def test_count_distinct_star(alltypes, df, ibis_cond, pandas_cond):
                     ],
                     raises=com.OperationNotDefinedError,
                 ),
-                mark.never(
+                pytest.mark.never(
                     ["dask"],
                     reason="backend implements approximate quantiles",
                     raises=AssertionError,
                 ),
-                mark.never(
+                pytest.mark.never(
                     ["trino"],
                     reason="backend implements approximate quantiles",
                     raises=com.OperationNotDefinedError,
                 ),
-                mark.never(
+                pytest.mark.never(
                     ["pyspark"],
                     reason="backend implements approximate quantiles",
                     raises=AssertionError,
+                ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
                 ),
             ],
         ),
@@ -833,7 +885,7 @@ def test_count_distinct_star(alltypes, df, ibis_cond, pandas_cond):
             lambda t, where: t.double_col[where].quantile([0.5]),
             id="multi-quantile",
             marks=[
-                mark.notimpl(
+                pytest.mark.notimpl(
                     [
                         "bigquery",
                         "dask",
@@ -848,20 +900,23 @@ def test_count_distinct_star(alltypes, df, ibis_cond, pandas_cond):
                     ],
                     raises=com.OperationNotDefinedError,
                 ),
-                mark.notyet(
+                pytest.mark.notyet(
                     ["snowflake"],
                     reason="backend doesn't implement array of quantiles as input",
                     raises=com.OperationNotDefinedError,
                 ),
-                mark.never(
+                pytest.mark.never(
                     ["trino"],
                     reason="backend implements approximate quantiles",
                     raises=com.OperationNotDefinedError,
                 ),
-                mark.broken(
+                pytest.mark.broken(
                     ["pyspark"],
                     reason="backend implements approximate quantiles",
                     raises=AssertionError,
+                ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
                 ),
             ],
         ),
@@ -875,7 +930,9 @@ def test_count_distinct_star(alltypes, df, ibis_cond, pandas_cond):
             lambda t: t.string_col.isin(["1", "7"]),
             lambda t: t.string_col.isin(["1", "7"]),
             id="is_in",
-            marks=[mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)],
+            marks=[
+                pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
+            ],
         ),
     ],
 )
@@ -908,6 +965,9 @@ def test_quantile(
                 pytest.mark.notyet(
                     ["mysql", "impala", "sqlite"], raises=com.OperationNotDefinedError
                 ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
+                ),
             ],
         ),
         param(
@@ -922,6 +982,9 @@ def test_quantile(
                 pytest.mark.notyet(
                     ["mysql", "impala", "sqlite"],
                     raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
                 ),
             ],
         ),
@@ -948,6 +1011,9 @@ def test_quantile(
                     raises=ValueError,
                     reason="PySpark only implements sample correlation",
                 ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
+                ),
             ],
         ),
         param(
@@ -973,6 +1039,9 @@ def test_quantile(
                     raises=ValueError,
                     reason="XXXXSQLExprTranslator only implements population correlation coefficient",
                 ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
+                ),
             ],
         ),
         param(
@@ -990,6 +1059,9 @@ def test_quantile(
                 ),
                 pytest.mark.notyet(
                     ["mysql", "impala", "sqlite"], raises=com.OperationNotDefinedError
+                ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
                 ),
             ],
         ),
@@ -1019,6 +1091,9 @@ def test_quantile(
                     ["pyspark"],
                     raises=ValueError,
                     reason="PySpark only implements sample correlation",
+                ),
+                pytest.mark.notimpl(
+                    ["flink"], "WIP", raises=com.OperationNotDefinedError
                 ),
             ],
         ),
@@ -1069,6 +1144,7 @@ def test_corr_cov(
     raises=AttributeError,
     reason="'Series' object has no attribute 'approx_median'",
 )
+@pytest.mark.notimpl(["flink"], "WIP", raises=Py4JError)
 def test_approx_median(alltypes):
     expr = alltypes.double_col.approx_median()
     result = expr.execute()
@@ -1083,6 +1159,7 @@ def test_approx_median(alltypes):
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.notyet(["dask"], raises=NotImplementedError)
+@pytest.mark.notimpl(["flink"], "WIP", raises=com.OperationNotDefinedError)
 def test_median(alltypes, df):
     expr = alltypes.double_col.median()
     result = expr.execute()
@@ -1090,7 +1167,7 @@ def test_median(alltypes, df):
     assert result == expected
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     ("result_fn", "expected_fn"),
     [
         param(
@@ -1117,7 +1194,7 @@ def test_median(alltypes, df):
         )
     ],
 )
-@mark.parametrize(
+@pytest.mark.parametrize(
     ("ibis_sep", "pandas_sep"),
     [
         param(":", ":", id="const"),
@@ -1126,19 +1203,19 @@ def test_median(alltypes, df):
             "::",
             id="expr",
             marks=[
-                mark.notyet(
+                pytest.mark.notyet(
                     ["duckdb", "trino"],
                     raises=com.UnsupportedOperationError,
                 ),
-                mark.notyet(
+                pytest.mark.notyet(
                     ["bigquery"],
                     raises=GoogleBadRequest,
                     reason="Argument 2 to STRING_AGG must be a literal or query parameter",
                 ),
-                mark.broken(
+                pytest.mark.broken(
                     ["pyspark"], raises=TypeError, reason="Column is not iterable"
                 ),
-                mark.broken(
+                pytest.mark.broken(
                     ["mysql"],
                     raises=sa.exc.ProgrammingError,
                 ),
@@ -1146,38 +1223,39 @@ def test_median(alltypes, df):
         ),
     ],
 )
-@mark.parametrize(
+@pytest.mark.parametrize(
     ("ibis_cond", "pandas_cond"),
     [
         param(lambda _: None, lambda _: slice(None), id="no_cond"),
         param(
             lambda t: t.string_col.isin(["1", "7"]),
             lambda t: t.string_col.isin(["1", "7"]),
-            marks=mark.notimpl(["dask"], raises=com.OperationNotDefinedError),
+            marks=pytest.mark.notimpl(["dask"], raises=com.OperationNotDefinedError),
             id="is_in",
         ),
         param(
             lambda t: t.string_col.notin(["1", "7"]),
             lambda t: ~t.string_col.isin(["1", "7"]),
-            marks=mark.notimpl(["dask"], raises=com.OperationNotDefinedError),
+            marks=pytest.mark.notimpl(["dask"], raises=com.OperationNotDefinedError),
             id="not_in",
         ),
     ],
 )
-@mark.notimpl(
+@pytest.mark.notimpl(
     ["datafusion", "polars", "mssql"],
     raises=com.OperationNotDefinedError,
 )
-@mark.notimpl(
+@pytest.mark.notimpl(
     ["druid"],
     raises=sa.exc.ProgrammingError,
     reason="No match found for function signature group_concat(<CHARACTER>, <CHARACTER>)",
 )
-@mark.notyet(
+@pytest.mark.notyet(
     ["oracle"],
     raises=sa.exc.DatabaseError,
     reason="ORA-00904: 'GROUP_CONCAT': invalid identifier",
 )
+@pytest.mark.notimpl(["flink"], "WIP", raises=Py4JError)
 def test_group_concat(
     backend,
     alltypes,
@@ -1196,7 +1274,7 @@ def test_group_concat(
     backend.assert_frame_equal(result.fillna(pd.NA), expected.fillna(pd.NA))
 
 
-@mark.notimpl(
+@pytest.mark.notimpl(
     ["dask"],
     raises=NotImplementedError,
     reason="sorting on aggregations not yet implemented",
@@ -1228,7 +1306,7 @@ def test_topk_op(alltypes, df):
         )
     ],
 )
-@mark.broken(
+@pytest.mark.broken(
     ["druid"],
     raises=sa.exc.ProgrammingError,
     reason=(
@@ -1236,11 +1314,12 @@ def test_topk_op(alltypes, df):
         "(org.apache.calcite.tools.ValidationException): java.lang.NullPointerException"
     ),
 )
-@mark.notimpl(
+@pytest.mark.notimpl(
     ["dask"],
     raises=NotImplementedError,
     reason="sorting on aggregations not yet implemented",
 )
+@pytest.mark.notimpl(["flink"], "WIP", raises=Py4JError)
 def test_topk_filter_op(alltypes, df, result_fn, expected_fn):
     # TopK expression will order rows by "count" but each backend
     # can have different result for that.
@@ -1257,7 +1336,7 @@ def test_topk_filter_op(alltypes, df, result_fn, expected_fn):
 @pytest.mark.parametrize(
     "agg_fn", [lambda s: list(s), lambda s: np.array(s)], ids=lambda obj: obj.__name__
 )
-@mark.notimpl(
+@pytest.mark.notimpl(
     [
         "bigquery",
         "clickhouse",
@@ -1276,6 +1355,7 @@ def test_topk_filter_op(alltypes, df, result_fn, expected_fn):
     ],
     raises=com.OperationNotDefinedError,
 )
+@pytest.mark.notimpl(["flink"], "WIP", raises=com.OperationNotDefinedError)
 def test_aggregate_list_like(backend, alltypes, df, agg_fn):
     """Tests .aggregate() where the result of an aggregation is a list-like.
 
@@ -1295,7 +1375,7 @@ def test_aggregate_list_like(backend, alltypes, df, agg_fn):
     backend.assert_frame_equal(result, expected)
 
 
-@mark.notimpl(
+@pytest.mark.notimpl(
     [
         "bigquery",
         "clickhouse",
@@ -1314,6 +1394,7 @@ def test_aggregate_list_like(backend, alltypes, df, agg_fn):
     ],
     raises=com.OperationNotDefinedError,
 )
+@pytest.mark.notimpl(["flink"], "WIP", raises=com.OperationNotDefinedError)
 def test_aggregate_mixed_udf(backend, alltypes, df):
     """Tests .aggregate() with multiple aggregations with mixed result types.
 
@@ -1393,6 +1474,7 @@ def test_agg_name_in_output_column(alltypes):
     assert "max" in df.columns[1].lower()
 
 
+@pytest.mark.notimpl(["flink"], "WIP", raises=Py4JError)
 def test_grouped_case(backend, con):
     table = ibis.memtable({"key": [1, 1, 2, 2], "value": [10, 30, 20, 40]})
 
@@ -1418,6 +1500,7 @@ def test_grouped_case(backend, con):
 @pytest.mark.notyet("mysql", raises=sa.exc.NotSupportedError)
 @pytest.mark.notyet("oracle", raises=sa.exc.DatabaseError)
 @pytest.mark.notyet("pyspark", raises=PysparkAnalysisException)
+@pytest.mark.notimpl(["flink"], "WIP", raises=com.UnsupportedOperationError)
 def test_group_concat_over_window(backend, con):
     input_df = pd.DataFrame(
         {

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -54,6 +54,7 @@ pytestmark = [
 # list.
 
 
+@pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
 def test_array_column(backend, alltypes, df):
     expr = ibis.array([alltypes["double_col"], alltypes["double_col"]])
     assert isinstance(expr, ir.ArrayColumn)
@@ -73,6 +74,7 @@ ARRAY_BACKEND_TYPES = {
     "bigquery": "ARRAY",
     "duckdb": "DOUBLE[]",
     "postgres": "numeric[]",
+    "flink": "ARRAY<DECIMAL(2, 1) NOT NULL> NOT NULL",
 }
 
 
@@ -90,7 +92,7 @@ def test_array_scalar(con, backend):
         assert con.execute(expr.typeof()) == ARRAY_BACKEND_TYPES[backend_name]
 
 
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["polars", "flink"], raises=com.OperationNotDefinedError)
 def test_array_repeat(con):
     expr = ibis.array([1.0, 2.0]) * 2
 
@@ -101,6 +103,7 @@ def test_array_repeat(con):
 
 
 # Issues #2370
+@pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
 def test_array_concat(con):
     left = ibis.literal([1, 2, 3])
     right = ibis.literal([2, 1])
@@ -111,6 +114,7 @@ def test_array_concat(con):
 
 
 # Issues #2370
+@pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
 def test_array_concat_variadic(con):
     left = ibis.literal([1, 2, 3])
     right = ibis.literal([2, 1])
@@ -122,6 +126,7 @@ def test_array_concat_variadic(con):
 
 # Issues #2370
 @pytest.mark.notimpl(["datafusion"], raises=BaseException)
+@pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
 @pytest.mark.notyet(
     ["postgres", "trino"],
     raises=sa.exc.ProgrammingError,
@@ -136,6 +141,7 @@ def test_array_concat_some_empty(con):
     assert np.array_equal(result, expected)
 
 
+@pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
 def test_array_radd_concat(con):
     left = [1]
     right = ibis.literal([2])
@@ -188,6 +194,7 @@ builtin_array = toolz.compose(
         ["sqlite"], reason="array types are unsupported", raises=NotImplementedError
     ),
     # someone just needs to implement these
+    pytest.mark.notimpl(["flink"], raises=Exception),
 )
 
 
@@ -484,7 +491,7 @@ def test_unnest_default_name(backend):
 )
 @pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(
-    ["datafusion"], raises=Exception, reason="array_types table isn't defined"
+    ["datafusion", "flink"], raises=Exception, reason="array_types table isn't defined"
 )
 @pytest.mark.notimpl(["dask"], raises=com.OperationNotDefinedError)
 def test_array_slice(backend, start, stop):
@@ -698,7 +705,7 @@ def test_array_union(con):
 
 
 @pytest.mark.notimpl(
-    ["dask", "datafusion", "impala", "mssql", "pandas", "polars", "mysql"],
+    ["dask", "datafusion", "impala", "mssql", "pandas", "polars", "mysql", "flink"],
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.notimpl(

--- a/ibis/backends/tests/test_binary.py
+++ b/ibis/backends/tests/test_binary.py
@@ -16,6 +16,7 @@ BINARY_BACKEND_TYPES = {
     "sqlite": "blob",
     "trino": "STRING",
     "postgres": "bytea",
+    "flink": "BINARY(1) NOT NULL",
 }
 
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -33,6 +33,11 @@ from ibis.util import gen_name, guid
 if TYPE_CHECKING:
     from ibis.backends.base import BaseBackend
 
+try:
+    from py4j.protocol import Py4JJavaError
+except ImportError:
+    Py4JJavaError = None
+
 
 @pytest.fixture
 def new_schema():
@@ -70,17 +75,22 @@ def _create_temp_table_with_schema(con, temp_table_name, schema, data=None):
 @pytest.mark.parametrize(
     "sch",
     [
-        ibis.schema(
-            [
-                ("first_name", "string"),
-                ("last_name", "string"),
-                ("department_name", "string"),
-                ("salary", "float64"),
-            ]
+        param(
+            None,
+            id="no schema",
         ),
-        None,
+        param(
+            ibis.schema(
+                [
+                    ("first_name", "string"),
+                    ("last_name", "string"),
+                    ("department_name", "string"),
+                    ("salary", "float64"),
+                ]
+            ),
+            id="schema",
+        ),
     ],
-    ids=["schema", "no schema"],
 )
 @pytest.mark.notimpl(["dask", "datafusion", "druid"])
 def test_create_table(backend, con, temp_table, lamduh, sch):
@@ -94,7 +104,12 @@ def test_create_table(backend, con, temp_table, lamduh, sch):
     )
 
     obj = lamduh(df)
-    con.create_table(temp_table, obj, schema=sch)
+    con.create_table(
+        temp_table,
+        obj,
+        schema=sch,
+        **{"tbl_properties": {"connector": None}} if backend.name() == "flink" else {},
+    )
     result = (
         con.table(temp_table).execute().sort_values("first_name").reset_index(drop=True)
     )
@@ -149,6 +164,14 @@ def test_load_data_sqlalchemy(alchemy_backend, alchemy_con, alchemy_temp_table, 
         ),
     ],
 )
+@pytest.mark.broken(
+    ["flink"],
+    raises=Py4JJavaError,
+    reason=(
+        "org.apache.flink.table.api.ValidationException: "
+        "Table `default_catalog`.`default_database`.`functional_alltypes` was not found."
+    ),
+)
 def test_query_schema(ddl_backend, expr_fn, expected):
     expr = expr_fn(ddl_backend.functional_alltypes)
 
@@ -170,6 +193,9 @@ _LIMIT = {
 
 @pytest.mark.notimpl(["datafusion", "polars", "mssql"])
 @pytest.mark.never(["dask", "pandas"], reason="dask and pandas do not support SQL")
+@pytest.mark.notimpl(
+    ["flink"], raises=AttributeError, reason="'Backend' object has no attribute 'sql'"
+)
 def test_sql(backend, con):
     # execute the expression using SQL query
     table = backend.format_table("functional_alltypes")
@@ -190,7 +216,7 @@ backend_type_mapping = {
 }
 
 
-@mark.notimpl(["datafusion", "druid"])
+@mark.notimpl(["datafusion", "druid", "flink"])
 def test_create_table_from_schema(con, new_schema, temp_table):
     new_table = con.create_table(temp_table, schema=new_schema)
     backend_mapping = backend_type_mapping.get(con.name, {})
@@ -251,6 +277,7 @@ def test_create_temporary_table_from_schema(tmpcon, new_schema):
         "datafusion",
         "druid",
         "duckdb",
+        "flink",
         "mssql",
         "mysql",
         "oracle",
@@ -276,19 +303,23 @@ def test_rename_table(con, temp_table, temp_table_orig):
 @mark.notyet(
     ["trino"], reason="trino doesn't support NOT NULL in its in-memory catalog"
 )
-@mark.broken(["snowflake"], reason="snowflake shows not nullable column as nullable")
+@mark.broken(["snowflake", "flink"], reason="shows not nullable column as nullable")
 def test_nullable_input_output(con, temp_table):
     sch = ibis.schema(
         [("foo", "int64"), ("bar", dt.int64(nullable=False)), ("baz", "boolean")]
     )
-    t = con.create_table(temp_table, schema=sch)
+    t = con.create_table(
+        temp_table,
+        schema=sch,
+        **{"tbl_properties": {"connector": None}} if con.name == "flink" else {},
+    )
 
     assert t.schema().types[0].nullable
     assert not t.schema().types[1].nullable
     assert t.schema().types[2].nullable
 
 
-@mark.notimpl(["datafusion", "druid", "polars"])
+@mark.notimpl(["datafusion", "druid", "flink", "polars"])
 def test_create_drop_view(ddl_con, temp_view):
     # setup
     table_name = "functional_alltypes"
@@ -834,10 +865,12 @@ def test_self_join_memory_table(backend, con):
         param(
             ibis.memtable([("a", 1.0)], columns=["a", "b"]),
             id="python",
+            marks=pytest.mark.notimpl(["flink"], raises=NotImplementedError),
         ),
         param(
             ibis.memtable(pd.DataFrame([("a", 1.0)], columns=["a", "b"])),
             id="pandas-memtable",
+            marks=pytest.mark.notimpl(["flink"], raises=NotImplementedError),
         ),
         param(pd.DataFrame([("a", 1.0)], columns=["a", "b"]), id="pandas"),
     ],
@@ -939,7 +972,16 @@ def test_dunder_array_column(alltypes, dtype):
     np.testing.assert_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("interactive", [True, False])
+@pytest.mark.parametrize(
+    "interactive",
+    [
+        param(
+            True,
+            marks=pytest.mark.notimpl(["flink"], raises=NotImplementedError),
+        ),
+        False,
+    ],
+)
 def test_repr(alltypes, interactive, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", interactive)
 
@@ -955,6 +997,7 @@ def test_repr(alltypes, interactive, monkeypatch):
 
 
 @pytest.mark.parametrize("show_types", [True, False])
+@pytest.mark.notimpl(["flink"], raises=NotImplementedError)
 def test_interactive_repr_show_types(alltypes, show_types, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)
     monkeypatch.setattr(ibis.options.repr.interactive, "show_types", show_types)
@@ -968,6 +1011,7 @@ def test_interactive_repr_show_types(alltypes, show_types, monkeypatch):
 
 
 @pytest.mark.parametrize("is_jupyter", [True, False])
+@pytest.mark.notimpl(["flink"], raises=NotImplementedError)
 def test_interactive_repr_max_columns(alltypes, is_jupyter, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)
 
@@ -1006,7 +1050,16 @@ def test_interactive_repr_max_columns(alltypes, is_jupyter, monkeypatch):
 
 
 @pytest.mark.parametrize("expr_type", ["table", "column"])
-@pytest.mark.parametrize("interactive", [True, False])
+@pytest.mark.parametrize(
+    "interactive",
+    [
+        param(
+            True,
+            marks=pytest.mark.notimpl(["flink"], raises=NotImplementedError),
+        ),
+        False,
+    ],
+)
 def test_repr_mimebundle(alltypes, interactive, expr_type, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", interactive)
 
@@ -1143,17 +1196,27 @@ def test_set_backend_url(url, monkeypatch):
 )
 @pytest.mark.broken(["oracle"], reason="oracle doesn't like `DESCRIBE` from sqlalchemy")
 @pytest.mark.broken(["druid"], reason="sqlalchemy dialect is broken")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=AttributeError,
+    reason="'Backend' object has no attribute 'raw_sql'",
+)
 def test_create_table_timestamp(con, temp_table):
     schema = ibis.schema(
         dict(zip(string.ascii_letters, map("timestamp({:d})".format, range(10))))
     )
-    con.create_table(temp_table, schema=schema, overwrite=True)
+    con.create_table(
+        temp_table,
+        schema=schema,
+        **{"tbl_properties": {"connector": None}} if con.name == "flink" else {},
+        overwrite=True,
+    )
     rows = con.raw_sql(f"DESCRIBE {temp_table}").fetchall()
     result = ibis.schema((name, typ) for name, typ, *_ in rows)
     assert result == schema
 
 
-@mark.notimpl(["datafusion", "bigquery", "impala", "trino", "druid"])
+@mark.notimpl(["datafusion", "bigquery", "flink", "impala", "trino", "druid"])
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1170,7 +1233,7 @@ def test_persist_expression_ref_count(con, alltypes):
     assert con._query_cache.refs[op] == 1
 
 
-@mark.notimpl(["datafusion", "bigquery", "impala", "trino", "druid"])
+@mark.notimpl(["datafusion", "bigquery", "flink", "impala", "trino", "druid"])
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1181,7 +1244,7 @@ def test_persist_expression(alltypes):
     tm.assert_frame_equal(non_persisted_table.to_pandas(), persisted_table.to_pandas())
 
 
-@mark.notimpl(["datafusion", "bigquery", "impala", "trino", "druid"])
+@mark.notimpl(["datafusion", "bigquery", "flink", "impala", "trino", "druid"])
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1194,7 +1257,7 @@ def test_persist_expression_contextmanager(alltypes):
         tm.assert_frame_equal(non_cached_table.to_pandas(), cached_table.to_pandas())
 
 
-@mark.notimpl(["datafusion", "bigquery", "impala", "trino", "druid"])
+@mark.notimpl(["datafusion", "bigquery", "flink", "impala", "trino", "druid"])
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1210,7 +1273,7 @@ def test_persist_expression_contextmanager_ref_count(con, alltypes):
     assert con._query_cache.refs[op] == 0
 
 
-@mark.notimpl(["datafusion", "bigquery", "impala", "trino", "druid"])
+@mark.notimpl(["datafusion", "bigquery", "flink", "impala", "trino", "druid"])
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1243,7 +1306,7 @@ def test_persist_expression_multiple_refs(con, alltypes):
     assert name2 not in con.list_tables()
 
 
-@mark.notimpl(["datafusion", "bigquery", "impala", "trino", "druid"])
+@mark.notimpl(["datafusion", "bigquery", "flink", "impala", "trino", "druid"])
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1257,7 +1320,7 @@ def test_persist_expression_repeated_cache(alltypes):
             assert not nested_cached_table.to_pandas().empty
 
 
-@mark.notimpl(["datafusion", "bigquery", "impala", "trino", "druid"])
+@mark.notimpl(["datafusion", "bigquery", "flink", "impala", "trino", "druid"])
 @mark.never(
     ["mssql"],
     reason="mssql supports support temporary tables through naming conventions",
@@ -1298,7 +1361,7 @@ def gen_test_name(con: BaseBackend) -> str:
     ["druid"], raises=sa.exc.ProgrammingError, reason="generated SQL fails to parse"
 )
 @mark.notimpl(["impala"], reason="impala doesn't support memtable")
-@mark.notimpl(["pyspark"])
+@mark.notimpl(["flink", "pyspark"])
 def test_overwrite(ddl_con):
     t0 = ibis.memtable({"a": [1, 2, 3]})
 

--- a/ibis/backends/tests/test_column.py
+++ b/ibis/backends/tests/test_column.py
@@ -22,6 +22,7 @@ import ibis.common.exceptions as com
         "snowflake",
         "trino",
         "druid",
+        "flink",
     ],
     raises=com.OperationNotDefinedError,
 )

--- a/ibis/backends/tests/test_dataframe_interchange.py
+++ b/ibis/backends/tests/test_dataframe_interchange.py
@@ -53,6 +53,7 @@ def test_dataframe_interchange_no_execute(con, alltypes, mocker):
     assert not to_pyarrow.called
 
 
+@pytest.mark.notimpl(["flink"])
 def test_dataframe_interchange_dataframe_methods_execute(con, alltypes, mocker):
     t = alltypes.select("int_col", "double_col", "string_col")
     pa_df = t.to_pyarrow().__dataframe__()
@@ -69,7 +70,7 @@ def test_dataframe_interchange_dataframe_methods_execute(con, alltypes, mocker):
     assert to_pyarrow.call_count == 1
 
 
-@pytest.mark.notimpl(["druid"])
+@pytest.mark.notimpl(["druid", "flink"])
 def test_dataframe_interchange_column_methods_execute(con, alltypes, mocker):
     t = alltypes.select("int_col", "double_col", "string_col")
     pa_df = t.to_pyarrow().__dataframe__()
@@ -98,6 +99,7 @@ def test_dataframe_interchange_column_methods_execute(con, alltypes, mocker):
     assert col2.size() == pa_col2.size()
 
 
+@pytest.mark.notimpl(["flink"])
 def test_dataframe_interchange_select_after_execution_no_reexecute(
     con, alltypes, mocker
 ):

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -15,7 +15,7 @@ except ImportError:
     PolarsComputeError = None
 
 table_dot_sql_notimpl = pytest.mark.notimpl(["bigquery", "impala", "druid"])
-dot_sql_notimpl = pytest.mark.notimpl(["datafusion"])
+dot_sql_notimpl = pytest.mark.notimpl(["datafusion", "flink"])
 dot_sql_notyet = pytest.mark.notyet(
     ["snowflake", "oracle"],
     reason="snowflake and oracle column names are case insensitive",

--- a/ibis/backends/tests/test_examples.py
+++ b/ibis/backends/tests/test_examples.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.examples
     (LINUX or MACOS) and SANDBOXED,
     reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
 )
-@pytest.mark.notimpl(["dask", "datafusion", "pyspark"])
+@pytest.mark.notimpl(["dask", "datafusion", "pyspark", "flink"])
 @pytest.mark.notyet(["bigquery", "clickhouse", "druid", "impala", "mssql", "trino"])
 @pytest.mark.parametrize(
     ("example", "columns"),

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -35,13 +35,20 @@ limit = [
                     "datafusion",
                     "pandas",
                     "pyspark",
+                    "flink",
                 ]
             ),
         ],
     ),
 ]
 
-no_limit = [param(None, id="nolimit")]
+no_limit = [
+    param(
+        None,
+        id="nolimit",
+        marks=pytest.mark.notimpl(["flink"]),
+    )
+]
 
 limit_no_limit = limit + no_limit
 
@@ -105,7 +112,7 @@ def test_scalar_to_pyarrow_scalar(limit, awards_players):
     assert isinstance(scalar, pa.Scalar)
 
 
-@pytest.mark.notimpl(["druid"])
+@pytest.mark.notimpl(["druid", "flink"])
 def test_table_to_pyarrow_table_schema(awards_players):
     table = awards_players.to_pyarrow()
     assert isinstance(table, pa.Table)
@@ -124,6 +131,7 @@ def test_table_to_pyarrow_table_schema(awards_players):
     assert table.schema == expected_schema
 
 
+@pytest.mark.notimpl(["flink"])
 def test_column_to_pyarrow_table_schema(awards_players):
     expr = awards_players.awardID
     array = expr.to_pyarrow()
@@ -131,7 +139,7 @@ def test_column_to_pyarrow_table_schema(awards_players):
     assert array.type == pa.string() or array.type == pa.large_string()
 
 
-@pytest.mark.notimpl(["pandas", "dask", "datafusion"])
+@pytest.mark.notimpl(["pandas", "dask", "datafusion", "flink"])
 @pytest.mark.notyet(
     ["clickhouse"],
     raises=AssertionError,
@@ -146,7 +154,7 @@ def test_table_pyarrow_batch_chunk_size(awards_players):
         util.consume(batch_reader)
 
 
-@pytest.mark.notimpl(["pandas", "dask", "datafusion"])
+@pytest.mark.notimpl(["pandas", "dask", "datafusion", "flink"])
 @pytest.mark.notyet(
     ["clickhouse"],
     raises=AssertionError,
@@ -163,7 +171,7 @@ def test_column_pyarrow_batch_chunk_size(awards_players):
         util.consume(batch_reader)
 
 
-@pytest.mark.notimpl(["pandas", "dask", "datafusion"])
+@pytest.mark.notimpl(["pandas", "dask", "datafusion", "flink"])
 @pytest.mark.broken(
     ["pyspark"], raises=AssertionError, reason="chunk_size isn't respected"
 )
@@ -183,6 +191,7 @@ def test_to_pyarrow_batches_borked_types(batting):
         util.consume(batch_reader)
 
 
+@pytest.mark.notimpl(["flink"])
 def test_to_pyarrow_memtable(con):
     expr = ibis.memtable({"x": [1, 2, 3]})
     table = con.to_pyarrow(expr)
@@ -190,6 +199,7 @@ def test_to_pyarrow_memtable(con):
     assert len(table) == 3
 
 
+@pytest.mark.notimpl(["flink"])
 def test_to_pyarrow_batches_memtable(con):
     expr = ibis.memtable({"x": [1, 2, 3]})
     n = 0
@@ -200,6 +210,7 @@ def test_to_pyarrow_batches_memtable(con):
     assert n == 3
 
 
+@pytest.mark.notimpl(["flink"])
 def test_table_to_parquet(tmp_path, backend, awards_players):
     outparquet = tmp_path / "out.parquet"
     awards_players.to_parquet(outparquet)
@@ -229,7 +240,7 @@ def test_table_to_parquet(tmp_path, backend, awards_players):
     ],
     reason="no partitioning support",
 )
-@pytest.mark.notimpl(["druid"], reason="No to_parquet support")
+@pytest.mark.notimpl(["druid", "flink"], reason="No to_parquet support")
 def test_roundtrip_partitioned_parquet(tmp_path, con, backend, awards_players):
     outparquet = tmp_path / "outhive.parquet"
     awards_players.to_parquet(outparquet, partition_by="yearID")
@@ -253,6 +264,7 @@ def test_roundtrip_partitioned_parquet(tmp_path, con, backend, awards_players):
     backend.assert_frame_equal(reingest.to_pandas(), awards_players.to_pandas())
 
 
+@pytest.mark.notimpl(["flink"], reason="No support for exporting files")
 @pytest.mark.parametrize("ftype", ["csv", "parquet"])
 def test_memtable_to_file(tmp_path, con, ftype, monkeypatch):
     """
@@ -273,6 +285,7 @@ def test_memtable_to_file(tmp_path, con, ftype, monkeypatch):
     assert outfile.is_file()
 
 
+@pytest.mark.notimpl(["flink"])
 def test_table_to_csv(tmp_path, backend, awards_players):
     outcsv = tmp_path / "out.csv"
 
@@ -293,7 +306,10 @@ def test_table_to_csv(tmp_path, backend, awards_players):
             dt.Decimal(38, 9),
             pa.Decimal128Type,
             id="decimal128",
-            marks=[pytest.mark.notyet(["druid"], raises=sa.exc.ProgrammingError)],
+            marks=[
+                pytest.mark.notyet(["druid"], raises=sa.exc.ProgrammingError),
+                pytest.mark.notyet(["flink"], raises=NotImplementedError),
+            ],
         ),
         param(
             dt.Decimal(76, 38),
@@ -312,6 +328,7 @@ def test_table_to_csv(tmp_path, backend, awards_players):
                     raises=AnalysisException,
                     reason="precision is out of range",
                 ),
+                pytest.mark.notyet(["flink"], raises=NotImplementedError),
             ],
         ),
     ],
@@ -338,6 +355,7 @@ def test_to_pyarrow_decimal(backend, dtype, pyarrow_dtype):
         "bigquery",
         "dask",
         "trino",
+        "flink",
     ],
     raises=NotImplementedError,
     reason="read_delta not yet implemented",
@@ -374,6 +392,7 @@ def test_roundtrip_delta(con, alltypes, tmp_path, monkeypatch):
     ["druid"], raises=AttributeError, reason="string type is used for timestamp_col"
 )
 @pytest.mark.notimpl(["mssql"], raises=pa.ArrowTypeError)
+@pytest.mark.notimpl(["flink"], raises=NotImplementedError)
 def test_arrow_timestamp_with_time_zone(alltypes):
     t = alltypes.select(
         tz=alltypes.timestamp_col.cast(
@@ -392,7 +411,7 @@ def test_arrow_timestamp_with_time_zone(alltypes):
     assert batch.schema.types == expected
 
 
-@pytest.mark.notimpl(["druid"])
+@pytest.mark.notimpl(["druid", "flink"])
 @pytest.mark.notimpl(
     ["impala"], raises=AttributeError, reason="missing `fetchmany` on the cursor"
 )
@@ -413,6 +432,7 @@ def test_to_torch(alltypes):
         non_numeric.to_torch()
 
 
+@pytest.mark.notimpl(["flink"])
 def test_empty_memtable(backend, con):
     expected = pd.DataFrame({"a": []})
     table = ibis.memtable(expected)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -46,6 +46,11 @@ try:
 except ImportError:
     HiveServer2Error = None
 
+try:
+    from py4j.protocol import Py4JJavaError
+except ImportError:
+    Py4JJavaError = None
+
 
 NULL_BACKEND_TYPES = {
     "bigquery": "NULL",
@@ -61,6 +66,7 @@ NULL_BACKEND_TYPES = {
 
 
 @pytest.mark.broken(["impala", "bigquery"], "assert nan is None")
+@pytest.mark.notyet(["flink"], "The runtime does not support untyped `NULL` values.")
 def test_null_literal(con, backend):
     expr = ibis.null()
     result = con.execute(expr)
@@ -80,6 +86,7 @@ BOOLEAN_BACKEND_TYPE = {
     "trino": "boolean",
     "duckdb": "BOOLEAN",
     "postgres": "boolean",
+    "flink": "BOOLEAN NOT NULL",
 }
 
 
@@ -133,6 +140,7 @@ def test_scalar_fillna_nullif(con, expr, expected):
     ],
 )
 @pytest.mark.notimpl(["mssql", "druid", "oracle"])
+@pytest.mark.notyet(["flink"], "NaN is not supported in Flink SQL", raises=ValueError)
 def test_isna(backend, alltypes, col, filt):
     table = alltypes.select(
         nan_col=ibis.literal(np.nan), none_col=ibis.NA.cast("float64")
@@ -151,23 +159,28 @@ def test_isna(backend, alltypes, col, filt):
         None,
         param(
             np.nan,
-            marks=pytest.mark.notimpl(
-                [
-                    "bigquery",
-                    "clickhouse",
-                    "duckdb",
-                    "impala",
-                    "postgres",
-                    "mysql",
-                    "snowflake",
-                    "polars",
-                    "trino",
-                    "mssql",
-                    "druid",
-                    "oracle",
-                ],
-                reason="NaN != NULL for these backends",
-            ),
+            marks=[
+                pytest.mark.notimpl(
+                    [
+                        "bigquery",
+                        "clickhouse",
+                        "duckdb",
+                        "impala",
+                        "postgres",
+                        "mysql",
+                        "snowflake",
+                        "polars",
+                        "trino",
+                        "mssql",
+                        "druid",
+                        "oracle",
+                    ],
+                    reason="NaN != NULL for these backends",
+                ),
+                pytest.mark.notyet(
+                    ["flink"], "NaN is not supported in Flink SQL", raises=ValueError
+                ),
+            ],
             id="nan_col",
         ),
     ],
@@ -318,6 +331,10 @@ def test_filter(backend, alltypes, sorted_df, predicate_fn, expected_fn):
         "oracle",
     ]
 )
+@pytest.mark.never(
+    ["flink"],
+    reason="Flink engine does not support generic window clause with no order by",
+)
 def test_filter_with_window_op(backend, alltypes, sorted_df):
     sorted_alltypes = alltypes.order_by("id")
     table = sorted_alltypes
@@ -360,6 +377,7 @@ def test_case_where(backend, alltypes, df):
 
 # TODO: some of these are notimpl (datafusion) others are probably never
 @pytest.mark.notimpl(["datafusion", "mysql", "sqlite", "mssql", "druid", "oracle"])
+@pytest.mark.notyet(["flink"], "NaN is not supported in Flink SQL", raises=ValueError)
 def test_select_filter_mutate(backend, alltypes, df):
     """Test that select, filter and mutate are executed in right order.
 
@@ -748,6 +766,7 @@ def test_between(backend, alltypes, df):
 
 
 @pytest.mark.notimpl(["druid"])
+@pytest.mark.notimpl(["flink"], raises=NotImplementedError)
 def test_interactive(alltypes, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)
 
@@ -767,6 +786,7 @@ def test_correlated_subquery(alltypes):
 
 
 @pytest.mark.notimpl(["polars", "pyspark"])
+@pytest.mark.broken(["flink"], reason="`result` order differs from `expected`")
 def test_uncorrelated_subquery(backend, batting, batting_df):
     subset_batting = batting[batting.yearID <= 2000]
     expr = batting[_.yearID == subset_batting.yearID.max()]["playerID", "yearID"]
@@ -943,7 +963,7 @@ def test_memtable_construct(backend, con, monkeypatch):
 @pytest.mark.notimpl(
     ["pyspark"], reason="pyspark doesn't generate SQL", raises=NotImplementedError
 )
-@pytest.mark.notimpl(["druid"], reason="no sqlglot dialect", raises=ValueError)
+@pytest.mark.notimpl(["druid", "flink"], reason="no sqlglot dialect", raises=ValueError)
 def test_many_subqueries(con, snapshot):
     def query(t, group_cols):
         t2 = t.mutate(key=ibis.row_number().over(ibis.window(order_by=group_cols)))
@@ -957,7 +977,9 @@ def test_many_subqueries(con, snapshot):
     snapshot.assert_match(str(ibis.to_sql(t3, dialect=con.name)), "out.sql")
 
 
-@pytest.mark.notimpl(["dask", "pandas", "oracle"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(
+    ["dask", "pandas", "oracle", "flink"], raises=com.OperationNotDefinedError
+)
 @pytest.mark.notimpl(["druid"], raises=AssertionError)
 @pytest.mark.notyet(
     ["datafusion", "impala", "mssql", "mysql", "sqlite"],
@@ -1065,6 +1087,11 @@ def test_pivot_wider(backend):
     raises=com.OperationNotDefinedError,
     reason="backend doesn't implement ops.WindowFunction",
 )
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=com.OperationNotDefinedError,
+    reason="backend doesn't implement deduplication",
+)
 def test_distinct_on_keep(backend, on, keep):
     from ibis import _
 
@@ -1130,6 +1157,11 @@ def test_distinct_on_keep(backend, on, keep):
     raises=com.UnsupportedOperationError,
     reason="backend doesn't support `having` filters",
 )
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=com.OperationNotDefinedError,
+    reason="backend doesn't implement deduplication",
+)
 def test_distinct_on_keep_is_none(backend, on):
     from ibis import _
 
@@ -1152,7 +1184,7 @@ def test_distinct_on_keep_is_none(backend, on):
     assert len(result) == len(expected)
 
 
-@pytest.mark.notimpl(["dask", "pandas", "postgres"])
+@pytest.mark.notimpl(["dask", "pandas", "postgres", "flink"])
 @pytest.mark.notyet(
     [
         "sqlite",
@@ -1460,6 +1492,7 @@ def test_static_table_slice(backend, slc, expected_count_fn):
     raises=HiveServer2Error,
 )
 @pytest.mark.notyet(["pyspark"], reason="pyspark doesn't support dynamic limit/offset")
+@pytest.mark.notyet(["flink"], reason="flink doesn't support dynamic limit/offset")
 def test_dynamic_table_slice(backend, slc, expected_count_fn):
     t = backend.functional_alltypes
 
@@ -1503,6 +1536,7 @@ def test_dynamic_table_slice(backend, slc, expected_count_fn):
     raises=AssertionError,
     reason="https://github.com/duckdb/duckdb/issues/8412",
 )
+@pytest.mark.notyet(["flink"], reason="flink doesn't support dynamic limit/offset")
 def test_dynamic_table_slice_with_computed_offset(backend):
     t = backend.functional_alltypes
 

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -123,6 +123,7 @@ def test_mutating_join(backend, batting, awards_players, how):
 
 @pytest.mark.parametrize("how", ["semi", "anti"])
 @pytest.mark.notimpl(["dask", "druid"])
+@pytest.mark.notyet(["flink"], reason="Flink doesn't support semi joins or anti joins")
 def test_filtering_join(backend, batting, awards_players, how):
     left = batting[batting.yearID == 2015]
     right = awards_players[awards_players.lgID == "NL"].drop("yearID", "lgID")
@@ -183,6 +184,7 @@ def test_mutate_then_join_no_column_overlap(batting, awards_players):
 
 @pytest.mark.notimpl(["druid"])
 @pytest.mark.notyet(["dask"], reason="dask doesn't support descending order by")
+@pytest.mark.notyet(["flink"], reason="Flink doesn't support semi joins")
 @pytest.mark.broken(
     ["polars"],
     raises=ValueError,

--- a/ibis/backends/tests/test_json.py
+++ b/ibis/backends/tests/test_json.py
@@ -36,6 +36,10 @@ pytestmark = [
     condition=vparse(sqlite3.sqlite_version) < vparse("3.38.0"),
     reason="JSON not supported in SQLite < 3.38.0",
 )
+@pytest.mark.broken(
+    ["flink"],
+    reason="https://github.com/ibis-project/ibis/pull/6920#discussion_r1373212503",
+)
 def test_json_getitem(json_t, expr_fn, expected):
     expr = expr_fn(json_t)
     result = expr.execute()
@@ -46,7 +50,7 @@ def test_json_getitem(json_t, expr_fn, expected):
 @pytest.mark.notyet(["bigquery", "sqlite"], reason="doesn't support maps")
 @pytest.mark.notyet(["postgres"], reason="only supports map<string, string>")
 @pytest.mark.notyet(
-    ["pyspark", "trino"], reason="should work but doesn't deserialize JSON"
+    ["pyspark", "trino", "flink"], reason="should work but doesn't deserialize JSON"
 )
 def test_json_map(json_t):
     expr = json_t.js.map.name("res")
@@ -69,7 +73,7 @@ def test_json_map(json_t):
 @pytest.mark.notimpl(["dask", "mysql", "pandas"])
 @pytest.mark.notyet(["sqlite"], reason="doesn't support arrays")
 @pytest.mark.notyet(
-    ["pyspark", "trino"], reason="should work but doesn't deserialize JSON"
+    ["pyspark", "trino", "flink"], reason="should work but doesn't deserialize JSON"
 )
 @pytest.mark.notyet(["bigquery"], reason="doesn't allow null in arrays")
 def test_json_array(json_t):

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -60,6 +60,11 @@ def test_column_map_merge(backend):
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.maps.MapKeys'>",
+)
 def test_literal_map_keys(con):
     mapping = ibis.literal({"1": "a", "2": "b"})
     expr = mapping.keys().name("tmp")
@@ -70,6 +75,11 @@ def test_literal_map_keys(con):
     assert np.array_equal(result, ["1", "2"])
 
 
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.maps.MapValues'>",
+)
 def test_literal_map_values(con):
     mapping = ibis.literal({"1": "a", "2": "b"})
     expr = mapping.values().name("tmp")
@@ -79,6 +89,11 @@ def test_literal_map_values(con):
 
 
 @pytest.mark.notimpl(["postgres"])
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.arrays.ArrayContains'>",
+)
 def test_scalar_isin_literal_map_keys(con):
     mapping = ibis.literal({"a": 1, "b": 2})
     a = ibis.literal("a")
@@ -90,6 +105,11 @@ def test_scalar_isin_literal_map_keys(con):
 
 
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.maps.MapContains'>",
+)
 def test_map_scalar_contains_key_scalar(con):
     mapping = ibis.literal({"a": 1, "b": 2})
     a = ibis.literal("a")
@@ -100,6 +120,11 @@ def test_map_scalar_contains_key_scalar(con):
     assert con.execute(false) == False  # noqa: E712
 
 
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.maps.MapContains'>",
+)
 def test_map_scalar_contains_key_column(backend, alltypes, df):
     value = {"1": "a", "3": "c"}
     mapping = ibis.literal(value)
@@ -110,6 +135,11 @@ def test_map_scalar_contains_key_column(backend, alltypes, df):
 
 
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason=("No translation rule for <class 'ibis.expr.operations.maps.MapContains'>"),
+)
 def test_map_column_contains_key_scalar(backend, alltypes, df):
     expr = ibis.map(ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col]))
     series = df.apply(lambda row: {row["string_col"]: row["int_col"]}, axis=1)
@@ -121,6 +151,11 @@ def test_map_column_contains_key_scalar(backend, alltypes, df):
 
 
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.maps.MapContains'>",
+)
 def test_map_column_contains_key_column(alltypes):
     map_expr = ibis.map(
         ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col])
@@ -131,6 +166,11 @@ def test_map_column_contains_key_column(alltypes):
 
 
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.maps.MapMerge'>",
+)
 def test_literal_map_merge(con):
     a = ibis.literal({"a": 0, "b": 2})
     b = ibis.literal({"a": 1, "c": 3})
@@ -139,6 +179,11 @@ def test_literal_map_merge(con):
     assert con.execute(expr) == {"a": 1, "b": 2, "c": 3}
 
 
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=NotImplementedError,
+    reason="No translation rule for map<string, string>",
+)
 def test_literal_map_getitem_broadcast(backend, alltypes, df):
     value = {"1": "a", "2": "b"}
 
@@ -151,6 +196,11 @@ def test_literal_map_getitem_broadcast(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=NotImplementedError,
+    reason="No translation rule for map<string, string>",
+)
 def test_literal_map_get_broadcast(backend, alltypes, df):
     value = {"1": "a", "2": "b"}
 
@@ -177,6 +227,9 @@ def test_literal_map_get_broadcast(backend, alltypes, df):
         param(["a", "b"], ["1", "2"], id="int"),
     ],
 )
+@pytest.mark.notimpl(
+    ["flink"], raises=AssertionError, reason="WIP; got [('a', 1), ('b', 2)] instead"
+)
 def test_map_construct_dict(con, keys, values):
     expr = ibis.map(keys, values)
     result = con.execute(expr.name("tmp"))
@@ -184,6 +237,11 @@ def test_map_construct_dict(con, keys, values):
 
 
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.arrays.ArrayColumn'>",
+)
 def test_map_construct_array_column(con, alltypes, df):
     expr = ibis.map(ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col]))
     result = con.execute(expr)
@@ -193,6 +251,11 @@ def test_map_construct_array_column(con, alltypes, df):
 
 
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=NotImplementedError,
+    reason="No translation rule for map<string, int16>",
+)
 def test_map_get_with_compatible_value_smaller(con):
     value = ibis.literal({"A": 1000, "B": 2000})
     expr = value.get("C", 3)
@@ -200,6 +263,11 @@ def test_map_get_with_compatible_value_smaller(con):
 
 
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=NotImplementedError,
+    reason="No translation rule for map<string, int8>",
+)
 def test_map_get_with_compatible_value_bigger(con):
     value = ibis.literal({"A": 1, "B": 2})
     expr = value.get("C", 3000)
@@ -207,6 +275,11 @@ def test_map_get_with_compatible_value_bigger(con):
 
 
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=NotImplementedError,
+    reason="NotImplementedError: No translation rule for map<string, int16>",
+)
 def test_map_get_with_incompatible_value_different_kind(con):
     value = ibis.literal({"A": 1000, "B": 2000})
     expr = value.get("C", 3.0)
@@ -215,6 +288,11 @@ def test_map_get_with_incompatible_value_different_kind(con):
 
 @pytest.mark.parametrize("null_value", [None, ibis.NA])
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=NotImplementedError,
+    reason="No translation rule for map<string, int16>",
+)
 def test_map_get_with_null_on_not_nullable(con, null_value):
     map_type = dt.Map(dt.string, dt.Int16(nullable=False))
     value = ibis.literal({"A": 1000, "B": 2000}).cast(map_type)
@@ -224,6 +302,11 @@ def test_map_get_with_null_on_not_nullable(con, null_value):
 
 
 @pytest.mark.parametrize("null_value", [None, ibis.NA])
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=NotImplementedError,
+    reason="No translation rule for map<string, null>",
+)
 def test_map_get_with_null_on_null_type_with_null(con, null_value):
     value = ibis.literal({"A": None, "B": None})
     expr = value.get("C", null_value)
@@ -232,19 +315,36 @@ def test_map_get_with_null_on_null_type_with_null(con, null_value):
 
 
 @pytest.mark.notyet(["postgres"], reason="only support maps of string -> string")
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=NotImplementedError,
+    reason="No translation rule for map<string, null>",
+)
 def test_map_get_with_null_on_null_type_with_non_null(con):
     value = ibis.literal({"A": None, "B": None})
     expr = value.get("C", 1)
     assert con.execute(expr) == 1
 
 
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.UnsupportedBackendType,
+    reason="UnsupportedBackendType: map",
+)
 def test_map_create_table(con, temp_table):
     t = con.create_table(
-        temp_table, schema=ibis.schema(dict(xyz="map<string, string>"))
+        temp_table,
+        schema=ibis.schema(dict(xyz="map<string, string>")),
+        **{"tbl_properties": {"connector": None}} if con.name == "flink" else {},
     )
     assert t.schema()["xyz"].is_map()
 
 
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=exc.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.maps.MapLength'>",
+)
 def test_map_length(con):
     expr = ibis.literal(dict(a="A", b="B")).length()
     assert con.execute(expr) == 2

--- a/ibis/backends/tests/test_network.py
+++ b/ibis/backends/tests/test_network.py
@@ -19,10 +19,11 @@ MACADDR_BACKEND_TYPE = {
     "trino": "varchar(17)",
     "impala": "STRING",
     "postgres": "text",
+    "flink": "CHAR(17) NOT NULL",
 }
 
 
-@pytest.mark.notimpl(["polars"], raises=NotImplementedError)
+@pytest.mark.notimpl(["flink", "polars"], raises=NotImplementedError)
 def test_macaddr_literal(con, backend):
     test_macaddr = "00:00:0A:BB:28:FC"
     expr = ibis.literal(test_macaddr, type=dt.macaddr)
@@ -54,6 +55,7 @@ def test_macaddr_literal(con, backend):
                 "dask": "127.0.0.1",
                 "mssql": "127.0.0.1",
                 "datafusion": "127.0.0.1",
+                "flink": "127.0.0.1",
             },
             {
                 "bigquery": "STRING",
@@ -64,6 +66,7 @@ def test_macaddr_literal(con, backend):
                 "trino": "varchar(9)",
                 "impala": "STRING",
                 "postgres": "text",
+                "flink": "CHAR(9) NOT NULL",
             },
             id="ipv4",
         ),
@@ -84,6 +87,7 @@ def test_macaddr_literal(con, backend):
                 "dask": "2001:db8::1",
                 "mssql": "2001:db8::1",
                 "datafusion": "2001:db8::1",
+                "flink": "2001:db8::1",
             },
             {
                 "bigquery": "STRING",
@@ -94,12 +98,13 @@ def test_macaddr_literal(con, backend):
                 "trino": "varchar(11)",
                 "impala": "STRING",
                 "postgres": "text",
+                "flink": "CHAR(11) NOT NULL",
             },
             id="ipv6",
         ),
     ],
 )
-@pytest.mark.notimpl(["polars"], raises=NotImplementedError)
+@pytest.mark.notimpl(["flink", "polars"], raises=NotImplementedError)
 @pytest.mark.notimpl(["druid", "oracle"], raises=KeyError)
 def test_inet_literal(con, backend, test_value, expected_values, expected_types):
     backend_name = backend.name()

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -19,6 +19,11 @@ try:
 except ImportError:
     GoogleBadRequest = None
 
+try:
+    from py4j.protocol import Py4JJavaError
+except ImportError:
+    Py4JJavaError = None
+
 
 @pytest.mark.parametrize(
     ("column", "raw_value"),
@@ -79,11 +84,14 @@ def test_scalar_param_array(con):
     assert result == len(value)
 
 
-@pytest.mark.notimpl(["datafusion", "impala", "postgres", "pyspark", "druid", "oracle"])
+@pytest.mark.notimpl(
+    ["datafusion", "impala", "flink", "postgres", "pyspark", "druid", "oracle"]
+)
 @pytest.mark.never(
     ["mysql", "sqlite", "mssql"],
     reason="mysql and sqlite will never implement struct types",
 )
+@pytest.mark.notimpl(["flink"], "WIP")
 def test_scalar_param_struct(con):
     value = dict(a=1, b="abc", c=3.0)
     param = ibis.param("struct<a: int64, b: string, c: float64>")
@@ -97,6 +105,15 @@ def test_scalar_param_struct(con):
     reason="mysql and sqlite will never implement map types",
 )
 @pytest.mark.notyet(["bigquery"])
+@pytest.mark.notimpl(
+    ["flink"],
+    "WIP",
+    raises=Py4JJavaError,
+    reason=(
+        "SqlParseException: Expecting alias, found character literal"
+        "sql= SELECT MAP_FROM_ARRAYS(ARRAY['a', 'b', 'c'], ARRAY['ghi', 'def', 'abc']) '[' 'b' ']' AS `MapGet(param_0, 'b', None)`"
+    ),
+)
 def test_scalar_param_map(con):
     value = {"a": "ghi", "b": "def", "c": "abc"}
     param = ibis.param(dt.Map(dt.string, dt.string))
@@ -208,7 +225,7 @@ def test_scalar_param_date(backend, alltypes, value):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notyet(["mysql"], reason="no struct support")
+@pytest.mark.notyet(["flink", "mysql"], reason="no struct support")
 @pytest.mark.notimpl(
     [
         "postgres",
@@ -225,6 +242,7 @@ def test_scalar_param_date(backend, alltypes, value):
         "druid",
     ]
 )
+@pytest.mark.notimpl(["flink"], "WIP")
 def test_scalar_param_nested(con):
     param = ibis.param("struct<x: array<struct<y: array<double>>>>")
     value = OrderedDict([("x", [OrderedDict([("y", [1.0, 2.0, 3.0])])])])

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -85,6 +85,7 @@ def gzip_csv(data_dir, tmp_path):
         "bigquery",
         "clickhouse",
         "dask",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -110,6 +111,7 @@ def test_register_csv(con, data_dir, fname, in_table_name, out_table_name):
         "bigquery",
         "clickhouse",
         "dask",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -132,6 +134,7 @@ def test_register_csv_gz(con, data_dir, gzip_csv):
         "bigquery",
         "clickhouse",
         "dask",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -187,6 +190,7 @@ def read_table(path: Path) -> Iterator[tuple[str, pa.Table]]:
         "bigquery",
         "clickhouse",
         "dask",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -222,6 +226,7 @@ def test_register_parquet(
         "clickhouse",
         "dask",
         "datafusion",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -260,6 +265,7 @@ def test_register_iterator_parquet(
         "bigquery",
         "clickhouse",
         "dask",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -289,6 +295,7 @@ def test_register_pandas(con):
         "bigquery",
         "clickhouse",
         "dask",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -313,6 +320,7 @@ def test_register_pyarrow_tables(con):
         "bigquery",
         "clickhouse",
         "dask",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -353,6 +361,7 @@ def test_csv_reregister_schema(con, tmp_path):
         "clickhouse",
         "dask",
         "datafusion",
+        "flink",
         "impala",
         "mysql",
         "mssql",
@@ -393,6 +402,7 @@ def test_register_garbage(con, monkeypatch):
 @pytest.mark.notyet(
     [
         "bigquery",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -433,6 +443,7 @@ def ft_data(data_dir):
 @pytest.mark.notyet(
     [
         "bigquery",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -461,6 +472,7 @@ def test_read_parquet_glob(con, tmp_path, ft_data):
 @pytest.mark.notyet(
     [
         "bigquery",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -492,6 +504,7 @@ def test_read_csv_glob(con, tmp_path, ft_data):
         "clickhouse",
         "dask",
         "datafusion",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -550,6 +563,7 @@ DIAMONDS_COLUMN_TYPES = {
 @pytest.mark.notyet(
     [
         "bigquery",
+        "flink",
         "impala",
         "mssql",
         "mysql",

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 
 import pytest
-from pytest import mark, param
+from pytest import param
 
 import ibis
 import ibis.common.exceptions as exc
@@ -16,16 +16,17 @@ sg = pytest.importorskip("sqlglot")
 pytestmark = pytest.mark.notimpl(["druid"])
 
 
-@mark.never(
+@pytest.mark.never(
     ["dask", "pandas"],
     reason="Dask and Pandas are not SQL backends",
     raises=(NotImplementedError, ValueError),
 )
-@mark.notimpl(
+@pytest.mark.notimpl(
     ["datafusion", "pyspark", "polars"],
     reason="Not clear how to extract SQL from the backend",
     raises=(exc.OperationNotDefinedError, NotImplementedError, ValueError),
 )
+@pytest.mark.notimpl(["flink"], "WIP")
 def test_table(backend):
     expr = backend.functional_alltypes.select(c=_.int_col + 1)
     buf = io.StringIO()
@@ -37,12 +38,12 @@ simple_literal = param(ibis.literal(1), id="simple_literal")
 array_literal = param(
     ibis.array([1]),
     marks=[
-        mark.never(
+        pytest.mark.never(
             ["mysql", "mssql", "oracle"],
             raises=sa.exc.CompileError,
             reason="arrays not supported in the backend",
         ),
-        mark.notyet(
+        pytest.mark.notyet(
             ["impala", "sqlite"],
             raises=NotImplementedError,
             reason="backends hasn't implemented array literals",
@@ -50,26 +51,26 @@ array_literal = param(
     ],
     id="array_literal",
 )
-no_structs = mark.never(
+no_structs = pytest.mark.never(
     ["impala", "mysql", "sqlite", "mssql"],
     raises=(NotImplementedError, sa.exc.CompileError),
     reason="structs not supported in the backend",
 )
-no_struct_literals = mark.notimpl(
+no_struct_literals = pytest.mark.notimpl(
     ["postgres", "mssql", "oracle"], reason="struct literals are not yet implemented"
 )
-not_sql = mark.never(
+not_sql = pytest.mark.never(
     ["pandas", "dask"],
     raises=(exc.IbisError, NotImplementedError, ValueError),
     reason="Not a SQL backend",
 )
-no_sql_extraction = mark.notimpl(
+no_sql_extraction = pytest.mark.notimpl(
     ["datafusion", "pyspark", "polars"],
     reason="Not clear how to extract SQL from the backend",
 )
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     "expr",
     [
         simple_literal,
@@ -83,6 +84,7 @@ no_sql_extraction = mark.notimpl(
 )
 @not_sql
 @no_sql_extraction
+@pytest.mark.notimpl(["flink"], "WIP")
 def test_literal(backend, expr):
     assert ibis.to_sql(expr, dialect=backend.name())
 
@@ -93,6 +95,7 @@ def test_literal(backend, expr):
 @pytest.mark.xfail_version(
     mssql=["sqlalchemy>=2"], reason="sqlalchemy 2 prefixes literals with `N`"
 )
+@pytest.mark.notimpl(["flink"], "WIP")
 def test_group_by_has_index(backend, snapshot):
     countries = ibis.table(
         dict(continent="string", population="int64"), name="countries"
@@ -118,6 +121,7 @@ def test_group_by_has_index(backend, snapshot):
 @pytest.mark.never(
     ["pandas", "dask", "datafusion", "polars", "pyspark"], reason="not SQL"
 )
+@pytest.mark.notimpl(["flink"], "WIP")
 def test_cte_refs_in_topo_order(backend, snapshot):
     mr0 = ibis.table(schema=ibis.schema(dict(key="int")), name="leaf")
 
@@ -133,6 +137,7 @@ def test_cte_refs_in_topo_order(backend, snapshot):
 @pytest.mark.never(
     ["pandas", "dask", "datafusion", "polars", "pyspark"], reason="not SQL"
 )
+@pytest.mark.notimpl(["flink"], "WIP")
 def test_isin_bug(con, snapshot):
     t = ibis.table(dict(x="int"), name="t")
     good = t[t.x > 2].x
@@ -149,7 +154,9 @@ def test_isin_bug(con, snapshot):
     ["sqlite", "mysql", "druid", "impala", "mssql"], reason="no unnest support upstream"
 )
 @pytest.mark.notimpl(
-    ["oracle"], reason="unnest not yet implemented", raises=exc.OperationNotDefinedError
+    ["oracle", "flink"],
+    reason="unnest not yet implemented",
+    raises=exc.OperationNotDefinedError,
 )
 @pytest.mark.parametrize("backend_name", _get_backends_to_test())
 def test_union_aliasing(backend_name, snapshot):

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -424,6 +424,11 @@ def uses_java_re(t):
                     ],
                     raises=com.OperationNotDefinedError,
                 ),
+                pytest.mark.notyet(
+                    ["flink"],
+                    raises=com.OperationNotDefinedError,
+                    reason="doesn't support `TRANSLATE`",
+                ),
             ],
         ),
         param(
@@ -457,41 +462,55 @@ def uses_java_re(t):
             lambda t: t.string_col.find_in_set(["1"]),
             lambda t: t.string_col.str.find("1"),
             id="find_in_set",
-            marks=pytest.mark.notimpl(
-                [
-                    "bigquery",
-                    "datafusion",
-                    "pyspark",
-                    "sqlite",
-                    "snowflake",
-                    "polars",
-                    "mssql",
-                    "trino",
-                    "druid",
-                    "oracle",
-                ],
-                raises=com.OperationNotDefinedError,
-            ),
+            marks=[
+                pytest.mark.notimpl(
+                    [
+                        "bigquery",
+                        "datafusion",
+                        "pyspark",
+                        "sqlite",
+                        "snowflake",
+                        "polars",
+                        "mssql",
+                        "trino",
+                        "druid",
+                        "oracle",
+                    ],
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notyet(
+                    ["flink"],
+                    raises=com.OperationNotDefinedError,
+                    reason="doesn't support `FIND_IN_SET`",
+                ),
+            ],
         ),
         param(
             lambda t: t.string_col.find_in_set(["a"]),
             lambda t: t.string_col.str.find("a"),
             id="find_in_set_all_missing",
-            marks=pytest.mark.notimpl(
-                [
-                    "bigquery",
-                    "datafusion",
-                    "pyspark",
-                    "sqlite",
-                    "snowflake",
-                    "polars",
-                    "mssql",
-                    "trino",
-                    "druid",
-                    "oracle",
-                ],
-                raises=com.OperationNotDefinedError,
-            ),
+            marks=[
+                pytest.mark.notimpl(
+                    [
+                        "bigquery",
+                        "datafusion",
+                        "pyspark",
+                        "sqlite",
+                        "snowflake",
+                        "polars",
+                        "mssql",
+                        "trino",
+                        "druid",
+                        "oracle",
+                    ],
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notyet(
+                    ["flink"],
+                    raises=com.OperationNotDefinedError,
+                    reason="doesn't support `FIND_IN_SET`",
+                ),
+            ],
         ),
         param(
             lambda t: t.string_col.lower(),
@@ -684,7 +703,9 @@ def uses_java_re(t):
             id="negative-index",
             marks=[
                 pytest.mark.broken(["druid"], raises=sa.exc.ProgrammingError),
-                pytest.mark.broken(["datafusion", "impala"], raises=AssertionError),
+                pytest.mark.broken(
+                    ["datafusion", "impala", "flink"], raises=AssertionError
+                ),
                 pytest.mark.notimpl(["pyspark"], raises=NotImplementedError),
             ],
         ),
@@ -817,6 +838,7 @@ def uses_java_re(t):
                     "mssql",
                     "druid",
                     "oracle",
+                    "flink",
                 ],
                 raises=com.OperationNotDefinedError,
             ),
@@ -990,7 +1012,7 @@ def test_capitalize(con):
 
 
 @pytest.mark.notimpl(
-    ["dask", "datafusion", "pandas", "polars", "druid", "oracle"],
+    ["dask", "datafusion", "pandas", "polars", "druid", "oracle", "flink"],
     raises=OperationNotDefinedError,
 )
 @pytest.mark.notyet(
@@ -1039,6 +1061,7 @@ def test_multiple_subs(con):
         "pandas",
         "polars",
         "sqlite",
+        "flink",
     ],
     raises=com.OperationNotDefinedError,
 )

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -13,7 +13,7 @@ import ibis.expr.datatypes as dt
 pytestmark = [
     pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
     pytest.mark.notyet(["impala"]),
-    pytest.mark.notimpl(["datafusion", "druid", "oracle"]),
+    pytest.mark.notimpl(["datafusion", "druid", "oracle", "flink"]),
 ]
 
 

--- a/ibis/backends/tests/test_timecontext.py
+++ b/ibis/backends/tests/test_timecontext.py
@@ -7,7 +7,14 @@ from packaging.version import parse as vparse
 from pytest import param
 
 import ibis
+import ibis.common.exceptions as com
 from ibis.backends.tests.test_vectorized_udf import calc_mean, create_demean_struct_udf
+
+try:
+    from py4j.protocol import Py4JJavaError
+except ImportError:
+    Py4JJavaError = None
+
 
 pytestmark = pytest.mark.notimpl(
     [
@@ -55,6 +62,11 @@ broken_pandas_grouped_rolling = pytest.mark.xfail(
 @pytest.mark.xfail_version(
     pyspark=["pyspark<3.1"], pandas=["pyarrow>=13", "pandas>=2.1"]
 )
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=com.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.vectorized.ReductionVectorizedUDF'>",
+)
 @pytest.mark.parametrize(
     "window",
     [
@@ -88,6 +100,12 @@ def test_context_adjustment_window_udf(alltypes, context, window, monkeypatch):
 
 @pytest.mark.notimpl(["dask", "duckdb"])
 @pytest.mark.xfail_version(pandas=["pyarrow>=13", "pandas>=2.1"])
+@pytest.mark.broken(
+    # TODO (mehmet): Check with the team.
+    ["flink"],
+    raises=Py4JJavaError,
+    reason="Cannot cast org.apache.flink.table.data.TimestampData to java.lang.Long",
+)
 def test_context_adjustment_filter_before_window(alltypes, context, monkeypatch):
     monkeypatch.setattr(ibis.options.context_adjustment, "time_col", "timestamp_col")
 
@@ -106,6 +124,11 @@ def test_context_adjustment_filter_before_window(alltypes, context, monkeypatch)
 
 
 @pytest.mark.notimpl(["duckdb", "pyspark"])
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=com.OperationNotDefinedError,
+    reason="No translation rule for <class 'ibis.expr.operations.structs.StructField'>",
+)
 def test_context_adjustment_multi_col_udf_non_grouped(alltypes, context, monkeypatch):
     monkeypatch.setattr(ibis.options.context_adjustment, "time_col", "timestamp_col")
 

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -4,6 +4,7 @@ import pandas.testing as tm
 import sqlalchemy as sa
 from pytest import mark, param
 
+import ibis.common.exceptions as com
 from ibis import _, udf
 
 no_python_udfs = mark.notimpl(
@@ -12,6 +13,7 @@ no_python_udfs = mark.notimpl(
         "clickhouse",
         "dask",
         "druid",
+        "flink",
         "impala",
         "mssql",
         "mysql",
@@ -25,6 +27,7 @@ no_python_udfs = mark.notimpl(
 @no_python_udfs
 @mark.notimpl(["pyspark"])
 @mark.notyet(["datafusion"], raises=NotImplementedError)
+@mark.notyet(["flink"], raises=com.OperationNotDefinedError)
 def test_udf(batting):
     @udf.scalar.python
     def num_vowels(s: str, include_y: bool = False) -> int:
@@ -83,6 +86,7 @@ def test_map_udf(batting):
     ["postgres"], raises=TypeError, reason="postgres only supports map<string, string>"
 )
 @mark.notimpl(["polars"])
+@mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
 @mark.notyet(["datafusion"], raises=NotImplementedError)
 @mark.notyet(["sqlite"], raises=TypeError, reason="sqlite doesn't support map types")
 def test_map_merge_udf(batting):
@@ -144,6 +148,11 @@ def add_one_pyarrow(s: int) -> int:  # s is series, int is the element type
     ["postgres"],
     raises=NotImplementedError,
     reason="postgres only supports Python-native UDFs",
+)
+@mark.notimpl(
+    ["flink"],
+    raises=com.OperationNotDefinedError,
+    reason="No translation rule for Pandas or PyArrow",
 )
 @mark.parametrize(
     "add_one",

--- a/ibis/backends/tests/test_uuid.py
+++ b/ibis/backends/tests/test_uuid.py
@@ -19,6 +19,7 @@ SQLALCHEMY2 = vparse(sqlalchemy.__version__) >= vparse("2")
 UUID_BACKEND_TYPE = {
     "bigquery": "STRING",
     "duckdb": "UUID",
+    "flink": "CHAR(36) NOT NULL",
     "sqlite": "text",
     "snowflake": "VARCHAR",
     "trino": "varchar(32)" if SQLALCHEMY2 else "uuid",
@@ -37,6 +38,7 @@ UUID_EXPECTED_VALUES = {
     "mssql": TEST_UUID,
     "dask": TEST_UUID,
     "oracle": TEST_UUID,
+    "flink": RAW_TEST_UUID,
 }
 
 pytestmark = pytest.mark.notimpl(


### PR DESCRIPTION
# Development notes

* `test_dot_sql.py`
  * **notimpl** Need to implement `Backend.sql()` for the Flink backend (or consider inheriting from `BaseSQLBackend`?); transpilation would further require a Flink SQLGlot dialect
* `test_column.py`
  * **notimpl** `ROWID` isn't defined for Flink
* `test_export.py`
  * **notimpl** PyArrow export needs to be implemented; Flink doesn't expose `Table.to_pyarrow()`; logic will need to be implemented like `Table.to_pandas()`, as in https://github.com/apache/flink/blob/release-1.17.1/flink-python/pyflink/table/table.py#L948 (or PyArrow export needs to be added upstream)
* `test_array.py` 
  * **notimpl** Flink does support arrays, but we need to load the `arraytypes` table in `conftest`, which we can most easily do once memtables are supported (from `ibis.backends.tests.data`)
* `test_dataframe_interchange.py`
  * **notimpl** depends on `Table.to_pyarrow()`, too
* `test_examples.py`
  * **notimpl**(?) I assume this needs some examples to be added in a bucket somewhere? Should this be `notimpl` or `notyet`? Seems like most of the `notyet` are for database backends, but not entirely sure on this one...
* `test_join.py`
  * **notyet** [Flink doesn't support semi joins, and it's not a priority to do so](https://issues.apache.org/jira/browse/FLINK-685)
  * **notyet**(?) Flink doesn't support anti joins
  * **notimpl** `test_join_with_pandas*` should work once `memtable` support is added
* `test_sql.py`
  * **notimpl** `UNNEST` not yet supported in backend
* `test_struct.py`
  * **notimpl** [`ROW` type is similar to the `STRUCT` type known from other non-standard-compliant frameworks](https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/dev/table/types/#row) (but not yet supported in backend)
* `test_string.py`
  * **notyet** `TRANSLATE` not yet supported in backend
  * **notyet** `FIND_IN_SET` not yet supported in backend
  * **broken** negative indexing is broken
  * **notimpl** `STRING_SPLIT` not yet supported in backend
  * **notimpl** `ARRAY_JOIN` not yet supported in backend
  * **notimpl** Levenshtein distance not supported in backend
* `test_numeric.py`
  * **notimpl** `IS_NAN` not yet supported in backend
  * **notimpl** `IS_INF` not yet supported in backend
  * **broken** [`SIGN` doesn't work on `TINYINT` (or `SMALLINT`)](https://apache-flink.slack.com/archives/C03G7LJTS2G/p1694066074658329)
  * **notyet** floating mod not yet supported in backend
  * **notyet** int division by int 0 isn't supported
  * **never** Flink isn't a SQLAlchemy backend
  * **never** Flink does not support 'MIN' or 'MAX' operation without specifying window (used in `histogram` implementation, but unbounded min/max doesn't make sense in a streaming context)
  * **notyet** [Flink doesn't implement bitwise operators yet](https://issues.apache.org/jira/browse/FLINK-6810)
* `test_generic.py`
  * **broken** [Flink runtime does not support untyped `NULL` values](https://nightlies.apache.org/flink/flink-docs-release-1.14/api/java/org/apache/flink/table/types/logical/NullType.html)
  * **broken** Sort on a non-time-attribute field is not supported.
  * **broken** NaN is not supported in Flink SQL
  * **notimpl** No SQLGlot dialect
  * **notimpl** Backend doesn't implement struct support yet
  * **notimpl** Backend doesn't implement deduplication yet (`test_distinct_keep*`), but [it's feasible](https://nightlies.apache.org/flink/flink-docs-release-1.17/docs/dev/table/sql/queries/deduplication/) (just very different from the default SQL implementation)
  * **notimpl** [`ops.Hash` implementation requires some thinking--here might be some weird impacts of using sha256 + a 64-bit sha256 hash is going to give back a much larger number than a 64bit integer](https://claypotai.slack.com/archives/C047W8D9674/p1695863030847869?thread_ts=1695860163.571209&cid=C047W8D9674)
* `test_aggregation.py`
  * **notimpl** Backend doesn't implement struct support yet 
  * **notyet** [Flink doesn't implement bitwise operators yet](https://issues.apache.org/jira/browse/FLINK-6810)
  * **notimpl** Backend doesn't implement deduplication yet (`test_reduction_ops[flink-no_cond-*]`, ), but it should be feasible (except `heavy`) (see `test_generic.py` notes)
  * **notyet** Attempted implementation of `_count_distinct_star`, but ran into, "We now only support the count of one field."