### PR TITLE
docs: fix dask compile docstring typo

### DIFF
--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -104,7 +104,7 @@ class Backend(BasePandasBackend):
 
         Returns
         -------
-        dask.dataframe.core.DataFrame | dask.dataframe.core.Series | das.dataframe.core.Scalar
+        dask.dataframe.core.DataFrame | dask.dataframe.core.Series | dask.dataframe.core.Scalar
             Dask graph.
         """
         params = {


### PR DESCRIPTION
I was looking at the docs and noticed a small typo with the return type specification for Dask Scalar objects. 

I'm not sure if [codespell](https://github.com/codespell-project/codespell) would have caught this one. ✍️ 

