### PR TITLE
perf: introduce quicker abstract base classes

### DIFF
--- a/ibis/backends/base/sql/compiler/base.py
+++ b/ibis/backends/base/sql/compiler/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import abc
 from itertools import chain
 
 import toolz
@@ -10,16 +9,14 @@ import ibis.expr.operations as ops
 from ibis import util
 
 
-class DML(abc.ABC):
-    @abc.abstractmethod
+class DML:
     def compile(self):
-        pass
+        raise NotImplementedError()
 
 
-class DDL(abc.ABC):
-    @abc.abstractmethod
+class DDL:
     def compile(self):
-        pass
+        raise NotImplementedError()
 
 
 class QueryAST:

--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from bidict import bidict
 
-from ibis.common.collections import FrozenDict
 from ibis.common.exceptions import IbisError
 
 if TYPE_CHECKING:
@@ -21,7 +20,7 @@ def memoize(func: Callable) -> Callable:
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        key = (args, FrozenDict(kwargs))
+        key = (args, tuple(kwargs.items()))
         try:
             return cache[key]
         except KeyError:

--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections import deque
-from collections.abc import Hashable, Iterable, Iterator, KeysView, Sequence
+from collections.abc import Iterable, Iterator, KeysView, Sequence
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
+from ibis.common.bases import Hashable
 from ibis.common.collections import frozendict
 from ibis.common.patterns import NoMatch, pattern
 from ibis.util import experimental

