### PR TITLE
chore(bigquery): regenerate sql

### DIFF
--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_compile_toplevel/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_compile_toplevel/out.sql
@@ -1,3 +1,3 @@
 SELECT
   sum(t0.`foo`) AS `Sum_foo`
-FROM t0 AS t0
+FROM t0

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_set_operation/difference/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_set_operation/difference/out.sql
@@ -7,5 +7,5 @@ FROM (
   EXCEPT DISTINCT
   SELECT
     t1.*
-  FROM t1 AS t1
+  FROM t1
 ) AS t0

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_set_operation/intersect/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_set_operation/intersect/out.sql
@@ -7,5 +7,5 @@ FROM (
   INTERSECT DISTINCT
   SELECT
     t1.*
-  FROM t1 AS t1
+  FROM t1
 ) AS t0

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_set_operation/union_all/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_set_operation/union_all/out.sql
@@ -7,5 +7,5 @@ FROM (
   UNION ALL
   SELECT
     t1.*
-  FROM t1 AS t1
+  FROM t1
 ) AS t0

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_set_operation/union_distinct/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_set_operation/union_distinct/out.sql
@@ -7,5 +7,5 @@ FROM (
   UNION DISTINCT
   SELECT
     t1.*
-  FROM t1 AS t1
+  FROM t1
 ) AS t0


### PR DESCRIPTION
Regenerate some failing bigquery test snapshots. I think this is due to [these lines](https://github.com/ibis-project/ibis/pull/7377/files#diff-ff7982dc41d280b20e266548b77f73ce378fc7d859b88192e8e3f07e63af75aaR131-R132) from #7377. Previously we unconditionally produced an alias in the string compiler, in that PR we only produce one if the the retrieved reference does not match the alias