### PR TITLE
refactor(sql): extract aggregate handling out into common utility class

### DIFF
--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -122,14 +122,6 @@ class BigQueryCompiler(SQLGlotCompiler):
         ops.TimestampNow: "current_timestamp",
     }
 
-    def _aggregate(self, funcname: str, *args, where):
-        func = self.f[funcname]
-
-        if where is not None:
-            args = tuple(self.if_(where, arg, NULL) for arg in args)
-
-        return func(*args, dialect=self.dialect)
-
     @staticmethod
     def _minimize_spec(start, end, spec):
         if (

--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -11,7 +11,7 @@ import sqlglot.expressions as sge
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.sql.compiler import FALSE, NULL, STAR, SQLGlotCompiler
+from ibis.backends.sql.compiler import FALSE, NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import DataFusionType
 from ibis.backends.sql.dialects import DataFusion
 from ibis.common.temporal import IntervalUnit, TimestampUnit
@@ -24,6 +24,8 @@ class DataFusionCompiler(SQLGlotCompiler):
 
     dialect = DataFusion
     type_mapper = DataFusionType
+
+    agg = AggGen(supports_filter=True)
 
     UNSUPPORTED_OPS = (
         ops.ArgMax,
@@ -72,12 +74,6 @@ class DataFusionCompiler(SQLGlotCompiler):
         ops.ArrayIntersect: "array_intersect",
         ops.ArrayUnion: "array_union",
     }
-
-    def _aggregate(self, funcname: str, *args, where):
-        expr = self.f[funcname](*args)
-        if where is not None:
-            return sg.exp.Filter(this=expr, expression=sg.exp.Where(this=where))
-        return expr
 
     def _to_timestamp(self, value, target_dtype, literal=False):
         tz = (

--- a/ibis/backends/druid/compiler.py
+++ b/ibis/backends/druid/compiler.py
@@ -6,7 +6,7 @@ import toolz
 
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.sql.compiler import NULL, SQLGlotCompiler
+from ibis.backends.sql.compiler import NULL, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import DruidType
 from ibis.backends.sql.dialects import Druid
 
@@ -16,6 +16,8 @@ class DruidCompiler(SQLGlotCompiler):
 
     dialect = Druid
     type_mapper = DruidType
+
+    agg = AggGen(supports_filter=True)
 
     LOWERED_OPS = {ops.Capitalize: None}
 
@@ -79,12 +81,6 @@ class DruidCompiler(SQLGlotCompiler):
         ops.ApproxCountDistinct: "approx_count_distinct",
         ops.StringContains: "contains_string",
     }
-
-    def _aggregate(self, funcname: str, *args, where):
-        expr = self.f[funcname](*args)
-        if where is not None:
-            return sg.exp.Filter(this=expr, expression=sg.exp.Where(this=where))
-        return expr
 
     def visit_Modulus(self, op, *, left, right):
         return self.f.anon.mod(left, right)

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -11,7 +11,7 @@ from sqlglot.dialects import DuckDB
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler
+from ibis.backends.sql.compiler import NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import DuckDBType
 
 _INTERVAL_SUFFIXES = {
@@ -32,6 +32,8 @@ class DuckDBCompiler(SQLGlotCompiler):
 
     dialect = DuckDB
     type_mapper = DuckDBType
+
+    agg = AggGen(supports_filter=True)
 
     LOWERED_OPS = {
         ops.Sample: None,
@@ -84,12 +86,6 @@ class DuckDBCompiler(SQLGlotCompiler):
         ops.GeoX: "st_x",
         ops.GeoY: "st_y",
     }
-
-    def _aggregate(self, funcname: str, *args, where):
-        expr = self.f[funcname](*args)
-        if where is not None:
-            return sge.Filter(this=expr, expression=sge.Where(this=where))
-        return expr
 
     def visit_StructColumn(self, op, *, names, values):
         return sge.Struct.from_arg_list(

--- a/ibis/backends/exasol/compiler.py
+++ b/ibis/backends/exasol/compiler.py
@@ -103,12 +103,6 @@ class ExasolCompiler(SQLGlotCompiler):
             return None
         return spec
 
-    def _aggregate(self, funcname: str, *args, where):
-        func = self.f[funcname]
-        if where is not None:
-            args = tuple(self.if_(where, arg, NULL) for arg in args)
-        return func(*args)
-
     @staticmethod
     def _gen_valid_name(name: str) -> str:
         """Exasol does not allow dots in quoted column names."""

--- a/ibis/backends/impala/compiler.py
+++ b/ibis/backends/impala/compiler.py
@@ -75,12 +75,6 @@ class ImpalaCompiler(SQLGlotCompiler):
         ops.TypeOf: "typeof",
     }
 
-    def _aggregate(self, funcname: str, *args, where):
-        if where is not None:
-            args = tuple(self.if_(where, arg, NULL) for arg in args)
-
-        return self.f[funcname](*args, dialect=self.dialect)
-
     @staticmethod
     def _minimize_spec(start, end, spec):
         # start is None means unbounded preceding

--- a/ibis/backends/mssql/compiler.py
+++ b/ibis/backends/mssql/compiler.py
@@ -144,12 +144,6 @@ class MSSQLCompiler(SQLGlotCompiler):
     def NEG_INF(self):
         return self.f.double("-Infinity")
 
-    def _aggregate(self, funcname: str, *args, where):
-        func = self.f[funcname]
-        if where is not None:
-            args = tuple(self.if_(where, arg, NULL) for arg in args)
-        return func(*args)
-
     @staticmethod
     def _generate_groups(groups):
         return groups

--- a/ibis/backends/mysql/compiler.py
+++ b/ibis/backends/mysql/compiler.py
@@ -107,12 +107,6 @@ class MySQLCompiler(SQLGlotCompiler):
         ops.Log2: "log2",
     }
 
-    def _aggregate(self, funcname: str, *args, where):
-        func = self.f[funcname]
-        if where is not None:
-            args = tuple(self.if_(where, arg, NULL) for arg in args)
-        return func(*args)
-
     @staticmethod
     def _minimize_spec(start, end, spec):
         if (

--- a/ibis/backends/oracle/compiler.py
+++ b/ibis/backends/oracle/compiler.py
@@ -95,12 +95,6 @@ class OracleCompiler(SQLGlotCompiler):
         ops.Hash: "ora_hash",
     }
 
-    def _aggregate(self, funcname: str, *args, where):
-        func = self.f[funcname]
-        if where is not None:
-            args = tuple(self.if_(where, arg) for arg in args)
-        return func(*args)
-
     @staticmethod
     def _generate_groups(groups):
         return groups

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -11,7 +11,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.rules as rlz
-from ibis.backends.sql.compiler import NULL, STAR, SQLGlotCompiler
+from ibis.backends.sql.compiler import NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import PostgresType
 from ibis.backends.sql.dialects import Postgres
 
@@ -26,6 +26,8 @@ class PostgresCompiler(SQLGlotCompiler):
 
     dialect = Postgres
     type_mapper = PostgresType
+
+    agg = AggGen(supports_filter=True)
 
     NAN = sge.Literal.number("'NaN'::double precision")
     POS_INF = sge.Literal.number("'Inf'::double precision")
@@ -95,12 +97,6 @@ class PostgresCompiler(SQLGlotCompiler):
         ops.RegexSearch: "regexp_like",
         ops.TimeFromHMS: "make_time",
     }
