### PR TITLE
ci(trino): pin to 449 to avoid truncate table memory bug

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -156,7 +156,7 @@ services:
       test:
         - CMD-SHELL
         - trino --output-format null --execute 'show schemas in hive; show schemas in memory'
-    image: trinodb/trino:452
+    image: trinodb/trino:449
     ports:
       - 8080:8080
     networks:


### PR DESCRIPTION
Pin trino for now until the truncate table statement for in-memory connector can be fixed. See https://github.com/trinodb/trino/pull/22337#issuecomment-2227135370 for a reproducer.