### PR TITLE
fix(sql): avoid excessive inlining during `Select` merge

### DIFF
--- a/ibis/backends/tests/snapshots/test_sql/test_isin_bug/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_isin_bug/mssql/out.sql
@@ -1,13 +1,13 @@
 SELECT
-  IIF(
+  IIF([t2].[InSubquery(x)] <> 0, 1, 0) AS [InSubquery(x)]
+FROM (
+  SELECT
     [t0].[x] IN (
       SELECT
         [t0].[x]
       FROM [t] AS [t0]
       WHERE
         [t0].[x] > 2
-    ),
-    1,
-    0
-  ) AS [InSubquery(x)]
-FROM [t] AS [t0]
+    ) AS [InSubquery(x)]
+  FROM [t] AS [t0]
+) AS [t2]

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -852,6 +852,11 @@ def test_typeof(con):
     reason="https://github.com/risingwavelabs/risingwave/issues/1343",
 )
 @pytest.mark.xfail_version(dask=["dask<2024.2.0"])
+@pytest.mark.notyet(
+    ["mssql"],
+    raises=PyODBCProgrammingError,
+    reason="naked IN queries are not supported",
+)
 def test_isin_uncorrelated(
     backend, batting, awards_players, batting_df, awards_players_df
 ):

--- a/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/duckdb/h20.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/duckdb/h20.sql
@@ -1,68 +1,90 @@
 SELECT
-  "t9"."s_name",
-  "t9"."s_address"
+  "t13"."s_name",
+  "t13"."s_address"
 FROM (
   SELECT
-    "t5"."s_suppkey",
-    "t5"."s_name",
-    "t5"."s_address",
-    "t5"."s_nationkey",
-    "t5"."s_phone",
-    "t5"."s_acctbal",
-    "t5"."s_comment",
-    "t6"."n_nationkey",
-    "t6"."n_name",
-    "t6"."n_regionkey",
-    "t6"."n_comment"
-  FROM "supplier" AS "t5"
-  INNER JOIN "nation" AS "t6"
-    ON "t5"."s_nationkey" = "t6"."n_nationkey"
-) AS "t9"
-WHERE
-  "t9"."n_name" = 'CANADA'
-  AND "t9"."s_suppkey" IN (
+    "t9"."s_suppkey",
+    "t9"."s_name",
+    "t9"."s_address",
+    "t9"."s_nationkey",
+    "t9"."s_phone",
+    "t9"."s_acctbal",
+    "t9"."s_comment",
+    "t9"."n_nationkey",
+    "t9"."n_name",
+    "t9"."n_regionkey",
+    "t9"."n_comment"
+  FROM (
     SELECT
-      "t1"."ps_suppkey"
-    FROM "partsupp" AS "t1"
-    WHERE
-      "t1"."ps_partkey" IN (
+      "t5"."s_suppkey",
+      "t5"."s_name",
+      "t5"."s_address",
+      "t5"."s_nationkey",
+      "t5"."s_phone",
+      "t5"."s_acctbal",
+      "t5"."s_comment",
+      "t6"."n_nationkey",
+      "t6"."n_name",
+      "t6"."n_regionkey",
+      "t6"."n_comment"
+    FROM "supplier" AS "t5"
+    INNER JOIN "nation" AS "t6"
+      ON "t5"."s_nationkey" = "t6"."n_nationkey"
+  ) AS "t9"
+  WHERE
+    "t9"."n_name" = 'CANADA'
+    AND "t9"."s_suppkey" IN (
+      SELECT
+        "t11"."ps_suppkey"
+      FROM (
         SELECT
-          "t3"."p_partkey"
-        FROM "part" AS "t3"
+          "t2"."ps_partkey",
+          "t2"."ps_suppkey",
+          "t2"."ps_availqty",
+          "t2"."ps_supplycost",
+          "t2"."ps_comment"
+        FROM "partsupp" AS "t2"
         WHERE
-          "t3"."p_name" LIKE 'forest%'
-      )
-      AND "t1"."ps_availqty" > (
-        (
-          SELECT
-            SUM("t8"."l_quantity") AS "Sum(l_quantity)"
-          FROM (
+          "t2"."ps_partkey" IN (
             SELECT
-              "t4"."l_orderkey",
-              "t4"."l_partkey",
-              "t4"."l_suppkey",
-              "t4"."l_linenumber",
-              "t4"."l_quantity",
-              "t4"."l_extendedprice",
-              "t4"."l_discount",
-              "t4"."l_tax",
-              "t4"."l_returnflag",
-              "t4"."l_linestatus",
-              "t4"."l_shipdate",
-              "t4"."l_commitdate",
-              "t4"."l_receiptdate",
-              "t4"."l_shipinstruct",
-              "t4"."l_shipmode",
-              "t4"."l_comment"
-            FROM "lineitem" AS "t4"
+              "t3"."p_partkey"
+            FROM "part" AS "t3"
             WHERE
-              "t4"."l_partkey" = "t1"."ps_partkey"
-              AND "t4"."l_suppkey" = "t1"."ps_suppkey"
-              AND "t4"."l_shipdate" >= MAKE_DATE(1994, 1, 1)
-              AND "t4"."l_shipdate" < MAKE_DATE(1995, 1, 1)
-          ) AS "t8"
-        ) * CAST(0.5 AS DOUBLE)
-      )
-  )
+              "t3"."p_name" LIKE 'forest%'
+          )
+          AND "t2"."ps_availqty" > (
+            (
+              SELECT
+                SUM("t8"."l_quantity") AS "Sum(l_quantity)"
+              FROM (
+                SELECT
+                  "t4"."l_orderkey",
+                  "t4"."l_partkey",
+                  "t4"."l_suppkey",
+                  "t4"."l_linenumber",
+                  "t4"."l_quantity",
+                  "t4"."l_extendedprice",
+                  "t4"."l_discount",
+                  "t4"."l_tax",
+                  "t4"."l_returnflag",
+                  "t4"."l_linestatus",
+                  "t4"."l_shipdate",
+                  "t4"."l_commitdate",
+                  "t4"."l_receiptdate",
+                  "t4"."l_shipinstruct",
+                  "t4"."l_shipmode",
+                  "t4"."l_comment"
+                FROM "lineitem" AS "t4"
+                WHERE
+                  "t4"."l_partkey" = "t2"."ps_partkey"
+                  AND "t4"."l_suppkey" = "t2"."ps_suppkey"
+                  AND "t4"."l_shipdate" >= MAKE_DATE(1994, 1, 1)
+                  AND "t4"."l_shipdate" < MAKE_DATE(1995, 1, 1)
+              ) AS "t8"
+            ) * CAST(0.5 AS DOUBLE)
+          )
+      ) AS "t11"
+    )
+) AS "t13"
 ORDER BY
