### PR TITLE
refactor(snowflake): replace array repeat udf with builtin transform function

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -64,13 +64,6 @@ return longest.map((_, i) => {
     return Object.assign(...keys.map((key, j) => ({[key]: arrays[j][i]})));
 })""",
     },
-    "ibis_udfs.public.array_repeat": {
-        # Integer inputs are not allowed because JavaScript only supports
-        # doubles
-        "inputs": {"value": "ARRAY", "count": "DOUBLE"},
-        "returns": "ARRAY",
-        "source": """return Array(count).fill(value).flat();""",
-    },
 }
 
 

--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -307,7 +307,12 @@ class SnowflakeCompiler(SQLGlotCompiler):
         return self.f.typeof(self.f.to_variant(arg))
 
     def visit_ArrayRepeat(self, op, *, arg, times):
-        return self.f.udf.array_repeat(arg, times)
+        return self.f.array_flatten(
+            self.f.transform(
+                self.f.array_generate_range(0, times),
+                sge.Lambda(this=arg, expressions=[sg.to_identifier("__arg__")]),
+            )
+        )
 
     def visit_ArrayUnion(self, op, *, left, right):
         return self.f.array_distinct(self.f.array_cat(left, right))


### PR DESCRIPTION
Turns out we can do this without a UDF. Thanks to @krzysztof-kwitt for the idea!