### PR TITLE
test(common): replace error message snapshot with match

### DIFF
--- a/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_positional_only_arguments/parameter_is_positional_only.txt
+++ b/ibis/common/tests/snapshots/test_annotations/test_signature_from_callable_with_positional_only_arguments/parameter_is_positional_only.txt
@@ -1,3 +1,0 @@
-test(1, b=2) 'b' parameter is positional only, but was passed as a keyword
-
-Expected signature: test(a: int, b: int, /, c: int = 1)

--- a/ibis/common/tests/test_annotations.py
+++ b/ibis/common/tests/test_annotations.py
@@ -227,9 +227,10 @@ def test_signature_from_callable_with_positional_only_arguments(snapshot):
     assert sig.validate(test, args=(2, 3, 4), kwargs={}) == {"a": 2, "b": 3, "c": 4}
     assert sig.validate(test, args=(2, 3), kwargs=dict(c=4)) == {"a": 2, "b": 3, "c": 4}
 
-    with pytest.raises(ValidationError) as excinfo:
+    with pytest.raises(
+        ValidationError, match=r"test\(1, b=2\).+positional[- ]only.+keyword"
+    ):
         sig.validate(test, args=(1,), kwargs=dict(b=2))
-    snapshot.assert_match(str(excinfo.value), "parameter_is_positional_only.txt")
 
     args, kwargs = sig.unbind(sig.validate(test, args=(2, 3), kwargs={}))
     assert args == (2, 3, 1)


### PR DESCRIPTION
Fixes an issue with one of our tests that assumes a specific error message structure. This structure changed in Python 3.12.4, causing the changed test to fail on `main`.