### PR TITLE
docs: display inherited methods [WIP-DNM]

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -193,6 +193,8 @@ quartodoc:
   renderer: _renderer.py
   options:
     signature_name: short
+    # sets include inherited everywhere by default ----
+    include_inherited: true
   sections:
     - title: Expression API
       desc: "APIs for manipulating table, column and scalar expressions"


### PR DESCRIPTION
Testing some things, I can't build docs locally.  

It looks like in some places we are missing some inherited methods in the docs, there is a solution according to quarto-docs https://github.com/machow/quartodoc/issues/239, giving this a try. We might not want it globally (do we?) but checking what happens if we enable it. 