### PR TITLE
fix: disallow empty struct

### DIFF
--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -170,7 +170,9 @@ class Backend(BasePandasBackend, NoUrl):
             schema = self.schemas[table_name]
         except KeyError:
             df = self.dictionary[table_name]
-            self.schemas[table_name] = schema = PandasData.infer_table(df.head(1))
+            if isinstance(df, dd.DataFrame):
+                df = df.compute()
+            self.schemas[table_name] = schema = PandasData.infer_table(df)
 
         return schema
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -828,6 +828,11 @@ class Struct(Parametric, MapSet):
     scalar = "StructScalar"
     column = "StructColumn"
 
+    def __init__(self, fields, **kwargs):
+        if fields is None or len(fields) == 0:
+            raise ValueError("Empty struct type is not supported")
+        super().__init__(fields=fields, **kwargs)
+
     @classmethod
     def from_tuples(
         cls, pairs: Iterable[tuple[str, str | DataType]], nullable: bool = True

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -830,7 +830,7 @@ class Struct(Parametric, MapSet):
 
     def __init__(self, fields, **kwargs):
         if fields is None or len(fields) == 0:
-            raise ValueError("Empty struct type is not supported")
+            raise TypeError("Empty struct type is not supported")
         super().__init__(fields=fields, **kwargs)
 
     @classmethod

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -42,8 +42,6 @@ def infer(value: Any) -> dt.DataType:
 @infer.register(collections.OrderedDict)
 def infer_struct(value: Mapping[str, Any]) -> dt.Struct:
     """Infer the [`Struct`](./datatypes.qmd#ibis.expr.datatypes.Struct) type of `value`."""
-    if not value:
-        raise TypeError("Empty struct type not supported")
     fields = {name: infer(val) for name, val in value.items()}
     return dt.Struct(fields)
 

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -90,8 +90,6 @@ class PyArrowType(TypeMapper):
             value_dtype = cls.to_ibis(typ.value_type, typ.value_field.nullable)
             return dt.Array(value_dtype, nullable=nullable)
         elif pa.types.is_struct(typ):
-            if typ.num_fields == 0:
-                raise ValueError("Empty struct type is not supported")
             field_dtypes = {
                 field.name: cls.to_ibis(field.type, field.nullable) for field in typ
             }

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -90,6 +90,8 @@ class PyArrowType(TypeMapper):
             value_dtype = cls.to_ibis(typ.value_type, typ.value_field.nullable)
             return dt.Array(value_dtype, nullable=nullable)
         elif pa.types.is_struct(typ):
+            if typ.num_fields == 0:
+                raise ValueError("Empty struct type is not supported")
             field_dtypes = {
                 field.name: cls.to_ibis(field.type, field.nullable) for field in typ
             }

--- a/ibis/formats/tests/test_pandas.py
+++ b/ibis/formats/tests/test_pandas.py
@@ -431,3 +431,11 @@ def test_convert_dataframe_with_timezone():
     desired_schema = ibis.schema(dict(time='timestamp("EST")'))
     result = PandasData.convert_table(df.copy(), desired_schema)
     tm.assert_frame_equal(expected, result)
+
+
+@pytest.mark.parametrize(
+    "df", [pd.DataFrame({"a": [{}, {}, {}]}), pd.DataFrame({"a": [{}, None]})]
+)
+def test_empty_struct_not_allowed(df):
+    with pytest.raises(TypeError):
+        PandasData.infer_table(df)

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -128,11 +128,6 @@ def test_struct_literal_non_castable(value):
         ibis.struct(value, type=typestr)
 
 
-def test_struct_cast_to_empty_struct():
-    value = ibis.struct({"a": 1, "b": 2.0})
-    assert value.type().castable(dt.Struct({}))
-
-
 @pytest.mark.parametrize(
     "value",
     [

--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -98,3 +98,19 @@ def test_nested_lift():
     )
     expr = t.a.b.lift()
     assert expr.schema() == ibis.schema({"x": "int", "y": "int"})
+
+
+def test_empty_struct():
+    with pytest.raises(ValueError, match="Empty struct type is not supported"):
+        ibis.memtable(
+            [
+                {
+                    "year": "2024",
+                    "period": "M01",
+                    "periodName": "January",
+                    "latest": "true",
+                    "value": "3.7",
+                    "footnotes": {},
+                }
+            ]
+        )

--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -101,16 +101,5 @@ def test_nested_lift():
 
 
 def test_empty_struct():
-    with pytest.raises(ValueError, match="Empty struct type is not supported"):
-        ibis.memtable(
-            [
-                {
-                    "year": "2024",
-                    "period": "M01",
-                    "periodName": "January",
-                    "latest": "true",
-                    "value": "3.7",
-                    "footnotes": {},
-                }
-            ]
-        )
+    with pytest.raises(TypeError, match="Empty struct type is not supported"):
+        ibis.memtable([{"year": "2024", "footnotes": {}}])

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -168,7 +168,7 @@ def struct_dtypes(
     draw,
     types=_item_strategy,
     names=_any_text,
-    num_fields=st.integers(min_value=0, max_value=20),  # noqa: B008
+    num_fields=st.integers(min_value=1, max_value=20),  # noqa: B008
     nullable=_nullable,
 ):
     num_fields = draw(num_fields)


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Disallow empty struct in type inference. Pyarrow allows the construction of empty structs but duckdb doesn't.

I think what the user in #8460 was attempting to create was an empty value in a struct column that has defined fields. You can accomplish this with the following:

```python
>>> import ibis
>>>
>>> ibis.options.interactive = True
>>>
>>> t = ibis.memtable(
...             [
...                 {
...                     "year": "2024",
...                     "period": "M01",
...                     "periodName": "January",
...                     "latest": "true",
...                     "value": "3.7",
...                     "footnotes": None,
...                 }
...             ],
...             schema={"year": "string", "period": "string", "periodName": "string", "latest": "string", "value": "string", "footnotes": "struct<key: string>"}
...         )
>>> t
┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━┓
┃ year   ┃ period ┃ periodName ┃ latest ┃ value  ┃ footnotes ┃
┡━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━┩
│ string │ string │ string     │ string │ string │ struct<k… │
├────────┼────────┼────────────┼────────┼────────┼───────────┤
│ 2024   │ M01    │ January    │ true   │ 3.7    │ NULL      │
└────────┴────────┴────────────┴────────┴────────┴───────────┘
```

I do want to note here that ibis interprets `{}` as a struct whose keys point to empty values rather than a struct that is empty:

```python
>>> t = ibis.memtable(
...             [
...                 {
...                     "year": "2024",
...                     "period": "M01",
...                     "periodName": "January",
...                     "latest": "true",
...                     "value": "3.7",
...                     "footnotes": {},
...                 }
...             ],
...             schema={"year": "string", "period": "string", "periodName": "string", "latest": "string", "value": "string", "footnotes": "struct<key: string>"}
...         )
>>> t
┏━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
┃ year   ┃ period ┃ periodName ┃ latest ┃ value  ┃ footnotes            ┃
┡━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
│ string │ string │ string     │ string │ string │ struct<key: string>  │
├────────┼────────┼────────────┼────────┼────────┼──────────────────────┤
│ 2024   │ M01    │ January    │ true   │ 3.7    │ {'key': None}        │
└────────┴────────┴────────────┴────────┴────────┴──────────────────────┘
```

## Issues closed

#8460