### PR TITLE
test(flink): revise mark for map dict construction

### DIFF
--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -227,8 +227,10 @@ def test_literal_map_get_broadcast(backend, alltypes, df):
         param(["a", "b"], ["1", "2"], id="int"),
     ],
 )
-@pytest.mark.notimpl(
-    ["flink"], raises=AssertionError, reason="WIP; got [('a', 1), ('b', 2)] instead"
+@pytest.mark.notyet(
+    ["flink"],
+    raises=AssertionError,
+    reason="got list of tuples instead; requires PyFlink compatibility with PyArrow 13",
 )
 def test_map_construct_dict(con, keys, values):
     expr = ibis.map(keys, values)


### PR DESCRIPTION
In short, this test needs PyArrow 13 to work, where [the `maps_as_pydicts` option for `pa.Table.to_pandas()` was introduced](https://github.com/apache/arrow/commit/1a697abd08d6db6ac1496e548dcdb86a9a82c152).

However, only PyFlink only supports up to PyArrow 11 (due to the Apache Beam dependency).

Once (if?) the Apache Beam dependency is relaxed, it would at least be possible to patch the PyFlink `Table.to_pandas()` call to call `pa.Table.to_pandas()` with `maps_as_pydicts="lossy"`, with the possibility of proposing the change in PyFlink `Table.to_pandas()` upstream.