### PR TITLE
feat(api): support all dtypes in MapGet and MapContains

### DIFF
--- a/ibis/backends/flink/compiler.py
+++ b/ibis/backends/flink/compiler.py
@@ -546,7 +546,7 @@ class FlinkCompiler(SQLGlotCompiler):
         return self.f.count(sge.Distinct(expressions=[arg]))
 
     def visit_MapContains(self, op: ops.MapContains, *, arg, key):
-        return self.f.array_contains(self.f.map_keys(arg), key)
+        return arg[key].is_(NULL)
 
     def visit_Map(self, op: ops.Map, *, keys, values):
         return self.cast(self.f.map_from_arrays(keys, values), op.dtype)

--- a/ibis/backends/flink/compiler.py
+++ b/ibis/backends/flink/compiler.py
@@ -546,7 +546,7 @@ class FlinkCompiler(SQLGlotCompiler):
         return self.f.count(sge.Distinct(expressions=[arg]))
 
     def visit_MapContains(self, op: ops.MapContains, *, arg, key):
-        return arg[key].is_(NULL)
+        return self.f.array_contains(self.f.map_keys(arg), key)
 
     def visit_Map(self, op: ops.Map, *, keys, values):
         return self.cast(self.f.map_from_arrays(keys, values), op.dtype)

--- a/ibis/backends/flink/compiler.py
+++ b/ibis/backends/flink/compiler.py
@@ -546,7 +546,11 @@ class FlinkCompiler(SQLGlotCompiler):
         return self.f.count(sge.Distinct(expressions=[arg]))
 
     def visit_MapContains(self, op: ops.MapContains, *, arg, key):
-        return self.f.array_contains(self.f.map_keys(arg), key)
+        key_type = op.arg.dtype.key_type
+        return self.f.array_contains(
+            self.cast(self.f.map_keys(arg), dt.Array(value_type=key_type)),
+            self.cast(key, key_type),
+        )
 
     def visit_Map(self, op: ops.Map, *, keys, values):
         return self.cast(self.f.map_from_arrays(keys, values), op.dtype)

--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -198,7 +198,7 @@ class SnowflakeCompiler(SQLGlotCompiler):
     def visit_Map(self, op, *, keys, values):
         return self.if_(
             sg.and_(self.f.is_array(keys), self.f.is_array(values)),
-            self.f.udf.object_from_arrays(keys, values),
+            self.f.arrays_to_object(keys, values),
             NULL,
         )
 

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -196,7 +196,6 @@ keys = pytest.mark.parametrize(
                 pytest.mark.notyet(
                     "clickhouse", reason="only supports str,int,bool,timestamp keys"
                 ),
-                pytest.mark.notyet("flink", reason="doesn't support float keys"),
                 mark_notyet_postgres,
             ],
             id="float",
@@ -227,7 +226,6 @@ keys = pytest.mark.parametrize(
                 ),
                 pytest.mark.notyet(["pandas", "dask"]),
                 mark_notyet_postgres,
-                pytest.mark.notimpl("flink"),
             ],
             id="array",
         ),

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -468,3 +468,10 @@ def test_map_keys_unnest(backend):
     expr = backend.map.kv.keys().unnest()
     result = expr.to_pandas()
     assert frozenset(result) == frozenset("abcdef")
