### PR TITLE
feat(datafusion): add TimestampTruncate / fix broken extract time part functions

### DIFF
--- a/ibis/backends/datafusion/registry.py
+++ b/ibis/backends/datafusion/registry.py
@@ -50,6 +50,14 @@ def extract_millisecond(array: pa.Array) -> pa.Array:
     return pc.cast(pc.millisecond(array), pa.int32())
 
 
+def extract_hour(array: pa.Array) -> pa.Array:
+    return pc.cast(pc.hour(array), pa.int32())
+
+
+def extract_minute(array: pa.Array) -> pa.Array:
+    return pc.cast(pc.minute(array), pa.int32())
+
+
 UDFS = {
     "extract_microseconds_time": create_udf(
         ops.ExtractMicrosecond,
@@ -110,5 +118,14 @@ UDFS = {
         extract_millisecond,
         input_types=[dt.timestamp],
         name="extract_millisecond_timestamp",
+    ),
+    "extract_hour_time": create_udf(
+        ops.ExtractHour, extract_hour, input_types=[dt.time], name="extract_hour_time"
+    ),
+    "extract_minute_time": create_udf(
+        ops.ExtractMinute,
+        extract_minute,
+        input_types=[dt.time],
+        name="extract_minute_time",
     ),
 }

--- a/ibis/backends/datafusion/tests/test_temporal.py
+++ b/ibis/backends/datafusion/tests/test_temporal.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from operator import methodcaller
+
+import pytest
+from pytest import param
+
+import ibis
+
+
+@pytest.mark.parametrize(
+    ("func", "expected"),
+    [
+        param(
+            methodcaller("hour"),
+            14,
+            id="hour",
+        ),
+        param(
+            methodcaller("minute"),
+            48,
+            id="minute",
+        ),
+        param(
+            methodcaller("second"),
+            5,
+            id="second",
+        ),
+        param(
+            methodcaller("millisecond"),
+            359,
+            id="millisecond",
+        ),
+    ],
+)
+def test_time_extract_literal(con, func, expected):
+    value = ibis.time("14:48:05.359")
+    assert con.execute(func(value).name("tmp")) == expected

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -433,7 +433,14 @@ PANDAS_UNITS = {
             "ms",
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse", "impala", "mysql", "pyspark", "sqlite"],
+                    [
+                        "clickhouse",
+                        "impala",
+                        "mysql",
+                        "pyspark",
+                        "sqlite",
+                        "datafusion",
+                    ],
                     raises=com.UnsupportedOperationError,
                 ),
                 pytest.mark.broken(
@@ -447,7 +454,15 @@ PANDAS_UNITS = {
             "us",
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse", "impala", "mysql", "pyspark", "sqlite", "trino"],
+                    [
+                        "clickhouse",
+                        "impala",
+                        "mysql",
+                        "pyspark",
+                        "sqlite",
+                        "trino",
+                        "datafusion",
+                    ],
                     raises=com.UnsupportedOperationError,
                 ),
                 pytest.mark.broken(
@@ -473,6 +488,7 @@ PANDAS_UNITS = {
                         "snowflake",
                         "trino",
                         "mssql",
+                        "datafusion",
                     ],
                     raises=com.UnsupportedOperationError,
                 ),
@@ -485,7 +501,7 @@ PANDAS_UNITS = {
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "oracle"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["oracle"], raises=com.OperationNotDefinedError)
 @pytest.mark.broken(
     ["druid"],
     raises=AttributeError,


### PR DESCRIPTION
This PR adds:
- TimestampTruncate for the defined precisions in DataFusion
- The missing missing tests suggested in [here](https://github.com/ibis-project/ibis/pull/7320#discussion_r1354650753), and also the corresponding bug fixes. 