### PR TITLE
refactor(bigquery): move `BigQueryType` to use sqlglot for type parsing and generation

### DIFF
--- a/ibis/backends/base/sqlglot/datatypes.py
+++ b/ibis/backends/base/sqlglot/datatypes.py
@@ -257,13 +257,15 @@ class SqlglotType(TypeMapper):
     @classmethod
     def _from_ibis_Array(cls, dtype: dt.Array) -> sge.DataType:
         value_type = cls.from_ibis(dtype.value_type)
-        return sge.DataType(this=typecode.ARRAY, expressions=[value_type])
+        return sge.DataType(this=typecode.ARRAY, expressions=[value_type], nested=True)
 
     @classmethod
     def _from_ibis_Map(cls, dtype: dt.Map) -> sge.DataType:
         key_type = cls.from_ibis(dtype.key_type)
         value_type = cls.from_ibis(dtype.value_type)
-        return sge.DataType(this=typecode.MAP, expressions=[key_type, value_type])
+        return sge.DataType(
+            this=typecode.MAP, expressions=[key_type, value_type], nested=True
+        )
 
     @classmethod
     def _from_ibis_Struct(cls, dtype: dt.Struct) -> sge.DataType:
@@ -271,7 +273,7 @@ class SqlglotType(TypeMapper):
             sge.ColumnDef(this=str(name), kind=cls.from_ibis(field))
             for name, field in dtype.items()
         ]
-        return sge.DataType(this=typecode.STRUCT, expressions=fields)
+        return sge.DataType(this=typecode.STRUCT, expressions=fields, nested=True)
 
     @classmethod
     def _from_ibis_Decimal(cls, dtype: dt.Decimal) -> sge.DataType:

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -36,7 +36,6 @@ from ibis.backends.bigquery.client import (
 )
 from ibis.backends.bigquery.compiler import BigQueryCompiler
 from ibis.backends.bigquery.datatypes import BigQuerySchema, BigQueryType
-from ibis.formats.pandas import PandasData
 
 with contextlib.suppress(ImportError):
     from ibis.backends.bigquery.udf import udf  # noqa: F401
@@ -709,6 +708,8 @@ class Backend(BaseSQLBackend, CanCreateSchema):
         return expr.__pandas_result__(result)
 
     def fetch_from_cursor(self, cursor, schema):
+        from ibis.formats.pandas import PandasData
+
         arrow_t = self._cursor_to_arrow(cursor)
         df = arrow_t.to_pandas(timestamp_as_object=True)
         return PandasData.convert_table(df, schema)
@@ -988,11 +989,7 @@ class Backend(BaseSQLBackend, CanCreateSchema):
         column_defs = [
             sg.exp.ColumnDef(
                 this=name,
-                kind=sg.parse_one(
-                    BigQueryType.from_ibis(typ),
-                    into=sg.exp.DataType,
-                    read=self.name,
-                ),
+                kind=BigQueryType.from_ibis(typ),
                 constraints=(
                     None
                     if typ.nullable or typ.is_array()

--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -75,7 +75,7 @@ def bigquery_cast_floating_to_integer(compiled_arg, from_, to):
 @bigquery_cast.register(str, dt.DataType, dt.DataType)
 def bigquery_cast_generate(compiled_arg, from_, to):
     """Cast to desired type."""
-    sql_type = BigQueryType.from_ibis(to)
+    sql_type = BigQueryType.to_string(to)
     return f"CAST({compiled_arg} AS {sql_type})"
 
 
@@ -337,7 +337,7 @@ def _literal(t, op):
 
     if value is None:
         if not dtype.is_null():
-            return f"CAST(NULL AS {BigQueryType.from_ibis(dtype)})"
+            return f"CAST(NULL AS {BigQueryType.to_string(dtype)})"
         return "NULL"
     elif dtype.is_boolean():
         return str(value).upper()
@@ -350,7 +350,7 @@ def _literal(t, op):
             prefix = "-" * value.is_signed()
             return f"CAST('{prefix}inf' AS FLOAT64)"
         else:
-            return f"{BigQueryType.from_ibis(dtype)} '{value}'"
+            return f"{BigQueryType.to_string(dtype)} '{value}'"
     elif dtype.is_uuid():
         return _sg_literal(str(value))
     elif dtype.is_numeric():
@@ -564,7 +564,7 @@ def compiles_string_to_timestamp(translator, op):
 
 
 def compiles_floor(t, op):
-    bigquery_type = BigQueryType.from_ibis(op.dtype)
+    bigquery_type = BigQueryType.to_string(op.dtype)
     arg = op.arg
     return f"CAST(FLOOR({t.translate(arg)}) AS {bigquery_type})"
 

--- a/ibis/backends/bigquery/udf/__init__.py
+++ b/ibis/backends/bigquery/udf/__init__.py
@@ -261,10 +261,10 @@ return {f.__name__}({args});\
             libraries = []
 
         bigquery_signature = ", ".join(
-            f"{name} {BigQueryType.from_ibis(dt.dtype(type_))}"
+            f"{name} {BigQueryType.to_string(dt.dtype(type_))}"
             for name, type_ in params.items()
         )
-        return_type = BigQueryType.from_ibis(dt.dtype(output_type))
+        return_type = BigQueryType.to_string(dt.dtype(output_type))
         libraries_opts = (
             f"\nOPTIONS (\n    library={list(libraries)!r}\n)" if libraries else ""
         )
@@ -361,14 +361,14 @@ RETURNS {return_type}
             name: rlz.ValueOf(None if type_ == "ANY TYPE" else type_)
             for name, type_ in params.items()
         }
-        return_type = BigQueryType.from_ibis(dt.dtype(output_type))
+        return_type = BigQueryType.to_string(dt.dtype(output_type))
 
         bigquery_signature = ", ".join(
             "{name} {type}".format(
                 name=name,
                 type="ANY TYPE"
                 if type_ == "ANY TYPE"
-                else BigQueryType.from_ibis(dt.dtype(type_)),
+                else BigQueryType.to_string(dt.dtype(type_)),
             )
             for name, type_ in params.items()
         )


### PR DESCRIPTION
This PR moves the BigQuery type mapper to use sqlglot instead of the string munging we are currently using. Closes #7531.