### PR TITLE
build(docs): clean up some warnings and duplicate method definitions

### DIFF
--- a/docs/404.qmd
+++ b/docs/404.qmd
@@ -1,4 +1,6 @@
-# Page not found
+---
+title: Page not found
+---
 
 The page you requested cannot be found (perhaps it was moved or renamed).
 

--- a/docs/backends/impala.qmd
+++ b/docs/backends/impala.qmd
@@ -126,13 +126,7 @@ The best way to interact with a single table is through the
 render_methods(
     table,
     "drop",
-    "drop_partition",
-    "files",
     "insert",
-    "is_partitioned",
-    "partition_schema",
-    "partitions",
-    "refresh",
     "describe_formatted",
 )
 ```

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -4,24 +4,26 @@ import re
 import sys
 from abc import abstractmethod
 from itertools import zip_longest
-from types import ModuleType  # noqa: F401
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,  # noqa: F401
-    Optional,
-    TypeVar,
-    Union,
-    get_args,
-    get_origin,
-)
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, get_args, get_origin
 from typing import get_type_hints as _get_type_hints
 
 from ibis.common.bases import Abstract
 from ibis.common.caching import memoize
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
     from typing_extensions import Self
+
+    import ibis.expr.datatypes as dt
+    import ibis.expr.schema as sch
+
+    SupportsSchema = TypeVar(
+        "SupportsSchema",
+        sch.Schema,
+        Mapping[str, str | dt.DataType],
+        Iterable[tuple[str, str | dt.DataType]],
+    )
 
 if sys.version_info >= (3, 10):
     from types import UnionType


### PR DESCRIPTION
Clean up a few docs warnings