### PR TITLE
fix(impala): generate memtables using `UNION ALL` to work around sqlglot bug

### DIFF
--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -60,3 +60,7 @@ class ImpalaCompiler(Compiler):
     translator_class = ImpalaExprTranslator
     table_set_formatter_class = ImpalaTableSetFormatter
     rewrites = Compiler.rewrites | rewrite_sample
+
+    # impala supports this but sqlglot fails to parse the aliasing in
+    # (VALUES (a AS b))
+    support_values_syntax_in_select = False


### PR DESCRIPTION
Work around [a bug in sqlglot](https://github.com/tobymao/sqlglot/issues/2717) where it cannot parse Impala `VALUES` syntax. Discovered by @chris-park in https://github.com/ibis-project/ibis/issues/7827#issuecomment-1867499217.

