### PR TITLE
feat(snowflake): implement support for `asof_join` API

### DIFF
--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -656,3 +656,18 @@ class SnowflakeCompiler(SQLGlotCompiler):
                 expressions=[param],
             ),
         )
+
+    def visit_JoinLink(self, op, *, how, table, predicates):
+        assert (
+            predicates or how == "cross"
+        ), "expected non-empty predicates when not a cross join"
+
+        if how == "asof":
+            # the asof join match condition is always the first predicate by
+            # construction
+            match_condition, *predicates = predicates
+            on = sg.and_(*predicates) if predicates else None
+            return sge.Join(
+                this=table, kind=how, on=on, match_condition=match_condition
+            )
+        return super().visit_JoinLink(op, how=how, table=table, predicates=predicates)

--- a/ibis/backends/tests/test_asof_join.py
+++ b/ibis/backends/tests/test_asof_join.py
@@ -84,7 +84,6 @@ def time_keyed_right(time_keyed_df2):
 @pytest.mark.notyet(
     [
         "datafusion",
-        "snowflake",
         "trino",
         "postgres",
         "mysql",
@@ -126,7 +125,6 @@ def test_asof_join(con, time_left, time_right, time_df1, time_df2, direction, op
 @pytest.mark.notyet(
     [
         "datafusion",
-        "snowflake",
         "trino",
         "postgres",
         "mysql",


### PR DESCRIPTION
Adds support for `asof_join` to the Snowflake backend.

Depends on #9181.