### PR TITLE
feat(postgres): provide translation for `hash` ops

### DIFF
--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -588,3 +588,26 @@ class PostgresCompiler(SQLGlotCompiler):
         return self.cast(arg, op.to)
 
     visit_TryCast = visit_Cast
+
+    def visit_Hash(self, op, *, arg):
+        arg_dtype = op.arg.dtype
+
+        if arg_dtype.is_int16():
+            return self.f.hashint2extended(arg, 0)
+        elif arg_dtype.is_int32():
+            return self.f.hashint4extended(arg, 0)
+        elif arg_dtype.is_int64():
+            return self.f.hashint8extended(arg, 0)
+        elif arg_dtype.is_float32():
+            return self.f.hashfloat4extended(arg, 0)
+        elif arg_dtype.is_float64():
+            return self.f.hashfloat8extended(arg, 0)
+        elif arg_dtype.is_string():
+            return self.f.hashtextextended(arg, 0)
+        elif arg_dtype.is_macaddr():
+            return self.f.hashmacaddr8extended(arg, 0)
+
+        raise com.UnsupportedOperationError(
+            f"Hash({arg_dtype!r}) operation is not supported in the "
+            f"{self.dialect} backend"
+        )

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -592,16 +592,8 @@ class PostgresCompiler(SQLGlotCompiler):
     def visit_Hash(self, op, *, arg):
         arg_dtype = op.arg.dtype
 
-        if arg_dtype.is_int16():
-            return self.f.hashint2extended(arg, 0)
-        elif arg_dtype.is_int32():
-            return self.f.hashint4extended(arg, 0)
-        elif arg_dtype.is_int64():
-            return self.f.hashint8extended(arg, 0)
-        elif arg_dtype.is_float32():
-            return self.f.hashfloat4extended(arg, 0)
-        elif arg_dtype.is_float64():
-            return self.f.hashfloat8extended(arg, 0)
+        if arg_dtype.is_numeric():
+            return self.f.hash_numeric_extended(arg, 0)
         elif arg_dtype.is_string():
             return self.f.hashtextextended(arg, 0)
         elif arg_dtype.is_macaddr():

--- a/ibis/backends/postgres/compiler.py
+++ b/ibis/backends/postgres/compiler.py
@@ -592,8 +592,16 @@ class PostgresCompiler(SQLGlotCompiler):
     def visit_Hash(self, op, *, arg):
         arg_dtype = op.arg.dtype
 
-        if arg_dtype.is_numeric():
-            return self.f.hash_numeric_extended(arg, 0)
+        if arg_dtype.is_int16():
+            return self.f.hashint2extended(arg, 0)
+        elif arg_dtype.is_int32():
+            return self.f.hashint4extended(arg, 0)
+        elif arg_dtype.is_int64():
+            return self.f.hashint8extended(arg, 0)
+        elif arg_dtype.is_float32():
+            return self.f.hashfloat4extended(arg, 0)
+        elif arg_dtype.is_float64():
+            return self.f.hashfloat8extended(arg, 0)
         elif arg_dtype.is_string():
             return self.f.hashtextextended(arg, 0)
         elif arg_dtype.is_macaddr():

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1504,10 +1504,13 @@ def test_distinct_on_keep_is_none(backend, on):
         "trino",  # checksum returns varbinary
     ]
 )
-def test_hash(backend, alltypes):
+@pytest.mark.parametrize(
+    "dtype", ["smallint", "int", "bigint", "float", "double", "string"]
+)
+def test_hash(backend, alltypes, dtype):
     # check that multiple executions return the same result
-    h1 = alltypes.string_col.hash().execute(limit=20)
-    h2 = alltypes.string_col.hash().execute(limit=20)
+    h1 = getattr(alltypes, f"{dtype}_col").hash().execute(limit=20)
+    h2 = getattr(alltypes, f"{dtype}_col").hash().execute(limit=20)
     backend.assert_series_equal(h1, h2)
     # check that the result is a signed 64-bit integer, no nulls
     assert h1.dtype == "i8"

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1494,7 +1494,7 @@ def test_distinct_on_keep_is_none(backend, on):
     assert len(result) == len(expected)
 
 
-@pytest.mark.notimpl(["dask", "pandas", "postgres", "risingwave", "flink", "exasol"])
+@pytest.mark.notimpl(["dask", "pandas", "risingwave", "flink", "exasol"])
 @pytest.mark.notyet(
     [
         "sqlite",

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1509,8 +1509,8 @@ def test_distinct_on_keep_is_none(backend, on):
 )
 def test_hash(backend, alltypes, dtype):
     # check that multiple executions return the same result
-    h1 = getattr(alltypes, f"{dtype}_col").hash().execute(limit=20)
-    h2 = getattr(alltypes, f"{dtype}_col").hash().execute(limit=20)
+    h1 = alltypes[f"{dtype}_col"].hash().execute(limit=20)
+    h2 = alltypes[f"{dtype}_col"].hash().execute(limit=20)
     backend.assert_series_equal(h1, h2)
     # check that the result is a signed 64-bit integer, no nulls
     assert h1.dtype == "i8"


### PR DESCRIPTION
## Description of changes

Postgres supports hashing on a per-type basis, with "extended" versions providing 64-bit integer output. To list these, run `\df hash*extended`:

   Schema   |           Name           | Result data type |   Argument data types    | Type 
----------- | ------------------------ | ---------------- | ------------------------ | -----
 pg_catalog | hash_aclitem_extended    | bigint           | aclitem, bigint          | func
 pg_catalog | hash_array_extended      | bigint           | anyarray, bigint         | func
 pg_catalog | hash_multirange_extended | bigint           | anymultirange, bigint    | func
 pg_catalog | hash_numeric_extended    | bigint           | numeric, bigint          | func
 pg_catalog | hash_range_extended      | bigint           | anyrange, bigint         | func
 pg_catalog | hash_record_extended     | bigint           | record, bigint           | func
 pg_catalog | hashbpcharextended       | bigint           | character, bigint        | func
 pg_catalog | hashcharextended         | bigint           | "char", bigint           | func
 pg_catalog | hashenumextended         | bigint           | anyenum, bigint          | func
 pg_catalog | hashfloat4extended       | bigint           | real, bigint             | func
 pg_catalog | hashfloat8extended       | bigint           | double precision, bigint | func
 pg_catalog | hashinetextended         | bigint           | inet, bigint             | func
 pg_catalog | hashint2extended         | bigint           | smallint, bigint         | func
 pg_catalog | hashint4extended         | bigint           | integer, bigint          | func
 pg_catalog | hashint8extended         | bigint           | bigint, bigint           | func
 pg_catalog | hashmacaddr8extended     | bigint           | macaddr8, bigint         | func
 pg_catalog | hashmacaddrextended      | bigint           | macaddr, bigint          | func
 pg_catalog | hashnameextended         | bigint           | name, bigint             | func
 pg_catalog | hashoidextended          | bigint           | oid, bigint              | func
 pg_catalog | hashoidvectorextended    | bigint           | oidvector, bigint        | func
 pg_catalog | hashtextextended         | bigint           | text, bigint             | func
 pg_catalog | hashtidextended          | bigint           | tid, bigint              | func
 pg_catalog | hashvarlenaextended      | bigint           | internal, bigint         | func

This PR implements as many of them as possible, from the set of available Ibis datatypes in ibis/backends/sql/datatypes.py. No attempt to cast is made (e.g. hashing booleans is unsupported, rather than casting to an integer and then using the available hash method).