### PR TITLE
fix(many): try to allow passing both overwrite and temp to create_table

### DIFF
--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -271,6 +271,7 @@ class Backend(SQLGlotBackend):
         schema: sch.Schema | None = None,
         database: str | None = None,
         overwrite: bool = False,
+        temp: bool = False,
     ) -> ir.Table:
         """Create a table in Snowflake.
 
@@ -289,13 +290,20 @@ class Backend(SQLGlotBackend):
         overwrite
             If `True`, replace the table if it already exists, otherwise fail
             if the table exists
+        temp
+            Create a temporary table (not supported)
         """
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
 
+        if temp:
+            raise com.UnsupportedOperationError(
+                "Creating temp tables is not supported by Exasol."
+            )
+
         if database is not None and database != self.current_database:
             raise com.UnsupportedOperationError(
-                "Creating tables in other databases is not supported by Postgres"
+                "Creating tables in other databases is not supported by Exasol"
             )
         else:
             database = None

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -340,7 +340,7 @@ class Backend(BaseBackend):
                 "effect: Polars cannot set a database."
             )
 
-        if temp is not None:
+        if temp:
             raise com.IbisError(
                 "Passing `temp=True` to the Polars backend create_table method has no "
                 "effect: all tables are in memory and temporary. "


### PR DESCRIPTION
This started out as a "simple" effort to allow passing both `temp` and `overwrite` to `create_table` in DuckDB.  That works, and so I added a test.  And there my journey begins...

## Description of changes

* Handle intersection of `temp=True` and `overwrite=True` in DuckDB and Oracle
* Fix drop table on oracle to handle dropping temp tables (this was missed in the port to sqlglot)
* Ensure that memtables on Oracle are both a) temporary and b) cleaned up on exit (another miss in the port)
* Add a missing `temp` kwarg to Exasol for API consistency
* Relax a check against the `temp` kwarg in Polars that was a bit too strict (`False` should be allowed)



## Issues closed

I never got around to opening the issue, but this should resolve the problems @ncclementi was seeing trying to create a temp table in DuckDB with `overwrite=True`.