### PR TITLE
fix(sql): outer order by should take precedence over inner order by

### DIFF
--- a/ibis/backends/pandas/executor.py
+++ b/ibis/backends/pandas/executor.py
@@ -591,8 +591,10 @@ class PandasExecutor(Dispatched, PandasUtils):
         newcols = {gen_name("sort_key"): col for col in keys}
         names = list(newcols.keys())
         df = parent.assign(**newcols)
-        df = df.sort_values(by=names, ascending=ascending, ignore_index=True)
-        return df.drop(names, axis=1)
+        df = df.sort_values(
+            by=names, ascending=ascending, ignore_index=True, kind="mergesort"
+        )
+        return df.drop(columns=names)
 
     @classmethod
     def visit(cls, op: PandasAggregate, parent, groups, metrics):

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -102,6 +102,12 @@ class Window(ops.Value):
         return self.func.dtype
 
 
+# TODO(kszucs): there is a better strategy to rewrite the relational operations
+# to Select nodes by wrapping the leaf nodes in a Select node and then merging
+# Project, Filter, Sort, etc. incrementally into the Select node. This way we
+# can have tighter control over simplification logic.
+
+
 @replace(p.Project)
 def project_to_select(_, **kwargs):
     """Convert a Project node to a Select node."""
@@ -167,17 +173,22 @@ def merge_select_select(_, **kwargs):
 
     subs = {ops.Field(_.parent, k): v for k, v in _.parent.values.items()}
     selections = {k: v.replace(subs, filter=ops.Value) for k, v in _.selections.items()}
-    predicates = tuple(p.replace(subs, filter=ops.Value) for p in _.predicates)
-    sort_keys = tuple(s.replace(subs, filter=ops.Value) for s in _.sort_keys)
 
+    predicates = tuple(p.replace(subs, filter=ops.Value) for p in _.predicates)
     unique_predicates = toolz.unique(_.parent.predicates + predicates)
-    unique_sort_keys = {s.expr: s for s in _.parent.sort_keys + sort_keys}
+
+    sort_keys = tuple(s.replace(subs, filter=ops.Value) for s in _.sort_keys)
+    sort_key_exprs = {s.expr for s in sort_keys}
+    parent_sort_keys = tuple(
+        k for k in _.parent.sort_keys if k.expr not in sort_key_exprs
+    )
+    unique_sort_keys = sort_keys + parent_sort_keys
 
     return Select(
         _.parent.parent,
         selections=selections,
         predicates=unique_predicates,
-        sort_keys=unique_sort_keys.values(),
+        sort_keys=unique_sort_keys,
     )
 
 

--- a/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  "t0"."b"
+FROM "t" AS "t0"
+ORDER BY
+  "t0"."b" DESC,
+  "t0"."a" ASC

--- a/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by_deferred/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by_deferred/out.sql
@@ -1,0 +1,9 @@
+SELECT
+  "t0"."a",
+  "t0"."b",
+  "t0"."c"
+FROM "t" AS "t0"
+ORDER BY
+  "t0"."b" ASC,
+  "t0"."a" DESC,
+  "t0"."c" ASC

--- a/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by_different_expression/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by_different_expression/out.sql
@@ -1,0 +1,10 @@
+SELECT
+  "t0"."a",
+  "t0"."b",
+  "t0"."c"
+FROM "t" AS "t0"
+ORDER BY
+  "t0"."b" ASC,
+  "t0"."a" + CAST(1 AS TINYINT) DESC,
+  "t0"."a" ASC,
+  "t0"."c" ASC

--- a/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by_not_fused/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by_not_fused/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  "t0"."b"
+FROM "t" AS "t0"
+ORDER BY
+  "t0"."a" ASC,
+  "t0"."b" DESC

--- a/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by_same_column/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_sql/test_double_order_by_same_column/out.sql
@@ -1,0 +1,9 @@
+SELECT
+  "t0"."a",
+  "t0"."b",
+  "t0"."c"
+FROM "t" AS "t0"
+ORDER BY
+  "t0"."b" ASC,
+  "t0"."a" DESC,
+  "t0"."c" ASC

--- a/ibis/backends/tests/sql/test_sql.py
+++ b/ibis/backends/tests/sql/test_sql.py
@@ -20,6 +20,7 @@ import pytest
 from pytest import param
 
 import ibis
+from ibis import _
 from ibis.backends.tests.sql.conftest import to_sql
 from ibis.tests.util import assert_decompile_roundtrip
 
@@ -515,6 +516,46 @@ def test_no_cart_join(snapshot):
 def test_order_by_expr(snapshot):
     t = ibis.table(dict(a="int", b="string"), name="t")
     expr = t[lambda t: t.a == 1].order_by(lambda t: t.b + "a")
