### PR TITLE
chore(api): remove defunct add_operation from backends

### DIFF
--- a/ibis/__init__.py
+++ b/ibis/__init__.py
@@ -95,7 +95,6 @@ def __getattr__(name: str) -> BaseBackend:
     # - connect
     # - compile
     # - has_operation
-    # - add_operation
     # - _from_url
     # - _to_sqlglot
     #
@@ -116,7 +115,6 @@ def __getattr__(name: str) -> BaseBackend:
     proxy.connect = connect
     proxy.compile = backend.compile
     proxy.has_operation = backend.has_operation
-    proxy.add_operation = backend.add_operation
     proxy.name = name
     proxy._from_url = backend._from_url
     proxy._to_sqlglot = backend._to_sqlglot

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -20,7 +20,7 @@ from ibis import util
 from ibis.common.caching import RefCountedCache
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
+    from collections.abc import Iterable, Iterator, Mapping, MutableMapping
 
     import pandas as pd
     import polars as pl
@@ -1050,23 +1050,6 @@ class BaseBackend(abc.ABC, _FileIOHandler):
 
     def execute(self, expr: ir.Expr) -> Any:
         """Execute an expression."""
-
-    def add_operation(self, operation: ops.Node) -> Callable:
-        """Add a translation function to the backend for a specific operation.
-
-        Operations are defined in `ibis.expr.operations`, and a translation
-        function receives the translator object and an expression as
-        parameters, and returns a value depending on the backend.
-        """
-        if not hasattr(self, "compiler"):
-            raise RuntimeError("Only SQL-based backends support `add_operation`")
-
-        def decorator(translation_function: Callable) -> None:
-            self.compiler.translator_class.add_operation(
-                operation, translation_function
-            )
-
-        return decorator
 
     @abc.abstractmethod
     def create_table(

--- a/ibis/tests/test_api.py
+++ b/ibis/tests/test_api.py
@@ -26,7 +26,7 @@ import ibis
 
 # def test_public_backend_methods():
 #     public = {m for m in dir(ibis.sqlite) if not m.startswith("_")}
-#     assert public == {"connect", "compile", "has_operation", "add_operation", "name"}
+#     assert public == {"connect", "compile", "has_operation", "name"}
 
 
 def test_missing_backend():


### PR DESCRIPTION
This functionality was never ported to work with the new compiler
infrastructure in 9.0.

Not marking as a breaking change because the breakage is already done.

Resolves #9158