### PR TITLE
ci: install decompiler as extra not as its own dependency

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -62,9 +62,9 @@ jobs:
               - deltalake
               - geospatial
               - examples
+              - decompiler
             additional_deps:
               - torch
-              - decompiler
           - name: clickhouse
             title: ClickHouse
             services:


### PR DESCRIPTION
Fixes installation of the `decompiler` extra.