### PR TITLE
docs: add fancy renderer for docstring examples

### DIFF
--- a/docs/_renderer.py
+++ b/docs/_renderer.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import griffe.dataclasses as dc  # noqa: F401
-import griffe.docstrings.dataclasses as ds  # noqa: F401
-import griffe.expressions as expr  # noqa: F401
 import quartodoc.ast as qast
+import toolz
 from plum import dispatch
 from quartodoc import MdRenderer
 
@@ -13,6 +11,46 @@ class Renderer(MdRenderer):
 
     @dispatch
     def render(self, el: qast.ExampleCode):
-        return f"""```
-{el.value}
-```"""
+        lines = el.value.splitlines()
+
+        result = []
+
+        prompt = ">>> "
+        continuation = "... "
+        skip_doctest = "doctest: +SKIP"
+        expect_failure = "quartodoc: +EXPECTED_FAILURE"
+        quartodoc_skip_doctest = "quartodoc: +SKIP"
+
+        chunker = lambda line: line.startswith((prompt, continuation))
+
+        for first, *rest in toolz.partitionby(chunker, lines):
+            if first.startswith(prompt):
+                if not (
+                    quartodoc_skip_doctest in first
+                    or skip_doctest in first
+                    or any(
+                        quartodoc_skip_doctest in line or skip_doctest in line
+                        for line in rest
+                    )
+                ):
+                    start, end = "{}"
+                else:
+                    start = end = ""
+
+                result.append(f"```{start}python{end}")
+
+                if expect_failure in first:
+                    assert (
+                        start and end
+                    ), "expected failure should never occur alongside a skipped doctest example"
+                    result.append("#| error: true")
+                result.append(
+                    first.replace(f"# {quartodoc_skip_doctest}", "")
+                    .replace(quartodoc_skip_doctest, "")
+                    .replace(f"# {expect_failure}", "")
+                    .replace(expect_failure, "")
+                )
+                result.extend(rest)
+                result.append("```\n")
+
+        return "\n".join(result)

--- a/docs/_renderer.py
+++ b/docs/_renderer.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import quartodoc.ast as qast
+import quartodoc as qd
 import toolz
 from plum import dispatch
-from quartodoc import MdRenderer
 
 
-class Renderer(MdRenderer):
+class Renderer(qd.MdRenderer):
     style = "ibis"
 
     @dispatch
-    def render(self, el: qast.ExampleCode):
+    def render(self, el: qd.ast.ExampleCode) -> str:
         lines = el.value.splitlines()
 
         result = []

