### PR TITLE
feat(geospatial): add support for duckdb operations on literals

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1178,6 +1178,10 @@ class Backend(SQLBackend, CanCreateSchema, UrlFromPath):
                 )
             elif started is False:
                 self._record_batch_readers_consumed[t.name] = True
+
+        if expr.op().find((ops.GeoSpatialUnOp, ops.GeoSpatialBinOp)):
+            self.load_extension("spatial")
+
         super()._run_pre_execute_hooks(expr)
 
     def to_pyarrow_batches(

--- a/ibis/backends/duckdb/tests/test_geospatial.py
+++ b/ibis/backends/duckdb/tests/test_geospatial.py
@@ -306,3 +306,31 @@ def test_literal_geospatial_inferred(con, shp, expected, snapshot):
 def test_load_geo_example(con):
     t = ibis.examples.zones.fetch(backend=con)
     assert t.geom.type().is_geospatial()
+
+
+# For the next two tests we really want to ensure that
+# load_extenstion("spatial") hasn't been run yet. So we create a new connection
+# instead of using the  con fixture.
+
+# geospatial literal object,
+geo_line_lit = ibis.literal(
+    shapely.LineString([[0, 0], [1, 0], [1, 1]]), type="geometry"
+)
+
+
+@pytest.mark.parametrize("geo_line_lit", [geo_line_lit])
+def test_geo_unop_geo_literals(geo_line_lit):
+    # GeoSpatialUnOp operation on a geospatial literal
+    con = ibis.duckdb.connect()
+    expr = geo_line_lit.length()
+
+    assert con.execute(expr) == 2
+
+
+@pytest.mark.parametrize("geo_line_lit", [geo_line_lit])
+def test_geo_binop_geo_literals(geo_line_lit):
+    # GeoSpatialBinOp operation on a geospatial literal
+    con = ibis.duckdb.connect()
+    expr = geo_line_lit.distance(shapely.Point(0, 0))
+
+    assert con.execute(expr) == 0


### PR DESCRIPTION
## Description of changes

This PR add support for duckdb geospatial operations directly on geospatial literals. 

I gave this a try, I'm not sure this is the best way to go, but happy to iterate over it if there is a better way around. 

## Issues closed

Closes: https://github.com/ibis-project/ibis/issues/8143

cc: @gforsyth (thanks for the pointer to `_run_pre_execute_hooks`)