### PR TITLE
fix(bigquery): escape the schema (project ID) for BQ builtin UDFs

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -9,7 +9,7 @@ import os
 import re
 import warnings
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Optional
 from urllib.parse import parse_qs, urlparse
 
 import google.auth.credentials
@@ -784,6 +784,12 @@ class Backend(BaseSQLBackend, CanCreateSchema):
             chunk_size=chunk_size,
         )
         return pa.RecordBatchReader.from_batches(schema.to_pyarrow(), batch_iter)
+
+    def _gen_udf_name(self, name: str, schema: Optional[str]) -> str:
+        func = ".".join(filter(None, (schema, name)))
+        if "." in func:
+            return ".".join(f"`{part}`" for part in func.split("."))
+        return func
 
     def get_schema(self, name, schema: str | None = None, database: str | None = None):
         table_ref = bq.TableReference(

--- a/ibis/backends/bigquery/tests/unit/udf/snapshots/test_builtin/test_bqutil_fn_from_hex/out.sql
+++ b/ibis/backends/bigquery/tests/unit/udf/snapshots/test_builtin/test_bqutil_fn_from_hex/out.sql
@@ -1,0 +1,2 @@
+SELECT
+  `bqutil`.`fn`.from_hex('face') AS `from_hex_'face'`

--- a/ibis/backends/bigquery/tests/unit/udf/snapshots/test_builtin/test_farm_fingerprint/out.sql
+++ b/ibis/backends/bigquery/tests/unit/udf/snapshots/test_builtin/test_farm_fingerprint/out.sql
@@ -1,0 +1,2 @@
+SELECT
+  farm_fingerprint(b'Hello, World!') AS `farm_fingerprint_b'Hello_ World_'`

--- a/ibis/backends/bigquery/tests/unit/udf/test_builtin.py
+++ b/ibis/backends/bigquery/tests/unit/udf/test_builtin.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import ibis
 

--- a/ibis/backends/bigquery/tests/unit/udf/test_builtin.py
+++ b/ibis/backends/bigquery/tests/unit/udf/test_builtin.py
@@ -1,0 +1,30 @@
+
+import ibis
+
+to_sql = ibis.bigquery.compile
+
+
+@ibis.udf.scalar.builtin
+def farm_fingerprint(value: bytes) -> int:
+    ...
+
+
+@ibis.udf.scalar.builtin(schema="bqutil.fn")
+def from_hex(value: str) -> int:
+    """Community function to convert from hex string to integer.
+
+    See:
+    https://github.com/GoogleCloudPlatform/bigquery-utils/tree/master/udfs/community#from_hexvalue-string
+    """
+
+
+def test_bqutil_fn_from_hex(snapshot):
+    # Project ID should be enclosed in backticks.
+    expr = from_hex("face")
+    snapshot.assert_match(to_sql(expr), "out.sql")
+
+
+def test_farm_fingerprint(snapshot):
+    # No backticks needed if there is no schema defined.
+    expr = farm_fingerprint(b"Hello, World!")
+    snapshot.assert_match(to_sql(expr), "out.sql")


### PR DESCRIPTION
Discovered in draft PR https://github.com/googleapis/python-bigquery-dataframes/pull/277/files

Often BigQuery Project IDs contain `-` which need to be enclosed in backticks to ensure it is interpreted as one identifier.