### PR TITLE
docs(install): point to `connect` anchor instead of `do_connect`

### DIFF
--- a/docs/_tabsets/install.qmd
+++ b/docs/_tabsets/install.qmd
@@ -54,7 +54,7 @@ for installer in installers:
         print()
         print(f"```bash\n{cmd.format(extra=extra)}\n```")
         print()
-        print(f"Connect using [`ibis.{mod}.connect`](./backends/{name.lower()}.qmd#ibis.backends.{mod}.Backend.do_connect).")
+        print(f"Connect using [`ibis.{mod}.connect`](./backends/{name.lower()}.qmd#ibis.{mod}.connect).")
         print()
 
     if name == "pip":


### PR DESCRIPTION
A small change in the installation tabset.

The `ibis.{backend_name}.connect` anchor has the sample connection strings and is located directly above the `do_connect` anchor we're currently linking to.  