### PR TITLE
ci: migrate to setup-python dependency caching

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -26,20 +26,21 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: install poetry
+        run: pipx install 'poetry==1.7.1'
+
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: "3.11"
+          cache: poetry
 
       - name: update apt-get
         run: sudo apt-get update -y -q
 
       - name: install system dependencies
         run: sudo apt-get install -y -q build-essential graphviz libgeos-dev freetds-dev unixodbc-dev
-
-      - name: install poetry
-        run: pip install 'poetry==1.7.1'
 
       - name: check consistency with pyproject.toml
         run: poetry check --lock
@@ -64,16 +65,6 @@ jobs:
 
       - name: check requirements-dev.txt
         run: git diff --exit-code requirements-dev.txt
-
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: requirements-dev.txt
-          custom_cache_key_element: check-setuptools-install
-
-      - uses: syphar/restore-pip-download-cache@v1
-        with:
-          requirement_files: requirements-dev.txt
-          custom_cache_key_element: check-setuptools-install-${{ steps.install_python.outputs.python-version }}
 
       - name: install using requirements-dev.txt
         run: pip install -r requirements-dev.txt

--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -48,24 +48,15 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: install poetry
+        run: pipx install 'poetry==1.7.1'
+
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
-
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
-
-      - name: upgrade pip and install poetry
-        run: python -m pip install --upgrade pip 'poetry==1.7.1'
-
-      - uses: syphar/restore-pip-download-cache@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
+          cache: poetry
 
       - name: install ibis
         run: poetry install --without dev --without docs --extras ${{ matrix.backend.name }}

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -585,51 +585,9 @@ jobs:
         with:
           flags: backend,pyspark,${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}
 
-  gen_lockfile_sqlalchemy2:
-    name: Generate Poetry Lockfile for SQLAlchemy 2
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-
-      - name: install python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - run: python -m pip install --upgrade pip 'poetry==1.7.1'
-
-      - name: remove deps that are not compatible with sqlalchemy 2
-        run: poetry remove snowflake-sqlalchemy sqlalchemy-exasol
-
-      - name: add sqlalchemy 2
-        run: poetry add --lock --optional 'sqlalchemy>=2,<3'
-
-      - name: checkout the lock file
-        run: git checkout poetry.lock
-
-      - name: lock with no updates
-        # poetry add is aggressive and will update other dependencies like
-        # numpy and pandas so we keep the pyproject.toml edits and then relock
-        # without updating anything except the requested versions
-        run: poetry lock --no-update
-
-      - name: check the sqlalchemy version
-        run: poetry show sqlalchemy --no-ansi | grep version | cut -d ':' -f2- | sed 's/ //g' | grep -P '^2\.'
-
-      - name: upload deps file
-        uses: actions/upload-artifact@v3
-        with:
-          name: deps
-          path: |
-            pyproject.toml
-            poetry.lock
-
   test_backends_sqlalchemy2:
     name: SQLAlchemy 2 ${{ matrix.backend.title }} ${{ matrix.os }} python-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
-    needs:
-      - gen_lockfile_sqlalchemy2
     strategy:
       fail-fast: false
       matrix:
@@ -708,37 +666,23 @@ jobs:
         if: matrix.backend.services != null
         run: docker compose up --wait ${{ join(matrix.backend.services, ' ') }}
 
+      - name: install poetry
+        run: pipx install 'poetry==1.7.1'
+
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: download poetry lockfile
-        uses: actions/download-artifact@v3
-        with:
-          name: deps
-          path: deps
+      - name: remove deps that are not compatible with sqlalchemy 2
+        run: poetry remove snowflake-sqlalchemy sqlalchemy-exasol
 
-      - name: pull out lockfile
-        run: |
-          set -euo pipefail
+      - name: add sqlalchemy 2
+        run: poetry update sqlalchemy
 
