### PR TITLE
fix(duckdb): allow connection to motherduck via ibis.connect

### DIFF
--- a/ibis/backends/base/__init__.py
+++ b/ibis/backends/base/__init__.py
@@ -1433,9 +1433,14 @@ class UrlFromPath:
         url = urlparse(url)
         netloc = url.netloc
         parts = list(filter(None, (netloc, url.path[bool(netloc) :])))
-        database = (
-            Path(*parts).absolute() if parts and parts != [":memory:"] else ":memory:"
-        )
+        database = Path(*parts) if parts and parts != [":memory:"] else ":memory:"
+        if (strdatabase := str(database)).startswith("md:") or strdatabase.startswith(
+            "motherduck:"
+        ):
+            database = strdatabase
+        elif isinstance(database, Path):
+            database = database.absolute()
+
         query_params = parse_qs(url.query)
 
         for name, value in query_params.items():


### PR DESCRIPTION
## Description of changes

Our `_from_url` was a little aggressive in calling `Path().absolute()`
on targets. Since we already handle that in `duckdb.do_connect` we can
use `urlparse` to rip out the appropriate bits and forward them.


## Issues closed

Fixes #8355
