### PR TITLE
fix(postgres): ensure that no timezone conversion takes place on timestamptz columns when selecting them out

### DIFF
--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -309,11 +309,6 @@ def _table_column(t, op):
     sa_table = get_sqla_table(ctx, table)
     out_expr = get_col(sa_table, op)
 
-    if op.dtype.is_timestamp():
-        timezone = op.dtype.timezone
-        if timezone is not None:
-            out_expr = out_expr.op("AT TIME ZONE")(timezone).label(op.name)
-
     # If the column does not originate from the table set in the current SELECT
     # context, we should format as a subquery
     if t.permit_subquery and ctx.is_foreign_expr(table):

--- a/ibis/backends/postgres/tests/snapshots/test_client/test_timezone_from_column/out.sql
+++ b/ibis/backends/postgres/tests/snapshots/test_client/test_timezone_from_column/out.sql
@@ -1,0 +1,15 @@
+WITH t0 AS (
+  SELECT
+    t2.id AS id,
+    t2.ts_tz AS tz,
+    t2.ts_no_tz AS no_tz
+  FROM x AS t2
+)
+SELECT
+  t0.id,
+  CAST(t0.tz AS TIMESTAMPTZ) AS tz,
+  CAST(t0.no_tz AS TIMESTAMP) AS no_tz,
+  t1.id AS id_right
+FROM t0
+LEFT OUTER JOIN y AS t1
+  ON t0.id = t1.id


### PR DESCRIPTION
## Description of changes

This PR addresses an issue where we are unintentionally converting values from
their time zone to UTC by using the `AT TIME ZONE 'timezone'` syntax.

`AT TIME ZONE` is used to convert a `timestamp with time zone` to a `timestamp
without time zone` after adjusting for the timezone offset. This is not the
desired behavior.

The values we get back from the database are always in UTC, regardless of the
system timezone so this PR leaves them as is.

## Issues closed

Resolves #7872.
