### PR TITLE
chore(test): consolidate ifelse() and case() tests

### DIFF
--- a/ibis/backends/dask/tests/test_operations.py
+++ b/ibis/backends/dask/tests/test_operations.py
@@ -773,64 +773,6 @@ def test_quantile_group_by(batting, batting_pandas_df):
     tm.assert_series_equal(result, expected, check_index=False)
 
 
-def test_searched_case_scalar(client):
-    expr = ibis.case().when(True, 1).when(False, 2).end()
-    result = client.execute(expr)
-    expected = np.int8(1)
-    assert result == expected
-
-
-def test_searched_case_column(batting, batting_pandas_df):
-    t = batting
-    df = batting_pandas_df
-    expr = (
-        ibis.case()
-        .when(t.RBI < 5, "really bad team")
-        .when(t.teamID == "PH1", "ph1 team")
-        .else_(t.teamID)
-        .end()
-    )
-    result = expr.execute()
-    expected = pd.Series(
-        np.select(
-            [df.RBI < 5, df.teamID == "PH1"],
-            ["really bad team", "ph1 team"],
-            df.teamID,
-        )
-    )
-    tm.assert_series_equal(result, expected, check_names=False)
-
-
-def test_simple_case_scalar(client):
-    x = ibis.literal(2)
-    expr = x.case().when(2, x - 1).when(3, x + 1).when(4, x + 2).end()
-    result = client.execute(expr)
-    expected = np.int8(1)
-    assert result == expected
-
-
-def test_simple_case_column(batting, batting_pandas_df):
-    t = batting
-    df = batting_pandas_df
-    expr = (
-        t.RBI.case()
-        .when(5, "five")
-        .when(4, "four")
-        .when(3, "three")
-        .else_("could be good?")
-        .end()
-    )
-    result = expr.execute()
-    expected = pd.Series(
-        np.select(
-            [df.RBI == 5, df.RBI == 4, df.RBI == 3],
-            ["five", "four", "three"],
-            "could be good?",
-        )
-    )
-    tm.assert_series_equal(result, expected, check_names=False)
-
-
 def test_table_distinct(t, df):
     expr = t[["dup_strings"]].distinct()
     result = expr.compile()

--- a/ibis/backends/pandas/tests/test_operations.py
+++ b/ibis/backends/pandas/tests/test_operations.py
@@ -683,64 +683,6 @@ def test_summary_non_numeric(batting, batting_df):
     assert dict(result.iloc[0]) == expected
 
 
