### PR TITLE
feat(ddl): distinguish views from tables while listing them

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,7 @@ services:
       - clickhouse
 
   mysql:
+    platform: linux/amd64
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
       MYSQL_DATABASE: ibis_testing
@@ -38,6 +39,7 @@ services:
       - $PWD/docker/mysql:/docker-entrypoint-initdb.d:ro
 
   postgres:
+    platform: linux/amd64
     user: postgres
     environment:
       POSTGRES_PASSWORD: postgres
@@ -59,6 +61,7 @@ services:
       - postgres:/data
 
   mssql:
+    platform: linux/amd64
     image: mcr.microsoft.com/mssql/server:2022-latest
     environment:
       MSSQL_SA_PASSWORD: 1bis_Testing!
@@ -341,6 +344,7 @@ services:
       - druid
 
   oracle:
+    platform: linux/amd64
     image: gvenzl/oracle-free:23.4-slim
     environment:
       ORACLE_PASSWORD: ibis

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -261,12 +261,34 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         with self._safe_raw_sql(sge.Drop(kind="SCHEMA", this=db_name, exists=force)):
             pass
 
+    def list(
+        self,
+        like: str | None = None,
+        database: str | None = None,
+    ) -> list[str]:
+        """List the names of tables and views in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern in Python's regex format.
+        database
+            Unused in the datafusion backend.
+
+        Returns
+        -------
+        list[str]
+            The list of the table/view names that match the pattern `like`.
+        """
+
+        return self.list_tables(like=like, database=database)
+
     def list_tables(
         self,
         like: str | None = None,
         database: str | None = None,
     ) -> list[str]:
-        """Return the list of table names in the current database.
+        """List the names of tables in the database.
 
         Parameters
         ----------
@@ -280,6 +302,11 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         list[str]
             The list of the table names that match the pattern `like`.
         """
+        # TODO (mehmet): `datafusion` library treats views as tables and
+        # does not expose any API that would make it possible to filter
+        # out the views from the tables.
+        # Ref: https://github.com/apache/arrow-datafusion-python
+
         database = database or "public"
         query = (
             sg.select("table_name")

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -158,6 +158,19 @@ class Backend(SQLBackend):
     def drop_table(self, *args, **kwargs):
         raise NotImplementedError()
 
+    def list(self, like: str | None = None, database: str | None = None) -> list[str]:
+        """List the names of tables and views in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables/views.
+        database
+            Database to list tables/views from. Default behavior is to
+            show tables/views in the current database.
+        """
+        return self.list_tables(like=like, database=database)
+
     def list_tables(
         self, like: str | None = None, database: str | None = None
     ) -> list[str]:
@@ -171,6 +184,11 @@ class Backend(SQLBackend):
             Database to list tables from. Default behavior is to show tables in
             the current database.
         """
