### PR TITLE
feat(exasol): add support for extracting milliseconds from timestamps

### DIFF
--- a/ibis/backends/exasol/compiler.py
+++ b/ibis/backends/exasol/compiler.py
@@ -156,6 +156,16 @@ class ExasolCompiler(SQLGlotCompiler):
     def visit_ExtractSecond(self, op, *, arg):
         return self.f.floor(self.cast(self.f.extract(self.v.second, arg), op.dtype))
 
+    def visit_ExtractMillisecond(self, op, *, arg):
+        return self.cast(
+            (
+                self.f.extract(self.v.second, arg)
+                - self.f.floor(self.f.extract(self.v.second, arg))
+            )
+            * 1000,
+            op.dtype,
+        )
+
     def visit_StringConcat(self, op, *, arg):
         any_args_null = (a.is_(NULL) for a in arg)
         return self.if_(sg.or_(*any_args_null), NULL, self.f.concat(*arg))

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -123,7 +123,7 @@ def test_timestamp_extract(backend, alltypes, df, attr):
             id="millisecond",
             marks=[
                 pytest.mark.notimpl(
-                    ["druid", "oracle", "exasol"], raises=com.OperationNotDefinedError
+                    ["druid", "oracle"], raises=com.OperationNotDefinedError
                 ),
             ],
         ),
@@ -199,7 +199,6 @@ def test_timestamp_extract_microseconds(backend, alltypes, df):
     reason="'StringColumn' object has no attribute 'millisecond'",
 )
 @pytest.mark.broken(["sqlite"], raises=AssertionError)
-@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract_milliseconds(backend, alltypes, df):
     expr = alltypes.timestamp_col.millisecond().name("millisecond")
     result = expr.execute()
@@ -1941,7 +1940,6 @@ def test_date_column_from_iso(backend, con, alltypes, df):
 
 
 @pytest.mark.notimpl(["druid", "oracle"], raises=com.OperationNotDefinedError)
-@pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_timestamp_extract_milliseconds_with_big_value(con):
     timestamp = ibis.timestamp("2021-01-01 01:30:59.333456")
     millis = timestamp.millisecond()


### PR DESCRIPTION
## Description of changes

Add support for extracting milliseconds from timestamps to exasol backend.