### PR TITLE
feat(api): add timestamp range support

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import atexit
 import glob
+import warnings
 from contextlib import closing, suppress
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
@@ -169,6 +170,11 @@ class Backend(BaseBackend, CanCreateDatabase):
             compress=compression,
             **kwargs,
         )
+        try:
+            with closing(self.raw_sql("SET session_timezone = 'UTC'")):
+                pass
+        except Exception as e:  # noqa: BLE001
+            warnings.warn(f"Could not set timezone to UTC: {e}", category=UserWarning)
         self._temp_views = set()
 
     @property

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/d/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/d/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDate(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toDate(makeDateTime(2009, 5, 17, 12, 34, 56)) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/h/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/h/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toStartOfHour(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toStartOfHour(makeDateTime(2009, 5, 17, 12, 34, 56)) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/m/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/m/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toStartOfMinute(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toStartOfMinute(makeDateTime(2009, 5, 17, 12, 34, 56)) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/minute/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/minute/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toStartOfMinute(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toStartOfMinute(makeDateTime(2009, 5, 17, 12, 34, 56)) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/w/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/w/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toMonday(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toMonday(makeDateTime(2009, 5, 17, 12, 34, 56)) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/y/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/y/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toStartOfYear(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toStartOfYear(makeDateTime(2009, 5, 17, 12, 34, 56)) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/micros/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/micros/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime64('2015-01-01T12:34:56.789321', 6) AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789321)"
+  makeDateTime64(2015, 1, 1, 12, 34, 56, 789321, 6) AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789321)"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/micros_tz/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/micros_tz/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime64('2015-01-01T12:34:56.789321', 6, 'UTC') AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789321, tzinfo=tzutc())"
+  makeDateTime64(2015, 1, 1, 12, 34, 56, 789321, 6, 'UTC') AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789321, tzinfo=tzutc())"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/millis/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/millis/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime64('2015-01-01T12:34:56.789000', 3) AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789000)"
+  makeDateTime64(2015, 1, 1, 12, 34, 56, 789, 3) AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789000)"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/millis_tz/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/millis_tz/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime64('2015-01-01T12:34:56.789000', 3, 'UTC') AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789000, tzinfo=tzutc())"
+  makeDateTime64(2015, 1, 1, 12, 34, 56, 789, 3, 'UTC') AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789000, tzinfo=tzutc())"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr0/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr0/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime('2015-01-01T12:34:56') AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"
+  makeDateTime(2015, 1, 1, 12, 34, 56) AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr1/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr1/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime('2015-01-01T12:34:56') AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"
+  makeDateTime(2015, 1, 1, 12, 34, 56) AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr2/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr2/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime('2015-01-01T12:34:56') AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"
+  makeDateTime(2015, 1, 1, 12, 34, 56) AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"

--- a/ibis/backends/dask/execution/temporal.py
+++ b/ibis/backends/dask/execution/temporal.py
@@ -32,7 +32,7 @@ from ibis.backends.pandas.execution.temporal import (
     execute_date_sub_diff_series_date,
     execute_day_of_week_index_series,
     execute_day_of_week_name_series,
-    execute_epoch_seconds,
+    execute_epoch_seconds_series,
     execute_extract_microsecond_series,
     execute_extract_millisecond_series,
     execute_extract_timestamp_field_series,
@@ -61,7 +61,7 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ops.ExtractTemporalField: [((dd.Series,), execute_extract_timestamp_field_series)],
     ops.ExtractMicrosecond: [((dd.Series,), execute_extract_microsecond_series)],
     ops.ExtractMillisecond: [((dd.Series,), execute_extract_millisecond_series)],
-    ops.ExtractEpochSeconds: [((dd.Series,), execute_epoch_seconds)],
+    ops.ExtractEpochSeconds: [((dd.Series,), execute_epoch_seconds_series)],
     ops.IntervalFromInteger: [((dd.Series,), execute_interval_from_integer_series)],
     ops.IntervalAdd: [
         (

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -183,7 +183,7 @@ def _literal(t, op):
     sqla_type = t.get_sqla_type(dtype)
 
     if dtype.is_interval():
-        return sa.literal_column(f"INTERVAL '{value} {dtype.resolution}'")
+        return getattr(sa.func, f"to_{dtype.unit.plural}")(value)
     elif dtype.is_array():
         values = value.tolist() if isinstance(value, np.ndarray) else value
         return sa.cast(sa.func.list_value(*values), sqla_type)
@@ -550,6 +550,8 @@ operation_registry.update(
         ops.GeoWithin: fixed_arity(sa.func.ST_Within, 2),
         ops.GeoX: unary(sa.func.ST_X),
         ops.GeoY: unary(sa.func.ST_Y),
+        # other ops
+        ops.TimestampRange: fixed_arity(sa.func.range, 3),
     }
 )
 

--- a/ibis/backends/pandas/execution/temporal.py
+++ b/ibis/backends/pandas/execution/temporal.py
@@ -65,9 +65,19 @@ def execute_extract_microsecond_series(op, data, **kwargs):
     return data.dt.microsecond.astype(np.int32)
 
 
-@execute_node.register(ops.ExtractEpochSeconds, (datetime.datetime, pd.Series))
-def execute_epoch_seconds(op, data, **kwargs):
-    return data.astype("datetime64[s]").astype("int64").astype("int32")
+@execute_node.register(ops.ExtractEpochSeconds, pd.Series)
+def execute_epoch_seconds_series(op, data, **kwargs):
+    return (
+        data.astype("datetime64[ns]")
+        .astype("int64")
+        .floordiv(1_000_000_000)
+        .astype("int32")
+    )
+
+
+@execute_node.register(ops.ExtractEpochSeconds, (pd.Timestamp, datetime.datetime))
+def execute_epoch_seconds_literal(op, data, **kwargs):
+    return pd.Timestamp(data).floor("s").value // 1_000_000_000
 
 
 @execute_node.register(

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1205,7 +1205,9 @@ def execute_agg_udf(op, **kw):
 @translate.register(ops.IntegerRange)
 def execute_integer_range(op, **kw):
     if not isinstance(op.step, ops.Literal):
-        raise NotImplementedError("Dynamic step not supported by Polars")
+        raise com.UnsupportedOperationError(
+            "Dynamic integer step not supported by Polars"
+        )
     step = op.step.value
 
     dtype = dtype_to_polars(op.dtype)
@@ -1217,3 +1219,17 @@ def execute_integer_range(op, **kw):
     start = translate(op.start, **kw)
     stop = translate(op.stop, **kw)
     return pl.int_ranges(start, stop, step, dtype=dtype)
+
+
+@translate.register(ops.TimestampRange)
+def execute_timestamp_range(op, **kw):
+    if not isinstance(op.step, ops.Literal):
+        raise com.UnsupportedOperationError(
+            "Dynamic interval step not supported by Polars"
+        )
+    step = op.step.value
+    unit = op.step.dtype.unit.value
+
+    start = translate(op.start, **kw)
+    stop = translate(op.stop, **kw)
+    return pl.datetime_ranges(start, stop, f"{step}{unit}", closed="left")

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -134,9 +134,16 @@ class TestConf(BackendTest):
     def connect(*, tmpdir, worker_id, **kw):
         from pyspark.sql import SparkSession
 
+        # Spark internally stores timestamps as UTC values, and timestamp
+        # data that is brought in without a specified time zone is
+        # converted as local time to UTC with microsecond resolution.
+        # https://spark.apache.org/docs/latest/sql-pyspark-pandas-with-arrow.html#timestamp-with-time-zone-semantics
         spark = (
             SparkSession.builder.appName("ibis_testing")
             .master("local[1]")
+            .config("spark.sql.session.timeZone", "UTC")
+            .config("spark.driver.extraJavaOptions", "-Duser.timezone=GMT")
+            .config("spark.executor.extraJavaOptions", "-Duser.timezone=GMT")
             .config("spark.cores.max", 1)
             .config("spark.executor.heartbeatInterval", "3600s")
             .config("spark.executor.instances", 1)

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from typing import TYPE_CHECKING
 
 from ibis.formats.pandas import PandasData
@@ -18,7 +19,31 @@ class SnowflakePandasData(PandasData):
         converter = SnowflakePandasData.convert_JSON_element(dtype)
         return s.map(converter, na_action="ignore").astype("object")
 
-    convert_Struct = convert_Array = convert_Map = convert_JSON
+    convert_Struct = convert_Map = convert_JSON
+
+    @staticmethod
+    def get_element_converter(dtype):
+        funcgen = getattr(
+            SnowflakePandasData,
+            f"convert_{type(dtype).__name__}_element",
+            lambda _: lambda x: x,
+        )
+        return funcgen(dtype)
+
+    def convert_Timestamp_element(dtype):
+        return lambda values: list(map(datetime.datetime.fromisoformat, values))
+
+    def convert_Date_element(dtype):
+        return lambda values: list(map(datetime.date.fromisoformat, values))
+
+    def convert_Time_element(dtype):
+        return lambda values: list(map(datetime.time.fromisoformat, values))
+
+    @staticmethod
+    def convert_Array(s, dtype, pandas_type):
+        raw_json_objects = SnowflakePandasData.convert_JSON(s, dtype, pandas_type)
+        converter = SnowflakePandasData.get_element_converter(dtype.value_type)
+        return raw_json_objects.map(converter, na_action="ignore")
 
 
 class SnowflakePyArrowData(PyArrowData):

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -14,35 +14,29 @@ if TYPE_CHECKING:
 
 
 class SnowflakePandasData(PandasData):
-    @staticmethod
-    def convert_JSON(s, dtype, pandas_type):
-        converter = SnowflakePandasData.convert_JSON_element(dtype)
+    @classmethod
+    def convert_JSON(cls, s, dtype, pandas_type):
+        converter = cls.convert_JSON_element(dtype)
         return s.map(converter, na_action="ignore").astype("object")
 
     convert_Struct = convert_Map = convert_JSON
 
-    @staticmethod
-    def get_element_converter(dtype):
-        funcgen = getattr(
-            SnowflakePandasData,
-            f"convert_{type(dtype).__name__}_element",
-            lambda _: lambda x: x,
-        )
-        return funcgen(dtype)
+    @classmethod
+    def convert_Timestamp_element(cls, dtype):
+        return datetime.datetime.fromisoformat
 
-    def convert_Timestamp_element(dtype):
-        return lambda values: list(map(datetime.datetime.fromisoformat, values))
+    @classmethod
+    def convert_Date_element(cls, dtype):
+        return datetime.date.fromisoformat
 
-    def convert_Date_element(dtype):
-        return lambda values: list(map(datetime.date.fromisoformat, values))
+    @classmethod
+    def convert_Time_element(cls, dtype):
+        return datetime.time.fromisoformat
 
-    def convert_Time_element(dtype):
-        return lambda values: list(map(datetime.time.fromisoformat, values))
-
-    @staticmethod
-    def convert_Array(s, dtype, pandas_type):
-        raw_json_objects = SnowflakePandasData.convert_JSON(s, dtype, pandas_type)
-        converter = SnowflakePandasData.get_element_converter(dtype.value_type)
+    @classmethod
+    def convert_Array(cls, s, dtype, pandas_type):
+        raw_json_objects = cls.convert_JSON(s, dtype, pandas_type)
+        converter = cls.get_element_converter(dtype.value_type)
         return raw_json_objects.map(converter, na_action="ignore")
 
 

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -15,13 +15,6 @@ if TYPE_CHECKING:
 
 class SnowflakePandasData(PandasData):
     @classmethod
-    def convert_JSON(cls, s, dtype, pandas_type):
-        converter = cls.convert_JSON_element(dtype)
-        return s.map(converter, na_action="ignore").astype("object")
-
-    convert_Struct = convert_Map = convert_JSON
-
-    @classmethod
     def convert_Timestamp_element(cls, dtype):
         return datetime.datetime.fromisoformat
 
@@ -34,10 +27,24 @@ class SnowflakePandasData(PandasData):
         return datetime.time.fromisoformat
 
     @classmethod
+    def convert_JSON(cls, s, dtype, pandas_type):
+        converter = cls.convert_JSON_element(dtype)
+        return s.map(converter, na_action="ignore").astype("object")
+
+    @classmethod
     def convert_Array(cls, s, dtype, pandas_type):
         raw_json_objects = cls.convert_JSON(s, dtype, pandas_type)
-        converter = cls.get_element_converter(dtype.value_type)
-        return raw_json_objects.map(converter, na_action="ignore")
+        return super().convert_Array(raw_json_objects, dtype, pandas_type)
+
+    @classmethod
+    def convert_Map(cls, s, dtype, pandas_type):
+        raw_json_objects = cls.convert_JSON(s, dtype, pandas_type)
+        return super().convert_Map(raw_json_objects, dtype, pandas_type)
+
+    @classmethod
+    def convert_Struct(cls, s, dtype, pandas_type):
+        raw_json_objects = cls.convert_JSON(s, dtype, pandas_type)
+        return super().convert_Struct(raw_json_objects, dtype, pandas_type)
 
 
 class SnowflakePyArrowData(PyArrowData):

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -996,7 +996,11 @@ timestamp_range_tzinfos = pytest.mark.parametrize(
             ibis.interval(hours=-1),
             "-1H",
             id="neg_inner",
-            marks=[pytest.mark.notyet(["polars"], raises=PolarsComputeError)],
+            marks=[
+                pytest.mark.broken(
+                    ["polars"], raises=AssertionError, reason="returns an empty array"
+                )
+            ],
         ),
         param(
             datetime(2017, 1, 2),

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -344,10 +344,6 @@ def test_timestamp_extract_milliseconds(backend, alltypes, df):
     raises=GoogleBadRequest,
     reason="UNIX_SECONDS does not support DATETIME arguments",
 )
-@pytest.mark.xfail_version(
-    pyspark=["pandas<2.1"],
-    reason="test was adjusted to work with pandas 2.1 output; pyspark doesn't support pandas 2",
-)
 @pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract_epoch_seconds(backend, alltypes, df):
     expr = alltypes.timestamp_col.epoch_seconds().name("tmp")

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -354,7 +354,11 @@ def test_timestamp_extract_epoch_seconds(backend, alltypes, df):
     result = expr.execute()
 
     expected = backend.default_series_rename(
-        df.timestamp_col.astype("datetime64[s]").astype("int64").astype("int32")
+        df.timestamp_col.astype("datetime64[ns]")
+        .dt.floor("s")
+        .astype("int64")
+        .floordiv(1_000_000_000)
+        .astype("int32")
     )
     backend.assert_series_equal(result, expected)
 

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -350,17 +350,35 @@ def _interval_from_integer(t, op):
     return sa.type_coerce(sa.func.parse_duration(arg), INTERVAL)
 
 
-def _integer_range(t, op):
+def zero_value(dtype):
+    if dtype.is_interval():
+        # the unit doesn't matter here, because e.g. 0d = 0s
+        return sa.func.parse_duration("0s")
+    return 0
+
+
+def interval_sign(v):
+    zero = sa.func.parse_duration("0s")
+    return sa.case((v == zero, 0), (v < zero, -1), (v > zero, 1))
+
+
+def _sign(value, dtype):
+    if dtype.is_interval():
+        return interval_sign(value)
+    return sa.func.sign(value)
+
+
+def _range(t, op):
     start = t.translate(op.start)
     stop = t.translate(op.stop)
     step = t.translate(op.step)
     satype = t.get_sqla_type(op.dtype)
-    # `sequence` doesn't allow arguments that would produce an empty range, so
-    # check that first
-    n = sa.func.floor((stop - start) / sa.func.nullif(step, 0))
+    zero = zero_value(op.step.dtype)
     return if_(
-        n > 0,
-        # TODO(cpcloud): revisit using array_remove when my brain is working
+        sa.and_(
+            sa.func.nullif(step, zero).is_not(None),
+            _sign(step, op.step.dtype) == _sign(stop - start, op.step.dtype),
+        ),
         sa.func.array_remove(
             sa.func.sequence(start, stop, step, type_=satype), stop, type_=satype
         ),
@@ -565,7 +583,8 @@ operation_registry.update(
         ops.IntervalAdd: fixed_arity(operator.add, 2),
         ops.IntervalSubtract: fixed_arity(operator.sub, 2),
         ops.IntervalFromInteger: _interval_from_integer,
-        ops.IntegerRange: _integer_range,
+        ops.IntegerRange: _range,
+        ops.TimestampRange: _range,
     }
 )
 

--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -217,3 +217,10 @@ class IntegerRange(Range):
     start: Value[dt.Integer]
     stop: Value[dt.Integer]
     step: Value[dt.Integer]
+
+
+@public
+class TimestampRange(Range):
+    start: Value[dt.Timestamp]
+    stop: Value[dt.Timestamp]
+    step: Value[dt.Interval]

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -1070,7 +1070,7 @@ def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayVa
     Create an array scalar from Python literals
 
     >>> ibis.array([1.0, 2.0, 3.0])
-    [1.0, 2.0, 3.0]
+    [1.0, 2.0, ... +1]
 
     Mixing scalar and column expressions is allowed
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1027,7 +1027,7 @@ class Value(Expr):
         │ b      │     5 │
         └────────┴───────┘
         >>> t.value.collect()
-        [1, 2, 3, 4, 5]
+        [1, 2, ... +3]
         >>> type(t.value.collect())
         <class 'ibis.expr.types.arrays.ArrayScalar'>
 
@@ -1229,7 +1229,18 @@ class Value(Expr):
 @public
 class Scalar(Value):
     def __interactive_rich_console__(self, console, options):
-        return console.render(repr(self.execute()), options=options)
+        import rich.pretty
+
+        interactive = ibis.options.repr.interactive
+        return console.render(
+            rich.pretty.Pretty(
+                self.execute(),
+                max_length=interactive.max_length,
+                max_string=interactive.max_string,
+                max_depth=interactive.max_depth,
+            ),
+            options=options,
+        )
 
     def __pyarrow_result__(
         self, table: pa.Table, data_mapper: type[PyArrowData] | None = None

--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -385,7 +385,7 @@ class MapValue(Value):
         >>> m1 = ibis.map({"a": 1, "b": 2})
         >>> m2 = ibis.map({"c": 3, "d": 4})
         >>> m1 + m2
-        {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        {'a': 1, 'b': 2, ... +2}
         """
         return ops.MapMerge(self, other).to_expr()
 
@@ -409,7 +409,7 @@ class MapValue(Value):
         >>> m1 = ibis.map({"a": 1, "b": 2})
         >>> m2 = ibis.map({"c": 3, "d": 4})
         >>> m1 + m2
-        {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        {'a': 1, 'b': 2, ... +2}
         """
         return ops.MapMerge(self, other).to_expr()
 


### PR DESCRIPTION
This PR adds timestamp range support.

Backend support:

- [x] BigQuery
- [x] ClickHouse: adopted a similar approach to the Snowflake backend (adding an offset multiple to each element)
- [x] DuckDB
- [x] Polars
- [x] Postgres
- [x] PySpark
- [x] Snowflake: partial support, only literal inputs are supported
- [x] Trino
