### PR TITLE
fix(datatypes): fix bad references in `to_numpy()`

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -243,9 +243,9 @@ class DataType(Concrete, Coercible):
 
     def to_numpy(self):
         """Return the equivalent numpy datatype."""
-        from ibis.formats.numpy import NumpyFormat
+        from ibis.formats.numpy import NumpyType
 
-        return NumpyFormat.from_dtype(self)
+        return NumpyType.from_ibis(self)
 
     def to_pandas(self):
         """Return the equivalent pandas datatype."""

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Annotated, NamedTuple
 
 import pytest
+from pytest import param
 
 import ibis.expr.datatypes as dt
 from ibis.common.annotations import ValidationError
@@ -672,3 +673,23 @@ def test_type_coercion():
     p = Pattern.from_typehint(Annotated[dt.Interval, Attrs(unit=As(TimeUnit))])
     assert p.match(dt.Interval("s"), {}) == dt.Interval("s")
     assert p.match(dt.Interval("ns"), {}) == dt.Interval("ns")
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        param(dt.int16, id="int16"),
+        param(dt.int32, id="int32"),
+        param(dt.int64, id="int64"),
+        param(dt.uint8, id="uint8"),
+        param(dt.uint16, id="uint16"),
+        param(dt.uint32, id="uint32"),
+        param(dt.uint64, id="uint64"),
+        param(dt.float32, id="float32"),
+        param(dt.float64, id="float64"),
+        param(dt.boolean, id="boolean"),
+    ],
+)
+@pytest.mark.parametrize("fmt", ["numpy", "pandas", "pyarrow"])
+def test_type_roundtrip(dtype, fmt):
+    assert getattr(dt.DataType, f"from_{fmt}")(getattr(dtype, f"to_{fmt}")()) == dtype


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->
Fix bad reference to `NumpyFormat`; use `NumpyType` as in the other `to_*` methods.

## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
Calling `.to_numpy()` on a `DataType` object resulted in:

```python
*** ImportError: cannot import name 'NumpyFormat' from 'ibis.formats.numpy' (/opt/miniconda3/envs/pandera-dev/lib/python3.11/site-packages/ibis/formats/numpy.py)
```
