### PR TITLE
fix(sql): avoid reselecting relations to prevent dropping order by clauses

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,7 @@
 use flake
+
 watch_file poetry.lock
+watch_file nix/overlay.nix
 
 export CLOUDSDK_ACTIVE_CONFIG_NAME=ibis-gbq
 export GOOGLE_CLOUD_PROJECT="$CLOUDSDK_ACTIVE_CONFIG_NAME"

--- a/ci/schema/clickhouse.sql
+++ b/ci/schema/clickhouse.sql
@@ -12,6 +12,9 @@ CREATE OR REPLACE TABLE ibis_testing.functional_alltypes ENGINE = Memory AS
 SELECT * REPLACE(CAST(timestamp_col AS Nullable(DateTime)) AS timestamp_col)
 FROM file('ibis/functional_alltypes.parquet', 'Parquet');
 
+CREATE OR REPLACE TABLE ibis_testing.astronauts ENGINE = Memory AS
+SELECT * FROM file('ibis/astronauts.parquet', 'Parquet');
+
 CREATE OR REPLACE TABLE ibis_testing.tzone (
     ts Nullable(DateTime),
     key Nullable(String),

--- a/ci/schema/druid.sql
+++ b/ci/schema/druid.sql
@@ -45,3 +45,15 @@ FROM TABLE(
   )
 )
 PARTITIONED BY ALL TIME;
+
+REPLACE INTO "astronauts"
+OVERWRITE ALL
+SELECT *
+FROM TABLE(
+  EXTERN(
+    '{"type":"local","files":["/data/astronauts.parquet"]}',
+    '{"type":"parquet"}',
+    '[{"name":"id","type":"long"},{"name":"number","type":"long"},{"name":"nationwide_number","type":"long"},{"name":"name","type":"string"},{"name":"original_name","type":"string"},{"name":"sex","type":"string"},{"name":"year_of_birth","type":"long"},{"name":"nationality","type":"string"},{"name":"military_civilian","type":"string"},{"name":"selection","type":"string"},{"name":"year_of_selection","type":"long"},{"name":"mission_number","type":"long"},{"name":"total_number_of_missions","type":"long"},{"name":"occupation","type":"string"},{"name":"year_of_mission","type":"long"},{"name":"mission_title","type":"string"},{"name":"ascend_shuttle","type":"string"},{"name":"in_orbit","type":"string"},{"name":"descend_shuttle","type":"string"},{"name":"hours_mission","type":"double"},{"name":"total_hrs_sum","type":"double"},{"name":"field21","type":"long"},{"name":"eva_hrs_mission","type":"double"},{"name":"total_eva_hrs","type":"double"}]'
+  )
+)
+PARTITIONED BY ALL TIME;

--- a/ci/schema/mssql.sql
+++ b/ci/schema/mssql.sql
@@ -21,6 +21,39 @@ BULK INSERT diamonds
 FROM '/data/diamonds.csv'
 WITH (FORMAT = 'CSV', FIELDTERMINATOR = ',', ROWTERMINATOR = '\n', FIRSTROW = 2)
 
