### PR TITLE
feat(api): make struct() idempotent, add `type` option

### DIFF
--- a/ibis/backends/exasol/compiler.py
+++ b/ibis/backends/exasol/compiler.py
@@ -73,6 +73,7 @@ class ExasolCompiler(SQLGlotCompiler):
         ops.StringSplit,
         ops.StringToDate,
         ops.StringToTimestamp,
+        ops.StructColumn,
         ops.TimeDelta,
         ops.TimestampAdd,
         ops.TimestampBucket,

--- a/ibis/backends/sqlite/compiler.py
+++ b/ibis/backends/sqlite/compiler.py
@@ -62,6 +62,7 @@ class SQLiteCompiler(SQLGlotCompiler):
         ops.TimestampDiff,
         ops.StringToDate,
         ops.StringToTimestamp,
+        ops.StructColumn,
         ops.TimeDelta,
         ops.DateDelta,
         ops.TimestampDelta,

--- a/ibis/tests/expr/test_literal.py
+++ b/ibis/tests/expr/test_literal.py
@@ -8,7 +8,7 @@ import pytest
 
 import ibis
 import ibis.expr.datatypes as dt
-from ibis.common.collections import frozendict
+from ibis.common.annotations import ValidationError
 from ibis.expr.operations import Literal
 from ibis.tests.util import assert_pickle_roundtrip
 
@@ -109,9 +109,6 @@ def test_normalized_underlying_value(userinput, literal_type, expected_type):
 def test_struct_literal(value):
     typestr = "struct<field1: string, field2: float64>"
     a = ibis.struct(value, type=typestr)
-    assert a.op().value == frozendict(
-        field1=str(value["field1"]), field2=float(value["field2"])
-    )
     assert a.type() == dt.dtype(typestr)
 
 
@@ -123,7 +120,7 @@ def test_struct_literal(value):
     ],
 )
 def test_struct_literal_non_castable(value):
-    with pytest.raises(TypeError, match="Unable to normalize"):
+    with pytest.raises(ValidationError):
         ibis.struct(value, type="struct<field1: string, field2: float64>")
 
 


### PR DESCRIPTION
Part of https://github.com/ibis-project/ibis/issues/8289

Depends on the array API getting updated