### PR TITLE
feat(expr): add `catalog` and `database` as options to `unbind`

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -682,12 +682,14 @@ class Expr(Immutable, Coercible):
             self, params=params, limit=limit, **kwargs
         )
 
-    def unbind(self) -> ir.Table:
+    def unbind(self, catalog=None, database=None) -> ir.Table:
         """Return an expression built on `UnboundTable` instead of backend-specific objects."""
         from ibis.expr.rewrites import _, d, p
 
+        namespace = ops.Namespace(catalog=catalog, database=database)
+
         rule = p.DatabaseTable >> d.UnboundTable(
-            name=_.name, schema=_.schema, namespace=_.namespace
+            name=_.name, schema=_.schema, namespace=namespace
         )
         return self.op().replace(rule).to_expr()
 


### PR DESCRIPTION
## Description of changes

Calling `unbind` on an expression removes all backend-specific
information from an expression, but some engine-specific details were
leaking through, especially with regards to
`catalog.database.table_name` hierarchies.

Here we add `catalog` and `database` as arguments to `unbind`, so we can
set specific namespace information on the newly unbound expression.  By
default, the arguments are `None`, which removes all namespacing
information and leaves only the base table names.


One case this doesn't currently cover is if an expression has multiple catalogs
and a user would like to specify a namespace on a per-table basis.  I think we
can leave that until we get a request for it.


## Issues closed

xref #9602