### PR TITLE
chore(sql): remove unused `ops.Project` compile method

### DIFF
--- a/ibis/backends/base/sqlglot/compiler.py
+++ b/ibis/backends/base/sqlglot/compiler.py
@@ -1059,10 +1059,6 @@ class SQLGlotCompiler(abc.ABC):
         on = sg.and_(*predicates) if predicates else None
         return sge.Join(this=table, side=sides[how], kind=kinds[how], on=on)
 
-    @visit_node.register(ops.Project)
-    def visit_Project(self, op, *, parent, values):
-        return sg.select(*self._cleanup_names(values)).from_(parent)
-
     @staticmethod
     def _generate_groups(groups):
         return map(sge.convert, range(1, len(groups) + 1))


### PR DESCRIPTION
`ops.Project` cannot reach the SQL compiler because the rewrites rule are replacing it with a SQL specific `Select` node.