### PR TITLE
feat(polars): add limited support for table dot sql

### DIFF
--- a/ci/schema/exasol.sql
+++ b/ci/schema/exasol.sql
@@ -48,7 +48,7 @@ CREATE OR REPLACE TABLE EXASOL."awards_players"
     "yearID"   BIGINT,
     "lgID"     VARCHAR(256),
     "tie"      VARCHAR(256),
-    "notest"   VARCHAR(256)
+    "notes"   VARCHAR(256)
 );
 
 CREATE OR REPLACE TABLE EXASOL."functional_alltypes"

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1225,8 +1225,6 @@ def execute_arg_min(op, **kw):
 
 @translate.register(ops.SQLStringView)
 def execute_sql_string_view(op, *, ctx: pl.SQLContext, **kw):
-    child = translate(op.child, ctx=ctx, **kw)
-    ctx.register(op.name, child)
     return ctx.execute(op.query)
 
 

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -77,7 +77,11 @@ def test_con_dot_sql(backend, con, schema):
     backend.assert_series_equal(result.astype(expected.dtype), expected)
 
 
-@pytest.mark.notyet(["polars"], raises=PolarsComputeError)
+@pytest.mark.notyet(
+    ["polars"],
+    raises=PolarsComputeError,
+    reason="polars doesn't support quoted identifiers referencing CTEs",
+)
 @pytest.mark.notyet(
     ["bigquery"], raises=GoogleBadRequest, reason="requires a qualified name"
 )
@@ -119,7 +123,11 @@ def test_table_dot_sql(backend):
     assert pytest.approx(result) == expected
 
 
-@pytest.mark.notyet(["polars"], raises=PolarsComputeError)
+@pytest.mark.notyet(
+    ["polars"],
+    raises=PolarsComputeError,
+    reason="polars doesn't support quoted identifiers referencing CTEs",
+)
 @pytest.mark.notyet(
     ["bigquery"], raises=GoogleBadRequest, reason="requires a qualified name"
 )
@@ -315,7 +323,11 @@ def mem_t(con):
 
 
 @dot_sql_never
-@pytest.mark.notyet(["polars"], raises=NotImplementedError)
+@pytest.mark.notyet(
+    ["polars"],
+    raises=PolarsComputeError,
+    reason="polars doesn't support selecting from quoted identifiers referencing CTEs",
+)
 @pytest.mark.notyet(
     ["druid"],
     raises=KeyError,
@@ -337,3 +349,13 @@ def test_cte(alltypes, df):
     )
 
     tm.assert_frame_equal(result, expected)
+
+
+@dot_sql_never
+def test_bare_minimum(alltypes, df):
+    """Test that a backend that supports dot sql can do the most basic thing."""
+
+    expr = alltypes.sql(
+        'SELECT COUNT(*) AS "n" FROM "functional_alltypes"', dialect="duckdb"
+    )
+    assert expr.to_pandas().iat[0, 0] == len(df)

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -103,7 +103,7 @@ def test_scalar_to_pyarrow_scalar(limit, awards_players):
     assert isinstance(scalar, pa.Scalar)
 
 
-@pytest.mark.notimpl(["druid", "exasol"])
+@pytest.mark.notimpl(["druid"])
 def test_table_to_pyarrow_table_schema(awards_players):
     table = awards_players.to_pyarrow()
     assert isinstance(table, pa.Table)


### PR DESCRIPTION
Adds limited support for `.sql` to the Polars backend. Closes #8525.