### PR TITLE
fix(graphviz): show proper field attributes of accessed relations and do not display join link property accesses

### DIFF
--- a/docs/how-to/visualization/graphs.qmd
+++ b/docs/how-to/visualization/graphs.qmd
@@ -7,7 +7,7 @@ graph](https://en.wikipedia.org/wiki/Directed_graph) using
 To get started, make sure you've installed the necessary dependencies.
 
 ```sh
-$ pip install 'ibis-framework[duckdb,examples,graphviz]'
+$ pip install 'ibis-framework[duckdb,examples,visualization]'
 ```
 
 ::: {.callout-note collapse="true"}

--- a/ibis/expr/tests/test_visualize.py
+++ b/ibis/expr/tests/test_visualize.py
@@ -144,8 +144,7 @@ def test_filter():
     t = ibis.table([("a", "int64"), ("b", "string"), ("c", "int32")])
     expr = t.filter((t.a == 1) & (t.b == "x"))
     graph = viz.to_graph(expr, label_edges=True)
-    assert "predicates[0]" in graph.source
-    assert "predicates[1]" in graph.source
+    assert "Filter" in graph.source
 
 
 def test_html_escape(monkeypatch):

--- a/ibis/expr/visualize.py
+++ b/ibis/expr/visualize.py
@@ -136,16 +136,26 @@ def to_graph(
                 if not label_edges:
                     label = None
                 else:
-                    for name, arg in zip(v.argnames, v.args):
-                        if isinstance(arg, tuple) and u in arg:
-                            index = arg.index(u)
-                            name = f"{name}[{index}]"
-                            break
-                        elif arg == u:
-                            break
+                    if isinstance(v, ops.Relation):
+                        if (name := getattr(u, "name", None)) in v.fields:
+                            name = f"fields[{name!r}]"
+                        else:
+                            name = None
                     else:
-                        name = None
-                    label = f"<.{name}>"
+                        for name, arg in zip(v.argnames, v.args):
+                            if isinstance(arg, tuple) and u in arg:
+                                index = arg.index(u)
+                                name = f"{name}[{index}]"
+                                break
+                            elif arg == u:
+                                break
+                        else:
+                            name = None
+
+                    if name is not None:
+                        label = f"<.{name}>"
+                    else:
+                        label = None
 
                 g.edge(
                     uhash,


### PR DESCRIPTION
This PR properly displays relation field names when accessed and avoids displaying references as `.None` when coming from a JoinLink object.