### PR TITLE
perf(drop): speed up performance of drop

### DIFF
--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -682,3 +682,11 @@ class BigQueryCompiler(SQLGlotCompiler):
             self.dialect
         )
         return self.f[name](*args)
+
+    def visit_DropColumns(self, op, *, parent, columns_to_drop):
+        quoted = self.quoted
+        excludes = [sg.column(column, quoted=quoted) for column in columns_to_drop]
+        star = sge.Star(**{"except": excludes})
+        table = sg.to_identifier(parent.alias_or_name, quoted=quoted)
+        column = sge.Column(this=star, table=table)
+        return sg.select(column).from_(parent)

--- a/ibis/backends/clickhouse/compiler.py
+++ b/ibis/backends/clickhouse/compiler.py
@@ -640,3 +640,11 @@ class ClickHouseCompiler(SQLGlotCompiler):
     @staticmethod
     def _generate_groups(groups):
         return groups
+
+    def visit_DropColumns(self, op, *, parent, columns_to_drop):
+        quoted = self.quoted
+        excludes = [sg.column(column, quoted=quoted) for column in columns_to_drop]
+        star = sge.Star(**{"except": excludes})
+        table = sg.to_identifier(parent.alias_or_name, quoted=quoted)
+        column = sge.Column(this=star, table=table)
+        return sg.select(column).from_(parent)

--- a/ibis/backends/pandas/executor.py
+++ b/ibis/backends/pandas/executor.py
@@ -602,6 +602,10 @@ class PandasExecutor(Dispatched, PandasUtils):
         return df.drop(columns=names)
 
     @classmethod
+    def visit(cls, op: ops.DropColumns, parent, columns_to_drop):
+        return parent.drop(columns=list(columns_to_drop))
+
+    @classmethod
     def visit(cls, op: PandasAggregate, parent, groups, metrics):
         if groups:
             parent = parent.groupby([col.name for col in groups.values()])

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1361,3 +1361,9 @@ def execute_timestamp_range(op, **kw):
     start = translate(op.start, **kw)
     stop = translate(op.stop, **kw)
     return pl.datetime_ranges(start, stop, f"{step}{unit}", closed="left")
+
+
+@translate.register(ops.DropColumns)
+def execute_drop_columns(op, **kw):
+    parent = translate(op.parent, **kw)
+    return parent.drop(op.columns_to_drop)

--- a/ibis/backends/snowflake/compiler.py
+++ b/ibis/backends/snowflake/compiler.py
@@ -654,3 +654,11 @@ class SnowflakeCompiler(SQLGlotCompiler):
                 this=table, kind=how, on=on, match_condition=match_condition
             )
         return super().visit_JoinLink(op, how=how, table=table, predicates=predicates)
+
+    def visit_DropColumns(self, op, *, parent, columns_to_drop):
+        quoted = self.quoted
+        excludes = [sg.column(column, quoted=quoted) for column in columns_to_drop]
+        star = sge.Star(**{"except": excludes})
+        table = sg.to_identifier(parent.alias_or_name, quoted=quoted)
+        column = sge.Column(this=star, table=table)
+        return sg.select(column).from_(parent)

--- a/ibis/backends/tests/sql/snapshots/test_compiler/test_table_drop_with_filter/decompiled.py
+++ b/ibis/backends/tests/sql/snapshots/test_compiler/test_table_drop_with_filter/decompiled.py
@@ -5,10 +5,14 @@ lit = ibis.timestamp("2018-01-01 00:00:00")
 s = ibis.table(name="s", schema={"b": "string"})
 t = ibis.table(name="t", schema={"a": "int64", "b": "string", "c": "timestamp"})
 f = t.filter(t.c == lit)
+dropcolumns = f.select(f.a, f.b, f.c.name("C")).drop("C")
 joinchain = (
-    f.select(f.a, f.b, lit.name("the_date"))
-    .inner_join(s, f.select(f.a, f.b, lit.name("the_date")).b == s.b)
-    .select(f.select(f.a, f.b, lit.name("the_date")).a)
+    dropcolumns.select(dropcolumns.a, dropcolumns.b, lit.name("the_date"))
+    .inner_join(
+        s,
+        dropcolumns.select(dropcolumns.a, dropcolumns.b, lit.name("the_date")).b == s.b,
+    )
+    .select(dropcolumns.select(dropcolumns.a, dropcolumns.b, lit.name("the_date")).a)
 )
 
 result = joinchain.filter(joinchain.a < 1.0)

