### PR TITLE
refactor(dtype): move all the castable logic to a single function

### DIFF
--- a/ibis/common/temporal.py
+++ b/ibis/common/temporal.py
@@ -217,7 +217,10 @@ def _from_str(value):
     elif lower == "today":
         return datetime.datetime.today()
 
-    value = dateutil.parser.parse(value)
+    try:
+        value = dateutil.parser.parse(value)
+    except dateutil.parser.ParserError:
+        raise TypeError(f"Unable to normalize {value} to timestamp")
     return value.replace(tzinfo=normalize_timezone(value.tzinfo))
 
 

--- a/ibis/expr/datatypes/cast.py
+++ b/ibis/expr/datatypes/cast.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from public import public
 
@@ -25,15 +25,117 @@ def cast(source: str | dt.DataType, target: str | dt.DataType, **kwargs) -> dt.D
 
 
 @public
+def castable(source: dt.DataType, target: dt.DataType, value: Any = None) -> bool:
+    """Return whether source ir type is implicitly castable to target."""
+    from ibis.expr.datatypes.value import normalizable
+
+    if source == target:
+        return True
+    elif source.is_null():
+        # The null type is castable to any type, even if the target type is *not*
+        # nullable.
+        #
+        # We handle the promotion of `null + !T -> T` at the `castable` call site.
+        #
+        # It might be possible to build a system with a single function that tries
+        # to promote types and use the exception to indicate castability, but that
+        # is a deeper refactor to be tackled later.
+        #
+        # See https://github.com/ibis-project/ibis/issues/2891 for the bug report
+        return True
+    elif target.is_boolean():
+        if source.is_boolean():
+            return True
+        elif source.is_integer():
+            return value in (0, 1)
+        else:
+            return False
+    elif target.is_integer():
+        # TODO(kszucs): ideally unsigned to signed shouldn't be allowed but that
+        # breaks the integral promotion rule logic in rules.py
+        if source.is_integer():
+            if value is not None:
+                return normalizable(target, value)
+            else:
+                return source.nbytes <= target.nbytes
+        else:
+            return False
+    elif target.is_floating():
+        if source.is_floating():
+            return source.nbytes <= target.nbytes
+        else:
+            return source.is_integer()
+    elif target.is_decimal():
+        if source.is_decimal():
+            downcast_precision = (
+                source.precision is not None
+                and target.precision is not None
+                and source.precision < target.precision
+            )
+            downcast_scale = (
+                source.scale is not None
+                and target.scale is not None
+                and source.scale < target.scale
+            )
+            return not (downcast_precision or downcast_scale)
+        else:
+            return source.is_numeric()
+    elif target.is_string():
+        return source.is_string() or source.is_uuid()
+    elif target.is_uuid():
+        return source.is_uuid() or source.is_string()
+    elif target.is_date() or target.is_timestamp():
+        if source.is_string():
+            return value is not None and normalizable(target, value)
+        else:
+            return source.is_timestamp() or source.is_date()
+    elif target.is_interval():
+        if source.is_interval():
+            return source.unit == target.unit
+        else:
+            return source.is_integer()
+    elif target.is_time():
+        if source.is_string():
+            return value is not None and normalizable(target, value)
+        else:
+            return source.is_time()
+    elif target.is_json():
+        return (
+            source.is_json()
+            or source.is_string()
+            or source.is_floating()
+            or source.is_integer()
+        )
+    elif target.is_array():
+        return source.is_array() and castable(source.value_type, target.value_type)
+    elif target.is_map():
+        return (
+            source.is_map()
+            and castable(source.key_type, target.key_type)
+            and castable(source.value_type, target.value_type)
+        )
+    elif target.is_struct():
+        return source.is_struct() and all(
+            castable(source[field], target[field]) for field in target.names
+        )
+    elif target.is_geospatial():
+        return source.is_geospatial() or source.is_array()
+    else:
+        return isinstance(target, source.__class__)
+
+
+@public
 def higher_precedence(left: dt.DataType, right: dt.DataType) -> dt.DataType:
     nullable = left.nullable or right.nullable
 
-    if left.castable(right, upcast=True):
+    if left.castable(right):
         return right.copy(nullable=nullable)
