### PR TITLE
ci(benchmarks): run benchmarks once in ibis-main to catch errors

### DIFF
--- a/.github/workflows/ibis-benchmarks.yml
+++ b/.github/workflows/ibis-benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-python@v5
         id: install_python
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: poetry
 
       - name: install system dependencies

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -85,13 +85,11 @@ jobs:
 
       - name: run all core tests and run benchmarks once parallel
         if: matrix.os != 'windows-latest'
-        # TODO(cpcloud): bring back benchmarks smoke tests -m 'core or benchmarks'
-        run: just ci-check -m core --numprocesses auto
+        run: just ci-check -m 'core or benchmarks' --numprocesses auto
 
       - name: run all core tests and run benchmarks once serial
         if: matrix.os == 'windows-latest'
-        # TODO(cpcloud): bring back benchmarks smoke tests -m 'core or benchmarks'
-        run: just ci-check -m core
+        run: just ci-check -m 'core or benchmarks'
 
       - name: upload code coverage
         if: success()


### PR DESCRIPTION
Address my own TODO before pre `the-epic-split`, enabling single-run benchmarks in the `ibis-main.yml` workflow.