### PR TITLE
fix(repr): add dispatch for repr of GeoSpatialBinOps

### DIFF
--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -346,3 +346,10 @@ def _scalar_parameter(op, dtype, **kwargs):
 @fmt.register(ops.SortKey)
 def _sort_key(op, expr, **kwargs):
     return f"{'asc' if op.ascending else 'desc'} {expr}"
+
+
+@fmt.register(ops.GeoSpatialBinOp)
+def _geo_bin_op(op, left, right, **kwargs):
+    fields = [left, right, inline_args(kwargs)]
+    args = ", ".join(f"{field}" for field in fields if field)
+    return f"{op.__class__.__name__}({args})"

--- a/ibis/tests/expr/test_geospatial.py
+++ b/ibis/tests/expr/test_geospatial.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+import ibis
+
+
+@pytest.fixture
+def geo_table():
+    return ibis.table({"geo1": "geometry", "geo2": "geometry"}, name="t")
+
+
+def test_geospatial_unary_op_repr(geo_table):
+    expr = geo_table.geo1.centroid()
+    assert expr.op().name in repr(expr)
+
+
+def test_geospatial_bin_op_repr(geo_table):
+    expr = geo_table.geo1.d_within(geo_table.geo2, 3.0)
+    assert expr.op().name in repr(expr)
+    assert "distance=" in repr(expr)
+
+
+def test_geospatial_bin_op_repr_no_kwarg(geo_table):
+    expr = geo_table.geo1.distance(geo_table.geo2)
+    assert expr.op().name in repr(expr)
+    assert "distance=" not in repr(expr)
+    # test that there isn't a trailing comma from empty kwargs
+    assert repr(expr).endswith("r0.geo2)")


### PR DESCRIPTION
The `GeoUnaryOp`s are already handled by the rules for the parent
classes, but the `GeoSpatialBinOps` break because they often have an
additional keyword (`distance`) passed in that doesn't get handled by
the existing rule for binary operations.

xref #7427