### PR TITLE
test(benchmarks): fix constructing large benchmark expression

### DIFF
--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -87,7 +87,7 @@ def make_large_expr(base):
         _timestamp=(src_table["_timestamp"] - src_table["_timestamp"] % 3600)
         .cast("int32")
         .name("_timestamp"),
-        valid_seconds=300,
+        valid_seconds=ibis.literal(300),
     )
 
     aggs = []


### PR DESCRIPTION
Fixing build error: https://github.com/ibis-project/ibis/actions/runs/8541350879/job/23400454706