### PR TITLE
perf(rename): avoid unnecessary rewrites and dereferencing in `rename`

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2405,13 +2405,12 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         exprs = {}
         fields = self.op().fields
-        rename_is_none = rename is None
         for c in self.columns:
             if (new_name_op := renamed.get(c)) is not None:
                 new_name, op = new_name_op
             else:
                 op = fields[c]
-                if rename_is_none or (new_name := rename(c)) is None:
+                if rename is None or (new_name := rename(c)) is None:
                     new_name = c
 
             exprs[new_name] = op

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -918,6 +918,33 @@ def test_wide_drop_compile(benchmark, wide_table, cols_to_drop):
     )
 
 
+@pytest.mark.parametrize(
+    "method",
+    [
+        "snake_case",
+        "ALL_CAPS",
+        lambda x: f"t_{x}",
+        "t_{name}",
+        lambda x: x,
+        "{name}",
+        {"b0": "a0"},
+    ],
+    ids=[
+        "snake_case",
+        "ALL_CAPS",
+        "function",
+        "format_string",
+        "no_op_function",
+        "no_op_string",
+        "mapping",
+    ],
+)
+@pytest.mark.parametrize("cols", [1_000, 10_000])
+def test_wide_rename(benchmark, method, cols):
+    t = ibis.table(name="t", schema={f"a{i}": "int" for i in range(cols)})
+    benchmark(t.rename, method)
+
+
 def test_duckdb_timestamp_conversion(benchmark):
     pytest.importorskip("duckdb")
 


### PR DESCRIPTION
Addresses `rename` performance from #9111 with wide tables by removing some unnecessary rewriting and dereferencing. Neither of these are necessary, because we already have all columns fully bound, we are simply giving them new names.