### PR TITLE
chore: add box to scalar expr in interactive mode

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -207,7 +207,9 @@ Examples
 >>> import ibis
 >>> ibis.options.interactive = True
 >>> ibis.NA.isnull()
-True
+┌──────┐
+│ True │
+└──────┘
 
 datatype-specific methods aren't available on `NA`:
 
@@ -219,7 +221,9 @@ AttributeError: 'NullScalar' object has no attribute 'upper'
 Instead, use the typed `ibis.null`:
 
 >>> ibis.null(str).upper().isnull()
-True
+┌──────┐
+│ True │
+└──────┘
 """
 
 deferred = _
@@ -848,12 +852,16 @@ def timestamp(
     Create a timestamp scalar from a string
 
     >>> ibis.timestamp("2023-01-02T03:04:05")
-    Timestamp('2023-01-02 03:04:05')
+    ┌──────────────────────────────────┐
+    │ Timestamp('2023-01-02 03:04:05') │
+    └──────────────────────────────────┘
 
     Create a timestamp scalar from components
 
     >>> ibis.timestamp(2023, 1, 2, 3, 4, 5)
-    Timestamp('2023-01-02 03:04:05')
+    ┌──────────────────────────────────┐
+    │ Timestamp('2023-01-02 03:04:05') │
+    └──────────────────────────────────┘
 
     Create a timestamp column from components
 
@@ -929,12 +937,16 @@ def date(value_or_year, month=None, day=None, /):
     Create a date scalar from a string
 
     >>> ibis.date("2023-01-02")
-    datetime.date(2023, 1, 2)
+    ┌───────────────────────────┐
+    │ datetime.date(2023, 1, 2) │
+    └───────────────────────────┘
 
     Create a date scalar from year, month, and day
 
     >>> ibis.date(2023, 1, 2)
-    datetime.date(2023, 1, 2)
+    ┌───────────────────────────┐
+    │ datetime.date(2023, 1, 2) │
+    └───────────────────────────┘
 
     Create a date column from year, month, and day
 
@@ -998,12 +1010,16 @@ def time(value_or_hour, minute=None, second=None, /):
     Create a time scalar from a string
 
     >>> ibis.time("01:02:03")
-    datetime.time(1, 2, 3)
+    ┌────────────────────────┐
+    │ datetime.time(1, 2, 3) │
+    └────────────────────────┘
 
     Create a time scalar from hour, minute, and second
 
     >>> ibis.time(1, 2, 3)
-    datetime.time(1, 2, 3)
+    ┌────────────────────────┐
+    │ datetime.time(1, 2, 3) │
+    └────────────────────────┘
 
     Create a time column from hour, minute, and second
 
@@ -2135,33 +2151,45 @@ def range(start, stop, step) -> ir.ArrayValue:
     Range using only a stop argument
 
     >>> ibis.range(5)
-    [0, 1, ... +3]
+    ┌────────────────┐
+    │ [0, 1, ... +3] │
+    └────────────────┘
 
     Simple range using start and stop
 
     >>> ibis.range(1, 5)
-    [1, 2, ... +2]
+    ┌────────────────┐
+    │ [1, 2, ... +2] │
+    └────────────────┘
 
     Generate an empty range
 
     >>> ibis.range(0)
-    []
+    ┌────┐
+    │ [] │
+    └────┘
 
     Negative step values are supported
 
     >>> ibis.range(10, 4, -2)
-    [10, 8, ... +1]
+    ┌─────────────────┐
+    │ [10, 8, ... +1] │
+    └─────────────────┘
 
     `ibis.range` behaves the same as Python's range ...
 
     >>> ibis.range(0, 7, -1)
-    []
+    ┌────┐
+    │ [] │
+    └────┘
 
     ... except when the step is zero, in which case `ibis.range` returns an
     empty array
 
     >>> ibis.range(0, 5, 0)
-    []
+    ┌────┐
+    │ [] │
+    └────┘
 
     Because the resulting expression is array, you can unnest the values
 
@@ -2182,11 +2210,13 @@ def range(start, stop, step) -> ir.ArrayValue:
 
     >>> expr = ibis.range("2002-01-01", "2002-02-01", ibis.interval(days=2)).name("ts")
     >>> expr
-    [
-        datetime.datetime(2002, 1, 1, 0, 0),
-        datetime.datetime(2002, 1, 3, 0, 0),
-        ... +14
-    ]
+    ┌──────────────────────────────────────────┐
+    │ [                                        │
+    │     datetime.datetime(2002, 1, 1, 0, 0), │
+    │     datetime.datetime(2002, 1, 3, 0, 0), │
+    │     ... +14                              │
+    │ ]                                        │
+    └──────────────────────────────────────────┘
     >>> expr.unnest()
     ┏━━━━━━━━━━━━━━━━━━━━━┓
     ┃ ts                  ┃
@@ -2405,7 +2435,9 @@ def coalesce(*args: Any) -> ir.Value:
     >>> import ibis
     >>> ibis.options.interactive = True
     >>> ibis.coalesce(None, 4, 5)
-    4
+    ┌───┐
+    │ 4 │
+    └───┘
 
     """
     return ops.Coalesce(args).to_expr()
