### PR TITLE
fix(api): add support for using deferreds in the `argmin`/`argmax` `key` argument

### DIFF
--- a/ibis/expr/tests/test_reductions.py
+++ b/ibis/expr/tests/test_reductions.py
@@ -99,3 +99,10 @@ def test_reduction_methods(fn, operation, cond):
         assert node.where == resolved
     else:
         assert node.where == where.op()
+
+
+@pytest.mark.parametrize("func_name", ["argmin", "argmax"])
+def test_argminmax_deferred(func_name):
+    t = ibis.table({"a": "int", "b": "int"}, name="t")
+    func = getattr(t.a, func_name)
+    assert func(_.b).equals(func(t.b))

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1744,7 +1744,9 @@ class Column(Value, _FixedTextJupyterMixin):
         └─────────────┘
         """
         return ops.ArgMax(
-            self, key=key, where=self._bind_to_parent_table(where)
+            self,
+            key=self._bind_to_parent_table(key),
+            where=self._bind_to_parent_table(where),
         ).to_expr()
 
     def argmin(self, key: ir.Value, where: ir.BooleanValue | None = None) -> Scalar:
@@ -1778,7 +1780,9 @@ class Column(Value, _FixedTextJupyterMixin):
         └──────────┘
         """
         return ops.ArgMin(
-            self, key=key, where=self._bind_to_parent_table(where)
+            self,
+            key=self._bind_to_parent_table(key),
+            where=self._bind_to_parent_table(where),
         ).to_expr()
 
     def median(self, where: ir.BooleanValue | None = None) -> Scalar:

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1539,10 +1539,7 @@ class Column(Value, _FixedTextJupyterMixin):
     def __deferred_repr__(self):
         return f"<column[{self.type()}]>"
 
-    def approx_nunique(
-        self,
-        where: ir.BooleanValue | None = None,
-    ) -> ir.IntegerScalar:
+    def approx_nunique(self, where: ir.BooleanValue | None = None) -> ir.IntegerScalar:
         """Return the approximate number of distinct elements in `self`.
 
         ::: {.callout-note}
@@ -1584,10 +1581,7 @@ class Column(Value, _FixedTextJupyterMixin):
             self, where=self._bind_to_parent_table(where)
         ).to_expr()
 
-    def approx_median(
-        self,
-        where: ir.BooleanValue | None = None,
-    ) -> Scalar:
+    def approx_median(self, where: ir.BooleanValue | None = None) -> Scalar:
         """Return an approximate of the median of `self`.
 
         ::: {.callout-note}
@@ -1945,11 +1939,7 @@ class Column(Value, _FixedTextJupyterMixin):
             self, where=self._bind_to_parent_table(where)
         ).to_expr()
 
-    def topk(
-        self,
-        k: int,
-        by: ir.Value | None = None,
-    ) -> ir.Table:
+    def topk(self, k: int, by: ir.Value | None = None) -> ir.Table:
         """Return a "top k" expression.
 
         Parameters


### PR DESCRIPTION
Adds support for using deferreds in the `argmin` and `argmax` `key` argument.