### PR TITLE
fix(pandas): make case work for non-RangeIndex dataframes

### DIFF
--- a/ibis/backends/pandas/executor.py
+++ b/ibis/backends/pandas/executor.py
@@ -170,9 +170,10 @@ class PandasExecutor(Dispatched, PandasUtils):
         if base is not None:
             cases = tuple(base == case for case in cases)
         cases, _ = cls.asframe(cases, concat=False)
+        index = cases[0].index
         results, _ = cls.asframe(results, concat=False)
         out = np.select(cases, results, default)
-        return pd.Series(out)
+        return pd.Series(out, index=index)
 
     @classmethod
     def visit(cls, op: ops.TimestampTruncate | ops.DateTruncate, arg, unit):

--- a/ibis/backends/pandas/tests/test_operations.py
+++ b/ibis/backends/pandas/tests/test_operations.py
@@ -742,27 +742,25 @@ def test_simple_case_column(batting, batting_df):
 
 
 def test_non_range_index():
-
     def do_replace(col):
-        return (
-            col
-            .cases(
-                (
-                    (1, "one"),
-                    (2, "two"),
-                ),
-                default="unk",
-            )
+        return col.cases(
+            (
+                (1, "one"),
+                (2, "two"),
+            ),
+            default="unk",
         )
 
-    df = pd.DataFrame({
-        "A": pd.Series({i: i % 3 for i in (0, 1, 2, 4)}),
-        "B": 0,
-    })
+    df = pd.DataFrame(
+        {
+            "A": pd.Series({i: i % 3 for i in (0, 1, 2, 4)}),
+            "B": 0,
+        }
+    )
     expr = (
         ibis.pandas.connect({"t": df})
         .table("t")
-        .mutate(**{"A": lambda t: t["A"].pipe(do_replace)})
+        .mutate(A=lambda t: t["A"].pipe(do_replace))
     )
     assert df.index.equals(expr.execute().index)
 

--- a/ibis/backends/pandas/tests/test_operations.py
+++ b/ibis/backends/pandas/tests/test_operations.py
@@ -741,6 +741,32 @@ def test_simple_case_column(batting, batting_df):
     tm.assert_series_equal(result, expected)
 
 
+def test_non_range_index():
+
+    def do_replace(col):
+        return (
+            col
+            .cases(
+                (
+                    (1, "one"),
+                    (2, "two"),
+                ),
+                default="unk",
+            )
+        )
+
+    df = pd.DataFrame({
+        "A": pd.Series({i: i % 3 for i in (0, 1, 2, 4)}),
+        "B": 0,
+    })
+    expr = (
+        ibis.pandas.connect({"t": df})
+        .table("t")
+        .mutate(**{"A": lambda t: t["A"].pipe(do_replace)})
+    )
+    assert df.index.equals(expr.execute().index)
+
+
 def test_table_distinct(t, df):
     expr = t[["dup_strings"]].distinct()
     result = expr.execute()


### PR DESCRIPTION
## Description of changes

This PR makes `PandasExecutor` create the `Series` with an index that matches the incoming data. Currently, when the incoming data does not use a `RangeIndex`, the output index is a union of a `RangeIndex` and the incoming data index.