### PR TITLE
ci: remove unused branches and ignore envrc file

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -5,9 +5,12 @@ on:
     # Skip the backend suite if all changes are in the docs directory
     paths-ignore:
       - "docs/**"
+      - "**/*.md"
+      - "**/*.qmd"
+      - "codecov.yml"
+      - ".envrc"
     branches:
       - master
-      - quarto
 
 permissions:
   # this allows extractions/setup-just to list releases for `just` at a higher

--- a/.github/workflows/ibis-backends-skip-helper.yml
+++ b/.github/workflows/ibis-backends-skip-helper.yml
@@ -9,20 +9,20 @@ on:
       - "**/*.md"
       - "**/*.qmd"
       - "codecov.yml"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   pull_request:
     paths:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
       - "codecov.yml"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   merge_group:
 jobs:
   test_backends:

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -8,10 +8,10 @@ on:
       - "**/*.md"
       - "**/*.qmd"
       - "codecov.yml"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   pull_request:
     # Skip the backend suite if all changes are docs
     paths-ignore:
@@ -19,10 +19,10 @@ on:
       - "**/*.md"
       - "**/*.qmd"
       - "codecov.yml"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   merge_group:
 
 permissions:

--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - master
       - "*.x.x"
-      - quarto
   pull_request:
     branches:
       - master
       - "*.x.x"
-      - quarto
   merge_group:
 
 concurrency:

--- a/.github/workflows/ibis-main-skip-helper.yml
+++ b/.github/workflows/ibis-main-skip-helper.yml
@@ -8,19 +8,19 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   pull_request:
     paths:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   merge_group:
 jobs:
   test_core:

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -7,20 +7,20 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   pull_request:
     # Skip the test suite if all changes are in the docs directory
     paths-ignore:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   merge_group:
 
 permissions:

--- a/.github/workflows/ibis-tpch-queries-skip-helper.yml
+++ b/.github/workflows/ibis-tpch-queries-skip-helper.yml
@@ -6,19 +6,19 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   pull_request:
     paths:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   merge_group:
 
 concurrency:

--- a/.github/workflows/ibis-tpch-queries.yml
+++ b/.github/workflows/ibis-tpch-queries.yml
@@ -6,19 +6,19 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   pull_request:
     paths-ignore:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   merge_group:
 
 concurrency:

--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -9,19 +9,19 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   pull_request:
     paths:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   merge_group:
 
 jobs:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,19 +6,19 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   pull_request:
     paths-ignore:
       - "docs/**"
       - "**/*.md"
       - "**/*.qmd"
+      - ".envrc"
     branches:
       - master
       - "*.x.x"
-      - quarto
   merge_group:
 
 concurrency:


### PR DESCRIPTION
A bit of github actions cleanup after the great quarto-ization.