### PR TITLE
ci(snowflake-snowpark): make install required

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: install additional deps
         if: matrix.backend.key == 'snowflake-snowpark'
-        run: poetry add snowflake-snowpark-python --optional --python="==${{ steps.install_python.outputs.python-version }}"
+        run: poetry add snowflake-snowpark-python --python="==${{ steps.install_python.outputs.python-version }}"
 
       - name: install ibis
         run: poetry install --without dev --without docs --extras "${{ join(matrix.backend.extras, ' ') }}"


### PR DESCRIPTION
Fixes the snowpark install in CI (again). The issue is that passing the optional flag causes the library to not be installed.