### PR TITLE
fix(trino): remove stateful `USE` pattern for cross-schema table compilation

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -128,7 +128,6 @@ class Backend(AlchemyCrossSchemaBackend, CanCreateDatabase, AlchemyCanCreateSche
     compiler = SnowflakeCompiler
     supports_create_or_replace = True
     supports_python_udfs = True
-    use_stmt_prefix = "USE SCHEMA"
 
     _latest_udf_python_version = (3, 10)
 
@@ -813,9 +812,6 @@ $$""".format(
 
         return self.table(table)
 
-    def _get_schema_for_table(self, *, qualname: str, schema: str) -> str:
-        return qualname
-
     def read_parquet(
         self, path: str | Path, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
@@ -886,20 +882,6 @@ $$""".format(
             )
 
         return self.table(table)
-
-
-@compiles(sa.Table, "snowflake")
-def compile_table(element, compiler, **kw):
-    """Override compilation of leaf tables.
-
-    The override is necessary because snowflake-sqlalchemy does not handle
-    quoting databases and schemas correctly.
-    """
-    schema = element.schema
-    name = compiler.preparer.quote_identifier(element.name)
-    if schema is not None:
-        return f"{schema}.{name}"
-    return name
 
 
 @compiles(sa.sql.Join, "snowflake")

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -335,14 +335,15 @@ def test_to_pyarrow_decimal(backend, dtype, pyarrow_dtype):
         "postgres",
         "snowflake",
         "sqlite",
+        "bigquery",
+        "dask",
         "trino",
     ],
-    raises=AttributeError,
+    raises=NotImplementedError,
     reason="read_delta not yet implemented",
 )
 @pytest.mark.notyet(["clickhouse"], raises=Exception)
 @pytest.mark.notyet(["mssql", "pandas"], raises=PyDeltaTableError)
