### PR TITLE
test(duckdb): test multiple connections to named in-memory db

### DIFF
--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -304,3 +304,19 @@ def test_settings_repr():
     view = repr(con.settings)
     assert "name" in view
     assert "value" in view
+
+
+def test_connect_named_in_memory_db():
+    con_named_db = ibis.duckdb.connect(":memory:mydb")
+
+    con_named_db.create_table("ork", schema=ibis.schema(dict(bork="int32")))
+    assert "ork" in con_named_db.list_tables()
+
+    con_named_db_2 = ibis.duckdb.connect(":memory:mydb")
+    assert "ork" in con_named_db_2.list_tables()
+
+    unnamed_memory_db = ibis.duckdb.connect(":memory:")
+    assert "ork" not in unnamed_memory_db.list_tables()
+
+    default_memory_db = ibis.duckdb.connect()
+    assert "ork" not in default_memory_db.list_tables()


### PR DESCRIPTION
Also test that named DB catalogs aren't bleeding over into unnamed memory dbs

This is a test to ensure we don't accidentally remove the functionality added in
#9241 for connecting to named in-memory databases in DuckDB.