### PR TITLE
feat(pyarrow): support Arrow PyCapsule interface on `ibis.Table` objects

### DIFF
--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.csv as pcsv
 import pytest
+from packaging.version import parse as vparse
 from pytest import param
 
 import ibis
@@ -42,6 +43,20 @@ no_limit = [
 ]
 
 limit_no_limit = limit + no_limit
+
+
+@pytest.mark.skipif(
+    vparse(pa.__version__) < vparse("14"), reason="pyarrow >= 14 required"
+)
+def test_table___arrow_c_stream__(awards_players):
+    res = pa.table(awards_players)
+    sol = awards_players.to_pyarrow()
+    assert res.equals(sol)
+
+    # With explicit schema
+    schema = awards_players.schema().to_pyarrow()
+    res = pa.table(awards_players, schema=schema)
+    assert res.equals(sol)
 
 
 @pytest.mark.parametrize("limit", limit_no_limit)

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -188,6 +188,9 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         return IbisDataFrame(self, nan_as_null=nan_as_null, allow_copy=allow_copy)
 
+    def __arrow_c_stream__(self, requested_schema: object | None = None) -> object:
+        return self.to_pyarrow().__arrow_c_stream__(requested_schema)
+
     def __pyarrow_result__(
         self, table: pa.Table, data_mapper: type[PyArrowData] | None = None
     ) -> pa.Table:


### PR DESCRIPTION
Fixes #9140.