### PR TITLE
docs(build): allow building individual docs without rendering api docs first

### DIFF
--- a/docs/contribute/05_reference.qmd
+++ b/docs/contribute/05_reference.qmd
@@ -33,5 +33,17 @@ class TestConf(BackendTest):
         ...
 ```
 
-{{< include ../reference/BackendTest.qmd >}}
-{{< include ../reference/ServiceBackendTest.qmd >}}
+```{python}
+#| echo: false
+#| output: asis
+import os
+
+paths = [
+    "../reference/BackendTest.qmd",
+    "../reference/ServiceBackendTest.qmd",
+]
+
+for path in filter(os.path.exists, paths):
+    with open(path) as f:
+        print(f.read())
+```


### PR DESCRIPTION
Before this change the API docs needed to be generated to render any single page. This skips including API docs if requested files do not exist.