### PR TITLE
fix(snowflake): fix array printing by using a pyarrow extension type

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -364,6 +364,8 @@ $$""".format(**self._get_udf_source(udf_node))
         limit: int | str | None = None,
         **_: Any,
     ) -> pa.Table:
+        from ibis.backends.snowflake.converter import SnowflakePyArrowData
+
         self._run_pre_execute_hooks(expr)
 
         query_ast = self.compiler.to_ast_ensure_limit(expr, limit, params=params)
@@ -375,9 +377,7 @@ $$""".format(**self._get_udf_source(udf_node))
         if res is None:
             res = target_schema.empty_table()
 
-        res = res.rename_columns(target_schema.names).cast(target_schema)
-
-        return expr.__pyarrow_result__(res)
+        return expr.__pyarrow_result__(res, data_mapper=SnowflakePyArrowData)
 
     def fetch_from_cursor(self, cursor, schema: sch.Schema) -> pd.DataFrame:
         if (table := cursor.cursor.fetch_arrow_all()) is None:

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ibis.formats.pandas import PandasData
+from ibis.formats.pyarrow import PYARROW_JSON_TYPE, PyArrowData
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+    import ibis.expr.datatypes as dt
+    from ibis.expr.schema import Schema
 
 
 class SnowflakePandasData(PandasData):
@@ -10,3 +19,23 @@ class SnowflakePandasData(PandasData):
         return s.map(converter, na_action="ignore").astype("object")
 
     convert_Struct = convert_Array = convert_Map = convert_JSON
+
+
+class SnowflakePyArrowData(PyArrowData):
+    @classmethod
+    def convert_table(cls, table: pa.Table, schema: Schema) -> pa.Table:
+        import pyarrow as pa
+
+        columns = [cls.convert_column(table[name], typ) for name, typ in schema.items()]
+        return pa.Table.from_arrays(columns, names=schema.names)
+
+    @classmethod
+    def convert_column(cls, column: pa.Array, dtype: dt.DataType) -> pa.Array:
+        if dtype.is_json() or dtype.is_array() or dtype.is_map() or dtype.is_struct():
+            import pyarrow as pa
+
+            if isinstance(column, pa.ChunkedArray):
+                column = column.combine_chunks()
+
+            return pa.ExtensionArray.from_storage(PYARROW_JSON_TYPE, column)
+        return super().convert_column(column, dtype)

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -219,3 +219,10 @@ def test_read_parquet(con, data_dir):
     t = con.read_parquet(path)
 
     assert t.timestamp_col.type().is_timestamp()
+
+
+def test_array_repr(con, monkeypatch):
+    monkeypatch.setattr(ibis.options, "interactive", True)
+    t = con.tables.ARRAY_TYPES
+    expr = t.x
+    assert repr(expr)

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
     import ibis.expr.builders as bl
     import ibis.expr.types as ir
+    from ibis.formats.pyarrow import PyArrowData
 
 
 @public
@@ -1204,10 +1205,13 @@ class Scalar(Value):
     def __interactive_rich_console__(self, console, options):
         return console.render(repr(self.execute()), options=options)
 
-    def __pyarrow_result__(self, table: pa.Table) -> pa.Scalar:
-        from ibis.formats.pyarrow import PyArrowData
+    def __pyarrow_result__(
+        self, table: pa.Table, data_mapper: type[PyArrowData] | None = None
+    ) -> pa.Scalar:
+        if data_mapper is None:
+            from ibis.formats.pyarrow import PyArrowData as data_mapper
 
-        return PyArrowData.convert_scalar(table[0][0], self.type())
+        return data_mapper.convert_scalar(table[0][0], self.type())
 
     def __pandas_result__(self, df: pd.DataFrame) -> Any:
         return df.iat[0, 0]
@@ -1275,10 +1279,13 @@ class Column(Value, _FixedTextJupyterMixin):
         projection = named.as_table()
         return console.render(projection, options=options)
 
-    def __pyarrow_result__(self, table: pa.Table) -> pa.Array | pa.ChunkedArray:
-        from ibis.formats.pyarrow import PyArrowData
+    def __pyarrow_result__(
+        self, table: pa.Table, data_mapper: type[PyArrowData] | None = None
+    ) -> pa.Array | pa.ChunkedArray:
+        if data_mapper is None:
+            from ibis.formats.pyarrow import PyArrowData as data_mapper
 
-        return PyArrowData.convert_column(table[0], self.type())
+        return data_mapper.convert_column(table[0], self.type())
 
     def __pandas_result__(self, df: pd.DataFrame) -> pd.Series:
         from ibis.formats.pandas import PandasData

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from ibis.expr.types.groupby import GroupedTable
     from ibis.expr.types.tvf import WindowedTable
     from ibis.selectors import IfAnyAll, Selector
+    from ibis.formats.pyarrow import PyArrowData
 
 _ALIASES = (f"_ibis_view_{n:d}" for n in itertools.count())
 
@@ -158,10 +159,13 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         return IbisDataFrame(self, nan_as_null=nan_as_null, allow_copy=allow_copy)
 
-    def __pyarrow_result__(self, table: pa.Table) -> pa.Table:
-        from ibis.formats.pyarrow import PyArrowData
+    def __pyarrow_result__(
+        self, table: pa.Table, data_mapper: type[PyArrowData] | None = None
+    ) -> pa.Table:
+        if data_mapper is None:
+            from ibis.formats.pyarrow import PyArrowData as data_mapper
 
-        return PyArrowData.convert_table(table, self.schema())
+        return data_mapper.convert_table(table, self.schema())
 
     def __pandas_result__(self, df: pd.DataFrame) -> pd.DataFrame:
         from ibis.formats.pandas import PandasData


### PR DESCRIPTION
This is a possible solution to #7561.

While it works, it does feel like a lot of code to solve the problem of array column printing.

That said, I'm not sure if there's a better way to do it, and we have similar code for pandas conversion (in fact, probably a lot more, and more complex too).

The reason I took the extension array approach was to avoid having to adjust any of the pretty printing code to be backend-specific.

With extension array approach I am attempting to limit the blast radius of Snowflake-specific behavior while allowing Snowflake to continue to be extremely relaxed about the underlying storage of the data.

I followed the examples here: https://arrow.apache.org/docs/python/extending_types.html#custom-extension-array-class

Fixes #7561.
