### PR TITLE
feat(api): add `ibis.today()` for retrieving the current date

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -449,6 +449,10 @@ quartodoc:
               package: ibis
               dynamic: true
               signature_name: full
+            - name: today
+              package: ibis
+              dynamic: true
+              signature_name: full
             - name: date
               package: ibis
               dynamic: true

--- a/ibis/backends/druid/compiler.py
+++ b/ibis/backends/druid/compiler.py
@@ -69,7 +69,6 @@ class DruidCompiler(SQLGlotCompiler):
             ops.TimeDelta,
             ops.TimestampBucket,
             ops.TimestampDelta,
-            ops.TimestampNow,
             ops.Translate,
             ops.TypeOf,
             ops.Unnest,

--- a/ibis/backends/flink/compiler.py
+++ b/ibis/backends/flink/compiler.py
@@ -455,6 +455,9 @@ class FlinkCompiler(SQLGlotCompiler):
     def visit_TimestampNow(self, op):
         return self.v.current_timestamp
 
+    def visit_DateNow(self, op):
+        return self.v.current_date
+
     def visit_TimestampBucket(self, op, *, arg, interval, offset):
         unit = op.interval.dtype.unit.name
         unit_var = self.v[unit]

--- a/ibis/backends/oracle/compiler.py
+++ b/ibis/backends/oracle/compiler.py
@@ -69,7 +69,6 @@ class OracleCompiler(SQLGlotCompiler):
             ops.TimeDelta,
             ops.DateDelta,
             ops.TimestampDelta,
-            ops.TimestampNow,
             ops.TimestampFromYMDHMS,
             ops.TimeFromHMS,
             ops.IntervalFromInteger,

--- a/ibis/backends/pandas/kernels.py
+++ b/ibis/backends/pandas/kernels.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import decimal
 import json
 import math
@@ -335,6 +336,7 @@ generic = {
     ops.E: lambda: np.e,
     ops.Pi: lambda: np.pi,
     ops.TimestampNow: lambda: pd.Timestamp("now", tz="UTC").tz_localize(None),
+    ops.DateNow: lambda: pd.Timestamp(datetime.date.today()),
     ops.StringConcat: lambda xs: reduce(operator.add, xs),
     ops.StringJoin: lambda xs, sep: reduce(lambda x, y: x + sep + y, xs),
     ops.Log: lambda x, base: np.log(x) if base is None else np.log(x) / np.log(base),

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import calendar
+import datetime
 import math
 import operator
 from collections.abc import Mapping
@@ -812,6 +813,11 @@ def count_star(op, **kw):
 @translate.register(ops.TimestampNow)
 def timestamp_now(op, **_):
     return pl.lit(pd.Timestamp("now", tz="UTC").tz_localize(None))
+
+
+@translate.register(ops.DateNow)
+def date_now(op, **_):
+    return pl.lit(datetime.date.today())
 
 
 @translate.register(ops.Strftime)

--- a/ibis/backends/risingwave/compiler.py
+++ b/ibis/backends/risingwave/compiler.py
@@ -40,6 +40,9 @@ class RisingwaveCompiler(PostgresCompiler):
         ops.Last: "last_value",
     }
 
+    def visit_DateNow(self, op):
+        return self.cast(sge.CurrentTimestamp(), dt.date)
+
     def visit_Correlation(self, op, *, left, right, how, where):
         if how == "sample":
             raise com.UnsupportedOperationError(

--- a/ibis/backends/sql/compiler.py
+++ b/ibis/backends/sql/compiler.py
@@ -698,6 +698,9 @@ class SQLGlotCompiler(abc.ABC):
     def visit_TimestampNow(self, op):
         return sge.CurrentTimestamp()
 
+    def visit_DateNow(self, op):
+        return sge.CurrentDate()
+
     def visit_Strftime(self, op, *, arg, format_str):
         return sge.TimeToStr(this=arg, format=format_str)
 

--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -34,6 +34,7 @@ class DataFusion(Postgres):
             sge.Pow: rename_func("pow"),
             sge.IsNan: rename_func("isnan"),
             sge.CurrentTimestamp: rename_func("now"),
+            sge.CurrentDate: rename_func("today"),
             sge.Split: rename_func("string_to_array"),
             sge.Array: rename_func("make_array"),
             sge.ArrayContains: rename_func("array_has"),
@@ -151,6 +152,7 @@ class Impala(Hive):
             sge.IsInf: rename_func("is_inf"),
             sge.DayOfWeek: rename_func("dayofweek"),
             sge.Interval: lambda self, e: _interval(self, e, quote_arg=False),
+            sge.CurrentDate: rename_func("current_date"),
         }
 
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1555,9 +1555,7 @@ def test_day_of_week_column_group_by(
     backend.assert_frame_equal(result, expected, check_dtype=False)
 
 
-@pytest.mark.notimpl(
-    ["datafusion", "druid", "oracle"], raises=com.OperationNotDefinedError
-)
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_now(con):
     expr = ibis.now()
     result = con.execute(expr.name("tmp"))
@@ -1565,9 +1563,7 @@ def test_now(con):
 
 
 @pytest.mark.notimpl(["polars"], reason="assert 1 == 5", raises=AssertionError)
-@pytest.mark.notimpl(
-    ["datafusion", "druid", "oracle"], raises=com.OperationNotDefinedError
-)
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_now_from_projection(alltypes):
     n = 2
     expr = alltypes.select(now=ibis.now()).limit(n)

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1578,6 +1578,23 @@ def test_now_from_projection(alltypes):
     assert not pd.isna(ts.iat[0])
 
 
+def test_today(con):
+    result = con.execute(ibis.today())
+    assert isinstance(result, datetime.date)
+
+
+@pytest.mark.notimpl(
+    ["polars"], reason="polars fails to project literal", raises=AssertionError
+)
+def test_today_from_projection(alltypes):
+    expr = alltypes.select(today=ibis.today()).limit(2).today
+    ts = expr.execute()
+    assert len(ts) == 2
+    assert ts.nunique() == 1
+    years = expr.year().execute()
+    assert years.nunique() == 1
+
+
 DATE_BACKEND_TYPES = {
     "bigquery": "DATE",
     "clickhouse": "Date",

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -161,6 +161,7 @@ __all__ = (
     "struct",
     "to_sql",
     "table",
+    "today",
     "time",
     "timestamp",
     "trailing_range_window",
@@ -1129,6 +1130,18 @@ def now() -> ir.TimestampScalar:
 
     """
     return ops.TimestampNow().to_expr()
+
+
+def today() -> ir.DateScalar:
+    """Return an expression that will compute the current date.
+
+    Returns
+    -------
+    DateScalar
+        An expression representing the current date.
+
+    """
+    return ops.DateNow().to_expr()
 
 
 def rank() -> ir.IntegerColumn:

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -189,6 +189,11 @@ class TimestampNow(Constant):
 
 
 @public
+class DateNow(Constant):
+    dtype = dt.date
+
+
+@public
 class RandomScalar(Constant):
     dtype = dt.float64
 

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -922,3 +922,9 @@ def test_timestamp_bucket():
         ValueError, match="Must specify either interval value or components"
     ):
         ts.bucket()
+
+
+def test_today():
+    result = ibis.today()
+    assert isinstance(result, ir.DateScalar)
+    assert isinstance(result.op(), ops.DateNow)


### PR DESCRIPTION
Responding to this user request: https://github.com/ibis-project/ibis/discussions/8213#discussioncomment-8798497

Also adds support for `ibis.now()` for `oracle` and `druid`. I assume these were marked as unsupported due to prior upstream issues in sqlglot? The compilation seems to work fine now.