--- a/ibis/backends/base/df/timecontext.py
+++ b/ibis/backends/base/df/timecontext.py
@@ -185,7 +185,7 @@ def construct_time_context_aware_series(
     1    2.2
     2    3.3
     Name: value, dtype: float64
-    >>> construct_time_context_aware_series(series, df)  # doctest: +SKIP
+    >>> construct_time_context_aware_series(series, df)  # quartodoc: +SKIP # doctest: +SKIP
        time
     0  2017-01-02    1.1
     1  2017-01-03    2.2
@@ -196,14 +196,14 @@ def construct_time_context_aware_series(
     and a DateTimeIndex.
 
     >>> timed_series = construct_time_context_aware_series(series, df)
-    >>> timed_series  # doctest: +SKIP
+    >>> timed_series  # quartodoc: +SKIP # doctest: +SKIP
        time
     0  2017-01-02    1.1
     1  2017-01-03    2.2
     2  2017-01-04    3.3
     Name: value, dtype: float64
 
-    >>> construct_time_context_aware_series(timed_series, df)  # doctest: +SKIP
+    >>> construct_time_context_aware_series(timed_series, df)  # quartodoc: +SKIP # doctest: +SKIP
        time
     0  2017-01-02    1.1
     1  2017-01-03    2.2

--- a/ibis/backends/dask/execution/util.py
+++ b/ibis/backends/dask/execution/util.py
@@ -109,18 +109,18 @@ def coerce_to_output(
     Examples below use pandas objects for legibility, but functionality is the
     same on dask objects.
 
-    >>> coerce_to_output(pd.Series(1), expr)  # doctest: +SKIP
+    >>> coerce_to_output(pd.Series(1), expr)  # quartodoc: +SKIP # doctest: +SKIP
     0    1
     Name: result, dtype: int64
-    >>> coerce_to_output(1, expr)  # doctest: +SKIP
+    >>> coerce_to_output(1, expr)  # quartodoc: +SKIP # doctest: +SKIP
     0    1
     Name: result, dtype: int64
-    >>> coerce_to_output(1, expr, [1,2,3])  # doctest: +SKIP
+    >>> coerce_to_output(1, expr, [1,2,3])  # quartodoc: +SKIP # doctest: +SKIP
     1    1
     2    1
     3    1
     Name: result, dtype: int64
-    >>> coerce_to_output([1,2,3], expr)  # doctest: +SKIP
+    >>> coerce_to_output([1,2,3], expr)  # quartodoc: +SKIP # doctest: +SKIP
     0    [1, 2, 3]
     Name: result, dtype: object
     """

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -924,10 +924,10 @@ class Backend(BaseSQLBackend):
         Examples
         --------
         >>> table = 'my_table'
-        >>> con.insert(table, table_expr)  # doctest: +SKIP
+        >>> con.insert(table, table_expr)  # quartodoc: +SKIP # doctest: +SKIP
 
         Completely overwrite contents
-        >>> con.insert(table, table_expr, overwrite=True)  # doctest: +SKIP
+        >>> con.insert(table, table_expr, overwrite=True)  # quartodoc: +SKIP # doctest: +SKIP
         """
         table = self.table(table_name, database=database)
         return table.insert(
@@ -956,7 +956,7 @@ class Backend(BaseSQLBackend):
         --------
         >>> table = 'my_table'
         >>> db = 'operations'
-        >>> con.drop_table(table, database=db, force=True)  # doctest: +SKIP
+        >>> con.drop_table(table, database=db, force=True)  # quartodoc: +SKIP # doctest: +SKIP
         """
         statement = DropTable(name, database=database, must_exist=not force)
         self._safe_exec_sql(statement)
@@ -1014,7 +1014,7 @@ class Backend(BaseSQLBackend):
         >>> table = 'my_table'
         >>> db = 'operations'
         >>> pool = 'op_4GB_pool'
-        >>> con.cache_table('my_table', database=db, pool=pool)  # doctest: +SKIP
+        >>> con.cache_table('my_table', database=db, pool=pool)  # quartodoc: +SKIP # doctest: +SKIP
         """
         statement = ddl.CacheTable(table_name, database=database, pool=pool)
         self._safe_exec_sql(statement)

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -31,7 +31,7 @@ Pandas
     ...     'time': pd.date_range(periods=4, start='now')
     ... })
     >>> s = pd.Series(df.value.sum(), index=df.index, name='sum_value')
-    >>> s  # doctest: +SKIP
+    >>> s  # quartodoc: +SKIP # doctest: +SKIP
 
 Ibis
 
@@ -42,7 +42,7 @@ Ibis
     ...    ('time', 'timestamp'), ('key', 'string'), ('value', 'double')
     ... ]
     >>> t = ibis.table(schema, name='t')
-    >>> t[t, t.value.sum().name('sum_value')].sum_value  # doctest: +SKIP
+    >>> t[t, t.value.sum().name('sum_value')].sum_value  # quartodoc: +SKIP # doctest: +SKIP
 
 
 ``group_by``, no ``order_by``: ``context.Transform()``
@@ -69,7 +69,7 @@ Pandas
     ...     'value': np.random.randn(4),
     ...     'time': pd.date_range(periods=4, start='now')
     ... })
