### PR TITLE
refactor(bigquery): clean up literal handling

### DIFF
--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hash/binary/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hash/binary/out.sql
@@ -1,1 +1,1 @@
-SELECT farm_fingerprint(FROM_BASE64('dGVzdCBvZiBoYXNo')) AS `Hash_b'test of hash'`
+SELECT farm_fingerprint(b'test of hash') AS `Hash_b'test of hash'`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hashbytes/md5-test-binary/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hashbytes/md5-test-binary/out.sql
@@ -1,1 +1,1 @@
-SELECT md5(FROM_BASE64('dGVzdA==')) AS `tmp`
+SELECT md5(b'test') AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hashbytes/sha1-test-binary/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hashbytes/sha1-test-binary/out.sql
@@ -1,1 +1,1 @@
-SELECT sha1(FROM_BASE64('dGVzdA==')) AS `tmp`
+SELECT sha1(b'test') AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hashbytes/sha256-test-binary/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hashbytes/sha256-test-binary/out.sql
@@ -1,1 +1,1 @@
-SELECT sha256(FROM_BASE64('dGVzdA==')) AS `tmp`
+SELECT sha256(b'test') AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hashbytes/sha512-test-binary/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_hashbytes/sha512-test-binary/out.sql
@@ -1,1 +1,1 @@
-SELECT sha512(FROM_BASE64('dGVzdA==')) AS `tmp`
+SELECT sha512(b'test') AS `tmp`


### PR DESCRIPTION
Clean up the bigquery backend literal translation. For some reason we had
a branch that checked whether the op was a literal, which is unnecessary since
by definition that is true.
