### PR TITLE
refactor(sql): automatically add simple ops implementations

### DIFF
--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -74,6 +74,62 @@ class BigQueryCompiler(SQLGlotCompiler):
         this=sge.convert("-Infinity"), to=sge.DataType(this=sge.DataType.Type.DOUBLE)
     )
 
+    SIMPLE_OPS = {
+        ops.StringAscii: "ascii",
+        ops.BitAnd: "bit_and",
+        ops.BitOr: "bit_or",
+        ops.BitXor: "bit_xor",
+        ops.DateFromYMD: "date",
+        ops.Divide: "ieee_divide",
+        ops.EndsWith: "ends_with",
+        ops.GeoArea: "st_area",
+        ops.GeoAsBinary: "st_asbinary",
+        ops.GeoAsText: "st_astext",
+        ops.GeoAzimuth: "st_azimuth",
+        ops.GeoBuffer: "st_buffer",
+        ops.GeoCentroid: "st_centroid",
+        ops.GeoContains: "st_contains",
+        ops.GeoCoveredBy: "st_coveredby",
+        ops.GeoCovers: "st_covers",
+        ops.GeoDWithin: "st_dwithin",
+        ops.GeoDifference: "st_difference",
+        ops.GeoDisjoint: "st_disjoint",
+        ops.GeoDistance: "st_distance",
+        ops.GeoEndPoint: "st_endpoint",
+        ops.GeoEquals: "st_equals",
+        ops.GeoGeometryType: "st_geometrytype",
+        ops.GeoIntersection: "st_intersection",
+        ops.GeoIntersects: "st_intersects",
+        ops.GeoLength: "st_length",
+        ops.GeoMaxDistance: "st_maxdistance",
+        ops.GeoNPoints: "st_numpoints",
+        ops.GeoPerimeter: "st_perimeter",
+        ops.GeoPoint: "st_geogpoint",
+        ops.GeoPointN: "st_pointn",
+        ops.GeoStartPoint: "st_startpoint",
+        ops.GeoTouches: "st_touches",
+        ops.GeoUnaryUnion: "st_union_agg",
+        ops.GeoUnion: "st_union",
+        ops.GeoWithin: "st_within",
+        ops.GeoX: "st_x",
+        ops.GeoY: "st_y",
+        ops.Hash: "farm_fingerprint",
+        ops.IsInf: "is_inf",
+        ops.IsNan: "is_nan",
+        ops.Log10: "log10",
+        ops.LPad: "lpad",
+        ops.RPad: "rpad",
+        ops.Levenshtein: "edit_distance",
+        ops.Modulus: "mod",
+        ops.RandomScalar: "rand",
+        ops.RegexReplace: "regexp_replace",
+        ops.RegexSearch: "regexp_contains",
+        ops.Time: "time",
+        ops.TimeFromHMS: "time",
+        ops.TimestampFromYMDHMS: "datetime",
+        ops.TimestampNow: "current_timestamp",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         func = self.f[funcname]
 
@@ -665,77 +721,3 @@ class BigQueryCompiler(SQLGlotCompiler):
         if where is not None:
             arg = self.if_(where, arg, NULL)
         return self.f.count(sge.Distinct(expressions=[arg]))
-
-
-_SIMPLE_OPS = {
-    ops.StringAscii: "ascii",
-    ops.BitAnd: "bit_and",
-    ops.BitOr: "bit_or",
-    ops.BitXor: "bit_xor",
-    ops.DateFromYMD: "date",
-    ops.Divide: "ieee_divide",
-    ops.EndsWith: "ends_with",
-    ops.GeoArea: "st_area",
-    ops.GeoAsBinary: "st_asbinary",
-    ops.GeoAsText: "st_astext",
-    ops.GeoAzimuth: "st_azimuth",
-    ops.GeoBuffer: "st_buffer",
-    ops.GeoCentroid: "st_centroid",
-    ops.GeoContains: "st_contains",
-    ops.GeoCoveredBy: "st_coveredby",
-    ops.GeoCovers: "st_covers",
-    ops.GeoDWithin: "st_dwithin",
-    ops.GeoDifference: "st_difference",
-    ops.GeoDisjoint: "st_disjoint",
-    ops.GeoDistance: "st_distance",
-    ops.GeoEndPoint: "st_endpoint",
-    ops.GeoEquals: "st_equals",
-    ops.GeoGeometryType: "st_geometrytype",
-    ops.GeoIntersection: "st_intersection",
-    ops.GeoIntersects: "st_intersects",
-    ops.GeoLength: "st_length",
-    ops.GeoMaxDistance: "st_maxdistance",
-    ops.GeoNPoints: "st_numpoints",
-    ops.GeoPerimeter: "st_perimeter",
-    ops.GeoPoint: "st_geogpoint",
-    ops.GeoPointN: "st_pointn",
-    ops.GeoStartPoint: "st_startpoint",
-    ops.GeoTouches: "st_touches",
-    ops.GeoUnaryUnion: "st_union_agg",
-    ops.GeoUnion: "st_union",
-    ops.GeoWithin: "st_within",
-    ops.GeoX: "st_x",
-    ops.GeoY: "st_y",
-    ops.Hash: "farm_fingerprint",
-    ops.IsInf: "is_inf",
-    ops.IsNan: "is_nan",
-    ops.Log10: "log10",
-    ops.LPad: "lpad",
-    ops.RPad: "rpad",
-    ops.Levenshtein: "edit_distance",
-    ops.Modulus: "mod",
-    ops.RandomScalar: "rand",
-    ops.RegexReplace: "regexp_replace",
-    ops.RegexSearch: "regexp_contains",
-    ops.Time: "time",
-    ops.TimeFromHMS: "time",
-    ops.TimestampFromYMDHMS: "datetime",
-    ops.TimestampNow: "current_timestamp",
-}
-
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(BigQueryCompiler, f"visit_{_op.__name__}", _fmt)
-
-del _op, _name, _fmt

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -41,6 +41,76 @@ class ClickHouseCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.All: "min",
+        ops.Any: "max",
+        ops.ApproxCountDistinct: "uniqHLL12",
+        ops.ApproxMedian: "median",
+        ops.ArgMax: "argMax",
+        ops.ArgMin: "argMin",
+        ops.ArrayCollect: "groupArray",
+        ops.ArrayContains: "has",
+        ops.ArrayFlatten: "arrayFlatten",
+        ops.ArrayIntersect: "arrayIntersect",
+        ops.ArrayPosition: "indexOf",
+        ops.BitwiseAnd: "bitAnd",
+        ops.BitwiseLeftShift: "bitShiftLeft",
+        ops.BitwiseNot: "bitNot",
+        ops.BitwiseOr: "bitOr",
+        ops.BitwiseRightShift: "bitShiftRight",
+        ops.BitwiseXor: "bitXor",
+        ops.Capitalize: "initcap",
+        ops.CountDistinct: "uniq",
+        ops.Date: "toDate",
+        ops.E: "e",
+        ops.EndsWith: "endsWith",
+        ops.ExtractAuthority: "netloc",
+        ops.ExtractDay: "toDayOfMonth",
+        ops.ExtractDayOfYear: "toDayOfYear",
+        ops.ExtractEpochSeconds: "toRelativeSecondNum",
+        ops.ExtractFragment: "fragment",
+        ops.ExtractHost: "domain",
+        ops.ExtractHour: "toHour",
+        ops.ExtractMinute: "toMinute",
+        ops.ExtractMonth: "toMonth",
+        ops.ExtractPath: "path",
+        ops.ExtractProtocol: "protocol",
+        ops.ExtractQuarter: "toQuarter",
+        ops.ExtractSecond: "toSecond",
+        ops.ExtractWeekOfYear: "toISOWeek",
+        ops.ExtractYear: "toYear",
+        ops.First: "any",
+        ops.IntegerRange: "range",
+        ops.IsInf: "isInfinite",
+        ops.IsNan: "isNaN",
+        ops.IsNull: "isNull",
+        ops.LStrip: "trimLeft",
+        ops.Last: "anyLast",
+        ops.Ln: "log",
+        ops.Log10: "log10",
+        ops.MapContains: "mapContains",
+        ops.MapKeys: "mapKeys",
+        ops.MapLength: "length",
+        ops.MapMerge: "mapUpdate",
+        ops.MapValues: "mapValues",
+        ops.Median: "quantileExactExclusive",
+        ops.NotNull: "isNotNull",
+        ops.NullIf: "nullIf",
+        ops.RStrip: "trimRight",
+        ops.RandomScalar: "randCanonical",
+        ops.RegexReplace: "replaceRegexpAll",
+        ops.RowNumber: "row_number",
+        ops.StartsWith: "startsWith",
+        ops.StrRight: "right",
+        ops.Strftime: "formatDateTime",
+        ops.StringLength: "length",
+        ops.StringReplace: "replaceAll",
+        ops.Strip: "trimBoth",
+        ops.TimestampNow: "now",
+        ops.TypeOf: "toTypeName",
+        ops.Unnest: "arrayJoin",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         has_filter = where is not None
         func = self.f[funcname + "If" * has_filter]
@@ -589,90 +659,3 @@ class ClickHouseCompiler(SQLGlotCompiler):
     @staticmethod
     def _generate_groups(groups):
         return groups
-
-
-_SIMPLE_OPS = {
-    ops.All: "min",
-    ops.Any: "max",
-    ops.ApproxCountDistinct: "uniqHLL12",
-    ops.ApproxMedian: "median",
-    ops.ArgMax: "argMax",
-    ops.ArgMin: "argMin",
-    ops.ArrayCollect: "groupArray",
-    ops.ArrayContains: "has",
-    ops.ArrayFlatten: "arrayFlatten",
-    ops.ArrayIntersect: "arrayIntersect",
-    ops.ArrayPosition: "indexOf",
-    ops.BitwiseAnd: "bitAnd",
-    ops.BitwiseLeftShift: "bitShiftLeft",
-    ops.BitwiseNot: "bitNot",
-    ops.BitwiseOr: "bitOr",
-    ops.BitwiseRightShift: "bitShiftRight",
-    ops.BitwiseXor: "bitXor",
-    ops.Capitalize: "initcap",
-    ops.CountDistinct: "uniq",
-    ops.Date: "toDate",
-    ops.E: "e",
-    ops.EndsWith: "endsWith",
-    ops.ExtractAuthority: "netloc",
-    ops.ExtractDay: "toDayOfMonth",
-    ops.ExtractDayOfYear: "toDayOfYear",
-    ops.ExtractEpochSeconds: "toRelativeSecondNum",
-    ops.ExtractFragment: "fragment",
-    ops.ExtractHost: "domain",
-    ops.ExtractHour: "toHour",
-    ops.ExtractMinute: "toMinute",
-    ops.ExtractMonth: "toMonth",
-    ops.ExtractPath: "path",
-    ops.ExtractProtocol: "protocol",
-    ops.ExtractQuarter: "toQuarter",
-    ops.ExtractSecond: "toSecond",
-    ops.ExtractWeekOfYear: "toISOWeek",
-    ops.ExtractYear: "toYear",
-    ops.First: "any",
-    ops.IntegerRange: "range",
-    ops.IsInf: "isInfinite",
-    ops.IsNan: "isNaN",
-    ops.IsNull: "isNull",
-    ops.LStrip: "trimLeft",
-    ops.Last: "anyLast",
-    ops.Ln: "log",
-    ops.Log10: "log10",
-    ops.MapContains: "mapContains",
-    ops.MapKeys: "mapKeys",
-    ops.MapLength: "length",
-    ops.MapMerge: "mapUpdate",
-    ops.MapValues: "mapValues",
-    ops.Median: "quantileExactExclusive",
-    ops.NotNull: "isNotNull",
-    ops.NullIf: "nullIf",
-    ops.RStrip: "trimRight",
-    ops.RandomScalar: "randCanonical",
-    ops.RegexReplace: "replaceRegexpAll",
-    ops.RowNumber: "row_number",
-    ops.StartsWith: "startsWith",
-    ops.StrRight: "right",
-    ops.Strftime: "formatDateTime",
-    ops.StringLength: "length",
-    ops.StringReplace: "replaceAll",
-    ops.Strip: "trimBoth",
-    ops.TimestampNow: "now",
-    ops.TypeOf: "toTypeName",
-    ops.Unnest: "arrayJoin",
-}
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(ClickHouseCompiler, f"visit_{_op.__name__}", _fmt)
-
-del _op, _name, _fmt

--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -70,6 +70,21 @@ class DataFusionCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.ApproxMedian: "approx_median",
+        ops.ArrayRemove: "array_remove_all",
+        ops.BitAnd: "bit_and",
+        ops.BitOr: "bit_or",
+        ops.BitXor: "bit_xor",
+        ops.Cot: "cot",
+        ops.ExtractMicrosecond: "extract_microsecond",
+        ops.First: "first_value",
+        ops.Last: "last_value",
+        ops.Median: "median",
+        ops.StringLength: "character_length",
+        ops.RegexSplit: "regex_split",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         expr = self.f[funcname](*args)
         if where is not None:
@@ -465,33 +480,3 @@ class DataFusionCompiler(SQLGlotCompiler):
             sel = sel.group_by(*by_names_quoted)
 
         return sel
-
-
-_SIMPLE_OPS = {
-    ops.ApproxMedian: "approx_median",
-    ops.ArrayRemove: "array_remove_all",
-    ops.BitAnd: "bit_and",
-    ops.BitOr: "bit_or",
-    ops.BitXor: "bit_xor",
-    ops.Cot: "cot",
-    ops.ExtractMicrosecond: "extract_microsecond",
-    ops.First: "first_value",
-    ops.Last: "last_value",
-    ops.Median: "median",
-    ops.StringLength: "character_length",
-    ops.RegexSplit: "regex_split",
-}
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(DataFusionCompiler, f"visit_{_op.__name__}", _fmt)

--- a/ibis/backends/druid/compiler.py
+++ b/ibis/backends/druid/compiler.py
@@ -67,6 +67,23 @@ class DruidCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.BitAnd: "bit_and",
+        ops.BitOr: "bit_or",
+        ops.BitXor: "bit_xor",
+        ops.BitwiseAnd: "bitwise_and",
+        ops.BitwiseNot: "bitwise_complement",
+        ops.BitwiseOr: "bitwise_or",
+        ops.BitwiseXor: "bitwise_xor",
+        ops.BitwiseLeftShift: "bitwise_shift_left",
+        ops.BitwiseRightShift: "bitwise_shift_right",
+        ops.Modulus: "mod",
+        ops.Power: "power",
+        ops.Log10: "log10",
+        ops.ApproxCountDistinct: "approx_count_distinct",
+        ops.StringContains: "contains_string",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         expr = self.f[funcname](*args)
         if where is not None:
@@ -164,35 +181,3 @@ class DruidCompiler(SQLGlotCompiler):
                 "Z",
             )
         )
