### PR TITLE
fix(types): fix histogram bin allocation

### DIFF
--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -1005,7 +1005,7 @@ class NumericColumn(Column, NumericValue):
 
             binwidth = (self.max() - base) / nbins
 
-        return ((self - base) / binwidth).floor()
+        return ((self - base) / binwidth).floor().clip(0, nbins - 1)
 
 
 @public


### PR DESCRIPTION
## Description of changes

```
import ibis

ibis.options.interactive = True
ibis.options.repr.interactive.max_rows = 20

t = ibis.range(1000).unnest().name("index").as_table()
t.select(hist=t["index"].histogram(nbins=10)).value_counts()
```

```
┏━━━━━━━┳━━━━━━━━━━━━┓
┃ hist  ┃ hist_count ┃
┡━━━━━━━╇━━━━━━━━━━━━┩
│ int64 │ int64      │
├───────┼────────────┤
│     5 │        100 │
│     9 │        100 │
│     0 │        100 │
│     3 │        100 │
│     6 │        100 │
│     2 │        100 │
│     7 │        100 │
│     8 │        100 │
│     1 │        100 │
│     4 │        100 │
└───────┴────────────┘
```

## Issues closed

* Resolves #9687.