### PR TITLE
docs(development): move pip to end of env creation tabset

### DIFF
--- a/docs/contribute/01_environment.qmd
+++ b/docs/contribute/01_environment.qmd
@@ -18,43 +18,6 @@ the `conda/mamba` setup and refer to the comment related to `arm64`
 architectures.
 :::
 
-## pip
-
-::: {.callout-warning}
-## `pip` will not handle installation of system dependencies
-
-`pip` will not install system dependencies needed for some packages such as `psycopg2` and `kerberos`.
-
-For a better development experience see the `conda/mamba` or `nix` setup instructions.
-:::
-
-1. [Install `gh`](https://cli.github.com/manual/installation)
-
-1. Fork and clone the ibis repository:
-
-   ```sh
-   gh repo fork --clone --remote ibis-project/ibis
-   ```
-
-1. Change directory into `ibis`:
-
-   ```sh
-   cd ibis
-   ```
-
-1. Install development dependencies
-
-   ```sh
-   pip install 'poetry==1.8.1'
-   pip install -r requirements-dev.txt
-   ```
-
-1. Install ibis in development mode
-
-   ```sh
-   pip install -e '.[all]'
-   ```
-
 ## Conda/Mamba
 
 ### Support matrix [^conda-callout]
@@ -201,6 +164,44 @@ for manager, params in managers.items():
 
     This will launch a `bash` shell with all of the required dependencies installed.
     This may take a while due to artifact download from the cache.
+
+
+## pip
+
+::: {.callout-warning}
+## `pip` will not handle installation of system dependencies
+
+`pip` will not install system dependencies needed for some packages such as `psycopg2` and `kerberos`.
+
+For a better development experience see the `conda/mamba` or `nix` setup instructions.
+:::
+
+1. [Install `gh`](https://cli.github.com/manual/installation)
+
+1. Fork and clone the ibis repository:
+
+   ```sh
+   gh repo fork --clone --remote ibis-project/ibis
+   ```
+
+1. Change directory into `ibis`:
+
+   ```sh
+   cd ibis
+   ```
+
+1. Install development dependencies
+
+   ```sh
+   pip install 'poetry==1.8.1'
+   pip install -r requirements-dev.txt
+   ```
+
+1. Install ibis in development mode
+
+   ```sh
+   pip install -e '.[all]'
+   ```
 
 :::
 


### PR DESCRIPTION
## Description of changes

Instead of defaulting to `pip` for environment setup, list in order
conda -> nix -> pip since we don't recommend using `pip` for this anyway.