### PR TITLE
docs: update link to sqlalchemy tutorial

### DIFF
--- a/docs/concepts/internals.qmd
+++ b/docs/concepts/internals.qmd
@@ -125,7 +125,7 @@ The next major component of Ibis is the compilers.
 
 The first few versions of Ibis directly generated strings, but the compiler
 infrastructure was generalized to support compilation of
-[SQLAlchemy](https://docs.sqlalchemy.org/en/latest/core/tutorial.html) based
+[SQLAlchemy](https://docs.sqlalchemy.org/en/latest/tutorial/index.html#unified-tutorial) based
 expressions.
 
 The compiler works by translating the different pieces of SQL expression into a


### PR DESCRIPTION
The previous link goes to a page that says the resource has moved, so I updated the link to that resource. 