### PR TITLE
perf(ir): avoid exponential growth on `name` attribute access

### DIFF
--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -85,7 +85,11 @@ class Value(Node, Coercible, DefaultTypeVars, Generic[T, S]):
     # TODO(kszucs): figure out how to represent not named arguments
     @property
     def name(self) -> str:
-        names = (arg.name for arg in self.__args__ if hasattr(arg, "name"))
+        names = (
+            name
+            for arg in self.__args__
+            if (name := getattr(arg, "name", None)) is not None
+        )
         return f"{self.__class__.__name__}({', '.join(names)})"
 
     @property

--- a/ibis/expr/tests/test_api.py
+++ b/ibis/expr/tests/test_api.py
@@ -147,3 +147,12 @@ def test_implicit_coercion_of_null_literal(op):
 
     assert expr1.op() == expected
     assert expr2.op() == expected
+
+
+def test_nested_name_property():
+    x = ibis.literal(1)
+    n = 100
+    for _ in range(n):  # noqa: F402
+        x = x + 1
+
+    assert x.op().name.count("Add") == n


### PR DESCRIPTION
Fixes #8432. In short, the pattern we are using here for accessing `name` results in exponential growth of attribute accesses.