-
-
-_SIMPLE_OPS = {
-    ops.BitAnd: "bit_and",
-    ops.BitOr: "bit_or",
-    ops.BitXor: "bit_xor",
-    ops.BitwiseAnd: "bitwise_and",
-    ops.BitwiseNot: "bitwise_complement",
-    ops.BitwiseOr: "bitwise_or",
-    ops.BitwiseXor: "bitwise_xor",
-    ops.BitwiseLeftShift: "bitwise_shift_left",
-    ops.BitwiseRightShift: "bitwise_shift_right",
-    ops.Modulus: "mod",
-    ops.Power: "power",
-    ops.Log10: "log10",
-    ops.ApproxCountDistinct: "approx_count_distinct",
-    ops.StringContains: "contains_string",
-}
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(DruidCompiler, f"visit_{_op.__name__}", _fmt)

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -37,6 +37,55 @@ class DuckDBCompiler(SQLGlotCompiler):
     dialect = DuckDB
     type_mapper = DuckDBType
 
+    SIMPLE_OPS = {
+        ops.ArrayPosition: "list_indexof",
+        ops.BitAnd: "bit_and",
+        ops.BitOr: "bit_or",
+        ops.BitXor: "bit_xor",
+        ops.EndsWith: "suffix",
+        ops.Hash: "hash",
+        ops.IntegerRange: "range",
+        ops.TimestampRange: "range",
+        ops.MapKeys: "map_keys",
+        ops.MapLength: "cardinality",
+        ops.MapMerge: "map_concat",
+        ops.MapValues: "map_values",
+        ops.Mode: "mode",
+        ops.TimeFromHMS: "make_time",
+        ops.TypeOf: "typeof",
+        ops.GeoPoint: "st_point",
+        ops.GeoAsText: "st_astext",
+        ops.GeoArea: "st_area",
+        ops.GeoBuffer: "st_buffer",
+        ops.GeoCentroid: "st_centroid",
+        ops.GeoContains: "st_contains",
+        ops.GeoCovers: "st_covers",
+        ops.GeoCoveredBy: "st_coveredby",
+        ops.GeoCrosses: "st_crosses",
+        ops.GeoDifference: "st_difference",
+        ops.GeoDisjoint: "st_disjoint",
+        ops.GeoDistance: "st_distance",
+        ops.GeoDWithin: "st_dwithin",
+        ops.GeoEndPoint: "st_endpoint",
+        ops.GeoEnvelope: "st_envelope",
+        ops.GeoEquals: "st_equals",
+        ops.GeoFlipCoordinates: "st_flipcoordinates",
+        ops.GeoGeometryType: "st_geometrytype",
+        ops.GeoIntersection: "st_intersection",
+        ops.GeoIntersects: "st_intersects",
+        ops.GeoIsValid: "st_isvalid",
+        ops.GeoLength: "st_length",
+        ops.GeoNPoints: "st_npoints",
+        ops.GeoOverlaps: "st_overlaps",
+        ops.GeoStartPoint: "st_startpoint",
+        ops.GeoTouches: "st_touches",
+        ops.GeoUnion: "st_union",
+        ops.GeoUnaryUnion: "st_union_agg",
+        ops.GeoWithin: "st_within",
+        ops.GeoX: "st_x",
+        ops.GeoY: "st_y",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         expr = self.f[funcname](*args)
         if where is not None:
@@ -334,71 +383,3 @@ class DuckDBCompiler(SQLGlotCompiler):
 
     def visit_StringConcat(self, op, *, arg):
         return reduce(lambda x, y: sge.DPipe(this=x, expression=y), arg)
-
-
-_SIMPLE_OPS = {
-    ops.ArrayPosition: "list_indexof",
-    ops.BitAnd: "bit_and",
-    ops.BitOr: "bit_or",
-    ops.BitXor: "bit_xor",
-    ops.EndsWith: "suffix",
-    ops.Hash: "hash",
-    ops.IntegerRange: "range",
-    ops.TimestampRange: "range",
-    ops.MapKeys: "map_keys",
-    ops.MapLength: "cardinality",
-    ops.MapMerge: "map_concat",
-    ops.MapValues: "map_values",
-    ops.Mode: "mode",
-    ops.TimeFromHMS: "make_time",
-    ops.TypeOf: "typeof",
-    ops.GeoPoint: "st_point",
-    ops.GeoAsText: "st_astext",
-    ops.GeoArea: "st_area",
-    ops.GeoBuffer: "st_buffer",
-    ops.GeoCentroid: "st_centroid",
-    ops.GeoContains: "st_contains",
-    ops.GeoCovers: "st_covers",
-    ops.GeoCoveredBy: "st_coveredby",
-    ops.GeoCrosses: "st_crosses",
-    ops.GeoDifference: "st_difference",
-    ops.GeoDisjoint: "st_disjoint",
-    ops.GeoDistance: "st_distance",
-    ops.GeoDWithin: "st_dwithin",
-    ops.GeoEndPoint: "st_endpoint",
-    ops.GeoEnvelope: "st_envelope",
-    ops.GeoEquals: "st_equals",
-    ops.GeoFlipCoordinates: "st_flipcoordinates",
-    ops.GeoGeometryType: "st_geometrytype",
-    ops.GeoIntersection: "st_intersection",
-    ops.GeoIntersects: "st_intersects",
-    ops.GeoIsValid: "st_isvalid",
-    ops.GeoLength: "st_length",
-    ops.GeoNPoints: "st_npoints",
-    ops.GeoOverlaps: "st_overlaps",
-    ops.GeoStartPoint: "st_startpoint",
-    ops.GeoTouches: "st_touches",
-    ops.GeoUnion: "st_union",
-    ops.GeoUnaryUnion: "st_union_agg",
-    ops.GeoWithin: "st_within",
-    ops.GeoX: "st_x",
-    ops.GeoY: "st_y",
-}
-
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(DuckDBCompiler, f"visit_{_op.__name__}", _fmt)
-
-
-del _op, _name, _fmt

--- a/ibis/backends/exasol/compiler.py
+++ b/ibis/backends/exasol/compiler.py
@@ -97,6 +97,13 @@ class ExasolCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.Log10: "log10",
+        ops.Modulus: "mod",
+        ops.All: "min",
+        ops.Any: "max",
+    }
+
     @staticmethod
     def _minimize_spec(start, end, spec):
         if (
@@ -165,25 +172,3 @@ class ExasolCompiler(SQLGlotCompiler):
 
     def visit_DateTruncate(self, op, *, arg, unit):
         return super().visit_TimestampTruncate(op, arg=arg, unit=unit)
-
-
-_SIMPLE_OPS = {
-    ops.Log10: "log10",
-    ops.Modulus: "mod",
-    ops.All: "min",
-    ops.Any: "max",
-}
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(ExasolCompiler, f"visit_{_op.__name__}", _fmt)

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -62,6 +62,30 @@ class ImpalaCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.All: "min",
+        ops.Any: "max",
+        ops.ApproxMedian: "appx_median",
+        ops.BaseConvert: "conv",
+        ops.BitwiseAnd: "bitand",
+        ops.BitwiseLeftShift: "shiftleft",
+        ops.BitwiseNot: "bitnot",
+        ops.BitwiseOr: "bitor",
+        ops.BitwiseRightShift: "shiftright",
+        ops.BitwiseXor: "bitxor",
+        ops.Cot: "cot",
+        ops.DayOfWeekName: "dayname",
+        ops.ExtractEpochSeconds: "unix_timestamp",
+        ops.Hash: "fnv_hash",
+        ops.LStrip: "ltrim",
+        ops.Ln: "ln",
+        ops.Log10: "log10",
+        ops.Log2: "log2",
+        ops.RStrip: "rtrim",
+        ops.Strip: "trim",
+        ops.TypeOf: "typeof",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         if where is not None:
             args = tuple(self.if_(where, arg, NULL) for arg in args)
@@ -329,44 +353,3 @@ class ImpalaCompiler(SQLGlotCompiler):
         if not dtype.is_float32():
             return self.cast(sign, dtype)
         return sign
-
-
-_SIMPLE_OPS = {
-    ops.All: "min",
-    ops.Any: "max",
-    ops.ApproxMedian: "appx_median",
-    ops.BaseConvert: "conv",
-    ops.BitwiseAnd: "bitand",
-    ops.BitwiseLeftShift: "shiftleft",
-    ops.BitwiseNot: "bitnot",
-    ops.BitwiseOr: "bitor",
-    ops.BitwiseRightShift: "shiftright",
-    ops.BitwiseXor: "bitxor",
-    ops.Cot: "cot",
-    ops.DayOfWeekName: "dayname",
-    ops.ExtractEpochSeconds: "unix_timestamp",
-    ops.Hash: "fnv_hash",
-    ops.LStrip: "ltrim",
-    ops.Ln: "ln",
-    ops.Log10: "log10",
-    ops.Log2: "log2",
-    ops.RStrip: "rtrim",
-    ops.Strip: "trim",
-    ops.TypeOf: "typeof",
-}
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(ImpalaCompiler, f"visit_{_op.__name__}", _fmt)
-
-del _op, _name, _fmt

--- a/ibis/backends/mssql/compiler.py
+++ b/ibis/backends/mssql/compiler.py
@@ -118,6 +118,22 @@ class MSSQLCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.Atan2: "atn2",
+        ops.DateFromYMD: "datefromparts",
+        ops.Hash: "checksum",
+        ops.Ln: "log",
+        ops.Log10: "log10",
+        ops.Power: "power",
+        ops.RandomScalar: "rand",
+        ops.Repeat: "replicate",
+        ops.Reverse: "reverse",
+        ops.StringAscii: "ascii",
+        ops.TimestampNow: "sysdatetime",
+        ops.Min: "min",
+        ops.Max: "max",
+    }
+
     @property
     def NAN(self):
         return self.f.double("NaN")
