### PR TITLE
docs: add deprecation to .nullifzero docstring

### DIFF
--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -8,10 +8,10 @@ from public import public
 
 import ibis
 import ibis.expr.operations as ops
+from ibis import util
 from ibis.common.exceptions import IbisTypeError
 from ibis.expr.types.core import _binop
 from ibis.expr.types.generic import Column, Scalar, Value
-from ibis import util
 
 if TYPE_CHECKING:
     import ibis.expr.types as ir
@@ -483,12 +483,12 @@ class NumericValue(Value):
 
     @util.deprecated(instead="use nullif(0)", as_of="7.0", removed_in="8.0")
     def nullifzero(self) -> NumericValue:
-        """Return `NULL` if an expression is zero."""
+        """DEPRECATED: Use `nullif(0)` instead."""
         return self.nullif(0)
 
     @util.deprecated(instead="use fillna(0)", as_of="7.0", removed_in="8.0")
     def zeroifnull(self) -> NumericValue:
-        """Return zero if an expression is `NULL`."""
+        """DEPRECATED: Use `fillna(0)` instead."""
         return self.fillna(0)
 
     def acos(self) -> NumericValue:


### PR DESCRIPTION
Although users got a deprecationWarning
whenever they used these in code,
in the docs there is no
indication they are deprecated.

Not sure, possibly we could do some hack where we add this
function to the class after the class block, and then
it wouldn't even show up in the documentation?
but probably if a user sees the deprecation warning, they might
want to look up that method on the docs for more info,
so it might be nice if there were something there...