### PR TITLE
refactor(sql): simplify `FirstValue`/`LastValue` usage

### DIFF
--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -18,8 +18,6 @@ from ibis.backends.sql.rewrites import (
     exclude_unsupported_window_frame_from_ops,
     exclude_unsupported_window_frame_from_rank,
     exclude_unsupported_window_frame_from_row_number,
-    rewrite_first_to_first_value,
-    rewrite_last_to_last_value,
     rewrite_sample_as_filter,
 )
 from ibis.common.temporal import DateUnit, IntervalUnit, TimestampUnit, TimeUnit
@@ -33,8 +31,6 @@ class BigQueryCompiler(SQLGlotCompiler):
     udf_type_mapper = BigQueryUDFType
     rewrites = (
         rewrite_sample_as_filter,
-        rewrite_first_to_first_value,
-        rewrite_last_to_last_value,
         exclude_unsupported_window_frame_from_ops,
         exclude_unsupported_window_frame_from_row_number,
         exclude_unsupported_window_frame_from_rank,

--- a/ibis/backends/flink/compiler.py
+++ b/ibis/backends/flink/compiler.py
@@ -15,8 +15,6 @@ from ibis.backends.sql.rewrites import (
     exclude_unsupported_window_frame_from_ops,
     exclude_unsupported_window_frame_from_rank,
     exclude_unsupported_window_frame_from_row_number,
-    rewrite_first_to_first_value,
-    rewrite_last_to_last_value,
     rewrite_sample_as_filter,
 )
 
@@ -30,8 +28,6 @@ class FlinkCompiler(SQLGlotCompiler):
         exclude_unsupported_window_frame_from_row_number,
         exclude_unsupported_window_frame_from_ops,
         exclude_unsupported_window_frame_from_rank,
-        rewrite_first_to_first_value,
-        rewrite_last_to_last_value,
         *SQLGlotCompiler.rewrites,
     )
 

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -12,8 +12,6 @@ from ibis.backends.sql.datatypes import ImpalaType
 from ibis.backends.sql.dialects import Impala
 from ibis.backends.sql.rewrites import (
     rewrite_empty_order_by_window,
-    rewrite_first_to_first_value,
-    rewrite_last_to_last_value,
     rewrite_sample_as_filter,
 )
 
@@ -25,8 +23,6 @@ class ImpalaCompiler(SQLGlotCompiler):
     type_mapper = ImpalaType
     rewrites = (
         rewrite_sample_as_filter,
-        rewrite_first_to_first_value,
-        rewrite_last_to_last_value,
         rewrite_empty_order_by_window,
         *SQLGlotCompiler.rewrites,
     )

--- a/ibis/backends/impala/tests/snapshots/test_window/test_add_default_order_by/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_window/test_add_default_order_by/out.sql
@@ -12,7 +12,7 @@ SELECT
   `t0`.`k`,
   LAG(`t0`.`f`) OVER (PARTITION BY `t0`.`g` ORDER BY NULL ASC NULLS LAST) AS `lag`,
   LEAD(`t0`.`f`) OVER (PARTITION BY `t0`.`g` ORDER BY NULL ASC NULLS LAST) - `t0`.`f` AS `fwd_diff`,
-  FIRST_VALUE(`t0`.`f`) OVER (PARTITION BY `t0`.`g`) AS `first`,
-  LAST_VALUE(`t0`.`f`) OVER (PARTITION BY `t0`.`g`) AS `last`,
+  FIRST_VALUE(`t0`.`f`) OVER (PARTITION BY `t0`.`g` ORDER BY NULL ASC NULLS LAST) AS `first`,
+  LAST_VALUE(`t0`.`f`) OVER (PARTITION BY `t0`.`g` ORDER BY NULL ASC NULLS LAST) AS `last`,
   LAG(`t0`.`f`) OVER (PARTITION BY `t0`.`g` ORDER BY `t0`.`d` ASC NULLS LAST) AS `lag2`
 FROM `alltypes` AS `t0`

--- a/ibis/backends/mssql/compiler.py
+++ b/ibis/backends/mssql/compiler.py
@@ -24,8 +24,6 @@ from ibis.backends.sql.rewrites import (
     exclude_unsupported_window_frame_from_row_number,
     p,
     replace,
-    rewrite_first_to_first_value,
-    rewrite_last_to_last_value,
     rewrite_sample_as_filter,
 )
 from ibis.common.deferred import var
