### PR TITLE
Tweak ibis.array() docstring, improve test, add xfail test

### DIFF
--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -19,8 +19,20 @@ if TYPE_CHECKING:
 
 @execute_node.register(ops.ArrayColumn, tuple)
 def execute_array_column(op, cols, **kwargs):
-    cols = [execute(arg, **kwargs) for arg in cols]
-    df = pd.concat(cols, axis=1)
+    vals = [execute(arg, **kwargs) for arg in cols]
+    # At least one of the values will be a Series.
+    # Otherwise op would be an ArrayScalar, not an ArrayColumn.
+    length = next(len(v) for v in vals if isinstance(v, pd.Series))
+
+    def ensure_series(v):
+        if isinstance(v, pd.Series):
+            return v
+        else:
+            return pd.Series(v, index=range(length))
+
+    # pd.concat() can only handle array-likes.
+    # If we're given a scalar, we need to broadcast it as a Series.
+    df = pd.concat([ensure_series(v) for v in vals], axis=1)
     return df.apply(lambda row: np.array(row, dtype=object), axis=1)
 
 

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -80,6 +80,15 @@ def test_array_scalar(con, backend):
         assert con.execute(expr.typeof()) == ARRAY_BACKEND_TYPES[backend_name]
 
 
+@pytest.mark.xfail
+def test_array_scalar_mixed_python_ibis(con, backend):
+    # https://github.com/ibis-project/ibis/issues/8022
+    # once fixed, probably merge this into test_array_scalar()
+    # by adding an ibis.literal() in that test data.
+    expr = ibis.array([1.0, ibis.literal(2.0), 3.0])
+    assert isinstance(expr, ir.ArrayScalar)
+
+
 @pytest.mark.notimpl(["polars", "flink"], raises=com.OperationNotDefinedError)
 def test_array_repeat(con):
     expr = ibis.array([1.0, 2.0]) * 2

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -42,12 +42,14 @@ pytestmark = [
 
 @pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
 def test_array_column(backend, alltypes, df):
-    expr = ibis.array([alltypes["double_col"], alltypes["double_col"]])
+    expr = ibis.array(
+        [alltypes["double_col"], alltypes["double_col"], 5.0, ibis.literal(6.0)]
+    )
     assert isinstance(expr, ir.ArrayColumn)
 
     result = expr.execute()
     expected = df.apply(
-        lambda row: [row["double_col"], row["double_col"]],
+        lambda row: [row["double_col"], row["double_col"], 5.0, 6.0],
         axis=1,
     )
     backend.assert_series_equal(result, expected, check_names=False)


### PR DESCRIPTION
adds an xfail test for https://github.com/ibis-project/ibis/issues/8022

I discovered that actually fixing the problem wasn't trivial, as I wasn't sure about the ibis internals and how to create an ArrayScalar object correctly. But still I think this is an improvement.

Not totally in love with how I patched ibis.options.repr.interactive.max_length, open to suggestions.

Also discovered that pandas and dask can't handle mixed scalars and columns, so I fixed that.