### PR TITLE
fix(datatypes): ensure that array construction supports literals and infers their shape from its inputs

### DIFF
--- a/ibis/backends/bigquery/registry.py
+++ b/ibis/backends/bigquery/registry.py
@@ -129,7 +129,7 @@ def _array_concat(translator, op):
 
 
 def _array_column(translator, op):
-    return "[{}]".format(", ".join(map(translator.translate, op.cols)))
+    return "[{}]".format(", ".join(map(translator.translate, op.exprs)))
 
 
 def _array_index(translator, op):
@@ -912,7 +912,7 @@ OPERATION_REGISTRY = {
     ops.StructColumn: _struct_column,
     ops.ArrayCollect: _array_agg,
     ops.ArrayConcat: _array_concat,
-    ops.ArrayColumn: _array_column,
+    ops.Array: _array_column,
     ops.ArrayIndex: _array_index,
     ops.ArrayLength: unary("ARRAY_LENGTH"),
     ops.ArrayRepeat: _array_repeat,

--- a/ibis/backends/clickhouse/compiler/values.py
+++ b/ibis/backends/clickhouse/compiler/values.py
@@ -554,9 +554,9 @@ def _bit_agg(func: str):
     return _translate
 
 
-@translate_val.register(ops.ArrayColumn)
-def _array_column(op, *, cols, **_):
-    return F.array(*cols)
+@translate_val.register(ops.Array)
+def _array_column(op, *, exprs, **_):
+    return F.array(*exprs)
 
 
 @translate_val.register(ops.StructColumn)

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -38,10 +38,8 @@ collect_list = dd.Aggregation(
 @execute_node.register(ops.Array, tuple)
 def execute_array_column(op, cols, **kwargs):
     vals = [execute(arg, **kwargs) for arg in cols]
-    # At least one of the values will be a Series.
-    # Otherwise op would be an ArrayScalar, not an ArrayColumn.
-    length = next(len(v) for v in vals if isinstance(v, dd.Series))
-    n_partitions = next(v.npartitions for v in vals if isinstance(v, dd.Series))
+    length = next((len(v) for v in vals if isinstance(v, dd.Series)), None)
+    n_partitions = next((v.npartitions for v in vals if isinstance(v, dd.Series)), None)
 
     def ensure_series(v):
         if isinstance(v, dd.Series):
@@ -49,6 +47,8 @@ def execute_array_column(op, cols, **kwargs):
         else:
             return dd.from_pandas(pd.Series([v] * length), npartitions=n_partitions)
 
+    if length is None:
+        return vals
     # dd.concat() can only handle array-likes.
     # If we're given a scalar, we need to broadcast it as a Series.
     df = dd.concat([ensure_series(v) for v in vals], axis=1)

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -34,7 +34,7 @@ collect_list = dd.Aggregation(
 )
 
 
-@execute_node.register(ops.ArrayColumn, tuple)
+@execute_node.register(ops.Array, tuple)
 def execute_array_column(op, cols, **kwargs):
     cols = [execute(arg, **kwargs) for arg in cols]
     df = dd.concat(cols, axis=1)

--- a/ibis/backends/dask/execution/arrays.py
+++ b/ibis/backends/dask/execution/arrays.py
@@ -6,6 +6,7 @@ from functools import partial
 import dask.dataframe as dd
 import dask.dataframe.groupby as ddgb
 import numpy as np
+import pandas as pd
 
 import ibis.expr.operations as ops
 from ibis.backends.dask.core import execute
@@ -36,8 +37,21 @@ collect_list = dd.Aggregation(
 
 @execute_node.register(ops.Array, tuple)
 def execute_array_column(op, cols, **kwargs):
-    cols = [execute(arg, **kwargs) for arg in cols]
-    df = dd.concat(cols, axis=1)
+    vals = [execute(arg, **kwargs) for arg in cols]
+    # At least one of the values will be a Series.
+    # Otherwise op would be an ArrayScalar, not an ArrayColumn.
+    length = next(len(v) for v in vals if isinstance(v, dd.Series))
+    n_partitions = next(v.npartitions for v in vals if isinstance(v, dd.Series))
+
+    def ensure_series(v):
+        if isinstance(v, dd.Series):
+            return v
+        else:
+            return dd.from_pandas(pd.Series([v] * length), npartitions=n_partitions)
+
+    # dd.concat() can only handle array-likes.
+    # If we're given a scalar, we need to broadcast it as a Series.
+    df = dd.concat([ensure_series(v) for v in vals], axis=1)
     return df.apply(
         lambda row: np.array(row, dtype=object), axis=1, meta=(None, "object")
     )

--- a/ibis/backends/datafusion/compiler/values.py
+++ b/ibis/backends/datafusion/compiler/values.py
@@ -733,9 +733,9 @@ def _not_null(op, *, arg, **_):
     return sg.not_(arg.is_(NULL))
 
 
-@translate_val.register(ops.ArrayColumn)
-def array_column(op, *, cols, **_):
-    return F.make_array(*cols)
+@translate_val.register(ops.Array)
+def array_column(op, *, exprs, **_):
+    return F.make_array(*exprs)
 
 
 @translate_val.register(ops.ArrayRepeat)

--- a/ibis/backends/duckdb/registry.py
+++ b/ibis/backends/duckdb/registry.py
@@ -399,9 +399,9 @@ def _array_remove(t, op):
 
 operation_registry.update(
     {
-        ops.ArrayColumn: (
+        ops.Array: (
             lambda t, op: sa.cast(
-                sa.func.list_value(*map(t.translate, op.cols)),
+                sa.func.list_value(*map(t.translate, op.exprs)),
                 t.get_sqla_type(op.dtype),
             )
         ),

--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -18,11 +18,9 @@ if TYPE_CHECKING:
 
 
 @execute_node.register(ops.Array, tuple)
-def execute_array_column(op, cols, **kwargs):
+def execute_array(op, cols, **kwargs):
     vals = [execute(arg, **kwargs) for arg in cols]
-    # At least one of the values will be a Series.
-    # Otherwise op would be an ArrayScalar, not an ArrayColumn.
-    length = next(len(v) for v in vals if isinstance(v, pd.Series))
+    length = next((len(v) for v in vals if isinstance(v, pd.Series)), None)
 
     def ensure_series(v):
         if isinstance(v, pd.Series):
@@ -30,6 +28,8 @@ def execute_array_column(op, cols, **kwargs):
         else:
             return pd.Series(v, index=range(length))
 
+    if length is None:
+        return vals
     # pd.concat() can only handle array-likes.
     # If we're given a scalar, we need to broadcast it as a Series.
     df = pd.concat([ensure_series(v) for v in vals], axis=1)
@@ -41,7 +41,7 @@ def execute_array_length(op, data, **kwargs):
     return data.apply(len)
 
 
-@execute_node.register(ops.ArrayLength, np.ndarray)
+@execute_node.register(ops.ArrayLength, (list, np.ndarray))
 def execute_array_length_scalar(op, data, **kwargs):
     return len(data)
 
@@ -51,7 +51,7 @@ def execute_array_slice(op, data, start, stop, **kwargs):
     return data.apply(operator.itemgetter(slice(start, stop)))
 
 
-@execute_node.register(ops.ArraySlice, np.ndarray, int, (int, type(None)))
+@execute_node.register(ops.ArraySlice, (list, np.ndarray), int, (int, type(None)))
 def execute_array_slice_scalar(op, data, start, stop, **kwargs):
     return data[start:stop]
 
@@ -65,7 +65,7 @@ def execute_array_index(op, data, index, **kwargs):
     )
 
 
-@execute_node.register(ops.ArrayIndex, np.ndarray, int)
+@execute_node.register(ops.ArrayIndex, (list, np.ndarray), int)
 def execute_array_index_scalar(op, data, index, **kwargs):
     try:
         return data[index]
@@ -73,7 +73,7 @@ def execute_array_index_scalar(op, data, index, **kwargs):
         return None
 
 
-@execute_node.register(ops.ArrayContains, np.ndarray, object)
+@execute_node.register(ops.ArrayContains, (list, np.ndarray), object)
 def execute_node_contains_value_array(op, haystack, needle, **kwargs):
     return needle in haystack
 
@@ -103,7 +103,7 @@ def execute_array_concat_series(op, first, second, *args, **kwargs):
 
 
 @execute_node.register(
-    ops.ArrayConcat, np.ndarray, pd.Series, [(pd.Series, np.ndarray)]
+    ops.ArrayConcat, (list, np.ndarray), pd.Series, [(pd.Series, list, np.ndarray)]
 )
 def execute_array_concat_mixed_left(op, left, right, *args, **kwargs):
     # ArrayConcat given a column (pd.Series) and a scalar (np.ndarray).
@@ -114,7 +114,7 @@ def execute_array_concat_mixed_left(op, left, right, *args, **kwargs):
 
 
 @execute_node.register(
-    ops.ArrayConcat, pd.Series, np.ndarray, [(pd.Series, np.ndarray)]
+    ops.ArrayConcat, pd.Series, (list, np.ndarray), [(pd.Series, list, np.ndarray)]
 )
 def execute_array_concat_mixed_right(op, left, right, *args, **kwargs):
     # Broadcast `right` to the length of `left`
@@ -122,7 +122,9 @@ def execute_array_concat_mixed_right(op, left, right, *args, **kwargs):
     return _concat_iterables_to_series(left, right)
 
 
-@execute_node.register(ops.ArrayConcat, np.ndarray, np.ndarray, [np.ndarray])
+@execute_node.register(
+    ops.ArrayConcat, (list, np.ndarray), (list, np.ndarray), [(list, np.ndarray)]
+)
 def execute_array_concat_scalar(op, left, right, *args, **kwargs):
     return np.concatenate([left, right, *args])
 
@@ -134,7 +136,7 @@ def execute_array_repeat(op, data, n, **kwargs):
     return pd.Series(np.tile(arr, n) for arr in data)
 
 
-@execute_node.register(ops.ArrayRepeat, np.ndarray, int)
+@execute_node.register(ops.ArrayRepeat, (list, np.ndarray), int)
 def execute_array_repeat_scalar(op, data, n, **kwargs):
     # Negative n will be treated as 0 (repeat will produce empty array)
     return np.tile(data, max(n, 0))

--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -22,14 +22,15 @@ def execute_array(op, cols, **kwargs):
     vals = [execute(arg, **kwargs) for arg in cols]
     length = next((len(v) for v in vals if isinstance(v, pd.Series)), None)
 
+    if length is None:
+        return vals
+
     def ensure_series(v):
         if isinstance(v, pd.Series):
             return v
         else:
             return pd.Series(v, index=range(length))
 
-    if length is None:
-        return vals
     # pd.concat() can only handle array-likes.
     # If we're given a scalar, we need to broadcast it as a Series.
     df = pd.concat([ensure_series(v) for v in vals], axis=1)

--- a/ibis/backends/pandas/execution/arrays.py
+++ b/ibis/backends/pandas/execution/arrays.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Collection
 
 
-@execute_node.register(ops.ArrayColumn, tuple)
+@execute_node.register(ops.Array, tuple)
 def execute_array_column(op, cols, **kwargs):
     cols = [execute(arg, **kwargs) for arg in cols]
     df = pd.concat(cols, axis=1)

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -888,9 +888,9 @@ def array_concat(op, **kw):
     return result
 
 
-@translate.register(ops.ArrayColumn)
+@translate.register(ops.Array)
 def array_column(op, **kw):
-    cols = [translate(col, **kw) for col in op.cols]
+    cols = [translate(col, **kw) for col in op.exprs]
     return pl.concat_list(cols)
 
 

--- a/ibis/backends/postgres/registry.py
+++ b/ibis/backends/postgres/registry.py
@@ -750,7 +750,7 @@ operation_registry.update(
         # array operations
         ops.ArrayLength: unary(sa.func.cardinality),
         ops.ArrayCollect: reduction(sa.func.array_agg),
-        ops.ArrayColumn: (lambda t, op: pg.array(list(map(t.translate, op.cols)))),
+        ops.Array: (lambda t, op: pg.array(list(map(t.translate, op.exprs)))),
         ops.ArraySlice: _array_slice(
             index_converter=_neg_idx_to_pos,
             array_length=sa.func.cardinality,

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -1634,9 +1634,9 @@ def compile_interval_from_integer(t, op, **kwargs):
 # -------------------------- Array Operations ----------------------------
 
 
-@compiles(ops.ArrayColumn)
+@compiles(ops.Array)
 def compile_array_column(t, op, **kwargs):
-    cols = [t.translate(col, **kwargs) for col in op.cols]
+    cols = [t.translate(col, **kwargs) for col in op.exprs]
     return F.array(cols)
 
 

--- a/ibis/backends/snowflake/registry.py
+++ b/ibis/backends/snowflake/registry.py
@@ -457,9 +457,7 @@ operation_registry.update(
         ops.ArrayConcat: varargs(
             lambda *args: functools.reduce(sa.func.array_cat, args)
         ),
-        ops.ArrayColumn: lambda t, op: sa.func.array_construct(
-            *map(t.translate, op.cols)
-        ),
+        ops.Array: lambda t, op: sa.func.array_construct(*map(t.translate, op.exprs)),
         ops.ArraySlice: _array_slice,
         ops.ArrayCollect: reduction(
             lambda arg: sa.func.array_agg(

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1052,7 +1052,6 @@ def test_timestamp_range_zero_step(con, start, stop, step, tzinfo):
 
 
 @pytest.mark.notimpl(["flink"], raises=Py4JJavaError)
-@pytest.mark.notimpl(["datafusion"], raises=Exception)
 def test_repr_timestamp_array(con, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)
     monkeypatch.setattr(ibis.options, "default_backend", con)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import functools
 from datetime import datetime
 
@@ -22,7 +21,6 @@ from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
     GoogleBadRequest,
     PolarsComputeError,
-    Py4JJavaError,
     PySparkAnalysisException,
 )
 
@@ -54,18 +52,7 @@ def test_array_column(backend, alltypes, df):
     backend.assert_series_equal(result, expected, check_names=False)
 
 
-ARRAY_BACKEND_TYPES = {
-    "clickhouse": "Array(Float64)",
-    "snowflake": "ARRAY",
-    "trino": "array(double)",
-    "bigquery": "ARRAY",
-    "duckdb": "DOUBLE[]",
-    "postgres": "numeric[]",
-    "flink": "ARRAY<DECIMAL(2, 1) NOT NULL> NOT NULL",
-}
-
-
-def test_array_scalar(con, backend):
+def test_array_scalar(con):
     expr = ibis.array([1.0, 2.0, 3.0])
     assert isinstance(expr, ir.ArrayScalar)
 
@@ -73,10 +60,6 @@ def test_array_scalar(con, backend):
     expected = np.array([1.0, 2.0, 3.0])
 
     assert np.array_equal(result, expected)
-
-    with contextlib.suppress(com.OperationNotDefinedError):
-        backend_name = backend.name()
-        assert con.execute(expr.typeof()) == ARRAY_BACKEND_TYPES[backend_name]
 
 
 @pytest.mark.notimpl(["polars", "flink"], raises=com.OperationNotDefinedError)
@@ -1051,7 +1034,9 @@ def test_timestamp_range_zero_step(con, start, stop, step, tzinfo):
     assert list(result) == []
 
 
-@pytest.mark.notimpl(["flink"], raises=Py4JJavaError)
+@pytest.mark.notimpl(
+    ["flink"], raises=AssertionError, reason="arrays not yet implemented"
+)
 def test_repr_timestamp_array(con, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)
     monkeypatch.setattr(ibis.options, "default_backend", con)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -41,12 +41,14 @@ pytestmark = [
 
 @pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
 def test_array_column(backend, alltypes, df):
-    expr = ibis.array([alltypes["double_col"], alltypes["double_col"]])
+    expr = ibis.array(
+        [alltypes["double_col"], alltypes["double_col"], 5.0, ibis.literal(6.0)]
+    )
     assert isinstance(expr, ir.ArrayColumn)
 
     result = expr.execute()
     expected = df.apply(
-        lambda row: [row["double_col"], row["double_col"]],
+        lambda row: [row["double_col"], row["double_col"], 5.0, 6.0],
         axis=1,
     )
     backend.assert_series_equal(result, expected, check_names=False)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1059,7 +1059,7 @@ def test_repr_timestamp_array(con, monkeypatch):
     assert ibis.options.interactive is True
     assert ibis.options.default_backend is con
     expr = ibis.array(pd.date_range("2010-01-01", "2010-01-03", freq="D").tolist())
-    assert repr(expr)
+    assert "No translation rule" not in repr(expr)
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -54,6 +54,7 @@ def test_array_column(backend, alltypes, df):
     backend.assert_series_equal(result, expected, check_names=False)
 
 
+@pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
 def test_array_scalar(con):
     expr = ibis.array([1.0, 2.0, 3.0])
     assert isinstance(expr, ir.ArrayScalar)
@@ -1060,9 +1061,6 @@ def test_unnest_range(con):
 
 
 @pytest.mark.notyet(["flink"], raises=com.OperationNotDefinedError)
-@pytest.mark.broken(
-    ["dask"], reason="expression input not supported", raises=AttributeError
-)
 @pytest.mark.parametrize(
     ("input", "expected"),
     [

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -328,7 +328,7 @@ def test_unnest_default_name(backend):
     array_types = backend.array_types
     df = array_types.execute()
     expr = (
-        array_types.x.cast("!array<int64>") + ibis.array([1], type="!array<int64>")
+        array_types.x.cast("!array<int64>") + ibis.array([1]).cast("!array<int64>")
     ).unnest()
     assert expr.get_name().startswith("ArrayConcat(")
 

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1061,9 +1061,6 @@ def test_unnest_range(con):
 
 @pytest.mark.notyet(["flink"], raises=com.OperationNotDefinedError)
 @pytest.mark.broken(
-    ["pandas"], reason="expression input not supported", raises=TypeError
-)
-@pytest.mark.broken(
     ["dask"], reason="expression input not supported", raises=AttributeError
 )
 @pytest.mark.parametrize(

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -236,7 +236,7 @@ def test_map_construct_dict(con, keys, values):
 @pytest.mark.notimpl(
     ["flink"],
     raises=exc.OperationNotDefinedError,
-    reason="No translation rule for <class 'ibis.expr.operations.arrays.ArrayColumn'>",
+    reason="No translation rule for <class 'ibis.expr.operations.arrays.Array'>",
 )
 def test_map_construct_array_column(con, alltypes, df):
     expr = ibis.map(ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col]))

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -60,7 +60,7 @@ def test_timestamp_accepts_date_literals(alltypes):
     assert expr.compile(params=params) is not None
 
 
-@pytest.mark.notimpl(["dask", "impala", "pyspark", "druid", "oracle", "exasol"])
+@pytest.mark.notimpl(["impala", "pyspark", "druid", "oracle", "exasol"])
 @pytest.mark.never(
     ["mysql", "sqlite", "mssql"], reason="backend will never implement array types"
 )

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -60,9 +60,7 @@ def test_timestamp_accepts_date_literals(alltypes):
     assert expr.compile(params=params) is not None
 
 
-@pytest.mark.notimpl(
-    ["dask", "impala", "pandas", "pyspark", "druid", "oracle", "exasol"]
-)
+@pytest.mark.notimpl(["dask", "impala", "pyspark", "druid", "oracle", "exasol"])
 @pytest.mark.never(
     ["mysql", "sqlite", "mssql"], reason="backend will never implement array types"
 )

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -18,19 +18,9 @@ array_literal = param(
     ibis.array([1]),
     marks=[
         pytest.mark.never(
-            ["mssql", "oracle"],
-            raises=sa.exc.CompileError,
-            reason="arrays not supported in the backend",
-        ),
-        pytest.mark.never(
-            ["mysql"],
+            ["mysql", "mssql", "oracle", "impala", "sqlite"],
             raises=exc.OperationNotDefinedError,
             reason="arrays not supported in the backend",
-        ),
-        pytest.mark.notyet(
-            ["impala", "sqlite"],
-            raises=NotImplementedError,
-            reason="backends hasn't implemented array literals",
         ),
     ],
     id="array_literal",

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -18,8 +18,13 @@ array_literal = param(
     ibis.array([1]),
     marks=[
         pytest.mark.never(
-            ["mysql", "mssql", "oracle"],
+            ["mssql", "oracle"],
             raises=sa.exc.CompileError,
+            reason="arrays not supported in the backend",
+        ),
+        pytest.mark.never(
+            ["mysql"],
+            raises=exc.OperationNotDefinedError,
             reason="arrays not supported in the backend",
         ),
         pytest.mark.notyet(

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -117,7 +117,7 @@ def _group_concat(t, op):
 def _array_column(t, op):
     args = ", ".join(
         str(t.translate(arg).compile(compile_kwargs={"literal_binds": True}))
-        for arg in op.cols
+        for arg in op.exprs
     )
     return sa.literal_column(f"ARRAY[{args}]", type_=t.get_sqla_type(op.dtype))
 
@@ -431,7 +431,7 @@ operation_registry.update(
         ops.ArrayIndex: fixed_arity(
             lambda arg, index: sa.func.element_at(arg, index + 1), 2
         ),
-        ops.ArrayColumn: _array_column,
+        ops.Array: _array_column,
         ops.ArrayRepeat: fixed_arity(
             lambda arg, times: sa.func.flatten(sa.func.repeat(arg, times)), 2
         ),

--- a/ibis/backends/trino/registry.py
+++ b/ibis/backends/trino/registry.py
@@ -43,7 +43,7 @@ class make_array(FunctionElement):
     pass
 
 
-@compiles(make_array, "trino")
+@compiles(make_array, "default")
 def compile_make_array(element, compiler, **kw):
     return f"ARRAY[{compiler.process(element.clauses, **kw)}]"
 

--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -13,14 +13,16 @@ from ibis.expr.operations.core import Unary, Value
 
 
 @public
-class ArrayColumn(Value):
-    cols: VarTuple[Value]
+class Array(Value):
+    exprs: VarTuple[Value]
 
-    shape = ds.columnar
+    @attribute
+    def shape(self):
+        return rlz.highest_precedence_shape(self.exprs)
 
     @attribute
     def dtype(self):
-        return dt.Array(rlz.highest_precedence_dtype(self.cols))
+        return dt.Array(rlz.highest_precedence_dtype(self.exprs))
 
 
 @public

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -382,7 +382,7 @@ def test_format_literal(literal, typ, output):
 
 
 def test_format_dummy_table(snapshot):
-    t = ops.DummyTable([ibis.array([1], type="array<int8>").name("foo")]).to_expr()
+    t = ops.DummyTable([ibis.array([1]).cast("array<int8>").name("foo")]).to_expr()
 
     result = fmt(t)
     assert "DummyTable" in result

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -1020,28 +1020,13 @@ class ArrayColumn(Column, ArrayValue):
 def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayValue:
     """Create an array expression.
 
-    If the input expressions are all column expressions, then the output will
-    be an `ArrayColumn`. The input columns will be concatenated row-wise to
-    produce each array in the output array column. Each array will have length
-    _n_, where _n_ is the number of input columns. All input columns should be
-    of the same datatype.
-
-    If the input expressions are Python literals, then the output will be a
-    single `ArrayScalar` of length _n_, where _n_ is the number of input
-    values. This is equivalent to
-
-    ```python
-    values = [1, 2, 3]
-    ibis.literal(values)
-    ```
-
     Parameters
     ----------
     values
         An iterable of Ibis expressions or a list of Python literals
     type
         An instance of `ibis.expr.datatypes.DataType` or a string indicating
-        the ibis type of `value`.
+        the Ibis type of `value`.
 
     Returns
     -------
@@ -1086,7 +1071,7 @@ def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayVa
     └──────────────────────┘
     """
     if any(isinstance(value, Value) for value in values):
-        return ops.ArrayColumn(values).to_expr()
+        return ops.Array(values).to_expr()
     else:
         try:
             return literal(list(values), type=type)

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -1031,38 +1031,36 @@ def array(values: Iterable[V]) -> ArrayValue:
 
     Examples
     --------
-    Create an array column from column expressions
+    Create an array from scalar values
 
     >>> import ibis
     >>> ibis.options.interactive = True
+    >>> ibis.array([1.0, None])
+    [1.0, None]
+
+    Create an array from column and scalar expressions
+
     >>> t = ibis.memtable({"a": [1, 2, 3], "b": [4, 5, 6]})
-    >>> ibis.array([t.a, t.b])
+    >>> ibis.array([t.a, 42, ibis.literal(None)])
     ┏━━━━━━━━━━━━━━━━━━━━━━┓
     ┃ Array()              ┃
     ┡━━━━━━━━━━━━━━━━━━━━━━┩
     │ array<int64>         │
     ├──────────────────────┤
-    │ [1, 4]               │
-    │ [2, 5]               │
-    │ [3, 6]               │
+    │ [1, 42, ... +1]      │
+    │ [2, 42, ... +1]      │
+    │ [3, 42, ... +1]      │
     └──────────────────────┘
 
-    Create an array scalar from Python literals
-
-    >>> ibis.array([1.0, 2.0, 3.0])
-    [1.0, 2.0, ... +1]
-
-    Mixing scalar and column expressions is allowed
-
-    >>> ibis.array([t.a, 42])
+    >>> ibis.array([t.a, 42 + ibis.literal(5)])
     ┏━━━━━━━━━━━━━━━━━━━━━━┓
     ┃ Array()              ┃
     ┡━━━━━━━━━━━━━━━━━━━━━━┩
     │ array<int64>         │
     ├──────────────────────┤
-    │ [1, 42]              │
-    │ [2, 42]              │
-    │ [3, 42]              │
+    │ [1, 47]              │
+    │ [2, 47]              │
+    │ [3, 47]              │
     └──────────────────────┘
     """
     return ops.Array(tuple(values)).to_expr()

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -1043,7 +1043,7 @@ def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayVa
     >>> t = ibis.memtable({"a": [1, 2, 3], "b": [4, 5, 6]})
     >>> ibis.array([t.a, t.b])
     ┏━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃ ArrayColumn()        ┃
+    ┃ Array()              ┃
     ┡━━━━━━━━━━━━━━━━━━━━━━┩
     │ array<int64>         │
     ├──────────────────────┤
@@ -1061,7 +1061,7 @@ def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayVa
 
     >>> ibis.array([t.a, 42])
     ┏━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃ ArrayColumn()        ┃
+    ┃ Array()              ┃
     ┡━━━━━━━━━━━━━━━━━━━━━━┩
     │ array<int64>         │
     ├──────────────────────┤
@@ -1070,14 +1070,6 @@ def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayVa
     │ [3, 42]              │
     └──────────────────────┘
     """
-    if any(isinstance(value, Value) for value in values):
-        return ops.Array(values).to_expr()
-    else:
-        try:
-            return literal(list(values), type=type)
-        except com.IbisTypeError as e:
-            raise com.IbisTypeError(
-                "Could not create an array scalar from the values provided "
-                "to `array`. Ensure that all input values have the same "
-                "Python type, or can be casted to a single Python type."
-            ) from e
+    if type is None:
+        return ops.Array(tuple(values)).to_expr()
+    return literal(list(values), type=type)

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -1017,22 +1017,17 @@ class ArrayColumn(Column, ArrayValue):
 
 @public
 @deferrable
-def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayValue:
+def array(values: Iterable[V]) -> ArrayValue:
     """Create an array expression.
 
     Parameters
     ----------
     values
         An iterable of Ibis expressions or a list of Python literals
-    type
-        An instance of `ibis.expr.datatypes.DataType` or a string indicating
-        the Ibis type of `value`.
 
     Returns
     -------
     ArrayValue
-        An array column (if the inputs are column expressions), or an array
-        scalar (if the inputs are Python literals)
 
     Examples
     --------
@@ -1070,6 +1065,4 @@ def array(values: Iterable[V], type: str | dt.DataType | None = None) -> ArrayVa
     │ [3, 42]              │
     └──────────────────────┘
     """
-    if type is None:
-        return ops.Array(tuple(values)).to_expr()
-    return literal(list(values), type=type)
+    return ops.Array(tuple(values)).to_expr()


### PR DESCRIPTION
We were previously returning `ArrayColumn` from `ibis.array` when any inputs were expressions regardless of their shape. This PR renames `ArrayColumn` -> `Array` and uses the input arguments shapes to determine the output array shape.

Fixes #8022.