### PR TITLE
test(datafusion): run tpch correctness tests

### DIFF
--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -16,8 +16,11 @@ class TestConf(BackendTest):
     supports_structs = False
     supports_json = False
     supports_arrays = True
+    supports_tpch = True
     stateful = False
     deps = ("datafusion",)
+    # Query 1 seems to require a bit more room here
+    tpch_absolute_tolerance = 0.11
 
     def _load_data(self, **_: Any) -> None:
         con = self.connection
@@ -34,6 +37,14 @@ class TestConf(BackendTest):
     @staticmethod
     def connect(*, tmpdir, worker_id, **kw):
         return ibis.datafusion.connect(**kw)
+
+    def load_tpch(self) -> None:
+        con = self.connection
+        for path in self.data_dir.joinpath("tpch", "sf=0.17", "parquet").glob(
+            "*.parquet"
+        ):
+            table_name = path.with_suffix("").name
+            con.read_parquet(path, table_name=table_name)
 
 
 @pytest.fixture(scope="session")

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -57,6 +57,8 @@ class BackendTest(abc.ABC):
     "Name of round method to use for rounding test comparisons."
     driver_supports_multiple_statements: bool = False
     "Whether the driver supports executing multiple statements in a single call."
+    tpch_absolute_tolerance: float | None = None
+    "Absolute tolerance for floating point comparisons with pytest.approx in TPC-H correctness tests."
 
     @property
     @abc.abstractmethod

--- a/ibis/backends/tests/tpch/conftest.py
+++ b/ibis/backends/tests/tpch/conftest.py
@@ -92,7 +92,11 @@ def tpch_test(test: Callable[..., ir.Table]):
             left = result.loc[:, column]
             right = expected.loc[:, column]
             assert (
-                pytest.approx(left.values.tolist(), nan_ok=True)
+                pytest.approx(
+                    left.values.tolist(),
+                    nan_ok=True,
+                    abs=backend.tpch_absolute_tolerance,
+                )
                 == right.values.tolist()
             )
 

--- a/ibis/backends/tests/tpch/snapshots/test_h01/test_tpc_h01/datafusion/h01.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h01/test_tpc_h01/datafusion/h01.sql
@@ -1,0 +1,57 @@
+SELECT
+  *
+FROM (
+  SELECT
+    "t1"."l_returnflag",
+    "t1"."l_linestatus",
+    SUM("t1"."l_quantity") AS "sum_qty",
+    SUM("t1"."l_extendedprice") AS "sum_base_price",
+    SUM("t1"."l_extendedprice" * (
+      1 - "t1"."l_discount"
+    )) AS "sum_disc_price",
+    SUM(
+      (
+        "t1"."l_extendedprice" * (
+          1 - "t1"."l_discount"
+        )
+      ) * (
+        "t1"."l_tax" + 1
+      )
+    ) AS "sum_charge",
+    AVG("t1"."l_quantity") AS "avg_qty",
+    AVG("t1"."l_extendedprice") AS "avg_price",
+    AVG("t1"."l_discount") AS "avg_disc",
+    COUNT(*) AS "count_order"
+  FROM (
+    SELECT
+      "t1"."l_orderkey",
+      "t1"."l_partkey",
+      "t1"."l_suppkey",
+      "t1"."l_linenumber",
+      "t1"."l_quantity",
+      "t1"."l_extendedprice",
+      "t1"."l_discount",
+      "t1"."l_tax",
+      "t1"."l_shipdate",
+      "t1"."l_commitdate",
+      "t1"."l_receiptdate",
+      "t1"."l_shipinstruct",
+      "t1"."l_shipmode",
+      "t1"."l_comment",
+      "t1"."l_returnflag",
+      "t1"."l_linestatus"
+    FROM (
+      SELECT
+        *
+      FROM "lineitem" AS "t0"
+      WHERE
+        "t0"."l_shipdate" <= DATE_TRUNC('DAY', '1998-09-02')
+    ) AS "t1"
+  ) AS t1
+  GROUP BY
+    "t1"."l_returnflag",
+    "t1"."l_linestatus"
+) AS "t2"
+ORDER BY
+  "t2"."l_returnflag" ASC,
+  "t2"."l_linestatus" ASC

--- a/ibis/backends/tests/tpch/snapshots/test_h02/test_tpc_h02/datafusion/h02.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h02/test_tpc_h02/datafusion/h02.sql
@@ -1,0 +1,98 @@
+SELECT
+  "t14"."s_acctbal",
+  "t14"."s_name",
+  "t14"."n_name",
+  "t14"."p_partkey",
+  "t14"."p_mfgr",
+  "t14"."s_address",
+  "t14"."s_phone",
+  "t14"."s_comment"
+FROM (
+  SELECT
+    "t5"."p_partkey",
+    "t5"."p_name",
+    "t5"."p_mfgr",
+    "t5"."p_brand",
+    "t5"."p_type",
+    "t5"."p_size",
+    "t5"."p_container",
+    "t5"."p_retailprice",
+    "t5"."p_comment",
+    "t6"."ps_partkey",
+    "t6"."ps_suppkey",
+    "t6"."ps_availqty",
+    "t6"."ps_supplycost",
+    "t6"."ps_comment",
+    "t8"."s_suppkey",
+    "t8"."s_name",
+    "t8"."s_address",
+    "t8"."s_nationkey",
+    "t8"."s_phone",
+    "t8"."s_acctbal",
+    "t8"."s_comment",
+    "t10"."n_nationkey",
+    "t10"."n_name",
+    "t10"."n_regionkey",
+    "t10"."n_comment",
+    "t12"."r_regionkey",
+    "t12"."r_name",
+    "t12"."r_comment"
+  FROM "part" AS "t5"
+  INNER JOIN "partsupp" AS "t6"
+    ON "t5"."p_partkey" = "t6"."ps_partkey"
+  INNER JOIN "supplier" AS "t8"
+    ON "t8"."s_suppkey" = "t6"."ps_suppkey"
+  INNER JOIN "nation" AS "t10"
+    ON "t8"."s_nationkey" = "t10"."n_nationkey"
+  INNER JOIN "region" AS "t12"
+    ON "t10"."n_regionkey" = "t12"."r_regionkey"
+) AS "t14"
+WHERE
+  "t14"."p_size" = 15
+  AND "t14"."p_type" LIKE '%BRASS'
+  AND "t14"."r_name" = 'EUROPE'
+  AND "t14"."ps_supplycost" = (
+    SELECT
+      MIN("t16"."ps_supplycost") AS "Min(ps_supplycost)"
+    FROM (
+      SELECT
+        *
+      FROM (
+        SELECT
+          "t7"."ps_partkey",
+          "t7"."ps_suppkey",
+          "t7"."ps_availqty",
+          "t7"."ps_supplycost",
+          "t7"."ps_comment",
+          "t9"."s_suppkey",
+          "t9"."s_name",
+          "t9"."s_address",
+          "t9"."s_nationkey",
+          "t9"."s_phone",
+          "t9"."s_acctbal",
+          "t9"."s_comment",
+          "t11"."n_nationkey",
+          "t11"."n_name",
+          "t11"."n_regionkey",
+          "t11"."n_comment",
+          "t13"."r_regionkey",
+          "t13"."r_name",
+          "t13"."r_comment"
+        FROM "partsupp" AS "t7"
+        INNER JOIN "supplier" AS "t9"
+          ON "t9"."s_suppkey" = "t7"."ps_suppkey"
+        INNER JOIN "nation" AS "t11"
+          ON "t9"."s_nationkey" = "t11"."n_nationkey"
+        INNER JOIN "region" AS "t13"
+          ON "t11"."n_regionkey" = "t13"."r_regionkey"
+      ) AS "t15"
+      WHERE
+        "t15"."r_name" = 'EUROPE' AND "t14"."p_partkey" = "t15"."ps_partkey"
+    ) AS "t16"
+  )
+ORDER BY
+  "t14"."s_acctbal" DESC NULLS LAST,
+  "t14"."n_name" ASC,
+  "t14"."s_name" ASC,
+  "t14"."p_partkey" ASC
+LIMIT 100

