### PR TITLE
fix(mssql): restore unbounded window functions

### DIFF
--- a/ibis/backends/mssql/compiler.py
+++ b/ibis/backends/mssql/compiler.py
@@ -22,6 +22,8 @@ from ibis.backends.base.sqlglot.dialects import MSSQL
 from ibis.backends.base.sqlglot.rewrites import (
     exclude_unsupported_window_frame_from_ops,
     exclude_unsupported_window_frame_from_row_number,
+    p,
+    replace,
     rewrite_first_to_first_value,
     rewrite_last_to_last_value,
     rewrite_sample_as_filter,
@@ -46,6 +48,16 @@ end = var("end")
 # * Boolean expressions MUST be used in a WHERE clause, i.e., SELECT * FROM t WHERE 1 is not allowed
 
 
+@replace(
+    p.WindowFunction(
+        p.Reduction & ~p.ReductionVectorizedUDF, frame=y @ p.WindowFrame(order_by=())
+    )
+)
+def rewrite_rows_range_order_by_window(_, y, **kwargs):
+    # MSSQL requires an order by in a window frame that has either ROWS or RANGE
+    return _.copy(frame=y.copy(order_by=(_.func.arg,)))
+
+
 @public
 class MSSQLCompiler(SQLGlotCompiler):
     __slots__ = ()
@@ -58,6 +70,7 @@ class MSSQLCompiler(SQLGlotCompiler):
         rewrite_last_to_last_value,
         exclude_unsupported_window_frame_from_ops,
         exclude_unsupported_window_frame_from_row_number,
+        rewrite_rows_range_order_by_window,
         *SQLGlotCompiler.rewrites,
     )
 

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -1342,11 +1342,6 @@ def test_clip(backend, alltypes, df, ibis_func, pandas_func):
     backend.assert_series_equal(result, expected, check_names=False)
 
 
-@pytest.mark.broken(
-    ["mssql"],
-    raises=PyODBCProgrammingError,
-    reason="unbounded window frames are not supported",
-)
 @pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.broken(
     ["druid"],

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -544,17 +544,7 @@ def test_grouped_bounded_preceding_window(backend, alltypes, df, window_fn):
 @pytest.mark.parametrize(
     ("ordered"),
     [
-        param(
-            False,
-            id="unordered",
-            marks=[
-                pytest.mark.broken(
-                    ["mssql"],
-                    raises=PyODBCProgrammingError,
-                    reason="unbounded window frames are not supported",
-                ),
-            ],
-        ),
+        param(False, id="unordered"),
     ],
 )
 @pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
@@ -667,13 +657,6 @@ def test_simple_ungrouped_window_with_scalar_order_by(alltypes):
             lambda df: pd.Series([df.double_col.mean()] * len(df.double_col)),
             False,
             id="unordered-mean",
-            marks=[
-                pytest.mark.broken(
-                    ["mssql"],
-                    raises=PyODBCProgrammingError,
-                    reason="unbounded window frames are not supported",
-                ),
-            ],
         ),
         param(
             lambda _, win: ibis.ntile(7).over(win),


### PR DESCRIPTION
## Description of changes

MSSQL requires an order-by clause in unbounded windows.  This is clearly
documented in
https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors-10000-to-10999
(just kidding, it's a huge list of error codes you have to scroll through.  You
want Error 10756)

The behavior of the mssql sqlalchemy connector is to order by the field used in
the window function.  This seems silly, and potentially slightly
computationally wasteful, but not incorrect.

So, I've added a rewrite rule to the MSSQL compiler that copies this behavior
for all reduction functions that aren't UDFs, since those aren't supported
anyway (and would require a different rewrite rule, in any case).


## Issues closed

* Resolves #8072
