### PR TITLE
test(sql): remove xdist_group marker for `.sql` tests

### DIFF
--- a/ibis/backends/base/sql/__init__.py
+++ b/ibis/backends/base/sql/__init__.py
@@ -408,8 +408,3 @@ class BaseSQLBackend(BaseBackend):
     @classmethod
     def has_operation(cls, operation: type[ops.Value]) -> bool:
         return operation in cls._get_operations()
-
-    def _create_temp_view(self, view, definition):
-        raise NotImplementedError(
-            f"The {self.name} backend does not implement temporary view creation"
-        )

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -35,8 +35,6 @@ dot_sql_never = pytest.mark.never(
     ["dask", "pandas"], reason="dask and pandas do not accept SQL"
 )
 
-pytestmark = [pytest.mark.xdist_group("dot_sql")]
-
 _NAMES = {
     "bigquery": "ibis_gbq_testing.functional_alltypes",
     "exasol": '"functional_alltypes"',

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -323,23 +323,6 @@ class Backend(SQLGlotBackend, CanListDatabases, NoUrl):
                 for name, _, _, _, trino_type, *_ in info
             )
 
-    def _execute_view_creation(self, name, definition):
-        # NB: trino doesn't support temporary views so we use the less
-        # desirable method of cleaning up when the Python process exits using
-        # an atexit hook
-        #
-        # the method that defines the atexit hook is defined in the parent
-        # class
-        view = sg.Create(
-            kind="VIEW",
-            this=sg.table(name, quoted=self.compiler.quoted),
-            expression=definition,
-            replace=True,
-        )
-
-        with self._safe_raw_sql(view):
-            pass
-
     def create_schema(
         self, name: str, database: str | None = None, force: bool = False
     ) -> None:


### PR DESCRIPTION
`.sql` tests can now run in separate processes because the implementation is no longer stateful