### PR TITLE
fix(clickhouse): avoid forcing UTC to allow connection to servers that do not allow it

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -154,7 +154,6 @@ class Backend(SQLBackend, CanCreateDatabase):
         """
         if settings is None:
             settings = {}
-        settings.setdefault("session_timezone", "UTC")
 
         self.con = cc.get_client(
             host=host,


### PR DESCRIPTION
Fixes the ability to connect to clickhouse playground