### PR TITLE
docs(mysql): render_do_connect mssql to mysql

### DIFF
--- a/docs/backends/mysql.qmd
+++ b/docs/backends/mysql.qmd
@@ -91,7 +91,7 @@ con = ibis.mysql.connect(
 #| output: asis
 from _utils import render_do_connect
 
-render_do_connect("mssql")
+render_do_connect("mysql")
 ```
 
 ### `ibis.connect` URL format


### PR DESCRIPTION
Hi :)

In looking through documentation I found a small typo where connection params under the mysql backend page were showing the mssql params instead.

Hope this PR fixes that