### PR TITLE
refactor(docker-compose): clean up unused exposed ports and make envar spec uniform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,13 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:23.9.1.1854-alpine
     ports:
-      - 8123:8123
-      - 9000:9000
+      - 8123:8123 # http port
     healthcheck:
       interval: 1s
       retries: 10
       test:
         - CMD-SHELL
-        - nc -z 127.0.0.1 8123 && nc -z 127.0.0.1 9000
+        - wget -qO- 'http://localhost:8123/?query=SELECT%201' # SELECT 1
       timeout: 10s
     volumes:
       - clickhouse:/var/lib/clickhouse/user_files/ibis
@@ -33,17 +32,10 @@ services:
     hostname: localhost
     image: ibisproject/impala:latest
     ports:
-      - 9020:9020
-      - 50070:50070
-      - 50075:50075
-      - 8020:8020
-      - 8042:8042
-      - 9083:9083
-      - 21000:21000
-      - 21050:21050
-      - 25000:25000
-      - 25010:25010
-      - 25020:25020
+      - 50070:50070 # namenode http (hdfs)
+      - 50075:50075 # datanode http (hdfs)
+      - 8020:8020 # namenode metadata (hdfs)
+      - 21050:21050 # hiveserver2 (impala)
     networks:
       - impala
 
@@ -71,9 +63,6 @@ services:
     environment:
       KUDU_MASTER: "true"
     image: ibisproject/kudu:latest
-    ports:
-      - 7051:7051
-      - 8051:8051
     networks:
       - impala
     healthcheck:
@@ -90,9 +79,6 @@ services:
     environment:
       KUDU_MASTER: "false"
     image: ibisproject/kudu:latest
-    ports:
-      - 7050:7050
-      - 8050:8050
     networks:
       - impala
     healthcheck:
@@ -147,6 +133,7 @@ services:
       - postgres
     volumes:
       - postgres:/data
+
   mssql:
     image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
@@ -185,10 +172,10 @@ services:
       - trino
 
   minio:
-    image: minio/minio:RELEASE.2023-10-14T05-17-22Z
+    image: minio/minio:latest
     environment:
-      - MINIO_ROOT_USER=accesskey
-      - MINIO_ROOT_PASSWORD=secretkey
+      MINIO_ROOT_USER: accesskey
+      MINIO_ROOT_PASSWORD: secretkey
     entrypoint: sh
     command: -c 'mkdir -p /data/warehouse && /opt/bin/minio server /data'
     networks:
@@ -253,16 +240,16 @@ services:
     image: postgres:16.0-alpine
     container_name: druid-postgres
     environment:
-      - POSTGRES_PASSWORD=FoolishPassword
-      - POSTGRES_USER=druid
-      - POSTGRES_DB=druid
+      POSTGRES_PASSWORD: FoolishPassword
+      POSTGRES_USER: druid
+      POSTGRES_DB: druid
     healthcheck:
       interval: 1s
       retries: 30
       timeout: 90s
       test:
         - CMD-SHELL
-        - nc -z 127.0.0.1 5432
+        - pg_isready
     networks:
       - druid
 
@@ -272,7 +259,7 @@ services:
     container_name: zookeeper
     image: zookeeper:3.9
     environment:
-      - ZOO_MY_ID=1
+      ZOO_MY_ID: 1
     healthcheck:
       interval: 10s
       retries: 9
@@ -327,7 +314,7 @@ services:
         - CMD-SHELL
         - nc -z 127.0.0.1 8082
     ports:
-      - "8082:8082"
+      - 8082:8082
     env_file:
       - ./docker/druid/environment
     networks:
@@ -398,7 +385,7 @@ services:
       - druid-historical
       - druid-broker
     ports:
-      - "8888:8888"
+      - 8888:8888
     command:
       - router
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,11 +60,10 @@ services:
       - SYS_TIME
     depends_on:
       - kudu-tserver
-    environment:
-      KUDU_MASTER: "true"
-    image: ibisproject/kudu:latest
+    image: apache/kudu:1.17.0
     networks:
       - impala
+    command: kudu master run --fs_wal_dir=/var/lib/kudu/master --fs_data_dirs=/var/lib/kudu/master
     healthcheck:
       interval: 5s
       retries: 20
@@ -76,11 +75,10 @@ services:
   kudu-tserver:
     cap_add:
       - SYS_TIME
-    environment:
-      KUDU_MASTER: "false"
-    image: ibisproject/kudu:latest
+    image: apache/kudu:1.17.0
     networks:
       - impala
+    command: kudu tserver run --fs_wal_dir=/var/lib/kudu/master --fs_data_dirs=/var/lib/kudu/master --tserver_master_addrs=kudu
     healthcheck:
       interval: 5s
       retries: 20


### PR DESCRIPTION
A few `docker-compose.yml` cleanups