### PR TITLE
test: use backend assertions in backend test suite

### DIFF
--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pandas as pd
-import pandas.testing as tm
 import pyarrow as pa
 import pyarrow.csv as pcsv
 import pytest
@@ -404,7 +403,7 @@ def test_to_pyarrow_decimal(backend, dtype, pyarrow_dtype):
     raises=pa.lib.ArrowTypeError,
     reason="arrow type conversion fails in `to_delta` call",
 )
-def test_roundtrip_delta(con, alltypes, tmp_path, monkeypatch):
+def test_roundtrip_delta(backend, con, alltypes, tmp_path, monkeypatch):
     if con.name == "pyspark":
         pytest.importorskip("delta")
     else:
@@ -419,7 +418,7 @@ def test_roundtrip_delta(con, alltypes, tmp_path, monkeypatch):
     dt = ibis.read_delta(path)
     result = dt.to_pandas()
 
-    tm.assert_frame_equal(result, expected)
+    backend.assert_frame_equal(result, expected)
 
 
 @pytest.mark.xfail_version(

--- a/ibis/backends/tests/test_json.py
+++ b/ibis/backends/tests/test_json.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import sqlite3
 
 import pandas as pd
-import pandas.testing as tm
 import pytest
 from packaging.version import parse as vparse
 from pytest import param
@@ -40,10 +39,10 @@ pytestmark = [
     ["flink"],
     reason="https://github.com/ibis-project/ibis/pull/6920#discussion_r1373212503",
 )
-def test_json_getitem(json_t, expr_fn, expected):
+def test_json_getitem(backend, json_t, expr_fn, expected):
     expr = expr_fn(json_t)
     result = expr.execute()
-    tm.assert_series_equal(result.fillna(pd.NA), expected.fillna(pd.NA))
+    backend.assert_series_equal(result.fillna(pd.NA), expected.fillna(pd.NA))
 
 
 @pytest.mark.notimpl(["dask", "mysql", "pandas"])
@@ -52,7 +51,7 @@ def test_json_getitem(json_t, expr_fn, expected):
 @pytest.mark.notyet(
     ["pyspark", "trino", "flink"], reason="should work but doesn't deserialize JSON"
 )
-def test_json_map(json_t):
+def test_json_map(backend, json_t):
     expr = json_t.js.map.name("res")
     result = expr.execute()
     expected = pd.Series(
@@ -67,7 +66,7 @@ def test_json_map(json_t):
         dtype="object",
         name="res",
     )
-    tm.assert_series_equal(result, expected)
+    backend.assert_series_equal(result, expected)
 
 
 @pytest.mark.notimpl(["dask", "mysql", "pandas"])
@@ -76,10 +75,10 @@ def test_json_map(json_t):
     ["pyspark", "trino", "flink"], reason="should work but doesn't deserialize JSON"
 )
 @pytest.mark.notyet(["bigquery"], reason="doesn't allow null in arrays")
-def test_json_array(json_t):
+def test_json_array(backend, json_t):
     expr = json_t.js.array.name("res")
     result = expr.execute()
     expected = pd.Series(
         [None, None, None, None, [42, 47, 55], []], name="res", dtype="object"
     )
-    tm.assert_series_equal(result, expected)
+    backend.assert_series_equal(result, expected)

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
-import pandas.testing as tm
 import pytest
 from pytest import param
 
@@ -40,7 +39,7 @@ def test_column_map_values(backend):
     expr = table.select("idx", vals=table.kv.values()).order_by("idx")
     result = expr.execute().vals
     expected = pd.Series([[1, 2, 3], [4, 5, 6]], name="vals")
-    tm.assert_series_equal(result, expected)
+    backend.assert_series_equal(result, expected)
 
 
 @pytest.mark.notimpl(["pandas", "dask"])
@@ -57,7 +56,7 @@ def test_column_map_merge(backend):
     expected = pd.Series(
         [{"a": 1, "b": 2, "c": 3, "d": 1}, {"d": 1, "e": 5, "f": 6}], name="merged"
     )
-    tm.assert_series_equal(result, expected)
+    backend.assert_series_equal(result, expected)
 
 
 @pytest.mark.notimpl(

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
-import pandas.testing as tm
 import pytest
 import sqlalchemy as sa
 from pytest import param
@@ -175,7 +174,7 @@ def test_scalar_param_map(con):
         ),
     ],
 )
-def test_scalar_param(alltypes, df, value, dtype, col):
+def test_scalar_param(backend, alltypes, df, value, dtype, col):
     param = ibis.param(dtype)
     expr = alltypes.filter([_[col] == param])
 
@@ -183,7 +182,7 @@ def test_scalar_param(alltypes, df, value, dtype, col):
         expr.execute(params={param: value}).sort_values("id").reset_index(drop=True)
     )
     expected = df.loc[df[col] == value].sort_values("id").reset_index(drop=True)
