### PR TITLE
ci: do not quote joined arguments to `pip install`

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -383,12 +383,12 @@ jobs:
 
       - name: install other deps
         if: matrix.backend.additional_deps != null
-        run: poetry run pip install "${{ join(matrix.backend.additional_deps, ' ') }}"
+        run: poetry run pip install ${{ join(matrix.backend.additional_deps, ' ') }}
 
       # FIXME(deepyaman)
       - name: install even more deps
         if: matrix.backend.even_more_deps != null
-        run: poetry run pip install "${{ join(matrix.backend.even_more_deps, ' ') }}"
+        run: poetry run pip install ${{ join(matrix.backend.even_more_deps, ' ') }}
 
       - name: show installed deps
         run: poetry run pip list


### PR DESCRIPTION
If you do, you can get things like:

```
Run poetry run pip install "apache-flink grpcio-status"
ERROR: Invalid requirement: 'apache-flink grpcio-status'
```