### PR TITLE
fix(api): ensure that deferred objects cannot be converted into literals

### DIFF
--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 import itertools
-from typing import Any, Optional, Union
+from typing import Annotated, Any, Optional, Union
 from typing import Literal as LiteralType
 
 from public import public
@@ -14,7 +14,9 @@ import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
 from ibis.common.grounds import Singleton
+from ibis.common.patterns import InstanceOf  # noqa: TCH001
 from ibis.common.typing import VarTuple  # noqa: TCH001
+from ibis.expr.deferred import Deferred  # noqa: TCH001
 from ibis.expr.operations.core import Named, Scalar, Unary, Value
 from ibis.expr.operations.relations import Relation  # noqa: TCH001
 
@@ -193,7 +195,7 @@ T = TypeVar("T", bound=dt.DataType, covariant=True)
 
 @public
 class Literal(Scalar[T]):
-    value: Any
+    value: Annotated[Any, ~InstanceOf(Deferred)]
     dtype: T
 
     shape = ds.scalar

--- a/ibis/tests/test_strategies.py
+++ b/ibis/tests/test_strategies.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import hypothesis as h
 import hypothesis.strategies as st
 import numpy as np
+import pytest
 
+import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 import ibis.tests.strategies as its
+from ibis.common.annotations import ValidationError
 
 
 @h.given(its.null_dtype)
@@ -167,6 +170,12 @@ def test_schema_to_pandas(schema):
 def test_memtable(memtable):
     assert isinstance(memtable, ir.TableExpr)
     assert isinstance(memtable.schema(), sch.Schema)
+
+
+@h.given(its.all_dtypes())
+def test_deferred_literal(dtype):
+    with pytest.raises(ValidationError):
+        ibis.literal(ibis._.a, type=dtype)
 
 
 # TODO(kszucs): we enforce field name uniqueness in the schema, but we don't for Struct datatype


### PR DESCRIPTION
Fail to spuriously convert deferred objects to literal values.

Closes #7051.