### PR TITLE
refactor(ir): stricter scalar subquery integrity checks

### DIFF
--- a/ibis/expr/rewrites.py
+++ b/ibis/expr/rewrites.py
@@ -140,10 +140,10 @@ def rewrite_project_input(value, relation):
     )
 
 
-ReductionValue = p.Reduction | p.Field(p.Aggregate(groups={}))
+ReductionLike = p.Reduction | p.Field(p.Aggregate(groups={}))
 
 
-@replace(ReductionValue)
+@replace(ReductionLike)
 def filter_wrap_reduction(_):
     # Wrap reductions or fields referencing an aggregation without a group by -
     # which are scalar fields - in a scalar subquery. In the latter case we

--- a/ibis/expr/tests/test_newrels.py
+++ b/ibis/expr/tests/test_newrels.py
@@ -139,10 +139,18 @@ def test_select_windowizing_analytic_function():
 
 def test_subquery_integrity_check():
     t = ibis.table(name="t", schema={"a": "int64", "b": "string"})
+    agg = t.agg([t.a.sum(), t.a.mean()])
 
     msg = "Subquery must have exactly one column, got 2"
     with pytest.raises(IntegrityError, match=msg):
+        ops.ScalarSubquery(agg)
+    with pytest.raises(IntegrityError, match=msg):
         ops.ScalarSubquery(t)
+
+    agg = t.agg(t.a.sum() + 1)
+    msg = "is not a reduction"
+    with pytest.raises(IntegrityError, match=msg):
+        ops.ScalarSubquery(agg)
 
 
 def test_select_turns_scalar_reduction_into_subquery():


### PR DESCRIPTION
Previously the integrity check allowed arbitrary value expressions originating from a reduction. This change enforces that the value wrapped in a `ScalarSubquery` must be a reduction instance.