### PR TITLE
fix(pyspark): unwind catalog/database settings in same order they were set

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -249,12 +249,12 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
         # 3. set catalog to previous
         # 4. set database to previous
         try:
-            if not PYSPARK_LT_34 and catalog is not None:
+            if catalog is not None:
                 self._session.catalog.setCurrentCatalog(catalog)
             self._session.catalog.setCurrentDatabase(db)
             yield
         finally:
-            if not PYSPARK_LT_34 and catalog is not None:
+            if catalog is not None:
                 self._session.catalog.setCurrentCatalog(current_catalog)
             self._session.catalog.setCurrentDatabase(current_db)
 
@@ -529,7 +529,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
         else:
             raise com.IbisError("The schema or obj parameter is required")
 
-        return self.table(name, database=db)
+        return self.table(name, database=(catalog, db))
 
     def create_view(
         self,

--- a/ibis/backends/pyspark/tests/test_client.py
+++ b/ibis/backends/pyspark/tests/test_client.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import pytest
+
 import ibis
 
 
+@pytest.mark.xfail_version(pyspark=["pyspark<3.4"], reason="no catalog support")
 def test_catalog_db_args(con, monkeypatch):
     monkeypatch.setattr(ibis.options, "default_backend", con)
     t = ibis.memtable({"epoch": [1712848119, 1712848121, 1712848155]})
@@ -18,5 +21,21 @@ def test_catalog_db_args(con, monkeypatch):
     assert "t2" in con.list_tables(database=("spark_catalog", "default"))
 
     con.drop_table("t2", database="spark_catalog.default")
+
+    assert "t2" not in con.list_tables(database="default")
+
+
+def test_create_table_no_catalog(con, monkeypatch):
+    monkeypatch.setattr(ibis.options, "default_backend", con)
+    t = ibis.memtable({"epoch": [1712848119, 1712848121, 1712848155]})
+
+    # create a table in specified catalog and db
+    con.create_table("t2", database=("default"), obj=t, overwrite=True)
+
+    assert "t2" not in con.list_tables()
+    assert "t2" in con.list_tables(database="default")
+    assert "t2" in con.list_tables(database=("default"))
+
+    con.drop_table("t2", database="default")
 
     assert "t2" not in con.list_tables(database="default")


### PR DESCRIPTION
We set the catalog using a context manager, and we set the database also
using a context manager. There is a weird edge case:

set catalog to comms_media_dev (succeeds)
set database to dart_extensions within comms_media_dev (succeeds)

then we write the table, great! Now we try to change catalog and database back in reverse order and...

set database to default (the previous value that we saved) within comms_media_dev (fails, you do not have permission to access that)

set catalog back to spark_catalog (or previous value, but we never get here because of the previous error.

So what we need to do is instead:

set catalog
set database
write table
set catalog back
set database back

It would be really great if spark would allow for setting both of these values at the same time, but that is apparently not a thing.

xref #9038