### PR TITLE
feat(ux/duckdb): implement recursive collection type conversion for `.execute()`

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -331,6 +331,11 @@ _temporal_delta = fixed_arity(
 )
 
 
+def _to_json_collection(t, op):
+    typ = t.get_sqla_type(op.dtype)
+    return try_cast(t.translate(op.arg), typ, type_=typ)
+
+
 operation_registry.update(
     {
         ops.ArrayColumn: (
@@ -477,6 +482,8 @@ operation_registry.update(
         ops.TimeDelta: _temporal_delta,
         ops.DateDelta: _temporal_delta,
         ops.TimestampDelta: _temporal_delta,
+        ops.ToJSONMap: _to_json_collection,
+        ops.ToJSONArray: _to_json_collection,
     }
 )
 
@@ -486,9 +493,6 @@ _invalid_operations = {
     ops.NTile,
     # ibis.expr.operations.strings
     ops.Translate,
-    # ibis.expr.operations.json
-    ops.ToJSONMap,
-    ops.ToJSONArray,
 }
 
 operation_registry = {

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -4,6 +4,9 @@ from ibis.formats.pandas import PandasData
 
 
 class SnowflakePandasData(PandasData):
-    convert_Struct = staticmethod(PandasData.convert_JSON)
-    convert_Array = staticmethod(PandasData.convert_JSON)
-    convert_Map = staticmethod(PandasData.convert_JSON)
+    @staticmethod
+    def convert_JSON(s, dtype, pandas_type):
+        converter = SnowflakePandasData.convert_JSON_element(dtype)
+        return s.map(converter, na_action="ignore").astype("object")
+
+    convert_Struct = convert_Array = convert_Map = convert_JSON

--- a/ibis/backends/tests/test_json.py
+++ b/ibis/backends/tests/test_json.py
@@ -9,8 +9,6 @@ import pytest
 from packaging.version import parse as vparse
 from pytest import param
 
-from ibis.common.exceptions import OperationNotDefinedError
-
 pytestmark = [
     pytest.mark.never(["impala"], reason="doesn't support JSON and never will"),
     pytest.mark.notyet(["clickhouse"], reason="upstream is broken"),
@@ -50,7 +48,6 @@ def test_json_getitem(json_t, expr_fn, expected):
 @pytest.mark.notyet(
     ["pyspark", "trino"], reason="should work but doesn't deserialize JSON"
 )
-@pytest.mark.notimpl(["duckdb"], raises=OperationNotDefinedError)
 def test_json_map(json_t):
     expr = json_t.js.map.name("res")
     result = expr.execute()
@@ -75,7 +72,6 @@ def test_json_map(json_t):
     ["pyspark", "trino"], reason="should work but doesn't deserialize JSON"
 )
 @pytest.mark.notyet(["bigquery"], reason="doesn't allow null in arrays")
-@pytest.mark.notimpl(["duckdb"], raises=OperationNotDefinedError)
 def test_json_array(json_t):
     expr = json_t.js.array.name("res")
     result = expr.execute()

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -223,7 +223,6 @@ def test_scalar_param_date(backend, alltypes, value):
         "oracle",
         "pyspark",
         "mssql",
-        "trino",
         "druid",
     ]
 )


### PR DESCRIPTION
This PR implements recursive element conversion for arrays, structs, maps and json datatypes, for the pandas execution path. `ToJSONArray` and `ToJSONMap` are also implemented here for DuckDB.