-    tm.assert_frame_equal(result, expected)
+    backend.assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -55,13 +55,13 @@ _NULL_STRUCT_LITERAL = ibis.NA.cast("struct<a: int64, b: string, c: float64>")
 
 @pytest.mark.notimpl(["postgres"])
 @pytest.mark.parametrize("field", ["a", "b", "c"])
-def test_literal(con, field):
+def test_literal(backend, con, field):
     query = _STRUCT_LITERAL[field]
     dtype = query.type().to_pandas()
     result = pd.Series([con.execute(query)], dtype=dtype)
     result = result.replace({np.nan: None})
     expected = pd.Series([_SIMPLE_DICT[field]])
-    tm.assert_series_equal(result, expected.astype(dtype))
+    backend.assert_series_equal(result, expected.astype(dtype))
 
 
 @pytest.mark.notimpl(["postgres"])
@@ -69,16 +69,16 @@ def test_literal(con, field):
 @pytest.mark.notyet(
     ["clickhouse"], reason="clickhouse doesn't support nullable nested types"
 )
-def test_null_literal(con, field):
+def test_null_literal(backend, con, field):
     query = _NULL_STRUCT_LITERAL[field]
     result = pd.Series([con.execute(query)])
     result = result.replace({np.nan: None})
     expected = pd.Series([None], dtype="object")
-    tm.assert_series_equal(result, expected)
+    backend.assert_series_equal(result, expected)
 
 
 @pytest.mark.notimpl(["dask", "pandas", "postgres"])
-def test_struct_column(alltypes, df):
+def test_struct_column(backend, alltypes, df):
     t = alltypes
     expr = ibis.struct(dict(a=t.string_col, b=1, c=t.bigint_col)).name("s")
     assert expr.type() == dt.Struct(dict(a=dt.string, b=dt.int8, c=dt.int64))

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pandas.testing as tm
 import sqlalchemy as sa
 from pytest import mark, param
 
@@ -179,7 +178,7 @@ def add_one_pyarrow(s: int) -> int:  # s is series, int is the element type
         ),
     ],
 )
-def test_vectorized_udf(batting, add_one):
+def test_vectorized_udf(backend, batting, add_one):
     batting = batting.limit(100)
 
     expr = (
@@ -195,4 +194,4 @@ def test_vectorized_udf(batting, add_one):
         .sort_values(["year_id"])
         .reset_index(drop=True)
     )
-    tm.assert_frame_equal(result, expected)
+    backend.assert_frame_equal(result, expected)

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -5,7 +5,6 @@ from operator import methodcaller
 
 import numpy as np
 import pandas as pd
-import pandas.testing as tm
 import pytest
 import sqlalchemy as sa
 from pytest import param
@@ -681,7 +680,7 @@ def test_simple_ungrouped_unbound_following_window(
     raises=Exception,
     reason="Exception: Error during planning: Sort operation is not applicable to scalar value NULL",
 )
-def test_simple_ungrouped_window_with_scalar_order_by(backend, alltypes):
+def test_simple_ungrouped_window_with_scalar_order_by(alltypes):
     t = alltypes[alltypes.double_col < 50].order_by("id")
     w = ibis.window(rows=(0, None), order_by=ibis.NA)
     expr = t.double_col.sum().over(w).name("double_col")
@@ -1143,7 +1142,7 @@ def test_grouped_ordered_window_coalesce(backend, alltypes, df):
     raises=Exception,
     reason="Exception: Internal error: Expects default value to have Int64 type.",
 )
-def test_mutate_window_filter(backend, alltypes, df):
+def test_mutate_window_filter(backend, alltypes):
     t = alltypes
     win = ibis.window(order_by=[t.id])
     expr = (
@@ -1190,7 +1189,7 @@ def test_first_last(backend):
             "y_last": [3, 2, 0, 1, 1],
         }
     )
-    tm.assert_frame_equal(result, expected)
+    backend.assert_frame_equal(result, expected)
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/tpch/conftest.py
+++ b/ibis/backends/tests/tpch/conftest.py
@@ -6,7 +6,6 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
-import pandas.testing as tm
 import pytest
 import sqlglot as sg
 from dateutil.relativedelta import relativedelta
@@ -68,7 +67,7 @@ def tpch_test(test: Callable[..., ir.Table]):
         expected.columns = result.columns
 
         assert len(expected) == len(result)
-        tm.assert_frame_equal(result, expected, check_dtype=False)
+        backend.assert_frame_equal(result, expected, check_dtype=False)
 
         # only produce sql if the execution passes
         result_expr_sql = ibis.to_sql(result_expr, dialect=backend_name)


### PR DESCRIPTION
Fixes flakiness associated with backends whose results are arbitrarily ordered (e.g., https://github.com/ibis-project/ibis/actions/runs/7092619807/job/19304311500)