### PR TITLE
fix(sql): only return tables in `current_database`

### DIFF
--- a/docker/mysql/startup.sql
+++ b/docker/mysql/startup.sql
@@ -1,5 +1,4 @@
 CREATE USER 'ibis'@'localhost' IDENTIFIED BY 'ibis';
 CREATE SCHEMA IF NOT EXISTS test_schema;
-GRANT CREATE, DROP ON *.* TO 'ibis'@'%';
-GRANT CREATE,SELECT,DROP ON `test_schema`.* TO 'ibis'@'%';
+GRANT CREATE,SELECT,DROP ON *.* TO 'ibis'@'%';
 FLUSH PRIVILEGES;

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -500,7 +500,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         query = (
             sg.select(f.anon.unnest(f.list_append(C.aliases, C.extension_name)))
             .from_(f.duckdb_extensions())
-            .where(sg.and_(C.installed, C.loaded))
+            .where(C.installed, C.loaded)
         )
         with self._safe_raw_sql(query) as cur:
             installed = map(itemgetter(0), cur.fetchall())

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -337,53 +337,29 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         -------
         sch.Schema
             Ibis schema
-
         """
-        conditions = [sg.column("table_name").eq(sge.convert(table_name))]
-
-        # If no catalog.database is specified, assume the current ones
-        db = database or self.current_database
-        cat = catalog or self.current_catalog
-
-        # If a catalog isn't specified, then include temp tables in the
-        # returned values
-        # temp tables live in the `temp` catalog
-        # We assume that we should return temp tables that match the database
-        # specified
-        if catalog is None:
-            conditions.append(
-                sg.column("table_catalog").isin(sge.convert(cat), sge.convert("temp"))
+        query = sge.Describe(
+            this=sg.table(
+                table_name, db=database, catalog=catalog, quoted=self.compiler.quoted
             )
-        else:
-            conditions.append(sg.column("table_catalog").eq(sge.convert(cat)))
+        ).sql(self.dialect)
 
-        conditions.append(sg.column("table_schema").eq(sge.convert(db)))
-
-        query = (
-            sg.select(
-                "column_name",
-                "data_type",
-                sg.column("is_nullable").eq(sge.convert("YES")).as_("nullable"),
-            )
-            .from_(sg.table("columns", db="information_schema"))
-            .where(sg.and_(*conditions))
-            .order_by("ordinal_position")
-        )
-
-        with self._safe_raw_sql(query) as cur:
-            meta = cur.fetch_arrow_table()
-
-        if not meta:
+        try:
+            result = self.con.sql(query)
+        except duckdb.CatalogException:
             raise exc.IbisError(f"Table not found: {table_name!r}")
+        else:
+            meta = result.fetch_arrow_table()
 
         names = meta["column_name"].to_pylist()
-        types = meta["data_type"].to_pylist()
-        nullables = meta["nullable"].to_pylist()
+        types = meta["column_type"].to_pylist()
+        nullables = meta["null"].to_pylist()
 
+        type_mapper = self.compiler.type_mapper
         return sch.Schema(
             {
-                name: self.compiler.type_mapper.from_string(typ, nullable=nullable)
-                for name, typ, nullable in zip(names, types, nullables)
+                name: type_mapper.from_string(typ, nullable=null == "YES")
+                for name, typ, null in zip(names, types, nullables)
             }
         )
 

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -345,12 +345,12 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
 
         if temp:
             raise com.UnsupportedOperationError(
-                "Creating temp tables is not supported by Exasol."
+                f"Creating temp tables is not supported by {self.name}"
             )
 
         if database is not None and database != self.current_database:
             raise com.UnsupportedOperationError(
-                "Creating tables in other databases is not supported by Exasol"
+                f"Creating tables in other databases is not supported by {self.name}"
             )
         else:
             database = None

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -397,13 +397,6 @@ class Backend(SQLBackend, CanCreateDatabase):
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
 
-        if database is not None and database != self.current_database:
-            raise com.UnsupportedOperationError(
-                f"Creating tables in other databases is not supported by {self.name}"
-            )
-        else:
-            database = None
-
         properties = []
 
         if temp:

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -399,7 +399,7 @@ class Backend(SQLBackend, CanCreateDatabase):
 
         if database is not None and database != self.current_database:
             raise com.UnsupportedOperationError(
-                "Creating tables in other databases is not supported by Postgres"
+                f"Creating tables in other databases is not supported by {self.name}"
             )
         else:
             database = None

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -472,7 +472,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
                 on=n.oid.eq(p.pronamespace),
                 join_type="LEFT",
             )
-            .where(sg.and_(*predicates))
+            .where(*predicates)
         )
 
         def split_name_type(arg: str) -> tuple[str, dt.DataType]:

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -303,6 +303,20 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         with self.begin() as cur:
             cur.execute("SET TIMEZONE = UTC")
 
+    @property
+    def _session_temp_db(self):
+        # Postgres doesn't assign the temporary table database until the first
+        # temp table is created in a given session.
+        # Before that temp table is created, this will return `None`
+        # After a temp table is created, it will return `pg_temp_N` where N is
+        # some integer
+        res = self.raw_sql(
+            "select nspname from pg_namespace where oid = pg_my_temp_schema()"
+        ).fetchone()
+        if res is not None:
+            return res[0]
+        return res
+
     def list_tables(
         self,
         like: str | None = None,
@@ -571,6 +585,16 @@ $$""".format(**self._get_udf_source(udf_node))
 
         format_type = self.compiler.f["pg_catalog.format_type"]
 