+
+
+@mark_notimpl_risingwave_hstore
+def test_map_contains_null(con):
+    expr = ibis.map(["a"], ibis.literal([None], type="array<string>"))
+    assert con.execute(expr.contains("a"))
+    assert not con.execute(expr.contains("b"))

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -309,6 +309,7 @@ values = pytest.mark.parametrize(
 @values
 @keys
 @mark_notimpl_risingwave_hstore
+@pytest.mark.notimpl("flink")
 def test_map_get_all_types(con, keys, values):
     m = ibis.map(ibis.array(keys), ibis.array(values))
     for key, val in zip(keys, values):
@@ -319,6 +320,7 @@ def test_map_get_all_types(con, keys, values):
 
 @keys
 @mark_notimpl_risingwave_hstore
+@pytest.mark.notimpl("flink")
 def test_map_contains_all_types(con, keys):
     m = ibis.map(ibis.array(keys), ibis.array(keys))
     for key in keys:

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -29,6 +29,10 @@ mark_notyet_postgres = pytest.mark.notyet(
     "postgres", reason="only supports string -> string"
 )
 
+mark_notyet_snowflake = pytest.mark.notyet(
+    "snowflake", reason="map keys must be strings"
+)
+
 mark_notimpl_risingwave_hstore = pytest.mark.notimpl(
     ["risingwave"],
     reason="function hstore(character varying[], character varying[]) does not exist",
@@ -178,16 +182,12 @@ keys = pytest.mark.parametrize(
         pytest.param(["a", "b"], id="string"),
         pytest.param(
             [1, 2],
-            marks=[
-                mark_notyet_postgres,
-            ],
+            marks=[mark_notyet_postgres, mark_notyet_snowflake],
             id="int",
         ),
         pytest.param(
             [True, False],
-            marks=[
-                mark_notyet_postgres,
-            ],
+            marks=[mark_notyet_postgres, mark_notyet_snowflake],
             id="bool",
         ),
         pytest.param(
@@ -197,12 +197,13 @@ keys = pytest.mark.parametrize(
                     "clickhouse", reason="only supports str,int,bool,timestamp keys"
                 ),
                 mark_notyet_postgres,
+                mark_notyet_snowflake,
             ],
             id="float",
         ),
         pytest.param(
             [ibis.timestamp("2021-01-01"), ibis.timestamp("2021-01-02")],
-            marks=mark_notyet_postgres,
+            marks=[mark_notyet_postgres, mark_notyet_snowflake],
             id="timestamp",
         ),
         pytest.param(
@@ -215,6 +216,7 @@ keys = pytest.mark.parametrize(
                     ["pandas", "dask"], reason="DateFromYMD isn't implemented"
                 ),
                 mark_notyet_postgres,
+                mark_notyet_snowflake,
             ],
             id="date",
         ),
@@ -226,6 +228,7 @@ keys = pytest.mark.parametrize(
                 ),
                 pytest.mark.notyet(["pandas", "dask"]),
                 mark_notyet_postgres,
+                mark_notyet_snowflake,
             ],
             id="array",
         ),
@@ -238,6 +241,7 @@ keys = pytest.mark.parametrize(
                 pytest.mark.notyet(["pandas", "dask"]),
                 mark_notyet_postgres,
                 pytest.mark.notimpl("flink"),
+                mark_notyet_snowflake,
             ],
             id="struct",
         ),

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -25,11 +25,11 @@ pytestmark = [
     ),
 ]
 
