### PR TITLE
fix(flink): rewrite `ops.Clip` using if statements

### DIFF
--- a/ibis/backends/flink/translator.py
+++ b/ibis/backends/flink/translator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ibis.expr.operations as ops
 from ibis.backends.base.sql.compiler import ExprTranslator
 from ibis.backends.flink.registry import operation_registry
 
@@ -9,3 +10,8 @@ class FlinkExprTranslator(ExprTranslator):
         "hive"  # TODO: neither sqlglot nor sqlalchemy supports flink dialect
     )
     _registry = operation_registry
+
+
+@FlinkExprTranslator.rewrites(ops.Clip)
+def _clip_no_op(op):
+    return op


### PR DESCRIPTION
For whatever reason, tests with both `upper` and `lower` fail with the base SQL translation:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.4.0, pluggy-1.2.0
Using --randomly-seed=236677405
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspaces/ibis
configfile: pyproject.toml
plugins: repeat-0.9.1, xdist-3.3.1, hypothesis-6.80.0, cov-4.1.0, httpserver-1.0.6, randomly-3.12.0, snapshot-0.0.0, benchmark-4.0.0, mock-3.11.1, clarity-1.0.1
collected 2538 items / 2532 deselected / 6 selected

ibis/backends/tests/test_numeric.py ...FFF                               [100%]

=================================== FAILURES ===================================
_____________________ test_clip[flink-<lambda>-<lambda>3] ______________________

backend = <ibis.backends.flink.tests.conftest.TestConf object at 0x7f3f028f43d0>
alltypes = DatabaseTable: functional_alltypes
  id              int64
  bool_col        boolean
  tinyint_col     int8
  smallint...ring_col string
  string_col      string
  timestamp_col   timestamp(3)
  year            int64
  month           int64
df =         id  bool_col  tinyint_col  ...           timestamp_col  year  month
0     6690      True            0  ... 201....780  2010      1
7299  3959     False            9  ... 2010-01-31 05:09:13.860  2010      1

[7300 rows x 13 columns]
ibis_func = <function <lambda> at 0x7f3f046dfb50>
pandas_func = <function <lambda> at 0x7f3f046dfbe0>

    @pytest.mark.parametrize(
        ("ibis_func", "pandas_func"),
        [
            (lambda x: x.clip(lower=0), lambda x: x.clip(lower=0)),
            (lambda x: x.clip(lower=0.0), lambda x: x.clip(lower=0.0)),
            (lambda x: x.clip(upper=0), lambda x: x.clip(upper=0)),
            param(
                lambda x: x.clip(lower=x - 1, upper=x + 1),
                lambda x: x.clip(lower=x - 1, upper=x + 1),
                marks=pytest.mark.notimpl(
                    "polars",
                    raises=com.UnsupportedArgumentError,
                    reason="Polars does not support columnar argument Subtract(int_col, 1)",
                ),
            ),
            (
                lambda x: x.clip(lower=0, upper=1),
                lambda x: x.clip(lower=0, upper=1),
            ),
            (
                lambda x: x.clip(lower=0, upper=1.0),
                lambda x: x.clip(lower=0, upper=1.0),
            ),
        ],
    )
    @pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
    def test_clip(backend, alltypes, df, ibis_func, pandas_func):
>       result = ibis_func(alltypes.int_col).execute()

ibis/backends/tests/test_numeric.py:1492: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
ibis/expr/types/core.py:322: in execute
    return self._find_backend(use_default=True).execute(
ibis/backends/flink/__init__.py:247: in execute
    df = self._table_env.sql_query(sql).to_pandas()
/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/pyflink/table/table.py:938: in to_pandas
    if batches_iterator.hasNext():
/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/py4j/java_gateway.py:1322: in __call__
    return_value = get_return_value(
/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/pyflink/util/exceptions.py:146: in deco
    return f(*a, **kw)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

answer = 'xro2304'
gateway_client = <py4j.java_gateway.GatewayClient object at 0x7f3f028f4b50>
target_id = 'o2303', name = 'hasNext'

    def get_return_value(answer, gateway_client, target_id=None, name=None):
        """Converts an answer received from the Java gateway into a Python object.
    
        For example, string representation of integers are converted to Python
        integer, string representation of objects are converted to JavaObject
        instances, etc.
    
        :param answer: the string returned by the Java gateway
        :param gateway_client: the gateway client used to communicate with the Java
            Gateway. Only necessary if the answer is a reference (e.g., object,
            list, map)
        :param target_id: the name of the object from which the answer comes from
            (e.g., *object1* in `object1.hello()`). Optional.
        :param name: the name of the member from which the answer comes from
            (e.g., *hello* in `object1.hello()`). Optional.
        """
        if is_error(answer)[0]:
            if len(answer) > 1:
                type = answer[1]
                value = OUTPUT_CONVERTER[type](answer[2:], gateway_client)
                if answer[1] == REFERENCE_TYPE:
>                   raise Py4JJavaError(
                        "An error occurred while calling {0}{1}{2}.\n".
                        format(target_id, ".", name), value)
E                   py4j.protocol.Py4JJavaError: An error occurred while calling o2303.hasNext.
E                   : java.lang.RuntimeException: Failed to fetch next result
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultIterator.nextResultFromFetcher(CollectResultIterator.java:109)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultIterator.hasNext(CollectResultIterator.java:80)
E                   	at org.apache.flink.table.planner.connectors.CollectDynamicSink$CloseableRowIteratorWrapper.hasNext(CollectDynamicSink.java:222)
E                   	at org.apache.flink.table.runtime.arrow.ArrowUtils$1.hasNext(ArrowUtils.java:571)
E                   	at org.apache.flink.table.runtime.arrow.ArrowUtils$2.hasNext(ArrowUtils.java:585)
E                   	at jdk.internal.reflect.GeneratedMethodAccessor43.invoke(Unknown Source)
E                   	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E                   	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
E                   	at org.apache.flink.api.python.shaded.py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
E                   	at org.apache.flink.api.python.shaded.py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:374)
E                   	at org.apache.flink.api.python.shaded.py4j.Gateway.invoke(Gateway.java:282)
E                   	at org.apache.flink.api.python.shaded.py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
E                   	at org.apache.flink.api.python.shaded.py4j.commands.CallCommand.execute(CallCommand.java:79)
E                   	at org.apache.flink.api.python.shaded.py4j.GatewayConnection.run(GatewayConnection.java:238)
E                   	at java.base/java.lang.Thread.run(Thread.java:829)
E                   Caused by: java.io.IOException: Failed to fetch job execution result
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.getAccumulatorResults(CollectResultFetcher.java:184)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.next(CollectResultFetcher.java:121)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultIterator.nextResultFromFetcher(CollectResultIterator.java:106)
E                   	... 14 more
E                   Caused by: java.util.concurrent.ExecutionException: org.apache.flink.runtime.client.JobExecutionException: Job execution failed.
E                   	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
E                   	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2022)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.getAccumulatorResults(CollectResultFetcher.java:182)
E                   	... 16 more
E                   Caused by: org.apache.flink.runtime.client.JobExecutionException: Job execution failed.
E                   	at org.apache.flink.runtime.jobmaster.JobResult.toJobExecutionResult(JobResult.java:144)
E                   	at org.apache.flink.runtime.minicluster.MiniClusterJobClient.lambda$getJobExecutionResult$3(MiniClusterJobClient.java:141)
E                   	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680)
E                   	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658)
E                   	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094)
E                   	at org.apache.flink.runtime.minicluster.MiniClusterJobClient.getJobExecutionResult(MiniClusterJobClient.java:138)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.getAccumulatorResults(CollectResultFetcher.java:181)
E                   	... 16 more
E                   Caused by: org.apache.flink.runtime.JobException: Recovery is suppressed by NoRestartBackoffTimeStrategy
E                   	at org.apache.flink.runtime.executiongraph.failover.flip1.ExecutionFailureHandler.handleFailure(ExecutionFailureHandler.java:139)
E                   	at org.apache.flink.runtime.executiongraph.failover.flip1.ExecutionFailureHandler.getFailureHandlingResult(ExecutionFailureHandler.java:83)
E                   	at org.apache.flink.runtime.scheduler.DefaultScheduler.recordTaskFailure(DefaultScheduler.java:258)
E                   	at org.apache.flink.runtime.scheduler.DefaultScheduler.handleTaskFailure(DefaultScheduler.java:249)
E                   	at org.apache.flink.runtime.scheduler.DefaultScheduler.onTaskFailed(DefaultScheduler.java:242)
E                   	at org.apache.flink.runtime.scheduler.SchedulerBase.onTaskExecutionStateUpdate(SchedulerBase.java:748)
E                   	at org.apache.flink.runtime.scheduler.SchedulerBase.updateTaskExecutionState(SchedulerBase.java:725)
E                   	at org.apache.flink.runtime.scheduler.SchedulerNG.updateTaskExecutionState(SchedulerNG.java:80)
E                   	at org.apache.flink.runtime.jobmaster.JobMaster.updateTaskExecutionState(JobMaster.java:479)
E                   	at jdk.internal.reflect.GeneratedMethodAccessor25.invoke(Unknown Source)
E                   	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E                   	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.lambda$handleRpcInvocation$1(AkkaRpcActor.java:309)
E                   	at org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.runWithContextClassLoader(ClassLoadingUtils.java:83)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleRpcInvocation(AkkaRpcActor.java:307)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleRpcMessage(AkkaRpcActor.java:222)
E                   	at org.apache.flink.runtime.rpc.akka.FencedAkkaRpcActor.handleRpcMessage(FencedAkkaRpcActor.java:84)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleMessage(AkkaRpcActor.java:168)
E                   	at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:24)
E                   	at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:20)
E                   	at scala.PartialFunction.applyOrElse(PartialFunction.scala:127)
E                   	at scala.PartialFunction.applyOrElse$(PartialFunction.scala:126)
E                   	at akka.japi.pf.UnitCaseStatement.applyOrElse(CaseStatements.scala:20)
E                   	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:175)
E                   	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:176)
E                   	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:176)
E                   	at akka.actor.Actor.aroundReceive(Actor.scala:537)
E                   	at akka.actor.Actor.aroundReceive$(Actor.scala:535)
E                   	at akka.actor.AbstractActor.aroundReceive(AbstractActor.scala:220)
E                   	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)
E                   	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
E                   	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
E                   	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
E                   	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
E                   	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
E                   	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
E                   	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
E                   	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
E                   	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
E                   Caused by: java.lang.RuntimeException: Could not instantiate generated class 'StreamExecCalc$33'
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.newInstance(GeneratedClass.java:84)
E                   	at org.apache.flink.table.runtime.operators.CodeGenOperatorFactory.createStreamOperator(CodeGenOperatorFactory.java:40)
E                   	at org.apache.flink.streaming.api.operators.StreamOperatorFactoryUtil.createOperator(StreamOperatorFactoryUtil.java:81)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.createOperator(OperatorChain.java:838)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.createOperatorChain(OperatorChain.java:806)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.createOutputCollector(OperatorChain.java:724)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.<init>(OperatorChain.java:199)
E                   	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.<init>(RegularOperatorChain.java:60)
E                   	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreInternal(StreamTask.java:688)
E                   	at org.apache.flink.streaming.runtime.tasks.StreamTask.restore(StreamTask.java:675)
E                   	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:952)
E                   	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:921)
E                   	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:745)
E                   	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:562)
E                   	at java.base/java.lang.Thread.run(Thread.java:829)
E                   Caused by: org.apache.flink.util.FlinkRuntimeException: org.apache.flink.api.common.InvalidProgramException: Table program cannot be compiled. This is a bug. Please file an issue.
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.compile(CompileUtils.java:94)
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.compile(GeneratedClass.java:101)
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.newInstance(GeneratedClass.java:82)
E                   	... 14 more
E                   Caused by: org.apache.flink.shaded.guava30.com.google.common.util.concurrent.UncheckedExecutionException: org.apache.flink.api.common.InvalidProgramException: Table program cannot be compiled. This is a bug. Please file an issue.
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2051)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache.get(LocalCache.java:3962)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4859)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.compile(CompileUtils.java:92)
E                   	... 16 more
E                   Caused by: org.apache.flink.api.common.InvalidProgramException: Table program cannot be compiled. This is a bug. Please file an issue.
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.doCompile(CompileUtils.java:107)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.lambda$compile$0(CompileUtils.java:92)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4864)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
E                   	... 19 more
E                   Caused by: org.codehaus.commons.compiler.CompileException: Line 53, Column 54: Expression "result$29" is not an rvalue
E                   	at org.codehaus.janino.UnitCompiler.compileError(UnitCompiler.java:12211)
E                   	at org.codehaus.janino.UnitCompiler.toRvalueOrCompileException(UnitCompiler.java:7512)
E                   	at org.codehaus.janino.UnitCompiler.getConstantValue2(UnitCompiler.java:5741)
E                   	at org.codehaus.janino.UnitCompiler.access$10300(UnitCompiler.java:215)
E                   	at org.codehaus.janino.UnitCompiler$18$1.visitAmbiguousName(UnitCompiler.java:5696)
E                   	at org.codehaus.janino.Java$AmbiguousName.accept(Java.java:4224)
E                   	at org.codehaus.janino.UnitCompiler$18.visitLvalue(UnitCompiler.java:5693)
E                   	at org.codehaus.janino.Java$Lvalue.accept(Java.java:4148)
E                   	at org.codehaus.janino.UnitCompiler.getConstantValue(UnitCompiler.java:5689)
E                   	at org.codehaus.janino.UnitCompiler.compileGetValue(UnitCompiler.java:5654)
E                   	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:2580)
E                   	at org.codehaus.janino.UnitCompiler.access$2700(UnitCompiler.java:215)
E                   	at org.codehaus.janino.UnitCompiler$6.visitLocalVariableDeclarationStatement(UnitCompiler.java:1503)
E                   	at org.codehaus.janino.UnitCompiler$6.visitLocalVariableDeclarationStatement(UnitCompiler.java:1487)
E                   	at org.codehaus.janino.Java$LocalVariableDeclarationStatement.accept(Java.java:3522)
E                   	at org.codehaus.janino.UnitCompiler.compile(UnitCompiler.java:1487)
E                   	at org.codehaus.janino.UnitCompiler.compileStatements(UnitCompiler.java:1567)
E                   	at org.codehaus.janino.UnitCompiler.compile(UnitCompiler.java:3388)
E                   	at org.codehaus.janino.UnitCompiler.compileDeclaredMethods(UnitCompiler.java:1357)
E                   	at org.codehaus.janino.UnitCompiler.compileDeclaredMethods(UnitCompiler.java:1330)
E                   	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:822)
E                   	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:432)
E                   	at org.codehaus.janino.UnitCompiler.access$400(UnitCompiler.java:215)
E                   	at org.codehaus.janino.UnitCompiler$2.visitPackageMemberClassDeclaration(UnitCompiler.java:411)
E                   	at org.codehaus.janino.UnitCompiler$2.visitPackageMemberClassDeclaration(UnitCompiler.java:406)
E                   	at org.codehaus.janino.Java$PackageMemberClassDeclaration.accept(Java.java:1414)
E                   	at org.codehaus.janino.UnitCompiler.compile(UnitCompiler.java:406)
E                   	at org.codehaus.janino.UnitCompiler.compileUnit(UnitCompiler.java:378)
E                   	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:237)
E                   	at org.codehaus.janino.SimpleCompiler.compileToClassLoader(SimpleCompiler.java:465)
E                   	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:216)
E                   	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:207)
E                   	at org.codehaus.commons.compiler.Cookable.cook(Cookable.java:80)
E                   	at org.codehaus.commons.compiler.Cookable.cook(Cookable.java:75)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.doCompile(CompileUtils.java:104)
E                   	... 25 more

