### PR TITLE
fix(clouds): account for new error types in bigquery and udf renaming in snowflake

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -41,10 +41,24 @@ jobs:
           - "3.9"
           - "3.11"
         backend:
-          - name: bigquery
-            title: BigQuery
           - name: snowflake
             title: Snowflake
+            extras:
+              - snowflake
+        include:
+          - python-version: "3.9"
+            backend:
+              name: bigquery
+              title: BigQuery
+              extras:
+                - bigquery
+          - python-version: "3.11"
+            backend:
+              name: bigquery
+              title: BigQuery
+              extras:
+                - bigquery
+                - geospatial
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -69,7 +83,7 @@ jobs:
           custom_cache_key_element: ${{ matrix.backend.name }}-${{ steps.install_python.outputs.python-version }}
 
       - name: install ibis
-        run: poetry install --without dev --without docs --extras ${{ matrix.backend.name }}
+        run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"
 
       - uses: extractions/setup-just@v1
         env:

--- a/ibis/backends/bigquery/datatypes.py
+++ b/ibis/backends/bigquery/datatypes.py
@@ -65,21 +65,3 @@ class BigQuerySchema(SchemaMapper):
     @classmethod
     def to_ibis(cls, fields: list[bq.SchemaField]) -> sch.Schema:
         return sch.Schema({f.name: cls._dtype_from_bigquery_field(f) for f in fields})
-
-
-# TODO(kszucs): we can eliminate this function by making dt.DataType traversible
-# using ibis.common.graph.Node, similarly to how we traverse ops.Node instances:
-# node.find(types)
-def spread_type(dt: dt.DataType):
-    """Returns a generator that contains all the types in the given type.
-
-    For complex types like set and array, it returns the types of the elements.
-    """
-    if dt.is_array():
-        yield from spread_type(dt.value_type)
-    elif dt.is_struct():
-        for type_ in dt.types:
-            yield from spread_type(type_)
-    elif dt.is_map():
-        raise NotImplementedError("Maps are not supported in BigQuery")
-    yield dt

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -328,6 +328,8 @@ def test_create_table_bignumeric(con, temp_table):
 
 
 def test_geography_table(con, temp_table):
+    pytest.importorskip("geopandas")
+
     schema = ibis.schema({"col1": dt.GeoSpatial(geotype="geography", srid=4326)})
     temporary_table = con.create_table(temp_table, schema=schema)
     con.raw_sql(

--- a/ibis/backends/bigquery/tests/unit/test_datatypes.py
+++ b/ibis/backends/bigquery/tests/unit/test_datatypes.py
@@ -4,6 +4,7 @@ import pytest
 import sqlglot as sg
 from pytest import param
 
+import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.backends.bigquery.datatypes import BigQueryType
 
@@ -41,7 +42,7 @@ from ibis.backends.bigquery.datatypes import BigQueryType
             dt.Timestamp(timezone="US/Eastern"),
             "TIMESTAMP",
             marks=pytest.mark.xfail(
-                raises=TypeError, reason="Not supported in BigQuery"
+                raises=com.UnsupportedBackendType, reason="Not supported in BigQuery"
             ),
             id="timestamp_with_other_tz",
         ),
@@ -59,10 +60,10 @@ from ibis.backends.bigquery.datatypes import BigQueryType
             dt.GeoSpatial(geotype="geography"),
             "GEOGRAPHY",
             marks=pytest.mark.xfail(
-                raises=TypeError,
+                raises=com.UnsupportedBackendType,
                 reason="Should use the WGS84 reference ellipsoid.",
             ),
-            id="geography",
+            id="geography-no-srid",
         ),
     ],
 )
@@ -72,7 +73,7 @@ def test_simple(datatype, expected):
 
 @pytest.mark.parametrize("datatype", [dt.uint64, dt.Decimal(8, 3)])
 def test_simple_failure_mode(datatype):
-    with pytest.raises(TypeError):
+    with pytest.raises(com.UnsupportedBackendType):
         BigQueryType.to_string(datatype)
 
 

--- a/ibis/backends/bigquery/tests/unit/test_datatypes.py
+++ b/ibis/backends/bigquery/tests/unit/test_datatypes.py
@@ -5,10 +5,7 @@ import sqlglot as sg
 from pytest import param
 
 import ibis.expr.datatypes as dt
-from ibis.backends.bigquery.datatypes import (
-    BigQueryType,
-    spread_type,
-)
+from ibis.backends.bigquery.datatypes import BigQueryType
 
 
 @pytest.mark.parametrize(
@@ -77,31 +74,6 @@ def test_simple(datatype, expected):
 def test_simple_failure_mode(datatype):
     with pytest.raises(TypeError):
         BigQueryType.to_string(datatype)
-
-
-@pytest.mark.parametrize(
-    ("type_", "expected"),
-    [
-        param(
-            dt.int64,
-            [dt.int64],
-        ),
-        param(
-            dt.Array(dt.int64),
-            [dt.int64, dt.Array(value_type=dt.int64)],
-        ),
-        param(
-            dt.Struct.from_tuples([("a", dt.Array(dt.int64))]),
-            [
-                dt.int64,
-                dt.Array(value_type=dt.int64),
-                dt.Struct.from_tuples([("a", dt.Array(value_type=dt.int64))]),
-            ],
-        ),
-    ],
-)
-def test_spread_type(type_, expected):
-    assert list(spread_type(type_)) == expected
 
 
 def test_struct_type():

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -305,6 +305,7 @@ $$ {defn["source"]} $$"""
         return dict(
             source=source,
             name=name,
+            func_name=udf_node.__func_name__,
             preamble="\n".join(preamble_lines).format(
                 name=name,
                 signature=signature,
@@ -351,7 +352,7 @@ $$ {defn["source"]} $$"""
     def _compile_python_udf(self, udf_node: ops.ScalarUDF) -> str:
         return """\
 {preamble}
-HANDLER = '{name}'
+HANDLER = '{func_name}'
 AS $$
 from __future__ import annotations
 
@@ -376,7 +377,7 @@ import pandas as pd
 
 @_snowflake.vectorized(input=pd.DataFrame)
 def wrapper(df):
-    return {name}(*(col for _, col in df.items()))
+    return {func_name}(*(col for _, col in df.items()))
 $$"""
         return template.format(**self._get_udf_source(udf_node))
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1897,7 +1897,7 @@ def test_timestamp_literal(con, backend):
 @pytest.mark.notimpl(
     ["bigquery"],
     "BigQuery does not support timestamps with timezones other than 'UTC'",
-    raises=TypeError,
+    raises=com.UnsupportedBackendType,
 )
 @pytest.mark.notimpl(
     ["druid"],


### PR DESCRIPTION
## Description of changes

This PR fixes some failing tests that slipped through the BigQuery sqlglot port:

- The type of errors raised from `BigQueryType` is now `UnsupportedBackendType` instead of the generic `TypeError`.
- Handling of UDF redefinitions wasn't implemented in the Snowflake backend.
- CI wasn't installing the geospatial dependencies for the BigQuery backend.
