### PR TITLE
fix(urls): standardize pass-through of parsed query parameters

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1369,18 +1369,12 @@ def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
         else:
             raise ValueError(f"Don't know how to connect to {resource!r}")
 
-    if kwargs:
-        # If there are kwargs (either explicit or from the query string),
-        # re-add them to the parsed URL
-        query = urllib.parse.urlencode(kwargs)
-        parsed = parsed._replace(query=query)
-
     if scheme in ("postgres", "postgresql"):
         # Treat `postgres://` and `postgresql://` the same
         scheme = "postgres"
 
     # Convert all arguments back to a single URL string
-    url = parsed.geturl()
+    url = parsed._replace(query="").geturl()
     if "://" not in url:
         # urllib may roundtrip `duckdb://` to `duckdb:`. Here we re-add the
         # missing `//`.
@@ -1391,7 +1385,7 @@ def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
     except AttributeError:
         raise ValueError(f"Don't know how to connect to {resource!r}") from None
 
-    return backend._from_url(url, **orig_kwargs)
+    return backend._from_url(url, **kwargs)
 
 
 class UrlFromPath:

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -8,7 +8,6 @@ import glob
 import os
 import re
 from typing import TYPE_CHECKING, Any, Optional
-from urllib.parse import parse_qs, urlparse
 
 import google.api_core.exceptions
 import google.auth.credentials
@@ -41,6 +40,7 @@ from ibis.backends.sql.datatypes import BigQueryType
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from pathlib import Path
+    from urllib.parse import ParseResult
 
     import pandas as pd
     import polars as pl
@@ -332,12 +332,10 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         )
         return self._read_file(path, table_name=table_name, job_config=job_config)
 
-    def _from_url(self, url: str, **kwargs):
-        result = urlparse(url)
-        params = parse_qs(result.query)
+    def _from_url(self, url: ParseResult, **kwargs):
         return self.connect(
-            project_id=result.netloc or params.get("project_id", [""])[0],
-            dataset_id=result.path[1:] or params.get("dataset_id", [""])[0],
+            project_id=url.netloc or kwargs.get("project_id", [""])[0],
+            dataset_id=url.path[1:] or kwargs.get("dataset_id", [""])[0],
             **kwargs,
         )
 

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import datetime
 import decimal
+from urllib.parse import urlparse
 
 import pandas as pd
 import pandas.testing as tm
@@ -428,3 +429,10 @@ def test_table_suffix():
     expr = t.filter(t._TABLE_SUFFIX == "1929", t.max != 9999.9).head(1)
     result = expr.execute()
     assert not result.empty
+
+
+def test_parameters_in_url_connect(mocker):
+    spy = mocker.spy(ibis.bigquery, "_from_url")
+    parsed = urlparse("bigquery://ibis-gbq?location=us-east1")
+    ibis.connect("bigquery://ibis-gbq?location=us-east1")
+    spy.assert_called_once_with(parsed, location="us-east1")

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -352,11 +352,10 @@ def test_create_table_no_syntax_error(con):
 def test_password_with_bracket():
     password = f'{os.environ.get("IBIS_TEST_CLICKHOUSE_PASSWORD", "")}['
     quoted_pass = quote_plus(password)
-    with pytest.raises(cc.driver.exceptions.DatabaseError) as e:
-        ibis.clickhouse.connect(
-            host=os.environ.get("IBIS_TEST_CLICKHOUSE_HOST", "localhost"),
-            user=os.environ.get("IBIS_TEST_CLICKHOUSE_USER", "default"),
-            port=int(os.environ.get("IBIS_TEST_CLICKHOUSE_PORT", 8123)),
-            password=quoted_pass,
-        )
-    assert "password is incorrect" in str(e.value)
+    host = os.environ.get("IBIS_TEST_CLICKHOUSE_HOST", "localhost")
+    user = os.environ.get("IBIS_TEST_CLICKHOUSE_USER", "default")
+    port = int(os.environ.get("IBIS_TEST_CLICKHOUSE_PORT", 8123))
+    with pytest.raises(
+        cc.driver.exceptions.DatabaseError, match="password is incorrect"
+    ):
+        ibis.clickhouse.connect(host=host, user=user, port=port, password=quoted_pass)

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -7,7 +7,6 @@ import operator
 import os
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import parse_qs, urlparse
 
 import impala.dbapi as impyla
 import sqlglot as sg
