### PR TITLE
fix(oracle): ensure that metadata queries use SQL and not sqlplus-specific syntax

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -169,7 +169,6 @@ _LIMIT = {
 
 
 @pytest.mark.notimpl(["datafusion", "polars", "mssql"])
-@pytest.mark.notimpl(["oracle"], raises=sa.exc.DatabaseError)
 @pytest.mark.never(["dask", "pandas"], reason="dask and pandas do not support SQL")
 def test_sql(backend, con):
     # execute the expression using SQL query

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -295,9 +295,9 @@ def test_con_dot_sql_transpile(backend, con, dialect, df):
 
 
 @dot_sql_notimpl
-@dot_sql_notyet
 @dot_sql_never
 @pytest.mark.notimpl(["druid", "flink", "impala", "polars", "pyspark"])
+@pytest.mark.notyet(["snowflake"], reason="snowflake column names are case insensitive")
 def test_order_by_no_projection(backend):
     con = backend.connection
     astronauts = con.table("astronauts")


### PR DESCRIPTION
Fixes #7164.
Closes #7165.