### PR TITLE
Docs: Reorganize reference v2

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -140,7 +140,7 @@ website:
       contents:
         - section: Expression API
           contents:
-            - reference/top_level.qmd
+            - reference/connection.qmd
             - reference/expression-tables.qmd
             - reference/selectors.qmd
             - reference/expression-generic.qmd
@@ -191,10 +191,10 @@ quartodoc:
       contents:
         - kind: page
           package: ibis
-          path: top_level
+          path: connection
           summary:
-            name: Top-level APIs
-            desc: Methods and objects available directly on the `ibis` module.
+            name: Connection API
+            desc: Create and manage backend connections.
           contents:
             - name: connect
               package: ibis.backends.base

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -140,7 +140,6 @@ website:
       contents:
         - section: Expression API
           contents:
-            - reference/connection.qmd
             - reference/expression-tables.qmd
             - reference/selectors.qmd
             - reference/expression-generic.qmd
@@ -158,6 +157,10 @@ website:
         - section: UDFs
           contents:
             - reference/scalar-udfs.qmd
+
+        - section: Connection APIs
+          contents:
+            - reference/connection.qmd
 
         - section: Configuration
           contents:
@@ -189,20 +192,6 @@ quartodoc:
       desc: "APIs for manipulating table, column and scalar expressions"
       package: ibis.expr.types
       contents:
-        - kind: page
-          package: ibis
-          path: connection
-          summary:
-            name: Connection API
-            desc: Create and manage backend connections.
-          contents:
-            - name: connect
-              package: ibis.backends.base
-            - name: get_backend
-              dynamic: true
-            - name: set_backend
-              dynamic: true
-
         - kind: page
           path: expression-tables
           package: ibis.expr.types.relations
@@ -305,27 +294,35 @@ quartodoc:
 
         - kind: page
           path: expression-numeric
-          package: ibis.expr.types.numeric
           summary:
             name: Numeric and Boolean expressions
             desc: Integer, floating point, decimal, and boolean expressions.
           contents:
-            - NumericValue
-            - NumericColumn
-            - IntegerValue
-            - IntegerColumn
-            - FloatingValue
-            - DecimalValue
+            - name: NumericValue
+              package: ibis.expr.types.numeric
+            - name: NumericColumn
+              package: ibis.expr.types.numeric
+            - name: IntegerValue
+              package: ibis.expr.types.numeric
+            - name: IntegerColumn
+              package: ibis.expr.types.numeric
+            - name: FloatingValue
+              package: ibis.expr.types.numeric
+            - name: DecimalValue
+              package: ibis.expr.types.numeric
             - name: BooleanValue
               package: ibis.expr.types.logical
             - name: and_
               dynamic: true
+              package: ibis
             - name: or_
               dynamic: true
+              package: ibis
             - name: negate
               package: ibis.expr.api
             - name: random
               dynamic: true
+              package: ibis
 
         - kind: page
           path: expression-strings
@@ -478,6 +475,23 @@ quartodoc:
               package: ibis
               dynamic: true
             - Schema
+
+    - title: Connection APIs
+      package: ibis.expr.operations.udf
+      contents:
+        - kind: page
+          package: ibis
+          path: connection
+          summary:
+            name: Top-level connection APIs
+            desc: Create and manage backend connections.
+          contents:
+            - name: connect
+              package: ibis.backends.base
+            - name: get_backend
+              dynamic: true
+            - name: set_backend
+              dynamic: true
 
     - title: UDFs
       desc: "User-defined function APIs"

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -196,21 +196,15 @@ quartodoc:
             name: Top-level APIs
             desc: Methods and objects available directly on the `ibis` module.
           contents:
-            - name: array
-              dynamic: true
             - name: connect
               package: ibis.backends.base
             - name: dtype
               dynamic: true
             - name: get_backend
               dynamic: true
-            - name: map
-              dynamic: true
             - name: schema
               dynamic: true
             - name: set_backend
-              dynamic: true
-            - name: struct
               dynamic: true
 
         - kind: page
@@ -376,16 +370,23 @@ quartodoc:
 
         - kind: page
           path: expression-collections
+          package: ibis
           summary:
             name: Collection expressions
             desc: Arrays, maps and structs.
           contents:
             - name: ArrayValue
               package: ibis.expr.types.arrays
