### PR TITLE
fix(api): improve error message for bad arguments to `Table.select`

### DIFF
--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -243,6 +243,16 @@ def test_projection_no_expr(table, empty):
         table.select(empty)
 
 
+def test_projection_invalid_nested_list(table):
+    errmsg = "must be coerceable to expressions"
+    with pytest.raises(com.IbisTypeError, match=errmsg):
+        table.select(["a", ["b"]])
+    with pytest.raises(com.IbisTypeError, match=errmsg):
+        table[["a", ["b"]]]
+    with pytest.raises(com.IbisTypeError, match=errmsg):
+        table["a", ["b"]]
+
+
 def test_mutate(table):
     expr = table.mutate(
         [


### PR DESCRIPTION
Previously passing a too-nested-list with a valid column name to `Table.select` would result in ibis trying (and failing) to "windowize" the expression. We now handle `.select` argument coercion more uniformly, and error appropriately if any of the arguments fail to coerce to an `Expr`.

Fixes #7039.