### PR TITLE
fix(ir): `ibis.parse_sql()` removes where clause

### DIFF
--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_aggregation_with_multiple_joins/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_aggregation_with_multiple_joins/decompiled.py
@@ -1,0 +1,41 @@
+import ibis
+
+
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+call_outcome = ibis.table(
+    name="call_outcome", schema={"outcome_text": "string", "id": "int64"}
+)
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+innerjoin = employee.inner_join(call, employee.id == call.employee_id)
+
+result = (
+    innerjoin.inner_join(call_outcome, call.call_outcome_id == call_outcome.id)
+    .select(
+        [
+            innerjoin.first_name,
+            innerjoin.last_name,
+            innerjoin.id,
+            innerjoin.start_time,
+            innerjoin.end_time,
+            innerjoin.employee_id,
+            innerjoin.call_outcome_id,
+            innerjoin.call_attempts,
+            call_outcome.outcome_text,
+            call_outcome.id.name("id_right"),
+        ]
+    )
+    .group_by(call.employee_id)
+    .aggregate(call.call_attempts.mean().name("avg_attempts"))
+)

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_aggregation/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_aggregation/decompiled.py
@@ -1,0 +1,17 @@
+import ibis
+
+
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+
+result = call.group_by(call.employee_id).aggregate(
+    call.call_attempts.sum().name("attempts")
+)

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_aggregation_with_join/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_aggregation_with_join/decompiled.py
@@ -1,0 +1,22 @@
+import ibis
+
+
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+leftjoin = employee.left_join(call, employee.id == call.employee_id)
+
+result = leftjoin.group_by(leftjoin.id).aggregate(
+    call.call_attempts.sum().name("attempts")
+)

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_join/inner/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_join/inner/decompiled.py
@@ -1,0 +1,34 @@
+import ibis
+
+
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+proj = employee.inner_join(call, employee.id == call.employee_id).filter(
+    employee.id < 5
+)
+
+result = proj.select(
+    [
+        proj.first_name,
+        proj.last_name,
+        proj.id,
+        call.start_time,
+        call.end_time,
+        call.employee_id,
+        call.call_outcome_id,
+        call.call_attempts,
+        proj.first_name.name("first"),
+    ]
+).order_by(proj.id.desc())

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_join/left/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_join/left/decompiled.py
@@ -1,0 +1,32 @@
+import ibis
+
+
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+proj = employee.left_join(call, employee.id == call.employee_id).filter(employee.id < 5)
+
+result = proj.select(
+    [
+        proj.first_name,
+        proj.last_name,
+        proj.id,
+        call.start_time,
+        call.end_time,
+        call.employee_id,
+        call.call_outcome_id,
+        call.call_attempts,
+        proj.first_name.name("first"),
+    ]
+).order_by(proj.id.desc())

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_join/right/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_join/right/decompiled.py
@@ -1,0 +1,34 @@
+import ibis
+
+
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+proj = employee.right_join(call, employee.id == call.employee_id).filter(
+    employee.id < 5
+)
+
+result = proj.select(
+    [
+        proj.first_name,
+        proj.last_name,
+        proj.id,
+        call.start_time,
+        call.end_time,
+        call.employee_id,
+        call.call_outcome_id,
+        call.call_attempts,
+        proj.first_name.name("first"),
+    ]
+).order_by(proj.id.desc())

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_projection/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_basic_projection/decompiled.py
@@ -1,0 +1,12 @@
+import ibis
+
+
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+proj = employee.filter(employee.id < 5)
+
+result = proj.select(
+    [proj.first_name, proj.last_name, proj.id, proj.first_name.name("first")]
+).order_by(proj.id.desc())

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_join_with_filter/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_join_with_filter/decompiled.py
@@ -1,0 +1,32 @@
+import ibis
+
+
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+proj = employee.left_join(call, employee.id == call.employee_id).filter(employee.id < 5)
+
+result = proj.select(
+    [
+        proj.first_name,
+        proj.last_name,
+        proj.id,
+        call.start_time,
+        call.end_time,
+        call.employee_id,
+        call.call_outcome_id,
+        call.call_attempts,
+        proj.first_name.name("first"),
+    ]
+).order_by(proj.id.desc())

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_multiple_joins/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_multiple_joins/decompiled.py
@@ -1,0 +1,38 @@
+import ibis
+
+
+call_outcome = ibis.table(
+    name="call_outcome", schema={"outcome_text": "string", "id": "int64"}
+)
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+innerjoin = employee.inner_join(call, employee.id == call.employee_id)
+
+result = innerjoin.inner_join(
+    call_outcome, call.call_outcome_id == call_outcome.id
+).select(
+    [
+        innerjoin.first_name,
+        innerjoin.last_name,
+        innerjoin.id,
+        innerjoin.start_time,
+        innerjoin.end_time,
+        innerjoin.employee_id,
+        innerjoin.call_outcome_id,
+        innerjoin.call_attempts,
+        call_outcome.outcome_text,
+        call_outcome.id.name("id_right"),
+    ]
+)

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_scalar_subquery/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_scalar_subquery/decompiled.py
@@ -1,0 +1,16 @@
+import ibis
+
+
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+agg = call.aggregate(call.call_attempts.mean().name("mean"))
+
+result = call.inner_join(agg, [])

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_simple_reduction/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_simple_reduction/decompiled.py
@@ -1,0 +1,15 @@
+import ibis
+
+
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+
+result = call.aggregate(call.call_attempts.mean().name("mean"))

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_simple_select_count/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_simple_select_count/decompiled.py
@@ -1,0 +1,9 @@
+import ibis
+
+
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+
+result = employee.aggregate(employee.first_name.count().name("_col_0"))

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_table_alias/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_table_alias/decompiled.py
@@ -1,0 +1,9 @@
+import ibis
+
+
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+
+result = employee.select([employee.first_name, employee.last_name, employee.id])

