### PR TITLE
chore(testing-data): update nix hash and rev

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -21,8 +21,8 @@ in
     name = "ibis-testing-data";
     owner = "ibis-project";
     repo = "testing-data";
-    rev = "2c6a4bb5d5d525058d8d5b2312a9fee5dafc5476";
-    sha256 = "sha256-Lq503bqh9ESZJSk6yVq/uZwkAubzmSmoTBZSsqMm0DY=";
+    rev = "1922bd4617546b877e66e78bb2b87abeb510cf8e";
+    sha256 = "sha256-l5d7r/6Voy6N2pXq3IivLX3N0tNfKKwsbZXRexzc8Z8=";
   };
 
   ibis39 = pkgs.callPackage ./ibis.nix { python3 = pkgs.python39; };


### PR DESCRIPTION
Update nix hash to pick up new geo parquet dataset.