### PR TITLE
refactor(ir): remove deprecated `Schema.apply_to()` method

### DIFF
--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -10,10 +10,9 @@ from ibis.common.dispatch import lazy_singledispatch
 from ibis.common.exceptions import InputTypeError, IntegrityError
 from ibis.common.grounds import Concrete
 from ibis.common.patterns import Coercible
-from ibis.util import deprecated, indent
+from ibis.util import indent
 
 if TYPE_CHECKING:
-    import pandas as pd
     from typing_extensions import TypeAlias
 
 
@@ -223,15 +222,6 @@ class Schema(Concrete, Coercible, MapSet):
 
         """
         return self.names[i]
-
-    @deprecated(
-        as_of="6.0",
-        instead="use ibis.formats.pandas.PandasConverter.convert_frame() instead",
-    )
-    def apply_to(self, df: pd.DataFrame) -> pd.DataFrame:
-        from ibis.formats.pandas import PandasData
-
-        return PandasData.convert_table(df, self)
 
 
 SchemaLike: TypeAlias = Union[

--- a/ibis/expr/tests/test_schema.py
+++ b/ibis/expr/tests/test_schema.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import NamedTuple
 
 import numpy as np
-import pandas.testing as tm
 import pyarrow as pa
 import pytest
 
@@ -178,22 +177,6 @@ def test_nullable_output():
 @pytest.fixture
 def df():
     return pd.DataFrame({"A": pd.Series([1], dtype="int8"), "b": ["x"]})
-
-
-def test_apply_to_column_rename(df):
-    schema = sch.Schema({"a": "int8", "B": "string"})
-    expected = df.rename({"A": "a", "b": "B"}, axis=1)
-    with pytest.warns(FutureWarning):
-        df = schema.apply_to(df.copy())
-    tm.assert_frame_equal(df, expected)
-
-
-def test_apply_to_column_order(df):
-    schema = sch.Schema({"a": "int8", "b": "string"})
-    expected = df.rename({"A": "a"}, axis=1)
-    with pytest.warns(FutureWarning):
-        new_df = schema.apply_to(df.copy())
-    tm.assert_frame_equal(new_df, expected)
 
 
 def test_api_accepts_schema_objects():


### PR DESCRIPTION
This logic has been moved to the `ibis.formats.pandas` module.

BREAKING CHANGE: `Schema.apply_to()` is removed, use `ibis.formats.pandas.PandasConverter.convert_frame()` instead
