### PR TITLE
feat(postgres): support loading tables with `pgvector` column types

### DIFF
--- a/ci/schema/postgres.sql
+++ b/ci/schema/postgres.sql
@@ -121,21 +121,6 @@ CREATE TABLE awards_players (
 
 COPY awards_players FROM '/data/awards_players.csv' WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',');
 
-DROP TYPE IF EXISTS vector CASCADE;
-CREATE TYPE vector AS (
-  x FLOAT8,
-  y FLOAT8,
-  z FLOAT8
-);
-
-DROP VIEW IF EXISTS awards_players_special_types CASCADE;
-CREATE VIEW awards_players_special_types AS
-SELECT
-    *,
-    setweight(to_tsvector('simple', notes), 'A')::TSVECTOR AS search,
-    NULL::vector AS simvec
-FROM awards_players;
-
 DROP TABLE IF EXISTS functional_alltypes CASCADE;
 
 CREATE TABLE functional_alltypes (
@@ -302,3 +287,18 @@ DROP TABLE IF EXISTS topk;
 
 CREATE TABLE topk (x BIGINT);
 INSERT INTO topk VALUES (1), (1), (NULL);
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+DROP VIEW IF EXISTS awards_players_special_types CASCADE;
+CREATE VIEW awards_players_special_types AS
+SELECT
+    *,
+    setweight(to_tsvector('simple', notes), 'A')::TSVECTOR AS search,
+    NULL::vector AS simvec
+FROM awards_players;
+
+
+DROP TABLE IF EXISTS items CASCADE;
+CREATE TABLE items (id bigserial PRIMARY KEY, embedding vector(3));
+INSERT INTO items (embedding) VALUES ('[1,2,3]'), ('[4,5,6]');

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,2 +1,16 @@
+FROM postgis/postgis:15-3.3-alpine AS pgvector-builder
+RUN apk add --no-cache git
+RUN apk add --no-cache build-base
+RUN apk add --no-cache clang15
+RUN apk add --no-cache llvm15-dev llvm15
+WORKDIR /tmp
+RUN git clone --branch v0.6.2 https://github.com/pgvector/pgvector.git
+WORKDIR /tmp/pgvector
+RUN make
+RUN make install
+
 FROM postgis/postgis:15-3.3-alpine
 RUN apk add --no-cache postgresql15-plpython3
+COPY --from=pgvector-builder /usr/local/lib/postgresql/bitcode/vector.index.bc /usr/local/lib/postgresql/bitcode/vector.index.bc
+COPY --from=pgvector-builder /usr/local/lib/postgresql/vector.so /usr/local/lib/postgresql/vector.so
+COPY --from=pgvector-builder /usr/local/share/postgresql/extension /usr/local/share/postgresql/extension

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -404,6 +404,16 @@ class PostgresType(SqlglotType):
             raise com.IbisTypeError("Postgres only supports string values in maps")
         return sge.DataType(this=typecode.HSTORE)
 
+    @classmethod
+    def from_string(cls, text: str, nullable: bool | None = None) -> dt.DataType:
+        if text.lower().startswith("vector"):
+            text = "vector"
+        if dtype := cls.unknown_type_strings.get(text.lower()):
+            return dtype
+
+        sgtype = sg.parse_one(text, into=sge.DataType, read=cls.dialect)
+        return cls.to_ibis(sgtype, nullable=nullable)
+
 
 class RisingWaveType(PostgresType):
     dialect = "risingwave"


### PR DESCRIPTION
Resolves #9025

We have had support for a bare `vector` type for a while, but `pgvector` defines
their vector type with precision, like `vector(3)` which was breaking our dtype
parsing.

I've opted to check here if the type starts with `vector` and treat all of those as `dt.unknown`.

For testing this, I've added `pgvector` to the postgres dockerfile -- if that's
too heavy, we can maybe mock up something in the `postgres.sql` file?  But it
does compile reasonably quickly on my machine (~4 seconds).