### PR TITLE
ci(codespell): separate codespell config into standalone file

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+# local codespell matches `./docs`, pre-commit codespell matches `docs`
+skip = *.lock,.direnv,.git,./docs/_freeze,./docs/_output/**,./docs/_inv/**,docs/_freeze/**,*.svg,*.css,*.html,*.js
+ignore-regex = \b(i[if]f|I[IF]F|AFE)\b
+builtin = clear,rare,names

--- a/.github/workflows/ibis-backends-skip-helper.yml
+++ b/.github/workflows/ibis-backends-skip-helper.yml
@@ -10,6 +10,7 @@ on:
       - "**/*.qmd"
       - "codecov.yml"
       - ".envrc"
+      - ".codespellrc"
     branches:
       - main
       - "*.x.x"
@@ -20,6 +21,7 @@ on:
       - "**/*.qmd"
       - "codecov.yml"
       - ".envrc"
+      - ".codespellrc"
     branches:
       - main
       - "*.x.x"

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -9,6 +9,7 @@ on:
       - "**/*.qmd"
       - "codecov.yml"
       - ".envrc"
+      - ".codespellrc"
     branches:
       - main
       - "*.x.x"
@@ -20,6 +21,7 @@ on:
       - "**/*.qmd"
       - "codecov.yml"
       - ".envrc"
+      - ".codespellrc"
     branches:
       - main
       - "*.x.x"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,12 +393,6 @@ show_dot = false
 no_dot = true
 show_deps = true
 
-[tool.codespell]
-# local codespell matches `./docs`, pre-commit codespell matches `docs`
-skip = "*.lock,.direnv,.git,./docs/_freeze,docs/_freeze/**,*.svg,*.css,*.html,*.js"
-ignore-regex = '\b(i[if]f|I[IF]F|AFE)\b'
-builtin = "clear,rare,names"
-
 [tool.ruff]
 line-length = 88
 respect-gitignore = true


### PR DESCRIPTION
I really like `pyproject.toml` and having one place to look.  But
running the full backend test suite because we need to add a word to an
"ignore-list" for codespell is silly.

So, breaking it out into a `.codespellrc` file so that it can be updated
without triggering a full CI run.

I have some other ideas for reducing build times for unrelated changes but I'll open an issue to document and track those.