### PR TITLE
depr: deprecate and warn on `legacy` udf usage

### DIFF
--- a/ibis/backends/dask/tests/test_window.py
+++ b/ibis/backends/dask/tests/test_window.py
@@ -473,14 +473,15 @@ def test_window_on_and_by_key_as_window_input(t, df):
     )
 
     # Test UDF
+    with pytest.warns(FutureWarning, match="v9.0"):
 
-    @reduction(input_type=[dt.int64], output_type=dt.int64)
-    def count(v):
-        return len(v)
+        @reduction(input_type=[dt.int64], output_type=dt.int64)
+        def count(v):
+            return len(v)
 
-    @reduction(input_type=[dt.int64, dt.int64], output_type=dt.int64)
-    def count_both(v1, v2):
-        return len(v1)
+        @reduction(input_type=[dt.int64, dt.int64], output_type=dt.int64)
+        def count_both(v1, v2):
+            return len(v1)
 
     tm.assert_series_equal(
         count(t[order_by]).over(row_window).execute(),

--- a/ibis/backends/datafusion/tests/test_udf.py
+++ b/ibis/backends/datafusion/tests/test_udf.py
@@ -11,21 +11,20 @@ from ibis.legacy.udf.vectorized import elementwise, reduction
 pytest.importorskip("datafusion")
 pc = pytest.importorskip("pyarrow.compute")
 
+with pytest.warns(FutureWarning, match="v9.0"):
 
-@elementwise(input_type=["string"], output_type="int64")
-def my_string_length(arr, **kwargs):
-    # arr is a pyarrow.StringArray
-    return pc.cast(pc.multiply(pc.utf8_length(arr), 2), target_type="int64")
+    @elementwise(input_type=["string"], output_type="int64")
+    def my_string_length(arr, **kwargs):
+        # arr is a pyarrow.StringArray
+        return pc.cast(pc.multiply(pc.utf8_length(arr), 2), target_type="int64")
 
+    @elementwise(input_type=[dt.int64, dt.int64], output_type=dt.int64)
+    def my_add(arr1, arr2, **kwargs):
+        return pc.add(arr1, arr2)
 
-@elementwise(input_type=[dt.int64, dt.int64], output_type=dt.int64)
-def my_add(arr1, arr2, **kwargs):
-    return pc.add(arr1, arr2)
-
-
-@reduction(input_type=[dt.float64], output_type=dt.float64)
-def my_mean(arr):
-    return pc.mean(arr)
+    @reduction(input_type=[dt.float64], output_type=dt.float64)
+    def my_mean(arr):
+        return pc.mean(arr)
 
 
 def test_udf(alltypes):

--- a/ibis/backends/pandas/tests/test_functions.py
+++ b/ibis/backends/pandas/tests/test_functions.py
@@ -216,9 +216,11 @@ def test_quantile_multi_array_access(client, t, df):
 def test_execute_with_same_hash_value_in_scope(
     left, right, expected_value, expected_type, left_dtype, right_dtype
 ):
-    @udf.elementwise([left_dtype, right_dtype], left_dtype)
-    def my_func(x, _):
-        return x
+    with pytest.warns(FutureWarning, match="v9.0"):
+
+        @udf.elementwise([left_dtype, right_dtype], left_dtype)
+        def my_func(x, _):
+            return x
 
     df = pd.DataFrame({"left": [left], "right": [right]})
     con = ibis.pandas.connect()
@@ -255,9 +257,11 @@ def test_ifelse_returning_bool():
     ],
 )
 def test_signature_does_not_match_input_type(dtype, value):
-    @udf.elementwise([dtype], dtype)
-    def func(x):
-        return x
+    with pytest.warns(FutureWarning, match="v9.0"):
+
+        @udf.elementwise([dtype], dtype)
+        def func(x):
+            return x
 
     df = pd.DataFrame({"col": [value]})
     table = ibis.pandas.connect().from_dataframe(df)

