### PR TITLE
docs: remove stray bracket

### DIFF
--- a/docs/how-to/analytics/basics.qmd
+++ b/docs/how-to/analytics/basics.qmd
@@ -63,7 +63,7 @@ t.join(t, t["species"] == t["species"], how="left_semi")
 
 ## Combining it all together
 
-We can use [the underscore to chain expressions together](./chain_expressions.qmd).]
+We can use [the underscore to chain expressions together](./chain_expressions.qmd).
 
 ```{python}
 t.join(t, t["species"] == t["species"], how="left_semi").filter(


### PR DESCRIPTION
this was the change I wanted to edit through the browser! removes a single stray bracket in a how-to guide
