### PR TITLE
docs: fix formatting for note on `_name`, `_dtype`

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2597,8 +2597,8 @@ multiple hash functions working.
     methods have been removed, `DataType.scalar` and `DataType.column` class
     fields can be used to directly construct a corresponding expression instance
     (though prefer to use `operation.to_expr()`)
-  - `ibis.expr.types.ValueExpr._name` and `ValueExpr._dtype`` fields are not
-    accassible anymore. While these were not supposed to used directly now
+  - `ibis.expr.types.ValueExpr._name` and `ValueExpr._dtype` fields are not
+    accessible anymore. While these were not supposed to used directly, now
     `ValueExpr.has_name()`, `ValueExpr.get_name()` and `ValueExpr.type()` methods
     are the only way to retrieve the expression's name and datatype.
   - `ibis.expr.operations.Node.output_type` is a property now not a method,


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

I was looking for information about the `get_name()` method, and I ran across a badly-formatted line:
<img width="1229" alt="image" src="https://github.com/ibis-project/ibis/assets/14007150/96c999d3-2293-438a-ab0d-30db125ba12e">
