### PR TITLE
refactor(sqlglot): make anonymous functions easier to use and remove `array_func` hack

### DIFF
--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -129,11 +129,9 @@ class SnowflakeCompiler(SQLGlotCompiler):
             if value.tzinfo is not None:
                 return self.f.timestamp_tz_from_parts(*args, dtype.timezone)
             else:
-                # workaround sqlglot not supporting more than 6 arguments
-                return sge.Anonymous(
-                    this=sg.to_identifier("timestamp_from_parts"),
-                    expressions=list(map(sge.convert, args)),
-                )
+                # workaround sqlglot not supporting more than 6 arguments by
+                # using an anonymous function
+                return self.f.anon.timestamp_from_parts(*args)
         elif dtype.is_time():
             nanos = value.microsecond * 1_000
             return self.f.time_from_parts(value.hour, value.minute, value.second, nanos)

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -451,7 +451,7 @@ class TrinoCompiler(SQLGlotCompiler):
     def visit_RegexpExtract(self, op, *, arg, pattern, index):
         # sqlglot doesn't support the third `group` argument for trino so work
         # around that limitation using an anonymous function
-        return sge.Anonymous(this="regexp_extract", expressions=[arg, pattern, index])
+        return self.f.anon.regexp_extract(arg, pattern, index)
 
     @visit_node.register(ops.Quantile)
     @visit_node.register(ops.MultiQuantile)


### PR DESCRIPTION
Clean up the use of anonymous functions and remove `array_func` hack in favor of `f.array`