### PR TITLE
chore: add to filterwarnings a pandas 2.2.x deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,6 +283,8 @@ filterwarnings = [
   "ignore:iteritems is deprecated and will be removed in a future version:FutureWarning",
   'ignore:Passing unit-less datetime64 dtype to \.astype is deprecated:FutureWarning',
   'ignore:The default value of numeric_only in DataFrameGroupBy\.sum is deprecated:FutureWarning',
+  # pandas 2.2.x
+  "ignore:Passing a BlockManager to DataFrame is deprecated and will raise in a future version. Use public APIs instead:DeprecationWarning",
   # numpy
   "ignore:Creating an ndarray from ragged nested sequences:",
   'ignore:`np\.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning',


### PR DESCRIPTION
I was running some tests `backends/flink/tests` locally, and I noticed this being raised by pandas 2.2.1

```
DeprecationWarning: Passing a BlockManager to DataFrame is deprecated and will raise in a future version. Use public APIs instead:
```

I'm not sure what we need to change on our end, but for now I think we need to filter it. For reference, it seems this comes from arrow. see https://github.com/pandas-dev/pandas/issues/56171