### PR TITLE
refactor(snowflake): use upstream map-from-arrays function instead of a custom UDF

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -95,11 +95,6 @@ _SNOWFLAKE_MAP_UDFS = {
         "returns": ARRAY,
         "source": "return Object.values(obj)",
     },
-    "ibis_udfs.public.object_from_arrays": {
-        "inputs": {"ks": ARRAY, "vs": ARRAY},
-        "returns": OBJECT,
-        "source": "return Object.assign(...ks.map((k, i) => ({[k]: vs[i]})))",
-    },
     "ibis_udfs.public.array_zip": {
         "inputs": {"arrays": ARRAY},
         "returns": ARRAY,

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -293,7 +293,7 @@ operation_registry.update(
         ops.Map: fixed_arity(
             lambda keys, values: sa.func.iff(
                 sa.func.is_array(keys) & sa.func.is_array(values),
-                sa.func.ibis_udfs.public.object_from_arrays(keys, values),
+                sa.func.arrays_to_object(keys, values),
                 sa.null(),
             ),
             2,


### PR DESCRIPTION
Remove a custom UDF in favor of equivalent upstream functionality