### PR TITLE
fix(postgres): passthrough additional kwargs in pguri

### DIFF
--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 import textwrap
-from typing import TYPE_CHECKING, Callable, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import sqlalchemy as sa
 
@@ -44,6 +44,7 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema):
         schema: str | None = None,
         url: str | None = None,
         driver: Literal["psycopg2"] = "psycopg2",
+        **kwargs: Any,
     ) -> None:
         """Create an Ibis client connected to PostgreSQL database.
 
@@ -67,6 +68,8 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema):
             If passed, the other connection arguments are ignored.
         driver
             Database driver
+        kwargs
+            Additional kwargs to pass to the backend client connection.
 
         Examples
         --------
@@ -110,6 +113,7 @@ class Backend(BaseAlchemyBackend, AlchemyCanCreateSchema):
             password=password,
             database=database,
             driver=f"postgresql+{driver}",
+            **kwargs,
         )
 
         connect_args = {}

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -272,3 +272,10 @@ def test_timezone_from_column(contz, snapshot):
     )
     tm.assert_frame_equal(result, expected)
     snapshot.assert_match(ibis.to_sql(case), "out.sql")
+
+
+def test_kwargs_passthrough_in_connect():
+    con = ibis.connect(
+        "postgresql://postgres:postgres@localhost/ibis_testing?sslmode=require"
+    )
+    assert con.current_database == "ibis_testing"


### PR DESCRIPTION
-------

<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Pass through any additional kwargs that come out of our URL parsing to the postgres `do_connect` call.

## Issues closed

Fixes #8168