### PR TITLE
chore(docs): remove title case capitalization from test class reference

### DIFF
--- a/docs/contribute/05_reference.qmd
+++ b/docs/contribute/05_reference.qmd
@@ -1,6 +1,4 @@
----
-title: Test class reference
----
+# Test class reference
 
 This page provides a partial reference to the attributes, methods, properties
 and class-level variables that are used to help configure a backend for the Ibis

--- a/docs/contribute/05_reference.qmd
+++ b/docs/contribute/05_reference.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Test Class Reference"
+title: Test class reference
 ---
 
 This page provides a partial reference to the attributes, methods, properties


### PR DESCRIPTION
## Description of changes

per style guidelines, edit the capitalization

also changes the title style, inline w/ the local docs but out of line w/ the rest of the docs 

## Issues closed

