### PR TITLE
fix(postgres): add dtype mapping for `citext`

### DIFF
--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -441,6 +441,8 @@ class PostgresType(SqlglotType):
             "information_schema.time_stamp": dt.timestamp,
             # the pre-bool version of bool kept for backwards compatibility
             "information_schema.yes_or_no": dt.string,
+            # a case-insensitive string that has it's own type for some reason
+            "citext": dt.string,
         }
     )
 


### PR DESCRIPTION
## Description of changes

`citext` is a case-insensitive text field.
https://www.postgresql.org/docs/current/citext.html

Seems reasonable to map this to a `dt.string`

## Issues closed

Resolves #9545