### PR TITLE
refactor(sqlglot): clean up `explode` usage

### DIFF
--- a/ibis/backends/base/sqlglot/compiler.py
+++ b/ibis/backends/base/sqlglot/compiler.py
@@ -1207,10 +1207,6 @@ class SQLGlotCompiler(abc.ABC):
     def visit_SQLQueryResult(self, op, *, query, schema, source):
         return sg.parse_one(query, read=self.dialect).subquery()
 
-    @visit_node.register(ops.Unnest)
-    def visit_Unnest(self, op, *, arg):
-        return sge.Explode(this=arg)
-
     @visit_node.register(ops.JoinTable)
     def visit_JoinTable(self, op, *, parent, index):
         return parent

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -233,9 +233,7 @@ class PostgresCompiler(SQLGlotCompiler):
     @visit_node.register(ops.ArrayDistinct)
     def visit_ArrayDistinct(self, op, *, arg):
         return self.if_(
-            arg.is_(NULL),
-            NULL,
-            self.f.array(sg.select(sge.Explode(this=arg)).distinct()),
+            arg.is_(NULL), NULL, self.f.array(sg.select(self.f.explode(arg)).distinct())
         )
 
     @visit_node.register(ops.ArrayUnion)
@@ -248,7 +246,7 @@ class PostgresCompiler(SQLGlotCompiler):
     def visit_ArrayIntersect(self, op, *, left, right):
         return self.f.anon.array(
             sg.intersect(
-                sg.select(sge.Explode(this=left)), sg.select(sge.Explode(this=right))
+                sg.select(self.f.explode(left)), sg.select(self.f.explode(right))
             )
         )
 

--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -495,7 +495,7 @@ class SnowflakeCompiler(SQLGlotCompiler):
         split = self.f.split(
             self.f.array_to_string(self.f.nullif(arg, self.f.array()), sep), sep
         )
-        expr = self.f.nullif(sge.Explode(this=split), "")
+        expr = self.f.nullif(self.f.explode(split), "")
         return self.cast(expr, op.dtype)
 
     @visit_node.register(ops.Quantile)


### PR DESCRIPTION
Cleans up some redundant use of `sge.Explode`