### PR TITLE
feat(api): time travel query

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -139,6 +139,8 @@ services:
       AZURE_ABFS_OAUTH_SECRET: ""
       AZURE_ABFS_OAUTH_ENDPOINT: ""
       AZURE_WASB_ACCESS_KEY: ""
+    ports:
+      - 9083:9083
     depends_on:
       hive-metastore-db:
         condition: service_healthy

--- a/docker/flink/conf/hive-site.xml
+++ b/docker/flink/conf/hive-site.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!--
+Hive configuration for Impala quickstart docker cluster.
+-->
+<configuration>
+  <property>
+    <name>hive.metastore.local</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>hive.metastore.uris</name>
+    <value>thrift://localhost:9083</value>
+  </property>
+</configuration>

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_time_travel/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_time_travel/out.sql
@@ -1,0 +1,15 @@
+SELECT
+  `t0`.`id`,
+  `t0`.`bool_col`,
+  `t0`.`tinyint_col`,
+  `t0`.`smallint_col`,
+  `t0`.`int_col`,
+  `t0`.`bigint_col`,
+  `t0`.`float_col`,
+  `t0`.`double_col`,
+  `t0`.`date_string_col`,
+  `t0`.`string_col`,
+  `t0`.`timestamp_col`,
+  `t0`.`year`,
+  `t0`.`month`
+FROM my_project.my_dataset.`my_table` FOR SYSTEM_TIME AS OF datetime('2023-01-02T03:04:05') AS `t0`

--- a/ibis/backends/flink/tests/conftest.py
+++ b/ibis/backends/flink/tests/conftest.py
@@ -188,3 +188,11 @@ def csv_source_configs():
         }
 
     return generate_csv_configs
+
+
+@pytest.fixture(scope="module")
+def tempdir_sink_configs():
+    def generate_tempdir_configs(tempdir):
+        return {"connector": "filesystem", "path": tempdir, "format": "csv"}
+
+    return generate_tempdir_configs

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -17,14 +17,6 @@ from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.errors import Py4JJavaError
 
 
-@pytest.fixture
-def tempdir_sink_configs():
-    def generate_tempdir_configs(tempdir):
-        return {"connector": "filesystem", "path": tempdir, "format": "csv"}
-
-    return generate_tempdir_configs
-
-
 @pytest.mark.parametrize("temp", [True, False])
 def test_list_tables(con, temp):
     assert len(con.list_tables(temp=temp))

