### PR TITLE
docs(algolia): add methods from backend pages to algolia index

### DIFF
--- a/.github/workflows/upload-algolia-api.py
+++ b/.github/workflows/upload-algolia-api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations  # noqa: INP001
 
+import glob
+import json
 import os
 import re
 from functools import partial
@@ -92,6 +94,20 @@ def main():
     # record to the Algolia index.  If the object ID already exists, it gets
     # updated with the new fields in the record dict
     print(f"Uploading {len(records)} records to {index.name=}")  # noqa:T201
+    index.save_objects(records)
+
+    # Methods documented on backend-specific docs pages aren't scraped by Quarto
+    # since we construct them programmatically.
+    # There is a hook in docs/backends/_templates/api.qmd that calls
+    # `dump_methods_to_json_for_algolia` that serializes all the backend methods
+    # to a backend-specific json file in docs/backends/
+    # (Not Pandas and Impala because those backend pages don't use the template)
+    #
+    # Here, we load those records and upload them to the Algolia index
+    records = []
+    for record_json in glob.glob("docs/backends/*.json"):
+        with open(record_json) as f:
+            records.extend(json.load(f))
     index.save_objects(records)
 
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -18,6 +18,7 @@ objects.json
 # generated notebooks and files
 *.ipynb
 *_files
+backends/*_methods.json
 
 # inventories
 _inv

--- a/docs/backends/_templates/api.qmd
+++ b/docs/backends/_templates/api.qmd
@@ -2,7 +2,7 @@
 #| echo: false
 #| output: asis
 
-from _utils import get_backend, render_methods
+from _utils import get_backend, render_methods, dump_methods_to_json_for_algolia
 
 # defined in the backend qmd, e.g., ../bigquery.qmd
 module = BACKEND.lower()
@@ -16,6 +16,8 @@ methods = sorted(
     if not value.name.startswith("_")
     if value.name != "do_connect"
 )
+
+dump_methods_to_json_for_algolia(backend, methods)
 
 render_methods(backend, *methods, level=3)
 ```

--- a/docs/backends/_utils.py
+++ b/docs/backends/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from functools import cache, partial
 from typing import TYPE_CHECKING
 
@@ -78,3 +79,24 @@ def render_methods(obj, *methods: str, level: int) -> None:
 
 def render_do_connect(backend, level: int = 4) -> None:
     render_methods(get_backend(backend), "do_connect", level=level)
+
+
+def dump_methods_to_json_for_algolia(backend, methods):
+    backend_algolia_methods = list()
+    backend_name = backend.canonical_path.split(".")[2]
+    base_url_template = "backends/{backend}#ibis.backends.{backend}.Backend.{method}"
+
+    for method in methods:
+        base_url = base_url_template.format(backend=backend_name, method=method)
+        record = {
+            "objectID": base_url,
+            "href": base_url,
+            "title": f"{backend_name}.Backend.{method}",
+            "text": getattr(backend.all_members[method].docstring, "value", ""),
+            "crumbs": ["Backend API", "API", f"{backend_name} methods"],
+        }
+
+        backend_algolia_methods.append(record)
+
+    with open(f"{backend_name}_methods.json", "w") as f:
+        json.dump(backend_algolia_methods, f)


### PR DESCRIPTION
## Description of changes

The backend-specific methods are added to the backend pages
programmatically using `quarto`.  That seems to lead to them not showing
up in our Algolia search, because they aren't being scraped.

It's a little gross, but I've added in a section to our api docs
rendering scripts to also dump the corresponding records for each method
into a backend-specific json file during `quarto` rendering.

Then those backend-specific records files are loaded and added to the
Algolia index in `upload-algolia-api.py`


## Issues closed

Resolves #9600