### PR TITLE
test(dot-sql): replace snapshot test with sqlglot compilation test to avoid clashing table names

### DIFF
--- a/ibis/backends/base/sqlglot/__init__.py
+++ b/ibis/backends/base/sqlglot/__init__.py
@@ -210,18 +210,6 @@ class SQLGlotBackend(BaseBackend):
         with self._safe_raw_sql(src):
             pass
 
-    def _register_temp_view_cleanup(self, name: str) -> None:
-        """Register a clean up function for a temporary view.
-
-        No-op by default.
-
-        Parameters
-        ----------
-        name
-            The temporary view to register for clean up.
-
-        """
-
     def _load_into_cache(self, name, expr):
         self.create_table(name, expr, schema=expr.schema(), temp=True)
 

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/bigquery/out.sql
@@ -1,8 +1,0 @@
-WITH `foo` AS (
-  SELECT
-    *
-  FROM `ibis-gbq`.`ibis_gbq_testing`.`test_bigquery_temp_mem_t_for_cte` AS `t0`
-)
-SELECT
-  COUNT(*) AS `x`
-FROM `foo`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/clickhouse/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_clickhouse_temp_mem_t_for_cte" AS "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/datafusion/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/datafusion/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_datafusion_temp_mem_t_for_cte" AS "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/duckdb/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_duckdb_temp_mem_t_for_cte" AS "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/exasol/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/exasol/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_exasol_temp_mem_t_for_cte" AS "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/impala/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/impala/out.sql
@@ -1,8 +1,0 @@
-WITH `foo` AS (
-  SELECT
-    *
-  FROM `ibis_testing`.`test_impala_temp_mem_t_for_cte` AS `t0`
-)
-SELECT
-  COUNT(*) AS `x`
-FROM `foo`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mssql/out.sql
@@ -1,8 +1,0 @@
-WITH [foo] AS (
-  SELECT
-    *
-  FROM [test_mssql_temp_mem_t_for_cte] AS [t0]
-)
-SELECT
-  COUNT(*) AS [x]
-FROM [foo]

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/mysql/out.sql
@@ -1,8 +1,0 @@
-WITH `foo` AS (
-  SELECT
-    *
-  FROM `test_mysql_temp_mem_t_for_cte` AS `t0`
-)
-SELECT
-  COUNT(*) AS `x`
-FROM `foo`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/oracle/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/oracle/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_oracle_temp_mem_t_for_cte" "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/postgres/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_postgres_temp_mem_t_for_cte" AS "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/pyspark/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/pyspark/out.sql
@@ -1,8 +1,0 @@
-WITH `foo` AS (
-  SELECT
-    *
-  FROM `test_pyspark_temp_mem_t_for_cte` AS `t0`
-)
-SELECT
-  COUNT(*) AS `x`
-FROM `foo`

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/risingwave/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/risingwave/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_risingwave_temp_mem_t_for_cte" AS "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/snowflake/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_snowflake_temp_mem_t_for_cte" AS "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/sqlite/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_sqlite_temp_mem_t_for_cte" AS "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"

--- a/ibis/backends/tests/snapshots/test_dot_sql/test_cte/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_dot_sql/test_cte/trino/out.sql
@@ -1,8 +1,0 @@
-WITH "foo" AS (
-  SELECT
-    *
-  FROM "test_trino_temp_mem_t_for_cte" AS "t0"
-)
-SELECT
-  COUNT(*) AS "x"
-FROM "foo"


### PR DESCRIPTION
Addresses flaky testing observed in https://github.com/ibis-project/ibis/actions/runs/7811784691/job/21307516496, ultimately coming from two concurrent runs of the BigQuery backend test suite trying to create the same table. Here I changed the test to compare against an equivalent sqlglot expression instead of using a snapshot test.