### PR TITLE
feat(polars): implement `create_view`/`drop_view`/`drop_table`

### DIFF
--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -383,6 +383,27 @@ class Backend(BaseBackend, NoUrl):
         self._add_table(name, obj)
         return self.table(name)
 
+    def create_view(
+        self,
+        name: str,
+        obj: ir.Table,
+        *,
+        database: str | None = None,
+        overwrite: bool = False,
+    ) -> ir.Table:
+        return self.create_table(
+            name, obj=obj, temp=None, database=database, overwrite=overwrite
+        )
+
+    def drop_table(self, name: str, *, force: bool = False) -> None:
+        if name in self._tables:
+            del self._tables[name]
+        elif not force:
+            raise com.IbisError(f"Table {name!r} does not exist")
+
+    def drop_view(self, name: str, *, force: bool = False) -> None:
+        self.drop_table(name, force=force)
+
     def get_schema(self, table_name):
         return self._tables[table_name].schema
 
@@ -532,12 +553,3 @@ class Backend(BaseBackend, NoUrl):
 
     def _clean_up_cached_table(self, op):
         self._remove_table(op.name)
-
-    def create_view(self, *_, **__) -> ir.Table:
-        raise NotImplementedError(self.name)
-
-    def drop_table(self, *_, **__) -> ir.Table:
-        raise NotImplementedError(self.name)
-
-    def drop_view(self, *_, **__) -> ir.Table:
-        raise NotImplementedError(self.name)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -391,7 +391,7 @@ def test_nullable_input_output(con, temp_table):
     assert t.schema().types[2].nullable
 
 
-@mark.notimpl(["druid", "polars"])
+@mark.notimpl(["druid"])
 def test_create_drop_view(ddl_con, temp_view):
     # setup
     table_name = "functional_alltypes"
@@ -1392,11 +1392,6 @@ def gen_test_name(con: BaseBackend):
     con.drop_table(name, force=True)
 
 
-@mark.notimpl(
-    ["polars"],
-    raises=NotImplementedError,
-    reason="overwriting not implemented in ibis for this backend",
-)
 @mark.broken(
     ["druid"], raises=NotImplementedError, reason="generated SQL fails to parse"
 )


### PR DESCRIPTION
For the `polars` backend:

- Implements `create_view`/`drop_view` as aliases for the equivalent table versions (as we do for pandas and dask).
- Implements `drop_table`