### PR TITLE
refactor(sql): remove temporary table creation when using inline sql

### DIFF
--- a/ibis/backends/base/sqlglot/__init__.py
+++ b/ibis/backends/base/sqlglot/__init__.py
@@ -151,6 +151,17 @@ class SQLGlotBackend(BaseBackend):
         """Return an ibis Schema from a backend-specific SQL string."""
         return sch.Schema.from_tuples(self._metadata(query))
 
+    def _get_sql_string_view_schema(self, child: ir.Table, query: str) -> sch.Schema:
+        # abort if somehow this was called with a non-view
+        assert isinstance(child.op(), ops.View), type(child.op())
+
+        obj = self._to_sqlglot(child)
+        dialect = self.compiler.dialect
+        parsed = sg.parse_one(query, read=dialect)
+        parsed.args["with"] = obj.args["with"]
+        sql = parsed.sql(dialect)
+        return self._get_schema_using_query(sql)
+
     def create_view(
         self,
         name: str,
@@ -194,27 +205,6 @@ class SQLGlotBackend(BaseBackend):
         )
         with self._safe_raw_sql(src):
             pass
-
-    def _get_temp_view_definition(self, name: str, definition: str) -> str:
-        return sge.Create(
-            this=sg.to_identifier(name, quoted=self.compiler.quoted),
-            kind="VIEW",
-            expression=definition,
-            replace=True,
-            properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
-        )
-
-    def _create_temp_view(self, table_name, source):
-        if table_name not in self._temp_views and table_name in self.list_tables():
-            raise ValueError(
-                f"{table_name} already exists as a non-temporary table or view"
-            )
-
-        with self._safe_raw_sql(self._get_temp_view_definition(table_name, source)):
-            pass
-
-        self._temp_views.add(table_name)
-        self._register_temp_view_cleanup(table_name)
 
     def _register_temp_view_cleanup(self, name: str) -> None:
         """Register a clean up function for a temporary view.

--- a/ibis/backends/base/sqlglot/__init__.py
+++ b/ibis/backends/base/sqlglot/__init__.py
@@ -152,12 +152,15 @@ class SQLGlotBackend(BaseBackend):
         return sch.Schema.from_tuples(self._metadata(query))
 
     def _get_sql_string_view_schema(self, name, table, query) -> sch.Schema:
-        dialect = self.compiler.dialect
+        compiler = self.compiler
+        dialect = compiler.dialect
 
         cte = self._to_sqlglot(table)
         parsed = sg.parse_one(query, read=dialect)
         parsed.args["with"] = cte.args.pop("with", [])
-        parsed = parsed.with_(name, as_=cte, dialect=dialect)
+        parsed = parsed.with_(
+            sg.to_identifier(name, quoted=compiler.quoted), as_=cte, dialect=dialect
+        )
 
         sql = parsed.sql(dialect)
         return self._get_schema_using_query(sql)

--- a/ibis/backends/base/sqlglot/rewrites.py
+++ b/ibis/backends/base/sqlglot/rewrites.py
@@ -157,7 +157,9 @@ def extract_ctes(node):
 
     g = Graph.from_bfs(node, filter=(ops.Relation, ops.Subquery, ops.JoinLink))
     for node, dependents in g.invert().items():
-        if len(dependents) > 1 and isinstance(node, cte_types):
+        if isinstance(node, ops.View) or (
+            len(dependents) > 1 and isinstance(node, cte_types)
+        ):
             result.append(node)
 
     return result
@@ -176,7 +178,7 @@ def sqlize(node):
     step2 = step1.replace(merge_select_select)
 
     ctes = extract_ctes(step2)
-    subs = {cte: CTE(cte) for cte in ctes}
+    subs = {cte: CTE(cte) for cte in ctes if not isinstance(cte, ops.View)}
     step3 = step2.replace(subs)
 
     return step3, ctes

--- a/ibis/backends/base/sqlglot/rewrites.py
+++ b/ibis/backends/base/sqlglot/rewrites.py
@@ -178,7 +178,7 @@ def sqlize(node):
     step2 = step1.replace(merge_select_select)
 
     ctes = extract_ctes(step2)
-    subs = {cte: CTE(cte) for cte in ctes if not isinstance(cte, ops.View)}
+    subs = {cte: CTE(cte) for cte in ctes}
     step3 = step2.replace(subs)
 
     return step3, ctes

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -92,8 +92,6 @@ class Backend(SQLGlotBackend, CanCreateDatabase, CanCreateSchema):
         for name, path in config.items():
             self.register(path, table_name=name)
 
-        self._temp_views = set()
-
     @contextlib.contextmanager
     def _safe_raw_sql(self, sql: sge.Statement) -> Any:
         yield self.raw_sql(sql)

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -86,7 +86,6 @@ class Backend(SQLGlotBackend):
         """Create an Ibis client using the passed connection parameters."""
         header = kwargs.pop("header", True)
         self.con = pydruid.db.connect(**kwargs, header=header)
-        self._temp_views = set()
 
     @contextlib.contextmanager
     def _safe_raw_sql(self, query, *args, **kwargs):

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1534,3 +1534,16 @@ class Backend(SQLGlotBackend, CanCreateSchema):
                 table_name,
                 obj if isinstance(obj, pd.DataFrame) else pd.DataFrame(obj),
             )
+
+    def _get_temp_view_definition(self, name: str, definition: str) -> str:
+        return sge.Create(
+            this=sg.to_identifier(name, quoted=self.compiler.quoted),
+            kind="VIEW",
+            expression=definition,
+            replace=True,
+            properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
+        )
+
+    def _create_temp_view(self, table_name, source):
+        with self._safe_raw_sql(self._get_temp_view_definition(table_name, source)):
+            pass

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from ibis.backends.base import BaseBackend
 
 # strip trailing encodings e.g., UTF8
-_VARCHAR_REGEX = re.compile(r"^(VARCHAR(?:\(\d+\)))?(?:\s+.+)?$")
+_VARCHAR_REGEX = re.compile(r"^((VAR)?CHAR(?:\(\d+\)))?(?:\s+.+)?$")
 
 
 class Backend(SQLGlotBackend):
@@ -90,7 +90,6 @@ class Backend(SQLGlotBackend):
             quote_ident=True,
             **kwargs,
         )
-        self._temp_views = set()
 
     def _from_url(self, url: str, **kwargs) -> BaseBackend:
         """Construct an ibis backend from a SQLAlchemy-conforming URL."""

--- a/ibis/backends/mssql/compiler.py
+++ b/ibis/backends/mssql/compiler.py
@@ -291,10 +291,6 @@ class MSSQLCompiler(SQLGlotCompiler):
             return self.f.dateadd(self.v.s, arg / 1_000, "1970-01-01 00:00:00")
         raise com.UnsupportedOperationError(f"{unit!r} unit is not supported!")
 
-    @visit_node.register(ops.SQLStringView)
-    def visit_SQLStringView(self, op, *, query: str, name: str, child):
-        return sg.parse_one(query, read=self.dialect).subquery(name)
-
     def visit_NonNullLiteral(self, op, *, value, dtype):
         if dtype.is_decimal():
             return self.cast(str(value.normalize()), dtype)

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -268,8 +268,6 @@ class Backend(SQLGlotBackend):
         with self.begin() as cur:
             cur.execute("SET TIMEZONE = UTC")
 
-        self._temp_views = set()
-
     def list_tables(
         self,
         like: str | None = None,
@@ -551,13 +549,6 @@ $$""".format(**self._get_udf_source(udf_node))
         finally:
             with self._safe_raw_sql(drop_stmt):
                 pass
