### PR TITLE
fix(trino): allow passing the `auth` keyword

### DIFF
--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import warnings
 from functools import cached_property
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
@@ -43,11 +44,12 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         catalog, db = url.path.strip("/").split("/")
         self.do_connect(
             user=url.username or None,
-            password=url.password or None,
+            auth=url.password or None,
             host=url.hostname or None,
             port=url.port or None,
             database=catalog,
             schema=db,
+            **kwargs,
         )
         return self
 
@@ -253,6 +255,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         schema: str | None = None,
         source: str | None = None,
         timezone: str = "UTC",
+        auth: str | None = None,
         **kwargs,
     ) -> None:
         """Connect to Trino.
@@ -262,7 +265,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         user
             Username to connect with
         password
-            Password to connect with
+            Password to connect with. Mutually exclusive with `auth`.
         host
             Hostname of the Trino server
         port
@@ -275,6 +278,9 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             Application name passed to Trino
         timezone
             Timezone to use for the connection
+        auth
+            Authentication method to use for the connection. Mutually exclusive
+            with `password`.
         kwargs
             Additional keyword arguments passed directly to the
             `trino.dbapi.connect` API.
@@ -298,15 +304,24 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         >>> con = ibis.trino.connect(database=catalog, schema=schema, source="my-app")
 
         """
+        if password is not None:
+            if auth is not None:
+                raise ValueError(
+                    "Cannot specify both `auth` and `password` when connecting to Trino"
+                )
+            warnings.warn(
+                "The `password` parameter is deprecated and will be removed in 10.0; use `auth` instead",
+                FutureWarning,
+            )
         self.con = trino.dbapi.connect(
             user=user,
-            auth=password,
             host=host,
             port=port,
             catalog=database,
             schema=schema,
             source=source or "ibis",
             timezone=timezone,
+            auth=auth or password,
             **kwargs,
         )
 

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -142,7 +142,7 @@ class TestConf(ServiceBackendTest):
             host=TRINO_HOST,
             port=TRINO_PORT,
             user=TRINO_USER,
-            password=TRINO_PASS,
+            auth=TRINO_PASS,
             database="memory",
             schema="default",
             **kw,

--- a/ibis/backends/trino/tests/test_client.py
+++ b/ibis/backends/trino/tests/test_client.py
@@ -74,12 +74,24 @@ def test_con_source(source, expected):
         user=TRINO_USER,
         host=TRINO_HOST,
         port=TRINO_PORT,
-        password=TRINO_PASS,
+        auth=TRINO_PASS,
         database="hive",
         schema="default",
         source=source,
     )
     assert con.con.source == expected
+
+
+def test_deprecated_password_parameter():
+    with pytest.warns(FutureWarning, match="The `password` parameter is deprecated"):
+        ibis.trino.connect(
+            user=TRINO_USER,
+            host=TRINO_HOST,
+            port=TRINO_PORT,
+            password=TRINO_PASS,
+            database="hive",
+            schema="default",
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In Ibis 10, I will change the connect API here to just forward kwargs, but for now this change is backward compatible and can be shipped in a non-major release.

Closes #9409.