### PR TITLE
feat(datafusion): `unnest`, struct literals, and `pivot_longer`

### DIFF
--- a/ibis/backends/sql/compilers/datafusion.py
+++ b/ibis/backends/sql/compilers/datafusion.py
@@ -478,3 +478,10 @@ class DataFusionCompiler(SQLGlotCompiler):
             sel = sel.group_by(*by_names_quoted)
 
         return sel
+
+    def visit_StructColumn(self, op, *, names, values):
+        args = []
+        for name, value in zip(names, values):
+            args.append(sge.convert(name))
+            args.append(value)
+        return self.f.named_struct(*args)

--- a/ibis/backends/sql/compilers/datafusion.py
+++ b/ibis/backends/sql/compilers/datafusion.py
@@ -122,6 +122,12 @@ class DataFusionCompiler(SQLGlotCompiler):
             return sg.exp.HexString(this=value.hex())
         elif dtype.is_uuid():
             return sge.convert(str(value))
+        elif dtype.is_struct():
+            args = []
+            for name, field_value in value.items():
+                args.append(sge.convert(name))
+                args.append(field_value)
+            return self.f.named_struct(*args)
         else:
             return None
 

--- a/ibis/backends/sql/compilers/datafusion.py
+++ b/ibis/backends/sql/compilers/datafusion.py
@@ -57,7 +57,6 @@ class DataFusionCompiler(SQLGlotCompiler):
         ops.TimestampDelta,
         ops.TimestampNow,
         ops.TypeOf,
-        ops.Unnest,
         ops.StringToDate,
         ops.StringToTimestamp,
     )

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/datafusion/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/datafusion/out.sql
@@ -1,0 +1,90 @@
+WITH "t5" AS (
+  SELECT
+    "t4"."field_of_study",
+    FIRST_VALUE("t4"."diff") FILTER(WHERE
+      NOT "t4"."diff" IS NULL) AS "diff"
+  FROM (
+    SELECT
+      "t4"."years",
+      "t4"."degrees",
+      "t4"."earliest_degrees",
+      "t4"."latest_degrees",
+      "t4"."diff",
+      "t4"."field_of_study"
+    FROM (
+      SELECT
+        "t3"."field_of_study",
+        "t3"."years",
+        "t3"."degrees",
+        "t3"."earliest_degrees",
+        "t3"."latest_degrees",
+        "t3"."latest_degrees" - "t3"."earliest_degrees" AS "diff"
+      FROM (
+        SELECT
+          "t2"."field_of_study",
+          "t2"."years",
+          "t2"."degrees",
+          FIRST_VALUE("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+          LAST_VALUE("t2"."degrees") OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
+        FROM (
+          SELECT
+            "t1"."field_of_study",
+            "t1"."__pivoted__"."years" AS "years",
+            "t1"."__pivoted__"."degrees" AS "degrees"
+          FROM (
+            SELECT
+              "t0"."field_of_study",
+              UNNEST(
+                MAKE_ARRAY(
+                  NAMED_STRUCT('years', '1970-71', 'degrees', "t0"."1970-71"),
+                  NAMED_STRUCT('years', '1975-76', 'degrees', "t0"."1975-76"),
+                  NAMED_STRUCT('years', '1980-81', 'degrees', "t0"."1980-81"),
+                  NAMED_STRUCT('years', '1985-86', 'degrees', "t0"."1985-86"),
+                  NAMED_STRUCT('years', '1990-91', 'degrees', "t0"."1990-91"),
+                  NAMED_STRUCT('years', '1995-96', 'degrees', "t0"."1995-96"),
+                  NAMED_STRUCT('years', '2000-01', 'degrees', "t0"."2000-01"),
+                  NAMED_STRUCT('years', '2005-06', 'degrees', "t0"."2005-06"),
+                  NAMED_STRUCT('years', '2010-11', 'degrees', "t0"."2010-11"),
+                  NAMED_STRUCT('years', '2011-12', 'degrees', "t0"."2011-12"),
+                  NAMED_STRUCT('years', '2012-13', 'degrees', "t0"."2012-13"),
+                  NAMED_STRUCT('years', '2013-14', 'degrees', "t0"."2013-14"),
+                  NAMED_STRUCT('years', '2014-15', 'degrees', "t0"."2014-15"),
+                  NAMED_STRUCT('years', '2015-16', 'degrees', "t0"."2015-16"),
+                  NAMED_STRUCT('years', '2016-17', 'degrees', "t0"."2016-17"),
+                  NAMED_STRUCT('years', '2017-18', 'degrees', "t0"."2017-18"),
+                  NAMED_STRUCT('years', '2018-19', 'degrees', "t0"."2018-19"),
+                  NAMED_STRUCT('years', '2019-20', 'degrees', "t0"."2019-20")
+                )
+              ) AS "__pivoted__"
+            FROM "humanities" AS "t0"
+          ) AS "t1"
+        ) AS "t2"
+      ) AS "t3"
+    ) AS "t4"
+  ) AS t4
+  GROUP BY
+    "t4"."field_of_study"
+)
+SELECT
+  *
+FROM (
+  SELECT
+    *
+  FROM "t5" AS "t6"
+  ORDER BY
+    "t6"."diff" DESC NULLS LAST
+  LIMIT 10
+) AS "t9"
+UNION ALL
+SELECT
+  *
+FROM (
+  SELECT
+    *
+  FROM "t5" AS "t6"
+  WHERE
+    "t6"."diff" < 0
+  ORDER BY
+    "t6"."diff" ASC
+  LIMIT 10
+) AS "t10"

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -258,7 +258,6 @@ def test_array_discovery(backend):
     reason="BigQuery doesn't support casting array<T> to array<U>",
     raises=GoogleBadRequest,
 )
