### PR TITLE
test: add test for impure function correlation behavior

### DIFF
--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -161,13 +161,13 @@ class PostgresCompiler(SQLGlotCompiler):
         type_mapper = self.type_mapper
         argnames = udf_node.argnames
         return """\
-    CREATE OR REPLACE FUNCTION {ident}({signature})
-    RETURNS {return_type}
-    LANGUAGE {language}
-    AS $$
-    {source}
-    return {name}({args})
-    $$""".format(
+CREATE OR REPLACE FUNCTION {ident}({signature})
+RETURNS {return_type}
+LANGUAGE {language}
+AS $$
+{source}
+return {name}({args})
+$$""".format(
             name=type(udf_node).__name__,
             ident=self.__sql_name__(udf_node),
             signature=", ".join(

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import operator
+import sys
 from collections.abc import Mapping
 from functools import reduce
 from typing import TYPE_CHECKING, Any
@@ -230,6 +231,9 @@ def complexity(node):
     def accum(node, *args):
         if isinstance(node, ops.Field):
             return 1
+        elif isinstance(node, ops.Impure):
+            # consider (potentially) impure functions maximally complex
+            return sys.maxsize
         else:
             return 1 + sum(args)
 

--- a/ibis/backends/tests/errors.py
+++ b/ibis/backends/tests/errors.py
@@ -127,12 +127,13 @@ try:
     from psycopg2.errors import ProgrammingError as PsycoPg2ProgrammingError
     from psycopg2.errors import SyntaxError as PsycoPg2SyntaxError
     from psycopg2.errors import UndefinedObject as PsycoPg2UndefinedObject
+    from psycopg2.errors import UniqueViolation as PsycoPg2UniqueViolation
 except ImportError:
     PsycoPg2SyntaxError = PsycoPg2IndeterminateDatatype = (
         PsycoPg2InvalidTextRepresentation
     ) = PsycoPg2DivisionByZero = PsycoPg2InternalError = PsycoPg2ProgrammingError = (
         PsycoPg2OperationalError
-    ) = PsycoPg2UndefinedObject = PsycoPg2ArraySubscriptError = None
+    ) = PsycoPg2UndefinedObject = PsycoPg2ArraySubscriptError = PsycoPg2UniqueViolation = None
 
 try:
     from psycopg.errors import ArraySubscriptError as PsycoPgArraySubscriptError

--- a/ibis/backends/tests/errors.py
+++ b/ibis/backends/tests/errors.py
@@ -127,13 +127,12 @@ try:
     from psycopg2.errors import ProgrammingError as PsycoPg2ProgrammingError
     from psycopg2.errors import SyntaxError as PsycoPg2SyntaxError
     from psycopg2.errors import UndefinedObject as PsycoPg2UndefinedObject
-    from psycopg2.errors import UniqueViolation as PsycoPg2UniqueViolation
 except ImportError:
     PsycoPg2SyntaxError = PsycoPg2IndeterminateDatatype = (
         PsycoPg2InvalidTextRepresentation
     ) = PsycoPg2DivisionByZero = PsycoPg2InternalError = PsycoPg2ProgrammingError = (
         PsycoPg2OperationalError
-    ) = PsycoPg2UndefinedObject = PsycoPg2ArraySubscriptError = PsycoPg2UniqueViolation = None
+    ) = PsycoPg2UndefinedObject = PsycoPg2ArraySubscriptError = None
 
 try:
     from psycopg.errors import ArraySubscriptError as PsycoPgArraySubscriptError

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1057,6 +1057,7 @@ def test_between(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
+@pytest.mark.notyet(["flink"], reason="timestamp subtraction doesn't work")
 def test_interactive(alltypes, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)
 

--- a/ibis/backends/tests/test_impure.py
+++ b/ibis/backends/tests/test_impure.py
@@ -11,6 +11,9 @@ from ibis.backends.tests.errors import Py4JJavaError
 
 tm = pytest.importorskip("pandas.testing")
 
+# Concurrent execution of CREATE OR REPLACE FUNCTION in postgres fails
+# This ensures that all tests in this module run in the same process as
+# long as --dist=loadgroup is passed, which it is.
 pytestmark = pytest.mark.xdist_group("impure")
 
 no_randoms = [

--- a/ibis/backends/tests/test_impure.py
+++ b/ibis/backends/tests/test_impure.py
@@ -99,9 +99,7 @@ mark_impures = pytest.mark.parametrize(
             lambda table: my_random(table.float_col),
             marks=[
                 *no_udfs,
-                pytest.mark.notyet(
-                    ["flink", "postgres"], reason="instances are uncorrelated"
-                ),
+                pytest.mark.notyet(["flink"], reason="instances are uncorrelated"),
             ],
             id="udf",
         ),

--- a/ibis/backends/tests/test_impure.py
+++ b/ibis/backends/tests/test_impure.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import sys
+
+import pandas.testing as tm
+import pytest
+
+import ibis
+import ibis.common.exceptions as com
+from ibis import _
+from ibis.backends.tests.errors import (
+    PsycoPg2InternalError,
+    Py4JJavaError,
+    PyDruidProgrammingError,
+)
+
+no_randoms = [
+    pytest.mark.notimpl(
+        ["dask", "pandas", "polars"], raises=com.OperationNotDefinedError
+    ),
+    pytest.mark.notimpl("druid", raises=PyDruidProgrammingError),
+    pytest.mark.notyet(
+        "risingwave",
+        raises=PsycoPg2InternalError,
+        reason="function random() does not exist",
+    ),
+]
+
+no_udfs = [
+    pytest.mark.notyet("datafusion", raises=NotImplementedError),
+    pytest.mark.notimpl(
+        [
+            "bigquery",
+            "clickhouse",
+            "dask",
+            "druid",
+            "exasol",
+            "impala",
+            "mssql",
+            "mysql",
+            "oracle",
+            "pandas",
+            "trino",
+            "risingwave",
+        ]
+    ),
+    pytest.mark.notimpl("pyspark", reason="only supports pandas UDFs"),
+    pytest.mark.notyet(
+        "flink",
+        condition=sys.version_info >= (3, 11),
+        raises=Py4JJavaError,
+        reason="Docker image has Python 3.10, results in `cloudpickle` version mismatch",
+    ),
+]
+
+no_uuids = [
+    pytest.mark.notimpl(
+        [
+            "druid",
+            "exasol",
+            "oracle",
+            "polars",
+            "pyspark",
+            "risingwave",
+            "pandas",
+            "dask",
+        ],
+        raises=com.OperationNotDefinedError,
+    ),
+    pytest.mark.notyet("mssql", reason="Unrelated bug: Incorrect syntax near '('"),
+]
+
+
+@ibis.udf.scalar.python(side_effects=True)
+def my_random(x: float) -> float:
+    # need to make the whole UDF self-contained for postgres to work
+    import random
+
+    return random.random()  # noqa: S311
+
+
+mark_impures = pytest.mark.parametrize(
+    "impure",
+    [
+        pytest.param(
+            lambda _: ibis.random(),
+            marks=no_randoms,
+            id="random",
+        ),
+        pytest.param(
+            lambda _: ibis.uuid().cast(str).contains("a").ifelse(1, 0),
+            marks=[
+                *no_uuids,
+                pytest.mark.notyet("impala", reason="instances are uncorrelated"),
+            ],
+            id="uuid",
+        ),
+        pytest.param(
+            lambda table: my_random(table.float_col),
+            marks=[
+                *no_udfs,
+                pytest.mark.notyet(
+                    ["flink", "postgres"], reason="instances are uncorrelated"
+                ),
+            ],
+            id="udf",
+        ),
+    ],
+)
+
+
+@pytest.mark.notyet("sqlite", reason="instances are uncorrelated")
+@mark_impures
+def test_impure_correlated(alltypes, impure):
+    # An "impure" expression is random(), uuid(), or some other non-deterministic UDF.
+    # If we evaluate it for two different rows in the same relation,
+    # we might get different results. This is expected.
+    # But, as soon as we .select() it into a new relation, then that "locks in" the
+    # value, and any further references to it will be the same.
+    # eg if you look at the following SQL:
+    # WITH
+    #   t AS (SELECT random() AS common)
+    # SELECT common as x, common as y FROM t
+    # Then both x and y should have the same value.
+    df = (
+        alltypes.select(common=impure(alltypes))
+        .select(x=_.common, y=_.common)
+        .execute()
+    )
+    tm.assert_series_equal(df.x, df.y, check_names=False)
+
+
+@pytest.mark.notyet("sqlite", reason="instances are uncorrelated")
+@mark_impures
+def test_chained_selections(alltypes, impure):
+    # https://github.com/ibis-project/ibis/issues/8921#issue-2234327722
+    # This is a slightly more complex version of test_impure_correlated.
+    # consider this SQL:
+    # WITH
+    #   t AS (SELECT random() AS num)
+    # SELECT num, num > 0.5 AS isbig FROM t
+    # We would expect that the value of num and isbig are consistent,
+    # since we "lock in" the value of num by selecting it into t.
+    t = alltypes.select(num=impure(alltypes))
+    t = t.mutate(isbig=(t.num > 0.5))
+    df = t.execute()
+    df["expected"] = df.num > 0.5
+    tm.assert_series_equal(df.isbig, df.expected, check_names=False)
+
+
+impure_params_uncorrelated = pytest.mark.parametrize(
+    "impure",
+    [
+        pytest.param(
+            lambda _: ibis.random(),
+            marks=[
+                *no_randoms,
+                pytest.mark.notyet(
+                    ["impala", "trino"], reason="instances are correlated"
+                ),
+            ],
+            id="random",
+        ),
+        pytest.param(
+            # make this a float so we can compare to .5
+            lambda _: ibis.uuid().cast(str).contains("a").ifelse(1, 0),
+            marks=[
+                *no_uuids,
+                pytest.mark.notyet(
+                    ["mysql", "trino"], reason="instances are correlated"
+                ),
+            ],
+            id="uuid",
+        ),
+        pytest.param(
+            lambda table: my_random(table.float_col),
+            marks=[
+                *no_udfs,
+                pytest.mark.notyet("duckdb", reason="instances are correlated"),
+            ],
+            id="udf",
+        ),
+    ],
+)
+
+
+@pytest.mark.notyet(["clickhouse"], reason="instances are correlated")
+@impure_params_uncorrelated
+def test_impure_uncorrelated_different_id(alltypes, impure):
+    # This is the opposite of test_impure_correlated.
+    # If we evaluate an impure expression for two different rows in the same relation,
+    # the should be uncorrelated.
+    # eg if you look at the following SQL:
+    # select random() as x, random() as y
+    # Then x and y should be uncorrelated.
+    df = alltypes.select(x=impure(alltypes), y=impure(alltypes)).execute()
+    assert (df.x != df.y).any()
+
+
+@pytest.mark.notyet(["clickhouse"], reason="instances are correlated")
+@impure_params_uncorrelated
+def test_impure_uncorrelated_same_id(alltypes, impure):
+    # Similar to test_impure_uncorrelated_different_id, but the two expressions
+    # have the same ID. Still, they should be uncorrelated.
+    common = impure(alltypes)
+    df = alltypes.select(x=common, y=common).execute()
+    assert (df.x != df.y).any()

--- a/ibis/expr/decompile.py
+++ b/ibis/expr/decompile.py
@@ -38,7 +38,6 @@ _method_overrides = {
     ops.StringContains: "contains",
     ops.StringSQLILike: "ilike",
     ops.StringSQLLike: "like",
-    ops.TimestampNow: "now",
 }
 
 
@@ -82,6 +81,11 @@ class CallStatement:
 def translate(op, *args, **kwargs):
     """Translate an ibis operation into a Python expression."""
     raise NotImplementedError(op)
+
+
+@translate.register(ops.TimestampNow)
+def now(_):
+    return "ibis.now()"
 
 
 @translate.register(ops.Value)

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -189,7 +189,7 @@ class Impure(Value):
 
 
 @public
-class TimestampNow(Constant):
+class TimestampNow(Impure):
     """Return the current timestamp."""
 
     dtype = dt.timestamp
@@ -197,7 +197,7 @@ class TimestampNow(Constant):
 
 
 @public
-class DateNow(Constant):
+class DateNow(Impure):
     """Return the current date."""
 
     dtype = dt.date

--- a/ibis/expr/operations/generic.py
+++ b/ibis/expr/operations/generic.py
@@ -193,6 +193,7 @@ class TimestampNow(Constant):
     """Return the current timestamp."""
 
     dtype = dt.timestamp
+    shape = ds.scalar
 
 
 @public
@@ -200,6 +201,7 @@ class DateNow(Constant):
     """Return the current date."""
 
     dtype = dt.date
+    shape = ds.scalar
 
 
 @public

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -51,7 +51,7 @@ class InputType(enum.Enum):
 
 
 @public
-class ScalarUDF(ops.Value):
+class ScalarUDF(ops.Impure):
     @attribute
     def shape(self):
         if not (args := getattr(self, "args")):  # noqa: B009
@@ -65,7 +65,7 @@ class ScalarUDF(ops.Value):
 
 
 @public
-class AggUDF(ops.Reduction):
+class AggUDF(ops.Reduction, ops.Impure):
     where: Optional[ops.Value[dt.Boolean]] = None
 
 


### PR DESCRIPTION
Related to https://github.com/ibis-project/ibis/issues/8921,
trying to write down exactly what the expected behavior is.

I figure we can use this PR to hash out exaclty what we want the semantics to be, and then the other discussions might be easier because our goal is written down precisely somewhere. Please let me know if you agree or disagree with this behavior, or if there are other tests we should add.

Need to fix the UDF test case in a followup. Also wasn't sure where to put these tests, I put them in their own little file but if you point me elsewhere Iwill move them.