### PR TITLE
refactor(pandas-converter): output Python types for scalar outputs

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1061,7 +1061,7 @@ def test_int_scalar(alltypes):
     expr = alltypes.int_col.min()
     result = expr.execute()
     assert expr.type() == dt.int32
-    assert result.dtype == np.int32
+    assert isinstance(result, int)
 
 
 @pytest.mark.notimpl(["dask", "datafusion", "pandas", "polars", "druid"])

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -164,7 +164,10 @@ class PandasData(DataMapper):
     @classmethod
     def convert_scalar(cls, obj, dtype):
         df = PandasData.convert_table(obj, sch.Schema({obj.columns[0]: dtype}))
-        return df.iat[0, 0]
+        value = df.iat[0, 0]
+        with contextlib.suppress(AttributeError):
+            return value.tolist()
+        return value
 
     @classmethod
     def convert_GeoSpatial(cls, s, dtype, pandas_type):


### PR DESCRIPTION
Sometimes we output Python types for scalar queries and other times we output NumPy types. This PR changes the output to always be Python types in the case of scalar queries. Changing the output type of `.execute` is a breaking change.