### PR TITLE
fix(datatypes): correct unsigned integer bounds

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -653,7 +653,7 @@ class UnsignedInteger(Integer):
 
     @property
     def bounds(self):
-        exp = self.nbytes * 8 - 1
+        exp = self.nbytes * 8
         upper = 1 << exp
         return Bounds(lower=0, upper=upper)
 

--- a/ibis/expr/datatypes/tests/test_cast.py
+++ b/ibis/expr/datatypes/tests/test_cast.py
@@ -21,7 +21,6 @@ import ibis.expr.datatypes as dt
         (dt.uint32, dt.Decimal(12, 2)),
         (dt.uint32, dt.float32),
         (dt.uint32, dt.float64),
-        (dt.uint64, dt.int64),
         (dt.Interval("s"), dt.Interval("s")),
     ],
 )
@@ -37,6 +36,7 @@ def test_implicitly_castable_primitives(source, target):
         (dt.int32, dt.uint16),
         (dt.uint64, dt.int16),
         (dt.uint64, dt.uint16),
+        (dt.uint64, dt.int64),
         (dt.Decimal(12, 2), dt.int32),
         (dt.timestamp, dt.boolean),
         (dt.Interval("s"), dt.Interval("ns")),

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -75,6 +75,23 @@ def test_dtype_from_classes(klass, expected):
     assert dt.dtype(klass) == expected
 
 
+@pytest.mark.parametrize(
+    ("uklass", "klass"),
+    [
+        (dt.UInt64, dt.Int64),
+        (dt.UInt32, dt.Int32),
+        (dt.UInt16, dt.Int16),
+        (dt.UInt8, dt.Int8),
+    ],
+)
+def test_signed_unsigned_bounds(uklass, klass):
+    unsigned = dt.dtype(uklass)
+    signed = dt.dtype(klass)
+    assert unsigned.bounds.upper > signed.bounds.upper
+    assert unsigned.bounds.lower == 0
+    assert signed.bounds.lower < 0
+
+
 class FooStruct:
     a: dt.int16
     b: dt.int32


### PR DESCRIPTION
they were off by an order of magnitude.

added a silly test but it should catch any regressions that arise in future refactors.