### PR TITLE
docs: fix self and external links

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -238,12 +238,10 @@ quartodoc:
       desc: ""
       package: ibis
       contents:
-        # # Column Selectors
+        # Column Selectors
         - selectors
 
-        # # Schemas
-        #
-        # This module contains APIs for interacting with table schemas.
+        # Schemas
         - expr.schema.Schema
 
         # # Configuration Options
@@ -252,11 +250,5 @@ quartodoc:
         - config.SQL
         - config.ContextAdjustment
 
-        # # Data Types
-        #
-        # This module contains classes for handling the different logical types that
-        # occur in databases.
-        #
-        # All data type constructors take a `nullable: bool` parameter whose default
-        # value is [`True`][True].
+        # Data types
         - expr.datatypes.core

--- a/docs/backends/impala.qmd
+++ b/docs/backends/impala.qmd
@@ -107,8 +107,6 @@ render_methods(
     "truncate_table",
     "get_schema",
     "cache_table",
-    "set_options",
-    "set_compression_codec",
 )
 ```
 
@@ -128,7 +126,6 @@ render_methods(
     "partition_schema",
     "partitions",
     "refresh",
-    "stats",
     "describe_formatted",
 )
 ```

--- a/docs/concepts/internals.qmd
+++ b/docs/concepts/internals.qmd
@@ -25,7 +25,8 @@ The internals are designed to map the Ibis API to the backend.
 ## Expressions
 
 The main user-facing component of Ibis is expressions. The base class of all
