### PR TITLE
docs: add some prose and move operation support matrix

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -110,8 +110,8 @@ website:
       style: "docked"
       collapse-level: 2
       contents:
-        - support_matrix.qmd
         - auto: backends/*.qmd
+        - support_matrix.qmd
     - id: how-to
       title: "How-to"
       style: "docked"

--- a/docs/support_matrix.qmd
+++ b/docs/support_matrix.qmd
@@ -5,6 +5,10 @@ hide:
 
 # Operation support matrix
 
+We provide Ibis's operation support matrix as a [Streamlit](https://streamlit.io/) app that shows supported operations for each backend. Ibis defines a common API for analytics and data transformation code that is transpiled to native code for each backend. This code is often, but not always, SQL -- see the [backends concept page](/concepts/backend.qmd) for details. Due to differences in SQL dialects and support for different operations in different backends, support for the full breadth of the Ibis API varies.
+
+You can use this page to see which operations are supported on each backend.
+
 ::: {.callout-tip}
 Backends with low coverage are good places to start contributing!
 


### PR DESCRIPTION
closes #7257

adds some prose explaining the page and why backends aren't all at 100%
