### PR TITLE
ci(flink): don't generate now-unused 3.10 lockfile

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -46,7 +46,6 @@ jobs:
       matrix:
         python-version:
           - "3.9"
-          - "3.10" # For PyFlink, which does not support Python 3.11 yet
           - "3.11"
     steps:
       - name: checkout


### PR DESCRIPTION
Should have been dropped in #6877 