### PR TITLE
test(doctest): sort `pivot_wider` case that occasionally fails in CI

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -3797,7 +3797,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         ...     names_from="tension",
         ...     values_from="breaks",
         ...     values_agg=_.sum(),
-        ... )
+        ... ).order_by("wool")
         ┏━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━┓
         ┃ wool   ┃ L     ┃ M     ┃ H     ┃
         ┡━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━┩


### PR DESCRIPTION
This PR fixes a test whose success seems to depend on the direction the wind is blowing. Sorting by the `wool` column should address this.