### PR TITLE
docs(blog): show how to install geospatial dependencies

### DIFF
--- a/docs/posts/ibis-duckdb-geospatial-dev-guru/index.qmd
+++ b/docs/posts/ibis-duckdb-geospatial-dev-guru/index.qmd
@@ -16,6 +16,15 @@ that walks you through a step-by-step geospatial analysis of bike sharing data u
 Ibis has support for all the geospatial functions used on the tutorial, and we
 decided to replicate it and share it with you.
 
+## Installation
+
+Install Ibis with the dependencies needed to work with geospatial data using DuckDB:
+
+```bash
+$ pip install 'ibis-framework[duckdb,geospatial]'
+```
+
+
 ## Data
 
 The parquet file used in the original tutorial is available at

--- a/docs/posts/ibis-duckdb-geospatial/index.qmd
+++ b/docs/posts/ibis-duckdb-geospatial/index.qmd
@@ -23,6 +23,14 @@ You can check Dr. Qiusheng Wu's full Spatial Data Management course material on 
 [YouTube](https://www.youtube.com/watch?v=A4TOAdsXsEs&list=PLAxJ4-o7ZoPe9SkgnophygyLjTDBzIEbi).
 :::
 
+## Installation
+
+Install Ibis with the dependencies needed to work with geospatial data using DuckDB:
+
+```bash
+$ pip install 'ibis-framework[duckdb,geospatial]'
+```
+
 ## Data
 
 We are going to be working with data from New York City. The database contains multiple tables with information about


### PR DESCRIPTION
Adds instructions on installing duckdb with geospatial dependencies in the relevant blogs.

Request from [Zulip topic](https://ibis-project.zulipchat.com/#narrow/stream/405265-tech-support/topic/.E2.9C.94.20Error.20on.20referencing.20a.20DuckDB.20table.20with.20geospatial.20column/near/417345894).