### PR TITLE
feat(oracle): add support for loading Oracle RAW and BLOB types

### DIFF
--- a/ibis/backends/oracle/datatypes.py
+++ b/ibis/backends/oracle/datatypes.py
@@ -15,6 +15,8 @@ class OracleType(AlchemyType):
     def to_ibis(cls, typ, nullable=True):
         if isinstance(typ, oracle.ROWID):
             return dt.String(nullable=nullable)
+        elif isinstance(typ, (oracle.RAW, sat.BLOB)):
+            return dt.Binary(nullable=nullable)
         elif isinstance(typ, sat.Float):
             return dt.Float64(nullable=nullable)
         elif isinstance(typ, sat.Numeric):

--- a/ibis/backends/oracle/tests/test_datatypes.py
+++ b/ibis/backends/oracle/tests/test_datatypes.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import ibis
+
+
+def test_failed_column_inference(con):
+    # This is a table in the Docker container that we know fails
+    # column type inference, so if is loaded, then we're in OK shape.
+    table = con.table("ALL_DOMAINS", schema="SYS")
+    assert len(table.columns)
+
+
+def test_blob_raw(con):
+    con.drop_table("blob_raw_blobs_blob_raw", force=True)
+
+    with con.begin() as bind:
+        bind.exec_driver_sql(
+            """CREATE TABLE "blob_raw_blobs_blob_raw" ("blob" BLOB, "raw" RAW(255))"""
+        )
+
+    raw_blob = con.table("blob_raw_blobs_blob_raw")
+
+    assert raw_blob.schema() == ibis.Schema(dict(blob="binary", raw="binary"))


### PR DESCRIPTION
Need to add a test for the `RAW` and `BLOB` loading and I don't like the fix for the column inference fallback