### PR TITLE
feat(flink): create views from more mem data types

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1732,6 +1732,9 @@ def test_schema_with_caching(alltypes):
 @pytest.mark.notyet(
     ["datafusion"], reason="Doesn't support table creation from records"
 )
+@pytest.mark.notimpl(
+    ["flink"], reason="Temp tables are implemented as views, which don't support insert"
+)
 @pytest.mark.parametrize(
     "first_row, second_row",
     [


### PR DESCRIPTION
## Description of changes

Related to #9617, this marks a few tests in `ibis/backends/tests/test_client.py` as `notimpl`, because they would mean updating a view (think that's generally not reasonable?).

At the same time, there's no reason we shouldn't support at least constructing the memtable from a broader set of types. This goes through the `ibis.memtable` route, since it already supports a variety of types.