### PR TITLE
feat(api): support deferred arguments in `ibis.case()`

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -945,16 +945,40 @@ def case() -> bl.SearchedCaseBuilder:
     """Begin constructing a case expression.
 
     Use the `.when` method on the resulting object followed by `.end` to create a
-    complete case.
+    complete case expression.
 
     Examples
     --------
     >>> import ibis
-    >>> cond1 = ibis.literal(1) == 1
-    >>> cond2 = ibis.literal(2) == 1
-    >>> expr = ibis.case().when(cond1, 3).when(cond2, 4).end()
-    >>> expr
-    SearchedCase(...)
+    >>> from ibis import _
+    >>> ibis.options.interactive = True
+    >>> t = ibis.memtable(
+    ...     {
+    ...         "left": [1, 2, 3, 4],
+    ...         "symbol": ["+", "-", "*", "/"],
+    ...         "right": [5, 6, 7, 8],
+    ...     }
+    ... )
+    >>> t.mutate(
+    ...     result=(
+    ...         ibis.case()
+    ...         .when(_.symbol == "+", _.left + _.right)
+    ...         .when(_.symbol == "-", _.left - _.right)
+    ...         .when(_.symbol == "*", _.left * _.right)
+    ...         .when(_.symbol == "/", _.left / _.right)
+    ...         .end()
+    ...     )
+    ... )
+    ┏━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━━┓
+    ┃ left  ┃ symbol ┃ right ┃ result  ┃
+    ┡━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━━┩
+    │ int64 │ string │ int64 │ float64 │
+    ├───────┼────────┼───────┼─────────┤
+    │     1 │ +      │     5 │     6.0 │
+    │     2 │ -      │     6 │    -4.0 │
+    │     3 │ *      │     7 │    21.0 │
+    │     4 │ /      │     8 │     0.5 │
+    └───────┴────────┴───────┴─────────┘
 
     Returns
     -------


### PR DESCRIPTION
- Adds support for case expressions in `ibis.case()` statements. Support is _not_ added for `Column.case()` statements, since it's not clear what the `_` would refer to there or when it would resolve.
- Improves docstrings and type annotations for case builders. In particular these APIs now pass `mypy`.
- Refactors the `CaseBuilder` implementations. The code shared between implementations was small, and since `SimpleCaseBuilder` doesn't support deferreds while `SearchedCaseBuilder` does it felt cleaner to me to fully split the implementations.