### PR TITLE
feat(selectors): parse Python types in `s.of_type`

### DIFF
--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -264,7 +264,7 @@ def of_type(dtype: dt.DataType | str | type[dt.DataType]) -> Predicate:
         else:
             dtype = dt.dtype(dtype)
             predicate = lambda col: col.type() == dtype
-    elif inspect.isclass(dtype):
+    elif inspect.isclass(dtype) and issubclass(dtype, dt.DataType):
         predicate = lambda col: isinstance(col.type(), dtype)
     else:
         dtype = dt.dtype(dtype)

--- a/ibis/tests/expr/test_selectors.py
+++ b/ibis/tests/expr/test_selectors.py
@@ -49,8 +49,13 @@ def test_numeric(t):
 
 @pytest.mark.parametrize(
     ("obj", "expected"),
-    [(dt.Array, ("c", "g")), ("float", ("e",)), (dt.Decimal(3, 1), ("f",))],
-    ids=["type", "string", "instance"],
+    [
+        (dt.Array, ("c", "g")),
+        ("float", ("e",)),
+        (dt.Decimal(3, 1), ("f",)),
+        (int, ("a",)),
+    ],
+    ids=["dtype", "string", "instance", "type"],
 )
 def test_of_type(t, obj, expected):
     assert t.select(s.of_type(obj)).equals(t.select(*expected))


### PR DESCRIPTION
## Description of changes

Make the is-class check more specific, ensuring the class is an Ibis data type, to avoid catching other inputs (like Python types).

## Issues closed

Resolves #9355