### PR TITLE
feat(snowflake): dispose connection

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -292,6 +292,10 @@ $$ {defn["source"]} $$"""
 
         self.con.dialect.normalize_name = normalize_name
 
+    def close(self):
+        """Dispose the current backend connection."""
+        self.con.dispose()
+
     def _get_udf_source(self, udf_node: ops.ScalarUDF):
         name = type(udf_node).__name__
         signature = ", ".join(


### PR DESCRIPTION
This change will dispose of a Snowflake connection with the `close` shorthand to the backend. 

This was talked about in regards to DuckDB in https://ibis-project.zulipchat.com/#narrow/stream/405265-tech-support/topic/Disposing.20Connections. 

We could likely add this to any backends using SQLAlchemy. 

```
In [3]: con.tables
Out[3]: 
Tables
------
- DIAMONDS

In [4]: con.read_csv("diamonds.csv")
Out[4]: 
┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┓
┃ "carat"       ┃ "cut"       ┃ "color" ┃ "clarity" ┃ "depth"       ┃ "table"       ┃ "price" ┃ "x"           ┃ "y"           ┃ "z"           ┃
┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━┩
│ decimal(3, 2) │ string      │ string  │ string    │ decimal(3, 1) │ decimal(3, 1) │ int64   │ decimal(4, 2) │ decimal(4, 2) │ decimal(4, 2) │
├───────────────┼─────────────┼─────────┼───────────┼───────────────┼───────────────┼─────────┼───────────────┼───────────────┼───────────────┤
│          0.23 │ "Ideal"     │ "E"     │ "SI2"     │          61.5 │          55.0 │     326 │          3.95 │          3.98 │          2.43 │
│          0.21 │ "Premium"   │ "E"     │ "SI1"     │          59.8 │          61.0 │     326 │          3.89 │          3.84 │          2.31 │
│          0.23 │ "Good"      │ "E"     │ "VS1"     │          56.9 │          65.0 │     327 │          4.05 │          4.07 │          2.31 │
│          0.29 │ "Premium"   │ "I"     │ "VS2"     │          62.4 │          58.0 │     334 │          4.20 │          4.23 │          2.63 │
│          0.31 │ "Good"      │ "J"     │ "SI2"     │          63.3 │          58.0 │     335 │          4.34 │          4.35 │          2.75 │
│          0.24 │ "Very Good" │ "J"     │ "VVS2"    │          62.8 │          57.0 │     336 │          3.94 │          3.96 │          2.48 │
│          0.24 │ "Very Good" │ "I"     │ "VVS1"    │          62.3 │          57.0 │     336 │          3.95 │          3.98 │          2.47 │
│          0.26 │ "Very Good" │ "H"     │ "SI1"     │          61.9 │          55.0 │     337 │          4.07 │          4.11 │          2.53 │
│          0.22 │ "Fair"      │ "E"     │ "VS2"     │          65.1 │          61.0 │     337 │          3.87 │          3.78 │          2.49 │
│          0.23 │ "Very Good" │ "H"     │ "VS1"     │          59.4 │          61.0 │     338 │          4.00 │          4.05 │          2.39 │
│             … │ …           │ …       │ …         │             … │             … │       … │             … │             … │             … │
└───────────────┴─────────────┴─────────┴───────────┴───────────────┴───────────────┴─────────┴───────────────┴───────────────┴───────────────┘

In [5]: con.tables
Out[5]: 
Tables
------
- DIAMONDS
- _ibis_read_csv_snowflake_lklwtqcvhzcjlhxxynjfb5pgwe

In [6]: con.close()

In [7]: con.tables
Out[7]: 
Tables
------
- DIAMONDS
```