+        # If no database is specified, assume the current database
+        db = database or self.current_database
+
+        dbs = [sge.convert(db)]
+
+        # If a database isn't specified, then include temp tables in the
+        # returned values
+        if database is None and (temp_table_db := self._session_temp_db) is not None:
+            dbs.append(sge.convert(temp_table_db))
+
         type_info = (
             sg.select(
                 a.attname.as_("column_name"),
@@ -591,7 +615,7 @@ $$""".format(**self._get_udf_source(udf_node))
             .where(
                 a.attnum > 0,
                 sg.not_(a.attisdropped),
-                n.nspname.eq(sge.convert(database)) if database is not None else TRUE,
+                n.nspname.isin(*dbs),
                 c.relname.eq(sge.convert(name)),
             )
             .order_by(a.attnum)

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -304,7 +304,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             cur.execute("SET TIMEZONE = UTC")
 
     @property
-    def _session_temp_db(self):
+    def _session_temp_db(self) -> str | None:
         # Postgres doesn't assign the temporary table database until the first
         # temp table is created in a given session.
         # Before that temp table is created, this will return `None`

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -586,3 +586,9 @@ class Backend(PostgresBackend):
         )
         with self._safe_raw_sql(src):
             pass
+
+    @property
+    def _session_temp_db(self) -> str | None:
+        # Return `None`, because RisingWave does not implement temp tables like
+        # Postgres
+        return None

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -646,6 +646,13 @@ $$"""
         catalog: str | None = None,
         database: str | None = None,
     ) -> Iterable[tuple[str, dt.DataType]]:
+        # this will always show temp tables with the same name as a non-temp
+        # table first
+        #
+        # snowflake puts temp tables in the same catalog and database as
+        # non-temp tables and differentiates between them using a different
+        # mechanism than other database that often put temp tables in a hidden
+        # or intentionall-difficult-to-access catalog/database
         table = sg.table(
             table_name, db=database, catalog=catalog, quoted=self.compiler.quoted
         )

--- a/ibis/backends/tests/errors.py
+++ b/ibis/backends/tests/errors.py
@@ -55,8 +55,9 @@ except ImportError:
 
 try:
     from google.api_core.exceptions import BadRequest as GoogleBadRequest
+    from google.api_core.exceptions import NotFound as GoogleNotFound
 except ImportError:
-    GoogleBadRequest = None
+    GoogleBadRequest = GoogleNotFound = None
 
 try:
     from polars.exceptions import ColumnNotFoundError as PolarsColumnNotFoundError

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1395,13 +1395,8 @@ def test_create_catalog(con_create_catalog):
 def test_create_database(con_create_database):
     database = gen_name("test_create_database")
     con_create_database.create_database(database)
-    if con_create_database.name == "exasol":
-        database = database.upper()
     assert database in con_create_database.list_databases()
-    database = database.lower()
     con_create_database.drop_database(database)
-    if con_create_database.name == "exasol":
-        database = database.upper()
     assert database not in con_create_database.list_databases()
 
 
@@ -1424,15 +1419,11 @@ def test_create_schema(con_create_database):
     with pytest.warns(FutureWarning):
         con_create_database.create_schema(schema)
     with pytest.warns(FutureWarning):
-        if con_create_database.name == "exasol":
-            schema = schema.upper()
         assert schema in con_create_database.list_schemas()
         schema = schema.lower()
     with pytest.warns(FutureWarning):
         con_create_database.drop_schema(schema)
     with pytest.warns(FutureWarning):
-        if con_create_database.name == "exasol":
-            schema = schema.upper()
         assert schema not in con_create_database.list_schemas()
 
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1658,6 +1658,7 @@ def test_no_accidental_cross_database_table_load(con_create_database):
                 PySparkAnalysisException,
                 MySQLProgrammingError,
                 ExaQueryError,
+                SnowflakeProgrammingError,
             ),
         ),
         # datafusion really needs to get their exception story in order

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1633,11 +1633,6 @@ def test_from_connection(con, top_level):
     assert result == 1
 
 
