### PR TITLE
build: bump the major version to ensure that prereleases are always sorted after existing versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -532,7 +532,8 @@ enable = true
 dirty = true
 style = "pep440"
 pattern = '^(?P<base>\d+(\.\d+)*)'
-format-jinja = "{% if distance == 0 %}{{ base }}{% else %}{{ bump_version(base) }}.dev{{ distance }}{% endif %}"
+# index=0 bumps the major version, to handle backports that occur after a breaking change commit
+format-jinja = "{% if distance == 0 %}{{ base }}{% else %}{{ bump_version(base, index=0) }}.dev{{ distance }}{% endif %}"
 
 [build-system]
 requires = ["poetry-core>=1.1.0", "poetry-dynamic-versioning"]


### PR DESCRIPTION
This PR changes pre-release versions to always start with the next major version, so that any releases in between major releases such as backports (#6980) will not be sorted _after_ a pre-release.

The change is visible by running `poetry build` from this PR's commit:

```
❯ poetry build
Building ibis-framework (7.0.0.dev217)
  - Building sdist
  - Built ibis_framework-7.0.0.dev217.tar.gz
  - Building wheel
  - Built ibis_framework-7.0.0.dev217-py3-none-any.whl
```

Note the 7.0.0 prefix.
