### PR TITLE
feat(api): support `order_by` in order-sensitive aggregates (`collect`/`group_concat`/`first`/`last`)

### DIFF
--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_group_concat/comma_none/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_group_concat/comma_none/out.sql
@@ -3,5 +3,5 @@ SELECT
     WHEN empty(groupArray("t0"."string_col"))
     THEN NULL
     ELSE arrayStringConcat(groupArray("t0"."string_col"), ',')
-  END AS "GroupConcat(string_col, ',')"
+  END AS "GroupConcat(string_col, ',', ())"
 FROM "functional_alltypes" AS "t0"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_group_concat/comma_zero/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_group_concat/comma_zero/out.sql
@@ -3,5 +3,5 @@ SELECT
     WHEN empty(groupArrayIf("t0"."string_col", "t0"."bool_col" = 0))
     THEN NULL
     ELSE arrayStringConcat(groupArrayIf("t0"."string_col", "t0"."bool_col" = 0), ',')
-  END AS "GroupConcat(string_col, ',', Equals(bool_col, 0))"
+  END AS "GroupConcat(string_col, ',', (), Equals(bool_col, 0))"
 FROM "functional_alltypes" AS "t0"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_group_concat/minus_none/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_group_concat/minus_none/out.sql
@@ -3,5 +3,5 @@ SELECT
     WHEN empty(groupArray("t0"."string_col"))
     THEN NULL
     ELSE arrayStringConcat(groupArray("t0"."string_col"), '-')
-  END AS "GroupConcat(string_col, '-')"
+  END AS "GroupConcat(string_col, '-', ())"
 FROM "functional_alltypes" AS "t0"

--- a/ibis/backends/impala/tests/snapshots/test_analytic_functions/test_analytic_exprs/first/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_analytic_functions/test_analytic_exprs/first/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  FIRST_VALUE(`t0`.`double_col`) OVER (ORDER BY `t0`.`id` ASC) AS `First(double_col)`
+  FIRST_VALUE(`t0`.`double_col`) OVER (ORDER BY `t0`.`id` ASC) AS `First(double_col, ())`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_analytic_functions/test_analytic_exprs/last/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_analytic_functions/test_analytic_exprs/last/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  LAST_VALUE(`t0`.`double_col`) OVER (ORDER BY `t0`.`id` ASC) AS `Last(double_col)`
+  LAST_VALUE(`t0`.`double_col`) OVER (ORDER BY `t0`.`id` ASC) AS `Last(double_col, ())`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -45,7 +45,7 @@ def _literal_value(op, nan_as_none=False):
 
 
 @singledispatch
-def translate(expr, *, ctx):
+def translate(expr, **_):
     raise NotImplementedError(expr)
 
 
@@ -748,6 +748,11 @@ def execute_first_last(op, **kw):
 
     arg = arg.filter(predicate)
 
+    if order_by := getattr(op, "order_by", ()):
+        keys = [translate(k.expr, **kw).filter(predicate) for k in order_by]
+        descending = [k.descending for k in order_by]
+        arg = arg.sort_by(keys, descending=descending)
+
     return arg.last() if isinstance(op, ops.Last) else arg.first()
 
 
@@ -985,14 +990,21 @@ def array_column(op, **kw):
 @translate.register(ops.ArrayCollect)
 def array_collect(op, in_group_by=False, **kw):
     arg = translate(op.arg, **kw)
-    if (where := op.where) is not None:
-        arg = arg.filter(translate(where, **kw))
-    out = arg.drop_nulls()
-    if not in_group_by:
-        # Polars' behavior changes for `implode` within a `group_by` currently.
-        # See https://github.com/pola-rs/polars/issues/16756
-        out = out.implode()
-    return out
+
+    predicate = arg.is_not_null()
+    if op.where is not None:
+        predicate &= translate(op.where, **kw)
+
+    arg = arg.filter(predicate)
+
+    if op.order_by:
+        keys = [translate(k.expr, **kw).filter(predicate) for k in op.order_by]
+        descending = [k.descending for k in op.order_by]
+        arg = arg.sort_by(keys, descending=descending)
+
+    # Polars' behavior changes for `implode` within a `group_by` currently.
+    # See https://github.com/pola-rs/polars/issues/16756
+    return arg if in_group_by else arg.implode()
 
 
 @translate.register(ops.ArrayFlatten)

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1414,10 +1414,11 @@ def execute_group_concat(op, **kw):
     if (where := op.where) is not None:
         predicate &= translate(where, **kw)
 
+    arg = arg.filter(predicate)
+
     if order_by := op.order_by:
         keys = [translate(k.expr, **kw).filter(predicate) for k in order_by]
         descending = [k.descending for k in order_by]
         arg = arg.sort_by(keys, descending=descending)
 
-    no_nulls = arg.filter(predicate)
-    return pl.when(no_nulls.count() > 0).then(no_nulls.str.join(sep)).otherwise(None)
+    return pl.when(arg.count() > 0).then(arg.str.join(sep)).otherwise(None)

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -82,18 +82,13 @@ class AggGen:
 
         __getitem__ = __getattr__
 
