### PR TITLE
fix(polars): columns are picked from the correct side in case of conflicting names

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -988,9 +988,7 @@ def test_memtable_column_naming_mismatch(backend, con, monkeypatch, df, columns)
 
 
 @pytest.mark.notimpl(
-    ["dask", "pandas", "polars"],
-    raises=NotImplementedError,
-    reason="not a SQL backend",
+    ["dask", "pandas", "polars"], raises=NotImplementedError, reason="not a SQL backend"
 )
 @pytest.mark.notimpl(["flink"], reason="no sqlglot dialect", raises=ValueError)
 def test_many_subqueries(con, snapshot):


### PR DESCRIPTION
It has been already fixed by [the rewrite converting the join chain to pairwise join operations](https://github.com/ibis-project/ibis/issues/7345
), so this only adds a test case.

Fixes https://github.com/ibis-project/ibis/issues/7345
Depends on https://github.com/ibis-project/ibis/pull/8127