-@pytest.mark.never(
-    ["postgres"],
-    raises=com.UnsupportedOperationError,
-    reason="tables cannot be created in other databases",
-)
 @pytest.mark.notimpl(
     ["exasol"],
     raises=com.UnsupportedOperationError,

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -29,6 +29,7 @@ from ibis.backends.conftest import ALL_BACKENDS
 from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
     ExaQueryError,
+    GoogleNotFound,
     ImpalaHiveServer2Error,
     MySQLProgrammingError,
     OracleDatabaseError,
@@ -1659,6 +1660,7 @@ def test_no_accidental_cross_database_table_load(con_create_database):
                 MySQLProgrammingError,
                 ExaQueryError,
                 SnowflakeProgrammingError,
+                GoogleNotFound,
             ),
         ),
         # datafusion really needs to get their exception story in order

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -30,6 +30,7 @@ from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
     ExaQueryError,
     ImpalaHiveServer2Error,
+    MySQLProgrammingError,
     OracleDatabaseError,
     PsycoPg2InternalError,
     PsycoPg2UndefinedObject,
@@ -1634,11 +1635,6 @@ def test_from_connection(con, top_level):
 
 
 @pytest.mark.notimpl(
-    ["mysql"],
-    raises=com.UnsupportedOperationError,
-    reason="not yet implemented for MySQL",
-)
-@pytest.mark.notimpl(
     ["exasol"],
     raises=com.UnsupportedOperationError,
     reason="unknown whether tables can be created in other databases",
@@ -1665,7 +1661,16 @@ def test_no_accidental_cross_database_table_load(con_create_database):
     # Now attempting to load same table name without specifying db should fail
     allowed_exceptions = (
         com.IbisError,
-        *tuple(filter(None, (ClickHouseDatabaseError, PySparkAnalysisException))),
+        *tuple(
+            filter(
+                None,
+                (
+                    ClickHouseDatabaseError,
+                    PySparkAnalysisException,
+                    MySQLProgrammingError,
+                ),
+            )
+        ),
         # datafusion really needs to get their exception story in order
         *((Exception,) * (con.name == "datafusion")),
     )

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1634,6 +1634,11 @@ def test_from_connection(con, top_level):
 
 
 @pytest.mark.notimpl(
+    ["mysql"],
+    raises=com.UnsupportedOperationError,
+    reason="not yet implemented for MySQL",
+)
+@pytest.mark.notimpl(
     ["exasol"],
     raises=com.UnsupportedOperationError,
     reason="unknown whether tables can be created in other databases",

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1635,6 +1635,9 @@ def test_from_connection(con, top_level):
 
 
 @pytest.mark.notimpl(
+    ["flink"], raises=com.IbisError, reason="not yet implemented for Flink"
+)
+@pytest.mark.notimpl(
     ["exasol"],
     raises=com.UnsupportedOperationError,
     reason="unknown whether tables can be created in other databases",

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1637,11 +1637,6 @@ def test_from_connection(con, top_level):
 @pytest.mark.notimpl(
     ["flink"], raises=com.IbisError, reason="not yet implemented for Flink"
 )
-@pytest.mark.notimpl(
-    ["exasol"],
-    raises=com.UnsupportedOperationError,
-    reason="unknown whether tables can be created in other databases",
-)
 def test_no_accidental_cross_database_table_load(con_create_database):
     con = con_create_database
 
@@ -1671,6 +1666,7 @@ def test_no_accidental_cross_database_table_load(con_create_database):
                     ClickHouseDatabaseError,
                     PySparkAnalysisException,
                     MySQLProgrammingError,
+                    ExaQueryError,
                 ),
             )
         ),

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1636,10 +1636,10 @@ def test_no_accidental_cross_database_table_load(con_create_database):
 
     # Create table with same name in current db and dummy db
     con.create_table(
-        table := gen_name("table"), schema=(sch1 := ibis.schema({"a": "int32"}))
+        table := gen_name("table"), schema=(sch1 := ibis.schema({"a": "int"}))
     )
 
