### PR TITLE
refactor(table_loc): return consistent object from catalog.db parsing

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -587,9 +587,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
 
         # Default `catalog` to None unless we've parsed it out of the database/schema kwargs
         # Raise if there are path specifications in both the name and as a kwarg
-        catalog = None if table_loc is None else table_loc.catalog
+        catalog = table_loc.args["catalog"]  # args access will return None, not ''
         if table.catalog:
-            if table_loc is not None and table_loc.catalog:
+            if table_loc.catalog:
                 raise com.IbisInputError(
                     "Cannot specify catalog both in the table name and as an argument"
                 )
@@ -597,9 +597,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
                 catalog = table.catalog
 
         # Default `db` to None unless we've parsed it out of the database/schema kwargs
-        db = None if table_loc is None else table_loc.db
+        db = table_loc.args["db"]  # args access will return None, not ''
         if table.db:
-            if table_loc is not None and table_loc.db:
+            if table_loc.db:
                 raise com.IbisInputError(
                     "Cannot specify database both in the table name and as an argument"
                 )

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -172,11 +172,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
                 "Don't specify a catalog to enable temp table creation."
             )
 
-        catalog = self.current_catalog
-        database = self.current_database
-        if table_loc is not None:
-            catalog = table_loc.catalog or catalog
-            database = table_loc.db or database
+        catalog = table_loc.catalog or self.current_catalog
+        database = table_loc.db or self.current_database
 
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
@@ -302,10 +299,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         """
         table_loc = self._warn_and_create_table_loc(database, schema)
 
-        catalog, database = None, None
-        if table_loc is not None:
-            catalog = table_loc.catalog or None
-            database = table_loc.db or None
+        # TODO: set these to better defaults
+        catalog = table_loc.catalog or None
+        database = table_loc.db or None
 
         table_schema = self.get_schema(name, catalog=catalog, database=database)
         # load geospatial only if geo columns
@@ -1018,11 +1014,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         """
         table_loc = self._warn_and_create_table_loc(database, schema)
 
-        catalog = self.current_catalog
-        database = self.current_database
-        if table_loc is not None:
-            catalog = table_loc.catalog or catalog
-            database = table_loc.db or database
+        catalog = table_loc.catalog or self.current_catalog
+        database = table_loc.db or self.current_database
 
         col = "table_name"
         sql = (

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -489,7 +489,7 @@ GO"""
         catalog, db = self._to_catalog_db_tuple(table_loc)
         conditions = []
 
-        if table_loc is not None:
+        if db:
             conditions.append(C.table_schema.eq(sge.convert(db)))
 
         sql = (

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -343,11 +343,11 @@ class Backend(SQLBackend, CanCreateDatabase):
 
         conditions = [TRUE]
 
-        if table_loc is not None:
-            if (sg_cat := table_loc.args["catalog"]) is not None:
-                sg_cat.args["quoted"] = False
-            if (sg_db := table_loc.args["db"]) is not None:
-                sg_db.args["quoted"] = False
+        if (sg_cat := table_loc.args["catalog"]) is not None:
+            sg_cat.args["quoted"] = False
+        if (sg_db := table_loc.args["db"]) is not None:
+            sg_db.args["quoted"] = False
+        if table_loc.catalog or table_loc.db:
             conditions = [C.table_schema.eq(sge.convert(table_loc.sql(self.name)))]
 
         col = "table_name"

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -734,7 +734,7 @@ $$"""
         tables_query = "SHOW TABLES"
         views_query = "SHOW VIEWS"
 
-        if table_loc is not None:
+        if table_loc.catalog or table_loc.db:
             tables_query += f" IN {table_loc}"
             views_query += f" IN {table_loc}"
 

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -132,10 +132,8 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         """
         table_loc = self._warn_and_create_table_loc(database, schema)
 
-        catalog, database = None, None
-        if table_loc is not None:
-            catalog = table_loc.catalog or None
-            database = table_loc.db or None
+        catalog = table_loc.catalog or None
+        database = table_loc.db or None
 
         table_schema = self.get_schema(name, catalog=catalog, database=database)
         return ops.DatabaseTable(
@@ -589,9 +587,6 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         )
 
     def _to_catalog_db_tuple(self, table_loc: sge.Table):
-        if table_loc is None or table_loc == (None, None):
-            return None, None
-
         if (sg_cat := table_loc.args["catalog"]) is not None:
             sg_cat.args["quoted"] = False
             sg_cat = sg_cat.sql(self.name)
@@ -603,7 +598,8 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
 
     def _to_sqlglot_table(self, database):
         if database is None:
-            return None
+            # Create "table" with empty catalog and db
+            database = sg.exp.Table(catalog=None, db=None)
         elif isinstance(database, (list, tuple)):
             if len(database) > 2:
                 raise ValueError(

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -236,7 +236,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
 
         query = "SHOW TABLES"
 
-        if table_loc is not None:
+        if table_loc.catalog or table_loc.db:
             table_loc = table_loc.sql(dialect=self.dialect)
             query += f" IN {table_loc}"
 


### PR DESCRIPTION
## Description of changes

The previous `return None` short-circuit led to a bunch of `is None`
checks across the codebase.  If we always have a `sg.exp.Table`, even if
the fields are set to `None`, we can simplify those checks.

## Issues closed

This is a small part of #9742