### PR TITLE
chore: add return `Table` typehint to `pivot_wider`

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -3755,7 +3755,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         values_from: str | Iterable[str] | s.Selector = "value",
         values_fill: int | float | str | ir.Scalar | None = None,
         values_agg: str | Callable[[ir.Value], ir.Scalar] | Deferred = "arbitrary",
-    ):
+    ) -> Table:
         """Pivot a table to a wider format.
 
         Parameters


### PR DESCRIPTION
## Description of changes

Adds `-> Table` to the signature of `pivot_wider` to ensure consistency with the other `Table` methods.

Each `Table` method with an indicated `Table` return in their docstring also has a corresponding `-> Table` in their signature, except `pivot_wider`, where no return typehint was present.