### PR TITLE
feat(api): support deferred or string column names in `cov`/`corr` me…

### DIFF
--- a/ibis/expr/tests/test_reductions.py
+++ b/ibis/expr/tests/test_reductions.py
@@ -106,3 +106,10 @@ def test_argminmax_deferred(func_name):
     t = ibis.table({"a": "int", "b": "int"}, name="t")
     func = getattr(t.a, func_name)
     assert func(_.b).equals(func(t.b))
+
+
+@pytest.mark.parametrize("func_name", ["cov", "corr"])
+def test_cov_corr_deferred(func_name):
+    t = ibis.table({"a": "int", "b": "int"}, name="t")
+    func = getattr(t.a, func_name)
+    assert func(_.b).equals(func(t.b))

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -836,7 +836,10 @@ class NumericColumn(Column, NumericValue):
             The correlation of `left` and `right`
         """
         return ops.Correlation(
-            self, right, how=how, where=self._bind_to_parent_table(where)
+            self,
+            self._bind_to_parent_table(right),
+            how=how,
+            where=self._bind_to_parent_table(where),
         ).to_expr()
 
     def cov(
@@ -862,7 +865,10 @@ class NumericColumn(Column, NumericValue):
             The covariance of `self` and `right`
         """
         return ops.Covariance(
-            self, right, how=how, where=self._bind_to_parent_table(where)
+            self,
+            self._bind_to_parent_table(right),
+            how=how,
+            where=self._bind_to_parent_table(where),
         ).to_expr()
 
     def mean(


### PR DESCRIPTION
Supports things like `t.a.corr("b")`/`t.a.corr(_.b)`.