### PR TITLE
test(bigquery): clean up test data loading

### DIFF
--- a/ci/schema/bigquery.sql
+++ b/ci/schema/bigquery.sql
@@ -1,0 +1,164 @@
+CREATE SCHEMA IF NOT EXISTS ibis_gbq_testing;
+
+CREATE OR REPLACE TABLE ibis_gbq_testing.struct (
+    abc STRUCT<a FLOAT64, b STRING, c INT64>
+);
+
+INSERT INTO ibis_gbq_testing.struct VALUES
+    (STRUCT(1.0, 'banana', 2)),
+    (STRUCT(2.0, 'apple', 3)),
+    (STRUCT(3.0, 'orange', 4)),
+    (STRUCT(NULL, 'banana', 2)),
+    (STRUCT(2.0, NULL, 3)),
+    (NULL),
+    (STRUCT(3.0, 'orange', NULL));
+
+CREATE OR REPLACE TABLE ibis_gbq_testing.array_types (
+    x ARRAY<INT64>,
+    y ARRAY<STRING>,
+    z ARRAY<FLOAT64>,
+    grouper STRING,
+    scalar_column FLOAT64,
+);
+
+INSERT INTO ibis_gbq_testing.array_types VALUES
+    ([1, 2, 3], ['a', 'b', 'c'], [1.0, 2.0, 3.0], 'a', 1.0),
+    ([4, 5], ['d', 'e'], [4.0, 5.0], 'a', 2.0),
+    ([6], ['f'], [6.0], 'a', 3.0),
+    ([1], ['a'], [], 'b', 4.0),
+    ([2, 3], ['b', 'c'], NULL, 'b', 5.0),
+    ([4, 5], ['d', 'e'], [4.0, 5.0], 'c', 6.0);
+
+CREATE OR REPLACE TABLE ibis_gbq_testing.win (
+    g STRING,
+    x INT64,
+    y INT64
+);
+
+INSERT INTO ibis_gbq_testing.win VALUES
+    ('a', 0, 3),
+    ('a', 1, 2),
+    ('a', 2, 0),
+    ('a', 3, 1),
+    ('a', 4, 1);
+
+CREATE OR REPLACE TABLE ibis_gbq_testing.topk (
+    x INT64
+);
+
+INSERT INTO ibis_gbq_testing.topk VALUES (1), (1), (NULL);
+
+CREATE OR REPLACE TABLE ibis_gbq_testing.numeric_table (
+    string_col STRING,
+    numeric_col NUMERIC
+);
+
+INSERT INTO ibis_gbq_testing.numeric_table VALUES
+    ('1st value', 0.999999999),
+    ('2nd value', 0.000000002);
+
+CREATE OR REPLACE TABLE ibis_gbq_testing.json_t (
+    js JSON
+);
+
+INSERT INTO ibis_gbq_testing.json_t VALUES
+    (JSON '{"a": [1,2,3,4], "b": 1}'),
+    (JSON '{"a":null,"b":2}'),
+    (JSON '{"a":"foo", "c":null}'),
+    (JSON 'null'),
+    (JSON '[42,47,55]'),
+    (JSON '[]');
+
+
+LOAD DATA OVERWRITE ibis_gbq_testing.functional_alltypes (
+    id INT64,
+    bool_col BOOLEAN,
+    tinyint_col INT64,
+    smallint_col INT64,
+    int_col INT64,
+    bigint_col INT64,
+    float_col FLOAT64,
+    double_col FLOAT64,
+    date_string_col STRING,
+    string_col STRING,
+    timestamp_col DATETIME,
+    year INT64,
+    month INT64
+)
+FROM FILES (
+    format = 'PARQUET',
+    uris = ['gs://ibis-ci-data/functional_alltypes.parquet']
+);
+
+LOAD DATA OVERWRITE ibis_gbq_testing.awards_players
+FROM FILES (
+    format = 'PARQUET',
+    uris = ['gs://ibis-ci-data/awards_players.parquet']
+);
+
+LOAD DATA OVERWRITE ibis_gbq_testing.batting
+FROM FILES (
+    format = 'PARQUET',
+    uris = ['gs://ibis-ci-data/batting.parquet']
+);
+
+LOAD DATA OVERWRITE ibis_gbq_testing.diamonds
+FROM FILES (
+    format = 'PARQUET',
+    uris = ['gs://ibis-ci-data/diamonds.parquet']
+);
+
+LOAD DATA OVERWRITE ibis_gbq_testing.astronauts
+FROM FILES (
+    format = 'PARQUET',
+    uris = ['gs://ibis-ci-data/astronauts.parquet']
+);
+
+LOAD DATA OVERWRITE ibis_gbq_testing.functional_alltypes_parted (
+    id INT64,
+    bool_col BOOLEAN,
+    tinyint_col INT64,
+    smallint_col INT64,
+    int_col INT64,
+    bigint_col INT64,
+    float_col FLOAT64,
+    double_col FLOAT64,
+    date_string_col STRING,
+    string_col STRING,
+    timestamp_col DATETIME,
+    year INT64,
+    month INT64
+)
+PARTITION BY _PARTITIONDATE
+FROM FILES (
+    format = 'PARQUET',
+    uris = ['gs://ibis-ci-data/functional_alltypes.parquet']
+);
+
+CREATE OR REPLACE TABLE ibis_gbq_testing.timestamp_column_parted (
+    my_timestamp_parted_col TIMESTAMP,
+    string_col STRING,
+    int_col INT64
+)
+PARTITION BY DATE(my_timestamp_parted_col);
+
+CREATE OR REPLACE TABLE ibis_gbq_testing.date_column_parted (
+    my_date_parted_col DATE,
+    string_col STRING,
+    int_col INT64
+)
+PARTITION BY my_date_parted_col;
+
+CREATE OR REPLACE TABLE ibis_gbq_testing.struct_table (
+    array_of_structs_col ARRAY<STRUCT<int_field INTEGER, string_field STRING>>,
+    nested_struct_col STRUCT<sub_struct STRUCT<timestamp_col TIMESTAMP>>,
+    struct_col STRUCT<string_field STRING>
+);
+
+INSERT INTO ibis_gbq_testing.struct_table VALUES
+    ([(12345, 'abcdefg'), (NULL, NULL)],
+     STRUCT(STRUCT(NULL)),
+     STRUCT(NULL)),
+    ([(12345, 'abcdefg'), (NULL, 'hijklmnop')],
+     STRUCT(STRUCT('2017-10-20 16:37:50.000000')),
+     STRUCT('a'));

