### PR TITLE
feat(api): allow grouping by scalar values

### DIFF
--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -299,7 +299,7 @@ class Aggregate(Relation):
     """Aggregate a table by a set of group by columns and metrics."""
 
     parent: Relation
-    groups: FrozenOrderedDict[str, Unaliased[Column]]
+    groups: FrozenOrderedDict[str, Unaliased[Value]]
     metrics: FrozenOrderedDict[str, Unaliased[Scalar]]
 
     def __init__(self, parent, groups, metrics):

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -16,16 +16,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 from public import public
 
 import ibis
-import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis.common.grounds import Concrete
+from ibis.common.patterns import Length  # noqa: TCH001
 from ibis.common.typing import VarTuple  # noqa: TCH001
 from ibis.expr.rewrites import rewrite_window_input
 
@@ -38,14 +38,9 @@ class GroupedTable(Concrete):
     """An intermediate table expression to hold grouping information."""
 
     table: ops.Relation
-    groupings: VarTuple[ops.Column]
+    groupings: Annotated[VarTuple[ops.Value], Length(at_least=1)]
     orderings: VarTuple[ops.SortKey] = ()
     havings: VarTuple[ops.Value[dt.Boolean]] = ()
-
-    def __init__(self, groupings, **kwargs):
-        if not groupings:
-            raise com.IbisInputError("No group keys provided")
-        super().__init__(groupings=groupings, **kwargs)
 
     def __getitem__(self, args):
         # Shortcut for projection with window functions

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -846,9 +846,13 @@ def test_groupby_convenience(table):
     assert_equal(expr, expected)
 
 
-@pytest.mark.parametrize("group", [[], (), None])
+@pytest.mark.parametrize(
+    "group",
+    [[], (), None, s.startswith("over9000")],
+    ids=["list", "tuple", "none", "selector"],
+)
 def test_group_by_nothing(table, group):
-    with pytest.raises(com.IbisInputError):
+    with pytest.raises(ValidationError):
         table.group_by(group)
 
 
@@ -1693,13 +1697,6 @@ def test_group_by_key_function():
     t = ibis.table([("a", "timestamp"), ("b", "string"), ("c", "double")])
     expr = t.group_by(new_key=lambda t: t.b.length()).aggregate(foo=t.c.mean())
     assert expr.columns == ["new_key", "foo"]
-
-
-def test_group_by_no_keys():
-    t = ibis.table([("a", "timestamp"), ("b", "string"), ("c", "double")])
-
-    with pytest.raises(com.IbisInputError):
-        t.group_by(s.startswith("x")).aggregate(foo=t.c.mean())
 
 
 def test_unbound_table_name():


### PR DESCRIPTION
Allow grouping by scalar values. Needed for TPC-DS. In particular, query 27 uses this functionality.

Also a somewhat common pattern for building unions of aggregations from disparate tables.