### PR TITLE
ci: replace apt-get with homebrew

### DIFF
--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -41,11 +41,8 @@ jobs:
       - name: install poetry
         run: pip install 'poetry==1.8.3'
 
-      - name: update apt-get
-        run: sudo apt-get update -y -q
-
       - name: install system dependencies
-        run: sudo apt-get install -y -q build-essential graphviz libgeos-dev freetds-dev unixodbc-dev
+        run: brew install gcc graphviz unixodbc geos freetds
 
       - name: check consistency with pyproject.toml
         run: poetry check --lock

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -143,7 +143,7 @@ jobs:
               - geospatial
               - polars
             sys-deps:
-              - libgeos-dev
+              - geos
           - name: postgres
             title: PostgreSQL
             extras:
@@ -152,7 +152,7 @@ jobs:
             services:
               - postgres
             sys-deps:
-              - libgeos-dev
+              - geos
           - name: postgres
             title: PostgreSQL + Torch
             extras:
@@ -164,7 +164,7 @@ jobs:
             services:
               - postgres
             sys-deps:
-              - libgeos-dev
+              - geos
           - name: risingwave
             title: Risingwave
             serial: true
@@ -182,7 +182,7 @@ jobs:
               - kudu
             sys-deps:
               - cmake
-              - ninja-build
+              - ninja
           - name: mssql
             title: MS SQL Server
             extras:
@@ -191,9 +191,8 @@ jobs:
             services:
               - mssql
             sys-deps:
-              - freetds-dev
-              - unixodbc-dev
-              - tdsodbc
+              - freetds
+              - unixodbc
           - name: trino
             title: Trino
             extras:
@@ -267,7 +266,7 @@ jobs:
                 - kudu
               sys-deps:
                 - cmake
-                - ninja-build
+                - ninja
         exclude:
           - os: windows-latest
             backend:
@@ -280,7 +279,7 @@ jobs:
               services:
                 - mysql
               sys-deps:
-                - libgeos-dev
+                - geos
           - os: windows-latest
             backend:
               name: clickhouse
@@ -300,7 +299,7 @@ jobs:
               services:
                 - postgres
               sys-deps:
-                - libgeos-dev
+                - geos
           - os: windows-latest
             backend:
               name: risingwave
@@ -323,7 +322,7 @@ jobs:
               services:
                 - postgres
               sys-deps:
-                - libgeos-dev
+                - geos
           # TODO(deepyaman): Test whether this works upon releasing https://github.com/cloudera/impyla/commit/bf1f94c3c4106ded6267d2485c1e939775a6a87f
           - os: ubuntu-latest
             python-version: "3.12"
@@ -338,7 +337,7 @@ jobs:
                 - kudu
               sys-deps:
                 - cmake
-                - ninja-build
+                - ninja
           - os: windows-latest
             backend:
               name: impala
@@ -351,7 +350,7 @@ jobs:
                 - kudu
               sys-deps:
                 - cmake
-                - ninja-build
+                - ninja
           - os: windows-latest
             backend:
               name: mssql
@@ -362,9 +361,8 @@ jobs:
               services:
                 - mssql
               sys-deps:
-                - freetds-dev
-                - unixodbc-dev
-                - tdsodbc
+                - freetds
+                - unixodbc
           - os: windows-latest
             backend:
               name: trino
@@ -430,11 +428,7 @@ jobs:
     steps:
       - name: update and install system dependencies
         if: matrix.os == 'ubuntu-latest' && matrix.backend.sys-deps != null
-        run: |
-          set -euo pipefail
-
-          sudo apt-get update -qq -y
-          sudo apt-get install -qq -y build-essential ${{ join(matrix.backend.sys-deps, ' ') }}
+        run: brew install gcc ${{ join(matrix.backend.sys-deps, ' ') }}
 
       - name: install sqlite
         if: matrix.os == 'windows-latest' && matrix.backend.name == 'sqlite'
@@ -603,9 +597,7 @@ jobs:
 
       - name: install libgeos for shapely
         if: matrix.backend.name == 'postgres'
-        run: |
-          sudo apt-get update -y -qq
-          sudo apt-get install -qq -y build-essential libgeos-dev
+        run: brew install gcc geos
 
       - uses: extractions/setup-just@v2
         env:

--- a/.github/workflows/ibis-benchmarks.yml
+++ b/.github/workflows/ibis-benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
         run: pip install 'poetry==1.8.3'
 
       - name: install system dependencies
-        run: sudo apt-get install -qq -y build-essential libgeos-dev freetds-dev unixodbc-dev
+        run: brew install gcc geos freetds unixodbc
 
       - name: install ibis
         run: poetry install --without dev --without docs --all-extras

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -63,12 +63,8 @@ jobs:
         run: pip install 'poetry==1.8.3'
 
       - name: install ${{ matrix.os }} system dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          set -euo pipefail
-
-          sudo apt-get update -y -qq
-          sudo apt-get install -y -q build-essential graphviz libgeos-dev freetds-dev
+        if: matrix.os != 'windows-latest'
+        run: brew install gcc graphviz geos freetds
 
       - name: install ${{ matrix.os }} system dependencies
         if: matrix.os == 'windows-latest'
@@ -114,11 +110,7 @@ jobs:
         run: pip install 'poetry==1.8.3'
 
       - name: install system dependencies
-        run: |
-          set -euo pipefail
-
-          sudo apt-get update -y -qq
-          sudo apt-get install -y -q build-essential libgeos-dev
+        run: brew install gcc geos
 
       - name: install ibis
         # install duckdb and geospatial because of https://github.com/ibis-project/ibis/issues/4856
@@ -134,11 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install system dependencies
-        run: |
-          set -euo pipefail
-
-          sudo apt-get update -y -q
-          sudo apt-get install -y -q build-essential graphviz libgeos-dev freetds-dev unixodbc-dev
+        run: brew install gcc graphviz geos freetds unixodbc
 
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -62,13 +62,11 @@ jobs:
       - name: install poetry
         run: pip install 'poetry==1.8.3'
 
-      - name: add homebrew to path
-        if: matrix.os == 'ubuntu-latest'
-        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-
       - name: install ${{ matrix.os }} system dependencies
         if: matrix.os != 'windows-latest'
-        run: brew install gcc graphviz geos freetds
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" || true
+          brew install gcc graphviz geos freetds
 
       - name: install ${{ matrix.os }} system dependencies
         if: matrix.os == 'windows-latest'
@@ -114,7 +112,9 @@ jobs:
         run: pip install 'poetry==1.8.3'
 
       - name: install system dependencies
-        run: brew install gcc geos
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" || true
+          brew install gcc geos
 
       - name: install ibis
         # install duckdb and geospatial because of https://github.com/ibis-project/ibis/issues/4856
@@ -130,7 +130,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install system dependencies
-        run: brew install gcc graphviz geos freetds unixodbc
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" || true
+          brew install gcc graphviz geos freetds unixodbc
 
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -62,6 +62,10 @@ jobs:
       - name: install poetry
         run: pip install 'poetry==1.8.3'
 
+      - name: add homebrew to path
+        if: matrix.os == 'ubuntu-latest'
+        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
       - name: install ${{ matrix.os }} system dependencies
         if: matrix.os != 'windows-latest'
         run: brew install gcc graphviz geos freetds


### PR DESCRIPTION
Simplify the CI system deps installation a bit by using homebrew instead of apt-get.