### PR TITLE
perf(common): improve the performance of replacing nodes using mappings

### DIFF
--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -193,7 +193,7 @@ def _coerce_replacer(obj: ReplacerLike, context: Optional[dict] = None) -> Repla
             try:
                 return obj[node]
             except KeyError:
-                return node.__class__(**kwargs)
+                return node.__recreate__(kwargs)
     elif callable(obj):
         fn = obj
     else:

--- a/ibis/common/tests/test_graph_benchmarks.py
+++ b/ibis/common/tests/test_graph_benchmarks.py
@@ -52,7 +52,13 @@ def test_dfs(benchmark):
     benchmark(Graph.from_dfs, node)
 
 
-def test_replace(benchmark):
+def test_replace_pattern(benchmark):
     node = generate_node(500)
     pattern = Object(MyNode, a=Between(lower=100)) >> _.copy(a=_.a + 1)
     benchmark(node.replace, pattern)
+
+
+def test_replace_mapping(benchmark):
+    node = generate_node(500)
+    subs = {generate_node(1): generate_node(0)}
+    benchmark(node.replace, subs)


### PR DESCRIPTION
Mitigate the performance overhead of signature binding during node reconstruction. 

Benchmark showing ~20% improvement:

```
------------------------------------------------------------------------------ benchmark 'test_replace_mapping': 2 tests ------------------------------------------------------------------------------
Name (time in ms)                           Min                Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_replace_mapping (0412_b5f9bbe)     10.6952 (1.17)     31.7057 (1.04)     12.0816 (1.20)     3.2477 (1.0)      11.6603 (1.22)     0.2742 (1.0)          2;15  82.7706 (0.84)         70           1
test_replace_mapping (NOW)               9.1150 (1.0)      30.4098 (1.0)      10.1019 (1.0)      3.4524 (1.06)      9.5369 (1.0)      0.3219 (1.17)          2;3  98.9909 (1.0)          72           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

We use this technique heavily for expression rewriting.