### PR TITLE
docs: remove final instances of gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,6 @@ Ibis is an open source project and welcomes contributions from anyone in the com
 - We care about keeping the community welcoming for all. Check out [the code of conduct](https://github.com/ibis-project/ibis/blob/master/docs/CODE_OF_CONDUCT.md).
 - The Ibis project is open sourced under the [Apache License](https://github.com/ibis-project/ibis/blob/master/LICENSE.txt).
 
-Join our community here:
-
-- Twitter: https://twitter.com/IbisData
-- Gitter: https://gitter.im/ibis-dev/Lobby
-- StackOverflow: https://stackoverflow.com/questions/tagged/ibis
+Join our community by interacting on GitHub or chatting with us on [Zulip](https://ibis-project.zulipchat.com).
 
 For more information visit https://ibis-project.org/.

--- a/docs/posts/ibis-version-4.0.0-release/index.qmd
+++ b/docs/posts/ibis-version-4.0.0-release/index.qmd
@@ -39,6 +39,6 @@ Notable changes include removing intermediate expressions, improving the testing
 ## Additional Changes
 
 As mentioned previously, additional functionality, bugfixes, and more have been included in the latest 4.0 release.
-To stay up to date and learn more about recent changes: check out the project's homepage at [ibis-project.org](https://ibis-project.org), follow [@IbisData](https://twitter.com/IbisData) on Twitter, find the source code and community on [GitHub](https://github.com/ibis-project/ibis), and join the discussion on [Gitter](https://gitter.im/ibis-dev/Lobby).
+To stay up to date and learn more about recent changes: check out the project's homepage at [ibis-project.org](https://ibis-project.org), follow [@IbisData](https://twitter.com/IbisData) on Twitter, find the source code and community on [GitHub](https://github.com/ibis-project/ibis), and join the discussion on [Zulip](https://ibis-project.zulipchat.com).
 
 As always, try Ibis by [installing](../../install.qmd) it today.


### PR DESCRIPTION
I should have checked before the last PR. feel free to reword, I took the liberty of removing the link to Twitter/X and StackOverflow from the README.md. if there's no objection, I'd like to keep GitHub + Zulip as the primary two channels of information and recommendations for community stuff
