### PR TITLE
fix(sqlglot): stop using removed singletons for true, false, null

### DIFF
--- a/ibis/backends/base/sqlglot/__init__.py
+++ b/ibis/backends/base/sqlglot/__init__.py
@@ -82,9 +82,9 @@ def interval(value, *, unit):
 
 C = ColGen()
 F = FuncGen()
-NULL = sg.exp.NULL
-FALSE = sg.exp.FALSE
-TRUE = sg.exp.TRUE
+NULL = sg.exp.Null()
+FALSE = sg.exp.false()
+TRUE = sg.exp.true()
 STAR = sg.exp.Star()
 
 


### PR DESCRIPTION
Fix for upstream removal in https://github.com/tobymao/sqlglot/pull/2884

Should we set a stricter upper bound on sqlglot before releasing 8.x?

