### PR TITLE
depr: deprecate Value.least() and Value.greatest()

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -8,8 +8,8 @@ from public import public
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
-from ibis.common.deferred import Deferred
 import ibis.expr.operations as ops
+from ibis.common.deferred import Deferred
 from ibis.common.grounds import Singleton
 from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin
 from ibis.util import deprecated
@@ -724,7 +724,7 @@ class Value(Expr):
         """
         import ibis.expr.analysis as an
         import ibis.expr.builders as bl
-        from ibis.common.deferred import Deferred, Call
+        from ibis.common.deferred import Call
         from ibis import _
 
         if window is None:

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -12,6 +12,7 @@ from ibis.common.deferred import Deferred
 import ibis.expr.operations as ops
 from ibis.common.grounds import Singleton
 from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin
+from ibis.util import deprecated
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -297,34 +298,12 @@ class Value(Expr):
         """
         return ops.Coalesce((self, *args)).to_expr()
 
-    def greatest(self, *args: ir.Value) -> ir.Value:
-        """Compute the largest value among the supplied arguments.
-
-        Parameters
-        ----------
-        args
-            Arguments to choose from
-
-        Returns
-        -------
-        Value
-            Maximum of the passed arguments
-        """
+    @deprecated(as_of="8.0.0", instead="use ibis.greatest(self, rest...) instead")
+    def greatest(self, *args: ir.Value) -> ir.Value:  # noqa: D102
         return ops.Greatest((self, *args)).to_expr()
 
-    def least(self, *args: ir.Value) -> ir.Value:
-        """Compute the smallest value among the supplied arguments.
-
-        Parameters
-        ----------
-        args
-            Arguments to choose from
-
-        Returns
-        -------
-        Value
-            Minimum of the passed arguments
-        """
+    @deprecated(as_of="8.0.0", instead="use ibis.least(self, rest...) instead")
+    def least(self, *args: ir.Value) -> ir.Value:  # noqa: D102
         return ops.Least((self, *args)).to_expr()
 
     def typeof(self) -> ir.StringValue:


### PR DESCRIPTION
moves towards https://github.com/ibis-project/ibis/issues/7295.

This just removes the methods from the docs
(by removing the docstring)
and informs current users of the API as to the upgrade path
(using the `@deprecated` decorator)
