### PR TITLE
feat(duckdb): add support for specific timestamp scales

### DIFF
--- a/ibis/backends/base/sqlglot/datatypes.py
+++ b/ibis/backends/base/sqlglot/datatypes.py
@@ -352,6 +352,26 @@ class DuckDBType(SqlglotType):
     default_decimal_scale = 3
     default_interval_precision = "us"
 
+    @classmethod
+    def _from_sqlglot_TIMESTAMP(cls) -> dt.Timestamp:
+        return dt.Timestamp(scale=6, nullable=cls.default_nullable)
+
+    @classmethod
+    def _from_sqlglot_TIMESTAMPTZ(cls) -> dt.Timestamp:
+        return dt.Timestamp(scale=6, timezone="UTC", nullable=cls.default_nullable)
+
+    @classmethod
+    def _from_sqlglot_TIMESTAMP_S(cls) -> dt.Timestamp:
+        return dt.Timestamp(scale=0, nullable=cls.default_nullable)
+
+    @classmethod
+    def _from_sqlglot_TIMESTAMP_MS(cls) -> dt.Timestamp:
+        return dt.Timestamp(scale=3, nullable=cls.default_nullable)
+
+    @classmethod
+    def _from_sqlglot_TIMESTAMP_NS(cls) -> dt.Timestamp:
+        return dt.Timestamp(scale=9, nullable=cls.default_nullable)
+
 
 class TrinoType(SqlglotType):
     dialect = "trino"

--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -29,8 +29,8 @@ from ibis.backends.duckdb.datatypes import DuckDBType
             ("SMALLINT", dt.int16),
             ("TIME", dt.time),
             ("TIME WITH TIME ZONE", dt.time),
-            ("TIMESTAMP", dt.timestamp),
-            ("TIMESTAMP WITH TIME ZONE", dt.Timestamp("UTC")),
+            ("TIMESTAMP", dt.Timestamp(scale=6)),
+            ("TIMESTAMP WITH TIME ZONE", dt.Timestamp(scale=6, timezone="UTC")),
             ("TINYINT", dt.int8),
             ("UBIGINT", dt.uint64),
             ("UINTEGER", dt.uint32),
@@ -53,6 +53,9 @@ from ibis.backends.duckdb.datatypes import DuckDBType
             ("INTEGER[][]", dt.Array(dt.Array(dt.int32))),
             ("JSON", dt.json),
             ("HUGEINT", dt.Decimal(38, 0)),
+            ("TIMESTAMP_S", dt.Timestamp(scale=0)),
+            ("TIMESTAMP_MS", dt.Timestamp(scale=3)),
+            ("TIMESTAMP_NS", dt.Timestamp(scale=9)),
         ]
     ],
 )


### PR DESCRIPTION
Add support for seconds, milliseconds, microseconds (the default) and nanoseconds scales in timestamp types.

Closes #7412.