### PR TITLE
docs: fix jupyterlite build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ docs/**/*.html
 
 # jupyterlite stuff
 .jupyterlite.doit.db
+docs/jupyter_lite_config.json

--- a/docs/jupyter_lite_config.json
+++ b/docs/jupyter_lite_config.json
@@ -1,8 +1,0 @@
-{
-  "PipliteAddon": {
-    "piplite_urls": [
-      "https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-0.10.2-cp311-cp311-emscripten_3_1_46_wasm32.whl",
-      "dist/ibis_framework-8.0.0-py3-none-any.whl"
-    ]
-  }
-}

--- a/justfile
+++ b/justfile
@@ -192,6 +192,10 @@ build-ibis-for-pyodide:
     poetry add 'pyarrow>=10.0.1' --allow-prereleases
     poetry build --format wheel
     git checkout poetry.lock pyproject.toml
+    jq '{"PipliteAddon": {"piplite_urls": [$ibis, $duckdb]}}' -nM \
+        --arg ibis dist/*.whl \
+        --arg duckdb "https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-0.10.2-cp311-cp311-emscripten_3_1_46_wasm32.whl" \
+        > docs/jupyter_lite_config.json
 
 # build the jupyterlite deployment
 build-jupyterlite: build-ibis-for-pyodide


### PR DESCRIPTION
Fix the docs build that is failing due to a hardcoded wheel name