### PR TITLE
fix(trino): enable passing the `database` argument when accessing tables

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -42,6 +42,18 @@ _IBIS_TO_SQLGLOT_DIALECT = {
 }
 
 
+_SQLALCHEMY_TO_SQLGLOT_DIALECT = {
+    # sqlalchemy dialects of backends not listed here match the sqlglot dialect
+    # name
+    "mssql": "tsql",
+    "postgresql": "postgres",
+    "default": "duckdb",
+    # druid allows double quotes for identifiers, like postgres:
+    # https://druid.apache.org/docs/latest/querying/sql#identifiers-and-literals
+    "druid": "postgres",
+}
+
+
 class Database:
     """Generic Database class."""
 

--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -90,7 +90,9 @@ class BaseSQLBackend(BaseBackend):
             )
         qualified_name = self._fully_qualified_name(name, database)
         schema = self.get_schema(qualified_name)
-        node = ops.DatabaseTable(name, schema, self, namespace=database)
+        node = ops.DatabaseTable(
+            name, schema, self, namespace=ops.Namespace(database=database)
+        )
         return node.to_expr()
 
     def _fully_qualified_name(self, name, database):

--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -114,9 +114,13 @@ class TableSetFormatter:
             if (name := op.name) is None:
                 raise com.RelationError(f"Table did not have a name: {op!r}")
 
