### PR TITLE
feat(examples): name examples tables according to example name

### DIFF
--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -38,7 +38,7 @@ class Example(Concrete):
         name = self.name
 
         if table_name is None:
-            table_name = ibis.util.gen_name(f"examples_{name}")
+            table_name = name
 
         board = _get_board()
 

--- a/ibis/examples/tests/test_examples.py
+++ b/ibis/examples/tests/test_examples.py
@@ -65,8 +65,11 @@ def test_examples(example, example_con):
 
     assert example in repr(ex)
 
-    df = ex.fetch(backend=example_con).limit(1).execute()
-    assert len(df) == 1
+    t = ex.fetch(backend=example_con)
+    assert t.op().name == example
+
+    n = t.limit(1).count().execute()
+    assert n == 1
 
 
 def test_non_example():


### PR DESCRIPTION
For illustrative purposes, especially when using `.sql` methods, having
examples tables named the same as the example reduces setup code.
