### PR TITLE
fix(snowflake-snowpark): disable the `reconnect` method

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -217,6 +217,7 @@ $$ {defn["source"]} $$"""
             session_parameters=session_parameters,
             create_object_udfs=create_object_udfs,
         )
+        self._from_snowpark = False
 
     def _setup_session(self, *, con, session_parameters, create_object_udfs: bool):
         self.con = con
@@ -320,7 +321,15 @@ $$ {defn["source"]} $$"""
             session_parameters={},
             create_object_udfs=create_object_udfs,
         )
+        backend._from_snowpark = True
         return backend
+
+    def reconnect(self) -> None:
+        if self._from_snowpark:
+            raise com.IbisError(
+                "Reconnecting is not supported when using a Snowpark session"
+            )
+        super().reconnect()
 
     def _get_udf_source(self, udf_node: ops.ScalarUDF):
         name = type(udf_node).__name__

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -5,6 +5,7 @@ import contextlib
 import importlib
 import inspect
 import json
+import os
 import re
 import string
 import subprocess
@@ -313,6 +314,11 @@ def test_create_table_from_schema(con, new_schema, temp_table):
     reason="`tbl_properties` is required when creating table with schema",
 )
 def test_create_temporary_table_from_schema(con_no_data, new_schema):
+    if con_no_data.name == "snowflake" and os.environ.get("SNOWFLAKE_SNOWPARK"):
+        with pytest.raises(com.IbisError, match="Reconnecting is not supported"):
+            con_no_data.reconnect()
+        return
+
     temp_table = gen_name(f"test_{con_no_data.name}_tmp")
     table = con_no_data.create_table(temp_table, schema=new_schema, temp=True)
 


### PR DESCRIPTION
It's not yet feasible to call `reconnect` with an Ibis Snowflake backend initialized from a Snowpark connection, so this PR disables that code path.
