### PR TITLE
feat(duckdb): allow all-null columns in memtables

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1419,16 +1419,9 @@ class Backend(SQLGlotBackend, CanCreateSchema, UrlFromPath):
             self._register_in_memory_table(memtable)
 
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
-        schema = op.schema
-        if null_columns := [col for col, dtype in schema.items() if dtype.is_null()]:
-            raise exc.IbisTypeError(
-                "DuckDB cannot yet reliably handle `null` typed columns; "
-                f"got null typed columns: {null_columns}"
-            )
-
         # only register if we haven't already done so
         if (name := op.name) not in self.list_tables():
-            self.con.register(name, op.data.to_pyarrow(schema))
+            self.con.register(name, op.data.to_pyarrow(op.schema))
 
     def _register_udfs(self, expr: ir.Expr) -> None:
         import ibis.expr.operations as ops

--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -5,7 +5,6 @@ import pytest
 from pytest import param
 
 import ibis
-import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
 from ibis.backends.base.sqlglot.datatypes import DuckDBType
 
@@ -76,11 +75,8 @@ def test_null_dtype():
     t = ibis.memtable({"a": [None, None]})
     assert t.schema() == ibis.schema(dict(a="null"))
 
-    with pytest.raises(
-        exc.IbisTypeError,
-        match="DuckDB cannot yet reliably handle `null` typed columns",
-    ):
-        con.execute(t)
+    df = con.execute(t)
+    assert df.a.tolist() == [None, None]
 
 
 def test_parse_quoted_struct_field():


### PR DESCRIPTION
Turns out we are artificially restricting the input of all-null columns in memtables. This works out of the box by simply deleting the check that raises an exception.