### PR TITLE
test(flink): use unordered comparisons for series and dataframe assertions

### DIFF
--- a/ibis/backends/flink/tests/conftest.py
+++ b/ibis/backends/flink/tests/conftest.py
@@ -6,10 +6,10 @@ import pytest
 
 import ibis
 from ibis.backends.conftest import TEST_TABLES
-from ibis.backends.tests.base import BackendTest, RoundAwayFromZero
+from ibis.backends.tests.base import BackendTest, RoundAwayFromZero, UnorderedComparator
 
 
-class TestConf(BackendTest, RoundAwayFromZero):
+class TestConf(UnorderedComparator, BackendTest, RoundAwayFromZero):
     supports_structs = False
     deps = "pandas", "pyflink"
 


### PR DESCRIPTION
The previous attempts to address this did not work. I believe we need to use `UnorderedComparator` for testing the Flink backend.