### PR TITLE
docs(links): fix release notes link in 8.0 release

### DIFF
--- a/docs/posts/ibis-version-8.0.0-release/index.qmd
+++ b/docs/posts/ibis-version-8.0.0-release/index.qmd
@@ -98,7 +98,7 @@ brings another great option for fast batch analytics to Ibis.
 
 ## Breaking changes
 
-You can view the [full changelog](../../../release_notes.md) for additional
+You can view the [full changelog](../../release_notes.md) for additional
 breaking changes. There have been few that we expect to affect most users.
 
 :::{.callout-note}


### PR DESCRIPTION
Fixes a broken link in the 8.0 release notes.