### PR TITLE
docs: only render file support methods once

### DIFF
--- a/docs/backends/datafusion.qmd
+++ b/docs/backends/datafusion.qmd
@@ -96,16 +96,6 @@ from _utils import render_do_connect
 render_do_connect("datafusion")
 ```
 
-## File Support
-
-```{python}
-#| echo: false
-#| output: asis
-from _utils import render_methods, get_backend
-backend = get_backend("datafusion")
-render_methods(backend, "read_csv", "read_parquet", "read_delta", level=4)
-```
-
 ```{python}
 #| echo: false
 BACKEND = "DataFusion"

--- a/docs/backends/duckdb.qmd
+++ b/docs/backends/duckdb.qmd
@@ -147,17 +147,6 @@ You can store it as an environment variable to avoid having to log in again:
 ['penguins']
 ```
 
-## File Support
-
-```{python}
-#| echo: false
-#| output: asis
-from _utils import render_methods, get_backend
-backend = get_backend("duckdb")
-methods = [f"read_{kind}" for kind in ("csv", "parquet", "delta", "json", "in_memory", "sqlite", "postgres")]
-render_methods(backend, *methods, level=4)
-```
-
 ```{python}
 #| echo: false
 BACKEND = "DuckDB"

--- a/docs/backends/polars.qmd
+++ b/docs/backends/polars.qmd
@@ -90,18 +90,6 @@ from _utils import render_do_connect
 render_do_connect("polars")
 ```
 
-## File Support
-
-```{python}
-#| echo: false
-#| output: asis
-from _utils import render_methods, get_backend
-
-methods = ("read_csv", "read_parquet", "read_delta")
-backend = get_backend("polars")
-render_methods(backend, *methods, level=4)
-```
-
 ```{python}
 #| echo: false
 BACKEND = "Polars"

--- a/docs/backends/pyspark.qmd
+++ b/docs/backends/pyspark.qmd
@@ -94,18 +94,6 @@ from _utils import render_do_connect
 render_do_connect("pyspark")
 ```
 
-## File Support
-
-```{python}
-#| echo: false
-#| output: asis
-from _utils import render_methods, get_backend
-
-methods = ("read_csv", "read_parquet")
-backend = get_backend("pyspark")
-render_methods(backend, *methods, level=4)
-```
-
 ```{python}
 #| echo: false
 BACKEND = "PySpark"

--- a/docs/backends/snowflake.qmd
+++ b/docs/backends/snowflake.qmd
@@ -163,18 +163,6 @@ app.
 
 ![Snowflake Database](./images/snowflake_database.png)
 
-## File Support
-
-```{python}
-#| echo: false
-#| output: asis
-from _utils import render_methods, get_backend
-
-methods = ("read_csv", "read_parquet", "read_json")
-backend = get_backend("snowflake")
-render_methods(backend, *methods, level=4)
-```
-
 ```{python}
 #| echo: false
 BACKEND = "Snowflake"


### PR DESCRIPTION
This PR removes some duplicate rendering of file support methods like `read_csv` etc.