### PR TITLE
fix(arrays): array.remove() erroneously removes NULLs

### DIFF
--- a/ibis/backends/pandas/kernels.py
+++ b/ibis/backends/pandas/kernels.py
@@ -144,6 +144,12 @@ def array_position_rowwise(row):
         return -1
 
 
+def array_remove_rowwise(row):
+    if row["arg"] is None:
+        return None
+    return [x for x in row["arg"] if x != row["other"]]
+
+
 def array_slice_rowwise(row):
     arg, start, stop = row["arg"], row["start"], row["stop"]
     if isnull(start) and isnull(stop):
@@ -380,11 +386,12 @@ columnwise = {
     ops.Repeat: lambda df: df["arg"] * df["times"],
 }
 
+
 rowwise = {
     ops.ArrayContains: lambda row: row["other"] in row["arg"],
     ops.ArrayIndex: array_index_rowwise,
     ops.ArrayPosition: array_position_rowwise,
-    ops.ArrayRemove: lambda row: [x for x in row["arg"] if x != row["other"]],
+    ops.ArrayRemove: array_remove_rowwise,
     ops.ArrayRepeat: lambda row: np.tile(row["arg"], max(0, row["times"])),
     ops.ArraySlice: array_slice_rowwise,
     ops.ArrayUnion: lambda row: toolz.unique(row["left"] + row["right"]),

--- a/ibis/backends/sql/compilers/bigquery.py
+++ b/ibis/backends/sql/compilers/bigquery.py
@@ -526,7 +526,9 @@ class BigQueryCompiler(SQLGlotCompiler):
     def visit_ArrayRemove(self, op, *, arg, other):
         name = sg.to_identifier(util.gen_name("bq_arr"))
         unnest = self._unnest(arg, as_=name)
-        return self.f.array(sg.select(name).from_(unnest).where(name.neq(other)))
+        both_null = sg.and_(name.is_(NULL), other.is_(NULL))
+        cond = sg.or_(name.neq(other), both_null)
+        return self.f.array(sg.select(name).from_(unnest).where(cond))
 
     def visit_ArrayDistinct(self, op, *, arg):
         name = util.gen_name("bq_arr")

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -584,9 +584,10 @@ class ClickHouseCompiler(SQLGlotCompiler):
         return self.f.arrayFilter(func, arg)
 
     def visit_ArrayRemove(self, op, *, arg, other):
-        x = sg.to_identifier("x")
-        body = x.neq(other)
-        return self.f.arrayFilter(sge.Lambda(this=body, expressions=[x]), arg)
+        x = sg.to_identifier(util.gen_name("x"))
+        should_keep_null = sg.and_(x.is_(NULL), sg.not_(other.is_(NULL)))
+        cond = sg.or_(x.neq(other), should_keep_null)
+        return self.f.arrayFilter(sge.Lambda(this=cond, expressions=[x]), arg)
 
     def visit_ArrayUnion(self, op, *, left, right):
         arg = self.f.arrayConcat(left, right)

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -585,7 +585,7 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
     def visit_ArrayRemove(self, op, *, arg, other):
         x = sg.to_identifier(util.gen_name("x"))
-        should_keep_null = sg.and_(x.is_(NULL), sg.not_(other.is_(NULL)))
+        should_keep_null = sg.and_(x.is_(NULL), other.is_(sg.not_(NULL)))
         cond = sg.or_(x.neq(other), should_keep_null)
         return self.f.arrayFilter(sge.Lambda(this=cond, expressions=[x]), arg)
 

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -621,16 +621,21 @@ def test_array_position(con, a, expected_array):
             id="all-non-empty-arrays",
         ),
         param(
+            [[3, 2, None], [None], [42, 2], [2, 2]],
+            [[3, None], [None], [42], []],
+            id="including_nested_null",
+        ),
+        param(
             [[3, 2, None], [None], [42, 2], [2, 2], None],
             [[3, None], [None], [42], [], None],
-            id="including_null",
-            # marks=[
-            #     pytest.mark.broken(
-            #         ["duckdb"],
-            #         raises=AssertionError,
-            #         reason="not implmented correctly",
-            #     ),
-            # ],
+            id="including_non_nested_null",
+            marks=[
+                pytest.mark.notyet(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="clickhouse still does not support nullable nested types",
+                )
+            ],
         ),
     ],
 )
@@ -640,9 +645,9 @@ def test_array_remove(con, inp, exp):
     result = con.execute(expr)
     expected = pd.Series(exp, dtype="object")
 
-    assert frozenset(
-        tuple(v) if v is not None else None for v in result.values
-    ) == frozenset(tuple(v) if v is not None else None for v in expected.values)
+    lhs = frozenset(tuple(v) if v is not None else None for v in result.values)
+    rhs = frozenset(tuple(v) if v is not None else None for v in expected.values)
+    assert lhs == rhs
 
 
 @builtin_array

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -625,6 +625,13 @@ def test_array_position(con, a, expected_array):
             [[3, 2, None], [None], [42, 2], [2, 2]],
             [[3, None], [None], [42], []],
             id="nested-null",
+            marks=[
+                pytest.mark.notyet(
+                    ["bigquery"],
+                    raises=GoogleBadRequest,
+                    reason="bigquery does not support arrays with nulls",
+                ),
+            ],
         ),
         param(
             [[3, 2, None], [None], [42, 2], [2, 2], None],
@@ -634,8 +641,13 @@ def test_array_position(con, a, expected_array):
                 pytest.mark.notyet(
                     ["clickhouse"],
                     raises=AssertionError,
-                    reason="clickhouse still does not support nullable nested types",
-                )
+                    reason="clickhouse does not support nullable nested types",
+                ),
+                pytest.mark.notyet(
+                    ["bigquery"],
+                    raises=GoogleBadRequest,
+                    reason="bigquery does not support arrays with nulls",
+                ),
             ],
         ),
     ],

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import statistics
 from collections import Counter
 from datetime import datetime
@@ -623,12 +624,12 @@ def test_array_position(con, a, expected_array):
         param(
             [[3, 2, None], [None], [42, 2], [2, 2]],
             [[3, None], [None], [42], []],
-            id="including_nested_null",
+            id="nested-null",
         ),
         param(
             [[3, 2, None], [None], [42, 2], [2, 2], None],
             [[3, None], [None], [42], [], None],
-            id="including_non_nested_null",
+            id="non-nested-null",
             marks=[
                 pytest.mark.notyet(
                     ["clickhouse"],
@@ -645,7 +646,13 @@ def test_array_remove(con, inp, exp):
     result = con.execute(expr)
     expected = pd.Series(exp, dtype="object")
 
-    lhs = frozenset(tuple(v) if v is not None else None for v in result.values)
+    lhs = frozenset(
+        # arg, things are coming back as nan
+        tuple(None if el is not None and math.isnan(el) else el for el in v)
+        if v is not None
+        else None
+        for v in result.values
+    )
     rhs = frozenset(tuple(v) if v is not None else None for v in expected.values)
     assert lhs == rhs
 


### PR DESCRIPTION
Still a WIP, figuring out what should be desired.

`ibis.array([1, None, 2]).remove(2)` currently results in `[1]` on many backends. I would expect the NULLs to remain, eg `[1, None]`