### PR TITLE
docs(blog-post): replicate sapatial dev guru blog

### DIFF
--- a/docs/posts/ibis-duckdb-geospatial-dev-guru/index.qmd
+++ b/docs/posts/ibis-duckdb-geospatial-dev-guru/index.qmd
@@ -1,0 +1,119 @@
+---
+title: "Geospatial analysis with Ibis and DuckDB (redux)"
+author: Naty Clementi and Gil Forsyth
+date: 2024-01-09
+categories:
+  - blog
+  - duckdb
+  - geospatial
+execute:
+  freeze: false
+---
+
+Spatial Dev Guru wrote a great [tutorial](https://spatial-dev.guru/2023/12/09/geospatial-analysis-using-duckdb/) that walks you through a step-by-step
+geospatial analysis of bike sharing data using DuckDB.
+
+Ibis has support for all the geospatial functions used on the tutorial, and we
+decided to replicate it and share it with you.
+
+## Data
+
+The citibike trip data can be downloaded as a `.csv` file from the original
+source https://s3.amazonaws.com/tripdata/index.html. We doubled checked and the
+data in the `202003-citibike-tripdata` entry matches the data used in Spatial
+Dev Guru's post.
+
+```{python}
+from pathlib import Path
+from zipfile import ZipFile
+from urllib.request import urlretrieve
+
+# Download and unzip
+url = "https://s3.amazonaws.com/tripdata/202003-citibike-tripdata.csv.zip"
+zip_path = Path("202003-citibike-tripdata.csv.zip")
+csv_path = Path("202003-citibike-tripdata.csv")
+
+if not zip_path.exists():
+    urlretrieve(url, zip_path)
+
+if not csv_path.exists():
+    with ZipFile(zip_path) as zip_file:
+        zip_file.extract("202003-citibike-tripdata.csv")
+```
+
+
+```{python}
+import ibis
+from ibis import _
+from ibis.interactive import *
+```
+
+This dataset does not contain any geometries, but we have information about the
+latitude and longitude for start and end stations
+
+```{python}
+con = ibis.duckdb.connect("biketrip.ddb")
+con.load_extension("spatial")
+
+#read data and rename columns to use snake case
+biketrip = con.read_csv("202003-citibike-tripdata.csv").rename("snake_case")
+biketrip
+```
+
+## Create bike trip table
+
+In the original tutorial, Spatial Dev Guru creates a table with transformed
+Pickup and Dropoff Points. In DuckDB the `st_transform` function takes by default
+points as `YX` (latitude/longitude) while in Ibis,  we assume data in the form
+`XY` (longitude/latitude) to be consistent with PostGIS and Geopandas.
+
+```{python}
+# Notice longitude/latitude order
+pickup = biketrip.start_station_longitude.point(biketrip.start_station_latitude).name("pickup")
+dropoff = biketrip.end_station_longitude.point(biketrip.end_station_latitude).name("dropoff")
+
+#convert is the equivalent of `st_transform`
+biketrip = biketrip.mutate(pickup_point=pickup.convert('EPSG:4326', 'EPSG:3857'),
+                           dropoff_point=dropoff.convert('EPSG:4326', 'EPSG:3857')
+                        )
+biketrip[["pickup_point", "dropoff_point"]]
+```
+
+## Identify popular starts and end stations
+
+**Top 10 start stations by trip count**
+
+```{python}
+biketrip.group_by(biketrip.start_station_name).agg(trips = ibis._.count()).order_by(ibis.desc("trips"))
+```
+
+**Top 10 end stations by trip count**
+
+```{python}
+biketrip.group_by(biketrip.end_station_name).agg(trips = ibis._.count()).order_by(ibis.desc("trips"))
+```
+
+## Explore trip patterns by user type
+
+```{python}
+biketrip.group_by(_.usertype).aggregate(
+    avg_duration=biketrip.tripduration.mean(),
+    avg_distance=biketrip.pickup_point.distance(biketrip.dropoff_point).name("trip_distance").mean()
+)
+```
+
+## Analyzing efficiency: Trip duration vs linear distance
+
+```{python}
+trip_distance = biketrip.pickup_point.distance(biketrip.dropoff_point).name("trip_distance")
+
+biketrip = biketrip.mutate(linear_distance = trip_distance, efficiency_radio = biketrip.tripduration / trip_distance)
+
+biketrip[["pickup_point", "dropoff_point", "linear_distance", "efficiency_radio"]]
+```
+
+Let's take take a look at the table in descending order for the `linear_distance`, for trips that are longer than 0 meters.
+
+```{python}
+biketrip.filter(biketrip.linear_distance > 0).order_by(ibis.desc("linear_distance"))
+```


### PR DESCRIPTION
## Description of changes
Replicate Spatial Dev Guru's blog using Ibis

## Issues closed
Closes #7717

##TODO / Update on last query

The last query is not currently working, the code should be as follows:

```python
some_point = biketrip.limit(1)

biketrip.filter(_.pickup_point.within(
    some_point.select(_.pickup_point.buffer(500)).to_array())).execute()
```

The error occurs in the query in
```python-traceback

ibis/ibis/backends/base/sql/alchemy/query_builder.py", line 152, in _format_table

    result = alias if hasattr(alias, "name") else result.alias(alias)
```

For some reason both `result` and `alias` are `'t1'`. After chatting with @gforsyth we decided investigating the reason of this failure is not worth it as the `query_builder.py` code will no longer exist after the `sqlglot` port. The options are: 

1.Replicate the blog fully in the branch  `the-epic-split` (This branch should have the geospatial literals support) and things work (just tested it and compare to duckdb result), leave the blog on draft until the branch is merged. 

2. Release the blog without the last query.   

I personally think, that (1) is worth the wait, the last query would look like.  

```python
import shapely
p = shapely.geometry.Point((-8238257.278, 4969875.321))
pb = p.buffer(500)

biketrip.filter(biketrip.pickup_point.within(pb)).execute()
```

If people agrees, I'll update the blog to be written relying on `the-epic-split` and leave it on draft until that branch is merged. 

cc: @gforsyth and @jcrist 