### PR TITLE
docs: fix more internal API docs links and improve `group_by` mutate example

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -882,6 +882,7 @@ class Value(Expr):
 
         Examples
         --------
+        >>> import ibis
         >>> t = ibis.table(dict(a="str"), name="t")
         >>> expr = t.a.length().name("len").as_table()
         >>> expected = t.select(len=t.a.length())

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -178,29 +178,48 @@ class GroupedTable:
         Examples
         --------
         >>> import ibis
-        >>> t = ibis.table([
-        ...     ('foo', 'string'),
-        ...     ('bar', 'string'),
-        ...     ('baz', 'double'),
-        ... ], name='t')
+        >>> ibis.options.interactive = True
+        >>> t = ibis.examples.penguins.fetch()
         >>> t
-        UnboundTable: t
-          foo string
-          bar string
-          baz float64
-        >>> expr = (t.group_by('foo')
-        ...          .order_by(ibis.desc('bar'))
-        ...          .mutate(qux=lambda x: x.baz.lag(), qux2=t.baz.lead()))
-        >>> print(expr)
-        r0 := UnboundTable: t
-          foo string
-          bar string
-          baz float64
-        Selection[r0]
-          selections:
-            r0
-            qux:  WindowFunction(...)
-            qux2: WindowFunction(...)
+        ┏━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━┓
+        ┃ species ┃ island    ┃ bill_length_mm ┃ bill_depth_mm ┃ flipper_length_mm ┃ … ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━┩
+        │ string  │ string    │ float64        │ float64       │ int64             │ … │
+        ├─────────┼───────────┼────────────────┼───────────────┼───────────────────┼───┤
+        │ Adelie  │ Torgersen │           39.1 │          18.7 │               181 │ … │
+        │ Adelie  │ Torgersen │           39.5 │          17.4 │               186 │ … │
+        │ Adelie  │ Torgersen │           40.3 │          18.0 │               195 │ … │
+        │ Adelie  │ Torgersen │            nan │           nan │              NULL │ … │
+        │ Adelie  │ Torgersen │           36.7 │          19.3 │               193 │ … │
+        │ Adelie  │ Torgersen │           39.3 │          20.6 │               190 │ … │
+        │ Adelie  │ Torgersen │           38.9 │          17.8 │               181 │ … │
+        │ Adelie  │ Torgersen │           39.2 │          19.6 │               195 │ … │
+        │ Adelie  │ Torgersen │           34.1 │          18.1 │               193 │ … │
+        │ Adelie  │ Torgersen │           42.0 │          20.2 │               190 │ … │
+        │ …       │ …         │              … │             … │                 … │ … │
+        └─────────┴───────────┴────────────────┴───────────────┴───────────────────┴───┘
+        >>> (
+        ...   t.select("species", "bill_length_mm")
+        ...    .group_by("species")
+        ...    .mutate(centered_bill_len=ibis._.bill_length_mm - ibis._.bill_length_mm.mean())
+        ... )
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+        ┃ species ┃ bill_length_mm ┃ centered_bill_len ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+        │ string  │ float64        │ float64           │
+        ├─────────┼────────────────┼───────────────────┤
+        │ Adelie  │           40.9 │          2.108609 │
+        │ Adelie  │           42.7 │          3.908609 │
+        │ Adelie  │           39.8 │          1.008609 │
+        │ Adelie  │           36.5 │         -2.291391 │
+        │ Adelie  │           36.7 │         -2.091391 │
+        │ Adelie  │           39.3 │          0.508609 │
+        │ Adelie  │           38.9 │          0.108609 │
+        │ Adelie  │           39.2 │          0.408609 │
+        │ Adelie  │           34.1 │         -4.691391 │
+        │ Adelie  │           42.0 │          3.208609 │
+        │ …       │              … │                 … │
+        └─────────┴────────────────┴───────────────────┘
 
         Returns
         -------

--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class MapValue(Value):
     """A map literal or column expression.
 
-    Can be constructed with [`ibis.map()`][ibis.expr.types.map].
+    Can be constructed with [`ibis.map()`](#ibis.expr.types.map).
 
     Examples
     --------

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -97,7 +97,7 @@ def struct(
 class StructValue(Value):
     """A struct literal or column.
 
-    Can be constructed with [`ibis.struct()`][ibis.expr.types.struct].
+    Can be constructed with [`ibis.struct()`](#ibis.expr.types.struct).
 
     Examples
     --------

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -211,6 +211,7 @@ def of_type(dtype: dt.DataType | str | type[dt.DataType]) -> Predicate:
     Select according to a specific `DataType` instance
 
     >>> import ibis
+    >>> import ibis.expr.datatypes as dt
     >>> import ibis.selectors as s
     >>> t = ibis.table(dict(name="string", siblings="array<string>", parents="array<int64>"))
     >>> expr = t.select(s.of_type(dt.Array(dt.string)))


### PR DESCRIPTION
Fixes some missing imports and improves the group_by.mutate example. Extracted from #7027.