### PR TITLE
feat(snowflake): add overwrite kwarg to read_parquet

### DIFF
--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -242,6 +242,13 @@ def test_read_parquet(con, data_dir):
 
     assert t.timestamp_col.type().is_timestamp()
 
+    with pytest.raises(IOError):
+        con.read_parquet(path, table_name=t.op().name)
+
+    t = con.read_parquet(path, table_name=t.op().name, overwrite=True)
+
+    assert t.timestamp_col.type().is_timestamp()
+
 
 def test_array_repr(con, monkeypatch):
     monkeypatch.setattr(ibis.options, "interactive", True)


### PR DESCRIPTION
xref #9199 

I'll get to the rest of the backends eventually, but in case anyone wanted to pick this up and run with it, I'm opening it as a draft PR.

Open question as to whether we handle catching all of the various "tried to create a table that already exists" errors and standardize them for the end-user.  