### PR TITLE
feat: improve error for memtable(has_dupe_columns)

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -921,6 +921,13 @@ def test_memtable_bool_column(backend, con):
     )
 
 
+def test_memtable_duplicate_columns(backend, con):
+    df = pd.DataFrame(columns=["oops", "oops"], data=[[1, 2], [3, 4]])
+    with pytest.raises(ValueError) as e_info:
+        ibis.memtable(df)
+    assert "oops" in str(e_info.value)
+
+
 @pytest.mark.broken(
     ["druid"],
     raises=(

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -92,6 +92,12 @@ class PandasData(DataMapper):
                 ibis_dtype = schema[column_name]
             else:
                 pandas_column = df[column_name]
+                if isinstance(pandas_column, pd.DataFrame):
+                    raise ValueError(
+                        "Converting Pandas DataFrames with duplicate "
+                        "column names is not supported. Found duplicate "
+                        f"column name: {column_name}"
+                    )
                 pandas_dtype = pandas_column.dtype
                 if pandas_dtype == np.object_:
                     ibis_dtype = cls.infer_column(pandas_column)


### PR DESCRIPTION
I was accidentally doing this and was getting an attribute
error when ibis tried to lookup the
dtype on the following lines.
This should point users in the right direction better.