### PR TITLE
docs: remove `all` extra installation from contributing docs

### DIFF
--- a/conda/environment-arm64-flink.yml
+++ b/conda/environment-arm64-flink.yml
@@ -6,6 +6,7 @@ dependencies:
   - python =3.10
   - atpublic >=2.3
   - bidict >=0.22.1
+  - black >=22.1.0,<25
   - clickhouse-connect >=0.5.23
   - dask >=2022.9.1
   - datafusion >=0.6

--- a/conda/environment-arm64.yml
+++ b/conda/environment-arm64.yml
@@ -6,6 +6,7 @@ dependencies:
   - python >=3.10
   - atpublic >=2.3
   - bidict >=0.22.1
+  - black >=22.1.0,<25
   - clickhouse-connect >=0.5.23
   - dask >=2022.9.1
   - datafusion >=0.6

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - apache-flink
   - atpublic >=2.3
   - bidict >=0.22.1
+  - black >=22.1.0,<25
   - clickhouse-connect >=0.5.23
   - dask >=2022.9.1
   - datafusion >=0.6

--- a/docs/contribute/01_environment.qmd
+++ b/docs/contribute/01_environment.qmd
@@ -97,7 +97,7 @@ for manager, params in managers.items():
     )
     print()
     print("    ```sh")
-    print("    pip install -e '.[all]'")
+    print("    pip install -e .")
     print("    ```")
     print()
 ```
@@ -200,7 +200,7 @@ For a better development experience see the `conda/mamba` or `nix` setup instruc
 1. Install ibis in development mode
 
    ```sh
-   pip install -e '.[all]'
+   pip install -e .
    ```
 
 :::


### PR DESCRIPTION
We removed the `all` extra in a previous PR and it is no longer necessary.

Fixes #9002