### PR TITLE
refactor(duckdb): use replace to generate less sql

### DIFF
--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_explicit/expr0/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_explicit/expr0/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("p") AS p
+  *
+  REPLACE (ST_ASWKB("p") AS "p")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('POINT (1 0)') AS "p"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_explicit/expr1/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_explicit/expr1/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("p") AS p
+  *
+  REPLACE (ST_ASWKB("p") AS "p")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('POINT (1 0)') AS "p"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp0-0_0/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp0-0_0/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("result") AS result
+  *
+  REPLACE (ST_ASWKB("result") AS "result")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('POINT (0 0)') AS "result"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp1-1_1/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp1-1_1/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("result") AS result
+  *
+  REPLACE (ST_ASWKB("result") AS "result")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('POINT (1 1)') AS "result"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp2-2_2/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp2-2_2/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("result") AS result
+  *
+  REPLACE (ST_ASWKB("result") AS "result")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('POINT (2 2)') AS "result"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp3-0_0_1_1_2_2/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp3-0_0_1_1_2_2/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("result") AS result
+  *
+  REPLACE (ST_ASWKB("result") AS "result")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('LINESTRING (0 0, 1 1, 2 2)') AS "result"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp4-2_2_1_1_0_0/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp4-2_2_1_1_0_0/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("result") AS result
+  *
+  REPLACE (ST_ASWKB("result") AS "result")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('LINESTRING (2 2, 1 1, 0 0)') AS "result"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp5-0_0_1_1_2_2_0_0/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp5-0_0_1_1_2_2_0_0/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("result") AS result
+  *
+  REPLACE (ST_ASWKB("result") AS "result")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('POLYGON ((0 0, 1 1, 2 2, 0 0))') AS "result"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp6-0_0_1_1_2_2_0_0/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp6-0_0_1_1_2_2_0_0/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("result") AS result
+  *
+  REPLACE (ST_ASWKB("result") AS "result")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('MULTIPOLYGON (((0 0, 1 1, 2 2, 0 0)))') AS "result"

--- a/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp7-0_0_1_1_2_2_2_2_1_1_0_0/out.sql
+++ b/ibis/backends/duckdb/tests/snapshots/test_geospatial/test_literal_geospatial_inferred/shp7-0_0_1_1_2_2_2_2_1_1_0_0/out.sql
@@ -1,5 +1,6 @@
 SELECT
-  ST_ASWKB("result") AS result
+  *
+  REPLACE (ST_ASWKB("result") AS "result")
 FROM (
   SELECT
     ST_GEOMFROMTEXT('MULTILINESTRING ((0 0, 1 1, 2 2), (2 2, 1 1, 0 0))') AS "result"


### PR DESCRIPTION
Refactors the duckdb output to geospatial to use `* REPLACE` syntax to generate less code when replacing a small number of geospatial columns (usually one) among an otherwise large set of columns. Additionally, we now only need to loop over expression columns once.