### PR TITLE
refactor(sql): deprecate and remove hierarchical usage of schema

### DIFF
--- a/ci/schema/duckdb.sql
+++ b/ci/schema/duckdb.sql
@@ -55,3 +55,7 @@ INSERT INTO map VALUES
 
 CREATE OR REPLACE TABLE topk (x BIGINT);
 INSERT INTO topk VALUES (1), (1), (NULL);
+
+CREATE SCHEMA shops;
+CREATE TABLE shops.ice_cream (flavor TEXT, quantity INT);
+INSERT INTO shops.ice_cream values ('vanilla', 2), ('chocolate', 3);

--- a/docs/backend_table_hiearchy.qmd
+++ b/docs/backend_table_hiearchy.qmd
@@ -1,0 +1,38 @@
+---
+title: Backend Table Hierarchy
+---
+
+Several SQL backends support two levels of hierarchy in organizing tables
+(although the levels are also used for other purposes, like data access,
+billing, etc.).
+
+Ibis uses the following terminology:
+
+- `database`: a collection of tables
+- `catalog`: a collection of databases
+
+Below is a table with the terminology used by each backend for the two levels of
+hierarchy. This is provided as a reference, note that when using Ibis, we will
+use the terms `catalog` and `database` and map them onto the appropriate fields.
+
+
+| Backend    | Catalog        | Database   |
+|------------|----------------|------------|
+| bigquery   | project        | database   |
+| clickhouse |                | database   |
+| dask       |                | NA         |
+| datafusion | catalog        | schema     |
+| druid      | dataSourceType | dataSource |
+| duckdb     | database       | schema     |
+| flink      | catalog        | database   |
+| impala     |                | database   |
+| mssql      | database       | schema     |
+| mysql      |                | database   |
+| oracle     |                | database   |
+| pandas     |                | NA         |
+| polars     |                | NA         |
+| postgres   | database       | schema     |
+| pyspark    |                | database   |
+| risingwave | database       | schema     |
+| snowflake  |                | database   |
+| trino      | catalog        | schema     |

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -812,7 +812,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
 
     @abc.abstractmethod
     def list_tables(
-        self, like: str | None = None, database: str | None = None
+        self, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
         """Return the list of table names in the current database.
 
@@ -824,8 +824,22 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         like
             A pattern in Python's regex format.
         database
-            The database from which to list tables. If not provided, the
-            current database is used.
+            The database from which to list tables.
+            If not provided, the current database is used.
+            For backends that support multi-level table hierarchies, you can
+            pass in a dotted string path like `"catalog.database"` or a tuple of
+            strings like `("catalog", "database")`.
+
+            ::: {.callout-note}
+            ## Ibis does not use the word `schema` to refer to database hierarchy.
+
+            A collection of tables is referred to as a `database`.
+            A collection of `database` is referred to as a `catalog`.
+
+            These terms are mapped onto the corresponding features in each
+            backend (where available), regardless of whether the backend itself
+            uses the same terminology.
+            :::
 
         Returns
         -------

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -933,7 +933,9 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         """
 
     @abc.abstractmethod
-    def table(self, name: str, database: str | None = None) -> ir.Table:
+    def table(
+        self, name: str, database: tuple[str, str] | str | None = None
+    ) -> ir.Table:
         """Construct a table expression.
 
         Parameters
@@ -942,6 +944,21 @@ class BaseBackend(abc.ABC, _FileIOHandler):
             Table name
         database
             Database name
+            If not provided, the current database is used.
+            For backends that support multi-level table hierarchies, you can
+            pass in a dotted string path like `"catalog.database"` or a tuple of
+            strings like `("catalog", "database")`.
+
+            ::: {.callout-note}
+            ## Ibis does not use the word `schema` to refer to database hierarchy.
+
+            A collection of tables is referred to as a `database`.
+            A collection of `database` is referred to as a `catalog`.
+
+            These terms are mapped onto the corresponding features in each
+            backend (where available), regardless of whether the backend itself
+            uses the same terminology.
+            :::
 
         Returns
         -------

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -716,11 +716,14 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
             If `True` then replace existing contents of table
 
         """
+        table_loc = self._warn_and_create_table_loc(database, schema)
+        catalog, db = self._to_catalog_db_tuple(table_loc)
+
         return super().insert(
             table_name,
             obj,
-            schema=schema if schema is not None else self.current_database,
-            database=database if database is not None else self.current_catalog,
+            schema=db if db is not None else self.current_database,
+            database=catalog if catalog is not None else self.current_catalog,
             overwrite=overwrite,
         )
 

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -558,7 +558,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
             table.name,
             schema=schema_from_bigquery_table(bq_table),
             source=self,
-            namespace=ops.Namespace(schema=dataset, database=project),
+            namespace=ops.Namespace(database=dataset, catalog=project),
         )
         table_expr = node.to_expr()
         return rename_partitioned_column(table_expr, bq_table, self.partition_column)

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -841,11 +841,17 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
             return ".".join(f"`{part}`" for part in func.split("."))
         return func
 
