### PR TITLE
test(flink): use remote flink cluster for testing

### DIFF
--- a/ibis/backends/flink/tests/conftest.py
+++ b/ibis/backends/flink/tests/conftest.py
@@ -19,11 +19,44 @@ class TestConf(BackendTest, RoundAwayFromZero):
         comply with the assumption that the tests under ibis/ibis/backends/tests/
         are for batch (storage or processing) backends.
         """
-        from pyflink.table import EnvironmentSettings, TableEnvironment
+        import os
 
-        env_settings = EnvironmentSettings.in_batch_mode()
-        table_env = TableEnvironment.create(env_settings)
-        return ibis.flink.connect(table_env, **kw)
+        from pyflink.java_gateway import get_gateway
+        from pyflink.table import (
+            EnvironmentSettings,
+            StreamTableEnvironment,
+            TableEnvironment,
+        )
+        from pyflink.table.table_environment import StreamExecutionEnvironment
+
+        if not bool(os.environ.get("FLINK_REMOTE_CLUSTER", False)):
+            env_settings = EnvironmentSettings.in_batch_mode()
+            table_env = TableEnvironment.create(env_settings)
+            return ibis.flink.connect(table_env, **kw)
+        else:
+            gateway = get_gateway()
+            string_class = gateway.jvm.String
+            string_array = gateway.new_array(string_class, 0)
+            env_settings = (
+                gateway.jvm.org.apache.flink.table.api.EnvironmentSettings.inBatchMode()
+            )
+            stream_env = gateway.jvm.org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
+            flink_cluster_addr = os.environ.get(
+                "FLINK_REMOTE_CLUSTER_ADDR", "localhost"
+            )
+            flink_cluster_port = int(
+                os.environ.get("FLINK_REMOTE_CLUSTER_PORT", "8081")
+            )
+            j_stream_exection_environment = stream_env.createRemoteEnvironment(
+                flink_cluster_addr,
+                flink_cluster_port,
+                env_settings.getConfiguration(),
+                string_array,
+            )
+
+            env = StreamExecutionEnvironment(j_stream_exection_environment)
+            stream_table_env = StreamTableEnvironment.create(env)
+            return ibis.flink.connect(stream_table_env, **kw)
 
     def _load_data(self, **_: Any) -> None:
         import pandas as pd
@@ -42,6 +75,7 @@ class TestConfForStreaming(TestConf):
     def connect(*, tmpdir, worker_id, **kw: Any):
         """Flink backend is created in streaming mode here. To be used
         in the tests under ibis/ibis/backends/flink/tests/.
+        We only use mini cluster here for simplicity.
         """
         from pyflink.table import EnvironmentSettings, TableEnvironment
 


### PR DESCRIPTION
We are experiencing slow Flink tests (~2 hours in ci testing). The main reason is PyFlink leverages [MiniCluster](https://github.com/apache/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java#L151) to execute Flink job. By default, it will start & stop a MiniCluster for [each](https://github.com/apache/flink/blob/master/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java#L84) job, which greatly slows down the execution speed if we have a lot tests.
There are two options to improve this:
1) Implement a new Executor which reuses MiniCluster for different jobs, and load this Executor in Flink to override the default one. However this approach is troublesome to implement.
2) connect an existed remote Flink cluster and run all tests there. This approach is much simpler and I'm using this approach in this PR. However PyFlink doesn't provide a direct API to connect with remote cluster, I have to directly call Flink Java API via Py4j.

In this PR, I check an environment value 'FLINK_REMOTE_CLUSTER' to decide whether we will run tests on local mini cluster or remote cluster, therefore it won't impact the existed ci pipeline. If we want to enable the Flink remote cluster for testing, there are some prerequisites:

1) Set up a Flink cluster

-  we can set up a local Flink cluster or using a remote one. But we need to include `flink-python-1.17.1.jar` in the Flink runtime path, because ibis depends on PyFlink to execute.
<img width="1441" alt="image" src="https://github.com/ibis-project/ibis/assets/8586065/59f97bf5-8f40-48bc-b1b2-25b7e9480175">

- well tuned TaskManager's memory to perform the tests. In my local environment, I set these key params in `flink-conf.yaml`:

```
taskmanager.memory.network.fraction: 0.4
taskmanager.memory.network.min: 512mb
taskmanager.memory.network.max: 2gb
```

2) Set up environment variables in test runner's environment.
```
export FLINK_REMOTE_CLUSTER=true
export FLINK_REMOTE_CLUSTER_ADDR=localhost
export FLINK_REMOTE_CLUSTER_PORT=8081
```