### PR TITLE
fix(duckdb): allow table creation from expr with geospatial datatypes

### DIFF
--- a/ibis/backends/base/sqlglot/datatypes.py
+++ b/ibis/backends/base/sqlglot/datatypes.py
@@ -354,6 +354,8 @@ class DuckDBType(SqlglotType):
     default_decimal_scale = 3
     default_interval_precision = "us"
 
+    unknown_type_strings = FrozenDict({"wkb_blob": dt.binary})
+
     @classmethod
     def _from_sqlglot_TIMESTAMP(cls) -> dt.Timestamp:
         return dt.Timestamp(scale=6, nullable=cls.default_nullable)

--- a/ibis/backends/duckdb/tests/test_geospatial.py
+++ b/ibis/backends/duckdb/tests/test_geospatial.py
@@ -219,7 +219,7 @@ def test_create_table_geospatial_types(geotable, con):
 
     # con = ibis.get_backend(geotable)
 
-    t = con.create_table(name, geotable)
+    t = con.create_table(name, geotable, temp=True)
 
     assert t.op().name in con.list_tables()
     assert any(map(methodcaller("is_geospatial"), t.schema().values()))

--- a/ibis/backends/duckdb/tests/test_geospatial.py
+++ b/ibis/backends/duckdb/tests/test_geospatial.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from operator import methodcaller
+
 import numpy.testing as npt
 import pandas.testing as tm
 import pyarrow as pa
@@ -210,3 +212,14 @@ def test_geospatial_convert(geotable, gdf):
     gtm.assert_geoseries_equal(
         geo_ll.to_pandas(), gdf_ll, check_less_precise=True, check_crs=False
     )
+
+
+def test_create_table_geospatial_types(geotable, con):
+    name = ibis.util.gen_name("geotable")
+
+    # con = ibis.get_backend(geotable)
+
+    t = con.create_table(name, geotable)
+
+    assert t.op().name in con.list_tables()
+    assert any(map(methodcaller("is_geospatial"), t.schema().values()))


### PR DESCRIPTION
I thought, initially, that `WKB_BLOB` should be mapped on to something
like `dt.GeoSpatial`, but that leads to a situation where we try to call
`AsWKB` on an existing WKB column, and DuckDB does not like that.

Mapping it as `binary` works and the created columns are still correctly
detected as `geometry:geospatial`.