@@ -426,38 +442,3 @@ class MSSQLCompiler(SQLGlotCompiler):
     def visit_StringConcat(self, op, *, arg):
         any_args_null = (a.is_(NULL) for a in arg)
         return self.if_(sg.or_(*any_args_null), NULL, self.f.concat(*arg))
-
-
-_SIMPLE_OPS = {
-    ops.Atan2: "atn2",
-    ops.DateFromYMD: "datefromparts",
-    ops.Hash: "checksum",
-    ops.Ln: "log",
-    ops.Log10: "log10",
-    ops.Power: "power",
-    ops.RandomScalar: "rand",
-    ops.Repeat: "replicate",
-    ops.Reverse: "reverse",
-    ops.StringAscii: "ascii",
-    ops.TimestampNow: "sysdatetime",
-    ops.Min: "min",
-    ops.Max: "max",
-}
-
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(MSSQLCompiler, f"visit_{_op.__name__}", _fmt)
-
-
-del _op, _name, _fmt

--- a/ibis/backends/mysql/compiler.py
+++ b/ibis/backends/mysql/compiler.py
@@ -101,6 +101,21 @@ class MySQLCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.BitAnd: "bit_and",
+        ops.BitOr: "bit_or",
+        ops.BitXor: "bit_xor",
+        ops.DayOfWeekName: "dayname",
+        ops.Log10: "log10",
+        ops.StringContains: "instr",
+        ops.ExtractWeekOfYear: "weekofyear",
+        ops.ExtractEpochSeconds: "unix_timestamp",
+        ops.ExtractDayOfYear: "dayofyear",
+        ops.Strftime: "date_format",
+        ops.StringToTimestamp: "str_to_date",
+        ops.Log2: "log2",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         func = self.f[funcname]
         if where is not None:
