### PR TITLE
fix(postgres): pass through additional kwargs in pguri

### DIFF
--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -207,6 +207,7 @@ class Backend(SQLGlotBackend):
         port: int = 5432,
         database: str | None = None,
         schema: str | None = None,
+        **kwargs: Any,
     ) -> None:
         """Create an Ibis client connected to PostgreSQL database.
 
@@ -224,6 +225,8 @@ class Backend(SQLGlotBackend):
             Database to connect to
         schema
             PostgreSQL schema to use. If `None`, use the default `search_path`.
+        kwargs
+            Additional keyword arguments to pass to the backend client connection.
 
         Examples
         --------
@@ -265,6 +268,7 @@ class Backend(SQLGlotBackend):
             password=password,
             database=database,
             options=(f"-csearch_path={schema}" * (schema is not None)) or None,
+            **kwargs,
         )
 
         with self.begin() as cur:

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -238,3 +238,10 @@ def test_timezone_from_column(contz, snapshot):
     )
     tm.assert_frame_equal(result, expected)
     snapshot.assert_match(ibis.to_sql(case), "out.sql")
+
+
+def test_kwargs_passthrough_in_connect():
+    con = ibis.connect(
+        "postgresql://postgres:postgres@localhost/ibis_testing?sslmode=allow"
+    )
+    assert con.current_database == "ibis_testing"


### PR DESCRIPTION
## Description of changes

Pass through additional kwargs that are parsed out of a connection string and send them on to the `psycopg2.connect` call.

## Issues closed

Resolves #8168
xref #8190 
