### PR TITLE
fix: datafusion: do_connect: properly handle config-is-actually-context

### DIFF
--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -60,7 +60,7 @@ class Backend(BaseBackend, CanCreateDatabase, CanCreateSchema):
         >>> ibis.datafusion.connect(config)
         """
         if isinstance(config, SessionContext):
-            self._context = config
+            (self._context, config) = (config, None)
         else:
             if SessionConfig is not None:
                 df_config = SessionConfig().with_information_schema(True)

--- a/ibis/backends/datafusion/tests/test_connect.py
+++ b/ibis/backends/datafusion/tests/test_connect.py
@@ -24,10 +24,7 @@ def test_none_config():
 
 
 def test_str_config(name_to_path):
-    config = {
-        name: str(path)
-        for name, path in name_to_path.items()
-    }
+    config = {name: str(path) for name, path in name_to_path.items()}
     conn = ibis.datafusion.connect(config)
     assert sorted(conn.list_tables()) == sorted(name_to_path)
 
@@ -40,7 +37,7 @@ def test_path_config(name_to_path):
 
 def test_context_config(name_to_path):
     ctx = SessionContext()
-    for (name, path) in name_to_path.items():
+    for name, path in name_to_path.items():
         ctx.register_parquet(name, str(path))
     conn = ibis.datafusion.connect(ctx)
     assert sorted(conn.list_tables()) == sorted(name_to_path)

--- a/ibis/backends/datafusion/tests/test_connect.py
+++ b/ibis/backends/datafusion/tests/test_connect.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+from datafusion import (
+    SessionContext,
+)
+
+import ibis
+from ibis.backends.conftest import TEST_TABLES
+
+
+@pytest.fixture
+def name_to_path(data_dir):
+    return {
+        table_name: data_dir / "parquet" / f"{table_name}.parquet"
+        for table_name in TEST_TABLES
+    }
+
+
+def test_none_config():
+    config = None
+    conn = ibis.datafusion.connect(config)
+    assert conn.list_tables() == []
+
+
+def test_str_config(name_to_path):
+    config = {
+        name: str(path)
+        for name, path in name_to_path.items()
+    }
+    conn = ibis.datafusion.connect(config)
+    assert sorted(conn.list_tables()) == sorted(name_to_path)
+
+
+def test_path_config(name_to_path):
+    config = name_to_path
+    conn = ibis.datafusion.connect(config)
+    assert sorted(conn.list_tables()) == sorted(name_to_path)
+
+
+def test_context_config(name_to_path):
+    ctx = SessionContext()
+    for (name, path) in name_to_path.items():
+        ctx.register_parquet(name, str(path))
+    conn = ibis.datafusion.connect(ctx)
+    assert sorted(conn.list_tables()) == sorted(name_to_path)


### PR DESCRIPTION
when `config` is an instance of `SessionContext`, it shouldn't subsequently be used as a config