### PR TITLE
fix(flink): translate `ops.RandomScalar` to `rand`

### DIFF
--- a/ibis/backends/flink/registry.py
+++ b/ibis/backends/flink/registry.py
@@ -195,6 +195,7 @@ operation_registry.update(
     {
         # Unary operations
         ops.NullIfZero: _nullifzero,
+        ops.RandomScalar: lambda *_: "rand()",
         ops.Degrees: unary("degrees"),
         ops.Radians: unary("radians"),
         # Unary aggregates


### PR DESCRIPTION
Nit: Is there a reason why the default translation of `ops.RandomScalar` for SQL backends is `rand(utc_to_unix_micros(utc_timestamp()))` (originally from https://github.com/ibis-project/ibis/pull/5558/files), instead of that being a specific implementation for Impala? The way I understand it, Impala has the unique behavior of always returning the same values for `rand()`, so you need to essentially randomize the seed, but this shouldn't be necessary for most backends?