/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/py4j/protocol.py:326: Py4JJavaError
----------------------------- Captured stdout call -----------------------------
/* 1 */
/* 2 */      public class StreamExecCalc$33 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$33(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$26;
/* 35 */          boolean isNull$26;
/* 36 */          boolean isNull$27;
/* 37 */          int result$28;
/* 38 */          boolean isNull$30;
/* 39 */          int result$31;
/* 40 */          
/* 41 */          
/* 42 */          isNull$26 = in1.isNullAt(4);
/* 43 */          field$26 = -1;
/* 44 */          if (!isNull$26) {
/* 45 */            field$26 = in1.getInt(4);
/* 46 */          }
/* 47 */          
/* 48 */          out.setRowKind(in1.getRowKind());
/* 49 */          
/* 50 */          
/* 51 */          
/* 52 */          
/* 53 */           java.lang.Integer tmpResult$32 = result$29;
/* 54 */           int result$32 = -1;
/* 55 */           boolean nullTerm$32 = false;
/* 56 */           
/* 57 */           
/* 58 */           java.lang.Integer tmpResult$29 = field$26;
/* 59 */           int result$29 = -1;
/* 60 */           boolean nullTerm$29 = false;
/* 61 */           
/* 62 */           
/* 63 */           if (!nullTerm$29) {
/* 64 */             java.lang.Integer cur$29 = field$26;
/* 65 */             if (isNull$26) {
/* 66 */               nullTerm$29 = true;
/* 67 */             } else {
/* 68 */               int compareResult = tmpResult$29.compareTo(cur$29);
/* 69 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 70 */                 tmpResult$29 = cur$29;
/* 71 */               }
/* 72 */             }
/* 73 */           }
/* 74 */                 
/* 75 */          
/* 76 */           
/* 77 */          
/* 78 */          
/* 79 */          isNull$27 = isNull$26 || false;
/* 80 */          result$28 = -1;
/* 81 */          if (!isNull$27) {
/* 82 */            
/* 83 */          
/* 84 */          result$28 = (int) (field$26 + ((int)(((byte) ((byte)1)))));
/* 85 */          
/* 86 */            
/* 87 */          }
/* 88 */          
/* 89 */           if (!nullTerm$29) {
/* 90 */             java.lang.Integer cur$29 = result$28;
/* 91 */             if (isNull$27) {
/* 92 */               nullTerm$29 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$29.compareTo(cur$29);
/* 95 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 96 */                 tmpResult$29 = cur$29;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */           if (!nullTerm$29) {
/* 102 */             result$29 = tmpResult$29;
/* 103 */           }
/* 104 */                 
/* 105 */           if (!nullTerm$32) {
/* 106 */             java.lang.Integer cur$32 = result$29;
/* 107 */             if (nullTerm$29) {
/* 108 */               nullTerm$32 = true;
/* 109 */             } else {
/* 110 */               int compareResult = tmpResult$32.compareTo(cur$32);
/* 111 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 112 */                 tmpResult$32 = cur$32;
/* 113 */               }
/* 114 */             }
/* 115 */           }
/* 116 */                 
/* 117 */          
/* 118 */           
/* 119 */          
/* 120 */          
/* 121 */          isNull$30 = isNull$26 || false;
/* 122 */          result$31 = -1;
/* 123 */          if (!isNull$30) {
/* 124 */            
/* 125 */          
/* 126 */          result$31 = (int) (field$26 - ((int)(((byte) ((byte)1)))));
/* 127 */          
/* 128 */            
/* 129 */          }
/* 130 */          
/* 131 */           if (!nullTerm$32) {
/* 132 */             java.lang.Integer cur$32 = result$31;
/* 133 */             if (isNull$30) {
/* 134 */               nullTerm$32 = true;
/* 135 */             } else {
/* 136 */               int compareResult = tmpResult$32.compareTo(cur$32);
/* 137 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 138 */                 tmpResult$32 = cur$32;
/* 139 */               }
/* 140 */             }
/* 141 */           }
/* 142 */                 
/* 143 */           if (!nullTerm$32) {
/* 144 */             result$32 = tmpResult$32;
/* 145 */           }
/* 146 */                 
/* 147 */          if (nullTerm$32) {
/* 148 */            out.setNullAt(0);
/* 149 */          } else {
/* 150 */            out.setInt(0, result$32);
/* 151 */          }
/* 152 */                    
/* 153 */                  
/* 154 */          output.collect(outElement.replace(out));
/* 155 */          
/* 156 */          
/* 157 */        }
/* 158 */
/* 159 */        
/* 160 */
/* 161 */        @Override
/* 162 */        public void finish() throws Exception {
/* 163 */            
/* 164 */            super.finish();
/* 165 */        }
/* 166 */
/* 167 */        @Override
/* 168 */        public void close() throws Exception {
/* 169 */           super.close();
/* 170 */           
/* 171 */        }
/* 172 */
/* 173 */        
/* 174 */      }
/* 175 */    

/* 1 */
/* 2 */      public class StreamExecCalc$33 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$33(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$26;
/* 35 */          boolean isNull$26;
/* 36 */          boolean isNull$27;
/* 37 */          int result$28;
/* 38 */          boolean isNull$30;
/* 39 */          int result$31;
/* 40 */          
/* 41 */          
/* 42 */          isNull$26 = in1.isNullAt(4);
/* 43 */          field$26 = -1;
/* 44 */          if (!isNull$26) {
/* 45 */            field$26 = in1.getInt(4);
/* 46 */          }
/* 47 */          
/* 48 */          out.setRowKind(in1.getRowKind());
/* 49 */          
/* 50 */          
/* 51 */          
/* 52 */          
/* 53 */           java.lang.Integer tmpResult$32 = result$29;
/* 54 */           int result$32 = -1;
/* 55 */           boolean nullTerm$32 = false;
/* 56 */           
/* 57 */           
/* 58 */           java.lang.Integer tmpResult$29 = field$26;
/* 59 */           int result$29 = -1;
/* 60 */           boolean nullTerm$29 = false;
/* 61 */           
/* 62 */           
/* 63 */           if (!nullTerm$29) {
/* 64 */             java.lang.Integer cur$29 = field$26;
/* 65 */             if (isNull$26) {
/* 66 */               nullTerm$29 = true;
/* 67 */             } else {
/* 68 */               int compareResult = tmpResult$29.compareTo(cur$29);
/* 69 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 70 */                 tmpResult$29 = cur$29;
/* 71 */               }
/* 72 */             }
/* 73 */           }
/* 74 */                 
/* 75 */          
/* 76 */           
/* 77 */          
/* 78 */          
/* 79 */          isNull$27 = isNull$26 || false;
/* 80 */          result$28 = -1;
/* 81 */          if (!isNull$27) {
/* 82 */            
/* 83 */          
/* 84 */          result$28 = (int) (field$26 + ((int)(((byte) ((byte)1)))));
/* 85 */          
/* 86 */            
/* 87 */          }
/* 88 */          
/* 89 */           if (!nullTerm$29) {
/* 90 */             java.lang.Integer cur$29 = result$28;
/* 91 */             if (isNull$27) {
/* 92 */               nullTerm$29 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$29.compareTo(cur$29);
/* 95 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 96 */                 tmpResult$29 = cur$29;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */           if (!nullTerm$29) {
/* 102 */             result$29 = tmpResult$29;
/* 103 */           }
/* 104 */                 
/* 105 */           if (!nullTerm$32) {
/* 106 */             java.lang.Integer cur$32 = result$29;
/* 107 */             if (nullTerm$29) {
/* 108 */               nullTerm$32 = true;
/* 109 */             } else {
/* 110 */               int compareResult = tmpResult$32.compareTo(cur$32);
/* 111 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 112 */                 tmpResult$32 = cur$32;
/* 113 */               }
/* 114 */             }
/* 115 */           }
/* 116 */                 
/* 117 */          
/* 118 */           
/* 119 */          
/* 120 */          
/* 121 */          isNull$30 = isNull$26 || false;
/* 122 */          result$31 = -1;
/* 123 */          if (!isNull$30) {
/* 124 */            
/* 125 */          
/* 126 */          result$31 = (int) (field$26 - ((int)(((byte) ((byte)1)))));
/* 127 */          
/* 128 */            
/* 129 */          }
/* 130 */          
/* 131 */           if (!nullTerm$32) {
/* 132 */             java.lang.Integer cur$32 = result$31;
/* 133 */             if (isNull$30) {
/* 134 */               nullTerm$32 = true;
/* 135 */             } else {
/* 136 */               int compareResult = tmpResult$32.compareTo(cur$32);
/* 137 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 138 */                 tmpResult$32 = cur$32;
/* 139 */               }
/* 140 */             }
/* 141 */           }
/* 142 */                 
/* 143 */           if (!nullTerm$32) {
/* 144 */             result$32 = tmpResult$32;
/* 145 */           }
/* 146 */                 
/* 147 */          if (nullTerm$32) {
/* 148 */            out.setNullAt(0);
/* 149 */          } else {
/* 150 */            out.setInt(0, result$32);
/* 151 */          }
/* 152 */                    
/* 153 */                  
/* 154 */          output.collect(outElement.replace(out));
/* 155 */          
/* 156 */          
/* 157 */        }
/* 158 */
/* 159 */        
/* 160 */
/* 161 */        @Override
/* 162 */        public void finish() throws Exception {
/* 163 */            
/* 164 */            super.finish();
/* 165 */        }
/* 166 */
/* 167 */        @Override
/* 168 */        public void close() throws Exception {
/* 169 */           super.close();
/* 170 */           
/* 171 */        }
/* 172 */
/* 173 */        
/* 174 */      }
/* 175 */    

