### PR TITLE
feat: join with selectors as predicates (alternative)

### DIFF
--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -675,7 +675,7 @@ def expand_overlap(
         return ((c.get_name(), c) for c in selector.expand(tab))
 
     right_map = dict(name_map(right))
-    return [(c, right_map[name]) for name, c in name_map(left) if c in right_map]
+    return [(c, right_map[name]) for name, c in name_map(left) if name in right_map]
 
 
 def _to_selector(

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -668,6 +668,16 @@ def all() -> Predicate:
     return r[:]
 
 
+def expand_overlap(
+    selector: Selector, left: ir.Table, right: ir.Table
+) -> Sequence[tuple[ir.Value, ir.Value]]:
+    def name_map(tab: ir.Table):
+        return ((c.get_name(), c) for c in selector.expand(tab))
+
+    right_map = dict(name_map(right))
+    return [(c, right_map[name]) for name, c in name_map(left) if c in right_map]
+
+
 def _to_selector(
     obj: str | Selector | ir.Column | Sequence[str | Selector | ir.Column],
 ) -> Selector:


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

As a continuation of the discussion in https://github.com/ibis-project/ibis/issues/8026 , and the first try in #8027 this alternative implementation tries to minimise the necessary code and only adds a small `expand_overlap` function to the `selectors` module that expands to the common columns a given selector finds on two tables.

This selector can be given as join predicate.

## Issues closed

* Resolves #8026 

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
