### PR TITLE
docs(datafusion): update website link

### DIFF
--- a/docs/backends/datafusion.qmd
+++ b/docs/backends/datafusion.qmd
@@ -1,6 +1,6 @@
 # DataFusion
 
-[https://arrow.apache.org/datafusion](https://arrow.apache.org/datafusion)
+[https://datafusion.apache.org/](https://datafusion.apache.org/)
 
 ![](https://img.shields.io/badge/memtables-not supported- grey?style=flat-square) ![](https://img.shields.io/badge/inputs-CSV | Delta Lake | Parquet-blue?style=flat-square) ![](https://img.shields.io/badge/outputs-CSV | Delta Lake | pandas | Parquet | PyArrow-orange?style=flat-square)
 


### PR DESCRIPTION
With DataFusion [now being a top-level project](https://github.com/apache/datafusion/issues/9691#issuecomment-2063690461), this URL now redirects, and I have updated it to point to the new site.

https://arrow.apache.org/datafusion

https://datafusion.apache.org/