--- a/ibis/backends/tests/tpch/snapshots/test_h03/test_tpc_h03/datafusion/h03.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h03/test_tpc_h03/datafusion/h03.sql
@@ -1,0 +1,107 @@
+SELECT
+  "t8"."l_orderkey",
+  "t8"."revenue",
+  "t8"."o_orderdate",
+  "t8"."o_shippriority"
+FROM (
+  SELECT
+    "t7"."l_orderkey",
+    "t7"."o_orderdate",
+    "t7"."o_shippriority",
+    SUM("t7"."l_extendedprice" * (
+      1 - "t7"."l_discount"
+    )) AS "revenue"
+  FROM (
+    SELECT
+      "t7"."c_custkey",
+      "t7"."c_name",
+      "t7"."c_address",
+      "t7"."c_nationkey",
+      "t7"."c_phone",
+      "t7"."c_acctbal",
+      "t7"."c_mktsegment",
+      "t7"."c_comment",
+      "t7"."o_orderkey",
+      "t7"."o_custkey",
+      "t7"."o_orderstatus",
+      "t7"."o_totalprice",
+      "t7"."o_orderpriority",
+      "t7"."o_clerk",
+      "t7"."o_comment",
+      "t7"."l_partkey",
+      "t7"."l_suppkey",
+      "t7"."l_linenumber",
+      "t7"."l_quantity",
+      "t7"."l_extendedprice",
+      "t7"."l_discount",
+      "t7"."l_tax",
+      "t7"."l_returnflag",
+      "t7"."l_linestatus",
+      "t7"."l_shipdate",
+      "t7"."l_commitdate",
+      "t7"."l_receiptdate",
+      "t7"."l_shipinstruct",
+      "t7"."l_shipmode",
+      "t7"."l_comment",
+      "t7"."l_orderkey",
+      "t7"."o_orderdate",
+      "t7"."o_shippriority"
+    FROM (
+      SELECT
+        *
+      FROM (
+        SELECT
+          "t3"."c_custkey",
+          "t3"."c_name",
+          "t3"."c_address",
+          "t3"."c_nationkey",
+          "t3"."c_phone",
+          "t3"."c_acctbal",
+          "t3"."c_mktsegment",
+          "t3"."c_comment",
+          "t4"."o_orderkey",
+          "t4"."o_custkey",
+          "t4"."o_orderstatus",
+          "t4"."o_totalprice",
+          "t4"."o_orderdate",
+          "t4"."o_orderpriority",
+          "t4"."o_clerk",
+          "t4"."o_shippriority",
+          "t4"."o_comment",
+          "t5"."l_orderkey",
+          "t5"."l_partkey",
+          "t5"."l_suppkey",
+          "t5"."l_linenumber",
+          "t5"."l_quantity",
+          "t5"."l_extendedprice",
+          "t5"."l_discount",
+          "t5"."l_tax",
+          "t5"."l_returnflag",
+          "t5"."l_linestatus",
+          "t5"."l_shipdate",
+          "t5"."l_commitdate",
+          "t5"."l_receiptdate",
+          "t5"."l_shipinstruct",
+          "t5"."l_shipmode",
+          "t5"."l_comment"
+        FROM "customer" AS "t3"
+        INNER JOIN "orders" AS "t4"
+          ON "t3"."c_custkey" = "t4"."o_custkey"
+        INNER JOIN "lineitem" AS "t5"
+          ON "t5"."l_orderkey" = "t4"."o_orderkey"
+      ) AS "t6"
+      WHERE
+        "t6"."c_mktsegment" = 'BUILDING'
+        AND "t6"."o_orderdate" < DATE_TRUNC('DAY', '1995-03-15')
+        AND "t6"."l_shipdate" > DATE_TRUNC('DAY', '1995-03-15')
+    ) AS "t7"
+  ) AS t7
+  GROUP BY
+    "t7"."l_orderkey",
+    "t7"."o_orderdate",
+    "t7"."o_shippriority"
+) AS "t8"
+ORDER BY
+  "t8"."revenue" DESC NULLS LAST,
+  "t8"."o_orderdate" ASC
+LIMIT 10

--- a/ibis/backends/tests/tpch/snapshots/test_h04/test_tpc_h04/datafusion/h04.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h04/test_tpc_h04/datafusion/h04.sql
@@ -1,0 +1,43 @@
+SELECT
+  *
+FROM (
+  SELECT
+    "t3"."o_orderpriority",
+    COUNT(*) AS "order_count"
+  FROM (
+    SELECT
+      "t3"."o_orderkey",
+      "t3"."o_custkey",
+      "t3"."o_orderstatus",
+      "t3"."o_totalprice",
+      "t3"."o_orderdate",
+      "t3"."o_clerk",
+      "t3"."o_shippriority",
+      "t3"."o_comment",
+      "t3"."o_orderpriority"
+    FROM (
+      SELECT
+        *
+      FROM "orders" AS "t0"
+      WHERE
+        EXISTS(
+          SELECT
+            1
+          FROM "lineitem" AS "t1"
+          WHERE
+            (
+              "t1"."l_orderkey" = "t0"."o_orderkey"
+            )
+            AND (
+              "t1"."l_commitdate" < "t1"."l_receiptdate"
+            )
+        )
+        AND "t0"."o_orderdate" >= DATE_TRUNC('DAY', '1993-07-01')
+        AND "t0"."o_orderdate" < DATE_TRUNC('DAY', '1993-10-01')
+    ) AS "t3"
+  ) AS t3
+  GROUP BY
+    "t3"."o_orderpriority"
+) AS "t4"
+ORDER BY
+  "t4"."o_orderpriority" ASC

