### PR TITLE
chore: patch scipy 1.14 for new usage of xcrun

### DIFF
--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -1,1 +1,10 @@
-_final: _prev: { }
+final: prev: {
+  scipy = prev.scipy.overridePythonAttrs (
+    old: final.lib.optionalAttrs (final.stdenv.isDarwin && (final.lib.versionAtLeast old.version "1.14.0")) {
+      prePatch = (old.prePatch or "") + ''
+        substituteInPlace scipy/meson.build \
+          --replace xcrun "${final.pkgs.xcbuild}/bin/xcrun"
+      '';
+    }
+  );
+}


### PR DESCRIPTION
Fixes nixos mac builds for newer scipy versions that run xcrun.