### PR TITLE
chore(flink): pin flink backend pyflink dependency version

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -164,7 +164,7 @@ jobs:
             extras:
               - flink
             additional_deps:
-              - apache-flink
+              - apache-flink==1.17.1
               - pytest-split
             services:
               - flink


### PR DESCRIPTION
pin pyflink to 1.17.1 until 1.18 official release