### PR TITLE
feat(api): add `Backend.rename_table` method

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -1000,6 +1000,20 @@ class BaseBackend(abc.ABC, _FileIOHandler):
             f'Backend "{self.name}" does not implement "drop_table"'
         )
 
+    def rename_table(self, old_name: str, new_name: str) -> None:
+        """Rename an existing table.
+
+        Parameters
+        ----------
+        old_name
+            The old name of the table.
+        new_name
+            The new name of the table.
+        """
+        raise NotImplementedError(
+            f'Backend "{self.name}" does not implement "rename_table"'
+        )
+
     @abc.abstractmethod
     def create_view(
         self,

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -32,6 +32,7 @@ from ibis.backends.base.sql.ddl import (
     DropDatabase,
     DropTable,
     DropView,
+    RenameTable,
     TruncateTable,
     fully_qualified_re,
     is_fully_qualified,
@@ -971,6 +972,19 @@ class Backend(BaseSQLBackend):
             Database name
         """
         statement = TruncateTable(name, database=database)
+        self._safe_exec_sql(statement)
+
+    def rename_table(self, old_name: str, new_name: str) -> None:
+        """Rename an existing table.
+
+        Parameters
+        ----------
+        old_name
+            The old name of the table.
+        new_name
+            The new name of the table.
+        """
+        statement = RenameTable(old_name, new_name)
         self._safe_exec_sql(statement)
 
     def drop_table_or_view(self, name, *, database=None, force=False):

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -13,12 +13,7 @@ import ibis.expr.types as ir
 from ibis import util
 from ibis.backends.base import Database
 from ibis.backends.base.sql.compiler import DDL, DML
-from ibis.backends.base.sql.ddl import (
-    AlterTable,
-    InsertSelect,
-    RenameTable,
-    fully_qualified_re,
-)
+from ibis.backends.base.sql.ddl import AlterTable, InsertSelect
 from ibis.backends.impala import ddl
 from ibis.backends.impala.compat import HS2Error, impyla
 
@@ -333,22 +328,6 @@ class ImpalaTable(ir.Table):
     @property
     def name(self) -> str:
         return self.op().name
-
-    def rename(self, new_name: str, database: str | None = None) -> ImpalaTable:
-        """Rename table inside Impala.
-
-        References to the old table are no longer valid.
-        """
-        m = fully_qualified_re.match(new_name)
-        if not m and database is None:
-            database = self._database
-        statement = RenameTable(
-            self.name, new_name, old_database=self._database, new_database=database
-        )
-        self._client._safe_exec_sql(statement)
-
-        op = self.op().copy(name=new_name, namespace=database)
-        return self.__class__(op)
 
     @property
     def is_partitioned(self):

--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -207,25 +207,6 @@ def test_drop_view(con, created_view):
     assert created_view not in con.list_tables()
 
 
-def test_rename_table(con, temp_database):
-    tmp_db = temp_database
-
-    orig_name = "tmp_rename_test"
-    con.create_table(orig_name, con.table("region"))
-    table = con.table(orig_name)
-
-    old_name = table.name
-
-    new_name = "rename_test"
-    renamed = table.rename(new_name, database=tmp_db)
-    renamed.execute()
-
-    t = con.table(new_name, database=tmp_db)
-    assert_equal(renamed, t)
-
-    assert table.name == old_name
-
-
 @pytest.fixture
 def path_uuid():
     return f"change-location-{util.guid()}"

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -507,6 +507,19 @@ class Backend(BaseSQLBackend, CanCreateDatabase):
         statement = DropTable(name, database=database, must_exist=not force)
         self.raw_sql(statement.compile())
 
+    def rename_table(self, old_name: str, new_name: str) -> None:
+        """Rename an existing table.
+
+        Parameters
+        ----------
+        old_name
+            The old name of the table.
+        new_name
+            The new name of the table.
+        """
+        statement = ddl.RenameTable(old_name, new_name)
+        self.raw_sql(statement.compile())
+
     def truncate_table(self, name: str, database: str | None = None) -> None:
         """Delete all rows from an existing table.
 

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -122,32 +122,6 @@ class PySparkTable(ir.Table):
         statement = ddl.InsertSelect(self._qualified_name, select, overwrite=overwrite)
         return self._client.raw_sql(statement.compile())
 
-    def rename(self, new_name: str) -> PySparkTable:
-        """Rename the table inside Spark.
-
-        References to the old table are no longer valid. Spark does not support
-        moving tables across databases using `rename`.
-
-        Parameters
-        ----------
-        new_name
-            New table name
-
-        Returns
-        -------
-        PySparkTable
-            Renamed spark table
-        """
-        new_qualified_name = self._client._fully_qualified_name(
-            new_name, self._database
-        )
-
-        statement = ddl.RenameTable(self.name, new_name)
-        self._client.raw_sql(statement.compile())
-
-        op = self.op().copy(name=new_qualified_name)
-        return type(self)(op)
-
     def alter(self, tbl_properties: Mapping[str, str] | None = None) -> Any:
         """Change settings and parameters of the table.
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -260,7 +260,6 @@ def test_create_temporary_table_from_schema(tmpcon, new_schema):
         "pandas",
         "polars",
         "postgres",
-        "pyspark",
         "snowflake",
         "sqlite",
         "trino",

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -253,7 +253,6 @@ def test_create_temporary_table_from_schema(tmpcon, new_schema):
         "datafusion",
         "druid",
         "duckdb",
-        "impala",
         "mssql",
         "mysql",
         "oracle",

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -251,26 +251,28 @@ def test_create_temporary_table_from_schema(tmpcon, new_schema):
         "clickhouse",
         "dask",
         "datafusion",
+        "druid",
         "duckdb",
-        "mysql",
-        "pandas",
-        "oracle",
-        "postgres",
-        "sqlite",
-        "snowflake",
-        "polars",
+        "impala",
         "mssql",
+        "mysql",
+        "oracle",
+        "pandas",
+        "polars",
+        "postgres",
+        "pyspark",
+        "snowflake",
+        "sqlite",
         "trino",
     ]
 )
-@mark.broken(["druid"], reason="sqlalchemy dialect is broken")
-def test_rename_table(con, temp_table, temp_table_orig, new_schema):
-    con.create_table(temp_table_orig, schema=new_schema)
-    t = con.table(temp_table_orig)
-    t.rename(temp_table)
-
-    assert con.table(temp_table) is not None
-    assert temp_table in con.list_tables()
+def test_rename_table(con, temp_table, temp_table_orig):
+    schema = ibis.schema({"a": "string", "b": "bool", "c": "int32"})
+    con.create_table(temp_table_orig, schema=schema)
+    con.rename_table(temp_table_orig, temp_table)
+    new = con.table(temp_table)
+    assert new.schema().equals(schema)
+    assert temp_table_orig not in con.list_tables()
 
 
 @mark.notimpl(["datafusion", "polars", "druid"])


### PR DESCRIPTION
- Adds a new `Backend.rename_table` method for renaming an existing table
- Implements this method for `impala` and `pyspark` alone
- Removes the existing `ImpalaTable.rename` method in favor of `Backend.rename_table`
- Removes the existing `PySparkTable.rename` method in favor of `Backend.rename_table`

Needed for #6959.