### PR TITLE
feat(api): add `ibis.range` function for generating sequences

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -776,6 +776,16 @@ def _group_concat(translator, op):
     return f"STRING_AGG({arg}, {sep})"
 
 
+def _integer_range(translator, op):
+    start = translator.translate(op.start)
+    stop = translator.translate(op.stop)
+    step = translator.translate(op.step)
+    n = f"FLOOR(({stop} - {start}) / NULLIF({step}, 0))"
+    gen_array = f"GENERATE_ARRAY({start}, {stop}, {step})"
+    inner = f"SELECT x FROM UNNEST({gen_array}) x WHERE x <> {stop}"
+    return f"IF({n} > 0, ARRAY({inner}), [])"
+
+
 OPERATION_REGISTRY = {
     **operation_registry,
     # Literal
@@ -939,6 +949,7 @@ OPERATION_REGISTRY = {
     ops.TimeDelta: _time_delta,
     ops.DateDelta: _date_delta,
     ops.TimestampDelta: _timestamp_delta,
+    ops.IntegerRange: _integer_range,
 }
 
 _invalid_operations = {

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -817,6 +817,7 @@ _simple_ops = {
     ops.ExtractFragment: "fragment",
     ops.ArrayPosition: "indexOf",
     ops.ArrayFlatten: "arrayFlatten",
+    ops.IntegerRange: "range",
 }
 
 

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -497,6 +497,7 @@ operation_registry.update(
         ops.ToJSONMap: _to_json_collection,
         ops.ToJSONArray: _to_json_collection,
         ops.ArrayFlatten: unary(sa.func.flatten),
+        ops.IntegerRange: fixed_arity(sa.func.range, 3),
     }
 )
 

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -491,6 +491,14 @@ operation_registry.update(
             lambda part, left, right: sa.func.timestampdiff(part, right, left), 3
         ),
         ops.TimestampBucket: _timestamp_bucket,
+        ops.IntegerRange: fixed_arity(
+            lambda start, stop, step: sa.func.iff(
+                step != 0,
+                sa.func.array_generate_range(start, stop, step),
+                sa.func.array_construct(),
+            ),
+            3,
+        ),
     }
 )
 

--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -202,3 +202,18 @@ class ArrayFlatten(Value):
     @property
     def dtype(self):
         return self.arg.dtype.value_type
+
+
+class Range(Value):
+    shape = rlz.shape_like("args")
+
+    @attribute
+    def dtype(self) -> dt.DataType:
+        return dt.Array(dt.highest_precedence((self.start.dtype, self.stop.dtype)))
+
+
+@public
+class IntegerRange(Range):
+    start: Value[dt.Integer]
+    stop: Value[dt.Integer]
+    step: Value[dt.Integer]

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -9,7 +9,6 @@ from typing import Union as UnionType
 from public import public
 
 import ibis.common.exceptions as com
-import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis import util
@@ -502,7 +501,7 @@ class Selection(Projection):
 @public
 class DummyTable(Relation):
     # TODO(kszucs): verify that it has at least one element: Length(at_least=1)
-    values: VarTuple[Value[dt.Any, ds.Scalar]]
+    values: VarTuple[Value[dt.Any]]
 
     @attribute
     def schema(self):

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1172,8 +1172,12 @@ class Value(Expr):
                 "involving multiple base table references "
                 "to a projection"
             )
-        table = roots[0].to_expr()
-        return table.select(self)
+
+        if roots:
+            return roots[0].to_expr().select(self)
+
+        # no child table to select from
+        return ops.DummyTable(values=(self,)).to_expr()
 
     def to_pandas(self, **kwargs) -> pd.Series:
         """Convert a column expression to a pandas Series or scalar object.


### PR DESCRIPTION
Adds an `ibis.range` API for generating sequences. This cannot yet be used with `ibis.read_parquet` et al. That will be done in a follow-up.

Closes #7169.

Backend support:

- [x] BigQuery
- [x] ClickHouse
- [x] DuckDB
- [x] Polars
- [x] Postgres
- [x] PySpark
- [x] Snowflake
- [x] Trino

Follow-ups:

- date range
- timestamp range
- decimal range
- floating range