@@ -2430,7 +2462,9 @@ def greatest(*args: Any) -> ir.Value:
     >>> import ibis
     >>> ibis.options.interactive = True
     >>> ibis.greatest(None, 4, 5)
-    5
+    ┌───┐
+    │ 5 │
+    └───┘
 
     """
     return ops.Greatest(args).to_expr()
@@ -2455,7 +2489,9 @@ def least(*args: Any) -> ir.Value:
     >>> import ibis
     >>> ibis.options.interactive = True
     >>> ibis.least(None, 4, 5)
-    4
+    ┌───┐
+    │ 4 │
+    └───┘
 
     """
     return ops.Least(args).to_expr()

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -621,7 +621,9 @@ class agg(_UDF):
         >>> t = ibis.examples.penguins.fetch()
         >>> expr = favg(t.bill_length_mm)
         >>> expr
-        43.9219298245614
+        ┌──────────────────┐
+        │ 43.9219298245614 │
+        └──────────────────┘
 
         """
         return _wrap(

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -1090,7 +1090,9 @@ def array(values: Iterable[V]) -> ArrayValue:
     >>> import ibis
     >>> ibis.options.interactive = True
     >>> ibis.array([1.0, None])
-    [1.0, None]
+    ┌─────────────┐
+    │ [1.0, None] │
+    └─────────────┘
 
     Create an array from column and scalar expressions
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1046,7 +1046,9 @@ class Value(Expr):
         │ b      │     5 │
         └────────┴───────┘
         >>> t.value.collect()
-        [1, 2, ... +3]
+        ┌────────────────┐
+        │ [1, 2, ... +3] │
+        └────────────────┘
         >>> type(t.value.collect())
         <class 'ibis.expr.types.arrays.ArrayScalar'>
 
@@ -1098,7 +1100,9 @@ class Value(Expr):
         >>> one = ibis.literal(1)
         >>> two = ibis.literal(2)
         >>> two.identical_to(one + one)
-        True
+        ┌──────┐
+        │ True │
+        └──────┘
         """
         try:
             return ops.IdenticalTo(self, other).to_expr()
@@ -1142,13 +1146,19 @@ class Value(Expr):
         │           36.7 │          19.3 │
         └────────────────┴───────────────┘
         >>> t.bill_length_mm.group_concat()
-        '39.1,39.5,40.3,36.7'
+        ┌───────────────────────┐
+        │ '39.1,39.5,40.3,36.7' │
+        └───────────────────────┘
 
         >>> t.bill_length_mm.group_concat(sep=": ")