/* 1 */
/* 2 */      public class StreamExecCalc$33 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$33(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$26;
/* 35 */          boolean isNull$26;
/* 36 */          boolean isNull$27;
/* 37 */          int result$28;
/* 38 */          boolean isNull$30;
/* 39 */          int result$31;
/* 40 */          
/* 41 */          
/* 42 */          isNull$26 = in1.isNullAt(4);
/* 43 */          field$26 = -1;
/* 44 */          if (!isNull$26) {
/* 45 */            field$26 = in1.getInt(4);
/* 46 */          }
/* 47 */          
/* 48 */          out.setRowKind(in1.getRowKind());
/* 49 */          
/* 50 */          
/* 51 */          
/* 52 */          
/* 53 */           java.lang.Integer tmpResult$32 = result$29;
/* 54 */           int result$32 = -1;
/* 55 */           boolean nullTerm$32 = false;
/* 56 */           
/* 57 */           
/* 58 */           java.lang.Integer tmpResult$29 = field$26;
/* 59 */           int result$29 = -1;
/* 60 */           boolean nullTerm$29 = false;
/* 61 */           
/* 62 */           
/* 63 */           if (!nullTerm$29) {
/* 64 */             java.lang.Integer cur$29 = field$26;
/* 65 */             if (isNull$26) {
/* 66 */               nullTerm$29 = true;
/* 67 */             } else {
/* 68 */               int compareResult = tmpResult$29.compareTo(cur$29);
/* 69 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 70 */                 tmpResult$29 = cur$29;
/* 71 */               }
/* 72 */             }
/* 73 */           }
/* 74 */                 
/* 75 */          
/* 76 */           
/* 77 */          
/* 78 */          
/* 79 */          isNull$27 = isNull$26 || false;
/* 80 */          result$28 = -1;
/* 81 */          if (!isNull$27) {
/* 82 */            
/* 83 */          
/* 84 */          result$28 = (int) (field$26 + ((int)(((byte) ((byte)1)))));
/* 85 */          
/* 86 */            
/* 87 */          }
/* 88 */          
/* 89 */           if (!nullTerm$29) {
/* 90 */             java.lang.Integer cur$29 = result$28;
/* 91 */             if (isNull$27) {
/* 92 */               nullTerm$29 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$29.compareTo(cur$29);
/* 95 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 96 */                 tmpResult$29 = cur$29;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */           if (!nullTerm$29) {
/* 102 */             result$29 = tmpResult$29;
/* 103 */           }
/* 104 */                 
/* 105 */           if (!nullTerm$32) {
/* 106 */             java.lang.Integer cur$32 = result$29;
/* 107 */             if (nullTerm$29) {
/* 108 */               nullTerm$32 = true;
/* 109 */             } else {
/* 110 */               int compareResult = tmpResult$32.compareTo(cur$32);
/* 111 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 112 */                 tmpResult$32 = cur$32;
/* 113 */               }
/* 114 */             }
/* 115 */           }
/* 116 */                 
/* 117 */          
/* 118 */           
/* 119 */          
/* 120 */          
/* 121 */          isNull$30 = isNull$26 || false;
/* 122 */          result$31 = -1;
/* 123 */          if (!isNull$30) {
/* 124 */            
/* 125 */          
/* 126 */          result$31 = (int) (field$26 - ((int)(((byte) ((byte)1)))));
/* 127 */          
/* 128 */            
/* 129 */          }
/* 130 */          
/* 131 */           if (!nullTerm$32) {
/* 132 */             java.lang.Integer cur$32 = result$31;
/* 133 */             if (isNull$30) {
/* 134 */               nullTerm$32 = true;
/* 135 */             } else {
/* 136 */               int compareResult = tmpResult$32.compareTo(cur$32);
/* 137 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 138 */                 tmpResult$32 = cur$32;
/* 139 */               }
/* 140 */             }
/* 141 */           }
/* 142 */                 
/* 143 */           if (!nullTerm$32) {
/* 144 */             result$32 = tmpResult$32;
/* 145 */           }
/* 146 */                 
/* 147 */          if (nullTerm$32) {
/* 148 */            out.setNullAt(0);
/* 149 */          } else {
/* 150 */            out.setInt(0, result$32);
/* 151 */          }
/* 152 */                    
/* 153 */                  
/* 154 */          output.collect(outElement.replace(out));
/* 155 */          
/* 156 */          
/* 157 */        }
/* 158 */
/* 159 */        
/* 160 */
/* 161 */        @Override
/* 162 */        public void finish() throws Exception {
/* 163 */            
/* 164 */            super.finish();
/* 165 */        }
/* 166 */
/* 167 */        @Override
/* 168 */        public void close() throws Exception {
/* 169 */           super.close();
/* 170 */           
/* 171 */        }
/* 172 */
/* 173 */        
/* 174 */      }
/* 175 */    

_____________________ test_clip[flink-<lambda>-<lambda>4] ______________________

backend = <ibis.backends.flink.tests.conftest.TestConf object at 0x7f3f028f43d0>
alltypes = DatabaseTable: functional_alltypes
  id              int64
  bool_col        boolean
  tinyint_col     int8
  smallint...ring_col string
  string_col      string
  timestamp_col   timestamp(3)
  year            int64
  month           int64
df =         id  bool_col  tinyint_col  ...           timestamp_col  year  month
0     6690      True            0  ... 201....780  2010      1
7299  3959     False            9  ... 2010-01-31 05:09:13.860  2010      1

[7300 rows x 13 columns]
ibis_func = <function <lambda> at 0x7f3f046dfc70>
pandas_func = <function <lambda> at 0x7f3f046dfd00>

    @pytest.mark.parametrize(
        ("ibis_func", "pandas_func"),
        [
            (lambda x: x.clip(lower=0), lambda x: x.clip(lower=0)),
            (lambda x: x.clip(lower=0.0), lambda x: x.clip(lower=0.0)),
            (lambda x: x.clip(upper=0), lambda x: x.clip(upper=0)),
            param(
                lambda x: x.clip(lower=x - 1, upper=x + 1),
                lambda x: x.clip(lower=x - 1, upper=x + 1),
                marks=pytest.mark.notimpl(
                    "polars",
                    raises=com.UnsupportedArgumentError,
                    reason="Polars does not support columnar argument Subtract(int_col, 1)",
                ),
            ),
            (
                lambda x: x.clip(lower=0, upper=1),
                lambda x: x.clip(lower=0, upper=1),
            ),
            (
                lambda x: x.clip(lower=0, upper=1.0),
                lambda x: x.clip(lower=0, upper=1.0),
            ),
        ],
    )
    @pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
    def test_clip(backend, alltypes, df, ibis_func, pandas_func):
>       result = ibis_func(alltypes.int_col).execute()

