### PR TITLE
feat(snowflake): use upstream `array_sort`

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -110,11 +110,6 @@ return longest.map((_, i) => {
     return Object.assign(...keys.map((key, j) => ({[key]: arrays[j][i]})));
 })""",
     },
-    "ibis_udfs.public.array_sort": {
-        "inputs": {"array": ARRAY},
-        "returns": ARRAY,
-        "source": """return array.sort();""",
-    },
     "ibis_udfs.public.array_repeat": {
         # Integer inputs are not allowed because JavaScript only supports
         # doubles

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -285,7 +285,6 @@ operation_registry.update(
     {
         ops.JSONGetItem: fixed_arity(sa.func.get, 2),
         ops.StringFind: _string_find,
-        ops.ArrayZip: _array_zip,
         ops.Map: fixed_arity(
             lambda keys, values: sa.func.iff(
                 sa.func.is_array(keys) & sa.func.is_array(values),
@@ -420,6 +419,9 @@ operation_registry.update(
         ),
         ops.ArrayRemove: fixed_arity(sa.func.array_remove, 2),
         ops.ArrayIntersect: fixed_arity(sa.func.array_intersection, 2),
+        ops.ArrayZip: _array_zip,
+        ops.ArraySort: unary(sa.func.ibis_udfs.public.array_sort),
+        ops.ArrayRepeat: fixed_arity(sa.func.ibis_udfs.public.array_repeat, 2),
         ops.StringSplit: fixed_arity(sa.func.split, 2),
         # snowflake typeof only accepts VARIANT, so we cast
         ops.TypeOf: unary(lambda arg: sa.func.typeof(sa.func.to_variant(arg))),
@@ -478,8 +480,6 @@ operation_registry.update(
         ops.Median: reduction(sa.func.median),
         ops.TableColumn: _table_column,
         ops.Levenshtein: fixed_arity(sa.func.editdistance, 2),
-        ops.ArraySort: unary(sa.func.ibis_udfs.public.array_sort),
-        ops.ArrayRepeat: fixed_arity(sa.func.ibis_udfs.public.array_repeat, 2),
         ops.TimeDelta: fixed_arity(
             lambda part, left, right: sa.func.timediff(part, right, left), 3
         ),

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -420,7 +420,7 @@ operation_registry.update(
         ops.ArrayRemove: fixed_arity(sa.func.array_remove, 2),
         ops.ArrayIntersect: fixed_arity(sa.func.array_intersection, 2),
         ops.ArrayZip: _array_zip,
-        ops.ArraySort: unary(sa.func.ibis_udfs.public.array_sort),
+        ops.ArraySort: unary(sa.func.array_sort),
         ops.ArrayRepeat: fixed_arity(sa.func.ibis_udfs.public.array_repeat, 2),
         ops.StringSplit: fixed_arity(sa.func.split, 2),
         # snowflake typeof only accepts VARIANT, so we cast


### PR DESCRIPTION
Use the now-GA `array_sort` function from upstream snowflake.