### PR TITLE
test(flink): revise WIP marks in aggregation tests

### DIFF
--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -67,6 +67,7 @@ aggregate_test_params = [
                     "trino",
                     "druid",
                     "oracle",
+                    "flink",
                 ],
                 raises=com.OperationNotDefinedError,
             ),
@@ -75,7 +76,6 @@ aggregate_test_params = [
                 reason="no udf support",
                 raises=com.OperationNotDefinedError,
             ),
-            pytest.mark.notimpl(["flink"], "WIP", raises=com.OperationNotDefinedError),
         ],
     ),
     param(lambda t: t.double_col.min(), lambda t: t.double_col.min(), id="min"),
@@ -98,10 +98,10 @@ aggregate_test_params = [
                     "trino",
                     "druid",
                     "oracle",
+                    "flink",
                 ],
                 raises=com.OperationNotDefinedError,
             ),
-            pytest.mark.notimpl(["flink"], "WIP", raises=com.OperationNotDefinedError),
         ],
     ),
     param(
@@ -130,15 +130,13 @@ argidx_not_grouped_marks = [
     "mssql",
     "druid",
     "oracle",
+    "flink",
 ]
 argidx_grouped_marks = ["dask"] + argidx_not_grouped_marks
 
 
 def make_argidx_params(marks):
-    marks = [
-        pytest.mark.notyet(marks, raises=com.OperationNotDefinedError),
-        pytest.mark.notimpl(["flink"], "WIP", raises=com.OperationNotDefinedError),
-    ]
+    marks = pytest.mark.notyet(marks, raises=com.OperationNotDefinedError)
     return [
         param(
             lambda t: t.timestamp_col.argmin(t.id),


### PR DESCRIPTION
# Development notes

* `test_aggregation.py`
  * **notimpl** Backend doesn't support UDFs yet
  * **notyet** Backend doesn't support mode aggregation (maybe never?)
  * **notyet** Flink doesn't support `ORDER BY` clauses in `JSONARRAY_AGG`
    * I tried implementing `ops.ArgMin`/`ops.ArgMax` (modeled on BigQuery and other backends):
        ```diff
        diff --git a/ibis/backends/flink/registry.py b/ibis/backends/flink/registry.py
        index 19bd95b61..06a02ad5f 100644
        --- a/ibis/backends/flink/registry.py
        +++ b/ibis/backends/flink/registry.py
        @@ -1,6 +1,6 @@
         from __future__ import annotations
 
        -from typing import TYPE_CHECKING
        +from typing import TYPE_CHECKING, Literal
 
         import ibis.common.exceptions as com
         import ibis.expr.operations as ops
        @@ -17,6 +17,21 @@ if TYPE_CHECKING:
         operation_registry = base_operation_registry.copy()
 
 
        +def _arg_min_max(sort_dir: Literal["ASC", "DESC"]):
        +    def translate(translator: ExprTranslator, op: ops.Node) -> str:
        +        arg = translator.translate(op.arg)
        +        key = translator.translate(op.key)
        +
        +        if (where :=  op.where) is not None:
        +            condition = f" FILTER (WHERE {translator.translate(where)})"
        +        else:
        +            condition = ""
        +
        +        return f"JSON_VALUE(JSON_ARRAYAGG({arg}{condition} ORDER BY {key} {sort_dir}), '$[0]')"
        +
        +    return translate
        +
        +
         def _count_star(translator: ExprTranslator, op: ops.Node) -> str:
             if (where := op.where) is not None:
                 condition = f" FILTER (WHERE {translator.translate(where)})"
        @@ -389,6 +404,8 @@ operation_registry.update(
                 ops.Degrees: unary("degrees"),
                 ops.Radians: unary("radians"),
                 # Unary aggregates
        +        ops.ArgMin: _arg_min_max("ASC"),
        +        ops.ArgMax: _arg_min_max("DESC"),
                 ops.CountStar: _count_star,
                 # String operations
                 ops.StringLength: unary("char_length"),
        ```
        However, the `ORDER BY` clause seems to not have any effect. It may be relevant the note that [the proposed `ARRAY_AGG` implementation also doesn't support `ORDER BY`, despite Calcite supporting it](https://github.com/apache/flink/pull/23411).