### PR TITLE
feat(snowflake): support connecting with no arguments

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -243,7 +243,14 @@ $$ {defn["source"]} $$"""
             ),
         )
 
-        con = sc.connect(**connect_args, session_parameters=session_parameters)
+        con = sc.connect(**connect_args)
+
+        with contextlib.closing(con.cursor()) as cur:
+            cur.execute(
+                "ALTER SESSION SET {}".format(
+                    " ".join(f"{k} = {v!r}" for k, v in session_parameters.items())
+                )
+            )
 
         if create_object_udfs:
             database = con.database

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 
 import pandas as pd
 import pandas.testing as tm
@@ -286,3 +287,17 @@ def test_compile_does_not_make_requests(con, mocker):
 
     assert ibis.to_sql(expr) is not None
     assert spy.call_count == 0
+
+
+# this won't be hit in CI, but folks can test locally
+@pytest.mark.xfail(
+    condition=os.environ.get("SNOWFLAKE_HOME") is None,
+    reason="SNOWFLAKE_HOME is not set",
+)
+@pytest.mark.xfail(
+    condition=os.environ.get("SNOWFLAKE_DEFAULT_CONNECTION_NAME") is None,
+    reason="SNOWFLAKE_DEFAULT_CONNECTION_NAME is not set",
+)
+def test_no_argument_connection():
+    con = ibis.snowflake.connect()
+    assert con.list_tables() is not None


### PR DESCRIPTION
Snowflake supports connecting with no arguments using [`connections.toml`](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect#connecting-using-the-connections-toml-file), but snowflake-connector-python does not work when passing sessions parameters and no connection arguments. The workaround is to set session parameters after connecting.