### PR TITLE
feat(api): add API for unwrapping JSON values into backend-native values

### DIFF
--- a/ci/schema/bigquery.sql
+++ b/ci/schema/bigquery.sql
@@ -65,7 +65,15 @@ INSERT INTO {dataset}.json_t VALUES
     (JSON '{{"a":"foo", "c":null}}'),
     (JSON 'null'),
     (JSON '[42,47,55]'),
-    (JSON '[]');
+    (JSON '[]'),
+    (JSON '"a"'),
+    (JSON '""'),
+    (JSON '"b"'),
+    (NULL),
+    (JSON 'true'),
+    (JSON 'false'),
+    (JSON '42'),
+    (JSON '37.37');
 
 
 LOAD DATA OVERWRITE {dataset}.functional_alltypes (

--- a/ci/schema/duckdb.sql
+++ b/ci/schema/duckdb.sql
@@ -29,7 +29,7 @@ INSERT INTO struct VALUES
     (NULL),
     ({'a': 3.0, 'b': 'orange', 'c': NULL});
 
-CREATE OR REPLACE TABLE json_t (js TEXT);
+CREATE OR REPLACE TABLE json_t (js JSON);
 
 INSERT INTO json_t VALUES
     ('{"a": [1,2,3,4], "b": 1}'),
@@ -37,7 +37,15 @@ INSERT INTO json_t VALUES
     ('{"a":"foo", "c":null}'),
     ('null'),
     ('[42,47,55]'),
-    ('[]');
+    ('[]'),
+    ('"a"'),
+    ('""'),
+    ('"b"'),
+    (NULL),
+    ('true'),
+    ('false'),
+    ('42'),
+    ('37.37');
 
 CREATE OR REPLACE TABLE win (g TEXT, x BIGINT NOT NULL, y BIGINT);
 INSERT INTO win VALUES

--- a/ci/schema/mysql.sql
+++ b/ci/schema/mysql.sql
@@ -108,7 +108,15 @@ INSERT INTO json_t VALUES
     ('{"a":"foo", "c":null}'),
     ('null'),
     ('[42,47,55]'),
-    ('[]');
+    ('[]'),
+    ('"a"'),
+    ('""'),
+    ('"b"'),
+    (NULL),
+    ('true'),
+    ('false'),
+    ('42'),
+    ('37.37');
 
 DROP TABLE IF EXISTS win CASCADE;
 

--- a/ci/schema/postgres.sql
+++ b/ci/schema/postgres.sql
@@ -273,7 +273,15 @@ INSERT INTO json_t VALUES
     ('{"a":"foo", "c":null}'),
     ('null'),
     ('[42,47,55]'),
-    ('[]');
+    ('[]'),
+    ('"a"'),
+    ('""'),
+    ('"b"'),
+    (NULL),
+    ('true'),
+    ('false'),
+    ('42'),
+    ('37.37');
 
 DROP TABLE IF EXISTS win CASCADE;
 CREATE TABLE win (g TEXT, x BIGINT NOT NULL, y BIGINT);

--- a/ci/schema/risingwave.sql
+++ b/ci/schema/risingwave.sql
@@ -165,7 +165,15 @@ INSERT INTO "json_t" VALUES
     ('{"a":"foo", "c":null}'),
     ('null'),
     ('[42,47,55]'),
-    ('[]');
+    ('[]'),
+    ('"a"'),
+    ('""'),
+    ('"b"'),
+    (NULL),
+    ('true'),
+    ('false'),
+    ('42'),
+    ('37.37');
 
 DROP TABLE IF EXISTS "win" CASCADE;
 CREATE TABLE "win" ("g" TEXT, "x" BIGINT, "y" BIGINT);

--- a/ci/schema/snowflake.sql
+++ b/ci/schema/snowflake.sql
@@ -131,7 +131,15 @@ INSERT INTO "json_t" ("js")
     SELECT parse_json('{"a":"foo", "c":null}') UNION
     SELECT parse_json('null') UNION
     SELECT parse_json('[42,47,55]') UNION
-    SELECT parse_json('[]');
+    SELECT parse_json('[]') UNION
+    SELECT parse_json('"a"') UNION
+    SELECT parse_json('""') UNION
+    SELECT parse_json('"b"') UNION
+    SELECT NULL UNION
+    SELECT parse_json('true') UNION
+    SELECT parse_json('false') UNION
+    SELECT parse_json('42') UNION
+    SELECT parse_json('37.37');
 
 CREATE OR REPLACE TABLE "win" ("g" TEXT, "x" BIGINT NOT NULL, "y" BIGINT);
 INSERT INTO "win" VALUES

--- a/ci/schema/sqlite.sql
+++ b/ci/schema/sqlite.sql
@@ -109,7 +109,15 @@ INSERT INTO json_t VALUES
     ('{"a":"foo", "c":null}'),
     ('null'),
     ('[42,47,55]'),
-    ('[]');
+    ('[]'),
+    ('"a"'),
+    ('""'),
+    ('"b"'),
+    (NULL),
+    ('true'),
+    ('false'),
+    ('42'),
+    ('37.37');
 
 DROP TABLE IF EXISTS win;
 CREATE TABLE win (g TEXT, x BIGINT NOT NULL, y BIGINT);

--- a/ci/schema/trino.sql
+++ b/ci/schema/trino.sql
@@ -168,7 +168,15 @@ INSERT INTO memory.default.json_t VALUES
     (JSON '{"a":"foo", "c":null}'),
     (JSON 'null'),
     (JSON '[42,47,55]'),
-    (JSON '[]');
+    (JSON '[]'),
+    (JSON '"a"'),
+    (JSON '""'),
+    (JSON '"b"'),
+    (NULL),
+    (JSON 'true'),
+    (JSON 'false'),
+    (JSON '42'),
+    (JSON '37.37');
 
 DROP TABLE IF EXISTS win;
 CREATE TABLE win (g VARCHAR, x BIGINT, y BIGINT);

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -381,6 +381,18 @@ class BigQueryCompiler(SQLGlotCompiler):
     def visit_JSONGetItem(self, op, *, arg, index):
         return arg[index]
 
+    def visit_UnwrapJSONString(self, op, *, arg):
+        return self.f.anon["safe.string"](arg)
+
+    def visit_UnwrapJSONInt64(self, op, *, arg):
+        return self.f.anon["safe.int64"](arg)
+
+    def visit_UnwrapJSONFloat64(self, op, *, arg):
+        return self.f.anon["safe.float64"](arg)
+
+    def visit_UnwrapJSONBoolean(self, op, *, arg):
+        return self.f.anon["safe.bool"](arg)
+
     def visit_ExtractEpochSeconds(self, op, *, arg):
         return self.f.unix_seconds(arg)
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -77,6 +77,10 @@ class PySparkCompiler(SQLGlotCompiler):
         ops.MapMerge: "map_concat",
         ops.MapKeys: "map_keys",
         ops.MapValues: "map_values",
+        ops.UnwrapJSONString: "unwrap_json_str",
+        ops.UnwrapJSONInt64: "unwrap_json_int",
+        ops.UnwrapJSONFloat64: "unwrap_json_float",
+        ops.UnwrapJSONBoolean: "unwrap_json_bool",
     }
 
     def _aggregate(self, funcname: str, *args, where):

