### PR TITLE
refactor(polars): remove extra backwards compatibility code no longer in use after 1.0 upgrade

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -314,12 +314,7 @@ def join(op, **kw):
         how = "full"
 
     joined = left.join(right, on=on, how=how, coalesce=False)
-
-    try:
-        joined = joined.drop(*on)
-    except TypeError:
-        joined = joined.drop(columns=on)
-
+    joined = joined.drop(*on)
     return joined
 
 
@@ -352,10 +347,7 @@ def asof_join(op, **kw):
 
     assert len(on) == 1
     joined = left.join_asof(right, on=on[0], by=by, strategy=direction)
-    try:
-        joined = joined.drop(*(on + by))
-    except TypeError:
-        joined = joined.drop(columns=on + by)
+    joined = joined.drop(*on, *by)
     return joined
 
 
@@ -537,7 +529,7 @@ def string_unary(op, **kw):
 @translate.register(ops.Reverse)
 def reverse(op, **kw):
     arg = translate(op.arg, **kw)
-    return arg.map_elements(lambda x: x[::-1])
+    return arg.str.reverse()
 
 
 @translate.register(ops.StringSplit)
@@ -829,10 +821,7 @@ def count_star(op, **kw):
         condition = translate(where, **kw)
         result = condition.sum()
     else:
-        try:
-            result = pl.len()
-        except AttributeError:
-            result = pl.count()
+        result = pl.len()
     return result.cast(PolarsType.from_ibis(op.dtype))
 
 


### PR DESCRIPTION
Cleans up some backwards compatibility code in the Polars backend that we no longer need.