### PR TITLE
fix(duckdb-sql): ignore importlib package errors when importing ibis.snowflake for transpilation

### DIFF
--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -190,8 +190,6 @@ def test_insert(con):
 
 
 def test_to_other_sql(con, snapshot):
-    pytest.importorskip("snowflake.connector")
-
     t = con.table("functional_alltypes")
 
     sql = ibis.to_sql(t, dialect="snowflake")

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -38,19 +38,6 @@ from ibis.backends.base.sqlglot.datatypes import SnowflakeType
 from ibis.backends.snowflake.compiler import SnowflakeCompiler
 from ibis.backends.snowflake.converter import SnowflakePandasData
 
-with warnings.catch_warnings(), contextlib.suppress(
-    importlib.metadata.PackageNotFoundError
-):
-    if vparse(importlib.metadata.version("snowflake-connector-python")) >= vparse(
-        "3.3.0"
-    ):
-        warnings.filterwarnings(
-            "ignore",
-            message="You have an incompatible version of 'pyarrow' installed",
-            category=UserWarning,
-        )
-        import snowflake.connector as sc
-
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping
 
@@ -224,6 +211,17 @@ $$ {defn["source"]} $$"""
             Additional arguments passed to the URL constructor.
 
         """
+        with warnings.catch_warnings():
+            if vparse(
+                importlib.metadata.version("snowflake-connector-python")
+            ) >= vparse("3.3.0"):
+                warnings.filterwarnings(
+                    "ignore",
+                    message="You have an incompatible version of 'pyarrow' installed",
+                    category=UserWarning,
+                )
+                import snowflake.connector as sc
+
         connect_args = kwargs.copy()
         session_parameters = connect_args.pop("session_parameters", {})
 

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -38,7 +38,9 @@ from ibis.backends.base.sqlglot.datatypes import SnowflakeType
 from ibis.backends.snowflake.compiler import SnowflakeCompiler
 from ibis.backends.snowflake.converter import SnowflakePandasData
 
-with warnings.catch_warnings():
+with warnings.catch_warnings(), contextlib.suppress(
+    importlib.metadata.PackageNotFoundError
+):
     if vparse(importlib.metadata.version("snowflake-connector-python")) >= vparse(
         "3.3.0"
     ):


### PR DESCRIPTION
Fixes an issue where we try to pluck package metadata for a non-existent package (`snowflake-connector-python`) when transpiling from one dialect to another; in this case duckdb sql to snowflake sql.