### PR TITLE
ci(flink): don't raise compressed class space size

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -353,12 +353,12 @@ jobs:
           IBIS_TEST_WEBHDFS_USER: hdfs
           IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
 
+      # FIXME(deepyaman): If some backend-specific test, in test_ddl.py,
+      #   executes before common tests, they will fail with:
+      #   org.apache.flink.table.api.ValidationException: Table `default_catalog`.`default_database`.`functional_alltypes` was not found.
+      #   Therefore, we run backend-specific tests second to avoid this.
       - name: "run serial tests: ${{ matrix.backend.name }}"
         if: matrix.backend.serial && matrix.backend.name == 'flink'
-        # FIXME(deepyaman): If some backend-specific test, in test_ddl.py,
-        # executes before common tests, they will fail with:
-        # org.apache.flink.table.api.ValidationException: Table `default_catalog`.`default_database`.`functional_alltypes` was not found.
-        # Therefore, we quarantine backend-specific tests to avoid this.
         run: |
           just ci-check -m ${{ matrix.backend.name }} ibis/backends/tests
           just ci-check -m ${{ matrix.backend.name }} ibis/backends/flink/tests
@@ -366,7 +366,6 @@ jobs:
           IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
           FLINK_REMOTE_CLUSTER_ADDR: localhost
           FLINK_REMOTE_CLUSTER_PORT: "8081"
-          JVM_ARGS: -XX:CompressedClassSpaceSize=3G
 
       - name: "run serial tests: ${{ matrix.backend.name }}"
         if: matrix.backend.serial && matrix.backend.name != 'impala' && matrix.backend.name != 'flink'


### PR DESCRIPTION
Increasing compressed class space size is only necessary if running the test suite using mini-cluster, but the CI here is using a remote, Dockerized cluster.