### PR TITLE
fix(duckdb): workaround remaining null map issues

### DIFF
--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -139,7 +139,13 @@ def test_map_values_nulls(con, map):
                     ["pandas", "dask"],
                     reason="result is False instead of None",
                     strict=False,  # passes for contains, but not for get
-                )
+                ),
+                pytest.mark.notimpl(
+                    "flink",
+                    raises=AssertionError,
+                    reason="not yet implemented",
+                    strict=False,
+                ),
             ],
             id="non_null_map_null_key",
         ),

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -61,6 +61,171 @@ def test_map_nulls(con, k, v):
     assert con.execute(m) is None
 
 
+@pytest.mark.notyet("clickhouse", reason="nested types can't be NULL")
+@pytest.mark.broken(["pandas", "dask"], reason="TypeError: iteration over a 0-d array")
+@pytest.mark.notimpl(
+    ["risingwave"],
+    raises=PsycoPg2InternalError,
+    reason="function hstore(character varying[], character varying[]) does not exist",
+)
+@pytest.mark.parametrize(
+    ("k", "v"),
+    [
+        param(None, ["c", "d"], id="null_keys"),
+        param(None, None, id="null_both"),
+    ],
+)
+def test_map_keys_nulls(con, k, v):
+    k = ibis.literal(k, type="array<string>")
+    v = ibis.literal(v, type="array<string>")
+    m = ibis.map(k, v)
+    assert con.execute(m.keys()) is None
+
+
+@pytest.mark.notyet("clickhouse", reason="nested types can't be NULL")
+@pytest.mark.notimpl(
+    ["risingwave"],
+    raises=PsycoPg2InternalError,
+    reason="function hstore(character varying[], character varying[]) does not exist",
+)
+@pytest.mark.parametrize(
+    "map",
+    [
+        param(
+            ibis.map(
+                ibis.literal(["a", "b"]), ibis.literal(None, type="array<string>")
+            ),
+            marks=[
+                pytest.mark.broken(
+                    ["pandas", "dask"], reason="TypeError: iteration over a 0-d array"
+                )
+            ],
+            id="null_values",
+        ),
+        param(
+            ibis.map(
+                ibis.literal(None, type="array<string>"),
+                ibis.literal(None, type="array<string>"),
+            ),
+            marks=[
+                pytest.mark.broken(
+                    ["pandas", "dask"], reason="TypeError: iteration over a 0-d array"
+                )
+            ],
+            id="null_both",
+        ),
+        param(ibis.literal(None, type="map<string, string>"), id="null_map"),
+    ],
+)
+def test_map_values_nulls(con, map):
+    assert con.execute(map.values()) is None
+
+
+@pytest.mark.notimpl(
+    ["risingwave"],
+    raises=PsycoPg2InternalError,
+    reason="function hstore(character varying[], character varying[]) does not exist",
+)
+@pytest.mark.parametrize(
+    ("map", "key"),
+    [
+        param(
+            ibis.map(
+                ibis.literal(["a", "b"]), ibis.literal(["c", "d"], type="array<string>")
+            ),
+            ibis.literal(None, type="string"),
+            marks=[
+                pytest.mark.broken(
+                    ["pandas", "dask"],
+                    reason="result is False instead of None",
+                    strict=False,  # passes for contains, but not for get
+                )
+            ],
+            id="non_null_map_null_key",
+        ),
+        param(
+            ibis.map(
+                ibis.literal(None, type="array<string>"),
+                ibis.literal(None, type="array<string>"),
+            ),
+            "a",
+            marks=[
+                pytest.mark.notyet("clickhouse", reason="nested types can't be NULL"),
+                pytest.mark.broken(
+                    ["pandas", "dask"], reason="TypeError: iteration over a 0-d array"
+                ),
+            ],
+            id="null_both_non_null_key",
+        ),
+        param(
+            ibis.map(
+                ibis.literal(None, type="array<string>"),
+                ibis.literal(None, type="array<string>"),
+            ),
+            ibis.literal(None, type="string"),
+            marks=[
+                pytest.mark.notyet("clickhouse", reason="nested types can't be NULL"),
+                pytest.mark.broken(
+                    ["pandas", "dask"], reason="TypeError: iteration over a 0-d array"
+                ),
+            ],
+            id="null_both_null_key",
+        ),
+        param(
+            ibis.literal(None, type="map<string, string>"),
+            "a",
+            marks=[
+                pytest.mark.notyet("clickhouse", reason="nested types can't be NULL")
+            ],
+            id="null_map_non_null_key",
+        ),
+        param(
+            ibis.literal(None, type="map<string, string>"),
+            ibis.literal(None, type="string"),
+            marks=[
+                pytest.mark.notyet("clickhouse", reason="nested types can't be NULL")
+            ],
+            id="null_map_null_key",
+        ),
+    ],
+)
+@pytest.mark.parametrize("method", ["get", "contains"])
+def test_map_get_contains_nulls(con, map, key, method):
+    expr = getattr(map, method)
+    assert con.execute(expr(key)) is None
+
+
+@pytest.mark.notyet("clickhouse", reason="nested types can't be NULL")
+@pytest.mark.notimpl(
+    ["risingwave"],
+    raises=PsycoPg2InternalError,
+    reason="function hstore(character varying[], character varying[]) does not exist",
+)
+@pytest.mark.parametrize(
+    ("m1", "m2"),
+    [
+        param(
+            ibis.literal(None, type="map<string, string>"),
+            ibis.literal({"a": "b"}, type="map<string, string>"),
+            id="null_and_non_null",
+        ),
+        param(
+            ibis.literal({"a": "b"}, type="map<string, string>"),
+            ibis.literal(None, type="map<string, string>"),
+            id="non_null_and_null",
+        ),
+        param(
+            ibis.literal(None, type="map<string, string>"),
+            ibis.literal(None, type="map<string, string>"),
+            id="null_and_null",
+        ),
+    ],
+)
+def test_map_merge_nulls(con, m1, m2):
+    concatted = m1 + m2
+    assert con.execute(concatted) is None
+
+
 @pytest.mark.notimpl(["pandas", "dask"])
 def test_map_table(backend):
     table = backend.map

--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -76,7 +76,7 @@ class MapValue(Value):
     ├───────────────────┤
     │                 2 │
     │                 0 │
-    │                 0 │
+    │              NULL │
     └───────────────────┘
     """
 
@@ -149,7 +149,7 @@ class MapValue(Value):
         ├───────────────────┤
         │                 2 │
         │                 0 │
-        │                 0 │
+        │              NULL │
         └───────────────────┘
         """
 
@@ -304,7 +304,7 @@ class MapValue(Value):
         ├─────────────────────┤
         │ True                │
         │ False               │
-        │ False               │
+        │ NULL                │
         └─────────────────────┘
         """
         return ops.MapContains(self, key).to_expr()


### PR DESCRIPTION
Closes #8632.

Note that of the backends that support nullable maps, DuckDB is the only one whose `NULL` handling semantics differ.

Other backends that support nullable maps and are implemented in Ibis and tested in CI:

- Postgres (only maps of string -> string via the postgres `hstore` extension)
- PySpark
- Snowflake
- Trino

BREAKING CHANGE: Calling the `get` or `contains` method on `NULL` map values now returns `NULL`. Use `coalesce(map.get(...), default)` or `coalesce(map.contains(), False)` to get the previous behavior.