### PR TITLE
refactor(ir): give unbound tables namespaces

### DIFF
--- a/ibis/backends/tests/tpch/snapshots/test_h01/test_tpc_h01/snowflake/h01.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h01/test_tpc_h01/snowflake/h01.sql
@@ -49,7 +49,7 @@ FROM (
       "t0"."L_SHIPINSTRUCT" AS "l_shipinstruct",
       "t0"."L_SHIPMODE" AS "l_shipmode",
       "t0"."L_COMMENT" AS "l_comment"
-    FROM "LINEITEM" AS "t0"
+    FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t0"
     WHERE
       "t0"."L_SHIPDATE" <= DATE_FROM_PARTS(1998, 9, 2)
   ) AS "t1"

--- a/ibis/backends/tests/tpch/snapshots/test_h01/test_tpc_h01/trino/h01.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h01/test_tpc_h01/trino/h01.sql
@@ -49,7 +49,7 @@ FROM (
       "t0"."l_shipinstruct",
       "t0"."l_shipmode",
       "t0"."l_comment"
-    FROM "lineitem" AS "t0"
+    FROM "hive"."ibis_sf1"."lineitem" AS "t0"
     WHERE
       "t0"."l_shipdate" <= FROM_ISO8601_DATE('1998-09-02')
   ) AS "t1"

