### PR TITLE
test(api): add test for alias generation

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1219,7 +1219,7 @@ def execute_view(op, *, ctx: pl.SQLContext, **kw):
 
 @translate.register(ops.SelfReference)
 def execute_self_reference(op, **kw):
-    return translate(op.table, **kw)
+    return translate(op.parent, **kw)
 
 
 @translate.register(ops.JoinTable)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -937,9 +937,6 @@ def test_agg_memory_table(con, monkeypatch):
     assert result == 3
 
 
-@pytest.mark.broken(
-    ["polars"], reason="join column renaming is currently incorrect on polars"
-)
 def test_self_join_memory_table(backend, con, monkeypatch):
     monkeypatch.setattr(ibis.options, "default_backend", con)
 

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -195,3 +195,14 @@ def test_union_aliasing(backend_name, snapshot):
     result = top_ten.union(bottom_ten)
 
     snapshot.assert_match(str(ibis.to_sql(result, dialect=backend_name)), "out.sql")
+
+
+def test_union_generates_predictable_aliases(con):
+    t = ibis.memtable(
+        data=[{"island": "Torgerson", "body_mass_g": 3750, "sex": "male"}]
+    )
+    sub1 = t.inner_join(t.view(), "island").mutate(island_right=lambda t: t.island)
+    sub2 = t.inner_join(t.view(), "sex").mutate(sex_right=lambda t: t.sex)
+    expr = ibis.union(sub1, sub2)
+    df = con.execute(expr)
+    assert len(df) == 2


### PR DESCRIPTION
Adds a test for #7350.

Closes #7350.