-    elif right.castable(left, upcast=True):
+    elif right.castable(left):
         return left.copy(nullable=nullable)
-
-    raise IbisTypeError(f"Cannot compute precedence for `{left}` and `{right}` types")
+    else:
+        raise IbisTypeError(
+            f"Cannot compute precedence for `{left}` and `{right}` types"
+        )
 
 
 @public

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -147,7 +147,9 @@ class DataType(Concrete, Coercible):
 
     def castable(self, to, **kwargs) -> bool:
         """Check whether this type is castable to another."""
-        return isinstance(to, self.__class__)
+        from ibis.expr.datatypes.cast import castable
+
+        return castable(self, to, **kwargs)
 
     @classmethod
     def from_string(cls, value) -> Self:
@@ -474,19 +476,6 @@ class Null(Primitive):
     scalar = "NullScalar"
     column = "NullColumn"
 
-    def castable(self, to, **kwargs) -> bool:
-        # The null type is castable to any type, even if the target type is *not*
-        # nullable.
-        #
-        # We handle the promotion of `null + !T -> T` at the `castable` call site.
-        #
-        # It might be possible to build a system with a single function that tries
-        # to promote types and use the exception to indicate castability, but that
-        # is a deeper refactor to be tackled later.
-        #
-        # See https://github.com/ibis-project/ibis/issues/2891 for the bug report
-        return True
-
 
 @public
 class Boolean(Primitive):
@@ -524,11 +513,6 @@ class Integer(Primitive, Numeric):
     def nbytes(self) -> int:
         """Return the number of bytes used to store values of this type."""
 
-    def castable(self, to, value: int | None = None, **kwargs) -> bool:
-        return (isinstance(to, Boolean) and value in (0, 1)) or isinstance(
-            to, (Floating, Decimal, JSON, Interval)
-        )
-
 
 @public
 class String(Variadic, Singleton):
@@ -543,24 +527,6 @@ class String(Variadic, Singleton):
 
     scalar = "StringScalar"
     column = "StringColumn"
-
-    def castable(self, to, value: str | None = None, **kwargs) -> bool:
-        def can_parse(value: str | None) -> bool:
-            import pandas as pd
-
-            if value is None:
-                return False
-
-            try:
-                pd.Timestamp(value)
-            except ValueError:
-                return False
-            else:
-                return True
-
-        return isinstance(to, (String, JSON, UUID)) or (
-            isinstance(to, (Date, Time, Timestamp)) and can_parse(value)
-        )
 
 
 @public
@@ -592,9 +558,6 @@ class Date(Temporal, Primitive):
 
     scalar = "DateScalar"
     column = "DateColumn"
-
-    def castable(self, to, **kwargs) -> bool:
-        return isinstance(to, (Date, Timestamp))
 
 
 @public
@@ -660,9 +623,6 @@ class Timestamp(Temporal, Parametric):
         else:
             return ""
 
-    def castable(self, to, **kwargs) -> bool:
-        return isinstance(to, (Date, Timestamp))
-
 
 @public
 class SignedInteger(Integer):
@@ -674,23 +634,6 @@ class SignedInteger(Integer):
         upper = (1 << exp) - 1
         return Bounds(lower=~upper, upper=upper)
 
-    def castable(self, to, value: int | None = None, **kwargs) -> bool:
-        if isinstance(to, SignedInteger):
-            return self.nbytes <= to.nbytes
-        elif isinstance(to, UnsignedInteger):
-            if value is not None:
-                # TODO(kszucs): we may not need to actually check the value since the
-                # literal construction now checks for bounds and doesn't use castable()
-                # anymore
-                return to.bounds.lower <= value <= to.bounds.upper
-            else:
-                return (
-                    to.bounds.upper - to.bounds.lower
-                    >= self.bounds.upper - self.bounds.lower
-                )
-        else:
-            return super().castable(to, value=value, **kwargs)
-
 
 @public
 class UnsignedInteger(Integer):
@@ -701,22 +644,6 @@ class UnsignedInteger(Integer):
         exp = self.nbytes * 8
         upper = (1 << exp) - 1
         return Bounds(lower=0, upper=upper)