@@ -338,37 +353,3 @@ class MySQLCompiler(SQLGlotCompiler):
                 this=right.this * 1_000, unit=sge.Var(this="MICROSECOND")
             )
         return self.f.date_add(left, right, dialect=self.dialect)
-
-
-_SIMPLE_OPS = {
-    ops.BitAnd: "bit_and",
-    ops.BitOr: "bit_or",
-    ops.BitXor: "bit_xor",
-    ops.DayOfWeekName: "dayname",
-    ops.Log10: "log10",
-    ops.StringContains: "instr",
-    ops.ExtractWeekOfYear: "weekofyear",
-    ops.ExtractEpochSeconds: "unix_timestamp",
-    ops.ExtractDayOfYear: "dayofyear",
-    ops.Strftime: "date_format",
-    ops.StringToTimestamp: "str_to_date",
-    ops.Log2: "log2",
-}
-
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(MySQLCompiler, f"visit_{_op.__name__}", _fmt)
-
-
-del _op, _name, _fmt

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -40,6 +40,64 @@ class PostgresCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.ArrayCollect: "array_agg",
+        ops.ArrayRemove: "array_remove",
+        ops.BitAnd: "bit_and",
+        ops.BitOr: "bit_or",
+        ops.BitXor: "bit_xor",
+        ops.GeoArea: "st_area",
+        ops.GeoAsBinary: "st_asbinary",
+        ops.GeoAsEWKB: "st_asewkb",
+        ops.GeoAsEWKT: "st_asewkt",
+        ops.GeoAsText: "st_astext",
+        ops.GeoAzimuth: "st_azimuth",
+        ops.GeoBuffer: "st_buffer",
+        ops.GeoCentroid: "st_centroid",
+        ops.GeoContains: "st_contains",
+        ops.GeoContainsProperly: "st_contains",
+        ops.GeoCoveredBy: "st_coveredby",
+        ops.GeoCovers: "st_covers",
+        ops.GeoCrosses: "st_crosses",
+        ops.GeoDFullyWithin: "st_dfullywithin",
+        ops.GeoDWithin: "st_dwithin",
+        ops.GeoDifference: "st_difference",
+        ops.GeoDisjoint: "st_disjoint",
+        ops.GeoDistance: "st_distance",
+        ops.GeoEndPoint: "st_endpoint",
+        ops.GeoEnvelope: "st_envelope",
+        ops.GeoEquals: "st_equals",
+        ops.GeoGeometryN: "st_geometryn",
+        ops.GeoGeometryType: "st_geometrytype",
+        ops.GeoIntersection: "st_intersection",
+        ops.GeoIntersects: "st_intersects",
+        ops.GeoIsValid: "st_isvalid",
+        ops.GeoLength: "st_length",
+        ops.GeoLineLocatePoint: "st_linelocatepoint",
+        ops.GeoLineMerge: "st_linemerge",
+        ops.GeoLineSubstring: "st_linesubstring",
+        ops.GeoNPoints: "st_npoints",
+        ops.GeoOrderingEquals: "st_orderingequals",
+        ops.GeoOverlaps: "st_overlaps",
+        ops.GeoPerimeter: "st_perimeter",
+        ops.GeoSRID: "st_srid",
+        ops.GeoSetSRID: "st_setsrid",
+        ops.GeoSimplify: "st_simplify",
+        ops.GeoStartPoint: "st_startpoint",
+        ops.GeoTouches: "st_touches",
+        ops.GeoTransform: "st_transform",
+        ops.GeoUnaryUnion: "st_union",
+        ops.GeoUnion: "st_union",
+        ops.GeoWithin: "st_within",
+        ops.GeoX: "st_x",
+        ops.GeoY: "st_y",
+        ops.MapContains: "exist",
+        ops.MapKeys: "akeys",
+        ops.MapValues: "avals",
+        ops.RegexSearch: "regexp_like",
+        ops.TimeFromHMS: "make_time",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         expr = self.f[funcname](*args)
         if where is not None:
