### PR TITLE
fix(api): support passing literal booleans to `filter`

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -106,7 +106,7 @@ def _regular_join_method(
 # nested inputs
 def bind(table: TableExpr, value: Any, prefer_column=True) -> Iterator[ir.Value]:
     """Bind a value to a table expression."""
-    if prefer_column and isinstance(value, (str, int)):
+    if prefer_column and type(value) in (str, int):
         yield table._get_column(value)
     elif isinstance(value, ValueExpr):
         yield value

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -730,6 +730,18 @@ def test_aggregate_keywords(table):
     assert_equal(expr2, expected)
 
 
+def test_filter_on_literal_boolean(table):
+    expr1 = table.filter(True)
+    expr2 = table.filter(ibis.literal(True))
+    assert expr1.equals(expr2)
+
+
+def test_filter_on_literal_string_is_column(table):
+    expr1 = table.filter("h")
+    expr2 = table.filter(table.h)
+    assert expr1.equals(expr2)
+
+
 def test_filter_on_literal_then_aggregate(table):
     # Mostly just a smoketest, this used to error on construction
     expr = table.filter(ibis.literal(True)).agg(lambda t: t.a.sum().name("total"))


### PR DESCRIPTION
Fixes #8103.