### PR TITLE
test(impala): ensure that topk table does not already exist

### DIFF
--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -113,6 +113,7 @@ class TestConf(BackendTest):
                 ('a', 4, 1)
             """
         )
+        con.drop_table("topk", database="ibis_testing", force=True)
         con.create_table(
             "topk", schema=ibis.schema({"x": "int64"}), database="ibis_testing"
         )


### PR DESCRIPTION
Ensure that the topk table gets created anew every time the test suite is run for Impala.