### PR TITLE
feat(datafusion): datafusion enhancements

### DIFF
--- a/ibis/backends/datafusion/tests/test_register.py
+++ b/ibis/backends/datafusion/tests/test_register.py
@@ -50,3 +50,9 @@ def test_register_dataset(conn):
     with pytest.warns(FutureWarning, match="v9.1"):
         conn.register(dataset, "my_table")
         assert conn.table("my_table").x.sum().execute() == 6
+
+
+def test_create_table_with_uppercase_name(conn):
+    tab = pa.table({"x": [1, 2, 3]})
+    conn.create_table("MY_TABLE", tab)
+    assert conn.table("MY_TABLE").x.sum().execute() == 6


### PR DESCRIPTION
- change collect to execute_stream, `collect` pulls all the data in memory, `execute_stream` only pulls partial data (reducing memory consumed)

- fix creation of table with uppercase name and object (`pa.Table`, `pd.DataFrame`, etc)

- remove the use of strings literal for dialect


