### PR TITLE
fix(snowflake): properly pass schema and database for sqlglot generation

### DIFF
--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -256,10 +256,10 @@ $$ {defn["source"]} $$"""
                 kind="DATABASE", this="ibis_udfs", exists=True
             ).sql(dialect)
             if "/" in con.database:
-                (database, schema) = con.database.split("/")
+                (catalog, db) = con.database.split("/")
                 use_stmt = sge.Use(
                     kind="SCHEMA",
-                    this=sg.table(schema, db=database, quoted=self.compiler.quoted),
+                    this=sg.table(db, catalog=catalog, quoted=self.compiler.quoted),
                 ).sql(dialect)
             else:
                 use_stmt = ""

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -251,16 +251,18 @@ $$ {defn["source"]} $$"""
             )
 
         if create_object_udfs:
-            database = con.database
-            schema = con.schema
             dialect = self.name
             create_stmt = sge.Create(
                 kind="DATABASE", this="ibis_udfs", exists=True
             ).sql(dialect)
-            use_stmt = sge.Use(
-                kind="SCHEMA",
-                this=sg.table(schema, db=database, quoted=self.compiler.quoted),
-            ).sql(dialect)
+            if "/" in con.database:
+                (database, schema) = con.database.split("/")
+                use_stmt = sge.Use(
+                    kind="SCHEMA",
+                    this=sg.table(schema, db=database, quoted=self.compiler.quoted),
+                ).sql(dialect)
+            else:
+                use_stmt = ""
 
             stmts = [
                 create_stmt,


### PR DESCRIPTION
## Description of changes

- split database and schema to pass to sqlglot for proper full name qualification
- conditionally include `use_stmt` to prevent invalid `USE SCHEMA` statement when 

currently `use_stmt` is generated like `'USE SCHEMA "DATABASE/SCHEMA"'`, it should be `'USE SCHEMA "DATABASE"."SCHEMA"'`
