### PR TITLE
fix: make devcontainer work correctly

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,4 @@
 FROM mcr.microsoft.com/vscode/devcontainers/python:3.11
 
-RUN apt-get update && apt-get install -y --no-install-recommends libgdal-dev
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends libgdal-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
-  "image": "mcr.microsoft.com/vscode/devcontainers/python:3.11",
-  "updateContentCommand": ".devcontainer/updateContent.sh",
+  "build": { "dockerfile": "Dockerfile" },
+  "postCreateCommand": ".devcontainer/postCreate.sh",
   "customizations": {
     "codespaces": {
       "openFiles": ["docs/tutorials/getting_started.qmd"]

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # install ibis
 python3 -m pip install ipython


### PR DESCRIPTION
## Description of changes

These change are what was required for me to get the devcontainer to run on my machine. Before these changes, the devcontainer image wasn't building correctly because it was missing gdal. The root cause of that was that the devcontainer.json wasn't using the Dockerfile.

- The previous devcontainer.json wasn't actually using the Dockerfile, now it does
- In devcontainer.json, I switched updateContent command for postCreateCommand as that looks more appropriate based on the docs
- A couple of minor tidying changes

## Issues closed

Resolves #9011

