### PR TITLE
refactor(sql): disable merging subsequent select nodes to avoid excessive inlining

### DIFF
--- a/ibis/backends/tests/sql/snapshots/test_compiler/test_agg_filter/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_compiler/test_agg_filter/out.sql
@@ -1,18 +1,25 @@
+WITH "t1" AS (
+  SELECT
+    "t0"."a",
+    "t0"."b",
+    "t0"."b" * CAST(2 AS TINYINT) AS "b2"
+  FROM "my_table" AS "t0"
+)
 SELECT
-  "t0"."a",
-  "t0"."b" * CAST(2 AS TINYINT) AS "b2"
-FROM "my_table" AS "t0"
+  "t2"."a",
+  "t2"."b2"
+FROM "t1" AS "t2"
 WHERE
-  "t0"."a" < CAST(100 AS TINYINT)
-  AND "t0"."a" = (
+  "t2"."a" < CAST(100 AS TINYINT)
+  AND "t2"."a" = (
     SELECT
-      MAX("t1"."a") AS "Max(a)"
+      MAX("t3"."a") AS "Max(a)"
     FROM (
       SELECT
-        "t0"."a",
-        "t0"."b" * CAST(2 AS TINYINT) AS "b2"
-      FROM "my_table" AS "t0"
+        "t2"."a",
+        "t2"."b2"
+      FROM "t1" AS "t2"
       WHERE
-        "t0"."a" < CAST(100 AS TINYINT)
-    ) AS "t1"
+        "t2"."a" < CAST(100 AS TINYINT)
+    ) AS "t3"
   )

--- a/ibis/backends/tests/sql/snapshots/test_compiler/test_agg_filter_with_alias/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_compiler/test_agg_filter_with_alias/out.sql
@@ -1,18 +1,25 @@
+WITH "t1" AS (
+  SELECT
+    "t0"."a",
+    "t0"."b",
+    "t0"."b" * CAST(2 AS TINYINT) AS "b2"
+  FROM "my_table" AS "t0"
+)
 SELECT
-  "t0"."a",
-  "t0"."b" * CAST(2 AS TINYINT) AS "b2"
-FROM "my_table" AS "t0"
+  "t2"."a",
+  "t2"."b2"
+FROM "t1" AS "t2"
 WHERE
-  "t0"."a" < CAST(100 AS TINYINT)
-  AND "t0"."a" = (
+  "t2"."a" < CAST(100 AS TINYINT)
+  AND "t2"."a" = (
     SELECT
-      MAX("t1"."a") AS "Max(a)"
+      MAX("t3"."a") AS "Max(a)"
     FROM (
       SELECT
-        "t0"."a",
-        "t0"."b" * CAST(2 AS TINYINT) AS "b2"
-      FROM "my_table" AS "t0"
+        "t2"."a",
+        "t2"."b2"
+      FROM "t1" AS "t2"
       WHERE
-        "t0"."a" < CAST(100 AS TINYINT)
-    ) AS "t1"
+        "t2"."a" < CAST(100 AS TINYINT)
+    ) AS "t3"
   )

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_aggregate_projection_subquery/agg_filtered.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_aggregate_projection_subquery/agg_filtered.sql
@@ -1,23 +1,40 @@
 SELECT
