### PR TITLE
fix(parse_sql): parse IN clauses

### DIFF
--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -260,6 +260,13 @@ def convert_sum(reduction, catalog):
     return getattr(this, method)()
 
 
+@convert.register(sge.In)
+def convert_in(in_, catalog):
+    this = convert(in_.this, catalog=catalog)
+    candidates = [convert(expression, catalog) for expression in in_.expressions]
+    return this.isin(candidates)
+
+
 @public
 @experimental
 def parse_sql(sqlstring, catalog, dialect=None):

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_in_clause/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_in_clause/decompiled.py
@@ -1,0 +1,19 @@
+import ibis
+
+
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+
+result = employee.select(employee.first_name).filter(
+    employee.first_name.isin(
+        (
+            ibis.literal("Graham"),
+            ibis.literal("John"),
+            ibis.literal("Terry"),
+            ibis.literal("Eric"),
+            ibis.literal("Michael"),
+        )
+    )
+)

--- a/ibis/expr/tests/test_sql.py
+++ b/ibis/expr/tests/test_sql.py
@@ -139,3 +139,13 @@ ORDER BY id DESC"""
     expr = ibis.parse_sql(sql, catalog)
     code = ibis.decompile(expr, format=True)
     snapshot.assert_match(code, "decompiled.py")
+
+
+def test_parse_sql_in_clause(snapshot):
+    sql = """
+SELECT first_name FROM employee
+WHERE first_name IN ('Graham', 'John', 'Terry', 'Eric', 'Michael')"""
+
+    expr = ibis.parse_sql(sql, catalog)
+    code = ibis.decompile(expr, format=True)
+    snapshot.assert_match(code, "decompiled.py")


### PR DESCRIPTION
With #7610 merged, now this fix for IN clauses in `parse_sql` should work. 