### PR TITLE
feat: join with selectors as predicates

### DIFF
--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import itertools
 from abc import abstractmethod
+from functools import reduce
+from operator import and_
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional
 from typing import Union as UnionType
 
@@ -121,12 +123,18 @@ class InMemoryTable(PhysicalTable):
 def _clean_join_predicates(left, right, predicates):
     import ibis.expr.analysis as an
     import ibis.expr.types as ir
+    import ibis.selectors as s
     from ibis.expr.analysis import shares_all_roots
 
     result = []
 
     for pred in predicates:
-        if isinstance(pred, tuple):
+        if isinstance(pred, s.Selector):
+            pred = s.join(pred)
+        if isinstance(pred, s.JoinSelector):
+            # TODO what do i do about `None`s here?, skip?
+            pred = reduce(and_, (lk == rk for lk, rk in pred.expand(left, right)))
+        elif isinstance(pred, tuple):
             if len(pred) != 2:
                 raise com.ExpressionError("Join key tuple must be length 2")
             lk, rk = pred


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

As a continuation of the discussion in #8026 , this PR adds a `join(selector, mode)` pseudo selector, which can expand a given `selector` on two tables.

f.ex. `s.join(~s.c("value"), mode="intersect").expand(df1, df2)` expands to `[(df1.model, df2.model), (df1.scenario, df2.scenario)]` if `"model"` and `"scenario"` are the only two common column names other than `"value"`.

This selector can be given as join predicate.

## Issues closed

* Resolves #8026