### PR TITLE
build: move `docker-compose.yml` to `compose.yaml`

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   clickhouse:
     image: clickhouse/clickhouse-server:23.11.1.2711-alpine

--- a/docs/contribute/02_workflow.qmd
+++ b/docs/contribute/02_workflow.qmd
@@ -42,7 +42,7 @@ pytest -m sqlite
 ## Setting up non-trivial backends
 
 These client-server backends need to be started before testing them.
-They can be started with `docker-compose` directly, or using the `just` tool.
+They can be started with `docker compose` directly, or using the `just` tool.
 
 - ClickHouse: `just up clickhouse`
 - PostgreSQL: `just up postgres`

--- a/ibis/backends/oracle/tests/conftest.py
+++ b/ibis/backends/oracle/tests/conftest.py
@@ -23,10 +23,10 @@ ORACLE_HOST = os.environ.get("IBIS_TEST_ORACLE_HOST", "localhost")
 ORACLE_PORT = int(os.environ.get("IBIS_TEST_ORACLE_PORT", 1521))
 
 # Creating test DB and user
-# The ORACLE_DB env-var needs to be set in the docker-compose.yml file
+# The ORACLE_DB env-var needs to be set in the compose.yaml file
 # Then, after the container is running, exec in and run (from `/opt/oracle`)
 # ./createAppUser user pass ORACLE_DB
-# where ORACLE_DB is the same name you used in the docker-compose file.
+# where ORACLE_DB is the same name you used in the Compose file.
 
 
 class TestConf(ServiceBackendTest):

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -346,9 +346,9 @@ class ServiceBackendTest(BackendTest):
     """
 
     service_name: str | None = None
-    "Name of service defined in docker-compose.yml corresponding to backend."
+    "Name of service defined in compose.yaml corresponding to backend."
     data_volume = "/data"
-    "Data volume defined in docker-compose.yml corresponding to backend."
+    "Data volume defined in compose.yaml corresponding to backend."
 
     @property
     @abc.abstractmethod


### PR DESCRIPTION
Reading https://docs.docker.com/compose/compose-file/03-compose-file/, apparently `compose.yaml` is preferred over `compose.yml` and `docker-compose.yml`. 

Also, `docker-compose` is only maintained as an alias of `docker compose` for compatibility in Docker Compose V2, and the `version` key in the Compose file is only maintained for backwards compatibility.