### PR TITLE
chore(formats): restore schema arg to convert_table

### DIFF
--- a/ibis/formats/__init__.py
+++ b/ibis/formats/__init__.py
@@ -168,13 +168,15 @@ class DataMapper(Generic[S, C, T]):
         raise NotImplementedError
 
     @classmethod
-    def convert_table(cls, obj: T) -> T:
+    def convert_table(cls, obj: T, schema: Schema) -> T:
         """Convert a format-specific table to the given ibis schema.
 
         Parameters
         ----------
         obj
             The format-specific table-like object to convert.
+        schema
+            The Ibis schema to convert to.
 
         Returns
         -------


### PR DESCRIPTION
This argument is used by several formatting classes and the function has
limited meaning without it.

xref #8814