### PR TITLE
fix(ir): raise if `Concrete.copy()` receives unexpected arguments

### DIFF
--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -229,5 +229,7 @@ class Concrete(Immutable, Comparable, Annotable):
 
     def copy(self, **overrides) -> Self:
         kwargs = dict(zip(self.__argnames__, self.__args__))
+        if unknown_args := overrides.keys() - kwargs.keys():
+            raise AttributeError(f"Unexpected arguments: {unknown_args}")
         kwargs.update(overrides)
         return self.__recreate__(kwargs)

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -616,21 +616,39 @@ def test_variadic_keyword_argument():
     assert Test(1, 2, a=3, b=4, c=5).options == {"a": 3, "b": 4, "c": 5}
 
 
-def test_concrete_copy_with_variadic_argument():
-    class Test(Annotable):
+def test_copy_with_variadic_argument():
+    class Foo(Annotable):
         a = is_int
         b = is_int
         args = varargs(is_int)
 
-    t = Test(1, 2, 3, 4, 5)
+    class Bar(Concrete):
+        a = is_int
+        b = is_int
+        args = varargs(is_int)
+
+    for t in [Foo(1, 2, 3, 4, 5), Bar(1, 2, 3, 4, 5)]:
+        assert t.a == 1
+        assert t.b == 2
+        assert t.args == (3, 4, 5)
+
+        u = t.copy(a=6, args=(8, 9, 10))
+        assert u.a == 6
+        assert u.b == 2
+        assert u.args == (8, 9, 10)
+
+
+def test_concrete_copy_with_unknown_argument_raise():
+    class Bar(Concrete):
+        a = is_int
+        b = is_int
+
+    t = Bar(1, 2)
     assert t.a == 1
     assert t.b == 2
-    assert t.args == (3, 4, 5)
 
-    u = t.copy(a=6, args=(8, 9, 10))
-    assert u.a == 6
-    assert u.b == 2
-    assert u.args == (8, 9, 10)
+    with pytest.raises(AttributeError, match="Unexpected arguments"):
+        t.copy(c=3, d=4)
 
 
 def test_concrete_pickling_variadic_arguments():


### PR DESCRIPTION
Previously we silently allowed unkown arguments.