### PR TITLE
test(bigquery): enable xpassing all-non-null array test

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -703,11 +703,6 @@ def test_array_sort(backend, con):
     ["dask", "datafusion", "impala", "mssql", "pandas", "polars"],
     raises=com.OperationNotDefinedError,
 )
-@pytest.mark.notyet(
-    ["bigquery"],
-    raises=GoogleBadRequest,
-    reason="BigQuery doesn't support arrays with null elements",
-)
 @pytest.mark.parametrize(
     ("a", "b", "expected_array"),
     [
@@ -721,7 +716,12 @@ def test_array_sort(backend, con):
                     ["flink"],
                     raises=Py4JJavaError,
                     reason="SQL validation failed; Flink does not support ARRAY[]",
-                )
+                ),
+                pytest.mark.notyet(
+                    ["bigquery"],
+                    raises=GoogleBadRequest,
+                    reason="BigQuery doesn't support arrays with null elements",
+                ),
             ],
         ),
         param(


### PR DESCRIPTION
Fixes an XPASS-ing BigQuery array test on `main`