### PR TITLE
fix(pyspark): ensure to_delta works and is tested in ci

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -549,18 +549,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: pyspark-3.3
-            python-version: "3.9"
-            pyspark-version: 3.3
+          - python-version: "3.9"
+            pyspark-version: "3.3"
             deps:
-              - "pyspark@3.3"
               - "'pandas@<2'"
               - "'numpy@<1.24'"
-          - name: pyspark-3.5
-            python-version: "3.11"
-            pyspark-version: 3.5
+          - python-version: "3.11"
+            pyspark-version: "3.5"
             deps:
-              - "pyspark@3.5"
               - "'pandas@>2'"
               - "'numpy@>1.24'"
     steps:
@@ -593,7 +589,7 @@ jobs:
         run: poetry remove lonboard
 
       - name: install exact versions of pyspark, pandas and numpy
-        run: poetry add --lock ${{ join(matrix.deps, ' ') }}
+        run: poetry add --lock 'pyspark@${{ matrix.pyspark-version }}' ${{ join(matrix.deps, ' ') }}
 
       - name: checkout the lock file
         run: git checkout poetry.lock
@@ -607,6 +603,10 @@ jobs:
       - name: install ibis
         run: poetry install --without dev --without docs --extras pyspark
 
+      - name: install delta-spark
+        if: matrix.pyspark-version == '3.5'
+        run: poetry run pip install delta-spark
+
       - name: run tests
         run: just ci-check -m pyspark
 
@@ -616,7 +616,7 @@ jobs:
 
       - name: upload code coverage
         # only upload coverage for jobs that aren't mostly xfails
-        if: success() && matrix.python-version != '3.11'
+        if: success()
         continue-on-error: true
         uses: codecov/codecov-action@v4
         with:

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -11,7 +11,7 @@ import pytest
 from pytest import param
 
 import ibis
-from ibis.backends.conftest import TEST_TABLES, is_older_than
+from ibis.backends.conftest import TEST_TABLES
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -50,9 +50,7 @@ def gzip_csv(data_dir, tmp_path):
             "Diamonds2",
             id="csv_name",
             marks=pytest.mark.notyet(
-                ["pyspark"],
-                reason="pyspark lowercases view names",
-                condition=is_older_than("pyspark", "3.5.0"),
+                ["pyspark"], reason="pyspark lowercases view names"
             ),
         ),
         param(


### PR DESCRIPTION
Fixes an issue where we were not testing `to_delta` for pyspark in CI and breakage to its `to_delta` method after the-epic-split crept in due to the return type of `compile()` being a `str` now instead of pyspark DataFrame.