### PR TITLE
ci(deps): remove dep caching and pipx usage in favor of plain pip

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -30,9 +30,6 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install poetry
-        run: pipx install 'poetry==1.8.2'
-
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
@@ -40,6 +37,9 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: requirements-dev.txt
+
+      - name: install poetry
+        run: pip install 'poetry==1.8.2'
 
       - name: update apt-get
         run: sudo apt-get update -y -q

--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -86,14 +86,14 @@ jobs:
           labels: ci-run-cloud
           github_token: ${{ steps.generate_token.outputs.token }}
 
-      - name: install poetry
-        run: pipx install 'poetry==1.8.2'
-
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: install poetry
+        run: pip install 'poetry==1.8.2'
 
       - name: install ibis
         run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -58,14 +58,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install poetry
-        run: pipx install 'poetry==1.8.2'
-
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: install poetry
+        run: pip install 'poetry==1.8.2'
 
       - name: install ibis
         run: poetry install --without dev --without docs --extras bigquery
@@ -389,14 +389,14 @@ jobs:
         if: matrix.backend.services != null
         run: docker compose up --wait ${{ join(matrix.backend.services, ' ') }}
 
-      - name: install poetry
-        run: pipx install 'poetry==1.8.2'
-
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: install poetry
+        run: pip install 'poetry==1.8.2'
 
       - name: install ibis
         run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -123,10 +123,6 @@ jobs:
             extras:
               - clickhouse
               - examples
-          - name: dask
-            title: Dask
-            extras:
-              - dask
           - name: pandas
             title: Pandas
             extras:
@@ -237,6 +233,21 @@ jobs:
               - "'apache-flink < 1.20.0'"
             services:
               - flink
+        include:
+          - os: ubuntu-latest
+            python-version: "3.11.8"
+            backend:
+              name: dask
+              title: Dask
+              extras:
+                - dask
+          - os: ubuntu-latest
+            python-version: "3.9"
+            backend:
+              name: dask
+              title: Dask
+              extras:
+                - dask
         exclude:
           - os: windows-latest
             backend:

--- a/.github/workflows/ibis-benchmarks.yml
+++ b/.github/workflows/ibis-benchmarks.yml
@@ -23,15 +23,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install poetry
-        run: pipx install 'poetry==1.8.2'
-
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: "3.11"
-          cache: poetry
+
+      - name: install poetry
+        run: pip install 'poetry==1.8.2'
 
       - name: install system dependencies
         run: sudo apt-get install -qq -y build-essential libgeos-dev freetds-dev unixodbc-dev

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -54,14 +54,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install poetry
-        run: pipx install 'poetry==1.8.2'
-
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: install poetry
+        run: pip install 'poetry==1.8.2'
 
       - name: install ${{ matrix.os }} system dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -105,14 +105,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install poetry
-        run: pipx install 'poetry==1.8.2'
-
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: "3.12"
+
+      - name: install poetry
+        run: pip install 'poetry==1.8.2'
 
       - name: install system dependencies
         run: |
@@ -144,15 +144,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: install poetry
-        run: pipx install 'poetry==1.8.2'
-
       - name: install python
         uses: actions/setup-python@v5
         id: install_python
         with:
           python-version: "3.12"
-          cache: poetry
+
+      - name: install poetry
+        run: pip install 'poetry==1.8.2'
 
       - name: install ibis with all extras
         run: poetry install --without dev --without docs --all-extras


### PR DESCRIPTION
Remove dependency caching and pipx usage to avoid CI hiccups from mismatching pipx python versions and target test python versions.