### PR TITLE
test(backends): remove now unused `supports_window_operations` backend flag

### DIFF
--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -24,7 +24,6 @@ IBIS_TEST_CLICKHOUSE_DB = os.environ.get("IBIS_TEST_DATA_DB", "ibis_testing")
 
 class TestConf(ServiceBackendTest):
     check_dtype = False
-    supports_window_operations = False
     returned_timestamp_unit = "s"
     supported_to_timestamp_units = {"s"}
     supports_floating_modulus = False

--- a/ibis/backends/druid/tests/conftest.py
+++ b/ibis/backends/druid/tests/conftest.py
@@ -94,7 +94,6 @@ def run_query(session: Session, query: str) -> None:
 class TestConf(ServiceBackendTest):
     # druid has the same rounding behavior as postgres
     check_dtype = False
-    supports_window_operations = False
     returned_timestamp_unit = "s"
     supports_arrays = False
     supports_arrays_outside_of_select = supports_arrays

--- a/ibis/backends/exasol/tests/conftest.py
+++ b/ibis/backends/exasol/tests/conftest.py
@@ -28,7 +28,6 @@ class TestConf(ServiceBackendTest):
     check_names = False
     supports_arrays = False
     supports_arrays_outside_of_select = supports_arrays
-    supports_window_operations = True
     supports_divide_by_zero = False
     returned_timestamp_unit = "us"
     supported_to_timestamp_units = {"s", "ms", "us"}

--- a/ibis/backends/mssql/tests/conftest.py
+++ b/ibis/backends/mssql/tests/conftest.py
@@ -23,7 +23,6 @@ MSSQL_PYODBC_DRIVER = os.environ.get("IBIS_TEST_MSSQL_PYODBC_DRIVER", "FreeTDS")
 class TestConf(ServiceBackendTest):
     # MSSQL has the same rounding behavior as postgres
     check_dtype = False
-    supports_window_operations = False
     returned_timestamp_unit = "s"
     supports_arrays_outside_of_select = supports_arrays = False
     supports_structs = False

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -30,7 +30,6 @@ class TestConf(ServiceBackendTest):
     rounding_method = "half_to_even"
     service_name = "mysql"
     deps = ("pymysql",)
-    supports_window_operations = True
 
     @property
     def test_files(self) -> Iterable[Path]:

--- a/ibis/backends/oracle/tests/conftest.py
+++ b/ibis/backends/oracle/tests/conftest.py
@@ -34,7 +34,6 @@ oracledb.defaults.fetch_decimals = True
 
 class TestConf(ServiceBackendTest):
     check_dtype = False
-    supports_window_operations = False
     returned_timestamp_unit = "s"
     supports_arrays = False
     supports_arrays_outside_of_select = False

--- a/ibis/backends/sqlite/tests/conftest.py
+++ b/ibis/backends/sqlite/tests/conftest.py
@@ -17,7 +17,6 @@ from ibis.backends.tests.base import BackendTest
 class TestConf(BackendTest):
     supports_arrays = False
     supports_arrays_outside_of_select = supports_arrays
-    supports_window_operations = True
     check_dtype = False
     returned_timestamp_unit = "s"
     supports_structs = False

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -38,8 +38,6 @@ class BackendTest(abc.ABC):
     "Whether backend supports Arrays / Lists"
     supports_arrays_outside_of_select: bool = supports_arrays
     "Whether backend supports Arrays / Lists outside of Select Statements"
-    supports_window_operations: bool = True
-    "Whether backend supports Window Operations"
     supports_divide_by_zero: bool = False
     "Whether backend supports division by zero"
     returned_timestamp_unit: str = "us"


### PR DESCRIPTION
Test case configuration now happens through pytest markers.