### PR TITLE
feat(chdb): implement chdb - the embedded clickhouse - backend

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -116,6 +116,10 @@ jobs:
               - geospatial
             additional_deps:
               - "duckdb==0.9.2"
+          - name: chdb
+            title: chDB
+            extras:
+              - chdb
           - name: clickhouse
             title: ClickHouse
             services:

--- a/ci/schema/chdb.sql
+++ b/ci/schema/chdb.sql
@@ -1,0 +1,96 @@
+-- NB: The paths in this file are all relative to /var/lib/clickhouse/user_files
+CREATE OR REPLACE TABLE ibis_testing.diamonds ENGINE = Log AS
+SELECT * FROM file('{parquet_dir}/diamonds.parquet', 'Parquet');
+
+CREATE OR REPLACE TABLE ibis_testing.batting ENGINE = Log AS
+SELECT * FROM file('{parquet_dir}/batting.parquet', 'Parquet');
+
+CREATE OR REPLACE TABLE ibis_testing.awards_players ENGINE = Log AS
+SELECT * FROM file('{parquet_dir}/awards_players.parquet', 'Parquet');
+
+CREATE OR REPLACE TABLE ibis_testing.functional_alltypes ENGINE = Log AS
+SELECT * REPLACE(CAST(timestamp_col AS Nullable(DateTime)) AS timestamp_col)
+FROM file('{parquet_dir}/functional_alltypes.parquet', 'Parquet');
+
+CREATE OR REPLACE TABLE ibis_testing.astronauts ENGINE = Log AS
+SELECT * FROM file('{parquet_dir}/astronauts.parquet', 'Parquet');
+
+CREATE OR REPLACE TABLE ibis_testing.tzone (
+    ts Nullable(DateTime),
+    key Nullable(String),
+    value Nullable(Float64)
+) ENGINE = Memory;
+
+CREATE OR REPLACE TABLE ibis_testing.array_types (
+    x Array(Nullable(Int64)),
+    y Array(Nullable(String)),
+    z Array(Nullable(Float64)),
+    grouper Nullable(String),
+    scalar_column Nullable(Float64),
+    multi_dim Array(Array(Nullable(Int64)))
+) ENGINE = Memory;
+
+-- INSERT INTO ibis_testing.array_types VALUES
+--     ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0, [[], [1, 2, 3], []]),
+--     ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0, []),
+--     ([6, NULL], ['f', NULL], [6.0, NULL], 'a', 3.0, [[], [], []]),
+--     ([NULL, 1, NULL], [NULL, 'a', NULL], [], 'b', 4.0, [[1], [2], [], [3, 4, 5]]),
+--     ([2, NULL, 3], ['b', NULL, 'c'], NULL, 'b', 5.0, []),
+--     ([4, NULL, NULL, 5], ['d', NULL, NULL, 'e'], [4.0, NULL, NULL, 5.0], 'c', 6.0, [[1, 2, 3]]);
+
+CREATE OR REPLACE TABLE ibis_testing.time_df1 (
+    time Int64,
+    value Nullable(Float64),
+    key Nullable(String)
+) ENGINE = Memory;
+-- INSERT INTO ibis_testing.time_df1 VALUES
+--     (1, 1.0, 'x'),
+--     (20, 20.0, 'x'),
+--     (30, 30.0, 'x'),
+--     (40, 40.0, 'x'),
+--     (50, 50.0, 'x');
+
+CREATE OR REPLACE TABLE ibis_testing.time_df2 (
+    time Int64,
+    value Nullable(Float64),
+    key Nullable(String)
+) ENGINE = Memory;
+-- INSERT INTO ibis_testing.time_df2 VALUES
+--     (19, 19.0, 'x'),
+--     (21, 21.0, 'x'),
+--     (39, 39.0, 'x'),
+--     (49, 49.0, 'x'),
+--     (1000, 1000.0, 'x');
+
+CREATE OR REPLACE TABLE ibis_testing.struct (
+    abc Tuple(
+        a Nullable(Float64),
+        b Nullable(String),
+        c Nullable(Int64)
+    )
+) ENGINE = Memory;
+
+-- NULL is the same as tuple(NULL, NULL, NULL) because clickhouse doesn't
+-- support Nullable(Tuple(...))
+-- INSERT INTO ibis_testing.struct VALUES
+--     (tuple(1.0, 'banana', 2)),
+--     (tuple(2.0, 'apple', 3)),
+--     (tuple(3.0, 'orange', 4)),
+--     (tuple(NULL, 'banana', 2)),
+--     (tuple(2.0, NULL, 3)),
+--     (tuple(NULL, NULL, NULL)),
+--     (tuple(3.0, 'orange', NULL));
+
+CREATE OR REPLACE TABLE ibis_testing.map (kv Map(String, Nullable(Int64))) ENGINE = Memory;
+
+-- INSERT INTO ibis_testing.map VALUES
+--     (map('a', 1, 'b', 2, 'c', 3)),
+--     (map('d', 4, 'e', 5, 'c', 6));
+
+CREATE OR REPLACE TABLE ibis_testing.win (g Nullable(String), x Int64, y Nullable(Int64)) ENGINE = Memory;
+-- INSERT INTO ibis_testing.win VALUES
+--     ('a', 0, 3),
+--     ('a', 1, 2),
+--     ('a', 2, 0),
+--     ('a', 3, 1),
+--     ('a', 4, 1);

--- a/ci/schema/chdb.sql
+++ b/ci/schema/chdb.sql
@@ -69,8 +69,6 @@ CREATE OR REPLACE TABLE ibis_testing.struct (
     )
 ) ENGINE = Log;
 
--- NULL is the same as tuple(NULL, NULL, NULL) because clickhouse doesn't
--- support Nullable(Tuple(...))
 INSERT INTO ibis_testing.struct VALUES
     (tuple(1.0, 'banana', 2)),
     (tuple(2.0, 'apple', 3)),

