### PR TITLE
docs: use interactive mode instead of execute for typed null docstrings

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -205,8 +205,8 @@ This is an untyped NULL. If you want a typed NULL, use eg `ibis.null(str)`.
 Examples
 --------
 >>> import ibis
->>> assert ibis.NA.execute() is None
->>> ibis.NA.isnull().execute()
+>>> ibis.options.interactive = True
+>>> ibis.NA.isnull()
 True
 
 datatype-specific methods aren't available on `NA`:
@@ -218,7 +218,7 @@ AttributeError: 'NullScalar' object has no attribute 'upper'
 
 Instead, use the typed `ibis.null`:
 
->>> ibis.null(str).upper().execute() is None
+>>> ibis.null(str).upper().isnull()
 True
 """
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2234,11 +2234,14 @@ def null(type: dt.DataType | str | None = None) -> Value:
     but lack datatype-specific methods:
 
     >>> import ibis
+    >>> ibis.options.interactive = True
     >>> ibis.null().upper()
     Traceback (most recent call last):
         ...
     AttributeError: 'NullScalar' object has no attribute 'upper'
-    >>> ibis.null(str).upper().execute() is None
+    >>> ibis.null(str).upper()
+    None
+    >>> ibis.null(str).upper().isnull()
     True
     """
     if type is None:


### PR DESCRIPTION
Use `ibis.options.interactive = True` in typed-null docstrings instead of calling `.execute()`.