### PR TITLE
fix(backends): preserve `order_by` position in window function when subsequent expressions are duplicated

### DIFF
--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -1264,6 +1264,7 @@ def test_rank_followed_by_over_call_merge_frames(backend, alltypes, df):
     raises=sa.exc.ProgrammingError,
 )
 @pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(["flink"], raises=com.UnsupportedOperationError)
 @pytest.mark.broken(
     ["pyspark"], reason="pyspark requires CURRENT ROW", raises=PySparkAnalysisException
 )

--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -182,7 +182,14 @@ def merge_windows(_, default_frame):
     group_by = tuple(toolz.unique(_.frame.group_by + default_frame.group_by))
 
     order_by = {}
-    for sort_key in _.frame.order_by + default_frame.order_by:
+    # iterate in the order of the existing keys followed by the new keys
+    #
+    # this allows duplicates to be overridden with no effect on the original
+    # position
+    #
+    # see https://github.com/ibis-project/ibis/issues/7940 for how this
+    # originally manifested
+    for sort_key in default_frame.order_by + _.frame.order_by:
         order_by[sort_key.expr] = sort_key.ascending
     order_by = tuple(ops.SortKey(k, v) for k, v in order_by.items())
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -765,7 +765,6 @@ class Value(Expr):
                 )
             return expr
 
-        op = self.op()
         if isinstance(window, bl.WindowBuilder):
             if table := an.find_first_base_table(self.op()):
                 return bind(table)


### PR DESCRIPTION
## Description of changes

This PR fixes an issue where duplicate window expressions were given the position of the new (duplicated value)
of the expression, rather than preserving the original order.

This was because we were iterating over the new keys first and putting those expressions into a `dict`.

BY iterating over the old keys first, we preserve the original order.

## Issues closed

Closes #7940.