--- a/ibis/backends/pandas/tests/test_window.py
+++ b/ibis/backends/pandas/tests/test_window.py
@@ -498,14 +498,15 @@ def test_window_on_and_by_key_as_window_input(t, df):
     )
 
     # Test UDF
+    with pytest.warns(FutureWarning, match="v9.0"):
 
-    @reduction(input_type=[dt.int64], output_type=dt.int64)
-    def count(v):
-        return len(v)
+        @reduction(input_type=[dt.int64], output_type=dt.int64)
+        def count(v):
+            return len(v)
 
-    @reduction(input_type=[dt.int64, dt.int64], output_type=dt.int64)
-    def count_both(v1, v2):
-        return len(v1)
+        @reduction(input_type=[dt.int64, dt.int64], output_type=dt.int64)
+        def count_both(v1, v2):
+            return len(v1)
 
     tm.assert_series_equal(
         count(t[order_by]).over(row_window).execute(),
@@ -545,17 +546,21 @@ def test_rolling_window_udf_nan_and_non_numeric(t, group_by, order_by):
     t = t.mutate(nan_int64=t["plain_int64"])
     t = t.mutate(nan_int64=None)
 
-    @reduction(input_type=[dt.int64], output_type=dt.int64)
-    def count_int64(v):
-        return len(v)
+    with pytest.warns(FutureWarning, match="v9.0"):
 
-    @reduction(input_type=[dt.timestamp], output_type=dt.int64)
-    def count_timestamp(v):
-        return len(v)
+        @reduction(input_type=[dt.int64], output_type=dt.int64)
+        def count_int64(v):
+            return len(v)
 
-    @reduction(input_type=[t["map_of_strings_integers"].type()], output_type=dt.int64)
-    def count_complex(v):
-        return len(v)
+        @reduction(input_type=[dt.timestamp], output_type=dt.int64)
+        def count_timestamp(v):
+            return len(v)
+
+        @reduction(
+            input_type=[t["map_of_strings_integers"].type()], output_type=dt.int64
+        )
+        def count_complex(v):
+            return len(v)
 
     window = ibis.trailing_window(preceding=1, order_by=order_by, group_by=group_by)
 

--- a/ibis/backends/polars/tests/test_udf.py
+++ b/ibis/backends/polars/tests/test_udf.py
@@ -12,22 +12,21 @@ from ibis.legacy.udf.vectorized import elementwise, reduction
 pytest.importorskip("polars")
 pc = pytest.importorskip("pyarrow.compute")
 
+with pytest.warns(FutureWarning, match="v9.0"):
 
-@elementwise(input_type=["string"], output_type="int64")
-def my_string_length(arr, **kwargs):
-    return pl.from_arrow(
-        pc.cast(pc.multiply(pc.utf8_length(arr.to_arrow()), 2), target_type="int64")
-    )
+    @elementwise(input_type=["string"], output_type="int64")
+    def my_string_length(arr, **kwargs):
+        return pl.from_arrow(
+            pc.cast(pc.multiply(pc.utf8_length(arr.to_arrow()), 2), target_type="int64")
+        )
 
+    @elementwise(input_type=[dt.int64, dt.int64], output_type=dt.int64)
+    def my_add(arr1, arr2, **kwargs):
+        return pl.from_arrow(pc.add(arr1.to_arrow(), arr2.to_arrow()))
 
-@elementwise(input_type=[dt.int64, dt.int64], output_type=dt.int64)
-def my_add(arr1, arr2, **kwargs):
-    return pl.from_arrow(pc.add(arr1.to_arrow(), arr2.to_arrow()))
-
-
-@reduction(input_type=[dt.float64], output_type=dt.float64)
-def my_mean(arr):
-    return pc.mean(arr)
+    @reduction(input_type=[dt.float64], output_type=dt.float64)
+    def my_mean(arr):
+        return pc.mean(arr)
 
 
 def test_udf(alltypes):

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -32,10 +32,11 @@ from ibis.backends.tests.errors import (
 )
 from ibis.legacy.udf.vectorized import reduction
 
+with pytest.warns(FutureWarning, match="v9.0"):
 
-@reduction(input_type=[dt.double], output_type=dt.double)
-def mean_udf(s):
-    return s.mean()
+    @reduction(input_type=[dt.double], output_type=dt.double)
+    def mean_udf(s):
+        return s.mean()
 
 
 aggregate_test_params = [
@@ -232,13 +233,14 @@ def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
 def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
     """Tests .aggregate() on a multi-key group_by with a reduction
     operation."""
+    with pytest.warns(FutureWarning, match="v9.0"):
 
-    @reduction(
-        input_type=[dt.double],
-        output_type=dt.Struct({"mean": dt.double, "std": dt.double}),
-    )
-    def mean_and_std(v):
-        return v.mean(), v.std()
+        @reduction(
+            input_type=[dt.double],
+            output_type=dt.Struct({"mean": dt.double, "std": dt.double}),
+        )
+        def mean_and_std(v):
+            return v.mean(), v.std()
 
     grouping_key_cols = ["bigint_col", "int_col"]
 
@@ -1427,8 +1429,8 @@ def test_aggregate_list_like(backend, alltypes, df, agg_fn):
     words, the resulting table expression should have one element, which
     is the list / np.array).
     """
-
-    udf = reduction(input_type=[dt.double], output_type=dt.Array(dt.double))(agg_fn)
+    with pytest.warns(FutureWarning, match="v9.0"):
+        udf = reduction(input_type=[dt.double], output_type=dt.Array(dt.double))(agg_fn)
 
     expr = alltypes.aggregate(result_col=udf(alltypes.double_col))
     result = expr.execute()
@@ -1468,14 +1470,15 @@ def test_aggregate_mixed_udf(backend, alltypes, df):
     (In particular, one aggregation that results in an array, and other
     aggregation(s) that result in a non-array)
     """
+    with pytest.warns(FutureWarning, match="v9.0"):
 
-    @reduction(input_type=[dt.double], output_type=dt.double)
-    def sum_udf(v):
-        return np.sum(v)
+        @reduction(input_type=[dt.double], output_type=dt.double)
+        def sum_udf(v):
+            return np.sum(v)
 
-    @reduction(input_type=[dt.double], output_type=dt.Array(dt.double))
-    def collect_udf(v):
-        return np.array(v)
+        @reduction(input_type=[dt.double], output_type=dt.Array(dt.double))
+        def collect_udf(v):
+            return np.array(v)
 
     expr = alltypes.aggregate(
         sum_col=sum_udf(alltypes.double_col),

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -43,9 +43,11 @@ def add_one(s):
 
 
 def create_add_one_udf(result_formatter, id):
-    @elementwise(input_type=[dt.double], output_type=dt.double)
-    def add_one_legacy(s):
-        return result_formatter(add_one(s))
+    with pytest.warns(FutureWarning, match="v9.0"):
+
+        @elementwise(input_type=[dt.double], output_type=dt.double)
+        def add_one_legacy(s):
+            return result_formatter(add_one(s))
 
     @ibis.udf.scalar.pandas
     def add_one_udf(s: float) -> float:
@@ -73,9 +75,10 @@ def calc_zscore(s):
 
 
 def create_calc_zscore_udf(result_formatter):
-    return analytic(input_type=[dt.double], output_type=dt.double)(
-        _format_udf_return_type(calc_zscore, result_formatter)
-    )
+    with pytest.warns(FutureWarning, match="v9.0"):
+        return analytic(input_type=[dt.double], output_type=dt.double)(
+            _format_udf_return_type(calc_zscore, result_formatter)
+        )
 
 
 calc_zscore_udfs = [
@@ -84,11 +87,12 @@ calc_zscore_udfs = [
     create_calc_zscore_udf(result_formatter=lambda v: list(v)),  # list,
 ]
 
+with pytest.warns(FutureWarning, match="v9.0"):
 
-@reduction(input_type=[dt.double], output_type=dt.double)
-def calc_mean(s):
-    assert isinstance(s, (np.ndarray, pd.Series))
-    return s.mean()
+    @reduction(input_type=[dt.double], output_type=dt.double)
+    def calc_mean(s):
+        assert isinstance(s, (np.ndarray, pd.Series))
+        return s.mean()
 
 
 # elementwise multi-column UDF
@@ -98,10 +102,11 @@ def add_one_struct(v):
 
 
 def create_add_one_struct_udf(result_formatter):
-    return elementwise(
-        input_type=[dt.double],
-        output_type=dt.Struct({"col1": dt.double, "col2": dt.double}),
-    )(_format_struct_udf_return_type(add_one_struct, result_formatter))
+    with pytest.warns(FutureWarning, match="v9.0"):
+        return elementwise(
+            input_type=[dt.double],
+            output_type=dt.Struct({"col1": dt.double, "col2": dt.double}),
+        )(_format_struct_udf_return_type(add_one_struct, result_formatter))
 
 
 add_one_struct_udfs = [
@@ -139,35 +144,37 @@ add_one_struct_udfs = [
     ),
 ]
 
+with pytest.warns(FutureWarning, match="v9.0"):
 
-@elementwise(
-    input_type=[dt.double],
-    output_type=dt.Struct({"double_col": dt.double, "col2": dt.double}),
-)
-def overwrite_struct_elementwise(v):
-    assert isinstance(v, pd.Series)
-    return v + 1, v + 2
+    @elementwise(
+        input_type=[dt.double],
+        output_type=dt.Struct({"double_col": dt.double, "col2": dt.double}),
+    )
+    def overwrite_struct_elementwise(v):
+        assert isinstance(v, pd.Series)
+        return v + 1, v + 2
+
+    @elementwise(
+        input_type=[dt.double],
+        output_type=dt.Struct(
+            {"double_col": dt.double, "col2": dt.double, "float_col": dt.double}
+        ),
+    )
+    def multiple_overwrite_struct_elementwise(v):
+        assert isinstance(v, pd.Series)
+        return v + 1, v + 2, v + 3
 
 
-@elementwise(
-    input_type=[dt.double],
-    output_type=dt.Struct(
-        {"double_col": dt.double, "col2": dt.double, "float_col": dt.double}
-    ),
-)
-def multiple_overwrite_struct_elementwise(v):
-    assert isinstance(v, pd.Series)
-    return v + 1, v + 2, v + 3
+with pytest.warns(FutureWarning, match="v9.0"):
 
-
-@analytic(
-    input_type=[dt.double, dt.double],
-    output_type=dt.Struct({"double_col": dt.double, "demean_weight": dt.double}),
-)
-def overwrite_struct_analytic(v, w):
-    assert isinstance(v, pd.Series)
-    assert isinstance(w, pd.Series)
-    return v - v.mean(), w - w.mean()
+    @analytic(
+        input_type=[dt.double, dt.double],
+        output_type=dt.Struct({"double_col": dt.double, "demean_weight": dt.double}),
+    )
+    def overwrite_struct_analytic(v, w):
+        assert isinstance(v, pd.Series)
+        assert isinstance(w, pd.Series)
+        return v - v.mean(), w - w.mean()
 
 
 # analytic multi-column UDF
@@ -178,10 +185,11 @@ def demean_struct(v, w):
 
 
 def create_demean_struct_udf(result_formatter):
-    return analytic(
-        input_type=[dt.double, dt.double],
-        output_type=dt.Struct({"demean": dt.double, "demean_weight": dt.double}),
-    )(_format_struct_udf_return_type(demean_struct, result_formatter))
+    with pytest.warns(FutureWarning, match="v9.0"):
+        return analytic(
+            input_type=[dt.double, dt.double],
+            output_type=dt.Struct({"demean": dt.double, "demean_weight": dt.double}),
+        )(_format_struct_udf_return_type(demean_struct, result_formatter))
 
 
 demean_struct_udfs = [
@@ -216,10 +224,11 @@ def mean_struct(v, w):
 
 
 def create_mean_struct_udf(result_formatter):
-    return reduction(
-        input_type=[dt.double, dt.int64],
-        output_type=dt.Struct({"mean": dt.double, "mean_weight": dt.double}),
-    )(_format_struct_udf_return_type(mean_struct, result_formatter))
+    with pytest.warns(FutureWarning, match="v9.0"):
+        return reduction(
+            input_type=[dt.double, dt.int64],
+            output_type=dt.Struct({"mean": dt.double, "mean_weight": dt.double}),
+        )(_format_struct_udf_return_type(mean_struct, result_formatter))
 
 
 mean_struct_udfs = [
@@ -232,23 +241,23 @@ mean_struct_udfs = [
     ),  # np.array of scalar
 ]
 
+with pytest.warns(FutureWarning, match="v9.0"):
 
-@reduction(
-    input_type=[dt.double, dt.int64],
-    output_type=dt.Struct({"double_col": dt.double, "mean_weight": dt.double}),
-)
-def overwrite_struct_reduction(v, w):
-    assert isinstance(v, (np.ndarray, pd.Series))
-    assert isinstance(w, (np.ndarray, pd.Series))
-    return v.mean(), w.mean()
+    @reduction(
+        input_type=[dt.double, dt.int64],
+        output_type=dt.Struct({"double_col": dt.double, "mean_weight": dt.double}),
+    )
+    def overwrite_struct_reduction(v, w):
+        assert isinstance(v, (np.ndarray, pd.Series))
+        assert isinstance(w, (np.ndarray, pd.Series))
+        return v.mean(), w.mean()
 
-
-@reduction(
-    input_type=[dt.double],
-    output_type=dt.Array(dt.double),
-)
-def quantiles(series, *, quantiles):
-    return series.quantile(quantiles)
+    @reduction(
+        input_type=[dt.double],
+        output_type=dt.Array(dt.double),
+    )
+    def quantiles(series, *, quantiles):
+        return series.quantile(quantiles)
 
 
 @pytest.mark.parametrize(
@@ -344,29 +353,31 @@ def test_output_type_in_list_invalid():
         com.IbisTypeError,
         match="The output type of a UDF must be a single datatype.",
     ):
+        with pytest.warns(FutureWarning, match="v9.0"):
 
-        @elementwise(input_type=[dt.double], output_type=[dt.double])
-        def _(s):
-            return s + 1
+            @elementwise(input_type=[dt.double], output_type=[dt.double])
+            def _(s):
+                return s + 1
 
 
 def test_valid_kwargs(udf_backend, udf_alltypes, udf_df):
     # Test different forms of UDF definition with keyword arguments
+    with pytest.warns(FutureWarning, match="v9.0"):
 
-    @elementwise(input_type=[dt.double], output_type=dt.double)
-    def foo1(v):
-        # Basic UDF with kwargs
-        return v + 1
+        @elementwise(input_type=[dt.double], output_type=dt.double)
+        def foo1(v):
+            # Basic UDF with kwargs
+            return v + 1
 
-    @elementwise(input_type=[dt.double], output_type=dt.double)
-    def foo2(v, *, amount):
-        # UDF with keyword only arguments
-        return v + amount
+        @elementwise(input_type=[dt.double], output_type=dt.double)
+        def foo2(v, *, amount):
+            # UDF with keyword only arguments
+            return v + amount
 
-    @elementwise(input_type=[dt.double], output_type=dt.double)
-    def foo3(v, **kwargs):
-        # UDF with kwargs
-        return v + kwargs.get("amount", 1)
+        @elementwise(input_type=[dt.double], output_type=dt.double)
+        def foo3(v, **kwargs):
+            # UDF with kwargs
+            return v + kwargs.get("amount", 1)
 
     expr = udf_alltypes.mutate(
         v1=foo1(udf_alltypes["double_col"]),
@@ -392,14 +403,15 @@ def test_valid_kwargs(udf_backend, udf_alltypes, udf_df):
 
 def test_valid_args(udf_backend, udf_alltypes, udf_df):
     # Test different forms of UDF definition with *args
+    with pytest.warns(FutureWarning, match="v9.0"):
 
-    @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
-    def foo1(*args):
-        return args[0] + args[1]
+        @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
+        def foo1(*args):
+            return args[0] + args[1]
 
-    @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
-    def foo2(v, *args):
-        return v + args[0]
+        @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
+        def foo2(v, *args):
+            return v + args[0]
 
     result = udf_alltypes.mutate(
         v1=foo1(udf_alltypes["double_col"], udf_alltypes["int_col"]),
@@ -416,27 +428,28 @@ def test_valid_args(udf_backend, udf_alltypes, udf_df):
 
 def test_valid_args_and_kwargs(udf_backend, udf_alltypes, udf_df):
     # Test UDFs with both *args and keyword arguments
+    with pytest.warns(FutureWarning, match="v9.0"):
 
-    @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
-    def foo1(*args, amount):
-        # UDF with *args and a keyword-only argument
-        return args[0] + args[1] + amount
+        @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
+        def foo1(*args, amount):
+            # UDF with *args and a keyword-only argument
+            return args[0] + args[1] + amount
 
-    @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
-    def foo2(*args, **kwargs):
-        # UDF with *args and **kwargs
-        return args[0] + args[1] + kwargs.get("amount", 1)
+        @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
+        def foo2(*args, **kwargs):
+            # UDF with *args and **kwargs
+            return args[0] + args[1] + kwargs.get("amount", 1)
 
-    @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
-    def foo3(v, *args, amount):
-        # UDF with an explicit positional argument, *args, and a keyword-only
-        # argument
-        return v + args[0] + amount
+        @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
+        def foo3(v, *args, amount):
+            # UDF with an explicit positional argument, *args, and a keyword-only
+            # argument
+            return v + args[0] + amount
 
-    @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
-    def foo4(v, *args, **kwargs):
-        # UDF with an explicit positional argument, *args, and **kwargs
-        return v + args[0] + kwargs.get("amount", 1)
+        @elementwise(input_type=[dt.double, dt.int32], output_type=dt.double)
+        def foo4(v, *args, **kwargs):
+            # UDF with an explicit positional argument, *args, and **kwargs
+            return v + args[0] + kwargs.get("amount", 1)
 
     result = udf_alltypes.mutate(
         v1=foo1(udf_alltypes["double_col"], udf_alltypes["int_col"], amount=2),
@@ -460,10 +473,11 @@ def test_invalid_kwargs():
     # keyword argument raises an error
 
     with pytest.raises(TypeError, match=".*must be defined as keyword only.*"):
+        with pytest.warns(FutureWarning, match="v9.0"):
 
-        @elementwise(input_type=[dt.double], output_type=dt.double)
-        def _(v, _):
-            return v + 1
+            @elementwise(input_type=[dt.double], output_type=dt.double)
+            def _(v, _):
+                return v + 1
 
 
 @pytest.mark.parametrize("udf", add_one_struct_udfs)
@@ -526,16 +540,18 @@ def test_elementwise_udf_overwrite_destruct_and_assign(udf_backend, udf_alltypes
 @pytest.mark.xfail_version(pyspark=["pyspark<3.1"])
 @pytest.mark.parametrize("method", ["destructure", "unpack"])
 def test_elementwise_udf_destructure_exact_once(udf_alltypes, method, tmp_path):
-    @elementwise(
-        input_type=[dt.double],
-        output_type=dt.Struct({"col1": dt.double, "col2": dt.double}),
-    )
-    def add_one_struct_exact_once(v):
-        key = v.iloc[0]
-        path = tmp_path / str(key)
-        assert not path.exists()
-        path.touch()
-        return v + 1, v + 2
+    with pytest.warns(FutureWarning, match="v9.0"):
+
+        @elementwise(
+            input_type=[dt.double],
+            output_type=dt.Struct({"col1": dt.double, "col2": dt.double}),
+        )
+        def add_one_struct_exact_once(v):
+            key = v.iloc[0]
+            path = tmp_path / str(key)
+            assert not path.exists()
+            path.touch()
+            return v + 1, v + 2
 
     struct = add_one_struct_exact_once(udf_alltypes["id"])
 

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -71,14 +71,15 @@ def pandas_ntile(x, bucket: int):
     )
 
 
-@reduction(input_type=[dt.double], output_type=dt.double)
-def mean_udf(s):
-    return s.mean()
+with pytest.warns(FutureWarning, match="v9.0"):
 
+    @reduction(input_type=[dt.double], output_type=dt.double)
+    def mean_udf(s):
+        return s.mean()
 
-@analytic(input_type=[dt.double], output_type=dt.double)
-def calc_zscore(s):
-    return (s - s.mean()) / s.std()
+    @analytic(input_type=[dt.double], output_type=dt.double)
+    def calc_zscore(s):
+        return (s - s.mean()) / s.std()
 
 
 @pytest.mark.parametrize(

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -337,12 +337,14 @@ def test_two_inner_joins(snapshot):
 def test_destruct_selection(snapshot):
     table = ibis.table([("col", "int64")], name="t")
 
-    @udf.reduction(
-        input_type=["int64"],
-        output_type=dt.Struct({"sum": "int64", "mean": "float64"}),
-    )
-    def multi_output_udf(v):
-        return v.sum(), v.mean()
+    with pytest.warns(FutureWarning, match="v9.0"):
+
+        @udf.reduction(
+            input_type=["int64"],
+            output_type=dt.Struct({"sum": "int64", "mean": "float64"}),
+        )
+        def multi_output_udf(v):
+            return v.sum(), v.mean()
 
     expr = table.aggregate(multi_output_udf(table["col"]).destructure())
     result = fmt(expr)

--- a/ibis/legacy/udf/vectorized.py
+++ b/ibis/legacy/udf/vectorized.py
@@ -19,6 +19,7 @@ from ibis.expr.operations import (
     ElementWiseVectorizedUDF,
     ReductionVectorizedUDF,
 )
+from ibis.util import deprecated
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -263,6 +264,7 @@ def _udf_decorator(node_type, input_type, output_type):
     return wrapper
 
 
+@deprecated(as_of="9.0", instead="")
 def analytic(input_type, output_type):
     """Define an analytic UDF that produces the same of rows as the input.
 
@@ -275,36 +277,11 @@ def analytic(input_type, output_type):
     output_type : ibis.expr.datatypes.DataType
         The return type of the function.
 
-    Examples
-    --------
-    >>> import ibis
-    >>> import ibis.expr.datatypes as dt
-    >>> from ibis.legacy.udf.vectorized import analytic
-    >>> @analytic(input_type=[dt.double], output_type=dt.double)
-    ... def zscore(series):  # note the use of aggregate functions
-    ...     return (series - series.mean()) / series.std()
-
-    Define and use an UDF with multiple return columns:
-
-    >>> @analytic(
-    ...     input_type=[dt.double],
-    ...     output_type=dt.Struct(dict(demean="double", zscore="double")),
-    ... )
-    ... def demean_and_zscore(v):
-    ...     mean = v.mean()
-    ...     std = v.std()
-    ...     return v - mean, (v - mean) / std
-    >>>
-    >>> win = ibis.window(preceding=None, following=None, group_by="key")
-    >>> # add two columns "demean" and "zscore"
-    >>> table = table.mutate(  # quartodoc: +SKIP # doctest: +SKIP
-    ...     demean_and_zscore(table["v"]).over(win).destructure()
-    ... )
-
     """
     return _udf_decorator(AnalyticVectorizedUDF, input_type, output_type)
 
 
+@deprecated(as_of="9.0", instead="use the ibis.udf.* api")
 def elementwise(input_type, output_type):
     """Define a UDF that operates element-wise on a Pandas Series.
 
@@ -317,39 +294,11 @@ def elementwise(input_type, output_type):
     output_type : ibis.expr.datatypes.DataType
         The return type of the function.
 
-    Examples
-    --------
-    >>> import ibis
-    >>> import ibis.expr.datatypes as dt
-    >>> from ibis.legacy.udf.vectorized import elementwise
-    >>> @elementwise(input_type=[dt.string], output_type=dt.int64)
-    ... def my_string_length(series):
-    ...     return series.str.len() * 2
-
-    Define an UDF with non-column parameters:
-
-    >>> @elementwise(input_type=[dt.string], output_type=dt.int64)
-    ... def my_string_length(series, *, times):
-    ...     return series.str.len() * times
-
-    Define and use an UDF with multiple return columns:
-
-    >>> @elementwise(
-    ...     input_type=[dt.string],
-    ...     output_type=dt.Struct(dict(year=dt.string, monthday=dt.string)),
-    ... )
-    ... def year_monthday(date):
-    ...     return date.str.slice(0, 4), date.str.slice(4, 8)
-    >>>
-    >>> # add two columns "year" and "monthday"
-    >>> table = table.mutate(
-    ...     year_monthday(table["date"]).destructure()
-    ... )  # quartodoc: +SKIP # doctest: +SKIP
-
     """
     return _udf_decorator(ElementWiseVectorizedUDF, input_type, output_type)
 
 
+@deprecated(as_of="9.0", instead="use the @ibis.udf.agg.builtin decorator")
 def reduction(input_type, output_type):
     """Define a UDF reduction function that produces 1 row of output for N rows of input.
 
@@ -361,29 +310,5 @@ def reduction(input_type, output_type):
         function. Variadic arguments are not yet supported.
     output_type : ibis.expr.datatypes.DataType
         The return type of the function.
-
-    Examples
-    --------
-    >>> import ibis
-    >>> import ibis.expr.datatypes as dt
-    >>> from ibis.legacy.udf.vectorized import reduction
-    >>> @reduction(input_type=[dt.string], output_type=dt.int64)
-    ... def my_string_length_agg(series, **kwargs):
-    ...     return (series.str.len() * 2).sum()
-
-    Define and use an UDF with multiple return columns:
-
-    >>> @reduction(
-    ...     input_type=[dt.double],
-    ...     output_type=dt.Struct(dict(mean="double", std="double")),
-    ... )
-    ... def mean_and_std(v):
-    ...     return v.mean(), v.std()
-    >>>
-    >>> # create aggregation columns "mean" and "std"
-    >>> table = table.group_by("key").aggregate(  # quartodoc: +SKIP # doctest: +SKIP
-    ...     mean_and_std(table["v"]).destructure()
-    ... )
-
     """
     return _udf_decorator(ReductionVectorizedUDF, input_type, output_type)


### PR DESCRIPTION
This PR adds warnings for deprecation of `ibis.legacy.udf` for `v9.0`. I'm not super sure about the `instead` message for `elementwise`, suggestions are welcomed. 

According to the issue, seems like we are not going to support `analytic` and `reduction` on the new system, hence the empty comment on `instead`

- Closes https://github.com/ibis-project/ibis/issues/8567