### PR TITLE
fix(duckdb): use existing table repr for settings view

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -67,11 +67,7 @@ class _Settings:
         self.con.execute(f"SET {key} = '{value}'")
 
     def __repr__(self):
-        ((kv,),) = self.con.execute(
-            "select map(array_agg(name), array_agg(value)) from duckdb_settings()"
-        ).fetch()
-
-        return repr(dict(zip(kv["key"], kv["value"])))
+        return repr(self.con.sql("from duckdb_settings()"))
 
 
 class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -297,3 +297,10 @@ def test_list_tables_schema_warning_refactor(con):
 
     assert con.list_tables(database="shops") == icecream_table
     assert con.list_tables(database=("shops",)) == icecream_table
+
+
+def test_settings_repr():
+    con = ibis.duckdb.connect()
+    view = repr(con.settings)
+    assert "name" in view
+    assert "value" in view


### PR DESCRIPTION
Fixes the repr of the duckdb backend settings property to be the table containing all settings