### PR TITLE
feat(bigquery): support filtering by `_TABLE_SUFFIX` when using a wildcard table name

### DIFF
--- a/ibis/backends/bigquery/client.py
+++ b/ibis/backends/bigquery/client.py
@@ -14,7 +14,7 @@ from ibis.backends.bigquery.datatypes import BigQuerySchema, BigQueryType
 NATIVE_PARTITION_COL = "_PARTITIONTIME"
 
 
-def schema_from_bigquery_table(table):
+def schema_from_bigquery_table(table, *, wildcard: bool):
     schema = BigQuerySchema.to_ibis(table.schema)
 
     # Check for partitioning information
@@ -25,6 +25,9 @@ def schema_from_bigquery_table(table):
         # Only add a new column if it's not already a column in the schema
         if partition_field not in schema:
             schema |= {partition_field: dt.Timestamp(timezone="UTC")}
+
+    if wildcard:
+        schema |= {"_TABLE_SUFFIX": dt.string}
 
     return schema
 

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -434,3 +434,11 @@ def test_create_temp_table_from_scratch(project_id, dataset_id):
     df = con.tables.functional_alltypes.limit(1)
     t = con.create_table(name, obj=df, temp=True)
     assert len(t.execute()) == 1
+
+
+def test_table_suffix():
+    con = ibis.connect("bigquery://ibis-gbq")
+    t = con.table("gsod*", database="bigquery-public-data.noaa_gsod")
+    expr = t.filter(t._TABLE_SUFFIX == "1929", t.max != 9999.9).head(1)
+    result = expr.execute()
+    assert not result.empty

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -200,10 +200,12 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         return data_mapper.convert_table(table, self.schema())
 
-    def __pandas_result__(self, df: pd.DataFrame) -> pd.DataFrame:
+    def __pandas_result__(
+        self, df: pd.DataFrame, schema: sch.Schema | None = None
+    ) -> pd.DataFrame:
         from ibis.formats.pandas import PandasData
 
-        return PandasData.convert_table(df, self.schema())
+        return PandasData.convert_table(df, self.schema() if schema is None else schema)
 
     def __polars_result__(self, df: pl.DataFrame) -> Any:
         from ibis.formats.polars import PolarsData


### PR DESCRIPTION
Add support for BigQuery sharded tables and use of `_TABLE_SUFFIX` pseudo-column for filtering shards. Closes #9371.