### PR TITLE
fix(sqlalchemy): ensure that limit on `.sql` calls works

### DIFF
--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -365,7 +365,10 @@ class AlchemySelect(Select):
             )
 
         if n is not None:
-            fragment = fragment.limit(n)
+            try:
+                fragment = fragment.limit(n)
+            except AttributeError:
+                fragment = fragment.subquery().select().limit(n)
 
         offset = self.limit.offset
 

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -306,3 +306,12 @@ def test_order_by_no_projection(backend):
 
     result = con.sql(ibis.to_sql(expr)).execute().name.iloc[:2]
     assert set(result) == {"Ross, Jerry L.", "Chang-Diaz, Franklin R."}
+
+
+@dot_sql_notimpl
+@dot_sql_notyet
+@dot_sql_never
+@pytest.mark.notyet(["polars"], raises=PolarsComputeError)
+def test_dot_sql_limit(con):
+    expr = con.sql("SELECT 'abc' ts").limit(1)
+    assert expr.execute().equals(pd.DataFrame({"ts": ["abc"]}))


### PR DESCRIPTION
Turns out that sqlalchemy does not allow most tabular operations on textual selects without a prior `.select()` call.

Fixes #7415.
