### PR TITLE
perf(schema): speed up failure case of duplicate keys when constructing schemas

### DIFF
--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Iterable, Iterator, Mapping
 from typing import TYPE_CHECKING, Any, Union
 
@@ -120,18 +121,19 @@ class Schema(Concrete, Coercible, MapSet):
         }
 
         """
+
         pairs = list(values)
-        if len(pairs) == 0:
+        if not pairs:
             return cls({})
 
         names, types = zip(*pairs)
 
         # validate unique field names
-        name_locs = {v: i for i, v in enumerate(names)}
-        if len(name_locs) < len(names):
-            duplicate_names = list(names)
-            for v in name_locs:
-                duplicate_names.remove(v)
+        name_counts = Counter(names)
+        [(_, most_common_count)] = name_counts.most_common(1)
+
+        if most_common_count > 1:
+            duplicate_names = [name for name, count in name_counts.items() if count > 1]
             raise IntegrityError(f"Duplicate column name(s): {duplicate_names}")
 
         # construct the schema


### PR DESCRIPTION
Adds a modest 2x performance improvement when trying to construct schemas with duplicate keys.