### PR TITLE
fix(sql): replace CTEs within CTEs

### DIFF
--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -188,7 +188,7 @@ def extract_ctes(node):
     g = Graph.from_bfs(node, filter=(ops.Relation, ops.Subquery, ops.JoinLink))
     for node, dependents in g.invert().items():
         if isinstance(node, ops.View) or (
-            isinstance(node, cte_types) and len(dependents) > 1
+            len(dependents) > 1 and isinstance(node, cte_types)
         ):
             result.append(node)
 
@@ -236,7 +236,7 @@ def sqlize(
     simplified = sqlized.replace(merge_select_select)
 
     # extract common table expressions while wrapping them in a CTE node
-    ctes = set(extract_ctes(simplified))
+    ctes = frozenset(extract_ctes(simplified))
 
     def wrap(node, _, **kwargs):
         new = node.__recreate__(kwargs)

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/bigquery/out.sql
@@ -1,42 +1,32 @@
-WITH `t6` AS (
-  SELECT
-    `t5`.`street`,
-    ROW_NUMBER() OVER (ORDER BY `t5`.`street` ASC) - 1 AS `key`
-  FROM (
-    SELECT
-      `t2`.`street`,
-      `t2`.`key`
-    FROM (
-      SELECT
-        `t0`.`street`,
-        ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC) - 1 AS `key`
-      FROM `data` AS `t0`
-    ) AS `t2`
-    INNER JOIN (
-      SELECT
-        `t1`.`key`
-      FROM (
-        SELECT
-          `t0`.`street`,
-          ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC) - 1 AS `key`
-        FROM `data` AS `t0`
-      ) AS `t1`
-    ) AS `t4`
-      ON `t2`.`key` = `t4`.`key`
-  ) AS `t5`
-), `t1` AS (
+WITH `t1` AS (
   SELECT
     `t0`.`street`,
     ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC) - 1 AS `key`
   FROM `data` AS `t0`
+), `t7` AS (
+  SELECT
+    `t6`.`street`,
+    ROW_NUMBER() OVER (ORDER BY `t6`.`street` ASC) - 1 AS `key`
+  FROM (
+    SELECT
+      `t3`.`street`,
+      `t3`.`key`
+    FROM `t1` AS `t3`
+    INNER JOIN (
+      SELECT
+        `t2`.`key`
+      FROM `t1` AS `t2`
+    ) AS `t5`
+      ON `t3`.`key` = `t5`.`key`
+  ) AS `t6`
 )
 SELECT
-  `t8`.`street`,
-  `t8`.`key`
-FROM `t6` AS `t8`
+  `t9`.`street`,
+  `t9`.`key`
+FROM `t7` AS `t9`
 INNER JOIN (
   SELECT
-    `t7`.`key`
-  FROM `t6` AS `t7`
-) AS `t10`
-  ON `t8`.`key` = `t10`.`key`
+    `t8`.`key`
+  FROM `t7` AS `t8`
+) AS `t11`
+  ON `t9`.`key` = `t11`.`key`

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/clickhouse/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-      FROM "data" AS "t0"
-    ) AS "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-        FROM "data" AS "t0"
-      ) AS "t1"
-    ) AS "t4"
-      ON "t2"."key" = "t4"."key"
-  ) AS "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
   FROM "data" AS "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" AS "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" AS "t2"
+    ) AS "t5"
+      ON "t3"."key" = "t5"."key"
+  ) AS "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" AS "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" AS "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" AS "t7"
-) AS "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" AS "t8"
+) AS "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/datafusion/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/datafusion/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-      FROM "data" AS "t0"
-    ) AS "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-        FROM "data" AS "t0"
-      ) AS "t1"
-    ) AS "t4"
-      ON "t2"."key" = "t4"."key"
-  ) AS "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
   FROM "data" AS "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" AS "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" AS "t2"
