### PR TITLE
ci: eagerly cancel docs previews

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -5,6 +5,10 @@ on:
     types:
       - labeled
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   docs_preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Right now our docs previews always run to completion, even if a new commit is pushed to the same PR. This PR will cancel in progress jobs if a new commit is pushed to a PR.