### PR TITLE
fix(snowflake): convert path to `str` when checking for a prefix

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -778,7 +778,7 @@ $$"""
             )
             con.exec_driver_sql(create_infer_fmt)
 
-            if path.startswith("https://"):
+            if str(path).startswith("https://"):
                 with tempfile.NamedTemporaryFile() as tmp:
                     urlretrieve(path, filename=tmp.name)
                     tmp.flush()


### PR DESCRIPTION
We have tests that hit this code path, but I forgot to run the whole test suite before merging.