### PR TITLE
fix(patterns): fix pattern mismatch error for default `Pattern`

### DIFF
--- a/ibis/common/patterns.py
+++ b/ibis/common/patterns.py
@@ -236,7 +236,7 @@ class Pattern(Hashable):
         return self.match(value, context) is not NoMatch
 
     def describe(self, plural=False):
-        return "matching {self!r}"
+        return f"matching {self!r}"
 
     @abstractmethod
     def __eq__(self, other: Pattern) -> bool:

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -150,6 +150,7 @@ def test_any():
     p = Any()
     assert p.match(1, context={}) == 1
     assert p.match("foo", context={}) == "foo"
+    assert p.describe() == "matching Any()"
 
 
 def test_variable():


### PR DESCRIPTION
Fixes a missing `f` for an f-string.