### PR TITLE
docs: add blog link on the homepage

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -23,6 +23,9 @@ about:
       href: install.qmd
     - icon: book
       href: tutorials/getting_started.qmd
+    - icon: postcard
+      text: Blog
+      href: posts.qmd
     - icon: github
       text: GitHub
       href: https://github.com/ibis-project


### PR DESCRIPTION
## Description of changes

add a button on the home page that goes to the blog

## Issues closed

