### PR TITLE
feat(flink): temporal join support

### DIFF
--- a/ibis/backends/flink/compiler.py
+++ b/ibis/backends/flink/compiler.py
@@ -566,3 +566,13 @@ class FlinkCompiler(SQLGlotCompiler):
         values = self.f.array_concat(left_values, right_values)
 
         return self.cast(self.f.map_from_arrays(keys, values), op.dtype)
+
+    def visit_TemporalJoinLink(self, op, *, how, table, at_time, predicates):
+        if how not in ("left", "inner"):
+            raise com.UnsupportedOperationError(
+                f"Flink temporal does not support {how} join, but only left and inner join"
+            )
+
+        return super().visit_TemporalJoinLink(
+            op=op, how=how, table=table, at_time=at_time, predicates=predicates
+        )

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -609,7 +609,7 @@ def test_temporal_join(con, table_left_and_right_and_source_df):
     table_left, table_right, source_df = table_left_and_right_and_source_df
 
     table_right = table_right.at_time(table_left.timestamp_col)
-    join_expr = table_left.temporal_join(
+    join_expr = table_left.join(
         table_right,
         predicates=[
             table_left["id"] == table_right["id"],
@@ -630,7 +630,7 @@ def test_temporal_join(con, table_left_and_right_and_source_df):
   `t3`.`int_col` AS `int_col_right`,
   `t3`.`timestamp_col` AS `timestamp_col_right`
 FROM `table_left` AS `t1`
-JOIN `table_right` FOR SYSTEM_TIME AS OF `t1`.`timestamp_col` AS `t3`
+INNER JOIN `table_right` FOR SYSTEM_TIME AS OF `t1`.`timestamp_col` AS `t3`
   ON `t1`.`id` = `t3`.`id`"""
     assert sql == expected_sql
 

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -591,7 +591,6 @@ def compare_temporal_joined_and_expected_dfs(
     joined_df = join_expr.to_pandas().sort_values("id")
     joined_df = joined_df.reindex(sorted(joined_df.columns), axis=1)
     joined_df = joined_df.drop("timestamp_col_right", axis=1)
-    # print(f"joined_df= \n{joined_df.to_string(index=False)}")
 
     expected_df = pd.merge_asof(
         source_df,
@@ -600,7 +599,6 @@ def compare_temporal_joined_and_expected_dfs(
         by="id",
     ).sort_values("id")
     expected_df = expected_df.reindex(sorted(expected_df.columns), axis=1)
-    # print(f"expected_df= \n{expected_df.to_string(index=False)}")
 
     assert (joined_df.values == expected_df.values).all()
 
@@ -617,7 +615,6 @@ def test_temporal_join(con, table_left_and_right_and_source_df):
     )
 
     sql = con.compile(join_expr)
-    print(f"sql= \n{sql}")
 
     expected_sql = """SELECT
   `t1`.`id`,

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -17,7 +17,6 @@ import ibis.expr.schema as sch
 from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.errors import Py4JJavaError
 
-
 if TYPE_CHECKING:
     import ibis.expr.types as ir
 
@@ -606,40 +605,7 @@ def compare_temporal_joined_and_expected_dfs(
     assert (joined_df.values == expected_df.values).all()
 
 
-def test_temporal_join_w_at_time(con, table_left_and_right_and_source_df):
-    table_left, table_right, source_df = table_left_and_right_and_source_df
-
-    join_expr = table_left.temporal_join(
-        table_right,
-        at_time=table_left.timestamp_col,
-        predicates=[
-            table_left["id"] == table_right["id"],
-        ],
-    )
-    # join_expr.visualize()
-
-    sql = con.compile(join_expr)
-    # print(f"sql= \n{sql}")
-
-    expected_sql = """SELECT
-  `t2`.`id`,
-  `t2`.`bool_col`,
-  `t2`.`smallint_col`,
-  `t2`.`int_col`,
-  `t2`.`timestamp_col`,
-  `t3`.`bool_col` AS `bool_col_right`,
-  `t3`.`smallint_col` AS `smallint_col_right`,
-  `t3`.`int_col` AS `int_col_right`,
-  `t3`.`timestamp_col` AS `timestamp_col_right`
-FROM `table_left` AS `t2`
-JOIN `table_right` FOR SYSTEM_TIME AS OF `t2`.`timestamp_col` AS `t3`
-  ON `t2`.`id` = `t3`.`id`"""
-    assert sql == expected_sql
-
-    compare_temporal_joined_and_expected_dfs(join_expr=join_expr, source_df=source_df)
-
-
-def test_temporal_join_w_right_at_time(con, table_left_and_right_and_source_df):
+def test_temporal_join(con, table_left_and_right_and_source_df):
     table_left, table_right, source_df = table_left_and_right_and_source_df
 
     table_right = table_right.at_time(table_left.timestamp_col)
@@ -651,7 +617,7 @@ def test_temporal_join_w_right_at_time(con, table_left_and_right_and_source_df):
     )
 
     sql = con.compile(join_expr)
-    # print(f"sql= \n{sql}")
+    print(f"sql= \n{sql}")
 
     expected_sql = """SELECT
   `t1`.`id`,

--- a/ibis/backends/sql/compiler.py
+++ b/ibis/backends/sql/compiler.py
@@ -1151,7 +1151,7 @@ class SQLGlotCompiler(abc.ABC):
 
     def visit_TemporalJoinLink(self, op, *, how, table, at_time, predicates):
         on = sg.and_(*predicates) if predicates else None
-        return TemporalJoin(this=table, at_time=at_time, on=on)
+        return TemporalJoin(this=table, kind=how, at_time=at_time, on=on)
 
     def visit_SelfReference(self, op, *, parent, identifier):
         return parent

--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -167,8 +167,8 @@ class Flink(Hive):
 
             this_alias_sql = self.sql(expr.this, "alias")
             expr.this.args["alias"] = None
-            this_sql_wo_alias = self.sql(expr.this)
-            op_sql = f"JOIN {this_sql_wo_alias}"
+            this_sql_wo_alias = self.sql(expr, "this")
+            op_sql = f"{expr.kind} JOIN {this_sql_wo_alias}"
             at_time_sql = self.sql(expr.at_time)
             return f"{self.seg(op_sql)} FOR SYSTEM_TIME AS OF {at_time_sql} AS {this_alias_sql}{on_sql}"
 

--- a/ibis/backends/sql/expressions.py
+++ b/ibis/backends/sql/expressions.py
@@ -10,7 +10,7 @@ class TemporalJoin(sge.Join):
         "this": True,
         "on": False,
         "side": False,
-        "kind": False,
+        "kind": True,
         "using": False,
         "method": False,
         "global": False,

--- a/ibis/backends/sql/expressions.py
+++ b/ibis/backends/sql/expressions.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+import sqlglot.expressions as sge
+
+
+class TemporalJoin(sge.Join):
+    arg_types = {
+        "this": True,
+        "on": False,
+        "side": False,
+        "kind": False,
+        "using": False,
+        "method": False,
+        "global": False,
+        "hint": False,
+        "at_time": True,  # Added only this, rest copied from sge.Join.
+    }
+
+    @property
+    def at_time(self) -> Any:
+        """Retrieves the argument with key "at_time"."""
+
+        return self.args.get("at_time")

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -161,6 +161,7 @@ JoinKind = Literal[
     "any_inner",
     "any_left",
     "cross",
+    "temporal",
 ]
 
 
@@ -174,6 +175,15 @@ class JoinLink(Node):
     how: JoinKind
     table: JoinTable
     predicates: VarTuple[Value[dt.Boolean]]
+
+
+# TODO: `TemporalJoinLink` extends `JoinLink` to avoid the validation
+# error, but `how` is unnecessary for `TemporalJoinLink`.
+# Perhaps, make this extend `Expression` and include `TemporalJoinLink` in
+# the validation logic.
+@public
+class TemporalJoinLink(JoinLink):
+    at_time: Column
 
 
 @public
@@ -328,6 +338,13 @@ class DatabaseTable(PhysicalTable):
     schema: Schema
     source: Any
     namespace: Namespace = Namespace()
+
+
+@public
+class VersionedDatabaseTable(DatabaseTable):
+    """Table that is versioned with snapshots by the backend."""
+
+    at_time: Optional[Column] = None
 
 
 @public

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -177,10 +177,6 @@ class JoinLink(Node):
     predicates: VarTuple[Value[dt.Boolean]]
 
 
-# TODO: `TemporalJoinLink` extends `JoinLink` to avoid the validation
-# error, but `how` is unnecessary for `TemporalJoinLink`.
-# Perhaps, make this extend `Expression` and include `TemporalJoinLink` in
-# the validation logic.
 @public
 class TemporalJoinLink(JoinLink):
     at_time: Column

--- a/ibis/expr/types/joins.py
+++ b/ibis/expr/types/joins.py
@@ -415,19 +415,18 @@ class Join(Table):
         right: Table,
         predicates=(),
         *,
-        at_time: Column = None,
         lname: str = "",
         rname: str = "{name}_right",
     ):
         if not isinstance(right.op(), ops.VersionedDatabaseTable):
             raise IbisError(
-                "Right-table is not versioned. "
-                "Temporal join is defined only when the right-table is versioned."
+                "Table `right` is not versioned. "
+                "Temporal join is defined only when right-table is versioned."
             )
-        elif at_time is None and right.at_time is None:
-            raise IbisInputError("Either `at_time` or `right.at_time` must be defined.")
+        elif right.at_time is None:
+            raise IbisInputError("`at_time` must be defined for `right` table.")
 
-        at_time_op = right.op().at_time if at_time is None else at_time.op()
+        at_time_op = right.op().at_time
         left = self.op()
         # Check if `at_time` is based on a left-table.
         # TODO (mehmet): Check with the reviewers the applicability of this check

--- a/ibis/expr/types/joins.py
+++ b/ibis/expr/types/joins.py
@@ -12,14 +12,13 @@ from ibis.common.deferred import Deferred
 from ibis.common.egraph import DisjointSet
 from ibis.common.exceptions import (
     ExpressionError,
-    IbisError,
     IbisInputError,
     InputTypeError,
     IntegrityError,
 )
 from ibis.expr.analysis import flatten_predicates
 from ibis.expr.rewrites import peel_join_field
-from ibis.expr.types.generic import Column, Value
+from ibis.expr.types.generic import Value
 from ibis.expr.types.relations import (
     Table,
     bind,

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -3069,41 +3069,46 @@ class Table(Expr, _FixedTextJupyterMixin):
         │  106782 │ drugs             │          1732 │ drugs             │
         │  106782 │ Leonardo DiCaprio │          5989 │ Leonardo DiCaprio │
         └─────────┴───────────────────┴───────────────┴───────────────────┘
-
-        Examples for temporal join
-        --------
-        # Create left- and right-table. Right-table should be a versioned table.
-        >>> table_left = con.create_table(...)
-        >>> table_right = con.create_table(...)
-
-        # Set the time-attribute that will determine the version of the rows to be
-        # joined against in `table_right` at runtime.
-        >>> table_right = table_right.at_time(table_left.timestamp_col)
-
-        >>> expr = table_left.join(
-        >>>     table_right,
-        >>>     predicates=[
-        >>>         table_left["id"] == table_right["id"],
-        >>>     ],
-        >>> )
-
-        TODO (mehmet): If we bring `at_time()` in `join()` as
-        expr = table_left.join(
-            table_right.at_time(table_left.timestamp_col),
-            predicates=[
-                table_left["id"] == table_right["id"],
-            ],
-        )
-        this will raise
-        E ibis.common.exceptions.IntegrityError: Cannot add <ibis.expr.operations.logical.Equals object at 0x17c374270> to projection, they belong to another relation
-
-        The reason is that `at_time()` returns a new copy of `table_right` and
-        the predicates are defined with the old copy of `table_right`.
-
-        Is there a way to make this work without having to define `table_right`
-        in a separate line before `temporal_join()`? The API would look better
-        when `table_right.at_time()` is provided directly to `temporal_join()`.
         """
+
+        # TODO (mehmet): Did not place the example below in the docstring above
+        # as it requires `con`. Should we add a temporal join example in a different
+        # format, or skip it entirely here as Flink is the only backend supporting it?
+        #
+        # Examples for temporal join
+        # --------
+        # # Create left- and right-table. Right-table should be a versioned table.
+        # >>> table_left = con.create_table(...)
+        # >>> table_right = con.create_table(...)
+        #
+        # # Set the time-attribute that will determine the version of the rows to be
+        # # joined against in `table_right` at runtime.
+        # >>> table_right = table_right.at_time(table_left.timestamp_col)
+        #
+        # >>> expr = table_left.join(
+        # >>>     table_right,
+        # >>>     predicates=[
+        # >>>         table_left["id"] == table_right["id"],
+        # >>>     ],
+        # >>> )
+        #
+        # TODO (mehmet): If we bring `at_time()` in `join()` as
+        # expr = table_left.join(
+        #     table_right.at_time(table_left.timestamp_col),
+        #     predicates=[
+        #         table_left["id"] == table_right["id"],
+        #     ],
+        # )
+        # this will raise
+        # E ibis.common.exceptions.IntegrityError: Cannot add <ibis.expr.operations.logical.Equals object at 0x17c374270> to projection, they belong to another relation
+        #
+        # The reason is that `at_time()` returns a new copy of `table_right` and
+        # the predicates are defined with the old copy of `table_right`.
+        #
+        # Is there a way to make this work without having to define `table_right`
+        # in a separate line before `temporal_join()`? The API would look better
+        # when `table_right.at_time()` is provided directly to `temporal_join()`.
+
         from ibis.expr.types.joins import Join
 
         return Join(left.op()).join(

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -3121,7 +3121,6 @@ class Table(Expr, _FixedTextJupyterMixin):
         right: Table,
         predicates: Sequence[ir.BooleanColumn] = (),
         *,
-        at_time: ir.Column = None,
         lname: str = "",
         rname: str = "{name}_right",
     ) -> Table:
@@ -3131,9 +3130,8 @@ class Table(Expr, _FixedTextJupyterMixin):
         with the corresponding versions of the matching rows in the `right` table.
         Thus, `right` must support versioning, i.e., it should be a "versioned table".
         Versions of the rows in `right` are determined with respect to a time-attribute
-        that must be a column of the `left` table. The time-attribute can be specified
-        either via the `at_time` arg, or by attaching it to `right` table by
-        `right.at_time(left.time_attribute)`.
+        that must be a column of the `left` table. The time-attribute should be specified
+        by attaching it to `right` table via `right.at_time(left.time_attribute)`.
 
         Columns on which the join will be performed should be provided in
         `predicates`. Every given predicate should be of an equality.
@@ -3144,8 +3142,6 @@ class Table(Expr, _FixedTextJupyterMixin):
             Table expression
         right
             Table expression
-        at_time
-            Time-attribute column.
         predicates
             Join predicates. Can only contain equalities.
         lname
@@ -3167,16 +3163,6 @@ class Table(Expr, _FixedTextJupyterMixin):
         table_left = con.create_table(...)
         table_right = con.create_table(...)
 
-        # By providing the time-attribute via `at_time` arg
-        join_expr = table_left.temporal_join(
-            table_right,
-            at_time=table_left.timestamp_col,
-            predicates=[
-                table_left["id"] == table_right["id"],
-            ],
-        )
-
-        # By attaching the time-attribute to `right` table
         table_right = table_right.at_time(table_left.timestamp_col)
         expr = table_left.temporal_join(
             table_right,
@@ -3207,7 +3193,6 @@ class Table(Expr, _FixedTextJupyterMixin):
         return Join(left.op()).temporal_join(
             right=right,
             predicates=predicates,
-            at_time=at_time,
             lname=lname,
             rname=rname,
         )

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2857,6 +2857,36 @@ class Table(Expr, _FixedTextJupyterMixin):
             aggs.append(agg)
         return ibis.union(*aggs).order_by(ibis.asc("pos"))
 
+    def at_time(
+        self: Table,
+        time_attribute: ir.Column,
+    ) -> Table:
+        """Sets the time-attribute used for picking the table version at runtime.
+
+        Time-attribute determines the version/snapshot used at runtime for the
+        versioned table. Defined only for versioned tables. Raises `IbisInputError`
+        if it is called on a table that does not support versioning.
+
+        Parameters
+        ----------
+        time_attribute
+            A table column to determine the version of this table.
+
+        Returns
+        -------
+        Table
+            Table expression
+        """
+
+        op = self.op()
+        if not isinstance(op, ops.VersionedDatabaseTable):
+            raise com.IbisInputError(
+                "Table is not versioned. "
+                "`at_time()` is defined only for versioned tables."
+            )
+
+        return op.copy(at_time=time_attribute).to_expr()
+
     def join(
         left: Table,
         right: Table,
@@ -2877,6 +2907,16 @@ class Table(Expr, _FixedTextJupyterMixin):
         rname: str = "{name}_right",
     ) -> Table:
         """Perform a join between two tables.
+
+        When `right` is a versioned table, this will perform a temporal join.
+        This will join the rows in `left` with the corresponding versions of the
+        matching rows in `right`. Thus, `right` must support versioning, i.e.,
+        it should be a "versioned table". Versions of the rows in `right` are
+        determined with respect to a time-attribute that must be a column of `left`.
+        The time-attribute should be specified by attaching it to `right` with
+        `right.at_time(left.time_attribute)`. Columns on which the join will be
+        performed should be provided in `predicates`. Every given predicate should
+        be of an equality.
 
         Parameters
         ----------
@@ -3029,6 +3069,40 @@ class Table(Expr, _FixedTextJupyterMixin):
         │  106782 │ drugs             │          1732 │ drugs             │
         │  106782 │ Leonardo DiCaprio │          5989 │ Leonardo DiCaprio │
         └─────────┴───────────────────┴───────────────┴───────────────────┘
+
+        Examples for temporal join
+        --------
+        # Create left- and right-table. Right-table should be a versioned table.
+        >>> table_left = con.create_table(...)
+        >>> table_right = con.create_table(...)
+
+        # Set the time-attribute that will determine the version of the rows to be
+        # joined against in `table_right` at runtime.
+        >>> table_right = table_right.at_time(table_left.timestamp_col)
+
+        >>> expr = table_left.join(
+        >>>     table_right,
+        >>>     predicates=[
+        >>>         table_left["id"] == table_right["id"],
+        >>>     ],
+        >>> )
+
+        TODO (mehmet): If we bring `at_time()` in `join()` as
+        expr = table_left.join(
+            table_right.at_time(table_left.timestamp_col),
+            predicates=[
+                table_left["id"] == table_right["id"],
+            ],
+        )
+        this will raise
+        E ibis.common.exceptions.IntegrityError: Cannot add <ibis.expr.operations.logical.Equals object at 0x17c374270> to projection, they belong to another relation
+
+        The reason is that `at_time()` returns a new copy of `table_right` and
+        the predicates are defined with the old copy of `table_right`.
+
+        Is there a way to make this work without having to define `table_right`
+        in a separate line before `temporal_join()`? The API would look better
+        when `table_right.at_time()` is provided directly to `temporal_join()`.
         """
         from ibis.expr.types.joins import Join
 
@@ -3084,117 +3158,6 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         return Join(left.op()).asof_join(
             right, on, predicates, by=by, tolerance=tolerance, lname=lname, rname=rname
-        )
-
-    def at_time(
-        self: Table,
-        time_attribute: ir.Column,
-    ) -> Table:
-        """Sets the time-attribute used for picking the table version at runtime.
-
-        Time-attribute determines the version/snapshot used at runtime for the
-        versioned table. Defined only for versioned tables. Raises `IbisInputError`
-        if it is called on a table that does not support versioning.
-
-        Parameters
-        ----------
-        time_attribute
-            A table column to determine the version of this table.
-
-        Returns
-        -------
-        Table
-            Table expression
-        """
-
-        op = self.op()
-        if not isinstance(op, ops.VersionedDatabaseTable):
-            raise com.IbisInputError(
-                "Table is not versioned. "
-                "`at_time()` is defined only for versioned tables."
-            )
-
-        return op.copy(at_time=time_attribute).to_expr()
-
-    def temporal_join(
-        left: Table,
-        right: Table,
-        predicates: Sequence[ir.BooleanColumn] = (),
-        *,
-        lname: str = "",
-        rname: str = "{name}_right",
-    ) -> Table:
-        """Perform a temporal join between tables `left` and `right`.
-
-        Similar to a left-join except that rows in the `left` table are joined
-        with the corresponding versions of the matching rows in the `right` table.
-        Thus, `right` must support versioning, i.e., it should be a "versioned table".
-        Versions of the rows in `right` are determined with respect to a time-attribute
-        that must be a column of the `left` table. The time-attribute should be specified
-        by attaching it to `right` table via `right.at_time(left.time_attribute)`.
-
-        Columns on which the join will be performed should be provided in
-        `predicates`. Every given predicate should be of an equality.
-
-        Parameters
-        ----------
-        left
-            Table expression
-        right
-            Table expression
-        predicates
-            Join predicates. Can only contain equalities.
-        lname
-            A format string to use to rename overlapping columns in the left
-            table (e.g. ``"left_{name}"``).
-        rname
-            A format string to use to rename overlapping columns in the right
-            table (e.g. ``"right_{name}"``).
-
-        Returns
-        -------
-        Table
-            Table expression
-
-        Examples
-        --------
-        >>> import ibis
-
-        table_left = con.create_table(...)
-        table_right = con.create_table(...)
-
-        table_right = table_right.at_time(table_left.timestamp_col)
-        expr = table_left.temporal_join(
-            table_right,
-            predicates=[
-                table_left["id"] == table_right["id"],
-            ],
-        )
-
-        # TODO (mehmet): If we do not over-write `table_right` as below
-        expr = table_left.temporal_join(
-            table_right.at_time(table_left.timestamp_col),
-            predicates=[
-                table_left["id"] == table_right["id"],
-            ],
-        )
-        it will raise
-        E ibis.common.exceptions.IntegrityError: Cannot add <ibis.expr.operations.logical.Equals object at 0x17c374270> to projection, they belong to another relation
-
-        This is because `at_time()` returns a new copy of `table_right` and
-        the predicates are defined with the old copy of `table_right`.
-
-        Is there a way to make this work without having to define `table_right`
-        in a separate line before `temporal_join()`? The API would look better
-        when `table_right.at_time()` is provided directly to `temporal_join()`.
-        """
-        from ibis.expr.types.joins import Join
-
-        return Join(left.op()).temporal_join(
-            right=right,
-            predicates=predicates,
-            lname=lname,
-            rname=rname,
         )
 
     def cross_join(

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -3086,6 +3086,132 @@ class Table(Expr, _FixedTextJupyterMixin):
             right, on, predicates, by=by, tolerance=tolerance, lname=lname, rname=rname
         )
 
+    def at_time(
+        self: Table,
+        time_attribute: ir.Column,
+    ) -> Table:
+        """Sets the time-attribute used for picking the table version at runtime.
+
+        Time-attribute determines the version/snapshot used at runtime for the
+        versioned table. Defined only for versioned tables. Raises `IbisInputError`
+        if it is called on a table that does not support versioning.
+
+        Parameters
+        ----------
+        time_attribute
+            A table column to determine the version of this table.
+
+        Returns
+        -------
+        Table
+            Table expression
+        """
+
+        op = self.op()
+        if not isinstance(op, ops.VersionedDatabaseTable):
+            raise com.IbisInputError(
+                "Table is not versioned. "
+                "`at_time()` is defined only for versioned tables."
+            )
+
+        return op.copy(at_time=time_attribute).to_expr()
+
+    def temporal_join(
+        left: Table,
+        right: Table,
+        predicates: Sequence[ir.BooleanColumn] = (),
+        *,
+        at_time: ir.Column = None,
+        lname: str = "",
+        rname: str = "{name}_right",
+    ) -> Table:
+        """Perform a temporal join between tables `left` and `right`.
+
+        Similar to a left-join except that rows in the `left` table are joined
+        with the corresponding versions of the matching rows in the `right` table.
+        Thus, `right` must support versioning, i.e., it should be a "versioned table".
+        Versions of the rows in `right` are determined with respect to a time-attribute
+        that must be a column of the `left` table. The time-attribute can be specified
+        either via the `at_time` arg, or by attaching it to `right` table by
+        `right.at_time(left.time_attribute)`.
+
+        Columns on which the join will be performed should be provided in
+        `predicates`. Every given predicate should be of an equality.
+
+        Parameters
+        ----------
+        left
+            Table expression
+        right
+            Table expression
+        at_time
+            Time-attribute column.
+        predicates
+            Join predicates. Can only contain equalities.
+        lname
+            A format string to use to rename overlapping columns in the left
+            table (e.g. ``"left_{name}"``).
+        rname
+            A format string to use to rename overlapping columns in the right
+            table (e.g. ``"right_{name}"``).
+
+        Returns
+        -------
+        Table
+            Table expression
+
+        Examples
+        --------
+        >>> import ibis
+
+        table_left = con.create_table(...)
+        table_right = con.create_table(...)
+
+        # By providing the time-attribute via `at_time` arg
+        join_expr = table_left.temporal_join(
+            table_right,
+            at_time=table_left.timestamp_col,
+            predicates=[
+                table_left["id"] == table_right["id"],
+            ],
+        )
+
+        # By attaching the time-attribute to `right` table
+        table_right = table_right.at_time(table_left.timestamp_col)
+        expr = table_left.temporal_join(
+            table_right,
+            predicates=[
+                table_left["id"] == table_right["id"],
+            ],
+        )
+
+        # TODO (mehmet): If we do not over-write `table_right` as below
+        expr = table_left.temporal_join(
+            table_right.at_time(table_left.timestamp_col),
+            predicates=[
+                table_left["id"] == table_right["id"],
+            ],
+        )
+        it will raise
+        E ibis.common.exceptions.IntegrityError: Cannot add <ibis.expr.operations.logical.Equals object at 0x17c374270> to projection, they belong to another relation
+
+        This is because `at_time()` returns a new copy of `table_right` and
+        the predicates are defined with the old copy of `table_right`.
+
+        Is there a way to make this work without having to define `table_right`
+        in a separate line before `temporal_join()`? The API would look better
+        when `table_right.at_time()` is provided directly to `temporal_join()`.
+        """
+        from ibis.expr.types.joins import Join
+
+        return Join(left.op()).temporal_join(
+            right=right,
+            predicates=predicates,
+            at_time=at_time,
+            lname=lname,
+            rname=rname,
+        )
+
     def cross_join(
         left: Table,
         right: Table,


### PR DESCRIPTION
## Description of changes

Explorative PR towards addressing https://github.com/ibis-project/ibis/issues/8247.

This is my first time getting hands-on with `sqlglot` changes :) So, particularly seeking suggestions on
- Temporal join API
- The newly added op `VersionedDatabaseTable` and expression `TemporalJoin`.

**Note**: Added support only in the Flink backend for now. Did not spend time on how to error out when the user calls `tempora_join()` on a backend that does not support temporal join. Plan to address these once we reach an agreement on the API.

## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