-expressions in Ibis is the [ibis.expr.types.Expr][] class.
+expressions in Ibis is the
+[`Expr`](../reference/expression-generic.qmd#ibis.expr.types.core.Expr) class.
 
 Expressions provide the user facing API, most of which is defined in
 `ibis/expr/api.py`.
@@ -37,25 +38,19 @@ inputs to `ibis.expr.types.Node` subclasses. Upon construction of a `Node`
 subclass, Ibis performs validation of every input to the node based on the rule
 that was used to declare the input.
 
-Rules are defined in `ibis.expr.rules`
+Rules are defined in `ibis.expr.rules`.
 
-<!-- prettier-ignore-start -->
-### The [`Expr`][ibis.expr.types.Expr] class
-<!-- prettier-ignore-end -->
+### The [`Expr`](../reference/expression-generic.qmd#ibis.expr.types.core.Expr) class
 
 Expressions are a thin but important abstraction over operations, containing
 only type information and shape information, i.e., whether they are tables,
 columns, or scalars.
 
-<!-- prettier-ignore-start -->
 Examples of expression types include
-[`StringValue`][ibis.expr.types.StringValue] and
-[`Table`][ibis.expr.types.Table].
-<!-- prettier-ignore-end -->
+[`StringValue`](../reference/expression-strings.qmd#ibis.expr.types.strings.StringValue) and
+[`Table`](../reference/expression-tables.qmd#ibis.expr.types.relations.Table).
 
-<!-- prettier-ignore-start -->
 ### The `ibis.expr.types.Node` Class
-<!-- prettier-ignore-end -->
 
 `Node` subclasses make up the core set of operations of Ibis. Each node
 corresponds to a particular operation.

--- a/docs/posts/_metadata.yml
+++ b/docs/posts/_metadata.yml
@@ -2,7 +2,7 @@
 
 # freeze computational output
 # (see https://quarto.org/docs/projects/code-execution.html#freeze)
-freeze: true
+freeze: auto
 
 # Enable banner style title blocks
 title-block-banner: true
@@ -11,6 +11,5 @@ title-block-banner: true
 comments:
   giscus:
     repo: ibis-project/ibis
-    theme: light
     category: Q&A
     reactions-enabled: false

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -132,10 +132,10 @@ class BaseSQLBackend(BaseBackend):
         """Execute a query string and return the cursor used for execution.
 
         ::: {.callout-tip}
-        ## Consider using [`.sql`][ibis.backends.base.sql.BaseSQLBackend.sql] instead
+        ## Consider using [`.sql`](#ibis.backends.base.sql.BaseSQLBackend.sql) instead
 
         If your query is a SELECT statement, you should use the
-        [`.sql`][ibis.backends.base.sql.BaseSQLBackend.sql] method to avoid
+        [backend `.sql`](#ibis.backends.base.sql.BaseSQLBackend.sql) method to avoid
         having to release the cursor returned from this method manually.
 
         ::: {.callout-warning collapse="true"}

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -691,13 +691,15 @@ WHERE catalog_name = :database"""
         )
         return self._filter_with_like(tables + views + temp_views, like)
 
-    def read_postgres(self, uri, table_name: str | None = None, schema: str = "public"):
+    def read_postgres(
+        self, uri: str, table_name: str | None = None, schema: str = "public"
+    ) -> ir.Table:
         """Register a table from a postgres instance into a DuckDB table.
 
         Parameters
         ----------
         uri
-            The postgres URI in form 'postgres://user:password@host:port'
+            A postgres URI of the form `postgres://user:password@host:port`
         table_name
             The table to read
         schema

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -918,7 +918,7 @@ class Backend(BaseSQLBackend):
         """Insert data into an existing table.
 
         See
-        [`ImpalaTable.insert`][ibis.backends.impala.client.ImpalaTable.insert]
+        [`ImpalaTable.insert`](../backends/impala.qmd#ibis.backends.impala.client.ImpalaTable.insert)
         for parameters.
 
         Examples

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -48,7 +48,7 @@ class PySparkTable(ir.Table):
 
         See Also
         --------
-        [`ibis.backends.spark.Backend.compute_stats`][ibis.backends.spark.Backend.compute_stats]
+        [`pyspark.Backend.compute_stats`](../backends/pyspark.qmd#ibis.backends.pyspark.Backend.compute_stats)
         """
         return self._client.compute_stats(self._qualified_name, noscan=noscan)
 

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -62,7 +62,7 @@ class SQL(Config):
     ----------
     default_limit : int | None
         Number of rows to be retrieved for a table expression without an
-        explicit limit. [`None`][None] means no limit.
+        explicit limit. [](`None`) means no limit.
     default_dialect : str
         Dialect to use for printing SQL when the backend cannot be determined.
     """
@@ -138,7 +138,7 @@ class Options(Config):
     repr : Repr
         Options controlling expression printing.
     verbose : bool
-        Run in verbose mode if [`True`][True]
+        Run in verbose mode if [](`True`)
     verbose_log: Callable[[str], None] | None
         A callable to use when logging.
     graphviz_repr : bool

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -236,7 +236,7 @@ def schema(
     names: Iterable[str] | None = None,
     types: Iterable[str | dt.DataType] | None = None,
 ) -> sch.Schema:
-    """Validate and return a [`Schema`][ibis.expr.schema.Schema] object.
+    """Validate and return a [`Schema`](./expr.schema.Schema.qmd#ibis.expr.schema.Schema) object.
 
     Parameters
     ----------
@@ -342,10 +342,10 @@ def memtable(
         Do not depend on the underlying storage type (e.g., pyarrow.Table), it's subject
         to change across non-major releases.
     columns
-        Optional [`Iterable`][typing.Iterable] of [`str`][str] column names.
+        Optional [](`typing.Iterable`) of [](`str`) column names.
     schema
-        Optional [`Schema`][ibis.expr.schema.Schema]. The functions use `data`
-        to infer a schema if not passed.
+        Optional [`Schema`](./expr.schema.Schema.qmd#ibis.expr.schema.Schema).
+        The functions use `data` to infer a schema if not passed.
     name
         Optional name of the table.
 
@@ -586,7 +586,7 @@ def or_(*predicates: ir.BooleanValue) -> ir.BooleanValue:
 def random() -> ir.FloatingScalar:
     """Return a random floating point number in the range [0.0, 1.0).
 
-    Similar to [`random.random`][random.random] in the Python standard library.
+    Similar to [](`random.random`) in the Python standard library.
 
     Returns
     -------

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -89,7 +89,7 @@ del dtype.register
 class DataType(Concrete, Coercible):
     """Base class for all data types.
 
-    [`DataType`][ibis.expr.datatypes.DataType] instances are immutable.
+    Instances are immutable.
     """
 
     nullable: bool = True
@@ -473,7 +473,7 @@ class Null(Primitive):
 
 @public
 class Boolean(Primitive):
-    """[`True`][True] or [`False`][False] values."""
+    """[](`True`) or [](`False`) values."""
 
     scalar = "BooleanScalar"
     column = "BooleanColumn"

--- a/ibis/expr/datatypes/parse.py
+++ b/ibis/expr/datatypes/parse.py
@@ -32,7 +32,7 @@ from ibis.common.parsing import (
 def parse(
     text: str, default_decimal_parameters: tuple[int | None, int | None] = (None, None)
 ) -> dt.DataType:
-    """Parse a type from a [`str`][str] `text`.
+    """Parse a type from a [](`str`) `text`.
 
     The default `maxsize` parameter for caching is chosen to cache the most
     commonly used types--there are about 30--along with some capacity for less

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -39,7 +39,7 @@ def infer(value: Any) -> dt.DataType:
 # which should trigger infer_map instead
 @infer.register(collections.OrderedDict)
 def infer_struct(value: Mapping[str, Any]) -> dt.Struct:
-    """Infer the [`Struct`][ibis.expr.datatypes.Struct] type of `value`."""
+    """Infer the [`Struct`](./expr.datatypes.core.qmd#ibis.expr.datatypes.Struct) type of `value`."""
     if not value:
         raise TypeError("Empty struct type not supported")
     fields = {name: infer(val) for name, val in value.items()}
@@ -48,7 +48,7 @@ def infer_struct(value: Mapping[str, Any]) -> dt.Struct:
 
 @infer.register(collections.abc.Mapping)
 def infer_map(value: Mapping[Any, Any]) -> dt.Map:
-    """Infer the [`Map`][ibis.expr.datatypes.Map] type of `value`."""
+    """Infer the [`Map`](./expr.datatypes.core.qmd#ibis.expr.datatypes.Map) type of `value`."""
     if not value:
         return dt.Map(dt.null, dt.null)
     try:
@@ -62,7 +62,7 @@ def infer_map(value: Mapping[Any, Any]) -> dt.Map:
 
 @infer.register((list, tuple, set, frozenset))
 def infer_list(values: Sequence[Any]) -> dt.Array:
-    """Infer the [`Array`][ibis.expr.datatypes.Array] type of `value`."""
+    """Infer the [`Array`](./expr.datatypes.core.qmd#ibis.expr.datatypes.Array) type of `value`."""
     if not values:
         return dt.Array(dt.null)
     return dt.Array(highest_precedence(map(infer, values)))
@@ -140,7 +140,7 @@ def infer_enum(_: enum.Enum) -> dt.String:
 
 @infer.register(decimal.Decimal)
 def infer_decimal(value: decimal.Decimal) -> dt.Decimal:
-    """Infer the [`Decimal`][ibis.expr.datatypes.Decimal] type of `value`."""
+    """Infer the [`Decimal`](./expr.datatypes.core.qmd#ibis.expr.datatypes.Decimal) type of `value`."""
     return dt.decimal
 
 

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -20,8 +20,9 @@ class Schema(Concrete, Coercible, MapSet):
     """An object for holding table schema information."""
 
     fields: FrozenDict[str, dt.DataType]
-    """A mapping of [`str`][str] to [`DataType`][ibis.expr.datatypes.DataType] objects
-    representing the type of each column."""
+    """A mapping of [](`str`) to
+    [`DataType`](./expr.datatypes.core.qmd#ibis.expr.datatypes.DataType)
+    objects representing the type of each column."""
 
     def __repr__(self) -> str:
         space = 2 + max(map(len, self.names), default=0)

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -64,10 +64,10 @@ class ArrayValue(Value):
         Returns
         -------
         Value
-            - If `index` is an [`int`][int] or
-              [`IntegerValue`][ibis.expr.types.IntegerValue] then the return
-              type is the element type of `self`.
-            - If `index` is a [`slice`][slice] then the return type is the same
+            - If `index` is an [](`int`) or
+              [`IntegerValue`](./expression-numeric.qmd#ibis.expr.types.IntegerValue)
+              then the return type is the element type of `self`.
+            - If `index` is a [](`slice`) then the return type is the same
               type as the input.
 
         Examples
@@ -351,7 +351,7 @@ class ArrayValue(Value):
 
         See Also
         --------
-        [`StringValue.join`][ibis.expr.types.strings.StringValue.join]
+        [`StringValue.join`](./expression-strings.qmd#ibis.expr.types.strings.StringValue.join)
         """
         return ops.ArrayStringJoin(sep, self).to_expr()
 

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -171,7 +171,7 @@ class Expr(Immutable, Coercible):
         label_edges
             Show operation input names as edge labels
         verbose
-            Print the graphviz DOT code to stderr if [`True`][True]
+            Print the graphviz DOT code to stderr if [](`True`)
 
         Raises
         ------
@@ -260,10 +260,10 @@ class Expr(Immutable, Coercible):
         Parameters
         ----------
         use_default
-            If [`True`][True] and the default backend isn't set, initialize the
+            If [](`True`) and the default backend isn't set, initialize the
             default backend and use that. This should only be set to `True` for
             `.execute()`. For other contexts such as compilation, this option
-            doesn't make sense so the default value is [`False`][False].
+            doesn't make sense so the default value is [](`False`).
 
         Returns
         -------
@@ -566,8 +566,7 @@ def _binop(op_class: type[ops.Binary], left: ir.Value, right: ir.Value) -> ir.Va
     Parameters
     ----------
     op_class
-        The [`Binary`][ibis.expr.operations.Binary] subclass for the
-        operation
+        The `ops.Binary` subclass for the operation
     left
         Left operand
     right

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -906,7 +906,7 @@ class Value(Expr):
         Parameters
         ----------
         kwargs
-            Same as keyword arguments to [`execute`][ibis.expr.types.core.Expr.execute]
+            Same as keyword arguments to [`execute`](#ibis.expr.types.core.Expr.execute)
 
         Examples
         --------
@@ -1626,9 +1626,9 @@ def literal(value: Any, type: dt.DataType | str | None = None) -> Scalar:
     Ibis supports literal construction of arrays using the following
     functions:
 
-    1. [`ibis.array`][ibis.array]
-    1. [`ibis.struct`][ibis.struct]
-    1. [`ibis.map`][ibis.map]
+    1. [`ibis.array`](./expression-collections.qmd#ibis.array)
+    1. [`ibis.struct`](./expression-collections.qmd#ibis.struct)
+    1. [`ibis.map`](./expression-collections.qmd#ibis.map)
 
     Constructing these types using `literal` will be deprecated in a future
     release.
@@ -1639,7 +1639,7 @@ def literal(value: Any, type: dt.DataType | str | None = None) -> Scalar:
     value
         A Python value
     type
-        An instance of [`DataType`][ibis.expr.datatypes.DataType] or a string
+        An instance of [`DataType`](./expr.datatypes.core.qmd#ibis.expr.datatypes.DataType) or a string
         indicating the ibis type of `value`. This parameter can be used
         in cases where ibis's type inference isn't sufficient for discovering
         the type of `value`.

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -215,7 +215,7 @@ class GroupedTable:
 
         See Also
         --------
-        [`GroupedTable.mutate`][ibis.expr.types.groupby.GroupedTable.mutate]
+        [`GroupedTable.mutate`](#ibis.expr.types.groupby.GroupedTable.mutate)
         """
         exprs = self._selectables(*exprs, **kwexprs)
         return self.table.select(exprs)
@@ -225,7 +225,7 @@ class GroupedTable:
 
         See Also
         --------
-        [`GroupedTable.mutate`][ibis.expr.types.groupby.GroupedTable.mutate]
+        [`GroupedTable.mutate`](#ibis.expr.types.groupby.GroupedTable.mutate)
         """
         table = self.table
         default_frame = self._get_window()

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -77,12 +77,10 @@ class NumericValue(Value):
             Here's how the `digits` parameter affects the expression output
             type:
 
-            |   `digits`    | `self.type()` |  Output   |
-            | :-----------: | :-----------: | :-------: |
-            | `None` or `0` |   `decimal`   | `decimal` |
-            |    Nonzero    |   `decimal`   | `decimal` |
-            | `None` or `0` |   Floating    |  `int64`  |
-            |    Nonzero    |   Floating    | `float64` |
+            - `digits` is `False`-y; `self.type()` is `decimal` → `decimal`
+            -   `digits` is nonzero; `self.type()` is `decimal` → `decimal`
+            - `digits` is `False`-y; `self.type()` is Floating  → `int64`
+            -   `digits` is nonzero; `self.type()` is Floating  → `float64`
 
         Returns
         -------

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -825,7 +825,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`ibis.difference`][ibis.difference]
+        [`ibis.difference`](./top_level.qmd#ibis.difference)
 
         Returns
         -------
@@ -1064,7 +1064,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         >>> t.count()
         344
 
-        You can pass [`selectors`][ibis.selectors] to `on`
+        You can pass [`selectors`](./selectors.qmd) to `on`
 
         >>> t.distinct(on=~s.numeric())
         ┏━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━┓
@@ -1132,7 +1132,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         """Select `n` rows from `self` starting at `offset`.
 
         ::: {.callout-note}
-        ## The result set is not deterministic without a call to [`order_by`][ibis.expr.types.relations.Table.order_by].
+        ## The result set is not deterministic without a call to [`order_by`](#ibis.expr.types.relations.Table.order_by).
         :::
 
         Parameters
@@ -1187,7 +1187,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`Table.order_by`][ibis.expr.types.relations.Table.order_by]
+        [`Table.order_by`](#ibis.expr.types.relations.Table.order_by)
         """
         return ops.Limit(self, n, offset).to_expr()
 
@@ -1195,7 +1195,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         """Select the first `n` rows of a table.
 
         ::: {.callout-note}
-        ## The result set is not deterministic without a call to [`order_by`][ibis.expr.types.relations.Table.order_by].
+        ## The result set is not deterministic without a call to [`order_by`](#ibis.expr.types.relations.Table.order_by).
         :::
 
         Parameters
@@ -1235,8 +1235,8 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`Table.limit`][ibis.expr.types.relations.Table.limit]
-        [`Table.order_by`][ibis.expr.types.relations.Table.order_by]
+        [`Table.limit`](#ibis.expr.types.relations.Table.limit)
+        [`Table.order_by`](#ibis.expr.types.relations.Table.order_by)
         """
         return self.limit(n=n)
 
@@ -1328,7 +1328,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`ibis.union`][ibis.union]
+        [`ibis.union`](./top_level.qmd#ibis.union)
 
         Examples
         --------
@@ -1402,7 +1402,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`ibis.intersect`][ibis.intersect]
+        [`ibis.intersect`](./top_level.qmd#ibis.intersect)
 
         Examples
         --------
@@ -2375,7 +2375,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`StructValue.lift`][ibis.expr.types.structs.StructValue.lift]
+        [`StructValue.lift`](./expression-collections.qmd#ibis.expr.types.structs.StructValue.lift)
         """
         columns_to_unpack = frozenset(columns)
         result_columns = []
@@ -2725,7 +2725,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         This method is useful for exposing an ibis expression to the underlying
         backend for use in the
-        [`Table.sql`][ibis.expr.types.relations.Table.sql] method.
+        [`Table.sql`](#ibis.expr.types.relations.Table.sql) method.
 
         ::: {.callout-note}
         ## `.alias` will create a temporary view
@@ -2841,7 +2841,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         └───────────┴─────────────────┘
 
         Because ibis expressions aren't named, they aren't visible to
-        subsequent `.sql` calls. Use the [`alias`][ibis.expr.types.relations.Table.alias] method
+        subsequent `.sql` calls. Use the [`alias`](#ibis.expr.types.relations.Table.alias) method
         to assign a name to an expression.
 
         >>> expr.alias("b").sql("SELECT * FROM b WHERE avg_bill_length > 40")
@@ -2856,7 +2856,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`Table.alias`][ibis.expr.types.relations.Table.alias]
+        [`Table.alias`](#ibis.expr.types.relations.Table.alias)
         '''
 
         # only transpile if dialect was passed
@@ -2872,7 +2872,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         Parameters
         ----------
         kwargs
-            Same as keyword arguments to [`execute`][ibis.expr.types.core.Expr.execute]
+            Same as keyword arguments to [`execute`](./expression-generic.qmd#ibis.expr.types.core.Expr.execute)
         """
         return self.execute(**kwargs)
 
@@ -3301,8 +3301,8 @@ class Table(Expr, _FixedTextJupyterMixin):
             argument will be used to join their values together into a single
             string to use as a column name.
         names_sort
-            If [`True`][True] columns are sorted. If [`False`][False] column
-            names are ordered by appearance.
+            If [](`True`) columns are sorted. If [](`False`) column names are
+            ordered by appearance.
         names
             An explicit sequence of values to look for in columns matching
             `names_from`.
@@ -3803,7 +3803,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         └────────┴───────┴───────┴───────┴────────┴────────┘
 
         You can relocate based on any predicate selector, such as
-        [`of_type`][ibis.selectors.of_type]
+        [`of_type`](./selectors.qmd#ibis.selectors.of_type)
 
         >>> t.relocate(s.of_type("string"))
         ┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -23,7 +23,7 @@ class StringValue(Value):
         Parameters
         ----------
         key
-            [`int`][int], [`slice`][slice] or integer scalar expression
+            [](`int`), [](`slice`) or integer scalar expression
 
         Returns
         -------
@@ -820,7 +820,7 @@ class StringValue(Value):
 
         See Also
         --------
-        [`ArrayValue.join`][ibis.expr.types.arrays.ArrayValue.join]
+        [`ArrayValue.join`](./expression-collections.qmd#ibis.expr.types.arrays.ArrayValue.join)
         """
         import ibis.expr.types as ir
 

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -46,11 +46,11 @@ def struct(
 
     Examples
     --------
-    Create a struct literal from a [`dict`][dict] with the type inferred
+    Create a struct literal from a [`dict`](dict) with the type inferred
     >>> import ibis
     >>> t = ibis.struct(dict(a=1, b='foo'))
 
-    Create a struct literal from a [`dict`][dict] with a specified type
+    Create a struct literal from a [`dict`](dict) with a specified type
     >>> t = ibis.struct(dict(a=1, b='foo'), type='struct<a: float, b: string>')
 
     Specify a specific type for the struct literal
@@ -330,7 +330,7 @@ class StructValue(Value):
 
         See Also
         --------
-        [`Table.unpack`][ibis.expr.types.relations.Table.unpack].
+        [`Table.unpack`](./expression-tables.qmd#ibis.expr.types.relations.Table.unpack)
         """
         import ibis.expr.analysis as an
 

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal
 
 from public import public
 
@@ -10,7 +10,6 @@ import ibis.expr.operations as ops
 from ibis.expr.types.core import _binop
 from ibis.expr.types.generic import Column, Scalar, Value
 from ibis.common.annotations import annotated
-from ibis.common.patterns import Pattern
 import ibis.expr.datatypes as dt
 from ibis import util
 from ibis.common.temporal import IntervalUnit
@@ -53,12 +52,7 @@ class TemporalColumn(Column, TemporalValue):
 
 
 class _DateComponentMixin:
-    """Temporal expressions that have a date component.
-
-    Currently this includes
-    [`TimestampValue`][ibis.expr.types.temporal.TimestampValue]s and
-    [`DateValue`][ibis.expr.types.temporal.DateValue]s
-    """
+    """Temporal expressions that have a date component."""
 
     def epoch_seconds(self) -> ir.IntegerValue:
         """Extract UNIX epoch in seconds."""
@@ -102,12 +96,7 @@ class _DateComponentMixin:
 
 
 class _TimeComponentMixin:
-    """Temporal expressions that have a time component.
-
-    Currently this includes
-    [`TimestampValue`][ibis.expr.types.temporal.TimestampValue]s and
-    [`TimeValue`][ibis.expr.types.temporal.TimeValue]s
-    """
+    """Temporal expressions that have a time component."""
 
     def time(self) -> TimeValue:
         """Return the time component of the expression.
@@ -622,14 +611,14 @@ class DayOfWeek:
     def index(self):
         """Get the index of the day of the week.
 
+        ::: {.callout-note}
+        ## Ibis follows the `pandas` convention for day numbering: Monday = 0 and Sunday = 6.
+        :::
+
         Returns
         -------
         IntegerValue
             The index of the day of the week.
-
-            ::: {.callout-note}
-            ## Ibis follows pandas' conventions for day numbers: Monday = 0 and Sunday = 6.
-            :::
         """
         return ops.DayOfWeekIndex(self._expr).to_expr()
 

--- a/ibis/legacy/udf/vectorized.py
+++ b/ibis/legacy/udf/vectorized.py
@@ -31,7 +31,7 @@ def _coerce_to_dict(
 ) -> tuple:
     """Coerce the following shapes to a tuple.
 
-    - [`list`][list]
+    - [`list`](list)
     - `np.ndarray`
     - `pd.Series`
     """
@@ -45,7 +45,7 @@ def _coerce_to_np_array(
 ) -> np.ndarray:
     """Coerce the following shapes to an np.ndarray.
 
-    - [`list`][list]
+    - [`list`](list)
     - `np.ndarray`
     - `pd.Series`
     """
@@ -62,7 +62,7 @@ def _coerce_to_series(
     This method does NOT always return a new Series. If a Series is
     passed in, this method will return the original object.
 
-    - [`list`][list]
+    - [`list`](list)
     - `np.ndarray`
     - `pd.Series`
 

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -21,7 +21,7 @@ Without selectors this becomes quite verbose and tedious to write:
 >>> t.select([t[c] for c in t.columns if t[c].type().is_numeric()])  # doctest: +SKIP
 ```
 
-Compare that to the [`numeric`][ibis.selectors.numeric] selector:
+Compare that to the [`numeric`](#ibis.selectors.numeric) selector:
 
 ```python
 >>> import ibis.selectors as s
@@ -192,7 +192,7 @@ def numeric() -> Predicate:
 
     See Also
     --------
-    [`of_type`][ibis.selectors.of_type]
+    [`of_type`](#ibis.selectors.of_type)
     """
     return of_type(dt.Numeric)
 
@@ -236,7 +236,7 @@ def of_type(dtype: dt.DataType | str | type[dt.DataType]) -> Predicate:
 
     See Also
     --------
-    [`numeric`][ibis.selectors.numeric]
+    [`numeric`](#ibis.selectors.numeric)
     """
     if isinstance(dtype, str):
         # A mapping of abstract or parametric types, to allow selecting all
@@ -286,7 +286,7 @@ def startswith(prefixes: str | tuple[str, ...]) -> Predicate:
 
     See Also
     --------
-    [`endswith`][ibis.selectors.endswith]
+    [`endswith`](#ibis.selectors.endswith)
     """
     return where(lambda col: col.get_name().startswith(prefixes))
 
@@ -302,7 +302,7 @@ def endswith(suffixes: str | tuple[str, ...]) -> Predicate:
 
     See Also
     --------
-    [`startswith`][ibis.selectors.startswith]
+    [`startswith`](#ibis.selectors.startswith)
     """
     return where(lambda col: col.get_name().endswith(suffixes))
 
@@ -340,7 +340,7 @@ def contains(
 
     See Also
     --------
-    [`matches`][ibis.selectors.matches]
+    [`matches`](#ibis.selectors.matches)
     """
 
     def predicate(col: ir.Value) -> bool:
@@ -370,7 +370,7 @@ def matches(regex: str | re.Pattern) -> Selector:
 
     See Also
     --------
-    [`contains`][ibis.selectors.contains]
+    [`contains`](#ibis.selectors.contains)
     """
     pattern = re.compile(regex)
     return where(lambda col: pattern.search(col.get_name()) is not None)

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -538,7 +538,7 @@ def gen_name(namespace: str) -> str:
 def slice_to_limit_offset(
     what: slice, count: ir.IntegerScalar
 ) -> tuple[int | ir.IntegerScalar, int | ir.IntegerScalar]:
-    """Convert a Python [`slice`][slice] to a `limit`, `offset` pair.
+    """Convert a Python [`slice`](slice) to a `limit`, `offset` pair.
 
     Parameters
     ----------

--- a/justfile
+++ b/justfile
@@ -149,3 +149,9 @@ docs-preview:
 
 docs-deploy:
     quarto publish --no-prompt --no-browser --no-render netlify docs
+
+# run the entire docs build pipeline
+docs-build-all:
+    just docs-apigen --verbose
+    just docs-render
+    just checklinks docs/_output --offline --no-progress

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,8 +1,1 @@
 require_https = true
-exclude = [
-  "duckdb:/:memory",
-  "postgres:/:*",
-  "backends/impala.qmd",
-  "raw_support_matrix.csv",
-]
-exclude_path = ["site/SUMMARY/index.html", "site/overrides/main.html"]


### PR DESCRIPTION
This PR fixes the remaining interlinks between ibis documentation and itself and links to inventories like the core Python docs.