### PR TITLE
fix(join): dereference literals in values of JoinChain

### DIFF
--- a/ibis/expr/rewrites.py
+++ b/ibis/expr/rewrites.py
@@ -55,7 +55,7 @@ class DerefMap(Concrete, Traversable):
     rels: VarTuple[ops.Relation]
 
     """Substitution mapping from values of earlier relations to the fields of `rels`."""
-    subs: FrozenDict[ops.Value, ops.Field]
+    subs: FrozenDict[ops.Value, ops.Field | ops.Literal]
 
     """Ambiguous field references."""
     ambigs: FrozenDict[ops.Value, VarTuple[ops.Value]]


### PR DESCRIPTION
## Description of changes

`Literal`s as value of a `JoinChain` should be substituted through subsequent joins like in the example illustrated in #9561 .

A statement like
`t3 = t1.inner_join(t2, "i").select("i", lit=1)` creates a `JoinChain` looking like
```
JoinChain[r0]
  JoinLink[inner, r1]
    r0.i == r1.i
  values:
    i:     r0.i
    lit:   1
```
with one of the reference "fields" in `values` actually pointing to a `Literal`.

Adding a subsequent `JoinLink` to this `JoinChain` like by
`t5 = t3.inner_join(t4, "i")` fails in `prepare_predicates`, since the `DerefMap.from_targets(..., extra=reverse)` call tries to add a substitute from the new `lit`-field to the `Literal(1)` object, which does not fit the `Field` type, that the `subs` attribute of the `DerefMap` are expected to have.

Allowing also `Literal` fixes this specific example.

*NOTE*: I am wondering if general `Value`s should be allowed.

In general, I am very unsure about the greater implications.

Will think about a small test.

## Issues closed

* Resolves #9561