### PR TITLE
feat(common): make `Deferred` objects hashable

### DIFF
--- a/ibis/common/deferred.py
+++ b/ibis/common/deferred.py
@@ -99,11 +99,6 @@ class Deferred(Slotted, Immutable, Final):
     def __iter__(self):
         raise TypeError(f"{self.__class__.__name__!r} object is not iterable")
 
-    def __bool__(self):
-        raise TypeError(
-            f"The truth value of {self.__class__.__name__} objects is not defined"
-        )
-
     def __getitem__(self, name):
         return Deferred(Item(self, name))
 
@@ -205,6 +200,9 @@ class Deferred(Slotted, Immutable, Final):
 
     def __rxor__(self, other: Any) -> Deferred:
         return Deferred(BinaryOperator(operator.xor, other, self))
+
+    def __hash__(self):
+        return hash((self.__class__, self._resolver))
 
 
 class Variable(FrozenSlotted, Resolver):

--- a/ibis/common/tests/test_deferred.py
+++ b/ibis/common/tests/test_deferred.py
@@ -202,12 +202,6 @@ def test_deferred_supports_string_arguments():
     assert b.resolve({}) == "3.14"
 
 
-def test_deferred_object_are_not_hashable():
-    # since __eq__ is overloaded, Deferred objects are not hashable
-    with pytest.raises(TypeError, match="unhashable type"):
-        hash(_.a)
-
-
 def test_deferred_const():
     obj = const({"a": 1, "b": 2, "c": "gamma"})
 
@@ -501,14 +495,6 @@ def test_deferred_is_not_iterable(obj):
         next(obj)
 
 
-@pytest.mark.parametrize("obj", [_, _.a, _.a.b[0]])
-def test_deferred_is_not_truthy(obj):
-    with pytest.raises(
-        TypeError, match="The truth value of Deferred objects is not defined"
-    ):
-        bool(obj)
-
-
 def test_deferrable(table):
     @deferrable
     def f(a, b, c=3):
@@ -539,11 +525,6 @@ def test_deferrable_repr():
         return x + 1
 
     assert repr(myfunc(_.a)) == "<test>"
-
-
-def test_deferred_set_raises():
-    with pytest.raises(TypeError, match="unhashable type"):
-        {_.a, _.b}  # noqa: B018
 
 
 @pytest.mark.parametrize(
@@ -602,3 +583,25 @@ def test_deferred_namespace(table):
 def test_custom_deferred_repr(table):
     expr = _.x + table.a
     assert repr(expr) == "(_.x + <column[int]>)"
+
+
+def test_deferred_hashable():
+    assert bool(_)
+    assert bool(_.a)
+    assert bool(_.a == _.a)
+    assert bool(_.a != _.b)
+
+    assert hash(_) == hash(_)
+    assert hash(_.a) == hash(_.a)
+    assert hash(_.b) != hash(_.a)
+
+    dct = {}
+    dct[_.a] = "a"
+    dct[_.b] = "b"
+    assert len(dct) == 2
+    assert dct[_.a] == "a"
+    assert dct[_.b] == "b"
+
+    dct[_.a] = "c"
+    assert len(dct) == 2
+    assert dct[_.a] == "c"


### PR DESCRIPTION
While implementing is straightforward, the semantics are not. The point of `Deferred` is to defer the evaluation of traditional python syntax such as the equality comparison `==`. Hence we need to implement `__eq__` to return another `Deferred` object which hasn't been allowed to be evaluated as a *truthy* value by raising from `__bool__`. 

When a hash collision occurs `__eq__` gets called and the result is evaluated a boolean. With the changes in this PR all deferred objects will evaluate as equal: `(_.a == _a) is True` as well as `bool(_.a != _.a)`. 
While this is tolerable for this esoteric use case, it violates the expected python behaviour so that if `a == b` then `hash(a) == hash(b)`.

Fixes [#8416](https://github.com/ibis-project/ibis/issues/8416)