### PR TITLE
docs(altair): remove to_pandas from altair example

### DIFF
--- a/docs/how-to/visualization/altair.qmd
+++ b/docs/how-to/visualization/altair.qmd
@@ -23,7 +23,7 @@ in Ibis tables or expressions:
 import altair as alt
 
 chart = (
-    alt.Chart(t.group_by("species").agg(count=ibis._.count()).to_pandas())
+    alt.Chart(t.group_by("species").agg(count=ibis._.count()))
     .mark_bar()
     .encode(
         x="species",


### PR DESCRIPTION
Noticed in @koaning's livestream that we never updated the Altair example to remove the call to `to_pandas`

Here's the local render:

![2024-04-12_10-13](https://github.com/ibis-project/ibis/assets/3596999/2fcd8681-7fb5-4f37-992c-2c00d149ca4b)
