### PR TITLE
fix(uri-parsing): handle password with bracket in connection url

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -6,7 +6,7 @@ import glob
 from contextlib import closing
 from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote_plus, urlparse
 
 import clickhouse_connect as cc
 import pyarrow as pa
@@ -82,7 +82,7 @@ class Backend(SQLBackend, CanCreateDatabase):
 
         connect_args = {
             "user": url.username,
-            "password": url.password or "",
+            "password": unquote_plus(url.password) or "",
             "host": url.hostname,
             "database": database or "",
         }

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -82,7 +82,7 @@ class Backend(SQLBackend, CanCreateDatabase):
 
         connect_args = {
             "user": url.username,
-            "password": unquote_plus(url.password) or "",
+            "password": unquote_plus(url.password or ""),
             "host": url.hostname,
             "database": database or "",
         }

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import quote_plus
 
 import pandas as pd
 import pandas.testing as tm
@@ -346,3 +347,16 @@ def test_create_table_no_syntax_error(con):
     )
     t = con.create_table(gen_name("clickouse_temp_table"), schema=schema, temp=True)
     assert t.count().execute() == 0
+
+
+def test_password_with_bracket():
+    password = f'{os.environ.get("IBIS_TEST_CLICKHOUSE_PASSWORD", "")}['
+    quoted_pass = quote_plus(password)
+    with pytest.raises(cc.driver.exceptions.DatabaseError) as e:
+        ibis.clickhouse.connect(
+            host=os.environ.get("IBIS_TEST_CLICKHOUSE_HOST", "localhost"),
+            user=os.environ.get("IBIS_TEST_CLICKHOUSE_USER", "default"),
+            port=int(os.environ.get("IBIS_TEST_CLICKHOUSE_PORT", 8123)),
+            password=quoted_pass,
+        )
+    assert "password is incorrect" in str(e.value)

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 from typing import TYPE_CHECKING, Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote_plus, urlparse
 
 import pydruid.db
 import sqlglot as sg
