### PR TITLE
docs(quarto): make sure blog post titles are readable in light mode

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -14,4 +14,8 @@ reference/
 objects.json
 *support_matrix.csv
 
+# generated notebooks and files
+*.ipynb
+*_files
+
 /.quarto/

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -124,9 +124,8 @@ website:
 format:
   html:
     theme:
-      light: flatly
+      light: [flatly, theme-light.scss]
       dark: [darkly, theme-dark.scss]
-    css: styles.css
     toc: true
 
 quartodoc:

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,1 +1,0 @@
-/* css styles */

--- a/docs/theme-light.scss
+++ b/docs/theme-light.scss
@@ -1,0 +1,4 @@
+/*-- scss:rules --*/
+.quarto-title-banner .quarto-title .title {
+    color: #ccd1d5;
+}


### PR DESCRIPTION
Fixes #6982.

![image](https://github.com/ibis-project/ibis/assets/417981/f6c61362-7704-4493-8f77-52fd153a41ee)
