### PR TITLE
docs: row_number always starts at 0

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1240,6 +1240,10 @@ def ntile(buckets: int | ir.IntegerValue) -> ir.IntegerColumn:
 def row_number() -> ir.IntegerColumn:
     """Return an analytic function expression for the current row number.
 
+    ::: {.callout-note}
+    `row_number` is normalized across backends to start at 0
+    :::
+
     Returns
     -------
     IntegerColumn


### PR DESCRIPTION
## Description of changes
documenting `row_number`'s behavior

## Issues closed

Resolves #8208