### PR TITLE
feat(patterns): support building sequences in replacement patterns

### DIFF
--- a/ibis/common/patterns.py
+++ b/ibis/common/patterns.py
@@ -328,7 +328,7 @@ class Builder(Hashable):
         ...
 
     @abstractmethod
-    def make(self, context: dict):
+    def build(self, context: dict):
         """Construct a new object from the context.
 
         Parameters
@@ -341,36 +341,6 @@ class Builder(Hashable):
         -------
         The constructed object.
         """
-
-
-def builder(obj):
-    """Convert an object to a builder.
-
-    It encapsulates:
-        - callable objects into a `Factory` builder
-        - non-callable objects into a `Just` builder
-
-    Parameters
-    ----------
-    obj
-        The object to convert to a builder.
-
-    Returns
-    -------
-    The builder instance.
-    """
-    # TODO(kszucs): the replacer object must be handled differently from patterns
-    # basically a replacer is just a lazy way to construct objects from the context
-    # we should have a separate base class for replacers like Variable, Function,
-    # Just, Apply and Call. Something like Replacer with a specific method e.g.
-    # apply() could work
-    if isinstance(obj, Builder):
-        return obj
-    elif callable(obj):
-        # not function but something else
-        return Factory(obj)
-    else:
-        return Just(obj)
 
 
 class Variable(Slotted, Builder):
@@ -388,7 +358,7 @@ class Variable(Slotted, Builder):
     def __init__(self, name):
         super().__init__(name=name)
 
-    def make(self, context):
+    def build(self, context):
         return context[self]
 
     def __getattr__(self, name):
@@ -410,11 +380,17 @@ class Just(Slotted, Builder):
     __slots__ = ("value",)
     value: AnyType
 
+    @classmethod
+    def __create__(cls, value):
+        if isinstance(value, Just):
+            return value
+        return super().__create__(value)
+
     def __init__(self, value):
         assert not isinstance(value, (Pattern, Builder))
         super().__init__(value=value)
 
-    def make(self, context):
+    def build(self, context):
         return self.value
 
 
@@ -440,7 +416,7 @@ class Factory(Slotted, Builder):
         assert callable(func)
         super().__init__(func=func)
 
-    def make(self, context):
+    def build(self, context):
         value = context[_]
         return self.func(value, context)
 
@@ -471,9 +447,9 @@ class Call(Slotted, Builder):
         kwargs = frozendict({k: builder(v) for k, v in kwargs.items()})
         super().__init__(func=func, args=args, kwargs=kwargs)
 
-    def make(self, context):
-        args = tuple(arg.make(context) for arg in self.args)
-        kwargs = {k: v.make(context) for k, v in self.kwargs.items()}
+    def build(self, context):
+        args = tuple(arg.build(context) for arg in self.args)
+        kwargs = {k: v.build(context) for k, v in self.kwargs.items()}
         return self.func(*args, **kwargs)
 
     def __call__(self, *args, **kwargs):
@@ -500,7 +476,7 @@ class Call(Slotted, Builder):
         >>> pattern = c.Negate(x)
         >>> pattern
         Call(func=<class 'ibis.expr.operations.numeric.Negate'>, args=(Variable(name='x'),), kwargs=FrozenDict({}))