-            - name: StructValue
-              package: ibis.expr.types.structs
             - name: MapValue
               package: ibis.expr.types.maps
+            - name: StructValue
+              package: ibis.expr.types.structs
+            - name: array
+              dynamic: true
+            - name: map
+              dynamic: true
+            - name: struct
+              dynamic: true
 
         - kind: page
           path: expression-geospatial

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -200,37 +200,17 @@ quartodoc:
               dynamic: true
             - name: connect
               package: ibis.backends.base
-            - name: cumulative_window
-              dynamic: true
             - name: date
-              dynamic: true
-            - name: difference
               dynamic: true
             - name: dtype
               dynamic: true
             - name: get_backend
               dynamic: true
-            - name: intersect
-              dynamic: true
             - name: interval
               dynamic: true
             - name: map
               dynamic: true
-            - name: memtable
-              dynamic: true
             - name: now
-              dynamic: true
-            - name: range_window
-              dynamic: true
-            - name: read_csv
-              dynamic: true
-            - name: read_delta
-              dynamic: true
-            - name: read_json
-              dynamic: true
-            - name: read_parquet
-              dynamic: true
-            - name: row_number
               dynamic: true
             - name: schema
               dynamic: true
@@ -238,19 +218,9 @@ quartodoc:
               dynamic: true
             - name: struct
               dynamic: true
-            - name: table
-              dynamic: true
             - name: time
               dynamic: true
             - name: timestamp
-              dynamic: true
-            - name: trailing_range_window
-              dynamic: true
-            - name: trailing_window
-              dynamic: true
-            - name: union
-              dynamic: true
-            - name: window
               dynamic: true
 
         - kind: page
@@ -262,6 +232,51 @@ quartodoc:
           contents:
             - Table
             - GroupedTable
+            - name: read_csv
+              package: ibis
+              dynamic: true
+            - name: read_delta
+              package: ibis
+              dynamic: true
+            - name: read_json
+              package: ibis
+              dynamic: true
+            - name: read_parquet
+              package: ibis
+              dynamic: true
+            - name: memtable
+              package: ibis
+              dynamic: true
+            - name: table
+              package: ibis
+              dynamic: true
+            - name: difference
+              package: ibis
+              dynamic: true
+            - name: intersect
+              package: ibis
+              dynamic: true
+            - name: union
+              package: ibis
+              dynamic: true
+            - name: row_number
+              package: ibis
+              dynamic: true
+            - name: window
+              package: ibis
+              dynamic: true
+            - name: cumulative_window
+              package: ibis
+              dynamic: true
+            - name: range_window
+              package: ibis
+              dynamic: true
+            - name: trailing_range_window
+              package: ibis
+              dynamic: true
+            - name: trailing_window
+              package: ibis
+              dynamic: true
 
         - kind: page
           path: expression-generic

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -198,19 +198,11 @@ quartodoc:
           contents:
             - name: array
               dynamic: true
-            - name: asc
-              dynamic: true
-            - name: case
-              dynamic: true
-            - name: coalesce
-              package: ibis.expr.api
             - name: connect
               package: ibis.backends.base
             - name: cumulative_window
               dynamic: true
             - name: date
-              dynamic: true
-            - name: desc
               dynamic: true
             - name: difference
               dynamic: true
@@ -218,33 +210,15 @@ quartodoc:
               dynamic: true
             - name: get_backend
               dynamic: true
-            - name: greatest
-              package: ibis.expr.api
-            - name: ifelse
-              package: ibis.expr.api
             - name: intersect
               dynamic: true
             - name: interval
-              dynamic: true
-            - name: least
-              package: ibis.expr.api
-            - name: literal
               dynamic: true
             - name: map
               dynamic: true
             - name: memtable
               dynamic: true
-            - name: NA
-              package: ibis.expr.api
             - name: now
-              dynamic: true
-            - name: "null"
-              dynamic: true
-            - name: param
-              dynamic: true
-            - name: show_sql
-              dynamic: true
-            - name: to_sql
               dynamic: true
             - name: range_window
               dynamic: true
@@ -299,6 +273,40 @@ quartodoc:
             - Value
             - Column
             - Scalar
