### PR TITLE
refactor(ir): loosen the join integrity checks

### DIFF
--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -184,9 +184,11 @@ class JoinChain(Relation):
 
     def __init__(self, first, rest, values):
         allowed_parents = {first}
-        assert first.index == 0
         for join in rest:
-            assert join.table.index == len(allowed_parents)
+            if join.table in allowed_parents:
+                raise IntegrityError(
+                    f"Cannot add {join.table!r} to the join chain, it is already in the chain"
+                )
             allowed_parents.add(join.table)
             _check_integrity(join.predicates, allowed_parents)
         _check_integrity(values.values(), allowed_parents)

--- a/ibis/expr/tests/test_newrels.py
+++ b/ibis/expr/tests/test_newrels.py
@@ -531,7 +531,6 @@ def test_project_before_and_after_filter():
     )
 
 
-# TODO(kszucs): add test for failing integrity checks
 def test_join():
     t1 = ibis.table(name="t1", schema={"a": "int64", "b": "string"})
     t2 = ibis.table(name="t2", schema={"c": "int64", "d": "string"})
@@ -559,6 +558,26 @@ def test_join():
                 "d": t2.d,
             },
         )
+
+
+def test_join_integrity_checks():
+    t1 = ibis.table(name="t1", schema={"a": "int64", "b": "string"})
+
+    # correct example
+    r1 = ops.JoinTable(t1, 10)
+    r2 = ops.JoinTable(t1, 20)
+    assert r1 != r2
+    assert hash(r1) != hash(r2)
+    chain = ops.JoinChain(r1, [ops.JoinLink("inner", r2, [True])], values={})
+    assert isinstance(chain, JoinChain)
+
+    # not unique tables
+    r1 = ops.JoinTable(t1, 10)
+    r2 = ops.JoinTable(t1, 10)
+    assert r1 == r2
+    assert hash(r1) == hash(r2)
+    with pytest.raises(IntegrityError):
+        ops.JoinChain(r1, [ops.JoinLink("inner", r2, [True])], values={})
 
 
 def test_join_unambiguous_select():


### PR DESCRIPTION
Enables us easier join chain rewrites since we don't need to maintain a monotonically increasing index for the join tables.

Resolves https://github.com/ibis-project/ibis/issues/8773