--- a/ibis/backends/tests/tpch/snapshots/test_h05/test_tpc_h05/datafusion/h05.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h05/test_tpc_h05/datafusion/h05.sql
@@ -1,0 +1,133 @@
+SELECT
+  *
+FROM (
+  SELECT
+    "t13"."n_name",
+    SUM("t13"."l_extendedprice" * (
+      1 - "t13"."l_discount"
+    )) AS "revenue"
+  FROM (
+    SELECT
+      "t13"."c_custkey",
+      "t13"."c_name",
+      "t13"."c_address",
+      "t13"."c_nationkey",
+      "t13"."c_phone",
+      "t13"."c_acctbal",
+      "t13"."c_mktsegment",
+      "t13"."c_comment",
+      "t13"."o_orderkey",
+      "t13"."o_custkey",
+      "t13"."o_orderstatus",
+      "t13"."o_totalprice",
+      "t13"."o_orderdate",
+      "t13"."o_orderpriority",
+      "t13"."o_clerk",
+      "t13"."o_shippriority",
+      "t13"."o_comment",
+      "t13"."l_orderkey",
+      "t13"."l_partkey",
+      "t13"."l_suppkey",
+      "t13"."l_linenumber",
+      "t13"."l_quantity",
+      "t13"."l_extendedprice",
+      "t13"."l_discount",
+      "t13"."l_tax",
+      "t13"."l_returnflag",
+      "t13"."l_linestatus",
+      "t13"."l_shipdate",
+      "t13"."l_commitdate",
+      "t13"."l_receiptdate",
+      "t13"."l_shipinstruct",
+      "t13"."l_shipmode",
+      "t13"."l_comment",
+      "t13"."s_suppkey",
+      "t13"."s_name",
+      "t13"."s_address",
+      "t13"."s_nationkey",
+      "t13"."s_phone",
+      "t13"."s_acctbal",
+      "t13"."s_comment",
+      "t13"."n_nationkey",
+      "t13"."n_regionkey",
+      "t13"."n_comment",
+      "t13"."r_regionkey",
+      "t13"."r_name",
+      "t13"."r_comment",
+      "t13"."n_name"
+    FROM (
+      SELECT
+        *
+      FROM (
+        SELECT
+          "t6"."c_custkey",
+          "t6"."c_name",
+          "t6"."c_address",
+          "t6"."c_nationkey",
+          "t6"."c_phone",
+          "t6"."c_acctbal",
+          "t6"."c_mktsegment",
+          "t6"."c_comment",
+          "t7"."o_orderkey",
+          "t7"."o_custkey",
+          "t7"."o_orderstatus",
+          "t7"."o_totalprice",
+          "t7"."o_orderdate",
+          "t7"."o_orderpriority",
+          "t7"."o_clerk",
+          "t7"."o_shippriority",
+          "t7"."o_comment",
+          "t8"."l_orderkey",
+          "t8"."l_partkey",
+          "t8"."l_suppkey",
+          "t8"."l_linenumber",
+          "t8"."l_quantity",
+          "t8"."l_extendedprice",
+          "t8"."l_discount",
+          "t8"."l_tax",
+          "t8"."l_returnflag",
+          "t8"."l_linestatus",
+          "t8"."l_shipdate",
+          "t8"."l_commitdate",
+          "t8"."l_receiptdate",
+          "t8"."l_shipinstruct",
+          "t8"."l_shipmode",
+          "t8"."l_comment",
+          "t9"."s_suppkey",
+          "t9"."s_name",
+          "t9"."s_address",
+          "t9"."s_nationkey",
+          "t9"."s_phone",
+          "t9"."s_acctbal",
+          "t9"."s_comment",
+          "t10"."n_nationkey",
+          "t10"."n_name",
+          "t10"."n_regionkey",
+          "t10"."n_comment",
+          "t11"."r_regionkey",
+          "t11"."r_name",
+          "t11"."r_comment"
+        FROM "customer" AS "t6"
+        INNER JOIN "orders" AS "t7"
+          ON "t6"."c_custkey" = "t7"."o_custkey"
+        INNER JOIN "lineitem" AS "t8"
+          ON "t8"."l_orderkey" = "t7"."o_orderkey"
+        INNER JOIN "supplier" AS "t9"
+          ON "t8"."l_suppkey" = "t9"."s_suppkey"
+        INNER JOIN "nation" AS "t10"
+          ON "t6"."c_nationkey" = "t9"."s_nationkey"
+          AND "t9"."s_nationkey" = "t10"."n_nationkey"
+        INNER JOIN "region" AS "t11"
+          ON "t10"."n_regionkey" = "t11"."r_regionkey"
+      ) AS "t12"
+      WHERE
+        "t12"."r_name" = 'ASIA'
+        AND "t12"."o_orderdate" >= DATE_TRUNC('DAY', '1994-01-01')
+        AND "t12"."o_orderdate" < DATE_TRUNC('DAY', '1995-01-01')
+    ) AS "t13"
+  ) AS t13
+  GROUP BY
+    "t13"."n_name"
+) AS "t14"
+ORDER BY
+  "t14"."revenue" DESC NULLS LAST

--- a/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/datafusion/h06.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h06/test_tpc_h06/datafusion/h06.sql
@@ -1,0 +1,12 @@
+SELECT
+  SUM("t1"."l_extendedprice" * "t1"."l_discount") AS "revenue"
+FROM (
+  SELECT
+    *
+  FROM "lineitem" AS "t0"
+  WHERE
+    "t0"."l_shipdate" >= DATE_TRUNC('DAY', '1994-01-01')
+    AND "t0"."l_shipdate" < DATE_TRUNC('DAY', '1995-01-01')
+    AND "t0"."l_discount" BETWEEN 0.05 AND 0.07
+    AND "t0"."l_quantity" < 24
+) AS "t1"

--- a/ibis/backends/tests/tpch/snapshots/test_h07/test_tpc_h07/datafusion/h07.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h07/test_tpc_h07/datafusion/h07.sql
@@ -1,0 +1,72 @@
+SELECT
+  *
+FROM (
+  SELECT
+    "t12"."supp_nation",
+    "t12"."cust_nation",
+    "t12"."l_year",
+    SUM("t12"."volume") AS "revenue"
+  FROM (
+    SELECT
+      "t12"."l_shipdate",
+      "t12"."l_extendedprice",
+      "t12"."l_discount",
+      "t12"."volume",
+      "t12"."supp_nation",
+      "t12"."cust_nation",
+      "t12"."l_year"
+    FROM (
+      SELECT
+        *
+      FROM (
+        SELECT
+          "t9"."n_name" AS "supp_nation",
+          "t10"."n_name" AS "cust_nation",
+          "t6"."l_shipdate",
+          "t6"."l_extendedprice",
+          "t6"."l_discount",
+          DATE_PART('year', "t6"."l_shipdate") AS "l_year",
+          "t6"."l_extendedprice" * (
+            1 - "t6"."l_discount"
+          ) AS "volume"
+        FROM "supplier" AS "t5"
+        INNER JOIN "lineitem" AS "t6"
+          ON "t5"."s_suppkey" = "t6"."l_suppkey"
+        INNER JOIN "orders" AS "t7"
+          ON "t7"."o_orderkey" = "t6"."l_orderkey"
+        INNER JOIN "customer" AS "t8"
+          ON "t8"."c_custkey" = "t7"."o_custkey"
+        INNER JOIN "nation" AS "t9"
+          ON "t5"."s_nationkey" = "t9"."n_nationkey"
+        INNER JOIN "nation" AS "t10"
+          ON "t8"."c_nationkey" = "t10"."n_nationkey"
+      ) AS "t11"
+      WHERE
+        (
+          (
+            (
+              "t11"."cust_nation" = 'FRANCE'
+            ) AND (
+              "t11"."supp_nation" = 'GERMANY'
+            )
+          )
+          OR (
+            (
+              "t11"."cust_nation" = 'GERMANY'
+            ) AND (
+              "t11"."supp_nation" = 'FRANCE'
+            )
+          )
+        )
+        AND "t11"."l_shipdate" BETWEEN DATE_TRUNC('DAY', '1995-01-01') AND DATE_TRUNC('DAY', '1996-12-31')
+    ) AS "t12"
+  ) AS t12
+  GROUP BY
+    "t12"."supp_nation",
+    "t12"."cust_nation",
+    "t12"."l_year"
+) AS "t13"
+ORDER BY
+  "t13"."supp_nation" ASC,
+  "t13"."cust_nation" ASC,
+  "t13"."l_year" ASC

