### PR TITLE
fix(ir): accidentally remapping fields during bind()

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -113,7 +113,7 @@ def bind(table: Table, value: Any, int_as_column=False) -> Iterator[ir.Value]:
         yield value
     elif isinstance(value, Table):
         for name in value.columns:
-            yield ops.Field(table, name).to_expr()
+            yield ops.Field(value, name).to_expr()
     elif isinstance(value, Deferred):
         yield value.resolve(table)
     elif isinstance(value, Resolver):

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -19,12 +19,7 @@ import ibis.selectors as s
 from ibis import _
 from ibis.common.annotations import ValidationError
 from ibis.common.deferred import Deferred
-from ibis.common.exceptions import (
-    ExpressionError,
-    IbisTypeError,
-    IntegrityError,
-    RelationError,
-)
+from ibis.common.exceptions import ExpressionError, IntegrityError, RelationError
 from ibis.expr import api
 from ibis.expr.rewrites import simplify
 from ibis.expr.tests.test_newrels import join_tables
@@ -235,7 +230,7 @@ def test_projection_with_star_expr(table):
 
     # cannot pass an invalid table expression
     t2 = t.aggregate([t["a"].sum().name("sum(a)")], by=["g"])
-    with pytest.raises(IbisTypeError):
+    with pytest.raises(IntegrityError):
         t[[t2]]
     # TODO: there may be some ways this can be invalid
 


### PR DESCRIPTION
Accidentally introduced in #8884 