### PR TITLE
fix: handle NULLs consistently in String.concat()

### DIFF
--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1019,6 +1019,41 @@ def test_capitalize(con):
     assert con.execute(expr) == expected
 
 
+_PD_NOTIMPL = pytest.mark.notimpl(
+    ["pandas"],
+    raises=TypeError,
+)
+
+
+@pytest.mark.parametrize(
+    ("args, expected"),
+    [
+        pytest.param((ibis.literal(None, str), None), None, marks=_PD_NOTIMPL),
+        pytest.param(("abc", None), None, marks=_PD_NOTIMPL),
+        pytest.param(("abc", ibis.literal(None, str)), None, marks=_PD_NOTIMPL),
+        pytest.param(("abc", "def", None), None, marks=_PD_NOTIMPL),
+        (("abc", "def"), "abcdef"),
+        (("abc", "def"), "abcdef"),
+    ],
+)
+@pytest.mark.parametrize("method", ["plus", "concat"])
+def test_string_concat(con, args, method, expected):
+    args = [
+        ibis.literal(arg, type="string") if isinstance(arg, str) else arg
+        for arg in args
+    ]
+    first, rest = args[0], args[1:]
+    if method == "plus":
+        expr = first
+        for arg in rest:
+            expr = expr + arg
+    elif method == "concat":
+        expr = first.concat(*rest)
+    else:
+        raise ValueError(f"Unknown method {method}")
+    assert con.execute(expr) == expected
+
+
 @pytest.mark.notimpl(
     ["dask", "pandas", "polars", "druid", "oracle", "flink"],
     raises=OperationNotDefinedError,

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -1488,7 +1488,7 @@ class StringValue(Value):
         return ops.StringSplit(self, delimiter).to_expr()
 
     def concat(self, other: str | StringValue, *args: str | StringValue) -> StringValue:
-        """Concatenate strings.
+        """Concatenate strings. NULLS are propagated. Equivalent to the `+` operator.
 
         Parameters
         ----------
@@ -1506,16 +1506,24 @@ class StringValue(Value):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.memtable({"s": ["abc", "bac", "bca"]})
-        >>> t.s.concat("xyz")
+        >>> t = ibis.memtable({"s": ["abc", None]})
+        >>> t.s.concat("xyz", "123")
+        ┏━━━━━━━━━━━━━━━━┓
+        ┃ StringConcat() ┃
+        ┡━━━━━━━━━━━━━━━━┩
+        │ string         │
+        ├────────────────┤
+        │ abcxyz123      │
+        │ NULL           │
+        └────────────────┘
+        >>> t.s + "xyz"
         ┏━━━━━━━━━━━━━━━━┓
         ┃ StringConcat() ┃
         ┡━━━━━━━━━━━━━━━━┩
         │ string         │
         ├────────────────┤
         │ abcxyz         │
-        │ bacxyz         │
-        │ bcaxyz         │
+        │ NULL           │
         └────────────────┘
         """
         return ops.StringConcat((self, other, *args)).to_expr()


### PR DESCRIPTION
Partially fixes https://github.com/ibis-project/ibis/issues/8302.
Still need to make pandas actually handle NULLs at all.