-    >>> df.groupby('key').value.transform('sum')  # doctest: +SKIP
+    >>> df.groupby('key').value.transform('sum')  # quartodoc: +SKIP # doctest: +SKIP
 
 Ibis
 
@@ -80,7 +80,7 @@ Ibis
     ...     ('time', 'timestamp'), ('key', 'string'), ('value', 'double')
     ... ]
     >>> t = ibis.table(schema, name='t')
-    >>> t.value.sum().over(ibis.window(group_by=t.key))  # doctest: +SKIP
+    >>> t.value.sum().over(ibis.window(group_by=t.key))  # quartodoc: +SKIP # doctest: +SKIP
 
 ``order_by``, no ``group_by``: ``context.Cumulative()``/``context.Rolling()``
 -----------------------------------------------------------------------------
@@ -113,7 +113,7 @@ Pandas
     ...     'value': np.random.randn(4),
     ...     'time': pd.date_range(periods=4, start='now')
     ... })
-    >>> df.sort_values('time').value.cumsum()  # doctest: +SKIP
+    >>> df.sort_values('time').value.cumsum()  # quartodoc: +SKIP # doctest: +SKIP
 
 Ibis
 
@@ -125,7 +125,7 @@ Ibis
     ... ]
     >>> t = ibis.table(schema, name='t')
     >>> window = ibis.cumulative_window(order_by=t.time)
-    >>> t.value.sum().over(window)  # doctest: +SKIP
+    >>> t.value.sum().over(window)  # quartodoc: +SKIP # doctest: +SKIP
 
 Moving
 ~~~~~~
@@ -153,7 +153,7 @@ Pandas
     ...     'value': np.random.randn(4),
     ...     'time': pd.date_range(periods=4, start='now')
     ... })
-    >>> df.sort_values('time').value.rolling(3).sum()  # doctest: +SKIP
+    >>> df.sort_values('time').value.rolling(3).sum()  # quartodoc: +SKIP # doctest: +SKIP
 
 Ibis
 
@@ -165,7 +165,7 @@ Ibis
     ... ]
     >>> t = ibis.table(schema, name='t')
     >>> window = ibis.trailing_window(3, order_by=t.time)
-    >>> t.value.sum().over(window)  # doctest: +SKIP
+    >>> t.value.sum().over(window)  # quartodoc: +SKIP # doctest: +SKIP
 
 
 ``group_by`` and ``order_by``: ``context.Cumulative()``/``context.Rolling()``
@@ -199,7 +199,7 @@ Pandas
     ...    drop=True
     ... ).groupby('key')
     >>> rolling = gb.value.rolling(2)
-    >>> rolling.sum()  # doctest: +SKIP
+    >>> rolling.sum()  # quartodoc: +SKIP # doctest: +SKIP
 
 Ibis
 
@@ -211,7 +211,7 @@ Ibis
     ... ]
     >>> t = ibis.table(schema, name='t')
     >>> window = ibis.trailing_window(2, order_by=t.time, group_by=t.key)
-    >>> t.value.sum().over(window)  # doctest: +SKIP
+    >>> t.value.sum().over(window)  # quartodoc: +SKIP # doctest: +SKIP
 """
 
 from __future__ import annotations

--- a/ibis/backends/pandas/execution/util.py
+++ b/ibis/backends/pandas/execution/util.py
@@ -114,18 +114,18 @@ def coerce_to_output(
     --------
     For dataframe outputs, see ``ibis.util.coerce_to_dataframe``.
 
-    >>> coerce_to_output(pd.Series(1), node)  # doctest: +SKIP
+    >>> coerce_to_output(pd.Series(1), node)  # quartodoc: +SKIP # doctest: +SKIP
     0    1
     Name: result, dtype: int64
-    >>> coerce_to_output(1, node)  # doctest: +SKIP
+    >>> coerce_to_output(1, node)  # quartodoc: +SKIP # doctest: +SKIP
     0    1
     Name: result, dtype: int64
-    >>> coerce_to_output(1, node, [1,2,3])  # doctest: +SKIP
+    >>> coerce_to_output(1, node, [1,2,3])  # quartodoc: +SKIP # doctest: +SKIP
     1    1
     2    1
     3    1
     Name: result, dtype: int64
-    >>> coerce_to_output([1,2,3], node)  # doctest: +SKIP
+    >>> coerce_to_output([1,2,3], node)  # quartodoc: +SKIP # doctest: +SKIP
     0    [1, 2, 3]
     Name: result, dtype: object
     """

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -379,7 +379,7 @@ class Backend(BaseSQLBackend, CanCreateDatabase):
 
         Examples
         --------
