### PR TITLE
fix(bigquery): quote all parts of table names

### DIFF
--- a/ibis/backends/bigquery/tests/system/test_connect.py
+++ b/ibis/backends/bigquery/tests/system/test_connect.py
@@ -238,3 +238,17 @@ def test_client_with_regional_endpoints(project_id, credentials, dataset_id):
     df = alltypes.execute()
     assert df.empty
     assert not len(alltypes.to_pyarrow())
+
+
+def test_create_table_from_memtable_needs_quotes(project_id, credentials):
+    con = ibis.bigquery.connect(
+        project_id=project_id,
+        dataset_id=f"{project_id}.testing",
+        credentials=credentials,
+    )
+
+    con.create_table(
+        "region-table",
+        schema=ibis.schema(dict(its_always="str", quoting="int")),
+    )
+    con.drop_table("region-table")

--- a/ibis/backends/bigquery/tests/unit/test_client.py
+++ b/ibis/backends/bigquery/tests/unit/test_client.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import pytest
+import sqlglot as sg
 
-from ibis.backends.bigquery import client
+from ibis.backends.bigquery import _force_quote_table, client
 
 
 @pytest.mark.parametrize(
@@ -30,3 +31,27 @@ def test_parse_project_and_dataset_raises_error():
     expected_message = "data-project.my_dataset.table is not a BigQuery dataset"
     with pytest.raises(ValueError, match=expected_message):
         client.parse_project_and_dataset("my-project", "data-project.my_dataset.table")
+
+
+@pytest.mark.parametrize(
+    "bq_path_str, expected",
+    [
+        ("ibis-gbq.ibis_gbq_testing.argle", "`ibis-gbq`.`ibis_gbq_testing`.`argle`"),
+        (
+            "ibis-gbq.ibis_gbq_testing.28argle",
+            "`ibis-gbq`.`ibis_gbq_testing`.`28argle`",
+        ),
+        ("mytable-287a", "`mytable-287a`"),
+        ("myproject.mydataset.my-table", "`myproject`.`mydataset`.`my-table`"),
+        ("my-dataset.mytable", "`my-dataset`.`mytable`"),
+        (
+            "a-7b0a.dev_test_dataset.test_ibis5",
+            "`a-7b0a`.`dev_test_dataset`.`test_ibis5`",
+        ),
+    ],
+)
+def test_force_quoting(bq_path_str, expected):
+    table = sg.parse_one(bq_path_str, into=sg.exp.Table, read="bigquery")
+    table = _force_quote_table(table)
+
+    assert table.sql("bigquery") == expected


### PR DESCRIPTION
The BigQuery identifier quoting semantics are bonkers
https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#identifiers

my-table is OK, but not mydataset.my-table

mytable-287 is OK, but not mytable-287a

Just quote everything.

xref #8679