### PR TITLE
refactor(backends): remove singledispatchmethod from the sql backends

### DIFF
--- a/docs/support_matrix.qmd
+++ b/docs/support_matrix.qmd
@@ -7,8 +7,6 @@ hide:
 
 ```{python}
 #| echo: false
-from pathlib import Path
-
 import pandas as pd
 
 import ibis

--- a/ibis/backends/base/sqlglot/__init__.py
+++ b/ibis/backends/base/sqlglot/__init__.py
@@ -35,10 +35,12 @@ class SQLGlotBackend(BaseBackend):
 
     @classmethod
     def has_operation(cls, operation: type[ops.Value]) -> bool:
-        # singledispatchmethod overrides `__get__` so we can't directly access
-        # the dispatcher
-        dispatcher = cls.compiler.visit_node.register.__self__.dispatcher
-        return dispatcher.dispatch(operation) is not dispatcher.dispatch(object)
+        compiler = cls.compiler
+        method = getattr(compiler, f"visit_{operation.__name__}", None)
+        return method is not None and method not in (
+            compiler.visit_Undefined,
+            compiler.visit_Unsupported,
+        )
 
     def _fetch_from_cursor(self, cursor, schema: sch.Schema) -> pd.DataFrame:
         import pandas as pd

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/datetime/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/datetime/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(HOUR FROM datetime('2017-01-01T04:55:59')) AS `tmp`
+  EXTRACT(hour FROM datetime('2017-01-01T04:55:59')) AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/string_time/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/string_time/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(HOUR FROM time(4, 55, 59)) AS `tmp`
+  EXTRACT(hour FROM time(4, 55, 59)) AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/string_timestamp/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/string_timestamp/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(HOUR FROM datetime('2017-01-01T04:55:59')) AS `tmp`
+  EXTRACT(hour FROM datetime('2017-01-01T04:55:59')) AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/time/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/time/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(HOUR FROM time(4, 55, 59)) AS `tmp`
+  EXTRACT(hour FROM time(4, 55, 59)) AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/timestamp/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_timestamp_or_time/timestamp/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(HOUR FROM datetime('2017-01-01T04:55:59')) AS `tmp`
+  EXTRACT(hour FROM datetime('2017-01-01T04:55:59')) AS `tmp`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/date/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/date/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(YEAR FROM DATE(2017, 1, 1)) AS `ExtractYear_datetime_date_2017_ 1_ 1`
+  EXTRACT(year FROM DATE(2017, 1, 1)) AS `ExtractYear_datetime_date_2017_ 1_ 1`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/datetime/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/datetime/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(YEAR FROM datetime('2017-01-01T04:55:59')) AS `ExtractYear_datetime_datetime_2017_ 1_ 1_ 4_ 55_ 59`
+  EXTRACT(year FROM datetime('2017-01-01T04:55:59')) AS `ExtractYear_datetime_datetime_2017_ 1_ 1_ 4_ 55_ 59`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/string_date/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/string_date/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(YEAR FROM DATE(2017, 1, 1)) AS `ExtractYear_datetime_date_2017_ 1_ 1`
+  EXTRACT(year FROM DATE(2017, 1, 1)) AS `ExtractYear_datetime_date_2017_ 1_ 1`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/string_timestamp/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/string_timestamp/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(YEAR FROM datetime('2017-01-01T04:55:59')) AS `ExtractYear_datetime_datetime_2017_ 1_ 1_ 4_ 55_ 59`
+  EXTRACT(year FROM datetime('2017-01-01T04:55:59')) AS `ExtractYear_datetime_datetime_2017_ 1_ 1_ 4_ 55_ 59`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/timestamp/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/timestamp/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(YEAR FROM datetime('2017-01-01T04:55:59')) AS `ExtractYear_datetime_datetime_2017_ 1_ 1_ 4_ 55_ 59`
+  EXTRACT(year FROM datetime('2017-01-01T04:55:59')) AS `ExtractYear_datetime_datetime_2017_ 1_ 1_ 4_ 55_ 59`

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/timestamp_date/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_literal_year/timestamp_date/out.sql
@@ -1,2 +1,2 @@
 SELECT
-  EXTRACT(YEAR FROM DATE(2017, 1, 1)) AS `ExtractYear_datetime_date_2017_ 1_ 1`
+  EXTRACT(year FROM DATE(2017, 1, 1)) AS `ExtractYear_datetime_date_2017_ 1_ 1`

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import calendar
 import math
-from functools import singledispatchmethod
 from typing import Any
 
 import sqlglot as sg
@@ -30,6 +29,18 @@ class ClickHouseCompiler(SQLGlotCompiler):
     type_mapper = ClickHouseType
     rewrites = (rewrite_sample_as_filter, *SQLGlotCompiler.rewrites)
 
+    UNSUPPORTED_OPERATIONS = frozenset(
+        (
+            ops.RowID,
+            ops.CumeDist,
+            ops.PercentRank,
+            ops.Time,
+            ops.TimeDelta,
+            ops.StringToTimestamp,
+            ops.Levenshtein,
+        )
+    )
+
     def _aggregate(self, funcname: str, *args, where):
         has_filter = where is not None
         func = self.f[funcname + "If" * has_filter]
@@ -48,11 +59,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
             return None
         return spec
 
-    @singledispatchmethod
-    def visit_node(self, op, **kw):
-        return super().visit_node(op, **kw)
-
-    @visit_node.register(ops.Cast)
     def visit_Cast(self, op, *, arg, to):
         _interval_cast_suffixes = {
             "s": "Second",
@@ -74,21 +80,17 @@ class ClickHouseCompiler(SQLGlotCompiler):
             return self.f.toTimeZone(result, timezone)
         return result
 
-    @visit_node.register(ops.TryCast)
     def visit_TryCast(self, op, *, arg, to):
         return self.f.accurateCastOrNull(arg, self.type_mapper.to_string(to))
 
-    @visit_node.register(ops.ArrayIndex)
     def visit_ArrayIndex(self, op, *, arg, index):
         return arg[self.if_(index >= 0, index + 1, index)]
 
-    @visit_node.register(ops.ArrayRepeat)
     def visit_ArrayRepeat(self, op, *, arg, times):
         param = sg.to_identifier("_")
         func = sge.Lambda(this=arg, expressions=[param])
         return self.f.arrayFlatten(self.f.arrayMap(func, self.f.range(times)))
 
-    @visit_node.register(ops.ArraySlice)
     def visit_ArraySlice(self, op, *, arg, start, stop):
         start = parenthesize(op.start, start)
         start_correct = self.if_(start < 0, start, start + 1)
@@ -109,15 +111,12 @@ class ClickHouseCompiler(SQLGlotCompiler):
         else:
             return self.f.arraySlice(arg, start_correct)
 
-    @visit_node.register(ops.CountStar)
     def visit_CountStar(self, op, *, where, arg):
         if where is not None:
             return self.f.countIf(where)
         return sge.Count(this=STAR)
 
-    @visit_node.register(ops.Quantile)
-    @visit_node.register(ops.MultiQuantile)
-    def visit_QuantileMultiQuantile(self, op, *, arg, quantile, where):
+    def visit_Quantile(self, op, *, arg, quantile, where):
         if where is None:
             return self.agg.quantile(arg, quantile, where=where)
 
@@ -128,7 +127,8 @@ class ClickHouseCompiler(SQLGlotCompiler):
             params=[arg, where],
         )
 
-    @visit_node.register(ops.Correlation)
+    visit_MultiQuantile = visit_Quantile
+
     def visit_Correlation(self, op, *, left, right, how, where):
         if how == "pop":
             raise ValueError(
@@ -136,7 +136,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
             )
         return self.agg.corr(left, right, where=where)
 
-    @visit_node.register(ops.Arbitrary)
     def visit_Arbitrary(self, op, *, arg, how, where):
         if how == "first":
             return self.agg.any(arg, where=where)
@@ -146,7 +145,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
             assert how == "heavy"
             return self.agg.anyHeavy(arg, where=where)
 
-    @visit_node.register(ops.Substring)
     def visit_Substring(self, op, *, arg, start, length):
         # Clickhouse is 1-indexed
         suffix = (length,) * (length is not None)
@@ -154,7 +152,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
         if_neg = self.f.substring(arg, self.f.length(arg) + start + 1, *suffix)
         return self.if_(start >= 0, if_pos, if_neg)
 
-    @visit_node.register(ops.StringFind)
     def visit_StringFind(self, op, *, arg, substr, start, end):
         if end is not None:
             raise com.UnsupportedOperationError(
@@ -166,11 +163,9 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         return self.f.locate(arg, substr)
 
-    @visit_node.register(ops.RegexSearch)
     def visit_RegexSearch(self, op, *, arg, pattern):
         return sge.RegexpLike(this=arg, expression=pattern)
 
-    @visit_node.register(ops.RegexExtract)
     def visit_RegexExtract(self, op, *, arg, pattern, index):
         arg = self.cast(arg, dt.String(nullable=False))
 
@@ -185,20 +180,16 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         return self.if_(self.f.notEmpty(then), then, NULL)
 
-    @visit_node.register(ops.FindInSet)
     def visit_FindInSet(self, op, *, needle, values):
         return self.f.indexOf(self.f.array(*values), needle)
 
-    @visit_node.register(ops.Sign)
     def visit_Sign(self, op, *, arg):
         """Workaround for missing sign function in older versions of clickhouse."""
         return self.f.intDivOrZero(arg, self.f.abs(arg))
 
-    @visit_node.register(ops.Hash)
     def visit_Hash(self, op, *, arg):
         return self.f.sipHash64(arg)
 
-    @visit_node.register(ops.HashBytes)
     def visit_HashBytes(self, op, *, arg, how):
         supported_algorithms = {
             "md5": "MD5",
@@ -221,14 +212,13 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         return self.f[funcname](arg)
 
-    @visit_node.register(ops.IntervalFromInteger)
     def visit_IntervalFromInteger(self, op, *, arg, unit):
         dtype = op.dtype
         if dtype.unit.short in ("ms", "us", "ns"):
             raise com.UnsupportedOperationError(
                 "Clickhouse doesn't support subsecond interval resolutions"
             )
-        return super().visit_node(op, arg=arg, unit=unit)
+        return super().visit_IntervalFromInteger(op, arg=arg, unit=unit)
 
     def visit_NonNullLiteral(self, op, *, value, dtype):
         if dtype.is_inet():
@@ -322,16 +312,12 @@ class ClickHouseCompiler(SQLGlotCompiler):
         else:
             return None
 
-    @visit_node.register(ops.TimestampFromUNIX)
     def visit_TimestampFromUNIX(self, op, *, arg, unit):
         if (unit := unit.short) in {"ms", "us", "ns"}:
             raise com.UnsupportedOperationError(f"{unit!r} unit is not supported!")
         return self.f.toDateTime(arg)
 
-    @visit_node.register(ops.DateTruncate)
-    @visit_node.register(ops.TimestampTruncate)
-    @visit_node.register(ops.TimeTruncate)
-    def visit_TimeTruncate(self, op, *, arg, unit):
+    def visit_TimestampTruncate(self, op, *, arg, unit):
         converters = {
             "Y": "toStartOfYear",
             "M": "toStartOfMonth",
@@ -348,7 +334,8 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         return self.f[converter](arg)
 
-    @visit_node.register(ops.TimestampBucket)
+    visit_TimeTruncate = visit_DateTruncate = visit_TimestampTruncate
+
     def visit_TimestampBucket(self, op, *, arg, interval, offset):
         if offset is not None:
             raise com.UnsupportedOperationError(
@@ -357,7 +344,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         return self.f.toStartOfInterval(arg, interval)
 
-    @visit_node.register(ops.DateFromYMD)
     def visit_DateFromYMD(self, op, *, year, month, day):
         return self.f.toDate(
             self.f.concat(
@@ -369,7 +355,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
             )
         )
 
-    @visit_node.register(ops.TimestampFromYMDHMS)
     def visit_TimestampFromYMDHMS(
         self, op, *, year, month, day, hours, minutes, seconds, **_
     ):
@@ -392,34 +377,28 @@ class ClickHouseCompiler(SQLGlotCompiler):
             return self.f.toTimeZone(to_datetime, timezone)
         return to_datetime
 
-    @visit_node.register(ops.StringSplit)
     def visit_StringSplit(self, op, *, arg, delimiter):
         return self.f.splitByString(
             delimiter, self.cast(arg, dt.String(nullable=False))
         )
 
-    @visit_node.register(ops.Capitalize)
     def visit_Capitalize(self, op, *, arg):
         return self.f.concat(
             self.f.upper(self.f.substr(arg, 1, 1)), self.f.lower(self.f.substr(arg, 2))
         )
 
-    @visit_node.register(ops.GroupConcat)
     def visit_GroupConcat(self, op, *, arg, sep, where):
         call = self.agg.groupArray(arg, where=where)
         return self.if_(self.f.empty(call), NULL, self.f.arrayStringConcat(call, sep))
 
-    @visit_node.register(ops.Cot)
     def visit_Cot(self, op, *, arg):
         return 1.0 / self.f.tan(arg)
 
-    @visit_node.register(ops.StructColumn)
     def visit_StructColumn(self, op, *, values, names):
         # ClickHouse struct types cannot be nullable
         # (non-nested fields can be nullable)
         return self.cast(self.f.tuple(*values), op.dtype.copy(nullable=False))
 
-    @visit_node.register(ops.Clip)
     def visit_Clip(self, op, *, arg, lower, upper):
         if upper is not None:
             arg = self.if_(self.f.isNull(arg), NULL, self.f.least(upper, arg))
@@ -429,26 +408,21 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         return arg
 
-    @visit_node.register(ops.StructField)
     def visit_StructField(self, op, *, arg, field: str):
         arg_dtype = op.arg.dtype
         idx = arg_dtype.names.index(field)
         return self.cast(sge.Dot(this=arg, expression=sge.convert(idx + 1)), op.dtype)
 
-    @visit_node.register(ops.Repeat)
     def visit_Repeat(self, op, *, arg, times):
         return self.f.repeat(arg, self.f.accurateCast(times, "UInt64"))
 
-    @visit_node.register(ops.StringContains)
     def visit_StringContains(self, op, haystack, needle):
         return self.f.locate(haystack, needle) > 0
 
-    @visit_node.register(ops.DayOfWeekIndex)
     def visit_DayOfWeekIndex(self, op, *, arg):
         weekdays = len(calendar.day_name)
         return (((self.f.toDayOfWeek(arg) - 1) % weekdays) + weekdays) % weekdays
 
-    @visit_node.register(ops.DayOfWeekName)
     def visit_DayOfWeekName(self, op, *, arg):
         # ClickHouse 20 doesn't support dateName
         #
@@ -470,31 +444,24 @@ class ClickHouseCompiler(SQLGlotCompiler):
             default=sge.convert(""),
         )
 
-    @visit_node.register(ops.Map)
     def visit_Map(self, op, *, keys, values):
         # cast here to allow lookups of nullable columns
         return self.cast(self.f.tuple(keys, values), op.dtype)
 
-    @visit_node.register(ops.MapGet)
     def visit_MapGet(self, op, *, arg, key, default):
         return self.if_(self.f.mapContains(arg, key), arg[key], default)
 
-    @visit_node.register(ops.ArrayConcat)
     def visit_ArrayConcat(self, op, *, arg):
         return self.f.arrayConcat(*arg)
 
-    @visit_node.register(ops.BitAnd)
-    @visit_node.register(ops.BitOr)
-    @visit_node.register(ops.BitXor)
     def visit_BitAndOrXor(self, op, *, arg, where):
         if not (dtype := op.arg.dtype).is_unsigned_integer():
             nbits = dtype.nbytes * 8
             arg = self.f[f"reinterpretAsUInt{nbits}"](arg)
         return self.agg[f"group{type(op).__name__}"](arg, where=where)
 
-    @visit_node.register(ops.StandardDev)
-    @visit_node.register(ops.Variance)
-    @visit_node.register(ops.Covariance)
+    visit_BitAnd = visit_BitOr = visit_BitXor = visit_BitAndOrXor
+
     def visit_StandardDevVariance(self, op, *, how, where, **kw):
         funcs = {
             ops.StandardDev: "stddev",
@@ -506,14 +473,14 @@ class ClickHouseCompiler(SQLGlotCompiler):
         funcname = variants[how]
         return self.agg[funcname](*kw.values(), where=where)
 
-    @visit_node.register(ops.ArrayDistinct)
+    visit_StandardDev = visit_Variance = visit_Covariance = visit_StandardDevVariance
+
     def visit_ArrayDistinct(self, op, *, arg):
         null_element = self.if_(
             self.f.countEqual(arg, NULL) > 0, self.f.array(NULL), self.f.array()
         )
         return self.f.arrayConcat(self.f.arrayDistinct(arg), null_element)
 
-    @visit_node.register(ops.ExtractMicrosecond)
     def visit_ExtractMicrosecond(self, op, *, arg):
         dtype = op.dtype
         return self.cast(
@@ -522,7 +489,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
             dtype,
         )
 
-    @visit_node.register(ops.ExtractMillisecond)
     def visit_ExtractMillisecond(self, op, *, arg):
         dtype = op.dtype
         return self.cast(
@@ -531,9 +497,7 @@ class ClickHouseCompiler(SQLGlotCompiler):
             dtype,
         )
 
-    @visit_node.register(ops.Lag)
-    @visit_node.register(ops.Lead)
-    def formatter(self, op, *, arg, offset, default):
+    def visit_LagLead(self, op, *, arg, offset, default):
         args = [arg]
 
         if default is not None:
@@ -548,38 +512,33 @@ class ClickHouseCompiler(SQLGlotCompiler):
         func = self.f[f"{type(op).__name__.lower()}InFrame"]
         return func(*args)
 
-    @visit_node.register(ops.ExtractFile)
+    visit_Lag = visit_Lead = visit_LagLead
+
     def visit_ExtractFile(self, op, *, arg):
         return self.f.cutFragment(self.f.pathFull(arg))
 
-    @visit_node.register(ops.ExtractQuery)
     def visit_ExtractQuery(self, op, *, arg, key):
         if key is not None:
             return self.f.extractURLParameter(arg, key)
         else:
             return self.f.queryString(arg)
 
-    @visit_node.register(ops.ArrayStringJoin)
     def visit_ArrayStringJoin(self, op, *, arg, sep):
         return self.f.arrayStringConcat(arg, sep)
 
-    @visit_node.register(ops.ArrayMap)
     def visit_ArrayMap(self, op, *, arg, param, body):
         func = sge.Lambda(this=body, expressions=[param])
         return self.f.arrayMap(func, arg)
 
-    @visit_node.register(ops.ArrayFilter)
     def visit_ArrayFilter(self, op, *, arg, param, body):
         func = sge.Lambda(this=body, expressions=[param])
         return self.f.arrayFilter(func, arg)
 
-    @visit_node.register(ops.ArrayRemove)
     def visit_ArrayRemove(self, op, *, arg, other):
         x = sg.to_identifier("x")
         body = x.neq(other)
         return self.f.arrayFilter(sge.Lambda(this=body, expressions=[x]), arg)
 
-    @visit_node.register(ops.ArrayUnion)
     def visit_ArrayUnion(self, op, *, left, right):
         arg = self.f.arrayConcat(left, right)
         null_element = self.if_(
@@ -587,11 +546,9 @@ class ClickHouseCompiler(SQLGlotCompiler):
         )
         return self.f.arrayConcat(self.f.arrayDistinct(arg), null_element)
 
-    @visit_node.register(ops.ArrayZip)
     def visit_ArrayZip(self, op: ops.ArrayZip, *, arg, **_: Any) -> str:
         return self.f.arrayZip(*arg)
 
-    @visit_node.register(ops.CountDistinctStar)
     def visit_CountDistinctStar(
         self, op: ops.CountDistinctStar, *, where, **_: Any
     ) -> str:
@@ -602,7 +559,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
         else:
             return self.f.countDistinct(columns)
 
-    @visit_node.register(ops.TimestampRange)
     def visit_TimestampRange(self, op, *, start, stop, step):
         unit = op.step.dtype.unit.name.lower()
 
@@ -627,23 +583,12 @@ class ClickHouseCompiler(SQLGlotCompiler):
             func, self.f.range(0, self.f.timestampDiff(unit, start, stop), step_value)
         )
 
-    @visit_node.register(ops.RegexSplit)
     def visit_RegexSplit(self, op, *, arg, pattern):
         return self.f.splitByRegexp(pattern, self.cast(arg, dt.String(nullable=False)))
 
     @staticmethod
     def _generate_groups(groups):
         return groups
-
-    @visit_node.register(ops.RowID)
-    @visit_node.register(ops.CumeDist)
-    @visit_node.register(ops.PercentRank)
-    @visit_node.register(ops.Time)
-    @visit_node.register(ops.TimeDelta)
-    @visit_node.register(ops.StringToTimestamp)
-    @visit_node.register(ops.Levenshtein)
-    def visit_Undefined(self, op, **_):
-        raise com.OperationNotDefinedError(type(op).__name__)
 
 
 _SIMPLE_OPS = {
@@ -720,13 +665,11 @@ for _op, _name in _SIMPLE_OPS.items():
     assert isinstance(type(_op), type), type(_op)
     if issubclass(_op, ops.Reduction):
 
-        @ClickHouseCompiler.visit_node.register(_op)
         def _fmt(self, op, *, _name: str = _name, where, **kw):
             return self.agg[_name](*kw.values(), where=where)
 
     else:
 
-        @ClickHouseCompiler.visit_node.register(_op)
         def _fmt(self, op, *, _name: str = _name, **kw):
             return self.f[_name](*kw.values())
 

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from functools import singledispatchmethod
-
 import sqlglot as sg
 import sqlglot.expressions as sge
 
@@ -31,6 +29,37 @@ class ImpalaCompiler(SQLGlotCompiler):
         rewrite_last_to_last_value,
         rewrite_empty_order_by_window,
         *SQLGlotCompiler.rewrites,
+    )
+
+    UNSUPPORTED_OPERATIONS = frozenset(
+        (
+            ops.Arbitrary,
+            ops.ArgMax,
+            ops.ArgMin,
+            ops.ArrayCollect,
+            ops.ArrayPosition,
+            ops.Array,
+            ops.Covariance,
+            ops.DateDelta,
+            ops.ExtractDayOfYear,
+            ops.First,
+            ops.Last,
+            ops.Levenshtein,
+            ops.Map,
+            ops.Median,
+            ops.MultiQuantile,
+            ops.NthValue,
+            ops.Quantile,
+            ops.RegexSplit,
+            ops.RowID,
+            ops.StringSplit,
+            ops.StructColumn,
+            ops.Time,
+            ops.TimeDelta,
+            ops.TimestampBucket,
+            ops.TimestampDelta,
+            ops.Unnest,
+        )
     )
 
     def _aggregate(self, funcname: str, *args, where):
@@ -64,23 +93,16 @@ class ImpalaCompiler(SQLGlotCompiler):
                 return None
         return spec
 
-    @singledispatchmethod
-    def visit_node(self, op, **kw):
-        return super().visit_node(op, **kw)
-
-    @visit_node.register(ops.Literal)
     def visit_Literal(self, op, *, value, dtype):
         if value is None and dtype.is_binary():
             return NULL
         return super().visit_Literal(op, value=value, dtype=dtype)
 
-    @visit_node.register(ops.CountStar)
     def visit_CountStar(self, op, *, arg, where):
         if where is not None:
             return self.f.sum(self.cast(where, op.dtype))
         return self.f.count(STAR)
 
-    @visit_node.register(ops.CountDistinctStar)
     def visit_CountDistinctStar(self, op, *, arg, where):
         expressions = (
             sg.column(name, table=arg.alias_or_name, quoted=self.quoted)
@@ -90,53 +112,42 @@ class ImpalaCompiler(SQLGlotCompiler):
             expressions = (self.if_(where, expr, NULL) for expr in expressions)
         return self.f.count(sge.Distinct(expressions=list(expressions)))
 
-    @visit_node.register(ops.CountDistinct)
     def visit_CountDistinct(self, op, *, arg, where):
         if where is not None:
             arg = self.if_(where, arg, NULL)
         return self.f.count(sge.Distinct(expressions=[arg]))
 
-    @visit_node.register(ops.Xor)
     def visit_Xor(self, op, *, left, right):
         return sg.and_(sg.or_(left, right), sg.not_(sg.and_(left, right)))
 
-    @visit_node.register(ops.RandomScalar)
     def visit_RandomScalar(self, op):
         return self.f.rand(self.f.utc_to_unix_micros(self.f.utc_timestamp()))
 
-    @visit_node.register(ops.DayOfWeekIndex)
     def visit_DayOfWeekIndex(self, op, *, arg):
         return self.f.pmod(self.f.dayofweek(arg) - 2, 7)
 
-    @visit_node.register(ops.ExtractMillisecond)
-    def viist_ExtractMillisecond(self, op, *, arg):
+    def visit_ExtractMillisecond(self, op, *, arg):
         return self.f.extract(self.v.millisecond, arg) % 1_000
 
-    @visit_node.register(ops.ExtractMicrosecond)
     def visit_ExtractMicrosecond(self, op, *, arg):
         return self.f.extract(self.v.microsecond, arg) % 1_000_000
 
-    @visit_node.register(ops.Degrees)
     def visit_Degrees(self, op, *, arg):
         return 180.0 * arg / self.f.pi()
 
-    @visit_node.register(ops.Radians)
     def visit_Radians(self, op, *, arg):
         return self.f.pi() * arg / 180.0
 
-    @visit_node.register(ops.HashBytes)
     def visit_HashBytes(self, op, *, arg, how):
         if how not in ("md5", "sha1", "sha256", "sha512"):
             raise com.UnsupportedOperationError(how)
         return self.f[how](arg)
 
-    @visit_node.register(ops.Log)
     def visit_Log(self, op, *, arg, base):
         if base is None:
             return self.f.ln(arg)
         return self.f.log(base, arg, dialect=self.dialect)
 
-    @visit_node.register(ops.DateFromYMD)
     def visit_DateFromYMD(self, op, *, year, month, day):
         return self.cast(
             self.f.concat(
@@ -186,7 +197,6 @@ class ImpalaCompiler(SQLGlotCompiler):
             return sge.convert(str(value))
         return None
 
-    @visit_node.register(ops.Cast)
     def visit_Cast(self, op, *, arg, to):
         from_ = op.arg.dtype
         if from_.is_integer() and to.is_interval():
@@ -195,50 +205,43 @@ class ImpalaCompiler(SQLGlotCompiler):
             return 1_000_000 * self.f.unix_timestamp(arg)
         return super().visit_Cast(op, arg=arg, to=to)
 
-    @visit_node.register(ops.StartsWith)
     def visit_StartsWith(self, op, *, arg, start):
         return arg.like(self.f.concat(start, "%"))
 
-    @visit_node.register(ops.EndsWith)
     def visit_EndsWith(self, op, *, arg, end):
         return arg.like(self.f.concat("%", end))
 
-    @visit_node.register(ops.FindInSet)
     def visit_FindInSet(self, op, *, needle, values):
         return self.f.find_in_set(needle, self.f.concat_ws(",", *values))
 
-    @visit_node.register(ops.ExtractProtocol)
-    @visit_node.register(ops.ExtractAuthority)
-    @visit_node.register(ops.ExtractUserInfo)
-    @visit_node.register(ops.ExtractHost)
-    @visit_node.register(ops.ExtractFile)
-    @visit_node.register(ops.ExtractPath)
     def visit_ExtractUrlField(self, op, *, arg):
         return self.f.parse_url(arg, type(op).__name__[len("Extract") :].upper())
 
-    @visit_node.register(ops.ExtractQuery)
+    visit_ExtractAuthority = (
+        visit_ExtractHost
+    ) = (
+        visit_ExtractUserInfo
+    ) = (
+        visit_ExtractProtocol
+    ) = visit_ExtractFile = visit_ExtractPath = visit_ExtractUrlField
+
     def visit_ExtractQuery(self, op, *, arg, key):
         return self.f.parse_url(*filter(None, (arg, "QUERY", key)))
 
-    @visit_node.register(ops.ExtractFragment)
     def visit_ExtractFragment(self, op, *, arg):
         return self.f.parse_url(arg, "REF")
 
-    @visit_node.register(ops.StringFind)
     def visit_StringFind(self, op, *, arg, substr, start, end):
         if start is not None:
             return self.f.locate(substr, arg, start + 1)
         return self.f.locate(substr, arg)
 
-    @visit_node.register(ops.StringContains)
     def visit_StringContains(self, op, *, haystack, needle):
         return self.f.locate(needle, haystack) > 0
 
-    @visit_node.register(ops.TimestampDiff)
     def visit_TimestampDiff(self, op, *, left, right):
         return self.f.unix_timestamp(left) - self.f.unix_timestamp(right)
 
-    @visit_node.register(ops.Strftime)
     def visit_Strftime(self, op, *, arg, format_str):
         if not isinstance(op.format_str, ops.Literal):
             raise com.UnsupportedOperationError(
@@ -252,11 +255,9 @@ class ImpalaCompiler(SQLGlotCompiler):
             self.f.unix_timestamp(self.cast(arg, dt.string)), format_str
         )
 
-    @visit_node.register(ops.ExtractWeekOfYear)
     def visit_ExtractWeekOfYear(self, op, *, arg):
         return self.f.anon.weekofyear(arg)
 
-    @visit_node.register(ops.TimestampTruncate)
     def visit_TimestampTruncate(self, op, *, arg, unit):
         units = {
             "Y": "YEAR",
@@ -277,25 +278,21 @@ class ImpalaCompiler(SQLGlotCompiler):
             )
         return self.f.date_trunc(impala_unit, arg)
 
-    @visit_node.register(ops.DateTruncate)
     def visit_DateTruncate(self, op, *, arg, unit):
         if unit.short == "Q":
             return self.f.trunc(arg, "Q")
         return self.f.date_trunc(unit.name.upper(), arg)
 
-    @visit_node.register(ops.TimestampFromUNIX)
     def visit_TimestampFromUNIX(self, op, *, arg, unit):
         arg = self.cast(util.convert_unit(arg, unit.short, "s"), dt.int32)
         return self.cast(self.f.from_unixtime(arg, "yyyy-MM-dd HH:mm:ss"), dt.timestamp)
 
-    @visit_node.register(ops.DateAdd)
     def visit_DateAdd(self, op, *, left, right):
         return self.cast(
             super().visit_DateAdd(op, left=self.cast(left, dt.date), right=right),
             dt.date,
         )
 
-    @visit_node.register(ops.TimestampAdd)
     def visit_TimestampAdd(self, op, *, left, right):
         if not isinstance(right, sge.Interval):
             raise com.UnsupportedOperationError(
@@ -309,19 +306,15 @@ class ImpalaCompiler(SQLGlotCompiler):
             dt.timestamp,
         )
 
-    @visit_node.register(ops.DateDiff)
     def visit_DateDiff(self, op, *, left, right):
         return self.f.anon.datediff(left, right)
 
-    @visit_node.register(ops.Date)
     def visit_Date(self, op, *, arg):
         return self.cast(self.f.to_date(arg), dt.date)
 
-    @visit_node.register(ops.RegexReplace)
     def visit_RegexReplace(self, op, *, arg, pattern, replacement):
         return self.f.regexp_replace(arg, pattern, replacement, dialect=self.dialect)
 
-    @visit_node.register(ops.Round)
     def visit_Round(self, op, *, arg, digits):
         rounded = self.f.round(*filter(None, (arg, digits)))
 
@@ -330,42 +323,12 @@ class ImpalaCompiler(SQLGlotCompiler):
             return self.cast(rounded, dtype)
         return rounded
 
-    @visit_node.register(ops.Sign)
     def visit_Sign(self, op, *, arg):
         sign = self.f.sign(arg)
         dtype = op.dtype
         if not dtype.is_float32():
             return self.cast(sign, dtype)
         return sign
-
-    @visit_node.register(ops.Arbitrary)
-    @visit_node.register(ops.ArgMax)
-    @visit_node.register(ops.ArgMin)
-    @visit_node.register(ops.ArrayCollect)
-    @visit_node.register(ops.ArrayPosition)
-    @visit_node.register(ops.Array)
-    @visit_node.register(ops.Covariance)
-    @visit_node.register(ops.DateDelta)
-    @visit_node.register(ops.ExtractDayOfYear)
-    @visit_node.register(ops.First)
-    @visit_node.register(ops.Last)
-    @visit_node.register(ops.Levenshtein)
-    @visit_node.register(ops.Map)
-    @visit_node.register(ops.Median)
-    @visit_node.register(ops.MultiQuantile)
-    @visit_node.register(ops.NthValue)
-    @visit_node.register(ops.Quantile)
-    @visit_node.register(ops.RegexSplit)
-    @visit_node.register(ops.RowID)
-    @visit_node.register(ops.StringSplit)
-    @visit_node.register(ops.StructColumn)
-    @visit_node.register(ops.Time)
-    @visit_node.register(ops.TimeDelta)
-    @visit_node.register(ops.TimestampBucket)
-    @visit_node.register(ops.TimestampDelta)
-    @visit_node.register(ops.Unnest)
-    def visit_Undefined(self, op, **_):
-        raise com.OperationNotDefinedError(type(op).__name__)
 
 
 _SIMPLE_OPS = {
@@ -396,13 +359,11 @@ for _op, _name in _SIMPLE_OPS.items():
     assert isinstance(type(_op), type), type(_op)
     if issubclass(_op, ops.Reduction):
 
-        @ImpalaCompiler.visit_node.register(_op)
         def _fmt(self, op, *, _name: str = _name, where, **kw):
             return self.agg[_name](*kw.values(), where=where)
 
     else:
 
-        @ImpalaCompiler.visit_node.register(_op)
         def _fmt(self, op, *, _name: str = _name, **kw):
             return self.f[_name](*kw.values())
 

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -672,7 +672,8 @@ def test_interactive_repr_shows_error(alltypes):
     with config.option_context("interactive", True):
         result = repr(expr)
 
-    assert "OperationNotDefinedError('BaseConvert')" in result
+    assert "OperationNotDefinedError" in result
+    assert "BaseConvert" in result
 
 
 def test_subquery(alltypes, df):

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1321,15 +1321,7 @@ def test_hexdigest(backend, alltypes):
     backend.assert_series_equal(h1, h2)
 
 
-@pytest.mark.notimpl(
-    [
-        "pandas",
-        "dask",
-        "oracle",
-        "snowflake",
-        "sqlite",
-    ]
-)
+@pytest.mark.notimpl(["pandas", "dask", "oracle", "sqlite"])
 @pytest.mark.parametrize(
     ("from_val", "to_type", "expected"),
     [
@@ -1344,6 +1336,7 @@ def test_hexdigest(backend, alltypes):
             marks=[
                 pytest.mark.notyet(["duckdb", "impala"], reason="casts to NULL"),
                 pytest.mark.notyet(["bigquery"], raises=GoogleBadRequest),
+                pytest.mark.notyet(["snowflake"], raises=SnowflakeProgrammingError),
                 pytest.mark.notyet(["trino"], raises=TrinoUserError),
                 pytest.mark.notyet(["exasol"], raises=ExaQueryError),
                 pytest.mark.broken(
@@ -1379,7 +1372,6 @@ def test_try_cast(con, from_val, to_type, expected):
         "pandas",
         "postgres",
         "risingwave",
-        "snowflake",
         "sqlite",
     ]
 )
@@ -1395,6 +1387,7 @@ def test_try_cast(con, from_val, to_type, expected):
                     ["clickhouse", "pyspark", "flink"], reason="casts to 1672531200"
                 ),
                 pytest.mark.notyet(["bigquery"], raises=GoogleBadRequest),
+                pytest.mark.notyet(["snowflake"], raises=SnowflakeProgrammingError),
                 pytest.mark.notyet(["trino"], raises=TrinoUserError),
                 pytest.mark.notyet(["mssql"], raises=PyODBCDataError),
                 pytest.mark.broken(["polars"], reason="casts to 1672531200000000000"),
@@ -1443,7 +1436,6 @@ def test_try_cast_table(backend, con):
         "oracle",
         "postgres",
         "risingwave",
-        "snowflake",
         "sqlite",
         "exasol",
     ]
@@ -1463,6 +1455,7 @@ def test_try_cast_table(backend, con):
                     reason="casts this to to a number",
                 ),
                 pytest.mark.notyet(["bigquery"], raises=GoogleBadRequest),
+                pytest.mark.notyet(["snowflake"], raises=SnowflakeProgrammingError),
                 pytest.mark.notyet(["trino"], raises=TrinoUserError),
                 pytest.mark.notyet(["mssql"], raises=PyODBCDataError),
             ],

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -409,7 +409,6 @@ def uses_java_re(t):
             id="find_start",
             marks=[
                 pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError),
-                pytest.mark.notyet(["bigquery"], raises=NotImplementedError),
             ],
         ),
         param(


### PR DESCRIPTION
## Description of changes

This pull request does two things:

1. Removes use of `singledispatchmethod` in the SQL compilers
1. Fixes the support matrix accuracy for SQL backends

Follow-ups:

* ~Deal with filtering out RisingWave geospatial~ Handled here
* `__init_subclass__` for `SIMPLE_OPS` handled here
* Fix coverage accuracy for the non-SQL backends

## Issues closed

Fixes #8283.

Thanks to @jcrist for the `__init_subclass__` tip, that saved N backends duplication of filling in undefined operations.