### PR TITLE
chore(deps): downgrade nixpkgs

### DIFF
--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -36,6 +36,5 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
     steps:
       - run: echo "No build required"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,7 +37,6 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/flake.lock
+++ b/flake.lock
@@ -61,16 +61,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711153457,
-        "narHash": "sha256-nyF133G37SgxqfxJuSK10thvG2+xCcabfEBYPN7R2lE=",
+        "lastModified": 1711668574,
+        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "821ddb024d15c0679e2c87511db2e4e505a03fd8",
+        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable-small",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
         git
         just
         nixpkgs-fmt
-        nodePackages.prettier
+        nodejs_20.pkgs.prettier
         shellcheck
         shfmt
         statix
@@ -98,7 +98,7 @@
           # link checking
           lychee
           # release automation
-          nodejs
+          nodejs_20
           # used in notebooks to download data
           curl
           # docs
@@ -152,7 +152,7 @@
 
         release = pkgs.mkShell {
           name = "release";
-          nativeBuildInputs = with pkgs; [ git poetry nodejs unzip gnugrep ];
+          nativeBuildInputs = with pkgs; [ git poetry nodejs_20 unzip gnugrep ];
         };
       };
     }

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
 
     poetry2nix = {
       url = "github:nix-community/poetry2nix";
@@ -138,7 +138,7 @@
         ibis311 = mkDevShell pkgs.ibisDevEnv311;
         ibis312 = mkDevShell pkgs.ibisDevEnv312;
 
-        default = ibis312;
+        default = ibis311;
 
         preCommit = pkgs.mkShell {
           name = "preCommit";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -36,7 +36,7 @@ in
   ibisDevEnv312 = mkPoetryDevEnv pkgs.python312;
 
   ibisSmallDevEnv = mkPoetryEnv {
-    python = pkgs.python312;
+    python = pkgs.python311;
     groups = [ "dev" ];
     extras = [ ];
   };


### PR DESCRIPTION
Downgrade nixpkgs to avoid picking up newer versions of xz. This is a developer-tools-only issue. We can revisit the 312 support in the nix job once nixos-unstable-small finishes building (it has the xz revert patch applied).