### PR TITLE
Snowflake: Add Support for "read_csv" with https

### DIFF
--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -197,6 +197,22 @@ def test_read_csv_options(con, tmp_path):
     assert t.schema() == ibis.schema(dict(a="int64", b="int64"))
 
 
+def test_read_csv_https(con):
+    t = con.read_csv(
+        "https://storage.googleapis.com/ibis-tutorial-data/wowah_data/locations.csv",
+        field_optionally_enclosed_by='"',
+    )
+    assert t.schema() == ibis.schema(
+        {
+            "Map_ID": "int64",
+            "Location_Type": "string",
+            "Location_Name": "string",
+            "Game_Version": "string",
+        }
+    )
+    assert t.count().execute() == 151
+
+
 @pytest.fixture(scope="module")
 def json_data():
     return [


### PR DESCRIPTION
Currently using the Snowflake backend with Ibis, you'll get an error if you specify a URL as a file path for read_csv. This works with other engines where the behavior is natively supported, but Snowflake requires those additional preprocessing steps. 

I added a portion to use a TempFile and load the content to the temporary stage. Complex file formats might cause issues with this, but I'll try to do some additional testing. 

We could likely add this to the other `read_...` methods, but I wanted to start with this for now. 

It's possible to make this work with S3, Azure Blob, GCS, etc., but that could get complex determining whether or not to use client storage options or integrations available natively in Snowflake. 

Here's some code you can use to test the new feature:

```python
from ibis.interactive import *
from pathlib import Path
from snowflake.ml.utils.connection_params import SnowflakeLoginOptions

con = ibis.snowflake.connect(**SnowflakeLoginOptions())

con.read_csv("https://storage.googleapis.com/ibis-tutorial-data/wowah_data/locations.csv")
```