### PR TITLE
fix(bigquery): escape table names with spaces for bigquery backend

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -40,7 +40,6 @@ from ibis.backends.sql.datatypes import BigQueryType
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from pathlib import Path
-    from urllib.parse import ParseResult
 
     import pandas as pd
     import polars as pl
@@ -548,10 +547,10 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         self, name: str, database: str | None = None, schema: str | None = None
     ) -> ir.Table:
         table_loc = self._warn_and_create_table_loc(database, schema)
-
+        name = f"`{name}`"
         table = sg.parse_one(name, into=sge.Table, read=self.name)
 
-        # Bigquery, unlike other bcakends, had existing support for specifying
+        # Bigquery, unlike other backends, had existing support for specifying
         # table hierarchy in the table name, e.g. con.table("dataset.table_name")
         # so here we have an extra layer of disambiguation to handle.
 
@@ -582,8 +581,6 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         )
 
         project, dataset = self._parse_project_and_dataset(database)
-
-        table = sg.parse_one(name, into=sge.Table, read=self.name)
 
         bq_table = self.client.get_table(
             bq.TableReference(

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -548,8 +548,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         self, name: str, database: str | None = None, schema: str | None = None
     ) -> ir.Table:
         table_loc = self._warn_and_create_table_loc(database, schema)
-        name = f"`{name}`"
-        table = sg.parse_one(name, into=sge.Table, read=self.name)
+        table = sg.parse_one(f"`{name}`", into=sge.Table, read=self.name)
 
         # Bigquery, unlike other backends, had existing support for specifying
         # table hierarchy in the table name, e.g. con.table("dataset.table_name")

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -40,6 +40,7 @@ from ibis.backends.sql.datatypes import BigQueryType
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from pathlib import Path
+    from urllib.parse import ParseResult
 
     import pandas as pd
     import polars as pl

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -423,6 +423,17 @@ def test_create_temp_table_from_scratch(project_id, dataset_id):
     assert len(t.execute()) == 1
 
 
+def test_create_table_from_scratch_with_spaces(project_id, dataset_id):
+    con = ibis.bigquery.connect(project_id=project_id, dataset_id=dataset_id)
+    name = f"{gen_name('bigquery_temp_table')} with spaces"
+    df = con.tables.functional_alltypes.limit(1)
+    t = con.create_table(name, obj=df)
+    try:
+        assert len(t.execute()) == 1
+    finally:
+        con.drop_table(name)
+
+
 def test_table_suffix():
     con = ibis.connect("bigquery://ibis-gbq")
     t = con.table("gsod*", database="bigquery-public-data.noaa_gsod")


### PR DESCRIPTION
## Description of changes

[bigquery docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical) "[Identifiers] Must be enclosed by backtick (`) characters."

- enclose table names with backticks to avoid failures when spaces are included 
- remove L.586 as it appears to be redundant (see L.551)
- fix typo

## Issues closed

* Resolves #9588 
