### PR TITLE
test(flink): ignore row order when comparing unnested array of structs

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -30,6 +30,7 @@ from ibis.backends.tests.errors import (
     PySparkAnalysisException,
     TrinoUserError,
 )
+from ibis.common.collections import frozendict
 
 pytestmark = [
     pytest.mark.never(
@@ -815,7 +816,9 @@ def test_unnest_struct(con):
     result = con.execute(expr)
 
     expected = pd.DataFrame(data).explode("value").iloc[:, 0].reset_index(drop=True)
-    tm.assert_series_equal(result, expected)
+    assert frozenset(map(frozendict, result.values)) == frozenset(
+        map(frozendict, expected.values)
+    )
 
 
 @builtin_array


### PR DESCRIPTION
Fixes a flaky test that would fail if the unnested array row order was different than the input for the flink backend.