### PR TITLE
docs: fix typo in `order_by` docstring

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1681,7 +1681,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         │     3 │ D      │     7 │
         └───────┴────────┴───────┘
 
-        This means than shuffling a Table is super simple
+        This means that shuffling a Table is super simple
 
         >>> t.order_by(ibis.random())  # doctest: +SKIP
         ┏━━━━━━━┳━━━━━━━━┳━━━━━━━┓


### PR DESCRIPTION
## Description of changes

Adjusted

> This means than shuffling a Table is super simple

to

>  This means that shuffling a Table is super simple
