### PR TITLE
fix(duckdb): ensure that parameter names are unlikely to overlap with column names

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -944,7 +944,7 @@ OPERATION_REGISTRY = {
     ops.EndsWith: fixed_arity("ENDS_WITH", 2),
     ops.TableColumn: table_column,
     ops.CountDistinctStar: _count_distinct_star,
-    ops.Argument: lambda _, op: op.name,
+    ops.Argument: lambda _, op: op.param,
     ops.Unnest: unary("UNNEST"),
     ops.TimeDelta: _time_delta,
     ops.DateDelta: _date_delta,

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -958,8 +958,8 @@ def _array_string_join(op, *, arg, sep, **_):
 
 
 @translate_val.register(ops.Argument)
-def _argument(op, *, name, **_):
-    return sg.to_identifier(name)
+def _argument(op, **_):
+    return sg.to_identifier(op.param)
 
 
 @translate_val.register(ops.ArrayMap)

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -318,7 +318,7 @@ def _array_filter(t, op):
 
 
 def _array_intersect(t, op):
-    name = "x"
+    name = "__array_filter_param__"
     parameter = ops.Argument(
         name=name, shape=op.left.shape, dtype=op.left.dtype.value_type
     )
@@ -423,10 +423,12 @@ operation_registry.update(
             t,
             ops.ArrayFilter(
                 op.arg,
-                param="x",
+                param="__array_filter_param__",
                 body=ops.NotEquals(
                     ops.Argument(
-                        name="x", shape=op.arg.shape, dtype=op.arg.dtype.value_type
+                        name="__array_filter_param__",
+                        shape=op.arg.shape,
+                        dtype=op.arg.dtype.value_type,
                     ),
                     op.other,
                 ),

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -644,7 +644,9 @@ operation_registry.update(
         ops.Literal: _literal,
         # We override this here to support time zones
         ops.TableColumn: _table_column,
-        ops.Argument: lambda t, op: sa.column(op.name, type_=t.get_sqla_type(op.dtype)),
+        ops.Argument: lambda t, op: sa.column(
+            op.param, type_=t.get_sqla_type(op.dtype)
+        ),
         # types
         ops.TypeOf: _typeof,
         # Floating

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1689,7 +1689,7 @@ def compile_array_collect(t, op, **kwargs):
 
 @compiles(ops.Argument)
 def compile_argument(t, op, arg_columns, **kwargs):
-    return arg_columns[op.name]
+    return arg_columns[op.param]
 
 
 @compiles(ops.ArrayFilter)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -869,3 +869,28 @@ def test_unnest_empty_array(con):
     expr = t.arr.unnest()
     result = con.execute(expr)
     assert len(result) == 3
+
+
+@builtin_array
+@pytest.mark.notimpl(
+    ["datafusion", "impala", "mssql", "polars", "snowflake", "sqlite", "mysql"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notimpl(
+    ["dask", "pandas"],
+    raises=com.OperationNotDefinedError,
+    reason="Operation 'ArrayMap' is not implemented for this backend",
+)
+@pytest.mark.notimpl(
+    ["sqlite"],
+    raises=NotImplementedError,
+    reason="Unsupported type: Array: ...",
+)
+def test_array_map_with_conflicting_names(backend, con):
+    t = ibis.memtable({"x": [[1, 2]]}, schema=ibis.schema(dict(x="!array<int8>")))
+    expr = t.select(a=t.x.map(lambda x: x + 1)).select(
+        b=lambda t: t.a.filter(lambda a: a > 2)
+    )
+    result = con.execute(expr)
+    expected = pd.DataFrame({"b": [[3]]})
+    backend.assert_frame_equal(result, expected)

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -327,7 +327,7 @@ def _try_cast(t, op):
 def _array_intersect(t, op):
     x = ops.Argument(name="x", shape=op.left.shape, dtype=op.left.dtype.value_type)
     return t.translate(
-        ops.ArrayFilter(op.left, param="x", body=ops.ArrayContains(op.right, x))
+        ops.ArrayFilter(op.left, param=x.param, body=ops.ArrayContains(op.right, x))
     )
 
 
@@ -538,7 +538,7 @@ operation_registry.update(
             lambda sep, arr: sa.func.array_join(arr, sep), 2
         ),
         ops.StartsWith: fixed_arity(sa.func.starts_with, 2),
-        ops.Argument: lambda _, op: sa.literal_column(op.name),
+        ops.Argument: lambda _, op: sa.literal_column(op.param),
         ops.First: partial(_first_last, offset=1),
         ops.Last: partial(_first_last, offset=-1),
         ops.ArrayZip: _zip,

--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -10,6 +10,7 @@ import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis import util
+from ibis.common.annotations import attribute
 from ibis.common.bases import Abstract
 from ibis.common.graph import Node as Traversable
 from ibis.common.grounds import Concrete
@@ -182,6 +183,10 @@ class Argument(Value):
     name: str
     shape: ds.DataShape
     dtype: dt.DataType
+
+    @attribute
+    def param(self) -> str:
+        return f"__ibis_param_{self.name}__"
 
 
 public(ValueOp=Value, UnaryOp=Unary, BinaryOp=Binary, Scalar=Scalar, Column=Column)

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -425,7 +425,8 @@ class ArrayValue(Value):
         │ []                     │
         └────────────────────────┘
         """
-        param = next(iter(inspect.signature(func).parameters.keys()))
+        name = next(iter(inspect.signature(func).parameters.keys()))
+        param = f"__array_map_param_{name}__"
         parameter = ops.Argument(
             name=param, shape=self.op().shape, dtype=self.type().value_type
         ).to_expr()
@@ -502,9 +503,12 @@ class ArrayValue(Value):
         │ []                            │
         └───────────────────────────────┘
         """
-        param = next(iter(inspect.signature(predicate).parameters.keys()))
+        name = next(iter(inspect.signature(predicate).parameters.keys()))
+        param = f"__array_filter_param_{name}__"
         parameter = ops.Argument(
-            name=param, shape=self.op().shape, dtype=self.type().value_type
+            name=param,
+            shape=self.op().shape,
+            dtype=self.type().value_type,
         ).to_expr()
         return ops.ArrayFilter(self, param=param, body=predicate(parameter)).to_expr()
 

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -426,11 +426,12 @@ class ArrayValue(Value):
         └────────────────────────┘
         """
         name = next(iter(inspect.signature(func).parameters.keys()))
-        param = f"__array_map_param_{name}__"
         parameter = ops.Argument(
-            name=param, shape=self.op().shape, dtype=self.type().value_type
+            name=name, shape=self.op().shape, dtype=self.type().value_type
+        )
+        return ops.ArrayMap(
+            self, param=parameter.param, body=func(parameter.to_expr())
         ).to_expr()
-        return ops.ArrayMap(self, param=param, body=func(parameter)).to_expr()
 
     def filter(
         self, predicate: Callable[[ir.Value], bool | ir.BooleanValue]
@@ -504,13 +505,14 @@ class ArrayValue(Value):
         └───────────────────────────────┘
         """
         name = next(iter(inspect.signature(predicate).parameters.keys()))
-        param = f"__array_filter_param_{name}__"
         parameter = ops.Argument(
-            name=param,
+            name=name,
             shape=self.op().shape,
             dtype=self.type().value_type,
+        )
+        return ops.ArrayFilter(
+            self, param=parameter.param, body=predicate(parameter.to_expr())
         ).to_expr()
-        return ops.ArrayFilter(self, param=param, body=predicate(parameter)).to_expr()
 
     def contains(self, other: ir.Value) -> ir.BooleanValue:
         """Return whether the array contains `other`.


### PR DESCRIPTION
Fixes #7676.

I created https://github.com/duckdb/duckdb/issues/9981 because I think this is a bug in DuckDB.

For now this is a workaround to address the issue.