### PR TITLE
feat: support deferred arguments in `ibis.array`/`ibis.map`/`ibis.struct`

### DIFF
--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -316,6 +316,8 @@ class SearchedCase(Value):
 
     def __init__(self, cases, results, default):
         assert len(cases) == len(results)
+        if default.dtype.is_null():
+            default = Cast(default, rlz.highest_precedence_dtype(results))
         super().__init__(cases=cases, results=results, default=default)
 
     @attribute

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -7,6 +7,7 @@ from public import public
 import ibis.expr.operations as ops
 from ibis.expr.types.generic import Column, Scalar, Value, literal
 from ibis.expr.types.typing import V
+from ibis.expr.deferred import deferrable
 
 if TYPE_CHECKING:
     import ibis.expr.datatypes as dt
@@ -913,6 +914,7 @@ class ArrayColumn(Column, ArrayValue):
 
 
 @public
+@deferrable
 def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayValue:
     """Create an array expression.
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -541,7 +541,7 @@ class Value(Expr):
             if table := an.find_first_base_table(self.op()):
                 return bind(table)
             else:
-                return de.deferred_apply(bind, _)
+                return de.DeferredCall(bind, (_,))
         else:
             return ops.WindowFunction(self, window).to_expr()
 

--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -7,6 +7,7 @@ from public import public
 import ibis.expr.operations as ops
 from ibis.expr.types.arrays import ArrayColumn
 from ibis.expr.types.generic import Column, Scalar, Value
+from ibis.expr.deferred import deferrable
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir
@@ -425,6 +426,7 @@ class MapColumn(Column, MapValue):
 
 
 @public
+@deferrable
 def map(
     keys: Iterable[Any] | Mapping[Any, Any] | ArrayColumn,
     values: Iterable[Any] | ArrayColumn | None = None,

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -9,6 +9,7 @@ from public import public
 import ibis.expr.operations as ops
 from ibis.expr.types.generic import Column, Scalar, Value, literal
 from ibis.expr.types.typing import V
+from ibis.expr.deferred import deferrable
 
 if TYPE_CHECKING:
     import ibis.expr.datatypes as dt
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 
 
 @public
+@deferrable
 def struct(
     value: Iterable[tuple[str, V]] | Mapping[str, V],
     type: str | dt.DataType | None = None,

--- a/ibis/tests/expr/test_case.py
+++ b/ibis/tests/expr/test_case.py
@@ -155,8 +155,11 @@ def test_simple_case_null_else(table):
 
 def test_multiple_case_null_else(table):
     expr = ibis.case().when(table.g == "foo", "bar").end()
-    op = expr.op()
+    expr2 = ibis.case().when(table.g == "foo", _).end().resolve("bar")
 
+    assert expr.equals(expr2)
+
+    op = expr.op()
     assert isinstance(expr, ir.StringColumn)
     assert isinstance(op.default.to_expr(), ir.Value)
     assert isinstance(op.default, ops.Cast)

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1590,6 +1590,10 @@ def test_deferred_function_call(func, expected_type):
         param(
             lambda: (ibis.map({"x": 1, "y": _}), ibis.map({"x": 1, "y": 2})), id="map"
         ),
+        param(
+            lambda: (ibis.struct({"x": 1, "y": _}), ibis.struct({"x": 1, "y": 2})),
+            id="struct",
+        ),
     ],
 )
 def test_deferred_nested_types(case):

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1584,7 +1584,13 @@ def test_deferred_function_call(func, expected_type):
 
 
 @pytest.mark.parametrize(
-    "case", [param(lambda: (ibis.array([1, _]), ibis.array([1, 2])), id="array")]
+    "case",
+    [
+        param(lambda: (ibis.array([1, _]), ibis.array([1, 2])), id="array"),
+        param(
+            lambda: (ibis.map({"x": 1, "y": _}), ibis.map({"x": 1, "y": 2})), id="map"
+        ),
+    ],
 )
 def test_deferred_nested_types(case):
     expr, sol = case()

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1583,6 +1583,14 @@ def test_deferred_function_call(func, expected_type):
     assert expr["col"].type() == expected_type
 
 
+@pytest.mark.parametrize(
+    "case", [param(lambda: (ibis.array([1, _]), ibis.array([1, 2])), id="array")]
+)
+def test_deferred_nested_types(case):
+    expr, sol = case()
+    assert expr.resolve(2).equals(sol)
+
+
 def test_numpy_ufuncs_dont_cast_columns():
     t = ibis.table(dict.fromkeys("abcd", "int"))
 


### PR DESCRIPTION
- Adds support for passing deferred arguments to `ibis.array`/`ibis.map`/`ibis.struct`
- Adds support for traversing builtin collections (`list`, `tuple`, `dict`, `set`) when detecting `Deferrred` arguments to `deferrable` functions
- Refactors the deferred case implementation to use `deferrable` instead of a custom `Deferred` subclass