### PR TITLE
build(ruff): don't use keep-runtime-typing anymore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -440,9 +440,6 @@ unfixable = [
   "F841",   # unused variables
 ]
 
-[tool.ruff.lint.pyupgrade]
-keep-runtime-typing = true
-
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]
 


### PR DESCRIPTION
## Description of changes

* We don't support Python 3.8 anymore
* We don't use pydantic, FastAPI, etc.
* All of the changes this would have guarded against were made in 25946f9865 anyway