### PR TITLE
feat(duckdb): allow users to register fsspec filesystem with DuckDB

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 
     import pandas as pd
     import torch
+    from fsspec import AbstractFileSystem
 
 
 def normalize_filenames(source_list):
@@ -848,6 +849,44 @@ WHERE catalog_name = :database"""
         with self.begin() as con:
             con.execute(sa.text(f"SET GLOBAL sqlite_all_varchar={all_varchar}"))
             con.execute(sa.text(f"CALL sqlite_attach('{path}', overwrite={overwrite})"))
+
+    def register_filesystem(self, filesystem: AbstractFileSystem):
+        """Register an `fsspec` filesystem object with DuckDB.
+
+        This allow a user to read from any `fsspec` compatible filesystem using
+        `read_csv`, `read_parquet`, `read_json`, etc.
+
+
+        ::: {.callout-note}
+        Creating an `fsspec` filesystem requires that the corresponding
+        backend-specific `fsspec` helper library is installed.
+
+        e.g. to connect to Google Cloud Storage, `gcsfs` must be installed.
+        :::
+
+        Parameters
+        ----------
+        filesystem
+            The fsspec filesystem object to register with DuckDB.
+            See https://duckdb.org/docs/guides/python/filesystems for details.
+
+        Examples
+        --------
+        >>> import ibis
+        >>> import fsspec
+        >>> gcs = fsspec.filesystem("gcs")
+        >>> con = ibis.duckdb.connect()
+        >>> con.register_filesystem(gcs)
+        >>> t = con.read_csv(
+        ...     "gcs://ibis-examples/data/band_members.csv.gz",
+        ...     table_name="band_members",
+        ... )
+        DatabaseTable: band_members
+          name string
+          band string
+        """
+        with self.begin() as con:
+            con.connection.register_filesystem(filesystem)
 
     def _run_pre_execute_hooks(self, expr: ir.Expr) -> None:
         # Warn for any tables depending on RecordBatchReaders that have already

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -350,3 +350,20 @@ def test_csv_with_slash_n_null(con, tmp_path):
     t = con.read_csv(data_path, nullstr="\\N")
     col = t.a.execute()
     assert pd.isna(col.iat[-1])
+
+
+@pytest.mark.xfail(
+    LINUX and SANDBOXED,
+    reason=("nix can't hit GCS because it is sandboxed."),
+)
+def test_register_filesystem_gcs(con):
+    import fsspec
+
+    gcs = fsspec.filesystem("gcs")
+
+    con.register_filesystem(gcs)
+    band_members = con.read_csv(
+        "gcs://ibis-examples/data/band_members.csv.gz", table_name="band_members"
+    )
+
+    assert band_members.count().to_pyarrow()

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -523,7 +523,9 @@ def normalize_filename(source: str | Path) -> str:
         source = source.removeprefix(f"{prefix}://")
 
     def _absolufy_paths(name):
-        if not name.startswith(("http", "s3", "az", "abfs", "abfss", "adl", "gs")):
+        if not name.startswith(
+            ("http", "s3", "az", "abfs", "abfss", "adl", "gs", "gcs", "azure")
+        ):
             return os.path.abspath(name)
         return name
 


### PR DESCRIPTION
DuckDB's python client introduced an integration with `fsspec` where you can use
`fsspec` to handle downloads from any supported `fsspec.AbstractFileSystem` and
feed that into various `DuckDB` `read_*` functions.

Upstream docs are here: https://duckdb.org/docs/guides/python/filesystems

The test is pulling from GCS, but it's also a 59 byte file -- if it ends up
being flaky we can always drop it.

Note for future self and other maintainers:
When we normalize filenames before passing them to DuckDB, we compare against a
known "allowlist" of various cloud blob prefixes (like `az`, `gcs`, `s3`, etc.)

If we _don't_ have the appropriate prefix in there, we mangle the URL quite badly.
For now, we can keep that list up-to-date, but we may want to revisit how we're handling that.