### PR TITLE
perf(common): improve the performance of replacing nodes by using a specialized `node.__recreate__()` method

### DIFF
--- a/ibis/common/tests/test_graph_benchmarks.py
+++ b/ibis/common/tests/test_graph_benchmarks.py
@@ -6,8 +6,10 @@ import pytest
 from typing_extensions import Self  # noqa: TCH002
 
 from ibis.common.collections import frozendict
+from ibis.common.deferred import _
 from ibis.common.graph import Graph, Node
 from ibis.common.grounds import Concrete
+from ibis.common.patterns import Between, Object
 
 
 class MyNode(Concrete, Node):
@@ -24,7 +26,7 @@ def generate_node(depth):
     if depth == 0:
         return MyNode(10, "20", c=(30, 40), d=frozendict(e=50, f=60))
     return MyNode(
-        1,
+        depth,
         "2",
         c=(3, 4),
         d=frozendict(e=5, f=6),
@@ -48,3 +50,9 @@ def test_bfs(benchmark):
 def test_dfs(benchmark):
     node = generate_node(500)
     benchmark(Graph.from_dfs, node)
+
+
+def test_replace(benchmark):
+    node = generate_node(500)
+    pattern = Object(MyNode, a=Between(lower=100)) >> _.copy(a=_.a + 1)
+    benchmark(node.replace, pattern)


### PR DESCRIPTION
depends on https://github.com/ibis-project/ibis/pull/7760

In the #7580 branch I measured 17% percent improvement, it it is roughly `12%` - `14%`. 
The reason of the performance gain is that `Concrete` implements `__recreate__(kwargs)` where we validate the argument but without going through the `Signature`'s binding process.

Using `recreated = node.__class__(**kwargs)` VS `recreated = node.__recreate__(kwargs)` (now):

```
------------------------------------------------------------------------------ benchmark 'test_replace': 2 tests ------------------------------------------------------------------------------
Name (time in ms)                   Min                Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_replace (0386_6d4c459)     14.7951 (1.16)     33.6163 (1.08)     15.3214 (1.15)     2.5658 (1.09)     14.9503 (1.14)     0.0716 (1.0)           1;7  65.2681 (0.87)         53           1
test_replace (NOW)              12.7203 (1.0)      31.2544 (1.0)      13.3571 (1.0)      2.3604 (1.0)      13.1114 (1.0)      0.2925 (4.08)          1;4  74.8663 (1.0)          60           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

