### PR TITLE
feat(ir): support showing variable names used to create an expression in `repr()`

### DIFF
--- a/ibis/backends/tests/test_interactive.py
+++ b/ibis/backends/tests/test_interactive.py
@@ -84,14 +84,6 @@ def test_interactive_non_compilable_repr_does_not_fail(table):
     repr(table.string_col.topk(3))
 
 
-def test_histogram_repr_no_query_execute(table, queries):
-    tier = table.double_col.histogram(10).name("bucket")
-    expr = table.group_by(tier).size()
-    expr._repr()
-
-    assert not queries
-
-
 def test_isin_rule_suppressed_exception_repr_not_fail(table):
     bool_clause = table["string_col"].notin(["1", "4", "7"])
     expr = table[bool_clause]["string_col"].value_counts()

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -119,9 +119,11 @@ class Repr(Config):
         SQLQueryResult operations.
     show_types : bool
         Show the inferred type of value expressions in the repr.
+    show_variables : bool
+        Show the variables in the repr instead of generated names. This is
+        an advanced option and may not work in all scenarios.
     interactive : bool
         Options controlling the interactive repr.
-
     """
 
     depth: Optional[PosInt] = None
@@ -129,6 +131,7 @@ class Repr(Config):
     table_rows: PosInt = 10
     query_text_length: PosInt = 80
     show_types: bool = False
+    show_variables: bool = False
     interactive: Interactive = Interactive()
 
 

--- a/ibis/expr/tests/snapshots/test_format/test_format_show_variables/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_format_show_variables/repr.txt
@@ -1,0 +1,29 @@
+alltypes := UnboundTable: alltypes
+  a int8
+  b int16
+  c int32
+  d int64
+  e float32
+  f float64
+  g string
+  h boolean
+  i timestamp
+  j date
+  k time
+
+filtered := Filter[alltypes]
+  alltypes.f > 0
+
+ordered := Sort[filtered]
+  asc filtered.f
+
+projected := Project[ordered]
+  a: ordered.a
+  b: ordered.b
+  f: ordered.f
+
+add := projected.a + projected.b
+
+sub := projected.a - projected.b
+
+Multiply(Add(a, b), Subtract(a, b)): add * sub

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -417,3 +417,24 @@ def test_format_new_value_operation(alltypes, snapshot):
 
     assert "Inc" in result
     assert last_line == "incremented: Inc(r0.a)"
+
+
+def test_format_show_variables(monkeypatch, alltypes, snapshot):
+    monkeypatch.setattr(ibis.options.repr, "show_variables", True)
+
+    filtered = alltypes[alltypes.f > 0]
+    ordered = filtered.order_by("f")
+    projected = ordered[["a", "b", "f"]]
+
+    add = projected.a + projected.b
+    sub = projected.a - projected.b
+    expr = add * sub
+
+    result = fmt(expr)
+
+    assert "projected.a" in result
+    assert "projected.b" in result
+    assert "filtered" in result
+    assert "ordered" in result
+
+    snapshot.assert_match(result, "repr.txt")


### PR DESCRIPTION
For the following code:

```py
import ibis

alltypes = ibis.table(...)

filtered = alltypes[alltypes.f > 0]
ordered = filtered.order_by("f")
projected = ordered[["a", "b", "f"]]

expr = projected.a + projected.b

ibis.options.repr.show_variables = True
repr(expr)
```

instead of showing 
```
r0 := UnboundTable: alltypes
  a int8
  b int16
  c int32
  d int64
  e float32
  f float64
  g string
  h boolean
  i timestamp
  j date
  k time

r1 := Filter[r0]
  r0.f > 0

r2 := Sort[r1]
  asc r1.f

r3 := Project[r2]
  a: r2.a
  b: r2.b
  f: r2.f

Add(a, b): r3.a + r3.b
```

now we can render the expression representation as 

```
alltypes := UnboundTable: alltypes
   a int8
   b int16
   c int32
   d int64
   e float32
   f float64
   g string
   h boolean
   i timestamp
   j date
   k time

 filtered := Filter[alltypes]
   alltypes.f > 0

 ordered := Sort[filtered]
   asc filtered.f

 projected := Project[ordered]
   a: ordered.a
   b: ordered.b
   f: ordered.f

 Add(a, b): projected.a + projected.b
```

This removes one level of indirection when we inspect an expression. Also not just tables but value nodes assigned to local variables are shown.

Note that it has its limitation based on where `repr()` is called, but `ibis.expr.format.pretty` now accepts a `scope` argument where the variable names can be passed.