### PR TITLE
refactor(ir): support join of joins without nesting the left side

### DIFF
--- a/ibis/expr/rewrites.py
+++ b/ibis/expr/rewrites.py
@@ -17,6 +17,11 @@ y = var("y")
 name = var("name")
 
 
+@replace(p.Field(p.JoinChain))
+def peel_join_field(_):
+    return _.rel.values[_.name]
+
+
 @replace(ops.Analytic)
 def project_wrap_analytic(_, rel):
     # Wrap analytic functions in a window function

--- a/ibis/expr/types/joins.py
+++ b/ibis/expr/types/joins.py
@@ -17,6 +17,8 @@ import functools
 from ibis.expr.types.relations import dereference_mapping
 import ibis
 
+from ibis.expr.rewrites import peel_join_field
+
 
 def disambiguate_fields(how, left_fields, right_fields, lname, rname):
     collisions = set()
@@ -207,6 +209,9 @@ class JoinExpr(Table):
         # if there are values referencing fields from the join chain constructed
         # so far, we need to replace them the fields from one of the join links
         subs = dereference_mapping_left(chain)
+        values = {
+            k: v.replace(peel_join_field, filter=ops.Value) for k, v in values.items()
+        }
         values = {k: v.replace(subs, filter=ops.Value) for k, v in values.items()}
 
         node = chain.copy(values=values)


### PR DESCRIPTION
@cpcloud this is going to fix several integrity errors in the duckdb refactor while producing a simpler join chain. 

A solution would have been to just remove the support of "continue the left chain"  in rather than just "nest the chains", but I managed to resolve the dereferencing issue by "peeling" all `JoinChain` fields in the input values. 

I still need to finish the PR.