### PR TITLE
ci(dev-tools): stop warning on leading blank line in body

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -26,7 +26,7 @@ jobs:
       - name: run commitlint
         run: npx commitlint --extends "@commitlint/config-conventional" --verbose <<< "$COMMIT_MSG"
         env:
-          COMMIT_MSG: >
+          COMMIT_MSG: |
             ${{ github.event.pull_request.title }}
 
             ${{ github.event.pull_request.body }}


### PR DESCRIPTION
Otherwise, we're stuck telling people to always start PR descriptions with a blank line which seems silly (and annoying).