### PR TITLE
refactor: delete unexposed `ibis.api.category_label` function

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1834,7 +1834,6 @@ def where(cond, true_expr, false_expr) -> ir.Value:
 coalesce = _deferred(ir.Value.coalesce)
 greatest = _deferred(ir.Value.greatest)
 least = _deferred(ir.Value.least)
-category_label = _deferred(ir.IntegerColumn.label)
 
 aggregate = ir.Table.aggregate
 cross_join = ir.Table.cross_join


### PR DESCRIPTION
This method wasn't exposed in the `ibis` namespace (nor documented), so there's no need to deprecate it IMO.