### PR TITLE
fix(flink): fix the xfailed outer join test in flink backend

### DIFF
--- a/ibis/backends/flink/tests/test_join.py
+++ b/ibis/backends/flink/tests/test_join.py
@@ -115,7 +115,6 @@ def remove_temp_files(left_tmp, right_tmp):
     right_tmp.close()
 
 
-@pytest.mark.xfail(raises=AssertionError, reason="test seems broken", strict=False)
 def test_outer_join(left_tumble, right_tumble):
     expr = left_tumble.join(
         right_tumble,


### PR DESCRIPTION
## Description of changes

Fix the xfailed outer join test in flink backend.