### PR TITLE
test(api): verify that null isin behavior is consistent across backends

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -2025,6 +2025,16 @@ def test_topk_counts_null(con):
     raises=AssertionError,
     reason="ClickHouse returns False for x.isin([None])",
 )
+@pytest.mark.notimpl(
+    ["pandas", "dask"],
+    raises=AssertionError,
+    reason="null isin semantics are not implemented for pandas or dask",
+)
+@pytest.mark.never(
+    "mssql",
+    raises=AssertionError,
+    reason="mssql doesn't support null isin semantics in a projection because there is no bool type",
+)
 def test_null_isin_null_is_null(con):
     t = ibis.memtable({"x": [1]})
     expr = t.x.isin([None])

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -498,6 +498,8 @@ class Value(Expr):
     def isin(self, values: Value | Sequence[Value]) -> ir.BooleanValue:
         """Check whether this expression's values are in `values`.
 
+        `NULL` values are propagated in the output. See examples for details.
+
         Parameters
         ----------
         values
@@ -567,6 +569,40 @@ class Value(Expr):
         │ True          │
         │ False         │
         └───────────────┘
+
+        `NULL` behavior
+
+        >>> t = ibis.memtable({"x": [1, 2]})
+        >>> t.x.isin([1, None])
+        ┏━━━━━━━━━━━━━┓
+        ┃ InValues(x) ┃
+        ┡━━━━━━━━━━━━━┩
+        │ boolean     │
+        ├─────────────┤
+        │ True        │
+        │ NULL        │
+        └─────────────┘
+        >>> t = ibis.memtable({"x": [1, None, 2]})
+        >>> t.x.isin([1])
+        ┏━━━━━━━━━━━━━┓
+        ┃ InValues(x) ┃
+        ┡━━━━━━━━━━━━━┩
+        │ boolean     │
+        ├─────────────┤
+        │ True        │
+        │ NULL        │
+        │ False       │
+        └─────────────┘
+        >>> t.x.isin([3])
+        ┏━━━━━━━━━━━━━┓
+        ┃ InValues(x) ┃
+        ┡━━━━━━━━━━━━━┩
+        │ boolean     │
+        ├─────────────┤
+        │ False       │
+        │ NULL        │
+        │ False       │
+        └─────────────┘
         """
         from ibis.expr.types import ArrayValue
 


### PR DESCRIPTION
Closes #8079.