### PR TITLE
ci: write benchmark data to parquet

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -126,21 +126,6 @@ jobs:
       - name: benchmark
         run: poetry run pytest --benchmark-enable --benchmark-json .benchmarks/output.json ibis/tests/benchmarks
 
-      - uses: tibdex/github-app-token@v2
-        id: generate-token
-        with:
-          app_id: ${{ secrets.SQUAWK_BOT_APP_ID }}
-          private_key: ${{ secrets.SQUAWK_BOT_APP_PRIVATE_KEY }}
-
-      - uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: pytest
-          github-token: ${{ steps.generate-token.outputs.token }}
-          output-file-path: .benchmarks/output.json
-          benchmark-data-dir-path: ./bench
-          auto-push: false
-          comment-on-alert: false
-
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}

--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -146,10 +146,13 @@ jobs:
         run: |
           set -euo pipefail
 
+          # sort json keys
+          jq --sort-keys -rcM < "$PWD/.benchmarks/output.json" > output.json
+
           # connect to a file to allow spilling to disk
           ./duckdb json2parquet.ddb <<EOF
             COPY (
-              SELECT * FROM read_json_auto('$PWD/.benchmarks/output.json', maximum_object_size=2**27)
+              SELECT * FROM read_ndjson_auto('output.json', maximum_object_size=2**27)
             ) TO 'output.parquet' (FORMAT PARQUET, COMPRESSION ZSTD)
           EOF
 

--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -150,13 +150,30 @@ jobs:
       - name: show gcloud info
         run: gcloud info
 
-      - name: copy benchmark data to gcs
+      - name: download the latest duckdb release
         run: |
-          # remove whitespace and compress
-          jq -rcM < ./.benchmarks/output.json | gzip -c > output.json.gz
+          set -euo pipefail
+
+          gh release download -R duckdb/duckdb --pattern 'duckdb_cli-linux-amd64.zip'
+          unzip duckdb_cli-linux-amd64.zip
+
+      - name: convert json data to parquet
+        run: |
+          set -euo pipefail
+
+          # connect to a file to allow spilling to disk
+          ./duckdb json2parquet.ddb <<EOF
+            COPY (
+              SELECT * FROM read_json_auto('$PWD/.benchmarks/output.json', maximum_object_size=2**27)
+            ) TO 'output.parquet' (FORMAT PARQUET, COMPRESSION ZSTD)
+          EOF
+
+      - name: copy data to gcs
+        run: |
+          set -euo pipefail
 
           timestamp="$(date --iso-8601=ns --utc | tr ','  '.')"
-          gsutil cp output.json.gz "gs://ibis-benchmark-data/ci/${timestamp}.json.gz"
+          gsutil cp output.parquet "gs://ibis-benchmark-data/ci/${timestamp}.parquet"
 
   docs_pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Converts JSON benchmark data to parquet before uploading to GCS.