### PR TITLE
refactor(analysis): remove `_rewrite_filter()` in favor of using replacement patterns

### DIFF
--- a/ibis/backends/impala/tests/snapshots/test_sql/test_join_key_name/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_join_key_name/out.sql
@@ -13,7 +13,7 @@ t1 AS (
   SELECT extract(t0.`odate`, 'year') AS `year`, count(1) AS `CountStar()`
   FROM t0
   WHERE t0.`o_totalprice` > (
-    SELECT avg(t3.`o_totalprice`) AS `mean`
+    SELECT avg(t3.`o_totalprice`) AS `Mean(o_totalprice)`
     FROM t0 t3
     WHERE t3.`region` = t0.`region`
   )

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import functools
-import operator
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -642,72 +640,6 @@ def find_subqueries(node: ops.Node, min_dependents=1) -> tuple[ops.Node, ...]:
         for node, dependents in reversed(subquery_dependents.items())
         if len(dependents) >= min_dependents
     )
-
-
-# TODO(kszucs): use substitute instead
-@functools.singledispatch
-def _rewrite_filter(op, **kwargs):
-    raise NotImplementedError(type(op))
-
-
-@_rewrite_filter.register(ops.Reduction)
-def _rewrite_filter_reduction(op, name: str | None = None, **kwargs):
-    """Turn a reduction inside of a filter into an aggregate."""
-    # TODO: what about reductions that reference a join that isn't visible at
-    # this level? Means we probably have the wrong design, but will have to
-    # revisit when it becomes a problem.
-    if name is not None:
-        op = ops.Alias(op, name=name)
-
-    agg = op.to_expr().as_table()
-    return ops.TableArrayView(agg)
-
-
-@_rewrite_filter.register(ops.Any)
-@_rewrite_filter.register(ops.TableColumn)
-@_rewrite_filter.register(ops.Literal)
-@_rewrite_filter.register(ops.ExistsSubquery)
-@_rewrite_filter.register(ops.WindowFunction)
-def _rewrite_filter_subqueries(op, **kwargs):
-    """Don't rewrite any of these operations in filters."""
-    return op
-
-
-@_rewrite_filter.register(ops.Alias)
-def _rewrite_filter_alias(op, name: str | None = None, **kwargs):
-    """Rewrite filters on aliases."""
-    return _rewrite_filter(
-        op.arg,
-        name=name if name is not None else op.name,
-        **kwargs,
-    )
-
-
-@_rewrite_filter.register(ops.Value)
-def _rewrite_filter_value(op, **kwargs):
-    """Recursively apply filter rewriting on operations."""
-
-    visited = [
-        _rewrite_filter(arg, **kwargs) if isinstance(arg, ops.Node) else arg
-        for arg in op.args
-    ]
-    if all(map(operator.is_, visited, op.args)):
-        return op
-
-    return op.__class__(*visited)
-
-
-@_rewrite_filter.register(tuple)
-def _rewrite_filter_value_list(op, **kwargs):
-    visited = [
-        _rewrite_filter(arg, **kwargs) if isinstance(arg, ops.Node) else arg
-        for arg in op.args
-    ]
-
-    if all(map(operator.is_, visited, op.args)):
-        return op
-
-    return op.__class__(*visited)
 
 
 def find_toplevel_unnest_children(nodes: Iterable[ops.Node]) -> Iterator[ops.Table]:

--- a/ibis/expr/operations/logical.py
+++ b/ibis/expr/operations/logical.py
@@ -226,9 +226,5 @@ class UnresolvedExistsSubquery(Value):
     shape = ds.columnar
 
     def resolve(self, table) -> ExistsSubquery:
-        from ibis.expr.operations.relations import TableNode
-
-        assert isinstance(table, TableNode)
-
         (foreign_table,) = (t for t in self.tables if t != table)
-        return ExistsSubquery(foreign_table, self.predicates).to_expr()
+        return ExistsSubquery(foreign_table, self.predicates)

--- a/ibis/tests/sql/snapshots/test_compiler/test_agg_filter/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_agg_filter/out.sql
@@ -10,6 +10,6 @@ t1 AS (
 SELECT t1.*
 FROM t1
 WHERE t1.`a` = (
-  SELECT max(t1.`a`) AS `blah`
+  SELECT max(t1.`a`) AS `Max(a)`
   FROM t1
 )

--- a/ibis/tests/sql/snapshots/test_compiler/test_agg_filter_with_alias/out.sql
+++ b/ibis/tests/sql/snapshots/test_compiler/test_agg_filter_with_alias/out.sql
@@ -10,6 +10,6 @@ t1 AS (
 SELECT t1.*
 FROM t1
 WHERE t1.`a` = (
-  SELECT max(t1.`a`) AS `blah`
+  SELECT max(t1.`a`) AS `Max(a)`
   FROM t1
 )

--- a/ibis/tests/sql/snapshots/test_compiler/test_subquery_where_location/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_compiler/test_subquery_where_location/decompiled.py
@@ -13,7 +13,7 @@ alltypes = ibis.table(
 param = ibis.param("timestamp")
 proj = alltypes.select(
     [alltypes.float_col, alltypes.timestamp_col, alltypes.int_col, alltypes.string_col]
-).filter(alltypes.timestamp_col < param)
+).filter(alltypes.timestamp_col < param.name("my_param"))
 agg = proj.group_by(proj.string_col).aggregate(proj.float_col.sum().name("foo"))
 
 result = agg.foo.count()


### PR DESCRIPTION
`_rewrite_filter()` was mostly about the traversal itself, now it can be expressed with a simple pattern:

```py
node.replace(
    p.Reduction >> (lambda _: ops.TableArrayView(_.to_expr().as_table()), 
    filter=p.Value & ~p.WindowFunction & ~p.TableArrayView & ~p.ExistsSubquery
)
```