### PR TITLE
feat(flink): implement support for temporal and lookup joins

### DIFF
--- a/ibis/backends/flink/compiler/core.py
+++ b/ibis/backends/flink/compiler/core.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import functools
+from io import StringIO
 
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
+from ibis import util
 from ibis.backends.base.sql.compiler import (
     Compiler,
     Select,
@@ -18,6 +20,11 @@ from ibis.backends.flink.translator import FlinkExprTranslator
 
 
 class FlinkTableSetFormatter(TableSetFormatter):
+    _join_names = {
+        **TableSetFormatter._join_names,
+        ops.AsOfJoin: "JOIN",
+    }
+
     def _quote_identifier(self, name):
         return quote_identifier(name, force=True)
 
@@ -59,6 +66,92 @@ class FlinkTableSetFormatter(TableSetFormatter):
             result += f"({', '.join(self._quote_identifier(name) for name in names)})"
 
         return result
+
+    def get_result(self):
+        # Got to unravel the join stack; the nesting order could be
+        # arbitrary, so we do a depth first search and push the join tokens
+        # and predicates onto a flat list, then format them
+        op = self.node
+
+        if isinstance(op, ops.Join):
+            self._walk_join_tree(op)
+        else:
+            self.join_tables.append(self._format_table(op))
+
+        # TODO: Now actually format the things
+        buf = StringIO()
+        buf.write(self.join_tables[0])
+        for jtype, table, preds in zip(
+            self.join_types, self.join_tables[1:], self.join_predicates
+        ):
+            buf.write("\n")
+            buf.write(util.indent(f"{jtype} {table}", self.indent))
+
+            fmt_preds = []
+            npreds = len(preds)
+
+            if jtype == "JOIN":
+                # extract the closest match condition
+                pred = [pred for pred in preds if not isinstance(pred, ops.Equals)]
+                if len(pred) < 1:
+                    raise com.UnsupportedArgumentError(
+                        "ASOF JOIN requires exactly one closest match condition in the predicate,"
+                        " none is provided"
+                    )
+                if len(pred) > 1:
+                    raise com.UnsupportedOperationError(
+                        f"ASOF JOIN requires exactly one closest match condition in the predicate, "
+                        f"{len(pred)} are provided ({pred})"
+                    )
+                closest_match = next(iter(pred))
+
+                # extract the column from the condition
+                if isinstance(closest_match, (ops.GreaterEqual, ops.Greater)):
+                    asof = closest_match.left
+                elif isinstance(closest_match, (ops.LessEqual, ops.Less)):
+                    asof = closest_match.right
+                else:
+                    raise com.UnsupportedArgumentError(
+                        "ASOF JOIN only supports >, >=, <, <= for the closest match condition"
+                    )
+                if self._format_table(asof.table) != self.join_tables[0]:
+                    raise com.UnsupportedArgumentError(
+                        "ASOF JOIN condition must be defined on the left table"
+                    )
+
+                buf.write(f" FOR SYSTEM_TIME AS OF {self._translate(asof)}")
+
+                for pred in [pred for pred in preds if isinstance(pred, ops.Equals)]:
+                    new_pred = self._translate(pred)
+                    if npreds > 1:
+                        new_pred = f"({new_pred})"
+                    fmt_preds.append(new_pred)
+
+                if len(fmt_preds):
+                    buf.write("\n")
+
+                    conj = " AND\n{}".format(" " * 3)
+                    fmt_preds = util.indent(
+                        "ON " + conj.join(fmt_preds), self.indent * 2
+                    )
+                    buf.write(fmt_preds)
+            else:
+                for pred in preds:
+                    new_pred = self._translate(pred)
+                    if npreds > 1:
+                        new_pred = f"({new_pred})"
+                    fmt_preds.append(new_pred)
+
+                if len(fmt_preds):
+                    buf.write("\n")
+
+                    conj = " AND\n{}".format(" " * 3)
+                    fmt_preds = util.indent(
+                        "ON " + conj.join(fmt_preds), self.indent * 2
+                    )
+                    buf.write(fmt_preds)
+
+        return buf.getvalue()
 
 
 class FlinkSelectBuilder(SelectBuilder):


### PR DESCRIPTION
Implement support for temporal and lookup joins.

Temporal (time-versioned) joins require

- an equality predicate on the primary key of the versioned table
- a time attribute

and lookup joins require

- a lookup source connector, (e.g., JDBC, HBase, Hive, or something custom)
- an equality join predicate
- using a processing time attribute in combination with FOR SYSTEM_TIME AS OF (to prevent needing to update the join results)

An example processing time temporal join query that should execute in Flink:
```sql
CREATE TABLE time_left (
  `createTime` TIMESTAMP(3),
  `value` FLOAT,
  `key` STRING,
WATERMARK FOR createTime AS createTime - INTERVAL '1' SECOND
) WITH (
  'connector'='kafka',
  'properties.bootstrap.servers'='kafka-service:29092',
  'properties.group.id'='test_3',
  'scan.startup.mode'='earliest-offset',
  'topic'='time_left',
  'format' = 'json'
);

CREATE TABLE time_right (
  `createTime` TIMESTAMP(3),
  `value` FLOAT,
  `key` STRING PRIMARY KEY NOT ENFORCED,
WATERMARK FOR createTime AS createTime - INTERVAL '1' SECOND
) WITH (
  'connector'='upsert-kafka',
  'properties.bootstrap.servers'='kafka-service:29092',
  'properties.group.id'='test_3',
  'topic'='time_right',
  'key.format'='csv',
  'value.format' = 'avro'
);

CREATE TABLE `kafka_sink`
(`createTime` timestamp(3),
`value` float,
`key` string,
`value_right` float
)
WITH (
  'connector'='kafka',
  'properties.bootstrap.servers'='kafka-service:29092',
  'topic'='sink',
  'format' = 'json'
);

EXECUTE STATEMENT SET
BEGIN
INSERT INTO kafka_sink
SELECT t0.`createTime`, t0.`value`, t0.`key`, 
      time_right.`value` AS `value_right`
FROM time_left t0
  JOIN time_right FOR SYSTEM_TIME AS OF t0.`createTime`
    ON (t0.`key` = time_right.`key`);
END;
```

Can use the following for testing the generated SQL. Note that this cannot actually be executed because temporal/lookup joins require watermarks to be configured appropriately, and we're not configuring a watermark in this toy example.
1. Set up the connection.
```python
import ibis
from pyflink.table import EnvironmentSettings, TableEnvironment
from pyflink.common import Configuration

env_settings = EnvironmentSettings.in_streaming_mode()
table_env = TableEnvironment.create(env_settings)

table_config = table_env.get_config()
config = Configuration()
config.set_string("parallelism.default", "1")
table_config.add_configuration(config)

connection = ibis.flink.connect(table_env)
```
2. Create two tables from pandas dataframes.
```python
import pandas as pd

time_pd1 = pd.DataFrame(
    {
        "time": pd.to_datetime([1, 2, 3, 4]), 
        "value": [1.1, 2.2, 3.3, 4.4],
        "key": ["x", "x", "x", "x"]
    }
)
time_left = connection.create_table("time_left", time_pd1)

time_pd2 = pd.DataFrame(
    {
        "time": pd.to_datetime([2, 4]), 
        "value": [1.2, 2.0],
        "key": ["x", "x"]
    }
)
time_right = connection.create_table("time_right", time_pd2)
```
3. Write `ASOF_JOIN` expression.
```python
expr = time_left.asof_join(
        time_right,
        predicates=[
            time_left["key"] == time_right["key"],
            time_left["time"] >= time_right["time"],
        ],
    )
print(connection.compile(expr))
```

The generated SQL should look something like this:
```sql
SELECT t0.`time`, t0.`value`, t0.`key`, t1.`time` AS `time_right`,
       t1.`value` AS `value_right`, t1.`key` AS `key_right`
FROM time_left t0
  JOIN time_right t1 FOR SYSTEM_TIME AS OF t0.`time`
    ON (t0.`key` = t1.`key`)
```
This will throw syntax error around `FOR SYSTEM_TIME` because Flink doesn't recognizing the aliasing after `JOIN`. We need to get rid of the aliasing somehow.

(Once we get rid of the aliasing, it should throw something like 
```
An error occurred while calling o8.executeSql.
: org.apache.flink.table.api.ValidationException: Temporal table join currently only supports 'FOR SYSTEM_TIME AS OF' left table's time attribute field
```
which means that the watermarks are not correctly set, as expected.)

TODO:
- [ ] Remove aliasing
- [ ] Fix select set (should not select keys that are being joined on)
- [ ] Add unit tests