+            - name: literal
+              package: ibis.expr.api
+              dynamic: true
+            - name: param
+              package: ibis
+              dynamic: true
+            - name: NA
+              package: ibis.expr.api
+            - name: "null"
+              package: ibis
+              dynamic: true
+            - name: coalesce
+              package: ibis.expr.api
+            - name: least
+              package: ibis.expr.api
+            - name: greatest
+              package: ibis.expr.api
+            - name: asc
+              package: ibis
+              dynamic: true
+            - name: desc
+              package: ibis
+              dynamic: true
+            - name: ifelse
+              package: ibis.expr.api
+            - name: case
+              package: ibis
+              dynamic: true
+            - name: show_sql
+              package: ibis
+              dynamic: true
+            - name: to_sql
+              package: ibis
+              dynamic: true
 
         - kind: page
           path: expression-numeric

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -196,8 +196,6 @@ quartodoc:
             name: Top-level APIs
             desc: Methods and objects available directly on the `ibis` module.
           contents:
-            - name: and_
-              dynamic: true
             - name: array
               dynamic: true
             - name: asc
@@ -236,23 +234,17 @@ quartodoc:
               dynamic: true
             - name: memtable
               dynamic: true
-            - name: negate
-              package: ibis.expr.api
             - name: NA
               package: ibis.expr.api
             - name: now
               dynamic: true
             - name: "null"
               dynamic: true
-            - name: or_
-              dynamic: true
             - name: param
               dynamic: true
             - name: show_sql
               dynamic: true
             - name: to_sql
-              dynamic: true
-            - name: random
               dynamic: true
             - name: range_window
               dynamic: true
@@ -323,6 +315,14 @@ quartodoc:
             - DecimalValue
             - name: BooleanValue
               package: ibis.expr.types.logical
+            - name: and_
+              dynamic: true
+            - name: or_
+              dynamic: true
+            - name: negate
+              package: ibis.expr.api
+            - name: random
+              dynamic: true
 
         - kind: page
           path: expression-strings

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -477,7 +477,6 @@ quartodoc:
             - Schema
 
     - title: Connection APIs
-      package: ibis.expr.operations.udf
       contents:
         - kind: page
           package: ibis

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -284,8 +284,6 @@ quartodoc:
               dynamic: true
             - name: union
               dynamic: true
-            - name: where
-              package: ibis.expr.api
             - name: window
               dynamic: true
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -198,11 +198,7 @@ quartodoc:
           contents:
             - name: connect
               package: ibis.backends.base
-            - name: dtype
-              dynamic: true
             - name: get_backend
-              dynamic: true
-            - name: schema
               dynamic: true
             - name: set_backend
               dynamic: true
@@ -434,6 +430,9 @@ quartodoc:
             name: Data types
             desc: Scalar and column data types
           contents:
+            - name: dtype
+              package: ibis
+              dynamic: true
             - Array
             - Binary
             - Boolean
@@ -475,6 +474,9 @@ quartodoc:
             name: Schemas
             desc: Table Schemas
           contents:
+            - name: schema
+              package: ibis
+              dynamic: true
             - Schema
 
     - title: UDFs

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -200,27 +200,17 @@ quartodoc:
               dynamic: true
             - name: connect
               package: ibis.backends.base
-            - name: date
-              dynamic: true
             - name: dtype
               dynamic: true
             - name: get_backend
               dynamic: true
-            - name: interval
-              dynamic: true
             - name: map
-              dynamic: true
-            - name: now
               dynamic: true
             - name: schema
               dynamic: true
             - name: set_backend
               dynamic: true
             - name: struct
-              dynamic: true
-            - name: time
-              dynamic: true
-            - name: timestamp
               dynamic: true
 
         - kind: page
@@ -368,6 +358,21 @@ quartodoc:
             - TimeValue
             - IntervalValue
             - DayOfWeek
+            - name: now
+              package: ibis
+              dynamic: true
+            - name: date
+              package: ibis
+              dynamic: true
+            - name: time
+              package: ibis
+              dynamic: true
+            - name: timestamp
+              package: ibis
+              dynamic: true
+            - name: interval
+              package: ibis
+              dynamic: true
 
         - kind: page
           path: expression-collections

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -1170,13 +1170,13 @@ def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
     The general pattern for `ibis.connect` is
 
     ```python
-    ibis.connect("backend://connection-parameters")
+    con = ibis.connect("backend://connection-parameters")
     ```
 
     With many backends that looks like
 
     ```python
-    ibis.connect("backend://user:password@host:port/database")
+    con = ibis.connect("backend://user:password@host:port/database")
     ```
 
     See the connection syntax for each backend for details about URL connection
