### PR TITLE
fix(sqlalchemy): properly handle aliases of extracted subqueries

### DIFF
--- a/ibis/backends/base/sql/alchemy/query_builder.py
+++ b/ibis/backends/base/sql/alchemy/query_builder.py
@@ -144,6 +144,11 @@ class _AlchemyTableSetFormatter(TableSetFormatter):
         elif ctx.is_extracted(op):
             if isinstance(orig_op, ops.SelfReference):
                 result = ctx.get_ref(op)
+            elif isinstance(alias, str):
+                result = sa.table(
+                    alias,
+                    *translator._schema_to_sqlalchemy_columns(orig_op.schema),
+                )
             else:
                 result = alias
         else:

--- a/ibis/backends/base/sql/compiler/translator.py
+++ b/ibis/backends/base/sql/compiler/translator.py
@@ -113,11 +113,11 @@ class QueryContext:
         """Return the alias used to refer to an expression."""
         assert isinstance(node, ops.Node), type(node)
 
-        if self.is_extracted(node):
-            return self.top_context.table_refs.get(node)
-
         if (ref := self.table_refs.get(node)) is not None:
             return ref
+
+        if self.is_extracted(node):
+            return self.top_context.table_refs.get(node)
 
         if search_parents and (parent := self.parent) is not None:
             return parent.get_ref(node, search_parents=search_parents)


### PR DESCRIPTION
This (potentially) fixes the bug found in #7952. With this fix the query at least runs successfully and I _think_ the fix makes sense. Pushing this up to see if it passes full CI for now. I haven't attempted to write a proper test for this yet.