### PR TITLE
docs: ensure that all parameters elements overflow with a scrollbar

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3,7 +3,7 @@ section#parameters {
     overflow-x: auto;
 }
 
-section#parameters-1 {
+section[id^="parameters-"] {
     /* scroll when child contents overflow the width */
     overflow-x: auto;
 }


### PR DESCRIPTION
Ensure that all parameters tables overflow with a horizontal scrollbar if necessary.