### PR TITLE
fix(polars): fix polars `std`/`var` to properly handle `sample`/`population`

### DIFF
--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -606,6 +606,12 @@ def test_reduction_ops(
     ibis_cond,
     pandas_cond,
 ):
+    # Operate on a subset of the data, since aggregations like var/std with
+    # sample/population can be too numerically similar for a larger number of
+    # rows.
+    alltypes = alltypes.filter(alltypes.id < 1550)
+    df = df[df.id < 1550]
+
     expr = alltypes.agg(tmp=result_fn(alltypes, ibis_cond(alltypes))).tmp
     result = expr.execute().squeeze()
     expected = expected_fn(df, pandas_cond(df))


### PR DESCRIPTION
Previously the `how` argument in `std`/`var` wasn't being handled. This wasn't caught, since for our testing dataset the results were close enough together that `assert_allclose` wouldn't notice. To fix this we subset the input data size to something small enough that the difference here is significant.

We also refactor the general reduction handling in the polars backend to simplify some of the code and remove some unnecessary filtering to improve performance.