### PR TITLE
fix(api): support passing `functools.partial` to array `.map`/`.filter` methods

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import os
 
 import numpy as np
@@ -527,9 +528,14 @@ def test_array_slice(backend, start, stop):
 )
 def test_array_map(backend, con, input, output):
     t = ibis.memtable(input, schema=ibis.schema(dict(a="!array<int8>")))
+    expected = pd.DataFrame(output)
+
     expr = t.select(a=t.a.map(lambda x: x + 1))
     result = con.execute(expr)
-    expected = pd.DataFrame(output)
+    backend.assert_frame_equal(result, expected)
+
+    expr = t.select(a=t.a.map(functools.partial(lambda x, y: x + y, y=1)))
+    result = con.execute(expr)
     backend.assert_frame_equal(result, expected)
 
 
@@ -555,9 +561,14 @@ def test_array_map(backend, con, input, output):
 )
 def test_array_filter(backend, con, input, output):
     t = ibis.memtable(input, schema=ibis.schema(dict(a="!array<int8>")))
+    expected = pd.DataFrame(output)
+
     expr = t.select(a=t.a.filter(lambda x: x > 1))
     result = con.execute(expr)
-    expected = pd.DataFrame(output)
+    backend.assert_frame_equal(result, expected)
+
+    expr = t.select(a=t.a.filter(functools.partial(lambda x, y: x > y, y=1)))
+    result = con.execute(expr)
     backend.assert_frame_equal(result, expected)
 
 

--- a/ibis/common/patterns.py
+++ b/ibis/common/patterns.py
@@ -1520,20 +1520,18 @@ class CallableWith(Slotted, Pattern):
         fn = annotated(self.args, self.return_, value)
 
         has_varargs = False
-        positional, keyword_only = [], []
+        positional = []
         for p in fn.__signature__.parameters.values():
             if p.kind in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD):
                 positional.append(p)
-            elif p.kind is Parameter.KEYWORD_ONLY:
-                keyword_only.append(p)
+            elif p.kind is Parameter.KEYWORD_ONLY and p.default is Parameter.empty:
+                raise MatchError(
+                    "Callable has mandatory keyword-only arguments which cannot be specified"
+                )
             elif p.kind is Parameter.VAR_POSITIONAL:
                 has_varargs = True
 
-        if keyword_only:
-            raise MatchError(
-                "Callable has mandatory keyword-only arguments which cannot be specified"
-            )
-        elif len(positional) > len(self.args):
+        if len(positional) > len(self.args):
             # Callable has more positional arguments than expected")
             return NoMatch
         elif len(positional) < len(self.args) and not has_varargs:

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -527,7 +527,10 @@ def test_callable_with():
     def func_with_kwargs(a, b, c=1, **kwargs):
         return str(a) + b + str(c)
 
-    def func_with_mandatory_kwargs(*, c):
+    def func_with_optional_keyword_only_kwargs(a, *, c=1):
+        return a + c
+
+    def func_with_required_keyword_only_kwargs(*, c):
         return c
 
     p = CallableWith([InstanceOf(int), InstanceOf(str)])
@@ -535,7 +538,7 @@ def test_callable_with():
 
     msg = "Callable has mandatory keyword-only arguments which cannot be specified"
     with pytest.raises(MatchError, match=msg):
-        p.match(func_with_mandatory_kwargs, context={})
+        p.match(func_with_required_keyword_only_kwargs, context={})
 
     # Callable has more positional arguments than expected
     p = CallableWith([InstanceOf(int)] * 2)
@@ -555,6 +558,10 @@ def test_callable_with():
 
     with pytest.raises(ValidationError, match="2 doesn't match InstanceOf"):
         wrapped(1, 2)
+
+    p = CallableWith([InstanceOf(int)])
+    wrapped = p.match(func_with_optional_keyword_only_kwargs, context={})
+    assert wrapped(1) == 2
 
 
 def test_pattern_list():

--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -80,7 +80,7 @@ class ArrayApply(Value):
 
     @attribute
     def parameter(self):
-        (name,) = self.func.__signature__.parameters.keys()
+        name = next(iter(self.func.__signature__.parameters.keys()))
         return name
 
     @attribute

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -396,8 +396,8 @@ class ArrayValue(Value):
         """
 
         @functools.wraps(func)
-        def wrapped(x):
-            return func(x.to_expr())
+        def wrapped(x, **kwargs):
+            return func(x.to_expr(), **kwargs)
 
         return ops.ArrayMap(self, func=wrapped).to_expr()
 
@@ -444,8 +444,8 @@ class ArrayValue(Value):
         """
 
         @functools.wraps(predicate)
-        def wrapped(x):
-            return predicate(x.to_expr())
+        def wrapped(x, **kwargs):
+            return predicate(x.to_expr(), **kwargs)
 
         return ops.ArrayFilter(self, func=wrapped).to_expr()
 

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import ipaddress
 import operator
 import uuid
@@ -1536,9 +1537,29 @@ def test_array_map():
     assert result_float.type() == dt.Array(dt.float64)
 
 
+def test_array_map_partial():
+    arr = ibis.array([1, 2, 3])
+
+    def add(x, y):
+        return x + y
+
+    result = arr.map(functools.partial(add, y=2))
+    assert result.type() == dt.Array(dt.int16)
+
+
 def test_array_filter():
     arr = ibis.array([1, 2, 3])
     result = arr.filter(is_negative)
+    assert result.type() == arr.type()
+
+
+def test_array_filter_partial():
+    arr = ibis.array([1, 2, 3])
+
+    def equal(x, y):
+        return x == y
+
+    result = arr.filter(functools.partial(equal, y=2))
     assert result.type() == arr.type()
 
 


### PR DESCRIPTION
Fixes #7095.