### PR TITLE
test(flink): materialize results to avoid consuming an iterator to check for element membership

### DIFF
--- a/ibis/backends/flink/tests/test_memtable.py
+++ b/ibis/backends/flink/tests/test_memtable.py
@@ -35,7 +35,7 @@ def test_create_memtable(con, data, schema, expected):
     # cannot use con.execute(t) directly because of some behavioral discrepancy between
     # `TableEnvironment.execute_sql()` and `TableEnvironment.sql_query()`; this doesn't
     # seem to be an issue if we don't execute memtable directly
-    result = con.raw_sql(con.compile(t)).collect()
+    result = list(con.raw_sql(con.compile(t)).collect())
     for element in expected:
         assert element in result
 


### PR DESCRIPTION
See https://github.com/ibis-project/ibis/actions/runs/9960229065/job/27519021003?pr=9608 for an example failure.