### PR TITLE
ci(clouds): allow running cloud backends with github label

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -11,6 +11,9 @@ on:
       - ".envrc"
     branches:
       - main
+  pull_request_target:
+    types:
+      - labeled
 
 permissions:
   # this allows extractions/setup-just to list releases for `just` at a higher
@@ -35,6 +38,7 @@ jobs:
       group: ${{ matrix.backend.name }}-${{ matrix.python-version }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.label.name == 'ci-run-cloud'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I had this thought the other day -- instead of relying on someone with cloud credentials, sometimes we might want to trigger the cloud runs on a PR manually.  So this does that following the same pattern as our docs preview.  Need to add the label `ci-run-cloud` and it should kick off bigquery and snowflake.

If we're game to try this, we can also make it more specific, and have labels for only running bigquery or snowflake, but before I start writing a GHA matrix generator I thought I'd see how folks feel about this.
