### PR TITLE
fix(ir): implicitly convert `None` literals with `dt.Null` type to the requested type during value coercion

### DIFF
--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -68,13 +68,19 @@ class Value(Node, Named, Coercible, DefaultTypeVars, Generic[T, S]):
     ) -> Self:
         # note that S=Shape is unused here since the pattern will check the
         # shape of the value expression after executing Value.__coerce__()
-        from ibis.expr.operations import Literal
+        from ibis.expr.operations.generic import NULL, Literal
         from ibis.expr.types import Expr
 
         if isinstance(value, Expr):
             value = value.op()
+
         if isinstance(value, Value):
-            return value
+            if value == NULL:
+                # treat the NULL literal the same as None to implicitly cast to
+                # the requested datatype if any
+                value = None
+            else:
+                return value
 
         if T is dt.Integer:
             dtype = dt.infer(int(value))

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -195,6 +195,9 @@ class Literal(Scalar[T]):
         return repr(self.value)
 
 
+NULL = Literal(None, dt.null)
+
+
 @public
 class ScalarParameter(Scalar, Named):
     _counter = itertools.count()
@@ -313,3 +316,6 @@ class SearchedCase(Value):
     def dtype(self):
         exprs = [*self.results, self.default]
         return rlz.highest_precedence_dtype(exprs)
+
+
+public(NULL=NULL)

--- a/ibis/expr/operations/tests/test_generic.py
+++ b/ibis/expr/operations/tests/test_generic.py
@@ -122,3 +122,24 @@ def test_error_message_when_constructing_literal(call, error, snapshot):
     with pytest.raises(ValidationError) as exc:
         call()
     snapshot.assert_match(str(exc.value), f"{error}.txt")
+
+
+def test_implicit_coercion_of_null_literal():
+    # GH #7775
+    NULL = ops.Literal(None, dt.null)
+
+    value = ops.Value.__coerce__(None, dt.Int8)
+    expected = ops.Literal(None, dt.int8)
+    assert value == expected
+
+    value = ops.Value.__coerce__(NULL, dt.Float64)
+    expected = ops.Literal(None, dt.float64)
+    assert value == expected
+
+
+def test_NULL():
+    assert isinstance(ops.NULL, ops.Literal)
+    assert ops.NULL.value is None
+    assert ops.NULL.dtype is dt.null
+    assert ops.NULL == ops.Literal(None, dt.null)
+    assert ops.NULL is not ops.Literal(None, dt.int8)

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1998,7 +1998,7 @@ class NullColumn(Column, NullValue):
 @public
 def null():
     """Create a NULL/NA scalar."""
-    return literal(None)
+    return ops.NULL.to_expr()
 
 
 @public


### PR DESCRIPTION
Resolves https://github.com/ibis-project/ibis/issues/7775