### PR TITLE
fix(druid): handle typed nulls where possible

### DIFF
--- a/ibis/backends/druid/compiler.py
+++ b/ibis/backends/druid/compiler.py
@@ -146,7 +146,12 @@ class DruidCompiler(SQLGlotCompiler):
 
     def visit_Literal(self, op, *, value, dtype):
         if value is None:
-            return NULL
+            # types that cannot be cast to NULL are null, and temporal types
+            # and druid doesn't have a bytes type so don't cast that
+            if dtype.is_null() or dtype.is_temporal() or dtype.is_binary():
+                return NULL
+            else:
+                return self.cast(NULL, dtype)
         return super().visit_Literal(op, value=value, dtype=dtype)
 
     def visit_NonNullLiteral(self, op, *, value, dtype):

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1567,15 +1567,6 @@ def test_group_by_expr(backend, con):
                     reason="nulls are discarded by default in group bys",
                     raises=IndexError,
                 ),
-                pytest.mark.notyet(
-                    ["druid"],
-                    raises=PyDruidProgrammingError,
-                    reason=(
-                        "druid resists typed nulls for reasons unrelated to grouping,"
-                        " and this is compiled as an untyped NULL "
-                        "which of course isn't allowed in a group by"
-                    ),
-                ),
             ],
         ),
     ],

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -16,7 +16,6 @@ from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
     OracleDatabaseError,
     PsycoPg2InternalError,
-    PyDruidProgrammingError,
     PyODBCProgrammingError,
 )
 from ibis.common.annotations import ValidationError
@@ -802,18 +801,7 @@ def test_parse_url(con, result_func, expected):
 @pytest.mark.parametrize(
     ("inp, expected"),
     [
-        param(
-            None,
-            None,
-            id="none",
-            marks=[
-                pytest.mark.notyet(
-                    ["druid"],
-                    raises=PyDruidProgrammingError,
-                    reason="illegal use of NULL",
-                )
-            ],
-        ),
+        param(None, None, id="none"),
         param(
             "",
             "",


### PR DESCRIPTION
Fixes a bug where we were not casting nulls to a specific type where we should.

Discovered during #9451.