### PR TITLE
ci: run one nix job on arm64 runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-arm64-small

--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -36,5 +36,8 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+        include:
+          - os: ubuntu-arm64-small
+            python-version: "3.12"
     steps:
       - run: echo "No build required"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,6 +37,9 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+        include:
+          - os: ubuntu-arm64-small
+            python-version: "3.12"
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Testing out the new GitHub-hosted arm64 runners with a single nix job.