### PR TITLE
refactor(api): remove string as a parent type from expression API

### DIFF
--- a/ibis/backends/base/sql/registry/literal.py
+++ b/ibis/backends/base/sql/registry/literal.py
@@ -96,7 +96,7 @@ def literal(translator, op):
 
     if dtype.is_boolean():
         typeclass = "boolean"
-    elif dtype.is_string():
+    elif dtype.is_string() or dtype.is_inet() or dtype.is_macaddr():
         typeclass = "string"
     elif dtype.is_date():
         typeclass = "date"

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -451,7 +451,7 @@ def _literal(op, **kw):
     elif dtype.is_inet():
         v = str(value)
         return f"toIPv6({v!r})" if ":" in v else f"toIPv4({v!r})"
-    elif dtype.is_string():
+    elif dtype.is_string() or dtype.is_macaddr():
         quoted = value.replace("'", "''").replace("\\", "\\\\")
         return f"'{quoted}'"
     elif dtype.is_decimal():

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -1017,7 +1017,7 @@ class UUID(DataType):
 
 
 @public
-class MACADDR(String):
+class MACADDR(DataType):
     """Media Access Control (MAC) address of a network interface."""
 
     scalar = "MACADDRScalar"
@@ -1025,7 +1025,7 @@ class MACADDR(String):
 
 
 @public
-class INET(String):
+class INET(DataType):
     """IP addresses."""
 
     scalar = "INETScalar"

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -287,7 +287,7 @@ def normalize(typ, value):
             return json.dumps(value)
     elif dtype.is_binary():
         return bytes(value)
-    elif dtype.is_string():
+    elif dtype.is_string() or dtype.is_macaddr() or dtype.is_inet():
         return str(value)
     elif dtype.is_decimal():
         return normalize_decimal(value, precision=dtype.precision, scale=dtype.scale)

--- a/ibis/expr/types/inet.py
+++ b/ibis/expr/types/inet.py
@@ -2,34 +2,34 @@ from __future__ import annotations
 
 from public import public
 
-from ibis.expr.types.strings import StringColumn, StringScalar, StringValue
+from ibis.expr.types.generic import Column, Scalar, Value
 
 
 @public
-class MACADDRValue(StringValue):
+class MACADDRValue(Value):
     pass
 
 
 @public
-class MACADDRScalar(StringScalar, MACADDRValue):
+class MACADDRScalar(Scalar, MACADDRValue):
     pass
 
 
 @public
-class MACADDRColumn(StringColumn, MACADDRValue):
+class MACADDRColumn(Column, MACADDRValue):
     pass
 
 
 @public
-class INETValue(StringValue):
+class INETValue(Value):
     pass
 
 
 @public
-class INETScalar(StringScalar, INETValue):
+class INETScalar(Scalar, INETValue):
     pass
 
 
 @public
-class INETColumn(StringColumn, INETValue):
+class INETColumn(Column, INETValue):
     pass

--- a/ibis/expr/types/uuid.py
+++ b/ibis/expr/types/uuid.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 from public import public
 
-from ibis.expr.types.strings import StringColumn, StringScalar, StringValue
+from ibis.expr.types.generic import Column, Scalar, Value
 
 
 @public
-class UUIDValue(StringValue):
+class UUIDValue(Value):
     pass
 
 
 @public
-class UUIDScalar(StringScalar, UUIDValue):
+class UUIDScalar(Scalar, UUIDValue):
     pass
 
 
 @public
-class UUIDColumn(StringColumn, UUIDValue):
+class UUIDColumn(Column, UUIDValue):
     pass

--- a/ibis/formats/numpy.py
+++ b/ibis/formats/numpy.py
@@ -80,6 +80,8 @@ class NumpyType(TypeMapper[np.dtype]):
             or dtype.is_unknown()
             or dtype.is_uuid()
             or dtype.is_geospatial()
+            or dtype.is_inet()
+            or dtype.is_macaddr()
         ):
             return np.dtype("object")
         else:


### PR DESCRIPTION
Removes String* as a parent class of other types. This is technically a breaking change, ~though we do not have any coverage of these that I could see.~ We have some coverage of the data type changes by way of literal normalization.