-        >>> pattern.make({x: 5})
+        >>> pattern.build({x: 5})
         <ibis.expr.operations.numeric.Negate object at 0x...>
         """
         return Namespace(cls, module)
@@ -597,7 +573,16 @@ class Replace(Slotted, Pattern):
         # use the `_` reserved variable to record the value being replaced
         # in the context, so that it can be used in the replacer pattern
         context[_] = value
-        return self.builder.make(context)
+        return self.builder.build(context)
+
+
+def replace(matcher):
+    """More convenient syntax for replacing a value with the output of a function."""
+
+    def decorator(replacer):
+        return Replace(matcher, replacer)
+
+    return decorator
 
 
 class Check(Slotted, Pattern):
@@ -1179,6 +1164,31 @@ class Length(Slotted, Pattern):
         return value
 
 
+class Between(Slotted, Pattern):
+    """Match a value between two bounds.
+
+    Parameters
+    ----------
+    lower
+        The lower bound.
+    upper
+        The upper bound.
+    """
+
+    __slots__ = ("lower", "upper")
+    lower: float
+    upper: float
+
+    def __init__(self, lower: float = -math.inf, upper: float = math.inf):
+        super().__init__(lower=lower, upper=upper)
+
+    def match(self, value, context):
+        if self.lower <= value <= self.upper:
+            return value
+        else:
+            return NoMatch
+
+
 class Contains(Slotted, Pattern):
     """Pattern that matches if a value contains a given value.
 
@@ -1251,7 +1261,8 @@ class SequenceOf(Slotted, Pattern):
     item: Pattern
     type: type
 
