### PR TITLE
refactor(api): revamp `asof` join predicates

### DIFF
--- a/ibis/backends/clickhouse/tests/test_select.py
+++ b/ibis/backends/clickhouse/tests/test_select.py
@@ -371,9 +371,9 @@ def test_join_with_external_table(alltypes, df):
 def test_asof_join(time_left, time_right):
     expr = time_left.asof_join(
         time_right,
+        on=time_left["time"] >= time_right["time"],
         predicates=[
             time_left["key"] == time_right["key"],
-            time_left["time"] >= time_right["time"],
         ],
     ).drop("time_right")
     result = expr.execute()

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -258,7 +258,7 @@ class JoinChain(Relation):
     def to_expr(self):
         import ibis.expr.types as ir
 
-        return ir.JoinExpr(self)
+        return ir.Join(self)
 
 
 @public

--- a/ibis/expr/tests/snapshots/test_format/test_asof_join/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_asof_join/repr.txt
@@ -8,7 +8,7 @@ r1 := UnboundTable: right
 
 JoinChain[r0]
   JoinLink[asof, r1]
-    r0.time1 == r1.time2
+    r0.time1 <= r1.time2
   JoinLink[inner, r1]
     r0.value == r1.value2
   values:

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -311,7 +311,7 @@ def test_fillna(snapshot):
 def test_asof_join(snapshot):
     left = ibis.table([("time1", "int32"), ("value", "double")], name="left")
     right = ibis.table([("time2", "int32"), ("value2", "double")], name="right")
-    joined = left.asof_join(right, [("time1", "time2")]).inner_join(
+    joined = left.asof_join(right, ("time1", "time2")).inner_join(
         right, left.value == right.value2
     )
 

--- a/ibis/expr/tests/test_newrels.py
+++ b/ibis/expr/tests/test_newrels.py
@@ -479,14 +479,14 @@ def test_join():
     t2 = ibis.table(name="t2", schema={"c": "int64", "d": "string"})
     joined = t1.join(t2, [t1.a == t2.c])
 
-    assert isinstance(joined, ir.JoinExpr)
+    assert isinstance(joined, ir.Join)
     assert isinstance(joined.op(), JoinChain)
-    assert isinstance(joined.op().to_expr(), ir.JoinExpr)
+    assert isinstance(joined.op().to_expr(), ir.Join)
 
     result = joined._finish()
     assert isinstance(joined, ir.TableExpr)
     assert isinstance(joined.op(), JoinChain)
-    assert isinstance(joined.op().to_expr(), ir.JoinExpr)
+    assert isinstance(joined.op().to_expr(), ir.Join)
 
     with join_tables(t1, t2) as (t1, t2):
         assert result.op() == JoinChain(
@@ -1256,3 +1256,32 @@ def test_join_between_joins():
             },
         )
         assert expr.op() == expected
