### PR TITLE
ci(docker): yes -> "yes" to avoid yaml parsing weirdness

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -98,7 +98,7 @@ services:
     environment:
       MINIO_ROOT_USER: accesskey
       MINIO_ROOT_PASSWORD: secretkey
-      MINIO_SKIP_CLIENT: yes
+      MINIO_SKIP_CLIENT: "yes"
     healthcheck:
       interval: 1s
       retries: 20


### PR DESCRIPTION
The `minio` container was failing to start in my local setup since `yes` was being parsed as `True` due to yaml's ~features~ weirdness. I'm assuming since this wasn't already failing in CI that some other version of docker-compose has patched around this yaml issue, but it's easy enough to fix it for everyone here.