### PR TITLE
test(perf): run all tpch queries in a single process to avoid high memory usage and multiple data loads

### DIFF
--- a/ibis/backends/tests/tpch/conftest.py
+++ b/ibis/backends/tests/tpch/conftest.py
@@ -27,6 +27,7 @@ def tpch_test(test: Callable[..., ir.Table]):
 
     @pytest.mark.tpch
     @pytest.mark.usefixtures("backend", "snapshot")
+    @pytest.mark.xdist_group("tpch")
     @functools.wraps(test)
     def wrapper(*args, backend, snapshot, **kwargs):
         backend_name = backend.name()


### PR DESCRIPTION
Decrease TPC-H test duration by avoiding parallelism. This prevents loading data multiple times in the case of duckdb (which seems to be the proximate cause of a large slowdown for these tests), and also prevents high memory usage for Trino.