### PR TITLE
fix(risingwave): set implicit flush to true

### DIFF
--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -119,6 +119,7 @@ class Backend(PostgresBackend):
 
         with self.begin() as cur:
             cur.execute("SET TIMEZONE = UTC")
+            cur.execute("SET RW_IMPLICIT_FLUSH TO true;")
 
     def create_table(
         self,


### PR DESCRIPTION
Resolves #8780

If we set this option then the table expression doesn't render until the transaction is complete.
I _think_ this is a reasonable thing to do by default, but there may be
streaming-related side-effects that I'm not considering.  

@KeXiangWang -- does this seem ok to you?