### PR TITLE
perf(sql): prevent sqlglot from extensive deepcopying every time we create a sqlglot object

### DIFF
--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -12,7 +12,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis import util
-from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler, paren
+from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler
 from ibis.backends.sql.datatypes import BigQueryType, BigQueryUDFType
 from ibis.backends.sql.rewrites import (
     exclude_unsupported_window_frame_from_ops,
@@ -707,10 +707,10 @@ class BigQueryCompiler(SQLGlotCompiler):
         return self.f.count(STAR)
 
     def visit_Degrees(self, op, *, arg):
-        return paren(180 * arg / self.f.acos(-1))
+        return sge.paren(180 * arg / self.f.acos(-1), copy=False)
 
     def visit_Radians(self, op, *, arg):
-        return paren(self.f.acos(-1) * arg / 180)
+        return sge.paren(self.f.acos(-1) * arg / 180, copy=False)
 
     def visit_CountDistinct(self, op, *, arg, where):
         if where is not None:

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -11,12 +11,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis import util
-from ibis.backends.sql.compiler import (
-    NULL,
-    STAR,
-    SQLGlotCompiler,
-    parenthesize,
-)
+from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler
 from ibis.backends.sql.datatypes import ClickHouseType
 from ibis.backends.sql.dialects import ClickHouse
 from ibis.backends.sql.rewrites import rewrite_sample_as_filter
@@ -163,11 +158,11 @@ class ClickHouseCompiler(SQLGlotCompiler):
         return self.f.arrayFlatten(self.f.arrayMap(func, self.f.range(times)))
 
     def visit_ArraySlice(self, op, *, arg, start, stop):
-        start = parenthesize(op.start, start)
+        start = self._add_parens(op.start, start)
         start_correct = self.if_(start < 0, start, start + 1)
 
         if stop is not None:
-            stop = parenthesize(op.stop, stop)
+            stop = self._add_parens(op.stop, stop)
 
             length = self.if_(
                 stop < 0,

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -11,7 +11,7 @@ from sqlglot.dialects import DuckDB
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler, paren
+from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler
 from ibis.backends.sql.datatypes import DuckDBType
 
 _INTERVAL_SUFFIXES = {
@@ -402,6 +402,7 @@ class DuckDBCompiler(SQLGlotCompiler):
         if not isinstance(op.arg, (ops.Field, sge.Struct)):
             # parenthesize anything that isn't a simple field access
             return sge.Dot(
-                this=paren(arg), expression=sg.to_identifier(field, quoted=self.quoted)
+                this=sge.paren(arg),
+                expression=sg.to_identifier(field, quoted=self.quoted),
             )
         return super().visit_StructField(op, arg=arg, field=field)

--- a/ibis/backends/flink/compiler.py
+++ b/ibis/backends/flink/compiler.py
@@ -8,7 +8,7 @@ import sqlglot.expressions as sge
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler, paren
+from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler
 from ibis.backends.sql.datatypes import FlinkType
 from ibis.backends.sql.dialects import Flink
 from ibis.backends.sql.rewrites import (
@@ -467,12 +467,12 @@ class FlinkCompiler(SQLGlotCompiler):
         bucket_width = op.interval.value
         unit_func = self.f["dayofmonth" if unit.upper() == "DAY" else unit]
 
-        arg = self.f.anon.timestampadd(unit_var, -paren(offset), arg)
+        arg = self.f.anon.timestampadd(unit_var, -sge.paren(offset, copy=False), arg)
         mod = unit_func(arg) % bucket_width
 
         return self.f.anon.timestampadd(
             unit_var,
-            -paren(mod) + offset,
+            -sge.paren(mod, copy=False) + offset,
             self.v[f"FLOOR({arg.sql(self.dialect)} TO {unit_var.sql(self.dialect)})"],
         )
 

--- a/ibis/backends/mssql/compiler.py
+++ b/ibis/backends/mssql/compiler.py
@@ -15,7 +15,6 @@ from ibis.backends.sql.compiler import (
     STAR,
     TRUE,
     SQLGlotCompiler,
-    paren,
 )
 from ibis.backends.sql.datatypes import MSSQLType
 from ibis.backends.sql.dialects import MSSQL
@@ -189,7 +188,7 @@ class MSSQLCompiler(SQLGlotCompiler):
 
         Thanks to @arkanovicz for this glorious hack.
         """
-        return paren(self.f.len(self.f.concat("A", arg, "Z")) - 2)
+        return sge.paren(self.f.len(self.f.concat("A", arg, "Z")) - 2, copy=False)
 
     def visit_GroupConcat(self, op, *, arg, sep, where):
         if where is not None:

--- a/ibis/backends/mssql/compiler.py
+++ b/ibis/backends/mssql/compiler.py
@@ -68,6 +68,7 @@ class MSSQLCompiler(SQLGlotCompiler):
         rewrite_rows_range_order_by_window,
         *SQLGlotCompiler.rewrites,
     )
+    copy_func_args = True
 
     UNSUPPORTED_OPERATIONS = frozenset(
         (

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -11,7 +11,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
-from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler, paren
+from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler
 from ibis.backends.sql.datatypes import PostgresType
 from ibis.backends.sql.dialects import Postgres
 from ibis.backends.sql.rewrites import rewrite_sample_as_filter
@@ -125,7 +125,7 @@ class PostgresCompiler(SQLGlotCompiler):
             sge.Ordered(this=sge.Order(this=arg, expressions=[key]), desc=desc),
             where=sg.and_(*conditions),
         )
-        return paren(agg)[0]
+        return sge.paren(agg, copy=False)[0]
 
     def visit_ArgMin(self, op, *, arg, key, where):
         return self.visit_ArgMinMax(op, arg=arg, key=key, where=where, desc=False)
@@ -381,7 +381,7 @@ class PostgresCompiler(SQLGlotCompiler):
     def visit_RegexExtract(self, op, *, arg, pattern, index):
         pattern = self.f.concat("(", pattern, ")")
         matches = self.f.regexp_match(arg, pattern)
-        return self.if_(arg.rlike(pattern), paren(matches)[index], NULL)
+        return self.if_(arg.rlike(pattern), sge.paren(matches, copy=False)[index], NULL)
 
     def visit_FindInSet(self, op, *, needle, values):
         return self.f.coalesce(
@@ -466,7 +466,7 @@ class PostgresCompiler(SQLGlotCompiler):
 
     def visit_ArrayIndex(self, op, *, arg, index):
         index = self.if_(index < 0, self.f.cardinality(arg) + index, index)
-        return paren(arg)[index + 1]
+        return sge.paren(arg, copy=False)[index + 1]
 
     def visit_ArraySlice(self, op, *, arg, start, stop):
         neg_to_pos_index = lambda n, index: self.if_(index < 0, n + index, index)
@@ -484,7 +484,7 @@ class PostgresCompiler(SQLGlotCompiler):
             stop = neg_to_pos_index(arg_length, stop)
 
         slice_expr = sge.Slice(this=start + 1, expression=stop)
-        return paren(arg)[slice_expr]
+        return sge.paren(arg, copy=False)[slice_expr]
 
     def visit_IntervalFromInteger(self, op, *, arg, unit):
         plural = unit.plural

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -107,7 +107,7 @@ class SQLBackend(BaseBackend):
         assert not isinstance(sql, sge.Subquery)
 
         if isinstance(sql, sge.Table):
-            sql = sg.select(STAR).from_(sql)
+            sql = sg.select(STAR, copy=False).from_(sql, copy=False)
 
         assert not isinstance(sql, sge.Subquery)
         return sql
@@ -117,7 +117,7 @@ class SQLBackend(BaseBackend):
     ):
         """Compile an Ibis expression to a SQL string."""
         query = self._to_sqlglot(expr, limit=limit, params=params, **kwargs)
-        sql = query.sql(dialect=self.dialect, pretty=True)
+        sql = query.sql(dialect=self.dialect, pretty=True, copy=False)
         self._log(sql)
         return sql
 

--- a/ibis/backends/sql/compiler.py
+++ b/ibis/backends/sql/compiler.py
@@ -92,7 +92,9 @@ class FuncGen:
 
     def __getattr__(self, name: str) -> Callable[..., sge.Func]:
         name = ".".join(filter(None, (self.namespace, name)))
-        return lambda *args, **kwargs: sg.func(name, *map(sge.convert, args), **kwargs)
+        return lambda *args, **kwargs: sg.func(
+            name, *map(sge.convert, args), **kwargs, copy=False
+        )
 
     def __getitem__(self, key: str) -> Callable[..., sge.Func]:
         return getattr(self, key)

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -10,13 +10,7 @@ import toolz
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.sql.compiler import (
-    FALSE,
-    NULL,
-    STAR,
-    SQLGlotCompiler,
-    paren,
-)
+from ibis.backends.sql.compiler import FALSE, NULL, STAR, SQLGlotCompiler
 from ibis.backends.sql.datatypes import TrinoType
 from ibis.backends.sql.dialects import Trino
 from ibis.backends.sql.rewrites import exclude_unsupported_window_frame_from_ops
@@ -181,7 +175,9 @@ class TrinoCompiler(SQLGlotCompiler):
         return self.f.json_extract(arg, self.f.format(f"$[{fmt}]", index))
 
     def visit_DayOfWeekIndex(self, op, *, arg):
-        return self.cast(paren(self.f.day_of_week(arg) + 6) % 7, op.dtype)
+        return self.cast(
+            sge.paren(self.f.day_of_week(arg) + 6, copy=False) % 7, op.dtype
+        )
 
     def visit_DayOfWeekName(self, op, *, arg):
         return self.f.date_format(arg, "%W")


### PR DESCRIPTION
Still profiling and adding more `copy=False` options, apparently it greatly improves the performance.

According to profiling the recursive generation of sqlglot is still a bottleneck for big queries which cannot be fixed on the ibis side. There could be one option though to compile the fragments in a greedy fashion which are going to be cached by `Node.map()` and inject those as arbitrary strings to other sqlglot expressions.

The benchmark shows a pretty solid improvement:

```
------------------------------------------------------------------------------ benchmark 'test_compile[large-duckdb]': 2 tests -------------------------------------------------------------------------------
Name (time in ms)                                 Min                Max               Mean            StdDev             Median               IQR            Outliers       OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_compile[large-duckdb] (0399_182b6a5)     15.0069 (1.63)     43.1253 (1.38)     17.0702 (1.76)     5.8277 (2.57)     15.7781 (1.69)     0.3220 (1.28)         3;11   58.5818 (0.57)         59           1
test_compile[large-duckdb] (NOW)               9.2348 (1.0)      31.1592 (1.0)       9.6997 (1.0)      2.2679 (1.0)       9.3424 (1.0)      0.2524 (1.0)           1;7  103.0959 (1.0)          94           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Also measured the heap usage right after translation:

```py
BEFORE
Partition of a set of 3349536 objects. Total size = 418566016 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0 994115  30 180331768  43 180331768  43 dict (no owner)
     1 435432  13 48768384  12 229100152  55 sqlglot.expressions.Literal
     2 435432  13 31351104   7 260451256  62 dict of sqlglot.expressions.Literal
     3  94643   3 14095526   3 274546782  66 str
     4 105890   3 11859680   3 286406462  68 sqlglot.expressions.Identifier
     5  23325   1  8770520   2 295176982  71 types.CodeType
     6 105890   3  7624080   2 302801062  72 dict of sqlglot.expressions.Identifier
     7  46724   1  7169992   2 309971054  74 list
     8  85244   3  6257008   1 316228062  76 tuple
     9  52938   2  5929056   1 322157118  77 sqlglot.expressions.Column

AFTER copy=False
Partition of a set of 1083787 objects. Total size = 142273068 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0 249758  23 46102480  32  46102480  32 dict (no owner)
     1  94632   9 14094707  10  60197187  42 str
     2 104392  10 11691904   8  71889091  51 sqlglot.expressions.Literal
     3  23325   2  8770976   6  80660067  57 types.CodeType
     4 104392  10  7516224   5  88176291  62 dict of sqlglot.expressions.Literal
     5  85257   8  6258104   4  94434395  66 tuple
     6  46189   4  4157973   3  98592368  69 bytes
     7  22557   2  3428664   2 102021032  72 function
     8  25386   2  2843232   2 104864264  74 sqlglot.expressions.Identifier
     9   2327   0  2578312   2 107442576  76 type
```

Now it uses 30% of the memory it used before. Apparently there are still a lot of sqlglot Literal objects around, looking into that.

fixes #8484 