### PR TITLE
chore(impala): remove unused imports

### DIFF
--- a/ibis/backends/impala/tests/test_bucket_histogram.py
+++ b/ibis/backends/impala/tests/test_bucket_histogram.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-from ibis.backends.impala.compiler import ImpalaCompiler
 from ibis.backends.impala.tests.conftest import translate
 
 

--- a/ibis/backends/impala/tests/test_case_exprs.py
+++ b/ibis/backends/impala/tests/test_case_exprs.py
@@ -4,7 +4,6 @@ import pytest
 
 import ibis
 import ibis.expr.types as ir
-from ibis.backends.impala.compiler import ImpalaCompiler
 from ibis.backends.impala.tests.conftest import translate
 
 

--- a/ibis/backends/impala/tests/test_sql.py
+++ b/ibis/backends/impala/tests/test_sql.py
@@ -5,7 +5,6 @@ import operator
 import pytest
 
 import ibis
-from ibis.backends.impala.compiler import ImpalaCompiler
 from ibis.backends.impala.tests.mocks import MockImpalaConnection
 
 

--- a/ibis/backends/impala/tests/test_window.py
+++ b/ibis/backends/impala/tests/test_window.py
@@ -4,9 +4,7 @@ import pytest
 from pytest import param
 
 import ibis
-import ibis.common.exceptions as com
 from ibis import window
-from ibis.backends.impala.compiler import ImpalaCompiler
 from ibis.tests.util import assert_equal
 
 pytest.importorskip("impala")


### PR DESCRIPTION
Found these while working on the exasol port. We cannot enable linting yet, but we should be able to do so once we port the backends.