### PR TITLE
build(flink): use PyFlink 1.18 and drop workaround

### DIFF
--- a/.github/workflows/ibis-backends-flink.yml
+++ b/.github/workflows/ibis-backends-flink.yml
@@ -118,12 +118,6 @@ jobs:
       - name: install other deps
         run: poetry run pip install ${{ join(matrix.backend.additional_deps, ' ') }}
 
-      # FIXME(deepyaman): We reinstall pandas~=1.5 to get a version with
-      #   ArrowDtype, but this step will be removed once PyFlink relaxes
-      #   its overly-restrictive dependencies (specifying pandas<1.4.0).
-      - name: override overly-restrictive PyFlink requirements
-        run: poetry run pip install pandas~=1.5
-
       - name: show installed deps
         run: poetry run pip list
 
@@ -203,12 +197,6 @@ jobs:
 
       - name: install other deps
         run: poetry run pip install ${{ join(matrix.backend.additional_deps, ' ') }}
-
-      # FIXME(deepyaman): We reinstall pandas~=1.5 to get a version with
-      #   ArrowDtype, but this step will be removed once PyFlink relaxes
-      #   its overly-restrictive dependencies (specifying pandas<1.4.0).
-      - name: override overly-restrictive PyFlink requirements
-        run: poetry run pip install pandas~=1.5
 
       - name: show installed deps
         run: poetry run pip list

--- a/.github/workflows/ibis-backends-flink.yml
+++ b/.github/workflows/ibis-backends-flink.yml
@@ -56,7 +56,6 @@ jobs:
               - flink
             additional_deps:
               - apache-flink
-              - grpcio-status # FIXME(deepyaman)
               - pytest-split
         group:
           [
@@ -167,7 +166,6 @@ jobs:
               - flink
             additional_deps:
               - apache-flink
-              - grpcio-status # FIXME(deepyaman)
               - pytest-split
     steps:
       - name: checkout

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -331,9 +331,6 @@ def test_timestamp_extract_milliseconds(backend, alltypes, df):
     pyspark=["pandas<2.1"],
     reason="test was adjusted to work with pandas 2.1 output; pyspark doesn't support pandas 2",
 )
-@pytest.mark.broken(
-    ["flink"], raises=AssertionError, reason="numpy array are different"
-)
 def test_timestamp_extract_epoch_seconds(backend, alltypes, df):
     expr = alltypes.timestamp_col.epoch_seconds().name("tmp")
     result = expr.execute()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,6 +324,9 @@ filterwarnings = [
   "ignore:the imp module is deprecated in favour of importlib:DeprecationWarning",
   # pytest raises a syntax error when encountering this from *any* module, including third party modules
   "ignore:invalid escape sequence:DeprecationWarning",
+  # `is_sparse` deprecation was addressed in pyarrow 13.0.0 (see https://github.com/apache/arrow/pull/35366),
+  # but flink requires apache-beam<2.49, which caps its pyarrow dependency (see https://github.com/apache/beam/blob/v2.48.0/sdks/python/setup.py#L144)
+  "ignore:is_sparse is deprecated and will be removed in a future version:FutureWarning",
 ]
 empty_parameter_set_mark = "fail_at_collect"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,6 +327,8 @@ filterwarnings = [
   # `is_sparse` deprecation was addressed in pyarrow 13.0.0 (see https://github.com/apache/arrow/pull/35366),
   # but flink requires apache-beam<2.49, which caps its pyarrow dependency (see https://github.com/apache/beam/blob/v2.48.0/sdks/python/setup.py#L144)
   "ignore:is_sparse is deprecated and will be removed in a future version:FutureWarning",
+  # google-api-core
+  "ignore:Please install grpcio-status to obtain helpful grpc error messages.",
 ]
 empty_parameter_set_mark = "fail_at_collect"
 markers = [


### PR DESCRIPTION
* `grpcio-status` isn't a dependency for the Flink backend; one of the underlying libraries just raises a warning, requesting to install it, if it isn't already
* No need to manually upgrade (or cap) pandas anymore. As a side effect, one of the pandas 2.x-only tests now works as expected.
* Using pandas 2.x will result in deprecation warnings, because (Py)Flink is stuck on an older Beam, which in turn pins an older PyArrow. So we ignore those for now.

I opened this while leaving #7444 still open, because we can't add the Flink dependencies officially to the backend (see [discussion](https://claypotai.slack.com/archives/C047W8D9674/p1698775815390869?thread_ts=1698338539.212219&cid=C047W8D9674)).