### PR TITLE
docs: update contribute index page content

### DIFF
--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -1,3 +1,3 @@
 # Contribute
 
-Check out our [contributing guide](../../CONTRIBUTING.md) for details! Guides for setting up an environment and getting started are here.
+Check out our [contributing guide](../contributing) for details! Guides for setting up an environment and getting started are here.

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -1,3 +1,3 @@
 # Contribute
 
-Check out our [contributing guide](../contributing) for details! Guides for setting up an environment and getting started are here.
+Check out our [contributing guide](../CONTRIBUTING.md) for details! Guides for setting up an environment and getting started are here.


### PR DESCRIPTION
## Description of changes

While it's not easy to navigate to, the index for https://ibis-project.org/contribute/ currently links to a [non-existent CONTRIBUTING.md](https://ibis-project.org/CONTRIBUTING.md). This swaps the entire index page for the content that currently lives in docs/CONTRIBUTING.md.

I didn't test these changes locally because my environment for docs isn't set up (which I'm also working on fixing) so a review of how I did the links would be good.