### PR TITLE
docs: setup codespace configuration for `getting_started.qmd` tutorial

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "image": "mcr.microsoft.com/vscode/devcontainers/python:3.11",
+  "updateContentCommand": ".devcontainer/updateContent.sh",
+  "customizations": {
+    "codespaces": {
+      "openFiles": ["docs/tutorials/getting_started.qmd"]
+    },
+    "vscode": {
+      "extensions": ["ms-toolsai.jupyter", "ms-python.python", "quarto.quarto"]
+    }
+  },
+  "features": {
+    "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
+      "version": "1.4.339"
+    }
+  }
+}

--- a/.devcontainer/updateContent.sh
+++ b/.devcontainer/updateContent.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# install ibis
+python3 -m pip install ipython
+python3 -m pip install -e '.[duckdb]'


### PR DESCRIPTION
Add a codespace devcontainer setup for the ibis `getting_started.qmd` tutorial.

I've enabled codespace prebuilds for the ibis repo, so once this is merged to `master` the images will be built and ready for use.

Going forward I would like to keep this codespace configuration extremely minimal: it should contain enough setup to be able to run the `getting_started.qmd` with the VSCode Jupyter extension, nothing more, nothing less.

Things like developer tooling, vim extensions and other customizations should IMO remain out-of-scope. This codespace is focused solely on giving people an environment they can use to try ibis out.

For posterity:

- https://containers.dev/features is where I found the feature for automatically installing the quarto CLI
- I was able to use one of the alpine base images, but I didn't feel like dealing with potential missing musllinux dependencies down the line and the image is only about 2x smaller and it doesn't come with Python installed, so I opted to stick with the python container.