### PR TITLE
fix: fix some missing operations in the support matrix

### DIFF
--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -35,8 +35,11 @@ class SQLBackend(BaseBackend):
     @classmethod
     def has_operation(cls, operation: type[ops.Value]) -> bool:
         compiler = cls.compiler
+        if operation in compiler.extra_supported_ops:
+            return True
         method = getattr(compiler, f"visit_{operation.__name__}", None)
-        return method is not None and method not in (
+        return method not in (
+            None,
             compiler.visit_Undefined,
             compiler.visit_Unsupported,
         )

--- a/ibis/backends/sql/compiler.py
+++ b/ibis/backends/sql/compiler.py
@@ -1203,30 +1203,6 @@ class SQLGlotCompiler(abc.ABC):
             return sge.paren(sg_expr, copy=False)
         return sg_expr
 
-    def visit_Filter(self, op, *, parent, predicates):
-        predicates = (
-            self._add_parens(raw_predicate, predicate)
-            for raw_predicate, predicate in zip(op.predicates, predicates)
-        )
-        try:
-            return parent.where(*predicates, copy=False)
-        except AttributeError:
-            return (
-                sg.select(STAR, copy=False)
-                .from_(parent, copy=False)
-                .where(*predicates, copy=False)
-            )
-
-    def visit_Sort(self, op, *, parent, keys):
-        try:
-            return parent.order_by(*keys, copy=False)
-        except AttributeError:
-            return (
-                sg.select(STAR, copy=False)
-                .from_(parent, copy=False)
-                .order_by(*keys, copy=False)
-            )
-
     def visit_Union(self, op, *, left, right, distinct):
         if isinstance(left, (sge.Table, sge.Subquery)):
             left = sg.select(STAR, copy=False).from_(left, copy=False)

--- a/ibis/backends/sqlite/tests/test_client.py
+++ b/ibis/backends/sqlite/tests/test_client.py
@@ -8,6 +8,7 @@ import pytest
 from pytest import param
 
 import ibis
+import ibis.expr.operations as ops
 from ibis.conftest import not_windows
 
 
@@ -75,3 +76,15 @@ def test_connect(url, ext, tmp_path):
     con = ibis.connect(url(path))
     one = ibis.literal(1)
     assert con.execute(one) == 1
+
+
+def test_has_operation(con):
+    # Core operations handled in non-standard ways
+    for op in [ops.Project, ops.Filter, ops.Sort, ops.Aggregate]:
+        assert con.has_operation(op)
+    # Handled by base class rewrite
+    assert con.has_operation(ops.Capitalize)
+    # Handled by compiler-specific rewrite
+    assert con.has_operation(ops.Sample)
+    # Handled by visit_* method
+    assert con.has_operation(ops.Cast)


### PR DESCRIPTION
Previously `has_operation` for the SQL backends was ignoring operations supported through rewrite rules, leading to some gaps in the support matrix. Related to question in #8715. The pandas/dask backends still aren't correct - I started down fixing these up, but got bogged down in the magic of the `Dispatched` class and decided to punt for now.

Also deletes some dead code in the base sql backend.