### PR TITLE
feat(api): add `length` parameter to the `String` datatype

### DIFF
--- a/ibis/backends/clickhouse/tests/test_datatypes.py
+++ b/ibis/backends/clickhouse/tests/test_datatypes.py
@@ -125,7 +125,7 @@ def test_array_discovery_clickhouse(con):
         ),
         param(
             "Array(FixedString(32))",
-            dt.Array(dt.String(nullable=False), nullable=False),
+            dt.Array(dt.String(length=32, nullable=False), nullable=False),
             id="array_fixed_string",
         ),
         param(

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -258,6 +258,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase):
                 C.numeric_precision,
                 C.numeric_scale,
                 C.datetime_precision,
+                C.character_maximum_length,
             )
             .from_(
                 sg.table(
@@ -288,12 +289,20 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase):
             numeric_precision,
             numeric_scale,
             datetime_precision,
+            character_maximum_length,
         ) in meta:
             newtyp = self.compiler.type_mapper.from_string(
                 typ, nullable=is_nullable == "YES"
             )
 
-            if typ == "float":
+            if (
+                typ.lower() != "hierarchyid"
+                and character_maximum_length is not None
+                and character_maximum_length != -1
+                and newtyp.is_string()
+            ):
+                newtyp = newtyp.copy(length=character_maximum_length)
+            elif typ == "float":
                 newcls = dt.Float64 if numeric_precision == 53 else dt.Float32
                 newtyp = newcls(nullable=newtyp.nullable)
             elif newtyp.is_decimal():

