### PR TITLE
fix(deps): remove `filelock` from required dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7361,4 +7361,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8b4afe7ece6da2cf9019d474c571ad0a5674e62fd8386030e0f341d9f3e84ba0"
+content-hash = "0fc60043be3fa036840f3a12d2fbc8bd60550e1efb1e5a3ebcc869b17ce2413a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
 python = "^3.9"
 atpublic = ">=2.3,<5"
 bidict = ">=0.22.1,<1"
-filelock = ">=3.7.0,<4"
 multipledispatch = ">=0.6,<2"
 numpy = ">=1,<2"
 pandas = ">=1.2.5,<3"
@@ -116,6 +115,7 @@ ruff = ">=0.1.8"
 tqdm = ">=4.66.1,<5"
 
 [tool.poetry.group.test.dependencies]
+filelock = ">=3.7.0,<4"
 hypothesis = ">=6.58.0,<7"
 packaging = ">=21.3,<24"
 pytest = ">=7.0.0,<8"


### PR DESCRIPTION
`filelock` is only used in testing, so move that dependency to the `test` dependency group