### PR TITLE
chore(deps): remove need for explicit scipy dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6105,4 +6105,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "96922eb89546be5281a3c10ff0f9d00566f52584565ade30bd1f1022f08acddb"
+content-hash = "ae7d22d01f67e05dcbcb585f964272ef796864483441108fd8b6c40789ecd8e5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,6 @@ quartodoc = { version = ">=0.6.1,<1", python = ">=3.10,<3.13" }
 requests = { version = ">=2,<3", python = ">=3.10,<3.13" }
 scikit-learn = { version = ">=1.3,<2", python = ">=3.10,<3.13" }
 seaborn = { version = ">=0.12.2,<1", python = ">=3.10,<3.13" }
-scipy = { version = ">=1.11,<2", python = ">=3.10,<3.13" }
 
 [tool.poetry.extras]
 # generate the `all` extra using nix run '.#gen-all-extras'


### PR DESCRIPTION
Turns out it is enough to set the upper bound of docs dependencies python to 3.13