--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -179,6 +179,18 @@ class SnowflakeCompiler(SQLGlotCompiler):
     def visit_ToJSONArray(self, op, *, arg):
         return self.if_(self.f.is_array(arg), arg, NULL)
 
+    def visit_UnwrapJSONString(self, op, *, arg):
+        return self.if_(self.f.is_varchar(arg), self.f.as_varchar(arg), NULL)
+
+    def visit_UnwrapJSONInt64(self, op, *, arg):
+        return self.if_(self.f.is_integer(arg), self.f.as_integer(arg), NULL)
+
+    def visit_UnwrapJSONFloat64(self, op, *, arg):
+        return self.if_(self.f.is_double(arg), self.f.as_double(arg), NULL)
+
+    def visit_UnwrapJSONBoolean(self, op, *, arg):
+        return self.if_(self.f.is_boolean(arg), self.f.as_boolean(arg), NULL)
+
     def visit_IsNan(self, op, *, arg):
         return arg.eq(self.NAN)
 

--- a/ibis/backends/tests/data.py
+++ b/ibis/backends/tests/data.py
@@ -100,6 +100,14 @@ json_types = pd.DataFrame(
             "null",
             "[42,47,55]",
             "[]",
+            '"a"',
+            '""',
+            '"b"',
+            None,
+            "true",
+            "false",
+            "42",
+            "37.37",
         ]
     }
 )

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1585,6 +1585,14 @@ def test_json_to_pyarrow(con):
         None,
         [42, 47, 55],
         [],