+DROP TABLE IF EXISTS astronauts;
+
+CREATE TABLE astronauts (
+    "id" BIGINT,
+    "number" BIGINT,
+    "nationwide_number" BIGINT,
+    "name" VARCHAR(MAX),
+    "original_name" VARCHAR(MAX),
+    "sex" VARCHAR(MAX),
+    "year_of_birth" BIGINT,
+    "nationality" VARCHAR(MAX),
+    "military_civilian" VARCHAR(MAX),
+    "selection" VARCHAR(MAX),
+    "year_of_selection" BIGINT,
+    "mission_number" BIGINT,
+    "total_number_of_missions" BIGINT,
+    "occupation" VARCHAR(MAX),
+    "year_of_mission" BIGINT,
+    "mission_title" VARCHAR(MAX),
+    "ascend_shuttle" VARCHAR(MAX),
+    "in_orbit" VARCHAR(MAX),
+    "descend_shuttle" VARCHAR(MAX),
+    "hours_mission" DOUBLE PRECISION,
+    "total_hrs_sum" DOUBLE PRECISION,
+    "field21" BIGINT,
+    "eva_hrs_mission" DOUBLE PRECISION,
+    "total_eva_hrs" DOUBLE PRECISION
+);
+
+BULK INSERT astronauts
+FROM '/data/astronauts.csv'
+WITH (FORMAT = 'CSV', FIELDTERMINATOR = ',', ROWTERMINATOR = '\n', FIRSTROW = 2)
+
 DROP TABLE IF EXISTS batting;
 
 CREATE TABLE batting (

--- a/ci/schema/mysql.sql
+++ b/ci/schema/mysql.sql
@@ -13,6 +13,35 @@ CREATE TABLE diamonds (
     z FLOAT
 ) DEFAULT CHARACTER SET = utf8;
 
+DROP TABLE IF EXISTS astronauts;
+
+CREATE TABLE astronauts (
+    `id` BIGINT,
+    `number` BIGINT,
+    `nationwide_number` BIGINT,
+    `name` TEXT,
+    `original_name` TEXT,
+    `sex` TEXT,
+    `year_of_birth` BIGINT,
+    `nationality` TEXT,
+    `military_civilian` TEXT,
+    `selection` TEXT,
+    `year_of_selection` BIGINT,
+    `mission_number` BIGINT,
+    `total_number_of_missions` BIGINT,
+    `occupation` TEXT,
+    `year_of_mission` BIGINT,
+    `mission_title` TEXT,
+    `ascend_shuttle` TEXT,
+    `in_orbit` TEXT,
+    `descend_shuttle` TEXT,
+    `hours_mission` FLOAT,
+    `total_hrs_sum` FLOAT,
+    `field21` BIGINT,
+    `eva_hrs_mission` FLOAT,
+    `total_eva_hrs` FLOAT
+);
+
 DROP TABLE IF EXISTS batting;
 
 CREATE TABLE batting (

--- a/ci/schema/oracle.sql
+++ b/ci/schema/oracle.sql
@@ -18,6 +18,35 @@ CREATE TABLE "diamonds" (
     "z" BINARY_FLOAT
 );
 
+DROP TABLE IF EXISTS "astronauts";
+
+CREATE TABLE "astronauts" (
+    "id" NUMBER(18),
+    "number" NUMBER(18),
+    "nationwide_number" NUMBER(18),
+    "name" VARCHAR2(255),
+    "original_name" VARCHAR2(255),
+    "sex" VARCHAR2(255),
+    "year_of_birth" NUMBER(18),
+    "nationality" VARCHAR2(255),
+    "military_civilian" VARCHAR2(255),
+    "selection" VARCHAR2(255),
+    "year_of_selection" NUMBER(18),
+    "mission_number" NUMBER(18),
+    "total_number_of_missions" NUMBER(18),
+    "occupation" VARCHAR2(255),
+    "year_of_mission" NUMBER(18),
+    "mission_title" VARCHAR2(255),
+    "ascend_shuttle" VARCHAR2(255),
+    "in_orbit" VARCHAR2(255),
+    "descend_shuttle" VARCHAR2(255),
+    "hours_mission" BINARY_FLOAT,
+    "total_hrs_sum" BINARY_FLOAT,
+    "field21" NUMBER(18),
+    "eva_hrs_mission" BINARY_FLOAT,
+    "total_eva_hrs" BINARY_FLOAT
+);
+
 DROP TABLE IF EXISTS "batting";
 
 CREATE TABLE "batting" (

--- a/ci/schema/oracle/astronauts.ctl
+++ b/ci/schema/oracle/astronauts.ctl
@@ -1,0 +1,29 @@
+options (SKIP=1)
+load data
+  infile '/opt/oracle/data/astronauts.csv'
+  into table "astronauts"
+  fields csv with embedded
+  ("id",
+    "number",
+    "nationwide_number",
+    "name",
+    "original_name",
+    "sex",
+    "year_of_birth",
+    "nationality",
+    "military_civilian",
+    "selection",
+    "year_of_selection",
+    "mission_number",
+    "total_number_of_missions",
+    "occupation",
+    "year_of_mission",
+    "mission_title",
+    "ascend_shuttle",
+    "in_orbit",
+    "descend_shuttle",
+    "hours_mission",
+    "total_hrs_sum",
+    "field21",
+    "eva_hrs_mission",
+    "total_eva_hrs")

--- a/ci/schema/oracle/awards_players.ctl
+++ b/ci/schema/oracle/awards_players.ctl
@@ -2,6 +2,6 @@ options (SKIP=1)
 load data
   infile '/opt/oracle/data/awards_players.csv'
   into table "awards_players"
-  fields terminated by "," optionally enclosed by '"'
+  fields csv without embedded
   TRAILING NULLCOLS
   ( "playerID", "awardID", "yearID", "lgID", "tie", "notes" )

--- a/ci/schema/oracle/batting.ctl
+++ b/ci/schema/oracle/batting.ctl
@@ -2,6 +2,6 @@ options (SKIP=1)
 load data
   infile '/opt/oracle/data/batting.csv'
   into table "batting"
-  fields terminated by "," optionally enclosed by '"'
+  fields csv without embedded
   TRAILING NULLCOLS
   ( "playerID", "yearID", "stint", "teamID", "lgID", "G", "AB", "R", "H", "X2B", "X3B", "HR", "RBI", "SB", "CS", "BB", "SO", "IBB", "HBP", "SH", "SF", "GIDP" )

--- a/ci/schema/oracle/diamonds.ctl
+++ b/ci/schema/oracle/diamonds.ctl
@@ -2,5 +2,5 @@ options (SKIP=1)
 load data
   infile '/opt/oracle/data/diamonds.csv'
   into table "diamonds"
-  fields terminated by "," optionally enclosed by '"'
+  fields csv without embedded
   ( "carat", "cut", "color", "clarity", "depth", "table", "price", "x", "y", "z" )

--- a/ci/schema/oracle/functional_alltypes.ctl
+++ b/ci/schema/oracle/functional_alltypes.ctl
@@ -2,7 +2,7 @@ options (SKIP=1)
 load data
   infile '/opt/oracle/data/functional_alltypes.csv'
   into table "functional_alltypes"
-  fields terminated by "," optionally enclosed by '"'
+  fields csv without embedded
   TRAILING NULLCOLS
   ( "id",
   "bool_col",

--- a/ci/schema/postgres.sql
+++ b/ci/schema/postgres.sql
@@ -22,6 +22,37 @@ CREATE TABLE diamonds (
 
 COPY diamonds FROM '/data/diamonds.csv' WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',');
 
+DROP TABLE IF EXISTS astronauts CASCADE;
+
+CREATE TABLE astronauts (
+    "id" BIGINT,
+    "number" BIGINT,
+    "nationwide_number" BIGINT,
+    "name" VARCHAR,
+    "original_name" VARCHAR,
+    "sex" VARCHAR,
+    "year_of_birth" BIGINT,
+    "nationality" VARCHAR,
+    "military_civilian" VARCHAR,
+    "selection" VARCHAR,
+    "year_of_selection" BIGINT,
+    "mission_number" BIGINT,
+    "total_number_of_missions" BIGINT,
+    "occupation" VARCHAR,
+    "year_of_mission" BIGINT,
+    "mission_title" VARCHAR,
+    "ascend_shuttle" VARCHAR,
+    "in_orbit" VARCHAR,
+    "descend_shuttle" VARCHAR,
+    "hours_mission" DOUBLE PRECISION,
+    "total_hrs_sum" DOUBLE PRECISION,
+    "field21" BIGINT,
+    "eva_hrs_mission" DOUBLE PRECISION,
+    "total_eva_hrs" DOUBLE PRECISION
+);
+
+COPY astronauts FROM '/data/astronauts.csv' WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',');
+
 DROP TABLE IF EXISTS batting CASCADE;
 
 CREATE TABLE batting (

--- a/ci/schema/snowflake.sql
+++ b/ci/schema/snowflake.sql
@@ -11,6 +11,33 @@ CREATE OR REPLACE TABLE diamonds (
     "z" FLOAT
 );
 
+CREATE OR REPLACE TABLE astronauts (
+    "id" BIGINT,
+    "number" BIGINT,
+    "nationwide_number" BIGINT,
+    "name" TEXT,
+    "original_name" TEXT,
+    "sex" TEXT,
+    "year_of_birth" BIGINT,
+    "nationality" TEXT,
+    "military_civilian" TEXT,
+    "selection" TEXT,
+    "year_of_selection" BIGINT,
+    "mission_number" BIGINT,
+    "total_number_of_missions" BIGINT,
+    "occupation" TEXT,
+    "year_of_mission" BIGINT,
+    "mission_title" TEXT,
+    "ascend_shuttle" TEXT,
+    "in_orbit" TEXT,
+    "descend_shuttle" TEXT,
+    "hours_mission" FLOAT,
+    "total_hrs_sum" FLOAT,
+    "field21" BIGINT,
+    "eva_hrs_mission" FLOAT,
+    "total_eva_hrs" FLOAT
+);
+
 CREATE OR REPLACE TABLE batting (
     "playerID" TEXT,
     "yearID" BIGINT,

--- a/ci/schema/sqlite.sql
+++ b/ci/schema/sqlite.sql
@@ -17,6 +17,35 @@ CREATE TABLE functional_alltypes (
     CHECK (bool_col IN (0, 1))
 );
 
+DROP TABLE IF EXISTS astronauts;
+
+CREATE TABLE astronauts (
+    "id" BIGINT,
+    "number" BIGINT,
+    "nationwide_number" BIGINT,
+    "name" TEXT,
+    "original_name" TEXT,
+    "sex" TEXT,
+    "year_of_birth" BIGINT,
+    "nationality" TEXT,
+    "military_civilian" TEXT,
+    "selection" TEXT,
+    "year_of_selection" BIGINT,
+    "mission_number" BIGINT,
+    "total_number_of_missions" BIGINT,
+    "occupation" TEXT,
+    "year_of_mission" BIGINT,
+    "mission_title" TEXT,
+    "ascend_shuttle" TEXT,
+    "in_orbit" TEXT,
+    "descend_shuttle" TEXT,
+    "hours_mission" FLOAT,
+    "total_hrs_sum" FLOAT,
+    "field21" BIGINT,
+    "eva_hrs_mission" FLOAT,
+    "total_eva_hrs" FLOAT
+);
+
 DROP TABLE IF EXISTS awards_players;
 
 CREATE TABLE awards_players (

--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -222,13 +222,14 @@ class AlchemySelect(Select):
         if self.table_set is not None:
             helper = self.table_set_formatter_class(self, self.table_set)
             result = helper.get_result()
-            if isinstance(result, sql.selectable.Select):
-                return result.subquery()
             return result
         else:
             return None
 
     def _add_select(self, table_set):
+        if not self.select_set:
+            return table_set.element
+
         to_select = []
 
         context = self.context
@@ -373,6 +374,11 @@ class AlchemySelect(Select):
 class AlchemySelectBuilder(SelectBuilder):
     def _convert_group_by(self, exprs):
         return exprs
+
+    def _collect_SQLQueryResult(self, op, toplevel=False):
+        if toplevel:
+            self.table_set = op
+            self.select_set = []
 
 
 class AlchemySetOp(SetOp):

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -94,6 +94,34 @@ TEST_TABLES = {
             "notes": "string",
         }
     ),
+    "astronauts": ibis.schema(
+        {
+            "id": "int64",
+            "number": "int64",
+            "nationwide_number": "int64",
+            "name": "string",
+            "original_name": "string",
+            "sex": "string",
+            "year_of_birth": "int64",
+            "nationality": "string",
+            "military_civilian": "string",
+            "selection": "string",
+            "year_of_selection": "int64",
+            "mission_number": "int64",
+            "total_number_of_missions": "int64",
+            "occupation": "string",
+            "year_of_mission": "int64",
+            "mission_title": "string",
+            "ascend_shuttle": "string",
+            "in_orbit": "string",
+            "descend_shuttle": "string",
+            "hours_mission": "float64",
+            "total_hrs_sum": "float64",
+            "field21": "int64",
+            "eva_hrs_mission": "float64",
+            "total_eva_hrs": "float64",
+        }
+    ),
 }
 
 # We want to check for exceptions in xfail tests for two reasons:

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -32,11 +32,8 @@ def awards_players_csv_connector_configs():
 
 
 def test_list_tables(con):
-    assert len(con.list_tables()) == 4
-    assert (
-        len(con.list_tables(catalog="default_catalog", database="default_database"))
-        == 4
-    )
+    assert len(con.list_tables())
+    assert con.list_tables(catalog="default_catalog", database="default_database")
 
 
 def test_create_table_from_schema(
@@ -47,38 +44,26 @@ def test_create_table_from_schema(
         schema=awards_players_schema,
         tbl_properties=awards_players_csv_connector_configs,
     )
-    assert len(con.list_tables()) == 5
     assert temp_table in con.list_tables()
     assert new_table.schema() == awards_players_schema
 
 
-def test_drop_table(
-    con, awards_players_schema, temp_table, awards_players_csv_connector_configs
+@pytest.mark.parametrize("temp", [True, False])
+def test_create_table(
+    con, awards_players_schema, temp_table, awards_players_csv_connector_configs, temp
 ):
     con.create_table(
         temp_table,
         schema=awards_players_schema,
         tbl_properties=awards_players_csv_connector_configs,
+        temp=temp,
     )
-    assert len(con.list_tables()) == 5
-    con.drop_table(temp_table)
-    assert len(con.list_tables()) == 4
-    assert temp_table not in con.list_tables()
-
-
-def test_temp_table(
-    con, awards_players_schema, temp_table, awards_players_csv_connector_configs
-):
-    con.create_table(
-        temp_table,
-        schema=awards_players_schema,
-        tbl_properties=awards_players_csv_connector_configs,
-        temp=True,
-    )
-    assert len(con.list_tables()) == 5
     assert temp_table in con.list_tables()
-    with pytest.raises(Py4JJavaError):
-        con.drop_table(temp_table)
-    con.drop_table(temp_table, temp=True)
-    assert len(con.list_tables()) == 4
+
+    if temp:
+        with pytest.raises(Py4JJavaError):
+            con.drop_table(temp_table)
+
+    con.drop_table(temp_table, temp=temp)
+
     assert temp_table not in con.list_tables()

--- a/ibis/backends/sqlite/tests/conftest.py
+++ b/ibis/backends/sqlite/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import csv
+import io
 import sqlite3
 from typing import Any
 
@@ -34,8 +35,14 @@ class TestConf(BackendTest, RoundAwayFromZero):
         with self.connection.begin() as con:
             for table in TEST_TABLES:
                 basename = f"{table}.csv"
-                with self.data_dir.joinpath("csv", basename).open("r") as f:
-                    reader = csv.reader(f)
+                with self.data_dir.joinpath("csv", basename).open(
+                    "r", encoding="UTF-8"
+                ) as f:
+                    if basename == "astronauts.csv":
+                        input = io.StringIO(f.read().replace("\n ", " "))
+                    else:
+                        input = f
+                    reader = csv.reader(input)
                     header = next(reader)
                     assert header, f"empty header for table: `{table}`"
                     spec = ", ".join("?" * len(header))

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -215,6 +215,10 @@ class BackendTest(abc.ABC):
         return self.connection.table(self.default_identifier_case_fn("diamonds"))
 
     @property
+    def astronauts(self) -> ir.Table:
+        return self.connection.table(self.default_identifier_case_fn("astronauts"))
+
+    @property
     def geo(self) -> ir.Table | None:
         name = self.default_identifier_case_fn("geo")
         if name in self.connection.list_tables():

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -292,3 +292,20 @@ def test_con_dot_sql_transpile(backend, con, dialect, df):
     result = expr.execute()
     expected = df.int_col.add(1).rename("x")
     backend.assert_series_equal(result.x, expected)
+
+
+@dot_sql_notimpl
+@dot_sql_notyet
+@dot_sql_never
+@pytest.mark.notimpl(["druid", "flink", "impala", "polars", "pyspark"])
+def test_order_by_no_projection(backend):
+    con = backend.connection
+    astronauts = con.table("astronauts")
+    expr = (
+        astronauts.group_by("name")
+        .agg(nbr_missions=_.count())
+        .order_by(_.nbr_missions.desc())
+    )
+
+    result = con.sql(ibis.to_sql(expr)).execute().name.iloc[:2]
+    assert set(result) == {"Ross, Jerry L.", "Chang-Diaz, Franklin R."}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -21,8 +21,8 @@ in
     name = "ibis-testing-data";
     owner = "ibis-project";
     repo = "testing-data";
-    rev = "2b3968deaa1a28791b2901dbbcc9bfd3d2f23e9b";
-    sha256 = "sha256-q1b5IcOl5oIFXP7/P5RufncjHEVrWp4NjoU2uo/BE9U=";
+    rev = "a5b2f66ec594f5fac23f2fa60328dfae8a14e5b4";
+    sha256 = "sha256-oU+RPo1Qsc1fagC8bHbq2YMGwSxfiCXv7o/mqE4hSEA=";
   };
 
   ibis39 = pkgs.callPackage ./ibis.nix { python3 = pkgs.python39; };


### PR DESCRIPTION
This PR address the removal of `ORDER BY` clauses that is happening due to an unnecessary extra projection on sqlalchemy relations. The fix is to return early when no `select_set` is collected. Closes #7050.