### PR TITLE
feat(ir): add default implementation of pretty formatting nodes

### DIFF
--- a/ibis/expr/format.py
+++ b/ibis/expr/format.py
@@ -169,7 +169,7 @@ class Rendered(str):
 
 
 @public
-def pretty(expr: ir.Expr, scope: Optional[dict[str, ir.Expr]] = None):
+def pretty(expr: ops.Node | ir.Expr, scope: Optional[dict[str, ir.Expr]] = None):
     """Pretty print an expression.
 
     Parameters
@@ -186,10 +186,13 @@ def pretty(expr: ir.Expr, scope: Optional[dict[str, ir.Expr]] = None):
     str
         A pretty printed representation of the expression.
     """
-    if not isinstance(expr, ir.Expr):
-        raise TypeError(f"Expected an expression, got {type(expr)}")
+    if isinstance(expr, ir.Expr):
+        node = expr.op()
+    elif isinstance(expr, ops.Node):
+        node = expr
+    else:
+        raise TypeError(f"Expected an expression or a node, got {type(expr)}")
 
-    node = expr.op()
     refs = {}
     refcnt = itertools.count()
     variables = {v.op(): k for k, v in (scope or {}).items()}
@@ -224,7 +227,8 @@ def pretty(expr: ir.Expr, scope: Optional[dict[str, ir.Expr]] = None):
 
 @functools.singledispatch
 def fmt(op, **kwargs):
-    raise NotImplementedError(f"no pretty printer for {type(op)}")
+    top = f"{op.__class__.__name__}\n"
+    return top + render_fields(kwargs, 1)
 
 
 @fmt.register(ops.Relation)

--- a/ibis/expr/tests/snapshots/test_format/test_default_format_implementation/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_default_format_implementation/repr.txt
@@ -1,0 +1,9 @@
+r0 := UnboundTable: t
+  a int64
+
+ValueList
+  values:
+    1
+    2.0
+    'three'
+    r0.a


### PR DESCRIPTION
We have custom nodes for example to lower expressions to certain backends. Pretty printing these are especially useful but currently we raise for unknown node types.