### PR TITLE
test(examples): add penguins example test

### DIFF
--- a/ibis/backends/tests/test_examples.py
+++ b/ibis/backends/tests/test_examples.py
@@ -43,6 +43,20 @@ pytest.importorskip("pins")
                 ),
             ),
         ),
+        param(
+            "penguins",
+            [
+                "species",
+                "island",
+                "bill_length_mm",
+                "bill_depth_mm",
+                "flipper_length_mm",
+                "body_mass_g",
+                "sex",
+                "year",
+            ],
+            id="has-null-integer-values",
+        ),
     ],
 )
 def test_load_examples(con, example, columns):


### PR DESCRIPTION
The palmer penguins data has null valued integers, which when used to
create a `memtable`, leads to pandas casting a column to `float` because
it reads in the nulls as NaN.

We added a fix for this for some backends in #9094.