### PR TITLE
fix(comparison): wrap isnull equality check in parens

### DIFF
--- a/ibis/backends/base/sqlglot/compiler.py
+++ b/ibis/backends/base/sqlglot/compiler.py
@@ -320,6 +320,8 @@ class SQLGlotCompiler(abc.ABC):
         ops.IntervalSubtract,
     )
 
+    NEEDS_PARENS = BINARY_INFIX_OPS + (ops.IsNull,)
+
     def __init__(self) -> None:
         self.agg = AggGen(aggfunc=self._aggregate)
         self.f = FuncGen()
@@ -1191,7 +1193,7 @@ class SQLGlotCompiler(abc.ABC):
 
     @classmethod
     def _add_parens(cls, op, sg_expr):
-        if isinstance(op, cls.BINARY_INFIX_OPS):
+        if isinstance(op, cls.NEEDS_PARENS):
             return paren(sg_expr)
         return sg_expr
 

--- a/ibis/backends/impala/tests/snapshots/test_sql/test_is_parens/isnull/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_is_parens/isnull/out.sql
@@ -3,4 +3,8 @@ SELECT
   `t0`.`b`
 FROM `table` AS `t0`
 WHERE
-  `t0`.`a` IS NULL = `t0`.`b` IS NULL
+  (
+    `t0`.`a` IS NULL
+  ) = (
+    `t0`.`b` IS NULL
+  )


### PR DESCRIPTION
## Description of changes

We wrap arguments to a `sge.Equals` in parens if the inputs are
themselves binary operations.  There are other operations we will have
to wrap -- for now I'm just adding `isNull` to the list, but I imagine
this will grow, possibly on a backend-by-backend basis.

I'm going to investigate the mssql and oracle failures but they are
unrelated to this PR (they fail the added test with or without the parentheses)

<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->


<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed

* Resolves #8346
<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
