### PR TITLE
fix(polars): ensure `t.select(col=scalar)` results in `len(t)` rows

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1863,6 +1863,12 @@ def test_select_mutate_with_dict(backend):
     backend.assert_frame_equal(result, expected)
 
 
+def test_select_scalar(alltypes):
+    res = alltypes.select(y=ibis.literal(1)).limit(3).execute()
+    assert len(res.y) == 3
+    assert (res.y == 1).all()
+
+
 @pytest.mark.broken(["mssql", "oracle"], reason="incorrect syntax")
 def test_isnull_equality(con, backend, monkeypatch):
     monkeypatch.setattr(ibis.options, "default_backend", con)

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1562,7 +1562,6 @@ def test_now(con):
     assert isinstance(result, datetime.datetime)
 
 
-@pytest.mark.notimpl(["polars"], reason="assert 1 == 5", raises=AssertionError)
 @pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_now_from_projection(alltypes):
     n = 2
@@ -1579,9 +1578,6 @@ def test_today(con):
     assert isinstance(result, datetime.date)
 
 
-@pytest.mark.notimpl(
-    ["polars"], reason="polars fails to project literal", raises=AssertionError
-)
 def test_today_from_projection(alltypes):
     expr = alltypes.select(today=ibis.today()).limit(2).today
     ts = expr.execute()


### PR DESCRIPTION
Previously broadcasting a scalar as a column and then selecting only that column would result in only one row (rather than `len(t)` rows). This fixes that bug and adds a test.

Based on #8664, since this fixes a test in that PR too.