### PR TITLE
fix(sql): overwrite the original sort key on successive order_by calls using the same key

### DIFF
--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -138,11 +138,14 @@ def merge_select_select(_, **kwargs):
     predicates = tuple(p.replace(subs, filter=ops.Value) for p in _.predicates)
     sort_keys = tuple(s.replace(subs, filter=ops.Value) for s in _.sort_keys)
 
+    unique_predicates = toolz.unique(_.parent.predicates + predicates)
+    unique_sort_keys = {s.expr: s for s in _.parent.sort_keys + sort_keys}
+
     return Select(
         _.parent.parent,
         selections=selections,
-        predicates=tuple(toolz.unique(_.parent.predicates + predicates)),
-        sort_keys=tuple(toolz.unique(_.parent.sort_keys + sort_keys)),
+        predicates=unique_predicates,
+        sort_keys=unique_sort_keys.values(),
     )
 
 

--- a/ibis/expr/tests/test_newrels.py
+++ b/ibis/expr/tests/test_newrels.py
@@ -1544,3 +1544,10 @@ def test_inner_join_convenience():
         # finish to evaluate the collisions
         result = fifth_join._finish().op()
         assert result == expected
+
+
+def test_subsequent_order_by_calls():
+    ts = t.order_by(ibis.desc("int_col")).order_by("int_col")
+    first = ops.Sort(t, [t.int_col.desc()]).to_expr()
+    second = ops.Sort(first, [first.int_col.asc()]).to_expr()
+    assert ts.equals(second)


### PR DESCRIPTION
After `the-epic-split` refactor we concatenated successive ordering keys (due to squashing selections) which can result in multiple order statements referring the same value expression. As turned out this can lead ambiguous behaviour based on the backend, so now we overwrite repeated order keys. 

For expression

```py
t.order_by(ibis.desc("a")).order_by("a")
```

Previously we compiled to:

```sql
SELECT t.a FROM t ORDER BY t.a DESC, t.a ASC
```

Now we compile to:

```sql
SELECT t.a FROM t ORDER BY t.a ASC
```

Fixes https://github.com/ibis-project/ibis/issues/8442