### PR TITLE
docs(flink): override default install instructions

### DIFF
--- a/docs/_tabsets/install.qmd
+++ b/docs/_tabsets/install.qmd
@@ -5,6 +5,7 @@ You can install Ibis and a supported backend with `pip`, `conda`, `mamba`, or `p
 ```{python}
 #| echo: false
 #| output: asis
+from textwrap import dedent
 
 backends = [
     {"name": "BigQuery", "module": "bigquery"},
@@ -13,6 +14,7 @@ backends = [
     {"name": "DataFusion", "module": "datafusion"},
     {"name": "Druid", "module": "druid"},
     {"name": "DuckDB", "module": "duckdb"},
+    {"name": "Flink", "module": "flink"},
     {"name": "Impala", "module": "impala"},
     {"name": "MSSQL", "module": "mssql"},
     {"name": "MySQL", "module": "mysql"},
@@ -34,30 +36,52 @@ installers = [
 ]
 
 for installer in installers:
-    name = installer["name"]
+    installer_name = installer["name"]
     cmd = installer["cmd"]
     line = installer["line"]
 
-    print(f"## `{name}`")
+    print(f"## `{installer_name}`")
 
     print("::: {.panel-tabset}")
     print()
 
     for backend in backends:
-        name = backend["name"]
+        backend_name = backend["name"]
         mod = backend["module"]
-        extra = backend.get("extra", mod)
 
-        print(f"## {name}")
-        print()
-        print(line.format(extra=extra))
-        print()
-        print(f"```bash\n{cmd.format(extra=extra)}\n```")
-        print()
-        print(f"Connect using [`ibis.{mod}.connect`](./backends/{name.lower()}.qmd#ibis.{mod}.connect).")
+        print(f"## {backend_name}")
         print()
 
-    if name == "pip":
+        if backend_name == "Flink":
+            if installer_name == "pip":
+                print("Install alongside the `apache-flink` package:")
+                print()
+                print(f"```bash\npip install ibis-framework apache-flink\n```")
+
+            else:
+                print(
+                    dedent(
+                        """\
+                        ::: {.callout-important}
+                        ## PyFlink is not available on conda-forge; please
+                        use `pip` to install the PyFlink backend instead.
+                        :::"""
+                    )
+                )
+                continue
+
+        else:
+            extra = backend.get("extra", mod)
+
+            print(line.format(extra=extra))
+            print()
+            print(f"```bash\n{cmd.format(extra=extra)}\n```")
+
+        print()
+        print(f"Connect using [`ibis.{mod}.connect`](./backends/{backend_name.lower()}.qmd#ibis.{mod}.connect).")
+        print()
+
+    if installer_name == "pip":
         print("{{< include /_callouts/pypi_warning.qmd >}}")
 
     print()


### PR DESCRIPTION
Closes #7738 

`pip`:
<img width="1436" alt="image" src="https://github.com/ibis-project/ibis/assets/14007150/65a81d83-2211-4749-8d63-11a8774a8694">

`conda`/`mamba`/`pixi`:
<img width="1436" alt="image" src="https://github.com/ibis-project/ibis/assets/14007150/5632fb41-cabd-4ff4-9573-92cac76847d1">

