### PR TITLE
perf(bigquery): use more efficient representation for memtables

### DIFF
--- a/ibis/backends/base/sql/compiler/query_builder.py
+++ b/ibis/backends/base/sql/compiler/query_builder.py
@@ -77,6 +77,9 @@ class TableSetFormatter:
         return quote_identifier(name)
 
     def _format_in_memory_table(self, op):
+        if self.context.compiler.cheap_in_memory_tables:
+            return op.name
+
         names = op.schema.names
         raw_rows = []
         for row in op.data.to_frame().itertuples(index=False):

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_compile_in_memory_table/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_compile_in_memory_table/out.sql
@@ -1,3 +1,0 @@
-SELECT
-  t0.*
-FROM UNNEST(ARRAY<STRUCT<`Column One` INT64>>[STRUCT(1 AS `Column One`), STRUCT(2 AS `Column One`), STRUCT(3 AS `Column One`)]) AS t0

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -628,9 +628,3 @@ def test_unnest(snapshot):
         ).select(level_two=lambda t: t.level_one.unnest())
     )
     snapshot.assert_match(result, "out_two_unnests.sql")
-
-
-def test_compile_in_memory_table(snapshot):
-    t = ibis.memtable({"Column One": [1, 2, 3]})
-    result = ibis.bigquery.compile(t)
-    snapshot.assert_match(result, "out.sql")


### PR DESCRIPTION
This PR moves the BigQuery memtable implementation to be much more efficient than the current one by using temporary tables along with the `bq.Client.load_table_from_dataframe` method.

Depends on #7527.
