### PR TITLE
test(benchmarks): ensure that the benchmark has a bit more breathing room (again)

### DIFF
--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -880,7 +880,7 @@ def lots_of_tables(tmp_path_factory):
     return ibis.duckdb.connect(db)
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(120)
 def test_memtable_register(lots_of_tables, benchmark):
     t = ibis.memtable({"x": [1, 2, 3]})
     result = benchmark(lots_of_tables.execute, t)


### PR DESCRIPTION
Hopefully this is enough time