-    __slots__ = ("supports_filter", "supports_order_by", "requires_within_group")
+    __slots__ = ("supports_filter", "supports_order_by")
 
     def __init__(
-        self,
-        *,
-        supports_filter: bool = False,
-        supports_order_by: bool = False,
-        requires_within_group: bool = False,
+        self, *, supports_filter: bool = False, supports_order_by: bool = False
     ):
         self.supports_filter = supports_filter
         self.supports_order_by = supports_order_by
-        self.requires_within_group = requires_within_group
 
     def __get__(self, instance, owner=None):
         if instance is None:
@@ -137,13 +132,8 @@ class AggGen:
             args = tuple(compiler.if_(where, arg, NULL) for arg in args)
 
         if order_by and self.supports_order_by:
-            if self.requires_within_group:
-                out = sge.WithinGroup(
-                    this=func(*args), expression=sge.Order(expressions=order_by)
-                )
-            else:
-                *rest, last = args
-                out = func(*rest, sge.Order(this=last, expressions=order_by))
+            *rest, last = args
+            out = func(*rest, sge.Order(this=last, expressions=order_by))
         else:
             out = func(*args)
 

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -128,7 +128,7 @@ class AggGen:
         if order_by and not self.supports_order_by:
             raise com.UnsupportedOperationError(
                 "ordering of order-sensitive aggregations via `order_by` is "
-                "not supported for this backend"
+                f"not supported for the {compiler.dialect} backend"
             )
 
         if where is not None and not self.supports_filter:

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -132,10 +132,7 @@ class AggGen:
             )
 
         if where is not None and not self.supports_filter:
-            args = tuple(
-                arg if isinstance(arg, sge.Literal) else compiler.if_(where, arg, NULL)
-                for arg in args
-            )
+            args = tuple(compiler.if_(where, arg, NULL) for arg in args)
 
         if order_by and self.supports_order_by:
             *rest, last = args

--- a/ibis/backends/sql/compilers/bigquery.py
+++ b/ibis/backends/sql/compilers/bigquery.py
@@ -70,7 +70,6 @@ class BigQueryCompiler(SQLGlotCompiler):
         ops.DateFromYMD: "date",
         ops.Divide: "ieee_divide",
         ops.EndsWith: "ends_with",
-        ops.GroupConcat: "string_agg",
         ops.GeoArea: "st_area",
         ops.GeoAsBinary: "st_asbinary",
         ops.GeoAsText: "st_astext",

--- a/ibis/backends/sql/compilers/bigquery.py
+++ b/ibis/backends/sql/compilers/bigquery.py
@@ -175,6 +175,15 @@ class BigQueryCompiler(SQLGlotCompiler):
             "timestamp difference with mixed timezone/timezoneless values is not implemented"
         )
 
+    def visit_GroupConcat(self, op, *, arg, sep, where, order_by):
+        if where is not None:
+            arg = self.if_(where, arg, NULL)
+
+        if order_by:
+            sep = sge.Order(this=sep, expressions=order_by)
+
+        return sge.GroupConcat(this=arg, separator=sep)
+
     def visit_FloorDivide(self, op, *, left, right):
         return self.cast(self.f.floor(self.f.ieee_divide(left, right)), op.dtype)
 

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -20,7 +20,12 @@ if TYPE_CHECKING:
 
 
 class ClickhouseAggGen(AggGen):
-    def aggregate(self, compiler, name, *args, where=None):
+    def aggregate(self, compiler, name, *args, where=None, order_by=()):
+        if order_by:
+            raise com.UnsupportedOperationError(
+                "ordering of order-sensitive aggregations via `order_by` is "
+                "not supported for this backend"
+            )
         # Clickhouse aggregate functions all have filtering variants with a
         # `If` suffix (e.g. `SumIf` instead of `Sum`).
         if where is not None:
@@ -433,7 +438,12 @@ class ClickHouseCompiler(SQLGlotCompiler):
             delimiter, self.cast(arg, dt.String(nullable=False))
         )
 
-    def visit_GroupConcat(self, op, *, arg, sep, where):
+    def visit_GroupConcat(self, op, *, arg, sep, where, order_by):
+        if order_by:
+            raise com.UnsupportedOperationError(
+                "ordering of order-sensitive aggregations via `order_by` is "
+                "not supported for this backend"
+            )
         call = self.agg.groupArray(arg, where=where)
         return self.if_(self.f.empty(call), NULL, self.f.arrayStringConcat(call, sep))
 

--- a/ibis/backends/sql/compilers/datafusion.py
+++ b/ibis/backends/sql/compilers/datafusion.py
@@ -30,7 +30,7 @@ class DataFusionCompiler(SQLGlotCompiler):
         *SQLGlotCompiler.rewrites,
     )
 
