### PR TITLE
feat(api): add `.as_scalar()` method for turning expressions into scalar subqueries

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -602,7 +602,15 @@ class Expr(Immutable, Coercible):
 
     def as_table(self) -> ir.Table:
         """Convert an expression to a table."""
-        raise NotImplementedError(type(self))
+        raise NotImplementedError(
+            f"{type(self)} expressions cannot be converted into tables"
+        )
+
+    def as_scalar(self) -> ir.Scalar:
+        """Convert an expression to a scalar."""
+        raise NotImplementedError(
+            f"{type(self)} expression cannot be converted into scalars"
+        )
 
 
 def _binop(op_class: type[ops.Binary], left: ir.Value, right: ir.Value) -> ir.Value:

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -285,6 +285,40 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         return where.resolve(self)
 
+    def as_scalar(self) -> ir.ScalarExpr:
+        """Inform ibis that the table expression should be treated as a scalar.
+
+        Note that the table must have exactly one column and one row for this to
+        work. If the table has more than one column an error will be raised in
+        expression construction time. If the table has more than one row an
+        error will be raised by the backend when the expression is executed.
+
+        Returns
+        -------
+        Scalar
+            A scalar subquery
+
+        Examples
+        --------
+        >>> import ibis
+        >>>
+        >>> ibis.options.interactive = True
+        >>>
+        >>> t = ibis.examples.penguins.fetch()
+        >>> heavy_gentoo = t.filter(t.species == "Gentoo", t.body_mass_g > 6200)
+        >>> from_that_island = t.filter(t.island == heavy_gentoo.select("island").as_scalar())
+        >>> from_that_island.group_by("species").count()
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━┓
+        ┃ species ┃ CountStar() ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━┩
+        │ string  │ int64       │
+        ├─────────┼─────────────┤
+        │ Adelie  │          44 │
+        │ Gentoo  │         124 │
+        └─────────┴─────────────┘
+        """
+        return ops.ScalarSubquery(self).to_expr()
+
     def as_table(self) -> Table:
         """Promote the expression to a table.
 
@@ -1805,7 +1839,7 @@ class Table(Expr, _FixedTextJupyterMixin):
             node = ops.Intersection(node, table, distinct=distinct)
         return node.to_expr().select(self.columns)
 
-    @deprecated(as_of="9.0", instead="conversion to scalar subquery is implicit")
+    @deprecated(as_of="9.0", instead="use table.as_scalar() instead")
     def to_array(self) -> ir.Column:
         """View a single column table as an array.
 
@@ -1819,8 +1853,7 @@ class Table(Expr, _FixedTextJupyterMixin):
             raise com.ExpressionError(
                 "Table must have exactly one column when viewed as array"
             )
-
-        return ops.ScalarSubquery(self).to_expr()
+        return self.as_scalar()
 
     def mutate(self, *exprs: Sequence[ir.Expr] | None, **mutations: ir.Value) -> Table:
         """Add columns to a table expression.


### PR DESCRIPTION
Since there is no safe way to determine whether a table or a column contains a single cell we need to provide a way for the users to inform ibis that it should treat an expression as a scalar subquery. Previously it was the `.to_array()` method, but it only worked for table expressions. 

Note that when a scalar reduction is passed to certain API methods ibis is able to infer that the value should be turned into a scalar subquery and it implicitly does it. Using this method can be omitted in those cases. 
