### PR TITLE
fix(pyspark): set catalog and database with `USE` instead of pyspark api

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -743,6 +743,11 @@ jobs:
         if: matrix.pyspark-version == '3.5'
         run: poetry run pip install delta-spark
 
+      - name: install iceberg
+        shell: bash
+        if: matrix.pyspark-version == '3.5'
+        run: pushd "$(poetry run python -c "import pyspark; print(pyspark.__file__.rsplit('/', 1)[0])")/jars" && curl -LO https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.5.2/iceberg-spark-runtime-3.5_2.12-1.5.2.jar
+
       - name: run tests
         run: just ci-check -m pyspark
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -11,7 +11,6 @@ import sqlglot as sg
 import sqlglot.expressions as sge
 from packaging.version import parse as vparse
 from pyspark import SparkConf
-from pyspark.errors import ParseException as PySparkParseException
 from pyspark.sql import SparkSession
 from pyspark.sql.types import BooleanType, DoubleType, LongType, StringType
 
@@ -29,6 +28,11 @@ from ibis.backends.sql.compilers import PySparkCompiler
 from ibis.expr.operations.udf import InputType
 from ibis.legacy.udf.vectorized import _coerce_to_series
 from ibis.util import deprecated
+
+try:
+    from pyspark.errors import ParseException as PySparkParseException
+except ImportError:
+    from pyspark.sql.utils import ParseException as PySparkParseException
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -168,6 +168,16 @@ class TestConf(BackendTest):
             .config("spark.sql.streaming.schemaInference", True)
         )
 
+        config = (
+            config.config(
+                "spark.sql.extensions",
+                "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
+            )
+            .config("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog")
+            .config("spark.sql.catalog.local.type", "hadoop")
+            .config("spark.sql.catalog.local.warehouse", "icehouse")
+        )
+
         try:
             from delta.pip_utils import configure_spark_with_delta_pip
         except ImportError:

--- a/ibis/backends/pyspark/tests/test_client.py
+++ b/ibis/backends/pyspark/tests/test_client.py
@@ -10,25 +10,41 @@ def test_catalog_db_args(con, monkeypatch):
     monkeypatch.setattr(ibis.options, "default_backend", con)
     t = ibis.memtable({"epoch": [1712848119, 1712848121, 1712848155]})
 
+    assert con.current_catalog == "spark_catalog"
+    assert con.current_database == "ibis_testing"
+    con.create_database("toot", catalog="local")
+
     # create a table in specified catalog and db
-    con.create_table(
-        "t2", database=(con.current_catalog, "default"), obj=t, overwrite=True
-    )
+    con.create_table("t2", database=("local", "toot"), obj=t, overwrite=True)
+    con.create_table("t3", database=("spark_catalog", "default"), obj=t, overwrite=True)
+
+    assert con.current_database == "ibis_testing"
 
     assert "t2" not in con.list_tables()
-    assert "t2" in con.list_tables(database="default")
-    assert "t2" in con.list_tables(database="spark_catalog.default")
-    assert "t2" in con.list_tables(database=("spark_catalog", "default"))
+    assert "t2" in con.list_tables(database="local.toot")
+    assert "t2" in con.list_tables(database=("local", "toot"))
 
-    con.drop_table("t2", database="spark_catalog.default")
+    assert "t3" not in con.list_tables()
+    assert "t3" in con.list_tables(database="default")
+    assert "t3" in con.list_tables(database="spark_catalog.default")
 
-    assert "t2" not in con.list_tables(database="default")
+    con.drop_table("t2", database="local.toot")
+    con.drop_table("t3", database="spark_catalog.default")
+
+    assert "t2" not in con.list_tables(database="local.toot")
+    assert "t3" not in con.list_tables(database="spark_catalog.default")
+
+    con.drop_database("toot", catalog="local")
+
+    assert con.current_catalog == "spark_catalog"
+    assert con.current_database == "ibis_testing"
 
 
 def test_create_table_no_catalog(con, monkeypatch):
     monkeypatch.setattr(ibis.options, "default_backend", con)
     t = ibis.memtable({"epoch": [1712848119, 1712848121, 1712848155]})
 
+    assert con.current_database != "default"
     # create a table in specified catalog and db
     con.create_table("t2", database=("default"), obj=t, overwrite=True)
 
@@ -39,3 +55,4 @@ def test_create_table_no_catalog(con, monkeypatch):
     con.drop_table("t2", database="default")
 
     assert "t2" not in con.list_tables(database="default")
+    assert con.current_database != "default"

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -1,1 +1,16 @@
-_final: _prev: { }
+final: prev: {
+  pyspark = prev.pyspark.overridePythonAttrs (attrs:
+    let
+      icebergJarUrl = "https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.5.2/iceberg-spark-runtime-3.5_2.12-1.5.2.jar";
+      icebergJar = final.pkgs.fetchurl {
+        name = "iceberg-spark-runtime-3.5_2.12-1.5.2.jar";
+        url = icebergJarUrl;
+        sha256 = "12v1704h0bq3qr2fci0mckg9171lyr8v6983wpa83k06v1w4pv1a";
+      };
+    in
+    {
+      postInstall = attrs.postInstall or "" + ''
+        cp ${icebergJar} $out/${final.python.sitePackages}/pyspark/jars/${icebergJar.name}
+      '';
+    });
+}


### PR DESCRIPTION
## Description of changes

As reported in #9604, there is apparently a mismatch in permissioning structure
on Databricks, so that you can set a catalog and database (schema, ugh) with sql
by running `USE CATALOG`, but not via the pyspark api calls that (ostensibly) do
the same thing.

This, however, is not part of standard Spark SQL and is special
Databricks Spark SQL.

SO, we try the special databricks SQL, if that throws a parser error, we
fall back to using the pyspark API methods.

## Issues closed

Resolves #9604 