### PR TITLE
refactor(duckdb): use pyarrow for all memtable registration

### DIFF
--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -367,3 +367,11 @@ def test_register_filesystem_gcs(con):
     )
 
     assert band_members.count().to_pyarrow()
+
+
+def test_memtable_null_column_parquet_dtype_roundtrip(con, tmp_path):
+    before = ibis.memtable({"a": [None, None, None]}, schema={"a": "string"})
+    before.to_parquet(tmp_path / "tmp.parquet")
+    after = ibis.read_parquet(tmp_path / "tmp.parquet")
+
+    assert before.a.type() == after.a.type()


### PR DESCRIPTION
Fixes #7621 

Potential performance impact for large dataframes getting converted to `pyarrow` before getting piped into PyArrow, but also... do we care?