@@ -66,8 +64,6 @@ class MSSQLCompiler(SQLGlotCompiler):
     type_mapper = MSSQLType
     rewrites = (
         rewrite_sample_as_filter,
-        rewrite_first_to_first_value,
-        rewrite_last_to_last_value,
         exclude_unsupported_window_frame_from_ops,
         exclude_unsupported_window_frame_from_row_number,
         rewrite_rows_range_order_by_window,

--- a/ibis/backends/mysql/compiler.py
+++ b/ibis/backends/mysql/compiler.py
@@ -18,8 +18,6 @@ from ibis.backends.sql.rewrites import (
     exclude_unsupported_window_frame_from_rank,
     exclude_unsupported_window_frame_from_row_number,
     rewrite_empty_order_by_window,
-    rewrite_first_to_first_value,
-    rewrite_last_to_last_value,
     rewrite_sample_as_filter,
 )
 from ibis.common.patterns import replace
@@ -53,8 +51,6 @@ class MySQLCompiler(SQLGlotCompiler):
     rewrites = (
         rewrite_limit,
         rewrite_sample_as_filter,
-        rewrite_first_to_first_value,
-        rewrite_last_to_last_value,
         exclude_unsupported_window_frame_from_ops,
         exclude_unsupported_window_frame_from_rank,
         exclude_unsupported_window_frame_from_row_number,

--- a/ibis/backends/oracle/compiler.py
+++ b/ibis/backends/oracle/compiler.py
@@ -18,8 +18,6 @@ from ibis.backends.sql.rewrites import (
     replace_log2,
     replace_log10,
     rewrite_empty_order_by_window,
-    rewrite_first_to_first_value,
-    rewrite_last_to_last_value,
     rewrite_sample_as_filter,
 )
 
@@ -33,8 +31,6 @@ class OracleCompiler(SQLGlotCompiler):
     rewrites = (
         exclude_unsupported_window_frame_from_row_number,
         exclude_unsupported_window_frame_from_ops,
-        rewrite_first_to_first_value,
-        rewrite_last_to_last_value,
         rewrite_empty_order_by_window,
         rewrite_sample_as_filter,
         replace_log2,

--- a/ibis/backends/oracle/compiler.py
+++ b/ibis/backends/oracle/compiler.py
@@ -11,6 +11,8 @@ from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler
 from ibis.backends.sql.datatypes import OracleType
 from ibis.backends.sql.dialects import Oracle
 from ibis.backends.sql.rewrites import (
+    FirstValue,
+    LastValue,
     exclude_unsupported_window_frame_from_ops,
     exclude_unsupported_window_frame_from_row_number,
     replace_log2,
@@ -409,8 +411,8 @@ class OracleCompiler(SQLGlotCompiler):
             ops.Correlation,  # "corr",
             ops.Count,  # "count",
             ops.Covariance,  # "covar_pop", "covar_samp",
-            ops.FirstValue,  # "first_value",
-            ops.LastValue,  # "last_value",
+            FirstValue,  # "first_value",
+            LastValue,  # "last_value",
             ops.Max,  # "max",
             ops.Min,  # "min",
             ops.NthValue,  # "nth_value",

--- a/ibis/backends/pandas/executor.py
+++ b/ibis/backends/pandas/executor.py
@@ -453,15 +453,6 @@ class PandasExecutor(Dispatched, PandasUtils):
         return agg
 
     @classmethod
-    def visit(cls, op: ops.FirstValue | ops.LastValue, arg):
-        i = 0 if isinstance(op, ops.FirstValue) else -1
-
-        def agg(df, order_keys):
-            return df[arg.name].iat[i]
-
-        return agg
-
-    @classmethod
     def visit(
         cls, op: ops.AnalyticVectorizedUDF, func, func_args, input_type, return_type
     ):

--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -20,8 +20,6 @@ from ibis.backends.sql.rewrites import (
     replace_log2,
     replace_log10,
     rewrite_empty_order_by_window,
-    rewrite_first_to_first_value,
-    rewrite_last_to_last_value,
 )
 
 
@@ -39,8 +37,6 @@ class SnowflakeCompiler(SQLGlotCompiler):
     rewrites = (
         exclude_unsupported_window_frame_from_row_number,
         exclude_unsupported_window_frame_from_ops,
-        rewrite_first_to_first_value,
-        rewrite_last_to_last_value,
         rewrite_empty_order_by_window,
         replace_log2,
         replace_log10,

--- a/ibis/backends/sql/compiler.py
+++ b/ibis/backends/sql/compiler.py
@@ -19,6 +19,8 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.backends.sql.rewrites import (
+    FirstValue,
+    LastValue,
     add_one_to_nth_value_input,
     add_order_by_to_empty_ranking_window_functions,
     empty_in_values_right_side,
@@ -235,7 +237,7 @@ class SQLGlotCompiler(abc.ABC):
         ops.DenseRank: "dense_rank",
         ops.Exp: "exp",
         ops.First: "first",
-        ops.FirstValue: "first_value",
+        FirstValue: "first_value",
         ops.GroupConcat: "group_concat",
         ops.IfElse: "if",
         ops.IsInf: "isinf",
@@ -243,7 +245,7 @@ class SQLGlotCompiler(abc.ABC):
         ops.JSONGetItem: "json_extract",
         ops.LPad: "lpad",
         ops.Last: "last",
-        ops.LastValue: "last_value",
+        LastValue: "last_value",
         ops.Levenshtein: "levenshtein",
         ops.Ln: "ln",
         ops.Log10: "log",

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -63,6 +63,28 @@ class Select(ops.Relation):
 
 
 @public
+class FirstValue(ops.Analytic):
+    """Retrieve the first element."""
+
+    arg: ops.Column[dt.Any]
+
+    @attribute
+    def dtype(self):
+        return self.arg.dtype
+
+
+@public
+class LastValue(ops.Analytic):
+    """Retrieve the last element."""
+
+    arg: ops.Column[dt.Any]
+
+    @attribute
+    def dtype(self):
+        return self.arg.dtype
+
+
+@public
 class Window(ops.Value):
     """Window modelled after SQL's window statements."""
 
@@ -277,7 +299,7 @@ def rewrite_first_to_first_value(_, x, y, **kwargs):
         raise com.UnsupportedOperationError(
             "`first` with `where` is unsupported in a window function"
         )
-    return _.copy(func=ops.FirstValue(x))
+    return _.copy(func=FirstValue(x))
 
 
 @replace(p.WindowFunction(p.Last(x, where=y)))
@@ -287,7 +309,7 @@ def rewrite_last_to_last_value(_, x, y, **kwargs):
         raise com.UnsupportedOperationError(
             "`last` with `where` is unsupported in a window function"
         )
-    return _.copy(func=ops.LastValue(x))
+    return _.copy(func=LastValue(x))
 
 
 @replace(p.WindowFunction(frame=y @ p.WindowFrame(order_by=())))

--- a/ibis/backends/sqlite/compiler.py
+++ b/ibis/backends/sqlite/compiler.py
@@ -10,11 +10,7 @@ import ibis.expr.operations as ops
 from ibis.backends.sql.compiler import NULL, SQLGlotCompiler
 from ibis.backends.sql.datatypes import SQLiteType
 from ibis.backends.sql.dialects import SQLite
-from ibis.backends.sql.rewrites import (
-    rewrite_first_to_first_value,
-    rewrite_last_to_last_value,
-    rewrite_sample_as_filter,
-)
+from ibis.backends.sql.rewrites import rewrite_sample_as_filter
 from ibis.common.temporal import DateUnit, IntervalUnit
 
 
@@ -24,12 +20,7 @@ class SQLiteCompiler(SQLGlotCompiler):
 
     dialect = SQLite
     type_mapper = SQLiteType
-    rewrites = (
-        rewrite_sample_as_filter,
-        rewrite_first_to_first_value,
-        rewrite_last_to_last_value,
-        *SQLGlotCompiler.rewrites,
-    )
+    rewrites = (rewrite_sample_as_filter, *SQLGlotCompiler.rewrites)
 
     NAN = NULL
     POS_INF = sge.Literal.number("1e999")

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/clickhouse/out.sql
@@ -15,8 +15,8 @@ WITH "t5" AS (
         "t2"."field_of_study",
         "t2"."years",
         "t2"."degrees",
-        any("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
-        anyLast("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
+        first_value("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+        last_value("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
       FROM (
         SELECT
           "t1"."field_of_study",

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/duckdb/out.sql
@@ -15,8 +15,8 @@ WITH "t5" AS (
         "t2"."field_of_study",
         "t2"."years",
         "t2"."degrees",
-        FIRST("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
-        LAST("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
+        FIRST_VALUE("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+        LAST_VALUE("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
       FROM (
         SELECT
           "t1"."field_of_study",

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/postgres/out.sql
@@ -15,8 +15,8 @@ WITH "t5" AS (
         "t2"."field_of_study",
         "t2"."years",
         "t2"."degrees",
-        FIRST("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
-        LAST("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
+        FIRST_VALUE("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+        LAST_VALUE("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
       FROM (
         SELECT
           "t1"."field_of_study",

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -177,17 +177,11 @@ def calc_zscore(s):
             lambda t, win: t.float_col.first().over(win),
             lambda t: t.float_col.transform("first"),
             id="first",
-            marks=[
-                pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError),
-            ],
         ),
         param(
             lambda t, win: t.float_col.last().over(win),
             lambda t: t.float_col.transform("last"),
             id="last",
-            marks=[
-                pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError),
-            ],
         ),
         param(
             lambda t, win: t.double_col.nth(3).over(win),
@@ -1073,7 +1067,7 @@ def test_mutate_window_filter(backend, alltypes):
     backend.assert_frame_equal(res, sol, check_dtype=False)
 
 
-@pytest.mark.notimpl(["polars", "exasol"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 def test_first_last(backend):
     t = backend.win
     w = ibis.window(group_by=t.g, order_by=[t.x, t.y], preceding=1, following=0)

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -19,11 +19,7 @@ from ibis.backends.sql.compiler import (
 )
 from ibis.backends.sql.datatypes import TrinoType
 from ibis.backends.sql.dialects import Trino
-from ibis.backends.sql.rewrites import (
-    exclude_unsupported_window_frame_from_ops,
-    rewrite_first_to_first_value,
-    rewrite_last_to_last_value,
-)
+from ibis.backends.sql.rewrites import exclude_unsupported_window_frame_from_ops
 
 
 class TrinoCompiler(SQLGlotCompiler):
@@ -31,12 +27,7 @@ class TrinoCompiler(SQLGlotCompiler):
 
     dialect = Trino
     type_mapper = TrinoType
-    rewrites = (
-        rewrite_first_to_first_value,
-        rewrite_last_to_last_value,
-        exclude_unsupported_window_frame_from_ops,
-        *SQLGlotCompiler.rewrites,
-    )
+    rewrites = (exclude_unsupported_window_frame_from_ops, *SQLGlotCompiler.rewrites)
     quoted = True
 
     NAN = sg.func("nan")

--- a/ibis/expr/operations/analytic.py
+++ b/ibis/expr/operations/analytic.py
@@ -90,24 +90,6 @@ class NTile(Analytic):
 
 
 @public
-class FirstValue(Analytic):
-    """Retrieve the first element."""
-
-    arg: Column[dt.Any]
-
-    dtype = rlz.dtype_like("arg")
-
-
-@public
-class LastValue(Analytic):
-    """Retrieve the last element."""
-
-    arg: Column[dt.Any]
-
-    dtype = rlz.dtype_like("arg")
-
-
-@public
 class NthValue(Analytic):
     """Retrieve the Nth element."""
 


### PR DESCRIPTION
During recent refactors the `FirstValue`/`LastValue` have been pretty much removed from the codebase - at this point they only exist since some backends require spelling `first`/`last` as `first_value`/`last_value` when used in a window function context (other backends alias `first`/`last` to these for nicer SQL UX).

This PR:

- Moves `FirstValue`/`LastValue` to `ibis/backends/sql/rewrites.py` to treat them as SQL-specific IR.
- Refactors the `First -> FirstValue`/`Last -> LastValue` window function rewrites to always apply for all SQL backends, making our compilation more uniform here.