--- a/ci/schema/chdb.sql
+++ b/ci/schema/chdb.sql
@@ -19,7 +19,7 @@ CREATE OR REPLACE TABLE ibis_testing.tzone (
     ts Nullable(DateTime),
     key Nullable(String),
     value Nullable(Float64)
-) ENGINE = Memory;
+) ENGINE = Log;
 
 CREATE OR REPLACE TABLE ibis_testing.array_types (
     x Array(Nullable(Int64)),
@@ -28,39 +28,38 @@ CREATE OR REPLACE TABLE ibis_testing.array_types (
     grouper Nullable(String),
     scalar_column Nullable(Float64),
     multi_dim Array(Array(Nullable(Int64)))
-) ENGINE = Memory;
-
--- INSERT INTO ibis_testing.array_types VALUES
---     ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0, [[], [1, 2, 3], []]),
---     ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0, []),
---     ([6, NULL], ['f', NULL], [6.0, NULL], 'a', 3.0, [[], [], []]),
---     ([NULL, 1, NULL], [NULL, 'a', NULL], [], 'b', 4.0, [[1], [2], [], [3, 4, 5]]),
---     ([2, NULL, 3], ['b', NULL, 'c'], NULL, 'b', 5.0, []),
---     ([4, NULL, NULL, 5], ['d', NULL, NULL, 'e'], [4.0, NULL, NULL, 5.0], 'c', 6.0, [[1, 2, 3]]);
+) ENGINE = Log;
+INSERT INTO ibis_testing.array_types VALUES
+    ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0, [[], [1, 2, 3], []]),
+    ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0, []),
+    ([6, NULL], ['f', NULL], [6.0, NULL], 'a', 3.0, [[], [], []]),
+    ([NULL, 1, NULL], [NULL, 'a', NULL], [], 'b', 4.0, [[1], [2], [], [3, 4, 5]]),
+    ([2, NULL, 3], ['b', NULL, 'c'], NULL, 'b', 5.0, []),
+    ([4, NULL, NULL, 5], ['d', NULL, NULL, 'e'], [4.0, NULL, NULL, 5.0], 'c', 6.0, [[1, 2, 3]]);
 
 CREATE OR REPLACE TABLE ibis_testing.time_df1 (
     time Int64,
     value Nullable(Float64),
     key Nullable(String)
-) ENGINE = Memory;
--- INSERT INTO ibis_testing.time_df1 VALUES
---     (1, 1.0, 'x'),
---     (20, 20.0, 'x'),
---     (30, 30.0, 'x'),
---     (40, 40.0, 'x'),
---     (50, 50.0, 'x');
+) ENGINE = Log;
+INSERT INTO ibis_testing.time_df1 VALUES
+    (1, 1.0, 'x'),
+    (20, 20.0, 'x'),
+    (30, 30.0, 'x'),
+    (40, 40.0, 'x'),
+    (50, 50.0, 'x');
 
 CREATE OR REPLACE TABLE ibis_testing.time_df2 (
     time Int64,
     value Nullable(Float64),
     key Nullable(String)
-) ENGINE = Memory;
--- INSERT INTO ibis_testing.time_df2 VALUES
---     (19, 19.0, 'x'),
---     (21, 21.0, 'x'),
---     (39, 39.0, 'x'),
---     (49, 49.0, 'x'),
---     (1000, 1000.0, 'x');
+) ENGINE = Log;
+INSERT INTO ibis_testing.time_df2 VALUES
+    (19, 19.0, 'x'),
+    (21, 21.0, 'x'),
+    (39, 39.0, 'x'),
+    (49, 49.0, 'x'),
+    (1000, 1000.0, 'x');
 
 CREATE OR REPLACE TABLE ibis_testing.struct (
     abc Tuple(
@@ -68,29 +67,28 @@ CREATE OR REPLACE TABLE ibis_testing.struct (
         b Nullable(String),
         c Nullable(Int64)
     )
-) ENGINE = Memory;
+) ENGINE = Log;
 
 -- NULL is the same as tuple(NULL, NULL, NULL) because clickhouse doesn't
 -- support Nullable(Tuple(...))
--- INSERT INTO ibis_testing.struct VALUES
---     (tuple(1.0, 'banana', 2)),
---     (tuple(2.0, 'apple', 3)),
---     (tuple(3.0, 'orange', 4)),
---     (tuple(NULL, 'banana', 2)),
---     (tuple(2.0, NULL, 3)),
---     (tuple(NULL, NULL, NULL)),
---     (tuple(3.0, 'orange', NULL));
+INSERT INTO ibis_testing.struct VALUES
+    (tuple(1.0, 'banana', 2)),
+    (tuple(2.0, 'apple', 3)),
+    (tuple(3.0, 'orange', 4)),
+    (tuple(NULL, 'banana', 2)),
+    (tuple(2.0, NULL, 3)),
+    (tuple(NULL, NULL, NULL)),
+    (tuple(3.0, 'orange', NULL));
 
 CREATE OR REPLACE TABLE ibis_testing.map (kv Map(String, Nullable(Int64))) ENGINE = Memory;
-
--- INSERT INTO ibis_testing.map VALUES
---     (map('a', 1, 'b', 2, 'c', 3)),
---     (map('d', 4, 'e', 5, 'c', 6));
+INSERT INTO ibis_testing.map VALUES
+    (map('a', 1, 'b', 2, 'c', 3)),
+    (map('d', 4, 'e', 5, 'c', 6));
 
 CREATE OR REPLACE TABLE ibis_testing.win (g Nullable(String), x Int64, y Nullable(Int64)) ENGINE = Memory;
--- INSERT INTO ibis_testing.win VALUES
---     ('a', 0, 3),
---     ('a', 1, 2),
---     ('a', 2, 0),
---     ('a', 3, 1),
---     ('a', 4, 1);
+INSERT INTO ibis_testing.win VALUES
+    ('a', 0, 3),
+    ('a', 1, 2),
+    ('a', 2, 0),
+    ('a', 3, 1),
+    ('a', 4, 1);

--- a/ibis/backends/chdb/tests/conftest.py
+++ b/ibis/backends/chdb/tests/conftest.py
@@ -31,8 +31,6 @@ class TestConf(BackendTest):
     @property
     def native_bool(self) -> bool:
         return True
-        # [(value,)] = self.connection.con.query("SELECT true").result_set
-        # return isinstance(value, bool)
 
     @property
     def test_files(self) -> Iterable[Path]:
@@ -59,6 +57,7 @@ class TestConf(BackendTest):
         con.query(f"CREATE DATABASE {database} ENGINE = Atomic")
         con.query(f"USE {database}")
         for sql in self.ddl_script:
+            sql = sql.replace("\n", " ")
             con.query(sql)
 
     @staticmethod

--- a/ibis/backends/chdb/tests/conftest.py
+++ b/ibis/backends/chdb/tests/conftest.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any, Callable
+
+import pytest
+
+import ibis
+import ibis.expr.types as ir
+from ibis.backends.tests.base import BackendTest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+
+IBIS_TEST_CHDB_DB = os.environ.get("IBIS_TEST_DATA_DB", "ibis_testing")
+
+
+class TestConf(BackendTest):
+    check_dtype = False
+    supports_window_operations = False
+    returned_timestamp_unit = "s"
+    supported_to_timestamp_units = {"s"}
+    supports_floating_modulus = False
+    supports_json = False
+    force_sort = True
+    rounding_method = "half_to_even"
+    deps = ("chdb",)
+
+    @property
+    def native_bool(self) -> bool:
+        return True
+        # [(value,)] = self.connection.con.query("SELECT true").result_set
+        # return isinstance(value, bool)
+
+    @property
+    def test_files(self) -> Iterable[Path]:
+        return self.data_dir.joinpath("parquet").glob("*.parquet")
+
+    @property
+    def ddl_script(self) -> Iterable[str]:
+        parquet_dir = self.data_dir / "parquet"
+        for sql in super().ddl_script:
+            yield sql.format(parquet_dir=parquet_dir)
+
+    def _load_data(self, *, database: str = IBIS_TEST_CHDB_DB, **_) -> None:
+        """Load test data into a ClickHouse backend instance.
+
+        Parameters
+        ----------
+        data_dir
+            Location of test data
+        script_dir
+            Location of scripts defining schemas
+        """
+        con = self.connection.con
+
+        con.query(f"CREATE DATABASE {database} ENGINE = Atomic")
+        con.query(f"USE {database}")
+        for sql in self.ddl_script:
+            con.query(sql)
+
+    @staticmethod
+    def connect(*, tmpdir, worker_id, **kw: Any):
+        return ibis.chdb.connect()
+
+    @staticmethod
+    def greatest(f: Callable[..., ir.Value], *args: ir.Value) -> ir.Value:
+        if len(args) > 2:
+            raise NotImplementedError(
+                "Clickhouse does not support more than 2 arguments to greatest"
+            )
+        return f(*args)
+
+    @staticmethod
+    def least(f: Callable[..., ir.Value], *args: ir.Value) -> ir.Value:
+        if len(args) > 2:
+            raise NotImplementedError(
+                "Clickhouse does not support more than 2 arguments to least"
+            )
+        return f(*args)
+
+
+@pytest.fixture(scope="session")
+def con(tmp_path_factory, data_dir, worker_id):
+    return TestConf.load_data(data_dir, tmp_path_factory, worker_id).connection
+
+
+@pytest.fixture(scope="session")
+def alltypes(con):
+    return con.tables.functional_alltypes
+
+
+@pytest.fixture(scope="session")
+def df(alltypes):
+    return alltypes.execute()

--- a/ibis/backends/chdb/tests/conftest.py
+++ b/ibis/backends/chdb/tests/conftest.py
@@ -83,7 +83,8 @@ class TestConf(BackendTest):
 
 @pytest.fixture(scope="session")
 def con(tmp_path_factory, data_dir, worker_id):
