### PR TITLE
feat(oracle): support `group_concat` operator

### DIFF
--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -446,3 +446,9 @@ class OracleCompiler(SQLGlotCompiler):
 
     def visit_ExtractIsoYear(self, op, *, arg):
         return self.cast(self.f.to_char(arg, "IYYY"), op.dtype)
+
+    def visit_GroupConcat(self, op, *, arg, where, sep):
+        if where is not None:
+            arg = self.if_(where, arg)
+
+        return self.f.listagg(arg, sep)

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1234,11 +1234,6 @@ def test_date_quantile(alltypes):
     ],
 )
 @pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
-@pytest.mark.notyet(
-    ["oracle"],
-    raises=OracleDatabaseError,
-    reason="ORA-00904: 'GROUP_CONCAT': invalid identifier",
-)
 @pytest.mark.notimpl(["exasol"], raises=ExaQueryError)
 @pytest.mark.notyet(["flink"], raises=Py4JJavaError)
 def test_group_concat(


### PR DESCRIPTION
Implements `group_concat` for Oracle, but correctly, compared to what we're currently doing in `main`, which is to compile it as `GROUP_CONCAT` instead of `LISTAGG`.