### PR TITLE
refactor(caching): remove parameters that are always the same

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -772,8 +772,6 @@ class BaseBackend(abc.ABC, _FileIOHandler):
             populate=self._load_into_cache,
             lookup=lambda name: self.table(name).op(),
             finalize=self._clean_up_cached_table,
-            generate_name=functools.partial(util.gen_name, "cache"),
-            key=lambda expr: expr.op(),
         )
 
     @property

--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -45,14 +45,10 @@ class RefCountedCache:
         populate: Callable[[str, Any], None],
         lookup: Callable[[str], Any],
         finalize: Callable[[Any], None],
-        generate_name: Callable[[], str],
-        key: Callable[[Any], Any],
     ) -> None:
         self.populate = populate
         self.lookup = lookup
         self.finalize = finalize
-        self.generate_name = generate_name
-        self.key = key or (lambda x: x)
 
         self.cache: dict[Any, CacheEntry] = dict()
 
@@ -70,8 +66,10 @@ class RefCountedCache:
 
     def store(self, input):
         """Compute and store a reference to `key`."""
-        key = self.key(input)
-        name = self.generate_name()
+        from ibis.util import gen_name
+
+        key = input.op()
+        name = gen_name("cache")
         self.populate(name, input)
         cached = self.lookup(name)
         finalizer = finalize(cached, self._release, key)


### PR DESCRIPTION
Remove some unnecessary parameters from `RefCountedCache`