### PR TITLE
chore: escape "\." in re_split() docstring

### DIFF
--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -1082,7 +1082,7 @@ class StringValue(Value):
         why="Different backends support different regular expression syntax."
     )
     def re_split(self, pattern: str | StringValue) -> ir.ArrayValue:
-        """Split a string by a regular expression `pattern`.
+        r"""Split a string by a regular expression `pattern`.
 
         Parameters
         ----------


### PR DESCRIPTION
This was giving me a `SyntaxError: invalid escape sequence '\.'`