### PR TITLE
feat(api): support deferred expressions in `ibis.date`/`ibis.time`/`ibis.timestamp`

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -695,7 +695,9 @@ def timestamp(
 
     if is_ymdhms:
         if timezone is not None:
-            raise NotImplementedError("timestamp timezone not implemented")
+            raise NotImplementedError(
+                "Timezone currently not supported when creating a timestamp from components"
+            )
         return ops.TimestampFromYMDHMS(*args).to_expr()
     elif isinstance(value_or_year, (numbers.Real, ir.IntegerValue)):
         raise TypeError("Use ibis.literal(...).to_timestamp() instead")

--- a/ibis/expr/deferred.py
+++ b/ibis/expr/deferred.py
@@ -220,7 +220,10 @@ class DeferredCall(Deferred):
     def __repr__(self) -> str:
         params = [repr(a) for a in self._args]
         params.extend(f"{k}={v!r}" for k, v in self._kwargs.items())
-        return f"{self._func!r}({', '.join(params)})"
+        # Repr directly wrapped functions as their name, fallback to repr for
+        # deferred objects or callables without __name__ otherwise
+        func = getattr(self._func, "__name__", "") or repr(self._func)
+        return f"{func}({', '.join(params)})"
 
     def _resolve(self, param: Any) -> Any:
         func = _resolve(self._func, param)

--- a/ibis/expr/tests/test_deferred.py
+++ b/ibis/expr/tests/test_deferred.py
@@ -8,6 +8,7 @@ from pytest import param
 
 import ibis
 from ibis import _
+from ibis.expr.deferred import deferred_apply
 
 
 @pytest.fixture
@@ -98,6 +99,19 @@ def test_method_kwargs(table):
     res = expr.resolve(table)
     assert res.equals(table.a.log(base=table.b))
     assert repr(expr) == "_.a.log(base=_.b)"
+
+
+def test_deferred_apply(table):
+    expr = deferred_apply(operator.add, _.a, 2)
+    res = expr.resolve(table)
+    assert res.equals(table.a + 2)
+    assert repr(expr) == "add(_.a, 2)"
+
+    func = lambda a, b: a + b
+    expr = deferred_apply(func, _.a, 2)
+    res = expr.resolve(table)
+    assert res.equals(table.a + 2)
+    assert func.__name__ in repr(expr)
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -860,3 +860,32 @@ def test_time_expression():
 
 def test_timestamp_literals():
     assert ibis.timestamp(2022, 2, 4, 16, 20, 00).type() == dt.timestamp
+
+
+def test_timestamp_literal():
+    expr = ibis.timestamp(2022, 2, 4, 16, 20, 0)
+    sol = ops.TimestampFromYMDHMS(2022, 2, 4, 16, 20, 0).to_expr()
+    assert expr.equals(sol)
+
+    expr = ibis.timestamp("2022-02-04T01:02:03")
+    sol = ibis.literal("2022-02-04T01:02:03", type=dt.timestamp)
+    assert expr.equals(sol)
+
+    expr = ibis.timestamp("2022-02-04T01:02:03Z")
+    sol = ibis.literal("2022-02-04T01:02:03", type=dt.Timestamp(timezone="UTC"))
+    assert expr.equals(sol)
+
+
+def test_timestamp_expression():
+    t = ibis.table(dict.fromkeys("abcdef", "int"))
+    deferred = ibis.timestamp(_.a, _.b, _.c, _.d, _.e, _.f)
+    expr = ibis.timestamp(t.a, t.b, t.c, t.d, t.e, t.f)
+    assert isinstance(expr.op(), ops.TimestampFromYMDHMS)
+    assert deferred.resolve(t).equals(expr)
+    assert repr(deferred) == "timestamp(_.a, _.b, _.c, _.d, _.e, _.f)"
+
+    t2 = ibis.table({"s": "string"})
+    deferred = ibis.timestamp(_.s, timezone="UTC")
+    expr = ibis.timestamp(t2.s, timezone="UTC")
+    assert deferred.resolve(t2).equals(expr)
+    assert repr(deferred) == "timestamp(_.s, timezone='UTC')"

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -834,6 +834,29 @@ def test_date_expression():
     assert repr(deferred) == "date(_.s)"
 
 
-def test_date_time_literals():
-    assert ibis.time(16, 20, 00).type() == dt.time
+def test_time_literal():
+    expr = ibis.time(1, 2, 3)
+    sol = ops.TimeFromHMS(1, 2, 3).to_expr()
+    assert expr.equals(sol)
+
+    expr = ibis.time("01:02:03")
+    sol = ibis.literal("01:02:03", type=dt.time)
+    assert expr.equals(sol)
+
+
+def test_time_expression():
+    t = ibis.table({"x": "int", "y": "int", "z": "int", "s": "string"})
+    deferred = ibis.time(_.x, _.y, _.z)
+    expr = ibis.time(t.x, t.y, t.z)
+    assert isinstance(expr.op(), ops.TimeFromHMS)
+    assert deferred.resolve(t).equals(expr)
+    assert repr(deferred) == "time(_.x, _.y, _.z)"
+
+    deferred = ibis.time(_.s)
+    expr = ibis.time(t.s)
+    assert deferred.resolve(t).equals(expr)
+    assert repr(deferred) == "time(_.s)"
+
+
+def test_timestamp_literals():
     assert ibis.timestamp(2022, 2, 4, 16, 20, 00).type() == dt.timestamp

--- a/ibis/tests/expr/test_timestamp.py
+++ b/ibis/tests/expr/test_timestamp.py
@@ -183,5 +183,5 @@ def test_timestamp_field_access_on_time_failure(
 
 @pytest.mark.parametrize("value", [42, np.int64(42), np.int8(-42)])
 def test_integer_timestamp_fails(value):
-    with pytest.raises(TypeError, match=r"Use ibis\.literal\(-?\d+\)\.to_timestamp"):
+    with pytest.raises(TypeError, match=r"Use ibis\.literal\(\.\.\.\)\.to_timestamp"):
         ibis.timestamp(value)

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1566,15 +1566,7 @@ def test_array_filter_partial():
 @pytest.mark.parametrize(
     ("func", "expected_type"),
     [
-        param(
-            ibis.timestamp,
-            dt.timestamp,
-            id="timestamp",
-            marks=pytest.mark.xfail(
-                raises=NotImplementedError,
-                reason=("`ibis.timestamp` isn't implemented for expression inputs"),
-            ),
-        ),
+        param(ibis.timestamp, dt.timestamp, id="timestamp"),
         param(ibis.date, dt.date, id="date"),
         param(ibis.time, dt.time, id="time"),
         param(ibis.coalesce, dt.timestamp, id="coalesce"),


### PR DESCRIPTION
This PR does a few things:

- Adds full support for deferred expressions passed to `ibis.date`/`ibis.time`/`ibis.timestamp`
- Adds a new `deferrable` decorator (non-public) for wrapping top-level expr functions and making them work with deferred arguments.
- Improves the docstrings of `ibis.date`/`ibis.time`/`ibis.timestamp`
- Improves the type-signatures of `ibis.date`/`ibis.time`/`ibis.timestamp`. In particular, now mypy/pyright will complain if you don't pass in all components required or the components are the incorrect type. It also fixes the return type to indicate it's not always a scalar.

Fixes #4534.