### PR TITLE
docs(website): make icon grayscale for consistency

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -13,6 +13,7 @@ section[id^="parameters-"] {
   content: url("./zulip.svg");
   vertical-align: -0.125em;
   width: 1em;
+  filter: grayscale(1);
 }
 
 .jupyterlite-console {


### PR DESCRIPTION
## Description of changes

### New

<img width="120" alt="image" src="https://github.com/ibis-project/ibis/assets/14007150/b4251471-c859-4c88-a0eb-500db0c153e3">

### Old

<img width="120" alt="image" src="https://github.com/ibis-project/ibis/assets/14007150/cb87c1a4-ea71-4f2f-98c0-2a7e085ac9cf">