-  "t9"."s_name" ASC
+  "t13"."s_name" ASC

--- a/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/trino/h20.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/trino/h20.sql
@@ -1,93 +1,115 @@
 SELECT
-  "t12"."s_name",
-  "t12"."s_address"
+  "t16"."s_name",
+  "t16"."s_address"
 FROM (
   SELECT
-    "t10"."s_suppkey",
-    "t10"."s_name",
-    "t10"."s_address",
-    "t10"."s_nationkey",
-    "t10"."s_phone",
-    "t10"."s_acctbal",
-    "t10"."s_comment",
-    "t8"."n_nationkey",
-    "t8"."n_name",
-    "t8"."n_regionkey",
-    "t8"."n_comment"
+    "t12"."s_suppkey",
+    "t12"."s_name",
+    "t12"."s_address",
+    "t12"."s_nationkey",
+    "t12"."s_phone",
+    "t12"."s_acctbal",
+    "t12"."s_comment",
+    "t12"."n_nationkey",
+    "t12"."n_name",
+    "t12"."n_regionkey",
+    "t12"."n_comment"
   FROM (
     SELECT
-      "t0"."s_suppkey",
-      "t0"."s_name",
-      "t0"."s_address",
-      "t0"."s_nationkey",
-      "t0"."s_phone",
-      CAST("t0"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
-      "t0"."s_comment"
-    FROM "hive"."ibis_sf1"."supplier" AS "t0"
-  ) AS "t10"
-  INNER JOIN (
-    SELECT
-      "t2"."n_nationkey",
-      "t2"."n_name",
-      "t2"."n_regionkey",
-      "t2"."n_comment"
-    FROM "hive"."ibis_sf1"."nation" AS "t2"
-  ) AS "t8"
-    ON "t10"."s_nationkey" = "t8"."n_nationkey"
-) AS "t12"
-WHERE
-  "t12"."n_name" = 'CANADA'
-  AND "t12"."s_suppkey" IN (
-    SELECT
-      "t7"."ps_suppkey"
+      "t10"."s_suppkey",
+      "t10"."s_name",
+      "t10"."s_address",
+      "t10"."s_nationkey",
+      "t10"."s_phone",
+      "t10"."s_acctbal",
+      "t10"."s_comment",
+      "t7"."n_nationkey",
+      "t7"."n_name",
+      "t7"."n_regionkey",
+      "t7"."n_comment"
     FROM (
       SELECT
-        "t1"."ps_partkey",
-        "t1"."ps_suppkey",
-        "t1"."ps_availqty",
-        CAST("t1"."ps_supplycost" AS DECIMAL(15, 2)) AS "ps_supplycost",
-        "t1"."ps_comment"
-      FROM "hive"."ibis_sf1"."partsupp" AS "t1"
+        "t0"."s_suppkey",
+        "t0"."s_name",
+        "t0"."s_address",
+        "t0"."s_nationkey",
+        "t0"."s_phone",
+        CAST("t0"."s_acctbal" AS DECIMAL(15, 2)) AS "s_acctbal",
+        "t0"."s_comment"
+      FROM "hive"."ibis_sf1"."supplier" AS "t0"
+    ) AS "t10"
+    INNER JOIN (
+      SELECT
+        "t1"."n_nationkey",
+        "t1"."n_name",
+        "t1"."n_regionkey",
+        "t1"."n_comment"
+      FROM "hive"."ibis_sf1"."nation" AS "t1"
     ) AS "t7"
-    WHERE
-      "t7"."ps_partkey" IN (
+      ON "t10"."s_nationkey" = "t7"."n_nationkey"
+  ) AS "t12"
+  WHERE
+    "t12"."n_name" = 'CANADA'
+    AND "t12"."s_suppkey" IN (
+      SELECT
+        "t14"."ps_suppkey"
+      FROM (
         SELECT
-          "t3"."p_partkey"
-        FROM "hive"."ibis_sf1"."part" AS "t3"
-        WHERE
-          "t3"."p_name" LIKE 'forest%'
-      )
-      AND "t7"."ps_availqty" > (
-        (
+          "t8"."ps_partkey",
+          "t8"."ps_suppkey",
+          "t8"."ps_availqty",
+          "t8"."ps_supplycost",
+          "t8"."ps_comment"
+        FROM (
           SELECT
-            SUM("t11"."l_quantity") AS "Sum(l_quantity)"
-          FROM (
+            "t2"."ps_partkey",
+            "t2"."ps_suppkey",
+            "t2"."ps_availqty",
+            CAST("t2"."ps_supplycost" AS DECIMAL(15, 2)) AS "ps_supplycost",
+            "t2"."ps_comment"
+          FROM "hive"."ibis_sf1"."partsupp" AS "t2"
+        ) AS "t8"
+        WHERE
+          "t8"."ps_partkey" IN (
             SELECT
-              "t4"."l_orderkey",
-              "t4"."l_partkey",
-              "t4"."l_suppkey",
-              "t4"."l_linenumber",
-              CAST("t4"."l_quantity" AS DECIMAL(15, 2)) AS "l_quantity",
-              CAST("t4"."l_extendedprice" AS DECIMAL(15, 2)) AS "l_extendedprice",
-              CAST("t4"."l_discount" AS DECIMAL(15, 2)) AS "l_discount",
-              CAST("t4"."l_tax" AS DECIMAL(15, 2)) AS "l_tax",
-              "t4"."l_returnflag",
-              "t4"."l_linestatus",
-              "t4"."l_shipdate",
-              "t4"."l_commitdate",
-              "t4"."l_receiptdate",
-              "t4"."l_shipinstruct",
-              "t4"."l_shipmode",
-              "t4"."l_comment"
-            FROM "hive"."ibis_sf1"."lineitem" AS "t4"
+              "t3"."p_partkey"
+            FROM "hive"."ibis_sf1"."part" AS "t3"
             WHERE
-              "t4"."l_partkey" = "t7"."ps_partkey"
-              AND "t4"."l_suppkey" = "t7"."ps_suppkey"
-              AND "t4"."l_shipdate" >= FROM_ISO8601_DATE('1994-01-01')
-              AND "t4"."l_shipdate" < FROM_ISO8601_DATE('1995-01-01')
-          ) AS "t11"
-        ) * CAST(0.5 AS DOUBLE)
-      )
-  )
+              "t3"."p_name" LIKE 'forest%'
+          )
+          AND "t8"."ps_availqty" > (
+            (
+              SELECT
+                SUM("t11"."l_quantity") AS "Sum(l_quantity)"
+              FROM (
+                SELECT
+                  "t4"."l_orderkey",
+                  "t4"."l_partkey",
+                  "t4"."l_suppkey",
+                  "t4"."l_linenumber",
+                  CAST("t4"."l_quantity" AS DECIMAL(15, 2)) AS "l_quantity",
+                  CAST("t4"."l_extendedprice" AS DECIMAL(15, 2)) AS "l_extendedprice",
+                  CAST("t4"."l_discount" AS DECIMAL(15, 2)) AS "l_discount",
+                  CAST("t4"."l_tax" AS DECIMAL(15, 2)) AS "l_tax",
+                  "t4"."l_returnflag",
+                  "t4"."l_linestatus",
+                  "t4"."l_shipdate",
+                  "t4"."l_commitdate",
+                  "t4"."l_receiptdate",
+                  "t4"."l_shipinstruct",
+                  "t4"."l_shipmode",
+                  "t4"."l_comment"
+                FROM "hive"."ibis_sf1"."lineitem" AS "t4"
+                WHERE
+                  "t4"."l_partkey" = "t8"."ps_partkey"
+                  AND "t4"."l_suppkey" = "t8"."ps_suppkey"
+                  AND "t4"."l_shipdate" >= FROM_ISO8601_DATE('1994-01-01')
+                  AND "t4"."l_shipdate" < FROM_ISO8601_DATE('1995-01-01')
+              ) AS "t11"
+            ) * CAST(0.5 AS DOUBLE)
+          )
+      ) AS "t14"
+    )
+) AS "t16"
 ORDER BY
