### PR TITLE
refactor(backends): remove `_metadata` method in favor of `_get_schema_using_query`

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -483,17 +483,15 @@ class Backend(SQLBackend, CanCreateDatabase):
             dict(zip(names, map(self.compiler.type_mapper.from_string, types)))
         )
 
-    def _metadata(self, query: str) -> sch.Schema:
+    def _get_schema_using_query(self, query: str) -> sch.Schema:
         name = util.gen_name("clickhouse_metadata")
         with closing(self.raw_sql(f"CREATE VIEW {name} AS {query}")):
             pass
         try:
-            with closing(self.raw_sql(f"DESCRIBE {name}")) as results:
-                names, types, *_ = results.result_columns
+            return self.get_schema(name)
         finally:
             with closing(self.raw_sql(f"DROP VIEW {name}")):
                 pass
-        return zip(names, map(self.compiler.type_mapper.from_string, types))
 
     def create_database(
         self, name: str, *, force: bool = False, engine: str = "Atomic"

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -76,7 +76,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def raw_sql(self, query: str) -> TableResult:
         return self._table_env.execute_sql(query)
 
-    def _metadata(self, query: str):
+    def _get_schema_using_query(self, query: str) -> sch.Schema:
         from pyflink.table.types import create_arrow_schema
 
         table = self._table_env.sql_query(query)
@@ -84,8 +84,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
         pa_schema = create_arrow_schema(
             schema.get_field_names(), schema.get_field_data_types()
         )
-        # sort of wasteful, but less code to write
-        return sch.Schema.from_pyarrow(pa_schema).items()
+        return sch.Schema.from_pyarrow(pa_schema)
 
     def list_databases(self, like: str | None = None) -> list[str]:
         databases = self._table_env.list_databases()

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -30,8 +30,6 @@ from ibis.backends.sql.compiler import TRUE, C, ColGen, F
 from ibis.common.exceptions import InvalidDecoratorError
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     import pandas as pd
     import pyarrow as pa
 
@@ -510,7 +508,7 @@ $$""".format(**self._get_udf_source(udf_node))
             }
         )
 
-    def _metadata(self, query: str) -> Iterable[tuple[str, dt.DataType]]:
+    def _get_schema_using_query(self, query: str) -> sch.Schema:
         name = util.gen_name(f"{self.name}_metadata")
 
         create_stmt = sge.Create(
@@ -526,7 +524,7 @@ $$""".format(**self._get_udf_source(udf_node))
         with self._safe_raw_sql(create_stmt):
             pass
         try:
-            yield from self.get_schema(name).items()
+            return self.get_schema(name)
         finally:
             with self._safe_raw_sql(drop_stmt):
                 pass

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -165,10 +165,10 @@ class Backend(SQLBackend, CanCreateDatabase):
     def disconnect(self) -> None:
         self._session.stop()
 
-    def _metadata(self, query: str):
+    def _get_schema_using_query(self, query: str) -> sch.Schema:
         cursor = self.raw_sql(query)
         struct_dtype = PySparkType.to_ibis(cursor.query.schema)
-        return struct_dtype.items()
+        return sch.Schema(struct_dtype)
 
     @property
     def version(self):

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -15,12 +15,11 @@ from ibis.backends import BaseBackend
 from ibis.backends.sql.compiler import STAR
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator, Mapping
+    from collections.abc import Iterable, Mapping
 
     import pandas as pd
     import pyarrow as pa
 
-    import ibis.expr.datatypes as dt
     from ibis.backends.sql.compiler import SQLGlotCompiler
     from ibis.expr.schema import SchemaLike
 
@@ -145,14 +144,20 @@ class SQLBackend(BaseBackend):
             schema = self._get_schema_using_query(query)
         return ops.SQLQueryResult(query, ibis.schema(schema), self).to_expr()
 
-    # TODO(kszucs): should be removed in favor of _get_schema_using_query()
     @abc.abstractmethod
-    def _metadata(self, query: str) -> Iterator[tuple[str, dt.DataType]]:
-        """Return the metadata of a SQL query."""
-
     def _get_schema_using_query(self, query: str) -> sch.Schema:
-        """Return an ibis Schema from a backend-specific SQL string."""
-        return sch.Schema.from_tuples(self._metadata(query))
+        """Return an ibis Schema from a backend-specific SQL string.
+
+        Parameters
+        ----------
+        query
+            Backend-specific SQL string
+
+        Returns
+        -------
+        Schema
+            The schema inferred from `query`
+        """
 
     def _get_sql_string_view_schema(self, name, table, query) -> sch.Schema:
         compiler = self.compiler


### PR DESCRIPTION
Remove the unnecessary `_metadata` method in favor of `_get_schema_using_query`