### PR TITLE
refactor(polars): delete some dead code in the polars backend

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -176,16 +176,6 @@ def column(op, **_):
     return pl.col(op.name)
 
 
-@translate.register(ops.SortKey)
-def sort_key(op, **kw):
-    arg = translate(op.expr, **kw)
-    descending = op.descending
-    try:
-        return arg.sort(descending=descending)
-    except TypeError:  # pragma: no cover
-        return arg.sort(reverse=descending)  # pragma: no cover
-
-
 @translate.register(ops.Project)
 def project(op, **kw):
     lf = translate(op.parent, **kw)


### PR DESCRIPTION
This was never called, and its presence led to bugs when trying to add new code that works with `SortKey` instances (mistakenly assuming that this was doing the correct thing). Better to just raise a translation error when translating `SortKey` instances.