### PR TITLE
ci(deps): use non-deprecated method of updating nix flakes

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -53,7 +53,7 @@ jobs:
           input: ${{ matrix.flake }}
 
       - name: update ${{ matrix.flake }}
-        run: nix flake lock --update-input ${{ matrix.flake }}
+        run: nix flake update ${{ matrix.flake }}
 
       - uses: cpcloud/flake-dep-info-action@v2.0.11
         id: get_new_commit


### PR DESCRIPTION
Fixes the currently-failing `update-deps.yml` workflow.