### PR TITLE
refactor(udfs): consolidate builtin udf compilation and failure modes for unimplemented udfs

### DIFF
--- a/ibis/backends/base/sqlglot/__init__.py
+++ b/ibis/backends/base/sqlglot/__init__.py
@@ -390,3 +390,21 @@ class SQLGlotBackend(BaseBackend):
         # This is part of the Python DB-API specification so should work for
         # _most_ sqlglot backends
         self.con.close()
+
+    def _compile_builtin_udf(self, udf_node: ops.ScalarUDF | ops.AggUDF) -> None:
+        """Compile a built-in UDF. No-op by default."""
+
+    def _compile_python_udf(self, udf_node: ops.ScalarUDF) -> None:
+        raise NotImplementedError(
+            f"Python UDFs are not supported in the {self.name} backend"
+        )
+
+    def _compile_pyarrow_udf(self, udf_node: ops.ScalarUDF) -> None:
+        raise NotImplementedError(
+            f"PyArrow UDFs are not supported in the {self.name} backend"
+        )
+
+    def _compile_pandas_udf(self, udf_node: ops.ScalarUDF) -> str:
+        raise NotImplementedError(
+            f"pandas UDFs are not supported in the {self.name} backend"
+        )

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -1195,17 +1195,8 @@ class Backend(SQLGlotBackend, CanCreateSchema):
 
         return func
 
-    def _compile_builtin_udf(self, udf_node: ops.ScalarUDF) -> None:
-        """No op."""
-
     def _compile_python_udf(self, udf_node: ops.ScalarUDF) -> None:
         return self._get_udf_source(udf_node)
-
-    def _compile_pyarrow_udf(self, udf_node: ops.ScalarUDF) -> None:
-        raise NotImplementedError("PyArrow UDFs are not supported in BigQuery")
-
-    def _compile_pandas_udf(self, udf_node: ops.ScalarUDF) -> str:
-        raise NotImplementedError("Pandas UDFs are not supported in BigQuery")
 
     def _register_udfs(self, expr: ir.Expr) -> None:
         """No op because UDFs made with CREATE TEMPORARY FUNCTION must be followed by a query."""

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1463,12 +1463,6 @@ class Backend(SQLGlotBackend, CanCreateSchema, UrlFromPath):
     _compile_python_udf = _compile_udf
     _compile_pyarrow_udf = _compile_udf
 
-    def _compile_builtin_udf(self, udf_node: ops.ScalarUDF) -> None:
-        """No op."""
-
-    def _compile_pandas_udf(self, _: ops.ScalarUDF) -> None:
-        raise NotImplementedError("duckdb doesn't support pandas UDFs")
-
     def _get_temp_view_definition(self, name: str, definition: str) -> str:
         return sge.Create(
             this=sg.to_identifier(name, quoted=self.compiler.quoted),

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -434,15 +434,6 @@ class Backend(SQLGlotBackend):
             args=", ".join(argnames),
         )
 
-    def _compile_builtin_udf(self, udf_node: ops.ScalarUDF) -> None:
-        """No op."""
-
-    def _compile_pyarrow_udf(self, udf_node: ops.ScalarUDF) -> None:
-        raise NotImplementedError(f"pyarrow UDFs are not supported in {self.name}")
-
-    def _compile_pandas_udf(self, udf_node: ops.ScalarUDF) -> str:
-        raise NotImplementedError(f"pandas UDFs are not supported in {self.name}")
-
     def _define_udf_translation_rules(self, expr: ir.Expr) -> None:
         """No-op, these are defined in the compiler."""
 

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -344,12 +344,6 @@ $$ {defn["source"]} $$"""
             with self._safe_raw_sql(";\n".join(udf_sources)):
                 pass
 
-    def _compile_builtin_udf(self, udf_node: ops.ScalarUDF) -> None:
-        """No op."""
-
-    def _compile_pyarrow_udf(self, udf_node: ops.ScalarUDF) -> None:
-        raise NotImplementedError("pyarrow UDFs are not supported in Snowflake")
-
     def _compile_python_udf(self, udf_node: ops.ScalarUDF) -> str:
         return """\
 {preamble}

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import sqlite3
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -318,9 +318,6 @@ class Backend(SQLGlotBackend, UrlFromPath):
             if registration_func is not None:
                 registration_func(con)
 
-    def _compile_builtin_udf(self, udf_node: ops.ScalarUDF) -> None:
-        pass
-
     def _compile_python_udf(self, udf_node: ops.ScalarUDF) -> None:
         name = type(udf_node).__name__
         nargs = len(udf_node.__signature__.parameters)
@@ -347,12 +344,6 @@ class Backend(SQLGlotBackend, UrlFromPath):
             return con.create_function(name, nargs, ignore_nulls(func))
 
         return register_udf
-
-    def _compile_pyarrow_udf(self, udf_node: ops.ScalarUDF) -> NoReturn:
-        raise NotImplementedError("pyarrow UDFs are not supported in SQLite")
-
-    def _compile_pandas_udf(self, udf_node: ops.ScalarUDF) -> NoReturn:
-        raise NotImplementedError("pandas UDFs are not supported in SQLite")
 
     def attach(self, name: str, path: str | Path) -> None:
         """Connect another SQLite database file to the current connection.


### PR DESCRIPTION
Removes dupcliated udf registration and default failure mode logic for sql backends.