-
-    def _aggregate(self, funcname: str, *args, where):
-        expr = self.f[funcname](*args)
-        if where is not None:
-            return sge.Filter(this=expr, expression=sge.Where(this=where))
-        return expr
 
     def visit_RandomUUID(self, op, **kwargs):
         return self.f.gen_random_uuid()

--- a/ibis/backends/pyspark/compiler.py
+++ b/ibis/backends/pyspark/compiler.py
@@ -86,12 +86,6 @@ class PySparkCompiler(SQLGlotCompiler):
         ops.UnwrapJSONBoolean: "unwrap_json_bool",
     }
 
-    def _aggregate(self, funcname: str, *args, where):
-        func = self.f[funcname]
-        if where is not None:
-            args = tuple(self.if_(where, arg, NULL) for arg in args)
-        return func(*args)
-
     def visit_InSubquery(self, op, *, rel, needle):
         if op.needle.dtype.is_struct():
             # construct the outer struct for pyspark

--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -87,13 +87,6 @@ class SnowflakeCompiler(SQLGlotCompiler):
         super().__init__()
         self.f = SnowflakeFuncGen()
 
-    def _aggregate(self, funcname: str, *args, where):
-        if where is not None:
-            args = [self.if_(where, arg, NULL) for arg in args]
-
-        func = self.f[funcname]
-        return func(*args)
-
     @staticmethod
     def _minimize_spec(start, end, spec):
         if (

--- a/ibis/backends/sqlite/compiler.py
+++ b/ibis/backends/sqlite/compiler.py
@@ -9,7 +9,7 @@ from public import public
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-from ibis.backends.sql.compiler import NULL, SQLGlotCompiler
+from ibis.backends.sql.compiler import NULL, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import SQLiteType
 from ibis.backends.sql.dialects import SQLite
 from ibis.common.temporal import DateUnit, IntervalUnit
@@ -21,6 +21,8 @@ class SQLiteCompiler(SQLGlotCompiler):
 
     dialect = SQLite
     type_mapper = SQLiteType
+
+    agg = AggGen(supports_filter=True)
 
     NAN = NULL
     POS_INF = sge.Literal.number("1e999")
@@ -96,12 +98,6 @@ class SQLiteCompiler(SQLGlotCompiler):
         ops.Time: "time",
         ops.Date: "date",
     }
