### PR TITLE
perf(sql): reduce the memory overhead of sqlglot compilation [WIP]

### DIFF
--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -117,7 +117,7 @@ class SQLBackend(BaseBackend):
     ):
         """Compile an Ibis expression to a SQL string."""
         query = self._to_sqlglot(expr, limit=limit, params=params, **kwargs)
-        sql = query.sql(dialect=self.dialect, pretty=True)
+        sql = query.sql(dialect=self.dialect, pretty=True, copy=False)
         self._log(sql)
         return sql
 


### PR DESCRIPTION
I experienced heavy memory usage during the reproduction of #8484, gigabytes of memory was used...

As turned out sqlglot expressions are aggressively deepcopied so we should minimize the amount of sqlglot expressions we hold references to. `Node.map()` keeps the output for each ibis expression in a mapping during translation which is not ideal in this scenario. 

Luckily #7863 added a memory efficient `.map_clear()` alternative which was primarily used in the pandas backend, but turns out to be useful here as well.

Depends on #8592 