### PR TITLE
feat(pyarrow): support `__arrow_c_schema__` on `ibis.Schema` objects

### DIFF
--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -183,6 +183,9 @@ class Schema(Concrete, Coercible, MapSet):
 
         return PyArrowSchema.from_ibis(self)
 
+    def __arrow_c_schema__(self):
+        return self.to_pyarrow().__arrow_c_schema__()
+
     def to_polars(self):
         """Return the equivalent polars schema."""
         from ibis.formats.polars import PolarsSchema

--- a/ibis/expr/tests/test_schema.py
+++ b/ibis/expr/tests/test_schema.py
@@ -393,6 +393,13 @@ def test_schema_from_to_pyarrow_schema():
     assert restored_schema == pyarrow_schema
 
 
+def test_schema___arrow_c_schema__():
+    pytest.importorskip("pyarrow")
+    schema = sch.Schema({"a": dt.int64, "b": dt.string, "c": dt.boolean})
+    # smoketest, since no way to create schema from capsule in current pyarrow
+    assert schema.__arrow_c_schema__() is not None
+
+
 @pytest.mark.parametrize("lazy", [False, True])
 def test_schema_infer_polars_dataframe(lazy):
     pl = pytest.importorskip("polars")


### PR DESCRIPTION
Part of #9660.