### PR TITLE
perf(duckdb): speedup timestamp conversion by avoiding conversion to object

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1393,7 +1393,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
                         # but calling `to_pylist()` will render it as None
                         col.null_count
                     )
-                    else col.to_pandas(timestamp_as_object=True)
+                    else col.to_pandas()
                 )
                 for name, col in zip(table.column_names, table.columns)
             }

--- a/ibis/backends/tests/test_asof_join.py
+++ b/ibis/backends/tests/test_asof_join.py
@@ -111,7 +111,8 @@ def test_asof_join(con, time_left, time_right, time_df1, time_df2, direction, op
     result = result.sort_values(["group", "time"]).reset_index(drop=True)
     expected = expected.sort_values(["group", "time"]).reset_index(drop=True)
 
-    tm.assert_frame_equal(result[expected.columns], expected)
+    # duckdb returns datetime64[us], pandas defaults to use datetime64[ns]
+    tm.assert_frame_equal(result[expected.columns], expected, check_dtype=False)
     with pytest.raises(AssertionError):
         tm.assert_series_equal(result["time"], result["time_right"])
 

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -200,8 +200,10 @@ class PandasData(DataMapper):
 
     @classmethod
     def convert_Timestamp(cls, s, dtype, pandas_type):
-        if isinstance(dtype, pd.DatetimeTZDtype):
-            return s.dt.tz_convert(dtype.timezone)
+        if isinstance(pandas_type, pd.DatetimeTZDtype) and isinstance(
+            s.dtype, pd.DatetimeTZDtype
+        ):
+            return s if s.dtype == pandas_type else s.dt.tz_convert(dtype.timezone)
         elif pdt.is_datetime64_dtype(s.dtype):
             return s.dt.tz_localize(dtype.timezone)
         else:


### PR DESCRIPTION
Redo of #9554. The slow bit here was object conversion of timestamps, which seemed to only be hit by this one test.