### PR TITLE
feat(flink): export result to pyarrow

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1023,16 +1023,7 @@ def test_dunder_array_column(alltypes, dtype):
     np.testing.assert_array_equal(result, expected)
 
 
-@pytest.mark.parametrize(
-    "interactive",
-    [
-        param(
-            True,
-            marks=pytest.mark.notimpl(["flink"], raises=NotImplementedError),
-        ),
-        False,
-    ],
-)
+@pytest.mark.parametrize("interactive", [True, False])
 def test_repr(alltypes, interactive, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", interactive)
 
@@ -1048,7 +1039,6 @@ def test_repr(alltypes, interactive, monkeypatch):
 
 
 @pytest.mark.parametrize("show_types", [True, False])
-@pytest.mark.notimpl(["flink"], raises=NotImplementedError)
 def test_interactive_repr_show_types(alltypes, show_types, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)
     monkeypatch.setattr(ibis.options.repr.interactive, "show_types", show_types)
@@ -1062,7 +1052,6 @@ def test_interactive_repr_show_types(alltypes, show_types, monkeypatch):
 
 
 @pytest.mark.parametrize("is_jupyter", [True, False])
-@pytest.mark.notimpl(["flink"], raises=NotImplementedError)
 def test_interactive_repr_max_columns(alltypes, is_jupyter, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)
 
@@ -1101,16 +1090,7 @@ def test_interactive_repr_max_columns(alltypes, is_jupyter, monkeypatch):
 
 
 @pytest.mark.parametrize("expr_type", ["table", "column"])
-@pytest.mark.parametrize(
-    "interactive",
-    [
-        param(
-            True,
-            marks=pytest.mark.notimpl(["flink"], raises=NotImplementedError),
-        ),
-        False,
-    ],
-)
+@pytest.mark.parametrize("interactive", [True, False])
 def test_repr_mimebundle(alltypes, interactive, expr_type, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", interactive)
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -22,6 +22,7 @@ from ibis.backends.tests.errors import (
     ExaQueryError,
     GoogleBadRequest,
     ImpalaHiveServer2Error,
+    Py4JJavaError,
 )
 from ibis.common.annotations import ValidationError
 
@@ -758,7 +759,11 @@ def test_between(backend, alltypes, df):
 
 
 @pytest.mark.notimpl(["druid"])
-@pytest.mark.notimpl(["flink"], raises=NotImplementedError)
+@pytest.mark.notimpl(
+    ["flink"],
+    raises=Py4JJavaError,
+    reason="Flink does not support now() - t.`timestamp_col`",
+)
 def test_interactive(alltypes, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)
 

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -330,7 +330,6 @@ outer_join_nullability_failures = [
     raises=sa.exc.NoSuchTableError,
     reason="`win` table isn't loaded",
 )
-@pytest.mark.notimpl(["flink"], reason="`win` table isn't loaded")
 @pytest.mark.parametrize(
     ("how", "nrows", "gen_right", "keys"),
     [


### PR DESCRIPTION
## Description of changes

The goal of this change is to support `to_csv()` and `to_parquet()` for the Flink backend. Adds `to_pyarrow()` and `to_pyarrow_batches()` in `Backend` class for Flink.

`Note to reviewers`: Please pay special attention on `get_field_data_types()` which I added to work around the "precision issue" in PyFlink.