### PR TITLE
chore(justfile): add check to justfile docs preview commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -171,10 +171,26 @@ docs-apigen *args:
 
 # build documentation
 docs-render:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Check if the folder "reference" exists and has contents
+    if [ ! -d "docs/reference" ] || [ -z "$(ls -A docs/reference)" ]; then
+        just docs-apigen
+    fi
+
     quarto render docs
 
 # preview docs
 docs-preview:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Check if the folder "reference" exists and has contents
+    if [ ! -d "docs/reference" ] || [ -z "$(ls -A docs/reference)" ]; then
+        just docs-apigen
+    fi
+
     quarto preview docs
 
 # regen api and preview docs


### PR DESCRIPTION
the `quartodoc` output lives in `docs/reference`, so if that folder
doesn't exist, or if it is empty, we can run the `docs-apigen` justfile
target to make sure the build succeeds.

There will definitely still be failure modes in here, but this should
cover the most common ones.

xref #9555