### PR TITLE
test: fix pandas import test case

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -22,7 +22,6 @@ import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common.caching import RefCountedCache
-from ibis.formats.pandas import PandasData
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, MutableMapping
@@ -266,6 +265,8 @@ class _FileIOHandler:
         Iterator[pd.DataFrame]
             An iterator of pandas `DataFrame`s.
         """
+        from ibis.formats.pandas import PandasData
+
         orig_expr = expr
         expr = expr.as_table()
         schema = expr.schema()

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -64,10 +64,11 @@ def test_multiple_backends(mocker):
 
 
 def test_no_import_pandas():
-    script = """\
+    script = """
 import ibis
 import sys
 
-assert "pandas" not in sys.modules"""
+assert "pandas" not in sys.modules
+"""
 
-    subprocess.check_call([sys.executable], text=script)
+    subprocess.run([sys.executable, "-c", script], check=True)

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -63,12 +63,12 @@ def test_multiple_backends(mocker):
         ibis.foo  # noqa: B018
 
 
-def test_no_import_pandas():
-    script = """
+@pytest.mark.parametrize("module", ["pandas", "pyarrow"])
+def test_no_import(module):
+    script = f"""
 import ibis
 import sys
 
-assert "pandas" not in sys.modules
+assert "{module}" not in sys.modules
 """
-
     subprocess.run([sys.executable, "-c", script], check=True)

--- a/justfile
+++ b/justfile
@@ -129,7 +129,7 @@ view-changelog flags="":
         | ([ "{{ flags }}" = "--pretty" ] && glow -p - || cat -)
 
 # run the decouple script to check for prohibited inter-module dependencies
-decouple *args:
+decouple +args:
     python ci/check_disallowed_imports.py {{ args }}
 
 # profile something


### PR DESCRIPTION
With `pytest -s` this test case opens a python terminal for me. Apparently the original test case was wrong too since it wasn't running the given `script`

```
❯ pytest -s ibis/tests/test_api.py::test_no_import_pandas
================================================================================================================= test session starts ==================================================================================================================
platform darwin -- Python 3.11.4, pytest-7.4.0, pluggy-1.3.0
Using --randomly-seed=1649009272
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/kszucs/Workspace/ibis
configfile: pyproject.toml
plugins: snapshot-0.9.0, hypothesis-6.82.6, httpserver-1.0.8, randomly-3.15.0, cov-4.1.0, clarity-1.0.1, mock-3.11.1, anyio-3.7.1, profiling-1.7.0, xdist-3.3.1, repeat-0.9.1, benchmark-4.0.0
collected 1 item

ibis/tests/test_api.py Python 3.11.4 | packaged by conda-forge | (main, Jun 10 2023, 18:08:41) [Clang 15.0.7 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>>
```