### PR TITLE
perf(duckdb): avoid ifs with literal array slice indices

### DIFF
--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -135,11 +135,15 @@ class DuckDBCompiler(SQLGlotCompiler):
 
         if start is None:
             start = 0
+        elif isinstance(op.start, ops.Literal) and op.start.value >= 0:
+            start = op.start.value
         else:
             start = self.f.least(arg_length, self._neg_idx_to_pos(arg, start))
 
         if stop is None:
             stop = arg_length
+        elif isinstance(op.stop, ops.Literal) and op.stop.value >= 0:
+            stop = op.stop.value
         else:
             stop = self._neg_idx_to_pos(arg, stop)
 


### PR DESCRIPTION
This is related to https://github.com/ibis-project/ibis/issues/8770

Post this change, the SQL for `ibis.array([1,2,3])[1:3]`  is

```sql
SELECT
  LIST_SLICE([CAST(1 AS TINYINT), CAST(2 AS TINYINT), CAST(3 AS TINYINT)], 2, 3) AS "ArraySlice(Array(), 1, 3)"`
```

Before this change, you got the monstrosity, which would evaluate `[CAST(1 AS TINYINT), CAST(2 AS TINYINT), CAST(3 AS TINYINT)]` a whopping 6 times, instead of the needed once:

```sql
SELECT
  LIST_SLICE(
    [CAST(1 AS TINYINT), CAST(2 AS TINYINT), CAST(3 AS TINYINT)],
    LEAST(
      LENGTH([CAST(1 AS TINYINT), CAST(2 AS TINYINT), CAST(3 AS TINYINT)]),
      CASE
        WHEN CAST(1 AS TINYINT) >= 0
        THEN CAST(1 AS TINYINT)
        ELSE ARRAY_LENGTH([CAST(1 AS TINYINT), CAST(2 AS TINYINT), CAST(3 AS TINYINT)]) + GREATEST(
          CAST(1 AS TINYINT),
          -ARRAY_LENGTH([CAST(1 AS TINYINT), CAST(2 AS TINYINT), CAST(3 AS TINYINT)])
        )
      END
    ) + 1,
    CASE
      WHEN CAST(3 AS TINYINT) >= 0
      THEN CAST(3 AS TINYINT)
      ELSE ARRAY_LENGTH([CAST(1 AS TINYINT), CAST(2 AS TINYINT), CAST(3 AS TINYINT)]) + GREATEST(
        CAST(3 AS TINYINT),
        -ARRAY_LENGTH([CAST(1 AS TINYINT), CAST(2 AS TINYINT), CAST(3 AS TINYINT)])
      )
    END
  ) AS "ArraySlice(Array(), 1, 3)"
```

This makes me wonder if we should come up with some framework for other backends to be able to take advantage of this easily. Make some Operation `ArrayIndex(arr, idx)`? IDK exactly how best to do this.