### PR TITLE
test(clickhouse): bring back xpassing array unnest of structs test

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -819,11 +819,6 @@ def test_unnest_struct(con):
 
 
 @builtin_array
-@pytest.mark.notimpl(
-    ["clickhouse"],
-    raises=ClickHouseDatabaseError,
-    reason="ClickHouse won't accept dicts for struct type values",
-)
 @pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError)
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2InternalError)
 @pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)


### PR DESCRIPTION
Quick fix for an XPASS-ing clickhouse test.