### PR TITLE
feat(api): add `catalog` and `database` kwargs to `ibis.table`

### DIFF
--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -244,6 +244,14 @@ def _physical_table(op, name, **kwargs):
     return f"{op.__class__.__name__}: {name}\n{schema}"
 
 
+@fmt.register(ops.UnboundTable)
+@fmt.register(ops.DatabaseTable)
+def _unbound_table(op, name, **kwargs):
+    schema = render_schema(op.schema, indent_level=1)
+    name = ".".join(filter(None, op.namespace.args + (name,)))
+    return f"{op.__class__.__name__}: {name}\n{schema}"
+
+
 @fmt.register(ops.InMemoryTable)
 def _in_memory_table(op, data, **kwargs):
     import rich.pretty

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -313,8 +313,8 @@ class PhysicalTable(Relation):
 
 @public
 class Namespace(Concrete):
-    database: Optional[str] = None
     catalog: Optional[str] = None
+    database: Optional[str] = None
 
 
 @public

--- a/ibis/expr/tests/snapshots/test_format/test_format_unbound_table_namespace/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_format_unbound_table_namespace/repr.txt
@@ -1,0 +1,3 @@
+UnboundTable: bork
+  a int64
+  b int64

--- a/ibis/expr/tests/snapshots/test_format/test_format_unbound_table_namespace/reprcatdb.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_format_unbound_table_namespace/reprcatdb.txt
@@ -1,0 +1,3 @@
+UnboundTable: ork.bork.bork
+  a int64
+  b int64

--- a/ibis/expr/tests/snapshots/test_format/test_format_unbound_table_namespace/reprdb.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_format_unbound_table_namespace/reprdb.txt
@@ -1,0 +1,3 @@
+UnboundTable: bork.bork
+  a int64
+  b int64

--- a/ibis/expr/tests/test_api.py
+++ b/ibis/expr/tests/test_api.py
@@ -156,3 +156,18 @@ def test_nested_name_property():
         x = x + 1
 
     assert x.op().name.count("Add") == n
+
+
+def test_unbound_table_namespace():
+    t = ibis.table(name="bork", schema=(("a", "int"), ("b", "int")), database="bork")
+
+    assert t.op().namespace == ops.Namespace(database="bork")
+
+    t = ibis.table(
+        name="bork", schema=(("a", "int"), ("b", "int")), database="bork", catalog="ork"
+    )
+
+    assert t.op().namespace == ops.Namespace(catalog="ork", database="bork")
+
+    with pytest.raises(ValueError, match="A catalog-only namespace is invalid in Ibis"):
+        ibis.table(name="bork", schema=(("a", "int"), ("b", "int")), catalog="bork")

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -379,6 +379,25 @@ def test_format_in_memory_table(snapshot):
     snapshot.assert_match(result, "repr.txt")
 
 
+def test_format_unbound_table_namespace(snapshot):
+    t = ibis.table(name="bork", schema=(("a", "int"), ("b", "int")))
+
+    result = fmt(t)
+    snapshot.assert_match(result, "repr.txt")
+
+    t = ibis.table(name="bork", schema=(("a", "int"), ("b", "int")), database="bork")
+
+    result = fmt(t)
+    snapshot.assert_match(result, "reprdb.txt")
+
+    t = ibis.table(
+        name="bork", schema=(("a", "int"), ("b", "int")), catalog="ork", database="bork"
+    )
+
+    result = fmt(t)
+    snapshot.assert_match(result, "reprcatdb.txt")
+
+
 def test_format_new_relational_operation(alltypes, snapshot):
     class MyRelation(ops.Relation):
         parent: ops.Relation


### PR DESCRIPTION
This allows specifying 1 or 2 levels of table positional hierarchy in a
call to `ibis.table`. I've updated the reprs for `UnboundTable` and
`DatabaseTable` to show that hierarchy when it is specified.

I've also swapped the attribute order for `ops.Namespace` as a
convenience to allow unpacking the argnames in the correct hierarchical
order.

Resolves #8253