### PR TITLE
chore(snowflake): patch `oscrypto` in the nix environment

### DIFF
--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -11,12 +11,6 @@ in
   # `wheel` cannot be used as a wheel to unpack itself, since that would
   # require itself (infinite recursion)
   wheel = super.wheel.override { preferWheel = false; };
-  paginate = super.paginate.overridePythonAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs or [ ] ++ [ self.setuptools ];
-  });
-  readtime = super.readtime.overridePythonAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs or [ ] ++ [ self.setuptools ];
-  });
 
   # patch oscrypto for openssl 3 support: the fix is to relax some regexes that
   # inspect the libcrypto version

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -17,6 +17,26 @@ in
   readtime = super.readtime.overridePythonAttrs (attrs: {
     nativeBuildInputs = attrs.nativeBuildInputs or [ ] ++ [ self.setuptools ];
   });
+
+  # patch oscrypto for openssl 3 support: the fix is to relax some regexes that
+  # inspect the libcrypto version
+  #
+  # without these patches applied, snowflake doesn't work in the nix environment
+  #
+  # these overrides can be removed when oscrypto is released again (1.3.0 was
+  # released on 2022-03-17)
+  oscrypto = (super.oscrypto.override { preferWheel = false; }).overridePythonAttrs (attrs: {
+    patches = attrs.patches or [ ] ++ [
+      (self.pkgs.fetchpatch {
+        url = "https://github.com/wbond/oscrypto/commit/ebbc944485b278192b60080ea1f495e287efb4f8.patch";
+        sha256 = "sha256-c1faM8szkn/7AjDthzmDisytzO8UdrzDtPkuuITjkRQ=";
+      })
+      (self.pkgs.fetchpatch {
+        url = "https://github.com/wbond/oscrypto/commit/d5f3437ed24257895ae1edd9e503cfb352e635a8.patch";
+        sha256 = "sha256-sRwxD99EV8mmiOAjM8emews9gvDeFtpBV3sSLiNEziM=";
+      })
+    ];
+  });
 } // super.lib.listToAttrs (
   map
     (name: {


### PR DESCRIPTION
This PR adds two tiny, related patches to `oscrypto` in the nix environment.

I discovered this problem by trying to run snowflake tests after a recent
nixpkgs update (ca2b0238b).

This update broke snowflake tests in the nix environment, due to a switch to
openssl 3 in that update.

Searching around the internets I found
https://github.com/dbt-labs/dbt-core/issues/3366, which led me to
https://github.com/wbond/oscrypto/issues/78 which is fixed upstream in
`oscrypto`.

Nix has a solid patching mechanism for doing post-install surgery on packages,
which I use here to apply two patches that address the regex-version-searching
bug (the root cause of the original failure).

We can remove these when the next version of `oscrypto` is released to PyPI.
