### PR TITLE
fix(polars): add workaround to compile Array<Array> correctly

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1352,14 +1352,7 @@ def test_unnest_range(con):
             [[1], ibis.literal([2])],
             [[1], [2]],
             id="array",
-            marks=[
-                pytest.mark.notyet(["bigquery"], raises=GoogleBadRequest),
-                pytest.mark.broken(
-                    ["polars"],
-                    reason="expression input not supported with nested arrays",
-                    raises=TypeError,
-                ),
-            ],
+            marks=[pytest.mark.notyet(["bigquery"], raises=GoogleBadRequest)],
         ),
     ],
 )


### PR DESCRIPTION
Workaround for https://github.com/pola-rs/polars/issues/17294

pl.concat_list(Iterable[T]) results in pl.List[T], EXCEPT when T is a
pl.List, in which case pl.concat_list(Iterable[pl.List[T]]) results in pl.List[T].
If polars ever supports a more consistent array constructor,
we should switch to that.

Found this when working on https://github.com/ibis-project/ibis/pull/9473