### PR TITLE
chore: remove ruff.toml causing types directory to be ignore and fix subsequent lint errors

### DIFF
--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Iterable
 import inspect
+from typing import TYPE_CHECKING, Callable
+
 from public import public
 
 import ibis.expr.operations as ops
-from ibis.expr.types.generic import Column, Scalar, Value, literal
-from ibis.expr.types.typing import V
 from ibis.common.deferred import deferrable
+from ibis.expr.types.generic import Column, Scalar, Value
 
 if TYPE_CHECKING:
-    import ibis.expr.datatypes as dt
+    from collections.abc import Iterable
+
     import ibis.expr.types as ir
+    from ibis.expr.types.typing import V
 
 import ibis.common.exceptions as com
 
@@ -401,7 +403,6 @@ class ArrayValue(Value):
         >>> from functools import partial
         >>> def add(x, y):
         ...     return x + y
-        ...
         >>> add2 = partial(add, y=2)
         >>> t.a.map(add2)
         ┏━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -480,7 +481,6 @@ class ArrayValue(Value):
         >>> from functools import partial
         >>> def gt(x, y):
         ...     return x > y
-        ...
         >>> gt1 = partial(gt, y=1)
         >>> t.a.filter(gt1)
         ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -770,9 +770,7 @@ class ArrayValue(Value):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.memtable(
-        ...     {"arr1": [[3, 2], [], None], "arr2": [[1, 3], [None], [5]]}
-        ... )
+        >>> t = ibis.memtable({"arr1": [[3, 2], [], None], "arr2": [[1, 3], [None], [5]]})
         >>> t
         ┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ arr1                 ┃ arr2                 ┃
@@ -823,9 +821,7 @@ class ArrayValue(Value):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.memtable(
-        ...     {"arr1": [[3, 2], [], None], "arr2": [[1, 3], [None], [5]]}
-        ... )
+        >>> t = ibis.memtable({"arr1": [[3, 2], [], None], "arr2": [[1, 3], [None], [5]]})
         >>> t
         ┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ arr1                 ┃ arr2                 ┃
@@ -869,9 +865,7 @@ class ArrayValue(Value):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.memtable(
-        ...     {"numbers": [[3, 2], [], None], "strings": [["a", "c"], None, ["e"]]}
-        ... )
+        >>> t = ibis.memtable({"numbers": [[3, 2], [], None], "strings": [["a", "c"], None, ["e"]]})
         >>> t
         ┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ numbers              ┃ strings              ┃

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 import webbrowser
-from typing import TYPE_CHECKING, Any, Mapping, NoReturn, Tuple, Iterator
+from typing import TYPE_CHECKING, Any, NoReturn
 
 from public import public
 from rich.jupyter import JupyterMixin
@@ -13,10 +13,12 @@ from ibis.common.annotations import ValidationError
 from ibis.common.exceptions import IbisError, TranslationError
 from ibis.common.grounds import Immutable
 from ibis.common.patterns import Coercible, CoercionError
-from ibis.config import _default_backend, options as opts
+from ibis.config import _default_backend
+from ibis.config import options as opts
 from ibis.util import experimental
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
     from pathlib import Path
 
     import pandas as pd
@@ -26,7 +28,7 @@ if TYPE_CHECKING:
     import ibis.expr.types as ir
     from ibis.backends.base import BaseBackend
 
-    TimeContext = Tuple[pd.Timestamp, pd.Timestamp]
+    TimeContext = tuple[pd.Timestamp, pd.Timestamp]
 
 
 class _FixedTextJupyterMixin(JupyterMixin):
@@ -232,7 +234,7 @@ class Expr(Immutable, Coercible):
         else:
             return f(self, *args, **kwargs)
 
-    def op(self) -> ops.Node:  # noqa: D102
+    def op(self) -> ops.Node:
         return self._arg
 
     def _find_backends(self) -> tuple[list[BaseBackend], bool]:
