### PR TITLE
feat(bigquery): implement CountDistinctStar

### DIFF
--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -36,7 +36,6 @@ class BigQueryCompiler(SQLGlotCompiler):
     )
 
     UNSUPPORTED_OPS = (
-        ops.CountDistinctStar,
         ops.DateDiff,
         ops.ExtractAuthority,
         ops.ExtractUserInfo,
@@ -644,6 +643,23 @@ class BigQueryCompiler(SQLGlotCompiler):
         if where is not None:
             return self.f.countif(where)
         return self.f.count(STAR)
+
+    def visit_CountDistinctStar(self, op, *, where, arg):
+        # Bigquery does not support count(distinct a,b,c) or count(distinct (a, b, c))
+        # as expressions must be "groupable":
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#group_by_grouping_item
+        #
+        # Instead, convert the entire expression to a string
+        # SELECT COUNT(DISTINCT concat(to_json_string(a), to_json_string(b)))
+        # This works with an array of datatypes which generates a unique string
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_encodings
+        row = sge.Concat(
+            expressions=[
+                self.f.to_json_string(sg.column(x, quoted=self.quoted))
+                for x in op.arg.schema.keys()
+            ]
+        )
+        return self.agg.count(sge.Distinct(expressions=[row]), where=where)
 
     def visit_Degrees(self, op, *, arg):
         return self._pudf("degrees", arg)

--- a/ibis/backends/bigquery/compiler.py
+++ b/ibis/backends/bigquery/compiler.py
@@ -659,7 +659,9 @@ class BigQueryCompiler(SQLGlotCompiler):
                 for x in op.arg.schema.keys()
             ]
         )
-        return self.agg.count(sge.Distinct(expressions=[row]), where=where)
+        if where is not None:
+            row = self.if_(where, row, NULL)
+        return self.f.count(sge.Distinct(expressions=[row]))
 
     def visit_Degrees(self, op, *, arg):
         return self._pudf("degrees", arg)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -713,7 +713,7 @@ def test_arbitrary(backend, alltypes, df, filtered):
     ],
 )
 @pytest.mark.notyet(
-    ["bigquery", "druid", "mssql", "oracle", "sqlite", "flink"],
+    ["druid", "mssql", "oracle", "sqlite", "flink"],
     raises=(
         OracleDatabaseError,
         com.UnsupportedOperationError,


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Implements countdistinctstar for bigquery

Bigquery does not support count(distinct a,b,c) or count(distinct (a, b, c)) (e.g. using a tuple, as is done with DuckDB) as expressions must be [groupable](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#group_by_grouping_item)

Instead, convert the entire expression to a string  `SELECT COUNT(DISTINCT ARRAY_TO_STRING([TO_JSON_STRING(a), TO_JSON_STRING(b)], ''))`

This works with all the bigquery datatypes ([source](https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_functions#other_conv_functions)). Using an array generates a unique, deterministic string for each combination of rows deterministically (see [json encoding](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_encodings))

I do not know what the impact on cost or runtime is here, but there aren't many other ways of achieving a count distinct on multiple column types of rows. 