### PR TITLE
feat: just chat to open zulip in terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ prof/
 ibis/examples/data
 ibis/examples/descriptions
 .coverage*
+
+# zulip config
+.zuliprc

--- a/justfile
+++ b/justfile
@@ -127,3 +127,8 @@ decouple *args:
 # profile something
 profile +args:
     pyinstrument {{ args }}
+
+# open zulip chat
+# use ibis-project.zulipchat.com when connecting the first time
+chat:
+    @zulip-term --color-depth 24bit -c ./.zuliprc


### PR DESCRIPTION
opening for discussion -- I think `just chat` would be a very convenient command when working in the repo to instantly open Zulip chat in the terminal

should probably adjust the justfile to pass through args (note some of the themes don't seem to work out of the box on Mac) and add to dev-requirements or something (note 3.11 is not supported on released versions, I'm installing from git+https://)
