### PR TITLE
chore: fix commit hash for git-blame-ignore-rev

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -18,4 +18,4 @@ cd31389542561a94d9d0207e09c9c906c3831fe9 # refactor(ir): rename ops.AnalyticOp -
 2673ac391c89b73fb97bb646eeef898b4d48fe30 # refactor(ir): rename ops.UnaryOp -> ops.Unary
 4803894dcff2afced4a1fc651d40b235c862791a # refactor(ir): rename ops.ValueOp -> ops.Value
 d36af084837d4d469efce060268295eec43139fb # style: format to the black default line length
-45b07de8e1989cdd0983bd2a06da4506427cdbd1 # style: don't skip string normalization using Black
+8fda6eec76220be87c477a4e40a423a0c91b2390 # style: don't skip string normalization using Black


### PR DESCRIPTION
Apparently the commit hash was wrong. Discovered this while blaming `ibis/formats/tests/test_dask.py`: https://github.com/ibis-project/ibis/blame/main/ibis/formats/tests/test_dask.py