### PR TITLE
fix(postgres): fix json type conversion in `to_pyarrow` output

### DIFF
--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -260,7 +260,7 @@ class Backend(SQLBackend):
             month : int32
 
         """
-
+        psycopg2.extras.register_default_json(loads=lambda x: x)
         self.con = psycopg2.connect(
             host=host,
             port=port,

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-import json
 import os
 
 import numpy as np
@@ -246,25 +245,3 @@ def test_kwargs_passthrough_in_connect():
         "postgresql://postgres:postgres@localhost/ibis_testing?sslmode=allow"
     )
     assert con.current_database == "ibis_testing"
-
-
-def test_json_to_pyarrow(con):
-    t = con.tables.json_t
-    table = t.to_pyarrow()
-    js = table["js"]
-
-    expected = [
-        {"a": [1, 2, 3, 4], "b": 1},
-        {"a": None, "b": 2},
-        {"a": "foo", "c": None},
-        None,
-        [42, 47, 55],
-        [],
-    ]
-    expected = frozenset(map(json.dumps, expected))
-
-    result = frozenset(
-        # loads and dumps so the string representation is the same
-        map(json.dumps, map(json.loads, js.to_pylist()))
-    )
-    assert result == expected

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import json
 import os
 
 import numpy as np
@@ -245,3 +246,25 @@ def test_kwargs_passthrough_in_connect():
         "postgresql://postgres:postgres@localhost/ibis_testing?sslmode=allow"
     )
     assert con.current_database == "ibis_testing"
+
+
+def test_json_to_pyarrow(con):
+    t = con.tables.json_t
+    table = t.to_pyarrow()
+    js = table["js"]
+
+    expected = [
+        {"a": [1, 2, 3, 4], "b": 1},
+        {"a": None, "b": 2},
+        {"a": "foo", "c": None},
+        None,
+        [42, 47, 55],
+        [],
+    ]
+    expected = frozenset(map(json.dumps, expected))
+
+    result = frozenset(
+        # loads and dumps so the string representation is the same
+        map(json.dumps, map(json.loads, js.to_pylist()))
+    )
+    assert result == expected

--- a/ibis/backends/snowflake/converter.py
+++ b/ibis/backends/snowflake/converter.py
@@ -1,16 +1,52 @@
 from __future__ import annotations
 
 import datetime
+import json
 from typing import TYPE_CHECKING
 
+import pyarrow as pa
+
 from ibis.formats.pandas import PandasData
-from ibis.formats.pyarrow import PYARROW_JSON_TYPE, PyArrowData
+from ibis.formats.pyarrow import PyArrowData
 
 if TYPE_CHECKING:
-    import pyarrow as pa
-
     import ibis.expr.datatypes as dt
     from ibis.expr.schema import Schema
+
+
+class JSONScalar(pa.ExtensionScalar):
+    def as_py(self):
+        value = self.value
+        if value is None:
+            return value
+        else:
+            return json.loads(value.as_py())
+
+
+class JSONArray(pa.ExtensionArray):
+    pass
+
+
+class JSONType(pa.ExtensionType):
+    def __init__(self):
+        super().__init__(pa.string(), "ibis.json")
+
+    def __arrow_ext_serialize__(self):
+        return b""
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        return cls()
+
+    def __arrow_ext_class__(self):
+        return JSONArray
+
+    def __arrow_ext_scalar_class__(self):
+        return JSONScalar
+
+
+PYARROW_JSON_TYPE = JSONType()
+pa.register_extension_type(PYARROW_JSON_TYPE)
 
 
 class SnowflakePandasData(PandasData):
@@ -50,16 +86,12 @@ class SnowflakePandasData(PandasData):
 class SnowflakePyArrowData(PyArrowData):
     @classmethod
     def convert_table(cls, table: pa.Table, schema: Schema) -> pa.Table:
-        import pyarrow as pa
-
         columns = [cls.convert_column(table[name], typ) for name, typ in schema.items()]
         return pa.Table.from_arrays(columns, names=schema.names)
 
     @classmethod
     def convert_column(cls, column: pa.Array, dtype: dt.DataType) -> pa.Array:
         if dtype.is_json() or dtype.is_array() or dtype.is_map() or dtype.is_struct():
-            import pyarrow as pa
-
             if isinstance(column, pa.ChunkedArray):
                 column = column.combine_chunks()
 

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -304,3 +304,16 @@ def test_no_argument_connection():
 
     con = ibis.connect("snowflake://")
     assert con.list_tables() is not None
+
+
+def test_struct_of_json(con):
+    raw = {"a": [1, 2, 3], "b": "456"}
+    lit = ibis.struct(raw)
+    expr = lit.cast("struct<a: array<int>, b: json>")
+
+    n = 5
+    t = con.tables.functional_alltypes.mutate(lit=expr).limit(n).lit
+    result = con.to_pyarrow(t)
+
+    assert len(result) == n
+    assert all(value == raw for value in result.to_pylist())

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1471,6 +1471,26 @@ def test_close_connection(con):
         new_con.list_tables()
 
 
+@pytest.mark.notyet(
+    ["clickhouse"],
+    raises=AttributeError,
+    reason="JSON extension is experimental and not enabled by default in testing",
+)
+@pytest.mark.notyet(
+    ["datafusion", "polars", "mssql", "druid", "oracle", "exasol", "impala"],
+    raises=AttributeError,
+    reason="JSON type not implemented",
+)
+@pytest.mark.notimpl(
+    ["risingwave", "sqlite"],
+    raises=pa.ArrowTypeError,
+    reason="mismatch between output value and expected input type",
+)
+@pytest.mark.never(
+    ["snowflake"],
+    raises=TypeError,
+    reason="snowflake uses a custom pyarrow extension type for JSON pretty printing",
+)
 def test_json_to_pyarrow(con):
     t = con.tables.json_t
     table = t.to_pyarrow()

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
@@ -12,37 +11,6 @@ from ibis.formats import DataMapper, SchemaMapper, TableProxy, TypeMapper
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
-
-
-class JSONScalar(pa.ExtensionScalar):
-    def as_py(self):
-        value = self.value
-        if value is None:
-            return value
-        else:
-            return json.loads(value.as_py())
-
-
-class JSONArray(pa.ExtensionArray):
-    pass
-
-
-class JSONType(pa.ExtensionType):
-    def __init__(self):
-        super().__init__(pa.string(), "ibis.json")
-
-    def __arrow_ext_serialize__(self):
-        return b""
-
-    @classmethod
-    def __arrow_ext_deserialize__(cls, storage_type, serialized):
-        return cls()
-
-    def __arrow_ext_class__(self):
-        return JSONArray
-
-    def __arrow_ext_scalar_class__(self):
-        return JSONScalar
 
 
 _from_pyarrow_types = {
@@ -91,6 +59,7 @@ _to_pyarrow_types = {
     dt.MACADDR: pa.string(),
     dt.INET: pa.string(),
     dt.UUID: pa.string(),
+    dt.JSON: pa.string(),
 }
 
 
@@ -128,8 +97,6 @@ class PyArrowType(TypeMapper):
             key_dtype = cls.to_ibis(typ.key_type, typ.key_field.nullable)
             value_dtype = cls.to_ibis(typ.item_type, typ.item_field.nullable)
             return dt.Map(key_dtype, value_dtype, nullable=nullable)
-        elif isinstance(typ, JSONType):
-            return dt.JSON()
         elif pa.types.is_dictionary(typ):
             return cls.to_ibis(typ.value_type)
         else:
@@ -191,8 +158,6 @@ class PyArrowType(TypeMapper):
                 nullable=dtype.value_type.nullable,
             )
             return pa.map_(key_field, value_field, keys_sorted=False)
-        elif dtype.is_json():
-            return PYARROW_JSON_TYPE
         elif dtype.is_geospatial():
             return pa.binary()
         else:
@@ -303,7 +268,3 @@ class PyArrowTableProxy(TableProxy[pa.Table]):
 
     def to_pyarrow(self, schema: Schema) -> pa.Table:
         return self.obj
-
-
-PYARROW_JSON_TYPE = JSONType()
-pa.register_extension_type(PYARROW_JSON_TYPE)


### PR DESCRIPTION
Localize custom pyarrow json serialization to snowflake. This custom type doesn't compose well (e.g., inside structs, which aren't directly supported in snowflake anyway) and was causing problems for other backends when trying to convert rows into a struct of the table schema and then into a proper table.

Fixes #8318.