### PR TITLE
test(flink): deep dive on the tests marked for Flink in test_client.py

### DIFF
--- a/ibis/backends/flink/tests/conftest.py
+++ b/ibis/backends/flink/tests/conftest.py
@@ -53,10 +53,10 @@ class TestConf(BackendTest):
 
         for table_name in TEST_TABLES:
             path = self.data_dir / "parquet" / f"{table_name}.parquet"
-            self.connection.create_table(table_name, pd.read_parquet(path))
+            self.connection.create_table(table_name, pd.read_parquet(path), temp=True)
 
-        self.connection.create_table("json_t", json_types)
-        self.connection.create_table("struct", struct_types)
+        self.connection.create_table("json_t", json_types, temp=True)
+        self.connection.create_table("struct", struct_types, temp=True)
 
 
 class TestConfForStreaming(TestConf):
@@ -110,3 +110,28 @@ def db(con):
 @pytest.fixture(scope="session")
 def alltypes(con):
     return con.tables.functional_alltypes
+
+
+@pytest.fixture
+def temp_view(con) -> str:
+    """Return a temporary view name.
+
+    Parameters
+    ----------
+    con : backend connection
+
+    Yields
+    ------
+    name : string
+        Random view name for a temporary usage.
+
+    Note (mehmet): Added this here because the fixture
+    ibis/ibis/backends/conftest.py::temp_view()
+    leads to docker related errors through its parameter `ddl_con`.
+    """
+    from ibis import util
+
+    name = util.gen_name("view")
+    yield name
+
+    con.drop_view(name, force=True)

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -329,14 +329,13 @@ def test_map_get_with_null_on_null_type_with_non_null(con):
 
 @pytest.mark.notimpl(
     ["flink"],
-    raises=exc.UnsupportedBackendType,
-    reason="UnsupportedBackendType: map",
+    raises=exc.IbisError,
+    reason="`tbl_properties` is required when creating table with schema",
 )
 def test_map_create_table(con, temp_table):
     t = con.create_table(
         temp_table,
         schema=ibis.schema(dict(xyz="map<string, string>")),
-        **{"tbl_properties": {"connector": None}} if con.name == "flink" else {},
     )
     assert t.schema()["xyz"].is_map()
 


### PR DESCRIPTION
[Previously](https://github.com/ibis-project/ibis/pull/6920), we made a pass over the tests under `ibis/ibis/backends/tests/` and marked them if they fail for the Flink backend. We are now making the second pass over these tests, and looking deeper into those marked previously. This PR contains the changes for the deep dive on `test_client.py`.

**Edit**: The scope of this PR got extended during the review process and after the merging with https://github.com/ibis-project/ibis/pull/7650. Now contains the following major changes:
- Adds support for creating `temporary view` for in-memory `obj` in `create_table()` and `create_view()`.
  - Raises error when the user-set `temp` argument does not match the supported behavior.
- Adds `rename_table()` for Flink backend.
- Adds unit tests that were previously missing for `create_table/view()` etc.
- Corrects some of the tests with `ibis.memtable()` by setting the backend using monkeypatch.