### PR TITLE
refactor(formats): remove unnecessary schema argument from schema inference

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -247,11 +247,6 @@ class DataType(Concrete, Coercible):
 
         return PolarsType.to_ibis(polars_type, nullable=nullable)
 
-    @classmethod
-    def from_dask(cls, dask_type, nullable=True) -> Self:
-        """Return the equivalent ibis datatype."""
-        return cls.from_pandas(dask_type, nullable=nullable)
-
     def to_numpy(self):
         """Return the equivalent numpy datatype."""
         from ibis.formats.numpy import NumpyType
@@ -275,10 +270,6 @@ class DataType(Concrete, Coercible):
         from ibis.formats.polars import PolarsType
 
         return PolarsType.from_ibis(self)
-
-    def to_dask(self):
-        """Return the equivalent dask datatype."""
-        return self.to_pandas()
 
     def is_array(self) -> bool:
         """Return True if an instance of an Array type."""

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -229,7 +229,7 @@ def schema(value: Any) -> Schema:
 
 
 @lazy_singledispatch
-def infer(value: Any, schema=None) -> Schema:
+def infer(value: Any) -> Schema:
     """Infer the corresponding ibis schema for a python object."""
     raise InputTypeError(value)
 
@@ -269,28 +269,25 @@ def from_pyarrow_schema(schema):
 
 
 @infer.register("pandas.DataFrame")
-def infer_pandas_dataframe(df, schema=None):
+def infer_pandas_dataframe(df):
     from ibis.formats.pandas import PandasData
 
-    return PandasData.infer_table(df, schema)
+    return PandasData.infer_table(df)
 
 
-# TODO(kszucs): do we really need the schema kwarg?
 @infer.register("pyarrow.Table")
-def infer_pyarrow_table(table, schema=None):
+def infer_pyarrow_table(table):
     from ibis.formats.pyarrow import PyArrowSchema
 
-    schema = schema if schema is not None else table.schema
-    return PyArrowSchema.to_ibis(schema)
+    return PyArrowSchema.to_ibis(table.schema)
 
 
 @infer.register("polars.DataFrame")
 @infer.register("polars.LazyFrame")
-def infer_polars_dataframe(df, schema=None):
+def infer_polars_dataframe(df):
     from ibis.formats.polars import PolarsSchema
 
-    schema = schema if schema is not None else df.schema
-    return PolarsSchema.to_ibis(schema)
+    return PolarsSchema.to_ibis(df.schema)
 
 
 # lock the dispatchers to avoid adding new implementations

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -162,11 +162,6 @@ class Schema(Concrete, Coercible, MapSet):
 
         return PolarsSchema.to_ibis(polars_schema)
 
-    @classmethod
-    def from_dask(cls, dask_schema):
-        """Return the equivalent ibis schema."""
-        return cls.from_pandas(dask_schema)
-
     def to_numpy(self):
         """Return the equivalent numpy dtypes."""
         from ibis.formats.numpy import NumpySchema
@@ -190,10 +185,6 @@ class Schema(Concrete, Coercible, MapSet):
         from ibis.formats.polars import PolarsSchema
 
         return PolarsSchema.from_ibis(self)
-
-    def to_dask(self):
-        """Return the equivalent dask dtypes."""
-        return self.to_pandas()
 
     def as_struct(self) -> dt.Struct:
         return dt.Struct(self)

--- a/ibis/expr/tests/test_schema.py
+++ b/ibis/expr/tests/test_schema.py
@@ -20,12 +20,6 @@ with contextlib.suppress(ImportError):
 
     has_pandas = True
 
-has_dask = False
-with contextlib.suppress(ImportError):
-    import dask.dataframe as dd  # noqa: F401
-
-    has_dask = True
-
 
 def test_whole_schema():
     schema = {
@@ -437,11 +431,6 @@ def test_schema_from_to_numpy_dtypes():
 @pytest.mark.parametrize(
     ("from_method", "to_method"),
     [
-        pytest.param(
-            "from_dask",
-            "to_dask",
-            marks=pytest.mark.skipif(not has_dask, reason="dask not installed"),
-        ),
         pytest.param(
             "from_pandas",
             "to_pandas",

--- a/ibis/formats/__init__.py
+++ b/ibis/formats/__init__.py
@@ -168,15 +168,13 @@ class DataMapper(Generic[S, C, T]):
         raise NotImplementedError
 
     @classmethod
-    def convert_table(cls, obj: T, schema: Schema) -> T:
+    def convert_table(cls, obj: T) -> T:
         """Convert a format-specific table to the given ibis schema.
 
         Parameters
         ----------
         obj
             The format-specific table-like object to convert.
-        schema
-            The Ibis schema to convert to.
 
         Returns
         -------

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -94,9 +94,7 @@ class PandasData(DataMapper):
         return PyArrowData.infer_column(s)
 
     @classmethod
-    def infer_table(cls, df, schema=None):
-        schema = schema if schema is not None else {}
-
+    def infer_table(cls, df):
         pairs = []
         for column_name in df.dtypes.keys():
             if not isinstance(column_name, str):
@@ -104,15 +102,12 @@ class PandasData(DataMapper):
                     "Column names must be strings to use the pandas backend"
                 )
 
-            if column_name in schema:
-                ibis_dtype = schema[column_name]
+            pandas_column = df[column_name]
+            pandas_dtype = pandas_column.dtype
+            if pandas_dtype == np.object_:
+                ibis_dtype = cls.infer_column(pandas_column)
             else:
-                pandas_column = df[column_name]
-                pandas_dtype = pandas_column.dtype
-                if pandas_dtype == np.object_:
-                    ibis_dtype = cls.infer_column(pandas_column)
-                else:
-                    ibis_dtype = PandasType.to_ibis(pandas_dtype)
+                ibis_dtype = PandasType.to_ibis(pandas_dtype)
 
             pairs.append((column_name, ibis_dtype))
 


### PR DESCRIPTION
`sch.infer()` and `DataMapper.infer_table()` implementations had an unnecessary schema argument which wan't actually used.