### PR TITLE
test(snowflake): create stage for copy into

### DIFF
--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -146,6 +146,7 @@ class TestConf(BackendTest):
                 CREATE SCHEMA IF NOT EXISTS {dbschema};
                 USE {dbschema};
                 CREATE TEMP STAGE {db};
+                CREATE STAGE IF NOT EXISTS ibis_testing;
                 CREATE STAGE IF NOT EXISTS models;
                 {self.script_dir.joinpath("snowflake.sql").read_text()}
                 """


### PR DESCRIPTION
## Description of changes

Add a statement in the Snowflake test configuration to create the **ibis_testing** stage if it does not already exist. This is used in the `copy_into` function. 

https://github.com/ibis-project/ibis/blob/4f93a917a00173c03968b79e1210ab53de8d85ce/ibis/backends/snowflake/tests/conftest.py#L71-L72

When configuring these tests to run locally, I noticed yesterday that the models stage was being created automatically for the joblib file, but not this one. When the `PUT ibis/ci/ibis-testing-data/parquet/*.parquet` queries run, this results in query failures.

I hope this will help ease the onboarding for anyone wanting to test the Snowflake backend. 