### PR TITLE
test(bench): reduce big union join threshold

### DIFF
--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -775,7 +775,7 @@ def srcs():
 
 @pytest.fixture
 def nrels():
-    return 225
+    return 50
 
 
 def make_big_union(t, nrels):


### PR DESCRIPTION
This PR gets benchmarks passing again. Nesting levels were increased by https://github.com/ibis-project/ibis/pull/8414.

Unfortunately, SQLGlot's SQL generation algorithm (but not its parsing algorithm) is recursive.

This means that it cannot handle large nesting levels of select statements.

Pre-SQLGlot, Ibis used to handle much larger nesting levels. This functionality was lost in the sqlglot refactor.

Ultimately, someone needs to address this upstream in sqlglot by converting the generation algorithm to an iterative
one.

I believe we should gain a little bit back after #8572 is merged, since fewer select statements will be generated.