-  "t12"."s_name" ASC
+  "t16"."s_name" ASC

--- a/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/duckdb/h22.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/duckdb/h22.sql
@@ -1,80 +1,91 @@
 SELECT
-  "t6"."cntrycode",
-  "t6"."numcust",
-  "t6"."totacctbal"
+  "t7"."cntrycode",
+  "t7"."numcust",
+  "t7"."totacctbal"
 FROM (
   SELECT
-    "t5"."cntrycode",
+    "t6"."cntrycode",
     COUNT(*) AS "numcust",
-    SUM("t5"."c_acctbal") AS "totacctbal"
+    SUM("t6"."c_acctbal") AS "totacctbal"
   FROM (
     SELECT
       SUBSTRING(
-        "t0"."c_phone",
+        "t5"."c_phone",
         CASE
           WHEN (
             CAST(0 AS TINYINT) + 1
           ) >= 1
           THEN CAST(0 AS TINYINT) + 1
-          ELSE CAST(0 AS TINYINT) + 1 + LENGTH("t0"."c_phone")
+          ELSE CAST(0 AS TINYINT) + 1 + LENGTH("t5"."c_phone")
         END,
         CAST(2 AS TINYINT)
       ) AS "cntrycode",
-      "t0"."c_acctbal"
-    FROM "customer" AS "t0"
-    WHERE
-      SUBSTRING(
+      "t5"."c_acctbal"
+    FROM (
+      SELECT
+        "t0"."c_custkey",
+        "t0"."c_name",
+        "t0"."c_address",
+        "t0"."c_nationkey",
         "t0"."c_phone",
-        CASE
-          WHEN (
-            CAST(0 AS TINYINT) + 1
-          ) >= 1
-          THEN CAST(0 AS TINYINT) + 1
-          ELSE CAST(0 AS TINYINT) + 1 + LENGTH("t0"."c_phone")
-        END,
-        CAST(2 AS TINYINT)
-      ) IN ('13', '31', '23', '29', '30', '18', '17')
-      AND "t0"."c_acctbal" > (
-        SELECT
-          AVG("t3"."c_acctbal") AS "Mean(c_acctbal)"
-        FROM (
+        "t0"."c_acctbal",
+        "t0"."c_mktsegment",
+        "t0"."c_comment"
+      FROM "customer" AS "t0"
+      WHERE
+        SUBSTRING(
+          "t0"."c_phone",
+          CASE
+            WHEN (
+              CAST(0 AS TINYINT) + 1
+            ) >= 1
+            THEN CAST(0 AS TINYINT) + 1
+            ELSE CAST(0 AS TINYINT) + 1 + LENGTH("t0"."c_phone")
+          END,
+          CAST(2 AS TINYINT)
+        ) IN ('13', '31', '23', '29', '30', '18', '17')
+        AND "t0"."c_acctbal" > (
           SELECT
-            "t0"."c_custkey",
-            "t0"."c_name",
-            "t0"."c_address",
-            "t0"."c_nationkey",
-            "t0"."c_phone",
-            "t0"."c_acctbal",
-            "t0"."c_mktsegment",
-            "t0"."c_comment"
-          FROM "customer" AS "t0"
-          WHERE
-            "t0"."c_acctbal" > CAST(0.0 AS DOUBLE)
-            AND SUBSTRING(
+            AVG("t3"."c_acctbal") AS "Mean(c_acctbal)"
+          FROM (
+            SELECT
+              "t0"."c_custkey",
+              "t0"."c_name",
+              "t0"."c_address",
+              "t0"."c_nationkey",
               "t0"."c_phone",
-              CASE
-                WHEN (
-                  CAST(0 AS TINYINT) + 1
-                ) >= 1
-                THEN CAST(0 AS TINYINT) + 1
-                ELSE CAST(0 AS TINYINT) + 1 + LENGTH("t0"."c_phone")
-              END,
-              CAST(2 AS TINYINT)
-            ) IN ('13', '31', '23', '29', '30', '18', '17')
-        ) AS "t3"
-      )
-      AND NOT (
-        EXISTS(
-          SELECT
-            1
-          FROM "orders" AS "t1"
-          WHERE
-            "t1"."o_custkey" = "t0"."c_custkey"
+              "t0"."c_acctbal",
+              "t0"."c_mktsegment",
+              "t0"."c_comment"
+            FROM "customer" AS "t0"
+            WHERE
+              "t0"."c_acctbal" > CAST(0.0 AS DOUBLE)
+              AND SUBSTRING(
+                "t0"."c_phone",
+                CASE
+                  WHEN (
+                    CAST(0 AS TINYINT) + 1
+                  ) >= 1
+                  THEN CAST(0 AS TINYINT) + 1
+                  ELSE CAST(0 AS TINYINT) + 1 + LENGTH("t0"."c_phone")
+                END,
+                CAST(2 AS TINYINT)
+              ) IN ('13', '31', '23', '29', '30', '18', '17')
+          ) AS "t3"
         )
-      )
-  ) AS "t5"
+        AND NOT (
+          EXISTS(
+            SELECT
+              1
+            FROM "orders" AS "t1"
+            WHERE
+              "t1"."o_custkey" = "t0"."c_custkey"
+          )
+        )
+    ) AS "t5"
+  ) AS "t6"
   GROUP BY
     1
-) AS "t6"
+) AS "t7"
 ORDER BY
