### PR TITLE
fix(pyspark): remove use of attribute that prevents using spark connect

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -197,7 +197,6 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
 
             session = SparkSession.builder.getOrCreate()
 
-        self._context = session.sparkContext
         self._session = session
 
         # Spark internally stores timestamps as UTC values, and timestamp data


### PR DESCRIPTION
Remove unused of `sparkContext` attribute, use of which prevents using spark connect.

Closes #9060.