### PR TITLE
test(backends): remove now unused `supports_divide_by_zero` backend flag

### DIFF
--- a/docs/contribute/05_reference.qmd
+++ b/docs/contribute/05_reference.qmd
@@ -18,7 +18,6 @@ from ibis.backends.tests.base import BackendTest
 class TestConf(BackendTest):
     """Backend-specific class with information for testing."""
 
-    supports_divide_by_zero = True
     supports_floating_modulus = False
     returned_timestamp_unit = "us"
     supports_structs = True

--- a/ibis/backends/bigquery/tests/conftest.py
+++ b/ibis/backends/bigquery/tests/conftest.py
@@ -21,7 +21,6 @@ PROJECT_ID_ENV_VAR = "GOOGLE_BIGQUERY_PROJECT_ID"
 class TestConf(BackendTest):
     """Backend-specific class with information for testing."""
 
-    supports_divide_by_zero = True
     supports_floating_modulus = False
     returned_timestamp_unit = "us"
     supports_structs = True

--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -12,7 +12,6 @@ from ibis.backends.tests.data import array_types, topk, win
 
 class TestConf(BackendTest):
     # check_names = False
-    # supports_divide_by_zero = True
     # returned_timestamp_unit = 'ns'
     supports_structs = False
     supports_json = False

--- a/ibis/backends/exasol/tests/conftest.py
+++ b/ibis/backends/exasol/tests/conftest.py
@@ -27,7 +27,6 @@ class TestConf(ServiceBackendTest):
     check_dtype = False
     check_names = False
     supports_arrays = False
-    supports_divide_by_zero = False
     returned_timestamp_unit = "us"
     supported_to_timestamp_units = {"s", "ms", "us"}
     supports_floating_modulus = True

--- a/ibis/backends/impala/tests/conftest.py
+++ b/ibis/backends/impala/tests/conftest.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
 class TestConf(BackendTest):
     supports_arrays = True
     check_dtype = False
-    supports_divide_by_zero = True
     returned_timestamp_unit = "s"
     supports_structs = False
     supports_json = False

--- a/ibis/backends/pandas/tests/conftest.py
+++ b/ibis/backends/pandas/tests/conftest.py
@@ -18,7 +18,6 @@ from ibis.backends.tests.data import array_types, json_types, struct_types, topk
 class TestConf(BackendTest):
     check_names = False
     supported_to_timestamp_units = BackendTest.supported_to_timestamp_units | {"ns"}
-    supports_divide_by_zero = True
     returned_timestamp_unit = "ns"
     stateful = False
     rounding_method = "half_to_even"

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -36,8 +36,6 @@ class BackendTest(abc.ABC):
     "Check that column name matches when comparing Pandas Series"
     supports_arrays: bool = True
     "Whether backend supports Arrays / Lists"
-    supports_divide_by_zero: bool = False
-    "Whether backend supports division by zero"
     returned_timestamp_unit: str = "us"
     supported_to_timestamp_units = {"s", "ms", "us"}
     supports_floating_modulus: bool = True


### PR DESCRIPTION
Test case configuration now happens through pytest markers.

depends on #8935 