+    ) AS "t5"
+      ON "t3"."key" = "t5"."key"
+  ) AS "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" AS "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" AS "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" AS "t7"
-) AS "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" AS "t8"
+) AS "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/druid/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/druid/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-      FROM "data" AS "t0"
-    ) AS "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-        FROM "data" AS "t0"
-      ) AS "t1"
-    ) AS "t4"
-      ON "t2"."key" = "t4"."key"
-  ) AS "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
   FROM "data" AS "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" AS "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" AS "t2"
+    ) AS "t5"
+      ON "t3"."key" = "t5"."key"
+  ) AS "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" AS "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" AS "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" AS "t7"
-) AS "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" AS "t8"
+) AS "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/duckdb/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - CAST(1 AS TINYINT) AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - CAST(1 AS TINYINT) AS "key"
-      FROM "data" AS "t0"
-    ) AS "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - CAST(1 AS TINYINT) AS "key"
-        FROM "data" AS "t0"
-      ) AS "t1"
-    ) AS "t4"
-      ON "t2"."key" = "t4"."key"
-  ) AS "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - CAST(1 AS TINYINT) AS "key"
   FROM "data" AS "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - CAST(1 AS TINYINT) AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" AS "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" AS "t2"
+    ) AS "t5"
+      ON "t3"."key" = "t5"."key"
+  ) AS "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" AS "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" AS "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" AS "t7"
-) AS "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" AS "t8"
+) AS "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/exasol/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/exasol/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC) - 1 AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC) - 1 AS "key"
-      FROM "data" AS "t0"
-    ) AS "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC) - 1 AS "key"
-        FROM "data" AS "t0"
-      ) AS "t1"
-    ) AS "t4"
-      ON "t2"."key" = "t4"."key"
-  ) AS "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC) - 1 AS "key"
   FROM "data" AS "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC) - 1 AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" AS "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" AS "t2"
+    ) AS "t5"
+      ON "t3"."key" = "t5"."key"
+  ) AS "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" AS "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" AS "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" AS "t7"
-) AS "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" AS "t8"
+) AS "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/flink/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/flink/out.sql
@@ -1,42 +1,32 @@
-WITH `t6` AS (
-  SELECT
-    `t5`.`street`,
-    ROW_NUMBER() OVER (ORDER BY `t5`.`street` ASC NULLS LAST) - 1 AS `key`
-  FROM (
-    SELECT
-      `t2`.`street`,
-      `t2`.`key`
-    FROM (
-      SELECT
-        `t0`.`street`,
-        ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC NULLS LAST) - 1 AS `key`
-      FROM `data` AS `t0`
-    ) AS `t2`
-    INNER JOIN (
-      SELECT
-        `t1`.`key`
-      FROM (
-        SELECT
-          `t0`.`street`,
-          ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC NULLS LAST) - 1 AS `key`
-        FROM `data` AS `t0`
-      ) AS `t1`
-    ) AS `t4`
-      ON `t2`.`key` = `t4`.`key`
-  ) AS `t5`
-), `t1` AS (
+WITH `t1` AS (
   SELECT
     `t0`.`street`,
     ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC NULLS LAST) - 1 AS `key`
   FROM `data` AS `t0`
+), `t7` AS (
+  SELECT
+    `t6`.`street`,
+    ROW_NUMBER() OVER (ORDER BY `t6`.`street` ASC NULLS LAST) - 1 AS `key`
+  FROM (
+    SELECT
+      `t3`.`street`,
+      `t3`.`key`
+    FROM `t1` AS `t3`
+    INNER JOIN (
+      SELECT
+        `t2`.`key`
+      FROM `t1` AS `t2`
+    ) AS `t5`
+      ON `t3`.`key` = `t5`.`key`
+  ) AS `t6`
 )
 SELECT
