### PR TITLE
fix(duckdb): parenthesize argument to StructField operation to support field access on CASE statements

### DIFF
--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -11,11 +11,7 @@ from sqlglot.dialects import DuckDB
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.sql.compiler import (
-    NULL,
-    STAR,
-    SQLGlotCompiler,
-)
+from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler, paren
 from ibis.backends.sql.datatypes import DuckDBType
 
 _INTERVAL_SUFFIXES = {
@@ -401,3 +397,8 @@ class DuckDBCompiler(SQLGlotCompiler):
 
     def visit_StringConcat(self, op, *, arg):
         return reduce(lambda x, y: sge.DPipe(this=x, expression=y), arg)
+
+    def visit_StructField(self, op, *, arg, field):
+        return sge.Dot(
+            this=paren(arg), expression=sg.to_identifier(field, quoted=self.quoted)
+        )

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -399,6 +399,9 @@ class DuckDBCompiler(SQLGlotCompiler):
         return reduce(lambda x, y: sge.DPipe(this=x, expression=y), arg)
 
     def visit_StructField(self, op, *, arg, field):
-        return sge.Dot(
-            this=paren(arg), expression=sg.to_identifier(field, quoted=self.quoted)
-        )
+        if not isinstance(op.arg, (ops.Field, sge.Struct)):
+            # parenthesize anything that isn't a simple field access
+            return sge.Dot(
+                this=paren(arg), expression=sg.to_identifier(field, quoted=self.quoted)
+            )
+        return super().visit_StructField(op, arg=arg, field=field)

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -133,3 +133,10 @@ def test_collect_into_struct(alltypes):
     val = result.val
     assert len(val.loc[result.group == "0"].iat[0]["key"]) == 730
     assert len(val.loc[result.group == "1"].iat[0]["key"]) == 730
+
+
+def test_field_access_after_case(con):
+    s = ibis.struct({"a": 3})
+    x = ibis.case().when(True, s).else_(ibis.struct({"a": 4})).end()
+    y = x.a
+    assert con.to_pandas(y) == 3

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -10,6 +10,7 @@ from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
+from ibis.backends.tests.errors import PsycoPg2SyntaxError
 
 pytestmark = [
     pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
@@ -135,6 +136,9 @@ def test_collect_into_struct(alltypes):
     assert len(val.loc[result.group == "1"].iat[0]["key"]) == 730
 
 
+@pytest.mark.notimpl(
+    ["postgres"], reason="struct literals not implemented", raises=PsycoPg2SyntaxError
+)
 def test_field_access_after_case(con):
     s = ibis.struct({"a": 3})
     x = ibis.case().when(True, s).else_(ibis.struct({"a": 4})).end()

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -10,7 +10,11 @@ from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.backends.tests.errors import PsycoPg2InternalError, PsycoPg2SyntaxError
+from ibis.backends.tests.errors import (
+    PsycoPg2InternalError,
+    PsycoPg2SyntaxError,
+    Py4JJavaError,
+)
 
 pytestmark = [
     pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
@@ -144,6 +148,7 @@ def test_collect_into_struct(alltypes):
     reason="struct literals not implemented",
     raises=PsycoPg2InternalError,
 )
+@pytest.mark.notimpl(["flink"], raises=Py4JJavaError, reason="not implemented in ibis")
 def test_field_access_after_case(con):
     s = ibis.struct({"a": 3})
     x = ibis.case().when(True, s).else_(ibis.struct({"a": 4})).end()

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -10,7 +10,7 @@ from pytest import param
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.backends.tests.errors import PsycoPg2SyntaxError
+from ibis.backends.tests.errors import PsycoPg2InternalError, PsycoPg2SyntaxError
 
 pytestmark = [
     pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
@@ -138,6 +138,11 @@ def test_collect_into_struct(alltypes):
 
 @pytest.mark.notimpl(
     ["postgres"], reason="struct literals not implemented", raises=PsycoPg2SyntaxError
+)
+@pytest.mark.notimpl(
+    ["risingwave"],
+    reason="struct literals not implemented",
+    raises=PsycoPg2InternalError,
 )
 def test_field_access_after_case(con):
     s = ibis.struct({"a": 3})


### PR DESCRIPTION
Fixes #8485.