### PR TITLE
test(clouds): disable flaky tests

### DIFF
--- a/ibis/backends/snowflake/tests/test_udf.py
+++ b/ibis/backends/snowflake/tests/test_udf.py
@@ -93,6 +93,7 @@ def test_builtin_agg_udf(con):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.xfail(reason="a reason that cannot be determined")
 def test_xgboost_model(con):
     from ibis import _
 

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1505,7 +1505,40 @@ def test_distinct_on_keep_is_none(backend, on):
     ]
 )
 @pytest.mark.parametrize(
-    "dtype", ["smallint", "int", "bigint", "float", "double", "string"]
+    "dtype",
+    [
+        param(
+            "smallint",
+            marks=pytest.mark.notyet(
+                ["bigquery"], reason="only supports bytes and strings"
+            ),
+        ),
+        param(
+            "int",
+            marks=pytest.mark.notyet(
+                ["bigquery"], reason="only supports bytes and strings"
+            ),
+        ),
+        param(
+            "bigint",
+            marks=pytest.mark.notyet(
+                ["bigquery"], reason="only supports bytes and strings"
+            ),
+        ),
+        param(
+            "float",
+            marks=pytest.mark.notyet(
+                ["bigquery"], reason="only supports bytes and strings"
+            ),
+        ),
+        param(
+            "double",
+            marks=pytest.mark.notyet(
+                ["bigquery"], reason="only supports bytes and strings"
+            ),
+        ),
+        "string",
+    ],
 )
 def test_hash(backend, alltypes, dtype):
     # check that multiple executions return the same result


### PR DESCRIPTION
Ideally we can reenable these in the future in the Snowflake case, but it looks like `FARM_FINGERPRINT` no longer accepts anything except strings and bytes, so we might be out of luck there.