### PR TITLE
fix(dask): fix argmin/argmax implementation for dask

### DIFF
--- a/ibis/backends/dask/executor.py
+++ b/ibis/backends/dask/executor.py
@@ -52,7 +52,8 @@ def limit_df(
 
 
 def argminmax_chunk(df, keycol, valcol, method):
-    return df.iloc[getattr(df[keycol], method)()]
+    idx = getattr(df[keycol], method)()
+    return df[[keycol, valcol]].iloc[idx : idx + 1]
 
 
 def argminmax_aggregate(df, keycol, valcol, method):


### PR DESCRIPTION
Fixes a bug introduced in #9015 that was masked by pandas magically doing the right thing in newer pandas versions.