### PR TITLE
test(duckdb): preload extensions to avoid race condition

### DIFF
--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 import ibis
 from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
+from ibis.conftest import SANDBOXED
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -19,6 +20,12 @@ class TestConf(BackendTest, RoundAwayFromZero):
     deps = "duckdb", "duckdb_engine"
     stateful = False
     supports_tpch = True
+
+    def preload(self):
+        if not SANDBOXED:
+            self.connection._load_extensions(
+                ["httpfs", "postgres_scanner", "sqlite_scanner"]
+            )
 
     @property
     def ddl_script(self) -> Iterator[str]:


### PR DESCRIPTION
A race condition in downloading extensions [still seems to be an issue on Windows](https://github.com/ibis-project/ibis/actions/runs/6551379268/job/17792455543). Bringing back preloading (one of the things we did before) should avoid downloading extensions in tests that aren't explicitly testing installing/downloading extensions.