### PR TITLE
perf(expressions): speed up `.describe()` and `.info()` expression construction

### DIFF
--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -816,5 +816,13 @@ class ClickHouseCompiler(SQLGlotCompiler):
             sg.or_(arg.is_(NULL), key.is_(NULL)), NULL, self.f.mapContains(arg, key)
         )
 
+    def visit_Info(self, op, *, parent):
+        # clickhouse explode is not pairwise, so fall back to generic impl
+        return self.visit_GenericInfo(op, parent=parent)
+
+    def visit_Describe(self, op, *, parent, quantile):
+        # clickhouse explode is not pairwise, so fall back to generic impl
+        return self.visit_GenericDescribe(op, parent=parent, quantile=quantile)
+
 
 compiler = ClickHouseCompiler()

--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -450,7 +450,7 @@ class SQLiteCompiler(SQLGlotCompiler):
         )
 
     def visit_Xor(self, op, *, left, right):
-        return (left.or_(right)).and_(sg.not_(left.and_(right)))
+        return left.or_(right).and_(sg.not_(left.and_(right)))
 
     def visit_NonNullLiteral(self, op, *, value, dtype):
         if dtype.is_binary():

--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -64,6 +64,7 @@ class SQLiteCompiler(SQLGlotCompiler):
         ops.DateDelta,
         ops.TimestampDelta,
         ops.TryCast,
+        ops.Unnest,
     )
 
     SIMPLE_OPS = {

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -659,5 +659,13 @@ class TrinoCompiler(SQLGlotCompiler):
     def visit_ArrayMean(self, op, *, arg):
         return self.visit_ArraySumAgg(op, arg=arg, output=operator.truediv)
 
+    def visit_Info(self, op, *, parent):
+        # unnest cannot contain aggregates
+        return self.visit_GenericInfo(op, parent=parent)
+
+    def visit_Describe(self, op, *, parent, quantile):
+        # unnest cannot contain aggregates
+        return self.visit_GenericDescribe(op, parent=parent, quantile=quantile)
+
 
 compiler = TrinoCompiler()

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -85,7 +85,6 @@ aggregate_test_params = [
             pytest.mark.notyet(
                 [
                     "bigquery",
-                    "clickhouse",
                     "datafusion",
                     "impala",
                     "mysql",
@@ -393,7 +392,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                 pytest.mark.notyet(
                     [
                         "bigquery",
-                        "clickhouse",
                         "datafusion",
                         "impala",
                         "mysql",

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -795,31 +795,10 @@ def test_table_info_large(con):
     reason="Druid only supports trivial unions",
 )
 @pytest.mark.parametrize(
-    ("selector", "expected_columns"),
+    "selector",
     [
         param(
-            s.any_of(
-                s.of_type("numeric"),
-                s.of_type("string"),
-                s.of_type("bool"),
-                s.of_type("timestamp"),
-            ),
-            [
-                "name",
-                "pos",
-                "type",
-                "count",
-                "nulls",
-                "unique",
-                "mode",
-                "mean",
-                "std",
-                "min",
-                "p25",
-                "p50",
-                "p75",
-                "max",
-            ],
+            s.any_of(*map(s.of_type, ["numeric", "string", "bool", "timestamp"])),
             marks=[
                 pytest.mark.notimpl(
                     ["sqlite"],
@@ -827,13 +806,7 @@ def test_table_info_large(con):
                     reason="quantile is not supported",
                 ),
                 pytest.mark.notimpl(
-                    [
-                        "clickhouse",
-                        "pyspark",
-                        "clickhouse",
-                        "risingwave",
-                        "impala",
-                    ],
+                    ["pyspark", "risingwave", "impala"],
                     raises=com.OperationNotDefinedError,
                     reason="mode is not supported",
                 ),
@@ -862,21 +835,6 @@ def test_table_info_large(con):
         ),
         param(
             s.of_type("numeric"),
-            [
-                "name",
-                "pos",
-                "type",
-                "count",
-                "nulls",
-                "unique",
-                "mean",
-                "std",
-                "min",
-                "p25",
-                "p50",
-                "p75",
-                "max",
-            ],
             marks=[
                 pytest.mark.notimpl(
                     ["sqlite"],
@@ -898,24 +856,9 @@ def test_table_info_large(con):
         ),
         param(
             s.of_type("string"),
-            [
-                "name",
-                "pos",
-                "type",
-                "count",
-                "nulls",
-                "unique",
-                "mode",
-            ],
             marks=[
                 pytest.mark.notimpl(
-                    [
-                        "clickhouse",
-                        "pyspark",
-                        "clickhouse",
-                        "risingwave",
-                        "impala",
-                    ],
+                    ["pyspark", "risingwave", "impala"],
                     raises=com.OperationNotDefinedError,
                     reason="mode is not supported",
                 ),
@@ -934,12 +877,11 @@ def test_table_info_large(con):
         ),
     ],
 )
-def test_table_describe(alltypes, selector, expected_columns):
+def test_table_describe(alltypes, selector):
     sometypes = alltypes.select(selector)
     expr = sometypes.describe()
     df = expr.execute()
     assert sorted(sometypes.columns) == sorted(df.name)
-    assert sorted(expr.columns) == sorted(expected_columns)
     assert sorted(expr.columns) == sorted(df.columns)
 
 


### PR DESCRIPTION
Speed up `.info()` and `.describe()` methods. This approach builds an array containing each aggregate, and then jointly unnests them in a single select. This safely bypasses the validation that happens in `.agg` method, and only requires a single `.agg` call at the end, to unnest the built arrays.

Closes #9639.