### PR TITLE
fix(pandas): map `date` type to `datetime64[s]`

### DIFF
--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -59,6 +59,8 @@ class PandasType(NumpyType):
     def from_ibis(cls, dtype):
         if dtype.is_timestamp() and dtype.timezone:
             return pdt.DatetimeTZDtype("ns", dtype.timezone)
+        elif dtype.is_date():
+            return np.dtype("M8[s]")
         elif dtype.is_interval():
             return np.dtype(f"timedelta64[{dtype.unit.short}]")
         else:

--- a/ibis/formats/tests/test_pandas.py
+++ b/ibis/formats/tests/test_pandas.py
@@ -32,7 +32,7 @@ from ibis.formats.pandas import PandasData, PandasSchema, PandasType
         (dt.float32, np.dtype("float32")),
         (dt.float64, np.dtype("float64")),
         (dt.boolean, np.dtype("bool")),
-        (dt.date, np.dtype("datetime64[D]")),
+        (dt.date, np.dtype("datetime64[s]")),
         (dt.time, np.dtype("timedelta64[ns]")),
         (dt.timestamp, np.dtype("datetime64[ns]")),
         (dt.Interval("s"), np.dtype("timedelta64[s]")),


### PR DESCRIPTION
Previously ibis's `date` type was mapped to `datetime64[D]`. This type isn't supported by pandas (the max is `datetime64[s]`), but the errors were hidden due to a `try/except` block causing things to fallback to `dtype('O')`. Pandas 2.2 changed the error raised here resulting in test failures.