### PR TITLE
refactor(formats): move the `TableProxy` object to formats from the operations

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -445,7 +445,7 @@ def _memtable_from_pyarrow_table(
     schema: SupportsSchema | None = None,
     columns: Iterable[str] | None = None,
 ):
-    from ibis.expr.operations.relations import PyArrowTableProxy
+    from ibis.formats.pyarrow import PyArrowTableProxy
 
     if columns is not None:
         assert schema is None, "if `columns` is not `None` then `schema` must be `None`"
@@ -467,7 +467,7 @@ def _memtable_from_dataframe(
 ) -> Table:
     import pandas as pd
 
-    from ibis.expr.operations.relations import PandasDataFrameProxy
+    from ibis.formats.pandas import PandasDataFrameProxy
 
     if not isinstance(data, pd.DataFrame):
         df = pd.DataFrame(data, columns=columns)

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -8,7 +8,7 @@ import pyarrow_hotfix  # noqa: F401
 
 import ibis.expr.datatypes as dt
 from ibis.expr.schema import Schema
-from ibis.formats import DataMapper, SchemaMapper, TypeMapper
+from ibis.formats import DataMapper, SchemaMapper, TableProxy, TypeMapper
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -291,6 +291,14 @@ class PyArrowData(DataMapper):
             return table.cast(desired_schema)
         else:
             return table
+
+
+class PyArrowTableProxy(TableProxy[pa.Table]):
+    def to_frame(self):
+        return self.obj.to_pandas()
+
+    def to_pyarrow(self, schema: Schema) -> pa.Table:
+        return self.obj
 
 
 PYARROW_JSON_TYPE = JSONType()


### PR DESCRIPTION
The `TableProxy` classes were misplaced under `ibis.expr.operations.relations`, probably because the `formats` arrived later. This change moves the types to the respective `ibis.formats.pandas` and `ibis.formats.pyarrow` modules as well as use `ibis.util.PseudoHashable` to make them well, "pseudo" hashable.