### PR TITLE
build(dev-tools): enable duckdb cli in the github dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,9 @@
   "features": {
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
       "version": "1.4.549"
+    },
+    "ghcr.io/eitsupi/devcontainer-features/duckdb-cli:1": {
+      "extensions": "httpfs,sqlite,postgres,spatial,substrait,parquet,json,arrow,mysql"
     }
   }
 }


### PR DESCRIPTION
Allows use of the duckdb cli in our dev container