### PR TITLE
fix(ir): ensure that schema column order matters

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1608,3 +1608,29 @@ def test_json_to_pyarrow(con):
         if val is not None
     }
     assert result == expected
+
+
+@pytest.mark.notyet(["mssql"], raises=PyODBCProgrammingError)
+@pytest.mark.notyet(
+    ["risingwave", "exasol"],
+    raises=com.UnsupportedOperationError,
+    reason="no temp table support",
+)
+@pytest.mark.notyet(
+    ["impala", "trino"], raises=NotImplementedError, reason="no temp table support"
+)
+@pytest.mark.notyet(
+    ["druid"], raises=NotImplementedError, reason="doesn't support create_table"
+)
+@pytest.mark.notyet(
+    ["flink"], raises=com.IbisError, reason="no persistent temp table support"
+)
+def test_schema_with_caching(alltypes):
+    t1 = alltypes.limit(5).select("bigint_col", "string_col")
+    t2 = alltypes.limit(5).select("string_col", "bigint_col")
+
+    pt1 = t1.cache()
+    pt2 = t2.cache()
+
+    assert pt1.schema() == t1.schema()
+    assert pt2.schema() == t2.schema()

--- a/ibis/common/collections.py
+++ b/ibis/common/collections.py
@@ -287,6 +287,11 @@ class FrozenDict(dict, Mapping[K, V], Hashable):
     def __hash__(self) -> int:
         return self.__precomputed_hash__
 
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, collections.abc.Mapping):
+            return NotImplemented
+        return collections.OrderedDict(self) == collections.OrderedDict(other)
+
     def __setitem__(self, key: K, value: V) -> None:
         raise TypeError("'FrozenDict' object does not support item assignment")
 

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections
 from collections.abc import Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Union
 
@@ -89,6 +90,14 @@ class Schema(Concrete, Coercible, MapSet):
                 f"invalid equality comparison between Schema and {type(other)}"
             )
         return self == other
+
+    def __hash__(self) -> int:
+        return super().__hash__()
+
+    def __eq__(self, other):
+        if not isinstance(other, Mapping):
+            return NotImplemented
+        return collections.OrderedDict(self) == collections.OrderedDict(other)
 
     @classmethod
     def from_tuples(

--- a/ibis/expr/tests/test_dereference.py
+++ b/ibis/expr/tests/test_dereference.py
@@ -24,8 +24,8 @@ def test_dereference_project():
     expected = dereference_expect(
         {
             p.int_col: p.int_col,
-            p.double_col: p.double_col,
             t.int_col: p.int_col,
+            p.double_col: p.double_col,
             t.double_col: p.double_col,
         }
     )

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -21,8 +21,8 @@ in
     name = "ibis-testing-data";
     owner = "ibis-project";
     repo = "testing-data";
-    rev = "2c6a4bb5d5d525058d8d5b2312a9fee5dafc5476";
-    sha256 = "sha256-Lq503bqh9ESZJSk6yVq/uZwkAubzmSmoTBZSsqMm0DY=";
+    rev = "1922bd4617546b877e66e78bb2b87abeb510cf8e";
+    sha256 = "sha256-l5d7r/6Voy6N2pXq3IivLX3N0tNfKKwsbZXRexzc8Z8=";
   };
 
   ibis39 = pkgs.callPackage ./ibis.nix { python3 = pkgs.python39; };


### PR DESCRIPTION
Ensure that column order is taken into account for equality comparisons. Fixes #9063.