### PR TITLE
fix: `Node.map_clear` should return `Any`

### DIFF
--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -264,9 +264,7 @@ class Node(Hashable):
         return results
 
     @experimental
-    def map_clear(
-        self, fn: Callable, filter: Optional[Finder] = None
-    ) -> dict[Node, Any]:
+    def map_clear(self, fn: Callable, filter: Optional[Finder] = None) -> Any:
         """Apply a function to all nodes in the graph more memory efficiently.
 
         Alternative implementation of `map` to reduce memory usage. While `map` keeps


### PR DESCRIPTION
## Description of changes

Previously `Node.map_clear` had a `dict` return type annotation,  just as `Node.map`, even though the main rationale behind `map_clear` is that it returns only the result of the root node and discards all the intermediaries.
