### PR TITLE
feat(polars): various Polars compiler enhancements

### DIFF
--- a/ibis/backends/polars/datatypes.py
+++ b/ibis/backends/polars/datatypes.py
@@ -41,7 +41,7 @@ def dtype_to_polars(dtype):
 
 @dtype_to_polars.register(dt.Decimal)
 def from_ibis_decimal(dtype):
-    return pl.Decimal(dtype.precision, dtype.scale)
+    return pl.Decimal(precision=dtype.precision, scale=dtype.scale)
 
 
 @dtype_to_polars.register(dt.Timestamp)

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -669,11 +669,6 @@ def uses_java_re(t):
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.broken(
-                    ["polars"],
-                    raises=AttributeError,
-                    reason="'NoneType' object has no attribute 'name'",
-                ),
-                pytest.mark.broken(
                     ["mssql"],
                     reason="substr requires 3 arguments",
                     raises=sa.exc.OperationalError,


### PR DESCRIPTION
A few improvements:

* Replace `map_elements` lambdas for Capitalize and Repeat with native expressions.
* Gracefully handles various upcoming deprecations (eg: `clip_min/max` → `clip`).
* Fixes start-only slice ("substr-start-only" test now passes).
* Streamlines usage of literal values (`_assert_literal` → `_literal_value`)
* Use explicit "scale" & "precision" param names with `pl.Decimal`, as we may make a breaking change to switch the order in the near-ish future (apparently we are the odd ones out at the moment ;)