### PR TITLE
Adding `pipe` for method chaining

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -981,6 +981,9 @@ class Table(Expr, _FixedTextJupyterMixin):
         by = tuple(v for v in by if v is not None)
         groups = bind(self, (by, key_exprs))
         return GroupedTable(self, groups)
+    
+    def pipe(self, func, *args, **kwargs):
+        return func(self, *args, **kwargs)
 
     # TODO(kszucs): shouldn't this be ibis.rowid() instead not bound to a specific table?
     def rowid(self) -> ir.IntegerValue:


### PR DESCRIPTION
A first stab at https://github.com/ibis-project/ibis/issues/8926. This is totally to help get the ball rolling if folks prefer we discuss this in the issue first that's totally cool and I can create a new PR after.

## Description of changes

Adds a `.pipe()` method to allow for method chaining. 

## Issues closed

Resolves https://github.com/ibis-project/ibis/issues/8926