### PR TITLE
chore(codecov): skip processing bigquery and snowflake codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,9 @@ codecov:
 comment: false
 
 ignore:
-  - "docs/**"
+  - "docs/**/*"
+  - "ibis/backends/bigquery/**/*"
+  - "ibis/backends/snowflake/**/*"
 
 coverage:
   status:


### PR DESCRIPTION
I _think_ this will stop flagging "code not covered" annotations on all
bigquery and snowflake diffs -- those warnings just take up space
because the test suite isn't running those tests on PRs.