### PR TITLE
docs: replace deprecated `relabel`s with `rename`s

### DIFF
--- a/docs/tutorials/ibis-for-pandas-users.qmd
+++ b/docs/tutorials/ibis-for-pandas-users.qmd
@@ -242,17 +242,17 @@ mutated
 ### Renaming columns
 
 In addition to replacing columns, you can rename them as well. This is done with
-the `relabel` method which takes a dictionary containing the name mappings.
+the `rename` method which takes a dictionary containing the name mappings.
 
 
 ```{python}
-relabeled = t.relabel(
+renamed = t.rename(
     dict(
-        one="a",
-        two="b",
+        a="one",
+        b="two",
     )
 )
-relabeled
+renamed
 ```
 
 ## Selecting rows


### PR DESCRIPTION
https://github.com/ibis-project/ibis/blob/11e03fa7003ff05bfc243a7cd16b0f791b488737/ibis/expr/types/relations.py#L2026-L2032