### PR TITLE
feat(pyspark): implement support for window_by op

### DIFF
--- a/ibis/backends/flink/compiler.py
+++ b/ibis/backends/flink/compiler.py
@@ -148,9 +148,9 @@ class FlinkCompiler(SQLGlotCompiler):
             spec.args["end_side"] = None
         return spec
 
-    def visit_TumbleWindowingTVF(self, op, *, table, time_col, window_size, offset):
+    def visit_TumbleWindowingTVF(self, op, *, parent, time_col, window_size, offset):
         args = [
-            self.v[f"TABLE {table.this.sql(self.dialect)}"],
+            self.v[f"TABLE {parent.this.sql(self.dialect)}"],
             # `time_col` has the table _alias_, instead of the table, but it is
             # required to be bound to the table, this happens because of the
             # way we construct the op in the tumble API using bind
@@ -163,19 +163,19 @@ class FlinkCompiler(SQLGlotCompiler):
 
         return sg.select(
             sge.Column(
-                this=STAR, table=sg.to_identifier(table.alias_or_name, quoted=True)
+                this=STAR, table=sg.to_identifier(parent.alias_or_name, quoted=True)
             )
         ).from_(
             self.f.table(self.f.tumble(*filter(None, args))).as_(
-                table.alias_or_name, quoted=True
+                parent.alias_or_name, quoted=True
             )
         )
 
     def visit_HopWindowingTVF(
-        self, op, *, table, time_col, window_size, window_slide, offset
+        self, op, *, parent, time_col, window_size, window_slide, offset
     ):
         args = [
-            self.v[f"TABLE {table.this.sql(self.dialect)}"],
+            self.v[f"TABLE {parent.this.sql(self.dialect)}"],
             self.f.descriptor(time_col.this),
             window_slide,
             window_size,
@@ -183,19 +183,19 @@ class FlinkCompiler(SQLGlotCompiler):
         ]
         return sg.select(
             sge.Column(
-                this=STAR, table=sg.to_identifier(table.alias_or_name, quoted=True)
+                this=STAR, table=sg.to_identifier(parent.alias_or_name, quoted=True)
             )
         ).from_(
             self.f.table(self.f.hop(*filter(None, args))).as_(
-                table.alias_or_name, quoted=True
+                parent.alias_or_name, quoted=True
             )
         )
 
     def visit_CumulateWindowingTVF(
-        self, op, *, table, time_col, window_size, window_step, offset
+        self, op, *, parent, time_col, window_size, window_step, offset
     ):
         args = [
-            self.v[f"TABLE {table.this.sql(self.dialect)}"],
+            self.v[f"TABLE {parent.this.sql(self.dialect)}"],
             self.f.descriptor(time_col.this),
             window_step,
             window_size,
@@ -203,11 +203,11 @@ class FlinkCompiler(SQLGlotCompiler):
         ]
         return sg.select(
             sge.Column(
-                this=STAR, table=sg.to_identifier(table.alias_or_name, quoted=True)
+                this=STAR, table=sg.to_identifier(parent.alias_or_name, quoted=True)
             )
         ).from_(
             self.f.table(self.f.cumulate(*filter(None, args))).as_(
-                table.alias_or_name, quoted=True
+                parent.alias_or_name, quoted=True
             )
         )
 

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import calendar
 import itertools
 import re
-from functools import partial
 
 import sqlglot as sg
 import sqlglot.expressions as sge

--- a/ibis/expr/operations/temporal_windows.py
+++ b/ibis/expr/operations/temporal_windows.py
@@ -13,7 +13,13 @@ from ibis.expr.schema import Schema
 
 @public
 class WindowingTVF(Relation):
-    """Generic windowing table-valued function."""
+    """Generic windowing table-valued function.
+
+    Table-valued functions return tables.
+
+    Windowing TVFs in Ibis return the original columns plus `window_start`,
+    `window_end`, and `window_time`.
+    """
 
     # TODO(kszucs): rename to `parent`
     table: Relation
@@ -28,14 +34,7 @@ class WindowingTVF(Relation):
         names = list(self.table.schema.names)
         types = list(self.table.schema.types)
 
-        # The return value of windowing TVF is a new relation that includes all columns
-        # of original relation as well as additional 3 columns named “window_start”,
-        # “window_end”, “window_time” to indicate the assigned window
-
-        # TODO(kszucs): this looks like an implementation detail leaked from the
-        # flink backend
         names.extend(["window_start", "window_end", "window_time"])
-        # window_start, window_end, window_time have type TIMESTAMP(3) in Flink
         types.extend([dt.timestamp(scale=3)] * 3)
 
         return Schema.from_tuples(list(zip(names, types)))

--- a/ibis/expr/operations/temporal_windows.py
+++ b/ibis/expr/operations/temporal_windows.py
@@ -21,18 +21,17 @@ class WindowingTVF(Relation):
     `window_end`, and `window_time`.
     """
 
-    # TODO(kszucs): rename to `parent`
-    table: Relation
+    parent: Relation
     time_col: Column[dt.Timestamp]  # enforce timestamp column type here
 
     @attribute
     def values(self):
-        return self.table.fields
+        return self.parent.fields
 
     @property
     def schema(self):
-        names = list(self.table.schema.names)
-        types = list(self.table.schema.types)
+        names = list(self.parent.schema.names)
+        types = list(self.parent.schema.types)
 
         names.extend(["window_start", "window_end", "window_time"])
         types.extend([dt.timestamp(scale=3)] * 3)

--- a/ibis/expr/types/temporal_windows.py
+++ b/ibis/expr/types/temporal_windows.py
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
 class WindowedTable:
     """An intermediate table expression to hold windowing information."""
 
-    def __init__(self, table: ir.Table, time_col: ir.Value):
-        self.table = table
-        self.time_col = next(bind(table, time_col))
+    def __init__(self, parent: ir.Table, time_col: ir.Value):
+        self.parent = parent
+        self.time_col = next(bind(parent, time_col))
 
         if self.time_col is None:
             raise com.IbisInputError(
@@ -48,9 +48,9 @@ class WindowedTable:
         Table
             Table expression after applying tumbling table-valued function.
         """
-        time_col = next(bind(self.table, self.time_col))
+        time_col = next(bind(self.parent, self.time_col))
         return ops.TumbleWindowingTVF(
-            table=self.table,
+            parent=self.parent,
             time_col=time_col,
             window_size=window_size,
             offset=offset,
@@ -87,9 +87,9 @@ class WindowedTable:
         Table
             Table expression after applying hopping table-valued function.
         """
-        time_col = next(bind(self.table, self.time_col))
+        time_col = next(bind(self.parent, self.time_col))
         return ops.HopWindowingTVF(
-            table=self.table,
+            parent=self.parent,
             time_col=time_col,
             window_size=window_size,
             window_slide=window_slide,
@@ -125,9 +125,9 @@ class WindowedTable:
         Table
             Table expression after applying cumulate table-valued function.
         """
-        time_col = next(bind(self.table, self.time_col))
+        time_col = next(bind(self.parent, self.time_col))
         return ops.CumulateWindowingTVF(
-            table=self.table,
+            parent=self.parent,
             time_col=time_col,
             window_size=window_size,
             window_step=window_step,


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

1. Implement support for `window_by` in pyspark backend.
2. Code cleanup/refactor.

## Issues closed

#8847
