### PR TITLE
fix(repr): default to pa.binary for all geospatial dtypes

### DIFF
--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -90,7 +90,6 @@ _to_pyarrow_types = {
     dt.Unknown: pa.string(),
     dt.MACADDR: pa.string(),
     dt.INET: pa.string(),
-    dt.GeoSpatial: pa.binary(),
 }
 
 
@@ -191,6 +190,8 @@ class PyArrowType(TypeMapper):
             return pa.map_(key_field, value_field, keys_sorted=False)
         elif dtype.is_json():
             return PYARROW_JSON_TYPE
+        elif dtype.is_geospatial():
+            return pa.binary()
         else:
             try:
                 return _to_pyarrow_types[type(dtype)]

--- a/ibis/formats/tests/test_pyarrow.py
+++ b/ibis/formats/tests/test_pyarrow.py
@@ -159,3 +159,20 @@ def test_schema_roundtrip(pyarrow_schema):
 
 def test_unknown_dtype_gets_converted_to_string():
     assert PyArrowType.from_ibis(dt.unknown) == pa.string()
+
+
+@pytest.mark.parametrize(
+    "ibis_type",
+    [
+        pytest.param(dt.geometry, id="geometry"),
+        pytest.param(dt.geography, id="geography"),
+        pytest.param(dt.point, id="point"),
+        pytest.param(dt.linestring, id="linestring"),
+        pytest.param(dt.polygon, id="polygon"),
+        pytest.param(dt.multilinestring, id="multilinestring"),
+        pytest.param(dt.multipoint, id="multipoint"),
+        pytest.param(dt.multipolygon, id="multipolygon"),
+    ],
+)
+def test_geo_gets_converted_to_binary(ibis_type):
+    assert PyArrowType.from_ibis(ibis_type) == pa.binary()


### PR DESCRIPTION
Does what it says on the tin. We will want to specialize this more once we have
proper support for `geoarrow` and friends, but for now, we should assume all
geospatial types should be rendered as binary.