### PR TITLE
feat(ir): more flexible dereferencing for join right-hand side

### DIFF
--- a/ibis/backends/impala/tests/snapshots/test_sql/test_join_aliasing/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_sql/test_join_aliasing/out.sql
@@ -62,7 +62,7 @@ INNER JOIN (
       GROUP BY
         1
     ) AS `t10`
-      ON `t8`.`d` = `t10`.`d`
+      ON `t10`.`d` = `t10`.`d`
   ) AS `t11`
   WHERE
     `t11`.`row_count` < (


### PR DESCRIPTION
The join dereferencing logic required explicit references to the exact right hand side table which disallowed more convenient syntaxes like `t1.join(t2.at_time(t1.c), [t1.a == t2.d])`. 

Resolves https://github.com/ibis-project/ibis/issues/8581