--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import concurrent.futures
-import contextlib
-import io
 import os
 from typing import Any
 
@@ -13,20 +10,9 @@ from google.cloud import bigquery as bq
 
 import ibis
 from ibis.backends.bigquery import EXTERNAL_DATA_SCOPES, Backend
-from ibis.backends.bigquery.datatypes import BigQuerySchema
-from ibis.backends.conftest import TEST_TABLES
 from ibis.backends.tests.base import BackendTest
-from ibis.backends.tests.data import (
-    json_types,
-    non_null_array_types,
-    struct_types,
-    topk,
-    win,
-)
 
 DATASET_ID = "ibis_gbq_testing"
-DATASET_ID_TOKYO = "ibis_gbq_testing_tokyo"
-REGION_TOKYO = "asia-northeast1"
 DEFAULT_PROJECT_ID = "ibis-gbq"
 PROJECT_ID_ENV_VAR = "GOOGLE_BIGQUERY_PROJECT_ID"
 
@@ -70,226 +56,10 @@ class TestConf(BackendTest):
         except gexc.Forbidden:
             pytest.skip("User does not have permission to create dataset")
 
-        testing_dataset = bq.DatasetReference(project_id, DATASET_ID)
-
-        with contextlib.suppress(gexc.NotFound):
-            client.create_dataset(testing_dataset, exists_ok=True)
-
-        testing_dataset_tokyo = bq.Dataset(
-            bq.DatasetReference(project_id, DATASET_ID_TOKYO)
-        )
-        testing_dataset_tokyo.location = REGION_TOKYO
-
-        with contextlib.suppress(gexc.NotFound):
-            client.create_dataset(testing_dataset_tokyo, exists_ok=True)
-
-        # day partitioning
-        functional_alltypes_parted = bq.Table(
-            bq.TableReference(testing_dataset, "functional_alltypes_parted")
-        )
-        functional_alltypes_parted.require_partition_filter = False
-        functional_alltypes_parted.time_partitioning = bq.TimePartitioning(
-            type_=bq.TimePartitioningType.DAY
-        )
-
-        # ingestion timestamp partitioning
-        timestamp_table = bq.Table(
-            bq.TableReference(testing_dataset, "timestamp_column_parted")
-        )
-        timestamp_table.schema = BigQuerySchema.from_ibis(
-            ibis.schema(
-                dict(
-                    my_timestamp_parted_col="timestamp",
-                    string_col="string",
-                    int_col="int",
-                )
-            )
-        )
-        timestamp_table.time_partitioning = bq.TimePartitioning(
-            field="my_timestamp_parted_col"
-        )
-        client.create_table(timestamp_table, exists_ok=True)
-
-        # ingestion date partitioning
-        date_table = bq.Table(bq.TableReference(testing_dataset, "date_column_parted"))
-        date_table.schema = BigQuerySchema.from_ibis(
-            ibis.schema(
-                dict(my_date_parted_col="date", string_col="string", int_col="int")
-            )
-        )
-        date_table.time_partitioning = bq.TimePartitioning(field="my_date_parted_col")
-        client.create_table(date_table, exists_ok=True)
-
-        write_disposition = bq.WriteDisposition.WRITE_TRUNCATE
-        make_job = lambda func, *a, **kw: func(*a, **kw).result()
-
-        futures = []
-        # 10 is because of urllib3 connection pool size
-        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as e:
-            futures.append(
-                e.submit(
-                    make_job,
-                    client.load_table_from_dataframe,
-                    struct_types,
-                    bq.TableReference(testing_dataset, "struct"),
-                    job_config=bq.LoadJobConfig(
-                        write_disposition=write_disposition,
-                        schema=BigQuerySchema.from_ibis(
-                            ibis.schema(
-                                dict(abc="struct<a: float64, b: string, c: int64>")
-                            )
-                        ),
-                    ),
-                )
-            )
-
-            futures.append(
-                e.submit(
-                    make_job,
-                    client.load_table_from_dataframe,
-                    non_null_array_types.drop(columns=["multi_dim"]),
-                    bq.TableReference(testing_dataset, "array_types"),
-                    job_config=bq.LoadJobConfig(
-                        write_disposition=write_disposition,
-                        schema=BigQuerySchema.from_ibis(
-                            ibis.schema(
-                                dict(
-                                    x="array<int64>",
-                                    y="array<string>",
-                                    z="array<float64>",
-                                    grouper="string",
-                                    scalar_column="float64",
-                                )
-                            )
-                        ),
-                    ),
-                )
-            )
-
-            futures.append(
-                e.submit(
-                    make_job,
-                    client.load_table_from_file,
-                    io.BytesIO(
-                        self.data_dir.joinpath("avro", "struct_table.avro").read_bytes()
-                    ),
-                    bq.TableReference(testing_dataset, "struct_table"),
-                    job_config=bq.LoadJobConfig(
-                        write_disposition=write_disposition,
-                        source_format=bq.SourceFormat.AVRO,
-                    ),
-                )
-            )
-
-            futures.append(
-                e.submit(
-                    make_job,
-                    client.load_table_from_file,
-                    io.StringIO(
-                        "\n".join(  # noqa: FLY002
-                            [
-                                """{"string_col": "1st value", "numeric_col": 0.999999999}""",
-                                """{"string_col": "2nd value", "numeric_col": 0.000000002}""",
-                            ]
-                        )
-                    ),
-                    bq.TableReference(testing_dataset, "numeric_table"),
-                    job_config=bq.LoadJobConfig(
-                        write_disposition=write_disposition,
-                        schema=BigQuerySchema.from_ibis(
-                            ibis.schema(
-                                dict(string_col="string", numeric_col="decimal(38, 9)")
-                            )
-                        ),
-                        source_format=bq.SourceFormat.NEWLINE_DELIMITED_JSON,
-                    ),
-                )
-            )
-
-            futures.append(
-                e.submit(
-                    make_job,
-                    client.load_table_from_dataframe,
-                    win,
-                    bq.TableReference(testing_dataset, "win"),
-                    job_config=bq.LoadJobConfig(
-                        write_disposition=write_disposition,
-                        schema=BigQuerySchema.from_ibis(
-                            ibis.schema(dict(g="string", x="!int64", y="int64"))
-                        ),
-                    ),
-                )
-            )
-
-            futures.append(
-                e.submit(
-                    make_job,
-                    client.load_table_from_dataframe,
-                    topk.to_pandas(),
-                    bq.TableReference(testing_dataset, "topk"),
-                    job_config=bq.LoadJobConfig(
-                        write_disposition=write_disposition,
-                        schema=BigQuerySchema.from_ibis(ibis.schema(dict(x="int64"))),
-                    ),
-                )
-            )
-
-            futures.append(
-                e.submit(
-                    make_job,
-                    client.load_table_from_file,
-                    io.StringIO("\n".join(f'{{"js": {row}}}' for row in json_types.js)),
-                    bq.TableReference(testing_dataset, "json_t"),
-                    job_config=bq.LoadJobConfig(
-                        write_disposition=write_disposition,
-                        schema=BigQuerySchema.from_ibis(ibis.schema(dict(js="json"))),
-                        source_format=bq.SourceFormat.NEWLINE_DELIMITED_JSON,
-                    ),
-                )
-            )
-
-            futures.extend(
-                e.submit(
-                    make_job,
-                    client.load_table_from_file,
-                    io.BytesIO(
-                        self.data_dir.joinpath(
-                            "parquet", f"{table}.parquet"
-                        ).read_bytes()
-                    ),
-                    bq.TableReference(testing_dataset, table),
-                    job_config=bq.LoadJobConfig(
-                        schema=BigQuerySchema.from_ibis(ibis.schema(schema)),
-                        write_disposition=write_disposition,
-                        source_format=bq.SourceFormat.PARQUET,
-                    ),
-                )
-                for table, schema in TEST_TABLES.items()
-            )
-
-            # Test regional endpoints with non-US data.
-
-            futures.extend(
-                e.submit(
-                    make_job,
-                    client.load_table_from_file,
-                    io.BytesIO(
-                        self.data_dir.joinpath(
-                            "parquet", f"{table}.parquet"
-                        ).read_bytes()
-                    ),
-                    bq.TableReference(testing_dataset_tokyo, table),
-                    job_config=bq.LoadJobConfig(
-                        schema=BigQuerySchema.from_ibis(ibis.schema(schema)),
-                        write_disposition=write_disposition,
-                        source_format=bq.SourceFormat.PARQUET,
-                    ),
-                )
-                for table, schema in TEST_TABLES.items()
-            )
-
-            for fut in concurrent.futures.as_completed(futures):
-                fut.result()
+        path = self.script_dir.joinpath(f"{self.name()}.sql")
+        ddl = path.read_text()
+        query = client.query(ddl)
+        query.result()
 
     @staticmethod
     def connect(*, tmpdir, worker_id, **kw) -> Backend:

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -94,7 +94,7 @@ def test_cast_string_to_date(alltypes, df):
 def test_cast_float_to_int(alltypes, df):
     result = (alltypes.float_col - 2.55).cast("int64").to_pandas().sort_values()
     expected = (df.float_col - 2.55).astype("int64").sort_values()
-    tm.assert_series_equal(result, expected, check_names=False)
+    tm.assert_series_equal(result, expected, check_names=False, check_index=False)
 
 
 def test_has_partitions(alltypes, parted_alltypes, con):


### PR DESCRIPTION
This PR moves bigquery test data loading to SQL DDL in an effort to reduce the complexity of the setup code and make it less stateful.