-MARK_NOTYET_POSTGRES = pytest.mark.notyet(
+mark_notyet_postgres = pytest.mark.notyet(
     "postgres", reason="only supports string -> string"
 )
 
-MARK_NOTIMPL_RISINGWAVE_HSTORE = pytest.mark.notimpl(
+mark_notimpl_risingwave_hstore = pytest.mark.notimpl(
     ["risingwave"],
     reason="function hstore(character varying[], character varying[]) does not exist",
 )
@@ -46,7 +46,7 @@ def test_map_table(backend):
 @pytest.mark.xfail_version(
     duckdb=["duckdb<0.8.0"], raises=exc.UnsupportedOperationError
 )
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_column_map_values(backend):
     table = backend.map
     expr = table.select("idx", vals=table.kv.values()).order_by("idx")
@@ -72,7 +72,7 @@ def test_column_map_merge(backend):
     tm.assert_series_equal(result, expected)
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_literal_map_keys(con):
     mapping = ibis.literal({"1": "a", "2": "b"})
     expr = mapping.keys().name("tmp")
@@ -83,7 +83,7 @@ def test_literal_map_keys(con):
     assert np.array_equal(result, ["1", "2"])
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_literal_map_values(con):
     mapping = ibis.literal({"1": "a", "2": "b"})
     expr = mapping.values().name("tmp")
@@ -92,8 +92,8 @@ def test_literal_map_values(con):
     assert np.array_equal(result, ["a", "b"])
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 def test_scalar_isin_literal_map_keys(con):
     mapping = ibis.literal({"a": 1, "b": 2})
     a = ibis.literal("a")
@@ -104,8 +104,8 @@ def test_scalar_isin_literal_map_keys(con):
     assert con.execute(false) == False  # noqa: E712
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 def test_map_scalar_contains_key_scalar(con):
     mapping = ibis.literal({"a": 1, "b": 2})
     a = ibis.literal("a")
@@ -116,7 +116,7 @@ def test_map_scalar_contains_key_scalar(con):
     assert con.execute(false) == False  # noqa: E712
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_map_scalar_contains_key_column(backend, alltypes, df):
     value = {"1": "a", "3": "c"}
     mapping = ibis.literal(value)
@@ -126,8 +126,8 @@ def test_map_scalar_contains_key_column(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 def test_map_column_contains_key_scalar(backend, alltypes, df):
     expr = ibis.map(ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col]))
     series = df.apply(lambda row: {row["string_col"]: row["int_col"]}, axis=1)
@@ -138,8 +138,8 @@ def test_map_column_contains_key_scalar(backend, alltypes, df):
     backend.assert_series_equal(result, series)
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 def test_map_column_contains_key_column(alltypes):
     map_expr = ibis.map(
         ibis.array([alltypes.string_col]), ibis.array([alltypes.int_col])
@@ -149,8 +149,8 @@ def test_map_column_contains_key_column(alltypes):
     assert result.all()
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 def test_literal_map_merge(con):
     a = ibis.literal({"a": 0, "b": 2})
     b = ibis.literal({"a": 1, "c": 3})
@@ -159,7 +159,7 @@ def test_literal_map_merge(con):
     assert con.execute(expr) == {"a": 1, "b": 2, "c": 3}
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_literal_map_getitem_broadcast(backend, alltypes, df):
     value = {"1": "a", "2": "b"}
 
@@ -179,14 +179,14 @@ keys = pytest.mark.parametrize(
         pytest.param(
             [1, 2],
             marks=[
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="int",
         ),
         pytest.param(
             [True, False],
             marks=[
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="bool",
         ),
@@ -196,13 +196,13 @@ keys = pytest.mark.parametrize(
                 pytest.mark.notyet(
                     "clickhouse", reason="only supports str,int,bool,timestamp keys"
                 ),
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="float",
         ),
         pytest.param(
             [ibis.timestamp("2021-01-01"), ibis.timestamp("2021-01-02")],
-            marks=MARK_NOTYET_POSTGRES,
+            marks=mark_notyet_postgres,
             id="timestamp",
         ),
         pytest.param(
@@ -214,7 +214,7 @@ keys = pytest.mark.parametrize(
                 pytest.mark.notimpl(
                     ["pandas", "dask"], reason="DateFromYMD isn't implemented"
                 ),
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="date",
         ),
@@ -225,7 +225,7 @@ keys = pytest.mark.parametrize(
                     "clickhouse", reason="only supports str,int,bool,timestamp keys"
                 ),
                 pytest.mark.notyet(["pandas", "dask"]),
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="array",
         ),
@@ -236,7 +236,7 @@ keys = pytest.mark.parametrize(
                     "clickhouse", reason="only supports str,int,bool,timestamp keys"
                 ),
                 pytest.mark.notyet(["pandas", "dask"]),
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="struct",
         ),
@@ -251,28 +251,28 @@ values = pytest.mark.parametrize(
         pytest.param(
             [1, 2],
             marks=[
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="int",
         ),
         pytest.param(
             [True, False],
             marks=[
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="bool",
         ),
         pytest.param(
             [1.0, 2.0],
             marks=[
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="float",
         ),
         pytest.param(
             [ibis.timestamp("2021-01-01"), ibis.timestamp("2021-01-02")],
             marks=[
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="timestamp",
         ),
@@ -282,7 +282,7 @@ values = pytest.mark.parametrize(
                 pytest.mark.notimpl(
                     ["pandas", "dask"], reason="DateFromYMD isn't implemented"
                 ),
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="date",
         ),
@@ -290,7 +290,7 @@ values = pytest.mark.parametrize(
             [[1, 2], [3, 4]],
             marks=[
                 pytest.mark.notyet("clickhouse", reason="nested types can't be null"),
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="array",
         ),
@@ -298,7 +298,7 @@ values = pytest.mark.parametrize(
             [ibis.struct(dict(a=1)), ibis.struct(dict(a=2))],
             marks=[
                 pytest.mark.notyet("clickhouse", reason="nested types can't be null"),
-                MARK_NOTYET_POSTGRES,
+                mark_notyet_postgres,
             ],
             id="struct",
         ),
@@ -308,7 +308,7 @@ values = pytest.mark.parametrize(
 
 @values
 @keys
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_map_get_all_types(con, keys, values):
     m = ibis.map(ibis.array(keys), ibis.array(values))
     for key, val in zip(keys, values):
@@ -318,14 +318,14 @@ def test_map_get_all_types(con, keys, values):
 
 
 @keys
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_map_contains_all_types(con, keys):
     m = ibis.map(ibis.array(keys), ibis.array(keys))
     for key in keys:
         assert con.execute(m.contains(key))
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_literal_map_get_broadcast(backend, alltypes, df):
     value = {"1": "a", "2": "b"}
 
@@ -353,15 +353,15 @@ def test_literal_map_get_broadcast(backend, alltypes, df):
         param(["a", "b"], ["1", "2"], id="int"),
     ],
 )
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_map_construct_dict(con, keys, values):
     expr = ibis.map(keys, values)
     result = con.execute(expr.name("tmp"))
     assert result == dict(zip(keys, values))
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 @pytest.mark.broken(
     ["flink"],
     raises=pa.lib.ArrowInvalid,
@@ -375,32 +375,32 @@ def test_map_construct_array_column(con, alltypes, df):
     assert result.to_list() == expected.to_list()
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 def test_map_get_with_compatible_value_smaller(con):
     value = ibis.literal({"A": 1000, "B": 2000})
     expr = value.get("C", 3)
     assert con.execute(expr) == 3
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 def test_map_get_with_compatible_value_bigger(con):
     value = ibis.literal({"A": 1, "B": 2})
     expr = value.get("C", 3000)
     assert con.execute(expr) == 3000
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 def test_map_get_with_incompatible_value_different_kind(con):
     value = ibis.literal({"A": 1000, "B": 2000})
     expr = value.get("C", 3.0)
     assert con.execute(expr) == 3.0
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 @pytest.mark.parametrize("null_value", [None, ibis.NA])
 def test_map_get_with_null_on_not_nullable(con, null_value):
     map_type = dt.Map(dt.string, dt.Int16(nullable=False))
@@ -414,7 +414,7 @@ def test_map_get_with_null_on_not_nullable(con, null_value):
 @pytest.mark.notyet(
     ["flink"], raises=Py4JJavaError, reason="Flink cannot handle typeless nulls"
 )
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_map_get_with_null_on_null_type_with_null(con, null_value):
     value = ibis.literal({"A": None, "B": None})
     expr = value.get("C", null_value)
@@ -422,8 +422,8 @@ def test_map_get_with_null_on_null_type_with_null(con, null_value):
     assert pd.isna(result)
 
 
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
-@MARK_NOTYET_POSTGRES
+@mark_notimpl_risingwave_hstore
+@mark_notyet_postgres
 @pytest.mark.notyet(
     ["flink"], raises=Py4JJavaError, reason="Flink cannot handle typeless nulls"
 )
@@ -438,7 +438,7 @@ def test_map_get_with_null_on_null_type_with_non_null(con):
     raises=exc.IbisError,
     reason="`tbl_properties` is required when creating table with schema",
 )
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_map_create_table(con, temp_table):
     t = con.create_table(
         temp_table,
@@ -452,7 +452,7 @@ def test_map_create_table(con, temp_table):
     raises=exc.OperationNotDefinedError,
     reason="No translation rule for <class 'ibis.expr.operations.maps.MapLength'>",
 )
-@MARK_NOTIMPL_RISINGWAVE_HSTORE
+@mark_notimpl_risingwave_hstore
 def test_map_length(con):
     expr = ibis.literal(dict(a="A", b="B")).length()
     assert con.execute(expr) == 2

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -226,6 +226,7 @@ keys = pytest.mark.parametrize(
                 ),
                 pytest.mark.notyet(["pandas", "dask"]),
                 mark_notyet_postgres,
+                pytest.mark.notimpl("flink"),
             ],
             id="array",
         ),
@@ -237,6 +238,7 @@ keys = pytest.mark.parametrize(
                 ),
                 pytest.mark.notyet(["pandas", "dask"]),
                 mark_notyet_postgres,
+                pytest.mark.notimpl("flink"),
             ],
             id="struct",
         ),
@@ -309,7 +311,6 @@ values = pytest.mark.parametrize(
 @values
 @keys
 @mark_notimpl_risingwave_hstore
-@pytest.mark.notimpl("flink")
 def test_map_get_all_types(con, keys, values):
     m = ibis.map(ibis.array(keys), ibis.array(values))
     for key, val in zip(keys, values):
@@ -320,7 +321,6 @@ def test_map_get_all_types(con, keys, values):
 
 @keys
 @mark_notimpl_risingwave_hstore
-@pytest.mark.notimpl("flink")
 def test_map_contains_all_types(con, keys):
     m = ibis.map(ibis.array(keys), ibis.array(keys))
     for key in keys:

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -327,12 +327,6 @@ def test_map_contains_all_types(con, keys):
     a = ibis.array(keys)
     m = ibis.map(a, a)
     for key in keys:
-        # ensure key is the same type as the array
-        # Otherwise on flink we get an error when we try
-        # ARRAY_CONTAINS(ARRAY<TINYINT NOT NULL> NOT NULL, INT NOT NULL)
-        if not isinstance(key, ibis.Expr):
-            key = ibis.literal(key)
-        key = key.cast(a.type().value_type)
         assert con.execute(m.contains(key))
 
 

--- a/ibis/expr/operations/maps.py
+++ b/ibis/expr/operations/maps.py
@@ -32,7 +32,7 @@ class MapLength(Unary):
 @public
 class MapGet(Value):
     arg: Value[dt.Map]
-    key: Value[dt.String | dt.Integer]
+    key: Value
     default: Value = None
 
     shape = rlz.shape_like("args")
@@ -45,7 +45,7 @@ class MapGet(Value):
 @public
 class MapContains(Value):
     arg: Value[dt.Map]
-    key: Value[dt.String | dt.Integer]
+    key: Value
 
     shape = rlz.shape_like("args")
     dtype = dt.bool


### PR DESCRIPTION
Fixes https://github.com/ibis-project/ibis/issues/8605

I bet a lot of these tests will fail in CI. IDK, a lot of these tests feel like overkill. Could just ensure that the Expr can get created, but skip actually executing them on the backend. That requires a lot more boilerplate. But, it is sort of nice to actually have an up-to-date status on what types each backend supports in maps.