-  `t8`.`street`,
-  `t8`.`key`
-FROM `t6` AS `t8`
+  `t9`.`street`,
+  `t9`.`key`
+FROM `t7` AS `t9`
 INNER JOIN (
   SELECT
-    `t7`.`key`
-  FROM `t6` AS `t7`
-) AS `t10`
-  ON `t8`.`key` = `t10`.`key`
+    `t8`.`key`
+  FROM `t7` AS `t8`
+) AS `t11`
+  ON `t9`.`key` = `t11`.`key`

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/impala/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/impala/out.sql
@@ -1,42 +1,32 @@
-WITH `t6` AS (
-  SELECT
-    `t5`.`street`,
-    ROW_NUMBER() OVER (ORDER BY `t5`.`street` ASC NULLS LAST) - 1 AS `key`
-  FROM (
-    SELECT
-      `t2`.`street`,
-      `t2`.`key`
-    FROM (
-      SELECT
-        `t0`.`street`,
-        ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC NULLS LAST) - 1 AS `key`
-      FROM `data` AS `t0`
-    ) AS `t2`
-    INNER JOIN (
-      SELECT
-        `t1`.`key`
-      FROM (
-        SELECT
-          `t0`.`street`,
-          ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC NULLS LAST) - 1 AS `key`
-        FROM `data` AS `t0`
-      ) AS `t1`
-    ) AS `t4`
-      ON `t2`.`key` = `t4`.`key`
-  ) AS `t5`
-), `t1` AS (
+WITH `t1` AS (
   SELECT
     `t0`.`street`,
     ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC NULLS LAST) - 1 AS `key`
   FROM `data` AS `t0`
+), `t7` AS (
+  SELECT
+    `t6`.`street`,
+    ROW_NUMBER() OVER (ORDER BY `t6`.`street` ASC NULLS LAST) - 1 AS `key`
+  FROM (
+    SELECT
+      `t3`.`street`,
+      `t3`.`key`
+    FROM `t1` AS `t3`
+    INNER JOIN (
+      SELECT
+        `t2`.`key`
+      FROM `t1` AS `t2`
+    ) AS `t5`
+      ON `t3`.`key` = `t5`.`key`
+  ) AS `t6`
 )
 SELECT
