### PR TITLE
docs: fix whitespace issue on homepage

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -341,6 +341,8 @@ px.scatter_3d(  # <6>
 
 :::
 
+###
+
 <div class="d-grid gap-2"><a class="btn btn-lg btn-primary" data-bs-toggle="collapse" href="#collapseInputOutput" role="button" aria-expanded="false" aria-controls="collapseInputOutput">Show input and output</a></div>
 
 ###


### PR DESCRIPTION
adds a break after the 3d scatter plot before the button