-    def __new__(
+    @classmethod
+    def __create__(
         cls,
         item,
         type: type = tuple,
@@ -1268,8 +1279,7 @@ class SequenceOf(Slotted, Pattern):
             return GenericSequenceOf(
                 item, type=type, exactly=exactly, at_least=at_least, at_most=at_most
             )
-        else:
-            return super().__new__(cls)
+        return super().__create__(item, type=type)
 
     def __init__(self, item, type=tuple):
         super().__init__(item=pattern(item), type=type)
@@ -1315,7 +1325,8 @@ class GenericSequenceOf(Slotted, Pattern):
     type: Pattern
     length: Length
 
-    def __new__(
+    @classmethod
+    def __create__(
         cls,
         item: Pattern,
         type: type = tuple,
@@ -1331,7 +1342,7 @@ class GenericSequenceOf(Slotted, Pattern):
         ):
             return SequenceOf(item, type=type)
         else:
-            return super().__new__(cls)
+            return super().__create__(item, type, exactly, at_least, at_most)
 
     def __init__(
         self,
@@ -1376,11 +1387,11 @@ class TupleOf(Slotted, Pattern):
     __slots__ = ("fields",)
     fields: tuple[Pattern, ...]
 
-    def __new__(cls, fields):
-        if isinstance(fields, tuple):
-            return super().__new__(cls)
-        else:
+    @classmethod
+    def __create__(cls, fields):
+        if not isinstance(fields, tuple):
             return SequenceOf(fields, tuple)
+        return super().__create__(fields)
 
     def __init__(self, fields):
         fields = tuple(map(pattern, fields))
@@ -1494,11 +1505,11 @@ class Object(Slotted, Pattern):
     args: tuple[Pattern, ...]
     kwargs: FrozenDict[str, Pattern]
 
-    def __new__(cls, type, *args, **kwargs):
+    @classmethod
+    def __create__(cls, type, *args, **kwargs):
         if not args and not kwargs:
             return InstanceOf(type)
-        else:
-            return super().__new__(cls)
+        return super().__create__(type, *args, **kwargs)
 
     def __init__(self, type, *args, **kwargs):
         type = pattern(type)
@@ -1708,29 +1719,47 @@ class PatternMapping(Slotted, Pattern):
         return dict(zip(keys, values))
 
 
-class Between(Slotted, Pattern):
-    """Match a value between two bounds.
+class Topmost(Slotted, Pattern):
+    """Traverse the value tree topmost first and match the first value that matches."""
 
-    Parameters
-    ----------
-    lower
-        The lower bound.
-    upper
-        The upper bound.
-    """
+    __slots__ = ("pattern", "filter")
+    pattern: Pattern
+    filter: AnyType
 
-    __slots__ = ("lower", "upper")
-    lower: float
-    upper: float
-
-    def __init__(self, lower: float = -math.inf, upper: float = math.inf):
-        super().__init__(lower=lower, upper=upper)
+    def __init__(self, searcher, filter=None):
+        super().__init__(pattern=pattern(searcher), filter=filter)
 
     def match(self, value, context):
-        if self.lower <= value <= self.upper:
-            return value
-        else:
-            return NoMatch
+        result = self.pattern.match(value, context)
+        if result is not NoMatch:
+            return result
+
+        for child in value.__children__(self.filter):
+            result = self.match(child, context)
+            if result is not NoMatch:
+                return result
+
+        return NoMatch
+
+
+class Innermost(Slotted, Pattern):
+    # matches items in the innermost layer first, but all matches belong to the same layer
+    """Traverse the value tree innermost first and match the first value that matches."""
+
+    __slots__ = ("pattern", "filter")
+    pattern: Pattern
+    filter: AnyType
+
+    def __init__(self, searcher, filter=None):
+        super().__init__(pattern=pattern(searcher), filter=filter)
+
+    def match(self, value, context):
+        for child in value.__children__(self.filter):
+            result = self.match(child, context)
+            if result is not NoMatch:
+                return result
+
+        return self.pattern.match(value, context)
 
 
 def NoneOf(*args) -> Pattern:
@@ -1751,6 +1780,39 @@ def DictOf(key_pattern, value_pattern):
 def FrozenDictOf(key_pattern, value_pattern):
     """Match a frozendict with keys and values matching the given patterns."""
     return MappingOf(key_pattern, value_pattern, type=frozendict)
+
+
+def builder(obj):
+    """Convert an object to a builder.
+
+    It encapsulates:
+        - callable objects into a `Factory` builder
+        - non-callable objects into a `Just` builder
+
+    Parameters
+    ----------
+    obj
+        The object to convert to a builder.
+
+    Returns
+    -------
+    The builder instance.
+    """
+    if isinstance(obj, Builder):
+        # already a builder, no need to convert
+        return obj
+    elif callable(obj):
+        # the callable builds the substitution
+        return Factory(obj)
+    elif isinstance(obj, Sequence):
+        # allow nesting builder patterns in tuples/lists
+        return Call(lambda *args: type(obj)(args), *obj)
+    elif isinstance(obj, Mapping):
+        # allow nesting builder patterns in dicts
+        return Call(type(obj), **obj)
+    else:
+        # the object is used as a constant value
+        return Just(obj)
 
 
 def pattern(obj: AnyType) -> Pattern:
@@ -1839,49 +1901,6 @@ def match(
     pat = pattern(pat)
     result = pat.match(value, context)
     return NoMatch if result is NoMatch else result
-
-
-class Topmost(Slotted, Pattern):
-    """Traverse the value tree topmost first and match the first value that matches."""
-
-    __slots__ = ("pattern", "filter")
-    pattern: Pattern
-    filter: AnyType
-
-    def __init__(self, searcher, filter=None):
-        super().__init__(pattern=pattern(searcher), filter=filter)
-
-    def match(self, value, context):
-        result = self.pattern.match(value, context)
-        if result is not NoMatch:
-            return result
-
-        for child in value.__children__(self.filter):
-            result = self.match(child, context)
-            if result is not NoMatch:
-                return result
-
-        return NoMatch
-
-
-class Innermost(Slotted, Pattern):
-    # matches items in the innermost layer first, but all matches belong to the same layer
-    """Traverse the value tree innermost first and match the first value that matches."""
-
-    __slots__ = ("pattern", "filter")
-    pattern: Pattern
-    filter: AnyType
-
-    def __init__(self, searcher, filter=None):
-        super().__init__(pattern=pattern(searcher), filter=filter)
-
-    def match(self, value, context):
-        for child in value.__children__(self.filter):
-            result = self.match(child, context)
-            if result is not NoMatch:
-                return result
-
-        return self.pattern.match(value, context)
 
 
 IsTruish = Check(lambda x: bool(x))

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -39,6 +39,7 @@ from ibis.common.patterns import (
     Contains,
     DictOf,
     EqualTo,
+    Factory,
     FrozenDictOf,
     Function,
     GenericInstanceOf,
@@ -69,8 +70,10 @@ from ibis.common.patterns import (
     TypeOf,
     Variable,
     _,
+    builder,
     match,
     pattern,
+    replace,
 )
 
 
@@ -121,8 +124,11 @@ def test_nothing():
 
 def test_just():
     p = Just(1)
-    assert p.make({}) == 1
-    assert p.make({"a": 1}) == 1
+    assert p.build({}) == 1
+    assert p.build({"a": 1}) == 1
+
+    # unwrap subsequently nested Just instances
+    assert Just(p) == p
 
 
 def test_min():
@@ -145,7 +151,7 @@ def test_any():
 def test_variable():
     p = Variable("other")
     context = {p: 10}
-    assert p.make(context) == 10
+    assert p.build(context) == 10
 
 
 def test_pattern_factory_wraps_variable_with_capture():
@@ -744,6 +750,15 @@ def test_replace_in_nested_object_pattern():
     assert h1.b.b == 3
 
 
+def test_replace_decorator():
+    @replace(int)
+    def sub(value, ctx):
+        return value - 1
+
+    assert match(sub, 1) == 0
+    assert match(sub, 2) == 1
+
+
 def test_matching_sequence_pattern():
     assert match([], []) == []
     assert match([], [1]) is NoMatch
@@ -1198,3 +1213,57 @@ def test_node():
     )
     result = six.replace(pat)
     assert result == Mul(two, Add(Lit(101), two))
+
+
+def test_factory():
+    f = Factory(lambda x, ctx: x + 1)
+    assert f.build({_: 1}) == 2
+    assert f.build({_: 2}) == 3
+
+    def fn(x, ctx):
+        assert ctx == {_: 10, "a": 5}
+        assert x == 10
+        return -1
+
+    f = Factory(fn)
+    assert f.build({_: 10, "a": 5}) == -1
+
+
+def test_call():
+    def fn(a, b, c=1):
+        return a + b + c
+
+    c = Call(fn, 1, 2, c=3)
+    assert c.build({}) == 6
+
+    c = Call(fn, Just(-1), Just(-2))
+    assert c.build({}) == -2
+
+    c = Call(dict, a=1, b=2)
+    assert c.build({}) == {"a": 1, "b": 2}
+
+
+def test_builder():
+    def fn(x, ctx):
+        return x + 1
+
+    assert builder(1) == Just(1)
+    assert builder(Just(1)) == Just(1)
+    assert builder(Just(Just(1))) == Just(1)
+    assert builder(fn) == Factory(fn)
+
+    b = builder((1, 2, 3))
+    assert b.args == (Just(1), Just(2), Just(3))
+    assert b.build({}) == (1, 2, 3)
+
+    b = builder([1, 2, 3])
+    assert b.args == (Just(1), Just(2), Just(3))
+    assert b.build({}) == [1, 2, 3]
+
+    b = builder({"a": 1, "b": 2})
+    assert b.kwargs == {"a": Just(1), "b": Just(2)}
+    assert b.build({}) == {"a": 1, "b": 2}
+
+    b = builder(FrozenDict({"a": 1, "b": 2, "c": 3}))
+    assert b.kwargs == {"a": Just(1), "b": Just(2), "c": Just(3)}
+    assert b.build({}) == FrozenDict({"a": 1, "b": 2, "c": 3})


### PR DESCRIPTION
Support sequences in the right hand side of replacements:
```py
from ibis.common.patterns import Replace, Variable

a = Variable("a")
r = Replace(searcher, (1, 2, a))
```

Added a new decorator based syntax for defining replacement rules:

```py
from ibis.common.patterns import replace

@replace(searcher)
def substitute(value, context):
    # build replacement value
```

Miscellaneous changes:
 - renamed `Builder.make()` method to `Builder.build()`
 - use `Base.__create__()` instead of `__new__()`