### PR TITLE
feat(pyspark): builtin udf support

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -275,15 +275,17 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def _register_udfs(self, expr: ir.Expr) -> None:
         node = expr.op()
         for udf in node.find(ops.ScalarUDF):
-            udf_name = self.compiler.__sql_name__(udf)
-            udf_func = self._wrap_udf_to_return_pandas(udf.__func__, udf.dtype)
-            udf_return = PySparkType.from_ibis(udf.dtype)
-            if udf.__input_type__ != InputType.PANDAS:
+            if udf.__input_type__ not in (InputType.PANDAS, InputType.BUILTIN):
                 raise NotImplementedError(
-                    "Only Pandas UDFs are support in the PySpark backend"
+                    "Only Builtin UDFs and Pandas UDFs are support in the PySpark backend"
                 )
-            spark_udf = pandas_udf(udf_func, udf_return, PandasUDFType.SCALAR)
-            self._session.udf.register(udf_name, spark_udf)
+            # register pandas UDFs
+            if udf.__input_type__ == InputType.PANDAS:
+                udf_name = self.compiler.__sql_name__(udf)
+                udf_func = self._wrap_udf_to_return_pandas(udf.__func__, udf.dtype)
+                udf_return = PySparkType.from_ibis(udf.dtype)
+                spark_udf = pandas_udf(udf_func, udf_return, PandasUDFType.SCALAR)
+                self._session.udf.register(udf_name, spark_udf)
 
         for udf in node.find(ops.ElementWiseVectorizedUDF):
             udf_name = self.compiler.__sql_name__(udf)

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -12,6 +12,7 @@ import ibis
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
+from ibis.expr.operations.udf import InputType
 from ibis.backends.sql.compiler import FALSE, NULL, STAR, SQLGlotCompiler
 from ibis.backends.sql.datatypes import PySparkType
 from ibis.backends.sql.dialects import PySpark
@@ -326,6 +327,10 @@ class PySparkCompiler(SQLGlotCompiler):
             name = op.func.__name__
         else:
             raise TypeError(f"Cannot get SQL name for {type(op).__name__}")
+
+        # builtin functions will not modify the name
+        if op.__input_type__ == InputType.BUILTIN:
+            return name
 
         if not name.isidentifier():
             # replace invalid characters with underscores

--- a/ibis/backends/pyspark/tests/test_udf.py
+++ b/ibis/backends/pyspark/tests/test_udf.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pandas.testing as tm
+import pytest
+
+import ibis
+
+pytest.importorskip("pyspark")
+
+
+@pytest.fixture
+def t(con):
+    return con.table("basic_table")
+
+
+@pytest.fixture
+def df(con):
+    return con._session.table("basic_table").toPandas()
+
+
+def test_builtin_udf(t, df):
+    @ibis.udf.scalar.builtin
+    def repeat(x, n):
+        ...
+
+    result = t.mutate(repeated=repeat(t.str_col, 2)).execute()
+    expected = df.assign(repeated=df.str_col * 2)
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Description of changes
support builtin udf by using @ibis.udf.scalar.builtin annotation in spark backend.

modified spark backend `_register_udfs` to accept builtin udf.
modified spark compiler `__sql_name__` to remain the origin function name.


