### PR TITLE
docs(api): expose relevant mixin members in temporal docs

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -367,9 +367,60 @@ quartodoc:
             name: Temporal expressions
             desc: Dates, times, timestamps and intervals.
           contents:
-            - TimestampValue
-            - DateValue
-            - TimeValue
+            - name: TimestampValue
+              members:
+                - add
+                - radd
+                - sub
+                - between
+                - bucket
+                - date
+                - day
+                - day_of_week
+                - day_of_year
+                - delta
+                - epoch_seconds
+                - hour
+                - microsecond
+                - millisecond
+                - minute
+                - month
+                - quarter
+                - second
+                - strftime
+                - time
+                - truncate
+                - week_of_year
+                - year
+            - name: DateValue
+              members:
+                - add
+                - radd
+                - sub
+                - day
+                - day_of_week
+                - day_of_year
+                - epoch_seconds
+                - month
+                - quarter
+                - strftime
+                - truncate
+                - week_of_year
+                - year
+            - name: TimeValue
+              members:
+                - add
+                - radd
+                - sub
+                - between
+                - hour
+                - microsecond
+                - millisecond
+                - minute
+                - second
+                - strftime
+                - time
+                - truncate
             - IntervalValue
             - DayOfWeek
             - name: now
@@ -392,7 +443,6 @@ quartodoc:
               package: ibis
               dynamic: true
               signature_name: full
-
         - kind: page
           path: expression-collections
           package: ibis

--- a/justfile
+++ b/justfile
@@ -160,6 +160,11 @@ docs-render:
 docs-preview:
     quarto preview docs
 
+# regen api and preview docs
+docs-api-preview:
+    just docs-apigen --verbose
+    quarto preview docs
+
 # deploy docs to netlify
 docs-deploy:
     quarto publish --no-prompt --no-browser --no-render netlify docs


### PR DESCRIPTION
## Description of changes

Explicitly listing out the members of `_DateComponentMixin` and
`_TimeComponentMixin` where relevant.

A bit verbose, but I also don't imagine these changing all that often.

Or maybe we can add support to `quartodoc` at some point to exclude
inheriting from certain parents?  dunno.


<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed

Fixes #8179

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->