### PR TITLE
docs(reference): improve signatures

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -200,7 +200,7 @@ quartodoc:
             - name: Table
               package: ibis.expr.types.relations
             - name: GroupedTable
-              package: ibis.expr.types.relations
+              package: ibis.expr.types.groupby
             - name: read_csv
               dynamic: true
             - name: read_delta

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -185,7 +185,7 @@ quartodoc:
   render_interlinks: true
   renderer: _renderer.py
   options:
-    signature_name: full
+    signature_name: short
   sections:
     - title: Expression API
       desc: "APIs for manipulating table, column and scalar expressions"
@@ -202,34 +202,49 @@ quartodoc:
               package: ibis.expr.types.groupby
             - name: read_csv
               dynamic: true
+              signature_name: full
             - name: read_delta
               dynamic: true
+              signature_name: full
             - name: read_json
               dynamic: true
+              signature_name: full
             - name: read_parquet
               dynamic: true
+              signature_name: full
             - name: memtable
               dynamic: true
+              signature_name: full
             - name: table
               dynamic: true
+              signature_name: full
             - name: difference
               dynamic: true
+              signature_name: full
             - name: intersect
               dynamic: true
+              signature_name: full
             - name: union
               dynamic: true
+              signature_name: full
             - name: row_number
               dynamic: true
+              signature_name: full
             - name: window
               dynamic: true
+              signature_name: full
             - name: cumulative_window
               dynamic: true
+              signature_name: full
             - name: range_window
               dynamic: true
+              signature_name: full
             - name: trailing_range_window
               dynamic: true
+              signature_name: full
             - name: trailing_window
               dynamic: true
+              signature_name: full
 
         - kind: page
           path: expression-generic
@@ -245,31 +260,44 @@ quartodoc:
               package: ibis.expr.types.generic
             - name: literal
               dynamic: true
+              signature_name: full
             - name: param
               dynamic: true
+              signature_name: full
             - name: NA
               # Ideally exposed under `ibis` but that doesn't seem to work??
               package: ibis.expr.api
+              signature_name: full
             - name: "null"
               dynamic: true
+              signature_name: full
             - name: coalesce
               dynamic: true
+              signature_name: full
             - name: least
               dynamic: true
+              signature_name: full
             - name: greatest
               dynamic: true
+              signature_name: full
             - name: asc
               dynamic: true
+              signature_name: full
             - name: desc
               dynamic: true
+              signature_name: full
             - name: ifelse
               dynamic: true
+              signature_name: full
             - name: case
               dynamic: true
+              signature_name: full
             - name: show_sql
               dynamic: true
+              signature_name: full
             - name: to_sql
               dynamic: true
+              signature_name: full
 
         - kind: page
           path: expression-numeric
@@ -293,10 +321,13 @@ quartodoc:
               package: ibis.expr.types.logical
             - name: and_
               dynamic: true
+              signature_name: full
             - name: or_
               dynamic: true
+              signature_name: full
             - name: random
               dynamic: true
+              signature_name: full
 
         - kind: page
           path: expression-strings
@@ -322,18 +353,23 @@ quartodoc:
             - name: now
               package: ibis
               dynamic: true
+              signature_name: full
             - name: date
               package: ibis
               dynamic: true
+              signature_name: full
             - name: time
               package: ibis
               dynamic: true
+              signature_name: full
             - name: timestamp
               package: ibis
               dynamic: true
+              signature_name: full
             - name: interval
               package: ibis
               dynamic: true
+              signature_name: full
 
         - kind: page
           path: expression-collections
@@ -350,10 +386,13 @@ quartodoc:
               package: ibis.expr.types.structs
             - name: array
               dynamic: true
+              signature_name: full
             - name: map
               dynamic: true
+              signature_name: full
             - name: struct
               dynamic: true
+              signature_name: full
 
         - kind: page
           path: expression-geospatial
@@ -403,6 +442,7 @@ quartodoc:
             - name: dtype
               package: ibis
               dynamic: true
+              signature_name: full
             - Array
             - Binary
             - Boolean
@@ -445,6 +485,7 @@ quartodoc:
           contents:
             - name: schema
               dynamic: true
+              signature_name: full
             - name: Schema
               package: ibis.expr.schema
 
@@ -458,10 +499,13 @@ quartodoc:
           contents:
             - name: connect
               dynamic: true
+              signature_name: full
             - name: get_backend
               dynamic: true
+              signature_name: full
             - name: set_backend
               dynamic: true
+              signature_name: full
 
     - title: UDFs
       desc: "User-defined function APIs"

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -190,83 +190,68 @@ quartodoc:
   sections:
     - title: Expression API
       desc: "APIs for manipulating table, column and scalar expressions"
-      package: ibis.expr.types
       contents:
         - kind: page
           path: expression-tables
-          package: ibis.expr.types.relations
           summary:
             name: Table expressions
             desc: Tables are one of the core data structures in Ibis.
           contents:
-            - Table
-            - GroupedTable
+            - name: Table
+              package: ibis.expr.types.relations
+            - name: GroupedTable
+              package: ibis.expr.types.relations
             - name: read_csv
-              package: ibis
               dynamic: true
             - name: read_delta
-              package: ibis
               dynamic: true
             - name: read_json
-              package: ibis
               dynamic: true
             - name: read_parquet
