### PR TITLE
docs(pyspark): remove outdated `connect()` callout

### DIFF
--- a/docs/backends/pyspark.qmd
+++ b/docs/backends/pyspark.qmd
@@ -78,10 +78,6 @@ con = ibis.pyspark.connect(session=session)
 `ibis.pyspark.connect` is a thin wrapper around [`ibis.backends.pyspark.Backend.do_connect`](#ibis.backends.pyspark.Backend.do_connect).
 :::
 
-::: {.callout-note}
-The `pyspark` backend does not create `SparkSession` objects (unless you [connect using a URL](#ibis.connect-url-format)); you must create a `SparkSession` and pass that to `ibis.pyspark.connect`.
-:::
-
 ### Connection Parameters
 
 ```{python}


### PR DESCRIPTION
## Description of changes

As of Ibis 9.0.0, passing a `SparkSession` to `ibis.pyspark.connect()` is no longer required; see https://github.com/ibis-project/ibis/commit/0f663e68dd30d3dc27ec83f787f438f96c71f6cc.