### PR TITLE
feat(pandas, dask): add read_csv and read_parquet

### DIFF
--- a/docs/backends/_utils.py
+++ b/docs/backends/_utils.py
@@ -16,7 +16,10 @@ def get_renderer(level: int) -> MdRenderer:
 
 @cache
 def get_backend(backend: str):
-    return get_object(f"ibis.backends.{backend}", "Backend")
+    if backend == "pandas":
+        return get_object(f"ibis.backends.{backend}", "BasePandasBackend")
+    else:
+        return get_object(f"ibis.backends.{backend}", "Backend")
 
 
 def get_callable(obj, name):

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -433,7 +433,6 @@ def ft_data(data_dir):
 @pytest.mark.notyet(
     [
         "bigquery",
-        "dask",
         "impala",
         "mssql",
         "mysql",
@@ -462,7 +461,6 @@ def test_read_parquet_glob(con, tmp_path, ft_data):
 @pytest.mark.notyet(
     [
         "bigquery",
-        "dask",
         "impala",
         "mssql",
         "mysql",

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -393,11 +393,9 @@ def test_register_garbage(con, monkeypatch):
 @pytest.mark.notyet(
     [
         "bigquery",
-        "dask",
         "impala",
         "mssql",
         "mysql",
-        "pandas",
         "postgres",
         "sqlite",
         "trino",
@@ -554,11 +552,9 @@ DIAMONDS_COLUMN_TYPES = {
 @pytest.mark.notyet(
     [
         "bigquery",
-        "dask",
         "impala",
         "mssql",
         "mysql",
-        "pandas",
         "postgres",
         "sqlite",
         "trino",


### PR DESCRIPTION
This adds `read_csv` and `read_parquet` methods to the Pandas and Dask backends.