### PR TITLE
feat(api): support median and quantile on more types

### DIFF
--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -489,8 +489,16 @@ operation_registry.update(
         ops.JSONGetItem: fixed_arity(_json_get_item, 2),
         ops.RowID: lambda *_: sa.literal_column("rowid"),
         ops.StringToTimestamp: _strptime,
-        ops.Quantile: reduction(sa.func.quantile_cont),
-        ops.MultiQuantile: reduction(sa.func.quantile_cont),
+        ops.Quantile: lambda t, op: (
+            reduction(sa.func.quantile_cont)(t, op)
+            if op.arg.dtype.is_numeric()
+            else reduction(sa.func.quantile_disc)(t, op)
+        ),
+        ops.MultiQuantile: lambda t, op: (
+            reduction(sa.func.quantile_cont)(t, op)
+            if op.arg.dtype.is_numeric()
+            else reduction(sa.func.quantile_disc)(t, op)
+        ),
         ops.TypeOf: unary(sa.func.typeof),
         ops.IntervalAdd: fixed_arity(operator.add, 2),
         ops.IntervalSubtract: fixed_arity(operator.sub, 2),

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -457,9 +457,11 @@ def _quantile(t, op):
     arg = op.arg
     if (where := op.where) is not None:
         arg = ops.IfElse(where, arg, None)
-    return sa.func.percentile_cont(t.translate(op.quantile)).within_group(
-        t.translate(arg)
-    )
+    if arg.dtype.is_numeric():
+        func = sa.func.percentile_cont
+    else:
+        func = sa.func.percentile_disc
+    return func(t.translate(op.quantile)).within_group(t.translate(arg))
 
 
 def _median(t, op):
@@ -467,7 +469,11 @@ def _median(t, op):
     if (where := op.where) is not None:
         arg = ops.IfElse(where, arg, None)
 
-    return sa.func.percentile_cont(0.5).within_group(t.translate(arg))
+    if arg.dtype.is_numeric():
+        func = sa.func.percentile_cont
+    else:
+        func = sa.func.percentile_disc
+    return func(0.5).within_group(t.translate(arg))
 
 
 def _binary_variance_reduction(func):

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from datetime import date
+from operator import methodcaller
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -24,11 +27,6 @@ except ImportError:
     GoogleBadRequest = None
 
 try:
-    from polars.exceptions import ComputeError
-except ImportError:
-    ComputeError = None
-
-try:
     from clickhouse_connect.driver.exceptions import (
         DatabaseError as ClickhouseDatabaseError,
     )
@@ -40,11 +38,15 @@ try:
 except ImportError:
     Py4JError = None
 
-
 try:
     from pyexasol.exceptions import ExaQueryError
 except ImportError:
     ExaQueryError = None
+
+try:
+    from polars.exceptions import InvalidOperationError as PolarsInvalidOperationError
+except ImportError:
+    PolarsInvalidOperationError = None
 
 
 @reduction(input_type=[dt.double], output_type=dt.double)
@@ -1208,6 +1210,102 @@ def test_median(alltypes, df):
     result = expr.execute()
     expected = df.double_col.median()
     assert result == expected
+
+
+@pytest.mark.notimpl(
+    ["bigquery", "druid", "sqlite"], raises=com.OperationNotDefinedError
+)
+@pytest.mark.notyet(
+    ["impala", "mysql", "mssql", "trino", "exasol", "flink"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(
+    ["clickhouse"],
+    raises=ClickhouseDatabaseError,
+    reason="doesn't support median of strings",
+)
+@pytest.mark.notyet(
+    ["oracle"], raises=sa.exc.DatabaseError, reason="doesn't support median of strings"
+)
+@pytest.mark.broken(
+    ["pyspark"], raises=AssertionError, reason="pyspark returns null for string median"
+)
+@pytest.mark.notimpl(["dask"], raises=(AssertionError, NotImplementedError, TypeError))
+@pytest.mark.notyet(
+    ["snowflake"],
+    raises=sa.exc.ProgrammingError,
+    reason="doesn't support median of strings",
+)
+@pytest.mark.notyet(["polars"], raises=PolarsInvalidOperationError)
+@pytest.mark.notyet(["datafusion"], raises=Exception, reason="not supported upstream")
+@pytest.mark.notimpl(
+    ["pandas"], raises=TypeError, reason="results aren't correctly typed"
+)
+@pytest.mark.parametrize(
+    "func",
+    [
+        param(
+            methodcaller("quantile", 0.5),
+            id="quantile",
+            marks=[
+                pytest.mark.notimpl(["oracle"], raises=com.OperationNotDefinedError)
+            ],
+        ),
+        param(
+            methodcaller("median"),
+            id="median",
+            marks=[
+                pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
+            ],
+        ),
+    ],
+)
+def test_string_quantile(alltypes, func):
+    expr = func(alltypes.select(col=ibis.literal("a")).limit(5).col)
+    result = expr.execute()
+    assert result == "a"
+
+
+@pytest.mark.notimpl(["bigquery", "sqlite"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(
+    ["impala", "mysql", "mssql", "trino", "exasol", "flink"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.broken(["druid"], raises=AttributeError)
+@pytest.mark.notyet(
+    ["snowflake"],
+    raises=sa.exc.ProgrammingError,
+    reason="doesn't support median of dates",
+)
+@pytest.mark.notimpl(["dask"], raises=(AssertionError, NotImplementedError, TypeError))
+@pytest.mark.notyet(["polars"], raises=PolarsInvalidOperationError)
+@pytest.mark.notyet(["datafusion"], raises=Exception, reason="not supported upstream")
+@pytest.mark.broken(
+    ["pandas"], raises=AssertionError, reason="possibly incorrect results"
+)
+@pytest.mark.parametrize(
+    "func",
+    [
+        param(
+            methodcaller("quantile", 0.5),
+            id="quantile",
+            marks=[
+                pytest.mark.notimpl(["oracle"], raises=com.OperationNotDefinedError)
+            ],
+        ),
+        param(
+            methodcaller("median"),
+            id="median",
+            marks=[
+                pytest.mark.notimpl(["pyspark"], raises=com.OperationNotDefinedError)
+            ],
+        ),
+    ],
+)
+def test_date_quantile(alltypes, func):
+    expr = func(alltypes.timestamp_col.date())
+    result = expr.execute()
+    assert result == date(2009, 12, 31)
 
 
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -901,7 +901,6 @@ def test_count_distinct_star(alltypes, df, ibis_cond, pandas_cond):
                         "impala",
                         "mssql",
                         "mysql",
-                        "polars",
                         "sqlite",
                         "druid",
                         "oracle",

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -187,29 +187,38 @@ class Mean(Filterable, Reduction):
             return dt.higher_precedence(dtype, dt.float64)
 
 
-@public
-class Median(Filterable, Reduction):
-    arg: Column[dt.Numeric | dt.Boolean]
+class QuantileBase(Filterable, Reduction):
+    arg: Column
 
     @attribute
     def dtype(self):
-        return dt.higher_precedence(self.arg.dtype, dt.float64)
+        dtype = self.arg.dtype
+        if dtype.is_numeric():
+            dtype = dt.higher_precedence(dtype, dt.float64)
+        return dtype
 
 
 @public
-class Quantile(Filterable, Reduction):
-    arg: Value
-    quantile: Value[dt.Numeric]
+class Median(QuantileBase):
+    pass
 
-    dtype = dt.float64
+
+@public
+class Quantile(QuantileBase):
+    quantile: Value[dt.Numeric]
 
 
 @public
 class MultiQuantile(Filterable, Reduction):
-    arg: Value
-    quantile: Value[dt.Array[dt.Float64]]
+    arg: Column
+    quantile: Value[dt.Array[dt.Numeric]]
 
-    dtype = dt.Array(dt.float64)
+    @attribute
+    def dtype(self):
+        dtype = self.arg.dtype
+        if dtype.is_numeric():
+            dtype = dt.higher_precedence(dtype, dt.float64)
+        return dt.Array(dtype)
 
 
 @public

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -755,47 +755,6 @@ class NumericScalar(Scalar, NumericValue):
 
 @public
 class NumericColumn(Column, NumericValue):
-    def median(self, where: ir.BooleanValue | None = None) -> NumericScalar:
-        """Return the median of the column.
-
-        Parameters
-        ----------
-        where
-            Optional boolean expression. If given, only the values where
-            `where` evaluates to true will be considered for the median.
-
-        Returns
-        -------
-        NumericScalar
-            Median of the column
-        """
-        return ops.Median(self, where=self._bind_reduction_filter(where)).to_expr()
-
-    def quantile(
-        self,
-        quantile: Sequence[NumericValue | float],
-        where: ir.BooleanValue | None = None,
-    ) -> NumericScalar:
-        """Return value at the given quantile.
-
-        Parameters
-        ----------
-        quantile
-            `0 <= quantile <= 1`, the quantile(s) to compute
-        where
-            Boolean filter for input values
-
-        Returns
-        -------
-        NumericScalar
-            Quantile of the input
-        """
-        if isinstance(quantile, collections.abc.Sequence):
-            op = ops.MultiQuantile
-        else:
-            op = ops.Quantile
-        return op(self, quantile, where=self._bind_reduction_filter(where)).to_expr()
-
     def std(
         self,
         where: ir.BooleanValue | None = None,


### PR DESCRIPTION
Adds support for calling `median` and `quantile` on more types than numeric.

Tests are included for computing the median of dates + strings.

Closes #7250.