### PR TITLE
fix(impala): allow arbitrary connection params

### DIFF
--- a/docs/backends/impala.qmd
+++ b/docs/backends/impala.qmd
@@ -163,6 +163,26 @@ hdfs = ibis.impala.hdfs_connect(host=webhdfs_host, port=webhdfs_port)
 client = ibis.impala.connect(host=impala_host, port=impala_port, hdfs_client=hdfs)
 ```
 
+By default binary transport mode is used, however it is also possible to use HTTP.
+Depending on your configuration, additional connection arguments may need to be provided.
+For the full list of possible connection arguments please refer to
+the [`impyla`](https://github.com/cloudera/impyla) documentation.
+
+```python
+import ibis
+
+client = ibis.impala.connect(
+    host=impala_host,
+    port=impala_port,
+    username=username,
+    password=password,
+    use_ssl=True,
+    auth_mechanism='LDAP',
+    use_http_transport=True,
+    http_path='cliservice',
+)
+```
+
 All examples here use the following block of code to connect to impala
 using docker:
 

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -226,6 +226,7 @@ class Backend(BaseSQLBackend):
         kerberos_service_name: str = "impala",
         pool_size: int = 8,
         hdfs_client: fsspec.spec.AbstractFileSystem | None = None,
+        **params: Any,
     ):
         """Create an Impala `Backend` for use with Ibis.
 
@@ -262,6 +263,10 @@ class Backend(BaseSQLBackend):
             Size of the connection pool. Typically this is not necessary to configure.
         hdfs_client
             An existing HDFS client.
+        params
+            Any additional parameters necessary to open a connection to Impala.
+            Please refer to impyla documentation for the full list of
+            possible arguments.
 
         Examples
         --------
@@ -283,7 +288,6 @@ class Backend(BaseSQLBackend):
         self._temp_objects = set()
         self._hdfs = hdfs_client
 
-        params = {}
         if ca_cert is not None:
             params["ca_cert"] = str(ca_cert)
         self.con = ImpalaConnection(


### PR DESCRIPTION
Hello,

At the moment it is not possible to pass arbitrary keyword arguments to Impala backend, which makes it impossible to connect if, for example, Impala is configured to use HTTP transport. It should be possible to supply any arguments required by Impyla. I tested this on Impala (with S3) and both querying and table creation worked fine.

I also added one more example of how a connection can be created, which I think is more realistic to what users encounter in practice, especially with CDP. As hdfs_client is optional and not relevant to S3 setups I purposely leave it out from this example.

p.s. I closed [!7116](https://github.com/ibis-project/ibis/pull/7116) because I was having trouble rebasing my commits, hopefully commitlint will not complain anymore.