### PR TITLE
fix(drop): ignore order for `DropColumns` equality

### DIFF
--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -148,7 +148,7 @@ class Simple(Relation):
 @public
 class DropColumns(Relation):
     parent: Relation
-    columns_to_drop: VarTuple[str]
+    columns_to_drop: frozenset[str]
 
     @attribute
     def schema(self):

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2501,7 +2501,7 @@ class Table(Expr, _FixedTextJupyterMixin):
             # no-op if nothing to be dropped
             return self
 
-        columns_to_drop = tuple(
+        columns_to_drop = frozenset(
             map(operator.methodcaller("get_name"), self._fast_bind(*fields))
         )
         return ops.DropColumns(parent=self, columns_to_drop=columns_to_drop).to_expr()

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1886,6 +1886,12 @@ def test_drop():
         t.drop("e")
 
 
+def test_drop_equality():
+    t = ibis.table(dict.fromkeys("abcd", "int"))
+
+    assert t.drop("a", "b").equals(t.drop("b", "a"))
+
+
 def test_python_table_ambiguous():
     with pytest.raises(NotImplementedError):
         ibis.memtable(


### PR DESCRIPTION
## Description of changes

Since the ordering doesn't matter for `DropColumns`, a `VarTuple[str]` is probably the wrong data structure for the `columns_to_drop` attribute. This is a bug in the implementation of `DropColumns`—we should either change the type (a `frozenset[str]` would make more sense), or override the comparison so that `.equals` treats those as equal.