### PR TITLE
chore: render sql using the notebook instead of only printing to stdout

### DIFF
--- a/docs/tutorials/ibis-for-sql-users.qmd
+++ b/docs/tutorials/ibis-for-sql-users.qmd
@@ -69,7 +69,7 @@ This generates the expected SQL:
 
 
 ```{python}
-ibis.show_sql(proj)
+ibis.to_sql(proj)
 ```
 
 What about adding new columns? To form a valid projection, all column
@@ -92,7 +92,7 @@ Now, we have:
 
 ```{python}
 proj = t["two", "one", new_col]
-ibis.show_sql(proj)
+ibis.to_sql(proj)
 ```
 
 ### `mutate`: Add or modify columns easily
@@ -110,7 +110,7 @@ Python keywords to provide the name. Indeed:
 
 
 ```{python}
-ibis.show_sql(mutated)
+ibis.to_sql(mutated)
 ```
 
 If you modify an existing column with `mutate` it will list out all the
@@ -119,7 +119,7 @@ other columns:
 
 ```{python}
 mutated = t.mutate(two=t.two * 2)
-ibis.show_sql(mutated)
+ibis.to_sql(mutated)
 ```
 
 ### `SELECT *` equivalent
@@ -131,7 +131,7 @@ do this, use the table expression itself in a projection:
 
 ```{python}
 proj = t[t]
-ibis.show_sql(proj)
+ibis.to_sql(proj)
 ```
 
 This is how `mutate` is implemented. The example above
@@ -140,7 +140,7 @@ This is how `mutate` is implemented. The example above
 
 ```{python}
 proj = t[t, new_col]
-ibis.show_sql(proj)
+ibis.to_sql(proj)
 ```
 
 Let's consider a table we might wish to join with `t`:
@@ -171,7 +171,7 @@ And verify the generated SQL:
 
 
 ```{python}
-ibis.show_sql(joined)
+ibis.to_sql(joined)
 ```
 
 ### Using functions in projections
@@ -207,7 +207,7 @@ Indeed:
 
 
 ```{python}
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ## Filtering / `WHERE`
@@ -218,7 +218,7 @@ You can add filter clauses to a table expression either by indexing with
 
 ```{python}
 filtered = t[t.two > 0]
-ibis.show_sql(filtered)
+ibis.to_sql(filtered)
 ```
 
 `filter` can take a list of expressions, which must all be satisfied for
@@ -227,7 +227,7 @@ a row to be included in the result:
 
 ```{python}
 filtered = t.filter([t.two > 0, t.one.isin(["A", "B"])])
-ibis.show_sql(filtered)
+ibis.to_sql(filtered)
 ```
 
 To compose boolean expressions with `AND` or `OR`, use the respective
@@ -237,7 +237,7 @@ To compose boolean expressions with `AND` or `OR`, use the respective
 ```{python}
 cond = (t.two < 0) | ((t.two > 0) | t.one.isin(["A", "B"]))
 filtered = t[cond]
-ibis.show_sql(filtered)
+ibis.to_sql(filtered)
 ```
 
 ## Aggregation / `GROUP BY`
@@ -265,7 +265,7 @@ agged.schema()
 
 
 ```{python}
-ibis.show_sql(agged)
+ibis.to_sql(agged)
 ```
 
 To add groupings, use either the `by` argument of `aggregate` or use the
@@ -275,7 +275,7 @@ To add groupings, use either the `by` argument of `aggregate` or use the
 ```{python}
 agged2 = t.aggregate(stats, by="one")
 agged3 = t.group_by("one").aggregate(stats)
-ibis.show_sql(agged3)
+ibis.to_sql(agged3)
 ```
 
 ### Non-trivial grouping keys
@@ -306,7 +306,7 @@ Now we have:
 
 
 ```{python}
-ibis.show_sql(stats)
+ibis.to_sql(stats)
 ```
 
 ### Aggregates considering table subsets
@@ -372,7 +372,7 @@ the SQL expression that is correct for your query engine.
 
 
 ```{python}
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### `count(*)` convenience: `size()`
@@ -383,7 +383,7 @@ method `size` that is a shortcut for the `count(*)` idiom:
 
 ```{python}
 freqs = events.group_by(keys).size()
-ibis.show_sql(freqs)
+ibis.to_sql(freqs)
 ```
 
 ### Frequency table convenience: `value_counts`
