### PR TITLE
test(risingwave): make unnest test not flaky

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -251,6 +251,9 @@ def test_array_discovery(backend):
     raises=GoogleBadRequest,
 )
 @pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
+@pytest.mark.broken(
+    ["risingwave"], raises=AssertionError, reason="ordering is different", strict=False
+)
 def test_unnest_simple(backend):
     array_types = backend.array_types
     expected = (


### PR DESCRIPTION
Fixes a flaky risingwave test noticed in #8161.