### PR TITLE
docs: add missing dev docker instructions for backends

### DIFF
--- a/docs/contribute/02_workflow.qmd
+++ b/docs/contribute/02_workflow.qmd
@@ -45,9 +45,15 @@ These client-server backends need to be started before testing them.
 They can be started with `docker compose` directly, or using the `just` tool.
 
 - ClickHouse: `just up clickhouse`
-- PostgreSQL: `just up postgres`
+- Exasol: `just up exasol`
+- Flink: `just up flink`
+- Impala: `just up impala`
+- SQL Server: `just up mssql`
 - MySQL: `just up mysql`
-- impala: `just up impala`
+- Oracle: `just up oracle`
+- PostgreSQL: `just up postgres`
+- RisingWave: `just up risingwave`
+- Trino: `just up trino`
 
 ### Test the backend locally
 


### PR DESCRIPTION
We have some new backends and old ones that are not listed in the contribute section, I'm adding them. in this PR. 

I also noticed that we don't have instructions on how to tests Bigquery and Snowflake. My guess is that we have some limitations in terms of exposing resources for that? We might want to have a note about that. 
