### PR TITLE
docs: add `deferred`, `range`, `e`, and `pi` to API reference

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -286,12 +286,19 @@ quartodoc:
             name: Generic expressions
             desc: Scalars and columns of any element type.
           contents:
+            # types
             - name: Value
               package: ibis.expr.types.generic
             - name: Column
               package: ibis.expr.types.generic
+            - name: Deferred
+              package: ibis.common.deferred
             - name: Scalar
               package: ibis.expr.types.generic
+
+            # constants
+            - name: deferred
+              package: ibis.expr.api
             - name: literal
               dynamic: true
               signature_name: full
@@ -301,19 +308,18 @@ quartodoc:
             - name: "null"
               dynamic: true
               signature_name: full
+            - name: range
+              dynamic: true
+              signature_name: full
             - name: coalesce
               dynamic: true
               signature_name: full
+
+            # comparisons
             - name: least
               dynamic: true
               signature_name: full
             - name: greatest
-              dynamic: true
-              signature_name: full
-            - name: asc
-              dynamic: true
-              signature_name: full
-            - name: desc
               dynamic: true
               signature_name: full
             - name: ifelse
@@ -322,6 +328,17 @@ quartodoc:
             - name: case
               dynamic: true
               signature_name: full
+
+            # sorting
+            - name: asc
+              dynamic: true
+              signature_name: full
+            - name: desc
+              dynamic: true
+              signature_name: full
+
+            # conversions
+            # TODO: add decompile here once the API is not experimental
             - name: to_sql
               dynamic: true
               signature_name: full
@@ -355,6 +372,12 @@ quartodoc:
             - name: random
               dynamic: true
               signature_name: full
+
+            # constants
+            - name: e
+              package: ibis.expr.api
+            - name: pi
+              package: ibis.expr.api
 
         - kind: page
           path: expression-strings
@@ -642,6 +665,13 @@ quartodoc:
             desc: "Scalar user-defined function APIs"
           contents:
             - scalar
+        - kind: page
+          path: aggregate-udfs
+          summary:
+            name: Aggregate UDFs (experimental)
+            desc: "Aggregate user-defined function APIs"
+          contents:
+            - agg
 
     - title: Configuration
       desc: "Ibis configuration"

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -22,8 +22,6 @@ interlinks:
   sources:
     python:
       url: https://docs.python.org/3/
-    sqlalchemy:
-      url: https://docs.sqlalchemy.org/
     arrow:
       url: https://arrow.apache.org/docs/
     pandas:

--- a/docs/presentations-listing.json
+++ b/docs/presentations-listing.json
@@ -1,8 +1,0 @@
-{
-  "listing": "/presentations.html",
-  "items": [
-    "/presentations/pycon2024/maintainers.html",
-    "/presentations/linkedin-meetup-2024-04-24.html",
-    "/presentations/overview.html"
-  ]
-}

--- a/docs/presentations-listing.json
+++ b/docs/presentations-listing.json
@@ -1,0 +1,8 @@
+{
+  "listing": "/presentations.html",
+  "items": [
+    "/presentations/pycon2024/maintainers.html",
+    "/presentations/linkedin-meetup-2024-04-24.html",
+    "/presentations/overview.html"
+  ]
+}

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2094,8 +2094,8 @@ def range(start, stop, step) -> ir.ArrayValue:
     Integer ranges are supported, as well as timestamp ranges.
 
     ::: {.callout-note}
-    `start` is inclucive and `stop` is exclusive, just like Python's builtin
-    [`range`](range).
+    `start` is inclusive and `stop` is exclusive, just like Python's builtin
+    [`range`](:py:class:`range`).
 
     When `step` equals 0, however, this function will return an empty array.
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2095,7 +2095,7 @@ def range(start, stop, step) -> ir.ArrayValue:
 
     ::: {.callout-note}
     `start` is inclusive and `stop` is exclusive, just like Python's builtin
-    [`range`](:py:class:`range`).
+    [](`range`).
 
     When `step` equals 0, however, this function will return an empty array.
 

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -559,6 +559,13 @@ class scalar(_UDF):
 
 @public
 class agg(_UDF):
+    """Aggregate user-defined functions.
+
+    ::: {.callout-note}
+    ## The `agg` class itself is **not** a public API, its methods are.
+    :::
+    """
+
     __slots__ = ()
 
     _base = AggUDF


### PR DESCRIPTION
## Description of changes

Some top-level APIs were missing from the API reference. This adds them.
