### PR TITLE
fix(duckdb): udfs builtins taking zero args

### DIFF
--- a/ibis/backends/duckdb/tests/test_udf.py
+++ b/ibis/backends/duckdb/tests/test_udf.py
@@ -57,6 +57,19 @@ def test_builtin_scalar(con, func):
     assert con.execute(expr) == expected
 
 
+def test_builtin_scalar_noargs(con):
+    @udf.scalar.builtin
+    def version() -> str:
+        ...
+
+    expr = version()
+
+    with con.begin() as c:
+        expected = c.exec_driver_sql("SELECT version()").scalar()
+
+    assert con.execute(expr) == expected
+
+
 @udf.agg.builtin
 def product(x, where: bool = True) -> float:
     ...

--- a/ibis/tests/expr/test_udf.py
+++ b/ibis/tests/expr/test_udf.py
@@ -146,3 +146,13 @@ def test_udf_deferred(dec, table):
     assert isinstance(expr, Deferred)
     assert repr(expr) == "myfunc(_.a)"
     assert expr.resolve(table).equals(myfunc(table.a))
+
+
+def test_builtin_scalar_noargs():
+    @ibis.udf.scalar.builtin
+    def version() -> str:
+        ...
+
+    expr = version()
+    assert expr.type().is_string()
+    assert type(expr.op().shape) is ibis.expr.datashape.Scalar


### PR DESCRIPTION
## Description of changes

This PR fixes the error thrown when trying to create a `udf.scalar.builtin` for an function that takes no arguments, for example

```python
@ibis.udf.scalar.builtin
def version() -> str: ...

version()
```

Thank you @gforsyth for the help troubleshooting this, as it wasn't that straightforward to figure out the core issue.

For a bit more context, the error was happening because when we had a udf that takes no arguments, then the shape check happening here: 

```python
@public
class ScalarUDF(ops.Value):
    shape = rlz.shape_like("args")
```
was failing, because there are no arguments to grab the shape of.

This fix, now takes cares of that by  defaulting to a scalar shape when this happens. 

## Issues closed

Closes https://github.com/ibis-project/ibis/issues/8256
