### PR TITLE
fix(bigquery): get literals working again

### DIFF
--- a/ibis/backends/bigquery/tests/system/conftest.py
+++ b/ibis/backends/bigquery/tests/system/conftest.py
@@ -76,6 +76,7 @@ def con(credentials, project_id, dataset_id):
     con = ibis.bigquery.connect(
         project_id=project_id, dataset_id=dataset_id, credentials=credentials
     )
+    con.client.default_query_job_config.use_query_cache = False
     try:
         con.sql("SELECT 1")
     except gexc.Forbidden:

--- a/ibis/backends/bigquery/tests/system/udf/test_udf_execute.py
+++ b/ibis/backends/bigquery/tests/system/udf/test_udf_execute.py
@@ -150,7 +150,10 @@ def test_builtin_scalar(con, value, expected):
     @udf.scalar.builtin
     def bit_count(x: bytes) -> int: ...
 
+    assert con.client.default_query_job_config.use_query_cache is False
+
     expr = bit_count(value)
+
     result = con.execute(expr)
     assert result == expected
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -306,7 +306,9 @@ class Backend(SQLBackend, CanCreateDatabase):
             database does not exist
 
         """
-        sql = sge.Drop(kind="DATABASE", exist=force, this=sg.to_identifier(name))
+        sql = sge.Drop(
+            kind="DATABASE", exist=force, this=sg.to_identifier(name), cascade=force
+        )
         with self._safe_raw_sql(sql):
             pass
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1343,12 +1343,10 @@ def test_persist_expression_release(con, alltypes):
 
 
 @contextlib.contextmanager
-def gen_test_name(con: BaseBackend) -> str:
+def gen_test_name(con: BaseBackend):
     name = gen_name("test_table")
-    try:
-        yield name
-    finally:
-        con.drop_table(name, force=True)
+    yield name
+    con.drop_table(name, force=True)
 
 
 @mark.notimpl(


### PR DESCRIPTION
Workaround for https://github.com/googleapis/python-bigquery/issues/1845.