### PR TITLE
test(trino): use `tpch.tiny` for faster testing of tpch queries

### DIFF
--- a/ibis/backends/tests/tpch/conftest.py
+++ b/ibis/backends/tests/tpch/conftest.py
@@ -59,7 +59,10 @@ def tpch_test(test: Callable[..., ir.Table]):
         result_expr = test(*args, **kwargs)
 
         result = result_expr.execute()
+        assert not result.empty
+
         expected = expected_expr.execute()
+        assert not expected.empty
 
         assert list(map(str.lower, expected.columns)) == result.columns.tolist()
         expected.columns = result.columns

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -40,7 +40,7 @@ class TestConf(BackendTest, RoundAwayFromZero):
     supports_tpch = True
     deps = ("sqlalchemy", "trino.sqlalchemy")
 
-    _tpch_data_schema = "tpch.sf1"
+    _tpch_data_schema = "tpch.tiny"
     _tpch_query_schema = "hive.ibis_sf1"
 
     def preload(self):


### PR DESCRIPTION
This is a little under 3x faster on my machine.