### PR TITLE
feat(snowflake): implement Table.sample

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1925,26 +1925,33 @@ def test_dynamic_table_slice_with_computed_offset(backend):
 
 @pytest.mark.notimpl(["druid", "polars"])
 @pytest.mark.notimpl(
-    ["snowflake"],
-    raises=SnowflakeProgrammingError,
-    reason="SAMPLE clause on views only supports row wise sampling without seed.",
-)
-@pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,
     reason="function random() does not exist",
 )
-def test_sample(backend):
+@pytest.mark.parametrize(
+    "method",
+    [
+        "row",
+        param(
+            "block",
+            marks=[
+                pytest.mark.notimpl(
+                    ["snowflake"],
+                    raises=SnowflakeProgrammingError,
+                    reason="SAMPLE clause on views only supports row wise sampling without seed.",
+                )
+            ],
+        ),
+    ],
+)
+def test_sample(backend, method):
     t = backend.functional_alltypes.filter(_.int_col >= 2)
 
     total_rows = t.count().execute()
     empty = t.limit(1).execute().iloc[:0]
 
-    df = t.sample(0.1, method="row").execute()
-    assert len(df) <= total_rows
-    backend.assert_frame_equal(empty, df.iloc[:0])
-
-    df = t.sample(0.1, method="block").execute()
+    df = t.sample(0.1, method=method).execute()
     assert len(df) <= total_rows
     backend.assert_frame_equal(empty, df.iloc[:0])
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1923,7 +1923,7 @@ def test_dynamic_table_slice_with_computed_offset(backend):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["druid", "polars", "snowflake"])
+@pytest.mark.notimpl(["druid", "polars"])
 @pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1925,6 +1925,11 @@ def test_dynamic_table_slice_with_computed_offset(backend):
 
 @pytest.mark.notimpl(["druid", "polars"])
 @pytest.mark.notimpl(
+    ["snowflake"],
+    raises=SnowflakeProgrammingError,
+    reason="SAMPLE clause on views only supports row wise sampling without seed.",
+)
+@pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,
     reason="function random() does not exist",
@@ -1944,7 +1949,7 @@ def test_sample(backend):
     backend.assert_frame_equal(empty, df.iloc[:0])
 
 
-@pytest.mark.notimpl(["druid", "polars", "snowflake"])
+@pytest.mark.notimpl(["druid", "polars"])
 @pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1976,7 +1976,6 @@ def test_sample_memtable(con, backend):
         "polars",
         "postgres",
         "risingwave",
-        "snowflake",
         "sqlite",
         "trino",
         "exasol",


### PR DESCRIPTION
This PR aims to add support for SAMPLE/TABLESAMPLE for Snowflake to build on the work done in #7377. 

As the SAMPLE/TABLESAMPLE clause seems to be written the same way between Snowflake and DuckDB in SQL, I was able reuse code from: https://github.com/ibis-project/ibis/blob/b48f451de77bd9af832cea10d7ddf8c44097c45a/ibis/backends/duckdb/compiler.py#L118-L128

Snowflake Docs: [SAMPLE/TABLESAMPLE](https://docs.snowflake.com/en/sql-reference/constructs/sample)

Code Snippet I used to validate it was working:

```
import ibis

con = ibis.snowflake.connect(create_object_udfs=False)

t = con.table("WOWAH_DATA_RAW", database=("WOWAH", "PUBLIC"))

print(t.count().execute())

for expression in (
    t.sample(fraction=0.01),
    t.sample(fraction=0.01, seed=42),
    t.sample(fraction=0.01, method="block", seed=42),
):
    print(ibis.to_sql(expression, dialect="snowflake"))
    print(expression.count().execute())
```

Results:

```txt
10826734
SELECT
  *
FROM "WOWAH"."PUBLIC"."WOWAH_DATA_RAW" AS "t0" TABLESAMPLE bernoulli (1.0)
107897
SELECT
  *
FROM "WOWAH"."PUBLIC"."WOWAH_DATA_RAW" AS "t0" TABLESAMPLE bernoulli (1.0) SEED (42)
107953
SELECT
  *
FROM "WOWAH"."PUBLIC"."WOWAH_DATA_RAW" AS "t0" TABLESAMPLE system (1.0) SEED (42)
107953
```



