### PR TITLE
fix(rewrite): avoid dereferencing all binary operations

### DIFF
--- a/ibis/expr/types/joins.py
+++ b/ibis/expr/types/joins.py
@@ -81,15 +81,15 @@ def dereference_sides(left, right, deref_left, deref_right):
     return left, right
 
 
-def dereference_binop(pred, deref_left, deref_right):
+def dereference_comparison_op(pred, deref_left, deref_right):
     left, right = dereference_sides(pred.left, pred.right, deref_left, deref_right)
     return pred.copy(left=left, right=right)
 
 
 def dereference_value(pred, deref_left, deref_right):
     deref_both = {**deref_left, **deref_right}
-    if isinstance(pred, ops.Binary) and pred.left.relations == pred.right.relations:
-        return dereference_binop(pred, deref_left, deref_right)
+    if isinstance(pred, ops.Comparison) and pred.left.relations == pred.right.relations:
+        return dereference_comparison_op(pred, deref_left, deref_right)
     else:
         return pred.replace(deref_both, filter=ops.Value)
 


### PR DESCRIPTION
This PR fixes an issue where predicates containing non-comparison boolean operations raised integrity errors. @kszucs Can you help clarify why this works?