### PR TITLE
fix(duckdb): `to_pyarrow_batches` can result in broken RecordBatchReader

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -274,6 +274,14 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         return data_mapper.convert_table(table, self.schema())
 
+    def __pyarrow_batch_result__(
+        self, reader: pa.RecordBatchReader, data_mapper: type[PyArrowData] | None = None
+    ) -> pa.RecordBatchReader:
+        if data_mapper is None:
+            from ibis.formats.pyarrow import PyArrowData as data_mapper
+
+        return data_mapper.convert_record_batch_reader(reader, self.schema())
+
     def __pandas_result__(self, df: pd.DataFrame) -> pd.DataFrame:
         from ibis.formats.pandas import PandasData
 


### PR DESCRIPTION
## Description of changes

Fixes an issues with `to_pyarrow_batches` for DuckDB where long column names could cause a mismatch in
the schema of a RecordBatchReader and the
RecordBatches which is contained.

## Issues closed

* Resolves #8393