-  "t6"."cntrycode" ASC
+  "t7"."cntrycode" ASC

--- a/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/trino/h22.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h22/test_tpc_h22/trino/h22.sql
@@ -1,67 +1,78 @@
 SELECT
-  "t7"."cntrycode",
-  "t7"."numcust",
-  "t7"."totacctbal"
+  "t8"."cntrycode",
+  "t8"."numcust",
+  "t8"."totacctbal"
 FROM (
   SELECT
-    "t6"."cntrycode",
+    "t7"."cntrycode",
     COUNT(*) AS "numcust",
-    SUM("t6"."c_acctbal") AS "totacctbal"
+    SUM("t7"."c_acctbal") AS "totacctbal"
   FROM (
     SELECT
-      SUBSTRING("t2"."c_phone", IF((
+      SUBSTRING("t6"."c_phone", IF((
         0 + 1
-      ) >= 1, 0 + 1, 0 + 1 + LENGTH("t2"."c_phone")), 2) AS "cntrycode",
-      "t2"."c_acctbal"
+      ) >= 1, 0 + 1, 0 + 1 + LENGTH("t6"."c_phone")), 2) AS "cntrycode",
+      "t6"."c_acctbal"
     FROM (
       SELECT
-        "t0"."c_custkey",
-        "t0"."c_name",
-        "t0"."c_address",
-        "t0"."c_nationkey",
-        "t0"."c_phone",
-        CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
-        "t0"."c_mktsegment",
-        "t0"."c_comment"
-      FROM "hive"."ibis_sf1"."customer" AS "t0"
-    ) AS "t2"
-    WHERE
-      SUBSTRING("t2"."c_phone", IF((
-        0 + 1
-      ) >= 1, 0 + 1, 0 + 1 + LENGTH("t2"."c_phone")), 2) IN ('13', '31', '23', '29', '30', '18', '17')
-      AND "t2"."c_acctbal" > (
+        "t2"."c_custkey",
+        "t2"."c_name",
+        "t2"."c_address",
+        "t2"."c_nationkey",
+        "t2"."c_phone",
+        "t2"."c_acctbal",
+        "t2"."c_mktsegment",
+        "t2"."c_comment"
+      FROM (
         SELECT
-          AVG("t3"."c_acctbal") AS "Mean(c_acctbal)"
-        FROM (
+          "t0"."c_custkey",
+          "t0"."c_name",
+          "t0"."c_address",
+          "t0"."c_nationkey",
+          "t0"."c_phone",
+          CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
+          "t0"."c_mktsegment",
+          "t0"."c_comment"
+        FROM "hive"."ibis_sf1"."customer" AS "t0"
+      ) AS "t2"
+      WHERE
+        SUBSTRING("t2"."c_phone", IF((
+          0 + 1
+        ) >= 1, 0 + 1, 0 + 1 + LENGTH("t2"."c_phone")), 2) IN ('13', '31', '23', '29', '30', '18', '17')
+        AND "t2"."c_acctbal" > (
           SELECT
-            "t0"."c_custkey",
-            "t0"."c_name",
-            "t0"."c_address",
-            "t0"."c_nationkey",
-            "t0"."c_phone",
-            CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
-            "t0"."c_mktsegment",
-            "t0"."c_comment"
-          FROM "hive"."ibis_sf1"."customer" AS "t0"
-          WHERE
-            CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) > CAST(0.0 AS DOUBLE)
-            AND SUBSTRING("t0"."c_phone", IF((
-              0 + 1
-            ) >= 1, 0 + 1, 0 + 1 + LENGTH("t0"."c_phone")), 2) IN ('13', '31', '23', '29', '30', '18', '17')
-        ) AS "t3"
-      )
-      AND NOT (
-        EXISTS(
-          SELECT
-            1
-          FROM "hive"."ibis_sf1"."orders" AS "t1"
-          WHERE
-            "t1"."o_custkey" = "t2"."c_custkey"
+            AVG("t3"."c_acctbal") AS "Mean(c_acctbal)"
+          FROM (
+            SELECT
+              "t0"."c_custkey",
+              "t0"."c_name",
+              "t0"."c_address",
+              "t0"."c_nationkey",
+              "t0"."c_phone",
+              CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) AS "c_acctbal",
+              "t0"."c_mktsegment",
+              "t0"."c_comment"
+            FROM "hive"."ibis_sf1"."customer" AS "t0"
+            WHERE
+              CAST("t0"."c_acctbal" AS DECIMAL(15, 2)) > CAST(0.0 AS DOUBLE)
+              AND SUBSTRING("t0"."c_phone", IF((
+                0 + 1
+              ) >= 1, 0 + 1, 0 + 1 + LENGTH("t0"."c_phone")), 2) IN ('13', '31', '23', '29', '30', '18', '17')
+          ) AS "t3"
         )
-      )
-  ) AS "t6"
+        AND NOT (
+          EXISTS(
+            SELECT
+              1
+            FROM "hive"."ibis_sf1"."orders" AS "t1"
+            WHERE
+              "t1"."o_custkey" = "t2"."c_custkey"
+          )
+        )
+    ) AS "t6"
+  ) AS "t7"
   GROUP BY
     1
-) AS "t7"
+) AS "t8"
 ORDER BY
-  "t7"."cntrycode" ASC
+  "t8"."cntrycode" ASC


### PR DESCRIPTION
Another take on https://github.com/ibis-project/ibis/pull/8820 by introducing a complexity metric and only merge `Select` nodes if the outcome is less complex.