--- a/ibis/backends/tests/tpch/snapshots/test_h02/test_tpc_h02/snowflake/h02.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h02/test_tpc_h02/snowflake/h02.sql
@@ -48,7 +48,7 @@ FROM (
       "t0"."P_CONTAINER" AS "p_container",
       "t0"."P_RETAILPRICE" AS "p_retailprice",
       "t0"."P_COMMENT" AS "p_comment"
-    FROM "PART" AS "t0"
+    FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PART" AS "t0"
   ) AS "t10"
   INNER JOIN (
     SELECT
@@ -57,7 +57,7 @@ FROM (
       "t1"."PS_AVAILQTY" AS "ps_availqty",
       "t1"."PS_SUPPLYCOST" AS "ps_supplycost",
       "t1"."PS_COMMENT" AS "ps_comment"
-    FROM "PARTSUPP" AS "t1"
+    FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PARTSUPP" AS "t1"
   ) AS "t11"
     ON "t10"."p_partkey" = "t11"."ps_partkey"
   INNER JOIN (
@@ -69,7 +69,7 @@ FROM (
       "t2"."S_PHONE" AS "s_phone",
       "t2"."S_ACCTBAL" AS "s_acctbal",
       "t2"."S_COMMENT" AS "s_comment"
-    FROM "SUPPLIER" AS "t2"
+    FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t2"
   ) AS "t13"
     ON "t13"."s_suppkey" = "t11"."ps_suppkey"
   INNER JOIN (
@@ -78,7 +78,7 @@ FROM (
       "t3"."N_NAME" AS "n_name",
       "t3"."N_REGIONKEY" AS "n_regionkey",
       "t3"."N_COMMENT" AS "n_comment"
-    FROM "NATION" AS "t3"
+    FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t3"
   ) AS "t15"
     ON "t13"."s_nationkey" = "t15"."n_nationkey"
   INNER JOIN (
@@ -86,7 +86,7 @@ FROM (
       "t4"."R_REGIONKEY" AS "r_regionkey",
       "t4"."R_NAME" AS "r_name",
       "t4"."R_COMMENT" AS "r_comment"
-    FROM "REGION" AS "t4"
+    FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."REGION" AS "t4"
   ) AS "t17"
     ON "t15"."n_regionkey" = "t17"."r_regionkey"
 ) AS "t26"
@@ -146,7 +146,7 @@ WHERE
             "t1"."PS_AVAILQTY" AS "ps_availqty",
             "t1"."PS_SUPPLYCOST" AS "ps_supplycost",
             "t1"."PS_COMMENT" AS "ps_comment"
-          FROM "PARTSUPP" AS "t1"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PARTSUPP" AS "t1"
         ) AS "t12"
         INNER JOIN (
           SELECT
@@ -157,7 +157,7 @@ WHERE
             "t2"."S_PHONE" AS "s_phone",
             "t2"."S_ACCTBAL" AS "s_acctbal",
             "t2"."S_COMMENT" AS "s_comment"
-          FROM "SUPPLIER" AS "t2"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t2"
         ) AS "t14"
           ON "t14"."s_suppkey" = "t12"."ps_suppkey"
         INNER JOIN (
@@ -166,7 +166,7 @@ WHERE
             "t3"."N_NAME" AS "n_name",
             "t3"."N_REGIONKEY" AS "n_regionkey",
             "t3"."N_COMMENT" AS "n_comment"
-          FROM "NATION" AS "t3"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t3"
         ) AS "t16"
           ON "t14"."s_nationkey" = "t16"."n_nationkey"
         INNER JOIN (
@@ -174,7 +174,7 @@ WHERE
             "t4"."R_REGIONKEY" AS "r_regionkey",
             "t4"."R_NAME" AS "r_name",
             "t4"."R_COMMENT" AS "r_comment"
-          FROM "REGION" AS "t4"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."REGION" AS "t4"
         ) AS "t18"
           ON "t16"."n_regionkey" = "t18"."r_regionkey"
       ) AS "t27"

--- a/ibis/backends/tests/tpch/snapshots/test_h02/test_tpc_h02/trino/h02.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h02/test_tpc_h02/trino/h02.sql
@@ -48,7 +48,7 @@ FROM (
       "t0"."p_container",
       CAST("t0"."p_retailprice" AS DECIMAL(15, 2)) AS "p_retailprice",
       "t0"."p_comment"
-    FROM "part" AS "t0"
+    FROM "hive"."ibis_sf1"."part" AS "t0"
   ) AS "t14"
   INNER JOIN (
     SELECT
@@ -57,7 +57,7 @@ FROM (
       "t1"."ps_availqty",
       CAST("t1"."ps_supplycost" AS DECIMAL(15, 2)) AS "ps_supplycost",
       "t1"."ps_comment"
-    FROM "partsupp" AS "t1"
+    FROM "hive"."ibis_sf1"."partsupp" AS "t1"
   ) AS "t15"
     ON "t14"."p_partkey" = "t15"."ps_partkey"
   INNER JOIN (
@@ -69,7 +69,7 @@ FROM (
       "t2"."s_phone",
       CAST("t2"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
       "t2"."s_comment"
-    FROM "supplier" AS "t2"
+    FROM "hive"."ibis_sf1"."supplier" AS "t2"
   ) AS "t17"
     ON "t17"."s_suppkey" = "t15"."ps_suppkey"
   INNER JOIN (
@@ -78,7 +78,7 @@ FROM (
       "t3"."n_name",
       "t3"."n_regionkey",
       "t3"."n_comment"
-    FROM "nation" AS "t3"
+    FROM "hive"."ibis_sf1"."nation" AS "t3"
   ) AS "t10"
     ON "t17"."s_nationkey" = "t10"."n_nationkey"
   INNER JOIN (
@@ -86,7 +86,7 @@ FROM (
       "t4"."r_regionkey",
       "t4"."r_name",
       "t4"."r_comment"
-    FROM "region" AS "t4"
+    FROM "hive"."ibis_sf1"."region" AS "t4"
   ) AS "t12"
     ON "t10"."n_regionkey" = "t12"."r_regionkey"
 ) AS "t26"
@@ -146,7 +146,7 @@ WHERE
             "t1"."ps_availqty",
             CAST("t1"."ps_supplycost" AS DECIMAL(15, 2)) AS "ps_supplycost",
             "t1"."ps_comment"
-          FROM "partsupp" AS "t1"
+          FROM "hive"."ibis_sf1"."partsupp" AS "t1"
         ) AS "t16"
         INNER JOIN (
           SELECT
@@ -157,7 +157,7 @@ WHERE
             "t2"."s_phone",
             CAST("t2"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
             "t2"."s_comment"
-          FROM "supplier" AS "t2"
+          FROM "hive"."ibis_sf1"."supplier" AS "t2"
         ) AS "t18"
           ON "t18"."s_suppkey" = "t16"."ps_suppkey"
         INNER JOIN (
@@ -166,7 +166,7 @@ WHERE
             "t3"."n_name",
             "t3"."n_regionkey",
             "t3"."n_comment"
-          FROM "nation" AS "t3"
+          FROM "hive"."ibis_sf1"."nation" AS "t3"
         ) AS "t11"
           ON "t18"."s_nationkey" = "t11"."n_nationkey"
         INNER JOIN (
@@ -174,7 +174,7 @@ WHERE
             "t4"."r_regionkey",
             "t4"."r_name",
             "t4"."r_comment"
-          FROM "region" AS "t4"
+          FROM "hive"."ibis_sf1"."region" AS "t4"
         ) AS "t13"
           ON "t11"."n_regionkey" = "t13"."r_regionkey"
       ) AS "t27"

--- a/ibis/backends/tests/tpch/snapshots/test_h03/test_tpc_h03/snowflake/h03.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h03/test_tpc_h03/snowflake/h03.sql
@@ -91,7 +91,7 @@ FROM (
           "t0"."C_ACCTBAL" AS "c_acctbal",
           "t0"."C_MKTSEGMENT" AS "c_mktsegment",
           "t0"."C_COMMENT" AS "c_comment"
-        FROM "CUSTOMER" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."CUSTOMER" AS "t0"
       ) AS "t6"
       INNER JOIN (
         SELECT
@@ -104,7 +104,7 @@ FROM (
           "t1"."O_CLERK" AS "o_clerk",
           "t1"."O_SHIPPRIORITY" AS "o_shippriority",
           "t1"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t1"
       ) AS "t7"
         ON "t6"."c_custkey" = "t7"."o_custkey"
       INNER JOIN (
@@ -125,7 +125,7 @@ FROM (
           "t2"."L_SHIPINSTRUCT" AS "l_shipinstruct",
           "t2"."L_SHIPMODE" AS "l_shipmode",
           "t2"."L_COMMENT" AS "l_comment"
-        FROM "LINEITEM" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t2"
       ) AS "t8"
         ON "t8"."l_orderkey" = "t7"."o_orderkey"
     ) AS "t11"

--- a/ibis/backends/tests/tpch/snapshots/test_h03/test_tpc_h03/trino/h03.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h03/test_tpc_h03/trino/h03.sql
@@ -91,7 +91,7 @@ FROM (
           CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
           "t0"."c_mktsegment",
           "t0"."c_comment"
-        FROM "customer" AS "t0"
+        FROM "hive"."ibis_sf1"."customer" AS "t0"
       ) AS "t6"
       INNER JOIN (
         SELECT
@@ -104,7 +104,7 @@ FROM (
           "t1"."o_clerk",
           "t1"."o_shippriority",
           "t1"."o_comment"
-        FROM "orders" AS "t1"
+        FROM "hive"."ibis_sf1"."orders" AS "t1"
       ) AS "t7"
         ON "t6"."c_custkey" = "t7"."o_custkey"
       INNER JOIN (
@@ -125,7 +125,7 @@ FROM (
           "t2"."l_shipinstruct",
           "t2"."l_shipmode",
           "t2"."l_comment"
-        FROM "lineitem" AS "t2"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t2"
       ) AS "t8"
         ON "t8"."l_orderkey" = "t7"."o_orderkey"
     ) AS "t11"

--- a/ibis/backends/tests/tpch/snapshots/test_h04/test_tpc_h04/snowflake/h04.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h04/test_tpc_h04/snowflake/h04.sql
@@ -27,13 +27,13 @@ FROM (
         "t0"."O_CLERK" AS "o_clerk",
         "t0"."O_SHIPPRIORITY" AS "o_shippriority",
         "t0"."O_COMMENT" AS "o_comment"
-      FROM "ORDERS" AS "t0"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t0"
     ) AS "t2"
     WHERE
       EXISTS(
         SELECT
           1 AS "1"
-        FROM "LINEITEM" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t1"
         WHERE
           (
             "t1"."L_ORDERKEY" = "t2"."o_orderkey"

--- a/ibis/backends/tests/tpch/snapshots/test_h04/test_tpc_h04/trino/h04.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h04/test_tpc_h04/trino/h04.sql
@@ -27,13 +27,13 @@ FROM (
         "t0"."o_clerk",
         "t0"."o_shippriority",
         "t0"."o_comment"
-      FROM "orders" AS "t0"
+      FROM "hive"."ibis_sf1"."orders" AS "t0"
     ) AS "t2"
     WHERE
       EXISTS(
         SELECT
           1 AS "1"
-        FROM "lineitem" AS "t1"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t1"
         WHERE
           (
             "t1"."l_orderkey" = "t2"."o_orderkey"

--- a/ibis/backends/tests/tpch/snapshots/test_h05/test_tpc_h05/snowflake/h05.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h05/test_tpc_h05/snowflake/h05.sql
@@ -115,7 +115,7 @@ FROM (
           "t0"."C_ACCTBAL" AS "c_acctbal",
           "t0"."C_MKTSEGMENT" AS "c_mktsegment",
           "t0"."C_COMMENT" AS "c_comment"
-        FROM "CUSTOMER" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."CUSTOMER" AS "t0"
       ) AS "t12"
       INNER JOIN (
         SELECT
@@ -128,7 +128,7 @@ FROM (
           "t1"."O_CLERK" AS "o_clerk",
           "t1"."O_SHIPPRIORITY" AS "o_shippriority",
           "t1"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t1"
       ) AS "t13"
         ON "t12"."c_custkey" = "t13"."o_custkey"
       INNER JOIN (
@@ -149,7 +149,7 @@ FROM (
           "t2"."L_SHIPINSTRUCT" AS "l_shipinstruct",
           "t2"."L_SHIPMODE" AS "l_shipmode",
           "t2"."L_COMMENT" AS "l_comment"
-        FROM "LINEITEM" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t2"
       ) AS "t14"
         ON "t14"."l_orderkey" = "t13"."o_orderkey"
       INNER JOIN (
@@ -161,7 +161,7 @@ FROM (
           "t3"."S_PHONE" AS "s_phone",
           "t3"."S_ACCTBAL" AS "s_acctbal",
           "t3"."S_COMMENT" AS "s_comment"
-        FROM "SUPPLIER" AS "t3"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t3"
       ) AS "t15"
         ON "t14"."l_suppkey" = "t15"."s_suppkey"
       INNER JOIN (
@@ -170,7 +170,7 @@ FROM (
           "t4"."N_NAME" AS "n_name",
           "t4"."N_REGIONKEY" AS "n_regionkey",
           "t4"."N_COMMENT" AS "n_comment"
-        FROM "NATION" AS "t4"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t4"
       ) AS "t16"
         ON "t12"."c_nationkey" = "t15"."s_nationkey"
         AND "t15"."s_nationkey" = "t16"."n_nationkey"
@@ -179,7 +179,7 @@ FROM (
           "t5"."R_REGIONKEY" AS "r_regionkey",
           "t5"."R_NAME" AS "r_name",
           "t5"."R_COMMENT" AS "r_comment"
-        FROM "REGION" AS "t5"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."REGION" AS "t5"
       ) AS "t17"
         ON "t16"."n_regionkey" = "t17"."r_regionkey"
     ) AS "t23"

--- a/ibis/backends/tests/tpch/snapshots/test_h05/test_tpc_h05/trino/h05.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h05/test_tpc_h05/trino/h05.sql
@@ -115,7 +115,7 @@ FROM (
           CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
           "t0"."c_mktsegment",
           "t0"."c_comment"
-        FROM "customer" AS "t0"
+        FROM "hive"."ibis_sf1"."customer" AS "t0"
       ) AS "t14"
       INNER JOIN (
         SELECT
@@ -128,7 +128,7 @@ FROM (
           "t1"."o_clerk",
           "t1"."o_shippriority",
           "t1"."o_comment"
-        FROM "orders" AS "t1"
+        FROM "hive"."ibis_sf1"."orders" AS "t1"
       ) AS "t15"
         ON "t14"."c_custkey" = "t15"."o_custkey"
       INNER JOIN (
@@ -149,7 +149,7 @@ FROM (
           "t2"."l_shipinstruct",
           "t2"."l_shipmode",
           "t2"."l_comment"
-        FROM "lineitem" AS "t2"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t2"
       ) AS "t16"
         ON "t16"."l_orderkey" = "t15"."o_orderkey"
       INNER JOIN (
@@ -161,7 +161,7 @@ FROM (
           "t3"."s_phone",
           CAST("t3"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
           "t3"."s_comment"
-        FROM "supplier" AS "t3"
+        FROM "hive"."ibis_sf1"."supplier" AS "t3"
       ) AS "t17"
         ON "t16"."l_suppkey" = "t17"."s_suppkey"
       INNER JOIN (
@@ -170,7 +170,7 @@ FROM (
           "t4"."n_name",
           "t4"."n_regionkey",
           "t4"."n_comment"
-        FROM "nation" AS "t4"
+        FROM "hive"."ibis_sf1"."nation" AS "t4"
       ) AS "t12"
         ON "t14"."c_nationkey" = "t17"."s_nationkey"
         AND "t17"."s_nationkey" = "t12"."n_nationkey"
@@ -179,7 +179,7 @@ FROM (
           "t5"."r_regionkey",
           "t5"."r_name",
           "t5"."r_comment"
-        FROM "region" AS "t5"
+        FROM "hive"."ibis_sf1"."region" AS "t5"
       ) AS "t13"
         ON "t12"."n_regionkey" = "t13"."r_regionkey"
     ) AS "t23"

--- a/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/snowflake/h06.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/snowflake/h06.sql
@@ -18,7 +18,7 @@ FROM (
     "t0"."L_SHIPINSTRUCT" AS "l_shipinstruct",
     "t0"."L_SHIPMODE" AS "l_shipmode",
     "t0"."L_COMMENT" AS "l_comment"
-  FROM "LINEITEM" AS "t0"
+  FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t0"
   WHERE
     "t0"."L_SHIPDATE" >= DATE_FROM_PARTS(1994, 1, 1)
     AND "t0"."L_SHIPDATE" < DATE_FROM_PARTS(1995, 1, 1)

--- a/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/trino/h06.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/trino/h06.sql
@@ -18,7 +18,7 @@ FROM (
     "t0"."l_shipinstruct",
     "t0"."l_shipmode",
     "t0"."l_comment"
-  FROM "lineitem" AS "t0"
+  FROM "hive"."ibis_sf1"."lineitem" AS "t0"
   WHERE
     "t0"."l_shipdate" >= FROM_ISO8601_DATE('1994-01-01')
     AND "t0"."l_shipdate" < FROM_ISO8601_DATE('1995-01-01')

--- a/ibis/backends/tests/tpch/snapshots/test_h07/test_tpc_h07/snowflake/h07.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h07/test_tpc_h07/snowflake/h07.sql
@@ -38,7 +38,7 @@ FROM (
           "t0"."S_PHONE" AS "s_phone",
           "t0"."S_ACCTBAL" AS "s_acctbal",
           "t0"."S_COMMENT" AS "s_comment"
-        FROM "SUPPLIER" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t0"
       ) AS "t10"
       INNER JOIN (
         SELECT
@@ -58,7 +58,7 @@ FROM (
           "t1"."L_SHIPINSTRUCT" AS "l_shipinstruct",
           "t1"."L_SHIPMODE" AS "l_shipmode",
           "t1"."L_COMMENT" AS "l_comment"
-        FROM "LINEITEM" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t1"
       ) AS "t11"
         ON "t10"."s_suppkey" = "t11"."l_suppkey"
       INNER JOIN (
@@ -72,7 +72,7 @@ FROM (
           "t2"."O_CLERK" AS "o_clerk",
           "t2"."O_SHIPPRIORITY" AS "o_shippriority",
           "t2"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t2"
       ) AS "t12"
         ON "t12"."o_orderkey" = "t11"."l_orderkey"
       INNER JOIN (
@@ -85,7 +85,7 @@ FROM (
           "t3"."C_ACCTBAL" AS "c_acctbal",
           "t3"."C_MKTSEGMENT" AS "c_mktsegment",
           "t3"."C_COMMENT" AS "c_comment"
-        FROM "CUSTOMER" AS "t3"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."CUSTOMER" AS "t3"
       ) AS "t13"
         ON "t13"."c_custkey" = "t12"."o_custkey"
       INNER JOIN (
@@ -94,7 +94,7 @@ FROM (
           "t4"."N_NAME" AS "n_name",
           "t4"."N_REGIONKEY" AS "n_regionkey",
           "t4"."N_COMMENT" AS "n_comment"
-        FROM "NATION" AS "t4"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t4"
       ) AS "t14"
         ON "t10"."s_nationkey" = "t14"."n_nationkey"
       INNER JOIN (
@@ -103,7 +103,7 @@ FROM (
           "t4"."N_NAME" AS "n_name",
           "t4"."N_REGIONKEY" AS "n_regionkey",
           "t4"."N_COMMENT" AS "n_comment"
-        FROM "NATION" AS "t4"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t4"
       ) AS "t16"
         ON "t13"."c_nationkey" = "t16"."n_nationkey"
     ) AS "t22"

--- a/ibis/backends/tests/tpch/snapshots/test_h07/test_tpc_h07/trino/h07.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h07/test_tpc_h07/trino/h07.sql
@@ -38,7 +38,7 @@ FROM (
           "t0"."s_phone",
           CAST("t0"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
           "t0"."s_comment"
-        FROM "supplier" AS "t0"
+        FROM "hive"."ibis_sf1"."supplier" AS "t0"
       ) AS "t12"
       INNER JOIN (
         SELECT
@@ -58,7 +58,7 @@ FROM (
           "t1"."l_shipinstruct",
           "t1"."l_shipmode",
           "t1"."l_comment"
-        FROM "lineitem" AS "t1"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t1"
       ) AS "t13"
         ON "t12"."s_suppkey" = "t13"."l_suppkey"
       INNER JOIN (
@@ -72,7 +72,7 @@ FROM (
           "t2"."o_clerk",
           "t2"."o_shippriority",
           "t2"."o_comment"
-        FROM "orders" AS "t2"
+        FROM "hive"."ibis_sf1"."orders" AS "t2"
       ) AS "t14"
         ON "t14"."o_orderkey" = "t13"."l_orderkey"
       INNER JOIN (
@@ -85,7 +85,7 @@ FROM (
           CAST("t3"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
           "t3"."c_mktsegment",
           "t3"."c_comment"
-        FROM "customer" AS "t3"
+        FROM "hive"."ibis_sf1"."customer" AS "t3"
       ) AS "t15"
         ON "t15"."c_custkey" = "t14"."o_custkey"
       INNER JOIN (
@@ -94,7 +94,7 @@ FROM (
           "t4"."n_name",
           "t4"."n_regionkey",
           "t4"."n_comment"
-        FROM "nation" AS "t4"
+        FROM "hive"."ibis_sf1"."nation" AS "t4"
       ) AS "t10"
         ON "t12"."s_nationkey" = "t10"."n_nationkey"
       INNER JOIN (
@@ -103,7 +103,7 @@ FROM (
           "t4"."n_name",
           "t4"."n_regionkey",
           "t4"."n_comment"
-        FROM "nation" AS "t4"
+        FROM "hive"."ibis_sf1"."nation" AS "t4"
       ) AS "t16"
         ON "t15"."c_nationkey" = "t16"."n_nationkey"
     ) AS "t22"

--- a/ibis/backends/tests/tpch/snapshots/test_h08/test_tpc_h08/snowflake/h08.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h08/test_tpc_h08/snowflake/h08.sql
@@ -35,7 +35,7 @@ FROM (
           "t0"."P_CONTAINER" AS "p_container",
           "t0"."P_RETAILPRICE" AS "p_retailprice",
           "t0"."P_COMMENT" AS "p_comment"
-        FROM "PART" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PART" AS "t0"
       ) AS "t14"
       INNER JOIN (
         SELECT
@@ -55,7 +55,7 @@ FROM (
           "t1"."L_SHIPINSTRUCT" AS "l_shipinstruct",
           "t1"."L_SHIPMODE" AS "l_shipmode",
           "t1"."L_COMMENT" AS "l_comment"
-        FROM "LINEITEM" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t1"
       ) AS "t15"
         ON "t14"."p_partkey" = "t15"."l_partkey"
       INNER JOIN (
@@ -67,7 +67,7 @@ FROM (
           "t2"."S_PHONE" AS "s_phone",
           "t2"."S_ACCTBAL" AS "s_acctbal",
           "t2"."S_COMMENT" AS "s_comment"
-        FROM "SUPPLIER" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t2"
       ) AS "t16"
         ON "t16"."s_suppkey" = "t15"."l_suppkey"
       INNER JOIN (
@@ -81,7 +81,7 @@ FROM (
           "t3"."O_CLERK" AS "o_clerk",
           "t3"."O_SHIPPRIORITY" AS "o_shippriority",
           "t3"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t3"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t3"
       ) AS "t17"
         ON "t15"."l_orderkey" = "t17"."o_orderkey"
       INNER JOIN (
@@ -94,7 +94,7 @@ FROM (
           "t4"."C_ACCTBAL" AS "c_acctbal",
           "t4"."C_MKTSEGMENT" AS "c_mktsegment",
           "t4"."C_COMMENT" AS "c_comment"
-        FROM "CUSTOMER" AS "t4"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."CUSTOMER" AS "t4"
       ) AS "t18"
         ON "t17"."o_custkey" = "t18"."c_custkey"
       INNER JOIN (
@@ -103,7 +103,7 @@ FROM (
           "t5"."N_NAME" AS "n_name",
           "t5"."N_REGIONKEY" AS "n_regionkey",
           "t5"."N_COMMENT" AS "n_comment"
-        FROM "NATION" AS "t5"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t5"
       ) AS "t19"
         ON "t18"."c_nationkey" = "t19"."n_nationkey"
       INNER JOIN (
@@ -111,7 +111,7 @@ FROM (
           "t6"."R_REGIONKEY" AS "r_regionkey",
           "t6"."R_NAME" AS "r_name",
           "t6"."R_COMMENT" AS "r_comment"
-        FROM "REGION" AS "t6"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."REGION" AS "t6"
       ) AS "t21"
         ON "t19"."n_regionkey" = "t21"."r_regionkey"
       INNER JOIN (
@@ -120,7 +120,7 @@ FROM (
           "t5"."N_NAME" AS "n_name",
           "t5"."N_REGIONKEY" AS "n_regionkey",
           "t5"."N_COMMENT" AS "n_comment"
-        FROM "NATION" AS "t5"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t5"
       ) AS "t22"
         ON "t16"."s_nationkey" = "t22"."n_nationkey"
     ) AS "t30"

--- a/ibis/backends/tests/tpch/snapshots/test_h08/test_tpc_h08/trino/h08.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h08/test_tpc_h08/trino/h08.sql
@@ -35,7 +35,7 @@ FROM (
           "t0"."p_container",
           CAST("t0"."p_retailprice" AS DECIMAL(15, 2)) AS "p_retailprice",
           "t0"."p_comment"
-        FROM "part" AS "t0"
+        FROM "hive"."ibis_sf1"."part" AS "t0"
       ) AS "t17"
       INNER JOIN (
         SELECT
@@ -55,7 +55,7 @@ FROM (
           "t1"."l_shipinstruct",
           "t1"."l_shipmode",
           "t1"."l_comment"
-        FROM "lineitem" AS "t1"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t1"
       ) AS "t18"
         ON "t17"."p_partkey" = "t18"."l_partkey"
       INNER JOIN (
@@ -67,7 +67,7 @@ FROM (
           "t2"."s_phone",
           CAST("t2"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
           "t2"."s_comment"
-        FROM "supplier" AS "t2"
+        FROM "hive"."ibis_sf1"."supplier" AS "t2"
       ) AS "t19"
         ON "t19"."s_suppkey" = "t18"."l_suppkey"
       INNER JOIN (
@@ -81,7 +81,7 @@ FROM (
           "t3"."o_clerk",
           "t3"."o_shippriority",
           "t3"."o_comment"
-        FROM "orders" AS "t3"
+        FROM "hive"."ibis_sf1"."orders" AS "t3"
       ) AS "t20"
         ON "t18"."l_orderkey" = "t20"."o_orderkey"
       INNER JOIN (
@@ -94,7 +94,7 @@ FROM (
           CAST("t4"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
           "t4"."c_mktsegment",
           "t4"."c_comment"
-        FROM "customer" AS "t4"
+        FROM "hive"."ibis_sf1"."customer" AS "t4"
       ) AS "t21"
         ON "t20"."o_custkey" = "t21"."c_custkey"
       INNER JOIN (
@@ -103,7 +103,7 @@ FROM (
           "t5"."n_name",
           "t5"."n_regionkey",
           "t5"."n_comment"
-        FROM "nation" AS "t5"
+        FROM "hive"."ibis_sf1"."nation" AS "t5"
       ) AS "t14"
         ON "t21"."c_nationkey" = "t14"."n_nationkey"
       INNER JOIN (
@@ -111,7 +111,7 @@ FROM (
           "t6"."r_regionkey",
           "t6"."r_name",
           "t6"."r_comment"
-        FROM "region" AS "t6"
+        FROM "hive"."ibis_sf1"."region" AS "t6"
       ) AS "t16"
         ON "t14"."n_regionkey" = "t16"."r_regionkey"
       INNER JOIN (
@@ -120,7 +120,7 @@ FROM (
           "t5"."n_name",
           "t5"."n_regionkey",
           "t5"."n_comment"
-        FROM "nation" AS "t5"
+        FROM "hive"."ibis_sf1"."nation" AS "t5"
       ) AS "t22"
         ON "t19"."s_nationkey" = "t22"."n_nationkey"
     ) AS "t30"

--- a/ibis/backends/tests/tpch/snapshots/test_h09/test_tpc_h09/snowflake/h09.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h09/test_tpc_h09/snowflake/h09.sql
@@ -43,7 +43,7 @@ FROM (
           "t0"."L_SHIPINSTRUCT" AS "l_shipinstruct",
           "t0"."L_SHIPMODE" AS "l_shipmode",
           "t0"."L_COMMENT" AS "l_comment"
-        FROM "LINEITEM" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t0"
       ) AS "t12"
       INNER JOIN (
         SELECT
@@ -54,7 +54,7 @@ FROM (
           "t1"."S_PHONE" AS "s_phone",
           "t1"."S_ACCTBAL" AS "s_acctbal",
           "t1"."S_COMMENT" AS "s_comment"
-        FROM "SUPPLIER" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t1"
       ) AS "t13"
         ON "t13"."s_suppkey" = "t12"."l_suppkey"
       INNER JOIN (
@@ -64,7 +64,7 @@ FROM (
           "t2"."PS_AVAILQTY" AS "ps_availqty",
           "t2"."PS_SUPPLYCOST" AS "ps_supplycost",
           "t2"."PS_COMMENT" AS "ps_comment"
-        FROM "PARTSUPP" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PARTSUPP" AS "t2"
       ) AS "t14"
         ON "t14"."ps_suppkey" = "t12"."l_suppkey" AND "t14"."ps_partkey" = "t12"."l_partkey"
       INNER JOIN (
@@ -78,7 +78,7 @@ FROM (
           "t3"."P_CONTAINER" AS "p_container",
           "t3"."P_RETAILPRICE" AS "p_retailprice",
           "t3"."P_COMMENT" AS "p_comment"
-        FROM "PART" AS "t3"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PART" AS "t3"
       ) AS "t15"
         ON "t15"."p_partkey" = "t12"."l_partkey"
       INNER JOIN (
@@ -92,7 +92,7 @@ FROM (
           "t4"."O_CLERK" AS "o_clerk",
           "t4"."O_SHIPPRIORITY" AS "o_shippriority",
           "t4"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t4"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t4"
       ) AS "t16"
         ON "t16"."o_orderkey" = "t12"."l_orderkey"
       INNER JOIN (
@@ -101,7 +101,7 @@ FROM (
           "t5"."N_NAME" AS "n_name",
           "t5"."N_REGIONKEY" AS "n_regionkey",
           "t5"."N_COMMENT" AS "n_comment"
-        FROM "NATION" AS "t5"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t5"
       ) AS "t17"
         ON "t13"."s_nationkey" = "t17"."n_nationkey"
     ) AS "t23"

--- a/ibis/backends/tests/tpch/snapshots/test_h09/test_tpc_h09/trino/h09.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h09/test_tpc_h09/trino/h09.sql
@@ -43,7 +43,7 @@ FROM (
           "t0"."l_shipinstruct",
           "t0"."l_shipmode",
           "t0"."l_comment"
-        FROM "lineitem" AS "t0"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t0"
       ) AS "t13"
       INNER JOIN (
         SELECT
@@ -54,7 +54,7 @@ FROM (
           "t1"."s_phone",
           CAST("t1"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
           "t1"."s_comment"
-        FROM "supplier" AS "t1"
+        FROM "hive"."ibis_sf1"."supplier" AS "t1"
       ) AS "t14"
         ON "t14"."s_suppkey" = "t13"."l_suppkey"
       INNER JOIN (
@@ -64,7 +64,7 @@ FROM (
           "t2"."ps_availqty",
           CAST("t2"."ps_supplycost" AS DECIMAL(15, 2)) AS "ps_supplycost",
           "t2"."ps_comment"
-        FROM "partsupp" AS "t2"
+        FROM "hive"."ibis_sf1"."partsupp" AS "t2"
       ) AS "t15"
         ON "t15"."ps_suppkey" = "t13"."l_suppkey" AND "t15"."ps_partkey" = "t13"."l_partkey"
       INNER JOIN (
@@ -78,7 +78,7 @@ FROM (
           "t3"."p_container",
           CAST("t3"."p_retailprice" AS DECIMAL(15, 2)) AS "p_retailprice",
           "t3"."p_comment"
-        FROM "part" AS "t3"
+        FROM "hive"."ibis_sf1"."part" AS "t3"
       ) AS "t16"
         ON "t16"."p_partkey" = "t13"."l_partkey"
       INNER JOIN (
@@ -92,7 +92,7 @@ FROM (
           "t4"."o_clerk",
           "t4"."o_shippriority",
           "t4"."o_comment"
-        FROM "orders" AS "t4"
+        FROM "hive"."ibis_sf1"."orders" AS "t4"
       ) AS "t17"
         ON "t17"."o_orderkey" = "t13"."l_orderkey"
       INNER JOIN (
@@ -101,7 +101,7 @@ FROM (
           "t5"."n_name",
           "t5"."n_regionkey",
           "t5"."n_comment"
-        FROM "nation" AS "t5"
+        FROM "hive"."ibis_sf1"."nation" AS "t5"
       ) AS "t12"
         ON "t14"."s_nationkey" = "t12"."n_nationkey"
     ) AS "t23"

--- a/ibis/backends/tests/tpch/snapshots/test_h10/test_tpc_h10/snowflake/h10.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h10/test_tpc_h10/snowflake/h10.sql
@@ -107,7 +107,7 @@ FROM (
           "t0"."C_ACCTBAL" AS "c_acctbal",
           "t0"."C_MKTSEGMENT" AS "c_mktsegment",
           "t0"."C_COMMENT" AS "c_comment"
-        FROM "CUSTOMER" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."CUSTOMER" AS "t0"
       ) AS "t8"
       INNER JOIN (
         SELECT
@@ -120,7 +120,7 @@ FROM (
           "t1"."O_CLERK" AS "o_clerk",
           "t1"."O_SHIPPRIORITY" AS "o_shippriority",
           "t1"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t1"
       ) AS "t9"
         ON "t8"."c_custkey" = "t9"."o_custkey"
       INNER JOIN (
@@ -141,7 +141,7 @@ FROM (
           "t2"."L_SHIPINSTRUCT" AS "l_shipinstruct",
           "t2"."L_SHIPMODE" AS "l_shipmode",
           "t2"."L_COMMENT" AS "l_comment"
-        FROM "LINEITEM" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t2"
       ) AS "t10"
         ON "t10"."l_orderkey" = "t9"."o_orderkey"
       INNER JOIN (
@@ -150,7 +150,7 @@ FROM (
           "t3"."N_NAME" AS "n_name",
           "t3"."N_REGIONKEY" AS "n_regionkey",
           "t3"."N_COMMENT" AS "n_comment"
-        FROM "NATION" AS "t3"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t3"
       ) AS "t11"
         ON "t8"."c_nationkey" = "t11"."n_nationkey"
     ) AS "t15"

--- a/ibis/backends/tests/tpch/snapshots/test_h10/test_tpc_h10/trino/h10.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h10/test_tpc_h10/trino/h10.sql
@@ -107,7 +107,7 @@ FROM (
           CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
           "t0"."c_mktsegment",
           "t0"."c_comment"
-        FROM "customer" AS "t0"
+        FROM "hive"."ibis_sf1"."customer" AS "t0"
       ) AS "t9"
       INNER JOIN (
         SELECT
@@ -120,7 +120,7 @@ FROM (
           "t1"."o_clerk",
           "t1"."o_shippriority",
           "t1"."o_comment"
-        FROM "orders" AS "t1"
+        FROM "hive"."ibis_sf1"."orders" AS "t1"
       ) AS "t10"
         ON "t9"."c_custkey" = "t10"."o_custkey"
       INNER JOIN (
@@ -141,7 +141,7 @@ FROM (
           "t2"."l_shipinstruct",
           "t2"."l_shipmode",
           "t2"."l_comment"
-        FROM "lineitem" AS "t2"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t2"
       ) AS "t11"
         ON "t11"."l_orderkey" = "t10"."o_orderkey"
       INNER JOIN (
@@ -150,7 +150,7 @@ FROM (
           "t3"."n_name",
           "t3"."n_regionkey",
           "t3"."n_comment"
-        FROM "nation" AS "t3"
+        FROM "hive"."ibis_sf1"."nation" AS "t3"
       ) AS "t8"
         ON "t9"."c_nationkey" = "t8"."n_nationkey"
     ) AS "t15"

--- a/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/snowflake/h11.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/snowflake/h11.sql
@@ -48,7 +48,7 @@ FROM (
           "t0"."PS_AVAILQTY" AS "ps_availqty",
           "t0"."PS_SUPPLYCOST" AS "ps_supplycost",
           "t0"."PS_COMMENT" AS "ps_comment"
-        FROM "PARTSUPP" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PARTSUPP" AS "t0"
       ) AS "t6"
       INNER JOIN (
         SELECT
@@ -59,7 +59,7 @@ FROM (
           "t1"."S_PHONE" AS "s_phone",
           "t1"."S_ACCTBAL" AS "s_acctbal",
           "t1"."S_COMMENT" AS "s_comment"
-        FROM "SUPPLIER" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t1"
       ) AS "t7"
         ON "t6"."ps_suppkey" = "t7"."s_suppkey"
       INNER JOIN (
@@ -68,7 +68,7 @@ FROM (
           "t2"."N_NAME" AS "n_name",
           "t2"."N_REGIONKEY" AS "n_regionkey",
           "t2"."N_COMMENT" AS "n_comment"
-        FROM "NATION" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t2"
       ) AS "t8"
         ON "t8"."n_nationkey" = "t7"."s_nationkey"
     ) AS "t11"
@@ -126,7 +126,7 @@ WHERE
               "t0"."PS_AVAILQTY" AS "ps_availqty",
               "t0"."PS_SUPPLYCOST" AS "ps_supplycost",
               "t0"."PS_COMMENT" AS "ps_comment"
-            FROM "PARTSUPP" AS "t0"
+            FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PARTSUPP" AS "t0"
           ) AS "t6"
           INNER JOIN (
             SELECT
@@ -137,7 +137,7 @@ WHERE
               "t1"."S_PHONE" AS "s_phone",
               "t1"."S_ACCTBAL" AS "s_acctbal",
               "t1"."S_COMMENT" AS "s_comment"
-            FROM "SUPPLIER" AS "t1"
+            FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t1"
           ) AS "t7"
             ON "t6"."ps_suppkey" = "t7"."s_suppkey"
           INNER JOIN (
@@ -146,7 +146,7 @@ WHERE
               "t2"."N_NAME" AS "n_name",
               "t2"."N_REGIONKEY" AS "n_regionkey",
               "t2"."N_COMMENT" AS "n_comment"
-            FROM "NATION" AS "t2"
+            FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t2"
           ) AS "t8"
             ON "t8"."n_nationkey" = "t7"."s_nationkey"
         ) AS "t11"

--- a/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/trino/h11.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/trino/h11.sql
@@ -48,7 +48,7 @@ FROM (
           "t0"."ps_availqty",
           CAST("t0"."ps_supplycost" AS DECIMAL(15, 2)) AS "ps_supplycost",
           "t0"."ps_comment"
-        FROM "partsupp" AS "t0"
+        FROM "hive"."ibis_sf1"."partsupp" AS "t0"
       ) AS "t7"
       INNER JOIN (
         SELECT
@@ -59,7 +59,7 @@ FROM (
           "t1"."s_phone",
           CAST("t1"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
           "t1"."s_comment"
-        FROM "supplier" AS "t1"
+        FROM "hive"."ibis_sf1"."supplier" AS "t1"
       ) AS "t8"
         ON "t7"."ps_suppkey" = "t8"."s_suppkey"
       INNER JOIN (
@@ -68,7 +68,7 @@ FROM (
           "t2"."n_name",
           "t2"."n_regionkey",
           "t2"."n_comment"
-        FROM "nation" AS "t2"
+        FROM "hive"."ibis_sf1"."nation" AS "t2"
       ) AS "t6"
         ON "t6"."n_nationkey" = "t8"."s_nationkey"
     ) AS "t11"
@@ -126,7 +126,7 @@ WHERE
               "t0"."ps_availqty",
               CAST("t0"."ps_supplycost" AS DECIMAL(15, 2)) AS "ps_supplycost",
               "t0"."ps_comment"
-            FROM "partsupp" AS "t0"
+            FROM "hive"."ibis_sf1"."partsupp" AS "t0"
           ) AS "t7"
           INNER JOIN (
             SELECT
@@ -137,7 +137,7 @@ WHERE
               "t1"."s_phone",
               CAST("t1"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
               "t1"."s_comment"
-            FROM "supplier" AS "t1"
+            FROM "hive"."ibis_sf1"."supplier" AS "t1"
           ) AS "t8"
             ON "t7"."ps_suppkey" = "t8"."s_suppkey"
           INNER JOIN (
@@ -146,7 +146,7 @@ WHERE
               "t2"."n_name",
               "t2"."n_regionkey",
               "t2"."n_comment"
-            FROM "nation" AS "t2"
+            FROM "hive"."ibis_sf1"."nation" AS "t2"
           ) AS "t6"
             ON "t6"."n_nationkey" = "t8"."s_nationkey"
         ) AS "t11"

--- a/ibis/backends/tests/tpch/snapshots/test_h12/test_tpc_h12/snowflake/h12.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h12/test_tpc_h12/snowflake/h12.sql
@@ -76,7 +76,7 @@ FROM (
           "t0"."O_CLERK" AS "o_clerk",
           "t0"."O_SHIPPRIORITY" AS "o_shippriority",
           "t0"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t0"
       ) AS "t4"
       INNER JOIN (
         SELECT
@@ -96,7 +96,7 @@ FROM (
           "t1"."L_SHIPINSTRUCT" AS "l_shipinstruct",
           "t1"."L_SHIPMODE" AS "l_shipmode",
           "t1"."L_COMMENT" AS "l_comment"
-        FROM "LINEITEM" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t1"
       ) AS "t5"
         ON "t4"."o_orderkey" = "t5"."l_orderkey"
     ) AS "t7"

--- a/ibis/backends/tests/tpch/snapshots/test_h12/test_tpc_h12/trino/h12.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h12/test_tpc_h12/trino/h12.sql
@@ -76,7 +76,7 @@ FROM (
           "t0"."o_clerk",
           "t0"."o_shippriority",
           "t0"."o_comment"
-        FROM "orders" AS "t0"
+        FROM "hive"."ibis_sf1"."orders" AS "t0"
       ) AS "t4"
       INNER JOIN (
         SELECT
@@ -96,7 +96,7 @@ FROM (
           "t1"."l_shipinstruct",
           "t1"."l_shipmode",
           "t1"."l_comment"
-        FROM "lineitem" AS "t1"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t1"
       ) AS "t5"
         ON "t4"."o_orderkey" = "t5"."l_orderkey"
     ) AS "t7"

--- a/ibis/backends/tests/tpch/snapshots/test_h13/test_tpc_h13/snowflake/h13.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h13/test_tpc_h13/snowflake/h13.sql
@@ -38,7 +38,7 @@ FROM (
           "t0"."C_ACCTBAL" AS "c_acctbal",
           "t0"."C_MKTSEGMENT" AS "c_mktsegment",
           "t0"."C_COMMENT" AS "c_comment"
-        FROM "CUSTOMER" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."CUSTOMER" AS "t0"
       ) AS "t4"
       LEFT OUTER JOIN (
         SELECT
@@ -51,7 +51,7 @@ FROM (
           "t1"."O_CLERK" AS "o_clerk",
           "t1"."O_SHIPPRIORITY" AS "o_shippriority",
           "t1"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t1"
       ) AS "t5"
         ON "t4"."c_custkey" = "t5"."o_custkey"
         AND NOT (

--- a/ibis/backends/tests/tpch/snapshots/test_h13/test_tpc_h13/trino/h13.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h13/test_tpc_h13/trino/h13.sql
@@ -38,7 +38,7 @@ FROM (
           CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
           "t0"."c_mktsegment",
           "t0"."c_comment"
-        FROM "customer" AS "t0"
+        FROM "hive"."ibis_sf1"."customer" AS "t0"
       ) AS "t4"
       LEFT OUTER JOIN (
         SELECT
@@ -51,7 +51,7 @@ FROM (
           "t1"."o_clerk",
           "t1"."o_shippriority",
           "t1"."o_comment"
-        FROM "orders" AS "t1"
+        FROM "hive"."ibis_sf1"."orders" AS "t1"
       ) AS "t5"
         ON "t4"."c_custkey" = "t5"."o_custkey"
         AND NOT (

--- a/ibis/backends/tests/tpch/snapshots/test_h14/test_tpc_h14/snowflake/h14.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h14/test_tpc_h14/snowflake/h14.sql
@@ -80,7 +80,7 @@ FROM (
         "t0"."L_SHIPINSTRUCT" AS "l_shipinstruct",
         "t0"."L_SHIPMODE" AS "l_shipmode",
         "t0"."L_COMMENT" AS "l_comment"
-      FROM "LINEITEM" AS "t0"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t0"
     ) AS "t4"
     INNER JOIN (
       SELECT
@@ -93,7 +93,7 @@ FROM (
         "t1"."P_CONTAINER" AS "p_container",
         "t1"."P_RETAILPRICE" AS "p_retailprice",
         "t1"."P_COMMENT" AS "p_comment"
-      FROM "PART" AS "t1"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PART" AS "t1"
     ) AS "t5"
       ON "t4"."l_partkey" = "t5"."p_partkey"
   ) AS "t7"

--- a/ibis/backends/tests/tpch/snapshots/test_h14/test_tpc_h14/trino/h14.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h14/test_tpc_h14/trino/h14.sql
@@ -80,7 +80,7 @@ FROM (
         "t0"."l_shipinstruct",
         "t0"."l_shipmode",
         "t0"."l_comment"
-      FROM "lineitem" AS "t0"
+      FROM "hive"."ibis_sf1"."lineitem" AS "t0"
     ) AS "t4"
     INNER JOIN (
       SELECT
@@ -93,7 +93,7 @@ FROM (
         "t1"."p_container",
         CAST("t1"."p_retailprice" AS DECIMAL(15, 2)) AS "p_retailprice",
         "t1"."p_comment"
-      FROM "part" AS "t1"
+      FROM "hive"."ibis_sf1"."part" AS "t1"
     ) AS "t5"
       ON "t4"."l_partkey" = "t5"."p_partkey"
   ) AS "t7"

--- a/ibis/backends/tests/tpch/snapshots/test_h15/test_tpc_h15/snowflake/h15.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h15/test_tpc_h15/snowflake/h15.sql
@@ -24,7 +24,7 @@ FROM (
       "t0"."S_PHONE" AS "s_phone",
       "t0"."S_ACCTBAL" AS "s_acctbal",
       "t0"."S_COMMENT" AS "s_comment"
-    FROM "SUPPLIER" AS "t0"
+    FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t0"
   ) AS "t3"
   INNER JOIN (
     SELECT
@@ -50,7 +50,7 @@ FROM (
         "t1"."L_SHIPINSTRUCT" AS "l_shipinstruct",
         "t1"."L_SHIPMODE" AS "l_shipmode",
         "t1"."L_COMMENT" AS "l_comment"
-      FROM "LINEITEM" AS "t1"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t1"
       WHERE
         "t1"."L_SHIPDATE" >= DATE_FROM_PARTS(1996, 1, 1)
         AND "t1"."L_SHIPDATE" < DATE_FROM_PARTS(1996, 4, 1)
@@ -84,7 +84,7 @@ WHERE
           "t0"."S_PHONE" AS "s_phone",
           "t0"."S_ACCTBAL" AS "s_acctbal",
           "t0"."S_COMMENT" AS "s_comment"
-        FROM "SUPPLIER" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t0"
       ) AS "t3"
       INNER JOIN (
         SELECT
@@ -110,7 +110,7 @@ WHERE
             "t1"."L_SHIPINSTRUCT" AS "l_shipinstruct",
             "t1"."L_SHIPMODE" AS "l_shipmode",
             "t1"."L_COMMENT" AS "l_comment"
-          FROM "LINEITEM" AS "t1"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t1"
           WHERE
             "t1"."L_SHIPDATE" >= DATE_FROM_PARTS(1996, 1, 1)
             AND "t1"."L_SHIPDATE" < DATE_FROM_PARTS(1996, 4, 1)

--- a/ibis/backends/tests/tpch/snapshots/test_h15/test_tpc_h15/trino/h15.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h15/test_tpc_h15/trino/h15.sql
@@ -24,7 +24,7 @@ FROM (
       "t0"."s_phone",
       CAST("t0"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
       "t0"."s_comment"
-    FROM "supplier" AS "t0"
+    FROM "hive"."ibis_sf1"."supplier" AS "t0"
   ) AS "t4"
   INNER JOIN (
     SELECT
@@ -50,7 +50,7 @@ FROM (
         "t1"."l_shipinstruct",
         "t1"."l_shipmode",
         "t1"."l_comment"
-      FROM "lineitem" AS "t1"
+      FROM "hive"."ibis_sf1"."lineitem" AS "t1"
       WHERE
         "t1"."l_shipdate" >= FROM_ISO8601_DATE('1996-01-01')
         AND "t1"."l_shipdate" < FROM_ISO8601_DATE('1996-04-01')
@@ -84,7 +84,7 @@ WHERE
           "t0"."s_phone",
           CAST("t0"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
           "t0"."s_comment"
-        FROM "supplier" AS "t0"
+        FROM "hive"."ibis_sf1"."supplier" AS "t0"
       ) AS "t4"
       INNER JOIN (
         SELECT
@@ -110,7 +110,7 @@ WHERE
             "t1"."l_shipinstruct",
             "t1"."l_shipmode",
             "t1"."l_comment"
-          FROM "lineitem" AS "t1"
+          FROM "hive"."ibis_sf1"."lineitem" AS "t1"
           WHERE
             "t1"."l_shipdate" >= FROM_ISO8601_DATE('1996-01-01')
             AND "t1"."l_shipdate" < FROM_ISO8601_DATE('1996-04-01')

--- a/ibis/backends/tests/tpch/snapshots/test_h16/test_tpc_h16/snowflake/h16.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h16/test_tpc_h16/snowflake/h16.sql
@@ -48,7 +48,7 @@ FROM (
           "t0"."PS_AVAILQTY" AS "ps_availqty",
           "t0"."PS_SUPPLYCOST" AS "ps_supplycost",
           "t0"."PS_COMMENT" AS "ps_comment"
-        FROM "PARTSUPP" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PARTSUPP" AS "t0"
       ) AS "t5"
       INNER JOIN (
         SELECT
@@ -61,7 +61,7 @@ FROM (
           "t2"."P_CONTAINER" AS "p_container",
           "t2"."P_RETAILPRICE" AS "p_retailprice",
           "t2"."P_COMMENT" AS "p_comment"
-        FROM "PART" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PART" AS "t2"
       ) AS "t7"
         ON "t7"."p_partkey" = "t5"."ps_partkey"
     ) AS "t9"
@@ -75,7 +75,7 @@ FROM (
         "t9"."ps_suppkey" IN (
           SELECT
             "t1"."S_SUPPKEY" AS "s_suppkey"
-          FROM "SUPPLIER" AS "t1"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t1"
           WHERE
             "t1"."S_COMMENT" LIKE '%Customer%Complaints%'
         )

--- a/ibis/backends/tests/tpch/snapshots/test_h16/test_tpc_h16/trino/h16.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h16/test_tpc_h16/trino/h16.sql
@@ -48,7 +48,7 @@ FROM (
           "t0"."ps_availqty",
           CAST("t0"."ps_supplycost" AS DECIMAL(15, 2)) AS "ps_supplycost",
           "t0"."ps_comment"
-        FROM "partsupp" AS "t0"
+        FROM "hive"."ibis_sf1"."partsupp" AS "t0"
       ) AS "t6"
       INNER JOIN (
         SELECT
@@ -61,7 +61,7 @@ FROM (
           "t2"."p_container",
           CAST("t2"."p_retailprice" AS DECIMAL(15, 2)) AS "p_retailprice",
           "t2"."p_comment"
-        FROM "part" AS "t2"
+        FROM "hive"."ibis_sf1"."part" AS "t2"
       ) AS "t7"
         ON "t7"."p_partkey" = "t6"."ps_partkey"
     ) AS "t9"
@@ -75,7 +75,7 @@ FROM (
         "t9"."ps_suppkey" IN (
           SELECT
             "t1"."s_suppkey"
-          FROM "supplier" AS "t1"
+          FROM "hive"."ibis_sf1"."supplier" AS "t1"
           WHERE
             "t1"."s_comment" LIKE '%Customer%Complaints%'
         )

--- a/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/snowflake/h17.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/snowflake/h17.sql
@@ -72,7 +72,7 @@ FROM (
         "t0"."L_SHIPINSTRUCT" AS "l_shipinstruct",
         "t0"."L_SHIPMODE" AS "l_shipmode",
         "t0"."L_COMMENT" AS "l_comment"
-      FROM "LINEITEM" AS "t0"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t0"
     ) AS "t4"
     INNER JOIN (
       SELECT
@@ -85,7 +85,7 @@ FROM (
         "t1"."P_CONTAINER" AS "p_container",
         "t1"."P_RETAILPRICE" AS "p_retailprice",
         "t1"."P_COMMENT" AS "p_comment"
-      FROM "PART" AS "t1"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PART" AS "t1"
     ) AS "t5"
       ON "t5"."p_partkey" = "t4"."l_partkey"
   ) AS "t7"
@@ -114,7 +114,7 @@ FROM (
             "t0"."L_SHIPINSTRUCT" AS "l_shipinstruct",
             "t0"."L_SHIPMODE" AS "l_shipmode",
             "t0"."L_COMMENT" AS "l_comment"
-          FROM "LINEITEM" AS "t0"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t0"
           WHERE
             "t0"."L_PARTKEY" = "t7"."p_partkey"
         ) AS "t8"

--- a/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/trino/h17.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/trino/h17.sql
@@ -72,7 +72,7 @@ FROM (
         "t0"."l_shipinstruct",
         "t0"."l_shipmode",
         "t0"."l_comment"
-      FROM "lineitem" AS "t0"
+      FROM "hive"."ibis_sf1"."lineitem" AS "t0"
     ) AS "t4"
     INNER JOIN (
       SELECT
@@ -85,7 +85,7 @@ FROM (
         "t1"."p_container",
         CAST("t1"."p_retailprice" AS DECIMAL(15, 2)) AS "p_retailprice",
         "t1"."p_comment"
-      FROM "part" AS "t1"
+      FROM "hive"."ibis_sf1"."part" AS "t1"
     ) AS "t5"
       ON "t5"."p_partkey" = "t4"."l_partkey"
   ) AS "t7"
@@ -114,7 +114,7 @@ FROM (
             "t0"."l_shipinstruct",
             "t0"."l_shipmode",
             "t0"."l_comment"
-          FROM "lineitem" AS "t0"
+          FROM "hive"."ibis_sf1"."lineitem" AS "t0"
           WHERE
             "t0"."l_partkey" = "t7"."p_partkey"
         ) AS "t8"

--- a/ibis/backends/tests/tpch/snapshots/test_h18/test_tpc_h18/snowflake/h18.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h18/test_tpc_h18/snowflake/h18.sql
@@ -93,7 +93,7 @@ FROM (
           "t0"."C_ACCTBAL" AS "c_acctbal",
           "t0"."C_MKTSEGMENT" AS "c_mktsegment",
           "t0"."C_COMMENT" AS "c_comment"
-        FROM "CUSTOMER" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."CUSTOMER" AS "t0"
       ) AS "t6"
       INNER JOIN (
         SELECT
@@ -106,7 +106,7 @@ FROM (
           "t1"."O_CLERK" AS "o_clerk",
           "t1"."O_SHIPPRIORITY" AS "o_shippriority",
           "t1"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t1"
       ) AS "t7"
         ON "t6"."c_custkey" = "t7"."o_custkey"
       INNER JOIN (
@@ -127,7 +127,7 @@ FROM (
           "t2"."L_SHIPINSTRUCT" AS "l_shipinstruct",
           "t2"."L_SHIPMODE" AS "l_shipmode",
           "t2"."L_COMMENT" AS "l_comment"
-        FROM "LINEITEM" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t2"
       ) AS "t8"
         ON "t7"."o_orderkey" = "t8"."l_orderkey"
     ) AS "t12"
@@ -157,7 +157,7 @@ FROM (
               "t2"."L_SHIPINSTRUCT" AS "l_shipinstruct",
               "t2"."L_SHIPMODE" AS "l_shipmode",
               "t2"."L_COMMENT" AS "l_comment"
-            FROM "LINEITEM" AS "t2"
+            FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t2"
           ) AS "t5"
           GROUP BY
             1

--- a/ibis/backends/tests/tpch/snapshots/test_h18/test_tpc_h18/trino/h18.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h18/test_tpc_h18/trino/h18.sql
@@ -93,7 +93,7 @@ FROM (
           CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
           "t0"."c_mktsegment",
           "t0"."c_comment"
-        FROM "customer" AS "t0"
+        FROM "hive"."ibis_sf1"."customer" AS "t0"
       ) AS "t6"
       INNER JOIN (
         SELECT
@@ -106,7 +106,7 @@ FROM (
           "t1"."o_clerk",
           "t1"."o_shippriority",
           "t1"."o_comment"
-        FROM "orders" AS "t1"
+        FROM "hive"."ibis_sf1"."orders" AS "t1"
       ) AS "t7"
         ON "t6"."c_custkey" = "t7"."o_custkey"
       INNER JOIN (
@@ -127,7 +127,7 @@ FROM (
           "t2"."l_shipinstruct",
           "t2"."l_shipmode",
           "t2"."l_comment"
-        FROM "lineitem" AS "t2"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t2"
       ) AS "t8"
         ON "t7"."o_orderkey" = "t8"."l_orderkey"
     ) AS "t12"
@@ -157,7 +157,7 @@ FROM (
               "t2"."l_shipinstruct",
               "t2"."l_shipmode",
               "t2"."l_comment"
-            FROM "lineitem" AS "t2"
+            FROM "hive"."ibis_sf1"."lineitem" AS "t2"
           ) AS "t5"
           GROUP BY
             1

--- a/ibis/backends/tests/tpch/snapshots/test_h19/test_tpc_h19/snowflake/h19.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h19/test_tpc_h19/snowflake/h19.sql
@@ -74,7 +74,7 @@ FROM (
         "t0"."L_SHIPINSTRUCT" AS "l_shipinstruct",
         "t0"."L_SHIPMODE" AS "l_shipmode",
         "t0"."L_COMMENT" AS "l_comment"
-      FROM "LINEITEM" AS "t0"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t0"
     ) AS "t4"
     INNER JOIN (
       SELECT
@@ -87,7 +87,7 @@ FROM (
         "t1"."P_CONTAINER" AS "p_container",
         "t1"."P_RETAILPRICE" AS "p_retailprice",
         "t1"."P_COMMENT" AS "p_comment"
-      FROM "PART" AS "t1"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PART" AS "t1"
     ) AS "t5"
       ON "t5"."p_partkey" = "t4"."l_partkey"
   ) AS "t7"

--- a/ibis/backends/tests/tpch/snapshots/test_h19/test_tpc_h19/trino/h19.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h19/test_tpc_h19/trino/h19.sql
@@ -74,7 +74,7 @@ FROM (
         "t0"."l_shipinstruct",
         "t0"."l_shipmode",
         "t0"."l_comment"
-      FROM "lineitem" AS "t0"
+      FROM "hive"."ibis_sf1"."lineitem" AS "t0"
     ) AS "t4"
     INNER JOIN (
       SELECT
@@ -87,7 +87,7 @@ FROM (
         "t1"."p_container",
         CAST("t1"."p_retailprice" AS DECIMAL(15, 2)) AS "p_retailprice",
         "t1"."p_comment"
-      FROM "part" AS "t1"
+      FROM "hive"."ibis_sf1"."part" AS "t1"
     ) AS "t5"
       ON "t5"."p_partkey" = "t4"."l_partkey"
   ) AS "t7"

--- a/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/snowflake/h20.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/snowflake/h20.sql
@@ -23,7 +23,7 @@ FROM (
       "t0"."S_PHONE" AS "s_phone",
       "t0"."S_ACCTBAL" AS "s_acctbal",
       "t0"."S_COMMENT" AS "s_comment"
-    FROM "SUPPLIER" AS "t0"
+    FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t0"
   ) AS "t8"
   INNER JOIN (
     SELECT
@@ -31,7 +31,7 @@ FROM (
       "t2"."N_NAME" AS "n_name",
       "t2"."N_REGIONKEY" AS "n_regionkey",
       "t2"."N_COMMENT" AS "n_comment"
-    FROM "NATION" AS "t2"
+    FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t2"
   ) AS "t9"
     ON "t8"."s_nationkey" = "t9"."n_nationkey"
 ) AS "t13"
@@ -47,13 +47,13 @@ WHERE
         "t1"."PS_AVAILQTY" AS "ps_availqty",
         "t1"."PS_SUPPLYCOST" AS "ps_supplycost",
         "t1"."PS_COMMENT" AS "ps_comment"
-      FROM "PARTSUPP" AS "t1"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PARTSUPP" AS "t1"
     ) AS "t6"
     WHERE
       "t6"."ps_partkey" IN (
         SELECT
           "t3"."P_PARTKEY" AS "p_partkey"
-        FROM "PART" AS "t3"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."PART" AS "t3"
         WHERE
           "t3"."P_NAME" LIKE 'forest%'
       )
@@ -79,7 +79,7 @@ WHERE
               "t4"."L_SHIPINSTRUCT" AS "l_shipinstruct",
               "t4"."L_SHIPMODE" AS "l_shipmode",
               "t4"."L_COMMENT" AS "l_comment"
-            FROM "LINEITEM" AS "t4"
+            FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t4"
             WHERE
               "t4"."L_PARTKEY" = "t6"."ps_partkey"
               AND "t4"."L_SUPPKEY" = "t6"."ps_suppkey"

--- a/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/trino/h20.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/trino/h20.sql
@@ -23,7 +23,7 @@ FROM (
       "t0"."s_phone",
       CAST("t0"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
       "t0"."s_comment"
-    FROM "supplier" AS "t0"
+    FROM "hive"."ibis_sf1"."supplier" AS "t0"
   ) AS "t10"
   INNER JOIN (
     SELECT
@@ -31,7 +31,7 @@ FROM (
       "t2"."n_name",
       "t2"."n_regionkey",
       "t2"."n_comment"
-    FROM "nation" AS "t2"
+    FROM "hive"."ibis_sf1"."nation" AS "t2"
   ) AS "t8"
     ON "t10"."s_nationkey" = "t8"."n_nationkey"
 ) AS "t13"
@@ -47,13 +47,13 @@ WHERE
         "t1"."ps_availqty",
         CAST("t1"."ps_supplycost" AS DECIMAL(15, 2)) AS "ps_supplycost",
         "t1"."ps_comment"
-      FROM "partsupp" AS "t1"
+      FROM "hive"."ibis_sf1"."partsupp" AS "t1"
     ) AS "t7"
     WHERE
       "t7"."ps_partkey" IN (
         SELECT
           "t3"."p_partkey"
-        FROM "part" AS "t3"
+        FROM "hive"."ibis_sf1"."part" AS "t3"
         WHERE
           "t3"."p_name" LIKE 'forest%'
       )
@@ -79,7 +79,7 @@ WHERE
               "t4"."l_shipinstruct",
               "t4"."l_shipmode",
               "t4"."l_comment"
-            FROM "lineitem" AS "t4"
+            FROM "hive"."ibis_sf1"."lineitem" AS "t4"
             WHERE
               "t4"."l_partkey" = "t7"."ps_partkey"
               AND "t4"."l_suppkey" = "t7"."ps_suppkey"

--- a/ibis/backends/tests/tpch/snapshots/test_h21/test_tpc_h21/snowflake/h21.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h21/test_tpc_h21/snowflake/h21.sql
@@ -32,7 +32,7 @@ FROM (
           "t0"."S_PHONE" AS "s_phone",
           "t0"."S_ACCTBAL" AS "s_acctbal",
           "t0"."S_COMMENT" AS "s_comment"
-        FROM "SUPPLIER" AS "t0"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."SUPPLIER" AS "t0"
       ) AS "t8"
       INNER JOIN (
         SELECT
@@ -52,7 +52,7 @@ FROM (
           "t1"."L_SHIPINSTRUCT" AS "l_shipinstruct",
           "t1"."L_SHIPMODE" AS "l_shipmode",
           "t1"."L_COMMENT" AS "l_comment"
-        FROM "LINEITEM" AS "t1"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t1"
       ) AS "t9"
         ON "t8"."s_suppkey" = "t9"."l_suppkey"
       INNER JOIN (
@@ -66,7 +66,7 @@ FROM (
           "t2"."O_CLERK" AS "o_clerk",
           "t2"."O_SHIPPRIORITY" AS "o_shippriority",
           "t2"."O_COMMENT" AS "o_comment"
-        FROM "ORDERS" AS "t2"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t2"
       ) AS "t12"
         ON "t12"."o_orderkey" = "t9"."l_orderkey"
       INNER JOIN (
@@ -75,7 +75,7 @@ FROM (
           "t3"."N_NAME" AS "n_name",
           "t3"."N_REGIONKEY" AS "n_regionkey",
           "t3"."N_COMMENT" AS "n_comment"
-        FROM "NATION" AS "t3"
+        FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."NATION" AS "t3"
       ) AS "t13"
         ON "t8"."s_nationkey" = "t13"."n_nationkey"
     ) AS "t17"
@@ -104,7 +104,7 @@ FROM (
             "t1"."L_SHIPINSTRUCT" AS "l_shipinstruct",
             "t1"."L_SHIPMODE" AS "l_shipmode",
             "t1"."L_COMMENT" AS "l_comment"
-          FROM "LINEITEM" AS "t1"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t1"
         ) AS "t10"
         WHERE
           (
@@ -136,7 +136,7 @@ FROM (
               "t1"."L_SHIPINSTRUCT" AS "l_shipinstruct",
               "t1"."L_SHIPMODE" AS "l_shipmode",
               "t1"."L_COMMENT" AS "l_comment"
-            FROM "LINEITEM" AS "t1"
+            FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."LINEITEM" AS "t1"
           ) AS "t11"
           WHERE
             (

--- a/ibis/backends/tests/tpch/snapshots/test_h21/test_tpc_h21/trino/h21.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h21/test_tpc_h21/trino/h21.sql
@@ -32,7 +32,7 @@ FROM (
           "t0"."s_phone",
           CAST("t0"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
           "t0"."s_comment"
-        FROM "supplier" AS "t0"
+        FROM "hive"."ibis_sf1"."supplier" AS "t0"
       ) AS "t9"
       INNER JOIN (
         SELECT
@@ -52,7 +52,7 @@ FROM (
           "t1"."l_shipinstruct",
           "t1"."l_shipmode",
           "t1"."l_comment"
-        FROM "lineitem" AS "t1"
+        FROM "hive"."ibis_sf1"."lineitem" AS "t1"
       ) AS "t10"
         ON "t9"."s_suppkey" = "t10"."l_suppkey"
       INNER JOIN (
@@ -66,7 +66,7 @@ FROM (
           "t2"."o_clerk",
           "t2"."o_shippriority",
           "t2"."o_comment"
-        FROM "orders" AS "t2"
+        FROM "hive"."ibis_sf1"."orders" AS "t2"
       ) AS "t13"
         ON "t13"."o_orderkey" = "t10"."l_orderkey"
       INNER JOIN (
@@ -75,7 +75,7 @@ FROM (
           "t3"."n_name",
           "t3"."n_regionkey",
           "t3"."n_comment"
-        FROM "nation" AS "t3"
+        FROM "hive"."ibis_sf1"."nation" AS "t3"
       ) AS "t8"
         ON "t9"."s_nationkey" = "t8"."n_nationkey"
     ) AS "t17"
@@ -104,7 +104,7 @@ FROM (
             "t1"."l_shipinstruct",
             "t1"."l_shipmode",
             "t1"."l_comment"
-          FROM "lineitem" AS "t1"
+          FROM "hive"."ibis_sf1"."lineitem" AS "t1"
         ) AS "t11"
         WHERE
           (
@@ -136,7 +136,7 @@ FROM (
               "t1"."l_shipinstruct",
               "t1"."l_shipmode",
               "t1"."l_comment"
-            FROM "lineitem" AS "t1"
+            FROM "hive"."ibis_sf1"."lineitem" AS "t1"
           ) AS "t12"
           WHERE
             (

--- a/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/snowflake/h22.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/snowflake/h22.sql
@@ -27,7 +27,7 @@ FROM (
         "t0"."C_ACCTBAL" AS "c_acctbal",
         "t0"."C_MKTSEGMENT" AS "c_mktsegment",
         "t0"."C_COMMENT" AS "c_comment"
-      FROM "CUSTOMER" AS "t0"
+      FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."CUSTOMER" AS "t0"
     ) AS "t2"
     WHERE
       IFF(
@@ -50,7 +50,7 @@ FROM (
             "t0"."C_ACCTBAL" AS "c_acctbal",
             "t0"."C_MKTSEGMENT" AS "c_mktsegment",
             "t0"."C_COMMENT" AS "c_comment"
-          FROM "CUSTOMER" AS "t0"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."CUSTOMER" AS "t0"
           WHERE
             "t0"."C_ACCTBAL" > 0.0
             AND IFF(
@@ -66,7 +66,7 @@ FROM (
         EXISTS(
           SELECT
             1 AS "1"
-          FROM "ORDERS" AS "t1"
+          FROM "SNOWFLAKE_SAMPLE_DATA"."TPCH_SF1"."ORDERS" AS "t1"
           WHERE
             "t1"."O_CUSTKEY" = "t2"."c_custkey"
         )

--- a/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/trino/h22.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/trino/h22.sql
@@ -27,7 +27,7 @@ FROM (
         CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
         "t0"."c_mktsegment",
         "t0"."c_comment"
-      FROM "customer" AS "t0"
+      FROM "hive"."ibis_sf1"."customer" AS "t0"
     ) AS "t2"
     WHERE
       IF(
@@ -50,7 +50,7 @@ FROM (
             CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
             "t0"."c_mktsegment",
             "t0"."c_comment"
-          FROM "customer" AS "t0"
+          FROM "hive"."ibis_sf1"."customer" AS "t0"
           WHERE
             CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) > CAST(0.0 AS DOUBLE)
             AND IF(
@@ -66,7 +66,7 @@ FROM (
         EXISTS(
           SELECT
             1 AS "1"
-          FROM "orders" AS "t1"
+          FROM "hive"."ibis_sf1"."orders" AS "t1"
           WHERE
             "t1"."o_custkey" = "t2"."c_custkey"
         )

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -372,14 +372,15 @@ class PhysicalTable(Relation):
 
 
 @public
-class UnboundTable(PhysicalTable):
-    schema: Schema
-
-
-@public
 class Namespace(Concrete):
     database: Optional[str] = None
     schema: Optional[str] = None
+
+
+@public
+class UnboundTable(PhysicalTable):
+    schema: Schema
+    namespace: Namespace = Namespace()
 
 
 @public

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -593,7 +593,9 @@ class Expr(Immutable, Coercible):
         from ibis.expr.analysis import p, c
         from ibis.common.deferred import _
 
-        rule = p.DatabaseTable >> c.UnboundTable(name=_.name, schema=_.schema)
+        rule = p.DatabaseTable >> c.UnboundTable(
+            name=_.name, schema=_.schema, namespace=_.namespace
+        )
         return self.op().replace(rule).to_expr()
 
     def as_table(self) -> ir.Table:

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -2018,3 +2018,17 @@ def test_invalid_distinct_empty_key():
     t = ibis.table(dict(a="int", b="string"), name="t")
     with pytest.raises(com.IbisInputError):
         t.distinct(on="c", keep="first")
+
+
+def test_unbind_with_namespace():
+    schema = ibis.schema({"a": "int"})
+    ns = ops.Namespace(database="db", schema="sch")
+
+    t_op = ops.DatabaseTable(name="t", schema=schema, source=None, namespace=ns)
+    t = t_op.to_expr()
+    s = t.unbind()
+
+    expected = ops.UnboundTable(name="t", schema=schema, namespace=ns).to_expr()
+
+    assert s.op() == expected.op()
+    assert s.equals(expected)


### PR DESCRIPTION
This PR adds namespaces to unbound tables, which allows roundtripping of unbound expressions through `con.sql`. I pulled out these changes from the BigQuery sqlglot port.