### PR TITLE
test(datafusion): enable compile benchmarks for datafusion after move to sqlglot

### DIFF
--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -159,7 +159,7 @@ _backends = set(_get_backend_names())
 # compile is a no-op
 _backends.remove("pandas")
 
-_XFAIL_COMPILE_BACKENDS = {"dask", "datafusion", "pyspark", "polars"}
+_XFAIL_COMPILE_BACKENDS = {"dask", "pyspark", "polars"}
 
 
 @pytest.mark.benchmark(group="compilation")


### PR DESCRIPTION
[Benchmarks for compiling unbound tables](https://github.com/ibis-project/ibis/actions/runs/6652773664/job/18077408762) are now failing (with `XPASS`, yay!) after moving DataFusion to sqlglot. This PR fixes that.