### PR TITLE
feat(api): `add Table.rename`, deprecate `Table.relabel`

### DIFF
--- a/ibis/backends/bigquery/client.py
+++ b/ibis/backends/bigquery/client.py
@@ -159,7 +159,7 @@ def rename_partitioned_column(table_expr, bq_table, partition_col):
     # is not _PARTITIONTIME
     if partition_col is None or partition_field != NATIVE_PARTITION_COL:
         return table_expr
-    return table_expr.relabel({NATIVE_PARTITION_COL: partition_col})
+    return table_expr.rename({partition_col: NATIVE_PARTITION_COL})
 
 
 def parse_project_and_dataset(project: str, dataset: str = "") -> tuple[str, str, str]:

--- a/ibis/backends/dask/tests/execution/test_join.py
+++ b/ibis/backends/dask/tests/execution/test_join.py
@@ -201,7 +201,7 @@ def test_join_with_post_expression_filter(how, left):
 def test_multi_join_with_post_expression_filter(how, left, df1):
     lhs = left[["key", "key2"]]
     rhs = left[["key2", "value"]]
-    rhs2 = left[["key2", "value"]].relabel({"value": "value2"})
+    rhs2 = left[["key2", "value"]].rename(value2="value")
 
     joined = lhs.join(rhs, "key2", how=how)
     projected = joined[lhs, rhs.value]

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -157,7 +157,7 @@ class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
     def _get_renamed_table(self, tablename: str) -> ir.Table:
         t = self.connection.table(tablename)
         original_names = self._get_original_column_names(tablename)
-        return t.relabel(dict(zip(t.columns, original_names)))
+        return t.rename(dict(zip(original_names, t.columns)))
 
     @property
     def batting(self) -> ir.Table:

--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -9,16 +9,6 @@ from ibis.backends.impala.compiler import ImpalaCompiler
 from ibis.backends.impala.tests.mocks import MockImpalaConnection
 
 
-def test_relabel_projection(snapshot):
-    # GH #551
-    types = ["int32", "string", "double"]
-    table = ibis.table(zip(["foo", "bar", "baz"], types), name="table")
-    relabeled = table.relabel({"foo": "one", "baz": "three"})
-
-    result = ImpalaCompiler.to_sql(relabeled)
-    snapshot.assert_match(result, "out.sql")
-
-
 @pytest.fixture(scope="module")
 def con():
     return MockImpalaConnection()

--- a/ibis/backends/pandas/tests/execution/test_join.py
+++ b/ibis/backends/pandas/tests/execution/test_join.py
@@ -146,7 +146,7 @@ def test_join_with_post_expression_filter(how, left):
 def test_multi_join_with_post_expression_filter(how, left, df1):
     lhs = left[["key", "key2"]]
     rhs = left[["key2", "value"]]
-    rhs2 = left[["key2", "value"]].relabel({"value": "value2"})
+    rhs2 = left[["key2", "value"]].rename(value2="value")
 
     joined = lhs.join(rhs, "key2", how=how)
     projected = joined[lhs, rhs.value]

--- a/ibis/backends/pyspark/tests/test_basic.py
+++ b/ibis/backends/pyspark/tests/test_basic.py
@@ -200,11 +200,11 @@ def test_alias_after_select(con):
         # new id != t['id']
         (lambda t: t.mutate(id=t["id"] + 1), 0, False),
         # new column id is selections[0], OK to replace since
-        # new id == t['id'] (relabel is a no-op)
-        (lambda t: t.relabel({"id": "id"}), 0, True),
+        # new id == t['id'] (rename is a no-op)
+        (lambda t: t.rename({"id": "id"}), 0, True),
         # new column id2 is selections[0], cannot be replaced since
         # id2 does not exist in the table
-        (lambda t: t.relabel({"id": "id2"}), 0, False),
+        (lambda t: t.rename({"id2": "id"}), 0, False),
     ],
 )
 def test_can_be_replaced_by_column_name(selection_fn, selection_idx, expected):

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -110,8 +110,8 @@ class TestConf(BackendTest, RoundAwayFromZero):
 
     def _remap_column_names(self, table_name: str) -> dict[str, str]:
         table = self.connection.table(table_name)
-        return table.relabel(
-            dict(zip(table.schema().names, TEST_TABLES[table_name].names))
+        return table.rename(
+            dict(zip(TEST_TABLES[table_name].names, table.schema().names))
         )
 
     @property

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1722,6 +1722,13 @@ class Table(Expr, _FixedTextJupyterMixin):
 
     projection = select
 
+    @util.deprecated(
+        as_of="7.0",
+        instead=(
+            "use `Table.rename` instead (if passing a mapping, note the meaning "
+            "of keys and values are swapped in Table.rename)."
+        ),
+    )
     def relabel(
         self,
         substitutions: Mapping[str, str]

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -378,22 +378,26 @@ def test_relabel():
     table = api.table({"x": "int32", "y": "string", "z": "double"})
 
     # Using a mapping
-    res = table.relabel({"x": "x_1", "y": "y_1"}).schema()
+    with pytest.warns(FutureWarning, match="Table.rename"):
+        res = table.relabel({"x": "x_1", "y": "y_1"}).schema()
     sol = sch.schema({"x_1": "int32", "y_1": "string", "z": "double"})
     assert_equal(res, sol)
 
     # Using a function
-    res = table.relabel(lambda x: None if x == "z" else f"{x}_1").schema()
+    with pytest.warns(FutureWarning, match="Table.rename"):
+        res = table.relabel(lambda x: None if x == "z" else f"{x}_1").schema()
     assert_equal(res, sol)
 
     # Using a format string
-    res = table.relabel("_{name}_")
-    sol = table.relabel({"x": "_x_", "y": "_y_", "z": "_z_"})
+    with pytest.warns(FutureWarning, match="Table.rename"):
+        res = table.relabel("_{name}_")
+        sol = table.relabel({"x": "_x_", "y": "_y_", "z": "_z_"})
     assert_equal(res, sol)
 
     # Mapping with unknown columns errors
     with pytest.raises(com.IbisTypeError, match="'missing' is not found in table"):
-        table.relabel({"missing": "oops"})
+        with pytest.warns(FutureWarning, match="Table.rename"):
+            table.relabel({"missing": "oops"})
 
 
 def test_rename():

--- a/ibis/tests/sql/test_compiler.py
+++ b/ibis/tests/sql/test_compiler.py
@@ -159,7 +159,7 @@ def test_agg_filter_with_alias(snapshot):
 def test_table_drop_with_filter(snapshot):
     left = ibis.table(
         [("a", "int64"), ("b", "string"), ("c", "timestamp")], name="t"
-    ).relabel({"c": "C"})
+    ).rename(C="c")
     left = left.filter(left.C == datetime.datetime(2018, 1, 1))
     left = left.drop("C")
     left = left.mutate(the_date=datetime.datetime(2018, 1, 1))


### PR DESCRIPTION
As suggested in #6801, this:

- Adds a new `Table.rename` method that accepts column names as `new_name="old_name"` kwargs. This new method also swaps the order of key-value pairs when passing a mapping as an argument to `{"new_name": "old_name"}` for consistency.
- Deprecates `Tabel.relabel` in favor of `Table.rename`.

Fixes #6801.