### PR TITLE
feat(ux): improve error message on unequal schemas during set ops

### DIFF
--- a/ibis/common/exceptions.py
+++ b/ibis/common/exceptions.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 
 class IbisError(Exception):
@@ -141,6 +141,16 @@ class InvalidDecoratorError(IbisError):
     def __str__(self) -> str:
         name, lines = self.args
         return f"Only the `@udf` decorator is allowed in user-defined function: `{name}`; found lines {lines}"
+
+
+class ConflictingValuesError(ValueError):
+    """A single key has conflicting values in two different mappings."""
+
+    def __init__(self, conflicts: set[tuple[Any, Any, Any]]):
+        self.conflicts = conflicts
+        msgs = [f"  `{key}`: {v1} != {v2}" for key, v1, v2 in conflicts]
+        msg = "Conflicting values for keys:\n" + "\n".join(msgs)
+        super().__init__(msg)
 
 
 def mark_as_unsupported(f: Callable) -> Callable:

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -69,6 +69,8 @@ class Schema(Concrete, Coercible, MapSet):
     def equals(self, other: Schema) -> bool:
         """Return whether `other` is equal to `self`.
 
+        The order of fields in the schema is taken into account when computing equality.
+
         Parameters
         ----------
         other
@@ -77,12 +79,13 @@ class Schema(Concrete, Coercible, MapSet):
         Examples
         --------
         >>> import ibis
-        >>> first = ibis.schema({"a": "int"})
-        >>> second = ibis.schema({"a": "int"})
-        >>> assert first.equals(second)
-        >>> third = ibis.schema({"a": "array<int>"})
-        >>> assert not first.equals(third)
-
+        >>> xy = ibis.schema({"x": int, "y": str})
+        >>> xy2 = ibis.schema({"x": int, "y": str})
+        >>> yx = ibis.schema({"y": str, "x": int})
+        >>> xy_float = ibis.schema({"x": float, "y": str})
+        >>> assert xy.equals(xy2)
+        >>> assert not xy.equals(yx)
+        >>> assert not xy.equals(xy_float)
         """
         if not isinstance(other, Schema):
             raise TypeError(

--- a/ibis/tests/expr/test_set_operations.py
+++ b/ibis/tests/expr/test_set_operations.py
@@ -40,7 +40,7 @@ d = ibis.table(D)
 
 @pytest.mark.parametrize("method", ["union", "intersect", "difference"])
 def test_operation_requires_equal_schemas(method):
-    with pytest.raises(RelationError):
+    with pytest.raises(RelationError, match="`c`: string != float64"):
         getattr(a, method)(d)
 
 


### PR DESCRIPTION
I got tired of `ibis.union()` failing but only saying "the schemas are different"

The relevant tests are in ibis/tests/expr/test_set_operations.py, looks like the bases are already covered pretty well, don't think I need to add any more