### PR TITLE
ci(dev-tools): add PR title and body linter to verify conventional commits and allow squash merges

### DIFF
--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -21,25 +21,6 @@ permissions:
   contents: read
 
 jobs:
-  commitlint:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: install nix
-        uses: cachix/install-nix-action@v24
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable-small
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-
-      - name: lint commits
-        run: nix run 'nixpkgs#commitlint' -- --from=${{ github.event.pull_request.base.sha }} --to=${{ github.sha }} --verbose
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,53 @@
+name: Conventional commits check
+
+on:
+  # runs on `pull_request_target` events so that commenting on the PR is allowed
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  commitlint:
+    name: Check PR title conforms to semantic-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: checkout code to pick up commitlint configuration
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: install deps
+        run: npm install "@commitlint/config-conventional"
+
+      - name: run commitlint
+        run: npx commitlint --extends "@commitlint/config-conventional" --verbose <<< "$COMMIT_MSG"
+        env:
+          COMMIT_MSG: >
+            ${{ github.event.pull_request.title }}
+
+            ${{ github.event.pull_request.body }}
+
+      - name: find existing comment
+        if: failure()
+        uses: peter-evans/find-comment@v2
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-regex: '\*\*ACTION NEEDED\*\*.+'
+
+      - name: post a message if the pull request title and body fail `commitlint`
+        if: steps.fc.outputs.comment-body == ''
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          body: |
+            **ACTION NEEDED**
+
+            Ibis follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for release automation.
+
+            The PR title and description are used as the merge commit message.
+
+            Please update your PR title and description to match the specification.


### PR DESCRIPTION
Adapt the https://github.com/substrait-io/substrait-python/blob/main/.github/workflows/pr_title.yml workflow for our needs, so that we can allow squash merges.

Closes #6549.