### PR TITLE
fix(pandas): make ibis compatible with pandas 2.1.0

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -425,13 +425,18 @@ class Backend(BaseBackend, CanCreateDatabase):
         **kwargs: Any,
     ):
         import pandas as pd
+        import pyarrow as pa
 
         if not isinstance(obj, pd.DataFrame):
             raise com.IbisError(
                 f"Invalid input type {type(obj)}; only pandas DataFrames are accepted as input"
             )
 
-        return self.con.insert_df(name, obj, settings=settings, **kwargs)
+        # TODO(cpcloud): add support for arrow tables
+        # TODO(cpcloud): insert_df doesn't work with pandas 2.1.0, move back to
+        # that (maybe?) when `clickhouse_connect` is fixed
+        t = pa.Table.from_pandas(obj)
+        return self.con.insert_arrow(name, t, settings=settings, **kwargs)
 
     def raw_sql(
         self,

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -140,7 +140,7 @@ def test_insert_with_less_columns(con, temporary_alltypes, df):
     records = df.loc[:10, ["string_col"]].copy()
     records["date_col"] = None
 
-    with pytest.raises(cc.driver.exceptions.ProgrammingError):
+    with pytest.raises(cc.driver.exceptions.DatabaseError):
         con.insert(temporary.op().name, records)
 
 
@@ -149,7 +149,7 @@ def test_insert_with_more_columns(con, temporary_alltypes, df):
     records = df[:10].copy()
     records["non_existing_column"] = "raise on me"
 
-    with pytest.raises(cc.driver.exceptions.ProgrammingError):
+    with pytest.raises(cc.driver.exceptions.DatabaseError):
         con.insert(temporary.op().name, records)
 
 

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -380,7 +380,9 @@ def test_asof_join(time_left, time_right):
     expected = pd.merge_asof(
         time_left.execute(), time_right.execute(), on="time", suffixes=("", "_right")
     )
-    tm.assert_frame_equal(result[expected.columns], expected)
+    tm.assert_frame_equal(
+        result[expected.columns].fillna(pd.NA), expected.fillna(pd.NA)
+    )
 
 
 def test_count_name(snapshot):

--- a/ibis/backends/clickhouse/tests/test_types.py
+++ b/ibis/backends/clickhouse/tests/test_types.py
@@ -28,7 +28,7 @@ def test_columns_types_with_additional_argument(con):
     ]
     df = con.sql(f"SELECT {', '.join(sql_types)}").execute()
     assert df.fixedstring_col.dtype.name == "object"
-    assert df.datetime_col.dtype.name == "datetime64[s, UTC]"
+    assert df.datetime_col.dtype.name in ("datetime64[ns, UTC]", "datetime64[s, UTC]")
     assert df.datetime_ns_col.dtype.name == "datetime64[ns, UTC]"
 
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -227,6 +227,10 @@ WHERE catalog_name = :database"""
                 dbapi_connection.execute("SET enable_progress_bar = false")
 
         self._record_batch_readers_consumed = {}
+
+        with contextlib.suppress(duckdb.InvalidInputException):
+            duckdb.execute("SELECT ?", (1,))
+
         super().do_connect(engine)
 
     def _load_extensions(self, extensions):

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -228,6 +228,8 @@ WHERE catalog_name = :database"""
 
         self._record_batch_readers_consumed = {}
 
+        # TODO(cpcloud): remove this when duckdb is >0.8.1
+        # this is here to workaround https://github.com/duckdb/duckdb/issues/8735
         with contextlib.suppress(duckdb.InvalidInputException):
             duckdb.execute("SELECT ?", (1,))
 

--- a/ibis/backends/impala/tests/test_pandas_interop.py
+++ b/ibis/backends/impala/tests/test_pandas_interop.py
@@ -169,7 +169,7 @@ def test_insert(con, temp_table_db, exhaustive_df):
     table = con.table(table_name, database=tmp_db)
 
     result = table.execute().sort_values(by="tinyint_col").reset_index(drop=True)
-    tm.assert_frame_equal(result, exhaustive_df)
+    tm.assert_frame_equal(result.fillna(pd.NA), exhaustive_df.fillna(pd.NA))
 
 
 def test_round_trip_exhaustive(con, exhaustive_df):
@@ -182,7 +182,7 @@ def _check_roundtrip(con, df):
 
     table = writer.delimited_table(path)
     df2 = table.execute()
-    tm.assert_frame_equal(df2, df)
+    tm.assert_frame_equal(df2.fillna(pd.NA), df.fillna(pd.NA))
 
 
 def test_timestamp_with_timezone():

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -588,7 +588,10 @@ def execute_aggregation_dataframe(
             )
             for key in op.by
         ]
-        source = data.groupby(grouping_keys, group_keys=False)
+        source = data.groupby(
+            grouping_keys[0] if len(grouping_keys) == 1 else grouping_keys,
+            group_keys=False,
+        )
     else:
         source = data
 

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -584,7 +584,11 @@ def test_where_series(t, df, left_f, right_f):
         left = pd.Series(np.repeat(left, len(cond)), name=cond.name)
     expected = left.where(cond, right_f(series))
 
