### PR TITLE
test(duckdb): ensure that no test causes the default backend to be set

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -929,10 +929,14 @@ def test_create_from_in_memory_table(con, temp_table, arg, func, monkeypatch):
 
 
 @pytest.mark.usefixtures("backend")
-def test_default_backend_option(monkeypatch):
-    monkeypatch.setattr(ibis.options, "default_backend", ibis.pandas)
+def test_default_backend_option(con, monkeypatch):
+    # verify that there's nothing already set
+    assert ibis.options.default_backend is None
+
+    monkeypatch.setattr(ibis.options, "default_backend", con)
+
     backend = ibis.config._default_backend()
-    assert backend.name == "pandas"
+    assert backend.name == con.name
 
 
 # backend is used to ensure that this test runs in CI in the setting


### PR DESCRIPTION
Fixes a rare test case failure observed when tests execute in a particular order that implicitly sets the default backend (ex: https://github.com/ibis-project/ibis/actions/runs/7412054856/job/20167990310?pr=7877).