### PR TITLE
refactor(ir): dereference literal expressions

### DIFF
--- a/ibis/expr/tests/test_newrels.py
+++ b/ibis/expr/tests/test_newrels.py
@@ -499,6 +499,26 @@ def test_subsequent_filter():
     assert f2.op() == expected
 
 
+def test_project_dereferences_literal_expressions():
+    one = ibis.literal(1)
+    two = ibis.literal(2)
+    four = (one + one) * two
+    t1 = t.mutate(four=four)
+    assert t1.op() == Project(
+        parent=t,
+        values={
+            "bool_col": t.bool_col,
+            "int_col": t.int_col,
+            "float_col": t.float_col,
+            "string_col": t.string_col,
+            "four": four,
+        },
+    )
+
+    t2 = t1.select(four)
+    assert t2.op() == Project(parent=t1, values={four.get_name(): t1.four})
+
+
 def test_project_before_and_after_filter():
     t1 = t.select(
         bool_col=~t.bool_col, int_col=t.int_col + 1, float_col=t.float_col * 3

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -163,7 +163,7 @@ def dereference_mapping(parents):
                 while isinstance(v, ops.Field) and v not in mapping:
                     mapping[v] = ops.Field(parent, k)
                     v = v.rel.values.get(v.name)
-            elif v.relations and v not in mapping:
+            elif v not in mapping:
                 # do not dereference literal expressions
                 mapping[v] = ops.Field(parent, k)
 


### PR DESCRIPTION
Slightly smarter dereferencing to also dereference literal expressions without any relations attached. 
The following expression 

```py
one = ibis.literal(1)
two = ibis.literal(2)
four = (one + one) * two

t1 = t.mutate(four=four)
t2 = t1.select(four)
```

Before

```
r0 := UnboundTable: t
  bool_col   boolean
  int_col    int64
  float_col  float64
  string_col string

r1 := Project[r0]
  bool_col:   r0.bool_col
  int_col:    r0.int_col
  float_col:  r0.float_col
  string_col: r0.string_col
  four:       1 + 1 * 2

Project[r1]
  Multiply(Add(1, 1), 2): 1 + 1 * 2
```

After

```
r0 := UnboundTable: t
  bool_col   boolean
  int_col    int64
  float_col  float64
  string_col string

r1 := Project[r0]
  bool_col:   r0.bool_col
  int_col:    r0.int_col
  float_col:  r0.float_col
  string_col: r0.string_col
  four:       1 + 1 * 2

Project[r1]
  Multiply(Add(1, 1), 2): r1.four
```