### PR TITLE
fix(datatypes): manually cast the type of pos to int16 for `table.describe()`

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -831,6 +831,11 @@ def test_table_describe(alltypes, selector, expected_columns):
     raises=PyDruidProgrammingError,
     reason="Druid only supports trivial unions",
 )
+@pytest.mark.notyet(
+    ["oracle"],
+    raises=OracleDatabaseError,
+    reason="Mode is not supported and ORA-02000: missing AS keyword",
+)
 def test_table_describe_large(con):
     num_cols = 129
     col_names = [f"col_{i}" for i in range(num_cols)]

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -813,9 +813,10 @@ def test_table_describe(alltypes, selector, expected_columns):
         "mssql",
         "trino",
         "flink",
+        "sqlite",
     ],
     raises=com.OperationNotDefinedError,
-    reason="quantile and mode is not supported",
+    reason="quantile is not supported",
 )
 @pytest.mark.notimpl(
     [
@@ -823,22 +824,12 @@ def test_table_describe(alltypes, selector, expected_columns):
         "druid",
     ],
     raises=com.OperationNotDefinedError,
-    reason="Mode and StandardDev is not supported",
+    reason="StandardDev is not supported",
 )
 @pytest.mark.notyet(
     ["druid"],
     raises=PyDruidProgrammingError,
     reason="Druid only supports trivial unions",
-)
-@pytest.mark.notimpl(
-    ["sqlite"],
-    raises=com.OperationNotDefinedError,
-    reason="quantile is not supported",
-)
-@pytest.mark.notimpl(
-    ["oracle"],
-    raises=OracleDatabaseError,
-    reason="Mode is not supported and ORA-02000: missing AS keyword",
 )
 def test_table_describe_large(con):
     num_cols = 129

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -804,6 +804,51 @@ def test_table_describe(alltypes, selector, expected_columns):
     assert sorted(expr.columns) == sorted(df.columns)
 
 
