### PR TITLE
fix(sec): remove most instances of possible sql injection

### DIFF
--- a/ci/check_disallowed_imports.py
+++ b/ci/check_disallowed_imports.py
@@ -14,7 +14,7 @@ CURRENT_DIR = pathlib.Path(__file__).parent.absolute()
 def generate_dependency_graph(*args):
     command = ("pydeps", "--show-deps", *args)
     print(f"Running: {' '.join(command)}")  # noqa: T201
-    result = subprocess.check_output(command, text=True)
+    result = subprocess.check_output(command, text=True)  # noqa: S603
     return json.loads(result)
 
 

--- a/ci/make_geography_db.py
+++ b/ci/make_geography_db.py
@@ -90,7 +90,7 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    response = requests.get(args.input_data_url)
+    response = requests.get(args.input_data_url, timeout=600)
     response.raise_for_status()
     input_data = response.json()
     db_path = Path(args.output_directory).joinpath("geography.duckdb")

--- a/docs/how-to/visualization/example_streamlit_app/example_streamlit_app.py
+++ b/docs/how-to/visualization/example_streamlit_app/example_streamlit_app.py
@@ -13,7 +13,8 @@ st.title("Yummy Data :bacon:")
 @st.cache_data
 def get_emoji():
     resp = requests.get(
-        "https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json"
+        "https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json",
+        timeout=60,
     )
     resp.raise_for_status()
     emojis = resp.json()

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -54,7 +54,7 @@ EXTERNAL_DATA_SCOPES = [
     "https://www.googleapis.com/auth/drive",
 ]
 CLIENT_ID = "546535678771-gvffde27nd83kfl6qbrnletqvkdmsese.apps.googleusercontent.com"
-CLIENT_SECRET = "iU5ohAF2qcqrujegE3hQ1cPt"
+CLIENT_SECRET = "iU5ohAF2qcqrujegE3hQ1cPt"  # noqa: S105
 
 
 def _create_user_agent(application_name: str) -> str:

--- a/ibis/backends/bigquery/tests/unit/udf/test_core.py
+++ b/ibis/backends/bigquery/tests/unit/udf/test_core.py
@@ -56,7 +56,7 @@ def f(a):
         )
         f.seek(0)
         code = builtins.compile(f.read(), f.name, "exec")
-        exec(code, d)
+        exec(code, d)  # noqa: S102
         f = d["f"]
         js = compile(f)
     snapshot.assert_match(js, "out.js")

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -423,7 +423,7 @@ class Backend(SQLBackend, CanCreateDatabase):
         elif not isinstance(obj, ir.Table):
             obj = ibis.memtable(obj)
 
-        query = self._build_insert_query(target=name, source=obj)
+        query = self._build_insert_from_table(target=name, source=obj)
         external_tables = self._collect_in_memory_tables(obj, {})
         external_data = self._normalize_external_tables(external_tables)
         return self.con.command(query.sql(self.name), external_data=external_data)

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -166,7 +166,9 @@ def test_temp_directory(tmp_path):
 @pytest.fixture(scope="session")
 def pgurl():  # pragma: no cover
     pgcon = ibis.postgres.connect(
-        user="postgres", password="postgres", host="localhost"
+        user="postgres",
+        password="postgres",  # noqa: S106
+        host="localhost",
     )
 
     df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 1.0], "y": ["a", "b", "c", "a"]})
@@ -193,7 +195,11 @@ def test_read_postgres(con, pgurl):  # pragma: no cover
 
 @pytest.fixture(scope="session")
 def mysqlurl():  # pragma: no cover
-    mysqlcon = ibis.mysql.connect(user="ibis", password="ibis", database="ibis_testing")
+    mysqlcon = ibis.mysql.connect(
+        user="ibis",
+        password="ibis",  # noqa: S106
+        database="ibis_testing",
+    )
 
     df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 1.0], "y": ["a", "b", "c", "a"]})
     s = ibis.schema(dict(x="float64", y="str"))

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -1239,9 +1239,7 @@ class Backend(SQLBackend):
             ).sql(self.name, pretty=True)
 
             data = op.data.to_frame().itertuples(index=False)
