### PR TITLE
refactor(ir): remove `find_first_base_table()` analysis function

### DIFF
--- a/ibis/expr/analysis.py
+++ b/ibis/expr/analysis.py
@@ -2,29 +2,6 @@ from __future__ import annotations
 
 import ibis.common.graph as g
 import ibis.expr.operations as ops
-from ibis.common.deferred import deferred, var
-from ibis.common.patterns import pattern
-from ibis.util import Namespace
-
-p = Namespace(pattern, module=ops)
-c = Namespace(deferred, module=ops)
-
-x = var("x")
-y = var("y")
-
-
-# TODO(kszucs): should be removed
-def find_first_base_table(node):
-    def predicate(node):
-        if isinstance(node, ops.Relation):
-            return g.halt, node
-        else:
-            return g.proceed, None
-
-    try:
-        return next(g.traverse(predicate, node))
-    except StopIteration:
-        return None
 
 
 def flatten_predicates(node):

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -592,10 +592,9 @@ class Expr(Immutable, Coercible):
 
     def unbind(self) -> ir.Table:
         """Return an expression built on `UnboundTable` instead of backend-specific objects."""
-        from ibis.common.deferred import _
-        from ibis.expr.analysis import c, p
+        from ibis.expr.rewrites import _, d, p
 
-        rule = p.DatabaseTable >> c.UnboundTable(
+        rule = p.DatabaseTable >> d.UnboundTable(
             name=_.name, schema=_.schema, namespace=_.namespace
         )
         return self.op().replace(rule).to_expr()
@@ -609,7 +608,7 @@ class Expr(Immutable, Coercible):
     def as_scalar(self) -> ir.Scalar:
         """Convert an expression to a scalar."""
         raise NotImplementedError(
-            f"{type(self)} expression cannot be converted into scalars"
+            f"{type(self)} expressions cannot be converted into scalars"
         )
 
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -4109,8 +4109,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         import pandas as pd
 
         import ibis.selectors as s
-        from ibis import _
-        from ibis.expr.analysis import p, x
+        from ibis.expr.rewrites import _, p, x
 
         orig_names_from = util.promote_list(names_from)
 


### PR DESCRIPTION
There were just a couple of places left where `find_first_base_table()` was still in use. Since the epic split refactor the preferred way to retrieve parent relation(s) is the `value.relations` property. 