+@pytest.mark.notimpl(
+    [
+        "datafusion",
+        "bigquery",
+        "impala",
+        "mysql",
+        "mssql",
+        "trino",
+        "flink",
+    ],
+    raises=com.OperationNotDefinedError,
+    reason="quantile and mode is not supported",
+)
+@pytest.mark.notimpl(
+    [
+        "exasol",
+        "druid",
+    ],
+    raises=com.OperationNotDefinedError,
+    reason="Mode and StandardDev is not supported",
+)
+@pytest.mark.notyet(
+    ["druid"],
+    raises=PyDruidProgrammingError,
+    reason="Druid only supports trivial unions",
+)
+@pytest.mark.notimpl(
+    ["sqlite"],
+    raises=com.OperationNotDefinedError,
+    reason="quantile is not supported",
+)
+@pytest.mark.notimpl(
+    ["oracle"],
+    raises=OracleDatabaseError,
+    reason="Mode is not supported and ORA-02000: missing AS keyword",
+)
+def test_table_describe_large(con):
+    num_cols = 129
+    col_names = [f"col_{i}" for i in range(num_cols)]
+    t = ibis.memtable({col: [0, 1] for col in col_names})
+    result = con.execute(t.describe())
+    assert set(result.name) == set(col_names)
+    assert result.pos.dtype == np.int16
+
+
 @pytest.mark.parametrize(
     ("ibis_op", "pandas_op"),
     [

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2899,42 +2899,42 @@ class Table(Expr, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> p = ibis.examples.penguins.fetch()
         >>> p.describe()
-        ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━┓
-        ┃ name              ┃ pos  ┃ type    ┃ count ┃ nulls ┃ unique ┃ mode   ┃ … ┃
-        ┡━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━┩
-        │ string            │ int8 │ string  │ int64 │ int64 │ int64  │ string │ … │
-        ├───────────────────┼──────┼─────────┼───────┼───────┼────────┼────────┼───┤
-        │ species           │    0 │ string  │   344 │     0 │      3 │ Adelie │ … │
-        │ island            │    1 │ string  │   344 │     0 │      3 │ Biscoe │ … │
-        │ bill_length_mm    │    2 │ float64 │   344 │     2 │    164 │ NULL   │ … │
-        │ bill_depth_mm     │    3 │ float64 │   344 │     2 │     80 │ NULL   │ … │
-        │ flipper_length_mm │    4 │ int64   │   344 │     2 │     55 │ NULL   │ … │
-        │ body_mass_g       │    5 │ int64   │   344 │     2 │     94 │ NULL   │ … │
-        │ sex               │    6 │ string  │   344 │    11 │      2 │ male   │ … │
-        │ year              │    7 │ int64   │   344 │     0 │      3 │ NULL   │ … │
-        └───────────────────┴──────┴─────────┴───────┴───────┴────────┴────────┴───┘
+        ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━┓
+        ┃ name              ┃ pos   ┃ type    ┃ count ┃ nulls ┃ unique ┃ mode   ┃ … ┃
+        ┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━┩
+        │ string            │ int16 │ string  │ int64 │ int64 │ int64  │ string │ … │
+        ├───────────────────┼───────┼─────────┼───────┼───────┼────────┼────────┼───┤
+        │ species           │     0 │ string  │   344 │     0 │      3 │ Adelie │ … │
+        │ island            │     1 │ string  │   344 │     0 │      3 │ Biscoe │ … │
+        │ bill_length_mm    │     2 │ float64 │   344 │     2 │    164 │ NULL   │ … │
+        │ bill_depth_mm     │     3 │ float64 │   344 │     2 │     80 │ NULL   │ … │
+        │ flipper_length_mm │     4 │ int64   │   344 │     2 │     55 │ NULL   │ … │
+        │ body_mass_g       │     5 │ int64   │   344 │     2 │     94 │ NULL   │ … │
+        │ sex               │     6 │ string  │   344 │    11 │      2 │ male   │ … │
+        │ year              │     7 │ int64   │   344 │     0 │      3 │ NULL   │ … │
+        └───────────────────┴───────┴─────────┴───────┴───────┴────────┴────────┴───┘
         >>> p.select(s.of_type("numeric")).describe()
-        ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━┓
-        ┃ name              ┃ pos  ┃ type    ┃ count ┃ nulls ┃ unique ┃ … ┃
-        ┡━━━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━┩
-        │ string            │ int8 │ string  │ int64 │ int64 │ int64  │ … │
-        ├───────────────────┼──────┼─────────┼───────┼───────┼────────┼───┤
-        │ flipper_length_mm │    2 │ int64   │   344 │     2 │     55 │ … │
-        │ body_mass_g       │    3 │ int64   │   344 │     2 │     94 │ … │
-        │ year              │    4 │ int64   │   344 │     0 │      3 │ … │
-        │ bill_length_mm    │    0 │ float64 │   344 │     2 │    164 │ … │
-        │ bill_depth_mm     │    1 │ float64 │   344 │     2 │     80 │ … │
-        └───────────────────┴──────┴─────────┴───────┴───────┴────────┴───┘
+        ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━┓
+        ┃ name              ┃ pos   ┃ type    ┃ count ┃ nulls ┃ unique ┃ … ┃
+        ┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━┩
+        │ string            │ int16 │ string  │ int64 │ int64 │ int64  │ … │
+        ├───────────────────┼───────┼─────────┼───────┼───────┼────────┼───┤
+        │ flipper_length_mm │     2 │ int64   │   344 │     2 │     55 │ … │
+        │ body_mass_g       │     3 │ int64   │   344 │     2 │     94 │ … │
+        │ year              │     4 │ int64   │   344 │     0 │      3 │ … │
+        │ bill_length_mm    │     0 │ float64 │   344 │     2 │    164 │ … │
+        │ bill_depth_mm     │     1 │ float64 │   344 │     2 │     80 │ … │
+        └───────────────────┴───────┴─────────┴───────┴───────┴────────┴───┘
         >>> p.select(s.of_type("string")).describe()
-        ┏━━━━━━━━━┳━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
-        ┃ name    ┃ pos  ┃ type   ┃ count ┃ nulls ┃ unique ┃ mode   ┃
-        ┡━━━━━━━━━╇━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
-        │ string  │ int8 │ string │ int64 │ int64 │ int64  │ string │
-        ├─────────┼──────┼────────┼───────┼───────┼────────┼────────┤
-        │ sex     │    2 │ string │   344 │    11 │      2 │ male   │
-        │ species │    0 │ string │   344 │     0 │      3 │ Adelie │
-        │ island  │    1 │ string │   344 │     0 │      3 │ Biscoe │
-        └─────────┴──────┴────────┴───────┴───────┴────────┴────────┘
+        ┏━━━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━━━━┳━━━━━━━━┓
+        ┃ name    ┃ pos   ┃ type   ┃ count ┃ nulls ┃ unique ┃ mode   ┃
+        ┡━━━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━━━━╇━━━━━━━━┩
+        │ string  │ int16 │ string │ int64 │ int64 │ int64  │ string │
+        ├─────────┼───────┼────────┼───────┼───────┼────────┼────────┤
+        │ sex     │     2 │ string │   344 │    11 │      2 │ male   │
+        │ species │     0 │ string │   344 │     0 │      3 │ Adelie │
+        │ island  │     1 │ string │   344 │     0 │      3 │ Biscoe │
+        └─────────┴───────┴────────┴───────┴───────┴────────┴────────┘
         """
         import ibis.selectors as s
         from ibis import literal as lit
@@ -2980,7 +2980,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
             agg = self.agg(
                 name=lit(colname),
-                pos=lit(pos),
+                pos=lit(pos, type=dt.int16),
                 type=lit(str(typ)),
                 count=col.isnull().count(),
                 nulls=col.isnull().sum(),


### PR DESCRIPTION
## Description of changes

the same problem as in PR #9139,

Want to use `describe()` function on a large table from a Kaggle competition, which will serve as an example for IbisML.

## Issues closed

None
