### PR TITLE
docs: add Polars SQL example to why article

### DIFF
--- a/docs/why.qmd
+++ b/docs/why.qmd
@@ -265,6 +265,19 @@ g
 g.order_by("count")
 ```
 
+## Polars
+
+```{python}
+con = ibis.polars.connect()
+t = con.read_parquet("penguins.parquet")
+g = t.alias("penguins").sql(sql)
+g
+```
+
+```{python}
+g.order_by("count")
+```
+
 ## DataFusion
 
 ```{python}


### PR DESCRIPTION
## Description of changes

add Polars SQL example to the Why Ibis concept article after https://github.com/ibis-project/ibis/pull/8528

for some reason, this is failing on `docs-preview` locally but works fine for my locally otherwise. opening the PR to see if issues in CI

## Issues closed

