### PR TITLE
refactor(ir): remove `ibis.expr.streaming`

### DIFF
--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from pyflink.table import TableEnvironment
     from pyflink.table.table_result import TableResult
 
-    from ibis.expr.streaming import Watermark
+    from ibis.api import Watermark
 
 
 class Backend(BaseBackend, CanCreateDatabase):

--- a/ibis/backends/flink/ddl.py
+++ b/ibis/backends/flink/ddl.py
@@ -18,7 +18,7 @@ from ibis.backends.base.sql.ddl import (
 from ibis.backends.base.sql.registry import quote_identifier, type_to_sql_string
 
 if TYPE_CHECKING:
-    from ibis.expr.streaming import Watermark
+    from ibis.api import Watermark
 
 
 def format_schema(schema):

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -17,12 +17,12 @@ from ibis import selectors, util
 from ibis.backends.base import BaseBackend, connect
 from ibis.common.dispatch import lazy_singledispatch
 from ibis.common.exceptions import IbisInputError
+from ibis.common.grounds import Concrete
 from ibis.common.temporal import normalize_datetime, normalize_timezone
 from ibis.expr.decompile import decompile
 from ibis.expr.deferred import Deferred, deferrable
 from ibis.expr.schema import Schema
 from ibis.expr.sql import parse_sql, show_sql, to_sql
-from ibis.expr.streaming import Watermark
 from ibis.expr.types import (
     DateValue,
     Expr,
@@ -1743,6 +1743,11 @@ def difference(table: ir.Table, *rest: ir.Table, distinct: bool = True) -> ir.Ta
     └───────┘
     """
     return table.difference(*rest, distinct=distinct) if rest else table
+
+
+class Watermark(Concrete):
+    time_col: str
+    allowed_delay: ir.IntervalScalar
 
 
 def watermark(time_col: str, allowed_delay: ir.IntervalScalar) -> Watermark:

--- a/ibis/expr/streaming.py
+++ b/ibis/expr/streaming.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-import ibis.expr.types as ir  # noqa: TCH001
-from ibis.common.grounds import Concrete
-
-
-class Watermark(Concrete):
-    time_col: str
-    allowed_delay: ir.IntervalScalar


### PR DESCRIPTION
We shouldn't introduce a new module for a single object just yet. If there will be more streaming related construct we can factor them out to a separate module. 

