### PR TITLE
fix(flink): re-implement `ops.ApproxCountDistinct`

### DIFF
--- a/ibis/backends/flink/registry.py
+++ b/ibis/backends/flink/registry.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
-from ibis.backends.base.sql.registry import fixed_arity, helpers, unary
+from ibis.backends.base.sql.registry import aggregate, fixed_arity, helpers, unary
 from ibis.backends.base.sql.registry import (
     operation_registry as base_operation_registry,
 )
@@ -389,6 +389,7 @@ operation_registry.update(
         ops.Degrees: unary("degrees"),
         ops.Radians: unary("radians"),
         # Unary aggregates
+        ops.ApproxCountDistinct: aggregate.reduction("approx_count_distinct"),
         ops.CountStar: _count_star,
         # String operations
         ops.StringLength: unary("char_length"),

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -533,7 +533,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             id="approx_nunique",
             marks=[
                 pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError),
-                pytest.mark.notimpl(["flink"], "WIP", raises=Py4JError),
             ],
         ),
         param(


### PR DESCRIPTION
Note that this won't work in streaming mode: `APPROX_COUNT_DISTINCT aggregate function does not support yet for streaming.`

However, it works in batch mode, which is also how the test suite is run. (There are also other things that don't work in streaming mode, such as unbounded ordering, that are already implemented in the backend/passing batch tests, so this isn't any different.)