### PR TITLE
perf(drop): use `_fast_bind` to speed up `drop` even more

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -213,7 +213,7 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         return PolarsData.convert_table(df, self.schema())
 
-    def bind(self, *args, **kwargs):
+    def _fast_bind(self, *args, **kwargs):
         # allow the first argument to be either a dictionary or a list of values
         if len(args) == 1:
             if isinstance(args[0], dict):
@@ -236,7 +236,10 @@ class Table(Expr, _FixedTextJupyterMixin):
                 )
             (value,) = bindings
             values.append(value.name(key))
+        return values
 
+    def bind(self, *args, **kwargs):
+        values = self._fast_bind(*args, **kwargs)
         # dereference the values to `self`
         dm = DerefMap.from_targets(self.op())
         result = []

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2491,7 +2491,7 @@ class Table(Expr, _FixedTextJupyterMixin):
             return self
 
         columns_to_drop = tuple(
-            map(operator.methodcaller("get_name"), self.bind(*fields))
+            map(operator.methodcaller("get_name"), self._fast_bind(*fields))
         )
         return ops.DropColumns(parent=self, columns_to_drop=columns_to_drop).to_expr()
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -238,7 +238,25 @@ class Table(Expr, _FixedTextJupyterMixin):
             values.append(value.name(key))
         return values
 
-    def bind(self, *args, **kwargs):
+    def bind(self, *args: Any, **kwargs: Any) -> tuple[Value, ...]:
+        """Bind column values to a table expression.
+
+        This method handles the binding of every kind of column-like value that
+        Ibis handles, including strings, integers, deferred expressions and
+        selectors, to a table expression.
+
+        Parameters
+        ----------
+        args
+            Column-like values to bind.
+        kwargs
+            Column-like values to bind, with names.
+
+        Returns
+        -------
+        tuple[Value, ...]
+            A tuple of bound values
+        """
         values = self._fast_bind(*args, **kwargs)
         # dereference the values to `self`
         dm = DerefMap.from_targets(self.op())


### PR DESCRIPTION
Adds `_fast_bind` from #9641, and uses it for the `drop` method, to gain a bit more performance.


Benchmarks show about 2-3x in all cases except when there are a relatively small number of columns **AND** only one column is dropped. If there are a large number of columns **OR** a large proportion of the columns are dropped then there's a notable improvement.


