### PR TITLE
fix(duckdb): ensure that create_schema and create_database are actually tested

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -491,8 +491,9 @@ class Backend(SQLGlotBackend, CanCreateSchema):
                 "DuckDB cannot create a schema in another database."
             )
 
-        name = sg.to_identifier(database, quoted=True)
-        return sge.Create(this=name, kind="SCHEMA", replace=force)
+        name = sg.table(name, catalog=database, quoted=self.compiler.quoted)
+        with self._safe_raw_sql(sge.Create(this=name, kind="SCHEMA", replace=force)):
+            pass
 
     def drop_schema(
         self, name: str, database: str | None = None, force: bool = False
@@ -502,8 +503,9 @@ class Backend(SQLGlotBackend, CanCreateSchema):
                 "DuckDB cannot drop a schema in another database."
             )
 
-        name = sg.to_identifier(database, quoted=True)
-        return sge.Drop(this=name, kind="SCHEMA", replace=force)
+        name = sg.table(name, catalog=database, quoted=self.compiler.quoted)
+        with self._safe_raw_sql(sge.Drop(this=name, kind="SCHEMA", replace=force)):
+            pass
 
     def register(
         self,

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1471,13 +1471,17 @@ def test_overwrite(ddl_con, monkeypatch):
 def test_create_database(con_create_database):
     database = gen_name("test_create_database")
     con_create_database.create_database(database)
+    assert database in con_create_database.list_databases()
     con_create_database.drop_database(database)
+    assert database not in con_create_database.list_databases()
 
 
 def test_create_schema(con_create_schema):
     schema = gen_name("test_create_schema")
     con_create_schema.create_schema(schema)
+    assert schema in con_create_schema.list_schemas()
     con_create_schema.drop_schema(schema)
+    assert schema not in con_create_schema.list_schemas()
 
 
 def test_list_schemas(con_create_schema):


### PR DESCRIPTION
Ensure that create_schema and create_database tests actually assert something meaningful. Before this PR there was no validation in the test suite that calling create_schema/create_database had any stateful effect.