--- a/ibis/backends/tests/tpch/snapshots/test_h08/test_tpc_h08/datafusion/h08.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h08/test_tpc_h08/datafusion/h08.sql
@@ -1,0 +1,61 @@
+SELECT
+  *
+FROM (
+  SELECT
+    "t16"."o_year",
+    CAST(SUM("t16"."nation_volume") AS DOUBLE PRECISION) / SUM("t16"."volume") AS "mkt_share"
+  FROM (
+    SELECT
+      "t16"."volume",
+      "t16"."nation",
+      "t16"."r_name",
+      "t16"."o_orderdate",
+      "t16"."p_type",
+      "t16"."nation_volume",
+      "t16"."o_year"
+    FROM (
+      SELECT
+        "t15"."o_year",
+        "t15"."volume",
+        "t15"."nation",
+        "t15"."r_name",
+        "t15"."o_orderdate",
+        "t15"."p_type",
+        CASE WHEN "t15"."nation" = 'BRAZIL' THEN "t15"."volume" ELSE 0 END AS "nation_volume"
+      FROM (
+        SELECT
+          DATE_PART('year', "t10"."o_orderdate") AS "o_year",
+          "t8"."l_extendedprice" * (
+            1 - "t8"."l_discount"
+          ) AS "volume",
+          "t13"."n_name" AS "nation",
+          "t14"."r_name",
+          "t10"."o_orderdate",
+          "t7"."p_type"
+        FROM "part" AS "t7"
+        INNER JOIN "lineitem" AS "t8"
+          ON "t7"."p_partkey" = "t8"."l_partkey"
+        INNER JOIN "supplier" AS "t9"
+          ON "t9"."s_suppkey" = "t8"."l_suppkey"
+        INNER JOIN "orders" AS "t10"
+          ON "t8"."l_orderkey" = "t10"."o_orderkey"
+        INNER JOIN "customer" AS "t11"
+          ON "t10"."o_custkey" = "t11"."c_custkey"
+        INNER JOIN "nation" AS "t12"
+          ON "t11"."c_nationkey" = "t12"."n_nationkey"
+        INNER JOIN "region" AS "t14"
+          ON "t12"."n_regionkey" = "t14"."r_regionkey"
+        INNER JOIN "nation" AS "t13"
+          ON "t9"."s_nationkey" = "t13"."n_nationkey"
+      ) AS "t15"
+      WHERE
+        "t15"."r_name" = 'AMERICA'
+        AND "t15"."o_orderdate" BETWEEN DATE_TRUNC('DAY', '1995-01-01') AND DATE_TRUNC('DAY', '1996-12-31')
+        AND "t15"."p_type" = 'ECONOMY ANODIZED STEEL'
+    ) AS "t16"
+  ) AS t16
+  GROUP BY
+    "t16"."o_year"
+) AS "t17"
+ORDER BY
+  "t17"."o_year" ASC

--- a/ibis/backends/tests/tpch/snapshots/test_h09/test_tpc_h09/datafusion/h09.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h09/test_tpc_h09/datafusion/h09.sql
@@ -1,0 +1,51 @@
+SELECT
+  *
+FROM (
+  SELECT
+    "t13"."nation",
+    "t13"."o_year",
+    SUM("t13"."amount") AS "sum_profit"
+  FROM (
+    SELECT
+      "t13"."amount",
+      "t13"."p_name",
+      "t13"."nation",
+      "t13"."o_year"
+    FROM (
+      SELECT
+        *
+      FROM (
+        SELECT
+          (
+            "t6"."l_extendedprice" * (
+              1 - "t6"."l_discount"
+            )
+          ) - (
+            "t8"."ps_supplycost" * "t6"."l_quantity"
+          ) AS "amount",
+          DATE_PART('year', "t10"."o_orderdate") AS "o_year",
+          "t11"."n_name" AS "nation",
+          "t9"."p_name"
+        FROM "lineitem" AS "t6"
+        INNER JOIN "supplier" AS "t7"
+          ON "t7"."s_suppkey" = "t6"."l_suppkey"
+        INNER JOIN "partsupp" AS "t8"
+          ON "t8"."ps_suppkey" = "t6"."l_suppkey" AND "t8"."ps_partkey" = "t6"."l_partkey"
+        INNER JOIN "part" AS "t9"
+          ON "t9"."p_partkey" = "t6"."l_partkey"
+        INNER JOIN "orders" AS "t10"
+          ON "t10"."o_orderkey" = "t6"."l_orderkey"
+        INNER JOIN "nation" AS "t11"
+          ON "t7"."s_nationkey" = "t11"."n_nationkey"
+      ) AS "t12"
+      WHERE
+        "t12"."p_name" LIKE '%green%'
+    ) AS "t13"
+  ) AS t13
+  GROUP BY
+    "t13"."nation",
+    "t13"."o_year"
+) AS "t14"
+ORDER BY
+  "t14"."nation" ASC,
+  "t14"."o_year" DESC NULLS LAST

