### PR TITLE
docs: remove extra bits in zulip links

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -57,7 +57,7 @@ website:
       - icon: github
         href: https://github.com/ibis-project
       - icon: zulip
-        href: https://ibis-project.zulipchat.com/join/ldd2gyoqkbsqli3dzlb463u4
+        href: https://ibis-project.zulipchat.com
       - icon: rss
         href: https://ibis-project.org/posts.xml
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -25,7 +25,7 @@ about:
       text: GitHub
       href: https://github.com/ibis-project
     - icon: zulip
-      href: https://ibis-project.zulipchat.com/join/ldd2gyoqkbsqli3dzlb463u4
+      href: https://ibis-project.zulipchat.com
       text: Chat
     - icon: rss
       text: RSS


### PR DESCRIPTION
I had added these, now invitation requirement is removed, removing these 
