### PR TITLE
refactor(api): remove `Schema.from/to_dask()` and `DataType.from/to_dask()`

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -247,11 +247,6 @@ class DataType(Concrete, Coercible):
 
         return PolarsType.to_ibis(polars_type, nullable=nullable)
 
-    @classmethod
-    def from_dask(cls, dask_type, nullable=True) -> Self:
-        """Return the equivalent ibis datatype."""
-        return cls.from_pandas(dask_type, nullable=nullable)
-
     def to_numpy(self):
         """Return the equivalent numpy datatype."""
         from ibis.formats.numpy import NumpyType
@@ -275,10 +270,6 @@ class DataType(Concrete, Coercible):
         from ibis.formats.polars import PolarsType
 
         return PolarsType.from_ibis(self)
-
-    def to_dask(self):
-        """Return the equivalent dask datatype."""
-        return self.to_pandas()
 
     def is_array(self) -> bool:
         """Return True if an instance of an Array type."""

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -162,11 +162,6 @@ class Schema(Concrete, Coercible, MapSet):
 
         return PolarsSchema.to_ibis(polars_schema)
 
-    @classmethod
-    def from_dask(cls, dask_schema):
-        """Return the equivalent ibis schema."""
-        return cls.from_pandas(dask_schema)
-
     def to_numpy(self):
         """Return the equivalent numpy dtypes."""
         from ibis.formats.numpy import NumpySchema
@@ -190,10 +185,6 @@ class Schema(Concrete, Coercible, MapSet):
         from ibis.formats.polars import PolarsSchema
 
         return PolarsSchema.from_ibis(self)
-
-    def to_dask(self):
-        """Return the equivalent dask dtypes."""
-        return self.to_pandas()
 
     def as_struct(self) -> dt.Struct:
         return dt.Struct(self)

--- a/ibis/expr/tests/test_schema.py
+++ b/ibis/expr/tests/test_schema.py
@@ -20,12 +20,6 @@ with contextlib.suppress(ImportError):
 
     has_pandas = True
 
-has_dask = False
-with contextlib.suppress(ImportError):
-    import dask.dataframe as dd  # noqa: F401
-
-    has_dask = True
-
 
 def test_whole_schema():
     schema = {
@@ -437,11 +431,6 @@ def test_schema_from_to_numpy_dtypes():
 @pytest.mark.parametrize(
     ("from_method", "to_method"),
     [
-        pytest.param(
-            "from_dask",
-            "to_dask",
-            marks=pytest.mark.skipif(not has_dask, reason="dask not installed"),
-        ),
         pytest.param(
             "from_pandas",
             "to_pandas",


### PR DESCRIPTION
Dask is not an explicitly supported format and these methods were just aliases for `.to_pandas()` and `.from_pandas()`.

BREAKING CHANGE: Schema.to_dask(), Schema.from_dask(), DataType.from_dask(), DataType.to_dask() methods are removed, use `.to_pandas()` and `.from_pandas()` methods instead
