### PR TITLE
test: fixup arrow c stream test to be robust to nondeterministic execution

### DIFF
--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -49,14 +49,16 @@ limit_no_limit = limit + no_limit
     vparse(pa.__version__) < vparse("14"), reason="pyarrow >= 14 required"
 )
 def test_table___arrow_c_stream__(awards_players):
-    res = pa.table(awards_players)
     sol = awards_players.to_pyarrow()
-    assert res.equals(sol)
+    res = pa.table(awards_players)
+    assert res.schema.equals(sol.schema)
+    assert len(res) == len(sol)
 
     # With explicit schema
     schema = awards_players.schema().to_pyarrow()
     res = pa.table(awards_players, schema=schema)
-    assert res.equals(sol)
+    assert res.schema.equals(sol.schema)
+    assert len(res) == len(sol)
 
 
 @pytest.mark.parametrize("limit", limit_no_limit)


### PR DESCRIPTION
Fixes #9144.