-    con.create_table(table, schema=ibis.schema({"b": "int64"}), database=dbname)
+    con.create_table(table, schema=ibis.schema({"b": "string"}), database=dbname)
 
     # Can grab table object from current db:
     t = con.table(table)

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -147,10 +147,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             )
             .from_(sg.table("columns", db="information_schema", catalog=catalog))
             .where(
-                sg.and_(
-                    C.table_name.eq(sge.convert(table_name)),
-                    C.table_schema.eq(sge.convert(database or self.current_database)),
-                )
+                C.table_name.eq(sge.convert(table_name)),
+                C.table_schema.eq(sge.convert(database or self.current_database)),
             )
             .order_by(C.ordinal_position)
         )

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -139,20 +139,20 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             Ibis schema
 
         """
-        conditions = [sg.column("table_name").eq(sge.convert(table_name))]
-
-        if database is not None:
-            conditions.append(sg.column("table_schema").eq(sge.convert(database)))
-
         query = (
             sg.select(
-                "column_name",
-                "data_type",
-                sg.column("is_nullable").eq(sge.convert("YES")).as_("nullable"),
+                C.column_name,
+                C.data_type,
+                C.is_nullable.eq(sge.convert("YES")).as_("nullable"),
             )
             .from_(sg.table("columns", db="information_schema", catalog=catalog))
-            .where(sg.and_(*conditions))
-            .order_by("ordinal_position")
+            .where(
+                sg.and_(
+                    C.table_name.eq(sge.convert(table_name)),
+                    C.table_schema.eq(sge.convert(database or self.current_database)),
+                )
+            )
+            .order_by(C.ordinal_position)
         )
 
         with self._safe_raw_sql(query) as cur:
@@ -162,9 +162,11 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
             fqn = sg.table(table_name, db=database, catalog=catalog).sql(self.name)
             raise com.IbisError(f"Table not found: {fqn}")
 
+        type_mapper = self.compiler.type_mapper
+
         return sch.Schema(
             {
-                name: self.compiler.type_mapper.from_string(typ, nullable=nullable)
+                name: type_mapper.from_string(typ, nullable=nullable)
                 for name, typ, nullable in meta
             }
         )


### PR DESCRIPTION
## Description of changes

This started as a fix of #9686 but it turned up a few issues in other backends.

The short version is: when we call `get_schema` without specifying a
`catalog.database` prefix, we get tables that exist in many (sometimes all) the
databases on a given backend (that match the name passed to `get_schema`).

Postgres has things like `search_path` to help with this, but the tables on `search_path` are slightly different than what's returned by `\dt` (just to make this extra fun).

What's implemented here (and what I'm proposing as a general standard) is:

When you ask for a table named `foo`, we will look through the
`current_database` and wherever temp tables are stored for a match and return
the schema of that table.

My idea here is that anything that shows up in the output of `list_tables` (or
`con.tables`) should be accessible via `con.table` without additional arguments.

There's at least one edge-case which I discovered while writing this
description, which is if the temp table has the same name as a table in the
`current_database`, the table returned will be the interleaved schema of the two
tables, which is terrible.

I'll fix that, too.

## Issues closed

* Fixes #9686

## Todo List of things to fix (not all in this PR):

* [ ] decide on whether `temp` tables take precedence over concrete tables or vice-versa
* [x] add spark, datafusion and clickhouse exceptions to test
* [x] add cross-database table creation to mysql
* [x] fix mssql table collection
* [x] fix trino table collection
* [x] separate out risingwave `get_schema` because it doesn't have postgres-specific function
* [x] confirm that exasol can't create tables in other databases