### PR TITLE
ci: move back to download artifact v4 until actions/download-artifact#249 is fixed

### DIFF
--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -44,7 +44,7 @@ jobs:
         run: mamba create --name ibis${{ matrix.python-version }} --file conda-lock/linux-64/${{ matrix.python-version }}.lock
 
       - name: upload conda lock files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: conda-lock-files-${{ github.run_attempt }}
           path: ci/conda-lock/*/${{ matrix.python-version }}.lock

--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -72,7 +72,7 @@ jobs:
           token: ${{ steps.generate_pr_token.outputs.token }}
 
       - name: download conda lock files
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: conda-lock-files-${{ github.run_attempt }}
           path: ci/conda-lock

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -748,7 +748,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: download poetry lockfile
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: deps
           path: deps

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -638,7 +638,7 @@ jobs:
         run: poetry show sqlalchemy --no-ansi | grep version | cut -d ':' -f2- | sed 's/ //g' | grep -P '^2\.'
 
       - name: upload deps file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: deps
           path: |


### PR DESCRIPTION
Avoid annoying spurious failures in CI due to a broken v4 of the upload and download artifact actions.