-    agg = AggGen(supports_filter=True)
+    agg = AggGen(supports_filter=True, supports_order_by=True)
 
     UNSUPPORTED_OPS = (
         ops.ArgMax,
@@ -425,15 +425,15 @@ class DataFusionCompiler(SQLGlotCompiler):
             sg.or_(*any_args_null), self.cast(NULL, dt.string), self.f.concat(*arg)
         )
 
-    def visit_First(self, op, *, arg, where):
+    def visit_First(self, op, *, arg, where, order_by):
         cond = arg.is_(sg.not_(NULL, copy=False))
         where = cond if where is None else sge.And(this=cond, expression=where)
-        return self.agg.first_value(arg, where=where)
+        return self.agg.first_value(arg, where=where, order_by=order_by)
 
-    def visit_Last(self, op, *, arg, where):
+    def visit_Last(self, op, *, arg, where, order_by):
         cond = arg.is_(sg.not_(NULL, copy=False))
         where = cond if where is None else sge.And(this=cond, expression=where)
-        return self.agg.last_value(arg, where=where)
+        return self.agg.last_value(arg, where=where, order_by=order_by)
 
     def visit_Aggregate(self, op, *, parent, groups, metrics):
         """Support `GROUP BY` expressions in `SELECT` since DataFusion does not."""

--- a/ibis/backends/sql/compilers/datafusion.py
+++ b/ibis/backends/sql/compilers/datafusion.py
@@ -488,3 +488,12 @@ class DataFusionCompiler(SQLGlotCompiler):
             args.append(sge.convert(name))
             args.append(value)
         return self.f.named_struct(*args)
+
+    def visit_GroupConcat(self, op, *, arg, sep, where, order_by):
+        if order_by:
+            raise com.UnsupportedOperationError(
+                "DataFusion does not support order-sensitive group_concat"
+            )
+        return super().visit_GroupConcat(
+            op, arg=arg, sep=sep, where=where, order_by=order_by
+        )

--- a/ibis/backends/sql/compilers/druid.py
+++ b/ibis/backends/sql/compilers/druid.py
@@ -121,8 +121,8 @@ class DruidCompiler(SQLGlotCompiler):
     def visit_Sign(self, op, *, arg):
         return self.if_(arg.eq(0), 0, self.if_(arg > 0, 1, -1))
 
-    def visit_GroupConcat(self, op, *, arg, sep, where):
-        return self.agg.string_agg(arg, sep, 1 << 20, where=where)
+    def visit_GroupConcat(self, op, *, arg, sep, where, order_by):
+        return self.agg.string_agg(arg, sep, 1 << 20, where=where, order_by=order_by)
 
     def visit_StartsWith(self, op, *, arg, start):
         return self.f.left(arg, self.f.length(start)).eq(start)

--- a/ibis/backends/sql/compilers/duckdb.py
+++ b/ibis/backends/sql/compilers/duckdb.py
@@ -34,7 +34,7 @@ class DuckDBCompiler(SQLGlotCompiler):
     dialect = DuckDB
     type_mapper = DuckDBType
 
-    agg = AggGen(supports_filter=True)
+    agg = AggGen(supports_filter=True, supports_order_by=True)
 
     rewrites = (
         exclude_nulls_from_array_collect,
@@ -476,15 +476,15 @@ class DuckDBCompiler(SQLGlotCompiler):
             arg, pattern, replacement, "g", dialect=self.dialect
         )
 
-    def visit_First(self, op, *, arg, where):
+    def visit_First(self, op, *, arg, where, order_by):
         cond = arg.is_(sg.not_(NULL, copy=False))
         where = cond if where is None else sge.And(this=cond, expression=where)
-        return self.agg.first(arg, where=where)
+        return self.agg.first(arg, where=where, order_by=order_by)
 
-    def visit_Last(self, op, *, arg, where):
+    def visit_Last(self, op, *, arg, where, order_by):
         cond = arg.is_(sg.not_(NULL, copy=False))
         where = cond if where is None else sge.And(this=cond, expression=where)
-        return self.agg.last(arg, where=where)
+        return self.agg.last(arg, where=where, order_by=order_by)
 
     def visit_Quantile(self, op, *, arg, quantile, where):
         suffix = "cont" if op.arg.dtype.is_numeric() else "disc"

--- a/ibis/backends/sql/compilers/exasol.py
+++ b/ibis/backends/sql/compilers/exasol.py
@@ -128,6 +128,15 @@ class ExasolCompiler(SQLGlotCompiler):
     def visit_Date(self, op, *, arg):
         return self.cast(arg, dt.date)
 
+    def visit_GroupConcat(self, op, *, arg, sep, where, order_by):
+        if where is not None:
+            arg = self.if_(where, arg, NULL)
+
+        if order_by:
+            arg = sge.Order(this=arg, expressions=order_by)
+
+        return sge.GroupConcat(this=arg, separator=sep)
+
     def visit_StartsWith(self, op, *, arg, start):
         return self.f.left(arg, self.f.length(start)).eq(start)
 

--- a/ibis/backends/sql/compilers/exasol.py
+++ b/ibis/backends/sql/compilers/exasol.py
@@ -133,7 +133,7 @@ class ExasolCompiler(SQLGlotCompiler):
             arg = self.if_(where, arg, NULL)
 
         if order_by:
