### PR TITLE
test: add test cases for no-op fillna expressions

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -464,6 +464,7 @@ def test_table_fillna_invalid(alltypes):
         param({"int_col": 20}, id="int"),
         param({"double_col": -1, "string_col": "missing"}, id="double-int-str"),
         param({"double_col": -1.5, "string_col": "missing"}, id="double-str"),
+        param({}, id="empty"),
     ],
 )
 def test_table_fillna_mapping(backend, alltypes, replacements):


### PR DESCRIPTION
Follow-up to #9134. In https://github.com/ibis-project/ibis/pull/9134#discussion_r1592696374 I said we might want to move these to be handled within the expr methods to return as a no-op, but in practice I think handling as part of the rewrite rule is cleaner. Here we just add a few test cases to improve coverage.