```
----------------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[10-1]': 2 tests -----------------------------------------------------------------------------------
Name (time in ns)                                      Min                 Max                Mean            StdDev              Median               IQR             Outliers  OPS (Mops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[10-1] (0001_2dcc9b8)     102.9900 (1.04)     540.6199 (1.64)     105.5181 (1.0)      4.3358 (1.17)     104.8998 (1.0)      1.3999 (2.33)     2342;2572        9.4770 (1.0)       90001         100
test_wide_drop_construct[10-1] (NOW)               99.3800 (1.0)      330.3302 (1.0)      106.1852 (1.01)     3.6958 (1.0)      105.8000 (1.01)     0.6001 (1.0)      1898;9804        9.4175 (0.99)      91483         100
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------------ benchmark 'test_wide_drop_construct[10-50]': 2 tests ------------------------------------------------------------------------------------
Name (time in us)                                       Min                   Max                Mean             StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[10-50] (0001_2dcc9b8)     585.1410 (2.45)     1,279.5690 (3.85)     602.4153 (2.44)     25.0608 (5.77)     598.4410 (2.43)     8.5960 (1.92)        43;90        1.6600 (0.41)       1200           1
test_wide_drop_construct[10-50] (NOW)              238.9530 (1.0)        332.5520 (1.0)      247.1769 (1.0)       4.3437 (1.0)      246.2670 (1.0)      4.4835 (1.0)        702;86        4.0457 (1.0)        3532           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[10-99]': 2 tests ----------------------------------------------------------------------------------
Name (time in us)                                       Min                 Max                Mean            StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[10-99] (0001_2dcc9b8)     755.6740 (2.56)     811.9010 (2.05)     769.4374 (2.54)     5.9647 (1.0)      768.9550 (2.54)     7.4950 (1.36)       359;32        1.2997 (0.39)       1254           1
test_wide_drop_construct[10-99] (NOW)              294.9500 (1.0)      396.6530 (1.0)      303.4895 (1.0)      6.5223 (1.09)     302.7595 (1.0)      5.5060 (1.0)        195;95        3.2950 (1.0)        2416           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[100-1]': 2 tests ----------------------------------------------------------------------------
Name (time in ms)                                     Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[100-1] (0001_2dcc9b8)     3.0980 (2.46)     3.3263 (2.50)     3.1493 (2.46)     0.0363 (3.97)     3.1400 (2.45)     0.0292 (2.39)        41;18  317.5267 (0.41)        259           1
test_wide_drop_construct[100-1] (NOW)              1.2574 (1.0)      1.3287 (1.0)      1.2806 (1.0)      0.0091 (1.0)      1.2800 (1.0)      0.0122 (1.0)         224;9  780.8675 (1.0)         763           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[100-50]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                      Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[100-50] (0001_2dcc9b8)     5.0454 (2.61)     5.3497 (2.64)     5.1560 (2.63)     0.0567 (4.76)     5.1623 (2.63)     0.0895 (6.21)         58;1  193.9494 (0.38)        187           1
test_wide_drop_construct[100-50] (NOW)              1.9332 (1.0)      2.0240 (1.0)      1.9630 (1.0)      0.0119 (1.0)      1.9615 (1.0)      0.0144 (1.0)        143;12  509.4205 (1.0)         494           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[100-99]': 2 tests -----------------------------------------------------------------------------
Name (time in ms)                                      Min               Max              Mean            StdDev            Median               IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[100-99] (0001_2dcc9b8)     7.0995 (2.71)     7.6384 (2.73)     7.1797 (2.71)     0.0563 (3.27)     7.1693 (2.71)     0.0622 (4.12)         25;1  139.2823 (0.37)        139           1
test_wide_drop_construct[100-99] (NOW)              2.6187 (1.0)      2.8016 (1.0)      2.6494 (1.0)      0.0172 (1.0)      2.6467 (1.0)      0.0151 (1.0)         79;21  377.4394 (1.0)         375           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------ benchmark 'test_wide_drop_construct[1000-1]': 2 tests ------------------------------------------------------------------------------
Name (time in ms)                                       Min                Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[1000-1] (0001_2dcc9b8)     29.3221 (2.38)     72.8602 (1.30)     30.8571 (2.37)     7.4241 (1.53)     29.5788 (2.37)     0.2683 (1.82)          1;2  32.4074 (0.42)         34           1
test_wide_drop_construct[1000-1] (NOW)              12.3122 (1.0)      55.9862 (1.0)      13.0241 (1.0)      4.8653 (1.0)      12.4725 (1.0)      0.1478 (1.0)           1;2  76.7809 (1.0)          80           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[1000-50]': 2 tests ------------------------------------------------------------------------------
Name (time in ms)                                        Min                Max               Mean             StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[1000-50] (0001_2dcc9b8)     49.1006 (2.54)     92.7210 (4.75)     53.8510 (2.77)     13.2363 (265.32)   49.5473 (2.55)     0.3806 (5.49)          2;3  18.5698 (0.36)         20           1
test_wide_drop_construct[1000-50] (NOW)              19.3271 (1.0)      19.5272 (1.0)      19.4094 (1.0)       0.0499 (1.0)      19.4053 (1.0)      0.0693 (1.0)          21;0  51.5214 (1.0)          52           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[1000-99]': 2 tests -------------------------------------------------------------------------------
Name (time in ms)                                        Min                 Max               Mean             StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[1000-99] (0001_2dcc9b8)     68.6750 (2.65)     114.7173 (1.65)     76.1654 (2.80)     14.4932 (2.06)     71.7965 (2.75)     0.3690 (2.21)          1;2  13.1293 (0.36)          9           1
test_wide_drop_construct[1000-99] (NOW)              25.8677 (1.0)       69.4801 (1.0)      27.2011 (1.0)       7.0446 (1.0)      26.0761 (1.0)      0.1673 (1.0)           1;1  36.7632 (1.0)          38           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[10000-1]': 2 tests --------------------------------------------------------------------------------
Name (time in ms)                                         Min                 Max                Mean             StdDev              Median                IQR            Outliers     OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[10000-1] (0001_2dcc9b8)     348.6009 (2.76)     354.7811 (2.08)     350.7116 (2.36)      2.3677 (1.0)      350.0450 (2.35)      1.9255 (1.0)           1;1  2.8513 (0.42)          5           1
test_wide_drop_construct[10000-1] (NOW)              126.3558 (1.0)      170.5475 (1.0)      148.7597 (1.0)      23.1980 (9.80)     149.0802 (1.0)      43.3844 (22.53)         0;0  6.7223 (1.0)           8           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[10000-50]': 2 tests ---------------------------------------------------------------------------------
Name (time in ms)                                          Min                 Max                Mean             StdDev              Median                IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[10000-50] (0001_2dcc9b8)     552.2250 (2.84)     601.7017 (2.49)     573.2314 (2.54)     23.2917 (1.0)      559.8068 (2.33)     40.8338 (1.0)           1;0  1.7445 (0.39)          5           1
test_wide_drop_construct[10000-50] (NOW)              194.7647 (1.0)      241.6048 (1.0)      225.6878 (1.0)      23.6948 (1.02)     240.3964 (1.0)      46.0286 (1.13)          2;0  4.4309 (1.0)           6           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------- benchmark 'test_wide_drop_construct[10000-99]': 2 tests ---------------------------------------------------------------------------------
Name (time in ms)                                          Min                 Max                Mean             StdDev              Median                IQR            Outliers     OPS            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_wide_drop_construct[10000-99] (0001_2dcc9b8)     753.2735 (2.87)     805.8374 (2.57)     792.6154 (2.63)     22.3360 (1.02)     802.5539 (2.58)     20.1197 (1.36)          1;1  1.2616 (0.38)          5           1
test_wide_drop_construct[10000-99] (NOW)              262.7244 (1.0)      313.4898 (1.0)      301.8234 (1.0)      21.9103 (1.0)      311.6365 (1.0)      14.7843 (1.0)           1;1  3.3132 (1.0)           5           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