+
+        # TODO (mehmet): Druid SQL does not seem to have a way to
+        # list the views.
+        # Ref: https://druid.apache.org/docs/latest/tutorials/tutorial-sql-query-view/
+
         t = sg.table("TABLES", db="INFORMATION_SCHEMA", quoted=True)
         c = self.compiler
         query = sg.select(sg.column("TABLE_NAME", quoted=True)).from_(t).sql(c.dialect)

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -271,7 +271,7 @@ def test_connect_local_file(out_method, extension, test_employee_data_1, tmp_pat
     with pytest.warns(FutureWarning, match="v9.1"):
         # ibis.connect uses con.register
         con = ibis.connect(tmp_path / f"out.{extension}")
-    t = next(iter(con.tables.values()))
+    t = next(iter(con.tabulars.values()))
     assert not t.head().execute().empty
 
 

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -286,7 +286,7 @@ def test_attach_sqlite(data_dir, tmp_path):
     con = ibis.duckdb.connect()
 
     con.attach_sqlite(test_db_path)
-    assert set(con.list_tables()) >= {
+    assert set(con.list()) >= {
         "functional_alltypes",
         "awards_players",
         "batting",
@@ -298,7 +298,7 @@ def test_attach_sqlite(data_dir, tmp_path):
 
     # overwrite existing sqlite_db and force schema to all strings
     con.attach_sqlite(test_db_path, overwrite=True, all_varchar=True)
-    assert set(con.list_tables()) >= {
+    assert set(con.list()) >= {
         "functional_alltypes",
         "awards_players",
         "batting",

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -27,8 +27,8 @@ def tempdir_sink_configs():
 
 @pytest.mark.parametrize("temp", [True, False])
 def test_list_tables(con, temp):
-    assert len(con.list_tables(temp=temp))
-    assert con.list_tables(catalog="default_catalog", database="default_database")
+    assert len(con.list(temp=temp))
+    assert con.list(catalog="default_catalog", database="default_database")
 
 
 def test_create_table_from_schema(
@@ -132,7 +132,7 @@ def test_recreate_in_mem_table(con, schema, table_name, temp_table, csv_source_c
         temp=True,
     )
     try:
-        assert temp_table in con.list_tables()
+        assert temp_table in con.list()
         if schema is not None:
             assert new_table.schema() == schema
 
@@ -175,7 +175,7 @@ def test_force_recreate_in_mem_table(con, schema_props, temp_table, csv_source_c
         temp=True,
     )
     try:
-        assert temp_table in con.list_tables()
+        assert temp_table in con.list()
         if schema is not None:
             assert new_table.schema() == schema
 
@@ -188,7 +188,7 @@ def test_force_recreate_in_mem_table(con, schema_props, temp_table, csv_source_c
             temp=True,
             overwrite=True,
         )
-        assert temp_table in con.list_tables()
+        assert temp_table in con.list()
         if schema is not None:
             assert new_table.schema() == schema
     finally:
@@ -299,7 +299,7 @@ def test_create_view(
         temp=temp,
         overwrite=False,
     )
-    view_list = sorted(con.list_tables())
+    view_list = sorted(con.list_views())
     assert temp_view in view_list
 
     # Try to re-create the same view with `force=False`
@@ -311,7 +311,7 @@ def test_create_view(
             temp=temp,
             overwrite=False,
         )
-    assert view_list == sorted(con.list_tables())
+    assert view_list == sorted(con.list_views())
 
     # Try to re-create the same view with `force=True`
     con.create_view(
@@ -321,7 +321,7 @@ def test_create_view(
         temp=temp,
         overwrite=False,
     )
-    assert view_list == sorted(con.list_tables())
+    assert view_list == sorted(con.list_views())
 
     # Overwrite the view
     con.create_view(
@@ -331,10 +331,10 @@ def test_create_view(
         temp=temp,
         overwrite=True,
     )
-    assert view_list == sorted(con.list_tables())
+    assert view_list == sorted(con.list_views())
 
     con.drop_view(name=temp_view, temp=temp, force=True)
-    assert temp_view not in con.list_tables()
+    assert temp_view not in con.list_views()
 
 
 def test_rename_table(con, awards_players_schema, temp_table, csv_source_configs):

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -208,8 +208,27 @@ class Backend(SQLBackend):
             databases = fetchall(cur)
         return self._filter_with_like(databases.name.tolist(), like)
 
+    def list(self, like=None, database=None):
+        """List the names of tables and views in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern in Python's regex format.
+        database
+            The database from which to list tables/views.
+            If not provided, the current database is used.
+
+        Returns
+        -------
+        list[str]
+            The list of table/view names that match the
+            pattern `like`.
+        """
+        return self.list_tables(like=like, database=database)
+
     def list_tables(self, like=None, database=None):
-        """Return the list of table names in the current database.
+        """List the names of tables in the database.
 
         Parameters
         ----------
@@ -224,6 +243,12 @@ class Backend(SQLBackend):
         list[str]
             The list of the table names that match the pattern `like`.
         """
+
+        # TODO (mehmet): Impala SQL does not seem to have a way to list
+        # the views. We could run DESCRIBE FORMATTED query for each
+        # table and check if it is view. But this would obviously be
+        # costly.
+        # Ref: https://impala.apache.org/docs/build/html/topics/impala_describe.html
 
         statement = "SHOW TABLES"
         if database is not None:

--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -114,8 +114,8 @@ def test_glorious_length_function_hack(con, string):
     assert result == len(string)
 
 
-def test_list_tables_schema_warning_refactor(con):
-    assert set(con.list_tables()) >= {
+def test_list_schema_warning_refactor(con):
+    assert set(con.list()) >= {
         "astronauts",
         "awards_players",
         "batting",
@@ -127,10 +127,7 @@ def test_list_tables_schema_warning_refactor(con):
     restore_tables = ["restorefile", "restorefilegroup", "restorehistory"]
 
     with pytest.warns(FutureWarning):
-        assert (
-            con.list_tables(database="msdb", schema="dbo", like="restore")
-            == restore_tables
-        )
+        assert con.list(database="msdb", schema="dbo", like="restore") == restore_tables
 
-    assert con.list_tables(database="msdb.dbo", like="restore") == restore_tables
-    assert con.list_tables(database=("msdb", "dbo"), like="restore") == restore_tables
+    assert con.list(database="msdb.dbo", like="restore") == restore_tables
+    assert con.list(database=("msdb", "dbo"), like="restore") == restore_tables

--- a/ibis/backends/oracle/tests/test_client.py
+++ b/ibis/backends/oracle/tests/test_client.py
@@ -62,12 +62,12 @@ def test_builtin_agg_udf(con):
 
 
 def test_list_tables_schema_warning_refactor(con):
-    assert con.list_tables()
+    assert con.list()
 
     with pytest.raises(exc.IbisInputError):
-        con.list_tables(database="not none", schema="not none")
+        con.list(database="not none", schema="not none")
 
     with pytest.warns(FutureWarning):
-        assert con.list_tables(schema="SYS", like="EXU8OPT") == ["EXU8OPT"]
+        assert con.list(schema="SYS", like="EXU8OPT") == ["EXU8OPT"]
 
-    assert con.list_tables(database="SYS", like="EXU8OPT") == ["EXU8OPT"]
+    assert con.list(database="SYS", like="EXU8OPT") == ["EXU8OPT"]

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -148,8 +148,25 @@ class BasePandasBackend(BaseBackend, NoUrl):
     def version(self) -> str:
         return pd.__version__
 
+    def list(self, like=None, database=None):
+        """List the names of tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern in Python's regex format.
+        database
+            Unused in the pandas backend.
+
+        Returns
+        -------
+        list[str]
+            The list of table names that match the pattern `like`.
+        """
+        return self.list_tables()
+
     def list_tables(self, like=None, database=None):
-        """Return the list of table names in the current database.
+        """List the names of tables in the database.
 
         Parameters
         ----------
@@ -229,6 +246,9 @@ class BasePandasBackend(BaseBackend, NoUrl):
         database: str | None = None,
         overwrite: bool = False,
     ) -> ir.Table:
+        # TODO (mehmet): Should we remove this to decouple
+        # views from tables across all backends?
+        # E.g., `polars` backend does not implement this.
         return self.create_table(
             name, obj=obj, temp=None, database=database, overwrite=overwrite
         )

--- a/ibis/backends/pandas/executor.py
+++ b/ibis/backends/pandas/executor.py
@@ -290,6 +290,7 @@ class PandasExecutor(Dispatched, PandasUtils):
             def agg(df):
                 indices = func(df[key.name])
                 return df[arg.name].iloc[indices]
+
         else:
 
             def agg(df):
@@ -316,6 +317,7 @@ class PandasExecutor(Dispatched, PandasUtils):
 
             def agg(df):
                 return df[left.name].corr(df[right.name])
+
         else:
 
             def agg(df):
@@ -333,6 +335,7 @@ class PandasExecutor(Dispatched, PandasUtils):
 
             def agg(df):
                 return df[left.name].cov(df[right.name], ddof=ddof)
+
         else:
 
             def agg(df):
@@ -349,6 +352,7 @@ class PandasExecutor(Dispatched, PandasUtils):
 
             def agg(df):
                 return sep.join(df[arg.name].astype(str))
+
         else:
 
             def agg(df):

--- a/ibis/backends/pandas/helpers.py
+++ b/ibis/backends/pandas/helpers.py
@@ -72,6 +72,7 @@ class PandasUtils:
 
             def applier(df):
                 return func(df[arg_column.name])
+
         else:
 
             def applier(df):

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -68,7 +68,41 @@ class Backend(BaseBackend, NoUrl):
     def version(self) -> str:
         return pl.__version__
 
+    def list(self, like=None, database=None):
+        """List the names of tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern in Python's regex format.
+        database
+            Unused in the polars backend.
+
+        Returns
+        -------
+        list[str]
+            The list of table names that match the pattern `like`.
+        """
+        # TODO (mehmet): Added this function explicitly for docs
+        # purposes.  Would it be cleaner to defined it as `self.list =
+        # self.list_tables`?
+        return self.list_tables(like=like, database=database)
+
     def list_tables(self, like=None, database=None):
+        """List the names of tables in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern in Python's regex format.
+        database
+            Unused in the polars backend.
+
+        Returns
+        -------
+        list[str]
+            The list of table names that match the pattern `like`.
+        """
         return self._filter_with_like(list(self._tables.keys()), like)
 
     def table(self, name: str, _schema: sch.Schema | None = None) -> ir.Table:

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -61,15 +61,15 @@ def test_simple_aggregate_execute(alltypes):
     assert isinstance(v, float)
 
 
-def test_list_tables(con):
+def test_list(con):
     assert len(con.list_tables(like="functional")) == 1
     assert {"astronauts", "batting", "diamonds"} <= set(con.list_tables())
 
     _ = con.create_table("tempy", schema=ibis.schema(dict(id="int")), temp=True)
 
-    assert "tempy" in con.list_tables()
+    assert "tempy" in con.list()
     # temp tables only show up when database='public' (or default)
-    assert "tempy" not in con.list_tables(database="tiger")
+    assert "tempy" not in con.list(database="tiger")
 
 
 def test_compile_toplevel(assert_sql):
@@ -192,7 +192,7 @@ def test_unknown_column_type(con, col):
 
 def test_insert_with_cte(con):
     X = con.create_table("X", schema=ibis.schema(dict(id="int")), temp=True)
-    assert "X" in con.list_tables()
+    assert "X" in con.list()
     expr = X.join(X.mutate(a=X["id"] + 1), ["id"])
     Y = con.create_table("Y", expr, temp=True)
     assert Y.execute().empty

--- a/ibis/backends/pyspark/converter.py
+++ b/ibis/backends/pyspark/converter.py
@@ -30,6 +30,7 @@ class PySparkPandasData(PandasData):
                     return value.astimezone(tz).replace(tzinfo=None)
                 except TypeError:
                     return value.tz_localize(tz).replace(tzinfo=None)
+
         else:
             tz = normalize_timezone(dtype.timezone)
 

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -35,7 +35,19 @@ class TestConf(BackendTest):
             t = s.read.parquet(path).repartition(num_partitions)
             if (sort_col := sort_cols.get(name)) is not None:
                 t = t.sort(sort_col)
+            # TODO (mehmet): Why are all created as views here?
+            # Why not use `self.connection.create_table()`?
+            # Update: It seems temporary tables are not allowed
+            # in Spark and creating tables here instead of views
+            # would require deleting them at the end of the tests.
+            # Is this the reason they were created as views in
+            # the first place?
             t.createOrReplaceTempView(name)
+
+            # TODO (mehmet): Getting the dataframe with `t.toPandas()`
+            # to maintain the outcome of `repartition()` and `sort()`
+            # performed above. Is this really necessary?
+            # self.connection.create_table(name=name, obj=t.toPandas(), overwrite=True)
 
         s.createDataFrame([(1, "a")], ["foo", "bar"]).createOrReplaceTempView("simple")
 

--- a/ibis/backends/pyspark/tests/test_ddl.py
+++ b/ibis/backends/pyspark/tests/test_ddl.py
@@ -26,7 +26,7 @@ def test_create_exists_view(con, alltypes, temp_view):
     t1 = alltypes.group_by("string_col").size()
     t2 = con.create_view(temp_view, t1)
 
-    assert temp_view in con.list_tables()
+    assert temp_view in con.list_views()
     # just check it works for now
     assert t2.execute() is not None
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -398,9 +398,9 @@ def test_nullable_input_output(con, temp_table):
 def test_create_drop_view(ddl_con, temp_view):
     # setup
     table_name = "functional_alltypes"
-    tables = ddl_con.list_tables()
+    tabulars = ddl_con.list()
 
-    if table_name in tables or (table_name := table_name.upper()) in tables:
+    if table_name in tabulars or (table_name := table_name.upper()) in tabulars:
         expr = ddl_con.table(table_name)
     else:
         raise ValueError(f"table `{table_name}` does not exist")
@@ -410,7 +410,7 @@ def test_create_drop_view(ddl_con, temp_view):
     # create a new view
     ddl_con.create_view(temp_view, expr)
     # check if the view was created
-    assert temp_view in ddl_con.list_tables()
+    assert temp_view in ddl_con.list()
 
     t_expr = ddl_con.table(table_name)
     v_expr = ddl_con.table(temp_view)

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -103,7 +103,7 @@ def test_register_csv(con, data_dir, fname, in_table_name, out_table_name):
         with pytest.warns(FutureWarning, match="v9.1"):
             table = con.register(fname, table_name=in_table_name)
 
-    assert any(out_table_name in t for t in con.list_tables())
+    assert any(out_table_name in t for t in con.list())
     if con.name != "datafusion":
         table.count().execute()
 
@@ -226,7 +226,7 @@ def test_register_parquet(
         with pytest.warns(FutureWarning, match="v9.1"):
             table = con.register(f"parquet://{fname.name}", table_name=in_table_name)
 
-        assert any(out_table_name in t for t in con.list_tables())
+    assert any(out_table_name in t for t in con.list())
 
     if con.name != "datafusion":
         table.count().execute()
@@ -273,7 +273,7 @@ def test_register_iterator_parquet(
                 table_name=None,
             )
 
-    assert any("ibis_read_parquet" in t for t in con.list_tables())
+    assert any("ibis_read_parquet" in t for t in con.list())
     assert table.count().execute()
 
 

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -206,30 +206,61 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             databases = cur.fetchall()
         return self._filter_with_like(list(map(itemgetter(0), databases)), like)
 
-    def list_tables(
+    def list(
         self,
         like: str | None = None,
         database: tuple[str, str] | str | None = None,
         schema: str | None = None,
     ) -> list[str]:
-        """List the tables in the database.
+        """List the names of tables and views in the database.
 
         Parameters
         ----------
         like
-            A pattern to use for listing tables.
+            A pattern to use for listing tables/views.
         database
             The database location to perform the list against.
 
             By default uses the current `database` (`self.current_database`) and
             `catalog` (`self.current_catalog`).
 
-            To specify a table in a separate catalog, you can pass in the
+            To specify a table/view in a separate catalog, you can pass in the
             catalog and database as a string `"catalog.database"`, or as a tuple of
             strings `("catalog", "database")`.
         schema
             [deprecated] The schema inside `database` to perform the list against.
         """
+        return self.list_tables(like=like, database=database, schema=schema)
+
+    def list_tables(
+        self,
+        like: str | None = None,
+        database: tuple[str, str] | str | None = None,
+        schema: str | None = None,
+    ) -> list[str]:
+        """List the names of tables and views in the database.
+
+        Parameters
+        ----------
+        like
+            A pattern to use for listing tables/views.
+        database
+            The database location to perform the list against.
+
+            By default uses the current `database` (`self.current_database`) and
+            `catalog` (`self.current_catalog`).
+
+            To specify a table/view in a separate catalog, you can pass in the
+            catalog and database as a string `"catalog.database"`, or as a tuple of
+            strings `("catalog", "database")`.
+        schema
+            [deprecated] The schema inside `database` to perform the list against.
+        """
+
+        # TODO (mehmet): Trino does not seem to allow for showing
+        # only the views.
+        # Ref: https://trino.io/docs/current/sql/show-tables.html
+
         table_loc = self._warn_and_create_table_loc(database, schema)
 
         query = "SHOW TABLES"

--- a/ibis/examples/tests/test_examples.py
+++ b/ibis/examples/tests/test_examples.py
@@ -84,7 +84,7 @@ def test_non_example():
 def test_backend_arg():
     con = ibis.duckdb.connect()
     t = ibis.examples.penguins.fetch(backend=con)
-    assert t.get_name() in con.list_tables()
+    assert t.get_name() in con.list()
 
 
 @pytest.mark.duckdb


### PR DESCRIPTION
## Description of changes

First step towards addressing https://github.com/ibis-project/ibis/issues/8382.

This
- Adds `no_views` arg to `list_tables()` for clickhouse, Flink and pyspark backends.

Asking for early feedback. If the change is reasonable, will proceed to make the same change for the remaining backends.

**Edit**: After the discussion on this PR:
* Made `list_tables()` and `list_views()` explicit.
  * For some of the backends, I could not find a direct way to distinguish views from the tables. Added `TODO` comments to decide for those during the reviews.
* Added `list()` to list tables and views together.