### PR TITLE
refactor: remove `show_sql` in favor of `print(to_sql)`

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -307,9 +307,6 @@ quartodoc:
             - name: case
               dynamic: true
               signature_name: full
-            - name: show_sql
-              dynamic: true
-              signature_name: full
             - name: to_sql
               dynamic: true
               signature_name: full

--- a/docs/how-to/timeseries/sessionize.qmd
+++ b/docs/how-to/timeseries/sessionize.qmd
@@ -74,6 +74,6 @@ sessionized = (
 )
 ```
 
-Calling `ibis.show_sql(sessionized)` displays the SQL query and can be used to confirm that this Ibis table expression does not rely on any join operations.
+Calling `print(ibis.to_sql(sessionized))` displays the SQL query and can be used to confirm that this Ibis table expression does not rely on any join operations.
 
 Calling `sessionized.to_pandas()` should complete in less than a minute, depending on the speed of the internet connection to download the data and the number of CPU cores available to parallelize the processing of this nested query.

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -355,7 +355,13 @@ Ibis supports a variety of input and output options.
 
 ### SQL + Python
 
-Ibis has the `ibis.to_sql` to generate SQL strings and `ibis.show_sql` display them. Ibis uses [SQLGlot](https://sqlglot.com) under the hood to allow passing a `dialect` parameter to SQL methods.
+Ibis has the `ibis.to_sql` to generate SQL strings.
+
+In a Jupyter notebook or IPython shell session, the output of `ibis.to_sql` will be syntax highlighted.
+
+In a plain Python REPL use `print(ibis.to_sql(...))` to pretty print SQL.
+
+Ibis uses [SQLGlot](https://sqlglot.com) under the hood to allow passing a `dialect` parameter to SQL methods.
 
 ::: {.panel-tabset}
 

--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -999,8 +999,8 @@ class BaseBackend(abc.ABC, _FileIOHandler):
     def _to_sql(self, expr: ir.Expr, **kwargs) -> str:
         """Convert an expression to a SQL string.
 
-        Called by `ibis.to_sql`/`ibis.show_sql`, gives the backend an
-        opportunity to generate nicer SQL for human consumption.
+        Called by `ibis.to_sql`; gives the backend an opportunity to generate
+        nicer SQL for human consumption.
         """
         raise NotImplementedError(f"Backend '{self.name}' backend doesn't support SQL")
 

--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -392,7 +392,6 @@ def test_count_name(snapshot):
         A=t.count(where=~t.b).fillna(0), B=t.count(where=t.b).fillna(0)
     )
 
-    ibis.show_sql(expr, dialect="clickhouse")
     snapshot.assert_match(str(ibis.to_sql(expr, dialect="clickhouse")), "out.sql")
 
 

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import io
-
 import pytest
 from pytest import param
 
@@ -14,25 +12,6 @@ sa = pytest.importorskip("sqlalchemy")
 sg = pytest.importorskip("sqlglot")
 
 pytestmark = pytest.mark.notimpl(["druid"])
-
-
-@pytest.mark.never(
-    ["dask", "pandas"],
-    reason="Dask and Pandas are not SQL backends",
-    raises=(NotImplementedError, ValueError),
-)
-@pytest.mark.notimpl(
-    ["datafusion", "pyspark", "polars"],
-    reason="Not clear how to extract SQL from the backend",
-    raises=(exc.OperationNotDefinedError, NotImplementedError, ValueError),
-)
-@pytest.mark.notimpl(["flink"], "WIP")
-def test_table(backend):
-    expr = backend.functional_alltypes.select(c=_.int_col + 1)
-    buf = io.StringIO()
-    ibis.show_sql(expr, file=buf)
-    assert buf.getvalue()
-
 
 simple_literal = param(ibis.literal(1), id="simple_literal")
 array_literal = param(

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -22,7 +22,7 @@ from ibis.common.grounds import Concrete
 from ibis.common.temporal import normalize_datetime, normalize_timezone
 from ibis.expr.decompile import decompile
 from ibis.expr.schema import Schema
-from ibis.expr.sql import parse_sql, show_sql, to_sql
+from ibis.expr.sql import parse_sql, to_sql
 from ibis.expr.types import (
     DateValue,
     Expr,
@@ -155,7 +155,6 @@ __all__ = (
     "Schema",
     "selectors",
     "set_backend",
-    "show_sql",
     "struct",
     "to_sql",
     "table",

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import operator
 from functools import singledispatch
-from typing import IO
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -288,45 +287,6 @@ def parse_sql(sqlstring, catalog, dialect=None):
     plan = sgp.Plan(tree)
 
     return convert(plan.root, catalog=catalog)
-
-
-@public
-def show_sql(
-    expr: ir.Expr,
-    dialect: str | None = None,
-    file: IO[str] | None = None,
-) -> None:
-    """Pretty-print the compiled SQL string of an expression.
-
-    If a dialect cannot be inferred and one was not passed, duckdb
-    will be used as the dialect
-
-    Parameters
-    ----------
-    expr
-        Ibis expression whose SQL will be printed
-    dialect
-        String dialect. This is typically not required, but can be useful if
-        ibis cannot infer the backend dialect.
-    file
-        File to write output to
-
-    Examples
-    --------
-    >>> import ibis
-    >>> from ibis import _
-    >>> t = ibis.table(dict(a="int"), name="t")
-    >>> expr = t.select(c=_.a * 2)
-    >>> ibis.show_sql(expr)  # duckdb dialect by default
-    SELECT
-      t0.a * CAST(2 AS TINYINT) AS c
-    FROM t AS t0
-    >>> ibis.show_sql(expr, dialect="mysql")
-    SELECT
-      t0.a * 2 AS c
-    FROM t AS t0
-    """
-    print(to_sql(expr, dialect=dialect), file=file)
 
 
 class SQLString(str):


### PR DESCRIPTION
Now that we syntax highlight the result of `to_sql` in IPython and Jupyter, we can decrease API surface a bit by removing `show_sql` in favor of `print(to_sql(...))` for folks that are not using IPython or Jupyter.