### PR TITLE
refactor(internals): remove unnecessary dynamism in `drop` method

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2501,9 +2501,7 @@ class Table(Expr, _FixedTextJupyterMixin):
             # no-op if nothing to be dropped
             return self
 
-        columns_to_drop = frozenset(
-            map(operator.methodcaller("get_name"), self._fast_bind(*fields))
-        )
+        columns_to_drop = frozenset(map(Expr.get_name, self._fast_bind(*fields)))
         return ops.DropColumns(parent=self, columns_to_drop=columns_to_drop).to_expr()
 
     def filter(


### PR DESCRIPTION
Removes unnecessary use of `methodcaller` at a call site known to be costly in some cases.

There's no noticeable performance gain (or loss) here, this is mostly about removing unnecessary dynamism.