### PR TITLE
refactor(ir): remove `ops.Negatable`, `ops.NotAny`, `ops.NotAll`, `ops.UnresolvedNotExistsSubquery`

### DIFF
--- a/gen_matrix.py
+++ b/gen_matrix.py
@@ -29,7 +29,6 @@ def main():
     internal_ops = {
         # Never translates into anything
         ops.UnresolvedExistsSubquery,
-        ops.UnresolvedNotExistsSubquery,
         ops.ScalarParameter,
     }
 

--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -316,7 +316,10 @@ class AlchemySelect(Select):
         if not self.where:
             return fragment
 
-        args = [self._translate(pred, permit_subquery=True) for pred in self.where]
+        args = [
+            self._translate(pred, permit_subquery=True, within_where=True)
+            for pred in self.where
+        ]
         clause = functools.reduce(sql.and_, args)
         return fragment.where(clause)
 

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -158,9 +158,6 @@ def _exists_subquery(t, op):
     sub_ctx = ctx.subcontext()
     clause = ctx.compiler.to_sql(filtered, sub_ctx, exists=True)
 
-    if isinstance(op, ops.NotExistsSubquery):
-        clause = sa.not_(clause)
-
     return clause
 
 
@@ -563,7 +560,6 @@ sqlalchemy_operation_registry: dict[Any, Any] = {
     ops.TableColumn: _table_column,
     ops.TableArrayView: _table_array_view,
     ops.ExistsSubquery: _exists_subquery,
-    ops.NotExistsSubquery: _exists_subquery,
     # miscellaneous varargs
     ops.Least: varargs(sa.func.least),
     ops.Greatest: varargs(sa.func.greatest),

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -216,12 +216,13 @@ class Select(DML, Comparable):
 
         self.indent = indent
 
-    def _translate(self, expr, named=False, permit_subquery=False):
+    def _translate(self, expr, named=False, permit_subquery=False, within_where=False):
         translator = self.translator_class(
             expr,
             context=self.context,
             named=named,
             permit_subquery=permit_subquery,
+            within_where=within_where,
         )
         return translator.get_result()
 
@@ -395,7 +396,7 @@ class Select(DML, Comparable):
         fmt_preds = []
         npreds = len(self.where)
         for pred in self.where:
-            new_pred = self._translate(pred, permit_subquery=True)
+            new_pred = self._translate(pred, permit_subquery=True, within_where=True)
             if npreds > 1:
                 new_pred = f"({new_pred})"
             fmt_preds.append(new_pred)

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -336,21 +336,9 @@ def _any_expand(op):
     return ops.Max(op.arg, where=op.where)
 
 
-@rewrites(ops.NotAny)
-def _notany_expand(op):
-    zero = ops.Literal(0, dtype=op.arg.dtype)
-    return ops.Min(ops.Equals(op.arg, zero), where=op.where)
-
-
 @rewrites(ops.All)
 def _all_expand(op):
     return ops.Min(op.arg, where=op.where)
-
-
-@rewrites(ops.NotAll)
-def _notall_expand(op):
-    zero = ops.Literal(0, dtype=op.arg.dtype)
-    return ops.Max(ops.Equals(op.arg, zero), where=op.where)
 
 
 @rewrites(ops.Cast)

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -188,7 +188,9 @@ class ExprTranslator:
     _dialect_name = "hive"
     _quote_identifiers = None
 
-    def __init__(self, node, context, named=False, permit_subquery=False):
+    def __init__(
+        self, node, context, named=False, permit_subquery=False, within_where=False
+    ):
         self.node = node
         self.permit_subquery = permit_subquery
 
@@ -197,6 +199,11 @@ class ExprTranslator:
 
         # For now, governing whether the result will have a name
         self.named = named
+
+        # used to indicate whether the expression being rendered is within a
+        # WHERE clause. This is used for MSSQL to determine whether to use
+        # boolean expressions or not.
+        self.within_where = within_where
 
     def _needs_name(self, op):
         if not self.named:

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -161,8 +161,7 @@ def exists_subquery(translator, op):
 
     subquery = ctx.get_compiled_expr(node)
 
-    prefix = "NOT " * isinstance(op, ops.NotExistsSubquery)
-    return f"{prefix}EXISTS (\n{util.indent(subquery, ctx.indent)}\n)"
+    return f"EXISTS (\n{util.indent(subquery, ctx.indent)}\n)"
 
 
 # XXX this is not added to operation_registry, but looks like impala is
@@ -350,7 +349,6 @@ operation_registry = {
     ops.TimestampDiff: timestamp.timestamp_diff,
     ops.TimestampFromUNIX: timestamp.timestamp_from_unix,
     ops.ExistsSubquery: exists_subquery,
-    ops.NotExistsSubquery: exists_subquery,
     # RowNumber, and rank functions starts with 0 in Ibis-land
     ops.RowNumber: lambda *_: "row_number()",
     ops.DenseRank: lambda *_: "dense_rank()",

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -113,16 +113,6 @@ class BigQueryExprTranslator(sql_compiler.ExprTranslator):
 compiles = BigQueryExprTranslator.compiles
 
 
-@BigQueryExprTranslator.rewrites(ops.NotAll)
-def _rewrite_notall(op):
-    return ops.Any(ops.Not(op.arg), where=op.where)
-
-
-@BigQueryExprTranslator.rewrites(ops.NotAny)
-def _rewrite_notany(op):
-    return ops.All(ops.Not(op.arg), where=op.where)
-
-
 class BigQueryTableSetFormatter(sql_compiler.TableSetFormatter):
     def _quote_identifier(self, name):
         return sg.to_identifier(name).sql("bigquery")

--- a/ibis/backends/bigquery/rewrites.py
+++ b/ibis/backends/bigquery/rewrites.py
@@ -29,6 +29,4 @@ REWRITES = {
     ops.Mean: bq_mean,
     ops.Any: toolz.identity,
     ops.All: toolz.identity,
-    ops.NotAny: toolz.identity,
-    ops.NotAll: toolz.identity,
 }

--- a/ibis/backends/clickhouse/compiler/core.py
+++ b/ibis/backends/clickhouse/compiler/core.py
@@ -101,18 +101,6 @@ def translate(op: ops.TableNode, params: Mapping[ir.Value, Any]) -> sg.exp.Expre
         False, dtype="bool"
     )
 
-    # replace `NotExistsSubquery` with `Not(ExistsSubquery)`
-    #
-    # this allows to avoid having another rule to negate ExistsSubquery
-    replace_notexists_subquery_with_not_exists = p.NotExistsSubquery(...) >> c.Not(
-        c.ExistsSubquery(...)
-    )
-
-    # clickhouse-specific rewrite to turn notany/notall into equivalent
-    # already-defined operations
-    replace_notany_with_min_not = p.NotAny(x, where=y) >> c.Min(c.Not(x), where=y)
-    replace_notall_with_max_not = p.NotAll(x, where=y) >> c.Max(c.Not(x), where=y)
-
     # subtract one from ranking functions to convert from 1-indexed to 0-indexed
     subtract_one_from_ranking_functions = p.WindowFunction(
         p.RankBase | p.NTile
@@ -124,9 +112,6 @@ def translate(op: ops.TableNode, params: Mapping[ir.Value, Any]) -> sg.exp.Expre
         replace_literals
         | replace_in_column_with_table_array_view
         | replace_empty_in_values_with_false
-        | replace_notexists_subquery_with_not_exists
-        | replace_notany_with_min_not
-        | replace_notall_with_max_not
         | subtract_one_from_ranking_functions
         | add_one_to_nth_value_input
     )

--- a/ibis/backends/dask/execution/aggregations.py
+++ b/ibis/backends/dask/execution/aggregations.py
@@ -2,10 +2,7 @@
 
 - ops.Aggregation
 - ops.Any
-- ops.NotAny
 - ops.All
-- ops.NotAll
-
 """
 
 from __future__ import annotations
@@ -131,34 +128,4 @@ def execute_any_all_series_group_by(op, data, mask, aggcontext=None, **kwargs):
         # Note this branch is not currently hit in the dask backend but is
         # here for future scaffolding.
         result = aggcontext.agg(data, operator.methodcaller(name))
-    return result
-
-
-@execute_node.register((ops.NotAny, ops.NotAll), dd.Series, (dd.Series, type(None)))
-def execute_notany_series(op, data, mask, aggcontext=None, **kwargs):
-    if mask is not None:
-        data = data.loc[mask]
-
-    name = type(op).__name__[len("Not") :].lower()
-    if isinstance(aggcontext, (agg_ctx.Summarize, agg_ctx.Transform)):
-        result = ~aggcontext.agg(data, name)
-    else:
-        # Note this branch is not currently hit in the dask backend but is
-        # here for future scaffolding.
-        method = operator.methodcaller(name)
-        result = aggcontext.agg(data, lambda data: ~method(data))
-    return result
-
-
-@execute_node.register((ops.NotAny, ops.NotAll), ddgb.SeriesGroupBy, type(None))
-def execute_notany_series_group_by(op, data, mask, aggcontext=None, **kwargs):
-    name = type(op).__name__[len("Not") :].lower()
-    if isinstance(aggcontext, (agg_ctx.Summarize, agg_ctx.Transform)):
-        result = ~aggcontext.agg(data, name)
-    else:
-        # Note this branch is not currently hit in the dask backend but is
-        # here for future scaffolding.
-        method = operator.methodcaller(name)
-        result = aggcontext.agg(data, lambda data: ~method(data))
-
     return result

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -55,8 +55,6 @@ rewrites = DuckDBSQLExprTranslator.rewrites
 
 @rewrites(ops.Any)
 @rewrites(ops.All)
-@rewrites(ops.NotAny)
-@rewrites(ops.NotAll)
 @rewrites(ops.StringContains)
 def _no_op(expr):
     return expr

--- a/ibis/backends/impala/tests/snapshots/test_value_exprs/test_any_all/not_all/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_value_exprs/test_any_all/not_all/out.sql
@@ -1,1 +1,1 @@
-max((`f` = 0) = FALSE)
+NOT min(`f` = 0)

--- a/ibis/backends/impala/tests/snapshots/test_value_exprs/test_any_all/not_any/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_value_exprs/test_any_all/not_any/out.sql
@@ -1,1 +1,1 @@
-min((`f` = 0) = FALSE)
+NOT max(`f` = 0)

--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -5,7 +5,6 @@ import operator
 import pytest
 
 import ibis
-import ibis.expr.operations as ops
 from ibis.backends.impala.compiler import ImpalaCompiler
 from ibis.backends.impala.tests.mocks import MockImpalaConnection
 
@@ -297,8 +296,5 @@ def test_group_by_with_window_preserves_range(snapshot):
     w = ibis.cumulative_window(order_by=t.one)
     expr = t.group_by(t.three).mutate(four=t.two.sum().over(w))
 
-    expected = ops.WindowFunction(
-        func=ops.Sum(t.two),
-        frame=ops.RowsWindowFrame(table=t, end=0, group_by=[t.three], order_by=[t.one]),
-    )
-    assert expr.op() == expected
+    result = ibis.impala.compile(expr)
+    snapshot.assert_match(result, "out.sql")

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -847,38 +847,6 @@ def execute_any_all_series_group_by(op, data, mask, aggcontext=None, **kwargs):
         return result
 
 
-@execute_node.register((ops.NotAny, ops.NotAll), pd.Series, (pd.Series, type(None)))
-def execute_notany_notall_series(op, data, mask, aggcontext=None, **kwargs):
-    name = type(op).__name__.lower()[len("Not") :]
-    if mask is not None:
-        data = data.loc[mask]
-    if isinstance(aggcontext, (agg_ctx.Summarize, agg_ctx.Transform)):
-        result = ~aggcontext.agg(data, name)
-    else:
-        method = operator.methodcaller(name)
-        result = aggcontext.agg(data, lambda data: ~method(data))
-    try:
-        return result.astype(bool)
-    except TypeError:
-        return result
-
-
-@execute_node.register((ops.NotAny, ops.NotAll), SeriesGroupBy, type(None))
-def execute_notany_notall_series_group_by(op, data, mask, aggcontext=None, **kwargs):
-    name = type(op).__name__.lower()[len("Not") :]
-    if mask is not None:
-        data = data.obj.loc[mask].groupby(get_grouping(data.grouper.groupings))
-    if isinstance(aggcontext, (agg_ctx.Summarize, agg_ctx.Transform)):
-        result = ~aggcontext.agg(data, name)
-    else:
-        method = operator.methodcaller(name)
-        result = aggcontext.agg(data, lambda data: ~method(data))
-    try:
-        return result.astype(bool)
-    except TypeError:
-        return result
-
-
 @execute_node.register(ops.CountStar, pd.DataFrame, type(None))
 def execute_count_star_frame(op, data, _, **kwargs):
     return len(data)

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1058,24 +1058,6 @@ def execute_hash(op, **kw):
     return translate(op.arg, **kw).hash()
 
 
-@translate.register(ops.NotAll)
-def execute_not_all(op, **kw):
-    arg = op.arg
-    if (op_where := op.where) is not None:
-        arg = ops.IfElse(op_where, arg, None)
-
-    return translate(arg, **kw).all().not_()
-
-
-@translate.register(ops.NotAny)
-def execute_not_any(op, **kw):
-    arg = op.arg
-    if (op_where := op.where) is not None:
-        arg = ops.IfElse(op_where, arg, None)
-
-    return translate(arg, **kw).any().not_()
-
-
 def _arg_min_max(op, func, **kw):
     key = op.key
     arg = op.arg

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -29,8 +29,6 @@ rewrites = PostgreSQLExprTranslator.rewrites
 
 @rewrites(ops.Any)
 @rewrites(ops.All)
-@rewrites(ops.NotAny)
-@rewrites(ops.NotAll)
 def _any_all_no_op(expr):
     return expr
 

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -608,8 +608,6 @@ operation_registry.update(
         # boolean reductions
         ops.Any: reduction(sa.func.bool_or),
         ops.All: reduction(sa.func.bool_and),
-        ops.NotAny: reduction(lambda x: sa.func.bool_and(~x)),
-        ops.NotAll: reduction(lambda x: sa.func.bool_or(~x)),
         # strings
         ops.GroupConcat: _string_agg,
         ops.Capitalize: unary(sa.func.initcap),

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -407,8 +407,6 @@ operation_registry.update(
         ops.TypeOf: unary(lambda arg: sa.func.typeof(sa.func.to_variant(arg))),
         ops.All: reduction(sa.func.booland_agg),
         ops.Any: reduction(sa.func.boolor_agg),
-        ops.NotAll: reduction(lambda arg: sa.func.boolor_agg(~arg)),
-        ops.NotAny: reduction(lambda arg: sa.func.booland_agg(~arg)),
         ops.BitAnd: reduction(sa.func.bitand_agg),
         ops.BitOr: reduction(sa.func.bitor_agg),
         ops.BitXor: reduction(sa.func.bitxor_agg),

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -644,16 +644,10 @@ def test_isin_notin_column_expr(backend, alltypes, df, ibis_op, pandas_op):
     [
         param(True, True, toolz.identity, id="true_noop"),
         param(False, False, toolz.identity, id="false_noop"),
-        param(
-            True, False, invert, id="true_invert", marks=pytest.mark.notimpl(["mssql"])
-        ),
-        param(
-            False, True, invert, id="false_invert", marks=pytest.mark.notimpl(["mssql"])
-        ),
-        param(True, False, neg, id="true_negate", marks=pytest.mark.notimpl(["mssql"])),
-        param(
-            False, True, neg, id="false_negate", marks=pytest.mark.notimpl(["mssql"])
-        ),
+        param(True, False, invert, id="true_invert"),
+        param(False, True, invert, id="false_invert"),
+        param(True, False, neg, id="true_negate"),
+        param(False, True, neg, id="false_negate"),
     ],
 )
 def test_logical_negation_literal(con, expr, expected, op):
@@ -664,8 +658,8 @@ def test_logical_negation_literal(con, expr, expected, op):
     "op",
     [
         toolz.identity,
-        param(invert, marks=pytest.mark.notimpl(["mssql"])),
-        param(neg, marks=pytest.mark.notimpl(["mssql"])),
+        invert,
+        neg,
     ],
 )
 def test_logical_negation_column(backend, alltypes, df, op):

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -210,7 +210,7 @@ def calc_zscore(s):
             id="cumnotany",
             marks=[
                 pytest.mark.broken(["mssql"], raises=sa.exc.ProgrammingError),
-                pytest.mark.notimpl(["dask"], raises=NotImplementedError),
+                pytest.mark.notimpl(["dask"], raises=com.OperationNotDefinedError),
                 pytest.mark.broken(["oracle"], raises=sa.exc.DatabaseError),
             ],
         ),
@@ -239,7 +239,7 @@ def calc_zscore(s):
             id="cumnotall",
             marks=[
                 pytest.mark.broken(["mssql"], raises=sa.exc.ProgrammingError),
-                pytest.mark.notimpl(["dask"], raises=NotImplementedError),
+                pytest.mark.notimpl(["dask"], raises=com.OperationNotDefinedError),
                 pytest.mark.broken(["oracle"], raises=sa.exc.DatabaseError),
             ],
         ),

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -210,7 +210,7 @@ def calc_zscore(s):
             id="cumnotany",
             marks=[
                 pytest.mark.broken(["mssql"], raises=sa.exc.ProgrammingError),
-                pytest.mark.notimpl(["dask"], raises=com.OperationNotDefinedError),
+                pytest.mark.notimpl(["dask"], raises=NotImplementedError),
                 pytest.mark.broken(["oracle"], raises=sa.exc.DatabaseError),
             ],
         ),
@@ -239,7 +239,7 @@ def calc_zscore(s):
             id="cumnotall",
             marks=[
                 pytest.mark.broken(["mssql"], raises=sa.exc.ProgrammingError),
-                pytest.mark.notimpl(["dask"], raises=com.OperationNotDefinedError),
+                pytest.mark.notimpl(["dask"], raises=NotImplementedError),
                 pytest.mark.broken(["oracle"], raises=sa.exc.DatabaseError),
             ],
         ),

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -209,7 +209,6 @@ def calc_zscore(s):
             ),
             id="cumnotany",
             marks=[
-                pytest.mark.broken(["mssql"], raises=sa.exc.ProgrammingError),
                 pytest.mark.notimpl(["dask"], raises=NotImplementedError),
                 pytest.mark.broken(["oracle"], raises=sa.exc.DatabaseError),
             ],
@@ -238,7 +237,6 @@ def calc_zscore(s):
             ),
             id="cumnotall",
             marks=[
-                pytest.mark.broken(["mssql"], raises=sa.exc.ProgrammingError),
                 pytest.mark.notimpl(["dask"], raises=NotImplementedError),
                 pytest.mark.broken(["oracle"], raises=sa.exc.DatabaseError),
             ],

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -36,8 +36,6 @@ rewrites = TrinoSQLExprTranslator.rewrites
 
 @rewrites(ops.Any)
 @rewrites(ops.All)
-@rewrites(ops.NotAny)
-@rewrites(ops.NotAll)
 @rewrites(ops.StringContains)
 def _no_op(expr):
     return expr

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -332,8 +332,6 @@ operation_registry.update(
         # boolean reductions
         ops.Any: reduction(sa.func.bool_or),
         ops.All: reduction(sa.func.bool_and),
-        ops.NotAny: reduction(lambda x: sa.func.bool_and(~x)),
-        ops.NotAll: reduction(lambda x: sa.func.bool_or(~x)),
         ops.ArgMin: reduction(sa.func.min_by),
         ops.ArgMax: reduction(sa.func.max_by),
         # array ops

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import abc
 import itertools
 from typing import Annotated, Any, Optional, Union
 from typing import Literal as LiteralType
@@ -13,7 +12,6 @@ import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
-from ibis.common.bases import Abstract
 from ibis.common.deferred import Deferred  # noqa: TCH001
 from ibis.common.grounds import Singleton
 from ibis.common.patterns import InstanceOf, Length  # noqa: TCH001
@@ -313,9 +311,3 @@ class SearchedCase(Value):
     def dtype(self):
         exprs = [*self.results, self.default]
         return rlz.highest_precedence_dtype(exprs)
-
-
-class _Negatable(Abstract):
-    @abc.abstractmethod
-    def negate(self):  # pragma: no cover
-        ...

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -10,7 +10,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
 from ibis.expr.operations.core import Column, Value
-from ibis.expr.operations.generic import _Negatable
 from ibis.expr.operations.relations import Relation  # noqa: TCH001
 
 
@@ -327,40 +326,14 @@ class ArrayCollect(Filterable, Reduction):
 
 
 @public
-class All(Filterable, Reduction, _Negatable):
+class All(Filterable, Reduction):
     arg: Column[dt.Boolean]
 
     dtype = dt.boolean
-
-    def negate(self):
-        return NotAll(self.arg)
 
 
 @public
-class NotAll(Filterable, Reduction, _Negatable):
+class Any(Filterable, Reduction):
     arg: Column[dt.Boolean]
 
     dtype = dt.boolean
-
-    def negate(self) -> Any:
-        return All(*self.args)
-
-
-@public
-class Any(Filterable, Reduction, _Negatable):
-    arg: Column[dt.Boolean]
-
-    dtype = dt.boolean
-
-    def negate(self) -> NotAny:
-        return NotAny(*self.args)
-
-
-@public
-class NotAny(Filterable, Reduction, _Negatable):
-    arg: Column[dt.Boolean]
-
-    dtype = dt.boolean
-
-    def negate(self) -> Any:
-        return Any(*self.args)

--- a/ibis/expr/operations/window.py
+++ b/ibis/expr/operations/window.py
@@ -12,11 +12,11 @@ import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.patterns import CoercionError
 from ibis.common.typing import VarTuple  # noqa: TCH001
-from ibis.expr.operations.analytic import Analytic
+from ibis.expr.operations.analytic import Analytic  # noqa: TCH001
 from ibis.expr.operations.core import Column, Value
 from ibis.expr.operations.generic import Literal
 from ibis.expr.operations.numeric import Negate
-from ibis.expr.operations.reductions import Reduction
+from ibis.expr.operations.reductions import Reduction  # noqa: TCH001
 from ibis.expr.operations.relations import Relation  # noqa: TCH001
 from ibis.expr.operations.sortkeys import SortKey  # noqa: TCH001
 
@@ -122,19 +122,15 @@ class RangeWindowFrame(WindowFrame):
 
 @public
 class WindowFunction(Value):
-    func: Value
+    func: Analytic | Reduction
     frame: WindowFrame
 
     dtype = rlz.dtype_like("func")
     shape = ds.columnar
 
     def __init__(self, func, frame):
-        from ibis.expr.analysis import propagate_down_window, shares_all_roots
+        from ibis.expr.analysis import shares_all_roots
 
-        if not func.find((Reduction, Analytic)):
-            raise com.IbisTypeError("Window function expression must be analytic")
-
-        func = propagate_down_window(func, frame)
         if not shares_all_roots(func, frame):
             raise com.RelationError(
                 "Window function expressions doesn't fully originate from the "

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -252,12 +252,12 @@ class GroupedTable:
             order_by=bind_expr(self.table, self._order_by),
         )
         return [
-            an.windowize_function(e2, default_frame)
+            an.windowize_function(e2, default_frame, merge_frames=True)
             for expr in exprs
             for e1 in util.promote_list(expr)
             for e2 in util.promote_list(table._ensure_expr(e1))
         ] + [
-            an.windowize_function(e, default_frame).name(k)
+            an.windowize_function(e, default_frame, merge_frames=True).name(k)
             for k, expr in kwexprs.items()
             for e in util.promote_list(table._ensure_expr(expr))
         ]

--- a/ibis/tests/expr/test_window_frames.py
+++ b/ibis/tests/expr/test_window_frames.py
@@ -529,3 +529,19 @@ def test_window_analysis_auto_windowize_bug():
     expected = annual_delay[annual_delay, expr]
 
     assert enriched.equals(expected)
+
+
+def test_windowization_wraps_reduction_inside_a_nested_value_expression(alltypes):
+    t = alltypes
+    win = ibis.window(
+        following=0,
+        group_by=[t.g],
+        order_by=[t.a],
+    )
+    expr = (t.f == 0).notany().over(win)
+    assert expr.op() == ops.Not(
+        ops.WindowFunction(
+            func=ops.Any(t.f == 0),
+            frame=ops.RowsWindowFrame(table=t, end=0, group_by=[t.g], order_by=[t.a]),
+        )
+    )


### PR DESCRIPTION
These were redundant operations, and now that we have better expression rewrite capabilities it is easier to replace operations nested under other value operations, e.g. `ops.Not`.

Supplemental changes:
- fixes a bug when we didn't wrap the analytical/reduction operation directly and we allowed any value operations inside a window function. This is now restricted to analytic/reduction ops
- managed to remove the window merge rewrite rule and the window propagation analysis function
- had to overcome that mssql not supports boolean expressions in selection positions, this fix actually resulted in 8 xpasses