-    return TestConf.load_data(data_dir, tmp_path_factory, worker_id).connection
+    conf = TestConf.load_data(data_dir, tmp_path_factory, worker_id)
+    return conf.connection
 
 
 @pytest.fixture(scope="session")

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -630,7 +630,8 @@ class ClickHouseCompiler(SQLGlotCompiler):
         )
 
         if step_value == 0:
-            return self.f.array()
+            dtype = dt.Array(dt.timestamp)
+            return self.cast(self.f.array(), dtype)
 
         return self.f.arrayMap(
             func, self.f.range(0, self.f.timestampDiff(unit, start, stop), step_value)

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -328,6 +328,8 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
             if (timezone := dtype.timezone) is not None:
                 args.append(timezone)
+            else:
+                args.append("UTC")
 
             return self.f[funcname](*args)
         elif dtype.is_date():

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -253,11 +253,11 @@ def pytest_collection_modifyitems(session, config, items):
                         f"""Unrecognize backend(s) {backend} passed to {name} marker in
 {item.path}::{item.originalname}"""
                     )
-                if "clickhouse" in marked_backends:
-                    chdb_mark = getattr(pytest.mark, mark.name)(
-                        "chdb", *mark.args[1:], **mark.kwargs
-                    )
-                    additional_markers.append((item, [chdb_mark]))
+                # if "clickhouse" in marked_backends:
+                #     chdb_mark = getattr(pytest.mark, mark.name)(
+                #         "chdb", *mark.args[1:], **mark.kwargs
+                #     )
+                #     additional_markers.append((item, [chdb_mark]))
 
         # add the backend marker to any tests are inside "ibis/backends"
         parts = item.path.parts

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -245,7 +245,7 @@ def pytest_collection_modifyitems(session, config, items):
     unrecognized_backends = set()
     for item in items:
         # Yell loudly if unrecognized backend in notimpl, notyet or never
-        for name in ("notimpl", "notyet", "never"):
+        for name in ("notimpl", "notyet", "never", "broken"):
             for mark in item.iter_markers(name=name):
                 marked_backends = util.promote_list(mark.args[0])
                 if backend := set(marked_backends).difference(ALL_BACKENDS):

--- a/ibis/backends/tests/errors.py
+++ b/ibis/backends/tests/errors.py
@@ -29,6 +29,11 @@ except ImportError:
 
 
 try:
+    from chdb import ChdbError
+except ImportError:
+    ChdbError = None
+
+try:
     from pyexasol.exceptions import ExaQueryError
 except ImportError:
     ExaQueryError = None

--- a/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/chdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_cte_refs_in_topo_order/chdb/out.sql
@@ -1,0 +1,20 @@
+WITH "t1" AS (
+  SELECT
+    "t0"."key"
+  FROM "leaf" AS "t0"
+  WHERE
+    TRUE
+)
+SELECT
+  "t3"."key"
+FROM "t1" AS "t3"
+INNER JOIN "t1" AS "t4"
+  ON "t3"."key" = "t4"."key"
+INNER JOIN (
+  SELECT
+    "t3"."key"
+  FROM "t1" AS "t3"
+  INNER JOIN "t1" AS "t4"
+    ON "t3"."key" = "t4"."key"
+) AS "t6"
+  ON "t3"."key" = "t6"."key"

--- a/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/chdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_group_by_has_index/chdb/out.sql
@@ -1,0 +1,38 @@
+SELECT
+  CASE "t0"."continent"
+    WHEN 'NA'
+    THEN 'North America'
+    WHEN 'SA'
+    THEN 'South America'
+    WHEN 'EU'
+    THEN 'Europe'
+    WHEN 'AF'
+    THEN 'Africa'
+    WHEN 'AS'
+    THEN 'Asia'
+    WHEN 'OC'
+    THEN 'Oceania'
+    WHEN 'AN'
+    THEN 'Antarctica'
+    ELSE 'Unknown continent'
+  END AS "cont",
+  SUM("t0"."population") AS "total_pop"
+FROM "countries" AS "t0"
+GROUP BY
+  CASE "t0"."continent"
+    WHEN 'NA'
+    THEN 'North America'
+    WHEN 'SA'
+    THEN 'South America'
+    WHEN 'EU'
+    THEN 'Europe'
+    WHEN 'AF'
+    THEN 'Africa'
+    WHEN 'AS'
+    THEN 'Asia'
+    WHEN 'OC'
+    THEN 'Oceania'
+    WHEN 'AN'
+    THEN 'Antarctica'
+    ELSE 'Unknown continent'
+  END