@@ -469,80 +527,3 @@ class PostgresCompiler(SQLGlotCompiler):
         return self.cast(arg, op.to)
 
     visit_TryCast = visit_Cast
-
-
-_SIMPLE_OPS = {
-    ops.ArrayCollect: "array_agg",
-    ops.ArrayRemove: "array_remove",
-    ops.BitAnd: "bit_and",
-    ops.BitOr: "bit_or",
-    ops.BitXor: "bit_xor",
-    ops.GeoArea: "st_area",
-    ops.GeoAsBinary: "st_asbinary",
-    ops.GeoAsEWKB: "st_asewkb",
-    ops.GeoAsEWKT: "st_asewkt",
-    ops.GeoAsText: "st_astext",
-    ops.GeoAzimuth: "st_azimuth",
-    ops.GeoBuffer: "st_buffer",
-    ops.GeoCentroid: "st_centroid",
-    ops.GeoContains: "st_contains",
-    ops.GeoContainsProperly: "st_contains",
-    ops.GeoCoveredBy: "st_coveredby",
-    ops.GeoCovers: "st_covers",
-    ops.GeoCrosses: "st_crosses",
-    ops.GeoDFullyWithin: "st_dfullywithin",
-    ops.GeoDWithin: "st_dwithin",
-    ops.GeoDifference: "st_difference",
-    ops.GeoDisjoint: "st_disjoint",
-    ops.GeoDistance: "st_distance",
-    ops.GeoEndPoint: "st_endpoint",
-    ops.GeoEnvelope: "st_envelope",
-    ops.GeoEquals: "st_equals",
-    ops.GeoGeometryN: "st_geometryn",
-    ops.GeoGeometryType: "st_geometrytype",
-    ops.GeoIntersection: "st_intersection",
-    ops.GeoIntersects: "st_intersects",
-    ops.GeoIsValid: "st_isvalid",
-    ops.GeoLength: "st_length",
-    ops.GeoLineLocatePoint: "st_linelocatepoint",
-    ops.GeoLineMerge: "st_linemerge",
-    ops.GeoLineSubstring: "st_linesubstring",
-    ops.GeoNPoints: "st_npoints",
-    ops.GeoOrderingEquals: "st_orderingequals",
-    ops.GeoOverlaps: "st_overlaps",
-    ops.GeoPerimeter: "st_perimeter",
-    ops.GeoSRID: "st_srid",
-    ops.GeoSetSRID: "st_setsrid",
-    ops.GeoSimplify: "st_simplify",
-    ops.GeoStartPoint: "st_startpoint",
-    ops.GeoTouches: "st_touches",
-    ops.GeoTransform: "st_transform",
-    ops.GeoUnaryUnion: "st_union",
-    ops.GeoUnion: "st_union",
-    ops.GeoWithin: "st_within",
-    ops.GeoX: "st_x",
-    ops.GeoY: "st_y",
-    ops.MapContains: "exist",
-    ops.MapKeys: "akeys",
-    ops.MapValues: "avals",
-    ops.RegexSearch: "regexp_like",
-    ops.TimeFromHMS: "make_time",
-}
-
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(PostgresCompiler, f"visit_{_op.__name__}", _fmt)
-
-
-del _op, _name, _fmt

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -59,6 +59,25 @@ class PySparkCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.ArrayDistinct: "array_distinct",
+        ops.ArrayFlatten: "flatten",
+        ops.ArrayIntersect: "array_intersect",
+        ops.ArrayRemove: "array_remove",
+        ops.ArraySort: "array_sort",
+        ops.ArrayUnion: "array_union",
+        ops.EndsWith: "endswith",
+        ops.Hash: "hash",
+        ops.Log10: "log10",
+        ops.LStrip: "ltrim",
+        ops.RStrip: "rtrim",
+        ops.MapLength: "size",
+        ops.MapContains: "map_contains_key",
+        ops.MapMerge: "map_concat",
+        ops.MapKeys: "map_keys",
+        ops.MapValues: "map_values",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         func = self.f[funcname]
         if where is not None:
