### PR TITLE
docs: move column selectors closer to relevant expression page

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -142,13 +142,13 @@ website:
           contents:
             - reference/top_level.qmd
             - reference/expression-tables.qmd
+            - reference/selectors.qmd
             - reference/expression-generic.qmd
             - reference/expression-strings.qmd
             - reference/expression-numeric.qmd
             - reference/expression-temporal.qmd
             - reference/expression-collections.qmd
             - reference/expression-geospatial.qmd
-            - reference/selectors.qmd
 
         - section: Type system
           contents:


### PR DESCRIPTION
This PR moves column selector API docs closer to where they are more likely to come up.