### PR TITLE
fix(oracle): support connection using oracle connection string

### DIFF
--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -9,6 +9,7 @@ import warnings
 from functools import cached_property
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import numpy as np
 import oracledb
@@ -160,7 +161,14 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
         oracledb.defaults.fetch_decimals = True
 
     def _from_url(self, url: str, **kwargs):
-        return self.do_connect(user=url.username, password=url.password, dsn=url.host)
+        url = urlparse(url)
+        self.do_connect(
+            user=url.username,
+            password=url.password,
+            database=url.path.removeprefix("/"),
+        )
+
+        return self
 
     @property
     def current_database(self) -> str:

--- a/ibis/backends/oracle/tests/test_client.py
+++ b/ibis/backends/oracle/tests/test_client.py
@@ -71,3 +71,9 @@ def test_list_tables_schema_warning_refactor(con):
         assert con.list_tables(schema="SYS", like="EXU8OPT") == ["EXU8OPT"]
 
     assert con.list_tables(database="SYS", like="EXU8OPT") == ["EXU8OPT"]
+
+
+def test_from_url(con):
+    new_con = ibis.connect("oracle://ibis:ibis@localhost:1521/IBIS_TESTING")
+
+    assert new_con.list_tables()


### PR DESCRIPTION
We were missing the parsing part of parsing the connection string.
I also added an oracle-specific test to make sure this gets hit.


Resolves #9428