### PR TITLE
refactor(flink): use built-in `DEGREES`, `RADIANS`

### DIFF
--- a/ibis/backends/flink/registry.py
+++ b/ibis/backends/flink/registry.py
@@ -7,6 +7,7 @@ import ibis.expr.operations as ops
 from ibis.backends.base.sql.registry import (
     fixed_arity,
     helpers,
+    unary,
     window,
 )
 from ibis.backends.base.sql.registry import (
@@ -192,6 +193,8 @@ operation_registry.update(
         ops.ExtractMinute: _extract_field("minute"),  # equivalent to MINUTE(timestamp)
         ops.ExtractSecond: _extract_field("second"),  # equivalent to SECOND(timestamp)
         ops.Literal: _literal,
+        ops.Degrees: unary("degrees"),
+        ops.Radians: unary("radians"),
         ops.RegexSearch: fixed_arity("regexp", 2),
         ops.TimestampFromUNIX: _timestamp_from_unix,
         ops.Where: _filter,


### PR DESCRIPTION
The SQLAlchemy backend's `ops.Radians` implementation works on Flink, but the `ops.Degrees` translation doesn't. For whatever reason, `SELECT 180 * CAST(5.556 AS DOUBLE) / pi()` causes casting errors, but `SELECT power(pi(), -1) * 180 * CAST(5.556 AS DOUBLE)` doesn't. However, rather than rewrite the arithmetic, we can just use the built-in method, and do the same for `ops.Radians` for consistency.