### PR TITLE
feat: support UUIDs to pyarrow on more backends

### DIFF
--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -1144,7 +1144,6 @@ class Backend(SQLBackend):
         limit: int | str | None = None,
         **kwargs: Any,
     ) -> pa.Table:
-        import pyarrow as pa
         import pyarrow_hotfix  # noqa: F401
 
         from ibis.formats.pyarrow import PyArrowData
@@ -1152,12 +1151,9 @@ class Backend(SQLBackend):
         self._run_pre_execute_hooks(expr)
 
         table_expr = expr.as_table()
-        output = pa.Table.from_pandas(
-            self.execute(table_expr, params=params, limit=limit, **kwargs),
-            preserve_index=False,
-        )
-        table = PyArrowData.convert_table(output, table_expr.schema())
-        return expr.__pyarrow_result__(table)
+        df = self.execute(table_expr, params=params, limit=limit, **kwargs)
+        pa_table = PyArrowData.convert_table(df, table_expr.schema())
+        return expr.__pyarrow_result__(pa_table)
 
     def to_pyarrow_batches(
         self,

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1556,9 +1556,14 @@ def test_close_connection(con):
     reason="JSON type not implemented",
 )
 @pytest.mark.notimpl(
-    ["risingwave", "sqlite"],
+    ["risingwave"],
     raises=pa.ArrowTypeError,
     reason="mismatch between output value and expected input type",
+)
+@pytest.mark.notimpl(
+    ["sqlite"],
+    raises=pa.ArrowInvalid,
+    reason="cannot mix list and non-list, non-null values",
 )
 @pytest.mark.never(
     ["snowflake"],

--- a/ibis/backends/tests/test_uuid.py
+++ b/ibis/backends/tests/test_uuid.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import uuid
 
+import pyarrow as pa
 import pytest
 
 import ibis
@@ -63,3 +64,17 @@ def test_uuid_unique_each_row(con):
         con.tables.functional_alltypes.mutate(uuid=ibis.uuid()).limit(2).uuid.nunique()
     )
     assert expr.execute() == 2
+
+
+@pytest.mark.notimpl(
+    ["druid", "exasol", "oracle", "polars", "pyspark", "risingwave"],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.notimpl(
+    ["clickhouse", "postgres", "trino"],
+    reason="Expected bytes, got a 'UUID' object. https://github.com/ibis-project/ibis/issues/8902",
+    raises=pa.lib.ArrowTypeError,
+)
+@pytest.mark.notimpl(["pandas", "dask"], raises=com.OperationNotDefinedError)
+def test_uuid_to_pyarrow(con):
+    con.to_pyarrow(ibis.uuid())


### PR DESCRIPTION
partially fixes #8902.

Implements UUID execution to pyarrow on some backends, and adds notimpl tests for the rest.