### PR TITLE
perf(api): speed up simple column accesses by avoiding dereferencing

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -770,6 +770,12 @@ class Table(Expr, _FixedTextJupyterMixin):
         if isinstance(what, slice):
             limit, offset = util.slice_to_limit_offset(what, self.count())
             return self.limit(limit, offset=offset)
+        # skip the self.bind call for single column access with strings or ints
+        # because dereferencing has significant overhead
+        elif isinstance(what, str):
+            return ops.Field(self.op(), what).to_expr()
+        elif isinstance(what, int):
+            return ops.Field(self.op(), self.columns[what]).to_expr()
 
         args = [
             self.columns[arg] if isinstance(arg, int) else arg

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -6,6 +6,7 @@ import inspect
 import itertools
 import os
 import string
+from operator import attrgetter, itemgetter
 
 import numpy as np
 import pandas as pd
@@ -832,3 +833,17 @@ def test_big_expression_compile(benchmark):
     t2 = clean_names(t)
 
     assert benchmark(ibis.to_sql, t2, dialect="duckdb")
+
+
+@pytest.fixture(scope="module")
+def many_cols():
+    return ibis.table({f"x{i:d}": "int" for i in range(10000)}, name="t")
+
+
+@pytest.mark.parametrize(
+    "getter",
+    [itemgetter("x0"), itemgetter(0), attrgetter("x0")],
+    ids=["str", "int", "attr"],
+)
+def test_column_access(benchmark, many_cols, getter):
+    benchmark(getter, many_cols)


### PR DESCRIPTION
Avoid the full dereference computation in the simple field access case, e.g., `t["a"]` or `t[0]`.