-
-    def _get_temp_view_definition(self, name: str, definition):
-        drop = sge.Drop(
-            kind="VIEW", exists=True, this=sg.table(name), cascade=True
-        ).sql(self.name)
-        create = super()._get_temp_view_definition(name, definition)
-        return f"{drop}; {create}"
 
     def create_schema(
         self, name: str, database: str | None = None, force: bool = False

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/bigquery/out.sql
@@ -1,0 +1,8 @@
+WITH foo AS (
+  SELECT
+    *
+  FROM `ibis-gbq`.ibis_gbq_testing.bigquery_temp_mem_t_for_cte AS t0
+)
+SELECT
+  COUNT(*) AS `x`
+FROM `foo`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/bigquery/out.sql
@@ -1,7 +1,7 @@
 WITH foo AS (
   SELECT
     *
-  FROM `ibis-gbq`.ibis_gbq_testing.bigquery_temp_mem_t_for_cte AS t0
+  FROM `ibis-gbq`.ibis_gbq_testing.test_bigquery_temp_mem_t_for_cte AS t0
 )
 SELECT
   COUNT(*) AS `x`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/clickhouse/out.sql
@@ -1,7 +1,7 @@
 WITH foo AS (
   SELECT
     *
-  FROM clickhouse_temp_mem_t_for_cte AS t0
+  FROM test_clickhouse_temp_mem_t_for_cte AS t0
 )
 SELECT
   COUNT(*) AS "x"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/clickhouse/out.sql
@@ -1,0 +1,8 @@
+WITH foo AS (
+  SELECT
+    *
+  FROM clickhouse_temp_mem_t_for_cte AS t0
+)
+SELECT
+  COUNT(*) AS "x"
+FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/datafusion/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/datafusion/out.sql
@@ -1,0 +1,8 @@
+WITH "foo" AS (
+  SELECT
+    *
+  FROM "datafusion_temp_mem_t_for_cte" AS "t0"
+)
+SELECT
+  COUNT(*) AS "x"
+FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/datafusion/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/datafusion/out.sql
@@ -1,7 +1,7 @@
 WITH "foo" AS (
   SELECT
     *
-  FROM "datafusion_temp_mem_t_for_cte" AS "t0"
+  FROM "test_datafusion_temp_mem_t_for_cte" AS "t0"
 )
 SELECT
   COUNT(*) AS "x"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/duckdb/out.sql
@@ -1,7 +1,7 @@
 WITH foo AS (
   SELECT
     *
-  FROM duckdb_temp_mem_t_for_cte AS t0
+  FROM test_duckdb_temp_mem_t_for_cte AS t0
 )
 SELECT
   COUNT(*) AS "x"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/duckdb/out.sql
@@ -1,0 +1,8 @@
+WITH foo AS (
+  SELECT
+    *
+  FROM duckdb_temp_mem_t_for_cte AS t0
+)
+SELECT
+  COUNT(*) AS "x"
+FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/exasol/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/exasol/out.sql
@@ -1,0 +1,8 @@
+WITH "foo" AS (
+  SELECT
+    *
+  FROM "exasol_temp_mem_t_for_cte" AS "t0"
+)
+SELECT
+  COUNT(*) AS "x"
+FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/impala/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/impala/out.sql
@@ -1,0 +1,8 @@
+WITH `foo` AS (
+  SELECT
+    *
+  FROM `ibis_testing`.`impala_temp_mem_t_for_cte` AS `t0`
+)
+SELECT
+  COUNT(*) AS `x`
+FROM `foo`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/impala/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/impala/out.sql
@@ -1,7 +1,7 @@
 WITH `foo` AS (
   SELECT
     *
-  FROM `ibis_testing`.`impala_temp_mem_t_for_cte` AS `t0`
+  FROM `ibis_testing`.`test_impala_temp_mem_t_for_cte` AS `t0`
 )
 SELECT
   COUNT(*) AS `x`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mssql/out.sql
@@ -1,0 +1,8 @@
+WITH [foo] AS (
+  SELECT
+    *
+  FROM [mssql_temp_mem_t_for_cte] AS [t0]
+)
+SELECT
+  COUNT(*) AS [x]
+FROM [foo]

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mssql/out.sql
@@ -1,7 +1,7 @@
 WITH [foo] AS (
   SELECT
     *
-  FROM [mssql_temp_mem_t_for_cte] AS [t0]
+  FROM [test_mssql_temp_mem_t_for_cte] AS [t0]
 )
 SELECT
   COUNT(*) AS [x]

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mysql/out.sql
@@ -1,7 +1,7 @@
 WITH `foo` AS (
   SELECT
     *
-  FROM `mysql_temp_mem_t_for_cte` AS `t0`
+  FROM `test_mysql_temp_mem_t_for_cte` AS `t0`
 )
 SELECT
   COUNT(*) AS `x`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mysql/out.sql
@@ -1,0 +1,8 @@
+WITH `foo` AS (
+  SELECT
+    *
+  FROM `mysql_temp_mem_t_for_cte` AS `t0`
+)
+SELECT
+  COUNT(*) AS `x`
+FROM `foo`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/oracle/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/oracle/out.sql
@@ -1,0 +1,8 @@
+WITH "foo" AS (
+  SELECT
+    *
+  FROM "oracle_temp_mem_t_for_cte" "t0"
+)
+SELECT
+  COUNT(*) AS "x"
+FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/oracle/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/oracle/out.sql
@@ -1,7 +1,7 @@
 WITH "foo" AS (
   SELECT
     *
-  FROM "oracle_temp_mem_t_for_cte" "t0"
+  FROM "test_oracle_temp_mem_t_for_cte" "t0"
 )
 SELECT
   COUNT(*) AS "x"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/postgres/out.sql
@@ -1,0 +1,8 @@
+WITH "foo" AS (
+  SELECT
+    *
+  FROM "postgres_temp_mem_t_for_cte" AS "t0"
+)
+SELECT
+  COUNT(*) AS "x"
+FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/postgres/out.sql
@@ -1,7 +1,7 @@
 WITH "foo" AS (
   SELECT
     *
-  FROM "postgres_temp_mem_t_for_cte" AS "t0"
+  FROM "test_postgres_temp_mem_t_for_cte" AS "t0"
 )
 SELECT
   COUNT(*) AS "x"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/pyspark/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/pyspark/out.sql
@@ -1,7 +1,7 @@
 WITH `foo` AS (
   SELECT
     *
-  FROM `pyspark_temp_mem_t_for_cte` AS `t0`
+  FROM `test_pyspark_temp_mem_t_for_cte` AS `t0`
 )
 SELECT
   COUNT(*) AS `x`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/pyspark/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/pyspark/out.sql
@@ -1,0 +1,8 @@
+WITH `foo` AS (
+  SELECT
+    *
+  FROM `pyspark_temp_mem_t_for_cte` AS `t0`
+)
+SELECT
+  COUNT(*) AS `x`
+FROM `foo`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/snowflake/out.sql
@@ -1,7 +1,7 @@
 WITH "foo" AS (
   SELECT
     *
-  FROM "test_exasol_temp_mem_t_for_cte" AS "t0"
+  FROM "test_snowflake_temp_mem_t_for_cte" AS "t0"
 )
 SELECT
   COUNT(*) AS "x"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/sqlite/out.sql
@@ -1,0 +1,8 @@
+WITH "foo" AS (
+  SELECT
+    *
+  FROM "test_sqlite_temp_mem_t_for_cte" AS "t0"
+)
+SELECT
+  COUNT(*) AS "x"
+FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/trino/out.sql
@@ -1,7 +1,7 @@
 WITH "foo" AS (
   SELECT
     *
-  FROM "trino_temp_mem_t_for_cte" AS "t0"
+  FROM "test_trino_temp_mem_t_for_cte" AS "t0"
 )
 SELECT
   COUNT(*) AS "x"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/trino/out.sql
@@ -1,0 +1,8 @@
+WITH "foo" AS (
+  SELECT
+    *
+  FROM "trino_temp_mem_t_for_cte" AS "t0"
+)
+SELECT
+  COUNT(*) AS "x"
+FROM "foo"

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
+import contextlib
+
 import pandas as pd
 import pytest
 import sqlglot as sg
 from pytest import param
 
 import ibis
+import ibis.common.exceptions as com
 from ibis import _
 from ibis.backends.base import _IBIS_TO_SQLGLOT_DIALECT, _get_backend_names
-from ibis.backends.tests.errors import PolarsComputeError
-
-table_dot_sql_notimpl = pytest.mark.notimpl(["bigquery", "impala", "druid"])
-dot_sql_notimpl = pytest.mark.notimpl(["exasol", "flink"])
-dot_sql_notyet = pytest.mark.notyet(
-    ["snowflake", "oracle"],
-    reason="snowflake and oracle column names are case insensitive",
+from ibis.backends.tests.errors import (
+    GoogleBadRequest,
+    OracleDatabaseError,
+    PolarsComputeError,
 )
+
+dot_sql_notimpl = pytest.mark.notimpl(["flink"])
 dot_sql_never = pytest.mark.never(
     ["dask", "pandas"], reason="dask and pandas do not accept SQL"
 )
@@ -49,7 +51,7 @@ def test_con_dot_sql(backend, con, schema):
     alltypes = backend.functional_alltypes
     # pull out the quoted name
     name = _NAMES.get(con.name, "functional_alltypes")
-    quoted = getattr(getattr(con, "compiler", None), "quoted", True)
+    quoted = True
     dialect = _IBIS_TO_SQLGLOT_DIALECT.get(con.name, con.name)
     cols = [
         sg.column("string_col", quoted=quoted).as_("s", quoted=quoted).sql(dialect),
@@ -82,26 +84,31 @@ def test_con_dot_sql(backend, con, schema):
     backend.assert_series_equal(result.astype(expected.dtype), expected)
 
 
-@table_dot_sql_notimpl
 @dot_sql_notimpl
-@dot_sql_notyet
 @dot_sql_never
 @pytest.mark.notyet(["polars"], raises=PolarsComputeError)
-def test_table_dot_sql(backend, con):
-    alltypes = con.table("functional_alltypes")
+@pytest.mark.notyet(
+    ["bigquery"], raises=GoogleBadRequest, reason="requires a qualified name"
+)
+@pytest.mark.notyet(
+    ["druid"], raises=com.IbisTypeError, reason="druid does not preserve case"
+)
+def test_table_dot_sql(backend):
+    alltypes = backend.functional_alltypes
     t = (
         alltypes.sql(
             """
             SELECT
-                string_col as s,
-                double_col + 1.0 AS new_col
-            FROM functional_alltypes
-            """
+              "string_col" AS "s",
+              "double_col" + CAST(1.0 AS DOUBLE) AS "new_col"
+            FROM "functional_alltypes"
+            """,
+            dialect="duckdb",
         )
         .group_by("s")  # group by a column from SQL
         .aggregate(fancy_af=lambda t: t.new_col.mean())
         .alias("awesome_t")  # create a name for the aggregate
-        .sql("SELECT fancy_af AS yas FROM awesome_t")
+        .sql('SELECT "fancy_af" AS "yas" FROM "awesome_t"', dialect="duckdb")
         .order_by(_.yas)
     )
 
@@ -117,24 +124,34 @@ def test_table_dot_sql(backend, con):
         .reset_index()
         .yas
     )
-    backend.assert_series_equal(result, expected)
+    assert pytest.approx(result) == expected
 
 
-@table_dot_sql_notimpl
 @dot_sql_notimpl
-@dot_sql_notyet
 @dot_sql_never
 @pytest.mark.notyet(["polars"], raises=PolarsComputeError)
-def test_table_dot_sql_with_join(backend, con):
-    alltypes = con.table("functional_alltypes")
+@pytest.mark.notyet(
+    ["bigquery"], raises=GoogleBadRequest, reason="requires a qualified name"
+)
+@pytest.mark.notyet(
+    ["druid"], raises=com.IbisTypeError, reason="druid does not preserve case"
+)
+@pytest.mark.notimpl(
+    ["oracle"],
+    OracleDatabaseError,
+    reason="oracle doesn't know which of the tables in the join to sort from",
+)
+def test_table_dot_sql_with_join(backend):
+    alltypes = backend.functional_alltypes
     t = (
         alltypes.sql(
             """
             SELECT
-                string_col as s,
-                double_col + 1.0 AS new_col
-            FROM functional_alltypes
-            """
+              "string_col" AS "s",
+              "double_col" + CAST(1.0 AS DOUBLE) AS "new_col"
+            FROM "functional_alltypes"
+            """,
+            dialect="duckdb",
         )
         .alias("ft")
         .group_by("s")  # group by a column from SQL
@@ -143,12 +160,13 @@ def test_table_dot_sql_with_join(backend, con):
         .sql(
             """
             SELECT
-                l.fancy_af AS yas,
-                r.s AS s
-            FROM awesome_t AS l
-            LEFT JOIN ft AS r
-            ON l.s = r.s
-            """  # clickhouse needs the r.s AS s, otherwise the column name is returned as r.s
+              "l"."fancy_af" AS "yas",
+              "r"."s" AS "s"
+            FROM "awesome_t" AS "l"
+            LEFT JOIN "ft" AS "r"
+            ON "l"."s" = "r"."s"
+            """,  # clickhouse needs the r.s AS s, otherwise the column name is returned as r.s
+            dialect="duckdb",
         )
         .order_by(["s", "yas"])
     )
@@ -168,48 +186,39 @@ def test_table_dot_sql_with_join(backend, con):
     backend.assert_frame_equal(result, expected)
 
 
-@table_dot_sql_notimpl
 @dot_sql_notimpl
-@dot_sql_notyet
 @dot_sql_never
 @pytest.mark.notyet(["polars"], raises=PolarsComputeError)
-def test_table_dot_sql_repr(con):
-    alltypes = con.table("functional_alltypes")
+@pytest.mark.notyet(["druid"], reason="druid doesn't respect column name case")
+@pytest.mark.notyet(
+    ["bigquery"], raises=GoogleBadRequest, reason="requires a qualified name"
+)
+def test_table_dot_sql_repr(backend):
+    alltypes = backend.functional_alltypes
     t = (
         alltypes.sql(
             """
             SELECT
-                string_col as s,
-                double_col + 1.0 AS new_col
-            FROM functional_alltypes
-            """
+              "string_col" AS "s",
+              "double_col" + CAST(1.0 AS DOUBLE) AS "new_col"
+            FROM "functional_alltypes"
+            """,
+            dialect="duckdb",
         )
         .group_by("s")  # group by a column from SQL
         .aggregate(fancy_af=lambda t: t.new_col.mean())
         .alias("awesome_t")  # create a name for the aggregate
-        .sql("SELECT fancy_af AS yas FROM awesome_t ORDER BY fancy_af")
+        .sql(
+            'SELECT "fancy_af" AS "yas" FROM "awesome_t" ORDER BY "fancy_af"',
+            dialect="duckdb",
+        )
     )
 
     assert repr(t)
 
 
-@table_dot_sql_notimpl
 @dot_sql_notimpl
 @dot_sql_never
-@pytest.mark.notimpl(["oracle"])
-@pytest.mark.notyet(["polars"], raises=PolarsComputeError)
-@pytest.mark.notimpl(["exasol"], strict=False)
-def test_table_dot_sql_does_not_clobber_existing_tables(con, temp_table):
-    t = con.create_table(temp_table, schema=ibis.schema(dict(a="string")))
-    expr = t.sql("SELECT 1 as x FROM functional_alltypes")
-    with pytest.raises(ValueError):
-        expr.alias(temp_table)
-
-
-@table_dot_sql_notimpl
-@dot_sql_notimpl
-@dot_sql_never
-@pytest.mark.notimpl(["oracle"])
 def test_dot_sql_alias_with_params(backend, alltypes, df):
     t = alltypes
     x = t.select(x=t.string_col + " abc").alias("foo")
@@ -218,10 +227,8 @@ def test_dot_sql_alias_with_params(backend, alltypes, df):
     backend.assert_series_equal(result.x, expected)
 
 
-@table_dot_sql_notimpl
 @dot_sql_notimpl
 @dot_sql_never
-@pytest.mark.notimpl(["oracle"])
 def test_dot_sql_reuse_alias_with_different_types(backend, alltypes, df):
     foo1 = alltypes.select(x=alltypes.string_col).alias("foo")
     foo2 = alltypes.select(x=alltypes.bigint_col).alias("foo")
@@ -248,14 +255,13 @@ no_sqlglot_dialect = sorted(
     ],
 )
 @pytest.mark.notyet(["polars"], raises=PolarsComputeError)
-@table_dot_sql_notimpl
 @dot_sql_notimpl
-@dot_sql_notyet
 @dot_sql_never
+@pytest.mark.notyet(["druid"], reason="druid doesn't respect column name case")
 def test_table_dot_sql_transpile(backend, alltypes, dialect, df):
     name = "foo2"
     foo = alltypes.select(x=_.bigint_col + 1).alias(name)
-    expr = sg.select("x").from_(sg.table(name, quoted=True))
+    expr = sg.select(sg.column("x", quoted=True)).from_(sg.table(name, quoted=True))
     dialect = _IBIS_TO_SQLGLOT_DIALECT.get(dialect, dialect)
     sqlstr = expr.sql(dialect=dialect, pretty=True)
     dot_sql_expr = foo.sql(sqlstr, dialect=dialect)
@@ -276,14 +282,13 @@ def test_table_dot_sql_transpile(backend, alltypes, dialect, df):
     ["druid"], raises=AttributeError, reason="druid doesn't respect column names"
 )
 @pytest.mark.notyet(["snowflake", "bigquery"])
-@pytest.mark.notyet(
-    ["oracle"], strict=False, reason="only works with backends that quote everything"
-)
 @dot_sql_notimpl
 @dot_sql_never
 def test_con_dot_sql_transpile(backend, con, dialect, df):
-    t = sg.table("functional_alltypes")
-    foo = sg.select(sg.alias(sg.column("bigint_col") + 1, "x")).from_(t)
+    t = sg.table("functional_alltypes", quoted=True)
+    foo = sg.select(
+        sg.alias(sg.column("bigint_col", quoted=True) + 1, "x", quoted=True)
+    ).from_(t)
     dialect = _IBIS_TO_SQLGLOT_DIALECT.get(dialect, dialect)
     sqlstr = foo.sql(dialect=dialect, pretty=True)
     expr = con.sql(sqlstr, dialect=dialect)
@@ -294,13 +299,12 @@ def test_con_dot_sql_transpile(backend, con, dialect, df):
 
 @dot_sql_notimpl
 @dot_sql_never
-@pytest.mark.notimpl(["druid", "flink", "polars"])
+@pytest.mark.notimpl(["druid", "flink", "polars", "exasol"])
 @pytest.mark.notyet(["snowflake"], reason="snowflake column names are case insensitive")
 def test_order_by_no_projection(backend):
     con = backend.connection
-    astronauts = con.table("astronauts")
     expr = (
-        astronauts.group_by("name")
+        backend.astronauts.group_by("name")
         .agg(nbr_missions=_.count())
         .order_by(_.nbr_missions.desc())
     )
@@ -310,9 +314,38 @@ def test_order_by_no_projection(backend):
 
 
 @dot_sql_notimpl
-@dot_sql_notyet
 @dot_sql_never
 @pytest.mark.notyet(["polars"], raises=PolarsComputeError)
 def test_dot_sql_limit(con):
-    expr = con.sql("SELECT * FROM (SELECT 'abc' ts) _").limit(1)
-    assert expr.execute().equals(pd.DataFrame({"ts": ["abc"]}))
+    expr = con.sql('SELECT * FROM (SELECT \'abc\' "ts") "x"', dialect="duckdb").limit(1)
+    result = expr.execute()
+
+    assert len(result) == 1
+    assert len(result.columns) == 1
+    assert result.columns[0].lower() == "ts"
+    assert result.iat[0, 0] == "abc"
+
+
+@pytest.fixture(scope="module")
+def mem_t(con):
+    if con.name == "druid":
+        pytest.xfail("druid does not support create_table")
+    name = f"{con.name}_temp_mem_t_for_cte"
+    t = con.create_table(name, ibis.memtable({"a": list("def")}))
+    yield t
+    with contextlib.suppress(NotImplementedError):
+        con.drop_table(name, force=True)
+
+
+@dot_sql_notimpl
+@dot_sql_never
+@pytest.mark.notyet(["polars"], raises=PolarsComputeError)
+def test_cte(con, snapshot, mem_t):
+    t = mem_t
+    foo = t.alias("foo")
+    assert foo.schema() == t.schema()
+    assert foo.count().execute() == t.count().execute()
+
+    expr = foo.sql('SELECT count(*) "x" FROM "foo"', dialect="duckdb")
+    sql = con.compile(expr)
+    snapshot.assert_match(sql, "out.sql")

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -330,7 +330,7 @@ def test_dot_sql_limit(con):
 def mem_t(con):
     if con.name == "druid":
         pytest.xfail("druid does not support create_table")
-    name = f"{con.name}_temp_mem_t_for_cte"
+    name = f"test_{con.name}_temp_mem_t_for_cte"
     t = con.create_table(name, ibis.memtable({"a": list("def")}))
     yield t
     with contextlib.suppress(NotImplementedError):

--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -223,8 +223,8 @@ def _sql_query_result(op, query, **kwargs):
     clsname = op.__class__.__name__
 
     if isinstance(op, ops.SQLStringView):
-        child, name = kwargs["child"], kwargs["name"]
-        top = f"{clsname}[{child}]: {name}\n"
+        child = kwargs["child"]
+        top = f"{clsname}[{child}]\n"
     else:
         top = f"{clsname}\n"
 

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -195,6 +195,7 @@ class Simple(Relation):
         return self.parent.schema
 
 
+# TODO(kszucs): remove in favor of View
 @public
 class SelfReference(Simple):
     _uid_counter = itertools.count()
@@ -411,6 +412,7 @@ class SQLQueryResult(Relation):
 class View(PhysicalTable):
     """A view created from an expression."""
 
+    # TODO(kszucs): rename it to parent
     child: Relation
 
     @attribute
@@ -422,16 +424,10 @@ class View(PhysicalTable):
 class SQLStringView(Relation):
     """A view created from a SQL string."""
 
-    child: View
+    child: Relation
     query: str
-
+    schema: Schema
     values = FrozenDict()
-
-    @attribute
-    def schema(self):
-        op = self.child
-        child = op.to_expr()
-        return child._find_backend()._get_sql_string_view_schema(child, self.query)
 
 
 @public

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -408,29 +408,30 @@ class SQLQueryResult(Relation):
 
 
 @public
-class SQLStringView(PhysicalTable):
-    """A view created from a SQL string."""
-
-    child: Relation
-    query: str
-
-    @attribute
-    def schema(self):
-        # TODO(kszucs): avoid converting to expression
-        backend = self.child.to_expr()._find_backend()
-        return backend._get_schema_using_query(self.query)
-
-
-@public
 class View(PhysicalTable):
     """A view created from an expression."""
 
     child: Relation
-    name: str
 
     @attribute
     def schema(self):
         return self.child.schema
+
+
+@public
+class SQLStringView(Relation):
+    """A view created from a SQL string."""
+
+    child: View
+    query: str
+
+    values = FrozenDict()
+
+    @attribute
+    def schema(self):
+        op = self.child
+        child = op.to_expr()
+        return child._find_backend()._get_sql_string_view_schema(child, self.query)
 
 
 @public

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -27,7 +27,6 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 from ibis import util
-from ibis.common.annotations import annotated
 
 from ibis.common.deferred import Deferred
 from ibis.expr.types.core import Expr, _FixedTextJupyterMixin
@@ -48,8 +47,6 @@ if TYPE_CHECKING:
     from ibis.expr.types.tvf import WindowedTable
     from ibis.selectors import IfAnyAll, Selector
     from ibis.formats.pyarrow import PyArrowData
-
-_ALIASES = (f"_ibis_view_{n:d}" for n in itertools.count())
 
 
 def _regular_join_method(
@@ -3166,11 +3163,6 @@ class Table(Expr, _FixedTextJupyterMixin):
         └─────────┴───────────┴────────────────┴───────────────┴───────────────────┴───┘
         """
         expr = ops.View(child=self, name=alias).to_expr()
-
-        # NB: calling compile is necessary so that any temporary views are
-        # created so that we can infer the schema without executing the entire
-        # query
-        expr.compile()
         return expr
 
     def sql(self, query: str, dialect: str | None = None) -> ir.Table:
@@ -3263,7 +3255,13 @@ class Table(Expr, _FixedTextJupyterMixin):
         if dialect is not None:
             backend = self._find_backend()
             query = backend._transpile_sql(query, dialect=dialect)
-        op = ops.SQLStringView(child=self, name=next(_ALIASES), query=query)
+
+        child = (
+            self
+            if isinstance(self.op(), ops.View)
+            else self.alias(util.gen_name("sql_string_view"))
+        )
+        op = ops.SQLStringView(child=child, query=query)
         return op.to_expr()
 
     def to_pandas(self, **kwargs) -> pd.DataFrame:

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -89,6 +89,9 @@ class MockBackend(BaseBackend):
     def _get_schema_using_query(self, query):
         return self.sql_query_schemas[query]
 
+    def _get_sql_string_view_schema(self, child, query):
+        return self.sql_query_schemas[query]
+
     @contextlib.contextmanager
     def set_query_schema(self, query, schema):
         self.sql_query_schemas[query] = schema

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -89,7 +89,7 @@ class MockBackend(BaseBackend):
     def _get_schema_using_query(self, query):
         return self.sql_query_schemas[query]
 
-    def _get_sql_string_view_schema(self, child, query):
+    def _get_sql_string_view_schema(self, name, table, query):
         return self.sql_query_schemas[query]
 
     @contextlib.contextmanager

--- a/ibis/tests/expr/snapshots/test_format_sql_operations/test_format_sql_query_result/repr.txt
+++ b/ibis/tests/expr/snapshots/test_format_sql_operations/test_format_sql_query_result/repr.txt
@@ -29,14 +29,45 @@ r0 := DatabaseTable: airlines
   security_delay      int32
   late_aircraft_delay int32
 
-r1 := SQLStringView[r0]: foo
+r1 := View: foo
+  year                int32
+  month               int32
+  day                 int32
+  dayofweek           int32
+  dep_time            int32
+  crs_dep_time        int32
+  arr_time            int32
+  crs_arr_time        int32
+  carrier             string
+  flight_num          int32
+  tail_num            int32
+  actual_elapsed_time int32
+  crs_elapsed_time    int32
+  airtime             int32
+  arrdelay            int32
+  depdelay            int32
+  origin              string
+  dest                string
+  distance            int32
+  taxi_in             int32
+  taxi_out            int32
+  cancelled           int32
+  cancellation_code   string
+  diverted            int32
+  carrier_delay       int32
+  weather_delay       int32
+  nas_delay           int32
+  security_delay      int32
+  late_aircraft_delay int32
+
+r2 := SQLStringView[r1]
   query:
     SELECT carrier, mean(arrdelay) AS avg_arrdelay FROM airlines GROUP BY 1 ORDER …
   schema:
     carrier      string
     avg_arrdelay float64
 
-Project[r1]
-  carrier:      r1.carrier
-  avg_arrdelay: Round(r1.avg_arrdelay, digits=1)
-  island:       Lowercase(r1.carrier)
+Project[r2]
+  carrier:      r2.carrier
+  avg_arrdelay: Round(r2.avg_arrdelay, digits=1)
+  island:       Lowercase(r2.carrier)

--- a/ibis/tests/expr/test_format_sql_operations.py
+++ b/ibis/tests/expr/test_format_sql_operations.py
@@ -16,10 +16,7 @@ def test_format_sql_query_result(con, snapshot):
     schema = ibis.schema({"carrier": "string", "avg_arrdelay": "double"})
 
     with con.set_query_schema(query, schema):
-        expr = t.sql(query)
-        # name is autoincremented so we need to set it manually to make the
-        # snapshot stable
-        expr = expr.op().copy(name="foo").to_expr()
+        expr = t.alias("foo").sql(query)
 
     expr = expr.mutate(
         island=_.carrier.lower(),


### PR DESCRIPTION
This PR fixes a long-standing annoyance with our `.sql` methods. Previously we pooped a bunch of temporary tables or views (depending on the backend), but after this PR the various `.sql` methods replace this hack with much more vanilla CTEs.