### PR TITLE
feat(api): support order statistics on more types

### DIFF
--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -457,9 +457,11 @@ def _quantile(t, op):
     arg = op.arg
     if (where := op.where) is not None:
         arg = ops.IfElse(where, arg, None)
-    return sa.func.percentile_cont(t.translate(op.quantile)).within_group(
-        t.translate(arg)
-    )
+    if arg.dtype.is_numeric():
+        func = sa.func.percentile_cont
+    else:
+        func = sa.func.percentile_disc
+    return func(t.translate(op.quantile)).within_group(t.translate(arg))
 
 
 def _median(t, op):
@@ -467,7 +469,11 @@ def _median(t, op):
     if (where := op.where) is not None:
         arg = ops.IfElse(where, arg, None)
 
-    return sa.func.percentile_cont(0.5).within_group(t.translate(arg))
+    if arg.dtype.is_numeric():
+        func = sa.func.percentile_cont
+    else:
+        func = sa.func.percentile_disc
+    return func(0.5).within_group(t.translate(arg))
 
 
 def _binary_variance_reduction(func):

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -187,29 +187,35 @@ class Mean(Filterable, Reduction):
             return dt.higher_precedence(dtype, dt.float64)
 
 
-@public
-class Median(Filterable, Reduction):
-    arg: Column[dt.Numeric | dt.Boolean]
+class OrderStatistic(Filterable, Reduction):
+    arg: Column
 
     @attribute
     def dtype(self):
-        return dt.higher_precedence(self.arg.dtype, dt.float64)
+        dtype = self.arg.dtype
+        if dtype.is_numeric():
+            return dt.higher_precedence(dtype, dt.float64)
+        else:
+            return dtype
 
 
 @public
-class Quantile(Filterable, Reduction):
-    arg: Value
+class Median(OrderStatistic):
+    pass
+
+
+@public
+class Quantile(OrderStatistic):
     quantile: Value[dt.Numeric]
 
-    dtype = dt.float64
-
 
 @public
-class MultiQuantile(Filterable, Reduction):
-    arg: Value
-    quantile: Value[dt.Array[dt.Float64]]
+class MultiQuantile(OrderStatistic):
+    quantile: Value[dt.Array[dt.Numeric]]
 
-    dtype = dt.Array(dt.float64)
+    @attribute
+    def dtype(self):
+        return dt.Array(super().dtype)
 
 
 @public

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1571,6 +1571,48 @@ class Column(Value, _FixedTextJupyterMixin):
             self, key=key, where=self._bind_reduction_filter(where)
         ).to_expr()
 
+    def median(self, where: ir.BooleanValue | None = None) -> Scalar:
+        """Return the median of the column.
+
+        Parameters
+        ----------
+        where
+            Optional boolean expression. If given, only the values where
+            `where` evaluates to true will be considered for the median.
+
+        Returns
+        -------
+        Scalar
+            Median of the column
+        """
+        return ops.Median(self, where=where).to_expr()
+
+    def quantile(
+        self,
+        quantile: float | ir.NumericValue | Sequence[ir.NumericValue | float],
+        where: ir.BooleanValue | None = None,
+    ) -> Scalar:
+        """Return value at the given quantile.
+
+        Parameters
+        ----------
+        quantile
+            `0 <= quantile <= 1`, or an array of such values
+            indicating the quantile or quantiles to compute
+        where
+            Boolean filter for input values
+
+        Returns
+        -------
+        Scalar
+            Quantile of the input
+        """
+        if isinstance(quantile, Sequence):
+            op = ops.MultiQuantile
+        else:
+            op = ops.Quantile
+        return op(self, quantile, where=where).to_expr()
+
     def nunique(self, where: ir.BooleanValue | None = None) -> ir.IntegerScalar:
         """Compute the number of distinct rows in an expression.
 

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -755,47 +755,6 @@ class NumericScalar(Scalar, NumericValue):
 
 @public
 class NumericColumn(Column, NumericValue):
-    def median(self, where: ir.BooleanValue | None = None) -> NumericScalar:
-        """Return the median of the column.
-
-        Parameters
-        ----------
-        where
-            Optional boolean expression. If given, only the values where
-            `where` evaluates to true will be considered for the median.
-
-        Returns
-        -------
-        NumericScalar
-            Median of the column
-        """
-        return ops.Median(self, where=self._bind_reduction_filter(where)).to_expr()
-
-    def quantile(
-        self,
-        quantile: Sequence[NumericValue | float],
-        where: ir.BooleanValue | None = None,
-    ) -> NumericScalar:
-        """Return value at the given quantile.
-
-        Parameters
-        ----------
-        quantile
-            `0 <= quantile <= 1`, the quantile(s) to compute
-        where
-            Boolean filter for input values
-
-        Returns
-        -------
-        NumericScalar
-            Quantile of the input
-        """
-        if isinstance(quantile, collections.abc.Sequence):
-            op = ops.MultiQuantile
-        else:
-            op = ops.Quantile
-        return op(self, quantile, where=self._bind_reduction_filter(where)).to_expr()
-
     def std(
         self,
         where: ir.BooleanValue | None = None,


### PR DESCRIPTION
Adds support for calling median and quantile on more generic types than numeric. Closes #7250.