### PR TITLE
ci(flink): clean up docker image specifications

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -428,11 +428,9 @@ services:
       - exasol:/data
 
   flink-jobmanager:
-    build: ./docker/flink
-    image: ibis-flink
+    image: flink:1.18.0
     environment:
-      - |
-        FLINK_PROPERTIES=
+      FLINK_PROPERTIES: |
         jobmanager.rpc.address: flink-jobmanager
     ports:
       - 8081:8081
@@ -444,8 +442,7 @@ services:
     build: ./docker/flink
     image: ibis-flink
     environment:
-      - |
-        FLINK_PROPERTIES=
+      FLINK_PROPERTIES: |
         jobmanager.rpc.address: flink-jobmanager
         taskmanager.numberOfTaskSlots: 2
         taskmanager.memory.process.size: 2048m

--- a/docker/flink/Dockerfile
+++ b/docker/flink/Dockerfile
@@ -1,3 +1,3 @@
-FROM flink:1.18.0-scala_2.12
+FROM flink:1.18.0
 # ibis-flink requires PyFlink dependency
 RUN wget -nv -P $FLINK_HOME/lib/ https://repo1.maven.org/maven2/org/apache/flink/flink-python/1.18.0/flink-python-1.18.0.jar


### PR DESCRIPTION
We should be able to use a simpler image specification to make it easier to Mend Renovate to perform automatic upgrades to the image. We can also isolate the flink job manager a bit more by running the flink base image.