### PR TITLE
fix(duckdb): clean up temp view junk when using memtables in `create_table`

### DIFF
--- a/docs/tutorials/getting_started.qmd
+++ b/docs/tutorials/getting_started.qmd
@@ -30,7 +30,6 @@ con.create_table(
 You can now see the example dataset copied over to the database:
 
 ```{python}
-con = ibis.connect("duckdb://penguins.ddb")
 con.list_tables()
 ```
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -169,9 +169,12 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         if temp:
             properties.append(sge.TemporaryProperty())
 
+        temp_memtable_view = None
+
         if obj is not None:
             if not isinstance(obj, ir.Expr):
                 table = ibis.memtable(obj)
+                temp_memtable_view = table.op().name
             else:
                 table = obj
 
@@ -247,6 +250,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
                             actions=[sge.RenameTable(this=final_table)],
                         ).sql(self.name)
                     )
+
+        if temp_memtable_view is not None:
+            self.con.unregister(temp_memtable_view)
 
         return self.table(name, database=database)
 


### PR DESCRIPTION
QoL improvement for loading from in-memory data: no more temporary view junk.