### PR TITLE
fix(pyspark): gate datediff op to restore pyspark 3.2 support

### DIFF
--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -949,6 +949,11 @@ timestamp_value = pd.Timestamp("2018-01-01 18:18:18")
             ),
             id="date-subtract-date",
             marks=[
+                pytest.mark.xfail_version(
+                    pyspark=["pyspark<3.3"],
+                    raises=AttributeError,
+                    reason="DayTimeIntervalType added in pyspark 3.3",
+                ),
                 pytest.mark.notimpl(["bigquery"], raises=com.OperationNotDefinedError),
                 pytest.mark.notimpl(
                     ["druid"],


### PR DESCRIPTION
This _might_ fix #7060 -- it gates the usage of the `DayTimeIntervalType` based on the pyspark version.

I can't even get pyspark 3.2 to start a session on my laptop, so this is untested locally.