### PR TITLE
feat(common): also traverse nodes used as dictionary keys

### DIFF
--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import itertools
 from abc import abstractmethod
 from collections import deque
 from collections.abc import Iterable, Iterator, KeysView, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 
 from ibis.common.bases import Hashable
-from ibis.common.collections import frozendict
 from ibis.common.patterns import NoMatch, Pattern
 from ibis.common.typing import _ClassInfo
 from ibis.util import experimental, promote_list
@@ -66,8 +66,9 @@ def _flatten_collections(node: Any) -> Iterator[N]:
             yield item
         elif isinstance(item, (tuple, list)):
             yield from _flatten_collections(item)
-        elif isinstance(item, (dict, frozendict)):
-            yield from _flatten_collections(item.values())
+        elif isinstance(item, dict):
+            items = itertools.chain.from_iterable(item.items())
+            yield from _flatten_collections(items)
 
 
 def _recursive_lookup(obj: Any, dct: dict) -> Any:
@@ -89,6 +90,7 @@ def _recursive_lookup(obj: Any, dct: dict) -> Any:
 
     Examples
     --------
+    >>> from ibis.common.collections import frozendict
     >>> from ibis.common.grounds import Concrete
     >>> from ibis.common.graph import Node
     >>>
@@ -117,8 +119,10 @@ def _recursive_lookup(obj: Any, dct: dict) -> Any:
         return dct.get(obj, obj)
     elif isinstance(obj, (tuple, list)):
         return tuple(_recursive_lookup(o, dct) for o in obj)
-    elif isinstance(obj, (dict, frozendict)):
-        return {k: _recursive_lookup(v, dct) for k, v in obj.items()}
+    elif isinstance(obj, dict):
+        return {
+            _recursive_lookup(k, dct): _recursive_lookup(v, dct) for k, v in obj.items()
+        }
     else:
         return obj
 

--- a/ibis/common/tests/test_graph.py
+++ b/ibis/common/tests/test_graph.py
@@ -55,6 +55,7 @@ D = MyNode(name="D", children=[])
 E = MyNode(name="E", children=[])
 B = MyNode(name="B", children=[D, E])
 A = MyNode(name="A", children=[B, C])
+F = MyNode(name="F", children=[{C: D, E: None}])
 
 
 def test_bfs():
@@ -68,8 +69,8 @@ def test_construction():
 
 
 def test_graph_nodes():
-    g = Graph(A)
-    assert g.nodes() == {A, B, C, D, E}
+    assert Graph(A).nodes() == {A, B, C, D, E}
+    assert Graph(F).nodes() == {F, C, D, E}
 
 
 def test_graph_repr():
@@ -286,6 +287,10 @@ def test_flatten_collections():
     )
     assert list(result) == [A, C, D]
 
+    # test that dictionary keys are also flattened
+    result = _flatten_collections([0.0, {A: B, C: [D]}, frozendict({E: 6})])
+    assert list(result) == [A, B, C, D, E]
+
 
 def test_recursive_lookup():
     results = {A: "A", B: "B", C: "C", D: "D"}
@@ -311,6 +316,9 @@ def test_recursive_lookup():
         ("B", "A"),
         my_map,
     )
+
+    # test that dictionary nodes as dictionary keys are also looked up
+    assert _recursive_lookup({A: B, C: D}, results) == {"A": "B", "C": "D"}
 
 
 def test_coerce_finder():


### PR DESCRIPTION
This change allows repr-ing node mappings, like the dereference mappings for easier inspection.

Inevitably this is slowing down the traversals, but changing the instance checks to use a plain dict instead of `(dict, frozendict)` maintains the previous traversal speed:

```
---------------------------------------------------------------------------- benchmark 'test_bfs': 2 tests -----------------------------------------------------------------------------
Name (time in ms)              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bfs (0738_9355281)     1.3995 (1.0)      1.5527 (1.05)     1.4131 (1.0)      0.0173 (2.86)     1.4101 (1.0)      0.0094 (2.24)        22;22  707.6590 (1.0)         442           1
test_bfs (NOW)              1.4234 (1.02)     1.4826 (1.0)      1.4338 (1.01)     0.0060 (1.0)      1.4333 (1.02)     0.0042 (1.0)         42;16  697.4705 (0.99)        370           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_dfs': 2 tests -----------------------------------------------------------------------------
Name (time in ms)              Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_dfs (0738_9355281)     1.4105 (1.0)      1.5869 (1.08)     1.4272 (1.0)      0.0222 (4.31)     1.4227 (1.0)      0.0087 (2.09)        29;32  700.6742 (1.0)         381           1
test_dfs (NOW)              1.4381 (1.02)     1.4726 (1.0)      1.4454 (1.01)     0.0051 (1.0)      1.4446 (1.02)     0.0042 (1.0)         41;23  691.8344 (0.99)        418           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------- benchmark 'test_equality_caching': 2 tests ----------------------------------------------------------------------------------
Name (time in ns)                             Min                 Max                Mean            StdDev              Median               IQR            Outliers  OPS (Mops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_equality_caching (0738_9355281)     151.2501 (1.01)     205.8300 (1.15)     152.8526 (1.00)     4.5554 (2.08)     152.0900 (1.00)     0.4200 (1.0)          4;27        6.5423 (1.00)        200         100
test_equality_caching (NOW)              150.4200 (1.0)      178.7501 (1.0)      152.3245 (1.0)      2.1914 (1.0)      152.0800 (1.0)      0.8300 (1.98)         8;15        6.5649 (1.0)         200         100
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_replace_mapping': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                          Min                Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_replace_mapping (0738_9355281)     7.3154 (1.0)      28.8150 (1.05)     7.6806 (1.02)     2.5469 (1.42)     7.3525 (1.0)      0.0231 (1.69)          2;6  130.1986 (0.98)        123           1
test_replace_mapping (NOW)              7.3534 (1.01)     27.3207 (1.0)      7.5403 (1.0)      1.7984 (1.0)      7.3719 (1.00)     0.0137 (1.0)          1;12  132.6202 (1.0)         123           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------ benchmark 'test_replace_pattern': 2 tests ------------------------------------------------------------------------------
Name (time in ms)                           Min                Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_replace_pattern (0738_9355281)     10.5733 (1.0)      30.5281 (1.07)     10.8404 (1.0)      2.1232 (1.10)     10.6082 (1.0)      0.0281 (1.0)           1;4  92.2472 (1.0)          88           1
test_replace_pattern (NOW)              10.6792 (1.01)     28.5771 (1.0)      10.9808 (1.01)     1.9221 (1.0)      10.7539 (1.01)     0.0330 (1.17)          1;8  91.0683 (0.99)         86           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