+        "a",
+        "",
+        "b",
+        None,
+        True,
+        False,
+        42,
+        37.37,
     ]
     expected = {json.dumps(val) for val in expected}
 
@@ -1592,5 +1600,10 @@ def test_json_to_pyarrow(con):
         # loads and dumps so the string representation is the same
         json.dumps(json.loads(val))
         for val in js.to_pylist()
+        # proper null values must be ignored because they cannot be
+        # deserialized as JSON
+        #
+        # they exist in the json_t table, so the `js` value contains them
+        if val is not None
     }
     assert result == expected

--- a/ibis/backends/tests/test_json.py
+++ b/ibis/backends/tests/test_json.py
@@ -9,6 +9,8 @@ import pandas as pd
 import pytest
 from packaging.version import parse as vparse
 
+import ibis.expr.types as ir
+
 pytestmark = [
     pytest.mark.never(["impala"], reason="doesn't support JSON and never will"),
     pytest.mark.notyet(["clickhouse"], reason="upstream is broken"),
@@ -74,10 +76,8 @@ def test_json_map(backend, json_t):
             {"a": [1, 2, 3, 4], "b": 1},
             {"a": None, "b": 2},
             {"a": "foo", "c": None},
-            None,
-            None,
-            None,
-        ],
+        ]
+        + [None] * 11,
         dtype="object",
         name="res",
     )
@@ -94,6 +94,42 @@ def test_json_array(backend, json_t):
     expr = json_t.js.array.name("res")
     result = expr.execute()
     expected = pd.Series(
-        [None, None, None, None, [42, 47, 55], []], name="res", dtype="object"
+        [None, None, None, None, [42, 47, 55], []] + [None] * 8,
+        name="res",
+        dtype="object",
     )
     backend.assert_series_equal(result, expected)
+
+
+@pytest.mark.notyet(
+    ["sqlite"],
+    condition=vparse(sqlite3.sqlite_version) < vparse("3.38.0"),
+    reason="JSON not supported in SQLite < 3.38.0",
+)
+@pytest.mark.notimpl(["dask", "pandas", "risingwave"])
+@pytest.mark.notyet(["flink"], reason="should work but doesn't deserialize JSON")
+@pytest.mark.parametrize(
+    ("typ", "expected_data"),
+    [
+        ("str", [None] * 6 + ["a", "", "b"] + [None] * 5),
+        ("int", [None] * 12 + [42, None]),
+        ("float", [None] * 12 + [42.0, 37.37]),
+        ("bool", [None] * 10 + [True, False, None, None]),
+    ],
+    ids=["str", "int", "float", "bool"],
+)
+@pytest.mark.parametrize(
+    "expr_fn", [getattr, ir.JSONValue.unwrap_as], ids=["getattr", "unwrap_as"]
+)
+def test_json_unwrap(backend, json_t, typ, expected_data, expr_fn):
+    expr = expr_fn(json_t.js, typ).name("res")
+    result = expr.execute()
+    expected = pd.Series(expected_data, name="res", dtype="object")
+    backend.assert_series_equal(
+        result.replace(np.nan, None).fillna(pd.NA).sort_values().reset_index(drop=True),
+        expected.replace(np.nan, None)
+        .fillna(pd.NA)
+        .sort_values()
+        .reset_index(drop=True),
+        check_dtype=False,
+    )

--- a/ibis/expr/operations/json.py
+++ b/ibis/expr/operations/json.py
@@ -30,3 +30,35 @@ class ToJSONMap(Value):
 
     dtype = dt.Map(dt.string, dt.json)
     shape = rlz.shape_like("arg")
+
+
+@public
+class UnwrapJSONString(Value):
+    arg: Value[dt.JSON]
+
+    dtype = dt.string
+    shape = rlz.shape_like("arg")
+
+
+@public
+class UnwrapJSONInt64(Value):
+    arg: Value[dt.JSON]
+
+    dtype = dt.int64
+    shape = rlz.shape_like("arg")
+
+
+@public
+class UnwrapJSONFloat64(Value):
+    arg: Value[dt.JSON]
+
+    dtype = dt.float64
+    shape = rlz.shape_like("arg")
+
+
+@public
+class UnwrapJSONBoolean(Value):
+    arg: Value[dt.JSON]
+
+    dtype = dt.boolean
+    shape = rlz.shape_like("arg")