--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -49,12 +49,12 @@ RAW_DB_TYPES = [
     ("DATETIMEOFFSET", dt.timestamp(scale=7, timezone="UTC")),
     ("SMALLDATETIME", dt.Timestamp(scale=0)),
     ("DATETIME", dt.Timestamp(scale=3)),
-    # Characters strings
-    ("CHAR", dt.string),
-    ("VARCHAR", dt.string),
+    # Character strings
+    ("CHAR", dt.String(length=1)),
+    ("VARCHAR", dt.String(length=1)),
     # Unicode character strings
-    ("NCHAR", dt.string),
-    ("NVARCHAR", dt.string),
+    ("NCHAR", dt.String(length=1)),
+    ("NVARCHAR", dt.String(length=1)),
     # Binary strings
     ("BINARY", dt.binary),
     ("VARBINARY", dt.binary),
@@ -256,7 +256,7 @@ def test_dot_sql_with_unnamed_columns(con):
 
     assert schema.types == (
         dt.Timestamp(timezone="UTC", scale=7),
-        dt.String(nullable=False),
+        dt.String(nullable=False, length=2),
         dt.Int32(nullable=False),
     )
 

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -192,11 +192,16 @@ class Backend(SQLBackend, CanCreateDatabase):
     def _get_schema_using_query(self, query: str) -> sch.Schema:
         from ibis.backends.mysql.datatypes import _type_from_cursor_info
 
+        char_set_info = self.con.get_character_set_info()
+        multi_byte_maximum_length = char_set_info["mbmaxlen"]
+
         sql = (
             sg.select(STAR)
             .from_(
                 sg.parse_one(query, dialect=self.dialect).subquery(
-                    sg.to_identifier("tmp", quoted=self.compiler.quoted)
+                    sg.to_identifier(
+                        util.gen_name("query_schema"), quoted=self.compiler.quoted
+                    )
                 )
             )
             .limit(0)
@@ -210,13 +215,13 @@ class Backend(SQLBackend, CanCreateDatabase):
         for (name, type_code, _, _, field_length, scale, _), raw_flags in zip(
             descr, flags
         ):
-            item = _type_from_cursor_info(
+            items[name] = _type_from_cursor_info(
                 flags=raw_flags,
                 type_code=type_code,
                 field_length=field_length,
                 scale=scale,
+                multi_byte_maximum_length=multi_byte_maximum_length,
             )
-            items[name] = item
         return sch.Schema(items)
 
     def get_schema(

--- a/ibis/backends/mysql/datatypes.py
+++ b/ibis/backends/mysql/datatypes.py
@@ -20,7 +20,9 @@ TEXT_TYPES = (
 )
 
 
-def _type_from_cursor_info(*, flags, type_code, field_length, scale) -> dt.DataType:
+def _type_from_cursor_info(
+    *, flags, type_code, field_length, scale, multi_byte_maximum_length
+) -> dt.DataType:
     """Construct an ibis type from MySQL field descr and field result metadata.
 
     This method is complex because the MySQL protocol is complex.
@@ -60,7 +62,7 @@ def _type_from_cursor_info(*, flags, type_code, field_length, scale) -> dt.DataT
         if flags.is_binary:
             typ = dt.Binary
         else:
-            typ = dt.String
+            typ = partial(dt.String, length=field_length // multi_byte_maximum_length)
     elif flags.is_timestamp or typename == "TIMESTAMP":
         typ = partial(dt.Timestamp, timezone="UTC", scale=scale or None)
     elif typename == "DATETIME":

--- a/ibis/backends/mysql/tests/test_client.py
+++ b/ibis/backends/mysql/tests/test_client.py
@@ -45,11 +45,9 @@ MYSQL_TYPES = [
     param("time", dt.time, id="time"),
     param("datetime", dt.timestamp, id="datetime"),
     param("year", dt.int8, id="year"),
-    param("char(32)", dt.string, id="char"),
+    param("char(32)", dt.String(length=32), id="char"),
     param("char byte", dt.binary, id="char_byte"),
-    param("varchar(42)", dt.string, id="varchar"),
-    param("mediumtext", dt.string, id="mediumtext"),
-    param("text", dt.string, id="text"),
+    param("varchar(42)", dt.String(length=42), id="varchar"),
     param("binary(42)", dt.binary, id="binary"),
     param("varbinary(42)", dt.binary, id="varbinary"),
     param("bit(1)", dt.int8, id="bit_1"),
@@ -57,7 +55,6 @@ MYSQL_TYPES = [
     param("bit(17)", dt.int32, id="bit_17"),
     param("bit(33)", dt.int64, id="bit_33"),
     # mariadb doesn't have a distinct json type
-    param("enum('small', 'medium', 'large')", dt.string, id="enum"),
     param("set('a', 'b', 'c', 'd')", dt.Array(dt.string), id="set"),
     param("mediumblob", dt.binary, id="mediumblob"),
     param("blob", dt.binary, id="blob"),
@@ -95,6 +92,14 @@ def test_get_schema_from_query(con, mysql_type, expected_type):
         param("json", dt.binary, dt.string, id="json"),
         param("inet6", dt.binary, dt.inet, id="inet"),
         param("uuid", dt.binary, dt.uuid, id="uuid"),
+        param(
+            "enum('small', 'medium', 'large')",
+            dt.String(length=6),
+            dt.string,
+            id="enum",
+        ),
+        param("mediumtext", dt.String(length=2**24 - 1), dt.string, id="mediumtext"),
+        param("text", dt.String(length=2**16 - 1), dt.string, id="text"),
     ],
 )
 def test_get_schema_from_query_special_cases(

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -148,7 +148,8 @@ def test_create_and_drop_table(con, temp_table, params):
         for (pg_type, ibis_type) in [
             ("boolean", dt.boolean),
             ("bytea", dt.binary),
-            ("char", dt.string),
+            ("char", dt.String(length=1)),
+            ("char(42)", dt.String(length=42)),
             ("bigint", dt.int64),
             ("smallint", dt.int16),
             ("integer", dt.int32),
@@ -162,8 +163,10 @@ def test_create_and_drop_table(con, temp_table, params):
             ("macaddr", dt.macaddr),
             ("macaddr8", dt.macaddr),
             ("inet", dt.inet),
-            ("character", dt.string),
+            ("character", dt.String(length=1)),
             ("character varying", dt.string),
+            ("character varying(73)", dt.String(length=73)),
+            ("varchar(37)", dt.String(length=37)),
             ("date", dt.date),
             ("time", dt.time),
             ("time without time zone", dt.time),
@@ -305,13 +308,13 @@ def test_pgvector_type_load(con, vector_size):
 def test_name_dtype(con):
     expected_schema = ibis.schema(
         {
-            "f_table_catalog": dt.String(nullable=True),
+            "f_table_catalog": dt.String(length=256, nullable=True),
             "f_table_schema": dt.String(nullable=True),
             "f_table_name": dt.String(nullable=True),
             "f_geometry_column": dt.String(nullable=True),
             "coord_dimension": dt.Int32(nullable=True),
             "srid": dt.Int32(nullable=True),
-            "type": dt.String(nullable=True),
+            "type": dt.String(length=30, nullable=True),
         }
     )
 

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -19,7 +19,6 @@ _from_sqlglot_types = {
     typecode.BIGINT: dt.Int64,
     typecode.BINARY: dt.Binary,
     typecode.BOOLEAN: dt.Boolean,
-    typecode.CHAR: dt.String,
     typecode.DATE: dt.Date,
     typecode.DATETIME: dt.Timestamp,
     typecode.DATE32: dt.Date,
@@ -28,7 +27,6 @@ _from_sqlglot_types = {
     typecode.ENUM8: dt.String,
     typecode.ENUM16: dt.String,
     typecode.FLOAT: dt.Float32,
-    typecode.FIXEDSTRING: dt.String,
     typecode.HSTORE: partial(dt.Map, dt.string, dt.string),
     typecode.INET: dt.INET,
     typecode.INT128: partial(dt.Decimal, 38, 0),
@@ -43,11 +41,9 @@ _from_sqlglot_types = {
     typecode.MEDIUMINT: dt.Int32,
     typecode.MEDIUMTEXT: dt.String,
     typecode.MONEY: dt.Decimal(19, 4),
-    typecode.NCHAR: dt.String,
     typecode.UUID: dt.UUID,
     typecode.NAME: dt.String,
     typecode.NULL: dt.Null,
-    typecode.NVARCHAR: dt.String,
     typecode.OBJECT: partial(dt.Map, dt.string, dt.json),
     typecode.ROWVERSION: partial(dt.Binary, nullable=False),
     typecode.SMALLINT: dt.Int16,
@@ -64,7 +60,6 @@ _from_sqlglot_types = {
     typecode.UTINYINT: dt.UInt8,
     typecode.UUID: dt.UUID,
     typecode.VARBINARY: dt.Binary,
-    typecode.VARCHAR: dt.String,
     typecode.VARIANT: dt.JSON,
     typecode.UNIQUEIDENTIFIER: dt.UUID,
     typecode.SET: partial(dt.Array, dt.string),
@@ -116,7 +111,6 @@ _to_sqlglot_types = {
     dt.Float16: typecode.FLOAT,
     dt.Float32: typecode.FLOAT,
     dt.Float64: typecode.DOUBLE,
-    dt.String: typecode.VARCHAR,
     dt.Binary: typecode.VARBINARY,
     dt.INET: typecode.INET,
     dt.UUID: typecode.UUID,
@@ -219,6 +213,19 @@ class SqlglotType(TypeMapper):
         cls, value_type: sge.DataType, nullable: bool | None = None
     ) -> dt.Array:
         return dt.Array(cls.to_ibis(value_type), nullable=nullable)
+
+    @classmethod
+    def _from_sqlglot_VARCHAR(
+        cls, length: sge.DataTypeParam | None = None, nullable: bool | None = None
+    ) -> dt.String:
+        return dt.String(
+            length=int(length.this.this) if length is not None else None,
+            nullable=nullable,
+        )
+
+    _from_sqlglot_NVARCHAR = _from_sqlglot_NCHAR = _from_sqlglot_CHAR = (
+        _from_sqlglot_FIXEDSTRING
+    ) = _from_sqlglot_VARCHAR
 
     @classmethod
     def _from_sqlglot_MAP(
@@ -358,6 +365,17 @@ class SqlglotType(TypeMapper):
         if srid is not None:
             srid = int(srid.this.this)
         return typeclass(geotype="geography", nullable=nullable, srid=srid)
+
+    @classmethod
+    def _from_ibis_String(cls, dtype: dt.String) -> sge.DataType:
+        return sge.DataType(
+            this=typecode.VARCHAR,
+            expressions=(
+                None
+                if (length := dtype.length) is None
+                else [sge.DataTypeParam(this=sge.convert(length))]
+            ),
+        )
 
     @classmethod
     def _from_ibis_JSON(cls, dtype: dt.JSON) -> sge.DataType:
@@ -584,10 +602,6 @@ class MySQLType(SqlglotType):
     def _from_sqlglot_TIMESTAMP(cls, nullable: bool | None = None) -> dt.Timestamp:
         return dt.Timestamp(timezone="UTC", nullable=nullable)
 
-    @classmethod
-    def _from_ibis_String(cls, dtype: dt.String) -> sge.DataType:
-        return sge.DataType(this=typecode.TEXT)
-
 
 class DuckDBType(SqlglotType):
     dialect = "duckdb"
@@ -768,19 +782,19 @@ class SnowflakeType(SqlglotType):
 
     @classmethod
     def _from_ibis_JSON(cls, dtype: dt.JSON) -> sge.DataType:
-        return sge.DataType(this=sge.DataType.Type.VARIANT)
+        return sge.DataType(this=typecode.VARIANT)
 
     @classmethod
     def _from_ibis_Array(cls, dtype: dt.Array) -> sge.DataType:
-        return sge.DataType(this=sge.DataType.Type.ARRAY, nested=True)
+        return sge.DataType(this=typecode.ARRAY, nested=True)
 
     @classmethod
     def _from_ibis_Map(cls, dtype: dt.Map) -> sge.DataType:
-        return sge.DataType(this=sge.DataType.Type.OBJECT, nested=True)
+        return sge.DataType(this=typecode.OBJECT, nested=True)
 
     @classmethod
     def _from_ibis_Struct(cls, dtype: dt.Struct) -> sge.DataType:
-        return sge.DataType(this=sge.DataType.Type.OBJECT, nested=True)
+        return sge.DataType(this=typecode.OBJECT, nested=True)
 
 
 class SQLiteType(SqlglotType):
@@ -899,9 +913,9 @@ class BigQueryType(SqlglotType):
     @classmethod
     def _from_ibis_Timestamp(cls, dtype: dt.Timestamp) -> sge.DataType:
         if dtype.timezone is None:
-            return sge.DataType(this=sge.DataType.Type.DATETIME)
+            return sge.DataType(this=typecode.DATETIME)
         elif dtype.timezone == "UTC":
-            return sge.DataType(this=sge.DataType.Type.TIMESTAMPTZ)
+            return sge.DataType(this=typecode.TIMESTAMPTZ)
         else:
             raise com.UnsupportedBackendType(
                 "BigQuery does not support timestamps with timezones other than 'UTC'"
@@ -912,9 +926,9 @@ class BigQueryType(SqlglotType):
         precision = dtype.precision
         scale = dtype.scale
         if (precision, scale) == (76, 38):
-            return sge.DataType(this=sge.DataType.Type.BIGDECIMAL)
+            return sge.DataType(this=typecode.BIGDECIMAL)
         elif (precision, scale) in ((38, 9), (None, None)):
-            return sge.DataType(this=sge.DataType.Type.DECIMAL)
+            return sge.DataType(this=typecode.DECIMAL)
         else:
             raise com.UnsupportedBackendType(
                 "BigQuery only supports decimal types with precision of 38 and "
@@ -930,14 +944,14 @@ class BigQueryType(SqlglotType):
 
     @classmethod
     def _from_ibis_UInt32(cls, dtype: dt.UInt32) -> sge.DataType:
-        return sge.DataType(this=sge.DataType.Type.BIGINT)
+        return sge.DataType(this=typecode.BIGINT)
 
     _from_ibis_UInt8 = _from_ibis_UInt16 = _from_ibis_UInt32
 
     @classmethod
     def _from_ibis_GeoSpatial(cls, dtype: dt.GeoSpatial) -> sge.DataType:
         if (dtype.geotype, dtype.srid) == ("geography", 4326):
-            return sge.DataType(this=sge.DataType.Type.GEOGRAPHY)
+            return sge.DataType(this=typecode.GEOGRAPHY)
         else:
             raise com.UnsupportedBackendType(
                 "BigQuery geography uses points on WGS84 reference ellipsoid."
@@ -981,9 +995,14 @@ class ExasolType(SqlglotType):
 
     @classmethod
     def _from_ibis_String(cls, dtype: dt.String) -> sge.DataType:
+        length = dtype.length
         return sge.DataType(
-            this=sge.DataType.Type.VARCHAR,
-            expressions=[sge.DataTypeParam(this=sge.convert(2_000_000))],
+            this=typecode.VARCHAR,
+            expressions=[
+                sge.DataTypeParam(
+                    this=sge.convert(length if length is not None else 2_000_000)
+                )
+            ],
         )
 
     @classmethod
@@ -1075,8 +1094,26 @@ class MSSQLType(SqlglotType):
     def _from_ibis_String(cls, dtype: dt.String) -> sge.DataType:
         return sge.DataType(
             this=typecode.VARCHAR,
-            expressions=[sge.DataTypeParam(this=sge.Var(this="max"))],
+            expressions=[
+                sge.DataTypeParam(
+                    this=(
+                        sge.Var(this="max")
+                        if (length := dtype.length) is None
+                        else sge.convert(length)
+                    )
+                )
+            ],
         )
+
+    @classmethod
+    def _from_sqlglot_VARCHAR(
+        cls, length: sge.DataTypeParam | None = None, nullable: bool | None = None
+    ) -> dt.String:
+        if length is not None and (bound := length.this.this).isdigit():
+            bound = int(bound)
+        else:
+            bound = None
+        return dt.String(length=bound, nullable=nullable)
 
     @classmethod
     def _from_ibis_Array(cls, dtype: dt.String) -> sge.DataType:
@@ -1206,6 +1243,15 @@ class ClickHouseType(SqlglotType):
             this=typecode.MAP, expressions=[key_type, value_type], nested=True
         )
 
+    @classmethod
+    def _from_ibis_String(cls, dtype: dt.String) -> sge.DataType:
+        if (length := dtype.length) is None:
+            return super()._from_ibis_String(dtype)
+        return sge.DataType(
+            this=typecode.FIXEDSTRING,
+            expressions=[sge.DataTypeParam(this=sge.convert(length))],
+        )
+
 
 class FlinkType(SqlglotType):
     dialect = "flink"
@@ -1214,7 +1260,7 @@ class FlinkType(SqlglotType):
 
     @classmethod
     def _from_ibis_Binary(cls, dtype: dt.Binary) -> sge.DataType:
-        return sge.DataType(this=sge.DataType.Type.VARBINARY)
+        return sge.DataType(this=typecode.VARBINARY)
 
     @classmethod
     def _from_ibis_Map(cls, dtype: dt.Map) -> sge.DataType:

--- a/ibis/backends/trino/tests/test_datatypes.py
+++ b/ibis/backends/trino/tests/test_datatypes.py
@@ -28,11 +28,11 @@ dtypes = [
     ("integer", dt.int32),
     ("uuid", dt.uuid),
     ("char", dt.string),
-    ("char(42)", dt.string),
+    ("char(42)", dt.String(length=42)),
     ("json", dt.json),
     ("ipaddress", dt.inet),
     ("varchar", dt.string),
-    ("varchar(7)", dt.string),
+    ("varchar(7)", dt.String(length=7)),
     ("decimal", dt.Decimal(18, 3)),
     ("decimal(15, 0)", dt.Decimal(15, 0)),
     ("decimal(23, 5)", dt.Decimal(23, 5)),
@@ -44,7 +44,7 @@ dtypes = [
     ("array(array(decimal(42, 23)))", dt.Array(dt.Array(dt.Decimal(42, 23)))),
     (
         "array(row(xYz map(varchar(3), double)))",
-        dt.Array(dt.Struct(dict(xYz=dt.Map(dt.string, dt.float64)))),
+        dt.Array(dt.Struct(dict(xYz=dt.Map(dt.String(length=3), dt.float64)))),
     ),
     ("map(varchar, array(double))", dt.Map(dt.string, dt.Array(dt.float64))),
     (

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -535,6 +535,12 @@ class Integer(Primitive, Numeric):
 class String(Variadic, Singleton):
     """A type representing a string.
 
+    ::: {.callout-note}
+    ## The `length` attribute has **no** effect on the end-user API.
+
+    `length` is supported so that fixed-length strings' metadata is preserved.
+    :::
+
     Notes
     -----
     Because of differences in the way different backends handle strings, we
@@ -542,8 +548,16 @@ class String(Variadic, Singleton):
 
     """
 
+    length: int | None = None
+
     scalar = "StringScalar"
     column = "StringColumn"
+
+    @property
+    def _pretty_piece(self) -> str:
+        if (length := self.length) is not None:
+            return f"({length:d})"
+        return ""
 
 
 @public

--- a/ibis/expr/datatypes/parse.py
+++ b/ibis/expr/datatypes/parse.py
@@ -113,7 +113,6 @@ def parse(
             "uint16",
             "uint32",
             "uint64",
-            "string",
             "binary",
             "timestamp",
             "time",
@@ -141,9 +140,11 @@ def parse(
     )
 
     varchar_or_char = (
-        spaceless_string("varchar", "char")
-        .then(LPAREN.then(RAW_NUMBER).skip(RPAREN).optional())
-        .result(dt.string)
+        spaceless_string("varchar", "string", "char")
+        .then(
+            LPAREN.then(parsy.seq(length=spaceless(LENGTH))).skip(RPAREN).optional({})
+        )
+        .combine_dict(dt.String)
     )
 
     decimal = spaceless_string("decimal").then(

--- a/ibis/expr/datatypes/tests/test_parse.py
+++ b/ibis/expr/datatypes/tests/test_parse.py
@@ -77,9 +77,12 @@ def test_parse_decimal_failure(case):
         dt.dtype(case)
 
 
-@pytest.mark.parametrize("spec", ["varchar", "varchar(10)", "char", "char(10)"])
-def test_parse_char_varchar(spec):
-    assert dt.dtype(spec) == dt.string
+@pytest.mark.parametrize(
+    ("spec", "length"),
+    [("varchar", None), ("varchar(10)", 10), ("char", None), ("char(10)", 10)],
+)
+def test_parse_char_varchar(spec, length):
+    assert dt.dtype(spec) == dt.String(length=length)
 
 
 @pytest.mark.parametrize(

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -24,35 +24,34 @@ def boolean_dtype(nullable=_nullable):
 
 
 def signed_integer_dtypes(nullable=_nullable):
-    return st.one_of(
-        st.builds(dt.Int8, nullable=nullable),
-        st.builds(dt.Int16, nullable=nullable),
-        st.builds(dt.Int32, nullable=nullable),
-        st.builds(dt.Int64, nullable=nullable),
+    return (
+        st.builds(dt.Int8, nullable=nullable)
+        | st.builds(dt.Int16, nullable=nullable)
+        | st.builds(dt.Int32, nullable=nullable)
+        | st.builds(dt.Int64, nullable=nullable)
     )
 
 
 def unsigned_integer_dtypes(nullable=_nullable):
-    return st.one_of(
-        st.builds(dt.UInt8, nullable=nullable),
-        st.builds(dt.UInt16, nullable=nullable),
-        st.builds(dt.UInt32, nullable=nullable),
-        st.builds(dt.UInt64, nullable=nullable),
+    return (
+        st.builds(dt.UInt8, nullable=nullable)
+        | st.builds(dt.UInt16, nullable=nullable)
+        | st.builds(dt.UInt32, nullable=nullable)
+        | st.builds(dt.UInt64, nullable=nullable)
     )
 
 
 def integer_dtypes(nullable=_nullable):
-    return st.one_of(
-        signed_integer_dtypes(nullable=nullable),
-        unsigned_integer_dtypes(nullable=nullable),
+    return signed_integer_dtypes(nullable=nullable) | unsigned_integer_dtypes(
+        nullable=nullable
     )
 
 
 def floating_dtypes(nullable=_nullable):
-    return st.one_of(
-        st.builds(dt.Float16, nullable=nullable),
-        st.builds(dt.Float32, nullable=nullable),
-        st.builds(dt.Float64, nullable=nullable),
+    return (
+        st.builds(dt.Float16, nullable=nullable)
+        | st.builds(dt.Float32, nullable=nullable)
+        | st.builds(dt.Float64, nullable=nullable)
     )
 
 
@@ -65,15 +64,17 @@ def decimal_dtypes(draw, nullable=_nullable):
 
 
 def numeric_dtypes(nullable=_nullable):
-    return st.one_of(
-        integer_dtypes(nullable=nullable),
-        floating_dtypes(nullable=nullable),
-        decimal_dtypes(nullable=nullable),
+    return (
+        integer_dtypes(nullable=nullable)
+        | floating_dtypes(nullable=nullable)
+        | decimal_dtypes(nullable=nullable)
     )
 
 
 def string_dtype(nullable=_nullable):
-    return st.builds(dt.String, nullable=nullable)
+    return st.builds(
+        dt.String, length=st.none() | st.integers(min_value=0), nullable=nullable
+    )
 
 
 def binary_dtype(nullable=_nullable):
@@ -97,13 +98,13 @@ def uuid_dtype(nullable=_nullable):
 
 
 def string_like_dtypes(nullable=_nullable):
-    return st.one_of(
-        string_dtype(nullable=nullable),
-        binary_dtype(nullable=nullable),
-        json_dtype(nullable=nullable),
-        inet_dtype(nullable=nullable),
-        macaddr_dtype(nullable=nullable),
-        uuid_dtype(nullable=nullable),
+    return (
+        string_dtype(nullable=nullable)
+        | binary_dtype(nullable=nullable)
+        | json_dtype(nullable=nullable)
+        | inet_dtype(nullable=nullable)
+        | macaddr_dtype(nullable=nullable)
+        | uuid_dtype(nullable=nullable)
     )
 
 
@@ -128,22 +129,22 @@ def interval_dtype(interval=_interval, nullable=_nullable):
     return st.builds(dt.Interval, unit=interval, nullable=nullable)
 
 
-def temporal_dtypes(timezone=_timezone, interval=_interval, nullable=_nullable):
-    return st.one_of(
-        date_dtype(nullable=nullable),
-        time_dtype(nullable=nullable),
-        timestamp_dtype(timezone=timezone, nullable=nullable),
+def temporal_dtypes(timezone=_timezone, nullable=_nullable):
+    return (
+        date_dtype(nullable=nullable)
+        | time_dtype(nullable=nullable)
+        | timestamp_dtype(timezone=timezone, nullable=nullable)
     )
 
 
 def primitive_dtypes(nullable=_nullable):
-    return st.one_of(
-        null_dtype,
-        boolean_dtype(nullable=nullable),
-        integer_dtypes(nullable=nullable),
-        floating_dtypes(nullable=nullable),
-        date_dtype(nullable=nullable),
-        time_dtype(nullable=nullable),
+    return (
+        null_dtype
+        | boolean_dtype(nullable=nullable)
+        | integer_dtypes(nullable=nullable)
+        | floating_dtypes(nullable=nullable)
+        | date_dtype(nullable=nullable)
+        | time_dtype(nullable=nullable)
     )
 
 
@@ -179,26 +180,26 @@ def struct_dtypes(
 
 
 def geospatial_dtypes(nullable=_nullable):
-    geotype = st.one_of(st.just("geography"), st.just("geometry"))
-    srid = st.one_of(st.just(None), st.integers(min_value=0))
-    return st.one_of(
-        st.builds(dt.Point, geotype=geotype, nullable=nullable, srid=srid),
-        st.builds(dt.LineString, geotype=geotype, nullable=nullable, srid=srid),
-        st.builds(dt.Polygon, geotype=geotype, nullable=nullable, srid=srid),
-        st.builds(dt.MultiPoint, geotype=geotype, nullable=nullable, srid=srid),
-        st.builds(dt.MultiLineString, geotype=geotype, nullable=nullable, srid=srid),
-        st.builds(dt.MultiPolygon, geotype=geotype, nullable=nullable, srid=srid),
-        st.builds(dt.GeoSpatial, geotype=geotype, nullable=nullable, srid=srid),
+    geotype = st.just("geography") | st.just("geometry")
+    srid = st.none() | st.integers(min_value=0)
+    return (
+        st.builds(dt.Point, geotype=geotype, nullable=nullable, srid=srid)
+        | st.builds(dt.LineString, geotype=geotype, nullable=nullable, srid=srid)
+        | st.builds(dt.Polygon, geotype=geotype, nullable=nullable, srid=srid)
+        | st.builds(dt.MultiPoint, geotype=geotype, nullable=nullable, srid=srid)
+        | st.builds(dt.MultiLineString, geotype=geotype, nullable=nullable, srid=srid)
+        | st.builds(dt.MultiPolygon, geotype=geotype, nullable=nullable, srid=srid)
+        | st.builds(dt.GeoSpatial, geotype=geotype, nullable=nullable, srid=srid)
     )
 
 
 def variadic_dtypes(nullable=_nullable):
-    return st.one_of(
-        string_dtype(nullable=nullable),
-        binary_dtype(nullable=nullable),
-        json_dtype(nullable=nullable),
-        array_dtypes(nullable=nullable),
-        map_dtypes(nullable=nullable),
+    return (
+        string_dtype(nullable=nullable)
+        | binary_dtype(nullable=nullable)
+        | json_dtype(nullable=nullable)
+        | array_dtypes(nullable=nullable)
+        | map_dtypes(nullable=nullable)
     )
 
 


### PR DESCRIPTION
Adds an optional `length` parameter to the `String` datatype.

Closes #9382.