### PR TITLE
fix: drop nulls in `.collect()` aggregation

### DIFF
--- a/ibis/backends/datafusion/compiler.py
+++ b/ibis/backends/datafusion/compiler.py
@@ -14,6 +14,7 @@ import ibis.expr.operations as ops
 from ibis.backends.sql.compiler import FALSE, NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import DataFusionType
 from ibis.backends.sql.dialects import DataFusion
+from ibis.backends.sql.rewrites import exclude_nulls_from_array_collect
 from ibis.common.temporal import IntervalUnit, TimestampUnit
 from ibis.expr.operations.udf import InputType
 from ibis.formats.pyarrow import PyArrowType
@@ -24,6 +25,8 @@ class DataFusionCompiler(SQLGlotCompiler):
 
     dialect = DataFusion
     type_mapper = DataFusionType
+
+    rewrites = (exclude_nulls_from_array_collect, *SQLGlotCompiler.rewrites)
 
     agg = AggGen(supports_filter=True)
 

--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -13,6 +13,7 @@ import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.backends.sql.compiler import NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import DuckDBType
+from ibis.backends.sql.rewrites import exclude_nulls_from_array_collect
 
 _INTERVAL_SUFFIXES = {
     "ms": "milliseconds",
@@ -34,6 +35,11 @@ class DuckDBCompiler(SQLGlotCompiler):
     type_mapper = DuckDBType
 
     agg = AggGen(supports_filter=True)
+
+    rewrites = (
+        exclude_nulls_from_array_collect,
+        *SQLGlotCompiler.rewrites,
+    )
 
     LOWERED_OPS = {
         ops.Sample: None,

--- a/ibis/backends/pandas/kernels.py
+++ b/ibis/backends/pandas/kernels.py
@@ -279,7 +279,7 @@ reductions = {
     ops.Arbitrary: arbitrary,
     ops.CountDistinct: lambda x: x.nunique(),
     ops.ApproxCountDistinct: lambda x: x.nunique(),
-    ops.ArrayCollect: lambda x: x.tolist(),
+    ops.ArrayCollect: lambda x: x.dropna().tolist(),
 }
 
 

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -14,6 +14,7 @@ import ibis.expr.rules as rlz
 from ibis.backends.sql.compiler import NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import PostgresType
 from ibis.backends.sql.dialects import Postgres
+from ibis.backends.sql.rewrites import exclude_nulls_from_array_collect
 
 
 class PostgresUDFNode(ops.Value):
@@ -26,6 +27,8 @@ class PostgresCompiler(SQLGlotCompiler):
 
     dialect = Postgres
     type_mapper = PostgresType
+
+    rewrites = (exclude_nulls_from_array_collect, *SQLGlotCompiler.rewrites)
 
     agg = AggGen(supports_filter=True)
 

--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -306,11 +306,6 @@ class SnowflakeCompiler(SQLGlotCompiler):
     def visit_ArrayContains(self, op, *, arg, other):
         return self.f.array_contains(arg, self.f.to_variant(other))
 
-    def visit_ArrayCollect(self, op, *, arg, where):
-        return self.agg.array_agg(
-            self.f.ifnull(arg, self.f.parse_json("null")), where=where
-        )
-
     def visit_ArrayConcat(self, op, *, arg):
         # array_cat only accepts two arguments
         return self.f.array_flatten(self.f.array(*arg))

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -374,6 +374,14 @@ def exclude_unsupported_window_frame_from_ops(_, **kwargs):
     return _.copy(start=None, end=0, order_by=_.order_by or (ops.NULL,))
 
 
+@replace(p.ArrayCollect)
+def exclude_nulls_from_array_collect(_, **kwargs):
+    where = ops.NotNull(_.arg)
+    if _.where is not None:
+        where = ops.And(where, _.where)
+    return _.copy(where=where)
+
+
 # Rewrite rules for lowering a high-level operation into one composed of more
 # primitive operations.
 

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -559,8 +559,8 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             id="count_star",
         ),
         param(
-            lambda t, where: t.string_col.collect(where=where),
-            lambda t, where: t.string_col[where].tolist(),
+            lambda t, where: t.string_col.nullif("3").collect(where=where),
+            lambda t, where: t.string_col[t.string_col != "3"][where].tolist(),
             id="collect",
             marks=[
                 pytest.mark.notimpl(

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -13,7 +13,10 @@ import ibis.expr.operations as ops
 from ibis.backends.sql.compiler import FALSE, NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import TrinoType
 from ibis.backends.sql.dialects import Trino
-from ibis.backends.sql.rewrites import exclude_unsupported_window_frame_from_ops
+from ibis.backends.sql.rewrites import (
+    exclude_nulls_from_array_collect,
+    exclude_unsupported_window_frame_from_ops,
+)
 
 
 class TrinoCompiler(SQLGlotCompiler):
@@ -25,6 +28,7 @@ class TrinoCompiler(SQLGlotCompiler):
     agg = AggGen(supports_filter=True)
 
     rewrites = (
+        exclude_nulls_from_array_collect,
         exclude_unsupported_window_frame_from_ops,
         *SQLGlotCompiler.rewrites,
     )


### PR DESCRIPTION
Fixes #9313, see that issue for the original context.

This PR standardizes the `null` handling behavior of our `.collect()` method to always exclude `NULL` values from the aggregated array. Previously the behavior was backend dependent.

This is _technically_ a breaking change for some backends. I currently haven't flagged it in the commit, but if we deem it worth flagging we probably also want to hold off merging if we plan on doing a 9.1 release (since a breaking change would need to go in 10.0). I'm inclined to treat this more as a behavioral bug, which is why I didn't mark it as breaking here.

I also haven't tested this on the cloud backends, :crossed_fingers: that it passes in CI.