ibis/backends/tests/test_numeric.py:1492: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
ibis/expr/types/core.py:322: in execute
    return self._find_backend(use_default=True).execute(
ibis/backends/flink/__init__.py:247: in execute
    df = self._table_env.sql_query(sql).to_pandas()
/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/pyflink/table/table.py:938: in to_pandas
    if batches_iterator.hasNext():
/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/py4j/java_gateway.py:1322: in __call__
    return_value = get_return_value(
/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/pyflink/util/exceptions.py:146: in deco
    return f(*a, **kw)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

answer = 'xro2316'
gateway_client = <py4j.java_gateway.GatewayClient object at 0x7f3f028f4b50>
target_id = 'o2315', name = 'hasNext'

    def get_return_value(answer, gateway_client, target_id=None, name=None):
        """Converts an answer received from the Java gateway into a Python object.
    
        For example, string representation of integers are converted to Python
        integer, string representation of objects are converted to JavaObject
        instances, etc.
    
        :param answer: the string returned by the Java gateway
        :param gateway_client: the gateway client used to communicate with the Java
            Gateway. Only necessary if the answer is a reference (e.g., object,
            list, map)
        :param target_id: the name of the object from which the answer comes from
            (e.g., *object1* in `object1.hello()`). Optional.
        :param name: the name of the member from which the answer comes from
            (e.g., *hello* in `object1.hello()`). Optional.
        """
        if is_error(answer)[0]:
            if len(answer) > 1:
                type = answer[1]
                value = OUTPUT_CONVERTER[type](answer[2:], gateway_client)
                if answer[1] == REFERENCE_TYPE:
>                   raise Py4JJavaError(
                        "An error occurred while calling {0}{1}{2}.\n".
                        format(target_id, ".", name), value)
E                   py4j.protocol.Py4JJavaError: An error occurred while calling o2315.hasNext.
E                   : java.lang.RuntimeException: Failed to fetch next result
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultIterator.nextResultFromFetcher(CollectResultIterator.java:109)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultIterator.hasNext(CollectResultIterator.java:80)
E                   	at org.apache.flink.table.planner.connectors.CollectDynamicSink$CloseableRowIteratorWrapper.hasNext(CollectDynamicSink.java:222)
E                   	at org.apache.flink.table.runtime.arrow.ArrowUtils$1.hasNext(ArrowUtils.java:571)
E                   	at org.apache.flink.table.runtime.arrow.ArrowUtils$2.hasNext(ArrowUtils.java:585)
E                   	at jdk.internal.reflect.GeneratedMethodAccessor43.invoke(Unknown Source)
E                   	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E                   	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
E                   	at org.apache.flink.api.python.shaded.py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
E                   	at org.apache.flink.api.python.shaded.py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:374)
E                   	at org.apache.flink.api.python.shaded.py4j.Gateway.invoke(Gateway.java:282)
E                   	at org.apache.flink.api.python.shaded.py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
E                   	at org.apache.flink.api.python.shaded.py4j.commands.CallCommand.execute(CallCommand.java:79)
E                   	at org.apache.flink.api.python.shaded.py4j.GatewayConnection.run(GatewayConnection.java:238)
E                   	at java.base/java.lang.Thread.run(Thread.java:829)
E                   Caused by: java.io.IOException: Failed to fetch job execution result
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.getAccumulatorResults(CollectResultFetcher.java:184)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.next(CollectResultFetcher.java:121)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultIterator.nextResultFromFetcher(CollectResultIterator.java:106)
E                   	... 14 more
E                   Caused by: java.util.concurrent.ExecutionException: org.apache.flink.runtime.client.JobExecutionException: Job execution failed.
E                   	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
E                   	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2022)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.getAccumulatorResults(CollectResultFetcher.java:182)
E                   	... 16 more
E                   Caused by: org.apache.flink.runtime.client.JobExecutionException: Job execution failed.
E                   	at org.apache.flink.runtime.jobmaster.JobResult.toJobExecutionResult(JobResult.java:144)
E                   	at org.apache.flink.runtime.minicluster.MiniClusterJobClient.lambda$getJobExecutionResult$3(MiniClusterJobClient.java:141)
E                   	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680)
E                   	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658)
E                   	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094)
E                   	at org.apache.flink.runtime.minicluster.MiniClusterJobClient.getJobExecutionResult(MiniClusterJobClient.java:138)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.getAccumulatorResults(CollectResultFetcher.java:181)
E                   	... 16 more
E                   Caused by: org.apache.flink.runtime.JobException: Recovery is suppressed by NoRestartBackoffTimeStrategy
E                   	at org.apache.flink.runtime.executiongraph.failover.flip1.ExecutionFailureHandler.handleFailure(ExecutionFailureHandler.java:139)
E                   	at org.apache.flink.runtime.executiongraph.failover.flip1.ExecutionFailureHandler.getFailureHandlingResult(ExecutionFailureHandler.java:83)
E                   	at org.apache.flink.runtime.scheduler.DefaultScheduler.recordTaskFailure(DefaultScheduler.java:258)
E                   	at org.apache.flink.runtime.scheduler.DefaultScheduler.handleTaskFailure(DefaultScheduler.java:249)
E                   	at org.apache.flink.runtime.scheduler.DefaultScheduler.onTaskFailed(DefaultScheduler.java:242)
E                   	at org.apache.flink.runtime.scheduler.SchedulerBase.onTaskExecutionStateUpdate(SchedulerBase.java:748)
E                   	at org.apache.flink.runtime.scheduler.SchedulerBase.updateTaskExecutionState(SchedulerBase.java:725)
E                   	at org.apache.flink.runtime.scheduler.SchedulerNG.updateTaskExecutionState(SchedulerNG.java:80)
E                   	at org.apache.flink.runtime.jobmaster.JobMaster.updateTaskExecutionState(JobMaster.java:479)
E                   	at jdk.internal.reflect.GeneratedMethodAccessor25.invoke(Unknown Source)
E                   	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E                   	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.lambda$handleRpcInvocation$1(AkkaRpcActor.java:309)
E                   	at org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.runWithContextClassLoader(ClassLoadingUtils.java:83)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleRpcInvocation(AkkaRpcActor.java:307)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleRpcMessage(AkkaRpcActor.java:222)
E                   	at org.apache.flink.runtime.rpc.akka.FencedAkkaRpcActor.handleRpcMessage(FencedAkkaRpcActor.java:84)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleMessage(AkkaRpcActor.java:168)
E                   	at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:24)
E                   	at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:20)
E                   	at scala.PartialFunction.applyOrElse(PartialFunction.scala:127)
E                   	at scala.PartialFunction.applyOrElse$(PartialFunction.scala:126)
E                   	at akka.japi.pf.UnitCaseStatement.applyOrElse(CaseStatements.scala:20)
E                   	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:175)
E                   	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:176)
E                   	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:176)
E                   	at akka.actor.Actor.aroundReceive(Actor.scala:537)
E                   	at akka.actor.Actor.aroundReceive$(Actor.scala:535)
E                   	at akka.actor.AbstractActor.aroundReceive(AbstractActor.scala:220)
E                   	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)
E                   	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
E                   	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
E                   	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
E                   	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
E                   	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
E                   	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
E                   	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
E                   	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
E                   	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
E                   Caused by: java.lang.RuntimeException: Could not instantiate generated class 'StreamExecCalc$47'
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.newInstance(GeneratedClass.java:84)
E                   	at org.apache.flink.table.runtime.operators.CodeGenOperatorFactory.createStreamOperator(CodeGenOperatorFactory.java:40)
E                   	at org.apache.flink.streaming.api.operators.StreamOperatorFactoryUtil.createOperator(StreamOperatorFactoryUtil.java:81)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.createOperator(OperatorChain.java:838)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.createOperatorChain(OperatorChain.java:806)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.createOutputCollector(OperatorChain.java:724)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.<init>(OperatorChain.java:199)
E                   	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.<init>(RegularOperatorChain.java:60)
E                   	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreInternal(StreamTask.java:688)
E                   	at org.apache.flink.streaming.runtime.tasks.StreamTask.restore(StreamTask.java:675)
E                   	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:952)
E                   	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:921)
E                   	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:745)
E                   	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:562)
E                   	at java.base/java.lang.Thread.run(Thread.java:829)
E                   Caused by: org.apache.flink.util.FlinkRuntimeException: org.apache.flink.api.common.InvalidProgramException: Table program cannot be compiled. This is a bug. Please file an issue.
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.compile(CompileUtils.java:94)
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.compile(GeneratedClass.java:101)
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.newInstance(GeneratedClass.java:82)
E                   	... 14 more
E                   Caused by: org.apache.flink.shaded.guava30.com.google.common.util.concurrent.UncheckedExecutionException: org.apache.flink.api.common.InvalidProgramException: Table program cannot be compiled. This is a bug. Please file an issue.
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2051)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache.get(LocalCache.java:3962)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4859)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.compile(CompileUtils.java:92)
E                   	... 16 more
E                   Caused by: org.apache.flink.api.common.InvalidProgramException: Table program cannot be compiled. This is a bug. Please file an issue.
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.doCompile(CompileUtils.java:107)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.lambda$compile$0(CompileUtils.java:92)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4864)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
E                   	... 19 more
E                   Caused by: org.codehaus.commons.compiler.CompileException: Line 49, Column 54: Expression "result$45" is not an rvalue
E                   	at org.codehaus.janino.UnitCompiler.compileError(UnitCompiler.java:12211)
E                   	at org.codehaus.janino.UnitCompiler.toRvalueOrCompileException(UnitCompiler.java:7512)
E                   	at org.codehaus.janino.UnitCompiler.getConstantValue2(UnitCompiler.java:5741)
E                   	at org.codehaus.janino.UnitCompiler.access$10300(UnitCompiler.java:215)
E                   	at org.codehaus.janino.UnitCompiler$18$1.visitAmbiguousName(UnitCompiler.java:5696)
E                   	at org.codehaus.janino.Java$AmbiguousName.accept(Java.java:4224)
E                   	at org.codehaus.janino.UnitCompiler$18.visitLvalue(UnitCompiler.java:5693)
E                   	at org.codehaus.janino.Java$Lvalue.accept(Java.java:4148)
E                   	at org.codehaus.janino.UnitCompiler.getConstantValue(UnitCompiler.java:5689)
E                   	at org.codehaus.janino.UnitCompiler.compileGetValue(UnitCompiler.java:5654)
E                   	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:2580)
E                   	at org.codehaus.janino.UnitCompiler.access$2700(UnitCompiler.java:215)
E                   	at org.codehaus.janino.UnitCompiler$6.visitLocalVariableDeclarationStatement(UnitCompiler.java:1503)
E                   	at org.codehaus.janino.UnitCompiler$6.visitLocalVariableDeclarationStatement(UnitCompiler.java:1487)
E                   	at org.codehaus.janino.Java$LocalVariableDeclarationStatement.accept(Java.java:3522)
E                   	at org.codehaus.janino.UnitCompiler.compile(UnitCompiler.java:1487)
E                   	at org.codehaus.janino.UnitCompiler.compileStatements(UnitCompiler.java:1567)
E                   	at org.codehaus.janino.UnitCompiler.compile(UnitCompiler.java:3388)
E                   	at org.codehaus.janino.UnitCompiler.compileDeclaredMethods(UnitCompiler.java:1357)
E                   	at org.codehaus.janino.UnitCompiler.compileDeclaredMethods(UnitCompiler.java:1330)
E                   	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:822)
E                   	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:432)
E                   	at org.codehaus.janino.UnitCompiler.access$400(UnitCompiler.java:215)
E                   	at org.codehaus.janino.UnitCompiler$2.visitPackageMemberClassDeclaration(UnitCompiler.java:411)
E                   	at org.codehaus.janino.UnitCompiler$2.visitPackageMemberClassDeclaration(UnitCompiler.java:406)
E                   	at org.codehaus.janino.Java$PackageMemberClassDeclaration.accept(Java.java:1414)
E                   	at org.codehaus.janino.UnitCompiler.compile(UnitCompiler.java:406)
E                   	at org.codehaus.janino.UnitCompiler.compileUnit(UnitCompiler.java:378)
E                   	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:237)
E                   	at org.codehaus.janino.SimpleCompiler.compileToClassLoader(SimpleCompiler.java:465)
E                   	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:216)
E                   	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:207)
E                   	at org.codehaus.commons.compiler.Cookable.cook(Cookable.java:80)
E                   	at org.codehaus.commons.compiler.Cookable.cook(Cookable.java:75)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.doCompile(CompileUtils.java:104)
E                   	... 25 more

/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/py4j/protocol.py:326: Py4JJavaError
----------------------------- Captured stdout call -----------------------------
/* 1 */
/* 2 */      public class StreamExecCalc$47 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$47(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$44;
/* 35 */          boolean isNull$44;
/* 36 */          
/* 37 */          
/* 38 */          isNull$44 = in1.isNullAt(4);
/* 39 */          field$44 = -1;
/* 40 */          if (!isNull$44) {
/* 41 */            field$44 = in1.getInt(4);
/* 42 */          }
/* 43 */          
/* 44 */          out.setRowKind(in1.getRowKind());
/* 45 */          
/* 46 */          
/* 47 */          
/* 48 */          
/* 49 */           java.lang.Integer tmpResult$46 = result$45;
/* 50 */           int result$46 = -1;
/* 51 */           boolean nullTerm$46 = false;
/* 52 */           
/* 53 */           
/* 54 */           java.lang.Integer tmpResult$45 = field$44;
/* 55 */           int result$45 = -1;
/* 56 */           boolean nullTerm$45 = false;
/* 57 */           
/* 58 */           
/* 59 */           if (!nullTerm$45) {
/* 60 */             java.lang.Integer cur$45 = field$44;
/* 61 */             if (isNull$44) {
/* 62 */               nullTerm$45 = true;
/* 63 */             } else {
/* 64 */               int compareResult = tmpResult$45.compareTo(cur$45);
/* 65 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 66 */                 tmpResult$45 = cur$45;
/* 67 */               }
/* 68 */             }
/* 69 */           }
/* 70 */                 
/* 71 */          
/* 72 */           
/* 73 */           if (!nullTerm$45) {
/* 74 */             java.lang.Integer cur$45 = ((int) 1);
/* 75 */             if (false) {
/* 76 */               nullTerm$45 = true;
/* 77 */             } else {
/* 78 */               int compareResult = tmpResult$45.compareTo(cur$45);
/* 79 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 80 */                 tmpResult$45 = cur$45;
/* 81 */               }
/* 82 */             }
/* 83 */           }
/* 84 */                 
/* 85 */           if (!nullTerm$45) {
/* 86 */             result$45 = tmpResult$45;
/* 87 */           }
/* 88 */                 
/* 89 */           if (!nullTerm$46) {
/* 90 */             java.lang.Integer cur$46 = result$45;
/* 91 */             if (nullTerm$45) {
/* 92 */               nullTerm$46 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$46.compareTo(cur$46);
/* 95 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 96 */                 tmpResult$46 = cur$46;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */          
/* 102 */           
/* 103 */           if (!nullTerm$46) {
/* 104 */             java.lang.Integer cur$46 = ((int) 0);
/* 105 */             if (false) {
/* 106 */               nullTerm$46 = true;
/* 107 */             } else {
/* 108 */               int compareResult = tmpResult$46.compareTo(cur$46);
/* 109 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 110 */                 tmpResult$46 = cur$46;
/* 111 */               }
/* 112 */             }
/* 113 */           }
/* 114 */                 
/* 115 */           if (!nullTerm$46) {
/* 116 */             result$46 = tmpResult$46;
/* 117 */           }
/* 118 */                 
/* 119 */          if (nullTerm$46) {
/* 120 */            out.setNullAt(0);
/* 121 */          } else {
/* 122 */            out.setInt(0, result$46);
/* 123 */          }
/* 124 */                    
/* 125 */                  
/* 126 */          output.collect(outElement.replace(out));
/* 127 */          
/* 128 */          
/* 129 */        }
/* 130 */
/* 131 */        
/* 132 */
/* 133 */        @Override
/* 134 */        public void finish() throws Exception {
/* 135 */            
/* 136 */            super.finish();
/* 137 */        }
/* 138 */
/* 139 */        @Override
/* 140 */        public void close() throws Exception {
/* 141 */           super.close();
/* 142 */           
/* 143 */        }
/* 144 */
/* 145 */        
/* 146 */      }
/* 147 */    

