### PR TITLE
ci(oracle): pin database version until flakiness can be fixed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -412,7 +412,7 @@ services:
       - druid
 
   oracle:
-    image: gvenzl/oracle-free:23
+    image: gvenzl/oracle-free:23.2-slim
     environment:
       ORACLE_PASSWORD: ibis
       ORACLE_DATABASE: IBIS_TESTING


### PR DESCRIPTION
Oracle 23.3 seems to have [some issues](https://github.com/ibis-project/ibis/actions/runs/6296921012/job/17092938287) with dropping existing tables related to timezone information. This PR pins our version to 23.2 to avoid flaky ci until we understand the issue.