### PR TITLE
fix(clickhouse): use backwards compatible string search function

### DIFF
--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -225,9 +225,9 @@ class ClickHouseCompiler(SQLGlotCompiler):
             )
 
         if start is not None:
-            return self.f.locate(arg, substr, start)
+            return self.f.position(arg, substr, start)
 
-        return self.f.locate(arg, substr)
+        return self.f.position(arg, substr)
 
     def visit_RegexSearch(self, op, *, arg, pattern):
         return sge.RegexpLike(this=arg, expression=pattern)
@@ -478,7 +478,7 @@ class ClickHouseCompiler(SQLGlotCompiler):
         return self.f.repeat(arg, self.f.accurateCast(times, "UInt64"))
 
     def visit_StringContains(self, op, haystack, needle):
-        return self.f.locate(haystack, needle) > 0
+        return self.f.position(haystack, needle) > 0
 
     def visit_DayOfWeekIndex(self, op, *, arg):
         weekdays = len(calendar.day_name)

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_string_column_find/out1.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_string_column_find/out1.sql
@@ -1,3 +1,3 @@
 SELECT
-  locate("t0"."string_col", 'a') - 1 AS "StringFind(string_col, 'a')"
+  position("t0"."string_col", 'a') - 1 AS "StringFind(string_col, 'a')"
 FROM "functional_alltypes" AS "t0"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_string_column_find/out2.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_string_column_find/out2.sql
@@ -1,3 +1,3 @@
 SELECT
-  locate("t0"."string_col", "t0"."string_col") - 1 AS "StringFind(string_col, string_col)"
+  position("t0"."string_col", "t0"."string_col") - 1 AS "StringFind(string_col, string_col)"
 FROM "functional_alltypes" AS "t0"


### PR DESCRIPTION
Makes our implementation of string find and substring operations backwards compatible with clickhouse 23.