### PR TITLE
test: add test for non-1 step in String slicing

### DIFF
--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -92,7 +92,8 @@ class StringValue(Value):
 
         if isinstance(key, slice):
             start, stop, step = key.start, key.stop, key.step
-            if step is not None and not isinstance(step, ir.Expr) and step != 1:
+
+            if isinstance(step, ir.Expr) or (step is not None and step != 1):
                 raise ValueError("Step can only be 1")
             if start is not None and not isinstance(start, ir.Expr) and start < 0:
                 raise ValueError(

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -437,6 +437,18 @@ def test_cast_same_type_noop(table):
     assert i.cast("int8") is i
 
 
+def test_string_slice_step(table):
+    s = ibis.literal("abcde")
+    s[1:3]
+    s[1:3:1]
+    with pytest.raises(ValueError):
+        s[1:3:2]
+    with pytest.raises(ValueError):
+        s[1 : 3 : ibis.literal(1)]
+    with pytest.raises(ValueError):
+        s[1 : 3 : ibis.literal(2)]
+
+
 @pytest.mark.parametrize("type", ["int8", "int32", "double", "float32"])
 def test_string_to_number(table, type):
     casted = table.g.cast(type)


### PR DESCRIPTION
Before, ibis.literal(1) or any ibis expression was a valid step in slices, but it shouldn't have been, since this argument
is ignored.