@@ -402,7 +402,7 @@ This is so common that, like pandas, there is a generic array method
 
 ```{python}
 expr = events.ts.year().value_counts()
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### `HAVING` clause
@@ -424,7 +424,7 @@ With Ibis, you can do:
 
 ```{python}
 expr = t.group_by("one").having(t.count() >= 1000).aggregate(t.two.sum().name("total"))
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ## Sorting / `ORDER BY`
@@ -436,7 +436,7 @@ or expressions that indicate the sorting keys:
 ```{python}
 sorted = events.order_by([events.ts.year(), events.ts.month()])
 
-ibis.show_sql(sorted)
+ibis.to_sql(sorted)
 ```
 
 The default for sorting is in ascending order. To reverse the sort
@@ -448,7 +448,7 @@ sorted = events.order_by([ibis.desc("event_type"), ibis.desc(events.ts.month())]
     100
 )
 
-ibis.show_sql(sorted)
+ibis.to_sql(sorted)
 ```
 
 ## `LIMIT` and `OFFSET`
@@ -460,7 +460,7 @@ may not be deterministic depending on the SQL engine), you can do:
 
 ```{python}
 limited = t.limit(1000)
-ibis.show_sql(limited)
+ibis.to_sql(limited)
 ```
 
 The `offset` option in `limit` skips rows. So if you wanted rows 11
@@ -469,7 +469,7 @@ through 20, you could do:
 
 ```{python}
 limited = t.limit(10, offset=10)
-ibis.show_sql(limited)
+ibis.to_sql(limited)
 ```
 
 ## Common column expressions
@@ -488,7 +488,7 @@ expressions from one Ibis type to another. For example:
 ```{python}
 expr = t.mutate(date=t.one.cast("timestamp"), four=t.three.cast("float32"))
 
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### `CASE` statements
@@ -521,7 +521,7 @@ case = (
 )
 
 expr = t.mutate(year_group=case)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 The more general case is that of an arbitrary list of boolean
@@ -545,7 +545,7 @@ case = (
 )
 
 expr = t.mutate(cond_value=case)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 There are several places where Ibis builds cases for you in a simplified
@@ -555,7 +555,7 @@ way. One example is the `ifelse` function:
 ```{python}
 switch = (t.two < 0).ifelse("Negative", "Non-Negative")
 expr = t.mutate(group=switch)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Using `NULL` in expressions
@@ -567,7 +567,7 @@ or `ibis.null()`:
 ```{python}
 pos_two = (t.two > 0).ifelse(t.two, ibis.NA)
 expr = t.mutate(two_positive=pos_two)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Set membership: `IN` / `NOT IN`
@@ -595,7 +595,7 @@ refined = (
 )
 
 expr = pop.mutate(refined_group=refined)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 The opposite of `isin` is `notin`.
@@ -636,7 +636,7 @@ other array or scalar expression:
 has_foo = value.isin([t3.column1, t3.column2])
 
 expr = t3.mutate(has_foo=has_foo)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 In many other situations, you can use constants without having to use
@@ -646,7 +646,7 @@ but the number 5 like so:
 
 ```{python}
 expr = t3.mutate(number5=5)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### `IS NULL` and `IS NOT NULL`
@@ -658,7 +658,7 @@ which yield boolean arrays:
 ```{python}
 indic = t.two.isnull().ifelse("valid", "invalid")
 expr = t.mutate(is_valid=indic)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 
@@ -669,7 +669,7 @@ agged = (
     .aggregate(three_count=lambda t: t.three.notnull().sum())
 )
 
-ibis.show_sql(agged)
+ibis.to_sql(agged)
 ```
 
 ### `BETWEEN`
@@ -681,7 +681,7 @@ other boolean expression:
 
 ```{python}
 expr = t[t.two.between(10, 50) & t.one.notnull()]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ## Joins
@@ -737,7 +737,7 @@ projection immediately after:
 
 ```{python}
 expr = joined[t1, t2.value2]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 If you need to compute an expression that involves both tables, you can
@@ -746,7 +746,7 @@ do that also:
 
 ```{python}
 expr = joined[t1.key1, (t1.value1 - t2.value2).name("diff")]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Join + aggregation
@@ -773,7 +773,7 @@ avg_diff = (t1.value1 - t2.value2).mean()
 expr = (
     t1.left_join(t2, t1.key1 == t2.key3).group_by(t1.key1).aggregate(avg_diff=avg_diff)
 )
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Join with `SELECT *`
@@ -784,7 +784,7 @@ aggregated, it will be *fully materialized*:
 
 ```{python}
 joined = t1.left_join(t2, t1.key1 == t2.key3)
-ibis.show_sql(joined)
+ibis.to_sql(joined)
 ```
 
 ### Multiple joins