+
+
+def test_join_method_docstrings():
+    t1 = ibis.table(name="t1", schema={"a": "int64", "b": "string"})
+    t2 = ibis.table(name="t2", schema={"c": "int64", "d": "string"})
+    joined = t1.join(t2, [t1.a == t2.c])
+
+    assert isinstance(t1, ir.Table)
+    assert isinstance(joined, ir.Join)
+    assert isinstance(joined, ir.Table)
+
+    method_names = [
+        "select",
+        "join",
+        "inner_join",
+        "left_join",
+        "outer_join",
+        "semi_join",
+        "anti_join",
+        "asof_join",
+        "cross_join",
+        "right_join",
+        "any_inner_join",
+        "any_left_join",
+    ]
+    for method in method_names:
+        join_method = getattr(joined, method)
+        table_method = getattr(t1, method)
+        assert join_method.__doc__ == table_method.__doc__

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2972,28 +2972,17 @@ class Table(Expr, _FixedTextJupyterMixin):
         │  106782 │ Leonardo DiCaprio │          5989 │ Leonardo DiCaprio │
         └─────────┴───────────────────┴───────────────┴───────────────────┘
         """
-        from ibis.expr.types.joins import JoinExpr
+        from ibis.expr.types.joins import Join
 
-        left = left.op()
-        if isinstance(left, ops.JoinChain):
-            # if the left side is already a join chain, we can reuse it, for
-            # example in the `a.join(b)[fields].join(c)` expression the first
-            # join followed by a projection `a.join(b)[...]` constructs a
-            # `ir.Table(ops.JoinChain())` expression, which we can reuse here
-            expr = left.to_expr()
-        else:
-            # all participants of the join must be wrapped in JoinTable nodes
-            # so that we can join the same table with itself multiple times and
-            # to enable optimization passes later on
-            left = ops.JoinTable(left, index=0)
-            expr = ops.JoinChain(left, rest=(), values=left.fields).to_expr()
-
-        return expr.join(right, predicates, how=how, lname=lname, rname=rname)
+        return Join(left.op()).join(
+            right, predicates, how=how, lname=lname, rname=rname
+        )
 
     def asof_join(
         left: Table,
         right: Table,
-        predicates: str | ir.BooleanColumn | Sequence[str | ir.BooleanColumn] = (),
+        on: str | ir.BooleanColumn,
+        predicates: str | ir.Column | Sequence[str | ir.Column] = (),
         by: str | ir.Column | Sequence[str | ir.Column] = (),
         tolerance: str | ir.IntervalScalar | None = None,
         *,
@@ -3013,10 +3002,10 @@ class Table(Expr, _FixedTextJupyterMixin):
             Table expression
         right
             Table expression
+        on
+            Closest match inequality condition
         predicates
-            Join expressions
-        by
-            column to group by before joining
+            Additional join predicates
         tolerance
             Amount of time to look behind when joining
         lname
@@ -3031,22 +3020,11 @@ class Table(Expr, _FixedTextJupyterMixin):
         Table
             Table expression
         """
-        if by:
-            # `by` is an argument that comes from pandas, which for pandas was
-            # a convenient and fast way to perform a standard join before the
-            # asof join, so we implement the equivalent behavior here for
-            # consistency across backends.
-            left = left.join(right, by, lname=lname, rname=rname)
+        from ibis.expr.types.joins import Join
 
-        if tolerance is not None:
-            if not isinstance(predicates, str):
-                raise TypeError(
-                    "tolerance can only be specified when predicates is a string"
-                )
-            left_key, right_key = left[predicates], right[predicates]
-            predicates = [left_key == right_key, left_key - right_key <= tolerance]
-
-        return left.join(right, predicates, how="asof", lname=lname, rname=rname)
+        return Join(left.op()).asof_join(
+            right, on, predicates, by=by, tolerance=tolerance, lname=lname, rname=rname
+        )
 
     def cross_join(
         left: Table,
@@ -3122,12 +3100,9 @@ class Table(Expr, _FixedTextJupyterMixin):
         >>> expr.count()
         344
         """
-        left = left.join(right, how="cross", predicates=(), lname=lname, rname=rname)
-        for right in rest:
-            left = left.join(
-                right, how="cross", predicates=(), lname=lname, rname=rname
-            )
-        return left
+        from ibis.expr.types.joins import Join
+
+        return Join(left.op()).cross_join(right, *rest, lname=lname, rname=rname)
 
     inner_join = _regular_join_method("inner_join", "inner")
     left_join = _regular_join_method("left_join", "left")


### PR DESCRIPTION
Previously the `ASOF` join API was imprecise. 

The backends supporting `asof` joins require exactly one nearest match (inequality) predicate along with arbitrary number of ordinary join predicates, see [ClickHouse ASOF](https://clickhouse.com/docs/en/sql-reference/statements/select/join#asof-join-usage), [DuckDB ASOF](https://duckdb.org/docs/guides/sql_features/asof_join.html#asof-joins-with-the-using-keyword) and [Pandas ASOF](https://pandas.pydata.org/docs/reference/api/pandas.merge_asof.html). 

This change alters the API to `table.asof_join(left, right, on, predicates, ...)` where `on` is the nearest match predicate defaulting to `left[on] <= right[on]` if not an expression is given. I kept the `by` argument for compatibility reasons, but we should phase that out in favor of `predicates`.

Also ensure that all the join methods or `ir.Join` have the exact same docstrings as `ir.Table`.

BREAKING CHANGE: `on` paremater of `table.asof_join()` is now only accept a single predicate, use `predicates` to supply additional join predicates.