### PR TITLE
docs: add missing import to `RowNumber` example

### DIFF
--- a/ibis/expr/operations/analytic.py
+++ b/ibis/expr/operations/analytic.py
@@ -58,6 +58,7 @@ class RowNumber(RankBase):
     Examples
     --------
     >>> import ibis
+    >>> import ibis.expr.datatypes as dt
     >>> t = ibis.table([("values", dt.int64)])
     >>> w = ibis.window(order_by=t.values)
     >>> row_num = ibis.row_number().over(w)


### PR DESCRIPTION
## Description of changes

The existing example was not self-contained. Upon execution, it raised an error as `dt.int64` could not be resolved.

```python
>>> import ibis
>>> t = ibis.table([("values", dt.int64)])  # NameError: name 'dt' is not defined
>>> w = ibis.window(order_by=t.values)
>>> row_num = ibis.row_number().over(w)
>>> result = t[t.values, row_num.name("row_num")]
```

This PR adds the missing `import ibis.expr.datatypes as dt` statement.