### PR TITLE
chore: add period to end of issue templates for consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: File a bug report for Ibis
+description: File a bug report for Ibis.
 title: "bug: "
 labels: ["bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/docs-issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs-issue.yml
@@ -1,5 +1,5 @@
 name: Documentation issue
-description: Open an issue about the Ibis documentation
+description: Open an issue about the Ibis documentation.
 title: "docs: "
 labels: ["docs"]
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest an idea for Ibis
+description: Suggest an idea for Ibis.
 title: "feat: "
 labels: ["feature"]
 body:

--- a/.github/ISSUE_TEMPLATE/new-backend.yml
+++ b/.github/ISSUE_TEMPLATE/new-backend.yml
@@ -1,5 +1,5 @@
 name: New backend request
-description: Suggest a new backend for Ibis
+description: Suggest a new backend for Ibis.
 title: "feat: "
 labels: ["feature", "new backend"]
 body:


### PR DESCRIPTION

## Description of changes

now that I've seen it, annoys me a lot -- the one we can't customize (?) has a period at the end, none of the others do:

<img width="349" alt="image" src="https://github.com/ibis-project/ibis/assets/54814569/028719f8-1f99-48a1-ab17-d2031affd5ee">

## Issues closed

