### PR TITLE
refactor(streamlit): update to use BaseConnection interface

### DIFF
--- a/docs/how-to/visualization/example_streamlit_app/example_streamlit_app.py
+++ b/docs/how-to/visualization/example_streamlit_app/example_streamlit_app.py
@@ -27,10 +27,10 @@ options = [1, 5, 10, 25, 50, 100]
 @st.cache_data
 def query():
     return (
-        con.tables.recipes.relabel("snake_case")
+        con.tables.recipes.rename("snake_case")
         .mutate(ner=_.ner.map(lambda n: n.lower()).unnest())
         .ner.topk(max(options))
-        .relabel(dict(ner="ingredient"))
+        .rename(ingredient="ner")
         .to_pandas()
         .assign(
             emoji=lambda df: df.ingredient.map(
@@ -43,7 +43,7 @@ def query():
 
 emojis = get_emoji()
 
-con = st.experimental_connection("ch", type=IbisConnection)
+con = st.connection("ch", type=IbisConnection)
 
 if n := st.radio("Ingredients", options, index=1, horizontal=True):
     table, whole = st.columns((2, 1))

--- a/docs/how-to/visualization/streamlit.qmd
+++ b/docs/how-to/visualization/streamlit.qmd
@@ -1,6 +1,6 @@
 # Streamlit + Ibis
 
-Ibis supports the [streamlit `experimental_connection` interface](https://blog.streamlit.io/introducing-st-experimental_connection/), making it easier than ever to combine the powers of both tools!
+Ibis supports the [streamlit `connection` interface](https://docs.streamlit.io/develop/concepts/connections/connecting-to-data), making it easier than ever to combine the powers of both tools!
 
 Check out the example application below that shows the top N ingredients from a corpus of recipes using [the ClickHouse backend](../../backends/clickhouse.qmd)!
 

--- a/ibis/streamlit/__init__.py
+++ b/ibis/streamlit/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from streamlit.connections import ExperimentalBaseConnection
+from streamlit.connections import BaseConnection
 from streamlit.runtime.caching import cache_data
 
 import ibis
@@ -11,14 +11,14 @@ from ibis.backends import BaseBackend
 __all__ = ["IbisConnection"]
 
 
-class IbisConnection(ExperimentalBaseConnection[BaseBackend]):
+class IbisConnection(BaseConnection[BaseBackend]):
     def _connect(self, **kwargs: Any) -> BaseBackend:
         """Connect to the backend and return a client object.
 
-        This method is invoked when `st.experimental_connection` is called and
-        pulls information from streamlit secrets. `_connect` is part of the
-        streamlit connection API to be implemented by developers of specific
-        connection types.
+        This method is invoked when `st.connection` is called and pulls
+        information from streamlit secrets. `_connect` is part of the streamlit
+        connection API to be implemented by developers of specific connection
+        types.
 
         Here's an example not-so-secret configuration:
 
@@ -48,7 +48,7 @@ class IbisConnection(ExperimentalBaseConnection[BaseBackend]):
 
         from ibis.streamlit import IbisConnection
 
-        con = st.experimental_connection("ch", type=IbisConnection)
+        con = st.connection("ch", type=IbisConnection)
 
         # Now you can use `con` as if it were an ibis backend
         con.list_tables()


### PR DESCRIPTION
## Description of changes

The Streamlit `connection` interface is no longer experimental as of https://github.com/streamlit/streamlit/pull/7536. 

`st.experimental_connection` was deprecated in Streamlit version 1.28.0 and replaced with [st.connection](https://docs.streamlit.io/develop/api-reference/connections/st.connection). 

Adjustments:
- `IbisConnection` class definition uses BaseConnection instead of ExperimentalBaseConnection.
- References of `st.experimental_connection` to use `st.connection`
- Usage of `relabel` to `rename` in the example application.
- "How To Streamlit + Ibis" post to reference `connection` usage with Streamlit developer documentation. 