### PR TITLE
fix(oracle): map bare `NUMBER` to `int64` and consolidate data type mapping code for shared inference

### DIFF
--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -314,6 +314,11 @@ def mem_t(con):
 
 @dot_sql_never
 @pytest.mark.notyet(["polars"], raises=NotImplementedError)
+@pytest.mark.notyet(
+    ["druid"],
+    raises=KeyError,
+    reason="upstream does not preserve column names in schema inference",
+)
 def test_cte(alltypes, df):
     expr = alltypes.alias("ft").sql(
         'SELECT "string_col", CAST(COUNT(*) AS BIGINT) "n" FROM "ft" GROUP BY "string_col"',


### PR DESCRIPTION
Fixes a bug discovered during polars dot sql implementation where we were mapping empty precision and scale decimal types, but the oracle docs say that empty precision and scale together are mapped to number(38, 0).

The discovery during polars dot sql implementation is incidental, due to the test I changed, which is included here.