### PR TITLE
test(risingwave): mark `test_union_aliasing` as notimpl because arbitrary aggregate function is not supported

### DIFF
--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -102,9 +102,12 @@ def test_isin_bug(con, snapshot):
     raises=NotImplementedError,
 )
 @pytest.mark.notyet(
-    ["datafusion", "exasol", "oracle", "flink", "risingwave"],
+    ["datafusion", "exasol", "oracle", "flink"],
     reason="no unnest support",
     raises=exc.OperationNotDefinedError,
+)
+@pytest.mark.notyet(
+    ["risingwave"], reason="no arbitrary support", raises=exc.OperationNotDefinedError
 )
 @pytest.mark.notyet(
     ["sqlite", "mysql", "druid", "impala", "mssql"], reason="no unnest support upstream"


### PR DESCRIPTION
Apparently risingwave has implement support for `UNNEST`.