### PR TITLE
fix(clickhouse): make arrays non nullable

### DIFF
--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -966,7 +966,7 @@ class ClickHouseType(SqlglotType):
     def from_ibis(cls, dtype: dt.DataType) -> sge.DataType:
         """Convert a sqlglot type to an ibis type."""
         typ = super().from_ibis(dtype)
-        if dtype.nullable and not dtype.is_map():
+        if dtype.nullable and not (dtype.is_map() or dtype.is_array()):
             # map cannot be nullable in clickhouse
             return sge.DataType(this=typecode.NULLABLE, expressions=[typ])
         else:

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -938,8 +938,8 @@ def flatten_data():
             marks=[
                 pytest.mark.notyet(
                     ["clickhouse"],
-                    reason="doesn't support nullable array elements",
-                    raises=ClickHouseDatabaseError,
+                    reason="Arrays are never nullable",
+                    raises=AssertionError,
                 )
             ],
         ),
@@ -950,8 +950,8 @@ def flatten_data():
             marks=[
                 pytest.mark.notyet(
                     ["clickhouse"],
-                    reason="doesn't support nullable array elements",
-                    raises=ClickHouseDatabaseError,
+                    reason="Arrays are never nullable",
+                    raises=AssertionError,
                 )
             ],
         ),


### PR DESCRIPTION
## Description of changes

This PR makes ClickHouse arrays non nullable. I ran into the issue when trying to convert text to an array of float values as part of a RAG pipeline and run into this error:

```text
File ~/Library/Caches/pypoetry/virtualenvs/ibis-clickhouse-ZMCVYiHj-py3.11/lib/python3.11/site-packages/clickhouse_connect/driver/httpclient.py:361, in HttpClient._error_handler(self, response, retried)
    359     err_msg = common.format_error(err_content.decode(errors='backslashreplace'))
    360     err_str = f':{err_str}\n {err_msg}'
--> 361 raise OperationalError(err_str) if retried else DatabaseError(err_str) from None

DatabaseError: :HTTPDriver for http://localhost:8123 returned response code 500)
 Code: 43. DB::Exception: Nested type Array(Nullable(Float64)) cannot be inside Nullable type. (ILLEGAL_TYPE_OF_ARGUMENT) (version 24.2.1.1933 (official build))
```

I think treating arrays the way that maps are treated should handle this. 