### PR TITLE
fix(deferred): don't pass expression in fstringified error message

### DIFF
--- a/ibis/common/deferred.py
+++ b/ibis/common/deferred.py
@@ -51,7 +51,9 @@ class Resolver(Coercible, Hashable):
         elif isinstance(value, Deferred):
             return value._resolver
         else:
-            raise CoercionError(f"Cannot coerce {value!r} to {cls.__name__!r}")
+            raise CoercionError(
+                f"Cannot coerce {type(value).__name__!r} to {cls.__name__!r}"
+            )
 
 
 class Deferred(Slotted, Immutable, Final):


### PR DESCRIPTION
This is a weird one, BUT:
There is (at least) one case where, when trying to resolve a deferred value, we end up at the `CoercionError` exception with a non-deferred expression.

When `ibis.options.interactive = True`, we then attempt to render that expression using `rich` because that's what f-strings do.

Even though in the calling code, which here is in `CoercedTo.match`, we catch the `CoercionError`, the `CoercionError` never gets thrown because we've instead errored out trying to render an f-string that will never be seen.

If, instead of rendering the expression, we instead mention the expression type, that prevents the short-circuit.

Fixes #7627 


Alternatively, we would have a context manager that disables interactive mode, so we don't end up inadvertently executing expressions.