+    snapshot.assert_match(to_sql(expr), "out.sql")
+
+
+def test_double_order_by(snapshot):
+    t = ibis.table(dict(a="int", b="string"), name="t")
+    # t.b DESC, t.a ASC
+    expr = t.order_by(t.a).order_by(t.b.desc())
+    sql = to_sql(expr, pretty=False)
+    expected = '"t0"."b" DESC, "t0"."a" ASC'
+    assert expected in sql
+    snapshot.assert_match(to_sql(expr), "out.sql")
+
+
+def test_double_order_by_same_column(snapshot):
+    t = ibis.table(dict(a="int", b="string", c="float"), name="t")
+    # t.b ASC, t.a DESC, t.c ASC
+    expr = t.order_by(t.a, t.c).order_by(t.b.asc(), t.a.desc())
+    sql = to_sql(expr, pretty=False)
+    expected = '"t0"."b" ASC, "t0"."a" DESC, "t0"."c" ASC'
+    assert expected in sql
+    snapshot.assert_match(to_sql(expr), "out.sql")
+
+
+def test_double_order_by_deferred(snapshot):
+    t = ibis.table(dict(a="int", b="string", c="float"), name="t")
+    expr = t.order_by(t.a, t.c).order_by(t.b.asc(), _.a.desc())
+    sql = to_sql(expr, pretty=False)
+    expected = '"t0"."b" ASC, "t0"."a" DESC, "t0"."c" ASC'
+    assert expected in sql
+    snapshot.assert_match(to_sql(expr), "out.sql")
+
+
+def test_double_order_by_different_expression(snapshot):
+    t = ibis.table(dict(a="int", b="string", c="float"), name="t")
+    expr = t.order_by(t.a, t.c).order_by(t.b.asc(), (t.a + 1).desc())
+    sql = to_sql(expr, pretty=False)
+    expected = (
+        '"t0"."b" ASC, "t0"."a" + CAST(1 AS TINYINT) DESC, "t0"."a" ASC, "t0"."c" ASC'
+    )
+    assert expected in sql
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -340,7 +340,9 @@ class SQLString(str):
 
 
 @public
-def to_sql(expr: ir.Expr, dialect: str | None = None, **kwargs) -> SQLString:
+def to_sql(
+    expr: ir.Expr, dialect: str | None = None, pretty: bool = True, **kwargs
+) -> SQLString:
     """Return the formatted SQL string for an expression.
 
     Parameters
@@ -349,6 +351,8 @@ def to_sql(expr: ir.Expr, dialect: str | None = None, **kwargs) -> SQLString:
         Ibis expression.
     dialect
         SQL dialect to use for compilation.
+    pretty
+        Whether to use pretty formatting.
     kwargs
         Scalar parameters
 
@@ -380,5 +384,5 @@ def to_sql(expr: ir.Expr, dialect: str | None = None, **kwargs) -> SQLString:
             read = write = getattr(backend, "dialect", dialect)
 
     sql = backend._to_sql(expr.unbind(), **kwargs)
-    (pretty,) = sg.transpile(sql, read=read, write=write, pretty=True)
-    return SQLString(pretty)
+    (transpiled,) = sg.transpile(sql, read=read, write=write, pretty=pretty)
+    return SQLString(transpiled)


### PR DESCRIPTION
Now we turn 

```
r0 := DatabaseTable: functional_alltypes
  id              int64
  bool_col        boolean
  tinyint_col     int8
  smallint_col    int16
  int_col         int32
  bigint_col      int64
  float_col       float32
  double_col      float64
  date_string_col string
  string_col      string
  timestamp_col   timestamp(6)
  year            int64
  month           int64

r1 := Sort[r0]
  asc r0.tinyint_col
  asc r0.bool_col

Sort[r1]
  asc r1.bool_col
  desc r1.tinyint_col + 1
```

into 

```
r0 := DatabaseTable: functional_alltypes
  id              int64
  bool_col        boolean
  tinyint_col     int8
  smallint_col    int16
  int_col         int32
  bigint_col      int64
  float_col       float32
  double_col      float64
  date_string_col string
  string_col      string
  timestamp_col   timestamp(6)
  year            int64
  month           int64

Select[r0]
  selections:
    id:              r0.id
    bool_col:        r0.bool_col
    tinyint_col:     r0.tinyint_col
    smallint_col:    r0.smallint_col
    int_col:         r0.int_col
    bigint_col:      r0.bigint_col
    float_col:       r0.float_col
    double_col:      r0.double_col
    date_string_col: r0.date_string_col
    string_col:      r0.string_col
    timestamp_col:   r0.timestamp_col
    year:            r0.year
    month:           r0.month
  sort_keys:
    asc r0.bool_col
    desc r0.tinyint_col + 1
    asc r0.tinyint_col
  schema:
    id              int64
    bool_col        boolean
    tinyint_col     int8
    smallint_col    int16
    int_col         int32
    bigint_col      int64
    float_col       float32
    double_col      float64
    date_string_col string
    string_col      string
    timestamp_col   timestamp(6)
    year            int64
    month           int64
```



Aims to resolve https://github.com/ibis-project/ibis/issues/8442#issuecomment-1967578311