@@ -468,7 +470,7 @@ class Expr(Immutable, Coercible):
         params: Mapping[ir.Scalar, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """Write the results of executing the given expression to a parquet file
+        """Write the results of executing the given expression to a parquet file.
 
         This method is eager and will execute the associated expression
         immediately.
@@ -515,7 +517,7 @@ class Expr(Immutable, Coercible):
         params: Mapping[ir.Scalar, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """Write the results of executing the given expression to a CSV file
+        """Write the results of executing the given expression to a CSV file.
 
         This method is eager and will execute the associated expression
         immediately.
@@ -541,7 +543,7 @@ class Expr(Immutable, Coercible):
         params: Mapping[ir.Scalar, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """Write the results of executing the given expression to a Delta Lake table
+        """Write the results of executing the given expression to a Delta Lake table.
 
         This method is eager and will execute the associated expression
         immediately.
@@ -589,8 +591,8 @@ class Expr(Immutable, Coercible):
 
     def unbind(self) -> ir.Table:
         """Return an expression built on `UnboundTable` instead of backend-specific objects."""
-        from ibis.expr.analysis import p, c
         from ibis.common.deferred import _
+        from ibis.expr.analysis import c, p
 
         rule = p.DatabaseTable >> c.UnboundTable(name=_.name, schema=_.schema)
         return self.op().replace(rule).to_expr()

--- a/ibis/expr/types/dataframe_interchange.py
+++ b/ibis/expr/types/dataframe_interchange.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import ibis.expr.types as ir
+    from collections.abc import Sequence
+
     import pyarrow as pa
+
+    import ibis.expr.types as ir
 
 
 class IbisDataFrame:
@@ -38,7 +41,8 @@ class IbisDataFrame:
         """Returns the pyarrow implementation of the __dataframe__ protocol.
 
         If the backing ibis Table hasn't been executed yet, this will result
-        in executing and caching the result."""
+        in executing and caching the result.
+        """
         if self._pyarrow_table is None:
             self._pyarrow_table = self._table.to_pyarrow()
         return self._pyarrow_table.__dataframe__(
@@ -48,8 +52,7 @@ class IbisDataFrame:
 
     @cached_property
     def _empty_pyarrow_df(self):
-        """A pyarrow implementation of the __dataframe__ protocol for an
-        empty table with the same schema as this table.
+        """A pyarrow implementation of the __dataframe__ protocol for an empty table.
 
         Used for returning dtype information without executing the backing ibis
         expression.
@@ -125,11 +128,11 @@ class IbisColumn:
 
     @cached_property
     def _pyarrow_col(self):
-        """Returns the pyarrow implementation of the __dataframe__ protocol's
-        Column type.
+        """Returns the pyarrow implementation of the __dataframe__ protocol's Column type.
 
         If the backing ibis Table hasn't been executed yet, this will result
-        in executing and caching the result."""
+        in executing and caching the result.
+        """
         return self._df._pyarrow_df.get_column_by_name(self._name)
 
     # These methods may all be handled without executing the query

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import contextlib
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 from public import public
 
@@ -212,6 +212,7 @@ class Value(Expr):
 
     def try_cast(self, target_type: Any) -> Value:
         """Try cast expression to indicated data type.
+
         If the cast fails for a row, the value is returned
         as null or NaN depending on target_type and backend behavior.
 
@@ -235,9 +236,7 @@ class Value(Expr):
         >>> import ibis
         >>> from ibis import _
         >>> ibis.options.interactive = True
-        >>> t = ibis.memtable(
-        ...     {"numbers": [1, 2, 3, 4], "strings": ["1.0", "2", "hello", "world"]}
-        ... )
+        >>> t = ibis.memtable({"numbers": [1, 2, 3, 4], "strings": ["1.0", "2", "hello", "world"]})
         >>> t
         ┏━━━━━━━━━┳━━━━━━━━━┓
         ┃ numbers ┃ strings ┃
@@ -274,7 +273,6 @@ class Value(Expr):
     def coalesce(self, *args: Value) -> Value:
         """Return the first non-null value from `args`.
 
-
         Parameters
         ----------
         args
@@ -299,11 +297,11 @@ class Value(Expr):
         return ops.Coalesce((self, *args)).to_expr()
 
     @deprecated(as_of="8.0.0", instead="use ibis.greatest(self, rest...) instead")
-    def greatest(self, *args: ir.Value) -> ir.Value:  # noqa: D102
+    def greatest(self, *args: ir.Value) -> ir.Value:
         return ops.Greatest((self, *args)).to_expr()
 
     @deprecated(as_of="8.0.0", instead="use ibis.least(self, rest...) instead")
-    def least(self, *args: ir.Value) -> ir.Value:  # noqa: D102
+    def least(self, *args: ir.Value) -> ir.Value:
         return ops.Least((self, *args)).to_expr()
 
     def typeof(self) -> ir.StringValue:
@@ -721,11 +719,12 @@ class Value(Expr):
         -------
         Value
             A window function expression
+
         """
         import ibis.expr.analysis as an
         import ibis.expr.builders as bl
-        from ibis.common.deferred import Call
         from ibis import _
+        from ibis.common.deferred import Call
 
         if window is None:
             window = ibis.window(
@@ -1021,9 +1020,7 @@ class Value(Expr):
 
         Collect elements per group using a filter
 
-        >>> t.group_by("key").agg(
-        ...     v=lambda t: t.value.collect(where=t.value > 1)
-        ... ).order_by("key")
+        >>> t.group_by("key").agg(v=lambda t: t.value.collect(where=t.value > 1)).order_by("key")
         ┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ key    ┃ v                    ┃
         ┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
@@ -1499,8 +1496,10 @@ class Column(Value, _FixedTextJupyterMixin):
 
         Parameters
         ----------
+        key
+            Key to use for `max` computation.
         where
-            Filter in values when `where` is `True`
+            Keep values when `where` is `True`
 
         Returns
         -------
@@ -1526,8 +1525,10 @@ class Column(Value, _FixedTextJupyterMixin):
 
         Parameters
         ----------
+        key
+            Key to use for `min` computation.
         where
-            Filter in values when `where` is `True`
+            Keep values when `where` is `True`
 
         Returns
         -------
@@ -1573,9 +1574,9 @@ class Column(Value, _FixedTextJupyterMixin):
 
         >>> t.bill_depth_mm.median()
         17.3
-        >>> t.group_by(t.species).agg(
-        ...     median_bill_depth=t.bill_depth_mm.median()
-        ... ).order_by(ibis.desc("median_bill_depth"))
+        >>> t.group_by(t.species).agg(median_bill_depth=t.bill_depth_mm.median()).order_by(
+        ...     ibis.desc("median_bill_depth")
+        ... )
         ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
         ┃ species   ┃ median_bill_depth ┃
         ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
@@ -1589,9 +1590,9 @@ class Column(Value, _FixedTextJupyterMixin):
         In addition to numeric types, any orderable non-numeric types such as
         strings and dates work with `median`.
 
-        >>> t.group_by(t.island).agg(
-        ...     median_species=t.species.median()
-        ... ).order_by(ibis.desc("median_species"))
+        >>> t.group_by(t.island).agg(median_species=t.species.median()).order_by(
+        ...     ibis.desc("median_species")
+        ... )
         ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
         ┃ island    ┃ median_species ┃
         ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
@@ -1637,9 +1638,9 @@ class Column(Value, _FixedTextJupyterMixin):
 
         >>> t.bill_depth_mm.quantile(0.99)
         21.1
-        >>> t.group_by(t.species).agg(
-        ...     p99_bill_depth=t.bill_depth_mm.quantile(0.99)
-        ... ).order_by(ibis.desc("p99_bill_depth"))
+        >>> t.group_by(t.species).agg(p99_bill_depth=t.bill_depth_mm.quantile(0.99)).order_by(
+        ...     ibis.desc("p99_bill_depth")
+        ... )
         ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
         ┃ species   ┃ p99_bill_depth ┃
         ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
@@ -1655,9 +1656,9 @@ class Column(Value, _FixedTextJupyterMixin):
 
         Let's compute the 99th percentile of the `species` column
 
-        >>> t.group_by(t.island).agg(
-        ...     p99_species=t.species.quantile(0.99)
-        ... ).order_by(ibis.desc("p99_species"))
+        >>> t.group_by(t.island).agg(p99_species=t.species.quantile(0.99)).order_by(
+        ...     ibis.desc("p99_species")
+        ... )
         ┏━━━━━━━━━━━┳━━━━━━━━━━━━━┓
         ┃ island    ┃ p99_species ┃
         ┡━━━━━━━━━━━╇━━━━━━━━━━━━━┩
@@ -1688,7 +1689,7 @@ class Column(Value, _FixedTextJupyterMixin):
             Number of distinct elements in an expression
 
         Examples
-        -------
+        --------
         >>> import ibis
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
@@ -1902,6 +1903,7 @@ class Column(Value, _FixedTextJupyterMixin):
         -------
         Int64Column
             The min rank
+
         Examples
         --------
         >>> import ibis

--- a/ibis/expr/types/geospatial.py
+++ b/ibis/expr/types/geospatial.py
@@ -130,7 +130,7 @@ class GeoSpatialValue(NumericValue):
         >>> ibis.options.interactive = True
         >>> import shapely
         >>> t = ibis.examples.zones.fetch()
-        >>> p = shapely.Point(935996.821, 191376.75) # centroid for zone 1
+        >>> p = shapely.Point(935996.821, 191376.75)  # centroid for zone 1
         >>> plit = ibis.literal(p, "geometry")
         >>> t.geom.contains(plit).name("contains")
         ┏━━━━━━━━━━┓
@@ -237,7 +237,7 @@ class GeoSpatialValue(NumericValue):
 
         Polygon area center in zone 1
 
-        >>> pol_big = shapely.Point(935996.821,191376.75).buffer(10000)
+        >>> pol_big = shapely.Point(935996.821, 191376.75).buffer(10000)
         >>> pol_big_lit = ibis.literal(pol_big, "geometry")
         >>> t.geom.covered_by(pol_big_lit).name("covered_by")
         ┏━━━━━━━━━━━━┓
@@ -257,7 +257,7 @@ class GeoSpatialValue(NumericValue):
         │ False      │
         │ …          │
         └────────────┘
-        >>> pol_small = shapely.Point(935996.821,191376.75).buffer(100)
+        >>> pol_small = shapely.Point(935996.821, 191376.75).buffer(100)
         >>> pol_small_lit = ibis.literal(pol_small, "geometry")
         >>> t.geom.covered_by(pol_small_lit).name("covered_by")
         ┏━━━━━━━━━━━━┓
@@ -281,8 +281,7 @@ class GeoSpatialValue(NumericValue):
         return ops.GeoCoveredBy(self, right).to_expr()
 
     def crosses(self, right: GeoSpatialValue) -> ir.BooleanValue:
-        """Check if the geometries have at least one, but not all, interior
-        points in common.
+        """Check if the geometries have at least one, but not all, interior points in common.
 
         Parameters
         ----------
@@ -383,7 +382,7 @@ class GeoSpatialValue(NumericValue):
         >>> ibis.options.interactive = True
         >>> import shapely
         >>> t = ibis.examples.zones.fetch()
-        >>> p = shapely.Point(935996.821, 191376.75) # zone 1 centroid
+        >>> p = shapely.Point(935996.821, 191376.75)  # zone 1 centroid
         >>> plit = ibis.literal(p, "geometry")
         >>> t.geom.disjoint(plit).name("disjoint")
         ┏━━━━━━━━━━┓
@@ -431,7 +430,7 @@ class GeoSpatialValue(NumericValue):
         >>> ibis.options.interactive = True
         >>> import shapely
         >>> t = ibis.examples.zones.fetch()
-        >>> penn_station = shapely.Point(986345.399 , 211974.446)
+        >>> penn_station = shapely.Point(986345.399, 211974.446)
         >>> penn_lit = ibis.literal(penn_station, "geometry")
 
         Check zones within 1000ft of Penn Station centroid
@@ -574,7 +573,7 @@ class GeoSpatialValue(NumericValue):
         >>> ibis.options.interactive = True
         >>> import shapely
         >>> t = ibis.examples.zones.fetch()
-        >>> p = shapely.Point(935996.821, 191376.75) # zone 1 centroid
+        >>> p = shapely.Point(935996.821, 191376.75)  # zone 1 centroid
         >>> plit = ibis.literal(p, "geometry")
         >>> t.geom.intersects(plit).name("intersects")
         ┏━━━━━━━━━━━━┓
@@ -1463,8 +1462,9 @@ class GeoSpatialValue(NumericValue):
     def convert(
         self, source: ir.StringValue, target: ir.StringValue | ir.IntegerValue
     ) -> GeoSpatialValue:
-        """Transform a geometry into a new SRID (CRS). The coordinates are assumed
-        to always be XY (Longitude-Latitude).
+        """Transform a geometry into a new SRID (CRS).
+
+        Coordinates are assumed to always be XY (Longitude-Latitude).
 
         Parameters
         ----------

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -18,18 +18,23 @@ from __future__ import annotations
 
 import itertools
 import types
-from typing import Iterable, Sequence
+from typing import TYPE_CHECKING
+
+from public import public
 
 import ibis
+import ibis.common.exceptions as com
 import ibis.expr.analysis as an
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common.deferred import Deferred
-from ibis.selectors import Selector
 from ibis.expr.types.relations import bind_expr
-import ibis.common.exceptions as com
-from public import public
+from ibis.selectors import Selector
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
 
 _function_types = tuple(
     filter(
@@ -198,10 +203,7 @@ class GroupedTable:
         >>> (
         ...     t.select("species", "bill_length_mm")
         ...     .group_by("species")
-        ...     .mutate(
-        ...         centered_bill_len=ibis._.bill_length_mm
-        ...         - ibis._.bill_length_mm.mean()
-        ...     )
+        ...     .mutate(centered_bill_len=ibis._.bill_length_mm - ibis._.bill_length_mm.mean())
         ...     .order_by(s.all())
         ... )
         ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓

--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable, Mapping
+from typing import TYPE_CHECKING, Any
 
 from public import public
 
 import ibis.expr.operations as ops
-from ibis.expr.types.arrays import ArrayColumn
-from ibis.expr.types.generic import Column, Scalar, Value
 from ibis.common.deferred import deferrable
+from ibis.expr.types.generic import Column, Scalar, Value
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     import ibis.expr.types as ir
+    from ibis.expr.types.arrays import ArrayColumn
 
 
 @public

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-import collections
 import functools
-from typing import TYPE_CHECKING, Iterable, Literal, Sequence
+from typing import TYPE_CHECKING, Literal
 
 from public import public
 
 import ibis
 import ibis.expr.operations as ops
-from ibis import util
 from ibis.common.exceptions import IbisTypeError
 from ibis.expr.types.core import _binop
 from ibis.expr.types.generic import Column, Scalar, Value
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
     import ibis.expr.types as ir
 
 

--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -55,7 +55,7 @@ def _(dtype, values):
             return None
         try:
             return json.loads(v)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return v
 
     return _format_nested([try_json(v) for v in values])

--- a/ibis/expr/types/ruff.toml
+++ b/ibis/expr/types/ruff.toml
@@ -1,5 +1,0 @@
-select = ["D102"]
-show-source = true
-
-[per-file-ignores]
-"dataframe_interchange.py" = ["D102"]

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import operator
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal
 
 from public import public
 
@@ -12,6 +12,8 @@ from ibis.expr.types.core import _binop
 from ibis.expr.types.generic import Column, Scalar, Value
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
     import ibis.expr.types as ir
 
 
@@ -1184,9 +1186,7 @@ class StringValue(Value):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.memtable(
-        ...     {"s": ["abc", "bac", "bca", "this has  multi \t whitespace"]}
-        ... )
+        >>> t = ibis.memtable({"s": ["abc", "bac", "bca", "this has  multi \t whitespace"]})
         >>> s = t.s
 
         Replace all "a"s that are at the beginning of the string with "b":

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -2,18 +2,20 @@ from __future__ import annotations
 
 import collections
 from keyword import iskeyword
-from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING
 
 from public import public
 
 import ibis.expr.operations as ops
-from ibis.expr.types.generic import Column, Scalar, Value, literal
-from ibis.expr.types.typing import V
 from ibis.common.deferred import deferrable
+from ibis.expr.types.generic import Column, Scalar, Value, literal
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
     import ibis.expr.datatypes as dt
     import ibis.expr.types as ir
+    from ibis.expr.types.typing import V
 
 
 @public

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
-import datetime
-from typing import TYPE_CHECKING, Literal, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from public import public
 
 import ibis
 import ibis.expr.datashape as ds
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+from ibis import util
+from ibis.common.annotations import annotated
+from ibis.common.temporal import IntervalUnit
 from ibis.expr.types.core import _binop
 from ibis.expr.types.generic import Column, Scalar, Value
-from ibis.common.annotations import annotated
-import ibis.expr.datatypes as dt
-from ibis import util
-from ibis.common.temporal import IntervalUnit
 
 if TYPE_CHECKING:
+    import datetime
+
     import pandas as pd
 
     import ibis.expr.types as ir
@@ -282,7 +283,6 @@ class TimeValue(_TimeComponentMixin, Value):
         ... 2016-02-01T00:11:13,2016-02-01T00:16:59'''
         >>> with open("/tmp/triptimes.csv", "w") as f:
         ...     nbytes = f.write(data)  # nbytes is unused
-        ...
         >>> taxi = ibis.read_csv("/tmp/triptimes.csv")
         >>> ride_duration = (
         ...     taxi.tpep_dropoff_datetime.time()
@@ -544,6 +544,28 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         interval
             The bucket width as an interval. Alternatively may be specified
             via component keyword arguments.
+        years
+            Number of years
+        quarters
+            Number of quarters
+        months
+            Number of months
+        weeks
+            Number of weeks
+        days
+            Number of days
+        hours
+            Number of hours
+        minutes
+            Number of minutes
+        seconds
+            Number of seconds
+        milliseconds
+            Number of milliseconds
+        microseconds
+            Number of microseconds
+        nanoseconds
+            Number of nanoseconds
         offset
             An interval to use to offset the start of the bucket.
 
@@ -758,7 +780,6 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         ... 2016-02-01T00:11:13,2016-02-01T00:16:59'''
         >>> with open("/tmp/triptimes.csv", "w") as f:
         ...     nbytes = f.write(data)  # nbytes is unused
-        ...
         >>> taxi = ibis.read_csv("/tmp/triptimes.csv")
         >>> ride_duration = taxi.tpep_dropoff_datetime.delta(
         ...     taxi.tpep_pickup_datetime, "minute"

--- a/ibis/expr/types/typing.py
+++ b/ibis/expr/types/typing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Hashable, TypeVar
+from collections.abc import Hashable
+from typing import TypeVar
 
 __all__ = ["K", "V"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -448,6 +448,7 @@ ignore = [
   "D213",    # Multi-line docstring summary should start at the second line
   "D401",    # Imperative mood
   "D402",    # First line should not be the function's signature
+  "D413",    # Blank line required after last section
   "E501",    # line-too-long, this is automatically enforced by ruff format
   "E731",    # lambda-assignment
   "ISC001",  # single line implicit string concat, handled by ruff format


### PR DESCRIPTION
The `ruff.toml` file in `ibis/expr/types` was causing the module to be ignored by `ruff`. This PR removes that file since it is no longer necessary, and fixes the resulting lint and format issues. I also added a new ignore rule to prevent an additional newline from being added to the end docstrings (`D413`).