-@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_unnest_simple(backend):
     array_types = backend.array_types
     expected = (
@@ -274,7 +273,6 @@ def test_unnest_simple(backend):
 
 
 @builtin_array
-@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_unnest_complex(backend):
     array_types = backend.array_types
     df = array_types.execute()
@@ -303,7 +301,12 @@ def test_unnest_complex(backend):
 
 
 @builtin_array
-@pytest.mark.notimpl(["datafusion", "flink"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(
+    ["datafusion"],
+    raises=Exception,
+    reason="Input field name ARRAY_AGG(t1.x) does not match with the projection expression",
+)
 def test_unnest_idempotent(backend):
     array_types = backend.array_types
     df = array_types.execute()
@@ -326,7 +329,12 @@ def test_unnest_idempotent(backend):
 
 
 @builtin_array
-@pytest.mark.notimpl(["datafusion", "flink"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["flink"], raises=com.OperationNotDefinedError)
+@pytest.mark.notyet(
+    ["datafusion"],
+    raises=Exception,
+    reason="Input field name ARRAY_AGG(t1.x) does not match with the projection expression",
+)
 def test_unnest_no_nulls(backend):
     array_types = backend.array_types
     df = array_types.execute()
@@ -358,7 +366,6 @@ def test_unnest_no_nulls(backend):
     raises=ValueError,
     reason="all the input arrays must have same number of dimensions",
 )
-@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_unnest_default_name(backend):
     array_types = backend.array_types
     df = array_types.execute()
@@ -785,7 +792,6 @@ def test_array_intersect(con, data):
 @builtin_array
 @pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError)
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2InternalError)
-@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(
     ["trino"], reason="inserting maps into structs doesn't work", raises=TrinoUserError
 )
@@ -805,7 +811,6 @@ def test_unnest_struct(con):
 @builtin_array
 @pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError)
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2InternalError)
-@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(
     ["trino"], reason="inserting maps into structs doesn't work", raises=TrinoUserError
 )
