### PR TITLE
fix(internals): ensure that CTEs are emitted in topological order

### DIFF
--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -322,7 +322,7 @@ def sqlize(
         return CTE(new) if node in ctes else new
 
     result = simplified.replace(wrap)
-    ctes = reversed([cte.parent for cte in result.find(CTE)])
+    ctes = [cte.parent for cte in result.find(CTE, ordered=True)]
 
     return result, ctes
 

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import operator
-from collections.abc import Mapping, Set
+from collections.abc import Mapping
 from functools import reduce
 from typing import TYPE_CHECKING, Any
 
@@ -249,7 +249,7 @@ def merge_select_select(_, **kwargs):
     return result if complexity(result) <= complexity(_) else _
 
 
-def extract_ctes(node: ops.Relation) -> Set[ops.Relation]:
+def extract_ctes(node: ops.Relation) -> set[ops.Relation]:
     cte_types = (Select, ops.Aggregate, ops.JoinChain, ops.Set, ops.Limit, ops.Sample)
     dont_count = (ops.Field, ops.CountStar, ops.CountDistinctStar)
 

--- a/ibis/backends/tests/sql/test_sql.py
+++ b/ibis/backends/tests/sql/test_sql.py
@@ -590,3 +590,17 @@ def test_no_cartesian_join(snapshot):
         ]
     )
     snapshot.assert_match(ibis.to_sql(final, dialect="duckdb"), "out.sql")
+
+
+def test_ctes_in_order():
+    table1 = ibis.table({"id": "int"}, name="table1")
+    table2 = ibis.table({"id": "int"}, name="table2")
+    table3 = ibis.table({"id": "int"}, name="table3")
+
+    ids_table = table1.union(table2).alias("first")
+    info_table = ids_table.union(table3).alias("second")
+
+    expr = ids_table.union(info_table)
+
+    sql = ibis.to_sql(expr, dialect="duckdb")
+    assert sql.find('"first" AS (') < sql.find('"second" AS (')

--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -338,6 +338,7 @@ class Node(Hashable):
         finder: FinderLike,
         filter: Optional[FinderLike] = None,
         context: Optional[dict] = None,
+        ordered: bool = False,
     ) -> list[Node]:
         """Find all nodes matching a given pattern or type in the graph.
 
@@ -355,6 +356,8 @@ class Node(Hashable):
             the given filter and stop otherwise.
         context
             Optional context to use if `finder` or `filter` is a pattern.
+        ordered
+            Emit nodes in topological order if `True`.
 
         Returns
         -------
@@ -364,6 +367,8 @@ class Node(Hashable):
         """
         graph = Graph.from_bfs(self, filter=filter, context=context)
         finder = _coerce_finder(finder, context)
+        if ordered:
+            graph, _ = graph.toposort()
         return [node for node in graph.nodes() if finder(node)]
 
     @experimental


### PR DESCRIPTION
## Description of changes

This PR fixes an issue reported at least twice on Zulip:

[Here](https://ibis-project.zulipchat.com/#narrow/stream/405265-tech-support/topic/CTEs.20generated.20out.20of.20order)
most recently, and
[here](https://ibis-project.zulipchat.com/#narrow/stream/405265-tech-support/topic/.E2.9C.94.20CTEs.20are.20appearing.20out.20of.20order.20in.20large.20queries)
a while back.

The issue was that we weren't emitting CTEs (common table expressions) in topological order,
because our `find` API on `Node`s didn't order its output topologically.

This meant that sometimes nodes *would* be in topological order because that's
the way the query was constructed but in the case of queries with a graph
structure (more than one shared dependent) child nodes would be emitted before parents.

I added a flag, `ordered` to the `find` method to address the specific use case
and then passed `ordered=True` at the call site.

I'll run the benchmarks locally to make sure this doesn't introduce a huge
performance regression, since the sort will happen on every call to `translate`
even if there end up being no found `CTE`s.

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed

None that are open on GitHub, just those discussed on Zulip.