### PR TITLE
feat(duckdb): expose loading extensions

### DIFF
--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import duckdb
+import pytest
+import sqlalchemy as sa
+
+import ibis
+from ibis.conftest import LINUX, SANDBOXED
+
+
+@pytest.mark.xfail(
+    LINUX and SANDBOXED,
+    reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
+    raises=sa.exc.OperationalError,
+)
+def test_connect_extensions():
+    con = ibis.duckdb.connect(extensions=["s3", "sqlite"])
+    results = con.raw_sql(
+        """
+        SELECT loaded FROM duckdb_extensions()
+        WHERE extension_name = 'httpfs' OR extension_name = 'sqlite'
+        """
+    ).fetchall()
+    assert all(loaded for (loaded,) in results)
+
+
+@pytest.mark.xfail(
+    LINUX and SANDBOXED,
+    reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
+    raises=duckdb.IOException,
+)
+def test_load_extension():
+    con = ibis.duckdb.connect()
+    con.load_extension("s3")
+    con.load_extension("sqlite")
+    results = con.raw_sql(
+        """
+        SELECT loaded FROM duckdb_extensions()
+        WHERE extension_name = 'httpfs' OR extension_name = 'sqlite'
+        """
+    ).fetchall()
+    assert all(loaded for (loaded,) in results)


### PR DESCRIPTION
- Adds an `extensions` option to `ibis.duckdb.connect` for automatically installing/loading extensions by name on connect
- Adds a `con.load_extension` method for installing/loading an extension on an existing connection

~Still needs tests, will finish up tomorrow.~

Fixes #7063.