### PR TITLE
ci: add m1 runners to nix builds and fast ci suites and bump nixpkgs dependency

### DIFF
--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-latest # x86_64-linux
         python-version:
           - "3.10"
           - "3.11"
@@ -39,5 +39,7 @@ jobs:
         include:
           - os: ubuntu-arm64-small
             python-version: "3.12"
+          - os: macos-14
+            python-version: "3.10"
     steps:
       - run: echo "No build required"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-latest # x86_64-linux
         python-version:
           - "3.10"
           - "3.11"
@@ -40,6 +40,8 @@ jobs:
         include:
           - os: ubuntu-arm64-small
             python-version: "3.12"
+          - os: macos-14
+            python-version: "3.10"
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -71,4 +73,10 @@ jobs:
           version='${{ matrix.python-version }}'
           host_system="$(nix eval --raw 'nixpkgs#stdenv.hostPlatform.system')"
           flake=".#devShells.${host_system}.ibis${version//./}"
-          nix build "$flake" --fallback --keep-going --print-build-logs
+
+          args=()
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            args+=("--dry-run")
+          fi
+
+          nix build "$flake" --fallback --keep-going --print-build-logs "${args[@]}"

--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717737457,
-        "narHash": "sha256-hqHp0W7ibfdu5DFc6EG3S3c+GSAbti7VUldFXSf/WiI=",
+        "lastModified": 1718123384,
+        "narHash": "sha256-YdNUQyqTVL6vQByCPEI8684yL1JruidnaAt+ZxVCHv0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bf3faad723ca984fc4ea95c1cee1d975a8ca2a28",
+        "rev": "55666187a1d040436155930dba5ad59b41745c30",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1717774136,
-        "narHash": "sha256-comOhXDFUrbVba47gPenVBKy2foM3m3qOqpcP8umWDA=",
+        "lastModified": 1717965289,
+        "narHash": "sha256-62VsS1MvwcsyYWnxxOD9rX5yqDUvMXH7qE3Kj8HECYE=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "370da3b6fefc6c11367463b68d010f9950aaa80c",
+        "rev": "304f8235fb0729fd48567af34fcd1b58d18f9b95",
         "type": "github"
       },
       "original": {

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -406,7 +406,7 @@ def test_roundtrip_delta(backend, con, alltypes, tmp_path, monkeypatch):
     if con.name == "pyspark":
         pytest.importorskip("delta")
     else:
-        pytest.importorskip("deltalake")
+        pytest.importorskip("deltalake", exc_type=ImportError)
 
     t = alltypes.head()
     expected = t.to_pandas()

--- a/ibis/conftest.py
+++ b/ibis/conftest.py
@@ -15,6 +15,7 @@ SANDBOXED = (
 LINUX = platform.system() == "Linux"
 MACOS = platform.system() == "Darwin"
 WINDOWS = platform.system() == "Windows"
+ARM64 = platform.machine() in ("arm64", "aarch64")
 CI = os.environ.get("CI") is not None
 
 


### PR DESCRIPTION
Apparently github has m1 hosted runners now