### PR TITLE
chore(dev-deps): check poetry version when invoking `just lock`

### DIFF
--- a/justfile
+++ b/justfile
@@ -8,6 +8,12 @@ clean:
 
 # lock dependencies without updating existing versions
 lock:
+    #!/usr/bin/env bash
+    version="$(poetry --version)"
+    if ! grep -qP '\(version 1\.3\.\d+\)' <<< "${version}"; then
+        >&2 echo "poetry version must be 1.3.x, got ${version}"
+        exit 1
+    fi
     poetry lock --no-update
     poetry export --extras all --with dev --with test --with docs --without-hashes --no-ansi > requirements-dev.txt
 


### PR DESCRIPTION
Closes #6926.