### PR TITLE
chore: lower the test set size of big unions

### DIFF
--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -775,7 +775,7 @@ def srcs():
 
 @pytest.fixture
 def nrels():
-    return 300
+    return 225
 
 
 def make_big_union(t, nrels):


### PR DESCRIPTION
xref: https://github.com/tobymao/sqlglot/issues/2961. This lowers the number of tables in the test to avoid hitting issues with sqlglot.