/* 1 */
/* 2 */      public class StreamExecCalc$47 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$47(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$44;
/* 35 */          boolean isNull$44;
/* 36 */          
/* 37 */          
/* 38 */          isNull$44 = in1.isNullAt(4);
/* 39 */          field$44 = -1;
/* 40 */          if (!isNull$44) {
/* 41 */            field$44 = in1.getInt(4);
/* 42 */          }
/* 43 */          
/* 44 */          out.setRowKind(in1.getRowKind());
/* 45 */          
/* 46 */          
/* 47 */          
/* 48 */          
/* 49 */           java.lang.Integer tmpResult$46 = result$45;
/* 50 */           int result$46 = -1;
/* 51 */           boolean nullTerm$46 = false;
/* 52 */           
/* 53 */           
/* 54 */           java.lang.Integer tmpResult$45 = field$44;
/* 55 */           int result$45 = -1;
/* 56 */           boolean nullTerm$45 = false;
/* 57 */           
/* 58 */           
/* 59 */           if (!nullTerm$45) {
/* 60 */             java.lang.Integer cur$45 = field$44;
/* 61 */             if (isNull$44) {
/* 62 */               nullTerm$45 = true;
/* 63 */             } else {
/* 64 */               int compareResult = tmpResult$45.compareTo(cur$45);
/* 65 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 66 */                 tmpResult$45 = cur$45;
/* 67 */               }
/* 68 */             }
/* 69 */           }
/* 70 */                 
/* 71 */          
/* 72 */           
/* 73 */           if (!nullTerm$45) {
/* 74 */             java.lang.Integer cur$45 = ((int) 1);
/* 75 */             if (false) {
/* 76 */               nullTerm$45 = true;
/* 77 */             } else {
/* 78 */               int compareResult = tmpResult$45.compareTo(cur$45);
/* 79 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 80 */                 tmpResult$45 = cur$45;
/* 81 */               }
/* 82 */             }
/* 83 */           }
/* 84 */                 
/* 85 */           if (!nullTerm$45) {
/* 86 */             result$45 = tmpResult$45;
/* 87 */           }
/* 88 */                 
/* 89 */           if (!nullTerm$46) {
/* 90 */             java.lang.Integer cur$46 = result$45;
/* 91 */             if (nullTerm$45) {
/* 92 */               nullTerm$46 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$46.compareTo(cur$46);
/* 95 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 96 */                 tmpResult$46 = cur$46;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */          
/* 102 */           
/* 103 */           if (!nullTerm$46) {
/* 104 */             java.lang.Integer cur$46 = ((int) 0);
/* 105 */             if (false) {
/* 106 */               nullTerm$46 = true;
/* 107 */             } else {
/* 108 */               int compareResult = tmpResult$46.compareTo(cur$46);
/* 109 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 110 */                 tmpResult$46 = cur$46;
/* 111 */               }
/* 112 */             }
/* 113 */           }
/* 114 */                 
/* 115 */           if (!nullTerm$46) {
/* 116 */             result$46 = tmpResult$46;
/* 117 */           }
/* 118 */                 
/* 119 */          if (nullTerm$46) {
/* 120 */            out.setNullAt(0);
/* 121 */          } else {
/* 122 */            out.setInt(0, result$46);
/* 123 */          }
/* 124 */                    
/* 125 */                  
/* 126 */          output.collect(outElement.replace(out));
/* 127 */          
/* 128 */          
/* 129 */        }
/* 130 */
/* 131 */        
/* 132 */
/* 133 */        @Override
/* 134 */        public void finish() throws Exception {
/* 135 */            
/* 136 */            super.finish();
/* 137 */        }
/* 138 */
/* 139 */        @Override
/* 140 */        public void close() throws Exception {
/* 141 */           super.close();
/* 142 */           
/* 143 */        }
/* 144 */
/* 145 */        
/* 146 */      }
/* 147 */    

/* 1 */
/* 2 */      public class StreamExecCalc$47 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$47(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$44;
/* 35 */          boolean isNull$44;
/* 36 */          
/* 37 */          
/* 38 */          isNull$44 = in1.isNullAt(4);
/* 39 */          field$44 = -1;
/* 40 */          if (!isNull$44) {
/* 41 */            field$44 = in1.getInt(4);
/* 42 */          }
/* 43 */          
/* 44 */          out.setRowKind(in1.getRowKind());
/* 45 */          
/* 46 */          
/* 47 */          
/* 48 */          
/* 49 */           java.lang.Integer tmpResult$46 = result$45;
/* 50 */           int result$46 = -1;
/* 51 */           boolean nullTerm$46 = false;
/* 52 */           
/* 53 */           
/* 54 */           java.lang.Integer tmpResult$45 = field$44;
/* 55 */           int result$45 = -1;
/* 56 */           boolean nullTerm$45 = false;
/* 57 */           
/* 58 */           
/* 59 */           if (!nullTerm$45) {
/* 60 */             java.lang.Integer cur$45 = field$44;
/* 61 */             if (isNull$44) {
/* 62 */               nullTerm$45 = true;
/* 63 */             } else {
/* 64 */               int compareResult = tmpResult$45.compareTo(cur$45);
/* 65 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 66 */                 tmpResult$45 = cur$45;
/* 67 */               }
/* 68 */             }
/* 69 */           }
/* 70 */                 
/* 71 */          
/* 72 */           
/* 73 */           if (!nullTerm$45) {
/* 74 */             java.lang.Integer cur$45 = ((int) 1);
/* 75 */             if (false) {
/* 76 */               nullTerm$45 = true;
/* 77 */             } else {
/* 78 */               int compareResult = tmpResult$45.compareTo(cur$45);
/* 79 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 80 */                 tmpResult$45 = cur$45;
/* 81 */               }
/* 82 */             }
/* 83 */           }
/* 84 */                 
/* 85 */           if (!nullTerm$45) {
/* 86 */             result$45 = tmpResult$45;
/* 87 */           }
/* 88 */                 
/* 89 */           if (!nullTerm$46) {
/* 90 */             java.lang.Integer cur$46 = result$45;
/* 91 */             if (nullTerm$45) {
/* 92 */               nullTerm$46 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$46.compareTo(cur$46);
/* 95 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 96 */                 tmpResult$46 = cur$46;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */          
/* 102 */           
/* 103 */           if (!nullTerm$46) {
/* 104 */             java.lang.Integer cur$46 = ((int) 0);
/* 105 */             if (false) {
/* 106 */               nullTerm$46 = true;
/* 107 */             } else {
/* 108 */               int compareResult = tmpResult$46.compareTo(cur$46);
/* 109 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 110 */                 tmpResult$46 = cur$46;
/* 111 */               }
/* 112 */             }
/* 113 */           }
/* 114 */                 
/* 115 */           if (!nullTerm$46) {
/* 116 */             result$46 = tmpResult$46;
/* 117 */           }
/* 118 */                 
/* 119 */          if (nullTerm$46) {
/* 120 */            out.setNullAt(0);
/* 121 */          } else {
/* 122 */            out.setInt(0, result$46);
/* 123 */          }
/* 124 */                    
/* 125 */                  
/* 126 */          output.collect(outElement.replace(out));
/* 127 */          
/* 128 */          
/* 129 */        }
/* 130 */
/* 131 */        
/* 132 */
/* 133 */        @Override
/* 134 */        public void finish() throws Exception {
/* 135 */            
/* 136 */            super.finish();
/* 137 */        }
/* 138 */
/* 139 */        @Override
/* 140 */        public void close() throws Exception {
/* 141 */           super.close();
/* 142 */           
/* 143 */        }
/* 144 */
/* 145 */        
/* 146 */      }
/* 147 */    

/* 1 */
/* 2 */      public class StreamExecCalc$47 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$47(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$44;
/* 35 */          boolean isNull$44;
/* 36 */          
/* 37 */          
/* 38 */          isNull$44 = in1.isNullAt(4);
/* 39 */          field$44 = -1;
/* 40 */          if (!isNull$44) {
/* 41 */            field$44 = in1.getInt(4);
/* 42 */          }
/* 43 */          
/* 44 */          out.setRowKind(in1.getRowKind());
/* 45 */          
/* 46 */          
/* 47 */          
/* 48 */          
/* 49 */           java.lang.Integer tmpResult$46 = result$45;
/* 50 */           int result$46 = -1;
/* 51 */           boolean nullTerm$46 = false;
/* 52 */           
/* 53 */           
/* 54 */           java.lang.Integer tmpResult$45 = field$44;
/* 55 */           int result$45 = -1;
/* 56 */           boolean nullTerm$45 = false;
/* 57 */           
/* 58 */           
/* 59 */           if (!nullTerm$45) {
/* 60 */             java.lang.Integer cur$45 = field$44;
/* 61 */             if (isNull$44) {
/* 62 */               nullTerm$45 = true;
/* 63 */             } else {
/* 64 */               int compareResult = tmpResult$45.compareTo(cur$45);
/* 65 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 66 */                 tmpResult$45 = cur$45;
/* 67 */               }
/* 68 */             }
/* 69 */           }
/* 70 */                 
/* 71 */          
/* 72 */           
/* 73 */           if (!nullTerm$45) {
/* 74 */             java.lang.Integer cur$45 = ((int) 1);
/* 75 */             if (false) {
/* 76 */               nullTerm$45 = true;
/* 77 */             } else {
/* 78 */               int compareResult = tmpResult$45.compareTo(cur$45);
/* 79 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 80 */                 tmpResult$45 = cur$45;
/* 81 */               }
/* 82 */             }
/* 83 */           }
/* 84 */                 
/* 85 */           if (!nullTerm$45) {
/* 86 */             result$45 = tmpResult$45;
/* 87 */           }
/* 88 */                 
/* 89 */           if (!nullTerm$46) {
/* 90 */             java.lang.Integer cur$46 = result$45;
/* 91 */             if (nullTerm$45) {
/* 92 */               nullTerm$46 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$46.compareTo(cur$46);
/* 95 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 96 */                 tmpResult$46 = cur$46;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */          
/* 102 */           
/* 103 */           if (!nullTerm$46) {
/* 104 */             java.lang.Integer cur$46 = ((int) 0);
/* 105 */             if (false) {
/* 106 */               nullTerm$46 = true;
/* 107 */             } else {
/* 108 */               int compareResult = tmpResult$46.compareTo(cur$46);
/* 109 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 110 */                 tmpResult$46 = cur$46;
/* 111 */               }
/* 112 */             }
/* 113 */           }
/* 114 */                 
/* 115 */           if (!nullTerm$46) {
/* 116 */             result$46 = tmpResult$46;
/* 117 */           }
/* 118 */                 
/* 119 */          if (nullTerm$46) {
/* 120 */            out.setNullAt(0);
/* 121 */          } else {
/* 122 */            out.setInt(0, result$46);
/* 123 */          }
/* 124 */                    
/* 125 */                  
/* 126 */          output.collect(outElement.replace(out));
/* 127 */          
/* 128 */          
/* 129 */        }
/* 130 */
/* 131 */        
/* 132 */
/* 133 */        @Override
/* 134 */        public void finish() throws Exception {
/* 135 */            
/* 136 */            super.finish();
/* 137 */        }
/* 138 */
/* 139 */        @Override
/* 140 */        public void close() throws Exception {
/* 141 */           super.close();
/* 142 */           
/* 143 */        }
/* 144 */
/* 145 */        
/* 146 */      }
/* 147 */    

