### PR TITLE
fix(exasol): use slower but more reliable ddl and allow non-strict xfail on window function test

### DIFF
--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -775,7 +775,7 @@ def test_simple_ungrouped_window_with_scalar_order_by(alltypes):
             id="unordered-lag",
             marks=[
                 pytest.mark.broken(
-                    ["trino"],
+                    ["trino", "exasol"],
                     reason="this isn't actually broken: the backend result is equal up to ordering",
                     raises=AssertionError,
                     strict=False,  # sometimes it passes


### PR DESCRIPTION
- chore(exasol): avoid complex websocket callback for inserting memtables
- test(exasol): account for unordered results in window function tests
