### PR TITLE
feat(sql): add option to enable/disable select merging

### DIFF
--- a/ibis/backends/sql/compiler.py
+++ b/ibis/backends/sql/compiler.py
@@ -27,6 +27,7 @@ from ibis.backends.sql.rewrites import (
     rewrite_capitalize,
     sqlize,
 )
+from ibis.config import options
 from ibis.expr.operations.udf import InputType
 from ibis.expr.rewrites import replace_bucket
 
@@ -453,7 +454,12 @@ class SQLGlotCompiler(abc.ABC):
         # substitute parameters immediately to avoid having to define a
         # ScalarParameter translation rule
         params = self._prepare_params(params)
-        op, ctes = sqlize(op, params=params, rewrites=self.rewrites)
+        op, ctes = sqlize(
+            op,
+            params=params,
+            rewrites=self.rewrites,
+            fuse_selects=options.sql.fuse_selects,
+        )
 
         aliases = {}
         counter = itertools.count()

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -205,6 +205,7 @@ def sqlize(
     node: ops.Node,
     params: Mapping[ops.ScalarParameter, Any],
     rewrites: Sequence[Pattern] = (),
+    fuse_selects: bool = True,
 ) -> tuple[ops.Node, list[ops.Node]]:
     """Lower the ibis expression graph to a SQL-like relational algebra.
 
@@ -216,6 +217,8 @@ def sqlize(
         A mapping of scalar parameters to their values.
     rewrites
         Supplementary rewrites to apply to the expression graph.
+    fuse_selects
+        Whether to merge subsequent Select nodes into one where possible.
 
     Returns
     -------
@@ -240,7 +243,10 @@ def sqlize(
     )
 
     # squash subsequent Select nodes into one
-    simplified = sqlized.replace(merge_select_select)
+    if fuse_selects:
+        simplified = sqlized.replace(merge_select_select)
+    else:
+        simplified = sqlized
 
     # extract common table expressions while wrapping them in a CTE node
     ctes = frozenset(extract_ctes(simplified))

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -47,6 +47,9 @@ class SQL(Config):
 
     Attributes
     ----------
+    fuse_selects : bool
+        Whether to fuse consecutive select queries into a single query where
+        possible.
     default_limit : int | None
         Number of rows to be retrieved for a table expression without an
         explicit limit. [](`None`) means no limit.
@@ -55,6 +58,7 @@ class SQL(Config):
 
     """
 
+    fuse_selects: bool = True
     default_limit: Optional[PosInt] = None
     default_dialect: str = "duckdb"
 


### PR DESCRIPTION
Add a global option to enable or disable merging select statements where possible. This can serve as an escape route if the optimization fails. It is currently enabled by default, we may change to make it opt-in. 

xref #9064 and https://github.com/ibis-project/ibis/issues/9058 