### PR TITLE
chore(flink): use `pytestmark` over repeated marks

### DIFF
--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -13,7 +13,7 @@ from ibis.backends.conftest import _get_backends_to_test
 sa = pytest.importorskip("sqlalchemy")
 sg = pytest.importorskip("sqlglot")
 
-pytestmark = pytest.mark.notimpl(["druid"])
+pytestmark = pytest.mark.notimpl(["druid", "flink"])
 
 
 @pytest.mark.never(
@@ -26,7 +26,6 @@ pytestmark = pytest.mark.notimpl(["druid"])
     reason="Not clear how to extract SQL from the backend",
     raises=(exc.OperationNotDefinedError, NotImplementedError, ValueError),
 )
-@pytest.mark.notimpl(["flink"], "WIP")
 def test_table(backend):
     expr = backend.functional_alltypes.select(c=_.int_col + 1)
     buf = io.StringIO()
@@ -84,7 +83,6 @@ no_sql_extraction = pytest.mark.notimpl(
 )
 @not_sql
 @no_sql_extraction
-@pytest.mark.notimpl(["flink"], "WIP")
 def test_literal(backend, expr):
     assert ibis.to_sql(expr, dialect=backend.name())
 
@@ -95,7 +93,6 @@ def test_literal(backend, expr):
 @pytest.mark.xfail_version(
     mssql=["sqlalchemy>=2"], reason="sqlalchemy 2 prefixes literals with `N`"
 )
-@pytest.mark.notimpl(["flink"], "WIP")
 def test_group_by_has_index(backend, snapshot):
     countries = ibis.table(
         dict(continent="string", population="int64"), name="countries"
@@ -121,7 +118,6 @@ def test_group_by_has_index(backend, snapshot):
 @pytest.mark.never(
     ["pandas", "dask", "datafusion", "polars", "pyspark"], reason="not SQL"
 )
-@pytest.mark.notimpl(["flink"], "WIP")
 def test_cte_refs_in_topo_order(backend, snapshot):
     mr0 = ibis.table(schema=ibis.schema(dict(key="int")), name="leaf")
 
@@ -137,7 +133,6 @@ def test_cte_refs_in_topo_order(backend, snapshot):
 @pytest.mark.never(
     ["pandas", "dask", "datafusion", "polars", "pyspark"], reason="not SQL"
 )
-@pytest.mark.notimpl(["flink"], "WIP")
 def test_isin_bug(con, snapshot):
     t = ibis.table(dict(x="int"), name="t")
     good = t[t.x > 2].x


### PR DESCRIPTION
Two options:

1. [Expect `to_sql` to fail, because we don't have a SQLGlot dialect for Flink, and don't feel like anything is "close enough."](https://github.com/ibis-project/ibis/pull/7639/commits/aef728321981585e79d38fbb15155a920b652b28)
2. [Use Hive (or some other?) dialect as a close-enough stand-in, in order to enable SQL rendering.](https://github.com/ibis-project/ibis/pull/7639/commits/4492ae5d0b6dcb0a5f45906e071ba2ecd386f4bb)

---

Double-checked--`to_sql` doesn't work without a SQLGlot dialect. ~I don't believe we've identified one that's "close enough".~

Wonder if https://github.com/apache/flink/blob/76f754833298beb3e7589d521e75325adf283bf3/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java#L270 might indicate that can start with something that's a basic ANSI dialect? However, using dialect `""` (the base SQLGlot dialect) results in SQL rendering errors, so I've tried Hive.