--- a/ibis/backends/tests/tpch/snapshots/test_h10/test_tpc_h10/datafusion/h10.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h10/test_tpc_h10/datafusion/h10.sql
@@ -1,0 +1,128 @@
+SELECT
+  "t10"."c_custkey",
+  "t10"."c_name",
+  "t10"."revenue",
+  "t10"."c_acctbal",
+  "t10"."n_name",
+  "t10"."c_address",
+  "t10"."c_phone",
+  "t10"."c_comment"
+FROM (
+  SELECT
+    "t9"."c_custkey",
+    "t9"."c_name",
+    "t9"."c_acctbal",
+    "t9"."n_name",
+    "t9"."c_address",
+    "t9"."c_phone",
+    "t9"."c_comment",
+    SUM("t9"."l_extendedprice" * (
+      1 - "t9"."l_discount"
+    )) AS "revenue"
+  FROM (
+    SELECT
+      "t9"."c_nationkey",
+      "t9"."c_mktsegment",
+      "t9"."o_orderkey",
+      "t9"."o_custkey",
+      "t9"."o_orderstatus",
+      "t9"."o_totalprice",
+      "t9"."o_orderdate",
+      "t9"."o_orderpriority",
+      "t9"."o_clerk",
+      "t9"."o_shippriority",
+      "t9"."o_comment",
+      "t9"."l_orderkey",
+      "t9"."l_partkey",
+      "t9"."l_suppkey",
+      "t9"."l_linenumber",
+      "t9"."l_quantity",
+      "t9"."l_extendedprice",
+      "t9"."l_discount",
+      "t9"."l_tax",
+      "t9"."l_returnflag",
+      "t9"."l_linestatus",
+      "t9"."l_shipdate",
+      "t9"."l_commitdate",
+      "t9"."l_receiptdate",
+      "t9"."l_shipinstruct",
+      "t9"."l_shipmode",
+      "t9"."l_comment",
+      "t9"."n_nationkey",
+      "t9"."n_regionkey",
+      "t9"."n_comment",
+      "t9"."c_custkey",
+      "t9"."c_name",
+      "t9"."c_acctbal",
+      "t9"."n_name",
+      "t9"."c_address",
+      "t9"."c_phone",
+      "t9"."c_comment"
+    FROM (
+      SELECT
+        *
+      FROM (
+        SELECT
+          "t4"."c_custkey",
+          "t4"."c_name",
+          "t4"."c_address",
+          "t4"."c_nationkey",
+          "t4"."c_phone",
+          "t4"."c_acctbal",
+          "t4"."c_mktsegment",
+          "t4"."c_comment",
+          "t5"."o_orderkey",
+          "t5"."o_custkey",
+          "t5"."o_orderstatus",
+          "t5"."o_totalprice",
+          "t5"."o_orderdate",
+          "t5"."o_orderpriority",
+          "t5"."o_clerk",
+          "t5"."o_shippriority",
+          "t5"."o_comment",
+          "t6"."l_orderkey",
+          "t6"."l_partkey",
+          "t6"."l_suppkey",
+          "t6"."l_linenumber",
+          "t6"."l_quantity",
+          "t6"."l_extendedprice",
+          "t6"."l_discount",
+          "t6"."l_tax",
+          "t6"."l_returnflag",
+          "t6"."l_linestatus",
+          "t6"."l_shipdate",
+          "t6"."l_commitdate",
+          "t6"."l_receiptdate",
+          "t6"."l_shipinstruct",
+          "t6"."l_shipmode",
+          "t6"."l_comment",
+          "t7"."n_nationkey",
+          "t7"."n_name",
+          "t7"."n_regionkey",
+          "t7"."n_comment"
+        FROM "customer" AS "t4"
+        INNER JOIN "orders" AS "t5"
+          ON "t4"."c_custkey" = "t5"."o_custkey"
+        INNER JOIN "lineitem" AS "t6"
+          ON "t6"."l_orderkey" = "t5"."o_orderkey"
+        INNER JOIN "nation" AS "t7"
+          ON "t4"."c_nationkey" = "t7"."n_nationkey"
+      ) AS "t8"
+      WHERE
+        "t8"."o_orderdate" >= DATE_TRUNC('DAY', '1993-10-01')
+        AND "t8"."o_orderdate" < DATE_TRUNC('DAY', '1994-01-01')
+        AND "t8"."l_returnflag" = 'R'
+    ) AS "t9"
+  ) AS t9
+  GROUP BY
+    "t9"."c_custkey",
+    "t9"."c_name",
+    "t9"."c_acctbal",
+    "t9"."n_name",
+    "t9"."c_address",
+    "t9"."c_phone",
+    "t9"."c_comment"
+) AS "t10"
+ORDER BY
+  "t10"."revenue" DESC NULLS LAST
+LIMIT 20

--- a/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/datafusion/h11.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h11/test_tpc_h11/datafusion/h11.sql
@@ -1,0 +1,69 @@
+WITH "t7" AS (
+  SELECT
+    *
+  FROM (
+    SELECT
+      "t3"."ps_partkey",
+      "t3"."ps_suppkey",
+      "t3"."ps_availqty",
+      "t3"."ps_supplycost",
+      "t3"."ps_comment",
+      "t4"."s_suppkey",
+      "t4"."s_name",
+      "t4"."s_address",
+      "t4"."s_nationkey",
+      "t4"."s_phone",
+      "t4"."s_acctbal",
+      "t4"."s_comment",
+      "t5"."n_nationkey",
+      "t5"."n_name",
+      "t5"."n_regionkey",
+      "t5"."n_comment"
+    FROM "partsupp" AS "t3"
+    INNER JOIN "supplier" AS "t4"
+      ON "t3"."ps_suppkey" = "t4"."s_suppkey"
+    INNER JOIN "nation" AS "t5"
+      ON "t5"."n_nationkey" = "t4"."s_nationkey"
+  ) AS "t6"
+  WHERE
+    "t6"."n_name" = 'GERMANY'
+)
+SELECT
+  *
+FROM (
+  SELECT
+    "t8"."ps_partkey",
+    SUM("t8"."ps_supplycost" * "t8"."ps_availqty") AS "value"
+  FROM (
+    SELECT
+      "t8"."ps_suppkey",
+      "t8"."ps_availqty",
+      "t8"."ps_supplycost",
+      "t8"."ps_comment",
+      "t8"."s_suppkey",
+      "t8"."s_name",
+      "t8"."s_address",
+      "t8"."s_nationkey",
+      "t8"."s_phone",
+      "t8"."s_acctbal",
+      "t8"."s_comment",
+      "t8"."n_nationkey",
+      "t8"."n_name",
+      "t8"."n_regionkey",
+      "t8"."n_comment",
+      "t8"."ps_partkey"
+    FROM "t7" AS "t8"
+  ) AS t8
+  GROUP BY
+    "t8"."ps_partkey"
+) AS "t9"
+WHERE
+  "t9"."value" > (
+    (
+      SELECT
+        SUM("t8"."ps_supplycost" * "t8"."ps_availqty") AS "Sum(Multiply(ps_supplycost, ps_availqty))"
+      FROM "t7" AS "t8"
+    ) * 0.0001
+  )
+ORDER BY
+  "t9"."value" DESC NULLS LAST

--- a/ibis/backends/tests/tpch/snapshots/test_h12/test_tpc_h12/datafusion/h12.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h12/test_tpc_h12/datafusion/h12.sql
@@ -1,0 +1,85 @@
+SELECT
+  *
+FROM (
+  SELECT
+    "t5"."l_shipmode",
+    SUM(
+      CASE "t5"."o_orderpriority" WHEN '1-URGENT' THEN 1 WHEN '2-HIGH' THEN 1 ELSE 0 END
+    ) AS "high_line_count",
+    SUM(
+      CASE "t5"."o_orderpriority" WHEN '1-URGENT' THEN 0 WHEN '2-HIGH' THEN 0 ELSE 1 END
+    ) AS "low_line_count"
+  FROM (
+    SELECT
+      "t5"."o_orderkey",
+      "t5"."o_custkey",
+      "t5"."o_orderstatus",
+      "t5"."o_totalprice",
+      "t5"."o_orderdate",
+      "t5"."o_orderpriority",
+      "t5"."o_clerk",
+      "t5"."o_shippriority",
+      "t5"."o_comment",
+      "t5"."l_orderkey",
+      "t5"."l_partkey",
+      "t5"."l_suppkey",
+      "t5"."l_linenumber",
+      "t5"."l_quantity",
+      "t5"."l_extendedprice",
+      "t5"."l_discount",
+      "t5"."l_tax",
+      "t5"."l_returnflag",
+      "t5"."l_linestatus",
+      "t5"."l_shipdate",
+      "t5"."l_commitdate",
+      "t5"."l_receiptdate",
+      "t5"."l_shipinstruct",
+      "t5"."l_comment",
+      "t5"."l_shipmode"
+    FROM (
+      SELECT
+        *
+      FROM (
+        SELECT
+          "t2"."o_orderkey",
+          "t2"."o_custkey",
+          "t2"."o_orderstatus",
+          "t2"."o_totalprice",
+          "t2"."o_orderdate",
+          "t2"."o_orderpriority",
+          "t2"."o_clerk",
+          "t2"."o_shippriority",
+          "t2"."o_comment",
+          "t3"."l_orderkey",
+          "t3"."l_partkey",
+          "t3"."l_suppkey",
+          "t3"."l_linenumber",
+          "t3"."l_quantity",
+          "t3"."l_extendedprice",
+          "t3"."l_discount",
+          "t3"."l_tax",
+          "t3"."l_returnflag",
+          "t3"."l_linestatus",
+          "t3"."l_shipdate",
+          "t3"."l_commitdate",
+          "t3"."l_receiptdate",
+          "t3"."l_shipinstruct",
+          "t3"."l_shipmode",
+          "t3"."l_comment"
+        FROM "orders" AS "t2"
+        INNER JOIN "lineitem" AS "t3"
+          ON "t2"."o_orderkey" = "t3"."l_orderkey"
+      ) AS "t4"
+      WHERE
+        "t4"."l_shipmode" IN ('MAIL', 'SHIP')
+        AND "t4"."l_commitdate" < "t4"."l_receiptdate"
+        AND "t4"."l_shipdate" < "t4"."l_commitdate"
+        AND "t4"."l_receiptdate" >= DATE_TRUNC('DAY', '1994-01-01')
+        AND "t4"."l_receiptdate" < DATE_TRUNC('DAY', '1995-01-01')
+    ) AS "t5"
+  ) AS t5
+  GROUP BY
+    "t5"."l_shipmode"
+) AS "t6"
+ORDER BY
+  "t6"."l_shipmode" ASC

