### PR TITLE
refactor(ir): introduce `JoinTable` operation unique to a `JoinChain` instead of using the globally unique `SelfReference`

### DIFF
--- a/ibis/expr/decompile.py
+++ b/ibis/expr/decompile.py
@@ -184,6 +184,11 @@ def self_reference(op, parent, identifier):
     return parent
 
 
+@translate.register(ops.JoinTable)
+def join_table(op, parent, index):
+    return parent
+
+
 @translate.register(ops.JoinLink)
 def join_link(op, table, predicates, how):
     return f".{how}_join({table}, {_try_unwrap(predicates)})"
@@ -327,7 +332,7 @@ def isin(op, value, options):
 class CodeContext:
     always_assign = (ops.ScalarParameter, ops.UnboundTable, ops.Aggregate)
     always_ignore = (
-        ops.SelfReference,
+        ops.JoinTable,
         ops.Field,
         dt.Primitive,
         dt.Variadic,

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -162,7 +162,7 @@ def pretty(node):
 
     def mapper(op, _, **kwargs):
         result = fmt(op, **kwargs)
-        if isinstance(op, ops.Relation):
+        if isinstance(op, ops.Relation) and not isinstance(op, ops.JoinTable):
             tables[op] = result
             result = f"r{next(refcnt)}"
         return Rendered(result)
@@ -335,6 +335,11 @@ def _limit(op, parent, **kwargs):
 @fmt.register(ops.Distinct)
 def _self_reference(op, parent, **kwargs):
     return f"{op.__class__.__name__}[{parent}]"
+
+
+@fmt.register(ops.JoinTable)
+def _join_table(op, parent, index):
+    return parent
 
 
 @fmt.register(ops.Literal)

--- a/ibis/expr/tests/snapshots/test_format/test_asof_join/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_asof_join/repr.txt
@@ -6,21 +6,15 @@ r1 := UnboundTable: right
   time2  int32
   value2 float64
 
-r2 := SelfReference[r0]
-
-r3 := SelfReference[r1]
-
-r4 := SelfReference[r1]
-
-JoinChain[r2]
-  JoinLink[asof, r3]
-    r2.time1 == r3.time2
-  JoinLink[inner, r4]
-    r2.value == r4.value2
+JoinChain[r0]
+  JoinLink[asof, r1]
+    r0.time1 == r1.time2
+  JoinLink[inner, r1]
+    r0.value == r1.value2
   values:
-    time1:        r2.time1
-    value:        r2.value
-    time2:        r3.time2
-    value2:       r3.value2
-    time2_right:  r4.time2
-    value2_right: r4.value2
+    time1:        r0.time1
+    value:        r0.value
+    time2:        r1.time2
+    value2:       r1.value2
+    time2_right:  r1.time2
+    value2_right: r1.value2

--- a/ibis/expr/tests/snapshots/test_format/test_format_multiple_join_with_projection/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_format_multiple_join_with_projection/repr.txt
@@ -12,24 +12,18 @@ r2 := UnboundTable: three
   bar_id string
   value2 float64
 
-r3 := SelfReference[r1]
-
-r4 := SelfReference[r2]
-
-r5 := Filter[r0]
+r3 := Filter[r0]
   r0.f > 0
 
-r6 := SelfReference[r5]
-
-JoinChain[r6]
-  JoinLink[left, r3]
-    r6.foo_id == r3.foo_id
-  JoinLink[inner, r4]
-    r6.bar_id == r4.bar_id
+JoinChain[r3]
+  JoinLink[left, r1]
+    r3.foo_id == r1.foo_id
+  JoinLink[inner, r2]
+    r3.bar_id == r2.bar_id
   values:
-    c:      r6.c
-    f:      r6.f
-    foo_id: r6.foo_id
-    bar_id: r6.bar_id
-    value1: r3.value1
-    value2: r4.value2
+    c:      r3.c
+    f:      r3.f
+    foo_id: r3.foo_id
+    bar_id: r3.bar_id
+    value1: r1.value1
+    value2: r2.value2

--- a/ibis/expr/tests/snapshots/test_format/test_memoize_filtered_tables_in_join/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_memoize_filtered_tables_in_join/repr.txt
@@ -17,15 +17,11 @@ r2 := Filter[r1]
 r3 := Filter[r1]
   r1.kind == 'bar'
 
-r4 := SelfReference[r2]
-
-r5 := SelfReference[r3]
-
-JoinChain[r4]
-  JoinLink[inner, r5]
-    r4.region == r5.region
+JoinChain[r2]
+  JoinLink[inner, r3]
+    r2.region == r3.region
   values:
-    region:      r4.region
-    kind:        r4.kind
-    total:       r4.total
-    right_total: r5.total
+    region:      r2.region
+    kind:        r2.kind
+    total:       r2.total
+    right_total: r3.total

--- a/ibis/expr/tests/snapshots/test_format/test_table_count_expr/join_repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_table_count_expr/join_repr.txt
@@ -6,17 +6,13 @@ r1 := UnboundTable: t2
   a int64
   b float64
 
-r2 := SelfReference[r0]
-
-r3 := SelfReference[r1]
-
-r4 := JoinChain[r2]
-  JoinLink[inner, r3]
-    r2.a == r3.a
+r2 := JoinChain[r0]
+  JoinLink[inner, r1]
+    r0.a == r1.a
   values:
-    a:       r2.a
-    b:       r2.b
-    a_right: r3.a
-    b_right: r3.b
+    a:       r0.a
+    b:       r0.b
+    a_right: r1.a
+    b_right: r1.b
 
-CountStar(): CountStar(r4)
+CountStar(): CountStar(r2)

--- a/ibis/expr/tests/snapshots/test_format/test_two_inner_joins/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_two_inner_joins/repr.txt
@@ -8,24 +8,18 @@ r1 := UnboundTable: right
   value2 float64
   b      string
 
-r2 := SelfReference[r0]
-
-r3 := SelfReference[r1]
-
-r4 := SelfReference[r1]
-
-JoinChain[r2]
-  JoinLink[inner, r3]
-    r2.a == r3.b
-  JoinLink[inner, r4]
-    r2.value == r4.value2
+JoinChain[r0]
+  JoinLink[inner, r1]
+    r0.a == r1.b
+  JoinLink[inner, r1]
+    r0.value == r1.value2
   values:
-    time1:        r2.time1
-    value:        r2.value
-    a:            r2.a
-    time2:        r3.time2
-    value2:       r3.value2
-    b:            r3.b
-    time2_right:  r4.time2
-    value2_right: r4.value2
-    b_right:      r4.b
+    time1:        r0.time1
+    value:        r0.value
+    a:            r0.a
+    time2:        r1.time2
+    value2:       r1.value2
+    b:            r1.b
+    time2_right:  r1.time2
+    value2_right: r1.value2
+    b_right:      r1.b

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2982,13 +2982,10 @@ class Table(Expr, _FixedTextJupyterMixin):
             # `ir.Table(ops.JoinChain())` expression, which we can reuse here
             expr = left.to_expr()
         else:
-            # all participants of the join must be wrapped in SelfReferences so
-            # that we can join the same table with itself multiple times and to
-            # enable optimization passes later on
-            if not isinstance(left, ops.SelfReference):
-                left = ops.SelfReference(left)
-            # construct an empty join chain and wrap it with a JoinExpr, the
-            # projected fields are the fields of the starting table
+            # all participants of the join must be wrapped in JoinTable nodes
+            # so that we can join the same table with itself multiple times and
+            # to enable optimization passes later on
+            left = ops.JoinTable(left, index=0)
             expr = ops.JoinChain(left, rest=(), values=left.fields).to_expr()
 
         return expr.join(right, predicates, how=how, lname=lname, rname=rname)

--- a/ibis/tests/expr/snapshots/test_format_sql_operations/test_memoize_database_table/repr.txt
+++ b/ibis/tests/expr/snapshots/test_format_sql_operations/test_memoize_database_table/repr.txt
@@ -7,27 +7,23 @@ r1 := DatabaseTable: test1
   f float64
   g string
 
-r2 := SelfReference[r0]
-
-r3 := Filter[r1]
+r2 := Filter[r1]
   r1.f > 0
 
-r4 := SelfReference[r3]
-
-r5 := JoinChain[r2]
-  JoinLink[inner, r4]
-    r4.g == r2.key
+r3 := JoinChain[r0]
+  JoinLink[inner, r2]
+    r2.g == r0.key
   values:
-    key:   r2.key
-    value: r2.value
-    c:     r4.c
-    f:     r4.f
-    g:     r4.g
+    key:   r0.key
+    value: r0.value
+    c:     r2.c
+    f:     r2.f
+    g:     r2.g
 
-Aggregate[r5]
+Aggregate[r3]
   groups:
-    g:   r5.g
-    key: r5.key
+    g:   r3.g
+    key: r3.key
   metrics:
-    foo: Mean(r5.f - r5.value)
-    bar: Sum(r5.f)
+    foo: Mean(r3.f - r3.value)
+    bar: Sum(r3.f)

--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -8,7 +8,7 @@ import ibis
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import _
-from ibis.expr.tests.test_newrels import self_references
+from ibis.expr.tests.test_newrels import join_tables
 from ibis.tests.util import assert_pickle_roundtrip
 
 
@@ -70,10 +70,10 @@ def test_unpack_from_table(t):
 
 
 def test_lift_join(t, s):
-    with self_references():
-        join = t.join(s, t.d == s.a.g)
-        result = join.a_right.lift()
-    with self_references(t, s) as (r1, r2):
+    join = t.join(s, t.d == s.a.g)
+    result = join.a_right.lift()
+
+    with join_tables(t, s) as (r1, r2):
         join = ops.JoinChain(
             first=r1,
             rest=[


### PR DESCRIPTION
This enables us to maintain join expression equality: `a.join(b).equals(a.join(b))`

So far we have been using `SelfReference` to make join tables unique, but it was globally unique which broke the equality check above. Therefore we need to restrict the uniqueness to the scope of the join chain. The simplest solution for that is to simply enumerate the join tables in the join chain, hence now all join participants must be `ops.JoinTable(rel, index)` instances. 

`ops.SelfReference` is still required to distinguish between two identical tables at the API level, but it is now decoupled from the join internal representation. 