### PR TITLE
ci: prevent labelled workflows from clobbering each other

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -5,13 +5,12 @@ on:
     types:
       - labeled
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
-
 jobs:
   docs_preview:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}-${{ github.event.label.name }}
+      cancel-in-progress: true
     if: github.event.label.name == 'docs-preview'
     steps:
       - uses: tibdex/github-app-token@v2

--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -20,10 +20,6 @@ permissions:
   # rate limit while restricting GITHUB_TOKEN permissions elsewhere
   contents: read
 
-concurrency:
-  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
-
 env:
   FORCE_COLOR: "1"
   SQLALCHEMY_WARN_20: "1"
@@ -35,8 +31,9 @@ jobs:
     # only a single bigquery or snowflake run at a time, otherwise test data is
     # clobbered by concurrent runs
     concurrency:
-      group: ${{ matrix.backend.name }}-${{ matrix.python-version }}
+      group: ${{ matrix.backend.name }}-${{ matrix.python-version }}-${{ github.event.label.name || 'ci-run-cloud' }}
       cancel-in-progress: false
+
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event.label.name == 'ci-run-cloud'
     strategy:


### PR DESCRIPTION
## Description of changes

This PR attempts to address an issue when running cloud CI along with our docs preview.

The issue is that when you run one, it clobbers the other.

This is because for a given workflow, the other is skipped, which will clobber
an existing run **from the other workflow**.

Let's walk through a scenario:

1. Label a PR with `docs-preview`
1. This creates a concurrency group with the name `ibis-project-$SHA-Docs Preview` and kicks off a job.
1. While that job is running, you add the `ci-run-cloud` label.
1. Both the `docs-preview` and `ci-run-cloud` workflows are invoked, because they are run on `pull_request_target` events with `labeled` type.
1. The `docs-preview` **workflow** runs, **under the same concurrency group** and is thus cancelled, because `cancel-in-progress` is set to `true`.
1. The `docs-preview` **job** is skipped, so appear to have never run.

You can swap `docs-preview` with `ci-run-cloud` in that scenario and the result is exactly the same.

This PR addresses the problem by setting the concurrency group at the job level and adding the github event label to the name of the concurrency group.

Now the scenario looks like this:

1. Label a PR with `docs-preview`
1. This creates a concurrency group with the name `ibis-project-$SHA-Docs Preview-docs-preview` and kicks off a job.
1. While that job is running, you add the `ci-run-cloud` label.
1. Both the `docs-preview` and `ci-run-cloud` workflows are invoked, because they are run on `pull_request_target` events with `labeled` type.
1. The `docs-preview` **workflow** runs, **under a different concurrency group**, and therefore doesn't clobber the existing one that has `docs-preview` in the group name
1. The `docs-preview` **job** is still skipped, but this skip does not clobber the running one because the running one has a different concurrency group
