### PR TITLE
feat: just chat to open Zulip in terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ prof/
 # generated examples data
 ibis/examples/data
 ibis/examples/descriptions
+
+# chat
+*zuliprc*

--- a/justfile
+++ b/justfile
@@ -156,3 +156,7 @@ docs-build-all:
     just docs-apigen --verbose
     just docs-render
     just checklinks docs/_output --offline --no-progress
+
+# open chat
+chat *args:
+    zulip-term {{ args }}


### PR DESCRIPTION
opening for discussion -- I think just chat would be a very convenient command when working in the repo to instantly open Zulip chat in the terminal

should probably adjust the justfile to pass through args (note some of the themes don't seem to work out of the box on Mac) and add to dev-requirements or something (note 3.11 is not supported on released versions, I'm installing from git+https://)
