### PR TITLE
refactor(ir): remove the decimal precision promotion logic

### DIFF
--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import operator
 from itertools import product, starmap
 from typing import Optional
 
@@ -108,39 +107,6 @@ def _promote_integral_binop(exprs, op):
     return dt.highest_precedence(dtypes)
 
 
-def _promote_decimal_binop(args, op):
-    if len(args) != 2:
-        return highest_precedence_dtype(args)
-
-    # TODO: Add support for setting the maximum precision and maximum scale
-    left = args[0].dtype
-    right = args[1].dtype
-
-    max_prec = 31 if left.precision <= 31 and right.precision <= 31 else 63
-    max_scale = 31
-
-    if op is operator.mul:
-        return dt.Decimal(
-            min(max_prec, left.precision + right.precision),
-            min(max_scale, left.scale + right.scale),
-        )
-    elif op is operator.add or op is operator.sub:
-        return dt.Decimal(
-            min(
-                max_prec,
-                max(
-                    left.precision - left.scale,
-                    right.precision - right.scale,
-                )
-                + max(left.scale, right.scale)
-                + 1,
-            ),
-            max(left.scale, right.scale),
-        )
-    else:
-        return highest_precedence_dtype(args)
-
-
 @public
 def numeric_like(name, op):
     @attribute
@@ -149,8 +115,6 @@ def numeric_like(name, op):
         dtypes = [arg.dtype for arg in args]
         if util.all_of(dtypes, dt.Integer):
             result = _promote_integral_binop(args, op)
-        elif util.all_of(dtypes, dt.Decimal):
-            result = _promote_decimal_binop(args, op)
         else:
             result = highest_precedence_dtype(args)
 

--- a/ibis/tests/expr/test_decimal.py
+++ b/ibis/tests/expr/test_decimal.py
@@ -36,15 +36,15 @@ def test_promote_decimal_type_mul(lineitem):
     col_1 = lineitem.l_extendedprice
     col_2 = lineitem.l_discount
     result = col_1 * col_2
-    assert result.type().precision == 24
-    assert result.type().scale == 4
+    assert result.type().precision == 12
+    assert result.type().scale == 2
 
 
 def test_promote_decimal_type_add(lineitem):
     col_1 = lineitem.l_extendedprice
     col_2 = lineitem.l_discount
     result = col_1 + col_2
-    assert result.type().precision == 13
+    assert result.type().precision == 12
     assert result.type().scale == 2
 
 
@@ -60,7 +60,7 @@ def test_promote_decimal_type_max():
     t = ibis.table([("a", "decimal(31, 3)"), ("b", "decimal(31, 3)")], "t")
     result = t.a * t.b
     assert result.type().precision == 31
-    assert result.type().scale == 6
+    assert result.type().scale == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description of changes
This change is removing the decimal precision promotion logic from the unbounded ibis expr. The logic was introduced by #4330 so the decimal precision can matches the [DB2](https://www.ibm.com/docs/en/i/7.1?topic=operators-decimal-arithmetic-in-sql). However, this rule is not generic for all. For example, BQ only support `precision=38`. 

## Issues closed

* Resolves #8189