_____________________ test_clip[flink-<lambda>-<lambda>5] ______________________

backend = <ibis.backends.flink.tests.conftest.TestConf object at 0x7f3f028f43d0>
alltypes = DatabaseTable: functional_alltypes
  id              int64
  bool_col        boolean
  tinyint_col     int8
  smallint...ring_col string
  string_col      string
  timestamp_col   timestamp(3)
  year            int64
  month           int64
df =         id  bool_col  tinyint_col  ...           timestamp_col  year  month
0     6690      True            0  ... 201....780  2010      1
7299  3959     False            9  ... 2010-01-31 05:09:13.860  2010      1

[7300 rows x 13 columns]
ibis_func = <function <lambda> at 0x7f3f046dfd90>
pandas_func = <function <lambda> at 0x7f3f046dfe20>

    @pytest.mark.parametrize(
        ("ibis_func", "pandas_func"),
        [
            (lambda x: x.clip(lower=0), lambda x: x.clip(lower=0)),
            (lambda x: x.clip(lower=0.0), lambda x: x.clip(lower=0.0)),
            (lambda x: x.clip(upper=0), lambda x: x.clip(upper=0)),
            param(
                lambda x: x.clip(lower=x - 1, upper=x + 1),
                lambda x: x.clip(lower=x - 1, upper=x + 1),
                marks=pytest.mark.notimpl(
                    "polars",
                    raises=com.UnsupportedArgumentError,
                    reason="Polars does not support columnar argument Subtract(int_col, 1)",
                ),
            ),
            (
                lambda x: x.clip(lower=0, upper=1),
                lambda x: x.clip(lower=0, upper=1),
            ),
            (
                lambda x: x.clip(lower=0, upper=1.0),
                lambda x: x.clip(lower=0, upper=1.0),
            ),
        ],
    )
    @pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
    def test_clip(backend, alltypes, df, ibis_func, pandas_func):
>       result = ibis_func(alltypes.int_col).execute()

ibis/backends/tests/test_numeric.py:1492: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
ibis/expr/types/core.py:322: in execute
    return self._find_backend(use_default=True).execute(
ibis/backends/flink/__init__.py:247: in execute
    df = self._table_env.sql_query(sql).to_pandas()
/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/pyflink/table/table.py:938: in to_pandas
    if batches_iterator.hasNext():
/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/py4j/java_gateway.py:1322: in __call__
    return_value = get_return_value(
/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/pyflink/util/exceptions.py:146: in deco
    return f(*a, **kw)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

answer = 'xro2328'
gateway_client = <py4j.java_gateway.GatewayClient object at 0x7f3f028f4b50>
target_id = 'o2327', name = 'hasNext'

    def get_return_value(answer, gateway_client, target_id=None, name=None):
        """Converts an answer received from the Java gateway into a Python object.
    
        For example, string representation of integers are converted to Python
        integer, string representation of objects are converted to JavaObject
        instances, etc.
    
        :param answer: the string returned by the Java gateway
        :param gateway_client: the gateway client used to communicate with the Java
            Gateway. Only necessary if the answer is a reference (e.g., object,
            list, map)
        :param target_id: the name of the object from which the answer comes from
            (e.g., *object1* in `object1.hello()`). Optional.
        :param name: the name of the member from which the answer comes from
            (e.g., *hello* in `object1.hello()`). Optional.
        """
        if is_error(answer)[0]:
            if len(answer) > 1:
                type = answer[1]
                value = OUTPUT_CONVERTER[type](answer[2:], gateway_client)
                if answer[1] == REFERENCE_TYPE:
>                   raise Py4JJavaError(
                        "An error occurred while calling {0}{1}{2}.\n".
                        format(target_id, ".", name), value)
E                   py4j.protocol.Py4JJavaError: An error occurred while calling o2327.hasNext.
E                   : java.lang.RuntimeException: Failed to fetch next result
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultIterator.nextResultFromFetcher(CollectResultIterator.java:109)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultIterator.hasNext(CollectResultIterator.java:80)
E                   	at org.apache.flink.table.planner.connectors.CollectDynamicSink$CloseableRowIteratorWrapper.hasNext(CollectDynamicSink.java:222)
E                   	at org.apache.flink.table.runtime.arrow.ArrowUtils$1.hasNext(ArrowUtils.java:571)
E                   	at org.apache.flink.table.runtime.arrow.ArrowUtils$2.hasNext(ArrowUtils.java:585)
E                   	at jdk.internal.reflect.GeneratedMethodAccessor43.invoke(Unknown Source)
E                   	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E                   	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
E                   	at org.apache.flink.api.python.shaded.py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
E                   	at org.apache.flink.api.python.shaded.py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:374)
E                   	at org.apache.flink.api.python.shaded.py4j.Gateway.invoke(Gateway.java:282)
E                   	at org.apache.flink.api.python.shaded.py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
E                   	at org.apache.flink.api.python.shaded.py4j.commands.CallCommand.execute(CallCommand.java:79)
E                   	at org.apache.flink.api.python.shaded.py4j.GatewayConnection.run(GatewayConnection.java:238)
E                   	at java.base/java.lang.Thread.run(Thread.java:829)
E                   Caused by: java.io.IOException: Failed to fetch job execution result
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.getAccumulatorResults(CollectResultFetcher.java:184)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.next(CollectResultFetcher.java:121)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultIterator.nextResultFromFetcher(CollectResultIterator.java:106)
E                   	... 14 more
E                   Caused by: java.util.concurrent.ExecutionException: org.apache.flink.runtime.client.JobExecutionException: Job execution failed.
E                   	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
E                   	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2022)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.getAccumulatorResults(CollectResultFetcher.java:182)
E                   	... 16 more
E                   Caused by: org.apache.flink.runtime.client.JobExecutionException: Job execution failed.
E                   	at org.apache.flink.runtime.jobmaster.JobResult.toJobExecutionResult(JobResult.java:144)
E                   	at org.apache.flink.runtime.minicluster.MiniClusterJobClient.lambda$getJobExecutionResult$3(MiniClusterJobClient.java:141)
E                   	at java.base/java.util.concurrent.CompletableFuture.uniApplyNow(CompletableFuture.java:680)
E                   	at java.base/java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:658)
E                   	at java.base/java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:2094)
E                   	at org.apache.flink.runtime.minicluster.MiniClusterJobClient.getJobExecutionResult(MiniClusterJobClient.java:138)
E                   	at org.apache.flink.streaming.api.operators.collect.CollectResultFetcher.getAccumulatorResults(CollectResultFetcher.java:181)
E                   	... 16 more
E                   Caused by: org.apache.flink.runtime.JobException: Recovery is suppressed by NoRestartBackoffTimeStrategy
E                   	at org.apache.flink.runtime.executiongraph.failover.flip1.ExecutionFailureHandler.handleFailure(ExecutionFailureHandler.java:139)
E                   	at org.apache.flink.runtime.executiongraph.failover.flip1.ExecutionFailureHandler.getFailureHandlingResult(ExecutionFailureHandler.java:83)
E                   	at org.apache.flink.runtime.scheduler.DefaultScheduler.recordTaskFailure(DefaultScheduler.java:258)
E                   	at org.apache.flink.runtime.scheduler.DefaultScheduler.handleTaskFailure(DefaultScheduler.java:249)
E                   	at org.apache.flink.runtime.scheduler.DefaultScheduler.onTaskFailed(DefaultScheduler.java:242)
E                   	at org.apache.flink.runtime.scheduler.SchedulerBase.onTaskExecutionStateUpdate(SchedulerBase.java:748)
E                   	at org.apache.flink.runtime.scheduler.SchedulerBase.updateTaskExecutionState(SchedulerBase.java:725)
E                   	at org.apache.flink.runtime.scheduler.SchedulerNG.updateTaskExecutionState(SchedulerNG.java:80)
E                   	at org.apache.flink.runtime.jobmaster.JobMaster.updateTaskExecutionState(JobMaster.java:479)
E                   	at jdk.internal.reflect.GeneratedMethodAccessor25.invoke(Unknown Source)
E                   	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E                   	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.lambda$handleRpcInvocation$1(AkkaRpcActor.java:309)
E                   	at org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.runWithContextClassLoader(ClassLoadingUtils.java:83)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleRpcInvocation(AkkaRpcActor.java:307)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleRpcMessage(AkkaRpcActor.java:222)
E                   	at org.apache.flink.runtime.rpc.akka.FencedAkkaRpcActor.handleRpcMessage(FencedAkkaRpcActor.java:84)
E                   	at org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleMessage(AkkaRpcActor.java:168)
E                   	at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:24)
E                   	at akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:20)
E                   	at scala.PartialFunction.applyOrElse(PartialFunction.scala:127)
E                   	at scala.PartialFunction.applyOrElse$(PartialFunction.scala:126)
E                   	at akka.japi.pf.UnitCaseStatement.applyOrElse(CaseStatements.scala:20)
E                   	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:175)
E                   	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:176)
E                   	at scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:176)
E                   	at akka.actor.Actor.aroundReceive(Actor.scala:537)
E                   	at akka.actor.Actor.aroundReceive$(Actor.scala:535)
E                   	at akka.actor.AbstractActor.aroundReceive(AbstractActor.scala:220)
E                   	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)
E                   	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
E                   	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
E                   	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
E                   	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
E                   	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
E                   	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
E                   	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
E                   	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
E                   	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
E                   Caused by: java.lang.RuntimeException: Could not instantiate generated class 'StreamExecCalc$57'
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.newInstance(GeneratedClass.java:84)
E                   	at org.apache.flink.table.runtime.operators.CodeGenOperatorFactory.createStreamOperator(CodeGenOperatorFactory.java:40)
E                   	at org.apache.flink.streaming.api.operators.StreamOperatorFactoryUtil.createOperator(StreamOperatorFactoryUtil.java:81)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.createOperator(OperatorChain.java:838)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.createOperatorChain(OperatorChain.java:806)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.createOutputCollector(OperatorChain.java:724)
E                   	at org.apache.flink.streaming.runtime.tasks.OperatorChain.<init>(OperatorChain.java:199)
E                   	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.<init>(RegularOperatorChain.java:60)
E                   	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreInternal(StreamTask.java:688)
E                   	at org.apache.flink.streaming.runtime.tasks.StreamTask.restore(StreamTask.java:675)
E                   	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:952)
E                   	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:921)
E                   	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:745)
E                   	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:562)
E                   	at java.base/java.lang.Thread.run(Thread.java:829)
E                   Caused by: org.apache.flink.util.FlinkRuntimeException: org.apache.flink.api.common.InvalidProgramException: Table program cannot be compiled. This is a bug. Please file an issue.
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.compile(CompileUtils.java:94)
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.compile(GeneratedClass.java:101)
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.newInstance(GeneratedClass.java:82)
E                   	... 14 more
E                   Caused by: org.apache.flink.shaded.guava30.com.google.common.util.concurrent.UncheckedExecutionException: org.apache.flink.api.common.InvalidProgramException: Table program cannot be compiled. This is a bug. Please file an issue.
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2051)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache.get(LocalCache.java:3962)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4859)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.compile(CompileUtils.java:92)
E                   	... 16 more
E                   Caused by: org.apache.flink.api.common.InvalidProgramException: Table program cannot be compiled. This is a bug. Please file an issue.
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.doCompile(CompileUtils.java:107)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.lambda$compile$0(CompileUtils.java:92)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4864)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache.get(LocalCache.java:3962)
E                   	at org.apache.flink.shaded.guava30.com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4859)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.compile(CompileUtils.java:92)
E                   	at org.apache.flink.table.runtime.generated.GeneratedClass.compile(GeneratedClass.java:97)
E                   	... 15 more
E                   Caused by: org.codehaus.commons.compiler.CompileException: Line 49, Column 54: Expression "result$55" is not an rvalue
E                   	at org.codehaus.janino.UnitCompiler.compileError(UnitCompiler.java:12211)
E                   	at org.codehaus.janino.UnitCompiler.toRvalueOrCompileException(UnitCompiler.java:7512)
E                   	at org.codehaus.janino.UnitCompiler.getConstantValue2(UnitCompiler.java:5741)
E                   	at org.codehaus.janino.UnitCompiler.access$10300(UnitCompiler.java:215)
E                   	at org.codehaus.janino.UnitCompiler$18$1.visitAmbiguousName(UnitCompiler.java:5696)
E                   	at org.codehaus.janino.Java$AmbiguousName.accept(Java.java:4224)
E                   	at org.codehaus.janino.UnitCompiler$18.visitLvalue(UnitCompiler.java:5693)
E                   	at org.codehaus.janino.Java$Lvalue.accept(Java.java:4148)
E                   	at org.codehaus.janino.UnitCompiler.getConstantValue(UnitCompiler.java:5689)
E                   	at org.codehaus.janino.UnitCompiler.compileGetValue(UnitCompiler.java:5654)
E                   	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:2580)
E                   	at org.codehaus.janino.UnitCompiler.access$2700(UnitCompiler.java:215)
E                   	at org.codehaus.janino.UnitCompiler$6.visitLocalVariableDeclarationStatement(UnitCompiler.java:1503)
E                   	at org.codehaus.janino.UnitCompiler$6.visitLocalVariableDeclarationStatement(UnitCompiler.java:1487)
E                   	at org.codehaus.janino.Java$LocalVariableDeclarationStatement.accept(Java.java:3522)
E                   	at org.codehaus.janino.UnitCompiler.compile(UnitCompiler.java:1487)
E                   	at org.codehaus.janino.UnitCompiler.compileStatements(UnitCompiler.java:1567)
E                   	at org.codehaus.janino.UnitCompiler.compile(UnitCompiler.java:3388)
E                   	at org.codehaus.janino.UnitCompiler.compileDeclaredMethods(UnitCompiler.java:1357)
E                   	at org.codehaus.janino.UnitCompiler.compileDeclaredMethods(UnitCompiler.java:1330)
E                   	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:822)
E                   	at org.codehaus.janino.UnitCompiler.compile2(UnitCompiler.java:432)
E                   	at org.codehaus.janino.UnitCompiler.access$400(UnitCompiler.java:215)
E                   	at org.codehaus.janino.UnitCompiler$2.visitPackageMemberClassDeclaration(UnitCompiler.java:411)
E                   	at org.codehaus.janino.UnitCompiler$2.visitPackageMemberClassDeclaration(UnitCompiler.java:406)
E                   	at org.codehaus.janino.Java$PackageMemberClassDeclaration.accept(Java.java:1414)
E                   	at org.codehaus.janino.UnitCompiler.compile(UnitCompiler.java:406)
E                   	at org.codehaus.janino.UnitCompiler.compileUnit(UnitCompiler.java:378)
E                   	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:237)
E                   	at org.codehaus.janino.SimpleCompiler.compileToClassLoader(SimpleCompiler.java:465)
E                   	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:216)
E                   	at org.codehaus.janino.SimpleCompiler.cook(SimpleCompiler.java:207)
E                   	at org.codehaus.commons.compiler.Cookable.cook(Cookable.java:80)
E                   	at org.codehaus.commons.compiler.Cookable.cook(Cookable.java:75)
E                   	at org.apache.flink.table.runtime.generated.CompileUtils.doCompile(CompileUtils.java:104)
E                   	... 25 more

