### PR TITLE
fix(join): skip substitution of non-field references in join chains

### DIFF
--- a/ibis/expr/tests/test_newrels.py
+++ b/ibis/expr/tests/test_newrels.py
@@ -1769,6 +1769,7 @@ def test_projections_with_similar_expressions_have_different_names():
 def test_expr_in_join_projection():
     t1 = ibis.table({"a": "int64", "b": "string"}, name="t1")
     t2 = ibis.table({"c": "int64", "b": "string"}, name="t2")
+    t3 = ibis.table({"a": "int64", "d": "int64"}, name="t3")
     expr = t1.inner_join(t2, "b").select(
         "a", lit1=1, lit2=2 * t1.a, lit3=_.c - 5, lit4=t2.b.length() / 2.0
     )
@@ -1778,6 +1779,20 @@ def test_expr_in_join_projection():
     assert op.schema == ibis.schema(
         {
             "a": "int64",
+            "lit1": "int8",
+            "lit2": "int64",
+            "lit3": "int64",
+            "lit4": "float64",
+        }
+    )
+
+    expr2 = expr.inner_join(t3, "a").select("a", "d", "lit1", "lit2", "lit3", "lit4")
+    op2 = expr2.op()
+    assert isinstance(op2, ops.JoinChain)
+    assert op2.schema == ibis.schema(
+        {
+            "a": "int64",
+            "d": "int64",
             "lit1": "int8",
             "lit2": "int64",
             "lit3": "int64",

--- a/ibis/expr/tests/test_newrels.py
+++ b/ibis/expr/tests/test_newrels.py
@@ -1764,3 +1764,23 @@ def test_projections_with_similar_expressions_have_different_names():
     assert b.op().name in fields
 
     assert expr.schema() == ibis.schema({a.op().name: "string", b.op().name: "string"})
+
+
+def test_expr_in_join_projection():
+    t1 = ibis.table({"a": "int64", "b": "string"}, name="t1")
+    t2 = ibis.table({"c": "int64", "b": "string"}, name="t2")
+    expr = t1.inner_join(t2, "b").select(
+        "a", lit1=1, lit2=2 * t1.a, lit3=_.c - 5, lit4=t2.b.length() / 2.0
+    )
+
+    op = expr.op()
+    assert isinstance(op, ops.JoinChain)
+    assert op.schema == ibis.schema(
+        {
+            "a": "int64",
+            "lit1": "int8",
+            "lit2": "int64",
+            "lit3": "int64",
+            "lit4": "float64",
+        }
+    )

--- a/ibis/expr/types/joins.py
+++ b/ibis/expr/types/joins.py
@@ -179,7 +179,11 @@ def prepare_predicates(
         The comparison operation to construct if the input is a pair of
         expression-like objects
     """
-    reverse = {ops.Field(chain, k): v for k, v in chain.values.items()}
+    reverse = {
+        ops.Field(chain, k): v
+        for k, v in chain.values.items()
+        if isinstance(v, ops.Field)
+    }
     deref_right = DerefMap.from_targets(right)
     deref_left = DerefMap.from_targets(chain.tables, extra=reverse)
     deref_both = DerefMap.from_targets([*chain.tables, right], extra=reverse)


### PR DESCRIPTION
## Description of changes

As alternative to #9594, we here avoid the same signature error raised in #9561, when a `Literal` or more general `Value` in a `JoinChain` fails to be included in a `DerefMap`.

A statement like
`t3 = t1.inner_join(t2, "i").select("i", lit=1, val=2 * t1.x)` creates a `JoinChain` looking like
```
JoinChain[r0]
  JoinLink[inner, r1]
    r0.i == r1.i
  values:
    i:     r0.i
    lit:   1
    val:   2 * r0.x
```
with one of the reference "fields" in `values` actually pointing to a `Literal` and another one to a more general `Value`.

Adding a subsequent `JoinLink` to this `JoinChain` like by
`t5 = t3.inner_join(t4, "i")` fails in `prepare_predicates`, since the `DerefMap.from_targets(..., extra=reverse)` call tries to add a substitute from the new `lit`-field to the `Literal(1)` object and from `val` to the `Value`-like expression, which both do not fit the `Field` type, that the `subs` attribute of the `DerefMap` are expected to have.

Here we skip those as direct substitution possibilities.

## Issues closed

* Resolves #9561
