### PR TITLE
feat(api): add programmatic `epoch` API for computing unix epoch in seconds, milliseconds, and microseconds

### DIFF
--- a/ibis/backends/sql/compilers/bigquery.py
+++ b/ibis/backends/sql/compilers/bigquery.py
@@ -113,6 +113,9 @@ class BigQueryCompiler(SQLGlotCompiler):
         ops.TimeFromHMS: "time_from_parts",
         ops.TimestampNow: "current_timestamp",
         ops.ExtractHost: "net.host",
+        ops.ExtractEpochMilliseconds: "unix_millis",
+        ops.ExtractEpochMicroseconds: "unix_micros",
+        ops.ExtractEpochSeconds: "unix_seconds",
     }
 
     @staticmethod
@@ -382,9 +385,6 @@ class BigQueryCompiler(SQLGlotCompiler):
 
     def visit_UnwrapJSONBoolean(self, op, *, arg):
         return self.f.anon["safe.bool"](arg)
-
-    def visit_ExtractEpochSeconds(self, op, *, arg):
-        return self.f.unix_seconds(arg)
 
     def visit_ExtractWeekOfYear(self, op, *, arg):
         return self.f.extract(self.v.isoweek, arg)

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -529,20 +529,30 @@ class ClickHouseCompiler(SQLGlotCompiler):
         )
         return self.f.arrayConcat(self.f.arrayDistinct(arg), null_element)
 
+    def visit_ExtractEpochMicroseconds(self, op, *, arg):
+        return self.cast(
+            self.f.toUnixTimestamp64Micro(self.cast(arg, op.arg.dtype.copy(scale=6))),
+            op.dtype,
+        )
+
+    def visit_ExtractEpochMilliseconds(self, op, *, arg):
+        return self.cast(
+            self.f.toUnixTimestamp64Milli(self.cast(arg, op.arg.dtype.copy(scale=3))),
+            op.dtype,
+        )
+
     def visit_ExtractMicrosecond(self, op, *, arg):
-        dtype = op.dtype
         return self.cast(
             self.f.toUnixTimestamp64Micro(self.cast(arg, op.arg.dtype.copy(scale=6)))
             % 1_000_000,
-            dtype,
+            op.dtype,
         )
 
     def visit_ExtractMillisecond(self, op, *, arg):
-        dtype = op.dtype
         return self.cast(
             self.f.toUnixTimestamp64Milli(self.cast(arg, op.arg.dtype.copy(scale=3)))
             % 1_000,
-            dtype,
+            op.dtype,
         )
 
     def visit_LagLead(self, op, *, arg, offset, default):

--- a/ibis/backends/sql/compilers/duckdb.py
+++ b/ibis/backends/sql/compilers/duckdb.py
@@ -323,6 +323,12 @@ class DuckDBCompiler(SQLGlotCompiler):
     def visit_ExtractMicrosecond(self, op, *, arg):
         return self.f.mod(self.f.extract("us", arg), 1_000_000)
 
+    def visit_ExtractEpochMilliseconds(self, op, *, arg):
+        return self.f.epoch_ms(self.cast(arg, dt.timestamp))
+
+    def visit_ExtractEpochMicroseconds(self, op, *, arg):
+        return self.f.epoch_us(self.cast(arg, dt.timestamp))
+
     def visit_TimestampFromUNIX(self, op, *, arg, unit):
         unit = unit.short
         if unit == "ms":

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -514,7 +514,15 @@ class PostgresCompiler(SQLGlotCompiler):
         return self.f.extract("isoyear", arg)
 
     def visit_ExtractEpochSeconds(self, op, *, arg):
-        return self.f.extract("epoch", arg)
+        return self.cast(self.f.trunc(self.f.extract("epoch", arg)), op.dtype)
+
+    def visit_ExtractEpochMilliseconds(self, op, *, arg):
+        return self.cast(self.f.trunc(self.f.extract("epoch", arg) * 1_000), op.dtype)
+
+    def visit_ExtractEpochMicroseconds(self, op, *, arg):
+        return self.cast(
+            self.f.trunc(self.f.extract("epoch", arg) * 1_000_000), op.dtype
+        )
 
     def visit_ArrayIndex(self, op, *, arg, index):
         index = self.if_(index < 0, self.f.cardinality(arg) + index, index)

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -393,6 +393,12 @@ class SnowflakeCompiler(SQLGlotCompiler):
     def visit_ExtractEpochSeconds(self, op, *, arg):
         return self.f.extract("epoch", arg)
 
+    def visit_ExtractEpochMicroseconds(self, op, *, arg):
+        return self.f.extract("epoch_microsecond", arg)
+
+    def visit_ExtractEpochMilliseconds(self, op, *, arg):
+        return self.f.extract("epoch_millisecond", arg)
+
     def visit_ExtractMicrosecond(self, op, *, arg):
         return self.f.extract("epoch_microsecond", arg) % 1_000_000
 

--- a/ibis/expr/operations/temporal.py
+++ b/ibis/expr/operations/temporal.py
@@ -152,6 +152,20 @@ class ExtractEpochSeconds(ExtractDateField):
 
 
 @public
+class ExtractEpochMilliseconds(ExtractDateField):
+    """Extract milliseconds since the UNIX epoch from a date or timestamp."""
+
+    dtype = dt.int64
+
+
+@public
+class ExtractEpochMicroseconds(ExtractDateField):
+    """Extract microseconds since the UNIX epoch from a date or timestamp."""
+
+    dtype = dt.int64
+
+
+@public
 class ExtractWeekOfYear(ExtractDateField):
     """Extract the week of the year from a date or timestamp."""
 


### PR DESCRIPTION
Adds an `epoch` API for getting UNIX epochs in different units. Currently supports seconds, milliseconds and microseconds. I did only a few of the backends so that there could be some smaller follow ups for people getting their feet wet in Ibis development by adding a translation rule for one of the unimplemented backends.