### PR TITLE
test(snowflake): use standard fixture instead of assuming `SNOWFLAKE_HOME` is set

### DIFF
--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -357,8 +357,7 @@ def test_list_tables_schema_warning_refactor(con):
     )
 
 
-def test_timestamp_memtable():
-    con = ibis.snowflake.connect()
+def test_timestamp_memtable(con):
     df = pd.DataFrame(
         {
             "ts": [


### PR DESCRIPTION
Fixes a testing usage of `ibis.snowflake.connect()`