### PR TITLE
feat(flink): implement array operators

### DIFF
--- a/ibis/backends/flink/tests/conftest.py
+++ b/ibis/backends/flink/tests/conftest.py
@@ -52,12 +52,13 @@ class TestConf(BackendTest):
     def _load_data(self, **_: Any) -> None:
         import pandas as pd
 
-        from ibis.backends.tests.data import json_types, struct_types, win
+        from ibis.backends.tests.data import array_types, json_types, struct_types, win
 
         for table_name in TEST_TABLES:
             path = self.data_dir / "parquet" / f"{table_name}.parquet"
             self.connection.create_table(table_name, pd.read_parquet(path), temp=True)
 
+        self.connection.create_table("array_types", array_types, temp=True)
         self.connection.create_table("json_t", json_types, temp=True)
         self.connection.create_table("struct", struct_types, temp=True)
         self.connection.create_table("win", win, temp=True)

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -9,6 +9,7 @@ from pytest import param
 import ibis
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
+from ibis.backends.tests.errors import Py4JJavaError
 
 pytestmark = [
     pytest.mark.never(
@@ -282,8 +283,8 @@ def test_map_construct_dict(con, keys, values):
 )
 @pytest.mark.notimpl(
     ["flink"],
-    raises=exc.OperationNotDefinedError,
-    reason="No translation rule for <class 'ibis.expr.operations.arrays.Array'>",
+    raises=Py4JJavaError,
+    reason="Map key type should be non-nullable",
 )
 def test_map_construct_array_column(con, alltypes, df):
     expr = ibis.map(ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col]))


### PR DESCRIPTION
## Description of changes

Adds several new array operators for Flink backend. The goal with this is to clear as many of the tests in `ibis/ibis/backends/tests/test_array.py` as possible for the Flink backend.