-            specs = ", ".join("?" * len(schema))
-            table = sg.table(name, quoted=quoted).sql(self.name)
-            insert_stmt = f"INSERT INTO {table} VALUES ({specs})"
+            insert_stmt = self._build_insert_template(name, schema=schema)
             with self._safe_raw_sql(create_stmt) as cur:
                 for row in data:
                     cur.execute(insert_stmt, row)

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import contextlib
 import re
 import warnings
-from functools import cached_property, partial
-from itertools import repeat
+from functools import cached_property
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
@@ -26,7 +25,7 @@ from ibis.backends import CanCreateDatabase
 from ibis.backends.mysql.compiler import MySQLCompiler
 from ibis.backends.mysql.datatypes import _type_from_cursor_info
 from ibis.backends.sql import SQLBackend
-from ibis.backends.sql.compiler import TRUE, C
+from ibis.backends.sql.compiler import STAR, TRUE, C
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -195,7 +194,16 @@ class Backend(SQLBackend, CanCreateDatabase):
 
     def _get_schema_using_query(self, query: str) -> sch.Schema:
         with self.begin() as cur:
-            cur.execute(f"SELECT * FROM ({query}) AS tmp LIMIT 0")
+            cur.execute(
+                sg.select(STAR)
+                .from_(
+                    sg.parse_one(query, dialect=self.dialect).subquery(
+                        sg.to_identifier("tmp", quoted=self.compiler.quoted)
+                    )
+                )
+                .limit(0)
+                .sql(self.dialect)
+            )
 
             return sch.Schema(
                 {
@@ -207,10 +215,12 @@ class Backend(SQLBackend, CanCreateDatabase):
     def get_schema(
         self, name: str, *, catalog: str | None = None, database: str | None = None
     ) -> sch.Schema:
-        table = sg.table(name, db=database, catalog=catalog, quoted=True).sql(self.name)
+        table = sg.table(
+            name, db=database, catalog=catalog, quoted=self.compiler.quoted
+        ).sql(self.dialect)
 
         with self.begin() as cur:
-            cur.execute(f"DESCRIBE {table}")
+            cur.execute(sge.Describe(this=table).sql(self.dialect))
             result = cur.fetchall()
 
         type_mapper = self.compiler.type_mapper
@@ -497,19 +507,14 @@ class Backend(SQLBackend, CanCreateDatabase):
             )
             create_stmt_sql = create_stmt.sql(self.name)
 
-            columns = schema.keys()
             df = op.data.to_frame()
             # nan can not be used with MySQL
             df = df.replace(np.nan, None)
 
             data = df.itertuples(index=False)
-            cols = ", ".join(
-                ident.sql(self.name)
-                for ident in map(partial(sg.to_identifier, quoted=quoted), columns)
+            sql = self._build_insert_template(
+                name, schema=schema, columns=True, placeholder="%s"
             )
-            specs = ", ".join(repeat("%s", len(columns)))
-            table = sg.table(name, quoted=quoted)
-            sql = f"INSERT INTO {table.sql(self.name)} ({cols}) VALUES ({specs})"
             with self.begin() as cur:
                 cur.execute(create_stmt_sql)
 

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -14,8 +14,9 @@
 from __future__ import annotations
 
 import os
-import random
 
+import hypothesis as h
+import hypothesis.strategies as st
 import numpy as np
 import pandas as pd
 import pandas.testing as tm
@@ -260,7 +261,8 @@ def test_port():
         ibis.connect("postgresql://postgres:postgres@localhost:1337/ibis_testing")
 
 
-def test_pgvector_type_load(con):
+@h.given(st.integers(min_value=4, max_value=1000))
+def test_pgvector_type_load(con, vector_size):
     """
     CREATE TABLE items (id bigserial PRIMARY KEY, embedding vector(3));
     INSERT INTO items (embedding) VALUES ('[1,2,3]'), ('[4,5,6]');
@@ -279,7 +281,7 @@ def test_pgvector_type_load(con):
 
     query = f"""
     DROP TABLE IF EXISTS itemsvrandom;
-    CREATE TABLE itemsvrandom (id bigserial PRIMARY KEY, embedding vector({random.randint(4, 1000)}));
+    CREATE TABLE itemsvrandom (id bigserial PRIMARY KEY, embedding vector({vector_size}));
     """
 
     with con.raw_sql(query):

--- a/ibis/backends/pyspark/tests/test_ddl.py
+++ b/ibis/backends/pyspark/tests/test_ddl.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import tempfile
 from posixpath import join as pjoin
 
 import pytest
@@ -14,7 +15,7 @@ pyspark = pytest.importorskip("pyspark")
 
 
 @pytest.fixture
-def temp_view(con) -> str:
+def temp_view(con):
     name = util.gen_name("view")
     yield name
     con.drop_view(name, force=True)
@@ -42,7 +43,10 @@ def test_drop_non_empty_database(con, alltypes, temp_table_db):
 
 @pytest.fixture
 def temp_base():
-    base = pjoin(f"/tmp/{util.gen_name('pyspark_testing')}", util.gen_name("temp_base"))
+    base = pjoin(
+        f"{tempfile.gettempdir()}/{util.gen_name('pyspark_testing')}",
+        util.gen_name("temp_base"),
+    )
     yield base
     shutil.rmtree(base, ignore_errors=True)
 

--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -392,7 +392,7 @@ class RisingWave(Postgres):
         TABLE_HINTS = False
         QUERY_HINTS = False
         NVL2_SUPPORTED = False
-        PARAMETER_TOKEN = "$"
+        PARAMETER_TOKEN = "$"  # noqa: S105
         TABLESAMPLE_SIZE_IS_ROWS = False
         TABLESAMPLE_SEED_KEYWORD = "REPEATABLE"
         SUPPORTS_SELECT_INTO = True

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -562,9 +562,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             ).sql(self.name, pretty=True)
 
             data = op.data.to_frame().itertuples(index=False)
-            specs = ", ".join("?" * len(schema))
-            table = sg.table(name, quoted=quoted).sql(self.name)
-            insert_stmt = f"INSERT INTO {table} VALUES ({specs})"
+            insert_stmt = self._build_insert_template(name, schema=schema)
             with self.begin() as cur:
                 cur.execute(create_stmt)
                 for row in data:

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -193,7 +193,7 @@ def evaluate_annotations(
     for k, v in annots.items():
         if isinstance(v, str):
             try:
-                v = eval(v, globalns, localns)
+                v = eval(v, globalns, localns)  # noqa: S307
             except NameError:
                 if not best_effort:
                     raise

--- a/ibis/examples/gen_registry.py
+++ b/ibis/examples/gen_registry.py
@@ -82,7 +82,7 @@ def add_movielens_example(
         raw_bytes = source_zip.read_bytes()
     else:
         resp = requests.get(
-            f"https://files.grouplens.org/datasets/movielens/{filename}"
+            f"https://files.grouplens.org/datasets/movielens/{filename}", timeout=600
         )
         resp.raise_for_status()
         raw_bytes = resp.content
@@ -135,7 +135,7 @@ def add_nycflights13_example(data_path: Path, *, metadata: Metadata) -> None:
                 table = con.read_csv(BASE_URL.format(filename))
                 table.to_parquet(parquet_path, codec="zstd")
         else:
-            resp = requests.get(BASE_URL.format(filename))
+            resp = requests.get(BASE_URL.format(filename), timeout=600)
             resp.raise_for_status()
             raw_bytes = resp.content
 
@@ -172,7 +172,7 @@ def add_zones_geojson(data_path: Path) -> None:
     file_path = Path(file_name)
 
     if not file_path.exists():
-        urlretrieve(url, data_path / file_path)
+        urlretrieve(url, filename=data_path / file_path)  # noqa: S310
 
 
 def add_imdb_example(data_path: Path) -> None:
@@ -307,8 +307,9 @@ def main(parser):
     add_nycflights13_example(data_path, metadata=metadata)
 
     print("Adding R examples...")  # noqa: T201
+
     # generate data from R
-    subprocess.check_call(["Rscript", str(EXAMPLES_DIRECTORY / "gen_examples.R")])
+    subprocess.check_call(["Rscript", str(EXAMPLES_DIRECTORY / "gen_examples.R")])  # noqa: S603, S607
 
     verify_case(parser, metadata)
 

--- a/ibis/expr/tests/test_decompile.py
+++ b/ibis/expr/tests/test_decompile.py
@@ -69,7 +69,7 @@ def test_basic(expr, expected):
     rendered = decompile(expr)
 
     locals_ = {}
-    exec(rendered, {}, locals_)
+    exec(rendered, {}, locals_)  # noqa: S102
     restored = locals_["result"]
 
     if isinstance(expected, ir.Expr):

--- a/ibis/tests/util.py
+++ b/ibis/tests/util.py
@@ -68,7 +68,7 @@ def assert_decompile_roundtrip(
 
     # execute the rendered python code
     locals_ = {}
-    exec(rendered, {}, locals_)
+    exec(rendered, {}, locals_)  # noqa: S102
     restored = locals_["result"]
 
     assert eq(expr.unbind(), restored)

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -678,3 +678,28 @@ class PseudoHashable(Coercible, Generic[V]):
             return self.obj != other.obj
         else:
             return NotImplemented
+
+
+def chunks(n: int, *, chunk_size: int) -> Iterator[tuple[int, int]]:
+    """Return an iterator of chunk start and end indices.
+
+    Parameters
+    ----------
+    n
+        The total number of elements.
+    chunk_size
+        The size of each chunk.
+
+    Returns
+    -------
+    int
+        THE start and end indices of each chunk.
+
+    Examples
+    --------
+    >>> list(chunks(10, chunk_size=3))
+    [(0, 3), (3, 6), (6, 9), (9, 10)]
+    >>> list(chunks(10, chunk_size=4))
+    [(0, 4), (4, 8), (8, 10)]
+    """
+    return ((start, min(start + chunk_size, n)) for start in range(0, n, chunk_size))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -384,6 +384,7 @@ select = [
   "UP",  # pyupgrade
   "W",   # pycodestyle
   "YTT", # flake8-2020
+  "S",   # flake8-bandit
 ]
 ignore = [
   "B028",    # required stacklevel argument to warn
@@ -432,6 +433,7 @@ ignore = [
   "SIM300",  # yoda conditions
   "UP007",   # Optional[str] -> str | None
   "UP038",   # non-pep604-isinstance, results in slower code
+  "S101",    # ignore "Use of `assert` detected"
 ]
 # none of these codes will be automatically fixed by ruff
 unfixable = [
@@ -446,7 +448,12 @@ required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
 "*test*.py" = [
-  "D", # ignore all docstring lints in tests
+  "D",    # ignore all docstring lints in tests
+  "S301", # pickle is allowed in tests
+  "S603", # ignore subprocess untrusted input warnings in test files, input is under control of ibis
+  "S607", # ignore subprocess untrusted exe path warnings in test files, input is under control of ibis
+  "S608", # ignore sql injection warnings in test files, input is under control of ibis
+  "S108", # /tmp usage refers to hdfs path
 ]
 "{docs,ci}/**/*.py" = ["INP001"]
 "{ci/release/verify_release,docs/**/*_impl}.py" = [


### PR DESCRIPTION
This PR adds ruff's `flake8-bandit` checks and fixes the lints or explicitly
ignores them (where it's low risk or unavoidable).

Most of the work here was in building SQL using sqlglot instead of constructing
queries using format strings.

That's not 100% foolproof for cases like `.sql()` methods, but we're at least
covering the bases in cases where we have more control over input.
