### PR TITLE
ci: make skip helper jobs match non-skip-helper workflows

### DIFF
--- a/.github/workflows/ibis-backends-skip-helper.yml
+++ b/.github/workflows/ibis-backends-skip-helper.yml
@@ -35,11 +35,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No build required"
+  test_pyspark:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No build required"
   backends:
     # this job exists so that we can use a single job from this workflow to gate merging
     runs-on: ubuntu-latest
     needs:
       - test_backends_min_version
       - test_backends
+      - test_pyspark
     steps:
       - run: exit 0


### PR DESCRIPTION
I _think_ this should prevent weird merge-even-though-the-things-failed problems observed in https://github.com/ibis-project/ibis/pull/9015.