### PR TITLE
test(markers): test the test markers

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -423,7 +423,14 @@ def pytest_runtest_call(item):
         # Filter out any None values from kwargs['raises']
         # to cover any missing backend error types as defined in ibis/backends/tests/errors.py
         if (raises := kwargs.get("raises")) is not None:
-            kwargs["raises"] = tuple(filter(None, promote_tuple(raises)))
+            raises = tuple(filter(None, promote_tuple(raises)))
+            if raises:
+                kwargs["raises"] = raises
+            else:
+                # if filtering removes all of the values of raises pop the
+                # argument otherwise it gets passed as an empty tuple and this
+                # messes up xfail
+                kwargs.pop("raises")
         return kwargs
 
     # Ibis hasn't exposed existing functionality

--- a/ibis/backends/tests/test_markers.py
+++ b/ibis/backends/tests/test_markers.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+
+from ibis.backends.base import _get_backend_names
+
+all_backends = list(_get_backend_names())
+
+
+@pytest.mark.notimpl(all_backends)
+def test_notimpl(con):
+    raise Exception
+
+
+@pytest.mark.notimpl(all_backends, raises=None)
+def test_notimpl_raises_none(con):
+    raise Exception
+
+
+@pytest.mark.notimpl(all_backends, raises=(None, None))
+def test_notimpl_raises_none_tuple(con):
+    raise Exception
+
+
+@pytest.mark.notimpl(all_backends, raises=(Exception, None))
+def test_notimpl_raises_tuple_exception_none(con):
+    raise Exception
+
+
+@pytest.mark.notyet(all_backends)
+def test_notyet(con):
+    raise Exception
+
+
+@pytest.mark.notyet(all_backends, raises=None)
+def test_notyet_raises_none(con):
+    raise Exception
+
+
+@pytest.mark.notyet(all_backends, raises=(None, None))
+def test_notyet_raises_none_tuple(con):
+    raise Exception
+
+
+@pytest.mark.notyet(all_backends, raises=(Exception, None))
+def test_notyet_raises_tuple_exception_none(con):
+    raise Exception
+
+
+@pytest.mark.never(all_backends, reason="because I said so")
+def test_never(con):
+    raise Exception
+
+
+@pytest.mark.never(all_backends, raises=None, reason="because I said so")
+def test_never_raises_none(con):
+    raise Exception
+
+
+@pytest.mark.never(all_backends, raises=(None, None), reason="because I said so")
+def test_never_raises_none_tuple(con):
+    raise Exception
+
+
+@pytest.mark.never(all_backends, raises=(Exception, None), reason="because I said so")
+def test_never_raises_tuple_exception_none(con):
+    raise Exception


### PR DESCRIPTION
I had a thought about a potential edge case with `None` being the only
listed "Exception" in a `raises` argument.  This fixes the edge case and
also adds some simple tests to make sure our custom markers correctly
handle when an imported backend exception is set to `None` due to a
missing import.