### PR TITLE
chore(ci): skip bad CI runs on forks

### DIFF
--- a/.github/workflows/ci-data.yml
+++ b/.github/workflows/ci-data.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   gcs_insert:
+    if: github.repository_owner == 'ibis-project'
     runs-on: ubuntu-latest
     steps:
       - name: set date

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.repository_owner == 'ibis-project'
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   condalock:
+    if: github.repository_owner == 'ibis-project'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,7 +50,7 @@ jobs:
           path: ci/conda-lock/*/${{ matrix.python-version }}.lock
 
   condalock_pr:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: (github.repository_owner == 'ibis-project') && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     needs:
       - condalock

--- a/.github/workflows/create-rotate-key-issue.yml
+++ b/.github/workflows/create-rotate-key-issue.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   rotate_private_key:
+    if: github.repository_owner == 'ibis-project'
     runs-on: ubuntu-latest
     steps:
       - name: Generate a GitHub token

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   pre-release:
+    if: github.repository_owner == 'ibis-project'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   get-flakes:
+    if: github.repository_owner == 'ibis-project'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.get-flakes.outputs.matrix }}
@@ -25,6 +26,7 @@ jobs:
           echo "matrix=${flakes}" >> "$GITHUB_OUTPUT"
 
   flake-update:
+    if: github.repository_owner == 'ibis-project'
     runs-on: ubuntu-latest
     needs:
       - get-flakes


### PR DESCRIPTION
These CI workflows don't make sense to run on forks. As a fork owner,
I get emails every time these flows fail.
Let's save some junk emails and some
wasted electricity.

Double check me that I picked out the right workflows to skip, and that I didn't miss other ones.

fixes https://github.com/ibis-project/ibis/issues/7568