### PR TITLE
fix(pandas, dask): fix `drop_table` handling of `force` keyword

### DIFF
--- a/ibis/backends/pandas/__init__.py
+++ b/ibis/backends/pandas/__init__.py
@@ -237,11 +237,11 @@ class BasePandasBackend(BaseBackend, NoUrl):
         self.drop_table(name, force=force)
 
     def drop_table(self, name: str, *, force: bool = False) -> None:
-        if not force and name in self.dictionary:
-            raise com.IbisError(
-                "Cannot drop existing table. Call drop_table with force=True to drop existing table."
-            )
-        del self.dictionary[name]
+        try:
+            del self.dictionary[name]
+        except KeyError:
+            if not force:
+                raise com.IbisError(f"Table {name} does not exist") from None
 
     def _convert_object(self, obj: Any) -> Any:
         return _convert_object(obj, self)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1024,9 +1024,7 @@ def test_create_table_in_memory(con, obj, table_name, monkeypatch):
 
     assert result.equals(t.to_pyarrow())
 
-    with contextlib.suppress(NotImplementedError):
-        # polars doesn't have drop_table
-        con.drop_table(table_name, force=True)
+    con.drop_table(table_name, force=True)
 
 
 def test_default_backend_option(con, monkeypatch):


### PR DESCRIPTION
Noticed while reviewing some other code. `force=True` indicates that `drop_table` shouldn't error if the table doesn't exist, the previous implementation would error if the table did exist unless `force=True` was passed.