### PR TITLE
fix: replace NaNs with None in some backends when loading from pandas dataframe

### DIFF
--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -11,6 +11,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
 
+import numpy as np
 import pymysql
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -481,6 +482,9 @@ class Backend(SQLBackend, CanCreateDatabase):
 
             columns = schema.keys()
             df = op.data.to_frame()
+            # nan can not be used with MySQL
+            df = df.replace(np.nan, None)
+
             data = df.itertuples(index=False)
             cols = ", ".join(
                 ident.sql(self.name)

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -155,7 +155,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             convert_df = df.convert_dtypes()
             for col in convert_df.columns:
                 if not is_float_dtype(convert_df[col]):
-                    df[col].replace(np.nan, None, inplace=True)
+                    df[col] = df[col].replace(np.nan, None)
 
             data = df.itertuples(index=False)
             cols = ", ".join(

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -11,6 +11,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import parse_qs, urlparse
 
+import numpy as np
 import sqlglot as sg
 import sqlglot.expressions as sge
 
@@ -144,6 +145,9 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
 
             columns = schema.keys()
             df = op.data.to_frame()
+            # nan gets compiled into 'NaN'::float which throws errors in non-float columns
+            df = df.replace(np.nan, None)
+
             data = df.itertuples(index=False)
             cols = ", ".join(
                 ident.sql(self.dialect)


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Examples were broken on MySQL backend and PySpark backend when there are null values in a numeric column. 

Druid, PySpark, RW don't support examples.

- Exasol - did not test
- Flink - broken
- Impala - did not test
- MSSQL - broken #9095 
- MySQL - fixed
- Oracle - did not test
- PostgreSQL - fixed
- Snowflake - did not test

## Issues closed

#8792 