### PR TITLE
feat(postgres): add mappings for more esoteric dtypes

### DIFF
--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -295,3 +295,19 @@ def test_pgvector_type_load(con):
     )
 
     con.drop_table("itemsvrandom")
+
+
+def test_name_dtype(con):
+    expected_schema = ibis.schema(
+        {
+            "f_table_catalog": dt.String(nullable=True),
+            "f_table_schema": dt.String(nullable=True),
+            "f_table_name": dt.String(nullable=True),
+            "f_geometry_column": dt.String(nullable=True),
+            "coord_dimension": dt.Int32(nullable=True),
+            "srid": dt.Int32(nullable=True),
+            "type": dt.String(nullable=True),
+        }
+    )
+
+    assert con.tables.geometry_columns.schema() == expected_schema

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -311,3 +311,68 @@ def test_name_dtype(con):
     )
 
     assert con.tables.geometry_columns.schema() == expected_schema
+
+
+def test_infoschema_dtypes(con):
+    # information_schema.views
+
+    #   |----------------------------+----------------|
+    #   | table_catalog              | sql_identifier |
+    #   | table_schema               | sql_identifier |
+    #   | table_name                 | sql_identifier |
+    #   | view_definition            | character_data |
+    #   | check_option               | character_data |
+    #   | is_updatable               | yes_or_no      |
+    #   | is_insertable_into         | yes_or_no      |
+    #   | is_trigger_updatable       | yes_or_no      |
+    #   | is_trigger_deletable       | yes_or_no      |
+    #   | is_trigger_insertable_into | yes_or_no      |
+    #   |----------------------------+----------------|
+    #
+    views_schema = ibis.schema(
+        {
+            "table_catalog": dt.String(nullable=True),
+            "table_schema": dt.String(nullable=True),
+            "table_name": dt.String(nullable=True),
+            "view_definition": dt.String(nullable=True),
+            "check_option": dt.String(nullable=True),
+            "is_updatable": dt.String(nullable=True),
+            "is_insertable_into": dt.String(nullable=True),
+            "is_trigger_updatable": dt.String(nullable=True),
+            "is_trigger_deletable": dt.String(nullable=True),
+            "is_trigger_insertable_into": dt.String(nullable=True),
+        }
+    )
+
+    assert con.table("views", database="information_schema").schema() == views_schema
+
+    # information_schema.sql_sizing
+
+    #   |-----------------+-----------------|
+    #   | sizing_id       | cardinal_number |
+    #   | sizing_name     | character_data  |
+    #   | supported_value | cardinal_number |
+    #   | comments        | character_data  |
+    #   |-----------------+-----------------|
+
+    sql_sizing_schema = ibis.schema(
+        {
+            "sizing_id": dt.UInt64(nullable=True),
+            "sizing_name": dt.String(nullable=True),
+            "supported_value": dt.UInt64(nullable=True),
+            "comments": dt.String(nullable=True),
+        }
+    )
+
+    assert (
+        con.table("sql_sizing", database="information_schema").schema()
+        == sql_sizing_schema
+    )
+
+    # information_schema.triggers has a `created` field with the custom timestamp type
+    triggers_created_schema = ibis.schema({"created": dt.Timestamp()})
+
+    assert (
+        con.table("triggers", database="information_schema").select("created").schema()
+        == triggers_created_schema
+    )

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -369,7 +369,11 @@ class SqlglotType(TypeMapper):
             return sge.DataType(this=getattr(typecode, geotype.upper()))
         return sge.DataType(this=typecode.GEOMETRY)
 
-    _from_ibis_Point = _from_ibis_LineString = _from_ibis_Polygon = (
+    _from_ibis_Point = (
+        _from_ibis_LineString
+    ) = (
+        _from_ibis_Polygon
+    ) = (
         _from_ibis_MultiLineString
     ) = _from_ibis_MultiPoint = _from_ibis_MultiPolygon = _from_ibis_GeoSpatial
 
@@ -393,6 +397,7 @@ class PostgresType(SqlglotType):
             "macaddr[]": dt.Array(dt.macaddr),
             "macaddr8": dt.macaddr,
             "macaddr8[]": dt.Array(dt.macaddr),
+            "name": dt.string,
         }
     )
 
@@ -757,9 +762,11 @@ class BigQueryType(SqlglotType):
     def _from_sqlglot_TINYINT(cls) -> dt.Int64:
         return dt.Int64(nullable=cls.default_nullable)
 
-    _from_sqlglot_UINT = _from_sqlglot_USMALLINT = _from_sqlglot_UTINYINT = (
-        _from_sqlglot_INT
-    ) = _from_sqlglot_SMALLINT = _from_sqlglot_TINYINT
+    _from_sqlglot_UINT = (
+        _from_sqlglot_USMALLINT
+    ) = (
+        _from_sqlglot_UTINYINT
+    ) = _from_sqlglot_INT = _from_sqlglot_SMALLINT = _from_sqlglot_TINYINT
 
     @classmethod
     def _from_sqlglot_UBIGINT(cls) -> NoReturn:

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -369,11 +369,7 @@ class SqlglotType(TypeMapper):
             return sge.DataType(this=getattr(typecode, geotype.upper()))
         return sge.DataType(this=typecode.GEOMETRY)
 
-    _from_ibis_Point = (
-        _from_ibis_LineString
-    ) = (
-        _from_ibis_Polygon
-    ) = (
+    _from_ibis_Point = _from_ibis_LineString = _from_ibis_Polygon = (
         _from_ibis_MultiLineString
     ) = _from_ibis_MultiPoint = _from_ibis_MultiPolygon = _from_ibis_GeoSpatial
 
@@ -398,6 +394,17 @@ class PostgresType(SqlglotType):
             "macaddr8": dt.macaddr,
             "macaddr8[]": dt.Array(dt.macaddr),
             "name": dt.string,
+            # information schema dtypes
+            # defined as nonnegative int
+            "information_schema.cardinal_number": dt.uint64,
+            # character string with no specific max length
+            "information_schema.character_data": dt.string,
+            # same as above but used for SQL identifiers
+            "information_schema.sql_identifier": dt.string,
+            # "domain over type `timestamp with time zone`"
+            "information_schema.time_stamp": dt.timestamp,
+            # the pre-bool version of bool kept for backwards compatibility
+            "information_schema.yes_or_no": dt.string,
         }
     )
 
@@ -762,11 +769,9 @@ class BigQueryType(SqlglotType):
     def _from_sqlglot_TINYINT(cls) -> dt.Int64:
         return dt.Int64(nullable=cls.default_nullable)
 
-    _from_sqlglot_UINT = (
-        _from_sqlglot_USMALLINT
-    ) = (
-        _from_sqlglot_UTINYINT
-    ) = _from_sqlglot_INT = _from_sqlglot_SMALLINT = _from_sqlglot_TINYINT
+    _from_sqlglot_UINT = _from_sqlglot_USMALLINT = _from_sqlglot_UTINYINT = (
+        _from_sqlglot_INT
+    ) = _from_sqlglot_SMALLINT = _from_sqlglot_TINYINT
 
     @classmethod
     def _from_sqlglot_UBIGINT(cls) -> NoReturn:


### PR DESCRIPTION
Resolves #8845

Postgres' `information_schema` has a few custom dtypes that are only used there. Most of them just map to stringlike things, but users should be able to load these tables without issue.

I also added a mapping for the `name` type, which shows up in some of the default tables in `postgis`.