### PR TITLE
fix: make topk() use {name}_count format, like .value_counts()

### DIFF
--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1263,6 +1263,7 @@ def test_topk_op(alltypes, df):
     result = expr.execute()
     expected = df.groupby("string_col")["string_col"].count().head(3)
     assert all(result.iloc[:, 1].values == expected.values)
+    assert expr.columns == ["string_col", "string_col_count"]
 
 
 @pytest.mark.parametrize(

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1904,7 +1904,7 @@ class Column(Value, _FixedTextJupyterMixin):
         table = table.to_expr()
 
         if by is None:
-            by = lambda t: t.count()
+            by = lambda t: t.count().name(f"{self.get_name()}_count")
 
         (metric,) = bind(table, by)
 

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -294,6 +294,7 @@ def test_value_counts(table, string_col):
     bool_clause = table[string_col].notin(["1", "4", "7"])
     expr = table[bool_clause][string_col].value_counts()
     assert isinstance(expr, ir.Table)
+    assert expr.columns == ["g", "g_count"]
 
 
 def test_isin_notin_scalars():


### PR DESCRIPTION
Fixes (partially) https://github.com/ibis-project/ibis/issues/8540

this is breaking, but I think much better.