### PR TITLE
feat(ux): fix long links, add repr links in vscode

### DIFF
--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -126,6 +126,7 @@ def _(dtype, values):
     for v in values:
         v = str(v)
         if v:
+            raw_v = v
             if len(v) > max_string:
                 v = v[: max_string - 1] + "…"
             v = v[:max_string]
@@ -139,12 +140,11 @@ def _(dtype, values):
                 v = "".join(
                     f"[dim]{repr(c)[1:-1]}[/]" if not c.isprintable() else c for c in v
                 )
-            elif len(v) <= max_string:
-                url = urlparse(v)
-                # check both scheme and netloc to avoid rendering e.g.,
-                # `https://` as link
-                if url.scheme and url.netloc:
-                    v = f"[link]{v}[/link]"
+            url = urlparse(raw_v)
+            # check both scheme and netloc to avoid rendering e.g.,
+            # `https://` as link
+            if url.scheme and url.netloc:
+                v = f"[link={raw_v}]{v}[/link]"
             text = Text.from_markup(v, style="green")
         else:
             text = Text.styled("~", "dim")

--- a/ibis/tests/expr/test_pretty_repr.py
+++ b/ibis/tests/expr/test_pretty_repr.py
@@ -181,9 +181,18 @@ def test_non_interactive_column_repr():
 
 
 def test_format_link():
-    result = format_values(dt.string, ["https://ibis-project.org"])
-    assert result[0].spans[0].style == "link"
+    result = format_values(dt.string, ["https://ibis-project.org"])[0]
+    assert str(result) == "https://ibis-project.org"
+    assert result.spans[0].style == "link https://ibis-project.org"
+
+    # Check that long urls are truncated visually, but the link
+    # itself is still the full url.
+    long = "https://" + "x" * 1000
+    result = format_values(dt.string, [long])[0]
+    assert str(result).startswith("https://xxxxx")
+    assert len(str(result)) < 1000
+    assert result.spans[0].style == "link " + long
 
     # not links
-    result = format_values(dt.string, ["https://", "https:", "https"])
-    assert all(not rendered.spans for rendered in result)
+    results = format_values(dt.string, ["https://", "https:", "https"])
+    assert all(not rendered.spans for rendered in results)


### PR DESCRIPTION
Followup to https://github.com/ibis-project/ibis/pull/7304

Before, long links would take you to the truncated version, eg https://www.super.long.url.that.is.trucated.com
would both display and link to
https://www.super.long.url.tha...

Now it just renders as that, but links to the full url.

This also makes links render in vscode notebook environment. Before, links were rendering correctly in ipython console. But, they weren't
showing up as links in vscode notebook environment either. This commit adds vscode functionality.