### PR TITLE
make snowflake unnest consistent

### DIFF
--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -146,4 +146,4 @@ def execute_array_collect_groupby(op, data, where, aggcontext=None, **kwargs):
 
 @execute_node.register(ops.Unnest, pd.Series)
 def execute_unnest(op, data, **kwargs):
-    return data.explode()
+    return data[data.map(lambda v: v != [], na_action="ignore")].explode()

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -193,7 +193,12 @@ def _unnest(t, op):
     # HACK: https://community.snowflake.com/s/question/0D50Z000086MVhnSAG/has-anyone-found-a-way-to-unnest-an-array-without-loosing-the-null-values
     sep = util.guid()
     col = sa.func.nullif(
-        sa.func.split_to_table(sa.func.array_to_string(arg, sep), sep)
+        sa.func.split_to_table(
+            sa.func.array_to_string(
+                sa.func.nullif(arg, sa.func.array_construct()), sep
+            ),
+            sep,
+        )
         .table_valued("value")  # seq, index, value is supported but we only need value
         .lateral()
         .c["value"],

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -842,3 +842,20 @@ def test_array_of_struct_unnest(con):
     # `value` can be `None` because the order of results is arbitrary; observed
     # in the wild with the trino backend
     assert value is None or isinstance(value, str)
+
+
+@pytest.mark.notimpl(
+    ["polars"],
+    raises=AssertionError,
+    reason="ibis hasn't implemented this behavior yet",
+)
+@pytest.mark.notyet(
+    ["datafusion"],
+    raises=com.OperationNotDefinedError,
+    reason="backend doesn't support unnest",
+)
+def test_unnest_empty_array(con):
+    t = ibis.memtable({"arr": [[], ["a"], ["a", "b"]]})
+    expr = t.arr.unnest()
+    result = con.execute(expr)
+    assert len(result) == 3

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -268,7 +268,7 @@ class ArrayValue(Value):
         """Flatten an array into a column.
 
         ::: {.callout-note}
-        ## This operation changes the cardinality of the result
+        ## Rows with empty arrays are dropped in the output.
         :::
 
         Examples


### PR DESCRIPTION
Fixes pandas and snowflake to drop empty array rows when unnesting.