### PR TITLE
chore: update flags for ruff 0.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         types_or:
           - python
           - pyi
-        args: ["check", "--force-exclude", "--show-source", "--fix"]
+        args: ["check", "--force-exclude", "--output-format=full", "--fix"]
         require_serial: true
         minimum_pre_commit_version: "2.9.2"
   - repo: local


### PR DESCRIPTION
I was getting "warning: The `--show-source` argument is deprecated. Use `--output-format=full` instead." in
https://github.com/ibis-project/ibis/actions/runs/7805418174/job/21289589595?pr=7915

This is the new API in [ruff 0.2.0](https://github.com/astral-sh/ruff/releases/tag/v0.2.0), and we now have that version
of ruff pinned.

<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
