### PR TITLE
docs: remove streamlit app on front page

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -253,14 +253,6 @@ chart = sns.barplot(
 chart.figure.set_size_inches(width / 100, height / 100)
 ```
 
-## Streamlit
-
-See [the demo](/posts/ibis-analytics/) for more.
-
-```{=html}
-<iframe class="streamlit-app-inner" width="100%" height="500" src="https://ibis-analytics.streamlit.app/?embedded=true"></iframe>
-```
-
 :::
 
 :::


### PR DESCRIPTION
meant to do this pre-merge -- Streamlit doesn't really fit into the category of visualization of the rest; we have a how-to elsewhere; this app is sluggish and from my personal accounts (and goes down frequently) so we shouldn't have it on the front page


edit: oh and the post it links to is hidden and needs a full rewrite