### PR TITLE
ci(clickhouse): use a different health check

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -450,6 +450,10 @@ jobs:
       - name: download backend data
         run: just download-data
 
+      - name: show docker compose version
+        if: matrix.backend.services != null
+        run: docker compose version
+
       - name: start services
         if: matrix.backend.services != null
         run: docker compose up --wait ${{ join(matrix.backend.services, ' ') }}

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
       retries: 10
       test:
         - CMD-SHELL
-        - wget -qO- 'http://localhost:8123/?query=SELECT%201' # SELECT 1
+        - wget -qO- 'http://127.0.0.1:8123/?query=SELECT%201' # SELECT 1
     volumes:
       - clickhouse:/var/lib/clickhouse/user_files/ibis
     networks:


### PR DESCRIPTION
For some reason the existing clickhouse health check is not working on GHA, despite it working locally for me. Using the specific ipv4 address works in both case. Probably some DNS or other networking detail has changed and is leaking through from the host configuration into the container.