### PR TITLE
refactor(api): remove now unsupported `max_lookback` window attribute

### DIFF
--- a/ibis/backends/impala/tests/test_window.py
+++ b/ibis/backends/impala/tests/test_window.py
@@ -63,15 +63,6 @@ def test_window_frame_specs(alltypes, window, snapshot):
     assert_sql_equal(expr, snapshot)
 
 
-def test_window_rows_with_max_lookback(alltypes):
-    mlb = ibis.rows_with_max_lookback(3, ibis.interval(days=3))
-    t = alltypes
-    w = ibis.trailing_window(mlb, order_by=t.i)
-    expr = t.a.sum().over(w)
-    with pytest.raises(NotImplementedError):
-        ibis.to_sql(expr, dialect="impala")
-
-
 @pytest.mark.parametrize("name", ["sum", "min", "max", "mean"])
 def test_cumulative_functions(alltypes, name, snapshot):
     t = alltypes

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -712,17 +712,6 @@ def test_rolling_window(alltypes, func, df):
     tm.assert_series_equal(result, expected)
 
 
-def test_rolling_window_with_mlb(alltypes):
-    t = alltypes
-    window = ibis.trailing_window(
-        preceding=ibis.rows_with_max_lookback(3, ibis.interval(days=5)),
-        order_by=t.timestamp_col,
-    )
-    expr = t["double_col"].sum().over(window)
-    with pytest.raises(NotImplementedError):
-        expr.execute()
-
-
 @pytest.mark.parametrize("func", ["mean", "sum", "min", "max"])
 def test_partitioned_window(alltypes, func, df):
     t = alltypes

--- a/ibis/backends/risingwave/tests/test_functions.py
+++ b/ibis/backends/risingwave/tests/test_functions.py
@@ -506,17 +506,6 @@ def test_rolling_window(alltypes, func, df):
     tm.assert_series_equal(result, expected)
 
 
-def test_rolling_window_with_mlb(alltypes):
-    t = alltypes
-    window = ibis.trailing_window(
-        preceding=ibis.rows_with_max_lookback(3, ibis.interval(days=5)),
-        order_by=t.timestamp_col,
-    )
-    expr = t["double_col"].sum().over(window)
-    with pytest.raises(NotImplementedError):
-        expr.execute()
-
-
 @pytest.mark.parametrize("func", ["mean", "sum", "min", "max"])
 @pytest.mark.xfail(
     reason="Window function with empty PARTITION BY is not supported yet"

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -102,8 +102,6 @@ def sort_to_select(_, **kwargs):
 @replace(p.WindowFunction)
 def window_function_to_window(_, **kwargs):
     """Convert a WindowFunction node to a Window node."""
-    if isinstance(_.frame, ops.RowsWindowFrame) and _.frame.max_lookback is not None:
-        raise NotImplementedError("max_lookback is not supported for SQL backends")
     return Window(
         how=_.frame.how,
         func=_.func,

--- a/ibis/expr/builders.py
+++ b/ibis/expr/builders.py
@@ -147,7 +147,6 @@ class WindowBuilder(Builder):
     end: Optional[RangeWindowBoundary] = None
     groupings: VarTuple[Union[str, Resolver, ops.Value]] = ()
     orderings: VarTuple[Union[str, Resolver, ops.Value]] = ()
-    max_lookback: Optional[ops.Value[dt.Interval]] = None
 
     @attribute
     def _table(self):
@@ -156,7 +155,6 @@ class WindowBuilder(Builder):
             self.end,
             *self.groupings,
             *self.orderings,
-            self.max_lookback,
         )
         valuerels = (v.relations for v in inputs if isinstance(v, ops.Value))
         relations = frozenset().union(*valuerels)
@@ -227,9 +225,6 @@ class WindowBuilder(Builder):
     def order_by(self, expr) -> Self:
         return self.copy(orderings=self.orderings + util.promote_tuple(expr))
 
-    def lookback(self, value) -> Self:
-        return self.copy(max_lookback=value)
-
     @annotated
     def bind(self, table: Optional[ops.Relation]):
         table = table or self._table
@@ -255,7 +250,6 @@ class WindowBuilder(Builder):
                 end=self.end,
                 group_by=groupings,
                 order_by=orderings,
-                max_lookback=self.max_lookback,
             )
         elif self.how == "range":
             return ops.RangeWindowFrame(

--- a/ibis/expr/operations/window.py
+++ b/ibis/expr/operations/window.py
@@ -100,21 +100,6 @@ class RowsWindowFrame(WindowFrame):
     how = "rows"
     start: Optional[WindowBoundary[dt.Integer]] = None
     end: Optional[WindowBoundary] = None
-    max_lookback: Optional[Value[dt.Interval]] = None
-
-    def __init__(self, max_lookback, order_by, **kwargs):
-        if max_lookback:
-            # TODO(kszucs): this should belong to a timeseries extension rather than
-            # the core window operation
-            if len(order_by) != 1:
-                raise com.IbisTypeError(
-                    "`max_lookback` window must be ordered by a single column"
-                )
-            if not order_by[0].dtype.is_timestamp():
-                raise com.IbisTypeError(
-                    "`max_lookback` window must be ordered by a timestamp column"
-                )
-        super().__init__(max_lookback=max_lookback, order_by=order_by, **kwargs)
 
 
 @public


### PR DESCRIPTION
This feature was only supported by the pandas backend, but wasn\'t tested
properly and the support for it was entirely removed in the-epic-split refactor.

BREAKING CHANGE: `ibis.rows_with_max_lookback()` function and `ibis.window(max_lookback)` argument are removed
