### PR TITLE
fix(substitute): allow mappings with None keys

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -684,7 +684,7 @@ class Value(Expr):
         """
         expr = self.case()
         if isinstance(value, dict):
-            for k, v in sorted(value.items()):
+            for k, v in value.items():
                 expr = expr.when(k, v)
         else:
             expr = expr.when(value, replacement)


### PR DESCRIPTION
We don't need to sort this dictionary anymore.

Fixes #7191 