### PR TITLE
test: check for ordering with Table.distinct(keep=...)

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1144,12 +1144,7 @@ def test_pivot_wider(backend):
     reason="function last(double precision) does not exist, do you mean left or least",
 )
 def test_distinct_on_keep(backend, on, keep):
-    from ibis import _
-
-    t = backend.diamonds.mutate(one=ibis.literal(1)).mutate(
-        idx=ibis.row_number().over(order_by=_.one, rows=(None, 0))
-    )
-
+    t = backend.diamonds.mutate(idx=ibis.row_number())
     expr = t.distinct(on=on, keep=keep).order_by(ibis.asc("idx"))
     result = expr.execute()
     df = t.execute()
@@ -1209,11 +1204,7 @@ def test_distinct_on_keep(backend, on, keep):
     reason="function first(double precision) does not exist",
 )
 def test_distinct_on_keep_is_none(backend, on):
-    from ibis import _
-
-    t = backend.diamonds.mutate(one=ibis.literal(1)).mutate(
-        idx=ibis.row_number().over(order_by=_.one, rows=(None, 0))
-    )
+    t = backend.diamonds.mutate(idx=ibis.row_number())
 
     expr = t.distinct(on=on, keep=None).order_by(ibis.asc("idx"))
     result = expr.execute()

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1145,15 +1145,12 @@ def test_pivot_wider(backend):
 )
 def test_distinct_on_keep(backend, on, keep):
     t = backend.diamonds.mutate(idx=ibis.row_number())
-    expr = t.distinct(on=on, keep=keep).order_by(ibis.asc("idx"))
+    expr = t.distinct(on=on, keep=keep)
     result = expr.execute()
     df = t.execute()
-    expected = (
-        df.drop_duplicates(subset=on, keep=keep or False)
-        .sort_values(by=["idx"])
-        .reset_index(drop=True)
-    )
-    assert len(result) == len(expected)
+    expected = df.drop_duplicates(subset=on, keep=keep)
+    assert result.columns.tolist() == expected.columns.tolist()
+    assert set(result.idx) == set(expected.idx)
 
 
 @pytest.mark.parametrize(
@@ -1204,16 +1201,13 @@ def test_distinct_on_keep(backend, on, keep):
     reason="function first(double precision) does not exist",
 )
 def test_distinct_on_keep_is_none(backend, on):
-    t = backend.diamonds.mutate(idx=ibis.row_number())
-
-    expr = t.distinct(on=on, keep=None).order_by(ibis.asc("idx"))
+    t = backend.diamonds
+    expr = t.distinct(on=on, keep=None)
     result = expr.execute()
     df = t.execute()
-    expected = (
-        df.drop_duplicates(subset=on, keep=False)
-        .sort_values(by=["idx"])
-        .reset_index(drop=True)
-    )
+    expected = df.drop_duplicates(subset=on, keep=False)
+    # which row from each group isn't guaranteed, so we can't compare the actual rows
+    assert result.columns.tolist() == expected.columns.tolist()
     assert len(result) == len(expected)
 
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1144,11 +1144,12 @@ def test_pivot_wider(backend):
     reason="function last(double precision) does not exist, do you mean left or least",
 )
 def test_distinct_on_keep(backend, on, keep):
+    # We had better preserve previous ordering so that first/last are well-defined
     t = backend.diamonds.mutate(idx=ibis.row_number())
-    expr = t.distinct(on=on, keep=keep)
+    expr = t.order_by(t.columns).distinct(on=on, keep=keep)
     result = expr.execute()
     df = t.execute()
-    expected = df.drop_duplicates(subset=on, keep=keep)
+    expected = df.sort_values(t.columns).drop_duplicates(subset=on, keep=keep)
     assert result.columns.tolist() == expected.columns.tolist()
     assert set(result.idx) == set(expected.idx)
 


### PR DESCRIPTION
Before, we didn't actually verify that the resulting row from each group
was the first or last one. Now we order
beforehand, do the distinct, and then check that the ordering was preserved throughout.

I started poking because I think ibis is giving me wrong results here. Still need to dig in more, but the initial failing tests seem to corroborate that...