### PR TITLE
feat(snowflake): allow empty url when using ibis.connect

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -106,17 +106,21 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         """
 
         url = urlparse(url)
-        database, schema = url.path[1:].split("/", 1)
-        query_params = parse_qs(url.query)
-        (warehouse,) = query_params.pop("warehouse", (None,))
-        connect_args = {
-            "user": url.username,
-            "password": url.password or "",
-            "account": url.hostname,
-            "warehouse": warehouse,
-            "database": database or "",
-            "schema": schema or "",
-        }
+        if url.path:
+            database, schema = url.path[1:].split("/", 1)
+            query_params = parse_qs(url.query)
+            (warehouse,) = query_params.pop("warehouse", (None,))
+            connect_args = {
+                "user": url.username,
+                "password": url.password or "",
+                "account": url.hostname,
+                "warehouse": warehouse,
+                "database": database or "",
+                "schema": schema or "",
+            }
+        else:
+            connect_args = {}
+            query_params = {}
 
         for name, value in query_params.items():
             if len(value) > 1:

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -301,3 +301,6 @@ def test_compile_does_not_make_requests(con, mocker):
 def test_no_argument_connection():
     con = ibis.snowflake.connect()
     assert con.list_tables() is not None
+
+    con = ibis.connect("snowflake://")
+    assert con.list_tables() is not None


### PR DESCRIPTION
Follow-up to #8422 to support that behavior in `ibis.connect()`.