### PR TITLE
revert: chore(deps): update clickhouse/clickhouse-server docker tag to v24

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: clickhouse/clickhouse-server:24.1.1.2048-alpine
+    image: clickhouse/clickhouse-server:23.12.2.59-alpine
     ports:
       - 8123:8123 # http port
       - 9000:9000 # native protocol port


### PR DESCRIPTION
Revert 87525f5817 due to https://github.com/ClickHouse/ClickHouse/issues/59414.