### PR TITLE
feat(common): support removing elements from a `DisjointSet`

### DIFF
--- a/ibis/common/egraph.py
+++ b/ibis/common/egraph.py
@@ -95,6 +95,19 @@ class DisjointSet(Mapping[K, set[K]]):
         id = self._parents[id]
         return self._classes[id]
 
+    def __delitem__(self, id):
+        """Remove the given id from the disjoint set.
+
+        Parameters
+        ----------
+        id :
+            The id to remove from the disjoint set.
+
+        """
+        self[id].remove(id)
+        del self._classes[id]
+        del self._parents[id]
+
     def __iter__(self) -> Iterator[K]:
         """Iterate over the ids in the disjoint set."""
         return iter(self._parents)

--- a/ibis/common/tests/test_egraph.py
+++ b/ibis/common/tests/test_egraph.py
@@ -73,6 +73,12 @@ def test_disjoint_set():
         (4, {4}),
     )
 
+    # test removing an element
+    del ds[3]
+    assert 3 not in ds
+    assert len(ds) == 3
+    assert tuple(ds.items()) == ((1, {1, 2}), (2, {1, 2}), (4, {4}))
+
     # check that the disjoint set doesn't get corrupted by adding an existing element
     ds.verify()
     ds.add(1)


### PR DESCRIPTION
Item removal has been missing from the `DisjointSet` implementation which I am going to use in an upcoming PR.

depends on https://github.com/ibis-project/ibis/pull/8702