### PR TITLE
perf(api): rewrite union and intersection construction to support more operands

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -660,6 +660,7 @@ def test_table_info(alltypes):
             ),
             [
                 "name",
+                "pos",
                 "type",
                 "count",
                 "nulls",
@@ -712,6 +713,7 @@ def test_table_info(alltypes):
             s.of_type("numeric"),
             [
                 "name",
+                "pos",
                 "type",
                 "count",
                 "nulls",
@@ -742,6 +744,7 @@ def test_table_info(alltypes):
             s.of_type("string"),
             [
                 "name",
+                "pos",
                 "type",
                 "count",
                 "nulls",

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -847,3 +847,21 @@ def many_cols():
 )
 def test_column_access(benchmark, many_cols, getter):
     benchmark(getter, many_cols)
+
+
+@pytest.fixture(scope="module")
+def many_tables():
+    num_cols = 10
+    num_tables = 1000
+    return [
+        ibis.table({f"c{i}": "int" for i in range(num_cols)}) for _ in range(num_tables)
+    ]
+
+
+def test_large_union_construct(benchmark, many_tables):
+    assert benchmark(lambda args: ibis.union(*args), many_tables) is not None
+
+
+def test_large_union_compile(benchmark, many_tables):
+    expr = ibis.union(*many_tables)
+    assert benchmark(ibis.to_sql, expr) is not None


### PR DESCRIPTION

## Description of changes
When I am working on the https://github.com/ibis-project/ibis/pull/9139#issuecomment-2101711159, I had a `RecursionError: maximum recursion depth exceeded while calling a Python object` when union large number of tables, I found we had this similar issues before, https://github.com/ibis-project/ibis/issues/7124 and https://github.com/tobymao/sqlglot/issues/2961.

I am trying to rewrite the `union` in our codebase, It recursively union the tables using a queue, the number of unions is still similar to the original implementation, but it allow us to union more tables than before (It could unblock #9139 and added a test for larger number of tables where the original implementation will fail). Not sure if there is other side effect or not.  If it is not a good solution, I could close this PR. Thanks for your review.

I was thinking to open an issue for discussion first, since I had some code ready, just open this for discussion, if it is not the best practice to file a PR, please let me know. 

-----
**Update from the below comment**
> The updated implementation generates SQL in a manner that reduces the depth of nesting, thereby delaying the hitting of the recursion error in the SQLglot implementation

sql query: Union 7 tables in the new implementation
```
 SELECT
*
FROM (
SELECT
  *
FROM (
  SELECT
    *
  FROM "ibis_pandas_memtable_3dqxlaaxrjbrhn6sezkq3jfey4" AS "t0"
  UNION ALL
  SELECT
    *
  FROM (
    SELECT
      *
    FROM "ibis_pandas_memtable_gjf7ximrfnat7ocq7u3snufdwy" AS "t1"
    UNION ALL
    SELECT
      *
    FROM "ibis_pandas_memtable_khxo6jdnpnbc3lz4kdpkoll6ny" AS "t2"
  ) AS "t7"
) AS "t10"
UNION ALL
SELECT
  *
FROM (
  SELECT
    *
  FROM (
    SELECT
      *
    FROM "ibis_pandas_memtable_4wg3k2vsvzf4tophotkj6n6ope" AS "t3"
    UNION ALL
    SELECT
      *
    FROM "ibis_pandas_memtable_zpp6dkndfnhjla473tjklyp3ku" AS "t4"
  ) AS "t8"
  UNION ALL
  SELECT
    *
  FROM (
    SELECT
      *
    FROM "ibis_pandas_memtable_y5w7wpkhkbgr3agcuc3ftnujai" AS "t5"
    UNION ALL
    SELECT
      *
    FROM "ibis_pandas_memtable_ebrddatk6bfgti4x7gwrkgi3gm" AS "t6"
  ) AS "t9"
) AS "t11"
) AS "t12"
```

SQL query for the same union from the original implementation

```
 SELECT
  *
FROM (
  SELECT
    *
  FROM (
    SELECT
      *
    FROM (
      SELECT
        *
      FROM (
        SELECT
          *
        FROM (
          SELECT
            *
          FROM (
            SELECT
              *
            FROM "ibis_pandas_memtable_n4qzohbx3nfjdi6crezpa3zkfu" AS "t5"
            UNION ALL
            SELECT
              *
            FROM "ibis_pandas_memtable_3dhomfxvdfb2tezjssmbdkvvam" AS "t6"
          ) AS "t7"
          UNION ALL
          SELECT
            *
          FROM "ibis_pandas_memtable_mqknkr6dr5gv7hpcrri34hxydq" AS "t4"
        ) AS "t8"
        UNION ALL
        SELECT
          *
        FROM "ibis_pandas_memtable_v5wru54hhfabxd7khavq27zruq" AS "t3"
      ) AS "t9"
      UNION ALL
      SELECT
        *
      FROM "ibis_pandas_memtable_m4hgmj33nreopoxvxwhkycicfy" AS "t2"
    ) AS "t10"
    UNION ALL
    SELECT
      *
    FROM "ibis_pandas_memtable_lilxpxko6jh4lplqw2kp6jny3y" AS "t1"
  ) AS "t11"
  UNION ALL
  SELECT
    *
  FROM "ibis_pandas_memtable_mxiz4rs5z5dohdjxror5hm6p5a" AS "t0"
) AS "t12"
```


## Issues closed


