### PR TITLE
feat(polars): add more accurate type mapping for timestamps

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -612,6 +612,9 @@ class Timestamp(Temporal, Parametric):
         elif unit == TimestampUnit.NANOSECOND:
             scale = 9
         else:
+            # TODO: remove raise path as it's never triggered
+            # Timestamp op has a restriction that only the literal
+            # ints from 0 through 9 can be passed as scale
             raise ValueError(f"Invalid unit {unit}")
         return cls(scale=scale, timezone=timezone, nullable=nullable)
 
@@ -627,6 +630,9 @@ class Timestamp(Temporal, Parametric):
         elif 7 <= self.scale <= 9:
             return TimestampUnit.NANOSECOND
         else:
+            # TODO: remove raise path as it's never triggered
+            # TimestampUnit, which is a (child of) Enum
+            # so it'll raise in the Enum class constructor instead
             raise ValueError(f"Invalid scale {self.scale}")
 
     @property

--- a/ibis/formats/tests/test_polars.py
+++ b/ibis/formats/tests/test_polars.py
@@ -31,9 +31,19 @@ from ibis.formats.polars import PolarsData, PolarsSchema, PolarsType  # noqa: E4
         param(dt.uint64, pl.UInt64, id="uint64"),
         param(dt.float32, pl.Float32, id="float32"),
         param(dt.float64, pl.Float64, id="float64"),
-        param(dt.timestamp, pl.Datetime("ns", time_zone=None), id="timestamp"),
         param(
-            dt.Timestamp("UTC"), pl.Datetime("ns", time_zone="UTC"), id="timestamp_tz"
+            dt.Timestamp(scale=9), pl.Datetime("ns", time_zone=None), id="timestamp_ns"
+        ),
+        param(
+            dt.Timestamp(scale=6), pl.Datetime("us", time_zone=None), id="timestamp_us"
+        ),
+        param(
+            dt.Timestamp(scale=3), pl.Datetime("ms", time_zone=None), id="timestamp_ms"
+        ),
+        param(
+            dt.Timestamp("UTC", scale=9),
+            pl.Datetime("ns", time_zone="UTC"),
+            id="timestamp_tz",
         ),
         param(dt.Interval(unit="ms"), pl.Duration("ms"), id="interval_ms"),
         param(dt.Interval(unit="us"), pl.Duration("us"), id="interval_us"),
@@ -58,6 +68,25 @@ def test_to_from_ibis_type(ibis_dtype, polars_type):
     assert PolarsType.from_ibis(ibis_dtype) == polars_type
     assert PolarsType.to_ibis(polars_type) == ibis_dtype
     assert PolarsType.to_ibis(polars_type, nullable=False) == ibis_dtype(nullable=False)
+
+
+@pytest.mark.parametrize(
+    ("ibis_dtype", "polars_type"),
+    [
+        param(
+            dt.Timestamp(scale=0), pl.Datetime("ns", time_zone=None), id="timestamp_sc0"
+        ),
+        param(dt.Timestamp(), pl.Datetime("ns", time_zone=None), id="timestamp_scn"),
+        param(
+            dt.Timestamp("UTC", scale=0),
+            pl.Datetime("ns", time_zone="UTC"),
+            id="timestamp_tz_sc0",
+        ),
+    ],
+)
+def test_from_ibis_type_seconds(ibis_dtype, polars_type):
+    # we accept seconds as an ibis type, default to ns in polars
+    assert PolarsType.from_ibis(ibis_dtype) == polars_type
 
 
 def test_decimal():


### PR DESCRIPTION
- Closes https://github.com/ibis-project/ibis/issues/8479

polars datetime types have a fixed time unit (us, ns, or ms). Ibis timestamp types do too (but we also have seocnds as an option). In the case of polars we're currently mapping all timestamps to `ns`, this PR makes things a bit more specific and uses proper units. 

I'm still not sure how to handle the case `Ibis seconds` to maybe `ms in polars` ? Need a bit help on how the conversion of units happens, more specifically where is the value part handled? we would need to do `ibis_seconds*1000` = `polars_ms` at the moment I'm raising, similarly to what we do in durations, but I need to tackle this differently, see all the current failures in CI.