-  "t1"."g",
-  SUM("t1"."foo") AS "foo total"
+  "t2"."g",
+  SUM("t2"."foo") AS "foo total"
 FROM (
   SELECT
-    "t0"."a",
-    "t0"."b",
-    "t0"."c",
-    "t0"."d",
-    "t0"."e",
-    "t0"."f",
-    "t0"."g",
-    "t0"."h",
-    "t0"."i",
-    "t0"."j",
-    "t0"."k",
-    "t0"."a" + "t0"."b" AS "foo"
-  FROM "alltypes" AS "t0"
+    "t1"."a",
+    "t1"."b",
+    "t1"."c",
+    "t1"."d",
+    "t1"."e",
+    "t1"."f",
+    "t1"."g",
+    "t1"."h",
+    "t1"."i",
+    "t1"."j",
+    "t1"."k",
+    "t1"."foo"
+  FROM (
+    SELECT
+      "t0"."a",
+      "t0"."b",
+      "t0"."c",
+      "t0"."d",
+      "t0"."e",
+      "t0"."f",
+      "t0"."g",
+      "t0"."h",
+      "t0"."i",
+      "t0"."j",
+      "t0"."k",
+      "t0"."a" + "t0"."b" AS "foo"
+    FROM "alltypes" AS "t0"
+    WHERE
+      "t0"."f" > CAST(0 AS TINYINT)
+  ) AS "t1"
   WHERE
-    "t0"."f" > CAST(0 AS TINYINT) AND "t0"."g" = 'bar'
-) AS "t1"
+    "t1"."g" = 'bar'
+) AS "t2"
 GROUP BY
   1

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_aggregate_projection_subquery/agg_filtered2.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_aggregate_projection_subquery/agg_filtered2.sql
@@ -1,25 +1,40 @@
 SELECT
-  "t1"."g",
-  SUM("t1"."foo") AS "foo total"
+  "t2"."g",
+  SUM("t2"."foo") AS "foo total"
 FROM (
   SELECT
-    "t0"."a",
-    "t0"."b",
-    "t0"."c",
-    "t0"."d",
-    "t0"."e",
-    "t0"."f",
-    "t0"."g",
-    "t0"."h",
-    "t0"."i",
-    "t0"."j",
-    "t0"."k",
-    "t0"."a" + "t0"."b" AS "foo"
-  FROM "alltypes" AS "t0"
+    "t1"."a",
+    "t1"."b",
+    "t1"."c",
+    "t1"."d",
+    "t1"."e",
+    "t1"."f",
+    "t1"."g",
+    "t1"."h",
+    "t1"."i",
+    "t1"."j",
+    "t1"."k",
+    "t1"."foo"
+  FROM (
+    SELECT
+      "t0"."a",
+      "t0"."b",
+      "t0"."c",
+      "t0"."d",
+      "t0"."e",
+      "t0"."f",
+      "t0"."g",
+      "t0"."h",
+      "t0"."i",
+      "t0"."j",
+      "t0"."k",
+      "t0"."a" + "t0"."b" AS "foo"
+    FROM "alltypes" AS "t0"
+    WHERE
+      "t0"."f" > CAST(0 AS TINYINT)
+  ) AS "t1"
   WHERE
-    "t0"."f" > CAST(0 AS TINYINT) AND (
-      "t0"."a" + "t0"."b"
-    ) < CAST(10 AS TINYINT)
-) AS "t1"
+    "t1"."foo" < CAST(10 AS TINYINT)
+) AS "t2"
 GROUP BY
   1

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_aggregate_projection_subquery/filtered.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_aggregate_projection_subquery/filtered.sql
@@ -1,16 +1,33 @@
 SELECT
-  "t0"."a",
-  "t0"."b",
-  "t0"."c",
-  "t0"."d",
-  "t0"."e",
-  "t0"."f",
-  "t0"."g",
-  "t0"."h",
-  "t0"."i",
-  "t0"."j",
-  "t0"."k",
-  "t0"."a" + "t0"."b" AS "foo"
-FROM "alltypes" AS "t0"
+  "t1"."a",
+  "t1"."b",
+  "t1"."c",
+  "t1"."d",
+  "t1"."e",
+  "t1"."f",
+  "t1"."g",
+  "t1"."h",
+  "t1"."i",
+  "t1"."j",
+  "t1"."k",
+  "t1"."foo"
+FROM (
+  SELECT
+    "t0"."a",
+    "t0"."b",
+    "t0"."c",
+    "t0"."d",
+    "t0"."e",
+    "t0"."f",
+    "t0"."g",
+    "t0"."h",
+    "t0"."i",
+    "t0"."j",
+    "t0"."k",
+    "t0"."a" + "t0"."b" AS "foo"
+  FROM "alltypes" AS "t0"
+  WHERE
+    "t0"."f" > CAST(0 AS TINYINT)
+) AS "t1"
 WHERE
