### PR TITLE
feat: add `ArrayValue.flatten` method that removes one level of nesting from array values

### DIFF
--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -816,6 +816,7 @@ _simple_ops = {
     ops.ExtractPath: "path",
     ops.ExtractFragment: "fragment",
     ops.ArrayPosition: "indexOf",
+    ops.ArrayFlatten: "arrayFlatten",
 }
 
 

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -496,6 +496,7 @@ operation_registry.update(
         ops.TimestampDelta: _temporal_delta,
         ops.ToJSONMap: _to_json_collection,
         ops.ToJSONArray: _to_json_collection,
+        ops.ArrayFlatten: unary(sa.func.flatten),
     }
 )
 

--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 import operator
 from functools import partial
 from typing import TYPE_CHECKING, Any
@@ -147,3 +148,10 @@ def execute_array_collect_groupby(op, data, where, aggcontext=None, **kwargs):
 @execute_node.register(ops.Unnest, pd.Series)
 def execute_unnest(op, data, **kwargs):
     return data.explode()
+
+
+@execute_node.register(ops.ArrayFlatten, pd.Series)
+def execute_array_flatten(op, data, **kwargs):
+    return data.map(
+        lambda v: list(itertools.chain.from_iterable(v)), na_action="ignore"
+    )

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -885,6 +885,11 @@ def array_collect(op, **kw):
     return arg
 
 
+@translate.register(ops.ArrayFlatten)
+def array_flatten(op, **kw):
+    return pl.concat_list(translate(op.arg, **kw))
+
+
 _date_methods = {
     ops.ExtractDay: "day",
     ops.ExtractMonth: "month",

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -2072,3 +2072,8 @@ def compile_levenshtein(t, op, **kwargs):
     left = t.translate(op.left, **kwargs)
     right = t.translate(op.right, **kwargs)
     return F.levenshtein(left, right)
+
+
+@compiles(ops.ArrayFlatten)
+def compile_flatten(t, op, **kwargs):
+    return F.flatten(t.translate(op.arg, **kwargs))

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -422,6 +422,7 @@ operation_registry.update(
         ops.ArrayZip: _array_zip,
         ops.ArraySort: unary(sa.func.array_sort),
         ops.ArrayRepeat: fixed_arity(sa.func.ibis_udfs.public.array_repeat, 2),
+        ops.ArrayFlatten: fixed_arity(sa.func.array_flatten, 1),
         ops.StringSplit: fixed_arity(sa.func.split, 2),
         # snowflake typeof only accepts VARIANT, so we cast
         ops.TypeOf: unary(lambda arg: sa.func.typeof(sa.func.to_variant(arg))),

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -860,7 +860,7 @@ def flatten_data():
 @pytest.mark.notyet(
     ["bigquery"],
     reason="BigQuery doesn't support arrays of arrays",
-    raises=BadRequest,
+    raises=TypeError,
 )
 @pytest.mark.notyet(
     ["postgres"],
@@ -900,6 +900,8 @@ def flatten_data():
         ),
     ],
 )
+@pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(["datafusion"], raises=com.OperationNotDefinedError)
 def test_array_flatten(backend, flatten_data, column, expected):
     data = flatten_data[column]
     t = ibis.memtable(

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -417,6 +417,7 @@ operation_registry.update(
         ops.ArraySort: fixed_arity(sa.func.array_sort, 1),
         ops.ArrayRemove: fixed_arity(sa.func.array_remove, 2),
         ops.ArrayUnion: fixed_arity(sa.func.array_union, 2),
+        ops.ArrayFlatten: unary(sa.func.flatten),
         ops.JSONGetItem: _json_get_item,
         ops.ExtractDayOfYear: unary(sa.func.day_of_year),
         ops.ExtractWeekOfYear: unary(sa.func.week_of_year),

--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -186,3 +186,19 @@ class ArrayZip(Value):
                 }
             )
         )
+
+
+@public
+class ArrayFlatten(Value):
+    """Flatten a nested array one level.
+
+    The input expression must have at least one level of nesting for flattening
+    to make sense.
+    """
+
+    arg: Value[dt.Array[dt.Array]]
+    shape = rlz.shape_like("arg")
+
+    @property
+    def dtype(self):
+        return self.arg.dtype.value_type


### PR DESCRIPTION
This PR implements `ArrayFlatten` which can be used to remove a single level of
nesting from a nested array value.

Closes #7575.

#### Backend support

- [ ] ~BigQuery~ (BigQuery doesn't support arrays of arrays)
- [x] ClickHouse
- [ ] ~DataFusion~ (Doesn't implement a flatten function)
- [x] DuckDB
- [x] Polars
- [ ] ~Postgres~ (Postgres doesn't preserve dimension information in user-facing way)
- [x] PySpark
- [x] Snowflake
- [x] Trino