@@ -61,7 +61,7 @@ class Backend(SQLBackend):
         query_params = parse_qs(url.query)
         kwargs = {
             "user": url.username,
-            "password": url.password,
+            "password": unquote_plus(url.password),
             "host": url.hostname,
             "path": url.path,
             "port": url.port,

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -61,7 +61,9 @@ class Backend(SQLBackend):
         query_params = parse_qs(url.query)
         kwargs = {
             "user": url.username,
-            "password": unquote_plus(url.password),
+            "password": unquote_plus(url.password)
+            if url.password is not None
+            else None,
             "host": url.hostname,
             "path": url.path,
             "port": url.port,

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -5,7 +5,7 @@ import contextlib
 import datetime
 import re
 from typing import TYPE_CHECKING, Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote_plus, urlparse
 
 import pyexasol
 import sqlglot as sg
@@ -105,7 +105,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         query_params = parse_qs(url.query)
         kwargs = {
             "user": url.username,
-            "password": url.password,
+            "password": unquote_plus(url.password),
             "schema": url.path[1:] or None,
             "host": url.hostname,
             "port": url.port,

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -105,7 +105,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         query_params = parse_qs(url.query)
         kwargs = {
             "user": url.username,
-            "password": unquote_plus(url.password),
+            "password": unquote_plus(url.password)
+            if url.password is not None
+            else None,
             "schema": url.path[1:] or None,
             "host": url.hostname,
             "port": url.port,

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -62,7 +62,7 @@ class Backend(SQLBackend, CanCreateDatabase):
         query_params = parse_qs(url.query)
         connect_args = {
             "user": url.username,
-            "password": unquote_plus(url.password) or "",
+            "password": unquote_plus(url.password or ""),
             "host": url.hostname,
             "database": database or "",
             "port": url.port or None,

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -8,7 +8,7 @@ import warnings
 from functools import cached_property
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote_plus, urlparse
 
 import numpy as np
 import pymysql
@@ -62,7 +62,7 @@ class Backend(SQLBackend, CanCreateDatabase):
         query_params = parse_qs(url.query)
         connect_args = {
             "user": url.username,
-            "password": url.password or "",
+            "password": unquote_plus(url.password) or "",
             "host": url.hostname,
             "database": database or "",
             "port": url.port or None,

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -9,7 +9,7 @@ import warnings
 from functools import cached_property
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import unquote_plus, urlparse
 
 import numpy as np
 import oracledb
@@ -164,7 +164,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
         url = urlparse(url)
         self.do_connect(
             user=url.username,
-            password=url.password,
+            password=unquote_plus(url.password),
             database=url.path.removeprefix("/"),
         )
 

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -164,7 +164,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
         url = urlparse(url)
         self.do_connect(
             user=url.username,
-            password=unquote_plus(url.password),
+            password=unquote_plus(url.password) if url.password is not None else None,
             database=url.path.removeprefix("/"),
         )
 

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -71,7 +71,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         query_params = parse_qs(url.query)
         connect_args = {
             "user": url.username,
-            "password": unquote_plus(url.password) or "",
+            "password": unquote_plus(url.password or ""),
             "host": url.hostname,
             "database": database or "",
             "schema": schema[0] if schema else "",

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -9,7 +9,7 @@ from functools import partial
 from itertools import takewhile
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote_plus, urlparse
 
 import numpy as np
 import pandas as pd
@@ -71,7 +71,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         query_params = parse_qs(url.query)
         connect_args = {
             "user": url.username,
-            "password": url.password or "",
+            "password": unquote_plus(url.password) or "",
             "host": url.hostname,
             "database": database or "",
             "schema": schema[0] if schema else "",

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -387,4 +387,6 @@ def test_password_with_bracket():
     url = f"postgres://{IBIS_POSTGRES_USER}:{quoted_pass}@{IBIS_POSTGRES_HOST}:{IBIS_POSTGRES_PORT}/{POSTGRES_TEST_DB}"
     with pytest.raises(PsycoPg2OperationalError) as e:
         ibis.connect(url)
-    assert f'password authentication failed for user "{IBIS_POSTGRES_USER}"' in str(e.value)
+    assert f'password authentication failed for user "{IBIS_POSTGRES_USER}"' in str(
+        e.value
+    )

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import quote_plus
 
 import hypothesis as h
 import hypothesis.strategies as st
@@ -378,3 +379,12 @@ def test_infoschema_dtypes(con):
         con.table("triggers", database="information_schema").select("created").schema()
         == triggers_created_schema
     )
+
+
+def test_password_with_bracket():
+    password = f"{IBIS_POSTGRES_PASS}["
+    quoted_pass = quote_plus(password)
+    url = f"postgres://{IBIS_POSTGRES_USER}:{quoted_pass}@{IBIS_POSTGRES_HOST}:{IBIS_POSTGRES_PORT}/{POSTGRES_TEST_DB}"
+    with pytest.raises(PsycoPg2OperationalError) as e:
+        ibis.connect(url)
+    assert f'password authentication failed for user "{IBIS_POSTGRES_USER}"' in str(e.value)

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -17,7 +17,7 @@ from operator import itemgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
-from urllib.request import urlretrieve
+from urllib.request import unquote_plus, urlretrieve
 
 import pyarrow as pa
 import pyarrow_hotfix  # noqa: F401
@@ -116,7 +116,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema):
             (warehouse,) = query_params.pop("warehouse", (None,))
             connect_args = {
                 "user": url.username,
-                "password": url.password or "",
+                "password": unquote_plus(url.password) or "",
                 "account": url.hostname,
                 "warehouse": warehouse,
                 "database": database or "",

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -116,7 +116,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema):
             (warehouse,) = query_params.pop("warehouse", (None,))
             connect_args = {
                 "user": url.username,
-                "password": unquote_plus(url.password) or "",
+                "password": unquote_plus(url.password or ""),
                 "account": url.hostname,
                 "warehouse": warehouse,
                 "database": database or "",

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -16,8 +16,8 @@ import warnings
 from operator import itemgetter
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import parse_qs, urlparse
-from urllib.request import unquote_plus, urlretrieve
+from urllib.parse import parse_qs, unquote_plus, urlparse
+from urllib.request import urlretrieve
 
 import pyarrow as pa
 import pyarrow_hotfix  # noqa: F401

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -44,7 +44,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         catalog, db = url.path.strip("/").split("/")
         self.do_connect(
             user=url.username or None,
-            auth=unquote_plus(url.password) or None,
+            auth=unquote_plus(url.password) if url.password is not None else None,
             host=url.hostname or None,
             port=url.port or None,
             database=catalog,

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -7,7 +7,7 @@ import warnings
 from functools import cached_property
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlparse
+from urllib.parse import unquote_plus, urlparse
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -44,7 +44,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         catalog, db = url.path.strip("/").split("/")
         self.do_connect(
             user=url.username or None,
-            auth=url.password or None,
+            auth=unquote_plus(url.password) or None,
             host=url.hostname or None,
             port=url.port or None,
             database=catalog,


### PR DESCRIPTION
## Description of changes
If the password is with a bracket in the connection url, `urllib.parse.urlparse(url)` will raise the error `ValueError: Invalid IPv6 URL` in `backends.connect()`. But if the caller quotes the password to avoid parsing failing, ibis does not unquote back the password.

### Reproducible example
```python
import ibis
import pytest

invalid_password = "invalid_password["
with pytest.raises(ValueError) as e:
    ibis.connect(f"postgres://username:{invalid_password}@localhost:5432/dbname")
assert str(e.value) == "Invalid IPv6 URL"
```