### PR TITLE
feat(api): improve repr for deferred expressions containing Column/Scalar values

### DIFF
--- a/ibis/expr/tests/test_deferred.py
+++ b/ibis/expr/tests/test_deferred.py
@@ -219,3 +219,18 @@ def test_deferrable(table):
 
     with pytest.raises(TypeError, match="unknown"):
         f(_.a, _.b, unknown=3)  # invalid calls caught at call time
+
+
+@pytest.mark.parametrize(
+    "f, sol",
+    [
+        (lambda t: _.x + t.a, "(_.x + <column[int64]>)"),
+        (lambda t: _.x + t.a.sum(), "(_.x + <scalar[int64]>)"),
+        (lambda t: ibis.date(_.x, 2, t.a), "date(_.x, 2, <column[int64]>)"),
+    ],
+)
+def test_repr_deferred_with_exprs(f, sol):
+    t = ibis.table({"a": "int64"})
+    expr = f(t)
+    res = repr(expr)
+    assert res == sol


### PR DESCRIPTION
This makes `Column`/`Scalar` values found in a deferred expression repr as `<column[type]>`/`<scalar[type]>`. Previously they'd repr using their standard repr, which would lead to weird displays (especially in interactive mode).

Example:

```python
In [1]: import ibis

In [2]: from ibis import _

In [3]: t = ibis.table({"x": "int"})

In [4]: ibis.date(_.h, _.m, t.x.sum())
Out[4]: date(_.h, _.m, <scalar[int64]>)
```