### PR TITLE
docs(exasol): remove deprecated parameters from example

### DIFF
--- a/docs/backends/exasol.qmd
+++ b/docs/backends/exasol.qmd
@@ -73,11 +73,7 @@ con = ibis.exasol.connect(
     user = "username",
     password = "password",
     host = "localhost",
-    port = 8563,
-    schema = None,
-    encryption = True,
-    certificate_validation = True,
-    encoding = "en_US.UTF-8"
+    port = 8563
 )
 ```
 


### PR DESCRIPTION
## Description of changes

Remove outdated or deprecated parameters from the Exasol backend example.
