### PR TITLE
chore(quarto-preview): avoid trying to process `nil` value when API docs do not exist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,3 @@ requirements.txt linguist-generated=true
 docs/backends/app/requirements.txt linguist-generated=false
 docs/_freeze/**/html.json linguist-generated=true
 docs/**/*.excalidraw linguist-generated=true
-docs/_extensions/** linguist-generated=true

--- a/docs/_extensions/machow/interlinks/interlinks.lua
+++ b/docs/_extensions/machow/interlinks/interlinks.lua
@@ -236,7 +236,9 @@ return {
                 local base_name = quarto.project.offset .. "/_inv/" .. k .. "_objects"
                 json = read_inv_text_or_json(base_name)
                 prefix = pandoc.utils.stringify(v.url)
-                fixup_json(json, prefix)
+                if json ~= nil then
+                    fixup_json(json, prefix)
+                end
             end
             json = read_inv_text_or_json(quarto.project.offset .. "/objects")
             if json ~= nil then


### PR DESCRIPTION
Addresses https://github.com/machow/quartodoc/pull/268 until that is in a release.

Since we're likely going to encounter extension issues in the future I've turned off considering extension code generated.