/home/vscode/miniconda3/envs/ibis-dev/lib/python3.10/site-packages/py4j/protocol.py:326: Py4JJavaError
----------------------------- Captured stdout call -----------------------------
/* 1 */
/* 2 */      public class StreamExecCalc$57 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$57(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$54;
/* 35 */          boolean isNull$54;
/* 36 */          
/* 37 */          
/* 38 */          isNull$54 = in1.isNullAt(4);
/* 39 */          field$54 = -1;
/* 40 */          if (!isNull$54) {
/* 41 */            field$54 = in1.getInt(4);
/* 42 */          }
/* 43 */          
/* 44 */          out.setRowKind(in1.getRowKind());
/* 45 */          
/* 46 */          
/* 47 */          
/* 48 */          
/* 49 */           java.lang.Integer tmpResult$56 = result$55;
/* 50 */           int result$56 = -1;
/* 51 */           boolean nullTerm$56 = false;
/* 52 */           
/* 53 */           
/* 54 */           java.lang.Integer tmpResult$55 = field$54;
/* 55 */           int result$55 = -1;
/* 56 */           boolean nullTerm$55 = false;
/* 57 */           
/* 58 */           
/* 59 */           if (!nullTerm$55) {
/* 60 */             java.lang.Integer cur$55 = field$54;
/* 61 */             if (isNull$54) {
/* 62 */               nullTerm$55 = true;
/* 63 */             } else {
/* 64 */               int compareResult = tmpResult$55.compareTo(cur$55);
/* 65 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 66 */                 tmpResult$55 = cur$55;
/* 67 */               }
/* 68 */             }
/* 69 */           }
/* 70 */                 
/* 71 */          
/* 72 */           
/* 73 */           if (!nullTerm$55) {
/* 74 */             java.lang.Integer cur$55 = ((int) 1);
/* 75 */             if (false) {
/* 76 */               nullTerm$55 = true;
/* 77 */             } else {
/* 78 */               int compareResult = tmpResult$55.compareTo(cur$55);
/* 79 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 80 */                 tmpResult$55 = cur$55;
/* 81 */               }
/* 82 */             }
/* 83 */           }
/* 84 */                 
/* 85 */           if (!nullTerm$55) {
/* 86 */             result$55 = tmpResult$55;
/* 87 */           }
/* 88 */                 
/* 89 */           if (!nullTerm$56) {
/* 90 */             java.lang.Integer cur$56 = result$55;
/* 91 */             if (nullTerm$55) {
/* 92 */               nullTerm$56 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$56.compareTo(cur$56);
/* 95 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 96 */                 tmpResult$56 = cur$56;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */          
/* 102 */           
/* 103 */           if (!nullTerm$56) {
/* 104 */             java.lang.Integer cur$56 = ((int) 0);
/* 105 */             if (false) {
/* 106 */               nullTerm$56 = true;
/* 107 */             } else {
/* 108 */               int compareResult = tmpResult$56.compareTo(cur$56);
/* 109 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 110 */                 tmpResult$56 = cur$56;
/* 111 */               }
/* 112 */             }
/* 113 */           }
/* 114 */                 
/* 115 */           if (!nullTerm$56) {
/* 116 */             result$56 = tmpResult$56;
/* 117 */           }
/* 118 */                 
/* 119 */          if (nullTerm$56) {
/* 120 */            out.setNullAt(0);
/* 121 */          } else {
/* 122 */            out.setInt(0, result$56);
/* 123 */          }
/* 124 */                    
/* 125 */                  
/* 126 */          output.collect(outElement.replace(out));
/* 127 */          
/* 128 */          
/* 129 */        }
/* 130 */
/* 131 */        
/* 132 */
/* 133 */        @Override
/* 134 */        public void finish() throws Exception {
/* 135 */            
/* 136 */            super.finish();
/* 137 */        }
/* 138 */
/* 139 */        @Override
/* 140 */        public void close() throws Exception {
/* 141 */           super.close();
/* 142 */           
/* 143 */        }
/* 144 */
/* 145 */        
/* 146 */      }
/* 147 */    

/* 1 */
/* 2 */      public class StreamExecCalc$57 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$57(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$54;
/* 35 */          boolean isNull$54;
/* 36 */          
/* 37 */          
/* 38 */          isNull$54 = in1.isNullAt(4);
/* 39 */          field$54 = -1;
/* 40 */          if (!isNull$54) {
/* 41 */            field$54 = in1.getInt(4);
/* 42 */          }
/* 43 */          
/* 44 */          out.setRowKind(in1.getRowKind());
/* 45 */          
/* 46 */          
/* 47 */          
/* 48 */          
/* 49 */           java.lang.Integer tmpResult$56 = result$55;
/* 50 */           int result$56 = -1;
/* 51 */           boolean nullTerm$56 = false;
/* 52 */           
/* 53 */           
/* 54 */           java.lang.Integer tmpResult$55 = field$54;
/* 55 */           int result$55 = -1;
/* 56 */           boolean nullTerm$55 = false;
/* 57 */           
/* 58 */           
/* 59 */           if (!nullTerm$55) {
/* 60 */             java.lang.Integer cur$55 = field$54;
/* 61 */             if (isNull$54) {
/* 62 */               nullTerm$55 = true;
/* 63 */             } else {
/* 64 */               int compareResult = tmpResult$55.compareTo(cur$55);
/* 65 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 66 */                 tmpResult$55 = cur$55;
/* 67 */               }
/* 68 */             }
/* 69 */           }
/* 70 */                 
/* 71 */          
/* 72 */           
/* 73 */           if (!nullTerm$55) {
/* 74 */             java.lang.Integer cur$55 = ((int) 1);
/* 75 */             if (false) {
/* 76 */               nullTerm$55 = true;
/* 77 */             } else {
/* 78 */               int compareResult = tmpResult$55.compareTo(cur$55);
/* 79 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 80 */                 tmpResult$55 = cur$55;
/* 81 */               }
/* 82 */             }
/* 83 */           }
/* 84 */                 
/* 85 */           if (!nullTerm$55) {
/* 86 */             result$55 = tmpResult$55;
/* 87 */           }
/* 88 */                 
/* 89 */           if (!nullTerm$56) {
/* 90 */             java.lang.Integer cur$56 = result$55;
/* 91 */             if (nullTerm$55) {
/* 92 */               nullTerm$56 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$56.compareTo(cur$56);
/* 95 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 96 */                 tmpResult$56 = cur$56;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */          
/* 102 */           
/* 103 */           if (!nullTerm$56) {
/* 104 */             java.lang.Integer cur$56 = ((int) 0);
/* 105 */             if (false) {
/* 106 */               nullTerm$56 = true;
/* 107 */             } else {
/* 108 */               int compareResult = tmpResult$56.compareTo(cur$56);
/* 109 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 110 */                 tmpResult$56 = cur$56;
/* 111 */               }
/* 112 */             }
/* 113 */           }
/* 114 */                 
/* 115 */           if (!nullTerm$56) {
/* 116 */             result$56 = tmpResult$56;
/* 117 */           }
/* 118 */                 
/* 119 */          if (nullTerm$56) {
/* 120 */            out.setNullAt(0);
/* 121 */          } else {
/* 122 */            out.setInt(0, result$56);
/* 123 */          }
/* 124 */                    
/* 125 */                  
/* 126 */          output.collect(outElement.replace(out));
/* 127 */          
/* 128 */          
/* 129 */        }
/* 130 */
/* 131 */        
/* 132 */
/* 133 */        @Override
/* 134 */        public void finish() throws Exception {
/* 135 */            
/* 136 */            super.finish();
/* 137 */        }
/* 138 */
/* 139 */        @Override
/* 140 */        public void close() throws Exception {
/* 141 */           super.close();
/* 142 */           
/* 143 */        }
/* 144 */
/* 145 */        
/* 146 */      }
/* 147 */    

