### PR TITLE
fix(mysql): catch PyMySQL OperationalError exception

### DIFF
--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Literal
 
+import pymysql
 import sqlalchemy as sa
 from sqlalchemy.dialects import mysql
 
@@ -112,7 +113,7 @@ class Backend(BaseAlchemyBackend, CanCreateDatabase):
             with dbapi_connection.cursor() as cur:
                 try:
                     cur.execute("SET @@session.time_zone = 'UTC'")
-                except sa.exc.OperationalError:
+                except (sa.exc.OperationalError, pymysql.err.OperationalError):
                     warnings.warn("Unable to set session timezone to UTC.")
 
         super().do_connect(engine)


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

When trying to connect to a mySQL backend, the following error can appear:

```
OperationalError: (pymysql.err.OperationalError) (1298, "Unknown or incorrect time zone: 'UTC'")
(Background on this error at: https://sqlalche.me/e/20/e3q8)
```

This is due to an exception generated by PyMySQL.
The exception, formerly generated by SQLAlchemy was already caught by Ibis since #6010, this PR adds a catching of the PyMySQL exception.

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed
Resolves #7918

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
