### PR TITLE
feat(exporting): allow passing writer_opts to PyArrow ParquetWriter and CSVWriter

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -547,7 +547,7 @@ class _FileIOHandler:
         import pyarrow.parquet as pq
 
         with expr.to_pyarrow_batches(params=params) as batch_reader:
-            with pq.ParquetWriter(path, batch_reader.schema) as writer:
+            with pq.ParquetWriter(path, batch_reader.schema, **kwargs) as writer:
                 for batch in batch_reader:
                     writer.write_batch(batch)
 
@@ -582,7 +582,7 @@ class _FileIOHandler:
         import pyarrow.csv as pcsv
 
         with expr.to_pyarrow_batches(params=params) as batch_reader:
-            with pcsv.CSVWriter(path, batch_reader.schema) as writer:
+            with pcsv.CSVWriter(path, batch_reader.schema, **kwargs) as writer:
                 for batch in batch_reader:
                     writer.write_batch(batch)
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -98,24 +98,6 @@ class Backend(AlchemyCrossSchemaBackend, CanCreateSchema):
     name = "duckdb"
     compiler = DuckDBSQLCompiler
     supports_create_or_replace = True
-    reserved_csv_copy_args = [
-        "COMPRESSION",
-        "FORCE_QUOTE",
-        "DATEFORMAT",
-        "DELIM",
-        "SEP",
-        "ESCAPE",
-        "HEADER",
-        "NULLSTR",
-        "QUOTE",
-        "TIMESTAMP_FORMAT"
-    ]
-    reserved_parquet_copy_args = [
-        "COMPRESSION",
-        "ROW_GROUP_SIZE",
-        "ROW_GROUP_SIZE_BYTES",
-        "FIELD_IDS",
-    ]
 
     @property
     def settings(self) -> _Settings:
@@ -1107,7 +1089,7 @@ WHERE catalog_name = :database"""
         """
         self._run_pre_execute_hooks(expr)
         query = self._to_sql(expr, params=params)
-        args = ["FORMAT 'parquet'", *(f"{k.upper()} {v!r}" for k, v in kwargs.items() if k.upper() in self.reserved_parquet_copy_args)]
+        args = ["FORMAT 'parquet'", *(f"{k.upper()} {v!r}" for k, v in kwargs.items())]
         copy_cmd = f"COPY ({query}) TO {str(path)!r} ({', '.join(args)})"
         with self.begin() as con:
             con.exec_driver_sql(copy_cmd)
@@ -1145,7 +1127,7 @@ WHERE catalog_name = :database"""
         args = [
             "FORMAT 'csv'",
             f"HEADER {int(header)}",
-            *(f"{k.upper()} {v!r}" for k, v in kwargs.items() if k.upper() in self.reserved_csv_copy_args),
+            *(f"{k.upper()} {v!r}" for k, v in kwargs.items()),
         ]
         copy_cmd = f"COPY ({query}) TO {str(path)!r} ({', '.join(args)})"
         with self.begin() as con:

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -129,7 +129,7 @@ class Table(Expr, _FixedTextJupyterMixin):
     - from an existing table in a data platform with
       [`connection.table("name")`](./expression-tables.qmd#ibis.backends.duckdb.Backend.table)
     - from a file or URL, into a specific backend with
-      [`connection.read_csv/parsquet/json("path/to/file")`](../backends/duckdb.qmd#ibis.backends.duckdb.Backend.read_csv)
+      [`connection.read_csv/parquet/json("path/to/file")`](../backends/duckdb.qmd#ibis.backends.duckdb.Backend.read_csv)
       (only some backends, typically local ones, support this)
     - from a file or URL, into the default backend with
        [`ibis.read_csv/read_json/read_parquet("path/to/file")`](./expression-tables.qmd#ibis.read_csv)


### PR DESCRIPTION
Small tweak to allow passing of writer specific args/kwargs. Also fixes a typo