### PR TITLE
chore(deps): remove `packaging` requirement for the duckdb backend

### DIFF
--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import duckdb_engine
 import pytest
 import sqlalchemy as sa
-import sqlglot as sg
 from packaging.version import parse as vparse
 from pytest import param
 
@@ -63,11 +62,6 @@ def test_parser(typ, expected):
 
 
 @pytest.mark.parametrize("uint_type", ["uint8", "uint16", "uint32", "uint64"])
-@pytest.mark.xfail(
-    vparse(sg.__version__) < vparse("11.3.4"),
-    raises=sg.ParseError,
-    reason="sqlglot version doesn't support duckdb unsigned integer types",
-)
 def test_cast_uints(uint_type, snapshot):
     import ibis
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -5921,7 +5921,7 @@ datafusion = ["datafusion"]
 decompiler = ["black"]
 deltalake = ["deltalake"]
 druid = ["pydruid", "sqlalchemy"]
-duckdb = ["duckdb", "duckdb-engine", "packaging", "sqlalchemy", "sqlalchemy-views"]
+duckdb = ["duckdb", "duckdb-engine", "sqlalchemy", "sqlalchemy-views"]
 flink = []
 geospatial = ["GeoAlchemy2", "geopandas", "shapely"]
 impala = ["fsspec", "impyla", "requests", "sqlalchemy"]
@@ -5940,4 +5940,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "59096eef883d4a14e45ada357c46efea88931925b75f5d04564581a6bc0b42f0"
+content-hash = "9711e7c4b107306be01969b748cd676a4085c34c7b72423a304796ba3053b98d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,13 +186,7 @@ clickhouse = ["clickhouse-connect", "sqlalchemy"]
 dask = ["dask", "regex"]
 datafusion = ["datafusion"]
 druid = ["pydruid", "sqlalchemy"]
-duckdb = [
-  "duckdb",
-  "duckdb-engine",
-  "packaging",
-  "sqlalchemy",
-  "sqlalchemy-views",
-]
+duckdb = ["duckdb", "duckdb-engine", "sqlalchemy", "sqlalchemy-views"]
 flink = []
 geospatial = ["GeoAlchemy2", "geopandas", "shapely"]
 impala = ["fsspec", "impyla", "requests", "sqlalchemy"]


### PR DESCRIPTION
Removes unnecessary version checking from the duckdb backend due to increasing the lower bound to 0.8.1 in previous PR.