### PR TITLE
test(snowflake): add tests for inserting from a list of dictionaries

### DIFF
--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -438,3 +438,18 @@ def test_table_unnest_with_empty_strings(con):
     expr = t.unnest(t.x)["x"]
     result = con.execute(expr)
     assert Counter(result.values) == expected
+
+
+def test_insert_dict_variants(con):
+    name = gen_name("test_insert_dict_variants")
+
+    t = con.create_table(name, schema=ibis.schema({"a": "int", "b": "str"}), temp=True)
+    assert len(t.execute()) == 0
+
+    data = [{"a": 1, "b": "a"}, {"a": 2, "b": "b"}]
+
+    con.insert(name, data)
+    assert len(t.execute()) == 2
+
+    con.insert(name, ibis.memtable(data))
+    assert len(t.execute()) == 4


### PR DESCRIPTION
Adds a test for inserting from lists of dicts based on a [Zulip conversation](https://ibis-project.zulipchat.com/#narrow/stream/405263-general/topic/ibis-snowflake.208.2E0.2E0.20insert.20failures).
