### PR TITLE
fix(pandas/snowflake): make unnest of empty array rows consistent with other backends

### DIFF
--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -147,7 +147,7 @@ def execute_array_collect_groupby(op, data, where, aggcontext=None, **kwargs):
 
 @execute_node.register(ops.Unnest, pd.Series)
 def execute_unnest(op, data, **kwargs):
-    return data.explode()
+    return data[data.map(lambda v: bool(len(v)), na_action="ignore")].explode()
 
 
 @execute_node.register(ops.ArrayFlatten, pd.Series)

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -193,7 +193,12 @@ def _unnest(t, op):
     # HACK: https://community.snowflake.com/s/question/0D50Z000086MVhnSAG/has-anyone-found-a-way-to-unnest-an-array-without-loosing-the-null-values
     sep = util.guid()
     col = sa.func.nullif(
-        sa.func.split_to_table(sa.func.array_to_string(arg, sep), sep)
+        sa.func.split_to_table(
+            sa.func.array_to_string(
+                sa.func.nullif(arg, sa.func.array_construct()), sep
+            ),
+            sep,
+        )
         .table_valued("value")  # seq, index, value is supported but we only need value
         .lateral()
         .c["value"],

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -943,32 +943,7 @@ def test_range_single_argument(con, n):
     reason="range and unnest aren't implemented upstream",
     raises=com.OperationNotDefinedError,
 )
-@pytest.mark.parametrize(
-    "n",
-    [
-        param(
-            -2,
-            marks=[
-                pytest.mark.broken(
-                    ["snowflake"],
-                    reason="snowflake unnests empty arrays to null",
-                    raises=AssertionError,
-                )
-            ],
-        ),
-        param(
-            0,
-            marks=[
-                pytest.mark.broken(
-                    ["snowflake"],
-                    reason="snowflake unnests empty arrays to null",
-                    raises=AssertionError,
-                )
-            ],
-        ),
-        2,
-    ],
-)
+@pytest.mark.parametrize("n", [-2, 0, 2])
 @pytest.mark.notimpl(
     ["polars", "flink", "pandas", "dask"], raises=com.OperationNotDefinedError
 )

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1048,3 +1048,20 @@ def test_range_start_stop_step_zero(con, start, stop):
     expr = ibis.range(start, stop, 0)
     result = con.execute(expr)
     assert list(result) == []
+
+
+@pytest.mark.notimpl(
+    ["polars"],
+    raises=AssertionError,
+    reason="ibis hasn't implemented this behavior yet",
+)
+@pytest.mark.notyet(
+    ["datafusion", "flink"],
+    raises=com.OperationNotDefinedError,
+    reason="backend doesn't support unnest",
+)
+def test_unnest_empty_array(con):
+    t = ibis.memtable({"arr": [[], ["a"], ["a", "b"]]})
+    expr = t.arr.unnest()
+    result = con.execute(expr)
+    assert len(result) == 3

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -268,7 +268,7 @@ class ArrayValue(Value):
         """Flatten an array into a column.
 
         ::: {.callout-note}
-        ## This operation changes the cardinality of the result
+        ## Rows with empty arrays are dropped in the output.
         :::
 
         Examples


### PR DESCRIPTION
Fixes pandas and snowflake to drop empty array rows when unnesting.