### PR TITLE
fix: convert the uint64's from some backends' hash() to the desired int64

### DIFF
--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -235,7 +235,7 @@ class ClickHouseCompiler(SQLGlotCompiler):
         return self.f.intDivOrZero(arg, self.f.abs(arg))
 
     def visit_Hash(self, op, *, arg):
-        return self.f.sipHash64(arg)
+        return self.f.reinterpretAsInt64(self.f.sipHash64(arg))
 
     def visit_HashBytes(self, op, *, arg, how):
         supported_algorithms = {

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_hash/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_hash/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  sipHash64("t0"."string_col") AS "Hash(string_col)"
+  reinterpretAsInt64(sipHash64("t0"."string_col")) AS "Hash(string_col)"
 FROM "functional_alltypes" AS "t0"

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1206,7 +1206,8 @@ def execute_union(op, **kw):
 
 @translate.register(ops.Hash)
 def execute_hash(op, **kw):
-    return translate(op.arg, **kw).hash()
+    # polars' hash() returns a uint64, but we want to return an int64
+    return translate(op.arg, **kw).hash().reinterpret(signed=True)
 
 
 def _arg_min_max(op, func, **kw):

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -180,7 +180,7 @@ class SqlglotType(TypeMapper):
 
     @classmethod
     def from_ibis(cls, dtype: dt.DataType) -> sge.DataType:
-        """Convert a sqlglot type to an ibis type."""
+        """Convert an Ibis dtype to an sqlglot dtype."""
 
         if method := getattr(cls, f"_from_ibis_{dtype.name}", None):
             return method(dtype)

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1439,11 +1439,14 @@ def test_distinct_on_keep_is_none(backend, on):
         "trino",  # checksum returns varbinary
     ]
 )
-def test_hash_consistent(backend, alltypes):
-    h1 = alltypes.string_col.hash().execute(limit=10)
-    h2 = alltypes.string_col.hash().execute(limit=10)
+def test_hash(backend, alltypes):
+    # check that multiple executions return the same result
+    h1 = alltypes.string_col.hash().execute(limit=20)
+    h2 = alltypes.string_col.hash().execute(limit=20)
     backend.assert_series_equal(h1, h2)
-    assert h1.dtype in ("i8", "uint64")  # polars likes returning uint64 for this
+    # check that the result is a signed 64-bit integer, no nulls
+    assert h1.dtype == "i8"
+    assert h1.notnull().all()
 
 
 @pytest.mark.notimpl(["trino", "oracle", "exasol", "snowflake"])


### PR DESCRIPTION
fixes https://github.com/ibis-project/ibis/issues/9135

I don't love the logic that does the conversion. It seems more complicated than it needs to be, and I don't like how I had to implement it once for each backend, but maybe there is no universal way to do this. If you can think of a cleaner way to do this or sidestep the need entirely that would be awesome