### PR TITLE
ci: enable docs publishing again

### DIFF
--- a/.github/workflows/ibis-docs-main.yml
+++ b/.github/workflows/ibis-docs-main.yml
@@ -51,8 +51,7 @@ jobs:
       - name: verify internal links
         run: nix develop --ignore-environment '.#links' -c just checklinks --offline --no-progress
 
-      # TODO: re-enable when geo blog is fixed (to_array)
-      # - name: build and push quarto docs
-      #   run: nix develop --ignore-environment --keep NETLIFY_AUTH_TOKEN -c just docs-deploy
-      #   env:
-      #     NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      - name: deploy docs
+        run: nix develop --ignore-environment --keep NETLIFY_AUTH_TOKEN -c just docs-deploy
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
Now that the geospatial blog rendering has been fixed, we can re-enable docs publishing