@@ -419,35 +438,3 @@ class PySparkCompiler(SQLGlotCompiler):
             return self.f.sha2(arg, int(how[-3:]))
         else:
             raise NotImplementedError(f"No available hashing function for {how}")
-
-
-_SIMPLE_OPS = {
-    ops.ArrayDistinct: "array_distinct",
-    ops.ArrayFlatten: "flatten",
-    ops.ArrayIntersect: "array_intersect",
-    ops.ArrayRemove: "array_remove",
-    ops.ArraySort: "array_sort",
-    ops.ArrayUnion: "array_union",
-    ops.EndsWith: "endswith",
-    ops.Hash: "hash",
-    ops.Log10: "log10",
-    ops.LStrip: "ltrim",
-    ops.RStrip: "rtrim",
-    ops.MapLength: "size",
-    ops.MapContains: "map_contains_key",
-    ops.MapMerge: "map_concat",
-    ops.MapKeys: "map_keys",
-    ops.MapValues: "map_values",
-}
-
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-
-    def _fmt(self, op, *, _name: str = _name, **kw):
-        return self.f[_name](*kw.values())
-
-    setattr(PySparkCompiler, f"visit_{_op.__name__}", _fmt)
-
-
-del _op, _name, _fmt

--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -59,6 +59,32 @@ class SnowflakeCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.Any: "max",
+        ops.All: "min",
+        ops.ArrayDistinct: "array_distinct",
+        ops.ArrayFlatten: "array_flatten",
+        ops.ArrayIndex: "get",
+        ops.ArrayIntersect: "array_intersection",
+        ops.ArrayRemove: "array_remove",
+        ops.BitAnd: "bitand_agg",
+        ops.BitOr: "bitor_agg",
+        ops.BitXor: "bitxor_agg",
+        ops.BitwiseAnd: "bitand",
+        ops.BitwiseLeftShift: "bitshiftleft",
+        ops.BitwiseNot: "bitnot",
+        ops.BitwiseOr: "bitor",
+        ops.BitwiseRightShift: "bitshiftright",
+        ops.BitwiseXor: "bitxor",
+        ops.EndsWith: "endswith",
+        ops.Hash: "hash",
+        ops.Median: "median",
+        ops.Mode: "mode",
+        ops.StringToTimestamp: "to_timestamp_tz",
+        ops.TimeFromHMS: "time_from_parts",
+        ops.TimestampFromYMDHMS: "timestamp_from_parts",
+    }
+
     def __init__(self):
         super().__init__()
         self.f = SnowflakeFuncGen()
