### PR TITLE
docs: fix typo in `drop` method docstring

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1266,7 +1266,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ …       │ …         │              … │             … │                 … │ … │
         └─────────┴───────────┴────────────────┴───────────────┴───────────────────┴───┘
 
-        The only valid values of `keep` are `"first"`, `"last"` and [`None][None]
+        The only valid values of `keep` are `"first"`, `"last"` and [](`None`).
 
         >>> t.distinct(on="species", keep="second")  # quartodoc: +EXPECTED_FAILURE
         Traceback (most recent call last):


### PR DESCRIPTION
Fixes a typo in the `drop` method failure mode example.