### PR TITLE
ci(dev): simplify minio container setup

### DIFF
--- a/ci/schema/trino.sql
+++ b/ci/schema/trino.sql
@@ -93,7 +93,7 @@ CREATE TABLE hive.default.awards_players (
     "tie" VARCHAR,
     "notes" VARCHAR
 ) WITH (
-    external_location = 's3a://warehouse/awards_players',
+    external_location = 's3a://warehouse/awards-players',
     format = 'PARQUET'
 );
 
@@ -116,7 +116,7 @@ CREATE TABLE hive.default.functional_alltypes (
     "year" INTEGER,
     "month" INTEGER
 ) WITH (
-    external_location = 's3a://warehouse/functional_alltypes',
+    external_location = 's3a://warehouse/functional-alltypes',
     format = 'PARQUET'
 );
 CREATE OR REPLACE VIEW memory.default.functional_alltypes AS

--- a/compose.yaml
+++ b/compose.yaml
@@ -162,13 +162,11 @@ services:
       - trino
 
   minio:
-    # TODO: healthcheck?
-    image: minio/minio:RELEASE.2023-11-01T18-37-25Z
+    image: bitnami/minio:2023.12.14
     environment:
       MINIO_ROOT_USER: accesskey
       MINIO_ROOT_PASSWORD: secretkey
-    entrypoint: sh
-    command: -c 'mkdir -p /data/warehouse && minio server /data'
+      MINIO_SKIP_CLIENT: yes
     healthcheck:
       interval: 1s
       retries: 20
@@ -178,8 +176,8 @@ services:
     networks:
       - trino
     volumes:
-      - minio:/opt/data/raw
-      - $PWD/docker/minio/config.json:/tmp/.mc/config.json:ro
+      - minio:/data
+      - $PWD/docker/minio/config.json:/.mc/config.json:ro
 
   hive-metastore:
     # TODO: healthcheck?

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -366,7 +366,7 @@ class ServiceBackendTest(BackendTest):
         with concurrent.futures.ThreadPoolExecutor() as e:
             for fut in concurrent.futures.as_completed(
                 e.submit(
-                    subprocess.check_call,
+                    subprocess.run,
                     [
                         "docker",
                         "compose",
@@ -374,6 +374,7 @@ class ServiceBackendTest(BackendTest):
                         str(path),
                         f"{service}:{data_volume}/{path.name}",
                     ],
+                    check=True,
                 )
                 for path in self.test_files
             ):


### PR DESCRIPTION
Simplify the minio setup by using bitnami, which allows use of a non-root container and allows us to avoid hacking the entrypoint and command.