### PR TITLE
test(trino): make sure uri connect test does not rely on backend data

### DIFF
--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-import os
 import string
 
 import pytest
@@ -187,12 +186,11 @@ def test_list_tables_schema_warning_refactor(con):
 
 
 def test_connect_uri():
-    TRINO_USER = os.getenv("IBIS_TEST_TRINO_USER", os.getenv("TRINO_USER", "user"))
-    TRINO_PASS = os.getenv("IBIS_TEST_TRINO_PASSWORD", os.getenv("TRINO_PASSWORD", ""))
-    TRINO_HOST = os.getenv("IBIS_TEST_TRINO_HOST", os.getenv("TRINO_HOST", "localhost"))
-    TRINO_PORT = int(os.getenv("IBIS_TEST_TRINO_PORT", os.getenv("TRINO_PORT", "8080")))
     con = ibis.connect(
         f"trino://{TRINO_USER}:{TRINO_PASS}@{TRINO_HOST}:{TRINO_PORT}/memory/default"
     )
 
-    assert con.list_tables()
+    result = con.sql("SELECT 1 AS a, 'b' AS b").to_pandas()
+
+    assert result.iat[0, 0] == 1
+    assert result.iat[0, 1] == "b"


### PR DESCRIPTION
`test_connect_uri` relies on the backend having been initialized with tables, which breaks when the test is run before that happens in another test. This PR fixes that by running a simple SQL query instead.