### PR TITLE
fix(trino): differentiate between a single column struct and a column when chaining unnest expressions with field accesses

### DIFF
--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -47,9 +47,6 @@ array_literal = param(
             raises=NotImplementedError,
             reason="backends hasn't implemented array literals",
         ),
-        mark.notimpl(
-            ["trino"], reason="Cannot render array literals", raises=sa.exc.CompileError
-        ),
     ],
     id="array_literal",
 )


### PR DESCRIPTION
Fixes a bug in the Trino backend when accessing fields on an `array<struct<...>>`.
