### PR TITLE
feat(datatypes): fix decimal support and add geospatial types to the sqlglot type mapper

### DIFF
--- a/ibis/backends/base/sqlglot/tests/test_datatypes.py
+++ b/ibis/backends/base/sqlglot/tests/test_datatypes.py
@@ -39,6 +39,9 @@ roundtripable_types = st.deferred(
         | its.array_dtypes(roundtripable_types, nullable=true)
         | its.map_dtypes(roundtripable_types, roundtripable_types, nullable=true)
         | its.struct_dtypes(roundtripable_types, nullable=true)
+        | its.geometry_dtypes(nullable=true)
+        | its.geography_dtypes(nullable=true)
+        | its.decimal_dtypes(nullable=true)
     )
 )
 
@@ -51,3 +54,13 @@ roundtripable_types = st.deferred(
 @h.given(roundtripable_types)
 def test_roundtripable_types(ibis_type):
     assert_dtype_roundtrip(ibis_type)
+
+
+@h.given(its.specific_geometry_dtypes(nullable=true))
+def test_specific_geometry_types(ibis_type):
+    sqlglot_result = SqlglotType.from_ibis(ibis_type)
+    assert isinstance(sqlglot_result, sge.DataType)
+    assert sqlglot_result == sge.DataType(this=sge.DataType.Type.GEOMETRY)
+    assert SqlglotType.to_ibis(sqlglot_result) == dt.GeoSpatial(
+        geotype="geometry", nullable=ibis_type.nullable
+    )

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -186,7 +186,7 @@ def geography_dtypes(nullable=_nullable):
     return st.builds(dt.GeoSpatial, geotype=st.just("geography"), nullable=nullable)
 
 
-def geospatial_dtypes(nullable=_nullable):
+def specific_geometry_dtypes(nullable=_nullable):
     return st.one_of(
         st.builds(dt.Point, nullable=nullable),
         st.builds(dt.LineString, nullable=nullable),
@@ -194,6 +194,12 @@ def geospatial_dtypes(nullable=_nullable):
         st.builds(dt.MultiPoint, nullable=nullable),
         st.builds(dt.MultiLineString, nullable=nullable),
         st.builds(dt.MultiPolygon, nullable=nullable),
+    )
+
+
+def geospatial_dtypes(nullable=_nullable):
+    return st.one_of(
+        specific_geometry_dtypes(nullable=nullable),
         geometry_dtypes(nullable=nullable),
         geography_dtypes(nullable=nullable),
     )


### PR DESCRIPTION
Fix support for decimal types and add support for basic geograph and geometry types to the sqlglot type mapper.