### PR TITLE
fix(clip): preserve nulls when clipping

### DIFF
--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -761,10 +761,10 @@ def _struct_column(op, **kw):
 def _clip(op, **kw):
     arg = translate_val(op.arg, **kw)
     if (upper := op.upper) is not None:
-        arg = f"least({translate_val(upper, **kw)}, {arg})"
+        arg = f"if(isNull({arg}), NULL, least({translate_val(upper, **kw)}, {arg}))"
 
     if (lower := op.lower) is not None:
-        arg = f"greatest({translate_val(lower, **kw)}, {arg})"
+        arg = f"if(isNull({arg}), NULL, greatest({translate_val(lower, **kw)}, {arg}))"
 
     return arg
 

--- a/ibis/backends/flink/registry.py
+++ b/ibis/backends/flink/registry.py
@@ -207,11 +207,11 @@ def _clip(translator: ExprTranslator, op: ops.Node) -> str:
 
     if op.upper is not None:
         upper = translator.translate(op.upper)
-        arg = f"IF({arg} > {upper}, {upper}, {arg})"
+        arg = f"IF({arg} > {upper} AND {arg} IS NOT NULL, {upper}, {arg})"
 
     if op.lower is not None:
         lower = translator.translate(op.lower)
-        arg = f"IF({arg} < {lower}, {lower}, {arg})"
+        arg = f"IF({arg} < {lower} AND {arg} IS NOT NULL, {lower}, {arg})"
 
     return f"CAST({arg} AS {_to_pyflink_types[type(op.dtype)]!s})"
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -775,11 +775,11 @@ def compile_clip(t, op, **kwargs):
 
     def column_min(value, limit):
         """Return values greater than or equal to `limit`."""
-        return F.when(value < limit, limit).otherwise(value)
+        return F.when((value < limit) & ~F.isnull(value), limit).otherwise(value)
 
     def column_max(value, limit):
         """Return values less than or equal to `limit`."""
-        return F.when(value > limit, limit).otherwise(value)
+        return F.when((value > limit) & ~F.isnull(value), limit).otherwise(value)
 
     def clip(column, lower_value, upper_value):
         return column_max(column_min(column, F.lit(lower_value)), F.lit(upper_value))

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -1364,10 +1364,12 @@ def test_random(con):
 @pytest.mark.parametrize(
     ("ibis_func", "pandas_func"),
     [
-        (lambda x: x.clip(lower=0), lambda x: x.clip(lower=0)),
-        (lambda x: x.clip(lower=0.0), lambda x: x.clip(lower=0.0)),
-        (lambda x: x.clip(upper=0), lambda x: x.clip(upper=0)),
-        pytest.param(
+        param(lambda x: x.clip(lower=0), lambda x: x.clip(lower=0), id="lower-int"),
+        param(
+            lambda x: x.clip(lower=0.0), lambda x: x.clip(lower=0.0), id="lower-float"
+        ),
+        param(lambda x: x.clip(upper=0), lambda x: x.clip(upper=0), id="upper-int"),
+        param(
             lambda x: x.clip(lower=x - 1, upper=x + 1),
             lambda x: x.clip(lower=x - 1, upper=x + 1),
             marks=pytest.mark.notimpl(
@@ -1375,14 +1377,27 @@ def test_random(con):
                 raises=com.UnsupportedArgumentError,
                 reason="Polars does not support columnar argument Subtract(int_col, 1)",
             ),
+            id="lower-upper-expr",
         ),
-        (
+        param(
             lambda x: x.clip(lower=0, upper=1),
             lambda x: x.clip(lower=0, upper=1),
+            id="lower-upper-int",
         ),
-        (
+        param(
             lambda x: x.clip(lower=0, upper=1.0),
             lambda x: x.clip(lower=0, upper=1.0),
+            id="lower-upper-float",
+        ),
+        param(
+            lambda x: x.nullif(1).clip(lower=0),
+            lambda x: x.where(x != 1).clip(lower=0),
+            id="null-lower",
+        ),
+        param(
+            lambda x: x.nullif(1).clip(upper=0),
+            lambda x: x.where(x != 1).clip(upper=0),
+            id="null-upper",
         ),
     ],
 )

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -182,6 +182,8 @@ class NumericValue(Value):
     ) -> NumericValue:
         """Trim values outside of `lower` and `upper` bounds.
 
+        `NULL` values are preserved and are not replaced with bounds.
+
         Parameters
         ----------
         lower
@@ -198,20 +200,23 @@ class NumericValue(Value):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.memtable({"values": range(8)})
+        >>> t = ibis.memtable(
+        ...     {"values": [None, 2, 3, None, 5, None, None, 8]},
+        ...     schema=dict(values="int"),
+        ... )
         >>> t.values.clip(lower=3, upper=6)
         ┏━━━━━━━━━━━━━━━━━━━━┓
         ┃ Clip(values, 3, 6) ┃
         ┡━━━━━━━━━━━━━━━━━━━━┩
         │ int64              │
         ├────────────────────┤
+        │               NULL │
         │                  3 │
         │                  3 │
-        │                  3 │
-        │                  3 │
-        │                  4 │
+        │               NULL │
         │                  5 │
-        │                  6 │
+        │               NULL │
+        │               NULL │
         │                  6 │
         └────────────────────┘
         """


### PR DESCRIPTION
Ensure that NULLs are propagated through `clip`

Fixes #7168.