### PR TITLE
fix(backends): ensure that returned date results are actually proper date values

### DIFF
--- a/ci/make_geography_db.py
+++ b/ci/make_geography_db.py
@@ -56,10 +56,7 @@ POST_PARSE_FUNCTIONS = {
     "independence": lambda row: toolz.assoc(
         row,
         "independence_date",
-        datetime.datetime.strptime(
-            row["independence_date"],
-            "%Y-%m-%d",
-        ).date(),
+        datetime.datetime.fromisoformat(row["independence_date"]).date(),
     )
 }
 

--- a/ibis/backends/base/sql/registry/literal.py
+++ b/ibis/backends/base/sql/registry/literal.py
@@ -62,7 +62,7 @@ def _interval_literal_format(translator, op):
 def _date_literal_format(translator, op):
     value = op.value
     if isinstance(value, datetime.date):
-        value = value.strftime("%Y-%m-%d")
+        value = value.isoformat()
 
     return repr(value)
 

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -250,8 +250,8 @@ def test_multiple_project_queries(con, snapshot):
 def test_multiple_project_queries_execute(con):
     posts_questions = con.table(
         "posts_questions", database="bigquery-public-data", schema="stackoverflow"
-    )
-    trips = con.table("trips", database="nyc-taxi", schema="yellow").limit(5)
+    ).limit(5)
+    trips = con.table("trips", database="nyc-tlc", schema="yellow").limit(5)
     predicate = posts_questions.tags == trips.rate_code
     cols = [posts_questions.title]
     join = posts_questions.left_join(trips, predicate)[cols]

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -346,14 +346,14 @@ def _literal(op, *, value, dtype, **kw):
 
         return interval(value, unit=dtype.resolution.upper())
     elif dtype.is_timestamp():
-        funcname = "toDateTime"
-        fmt = "%Y-%m-%dT%H:%M:%S"
+        funcname = "parseDateTime"
 
         if micros := value.microsecond:
             funcname += "64"
-            fmt += ".%f"
 
-        args = [value.strftime(fmt)]
+        funcname += "BestEffort"
+
+        args = [value.isoformat()]
 
         if micros % 1000:
             args.append(6)
@@ -365,7 +365,7 @@ def _literal(op, *, value, dtype, **kw):
 
         return F[funcname](*args)
     elif dtype.is_date():
