### PR TITLE
feat(common): add `Node.find_below()` methods to exclude the root node from filtering

### DIFF
--- a/ibis/common/tests/test_graph.py
+++ b/ibis/common/tests/test_graph.py
@@ -59,11 +59,8 @@ A = MyNode(name="A", children=[B, C])
 
 def test_bfs():
     assert list(bfs(A).keys()) == [A, B, C, D, E]
-
-    with pytest.raises(
-        TypeError, match="must be an instance of ibis.common.graph.Node"
-    ):
-        bfs(1)
+    assert list(bfs([D, E, B])) == [D, E, B]
+    assert bfs(1) == {}
 
 
 def test_construction():
@@ -82,11 +79,8 @@ def test_graph_repr():
 
 def test_dfs():
     assert list(dfs(A).keys()) == [D, E, B, C, A]
-
-    with pytest.raises(
-        TypeError, match="must be an instance of ibis.common.graph.Node"
-    ):
-        dfs(1)
+    assert list(dfs([D, E, B])) == [D, E, B]
+    assert dfs(1) == {}
 
 
 def test_invert():
@@ -391,6 +385,16 @@ def test_node_find_using_pattern():
 
     result = A.find(If(_.children))
     assert result == [A, B]
+
+
+def test_node_find_below():
+    lowercase = MyNode(name="lowercase", children=[])
+    root = MyNode(name="root", children=[A, B, lowercase])
+    result = root.find_below(MyNode)
+    assert result == [A, B, lowercase, C, D, E]
+
+    result = root.find_below(lambda x: x.name.islower(), filter=lambda x: x != root)
+    assert result == [lowercase]
 
 
 def test_node_find_topmost_using_type():


### PR DESCRIPTION
Currently we are unable to locate certain values under a relation while applying a value filter because the root node gets filtered out, like:

```py
relation.find(pattern, filter=ops.Value)
```

Used in practice at https://github.com/ibis-project/ibis/pull/8825

```py
for child in _.__children__ + _.parent.__children__:
    if child.find((Window, ops.ExistsSubquery, ops.InSubquery, ops.Unnest), filter=ops.Value):
        ...
```
   
Which can be simplified to `_.find_below() or _.parent.find_below()` after this feature.

I am not that satisfied with the name, but marked as experimental so we can change it anytime. 
This feature will also help with pretty printing the dereference mapping without traversing the dictionary keys in `_flatten_collections()`. 