### PR TITLE
ci(trino): remove postgres extras

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -141,7 +141,6 @@ jobs:
             title: Trino
             extras:
               - trino
-              - postgres
             services:
               - trino
           - name: druid
@@ -250,7 +249,6 @@ jobs:
                 - trino
               extras:
                 - trino
-                - postgres
           - os: windows-latest
             backend:
               name: druid
@@ -681,7 +679,6 @@ jobs:
               - trino
             extras:
               - trino
-              - postgres
           - name: duckdb
             title: DuckDB
             extras:


### PR DESCRIPTION
Installation of postgres extras are no longer necessary for Trino, so no reason to waste time installing them.