### PR TITLE
feat: remove .case(), move to .cases()

### DIFF
--- a/docs/posts/ci-analysis/index.qmd
+++ b/docs/posts/ci-analysis/index.qmd
@@ -203,13 +203,11 @@ Let's also give them some names that'll look nice on our plots.
 stats = stats.mutate(
     raw_improvements=_.has_poetry.cast("int") + _.has_team.cast("int")
 ).mutate(
-    improvements=(
-        _.raw_improvements.case()
-        .when(0, "None")
-        .when(1, "Poetry")
-        .when(2, "Poetry + Team Plan")
-        .else_("NA")
-        .end()
+    improvements=_.raw_improvements.cases(
+        (0, "None"),
+        (1, "Poetry"),
+        (2, "Poetry + Team Plan"),
+        else_="NA",
     ),
     team_plan=ibis.where(_.raw_improvements > 1, "Poetry + Team Plan", "None"),
 )

--- a/docs/tutorials/ibis-for-sql-users.qmd
+++ b/docs/tutorials/ibis-for-sql-users.qmd
@@ -473,11 +473,11 @@ semantics:
 case = (
     t.one.cast("timestamp")
     .year()
-    .case()
-    .when(2015, "This year")
-    .when(2014, "Last year")
-    .else_("Earlier")
-    .end()
+    .cases(
+        (2015, "This year"),
+        (2014, "Last year"),
+        else_="Earlier",
+    )
 )
 
 expr = t.mutate(year_group=case)
@@ -496,15 +496,13 @@ CASE
 END
 ```
 
-To do this, use `ibis.case`:
+To do this, use `ibis.cases`:
 
 ```{python}
-case = (
-    ibis.case()
-    .when(t.two < 0, t.three * 2)
-    .when(t.two > 1, t.three)
-    .else_(t.two)
-    .end()
+case = ibis.cases(
+    (t.two < 0, t.three * 2),
+    (t.two > 1, t.three),
+    else_=t.two,
 )
 
 expr = t.mutate(cond_value=case)

--- a/ibis/backends/base/sql/alchemy/registry.py
+++ b/ibis/backends/base/sql/alchemy/registry.py
@@ -273,18 +273,10 @@ def _floor_divide(t, op):
     return sa.func.floor(left / right)
 
 
-def _simple_case(t, op):
-    return _translate_case(t, op, value=t.translate(op.base))
-
-
-def _searched_case(t, op):
-    return _translate_case(t, op, value=None)
-
-
-def _translate_case(t, op, *, value):
+def _translate_case(t, op):
     return sa.case(
         *zip(map(t.translate, op.cases), map(t.translate, op.results)),
-        value=value,
+        value=None,
         else_=t.translate(op.default),
     )
 
@@ -558,8 +550,7 @@ sqlalchemy_operation_registry: dict[Any, Any] = {
     ops.Negate: _negate,
     ops.Round: _round,
     ops.Literal: _literal,
-    ops.SimpleCase: _simple_case,
-    ops.SearchedCase: _searched_case,
+    ops.SearchedCase: _translate_case,
     ops.TableColumn: _table_column,
     ops.TableArrayView: _table_array_view,
     ops.ExistsSubquery: _exists_subquery,

--- a/ibis/backends/base/sql/registry/main.py
+++ b/ibis/backends/base/sql/registry/main.py
@@ -338,7 +338,6 @@ operation_registry = {
     ops.Between: between,
     ops.InValues: binary_infix.in_values,
     ops.InColumn: binary_infix.in_column,
-    ops.SimpleCase: case.simple_case,
     ops.SearchedCase: case.searched_case,
     ops.TableColumn: table_column,
     ops.TableArrayView: table_array_view,

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -411,7 +411,6 @@ def _literal(op, *, value, dtype, **kw):
         raise NotImplementedError(f"Unsupported type: {dtype!r}")
 
 
-@translate_val.register(ops.SimpleCase)
 @translate_val.register(ops.SearchedCase)
 def _case(op, *, base=None, cases, results, default, **_):
     return sg.exp.Case(this=base, ifs=list(map(if_, cases, results)), default=default)

--- a/ibis/backends/clickhouse/tests/test_operators.py
+++ b/ibis/backends/clickhouse/tests/test_operators.py
@@ -201,9 +201,7 @@ def test_ifelse(alltypes, df, op, pandas_op):
 
 def test_simple_case(con, alltypes, snapshot):
     t = alltypes
-    expr = (
-        t.string_col.case().when("foo", "bar").when("baz", "qux").else_("default").end()
-    )
+    expr = t.string_col.cases(("foo", "bar"), ("baz", "qux"), else_="default")
 
     snapshot.assert_match(expr.compile(), "out.sql")
     assert len(con.execute(expr))
@@ -211,12 +209,10 @@ def test_simple_case(con, alltypes, snapshot):
 
 def test_search_case(con, alltypes, snapshot):
     t = alltypes
-    expr = (
-        ibis.case()
-        .when(t.float_col > 0, t.int_col * 2)
-        .when(t.float_col < 0, t.int_col)
-        .else_(0)
-        .end()
+    expr = ibis.cases(
+        (t.float_col > 0, t.int_col * 2),
+        (t.float_col < 0, t.int_col),
+        else_=0,
     )
 
     snapshot.assert_match(expr.compile(), "out.sql")

--- a/ibis/backends/dask/execution/generic.py
+++ b/ibis/backends/dask/execution/generic.py
@@ -509,16 +509,6 @@ def execute_searched_case_dask(op, when_nodes, then_nodes, otherwise, **kwargs):
     return out
 
 
-@execute_node.register(ops.SimpleCase, dd.Series, tuple, tuple, object)
-def execute_simple_case_series(op, value, whens, thens, otherwise, **kwargs):
-    whens = [execute(arg, **kwargs) for arg in whens]
-    thens = [execute(arg, **kwargs) for arg in thens]
-    if otherwise is None:
-        otherwise = np.nan
-    raw = np.select([value == when for when in whens], thens, otherwise)
-    return wrap_case_result(raw, op.to_expr())
-
-
 @execute_node.register(ops.Greatest, tuple)
 def execute_node_greatest_list(op, values, **kwargs):
     values = [execute(arg, **kwargs) for arg in values]

--- a/ibis/backends/dask/tests/execution/test_operations.py
+++ b/ibis/backends/dask/tests/execution/test_operations.py
@@ -845,7 +845,7 @@ def test_quantile_group_by(batting, batting_df):
 
 
 def test_searched_case_scalar(client):
-    expr = ibis.case().when(True, 1).when(False, 2).end()
+    expr = ibis.cases((True, 1), (False, 2))
     result = client.execute(expr)
     expected = np.int8(1)
     assert result == expected
@@ -854,12 +854,10 @@ def test_searched_case_scalar(client):
 def test_searched_case_column(batting, batting_df):
     t = batting
     df = batting_df
-    expr = (
-        ibis.case()
-        .when(t.RBI < 5, "really bad team")
-        .when(t.teamID == "PH1", "ph1 team")
-        .else_(t.teamID)
-        .end()
+    expr = ibis.cases(
+        (t.RBI < 5, "really bad team"),
+        (t.teamID == "PH1", "ph1 team"),
+        else_=t.teamID,
     )
     result = expr.compile()
     expected = dd.from_array(
@@ -874,7 +872,7 @@ def test_searched_case_column(batting, batting_df):
 
 def test_simple_case_scalar(client):
     x = ibis.literal(2)
-    expr = x.case().when(2, x - 1).when(3, x + 1).when(4, x + 2).end()
+    expr = x.cases((2, x - 1), (3, x + 1), (4, x + 2))
     result = client.execute(expr)
     expected = np.int8(1)
     assert result == expected
@@ -883,13 +881,11 @@ def test_simple_case_scalar(client):
 def test_simple_case_column(batting, batting_df):
     t = batting
     df = batting_df
-    expr = (
-        t.RBI.case()
-        .when(5, "five")
-        .when(4, "four")
-        .when(3, "three")
-        .else_("could be good?")
-        .end()
+    expr = t.RBI.cases(
+        (5, "five"),
+        (4, "four"),
+        (3, "three"),
+        else_=("could be good?"),
     )
     result = expr.compile()
     expected = dd.from_array(

--- a/ibis/backends/impala/tests/test_case_exprs.py
+++ b/ibis/backends/impala/tests/test_case_exprs.py
@@ -15,13 +15,21 @@ def table(mockcon):
 
 @pytest.fixture
 def simple_case(table):
-    return table.g.case().when("foo", "bar").when("baz", "qux").else_("default").end()
+    return table.g.cases(
+        ("foo", "bar"),
+        ("baz", "qux"),
+        else_="default",
+    )
 
 
 @pytest.fixture
 def search_case(table):
     t = table
-    return ibis.case().when(t.f > 0, t.d * 2).when(t.c < 0, t.a * 2).end()
+    return ibis.cases(
+        (t.f > 0, t.d * 2),
+        (t.c < 0, t.a * 2),
+    )
+    return ibis.cases((t.f > 0, t.d * 2), (t.c < 0, t.a * 2))
 
 
 @pytest.fixture

--- a/ibis/backends/pandas/execution/generic.py
+++ b/ibis/backends/pandas/execution/generic.py
@@ -1443,32 +1443,6 @@ def execute_searched_case(op, whens, thens, otherwise, **kwargs):
     return _build_select(op, whens, thens, otherwise, **kwargs)
 
 
-@execute_node.register(ops.SimpleCase, object, tuple, tuple, object)
-def execute_simple_case_scalar(op, value, whens, thens, otherwise, **kwargs):
-    value = getattr(value, "obj", value)
-    return _build_select(
-        op,
-        whens,
-        thens,
-        otherwise,
-        func=lambda whens: np.asarray(whens) == value,
-        **kwargs,
-    )
-
-
-@execute_node.register(ops.SimpleCase, (pd.Series, SeriesGroupBy), tuple, tuple, object)
-def execute_simple_case_series(op, value, whens, thens, otherwise, **kwargs):
-    value = getattr(value, "obj", value)
-    return _build_select(
-        op,
-        whens,
-        thens,
-        otherwise,
-        func=lambda whens: [value == when for when in whens],
-        **kwargs,
-    )
-
-
 @execute_node.register(ops.Distinct, pd.DataFrame)
 def execute_distinct_dataframe(op, df, **kwargs):
     return df.drop_duplicates()

--- a/ibis/backends/pandas/tests/execution/test_operations.py
+++ b/ibis/backends/pandas/tests/execution/test_operations.py
@@ -687,7 +687,7 @@ def test_summary_non_numeric(batting, batting_df):
 
 
 def test_searched_case_scalar(client):
-    expr = ibis.case().when(True, 1).when(False, 2).end()
+    expr = ibis.cases((True, 1), (False, 2))
     result = client.execute(expr)
     expected = np.int8(1)
     assert result == expected
@@ -696,12 +696,10 @@ def test_searched_case_scalar(client):
 def test_searched_case_column(batting, batting_df):
     t = batting
     df = batting_df
-    expr = (
-        ibis.case()
-        .when(t.RBI < 5, "really bad team")
-        .when(t.teamID == "PH1", "ph1 team")
-        .else_(t.teamID)
-        .end()
+    expr = ibis.cases(
+        (t.RBI < 5, "really bad team"),
+        (t.teamID == "PH1", "ph1 team"),
+        else_=t.teamID,
     )
     result = expr.execute()
     expected = pd.Series(
@@ -716,7 +714,7 @@ def test_searched_case_column(batting, batting_df):
 
 def test_simple_case_scalar(client):
     x = ibis.literal(2)
-    expr = x.case().when(2, x - 1).when(3, x + 1).when(4, x + 2).end()
+    expr = x.cases((2, x - 1), (3, x + 1), (4, x + 2))
     result = client.execute(expr)
     expected = np.int8(1)
     assert result == expected
@@ -725,14 +723,7 @@ def test_simple_case_scalar(client):
 def test_simple_case_column(batting, batting_df):
     t = batting
     df = batting_df
-    expr = (
-        t.RBI.case()
-        .when(5, "five")
-        .when(4, "four")
-        .when(3, "three")
-        .else_("could be good?")
-        .end()
-    )
+    expr = t.RBI.cases((5, "five"), (4, "four"), (3, "three"), else_="could be good?")
     result = expr.execute()
     expected = pd.Series(
         np.select(

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -374,17 +374,6 @@ def ifelse(op, **kw):
     return pl.when(bool_expr).then(true_expr).otherwise(false_null_expr)
 
 
-@translate.register(ops.SimpleCase)
-def simple_case(op, **kw):
-    base = translate(op.base, **kw)
-    default = translate(op.default, **kw)
-    for case, result in reversed(list(zip(op.cases, op.results))):
-        case = base == translate(case, **kw)
-        result = translate(result, **kw)
-        default = pl.when(case).then(result).otherwise(default)
-    return default
-
-
 @translate.register(ops.SearchedCase)
 def searched_case(op, **kw):
     default = translate(op.default, **kw)

--- a/ibis/backends/sqlite/registry.py
+++ b/ibis/backends/sqlite/registry.py
@@ -80,13 +80,11 @@ def _strftime_int(fmt):
 
 def _extract_quarter(t, op):
     expr_new = ops.ExtractMonth(op.arg).to_expr()
-    expr_new = (
-        ibis.case()
-        .when(expr_new.isin([1, 2, 3]), 1)
-        .when(expr_new.isin([4, 5, 6]), 2)
-        .when(expr_new.isin([7, 8, 9]), 3)
-        .else_(4)
-        .end()
+    expr_new = ibis.cases(
+        (expr_new.isin([1, 2, 3]), 1),
+        (expr_new.isin([4, 5, 6]), 2),
+        (expr_new.isin([7, 8, 9]), 3),
+        else_=4,
     )
     return sa.cast(t.translate(expr_new.op()), sa.Integer)
 

--- a/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/duckdb/out.sql
@@ -1,18 +1,32 @@
 SELECT
-  CASE t0.continent
-    WHEN 'NA'
+  CASE
+    WHEN (
+      t0.continent = 'NA'
+    )
     THEN 'North America'
-    WHEN 'SA'
+    WHEN (
+      t0.continent = 'SA'
+    )
     THEN 'South America'
-    WHEN 'EU'
+    WHEN (
+      t0.continent = 'EU'
+    )
     THEN 'Europe'
-    WHEN 'AF'
+    WHEN (
+      t0.continent = 'AF'
+    )
     THEN 'Africa'
-    WHEN 'AS'
+    WHEN (
+      t0.continent = 'AS'
+    )
     THEN 'Asia'
-    WHEN 'OC'
+    WHEN (
+      t0.continent = 'OC'
+    )
     THEN 'Oceania'
-    WHEN 'AN'
+    WHEN (
+      t0.continent = 'AN'
+    )
     THEN 'Antarctica'
     ELSE 'Unknown continent'
   END AS cont,

--- a/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/sqlite/out.sql
@@ -1,18 +1,32 @@
 SELECT
-  CASE t0.continent
-    WHEN 'NA'
+  CASE
+    WHEN (
+      t0.continent = 'NA'
+    )
     THEN 'North America'
-    WHEN 'SA'
+    WHEN (
+      t0.continent = 'SA'
+    )
     THEN 'South America'
-    WHEN 'EU'
+    WHEN (
+      t0.continent = 'EU'
+    )
     THEN 'Europe'
-    WHEN 'AF'
+    WHEN (
+      t0.continent = 'AF'
+    )
     THEN 'Africa'
-    WHEN 'AS'
+    WHEN (
+      t0.continent = 'AS'
+    )
     THEN 'Asia'
-    WHEN 'OC'
+    WHEN (
+      t0.continent = 'OC'
+    )
     THEN 'Oceania'
-    WHEN 'AN'
+    WHEN (
+      t0.continent = 'AN'
+    )
     THEN 'Antarctica'
     ELSE 'Unknown continent'
   END AS cont,

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1378,9 +1378,7 @@ def test_aggregate_mixed_udf(backend, alltypes, df):
 @pytest.mark.notimpl(["datafusion", "pyspark"], raises=com.OperationNotDefinedError)
 def test_binds_are_cast(alltypes):
     expr = alltypes.aggregate(
-        high_line_count=(
-            alltypes.string_col.case().when("1-URGENT", 1).else_(0).end().sum()
-        )
+        high_line_count=alltypes.string_col.cases(("1-URGENT", 1), else_=0).sum()
     )
 
     expr.execute()
@@ -1427,7 +1425,7 @@ def test_agg_name_in_output_column(alltypes):
 def test_grouped_case(backend, con):
     table = ibis.memtable({"key": [1, 1, 2, 2], "value": [10, 30, 20, 40]})
 
-    case_expr = ibis.case().when(table.value < 25, table.value).else_(ibis.null()).end()
+    case_expr = ibis.cases((table.value < 25, table.value), else_=ibis.null())
 
     expr = table.group_by("key").aggregate(mx=case_expr.max()).order_by("key")
     result = con.execute(expr)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -338,14 +338,9 @@ def test_filter_with_window_op(backend, alltypes, sorted_df):
 def test_case_where(backend, alltypes, df):
     table = alltypes
     table = table.mutate(
-        new_col=(
-            ibis.case()
-            .when(table["int_col"] == 1, 20)
-            .when(table["int_col"] == 0, 10)
-            .else_(0)
-            .end()
-            .cast("int64")
-        )
+        new_col=ibis.cases(
+            (table["int_col"] == 1, 20), (table["int_col"] == 0, 10), else_=0
+        ).cast("int64")
     )
 
     result = table.execute()
@@ -374,9 +369,7 @@ def test_select_filter_mutate(backend, alltypes, df):
 
     # Prepare the float_col so that filter must execute
     # before the cast to get the correct result.
-    t = t.mutate(
-        float_col=ibis.case().when(t["bool_col"], t["float_col"]).else_(np.nan).end()
-    )
+    t = t.mutate(float_col=ibis.cases((t["bool_col"], t["float_col"]), else_=np.nan))
 
     # Actual test
     t = t[t.columns]

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -98,17 +98,15 @@ def test_group_by_has_index(backend, snapshot):
         dict(continent="string", population="int64"), name="countries"
     )
     expr = countries.group_by(
-        cont=(
-            _.continent.case()
-            .when("NA", "North America")
-            .when("SA", "South America")
-            .when("EU", "Europe")
-            .when("AF", "Africa")
-            .when("AS", "Asia")
-            .when("OC", "Oceania")
-            .when("AN", "Antarctica")
-            .else_("Unknown continent")
-            .end()
+        cont=_.continent.cases(
+            ("NA", "North America"),
+            ("SA", "South America"),
+            ("EU", "Europe"),
+            ("AF", "Africa"),
+            ("AS", "Asia"),
+            ("OC", "Oceania"),
+            ("AN", "Antarctica"),
+            else_="Unknown continent",
         )
     ).agg(total_pop=_.population.sum())
     sql = str(ibis.to_sql(expr, dialect=backend.name()))

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -524,9 +524,9 @@ def uses_java_re(t):
             id="length",
         ),
         param(
-            lambda t: t.int_col.cases([(1, "abcd"), (2, "ABCD")], "dabc").startswith(
-                "abc"
-            ),
+            lambda t: t.int_col.cases(
+                (1, "abcd"), (2, "ABCD"), else_="dabc"
+            ).startswith("abc"),
             lambda t: t.int_col == 1,
             id="startswith",
             # pyspark doesn't support `cases` yet
@@ -554,7 +554,7 @@ def uses_java_re(t):
             ],
         ),
         param(
-            lambda t: t.int_col.cases([(1, "abcd"), (2, "ABCD")], "dabc").endswith(
+            lambda t: t.int_col.cases((1, "abcd"), (2, "ABCD"), else_="dabc").endswith(
                 "bcd"
             ),
             lambda t: t.int_col == 1,
@@ -883,11 +883,10 @@ def test_re_replace_global(con):
 )
 def test_substr_with_null_values(backend, alltypes, df):
     table = alltypes.mutate(
-        substr_col_null=ibis.case()
-        .when(alltypes["bool_col"], alltypes["string_col"])
-        .else_(None)
-        .end()
-        .substr(0, 2)
+        substr_col_null=ibis.cases(
+            (alltypes["bool_col"], alltypes["string_col"]),
+            else_=None,
+        ).substr(0, 2)
     )
     result = table.execute()
 
@@ -1067,7 +1066,7 @@ def test_levenshtein(con, right):
 @pytest.mark.parametrize(
     "expr",
     [
-        param(ibis.case().when(True, "%").end(), id="case"),
+        param(ibis.cases((True, "%")), id="case"),
         param(ibis.ifelse(True, "%", ibis.NA), id="ifelse"),
     ],
 )

--- a/ibis/backends/tests/tpch/test_h08.py
+++ b/ibis/backends/tests/tpch/test_h08.py
@@ -54,9 +54,7 @@ def test_tpc_h08(part, supplier, region, lineitem, orders, customer, nation):
         ]
     )
 
-    q = q.mutate(
-        nation_volume=ibis.case().when(q.nation == NATION, q.volume).else_(0).end()
-    )
+    q = q.mutate(nation_volume=ibis.cases((q.nation == NATION, q.volume), else_=0))
     gq = q.group_by([q.o_year])
     q = gq.aggregate(mkt_share=q.nation_volume.sum() / q.volume.sum())
     q = q.order_by([q.o_year])

--- a/ibis/backends/tests/tpch/test_h12.py
+++ b/ibis/backends/tests/tpch/test_h12.py
@@ -31,19 +31,15 @@ def test_tpc_h12(orders, lineitem):
 
     gq = q.group_by([q.l_shipmode])
     q = gq.aggregate(
-        high_line_count=(
-            q.o_orderpriority.case()
-            .when("1-URGENT", 1)
-            .when("2-HIGH", 1)
-            .else_(0)
-            .end()
+        high_line_count=q.o_orderpriority.cases(
+            ("1-URGENT", 1),
+            ("2-HIGH", 1),
+            else_=0,
         ).sum(),
-        low_line_count=(
-            q.o_orderpriority.case()
-            .when("1-URGENT", 0)
-            .when("2-HIGH", 0)
-            .else_(1)
-            .end()
+        low_line_count=q.o_orderpriority.cases(
+            ("1-URGENT", 0),
+            ("2-HIGH", 0),
+            else_=1,
         ).sum(),
     )
     q = q.order_by(q.l_shipmode)

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -52,7 +52,7 @@ __all__ = (
     "and_",
     "array",
     "asc",
-    "case",
+    "cases",
     "coalesce",
     "connect",
     "cross_join",
@@ -960,55 +960,11 @@ def interval(
     return functools.reduce(operator.add, intervals)
 
 
-def case() -> bl.SearchedCaseBuilder:
-    """Begin constructing a case expression.
-
-    Use the `.when` method on the resulting object followed by `.end` to create a
-    complete case expression.
-
-    Returns
-    -------
-    SearchedCaseBuilder
-        A builder object to use for constructing a case expression.
-
-    See Also
-    --------
-    [`Value.case()`](./expression-generic.qmd#ibis.expr.types.generic.Value.case)
-
-    Examples
-    --------
-    >>> import ibis
-    >>> from ibis import _
-    >>> ibis.options.interactive = True
-    >>> t = ibis.memtable(
-    ...     {
-    ...         "left": [1, 2, 3, 4],
-    ...         "symbol": ["+", "-", "*", "/"],
-    ...         "right": [5, 6, 7, 8],
-    ...     }
-    ... )
-    >>> t.mutate(
-    ...     result=(
-    ...         ibis.case()
-    ...         .when(_.symbol == "+", _.left + _.right)
-    ...         .when(_.symbol == "-", _.left - _.right)
-    ...         .when(_.symbol == "*", _.left * _.right)
-    ...         .when(_.symbol == "/", _.left / _.right)
-    ...         .end()
-    ...     )
-    ... )
-    ┏━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━━━┓
-    ┃ left  ┃ symbol ┃ right ┃ result  ┃
-    ┡━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━━━┩
-    │ int64 │ string │ int64 │ float64 │
-    ├───────┼────────┼───────┼─────────┤
-    │     1 │ +      │     5 │     6.0 │
-    │     2 │ -      │     6 │    -4.0 │
-    │     3 │ *      │     7 │    21.0 │
-    │     4 │ /      │     8 │     0.5 │
-    └───────┴────────┴───────┴─────────┘
-    """
-    return bl.SearchedCaseBuilder()
+@deferrable(repr="<cases>")
+def cases(*branches: tuple[Any, Any], else_: Any | None = None) -> ir.Value:
+    """Create a multi-branch if-else case expression."""
+    cases, results = zip(*branches)
+    return ops.SearchedCase(cases=cases, results=results, default=else_).to_expr()
 
 
 def now() -> ir.TimestampScalar:

--- a/ibis/expr/decompile.py
+++ b/ibis/expr/decompile.py
@@ -243,18 +243,13 @@ def ifelse(op, bool_expr, true_expr, false_null_expr):
     return f"{bool_expr}.ifelse({true_expr}, {false_null_expr})"
 
 
-@translate.register(ops.SimpleCase)
 @translate.register(ops.SearchedCase)
 def switch_case(op, cases, results, default, base=None):
-    out = f"{base}.case()" if base else "ibis.case()"
-
-    for case, result in zip(cases, results):
-        out = f"{out}.when({case}, {result})"
-
-    if default is not None:
-        out = f"{out}.else_({default})"
-
-    return f"{out}.end()"
+    func_str = f"{base}.cases" if base else "ibis.cases"
+    branch_strings = [f"({case}, {result})" for case, result in zip(cases, results)]
+    branch_str = ", ".join(branch_strings)
+    default_str = f", else_={default}" if default is not None else ""
+    return f"{func_str}({branch_str}{default_str})"
 
 
 _infix_ops = {

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -270,28 +270,6 @@ class HashBytes(Value):
     shape = rlz.shape_like("arg")
 
 
-# TODO(kszucs): we should merge the case operations by making the
-# cases, results and default optional arguments like they are in
-# api.py
-@public
-class SimpleCase(Value):
-    base: Value
-    cases: VarTuple[Value]
-    results: VarTuple[Value]
-    default: Value
-
-    shape = rlz.shape_like("base")
-
-    def __init__(self, cases, results, **kwargs):
-        assert len(cases) == len(results)
-        super().__init__(cases=cases, results=results, **kwargs)
-
-    @attribute
-    def dtype(self):
-        values = [*self.results, self.default]
-        return rlz.highest_precedence_dtype(values)
-
-
 @public
 class SearchedCase(Value):
     cases: VarTuple[Value[dt.Boolean]]

--- a/ibis/expr/operations/logical.py
+++ b/ibis/expr/operations/logical.py
@@ -153,7 +153,7 @@ class InColumn(Value):
 class IfElse(Value):
     """Ternary case expression, equivalent to.
 
-    bool_expr.case().when(True, true_expr).else_(false_or_null_expr)
+    bool_expr.cases((True, true_expr), else_=false_or_null_expr)
 
     Many backends implement this as a built-in function.
     """

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -1174,13 +1174,7 @@ class IntegerValue(NumericValue):
         │     2 │ c       │
         └───────┴─────────┘
         """
-        return (
-            functools.reduce(
-                lambda stmt, inputs: stmt.when(*inputs), enumerate(labels), self.case()
-            )
-            .else_(nulls)
-            .end()
-        )
+        return self.cases(*enumerate(labels), else_=nulls)
 
 
 @public

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2607,9 +2607,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         for pos, colname in enumerate(self.columns):
             col = self[colname]
             typ = col.type()
-            agg = self.select(
-                isna=ibis.case().when(col.isnull(), 1).else_(0).end()
-            ).agg(
+            agg = self.select(isna=ibis.cases((col.isnull(), 1), else_=0)).agg(
                 name=lit(colname),
                 type=lit(str(typ)),
                 nullable=lit(int(typ.nullable)).cast("bool"),

--- a/ibis/tests/expr/test_case.py
+++ b/ibis/tests/expr/test_case.py
@@ -5,7 +5,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import _
-from ibis.tests.util import assert_equal, assert_pickle_roundtrip
+from ibis.tests.util import assert_pickle_roundtrip
 
 
 def test_ifelse_method(table):
@@ -45,74 +45,46 @@ def test_ifelse_function_deferred(table):
 
 
 def test_simple_case_expr(table):
-    case1, result1 = "foo", table.a
-    case2, result2 = "bar", table.c
-    default_result = table.b
-
-    expr1 = table.g.lower().cases(
-        [(case1, result1), (case2, result2)], default=default_result
-    )
-
-    expr2 = (
-        table.g.lower()
-        .case()
-        .when(case1, result1)
-        .when(case2, result2)
-        .else_(default_result)
-        .end()
-    )
-
-    assert_equal(expr1, expr2)
+    expr1 = table.g.lower().cases(("foo", table.a), ("bar", table.c), else_=table.b)
     assert isinstance(expr1, ir.IntegerColumn)
 
 
 def test_multiple_case_expr(table):
-    expr = (
-        ibis.case()
-        .when(table.a == 5, table.f)
-        .when(table.b == 128, table.b * 2)
-        .when(table.c == 1000, table.e)
-        .else_(table.d)
-        .end()
+    expr = ibis.cases(
+        (table.a == 5, table.f),
+        (table.b == 128, table.b * 2),
+        (table.c == 1000, table.e),
+        else_=table.d,
     )
 
     # deferred cases
-    deferred = (
-        ibis.case()
-        .when(_.a == 5, table.f)
-        .when(_.b == 128, table.b * 2)
-        .when(_.c == 1000, table.e)
-        .else_(table.d)
-        .end()
+    expr2 = ibis.cases(
+        (_.a == 5, table.f),
+        (_.b == 128, table.b * 2),
+        (_.c == 1000, table.e),
+        else_=table.d,
     )
-    expr2 = deferred.resolve(table)
 
     # deferred results
-    expr3 = (
-        ibis.case()
-        .when(table.a == 5, _.f)
-        .when(table.b == 128, _.b * 2)
-        .when(table.c == 1000, _.e)
-        .else_(table.d)
-        .end()
-        .resolve(table)
+    expr3 = ibis.cases(
+        (table.a == 5, _.f),
+        (table.b == 128, _.b * 2),
+        (table.c == 1000, _.e),
+        else_=table.d,
     )
 
     # deferred default
-    expr4 = (
-        ibis.case()
-        .when(table.a == 5, table.f)
-        .when(table.b == 128, table.b * 2)
-        .when(table.c == 1000, table.e)
-        .else_(_.d)
-        .end()
-        .resolve(table)
+    expr4 = ibis.cases(
+        (table.a == 5, table.f),
+        (table.b == 128, table.b * 2),
+        (table.c == 1000, table.e),
+        else_=_.d,
     )
 
-    assert repr(deferred) == "<case>"
-    assert expr.equals(expr2)
-    assert expr.equals(expr3)
-    assert expr.equals(expr4)
+    assert repr(expr2) == "<cases>"
+    assert expr.equals(expr2.resolve(table))
+    assert expr.equals(expr3.resolve(table))
+    assert expr.equals(expr4.resolve(table))
 
     op = expr.op()
     assert isinstance(expr, ir.FloatingColumn)
@@ -130,13 +102,11 @@ def test_pickle_multiple_case_node(table):
     result3 = table.e
 
     default = table.d
-    expr = (
-        ibis.case()
-        .when(case1, result1)
-        .when(case2, result2)
-        .when(case3, result3)
-        .else_(default)
-        .end()
+    expr = ibis.cases(
+        (case1, result1),
+        (case2, result2),
+        (case3, result3),
+        else_=default,
     )
 
     op = expr.op()
@@ -144,7 +114,7 @@ def test_pickle_multiple_case_node(table):
 
 
 def test_simple_case_null_else(table):
-    expr = table.g.case().when("foo", "bar").end()
+    expr = table.g.cases(("foo", "bar"))
     op = expr.op()
 
     assert isinstance(expr, ir.StringColumn)
@@ -154,8 +124,8 @@ def test_simple_case_null_else(table):
 
 
 def test_multiple_case_null_else(table):
-    expr = ibis.case().when(table.g == "foo", "bar").end()
-    expr2 = ibis.case().when(table.g == "foo", _).end().resolve("bar")
+    expr = ibis.cases((table.g == "foo", "bar"))
+    expr2 = ibis.cases((table.g == "foo", _)).resolve("bar")
 
     assert expr.equals(expr2)
 
@@ -172,8 +142,6 @@ def test_case_mixed_type():
         name="my_data",
     )
 
-    expr = (
-        t0.three.case().when(0, "low").when(1, "high").else_("null").end().name("label")
-    )
+    expr = t0.three.cases((0, "low"), (1, "high"), else_="null").name("label")
     result = t0[expr]
     assert result["label"].type().equals(dt.string)

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -792,15 +792,11 @@ def test_substitute_dict():
     subs = {"a": "one", "b": table.bar}
 
     result = table.foo.substitute(subs)
-    expected = (
-        table.foo.case().when("a", "one").when("b", table.bar).else_(table.foo).end()
-    )
+    expected = table.foo.cases(("a", "one"), ("b", table.bar), else_=table.foo)
     assert_equal(result, expected)
 
     result = table.foo.substitute(subs, else_=ibis.NA)
-    expected = (
-        table.foo.case().when("a", "one").when("b", table.bar).else_(ibis.NA).end()
-    )
+    expected = table.foo.cases(("a", "one"), ("b", table.bar), else_=ibis.NA)
     assert_equal(result, expected)
 
 

--- a/ibis/tests/sql/conftest.py
+++ b/ibis/tests/sql/conftest.py
@@ -167,15 +167,9 @@ def difference(con):
 
 
 @pytest.fixture(scope="module")
-def simple_case(con):
-    t = con.table("alltypes")
-    return t.g.case().when("foo", "bar").when("baz", "qux").else_("default").end()
-
-
-@pytest.fixture(scope="module")
 def search_case(con):
     t = con.table("alltypes")
-    return ibis.case().when(t.f > 0, t.d * 2).when(t.c < 0, t.a * 2).end()
+    return ibis.cases((t.f > 0, t.d * 2), (t.c < 0, t.a * 2))
 
 
 @pytest.fixture(scope="module")

--- a/ibis/tests/sql/snapshots/test_select_sql/test_case_in_projection/decompiled.py
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_case_in_projection/decompiled.py
@@ -17,24 +17,20 @@ alltypes = ibis.table(
         "k": "time",
     },
 )
-lit = ibis.literal("foo")
-lit1 = ibis.literal("baz")
-lit2 = ibis.literal("bar")
+lit = ibis.literal("bar")
+equals = alltypes.g == "foo"
+equals1 = alltypes.g == "baz"
 
 result = alltypes.select(
     [
-        alltypes.g.case()
-        .when(lit, lit2)
-        .when(lit1, ibis.literal("qux"))
-        .else_(ibis.literal("default"))
-        .end()
-        .name("col1"),
-        ibis.case()
-        .when(alltypes.g == lit, lit2)
-        .when(alltypes.g == lit1, alltypes.g)
-        .else_(ibis.literal(None).cast("string"))
-        .end()
-        .name("col2"),
+        ibis.cases(
+            (equals, lit), (equals1, ibis.literal("qux")), else_=ibis.literal("default")
+        ).name("col1"),
+        ibis.cases(
+            (equals, lit),
+            (equals1, alltypes.g),
+            else_=ibis.literal(None).cast("string"),
+        ).name("col2"),
         alltypes,
     ]
 )

--- a/ibis/tests/sql/snapshots/test_select_sql/test_case_in_projection/out.sql
+++ b/ibis/tests/sql/snapshots/test_select_sql/test_case_in_projection/out.sql
@@ -1,7 +1,7 @@
 SELECT
-  CASE t0.`g`
-    WHEN 'foo' THEN 'bar'
-    WHEN 'baz' THEN 'qux'
+  CASE
+    WHEN t0.`g` = 'foo' THEN 'bar'
+    WHEN t0.`g` = 'baz' THEN 'qux'
     ELSE 'default'
   END AS `col1`,
   CASE

--- a/ibis/tests/sql/test_select_sql.py
+++ b/ibis/tests/sql/test_select_sql.py
@@ -406,8 +406,8 @@ def test_bool_bool(snapshot):
 
 def test_case_in_projection(alltypes, snapshot):
     t = alltypes
-    expr = t.g.case().when("foo", "bar").when("baz", "qux").else_("default").end()
-    expr2 = ibis.case().when(t.g == "foo", "bar").when(t.g == "baz", t.g).end()
+    expr = t.g.cases(("foo", "bar"), ("baz", "qux"), else_="default")
+    expr2 = ibis.cases((t.g == "foo", "bar"), (t.g == "baz", t.g))
     expr = t[expr.name("col1"), expr2.name("col2"), t]
 
     snapshot.assert_match(to_sql(expr), "out.sql")

--- a/ibis/tests/sql/test_sqlalchemy.py
+++ b/ibis/tests/sql/test_sqlalchemy.py
@@ -183,11 +183,6 @@ def test_full_outer_join(con):
     assert "left" not in joined_sql_str.lower()
 
 
-def test_simple_case(simple_case, snapshot):
-    expr = simple_case.name("tmp")
-    snapshot.assert_match(to_sql(expr), "out.sql")
-
-
 def test_searched_case(search_case, snapshot):
     expr = search_case.name("tmp")
     snapshot.assert_match(to_sql(expr), "out.sql")


### PR DESCRIPTION
Redo of #7319 targeting main instead of master

Fixes https://github.com/ibis-project/ibis/issues/7280

This is still WIP for getting all tests to pass, but putting something concrete out here for feedback. I would love you initial thoughts here.

TODO:
- [x] core tests pass
- [ ] backend tests pass
- [ ] document

Questions:
- Don't remove .case(), just deprecate it?
- don't even hard deprecate it, merely soft-deprecate it by removing from examples and docs? It's not _that_ hard to transition to the new API, but it also wouldn't be that hard for us to stealthily continue supporting the old API.
- rename SearchedCase to just Case, since SimpleCase is now gone?
- make deferreds on non-Table values work: `t.values.cases((_ > 5), "big"), else_="small")`. This doesn't work currently either, so we're not moving backwards.
- The generated SQL isn't as idiomatic for some dialects (eg duckdb) when you pass in values. Eg t.values.cases((5, "five"))` generates
```sql
CASE
    WHEN values = 5 THEN "five"
```
instead of what it used to:
```sql
CASE values
   WHEN 5 THEN "five"
```
IDK if this has any performance penalty (the previous SQL looks ripe for a hash lookup, the new SQL does not, but IDK duckdb is probably smart enough to get around this)