### PR TITLE
feat(duckdb): add enumerate function to provide access to array element offsets

### DIFF
--- a/ibis/expr/operations/arrays.py
+++ b/ibis/expr/operations/arrays.py
@@ -226,3 +226,15 @@ class TimestampRange(Range):
     start: Value[dt.Timestamp]
     stop: Value[dt.Timestamp]
     step: Value[dt.Interval]
+
+
+@public
+class Enumerate(Value):
+    arg: Value[dt.Array]
+    start: int
+
+    shape = ds.columnar
+
+    @attribute
+    def dtype(self) -> dt.DataType:
+        return dt.Struct({"index": dt.int64, "value": self.arg.dtype.value_type})

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -12,6 +12,7 @@ from ibis.expr.types.generic import Column, Scalar, Value
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    import ibis.expr.datatypes as dt
     import ibis.expr.types as ir
     from ibis.expr.types.typing import V
 
@@ -1040,6 +1041,38 @@ class ArrayValue(Value):
         └──────────────────────┴──────────────────────┴────────────┴───┘
         """
         return ops.ArrayFlatten(self).to_expr()
+
+    def enumerate(self, *, start: int = 0) -> dt.Struct:
+        """Return a struct column with an index field and a value field.
+
+        The `index` field starts from `start`.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> a = ibis.array(["a", "b", "c"])
+        >>> a.enumerate()
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Enumerate(Array())                  ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ struct<index: int64, value: string> │
+        ├─────────────────────────────────────┤
+        │ {'index': 0, 'value': 'a'}          │
+        │ {'index': 1, 'value': 'b'}          │
+        │ {'index': 2, 'value': 'c'}          │
+        └─────────────────────────────────────┘
+        >>> a.enumerate(start=1)
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Enumerate(Array())                  ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ struct<index: int64, value: string> │
+        ├─────────────────────────────────────┤
+        │ {'index': 1, 'value': 'a'}          │
+        │ {'index': 2, 'value': 'b'}          │
+        │ {'index': 3, 'value': 'c'}          │
+        └─────────────────────────────────────┘
+        """
+        return ops.Enumerate(self, start).to_expr()
 
 
 @public


### PR DESCRIPTION
Draft PR to demonstrate the API for `enumerate` discussed in #8356. Happy to expand the implement to other backends as needed.