@@ -44,6 +43,7 @@ from ibis.backends.sql import SQLBackend
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
+    from urllib.parse import ParseResult
 
     import pandas as pd
     import polars as pl
@@ -67,7 +67,7 @@ class Backend(SQLBackend):
 
     supports_in_memory_tables = True
 
-    def _from_url(self, url: str, **kwargs: Any) -> Backend:
+    def _from_url(self, url: ParseResult, **kwargs: Any) -> Backend:
         """Connect to a backend using a URL `url`.
 
         Parameters
@@ -83,8 +83,6 @@ class Backend(SQLBackend):
             A backend instance
 
         """
-        url = urlparse(url)
-
         for name in ("username", "hostname", "port", "password"):
             if value := (
                 getattr(url, name, None)
@@ -98,16 +96,6 @@ class Backend(SQLBackend):
         (database,) = url.path[1:].split("/", 1)
         if database:
             kwargs["database"] = database
-
-        query_params = parse_qs(url.query)
-
-        for name, value in query_params.items():
-            if len(value) > 1:
-                kwargs[name] = value
-            elif len(value) == 1:
-                kwargs[name] = value[0]
-            else:
-                raise com.IbisError(f"Invalid URL parameter: {name}")
 
         self._convert_kwargs(kwargs)
         return self.connect(**kwargs)

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -9,7 +9,7 @@ import warnings
 from functools import cached_property
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
-from urllib.parse import unquote_plus, urlparse
+from urllib.parse import unquote_plus
 
 import numpy as np
 import oracledb
@@ -29,6 +29,8 @@ from ibis.backends.sql import STAR, SQLBackend
 from ibis.backends.sql.compiler import C
 
 if TYPE_CHECKING:
+    from urllib.parse import ParseResult
+
     import pandas as pd
     import polars as pl
     import pyarrow as pa
@@ -160,12 +162,12 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
         # Set to ensure decimals come back as decimals
         oracledb.defaults.fetch_decimals = True
 
-    def _from_url(self, url: str, **kwargs):
-        url = urlparse(url)
+    def _from_url(self, url: ParseResult, **kwargs):
         self.do_connect(
             user=url.username,
             password=unquote_plus(url.password) if url.password is not None else None,
             database=url.path.removeprefix("/"),
+            **kwargs,
         )
 
         return self

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -385,8 +385,8 @@ def test_password_with_bracket():
     password = f"{IBIS_POSTGRES_PASS}["
     quoted_pass = quote_plus(password)
     url = f"postgres://{IBIS_POSTGRES_USER}:{quoted_pass}@{IBIS_POSTGRES_HOST}:{IBIS_POSTGRES_PORT}/{POSTGRES_TEST_DB}"
-    with pytest.raises(PsycoPg2OperationalError) as e:
+    with pytest.raises(
+        PsycoPg2OperationalError,
+        match=f'password authentication failed for user "{IBIS_POSTGRES_USER}"',
+    ):
         ibis.connect(url)
-    assert f'password authentication failed for user "{IBIS_POSTGRES_USER}"' in str(
-        e.value
-    )

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -7,7 +7,7 @@ import warnings
 from functools import cached_property
 from operator import itemgetter
 from typing import TYPE_CHECKING, Any
-from urllib.parse import unquote_plus, urlparse
+from urllib.parse import unquote_plus
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -25,6 +25,7 @@ from ibis.backends.trino.compiler import TrinoCompiler
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
+    from urllib.parse import ParseResult
 
     import pandas as pd
     import polars as pl
@@ -39,8 +40,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
     supports_create_or_replace = False
     supports_temporary_tables = False
 
-    def _from_url(self, url: str, **kwargs):
-        url = urlparse(url)
+    def _from_url(self, url: ParseResult, **kwargs):
         catalog, db = url.path.strip("/").split("/")
         self.do_connect(
             user=url.username or None,


### PR DESCRIPTION
This PR cleans up our URL handling a bit.

1. We were doing a bunch of unnecessary url parse -> url unparse, only to
   immediately again parse the URL as the first call in every `_from_url`
   implementation.
1. Each backend was separately handling converting query parameters to single
   scalars where possible, due to the unparsing
1. Query parameters were sometimes passed into `kwargs` and sometimes parsed
   again to then be used as kwargs later


So, I did the following:

1. Pass the `ParseResult` into the `_from_url` implementation.
1. Convert query parameters into single values where possible _before_ calling `backend._from_url`
1. Pass all query parameters as `**kwargs` into the `_from_url` call.

Fixes #9456.