### PR TITLE
fix(druid): import pydruid.db module explicitly

### DIFF
--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -7,7 +7,7 @@ import json
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
 
-import pydruid
+import pydruid.db
 import sqlglot as sg
 
 import ibis.common.exceptions as com


### PR DESCRIPTION
I tried connecting to the druid container and got an
`AttributeError: module 'pydruid' has no attribute 'db'`