-
-    def castable(self, to, value: int | None = None, **kwargs) -> bool:
-        if isinstance(to, UnsignedInteger):
-            return self.nbytes <= to.nbytes
-        elif isinstance(to, SignedInteger):
-            if value is not None:
-                # TODO(kszucs): we may not need to actually check the value since the
-                # literal construction now checks for bounds and doesn't use castable()
-                # anymore
-                return to.bounds.lower <= value <= to.bounds.upper
-            else:
-                return (to.bounds.upper - to.bounds.lower) >= (
-                    self.bounds.upper - self.bounds.lower
-                )
-        else:
-            return super().castable(to, value=value, **kwargs)
 
 
 @public
@@ -730,14 +657,6 @@ class Floating(Primitive, Numeric):
     @abstractmethod
     def nbytes(self) -> int:  # pragma: no cover
         """Return the number of bytes used to store values of this type."""
-
-    def castable(self, to, upcast: bool = False, **kwargs) -> bool:
-        return isinstance(to, (Decimal, JSON)) or (
-            isinstance(to, Floating)
-            # double -> float must be allowed because
-            # float literals are inferred as doubles
-            and ((not upcast) or to.nbytes >= self.nbytes)
-        )
 
 
 @public
@@ -872,25 +791,6 @@ class Decimal(Numeric, Parametric):
 
         return f"({', '.join(args)})"
 
-    def castable(self, to, **kwargs) -> bool:
-        if not isinstance(to, Decimal):
-            return False
-
-        to_prec = to.precision
-        self_prec = self.precision
-        to_sc = to.scale
-        self_sc = self.scale
-        return (
-            # If either sides precision and scale are both `None`, return `True`.
-            to_prec is None
-            and to_sc is None
-            or self_prec is None
-            and self_sc is None
-            # towise, return `True` unless we are downcasting precision or scale.
-            or (to_prec is None or (self_prec is not None and to_prec >= self_prec))
-            and (to_sc is None or (self_sc is not None and to_sc >= self_sc))
-        )
-
 
 @public
 class Interval(Parametric):
@@ -910,9 +810,6 @@ class Interval(Parametric):
     @property
     def _pretty_piece(self) -> str:
         return f"('{self.unit.value}')"
-
-    def castable(self, to, **kwargs) -> bool:
-        return isinstance(to, Interval) and self.unit == to.unit
 
 
 @public
@@ -972,12 +869,6 @@ class Struct(Parametric, MapSet):
         pairs = ", ".join(map("{}: {}".format, self.names, self.types))
         return f"<{pairs}>"
 
-    def castable(self, to, **kwargs) -> bool:
-        return isinstance(to, Struct) and all(
-            self[field].castable(to[field], **kwargs)
-            for field in self.keys() & to.keys()
-        )
-
 
 T = TypeVar("T", bound=DataType, covariant=True)
 
@@ -994,11 +885,6 @@ class Array(Variadic, Parametric, Generic[T]):
     @property
     def _pretty_piece(self) -> str:
         return f"<{self.value_type}>"
-
-    def castable(self, to, **kwargs) -> bool:
-        return isinstance(to, GeoSpatial) or (
-            isinstance(to, Array) and self.value_type.castable(to.value_type, **kwargs)
-        )
 
 
 K = TypeVar("K", bound=DataType, covariant=True)
@@ -1018,13 +904,6 @@ class Map(Variadic, Parametric, Generic[K, V]):
     @property
     def _pretty_piece(self) -> str:
         return f"<{self.key_type}, {self.value_type}>"
-
-    def castable(self, to, **kwargs) -> bool:
-        return (
-            isinstance(to, Map)
-            and self.key_type.castable(to.key_type, **kwargs)
-            and self.value_type.castable(to.value_type, **kwargs)
-        )
 
 
 @public
@@ -1116,9 +995,6 @@ class UUID(DataType):
 
     scalar = "UUIDScalar"
     column = "UUIDColumn"
-
-    def castable(self, to, **kwargs) -> bool:
-        return super().castable(to, **kwargs) or isinstance(to, String)
 
 
 @public