-    tm.assert_series_equal(result, expected, check_dtype=False)
+    tm.assert_series_equal(
+        result.astype(object).fillna(pd.NA),
+        expected.astype(object).fillna(pd.NA),
+        check_dtype=False,
+    )
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1226,7 +1226,7 @@ def test_group_concat(
     result = expr.execute()
     expected = expected_fn(df, pandas_cond(df), pandas_sep)
 
-    backend.assert_frame_equal(result, expected)
+    backend.assert_frame_equal(result.fillna(pd.NA), expected.fillna(pd.NA))
 
 
 @mark.notimpl(

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -455,7 +455,9 @@ def test_unnest_default_name(backend):
 
     result = expr.name("x").execute()
     expected = df.x.map(lambda x: x + [1]).explode("x")
-    tm.assert_series_equal(result, expected, check_dtype=False)
+    tm.assert_series_equal(
+        result.astype(object).fillna(pd.NA), expected.fillna(pd.NA), check_dtype=False
+    )
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -924,7 +924,10 @@ def test_memtable_bool_column(backend, con):
 
 @pytest.mark.broken(
     ["druid"],
-    raises=AssertionError,
+    raises=(
+        TypeError,  # pandas >=2.1.0
+        AssertionError,  # pandas <2.1.0
+    ),
     reason="result contains empty strings instead of None",
 )
 def test_memtable_construct(backend, con, monkeypatch):
@@ -940,7 +943,9 @@ def test_memtable_construct(backend, con, monkeypatch):
         }
     )
     t = ibis.memtable(pa_t)
-    backend.assert_frame_equal(t.execute(), pa_t.to_pandas())
+    backend.assert_frame_equal(
+        t.execute().fillna(pd.NA), pa_t.to_pandas().fillna(pd.NA)
+    )
 
 
 @pytest.mark.notimpl(

--- a/ibis/backends/tests/test_json.py
+++ b/ibis/backends/tests/test_json.py
@@ -41,7 +41,7 @@ pytestmark = [
 def test_json_getitem(json_t, expr_fn, expected):
     expr = expr_fn(json_t)
     result = expr.execute()
-    tm.assert_series_equal(result, expected)
+    tm.assert_series_equal(result.fillna(pd.NA), expected.fillna(pd.NA))
 
 
 @pytest.mark.notimpl(["dask", "mysql", "pandas"])

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 
+import pandas as pd
 import pytest
 import sqlalchemy as sa
 from pytest import param
@@ -882,7 +883,7 @@ def test_substr_with_null_values(backend, alltypes, df):
     expected.loc[mask, "substr_col_null"] = None
     expected["substr_col_null"] = expected["substr_col_null"].str.slice(0, 2)
 
-    backend.assert_frame_equal(result, expected)
+    backend.assert_frame_equal(result.fillna(pd.NA), expected.fillna(pd.NA))
 
 
 @pytest.mark.parametrize(

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -24,11 +24,11 @@ if not _has_arrow_dtype:
 class PandasType(NumpyType):
     @classmethod
     def to_ibis(cls, typ, nullable=True):
-        if pdt.is_datetime64tz_dtype(typ):
+        if isinstance(typ, pdt.DatetimeTZDtype):
             return dt.Timestamp(timezone=str(typ.tz), nullable=nullable)
         elif pdt.is_datetime64_dtype(typ):
             return dt.Timestamp(nullable=nullable)
-        elif pdt.is_categorical_dtype(typ):
+        elif isinstance(typ, pdt.CategoricalDtype):
             return dt.String(nullable=nullable)
         elif pdt.is_extension_array_dtype(typ):
             if _has_arrow_dtype and isinstance(typ, pd.ArrowDtype):
@@ -162,15 +162,11 @@ class PandasData(DataMapper):
 
     @staticmethod
     def convert_Timestamp(s, dtype, pandas_type):
-        import pandas.api.types as pdt
-
-        if pdt.is_datetime64tz_dtype(s.dtype):
+        if isinstance(dtype, pd.DatetimeTZDtype):
             return s.dt.tz_convert(dtype.timezone)
         elif pdt.is_datetime64_dtype(s.dtype):
             return s.dt.tz_localize(dtype.timezone)
         else:
-            import pandas as pd
-
             try:
                 return s.astype(pandas_type)
             except pd.errors.OutOfBoundsDatetime:  # uncovered
@@ -188,9 +184,7 @@ class PandasData(DataMapper):
 
     @staticmethod
     def convert_Date(s, dtype, pandas_type):
-        import pandas.api.types as pdt
-
-        if pdt.is_datetime64tz_dtype(s.dtype):
+        if isinstance(s.dtype, pd.DatetimeTZDtype):
             s = s.dt.tz_convert("UTC").dt.tz_localize(None)
         return s.astype(pandas_type, errors="ignore").dt.normalize()
 

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import hypothesis as h
 import hypothesis.extra.pandas as past
 import hypothesis.extra.pytz as tzst
@@ -249,5 +251,8 @@ def memtable(draw, schema=schema(primitive_dtypes)):  # noqa: B008
     columns = [past.column(name, dtype=dtype) for name, dtype in schema.to_pandas()]
     dataframe = past.data_frames(columns=columns)
 
-    df = draw(dataframe)
+    with warnings.catch_warnings():
+        # TODO(cpcloud): pandas 2.1.0 junk
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        df = draw(dataframe)
     return ibis.memtable(df)


### PR DESCRIPTION
This PR makes ibis compatible with pandas 2.1.0.

Unfortunately at least one hack was required due to duckdb's aggressive imports
when using bind parameters with arrow output reported in https://github.com/duckdb/duckdb/issues/8735.

`clickhouse_connect` is using a removed API as well. The workaround there was
easy: use `insert_arrow` instead of `insert_df`. Filed an issue there too: https://github.com/ClickHouse/clickhouse-connect/issues/234

`hypothesis` is another one that is using a removed API (`is_categorical_dtype`).