### PR TITLE
feat(api): improve map()

### DIFF
--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -11,6 +11,7 @@ import ibis
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
 from ibis.backends.tests.errors import PsycoPg2InternalError, Py4JJavaError
+from ibis.common.annotations import ValidationError
 
 pytestmark = [
     pytest.mark.never(
@@ -37,6 +38,31 @@ mark_notimpl_risingwave_hstore = pytest.mark.notimpl(
     ["risingwave"],
     reason="function hstore(character varying[], character varying[]) does not exist",
 )
+
+
+@mark_notimpl_risingwave_hstore
+@pytest.mark.parametrize(
+    "values_factory",
+    [
+        lambda: ({"a": "b"},),
+        lambda: (["a"], ["b"]),
+        lambda: (ibis.map({"a": "b"}),),
+    ],
+)
+def test_map_factory(con, values_factory):
+    vals = values_factory()
+    with pytest.raises(ValidationError):
+        ibis.map(*vals, type="array<string>")
+    assert con.execute(ibis.map(*vals)) == {"a": "b"}
+    assert con.execute(ibis.map(*vals, type="map<string, string>")) == {"a": "b"}
+
+
+def test_map_null(con):
+    with pytest.raises(ValidationError):
+        ibis.map(None)
+    with pytest.raises(ValidationError):
+        ibis.map(None, type="array<string>")
+    assert con.execute(ibis.map(None, type="map<string, string>")) is None
 
 
 @pytest.mark.notyet("clickhouse", reason="nested types can't be NULL")
@@ -503,6 +529,11 @@ values = pytest.mark.parametrize(
             marks=[
                 pytest.mark.notyet("clickhouse", reason="nested types can't be null"),
                 mark_notyet_postgres,
+                pytest.mark.notimpl(
+                    "flink",
+                    raises=Py4JJavaError,
+                    reason="Unexpected error in type inference logic of function 'COALESCE'",
+                ),
             ],
             id="struct",
         ),

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -134,8 +134,6 @@ def test_struct_cast_to_empty_struct():
 
 def test_map_literal():
     a = ibis.map(["a", "b"], [1, 2])
-    assert a.op().keys.value == ("a", "b")
-    assert a.op().values.value == (1, 2)
     assert a.type() == dt.dtype("map<string, int8>")
 
 


### PR DESCRIPTION
works towards https://github.com/ibis-project/ibis/issues/8289

depends on the new array API of #9458 

One this is adding support for passing in None.
These use the new `ibis.null(<type>)` API to return `op.Literal(None, <type>)`s

Also, now map() is idempotent: you can
pass in existing Expressions into map().
The type argument for all of these now always has an effect, not just when passing in python literals. So basically it acts like a cast if the argument is already an expression.

You can test this locally with eg
`pytest -m <backend> -k factory   ibis/backends/tests/test_map.py`