### PR TITLE
fix(clickhouse): more explicitly disallow null structs

### DIFF
--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -1016,10 +1016,11 @@ class ClickHouseType(SqlglotType):
 
     @classmethod
     def from_ibis(cls, dtype: dt.DataType) -> sge.DataType:
-        """Convert a sqlglot type to an ibis type."""
         typ = super().from_ibis(dtype)
-        if dtype.nullable and not (dtype.is_map() or dtype.is_array()):
-            # map cannot be nullable in clickhouse
+        # nested types cannot be nullable in clickhouse
+        if dtype.nullable and not (
+            dtype.is_map() or dtype.is_array() or dtype.is_struct()
+        ):
             return sge.DataType(this=typecode.NULLABLE, expressions=[typ])
         else:
             return typ

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -923,11 +923,6 @@ def test_zip_null(con, fn):
 
 
 @builtin_array
-@pytest.mark.notyet(
-    ["clickhouse"],
-    raises=ClickHouseDatabaseError,
-    reason="https://github.com/ClickHouse/ClickHouse/issues/41112",
-)
 @pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError)
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2ProgrammingError)
 @pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -14,7 +14,6 @@ import ibis
 import ibis.expr.datatypes as dt
 from ibis import util
 from ibis.backends.tests.errors import (
-    ClickHouseDatabaseError,
     PolarsColumnNotFoundError,
     PsycoPg2InternalError,
     PsycoPg2SyntaxError,
@@ -158,28 +157,16 @@ def test_field_access_after_case(con):
     ["postgres"], reason="struct literals not implemented", raises=PsycoPg2SyntaxError
 )
 @pytest.mark.notimpl(["flink"], raises=IbisError, reason="not implemented in ibis")
+@pytest.mark.notyet(
+    ["clickhouse"], raises=sg.ParseError, reason="sqlglot fails to parse"
+)
 @pytest.mark.parametrize(
     "nullable",
     [
-        param(
-            True,
-            marks=[
-                pytest.mark.notyet(
-                    ["clickhouse"],
-                    raises=ClickHouseDatabaseError,
-                    reason="ClickHouse doesn't support nested nullable types",
-                )
-            ],
-            id="nullable",
-        ),
+        param(True, id="nullable"),
         param(
             False,
             marks=[
-                pytest.mark.notyet(
-                    ["clickhouse"],
-                    raises=sg.ParseError,
-                    reason="sqlglot fails to parse",
-                ),
                 pytest.mark.notyet(
                     ["polars"],
                     raises=AssertionError,


### PR DESCRIPTION
I remove the docstring because it is obvious from the type signature,
and the docstring was wrong. The superclass has the correct docstring though,
just inherit that.

Part of https://github.com/ibis-project/ibis/pull/8666