### PR TITLE
feat(mssql): add datatype mapping for `hierarchyid`

### DIFF
--- a/ibis/backends/base/sqlglot/datatypes.py
+++ b/ibis/backends/base/sqlglot/datatypes.py
@@ -894,6 +894,8 @@ class ExasolType(SqlglotType):
 class MSSQLType(SqlglotType):
     dialect = "mssql"
 
+    unknown_type_strings = FrozenDict({"hierarchyid": dt.string})
+
     @classmethod
     def _from_sqlglot_BIT(cls):
         return dt.Boolean(nullable=cls.default_nullable)

--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -52,6 +52,7 @@ DB_TYPES = [
     ("DATETIMEOFFSET(5)", dt.timestamp(scale=5, timezone="UTC")),
     ("GEOMETRY", dt.geometry),
     ("GEOGRAPHY", dt.geography),
+    ("HIERARCHYID", dt.string),
 ]
 
 


### PR DESCRIPTION
## Description of changes

See https://learn.microsoft.com/en-us/sql/relational-databases/hierarchical-data-sql-server?view=sql-server-ver16
for reference.

We represent this as a string column internally in Ibis (this seems to
be the recommended thing to do by MSSQL itself).


## Issues closed

Resolves #8381