### PR TITLE
fix(oracle): use case statements to grab table metadata instead of bools

### DIFF
--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -305,7 +305,10 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 C.data_type,
                 C.data_precision,
                 C.data_scale,
-                C.nullable.eq(sge.convert("Y")).as_("nullable"),
+                sg.case()
+                .when(C.nullable.eq(sge.convert("Y")), sge.convert("Y"))
+                .else_(sge.convert("N"))
+                .as_("nullable"),
             )
             .from_(sg.table("all_tab_columns"))
             .where(
@@ -327,7 +330,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 type_string=type_string,
                 precision=precision,
                 scale=scale,
-                nullable=nullable,
+                nullable=nullable == "Y",
             )
             for name, type_string, precision, scale, nullable in results
         }
@@ -550,7 +553,10 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 C.data_type,
                 C.data_precision,
                 C.data_scale,
-                C.nullable.eq(sge.convert("Y")),
+                sg.case()
+                .when(C.nullable.eq(sge.convert("Y")), sge.convert("Y"))
+                .else_(sge.convert("N"))
+                .as_("nullable"),
             )
             .from_("all_tab_columns")
             .where(C.table_name.eq(sge.convert(name)))
@@ -576,7 +582,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 type_string=type_string,
                 precision=precision,
                 scale=scale,
-                nullable=nullable,
+                nullable=nullable == "Y",
             )
             schema[name] = typ
 

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -306,8 +306,8 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 C.data_precision,
                 C.data_scale,
                 sg.case()
-                .when(C.nullable.eq(sge.convert("Y")), sge.convert("Y"))
-                .else_(sge.convert("N"))
+                .when(C.nullable.eq(sge.convert("Y")), sge.convert(1))
+                .else_(sge.convert(0))
                 .as_("nullable"),
             )
             .from_(sg.table("all_tab_columns"))
@@ -330,7 +330,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 type_string=type_string,
                 precision=precision,
                 scale=scale,
-                nullable=nullable == "Y",
+                nullable=bool(nullable),
             )
             for name, type_string, precision, scale, nullable in results
         }
@@ -554,8 +554,8 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 C.data_precision,
                 C.data_scale,
                 sg.case()
-                .when(C.nullable.eq(sge.convert("Y")), sge.convert("Y"))
-                .else_(sge.convert("N"))
+                .when(C.nullable.eq(sge.convert("Y")), sge.convert(1))
+                .else_(sge.convert(0))
                 .as_("nullable"),
             )
             .from_("all_tab_columns")
@@ -582,7 +582,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 type_string=type_string,
                 precision=precision,
                 scale=scale,
-                nullable=nullable == "Y",
+                nullable=bool(nullable),
             )
             schema[name] = typ
 

--- a/ibis/backends/oracle/compiler.py
+++ b/ibis/backends/oracle/compiler.py
@@ -447,3 +447,6 @@ class OracleCompiler(SQLGlotCompiler):
 
     def visit_ExtractIsoYear(self, op, *, arg):
         return self.cast(self.f.to_char(arg, "IYYY"), op.dtype)
+
+    def visit_DummyTable(self, op, *, values):
+        return sg.select(*self._cleanup_names(values), copy=False).from_("dual")

--- a/ibis/backends/oracle/compiler.py
+++ b/ibis/backends/oracle/compiler.py
@@ -454,7 +454,7 @@ class OracleCompiler(SQLGlotCompiler):
     def visit_JoinLink(self, op, *, how, table, predicates):
         def _rewrite_bools(pred):
             if isinstance(pred, sge.Boolean):
-                if bool(pred.this):
+                if pred.this:
                     return sge.convert(1).eq(1)
                 else:
                     return sge.convert(1).eq(0)

--- a/ibis/backends/oracle/compiler.py
+++ b/ibis/backends/oracle/compiler.py
@@ -450,3 +450,17 @@ class OracleCompiler(SQLGlotCompiler):
 
     def visit_DummyTable(self, op, *, values):
         return sg.select(*self._cleanup_names(values), copy=False).from_("dual")
+
+    def visit_JoinLink(self, op, *, how, table, predicates):
+        def _rewrite_bools(pred):
+            if isinstance(pred, sge.Boolean):
+                if bool(pred.this):
+                    return sge.convert(1).eq(1)
+                else:
+                    return sge.convert(1).eq(0)
+            return pred
+
+        if predicates:
+            predicates = tuple(map(_rewrite_bools, predicates))
+
+        return super().visit_JoinLink(op, how=how, table=table, predicates=predicates)


### PR DESCRIPTION
xref: #9179 #9378 

Definitely more fixes needed, I just didn't want to lose track of this branch.

I was able to get some sense of the failures by switching the Oracle docker container:

```diff
       - druid
 
   oracle:
-    image: gvenzl/oracle-free:23.4-slim
+    image: gvenzl/oracle-xe:18.4.0-slim
     environment:
       ORACLE_PASSWORD: ibis
       ORACLE_DATABASE: IBIS_TESTING
```

I couldn't find a version 19 container.
Also note that this requires a bunch of annoying changes to the conftest setup because Oracle 18 doesn't support `DROP TABLE IF EXISTS` 
