### PR TITLE
fix(common): don't match an `Object` pattern with more positional arguments defined than `__match_args__` has

### DIFF
--- a/ibis/backends/base/sqlglot/tests/test_compiler.py
+++ b/ibis/backends/base/sqlglot/tests/test_compiler.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import ibis
+from ibis import _
+
+
+def test_window_with_row_number_compiles():
+    # GH #8058: the add_order_by_to_empty_ranking_window_functions rule was
+    # matching on `RankBase` subclasses with a pattern expecting an `arg`
+    # attribute, which is not present on `RowNumber`
+    expr = (
+        ibis.memtable({"a": range(30)})
+        .mutate(id=ibis.row_number())
+        .sample(fraction=0.25, seed=0)
+        .mutate(is_test=_.id.isin(_.id))
+        .filter(~_.is_test)
+    )
+    assert ibis.to_sql(expr)


### PR DESCRIPTION
Turns out one of the patterns were referencing non-existing fields and the `Object` pattern was still matching on it.

Fixes https://github.com/ibis-project/ibis/issues/8058.