### PR TITLE
fix(deps): support python 3.12

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-python@v5
         id: install_python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
           cache-dependency-path: requirements-dev.txt
 

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -563,6 +563,11 @@ jobs:
             deps:
               - "'pandas@>2'"
               - "'numpy@>1.24'"
+          - python-version: "3.12"
+            pyspark-version: "3.5"
+            deps:
+              - "'pandas@>2'"
+              - "'numpy@>1.24'"
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ibis-benchmarks.yml
+++ b/.github/workflows/ibis-benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-python@v5
         id: install_python
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: poetry
 
       - name: install system dependencies

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -49,6 +49,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -101,14 +102,7 @@ jobs:
 
   test_shapely_duckdb_import:
     name: Test shapely and duckdb import
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        python-version:
-          - "3.11"
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -120,10 +114,10 @@ jobs:
         uses: actions/setup-python@v5
         id: install_python
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
           cache: poetry
 
-      - name: install ${{ matrix.os }} system dependencies
+      - name: install system dependencies
         run: |
           set -euo pipefail
 
@@ -141,14 +135,7 @@ jobs:
     # FIXME(kszucs): re-enable this build
     if: false
     name: Doctests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        python-version:
-          - "3.11"
+    runs-on: ubuntu-latest
     steps:
       - name: install system dependencies
         run: |
@@ -167,7 +154,7 @@ jobs:
         uses: actions/setup-python@v5
         id: install_python
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
           cache: poetry
 
       - name: install ibis with all extras

--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -36,5 +36,6 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - run: echo "No build required"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,6 +37,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/flake.nix
+++ b/flake.nix
@@ -125,9 +125,9 @@
     in
     rec {
       packages = {
-        inherit (pkgs) ibis39 ibis310 ibis311;
+        inherit (pkgs) ibis39 ibis310 ibis311 ibis312;
 
-        default = pkgs.ibis311;
+        default = pkgs.ibis312;
 
         inherit (pkgs) update-lock-files gen-all-extras gen-examples check-release-notes-spelling;
       };
@@ -136,8 +136,9 @@
         ibis39 = mkDevShell pkgs.ibisDevEnv39;
         ibis310 = mkDevShell pkgs.ibisDevEnv310;
         ibis311 = mkDevShell pkgs.ibisDevEnv311;
+        ibis312 = mkDevShell pkgs.ibisDevEnv312;
 
-        default = ibis311;
+        default = ibis312;
 
         preCommit = pkgs.mkShell {
           name = "preCommit";

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1575,7 +1575,7 @@ def test_now_from_projection(alltypes):
     ts = result.now
     assert len(result) == n
     assert ts.nunique() == 1
-    assert ~pd.isna(ts.iat[0])
+    assert not pd.isna(ts.iat[0])
 
 
 DATE_BACKEND_TYPES = {

--- a/ibis/common/temporal.py
+++ b/ibis/common/temporal.py
@@ -226,7 +226,7 @@ def _from_str(value):
 
 @normalize_datetime.register(numbers.Number)
 def _from_number(value):
-    return datetime.datetime.utcfromtimestamp(value)
+    return datetime.datetime.fromtimestamp(value, dateutil.tz.UTC)
 
 
 @normalize_datetime.register(datetime.time)

--- a/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_keyword_only_arguments/missing_a_required_argument.txt
+++ b/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_keyword_only_arguments/missing_a_required_argument.txt
@@ -1,3 +1,0 @@
-test(2, 3) missing a required argument: 'c'
-
-Expected signature: test(a: int, b: int, *, c: float, d: float = 0.0)

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -253,9 +253,10 @@ def test_signature_from_callable_with_keyword_only_arguments(snapshot):
         "d": 5.0,
     }
 
-    with pytest.raises(ValidationError) as excinfo:
+    with pytest.raises(
+        ValidationError, match="missing a required (?:keyword-only )?argument: 'c'"
+    ) as excinfo:
         sig.validate(test, args=(2, 3), kwargs={})
-    snapshot.assert_match(str(excinfo.value), "missing_a_required_argument.txt")
 
     with pytest.raises(ValidationError) as excinfo:
         sig.validate(test, args=(2, 3, 4), kwargs={})

--- a/ibis/common/tests/test_temporal.py
+++ b/ibis/common/tests/test_temporal.py
@@ -186,9 +186,9 @@ def test_normalize_timezone(value, expected):
             datetime(2017, 1, 1, 0, 0, 0, 1, tzinfo=dateutil.tz.UTC),
         ),
         # plain integer
-        (1000, datetime(1970, 1, 1, 0, 16, 40)),
+        (1000, datetime(1970, 1, 1, 0, 16, 40, tzinfo=dateutil.tz.UTC)),
         # floating point
-        (1000.123, datetime(1970, 1, 1, 0, 16, 40, 123000)),
+        (1000.123, datetime(1970, 1, 1, 0, 16, 40, 123000, tzinfo=dateutil.tz.UTC)),
     ],
 )
 def test_normalize_datetime(value, expected):