-        '39.1: 39.5: 40.3: 36.7'
+        ┌──────────────────────────┐
+        │ '39.1: 39.5: 40.3: 36.7' │
+        └──────────────────────────┘
 
         >>> t.bill_length_mm.group_concat(sep=": ", where=t.bill_depth_mm > 18)
-        '39.1: 36.7'
+        ┌──────────────┐
+        │ '39.1: 36.7' │
+        └──────────────┘
         """
         return ops.GroupConcat(
             self, sep=sep, where=self._bind_to_parent_table(where)
@@ -1548,9 +1558,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.approx_nunique()
-        94
+        ┌────┐
+        │ 94 │
+        └────┘
         >>> t.body_mass_g.approx_nunique(where=t.species == "Adelie")
-        55
+        ┌────┐
+        │ 55 │
+        └────┘
         """
         return ops.ApproxCountDistinct(
             self, where=self._bind_to_parent_table(where)
@@ -1589,9 +1603,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.approx_median()
-        4030
+        ┌──────┐
+        │ 4030 │
+        └──────┘
         >>> t.body_mass_g.approx_median(where=t.species == "Chinstrap")
-        3700
+        ┌──────┐
+        │ 3700 │
+        └──────┘
         """
         return ops.ApproxMedian(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -1614,9 +1632,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.mode()
-        3800
+        ┌──────┐
+        │ 3800 │
+        └──────┘
         >>> t.body_mass_g.mode(where=(t.species == "Gentoo") & (t.sex == "male"))
-        5550
+        ┌──────┐
+        │ 5550 │
+        └──────┘
         """
         return ops.Mode(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -1639,9 +1661,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.max()
-        6300
+        ┌──────┐
+        │ 6300 │
+        └──────┘
         >>> t.body_mass_g.max(where=t.species == "Chinstrap")
-        4800
+        ┌──────┐
+        │ 4800 │
+        └──────┘
         """
         return ops.Max(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -1664,9 +1690,14 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.min()
-        2700
+        ┌──────┐
+        │ 2700 │
+        └──────┘
         >>> t.body_mass_g.min(where=t.species == "Adelie")
-        2850
+        ┌──────┐
+        │ 2850 │
+        └──────┘
+
         """
         return ops.Min(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -1691,9 +1722,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.species.argmax(t.body_mass_g)
-        'Gentoo'
+        ┌──────────┐
+        │ 'Gentoo' │
+        └──────────┘
         >>> t.species.argmax(t.body_mass_g, where=t.island == "Dream")
-        'Chinstrap'
+        ┌─────────────┐
+        │ 'Chinstrap' │
+        └─────────────┘
         """
         return ops.ArgMax(
             self, key=key, where=self._bind_to_parent_table(where)
@@ -1720,10 +1755,14 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.species.argmin(t.body_mass_g)
-        'Chinstrap'
+        ┌─────────────┐
+        │ 'Chinstrap' │
+        └─────────────┘
 
         >>> t.species.argmin(t.body_mass_g, where=t.island == "Biscoe")
-        'Adelie'
+        ┌──────────┐
+        │ 'Adelie' │
+        └──────────┘
         """
         return ops.ArgMin(
             self, key=key, where=self._bind_to_parent_table(where)
@@ -1752,7 +1791,9 @@ class Column(Value, _FixedTextJupyterMixin):
         Compute the median of `bill_depth_mm`
 
         >>> t.bill_depth_mm.median()
-        17.3
+        ┌──────┐
+        │ 17.3 │
+        └──────┘
         >>> t.group_by(t.species).agg(median_bill_depth=t.bill_depth_mm.median()).order_by(
         ...     ibis.desc("median_bill_depth")
         ... )
@@ -1816,7 +1857,9 @@ class Column(Value, _FixedTextJupyterMixin):
         Compute the 99th percentile of `bill_depth`
 
         >>> t.bill_depth_mm.quantile(0.99)
-        21.1
+        ┌──────┐
+        │ 21.1 │
+        └──────┘
         >>> t.group_by(t.species).agg(p99_bill_depth=t.bill_depth_mm.quantile(0.99)).order_by(
         ...     ibis.desc("p99_bill_depth")
         ... )
@@ -1873,9 +1916,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.nunique()
-        94
+        ┌────┐
+        │ 94 │
+        └────┘
         >>> t.body_mass_g.nunique(where=t.species == "Adelie")
-        55
+        ┌────┐
+        │ 55 │
+        └────┘
         """
         return ops.CountDistinct(
             self, where=self._bind_to_parent_table(where)
@@ -2024,9 +2071,13 @@ class Column(Value, _FixedTextJupyterMixin):
         │ d      │
         └────────┘
         >>> t.chars.first()
-        'a'
+        ┌─────┐
+        │ 'a' │
+        └─────┘
         >>> t.chars.first(where=t.chars != "a")
-        'b'
+        ┌─────┐
+        │ 'b' │
+        └─────┘
         """
         return ops.First(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -2050,9 +2101,13 @@ class Column(Value, _FixedTextJupyterMixin):
         │ d      │
         └────────┘
         >>> t.chars.last()
-        'd'
+        ┌─────┐
+        │ 'd' │
+        └─────┘
         >>> t.chars.last(where=t.chars != "d")
-        'c'
+        ┌─────┐
+        │ 'c' │
+        └─────┘
         """
         return ops.Last(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -2246,9 +2301,13 @@ def null(type: dt.DataType | str | None = None) -> Value:
         ...
     AttributeError: 'NullScalar' object has no attribute 'upper'
     >>> ibis.null(str).upper()
-    None
+    ┌──────┐
+    │ None │
+    └──────┘
     >>> ibis.null(str).upper().isnull()
-    True
+    ┌──────┐
+    │ True │
+    └──────┘
     """
     if type is None:
         type = dt.null

--- a/ibis/expr/types/geospatial.py
+++ b/ibis/expr/types/geospatial.py
@@ -803,7 +803,9 @@ class GeoSpatialValue(NumericValue):
         >>> line = shapely.LineString([[0, 0], [1, 0], [1, 1]])
         >>> line_lit = ibis.literal(line, type="geometry")
         >>> line_lit.length()
-        2.0
+        ┌─────┐
+        │ 2.0 │
+        └─────┘
         >>> t = ibis.examples.zones.fetch()
         >>> t.geom.length()
         ┏━━━━━━━━━━━━━━━━━┓
@@ -1034,7 +1036,9 @@ class GeoSpatialValue(NumericValue):
         >>> line = shapely.LineString([[0, 0], [1, 0], [1, 1]])
         >>> line_lit = ibis.literal(line, type="geometry")
         >>> line_lit.start_point()
-        <POINT (0 0)>
+        ┌───────────────┐
+        │ <POINT (0 0)> │
+        └───────────────┘
         """
         return ops.GeoStartPoint(self).to_expr()
 
@@ -1058,7 +1062,9 @@ class GeoSpatialValue(NumericValue):
         >>> line = shapely.LineString([[0, 0], [1, 0], [1, 1]])
         >>> line_lit = ibis.literal(line, type="geometry")
         >>> line_lit.end_point()
-        <POINT (1 1)>
+        ┌───────────────┐
+        │ <POINT (1 1)> │
+        └───────────────┘
         """
         return ops.GeoEndPoint(self).to_expr()
 
@@ -1647,7 +1653,11 @@ class GeoSpatialColumn(NumericColumn, GeoSpatialValue):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.zones.fetch()
         >>> t.geom.unary_union()
-        <MULTIPOLYGON (((934491.267 196304.019, 934656.105 196375.819, 934810.948 19...>
+        ┌──────────────────────────────────────────────────────────────────────────────┐
+        │ <MULTIPOLYGON (((934491.267 196304.019, 934656.105 196375.819, 934810.948    │
+        │ 19...>                                                                       │
+        └──────────────────────────────────────────────────────────────────────────────┘
+
         """
         return ops.GeoUnaryUnion(self, where=where).to_expr()
 

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -322,12 +322,18 @@ class BooleanColumn(NumericColumn, BooleanValue):
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable({"arr": [1, 2, 3, None]})
         >>> (t.arr > 2).any()
-        True
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> (t.arr > 4).any()
-        False
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> m = ibis.memtable({"arr": [True, True, True, False]})
         >>> (t.arr == None).any(where=t.arr != None)
-        False
+        ┌───────┐
+        │ False │
+        └───────┘
         """
         from ibis.common.deferred import Call, Deferred, _
 
@@ -370,12 +376,18 @@ class BooleanColumn(NumericColumn, BooleanValue):
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable({"arr": [1, 2, 3, 4]})
         >>> (t.arr > 1).notany()
-        False
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> (t.arr > 4).notany()
-        True
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> m = ibis.memtable({"arr": [True, True, True, False]})
         >>> (t.arr == None).notany(where=t.arr != None)
-        True
+        ┌──────┐
+        │ True │
+        └──────┘
         """
         return ~self.any(where=where)
 
@@ -398,13 +410,21 @@ class BooleanColumn(NumericColumn, BooleanValue):
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable({"arr": [1, 2, 3, 4]})
         >>> (t.arr >= 1).all()
-        True
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> (t.arr > 2).all()
-        False
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> (t.arr == 2).all(where=t.arr == 2)
-        True
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> (t.arr == 2).all(where=t.arr >= 2)
-        False
+        ┌───────┐
+        │ False │
+        └───────┘
 
         """
         return ops.All(self, where=self._bind_to_parent_table(where)).to_expr()
@@ -428,13 +448,22 @@ class BooleanColumn(NumericColumn, BooleanValue):
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable({"arr": [1, 2, 3, 4]})
         >>> (t.arr >= 1).notall()
-        False
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> (t.arr > 2).notall()
-        True
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> (t.arr == 2).notall(where=t.arr == 2)
-        False
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> (t.arr == 2).notall(where=t.arr >= 2)
-        True
+        ┌──────┐
+        │ True │
+        └──────┘
+
         """
         return ~self.all(where=where)
 

--- a/ibis/expr/types/maps.py
+++ b/ibis/expr/types/maps.py
@@ -368,7 +368,9 @@ class MapValue(Value):
         >>> ibis.options.interactive = True
         >>> m = ibis.map({"a": 1, "b": 2})
         >>> m.values()
-        [1, 2]
+        ┌────────┐
+        │ [1, 2] │
+        └────────┘
         """
         return ops.MapValues(self).to_expr()
 
@@ -392,7 +394,9 @@ class MapValue(Value):
         >>> m1 = ibis.map({"a": 1, "b": 2})
         >>> m2 = ibis.map({"c": 3, "d": 4})
         >>> m1 + m2
-        {'a': 1, 'b': 2, ... +2}
+        ┌──────────────────────────┐
+        │ {'a': 1, 'b': 2, ... +2} │
+        └──────────────────────────┘
         """
         return ops.MapMerge(self, other).to_expr()
 
@@ -416,7 +420,9 @@ class MapValue(Value):
         >>> m1 = ibis.map({"a": 1, "b": 2})
         >>> m2 = ibis.map({"c": 3, "d": 4})
         >>> m1 + m2
-        {'a': 1, 'b': 2, ... +2}
+        ┌──────────────────────────┐
+        │ {'a': 1, 'b': 2, ... +2} │
+        └──────────────────────────┘
         """
         return ops.MapMerge(self, other).to_expr()
 
@@ -462,7 +468,9 @@ def map(
     >>> import ibis
     >>> ibis.options.interactive = True
     >>> ibis.map(dict(a=1, b=2))
-    {'a': 1, 'b': 2}
+    ┌──────────────────┐
+    │ {'a': 1, 'b': 2} │
+    └──────────────────┘
 
     Create a Map Column from columns with keys and values
 

--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -9,7 +9,9 @@ from urllib.parse import urlparse
 
 import rich
 import rich.table
+from rich import box
 from rich.align import Align
+from rich.panel import Panel
 from rich.pretty import Pretty
 from rich.text import Text
 
@@ -286,12 +288,13 @@ def _to_rich_scalar(
     max_string: int | None = None,
     max_depth: int | None = None,
 ) -> Pretty:
-    return Pretty(
+    scalar = Pretty(
         expr.execute(),
         max_length=max_length or ibis.options.repr.interactive.max_length,
         max_string=max_string or ibis.options.repr.interactive.max_string,
         max_depth=max_depth or ibis.options.repr.interactive.max_depth,
     )
+    return Panel(scalar, expand=False, box=box.SQUARE)
 
 
 def _to_rich_table(

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1274,9 +1274,13 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         >>> expr = t.distinct(on=["species", "island", "year", "bill_length_mm"], keep=None)
         >>> expr.count()
-        273
+        ┌─────┐
+        │ 273 │
+        └─────┘
         >>> t.count()
-        344
+        ┌─────┐
+        │ 344 │
+        └─────┘
 
         You can pass [`selectors`](./selectors.qmd) to `on`
 
@@ -2517,9 +2521,13 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ bar    │
         └────────┘
         >>> t.nunique()
-        2
+        ┌───┐
+        │ 2 │
+        └───┘
         >>> t.nunique(t.a != "foo")
-        1
+        ┌───┐
+        │ 1 │
+        └───┘
         """
         if where is not None:
             (where,) = bind(self, where)
@@ -2554,9 +2562,13 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ baz    │
         └────────┘
         >>> t.count()
-        3
+        ┌───┐
+        │ 3 │
+        └───┘
         >>> t.count(t.a != "foo")
-        2
+        ┌───┐
+        │ 2 │
+        └───┘
         >>> type(t.count())
         <class 'ibis.expr.types.numeric.IntegerScalar'>
         """
@@ -2610,11 +2622,17 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ …       │ …         │              … │             … │                 … │ … │
         └─────────┴───────────┴────────────────┴───────────────┴───────────────────┴───┘
         >>> t.count()
-        344
+        ┌─────┐
+        │ 344 │
+        └─────┘
         >>> t.dropna(["bill_length_mm", "body_mass_g"]).count()
-        342
+        ┌─────┐
+        │ 342 │
+        └─────┘
         >>> t.dropna(how="all").count()  # no rows where all columns are null
-        344
+        ┌─────┐
+        │ 344 │
+        └─────┘
         """
         if subset is not None:
             subset = self.bind(subset)
@@ -3226,7 +3244,9 @@ class Table(Expr, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.count()
-        344
+        ┌─────┐
+        │ 344 │
+        └─────┘
         >>> agg = t.drop("year").agg(s.across(s.numeric(), _.mean()))
         >>> expr = t.cross_join(agg)
         >>> expr
@@ -3261,7 +3281,9 @@ class Table(Expr, _FixedTextJupyterMixin):
          'flipper_length_mm_right',
          'body_mass_g_right']
         >>> expr.count()
-        344
+        ┌─────┐
+        │ 344 │
+        └─────┘
         """
         from ibis.expr.types.joins import Join
 

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -1702,7 +1702,6 @@ class StringValue(Value):
         ┌───┐
         │ 3 │
         └───┘
-
         """
         return ops.Levenshtein(self, other).to_expr()
 

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -1699,7 +1699,10 @@ class StringValue(Value):
         >>> ibis.options.interactive = True
         >>> s = ibis.literal("kitten")
         >>> s.levenshtein("sitting")
-        3
+        ┌───┐
+        │ 3 │
+        └───┘
+
         """
         return ops.Levenshtein(self, other).to_expr()
 

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -52,12 +52,16 @@ def struct(
     >>> import ibis
     >>> ibis.options.interactive = True
     >>> ibis.struct(dict(a=1, b="foo"))
-    {'a': 1, 'b': 'foo'}
+    ┌──────────────────────┐
+    │ {'a': 1, 'b': 'foo'} │
+    └──────────────────────┘
 
     Specify a type (note the 1 is now a `float`):
 
     >>> ibis.struct(dict(a=1, b="foo"), type="struct<a: float, b: string>")
-    {'a': 1.0, 'b': 'foo'}
+    ┌────────────────────────┐
+    │ {'a': 1.0, 'b': 'foo'} │
+    └────────────────────────┘
 
     Create a struct column from a column and a scalar literal
 

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -278,7 +278,9 @@ class TimeValue(_TimeComponentMixin, Value):
         >>> start = ibis.time("01:58:00")
         >>> end = ibis.time("23:59:59")
         >>> end.delta(start, "hour")
-        22
+        ┌────┐
+        │ 22 │
+        └────┘
         >>> data = '''tpep_pickup_datetime,tpep_dropoff_datetime
         ... 2016-02-01T00:23:56,2016-02-01T00:42:28
         ... 2016-02-01T00:12:14,2016-02-01T00:21:41
@@ -443,7 +445,9 @@ class DateValue(Value, _DateComponentMixin):
         >>> start = ibis.date("1992-09-30")
         >>> end = ibis.date("1992-10-01")
         >>> end.delta(start, "day")
-        1
+        ┌───┐
+        │ 1 │
+        └───┘
         >>> prez = ibis.examples.presidential.fetch()
         >>> prez.mutate(
         ...     years_in_office=prez.end.delta(prez.start, "year"),
@@ -775,7 +779,9 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         >>> start = ibis.time("01:58:00")
         >>> end = ibis.time("23:59:59")
         >>> end.delta(start, "hour")
-        22
+        ┌────┐
+        │ 22 │
+        └────┘
         >>> data = '''tpep_pickup_datetime,tpep_dropoff_datetime
         ... 2016-02-01T00:23:56,2016-02-01T00:42:28
         ... 2016-02-01T00:12:14,2016-02-01T00:21:41


### PR DESCRIPTION
This is an attempt to close https://github.com/ibis-project/ibis/issues/9247 and possible the discussion around https://github.com/ibis-project/ibis/issues/8833

I'm using rich Panel and the `box.SQUARE` style to wrap scalar values into a box. There are multiple styles (see https://rich.readthedocs.io/en/stable/appendix/box.html), I chose the one that looks the most similar to what we have now. 

TODO:
- Do we need a tests for this? I wasn't quite sure how to add a test for it. 
- Modify doctests accordingly if we like this change

Closes https://github.com/ibis-project/ibis/issues/9247

Here is how it renders in ipython. 

```python
In [1]: import ibis

In [2]: ibis.options.interactive = True

In [3]: ibis.literal(1).nullif(1)
Out[3]: 
┌──────┐
│ None │
└──────┘

In [4]: ibis.literal(1).nullif(0)
Out[4]: 
┌───┐
│ 1 │
└───┘

In [5]: ibis.literal("abcdefghi").substr(3)
Out[5]: 
┌──────────┐
│ 'defghi' │
└──────────┘

In [6]: print(ibis.literal("abcdefghi").substr(3))
┌──────────┐
│ 'defghi' │
└──────────┘

In [7]: print(ibis.literal(True))
┌──────┐
│ True │
└──────┘

In [8]: import datetime

In [9]: date = datetime.datetime(2015, 1, 1, 12, 34, 56)

In [10]: print(ibis.literal(date))
┌──────────────────────────────────┐
│ Timestamp('2015-01-01 12:34:56') │
└──────────────────────────────────┘


```

