### PR TITLE
test(flink): add unit test for window join

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -25,6 +25,8 @@ from ibis.conftest import WINDOWS
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from ibis.backends.tests.base import BackendTest
+
 TEST_TABLES = {
     "functional_alltypes": ibis.schema(
         {
@@ -467,7 +469,7 @@ def pytest_runtest_call(item):
 
 
 @pytest.fixture(params=_get_backends_to_test(), scope="session")
-def backend(request, data_dir, tmp_path_factory, worker_id):
+def backend(request, data_dir, tmp_path_factory, worker_id) -> BackendTest:
     """Return an instance of BackendTest, loaded with data."""
 
     cls = _get_backend_conf(request.param)

--- a/ibis/backends/flink/datatypes.py
+++ b/ibis/backends/flink/datatypes.py
@@ -101,7 +101,7 @@ class FlinkType(TypeMapper):
             # if `precision` is None, and assumes `precision = 6`
             # if it is not provided.
             return DataTypes.TIMESTAMP(
-                precision=dtype.scale if dtype.scale else 6,
+                precision=dtype.scale if dtype.scale is not None else 6,
                 nullable=dtype.nullable,
             )
         else:

--- a/ibis/backends/flink/ddl.py
+++ b/ibis/backends/flink/ddl.py
@@ -42,7 +42,7 @@ def _format_schema_element(name, t):
 
 def type_to_flink_sql_string(tval):
     if tval.is_timestamp():
-        return f"TIMESTAMP({tval.scale})"
+        return f"timestamp({tval.scale})" if tval.scale is not None else "timestamp"
     else:
         sql_string = type_to_sql_string(tval)
         if not tval.nullable:

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -16,65 +16,6 @@ import ibis.expr.schema as sch
 from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.errors import Py4JJavaError
 
-_awards_players_schema = sch.Schema(
-    {
-        "playerID": dt.string,
-        "awardID": dt.string,
-        "yearID": dt.int32,
-        "lgID": dt.string,
-        "tie": dt.string,
-        "notes": dt.string,
-    }
-)
-
-_functional_alltypes_schema = sch.Schema(
-    {
-        "id": dt.int32,
-        "bool_col": dt.bool,
-        "smallint_col": dt.int16,
-        "int_col": dt.int32,
-        "bigint_col": dt.int64,
-        "float_col": dt.float32,
-        "double_col": dt.float64,
-        "date_string_col": dt.string,
-        "string_col": dt.string,
-        "timestamp_col": dt.timestamp(scale=3),
-        "year": dt.int32,
-        "month": dt.int32,
-    }
-)
-
-
-@pytest.fixture(autouse=True)
-def reset_con(con):
-    yield
-    tables_to_drop = list(set(con.list_tables()) - set(TEST_TABLES.keys()))
-    for table in tables_to_drop:
-        con.drop_table(table, force=True)
-
-
-@pytest.fixture
-def awards_players_schema():
-    return _awards_players_schema
-
-
-@pytest.fixture
-def functional_alltypes_schema():
-    return _functional_alltypes_schema
-
-
-@pytest.fixture
-def csv_source_configs():
-    def generate_csv_configs(csv_file):
-        return {
-            "connector": "filesystem",
-            "path": f"ci/ibis-testing-data/csv/{csv_file}.csv",
-            "format": "csv",
-            "csv.ignore-parse-errors": "true",
-        }
-
-    return generate_csv_configs
-
 
 @pytest.fixture
 def tempdir_sink_configs():
@@ -178,7 +119,8 @@ def test_force_recreate_table_from_schema(
     ],
 )
 @pytest.mark.parametrize(
-    "schema, table_name", [(None, None), (_awards_players_schema, "awards_players")]
+    "schema, table_name",
+    [(None, None), (TEST_TABLES["awards_players"], "awards_players")],
 )
 def test_recreate_in_mem_table(
     con, employee_df, schema, table_name, temp_table, csv_source_configs
@@ -224,7 +166,7 @@ def test_recreate_in_mem_table(
     ],
 )
 @pytest.mark.parametrize(
-    "schema_props", [(None, None), (_awards_players_schema, "awards_players")]
+    "schema_props", [(None, None), (TEST_TABLES["awards_players"], "awards_players")]
 )
 def test_force_recreate_in_mem_table(
     con, employee_df, schema_props, temp_table, csv_source_configs
@@ -512,26 +454,26 @@ def test_read_csv(con, awards_players_schema, csv_source_configs, table_name):
 
 
 @pytest.mark.parametrize("table_name", ["new_table", None])
-def test_read_parquet(con, data_dir, tmp_path, table_name):
+def test_read_parquet(con, data_dir, tmp_path, table_name, functional_alltypes_schema):
     fname = Path("functional_alltypes.parquet")
     fname = Path(data_dir) / "parquet" / fname.name
     table = con.read_parquet(
         path=tmp_path / fname.name,
-        schema=_functional_alltypes_schema,
+        schema=functional_alltypes_schema,
         table_name=table_name,
     )
 
     if table_name is None:
         table_name = table.get_name()
     assert table_name in con.list_tables()
-    assert table.schema() == _functional_alltypes_schema
+    assert table.schema() == functional_alltypes_schema
 
     con.drop_table(table_name)
     assert table_name not in con.list_tables()
 
 
 @pytest.mark.parametrize("table_name", ["new_table", None])
-def test_read_json(con, data_dir, tmp_path, table_name):
+def test_read_json(con, data_dir, tmp_path, table_name, functional_alltypes_schema):
     pq = pytest.importorskip("pyarrow.parquet")
 
     pq_table = pq.read_table(
@@ -542,13 +484,13 @@ def test_read_json(con, data_dir, tmp_path, table_name):
     path = tmp_path / "functional_alltypes.json"
     df.to_json(path, orient="records", lines=True, date_format="iso")
     table = con.read_json(
-        path=path, schema=_functional_alltypes_schema, table_name=table_name
+        path=path, schema=functional_alltypes_schema, table_name=table_name
     )
 
     if table_name is None:
         table_name = table.get_name()
     assert table_name in con.list_tables()
-    assert table.schema() == _functional_alltypes_schema
+    assert table.schema() == functional_alltypes_schema
     assert table.count().execute() == len(pq_table)
 
     con.drop_table(table_name)
@@ -569,7 +511,7 @@ def functional_alltypes(con):
         "functional_alltypes",
     ],
 )
-def test_to_csv(con, functional_alltypes, tmp_path, table_name):
+def test_to_csv(con, tmp_path, table_name):
     table = con.table(table_name)
     out_path = tmp_path / "out.csv"
     con.to_csv(table, out_path)

--- a/ibis/backends/flink/tests/test_join.py
+++ b/ibis/backends/flink/tests/test_join.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import ibis
+from ibis.backends.flink.tests.conftest import TestConf as tm
+
+
+@pytest.fixture(scope="module")
+def left_tmp():
+    return tempfile.NamedTemporaryFile()
+
+
+@pytest.fixture(scope="module")
+def right_tmp():
+    return tempfile.NamedTemporaryFile()
+
+
+@pytest.fixture(scope="module")
+def left_tumble(con, left_tmp):
+    left_pd = pd.DataFrame(
+        {
+            "row_time": [
+                pd.to_datetime("2020-04-15 12:02"),
+                pd.to_datetime("2020-04-15 12:06"),
+                pd.to_datetime("2020-04-15 12:03"),
+            ],
+            "num": [1, 2, 3],
+            "id": ["L1", "L2", "L3"],
+        }
+    )
+    left_pd.to_csv(left_tmp.name, header=False, index=None)
+
+    left_schema = ibis.schema(
+        {
+            "row_time": "timestamp(3)",
+            "num": "int32",
+            "id": "string",
+        }
+    )
+    left = con.create_table(
+        "left",
+        schema=left_schema,
+        tbl_properties={
+            "connector": "filesystem",
+            "path": left_tmp.name,
+            "format": "csv",
+        },
+        watermark=ibis.watermark(
+            time_col="row_time",
+            allowed_delay=ibis.interval(seconds=1),
+        ),
+    )
+    left_tumble = left.window_by(time_col=left.row_time).tumble(
+        window_size=ibis.interval(minutes=5)
+    )
+    left_tumble = left_tumble[
+        left_tumble
+    ]  # this is required in order to avoid `row_time` being an ambiguous reference
+    return left_tumble
+
+
+@pytest.fixture(scope="module")
+def right_tumble(con, right_tmp):
+    right_pd = pd.DataFrame(
+        {
+            "row_time": [
+                pd.to_datetime("2020-04-15 12:01"),
+                pd.to_datetime("2020-04-15 12:04"),
+                pd.to_datetime("2020-04-15 12:05"),
+            ],
+            "num": [2, 3, 4],
+            "id": ["R2", "R3", "R4"],
+        }
+    )
+    right_pd.to_csv(right_tmp.name, header=False, index=None)
+
+    right_schema = ibis.schema(
+        {
+            "row_time": "timestamp(3)",
+            "num": "int32",
+            "id": "string",
+        }
+    )
+    right = con.create_table(
+        "right",
+        schema=right_schema,
+        tbl_properties={
+            "connector": "filesystem",
+            "path": right_tmp.name,
+            "format": "csv",
+        },
+        watermark=ibis.watermark(
+            time_col="row_time",
+            allowed_delay=ibis.interval(seconds=1),
+        ),
+    )
+    right_tumble = right.window_by(time_col=right.row_time).tumble(
+        window_size=ibis.interval(minutes=5)
+    )
+    right_tumble = right_tumble[
+        right_tumble
+    ]  # this is required in order to avoid `row_time` being an ambiguous reference
+    return right_tumble
+
+
+@pytest.fixture(autouse=True, scope="module")
+def remove_temp_files(left_tmp, right_tmp):
+    yield
+    left_tmp.close()
+    right_tmp.close()
+
+
+def test_outer_join(left_tumble, right_tumble):
+    expr = left_tumble.join(
+        right_tumble,
+        ["num", "window_start", "window_end"],
+        how="outer",
+        lname="L_{name}",
+        rname="R_{name}",
+    )
+    expr = expr[
+        "L_num",
+        "L_id",
+        "R_num",
+        "R_id",
+        ibis.coalesce(expr["L_window_start"], expr["R_window_start"]).name(
+            "window_start"
+        ),
+        ibis.coalesce(expr["L_window_end"], expr["R_window_end"]).name("window_end"),
+    ]
+    result_df = expr.to_pandas()
+
+    expected_df = pd.DataFrame.from_dict(
+        {
+            "L_num": {0: np.nan, 1: 1.0, 2: 3.0, 3: 2.0, 4: np.nan},
+            "L_id": {0: None, 1: "L1", 2: "L3", 3: "L2", 4: None},
+            "R_num": {0: 2.0, 1: np.nan, 2: 3.0, 3: np.nan, 4: 4.0},
+            "R_id": {0: "R2", 1: None, 2: "R3", 3: None, 4: "R4"},
+            "window_start": {
+                0: pd.Timestamp("2020-04-15 12:00:00"),
+                1: pd.Timestamp("2020-04-15 12:00:00"),
+                2: pd.Timestamp("2020-04-15 12:00:00"),
+                3: pd.Timestamp("2020-04-15 12:05:00"),
+                4: pd.Timestamp("2020-04-15 12:05:00"),
+            },
+            "window_end": {
+                0: pd.Timestamp("2020-04-15 12:05:00"),
+                1: pd.Timestamp("2020-04-15 12:05:00"),
+                2: pd.Timestamp("2020-04-15 12:05:00"),
+                3: pd.Timestamp("2020-04-15 12:10:00"),
+                4: pd.Timestamp("2020-04-15 12:10:00"),
+            },
+        }
+    )
+    tm.assert_frame_equal(result_df, expected_df)


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

1. Added unit test for window join
2. Cleaned up some existing test files
3. Fixed a couple of bugs

A couple of notes:
1. The generated SQL is not an exact match to the example Flink has in their documentation. The one Ibis generates is a little more complicated, because it automatically turns them into subqueries and it's also not able to fuse the select statements automatically.
2. Right now only full outer join works. Other types of join have a different syntax in Flink, e.g. semi join looks like
```sql
SELECT *
FROM (
    SELECT * FROM TABLE(TUMBLE(TABLE LeftTable, DESCRIPTOR(row_time), INTERVAL '5' MINUTES))
) L WHERE L.num IN (
    SELECT num FROM (   
    SELECT * FROM TABLE(TUMBLE(TABLE RightTable, DESCRIPTOR(row_time), INTERVAL '5' MINUTES))
    ) R WHERE L.window_start = R.window_start AND L.window_end = R.window_end);
```
or
```sql
SELECT *
FROM (
    SELECT * FROM TABLE(TUMBLE(TABLE LeftTable, DESCRIPTOR(row_time), INTERVAL '5' MINUTES))
) L WHERE EXISTS (
    SELECT * FROM (
    SELECT * FROM TABLE(TUMBLE(TABLE RightTable, DESCRIPTOR(row_time), INTERVAL '5' MINUTES))
    ) R WHERE L.num = R.num AND L.window_start = R.window_start AND L.window_end = R.window_end);
```
which is not as simple as changing the keyword from `FULL OUTER JOIN` to `LEFT SEMI JOIN`. I need to spend some time digging and understanding how we can support semi/anti window joins.