-              package: ibis
               dynamic: true
             - name: memtable
-              package: ibis
               dynamic: true
             - name: table
-              package: ibis
               dynamic: true
             - name: difference
-              package: ibis
               dynamic: true
             - name: intersect
-              package: ibis
               dynamic: true
             - name: union
-              package: ibis
               dynamic: true
             - name: row_number
-              package: ibis
               dynamic: true
             - name: window
-              package: ibis
               dynamic: true
             - name: cumulative_window
-              package: ibis
               dynamic: true
             - name: range_window
-              package: ibis
               dynamic: true
             - name: trailing_range_window
-              package: ibis
               dynamic: true
             - name: trailing_window
-              package: ibis
               dynamic: true
 
         - kind: page
           path: expression-generic
-          package: ibis.expr.types.generic
           summary:
             name: Generic expressions
             desc: Scalars and columns of any element type.
           contents:
-            - Value
-            - Column
-            - Scalar
+            - name: Value
+              package: ibis.expr.types.generic
+            - name: Column
+              package: ibis.expr.types.generic
+            - name: Scalar
+              package: ibis.expr.types.generic
             - name: literal
               package: ibis.expr.api
               dynamic: true
             - name: param
-              package: ibis
               dynamic: true
             - name: NA
               package: ibis.expr.api
             - name: "null"
-              package: ibis
               dynamic: true
             - name: coalesce
               package: ibis.expr.api
@@ -275,21 +260,16 @@ quartodoc:
             - name: greatest
               package: ibis.expr.api
             - name: asc
-              package: ibis
               dynamic: true
             - name: desc
-              package: ibis
               dynamic: true
             - name: ifelse
               package: ibis.expr.api
             - name: case
-              package: ibis
               dynamic: true
             - name: show_sql
-              package: ibis
               dynamic: true
             - name: to_sql
-              package: ibis
               dynamic: true
 
         - kind: page
@@ -314,13 +294,10 @@ quartodoc:
               package: ibis.expr.types.logical
             - name: and_
               dynamic: true
-              package: ibis
             - name: or_
               dynamic: true
-              package: ibis
             - name: random
               dynamic: true
-              package: ibis
 
         - kind: page
           path: expression-strings
@@ -416,7 +393,6 @@ quartodoc:
 
     - title: Type System
       desc: "Data types and schemas"
-      package: ibis
       contents:
         - kind: page
           path: datatypes
@@ -464,20 +440,18 @@ quartodoc:
             - UUID
         - kind: page
           path: schemas
-          package: ibis.expr.schema
           summary:
             name: Schemas
             desc: Table Schemas
           contents:
             - name: schema
-              package: ibis
               dynamic: true
-            - Schema
+            - name: Schema
+              package: ibis.expr.schema
 
     - title: Connection APIs
       contents:
         - kind: page
-          package: ibis
           path: connection
           summary:
             name: Top-level connection APIs
@@ -496,7 +470,6 @@ quartodoc:
       contents:
         - kind: page
           path: scalar-udfs
-          package: ibis.expr.operations.udf
           summary:
             name: Scalar UDFs
             desc: "Scalar user-defined function APIs"

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -185,8 +185,7 @@ quartodoc:
   render_interlinks: true
   renderer: _renderer.py
   options:
-    member_options:
-      signature_name: short
+    signature_name: full
   sections:
     - title: Expression API
       desc: "APIs for manipulating table, column and scalar expressions"

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -245,26 +245,26 @@ quartodoc:
             - name: Scalar
               package: ibis.expr.types.generic
             - name: literal
-              package: ibis.expr.api
               dynamic: true
             - name: param
               dynamic: true
             - name: NA
+              # Ideally exposed under `ibis` but that doesn't seem to work??
               package: ibis.expr.api
             - name: "null"
               dynamic: true
             - name: coalesce
-              package: ibis.expr.api
+              dynamic: true
             - name: least
-              package: ibis.expr.api
+              dynamic: true
             - name: greatest
-              package: ibis.expr.api
+              dynamic: true
             - name: asc
               dynamic: true
             - name: desc
               dynamic: true
             - name: ifelse
-              package: ibis.expr.api
+              dynamic: true
             - name: case
               dynamic: true
             - name: show_sql
@@ -458,7 +458,7 @@ quartodoc:
             desc: Create and manage backend connections.
           contents:
             - name: connect
-              package: ibis.backends.base
+              dynamic: true
             - name: get_backend
               dynamic: true
             - name: set_backend


### PR DESCRIPTION
Followup to https://github.com/ibis-project/ibis/pull/7159

Make the signatures appear show the full path,
eg `random()` is now `ibis.random()`.

Also fix some of the paths where possible,
eg now it is `ibis.connect()` instead of `backends.base.connect()`

@machow, note how quartodoc was silently ignoring the previously-incorrectly-configured `signature_name` option. It would have been nice if the build had failed here, instead of us thinking that we
had configured something.

See the difference in `ibis.connect()`:
<img width="557" alt="image" src="https://github.com/ibis-project/ibis/assets/10820686/82e06bc8-582d-4b42-acec-8827fae95009">

and note how in the sidebar you just see "random", not "ibis.random"
<img width="955" alt="image" src="https://github.com/ibis-project/ibis/assets/10820686/c5f178d9-c9c6-46b0-a1e3-0499a7406a0e">
