### PR TITLE
test(flink): fix flakiness in test results output order

### DIFF
--- a/ibis/backends/flink/tests/test_memtable.py
+++ b/ibis/backends/flink/tests/test_memtable.py
@@ -35,9 +35,8 @@ def test_create_memtable(con, data, schema, expected):
     # cannot use con.execute(t) directly because of some behavioral discrepancy between
     # `TableEnvironment.execute_sql()` and `TableEnvironment.sql_query()`; this doesn't
     # seem to be an issue if we don't execute memtable directly
-    result = con.raw_sql(con.compile(t))
-    # raw_sql() returns a `TableResult` object and doesn't natively convert to pandas
-    assert list(result.collect()) == expected
+    result = con.raw_sql(con.compile(t)).collect()
+    assert all(element in result for element in expected)
 
 
 @pytest.mark.notyet(


### PR DESCRIPTION
Fix flaky flink test output order.