-  "t0"."f" > CAST(0 AS TINYINT) AND "t0"."g" = 'bar'
+  "t1"."g" = 'bar'

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_bug_duplicated_where/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_bug_duplicated_where/out.sql
@@ -1,23 +1,18 @@
 SELECT
-  "t2"."arrdelay",
-  "t2"."dest",
-  "t2"."dest_avg",
-  "t2"."dev"
+  "t1"."arrdelay",
+  "t1"."dest",
+  "t1"."dest_avg",
+  "t1"."dev"
 FROM (
   SELECT
-    "t1"."arrdelay",
-    "t1"."dest",
-    AVG("t1"."arrdelay") OVER (PARTITION BY "t1"."dest" ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "dest_avg",
-    "t1"."arrdelay" - AVG("t1"."arrdelay") OVER (PARTITION BY "t1"."dest" ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "dev"
-  FROM (
-    SELECT
-      "t0"."arrdelay",
-      "t0"."dest"
-    FROM "airlines" AS "t0"
-  ) AS "t1"
-) AS "t2"
+    "t0"."arrdelay",
+    "t0"."dest",
+    AVG("t0"."arrdelay") OVER (PARTITION BY "t0"."dest" ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "dest_avg",
+    "t0"."arrdelay" - AVG("t0"."arrdelay") OVER (PARTITION BY "t0"."dest" ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "dev"
+  FROM "airlines" AS "t0"
+) AS "t1"
 WHERE
-  "t2"."dev" IS NOT NULL
+  "t1"."dev" IS NOT NULL
 ORDER BY
-  "t2"."dev" DESC
+  "t1"."dev" DESC
 LIMIT 10

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_complex_union/result.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_complex_union/result.sql
@@ -1,22 +1,32 @@
 SELECT
-  "t4"."diag",
-  "t4"."status"
+  "t6"."diag",
+  "t6"."status"
 FROM (
   SELECT
     *
   FROM (
     SELECT
-      CAST("t0"."diag" + CAST(1 AS TINYINT) AS INT) AS "diag",
-      "t0"."status"
-    FROM "aids2_one" AS "t0"
-  ) AS "t2"
+      CAST("t2"."diag" AS INT) AS "diag",
+      "t2"."status"
+    FROM (
+      SELECT
+        "t0"."diag" + CAST(1 AS TINYINT) AS "diag",
+        "t0"."status"
+      FROM "aids2_one" AS "t0"
+    ) AS "t2"
+  ) AS "t4"
   UNION ALL
   SELECT
     *
   FROM (
     SELECT
-      CAST("t1"."diag" + CAST(1 AS TINYINT) AS INT) AS "diag",
-      "t1"."status"
-    FROM "aids2_two" AS "t1"
-  ) AS "t3"
-) AS "t4"
+      CAST("t3"."diag" AS INT) AS "diag",
+      "t3"."status"
+    FROM (
+      SELECT
+        "t1"."diag" + CAST(1 AS TINYINT) AS "diag",
+        "t1"."status"
+      FROM "aids2_two" AS "t1"
+    ) AS "t3"
+  ) AS "t5"
+) AS "t6"

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_fuse_projections/project.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_fuse_projections/project.sql
@@ -1,7 +1,14 @@
 SELECT
-  "t0"."foo",
-  "t0"."bar",
-  "t0"."value",
-  "t0"."foo" + "t0"."bar" AS "baz",
-  "t0"."foo" * CAST(2 AS TINYINT) AS "qux"
-FROM "tbl" AS "t0"
+  "t1"."foo",
+  "t1"."bar",
+  "t1"."value",
+  "t1"."baz",
+  "t1"."foo" * CAST(2 AS TINYINT) AS "qux"
+FROM (
+  SELECT
+    "t0"."foo",
+    "t0"."bar",
+    "t0"."value",
+    "t0"."foo" + "t0"."bar" AS "baz"
+  FROM "tbl" AS "t0"
+) AS "t1"

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_fuse_projections/project_filter.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_fuse_projections/project_filter.sql
@@ -1,9 +1,16 @@
 SELECT
