### PR TITLE
fix(bigquery): repr geospatial values in interactive mode

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -684,9 +684,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         sql = super()._to_sqlglot(expr, limit=limit, params=params, **kwargs)
 
         table_expr = expr.as_table()
-        geocols = frozenset(
+        geocols = [
             name for name, typ in table_expr.schema().items() if typ.is_geospatial()
-        )
+        ]
 
         query = sql.transform(
             _qualify_memtable,

--- a/ibis/backends/bigquery/converter.py
+++ b/ibis/backends/bigquery/converter.py
@@ -9,7 +9,7 @@ class BigQueryPandasData(PandasData):
         import geopandas as gpd
         import shapely as shp
 
-        return gpd.GeoSeries(shp.from_wkt(s))
+        return gpd.GeoSeries(shp.from_wkb(s))
 
     convert_Point = convert_LineString = convert_Polygon = convert_MultiLineString = (
         convert_MultiPoint

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -455,3 +455,17 @@ def test_complex_column_name(con):
     )
     result = con.to_pandas(expr)
     assert result == 1
+
+
+def test_geospatial_interactive(con, monkeypatch):
+    pytest.importorskip("geopandas")
+
+    monkeypatch.setattr(ibis.options, "interactive", True)
+    t = con.table("bigquery-public-data.geo_us_boundaries.zip_codes")
+    expr = (
+        t.filter(lambda t: t.zip_code_geom.geometry_type() == "ST_Polygon")
+        .head(1)
+        .zip_code_geom
+    )
+    result = repr(expr)
+    assert "POLYGON" in result

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_binary/difference/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_binary/difference/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_difference(`t0`.`geog0`, `t0`.`geog1`) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_difference(`t0`.`geog0`, `t0`.`geog1`) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_binary/intersection/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_binary/intersection/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_intersection(`t0`.`geog0`, `t0`.`geog1`) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_intersection(`t0`.`geog0`, `t0`.`geog1`) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_binary/union/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_binary/union/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_union(`t0`.`geog0`, `t0`.`geog1`) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_union(`t0`.`geog0`, `t0`.`geog1`) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_point/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_point/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_geogpoint(`t0`.`lon`, `t0`.`lat`) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_geogpoint(`t0`.`lon`, `t0`.`lat`) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_simplify/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_simplify/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_simplify(`t0`.`geog`, 5.2) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_simplify(`t0`.`geog`, 5.2) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/buffer/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/buffer/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_buffer(`t0`.`geog`, 5.2) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_buffer(`t0`.`geog`, 5.2) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/centroid/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/centroid/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_centroid(`t0`.`geog`) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_centroid(`t0`.`geog`) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/end_point/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/end_point/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_endpoint(`t0`.`geog`) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_endpoint(`t0`.`geog`) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/point_n/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/point_n/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_pointn(`t0`.`geog`, 3) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_pointn(`t0`.`geog`, 3) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/start_point/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary/start_point/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_startpoint(`t0`.`geog`) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_startpoint(`t0`.`geog`) AS `tmp`
+  FROM `t` AS `t0`
+)

--- a/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary_union/out.sql
+++ b/ibis/backends/bigquery/tests/unit/snapshots/test_compiler/test_geospatial_unary_union/out.sql
@@ -1,3 +1,8 @@
 SELECT
-  st_union_agg(`t0`.`geog`) AS `tmp`
-FROM `t` AS `t0`
+  *
+  REPLACE (st_asbinary(`tmp`) AS `tmp`)
+FROM (
+  SELECT
+    st_union_agg(`t0`.`geog`) AS `tmp`
+  FROM `t` AS `t0`
+)


### PR DESCRIPTION
Fixes a bug in the BigQuery backend when looking at geospatial types in interactive mode.