### PR TITLE
fix(dtypes): switch scale and timestamp parameter order when formatting a timestamp datatype

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -611,10 +611,14 @@ class Timestamp(Temporal, Parametric):
 
     @property
     def _pretty_piece(self) -> str:
-        pieces = [
-            repr(piece) for piece in (self.scale, self.timezone) if piece is not None
-        ]
-        return f"({', '.join(pieces)})" * bool(pieces)
+        if self.scale is not None and self.timezone is not None:
+            return f"('{self.timezone}', {self.scale:d})"
+        elif self.timezone is not None:
+            return f"('{self.timezone}')"
+        elif self.scale is not None:
+            return f"({self.scale:d})"
+        else:
+            return ""
 
 
 @public

--- a/ibis/expr/datatypes/tests/test_parse.py
+++ b/ibis/expr/datatypes/tests/test_parse.py
@@ -202,9 +202,10 @@ def test_parse_timestamp_with_timezone_invalid_timezone():
 @pytest.mark.parametrize("scale", range(10))
 @pytest.mark.parametrize("tz", ["UTC", "America/New_York"])
 def test_parse_timestamp_with_scale(scale, tz):
-    assert dt.parse(f"timestamp({tz!r}, {scale:d})") == dt.Timestamp(
-        timezone=tz, scale=scale
-    )
+    expected = dt.Timestamp(timezone=tz, scale=scale)
+    typestring = f"timestamp({tz!r}, {scale:d})"
+    assert dt.parse(typestring) == expected
+    assert str(expected) == typestring
 
 
 @pytest.mark.parametrize("scale", range(10))


### PR DESCRIPTION
Hypothesis has discoreved this bug in another PR: https://github.com/ibis-project/ibis/actions/runs/6059728425/job/16443137662?pr=6876#step:11:121

Parsing expects a different parameter order as the formatting produces.