-  `t8`.`street`,
-  `t8`.`key`
-FROM `t6` AS `t8`
+  `t9`.`street`,
+  `t9`.`key`
+FROM `t7` AS `t9`
 INNER JOIN (
   SELECT
-    `t7`.`key`
-  FROM `t6` AS `t7`
-) AS `t10`
-  ON `t8`.`key` = `t10`.`key`
+    `t8`.`key`
+  FROM `t7` AS `t8`
+) AS `t11`
+  ON `t9`.`key` = `t11`.`key`

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/mssql/out.sql
@@ -1,42 +1,32 @@
-WITH [t6] AS (
-  SELECT
-    [t5].[street] AS [street],
-    ROW_NUMBER() OVER (ORDER BY CASE WHEN [t5].[street] IS NULL THEN 1 ELSE 0 END, [t5].[street] ASC) - 1 AS [key]
-  FROM (
-    SELECT
-      [t2].[street] AS [street],
-      [t2].[key] AS [key]
-    FROM (
-      SELECT
-        [t0].[street] AS [street],
-        ROW_NUMBER() OVER (ORDER BY CASE WHEN [t0].[street] IS NULL THEN 1 ELSE 0 END, [t0].[street] ASC) - 1 AS [key]
-      FROM [data] AS [t0]
-    ) AS [t2]
-    INNER JOIN (
-      SELECT
-        [t1].[key] AS [key]
-      FROM (
-        SELECT
-          [t0].[street] AS [street],
-          ROW_NUMBER() OVER (ORDER BY CASE WHEN [t0].[street] IS NULL THEN 1 ELSE 0 END, [t0].[street] ASC) - 1 AS [key]
-        FROM [data] AS [t0]
-      ) AS [t1]
-    ) AS [t4]
-      ON [t2].[key] = [t4].[key]
-  ) AS [t5]
-), [t1] AS (
+WITH [t1] AS (
   SELECT
     [t0].[street] AS [street],
     ROW_NUMBER() OVER (ORDER BY CASE WHEN [t0].[street] IS NULL THEN 1 ELSE 0 END, [t0].[street] ASC) - 1 AS [key]
   FROM [data] AS [t0]
+), [t7] AS (
+  SELECT
+    [t6].[street] AS [street],
+    ROW_NUMBER() OVER (ORDER BY CASE WHEN [t6].[street] IS NULL THEN 1 ELSE 0 END, [t6].[street] ASC) - 1 AS [key]
+  FROM (
+    SELECT
+      [t3].[street] AS [street],
+      [t3].[key] AS [key]
+    FROM [t1] AS [t3]
+    INNER JOIN (
+      SELECT
+        [t2].[key] AS [key]
+      FROM [t1] AS [t2]
+    ) AS [t5]
+      ON [t3].[key] = [t5].[key]
+  ) AS [t6]
 )
 SELECT
-  [t8].[street],
-  [t8].[key]
-FROM [t6] AS [t8]
+  [t9].[street],
+  [t9].[key]
+FROM [t7] AS [t9]
 INNER JOIN (
   SELECT
-    [t7].[key] AS [key]
-  FROM [t6] AS [t7]
-) AS [t10]
-  ON [t8].[key] = [t10].[key]
+    [t8].[key] AS [key]
+  FROM [t7] AS [t8]
+) AS [t11]
+  ON [t9].[key] = [t11].[key]

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/mysql/out.sql
@@ -1,42 +1,32 @@
-WITH `t6` AS (
-  SELECT
-    `t5`.`street`,
-    ROW_NUMBER() OVER (ORDER BY CASE WHEN `t5`.`street` IS NULL THEN 1 ELSE 0 END, `t5`.`street` ASC) - 1 AS `key`
-  FROM (
-    SELECT
-      `t2`.`street`,
-      `t2`.`key`
-    FROM (
-      SELECT
-        `t0`.`street`,
-        ROW_NUMBER() OVER (ORDER BY CASE WHEN `t0`.`street` IS NULL THEN 1 ELSE 0 END, `t0`.`street` ASC) - 1 AS `key`
-      FROM `data` AS `t0`
-    ) AS `t2`
-    INNER JOIN (
-      SELECT
-        `t1`.`key`
-      FROM (
-        SELECT
-          `t0`.`street`,
-          ROW_NUMBER() OVER (ORDER BY CASE WHEN `t0`.`street` IS NULL THEN 1 ELSE 0 END, `t0`.`street` ASC) - 1 AS `key`
-        FROM `data` AS `t0`
-      ) AS `t1`
-    ) AS `t4`
-      ON `t2`.`key` = `t4`.`key`
-  ) AS `t5`
-), `t1` AS (
+WITH `t1` AS (
   SELECT
     `t0`.`street`,
     ROW_NUMBER() OVER (ORDER BY CASE WHEN `t0`.`street` IS NULL THEN 1 ELSE 0 END, `t0`.`street` ASC) - 1 AS `key`
   FROM `data` AS `t0`
+), `t7` AS (
+  SELECT
+    `t6`.`street`,
+    ROW_NUMBER() OVER (ORDER BY CASE WHEN `t6`.`street` IS NULL THEN 1 ELSE 0 END, `t6`.`street` ASC) - 1 AS `key`
+  FROM (
+    SELECT
+      `t3`.`street`,
+      `t3`.`key`
+    FROM `t1` AS `t3`
+    INNER JOIN (
+      SELECT
+        `t2`.`key`
+      FROM `t1` AS `t2`
+    ) AS `t5`
+      ON `t3`.`key` = `t5`.`key`
+  ) AS `t6`
 )
 SELECT
-  `t8`.`street`,
-  `t8`.`key`
-FROM `t6` AS `t8`
+  `t9`.`street`,
+  `t9`.`key`
+FROM `t7` AS `t9`
 INNER JOIN (
   SELECT
-    `t7`.`key`
-  FROM `t6` AS `t7`
-) AS `t10`
-  ON `t8`.`key` = `t10`.`key`
+    `t8`.`key`
+  FROM `t7` AS `t8`
+) AS `t11`
+  ON `t9`.`key` = `t11`.`key`

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/oracle/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/oracle/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC NULLS LAST) - 1 AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC NULLS LAST) - 1 AS "key"
-      FROM "data" "t0"
-    ) "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC NULLS LAST) - 1 AS "key"
-        FROM "data" "t0"
-      ) "t1"
-    ) "t4"
-      ON "t2"."key" = "t4"."key"
-  ) "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC NULLS LAST) - 1 AS "key"
   FROM "data" "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC NULLS LAST) - 1 AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" "t2"