--- a/ibis/backends/tests/tpch/snapshots/test_h13/test_tpc_h13/datafusion/h13.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h13/test_tpc_h13/datafusion/h13.sql
@@ -1,0 +1,70 @@
+SELECT
+  *
+FROM (
+  SELECT
+    "t5"."c_count",
+    COUNT(*) AS "custdist"
+  FROM (
+    SELECT
+      "t5"."c_custkey",
+      "t5"."c_count"
+    FROM (
+      SELECT
+        "t4"."c_custkey",
+        COUNT("t4"."o_orderkey") AS "c_count"
+      FROM (
+        SELECT
+          "t4"."c_name",
+          "t4"."c_address",
+          "t4"."c_nationkey",
+          "t4"."c_phone",
+          "t4"."c_acctbal",
+          "t4"."c_mktsegment",
+          "t4"."c_comment",
+          "t4"."o_orderkey",
+          "t4"."o_custkey",
+          "t4"."o_orderstatus",
+          "t4"."o_totalprice",
+          "t4"."o_orderdate",
+          "t4"."o_orderpriority",
+          "t4"."o_clerk",
+          "t4"."o_shippriority",
+          "t4"."o_comment",
+          "t4"."c_custkey"
+        FROM (
+          SELECT
+            "t2"."c_custkey",
+            "t2"."c_name",
+            "t2"."c_address",
+            "t2"."c_nationkey",
+            "t2"."c_phone",
+            "t2"."c_acctbal",
+            "t2"."c_mktsegment",
+            "t2"."c_comment",
+            "t3"."o_orderkey",
+            "t3"."o_custkey",
+            "t3"."o_orderstatus",
+            "t3"."o_totalprice",
+            "t3"."o_orderdate",
+            "t3"."o_orderpriority",
+            "t3"."o_clerk",
+            "t3"."o_shippriority",
+            "t3"."o_comment"
+          FROM "customer" AS "t2"
+          LEFT OUTER JOIN "orders" AS "t3"
+            ON "t2"."c_custkey" = "t3"."o_custkey"
+            AND NOT (
+              "t3"."o_comment" LIKE '%special%requests%'
+            )
+        ) AS "t4"
+      ) AS t4
+      GROUP BY
+        "t4"."c_custkey"
+    ) AS "t5"
+  ) AS t5
+  GROUP BY
+    "t5"."c_count"
+) AS "t6"
+ORDER BY
+  "t6"."custdist" DESC NULLS LAST,
+  "t6"."c_count" DESC NULLS LAST

--- a/ibis/backends/tests/tpch/snapshots/test_h14/test_tpc_h14/datafusion/h14.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h14/test_tpc_h14/datafusion/h14.sql
@@ -1,0 +1,52 @@
+SELECT
+  CAST((
+    SUM(
+      CASE
+        WHEN "t5"."p_type" LIKE 'PROMO%'
+        THEN "t5"."l_extendedprice" * (
+          1 - "t5"."l_discount"
+        )
+        ELSE 0
+      END
+    ) * 100
+  ) AS DOUBLE PRECISION) / SUM("t5"."l_extendedprice" * (
+    1 - "t5"."l_discount"
+  )) AS "promo_revenue"
+FROM (
+  SELECT
+    *
+  FROM (
+    SELECT
+      "t2"."l_orderkey",
+      "t2"."l_partkey",
+      "t2"."l_suppkey",
+      "t2"."l_linenumber",
+      "t2"."l_quantity",
+      "t2"."l_extendedprice",
+      "t2"."l_discount",
+      "t2"."l_tax",
+      "t2"."l_returnflag",
+      "t2"."l_linestatus",
+      "t2"."l_shipdate",
+      "t2"."l_commitdate",
+      "t2"."l_receiptdate",
+      "t2"."l_shipinstruct",
+      "t2"."l_shipmode",
+      "t2"."l_comment",
+      "t3"."p_partkey",
+      "t3"."p_name",
+      "t3"."p_mfgr",
+      "t3"."p_brand",
+      "t3"."p_type",
+      "t3"."p_size",
+      "t3"."p_container",
+      "t3"."p_retailprice",
+      "t3"."p_comment"
+    FROM "lineitem" AS "t2"
+    INNER JOIN "part" AS "t3"
+      ON "t2"."l_partkey" = "t3"."p_partkey"
+  ) AS "t4"
+  WHERE
+    "t4"."l_shipdate" >= DATE_TRUNC('DAY', '1995-09-01')
+    AND "t4"."l_shipdate" < DATE_TRUNC('DAY', '1995-10-01')
+) AS "t5"

--- a/ibis/backends/tests/tpch/snapshots/test_h15/test_tpc_h15/datafusion/h15.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h15/test_tpc_h15/datafusion/h15.sql
@@ -1,0 +1,65 @@
+WITH "t6" AS (
+  SELECT
+    "t2"."s_suppkey",
+    "t2"."s_name",
+    "t2"."s_address",
+    "t2"."s_nationkey",
+    "t2"."s_phone",
+    "t2"."s_acctbal",
+    "t2"."s_comment",
+    "t5"."l_suppkey",
+    "t5"."total_revenue"
+  FROM "supplier" AS "t2"
+  INNER JOIN (
+    SELECT
+      "t3"."l_suppkey",
+      SUM("t3"."l_extendedprice" * (
+        1 - "t3"."l_discount"
+      )) AS "total_revenue"
+    FROM (
+      SELECT
+        "t3"."l_orderkey",
+        "t3"."l_partkey",
+        "t3"."l_linenumber",
+        "t3"."l_quantity",
+        "t3"."l_extendedprice",
+        "t3"."l_discount",
+        "t3"."l_tax",
+        "t3"."l_returnflag",
+        "t3"."l_linestatus",
+        "t3"."l_shipdate",
+        "t3"."l_commitdate",
+        "t3"."l_receiptdate",
+        "t3"."l_shipinstruct",
+        "t3"."l_shipmode",
+        "t3"."l_comment",
+        "t3"."l_suppkey"
+      FROM (
+        SELECT
+          *
+        FROM "lineitem" AS "t1"
+        WHERE
+          "t1"."l_shipdate" >= DATE_TRUNC('DAY', '1996-01-01')
+          AND "t1"."l_shipdate" < DATE_TRUNC('DAY', '1996-04-01')
+      ) AS "t3"
+    ) AS t3
+    GROUP BY
+      "t3"."l_suppkey"
+  ) AS "t5"
+    ON "t2"."s_suppkey" = "t5"."l_suppkey"
+)
+SELECT
+  "t7"."s_suppkey",
+  "t7"."s_name",
+  "t7"."s_address",
+  "t7"."s_phone",
+  "t7"."total_revenue"
+FROM "t6" AS "t7"
+WHERE
+  "t7"."total_revenue" = (
+    SELECT
+      MAX("t7"."total_revenue") AS "Max(total_revenue)"
+    FROM "t6" AS "t7"
+  )
+ORDER BY
+  "t7"."s_suppkey" ASC

