### PR TITLE
fix(oracle): clarify sid vs service_name handling and allow dsn

### DIFF
--- a/ibis/backends/oracle/tests/conftest.py
+++ b/ibis/backends/oracle/tests/conftest.py
@@ -22,6 +22,12 @@ ORACLE_PASS = os.environ.get("IBIS_TEST_ORACLE_PASSWORD", "ibis")
 ORACLE_HOST = os.environ.get("IBIS_TEST_ORACLE_HOST", "localhost")
 ORACLE_PORT = int(os.environ.get("IBIS_TEST_ORACLE_PORT", 1521))
 
+# Creating test DB and user
+# The ORACLE_DB env-var needs to be set in the docker-compose.yml file
+# Then, after the container is running, exec in and run (from `/opt/oracle`)
+# ./createAppUser user pass ORACLE_DB
+# where ORACLE_DB is the same name you used in the docker-compose file.
+
 
 class TestConf(ServiceBackendTest, RoundHalfToEven):
     check_dtype = False


### PR DESCRIPTION
Maybe resolves #6913 

just so I don't forget this _again_:
A `sid` is a unique name of an INSTANCE running an oracle process (a single, identifiable machine).
A `service name` is an ALIAS to one (or many) individual instances that can be hotswapped without the client knowing / caring -- so a `service_name` might map to one or more `sid`s but this would be opaque to the user.
A `dsn` is a 'data source name' and is a very lispy connection definition that the oracle python clients can parse for things like `sid`, `service_name`, `host`, `port`, etc.

In order to allow for maximal connection flexibility, this PR lets users pass in a DSN directly, which will override every other keyword argument.  If they don't pass in a DSN, we construct one from the provided keyword arguments (like `host`, `port`, `sid`, `service_name`).

I've tested this locally and it seems to work (although I don't understand how to specify my machine as a `sid`, so that particular bit of functionality is untested).