### PR TITLE
refactor(all): unify method signatures across backends

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -388,7 +388,7 @@ class _FileIOHandler:
         )
 
     def read_json(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Register a JSON file as a table in the current backend.
 

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -493,7 +493,8 @@ class _FileIOHandler:
         expr
             The ibis expression to execute and persist to parquet.
         directory
-            The data source. A string or Path to the directory where the parquet file will be written.
+            A string or Path to the directory where the parquet file will be
+            written.
         params
             Mapping of scalar parameter expressions to value.
         **kwargs

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -337,7 +337,7 @@ class _FileIOHandler:
         }
 
     def read_parquet(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Register a parquet file as a table in the current backend.
 

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1083,7 +1083,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         """Compile an expression."""
         return self.compiler.to_sql(expr, params=params)
 
-    def execute(self, expr: ir.Expr) -> Any:
+    def execute(self, expr: ir.Expr, /) -> Any:
         """Execute an expression."""
 
     @abc.abstractmethod

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -973,7 +973,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
 
     @abc.abstractmethod
     def table(
-        self, name: str, database: tuple[str, str] | str | None = None
+        self, name: str, /, *, database: tuple[str, str] | str | None = None
     ) -> ir.Table:
         """Construct a table expression.
 

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -588,7 +588,7 @@ class _FileIOHandler:
 
 class CanListCatalog(abc.ABC):
     @abc.abstractmethod
-    def list_catalogs(self, like: str | None = None) -> list[str]:
+    def list_catalogs(self, *, like: str | None = None) -> list[str]:
         """List existing catalogs in the current connection.
 
         ::: {.callout-note}
@@ -624,7 +624,7 @@ class CanListCatalog(abc.ABC):
 
 class CanCreateCatalog(CanListCatalog):
     @abc.abstractmethod
-    def create_catalog(self, name: str, force: bool = False) -> None:
+    def create_catalog(self, name: str, /, *, force: bool = False) -> None:
         """Create a new catalog.
 
         ::: {.callout-note}
@@ -648,7 +648,7 @@ class CanCreateCatalog(CanListCatalog):
         """
 
     @abc.abstractmethod
-    def drop_catalog(self, name: str, force: bool = False) -> None:
+    def drop_catalog(self, name: str, /, *, force: bool = False) -> None:
         """Drop a catalog with name `name`.
 
         ::: {.callout-note}

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -935,7 +935,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
 
     @abc.abstractmethod
     def list_tables(
-        self, like: str | None = None, database: tuple[str, str] | str | None = None
+        self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
         """Return the list of table names in the current database.
 
@@ -1088,6 +1088,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
     def create_table(
         self,
         name: str,
+        /,
         obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: ibis.Schema | None = None,
@@ -1127,6 +1128,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
     def drop_table(
         self,
         name: str,
+        /,
         *,
         database: str | None = None,
         force: bool = False,

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -362,14 +362,15 @@ class _FileIOHandler:
         )
 
     def read_csv(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Register a CSV file as a table in the current backend.
 
         Parameters
         ----------
         path
-            The data source. A string or Path to the CSV file.
+            The data source(s). A string or Path to the CSV file or directory
+            containing CSV files.
         table_name
             An optional name to use for the created table. This defaults to
             a sequentially generated name.

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -675,7 +675,7 @@ class CanCreateCatalog(CanListCatalog):
 class CanListDatabase(abc.ABC):
     @abc.abstractmethod
     def list_databases(
-        self, like: str | None = None, catalog: str | None = None
+        self, *, like: str | None = None, catalog: str | None = None
     ) -> list[str]:
         """List existing databases in the current connection.
 
@@ -716,7 +716,7 @@ class CanListDatabase(abc.ABC):
 class CanCreateDatabase(CanListDatabase):
     @abc.abstractmethod
     def create_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         """Create a database named `name` in `catalog`.
 
@@ -734,7 +734,7 @@ class CanCreateDatabase(CanListDatabase):
 
     @abc.abstractmethod
     def drop_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         """Drop the database with `name` in `catalog`.
 
@@ -778,7 +778,7 @@ class CanCreateSchema(CanListSchema):
     def create_schema(
         self, name: str, database: str | None = None, force: bool = False
     ) -> None:
-        self.create_database(name=name, catalog=database, force=force)
+        self.create_database(name, catalog=database, force=force)
 
     @util.deprecated(
         instead="Use `drop_database` instead", as_of="9.0", removed_in="10.0"
@@ -786,7 +786,7 @@ class CanCreateSchema(CanListSchema):
     def drop_schema(
         self, name: str, database: str | None = None, force: bool = False
     ) -> None:
-        self.drop_database(name=name, catalog=database, force=force)
+        self.drop_database(name, catalog=database, force=force)
 
 
 class BaseBackend(abc.ABC, _FileIOHandler):

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1076,6 +1076,8 @@ class BaseBackend(abc.ABC, _FileIOHandler):
     def compile(
         self,
         expr: ir.Expr,
+        /,
+        *,
         params: Mapping[ir.Expr, Any] | None = None,
     ) -> Any:
         """Compile an expression."""

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1170,6 +1170,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
     def create_view(
         self,
         name: str,
+        /,
         obj: ir.Table,
         *,
         database: str | None = None,
@@ -1198,7 +1199,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
 
     @abc.abstractmethod
     def drop_view(
-        self, name: str, *, database: str | None = None, force: bool = False
+        self, name: str, /, *, database: str | None = None, force: bool = False
     ) -> None:
         """Drop a view.
 

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -413,13 +413,13 @@ class _FileIOHandler:
         )
 
     def read_delta(
-        self, source: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ):
         """Register a Delta Lake table in the current database.
 
         Parameters
         ----------
-        source
+        path
             The data source. Must be a directory
             containing a Delta Lake table.
         table_name

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -274,7 +274,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         )
 
     def read_csv(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Read CSV data into a BigQuery table.
 

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -870,6 +870,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
 
     def list_tables(
         self,
+        *,
         like: str | None = None,
         database: tuple[str, str] | str | None = None,
         schema: str | None = None,
@@ -920,6 +921,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -1073,6 +1075,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     def drop_table(
         self,
         name: str,
+        /,
         *,
         schema: str | None = None,
         database: tuple[str | str] | str | None = None,

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -303,7 +303,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         return self._read_file(path, table_name=table_name, job_config=job_config)
 
     def read_json(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Read newline-delimited JSON data into a BigQuery table.
 

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -533,6 +533,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     def create_database(
         self,
         name: str,
+        /,
+        *,
         catalog: str | None = None,
         force: bool = False,
         collate: str | None = None,
@@ -560,6 +562,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     def drop_database(
         self,
         name: str,
+        /,
+        *,
         catalog: str | None = None,
         force: bool = False,
         cascade: bool = False,

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -246,7 +246,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         return self.table(table_name, database=(catalog, database))
 
     def read_parquet(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ):
         """Read Parquet data into a BigQuery table.
 

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -759,7 +759,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     def insert(
         self,
         table_name: str,
+        /,
         obj: pd.DataFrame | ir.Table | list | dict,
+        *,
         schema: str | None = None,
         database: str | None = None,
         overwrite: bool = False,

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -712,7 +712,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         self._log(sql)
         return sql
 
-    def execute(self, expr, params=None, limit="default", **kwargs):
+    def execute(self, expr, /, *, params=None, limit="default", **kwargs):
         """Compile and execute the given Ibis expression.
 
         Compile and execute Ibis expression using this backend client

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -579,7 +579,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         self.raw_sql(stmt.sql(self.name))
 
     def table(
-        self, name: str, database: str | None = None, schema: str | None = None
+        self, name: str, /, *, database: str | None = None, schema: str | None = None
     ) -> ir.Table:
         table_loc = self._warn_and_create_table_loc(database, schema)
         table = sg.parse_one(f"`{name}`", into=sge.Table, read=self.name)

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -690,6 +690,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     def compile(
         self,
         expr: ir.Expr,
+        /,
+        *,
         limit: str | None = None,
         params=None,
         pretty: bool = True,

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -1101,6 +1101,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     def create_view(
         self,
         name: str,
+        /,
         obj: ir.Table,
         *,
         schema: str | None = None,
@@ -1127,6 +1128,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     def drop_view(
         self,
         name: str,
+        /,
         *,
         schema: str | None = None,
         database: str | None = None,

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -544,6 +544,8 @@ class Backend(SQLBackend, CanCreateDatabase):
     def read_parquet(
         self,
         path: str | Path,
+        /,
+        *,
         table_name: str | None = None,
         engine: str = "MergeTree",
         **kwargs: Any,

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -518,7 +518,7 @@ class Backend(SQLBackend, CanCreateDatabase):
                 pass
 
     def create_database(
-        self, name: str, *, force: bool = False, engine: str = "Atomic"
+        self, name: str, /, *, force: bool = False, engine: str = "Atomic"
     ) -> None:
         src = sge.Create(
             this=sg.to_identifier(name),
@@ -531,7 +531,7 @@ class Backend(SQLBackend, CanCreateDatabase):
         with self._safe_raw_sql(src):
             pass
 
-    def drop_database(self, name: str, *, force: bool = False) -> None:
+    def drop_database(self, name: str, /, *, force: bool = False) -> None:
         src = sge.Drop(this=sg.to_identifier(name), kind="DATABASE", exists=force)
         with self._safe_raw_sql(src):
             pass

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -379,6 +379,8 @@ class Backend(SQLBackend, CanCreateDatabase):
     def execute(
         self,
         expr: ir.Expr,
+        /,
+        *,
         limit: str | None = "default",
         external_tables: Mapping[str, pd.DataFrame] | None = None,
         **kwargs: Any,

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -763,6 +763,7 @@ class Backend(SQLBackend, CanCreateDatabase):
     def create_view(
         self,
         name: str,
+        /,
         obj: ir.Table,
         *,
         database: str | None = None,

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -536,7 +536,7 @@ class Backend(SQLBackend, CanCreateDatabase):
         with self._safe_raw_sql(src):
             pass
 
-    def truncate_table(self, name: str, database: str | None = None) -> None:
+    def truncate_table(self, name: str, /, *, database: str | None = None) -> None:
         ident = sg.table(name, db=database).sql(self.name)
         with self._safe_raw_sql(f"TRUNCATE TABLE {ident}"):
             pass
@@ -598,6 +598,7 @@ class Backend(SQLBackend, CanCreateDatabase):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -572,6 +572,8 @@ class Backend(SQLBackend, CanCreateDatabase):
     def read_csv(
         self,
         path: str | Path,
+        /,
+        *,
         table_name: str | None = None,
         engine: str = "MergeTree",
         **kwargs: Any,

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -27,6 +27,7 @@ from ibis.conftest import WINDOWS
 from ibis.util import promote_tuple
 
 if TYPE_CHECKING:
+    from ibis.backends import BaseBackend
     from ibis.backends.tests.base import BackendTest
 
 
@@ -389,6 +390,22 @@ def pytest_runtest_call(item):
             reason += f"; {provided_reason}"
         if failing_specs:
             item.add_marker(pytest.mark.xfail(reason=reason, **kwargs))
+
+
+def _get_backend_cls(backend_str: str):
+    """Convert a backend string to the test class for the backend."""
+    backend_mod = importlib.import_module(f"ibis.backends.{backend_str}")
+    return backend_mod.Backend
+
+
+@pytest.fixture(params=_get_backends_to_test(), scope="session")
+def backend_cls(request) -> BaseBackend:
+    """Return the uninstantiated backend class, unconnected.
+
+    This is used for signature checking and nothing should be executed."""
+
+    cls = _get_backend_cls(request.param)
+    return cls
 
 
 @pytest.fixture(params=_get_backends_to_test(), scope="session")

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -408,6 +408,19 @@ def backend_cls(request) -> BaseBackend:
     return cls
 
 
+@pytest.fixture(
+    params=_get_backends_to_test(discard=("dask", "pandas", "polars")),
+    scope="session",
+)
+def backend_sql_cls(request, data_dir, tmp_path_factory, worker_id):
+    """Return the uninstantiated backend class, unconnected.
+
+    SQL backends only.
+    This is used for signature checking and nothing should be executed."""
+    cls = _get_backend_cls(request.param)
+    return cls
+
+
 @pytest.fixture(params=_get_backends_to_test(), scope="session")
 def backend(request, data_dir, tmp_path_factory, worker_id) -> BackendTest:
     """Return an instance of BackendTest, loaded with data."""

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -80,6 +80,8 @@ class Backend(BasePandasBackend, NoUrl):
     def compile(
         self,
         expr: ir.Expr,
+        /,
+        *,
         params: dict | None = None,
         limit: int | None = None,
         **kwargs,

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -108,13 +108,18 @@ class Backend(BasePandasBackend, NoUrl):
         return DaskExecutor.execute(expr.op(), backend=self, params=params)
 
     def read_csv(
-        self, source: str | pathlib.Path, table_name: str | None = None, **kwargs: Any
+        self,
+        path: str | pathlib.Path,
+        /,
+        *,
+        table_name: str | None = None,
+        **kwargs: Any,
     ):
         """Register a CSV file as a table in the current session.
 
         Parameters
         ----------
-        source
+        path
             The data source. Can be a local or remote file, pathlike objects
             also accepted.
         table_name
@@ -132,7 +137,7 @@ class Backend(BasePandasBackend, NoUrl):
 
         """
         table_name = table_name or util.gen_name("read_csv")
-        df = dd.read_csv(source, **kwargs)
+        df = dd.read_csv(path, **kwargs)
         self.dictionary[table_name] = df
         return self.table(table_name)
 

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -97,6 +97,8 @@ class Backend(BasePandasBackend, NoUrl):
     def execute(
         self,
         expr: ir.Expr,
+        /,
+        *,
         params: Mapping[ir.Expr, object] | None = None,
         limit: str = "default",
         **kwargs,

--- a/ibis/backends/dask/__init__.py
+++ b/ibis/backends/dask/__init__.py
@@ -142,13 +142,18 @@ class Backend(BasePandasBackend, NoUrl):
         return self.table(table_name)
 
     def read_parquet(
-        self, source: str | pathlib.Path, table_name: str | None = None, **kwargs: Any
+        self,
+        path: str | pathlib.Path,
+        /,
+        *,
+        table_name: str | None = None,
+        **kwargs: Any,
     ):
         """Register a parquet file as a table in the current session.
 
         Parameters
         ----------
-        source
+        path
             The data source(s). May be a path to a file, an iterable of files,
             or directory of parquet files.
         table_name
@@ -166,7 +171,7 @@ class Backend(BasePandasBackend, NoUrl):
 
         """
         table_name = table_name or util.gen_name("read_parquet")
-        df = dd.read_parquet(source, **kwargs)
+        df = dd.read_parquet(path, **kwargs)
         self.dictionary[table_name] = df
         return self.table(table_name)
 

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -577,6 +577,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -684,7 +685,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         return self.table(name, database=database)
 
     def truncate_table(
-        self, name: str, database: str | None = None, schema: str | None = None
+        self, name: str, /, *, database: str | None = None, schema: str | None = None
     ) -> None:
         """Delete all rows from a table.
 

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -426,7 +426,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             self.con.register_dataset(name=name, dataset=empty_dataset)
 
     def read_csv(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Register a CSV file as a table in the current database.
 

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -242,13 +242,13 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         result = self.con.sql(code).to_pydict()
         return self._filter_with_like(result["table_catalog"], like)
 
-    def create_catalog(self, name: str, force: bool = False) -> None:
+    def create_catalog(self, name: str, /, *, force: bool = False) -> None:
         with self._safe_raw_sql(
             sge.Create(kind="DATABASE", this=sg.to_identifier(name), exists=force)
         ):
             pass
 
-    def drop_catalog(self, name: str, force: bool = False) -> None:
+    def drop_catalog(self, name: str, /, *, force: bool = False) -> None:
         raise com.UnsupportedOperationError(
             "DataFusion does not support dropping databases"
         )

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -482,13 +482,13 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         return self.table(table_name)
 
     def read_delta(
-        self, source_table: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Register a Delta Lake table as a table in the current database.
 
         Parameters
         ----------
-        source_table
+        path
             The data source. Must be a directory
             containing a Delta Lake table.
         table_name
@@ -503,7 +503,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             The just-registered table
 
         """
-        source_table = normalize_filename(source_table)
+        source_table = normalize_filename(path)
 
         table_name = table_name or gen_name("read_delta")
 

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -454,7 +454,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         return self.table(table_name)
 
     def read_parquet(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Register a parquet file as a table in the current database.
 

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -568,7 +568,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         arrow_table = batch_reader.read_all()
         return expr.__pyarrow_result__(arrow_table)
 
-    def execute(self, expr: ir.Expr, **kwargs: Any):
+    def execute(self, expr: ir.Expr, /, **kwargs: Any):
         batch_reader = self.to_pyarrow_batches(expr, **kwargs)
         return expr.__pandas_result__(
             batch_reader.read_pandas(timestamp_as_object=True)

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -262,7 +262,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         )
 
     def create_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         # not actually a table, but this is how sqlglot represents schema names
         db_name = sg.table(name, db=catalog)
@@ -270,7 +270,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             pass
 
     def drop_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         db_name = sg.table(name, db=catalog)
         with self._safe_raw_sql(sge.Drop(kind="SCHEMA", this=db_name, exists=force)):

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -155,6 +155,7 @@ class Backend(SQLBackend):
     def create_table(
         self,
         name: str,
+        /,
         obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: sch.Schema | None = None,
@@ -164,7 +165,7 @@ class Backend(SQLBackend):
     ) -> ir.Table:
         raise NotImplementedError()
 
-    def drop_table(self, *args, **kwargs):
+    def drop_table(self, name: str, /, **kwargs):
         raise NotImplementedError()
 
     def list_tables(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1423,6 +1423,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
     def execute(
         self,
         expr: ir.Expr,
+        /,
+        *,
         params: Mapping | None = None,
         limit: str | None = "default",
         **_: Any,

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -636,7 +636,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
 
     def read_csv(
         self,
-        source_list: str | list[str] | tuple[str],
+        path: str | list[str] | tuple[str],
+        /,
+        *,
         table_name: str | None = None,
         columns: Mapping[str, str | dt.DataType] | None = None,
         types: Mapping[str, str | dt.DataType] | None = None,
@@ -646,9 +648,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
 
         Parameters
         ----------
-        source_list
-            The data source(s). May be a path to a file or directory of CSV
-            files, or an iterable of CSV files.
+        path
+            The data source(s). May be a path to a file or directory of CSV files, or an
+            iterable of CSV files.
         table_name
             An optional name to use for the created table. This defaults to a
             sequentially generated name.
@@ -713,7 +715,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         │     2.0 │     3.0 │ <POINT (2 3)>        │
         └─────────┴─────────┴──────────────────────┘
         """
-        source_list = util.normalize_filenames(source_list)
+        source_list = util.normalize_filenames(path)
 
         if not table_name:
             table_name = util.gen_name("read_csv")

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -591,7 +591,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
     @util.experimental
     def read_json(
         self,
-        source_list: str | list[str] | tuple[str],
+        path: str | list[str] | tuple[str],
+        /,
+        *,
         table_name: str | None = None,
         **kwargs,
     ) -> ir.Table:
@@ -603,7 +605,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
 
         Parameters
         ----------
-        source_list
+        path
             File or list of files
         table_name
             Optional table name
@@ -626,9 +628,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         self._create_temp_view(
             table_name,
             sg.select(STAR).from_(
-                self.compiler.f.read_json_auto(
-                    util.normalize_filenames(source_list), *options
-                )
+                self.compiler.f.read_json_auto(util.normalize_filenames(path), *options)
             ),
         )
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -936,7 +936,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
 
     def read_delta(
         self,
-        source_table: str,
+        path: str,
+        /,
+        *,
         table_name: str | None = None,
         **kwargs: Any,
     ) -> ir.Table:
@@ -944,7 +946,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
 
         Parameters
         ----------
-        source_table
+        path
             The data source. Must be a directory
             containing a Delta Lake table.
         table_name
@@ -959,7 +961,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
             The just-registered table.
 
         """
-        source_table = util.normalize_filenames(source_table)[0]
+        source_table = util.normalize_filenames(path)[0]
 
         table_name = table_name or util.gen_name("read_delta")
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -824,7 +824,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
 
     def read_parquet(
         self,
-        source_list: str | Iterable[str],
+        path: str | Iterable[str],
+        /,
+        *,
         table_name: str | None = None,
         **kwargs: Any,
     ) -> ir.Table:
@@ -832,7 +834,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
 
         Parameters
         ----------
-        source_list
+        path
             The data source(s). May be a path to a file, an iterable of files,
             or directory of parquet files.
         table_name
@@ -848,7 +850,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
             The just-registered table
 
         """
-        source_list = util.normalize_filenames(source_list)
+        source_list = util.normalize_filenames(path)
 
         table_name = table_name or util.gen_name("read_parquet")
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -494,7 +494,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         self._load_extensions([extension], force_install=force_install)
 
     def create_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         if catalog is not None:
             raise exc.UnsupportedOperationError(
@@ -506,7 +506,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
             pass
 
     def drop_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         if catalog is not None:
             raise exc.UnsupportedOperationError(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -96,6 +96,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -248,7 +248,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         return self.table(name, database=(catalog, database))
 
     def table(
-        self, name: str, schema: str | None = None, database: str | None = None
+        self, name: str, /, *, schema: str | None = None, database: str | None = None
     ) -> ir.Table:
         """Construct a table expression.
 

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -307,6 +307,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -422,7 +422,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         return schema
 
     def drop_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         if catalog is not None:
             raise NotImplementedError(
@@ -437,7 +437,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
             con.execute(drop_schema.sql(dialect=self.dialect))
 
     def create_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         if catalog is not None:
             raise NotImplementedError(

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -361,7 +361,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
             expr, params=params, pretty=pretty
         )  # Discard `limit` and other kwargs.
 
-    def execute(self, expr: ir.Expr, **kwargs: Any) -> Any:
+    def execute(self, expr: ir.Expr, /, **kwargs: Any) -> Any:
         """Execute an expression."""
         self._register_udfs(expr)
 

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -762,6 +762,8 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def read_parquet(
         self,
         path: str | Path,
+        /,
+        *,
         schema: sch.Schema | None = None,
         table_name: str | None = None,
     ) -> ir.Table:

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -860,7 +860,9 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def insert(
         self,
         table_name: str,
+        /,
         obj: pa.Table | pd.DataFrame | ir.Table | list | dict,
+        *,
         database: str | None = None,
         catalog: str | None = None,
         overwrite: bool = False,

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -485,7 +485,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
             # which may not be ideal. We plan to get back to this later.
             # Ref: https://github.com/ibis-project/ibis/pull/7479#discussion_r1416237088
             return self.create_view(
-                name=name,
+                name,
                 obj=dataframe,
                 schema=schema,
                 database=database,
@@ -586,6 +586,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def create_view(
         self,
         name: str,
+        /,
         obj: pd.DataFrame | ir.Table,
         *,
         schema: sch.Schema | None = None,
@@ -639,7 +640,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
 
         if overwrite and self.list_views(like=name, temp=temp):
             self.drop_view(
-                name=name,
+                name,
                 database=database,
                 catalog=catalog,
                 temp=temp,
@@ -683,6 +684,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def drop_view(
         self,
         name: str,
+        /,
         *,
         database: str | None = None,
         catalog: str | None = None,

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -790,8 +790,10 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def read_csv(
         self,
         path: str | Path,
-        schema: sch.Schema | None = None,
+        /,
+        *,
         table_name: str | None = None,
+        schema: sch.Schema | None = None,
     ) -> ir.Table:
         """Register a csv file as a table in the current database.
 
@@ -799,11 +801,11 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
         ----------
         path
             The data source.
-        schema
-            The schema for the new table.
         table_name
             An optional name to use for the created table. This defaults to
             a sequentially generated name.
+        schema
+            The schema for the new table.
 
         Returns
         -------

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -350,6 +350,8 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def compile(
         self,
         expr: ir.Expr,
+        /,
+        *,
         params: Mapping[ir.Expr, Any] | None = None,
         pretty: bool = False,
         **_: Any,

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -241,6 +241,8 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def table(
         self,
         name: str,
+        /,
+        *,
         database: str | None = None,
         catalog: str | None = None,
     ) -> ir.Table:
@@ -672,7 +674,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
         else:
             raise exc.IbisError(f"Unsupported `obj` type: {type(obj)}")
 
-        return self.table(name=name, database=database, catalog=catalog)
+        return self.table(name, database=database, catalog=catalog)
 
     def drop_view(
         self,

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -115,6 +115,8 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def create_database(
         self,
         name: str,
+        /,
+        *,
         db_properties: dict | None = None,
         catalog: str | None = None,
         force: bool = False,
@@ -140,7 +142,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
         self.raw_sql(statement.compile())
 
     def drop_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         """Drop a database with name `name`.
 

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -822,6 +822,8 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def read_json(
         self,
         path: str | Path,
+        /,
+        *,
         schema: sch.Schema | None = None,
         table_name: str | None = None,
     ) -> ir.Table:

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -372,6 +372,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def create_table(
         self,
         name: str,
+        /,
         obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: sch.Schema | None = None,
@@ -450,7 +451,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
         if overwrite:
             if self.list_tables(like=name, temp=temp):
                 self.drop_table(
-                    name=name,
+                    name,
                     catalog=catalog,
                     database=database,
                     temp=temp,
@@ -522,6 +523,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
     def drop_table(
         self,
         name: str,
+        /,
         *,
         database: str | None = None,
         catalog: str | None = None,
@@ -758,7 +760,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
         }
 
         return self.create_table(
-            name=table_name,
+            table_name,
             schema=schema,
             tbl_properties=tbl_properties,
         )

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -526,7 +526,7 @@ def test_read_parquet(con, data_dir, tmp_path, table_name, functional_alltypes_s
     fname = Path("functional_alltypes.parquet")
     fname = Path(data_dir) / "parquet" / fname.name
     table = con.read_parquet(
-        path=tmp_path / fname.name,
+        tmp_path / fname.name,
         schema=functional_alltypes_schema,
         table_name=table_name,
     )

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -354,7 +354,7 @@ def test_create_view(
     assert temp_table in con.list_tables()
 
     con.create_view(
-        name=temp_view,
+        temp_view,
         obj=table,
         force=False,
         temp=temp,
@@ -366,7 +366,7 @@ def test_create_view(
     # Try to re-create the same view with `force=False`
     with pytest.raises(Py4JJavaError):
         con.create_view(
-            name=temp_view,
+            temp_view,
             obj=table,
             force=False,
             temp=temp,
@@ -376,7 +376,7 @@ def test_create_view(
 
     # Try to re-create the same view with `force=True`
     con.create_view(
-        name=temp_view,
+        temp_view,
         obj=table,
         force=True,
         temp=temp,
@@ -386,7 +386,7 @@ def test_create_view(
 
     # Overwrite the view
     con.create_view(
-        name=temp_view,
+        temp_view,
         obj=table,
         force=False,
         temp=temp,
@@ -394,7 +394,7 @@ def test_create_view(
     )
     assert view_list == sorted(con.list_tables())
 
-    con.drop_view(name=temp_view, temp=temp, force=True)
+    con.drop_view(temp_view, temp=temp, force=True)
     assert temp_view not in con.list_tables()
 
 

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -507,7 +507,7 @@ def test_insert_simple_select(con, tempdir_sink_configs):
 def test_read_csv(con, awards_players_schema, csv_source_configs, table_name):
     source_configs = csv_source_configs("awards_players")
     table = con.read_csv(
-        path=source_configs["path"],
+        source_configs["path"],
         schema=awards_players_schema,
         table_name=table_name,
     )

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -186,7 +186,7 @@ def test_recreate_in_mem_table(con, schema, table_name, temp_table, csv_source_c
         tbl_properties = None
 
     new_table = con.create_table(
-        name=temp_table,
+        temp_table,
         obj=employee_df,
         schema=schema,
         tbl_properties=tbl_properties,
@@ -203,7 +203,7 @@ def test_recreate_in_mem_table(con, schema, table_name, temp_table, csv_source_c
             match=r"An error occurred while calling o\d+\.createTemporaryView",
         ):
             new_table = con.create_table(
-                name=temp_table,
+                temp_table,
                 obj=employee_df,
                 schema=schema,
                 tbl_properties=tbl_properties,
@@ -229,7 +229,7 @@ def test_force_recreate_in_mem_table(con, schema_props, temp_table, csv_source_c
         tbl_properties = None
 
     new_table = con.create_table(
-        name=temp_table,
+        temp_table,
         obj=employee_df,
         schema=schema,
         tbl_properties=tbl_properties,
@@ -242,7 +242,7 @@ def test_force_recreate_in_mem_table(con, schema_props, temp_table, csv_source_c
 
         # force recreate the same table a second time should succeed
         new_table = con.create_table(
-            name=temp_table,
+            temp_table,
             obj=employee_df,
             schema=schema,
             tbl_properties=tbl_properties,
@@ -347,7 +347,7 @@ def test_create_view(
     con, temp_table, awards_players_schema, csv_source_configs, temp_view, temp
 ):
     table = con.create_table(
-        name=temp_table,
+        temp_table,
         schema=awards_players_schema,
         tbl_properties=csv_source_configs("awards_players"),
     )
@@ -401,7 +401,7 @@ def test_create_view(
 def test_rename_table(con, awards_players_schema, temp_table, csv_source_configs):
     table_name = temp_table
     con.create_table(
-        name=table_name,
+        table_name,
         schema=awards_players_schema,
         tbl_properties=csv_source_configs("awards_players"),
     )

--- a/ibis/backends/flink/tests/test_ddl.py
+++ b/ibis/backends/flink/tests/test_ddl.py
@@ -553,7 +553,7 @@ def test_read_json(con, data_dir, tmp_path, table_name, functional_alltypes_sche
     path = tmp_path / "functional_alltypes.json"
     df.to_json(path, orient="records", lines=True, date_format="iso")
     table = con.read_json(
-        path=path, schema=functional_alltypes_schema, table_name=table_name
+        path, schema=functional_alltypes_schema, table_name=table_name
     )
 
     try:

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -297,7 +297,7 @@ class Backend(SQLBackend):
             [(db,)] = cur.fetchall()
         return db
 
-    def create_database(self, name, path=None, force=False):
+    def create_database(self, name, /, *, path=None, force=False):
         """Create a new Impala database.
 
         Parameters
@@ -313,7 +313,7 @@ class Backend(SQLBackend):
         statement = CreateDatabase(name, path=path, can_exist=force)
         self._safe_exec_sql(statement)
 
-    def drop_database(self, name, force=False):
+    def drop_database(self, name, /, *, force=False):
         """Drop an Impala database.
 
         Parameters

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -435,6 +435,7 @@ class Backend(SQLBackend):
     def create_view(
         self,
         name: str,
+        /,
         obj: ir.Table,
         *,
         database: str | None = None,
@@ -445,7 +446,7 @@ class Backend(SQLBackend):
         self._safe_exec_sql(statement)
         return self.table(name, database=database)
 
-    def drop_view(self, name, database=None, force=False):
+    def drop_view(self, name, /, *, database=None, force=False):
         stmt = DropView(name, database=database, must_exist=not force)
         self._safe_exec_sql(stmt)
 

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -458,6 +458,7 @@ class Backend(SQLBackend):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -772,7 +773,7 @@ class Backend(SQLBackend):
         )
 
     def drop_table(
-        self, name: str, *, database: str | None = None, force: bool = False
+        self, name: str, /, *, database: str | None = None, force: bool = False
     ) -> None:
         """Drop an Impala table.
 
@@ -795,7 +796,7 @@ class Backend(SQLBackend):
         statement = DropTable(name, database=database, must_exist=not force)
         self._safe_exec_sql(statement)
 
-    def truncate_table(self, name: str, database: str | None = None) -> None:
+    def truncate_table(self, name: str, /, *, database: str | None = None) -> None:
         """Delete all rows from an existing table.
 
         Parameters

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -739,7 +739,9 @@ class Backend(SQLBackend):
     def insert(
         self,
         table_name,
-        obj=None,
+        /,
+        obj,
+        *,
         database=None,
         overwrite=False,
         partition=None,

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -449,7 +449,9 @@ class Backend(SQLBackend):
         stmt = DropView(name, database=database, must_exist=not force)
         self._safe_exec_sql(stmt)
 
-    def table(self, name: str, database: str | None = None, **kwargs: Any) -> ir.Table:
+    def table(
+        self, name: str, /, *, database: str | None = None, **kwargs: Any
+    ) -> ir.Table:
         expr = super().table(name, database=database, **kwargs)
         return ImpalaTable(expr.op())
 

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -342,7 +342,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         cursor.execute(query, **kwargs)
         return cursor
 
-    def create_catalog(self, name: str, force: bool = False) -> None:
+    def create_catalog(self, name: str, /, *, force: bool = False) -> None:
         expr = (
             sg.select(STAR)
             .from_(sg.table("databases", db="sys"))
@@ -364,7 +364,7 @@ GO"""
         with self._safe_ddl(create_stmt):
             pass
 
-    def drop_catalog(self, name: str, force: bool = False) -> None:
+    def drop_catalog(self, name: str, /, *, force: bool = False) -> None:
         with self._safe_ddl(
             sge.Drop(
                 kind="DATABASE",

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -375,7 +375,7 @@ GO"""
             pass
 
     def create_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         current_catalog = self.current_catalog
         should_switch_catalog = catalog is not None and catalog != current_catalog
@@ -419,7 +419,7 @@ GO"""
                 )
 
     def drop_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         current_catalog = self.current_catalog
         should_switch_catalog = catalog is not None and catalog != current_catalog

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -521,6 +521,7 @@ GO"""
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -237,14 +237,14 @@ class Backend(SQLBackend, CanCreateDatabase):
 
         return sch.Schema(fields)
 
-    def create_database(self, name: str, force: bool = False) -> None:
+    def create_database(self, name: str, /, *, force: bool = False) -> None:
         sql = sge.Create(kind="DATABASE", exist=force, this=sg.to_identifier(name)).sql(
             self.name
         )
         with self.begin() as cur:
             cur.execute(sql)
 
-    def drop_database(self, name: str, force: bool = False) -> None:
+    def drop_database(self, name: str, /, *, force: bool = False) -> None:
         sql = sge.Drop(kind="DATABASE", exist=force, this=sg.to_identifier(name)).sql(
             self.name
         )

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -364,7 +364,7 @@ class Backend(SQLBackend, CanCreateDatabase):
         return self._filter_with_like(map(itemgetter(0), out), like)
 
     def execute(
-        self, expr: ir.Expr, limit: str | None = "default", **kwargs: Any
+        self, expr: ir.Expr, /, *, limit: str | None = "default", **kwargs: Any
     ) -> Any:
         """Execute an expression."""
 

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -381,6 +381,7 @@ class Backend(SQLBackend, CanCreateDatabase):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -235,6 +235,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
 
     def list_tables(
         self,
+        *,
         like: str | None = None,
         schema: str | None = None,
         database: tuple[str, str] | str | None = None,
@@ -367,6 +368,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -460,9 +462,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 cur.execute(insert_stmt)
 
             if overwrite:
-                self.drop_table(
-                    name=final_table.name, database=final_table.db, force=True
-                )
+                self.drop_table(final_table.name, database=final_table.db, force=True)
                 cur.execute(
                     f"ALTER TABLE IF EXISTS {initial_table.sql(self.name)} RENAME TO {final_table.sql(self.name)}"
                 )
@@ -482,6 +482,8 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
     def drop_table(
         self,
         name: str,
+        /,
+        *,
         database: tuple[str, str] | str | None = None,
         force: bool = False,
     ) -> None:

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -313,7 +313,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
 class Backend(BasePandasBackend):
     name = "pandas"
 
-    def execute(self, query, params=None, limit="default", **kwargs):
+    def execute(self, expr, /, *, params=None, limit="default", **kwargs):
         from ibis.backends.pandas.executor import PandasExecutor
 
         if limit != "default" and limit is not None:
@@ -322,15 +322,15 @@ class Backend(BasePandasBackend):
                 "pandas backend"
             )
 
-        if not isinstance(query, ir.Expr):
+        if not isinstance(expr, ir.Expr):
             raise TypeError(
-                f"`query` has type {type(query).__name__!r}, expected ibis.expr.types.Expr"
+                f"`expr` has type {type(expr).__name__!r}, expected ibis.expr.types.Expr"
             )
 
         params = params or {}
         params = {k.op() if isinstance(k, ir.Expr) else k: v for k, v in params.items()}
 
-        return PandasExecutor.execute(query.op(), backend=self, params=params)
+        return PandasExecutor.execute(expr.op(), backend=self, params=params)
 
     def _load_into_cache(self, name, expr):
         self.create_table(name, expr.execute())

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -195,6 +195,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
     def create_table(
         self,
         name: str,
+        /,
         obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: sch.Schema | None = None,
@@ -246,7 +247,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
     def drop_view(self, name: str, *, force: bool = False) -> None:
         self.drop_table(name, force=force)
 
-    def drop_table(self, name: str, *, force: bool = False) -> None:
+    def drop_table(self, name: str, /, *, force: bool = False) -> None:
         try:
             del self.dictionary[name]
         except KeyError:

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -121,13 +121,18 @@ class BasePandasBackend(BaseBackend, NoUrl):
         return self.table(table_name)
 
     def read_parquet(
-        self, source: str | pathlib.Path, table_name: str | None = None, **kwargs: Any
+        self,
+        path: str | pathlib.Path,
+        /,
+        *,
+        table_name: str | None = None,
+        **kwargs: Any,
     ):
         """Register a parquet file as a table in the current session.
 
         Parameters
         ----------
-        source
+        path
             The data source(s). May be a path to a file, an iterable of files,
             or directory of parquet files.
         table_name
@@ -145,7 +150,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
 
         """
         table_name = table_name or util.gen_name("read_parquet")
-        df = pd.read_parquet(source, **kwargs)
+        df = pd.read_parquet(path, **kwargs)
         self.dictionary[table_name] = df
         return self.table(table_name)
 

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -87,13 +87,18 @@ class BasePandasBackend(BaseBackend, NoUrl):
         return client.table(name)
 
     def read_csv(
-        self, source: str | pathlib.Path, table_name: str | None = None, **kwargs: Any
+        self,
+        path: str | pathlib.Path,
+        /,
+        *,
+        table_name: str | None = None,
+        **kwargs: Any,
     ):
         """Register a CSV file as a table in the current session.
 
         Parameters
         ----------
-        source
+        path
             The data source. Can be a local or remote file, pathlike objects
             also accepted.
         table_name
@@ -111,7 +116,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
 
         """
         table_name = table_name or util.gen_name("read_csv")
-        df = pd.read_csv(source, **kwargs)
+        df = pd.read_csv(path, **kwargs)
         self.dictionary[table_name] = df
         return self.table(table_name)
 

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -175,7 +175,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
         """
         return self._filter_with_like(list(self.dictionary.keys()), like)
 
-    def table(self, name: str, schema: sch.Schema | None = None):
+    def table(self, name: str, /, *, schema: sch.Schema | None = None):
         inferred_schema = self.get_schema(name)
         overridden_schema = {**inferred_schema, **(schema or {})}
         return ops.DatabaseTable(name, overridden_schema, self).to_expr()

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -189,7 +189,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
 
         return schema
 
-    def compile(self, expr, *args, **kwargs):
+    def compile(self, expr, /, **kwargs):
         return expr
 
     def create_table(

--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -235,6 +235,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
     def create_view(
         self,
         name: str,
+        /,
         obj: ir.Table,
         *,
         database: str | None = None,
@@ -244,7 +245,7 @@ class BasePandasBackend(BaseBackend, NoUrl):
             name, obj=obj, temp=None, database=database, overwrite=overwrite
         )
 
-    def drop_view(self, name: str, *, force: bool = False) -> None:
+    def drop_view(self, name: str, /, *, force: bool = False) -> None:
         self.drop_table(name, force=force)
 
     def drop_table(self, name: str, /, *, force: bool = False) -> None:

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -439,7 +439,12 @@ class Backend(BaseBackend, NoUrl):
         return operation in op_classes or issubclass(operation, op_classes)
 
     def compile(
-        self, expr: ir.Expr, params: Mapping[ir.Expr, object] | None = None, **_: Any
+        self,
+        expr: ir.Expr,
+        /,
+        *,
+        params: Mapping[ir.Expr, object] | None = None,
+        **_: Any,
     ):
         if params is None:
             params = dict()

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -165,6 +165,8 @@ class Backend(BaseBackend, NoUrl):
     def read_csv(
         self,
         path: str | Path | list[str | Path] | tuple[str | Path],
+        /,
+        *,
         table_name: str | None = None,
         **kwargs: Any,
     ) -> ir.Table:

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -489,6 +489,8 @@ class Backend(BaseBackend, NoUrl):
     def execute(
         self,
         expr: ir.Expr,
+        /,
+        *,
         params: Mapping[ir.Expr, object] | None = None,
         limit: int | None = None,
         streaming: bool = False,

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -209,7 +209,7 @@ class Backend(BaseBackend, NoUrl):
         return self.table(table_name)
 
     def read_json(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Register a JSON file as a table.
 

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -71,7 +71,7 @@ class Backend(BaseBackend, NoUrl):
     def list_tables(self, like=None, database=None):
         return self._filter_with_like(list(self._tables.keys()), like)
 
-    def table(self, name: str) -> ir.Table:
+    def table(self, name: str, /, *, _schema: sch.Schema | None = None) -> ir.Table:
         schema = sch.infer(self._tables[name])
         return ops.DatabaseTable(name, schema, self).to_expr()
 

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -241,7 +241,7 @@ class Backend(BaseBackend, NoUrl):
         return self.table(table_name)
 
     def read_delta(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Register a Delta Lake as a table in the current database.
 

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -307,6 +307,8 @@ class Backend(BaseBackend, NoUrl):
     def read_parquet(
         self,
         path: str | Path | Iterable[str],
+        /,
+        *,
         table_name: str | None = None,
         **kwargs: Any,
     ) -> ir.Table:

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -400,6 +400,7 @@ class Backend(BaseBackend, NoUrl):
     def create_view(
         self,
         name: str,
+        /,
         obj: ir.Table,
         *,
         database: str | None = None,
@@ -415,7 +416,7 @@ class Backend(BaseBackend, NoUrl):
         elif not force:
             raise com.IbisError(f"Table {name!r} does not exist")
 
-    def drop_view(self, name: str, *, force: bool = False) -> None:
+    def drop_view(self, name: str, /, *, force: bool = False) -> None:
         self.drop_table(name, force=force)
 
     def get_schema(self, table_name):

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -357,6 +357,7 @@ class Backend(BaseBackend, NoUrl):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -408,7 +409,7 @@ class Backend(BaseBackend, NoUrl):
             name, obj=obj, temp=None, database=database, overwrite=overwrite
         )
 
-    def drop_table(self, name: str, *, force: bool = False) -> None:
+    def drop_table(self, name: str, /, *, force: bool = False) -> None:
         if name in self._tables:
             del self._tables[name]
         elif not force:

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -621,6 +621,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -727,6 +728,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
     def drop_table(
         self,
         name: str,
+        /,
+        *,
         database: str | None = None,
         force: bool = False,
     ) -> None:

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -583,7 +583,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
                 pass
 
     def create_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         if catalog is not None and catalog != self.current_catalog:
             raise exc.UnsupportedOperationError(
@@ -598,6 +598,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
     def drop_database(
         self,
         name: str,
+        /,
+        *,
         catalog: str | None = None,
         force: bool = False,
         cascade: bool = False,

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -436,6 +436,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def create_database(
         self,
         name: str,
+        /,
         *,
         catalog: str | None = None,
         path: str | Path | None = None,
@@ -473,7 +474,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
                 pass
 
     def drop_database(
-        self, name: str, *, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> Any:
         """Drop a Spark database.
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -782,7 +782,9 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
 
     def read_csv(
         self,
-        source_list: str | list[str] | tuple[str],
+        path: str | list[str] | tuple[str],
+        /,
+        *,
         table_name: str | None = None,
         **kwargs: Any,
     ) -> ir.Table:
@@ -790,7 +792,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
 
         Parameters
         ----------
-        source_list
+        path
             The data source(s). May be a path to a file or directory of CSV files, or an
             iterable of CSV files.
         table_name
@@ -813,7 +815,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
             )
         inferSchema = kwargs.pop("inferSchema", True)
         header = kwargs.pop("header", True)
-        source_list = normalize_filenames(source_list)
+        source_list = normalize_filenames(path)
         spark_df = self._session.read.csv(
             source_list, inferSchema=inferSchema, header=header, **kwargs
         )

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -619,6 +619,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def create_view(
         self,
         name: str,
+        /,
         obj: ir.Table,
         *,
         database: str | None = None,

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -746,6 +746,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def read_parquet(
         self,
         path: str | Path,
+        /,
+        *,
         table_name: str | None = None,
         **kwargs: Any,
     ) -> ir.Table:

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -532,9 +532,13 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def create_table(
         self,
         name: str,
-        obj: (
-            ir.Table | pd.DataFrame | pa.Table | pl.DataFrame | pl.LazyFrame | None
-        ) = None,
+        /,
+        obj: ir.Table
+        | pd.DataFrame
+        | pa.Table
+        | pl.DataFrame
+        | pl.LazyFrame
+        | None = None,
         *,
         schema: sch.Schema | None = None,
         database: str | None = None,

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -416,6 +416,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def execute(
         self,
         expr: ir.Expr,
+        /,
+        *,
         params: Mapping | None = None,
         limit: str | None = "default",
         **kwargs: Any,

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -710,6 +710,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def read_delta(
         self,
         path: str | Path,
+        /,
+        *,
         table_name: str | None = None,
         **kwargs: Any,
     ) -> ir.Table:

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -828,7 +828,9 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
 
     def read_json(
         self,
-        source_list: str | Sequence[str],
+        path: str | Sequence[str],
+        /,
+        *,
         table_name: str | None = None,
         **kwargs: Any,
     ) -> ir.Table:
@@ -836,7 +838,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
 
         Parameters
         ----------
-        source_list
+        path
             The data source(s). May be a path to a file or directory of JSON files, or an
             iterable of JSON files.
         table_name
@@ -857,7 +859,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
                 "Pyspark in streaming mode does not support direction registration of JSON files. "
                 "Please use `read_json_dir` instead."
             )
-        source_list = normalize_filenames(source_list)
+        source_list = normalize_filenames(path)
         spark_df = self._session.read.json(source_list, **kwargs)
         table_name = table_name or util.gen_name("read_json")
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1314,7 +1314,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def to_parquet_dir(
         self,
         expr: ir.Expr,
-        path: str | Path,
+        directory: str | Path,
+        *,
         params: Mapping[ir.Scalar, Any] | None = None,
         limit: int | str | None = None,
         options: Mapping[str, str] | None = None,
@@ -1325,8 +1326,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
         ----------
         expr
             The ibis expression to execute and persist to parquet.
-        path
-            The data source. A string or Path to the parquet directory.
+        directory
+            A string or Path to the parquet directory.
         params
             Mapping of scalar parameter expressions to value.
         limit
@@ -1341,7 +1342,9 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
             Returns a Pyspark StreamingQuery object if in streaming mode, otherwise None
         """
         self._run_pre_execute_hooks(expr)
-        return self._to_filesystem_output(expr, "parquet", path, params, limit, options)
+        return self._to_filesystem_output(
+            expr, "parquet", directory, params, limit, options
+        )
 
     @util.experimental
     def to_csv_dir(

--- a/ibis/backends/pyspark/tests/test_import_export.py
+++ b/ibis/backends/pyspark/tests/test_import_export.py
@@ -12,7 +12,7 @@ from ibis.backends.pyspark.datatypes import PySparkSchema
 @pytest.mark.parametrize(
     "method",
     [
-        methodcaller("read_delta", path="test.delta"),
+        methodcaller("read_delta", "test.delta"),
         methodcaller("read_csv", "test.csv"),
         methodcaller("read_parquet", "test.parquet"),
         methodcaller("read_json", "test.json"),

--- a/ibis/backends/pyspark/tests/test_import_export.py
+++ b/ibis/backends/pyspark/tests/test_import_export.py
@@ -66,7 +66,7 @@ def test_to_parquet_dir(con_streaming, tmp_path):
     path = tmp_path / "out"
     con_streaming.to_parquet_dir(
         t.limit(5),
-        path=path,
+        directory=path,
         options={"checkpointLocation": tmp_path / "checkpoint"},
     )
     sleep(2)

--- a/ibis/backends/pyspark/tests/test_import_export.py
+++ b/ibis/backends/pyspark/tests/test_import_export.py
@@ -13,7 +13,7 @@ from ibis.backends.pyspark.datatypes import PySparkSchema
     "method",
     [
         methodcaller("read_delta", path="test.delta"),
-        methodcaller("read_csv", source_list="test.csv"),
+        methodcaller("read_csv", "test.csv"),
         methodcaller("read_parquet", path="test.parquet"),
         methodcaller("read_json", source_list="test.json"),
     ],

--- a/ibis/backends/pyspark/tests/test_import_export.py
+++ b/ibis/backends/pyspark/tests/test_import_export.py
@@ -14,7 +14,7 @@ from ibis.backends.pyspark.datatypes import PySparkSchema
     [
         methodcaller("read_delta", path="test.delta"),
         methodcaller("read_csv", "test.csv"),
-        methodcaller("read_parquet", path="test.parquet"),
+        methodcaller("read_parquet", "test.parquet"),
         methodcaller("read_json", source_list="test.json"),
     ],
 )

--- a/ibis/backends/pyspark/tests/test_import_export.py
+++ b/ibis/backends/pyspark/tests/test_import_export.py
@@ -15,7 +15,7 @@ from ibis.backends.pyspark.datatypes import PySparkSchema
         methodcaller("read_delta", path="test.delta"),
         methodcaller("read_csv", "test.csv"),
         methodcaller("read_parquet", "test.parquet"),
-        methodcaller("read_json", source_list="test.json"),
+        methodcaller("read_json", "test.json"),
     ],
 )
 def test_streaming_import_not_implemented(con_streaming, method):

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -123,6 +123,7 @@ class Backend(PostgresBackend):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table

--- a/ibis/backends/risingwave/tests/test_streaming.py
+++ b/ibis/backends/risingwave/tests/test_streaming.py
@@ -68,7 +68,7 @@ def test_mv_on_table_with_connector(con):
         "datagen.split.num": "1",
     }
     tblc = con.create_table(
-        name=tblc_name,
+        tblc_name,
         obj=None,
         schema=schema,
         connector_properties=connector_properties,

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -866,7 +866,7 @@ $$ {defn["source"]} $$"""
         return self.table(name, database=(catalog, db))
 
     def read_csv(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Register a CSV file as a table in the Snowflake backend.
 

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -698,7 +698,7 @@ $$ {defn["source"]} $$"""
             pass
 
     def create_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         current_catalog = self.current_catalog
         current_database = self.current_database
@@ -738,7 +738,7 @@ $$ {defn["source"]} $$"""
             return cur
 
     def drop_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         if self.current_database == name and (
             catalog is None or self.current_catalog == catalog

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -665,7 +665,7 @@ $$ {defn["source"]} $$"""
                     with contextlib.suppress(Exception):
                         shutil.rmtree(tmpdir.name)
 
-    def create_catalog(self, name: str, force: bool = False) -> None:
+    def create_catalog(self, name: str, /, *, force: bool = False) -> None:
         current_catalog = self.current_catalog
         current_database = self.current_database
         quoted = self.compiler.quoted
@@ -683,7 +683,7 @@ $$ {defn["source"]} $$"""
             # so we switch back to the original database and schema
             cur.execute(use_stmt)
 
-    def drop_catalog(self, name: str, force: bool = False) -> None:
+    def drop_catalog(self, name: str, /, *, force: bool = False) -> None:
         current_catalog = self.current_catalog
         if name == current_catalog:
             raise com.UnsupportedOperationError(

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -995,7 +995,7 @@ $$ {defn["source"]} $$"""
         return self.table(table)
 
     def read_json(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Read newline-delimited JSON into an ibis table, using Snowflake.
 

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -1179,7 +1179,9 @@ $$ {defn["source"]} $$"""
     def insert(
         self,
         table_name: str,
+        /,
         obj: pd.DataFrame | ir.Table | list | dict,
+        *,
         schema: str | None = None,
         database: str | None = None,
         overwrite: bool = False,

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -758,6 +758,7 @@ $$ {defn["source"]} $$"""
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -1084,7 +1084,7 @@ $$ {defn["source"]} $$"""
         return self.table(table)
 
     def read_parquet(
-        self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Read a Parquet file into an ibis table, using Snowflake.
 

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -267,6 +267,8 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
     def execute(
         self,
         expr: ir.Expr,
+        /,
+        *,
         params: Mapping | None = None,
         limit: str | None = "default",
         **kwargs: Any,

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -109,6 +109,8 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
     def table(
         self,
         name: str,
+        /,
+        *,
         schema: str | None = None,
         database: tuple[str, str] | str | None = None,
     ) -> ir.Table:

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -286,6 +286,8 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
     def drop_table(
         self,
         name: str,
+        /,
+        *,
         database: tuple[str, str] | str | None = None,
         force: bool = False,
     ) -> None:
@@ -494,7 +496,7 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         ).sql(self.dialect)
 
     def truncate_table(
-        self, name: str, database: str | None = None, schema: str | None = None
+        self, name: str, /, *, database: str | None = None, schema: str | None = None
     ) -> None:
         """Delete all rows from a table.
 

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -147,6 +147,8 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
     def compile(
         self,
         expr: ir.Expr,
+        /,
+        *,
         limit: str | None = None,
         params: Mapping[ir.Expr, Any] | None = None,
         pretty: bool = False,

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -219,6 +219,7 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
     def create_view(
         self,
         name: str,
+        /,
         obj: ir.Table,
         *,
         database: str | None = None,
@@ -242,6 +243,7 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
     def drop_view(
         self,
         name: str,
+        /,
         *,
         database: str | None = None,
         schema: str | None = None,

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -371,7 +371,9 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
     def insert(
         self,
         table_name: str,
+        /,
         obj: pd.DataFrame | ir.Table | list | dict,
+        *,
         schema: str | None = None,
         database: str | None = None,
         overwrite: bool = False,

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -560,6 +560,7 @@ class Backend(SQLBackend, UrlFromPath):
     def create_view(
         self,
         name: str,
+        /,
         obj: ir.Table,
         *,
         database: str | None = None,

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -429,6 +429,7 @@ class Backend(SQLBackend, UrlFromPath):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -543,6 +544,8 @@ class Backend(SQLBackend, UrlFromPath):
     def drop_table(
         self,
         name: str,
+        /,
+        *,
         database: str | None = None,
         force: bool = False,
     ) -> None:

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -592,7 +592,9 @@ class Backend(SQLBackend, UrlFromPath):
     def insert(
         self,
         table_name: str,
+        /,
         obj: pd.DataFrame | ir.Table | list | dict,
+        *,
         database: str | None = None,
         overwrite: bool = False,
     ) -> None:

--- a/ibis/backends/tests/signature/tests/test_compatible.py
+++ b/ibis/backends/tests/signature/tests/test_compatible.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # noqa: INP001
 
 from inspect import signature
+from typing import Any
 
 import pytest
 from pytest import param
@@ -8,8 +9,26 @@ from pytest import param
 from ibis.backends.tests.signature.typecheck import compatible
 
 
+def a1(posarg: int): ...
+
+
+def b1(posarg: str): ...
+
+
+def a2(posarg: int, **kwargs: Any): ...
+def b2(posarg: str, **kwargs): ...
+
+
+def a3(posarg: int, other_kwarg: bool = True, **kwargs: Any): ...
+def b3(posarg: str, **kwargs: Any): ...
+
+
+def a4(posarg: int, other_kwarg=True, **kwargs: Any): ...
+def b4(posarg: str, **kwargs: Any): ...
+
+
 @pytest.mark.parametrize(
-    "a, b, expected",
+    "a, b, check_annotations",
     [
         param(
             lambda posarg, *, kwarg1=None, kwarg2=None: ...,
@@ -30,19 +49,71 @@ from ibis.backends.tests.signature.typecheck import compatible
             id="swapped kwarg order w/extra kwarg second",
         ),
         param(
+            a1,
+            b1,
+            False,
+            id="annotations diff types w/out anno check",
+        ),
+        param(
+            a2,
+            b3,
+            False,
+            id="annotations different but parity in annotations",
+        ),
+        param(
+            a3,
+            b3,
+            False,
+            id="annotations different but parity in annotations for matching kwargs",
+        ),
+        param(
+            a4,
+            b4,
+            False,
+            id="annotations different but parity in annotations for matching kwargs",
+        ),
+        param(
+            a2,
+            b2,
+            False,
+            id="annotations different, no anno check, but missing annotation",
+        ),
+    ],
+)
+def test_sigs_compatible(a, b, check_annotations):
+    sig_a, sig_b = signature(a), signature(b)
+    assert compatible(sig_a, sig_b, check_annotations=check_annotations)
+
+
+@pytest.mark.parametrize(
+    "a, b, check_annotations",
+    [
+        param(
             lambda posarg, /, *, kwarg2=None, kwarg1=None: ...,
             lambda posarg, *, kwarg1=None, kwarg2=None, kwarg3=None: ...,
-            False,
+            True,
             id="one positional only",
         ),
         param(
             lambda posarg, *, kwarg1=None, kwarg2=None: ...,
             lambda posarg, kwarg1=None, kwarg2=None: ...,
-            False,
+            True,
             id="not kwarg only",
+        ),
+        param(
+            a1,
+            b1,
+            True,
+            id="annotations diff types w/anno check",
+        ),
+        param(
+            a2,
+            b3,
+            True,
+            id="annotations different but parity in annotations",
         ),
     ],
 )
-def test_sigs_compatible(a, b, expected):
+def test_sigs_incompatible(a, b, check_annotations):
     sig_a, sig_b = signature(a), signature(b)
-    assert compatible(sig_a, sig_b) == expected
+    assert not compatible(sig_a, sig_b, check_annotations=check_annotations)

--- a/ibis/backends/tests/signature/tests/test_compatible.py
+++ b/ibis/backends/tests/signature/tests/test_compatible.py
@@ -1,0 +1,48 @@
+from __future__ import annotations  # noqa: INP001
+
+from inspect import signature
+
+import pytest
+from pytest import param
+
+from ibis.backends.tests.signature.typecheck import compatible
+
+
+@pytest.mark.parametrize(
+    "a, b, expected",
+    [
+        param(
+            lambda posarg, *, kwarg1=None, kwarg2=None: ...,
+            lambda posarg, *, kwarg2=None, kwarg1=None: ...,
+            True,
+            id="swapped kwarg order",
+        ),
+        param(
+            lambda posarg, *, kwarg1=None, kwarg2=None, kwarg3=None: ...,
+            lambda posarg, *, kwarg2=None, kwarg1=None: ...,
+            True,
+            id="swapped kwarg order w/extra kwarg first",
+        ),
+        param(
+            lambda posarg, *, kwarg2=None, kwarg1=None: ...,
+            lambda posarg, *, kwarg1=None, kwarg2=None, kwarg3=None: ...,
+            True,
+            id="swapped kwarg order w/extra kwarg second",
+        ),
+        param(
+            lambda posarg, /, *, kwarg2=None, kwarg1=None: ...,
+            lambda posarg, *, kwarg1=None, kwarg2=None, kwarg3=None: ...,
+            False,
+            id="one positional only",
+        ),
+        param(
+            lambda posarg, *, kwarg1=None, kwarg2=None: ...,
+            lambda posarg, kwarg1=None, kwarg2=None: ...,
+            False,
+            id="not kwarg only",
+        ),
+    ],
+)
+def test_sigs_compatible(a, b, expected):
+    sig_a, sig_b = signature(a), signature(b)
+    assert compatible(sig_a, sig_b) == expected

--- a/ibis/backends/tests/signature/tests/test_compatible.py
+++ b/ibis/backends/tests/signature/tests/test_compatible.py
@@ -27,6 +27,10 @@ def a4(posarg: int, other_kwarg=True, **kwargs: Any): ...
 def b4(posarg: str, **kwargs: Any): ...
 
 
+def a5(posarg: int, /): ...
+def b5(posarg2: str, /): ...
+
+
 @pytest.mark.parametrize(
     "a, b, check_annotations",
     [
@@ -111,6 +115,12 @@ def test_sigs_compatible(a, b, check_annotations):
             b3,
             True,
             id="annotations different but parity in annotations",
+        ),
+        param(
+            a5,
+            b5,
+            False,
+            id="names different, but positional only",
         ),
     ],
 )

--- a/ibis/backends/tests/signature/typecheck.py
+++ b/ibis/backends/tests/signature/typecheck.py
@@ -1,0 +1,116 @@
+"""The following was forked from the python-interface project:
+
+* Copyright (c) 2016-2021, Scott Sanderson
+
+Utilities for typed interfaces.
+"""
+
+# ruff: noqa: D205, D415, D400
+
+from __future__ import annotations
+
+from inspect import Parameter, Signature
+from itertools import starmap, takewhile, zip_longest
+
+
+def valfilter(f, d):
+    return {k: v for k, v in d.items() if f(v)}
+
+
+def dzip(left, right):
+    return {k: (left.get(k), right.get(k)) for k in left.keys() & right.keys()}
+
+
+def complement(f):
+    def not_f(*args, **kwargs):
+        return not f(*args, **kwargs)
+
+    return not_f
+
+
+def compatible(impl_sig: Signature, iface_sig: Signature) -> bool:
+    """Check whether ``impl_sig`` is compatible with ``iface_sig``.
+
+    Parameters
+    ----------
+    impl_sig
+        The signature of the implementation function.
+    iface_sig
+        The signature of the interface function.
+
+    In general, an implementation is compatible with an interface if any valid
+    way of passing parameters to the interface method is also valid for the
+    implementation.
+
+    Consequently, the following differences are allowed between the signature
+    of an implementation method and the signature of its interface definition:
+
+    1. An implementation may add new arguments to an interface iff:
+       a. All new arguments have default values.
+       b. All new arguments accepted positionally (i.e. all non-keyword-only
+          arguments) occur after any arguments declared by the interface.
+       c. Keyword-only arguments may be reordered by the implementation.
+
+    2. For type-annotated interfaces, type annotations my differ as follows:
+       a. Arguments to implementations of an interface may be annotated with
+          a **superclass** of the type specified by the interface.
+       b. The return type of an implementation may be annotated with a
+          **subclass** of the type specified by the interface.
+    """
+    # Unwrap to get the underlying inspect.Signature objects.
+    return all(
+        [
+            positionals_compatible(
+                takewhile(is_positional, impl_sig.parameters.values()),
+                takewhile(is_positional, iface_sig.parameters.values()),
+            ),
+            keywords_compatible(
+                valfilter(complement(is_positional), impl_sig.parameters),
+                valfilter(complement(is_positional), iface_sig.parameters),
+            ),
+        ]
+    )
+
+
+_POSITIONALS = frozenset([Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD])
+
+
+def is_positional(arg):
+    return arg.kind in _POSITIONALS
+
+
+def has_default(arg):
+    """Does ``arg`` provide a default?."""
+    return arg.default is not Parameter.empty
+
+
+def params_compatible(impl, iface):
+    if impl is None:
+        return False
+
+    if iface is None:
+        return has_default(impl)
+
+    return (
+        impl.name == iface.name
+        and impl.kind == iface.kind
+        and has_default(impl) == has_default(iface)
+        and annotations_compatible(impl, iface)
+    )
+
+
+def positionals_compatible(impl_positionals, iface_positionals):
+    return all(
+        starmap(params_compatible, zip_longest(impl_positionals, iface_positionals))
+    )
+
+
+def keywords_compatible(impl_keywords, iface_keywords):
+    return all(starmap(params_compatible, dzip(impl_keywords, iface_keywords).values()))
+
+
+def annotations_compatible(impl, iface):
+    """Check whether the type annotations of an implementation are compatible with
+    the annotations of the interface it implements.
+    """
+    return impl.annotation == iface.annotation

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -207,5 +207,5 @@ def test_scalar_param_date(backend, alltypes, value):
 def test_scalar_param_nested(con):
     param = ibis.param("struct<x: array<struct<y: array<double>>>>")
     value = OrderedDict([("x", [OrderedDict([("y", [1.0, 2.0, 3.0])])])])
-    result = con.execute(param, {param: value})
+    result = con.execute(param, params={param: value})
     assert pytest.approx(result["x"][0]["y"]) == np.array([1.0, 2.0, 3.0])

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -195,7 +195,6 @@ def test_scalar_param_date(backend, alltypes, value):
         "postgres",
         "risingwave",
         "datafusion",
-        "clickhouse",
         "sqlite",
         "impala",
         "oracle",

--- a/ibis/backends/tests/test_signatures.py
+++ b/ibis/backends/tests/test_signatures.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from ibis.backends import _FileIOHandler
+from ibis.backends.tests.signature.typecheck import compatible
+
+params = []
+
+for module in [_FileIOHandler]:
+    methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
+    for method in methods:
+        params.append((_FileIOHandler, method))
+
+
+@pytest.mark.parametrize("base_cls, method", params)
+def test_signatures(base_cls, method, backend_cls):
+    if not hasattr(backend_cls, method):
+        pytest.skip(f"Method {method} not present in {backend_cls}, skipping...")
+
+    base_sig = inspect.signature(getattr(base_cls, method))
+    backend_sig = inspect.signature(getattr(backend_cls, method))
+
+    # Usage is compatible(implementation_signature, defined_interface_signature, ...)
+    assert compatible(backend_sig, base_sig, check_annotations=False)

--- a/ibis/backends/tests/test_signatures.py
+++ b/ibis/backends/tests/test_signatures.py
@@ -4,15 +4,30 @@ import inspect
 
 import pytest
 
-from ibis.backends import _FileIOHandler
+from ibis.backends import (
+    BaseBackend,
+    CanCreateCatalog,
+    CanCreateDatabase,
+    CanListCatalog,
+    CanListDatabase,
+    _FileIOHandler,
+)
+from ibis.backends.sql import SQLBackend
 from ibis.backends.tests.signature.typecheck import compatible
 
 params = []
 
-for module in [_FileIOHandler]:
+for module in [
+    BaseBackend,
+    CanCreateCatalog,
+    CanCreateDatabase,
+    CanListCatalog,
+    CanListDatabase,
+    _FileIOHandler,
+]:
     methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
     for method in methods:
-        params.append((_FileIOHandler, method))
+        params.append((module, method))
 
 
 @pytest.mark.parametrize("base_cls, method", params)
@@ -20,8 +35,38 @@ def test_signatures(base_cls, method, backend_cls):
     if not hasattr(backend_cls, method):
         pytest.skip(f"Method {method} not present in {backend_cls}, skipping...")
 
-    base_sig = inspect.signature(getattr(base_cls, method))
+    if not callable(base_method := getattr(base_cls, method)):
+        pytest.skip(
+            f"Method {method} in {base_cls} isn't callable, can't grab signature"
+        )
+
+    base_sig = inspect.signature(base_method)
     backend_sig = inspect.signature(getattr(backend_cls, method))
+
+    # Usage is compatible(implementation_signature, defined_interface_signature, ...)
+    assert compatible(backend_sig, base_sig, check_annotations=False)
+
+
+sql_backend_params = []
+
+for module in [SQLBackend]:
+    methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
+    for method in methods:
+        sql_backend_params.append((module, method))
+
+
+@pytest.mark.parametrize("base_cls, method", sql_backend_params)
+def test_signatures_sql_backends(base_cls, method, backend_sql_cls):
+    if not hasattr(backend_sql_cls, method):
+        pytest.skip(f"Method {method} not present in {backend_sql_cls}, skipping...")
+
+    if not callable(base_method := getattr(base_cls, method)):
+        pytest.skip(
+            f"Method {method} in {base_cls} isn't callable, can't grab signature"
+        )
+
+    base_sig = inspect.signature(getattr(base_method))
+    backend_sig = inspect.signature(getattr(backend_sql_cls, method))
 
     # Usage is compatible(implementation_signature, defined_interface_signature, ...)
     assert compatible(backend_sig, base_sig, check_annotations=False)

--- a/ibis/backends/tests/test_signatures.py
+++ b/ibis/backends/tests/test_signatures.py
@@ -10,7 +10,6 @@ from ibis.backends import (
     CanCreateDatabase,
     CanListCatalog,
     CanListDatabase,
-    _FileIOHandler,
 )
 from ibis.backends.sql import SQLBackend
 from ibis.backends.tests.signature.typecheck import compatible
@@ -23,7 +22,6 @@ for module in [
     CanCreateDatabase,
     CanListCatalog,
     CanListDatabase,
-    _FileIOHandler,
 ]:
     methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
     for method in methods:
@@ -65,7 +63,7 @@ def test_signatures_sql_backends(base_cls, method, backend_sql_cls):
             f"Method {method} in {base_cls} isn't callable, can't grab signature"
         )
 
-    base_sig = inspect.signature(getattr(base_method))
+    base_sig = inspect.signature(base_method)
     backend_sig = inspect.signature(getattr(backend_sql_cls, method))
 
     # Usage is compatible(implementation_signature, defined_interface_signature, ...)

--- a/ibis/backends/tests/test_signatures.py
+++ b/ibis/backends/tests/test_signatures.py
@@ -14,7 +14,7 @@ from ibis.backends import (
 from ibis.backends.sql import SQLBackend
 from ibis.backends.tests.signature.typecheck import compatible
 
-SKIP_METHODS = ["do_connect"]
+SKIP_METHODS = ["do_connect", "from_connection"]
 
 
 def _scrape_methods(modules):

--- a/ibis/backends/tests/test_signatures.py
+++ b/ibis/backends/tests/test_signatures.py
@@ -14,18 +14,31 @@ from ibis.backends import (
 from ibis.backends.sql import SQLBackend
 from ibis.backends.tests.signature.typecheck import compatible
 
-params = []
+SKIP_METHODS = ["do_connect"]
 
-for module in [
-    BaseBackend,
-    CanCreateCatalog,
-    CanCreateDatabase,
-    CanListCatalog,
-    CanListDatabase,
-]:
-    methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
-    for method in methods:
-        params.append((module, method))
+
+def _scrape_methods(modules):
+    params = []
+    for module in modules:
+        methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
+        for method in methods:
+            # Only test methods that are callable (so we can grab the signature)
+            # and skip any methods that we don't want to check
+            if method not in SKIP_METHODS and callable(getattr(module, method)):
+                params.append((module, method))
+
+    return params
+
+
+params = _scrape_methods(
+    [
+        BaseBackend,
+        CanCreateCatalog,
+        CanCreateDatabase,
+        CanListCatalog,
+        CanListDatabase,
+    ]
+)
 
 
 @pytest.mark.parametrize("base_cls, method", params)
@@ -33,24 +46,14 @@ def test_signatures(base_cls, method, backend_cls):
     if not hasattr(backend_cls, method):
         pytest.skip(f"Method {method} not present in {backend_cls}, skipping...")
 
-    if not callable(base_method := getattr(base_cls, method)):
-        pytest.skip(
-            f"Method {method} in {base_cls} isn't callable, can't grab signature"
-        )
-
-    base_sig = inspect.signature(base_method)
+    base_sig = inspect.signature(getattr(base_cls, method))
     backend_sig = inspect.signature(getattr(backend_cls, method))
 
     # Usage is compatible(implementation_signature, defined_interface_signature, ...)
     assert compatible(backend_sig, base_sig, check_annotations=False)
 
 
-sql_backend_params = []
-
-for module in [SQLBackend]:
-    methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
-    for method in methods:
-        sql_backend_params.append((module, method))
+sql_backend_params = _scrape_methods([SQLBackend])
 
 
 @pytest.mark.parametrize("base_cls, method", sql_backend_params)
@@ -58,12 +61,7 @@ def test_signatures_sql_backends(base_cls, method, backend_sql_cls):
     if not hasattr(backend_sql_cls, method):
         pytest.skip(f"Method {method} not present in {backend_sql_cls}, skipping...")
 
-    if not callable(base_method := getattr(base_cls, method)):
-        pytest.skip(
-            f"Method {method} in {base_cls} isn't callable, can't grab signature"
-        )
-
-    base_sig = inspect.signature(base_method)
+    base_sig = inspect.signature(getattr(base_cls, method))
     backend_sig = inspect.signature(getattr(backend_sql_cls, method))
 
     # Usage is compatible(implementation_signature, defined_interface_signature, ...)

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -388,6 +388,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
     def create_table(
         self,
         name: str,
+        /,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -362,7 +362,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         )
 
     def create_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         with self._safe_raw_sql(
             sge.Create(
@@ -374,7 +374,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             pass
 
     def drop_database(
-        self, name: str, catalog: str | None = None, force: bool = False
+        self, name: str, /, *, catalog: str | None = None, force: bool = False
     ) -> None:
         with self._safe_raw_sql(
             sge.Drop(


### PR DESCRIPTION
We want to ensure that, for a given backend, that the argument names, plus usage of positional, positional-only, keyword, and keyword-only arguments match, so that there is API consistency when moving between backends.

I've grabbed a few small parts of some of the utilities in Scott Sanderson's
`python-interface` project (https://github.com/ssanderson/python-interface).

While the upstream is no longer maintained, the goal of that project
aligns quite well with some of the issues we face with maintaining
consistent interfaces across backends.

Whether we keep the `pytest` approach for testing the signatures or not, this has proven reasonably effective at finding spots where our argument names aren't matching.  (I think I'm in favor of keeping it, since it flagged up some inconsistencies in `to_parquet_dir` that were added after I opened this PR initially)

I've tried to keep the various refactor commits reasonably atomic so that this isn't an absolute nightmare to review.