### PR TITLE
feat(ux): add Table and Column.preview()

### DIFF
--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -169,7 +169,7 @@ class Rendered(str):
 
 
 @public
-def pretty(expr: ops.Node | ir.Expr, scope: Optional[dict[str, ir.Expr]] = None):
+def pretty(expr: ops.Node | ir.Expr, scope: Optional[dict[str, ir.Expr]] = None) -> str:
     """Pretty print an expression.
 
     Parameters
@@ -178,8 +178,11 @@ def pretty(expr: ops.Node | ir.Expr, scope: Optional[dict[str, ir.Expr]] = None)
         The expression to pretty print.
     scope
         A dictionary of expression to name mappings used to intermediate
-        assignments. If not provided, the names of the expressions will be
-        generated.
+        assignments.
+        If not provided the names of the expressions will either be
+        - the variable name in the defining scope if
+          `ibis.options.repr.show_variables` is enabled
+        - generated names like `r0`, `r1`, etc. otherwise
 
     Returns
     -------
@@ -192,6 +195,9 @@ def pretty(expr: ops.Node | ir.Expr, scope: Optional[dict[str, ir.Expr]] = None)
         node = expr
     else:
         raise TypeError(f"Expected an expression or a node, got {type(expr)}")
+
+    if scope is None and ibis.options.repr.show_variables:
+        scope = get_defining_scope(expr)
 
     refs = {}
     refcnt = itertools.count()

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -24,6 +24,7 @@ from ibis import util
 from ibis.common.deferred import Deferred, Resolver
 from ibis.expr.types.core import Expr, _FixedTextJupyterMixin
 from ibis.expr.types.generic import ValueExpr, literal
+from ibis.expr.types.pretty import to_rich
 from ibis.selectors import Selector
 from ibis.util import deprecated
 
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
     import pandas as pd
     import polars as pl
     import pyarrow as pa
+    from rich.table import Table as RichTable
 
     import ibis.expr.types as ir
     import ibis.selectors as s
@@ -497,41 +499,73 @@ class Table(Expr, _FixedTextJupyterMixin):
             cols.append(new_col)
         return self.select(*cols)
 
-    def __interactive_rich_console__(self, console, options):
-        from ibis.expr.types.pretty import to_rich_table
+    def preview(
+        self,
+        *,
+        max_rows: int | None = None,
+        max_columns: int | None = None,
+        max_length: int | None = None,
+        max_string: int | None = None,
+        max_depth: int | None = None,
+        console_width: int | float | None = None,
+    ) -> RichTable:
+        """Return a subset as a Rich Table.
 
-        if console.is_jupyter:
-            # Rich infers a console width in jupyter notebooks, but since
-            # notebooks can use horizontal scroll bars we don't want to apply a
-            # limit here. Since rich requires an integer for max_width, we
-            # choose an arbitrarily large integer bound. Note that we need to
-            # handle this here rather than in `to_rich_table`, as this setting
-            # also needs to be forwarded to `console.render`.
-            options = options.update(max_width=1_000_000)
-            width = None
-        else:
-            width = options.max_width
+        This is an explicit version of what you get when you inspect
+        this object in interactive mode, except with this version you
+        can pass formatting options. The options are the same as those exposed
+        in `ibis.options.interactive`.
 
-        try:
-            table = to_rich_table(self, width)
-        except Exception as e:
-            # In IPython exceptions inside of _repr_mimebundle_ are swallowed to
-            # allow calling several display functions and choosing to display
-            # the "best" result based on some priority.
-            # This behavior, though, means that exceptions that bubble up inside of the interactive repr
-            # are silently caught.
-            #
-            # We can't stop the exception from being swallowed, but we can force
-            # the display of that exception as we do here.
-            #
-            # A _very_ annoying caveat is that this exception is _not_ being
-            # ` raise`d, it is only being printed to the console.  This means
-            # that you cannot "catch" it.
-            #
-            # This restriction is only present in IPython, not in other REPLs.
-            console.print_exception()
-            raise e
-        return console.render(table, options=options)
+        Parameters
+        ----------
+        max_rows
+            Maximum number of rows to display
+        max_columns
+            Maximum number of columns to display
+        max_length
+            Maximum length for pretty-printed arrays and maps
+        max_string
+            Maximum length for pretty-printed strings
+        max_depth
+            Maximum depth for nested data types
+        console_width
+            Width of the console in characters. If not specified, the width
+            will be inferred from the console.
+
+        Examples
+        --------
+        >>> import ibis
+        >>> t = ibis.examples.penguins.fetch()
+
+        Because the console_width is too small, only 2 columns are shown even though
+        we specified up to 3.
+
+        >>> t.preview(
+        ...     max_rows=3,
+        ...     max_columns=3,
+        ...     max_string=8,
+        ...     console_width=30,
+        ... )  # doctest: +SKIP
+        ┏━━━━━━━━━┳━━━━━━━━━━┳━━━┓
+        ┃ species ┃ island   ┃ … ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━╇━━━┩
+        │ string  │ string   │ … │
+        ├─────────┼──────────┼───┤
+        │ Adelie  │ Torgers… │ … │
+        │ Adelie  │ Torgers… │ … │
+        │ Adelie  │ Torgers… │ … │
+        │ …       │ …        │ … │
+        └─────────┴──────────┴───┘
+        """
+        return to_rich(
+            self,
+            max_columns=max_columns,
+            max_rows=max_rows,
+            max_length=max_length,
+            max_string=max_string,
+            max_depth=max_depth,
+            console_width=console_width,
+        )
 
     # TODO(kszucs): expose this method in the public API
     def _get_column(self, name: str | int) -> ir.Column:


### PR DESCRIPTION
redo of #7408 targeting main instead of master

fixes #7172 

I wasn't sure how testing this should work so I didn't add any tests. I would really appreciate it if someone more familiar could pick this up and finish it off, I think I've gotten a lot of it out of the way.

Hopefully I've implemented this is such a way that it is testable.

Things I'm not sure about:

1. EDIT: I think this is fine to just keep them opaque as fmt_kwargs. adding **fmt_kwargs all over pretty.py. I didn't really want all the boilerplate that would be required if I was explicit with each kwarg. Possibly could pass around a container object such as options.Repr instead.
2. I encapsulated some logic into pretty.pretty_repr() because I thought that was going to be necessary for the functional change. It ended up not being needed, but I still think it is a good refactor to tie up some disparate ends. I can revert this though if you want.
3. EDIT: we decided this should just print. Should `.preview()` return a `rich.Table` for the caller/framework to render, or should it print to stdout directly? (ie the same difference as ibis.to_sql() vs ibis.show_sql())
I might argue for a kwarg like `def preview(..., file: io.StringIO | None = None)`, so the default is to just print to stdout.
This is because I imagine this method is mostly going to get used in notebooks or debuggers. For example, in the vscode debugger, if I want to see an ibis table, I have to `print()` it, otherwise I get the raw output with ANSI codes:
<img width="384" alt="image" src="https://github.com/ibis-project/ibis/assets/10820686/460d226e-f35e-4b14-884a-30b9e8c2742a">
<img width="289" alt="image" src="https://github.com/ibis-project/ibis/assets/10820686/c914ca26-870f-4c62-8a09-1c395804896d">