-  "t0"."foo",
-  "t0"."bar",
-  "t0"."value",
-  "t0"."foo" + "t0"."bar" AS "baz",
-  "t0"."foo" * CAST(2 AS TINYINT) AS "qux"
-FROM "tbl" AS "t0"
+  "t1"."foo",
+  "t1"."bar",
+  "t1"."value",
+  "t1"."baz",
+  "t1"."foo" * CAST(2 AS TINYINT) AS "qux"
+FROM (
+  SELECT
+    "t0"."foo",
+    "t0"."bar",
+    "t0"."value",
+    "t0"."foo" + "t0"."bar" AS "baz"
+  FROM "tbl" AS "t0"
+) AS "t1"
 WHERE
-  "t0"."value" > CAST(0 AS TINYINT)
+  "t1"."value" > CAST(0 AS TINYINT)

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_incorrect_predicate_pushdown/result.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_incorrect_predicate_pushdown/result.sql
@@ -1,7 +1,9 @@
 SELECT
-  "t0"."x" + CAST(1 AS TINYINT) AS "x"
-FROM "t" AS "t0"
+  "t1"."x"
+FROM (
+  SELECT
+    "t0"."x" + CAST(1 AS TINYINT) AS "x"
+  FROM "t" AS "t0"
+) AS "t1"
 WHERE
-  (
-    "t0"."x" + CAST(1 AS TINYINT)
-  ) > CAST(1 AS TINYINT)
+  "t1"."x" > CAST(1 AS TINYINT)

--- a/ibis/backends/tests/sql/snapshots/test_sql/test_gh_1045/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_sql/test_gh_1045/out.sql
@@ -1,13 +1,13 @@
 SELECT
   "t5"."t1_id1",
   "t5"."t1_val1",
-  "t9"."id3",
-  "t9"."val2",
-  "t9"."dt",
-  "t9"."t3_val2",
-  "t9"."id2a",
-  "t9"."id2b",
-  "t9"."val2_right"
+  "t10"."id3",
+  "t10"."val2",
+  "t10"."dt",
+  "t10"."t3_val2",
+  "t10"."id2a",
+  "t10"."id2b",
+  "t10"."val2_right"
 FROM (
   SELECT
     "t0"."id1" AS "t1_id1",
@@ -16,22 +16,28 @@ FROM (
 ) AS "t5"
 LEFT OUTER JOIN (
   SELECT
-    "t7"."id3",
-    "t7"."val2",
-    "t7"."dt",
-    "t7"."t3_val2",
+    "t8"."id3",
+    "t8"."val2",
+    "t8"."dt",
+    "t8"."t3_val2",
     "t3"."id2a",
     "t3"."id2b",
     "t3"."val2" AS "val2_right"
   FROM (
     SELECT
-      CAST("t1"."id3" AS BIGINT) AS "id3",
-      "t1"."val2",
-      "t1"."dt",
-      CAST("t1"."id3" AS BIGINT) AS "t3_val2"
-    FROM "test3" AS "t1"
-  ) AS "t7"
+      "t6"."id3",
+      "t6"."val2",
+      "t6"."dt",
+      "t6"."id3" AS "t3_val2"
+    FROM (
+      SELECT
+        CAST("t2"."id3" AS BIGINT) AS "id3",
+        "t2"."val2",
+        "t2"."dt"
+      FROM "test3" AS "t2"
+    ) AS "t6"
+  ) AS "t8"
   INNER JOIN "test2" AS "t3"
-    ON "t3"."id2b" = "t7"."id3"
-) AS "t9"
-  ON "t5"."t1_id1" = "t9"."id2a"
+    ON "t3"."id2b" = "t8"."id3"
+) AS "t10"
+  ON "t5"."t1_id1" = "t10"."id2a"


### PR DESCRIPTION
For less usual use cases like https://github.com/ibis-project/ibis/issues/8484 merging subsequent projections can result in excessive inlining.

cc @NickCrews @cpcloud 