### PR TITLE
fix(patterns): support passing mappings to Getitem builder

### DIFF
--- a/ibis/common/patterns.py
+++ b/ibis/common/patterns.py
@@ -421,7 +421,8 @@ class Getattr(Slotted, Builder):
     __slots__ = ("instance", "name")
 
     def __init__(self, instance, name):
-        super().__init__(instance=builder(instance), name=name)
+        instance = instance if isinstance(instance, Builder) else Just(instance)
+        super().__init__(instance=instance, name=name)
 
     def build(self, context):
         instance = self.instance.build(context)
@@ -432,7 +433,8 @@ class Getitem(Slotted, Builder):
     __slots__ = ("instance", "name")
 
     def __init__(self, instance, name):
-        super().__init__(instance=builder(instance), name=name)
+        instance = instance if isinstance(instance, Builder) else Just(instance)
+        super().__init__(instance=instance, name=name)
 
     def build(self, context):
         instance = self.instance.build(context)

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -1265,15 +1265,29 @@ def test_call():
 
 
 def test_getattr():
+    class MyType:
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+        def __hash__(self):
+            return hash((type(self), self.a, self.b))
+
     v = Variable("v")
     b = Getattr(v, "b")
-    assert b.build({v: Foo(1, 2)}) == 2
+    assert b.build({v: MyType(1, 2)}) == 2
+
+    b = Getattr(MyType(1, 2), "a")
+    assert b.build({}) == 1
 
 
 def test_getitem():
     v = Variable("v")
     b = Getitem(v, 1)
     assert b.build({v: [1, 2, 3]}) == 2
+
+    b = Getitem(FrozenDict(a=1, b=2), "a")
+    assert b.build({}) == 1
 
 
 def test_builder():


### PR DESCRIPTION
Currently both patterns and builders must be hashable, so the mapping passed must be a FrozenDict. 
We can possibly lift the hashable requirement in the future.