### PR TITLE
test: disallow empty structs

### DIFF
--- a/ibis/backends/dask/tests/conftest.py
+++ b/ibis/backends/dask/tests/conftest.py
@@ -151,9 +151,9 @@ def pandas_df():
             "array_of_float64": [[1.0, 2.0], [3.0], []],
             "array_of_int64": [[1, 2], [], [3]],
             "array_of_strings": [["a", "b"], [], ["c"]],
-            "map_of_strings_integers": [{"a": 1, "b": 2}, None, {}],
-            "map_of_integers_strings": [{}, None, {1: "a", 2: "b"}],
-            "map_of_complex_values": [None, {"a": [1, 2, 3], "b": []}, {}],
+            "map_of_strings_integers": [{"a": 1, "b": 2}, {}, None],
+            "map_of_integers_strings": [{1: "a", 2: "b"}, {}, None],
+            "map_of_complex_values": [{"a": [1, 2, 3], "b": []}, {}, None],
         }
     )
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -831,12 +831,22 @@ class Interval(Parametric):
 
 @public
 class Struct(Parametric, MapSet):
-    """Structured values."""
+    """A nested type with ordered fields of any type, analogous to a dataclass in Python.
+
+    eg a Struct might have a field a of type int64 and a field b of type string.
+    """
 
     fields: FrozenOrderedDict[str, DataType]
 
     scalar = "StructScalar"
     column = "StructColumn"
+
+    def __init__(self, fields, nullable=True):
+        # We could do this validation in a type annotation, but I thought this
+        # was common enough to warrant a nicer error message.
+        if not fields:
+            raise TypeError("Structs require at least one field")
+        super().__init__(fields=fields, nullable=nullable)
 
     @classmethod
     def from_tuples(

--- a/ibis/expr/datatypes/value.py
+++ b/ibis/expr/datatypes/value.py
@@ -42,8 +42,6 @@ def infer(value: Any) -> dt.DataType:
 @infer.register(collections.OrderedDict)
 def infer_struct(value: Mapping[str, Any]) -> dt.Struct:
     """Infer the [`Struct`](./datatypes.qmd#ibis.expr.datatypes.Struct) type of `value`."""
-    if not value:
-        raise TypeError("Empty struct type not supported")
     fields = {name: infer(val) for name, val in value.items()}
     return dt.Struct(fields)
 

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -127,11 +127,6 @@ def test_struct_literal_non_castable(value):
         ibis.struct(value, type="struct<field1: string, field2: float64>")
 
 
-def test_struct_cast_to_empty_struct():
-    value = ibis.struct({"a": 1, "b": 2.0})
-    assert value.type().castable(dt.Struct({}))
-
-
 def test_map_literal():
     a = ibis.map(["a", "b"], [1, 2])
     assert a.op().keys.value == ("a", "b")

--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -22,6 +22,13 @@ def s():
     return ibis.table(dict(a="struct<f: float, g: string>"), name="s")
 
 
+@pytest.mark.parametrize("val", [{}, []])
+@pytest.mark.parametrize("typ", [None, "struct<>"])
+def test_struct_factory_empty(val, typ):
+    with pytest.raises(TypeError):
+        ibis.struct(val, type=typ)
+
+
 def test_struct_operations():
     value = OrderedDict(
         [

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -168,7 +168,7 @@ def struct_dtypes(
     draw,
     types=_item_strategy,
     names=_any_text,
-    num_fields=st.integers(min_value=0, max_value=20),  # noqa: B008
+    num_fields=st.integers(min_value=1, max_value=20),  # noqa: B008
     nullable=_nullable,
 ):
     num_fields = draw(num_fields)


### PR DESCRIPTION
working towards https://github.com/ibis-project/ibis/issues/8289

I'm not sure how useful empty structs are, since it seems like
only bigquery, dask, and pandas actually support them.
But still, if you stay in ibis-land, perhaps it is useful.
ie doing datatype kung-fu or only using them for intermediate calculations.
Not that hard for us to support it, so why not.

I'm not sure of the history of the specific disallowment
that I am removing from the type inference.

Relevant context:

- https://github.com/ibis-project/ibis/pull/8876
- https://github.com/ibis-project/ibis/issues?q=empty+struct