### PR TITLE
fix(polars): remove bogus minus-one-week truncation

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -865,7 +865,7 @@ def temporal_truncate(op, **kw):
     arg = translate(op.arg, **kw)
     unit = "mo" if op.unit.short == "M" else op.unit.short
     unit = f"1{unit.lower()}"
-    return arg.dt.truncate(unit).dt.offset_by("-1w")
+    return arg.dt.truncate(unit)
 
 
 def _compile_literal_interval(op):

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -337,11 +337,6 @@ def test_timestamp_extract_week_of_year(backend, alltypes, df):
             "h",
             marks=[
                 pytest.mark.notimpl(["sqlite"], raises=com.UnsupportedOperationError),
-                pytest.mark.broken(
-                    ["polars"],
-                    raises=AssertionError,
-                    reason="numpy array are different",
-                ),
             ],
         ),
         param(
@@ -349,11 +344,6 @@ def test_timestamp_extract_week_of_year(backend, alltypes, df):
             "min",
             marks=[
                 pytest.mark.notimpl(["sqlite"], raises=com.UnsupportedOperationError),
-                pytest.mark.broken(
-                    ["polars"],
-                    raises=AssertionError,
-                    reason="numpy array are different",
-                ),
             ],
         ),
         param(
@@ -361,11 +351,6 @@ def test_timestamp_extract_week_of_year(backend, alltypes, df):
             "s",
             marks=[
                 pytest.mark.notimpl(["sqlite"], raises=com.UnsupportedOperationError),
-                pytest.mark.broken(
-                    ["polars"],
-                    raises=AssertionError,
-                    reason="numpy array are different",
-                ),
             ],
         ),
         param(
@@ -376,11 +361,6 @@ def test_timestamp_extract_week_of_year(backend, alltypes, df):
                     ["clickhouse", "mysql", "sqlite", "datafusion", "exasol"],
                     raises=com.UnsupportedOperationError,
                 ),
-                pytest.mark.broken(
-                    ["polars"],
-                    raises=AssertionError,
-                    reason="numpy array are different",
-                ),
             ],
         ),
         param(
@@ -390,11 +370,6 @@ def test_timestamp_extract_week_of_year(backend, alltypes, df):
                 pytest.mark.notimpl(
                     ["clickhouse", "mysql", "sqlite", "trino", "datafusion", "exasol"],
                     raises=com.UnsupportedOperationError,
-                ),
-                pytest.mark.broken(
-                    ["polars"],
-                    raises=AssertionError,
-                    reason="numpy array are different",
                 ),
                 pytest.mark.notyet(
                     ["flink"],
@@ -481,9 +456,7 @@ def test_timestamp_truncate(backend, alltypes, df, ibis_unit, pandas_unit):
         ),
     ],
 )
-@pytest.mark.broken(
-    ["polars", "druid"], reason="snaps to the UNIX epoch", raises=AssertionError
-)
+@pytest.mark.broken(["druid"], reason="snaps to the UNIX epoch", raises=AssertionError)
 @pytest.mark.broken(
     ["druid"],
     raises=AttributeError,


### PR DESCRIPTION
Apparently we had a slew of tests for this that were simply failing. Spelunking a bit I found https://github.com/ibis-project/ibis/commit/8b711e9896d7a9fed501b05e4e6a332a876ffb19#diff-a87d0374de79428031576dd258bfeb6c63b3bb03dfa533ad1259e34e08575b3cR647, which is definitely something I introduced, but I cannot find anywhere that I documented why I added that.

Closes #9618.