+    ) "t5"
+      ON "t3"."key" = "t5"."key"
+  ) "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" "t7"
-) "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" "t8"
+) "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/postgres/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-      FROM "data" AS "t0"
-    ) AS "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-        FROM "data" AS "t0"
-      ) AS "t1"
-    ) AS "t4"
-      ON "t2"."key" = "t4"."key"
-  ) AS "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
   FROM "data" AS "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" AS "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" AS "t2"
+    ) AS "t5"
+      ON "t3"."key" = "t5"."key"
+  ) AS "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" AS "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" AS "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" AS "t7"
-) AS "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" AS "t8"
+) AS "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/pyspark/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/pyspark/out.sql
@@ -1,42 +1,32 @@
-WITH `t6` AS (
-  SELECT
-    `t5`.`street`,
-    ROW_NUMBER() OVER (ORDER BY `t5`.`street` ASC NULLS LAST) - 1 AS `key`
-  FROM (
-    SELECT
-      `t2`.`street`,
-      `t2`.`key`
-    FROM (
-      SELECT
-        `t0`.`street`,
-        ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC NULLS LAST) - 1 AS `key`
-      FROM `data` AS `t0`
-    ) AS `t2`
-    INNER JOIN (
-      SELECT
-        `t1`.`key`
-      FROM (
-        SELECT
-          `t0`.`street`,
-          ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC NULLS LAST) - 1 AS `key`
-        FROM `data` AS `t0`
-      ) AS `t1`
-    ) AS `t4`
-      ON `t2`.`key` = `t4`.`key`
-  ) AS `t5`
-), `t1` AS (
+WITH `t1` AS (
   SELECT
     `t0`.`street`,
     ROW_NUMBER() OVER (ORDER BY `t0`.`street` ASC NULLS LAST) - 1 AS `key`
   FROM `data` AS `t0`
+), `t7` AS (
+  SELECT
+    `t6`.`street`,
+    ROW_NUMBER() OVER (ORDER BY `t6`.`street` ASC NULLS LAST) - 1 AS `key`
+  FROM (
+    SELECT
+      `t3`.`street`,
+      `t3`.`key`
+    FROM `t1` AS `t3`
+    INNER JOIN (
+      SELECT
+        `t2`.`key`
+      FROM `t1` AS `t2`
+    ) AS `t5`
+      ON `t3`.`key` = `t5`.`key`
+  ) AS `t6`
 )
 SELECT
-  `t8`.`street`,
-  `t8`.`key`
-FROM `t6` AS `t8`
+  `t9`.`street`,
+  `t9`.`key`
+FROM `t7` AS `t9`
 INNER JOIN (
   SELECT
-    `t7`.`key`
-  FROM `t6` AS `t7`
-) AS `t10`
-  ON `t8`.`key` = `t10`.`key`
+    `t8`.`key`
+  FROM `t7` AS `t8`
+) AS `t11`
+  ON `t9`.`key` = `t11`.`key`

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/risingwave/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/risingwave/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-      FROM "data" AS "t0"
-    ) AS "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-        FROM "data" AS "t0"
-      ) AS "t1"
-    ) AS "t4"
-      ON "t2"."key" = "t4"."key"
-  ) AS "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
   FROM "data" AS "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" AS "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" AS "t2"
+    ) AS "t5"
+      ON "t3"."key" = "t5"."key"
+  ) AS "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" AS "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" AS "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" AS "t7"
-) AS "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" AS "t8"
+) AS "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/sqlite/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-      FROM "data" AS "t0"
-    ) AS "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-        FROM "data" AS "t0"
-      ) AS "t1"
-    ) AS "t4"
-      ON "t2"."key" = "t4"."key"
-  ) AS "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
   FROM "data" AS "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" AS "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" AS "t2"
