### PR TITLE
test(ddl): use temporary tables where possible

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -1224,6 +1224,12 @@ class BaseBackend(abc.ABC, _FileIOHandler):
             )
         return query
 
+    def truncate_table(
+        self, name: str, database: str | None = None, schema: str | None = None
+    ) -> None:
+        """Delete all rows from a table without dropping it."""
+        raise NotImplementedError(self.name)
+
 
 @functools.cache
 def _get_backend_names() -> frozenset[str]:

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -690,8 +690,7 @@ def temp_table(con) -> str:
     """
     name = util.gen_name("temp_table")
     yield name
-    # some backends don't implement truncate_table
-    with contextlib.suppress((AttributeError, NotImplementedError)):
+    with contextlib.suppress(NotImplementedError):
         con.truncate_table(name)
     with contextlib.suppress(NotImplementedError):
         con.drop_table(name, force=True)

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -670,6 +670,8 @@ def alchemy_temp_table(alchemy_con) -> str:
     name = util.gen_name("alchemy_table")
     yield name
     with contextlib.suppress(NotImplementedError):
+        alchemy_con.truncate_table(name)
+    with contextlib.suppress(NotImplementedError):
         alchemy_con.drop_table(name, force=True)
 
 
@@ -688,6 +690,8 @@ def temp_table(con) -> str:
     """
     name = util.gen_name("temp_table")
     yield name
+    with contextlib.suppress(NotImplementedError):
+        con.truncate_table(name)
     with contextlib.suppress(NotImplementedError):
         con.drop_table(name, force=True)
 

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -690,7 +690,8 @@ def temp_table(con) -> str:
     """
     name = util.gen_name("temp_table")
     yield name
-    with contextlib.suppress(NotImplementedError):
+    # some backends don't implement truncate_table
+    with contextlib.suppress((AttributeError, NotImplementedError)):
         con.truncate_table(name)
     with contextlib.suppress(NotImplementedError):
         con.drop_table(name, force=True)

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -287,6 +287,11 @@ class Backend(BaseAlchemyBackend):
                 typ = OracleType.from_string(type_string, nullable=nullable)
             yield name, typ
 
+    def truncate_table(self, name: str, database: str | None = None) -> None:
+        ident = sg.table(name, catalog=database, quoted=True).sql(self.name)
+        with self.begin() as con:
+            con.exec_driver_sql(f"TRUNCATE TABLE {ident}")
+
     def _table_from_schema(
         self,
         name: str,

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -402,7 +402,7 @@ class Backend(BaseSQLBackend, CanCreateDatabase):
                 spark_df = self._session.createDataFrame(obj)
                 mode = "overwrite" if overwrite else "error"
                 spark_df.write.saveAsTable(name, format=format, mode=mode)
-                return None
+                return self.table(name)
             else:
                 self._register_in_memory_tables(obj)
 

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -48,20 +48,12 @@ class Backend(BaseAlchemyBackend, CanListDatabases):
 
     def __getstate__(self) -> dict:
         r = super().__getstate__()
-        r.update(
-            dict(
-                compiler=self.compiler,
-                database_name=self.database_name,
-                _con=None,  # clear connection on copy()
-                _meta=None,
-            )
-        )
+        r.update(dict(compiler=self.compiler, _con=None, _meta=None))
         return r
 
     @property
     def current_database(self) -> str:
-        # AFAICT there is no notion of a schema in SQLite
-        return "main"
+        return None
 
     def list_databases(self, like: str | None = None) -> list[str]:
         with self.begin() as con:
@@ -96,8 +88,6 @@ class Backend(BaseAlchemyBackend, CanListDatabases):
         >>> ibis.sqlite.connect("path/to/my/sqlite.db")
         """
         import pandas as pd
-
-        self.database_name = "main"
 
         engine = sa.create_engine(
             f"sqlite:///{database if database is not None else ':memory:'}",

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -585,9 +585,17 @@ def test_list_databases(alchemy_con):
 
 
 @pytest.mark.never(
-    ["bigquery", "postgres", "mssql", "mysql", "snowflake", "oracle"],
+    ["bigquery", "postgres", "mssql", "mysql", "snowflake"],
     reason="backend does not support client-side in-memory tables",
     raises=(sa.exc.OperationalError, TypeError),
+)
+@pytest.mark.never(
+    ["oracle"],
+    reason=(
+        "backend does not support client-side in-memory tables and "
+        "cannot execute truncation tear down"
+    ),
+    raises=(sa.exc.DatabaseError, TypeError),
 )
 @pytest.mark.notyet(
     ["trino"], reason="memory connector doesn't allow writing to tables"

--- a/ibis/backends/tests/test_examples.py
+++ b/ibis/backends/tests/test_examples.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.examples
     reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
 )
 @pytest.mark.notimpl(["dask", "datafusion", "pyspark", "flink"])
-@pytest.mark.notyet(["clickhouse", "druid", "impala", "mssql", "trino"])
+@pytest.mark.notyet(["clickhouse", "druid", "impala", "trino"])
 @pytest.mark.parametrize(
     ("example", "columns"),
     [


### PR DESCRIPTION
This avoids leaving tables around if anything goes wrong after create table. Unfortunately yield fixtures are not able to handle all failure modes, whereas if we let the database handle the cleanup where possible we do not need to worry about these other failure modes.