@@ -1193,6 +1193,7 @@ def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
     --------
     Connect to an in-memory DuckDB database:
 
+    >>> import ibis
     >>> con = ibis.connect("duckdb://")
 
     Connect to an on-disk SQLite database:

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1779,15 +1779,17 @@ ifelse = _deferred(ir.BooleanValue.ifelse)
 
 Parameters
 ----------
+condition : ir.BooleanValue
+    A boolean expression
 true_expr : ir.Value
-    Expression to return if `self` evaluates to `True`
+    Expression to return if `condition` evaluates to `True`
 false_expr : ir.Value
-    Expression to return if `self` evaluates to `False` or `NULL`
+    Expression to return if `condition` evaluates to `False` or `NULL`
 
 Returns
 -------
 Value : ir.Value
-    The value of `true_expr` if `arg` is `True` else `false_expr`
+    The value of `true_expr` if `condition` is `True` else `false_expr`
 
 Examples
 --------

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1806,38 +1806,8 @@ Examples
 │ no                            │
 └───────────────────────────────┘
 """
+# Deprecated, use ifelse instead: https://github.com/ibis-project/ibis/issues/7147
 where = _deferred(ir.BooleanValue.ifelse)
-"""Construct a ternary conditional expression.
-
-Parameters
-----------
-true_expr : ir.Value
-    Expression to return if `self` evaluates to `True`
-false_expr : ir.Value
-    Expression to return if `self` evaluates to `False` or `NULL`
-
-Returns
--------
-Value : ir.Value
-    The value of `true_expr` if `arg` is `True` else `false_expr`
-
-Examples
---------
->>> import ibis
->>> ibis.options.interactive = True
->>> t = ibis.memtable({"is_person": [True, False, True, None]})
->>> ibis.where(t.is_person, "yes", "no")
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Where(is_person, 'yes', 'no') ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ string                        │
-├───────────────────────────────┤
-│ yes                           │
-│ no                            │
-│ yes                           │
-│ no                            │
-└───────────────────────────────┘
-"""
 coalesce = _deferred(ir.Value.coalesce)
 greatest = _deferred(ir.Value.greatest)
 least = _deferred(ir.Value.least)

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -830,7 +830,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`ibis.difference`](./top_level.qmd#ibis.difference)
+        [`ibis.difference`](./expression-tables.qmd#ibis.difference)
 
         Returns
         -------
@@ -1345,7 +1345,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`ibis.union`](./top_level.qmd#ibis.union)
+        [`ibis.union`](./expression-tables.qmd#ibis.union)
 
         Examples
         --------
@@ -1419,7 +1419,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         See Also
         --------
-        [`ibis.intersect`](./top_level.qmd#ibis.intersect)
+        [`ibis.intersect`](./expression-tables.qmd#ibis.intersect)
 
         Examples
         --------


### PR DESCRIPTION
This is a followup per #7141

- Move every datatype-specific API out of the top-level section. eg ibis.array() got moved to collections section
- Now only backend-specific stuff got left in the top-level section. Therefore, I renamed it to "Connections API".

In addition to these high-level changes, also a few tweaks:
- soft deprecate ibis.where
- fix ibis.ifelse docstring (plenty other functions like this are still missing docstrings, but at least the existing ones should be correct)
- import ibis in a doctest to prevent a rendering failure. This was little weird. This wasn't failing before only due to the ordering of this function in the larger API tab. All of the members in a a quartodoc section get squashed into a single .qmd file. Then quarto goes through and evaluates all the docstrings. So if the very first docstring in each API page does `import ibis`, then we are all good. But due to the reordering I did, this no longer happened here, so I had to add this import. At a higher-level, this isn't great, because it means different docstrings share state, and that depends on their ordering in a page. yuck. But maybe not worth it to fix. Possibly we could del all existing variables with some prelude lines, similar to what is done in https://github.com/ibis-project/ibis/pull/7158, but IDK this might all be overkill.

Things that I think should still happen in a followup PR:
- I want it to be more obvious how top level stuff is accessed from ibis. e.g. looking at `now()` in the temporal section, I wish the function signature was `ibis.now()`.
- Make things appear in the correct place where possible, eg `ibis.random()` instead of `ibis.expr.api.random()`.
