### PR TITLE
ci(snowflake-snowpark): test against python 3.10 to avoid clobbering other runs test data

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -61,7 +61,7 @@ jobs:
               extras:
                 - bigquery
                 - geospatial
-          - python-version: "3.11"
+          - python-version: "3.10"
             backend:
               name: snowflake
               title: Snowflake + Snowpark


### PR DESCRIPTION
Sets the python version of the snowpark test job to be 3.10 to avoid clobbering the data in the 3.9 and 3.11 jobs.