### PR TITLE
test(tpcds): add queries 28-63

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # local codespell matches `./docs`, pre-commit codespell matches `docs`
-skip = *.lock,.direnv,.git,./docs/_freeze,./docs/_output/**,./docs/_inv/**,docs/_freeze/**,*.svg,*.css,*.html,*.js,ibis/backends/tests/tpc/queries/duckdb/ds/44.sql
+skip = *.lock,.direnv,.git,./docs/_freeze,./docs/_output/**,./docs/_inv/**,docs/_freeze/**,*.svg,*.css,*.html,*.js,ibis/backends/tests/tpc/queries/duckdb/ds/*.sql
 ignore-regex = \b(i[if]f|I[IF]F|AFE|alls)\b
 builtin = clear,rare,names
 ignore-words-list = tim,notin,ang

--- a/ibis/backends/tests/tpc/README.md
+++ b/ibis/backends/tests/tpc/README.md
@@ -1,0 +1,25 @@
+# TPC queries with Ibis
+
+These tests perform correctness tests against backends that are able to run
+some of the TPC-H and TPC-DS queries.
+
+The text queries are assumed to be correct, and also that if transpiled
+correctly will produce the same results as the written Ibis expression.
+
+**This is the assertion being made in these tests.**
+
+The ground truth SQL text is taken from
+[DuckDB](https://github.com/duckdb/duckdb/tree/main/extension/tpcds/dsdgen/queries)
+and transpiled using SQLGlot to the dialect of whatever backend is under test.
+
+Some queries are altered from the upstream DucKDB repo to have static column
+names and to cast strings that are dates explicitly to dates so that pedantic
+engines like Trino will accept these queries. These alterations do not change
+the computed results of the queries.
+
+ClickHouse is a bit odd in that queries that contain a cross join with an `OR`
+condition common to all operands of the `OR` will effectively never finish.
+This is probably a bug in ClickHouse.
+
+For that case, the queries for clickhouse have been minimally rewritten to pass
+by extracting the common join condition out into a single `AND` operand.

--- a/ibis/backends/tests/tpc/conftest.py
+++ b/ibis/backends/tests/tpc/conftest.py
@@ -94,17 +94,25 @@ def tpc_test(suite_name: Literal["h", "ds"], *, result_is_empty=False):
 
             assert result_expr._find_backend(use_default=False) is backend.connection
             result = backend.connection.to_pandas(result_expr)
-            assert (result_is_empty and result.empty) or not result.empty
+
+            assert (result_is_empty and result.empty) or (
+                not result_is_empty and not result.empty
+            )
 
             expected = expected_expr.to_pandas()
 
             assert len(expected.columns) == len(result.columns)
-            assert all(r in e.lower() for r, e in zip(result.columns, expected.columns))
+            assert all(
+                r.lower() in e.lower() for r, e in zip(result.columns, expected.columns)
+            )
 
             expected.columns = result.columns
 
             expected = PandasData.convert_table(expected, result_expr.schema())
-            assert (result_is_empty and expected.empty) or not expected.empty
+
+            assert (result_is_empty and expected.empty) or (
+                not result_is_empty and not expected.empty
+            )
 
             assert len(expected) == len(result)
             assert result.columns.tolist() == expected.columns.tolist()

--- a/ibis/backends/tests/tpc/conftest.py
+++ b/ibis/backends/tests/tpc/conftest.py
@@ -56,7 +56,6 @@ def tpc_test(suite_name: Literal["h", "ds"], *, result_is_empty=False):
         # join performance black holes
         #
         # trino can sometimes take a while as well, especially in CI
-        @pytest.mark.timeout(60)
         @pytest.mark.usefixtures("backend")
         @pytest.mark.xdist_group(name)
         @getattr(pytest.mark, name)

--- a/ibis/backends/tests/tpc/conftest.py
+++ b/ibis/backends/tests/tpc/conftest.py
@@ -56,6 +56,11 @@ def tpc_test(suite_name: Literal["h", "ds"], *, result_is_empty=False):
         # join performance black holes
         #
         # trino can sometimes take a while as well, especially in CI
+        #
+        # func_only=True doesn't include the fixture setup time in the duration
+        # of the test run, which is important since backends can take a hugely
+        # variable amount of time to load all the TPC-$WHATEVER tables.
+        @pytest.mark.timeout(60, func_only=True)
         @pytest.mark.usefixtures("backend")
         @pytest.mark.xdist_group(name)
         @getattr(pytest.mark, name)

--- a/ibis/backends/tests/tpc/conftest.py
+++ b/ibis/backends/tests/tpc/conftest.py
@@ -52,9 +52,14 @@ def tpc_test(suite_name: Literal["h", "ds"], *, result_is_empty=False):
     def inner(test: Callable[..., ir.Table]):
         name = f"tpc{suite_name}"
 
-        @getattr(pytest.mark, name)
+        # so that clickhouse doesn't run forever when we hit one of its weird cross
+        # join performance black holes
+        #
+        # trino can sometimes take a while as well, especially in CI
+        @pytest.mark.timeout(60)
         @pytest.mark.usefixtures("backend")
         @pytest.mark.xdist_group(name)
+        @getattr(pytest.mark, name)
         @functools.wraps(test)
         def wrapper(*args, backend, **kwargs):
             backend_name = backend.name()

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -17,7 +17,9 @@ from ibis.backends.tests.tpc.conftest import tpc_test
 
 # so that clickhouse doesn't run forever when we hit one of its weird cross
 # join performance black holes
-pytestmark = pytest.mark.timeout(30)
+#
+# trino can sometimes take a while as well, especially in CI
+pytestmark = pytest.mark.timeout(60)
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -4,12 +4,15 @@ import calendar as cal
 from operator import itemgetter
 
 import pytest
-from pyarrow import ArrowNotImplementedError
 
 from ibis import _, coalesce, cumulative_window, date, ifelse, null, rank, union
 from ibis import literal as lit
 from ibis import selectors as s
-from ibis.backends.tests.errors import ClickHouseDatabaseError, TrinoUserError
+from ibis.backends.tests.errors import (
+    ArrowNotImplementedError,
+    ClickHouseDatabaseError,
+    TrinoUserError,
+)
 from ibis.backends.tests.tpc.conftest import tpc_test
 
 # so that clickhouse doesn't run forever when we hit one of its weird cross

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -15,12 +15,6 @@ from ibis.backends.tests.errors import (
 )
 from ibis.backends.tests.tpc.conftest import tpc_test
 
-# so that clickhouse doesn't run forever when we hit one of its weird cross
-# join performance black holes
-#
-# trino can sometimes take a while as well, especially in CI
-pytestmark = pytest.mark.timeout(60)
-
 
 @pytest.mark.notyet(
     ["clickhouse"],

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -10,6 +10,10 @@ from ibis import selectors as s
 from ibis.backends.tests.errors import ClickHouseDatabaseError
 from ibis.backends.tests.tpc.conftest import tpc_test
 
+# so that clickhouse doesn't run forever when we hit one of its weird cross
+# join performance black holes
+pytestmark = pytest.mark.timeout(30)
+
 
 @pytest.mark.notyet(
     ["clickhouse"],

--- a/ibis/backends/tests/tpc/queries/clickhouse/ds/48.sql
+++ b/ibis/backends/tests/tpc/queries/clickhouse/ds/48.sql
@@ -1,0 +1,41 @@
+SELECT SUM (ss_quantity) total
+FROM store_sales,
+     store,
+     customer_demographics,
+     customer_address,
+     date_dim
+WHERE s_store_sk = ss_store_sk
+  AND ss_sold_date_sk = d_date_sk
+  AND d_year = 2000
+  AND cd_demo_sk = ss_cdemo_sk
+  AND ss_addr_sk = ca_address_sk
+  AND ((
+        cd_marital_status = 'M'
+        AND cd_education_status = '4 yr Degree'
+        AND ss_sales_price BETWEEN 100.00 AND 150.00)
+       OR (
+           cd_marital_status = 'D'
+           AND cd_education_status = '2 yr Degree'
+           AND ss_sales_price BETWEEN 50.00 AND 100.00)
+       OR (
+           cd_marital_status = 'S'
+           AND cd_education_status = 'College'
+           AND ss_sales_price BETWEEN 150.00 AND 200.00))
+  AND ((
+        ca_country = 'United States'
+        AND ca_state IN ('CO',
+                         'OH',
+                         'TX')
+        AND ss_net_profit BETWEEN 0 AND 2000)
+       OR (
+           ca_country = 'United States'
+           AND ca_state IN ('OR',
+                            'MN',
+                            'KY')
+           AND ss_net_profit BETWEEN 150 AND 3000)
+       OR (
+           ca_country = 'United States'
+           AND ca_state IN ('VA',
+                            'CA',
+                            'MS')
+           AND ss_net_profit BETWEEN 50 AND 25000)) ;

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/32.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/32.sql
@@ -4,13 +4,13 @@ FROM catalog_sales ,
      date_dim
 WHERE i_manufact_id = 977
   AND i_item_sk = cs_item_sk
-  AND d_date BETWEEN '2000-01-27' AND cast('2000-04-26' AS date)
+  AND d_date BETWEEN cast('2000-01-27' AS date) AND cast('2000-04-26' AS date)
   AND d_date_sk = cs_sold_date_sk
   AND cs_ext_discount_amt >
     ( SELECT 1.3 * avg(cs_ext_discount_amt)
      FROM catalog_sales ,
           date_dim
      WHERE cs_item_sk = i_item_sk
-       AND d_date BETWEEN '2000-01-27' AND cast('2000-04-26' AS date)
+       AND d_date BETWEEN cast('2000-01-27' AS date) AND cast('2000-04-26' AS date)
        AND d_date_sk = cs_sold_date_sk )
 LIMIT 100;

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/35.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/35.sql
@@ -13,9 +13,9 @@ SELECT ca_state,
        avg(cd_dep_employed_count) avg2,
        cd_dep_college_count,
        count(*) cnt3,
-       min(cd_dep_college_count),
-       max(cd_dep_college_count),
-       avg(cd_dep_college_count)
+       min(cd_dep_college_count) min3,
+       max(cd_dep_college_count) max3,
+       avg(cd_dep_college_count) avg3
 FROM customer c,
      customer_address ca,
      customer_demographics

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/38.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/38.sql
@@ -1,4 +1,4 @@
-SELECT count(*)
+SELECT count(*) cnt
 FROM
   (SELECT DISTINCT c_last_name,
                    c_first_name,

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/42.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/42.sql
@@ -1,7 +1,7 @@
 SELECT dt.d_year,
        item.i_category_id,
        item.i_category,
-       sum(ss_ext_sales_price)
+       sum(ss_ext_sales_price) total_sales
 FROM date_dim dt,
      store_sales,
      item

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/45.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/45.sql
@@ -1,6 +1,6 @@
 SELECT ca_zip,
        ca_city,
-       sum(ws_sales_price)
+       sum(ws_sales_price) total_web_sales
 FROM web_sales,
      customer,
      customer_address,

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/48.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/48.sql
@@ -1,4 +1,4 @@
-SELECT SUM (ss_quantity)
+SELECT SUM (ss_quantity) total
 FROM store_sales,
      store,
      customer_demographics,

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/49.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/49.sql
@@ -36,10 +36,10 @@ FROM
    WHERE (web.return_rank <= 10
           OR web.currency_rank <= 10)
    UNION SELECT 'catalog' AS channel,
-                catalog.item,
-                catalog.return_ratio,
-                catalog.return_rank,
-                catalog.currency_rank
+                CATALOG.item,
+                CATALOG.return_ratio,
+                CATALOG.return_rank,
+                CATALOG.currency_rank
    FROM
      (SELECT item,
              return_ratio,
@@ -63,8 +63,8 @@ FROM
            AND d_year = 2001
            AND d_moy = 12
          GROUP BY cs.cs_item_sk) in_cat) CATALOG
-   WHERE (catalog.return_rank <= 10
-          OR catalog.currency_rank <=10)
+   WHERE (CATALOG.return_rank <= 10
+          OR CATALOG.currency_rank <=10)
    UNION SELECT 'store' AS channel,
                 store.item,
                 store.return_ratio,

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/58.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/58.sql
@@ -11,7 +11,7 @@ WITH ss_items AS
         WHERE d_week_seq =
             (SELECT d_week_seq
              FROM date_dim
-             WHERE d_date = '2000-01-03'))
+             WHERE d_date = date '2000-01-03'))
      AND ss_sold_date_sk = d_date_sk
    GROUP BY i_item_id),
      cs_items AS
@@ -27,7 +27,7 @@ WITH ss_items AS
         WHERE d_week_seq =
             (SELECT d_week_seq
              FROM date_dim
-             WHERE d_date = '2000-01-03'))
+             WHERE d_date = date '2000-01-03'))
      AND cs_sold_date_sk = d_date_sk
    GROUP BY i_item_id),
      ws_items AS
@@ -43,7 +43,7 @@ WITH ss_items AS
         WHERE d_week_seq =
             (SELECT d_week_seq
              FROM date_dim
-             WHERE d_date = '2000-01-03'))
+             WHERE d_date = date '2000-01-03'))
      AND ws_sold_date_sk = d_date_sk
    GROUP BY i_item_id)
 SELECT ss_items.item_id,

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/61.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/61.sql
@@ -1,6 +1,6 @@
 SELECT promotions,
        total,
-       cast(promotions AS decimal(15,4))/cast(total AS decimal(15,4))*100
+       cast(promotions AS decimal(15,4))/cast(total AS decimal(15,4))*100 perc_promotions
 FROM
   (SELECT sum(ss_ext_sales_price) promotions
    FROM store_sales,

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/63.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/63.sql
@@ -1,4 +1,3 @@
-
 SELECT *
 FROM
   (SELECT i_manager_id,


### PR DESCRIPTION
Adds TPC-DS queries 28-63. The commits adding the Ibis expressions are in batches of 10. It seemed no less annoying to do it that way than to create a separate PR for each batch of 10.