@@ -896,7 +901,9 @@ def test_zip_null(con, fn):
 @builtin_array
 @pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError)
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2ProgrammingError)
-@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(
+    ["datafusion"], raises=Exception, reason="probably generating invalid SQL"
+)
 @pytest.mark.notimpl(
     ["polars"],
     raises=com.OperationNotDefinedError,
@@ -1094,11 +1101,6 @@ def test_range_start_stop_step_zero(con, start, stop):
     ["polars"],
     raises=AssertionError,
     reason="ibis hasn't implemented this behavior yet",
-)
-@pytest.mark.notyet(
-    ["datafusion"],
-    raises=com.OperationNotDefinedError,
-    reason="backend doesn't support unnest",
 )
 @pytest.mark.notyet(
     ["flink"],

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -901,9 +901,7 @@ def test_zip_null(con, fn):
 @builtin_array
 @pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError)
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2ProgrammingError)
-@pytest.mark.notimpl(
-    ["datafusion"], raises=Exception, reason="probably generating invalid SQL"
-)
+@pytest.mark.notimpl(["datafusion"], raises=Exception, reason="not yet supported")
 @pytest.mark.notimpl(
     ["polars"],
     raises=com.OperationNotDefinedError,

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1403,7 +1403,7 @@ def test_many_subqueries(con, snapshot):
 @pytest.mark.notimpl(["oracle", "exasol"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["druid"], raises=AssertionError)
 @pytest.mark.notyet(
-    ["datafusion", "impala", "mssql", "mysql", "sqlite"],
+    ["impala", "mssql", "mysql", "sqlite"],
     reason="backend doesn't support arrays and we don't implement pivot_longer with unions yet",
     raises=com.OperationNotDefinedError,
 )

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -102,7 +102,7 @@ def test_isin_bug(con, snapshot):
     raises=NotImplementedError,
 )
 @pytest.mark.notyet(
-    ["datafusion", "exasol", "oracle", "flink"],
+    ["exasol", "oracle", "flink"],
     reason="no unnest support",
     raises=exc.OperationNotDefinedError,
 )

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -24,7 +24,7 @@ from ibis.common.exceptions import IbisError
 pytestmark = [
     pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
     pytest.mark.notyet(["impala"]),
-    pytest.mark.notimpl(["datafusion", "druid", "oracle", "exasol"]),
+    pytest.mark.notimpl(["druid", "oracle", "exasol"]),
 ]
 
 
@@ -76,6 +76,7 @@ _NULL_STRUCT_LITERAL = ibis.null().cast("struct<a: int64, b: string, c: float64>
 
 
 @pytest.mark.notimpl(["postgres", "risingwave"])
+@pytest.mark.notyet(["datafusion"], raises=Exception, reason="unsupported syntax")
 @pytest.mark.parametrize("field", ["a", "b", "c"])
 def test_literal(backend, con, field):
     query = _STRUCT_LITERAL[field]
@@ -87,6 +88,7 @@ def test_literal(backend, con, field):
 
 
 @pytest.mark.notimpl(["postgres"])
+@pytest.mark.notyet(["datafusion"], raises=Exception, reason="unsupported syntax")
 @pytest.mark.parametrize("field", ["a", "b", "c"])
 @pytest.mark.notyet(
     ["clickhouse"], reason="clickhouse doesn't support nullable nested types"
@@ -112,6 +114,7 @@ def test_struct_column(alltypes, df):
 
 
 @pytest.mark.notimpl(["postgres", "risingwave", "polars"])
+@pytest.mark.notyet(["datafusion"], raises=Exception, reason="unsupported syntax")
 @pytest.mark.notyet(
     ["flink"], reason="flink doesn't support creating struct columns from collect"
 )
@@ -144,6 +147,7 @@ def test_collect_into_struct(alltypes):
     reason="struct literals not implemented",
     raises=PsycoPg2InternalError,
 )
+@pytest.mark.notyet(["datafusion"], raises=Exception, reason="unsupported syntax")
 @pytest.mark.notimpl(["flink"], raises=Py4JJavaError, reason="not implemented in ibis")
 def test_field_access_after_case(con):
     s = ibis.struct({"a": 3})
@@ -201,6 +205,7 @@ def test_field_access_after_case(con):
     raises=AssertionError,
     reason="snowflake doesn't have strongly typed structs",
 )
+@pytest.mark.notyet(["datafusion"], raises=Exception, reason="unsupported syntax")
 def test_keyword_fields(con, nullable):
     schema = ibis.schema(
         {
@@ -260,6 +265,7 @@ def test_keyword_fields(con, nullable):
     raises=Py4JJavaError,
     reason="fails to parse due to an unsupported operation; flink docs say the syntax is supported",
 )
+@pytest.mark.notyet(["datafusion"], raises=Exception, reason="unsupported syntax")
 def test_isin_struct(con):
     needle1 = ibis.struct({"x": 1, "y": 2})
     needle2 = ibis.struct({"x": 2, "y": 3})


### PR DESCRIPTION
Adds support for unnest, struct literals and fix struct field access, all enabling `pivot_longer` to work as well.