### PR TITLE
fix(ir): coerce integers passed to `Value[dt.Floating]` annotated values as `dt.float64`

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -499,11 +499,6 @@ class Bounds(NamedTuple):
 class Numeric(DataType):
     """Numeric types."""
 
-    @property
-    @abstractmethod
-    def largest(self) -> DataType:
-        """Return the largest type in this family."""
-
 
 @public
 class Integer(Primitive, Numeric):
@@ -631,11 +626,6 @@ class SignedInteger(Integer):
     """Signed integer values."""
 
     @property
-    def largest(self):
-        """Return the largest type of signed integer."""
-        return int64
-
-    @property
     def bounds(self):
         exp = self.nbytes * 8 - 1
         upper = (1 << exp) - 1
@@ -645,11 +635,6 @@ class SignedInteger(Integer):
 @public
 class UnsignedInteger(Integer):
     """Unsigned integer values."""
-
-    @property
-    def largest(self):
-        """Return the largest type of unsigned integer."""
-        return uint64
 
     @property
     def bounds(self):
@@ -666,14 +651,9 @@ class Floating(Primitive, Numeric):
     column = "FloatingColumn"
 
     @property
-    def largest(self):
-        """Return the largest type of floating point values."""
-        return float64
-
-    @property
     @abstractmethod
     def nbytes(self) -> int:  # pragma: no cover
-        ...
+        """Return the number of bytes used to store values of this type."""
 
 
 @public
@@ -793,14 +773,6 @@ class Decimal(Numeric, Parametric):
                     f"scale. Got precision={precision:d} and scale={scale:d}"
                 )
         super().__init__(precision=precision, scale=scale, **kwargs)
-
-    @property
-    def largest(self):
-        """Return the largest type of decimal."""
-        return self.__class__(
-            precision=max(self.precision, 38) if self.precision is not None else None,
-            scale=max(self.scale, 2) if self.scale is not None else None,
-        )
 
     @property
     def _pretty_piece(self) -> str:

--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -75,11 +75,17 @@ class Value(Node, Named, Coercible, DefaultTypeVars, Generic[T, S]):
         if isinstance(value, Value):
             return value
 
-        try:
+        if T is dt.Integer:
+            dtype = dt.infer(int(value))
+        elif T is dt.Floating:
+            dtype = dt.infer(float(value))
+        else:
             try:
                 dtype = dt.DataType.from_typehint(T)
             except TypeError:
                 dtype = dt.infer(value)
+
+        try:
             return Literal(value, dtype=dtype)
         except TypeError:
             raise CoercionError(f"Unable to coerce {value!r} to Value[{T!r}]")

--- a/ibis/expr/operations/numeric.py
+++ b/ibis/expr/operations/numeric.py
@@ -180,14 +180,17 @@ class MathUnary(Unary):
 
     @attribute
     def dtype(self):
-        return dt.higher_precedence(self.arg.dtype, dt.double)
+        return dt.higher_precedence(self.arg.dtype, dt.float64)
 
 
 @public
 class ExpandingMathUnary(MathUnary):
     @attribute
     def dtype(self):
-        return dt.higher_precedence(self.arg.dtype.largest, dt.double)
+        if self.arg.dtype.is_decimal():
+            return self.arg.dtype
+        else:
+            return dt.float64
 
 
 @public

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -154,10 +154,25 @@ class Sum(Filterable, Reduction):
 
     @attribute
     def dtype(self):
-        if self.arg.dtype.is_boolean():
+        dtype = self.arg.dtype
+        if dtype.is_boolean():
             return dt.int64
+        elif dtype.is_integer():
+            return dt.int64
+        elif dtype.is_unsigned_integer():
+            return dt.uint64
+        elif dtype.is_floating():
+            return dt.float64
+        elif dtype.is_decimal():
+            return dt.Decimal(
+                precision=max(dtype.precision, 38)
+                if dtype.precision is not None
+                else None,
+                scale=max(dtype.scale, 2) if dtype.scale is not None else None,
+            )
+
         else:
-            return self.arg.dtype.largest
+            raise TypeError(f"Cannot compute sum of {dtype} values")
 
 
 @public
@@ -204,8 +219,8 @@ class VarianceBase(Filterable, Reduction):
 
     @attribute
     def dtype(self):
-        if (dtype := self.arg.dtype).is_decimal():
-            return dtype.largest
+        if self.arg.dtype.is_decimal():
+            return self.arg.dtype
         else:
             return dt.float64
 


### PR DESCRIPTION
Add special coercion paths for non-concrete datatypes like `dt.Floating` and `dt.Integer`.

Resolves https://github.com/ibis-project/ibis/issues/7427