--- a/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/datafusion/h17.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h17/test_tpc_h17/datafusion/h17.sql
@@ -1,0 +1,53 @@
+SELECT
+  CAST(SUM("t7"."l_extendedprice") AS DOUBLE PRECISION) / 7.0 AS "avg_yearly"
+FROM (
+  SELECT
+    *
+  FROM (
+    SELECT
+      "t2"."l_orderkey",
+      "t2"."l_partkey",
+      "t2"."l_suppkey",
+      "t2"."l_linenumber",
+      "t2"."l_quantity",
+      "t2"."l_extendedprice",
+      "t2"."l_discount",
+      "t2"."l_tax",
+      "t2"."l_returnflag",
+      "t2"."l_linestatus",
+      "t2"."l_shipdate",
+      "t2"."l_commitdate",
+      "t2"."l_receiptdate",
+      "t2"."l_shipinstruct",
+      "t2"."l_shipmode",
+      "t2"."l_comment",
+      "t3"."p_partkey",
+      "t3"."p_name",
+      "t3"."p_mfgr",
+      "t3"."p_brand",
+      "t3"."p_type",
+      "t3"."p_size",
+      "t3"."p_container",
+      "t3"."p_retailprice",
+      "t3"."p_comment"
+    FROM "lineitem" AS "t2"
+    INNER JOIN "part" AS "t3"
+      ON "t3"."p_partkey" = "t2"."l_partkey"
+  ) AS "t4"
+  WHERE
+    "t4"."p_brand" = 'Brand#23'
+    AND "t4"."p_container" = 'MED BOX'
+    AND "t4"."l_quantity" < (
+      (
+        SELECT
+          AVG("t5"."l_quantity") AS "Mean(l_quantity)"
+        FROM (
+          SELECT
+            *
+          FROM "lineitem" AS "t0"
+          WHERE
+            "t0"."l_partkey" = "t4"."p_partkey"
+        ) AS "t5"
+      ) * 0.2
+    )
+) AS "t7"

--- a/ibis/backends/tests/tpch/snapshots/test_h18/test_tpc_h18/datafusion/h18.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h18/test_tpc_h18/datafusion/h18.sql
@@ -1,0 +1,136 @@
+SELECT
+  *
+FROM (
+  SELECT
+    "t9"."c_name",
+    "t9"."c_custkey",
+    "t9"."o_orderkey",
+    "t9"."o_orderdate",
+    "t9"."o_totalprice",
+    SUM("t9"."l_quantity") AS "sum_qty"
+  FROM (
+    SELECT
+      "t9"."c_address",
+      "t9"."c_nationkey",
+      "t9"."c_phone",
+      "t9"."c_acctbal",
+      "t9"."c_mktsegment",
+      "t9"."c_comment",
+      "t9"."o_custkey",
+      "t9"."o_orderstatus",
+      "t9"."o_orderpriority",
+      "t9"."o_clerk",
+      "t9"."o_shippriority",
+      "t9"."o_comment",
+      "t9"."l_orderkey",
+      "t9"."l_partkey",
+      "t9"."l_suppkey",
+      "t9"."l_linenumber",
+      "t9"."l_quantity",
+      "t9"."l_extendedprice",
+      "t9"."l_discount",
+      "t9"."l_tax",
+      "t9"."l_returnflag",
+      "t9"."l_linestatus",
+      "t9"."l_shipdate",
+      "t9"."l_commitdate",
+      "t9"."l_receiptdate",
+      "t9"."l_shipinstruct",
+      "t9"."l_shipmode",
+      "t9"."l_comment",
+      "t9"."c_name",
+      "t9"."c_custkey",
+      "t9"."o_orderkey",
+      "t9"."o_orderdate",
+      "t9"."o_totalprice"
+    FROM (
+      SELECT
+        *
+      FROM (
+        SELECT
+          "t3"."c_custkey",
+          "t3"."c_name",
+          "t3"."c_address",
+          "t3"."c_nationkey",
+          "t3"."c_phone",
+          "t3"."c_acctbal",
+          "t3"."c_mktsegment",
+          "t3"."c_comment",
+          "t4"."o_orderkey",
+          "t4"."o_custkey",
+          "t4"."o_orderstatus",
+          "t4"."o_totalprice",
+          "t4"."o_orderdate",
+          "t4"."o_orderpriority",
+          "t4"."o_clerk",
+          "t4"."o_shippriority",
+          "t4"."o_comment",
+          "t5"."l_orderkey",
+          "t5"."l_partkey",
+          "t5"."l_suppkey",
+          "t5"."l_linenumber",
+          "t5"."l_quantity",
+          "t5"."l_extendedprice",
+          "t5"."l_discount",
+          "t5"."l_tax",
+          "t5"."l_returnflag",
+          "t5"."l_linestatus",
+          "t5"."l_shipdate",
+          "t5"."l_commitdate",
+          "t5"."l_receiptdate",
+          "t5"."l_shipinstruct",
+          "t5"."l_shipmode",
+          "t5"."l_comment"
+        FROM "customer" AS "t3"
+        INNER JOIN "orders" AS "t4"
+          ON "t3"."c_custkey" = "t4"."o_custkey"
+        INNER JOIN "lineitem" AS "t5"
+          ON "t4"."o_orderkey" = "t5"."l_orderkey"
+      ) AS "t7"
+      WHERE
+        "t7"."o_orderkey" IN (
+          SELECT
+            "t6"."l_orderkey"
+          FROM (
+            SELECT
+              "t2"."l_orderkey",
+              SUM("t2"."l_quantity") AS "qty_sum"
+            FROM (
+              SELECT
+                "t2"."l_partkey",
+                "t2"."l_suppkey",
+                "t2"."l_linenumber",
+                "t2"."l_quantity",
+                "t2"."l_extendedprice",
+                "t2"."l_discount",
+                "t2"."l_tax",
+                "t2"."l_returnflag",
+                "t2"."l_linestatus",
+                "t2"."l_shipdate",
+                "t2"."l_commitdate",
+                "t2"."l_receiptdate",
+                "t2"."l_shipinstruct",
+                "t2"."l_shipmode",
+                "t2"."l_comment",
+                "t2"."l_orderkey"
+              FROM "lineitem" AS "t2"
+            ) AS t2
+            GROUP BY
+              "t2"."l_orderkey"
+          ) AS "t6"
+          WHERE
+            "t6"."qty_sum" > 300
+        )
+    ) AS "t9"
+  ) AS t9
+  GROUP BY
+    "t9"."c_name",
+    "t9"."c_custkey",
+    "t9"."o_orderkey",
+    "t9"."o_orderdate",
+    "t9"."o_totalprice"
+) AS "t10"
+ORDER BY
+  "t10"."o_totalprice" DESC NULLS LAST,
+  "t10"."o_orderdate" ASC
+LIMIT 100

