### PR TITLE
fix(mssql): fix temporary table creation and implement `cache`

### DIFF
--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -134,3 +134,21 @@ def test_list_tables_schema_warning_refactor(con):
 
     assert con.list_tables(database="msdb.dbo", like="restore") == restore_tables
     assert con.list_tables(database=("msdb", "dbo"), like="restore") == restore_tables
+
+
+def test_create_temp_table_from_obj(con):
+    obj = {"team": ["john", "joe"]}
+
+    t = con.create_table("team", obj, temp=True)
+
+    t2 = con.table("##team", database="tempdb.dbo")
+
+    assert t.to_pyarrow().equals(t2.to_pyarrow())
+
+    persisted_from_temp = con.create_table("fuhreal", t2)
+
+    assert "fuhreal" in con.list_tables()
+
+    assert persisted_from_temp.to_pyarrow().equals(t2.to_pyarrow())
+
+    con.drop_table("fuhreal")

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -129,7 +129,11 @@ def test_create_table(backend, con, temp_table, func, sch):
                     ["pyspark", "trino", "exasol", "risingwave"],
                     reason="No support for temp tables",
                 ),
-                pytest.mark.broken(["mssql"], reason="Incorrect temp table syntax"),
+                pytest.mark.notyet(
+                    ["mssql"],
+                    reason="Can't rename temp tables",
+                    raises=ValueError,
+                ),
                 pytest.mark.broken(
                     ["bigquery"],
                     reason="tables created with temp=True cause a 404 on retrieval",
@@ -1722,7 +1726,6 @@ def test_json_to_pyarrow(con):
     assert result == expected
 
 
-@pytest.mark.notyet(["mssql"], raises=PyODBCProgrammingError)
 @pytest.mark.notyet(
     ["risingwave", "exasol"],
     raises=com.UnsupportedOperationError,


### PR DESCRIPTION
MSSQL has two kinds of temporary tables.

1. Local temporary tables, created in `tempdb.dbo`, prefixed with a
single `#` and suffixed with ~~112 underscores and a number.
2. Global temporary tables, created in `tempdb.dbo`, and prefixed with a
double `#`.

The suffixing on local temporary tables is to avoid name collisions
between separate user sessions trying to create the same temporary table
name.
Otherwise, the two types of temporary tables are functionally
equivalent. Users need specific access to look at temporary tables that
they didn't create, and all temp tables are cleaned up after the session
closes and all stored procedures referencing those tables have run.

Because of the slightly wacky semantics of local temporary tables, this
PR makes all temp tables created by the MSSQL backend "global". This
makes the names much more predictable.

A user creating a temporary table with the name "hithere", will find
that there is no table called "hithere" in the output of
`con.list_tables()`. Instead, they will find a table called "##hithere"
if they run `con.list_tables(database=("tempdb", "dbo"))`.

The returned table reference from the `create_table` call works the same
as any other table reference, and you can create persistent tables from
temporary tables.  The only major hiccough is the perpending of the `##`
on the table name, but that is the behavior of MSSQL.

I've also added in support for passing in explicit `catalog` and
`database` to `create_table`, which was missing (I believe this was an
oversight, since MSSQL definitely supports this).

Resolves #9431