### PR TITLE
perf(common): improve equality caching by explicitly invalidating the entry on `__del__`

### DIFF
--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
 import functools
-import weakref
 from collections import Counter, defaultdict
-from collections.abc import MutableMapping
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 from bidict import bidict
 
 from ibis.common.exceptions import IbisError
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
 
 
 def memoize(func: Callable) -> Callable:
@@ -29,51 +24,6 @@ def memoize(func: Callable) -> Callable:
             return result
 
     return wrapper
-
-
-class WeakCache(MutableMapping):
-    __slots__ = ("_data",)
-    _data: dict
-
-    def __init__(self):
-        object.__setattr__(self, "_data", {})
-
-    def __setattr__(self, name, value):
-        raise TypeError(f"can't set {name}")
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-    def __iter__(self) -> Iterator[Any]:
-        return iter(self._data)
-
-    def __setitem__(self, key, value) -> None:
-        # construct an alternative representation of the key using the id()
-        # of the key's components, this prevents infinite recursions
-        identifiers = tuple(id(item) for item in key)
-
-        # create a function which removes the key from the cache
-        def callback(ref_):
-            return self._data.pop(identifiers, None)
-
-        # create weak references for the key's components with the callback
-        # to remove the cache entry if any of the key's components gets
-        # garbage collected
-        refs = tuple(weakref.ref(item, callback) for item in key)
-
-        self._data[identifiers] = (value, refs)
-
-    def __getitem__(self, key):
-        identifiers = tuple(id(item) for item in key)
-        value, _ = self._data[identifiers]
-        return value
-
-    def __delitem__(self, key):
-        identifiers = tuple(id(item) for item in key)
-        del self._data[identifiers]
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}({self._data})"
 
 
 class RefCountedCache:

--- a/ibis/common/grounds.py
+++ b/ibis/common/grounds.py
@@ -22,6 +22,7 @@ from ibis.common.bases import (  # noqa: F401
     AbstractMeta,
     Comparable,
     Final,
+    Hashable,
     Immutable,
     Singleton,
 )

--- a/ibis/common/tests/test_graph_benchmarks.py
+++ b/ibis/common/tests/test_graph_benchmarks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 from typing_extensions import Self
@@ -19,9 +19,10 @@ class MyNode(Concrete, Node):
     d: frozendict[str, int]
     e: Optional[Self] = None
     f: tuple[Self, ...] = ()
+    g: Any = None
 
 
-def generate_node(depth):
+def generate_node(depth, g=None):
     # generate a nested node object with the given depth
     if depth == 0:
         return MyNode(10, "20", c=(30, 40), d=frozendict(e=50, f=60))
@@ -32,6 +33,7 @@ def generate_node(depth):
         d=frozendict(e=5, f=6),
         e=generate_node(0),
         f=(generate_node(depth - 1), generate_node(0)),
+        g=g,
     )
 
 
@@ -62,3 +64,12 @@ def test_replace_mapping(benchmark):
     node = generate_node(500)
     subs = {generate_node(1): generate_node(0)}
     benchmark(node.replace, subs)
+
+
+def test_equality_caching(benchmark):
+    node = generate_node(150)
+    other = generate_node(150)
+    assert node == other
+    assert other == node
+    assert node is not other
+    benchmark.pedantic(node.__eq__, args=[other], iterations=100, rounds=200)

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -417,9 +417,7 @@ def test_composition_of_annotable_and_comparable():
     assert a != c
     assert c != a
     assert a.__equals__(b)
-    assert a.__cached_equals__(b)
     assert not a.__equals__(c)
-    assert not a.__cached_equals__(c)
 
 
 def test_maintain_definition_order():

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -140,7 +140,7 @@ class DataType(Concrete, Coercible):
             raise TypeError(
                 f"invalid equality comparison between DataType and {type(other)}"
             )
-        return super().__cached_equals__(other)
+        return self == other
 
     def cast(self, other, **kwargs):
         # TODO(kszucs): remove it or deprecate it?

--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -23,7 +23,7 @@ class Node(Concrete, Traversable):
             raise TypeError(
                 f"invalid equality comparison between Node and {type(other)}"
             )
