### PR TITLE
fix(conversion): convert decimals to the exact precision and scale requested by the input type

### DIFF
--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -244,7 +244,7 @@ def test_numeric_literal(con, backend, expr, expected_types):
             # TODO(krzysztof-kwitt): Should we unify it?
             {
                 "bigquery": decimal.Decimal("1.1"),
-                "snowflake": 1.1,
+                "snowflake": decimal.Decimal("1.1"),
                 "sqlite": 1.1,
                 "trino": 1.1,
                 "dask": decimal.Decimal("1.1"),
@@ -296,7 +296,7 @@ def test_numeric_literal(con, backend, expr, expected_types):
             # TODO(krzysztof-kwitt): Should we unify it?
             {
                 "bigquery": decimal.Decimal("1.1"),
-                "snowflake": 1.1,
+                "snowflake": decimal.Decimal("1.1"),
                 "sqlite": 1.1,
                 "trino": 1.1,
                 "duckdb": decimal.Decimal("1.100000000"),

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -653,7 +653,7 @@ def test_decimal_literal(con, backend, expr, expected_types, expected_result):
     if type(current_expected_result) in (float, decimal.Decimal) and math.isnan(
         current_expected_result
     ):
-        assert math.isnan(result) and type(result) == type(current_expected_result)
+        assert math.isnan(result)
     else:
         assert result == current_expected_result
 

--- a/ibis/common/numeric.py
+++ b/ibis/common/numeric.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from decimal import Context, Decimal, InvalidOperation
 
 
-def normalize_decimal(value, precision: int | None = None, scale: int | None = None):
+def normalize_decimal(
+    value,
+    precision: int | None = None,
+    scale: int | None = None,
+    strict: bool = True,
+):
     context = Context(prec=38 if precision is None else precision)
 
     try:
@@ -25,7 +30,7 @@ def normalize_decimal(value, precision: int | None = None, scale: int | None = N
         )
 
     if scale is not None:
-        if exponent < -scale:
+        if strict and exponent < -scale:
             raise TypeError(
                 f"Normalizing {value} with scale {exponent} to scale -{scale} "
                 "would loose precision"

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import datetime
-import decimal
 import warnings
+from functools import partial
 from importlib.util import find_spec as _find_spec
 
 import numpy as np
@@ -13,6 +13,7 @@ import pyarrow as pa
 
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
+from ibis.common.numeric import normalize_decimal
 from ibis.common.temporal import normalize_timezone
 from ibis.formats import DataMapper, SchemaMapper, TableProxy
 from ibis.formats.numpy import NumpyType
@@ -253,20 +254,13 @@ class PandasData(DataMapper):
 
     @classmethod
     def convert_Decimal(cls, s, dtype, pandas_type):
-        context = decimal.Context(prec=dtype.precision)
-
-        if dtype.scale is None:
-            normalize = context.create_decimal
-        else:
-            exponent = decimal.Decimal(10) ** -dtype.scale
-
-            def normalize(x, exponent=exponent):
-                try:
-                    return context.create_decimal(x).quantize(exponent)
-                except decimal.InvalidOperation:
-                    return x
-
-        return s.map(normalize, na_action="ignore").astype(pandas_type)
+        func = partial(
+            normalize_decimal,
+            precision=dtype.precision,
+            scale=dtype.scale,
+            strict=False,
+        )
+        return s.map(func, na_action="ignore")
 
     @classmethod
     def convert_UUID(cls, s, dtype, pandas_type):


### PR DESCRIPTION
Use `normalize_decimal` for output conversion from backend decimal values into pandas objects.