@@ -803,7 +803,7 @@ expr = (
     .group_by([t2.key4, t3.key5])
     .aggregate(total=total)
 )
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Self joins
@@ -831,7 +831,7 @@ expr = (
     .group_by(t.one)
     .aggregate(metric=stat)
 )
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Overlapping join keys
@@ -868,7 +868,7 @@ In these case, we can specify a list of common join keys:
 ```{python}
 joined = t4.join(t5, ["key1", "key2", "key3"])
 expr = joined[t4, t5.value2]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 You can mix the overlapping key names with other expressions:
@@ -877,7 +877,7 @@ You can mix the overlapping key names with other expressions:
 ```{python}
 joined = t4.join(t5, ["key1", "key2", t4.key3.left(4) == t4.key3.left(4)])
 expr = joined[t4, t5.value2]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Non-equality join predicates
@@ -890,7 +890,7 @@ at all. In the latter case, these conditions get moved by Ibis into the
 
 ```{python}
 expr = t1.join(t2, t1.value1 < t2.value2).group_by(t1.key1).size()
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Other ways to specify join keys
@@ -969,7 +969,7 @@ This can now be used to filter `events`:
 
 ```{python}
 expr = events[cond]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 If you negate the condition, it will instead give you only event data
@@ -978,7 +978,7 @@ from user *that have not made a purchase*:
 
 ```{python}
 expr = events[-cond]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Subqueries with `IN` / `NOT IN`
@@ -1002,7 +1002,7 @@ you can write with Ibis:
 ```{python}
 cond = events.user_id.isin(purchases.user_id)
 expr = events[cond]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 Depending on the query engine, the query planner/optimizer will often
@@ -1028,7 +1028,7 @@ With Ibis, the code is simpler and more pandas-like:
 
 ```{python}
 expr = t1[t1.value1 > t2.value2.max()]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Conditional aggregates
@@ -1057,7 +1057,7 @@ average statistic:
 ```{python}
 stat = t2[t1.key1 == t2.key3].value2.mean()
 expr = t1[t1.value1 > stat]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ## `DISTINCT` expressions
@@ -1081,7 +1081,7 @@ And the Ibis Python code:
 
 ```{python}
 expr = t1.distinct()
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 For distinct aggregates, the most common case is `COUNT(DISTINCT ...)`,
@@ -1101,7 +1101,7 @@ In Ibis this is:
 ```{python}
 metric = events.event_type.nunique()
 expr = events.group_by("user_id").aggregate(unique_events=metric)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ## Window functions
@@ -1136,7 +1136,7 @@ mean of a column from itself:
 
 ```{python}
 expr = t.mutate(two_demean=t.two - t.two.mean())
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 If you use `mutate` in conjunction with `group_by`, it will add a
@@ -1146,7 +1146,7 @@ If you use `mutate` in conjunction with `group_by`, it will add a
 ```{python}
 expr = t.group_by("one").mutate(two_demean=t.two - t.two.mean())
 
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 For functions like `LAG` that require an ordering, we can add an
@@ -1156,7 +1156,7 @@ For functions like `LAG` that require an ordering, we can add an
 ```{python}
 expr = t.group_by("one").order_by(t.two).mutate(two_first_diff=t.two - t.two.lag())
 
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 For more precision, you can create a `Window` object that also includes
@@ -1166,7 +1166,7 @@ a window frame clause:
 ```{python}
 w = ibis.window(group_by="one", preceding=5, following=5)
 expr = t.mutate(group_demeaned=t.two - t.two.mean().over(w))
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ## Top-K operations
@@ -1193,7 +1193,7 @@ This can be evaluated directly, yielding the above query:
 
 
 ```{python}
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ## Date / time data
@@ -1207,7 +1207,7 @@ For example, we can do:
 ```{python}
 expr = events.mutate(year=events.ts.year(), month=events.ts.month())
 
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ### Casting to date / time types
@@ -1224,7 +1224,7 @@ arithmetic. For example:
 
 ```{python}
 expr = events[events.ts > (ibis.now() - ibis.interval(years=1))]
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 The implementation of each timedelta offset will depend on the query
@@ -1251,7 +1251,7 @@ expr1 = t1.limit(10)
 expr2 = t1.limit(10, offset=10)
 
 expr = expr1.union(expr2)
-ibis.show_sql(expr)
+ibis.to_sql(expr)
 ```
 
 ## Esoterica
@@ -1307,5 +1307,5 @@ Ibis automatically creates a CTE for `agged`:
 
 
 ```{python}
-ibis.show_sql(result)
+ibis.to_sql(result)
 ```


### PR DESCRIPTION
Moves the SQL users tutoral to use `ibis.to_sql` which will render the SQl strings with syntax highlighting.