### PR TITLE
ci: make sure args is never empty

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -74,9 +74,9 @@ jobs:
           host_system="$(nix eval --raw 'nixpkgs#stdenv.hostPlatform.system')"
           flake=".#devShells.${host_system}.ibis${version//./}"
 
-          args=()
+          args=("--fallback" "--keep-going" "--print-build-logs")
           if [[ "${{ github.event_name }}" != "push" ]]; then
             args+=("--dry-run")
           fi
 
-          nix build "$flake" --fallback --keep-going --print-build-logs "${args[@]}"
+          nix build "$flake" "${args[@]}"


### PR DESCRIPTION
Apparently empty arrays do not expand in the way I expected.