### PR TITLE
feat(base): add `to_pandas` method to BaseBackend

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -249,6 +249,34 @@ class _FileIOHandler:
 
             return pyarrow
 
+    def to_pandas(
+        self,
+        expr: ir.Expr,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
+        **kwargs: Any,
+    ) -> pd.DataFrame | pd.Series | Any:
+        """Execute an Ibis expression and return a pandas `DataFrame`, `Series`, or scalar.
+
+        ::: {.callout-note}
+        This method is a wrapper around `execute`.
+        :::
+
+        Parameters
+        ----------
+        expr
+            Ibis expression to execute.
+        params
+            Mapping of scalar parameter expressions to value.
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
+        kwargs
+            Keyword arguments
+        """
+        return self.execute(expr, params=params, limit=limit, **kwargs)
+
     def to_pandas_batches(
         self,
         expr: ir.Expr,


### PR DESCRIPTION
It just wraps `execute` but I thought we should have it for consistency,
since it is present on expressions.