### PR TITLE
ci: allow codecov uploads to fail

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: upload code coverage
         if: success()
+        continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
           flags: core,${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}

--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: upload code coverage
         if: success()
+        continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
           flags: backend,${{ matrix.backend.name }},${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -397,6 +397,7 @@ jobs:
 
       - name: upload code coverage
         if: success()
+        continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
           flags: backend,${{ matrix.backend.name }},${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}
@@ -524,6 +525,7 @@ jobs:
 
       - name: upload code coverage
         if: success()
+        continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
           flags: backend,${{ matrix.backend.name }},${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}
@@ -596,6 +598,7 @@ jobs:
       - name: upload code coverage
         # only upload coverage for jobs that aren't mostly xfails
         if: success() && matrix.python-version != '3.11'
+        continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
           flags: backend,pyspark,${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}
@@ -711,6 +714,7 @@ jobs:
 
       - name: upload code coverage
         if: success()
+        continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
           flags: backend,${{ matrix.backend.name }},${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -92,6 +92,7 @@ jobs:
 
       - name: upload code coverage
         if: success()
+        continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
           flags: core,${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}
@@ -177,6 +178,7 @@ jobs:
 
       - name: upload code coverage
         if: success()
+        continue-on-error: true
         uses: codecov/codecov-action@v4
         with:
           flags: core,doctests,${{ runner.os }},python-${{ steps.install_python.outputs.python-version }}


### PR DESCRIPTION
## Description of changes

Currently our CI fails when codecov fails to upload, which has been happening more frequently after
the upgrade to `codecov-action@v4`.

This PR allows the codecov step to fail to upload, since:

1. It's not a useful enough indicator of a failed build.
2. It's likely to pass on the next run, as it's often a transient issue.
