### PR TITLE
refactor(api): remove interpolation argument

### DIFF
--- a/ibis/backends/dask/tests/execution/test_functions.py
+++ b/ibis/backends/dask/tests/execution/test_functions.py
@@ -13,7 +13,6 @@ from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import OperationNotDefinedError
 
 dd = pytest.importorskip("dask.dataframe")
@@ -179,7 +178,6 @@ def test_quantile_list(t, df, ibis_func, dask_func, column):
     ],
 )
 def test_quantile_scalar(t, df, ibis_func, dask_func):
-    # TODO - interpolation
     result = ibis_func(t.float64_with_zeros).compile()
     expected = dask_func(df.float64_with_zeros)
     assert result.compute() == expected.compute()
@@ -196,8 +194,6 @@ def test_quantile_scalar(t, df, ibis_func, dask_func):
         (lambda x: x.clip(), ValueError),
         # out of range on quantile
         (lambda x: x.quantile(5.0), ValueError),
-        # invalid interpolation arg
-        (lambda x: x.quantile(0.5, interpolation="foo"), ValidationError),
     ],
 )
 def test_arraylike_functions_transform_errors(t, df, ibis_func, exc):

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -825,20 +825,19 @@ def test_round(t, df):
     reason="MultiQuantile is not implemented for the dask backend",
 )
 def test_quantile_group_by(batting, batting_df):
-    def q_fun(x, quantile, interpolation):
-        res = x.quantile(quantile, interpolation=interpolation).tolist()
+    def q_fun(x, quantile):
+        res = x.quantile(quantile).tolist()
         return [res for _ in range(len(x))]
 
     frac = 0.2
-    intp = "linear"
     result = (
         batting.group_by("teamID")
-        .mutate(res=lambda x: x.RBI.quantile([frac, 1 - frac], intp))
+        .mutate(res=lambda x: x.RBI.quantile([frac, 1 - frac]))
         .res.compile()
     )
     expected = (
         batting_df.groupby("teamID")
-        .RBI.transform(q_fun, quantile=[frac, 1 - frac], interpolation=intp)
+        .RBI.transform(q_fun, quantile=[frac, 1 - frac])
         .rename("res")
     )
     tm.assert_series_equal(result.compute(), expected.compute(), check_index=False)

--- a/ibis/backends/pandas/tests/execution/test_functions.py
+++ b/ibis/backends/pandas/tests/execution/test_functions.py
@@ -16,7 +16,6 @@ import ibis.expr.datatypes as dt
 from ibis.backends.pandas.execution import execute
 from ibis.backends.pandas.tests.conftest import TestConf as tm
 from ibis.backends.pandas.udf import udf
-from ibis.common.annotations import ValidationError
 
 
 @pytest.mark.parametrize(
@@ -130,10 +129,7 @@ def test_round_decimal_with_negative_places(t):
     [
         (lambda x: x.quantile(0), lambda x: x.quantile(0)),
         (lambda x: x.quantile(1), lambda x: x.quantile(1)),
-        (
-            lambda x: x.quantile(0.5, interpolation="linear"),
-            lambda x: x.quantile(0.5, interpolation="linear"),
-        ),
+        (lambda x: x.quantile(0.5), lambda x: x.quantile(0.5)),
     ],
 )
 def test_quantile(t, df, ibis_func, pandas_func):
@@ -172,8 +168,6 @@ def test_quantile_multi(t, df, ibis_func, pandas_func, column):
         (lambda x: x.clip(), ValueError),
         # out of range on quantile
         (lambda x: x.quantile(5.0), ValueError),
-        # invalid interpolation arg
-        (lambda x: x.quantile(0.5, interpolation="foo"), ValidationError),
     ],
 )
 def test_arraylike_functions_transform_errors(t, ibis_func, exc):

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -624,20 +624,19 @@ def test_round(t, df):
 
 
 def test_quantile_groupby(batting, batting_df):
-    def q_fun(x, quantile, interpolation):
-        res = x.quantile(quantile, interpolation=interpolation).tolist()
+    def q_fun(x, quantile):
+        res = x.quantile(quantile).tolist()
         return [res for _ in range(len(x))]
 
     frac = 0.2
-    intp = "linear"
     result = (
         batting.group_by("teamID")
-        .mutate(res=lambda x: x.RBI.quantile([frac, 1 - frac], intp))
+        .mutate(res=lambda x: x.RBI.quantile([frac, 1 - frac]))
         .res.execute()
     )
     expected = (
         batting_df.groupby("teamID")
-        .RBI.transform(q_fun, quantile=[frac, 1 - frac], interpolation=intp)
+        .RBI.transform(q_fun, quantile=[frac, 1 - frac])
         .rename("res")
     )
     tm.assert_series_equal(result, expected)

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -7,7 +7,6 @@ import operator
 import platform
 import re
 import string
-import warnings
 
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql as pg
@@ -430,11 +429,6 @@ def _mode(t, op):
 
 
 def _quantile(t, op):
-    if op.interpolation is not None:
-        warnings.warn(
-            f"`{t.__module__.rsplit(',', 1)[0]}` backend does not support the "
-            "`interpolation` argument"
-        )
     arg = op.arg
     if (where := op.where) is not None:
         arg = ops.IfElse(where, arg, None)

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -186,9 +186,6 @@ class Median(Filterable, Reduction):
 class Quantile(Filterable, Reduction):
     arg: Value
     quantile: Value[dt.Numeric]
-    interpolation: Optional[
-        Literal["linear", "lower", "higher", "midpoint", "nearest"]
-    ] = None
 
     dtype = dt.float64
 
@@ -197,9 +194,6 @@ class Quantile(Filterable, Reduction):
 class MultiQuantile(Filterable, Reduction):
     arg: Value
     quantile: Value[dt.Array[dt.Float64]]
-    interpolation: Optional[
-        Literal["linear", "lower", "higher", "midpoint", "nearest"]
-    ] = None
 
     dtype = dt.Array(dt.float64)
 

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -781,14 +781,6 @@ class NumericColumn(Column, NumericValue):
     def quantile(
         self,
         quantile: Sequence[NumericValue | float],
-        interpolation: Literal[
-            "linear",
-            "lower",
-            "higher",
-            "midpoint",
-            "nearest",
-        ]
-        | None = None,
         where: ir.BooleanValue | None = None,
     ) -> NumericScalar:
         """Return value at the given quantile.
@@ -797,20 +789,6 @@ class NumericColumn(Column, NumericValue):
         ----------
         quantile
             `0 <= quantile <= 1`, the quantile(s) to compute
-        interpolation
-            ::: {.callout-warning}
-            ## This parameter is backend dependent and may have no effect
-            :::
-
-            This parameter specifies the interpolation method to use, when the
-            desired quantile lies between two data points `i` and `j`:
-
-            * linear: `i + (j - i) * fraction`, where `fraction` is the
-              fractional part of the index surrounded by `i` and `j`.
-            * lower: `i`.
-            * higher: `j`.
-            * nearest: `i` or `j` whichever is nearest.
-            * midpoint: (`i` + `j`) / 2.
         where
             Boolean filter for input values
 
@@ -823,7 +801,7 @@ class NumericColumn(Column, NumericValue):
             op = ops.MultiQuantile
         else:
             op = ops.Quantile
-        return op(self, quantile, interpolation, where=where).to_expr()
+        return op(self, quantile, where=where).to_expr()
 
     def std(
         self,


### PR DESCRIPTION
BREAKING CHANGE: the `interpolation` argument was only supported in the dask and pandas backends; for interpolated quantiles use dask or pandas directly