-def test_searched_case_scalar(client):
-    expr = ibis.case().when(True, 1).when(False, 2).end()
-    result = client.execute(expr)
-    expected = np.int8(1)
-    assert result == expected
-
-
-def test_searched_case_column(batting, batting_df):
-    t = batting
-    df = batting_df
-    expr = (
-        ibis.case()
-        .when(t.RBI < 5, "really bad team")
-        .when(t.teamID == "PH1", "ph1 team")
-        .else_(t.teamID)
-        .end()
-    )
-    result = expr.execute()
-    expected = pd.Series(
-        np.select(
-            [df.RBI < 5, df.teamID == "PH1"],
-            ["really bad team", "ph1 team"],
-            df.teamID,
-        )
-    )
-    tm.assert_series_equal(result, expected)
-
-
-def test_simple_case_scalar(client):
-    x = ibis.literal(2)
-    expr = x.case().when(2, x - 1).when(3, x + 1).when(4, x + 2).end()
-    result = client.execute(expr)
-    expected = np.int8(1)
-    assert result == expected
-
-
-def test_simple_case_column(batting, batting_df):
-    t = batting
-    df = batting_df
-    expr = (
-        t.RBI.case()
-        .when(5, "five")
-        .when(4, "four")
-        .when(3, "three")
-        .else_("could be good?")
-        .end()
-    )
-    result = expr.execute()
-    expected = pd.Series(
-        np.select(
-            [df.RBI == 5, df.RBI == 4, df.RBI == 3],
-            ["five", "four", "three"],
-            "could be good?",
-        )
-    )
-    tm.assert_series_equal(result, expected)
-
-
 def test_non_range_index():
     def do_replace(col):
         return col.cases(

--- a/ibis/backends/tests/test_conditionals.py
+++ b/ibis/backends/tests/test_conditionals.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections import Counter
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import ibis
+
+
+def test_ifelse_select(backend, alltypes, df):
+    table = alltypes
+    table = table.select(
+        [
+            "int_col",
+            (
+                ibis.ifelse(table["int_col"] == 0, 42, -1)
+                .cast("int64")
+                .name("where_col")
+            ),
+        ]
+    )
+
+    result = table.execute()
+
+    expected = df.loc[:, ["int_col"]].copy()
+
+    expected["where_col"] = -1
+    expected.loc[expected["int_col"] == 0, "where_col"] = 42
+
+    backend.assert_frame_equal(result, expected)
+
+
+def test_ifelse_column(backend, alltypes, df):
+    expr = ibis.ifelse(alltypes["int_col"] == 0, 42, -1).cast("int64").name("where_col")
+    result = expr.execute()
+
+    expected = pd.Series(
+        np.where(df.int_col == 0, 42, -1),
+        name="where_col",
+        dtype="int64",
+    )
+
+    backend.assert_series_equal(result, expected)
+
+
+def test_substitute(backend):
+    val = "400"
+    t = backend.functional_alltypes
+    expr = (
+        t.string_col.nullif("1")
+        .substitute({None: val})
+        .name("subs")
+        .value_counts()
+        .filter(lambda t: t.subs == val)
+    )
+    assert expr["subs_count"].execute()[0] == t.count().execute() // 10
+
+
+@pytest.mark.parametrize(
+    "inp, exp",
+    [
+        pytest.param(
+            lambda: ibis.literal(1)
+            .case()
+            .when(1, "one")
+            .when(2, "two")
+            .else_("other")
+            .end(),
+            "one",
+            id="one_kwarg",
+        ),
+        pytest.param(
+            lambda: ibis.literal(5).case().when(1, "one").when(2, "two").end(),
+            None,
+            id="fallthrough",
+        ),
+    ],
+)
+def test_value_cases_scalar(con, inp, exp):
+    result = con.execute(inp())
+    if exp is None:
+        assert pd.isna(result)
+    else:
+        assert result == exp
+
+
+@pytest.mark.broken(
+    "exasol",
+    reason="the int64 RBI column is .to_pandas()ed to an object column, which is incomparable to ints",
+    raises=AssertionError,
+)
+def test_value_cases_column(batting):
+    df = batting.to_pandas()
+    expr = (
+        batting.RBI.case()
+        .when(5, "five")
+        .when(4, "four")
+        .when(3, "three")
+        .else_("could be good?")
+        .end()
+    )
+    result = expr.execute()
+    expected = np.select(
+        [df.RBI == 5, df.RBI == 4, df.RBI == 3],
+        ["five", "four", "three"],
+        "could be good?",
+    )
+
+    assert Counter(result) == Counter(expected)
+
+
+def test_ibis_cases_scalar():
+    expr = ibis.literal(5).case().when(5, "five").when(4, "four").end()
+    result = expr.execute()
+    assert result == "five"
+
+
+@pytest.mark.broken(
+    ["sqlite", "exasol"],
+    reason="the int64 RBI column is .to_pandas()ed to an object column, which is incomparable to 5",
+    raises=TypeError,
+)
+def test_ibis_cases_column(batting):
+    t = batting
+    df = batting.to_pandas()
+    expr = (
+        ibis.case()
+        .when(t.RBI < 5, "really bad team")
+        .when(t.teamID == "PH1", "ph1 team")
+        .else_(t.teamID)
+        .end()
+    )
+    result = expr.execute()
+    expected = np.select(
+        [df.RBI < 5, df.teamID == "PH1"],
+        ["really bad team", "ph1 team"],
+        df.teamID,
+    )
+
+    assert Counter(result) == Counter(expected)
+
+
+@pytest.mark.broken("clickhouse", reason="special case this and returns 'oops'")
+def test_value_cases_null(con):
+    """CASE x WHEN NULL never gets hit"""
+    e = ibis.literal(5).nullif(5).case().when(None, "oops").else_("expected").end()
+    assert con.execute(e) == "expected"

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1082,42 +1082,6 @@ def test_zero_ifnull_column(backend, alltypes, df):
     backend.assert_series_equal(result, expected)
 
 
-def test_ifelse_select(backend, alltypes, df):
-    table = alltypes
-    table = table.select(
-        [
-            "int_col",
-            (
-                ibis.ifelse(table["int_col"] == 0, 42, -1)
-                .cast("int64")
-                .name("where_col")
-            ),
-        ]
-    )
-
-    result = table.execute()
-
-    expected = df.loc[:, ["int_col"]].copy()
-
-    expected["where_col"] = -1
-    expected.loc[expected["int_col"] == 0, "where_col"] = 42
-
-    backend.assert_frame_equal(result, expected)
-
-
-def test_ifelse_column(backend, alltypes, df):
-    expr = ibis.ifelse(alltypes["int_col"] == 0, 42, -1).cast("int64").name("where_col")
-    result = expr.execute()
-
-    expected = pd.Series(
-        np.where(df.int_col == 0, 42, -1),
-        name="where_col",
-        dtype="int64",
-    )
-
-    backend.assert_series_equal(result, expected)
-
-
 def test_select_filter(backend, alltypes, df):
     t = alltypes
 
@@ -2266,19 +2230,6 @@ def test_sample_with_seed(backend):
     df1 = expr.to_pandas()
     df2 = expr.to_pandas()
     backend.assert_frame_equal(df1, df2)
-
-
-def test_substitute(backend):
-    val = "400"
-    t = backend.functional_alltypes
-    expr = (
-        t.string_col.nullif("1")
-        .substitute({None: val})
-        .name("subs")
-        .value_counts()
-        .filter(lambda t: t.subs == val)
-    )
-    assert expr["subs_count"].execute()[0] == t.count().execute() // 10
 
 
 @pytest.mark.notimpl(


### PR DESCRIPTION
Prepping for https://github.com/ibis-project/ibis/pull/9096

- moves several .ifelse() and .substitute() tests from ibis/backens/test/test_generic.py into a new test_conditionals.py
- moves some .case() tests from the pandas and dask backends into there, so the other backends are now tested as well, and removed duplication.
- adds a test case that `ibis.literal(5).nullif(5).case().when(None, "oops").else_("expected")` results in "expected". Not saying this is actually the best behavior,
but it is currently what we claim to be expected. Perhaps we want to revisit.