### PR TITLE
docs: fix zulip link for new members

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,6 @@ Ibis is an open source project and welcomes contributions from anyone in the com
 - We care about keeping the community welcoming for all. Check out [the code of conduct](https://github.com/ibis-project/ibis/blob/master/docs/CODE_OF_CONDUCT.md).
 - The Ibis project is open sourced under the [Apache License](https://github.com/ibis-project/ibis/blob/master/LICENSE.txt).
 
-Join our community by interacting on GitHub or chatting with us on [Zulip](https://ibis-project.zulipchat.com).
+Join our community by interacting on GitHub or chatting with us on [Zulip](https://ibis-project.zulipchat.com/join/ldd2gyoqkbsqli3dzlb463u4).
 
 For more information visit https://ibis-project.org/.

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -57,7 +57,7 @@ website:
       - icon: github
         href: https://github.com/ibis-project
       - icon: zulip
-        href: https://ibis-project.zulipchat.com
+        href: https://ibis-project.zulipchat.com/join/ldd2gyoqkbsqli3dzlb463u4
       - icon: rss
         href: https://ibis-project.org/posts.xml
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -25,7 +25,7 @@ about:
       text: GitHub
       href: https://github.com/ibis-project
     - icon: zulip
-      href: https://ibis-project.zulipchat.com
+      href: https://ibis-project.zulipchat.com/join/ldd2gyoqkbsqli3dzlb463u4
       text: Chat
     - icon: rss
       text: RSS

--- a/docs/posts/ibis-version-4.0.0-release/index.qmd
+++ b/docs/posts/ibis-version-4.0.0-release/index.qmd
@@ -39,6 +39,6 @@ Notable changes include removing intermediate expressions, improving the testing
 ## Additional Changes
 
 As mentioned previously, additional functionality, bugfixes, and more have been included in the latest 4.0 release.
-To stay up to date and learn more about recent changes: check out the project's homepage at [ibis-project.org](https://ibis-project.org), follow [@IbisData](https://twitter.com/IbisData) on Twitter, find the source code and community on [GitHub](https://github.com/ibis-project/ibis), and join the discussion on [Zulip](https://ibis-project.zulipchat.com).
+To stay up to date and learn more about recent changes: check out the project's homepage at [ibis-project.org](https://ibis-project.org), follow [@IbisData](https://twitter.com/IbisData) on Twitter, find the source code and community on [GitHub](https://github.com/ibis-project/ibis), and join the discussion on [Zulip](https://ibis-project.zulipchat.com/join/ldd2gyoqkbsqli3dzlb463u4).
 
 As always, try Ibis by [installing](../../install.qmd) it today.


### PR DESCRIPTION
updates to use a join-as-member link that never expires, my bad on missing this earlier