-        >>> con.create_table('new_table_name', table_expr)  # doctest: +SKIP
+        >>> con.create_table('new_table_name', table_expr)  # quartodoc: +SKIP # doctest: +SKIP
         """
         import pandas as pd
         import pyarrow as pa
@@ -502,7 +502,7 @@ class Backend(BaseSQLBackend, CanCreateDatabase):
         --------
         >>> table = 'my_table'
         >>> db = 'operations'
-        >>> con.drop_table_or_view(table, db, force=True)  # doctest: +SKIP
+        >>> con.drop_table_or_view(table, db, force=True)  # quartodoc: +SKIP # doctest: +SKIP
         """
         statement = DropTable(name, database=database, must_exist=not force)
         self.raw_sql(statement.compile())
@@ -547,10 +547,10 @@ class Backend(BaseSQLBackend, CanCreateDatabase):
         Examples
         --------
         >>> table = 'my_table'
-        >>> con.insert(table, table_expr)  # doctest: +SKIP
+        >>> con.insert(table, table_expr)  # quartodoc: +SKIP # doctest: +SKIP
 
         # Completely overwrite contents
-        >>> con.insert(table, table_expr, overwrite=True)  # doctest: +SKIP
+        >>> con.insert(table, table_expr, overwrite=True)  # quartodoc: +SKIP # doctest: +SKIP
         """
         table = self.table(table_name, database=database)
         return table.insert(

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -94,10 +94,10 @@ class PySparkTable(ir.Table):
 
         Examples
         --------
-        >>> t.insert(table_expr)  # doctest: +SKIP
+        >>> t.insert(table_expr)  # quartodoc: +SKIP # doctest: +SKIP
 
         # Completely overwrite contents
-        >>> t.insert(table_expr, overwrite=True)  # doctest: +SKIP
+        >>> t.insert(table_expr, overwrite=True)  # quartodoc: +SKIP # doctest: +SKIP
         """
         import pandas as pd
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1070,7 +1070,7 @@ def set_backend(backend: str | BaseBackend) -> None:
 
     Or as a URI
 
-    >>> ibis.set_backend("postgres://user:password@hostname:5432")  # doctest: +SKIP
+    >>> ibis.set_backend("postgres://user:password@hostname:5432")  # quartodoc: +SKIP # doctest: +SKIP
 
     Or as an existing backend instance
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1667,7 +1667,7 @@ def literal(value: Any, type: dt.DataType | str | None = None) -> Scalar:
 
     Ibis checks for invalid types
 
-    >>> ibis.literal('foobar', type='int64')  # doctest: +ELLIPSIS
+    >>> ibis.literal('foobar', type='int64')  # quartodoc: +EXPECTED_FAILURE
     Traceback (most recent call last):
       ...
     TypeError: Value 'foobar' cannot be safely coerced to int64

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -237,7 +237,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         Columns that are in the input `schema` but not in the table raise an error
 
-        >>> t.cast({"foo": "string"})
+        >>> t.cast({"foo": "string"})  # quartodoc: +EXPECTED_FAILURE
         Traceback (most recent call last):
             ...
         ibis.common.exceptions.IbisError: Cast schema has fields that are not in the table: ['foo']
