### PR TITLE
depr(snowflake): deprecate `from_snowpark` method

### DIFF
--- a/docs/posts/run-on-snowflake/index.qmd
+++ b/docs/posts/run-on-snowflake/index.qmd
@@ -38,8 +38,8 @@ figure out, and these are the questions we will answer throughout the post.
 
 ## Getting the Ibis connection
 
-The release of Ibis 9.0 includes the introduction of a new method,
-[`from_snowpark`](../../backends/snowflake.qmd#ibis.backends.snowflake.Backend.from_snowpark)
+The release of Ibis 9.2 includes the introduction of a new method,
+[`from_connection`](../../backends/snowflake.qmd#ibis.backends.snowflake.Backend.from_connection)
 to provide users with a convenient mechanism to take an existing Snowpark
 session and create an Ibis Snowflake backend instance with it.
 
@@ -50,7 +50,7 @@ import ibis
 import snowflake.snowpark as sp
 
 session = sp.Session.builder.create()
-con = ibis.snowflake.from_snowpark(session)
+con = ibis.snowflake.from_connection(session)
 ```
 
 This connection uses the same session within Snowflake, so temporary objects

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -274,7 +274,7 @@ $$ {defn["source"]} $$"""
                         f"Unable to create Ibis UDFs, some functionality will not work: {e}"
                     )
 
-    @util.experimental
+    @util.deprecated(as_of="10.0", instead="use from_connection instead")
     @classmethod
     def from_snowpark(
         cls, session: snowflake.snowpark.Session, *, create_object_udfs: bool = True

--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -209,7 +209,7 @@ class TestConf(BackendTest):
                         "schema": os.environ["SNOWFLAKE_SCHEMA"],
                     }
                 )
-            return ibis.backends.snowflake.Backend.from_snowpark(builder.create())
+            return ibis.backends.snowflake.Backend.from_connection(builder.create())
         else:
             return ibis.connect(_get_url(), **kw)
 

--- a/ibis/backends/snowflake/tests/test_udf.py
+++ b/ibis/backends/snowflake/tests/test_udf.py
@@ -238,7 +238,7 @@ def test_ibis_inside_snowpark(snowpark_session, execute_as):
     def ibis_sproc(session):
         import ibis.backends.snowflake
 
-        con = ibis.backends.snowflake.Backend.from_snowpark(session)
+        con = ibis.backends.snowflake.Backend.from_connection(session)
 
         expr = (
             con.tables.functional_alltypes.group_by("string_col")

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -317,7 +317,9 @@ def test_create_table_from_schema(con, new_schema, temp_table):
 )
 def test_create_temporary_table_from_schema(con_no_data, new_schema):
     if con_no_data.name == "snowflake" and os.environ.get("SNOWFLAKE_SNOWPARK"):
-        with pytest.raises(com.IbisError, match="Reconnecting is not supported"):
+        with pytest.raises(
+            com.IbisError, match="Cannot reconnect to unconfigured .+ backend"
+        ):
             con_no_data.reconnect()
         return
 


### PR DESCRIPTION
Since Ibis 9.2, it should be possible to use `from_connection` (introduced in #9603) as a more standardized alternative to `from_snowpark`. `from_connection` also supports a `SnowflakeConnection` instance.