### PR TITLE
fix(duckdb): ensure that casting to floating point values produces valid types in generated sql

### DIFF
--- a/ibis/backends/base/sql/alchemy/datatypes.py
+++ b/ibis/backends/base/sql/alchemy/datatypes.py
@@ -41,6 +41,19 @@ def compiles_array(element, compiler, **kw):
     return f"ARRAY({compiler.process(element.value_type, **kw)})"
 
 
+@compiles(sat.FLOAT, "duckdb")
+def compiles_float(element, compiler, **kw):
+    precision = element.precision
+    if precision is None or 1 <= precision <= 24:
+        return "FLOAT"
+    elif 24 < precision <= 53:
+        return "DOUBLE"
+    else:
+        raise ValueError(
+            "FLOAT precision must be between 1 and 53 inclusive, or `None`"
+        )
+
+
 class StructType(sat.UserDefinedType):
     cache_ok = True
 

--- a/ibis/backends/duckdb/tests/snapshots/test_datatypes/test_cast_to_floating_point_type/float32/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_datatypes/test_cast_to_floating_point_type/float32/out.sql
@@ -1,0 +1,2 @@
+SELECT
+  CAST('1.0' AS REAL) AS "Cast('1.0', float32)"

--- a/ibis/backends/duckdb/tests/snapshots/test_datatypes/test_cast_to_floating_point_type/float64/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_datatypes/test_cast_to_floating_point_type/float64/out.sql
@@ -1,0 +1,2 @@
+SELECT
+  CAST('1.0' AS DOUBLE) AS "Cast('1.0', float64)"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_geospatial_dwithin/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_geospatial_dwithin/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  ST_DWITHIN(t0.geom, t0.geom, CAST(3.0 AS REAL(53))) AS tmp
+  ST_DWITHIN(t0.geom, t0.geom, CAST(3.0 AS DOUBLE)) AS tmp
 FROM t AS t0

--- a/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/duckdb/h06.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/duckdb/h06.sql
@@ -4,5 +4,5 @@ FROM main.lineitem AS t0
 WHERE
   t0.l_shipdate >= MAKE_DATE(1994, 1, 1)
   AND t0.l_shipdate < MAKE_DATE(1995, 1, 1)
-  AND t0.l_discount BETWEEN CAST(0.05 AS REAL(53)) AND CAST(0.07 AS REAL(53))
+  AND t0.l_discount BETWEEN CAST(0.05 AS DOUBLE) AND CAST(0.07 AS DOUBLE)
   AND t0.l_quantity < CAST(24 AS TINYINT)

--- a/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/duckdb/h11.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/duckdb/h11.sql
@@ -35,7 +35,7 @@ FROM (
         WHERE
           t4.n_name = 'GERMANY'
       ) AS anon_1
-    ) * CAST(0.0001 AS REAL(53))
+    ) * CAST(0.0001 AS DOUBLE)
 ) AS t1
 ORDER BY
   t1.value DESC

--- a/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/duckdb/h17.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/duckdb/h17.sql
@@ -1,5 +1,5 @@
 SELECT
-  SUM(t0.l_extendedprice) / CAST(7.0 AS REAL(53)) AS avg_yearly
+  SUM(t0.l_extendedprice) / CAST(7.0 AS DOUBLE) AS avg_yearly
 FROM main.lineitem AS t0
 JOIN main.part AS t1
   ON t1.p_partkey = t0.l_partkey
@@ -12,4 +12,4 @@ WHERE
     FROM main.lineitem AS t0
     WHERE
       t0.l_partkey = t1.p_partkey
-  ) * CAST(0.2 AS REAL(53))
+  ) * CAST(0.2 AS DOUBLE)

--- a/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/duckdb/h20.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/duckdb/h20.sql
@@ -56,7 +56,7 @@ WITH t0 AS (
               AND t6.l_suppkey = t5.ps_suppkey
               AND t6.l_shipdate >= MAKE_DATE(1994, 1, 1)
               AND t6.l_shipdate < MAKE_DATE(1995, 1, 1)
-          ) * CAST(0.5 AS REAL(53))
+          ) * CAST(0.5 AS DOUBLE)
       ) AS t4
     )
 )

--- a/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/duckdb/h22.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/duckdb/h22.sql
@@ -25,7 +25,7 @@ WITH t0 AS (
           AVG(t2.c_acctbal) AS avg_bal
         FROM main.customer AS t2
         WHERE
-          t2.c_acctbal > CAST(0.0 AS REAL(53))
+          t2.c_acctbal > CAST(0.0 AS DOUBLE)
           AND CASE
             WHEN (
               CAST(0 AS TINYINT) + 1 >= 1


### PR DESCRIPTION
Fixes a bug when compiling expressions to DuckDB sql. Discussed [in Zulip](https://ibis-project.zulipchat.com/#narrow/stream/405265-tech-support/topic/Issue.20with.20casting.20and.20sql.20genertion.20in.20duckdb).