### PR TITLE
fix(oracle, clickhouse): ensure `port` is captured in `_from_url` implementation

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -84,6 +84,7 @@ class Backend(SQLBackend, CanCreateDatabase):
             "password": unquote_plus(url.password or ""),
             "host": url.hostname,
             "database": database or "",
+            "port": url.port,
             **kwargs,
         }
 

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -13,6 +13,12 @@ import ibis
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
 from ibis import config, udf
+from ibis.backends.clickhouse.tests.conftest import (
+    CLICKHOUSE_HOST,
+    CLICKHOUSE_PASS,
+    CLICKHOUSE_USER,
+    IBIS_TEST_CLICKHOUSE_DB,
+)
 from ibis.util import gen_name
 
 cc = pytest.importorskip("clickhouse_connect")
@@ -359,3 +365,10 @@ def test_password_with_bracket():
         cc.driver.exceptions.DatabaseError, match="password is incorrect"
     ):
         ibis.clickhouse.connect(host=host, user=user, port=port, password=quoted_pass)
+
+
+def test_invalid_port(con):
+    port = 9999
+    url = f"clickhouse://{CLICKHOUSE_USER}:{CLICKHOUSE_PASS}@{CLICKHOUSE_HOST}:{port}/{IBIS_TEST_CLICKHOUSE_DB}"
+    with pytest.raises(cc.driver.exceptions.DatabaseError):
+        ibis.connect(url)

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -16,6 +16,7 @@ from ibis import config, udf
 from ibis.backends.clickhouse.tests.conftest import (
     CLICKHOUSE_HOST,
     CLICKHOUSE_PASS,
+    CLICKHOUSE_PORT,
     CLICKHOUSE_USER,
     IBIS_TEST_CLICKHOUSE_DB,
 )
@@ -365,6 +366,12 @@ def test_password_with_bracket():
         cc.driver.exceptions.DatabaseError, match="password is incorrect"
     ):
         ibis.clickhouse.connect(host=host, user=user, port=port, password=quoted_pass)
+
+
+def test_from_url(con):
+    assert ibis.connect(
+        f"clickhouse://{CLICKHOUSE_USER}:{CLICKHOUSE_PASS}@{CLICKHOUSE_HOST}:{CLICKHOUSE_PORT}/{IBIS_TEST_CLICKHOUSE_DB}"
+    )
 
 
 def test_invalid_port(con):

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -167,6 +167,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
             user=url.username,
             password=unquote_plus(url.password) if url.password is not None else None,
             database=url.path.removeprefix("/"),
+            port=url.port,
             **kwargs,
         )
 

--- a/ibis/backends/oracle/tests/test_client.py
+++ b/ibis/backends/oracle/tests/test_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date  # noqa: TCH003
 
+import oracledb
 import pandas as pd
 import pandas.testing as tm
 import pytest
@@ -9,6 +10,11 @@ import pytest
 import ibis
 import ibis.common.exceptions as exc
 from ibis import udf
+from ibis.backends.oracle.tests.conftest import (
+    ORACLE_HOST,
+    ORACLE_PASS,
+    ORACLE_USER,
+)
 
 
 def test_ibis_is_not_defeated_by_statement_cache(con):
@@ -77,3 +83,13 @@ def test_from_url(con):
     new_con = ibis.connect("oracle://ibis:ibis@localhost:1521/IBIS_TESTING")
 
     assert new_con.list_tables()
+
+
+def test_invalid_port(con):
+    port = 9999
+    url = f"oracle://{ORACLE_USER}:{ORACLE_PASS}@{ORACLE_HOST}:{port}/IBIS_TESTING"
+    with pytest.raises(
+        oracledb.OperationalError,
+        match="DPY-6005: cannot connect to database",
+    ):
+        ibis.connect(url)


### PR DESCRIPTION
## Description of changes
Fix oracle and clickhouse missing `port` in `_from_url`.
