### PR TITLE
feat(api): support `type` arg to ibis.null()

### DIFF
--- a/ibis/backends/pandas/kernels.py
+++ b/ibis/backends/pandas/kernels.py
@@ -348,7 +348,7 @@ _generic = {
 }
 
 
-def none_proof(func):
+def none_safe(func):
     def wrapper(*args, **kwargs):
         if any(map(isnull, args)):
             return None
@@ -358,7 +358,7 @@ def none_proof(func):
 
 
 generic = {
-    **{k: none_proof(v) for k, v in _generic.items()},
+    **{k: none_safe(v) for k, v in _generic.items()},
     ops.IsNull: pd.isnull,
     ops.NotNull: pd.notnull,
     ops.IsInf: np.isinf,

--- a/ibis/backends/pandas/kernels.py
+++ b/ibis/backends/pandas/kernels.py
@@ -282,7 +282,8 @@ reductions = {
     ops.ArrayCollect: lambda x: x.tolist(),
 }
 
-generic = {
+
+_generic = {
     ops.Abs: abs,
     ops.Acos: np.arccos,
     ops.Add: operator.add,
@@ -315,8 +316,6 @@ generic = {
     ops.IntervalFloorDivide: operator.floordiv,
     ops.IntervalMultiply: operator.mul,
     ops.IntervalSubtract: operator.sub,
-    ops.IsInf: np.isinf,
-    ops.IsNull: pd.isnull,
     ops.Less: operator.lt,
     ops.LessEqual: operator.le,
     ops.Ln: np.log,
@@ -327,7 +326,6 @@ generic = {
     ops.Negate: lambda x: not x if isinstance(x, (bool, np.bool_)) else -x,
     ops.Not: lambda x: not x if isinstance(x, (bool, np.bool_)) else ~x,
     ops.NotEquals: operator.ne,
-    ops.NotNull: pd.notnull,
     ops.Or: operator.or_,
     ops.Power: operator.pow,
     ops.Radians: np.radians,
@@ -348,6 +346,24 @@ generic = {
     ops.StringJoin: lambda xs, sep: reduce(lambda x, y: x + sep + y, xs),
     ops.Log: lambda x, base: np.log(x) if base is None else np.log(x) / np.log(base),
 }
+
+
+def none_proof(func):
+    def wrapper(*args, **kwargs):
+        if any(map(isnull, args)):
+            return None
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+generic = {
+    **{k: none_proof(v) for k, v in _generic.items()},
+    ops.IsNull: pd.isnull,
+    ops.NotNull: pd.notnull,
+    ops.IsInf: np.isinf,
+}
+
 
 columnwise = {
     ops.Clip: lambda df: df["arg"].clip(lower=df["lower"], upper=df["upper"]),

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -59,10 +59,7 @@ def test_null_literal(con, backend):
         backend_name = backend.name()
         assert con.execute(expr.typeof()) == NULL_BACKEND_TYPES[backend_name]
 
-    with pytest.raises(AttributeError):
-        expr.upper()
-    with pytest.raises(AttributeError):
-        expr.cast(str).max()
+    assert expr.type() == dt.null
     assert pd.isna(con.execute(expr.cast(str).upper()))
 
 
@@ -73,11 +70,10 @@ def test_null_literal(con, backend):
 )
 def test_null_literal_typed(con, backend):
     expr = ibis.null(bool)
+    assert expr.type() == dt.boolean
     assert pd.isna(con.execute(expr))
     assert pd.isna(con.execute(expr.negate()))
     assert pd.isna(con.execute(expr.cast(str).upper()))
-    with pytest.raises(AttributeError):
-        expr.upper()
 
 
 BOOLEAN_BACKEND_TYPE = {

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -211,7 +211,7 @@ True
 
 datatype-specific methods aren't available on `NA`:
 
->>> ibis.NA.upper().execute() is None  # quartodoc: +EXPECTED_FAILURE
+>>> ibis.NA.upper()  # quartodoc: +EXPECTED_FAILURE
 Traceback (most recent call last):
   ...
 AttributeError: 'NullScalar' object has no attribute 'upper'

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -200,11 +200,25 @@ pi = ops.Pi().to_expr()
 NA = null()
 """The NULL scalar.
 
+This is an untyped NULL. If you want a typed NULL, use eg `ibis.null(str)`.
+
 Examples
 --------
 >>> import ibis
->>> my_null = ibis.NA
->>> my_null.isnull()
+>>> assert ibis.NA.execute() is None
+>>> ibis.NA.isnull().execute()
+True
+
+datatype-specific methods aren't available on `NA`:
+
+>>> ibis.NA.upper().execute() is None  # quartodoc: +EXPECTED_FAILURE
+Traceback (most recent call last):
+  ...
+AttributeError: 'NullScalar' object has no attribute 'upper'
+
+Instead, use the typed `ibis.null`:
+
+>>> ibis.null(str).upper().execute() is None
 True
 """
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2224,13 +2224,13 @@ class NullColumn(Column, NullValue):
 
 @public
 def null(type: dt.DataType | str | None = None) -> Value:
-    """Create a NULL/NA scalar.
+    """Create a NULL scalar.
 
-    By default, the type will be NULLTYPE. This is castable and comparable to any type,
-    but lacks datatype-specific methods:
+    `NULL`s with an unspecified type are castable and comparable to values,
+    but lack datatype-specific methods:
 
     >>> import ibis
-    >>> ibis.null().upper().execute() is None
+    >>> ibis.null().upper()
     Traceback (most recent call last):
         ...
     AttributeError: 'NullScalar' object has no attribute 'upper'

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2223,9 +2223,23 @@ class NullColumn(Column, NullValue):
 
 
 @public
-def null():
-    """Create a NULL/NA scalar."""
-    return ops.NULL.to_expr()
+def null(type: dt.DataType | str | None = None) -> Value:
+    """Create a NULL/NA scalar.
+
+    By default, the type will be NULLTYPE. This is castable and comparable to any type,
+    but lacks datatype-specific methods:
+
+    >>> import ibis
+    >>> ibis.null().upper().execute() is None
+    Traceback (most recent call last):
+        ...
+    AttributeError: 'NullScalar' object has no attribute 'upper'
+    >>> ibis.null(str).upper().execute() is None
+    True
+    """
+    if type is None:
+        type = dt.null
+    return ops.Literal(None, type).to_expr()
 
 
 @public


### PR DESCRIPTION
This is mostly a UX nicety. Instead of needing to do `ibis.null().cast(int)`, you can do it as `ibis.null(int)`.

pandas tests were breaking due to not being resilient to None scalars. So I fixed a bunch of affected Ops, not just the ones that I needed to change.