--- a/ibis/expr/datatypes/tests/test_cast.py
+++ b/ibis/expr/datatypes/tests/test_cast.py
@@ -1,8 +1,52 @@
 from __future__ import annotations
 
+import hypothesis as h
 import pytest
 
 import ibis.expr.datatypes as dt
+import ibis.tests.strategies as ibst
+
+
+@h.given(ibst.signed_integer_dtypes(), ibst.signed_integer_dtypes())
+def test_signed_integer_castable_to_signed_integer(from_, to):
+    if from_.nbytes > to.nbytes:
+        assert not from_.castable(to)
+    else:
+        assert from_.castable(to)
+
+
+@h.given(ibst.unsigned_integer_dtypes(), ibst.unsigned_integer_dtypes())
+def test_unsigned_integer_castable_to_unsigned_integer(from_, to):
+    if from_.nbytes > to.nbytes:
+        assert not from_.castable(to)
+    else:
+        assert from_.castable(to)
+
+
+# TODO(kszucs): unsigned to signed implicit cast is currently allowed to not
+# break the integral promotion rule logic in rules.py
+# @h.given(ibst.signed_integer_dtypes(), ibst.unsigned_integer_dtypes())
+# def test_signed_integer_not_castable_to_unsigned_integer(from_, to):
+#     assert not from_.castable(to)
+
+
+@h.given(ibst.integer_dtypes(), ibst.floating_dtypes())
+def test_integer_castable_to_floating(from_, to):
+    assert from_.castable(to)
+
+
+# TODO(kszucs): we could be more pedantic here considering the precision
+@h.given(ibst.integer_dtypes(), ibst.decimal_dtypes())
+def test_integer_castable_to_decimal(from_, to):
+    assert from_.castable(to)
+
+
+@h.given(ibst.integer_dtypes(), ibst.boolean_dtype())
+def test_integer_castable_to_boolean(from_, to):
+    assert from_.castable(to, value=0)
+    assert from_.castable(to, value=1)
+    assert not from_.castable(to, value=-1)
+    assert not from_.castable(to)
 
 
 @pytest.mark.parametrize(
@@ -13,7 +57,7 @@ import ibis.expr.datatypes as dt
         (dt.null, dt.date),
         (dt.int8, dt.int64),
         (dt.int8, dt.Decimal(12, 2)),
-        (dt.int16, dt.uint64),
+        # (dt.int16, dt.uint64),
         (dt.int32, dt.int32),
         (dt.int32, dt.int64),
         (dt.uint32, dt.uint64),

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -346,4 +346,14 @@ def normalize(typ, value):
         raise TypeError(f"Unable to normalize {value!r} to {dtype!r}")
 
 
+def normalizable(typ, value):
+    """Check if a value can be normalized to a given type."""
+    try:
+        normalize(typ, value)
+    except TypeError:
+        return False
+    else:
+        return True
+
+
 public(infer=infer, normalize=normalize)

--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -88,8 +88,6 @@ def shape_like(name):
 
 
 def _promote_integral_binop(exprs, op):
-    import ibis.expr.operations as ops
-
     bounds, dtypes = [], []
     for arg in exprs:
         dtypes.append(arg.dtype)
@@ -133,9 +131,7 @@ def _promote_interval_resolution(units: list[IntervalUnit]) -> IntervalUnit:
 
 
 def _arg_type_error_format(op):
-    from ibis.expr.operations.generic import Literal
-
-    if isinstance(op, Literal):
+    if isinstance(op, ops.Literal):
         return f"Literal({op.value}):{op.dtype}"
     else:
         return f"{op.name}:{op.dtype}"

--- a/ibis/tests/expr/test_timestamp.py
+++ b/ibis/tests/expr/test_timestamp.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import datetime
 
-import dateutil.parser
 import numpy as np
 import pandas as pd
 import pytest
@@ -67,7 +66,7 @@ def test_timestamp_literals(function, value):
 
 
 def test_invalid_timestamp_literal():
-    with pytest.raises(dateutil.parser.ParserError):
+    with pytest.raises(TypeError, match="Unable to normalize"):
         ibis.timestamp("2015-01-01 00:71")
 
 


### PR DESCRIPTION
This makes it easier to understand the implicit casting rules. 