### PR TITLE
fix(ir): compute `InSubquery.shape` property from `needle` input

### DIFF
--- a/ibis/expr/operations/subqueries.py
+++ b/ibis/expr/operations/subqueries.py
@@ -53,7 +53,7 @@ class InSubquery(Subquery):
     needle: Value
 
     dtype = dt.boolean
-    shape = ds.columnar
+    shape = rlz.shape_like("needle")
 
     def __init__(self, rel, needle):
         if len(rel.schema) != 1:

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -1713,3 +1713,13 @@ def test_deferred_doesnt_convert_callables():
         b=t.b.split(",").filter(lambda pp: ~pp.isin(("word1", "word2")))
     )
     assert expr.equals(expected)
+
+
+def test_in_subquery_shape():
+    t = ibis.table([("a", "int64"), ("b", "string")])
+
+    expr = t.a.cast("string").isin(t.b)
+    assert expr.op().shape.is_columnar()
+
+    expr = ibis.literal(2).isin(t.a)
+    assert expr.op().shape.is_scalar()


### PR DESCRIPTION
Fixes #8361.