--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -18,6 +18,8 @@ from ibis.common.annotations import (
     Signature,
 )
 from ibis.common.bases import (  # noqa: F401
+    Abstract,
+    AbstractMeta,
     Base,
     BaseMeta,
     Comparable,
@@ -30,7 +32,7 @@ from ibis.common.patterns import Pattern
 from ibis.common.typing import evaluate_annotations
 
 
-class AnnotableMeta(BaseMeta):
+class AnnotableMeta(AbstractMeta):
     """Metaclass to turn class annotations into a validatable function signature."""
 
     __slots__ = ()
@@ -97,7 +99,7 @@ class AnnotableMeta(BaseMeta):
 
 
 @dataclass_transform()
-class Annotable(Base, metaclass=AnnotableMeta):
+class Annotable(Abstract, metaclass=AnnotableMeta):
     """Base class for objects with custom validation rules."""
 
     __signature__: ClassVar[Signature]

--- a/ibis/common/patterns.py
+++ b/ibis/common/patterns.py
@@ -4,8 +4,8 @@ import math
 import numbers
 import operator
 import sys
-from abc import ABC, abstractmethod
-from collections.abc import Callable, Hashable, Mapping, Sequence
+from abc import abstractmethod
+from collections.abc import Callable, Mapping, Sequence
 from enum import Enum
 from inspect import Parameter
 from itertools import chain
@@ -23,8 +23,8 @@ from typing import Any as AnyType
 import toolz
 from typing_extensions import GenericMeta, Self, get_args, get_origin
 
+from ibis.common.bases import Abstract, Hashable, Singleton
 from ibis.common.bases import FrozenSlotted as Slotted
-from ibis.common.bases import Singleton
 from ibis.common.collections import FrozenDict, RewindableIterator, frozendict
 from ibis.common.dispatch import lazy_singledispatch
 from ibis.common.typing import (
@@ -45,15 +45,13 @@ class CoercionError(Exception):
     ...
 
 
-class Coercible(ABC):
+class Coercible(Abstract):
     """Protocol for defining coercible types.
 
     Coercible types define a special ``__coerce__`` method that accepts an object
     with an instance of the type. Used in conjunction with the ``coerced_to``
     pattern to coerce arguments to a specific type.
     """
-
-    __slots__ = ()
 
     @classmethod
     @abstractmethod
@@ -74,8 +72,6 @@ class Pattern(Hashable):
     Patterns are used to match values against a given condition. They are extensively
     used by other core components of Ibis to validate and/or coerce user inputs.
     """
-
-    __slots__ = ()
 
     @classmethod
     def from_typehint(cls, annot: type, allow_coercion: bool = True) -> Pattern:
@@ -320,8 +316,6 @@ class Builder(Hashable):
     replace pattern, the builder is called with the context and the result
     of the builder is used as the replacement value.
     """
-
-    __slots__ = ()
 
     @abstractmethod
     def __eq__(self, other):
@@ -982,6 +976,8 @@ class GenericCoercedTo(Slotted, Pattern):
     >>> T = TypeVar("T", covariant=True)
     >>>
     >>> class MyNumber(Coercible, Generic[T]):
+    ...     __slots__ = ("value",)
+    ...
     ...     def __init__(self, value):
     ...         self.value = value
     ...

--- a/ibis/common/temporal.py
+++ b/ibis/common/temporal.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import numbers
-from abc import ABCMeta
 from decimal import Decimal
 from enum import Enum, EnumMeta
 
@@ -12,15 +11,16 @@ import pytz
 from public import public
 
 from ibis import util
+from ibis.common.bases import AbstractMeta
 from ibis.common.dispatch import lazy_singledispatch
 from ibis.common.patterns import Coercible, CoercionError
 
 
-class ABCEnumMeta(EnumMeta, ABCMeta):
+class AbstractEnumMeta(EnumMeta, AbstractMeta):
     pass
 
 
-class Unit(Coercible, Enum, metaclass=ABCEnumMeta):
+class Unit(Coercible, Enum, metaclass=AbstractEnumMeta):
     @classmethod
     def __coerce__(cls, value):
         if isinstance(value, cls):

--- a/ibis/common/tests/test_collections.py
+++ b/ibis/common/tests/test_collections.py
@@ -1,14 +1,234 @@
 from __future__ import annotations
 
-from collections.abc import ItemsView, Iterator, KeysView, ValuesView
+import collections.abc
 
 import pytest
 
-from ibis.common.collections import FrozenDict, MapSet, RewindableIterator
+from ibis.common.collections import (
+    Collection,
+    Container,
+    FrozenDict,
+    Iterable,
+    Iterator,
+    Mapping,
+    MapSet,
+    Reversible,
+    RewindableIterator,
+    Sequence,
+    Sized,
+)
 from ibis.tests.util import assert_pickle_roundtrip
 
 
+def test_iterable():
+    class MyIterable(Iterable):
+        __slots__ = ("n",)
+
+        def __init__(self, n):
+            self.n = n
+
+        def __iter__(self):
+            return iter(range(self.n))
+
+    i = MyIterable(10)
+    assert isinstance(i, Iterable)
+    assert isinstance(i, collections.abc.Iterable)
+    assert list(i) == list(range(10))
+
+
+def test_reversible():
+    class MyReversible(Reversible):
+        __slots__ = ("n",)
+
+        def __init__(self, n):
+            self.n = n
+
+        def __iter__(self):
+            return iter(range(self.n))
+
+        def __reversed__(self):
+            return reversed(range(self.n))
+
+    r = MyReversible(10)
+    assert isinstance(r, Reversible)
+    assert isinstance(r, Iterable)
+    assert isinstance(r, collections.abc.Reversible)
+    assert isinstance(r, collections.abc.Iterable)
+    assert list(r) == list(range(10))
+    assert list(reversed(r)) == list(reversed(range(10)))
+
+
+def test_iterator():
+    class MyIterator(Iterator):
+        __slots__ = ("n", "i")
+
+        def __init__(self, n):
+            self.n = n
+            self.i = iter(range(n))
+
+        def __next__(self):
+            return next(self.i)
+
+    i = MyIterator(10)
+    assert isinstance(i, Iterator)
+    assert isinstance(i, Iterable)
+    assert isinstance(i, collections.abc.Iterator)
+    assert isinstance(i, collections.abc.Iterable)
+    for j in range(10):
+        assert next(i) == j
+
+
+def test_sized():
+    class MySized(Sized):
+        __slots__ = ("n",)
+
+        def __init__(self, n):
+            self.n = n
+
+        def __len__(self):
+            return self.n
+
+    s = MySized(10)
+    assert isinstance(s, Sized)
+    assert isinstance(s, collections.abc.Sized)
+    assert len(s) == 10
+
+
+def test_container():
+    class MyContainer(Container):
+        __slots__ = ("n",)
+
+        def __init__(self, n):
+            self.n = n
+
+        def __contains__(self, x):
+            return x in range(self.n)
+
+    c = MyContainer(10)
+    assert isinstance(c, Container)
+    assert isinstance(c, collections.abc.Container)
+    assert 5 in c
+    assert 10 not in c
+
+
+def test_collection():
+    class MyCollection(Collection):
+        __slots__ = ("n",)
+
+        def __init__(self, n):
+            self.n = n
+
+        def __len__(self):
+            return self.n
+
+        def __iter__(self):
+            return iter(range(self.n))
+
+        def __contains__(self, x):
+            return x in range(self.n)
+
+    c = MyCollection(10)
+    assert isinstance(c, Collection)
+    assert isinstance(c, Sized)
+    assert isinstance(c, Iterable)
+    assert isinstance(c, Container)
+    assert isinstance(c, collections.abc.Collection)
+    assert isinstance(c, collections.abc.Sized)
+    assert isinstance(c, collections.abc.Iterable)
+    assert isinstance(c, collections.abc.Container)
+    assert len(c) == 10
+    assert list(c) == list(range(10))
+    assert 5 in c
+    assert 10 not in c
+
+
+def test_sequence():
+    class MySequence(Sequence):
+        __slots__ = ("n",)
+
+        def __init__(self, n):
+            self.n = n
+
+        def __len__(self):
+            return self.n
+
+        def __getitem__(self, index):
+            return list(range(self.n))[index]
+
+    s = MySequence(10)
+    assert isinstance(s, Sequence)
+    assert isinstance(s, Reversible)
+    assert isinstance(s, Collection)
+    assert isinstance(s, Sized)
+    assert isinstance(s, Iterable)
+    assert isinstance(s, Container)
+    assert isinstance(s, collections.abc.Sequence)
+    assert isinstance(s, collections.abc.Reversible)
+    assert isinstance(s, collections.abc.Collection)
+    assert isinstance(s, collections.abc.Sized)
+    assert isinstance(s, collections.abc.Iterable)
+    assert isinstance(s, collections.abc.Container)
+    assert len(s) == 10
+    assert list(s) == list(range(10))
+    assert 5 in s
+    assert 10 not in s
+    assert s[5] == 5
+    assert s[-1] == 9
+    assert s[1:5] == [1, 2, 3, 4]
+
+
+def test_mapping():
+    class MyMapping(Mapping):
+        __slots__ = ("wrapped",)
+
+        def __init__(self, **kwargs):
+            self.wrapped = dict(kwargs)
+
+        def __getitem__(self, key):
+            return self.wrapped[key]
+
+        def __len__(self):
+            return len(self.wrapped)
+
+        def __iter__(self):
+            return iter(self.wrapped)
+
+    m = MyMapping(a=1, b=2, c=3)
+    assert isinstance(m, Mapping)
+    assert isinstance(m, Collection)
+    assert isinstance(m, Sized)
+    assert isinstance(m, Iterable)
+    assert isinstance(m, Container)
+    assert isinstance(m, collections.abc.Mapping)
+    assert isinstance(m, collections.abc.Collection)
+    assert isinstance(m, collections.abc.Sized)
+    assert isinstance(m, collections.abc.Iterable)
+    assert isinstance(m, collections.abc.Container)
+    assert len(m) == 3
+    assert list(m) == ["a", "b", "c"]
+    assert "a" in m
+    assert "d" not in m
+    assert m["a"] == 1
+    assert m["b"] == 2
+    assert m["c"] == 3
+    assert m.get("a") == 1
+    assert m.get("d") is None
+    assert m.get("d", 4) == 4
+    assert m == m
+    assert m != MyMapping(a=1, b=2, c=3, d=4)
+    assert list(m.keys()) == ["a", "b", "c"]
+    assert list(m.values()) == [1, 2, 3]
+    assert list(m.items()) == [("a", 1), ("b", 2), ("c", 3)]
+    assert isinstance(m.keys(), collections.abc.KeysView)
+    assert isinstance(m.values(), collections.abc.ValuesView)
+    assert isinstance(m.items(), collections.abc.ItemsView)
+    assert m == dict(a=1, b=2, c=3)
+    assert m != dict(a=1, b=2, c=3, d=4)
+
+
 class MySchema(MapSet):
+    __slots__ = ("_fields",)
+
     def __init__(self, dct=None, **kwargs):
         self._fields = dict(dct or kwargs)
 
@@ -43,16 +263,20 @@ def test_myschema_identical():
 
 def test_mapset_mapping_api():
     ms = MySchema(a=1, b=2)
+
+    assert isinstance(ms, MapSet)
+    assert isinstance(ms, Mapping)
+    assert isinstance(ms, collections.abc.Mapping)
     assert ms["a"] == 1
     assert ms["b"] == 2
     assert len(ms) == 2
-    assert isinstance(iter(ms), Iterator)
+    assert isinstance(iter(ms), collections.abc.Iterator)
     assert list(ms) == ["a", "b"]
-    assert isinstance(ms.keys(), KeysView)
+    assert isinstance(ms.keys(), collections.abc.KeysView)
     assert list(ms.keys()) == ["a", "b"]
-    assert isinstance(ms.values(), ValuesView)
+    assert isinstance(ms.values(), collections.abc.ValuesView)
     assert list(ms.values()) == [1, 2]
-    assert isinstance(ms.items(), ItemsView)
+    assert isinstance(ms.items(), collections.abc.ItemsView)
     assert list(ms.items()) == [("a", 1), ("b", 2)]
     assert ms.get("a") == 1
     assert ms.get("c") is None
@@ -183,6 +407,10 @@ def test_frozendict():
     d = FrozenDict({"a": 1, "b": 2, "c": 3})
     e = FrozenDict(a=1, b=2, c=3)
     f = FrozenDict(a=1, b=2, c=3, d=4)
+
+    assert isinstance(d, Mapping)
+    assert isinstance(d, collections.abc.Mapping)
+
     assert d == e
     assert d != f
 

--- a/ibis/common/tests/test_graph.py
+++ b/ibis/common/tests/test_graph.py
@@ -19,6 +19,8 @@ from ibis.common.patterns import InstanceOf, TupleOf
 
 
 class MyNode(Node):
+    __slots__ = ("name", "children")
+
     def __init__(self, name, children):
         self.name = name
         self.children = children

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -4,7 +4,7 @@ import copy
 import pickle
 import sys
 import weakref
-from collections.abc import Mapping, Sequence
+from abc import ABCMeta
 from typing import Callable, Generic, Optional, TypeVar, Union
 
 import pytest
@@ -20,8 +20,11 @@ from ibis.common.annotations import (
     varargs,
     varkwargs,
 )
+from ibis.common.collections import Mapping, Sequence
 from ibis.common.grounds import (
+    Abstract,
     Annotable,
+    AnnotableMeta,
     Base,
     Comparable,
     Concrete,
@@ -220,6 +223,9 @@ class MyValue(Annotable, Generic[J, F]):
 def test_annotable():
     class Between(BetweenSimple):
         pass
+
+    assert not issubclass(type(Between), ABCMeta)
+    assert type(Between) is AnnotableMeta
 
     argnames = ("value", "lower", "upper")
     signature = BetweenSimple.__signature__
@@ -952,6 +958,7 @@ def test_concrete():
         Immutable,
         Comparable,
         Annotable,
+        Abstract,
         Base,
         object,
     )

--- a/ibis/common/tests/test_grounds_benchmarks.py
+++ b/ibis/common/tests/test_grounds_benchmarks.py
@@ -4,7 +4,7 @@ import pytest
 
 from ibis.common.annotations import attribute
 from ibis.common.collections import frozendict
-from ibis.common.grounds import Concrete
+from ibis.common.grounds import Annotable, Concrete
 
 pytestmark = pytest.mark.benchmark
 
@@ -30,3 +30,14 @@ class MyObject(Concrete):
 
 def test_concrete_construction(benchmark):
     benchmark(MyObject, 1, "2", c=(3, 4), d=frozendict(e=5, f=6))
+
+
+def test_concrete_isinstance(benchmark):
+    def check(obj):
+        for _ in range(100):
+            assert isinstance(obj, MyObject)
+            assert isinstance(obj, Concrete)
+            assert isinstance(obj, Annotable)
+
+    obj = MyObject(1, "2", c=(3, 4), d=frozendict(e=5, f=6))
+    benchmark(check, obj)

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -86,6 +86,8 @@ class Double(Pattern):
 
 
 class Min(Pattern):
+    __slots__ = ("min",)
+
     def __init__(self, min):
         self.min = min
 
@@ -340,9 +342,11 @@ def test_generic_coerced_to():
             ...
 
     class Literal(Value[T, Scalar]):
+        __slots__ = ("_value", "_dtype")
+
         def __init__(self, value, dtype):
-            self.value = value
-            self.dtype = dtype
+            self._value = value
+            self._dtype = dtype
 
         def dtype(self) -> T:
             return self.dtype
@@ -353,8 +357,8 @@ def test_generic_coerced_to():
         def __eq__(self, other):
             return (
                 type(self) == type(other)
-                and self.value == other.value
-                and self.dtype == other.dtype
+                and self._value == other._value
+                and self._dtype == other._dtype
             )
 
     p = Pattern.from_typehint(Literal[String])
@@ -1017,6 +1021,8 @@ def test_pattern_from_typehint_disable_coercion():
 
 
 class PlusOne(Coercible):
+    __slots__ = ("value",)
+
     def __init__(self, value):
         self.value = value
 
@@ -1132,6 +1138,7 @@ class Term(GraphNode):
 
 
 class Lit(Term):
+    __slots__ = ("value",)
     __argnames__ = ("value",)
     __match_args__ = ("value",)
 
@@ -1144,6 +1151,7 @@ class Lit(Term):
 
 
 class Binary(Term):
+    __slots__ = ("left", "right")
     __argnames__ = ("left", "right")
     __match_args__ = ("left", "right")
 

--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Generic, Optional
 
 from public import public
@@ -10,6 +10,7 @@ import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis import util
+from ibis.common.bases import Abstract
 from ibis.common.graph import Node as Traversable
 from ibis.common.grounds import Concrete
 from ibis.common.patterns import Coercible, CoercionError
@@ -38,8 +39,9 @@ class Node(Concrete, Traversable):
     __repr__ = object.__repr__
 
 
+# TODO(kszucs): remove this mixin
 @public
-class Named(ABC):
+class Named(Abstract):
     __slots__: VarTuple[str] = tuple()
 
     @property

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -13,6 +13,7 @@ import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
+from ibis.common.bases import Abstract
 from ibis.common.grounds import Singleton
 from ibis.common.patterns import InstanceOf  # noqa: TCH001
 from ibis.common.typing import VarTuple  # noqa: TCH001
@@ -328,7 +329,7 @@ class SearchedCase(Value):
         return rlz.highest_precedence_dtype(exprs)
 
 
-class _Negatable(abc.ABC):
+class _Negatable(Abstract):
     @abc.abstractmethod
     def negate(self):  # pragma: no cover
         ...


### PR DESCRIPTION
Almost all of the ibis objects have been extending `ABC` which hooks into the instance and subclass checks making the very common `isinstance()` calls more expensive. It had a significant impact based on occasional code profilings. 

I was thinking on how could we avoid the performance impact on instance checks while keep supporting the handy abstract methods and properties. Turns out that we can easily mitigate `ABC`'s overhead by setting the `__abstractmethods__` attribute for the created types and the python internals automatically raises the "Can't instantiate abstract class Foo with abstract methods bar, foo" error. This way we provide our own, less flexible abstract base classes using the python builtin isinstance checks.


On direct isinstance checks against base classes the improvement is significant:

```console
-------------------------------------------------------------------------------- benchmark 'test_concrete_isinstance': 2 tests ---------------------------------------------------------------------------------
Name (time in us)                               Min                Max               Mean            StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_concrete_isinstance (0292_b0b62cc)     21.5420 (2.21)     57.0000 (1.21)     22.2807 (2.24)     0.8539 (1.29)     22.5000 (2.28)     0.9160 (11.04)    1153;309       44.8818 (0.45)      20051           1
test_concrete_isinstance (NOW)               9.7500 (1.0)      47.2920 (1.0)       9.9492 (1.0)      0.6595 (1.0)       9.8750 (1.0)      0.0830 (1.0)     1050;8082      100.5107 (1.0)       69566           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

On average benchmarks show 10-30% performance gain: https://gist.github.com/kszucs/814e4336df010fa356012ef04b729c11

