### PR TITLE
fix(dask,pandas): make groupby null behavior consistent with other backends

### DIFF
--- a/ibis/backends/dask/executor.py
+++ b/ibis/backends/dask/executor.py
@@ -392,7 +392,7 @@ class DaskExecutor(PandasExecutor, DaskUtils):
             combined, _ = cls.asframe(results)
             return combined
 
-        parent = parent.groupby([col.name for col in groups.values()])
+        parent = parent.groupby([col.name for col in groups.values()], dropna=False)
 
         measures = {}
         for name, metric in metrics.items():

--- a/ibis/backends/pandas/executor.py
+++ b/ibis/backends/pandas/executor.py
@@ -623,7 +623,7 @@ class PandasExecutor(Dispatched, PandasUtils):
     @classmethod
     def visit(cls, op: PandasAggregate, parent, groups, metrics):
         if groups:
-            parent = parent.groupby([col.name for col in groups.values()])
+            parent = parent.groupby([col.name for col in groups.values()], dropna=False)
             metrics = {k: parent.apply(v) for k, v in metrics.items()}
             result = cls.concat(metrics, axis=1).reset_index()
             renames = {v.name: k for k, v in op.groups.items()}

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1556,21 +1556,7 @@ def test_group_by_expr(backend, con):
 
 
 @pytest.mark.parametrize(
-    "value",
-    [
-        ibis.literal("a"),
-        param(
-            ibis.null("str"),
-            marks=[
-                pytest.mark.notimpl(
-                    ["pandas", "dask"],
-                    reason="nulls are discarded by default in group bys",
-                    raises=IndexError,
-                ),
-            ],
-        ),
-    ],
-    ids=["string", "null"],
+    "value", [ibis.literal("a"), ibis.null("str")], ids=["string", "null"]
 )
 @pytest.mark.notyet(
     ["mssql"], raises=PyODBCProgrammingError, reason="not supported by the database"

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -2430,9 +2430,6 @@ def test_select_sort_sort_deferred(backend, alltypes, df):
 
 
 @pytest.mark.notimpl(
-    ["pandas", "dask"], raises=IndexError, reason="NaN isn't treated as NULL"
-)
-@pytest.mark.notimpl(
     ["druid"],
     raises=AttributeError,
     reason="inserting three rows into druid is difficult",


### PR DESCRIPTION
This is for consistency with other backends (duck, postgres), NULL should be included in output groups

**Please point me to where unit tests should be added** e.g. maybe somewhere in [here](https://github.com/ibis-project/ibis/blob/main/ibis/tests/expr/test_table.py)?

## Description of changes

adds dropna=False to .groupby() call for pandas, otherwise if any rows contain NULL in the groupby columns, they are dropped from the output

## Issues closed

* Resolves #9520


-->
