### PR TITLE
refactor(api): treat integer inputs as literals instead of column references

### DIFF
--- a/ibis/tests/expr/test_selectors.py
+++ b/ibis/tests/expr/test_selectors.py
@@ -342,7 +342,7 @@ def test_if_any(penguins):
 
 
 def test_negate_range(penguins):
-    assert penguins.select(~s.r[3:]).equals(penguins.select(0, 1, 2))
+    assert penguins.select(~s.r[3:]).equals(penguins[[0, 1, 2]])
 
 
 def test_string_range_start(penguins):
@@ -378,16 +378,15 @@ def test_all(penguins):
 @pytest.mark.parametrize(
     ("seq", "expected"),
     [
-        param([0, 1, 2], (0, 1, 2), id="int_tuple"),
         param(~s.r[[3, 4, 5]], sorted(set(range(8)) - {3, 4, 5}), id="neg_int_list"),
         param(~s.r[3, 4, 5], sorted(set(range(8)) - {3, 4, 5}), id="neg_int_tuple"),
         param(s.r["island", "year"], ("island", "year"), id="string_tuple"),
         param(s.r[["island", "year"]], ("island", "year"), id="string_list"),
-        param(iter(["island", 4, "year"]), ("island", 4, "year"), id="mixed_iterable"),
+        param(iter(["island", "year"]), ("island", "year"), id="mixed_iterable"),
     ],
 )
 def test_sequence(penguins, seq, expected):
-    assert penguins.select(seq).equals(penguins.select(*expected))
+    assert penguins.select(seq).equals(penguins[expected])
 
 
 def test_names_callable(penguins):

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -19,7 +19,12 @@ import ibis.selectors as s
 from ibis import _
 from ibis.common.annotations import ValidationError
 from ibis.common.deferred import Deferred
-from ibis.common.exceptions import ExpressionError, IntegrityError, RelationError
+from ibis.common.exceptions import (
+    ExpressionError,
+    IbisTypeError,
+    IntegrityError,
+    RelationError,
+)
 from ibis.expr import api
 from ibis.expr.rewrites import simplify
 from ibis.expr.tests.test_newrels import join_tables
@@ -230,7 +235,7 @@ def test_projection_with_star_expr(table):
 
     # cannot pass an invalid table expression
     t2 = t.aggregate([t["a"].sum().name("sum(a)")], by=["g"])
-    with pytest.raises(IntegrityError):
+    with pytest.raises(IbisTypeError):
         t[[t2]]
     # TODO: there may be some ways this can be invalid
 
@@ -581,10 +586,8 @@ def test_order_by_scalar(table, key, expected):
     ("key", "exc_type"),
     [
         ("bogus", com.IbisTypeError),
-        # (("bogus", False), com.IbisTypeError),
+        (("bogus", False), com.IbisTypeError),
         (ibis.desc("bogus"), com.IbisTypeError),
-        (1000, IndexError),
-        # ((1000, False), IndexError),
         (_.bogus, AttributeError),
         (_.bogus.desc(), AttributeError),
     ],
@@ -746,7 +749,7 @@ def test_aggregate_keywords(table):
 def test_select_on_literals(table):
     # literal ints and strings are column indices, everything else is a value
     expr1 = table.select(col1=True, col2=1, col3="a")
-    expr2 = table.select(col1=ibis.literal(True), col2=table.b, col3=table.a)
+    expr2 = table.select(col1=ibis.literal(True), col2=ibis.literal(1), col3=table.a)
     assert expr1.equals(expr2)
 
 
@@ -1280,7 +1283,7 @@ def test_inner_join_overlapping_column_names():
         lambda t1, t2: [(t1.foo_id, t2.foo_id)],
         lambda t1, t2: [(_.foo_id, _.foo_id)],
         lambda t1, t2: [(t1.foo_id, _.foo_id)],
-        lambda t1, t2: [(2, 0)],  # foo_id is 2nd in t1, 0th in t2
+        lambda t1, t2: [(t1[2], t2[0])],  # foo_id is 2nd in t1, 0th in t2
         lambda t1, t2: [(lambda t: t.foo_id, lambda t: t.foo_id)],
     ],
 )

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -882,18 +882,10 @@ def test_bitwise_exprs(fn, expected_op):
         ([1, 0], ["bar", "foo"]),
     ],
 )
-@pytest.mark.parametrize(
-    "expr_func",
-    [
-        lambda t, args: t[args],
-        lambda t, args: t.order_by(args),
-        lambda t, args: t.group_by(args).aggregate(bar_avg=t.bar.mean()),
-    ],
-)
-def test_table_operations_with_integer_column(position, names, expr_func):
+def test_table_operations_with_integer_column(position, names):
     t = ibis.table([("foo", "string"), ("bar", "double")])
-    result = expr_func(t, position)
-    expected = expr_func(t, names)
+    result = t[position]
+    expected = t[names]
     assert result.equals(expected)
 
 


### PR DESCRIPTION
Removing the int-as-column references in mutate and select. Further discussed in #8878.

BREAKING CHANGE: Integer inputs to `select` and `mutate` are now always interpreted as literals. Columns can still be accessed by their integer index using square-bracket syntax.