### PR TITLE
fix(ir): `asof` join `tolerance` parameter handling generated incorrect expression

### DIFF
--- a/ibis/backends/base/sqlglot/compiler.py
+++ b/ibis/backends/base/sqlglot/compiler.py
@@ -868,14 +868,14 @@ class SQLGlotCompiler(abc.ABC):
             "anti": "left",
             "cross": None,
             "outer": "full",
-            "asof": "left",
+            "asof": "asof",
             "any_left": "left",
             "any_inner": None,
         }
         kinds = {
             "any_left": "any",
             "any_inner": "any",
-            "asof": "asof",
+            "asof": "left",
             "inner": "inner",
             "left": "outer",
             "right": "outer",

--- a/ibis/backends/tests/test_asof_join.py
+++ b/ibis/backends/tests/test_asof_join.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import operator
+
+import pandas as pd
+import pandas.testing as tm
+import pytest
+
+import ibis
+
+
+@pytest.fixture(scope="module")
+def time_df1():
+    return pd.DataFrame(
+        {
+            "time": pd.to_datetime([1, 2, 3, 4], unit="s"),
+            "value": [1.1, 2.2, 3.3, 4.4],
+            "group": ["a", "a", "a", "a"],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def time_df2():
+    return pd.DataFrame(
+        {
+            "time": pd.to_datetime([2, 4], unit="s"),
+            "other_value": [1.2, 2.0],
+            "group": ["a", "a"],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def time_keyed_df1():
+    return pd.DataFrame(
+        {
+            "time": pd.Series(
+                pd.date_range(start="2017-01-02 01:02:03.234", periods=6)
+            ),
+            "key": [1, 2, 3, 1, 2, 3],
+            "value": [1.2, 1.4, 2.0, 4.0, 8.0, 16.0],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def time_keyed_df2():
+    return pd.DataFrame(
+        {
+            "time": pd.Series(
+                pd.date_range(start="2017-01-02 01:02:03.234", freq="3D", periods=3)
+            ),
+            "key": [1, 2, 3],
+            "other_value": [1.1, 1.2, 2.2],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def time_left(time_df1):
+    return ibis.memtable(time_df1)
+
+
+@pytest.fixture(scope="module")
+def time_right(time_df2):
+    return ibis.memtable(time_df2)
+
+
+@pytest.fixture(scope="module")
+def time_keyed_left(time_keyed_df1):
+    return ibis.memtable(time_keyed_df1)
+
+
+@pytest.fixture(scope="module")
+def time_keyed_right(time_keyed_df2):
+    return ibis.memtable(time_keyed_df2)
+
+
+@pytest.mark.parametrize(
+    ("direction", "op"),
+    [
+        ("backward", operator.ge),
+        ("forward", operator.le),
+    ],
+)
+@pytest.mark.notimpl(["datafusion", "snowflake"])
+def test_asof_join(con, time_left, time_right, time_df1, time_df2, direction, op):
+    on = op(time_left["time"], time_right["time"])
+    expr = time_left.asof_join(time_right, on=on, predicates="group")
+
+    result = con.execute(expr)
+    expected = pd.merge_asof(
+        time_df1, time_df2, on="time", by="group", direction=direction
+    )
+
+    result = result.sort_values(["group", "time"]).reset_index(drop=True)
+    expected = expected.sort_values(["group", "time"]).reset_index(drop=True)
+
+    tm.assert_frame_equal(result[expected.columns], expected)
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(result["time"], result["time_right"])
+
+
+@pytest.mark.parametrize(
+    ("direction", "op"),
+    [
+        ("backward", operator.ge),
+        ("forward", operator.le),
+    ],
+)
+@pytest.mark.broken(
+    ["clickhouse"], raises=AssertionError, reason="`time` is truncated to seconds"
+)
+@pytest.mark.notimpl(["datafusion", "snowflake"])
+def test_keyed_asof_join_with_tolerance(
+    con,
+    time_keyed_left,
+    time_keyed_right,
+    time_keyed_df1,
+    time_keyed_df2,
+    direction,
+    op,
+):
+    on = op(time_keyed_left["time"], time_keyed_right["time"])
+    expr = time_keyed_left.asof_join(
+        time_keyed_right, on=on, by="key", tolerance=ibis.interval(days=2)
+    )
+
+    result = con.execute(expr)
+    expected = pd.merge_asof(
+        time_keyed_df1,
+        time_keyed_df2,
+        on="time",
+        by="key",
+        tolerance=pd.Timedelta("2D"),
+        direction=direction,
+    )
+
+    result = result.sort_values(["key", "time"]).reset_index(drop=True)
+    expected = expected.sort_values(["key", "time"]).reset_index(drop=True)
+
+    tm.assert_frame_equal(result[expected.columns], expected)
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(result["time"], result["time_right"])
+    with pytest.raises(AssertionError):
+        tm.assert_series_equal(result["key"], result["key_right"])

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -299,9 +299,9 @@ def test_join_with_pandas_non_null_typed_columns(batting, awards_players):
     reason="polars doesn't support join predicates",
 )
 @pytest.mark.notimpl(
-    ["dask", "pandas"],
+    ["dask"],
     raises=TypeError,
-    reason="dask and pandas don't support join predicates",
+    reason="dask doesn't support join predicates",
 )
 @pytest.mark.notimpl(
     ["exasol"],

--- a/ibis/expr/tests/snapshots/test_format/test_asof_join/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_asof_join/repr.txt
@@ -8,7 +8,7 @@ r1 := UnboundTable: right
 
 JoinChain[r0]
   JoinLink[asof, r1]
-    r0.time1 <= r1.time2
+    r0.time1 >= r1.time2
   JoinLink[inner, r1]
     r0.value == r1.value2
   values:

--- a/ibis/expr/tests/test_dereference.py
+++ b/ibis/expr/tests/test_dereference.py
@@ -17,9 +17,30 @@ def dereference_expect(expected):
     return {k.op(): v.op() for k, v in expected.items()}
 
 
+def test_dereference_project():
+    p = t.projection([t.int_col, t.double_col])
+
+    mapping = dereference_mapping([p.op()])
+    expected = dereference_expect(
+        {
+            p.int_col: p.int_col,
+            p.double_col: p.double_col,
+            t.int_col: p.int_col,
+            t.double_col: p.double_col,
+        }
+    )
+    assert mapping == expected
+
+
 def test_dereference_mapping_self_reference():
     v = t.view()
 
     mapping = dereference_mapping([v.op()])
-    expected = dereference_expect({})
+    expected = dereference_expect(
+        {
+            v.int_col: v.int_col,
+            v.double_col: v.double_col,
+            v.string_col: v.string_col,
+        }
+    )
     assert mapping == expected

--- a/ibis/expr/tests/test_dereference.py
+++ b/ibis/expr/tests/test_dereference.py
@@ -18,7 +18,7 @@ def dereference_expect(expected):
 
 
 def test_dereference_project():
-    p = t.projection([t.int_col, t.double_col])
+    p = t.select([t.int_col, t.double_col])
 
     mapping = dereference_mapping([p.op()])
     expected = dereference_expect(

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -155,8 +155,14 @@ def unwrap_aliases(values: Iterator[ir.Value]) -> Mapping[str, ir.Value]:
 
 
 def dereference_mapping(parents):
-    mapping = {}
     parents = util.promote_list(parents)
+    mapping = {}
+
+    for parent in parents:
+        # do not defereference fields referencing the requested parents
+        for k, v in parent.fields.items():
+            mapping[v] = v
+
     for parent in parents:
         for k, v in parent.values.items():
             if isinstance(v, ops.Field):
@@ -171,6 +177,7 @@ def dereference_mapping(parents):
             elif v.relations and v not in mapping:
                 # do not dereference literal expressions
                 mapping[v] = ops.Field(parent, k)
+
     return mapping
 
 


### PR DESCRIPTION
To correctly mimic pandas' tolerance argument we need to do the following steps:
1. Do the ASOF join with `on` and `by` parameters
2. Filter the joined result using the predicate creates be the tolerance: `left[on] <= right[on] + tolerance AND left[on] >= right[on] - toletance`
3. Join the filtered table to the `left` table again using a LEFT JOIN

This PR also adds support for ASOF joins in duckdb: fixes https://github.com/ibis-project/ibis/issues/6487