@@ -532,47 +558,3 @@ class SnowflakeCompiler(SQLGlotCompiler):
             )
             .subquery()
         )
-
-
-_SIMPLE_OPS = {
-    ops.Any: "max",
-    ops.All: "min",
-    ops.ArrayDistinct: "array_distinct",
-    ops.ArrayFlatten: "array_flatten",
-    ops.ArrayIndex: "get",
-    ops.ArrayIntersect: "array_intersection",
-    ops.ArrayRemove: "array_remove",
-    ops.BitAnd: "bitand_agg",
-    ops.BitOr: "bitor_agg",
-    ops.BitXor: "bitxor_agg",
-    ops.BitwiseAnd: "bitand",
-    ops.BitwiseLeftShift: "bitshiftleft",
-    ops.BitwiseNot: "bitnot",
-    ops.BitwiseOr: "bitor",
-    ops.BitwiseRightShift: "bitshiftright",
-    ops.BitwiseXor: "bitxor",
-    ops.EndsWith: "endswith",
-    ops.Hash: "hash",
-    ops.Median: "median",
-    ops.Mode: "mode",
-    ops.StringToTimestamp: "to_timestamp_tz",
-    ops.TimeFromHMS: "time_from_parts",
-    ops.TimestampFromYMDHMS: "timestamp_from_parts",
-}
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(SnowflakeCompiler, f"visit_{_op.__name__}", _fmt)
-
-
-del _op, _name, _fmt

--- a/ibis/backends/sqlite/compiler.py
+++ b/ibis/backends/sqlite/compiler.py
@@ -76,6 +76,38 @@ class SQLiteCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.RegexReplace: "_ibis_regex_replace",
+        ops.RegexExtract: "_ibis_regex_extract",
+        ops.RegexSearch: "_ibis_regex_search",
+        ops.Translate: "_ibis_translate",
+        ops.Capitalize: "_ibis_capitalize",
+        ops.Reverse: "_ibis_reverse",
+        ops.RPad: "_ibis_rpad",
+        ops.LPad: "_ibis_lpad",
+        ops.Repeat: "_ibis_repeat",
+        ops.StringAscii: "_ibis_string_ascii",
+        ops.ExtractAuthority: "_ibis_extract_authority",
+        ops.ExtractFragment: "_ibis_extract_fragment",
+        ops.ExtractHost: "_ibis_extract_host",
+        ops.ExtractPath: "_ibis_extract_path",
+        ops.ExtractProtocol: "_ibis_extract_protocol",
+        ops.ExtractUserInfo: "_ibis_extract_user_info",
+        ops.BitwiseXor: "_ibis_xor",
+        ops.BitwiseNot: "_ibis_inv",
+        ops.Modulus: "mod",
+        ops.Log10: "log10",
+        ops.TypeOf: "typeof",
+        ops.BitOr: "_ibis_bit_or",
+        ops.BitAnd: "_ibis_bit_and",
+        ops.BitXor: "_ibis_bit_xor",
+        ops.First: "_ibis_arbitrary_first",
+        ops.Last: "_ibis_arbitrary_last",
+        ops.Mode: "_ibis_mode",
+        ops.Time: "time",
+        ops.Date: "date",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         expr = self.f[funcname](*args)
         if where is not None:
@@ -413,54 +445,3 @@ class SQLiteCompiler(SQLGlotCompiler):
         ):
             raise com.UnsupportedBackendType(f"Unsupported type: {dtype!r}")
         return super().visit_NonNullLiteral(op, value=value, dtype=dtype)
