### PR TITLE
fix(docs): surround executable code blocks with interactive mode on/off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ ibis/examples/descriptions
 
 # automatically generated odbc file for ci
 ci/odbc/odbc.ini
+*-citibike-tripdata.tar.xz

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -326,8 +326,7 @@ def table(
     Create a table with no data backing it
 
     >>> import ibis
-    >>> ibis.options.interactive
-    False
+    >>> ibis.options.interactive = False
     >>> t = ibis.table(schema=dict(a="int", b="string"), name="t")
     >>> t
     UnboundTable: t

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -180,11 +180,8 @@ def numeric() -> Predicate:
     >>> import ibis
     >>> import ibis.selectors as s
     >>> t = ibis.table(dict(a="int", b="string", c="array<string>"), name="t")
-    >>> t
-    UnboundTable: t
-      a int64
-      b string
-      c array<string>
+    >>> t.columns
+    ['a', 'b', 'c']
     >>> expr = t.select(s.numeric())  # `a` has integer type, so it's numeric
     >>> expr.columns
     ['a']


### PR DESCRIPTION
Fixes #8001. For each example were disabling interactive mode before rendering, which caused subsequent examples in the same docstring to use non-interactive rendering. The fix is to surround each code block with turning interactive mode on just before the block and off right after.