### PR TITLE
fix(sqlglot): ensure back compat for `DataTypeParam` import

### DIFF
--- a/ibis/backends/clickhouse/datatypes.py
+++ b/ibis/backends/clickhouse/datatypes.py
@@ -14,7 +14,12 @@ from ibis.formats.parser import TypeParser
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from sqlglot.expressions import DataTypeSize, Expression
+    from sqlglot.expressions import Expression
+
+    try:
+        from sqlglot.expressions import DataTypeParam
+    except ImportError:
+        from sqlglot.expressions import DataTypeSize as DataTypeParam
 
 
 def _bool_type() -> Literal["Bool", "UInt8", "Int8"]:
@@ -41,7 +46,7 @@ class ClickHouseTypeParser(TypeParser):
 
     @classmethod
     def _get_DATETIME(
-        cls, first: DataTypeSize | None = None, second: DataTypeSize | None = None
+        cls, first: DataTypeParam | None = None, second: DataTypeParam | None = None
     ) -> dt.Timestamp:
         if first is not None and second is not None:
             scale = first
@@ -57,7 +62,7 @@ class ClickHouseTypeParser(TypeParser):
 
     @classmethod
     def _get_DATETIME64(
-        cls, scale: DataTypeSize | None = None, timezone: DataTypeSize | None = None
+        cls, scale: DataTypeParam | None = None, timezone: DataTypeParam | None = None
     ) -> dt.Timestamp:
         return cls._get_TIMESTAMP(scale=scale, timezone=timezone)
 

--- a/ibis/formats/parser.py
+++ b/ibis/formats/parser.py
@@ -4,7 +4,7 @@ import abc
 from typing import TYPE_CHECKING
 
 import sqlglot as sg
-from sqlglot.expressions import ColumnDef, DataType, DataTypeSize
+from sqlglot.expressions import DataType
 
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
@@ -12,6 +12,13 @@ from ibis.common.collections import FrozenDict
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+    from sqlglot.expressions import ColumnDef
+
+    try:
+        from sqlglot.expressions import DataTypeParam
+    except ImportError:
+        from sqlglot.expressions import DataTypeSize as DataTypeParam
 
 SQLGLOT_TYPE_TO_IBIS_TYPE = {
     DataType.Type.BIGDECIMAL: dt.Decimal(76, 38),
@@ -151,7 +158,7 @@ class TypeParser(abc.ABC):
 
     @classmethod
     def _get_TIMESTAMP(
-        cls, scale: DataTypeSize | None = None, timezone: DataTypeSize | None = None
+        cls, scale: DataTypeParam | None = None, timezone: DataTypeParam | None = None
     ) -> dt.Timestamp:
         return dt.Timestamp(
             timezone=timezone if timezone is None else timezone.this.this,
@@ -160,7 +167,7 @@ class TypeParser(abc.ABC):
         )
 
     @classmethod
-    def _get_TIMESTAMPTZ(cls, scale: DataTypeSize | None = None) -> dt.Timestamp:
+    def _get_TIMESTAMPTZ(cls, scale: DataTypeParam | None = None) -> dt.Timestamp:
         return dt.Timestamp(
             timezone="UTC",
             scale=cls.default_temporal_scale if scale is None else int(scale.this.this),
@@ -168,7 +175,7 @@ class TypeParser(abc.ABC):
         )
 
     @classmethod
-    def _get_DATETIME(cls, scale: DataTypeSize | None = None) -> dt.Timestamp:
+    def _get_DATETIME(cls, scale: DataTypeParam | None = None) -> dt.Timestamp:
         return dt.Timestamp(
             timezone="UTC",
             scale=cls.default_temporal_scale if scale is None else int(scale.this.this),
@@ -176,14 +183,14 @@ class TypeParser(abc.ABC):
         )
 
     @classmethod
-    def _get_INTERVAL(cls, precision: DataTypeSize | None = None) -> dt.Interval:
+    def _get_INTERVAL(cls, precision: DataTypeParam | None = None) -> dt.Interval:
         if precision is None:
             precision = cls.default_interval_precision
         return dt.Interval(str(precision), nullable=cls.default_nullable)
 
     @classmethod
     def _get_DECIMAL(
-        cls, precision: DataTypeSize | None = None, scale: DataTypeSize | None = None
+        cls, precision: DataTypeParam | None = None, scale: DataTypeParam | None = None
     ) -> dt.Decimal:
         if precision is None:
             precision = cls.default_decimal_precision


### PR DESCRIPTION
Adds backcompat imports for some recently renamed objects in sqlglot 17.15.0. The TPC-H job exposed this failure because it has no dependency pins for better or worse.