### PR TITLE
feat(pyarrow): support arrow PyCapsule interface in more places

### DIFF
--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -927,27 +927,6 @@ def test_self_join_memory_table(backend, con, monkeypatch):
         param(
             lambda: pa.table({"a": ["a"], "b": [1]}).to_batches()[0],
             "df_arrow_single_batch",
-            marks=[
-                pytest.mark.notimpl(
-                    [
-                        "bigquery",
-                        "clickhouse",
-                        "duckdb",
-                        "exasol",
-                        "impala",
-                        "mssql",
-                        "mysql",
-                        "oracle",
-                        "postgres",
-                        "pyspark",
-                        "risingwave",
-                        "snowflake",
-                        "sqlite",
-                        "trino",
-                        "databricks",
-                    ]
-                )
-            ],
             id="pyarrow_single_batch",
         ),
         param(


### PR DESCRIPTION
~Two changes here:~

- ~Support `__arrow_c_schema__` in `ibis.Schema` objects~
- Support objects implementing `__arrow_c_stream__` as inputs to `ibis.memtable`

Fixes #9660.