### PR TITLE
refactor(backends): remove redundant implementations of `_register_in_memory_tables`

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1018,9 +1018,15 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         if self.supports_python_udfs:
             raise NotImplementedError(self.name)
 
-    def _register_in_memory_tables(self, expr: ir.Expr):
+    def _register_in_memory_tables(self, expr: ir.Expr) -> None:
+        for memtable in expr.op().find(ops.InMemoryTable):
+            self._register_in_memory_table(memtable)
+
+    def _register_in_memory_table(self, op: ops.InMemoryTable):
         if self.supports_in_memory_tables:
-            raise NotImplementedError(self.name)
+            raise NotImplementedError(
+                f"{self.name} must implement `_register_in_memory_table` to support in-memory tables"
+            )
 
     def _run_pre_execute_hooks(self, expr: ir.Expr) -> None:
         """Backend-specific hooks to run before an expression is executed."""

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -410,11 +410,6 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             empty_dataset = ds.dataset([], schema=schema.to_pyarrow())
             self.con.register_dataset(name=name, dataset=empty_dataset)
 
-    def _register_in_memory_tables(self, expr: ir.Expr) -> None:
-        if self.supports_in_memory_tables:
-            for memtable in expr.op().find(ops.InMemoryTable):
-                self._register_in_memory_table(memtable)
-
     def read_csv(
         self, path: str | Path, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
 
+    import ibis.expr.operations as ops
     import ibis.expr.types as ir
 
 
@@ -179,7 +180,7 @@ class Backend(SQLBackend):
             tables = result.fetchall()
         return self._filter_with_like([table.TABLE_NAME for table in tables], like=like)
 
-    def _register_in_memory_tables(self, expr):
+    def _register_in_memory_table(self, op: ops.InMemoryTable):
         """No-op. Table are inlined, for better or worse."""
 
     def _cursor_batches(

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1551,10 +1551,6 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
             }
         )
 
-    def _register_in_memory_tables(self, expr: ir.Expr) -> None:
-        for memtable in expr.op().find(ops.InMemoryTable):
-            self._register_in_memory_table(memtable)
-
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         # only register if we haven't already done so
         if (name := op.name) not in self.list_tables():

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -252,10 +252,6 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
             pass
         return self.table(name, database=(catalog, db))
 
-    def _register_in_memory_tables(self, expr: ir.Expr) -> None:
-        for memtable in expr.op().find(ops.InMemoryTable):
-            self._register_in_memory_table(memtable)
-
     def drop_view(
         self,
         name: str,


### PR DESCRIPTION
Removes redundant implementations of `_register_in_memory_tables`