### PR TITLE
fix: support self joins on memtables

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -814,6 +814,21 @@ def test_agg_memory_table(con):
     assert result == 3
 
 
+@pytest.mark.broken(
+    ["polars"], reason="join column renaming is currently incorrect on polars"
+)
+@pytest.mark.notimpl(["datafusion"])
+def test_self_join_memory_table(backend, con):
+    t = ibis.memtable({"x": [1, 2], "y": [2, 1], "z": ["a", "b"]})
+    t_view = t.view()
+    expr = t.join(t_view, t.x == t_view.y).select("x", "y", "z", "z_right")
+    result = con.execute(expr).sort_values("x").reset_index(drop=True)
+    expected = pd.DataFrame(
+        {"x": [1, 2], "y": [2, 1], "z": ["a", "b"], "z_right": ["b", "a"]}
+    )
+    backend.assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "t",
     [

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -49,7 +49,7 @@ def _rewrite_string_contains(op):
 
 
 class TrinoTableSetFormatter(_AlchemyTableSetFormatter):
-    def _format_in_memory_table(self, op, ref_op, translator):
+    def _format_in_memory_table(self, op, translator):
         if not op.data:
             return sa.select(
                 *(
@@ -64,10 +64,10 @@ class TrinoTableSetFormatter(_AlchemyTableSetFormatter):
                 translator.translate(ops.Literal(col, dtype=type_)).label(name)
                 for col, (name, type_) in zip(row, op_schema)
             )
-            for row in ref_op.data.to_frame().itertuples(index=False)
+            for row in op.data.to_frame().itertuples(index=False)
         ]
-        columns = translator._schema_to_sqlalchemy_columns(ref_op.schema)
-        return sa.values(*columns, name=ref_op.name).data(rows)
+        columns = translator._schema_to_sqlalchemy_columns(op.schema)
+        return sa.values(*columns, name=op.name).data(rows)
 
 
 class TrinoSQLCompiler(AlchemyCompiler):


### PR DESCRIPTION
I found this bug while refactoring a bit of this code to support `TABLESAMPLE` clauses. In short - the use of `ref_op` and `op` made it confusing which op to use, resulting in broken code for handling self joins on memtables. I renamed the variables to make it clear which `op` was the original operation and which was the `op` being compiled.