### PR TITLE
feat(api): support variadic arguments on `Table.group_by()`

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -922,7 +922,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
     def group_by(
         self,
-        by: str | ir.Value | Iterable[str] | Iterable[ir.Value] | None = (),
+        *by: str | ir.Value | Iterable[str] | Iterable[ir.Value] | None,
         **key_exprs: str | ir.Value | Iterable[str] | Iterable[ir.Value],
     ) -> GroupedTable:
         """Create a grouped table expression.
@@ -978,9 +978,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         """
         from ibis.expr.types.groupby import GroupedTable
 
-        if by is None:
-            by = ()
-
+        by = tuple(v for v in by if v is not None)
         groups = bind(self, (by, key_exprs))
         return GroupedTable(self, groups)
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -799,6 +799,14 @@ def test_group_by_kwargs(table):
     assert_equal(expr, expected)
 
 
+def test_group_by_nargs(table):
+    t = table
+    by = ["f", t.h]
+    e1 = t.group_by(by, z="g").aggregate(t.d.mean().name("foo"))
+    e2 = t.group_by(*by, z="g").aggregate(t.d.mean().name("foo"))
+    assert_equal(e1, e2)
+
+
 def test_compound_aggregate_expr(table):
     # See ibis #24
     compound_expr = (table["a"].sum() / table["a"].mean()).name("foo")


### PR DESCRIPTION
Fixes https://github.com/ibis-project/ibis/issues/8504