### PR TITLE
fix: exclude null values from `first` and `last` aggregations

### DIFF
--- a/ibis/backends/duckdb/compiler.py
+++ b/ibis/backends/duckdb/compiler.py
@@ -461,6 +461,16 @@ class DuckDBCompiler(SQLGlotCompiler):
             arg, pattern, replacement, "g", dialect=self.dialect
         )
 
+    def visit_First(self, op, *, arg, where):
+        cond = arg.is_(sg.not_(NULL, copy=False))
+        where = cond if where is None else sge.And(this=cond, expression=where)
+        return self.agg.first(arg, where=where)
+
+    def visit_Last(self, op, *, arg, where):
+        cond = arg.is_(sg.not_(NULL, copy=False))
+        where = cond if where is None else sge.And(this=cond, expression=where)
+        return self.agg.last(arg, where=where)
+
     def visit_Quantile(self, op, *, arg, quantile, where):
         suffix = "cont" if op.arg.dtype.is_numeric() else "disc"
         funcname = f"percentile_{suffix}"

--- a/ibis/backends/exasol/compiler.py
+++ b/ibis/backends/exasol/compiler.py
@@ -53,11 +53,9 @@ class ExasolCompiler(SQLGlotCompiler):
         ops.DateFromYMD,
         ops.DayOfWeekIndex,
         ops.ElementWiseVectorizedUDF,
-        ops.First,
         ops.IntervalFromInteger,
         ops.IsInf,
         ops.IsNan,
-        ops.Last,
         ops.Levenshtein,
         ops.Median,
         ops.MultiQuantile,
@@ -90,6 +88,8 @@ class ExasolCompiler(SQLGlotCompiler):
         ops.Log10: "log10",
         ops.All: "min",
         ops.Any: "max",
+        ops.First: "first_value",
+        ops.Last: "last_value",
     }
 
     @staticmethod

--- a/ibis/backends/pandas/kernels.py
+++ b/ibis/backends/pandas/kernels.py
@@ -254,10 +254,16 @@ def round_serieswise(arg, digits):
         return np.round(arg, digits).astype("float64")
 
 
-def arbitrary(arg):
-    # Arbitrary excludes null values unless they're all null
+def first(arg):
+    # first excludes null values unless they're all null
     arg = arg.dropna()
     return arg.iat[0] if len(arg) else None
+
+
+def last(arg):
+    # last excludes null values unless they're all null
+    arg = arg.dropna()
+    return arg.iat[-1] if len(arg) else None
 
 
 reductions = {
@@ -274,9 +280,9 @@ reductions = {
     ops.BitAnd: lambda x: np.bitwise_and.reduce(x.values),
     ops.BitOr: lambda x: np.bitwise_or.reduce(x.values),
     ops.BitXor: lambda x: np.bitwise_xor.reduce(x.values),
-    ops.Last: lambda x: x.iat[-1],
-    ops.First: lambda x: x.iat[0],
-    ops.Arbitrary: arbitrary,
+    ops.Last: last,
+    ops.First: first,
+    ops.Arbitrary: first,
     ops.CountDistinct: lambda x: x.nunique(),
     ops.ApproxCountDistinct: lambda x: x.nunique(),
     ops.ArrayCollect: lambda x: x.dropna().tolist(),

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -623,7 +623,22 @@ def test_reduction_ops(
 )
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2InternalError)
 @pytest.mark.parametrize("method", ["first", "last"])
-@pytest.mark.parametrize("filtered", [False, True])
+@pytest.mark.parametrize(
+    "filtered",
+    [
+        param(
+            False,
+            marks=[
+                pytest.mark.notyet(
+                    ["datafusion"],
+                    raises=Exception,
+                    reason="datafusion 38.0.1 has a bug in FILTER handling that causes this test to fail",
+                )
+            ],
+        ),
+        True,
+    ],
+)
 def test_first_last(backend, alltypes, method, filtered):
     # `first` and `last` effectively choose an arbitrary value when no
     # additional order is specified. *Most* backends will result in the

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1407,6 +1407,10 @@ def test_pivot_wider(backend):
     raises=PsycoPg2InternalError,
     reason="function last(double precision) does not exist, do you mean left or least",
 )
+@pytest.mark.notyet(
+    ["datafusion"],
+    reason="datafusion 38.0.1 has a bug in FILTER handling that causes this test to fail",
+)
 def test_distinct_on_keep(backend, on, keep):
     from ibis import _
 
@@ -1467,6 +1471,10 @@ def test_distinct_on_keep(backend, on, keep):
     ["risingwave"],
     raises=PsycoPg2InternalError,
     reason="function first(double precision) does not exist",
+)
+@pytest.mark.notyet(
+    ["datafusion"],
+    reason="datafusion 38.0.1 has a bug in FILTER handling that causes this test to fail",
 )
 def test_distinct_on_keep_is_none(backend, on):
     from ibis import _

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1403,10 +1403,6 @@ def test_pivot_wider(backend):
     reason="backend doesn't implement deduplication",
 )
 @pytest.mark.notimpl(
-    ["exasol"],
-    raises=com.OperationNotDefinedError,
-)
-@pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,
     reason="function last(double precision) does not exist, do you mean left or least",
@@ -1456,10 +1452,6 @@ def test_distinct_on_keep(backend, on, keep):
     ["druid", "impala", "oracle"],
     raises=(NotImplementedError, OracleDatabaseError, com.OperationNotDefinedError),
     reason="arbitrary not implemented in the backend",
-)
-@pytest.mark.notimpl(
-    ["exasol"],
-    raises=com.OperationNotDefinedError,
 )
 @pytest.mark.notimpl(
     ["polars"],

--- a/ibis/backends/trino/compiler.py
+++ b/ibis/backends/trino/compiler.py
@@ -362,9 +362,13 @@ class TrinoCompiler(SQLGlotCompiler):
         return self.f.array_join(arg, sep)
 
     def visit_First(self, op, *, arg, where):
+        cond = arg.is_(sg.not_(NULL, copy=False))
+        where = cond if where is None else sge.And(this=cond, expression=where)
         return self.f.element_at(self.agg.array_agg(arg, where=where), 1)
 
     def visit_Last(self, op, *, arg, where):
+        cond = arg.is_(sg.not_(NULL, copy=False))
+        where = cond if where is None else sge.And(this=cond, expression=where)
         return self.f.element_at(self.agg.array_agg(arg, where=where), -1)
 
     def visit_ArrayZip(self, op, *, arg):


### PR DESCRIPTION
Similar to #9318. The handling of `NULL` values in `first`/`last` previously was backend specific. We now standardize all backends to exclude `NULL` values from these aggregations.