### PR TITLE
feat(api): make deferred objects hashable by their identity

### DIFF
--- a/ibis/common/deferred.py
+++ b/ibis/common/deferred.py
@@ -104,6 +104,9 @@ class Deferred(Slotted, Immutable, Final):
             f"The truth value of {self.__class__.__name__} objects is not defined"
         )
 
+    def __hash__(self):
+        return id(self)
+
     def __getitem__(self, name):
         return Deferred(Item(self, name))
 

--- a/ibis/common/tests/test_deferred.py
+++ b/ibis/common/tests/test_deferred.py
@@ -202,10 +202,21 @@ def test_deferred_supports_string_arguments():
     assert b.resolve({}) == "3.14"
 
 
-def test_deferred_object_are_not_hashable():
-    # since __eq__ is overloaded, Deferred objects are not hashable
-    with pytest.raises(TypeError, match="unhashable type"):
-        hash(_.a)
+def test_deferred_objects_are_hashable():
+    a = _.a
+    assert hash(a) == hash(a)
+
+    # Works in dicts
+    d = {a: 1, _.b: 2}
+    assert d[a] == 1
+    assert _.c not in d
+    assert _.a not in d  # hash by identity only
+
+    # Works in sets
+    s = {a, a, _.b}
+    assert len(s) == 2
+    assert a in s
+    assert _.a not in s  # hash by identity only
 
 
 def test_deferred_const():
@@ -539,11 +550,6 @@ def test_deferrable_repr():
         return x + 1
 
     assert repr(myfunc(_.a)) == "<test>"
-
-
-def test_deferred_set_raises():
-    with pytest.raises(TypeError, match="unhashable type"):
-        {_.a, _.b}  # noqa: B018
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #8416, an alternative to #8469.

In this case we hash `Deferred` objects as their identity. This means they can be used in sets or as dict keys, but only the exact instance will match in the hash lookup. Since `dict` and `set` check for object identity equality before dispatching to `__eq__` this means we can keep erroring nicely for `__bool__` (which I think we should) while still allowing `Deferred` objects to be hashable.

```python
In [1]: from ibis import _

In [2]: a = _.a

In [3]: d = {a: 1, _.b: 2}

In [4]: a in d
Out[4]: True

In [5]: _.a in d  # hash by identity only
Out[5]: False

In [6]: d[a]
Out[6]: 1
```

This implementation doesn't do weird things with the semantics of `__eq__`/`__hash__`/`__bool__` and should be innocuous to add. It's also what we _used to have_ before the refactor. The only downside is I'm not sure how useful it actually is. A few use cases this could help with:

- If we ever want to support a deferred API where the _key_ in a mapping may be deferred. Something like `ibis.map({_.x: 1})` for example.
- Deduplicating deferred expressions by identity (`list(set(exprs))`).
- Using a `dict` to associate metadata with a deferred expression `{deferred: some_metadata, other_deferred: other_metadata, ...}`.