### PR TITLE
fix(datafusion): ensure that non-matching re_search calls return bool values when patterns do not match

### DIFF
--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 
+import numpy as np
 import pandas as pd
 import pytest
 import sqlalchemy as sa
@@ -1090,4 +1091,6 @@ def test_no_conditional_percent_escape(con, expr):
 )
 def test_non_match_regex_search_is_false(con):
     expr = ibis.literal("foo").re_search("bar")
-    assert con.execute(expr) is False
+    result = con.execute(expr)
+    assert isinstance(result, (bool, np.bool_))
+    assert not result

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1083,3 +1083,11 @@ def test_levenshtein(con, right):
 )
 def test_no_conditional_percent_escape(con, expr):
     assert con.execute(expr) == "%"
+
+
+@pytest.mark.notimpl(
+    ["dask", "pandas", "mssql", "oracle"], raises=com.OperationNotDefinedError
+)
+def test_non_match_regex_search_is_false(con):
+    expr = ibis.literal("foo").re_search("bar")
+    assert con.execute(expr) is False


### PR DESCRIPTION
Fixes an issue where we assume that non matching patterns return an empty array, when in fact they return null