### PR TITLE
fix(sql): allow CTEs in `.sql` method

### DIFF
--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -221,6 +221,8 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
 
         cte = self._to_sqlglot(table)
         parsed = sg.parse_one(query, read=dialect)
+        if parsed.args.get("with"):
+            parsed = sg.select(STAR).from_(parsed.subquery("_"))
         parsed.args["with"] = cte.args.pop("with", [])
         parsed = parsed.with_(
             sg.to_identifier(name, quoted=compiler.quoted), as_=cte, dialect=dialect

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -427,7 +427,22 @@ class DataFusionType(PostgresType):
     unknown_type_strings = {
         "utf8": dt.string,
         "float64": dt.float64,
+        "float32": dt.float32,
     }
+
+    @classmethod
+    def _from_sqlglot_TIMESTAMP(cls, scale, tz) -> dt.Timestamp:
+        scales = {"SECOND": 0, "MILLISECOND": 3, "MICROSECOND": 6, "NANOSECOND": 9}
+
+        assert tz is not None
+
+        tz = tz.this.this
+
+        return dt.Timestamp(
+            scale=scales[scale.this.this],
+            timezone=None if tz == "NONE" else tz,
+            nullable=cls.default_nullable,
+        )
 
 
 class MySQLType(SqlglotType):

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -187,7 +187,7 @@ def extract_ctes(node):
 
     g = Graph.from_bfs(node, filter=~InstanceOf(dont_count))
     for node, dependents in g.invert().items():
-        if isinstance(node, ops.View) or (
+        if isinstance(node, (ops.View, ops.SQLStringView)) or (
             len(dependents) > 1 and isinstance(node, cte_types)
         ):
             result.append(node)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -242,7 +242,7 @@ _LIMIT = {
 }
 
 
-@pytest.mark.notimpl(["datafusion", "mssql"])
+@pytest.mark.notimpl(["mssql"])
 @pytest.mark.never(["dask", "pandas"], reason="dask and pandas do not support SQL")
 def test_sql(backend, con):
     # execute the expression using SQL query


### PR DESCRIPTION
This PR addresses an issue with using CTEs in `.sql`. We were mutating the parsed query with the incoming query name, which is not valid if the user query is a CTE. The solution here was to throw SELECT * in front of the user query if it is a CTE. Additionally, in the presence of `View` ops, a `SQLStringView` op must be treated internally as a CTE to ensure it is compiled in topological order.

Fixes #8933.