### PR TITLE
fix(algolia): add parent class docstring to algolia index

### DIFF
--- a/docs/backends/_utils.py
+++ b/docs/backends/_utils.py
@@ -102,7 +102,11 @@ def dump_methods_to_json_for_algolia(backend, methods):
             "objectID": base_url,
             "href": base_url,
             "title": f"{backend_name}.Backend.{method}",
-            "text": getattr(backend.all_members[method].docstring, "value", ""),
+            "text": getattr(
+                find_member_with_docstring(backend.all_members[method]).docstring,
+                "value",
+                "",
+            ),
             "crumbs": ["Backend API", "API", f"{backend_name} methods"],
         }
 


### PR DESCRIPTION
## Description of changes

Follow-up to #9730.

I fixed adding the parent docstrings in the rendered docs, but those
weren't showing up in the search summary on Algolia.  They do now.