### PR TITLE
refactor: rename SupportSchema -> SchemaLike, fix type definition

### DIFF
--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
     import ibis.expr.datatypes as dt
     from ibis.backends.sql.compiler import SQLGlotCompiler
-    from ibis.common.typing import SupportsSchema
+    from ibis.expr.schema import SchemaLike
 
 
 class SQLBackend(BaseBackend):
@@ -137,7 +137,7 @@ class SQLBackend(BaseBackend):
     def sql(
         self,
         query: str,
-        schema: SupportsSchema | None = None,
+        schema: SchemaLike | None = None,
         dialect: str | None = None,
     ) -> ir.Table:
         query = self._transpile_sql(query, dialect=dialect)

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -11,19 +11,8 @@ from ibis.common.bases import Abstract
 from ibis.common.caching import memoize
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
-
     from typing_extensions import Self
 
-    import ibis.expr.datatypes as dt
-    import ibis.expr.schema as sch
-
-    SupportsSchema = TypeVar(
-        "SupportsSchema",
-        sch.Schema,
-        Mapping[str, str | dt.DataType],
-        Iterable[tuple[str, str | dt.DataType]],
-    )
 
 if sys.version_info >= (3, 10):
     from types import UnionType

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
 
-    from ibis.common.typing import SupportsSchema
+    from ibis.expr.schema import SchemaLike
 
 __all__ = (
     "aggregate",
@@ -266,7 +266,7 @@ def param(type: dt.DataType) -> ir.Scalar:
 
 
 def schema(
-    pairs: SupportsSchema | None = None,
+    pairs: SchemaLike | None = None,
     names: Iterable[str] | None = None,
     types: Iterable[str | dt.DataType] | None = None,
 ) -> sch.Schema:
@@ -310,7 +310,7 @@ _table_names = (f"unbound_table_{i:d}" for i in itertools.count())
 
 
 def table(
-    schema: SupportsSchema | None = None,
+    schema: SchemaLike | None = None,
     name: str | None = None,
 ) -> ir.Table:
     """Create a table literal or an abstract table without data.
@@ -352,7 +352,7 @@ def memtable(
     data,
     *,
     columns: Iterable[str] | None = None,
-    schema: SupportsSchema | None = None,
+    schema: SchemaLike | None = None,
     name: str | None = None,
 ) -> Table:
     """Construct an ibis table expression from in-memory data.
@@ -441,7 +441,7 @@ def _memtable(
     data: pd.DataFrame | Any,
     *,
     columns: Iterable[str] | None = None,
-    schema: SupportsSchema | None = None,
+    schema: SchemaLike | None = None,
     name: str | None = None,
 ) -> Table:
     import pandas as pd
@@ -493,7 +493,7 @@ def _memtable_from_pyarrow_table(
     data: pa.Table,
     *,
     name: str | None = None,
-    schema: SupportsSchema | None = None,
+    schema: SchemaLike | None = None,
     columns: Iterable[str] | None = None,
 ):
     from ibis.formats.pyarrow import PyArrowTableProxy

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator, Mapping
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union
 
 import ibis.expr.datatypes as dt
 from ibis.common.annotations import attribute
@@ -14,6 +14,7 @@ from ibis.util import deprecated, indent
 
 if TYPE_CHECKING:
     import pandas as pd
+    from typing_extensions import TypeAlias
 
 
 class Schema(Concrete, Coercible, MapSet):
@@ -218,6 +219,13 @@ class Schema(Concrete, Coercible, MapSet):
         from ibis.formats.pandas import PandasData
 
         return PandasData.convert_table(df, self)
+
+
+SchemaLike: TypeAlias = Union[
+    Schema,
+    Mapping[str, Union[str, dt.DataType]],
+    Iterable[tuple[str, Union[str, dt.DataType]]],
+]
 
 
 @lazy_singledispatch

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -33,8 +33,8 @@ if TYPE_CHECKING:
 
     import ibis.expr.types as ir
     import ibis.selectors as s
-    from ibis.common.typing import SupportsSchema
     from ibis.expr.operations.relations import JoinKind
+    from ibis.expr.schema import SchemaLike
     from ibis.expr.types import Table
     from ibis.expr.types.groupby import GroupedTable
     from ibis.expr.types.tvf import WindowedTable
@@ -361,7 +361,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         """
         return name in self.schema()
 
-    def cast(self, schema: SupportsSchema) -> Table:
+    def cast(self, schema: SchemaLike) -> Table:
         """Cast the columns of a table.
 
         Similar to `pandas.DataFrame.astype`.
@@ -438,7 +438,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         """
         return self._cast(schema, cast_method="cast")
 
-    def try_cast(self, schema: SupportsSchema) -> Table:
+    def try_cast(self, schema: SchemaLike) -> Table:
         """Cast the columns of a table.
 
         If the cast fails for a row, the value is returned
@@ -472,7 +472,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         """
         return self._cast(schema, cast_method="try_cast")
 
-    def _cast(self, schema: SupportsSchema, cast_method: str = "cast") -> Table:
+    def _cast(self, schema: SchemaLike, cast_method: str = "cast") -> Table:
         schema = sch.schema(schema)
 
         cols = []


### PR DESCRIPTION
This is a follow-up to #8421.

- The use of a `TypeVar` here was incorrect - what you want is a `TypeAlias` instead. The previous version would cause type checkers to error.
- I moved the type definition to be adjacent to `Schema`. This makes the import paths cleaner since you don't need as many `if TYPE_CHECKING` blocks. Logically it also makes sense to me to put the union of schema-like things next to the `Schema` code.
- I renamed the type alias to `SchemaLike` which reads better IMO.