### PR TITLE
refactor(sql): implement `Table.fillna`/`Table.dropna` using rewrite rules

### DIFF
--- a/ibis/backends/base/sql/compiler/select_builder.py
+++ b/ibis/backends/base/sql/compiler/select_builder.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import functools
-from collections.abc import Mapping
 from typing import NamedTuple
 
 import ibis.expr.analysis as an
-import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 
 
@@ -138,48 +135,6 @@ class SelectBuilder:
             self.distinct = True
 
         self._collect(op.table, toplevel=toplevel)
-
-    def _collect_DropNa(self, op, toplevel=False):
-        if toplevel:
-            if op.subset is None:
-                columns = [
-                    ops.TableColumn(op.table, name) for name in op.table.schema.names
-                ]
-            else:
-                columns = op.subset
-            if columns:
-                filters = [
-                    functools.reduce(
-                        ops.And if op.how == "any" else ops.Or,
-                        [ops.NotNull(c) for c in columns],
-                    )
-                ]
-            elif op.how == "all":
-                filters = [ops.Literal(False, dtype=dt.bool)]
-            else:
-                filters = []
-            self.table_set = op.table
-            self.select_set = [op.table]
-            self.filters = filters
-
-    def _collect_FillNa(self, op, toplevel=False):
-        if toplevel:
-            table = op.table.to_expr()
-            if isinstance(op.replacements, Mapping):
-                mapping = op.replacements
-            else:
-                mapping = {
-                    name: op.replacements
-                    for name, type in table.schema().items()
-                    if type.nullable
-                }
-            new_op = table.mutate(
-                [
-                    table[name].fillna(value).name(name)
-                    for name, value in mapping.items()
-                ]
-            ).op()
-            self._collect(new_op, toplevel=toplevel)
 
     def _collect_Limit(self, op, toplevel=False):
         if toplevel:

--- a/ibis/backends/clickhouse/compiler/core.py
+++ b/ibis/backends/clickhouse/compiler/core.py
@@ -29,6 +29,7 @@ from ibis.backends.clickhouse.compiler.relations import translate_rel
 from ibis.backends.clickhouse.compiler.values import translate_val
 from ibis.common.deferred import _
 from ibis.expr.analysis import c, find_first_base_table, p, x, y
+from ibis.expr.rewrites import rewrite_dropna, rewrite_fillna
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -122,6 +123,8 @@ def translate(op: ops.TableNode, params: Mapping[ir.Value, Any]) -> sg.exp.Expre
         | subtract_one_from_one_indexed_functions
         | add_one_to_nth_value_input
         | nullify_empty_string_results
+        | rewrite_fillna
+        | rewrite_dropna
     )
     # apply translate rules in topological order
     node = op.map(fn)[op]

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -425,7 +425,7 @@ def test_table_fillna_invalid(alltypes):
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "clickhouse"])
+@pytest.mark.notimpl(["datafusion"])
 def test_table_fillna_mapping(backend, alltypes, replacements):
     table = alltypes.mutate(
         int_col=alltypes.int_col.nullif(1),
@@ -440,7 +440,7 @@ def test_table_fillna_mapping(backend, alltypes, replacements):
     backend.assert_frame_equal(result, expected, check_dtype=False)
 
 
-@pytest.mark.notimpl(["datafusion", "clickhouse", "druid", "oracle"])
+@pytest.mark.notimpl(["datafusion", "druid", "oracle"])
 def test_table_fillna_scalar(backend, alltypes):
     table = alltypes.mutate(
         int_col=alltypes.int_col.nullif(1),

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -8,7 +8,7 @@ import ipaddress
 import json
 import uuid
 from collections.abc import Mapping, Sequence
-from typing import Any, NamedTuple
+from typing import Any
 
 import toolz
 from public import public
@@ -233,8 +233,9 @@ del infer.register
 
 
 @public
-class _WellKnownText(NamedTuple):
-    text: str
+class _WellKnownText:
+    def __init__(self, text: str):
+        self.text = text
 
     def __str__(self):
         return self.text
@@ -315,6 +316,8 @@ def normalize(typ, value):
                 return tuple(normalize(dt.linestring, item) for item in value)
             elif dtype.is_multipolygon():
                 return tuple(normalize(dt.polygon, item) for item in value)
+        elif isinstance(value, _WellKnownText):
+            return value
         return _WellKnownText(value.wkt)
     elif dtype.is_date():
         return normalize_datetime(value).date()

--- a/ibis/expr/rewrites.py
+++ b/ibis/expr/rewrites.py
@@ -1,0 +1,60 @@
+"""Some common rewrite functions to be shared between backends."""
+from __future__ import annotations
+
+import functools
+from collections.abc import Mapping
+
+import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
+from ibis.common.patterns import pattern, replace
+from ibis.util import Namespace
+
+p = Namespace(pattern, module=ops)
+
+
+@replace(p.FillNa)
+def rewrite_fillna(_):
+    """Rewrite FillNa expressions to use more common operations."""
+    if isinstance(_.replacements, Mapping):
+        mapping = _.replacements
+    else:
+        mapping = {
+            name: _.replacements
+            for name, type in _.table.schema.items()
+            if type.nullable
+        }
+
+    if not mapping:
+        return _.table
+
+    selections = []
+    for name in _.table.schema.names:
+        col = ops.TableColumn(_.table, name)
+        if (value := mapping.get(name)) is not None:
+            col = ops.Alias(ops.Coalesce((col, value)), name)
+        selections.append(col)
+
+    return ops.Selection(_.table, selections, (), ())
+
+
+@replace(p.DropNa)
+def rewrite_dropna(_):
+    """Rewrite DropNa expressions to use more common operations."""
+    if _.subset is None:
+        columns = [ops.TableColumn(_.table, name) for name in _.table.schema.names]
+    else:
+        columns = _.subset
+
+    if columns:
+        preds = [
+            functools.reduce(
+                ops.And if _.how == "any" else ops.Or,
+                [ops.NotNull(c) for c in columns],
+            )
+        ]
+    elif _.how == "all":
+        preds = [ops.Literal(False, dtype=dt.bool)]
+    else:
+        return _.table
+
+    return ops.Selection(_.table, (), preds, ())


### PR DESCRIPTION
Previously these were hacked in in a few different locations. Now all SQL backends share the same rewrite-rule based implementations, currently stored in a common location in `ibis.expr.rewrites`.

As a side effect, this also adds support for `Table.fillna` to the clickhouse backend.