### PR TITLE
fix(clickhouse): support `Date32` database type

### DIFF
--- a/ibis/backends/clickhouse/tests/test_datatypes.py
+++ b/ibis/backends/clickhouse/tests/test_datatypes.py
@@ -244,6 +244,7 @@ def test_array_discovery_clickhouse(con):
             ),
             id="nested",
         ),
+        param("Date32", dt.Date(nullable=False), id="date32"),
         param("DateTime", dt.Timestamp(scale=0, nullable=False), id="datetime"),
         param(
             "DateTime('Europe/Budapest')",

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -20,6 +20,7 @@ _from_sqlglot_types = {
     typecode.BOOLEAN: dt.Boolean,
     typecode.CHAR: dt.String,
     typecode.DATE: dt.Date,
+    typecode.DATE32: dt.Date,
     typecode.DOUBLE: dt.Float64,
     typecode.ENUM: dt.String,
     typecode.ENUM8: dt.String,


### PR DESCRIPTION
Add missing support for ClickHouse Date32 type.