### PR TITLE
docs(builtin): update url for packages.parquet file

### DIFF
--- a/docs/how-to/extending/builtin.qmd
+++ b/docs/how-to/extending/builtin.qmd
@@ -77,7 +77,7 @@ rest of the library:
 
 ```{python}
 pkgs = ibis.read_parquet(
-   "https://storage.googleapis.com/ibis-tutorial-data/pypi/packages.parquet"
+   "https://storage.googleapis.com/ibis-tutorial-data/pypi/2024-04-24/packages.parquet"
 )
 pandas_ish = pkgs[jw_sim(pkgs.name, "pandas") >= 0.9]
 pandas_ish


### PR DESCRIPTION
I updated the path of these in our google cloud bucket to reflect the
date of the pypi-data release (for tutorial purposes).  Inadvertantly
broke this usage here.