### PR TITLE
fix(api): treat `col == None` or `col == ibis.NA` as `col.isnull()`

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -737,3 +737,13 @@ def _binop(op_class: type[ops.Binary], left: ir.Value, right: ir.Value) -> ir.Va
         return NotImplemented
     else:
         return node.to_expr()
+
+
+def _is_null_literal(value: Any) -> bool:
+    """Detect whether `value` will be treated by ibis as a null literal."""
+    if value is None:
+        return True
+    if isinstance(value, Expr):
+        op = value.op()
+        return isinstance(op, ops.Literal) and op.value is None
+    return False

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1162,11 +1162,15 @@ class Value(Expr):
     def __eq__(self, other: Value) -> ir.BooleanValue:
         if _is_null_literal(other):
             return self.isnull()
+        elif _is_null_literal(self):
+            return other.isnull()
         return _binop(ops.Equals, self, other)
 
     def __ne__(self, other: Value) -> ir.BooleanValue:
         if _is_null_literal(other):
             return self.notnull()
+        elif _is_null_literal(self):
+            return other.notnull()
         return _binop(ops.NotEquals, self, other)
 
     def __ge__(self, other: Value) -> ir.BooleanValue:

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -13,7 +13,7 @@ import ibis.expr.operations as ops
 from ibis.common.deferred import Deferred, _, deferrable
 from ibis.common.grounds import Singleton
 from ibis.expr.rewrites import rewrite_window_input
-from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin
+from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin, _is_null_literal
 from ibis.expr.types.pretty import to_rich
 from ibis.util import deprecated, warn_deprecated
 
@@ -1160,13 +1160,13 @@ class Value(Expr):
         return super().__hash__()
 
     def __eq__(self, other: Value) -> ir.BooleanValue:
-        if other is None:
-            return _binop(ops.IdenticalTo, self, other)
+        if _is_null_literal(other):
+            return self.isnull()
         return _binop(ops.Equals, self, other)
 
     def __ne__(self, other: Value) -> ir.BooleanValue:
-        if other is None:
-            return ~self.__eq__(other)
+        if _is_null_literal(other):
+            return self.notnull()
         return _binop(ops.NotEquals, self, other)
 
     def __ge__(self, other: Value) -> ir.BooleanValue:

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -352,16 +352,14 @@ def test_notnull(table):
 
 @pytest.mark.parametrize(
     "value",
-    [
-        param(lambda: None, id="none"),
-        param(lambda: ibis.NA, id="NA"),
-        param(lambda: ibis.literal(None, type="int32"), id="typed-null"),
-    ],
+    [None, ibis.NA, ibis.literal(None, type="int32")],
+    ids=["none", "NA", "typed-null"],
 )
 def test_null_eq_and_ne(table, value):
-    other = value()
-    assert (table.a == other).equals(table.a.isnull())
-    assert (table.a != other).equals(table.a.notnull())
+    assert (table.a == value).equals(table.a.isnull())
+    assert (value == table.a).equals(table.a.isnull())
+    assert (table.a != value).equals(table.a.notnull())
+    assert (value != table.a).equals(table.a.notnull())
 
 
 @pytest.mark.parametrize("column", ["e", "f"], ids=["float32", "double"])

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -350,6 +350,20 @@ def test_notnull(table):
     assert isinstance(expr.op(), ops.NotNull)
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        param(lambda: None, id="none"),
+        param(lambda: ibis.NA, id="NA"),
+        param(lambda: ibis.literal(None, type="int32"), id="typed-null"),
+    ],
+)
+def test_null_eq_and_ne(table, value):
+    other = value()
+    assert (table.a == other).equals(table.a.isnull())
+    assert (table.a != other).equals(table.a.notnull())
+
+
 @pytest.mark.parametrize("column", ["e", "f"], ids=["float32", "double"])
 def test_isnan_isinf_column(table, column):
     expr = table[column].isnan()


### PR DESCRIPTION
Previously we coerced `co == None` to `IdenticalTo(col, None)`, but wouldn't do so for `ibis.NA` (resulting in that compiling as `Equals(col, None)` (which would result in incorrect SQL). This PR fixes this eager branch to handle any null literal, and compiles it the same as `isnull`/`notnull` (usually `col IS NULL`) rather than the more verbose `col IS NOT DISTINCT FROM NULL` that using `IdenticalTo` would result in.

Other options for this fix would be to:
- Always return `Equals` and use a rewrite rule to rewrite these cases. I opted against this since we'd have to have the same detection logic later, and this rewrite rule would be applied for every backend. Honestly having `Equals.__new__`/`NotEquals.__new__` optionally return `IsNull`/`NotNull` would be cleaner IMO, but that's harder to do with our operation infrastructure.
- Always return `Equals`, and branch when compiling to generate the proper SQL there. This is a bit harder to do, and also would need to be implemented for dataframe backends so `col == None` would still use the proper `isnull` call.