--- a/ibis/backends/tests/sql/snapshots/test_sql/test_no_cartesian_join/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_sql/test_no_cartesian_join/out.sql
@@ -8,12 +8,8 @@ SELECT
   "t11"."total_amount" AS "customer_lifetime_value"
 FROM (
   SELECT
-    "t10"."customer_id",
-    "t10"."first_name",
-    "t10"."last_name",
-    "t10"."first_order",
-    "t10"."most_recent_order",
-    "t10"."number_of_orders"
+    "t10".*
+    EXCLUDE ("customer_id_right")
   FROM (
     SELECT
       "t3"."customer_id",

--- a/ibis/expr/decompile.py
+++ b/ibis/expr/decompile.py
@@ -187,6 +187,11 @@ def distinct(op, parent):
     return f"{parent}.distinct()"
 
 
+@translate.register(ops.DropColumns)
+def drop(op, parent, columns_to_drop):
+    return f"{parent}.drop({_inline(map(repr, columns_to_drop))})"
+
+
 @translate.register(ops.SelfReference)
 def self_reference(op, parent, identifier):
     return f"{parent}.view()"

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -146,6 +146,26 @@ class Simple(Relation):
 
 
 @public
+class DropColumns(Relation):
+    parent: Relation
+    columns_to_drop: VarTuple[str]
+
+    @attribute
+    def schema(self):
+        schema = self.parent.schema.fields.copy()
+        for column in self.columns_to_drop:
+            del schema[column]
+        return Schema(schema)
+
+    @attribute
+    def values(self):
+        fields = self.parent.fields.copy()
+        for column in self.columns_to_drop:
+            del fields[column]
+        return fields
+
+
+@public
 class Reference(Relation):
     _uid_counter = itertools.count()
     parent: Relation

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1869,25 +1869,23 @@ def test_drop():
     assert t.drop() is t
 
     res = t.drop("a")
-    assert res.equals(t.select("b", "c", "d"))
+    assert res.schema() == t.select("b", "c", "d").schema()
 
     res = t.drop("a", "b")
-    assert res.equals(t.select("c", "d"))
+    assert res.schema() == t.select("c", "d").schema()
 
-    assert res.equals(t.select("c", "d"))
-
-    assert res.equals(t.drop(s.matches("a|b")))
+    assert res.schema() == t.drop(s.matches("a|b")).schema()
 
     res = t.drop(_.a)
-    assert res.equals(t.select("b", "c", "d"))
+    assert res.schema() == t.select("b", "c", "d").schema()
 
     res = t.drop(_.a, _.b)
-    assert res.equals(t.select("c", "d"))
+    assert res.schema() == t.select("c", "d").schema()
 
     res = t.drop(_.a, "b")
-    assert res.equals(t.select("c", "d"))
+    assert res.schema() == t.select("c", "d").schema()
 
-    with pytest.raises(KeyError):
+    with pytest.raises(com.IbisTypeError):
         t.drop("e")
 
 


### PR DESCRIPTION
This PR speeds up drop construction and compilation in cases where the number
of dropped columns is small relative to the total number of parent-table
columns.

There are two ways this is done:

- `drop` construction is sped up by reducing the number of iterations
  over the full set of columns when constructing an output schema.

  This is where the bulk of the improvement is.
- Compilation of the `drop` operation is also a bit faster for smaller sets of
  dropped columns on some backends due to use of `* EXCLUDE` syntax.

Since the optimization is done in the `schema` property, adding a new
`DropColumns` relation IR seemed like the lightest weight approach given
that that also enables compilers to use `EXCLUDE` syntax, which will produce a
far smaller query than using project-without-the-dropped-columns approach.

Partially addresses the `drop` performance seen in #9111.

To address this for all backends, they either need to all support
`SELECT * EXCLUDE(col1, ..., colN)` syntax or we need to implement column
pruning.

Follow-ups could include applying a similar approach to `rename` (using `REPLACE`
syntax for compilation).

It might be possible to reduce the overhead of `relocate` as well, but
I haven't explored that.
