### PR TITLE
ci(snowflake): allow concurrent python version tests to run

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -30,7 +30,7 @@ jobs:
     # only a single bigquery or snowflake run at a time, otherwise test data is
     # clobbered by concurrent runs
     concurrency:
-      group: ${{ matrix.backend.name }}
+      group: ${{ matrix.backend.name }}-${{ matrix.python-version }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     strategy:
@@ -42,13 +42,18 @@ jobs:
         backend:
           - name: bigquery
             title: BigQuery
+            deps: []
           - name: snowflake
             title: Snowflake
-          - name: snowflake
-            title: Snowflake with nanoarrow
-            deps:
-              - snowflake-connector-python[pandas]@3.3.0b1
-              - --optional
+            deps: []
+        include:
+          - python-version: "3.10"
+            backend:
+              name: snowflake
+              title: Snowflake with nanoarrow
+              deps:
+                - snowflake-connector-python[pandas]@3.3.0b1
+                - --optional
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -60,7 +65,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - uses: syphar/restore-virtualenv@v1
-        if: matrix.backend.deps == null
+        if: toJSON(matrix.backend.deps) == '[]'
         with:
           requirement_files: poetry.lock
           custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
@@ -69,11 +74,11 @@ jobs:
         run: python -m pip install --upgrade pip 'poetry==1.6.1'
 
       - name: install a prerelease version of `snowflake-connector-python`
-        if: matrix.backend.deps != null
+        if: toJSON(matrix.backend.deps) != '[]'
         run: poetry add ${{ join(matrix.backend.deps, ' ') }}
 
       - uses: syphar/restore-pip-download-cache@v1
-        if: matrix.backend.deps == null
+        if: toJSON(matrix.backend.deps) == '[]'
         with:
           requirement_files: poetry.lock
           custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}


### PR DESCRIPTION
We create a schema for snowflake tests per python version, so allowing e.g., 3.9 and 3.11 to run concurrently is okay.