### PR TITLE
ci(postgres): avoid pgxn due to expired certificate

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,8 +1,2 @@
 FROM postgis/postgis:15-3.3-alpine
-RUN apk add --no-cache build-base clang15 llvm15 postgresql15-plpython3 python3 py3-pip && \
-    python3 -m pip install pgxnclient && \
-    pgxn install vector && \
-    pgxn install first_last_agg && \
-    python3 -m pip uninstall -y pgxnclient && \
-    rm -rf ~/.cache/pip && \
-    apk del build-base clang15 llvm15 python3 py3-pip
+RUN apk add --no-cache postgresql15-plpython3


### PR DESCRIPTION
Fixes currently-failing CI due to an expired `pgxn` SSL certificate. I removed the usage of pgxn entirely so we hopefully never have to deal with that issue again.