### PR TITLE
docs: update to_delta kwargs docs

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -631,9 +631,7 @@ class Expr(Immutable, Coercible):
         params
             Mapping of scalar parameter expressions to value.
         **kwargs
-            Additional keyword arguments passed to pyarrow.csv.CSVWriter
-
-        https://arrow.apache.org/docs/python/generated/pyarrow.csv.CSVWriter.html
+            Additional keyword arguments passed to deltalake.writer.write_deltalake method
         """
         self._find_backend(use_default=True).to_delta(self, path, **kwargs)
 


### PR DESCRIPTION


## Description of changes

The docstring for to_delta in core.py seems copied from to_csv, I updated it to match the docstring here: https://github.com/ibis-project/ibis/blob/e94366700ae460052f675188674e24002b755ec5/ibis/backends/__init__.py#L536