--- a/ibis/expr/datatypes/tests/test_value.py
+++ b/ibis/expr/datatypes/tests/test_value.py
@@ -119,8 +119,7 @@ def test_infer_mixed_type_fails():
 
 
 def test_infer_timestamp_with_tz():
-    now_raw = datetime.utcnow()
-    now_utc = pytz.utc.localize(now_raw)
+    now_utc = datetime.now(pytz.UTC)
     assert now_utc.tzinfo == pytz.UTC
     assert dt.infer(now_utc).timezone == str(pytz.UTC)
 

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -1157,7 +1157,7 @@ class StringValue(Value):
         │ c.........a │
         │ def         │
         └─────────────┘
-        >>> t.s.re_split("\.+").name("splits")
+        >>> t.s.re_split(r"\.+").name("splits")
         ┏━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ splits               ┃
         ┡━━━━━━━━━━━━━━━━━━━━━━┩
@@ -1230,7 +1230,7 @@ class StringValue(Value):
 
         Normalize all whitespace to a single space:
 
-        >>> s.re_replace("\s+", " ")
+        >>> s.re_replace(r"\s+", " ")
         ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ RegexReplace(s, '\\s+', ' ') ┃
         ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -344,7 +344,9 @@ class PandasData(DataMapper):
                 # than the value supported by Python the value is an integer
                 #
                 # TODO: can we do better than implicit truncation to microseconds?
-                value = datetime.datetime.utcfromtimestamp(value / 1e9)
+                import dateutil
+
+                value = datetime.datetime.fromtimestamp(value / 1e9, dateutil.tz.UTC)
 
             if (tz := dtype.timezone) is not None:
                 return value.astimezone(normalize_timezone(tz))

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -166,7 +166,7 @@ def test_literal_mixed_type_fails():
 
 
 def test_timestamp_literal_without_tz():
-    now_raw = datetime.datetime.utcnow()
+    now_raw = datetime.datetime.now()
     assert now_raw.tzinfo is None
     assert ibis.literal(now_raw).type().timezone is None
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -28,13 +28,15 @@ in
   ibis39 = pkgs.callPackage ./ibis.nix { python3 = pkgs.python39; };
   ibis310 = pkgs.callPackage ./ibis.nix { python3 = pkgs.python310; };
   ibis311 = pkgs.callPackage ./ibis.nix { python3 = pkgs.python311; };
+  ibis312 = pkgs.callPackage ./ibis.nix { python3 = pkgs.python312; };
 
   ibisDevEnv39 = mkPoetryDevEnv pkgs.python39;
   ibisDevEnv310 = mkPoetryDevEnv pkgs.python310;
   ibisDevEnv311 = mkPoetryDevEnv pkgs.python311;
+  ibisDevEnv312 = mkPoetryDevEnv pkgs.python312;
 
   ibisSmallDevEnv = mkPoetryEnv {
-    python = pkgs.python311;
+    python = pkgs.python312;
     groups = [ "dev" ];
     extras = [ ];
   };
@@ -73,7 +75,7 @@ in
   gen-examples = pkgs.writeShellApplication {
     name = "gen-examples";
     runtimeInputs = [
-      pkgs.ibisDevEnv311
+      pkgs.ibisDevEnv312
       (pkgs.rWrapper.override {
         packages = with pkgs.rPackages; [
           Lahman

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -42,4 +42,12 @@ self: super: {
       rm $out/${self.python.sitePackages}/pyflink/__pycache__/version.*.pyc
     '';
   });
+
+  thrift = super.thrift.overridePythonAttrs (attrs: {
+    # ignore silly bytecode-compilation-on-install for Pythons >= 3.12
+    postPatch = (attrs.postPatch or "") +
+      self.pkgs.lib.optionalString (self.pkgs.lib.versionAtLeast self.python.version "3.12") ''
+        substituteInPlace setup.cfg --replace 'optimize = 1' 'optimize = 0'
+      '';
+  });
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,10 @@ filterwarnings = [
   "ignore:is_sparse is deprecated and will be removed in a future version:DeprecationWarning",
   # google-api-core
   "ignore:Please install grpcio-status to obtain helpful grpc error messages.",
+  # dateutil tz
+  'ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning',
+  # types using custom tp_new are deprecated in python 3.12
+  "ignore:Type .+ uses PyType_Spec with a metaclass that has custom tp_new:DeprecationWarning",
 ]
 empty_parameter_set_mark = "fail_at_collect"
 markers = [


### PR DESCRIPTION
Add 3.12 job and support in our nix builds and environment; fixes warnings about utcfromtimestamp from ibis code and ignores them in testing due to their use at the top level of dateutil.