--- a/ibis/backends/tests/snapshots/test_sql/test_isin_bug/chdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_isin_bug/chdb/out.sql
@@ -1,0 +1,9 @@
+SELECT
+  "t0"."x" IN (
+    SELECT
+      "t0"."x"
+    FROM "t" AS "t0"
+    WHERE
+      "t0"."x" > 2
+  ) AS "InSubquery(x)"
+FROM "t" AS "t0"

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/chdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/chdb/out.sql
@@ -1,0 +1,68 @@
+WITH "t5" AS (
+  SELECT
+    "t4"."field_of_study",
+    any("t4"."diff") AS "diff"
+  FROM (
+    SELECT
+      "t3"."field_of_study",
+      "t3"."years",
+      "t3"."degrees",
+      "t3"."earliest_degrees",
+      "t3"."latest_degrees",
+      "t3"."latest_degrees" - "t3"."earliest_degrees" AS "diff"
+    FROM (
+      SELECT
+        "t2"."field_of_study",
+        "t2"."years",
+        "t2"."degrees",
+        FIRST_VALUE("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+        LAST_VALUE("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
+      FROM (
+        SELECT
+          "t1"."field_of_study",
+          CAST("t1"."__pivoted__".1 AS Nullable(String)) AS "years",
+          CAST("t1"."__pivoted__".2 AS Nullable(Int64)) AS "degrees"
+        FROM (
+          SELECT
+            "t0"."field_of_study",
+            arrayJoin(
+              [CAST(tuple('1970-71', "t0"."1970-71") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('1975-76', "t0"."1975-76") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('1980-81', "t0"."1980-81") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('1985-86', "t0"."1985-86") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('1990-91', "t0"."1990-91") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('1995-96', "t0"."1995-96") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2000-01', "t0"."2000-01") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2005-06', "t0"."2005-06") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2010-11', "t0"."2010-11") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2011-12', "t0"."2011-12") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2012-13', "t0"."2012-13") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2013-14', "t0"."2013-14") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2014-15', "t0"."2014-15") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2015-16', "t0"."2015-16") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2016-17', "t0"."2016-17") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2017-18', "t0"."2017-18") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2018-19', "t0"."2018-19") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64))), CAST(tuple('2019-20', "t0"."2019-20") AS Tuple("years" Nullable(String), "degrees" Nullable(Int64)))]
+            ) AS "__pivoted__"
+          FROM "humanities" AS "t0"
+        ) AS "t1"
+      ) AS "t2"
+    ) AS "t3"
+  ) AS "t4"
+  GROUP BY
+    "t4"."field_of_study"
+)
+SELECT
+  "t11"."field_of_study",
+  "t11"."diff"
+FROM (
+  SELECT
+    *
+  FROM (
+    SELECT
+      "t6"."field_of_study",
+      "t6"."diff"
+    FROM "t5" AS "t6"
+    ORDER BY
+      "t6"."diff" DESC
+    LIMIT 10
+  ) AS "t9"
+  UNION ALL
+  SELECT
+    *
+  FROM (
+    SELECT
+      "t6"."field_of_study",
+      "t6"."diff"
+    FROM "t5" AS "t6"
+    WHERE
+      "t6"."diff" < 0
+    ORDER BY
+      "t6"."diff" ASC
+    LIMIT 10
+  ) AS "t10"
+) AS "t11"

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -14,6 +14,7 @@ import ibis.expr.datatypes as dt
 from ibis import _
 from ibis import literal as L
 from ibis.backends.tests.errors import (
+    ChdbError,
     ClickHouseDatabaseError,
     ExaQueryError,
     GoogleBadRequest,
@@ -53,6 +54,8 @@ aggregate_test_params = [
                     "postgres",
                     "risingwave",
                     "clickhouse",
+                    "chdb",
+                    "chdb",
                     "impala",
                     "duckdb",
                     "polars",
@@ -85,6 +88,8 @@ aggregate_test_params = [
                 [
                     "bigquery",
                     "clickhouse",
+                    "chdb",
+                    "chdb",
                     "datafusion",
                     "impala",
                     "mysql",
@@ -203,6 +208,8 @@ def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
     [
         "bigquery",
         "clickhouse",
+        "chdb",
+        "chdb",
         "datafusion",
         "duckdb",
         "impala",
@@ -418,6 +425,8 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     [
                         "bigquery",
                         "clickhouse",
+                        "chdb",
+                        "chdb",
                         "datafusion",
                         "impala",
                         "mysql",
@@ -923,8 +932,8 @@ def test_quantile(
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(
-                    ["clickhouse"],
-                    raises=(ValueError, AttributeError),
+                    ["clickhouse", "chdb"],
+                    raises=ValueError,
                     reason="ClickHouse only implements `sample` correlation coefficient",
                 ),
                 pytest.mark.notimpl(
@@ -1011,7 +1020,7 @@ def test_quantile(
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(
-                    ["clickhouse"],
+                    ["clickhouse", "chdb"],
                     raises=ValueError,
                     reason="ClickHouse only implements `sample` correlation coefficient",
                 ),
@@ -1101,8 +1110,8 @@ def test_median(alltypes, df):
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.notyet(
-    ["clickhouse"],
-    raises=ClickHouseDatabaseError,
+    ["clickhouse", "chdb"],
+    raises=(ClickHouseDatabaseError, ChdbError),
     reason="doesn't support median of strings",
 )
 @pytest.mark.broken(
@@ -1314,6 +1323,8 @@ def test_topk_filter_op(con, alltypes, df, result_fn, expected_fn):
     [
         "bigquery",
         "clickhouse",
+        "chdb",
+        "chdb",
         "datafusion",
         "duckdb",
         "impala",
@@ -1355,6 +1366,8 @@ def test_aggregate_list_like(backend, alltypes, df, agg_fn):
     [
         "bigquery",
         "clickhouse",
+        "chdb",
+        "chdb",
         "datafusion",
         "duckdb",
         "impala",
@@ -1470,7 +1483,7 @@ def test_grouped_case(backend, con):
 @pytest.mark.notimpl(["exasol"], raises=ExaQueryError)
 @pytest.mark.notyet(["flink"], raises=Py4JJavaError)
 @pytest.mark.notyet(["impala"], raises=ImpalaHiveServer2Error)
-@pytest.mark.notyet(["clickhouse"], raises=ClickHouseDatabaseError)
+@pytest.mark.notyet(["clickhouse", "chdb"], raises=(ClickHouseDatabaseError, ChdbError))
 @pytest.mark.notyet(["druid"], raises=PyDruidProgrammingError)
 @pytest.mark.notyet(["snowflake"], raises=SnowflakeProgrammingError)
 @pytest.mark.notyet(["trino"], raises=TrinoUserError)

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -23,6 +23,7 @@ def test_version(backend):
     [
         "polars",
         "clickhouse",
+        "chdb",
         "sqlite",
         "dask",
         "exasol",

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -17,6 +17,7 @@ import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis.backends.tests.errors import (
+    ChdbError,
     ClickHouseDatabaseError,
     GoogleBadRequest,
     ImpalaHiveServer2Error,
@@ -1056,7 +1057,9 @@ def test_range_start_stop_step(con, start, stop, step):
 @pytest.mark.parametrize("stop", [-7, 0, 7])
 @pytest.mark.parametrize("start", [-7, 0, 7])
 @pytest.mark.notyet(
-    ["clickhouse"], raises=ClickHouseDatabaseError, reason="not supported upstream"
+    ["clickhouse", "chdb"],
+    raises=(ClickHouseDatabaseError, ChdbError),
+    reason="not supported upstream",
 )
 @pytest.mark.notyet(
     ["datafusion"], raises=com.OperationNotDefinedError, reason="not supported upstream"
@@ -1227,7 +1230,7 @@ timestamp_range_tzinfos = pytest.mark.parametrize(
                 pytest.mark.notyet(["polars"], raises=com.UnsupportedOperationError),
                 pytest.mark.notyet(["bigquery"], raises=GoogleBadRequest),
                 pytest.mark.notyet(
-                    ["clickhouse", "snowflake"],
+                    ["clickhouse", "chdb", "snowflake"],
                     raises=com.UnsupportedOperationError,
                 ),
                 pytest.mark.notimpl(
@@ -1276,7 +1279,7 @@ def test_timestamp_range(con, start, stop, step, freq, tzinfo):
                 pytest.mark.notyet(["polars"], raises=com.UnsupportedOperationError),
                 pytest.mark.notyet(["bigquery"], raises=GoogleBadRequest),
                 pytest.mark.notyet(
-                    ["clickhouse", "snowflake"],
+                    ["clickhouse", "chdb", "snowflake"],
                     raises=com.UnsupportedOperationError,
                 ),
                 pytest.mark.notyet(

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -295,7 +295,7 @@ def test_unnest_complex(backend):
     "pyspark", reason="pyspark throws away nulls in collect_list", raises=AssertionError
 )
 @pytest.mark.never(
-    "clickhouse",
+    ["clickhouse", "chdb"],
     reason="clickhouse throws away nulls in groupArray",
     raises=AssertionError,
 )
@@ -650,8 +650,8 @@ def test_array_remove(con, a):
     reason="BigQuery doesn't support arrays with null elements",
 )
 @pytest.mark.notyet(
-    ["clickhouse"],
-    raises=(AssertionError, TypeError),
+    ["clickhouse", "chdb"],
+    raises=AssertionError,
     reason="clickhouse doesn't support nullable array types",
 )
 @pytest.mark.notyet(
@@ -858,8 +858,8 @@ def test_zip(backend):
 @builtin_array
 @array_zip_notimpl
 @pytest.mark.notyet(
-    "clickhouse",
-    raises=ClickHouseDatabaseError,
+    ["clickhouse", "chdb"],
+    raises=(ClickHouseDatabaseError, ChdbError),
     reason="clickhouse nested types can't be null",
 )
 @pytest.mark.never(
@@ -968,7 +968,7 @@ def flatten_data():
             id="nulls_only",
             marks=[
                 pytest.mark.notyet(
-                    ["clickhouse"],
+                    ["clickhouse", "chdb"],
                     reason="Arrays are never nullable",
                     raises=AssertionError,
                 )
@@ -980,7 +980,7 @@ def flatten_data():
             id="mixed_nulls",
             marks=[
                 pytest.mark.notyet(
-                    ["clickhouse"],
+                    ["clickhouse", "chdb"],
                     reason="Arrays are never nullable",
                     raises=AssertionError,
                 )

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -244,6 +244,7 @@ _LIMIT = {
 
 @pytest.mark.notimpl(["datafusion", "mssql"])
 @pytest.mark.never(["dask", "pandas"], reason="dask and pandas do not support SQL")
+@pytest.mark.never("chdb")  # flaky python abort
 def test_sql(backend, con):
     # execute the expression using SQL query
     table = backend.format_table("functional_alltypes")

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -234,7 +234,7 @@ def test_dot_sql_reuse_alias_with_different_types(backend, alltypes, df):
     backend.assert_series_equal(foo2.x.execute(), expected2)
 
 
-_NO_SQLGLOT_DIALECT = ("pandas", "dask")
+_NO_SQLGLOT_DIALECT = ("pandas", "dask", "chdb")
 no_sqlglot_dialect = [
     param(dialect, marks=pytest.mark.xfail) for dialect in sorted(_NO_SQLGLOT_DIALECT)
 ]

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -19,6 +19,7 @@ import ibis.selectors as s
 from ibis import _
 from ibis.backends.conftest import is_older_than
 from ibis.backends.tests.errors import (
+    ChdbError,
     ClickHouseDatabaseError,
     ExaQueryError,
     GoogleBadRequest,
@@ -63,6 +64,7 @@ def test_null_literal(con, backend):
 BOOLEAN_BACKEND_TYPE = {
     "bigquery": "BOOL",
     "clickhouse": "Bool",
+    "chdb": "Bool",
     "impala": "BOOLEAN",
     "snowflake": "BOOLEAN",
     "sqlite": "integer",
@@ -154,6 +156,7 @@ def test_isna(backend, alltypes, col, value, filt):
                     [
                         "bigquery",
                         "clickhouse",
+                        "chdb",
                         "datafusion",
                         "duckdb",
                         "impala",
@@ -1377,7 +1380,8 @@ def test_try_cast(con, from_val, to_type, expected):
             "int",
             marks=[
                 pytest.mark.never(
-                    ["clickhouse", "pyspark", "flink"], reason="casts to 1672531200"
+                    ["clickhouse", "chdb", "pyspark", "flink"],
+                    reason="casts to 1672531200",
                 ),
                 pytest.mark.notyet(["bigquery"], raises=GoogleBadRequest),
                 pytest.mark.notyet(["snowflake"], raises=SnowflakeProgrammingError),
@@ -1788,6 +1792,7 @@ def test_sample_memtable(con, backend):
     [
         "bigquery",
         "clickhouse",
+        "chdb",
         "datafusion",
         "druid",
         "flink",
@@ -1837,7 +1842,7 @@ def test_simple_memtable_construct(con):
     # we can't generically check for specific sql, even with a snapshot,
     # because memtables have a unique name per table per process, so smoke test
     # it
-    assert str(ibis.to_sql(expr, dialect=con.name)).startswith("SELECT")
+    assert con.compile(expr).startswith("SELECT")
 
 
 def test_select_mutate_with_dict(backend):

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -33,6 +33,13 @@ mark_notyet_snowflake = pytest.mark.notyet(
     "snowflake", reason="map keys must be strings"
 )
 
+mark_notyet_clickhouse_nullable = pytest.mark.notyet(
+    ["clickhouse", "chdb"], reason="nested types can't be null"
+)
+mark_notyet_clickhouse_keytypes = pytest.mark.notyet(
+    ["clickhouse", "chdb"], reason="only supports str,int,bool,timestamp keys"
+)
+
 mark_notimpl_risingwave_hstore = pytest.mark.notimpl(
     ["risingwave"],
     reason="function hstore(character varying[], character varying[]) does not exist",
@@ -193,9 +200,7 @@ keys = pytest.mark.parametrize(
         pytest.param(
             [1.0, 2.0],
             marks=[
-                pytest.mark.notyet(
-                    "clickhouse", reason="only supports str,int,bool,timestamp keys"
-                ),
+                mark_notyet_clickhouse_keytypes,
                 mark_notyet_postgres,
                 mark_notyet_snowflake,
             ],
@@ -209,9 +214,7 @@ keys = pytest.mark.parametrize(
         pytest.param(
             [ibis.date(1, 2, 3), ibis.date(4, 5, 6)],
             marks=[
-                pytest.mark.notyet(
-                    "clickhouse", reason="only supports str,int,bool,timestamp keys"
-                ),
+                mark_notyet_clickhouse_keytypes,
                 pytest.mark.notimpl(
                     ["pandas", "dask"], reason="DateFromYMD isn't implemented"
                 ),
@@ -223,9 +226,7 @@ keys = pytest.mark.parametrize(
         pytest.param(
             [[1, 2], [3, 4]],
             marks=[
-                pytest.mark.notyet(
-                    "clickhouse", reason="only supports str,int,bool,timestamp keys"
-                ),
+                mark_notyet_clickhouse_keytypes,
                 pytest.mark.notyet(["pandas", "dask"]),
                 mark_notyet_postgres,
                 mark_notyet_snowflake,
@@ -235,9 +236,7 @@ keys = pytest.mark.parametrize(
         pytest.param(
             [ibis.struct(dict(a=1)), ibis.struct(dict(a=2))],
             marks=[
-                pytest.mark.notyet(
-                    "clickhouse", reason="only supports str,int,bool,timestamp keys"
-                ),
+                mark_notyet_clickhouse_keytypes,
                 pytest.mark.notyet(["pandas", "dask"]),
                 mark_notyet_postgres,
                 pytest.mark.notyet(
@@ -298,7 +297,7 @@ values = pytest.mark.parametrize(
         pytest.param(
             [[1, 2], [3, 4]],
             marks=[
-                pytest.mark.notyet("clickhouse", reason="nested types can't be null"),
+                mark_notyet_clickhouse_nullable,
                 mark_notyet_postgres,
             ],
             id="array",
@@ -306,7 +305,7 @@ values = pytest.mark.parametrize(
         pytest.param(
             [ibis.struct(dict(a=1)), ibis.struct(dict(a=2))],
             marks=[
-                pytest.mark.notyet("clickhouse", reason="nested types can't be null"),
+                mark_notyet_clickhouse_nullable,
                 mark_notyet_postgres,
             ],
             id="struct",

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -46,6 +46,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "INT64",
                 "clickhouse": "UInt8",
+                "chdb": "UInt8",
                 "impala": "TINYINT",
                 "snowflake": "INTEGER",
                 "sqlite": "integer",
@@ -62,6 +63,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "INT64",
                 "clickhouse": "UInt8",
+                "chdb": "UInt8",
                 "impala": "TINYINT",
                 "snowflake": "INTEGER",
                 "sqlite": "integer",
@@ -78,6 +80,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "INT64",
                 "clickhouse": "UInt8",
+                "chdb": "UInt8",
                 "impala": "TINYINT",
                 "snowflake": "INTEGER",
                 "sqlite": "integer",
@@ -94,6 +97,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "INT64",
                 "clickhouse": "UInt8",
+                "chdb": "UInt8",
                 "impala": "TINYINT",
                 "snowflake": "INTEGER",
                 "sqlite": "integer",
@@ -110,6 +114,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "INT64",
                 "clickhouse": "UInt8",
+                "chdb": "UInt8",
                 "impala": "TINYINT",
                 "snowflake": "INTEGER",
                 "sqlite": "integer",
@@ -126,6 +131,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "INT64",
                 "clickhouse": "UInt8",
+                "chdb": "UInt8",
                 "impala": "TINYINT",
                 "snowflake": "INTEGER",
                 "sqlite": "integer",
@@ -142,6 +148,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "INT64",
                 "clickhouse": "UInt8",
+                "chdb": "UInt8",
                 "impala": "TINYINT",
                 "snowflake": "INTEGER",
                 "sqlite": "integer",
@@ -158,6 +165,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "INT64",
                 "clickhouse": "UInt8",
+                "chdb": "UInt8",
                 "impala": "TINYINT",
                 "snowflake": "INTEGER",
                 "sqlite": "integer",
@@ -174,6 +182,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "FLOAT64",
                 "clickhouse": "Float64",
+                "chdb": "Float64",
                 "impala": "DECIMAL(2,1)",
                 "snowflake": "INTEGER",
                 "sqlite": "real",
@@ -202,6 +211,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "FLOAT64",
                 "clickhouse": "Float64",
+                "chdb": "Float64",
                 "impala": "DECIMAL(2,1)",
                 "snowflake": "INTEGER",
                 "sqlite": "real",
@@ -218,6 +228,7 @@ from ibis.expr import datatypes as dt
             {
                 "bigquery": "FLOAT64",
                 "clickhouse": "Float64",
+                "chdb": "Float64",
                 "impala": "DECIMAL(2,1)",
                 "snowflake": "INTEGER",
                 "sqlite": "real",
@@ -303,6 +314,7 @@ def test_numeric_literal(con, backend, expr, expected_types):
                 "pyspark": decimal.Decimal("1.1"),
                 "mysql": decimal.Decimal("1.1"),
                 "clickhouse": decimal.Decimal("1.1"),
+                "chdb": decimal.Decimal("1.1"),
                 "dask": decimal.Decimal("1.1"),
                 "mssql": decimal.Decimal("1.1"),
                 "druid": decimal.Decimal("1.1"),
@@ -313,6 +325,7 @@ def test_numeric_literal(con, backend, expr, expected_types):
             {
                 "bigquery": "NUMERIC",
                 "clickhouse": "Decimal(38, 9)",
+                "chdb": "Decimal(38, 9)",
                 "snowflake": "DECIMAL",
                 "impala": "DECIMAL(38,9)",
                 "sqlite": "real",
@@ -339,11 +352,13 @@ def test_numeric_literal(con, backend, expr, expected_types):
                 "clickhouse": decimal.Decimal(
                     "1.10000000000000003193790845333396190208"
                 ),
+                "chdb": decimal.Decimal("1.10000000000000003193790845333396190208"),
                 "oracle": 1.1,
             },
             {
                 "bigquery": "BIGNUMERIC",
                 "clickhouse": "Decimal(76, 38)",
+                "chdb": "Decimal(76, 38)",
                 "sqlite": "real",
                 "trino": "decimal(2,1)",
                 "duckdb": "DECIMAL(18,3)",

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -13,6 +13,7 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.backends.tests.errors import (
+    ChdbError,
     ClickHouseDatabaseError,
     OracleDatabaseError,
     PsycoPg2InternalError,
@@ -30,6 +31,7 @@ from ibis.common.annotations import ValidationError
             {
                 "bigquery": "STRING",
                 "clickhouse": "String",
+                "chdb": "String",
                 "snowflake": "VARCHAR",
                 "sqlite": "text",
                 "trino": "varchar(6)",
@@ -46,6 +48,7 @@ from ibis.common.annotations import ValidationError
             {
                 "bigquery": "STRING",
                 "clickhouse": "String",
+                "chdb": "String",
                 "snowflake": "VARCHAR",
                 "sqlite": "text",
                 "trino": "varchar(7)",
@@ -74,6 +77,7 @@ from ibis.common.annotations import ValidationError
             {
                 "bigquery": "STRING",
                 "clickhouse": "String",
+                "chdb": "String",
                 "snowflake": "VARCHAR",
                 "sqlite": "text",
                 "trino": "varchar(7)",
@@ -995,6 +999,11 @@ def test_re_split_column(alltypes):
         "bigquery",
     ],
     raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notyet(
+    ["chdb"],
+    raises=ChdbError,
+    reason="clickhouse only supports pattern constants",
 )
 @pytest.mark.notyet(
     ["clickhouse"],

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -331,7 +331,7 @@ PANDAS_UNITS = {
             "ms",
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse", "mysql", "sqlite", "datafusion", "exasol"],
+                    ["clickhouse", "chdb", "mysql", "sqlite", "datafusion", "exasol"],
                     raises=com.UnsupportedOperationError,
                 ),
                 pytest.mark.broken(
@@ -345,7 +345,15 @@ PANDAS_UNITS = {
             "us",
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse", "mysql", "sqlite", "trino", "datafusion", "exasol"],
+                    [
+                        "clickhouse",
+                        "chdb",
+                        "mysql",
+                        "sqlite",
+                        "trino",
+                        "datafusion",
+                        "exasol",
+                    ],
                     raises=com.UnsupportedOperationError,
                 ),
                 pytest.mark.broken(
@@ -367,6 +375,7 @@ PANDAS_UNITS = {
                     [
                         "bigquery",
                         "clickhouse",
+                        "chdb",
                         "duckdb",
                         "impala",
                         "mysql",
@@ -544,7 +553,7 @@ def test_date_truncate(backend, alltypes, df, unit):
             pd.Timedelta,
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse"], raises=com.UnsupportedOperationError
+                    ["clickhouse", "chdb"], raises=com.UnsupportedOperationError
                 ),
                 pytest.mark.broken(
                     ["flink"],
@@ -563,7 +572,7 @@ def test_date_truncate(backend, alltypes, df, unit):
             pd.Timedelta,
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse"], raises=com.UnsupportedOperationError
+                    ["clickhouse", "chdb"], raises=com.UnsupportedOperationError
                 ),
                 pytest.mark.notimpl(
                     ["trino"],
@@ -919,7 +928,7 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     reason="alltypes.timestamp_col is represented as string",
                 ),
                 pytest.mark.broken(
-                    ["clickhouse"],
+                    ["clickhouse", "chdb"],
                     raises=AssertionError,
                     reason="DateTime column overflows, should use DateTime64",
                 ),
@@ -1003,7 +1012,7 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
                     reason="unsupported operand type(s) for -: 'StringColumn' and 'Timedelta'",
                 ),
                 pytest.mark.broken(
-                    ["clickhouse"],
+                    ["clickhouse", "chdb"],
                     raises=AssertionError,
                     reason="DateTime column overflows, should use DateTime64",
                 ),
@@ -1291,7 +1300,7 @@ unit_factors = {"s": 10**9, "ms": 10**6, "us": 10**3, "ns": 1}
                     reason="PySpark backend does not support timestamp from unix time with unit ms. Supported unit is s.",
                 ),
                 pytest.mark.notimpl(
-                    ["clickhouse"],
+                    ["clickhouse", "chdb"],
                     raises=com.UnsupportedOperationError,
                     reason="`ms` unit is not supported!",
                 ),
@@ -1306,7 +1315,7 @@ unit_factors = {"s": 10**9, "ms": 10**6, "us": 10**3, "ns": 1}
                     reason="PySpark backend does not support timestamp from unix time with unit us. Supported unit is s.",
                 ),
                 pytest.mark.notimpl(
-                    ["duckdb", "mssql", "clickhouse"],
+                    ["duckdb", "mssql", "clickhouse", "chdb"],
                     raises=com.UnsupportedOperationError,
                     reason="`us` unit is not supported!",
                 ),
@@ -1326,7 +1335,7 @@ unit_factors = {"s": 10**9, "ms": 10**6, "us": 10**3, "ns": 1}
                     reason="PySpark backend does not support timestamp from unix time with unit ms. Supported unit is s.",
                 ),
                 pytest.mark.notimpl(
-                    ["duckdb", "mssql", "clickhouse"],
+                    ["duckdb", "mssql", "clickhouse", "chdb"],
                     raises=com.UnsupportedOperationError,
                     reason="`ms` unit is not supported!",
                 ),
@@ -1420,6 +1429,7 @@ def test_integer_to_timestamp(backend, con, unit):
         "dask",
         "pandas",
         "clickhouse",
+        "chdb",
         "sqlite",
         "datafusion",
         "mssql",
@@ -1579,6 +1589,7 @@ def test_today_from_projection(alltypes):
 DATE_BACKEND_TYPES = {
     "bigquery": "DATE",
     "clickhouse": "Date",
+    "chdb": "Date",
     "duckdb": "DATE",
     "flink": "DATE NOT NULL",
     "impala": "DATE",
@@ -1611,7 +1622,8 @@ def test_date_literal(con, backend):
 
 TIMESTAMP_BACKEND_TYPES = {
     "bigquery": "DATETIME",
-    "clickhouse": "DateTime",
+    "clickhouse": "DateTime64(0, 'UTC')",
+    "chdb": "DateTime64(0, 'UTC')",
     "impala": "TIMESTAMP",
     "snowflake": "TIMESTAMP_NTZ",
     "sqlite": "text",
@@ -1706,7 +1718,7 @@ TIME_BACKEND_TYPES = {
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.notyet(
-    ["clickhouse", "impala", "exasol"], raises=com.OperationNotDefinedError
+    ["clickhouse", "chdb", "impala", "exasol"], raises=com.OperationNotDefinedError
 )
 @pytest.mark.notimpl(["druid"], raises=com.OperationNotDefinedError)
 def test_time_literal(con, backend):
@@ -1722,7 +1734,7 @@ def test_time_literal(con, backend):
 
 
 @pytest.mark.notyet(
-    ["clickhouse", "impala"],
+    ["clickhouse", "chdb", "impala"],
     raises=com.OperationNotDefinedError,
     reason="backend doesn't have a time datatype",
 )
@@ -1769,6 +1781,7 @@ def test_extract_time_from_timestamp(con, microsecond):
 INTERVAL_BACKEND_TYPES = {
     "bigquery": "INTERVAL",
     "clickhouse": "IntervalSecond",
+    "chdb": "IntervalSecond",
     "sqlite": "integer",
     "trino": "interval day to second",
     "duckdb": "INTERVAL",
@@ -2213,7 +2226,7 @@ def test_delta(con, start, end, unit, expected):
             "50ms",
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse"],
+                    ["clickhouse", "chdb"],
                     raises=com.UnsupportedOperationError,
                     reason="backend doesn't support sub-second interval precision",
                 ),
@@ -2410,7 +2423,7 @@ def test_time_literal_sql(dialect, snapshot, micros):
             "9999-01-02",
             marks=[
                 pytest.mark.broken(
-                    ["clickhouse"],
+                    ["clickhouse", "chdb"],
                     raises=AssertionError,
                     reason="clickhouse doesn't support dates after 2149-06-06",
                 ),
@@ -2429,7 +2442,7 @@ def test_time_literal_sql(dialect, snapshot, micros):
             id="small",
             marks=[
                 pytest.mark.broken(
-                    ["clickhouse"],
+                    ["clickhouse", "chdb"],
                     raises=AssertionError,
                     reason="clickhouse doesn't support dates before the UNIX epoch",
                 ),
@@ -2444,7 +2457,7 @@ def test_time_literal_sql(dialect, snapshot, micros):
         ),
         param(
             "2150-01-01",
-            marks=pytest.mark.broken(["clickhouse"], raises=AssertionError),
+            marks=pytest.mark.broken(["clickhouse", "chdb"], raises=AssertionError),
             id="medium",
         ),
     ],

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -161,6 +161,7 @@ class Options(Config):
     graphviz_repr: bool = False
     default_backend: Optional[Any] = None
     sql: SQL = SQL()
+    chdb: Optional[Config] = None
     clickhouse: Optional[Config] = None
     dask: Optional[Config] = None
     impala: Optional[Config] = None

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -30,7 +30,7 @@ class TimestampTruncate(Value):
     unit: IntervalUnit
 
     shape = rlz.shape_like("arg")
-    dtype = dt.timestamp
+    dtype = rlz.dtype_like("arg")
 
 
 @public

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -375,6 +375,8 @@ def to_sql(
         else:
             dialect = backend.dialect
     else:
+        if dialect == "chdb":
+            dialect = "clickhouse"
         try:
             backend = getattr(ibis, dialect)
         except AttributeError:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3450,6 +3450,7 @@ files = [
     {file = "msgpack-1.0.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fbb160554e319f7b22ecf530a80a3ff496d38e8e07ae763b9e82fadfe96f273"},
     {file = "msgpack-1.0.8-cp39-cp39-win32.whl", hash = "sha256:f9af38a89b6a5c04b7d18c492c8ccf2aee7048aff1ce8437c4683bb5a1df893d"},
     {file = "msgpack-1.0.8-cp39-cp39-win_amd64.whl", hash = "sha256:ed59dd52075f8fc91da6053b12e8c89e37aa043f8986efd89e61fae69dc1b011"},
+    {file = "msgpack-1.0.8-py3-none-any.whl", hash = "sha256:24f727df1e20b9876fa6e95f840a2a2651e34c0ad147676356f4bf5fbb0206ca"},
     {file = "msgpack-1.0.8.tar.gz", hash = "sha256:95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"},
 ]
 
@@ -5388,7 +5389,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -7360,4 +7360,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "09107743fe3df5b8f1681a46555a767bbd5eddb4d46e4f53ed5ea9abe8bf05d7"
+content-hash = "1c62b102929650077a62962e10d1cd141f50f5a7c41284374d57fea38e52a905"

--- a/poetry.lock
+++ b/poetry.lock
@@ -771,6 +771,34 @@ files = [
 ]
 
 [[package]]
+name = "chdb"
+version = "1.2.1"
+description = "chDB is an in-process SQL OLAP Engine powered by ClickHouse"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "chdb-1.2.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:5d7858769192694493b2b607db73daac5ca3df89b7be9c814657d936278da5dd"},
+    {file = "chdb-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4ae2b6de6d67a5238f67a195dea355127b275b4d78fd6192d45fc5441b605d6"},
+    {file = "chdb-1.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afe54f51c7042bad71a708fe37de00e293eeb72a94d80d6cb16524c9040f5c16"},
+    {file = "chdb-1.2.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59c44c29bf21325e32e5158bfd7a9413920e25e3630afe06d6106500f6010938"},
+    {file = "chdb-1.2.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:9fed280ebd14934dcdf0ec35b45211fa87acbc440f40df1ad253449759d53cf4"},
+    {file = "chdb-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b86b84e008501445e2bc54306e4dbc504673774e93b3d51ba7ed47af43141447"},
+    {file = "chdb-1.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac256f3aa3bfbd41c9bcdd0bacd5eb9a6e64a057750e567f50c7951116c03a1f"},
+    {file = "chdb-1.2.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41d62f4a02f04245c8865f921767db0fa8912a4a030e93a111855518b242c40a"},
+    {file = "chdb-1.2.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:243cdc4c8055dad3745922ad94c48986460dee7b4af5a95b19a0fead95fad86a"},
+    {file = "chdb-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d62fc66dc48e5fba6630169f3dd0b9597540ffa3fc7c59b7c02207dfb5b85b91"},
+    {file = "chdb-1.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7129b5a192f4920bcbf7deafbfcedf7b13347267797dbb943cd1ad2dc3ed86b"},
+    {file = "chdb-1.2.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d57d5b15ebc5d4158d75f3a19e50631513b1da57524c3ec7c0a48c2baf48836"},
+    {file = "chdb-1.2.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:e66646cf75d37fc61f530ca238fe89a8fcf527a7eed6524bf93d5db273948856"},
+    {file = "chdb-1.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7bba1fa210048f1548efc9926a4590465cf44de8f60dd90679601113464e8e1"},
+    {file = "chdb-1.2.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da243218bacf811e4d4ab0f2f26ac7a26c6dee0c3778739032bf93a3529725ae"},
+    {file = "chdb-1.2.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:3e62a3d8767cabfaca789d88b051d8f57f8d4ad21d238854e38e8f614d72551b"},
+    {file = "chdb-1.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:47d6ad89c0c1cd80ac6f49729515e9f43128f693d55b9b7bb2a62a5d93672fb0"},
+    {file = "chdb-1.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15f950ff17d27d62c624b8f1298b97aab5c244b4019bd37ada065381baa7fbf2"},
+    {file = "chdb-1.2.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa0595ad7b37a9d1344daca7a8b33ed52cc9ce5994def3b3ee5a197007e151da"},
+]
+
+[[package]]
 name = "cleo"
 version = "2.1.0"
 description = "Cleo allows you to create beautiful and testable command-line interfaces."
@@ -7303,6 +7331,7 @@ cffi = ["cffi (>=1.11)"]
 
 [extras]
 bigquery = ["db-dtypes", "google-cloud-bigquery", "google-cloud-bigquery-storage", "pydata-google-auth"]
+chdb = ["chdb"]
 clickhouse = ["clickhouse-connect"]
 dask = ["dask", "regex"]
 datafusion = ["datafusion"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -772,30 +772,30 @@ files = [
 
 [[package]]
 name = "chdb"
-version = "1.2.1"
+version = "1.3.0"
 description = "chDB is an in-process SQL OLAP Engine powered by ClickHouse"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "chdb-1.2.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:5d7858769192694493b2b607db73daac5ca3df89b7be9c814657d936278da5dd"},
-    {file = "chdb-1.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4ae2b6de6d67a5238f67a195dea355127b275b4d78fd6192d45fc5441b605d6"},
-    {file = "chdb-1.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afe54f51c7042bad71a708fe37de00e293eeb72a94d80d6cb16524c9040f5c16"},
-    {file = "chdb-1.2.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59c44c29bf21325e32e5158bfd7a9413920e25e3630afe06d6106500f6010938"},
-    {file = "chdb-1.2.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:9fed280ebd14934dcdf0ec35b45211fa87acbc440f40df1ad253449759d53cf4"},
-    {file = "chdb-1.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b86b84e008501445e2bc54306e4dbc504673774e93b3d51ba7ed47af43141447"},
-    {file = "chdb-1.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac256f3aa3bfbd41c9bcdd0bacd5eb9a6e64a057750e567f50c7951116c03a1f"},
-    {file = "chdb-1.2.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41d62f4a02f04245c8865f921767db0fa8912a4a030e93a111855518b242c40a"},
-    {file = "chdb-1.2.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:243cdc4c8055dad3745922ad94c48986460dee7b4af5a95b19a0fead95fad86a"},
-    {file = "chdb-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d62fc66dc48e5fba6630169f3dd0b9597540ffa3fc7c59b7c02207dfb5b85b91"},
-    {file = "chdb-1.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7129b5a192f4920bcbf7deafbfcedf7b13347267797dbb943cd1ad2dc3ed86b"},
-    {file = "chdb-1.2.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d57d5b15ebc5d4158d75f3a19e50631513b1da57524c3ec7c0a48c2baf48836"},
-    {file = "chdb-1.2.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:e66646cf75d37fc61f530ca238fe89a8fcf527a7eed6524bf93d5db273948856"},
-    {file = "chdb-1.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7bba1fa210048f1548efc9926a4590465cf44de8f60dd90679601113464e8e1"},
-    {file = "chdb-1.2.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da243218bacf811e4d4ab0f2f26ac7a26c6dee0c3778739032bf93a3529725ae"},
-    {file = "chdb-1.2.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:3e62a3d8767cabfaca789d88b051d8f57f8d4ad21d238854e38e8f614d72551b"},
-    {file = "chdb-1.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:47d6ad89c0c1cd80ac6f49729515e9f43128f693d55b9b7bb2a62a5d93672fb0"},
-    {file = "chdb-1.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15f950ff17d27d62c624b8f1298b97aab5c244b4019bd37ada065381baa7fbf2"},
-    {file = "chdb-1.2.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa0595ad7b37a9d1344daca7a8b33ed52cc9ce5994def3b3ee5a197007e151da"},
+    {file = "chdb-1.3.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:23465789b672357d5d8da37a6ea0fba38dbd8c44f496a9b6c5b18d5e040b5112"},
+    {file = "chdb-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:aef489a5741046287d4cf848955d65943843173cfa7a3cbc65dfdf516bb6c990"},
+    {file = "chdb-1.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82c0725048b9bc673053e82841187e8067b4cff24a25045aea4c83b320540fa6"},
+    {file = "chdb-1.3.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a3253d802ec69d61a5808c4a213ed26189517c86e4a1d681eef417fb9a820a1"},
+    {file = "chdb-1.3.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:f87b99b612ecd5d09285b88dcf93888f87307dd5db02c93ad9546f47883c18c4"},
+    {file = "chdb-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:02fa12c0c4457b9cc777023dbbb926440881512ab6eabe23322e9c69bec286d0"},
+    {file = "chdb-1.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:799bd5f49c9974c81c01e6f226980af488183b078af2fe2f67be5cb76b97f412"},
+    {file = "chdb-1.3.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d092e62189436cc1c541856d93103259a18da463567aeaeb89b9149de352e22a"},
+    {file = "chdb-1.3.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:b744482ddecc8a2977b2e7397227ee720acec98019c870368116f4745390d8fb"},
+    {file = "chdb-1.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:57eee4b1f1ff67e34afe2feea58a439a7310f9bb15c9f20525ce8bec387e22d7"},
+    {file = "chdb-1.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b67d97fbf10bde668c0e9de3d40af1da4fbe56720098a4d4815e35ed084cb1c4"},
+    {file = "chdb-1.3.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:caf28fdbf3f3845c5de29f7f9fd5a70b1abee59d7070ffcfa7963e17948b4a2e"},
+    {file = "chdb-1.3.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:a367e7030b2866a8f2a529998f2677437bada1f3048b6943e6baafa0011d8b3b"},
+    {file = "chdb-1.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1451fe5f0f228f2298d7fdd69cc122031274af96e8e9d13e308b6e06fcf8a035"},
+    {file = "chdb-1.3.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:706c92745ad9f7c71183579dc33eeb56f945ac02f7992e22de45176550902864"},
+    {file = "chdb-1.3.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:6011c424d6eadc768e3741937dd4af42d23be421879119d861eebb510b646360"},
+    {file = "chdb-1.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d6ef34988e9dc718ad0171cc1dacdb6687db9fe2a3a1e25811324562b6112f31"},
+    {file = "chdb-1.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89772c1d346ecd174006eb23e953a0783af4f14e0e12eab825ffe908c44e933d"},
+    {file = "chdb-1.3.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a57a92be7089885a752570fd2644aac3efbd842fcd706db3458a6b29423174a"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ clickhouse-connect = { version = ">=0.5.23,<1", optional = true, extras = [
   "numpy",
   "pandas",
 ] }
+chdb = { version = ">=1,<2", optional = true }
 dask = { version = ">=2022.9.1,<2024.3.0", optional = true, extras = [
   "array",
   "dataframe",
@@ -147,6 +148,7 @@ bigquery = [
   "pydata-google-auth",
 ]
 clickhouse = ["clickhouse-connect"]
+chdb = ["chdb"]
 dask = ["dask", "regex"]
 datafusion = ["datafusion"]
 druid = ["pydruid"]
@@ -175,6 +177,7 @@ geospatial = ["geopandas", "shapely"]
 [tool.poetry.plugins."ibis.backends"]
 bigquery = "ibis.backends.bigquery"
 clickhouse = "ibis.backends.clickhouse"
+chdb = "ibis.backends.chdb"
 dask = "ibis.backends.dask"
 datafusion = "ibis.backends.datafusion"
 druid = "ibis.backends.druid"
@@ -313,6 +316,7 @@ markers = [
   "broken: test has exposed existing broken functionality",
   "bigquery: BigQuery tests",
   "clickhouse: ClickHouse tests",
+  "chdb: chDB Database tests",
   "dask: Dask tests",
   "datafusion: Apache Datafusion tests",
   "druid: Apache Druid tests",


### PR DESCRIPTION
A big chunk of the backends testing suite is already passing, but there is still work to do:
1. Support passing in memory tables, this can be done using the same "pass as a file" trick used in [chdb.dataframe](https://github.com/chdb-io/chdb/blob/main/chdb/dataframe/query.py)
2. Better error handling
3. Pass the right dialect everywhere

Test suite is currently at `247 failed, 1067 passed, 28 skipped, 29854 deselected, 131 xfailed, 6 errors`