-        return self.__cached_equals__(other)
+        return self == other
 
     # Avoid custom repr for performance reasons
     __repr__ = object.__repr__

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -89,7 +89,7 @@ class Schema(Concrete, Coercible, MapSet):
             raise TypeError(
                 f"invalid equality comparison between Schema and {type(other)}"
             )
-        return self.__cached_equals__(other)
+        return self == other
 
     @classmethod
     def from_tuples(


### PR DESCRIPTION
Previously we used a rather complicated mechanism to implement global equality cache for operation nodes involving tricky weak reference tracking registering callbacks to invalidate cache entries. 

While this has greatly improved the overall performance of ibis internals we can have a simpler and more lightweight implementation by storing the equality comparison results in a `dict[dict[object_id, bool]]` data structure which allows us quick lookups and quick deletions. The caching is also specialized to a pair of objects in contrary to the previous `WeakCache` implementation which supported arbitrary number of key elements requiring multiple iterations over the key tuple.

```
---------------------------------------------------------------------------- benchmark 'test_bfs': 2 tests -----------------------------------------------------------------------------
Name (time in ms)              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bfs (0653_384b10f)     2.4032 (1.21)     2.7302 (1.14)     2.5057 (1.21)     0.0630 (1.0)      2.4830 (1.21)     0.0666 (1.0)         25;12  399.0923 (0.83)        169           1
test_bfs (NOW)              1.9786 (1.0)      2.3859 (1.0)      2.0748 (1.0)      0.0786 (1.25)     2.0521 (1.0)      0.0939 (1.41)         55;7  481.9678 (1.0)         229           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_dfs': 2 tests -----------------------------------------------------------------------------
Name (time in ms)              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_dfs (0653_384b10f)     2.3311 (1.18)     2.9268 (1.27)     2.4361 (1.17)     0.0925 (1.34)     2.3920 (1.14)     0.0478 (1.0)         23;25  410.4854 (0.86)        158           1
test_dfs (NOW)              1.9766 (1.0)      2.3061 (1.0)      2.0900 (1.0)      0.0689 (1.0)      2.0892 (1.0)      0.1262 (2.64)        107;0  478.4618 (1.0)         262           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------ benchmark 'test_equality': 2 tests -----------------------------------------------------------------------------------
Name (time in ns)                     Min                 Max                Mean             StdDev              Median                IQR            Outliers  OPS (Mops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_equality (0653_384b10f)     488.4580 (3.06)     670.3340 (2.18)     532.9611 (3.12)     14.3697 (2.14)     530.4795 (3.15)     17.6670 (3.26)     2752;186        1.8763 (0.32)      10000        1000
test_equality (NOW)              159.7090 (1.0)      307.0830 (1.0)      171.0032 (1.0)       6.7183 (1.0)      168.4161 (1.0)       5.4170 (1.0)       777;371        5.8478 (1.0)       10000        1000
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_replace_mapping': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                          Min                Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_replace_mapping (0653_384b10f)     9.3701 (1.11)     10.6236 (1.0)      9.6592 (1.02)     0.2626 (1.0)      9.5760 (1.08)     0.1286 (1.0)           4;5  103.5287 (0.98)         30           1
test_replace_mapping (NOW)              8.4357 (1.0)      28.9518 (2.73)     9.5036 (1.0)      3.4945 (13.31)    8.8787 (1.0)      0.3668 (2.85)          3;3  105.2228 (1.0)          87           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------ benchmark 'test_replace_pattern': 2 tests ------------------------------------------------------------------------------
Name (time in ms)                           Min                Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_replace_pattern (0653_384b10f)     13.3895 (1.10)     32.2786 (1.0)      14.7143 (1.10)     3.2605 (1.0)      14.2861 (1.13)     0.5695 (1.0)           2;2  67.9613 (0.91)         61           1
test_replace_pattern (NOW)              12.2229 (1.0)      34.5245 (1.07)     13.3812 (1.0)      3.3891 (1.04)     12.6136 (1.0)      0.7824 (1.37)          2;2  74.7315 (1.0)          64           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```