--- a/ibis/backends/tests/tpch/snapshots/test_h19/test_tpc_h19/datafusion/h19.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h19/test_tpc_h19/datafusion/h19.sql
@@ -1,0 +1,123 @@
+SELECT
+  SUM("t5"."l_extendedprice" * (
+    1 - "t5"."l_discount"
+  )) AS "revenue"
+FROM (
+  SELECT
+    *
+  FROM (
+    SELECT
+      "t2"."l_orderkey",
+      "t2"."l_partkey",
+      "t2"."l_suppkey",
+      "t2"."l_linenumber",
+      "t2"."l_quantity",
+      "t2"."l_extendedprice",
+      "t2"."l_discount",
+      "t2"."l_tax",
+      "t2"."l_returnflag",
+      "t2"."l_linestatus",
+      "t2"."l_shipdate",
+      "t2"."l_commitdate",
+      "t2"."l_receiptdate",
+      "t2"."l_shipinstruct",
+      "t2"."l_shipmode",
+      "t2"."l_comment",
+      "t3"."p_partkey",
+      "t3"."p_name",
+      "t3"."p_mfgr",
+      "t3"."p_brand",
+      "t3"."p_type",
+      "t3"."p_size",
+      "t3"."p_container",
+      "t3"."p_retailprice",
+      "t3"."p_comment"
+    FROM "lineitem" AS "t2"
+    INNER JOIN "part" AS "t3"
+      ON "t3"."p_partkey" = "t2"."l_partkey"
+  ) AS "t4"
+  WHERE
+    (
+      (
+        (
+          (
+            (
+              (
+                (
+                  (
+                    "t4"."p_brand" = 'Brand#12'
+                  )
+                  AND "t4"."p_container" IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+                )
+                AND (
+                  "t4"."l_quantity" >= 1
+                )
+              )
+              AND (
+                "t4"."l_quantity" <= 11
+              )
+            )
+            AND "t4"."p_size" BETWEEN 1 AND 5
+          )
+          AND "t4"."l_shipmode" IN ('AIR', 'AIR REG')
+        )
+        AND (
+          "t4"."l_shipinstruct" = 'DELIVER IN PERSON'
+        )
+      )
+      OR (
+        (
+          (
+            (
+              (
+                (
+                  (
+                    "t4"."p_brand" = 'Brand#23'
+                  )
+                  AND "t4"."p_container" IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+                )
+                AND (
+                  "t4"."l_quantity" >= 10
+                )
+              )
+              AND (
+                "t4"."l_quantity" <= 20
+              )
+            )
+            AND "t4"."p_size" BETWEEN 1 AND 10
+          )
+          AND "t4"."l_shipmode" IN ('AIR', 'AIR REG')
+        )
+        AND (
+          "t4"."l_shipinstruct" = 'DELIVER IN PERSON'
+        )
+      )
+    )
+    OR (
+      (
+        (
+          (
+            (
+              (
+                (
+                  "t4"."p_brand" = 'Brand#34'
+                )
+                AND "t4"."p_container" IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+              )
+              AND (
+                "t4"."l_quantity" >= 20
+              )
+            )
+            AND (
+              "t4"."l_quantity" <= 30
+            )
+          )
+          AND "t4"."p_size" BETWEEN 1 AND 15
+        )
+        AND "t4"."l_shipmode" IN ('AIR', 'AIR REG')
+      )
+      AND (
+        "t4"."l_shipinstruct" = 'DELIVER IN PERSON'
+      )
+    )
+) AS "t5"

--- a/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/datafusion/h20.sql
+++ b/ibis/backends/tests/tpch/snapshots/test_h20/test_tpc_h20/datafusion/h20.sql
@@ -1,0 +1,61 @@
+SELECT
+  "t13"."s_name",
+  "t13"."s_address"
+FROM (
+  SELECT
+    *
+  FROM (
+    SELECT
+      "t5"."s_suppkey",
+      "t5"."s_name",
+      "t5"."s_address",
+      "t5"."s_nationkey",
+      "t5"."s_phone",
+      "t5"."s_acctbal",
+      "t5"."s_comment",
+      "t6"."n_nationkey",
+      "t6"."n_name",
+      "t6"."n_regionkey",
+      "t6"."n_comment"
+    FROM "supplier" AS "t5"
+    INNER JOIN "nation" AS "t6"
+      ON "t5"."s_nationkey" = "t6"."n_nationkey"
+  ) AS "t9"
+  WHERE
+    "t9"."n_name" = 'CANADA'
+    AND "t9"."s_suppkey" IN (
+      SELECT
+        "t11"."ps_suppkey"
+      FROM (
+        SELECT
+          *
+        FROM "partsupp" AS "t2"
+        WHERE
+          "t2"."ps_partkey" IN (
+            SELECT
+              "t3"."p_partkey"
+            FROM "part" AS "t3"
+            WHERE
+              "t3"."p_name" LIKE 'forest%'
+          )
+          AND "t2"."ps_availqty" > (
+            (
+              SELECT
+                SUM("t8"."l_quantity") AS "Sum(l_quantity)"
+              FROM (
+                SELECT
+                  *
+                FROM "lineitem" AS "t4"
+                WHERE
+                  "t4"."l_partkey" = "t2"."ps_partkey"
+                  AND "t4"."l_suppkey" = "t2"."ps_suppkey"
+                  AND "t4"."l_shipdate" >= DATE_TRUNC('DAY', '1994-01-01')
+                  AND "t4"."l_shipdate" < DATE_TRUNC('DAY', '1995-01-01')
+              ) AS "t8"
+            ) * 0.5
+          )
+      ) AS "t11"
+    )
+) AS "t13"
+ORDER BY
+  "t13"."s_name" ASC

--- a/ibis/backends/tests/tpch/test_h16.py
+++ b/ibis/backends/tests/tpch/test_h16.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import pytest
+
 import ibis
 
 from .conftest import tpch_test
 
 
+@pytest.mark.notyet(
+    ["datafusion"],
+    raises=Exception,
+    reason="IN subqueries not supported in DataFusion",
+)
 @tpch_test
 def test_tpc_h16(partsupp, part, supplier):
     """Parts/Supplier Relationship Query (Q16)

--- a/ibis/backends/tests/tpch/test_h21.py
+++ b/ibis/backends/tests/tpch/test_h21.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import pytest
+
 import ibis
 
 from .conftest import tpch_test
 
 
+@pytest.mark.notyet(
+    ["datafusion"],
+    raises=Exception,
+    reason="EXISTS subqueries not supported in DataFusion",
+)
 @tpch_test
 def test_tpc_h21(supplier, lineitem, orders, nation):
     """Suppliers Who Kept Orders Waiting Query (Q21)

--- a/ibis/backends/tests/tpch/test_h22.py
+++ b/ibis/backends/tests/tpch/test_h22.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import pytest
+
 from .conftest import tpch_test
 
 
+@pytest.mark.notyet(
+    ["datafusion"],
+    raises=Exception,
+    reason="EXISTS subqueries not supported in DataFusion",
+)
 @tpch_test
 def test_tpc_h22(customer, orders):
     """Global Sales Opportunity Query (Q22)


### PR DESCRIPTION
This PR adds DataFusion to the TPC-H correctness test suite.

Depends on #9299.