### PR TITLE
perf(ops): allow larger table sets in expressions

### DIFF
--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -217,7 +217,7 @@ class Concrete(Immutable, Comparable, Annotable):
         return self.__precomputed_hash__
 
     def __equals__(self, other) -> bool:
-        return self.__args__ == other.__args__
+        return hash(self) == hash(other) and self.__args__ == other.__args__
 
     @property
     def args(self):


### PR DESCRIPTION
This PR is ~a draft of~ a fix for #7124.

There are at least four issues, two of which are addressed in this PR.

1. For giant set operations, like a nested union of 400 tables with another
   giant union, the schema was computed dynamically, resulting in a traversal
   of that entire 400 deep set on every access. I've replaced all the schema `@property`
   with `@attribute` where possible (e.g., not joins because `__init__`
   can affect the result and `@attribute` is computed on construction).
   This effectively removes the traversal at the cost of some additional memory
   used to store the `Schema` object on each relation.
2. The second problem is the recursion in `__cached_equals__` and is somewhat
   related to the first.

   Here, the stack builds rapidly due to `__eq__` being called for hash
   collision resolution in the global equality cache. When `schema` was
   accessed for comparison, it was done so on every child table expression,
   resulting in a traversal of N things, then N - 1, then N - 2 and so on until
   bottoming out. By storing attributes instead of computing them we avoid that
   adding to the call stack, but there's still the problem of the
   `__cached_equals__` call stack itself.

   This was a bit trickier to arrive at, but I was thinking about other ways that
   we've replaced some recursion with iteration in the code base and
   topological sort came to mind.

   I've reimplemented `equals` to call `__cached_equals__` in a "bottom up"
   fashion after topologically sorting the nodes of the left and right side
   operations.

   This populates the cache from the starting from the leaves and should avoid
   the recursion entirely: the (N + 1)th's child expressions comparison results
   are already cached, so only the top level fields are compared.
3. The third problem is backend specific and that is that the pandas backend is
   also *highly* recursive and will hit the recursion limit during evaluation.
   There's not much to do there I think except encourage folks to move off it
   ASAP.
4. The fourth problem is unrelated to property access or equality, but perhaps
   is another place where moving some recursive code to iteration is warranted
   and that is set operation compilation.

   Set operations are compiled recursively at the moment.

   This is almost certainly something that will improve with the move to
   sqlglot, so I don't think we should address it until after that is well
   underway.

This is in draft mode to get feedback on the idea and approach.

**EDIT**: The initial approach was about 1000x slower than current `master`.

@kszucs came up with a better idea (see discussion below) and that fixes
the issue and keeps the performance roughly the same if not slightly better.

Closes #7124.
