### PR TITLE
fix(pyspark): set lower bound of pyspark to 3.3.3 to avoid maintenance burden of pytest collection hook

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -680,7 +680,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.10"
-            pyspark-version: "3.3"
+            pyspark-version: "3.3.3"
             deps:
               - "'pandas@<2'"
               - "'numpy@<1.24'"

--- a/poetry.lock
+++ b/poetry.lock
@@ -7755,4 +7755,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "dfb7c483def7e2d0fded85c445aba1a47a725df201fd5429971124b986ff99c9"
+content-hash = "5eb74c4ef2fa148954d23067f6101fb71c0bf4633716b88d0ca028c9f48144ce"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ pydruid = { version = ">=0.6.7,<1", optional = true }
 pyexasol = { version = ">=0.25.2,<1", optional = true, extras = ["pandas"] }
 pymysql = { version = ">=1,<2", optional = true }
 pyodbc = { version = ">=4.0.39,<6", optional = true }
-pyspark = { version = ">=3,<4", optional = true }
+pyspark = { version = ">=3.3.3,<4", optional = true }
 # used to support posix regexen in the pandas, dask and sqlite backends
 regex = { version = ">=2021.7.6", optional = true }
 shapely = { version = ">=2,<3", optional = true }


### PR DESCRIPTION
Increase the lower bound of pyspark to avoid a big hack in test collection. Also reduces hacking around numpy imports when making those optional in #9564.