### PR TITLE
fix(pyspark): plumb through `limit` and `params` in export functions

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -863,6 +863,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
         self,
         expr: ir.Table,
         path: str | Path,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        limit: int | str | None = None,
         **kwargs: Any,
     ) -> None:
         """Write the results of executing the given expression to a Delta Lake table.
@@ -876,7 +878,11 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
             The ibis expression to execute and persist to a Delta Lake table.
         path
             The data source. A string or Path to the Delta Lake table.
-
+        params
+            Mapping of scalar parameter expressions to value.
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
         **kwargs
             PySpark Delta Lake table write arguments.
             https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.save.html
@@ -886,7 +892,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
             raise NotImplementedError(
                 "Writing to a Delta Lake table in streaming mode is not supported"
             )
-        df = self._session.sql(expr.compile())
+        df = self._session.sql(expr.compile(params=params, limit=limit))
         df.write.format("delta").save(os.fspath(path), **kwargs)
 
     def to_pyarrow(
@@ -938,6 +944,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def read_kafka(
         self,
         table_name: str | None = None,
+        *,
         watermark: Watermark | None = None,
         auto_parse: bool = False,
         schema: sch.Schema | None = None,
@@ -1001,8 +1008,11 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def to_kafka(
         self,
         expr: ir.Expr,
+        *,
         auto_format: bool = False,
         options: Mapping[str, str] | None = None,
+        params: Mapping | None = None,
+        limit: str | None = "default",
     ) -> StreamingQuery:
         """Write the results of executing the given expression to a Kafka topic.
 
@@ -1020,6 +1030,11 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
         options
             PySpark Kafka write arguments.
             https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html
+        params
+            Mapping of scalar parameter expressions to value.
+        limit
+            An integer to effect a specific row limit. A value of `None` means
+            "no limit". The default is in `ibis/config.py`.
 
         Returns
         -------
@@ -1028,7 +1043,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
         """
         if self.mode == "batch":
             raise NotImplementedError("Writing to Kafka in batch mode is not supported")
-        df = self._session.sql(expr.compile())
+        df = self._session.sql(expr.compile(params=params, limit=limit))
         if auto_format:
             df = df.select(
                 F.to_json(F.struct([F.col(c).alias(c) for c in df.columns])).alias(


### PR DESCRIPTION
We already covered `pyarrow` in the-epic-split, but added these to
`to_delta` and `to_kafka`

* Resolves #8898