### PR TITLE
fix(bigquery): quote qualified memtable names

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -93,6 +93,8 @@ def _qualify_memtable(
     if isinstance(node, sge.Table) and _MEMTABLE_PATTERN.match(node.name) is not None:
         node.args["db"] = dataset
         node.args["catalog"] = project
+        # make sure to quote table location
+        node = _force_quote_table(node)
     return node
 
 

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -386,6 +386,8 @@ def test_fully_qualified_memtable_compile(project_id, dataset_id):
     assert new_bq_con._session_dataset is not None
     assert project_id in sql
 
+    assert f"`{project_id}`.`{new_bq_con._session_dataset.dataset_id}`.`" in sql
+
 
 def test_create_table_with_options(con):
     name = gen_name("bigquery_temp_table")


### PR DESCRIPTION
xref #8679

This should hopefully fix the last failure mode noted by @kajen3 -- we weren't quoting the fully qualified path to memtables when we create them.