### PR TITLE
fix(ir): avoid deduplicating filters based solely on their name

### DIFF
--- a/ibis/expr/tests/test_newrels.py
+++ b/ibis/expr/tests/test_newrels.py
@@ -1737,3 +1737,14 @@ def test_projections_with_different_field_order_are_unequal():
     t2 = t.select(b=2, a=1)
 
     assert not t1.equals(t2)
+
+
+def test_filters_are_allowed_to_have_the_same_name():
+    t = ibis.table({"a": "int64", "b": "string"}, name="t")
+    f1 = t.filter(t.a > 1, t.a > 1)
+    f2 = t.filter(t.a > 1)
+    f3 = t.filter((t.a > 1).name("a"))
+    f4 = t.filter((t.a > 1).name("a"), (t.a > 1).name("b"))
+    assert f1.equals(f2)
+    assert f1.equals(f3)
+    assert f1.equals(f4)


### PR DESCRIPTION
This PR fixes an issue where we were using `unwrap_aliases` to deduplicate and
enforce expressions by their name in `filter`s.

That approach makes sense in the context of projections, but the name of
predicate expressions in a `filter` is irrelevant.

The solution was to continue to unwrap aliases but avoid deduplicating
expressions based on their name, and do it solely on the hash value of
expressions.

Closes #9474.
