### PR TITLE
feat(api): support specifying `sig` in udf definitions

### DIFF
--- a/ibis/tests/expr/test_udf.py
+++ b/ibis/tests/expr/test_udf.py
@@ -93,6 +93,50 @@ def test_vectorized_udf_operations(table, klass, output_type):
         pytest.param(ibis.udf.agg.builtin, id="agg-builtin"),
     ],
 )
+def test_udf_from_annotations(dec, table):
+    @dec
+    def myfunc(x: int, y: str) -> float:
+        ...
+
+    assert myfunc(table.a, table.b).type().is_floating()
+
+    with pytest.raises(ValidationError):
+        # Wrong arg types
+        myfunc(table.b, table.a)
+
+
+@pytest.mark.parametrize(
+    "dec",
+    [
+        pytest.param(ibis.udf.scalar.builtin, id="scalar-builtin"),
+        pytest.param(ibis.udf.scalar.pandas, id="scalar-pandas"),
+        pytest.param(ibis.udf.scalar.pyarrow, id="scalar-pyarrow"),
+        pytest.param(ibis.udf.scalar.python, id="scalar-python"),
+        pytest.param(ibis.udf.agg.builtin, id="agg-builtin"),
+    ],
+)
+def test_udf_from_sig(dec, table):
+    @dec(signature=((int, str), float))
+    def myfunc(x, y):
+        ...
+
+    assert myfunc(table.a, table.b).type().is_floating()
+
+    with pytest.raises(ValidationError):
+        # Wrong arg types
+        myfunc(table.b, table.a)
+
+
+@pytest.mark.parametrize(
+    "dec",
+    [
+        pytest.param(ibis.udf.scalar.builtin, id="scalar-builtin"),
+        pytest.param(ibis.udf.scalar.pandas, id="scalar-pandas"),
+        pytest.param(ibis.udf.scalar.pyarrow, id="scalar-pyarrow"),
+        pytest.param(ibis.udf.scalar.python, id="scalar-python"),
+        pytest.param(ibis.udf.agg.builtin, id="agg-builtin"),
+    ],
+)
 def test_udf_deferred(dec, table):
     @dec
     def myfunc(x: int) -> int:


### PR DESCRIPTION
This adds support for a new `sig` parameter to all udf definition functions. If present, this will be used for determining the UDF signature instead of the function annotations. This can be useful for:

- Users who don't want to make use of annotations
- Programmatic usage, where generating a function with a signature may be tricky
- Pandas or pyarrow udfs where you want the decorated function to be annotated with pandas/pyarrow types, and need another way of expressing the types ibis should use
- Expressing more complicated input/output types than can easily be expressed via python annotations. `sig` accepts anything coercible to an ibis dtype, so struct/map/array types are more easily expressible

Fixes #7201.