-            sep = sge.Order(this=sep, expressions=order_by)
+            arg = sge.Order(this=arg, expressions=order_by)
 
         return sge.GroupConcat(this=arg, separator=sep)
 

--- a/ibis/backends/sql/compilers/exasol.py
+++ b/ibis/backends/sql/compilers/exasol.py
@@ -133,7 +133,7 @@ class ExasolCompiler(SQLGlotCompiler):
             arg = self.if_(where, arg, NULL)
 
         if order_by:
-            arg = sge.Order(this=arg, expressions=order_by)
+            sep = sge.Order(this=sep, expressions=order_by)
 
         return sge.GroupConcat(this=arg, separator=sep)
 

--- a/ibis/backends/sql/compilers/flink.py
+++ b/ibis/backends/sql/compilers/flink.py
@@ -19,7 +19,13 @@ from ibis.backends.sql.rewrites import (
 
 
 class FlinkAggGen(AggGen):
-    def aggregate(self, compiler, name, *args, where=None):
+    def aggregate(self, compiler, name, *args, where=None, order_by=()):
+        if order_by:
+            raise com.UnsupportedOperationError(
+                "ordering of order-sensitive aggregations via `order_by` is "
+                "not supported for this backend"
+            )
+
         func = compiler.f[name]
         if where is not None:
             # Flink does support FILTER, but it's broken for:

--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -53,7 +53,7 @@ def rewrite_rows_range_order_by_window(_, **kwargs):
 class MSSQLCompiler(SQLGlotCompiler):
     __slots__ = ()
 
-    agg = AggGen(supports_order_by=True, requires_within_group=True)
+    agg = AggGen(supports_order_by=True)
 
     dialect = MSSQL
     type_mapper = MSSQLType

--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -13,6 +13,7 @@ from ibis.backends.sql.compilers.base import (
     NULL,
     STAR,
     TRUE,
+    AggGen,
     SQLGlotCompiler,
 )
 from ibis.backends.sql.datatypes import MSSQLType
@@ -51,6 +52,8 @@ def rewrite_rows_range_order_by_window(_, **kwargs):
 
 class MSSQLCompiler(SQLGlotCompiler):
     __slots__ = ()
+
+    agg = AggGen(supports_order_by=True, requires_within_group=True)
 
     dialect = MSSQL
     type_mapper = MSSQLType

--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -185,10 +185,16 @@ class MSSQLCompiler(SQLGlotCompiler):
             length = self.f.length(arg)
         return self.f.substring(arg, start, length)
 
-    def visit_GroupConcat(self, op, *, arg, sep, where):
+    def visit_GroupConcat(self, op, *, arg, sep, where, order_by):
         if where is not None:
             arg = self.if_(where, arg, NULL)
-        return self.f.group_concat(arg, sep)
+
+        out = self.f.group_concat(arg, sep)
+
+        if order_by:
+            out = sge.WithinGroup(this=out, expression=sge.Order(expressions=order_by))
+
+        return out
 
     def visit_CountStar(self, op, *, arg, where):
         if where is not None:

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -165,13 +165,18 @@ class MySQLCompiler(SQLGlotCompiler):
             sge.Distinct(expressions=list(map(func, op.arg.schema.keys())))
         )
 
-    def visit_GroupConcat(self, op, *, arg, sep, where):
+    def visit_GroupConcat(self, op, *, arg, sep, where, order_by):
         if not isinstance(op.sep, ops.Literal):
             raise com.UnsupportedOperationError(
                 "Only string literal separators are supported"
             )
+
         if where is not None:
-            arg = self.if_(where, arg)
+            arg = self.if_(where, arg, NULL)
+
+        if order_by:
+            arg = sge.Order(this=arg, expressions=order_by)
+
         return self.f.group_concat(arg, sep)
 
     def visit_DayOfWeekIndex(self, op, *, arg):

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -171,13 +171,9 @@ class MySQLCompiler(SQLGlotCompiler):
                 "Only string literal separators are supported"
             )
 
-        if where is not None:
-            arg = self.if_(where, arg, NULL)
-
-        if order_by:
-            arg = sge.Order(this=arg, expressions=order_by)
-
-        return self.f.group_concat(arg, sep)
+        return super().visit_GroupConcat(
+            op, arg=arg, sep=sep, where=where, order_by=order_by
+        )
 
     def visit_DayOfWeekIndex(self, op, *, arg):
         return (self.f.dayofweek(arg) + 5) % 7

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -171,9 +171,13 @@ class MySQLCompiler(SQLGlotCompiler):
                 "Only string literal separators are supported"
             )
 
-        return super().visit_GroupConcat(
-            op, arg=arg, sep=sep, where=where, order_by=order_by
-        )
+        if where is not None:
+            arg = self.if_(where, arg, NULL)
+
+        if order_by:
+            arg = sge.Order(this=arg, expressions=order_by)
+
+        return sge.GroupConcat(this=arg, separator=sep)
 
     def visit_DayOfWeekIndex(self, op, *, arg):
         return (self.f.dayofweek(arg) + 5) % 7

