### PR TITLE
feat(postgres): use port in connection string

### DIFF
--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -60,7 +60,6 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             A backend instance
 
         """
-
         url = urlparse(url)
         database, *schema = url.path[1:].split("/", 1)
         query_params = parse_qs(url.query)
@@ -70,6 +69,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             "host": url.hostname,
             "database": database or "",
             "schema": schema[0] if schema else "",
+            "port": url.port,
         }
 
         for name, value in query_params.items():
@@ -97,6 +97,9 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
 
         if "password" in kwargs and kwargs["password"] is None:
             del kwargs["password"]
+
+        if "port" in kwargs and kwargs["port"] is None:
+            del kwargs["port"]
 
         return self.connect(**kwargs)
 

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -26,6 +26,7 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
+from ibis.backends.tests.errors import PsycoPg2OperationalError
 
 pytest.importorskip("psycopg2")
 
@@ -247,6 +248,12 @@ def test_timezone_from_column(contz, snapshot):
 
 def test_kwargs_passthrough_in_connect():
     con = ibis.connect(
-        "postgresql://postgres:postgres@localhost/ibis_testing?sslmode=allow"
+        "postgresql://postgres:postgres@localhost:5432/ibis_testing?sslmode=allow"
     )
     assert con.current_catalog == "ibis_testing"
+
+
+def test_port():
+    # check that we parse and use the port (and then of course fail cuz it's bogus)
+    with pytest.raises(PsycoPg2OperationalError):
+        ibis.connect("postgresql://postgres:postgres@localhost:1337/ibis_testing")


### PR DESCRIPTION
Before this was just ignored, so if you tryied to connect to
anything besides port 5432, it would
just use the default of 5432