### PR TITLE
fix(duckdb): remove hack to workaround bug that was fixed upstream

### DIFF
--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -62,6 +62,9 @@ class Backend(BaseAlchemyBackend):
         # workaround a broken pydruid `has_table` implementation
         engine.dialect.has_table = self._has_table
 
+        # don't double percent signs
+        engine.dialect.identifier_preparer._double_percents = False
+
     @staticmethod
     def _new_sa_metadata():
         meta = sa.MetaData()

--- a/ibis/backends/druid/datatypes.py
+++ b/ibis/backends/druid/datatypes.py
@@ -54,6 +54,11 @@ def _smallint(element, compiler, **kw):
     return "SMALLINT"
 
 
+@compiles(DruidString, "druid")
+def _string(element, compiler, **kw):
+    return "VARCHAR"
+
+
 class DruidType(AlchemyType):
     dialect = "hive"
 

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1059,7 +1059,6 @@ def test_levenshtein(con, right):
     reason="doesn't allow boolean expressions in select statements",
     raises=sa.exc.OperationalError,
 )
-@pytest.mark.notyet(["druid"], raises=sa.exc.ProgrammingError)
 @pytest.mark.broken(
     ["oracle"],
     reason="sqlalchemy converts True to 1, which cannot be used in CASE WHEN statement",

--- a/poetry.lock
+++ b/poetry.lock
@@ -5907,4 +5907,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "60e563af5a8af6199518a35bbc8037f798f17cfee81b9cefb8d09c7509e6d70e"
+content-hash = "6863640d8684a49a7647f419cbcf4a690ea0354473f0cf68f088976cbeeb1796"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dask = { version = ">=2022.9.1", optional = true, extras = [
 datafusion = { version = ">=0.6,<29", optional = true }
 db-dtypes = { version = ">=0.3,<2", optional = true }
 deltalake = { version = ">=0.9.0,<1", optional = true }
-duckdb = { version = ">=0.3.3,<1", optional = true }
+duckdb = { version = ">=0.8.1,<1", optional = true }
 duckdb-engine = { version = ">=0.1.8,<1", optional = true }
 fsspec = { version = ">=2022.1.0", optional = true }
 GeoAlchemy2 = { version = ">=0.6.3,<1,!=0.13.0,!=0.14.0,!=0.14.1", optional = true }


### PR DESCRIPTION
Address doubly escaped percent signs in the duckdb backend, by bumping the lower bound of duckdb. Fixes #7103.

Apparently druid was broken here too, fixed that as well.