+    ) AS "t5"
+      ON "t3"."key" = "t5"."key"
+  ) AS "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" AS "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" AS "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" AS "t7"
-) AS "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" AS "t8"
+) AS "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_generic/test_many_subqueries/trino/out.sql
@@ -1,42 +1,32 @@
-WITH "t6" AS (
-  SELECT
-    "t5"."street",
-    ROW_NUMBER() OVER (ORDER BY "t5"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-  FROM (
-    SELECT
-      "t2"."street",
-      "t2"."key"
-    FROM (
-      SELECT
-        "t0"."street",
-        ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-      FROM "data" AS "t0"
-    ) AS "t2"
-    INNER JOIN (
-      SELECT
-        "t1"."key"
-      FROM (
-        SELECT
-          "t0"."street",
-          ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
-        FROM "data" AS "t0"
-      ) AS "t1"
-    ) AS "t4"
-      ON "t2"."key" = "t4"."key"
-  ) AS "t5"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."street",
     ROW_NUMBER() OVER (ORDER BY "t0"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
   FROM "data" AS "t0"
+), "t7" AS (
+  SELECT
+    "t6"."street",
+    ROW_NUMBER() OVER (ORDER BY "t6"."street" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) - 1 AS "key"
+  FROM (
+    SELECT
+      "t3"."street",
+      "t3"."key"
+    FROM "t1" AS "t3"
+    INNER JOIN (
+      SELECT
+        "t2"."key"
+      FROM "t1" AS "t2"
+    ) AS "t5"
+      ON "t3"."key" = "t5"."key"
+  ) AS "t6"
 )
 SELECT
-  "t8"."street",
-  "t8"."key"
-FROM "t6" AS "t8"
+  "t9"."street",
+  "t9"."key"
+FROM "t7" AS "t9"
 INNER JOIN (
   SELECT
-    "t7"."key"
-  FROM "t6" AS "t7"
-) AS "t10"
-  ON "t8"."key" = "t10"."key"
+    "t8"."key"
+  FROM "t7" AS "t8"
+) AS "t11"
+  ON "t9"."key" = "t11"."key"

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_subquery_in_union/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_subquery_in_union/out.sql
@@ -1,30 +1,4 @@
-WITH "t5" AS (
-  SELECT
-    "t2"."a",
-    "t2"."g",
-    "t2"."metric"
-  FROM (
-    SELECT
-      "t0"."a",
-      "t0"."g",
-      SUM("t0"."f") AS "metric"
-    FROM "alltypes" AS "t0"
-    GROUP BY
-      1,
-      2
-  ) AS "t2"
-  INNER JOIN (
-    SELECT
-      "t0"."a",
-      "t0"."g",
-      SUM("t0"."f") AS "metric"
-    FROM "alltypes" AS "t0"
-    GROUP BY
-      1,
-      2
-  ) AS "t4"
-    ON "t2"."g" = "t4"."g"
-), "t1" AS (
+WITH "t1" AS (
   SELECT
     "t0"."a",
     "t0"."g",
@@ -33,17 +7,25 @@ WITH "t5" AS (
   GROUP BY
     1,
     2
+), "t6" AS (
+  SELECT
+    "t3"."a",
+    "t3"."g",
+    "t3"."metric"
+  FROM "t1" AS "t3"
+  INNER JOIN "t1" AS "t5"
+    ON "t3"."g" = "t5"."g"
 )
 SELECT
-  "t8"."a",
-  "t8"."g",
-  "t8"."metric"
+  "t9"."a",
+  "t9"."g",
+  "t9"."metric"
 FROM (
   SELECT
     *
-  FROM "t5" AS "t6"
+  FROM "t6" AS "t7"
   UNION ALL
   SELECT
     *
-  FROM "t5" AS "t7"
-) AS "t8"
+  FROM "t6" AS "t8"
+) AS "t9"


### PR DESCRIPTION
While the CTE extraction worked properly, the CTEs haven't been replaced in the already extracted CTEs meaning that we didn't recursively replace.