-
-
-_SIMPLE_OPS = {
-    ops.RegexReplace: "_ibis_regex_replace",
-    ops.RegexExtract: "_ibis_regex_extract",
-    ops.RegexSearch: "_ibis_regex_search",
-    ops.Translate: "_ibis_translate",
-    ops.Capitalize: "_ibis_capitalize",
-    ops.Reverse: "_ibis_reverse",
-    ops.RPad: "_ibis_rpad",
-    ops.LPad: "_ibis_lpad",
-    ops.Repeat: "_ibis_repeat",
-    ops.StringAscii: "_ibis_string_ascii",
-    ops.ExtractAuthority: "_ibis_extract_authority",
-    ops.ExtractFragment: "_ibis_extract_fragment",
-    ops.ExtractHost: "_ibis_extract_host",
-    ops.ExtractPath: "_ibis_extract_path",
-    ops.ExtractProtocol: "_ibis_extract_protocol",
-    ops.ExtractUserInfo: "_ibis_extract_user_info",
-    ops.BitwiseXor: "_ibis_xor",
-    ops.BitwiseNot: "_ibis_inv",
-    ops.Modulus: "mod",
-    ops.Log10: "log10",
-    ops.TypeOf: "typeof",
-    ops.BitOr: "_ibis_bit_or",
-    ops.BitAnd: "_ibis_bit_and",
-    ops.BitXor: "_ibis_bit_xor",
-    ops.First: "_ibis_arbitrary_first",
-    ops.Last: "_ibis_arbitrary_last",
-    ops.Mode: "_ibis_mode",
-    ops.Time: "time",
-    ops.Date: "date",
-}
-
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(SQLiteCompiler, f"visit_{_op.__name__}", _fmt)
-
-
-del _op, _name, _fmt

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -53,6 +53,44 @@ class TrinoCompiler(SQLGlotCompiler):
         )
     )
 
+    SIMPLE_OPS = {
+        ops.Pi: "pi",
+        ops.E: "e",
+        ops.RegexReplace: "regexp_replace",
+        ops.Map: "map",
+        ops.MapKeys: "map_keys",
+        ops.MapLength: "cardinality",
+        ops.MapMerge: "map_concat",
+        ops.MapValues: "map_values",
+        ops.Log2: "log2",
+        ops.Log10: "log10",
+        ops.IsNan: "is_nan",
+        ops.IsInf: "is_infinite",
+        ops.StringToTimestamp: "date_parse",
+        ops.Strftime: "date_format",
+        ops.ExtractEpochSeconds: "to_unixtime",
+        ops.ExtractWeekOfYear: "week_of_year",
+        ops.ExtractDayOfYear: "day_of_year",
+        ops.ExtractMillisecond: "millisecond",
+        ops.ArrayUnion: "array_union",
+        ops.ArrayRemove: "array_remove",
+        ops.ArrayFlatten: "flatten",
+        ops.ArraySort: "array_sort",
+        ops.ArrayDistinct: "array_distinct",
+        ops.ArrayLength: "cardinality",
+        ops.ArrayCollect: "array_agg",
+        ops.ArrayIntersect: "array_intersect",
+        ops.BitAnd: "bitwise_and_agg",
+        ops.BitOr: "bitwise_or_agg",
+        ops.TypeOf: "typeof",
+        ops.Levenshtein: "levenshtein_distance",
+        ops.ExtractProtocol: "url_extract_protocol",
+        ops.ExtractHost: "url_extract_host",
+        ops.ExtractPath: "url_extract_path",
+        ops.ExtractFragment: "url_extract_fragment",
+        ops.ArrayPosition: "array_position",
+    }
+
     def _aggregate(self, funcname: str, *args, where):
         expr = self.f[funcname](*args)
         if where is not None:
@@ -422,58 +460,3 @@ class TrinoCompiler(SQLGlotCompiler):
         # sqlglot doesn't support the third `group` argument for trino so work
         # around that limitation using an anonymous function
         return self.f.anon.regexp_extract(arg, pattern, index)
-
-
-_SIMPLE_OPS = {
-    ops.Pi: "pi",
-    ops.E: "e",
-    ops.RegexReplace: "regexp_replace",
-    ops.Map: "map",
-    ops.MapKeys: "map_keys",
-    ops.MapLength: "cardinality",
-    ops.MapMerge: "map_concat",
-    ops.MapValues: "map_values",
-    ops.Log2: "log2",
-    ops.Log10: "log10",
-    ops.IsNan: "is_nan",
-    ops.IsInf: "is_infinite",
-    ops.StringToTimestamp: "date_parse",
-    ops.Strftime: "date_format",
-    ops.ExtractEpochSeconds: "to_unixtime",
-    ops.ExtractWeekOfYear: "week_of_year",
-    ops.ExtractDayOfYear: "day_of_year",
-    ops.ExtractMillisecond: "millisecond",
-    ops.ArrayUnion: "array_union",
-    ops.ArrayRemove: "array_remove",
-    ops.ArrayFlatten: "flatten",
-    ops.ArraySort: "array_sort",
-    ops.ArrayDistinct: "array_distinct",
-    ops.ArrayLength: "cardinality",
-    ops.ArrayCollect: "array_agg",
-    ops.ArrayIntersect: "array_intersect",
-    ops.BitAnd: "bitwise_and_agg",
-    ops.BitOr: "bitwise_or_agg",
-    ops.TypeOf: "typeof",
-    ops.Levenshtein: "levenshtein_distance",
-    ops.ExtractProtocol: "url_extract_protocol",
-    ops.ExtractHost: "url_extract_host",
-    ops.ExtractPath: "url_extract_path",
-    ops.ExtractFragment: "url_extract_fragment",
-    ops.ArrayPosition: "array_position",
-}
-
-for _op, _name in _SIMPLE_OPS.items():
-    assert isinstance(type(_op), type), type(_op)
-    if issubclass(_op, ops.Reduction):
-
-        def _fmt(self, op, *, _name: str = _name, where, **kw):
-            return self.agg[_name](*kw.values(), where=where)
-
-    else:
-
-        def _fmt(self, op, *, _name: str = _name, **kw):
-            return self.f[_name](*kw.values())
-
-    setattr(TrinoCompiler, f"visit_{_op.__name__}", _fmt)
-
-del _op, _name, _fmt


### PR DESCRIPTION
Follow up to #8338 to clean up the SIMPLE_OPS boilerplate.