### PR TITLE
docs(blog): update geospatial - no need to_array()

### DIFF
--- a/docs/posts/ibis-duckdb-geospatial/index.qmd
+++ b/docs/posts/ibis-duckdb-geospatial/index.qmd
@@ -117,7 +117,7 @@ boroughs
 ```
 
 ```{python}
-boroughs.filter(boroughs.geom.intersects(broad_station.select(broad_station.geom).to_array()))
+boroughs.filter(_.geom.intersects(broad_station.geom))
 ```
 
 ### `d_within` (ST_DWithin)
@@ -133,14 +133,9 @@ streets
 Using the deferred API, we can check which streets are within `d=10` meters of distance.
 
 ```{python}
-sts_near_broad = streets.filter(_.geom.d_within(broad_station.select(_.geom).to_array(), 10))
+sts_near_broad = streets.filter(_.geom.d_within(broad_station.geom, 10))
 sts_near_broad
 ```
-
-::: {.callout-note}
-In the previous query, `streets` and `broad_station` are different tables. We use [`to_array()`](../../reference/expression-tables.qmd#ibis.expr.types.relations.Table.to_array) to generate a
-scalar subquery from a table with a single column (whose shape is scalar).
-:::
 
 To visualize the findings, we will convert the tables to GeoPandas DataFrames.
 
@@ -201,7 +196,7 @@ To find if there were any homicides in that area, we can find where the polygon 
 200 meters buffer to our "Broad St" station point intersects with the geometry column in our homicides table.
 
 ```{python}
-h_near_broad = homicides.filter(_.geom.intersects(broad_station.select(_.geom.buffer(200)).to_array()))
+h_near_broad = homicides.filter(_.geom.intersects(broad_station.geom.buffer(200)))
 h_near_broad
 ```
 
@@ -210,7 +205,7 @@ data we can't tell the street near which it happened. However, we can check if t
 distance of a street.
 
 ```{python}
-h_street = streets.filter(_.geom.d_within(h_near_broad.select(_.geom).to_array(), 2))
+h_street = streets.filter(_.geom.d_within(h_near_broad.geom, 2))
 h_street
 ```
 


### PR DESCRIPTION
## Description of changes

At the moment of writing this blog, there was a need to use[to_array()](https://ibis-project.org/reference/expression-tables#ibis.expr.types.relations.Table.to_array) to generate a scalar subquery from a table with a single column (whose shape is scalar). Otherwise it wouldn't work. For example: 

```python
sts_near_broad = streets.filter(_.geom.d_within(broad_station.select(_.geom).to_array(), 10))
```
However, a user posted on Zulip, that this wasn't needed. See [Zulip: Geospatial-not clear why `.to_array()` is required](https://ibis-project.zulipchat.com/#narrow/stream/405265-tech-support/topic/Geospatial.20-.20not.20clear.20why.20.2Eto_array.28.29.20is.20required/near/417987170)

After checking, the user is right, there is no need now for this. 

This PR, updates the queries accordingly
