### PR TITLE
fix(duckdb): disable batching for calls to `arrow`

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1330,7 +1330,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         limit: int | str | None = None,
         **_: Any,
     ) -> pa.Table:
-        table = self._to_duckdb_relation(expr, params=params, limit=limit).arrow()
+        table = self._to_duckdb_relation(expr, params=params, limit=limit).arrow(
+            batch_size=0
+        )
         return expr.__pyarrow_result__(table)
 
     def execute(
@@ -1344,7 +1346,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         import pandas as pd
         import pyarrow.types as pat
 
-        table = self._to_duckdb_relation(expr, params=params, limit=limit).arrow()
+        table = self._to_duckdb_relation(expr, params=params, limit=limit).arrow(
+            batch_size=0
+        )
 
         df = pd.DataFrame(
             {


### PR DESCRIPTION
xref https://github.com/ibis-project/ibis/discussions/8896

This one took me a _while_ to figure out.

the `arrow` method has a `batch_size` kwarg that defaults to 1_000_000,
but the batch sizes aren't actually deterministic, they're just close to
that size. If the result-set is larger than `batch_size`, you can get
slightly different results because of the batching and where the
boundaries are.

I can add a test for this, but it will require a query that returns
north of a million rows and I don't know if we want that in our unit tests.