### PR TITLE
fix(api): ensure the order of duplicate non-renamed columns in `relocate` is preserved

### DIFF
--- a/ibis/tests/expr/test_relocate.py
+++ b/ibis/tests/expr/test_relocate.py
@@ -19,6 +19,12 @@ def test_move_blocks():
     assert t.relocate(s.of_type("string"), after=s.numeric()).columns == list("xyab")
 
 
+def test_duplicates_not_renamed():
+    t = ibis.table(dict(x="int", y="int"))
+    assert t.relocate("y", s.numeric()).columns == list("yx")
+    assert t.relocate("y", s.numeric(), "y").columns == list("yx")
+
+
 def test_keep_non_contiguous_variables():
     t = ibis.table(dict.fromkeys("abcde", "int"))
     assert t.relocate("b", after=s.c("a", "c", "e")).columns == list("acdeb")


### PR DESCRIPTION
Fixes #7225.

```
In [10]: from ibis.interactive import *

In [11]: t = ibis.examples.penguins.fetch()

In [12]: t.relocate("year", s.numeric()).columns
Out[12]:
['year',
 'bill_length_mm',
 'bill_depth_mm',
 'flipper_length_mm',
 'body_mass_g',
 'species',
 'island',
 'sex']

In [13]: t.relocate(s.numeric(), "year").columns
Out[13]:
['bill_length_mm',
 'bill_depth_mm',
 'flipper_length_mm',
 'body_mass_g',
 'year',
 'species',
 'island',
 'sex']
```