-          mv -f deps/* .
-          rm -r deps
-
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
-
-      - uses: syphar/restore-pip-download-cache@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: ${{ steps.install_python.outputs.python-version }}
-
-      - name: install poetry
-        run: python -m pip install --upgrade pip 'poetry==1.7.1'
+      - name: check sqlalchemy is version 2
+        run: poetry run python -c 'import sqlalchemy as sa; assert sa.__version__[0] == "2", sa.__version__'
 
       - name: install ibis
         run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -324,24 +324,15 @@ jobs:
         if: matrix.backend.services != null
         run: docker compose up --wait ${{ join(matrix.backend.services, ' ') }}
 
+      - name: install poetry
+        run: pipx install 'poetry==1.7.1'
+
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
-
-      - uses: syphar/restore-pip-download-cache@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
-
-      - name: install poetry
-        run: python -m pip install --upgrade pip 'poetry==1.7.1'
-
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
+          cache: poetry
 
       - name: install ibis
         run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"

--- a/.github/workflows/ibis-docs-lint.yml
+++ b/.github/workflows/ibis-docs-lint.yml
@@ -75,26 +75,18 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: install poetry
+        run: pipx install 'poetry==1.7.1'
+
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: "3.11"
+          cache: poetry
 
       - name: install system dependencies
         run: sudo apt-get install -qq -y build-essential libgeos-dev freetds-dev unixodbc-dev
-
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: benchmarks
-
-      - uses: syphar/restore-pip-download-cache@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: benchmarks-${{ steps.install_python.outputs.python-version }}
-
-      - run: python -m pip install --upgrade pip 'poetry==1.7.1'
 
       - name: install ibis
         run: poetry install --without dev --without docs --all-extras

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -173,7 +173,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run doctests
-        run: just doctest --junitxml=junit.xml --cov=ibis --cov-report=xml:coverage.xml
+        run: just ci-doctest --junitxml=junit.xml --cov=ibis --cov-report=xml:coverage.xml
 
       - name: upload code coverage
         if: success()

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -53,23 +53,15 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: install poetry
+        run: pipx install 'poetry==1.7.1'
+
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
-
-      - uses: syphar/restore-pip-download-cache@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: no-backends-${{ steps.install_python.outputs.python-version }}
-
-      - run: python -m pip install --upgrade pip 'poetry==1.7.1'
-
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: core
+          cache: poetry
 
       - name: install ${{ matrix.os }} system dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -118,21 +110,15 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: install poetry
+        run: pipx install 'poetry==1.7.1'
+
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
-
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: shapely-duckdb
-
-      - uses: syphar/restore-pip-download-cache@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: shapely-duckdb-${{ steps.install_python.outputs.python-version }}
+          cache: poetry
 
       - name: install ${{ matrix.os }} system dependencies
         run: |
@@ -140,8 +126,6 @@ jobs:
 
           sudo apt-get update -y -qq
           sudo apt-get install -y -q build-essential libgeos-dev
-
-      - run: python -m pip install --upgrade pip 'poetry==1.7.1'
 
       - name: install ibis
         # install duckdb and geospatial because of https://github.com/ibis-project/ibis/issues/4856
@@ -171,23 +155,15 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: install poetry
+        run: pipx install 'poetry==1.7.1'
+
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
-
-      - uses: syphar/restore-pip-download-cache@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: doctests-${{ steps.install_python.outputs.python-version }}
-
-      - run: python -m pip install --upgrade pip 'poetry==1.7.1'
-
-      - uses: syphar/restore-virtualenv@v1
-        with:
-          requirement_files: poetry.lock
-          custom_cache_key_element: doctests
+          cache: poetry
 
       - name: install ibis with all extras
         run: poetry install --without dev --without docs --extras all

--- a/ibis/backends/base/sql/alchemy/geospatial.py
+++ b/ibis/backends/base/sql/alchemy/geospatial.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from importlib.util import find_spec as _find_spec
 
 geospatial_supported = (
-    _find_spec("geoalchemy2") is not None and _find_spec("geopandas") is not None
+    _find_spec("geoalchemy2") is not None
+    and _find_spec("geopandas") is not None
+    and _find_spec("shapely") is not None
 )
 __all__ = ["geospatial_supported"]

--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -97,33 +97,34 @@ def con(data_dir, tmp_path_factory, worker_id):
 
 
 @pytest.fixture(scope="session")
-def zones(con, data_dir):
-    zones = con.read_geo(data_dir / "geojson" / "zones.geojson")
-    return zones
+def gpd():
+    pytest.importorskip("shapely")
+    pytest.importorskip("geoalchemy2")
+    return pytest.importorskip("geopandas")
 
 
 @pytest.fixture(scope="session")
-def lines(con, data_dir):
-    lines = con.read_geo(data_dir / "geojson" / "lines.geojson")
-    return lines
+def zones(con, data_dir, gpd):
+    return con.read_geo(data_dir / "geojson" / "zones.geojson")
 
 
 @pytest.fixture(scope="session")
-def zones_gdf(data_dir):
-    gpd = pytest.importorskip("geopandas")
-    zones_gdf = gpd.read_file(data_dir / "geojson" / "zones.geojson")
-    return zones_gdf
+def lines(con, data_dir, gpd):
+    return con.read_geo(data_dir / "geojson" / "lines.geojson")
 
 
 @pytest.fixture(scope="session")
-def lines_gdf(data_dir):
-    gpd = pytest.importorskip("geopandas")
-    lines_gdf = gpd.read_file(data_dir / "geojson" / "lines.geojson")
-    return lines_gdf
+def zones_gdf(data_dir, gpd):
+    return gpd.read_file(data_dir / "geojson" / "zones.geojson")
 
 
 @pytest.fixture(scope="session")
-def geotable(con):
+def lines_gdf(data_dir, gpd):
+    return gpd.read_file(data_dir / "geojson" / "lines.geojson")
+
+
+@pytest.fixture(scope="session")
+def geotable(con, gpd):
     return con.table("geo")
 
 

--- a/ibis/backends/duckdb/tests/test_geospatial.py
+++ b/ibis/backends/duckdb/tests/test_geospatial.py
@@ -13,6 +13,7 @@ import ibis
 gpd = pytest.importorskip("geopandas")
 gtm = pytest.importorskip("geopandas.testing")
 shapely = pytest.importorskip("shapely")
+pytest.importorskip("geoalchemy2")
 
 
 def test_geospatial_point(zones, zones_gdf):

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -91,8 +91,8 @@ WHERE installed AND loaded"""
     assert "spatial" in con.sql(query).name.to_pandas().values
 
 
+@pytest.mark.usefixtures("gpd")
 def test_read_geo_to_pyarrow(con, data_dir):
-    pytest.importorskip("geopandas")
     shapely = pytest.importorskip("shapely")
 
     t = con.read_geo(data_dir / "geojson" / "zones.geojson")
@@ -100,8 +100,7 @@ def test_read_geo_to_pyarrow(con, data_dir):
     assert len(shapely.from_wkb(raw_geometry))
 
 
-def test_read_geo_to_geopandas(con, data_dir):
-    gpd = pytest.importorskip("geopandas")
+def test_read_geo_to_geopandas(con, data_dir, gpd):
     t = con.read_geo(data_dir / "geojson" / "zones.geojson")
     gdf = t.head().to_pandas()
     assert isinstance(gdf, gpd.GeoDataFrame)
@@ -109,7 +108,7 @@ def test_read_geo_to_geopandas(con, data_dir):
 
 def test_read_geo_from_url(con, monkeypatch):
     loaded_exts = []
-    monkeypatch.setattr(con, "_load_extensions", lambda x, **kw: loaded_exts.extend(x))
+    monkeypatch.setattr(con, "_load_extensions", lambda x, **_: loaded_exts.extend(x))
 
     with pytest.raises((sa.exc.OperationalError, sa.exc.ProgrammingError)):
         # The read will fail, either because the URL is bogus (which it is) or
@@ -430,6 +429,7 @@ def test_csv_with_slash_n_null(con, tmp_path):
 )
 def test_register_filesystem_gcs(con):
     fsspec = pytest.importorskip("fsspec")
+    pytest.importorskip("gcsfs")
 
     gcs = fsspec.filesystem("gcs")
 

--- a/justfile
+++ b/justfile
@@ -54,12 +54,11 @@ test +backends:
 
     pytest "${pytest_args[@]}"
 
-# run doctests
-doctest *args:
+_doctest runner *args:
     #!/usr/bin/env bash
 
     # TODO(cpcloud): why doesn't pytest --ignore-glob=test_*.py work?
-    pytest --doctest-modules {{ args }} $(
+    {{ runner }} pytest --doctest-modules {{ args }} $(
       find \
         ibis \
         -wholename '*.py' \
@@ -69,6 +68,14 @@ doctest *args:
         -and -not -wholename '*ibis/expr/selectors.py' \
         -and -not -wholename '*ibis/backends/flink/*' # FIXME(deepyaman)
     )
+
+# run doctests
+doctest *args:
+    just _doctest "python -m" {{ args }}
+
+# run doctests using poetry
+ci-doctest *args:
+    just _doctest "poetry run" {{ args }}
 
 # download testing data
 download-data owner="ibis-project" repo="testing-data" rev="master":


### PR DESCRIPTION
Apparently these actions are archived and functionality is rolled into setup-python. This PR attempts to validate that.