### PR TITLE
refactor(polars): update the polars backend to use the new relational abstractions

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -88,11 +88,11 @@ jobs:
             title: Datafusion
             extras:
               - datafusion
-          # - name: polars
-          #   title: Polars
-          #   extras:
-          #     - polars
-          #     - deltalake
+          - name: polars
+            title: Polars
+            extras:
+              - polars
+              - deltalake
           # - name: mysql
           #   title: MySQL
           #   services:

--- a/ibis/backends/pandas/rewrites.py
+++ b/ibis/backends/pandas/rewrites.py
@@ -224,6 +224,7 @@ def split_join_predicates(left, right, predicates, only_equality=True):
 
 @replace(ops.JoinChain)
 def rewrite_join(_, **kwargs):
+    # TODO(kszucs): JoinTable.index can be used as a prefix
     prefixes = {}
     prefixes[_.first] = prefix = str(len(prefixes))
     left = PandasRename.from_prefix(_.first, prefix)

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -12,9 +12,13 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis.backends.base import BaseBackend, Database
+from ibis.backends.pandas.rewrites import (
+    bind_unbound_table,
+    replace_parameter,
+    rewrite_join,
+)
 from ibis.backends.polars.compiler import translate
 from ibis.backends.polars.datatypes import dtype_to_polars, schema_from_polars
-from ibis.common.patterns import Replace
 from ibis.util import gen_name, normalize_filename
 
 if TYPE_CHECKING:
@@ -379,20 +383,18 @@ class Backend(BaseBackend):
     def compile(
         self, expr: ir.Expr, params: Mapping[ir.Expr, object] | None = None, **_: Any
     ):
-        node = expr.op()
-        ctx = self._context
-
-        if params:
+        if params is None:
+            params = dict()
+        else:
             params = {param.op(): value for param, value in params.items()}
-            rule = Replace(
-                ops.ScalarParameter,
-                lambda _: ops.Literal(value=params[_], dtype=_.dtype),
-            )
-            node = node.replace(rule)
-            expr = node.to_expr()
 
         node = expr.as_table().op()
-        return translate(node, ctx=ctx)
+        node = node.replace(
+            rewrite_join | replace_parameter | bind_unbound_table,
+            context={"params": params, "backend": self},
+        )
+
+        return translate(node, ctx=self._context)
 
     def _get_schema_using_query(self, query: str) -> sch.Schema:
         return schema_from_polars(

--- a/ibis/backends/polars/tests/test_join.py
+++ b/ibis/backends/polars/tests/test_join.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pandas as pd
+import pandas.testing as tm
+
+import ibis
+
+
+def test_memtable_join(con):
+    t1 = ibis.memtable({"x": [1, 2, 3], "y": [4, 5, 6], "z": ["a", "b", "c"]})
+    t2 = ibis.memtable({"x": [3, 2, 1], "y": [7, 8, 9], "z": ["d", "e", "f"]})
+    expr = t1.join(t2, "x")
+
+    result = con.execute(expr)
+    expected = pd.DataFrame(
+        {
+            "x": [1, 2, 3],
+            "y": [4, 5, 6],
+            "z": ["a", "b", "c"],
+            "x_right": [1, 2, 3],
+            "y_right": [9, 8, 7],
+            "z_right": ["f", "e", "d"],
+        }
+    )
+
+    left = result.sort_values("x").reset_index(drop=True)
+    right = expected.sort_values("x").reset_index(drop=True)
+    tm.assert_frame_equal(left, right)

--- a/ibis/backends/tests/test_interactive.py
+++ b/ibis/backends/tests/test_interactive.py
@@ -33,7 +33,7 @@ def table(backend):
     return backend.functional_alltypes
 
 
-@pytest.mark.notimpl(["pandas"])
+@pytest.mark.notimpl(["pandas", "polars"])
 def test_interactive_execute_on_repr(table, queries, snapshot):
     repr(table.bigint_col.sum())
     snapshot.assert_match(queries[0], "out.sql")
@@ -53,21 +53,21 @@ def test_repr_png_is_not_none_in_not_interactive(table):
         assert table._repr_png_() is not None
 
 
-@pytest.mark.notimpl(["pandas"])
+@pytest.mark.notimpl(["pandas", "polars"])
 def test_default_limit(table, snapshot, queries):
     repr(table.select("id", "bool_col"))
 
     snapshot.assert_match(queries[0], "out.sql")
 
 
-@pytest.mark.notimpl(["pandas"])
+@pytest.mark.notimpl(["pandas", "polars"])
 def test_respect_set_limit(table, snapshot, queries):
     repr(table.select("id", "bool_col").limit(10))
 
     snapshot.assert_match(queries[0], "out.sql")
 
 
-@pytest.mark.notimpl(["pandas"])
+@pytest.mark.notimpl(["pandas", "polars"])
 def test_disable_query_limit(table, snapshot, queries):
     assert ibis.options.sql.default_limit is None
 

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -54,9 +54,6 @@ def check_eq(left, right, how, **kwargs):
                     + ["sqlite"] * (vparse(sqlite3.sqlite_version) < vparse("3.39"))
                 ),
                 pytest.mark.xfail_version(datafusion=["datafusion<31"]),