-        return F.toDate(value.strftime("%Y-%m-%d"))
+        return F.toDate(value.isoformat())
     elif dtype.is_array():
         value_type = dtype.value_type
         values = [

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/d/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/d/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDate(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toDate(parseDateTimeBestEffort('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/h/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/h/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toStartOfHour(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toStartOfHour(parseDateTimeBestEffort('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/m/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/m/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toStartOfMinute(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toStartOfMinute(parseDateTimeBestEffort('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/minute/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/minute/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toStartOfMinute(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toStartOfMinute(parseDateTimeBestEffort('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/w/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/w/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toMonday(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toMonday(parseDateTimeBestEffort('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/y/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_timestamp_truncate/y/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toStartOfYear(toDateTime('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"
+  toStartOfYear(parseDateTimeBestEffort('2009-05-17T12:34:56')) AS "TimestampTruncate(datetime.datetime(2009, 5, 17, 12, 34, 56))"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/micros/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/micros/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime64('2015-01-01T12:34:56.789321', 6) AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789321)"
+  parseDateTime64BestEffort('2015-01-01T12:34:56.789321', 6) AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789321)"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/micros_tz/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/micros_tz/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime64('2015-01-01T12:34:56.789321', 6, 'UTC') AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789321, tzinfo=tzutc())"
+  parseDateTime64BestEffort('2015-01-01T12:34:56.789321+00:00', 6, 'UTC') AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789321, tzinfo=tzutc())"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/millis/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/millis/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime64('2015-01-01T12:34:56.789000', 3) AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789000)"
+  parseDateTime64BestEffort('2015-01-01T12:34:56.789000', 3) AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789000)"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/millis_tz/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_fine_grained_timestamp_literals/millis_tz/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime64('2015-01-01T12:34:56.789000', 3, 'UTC') AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789000, tzinfo=tzutc())"
+  parseDateTime64BestEffort('2015-01-01T12:34:56.789000+00:00', 3, 'UTC') AS "datetime.datetime(2015, 1, 1, 12, 34, 56, 789000, tzinfo=tzutc())"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr0/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr0/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime('2015-01-01T12:34:56') AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"
+  parseDateTimeBestEffort('2015-01-01T12:34:56') AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr1/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr1/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime('2015-01-01T12:34:56') AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"
+  parseDateTimeBestEffort('2015-01-01T12:34:56') AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"

--- a/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr2/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_literals/test_timestamp_literals/expr2/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  toDateTime('2015-01-01T12:34:56') AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"
+  parseDateTimeBestEffort('2015-01-01T12:34:56') AS "datetime.datetime(2015, 1, 1, 12, 34, 56)"

--- a/ibis/backends/dask/execution/temporal.py
+++ b/ibis/backends/dask/execution/temporal.py
@@ -32,7 +32,7 @@ from ibis.backends.pandas.execution.temporal import (
     execute_date_sub_diff_series_date,
     execute_day_of_week_index_series,
     execute_day_of_week_name_series,
-    execute_epoch_seconds,
+    execute_epoch_seconds_series,
     execute_extract_microsecond_series,
     execute_extract_millisecond_series,
     execute_extract_timestamp_field_series,
@@ -61,7 +61,7 @@ DASK_DISPATCH_TYPES: TypeRegistrationDict = {
     ops.ExtractTemporalField: [((dd.Series,), execute_extract_timestamp_field_series)],
     ops.ExtractMicrosecond: [((dd.Series,), execute_extract_microsecond_series)],
     ops.ExtractMillisecond: [((dd.Series,), execute_extract_millisecond_series)],
-    ops.ExtractEpochSeconds: [((dd.Series,), execute_epoch_seconds)],
+    ops.ExtractEpochSeconds: [((dd.Series,), execute_epoch_seconds_series)],
     ops.IntervalFromInteger: [((dd.Series,), execute_interval_from_integer_series)],
     ops.IntervalAdd: [
         (

--- a/ibis/backends/flink/registry.py
+++ b/ibis/backends/flink/registry.py
@@ -66,7 +66,7 @@ def _cast(translator: ExprTranslator, op: ops.generic.Cast) -> str:
             arg_translated = f"FROM_UNIXTIME({arg_translated})"
 
         if to.timezone:
-            return f"TO_TIMESTAMP(CONVERT_TZ(CAST({arg_translated} AS STRING), 'UTC+0', '{to.timezone}'))"
+            return f"TO_TIMESTAMP(CONVERT_TZ(CAST({arg_translated} AS STRING), 'UTC', {to.timezone!r}))"
         else:
             return f"TO_TIMESTAMP({arg_translated})"
     elif to.is_date():

--- a/ibis/backends/pandas/execution/temporal.py
+++ b/ibis/backends/pandas/execution/temporal.py
@@ -65,9 +65,19 @@ def execute_extract_microsecond_series(op, data, **kwargs):
     return data.dt.microsecond.astype(np.int32)
 
 
-@execute_node.register(ops.ExtractEpochSeconds, (datetime.datetime, pd.Series))
-def execute_epoch_seconds(op, data, **kwargs):
-    return data.astype("datetime64[s]").astype("int64").astype("int32")
+@execute_node.register(ops.ExtractEpochSeconds, pd.Series)
+def execute_epoch_seconds_series(op, data, **kwargs):
+    return (
+        data.astype("datetime64[ns]")
+        .astype("int64")
+        .floordiv(1_000_000_000)
+        .astype("int32")
+    )
+
+
+@execute_node.register(ops.ExtractEpochSeconds, (pd.Timestamp, datetime.datetime))
+def execute_epoch_seconds_literal(op, data, **kwargs):
+    return pd.Timestamp(data).floor("s").value // 1_000_000_000
 
 
 @execute_node.register(

--- a/ibis/backends/pandas/tests/execution/test_cast.py
+++ b/ibis/backends/pandas/tests/execution/test_cast.py
@@ -154,7 +154,7 @@ def test_timestamp_with_timezone_is_inferred_correctly(t, df):
 def test_cast_date(t, df, column):
     expr = t[column].cast("date")
     result = expr.execute()
-    expected = df[column].dt.normalize().dt.tz_localize(None)
+    expected = df[column].dt.normalize().dt.tz_localize(None).dt.date
     tm.assert_series_equal(result, expected)
 
 

--- a/ibis/backends/pandas/tests/execution/test_temporal.py
+++ b/ibis/backends/pandas/tests/execution/test_temporal.py
@@ -66,7 +66,7 @@ def test_timestamp_functions(case_func, expected_func):
 def test_cast_datetime_strings_to_date(t, df, column):
     expr = t[column].cast("date")
     result = expr.execute()
-    expected = pd.to_datetime(df[column]).dt.normalize().dt.tz_localize(None)
+    expected = pd.to_datetime(df[column]).dt.normalize().dt.tz_localize(None).dt.date
     tm.assert_series_equal(result, expected)
 
 
@@ -103,7 +103,7 @@ def test_cast_integer_to_date(t, df):
     expr = t.plain_int64.cast("date")
     result = expr.execute()
     expected = pd.Series(
-        pd.to_datetime(df.plain_int64.values, unit="D").values,
+        pd.to_datetime(df.plain_int64.values, unit="D").date,
         index=df.index,
         name="plain_int64",
     )

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -420,7 +420,7 @@ class Backend(BaseBackend):
         else:
             assert isinstance(expr, ir.Column), type(expr)
             if expr.type().is_temporal():
-                return df.to_pandas().iloc[:, 0]
+                return expr.__pandas_result__(df.to_pandas())
             else:
                 # note: skip frame-construction overhead
                 return df.to_series().to_pandas()

--- a/ibis/backends/polars/tests/conftest.py
+++ b/ibis/backends/polars/tests/conftest.py
@@ -33,10 +33,10 @@ class TestConf(BackendTest):
 
     @classmethod
     def assert_series_equal(cls, left, right, *args, **kwargs) -> None:
-        check_dtype = not (
+        check_dtype = kwargs.pop("check_dtype", True) and not (
             issubclass(left.dtype.type, np.timedelta64)
             and issubclass(right.dtype.type, np.timedelta64)
-        ) and kwargs.pop("check_dtype", True)
+        )
         return super().assert_series_equal(
             left, right, *args, **kwargs, check_dtype=check_dtype
         )

--- a/ibis/backends/polars/tests/test_udf.py
+++ b/ibis/backends/polars/tests/test_udf.py
@@ -46,7 +46,7 @@ def test_multiple_argument_udf(alltypes):
     result = expr.execute()
 
     df = alltypes[["smallint_col", "int_col"]].execute()
-    expected = (df.smallint_col + df.int_col).astype("int32")
+    expected = df.smallint_col + df.int_col
 
     tm.assert_series_equal(result, expected.rename("tmp"))
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -218,8 +218,7 @@ class Backend(BaseSQLBackend, CanCreateDatabase):
         table_expr = expr.as_table()
         df = self.compile(table_expr, **kwargs).toPandas()
 
-        # TODO: remove the extra conversion
-        return expr.__pandas_result__(table_expr.__pandas_result__(df))
+        return expr.__pandas_result__(df)
 
     def _fully_qualified_name(self, name, database):
         if is_fully_qualified(name):

--- a/ibis/backends/sqlite/tests/test_types.py
+++ b/ibis/backends/sqlite/tests/test_types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from datetime import date
 
 import pandas as pd
 import pytest
@@ -86,10 +87,7 @@ def test_type_map(db):
     assert t.schema() == expected_schema
     res = t.filter(t.str_col == "a").execute()
     sol = pd.DataFrame(
-        {
-            "str_col": ["a"],
-            "date_col": pd.Series(["2022-01-01"], dtype="M8[ns]"),
-        }
+        {"str_col": ["a"], "date_col": pd.Series([date(2022, 1, 1)], dtype="object")}
     )
     assert res.equals(sol)
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -817,7 +817,7 @@ def test_int_column(alltypes):
     assert result.dtype == np.int8
 
 
-@pytest.mark.notimpl(["druid", "oracle", "exasol"])
+@pytest.mark.notimpl(["druid", "oracle"])
 @pytest.mark.never(
     ["bigquery", "sqlite", "snowflake"], reason="backend only implements int64"
 )

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -226,11 +226,6 @@ def test_literal_map_get_broadcast(backend, alltypes, df):
         param(["a", "b"], ["1", "2"], id="int"),
     ],
 )
-@pytest.mark.notyet(
-    ["flink"],
-    raises=AssertionError,
-    reason="got list of tuples instead; requires PyFlink compatibility with PyArrow 13",
-)
 def test_map_construct_dict(con, keys, values):
     expr = ibis.map(keys, values)
     result = con.execute(expr.name("tmp"))

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -225,7 +225,10 @@ def test_scalar_param_date(backend, alltypes, value):
     )
     df = base.execute()
     expected = (
-        df.loc[df.date_col.dt.normalize() == pd.Timestamp(value).normalize()]
+        df.loc[
+            pd.to_datetime(df.date_col).dt.normalize().dt.date
+            == pd.Timestamp(value).normalize().date()
+        ]
         .sort_values("id")
         .reset_index(drop=True)
         .drop(columns=["date_col"])

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -44,10 +44,13 @@ except ImportError:
 
 try:
     from clickhouse_connect.driver.exceptions import (
+        DatabaseError as ClickhouseDatabaseError,
+    )
+    from clickhouse_connect.driver.exceptions import (
         InternalError as ClickhouseOperationalError,
     )
 except ImportError:
-    ClickhouseOperationalError = None
+    ClickhouseOperationalError = ClickhouseDatabaseError = None
 
 try:
     from impala.error import (
@@ -64,11 +67,15 @@ try:
 except ImportError:
     Py4JJavaError = None
 
-
 try:
     from pyexasol.exceptions import ExaQueryError
 except ImportError:
     ExaQueryError = None
+
+try:
+    from pyspark.sql.utils import IllegalArgumentException
+except ImportError:
+    IllegalArgumentException = None
 
 
 @pytest.mark.parametrize("attr", ["year", "month", "day"])
@@ -344,17 +351,16 @@ def test_timestamp_extract_milliseconds(backend, alltypes, df):
     raises=GoogleBadRequest,
     reason="UNIX_SECONDS does not support DATETIME arguments",
 )
-@pytest.mark.xfail_version(
-    pyspark=["pandas<2.1"],
-    reason="test was adjusted to work with pandas 2.1 output; pyspark doesn't support pandas 2",
-)
 @pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract_epoch_seconds(backend, alltypes, df):
     expr = alltypes.timestamp_col.epoch_seconds().name("tmp")
     result = expr.execute()
 
     expected = backend.default_series_rename(
-        df.timestamp_col.astype("datetime64[s]").astype("int64").astype("int32")
+        df.timestamp_col.astype("datetime64[ns]")
+        .astype("int64")
+        .floordiv(1_000_000_000)
+        .astype("int32")
     )
     backend.assert_series_equal(result, expected)
 
@@ -707,9 +713,9 @@ def test_date_truncate(backend, alltypes, df, unit):
     unit = PANDAS_UNITS.get(unit, unit)
 
     try:
-        expected = df.timestamp_col.dt.floor(unit)
+        expected = df.timestamp_col.dt.floor(unit).dt.date
     except ValueError:
-        expected = df.timestamp_col.dt.to_period(unit).dt.to_timestamp()
+        expected = df.timestamp_col.dt.to_period(unit).dt.to_timestamp().dt.date
 
     result = expr.execute()
     expected = backend.default_series_rename(expected)
@@ -1017,10 +1023,14 @@ def test_integer_to_interval_date(backend, con, alltypes, df, unit):
         warnings.simplefilter(
             "ignore", category=(UserWarning, pd.errors.PerformanceWarning)
         )
-        expected = pd.to_datetime(df.date_string_col) + offset
+        expected = (
+            pd.to_datetime(df.date_string_col)
+            .add(offset)
+            .map(lambda ts: ts.normalize().date(), na_action="ignore")
+        )
 
     expected = backend.default_series_rename(expected)
-    backend.assert_series_equal(result, expected.map(lambda ts: ts.normalize()))
+    backend.assert_series_equal(result, expected)
 
 
 date_value = pd.Timestamp("2017-12-31")
@@ -1119,7 +1129,12 @@ timestamp_value = pd.Timestamp("2018-01-01 18:18:18")
         ),
         param(
             lambda t, _: t.timestamp_col.date() + ibis.interval(days=4),
-            lambda t, _: t.timestamp_col.dt.floor("d") + pd.Timedelta(days=4),
+            lambda t, _: (
+                t.timestamp_col.dt.floor("d")
+                .add(pd.Timedelta(days=4))
+                .dt.normalize()
+                .dt.date
+            ),
             id="date-add-interval",
             marks=[
                 pytest.mark.notimpl(
@@ -1131,7 +1146,12 @@ timestamp_value = pd.Timestamp("2018-01-01 18:18:18")
         ),
         param(
             lambda t, _: t.timestamp_col.date() - ibis.interval(days=14),
-            lambda t, _: t.timestamp_col.dt.floor("d") - pd.Timedelta(days=14),
+            lambda t, _: (
+                t.timestamp_col.dt.floor("d")
+                .sub(pd.Timedelta(days=14))
+                .dt.normalize()
+                .dt.date
+            ),
             id="date-subtract-interval",
             marks=[
                 pytest.mark.notimpl(
@@ -1229,7 +1249,9 @@ def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
     result = con.execute(expr)
     expected = backend.default_series_rename(expected)
 
-    backend.assert_series_equal(result, expected.astype(result.dtype))
+    backend.assert_series_equal(
+        result, expected.astype(result.dtype), check_dtype=False
+    )
 
 
 plus = lambda t, td: t.timestamp_col + pd.Timedelta(td)
@@ -1624,6 +1646,7 @@ def test_interval_add_cast_column(backend, alltypes, df):
         .dt.normalize()
         .add(df.bigint_col.astype("timedelta64[D]"))
         .rename("tmp")
+        .dt.date
     )
     backend.assert_series_equal(result, expected.astype(result.dtype))
 
@@ -2200,11 +2223,6 @@ def test_timestamp_literal(con, backend):
         "<NUMERIC>, <NUMERIC>, <NUMERIC>, <NUMERIC>)"
     ),
 )
-@pytest.mark.notimpl(
-    ["flink"],
-    "https://github.com/ibis-project/ibis/pull/6920/files#r1372453059",
-    raises=AssertionError,
-)
 @pytest.mark.notimpl(["exasol"], raises=ExaQueryError)
 def test_timestamp_with_timezone_literal(con, timezone, expected):
     expr = ibis.timestamp(2022, 2, 4, 16, 20, 0).cast(dt.Timestamp(timezone=timezone))
@@ -2511,7 +2529,7 @@ def test_date_column_from_iso(backend, con, alltypes, df):
 
     result = con.execute(expr.name("tmp"))
     golden = df.year.astype(str) + "-" + df.month.astype(str).str.rjust(2, "0") + "-13"
-    actual = result.dt.strftime("%Y-%m-%d")
+    actual = result.map(datetime.date.isoformat)
     backend.assert_series_equal(golden.rename("tmp"), actual.rename("tmp"))
 
 
@@ -2988,7 +3006,7 @@ def test_timestamp_bucket_offset(backend, offset_mins):
     backend.assert_series_equal(res, sol)
 
 
-_NO_SQLGLOT_DIALECT = {"pandas", "dask", "druid", "flink", "datafusion", "polars"}
+_NO_SQLGLOT_DIALECT = ("pandas", "dask", "druid", "flink", "datafusion", "polars")
 no_sqlglot_dialect = sorted(
     param(backend, marks=pytest.mark.xfail) for backend in _NO_SQLGLOT_DIALECT
 )
@@ -3014,6 +3032,11 @@ def test_temporal_literal_sql(value, dialect, snapshot):
     snapshot.assert_match(sql, "out.sql")
 
 
+no_time_type = pytest.mark.xfail(
+    raises=NotImplementedError, reason="no time type support"
+)
+
+
 @pytest.mark.parametrize(
     "dialect",
     [
@@ -3023,24 +3046,9 @@ def test_temporal_literal_sql(value, dialect, snapshot):
         ),
         *no_sqlglot_dialect,
         *[
-            param(
-                "impala",
-                marks=pytest.mark.xfail(
-                    raises=NotImplementedError, reason="no time type support"
-                ),
-            ),
-            param(
-                "clickhouse",
-                marks=pytest.mark.xfail(
-                    raises=NotImplementedError, reason="no time type support"
-                ),
-            ),
-            param(
-                "oracle",
-                marks=pytest.mark.xfail(
-                    raises=NotImplementedError, reason="no time type support"
-                ),
-            ),
+            param("impala", marks=no_time_type),
+            param("clickhouse", marks=no_time_type),
+            param("oracle", marks=no_time_type),
         ],
     ],
 )
@@ -3050,3 +3058,58 @@ def test_time_literal_sql(dialect, snapshot, micros):
     expr = ibis.literal(value)
     sql = ibis.to_sql(expr, dialect=dialect)
     snapshot.assert_match(sql, "out.sql")
+
+
+@pytest.mark.notimpl(["druid"], raises=sa.exc.CompileError, reason="no date support")
+@pytest.mark.parametrize(
+    "value",
+    [
+        param("2017-12-31", id="simple"),
+        param(
+            "9999-01-02",
+            marks=[
+                pytest.mark.broken(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="clickhouse doesn't support dates after 2149-06-06",
+                ),
+                pytest.mark.notyet(["datafusion"], raises=Exception),
+            ],
+            id="large",
+        ),
+        param(
+            "0001-07-17",
+            id="small",
+            marks=[
+                pytest.mark.broken(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="clickhouse doesn't support dates before the UNIX epoch",
+                ),
+                pytest.mark.notyet(["datafusion"], raises=Exception),
+                pytest.mark.notyet(["pyspark"], raises=IllegalArgumentException),
+            ],
+        ),
+        param(
+            "2150-01-01",
+            marks=pytest.mark.broken(["clickhouse"], raises=AssertionError),
+            id="medium",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "func",
+    [
+        param(lambda x: x, id="identity"),
+        param(datetime.date.fromisoformat, id="fromstring"),
+    ],
+)
+def test_date_scalar(con, value, func):
+    expr = ibis.date(func(value)).name("tmp")
+
+    result = con.execute(expr)
+
+    assert not isinstance(result, datetime.datetime)
+    assert isinstance(result, datetime.date)
+
+    assert result == datetime.date.fromisoformat(value)

--- a/ibis/backends/tests/test_uuid.py
+++ b/ibis/backends/tests/test_uuid.py
@@ -39,7 +39,7 @@ UUID_EXPECTED_VALUES = {
     "mssql": TEST_UUID,
     "dask": TEST_UUID,
     "oracle": TEST_UUID,
-    "flink": RAW_TEST_UUID,
+    "flink": TEST_UUID,
     "exasol": TEST_UUID,
 }
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -801,19 +801,19 @@ def date(value_or_year, month=None, day=None, /):
     Create a date scalar from a string
 
     >>> ibis.date("2023-01-02")
-    Timestamp('2023-01-02 00:00:00')
+    datetime.date(2023, 1, 2)
 
     Create a date scalar from year, month, and day
 
     >>> ibis.date(2023, 1, 2)
-    Timestamp('2023-01-02 00:00:00')
+    datetime.date(2023, 1, 2)
 
     Create a date column from year, month, and day
 
-    >>> t = ibis.memtable({"y": [2001, 2002], "m": [1, 3], "d": [2, 4]})
-    >>> ibis.date(t.y, t.m, t.d).name("date")
+    >>> t = ibis.memtable(dict(year=[2001, 2002], month=[1, 3], day=[2, 4]))
+    >>> ibis.date(t.year, t.month, t.day).name("my_date")
     ┏━━━━━━━━━━━━┓
-    ┃ date       ┃
+    ┃ my_date    ┃
     ┡━━━━━━━━━━━━┩
     │ date       │
     ├────────────┤

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1225,7 +1225,9 @@ class Scalar(Value):
         return data_mapper.convert_scalar(table[0][0], self.type())
 
     def __pandas_result__(self, df: pd.DataFrame) -> Any:
-        return df.iat[0, 0]
+        from ibis.formats.pandas import PandasData
+
+        return PandasData.convert_scalar(df, self.type())
 
     def as_table(self) -> ir.Table:
         """Promote the scalar expression to a table.

--- a/ibis/formats/numpy.py
+++ b/ibis/formats/numpy.py
@@ -68,8 +68,7 @@ class NumpyType(TypeMapper[np.dtype]):
             # return np.dtype(f"datetime64[{dtype.unit.short}]")
             return np.dtype("datetime64[ns]")
         elif dtype.is_date():
-            # return np.dtype("datetime64[D]")
-            return np.dtype("datetime64[ns]")
+            return np.dtype("datetime64[D]")
         elif dtype.is_time():
             return np.dtype("timedelta64[ns]")
         elif (

--- a/ibis/formats/tests/test_numpy.py
+++ b/ibis/formats/tests/test_numpy.py
@@ -80,9 +80,14 @@ def test_variadic_to_numpy(ibis_type):
     assert NumpyType.from_ibis(ibis_type) == np.dtype("object")
 
 
-@h.given(ibst.date_dtype() | ibst.timestamp_dtype())
-def test_date_to_numpy(ibis_type):
+@h.given(ibst.timestamp_dtype())
+def test_timestamp_to_numpy(ibis_type):
     assert NumpyType.from_ibis(ibis_type) == np.dtype("datetime64[ns]")
+
+
+@h.given(ibst.date_dtype())
+def test_date_to_numpy(ibis_type):
+    assert NumpyType.from_ibis(ibis_type) == np.dtype("datetime64[D]")
 
 
 @h.given(ibst.time_dtype())

--- a/ibis/formats/tests/test_pandas.py
+++ b/ibis/formats/tests/test_pandas.py
@@ -32,7 +32,7 @@ from ibis.formats.pandas import PandasData, PandasSchema, PandasType
         (dt.float32, np.dtype("float32")),
         (dt.float64, np.dtype("float64")),
         (dt.boolean, np.dtype("bool")),
-        (dt.date, np.dtype("datetime64[ns]")),
+        (dt.date, np.dtype("datetime64[D]")),
         (dt.time, np.dtype("timedelta64[ns]")),
         (dt.timestamp, np.dtype("datetime64[ns]")),
         (dt.Interval("s"), np.dtype("timedelta64[s]")),


### PR DESCRIPTION
Changes date types to actually be dates in all cases. Closes #7299.