--- a/ibis/expr/tests/test_sql.py
+++ b/ibis/expr/tests/test_sql.py
@@ -17,14 +17,15 @@ catalog = {
 }
 
 
-def test_parse_sql_basic_projection():
+def test_parse_sql_basic_projection(snapshot):
     sql = "SELECT *, first_name as first FROM employee WHERE id < 5 ORDER BY id DESC"
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
 
 
 @pytest.mark.parametrize("how", ["right", "left", "inner"])
-def test_parse_sql_basic_join(how):
+def test_parse_sql_basic_join(how, snapshot):
     sql = f"""
 SELECT
   *,
@@ -37,10 +38,11 @@ WHERE
 ORDER BY
   id DESC"""
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
 
 
-def test_parse_sql_multiple_joins():
+def test_parse_sql_multiple_joins(snapshot):
     sql = """
 SELECT *
 FROM employee
@@ -49,10 +51,11 @@ JOIN call
 JOIN call_outcome
   ON call.call_outcome_id = call_outcome.id"""
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
 
 
-def test_parse_sql_basic_aggregation():
+def test_parse_sql_basic_aggregation(snapshot):
     sql = """
 SELECT
   employee_id,
@@ -60,10 +63,11 @@ SELECT
 FROM call
 GROUP BY employee_id"""
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
 
 
-def test_parse_sql_basic_aggregation_with_join():
+def test_parse_sql_basic_aggregation_with_join(snapshot):
     sql = """
 SELECT
   id,
@@ -73,10 +77,11 @@ LEFT JOIN call
   ON employee.id = call.employee_id
 GROUP BY id"""
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
 
 
-def test_parse_sql_aggregation_with_multiple_joins():
+def test_parse_sql_aggregation_with_multiple_joins(snapshot):
     sql = """
 SELECT
   t.employee_id,
@@ -87,16 +92,18 @@ FROM (
 ) AS t
 GROUP BY t.employee_id"""
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
 
 
-def test_parse_sql_simple_reduction():
+def test_parse_sql_simple_reduction(snapshot):
     sql = """SELECT AVG(call_attempts) AS mean FROM call"""
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
 
 
-def test_parse_sql_scalar_subquery():
+def test_parse_sql_scalar_subquery(snapshot):
     sql = """
 SELECT *
 FROM call
@@ -105,16 +112,30 @@ WHERE call_attempts > (
   FROM call
 )"""
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
 
 
-def test_parse_sql_simple_select_count():
+def test_parse_sql_simple_select_count(snapshot):
     sql = """SELECT COUNT(first_name) FROM employee"""
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
 
 
-def test_parse_sql_table_alias():
+def test_parse_sql_table_alias(snapshot):
     sql = """SELECT e.* FROM employee AS e"""
     expr = ibis.parse_sql(sql, catalog)
-    code = ibis.decompile(expr, format=True)  # noqa: F841
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")
+
+
+def test_parse_sql_join_with_filter(snapshot):
+    sql = """
+SELECT *, first_name as first FROM employee
+LEFT JOIN call ON employee.id = call.employee_id
+WHERE id < 5
+ORDER BY id DESC"""
+    expr = ibis.parse_sql(sql, catalog)
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -451,7 +451,7 @@ ignore = [
   "SIM300",  # yoda conditions
   "UP007",   # Optional[str] -> str | None
 ]
-exclude = ["*_py310.py", "ibis/tests/*/snapshots/*"]
+exclude = ["*_py310.py"]
 target-version = "py39"
 # none of these codes will be automatically fixed by ruff
 unfixable = [
@@ -473,6 +473,7 @@ required-imports = ["from __future__ import annotations"]
 ]
 "ci/*.py" = ["INP001"]
 "docs/*.py" = ["INP001"]
+"*/decompiled.py" = ["ALL"]
 "ci/release/verify_release.py" = ["T201"] # CLI tool that prints stuff
 
 [tool.blackdoc]


### PR DESCRIPTION
Resolves https://github.com/ibis-project/ibis/issues/7516

SQLGlot has a `"condition"` field in the `Join` expression object which hasn't been mapped to an ibis expression previously. It also provides a `projections` field which is omitted for now, we may need to consider another level of projection for that too. 