-                pytest.mark.broken(
-                    ["polars"], reason="upstream outer joins are broken"
-                ),
             ],
         ),
     ],
@@ -141,11 +138,6 @@ def test_filtering_join(backend, batting, awards_players, how):
     backend.assert_frame_equal(result, expected, check_like=True)
 
 
-@pytest.mark.broken(
-    ["polars"],
-    raises=ValueError,
-    reason="https://github.com/pola-rs/polars/issues/9335",
-)
 @pytest.mark.notimpl(["exasol"], raises=com.IbisTypeError)
 def test_join_then_filter_no_column_overlap(awards_players, batting):
     left = batting[batting.yearID == 2015]
@@ -159,11 +151,6 @@ def test_join_then_filter_no_column_overlap(awards_players, batting):
     assert not q.execute().empty
 
 
-@pytest.mark.broken(
-    ["polars"],
-    raises=ValueError,
-    reason="https://github.com/pola-rs/polars/issues/9335",
-)
 @pytest.mark.notimpl(["exasol"], raises=com.IbisTypeError)
 def test_mutate_then_join_no_column_overlap(batting, awards_players):
     left = batting.mutate(year=batting.yearID).filter(lambda t: t.year == 2015)
@@ -176,11 +163,6 @@ def test_mutate_then_join_no_column_overlap(batting, awards_players):
 @pytest.mark.notimpl(["druid"])
 @pytest.mark.notyet(["dask"], reason="dask doesn't support descending order by")
 @pytest.mark.notyet(["flink"], reason="Flink doesn't support semi joins")
-@pytest.mark.broken(
-    ["polars"],
-    raises=ValueError,
-    reason="https://github.com/pola-rs/polars/issues/9335",
-)
 @pytest.mark.parametrize(
     "func",
     [
@@ -284,11 +266,6 @@ def test_join_with_pandas_non_null_typed_columns(batting, awards_players):
     ],
 )
 @pytest.mark.notimpl(
-    ["polars"],
-    raises=com.TranslationError,
-    reason="polars doesn't support join predicates",
-)
-@pytest.mark.notimpl(
     ["dask"],
     raises=TypeError,
     reason="dask doesn't support join predicates",
@@ -340,7 +317,6 @@ outer_join_nullability_failures = [
             lambda left: left.filter(lambda t: t.x == 1).select(y=lambda t: t.x),
             [("x", "y")],
             id="left-xy",
-            marks=pytest.mark.notyet(["polars"], reason="renaming fails"),
         ),
         param(
             "left",
@@ -356,7 +332,6 @@ outer_join_nullability_failures = [
             lambda left: left.filter(lambda t: t.x == 1).select(y=lambda t: t.x),
             [("x", "y")],
             id="right-xy",
-            marks=pytest.mark.notyet(["polars"], reason="renaming fails"),
         ),
         param(
             "right",


### PR DESCRIPTION
Bare minimum changes required for the polars backend to work with the new relational operations. Since polars' join API follows the same semantics as pandas, I'm using the pandas specific rewrites here.

In the future we may want to rewrite the compiler similarly to the pandas one: using `node.map()` and `Dispatched`.