### PR TITLE
docs(style): replace Black with Ruff in guidelines

### DIFF
--- a/docs/contribute/03_style.qmd
+++ b/docs/contribute/03_style.qmd
@@ -2,8 +2,7 @@
 
 ## Code style
 
-- [`black`](https://github.com/psf/black): Formatting Python code
-- [`ruff`](https://github.com/charliermarsh/ruff): Formatting and sorting `import` statements
+- [`ruff`](https://github.com/charliermarsh/ruff): Formatting Python code and sorting `import` statements
 - [`shellcheck`](https://github.com/koalaman/shellcheck): Linting shell scripts
 - [`shfmt`](https://github.com/mvdan/sh): Formatting shell scripts
 - [`statix`](https://github.com/nerdypepper/statix): Linting nix files


### PR DESCRIPTION
Must have missed it when I grepped for references to Black.