### PR TITLE
fix(sql): unbind expressions when generating sql to avoid backend-specific API calls

### DIFF
--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/bigquery/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(ibis-gbq.ibis_gbq_testing.functional_alltypes)"
+FROM "ibis-gbq.ibis_gbq_testing.functional_alltypes" AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/clickhouse/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/dask/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/dask/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/datafusion/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/datafusion/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/druid/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/druid/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/duckdb/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/impala/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/impala/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/mssql/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/mysql/out.sql
@@ -1,0 +1,19 @@
+SELECT
+  COUNT(*) AS "CountStar()"
+FROM (
+  SELECT
+    t1.id AS id,
+    t1.bool_col = CAST(1 AS TINYINT) AS bool_col,
+    t1.tinyint_col AS tinyint_col,
+    t1.smallint_col AS smallint_col,
+    t1.int_col AS int_col,
+    t1.bigint_col AS bigint_col,
+    t1.float_col AS float_col,
+    t1.double_col AS double_col,
+    t1.date_string_col AS date_string_col,
+    t1.string_col AS string_col,
+    t1.timestamp_col AS timestamp_col,
+    t1.year AS year,
+    t1.month AS month
+  FROM functional_alltypes AS t1
+) AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/oracle/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/oracle/out.sql
@@ -1,0 +1,19 @@
+SELECT
+  COUNT(*) AS "CountStar()"
+FROM (
+  SELECT
+    t1."id" AS "id",
+    t1."bool_col" = CAST(1 AS TINYINT) AS bool_col,
+    t1."tinyint_col" AS "tinyint_col",
+    t1."smallint_col" AS "smallint_col",
+    t1."int_col" AS "int_col",
+    t1."bigint_col" AS "bigint_col",
+    t1."float_col" AS "float_col",
+    t1."double_col" AS "double_col",
+    t1."date_string_col" AS "date_string_col",
+    t1."string_col" AS "string_col",
+    t1."timestamp_col" AS "timestamp_col",
+    t1."year" AS "year",
+    t1."month" AS "month"
+  FROM functional_alltypes AS t1
+) AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/pandas/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/pandas/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/polars/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/polars/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/postgres/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/pyspark/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/pyspark/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/sqlite/out.sql
@@ -1,0 +1,19 @@
+SELECT
+  COUNT(*) AS "CountStar()"
+FROM (
+  SELECT
+    t1.id AS id,
+    t1.bool_col AS bool_col,
+    t1.tinyint_col AS tinyint_col,
+    t1.smallint_col AS smallint_col,
+    t1.int_col AS int_col,
+    t1.bigint_col AS bigint_col,
+    t1.float_col AS float_col,
+    t1.double_col AS double_col,
+    t1.date_string_col AS date_string_col,
+    t1.string_col AS string_col,
+    t1.timestamp_col AS timestamp_col,
+    t1.year AS year,
+    t1.month AS month
+  FROM functional_alltypes AS t1
+) AS t0

--- a/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cross_dialect_to_sql/trino/out.sql
@@ -1,0 +1,3 @@
+SELECT
+  COUNT(*) AS "CountStar(functional_alltypes)"
+FROM functional_alltypes AS t0

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -376,6 +376,6 @@ def to_sql(expr: ir.Expr, dialect: str | None = None, **kwargs) -> SQLString:
         else:
             read = write = getattr(backend, "_sqlglot_dialect", dialect)
 
-    sql = backend._to_sql(expr, **kwargs)
+    sql = backend._to_sql(expr.unbind(), **kwargs)
     (pretty,) = sg.transpile(sql, read=read, write=write, pretty=True)
     return SQLString(pretty)


### PR DESCRIPTION
Allow generating sql from any backend.