### PR TITLE
feat(api): add positional joins

### DIFF
--- a/ibis/backends/pandas/executor.py
+++ b/ibis/backends/pandas/executor.py
@@ -642,6 +642,9 @@ class PandasExecutor(Dispatched, PandasUtils):
         if how == "cross":
             assert not left_on and not right_on
             return cls.merge(left, right, how="cross")
+        elif how == "positional":
+            assert not left_on and not right_on
+            return cls.concat([left, right], axis=1)
         elif how == "anti":
             df = cls.merge(
                 left,

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -296,6 +296,9 @@ def join(op, **kw):
     left = translate(op.left, **kw)
     right = translate(op.right, **kw)
 
+    if how == "positional":
+        return pl.concat([left, right], how="horizontal")
+
     # workaround required for https://github.com/pola-rs/polars/issues/13130
     prefix = gen_name("on")
     left_on = {f"{prefix}_{i}": translate(v, **kw) for i, v in enumerate(op.left_on)}

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -1259,6 +1259,7 @@ class SQLGlotCompiler(abc.ABC):
             "asof": "asof",
             "any_left": "left",
             "any_inner": None,
+            "positional": None,
         }
         kinds = {
             "any_left": "any",
@@ -1271,11 +1272,12 @@ class SQLGlotCompiler(abc.ABC):
             "anti": "anti",
             "cross": "cross",
             "outer": "outer",
+            "positional": "positional",
         }
-        assert (
-            predicates or how == "cross"
-        ), "expected non-empty predicates when not a cross join"
-
+        assert predicates or how in {
+            "cross",
+            "positional",
+        }, "expected non-empty predicates when not a cross join"
         on = sg.and_(*predicates) if predicates else None
         return sge.Join(this=table, side=sides[how], kind=kinds[how], on=on)
 

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -385,3 +385,33 @@ def test_join_conflicting_columns(backend, con):
         }
     )
     backend.assert_frame_equal(result, expected)
+
+
+@pytest.mark.never(
+    [
+        "bigquery",
+        "clickhouse",
+        "datafusion",
+        "druid",
+        "exasol",
+        "flink",
+        "impala",
+        "mssql",
+        "mysql",
+        "oracle",
+        "polars",
+        "postgres",
+        "pyspark",
+        "risingwave",
+        "snowflake",
+        "sqlite",
+    ],
+    reason="Users can implement this with ibis.row_number(): https://github.com/ibis-project/ibis/issues/9486",
+)
+def test_positional_join(backend, con):
+    t1 = ibis.memtable({"x": [1, 2, 3]})
+    t2 = ibis.memtable({"x": [3, 2, 1]})
+    j = t1.join(t2, how="positional")
+    result = con.execute(j)
+    expected = pd.DataFrame({"x": [1, 2, 3], "x_right": [3, 2, 1]})
+    backend.assert_frame_equal(result, expected)

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -399,7 +399,6 @@ def test_join_conflicting_columns(backend, con):
         "mssql",
         "mysql",
         "oracle",
-        "polars",
         "postgres",
         "pyspark",
         "risingwave",

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -404,6 +404,7 @@ def test_join_conflicting_columns(backend, con):
         "risingwave",
         "snowflake",
         "sqlite",
+        "trino",
     ],
     reason="Users can implement this with ibis.row_number(): https://github.com/ibis-project/ibis/issues/9486",
 )

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -205,6 +205,7 @@ JoinKind = Literal[
     "any_inner",
     "any_left",
     "cross",
+    "positional",
 ]
 
 

--- a/ibis/expr/types/joins.py
+++ b/ibis/expr/types/joins.py
@@ -265,7 +265,7 @@ class Join(Table):
         # bind and dereference the predicates
         preds = prepare_predicates(chain, right, predicates)
         preds = flatten_predicates(preds)
-        if not preds and how != "cross":
+        if not preds and how not in {"cross", "positional"}:
             # if there are no predicates, default to every row matching unless
             # the join is a cross join, because a cross join already has this
             # behavior


### PR DESCRIPTION
closes https://github.com/ibis-project/ibis/issues/9486. 

Add positional join to duckdb, pandas, and dask backends.

Amazingly simple to implement, a big cheers to the previous developers that made this code so clean and easy to edit!

By luck or magic, the pandas and dask backends seem to just work with no modification!

Should this be documented somewhere? I hesitate to clutter up the examples with this simple example. Really, I think the better thing that ibis really needs is a how-to guide on joining, where someone *actually* goes deep into the weeds and explains how things work.