--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -23,7 +23,7 @@ from ibis.backends.sql.rewrites import (
 class OracleCompiler(SQLGlotCompiler):
     __slots__ = ()
 
-    agg = AggGen(supports_order_by=True, requires_within_group=True)
+    agg = AggGen(supports_order_by=True)
 
     dialect = Oracle
     type_mapper = OracleType

--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -6,7 +6,7 @@ import toolz
 
 import ibis.common.exceptions as com
 import ibis.expr.operations as ops
-from ibis.backends.sql.compilers.base import NULL, STAR, SQLGlotCompiler
+from ibis.backends.sql.compilers.base import NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.datatypes import OracleType
 from ibis.backends.sql.dialects import Oracle
 from ibis.backends.sql.rewrites import (
@@ -22,6 +22,8 @@ from ibis.backends.sql.rewrites import (
 
 class OracleCompiler(SQLGlotCompiler):
     __slots__ = ()
+
+    agg = AggGen(supports_order_by=True, requires_within_group=True)
 
     dialect = Oracle
     type_mapper = OracleType
@@ -446,3 +448,14 @@ class OracleCompiler(SQLGlotCompiler):
 
     def visit_ExtractIsoYear(self, op, *, arg):
         return self.cast(self.f.to_char(arg, "IYYY"), op.dtype)
+
+    def visit_GroupConcat(self, op, *, arg, where, sep, order_by):
+        if where is not None:
+            arg = self.if_(where, arg, NULL)
+
+        out = self.f.listagg(arg, sep)
+
+        if order_by:
+            out = sge.WithinGroup(this=out, expression=sge.Order(expressions=order_by))
+
+        return out

--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -446,9 +446,3 @@ class OracleCompiler(SQLGlotCompiler):
 
     def visit_ExtractIsoYear(self, op, *, arg):
         return self.cast(self.f.to_char(arg, "IYYY"), op.dtype)
-
-    def visit_GroupConcat(self, op, *, arg, where, sep):
-        if where is not None:
-            arg = self.if_(where, arg)
-
-        return self.f.listagg(arg, sep)

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -43,7 +43,6 @@ class PostgresCompiler(SQLGlotCompiler):
 
     SIMPLE_OPS = {
         ops.Arbitrary: "first",  # could use any_value for postgres>=16
-        ops.ArrayCollect: "array_agg",
         ops.ArrayRemove: "array_remove",
         ops.BitAnd: "bit_and",
         ops.BitOr: "bit_or",

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -29,7 +29,7 @@ class PostgresCompiler(SQLGlotCompiler):
 
     rewrites = (exclude_nulls_from_array_collect, *SQLGlotCompiler.rewrites)
 
-    agg = AggGen(supports_filter=True)
+    agg = AggGen(supports_filter=True, supports_order_by=True)
 
     NAN = sge.Literal.number("'NaN'::double precision")
     POS_INF = sge.Literal.number("'Inf'::double precision")

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -240,15 +240,11 @@ class PySparkCompiler(SQLGlotCompiler):
     def visit_LastValue(self, op, *, arg):
         return sge.IgnoreNulls(this=self.f.last(arg))
 
-    def visit_First(self, op, *, arg, where):
-        if where is not None:
-            arg = self.if_(where, arg, NULL)
-        return sge.IgnoreNulls(this=self.f.first(arg))
+    def visit_First(self, op, *, arg, where, order_by):
+        return sge.IgnoreNulls(this=self.agg.first(arg, where=where, order_by=order_by))
 
-    def visit_Last(self, op, *, arg, where):
-        if where is not None:
-            arg = self.if_(where, arg, NULL)
-        return sge.IgnoreNulls(this=self.f.last(arg))
+    def visit_Last(self, op, *, arg, where, order_by):
+        return sge.IgnoreNulls(this=self.agg.last(arg, where=where, order_by=order_by))
 
     def visit_Arbitrary(self, op, *, arg, where):
         # For Spark>=3.4 we could use any_value here
@@ -259,7 +255,12 @@ class PySparkCompiler(SQLGlotCompiler):
     def visit_Median(self, op, *, arg, where):
         return self.agg.percentile(arg, 0.5, where=where)
 
-    def visit_GroupConcat(self, op, *, arg, sep, where):
+    def visit_GroupConcat(self, op, *, arg, sep, where, order_by):
+        if order_by:
+            raise com.UnsupportedOperationError(
+                "ordering of order-sensitive aggregations via `order_by` is "
+                "not supported for this backend"
+            )
         if where is not None:
             arg = self.if_(where, arg, NULL)
         collected = self.f.collect_list(arg)

--- a/ibis/backends/sql/compilers/risingwave.py
+++ b/ibis/backends/sql/compilers/risingwave.py
@@ -35,6 +35,20 @@ class RisingWaveCompiler(PostgresCompiler):
     def visit_DateNow(self, op):
         return self.cast(sge.CurrentTimestamp(), dt.date)
 
+    def visit_First(self, op, *, arg, where, order_by):
+        if not order_by:
+            raise com.UnsupportedOperationError(
+                "RisingWave requires an `order_by` be specified in `first`"
+            )
+        return self.agg.first_value(arg, where=where, order_by=order_by)
+
+    def visit_Last(self, op, *, arg, where, order_by):
+        if not order_by:
+            raise com.UnsupportedOperationError(
+                "RisingWave requires an `order_by` be specified in `last`"
+            )
+        return self.agg.last_value(arg, where=where, order_by=order_by)
+
     def visit_Correlation(self, op, *, left, right, how, where):
         if how == "sample":
             raise com.UnsupportedOperationError(

--- a/ibis/backends/sql/compilers/risingwave.py
+++ b/ibis/backends/sql/compilers/risingwave.py
@@ -58,12 +58,6 @@ class RisingWaveCompiler(PostgresCompiler):
             op, left=left, right=right, how=how, where=where
         )
 
-    def visit_First(self, op, *, arg, where):
-        return self.agg.first_value(arg, where=where)
-
-    def visit_Last(self, op, *, arg, where):
-        return self.agg.last_value(arg, where=where)
-
     def visit_TimestampTruncate(self, op, *, arg, unit):
         unit_mapping = {
             "Y": "year",

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -369,11 +369,14 @@ class SnowflakeCompiler(SQLGlotCompiler):
         return self.f.get(expr, self.f.array_size(expr) - 1)
 
     def visit_GroupConcat(self, op, *, arg, where, sep, order_by):
-        out = sge.WithinGroup(
-            this=self.f.listagg(arg, sep), expression=sge.Order(expressions=order_by)
-        )
         if where is not None:
-            out = self.if_(self.f.count_if(where) > 0, out, NULL)
+            arg = self.if_(where, arg, NULL)
+
+        out = self.f.listagg(arg, sep)
+
+        if order_by:
+            out = sge.WithinGroup(this=out, expression=sge.Order(expressions=order_by))
+
         return out
 
     def visit_TimestampBucket(self, op, *, arg, interval, offset):

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -40,7 +40,7 @@ class SnowflakeCompiler(SQLGlotCompiler):
     type_mapper = SnowflakeType
     no_limit_value = NULL
 
-    agg = AggGen(supports_order_by=True, requires_within_group=True)
+    agg = AggGen(supports_order_by=True)
 
     rewrites = (
         exclude_unsupported_window_frame_from_row_number,

--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -20,6 +20,7 @@ class SQLiteCompiler(SQLGlotCompiler):
     dialect = SQLite
     type_mapper = SQLiteType
 
+    # We could set `supports_order_by=True` for SQLite >= 3.44.0 (2023-11-01).
     agg = AggGen(supports_filter=True)
 
     NAN = NULL

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -34,7 +34,7 @@ class TrinoCompiler(SQLGlotCompiler):
     dialect = Trino
     type_mapper = TrinoType
 
-    agg = AggGen(supports_filter=True)
+    agg = AggGen(supports_filter=True, supports_order_by=True)
 
     rewrites = (
         exclude_nulls_from_array_collect,
@@ -370,15 +370,27 @@ class TrinoCompiler(SQLGlotCompiler):
     def visit_ArrayStringJoin(self, op, *, sep, arg):
         return self.f.array_join(arg, sep)
 
-    def visit_First(self, op, *, arg, where):
+    def visit_First(self, op, *, arg, where, order_by):
         cond = arg.is_(sg.not_(NULL, copy=False))
         where = cond if where is None else sge.And(this=cond, expression=where)
-        return self.f.element_at(self.agg.array_agg(arg, where=where), 1)
+        return self.f.element_at(
+            self.agg.array_agg(arg, where=where, order_by=order_by), 1
+        )
 
-    def visit_Last(self, op, *, arg, where):
+    def visit_Last(self, op, *, arg, where, order_by):
         cond = arg.is_(sg.not_(NULL, copy=False))
         where = cond if where is None else sge.And(this=cond, expression=where)
-        return self.f.element_at(self.agg.array_agg(arg, where=where), -1)
+        return self.f.element_at(
+            self.agg.array_agg(arg, where=where, order_by=order_by), -1
+        )
+
+    def visit_GroupConcat(self, op, *, arg, sep, where, order_by):
+        cond = arg.is_(sg.not_(NULL, copy=False))
+        where = cond if where is None else sge.And(this=cond, expression=where)
+        array = self.agg.array_agg(
+            self.cast(arg, dt.string), where=where, order_by=order_by
+        )
+        return self.f.array_join(array, sep)
 
     def visit_ArrayZip(self, op, *, arg):
         max_zip_arguments = 5

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -85,7 +85,6 @@ class TrinoCompiler(SQLGlotCompiler):
         ops.ArraySort: "array_sort",
         ops.ArrayDistinct: "array_distinct",
         ops.ArrayLength: "cardinality",
-        ops.ArrayCollect: "array_agg",
         ops.ArrayIntersect: "array_intersect",
         ops.BitAnd: "bitwise_and_agg",
         ops.BitOr: "bitwise_or_agg",

--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -358,6 +358,7 @@ Oracle.Generator.TRANSFORMS |= {
     sge.ApproxDistinct: rename_func("approx_count_distinct"),
     sge.Create: _create_sql,
     sge.Select: transforms.preprocess([transforms.eliminate_semi_and_anti_joins]),
+    sge.GroupConcat: rename_func("listagg"),
 }
 
 # TODO: can delete this after bumping sqlglot version > 20.9.0

--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -64,9 +64,18 @@ def _interval(self, e, quote_arg=True):
     return f"INTERVAL {arg} {e.args['unit']}"
 
 
+def _group_concat(self, e):
+    this = self.sql(e, "this")
+    separator = self.sql(e, "separator") or "','"
+    return f"GROUP_CONCAT({this} SEPARATOR {separator})"
+
+
 class Exasol(Postgres):
     class Generator(Postgres.Generator):
-        TRANSFORMS = Postgres.Generator.TRANSFORMS.copy() | {sge.Interval: _interval}
+        TRANSFORMS = Postgres.Generator.TRANSFORMS.copy() | {
+            sge.Interval: _interval,
+            sge.GroupConcat: _group_concat,
+        }
         TYPE_MAPPING = Postgres.Generator.TYPE_MAPPING.copy() | {
             sge.DataType.Type.TIMESTAMPTZ: "TIMESTAMP WITH LOCAL TIME ZONE",
         }

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1325,11 +1325,6 @@ def test_group_concat(
     raises=com.UnsupportedOperationError,
 )
 @pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
-@pytest.mark.notyet(
-    ["oracle"],
-    raises=OracleDatabaseError,
-    reason="ORA-00904: 'GROUP_CONCAT': invalid identifier",
-)
 @pytest.mark.parametrize("filtered", [False, True])
 def test_group_concat_ordered(alltypes, df, filtered):
     ibis_cond = (_.id % 13 == 0) if filtered else None

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1314,6 +1314,7 @@ def test_group_concat(
 @pytest.mark.notimpl(
     [
         "clickhouse",
+        "datafusion",
         "dask",
         "druid",
         "flink",
@@ -1324,7 +1325,7 @@ def test_group_concat(
     ],
     raises=com.UnsupportedOperationError,
 )
-@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.parametrize("filtered", [False, True])
 def test_group_concat_ordered(alltypes, df, filtered):
     ibis_cond = (_.id % 13 == 0) if filtered else None

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1328,7 +1328,6 @@ def test_group_concat(
     ],
     raises=com.UnsupportedOperationError,
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.parametrize("filtered", [False, True])
 def test_group_concat_ordered(alltypes, df, filtered):
     ibis_cond = (_.id % 13 == 0) if filtered else None

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1334,12 +1334,12 @@ def test_group_concat(
 def test_group_concat_ordered(alltypes, df, filtered):
     ibis_cond = (_.id % 13 == 0) if filtered else None
     pd_cond = (df.id % 13 == 0) if filtered else True
-    result = (
+    expr = (
         alltypes.filter(_.bigint_col == 10)
         .id.cast("str")
         .group_concat(":", where=ibis_cond, order_by=_.id.desc())
-        .execute()
     )
+    result = expr.execute()
     expected = ":".join(
         df.id[(df.bigint_col == 10) & pd_cond].sort_values(ascending=False).astype(str)
     )

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1257,6 +1257,11 @@ def test_date_quantile(alltypes):
                     raises=GoogleBadRequest,
                     reason="Argument 2 to STRING_AGG must be a literal or query parameter",
                 ),
+                pytest.mark.notimpl(
+                    ["polars"],
+                    raises=com.UnsupportedArgumentError,
+                    reason="polars doesn't support expression separators",
+                ),
             ],
         ),
     ],
@@ -1277,7 +1282,6 @@ def test_date_quantile(alltypes):
         ),
     ],
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["exasol"], raises=ExaQueryError)
 @pytest.mark.notyet(["flink"], raises=Py4JJavaError)
 def test_group_concat(

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1510,8 +1510,8 @@ def test_pivot_wider(backend):
 )
 @pytest.mark.notimpl(
     ["risingwave"],
-    raises=PsycoPg2InternalError,
-    reason="function last(double precision) does not exist, do you mean left or least",
+    raises=com.UnsupportedOperationError,
+    reason="first/last requires an order_by",
 )
 @pytest.mark.notyet(
     ["datafusion"],
@@ -1575,8 +1575,8 @@ def test_distinct_on_keep(backend, on, keep):
 )
 @pytest.mark.notimpl(
     ["risingwave"],
-    raises=PsycoPg2InternalError,
-    reason="function first(double precision) does not exist",
+    raises=com.UnsupportedOperationError,
+    reason="first/last requires an order_by",
 )
 @pytest.mark.notyet(
     ["datafusion"],

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -10,10 +10,10 @@ import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
-from ibis.common.typing import VarTuple
+from ibis.common.typing import VarTuple  # noqa: TCH001
 from ibis.expr.operations.core import Column, Value
 from ibis.expr.operations.relations import Relation  # noqa: TCH001
-from ibis.expr.operations.sortkeys import SortKey
+from ibis.expr.operations.sortkeys import SortKey  # noqa: TCH001
 
 
 @public

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -10,8 +10,10 @@ import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
 from ibis.common.annotations import attribute
+from ibis.common.typing import VarTuple
 from ibis.expr.operations.core import Column, Value
 from ibis.expr.operations.relations import Relation  # noqa: TCH001
+from ibis.expr.operations.sortkeys import SortKey
 
 
 @public
@@ -78,6 +80,7 @@ class First(Filterable, Reduction):
     """Retrieve the first element."""
 
     arg: Column[dt.Any]
+    order_by: VarTuple[SortKey] = ()
 
     dtype = rlz.dtype_like("arg")
 
@@ -87,6 +90,7 @@ class Last(Filterable, Reduction):
     """Retrieve the last element."""
 
     arg: Column[dt.Any]
+    order_by: VarTuple[SortKey] = ()
 
     dtype = rlz.dtype_like("arg")
 
@@ -344,6 +348,7 @@ class GroupConcat(Filterable, Reduction):
 
     arg: Column
     sep: Value[dt.String]
+    order_by: VarTuple[SortKey] = ()
 
     dtype = dt.string
 
@@ -362,6 +367,7 @@ class ArrayCollect(Filterable, Reduction):
     """Collect values into an array."""
 
     arg: Column
+    order_by: VarTuple[SortKey] = ()
 
     @attribute
     def dtype(self):

--- a/ibis/expr/tests/test_reductions.py
+++ b/ibis/expr/tests/test_reductions.py
@@ -7,6 +7,7 @@ import ibis
 import ibis.expr.operations as ops
 from ibis import _
 from ibis.common.deferred import Deferred
+from ibis.common.exceptions import IbisTypeError
 
 
 @pytest.mark.parametrize(
@@ -113,3 +114,40 @@ def test_cov_corr_deferred(func_name):
     t = ibis.table({"a": "int", "b": "int"}, name="t")
     func = getattr(t.a, func_name)
     assert func(_.b).equals(func(t.b))
+
+
+@pytest.mark.parametrize("method", ["collect", "first", "last", "group_concat"])
+def test_ordered_aggregations(method):
+    t = ibis.table({"a": "string", "b": "int", "c": "int"}, name="t")
+    func = getattr(t.a, method)
+
+    q1 = func(order_by="b")
+    q2 = func(order_by=("b",))
+    q3 = func(order_by=_.b)
+    q4 = func(order_by=t.b)
+    assert q1.equals(q2)
+    assert q1.equals(q3)
+    assert q1.equals(q4)
+
+    q5 = func(order_by=("b", "c"))
+    q6 = func(order_by=(_.b, _.c))
+    assert q5.equals(q6)
+
+    q7 = func(order_by=_.b.desc())
+    q8 = func(order_by=t.b.desc())
+    assert q7.equals(q8)
+
+    with pytest.raises(IbisTypeError):
+        func(order_by="oops")
+
+
+@pytest.mark.parametrize("method", ["collect", "first", "last", "group_concat"])
+def test_ordered_aggregations_no_order(method):
+    t = ibis.table({"a": "string", "b": "int", "c": "int"}, name="t")
+    func = getattr(t.a, method)
+
+    q1 = func()
+    q2 = func(order_by=None)
+    q3 = func(order_by=())
+    assert q1.equals(q2)
+    assert q1.equals(q3)


### PR DESCRIPTION
This adds a new `order_by` keyword argument to order-sensitive aggregates (`collect`/`group_concat`/`first`/`last`) to specify the ordering the aggregation should use. By default no ordering is specified, and the result is backend dependent (following the current behavior).

```python
In [1]: import ibis

In [2]: t = ibis.memtable({"x": [1, 3, 2, 4], "y": [10, 9, 8, 7]}, name="test")

In [3]: t.x.collect().execute()  # no ordering specified, backend-dependent result
Out[3]: [1, 3, 2, 4]

In [4]: t.x.collect(order_by="y").execute()  # use the specified ordering, or error if unsupported
Out[4]: [4, 2, 3, 1]

In [5]: ibis.to_sql(t.x.collect(order_by="y"))
Out[5]: 
SELECT
  ARRAY_AGG("t0"."x" ORDER BY "t0"."y" ASC) FILTER(WHERE
    "t0"."x" IS NOT NULL) AS "ArrayCollect(x, (y,))"
FROM "test" AS "t0"
```

This is generally implemented using either an aggregate-internal `ORDER BY` clause, or via `WITHIN GROUP (...)` (backend dependent). The SQL required here can vary significantly between backends unfortunately :/.

Fixes #9170.