### PR TITLE
chore: pin pandas <2.2 on conda envs

### DIFF
--- a/conda/environment-arm64-flink.yml
+++ b/conda/environment-arm64-flink.yml
@@ -22,7 +22,7 @@ dependencies:
   - numpy >=1.15,<2
   - oracledb >=1.3.1
   - packaging >=21.3
-  - pandas >=1.2.5
+  - pandas >=1.2.5,<2.2
   - parsy >=2
   - pins >=0.8.2
   - poetry-core >=1.0.0

--- a/conda/environment-arm64.yml
+++ b/conda/environment-arm64.yml
@@ -22,7 +22,7 @@ dependencies:
   - numpy >=1.15,<2
   - oracledb >=1.3.1
   - packaging >=21.3
-  - pandas >=1.2.5
+  - pandas >=1.2.5,<2.2
   - parsy >=2
   - pins >=0.8.2
   - poetry-core >=1.0.0

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - numpy >=1.15,<2
   - oracledb >=1.3.1
   - packaging >=21.3
-  - pandas >=1.2.5
+  - pandas >=1.2.5,<2.2
   - parsy >=2
   - pins >=0.8.2
   - pip


### PR DESCRIPTION
Looks like pandas 2.2 breaks many things, so setting the dependency for <2.2 for now. 