@@ -1087,7 +1087,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         The only valid values of `keep` are `"first"`, `"last"` and [`None][None]
 
-        >>> t.distinct(on="species", keep="second")
+        >>> t.distinct(on="species", keep="second")  # quartodoc: +EXPECTED_FAILURE
         Traceback (most recent call last):
           ...
         ibis.common.exceptions.IbisError: Invalid value for keep: 'second' ...
@@ -3199,7 +3199,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         The number of match groups in `names_pattern` must match the length of `names_to`
 
-        >>> who.pivot_longer(
+        >>> who.pivot_longer(  # quartodoc: +EXPECTED_FAILURE
         ...     s.r["new_sp_m014":"newrel_f65"],
         ...     names_to=["diagnosis", "gender", "age"],
         ...     names_pattern="new_?(.*)_.(.*)",
@@ -3210,7 +3210,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         `names_transform` must be a mapping or callable
 
-        >>> who.pivot_longer(s.r["new_sp_m014":"newrel_f65"], names_transform="upper")
+        >>> who.pivot_longer(s.r["new_sp_m014":"newrel_f65"], names_transform="upper")  # quartodoc: +EXPECTED_FAILURE
         Traceback (most recent call last):
           ...
         ibis.common.exceptions.IbisTypeError: ... Got <class 'str'>

--- a/ibis/legacy/udf/vectorized.py
+++ b/ibis/legacy/udf/vectorized.py
@@ -291,7 +291,7 @@ def analytic(input_type, output_type):
     >>>
     >>> win = ibis.window(preceding=None, following=None, group_by='key')
     >>> # add two columns "demean" and "zscore"
-    >>> table = table.mutate(  # doctest: +SKIP
+    >>> table = table.mutate(  # quartodoc: +SKIP # doctest: +SKIP
     ...     demean_and_zscore(table['v']).over(win).destructure()
     ... )
     """
@@ -335,7 +335,7 @@ def elementwise(input_type, output_type):
     ...     return date.str.slice(0, 4), date.str.slice(4, 8)
     >>>
     >>> # add two columns "year" and "monthday"
-    >>> table = table.mutate(year_monthday(table['date']).destructure())  # doctest: +SKIP
+    >>> table = table.mutate(year_monthday(table['date']).destructure())  # quartodoc: +SKIP # doctest: +SKIP
     """
     return _udf_decorator(ElementWiseVectorizedUDF, input_type, output_type)
 
@@ -371,7 +371,7 @@ def reduction(input_type, output_type):
     ...     return v.mean(), v.std()
     >>>
     >>> # create aggregation columns "mean" and "std"
-    >>> table = table.group_by('key').aggregate(  # doctest: +SKIP
+    >>> table = table.group_by('key').aggregate(  # quartodoc: +SKIP # doctest: +SKIP
     ...     mean_and_std(table['v']).destructure()
     ... )
     """


### PR DESCRIPTION
This PR fills out our docstring examples renderer to actually leverage quarto to run the examples and make the output look super nice. I had to cook up some custom docstring example comment markers because quartodoc (maybe griffe?) erases `doctest: ` indicators before passing the code to the renderer. Eventually we may want to upstream this renderer to quartodoc if the idea make sense and is not burdensome to maintain.

## Light Mode

### Current

![image](https://github.com/ibis-project/ibis/assets/417981/120be82b-2372-4041-b9a1-f8b31f9ac350)

### This PR

![image](https://github.com/ibis-project/ibis/assets/417981/4e5d62ee-d55e-410a-9d75-360ad2a0d0de)

## Dark Mode

### Current

![image](https://github.com/ibis-project/ibis/assets/417981/ee04a963-b98b-495a-a411-32bd9405dcd2)

### This PR

![image](https://github.com/ibis-project/ibis/assets/417981/a7348746-07a0-4107-b15f-28b1e0b5a73f)