### PR TITLE
fix(polars): project first when creating computed grouping keys

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -267,9 +267,11 @@ def aggregation(op, **kw):
             )
         )
 
+    # project first to handle computed group by columns
+    lf = lf.with_columns([translate(arg, **kw) for arg in op.by])
+
     if op.by:
-        group_by = [translate(arg, **kw) for arg in op.by]
-        lf = lf.group_by(group_by).agg
+        lf = lf.group_by([pl.col(by.name) for by in op.by]).agg
     else:
         lf = lf.select
 

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1476,9 +1476,11 @@ def test_grouped_case(backend, con):
 
     case_expr = ibis.case().when(table.value < 25, table.value).else_(ibis.null()).end()
 
-    expr = table.group_by("key").aggregate(mx=case_expr.max()).order_by("key")
+    expr = (
+        table.group_by(k="key").aggregate(mx=case_expr.max()).dropna("k").order_by("k")
+    )
     result = con.execute(expr)
-    expected = pd.DataFrame({"key": [1, 2], "mx": [10, 20]})
+    expected = pd.DataFrame({"k": [1, 2], "mx": [10, 20]})
     backend.assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
Works around a bug in the polars where column names from computed grouping kyes are not propagated through to drop_nulls.