### PR TITLE
fix(pyspark): ensure that the output of zip matches the expected ibis schema

### DIFF
--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -349,7 +349,7 @@ class PySparkCompiler(SQLGlotCompiler):
             return self.if_(self.f.map_contains_key(arg, key), arg[key], default)
 
     def visit_ArrayZip(self, op, *, arg):
-        return self.f.arrays_zip(*arg)
+        return self.cast(self.f.arrays_zip(*arg), op.dtype)
 
     def visit_ArrayMap(self, op, *, arg, body, param):
         param = sge.Identifier(this=param)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1404,7 +1404,7 @@ def test_array_literal_with_exprs(con, input, expected):
 
 
 @pytest.mark.notimpl(
-    ["datafusion", "postgres", "pandas", "polars", "risingwave", "dask"],
+    ["datafusion", "postgres", "pandas", "polars", "risingwave", "dask", "flink"],
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.broken(


### PR DESCRIPTION
Fix PySpark zip implementation to ensure that its output matches the schema expected by Ibis. Fixes #9049.