/* 1 */
/* 2 */      public class StreamExecCalc$57 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$57(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$54;
/* 35 */          boolean isNull$54;
/* 36 */          
/* 37 */          
/* 38 */          isNull$54 = in1.isNullAt(4);
/* 39 */          field$54 = -1;
/* 40 */          if (!isNull$54) {
/* 41 */            field$54 = in1.getInt(4);
/* 42 */          }
/* 43 */          
/* 44 */          out.setRowKind(in1.getRowKind());
/* 45 */          
/* 46 */          
/* 47 */          
/* 48 */          
/* 49 */           java.lang.Integer tmpResult$56 = result$55;
/* 50 */           int result$56 = -1;
/* 51 */           boolean nullTerm$56 = false;
/* 52 */           
/* 53 */           
/* 54 */           java.lang.Integer tmpResult$55 = field$54;
/* 55 */           int result$55 = -1;
/* 56 */           boolean nullTerm$55 = false;
/* 57 */           
/* 58 */           
/* 59 */           if (!nullTerm$55) {
/* 60 */             java.lang.Integer cur$55 = field$54;
/* 61 */             if (isNull$54) {
/* 62 */               nullTerm$55 = true;
/* 63 */             } else {
/* 64 */               int compareResult = tmpResult$55.compareTo(cur$55);
/* 65 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 66 */                 tmpResult$55 = cur$55;
/* 67 */               }
/* 68 */             }
/* 69 */           }
/* 70 */                 
/* 71 */          
/* 72 */           
/* 73 */           if (!nullTerm$55) {
/* 74 */             java.lang.Integer cur$55 = ((int) 1);
/* 75 */             if (false) {
/* 76 */               nullTerm$55 = true;
/* 77 */             } else {
/* 78 */               int compareResult = tmpResult$55.compareTo(cur$55);
/* 79 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 80 */                 tmpResult$55 = cur$55;
/* 81 */               }
/* 82 */             }
/* 83 */           }
/* 84 */                 
/* 85 */           if (!nullTerm$55) {
/* 86 */             result$55 = tmpResult$55;
/* 87 */           }
/* 88 */                 
/* 89 */           if (!nullTerm$56) {
/* 90 */             java.lang.Integer cur$56 = result$55;
/* 91 */             if (nullTerm$55) {
/* 92 */               nullTerm$56 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$56.compareTo(cur$56);
/* 95 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 96 */                 tmpResult$56 = cur$56;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */          
/* 102 */           
/* 103 */           if (!nullTerm$56) {
/* 104 */             java.lang.Integer cur$56 = ((int) 0);
/* 105 */             if (false) {
/* 106 */               nullTerm$56 = true;
/* 107 */             } else {
/* 108 */               int compareResult = tmpResult$56.compareTo(cur$56);
/* 109 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 110 */                 tmpResult$56 = cur$56;
/* 111 */               }
/* 112 */             }
/* 113 */           }
/* 114 */                 
/* 115 */           if (!nullTerm$56) {
/* 116 */             result$56 = tmpResult$56;
/* 117 */           }
/* 118 */                 
/* 119 */          if (nullTerm$56) {
/* 120 */            out.setNullAt(0);
/* 121 */          } else {
/* 122 */            out.setInt(0, result$56);
/* 123 */          }
/* 124 */                    
/* 125 */                  
/* 126 */          output.collect(outElement.replace(out));
/* 127 */          
/* 128 */          
/* 129 */        }
/* 130 */
/* 131 */        
/* 132 */
/* 133 */        @Override
/* 134 */        public void finish() throws Exception {
/* 135 */            
/* 136 */            super.finish();
/* 137 */        }
/* 138 */
/* 139 */        @Override
/* 140 */        public void close() throws Exception {
/* 141 */           super.close();
/* 142 */           
/* 143 */        }
/* 144 */
/* 145 */        
/* 146 */      }
/* 147 */    

/* 1 */
/* 2 */      public class StreamExecCalc$57 extends org.apache.flink.table.runtime.operators.TableStreamOperator
/* 3 */          implements org.apache.flink.streaming.api.operators.OneInputStreamOperator {
/* 4 */
/* 5 */        private final Object[] references;
/* 6 */        org.apache.flink.table.data.BoxedWrapperRowData out = new org.apache.flink.table.data.BoxedWrapperRowData(1);
/* 7 */        private final org.apache.flink.streaming.runtime.streamrecord.StreamRecord outElement = new org.apache.flink.streaming.runtime.streamrecord.StreamRecord(null);
/* 8 */
/* 9 */        public StreamExecCalc$57(
/* 10 */            Object[] references,
/* 11 */            org.apache.flink.streaming.runtime.tasks.StreamTask task,
/* 12 */            org.apache.flink.streaming.api.graph.StreamConfig config,
/* 13 */            org.apache.flink.streaming.api.operators.Output output,
/* 14 */            org.apache.flink.streaming.runtime.tasks.ProcessingTimeService processingTimeService) throws Exception {
/* 15 */          this.references = references;
/* 16 */          
/* 17 */          this.setup(task, config, output);
/* 18 */          if (this instanceof org.apache.flink.streaming.api.operators.AbstractStreamOperator) {
/* 19 */            ((org.apache.flink.streaming.api.operators.AbstractStreamOperator) this)
/* 20 */              .setProcessingTimeService(processingTimeService);
/* 21 */          }
/* 22 */        }
/* 23 */
/* 24 */        @Override
/* 25 */        public void open() throws Exception {
/* 26 */          super.open();
/* 27 */          
/* 28 */        }
/* 29 */
/* 30 */        @Override
/* 31 */        public void processElement(org.apache.flink.streaming.runtime.streamrecord.StreamRecord element) throws Exception {
/* 32 */          org.apache.flink.table.data.RowData in1 = (org.apache.flink.table.data.RowData) element.getValue();
/* 33 */          
/* 34 */          int field$54;
/* 35 */          boolean isNull$54;
/* 36 */          
/* 37 */          
/* 38 */          isNull$54 = in1.isNullAt(4);
/* 39 */          field$54 = -1;
/* 40 */          if (!isNull$54) {
/* 41 */            field$54 = in1.getInt(4);
/* 42 */          }
/* 43 */          
/* 44 */          out.setRowKind(in1.getRowKind());
/* 45 */          
/* 46 */          
/* 47 */          
/* 48 */          
/* 49 */           java.lang.Integer tmpResult$56 = result$55;
/* 50 */           int result$56 = -1;
/* 51 */           boolean nullTerm$56 = false;
/* 52 */           
/* 53 */           
/* 54 */           java.lang.Integer tmpResult$55 = field$54;
/* 55 */           int result$55 = -1;
/* 56 */           boolean nullTerm$55 = false;
/* 57 */           
/* 58 */           
/* 59 */           if (!nullTerm$55) {
/* 60 */             java.lang.Integer cur$55 = field$54;
/* 61 */             if (isNull$54) {
/* 62 */               nullTerm$55 = true;
/* 63 */             } else {
/* 64 */               int compareResult = tmpResult$55.compareTo(cur$55);
/* 65 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 66 */                 tmpResult$55 = cur$55;
/* 67 */               }
/* 68 */             }
/* 69 */           }
/* 70 */                 
/* 71 */          
/* 72 */           
/* 73 */           if (!nullTerm$55) {
/* 74 */             java.lang.Integer cur$55 = ((int) 1);
/* 75 */             if (false) {
/* 76 */               nullTerm$55 = true;
/* 77 */             } else {
/* 78 */               int compareResult = tmpResult$55.compareTo(cur$55);
/* 79 */               if ((false && compareResult < 0) || (compareResult > 0 && !false)) {
/* 80 */                 tmpResult$55 = cur$55;
/* 81 */               }
/* 82 */             }
/* 83 */           }
/* 84 */                 
/* 85 */           if (!nullTerm$55) {
/* 86 */             result$55 = tmpResult$55;
/* 87 */           }
/* 88 */                 
/* 89 */           if (!nullTerm$56) {
/* 90 */             java.lang.Integer cur$56 = result$55;
/* 91 */             if (nullTerm$55) {
/* 92 */               nullTerm$56 = true;
/* 93 */             } else {
/* 94 */               int compareResult = tmpResult$56.compareTo(cur$56);
/* 95 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 96 */                 tmpResult$56 = cur$56;
/* 97 */               }
/* 98 */             }
/* 99 */           }
/* 100 */                 
/* 101 */          
/* 102 */           
/* 103 */           if (!nullTerm$56) {
/* 104 */             java.lang.Integer cur$56 = ((int) 0);
/* 105 */             if (false) {
/* 106 */               nullTerm$56 = true;
/* 107 */             } else {
/* 108 */               int compareResult = tmpResult$56.compareTo(cur$56);
/* 109 */               if ((true && compareResult < 0) || (compareResult > 0 && !true)) {
/* 110 */                 tmpResult$56 = cur$56;
/* 111 */               }
/* 112 */             }
/* 113 */           }
/* 114 */                 
/* 115 */           if (!nullTerm$56) {
/* 116 */             result$56 = tmpResult$56;
/* 117 */           }
/* 118 */                 
/* 119 */          if (nullTerm$56) {
/* 120 */            out.setNullAt(0);
/* 121 */          } else {
/* 122 */            out.setInt(0, result$56);
/* 123 */          }
/* 124 */                    
/* 125 */                  
/* 126 */          output.collect(outElement.replace(out));
/* 127 */          
/* 128 */          
/* 129 */        }
/* 130 */
/* 131 */        
/* 132 */
/* 133 */        @Override
/* 134 */        public void finish() throws Exception {
/* 135 */            
/* 136 */            super.finish();
/* 137 */        }
/* 138 */
/* 139 */        @Override
/* 140 */        public void close() throws Exception {
/* 141 */           super.close();
/* 142 */           
/* 143 */        }
/* 144 */
/* 145 */        
/* 146 */      }
/* 147 */    

---------------- generated xml file: /workspaces/ibis/junit.xml ----------------

---------- coverage: platform linux, python 3.10.12-final-0 ----------
Coverage XML written to file coverage.xml

=========================== short test summary info ============================
FAILED ibis/backends/tests/test_numeric.py::test_clip[flink-<lambda>-<lambda>3]
FAILED ibis/backends/tests/test_numeric.py::test_clip[flink-<lambda>-<lambda>4]
FAILED ibis/backends/tests/test_numeric.py::test_clip[flink-<lambda>-<lambda>5]
================ 3 failed, 3 passed, 2532 deselected in 25.53s =================
```

Everything passes post-fix:

```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.4.0, pluggy-1.2.0
Using --randomly-seed=2752526453
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /workspaces/ibis
configfile: pyproject.toml
plugins: repeat-0.9.1, xdist-3.3.1, hypothesis-6.80.0, cov-4.1.0, httpserver-1.0.6, randomly-3.12.0, snapshot-0.0.0, benchmark-4.0.0, mock-3.11.1, clarity-1.0.1
collected 2538 items / 2532 deselected / 6 selected

ibis/backends/tests/test_numeric.py ......                               [100%]

---------------- generated xml file: /workspaces/ibis/junit.xml ----------------

---------- coverage: platform linux, python 3.10.12-final-0 ----------
Coverage XML written to file coverage.xml

===================== 6 passed, 2532 deselected in 25.32s ======================
```