### PR TITLE
docs: fix edit this page button

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -45,6 +45,8 @@ website:
   back-to-top-navigation: true
   repo-url: https://github.com/ibis-project/ibis
   repo-actions: [edit, issue]
+  repo-branch: master
+  repo-subdir: docs
   issue-url: https://github.com/ibis-project/ibis/issues/new/choose
 
   # footer


### PR DESCRIPTION
we should consider switching to `main` as the default branch; the `repo-subdir` will be needed either way

docs: https://quarto.org/docs/websites/website-navigation.html#github-links