-    def get_schema(self, name, schema: str | None = None, database: str | None = None):
+    def get_schema(
+        self,
+        name,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
+    ):
         table_ref = bq.TableReference(
             bq.DatasetReference(
-                project=database or self.data_project,
-                dataset_id=schema or self.current_database,
+                project=catalog or self.data_project,
+                dataset_id=database or self.current_database,
             ),
             name,
         )

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -25,7 +25,7 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
-from ibis.backends import CanCreateSchema
+from ibis.backends import CanCreateDatabase, CanCreateSchema
 from ibis.backends.bigquery.client import (
     BigQueryCursor,
     bigquery_param,
@@ -125,7 +125,7 @@ def _remove_null_ordering_from_unsupported_window(
     return node
 
 
-class Backend(SQLBackend, CanCreateSchema):
+class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     name = "bigquery"
     compiler = BigQueryCompiler()
     supports_in_memory_tables = True
@@ -471,10 +471,10 @@ class Backend(SQLBackend, CanCreateSchema):
     def dataset_id(self):
         return self.dataset
 
-    def create_schema(
+    def create_database(
         self,
         name: str,
-        database: str | None = None,
+        catalog: str | None = None,
         force: bool = False,
         collate: str | None = None,
         **options: Any,
@@ -491,24 +491,24 @@ class Backend(SQLBackend, CanCreateSchema):
 
         stmt = sge.Create(
             kind="SCHEMA",
-            this=sg.table(name, db=database),
+            this=sg.table(name, db=catalog),
             exists=force,
             properties=sge.Properties(expressions=properties),
         )
 
         self.raw_sql(stmt.sql(self.name))
 
-    def drop_schema(
+    def drop_database(
         self,
         name: str,
-        database: str | None = None,
+        catalog: str | None = None,
         force: bool = False,
         cascade: bool = False,
     ) -> None:
         """Drop a BigQuery dataset."""
         stmt = sge.Drop(
             kind="SCHEMA",
-            this=sg.table(name, db=database),
+            this=sg.table(name, db=catalog),
             exists=force,
             cascade=cascade,
         )
@@ -669,11 +669,11 @@ class Backend(SQLBackend, CanCreateSchema):
         return self._execute(query, query_parameters=query_parameters)
 
     @property
-    def current_database(self) -> str:
+    def current_catalog(self) -> str:
         return self.data_project
 
     @property
-    def current_schema(self) -> str | None:
+    def current_database(self) -> str | None:
         return self.dataset
 
     def compile(
@@ -756,8 +756,8 @@ class Backend(SQLBackend, CanCreateSchema):
         return super().insert(
             table_name,
             obj,
-            schema=schema if schema is not None else self.current_schema,
-            database=database if database is not None else self.current_database,
+            schema=schema if schema is not None else self.current_database,
+            database=database if database is not None else self.current_catalog,
             overwrite=overwrite,
         )
 
@@ -845,19 +845,19 @@ class Backend(SQLBackend, CanCreateSchema):
         table_ref = bq.TableReference(
             bq.DatasetReference(
                 project=database or self.data_project,
-                dataset_id=schema or self.current_schema,
+                dataset_id=schema or self.current_database,
             ),
             name,
         )
         return schema_from_bigquery_table(self.client.get_table(table_ref))
 
-    def list_schemas(
-        self, like: str | None = None, database: str | None = None
+    def list_databases(
+        self, like: str | None = None, catalog: str | None = None
     ) -> list[str]:
         results = [
             dataset.dataset_id
             for dataset in self.client.list_datasets(
-                project=database if database is not None else self.data_project
+                project=catalog if catalog is not None else self.data_project
             )
         ]
         return self._filter_with_like(results, like)
@@ -1018,7 +1018,7 @@ class Backend(SQLBackend, CanCreateSchema):
                 raise com.IbisInputError("Cannot specify database for temporary table")
             database = self._session_dataset.project
         else:
-            dataset = database or self.current_schema
+            dataset = database or self.current_database
 
         try:
             table = sg.parse_one(name, into=sge.Table, read="bigquery")
@@ -1069,7 +1069,7 @@ class Backend(SQLBackend, CanCreateSchema):
             kind="TABLE",
             this=sg.table(
                 name,
-                db=schema or self.current_schema,
+                db=schema or self.current_database,
                 catalog=database or self.billing_project,
             ),
             exists=force,
@@ -1089,7 +1089,7 @@ class Backend(SQLBackend, CanCreateSchema):
             kind="VIEW",
             this=sg.table(
                 name,
-                db=schema or self.current_schema,
+                db=schema or self.current_database,
                 catalog=database or self.billing_project,
             ),
             expression=self.compile(obj),
@@ -1111,7 +1111,7 @@ class Backend(SQLBackend, CanCreateSchema):
             kind="VIEW",
             this=sg.table(
                 name,
-                db=schema or self.current_schema,
+                db=schema or self.current_database,
                 catalog=database or self.billing_project,
             ),
             exists=force,

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -233,8 +233,8 @@ def test_exists_table_different_project(con):
     name = "co_daily_summary"
     dataset = "bigquery-public-data.epa_historical_air_quality"
 
-    assert name in con.list_tables(schema=dataset)
-    assert "foobar" not in con.list_tables(schema=dataset)
+    assert name in con.list_tables(database=dataset)
+    assert "foobar" not in con.list_tables(database=dataset)
 
 
 def test_multiple_project_queries(con, snapshot):
@@ -404,3 +404,19 @@ def test_create_table_with_options(con):
         assert t.execute().empty
     finally:
         con.drop_table(name)
+
+
+def test_list_tables_schema_warning_refactor(con):
+    pypi_tables = [
+        "external",
+        "native",
+    ]
+
+    assert con.list_tables()
+
+    # Warn but succeed for schema list
+    with pytest.raises(FutureWarning):
+        assert con.list_tables(schema="pypi") == pypi_tables
+
+    assert con.list_tables(database="ibis-gbq.pypi") == pypi_tables
+    assert con.list_tables(database=("ibis-gbq", "pypi")) == pypi_tables

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -322,7 +322,7 @@ def test_approx_median(alltypes):
 def test_create_table_bignumeric(con, temp_table):
     schema = ibis.schema({"col1": dt.Decimal(76, 38)})
     temporary_table = con.create_table(temp_table, schema=schema)
-    con.raw_sql(f"INSERT {con.current_schema}.{temp_table} (col1) VALUES (10.2)")
+    con.raw_sql(f"INSERT {con.current_database}.{temp_table} (col1) VALUES (10.2)")
     df = temporary_table.execute()
     assert df.shape == (1, 1)
 
@@ -333,7 +333,7 @@ def test_geography_table(con, temp_table):
     schema = ibis.schema({"col1": dt.GeoSpatial(geotype="geography", srid=4326)})
     temporary_table = con.create_table(temp_table, schema=schema)
     con.raw_sql(
-        f"INSERT {con.current_schema}.{temp_table} (col1) VALUES (ST_GEOGPOINT(1,3))"
+        f"INSERT {con.current_database}.{temp_table} (col1) VALUES (ST_GEOGPOINT(1,3))"
     )
     df = temporary_table.execute()
     assert df.shape == (1, 1)
@@ -349,7 +349,7 @@ def test_timestamp_table(con, temp_table):
     )
     temporary_table = con.create_table(temp_table, schema=schema)
     con.raw_sql(
-        f"INSERT {con.current_schema}.{temp_table} (datetime_col, timestamp_col) VALUES (CURRENT_DATETIME(), CURRENT_TIMESTAMP())"
+        f"INSERT {con.current_database}.{temp_table} (datetime_col, timestamp_col) VALUES (CURRENT_DATETIME(), CURRENT_TIMESTAMP())"
     )
     df = temporary_table.execute()
     assert df.shape == (1, 2)

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -463,7 +463,11 @@ class Backend(SQLBackend, CanCreateDatabase):
         self.con.close()
 
     def get_schema(
-        self, table_name: str, database: str | None = None, schema: str | None = None
+        self,
+        table_name: str,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
     ) -> sch.Schema:
         """Return a Schema object for the indicated table and database.
 
@@ -472,10 +476,10 @@ class Backend(SQLBackend, CanCreateDatabase):
         table_name
             May **not** be fully qualified. Use `database` if you want to
             qualify the identifier.
+        catalog
+            Catalog name, not supported by ClickHouse
         database
             Database name
-        schema
-            Schema name, not supported by ClickHouse
 
         Returns
         -------
@@ -483,9 +487,9 @@ class Backend(SQLBackend, CanCreateDatabase):
             Ibis schema
 
         """
-        if schema is not None:
+        if catalog is not None:
             raise com.UnsupportedBackendFeatureError(
-                "`schema` namespaces are not supported by clickhouse"
+                "`catalog` namespaces are not supported by clickhouse"
             )
         query = sge.Describe(this=sg.table(table_name, db=database))
         with self._safe_raw_sql(query) as results:

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -200,6 +200,17 @@ class Backend(SQLBackend, CanCreateDatabase):
     def list_tables(
         self, like: str | None = None, database: str | None = None
     ) -> list[str]:
+        """List the tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables.
+        database
+            Database to list tables from. Default behavior is to show tables in
+            the current database.
+        """
+
         query = sg.select(C.name).from_(sg.table("tables", db="system"))
 
         if database is None:

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -19,7 +19,12 @@ from packaging.version import parse as vparse
 import ibis
 import ibis.common.exceptions as com
 from ibis import util
-from ibis.backends import CanCreateDatabase, CanCreateSchema, _get_backend_names
+from ibis.backends import (
+    CanCreateCatalog,
+    CanCreateDatabase,
+    CanListSchema,
+    _get_backend_names,
+)
 from ibis.conftest import WINDOWS
 from ibis.util import promote_tuple
 
@@ -452,24 +457,32 @@ def con_no_data(backend_no_data):
 
 
 @pytest.fixture(scope="session")
-def con_create_database(con):
-    if isinstance(con, CanCreateDatabase):
-        return con
-    else:
-        pytest.skip(f"{con.name} backend cannot create databases")
-
-
-@pytest.fixture(scope="session")
-def con_create_schema(con):
-    if isinstance(con, CanCreateSchema):
+def con_list_schema(con):
+    if isinstance(con, CanListSchema):
         return con
     else:
         pytest.skip(f"{con.name} backend cannot create schemas")
 
 
 @pytest.fixture(scope="session")
-def con_create_database_schema(con):
-    if isinstance(con, CanCreateDatabase) and isinstance(con, CanCreateSchema):
+def con_create_catalog(con):
+    if isinstance(con, CanCreateCatalog):
+        return con
+    else:
+        pytest.skip(f"{con.name} backend cannot create databases")
+
+
+@pytest.fixture(scope="session")
+def con_create_database(con):
+    if isinstance(con, CanCreateDatabase):
+        return con
+    else:
+        pytest.skip(f"{con.name} backend cannot create schemas")
+
+
+@pytest.fixture(scope="session")
+def con_create_catalog_database(con):
+    if isinstance(con, CanCreateCatalog) and isinstance(con, CanCreateDatabase):
         return con
     else:
         pytest.skip(f"{con.name} backend cannot create both database and schemas")

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -664,6 +664,9 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         # datafusion doesn't support `TRUNCATE TABLE` so we use `DELETE FROM`
         #
         # however datafusion as of 34.0.0 doesn't implement DELETE DML yet
-        ident = sg.table(name, db=schema, catalog=database).sql(self.name)
+        table_loc = self._warn_and_create_table_loc(database, schema)
+        catalog, db = self._to_catalog_db_tuple(table_loc)
+
+        ident = sg.table(name, db=db, catalog=catalog).sql(self.name)
         with self._safe_raw_sql(sge.delete(ident)):
             pass

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -274,17 +274,20 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         """
         return self._filter_with_like(self.con.tables(), like)
 
-    # XXX(Gil): refactor schema out of this
     def get_schema(
-        self, table_name: str, schema: str | None = None, database: str | None = None
+        self,
+        table_name: str,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
     ) -> sch.Schema:
-        if database is not None:
-            catalog = self.con.catalog(database)
+        if catalog is not None:
+            catalog = self.con.catalog(catalog)
         else:
             catalog = self.con.catalog()
 
-        if schema is not None:
-            database = catalog.database(schema)
+        if database is not None:
+            database = catalog.database(database)
         else:
             database = catalog.database()
 

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -264,7 +264,20 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, NoUrl):
         like: str | None = None,
         database: str | None = None,
     ) -> list[str]:
-        """List the available tables."""
+        """Return the list of table names in the current database.
+
+        Parameters
+        ----------
+        like
+            A pattern in Python's regex format.
+        database
+            Unused in the datafusion backend.
+
+        Returns
+        -------
+        list[str]
+            The list of the table names that match the pattern `like`.
+        """
         return self._filter_with_like(self.con.tables(), like)
 
     def get_schema(

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -115,11 +115,15 @@ class Backend(SQLBackend):
         return sch.Schema(schema)
 
     def get_schema(
-        self, table_name: str, schema: str | None = None, database: str | None = None
+        self,
+        table_name: str,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
     ) -> sch.Schema:
         return self._get_schema_using_query(
             sg.select(STAR)
-            .from_(sg.table(table_name, db=schema, catalog=database))
+            .from_(sg.table(table_name, db=database, catalog=catalog))
             .sql(self.dialect)
         )
 

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -157,6 +157,16 @@ class Backend(SQLBackend):
     def list_tables(
         self, like: str | None = None, database: str | None = None
     ) -> list[str]:
+        """List the tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables.
+        database
+            Database to list tables from. Default behavior is to show tables in
+            the current database.
+        """
         t = sg.table("TABLES", db="INFORMATION_SCHEMA", quoted=True)
         c = self.compiler
         query = sg.select(sg.column("TABLE_NAME", quoted=True)).from_(t).sql(c.dialect)

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -273,7 +273,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
             Table expression
 
         """
-        table_schema = self.get_schema(name, schema=schema, database=database)
+        table_schema = self.get_schema(name, catalog=schema, database=database)
         # load geospatial only if geo columns
         if any(typ.is_geospatial() for typ in table_schema.types):
             self.load_extension("spatial")
@@ -285,7 +285,11 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         ).to_expr()
 
     def get_schema(
-        self, table_name: str, schema: str | None = None, database: str | None = None
+        self,
+        table_name: str,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
     ) -> sch.Schema:
         """Compute the schema of a `table`.
 
@@ -294,8 +298,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         table_name
             May **not** be fully qualified. Use `database` if you want to
             qualify the identifier.
-        schema
-            Schema name
+        catalog
+            Catalog name
         database
             Database name
 
@@ -307,11 +311,11 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         """
         conditions = [sg.column("table_name").eq(sge.convert(table_name))]
 
-        if database is not None:
-            conditions.append(sg.column("table_catalog").eq(sge.convert(database)))
+        if catalog is not None:
+            conditions.append(sg.column("table_catalog").eq(sge.convert(catalog)))
 
-        if schema is not None:
-            conditions.append(sg.column("table_schema").eq(sge.convert(schema)))
+        if database is not None:
+            conditions.append(sg.column("table_schema").eq(sge.convert(database)))
 
         query = (
             sg.select(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -263,7 +263,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         name
             Table name
         schema
-            Schema name
+            [deprecated] Schema name
         database
             Database name
 
@@ -273,7 +273,14 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
             Table expression
 
         """
-        table_schema = self.get_schema(name, catalog=schema, database=database)
+        table_loc = self._warn_and_create_table_loc(database, schema)
+
+        catalog, database = None, None
+        if table_loc is not None:
+            catalog = table_loc.catalog or None
+            database = table_loc.db or None
+
+        table_schema = self.get_schema(name, catalog=catalog, database=database)
         # load geospatial only if geo columns
         if any(typ.is_geospatial() for typ in table_schema.types):
             self.load_extension("spatial")
@@ -281,7 +288,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
             name,
             schema=table_schema,
             source=self,
-            namespace=ops.Namespace(database=database, schema=schema),
+            namespace=ops.Namespace(database=catalog, schema=database),
         ).to_expr()
 
     def get_schema(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -288,7 +288,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
             name,
             schema=table_schema,
             source=self,
-            namespace=ops.Namespace(database=catalog, schema=database),
+            namespace=ops.Namespace(catalog=catalog, database=database),
         ).to_expr()
 
     def get_schema(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -892,7 +892,7 @@ class Backend(SQLBackend, CanCreateSchema, UrlFromPath):
     def list_tables(
         self,
         like: str | None = None,
-        database: str | None = None,
+        database: tuple[str, str] | str | None = None,
         schema: str | None = None,
     ) -> list[str]:
         """List tables and views.
@@ -902,10 +902,27 @@ class Backend(SQLBackend, CanCreateSchema, UrlFromPath):
         like
             Regex to filter by table/view name.
         database
-            Database name. If not passed, uses the current database. Only
-            supported with MotherDuck.
+            Database location. If not passed, uses the current database.
+
+            By default uses the current `database` (`self.current_database`) and
+            `catalog` (`self.current_catalog`).
+
+            To specify a table in a separate catalog, you can pass in the
+            catalog and database as a string `"catalog.database"`, or as a tuple of
+            strings `("catalog", "database")`.
+
+            ::: {.callout-note}
+            ## Ibis does not use the word `schema` to refer to database hierarchy.
+
+            A collection of tables is referred to as a `database`.
+            A collection of `database` is referred to as a `catalog`.
+
+            These terms are mapped onto the corresponding features in each
+            backend (where available), regardless of whether the backend itself
+            uses the same terminology.
+            :::
         schema
-            Schema name. If not passed, uses the current schema.
+            [deprecated] Schema name. If not passed, uses the current schema.
 
         Returns
         -------
@@ -922,18 +939,23 @@ class Backend(SQLBackend, CanCreateSchema, UrlFromPath):
         >>> bar = con.create_view("bar", foo)
         >>> con.list_tables()
         ['bar', 'foo']
-        >>> con.create_schema("my_schema")
-        >>> con.list_tables(schema="my_schema")
+        >>> con.create_database("my_database")
+        >>> con.list_tables(database="my_database")
         []
         >>> with con.begin() as c:
-        ...     c.exec_driver_sql("CREATE TABLE my_schema.baz (a INTEGER)")  # doctest: +ELLIPSIS
+        ...     c.exec_driver_sql("CREATE TABLE my_database.baz (a INTEGER)")  # doctest: +ELLIPSIS
         <...>
-        >>> con.list_tables(schema="my_schema")
+        >>> con.list_tables(database="my_database")
         ['baz']
 
         """
-        database = F.current_database() if database is None else sge.convert(database)
-        schema = F.current_schema() if schema is None else sge.convert(schema)
+        table_loc = self._warn_and_create_table_loc(database, schema)
+
+        catalog = F.current_database()
+        database = F.current_schema()
+        if table_loc is not None:
+            catalog = table_loc.catalog or catalog
+            database = table_loc.db or database
 
         col = "table_name"
         sql = (
@@ -941,10 +963,10 @@ class Backend(SQLBackend, CanCreateSchema, UrlFromPath):
             .from_(sg.table("tables", db="information_schema"))
             .distinct()
             .where(
-                C.table_catalog.eq(database).or_(
+                C.table_catalog.eq(catalog).or_(
                     C.table_catalog.eq(sge.convert("temp"))
                 ),
-                C.table_schema.eq(schema),
+                C.table_schema.eq(database),
             )
             .sql(self.name, pretty=True)
         )

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -78,11 +78,13 @@ def test_cross_db(tmpdir):
 
     con2.attach(path1, name="test1", read_only=True)
 
-    t1_from_con2 = con2.table("t1", schema="main", database="test1")
+    with pytest.warns(FutureWarning):
+        t1_from_con2 = con2.table("t1", schema="main", database="test1")
     assert t1_from_con2.schema() == t2.schema()
     assert t1_from_con2.execute().equals(t2.execute())
 
-    foo_t1_from_con2 = con2.table("t1", schema="foo", database="test1")
+    with pytest.warns(FutureWarning):
+        foo_t1_from_con2 = con2.table("t1", schema="foo", database="test1")
     assert foo_t1_from_con2.schema() == t2.schema()
     assert foo_t1_from_con2.execute().equals(t2.execute())
 

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -276,3 +276,22 @@ def test_invalid_connect(tmp_path):
     url = f"duckdb://{tmp_path}?read_only=invalid_value"
     with pytest.raises(ValueError):
         ibis.connect(url)
+
+
+def test_list_tables_schema_warning_refactor(con):
+    assert {
+        "astronauts",
+        "awards_players",
+        "batting",
+        "diamonds",
+        "functional_alltypes",
+        "win",
+    }.issubset(con.list_tables())
+
+    icecream_table = ["ice_cream"]
+
+    with pytest.warns(FutureWarning):
+        assert con.list_tables(schema="shops") == icecream_table
+
+    assert con.list_tables(database="shops") == icecream_table
+    assert con.list_tables(database=("shops",)) == icecream_table

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -97,23 +97,23 @@ def test_attach_detach(tmpdir):
 
     # default name
     name = "test1"
-    assert name not in con2.list_databases()
+    assert name not in con2.list_catalogs()
 
     con2.attach(path1)
-    assert name in con2.list_databases()
+    assert name in con2.list_catalogs()
 
     con2.detach(name)
-    assert name not in con2.list_databases()
+    assert name not in con2.list_catalogs()
 
     # passed-in name
     name = "test_foo"
-    assert name not in con2.list_databases()
+    assert name not in con2.list_catalogs()
 
     con2.attach(path1, name=name)
-    assert name in con2.list_databases()
+    assert name in con2.list_catalogs()
 
     con2.detach(name)
-    assert name not in con2.list_databases()
+    assert name not in con2.list_catalogs()
 
     with pytest.raises(duckdb.BinderException):
         con2.detach(name)

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -167,13 +167,20 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         return self._filter_with_like([table for (table,) in tables], like=like)
 
     def get_schema(
-        self, table_name: str, schema: str | None = None, database: str | None = None
+        self,
+        table_name: str,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
     ) -> sch.Schema:
         return self._get_schema_using_query(
             sg.select(STAR)
             .from_(
                 sg.table(
-                    table_name, db=schema, catalog=database, quoted=self.compiler.quoted
+                    table_name,
+                    db=database,
+                    catalog=catalog,
+                    quoted=self.compiler.quoted,
                 )
             )
             .sql(self.dialect)

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -137,6 +137,16 @@ class Backend(SQLBackend):
             yield cur.execute(query, *args, **kwargs)
 
     def list_tables(self, like=None, database=None):
+        """List the tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables.
+        database
+            Database to list tables from. Default behavior is to show tables in
+            the current database.
+        """
         tables = sg.select("table_name").from_(
             sg.table("EXA_ALL_TABLES", catalog="SYS")
         )

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -18,6 +18,7 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
+from ibis.backends import CanCreateDatabase, CanCreateSchema
 from ibis.backends.exasol.compiler import ExasolCompiler
 from ibis.backends.sql import SQLBackend
 from ibis.backends.sql.compiler import STAR, C
@@ -34,7 +35,7 @@ if TYPE_CHECKING:
 _VARCHAR_REGEX = re.compile(r"^((VAR)?CHAR(?:\(\d+\)))?(?:\s+.+)?$")
 
 
-class Backend(SQLBackend):
+class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     name = "exasol"
     compiler = ExasolCompiler()
     supports_temporary_tables = False
@@ -378,52 +379,54 @@ class Backend(SQLBackend):
         ).to_expr()
 
     @property
-    def current_schema(self) -> str:
+    def current_database(self) -> str:
         with self._safe_raw_sql("SELECT CURRENT_SCHEMA") as cur:
             [(schema,)] = cur.fetchall()
         return schema
 
-    def drop_schema(
-        self, name: str, database: str | None = None, force: bool = False
+    def drop_database(
+        self, name: str, catalog: str | None = None, force: bool = False
     ) -> None:
-        if database is not None:
+        if catalog is not None:
             raise NotImplementedError(
-                "`database` argument is not supported for the Exasol backend"
+                "`catalog` argument is not supported for the Exasol backend"
             )
         drop_schema = sg.exp.Drop(kind="SCHEMA", this=name, exists=force)
         with self.begin() as con:
             con.execute(drop_schema.sql(dialect=self.dialect))
 
-    def create_schema(
-        self, name: str, database: str | None = None, force: bool = False
+    def create_database(
+        self, name: str, catalog: str | None = None, force: bool = False
     ) -> None:
-        if database is not None:
+        if catalog is not None:
             raise NotImplementedError(
-                "`database` argument is not supported for the Exasol backend"
+                "`catalog` argument is not supported for the Exasol backend"
             )
-        create_schema = sg.exp.Create(kind="SCHEMA", this=name, exists=force)
-        open_schema = self.current_schema
+        create_database = sg.exp.Create(kind="SCHEMA", this=name, exists=force)
+        open_database = self.current_database
         with self.begin() as con:
-            con.execute(create_schema.sql(dialect=self.dialect))
+            con.execute(create_database.sql(dialect=self.dialect))
             # Exasol implicitly opens the created schema, therefore we need to restore
             # the previous context.
             con.execute(
-                f"OPEN SCHEMA {open_schema}" if open_schema else f"CLOSE SCHEMA {name}"
+                f"OPEN SCHEMA {open_database}"
+                if open_database
+                else f"CLOSE SCHEMA {name}"
             )
 
-    def list_schemas(
-        self, like: str | None = None, database: str | None = None
+    def list_databases(
+        self, like: str | None = None, catalog: str | None = None
     ) -> list[str]:
-        if database is not None:
+        if catalog is not None:
             raise NotImplementedError(
-                "`database` argument is not supported for the Exasol backend"
+                "`catalog` argument is not supported for the Exasol backend"
             )
 
         query = sg.select("schema_name").from_(sg.table("EXA_SCHEMAS", catalog="SYS"))
 
         with self._safe_raw_sql(query) as con:
-            schemas = con.fetchall()
-        return self._filter_with_like([schema for (schema,) in schemas], like=like)
+            databases = con.fetchall()
+        return self._filter_with_like([db for (db,) in databases], like=like)
 
     def _cursor_batches(
         self,

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -261,8 +261,9 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def get_schema(
         self,
         table_name: str,
-        database: str | None = None,
+        *,
         catalog: str | None = None,
+        database: str | None = None,
     ) -> sch.Schema:
         """Return a Schema object for the indicated table and database.
 
@@ -270,10 +271,10 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
         ----------
         table_name : str
             Table name.
-        database : str, optional
-            Database name.
         catalog : str, optional
             Catalog name.
+        database : str, optional
+            Database name.
 
         Returns
         -------

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -254,7 +254,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
             name,
             schema=schema,
             source=self,
-            namespace=ops.Namespace(schema=catalog, database=database),
+            namespace=ops.Namespace(catalog=catalog, database=database),
         )
         return node.to_expr()
 

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -208,6 +208,22 @@ class Backend(SQLBackend):
         return self._filter_with_like(databases.name.tolist(), like)
 
     def list_tables(self, like=None, database=None):
+        """Return the list of table names in the current database.
+
+        Parameters
+        ----------
+        like
+            A pattern in Python's regex format.
+        database
+            The database from which to list tables.
+            If not provided, the current database is used.
+
+        Returns
+        -------
+        list[str]
+            The list of the table names that match the pattern `like`.
+        """
+
         statement = "SHOW TABLES"
         if database is not None:
             statement += f" IN {database}"

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -353,7 +353,11 @@ class Backend(SQLBackend):
         self._safe_exec_sql(statement)
 
     def get_schema(
-        self, table_name: str, schema: str | None = None, database: str | None = None
+        self,
+        table_name: str,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
     ) -> sch.Schema:
         """Return a Schema object for the indicated table and database.
 
@@ -361,8 +365,8 @@ class Backend(SQLBackend):
         ----------
         table_name
             Table name
-        schema
-            Schema name. Unused in the impala backend.
+        catalog
+            Catalog name. Unused in the impala backend.
         database
             Database name
 
@@ -374,7 +378,7 @@ class Backend(SQLBackend):
         """
         query = sge.Describe(
             this=sg.table(
-                table_name, db=schema, catalog=database, quoted=self.compiler.quoted
+                table_name, db=database, catalog=catalog, quoted=self.compiler.quoted
             )
         )
 

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -22,7 +22,7 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
-from ibis.backends import CanCreateDatabase, CanCreateSchema, NoUrl
+from ibis.backends import CanCreateCatalog, CanCreateDatabase, CanCreateSchema, NoUrl
 from ibis.backends.mssql.compiler import MSSQLCompiler
 from ibis.backends.sql import SQLBackend
 from ibis.backends.sql.compiler import C
@@ -55,7 +55,7 @@ def datetimeoffset_to_datetime(value):
     )
 
 
-class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, NoUrl):
+class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, NoUrl):
     name = "mssql"
     compiler = MSSQLCompiler()
     supports_create_or_replace = False
@@ -115,7 +115,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, NoUrl):
                 sg.table(
                     "columns",
                     db="information_schema",
-                    catalog=database or self.current_database,
+                    catalog=database or self.current_catalog,
                 )
             )
             .where(*conditions)
@@ -189,12 +189,12 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, NoUrl):
         return sch.Schema(schema)
 
     @property
