### PR TITLE
feat(ux): render url strings as links in rich table output

### DIFF
--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 from functools import singledispatch
 from math import isfinite
+from urllib.parse import urlparse
 
 import rich
 from rich.align import Align
@@ -138,6 +139,12 @@ def _(dtype, values):
                 v = "".join(
                     f"[dim]{repr(c)[1:-1]}[/]" if not c.isprintable() else c for c in v
                 )
+            elif len(v) <= max_string:
+                url = urlparse(v)
+                # check both scheme and netloc to avoid rendering e.g.,
+                # `https://` as link
+                if url.scheme and url.netloc:
+                    v = f"[link]{v}[/link]"
             text = Text.from_markup(v, style="green")
         else:
             text = Text.styled("~", "dim")

--- a/ibis/tests/expr/test_pretty_repr.py
+++ b/ibis/tests/expr/test_pretty_repr.py
@@ -9,7 +9,7 @@ from rich.console import Console
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.expr.types.pretty import format_column
+from ibis.expr.types.pretty import format_column, format_values
 
 null = "NULL"
 
@@ -178,3 +178,12 @@ def test_non_interactive_column_repr():
 
     result = capture.get()
     assert "Selection" not in result
+
+
+def test_format_link():
+    result = format_values(dt.string, ["https://ibis-project.org"])
+    assert result[0].spans[0].style == "link"
+
+    # not links
+    result = format_values(dt.string, ["https://", "https:", "https"])
+    assert all(not rendered.spans for rendered in result)


### PR DESCRIPTION
Render strings that have at least a scheme and netloc as clickable links in the terminal. This PR does not avoid rendering strings as links if they are truncated. Closes #7292.