+            namespace = getattr(op, "namespace", None)
+            catalog = getattr(namespace, "database", None)
+            db = getattr(namespace, "schema", None)
             result = sg.table(
                 name,
-                db=getattr(op, "namespace", None),
+                db=db,
+                catalog=catalog,
                 quoted=self.parent.translator_class._quote_identifiers,
             ).sql(dialect=self.parent.translator_class._dialect_name)
         elif ctx.is_extracted(op):

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -431,7 +431,10 @@ class Backend(BaseBackend, CanCreateDatabase):
         """
         schema = self.get_schema(name, database=database)
         op = ops.DatabaseTable(
-            name=name, schema=schema, source=self, namespace=database
+            name=name,
+            schema=schema,
+            source=self,
+            namespace=ops.Namespace(database=database),
         )
         return op.to_expr()
 

--- a/ibis/backends/clickhouse/compiler/relations.py
+++ b/ibis/backends/clickhouse/compiler/relations.py
@@ -28,7 +28,7 @@ def _physical_table(op: ops.PhysicalTable, **_):
 
 @translate_rel.register
 def _database_table(op: ops.DatabaseTable, *, name, namespace, **_):
-    return sg.table(name, db=namespace)
+    return sg.table(name, db=namespace.schema, catalog=namespace.database)
 
 
 def replace_tables_with_star_selection(node, alias=None):

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -123,7 +123,7 @@ class Backend(BaseAlchemyBackend):
         return bool(connection.execute(query).scalar())
 
     def _get_sqla_table(
-        self, name: str, schema: str | None = None, autoload: bool = True, **kwargs: Any
+        self, name: str, autoload: bool = True, **kwargs: Any
     ) -> sa.Table:
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -136,6 +136,4 @@ class Backend(BaseAlchemyBackend):
                 ),
                 category=sa.exc.SAWarning,
             )
-            return super()._get_sqla_table(
-                name, schema=schema, autoload=autoload, **kwargs
-            )
+            return super()._get_sqla_table(name, autoload=autoload, **kwargs)

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -191,7 +191,10 @@ class Backend(BaseBackend, CanCreateDatabase):
         _, quoted, unquoted = fully_qualified_re.search(qualified_name).groups()
         unqualified_name = quoted or unquoted
         node = ops.DatabaseTable(
-            unqualified_name, schema, self, namespace=database
+            unqualified_name,
+            schema,
+            self,
+            namespace=ops.Namespace(schema=database, database=catalog),
         )  # TODO(chloeh13q): look into namespacing with catalog + db
         return node.to_expr()
 

--- a/ibis/backends/impala/client.py
+++ b/ibis/backends/impala/client.py
@@ -185,7 +185,7 @@ class ImpalaTable(ir.Table):
     @property
     def _qualified_name(self) -> str:
         op = self.op()
-        return sg.table(op.name, db=op.namespace).sql(dialect="hive")
+        return sg.table(op.name, catalog=op.namespace.database).sql(dialect="hive")
 
     @property
     def _unqualified_name(self) -> str:

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -276,7 +276,9 @@ class Backend(BaseSQLBackend, CanCreateDatabase):
         qualified_name = self._fully_qualified_name(name, database)
 
         schema = self.get_schema(qualified_name)
-        node = ops.DatabaseTable(name, schema, self, namespace=database)
+        node = ops.DatabaseTable(
+            name, schema, self, namespace=ops.Namespace(database=database)
+        )
         return PySparkTable(node)
 
     def create_database(

--- a/ibis/backends/pyspark/client.py
+++ b/ibis/backends/pyspark/client.py
@@ -19,7 +19,9 @@ class PySparkTable(ir.Table):
     @property
     def _qualified_name(self) -> str:
         op = self.op()
-        return sg.table(op.name, db=op.namespace, quoted=True).sql(dialect="spark")
+        return sg.table(
+            op.name, db=op.namespace.schema, catalog=op.namespace.database, quoted=True
+        ).sql(dialect="spark")
 
     @property
     def _database(self) -> str:

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -6,6 +6,7 @@ import string
 import pytest
 
 import ibis
+import ibis.common.exceptions as exc
 from ibis import udf, util
 from ibis.backends.trino.tests.conftest import (
     TRINO_HOST,
@@ -161,3 +162,14 @@ def test_table_access_from_connection_without_catalog_or_schema():
     assert con.current_schema is None
 
     assert t.count().execute()
+
+
+def test_table_access_database_schema(con):
+    t = con.table("region", schema="sf1", database="tpch")
+    assert t.count().execute()
+
+    with pytest.raises(exc.IbisError, match="Cannot specify both"):
+        con.table("region", schema="tpch.sf1", database="tpch")
+
+    with pytest.raises(exc.IbisError, match="Cannot specify both"):
+        con.table("region", schema="tpch.sf1", database="system")

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -16,7 +16,7 @@ from ibis import util
 from ibis.common.annotations import annotated, attribute
 from ibis.common.collections import FrozenDict  # noqa: TCH001
 from ibis.common.deferred import Deferred
-from ibis.common.grounds import Immutable
+from ibis.common.grounds import Concrete, Immutable
 from ibis.common.patterns import Between, Coercible, Eq
 from ibis.common.typing import VarTuple  # noqa: TCH001
 from ibis.expr.operations.core import Column, Named, Node, Scalar, Value
@@ -70,6 +70,12 @@ TableNode = Relation
 
 
 @public
+class Namespace(Concrete):
+    database: Optional[str] = None
+    schema: Optional[str] = None
+
+
+@public
 class PhysicalTable(Relation, Named):
     pass
 
@@ -80,11 +86,12 @@ class PhysicalTable(Relation, Named):
 class UnboundTable(PhysicalTable):
     schema: Schema
     name: Optional[str] = None
+    namespace: Namespace = Namespace()
 
-    def __init__(self, schema, name) -> None:
+    def __init__(self, schema, name, namespace) -> None:
         if name is None:
             name = genname()
-        super().__init__(schema=schema, name=name)
+        super().__init__(schema=schema, name=name, namespace=namespace)
 
 
 @public
@@ -92,7 +99,7 @@ class DatabaseTable(PhysicalTable):
     name: str
     schema: Schema
     source: Any
-    namespace: Optional[str] = None
+    namespace: Namespace = Namespace()
 
 
 @public

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -130,7 +130,7 @@ class MockAlchemyBackend(MockBackend):
         pytest.importorskip("sqlalchemy")
         self.tables = {}
 
-    def table(self, name, database=None):
+    def table(self, name, **_):
         schema = self.get_schema(name)
         return self._inject_table(name, schema)
 
@@ -139,7 +139,7 @@ class MockAlchemyBackend(MockBackend):
             self.tables[name] = table_from_schema(name, sa.MetaData(), schema)
         return ops.DatabaseTable(source=self, name=name, schema=schema).to_expr()
 
-    def _get_sqla_table(self, name, schema=None, **kwargs):
+    def _get_sqla_table(self, name, **_):
         return self.tables[name]
 
 


### PR DESCRIPTION
Add a `Namespace` object for dealing with database hierarchies in the cross-schema backends. Fixes #7398.