--- a/ibis/expr/types/json.py
+++ b/ibis/expr/types/json.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 from public import public
 
+import ibis.common.exceptions as exc
+import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.expr.types import Column, Scalar, Value
 
@@ -98,6 +100,155 @@ class JSONValue(Value):
         """
         return ops.JSONGetItem(self, key).to_expr()
 
+    def unwrap_as(self, dtype: dt.DataType | str) -> ir.Value:
+        """Unwrap JSON into a specific data type.
+
+        Returns
+        -------
+        Value
+            An Ibis expression of a more specific type than JSON
+
+        Examples
+        --------
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> data = {
+        ...     "jstring": ['"a"', '""', None, "null"],
+        ...     "jbool": ["true", "false", "null", None],
+        ...     "jint": ["1", "null", None, "2"],
+        ...     "jfloat": ["42.42", None, "null", "37.37"],
+        ...     "jmap": ['{"a": 1}', "null", None, "{}"],
+        ...     "jarray": ["[]", "null", None, '[{},"1",2]'],
+        ... }
+        >>> t = ibis.memtable(data, schema=dict.fromkeys(data.keys(), "json"))
+        >>> t
+        ┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━┓
+        ┃ jstring              ┃ jbool                ┃ jint                 ┃ … ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━┩
+        │ json                 │ json                 │ json                 │ … │
+        ├──────────────────────┼──────────────────────┼──────────────────────┼───┤
+        │ 'a'                  │ True                 │ 1                    │ … │
+        │ ''                   │ False                │ None                 │ … │
+        │ NULL                 │ None                 │ NULL                 │ … │
+        │ None                 │ NULL                 │ 2                    │ … │
+        └──────────────────────┴──────────────────────┴──────────────────────┴───┘
+        >>> t.select(unwrapped=t.jstring.unwrap_as(str), original=t.jstring)
+        ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ unwrapped ┃ original             ┃
+        ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string    │ json                 │
+        ├───────────┼──────────────────────┤
+        │ a         │ 'a'                  │
+        │ ~         │ ''                   │
+        │ NULL      │ NULL                 │
+        │ NULL      │ None                 │
+        └───────────┴──────────────────────┘
+        >>> t.select(unwrapped=t.jbool.unwrap_as("bool"), original=t.jbool)
+        ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ unwrapped ┃ original             ┃
+        ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
+        │ boolean   │ json                 │
+        ├───────────┼──────────────────────┤
+        │ True      │ True                 │
+        │ False     │ False                │
+        │ NULL      │ None                 │
+        │ NULL      │ NULL                 │
+        └───────────┴──────────────────────┘
+        >>> t.select(
+        ...     unwrapped_int64=t.jint.unwrap_as("int64"),
+        ...     unwrapped_int32=t.jint.unwrap_as("int32"),
+        ...     original=t.jint,
+        ... )
+        ┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ unwrapped_int64 ┃ unwrapped_int32 ┃ original             ┃
+        ┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
+        │ int64           │ int32           │ json                 │
+        ├─────────────────┼─────────────────┼──────────────────────┤
+        │               1 │               1 │ 1                    │
+        │            NULL │            NULL │ None                 │
+        │            NULL │            NULL │ NULL                 │
+        │               2 │               2 │ 2                    │
+        └─────────────────┴─────────────────┴──────────────────────┘
+
+        You can cast to a more specific type than the types available in standards-compliant JSON.
+
+        Here's an example of casting JSON numbers to `float32`:
+
+        >>> t.select(unwrapped=t.jfloat.unwrap_as("float32"), original=t.jfloat)
+        ┏━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ unwrapped ┃ original             ┃
+        ┡━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
+        │ float32   │ json                 │
+        ├───────────┼──────────────────────┤
+        │ 42.419998 │ 42.42                │
+        │      NULL │ NULL                 │
+        │      NULL │ None                 │
+        │ 37.369999 │ 37.37                │
+        └───────────┴──────────────────────┘
+
+        You can cast JSON objects to a more specific `map` type:
+
+        >>> t.select(unwrapped=t.jmap.unwrap_as("map<string, int>"), original=t.jmap)
+        ┏━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ unwrapped            ┃ original             ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
+        │ map<string, int64>   │ json                 │
+        ├──────────────────────┼──────────────────────┤
+        │ {'a': 1}             │ {'a': 1}             │
+        │ NULL                 │ None                 │
+        │ NULL                 │ NULL                 │
+        │ {}                   │ {}                   │
+        └──────────────────────┴──────────────────────┘
+
+        You can cast JSON arrays to an array type as well. In this case the
+        array values don't have a single element type so we cast to
+        `array<json>`.
+
+        >>> t.select(unwrapped=t.jarray.unwrap_as("array<json>"), original=t.jarray)
+        ┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ unwrapped             ┃ original             ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
+        │ array<json>           │ json                 │
+        ├───────────────────────┼──────────────────────┤
+        │ []                    │ []                   │
+        │ NULL                  │ None                 │
+        │ NULL                  │ NULL                 │
+        │ ['{}', '"1"', ... +1] │ [{...}, '1', ... +1] │
+        └───────────────────────┴──────────────────────┘
+
+        See Also
+        --------
+        [`JSONValue.str`](#ibis.expr.types.json.JSONValue.str)
+        [`JSONValue.int`](#ibis.expr.types.json.JSONValue.int)
+        [`JSONValue.float`](#ibis.expr.types.json.JSONValue.float)
+        [`JSONValue.bool`](#ibis.expr.types.json.JSONValue.bool)
+        [`JSONValue.map`](#ibis.expr.types.json.JSONValue.map)
+        [`JSONValue.array`](#ibis.expr.types.json.JSONValue.array)
+        [`Value.cast`](#ibis.expr.types.generic.Value.cast)
+        """
+        dtype = dt.dtype(dtype)
+        if dtype.is_string():
+            return self.str
+        elif dtype.is_boolean():
+            return self.bool
+        elif dtype.is_integer():
+            i = self.int
+            return i.cast(dtype) if i.type() != dtype else i
+        elif dtype.is_floating():
+            f = self.float
+            return f.cast(dtype) if f.type() != dtype else f
+        elif dtype.is_map():
+            m = self.map
+            return m.cast(dtype) if m.type() != dtype else m
+        elif dtype.is_array():
+            a = self.array
+            return a.cast(dtype) if a.type() != dtype else a
+        else:
+            raise exc.IbisTypeError(
+                f"Data type {dtype} is unsupported for unwrapping JSON values. Supported "
+                "data types are strings, integers, floats, booleans, maps, and arrays."
+            )
+
     @property
     def map(self) -> ir.MapValue:
         """Cast JSON to a map of string to JSON.
@@ -123,6 +274,226 @@ class JSONValue(Value):
             Array of JSON objects
         """
         return ops.ToJSONArray(self).to_expr()
+
+    @property
+    def int(self) -> ir.IntegerValue:
+        """Unwrap a JSON value into a backend-native int.
+
+        Any non-float JSON values are returned as `NULL`.
+
+        Examples
+        --------
+        >>> import json, ibis
+        >>> ibis.options.interactive = True
+        >>> data = [
+        ...     {"name": "Alice", "json_data": '{"last_name":"Smith","age":40}'},
+        ...     {"name": "Bob", "json_data": '{"last_name":"Jones", "age":39}'},
+        ...     {"name": "Charlie", "json_data": '{"last_name":"Davies","age":54}'},
+        ... ]
+        >>> t = ibis.memtable(data, schema={"name": "string", "json_data": "json"})
+        >>> t
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ name    ┃ json_data                          ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string  │ json                               │
+        ├─────────┼────────────────────────────────────┤
+        │ Alice   │ {'last_name': 'Smith', 'age': 40}  │
+        │ Bob     │ {'last_name': 'Jones', 'age': 39}  │
+        │ Charlie │ {'last_name': 'Davies', 'age': 54} │
+        └─────────┴────────────────────────────────────┘
+        >>> t.mutate(age=t.json_data["age"].int)
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┓
+        ┃ name    ┃ json_data                          ┃ age   ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━┩
+        │ string  │ json                               │ int64 │
+        ├─────────┼────────────────────────────────────┼───────┤
+        │ Alice   │ {'last_name': 'Smith', 'age': 40}  │    40 │
+        │ Bob     │ {'last_name': 'Jones', 'age': 39}  │    39 │
+        │ Charlie │ {'last_name': 'Davies', 'age': 54} │    54 │
+        └─────────┴────────────────────────────────────┴───────┘
+        """
+        return ops.UnwrapJSONInt64(self).to_expr()
+
+    @property
+    def float(self) -> ir.FloatingValue:
+        """Unwrap a JSON value into a backend-native float.
+
+        Any non-float JSON values are returned as `NULL`.
+
+        ::: {.callout-warning}
+        ## The `float` property is lax with respect to integers
+
+        The `float` property will attempt to coerce integers to floating point numbers.
+        :::
+
+        Examples
+        --------
+        >>> import json, ibis
+        >>> ibis.options.interactive = True
+        >>> data = [
+        ...     {"name": "Alice", "json_data": '{"last_name":"Smith","salary":42.42}'},
+        ...     {"name": "Bob", "json_data": '{"last_name":"Jones", "salary":37.37}'},
+        ...     {"name": "Charlie", "json_data": '{"last_name":"Davies","salary":"NA"}'},
+        ...     {"name": "Joan", "json_data": '{"last_name":"Davies","salary":78}'},
+        ... ]
+        >>> t = ibis.memtable(data, schema={"name": "string", "json_data": "json"})
+        >>> t
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ name    ┃ json_data                               ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string  │ json                                    │
+        ├─────────┼─────────────────────────────────────────┤
+        │ Alice   │ {'last_name': 'Smith', 'salary': 42.42} │
+        │ Bob     │ {'last_name': 'Jones', 'salary': 37.37} │
+        │ Charlie │ {'last_name': 'Davies', 'salary': 'NA'} │
+        │ Joan    │ {'last_name': 'Davies', 'salary': 78}   │
+        └─────────┴─────────────────────────────────────────┘
+        >>> t.mutate(salary=t.json_data["salary"].float)
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+        ┃ name    ┃ json_data                               ┃ salary  ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+        │ string  │ json                                    │ float64 │
+        ├─────────┼─────────────────────────────────────────┼─────────┤
+        │ Alice   │ {'last_name': 'Smith', 'salary': 42.42} │   42.42 │
+        │ Bob     │ {'last_name': 'Jones', 'salary': 37.37} │   37.37 │
+        │ Charlie │ {'last_name': 'Davies', 'salary': 'NA'} │    NULL │
+        │ Joan    │ {'last_name': 'Davies', 'salary': 78}   │   78.00 │
+        └─────────┴─────────────────────────────────────────┴─────────┘
+        """
+        return ops.UnwrapJSONFloat64(self).to_expr()
+
+    @property
+    def bool(self) -> ir.BooleanValue:
+        """Unwrap a JSON value into a backend-native boolean.
+
+        Any non-boolean JSON values are returned as `NULL`.
+
+        Examples
+        --------
+        >>> import json, ibis
+        >>> ibis.options.interactive = True
+        >>> data = [
+        ...     {"name": "Alice", "json_data": '{"last_name":"Smith","is_bot":false}'},
+        ...     {"name": "Bob", "json_data": '{"last_name":"Jones","is_bot":true}'},
+        ...     {"name": "Charlie", "json_data": '{"last_name":"Davies","is_bot":false}'},
+        ... ]
+        >>> t = ibis.memtable(data, schema={"name": "string", "json_data": "json"})
+        >>> t
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ name    ┃ json_data                                ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string  │ json                                     │
+        ├─────────┼──────────────────────────────────────────┤
+        │ Alice   │ {'last_name': 'Smith', 'is_bot': False}  │
+        │ Bob     │ {'last_name': 'Jones', 'is_bot': True}   │
+        │ Charlie │ {'last_name': 'Davies', 'is_bot': False} │
+        └─────────┴──────────────────────────────────────────┘
+        >>> t.mutate(is_bot=t.json_data["is_bot"].bool)
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
+        ┃ name    ┃ json_data                                ┃ is_bot  ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
+        │ string  │ json                                     │ boolean │
+        ├─────────┼──────────────────────────────────────────┼─────────┤
+        │ Alice   │ {'last_name': 'Smith', 'is_bot': False}  │ False   │
+        │ Bob     │ {'last_name': 'Jones', 'is_bot': True}   │ True    │
+        │ Charlie │ {'last_name': 'Davies', 'is_bot': False} │ False   │
+        └─────────┴──────────────────────────────────────────┴─────────┘
+        """
+        return ops.UnwrapJSONBoolean(self).to_expr()
+
+    @property
+    def str(self) -> ir.StringValue:
+        """Unwrap a JSON string into a backend-native string.
+
+        Any non-string JSON values are returned as `NULL`.
+
+        Returns
+        -------
+        StringValue
+            A string expression
+
+        Examples
+        --------
+        >>> import json, ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.memtable(
+        ...     {"js": ['"a"', '"b"', "1", "{}", '[{"a": 1}]']},
+        ...     schema=ibis.schema(dict(js="json")),
+        ... )
+        >>> t
+        ┏━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ js                   ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━┩
+        │ json                 │
+        ├──────────────────────┤
+        │ 'a'                  │
+        │ 'b'                  │
+        │ 1                    │
+        │ {}                   │
+        │ [{...}]              │
+        └──────────────────────┘
+        >>> t.js.str
+        ┏━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ UnwrapJSONString(js) ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string               │
+        ├──────────────────────┤
+        │ a                    │
+        │ b                    │
+        │ NULL                 │
+        │ NULL                 │
+        │ NULL                 │
+        └──────────────────────┘
+
+        Note the difference between `.string` and `.cast("string")`.
+
+        The latter preserves quotes for JSON string values and returns a valid
+        JSON string.
+
+        >>> t.js.cast("string")
+        ┏━━━━━━━━━━━━━━━━━━┓
+        ┃ Cast(js, string) ┃
+        ┡━━━━━━━━━━━━━━━━━━┩
+        │ string           │
+        ├──────────────────┤
+        │ "a"              │
+        │ "b"              │
+        │ 1                │
+        │ {}               │
+        │ [{"a": 1}]       │
+        └──────────────────┘
+
+        Here's a more complex example with a table containing a JSON column
+        with nested fields.
+
+        >>> data = [
+        ...     {"name": "Alice", "json_data": '{"last_name":"Smith"}'},
+        ...     {"name": "Bob", "json_data": '{"last_name":"Jones"}'},
+        ...     {"name": "Charlie", "json_data": '{"last_name":"Davies"}'},
+        ... ]
+        >>> t = ibis.memtable(data, schema={"name": "string", "json_data": "json"})
+        >>> t
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ name    ┃ json_data               ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string  │ json                    │
+        ├─────────┼─────────────────────────┤
+        │ Alice   │ {'last_name': 'Smith'}  │
+        │ Bob     │ {'last_name': 'Jones'}  │
+        │ Charlie │ {'last_name': 'Davies'} │
+        └─────────┴─────────────────────────┘
+        >>> t.mutate(last_name=t.json_data["last_name"].str)
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+        ┃ name    ┃ json_data               ┃ last_name ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+        │ string  │ json                    │ string    │
+        ├─────────┼─────────────────────────┼───────────┤
+        │ Alice   │ {'last_name': 'Smith'}  │ Smith     │
+        │ Bob     │ {'last_name': 'Jones'}  │ Jones     │
+        │ Charlie │ {'last_name': 'Davies'} │ Davies    │
+        └─────────┴─────────────────────────┴───────────┘
+        """
+        return ops.UnwrapJSONString(self).to_expr()
 
 
 @public


### PR DESCRIPTION
Adds `str`, `int`, `float`, and `bool` properties to `JSONValue` as well as an `unwrap_as` method for easier programmatic usage and more fine-grained casting.

Unless someone really hates the static property names, I'd prefer to keep them as they are. Open to alternative names for `unwrap_as` though.

In theory this can all be done with casting, but if you look at what's being done in the various backends it's typically a lot more involved than that. Trino in particular requires queries over JSON to be `VARCHAR` inputs, when then have to be cast **back** to its `JSON` type to be able to cast _that_ to the desired output type.

Complicating the cast branching _just_ for the `JSON -> not JSON` case seemed like the wrong tradeoff.

I went with these names to match the `map` and `array` APIs, and to match the short type names we have for the specific types (`str`, `int`, `float`, and `bool`), which exist to match the equivalent Python types.