### PR TITLE
Update `list_tables` to account for database->schema hierarchy where applicable

### DIFF
--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -177,6 +177,37 @@ class Backend(BaseAlchemyBackend):
     def current_database(self) -> str:
         return self._scalar_query("SELECT * FROM global_name")
 
+    def list_tables(self, like=None, database=None, schema=None):
+        """List the tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables.
+        database
+            (deprecated) The database to perform the list against.
+        schema
+            The schema to perform the list against.
+
+            ::: {.callout-warning}
+            ## `schema` refers to database hierarchy
+
+            The `schema` parameter does **not** refer to the column names and
+            types of `table`.
+            :::
+        """
+        if database is not None:
+            util.warn_deprecated(
+                "database",
+                instead="Use the `schema` keyword argument instead",
+                as_of="7.1",
+                removed_in="8.0",
+            )
+        schema = schema or database
+        tables = self.inspector.get_table_names(schema=schema)
+        views = self.inspector.get_view_names(schema=schema)
+        return self._filter_with_like(tables + views, like)
+
     def _metadata(self, query: str) -> Iterable[tuple[str, dt.DataType]]:
         from sqlalchemy_views import CreateView, DropView
 

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -127,6 +127,37 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema):
 
         super().do_connect(engine)
 
+    def list_tables(self, like=None, database=None, schema=None):
+        """List the tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables.
+        database
+            (deprecated) The database to perform the list against.
+        schema
+            The schema to perform the list against.
+
+            ::: {.callout-warning}
+            ## `schema` refers to database hierarchy
+
+            The `schema` parameter does **not** refer to the column names and
+            types of `table`.
+            :::
+        """
+        if database is not None:
+            util.warn_deprecated(
+                "database",
+                instead="Use the `schema` keyword argument instead",
+                as_of="7.1",
+                removed_in="8.0",
+            )
+        schema = schema or database
+        tables = self.inspector.get_table_names(schema=schema)
+        views = self.inspector.get_view_names(schema=schema)
+        return self._filter_with_like(tables + views, like)
+
     def list_databases(self, like=None) -> list[str]:
         # http://dba.stackexchange.com/a/1304/58517
         dbs = sa.table(

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import sqlalchemy as sa
+import sqlglot as sg
 import toolz
 from trino.sqlalchemy.datatype import ROW as _ROW
 from trino.sqlalchemy.dialect import TrinoDialect
@@ -73,10 +74,46 @@ class Backend(AlchemyCrossSchemaBackend, AlchemyCanCreateSchema, CanListDatabase
         return self._scalar_query(sa.select(sa.literal_column("current_schema")))
 
     def list_tables(
-        self, like: str | None = None, database: str | None = None
+        self,
+        like: str | None = None,
+        database: str | None = None,
+        schema: str | None = None,
     ) -> list[str]:
+        """List the tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables.
+        database
+            The database (catalog) to perform the list against.
+        schema
+            The schema inside `database` to perform the list against.
+
+            ::: {.callout-warning}
+            ## `schema` refers to database hierarchy
+
+            The `schema` parameter does **not** refer to the column names and
+            types of `table`.
+            :::
+        """
         query = "SHOW TABLES"
 
+        if database is not None and schema is None:
+            util.warn_deprecated(
+                "database",
+                instead=(
+                    f"{self.name} cannot list tables only using `database` specifier. "
+                    "Include a `schema` argument."
+                ),
+                as_of="7.1",
+                removed_in="8.0",
+            )
+            database = sg.parse_one(database, into=sg.exp.Table).sql(dialect=self.name)
+        elif database is None and schema is not None:
+            database = sg.parse_one(schema, into=sg.exp.Table).sql(dialect=self.name)
+        else:
+            database = sg.table(schema, db=database).sql(dialect=self.name) or None
         if database is not None:
             query += f" IN {database}"
 

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -109,7 +109,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
         data_schema = self._tpch_data_schema
         database, schema = query_schema.split(".")
 
-        tables = con.list_tables(database=self._tpch_data_schema)
+        tables = con.list_tables(schema=self._tpch_data_schema)
         con.create_schema(schema, database=database, force=True)
 
         prefixes = {"partsupp": "ps"}


### PR DESCRIPTION
Ok, need to add tests for this, but the changes are a bit scattershot and I thought we can use this as a sounding-board for whether we want to go down this path.

The general idea here is:

1. Backends that only have a concept of `database` remain unchanged (`clickhouse`, `druid`, `impala`, `mysql`, `pyspark`, `sqlite`)
2. Backends that allow you to _interact_ with tables in other database -> schema hierarchies now have a `schema` kwarg in `list_tables` to allow fine-grained specification (formalized in `bigquery`, added for `trino`, `mssql`, and `snowflake`, and already present in `duckdb`)
3. Backends that have this hierarchy but don't allow for cross-database operations have a kwarg change from `database` to `schema` -- this unifies the arguments of `list_tables` and `table` for these backends.


For `trino`, this is quite pleasing:

```python
[ins] In [1]: import ibis

[ins] In [2]: con = ibis.trino.connect(user="user", password="", host="localhost", port=8080, data
         ...: base="memory", schema="default")

[ins] In [3]: con.list_databases()
Out[3]: ['hive', 'jmx', 'memory', 'postgresql', 'system', 'tpcds', 'tpch']

[ins] In [4]: con.list_schemas(database="tpch")
Out[4]: 
['information_schema',
 'sf1',
 'sf100',
 'sf1000',
 'sf10000',
 'sf100000',
 'sf300',
 'sf3000',
 'sf30000',
 'tiny']

[ins] In [5]: con.list_tables(database="tpch", schema="sf1")
Out[5]: 
['customer',
 'lineitem',
 'nation',
 'orders',
 'part',
 'partsupp',
 'region',
 'supplier']
```

It also adds consistency for users who are operating on Oracle or Postgres and trying to connect to tables in another schema:

```python
[ins] In [1]: import ibis
co
[ins] In [2]: con = ibis.oracle.connect(user="ibis", password="ibis", host="localhost", port=1521,
         ...:  database="ibis_testing")

[ins] In [3]: con.list_tables()
Out[3]: 
['astronauts',
 'awards_players',
 'batting',
 'diamonds',
 'functional_alltypes',
 'win']

[ins] In [4]: con.list_tables(schema="SYS", like="EXU8OPT")
Out[4]: ['EXU8OPT']

[ins] In [5]: con.table("EXU8OPT", schema="SYS")
Out[5]: 
DatabaseTable: EXU8OPT
  PARAMETER string
  VALUE     decimal(38, 0)
```


Downsides are that there's a bunch of fragmentation in the individual `list_tables` methods.
Probably can encapsulate some of this in one of the intermediate classes like `AlchemyCanCreateSchema`

xref #7329 