--- a/ibis/backends/flink/tests/test_time_travel.py
+++ b/ibis/backends/flink/tests/test_time_travel.py
@@ -1,0 +1,290 @@
+"""Tests in this module tests if
+(1) Ibis generates the correct SQL for time travel,
+(2) The generated SQL is executed by Flink without errors.
+They do NOT compare the time travel results against the expected results.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import pytest
+
+import ibis
+import ibis.expr.datatypes as dt
+import ibis.expr.schema as sch
+import ibis.expr.types as ir
+from ibis.backends.flink.tests.utils import download_jar_for_package, get_catalogs
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def create_temp_table(
+    table_name: str,
+    con,
+    data_dir: Path,
+    tempdir_sink_configs,
+    tmp_path_factory,
+):
+    # Subset of `functional_alltypes_schema`
+    schema = sch.Schema(
+        {
+            "id": dt.int32,
+            "bool_col": dt.bool,
+            "smallint_col": dt.int16,
+            "int_col": dt.int32,
+            "timestamp_col": dt.timestamp(scale=3),
+        }
+    )
+
+    df = pd.read_parquet(f"{data_dir}/parquet/functional_alltypes.parquet")
+    df = df[list(schema.names)]
+    df = df.head(20)
+
+    temp_path = tmp_path_factory.mktemp(table_name)
+    tbl_properties = tempdir_sink_configs(temp_path)
+
+    # Note: Paimon catalog supports 'warehouse'='file:...' only for temporary tables.
+    table = con.create_table(
+        table_name,
+        schema=schema,
+        tbl_properties=tbl_properties,
+        temp=True,
+    )
+    con.insert(
+        table_name,
+        obj=df,
+        schema=schema,
+    ).wait()
+
+    return table
+
+
+@pytest.fixture(scope="module")
+def temp_table(con, data_dir, tempdir_sink_configs, tmp_path_factory) -> ir.Table:
+    table_name = "test_table"
+
+    yield create_temp_table(
+        table_name=table_name,
+        con=con,
+        data_dir=data_dir,
+        tempdir_sink_configs=tempdir_sink_configs,
+        tmp_path_factory=tmp_path_factory,
+    )
+
+    con.drop_table(name=table_name, temp=True, force=True)
+
+
+@pytest.fixture(
+    params=[
+        (
+            ibis.timestamp("2023-01-02T03:04:05"),
+            "CAST('2023-01-02 03:04:05.000000' AS TIMESTAMP)",
+        ),
+        (
+            ibis.timestamp("2023-01-01 12:34:56.789 UTC"),
+            "CAST('2023-01-01 12:34:56.789000' AS TIMESTAMP)",
+        ),
+        (
+            ibis.timestamp("2023-01-02T03:04:05") + ibis.interval(days=3),
+            "CAST('2023-01-02 03:04:05.000000' AS TIMESTAMP) + INTERVAL '3' DAY(2)",
+        ),
+        (
+            ibis.timestamp("2023-01-02T03:04:05")
+            + ibis.interval(days=3)
+            + ibis.interval(hours=6),
+            "(CAST('2023-01-02 03:04:05.000000' AS TIMESTAMP) + INTERVAL '3' DAY(2)) + INTERVAL '6' HOUR(2)",
+        ),
+        (
+            ibis.timestamp("2023-01-02 03:04:05", timezone="EST"),
+            "CAST('2023-01-02 03:04:05.000000' AS TIMESTAMP)",
+        ),
+    ]
+)
+def timestamp_and_sql(request):
+    return request.param
+
+
+def test_time_travel(temp_table, timestamp_and_sql):
+    timestamp, _ = timestamp_and_sql
+    expr = temp_table.time_travel(timestamp)
+
+    assert expr.op().timestamp == timestamp.op()
+
+
+@pytest.fixture
+def time_travel_expr_and_expected_sql(
+    temp_table, timestamp_and_sql
+) -> tuple[ir.Expr, str]:
+    from ibis.selectors import all
+
+    timestamp, timestamp_sql = timestamp_and_sql
+
+    expr = temp_table.time_travel(timestamp).select(all())
+    expected_sql = f"""SELECT `t0`.`id`, `t0`.`bool_col`, `t0`.`smallint_col`, `t0`.`int_col`, `t0`.`timestamp_col` FROM `{temp_table.get_name()}` FOR SYSTEM_TIME AS OF {timestamp_sql} AS `t0`"""
+
+    return expr, expected_sql
+
+
+def test_time_travel_compile(con, time_travel_expr_and_expected_sql):
+    expr, expected_sql = time_travel_expr_and_expected_sql
+    sql = con.compile(expr)
+    assert sql == expected_sql
+
+
+@pytest.fixture
+def use_hive_catalog(con):
+    # Flink related
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="flink-sql-connector-hive-3.1.3_2.12-1.18.1",
+        jar_url="https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-hive-3.1.3_2.12/1.18.1/flink-sql-connector-hive-3.1.3_2.12-1.18.1.jar",
+    )
+
+    # Hadoop related
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="woodstox-core-5.3.0",
+        jar_url="https://repo1.maven.org/maven2/com/fasterxml/woodstox/woodstox-core/5.3.0/woodstox-core-5.3.0.jar",
+    )
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="commons-logging-1.1.3",
+        jar_url="https://repo1.maven.org/maven2/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3.jar",
+    )
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="commons-configuration2-2.1.1",
+        jar_url="https://repo1.maven.org/maven2/org/apache/commons/commons-configuration2/2.1.1/commons-configuration2-2.1.1.jar",
+    )
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="hadoop-auth-3.3.2",
+        jar_url="https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-auth/3.3.2/hadoop-auth-3.3.2.jar",
+    )
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="hadoop-common-3.3.2",
+        jar_url="https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-common/3.3.2/hadoop-common-3.3.2.jar",
+    )
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="hadoop-hdfs-client-3.3.2",
+        jar_url="https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-hdfs-client/3.3.2/hadoop-hdfs-client-3.3.2.jar",
+    )
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="hadoop-mapreduce-client-core-3.3.2",
+        jar_url="https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-mapreduce-client-core/3.3.2/hadoop-mapreduce-client-core-3.3.2.jar",
+    )
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="hadoop-shaded-guava-1.1.1",
+        jar_url="https://repo1.maven.org/maven2/org/apache/hadoop/thirdparty/hadoop-shaded-guava/1.1.1/hadoop-shaded-guava-1.1.1.jar",
+    )
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="stax2-api-4.2.1",
+        jar_url="https://repo1.maven.org/maven2/org/codehaus/woodstox/stax2-api/4.2.1/stax2-api-4.2.1.jar",
+    )
+
+    hive_catalog = "hive_catalog"
+    sql = """
+    CREATE CATALOG hive_catalog WITH (
+        'type' = 'hive',
+        'hive-conf-dir' = './docker/flink/conf/'
+    );
+    """
+    con.raw_sql(sql)
+
+    catalog_list = get_catalogs(con)
+    assert hive_catalog in catalog_list
+
+    con.raw_sql(f"USE CATALOG {hive_catalog};")
+
+
+@pytest.fixture
+def use_paimon_catalog(con):
+    # Note: It is not ideal to do "test ops" in code here. However,
+    # adding JAR files in the Flink container in this case won't help
+    # because the Flink specific tests do not run on the dockerized env,
+    # but on the local env.
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="paimon-flink-1.18-0.8-20240301.002155-30",
+        jar_url="https://repository.apache.org/content/groups/snapshots/org/apache/paimon/paimon-flink-1.18/0.8-SNAPSHOT/paimon-flink-1.18-0.8-20240301.002155-30.jar",
+    )
+    download_jar_for_package(
+        package_name="apache-flink",
+        jar_name="flink-shaded-hadoop-2-uber-2.8.3-10.0",
+        jar_url="https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop-2-uber/2.8.3-10.0/flink-shaded-hadoop-2-uber-2.8.3-10.0.jar",
+    )
+
+    paimon_catalog = "paimon_catalog"
+    catalog_list = get_catalogs(con)
+    if paimon_catalog not in catalog_list:
+        sql = """
+        CREATE CATALOG paimon_catalog WITH (
+            'type'='paimon',
+            'warehouse'='file:/tmp/paimon'
+        );
+        """
+        con.raw_sql(sql)
+        catalog_list = get_catalogs(con)
+        assert paimon_catalog in catalog_list
+
+    con.raw_sql(f"USE CATALOG {paimon_catalog};")
+
+
+@pytest.fixture
+def time_travel_expr(
+    con, data_dir, tempdir_sink_configs, tmp_path_factory, timestamp_and_sql
+) -> ir.Expr:
+    from ibis.selectors import all
+
+    table_name = "test_table"
+    table = create_temp_table(
+        con=con,
+        table_name=table_name,
+        data_dir=data_dir,
+        tempdir_sink_configs=tempdir_sink_configs,
+        tmp_path_factory=tmp_path_factory,
+    )
+
+    timestamp, _ = timestamp_and_sql
+
+    yield table.time_travel(timestamp).select(all())
+
+    con.drop_table(name=table_name, temp=True, force=True)
+
+
+# Note: `test_time_travel_w_xxx_catalog()` tests rely on `use_hive_catalog`
+# to appear before `time_travel_expr` per "Fixtures are evaluated in order
+# of presence in test function arguments, from left to right."
+# This is required to create the table in the catalog.
+@pytest.mark.skip(
+    reason=(
+        "Fixture `use_hive_catalog` uses `download_jar_for_package()`, "
+        "which does not work on CI. Downloading the JAR's in Flink container "
+        "is also not an option because tests under `ibis/backends/flink/tests/` "
+        "run on local env. So this is left to be run manually for now."
+    )
+)
+def test_time_travel_w_hive_catalog(con, use_hive_catalog, time_travel_expr):
+    # Start the Hive metastore first
+    # $ docker compose up hive-metastore --force-recreate
+    con.execute(time_travel_expr)
+
+
+@pytest.mark.skip(
+    reason=(
+        "Fixture `use_paimon_catalog` uses `download_jar_for_package()`, "
+        "which does not work on CI. Downloading the JAR's in Flink container "
+        "is also not an option because tests under `ibis/backends/flink/tests/` "
+        "run on local env. So this is left to be run manually for now."
+    )
+)
+def test_time_travel_w_paimon_catalog(con, use_paimon_catalog, time_travel_expr):
+    con.execute(time_travel_expr)

--- a/ibis/backends/flink/tests/utils.py
+++ b/ibis/backends/flink/tests/utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+
+def download_jar_for_package(
+    package_name: str,
+    jar_name: str,
+    jar_url: str,
+):
+    import os
+    from importlib import metadata
+
+    import requests
+
+    # Find the path to package lib
+    try:
+        distribution = metadata.distribution(package_name)
+        lib_path = distribution.locate_file("")
+    except metadata.PackageNotFoundError:
+        lib_path = None
+
+    # Check if the JAR already exists
+    jar_path = os.path.join(lib_path, "pyflink/lib", f"{jar_name}.jar")
+    if os.path.exists(jar_path):
+        return jar_path
+
+    # Download the JAR
+    response = requests.get(jar_url, stream=True)
+    if response.status_code != 200:
+        raise SystemError(
+            f"Failed to download the JAR file \n"
+            f"\t jar_url= {jar_url} \n"
+            f"\t response.status_code= {response.status_code}"
+        )
+
+    # Save the JAR
+    with open(jar_path, "wb") as jar_file:
+        for chunk in response.iter_content(chunk_size=128):
+            jar_file.write(chunk)
+
+    return jar_path
+
+
+# TODO (mehmet): Why does Flink backend not implement `list_catalogs()`?
+def get_catalogs(con) -> list[str]:
+    show_catalogs = con.raw_sql("show catalogs")
+    catalog_list = []
+    with show_catalogs.collect() as results:
+        for result in results:
+            catalog_list.append(result._values[0])
+
+    return catalog_list

--- a/ibis/backends/sql/compiler.py
+++ b/ibis/backends/sql/compiler.py
@@ -17,6 +17,7 @@ import ibis.common.exceptions as com
 import ibis.common.patterns as pats
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+from ibis.backends.sql.expressions import TimeTravelTable
 from ibis.backends.sql.rewrites import (
     FirstValue,
     LastValue,
@@ -1140,6 +1141,27 @@ class SQLGlotCompiler(abc.ABC):
     ) -> sg.Table:
         return sg.table(
             name, db=namespace.database, catalog=namespace.catalog, quoted=self.quoted
+        )
+
+    def visit_TimeTravelDatabaseTable(
+        self,
+        op,
+        *,
+        name: str,
+        schema: sch.Schema,
+        source: Any,
+        namespace: ops.Namespace,
+        timestamp: ops.Literal,
+    ) -> TimeTravelTable:
+        table = sg.table(
+            name, db=namespace.database, catalog=namespace.catalog, quoted=self.quoted
+        )
+        return TimeTravelTable(
+            this=table.this,
+            db=table.db,
+            catalog=table.catalog,
+            alias=table.alias,
+            timestamp=timestamp,
         )
 
     def visit_SelfReference(self, op, *, parent, identifier):

--- a/ibis/backends/sql/expressions.py
+++ b/ibis/backends/sql/expressions.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+import sqlglot.expressions as sge
+
+
+class TimeTravelTable(sge.Table):
+    arg_types = {
+        "this": True,
+        "alias": False,
+        "db": False,
+        "catalog": False,
+        "laterals": False,
+        "joins": False,
+        "pivots": False,
+        "hints": False,
+        "system_time": False,
+        "version": False,
+        "format": False,
+        "pattern": False,
+        "ordinality": False,
+        "when": False,
+        "timestamp": True,  # Added only this, rest copied from sge.Table.
+    }
+
+    @property
+    def timestamp(self) -> Any:
+        """Retrieves the argument with key 'timestamp'."""
+
+        return self.args.get("timestamp")

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -333,6 +333,25 @@ class DatabaseTable(PhysicalTable):
 
 
 @public
+class VersionedDatabaseTable(DatabaseTable):
+    """Table that is versioned with snapshots by the backend."""
+
+    at_time: Optional[Column] = None
+
+
+@public
+class TimeTravelDatabaseTable(DatabaseTable):
+    """Table for time travel."""
+
+    timestamp: Value[dt.Timestamp]
+
+    def to_expr(self):
+        from ibis.expr.types.temporal import TimeTravelTable
+
+        return TimeTravelTable(self)
+
+
+@public
 class InMemoryTable(PhysicalTable):
     schema: Schema
     data: TableProxy

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -8,18 +8,18 @@ import ibis
 import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+import ibis.expr.types as ir
 from ibis import util
 from ibis.common.annotations import annotated
 from ibis.common.temporal import IntervalUnit
 from ibis.expr.types.core import _binop
 from ibis.expr.types.generic import Column, Scalar, Value
+from ibis.expr.types.relations import Table
 
 if TYPE_CHECKING:
     import datetime
 
     import pandas as pd
-
-    import ibis.expr.types as ir
 
 
 class _DateComponentMixin:
@@ -984,3 +984,8 @@ class DayOfWeek:
             The name of the day of the week
         """
         return ops.DayOfWeekName(self._expr).to_expr()
+
+
+@public
+class TimeTravelTable(Table):
+    pass


### PR DESCRIPTION
## Description of changes

Aims to address https://github.com/ibis-project/ibis/issues/8203.

This PR
- Adds `time_travel()` for `Table`.
- Adds `ibis.expr.types.temporal.TimeTravelTable` and `ops.TimeTravelDatabaseTable`.
- Adds `visit_TimeTravelDatabaseTable()` in the compiler for BigQuery and Flink, and `time_travel_table_sql()` in the SQL generator for Flink.
- Adds tests for time travel in BigQuery and Flink backends.

Notes:
- Could not add a functional test for BigQuery as I do not have access to a GCP env to run the functional tests.
- Will add more unit and functional tests.
  - Especially, for timestamp expressions and timestamps with time zones.


## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
