### PR TITLE
docs: fix typos

### DIFF
--- a/docs/contribute/04_maintainers_guide.qmd
+++ b/docs/contribute/04_maintainers_guide.qmd
@@ -38,8 +38,8 @@ Assuming your file is called `example.csv`:
 1. Add a file named `ibis/examples/descriptions/example` that contains a
    description of your example. One line is best, but not necessary.
 1. Run one of the following **from the git root of an ibis clone**:
-   - `python ibis/examples/gen_registry.py` (doesn't include R dependenices)
-   - `nix run '.#gen-examples'` (includes R dependenices)
+   - `python ibis/examples/gen_registry.py` (doesn't include R dependencies)
+   - `nix run '.#gen-examples'` (includes R dependencies)
 
 ## Release
 

--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -169,7 +169,7 @@ def test_typeof(con, value, expected):
 
 
 @pytest.mark.parametrize(("value", "expected"), [("foo_bar", 7), ("", 0)])
-def test_string_length(con, value, expected):
+def test_tuple_string_length(con, value, expected):
     assert con.execute(L(value).length()) == expected
 
 
@@ -208,7 +208,7 @@ def test_string_lower(con):
     assert con.execute(L("FOO").lower()) == "foo"
 
 
-def test_string_lenght(con):
+def test_string_length(con):
     assert con.execute(L("FOO").length()) == 3
 
 

--- a/ibis/backends/dask/aggcontext.py
+++ b/ibis/backends/dask/aggcontext.py
@@ -140,7 +140,7 @@ class Window(AggregationContext):
             # (1) windowed.count() will exclude NaN observations
             #     , which results in incorrect window sizes.
             # (2) windowed.apply(len, raw=True) will include NaN
-            #     obversations, but doesn't work on non-numeric types.
+            #     observations, but doesn't work on non-numeric types.
             #     https://github.com/pandas-dev/pandas/issues/23002
             # To deal with this, we create a _placeholder column
             windowed_frame = self.construct_window(grouped_frame)

--- a/ibis/backends/dask/tests/test_client.py
+++ b/ibis/backends/dask/tests/test_client.py
@@ -119,10 +119,10 @@ def test_invalid_connection_parameter_types(npartitions):
             }
         )
 
-    expeced_msg = re.escape(
+    expected_msg = re.escape(
         "Expected an instance of 'dask.dataframe.DataFrame' for 'df', "
         "got an instance of 'str' instead."
     )
     con = ibis.dask.connect()
-    with pytest.raises(TypeError, match=expeced_msg):
+    with pytest.raises(TypeError, match=expected_msg):
         con.from_dataframe("file.csv")

--- a/ibis/backends/flink/tests/conftest.py
+++ b/ibis/backends/flink/tests/conftest.py
@@ -36,14 +36,14 @@ class TestConf(BackendTest):
         stream_env = gateway.jvm.org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
         flink_cluster_addr = os.environ.get("FLINK_REMOTE_CLUSTER_ADDR", "localhost")
         flink_cluster_port = int(os.environ.get("FLINK_REMOTE_CLUSTER_PORT", "8081"))
-        j_stream_exection_environment = stream_env.createRemoteEnvironment(
+        j_stream_execution_environment = stream_env.createRemoteEnvironment(
             flink_cluster_addr,
             flink_cluster_port,
             env_settings.getConfiguration(),
             string_array,
         )
 
-        env = StreamExecutionEnvironment(j_stream_exection_environment)
+        env = StreamExecutionEnvironment(j_stream_execution_environment)
         stream_table_env = StreamTableEnvironment.create(env)
         return ibis.flink.connect(stream_table_env, **kw)
 

--- a/ibis/backends/pandas/aggcontext.py
+++ b/ibis/backends/pandas/aggcontext.py
@@ -631,7 +631,7 @@ class Window(AggregationContext):
             # (1) windowed.count() will exclude NaN observations
             #     , which results in incorrect window sizes.
             # (2) windowed.apply(len, raw=True) will include NaN
-            #     obversations, but doesn't work on non-numeric types.
+            #     observations, but doesn't work on non-numeric types.
             #     https://github.com/pandas-dev/pandas/issues/23002
             # To deal with this, we create a _placeholder column
 

--- a/ibis/expr/operations/tests/test_core.py
+++ b/ibis/expr/operations/tests/test_core.py
@@ -89,7 +89,7 @@ def test_node_base():
     ]
 
 
-def test_node_subtitution():
+def test_node_substitution():
     class Aliased(Base):
         arg: ops.Node
         name: str

--- a/ibis/expr/tests/conftest.py
+++ b/ibis/expr/tests/conftest.py
@@ -298,7 +298,7 @@ MOCK_TABLES = {
         ("s_zip", "string"),
         ("s_country", "string"),
         ("s_gmt_offset", "decimal(5,2)"),
-        ("s_tax_precentage", "decimal(5,2)"),
+        ("s_tax_percentage", "decimal(5,2)"),
     ],
     "tpcds_store_sales": [
         ("ss_sold_time_sk", "bigint"),

--- a/ibis/tests/expr/test_interactive.py
+++ b/ibis/tests/expr/test_interactive.py
@@ -105,7 +105,7 @@ def test_compile_no_execute(con):
     assert con.executed_queries == []
 
 
-def test_isin_rule_supressed_exception_repr_not_fail(con):
+def test_isin_rule_suppressed_exception_repr_not_fail(con):
     with config.option_context("interactive", True):
         t = con.table("functional_alltypes")
         bool_clause = t["string_col"].notin(["1", "4", "7"])


### PR DESCRIPTION
Found via `typos --hidden --format brief`