### PR TITLE
depr(duckdb): deprecate `read_in_memory`

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -851,8 +851,12 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         # by the time we execute against this so we register it
         # explicitly.
 
+    @util.deprecated(
+        instead="Pass in-memory data to `create_table` instead.",
+        as_of="9.1",
+        removed_in="10.0",
+    )
     def read_in_memory(
-        # TODO: deprecate this in favor of `create_table`
         self,
         source: pd.DataFrame
         | pa.Table

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -321,11 +321,13 @@ def test_re_read_in_memory_overwrite(con):
     df_pandas_1 = pd.DataFrame({"a": ["a"], "b": [1], "d": ["hi"]})
     df_pandas_2 = pd.DataFrame({"a": [1], "c": [1.4]})
 
-    table = con.read_in_memory(df_pandas_1, table_name="df")
+    with pytest.warns(FutureWarning, match="create_table"):
+        table = con.read_in_memory(df_pandas_1, table_name="df")
     assert len(table.columns) == 3
     assert table.schema() == ibis.schema([("a", "str"), ("b", "int"), ("d", "str")])
 
-    table = con.read_in_memory(df_pandas_2, table_name="df")
+    with pytest.warns(FutureWarning, match="create_table"):
+        table = con.read_in_memory(df_pandas_2, table_name="df")
     assert len(table.columns) == 2
     assert table.schema() == ibis.schema([("a", "int"), ("c", "float")])
 
@@ -415,7 +417,8 @@ def test_s3_403_fallback(con, httpserver, monkeypatch):
 
 def test_register_numpy_str(con):
     data = pd.DataFrame({"a": [np.str_("xyz"), None]})
-    result = con.read_in_memory(data)
+    with pytest.warns(FutureWarning, match="create_table"):
+        result = con.read_in_memory(data)
     tm.assert_frame_equal(result.execute(), data)
 
 
@@ -428,7 +431,8 @@ def test_register_recordbatchreader_warns(con):
     )
     reader = table.to_reader()
     sol = table.to_pandas()
-    t = con.read_in_memory(reader)
+    with pytest.warns(FutureWarning, match="create_table"):
+        t = con.read_in_memory(reader)
 
     # First execute is fine
     res = t.execute()
@@ -440,7 +444,8 @@ def test_register_recordbatchreader_warns(con):
 
     # Re-registering over the name with a new reader is fine
     reader = table.to_reader()
-    t = con.read_in_memory(reader, table_name=t.get_name())
+    with pytest.warns(FutureWarning, match="create_table"):
+        t = con.read_in_memory(reader, table_name=t.get_name())
     res = t.execute()
     tm.assert_frame_equal(res, sol)
 

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -277,7 +277,9 @@ def test_register_iterator_parquet(
     assert table.count().execute()
 
 
-# TODO: modify test to use read_in_memory when implemented xref: 8858
+# TODO: remove entirely when `register` is removed
+# This same functionality is implemented across all backends
+# via `create_table` and tested in `test_client.py`
 @pytest.mark.notimpl(["datafusion"])
 @pytest.mark.notyet(
     [
@@ -311,7 +313,9 @@ def test_register_pandas(con):
     assert t.x.sum().execute() == 6
 
 
-# TODO: modify test to use read_in_memory when implemented xref: 8858
+# TODO: remove entirely when `register` is removed
+# This same functionality is implemented across all backends
+# via `create_table` and tested in `test_client.py`
 @pytest.mark.notimpl(["datafusion", "polars"])
 @pytest.mark.notyet(
     [


### PR DESCRIPTION
## Description of changes

This functionality is available via `create_table` (and also available
across all backends instead of just DuckDB).