### PR TITLE
fix: return UUID types as strings from `.execute()`/`.to_pandas()`

### DIFF
--- a/ibis/backends/tests/test_uuid.py
+++ b/ibis/backends/tests/test_uuid.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import contextlib
 import uuid
 
+import pyarrow as pa
 import pytest
 
 import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 
-RAW_TEST_UUID = "08f48812-7948-4718-96c7-27fa6a398db6"
-TEST_UUID = uuid.UUID(RAW_TEST_UUID)
+TEST_UUID = "08f48812-7948-4718-96c7-27fa6a398db6"
 
 UUID_BACKEND_TYPE = {
     "bigquery": "STRING",
@@ -31,13 +31,24 @@ UUID_BACKEND_TYPE = {
 def test_uuid_literal(con, backend):
     backend_name = backend.name()
 
-    expr = ibis.literal(RAW_TEST_UUID, type=dt.uuid)
+    expr = ibis.literal(TEST_UUID, type=dt.uuid)
     result = con.execute(expr)
 
     assert result == TEST_UUID
 
     with contextlib.suppress(com.OperationNotDefinedError):
         assert con.execute(expr.typeof()) == UUID_BACKEND_TYPE[backend_name]
+
+
+@pytest.mark.notimpl(["polars"], raises=NotImplementedError)
+def test_uuid_to_pyarrow(con):
+    expr = ibis.literal(TEST_UUID, type=dt.uuid)
+    result = con.to_pyarrow(expr)
+    assert str(result) == TEST_UUID
+
+    tbl = con.tables.functional_alltypes.mutate(uuid=expr).select("uuid")
+    result = con.to_pyarrow(tbl.limit(2))
+    assert pa.types.is_string(result["uuid"].type)
 
 
 @pytest.mark.notimpl(
@@ -58,8 +69,8 @@ def test_uuid_literal(con, backend):
 @pytest.mark.notimpl(["pandas", "dask"], raises=ValueError)
 def test_uuid_function(con):
     obj = con.execute(ibis.uuid())
-    assert isinstance(obj, uuid.UUID)
-    assert obj.version == 4
+    assert isinstance(obj, str)
+    assert uuid.UUID(obj).version == 4
 
 
 @pytest.mark.notimpl(

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -385,14 +385,12 @@ class PandasData(DataMapper):
 
     @classmethod
     def convert_UUID_element(cls, _):
-        from uuid import UUID
-
         def convert(value):
             if value is None:
                 return value
-            elif isinstance(value, UUID):
+            elif isinstance(value, str):
                 return value
-            return UUID(value)
+            return str(value)
 
         return convert
 


### PR DESCRIPTION
BREAKING CHANGE: previously UUIDs were returned as `uuid.UUID` instances from `.to_pandas()`/`.execute()`, but strings from `.to_pyarrow()`/`.to_polars()` - we now return these values as strings everywhere.

Fixes #8532.