-
-    def _aggregate(self, funcname: str, *args, where):
-        expr = self.f[funcname](*args)
-        if where is not None:
-            return sge.Filter(this=expr, expression=sge.Where(this=where))
-        return expr
 
     def visit_Log10(self, op, *, arg):
         return self.f.anon.log10(arg)
@@ -222,7 +218,7 @@ class SQLiteCompiler(SQLGlotCompiler):
         if op.where is not None:
             cond = sg.and_(cond, where)
 
-        agg = self._aggregate(func, key, where=cond)
+        agg = self.agg[func](key, where=cond)
         return self.f.anon.json_extract(self.f.json_array(arg, agg), "$[0]")
 
     def visit_UnwrapJSONString(self, op, *, arg):
@@ -254,10 +250,10 @@ class SQLiteCompiler(SQLGlotCompiler):
         )
 
     def visit_Variance(self, op, *, arg, how, where):
-        return self._aggregate(f"_ibis_var_{op.how}", arg, where=where)
+        return self.agg[f"_ibis_var_{op.how}"](arg, where=where)
 
     def visit_StandardDev(self, op, *, arg, how, where):
-        var = self._aggregate(f"_ibis_var_{op.how}", arg, where=where)
+        var = self.agg[f"_ibis_var_{op.how}"](arg, where=where)
         return self.f.sqrt(var)
 
     def visit_ApproxCountDistinct(self, op, *, arg, where):


### PR DESCRIPTION
This is an initial refactor moving towards #9170.

Previously every backend implemented their own `_aggregate` function - many of them copy-pasted (with slight variations) of each other.

To add a new `order_by` kwarg to `_aggregate` would require editing all 16 copies of this function, which would be _annoying_. This PR is an attempt to centralize their implementations into a common `Gen` class. The class takes a config flag to handle the common cases, the uncommon cases are then handled by backend-specific subclasses.

This also extracts the `.agg` attribute out to be a class variable (err, descriptor) rather than an instance variable.

An alternative implementation would be adding boolean flags directly to the `SQLGlotCompiler` class, but IIRC we intentionally moved away from those in the SQLAlchemy -> SQLGlot refactor. Could go either way here.