### PR TITLE
chore(snowflake): remove now-implemented `TimestampBucket` operation

### DIFF
--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -504,7 +504,6 @@ _invalid_operations = {
     # ibis.expr.operations.temporal
     ops.IntervalFromInteger,
     ops.TimestampDiff,
-    ops.TimestampBucket,
 }
 
 operation_registry = {


### PR DESCRIPTION
- chore(snowflake): remove now-implemented `TimestampBucket` operation
