### PR TITLE
refactor(common): remove `ibis.common.bases.Base` in favor of `Abstract`

### DIFF
--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -20,8 +20,6 @@ from ibis.common.annotations import (
 from ibis.common.bases import (  # noqa: F401
     Abstract,
     AbstractMeta,
-    Base,
-    BaseMeta,
     Comparable,
     Final,
     Immutable,

--- a/ibis/common/tests/test_bases.py
+++ b/ibis/common/tests/test_bases.py
@@ -9,8 +9,6 @@ import pytest
 from ibis.common.bases import (
     Abstract,
     AbstractMeta,
-    Base,
-    BaseMeta,
     Comparable,
     Final,
     Immutable,
@@ -19,12 +17,11 @@ from ibis.common.bases import (
 from ibis.common.caching import WeakCache
 
 
-def test_bases_are_based_on_base():
-    assert issubclass(Comparable, Base)
-    assert issubclass(Final, Base)
-    assert issubclass(Immutable, Base)
-    assert issubclass(Singleton, Base)
-    assert issubclass(Abstract, Base)
+def test_classes_are_based_on_abstract():
+    assert issubclass(Comparable, Abstract)
+    assert issubclass(Final, Abstract)
+    assert issubclass(Immutable, Abstract)
+    assert issubclass(Singleton, Abstract)
 
 
 def test_abstract():
@@ -40,7 +37,6 @@ def test_abstract():
 
     assert not issubclass(type(Foo), ABCMeta)
     assert issubclass(type(Foo), AbstractMeta)
-    assert issubclass(type(Foo), BaseMeta)
     assert Foo.__abstractmethods__ == frozenset({"foo", "bar"})
 
     with pytest.raises(TypeError, match="Can't instantiate abstract class .*Foo.*"):
@@ -59,7 +55,6 @@ def test_abstract():
     assert bar.bar == 2
     assert isinstance(bar, Foo)
     assert isinstance(bar, Abstract)
-    assert isinstance(bar, Base)
     assert Bar.__abstractmethods__ == frozenset()
 
 

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -25,7 +25,6 @@ from ibis.common.grounds import (
     Abstract,
     Annotable,
     AnnotableMeta,
-    Base,
     Comparable,
     Concrete,
     Immutable,
@@ -959,7 +958,6 @@ def test_concrete():
         Comparable,
         Annotable,
         Abstract,
-        Base,
         object,
     )
 


### PR DESCRIPTION
Separating the two is not worth it since `Base` is used in conjunction with `Abstract` in the rest of the codebase, e.g. `Annotable`. After this PR all of the base classes support abstract methods out of the box.

Performance-wise it only affects the class construction so it should have no "runtime" overhead. Just in case I ran the benchmark for constructing `Concrete` instances:

```
------------------------------------------------------------------------------- benchmark 'test_concrete_construction': 2 tests -------------------------------------------------------------------------------
Name (time in us)                                Min                Max              Mean            StdDev            Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_concrete_construction (0355_8502e81)     7.4169 (1.00)     48.0000 (1.20)     7.7361 (1.01)     1.2277 (1.95)     7.6659 (1.01)     0.0830 (1.0)        32;244      129.2646 (0.99)       4722           1
test_concrete_construction (NOW)              7.4159 (1.0)      39.9171 (1.0)      7.6425 (1.0)      0.6297 (1.0)      7.6250 (1.0)      0.0831 (1.00)       51;458      130.8475 (1.0)       12801           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------- benchmark 'test_concrete_isinstance': 2 tests -------------------------------------------------------------------------------
Name (time in us)                              Min                Max              Mean            StdDev            Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_concrete_isinstance (0355_8502e81)     9.7499 (1.01)     57.8329 (1.11)     9.9609 (1.01)     1.2566 (1.83)     9.8750 (1.01)     0.0001 (1.0)     375;33285      100.3926 (0.99)      71008           1
test_concrete_isinstance (NOW)              9.6670 (1.0)      52.2500 (1.0)      9.8250 (1.0)      0.6882 (1.0)      9.7919 (1.0)      0.0010 (9.00)     89;18170      101.7808 (1.0)       39604           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
