### PR TITLE
chore: allow overlapping docs-preview and cloud-ci runs via label

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -11,7 +11,7 @@ jobs:
     concurrency:
       group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}-${{ github.event.label.name }}
       cancel-in-progress: true
-    if: github.event.label.name == 'docs-preview'
+    if: contains(github.event.pull_request.labels.*.name, 'docs-preview')
     steps:
       - uses: actions/create-github-app-token@v1.10.0
         id: generate_token

--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -35,7 +35,7 @@ jobs:
       cancel-in-progress: false
 
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.label.name == 'ci-run-cloud'
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci-run-cloud')
     strategy:
       fail-fast: false
       matrix:
@@ -71,10 +71,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        if: github.event.label.name != 'ci-run-cloud'
+        if: ${{ ! contains(github.event.pull_request.labels.*.name , 'ci-run-cloud') }}
 
       - name: checkout
-        if: github.event.label.name == 'ci-run-cloud'
+        if: contains(github.event.pull_request.labels.*.name, 'ci-run-cloud')
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -88,7 +88,7 @@ jobs:
 
       - name: reset cloud ci run label
         uses: actions-ecosystem/action-remove-labels@v1
-        if: github.event.label.name == 'ci-run-cloud'
+        if: contains(github.event.pull_request.labels.*.name, 'ci-run-cloud')
         with:
           labels: ci-run-cloud
           github_token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Or at least, that's the hope here.  Up to now, applying one of these
labels while the other is in place has led to a clobbering of any CI
jobs triggered by adding a label.
My hope is that the use of `contains` will prevent that from happening
since it's about whether that label is _present_, not only if the most
recent labeling _event_ matches the target name.