-    def current_database(self) -> str:
+    def current_catalog(self) -> str:
         with self._safe_raw_sql(sg.select(self.compiler.f.db_name())) as cur:
             [(database,)] = cur.fetchall()
         return database
 
-    def list_databases(self, like: str | None = None) -> list[str]:
+    def list_catalogs(self, like: str | None = None) -> list[str]:
         s = sg.table("databases", db="sys")
 
         with self._safe_raw_sql(sg.select(C.name).from_(s)) as cur:
@@ -203,7 +203,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, NoUrl):
         return self._filter_with_like(results, like=like)
 
     @property
-    def current_schema(self) -> str:
+    def current_database(self) -> str:
         with self._safe_raw_sql(sg.select(self.compiler.f.schema_name())) as cur:
             [(schema,)] = cur.fetchall()
         return schema
@@ -248,7 +248,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, NoUrl):
             con.commit()
             return cursor
 
-    def create_database(self, name: str, force: bool = False) -> None:
+    def create_catalog(self, name: str, force: bool = False) -> None:
         name = self._quote(name)
         create_stmt = (
             f"""\
@@ -263,18 +263,18 @@ GO"""
         with self._safe_raw_sql(create_stmt):
             pass
 
-    def drop_database(self, name: str, force: bool = False) -> None:
+    def drop_catalog(self, name: str, force: bool = False) -> None:
         name = self._quote(name)
         if_exists = "IF EXISTS " * force
 
         with self._safe_raw_sql(f"DROP DATABASE {if_exists}{name}"):
             pass
 
-    def create_schema(
-        self, name: str, database: str | None = None, force: bool = False
+    def create_database(
+        self, name: str, catalog: str | None = None, force: bool = False
     ) -> None:
-        current_database = self.current_database
-        should_switch_database = database is not None and database != current_database
+        current_catalog = self.current_catalog
+        should_switch_catalog = catalog is not None and catalog != current_catalog
 
         name = self._quote(name)
 
@@ -290,35 +290,35 @@ GO"""
         )
 
         with self.begin() as cur:
-            if should_switch_database:
-                cur.execute(f"USE {self._quote(database)}")
+            if should_switch_catalog:
+                cur.execute(f"USE {self._quote(catalog)}")
 
             cur.execute(create_stmt)
 
-            if should_switch_database:
-                cur.execute(f"USE {self._quote(current_database)}")
+            if should_switch_catalog:
+                cur.execute(f"USE {self._quote(current_catalog)}")
 
     def _quote(self, name: str):
         return sg.to_identifier(name, quoted=True).sql(self.dialect)
 
-    def drop_schema(
-        self, name: str, database: str | None = None, force: bool = False
+    def drop_database(
+        self, name: str, catalog: str | None = None, force: bool = False
     ) -> None:
-        current_database = self.current_database
-        should_switch_database = database is not None and database != current_database
+        current_catalog = self.current_catalog
+        should_switch_catalog = catalog is not None and catalog != current_catalog
 
         name = self._quote(name)
 
         if_exists = "IF EXISTS " * force
 
         with self.begin() as cur:
-            if should_switch_database:
-                cur.execute(f"USE {self._quote(database)}")
+            if should_switch_catalog:
+                cur.execute(f"USE {self._quote(catalog)}")
 
             cur.execute(f"DROP SCHEMA {if_exists}{name}")
 
-            if should_switch_database:
-                cur.execute(f"USE {self._quote(current_database)}")
+            if should_switch_catalog:
+                cur.execute(f"USE {self._quote(current_catalog)}")
 
     def list_tables(
         self,
@@ -381,14 +381,14 @@ GO"""
 
         return self._filter_with_like(map(itemgetter(0), out), like)
 
-    def list_schemas(
-        self, like: str | None = None, database: str | None = None
+    def list_databases(
+        self, like: str | None = None, catalog: str | None = None
     ) -> list[str]:
         query = sg.select(C.schema_name).from_(
             sg.table(
                 "schemata",
                 db="information_schema",
-                catalog=database or self.current_database,
+                catalog=catalog or self.current_catalog,
             )
         )
         with self._safe_raw_sql(query) as cur:

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -95,12 +95,12 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         self.con = con
 
     def get_schema(
-        self, name: str, schema: str | None = None, database: str | None = None
+        self, name: str, *, catalog: str | None = None, database: str | None = None
     ) -> sch.Schema:
         conditions = [sg.column("table_name").eq(sge.convert(name))]
 
-        if schema is not None:
-            conditions.append(sg.column("table_schema").eq(sge.convert(schema)))
+        if database is not None:
+            conditions.append(sg.column("table_schema").eq(sge.convert(database)))
 
         query = (
             sg.select(
@@ -115,7 +115,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
                 sg.table(
                     "columns",
                     db="information_schema",
-                    catalog=database or self.current_catalog,
+                    catalog=catalog or self.current_catalog,
                 )
             )
             .where(*conditions)
@@ -126,7 +126,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             meta = cur.fetchall()
 
         if not meta:
-            fqn = sg.table(name, db=schema, catalog=database).sql(self.dialect)
+            fqn = sg.table(name, db=database, catalog=catalog).sql(self.dialect)
             raise com.IbisError(f"Table not found: {fqn}")
 
         mapping = {}

--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -112,3 +112,25 @@ def test_glorious_length_function_hack(con, string):
     expr = lit.length()
     result = con.execute(expr)
     assert result == len(string)
+
+
+def test_list_tables_schema_warning_refactor(con):
+    assert set(con.list_tables()) >= {
+        "astronauts",
+        "awards_players",
+        "batting",
+        "diamonds",
+        "functional_alltypes",
+        "win",
+    }
+
+    restore_tables = ["restorefile", "restorefilegroup", "restorehistory"]
+
+    with pytest.warns(FutureWarning):
+        assert (
+            con.list_tables(database="msdb", schema="dbo", like="restore")
+            == restore_tables
+        )
+
+    assert con.list_tables(database="msdb.dbo", like="restore") == restore_tables
+    assert con.list_tables(database=("msdb", "dbo"), like="restore") == restore_tables

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -197,9 +197,9 @@ class Backend(SQLBackend, CanCreateDatabase):
                 cur.execute(f"DROP TABLE {table}")
 
     def get_schema(
-        self, name: str, schema: str | None = None, database: str | None = None
+        self, name: str, *, catalog: str | None = None, database: str | None = None
     ) -> sch.Schema:
-        table = sg.table(name, db=schema, catalog=database, quoted=True).sql(self.name)
+        table = sg.table(name, db=database, catalog=catalog, quoted=True).sql(self.name)
 
         with self.begin() as cur:
             cur.execute(f"DESCRIBE {table}")

--- a/ibis/backends/mysql/tests/test_client.py
+++ b/ibis/backends/mysql/tests/test_client.py
@@ -185,3 +185,20 @@ def test_builtin_agg_udf(con):
     result = expr.execute()
     expected = '["0","1","2","3","4"]'
     assert result == expected
+
+
+def test_list_tables_schema_warning_refactor(con):
+    mysql_tables = {
+        "column_stats",
+        "columns_priv",
+        "db",
+        "event",
+        "func",
+    }
+    assert con.list_tables()
+
+    with pytest.warns(FutureWarning):
+        assert mysql_tables.issubset(con.list_tables(schema="mysql"))
+
+    assert mysql_tables.issubset(con.list_tables(database="mysql"))
+    assert mysql_tables.issubset(con.list_tables(database=("mysql",)))

--- a/ibis/backends/mysql/tests/test_client.py
+++ b/ibis/backends/mysql/tests/test_client.py
@@ -97,7 +97,7 @@ def tmp_t(con):
 
 
 def test_get_schema_from_query_other_schema(con, tmp_t):
-    t = con.table(tmp_t, schema="test_schema")
+    t = con.table(tmp_t, database="test_schema")
     assert t.schema() == ibis.schema({"x": dt.inet})
 
 

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -21,6 +21,7 @@ import ibis.expr.operations as ops
 import ibis.expr.schema as sch
 import ibis.expr.types as ir
 from ibis import util
+from ibis.backends import CanListDatabase, CanListSchema
 from ibis.backends.oracle.compiler import OracleCompiler
 from ibis.backends.sql import STAR, SQLBackend
 from ibis.backends.sql.compiler import C
@@ -71,7 +72,7 @@ def metadata_row_to_type(
     return typ
 
 
-class Backend(SQLBackend):
+class Backend(SQLBackend, CanListDatabase, CanListSchema):
     name = "oracle"
     compiler = OracleCompiler()
 
@@ -276,12 +277,12 @@ class Backend(SQLBackend):
 
         return self._filter_with_like(map(itemgetter(0), out), like)
 
-    def list_schemas(
-        self, like: str | None = None, database: str | None = None
+    def list_databases(
+        self, like: str | None = None, catalog: str | None = None
     ) -> list[str]:
-        if database is not None:
+        if catalog is not None:
             raise exc.UnsupportedArgumentError(
-                "No cross-database schema access in Oracle"
+                "No cross-catalog schema access in Oracle"
             )
 
         query = sg.select("username").from_("all_users").order_by("username")

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -293,10 +293,10 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
         return self._filter_with_like(schemata, like)
 
     def get_schema(
-        self, name: str, schema: str | None = None, database: str | None = None
+        self, name: str, *, catalog: str | None = None, database: str | None = None
     ) -> sch.Schema:
-        if schema is None:
-            schema = self.con.username.upper()
+        if database is None:
+            database = self.con.username.upper()
         stmt = (
             sg.select(
                 C.column_name,
@@ -308,7 +308,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
             .from_(sg.table("all_tab_columns"))
             .where(
                 C.table_name.eq(sge.convert(name)),
-                C.owner.eq(sge.convert(schema)),
+                C.owner.eq(sge.convert(database)),
             )
             .order_by(C.column_id)
         )

--- a/ibis/backends/oracle/tests/test_client.py
+++ b/ibis/backends/oracle/tests/test_client.py
@@ -4,8 +4,10 @@ from datetime import date  # noqa: TCH003
 
 import pandas as pd
 import pandas.testing as tm
+import pytest
 
 import ibis
+import ibis.common.exceptions as exc
 from ibis import udf
 
 
@@ -57,3 +59,15 @@ def test_builtin_agg_udf(con):
             c.execute(sql).fetchall(), columns=["string_col", "df_w"]
         )
     tm.assert_frame_equal(result, expected, check_dtype=False)
+
+
+def test_list_tables_schema_warning_refactor(con):
+    assert con.list_tables()
+
+    with pytest.raises(exc.IbisInputError):
+        con.list_tables(database="not none", schema="not none")
+
+    with pytest.warns(FutureWarning):
+        assert con.list_tables(schema="SYS", like="EXU8OPT") == ["EXU8OPT"]
+
+    assert con.list_tables(database="SYS", like="EXU8OPT") == ["EXU8OPT"]

--- a/ibis/backends/oracle/tests/test_datatypes.py
+++ b/ibis/backends/oracle/tests/test_datatypes.py
@@ -6,7 +6,7 @@ import ibis
 def test_failed_column_inference(con):
     # This is a table in the Docker container that we know fails
     # column type inference, so if is loaded, then we're in OK shape.
-    table = con.table("ALL_DOMAINS", schema="SYS")
+    table = con.table("ALL_DOMAINS", database="SYS")
     assert len(table.columns)
 
 

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -148,6 +148,20 @@ class BasePandasBackend(BaseBackend, NoUrl):
         return pd.__version__
 
     def list_tables(self, like=None, database=None):
+        """Return the list of table names in the current database.
+
+        Parameters
+        ----------
+        like
+            A pattern in Python's regex format.
+        database
+            Unused in the pandas backend.
+
+        Returns
+        -------
+        list[str]
+            The list of the table names that match the pattern `like`.
+        """
         return self._filter_with_like(list(self.dictionary.keys()), like)
 
     def table(self, name: str, schema: sch.Schema | None = None):

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -170,7 +170,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
         schema = PandasData.infer_table(df, schema=schema)
         return ops.DatabaseTable(name, schema, self).to_expr()
 
-    def get_schema(self, table_name, database=None):
+    def get_schema(self, table_name, *, database=None):
         schemas = self.schemas
         try:
             schema = schemas[table_name]

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -370,7 +370,7 @@ class Backend(BaseBackend, NoUrl):
         self._add_table(name, obj)
         return self.table(name)
 
-    def get_schema(self, table_name, database=None):
+    def get_schema(self, table_name):
         return self._tables[table_name].schema
 
     @classmethod

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -530,7 +530,11 @@ $$""".format(**self._get_udf_source(udf_node))
                 pass
 
     def get_schema(
-        self, name: str, schema: str | None = None, database: str | None = None
+        self,
+        name: str,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
     ):
         a = ColGen(table="a")
         c = ColGen(table="c")

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -673,13 +673,6 @@ $$""".format(**self._get_udf_source(udf_node))
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
 
-        if database is not None and database != self.current_catalog:
-            raise com.UnsupportedOperationError(
-                f"Creating tables in other databases is not supported by {self.name}"
-            )
-        else:
-            database = None
-
         properties = []
 
         if temp:
@@ -715,7 +708,7 @@ $$""".format(**self._get_udf_source(udf_node))
         else:
             temp_name = name
 
-        table = sg.table(temp_name, catalog=database, quoted=self.compiler.quoted)
+        table = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
         target = sge.Schema(this=table, expressions=column_defs)
 
         create_stmt = sge.Create(
@@ -750,20 +743,11 @@ $$""".format(**self._get_udf_source(udf_node))
         self,
         name: str,
         database: str | None = None,
-        schema: str | None = None,
         force: bool = False,
     ) -> None:
-        if database is not None and database != self.current_catalog:
-            raise com.UnsupportedOperationError(
-                f"Dropping tables in other databases is not supported by {self.name}"
-            )
-        else:
-            database = None
         drop_stmt = sg.exp.Drop(
             kind="TABLE",
-            this=sg.table(
-                name, db=schema, catalog=database, quoted=self.compiler.quoted
-            ),
+            this=sg.table(name, db=database, quoted=self.compiler.quoted),
             exists=force,
         )
         with self._safe_raw_sql(drop_stmt):

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -115,7 +115,7 @@ def test_unsupported_intervals(con):
     assert t["g"].type() == dt.Interval("M")
 
 
-@pytest.mark.parametrize("params", [{}, {"database": POSTGRES_TEST_DB}])
+@pytest.mark.parametrize("params", [{}, {"database": "public"}])
 def test_create_and_drop_table(con, temp_table, params):
     sch = ibis.schema(
         [

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -79,9 +79,9 @@ def test_compile_toplevel(snapshot):
     snapshot.assert_match(str(result), "out.sql")
 
 
-def test_list_databases(con):
+def test_list_catalogs(con):
     assert POSTGRES_TEST_DB is not None
-    assert POSTGRES_TEST_DB in con.list_databases()
+    assert POSTGRES_TEST_DB in con.list_catalogs()
 
 
 def test_interval_films_schema(con):
@@ -250,4 +250,4 @@ def test_kwargs_passthrough_in_connect():
     con = ibis.connect(
         "postgresql://postgres:postgres@localhost/ibis_testing?sslmode=allow"
     )
-    assert con.current_database == "ibis_testing"
+    assert con.current_catalog == "ibis_testing"

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -60,8 +60,14 @@ def test_simple_aggregate_execute(alltypes):
 
 
 def test_list_tables(con):
-    assert len(con.list_tables()) > 0
     assert len(con.list_tables(like="functional")) == 1
+    assert {"astronauts", "batting", "diamonds"} <= set(con.list_tables())
+
+    _ = con.create_table("tempy", schema=ibis.schema(dict(id="int")), temp=True)
+
+    assert "tempy" in con.list_tables()
+    # temp tables only show up when database='public' (or default)
+    assert "tempy" not in con.list_tables(database="tiger")
 
 
 def test_compile_toplevel(snapshot):

--- a/ibis/backends/postgres/tests/test_udf.py
+++ b/ibis/backends/postgres/tests/test_udf.py
@@ -17,11 +17,11 @@ pytest.importorskip("psycopg2")
 
 
 @pytest.fixture(scope="session")
-def test_schema(con):
-    schema_name = f"udf_test_{guid()}"
-    con.create_schema(schema_name, force=True)
-    yield schema_name
-    con.drop_schema(schema_name, force=True, cascade=True)
+def test_database(con):
+    db_name = f"udf_test_{guid()}"
+    con.create_database(db_name, force=True)
+    yield db_name
+    con.drop_database(db_name, force=True, cascade=True)
 
 
 @pytest.fixture(scope="session")
@@ -30,24 +30,24 @@ def table_name():
 
 
 @pytest.fixture(scope="session")
-def sql_table_setup(test_schema, table_name):
+def sql_table_setup(test_database, table_name):
     return f"""\
-DROP TABLE IF EXISTS {test_schema}.{table_name};
-CREATE TABLE {test_schema}.{table_name} (
+DROP TABLE IF EXISTS {test_database}.{table_name};
+CREATE TABLE {test_database}.{table_name} (
     user_id integer,
     user_name varchar,
     name_length integer
 );
-INSERT INTO {test_schema}.{table_name} VALUES
+INSERT INTO {test_database}.{table_name} VALUES
 (1, 'Raj', 3),
 (2, 'Judy', 4),
 (3, 'Jonathan', 8)"""
 
 
 @pytest.fixture(scope="session")
-def sql_define_py_udf(test_schema):
+def sql_define_py_udf(test_database):
     return f"""\
-CREATE OR REPLACE FUNCTION {test_schema}.pylen(x varchar)
+CREATE OR REPLACE FUNCTION {test_database}.pylen(x varchar)
 RETURNS integer
 LANGUAGE plpython3u
 AS
@@ -57,9 +57,9 @@ $$"""
 
 
 @pytest.fixture(scope="session")
-def sql_define_udf(test_schema):
+def sql_define_udf(test_database):
     return f"""\
-CREATE OR REPLACE FUNCTION {test_schema}.custom_len(x varchar)
+CREATE OR REPLACE FUNCTION {test_database}.custom_len(x varchar)
 RETURNS integer
 LANGUAGE SQL
 AS
@@ -69,7 +69,7 @@ $$"""
 
 
 @pytest.fixture(scope="session")
-def con_for_udf(con, sql_table_setup, sql_define_udf, sql_define_py_udf, test_schema):
+def con_for_udf(con, sql_table_setup, sql_define_udf, sql_define_py_udf, test_database):
     with con.begin() as c:
         c.execute(sql_table_setup)
         c.execute(sql_define_udf)
@@ -78,32 +78,32 @@ def con_for_udf(con, sql_table_setup, sql_define_udf, sql_define_py_udf, test_sc
 
 
 @pytest.fixture
-def table(con_for_udf, table_name, test_schema):
-    return con_for_udf.table(table_name, schema=test_schema)
+def table(con_for_udf, table_name, test_database):
+    return con_for_udf.table(table_name, database=test_database)
 
 
-def test_existing_sql_udf(con_for_udf, test_schema, table):
+def test_existing_sql_udf(con_for_udf, test_database, table):
     """Test creating ibis UDF object based on existing UDF in the database."""
     # Create ibis UDF objects referring to UDFs already created in the database
-    custom_length_udf = con_for_udf.function("custom_len", schema=test_schema)
+    custom_length_udf = con_for_udf.function("custom_len", schema=test_database)
     result_obj = table[table, custom_length_udf(table["user_name"]).name("custom_len")]
     result = result_obj.execute()
     assert result["custom_len"].sum() == result["name_length"].sum()
 
 
-def test_existing_plpython_udf(con_for_udf, test_schema, table):
+def test_existing_plpython_udf(con_for_udf, test_database, table):
     # Create ibis UDF objects referring to UDFs already created in the database
-    py_length_udf = con_for_udf.function("pylen", schema=test_schema)
+    py_length_udf = con_for_udf.function("pylen", schema=test_database)
     result_obj = table[table, py_length_udf(table["user_name"]).name("custom_len")]
     result = result_obj.execute()
     assert result["custom_len"].sum() == result["name_length"].sum()
 
 
-def test_udf(test_schema, table):
+def test_udf(test_database, table):
     """Test creating a UDF in database based on Python function and then
     creating an ibis UDF object based on that."""
 
-    @udf.scalar.python(schema=test_schema)
+    @udf.scalar.python(schema=test_database)
     def mult_a_b(a: int, b: int) -> int:
         return a * b
 
@@ -120,7 +120,7 @@ def test_udf(test_schema, table):
     raises=TypeError,
     reason="no straightforward way to use new (Python 3.9) annotations syntax",
 )
-def test_array_type(test_schema, table):
+def test_array_type(test_database, table):
     """Test that usage of Array types work Other scalar types can be
     represented either by the class or an instance, but Array types work
     differently.
@@ -129,7 +129,7 @@ def test_array_type(test_schema, table):
     instantiated specifying the datatype of the elements of the array.
     """
 
-    @udf.scalar.python(schema=test_schema)
+    @udf.scalar.python(schema=test_database)
     def pysplit(text: str, split: str) -> list[str]:
         return text.split(split)
 
@@ -138,11 +138,11 @@ def test_array_type(test_schema, table):
     result.execute()
 
 
-def test_client_udf_api(test_schema, table):
+def test_client_udf_api(test_database, table):
     """Test creating a UDF in database based on Python function using an ibis
     client method."""
 
-    @udf.scalar.python(schema=test_schema)
+    @udf.scalar.python(schema=test_database)
     def multiply(a: int, b: int) -> int:
         return a * b
 
@@ -154,7 +154,7 @@ def test_client_udf_api(test_schema, table):
     assert result["mult_result"].iat[0] == 8
 
 
-def test_client_udf_decorator_fails(con_for_udf, test_schema):
+def test_client_udf_decorator_fails(con_for_udf, test_database):
     """Test that UDF creation fails when creating a UDF based on a Python
     function that has been defined with decorators.
 
@@ -171,7 +171,7 @@ def test_client_udf_decorator_fails(con_for_udf, test_schema):
         return wrapped
 
     @decorator
-    @udf.scalar.python(schema=test_schema)
+    @udf.scalar.python(schema=test_database)
     def multiply(a: int, b: int) -> int:
         return a * b
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -325,7 +325,8 @@ class Backend(SQLBackend, CanCreateDatabase):
     def get_schema(
         self,
         table_name: str,
-        schema: str | None = None,
+        *,
+        catalog: str | None = None,
         database: str | None = None,
     ) -> sch.Schema:
         """Return a Schema object for the indicated table and database.
@@ -334,12 +335,10 @@ class Backend(SQLBackend, CanCreateDatabase):
         ----------
         table_name
             Table name. May be fully qualified
-        schema
-            Spark does not have a schema argument for its table() method,
-            so this must be None
+        catalog
+            Unsupported in PySpark backend.
         database
-            Spark does not have a database argument for its table() method,
-            so this must be None
+            Database to use to get the active database.
 
         Returns
         -------
@@ -347,11 +346,6 @@ class Backend(SQLBackend, CanCreateDatabase):
             An ibis schema
 
         """
-        if schema is not None:
-            raise com.UnsupportedArgumentError(
-                "Spark does not support the `schema` argument for `get_schema`"
-            )
-
         with self._active_database(database):
             df = self._session.table(table_name)
             struct = PySparkType.to_ibis(df.schema)

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -200,6 +200,16 @@ class Backend(SQLBackend, CanCreateDatabase):
     def list_tables(
         self, like: str | None = None, database: str | None = None
     ) -> list[str]:
+        """List the tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables.
+        database
+            Database to list tables from. Default behavior is to show tables in
+            the current database.
+        """
         tables = [
             row.tableName
             for row in self._session.sql(

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -420,7 +420,6 @@ class Backend(SQLBackend, CanCreateDatabase):
         obj: ir.Table,
         *,
         database: str | None = None,
-        schema: str | None = None,
         overwrite: bool = False,
     ) -> ir.Table:
         """Create a temporary Spark view from a table expression.
@@ -433,8 +432,6 @@ class Backend(SQLBackend, CanCreateDatabase):
             Expression to use for the view
         database
             Database name
-        schema
-            Schema name
         overwrite
             Replace an existing view of the same name if it exists
 
@@ -445,9 +442,7 @@ class Backend(SQLBackend, CanCreateDatabase):
 
         """
         src = sge.Create(
-            this=sg.table(
-                name, db=schema, catalog=database, quoted=self.compiler.quoted
-            ),
+            this=sg.table(name, db=database, quoted=self.compiler.quoted),
             kind="TEMPORARY VIEW",
             replace=overwrite,
             expression=self.compile(obj),

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from functools import partial
 from itertools import repeat
+from operator import itemgetter
 from typing import TYPE_CHECKING
 
 import psycopg2
@@ -257,3 +258,13 @@ class Backend(PostgresBackend):
             with self.begin() as cur:
                 cur.execute(create_stmt_sql)
                 extras.execute_batch(cur, sql, data, 128)
+
+    def list_databases(
+        self, *, like: str | None = None, catalog: str | None = None
+    ) -> list[str]:
+        dbs = "SHOW SCHEMAS"
+
+        with self._safe_raw_sql(dbs) as cur:
+            databases = list(map(itemgetter(0), cur))
+
+        return self._filter_with_like(databases, like)

--- a/ibis/backends/risingwave/tests/test_client.py
+++ b/ibis/backends/risingwave/tests/test_client.py
@@ -45,8 +45,16 @@ def test_simple_aggregate_execute(alltypes):
 
 
 def test_list_tables(con):
-    assert con.list_tables()
+    result = set(con.list_tables())
+
+    assert {"astronauts", "batting", "diamonds", "functional_alltypes"} <= result
     assert len(con.list_tables(like="functional")) == 1
+
+    assert len(con.list_tables(like="rw_")) == 0
+    result = set(con.list_tables(database="rw_catalog"))
+
+    assert {"rw_schemas", "rw_tables", "rw_types", "rw_users"} <= result
+    assert len(con.list_tables(like="astronauts", database="rw_catalog")) == 0
 
 
 def test_compile_toplevel(snapshot):
@@ -57,9 +65,18 @@ def test_compile_toplevel(snapshot):
     snapshot.assert_match(str(result), "out.sql")
 
 
-def test_list_databases(con):
+def test_list_catalogs(con):
     assert RISINGWAVE_TEST_DB is not None
-    assert RISINGWAVE_TEST_DB in con.list_databases()
+    assert RISINGWAVE_TEST_DB in con.list_catalogs()
+
+
+def test_list_databases(con):
+    assert con.list_databases() == [
+        "information_schema",
+        "pg_catalog",
+        "public",
+        "rw_catalog",
+    ]
 
 
 def test_create_and_drop_table(con, temp_table):

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -775,7 +775,7 @@ $$"""
         with self._safe_raw_sql(create_stmt):
             pass
 
-        return self.table(name, schema=db, database=catalog)
+        return self.table(name, database=(catalog, db))
 
     def read_csv(
         self, path: str | Path, table_name: str | None = None, **kwargs: Any

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -1051,16 +1051,34 @@ $$"""
             The source data or expression to insert
         schema
             The name of the schema that the table is located in
+        schema
+            [deprecated] The name of the schema that the table is located in
         database
             Name of the attached database that the table is located in.
+
+            For multi-level table hierarchies, you can pass in a dotted string
+            path like `"catalog.database"` or a tuple of strings like
+            `("catalog", "database")`.
+
+            ::: {.callout-note}
+            ## Ibis does not use the word `schema` to refer to database hierarchy.
+            A collection of tables is referred to as a `database`.
+            A collection of `database` is referred to as a `catalog`.
+            These terms are mapped onto the corresponding features in each
+            backend (where available), regardless of whether the backend itself
+            uses the same terminology.
+            :::
         overwrite
             If `True` then replace existing contents of table
 
         """
+        table_loc = self._warn_and_create_table_loc(database, schema)
+        catalog, db = self._to_catalog_db_tuple(table_loc)
+
         if not isinstance(obj, ir.Table):
             obj = ibis.memtable(obj)
 
-        table = sg.table(table_name, db=schema, catalog=database, quoted=True)
+        table = sg.table(table_name, db=db, catalog=catalog, quoted=True)
         self._run_pre_execute_hooks(obj)
         query = sg.exp.insert(
             expression=self.compile(obj),

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -518,7 +518,7 @@ $$"""
     def list_tables(
         self,
         like: str | None = None,
-        database: str | None = None,
+        database: tuple[str, str] | str | None = None,
         schema: str | None = None,
     ) -> list[str]:
         """List the tables in the database.
@@ -528,38 +528,33 @@ $$"""
         like
             A pattern to use for listing tables.
         database
-            The database (catalog) to perform the list against.
-        schema
-            The schema inside `database` to perform the list against.
+            Table location. If not passed, uses the current catalog and database.
 
-            ::: {.callout-warning}
-            ## `schema` refers to database hierarchy
+            To specify a table in a separate Snowflake catalog, you can pass in the
+            catalog and database as a string `"catalog.database"`, or as a tuple of
+            strings `("catalog", "database")`.
 
-            The `schema` parameter does **not** refer to the column names and
-            types of `table`.
+            ::: {.callout-note}
+            ## Ibis does not use the word `schema` to refer to database hierarchy.
+
+            A collection of tables is referred to as a `database`.
+            A collection of `database` is referred to as a `catalog`.
+
+            These terms are mapped onto the corresponding features in each
+            backend (where available), regardless of whether the backend itself
+            uses the same terminology.
             :::
-
+        schema
+            [deprecated] The schema inside `database` to perform the list against.
         """
-
-        if database is not None and schema is None:
-            raise com.IbisInputError(
-                f"{self.name} cannot list tables only using `database` specifier. "
-                "Include a `schema` argument."
-            )
-        elif database is None and schema is not None:
-            database = sg.parse_one(schema, into=sge.Table).sql(dialect=self.name)
-        else:
-            database = (
-                sg.table(schema, db=database, quoted=True).sql(dialect=self.name)
-                or None
-            )
+        table_loc = self._warn_and_create_table_loc(database, schema)
 
         tables_query = "SHOW TABLES"
         views_query = "SHOW VIEWS"
 
-        if database is not None:
-            tables_query += f" IN {database}"
-            views_query += f" IN {database}"
+        if table_loc is not None:
+            tables_query += f" IN {table_loc}"
+            views_query += f" IN {table_loc}"
 
         with self.con.cursor() as cur:
             # TODO: considering doing this with a single query using information_schema

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -464,10 +464,14 @@ $$"""
             )
 
     def get_schema(
-        self, table_name: str, schema: str | None = None, database: str | None = None
+        self,
+        table_name: str,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
     ) -> Iterable[tuple[str, dt.DataType]]:
         table = sg.table(
-            table_name, db=schema, catalog=database, quoted=self.compiler.quoted
+            table_name, db=database, catalog=catalog, quoted=self.compiler.quoted
         )
         with self._safe_raw_sql(sge.Describe(kind="TABLE", this=table)) as cur:
             result = cur.fetchall()

--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -96,9 +96,7 @@ class TestConf(BackendTest):
 
     def _tpch_table(self, name: str):
         name = name.upper()
-        t = self.connection.table(
-            name, database="SNOWFLAKE_SAMPLE_DATA", schema="TPCH_SF1"
-        )
+        t = self.connection.table(name, database="SNOWFLAKE_SAMPLE_DATA.TPCH_SF1")
         return t.rename("snake_case")
 
     def _transform_tpch_sql(self, parsed):

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -317,3 +317,39 @@ def test_struct_of_json(con):
 
     assert len(result) == n
     assert all(value == raw for value in result.to_pylist())
+
+
+def test_list_tables_schema_warning_refactor(con):
+    assert {
+        "ASTRONAUTS",
+        "AWARDS_PLAYERS",
+        "BATTING",
+        "DIAMONDS",
+        "FUNCTIONAL_ALLTYPES",
+    }.issubset(con.list_tables())
+
+    like_table = [
+        "EVENT_TABLES",
+        "EXTERNAL_TABLES",
+        "TABLES",
+        "TABLE_CONSTRAINTS",
+        "TABLE_PRIVILEGES",
+        "TABLE_STORAGE_METRICS",
+    ]
+
+    with pytest.warns(FutureWarning):
+        assert (
+            con.list_tables(
+                database="IBIS_TESTING", schema="INFORMATION_SCHEMA", like="TABLE"
+            )
+            == like_table
+        )
+
+    assert (
+        con.list_tables(database="IBIS_TESTING.INFORMATION_SCHEMA", like="TABLE")
+        == like_table
+    )
+    assert (
+        con.list_tables(database=("IBIS_TESTING", "INFORMATION_SCHEMA"), like="TABLE")
+        == like_table
+    )

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -16,44 +16,46 @@ from ibis.util import gen_name
 
 
 @pytest.fixture
-def temp_db(con):
-    db = gen_name("tmp_db")
+def temp_catalog(con):
+    cat = gen_name("tmp_catalog")
 
-    con.create_database(db)
-    assert db in con.list_databases()
+    con.create_catalog(cat)
+    assert cat in con.list_catalogs()
 
-    yield db
+    yield cat
 
-    con.drop_database(db)
-    assert db not in con.list_databases()
+    con.drop_catalog(cat)
+    assert cat not in con.list_catalogs()
 
 
 @pytest.fixture
-def temp_schema(con, temp_db):
-    schema = gen_name("tmp_schema")
+def temp_db(con, temp_catalog):
+    database = gen_name("tmp_database")
 
-    con.create_schema(schema, database=temp_db)
-    assert schema in con.list_schemas(database=temp_db)
+    con.create_database(database, catalog=temp_catalog)
+    assert database in con.list_databases(catalog=temp_catalog)
 
-    yield schema
+    yield database
 
-    con.drop_schema(schema, database=temp_db)
-    assert schema not in con.list_schemas(database=temp_db)
+    con.drop_database(database, catalog=temp_catalog)
+    assert database not in con.list_databases(catalog=temp_catalog)
 
 
-def test_cross_db_access(con, temp_db, temp_schema):
+def test_cross_db_access(con, temp_catalog, temp_db):
     table = gen_name("tmp_table")
-    con.raw_sql(f'CREATE TABLE "{temp_db}"."{temp_schema}"."{table}" ("x" INT)').close()
-    t = con.table(table, schema=temp_schema, database=temp_db)
+    con.raw_sql(
+        f'CREATE TABLE "{temp_catalog}"."{temp_db}"."{table}" ("x" INT)'
+    ).close()
+    t = con.table(table, schema=temp_db, database=temp_catalog)
     assert t.schema() == ibis.schema(dict(x="int"))
     assert t.execute().empty
 
 
-def test_cross_db_create_table(con, temp_db, temp_schema):
+def test_cross_db_create_table(con, temp_catalog, temp_db):
     table_name = gen_name("tmp_table")
     data = pd.DataFrame({"key": list("abc"), "value": [[1], [2], [3]]})
-    table = con.create_table(table_name, data, database=f"{temp_db}.{temp_schema}")
-    queried_table = con.table(table_name, database=temp_db, schema=temp_schema)
+    table = con.create_table(table_name, data, database=f"{temp_catalog}.{temp_db}")
+    queried_table = con.table(table_name, database=temp_catalog, schema=temp_db)
 
     tm.assert_frame_equal(table.execute(), data)
     tm.assert_frame_equal(queried_table.execute(), data)
@@ -108,32 +110,37 @@ def test_timestamp_tz_column(simple_con):
     assert expr.execute().empty
 
 
-def test_create_schema(simple_con):
-    schema = gen_name("test_create_schema")
-
-    cur_schema = simple_con.current_schema
-    cur_db = simple_con.current_database
-
-    simple_con.create_schema(schema)
-
-    assert simple_con.current_schema == cur_schema
-    assert simple_con.current_database == cur_db
-
-    simple_con.drop_schema(schema)
-
-    assert simple_con.current_schema == cur_schema
-    assert simple_con.current_database == cur_db
-
-
 def test_create_database(simple_con):
     database = gen_name("test_create_database")
-    cur_db = simple_con.current_database
+
+    cur_database = simple_con.current_database
+    cur_catalog = simple_con.current_catalog
 
     simple_con.create_database(database)
-    assert simple_con.current_database == cur_db
+
+    assert simple_con.current_database == cur_database
+    assert simple_con.current_catalog == cur_catalog
 
     simple_con.drop_database(database)
-    assert simple_con.current_database == cur_db
+
+    assert simple_con.current_database == cur_database
+    assert simple_con.current_catalog == cur_catalog
+
+
+def test_create_catalog(simple_con):
+    catalog = gen_name("test_create_catalog")
+    cur_catalog = simple_con.current_catalog
+
+    simple_con.create_catalog(catalog)
+    assert simple_con.current_catalog == cur_catalog
+
+    simple_con.drop_catalog(catalog)
+    assert simple_con.current_catalog == cur_catalog
+
+
+@pytest.fixture(scope="session")
+def cat_con():
+    return ibis.connect(_get_url())
 
 
 @pytest.fixture(scope="session")
@@ -141,45 +148,40 @@ def db_con():
     return ibis.connect(_get_url())
 
 
-@pytest.fixture(scope="session")
-def schema_con():
-    return ibis.connect(_get_url())
+def test_drop_current_catalog_not_allowed(cat_con):
+    catalog = gen_name("test_create_catalog")
+    cur_cat = cat_con.current_catalog
+
+    cat_con.create_catalog(catalog)
+
+    assert cat_con.current_catalog == cur_cat
+
+    cat_con.raw_sql(f'USE DATABASE "{catalog}"').close()
+
+    with pytest.raises(com.UnsupportedOperationError, match="behavior is undefined"):
+        cat_con.drop_catalog(catalog)
+
+    cat_con.raw_sql(f'USE DATABASE "{cur_cat}"').close()
+
+    cat_con.drop_catalog(catalog)
 
 
 def test_drop_current_db_not_allowed(db_con):
     database = gen_name("test_create_database")
-    cur_db = db_con.current_database
+    cur_database = db_con.current_database
 
     db_con.create_database(database)
 
-    assert db_con.current_database == cur_db
+    assert db_con.current_database == cur_database
 
-    db_con.raw_sql(f'USE DATABASE "{database}"').close()
+    db_con.raw_sql(f'USE SCHEMA "{database}"').close()
 
     with pytest.raises(com.UnsupportedOperationError, match="behavior is undefined"):
         db_con.drop_database(database)
 
-    db_con.raw_sql(f'USE DATABASE "{cur_db}"').close()
+    db_con.raw_sql(f'USE SCHEMA "{cur_database}"').close()
 
     db_con.drop_database(database)
-
-
-def test_drop_current_schema_not_allowed(schema_con):
-    schema = gen_name("test_create_schema")
-    cur_schema = schema_con.current_schema
-
-    schema_con.create_schema(schema)
-
-    assert schema_con.current_schema == cur_schema
-
-    schema_con.raw_sql(f'USE SCHEMA "{schema}"').close()
-
-    with pytest.raises(com.UnsupportedOperationError, match="behavior is undefined"):
-        schema_con.drop_schema(schema)
-
-    schema_con.raw_sql(f'USE SCHEMA "{cur_schema}"').close()
-
-    schema_con.drop_schema(schema)
 
 
 def test_read_csv_options(con, tmp_path):

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -46,7 +46,7 @@ def test_cross_db_access(con, temp_catalog, temp_db):
     con.raw_sql(
         f'CREATE TABLE "{temp_catalog}"."{temp_db}"."{table}" ("x" INT)'
     ).close()
-    t = con.table(table, schema=temp_db, database=temp_catalog)
+    t = con.table(table, database=(temp_catalog, temp_db))
     assert t.schema() == ibis.schema(dict(x="int"))
     assert t.execute().empty
 
@@ -55,7 +55,7 @@ def test_cross_db_create_table(con, temp_catalog, temp_db):
     table_name = gen_name("tmp_table")
     data = pd.DataFrame({"key": list("abc"), "value": [[1], [2], [3]]})
     table = con.create_table(table_name, data, database=f"{temp_catalog}.{temp_db}")
-    queried_table = con.table(table_name, database=temp_catalog, schema=temp_db)
+    queried_table = con.table(table_name, database=(temp_catalog, temp_db))
 
     tm.assert_frame_equal(table.execute(), data)
     tm.assert_frame_equal(queried_table.execute(), data)

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -298,15 +298,15 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
     def drop_table(
         self,
         name: str,
-        database: str | None = None,
-        schema: str | None = None,
+        database: tuple[str, str] | str | None = None,
         force: bool = False,
     ) -> None:
+        table_loc = self._warn_and_create_table_loc(database, None)
+        catalog, db = self._to_catalog_db_tuple(table_loc)
+
         drop_stmt = sg.exp.Drop(
             kind="TABLE",
-            this=sg.table(
-                name, db=schema, catalog=database, quoted=self.compiler.quoted
-            ),
+            this=sg.table(name, db=db, catalog=catalog, quoted=self.compiler.quoted),
             exists=force,
         )
         with self._safe_raw_sql(drop_stmt):

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -121,7 +121,7 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
             Table expression
 
         """
-        table_schema = self.get_schema(name, schema=schema, database=database)
+        table_schema = self.get_schema(name, catalog=schema, database=database)
         return ops.DatabaseTable(
             name,
             schema=table_schema,

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -136,7 +136,7 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
             name,
             schema=table_schema,
             source=self,
-            namespace=ops.Namespace(database=database, schema=schema),
+            namespace=ops.Namespace(catalog=catalog, database=database),
         ).to_expr()
 
     def _to_sqlglot(

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -102,7 +102,10 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         return df
 
     def table(
-        self, name: str, schema: str | None = None, database: str | None = None
+        self,
+        name: str,
+        schema: str | None = None,
+        database: tuple[str, str] | str | None = None,
     ) -> ir.Table:
         """Construct a table expression.
 
@@ -111,7 +114,7 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         name
             Table name
         schema
-            Schema name
+            [deprecated] Schema name
         database
             Database name
 
@@ -121,7 +124,14 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
             Table expression
 
         """
-        table_schema = self.get_schema(name, catalog=schema, database=database)
+        table_loc = self._warn_and_create_table_loc(database, schema)
+
+        catalog, database = None, None
+        if table_loc is not None:
+            catalog = table_loc.catalog or None
+            database = table_loc.db or None
+
+        table_schema = self.get_schema(name, catalog=catalog, database=database)
         return ops.DatabaseTable(
             name,
             schema=table_schema,

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -233,10 +233,11 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         schema: str | None = None,
         overwrite: bool = False,
     ) -> ir.Table:
+        table_loc = self._warn_and_create_table_loc(database, schema)
+        catalog, db = self._to_catalog_db_tuple(table_loc)
+
         src = sge.Create(
-            this=sg.table(
-                name, db=schema, catalog=database, quoted=self.compiler.quoted
-            ),
+            this=sg.table(name, db=db, catalog=catalog, quoted=self.compiler.quoted),
             kind="VIEW",
             replace=overwrite,
             expression=self.compile(obj),
@@ -244,7 +245,7 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         self._register_in_memory_tables(obj)
         with self._safe_raw_sql(src):
             pass
-        return self.table(name, database=database)
+        return self.table(name, database=(catalog, db))
 
     def _register_in_memory_tables(self, expr: ir.Expr) -> None:
         for memtable in expr.op().find(ops.InMemoryTable):
@@ -258,10 +259,11 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         schema: str | None = None,
         force: bool = False,
     ) -> None:
+        table_loc = self._warn_and_create_table_loc(database, schema)
+        catalog, db = self._to_catalog_db_tuple(table_loc)
+
         src = sge.Drop(
-            this=sg.table(
-                name, db=schema, catalog=database, quoted=self.compiler.quoted
-            ),
+            this=sg.table(name, db=db, catalog=catalog, quoted=self.compiler.quoted),
             kind="VIEW",
             exists=force,
         )

--- a/ibis/backends/sql/compiler.py
+++ b/ibis/backends/sql/compiler.py
@@ -1034,7 +1034,7 @@ class SQLGlotCompiler(abc.ABC):
         # not actually a table, but easier to quote individual namespace
         # components this way
         namespace = op.__udf_namespace__
-        return sg.table(funcname, db=namespace.schema, catalog=namespace.database).sql(
+        return sg.table(funcname, db=namespace.database, catalog=namespace.catalog).sql(
             self.dialect
         )
 
@@ -1113,7 +1113,7 @@ class SQLGlotCompiler(abc.ABC):
         self, op, *, name: str, schema: sch.Schema, namespace: ops.Namespace
     ) -> sg.Table:
         return sg.table(
-            name, db=namespace.schema, catalog=namespace.database, quoted=self.quoted
+            name, db=namespace.database, catalog=namespace.catalog, quoted=self.quoted
         )
 
     def visit_InMemoryTable(
@@ -1131,7 +1131,7 @@ class SQLGlotCompiler(abc.ABC):
         namespace: ops.Namespace,
     ) -> sg.Table:
         return sg.table(
-            name, db=namespace.schema, catalog=namespace.database, quoted=self.quoted
+            name, db=namespace.database, catalog=namespace.catalog, quoted=self.quoted
         )
 
     def visit_SelfReference(self, op, *, parent, identifier):

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -127,6 +127,16 @@ class Backend(SQLBackend, UrlFromPath):
         like: str | None = None,
         database: str | None = None,
     ) -> list[str]:
+        """List the tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables.
+        database
+            Database to list tables from. Default behavior is to show tables in
+            the current database.
+        """
         if database is None:
             database = "main"
 

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -509,6 +509,10 @@ class Backend(SQLBackend, UrlFromPath):
         schema: str | None = None,
         overwrite: bool = False,
     ) -> ir.Table:
+        # schema was never used here, but warn for consistency
+        if schema is not None:
+            self._warn_schema()
+
         view = sg.table(name, catalog=database, quoted=self.compiler.quoted)
 
         stmts = []

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -210,7 +210,11 @@ class Backend(SQLBackend, UrlFromPath):
         )
 
     def get_schema(
-        self, table_name: str, schema: str | None = None, database: str | None = None
+        self,
+        table_name: str,
+        *,
+        catalog: str | None = None,
+        database: str | None = None,
     ) -> sch.Schema:
         """Compute the schema of a `table`.
 
@@ -219,8 +223,8 @@ class Backend(SQLBackend, UrlFromPath):
         table_name
             May **not** be fully qualified. Use `database` if you want to
             qualify the identifier.
-        schema
-            Schema name. Unused for sqlite.
+        catalog
+            Catalog name. Unused for sqlite.
         database
             Database name
 
@@ -230,8 +234,8 @@ class Backend(SQLBackend, UrlFromPath):
             Ibis schema
 
         """
-        if schema is not None:
-            raise TypeError("sqlite doesn't support `schema`, use `database` instead")
+        if catalog is not None:
+            raise TypeError("sqlite doesn't support `catalog`, use `database` instead")
         with self.begin() as cur:
             return self._inspect_schema(cur, table_name, database)
 

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -18,31 +18,45 @@ def test_version(backend):
     assert isinstance(backend.api.version, str)
 
 
-# 1. `current_database` returns '.', but isn't listed in list_databases()
+# 1. `current_catalog` returns '.', but isn't listed in list_catalogs()
 @pytest.mark.never(
-    ["polars", "dask", "exasol", "pandas", "druid", "oracle", "bigquery"],
-    reason="backend does not support databases",
+    [
+        "polars",
+        "clickhouse",
+        "sqlite",
+        "dask",
+        "exasol",
+        "pandas",
+        "druid",
+        "oracle",
+        "bigquery",
+        "mysql",
+        "impala",
+        "pyspark",
+        "flink",
+    ],
+    reason="backend does not support catalogs",
     raises=AttributeError,
 )
 @pytest.mark.notimpl(
     ["datafusion"],
     raises=NotImplementedError,
-    reason="current_database isn't implemented",
+    reason="current_catalog isn't implemented",
 )
-def test_database_consistency(backend, con):
-    databases = con.list_databases()
-    assert isinstance(databases, list)
-    assert len(databases) >= 1
-    assert all(isinstance(database, str) for database in databases)
+def test_catalog_consistency(backend, con):
+    catalogs = con.list_catalogs()
+    assert isinstance(catalogs, list)
+    assert len(catalogs) >= 1
+    assert all(isinstance(catalog, str) for catalog in catalogs)
 
-    # every backend has a different set of databases, not testing the
+    # every backend has a different set of catalogs, not testing the
     # exact names for now
-    current_database = con.current_database
-    assert isinstance(current_database, str)
+    current_catalog = con.current_catalog
+    assert isinstance(current_catalog, str)
     if backend.name() == "snowflake":
-        assert current_database.upper() in databases
+        assert current_catalog.upper() in catalogs
     else:
-        assert current_database in databases
+        assert current_catalog in catalogs
 
 
 def test_list_tables(con):

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -589,7 +589,6 @@ def test_insert_from_memtable(con, temp_table):
     mt = ibis.memtable(df)
     con.create_table(table_name, schema=mt.schema())
     con.insert(table_name, mt)
-    con.insert(table_name, mt)
 
     table = con.tables[table_name]
     assert len(table.execute()) == 6

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -589,6 +589,7 @@ def test_insert_from_memtable(con, temp_table):
     mt = ibis.memtable(df)
     con.create_table(table_name, schema=mt.schema())
     con.insert(table_name, mt)
+    con.insert(table_name, mt)
 
     table = con.tables[table_name]
     assert len(table.execute()) == 6
@@ -596,28 +597,71 @@ def test_insert_from_memtable(con, temp_table):
 
 
 @pytest.mark.notyet(
-    ["bigquery", "oracle", "dask", "exasol", "polars", "pandas", "druid"],
+    [
+        "bigquery",
+        "clickhouse",
+        "dask",
+        "druid",
+        "exasol",
+        "impala",
+        "mysql",
+        "oracle",
+        "pandas",
+        "polars",
+        "flink",
+        "pyspark",
+        "sqlite",
+    ],
     raises=AttributeError,
-    reason="doesn't support the common notion of a database",
+    reason="doesn't support the common notion of a catalog",
 )
-def test_list_databases(con):
+def test_list_catalogs(con):
     # Every backend has its own databases
-    test_databases = {
-        "clickhouse": {"system", "default", "ibis_testing"},
+    test_catalogs = {
         "datafusion": {"datafusion"},
         "duckdb": {"memory"},
         "exasol": set(),
-        "impala": set(),
+        "flink": set(),
         "mssql": {"ibis_testing"},
-        "mysql": {"ibis_testing", "information_schema"},
         "oracle": set(),
         "postgres": {"postgres", "ibis_testing"},
         "risingwave": {"dev"},
         "snowflake": {"IBIS_TESTING"},
-        "pyspark": set(),
-        "sqlite": {"main"},
         "trino": {"memory"},
-        "flink": set(),
+    }
+    result = set(con.list_catalogs())
+    assert test_catalogs[con.name] <= result
+
+
+@pytest.mark.notyet(
+    [
+        "dask",
+        "druid",
+        "pandas",
+        "polars",
+    ],
+    raises=AttributeError,
+    reason="doesn't support the common notion of a catalog",
+)
+def test_list_database_contents(con):
+    # Every backend has its own databases
+    test_databases = {
+        "bigquery": {"ibis_gbq_testing"},
+        "clickhouse": {"system", "default", "ibis_testing"},
+        "datafusion": {"public"},
+        "duckdb": {"pg_catalog", "main", "information_schema"},
+        "exasol": {"EXASOL"},
+        "flink": {"default_database"},
+        "impala": {"ibis_testing", "default", "_impala_builtins"},
+        "mssql": {"INFORMATION_SCHEMA", "dbo", "guest"},
+        "mysql": {"ibis_testing", "information_schema"},
+        "oracle": {"SYS", "IBIS"},
+        "postgres": {"public", "information_schema"},
+        "pyspark": set(),
+        "risingwave": {"public", "rw_catalog", "information_schema"},
+        "snowflake": {"IBIS_TESTING"},
+        "sqlite": {"main"},
+        "trino": {"default", "information_schema"},
     }
     result = set(con.list_databases())
     assert test_databases[con.name] <= result
@@ -1388,59 +1432,92 @@ def test_overwrite(ddl_con, monkeypatch):
         assert t2.count().execute() == expected_count
 
 
-@pytest.mark.notyet(["datafusion"], reason="cannot list or drop databases")
+@pytest.mark.notyet(["datafusion"], reason="cannot list or drop catalogs")
+def test_create_catalog(con_create_catalog):
+    catalog = gen_name("test_create_catalog")
+    con_create_catalog.create_catalog(catalog)
+    assert catalog in con_create_catalog.list_catalogs()
+    con_create_catalog.drop_catalog(catalog)
+    assert catalog not in con_create_catalog.list_catalogs()
+
+
 def test_create_database(con_create_database):
     database = gen_name("test_create_database")
     con_create_database.create_database(database)
+    if con_create_database.name == "exasol":
+        database = database.upper()
     assert database in con_create_database.list_databases()
+    database = database.lower()
     con_create_database.drop_database(database)
+    if con_create_database.name == "exasol":
+        database = database.upper()
     assert database not in con_create_database.list_databases()
 
 
-def test_create_schema(con_create_schema):
-    schema = gen_name("test_create_schema")
-    con_create_schema.create_schema(schema)
-    assert schema in con_create_schema.list_schemas()
-    con_create_schema.drop_schema(schema)
-    assert schema not in con_create_schema.list_schemas()
+def test_list_schema_warns(con_list_schema):
+    with pytest.warns(FutureWarning):
+        con_list_schema.list_schemas()
 
 
-@pytest.mark.notimpl(
-    ["risingwave"],
-    raises=PsycoPg2InternalError,
-    reason="Feature is not yet implemented: information_schema.schemata is not supported,",
+@pytest.mark.never(
+    [
+        "clickhouse",
+        "mysql",
+        "pyspark",
+        "flink",
+    ],
+    reason="No schema methods",
 )
-def test_list_schemas(con_create_schema):
-    schemas = con_create_schema.list_schemas()
-    assert len(schemas) == len(set(schemas))
+def test_create_schema(con_create_database):
+    schema = gen_name("test_create_schema")
+    with pytest.warns(FutureWarning):
+        con_create_database.create_schema(schema)
+    with pytest.warns(FutureWarning):
+        if con_create_database.name == "exasol":
+            schema = schema.upper()
+        assert schema in con_create_database.list_schemas()
+        schema = schema.lower()
+    with pytest.warns(FutureWarning):
+        con_create_database.drop_schema(schema)
+    with pytest.warns(FutureWarning):
+        if con_create_database.name == "exasol":
+            schema = schema.upper()
+        assert schema not in con_create_database.list_schemas()
+
+
+def test_list_databases(con_create_database):
+    databases = con_create_database.list_databases()
+    assert len(databases) == len(set(databases))
 
 
 @pytest.mark.notyet(["datafusion"], reason="cannot list or drop databases")
-def test_create_database_schema(con_create_database_schema):
-    database = gen_name("test_create_database")
-    con_create_database_schema.create_database(database)
+def test_create_catalog_database(con_create_catalog_database):
+    catalog = gen_name("test_create_catalog")
+    con_create_catalog_database.create_catalog(catalog)
     try:
-        schema = gen_name("test_create_database_schema")
-        con_create_database_schema.create_schema(schema, database=database)
-        con_create_database_schema.drop_schema(schema, database=database)
+        database = gen_name("test_create_catalog_database")
+        con_create_catalog_database.create_database(database, catalog=catalog)
+        con_create_catalog_database.drop_database(database, catalog=catalog)
     finally:
-        con_create_database_schema.drop_database(database)
+        con_create_catalog_database.drop_catalog(catalog)
 
 
 @pytest.mark.notyet(["datafusion"], reason="cannot list or drop databases")
-def test_list_databases_schemas(con_create_database_schema):
-    database = gen_name("test_create_database")
-    con_create_database_schema.create_database(database)
+def test_list_catalogs_databases(con_create_catalog_database):
+    catalog = gen_name("test_create_catalog")
+    con_create_catalog_database.create_catalog(catalog)
     try:
-        schema = gen_name("test_create_database_schema")
-        con_create_database_schema.create_schema(schema, database=database)
+        database = gen_name("test_create_catalog_database")
+        con_create_catalog_database.create_database(database, catalog=catalog)
 
         try:
-            assert schema in con_create_database_schema.list_schemas(database=database)
+            assert database in con_create_catalog_database.list_databases(
+                catalog=catalog
+            )
         finally:
-            con_create_database_schema.drop_schema(schema, database=database)
+            con_create_catalog_database.drop_database(database, catalog=catalog)
     finally:
-        con_create_database_schema.drop_database(database)
+        con_create_catalog_database.drop_catalog(catalog)
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -95,7 +95,7 @@ class TestConf(ServiceBackendTest):
         database = "hive"
         schema = "ibis_sf1"
 
-        tables = con.list_tables(schema="tiny", database="tpch")
+        tables = con.list_tables(database=("tpch", "tiny"))
         con.create_schema(schema, database=database, force=True)
 
         prefixes = {"partsupp": "ps"}

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -92,11 +92,11 @@ class TestConf(ServiceBackendTest):
         to match the DuckDB TPC-H query conventions.
         """
         con = self.connection
-        database = "hive"
-        schema = "ibis_sf1"
+        catalog = "hive"
+        database = "ibis_sf1"
 
         tables = con.list_tables(database=("tpch", "tiny"))
-        con.create_schema(schema, database=database, force=True)
+        con.create_database(database, catalog=catalog, force=True)
 
         prefixes = {"partsupp": "ps"}
 
@@ -108,7 +108,7 @@ class TestConf(ServiceBackendTest):
                 prefix = prefixes.get(table, table[0])
 
                 t = (
-                    con.table(table, schema="tiny", database="tpch")
+                    con.table(table, database=("tpch", "tiny"))
                     .rename(f"{prefix}_{{}}".format)
                     # https://github.com/trinodb/trino/issues/19477
                     .mutate(
@@ -118,7 +118,7 @@ class TestConf(ServiceBackendTest):
 
                 sql = sge.Create(
                     kind="VIEW",
-                    this=sg.table(table, db=schema, catalog=database),
+                    this=sg.table(table, db=database, catalog=catalog),
                     expression=self.connection._to_sqlglot(t),
                     replace=True,
                 ).sql("trino", pretty=True)
@@ -128,7 +128,7 @@ class TestConf(ServiceBackendTest):
     def _tpch_table(self, name: str):
         from ibis import _
 
-        table = self.connection.table(name, schema="ibis_sf1", database="hive")
+        table = self.connection.table(name, database=("hive", "ibis_sf1"))
         table = table.mutate(s.across(s.of_type("double"), _.cast("decimal(15, 2)")))
         return table
 

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -159,3 +159,29 @@ def test_table_access_database_schema(con):
         exc.IbisError, match='Table not found: system."tpch.sf1".region'
     ):
         con.table("region", schema="tpch.sf1", database="system")
+
+
+def test_list_tables_schema_warning_refactor(con):
+    tpch_tables = [
+        "customer",
+        "lineitem",
+        "nation",
+        "orders",
+        "part",
+        "partsupp",
+        "region",
+        "supplier",
+    ]
+
+    assert con.list_tables()
+
+    # Error if user mixes tuple inputs and string inputs for database and schema
+    with pytest.raises(FutureWarning):
+        with pytest.raises(exc.IbisInputError):
+            con.list_tables(database=("tuple", "ohstuff"), schema="str")
+
+    with pytest.warns(FutureWarning):
+        assert con.list_tables(database="tpch", schema="sf1") == tpch_tables
+
+    assert con.list_tables(database="tpch.sf1") == tpch_tables
+    assert con.list_tables(database=("tpch", "sf1")) == tpch_tables

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -61,11 +61,11 @@ def test_hive_table_overwrite(tmp_name):
 
 
 def test_list_catalogs(con):
-    assert {"hive", "memory", "system", "tpch", "tpcds"}.issubset(con.list_databases())
+    assert {"hive", "memory", "system", "tpch", "tpcds"}.issubset(con.list_catalogs())
 
 
-def test_list_schemas(con):
-    assert {"information_schema", "sf1"}.issubset(con.list_schemas(database="tpch"))
+def test_list_databases(con):
+    assert {"information_schema", "sf1"}.issubset(con.list_databases(catalog="tpch"))
 
 
 @pytest.mark.parametrize(("source", "expected"), [(None, "ibis"), ("foo", "foo")])

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -314,7 +314,7 @@ class PhysicalTable(Relation):
 @public
 class Namespace(Concrete):
     database: Optional[str] = None
-    schema: Optional[str] = None
+    catalog: Optional[str] = None
 
 
 @public

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -139,7 +139,7 @@ class _UDF(abc.ABC):
                 # method
                 "__func__": property(fget=lambda _, fn=fn: fn),
                 "__config__": FrozenDict(kwargs),
-                "__udf_namespace__": ops.Namespace(schema=schema, database=database),
+                "__udf_namespace__": ops.Namespace(database=schema, catalog=database),
                 "__module__": fn.__module__,
                 "__func_name__": func_name,
             }

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -256,7 +256,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         """Return the fully qualified name of the table."""
         arg = self._arg
         namespace = getattr(arg, "namespace", ops.Namespace())
-        pieces = namespace.database, namespace.schema, arg.name
+        pieces = namespace.catalog, namespace.database, arg.name
         return ".".join(filter(None, pieces))
 
     def __array__(self, dtype=None):

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -2065,7 +2065,7 @@ def test_invalid_distinct_empty_key():
 
 def test_unbind_with_namespace():
     schema = ibis.schema({"a": "int"})
-    ns = ops.Namespace(database="db", schema="sch")
+    ns = ops.Namespace(catalog="catalog", database="database")
 
     t_op = ops.DatabaseTable(name="t", schema=schema, source=None, namespace=ns)
     t = t_op.to_expr()


### PR DESCRIPTION
# No more `schema`

This is part of a larger refactor where we are removing all usage of the
word `schema` in its hierarchical sense.

Ibis will adhere to the following convention moving forward:
* `schema`: a mapping of column names to datatypes
* `database`: a collection of tables
* `catalog`: a collection of databases

There are a bunch of commits here that I'm currently keeping separate so I can add fixup changes to the appropriate backend as needed.
I plan to squash all of these into their corresponding top-level commits before we rebase.
I've listed out the commit messages below for those top-level commits (each one corresponding to the changes to, e..g `list_tables` or `create_schema`, etc.).

## refactor(list_tables): deprecate schema keyword

This change to `list_tables` is not a breaking change. `schema` is
deprecated and will warn on usage, but all existing code should remain
functional.

## refactor(ddl): deprecate all *_schema methods 

BREAKING CHANGE: We are removing the word `schema` in its hierarchical
sense. We use `database` to mean a collection of tables. The behavior of
all `*_database` methods now applies only to collections of tables and
never to collections of `database` (formerly `schema`)
* `CanListDatabases` abstract methods now all refer to
collections of tables.
* `CanCreateDatabases` abstract methods now all refer to
collections of tables.
* `list_databases` now takes a kwarg `catalog`.
* `create_database` now takes a kwarg `catalog`.
* `drop_database` now takes a kwarg `catalog`.
* `current_database` now refers to the current collection of tables.
* `CanCreateSchema` is deprecated and `create_schema`, `drop_schema`,
  `list_schemas`, and `current_schema` are deprecated and redirect to the
  corresponding method/property ending in `database`.
* We add a `CanListCatalog` and `CanCreateCatalog` that can list and
   create collections of `database`, respectively.
   The new methods are `list_catalogs`, `create_catalog`, `drop_catalog`,
* There is a new `current_catalog` property.

## refactor(get_schema): remove schema kwarg, add catalog, kw-only

This is not a breaking change as `get_schema` was introduced during
the-epic-split refactor and has not yet been released.

## refactor(table): deprecate schema

`schema` kwarg is deprecated in all `Backend.table` usage. Wherever it
was present, we now have handling to warn if `schema` is passed, and to
encourage users to switch usage to the tuple of `(catalog, database)`.

## refactor(ops): use catalog and database kwargs for Namespace op

This is an internals only change, but changes `database` to `catalog`
and changes `schema` to `database` for our internal `Namespace` op.

## refactor(table ddl): remove hierarchical schema from *_table methods

The `schema` kwarg here was introduced during the-epic-split, so not deprecating.

## refactor(sql): deprecate schema in _view ddl methods

Deprecate the use of `schema` as a hierarchical term in all `*_view` DDL
methods.
Added a helper mixin to try to avoid continued repetition of the warning
code and the repeated parsing of the `database` + `schema` combinations.

## refactor(sql): deprecate schema kwarg in insert

`schema` as a hierarchical term is deprecated in `insert`.
It will be removed Ibis 10.0.

## refactor(ddl): deprecate schema keyword in truncate_table 


# A few followups

Not for this PR, which is already too big

* ~I missed `insert`, need to do deprecate `schema` there, too.~ done
* remove `schema` kwarg from `connect` and `do_connect`  (although I'm not sure this is necessary)
* make most/all kwargs for DDL methods kw-only -- I haven't done that here as it would introduce more breaking changes, but maybe before 10.0 when we also remove `schema`?
* refactor some of the common code paths I've added here around handling various combinations of deprecated and non-deprecated arguments (I've started to do this but I haven't gone back and added it everywhere I added it.

Fixes #8477
Fixes #8380 
Fixes #8491 



xref: #8253 
xref: #6821
xref: #6489