### PR TITLE
docs: remove experimental indicator from all backends

### DIFF
--- a/docs/_callouts/experimental_backend.qmd
+++ b/docs/_callouts/experimental_backend.qmd
@@ -1,3 +1,0 @@
-::: {.callout-warning}
-This backend is experimental and is subject to backwards incompatible changes.
-:::

--- a/docs/backends/datafusion.qmd
+++ b/docs/backends/datafusion.qmd
@@ -2,8 +2,6 @@
 
 [https://arrow.apache.org/datafusion](https://arrow.apache.org/datafusion)
 
-{{< include /_callouts/experimental_backend.qmd >}}
-
 ![](https://img.shields.io/badge/memtables-not supported- grey?style=flat-square) ![](https://img.shields.io/badge/inputs-CSV | Delta Lake | Parquet-blue?style=flat-square) ![](https://img.shields.io/badge/outputs-CSV | Delta Lake | pandas | Parquet | PyArrow-orange?style=flat-square)
 
 ## Install

--- a/docs/backends/druid.qmd
+++ b/docs/backends/druid.qmd
@@ -2,8 +2,6 @@
 
 [https://druid.apache.org](https://druid.apache.org)
 
-{{< include /_callouts/experimental_backend.qmd >}}
-
 ![](https://img.shields.io/badge/memtables-fallback-yellow?style=flat-square) ![](https://img.shields.io/badge/inputs-Druid tables-blue?style=flat-square) ![](https://img.shields.io/badge/outputs-Druid tables | CSV | pandas | Parquet | PyArrow-orange?style=flat-square)
 
 ## Install

--- a/docs/backends/oracle.qmd
+++ b/docs/backends/oracle.qmd
@@ -2,8 +2,6 @@
 
 [https://docs.oracle.com/database/oracle/oracle-database](https://docs.oracle.com/database/oracle/oracle-database)
 
-{{< include /_callouts/experimental_backend.qmd >}}
-
 ![](https://img.shields.io/badge/memtables-fallback-yellow?style=flat-square) ![](https://img.shields.io/badge/inputs-Oracle tables-blue?style=flat-square) ![](https://img.shields.io/badge/outputs-Oracle tables | CSV | pandas | Parquet | PyArrow-orange?style=flat-square)
 
 ## Install

--- a/docs/backends/polars.qmd
+++ b/docs/backends/polars.qmd
@@ -2,8 +2,6 @@
 
 [https://www.pola.rs](https://www.pola.rs)
 
-{{< include /_callouts/experimental_backend.qmd >}}
-
 ![](https://img.shields.io/badge/memtables-native-green?style=flat-square) ![](https://img.shields.io/badge/inputs-CSV | Delta Lake | pandas | Parquet-blue?style=flat-square) ![](https://img.shields.io/badge/outputs-CSV | pandas | Delta Lake | Parquet | PyArrow-orange?style=flat-square)
 
 ## Install

--- a/docs/backends/trino.qmd
+++ b/docs/backends/trino.qmd
@@ -2,8 +2,6 @@
 
 [https://trino.io](https://trino.io)
 
-{{< include /_callouts/experimental_backend.qmd >}}
-
 ![](https://img.shields.io/badge/memtables-fallback-yellow?style=flat-square) ![](https://img.shields.io/badge/inputs-Trino tables-blue?style=flat-square) ![](https://img.shields.io/badge/outputs-Trino tables | CSV | pandas | Parquet | PyArrow-orange?style=flat-square)
 
 ## Install


### PR DESCRIPTION
These backends have all been around for a while, no need to keep marking them as experimental.