### PR TITLE
feat(dtypes): fall back to `dt.unknown` for unknown types

### DIFF
--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pandas.testing as tm
 import pytest
-import sqlglot as sg
 from pytest import param
 
 import ibis
@@ -158,7 +157,9 @@ def test_field_access_after_case(con):
 )
 @pytest.mark.notimpl(["flink"], raises=IbisError, reason="not implemented in ibis")
 @pytest.mark.notyet(
-    ["clickhouse"], raises=sg.ParseError, reason="sqlglot fails to parse"
+    ["clickhouse"],
+    raises=AssertionError,
+    reason="sqlglot fails to parse, fall back to unknown",
 )
 @pytest.mark.parametrize(
     "nullable",
@@ -189,8 +190,8 @@ def test_field_access_after_case(con):
 )
 @pytest.mark.broken(
     ["trino"],
-    raises=sg.ParseError,
-    reason="trino returns unquoted and therefore unparsable struct field names",
+    raises=AssertionError,
+    reason="trino returns unquoted and therefore unparsable struct field names, we fall back to dt.unknown",
 )
 @pytest.mark.notyet(
     ["snowflake"],


### PR DESCRIPTION
We've had a number of issues where we haven't exposed a mapping to a
particular (usually Postgres) dtype.

We'll still have requests to provide useful mappings, depending on the
upstream dtype, but this should prevent users being unable to even open
a table because there's an unknown / user-defined dtype present in the
table.

To test, I've removed the special handling for the `vector` and
`ts.vector` types that we were explicitly mapping to `dt.unknown`.

Trying this one again...