-@pytest.mark.notyet(["bigquery", "dask"], raises=NotImplementedError)
 @pytest.mark.notyet(
     ["druid"],
     raises=pa.lib.ArrowTypeError,

--- a/ibis/backends/tests/tpch/snapshots/test_h01/test_tpc_h01/trino/h01.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h01/test_tpc_h01/trino/h01.sql
@@ -27,7 +27,7 @@ FROM (
     AVG(t1.l_extendedprice) AS avg_price,
     AVG(t1.l_discount) AS avg_disc,
     COUNT(*) AS count_order
-  FROM "hive".ibis_sf1.lineitem AS t1
+  FROM hive.ibis_sf1.lineitem AS t1
   WHERE
     t1.l_shipdate <= FROM_ISO8601_DATE('1998-09-02')
   GROUP BY

--- a/ibis/backends/tests/tpch/snapshots/test_h02/test_tpc_h02/trino/h02.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h02/test_tpc_h02/trino/h02.sql
@@ -28,14 +28,14 @@ WITH t0 AS (
     t6.r_regionkey AS r_regionkey,
     t6.r_name AS r_name,
     t6.r_comment AS r_comment
-  FROM "hive".ibis_sf1.part AS t2
-  JOIN "hive".ibis_sf1.partsupp AS t3
+  FROM hive.ibis_sf1.part AS t2
+  JOIN hive.ibis_sf1.partsupp AS t3
     ON t2.p_partkey = t3.ps_partkey
-  JOIN "hive".ibis_sf1.supplier AS t4
+  JOIN hive.ibis_sf1.supplier AS t4
     ON t4.s_suppkey = t3.ps_suppkey
-  JOIN "hive".ibis_sf1.nation AS t5
+  JOIN hive.ibis_sf1.nation AS t5
     ON t4.s_nationkey = t5.n_nationkey
-  JOIN "hive".ibis_sf1.region AS t6
+  JOIN hive.ibis_sf1.region AS t6
     ON t5.n_regionkey = t6.r_regionkey
   WHERE
     t2.p_size = 15
@@ -44,12 +44,12 @@ WITH t0 AS (
     AND t3.ps_supplycost = (
       SELECT
         MIN(t3.ps_supplycost) AS "Min(ps_supplycost)"
-      FROM "hive".ibis_sf1.partsupp AS t3
-      JOIN "hive".ibis_sf1.supplier AS t4
+      FROM hive.ibis_sf1.partsupp AS t3
+      JOIN hive.ibis_sf1.supplier AS t4
         ON t4.s_suppkey = t3.ps_suppkey
-      JOIN "hive".ibis_sf1.nation AS t5
+      JOIN hive.ibis_sf1.nation AS t5
         ON t4.s_nationkey = t5.n_nationkey
-      JOIN "hive".ibis_sf1.region AS t6
+      JOIN hive.ibis_sf1.region AS t6
         ON t5.n_regionkey = t6.r_regionkey
       WHERE
         t6.r_name = 'EUROPE' AND t2.p_partkey = t3.ps_partkey

--- a/ibis/backends/tests/tpch/snapshots/test_h03/test_tpc_h03/trino/h03.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h03/test_tpc_h03/trino/h03.sql
@@ -6,10 +6,10 @@ WITH t0 AS (
     SUM(t4.l_extendedprice * (
       1 - t4.l_discount
     )) AS revenue
-  FROM "hive".ibis_sf1.customer AS t2
-  JOIN "hive".ibis_sf1.orders AS t3
+  FROM hive.ibis_sf1.customer AS t2
+  JOIN hive.ibis_sf1.orders AS t3
     ON t2.c_custkey = t3.o_custkey
-  JOIN "hive".ibis_sf1.lineitem AS t4
+  JOIN hive.ibis_sf1.lineitem AS t4
     ON t4.l_orderkey = t3.o_orderkey
   WHERE
     t2.c_mktsegment = 'BUILDING'

--- a/ibis/backends/tests/tpch/snapshots/test_h04/test_tpc_h04/trino/h04.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h04/test_tpc_h04/trino/h04.sql
@@ -1,13 +1,13 @@
 SELECT
   t0.o_orderpriority,
   COUNT(*) AS order_count
-FROM "hive".ibis_sf1.orders AS t0
+FROM hive.ibis_sf1.orders AS t0
 WHERE
   (
     EXISTS(
       SELECT
         1 AS anon_1
-      FROM "hive".ibis_sf1.lineitem AS t1
+      FROM hive.ibis_sf1.lineitem AS t1
       WHERE
         t1.l_orderkey = t0.o_orderkey AND t1.l_commitdate < t1.l_receiptdate
     )

--- a/ibis/backends/tests/tpch/snapshots/test_h05/test_tpc_h05/trino/h05.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h05/test_tpc_h05/trino/h05.sql
@@ -7,16 +7,16 @@ FROM (
     SUM(t3.l_extendedprice * (
       1 - t3.l_discount
     )) AS revenue
-  FROM "hive".ibis_sf1.customer AS t1
-  JOIN "hive".ibis_sf1.orders AS t2
+  FROM hive.ibis_sf1.customer AS t1
+  JOIN hive.ibis_sf1.orders AS t2
     ON t1.c_custkey = t2.o_custkey
-  JOIN "hive".ibis_sf1.lineitem AS t3
+  JOIN hive.ibis_sf1.lineitem AS t3
     ON t3.l_orderkey = t2.o_orderkey
-  JOIN "hive".ibis_sf1.supplier AS t4
+  JOIN hive.ibis_sf1.supplier AS t4
     ON t3.l_suppkey = t4.s_suppkey
-  JOIN "hive".ibis_sf1.nation AS t5
+  JOIN hive.ibis_sf1.nation AS t5
     ON t1.c_nationkey = t4.s_nationkey AND t4.s_nationkey = t5.n_nationkey
-  JOIN "hive".ibis_sf1.region AS t6
+  JOIN hive.ibis_sf1.region AS t6
     ON t5.n_regionkey = t6.r_regionkey
   WHERE
     t6.r_name = 'ASIA'

--- a/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/trino/h06.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/trino/h06.sql
@@ -1,6 +1,6 @@
 SELECT
   SUM(t0.l_extendedprice * t0.l_discount) AS revenue
-FROM "hive".ibis_sf1.lineitem AS t0
+FROM hive.ibis_sf1.lineitem AS t0
 WHERE
   t0.l_shipdate >= FROM_ISO8601_DATE('1994-01-01')
   AND t0.l_shipdate < FROM_ISO8601_DATE('1995-01-01')

--- a/ibis/backends/tests/tpch/snapshots/test_h07/test_tpc_h07/trino/h07.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h07/test_tpc_h07/trino/h07.sql
@@ -9,16 +9,16 @@ WITH t0 AS (
     t3.l_extendedprice * (
       1 - t3.l_discount
     ) AS volume
-  FROM "hive".ibis_sf1.supplier AS t2
-  JOIN "hive".ibis_sf1.lineitem AS t3
+  FROM hive.ibis_sf1.supplier AS t2
+  JOIN hive.ibis_sf1.lineitem AS t3
     ON t2.s_suppkey = t3.l_suppkey
-  JOIN "hive".ibis_sf1.orders AS t4
+  JOIN hive.ibis_sf1.orders AS t4
     ON t4.o_orderkey = t3.l_orderkey
-  JOIN "hive".ibis_sf1.customer AS t5
+  JOIN hive.ibis_sf1.customer AS t5
     ON t5.c_custkey = t4.o_custkey
-  JOIN "hive".ibis_sf1.nation AS t6
+  JOIN hive.ibis_sf1.nation AS t6
     ON t2.s_nationkey = t6.n_nationkey
-  JOIN "hive".ibis_sf1.nation AS t7
+  JOIN hive.ibis_sf1.nation AS t7
     ON t5.c_nationkey = t7.n_nationkey
 )
 SELECT

--- a/ibis/backends/tests/tpch/snapshots/test_h08/test_tpc_h08/trino/h08.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h08/test_tpc_h08/trino/h08.sql
@@ -8,20 +8,20 @@ WITH t0 AS (
     t10.r_name AS r_name,
     t7.o_orderdate AS o_orderdate,
     t4.p_type AS p_type
-  FROM "hive".ibis_sf1.part AS t4
-  JOIN "hive".ibis_sf1.lineitem AS t5
+  FROM hive.ibis_sf1.part AS t4
+  JOIN hive.ibis_sf1.lineitem AS t5
     ON t4.p_partkey = t5.l_partkey
-  JOIN "hive".ibis_sf1.supplier AS t6
+  JOIN hive.ibis_sf1.supplier AS t6
     ON t6.s_suppkey = t5.l_suppkey
-  JOIN "hive".ibis_sf1.orders AS t7
+  JOIN hive.ibis_sf1.orders AS t7
     ON t5.l_orderkey = t7.o_orderkey
-  JOIN "hive".ibis_sf1.customer AS t8
+  JOIN hive.ibis_sf1.customer AS t8
     ON t7.o_custkey = t8.c_custkey
-  JOIN "hive".ibis_sf1.nation AS t9
+  JOIN hive.ibis_sf1.nation AS t9
     ON t8.c_nationkey = t9.n_nationkey
-  JOIN "hive".ibis_sf1.region AS t10
+  JOIN hive.ibis_sf1.region AS t10
     ON t9.n_regionkey = t10.r_regionkey
-  JOIN "hive".ibis_sf1.nation AS t11
+  JOIN hive.ibis_sf1.nation AS t11
     ON t6.s_nationkey = t11.n_nationkey
 ), t1 AS (
   SELECT

--- a/ibis/backends/tests/tpch/snapshots/test_h09/test_tpc_h09/trino/h09.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h09/test_tpc_h09/trino/h09.sql
@@ -6,16 +6,16 @@ WITH t0 AS (
     CAST(EXTRACT(year FROM t6.o_orderdate) AS SMALLINT) AS o_year,
     t7.n_name AS nation,
     t5.p_name AS p_name
-  FROM "hive".ibis_sf1.lineitem AS t2
-  JOIN "hive".ibis_sf1.supplier AS t3
+  FROM hive.ibis_sf1.lineitem AS t2
+  JOIN hive.ibis_sf1.supplier AS t3
     ON t3.s_suppkey = t2.l_suppkey
-  JOIN "hive".ibis_sf1.partsupp AS t4
+  JOIN hive.ibis_sf1.partsupp AS t4
     ON t4.ps_suppkey = t2.l_suppkey AND t4.ps_partkey = t2.l_partkey
-  JOIN "hive".ibis_sf1.part AS t5
+  JOIN hive.ibis_sf1.part AS t5
     ON t5.p_partkey = t2.l_partkey
-  JOIN "hive".ibis_sf1.orders AS t6
+  JOIN hive.ibis_sf1.orders AS t6
     ON t6.o_orderkey = t2.l_orderkey
-  JOIN "hive".ibis_sf1.nation AS t7
+  JOIN hive.ibis_sf1.nation AS t7
     ON t3.s_nationkey = t7.n_nationkey
   WHERE
     t5.p_name LIKE '%green%'

--- a/ibis/backends/tests/tpch/snapshots/test_h10/test_tpc_h10/trino/h10.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h10/test_tpc_h10/trino/h10.sql
@@ -10,12 +10,12 @@ WITH t0 AS (
     SUM(t4.l_extendedprice * (
       1 - t4.l_discount
     )) AS revenue
-  FROM "hive".ibis_sf1.customer AS t2
-  JOIN "hive".ibis_sf1.orders AS t3
+  FROM hive.ibis_sf1.customer AS t2
+  JOIN hive.ibis_sf1.orders AS t3
     ON t2.c_custkey = t3.o_custkey
-  JOIN "hive".ibis_sf1.lineitem AS t4
+  JOIN hive.ibis_sf1.lineitem AS t4
     ON t4.l_orderkey = t3.o_orderkey
-  JOIN "hive".ibis_sf1.nation AS t5
+  JOIN hive.ibis_sf1.nation AS t5
     ON t2.c_nationkey = t5.n_nationkey
   WHERE
     t3.o_orderdate >= FROM_ISO8601_DATE('1993-10-01')

--- a/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/trino/h11.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/trino/h11.sql
@@ -2,10 +2,10 @@ WITH t0 AS (
   SELECT
     t2.ps_partkey AS ps_partkey,
     SUM(t2.ps_supplycost * t2.ps_availqty) AS value
-  FROM "hive".ibis_sf1.partsupp AS t2
-  JOIN "hive".ibis_sf1.supplier AS t3
+  FROM hive.ibis_sf1.partsupp AS t2
+  JOIN hive.ibis_sf1.supplier AS t3
     ON t2.ps_suppkey = t3.s_suppkey
-  JOIN "hive".ibis_sf1.nation AS t4
+  JOIN hive.ibis_sf1.nation AS t4
     ON t4.n_nationkey = t3.s_nationkey
   WHERE
     t4.n_name = 'GERMANY'
@@ -27,10 +27,10 @@ FROM (
       FROM (
         SELECT
           SUM(t2.ps_supplycost * t2.ps_availqty) AS total
-        FROM "hive".ibis_sf1.partsupp AS t2
-        JOIN "hive".ibis_sf1.supplier AS t3
+        FROM hive.ibis_sf1.partsupp AS t2
+        JOIN hive.ibis_sf1.supplier AS t3
           ON t2.ps_suppkey = t3.s_suppkey
-        JOIN "hive".ibis_sf1.nation AS t4
+        JOIN hive.ibis_sf1.nation AS t4
           ON t4.n_nationkey = t3.s_nationkey
         WHERE
           t4.n_name = 'GERMANY'

--- a/ibis/backends/tests/tpch/snapshots/test_h12/test_tpc_h12/trino/h12.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h12/test_tpc_h12/trino/h12.sql
@@ -7,8 +7,8 @@ FROM (
     t2.l_shipmode AS l_shipmode,
     SUM(CASE t1.o_orderpriority WHEN '1-URGENT' THEN 1 WHEN '2-HIGH' THEN 1 ELSE 0 END) AS high_line_count,
     SUM(CASE t1.o_orderpriority WHEN '1-URGENT' THEN 0 WHEN '2-HIGH' THEN 0 ELSE 1 END) AS low_line_count
-  FROM "hive".ibis_sf1.orders AS t1
-  JOIN "hive".ibis_sf1.lineitem AS t2
+  FROM hive.ibis_sf1.orders AS t1
+  JOIN hive.ibis_sf1.lineitem AS t2
     ON t1.o_orderkey = t2.l_orderkey
   WHERE
     t2.l_shipmode IN ('MAIL', 'SHIP')

--- a/ibis/backends/tests/tpch/snapshots/test_h13/test_tpc_h13/trino/h13.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h13/test_tpc_h13/trino/h13.sql
@@ -2,8 +2,8 @@ WITH t0 AS (
   SELECT
     t2.c_custkey AS c_custkey,
     COUNT(t3.o_orderkey) AS c_count
-  FROM "hive".ibis_sf1.customer AS t2
-  LEFT OUTER JOIN "hive".ibis_sf1.orders AS t3
+  FROM hive.ibis_sf1.customer AS t2
+  LEFT OUTER JOIN hive.ibis_sf1.orders AS t3
     ON t2.c_custkey = t3.o_custkey AND NOT t3.o_comment LIKE '%special%requests%'
   GROUP BY
     1

--- a/ibis/backends/tests/tpch/snapshots/test_h14/test_tpc_h14/trino/h14.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h14/test_tpc_h14/trino/h14.sql
@@ -6,8 +6,8 @@ SELECT
   ) / SUM(t0.l_extendedprice * (
     1 - t0.l_discount
   )) AS promo_revenue
-FROM "hive".ibis_sf1.lineitem AS t0
-JOIN "hive".ibis_sf1.part AS t1
+FROM hive.ibis_sf1.lineitem AS t0
+JOIN hive.ibis_sf1.part AS t1
   ON t0.l_partkey = t1.p_partkey
 WHERE
   t0.l_shipdate >= FROM_ISO8601_DATE('1995-09-01')

--- a/ibis/backends/tests/tpch/snapshots/test_h15/test_tpc_h15/trino/h15.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h15/test_tpc_h15/trino/h15.sql
@@ -4,7 +4,7 @@ WITH t0 AS (
     SUM(t3.l_extendedprice * (
       1 - t3.l_discount
     )) AS total_revenue
-  FROM "hive".ibis_sf1.lineitem AS t3
+  FROM hive.ibis_sf1.lineitem AS t3
   WHERE
     t3.l_shipdate >= FROM_ISO8601_DATE('1996-01-01')
     AND t3.l_shipdate < FROM_ISO8601_DATE('1996-04-01')
@@ -21,7 +21,7 @@ WITH t0 AS (
     t3.s_comment AS s_comment,
     t0.l_suppkey AS l_suppkey,
     t0.total_revenue AS total_revenue
-  FROM "hive".ibis_sf1.supplier AS t3
+  FROM hive.ibis_sf1.supplier AS t3
   JOIN t0
     ON t3.s_suppkey = t0.l_suppkey
   WHERE

--- a/ibis/backends/tests/tpch/snapshots/test_h16/test_tpc_h16/trino/h16.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h16/test_tpc_h16/trino/h16.sql
@@ -9,8 +9,8 @@ FROM (
     t2.p_type AS p_type,
     t2.p_size AS p_size,
     COUNT(DISTINCT t1.ps_suppkey) AS supplier_cnt
-  FROM "hive".ibis_sf1.partsupp AS t1
-  JOIN "hive".ibis_sf1.part AS t2
+  FROM hive.ibis_sf1.partsupp AS t1
+  JOIN hive.ibis_sf1.part AS t2
     ON t2.p_partkey = t1.ps_partkey
   WHERE
     t2.p_brand <> 'Brand#45'
@@ -29,7 +29,7 @@ FROM (
             t4.s_phone AS s_phone,
             t4.s_acctbal AS s_acctbal,
             t4.s_comment AS s_comment
-          FROM "hive".ibis_sf1.supplier AS t4
+          FROM hive.ibis_sf1.supplier AS t4
           WHERE
             t4.s_comment LIKE '%Customer%Complaints%'
         ) AS t3

--- a/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/trino/h17.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/trino/h17.sql
@@ -1,7 +1,7 @@
 SELECT
   SUM(t0.l_extendedprice) / 7.0 AS avg_yearly
-FROM "hive".ibis_sf1.lineitem AS t0
-JOIN "hive".ibis_sf1.part AS t1
+FROM hive.ibis_sf1.lineitem AS t0
+JOIN hive.ibis_sf1.part AS t1
   ON t1.p_partkey = t0.l_partkey
 WHERE
   t1.p_brand = 'Brand#23'
@@ -9,7 +9,7 @@ WHERE
   AND t0.l_quantity < (
     SELECT
       AVG(t0.l_quantity) AS "Mean(l_quantity)"
-    FROM "hive".ibis_sf1.lineitem AS t0
+    FROM hive.ibis_sf1.lineitem AS t0
     WHERE
       t0.l_partkey = t1.p_partkey
   ) * 0.2

--- a/ibis/backends/tests/tpch/snapshots/test_h18/test_tpc_h18/trino/h18.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h18/test_tpc_h18/trino/h18.sql
@@ -2,7 +2,7 @@ WITH t0 AS (
   SELECT
     t2.l_orderkey AS l_orderkey,
     SUM(t2.l_quantity) AS qty_sum
-  FROM "hive".ibis_sf1.lineitem AS t2
+  FROM hive.ibis_sf1.lineitem AS t2
   GROUP BY
     1
 )
@@ -21,10 +21,10 @@ FROM (
     t3.o_orderdate AS o_orderdate,
     t3.o_totalprice AS o_totalprice,
     SUM(t4.l_quantity) AS sum_qty
-  FROM "hive".ibis_sf1.customer AS t2
-  JOIN "hive".ibis_sf1.orders AS t3
+  FROM hive.ibis_sf1.customer AS t2
+  JOIN hive.ibis_sf1.orders AS t3
     ON t2.c_custkey = t3.o_custkey
-  JOIN "hive".ibis_sf1.lineitem AS t4
+  JOIN hive.ibis_sf1.lineitem AS t4
     ON t3.o_orderkey = t4.l_orderkey
   WHERE
     t3.o_orderkey IN (

--- a/ibis/backends/tests/tpch/snapshots/test_h19/test_tpc_h19/trino/h19.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h19/test_tpc_h19/trino/h19.sql
@@ -2,8 +2,8 @@ SELECT
   SUM(t0.l_extendedprice * (
     1 - t0.l_discount
   )) AS revenue
-FROM "hive".ibis_sf1.lineitem AS t0
-JOIN "hive".ibis_sf1.part AS t1
+FROM hive.ibis_sf1.lineitem AS t0
+JOIN hive.ibis_sf1.part AS t1
   ON t1.p_partkey = t0.l_partkey
 WHERE
   t1.p_brand = 'Brand#12'

--- a/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/trino/h20.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/trino/h20.sql
@@ -11,8 +11,8 @@ WITH t0 AS (
     t3.n_name AS n_name,
     t3.n_regionkey AS n_regionkey,
     t3.n_comment AS n_comment
-  FROM "hive".ibis_sf1.supplier AS t2
-  JOIN "hive".ibis_sf1.nation AS t3
+  FROM hive.ibis_sf1.supplier AS t2
+  JOIN hive.ibis_sf1.nation AS t3
     ON t2.s_nationkey = t3.n_nationkey
   WHERE
     t3.n_name = 'CANADA'
@@ -26,7 +26,7 @@ WITH t0 AS (
           t5.ps_availqty AS ps_availqty,
           t5.ps_supplycost AS ps_supplycost,
           t5.ps_comment AS ps_comment
-        FROM "hive".ibis_sf1.partsupp AS t5
+        FROM hive.ibis_sf1.partsupp AS t5
         WHERE
           t5.ps_partkey IN (
             SELECT
@@ -42,7 +42,7 @@ WITH t0 AS (
                 t7.p_container AS p_container,
                 t7.p_retailprice AS p_retailprice,
                 t7.p_comment AS p_comment
-              FROM "hive".ibis_sf1.part AS t7
+              FROM hive.ibis_sf1.part AS t7
               WHERE
                 t7.p_name LIKE 'forest%'
             ) AS t6
@@ -50,7 +50,7 @@ WITH t0 AS (
           AND t5.ps_availqty > (
             SELECT
               SUM(t6.l_quantity) AS "Sum(l_quantity)"
-            FROM "hive".ibis_sf1.lineitem AS t6
+            FROM hive.ibis_sf1.lineitem AS t6
             WHERE
               t6.l_partkey = t5.ps_partkey
               AND t6.l_suppkey = t5.ps_suppkey

--- a/ibis/backends/tests/tpch/snapshots/test_h21/test_tpc_h21/trino/h21.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h21/test_tpc_h21/trino/h21.sql
@@ -7,12 +7,12 @@ WITH t0 AS (
     t3.l_suppkey AS l1_suppkey,
     t2.s_name AS s_name,
     t5.n_name AS n_name
-  FROM "hive".ibis_sf1.supplier AS t2
-  JOIN "hive".ibis_sf1.lineitem AS t3
+  FROM hive.ibis_sf1.supplier AS t2
+  JOIN hive.ibis_sf1.lineitem AS t3
     ON t2.s_suppkey = t3.l_suppkey
-  JOIN "hive".ibis_sf1.orders AS t4
+  JOIN hive.ibis_sf1.orders AS t4
     ON t4.o_orderkey = t3.l_orderkey
-  JOIN "hive".ibis_sf1.nation AS t5
+  JOIN hive.ibis_sf1.nation AS t5
     ON t2.s_nationkey = t5.n_nationkey
 )
 SELECT
@@ -31,7 +31,7 @@ FROM (
       EXISTS(
         SELECT
           1 AS anon_1
-        FROM "hive".ibis_sf1.lineitem AS t2
+        FROM hive.ibis_sf1.lineitem AS t2
         WHERE
           t2.l_orderkey = t0.l1_orderkey AND t2.l_suppkey <> t0.l1_suppkey
       )
@@ -40,7 +40,7 @@ FROM (
       EXISTS(
         SELECT
           1 AS anon_2
-        FROM "hive".ibis_sf1.lineitem AS t2
+        FROM hive.ibis_sf1.lineitem AS t2
         WHERE
           t2.l_orderkey = t0.l1_orderkey
           AND t2.l_suppkey <> t0.l1_suppkey

--- a/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/trino/h22.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/trino/h22.sql
@@ -8,7 +8,7 @@ WITH t0 AS (
       ELSE SUBSTR(t2.c_phone, 0 + 1 + LENGTH(t2.c_phone), 2)
     END AS cntrycode,
     t2.c_acctbal AS c_acctbal
-  FROM "hive".ibis_sf1.customer AS t2
+  FROM hive.ibis_sf1.customer AS t2
   WHERE
     CASE
       WHEN (
@@ -23,7 +23,7 @@ WITH t0 AS (
       FROM (
         SELECT
           AVG(t2.c_acctbal) AS avg_bal
-        FROM "hive".ibis_sf1.customer AS t2
+        FROM hive.ibis_sf1.customer AS t2
         WHERE
           t2.c_acctbal > 0.0
           AND CASE
@@ -39,7 +39,7 @@ WITH t0 AS (
       EXISTS(
         SELECT
           1 AS anon_2
-        FROM "hive".ibis_sf1.orders AS t3
+        FROM hive.ibis_sf1.orders AS t3
         WHERE
           t3.o_custkey = t2.c_custkey
       )

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -41,7 +41,6 @@ class Backend(AlchemyCrossSchemaBackend, AlchemyCanCreateSchema, CanListDatabase
     compiler = TrinoSQLCompiler
     supports_create_or_replace = False
     supports_temporary_tables = False
-    use_stmt_prefix = "USE"
 
     @cached_property
     def version(self) -> str:
@@ -373,11 +372,3 @@ class Backend(AlchemyCrossSchemaBackend, AlchemyCanCreateSchema, CanListDatabase
             trino_catalog=database or self.current_database,
             **kwargs,
         )
-
-    def _get_schema_for_table(self, *, qualname: str, schema: str) -> str:
-        """Trino compiles the `trino_catalog` argument into `sa.Table`.
-
-        This means we only need the schema and not the fully qualified
-        $catalog.$schema identifier.
-        """
-        return schema

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -145,3 +145,19 @@ def test_create_table_timestamp():
     finally:
         con.drop_table(table)
         assert table not in con.list_tables()
+
+
+def test_table_access_from_connection_without_catalog_or_schema():
+    con = ibis.trino.connect()
+    # can't use the `system` catalog to test here, because the trino sqlalchemy
+    # dialect defaults to `system` if no catalog is passed, so it wouldn't be a
+    # useful test
+    assert con.current_database != "tpch"
+    assert con.current_schema is None
+
+    t = con.table("region", schema="tpch.sf1")
+
+    assert con.current_database != "tpch"
+    assert con.current_schema is None
+
+    assert t.count().execute()


### PR DESCRIPTION
This PR fixes [an issue](https://github.com/ibis-project/ibis/issues/7354#issuecomment-1761439271) with Trino with the following undesirable behavior

```python
con = ibis.trino.connect() # default parameters
t = con.table("table_properties", schema="system.metadata") # fails
t = con.table("table_properties", schema="system.metadata") # succeeds
```

The first assignment to `t` fails because the `finally` handler in `_use_stmt` was
trying to roll back to the current schema and database, but `connect` has
no default database or schema (which is a valid operating mode for Trino clients).

However, it's not valid to roll back to an empty database or schema.

The second assignment to `t` **succeeds** because during the first assignment
we `USE system.metadata` so the finally handler has something to roll back to.

This PR fixes this issue by overriding table compilation for Trino (and
Snowflake, since the underlying base class is shared to deduplicate handling
cross-database/schema/catalog operations) by setting the `Table.fullname`
attribute (which I wasn't aware of until today) and always rendering that in
a `@compiles` override for `sa.Table`.

`fullname` is required because it is used when compiling `INSERT INTO` targets,
whereas if schema is used to hold both the catalog/database and the schema, the
target ends up being `"database.schema".table` which is incorrect.

The stateful nature of cross-database tables is now removed as part of this PR.

Fixes #7354.
