### PR TITLE
chore(deps): default to python 3.11 with nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,7 +127,7 @@
       packages = {
         inherit (pkgs) ibis39 ibis310 ibis311;
 
-        default = pkgs.ibis310;
+        default = pkgs.ibis311;
 
         inherit (pkgs) update-lock-files gen-all-extras gen-examples check-release-notes-spelling;
       };
@@ -137,7 +137,7 @@
         ibis310 = mkDevShell pkgs.ibisDevEnv310;
         ibis311 = mkDevShell pkgs.ibisDevEnv311;
 
-        default = ibis310;
+        default = ibis311;
 
         preCommit = pkgs.mkShell {
           name = "preCommit";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -73,7 +73,7 @@ in
   gen-examples = pkgs.writeShellApplication {
     name = "gen-examples";
     runtimeInputs = [
-      pkgs.ibisDevEnv310
+      pkgs.ibisDevEnv311
       (pkgs.rWrapper.override {
         packages = with pkgs.rPackages; [
           Lahman


### PR DESCRIPTION
Tiny PR to switch the default version of Python in the nix setup to be 3.11. Previously we avoided this because we did not support a version of PySpark that supported Python 3.11, but now we do (PySpark 3.5).