### PR TITLE
fix(bigquery): move sql code to proper argument

### DIFF
--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -329,7 +329,6 @@ def test_to_pyarrow_decimal(backend, dtype, pyarrow_dtype):
 
 @pytest.mark.notyet(
     [
-        "bigquery",
         "impala",
         "mysql",
         "oracle",
@@ -343,7 +342,7 @@ def test_to_pyarrow_decimal(backend, dtype, pyarrow_dtype):
 )
 @pytest.mark.notyet(["clickhouse"], raises=Exception)
 @pytest.mark.notyet(["mssql", "pandas"], raises=PyDeltaTableError)
-@pytest.mark.notyet(["dask"], raises=NotImplementedError)
+@pytest.mark.notyet(["bigquery", "dask"], raises=NotImplementedError)
 @pytest.mark.notyet(
     ["druid"],
     raises=pa.lib.ArrowTypeError,


### PR DESCRIPTION
This PR moves the current SQL code setting hack in the BigQuery backend to be a proper argument, so that when nodes are rewritten (and thus reconstructed) the sql string makes it through the process. This is a workaround to get BigQuery UDFs working again. Longer term we should try to roll BigQuery UDFs into the new UDF setup.