### PR TITLE
feat(pyspark): add support for pyarrow and python UDFs

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from ibis.expr.api import Watermark
 
 PYSPARK_LT_34 = vparse(pyspark.__version__) < vparse("3.4")
-
+PYSPARK_LT_35 = vparse(pyspark.__version__) < vparse("3.5")
 ConnectionMode = Literal["streaming", "batch"]
 
 
@@ -368,6 +368,11 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
                 udf_func = udf.__func__
                 spark_udf = F.udf(udf_func, udf_return)
             elif udf.__input_type__ == InputType.PYARROW:
+                # raise not implemented error if running on pyspark < 3.4
+                if PYSPARK_LT_35:
+                    raise NotImplementedError(
+                        "pyarrow UDFs are only supported in pyspark >= 3.5"
+                    )
                 udf_func = udf.__func__
                 spark_udf = F.udf(udf_func, udf_return, useArrow=True)
             else:

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -368,7 +368,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
                 udf_func = udf.__func__
                 spark_udf = F.udf(udf_func, udf_return)
             elif udf.__input_type__ == InputType.PYARROW:
-                # raise not implemented error if running on pyspark < 3.4
+                # raise not implemented error if running on pyspark < 3.5
                 if PYSPARK_LT_35:
                     raise NotImplementedError(
                         "pyarrow UDFs are only supported in pyspark >= 3.5"

--- a/ibis/backends/pyspark/tests/test_udf.py
+++ b/ibis/backends/pyspark/tests/test_udf.py
@@ -45,14 +45,14 @@ def test_python_udf(t, df):
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.skipif(PYSPARK_LT_35, reason="pyarrow UDFs require PySpark 3.5+")
+@pytest.mark.xfail(PYSPARK_LT_35, reason="pyarrow UDFs require PySpark 3.5+")
 def test_pyarrow_udf(t, df):
     result = t.mutate(repeated=pyarrow_repeat(t.str_col, 2)).execute()
     expected = df.assign(repeated=df.str_col * 2)
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.skipif(not PYSPARK_LT_35, reason="pyarrow UDFs require PySpark 3.5+")
+@pytest.mark.xfail(not PYSPARK_LT_35, reason="pyarrow UDFs require PySpark 3.5+")
 def test_illegal_udf_type(t):
     @ibis.udf.scalar.pyarrow
     def my_add_one(x) -> str:

--- a/ibis/backends/pyspark/tests/test_udf.py
+++ b/ibis/backends/pyspark/tests/test_udf.py
@@ -4,6 +4,7 @@ import pandas.testing as tm
 import pytest
 
 import ibis
+from ibis.backends.pyspark import PYSPARK_LT_35
 
 pytest.importorskip("pyspark")
 
@@ -44,7 +45,25 @@ def test_python_udf(t, df):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.skipif(PYSPARK_LT_35, reason="pyarrow UDFs require PySpark 3.5+")
 def test_pyarrow_udf(t, df):
     result = t.mutate(repeated=pyarrow_repeat(t.str_col, 2)).execute()
     expected = df.assign(repeated=df.str_col * 2)
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.skipif(not PYSPARK_LT_35, reason="pyarrow UDFs require PySpark 3.5+")
+def test_illegal_udf_type(t):
+    @ibis.udf.scalar.pyarrow
+    def my_add_one(x) -> str:
+        import pyarrow.compute as pac
+
+        return pac.add(pac.binary_length(x), 1)
+
+    expr = t.select(repeated=my_add_one(t.str_col))
+
+    with pytest.raises(
+        NotImplementedError,
+        match="pyarrow UDFs are only supported in pyspark >= 3.5",
+    ):
+        expr.execute()

--- a/ibis/backends/pyspark/tests/test_udf.py
+++ b/ibis/backends/pyspark/tests/test_udf.py
@@ -4,8 +4,6 @@ import pandas.testing as tm
 import pytest
 
 import ibis
-from ibis.expr.tests.snapshots.test_sql.test_parse_sql_aggregation_with_multiple_joins.decompiled import \
-    result
 
 pytest.importorskip("pyspark")
 
@@ -23,27 +21,30 @@ def df(con):
 @ibis.udf.scalar.builtin
 def repeat(x, n) -> str: ...
 
+
 @ibis.udf.scalar.python
 def py_repeat(x: str, n: int) -> str:
     return x * n
 
+
 @ibis.udf.scalar.pyarrow
 def pyarrow_repeat(x: str, n: int) -> str:
     return x * n
+
 
 def test_builtin_udf(t, df):
     result = t.mutate(repeated=repeat(t.str_col, 2)).execute()
     expected = df.assign(repeated=df.str_col * 2)
     tm.assert_frame_equal(result, expected)
 
+
 def test_python_udf(t, df):
     result = t.mutate(repeated=py_repeat(t.str_col, 2)).execute()
     expected = df.assign(repeated=df.str_col * 2)
     tm.assert_frame_equal(result, expected)
 
+
 def test_pyarrow_udf(t, df):
     result = t.mutate(repeated=pyarrow_repeat(t.str_col, 2)).execute()
     expected = df.assign(repeated=df.str_col * 2)
     tm.assert_frame_equal(result, expected)
-
-

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -6,6 +6,7 @@ from pytest import mark, param
 
 import ibis.common.exceptions as com
 from ibis import _, udf
+from ibis.backends.pyspark import PYSPARK_LT_35
 from ibis.backends.tests.errors import Py4JJavaError
 
 no_python_udfs = mark.notimpl(
@@ -29,6 +30,13 @@ cloudpickle_version_mismatch = mark.notimpl(
     condition=sys.version_info >= (3, 11),
     raises=Py4JJavaError,
     reason="Docker image has Python 3.10, results in `cloudpickle` version mismatch",
+)
+
+pyspark_version_mismatch = mark.notimpl(
+    ["pyspark"],
+    condition=PYSPARK_LT_35,
+    raises=NotImplementedError,
+    reason="pyarrow UDFs require PySpark 3.5+",
 )
 
 
@@ -174,7 +182,8 @@ def add_one_pyarrow(s: int) -> int:  # s is series, int is the element type
                     ["snowflake", "sqlite", "flink"],
                     raises=NotImplementedError,
                     reason="backend doesn't support pyarrow UDFs",
-                )
+                ),
+                pyspark_version_mismatch,
             ],
         ),
     ],

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -34,7 +34,6 @@ cloudpickle_version_mismatch = mark.notimpl(
 
 @no_python_udfs
 @cloudpickle_version_mismatch
-@mark.notimpl(["pyspark"])
 @mark.notyet(["datafusion"], raises=NotImplementedError)
 def test_udf(batting):
     @udf.scalar.python
@@ -59,7 +58,6 @@ def test_udf(batting):
 
 @no_python_udfs
 @cloudpickle_version_mismatch
-@mark.notimpl(["pyspark"])
 @mark.notyet(
     ["postgres"], raises=TypeError, reason="postgres only supports map<string, string>"
 )
@@ -89,7 +87,6 @@ def test_map_udf(batting):
 
 @no_python_udfs
 @cloudpickle_version_mismatch
-@mark.notimpl(["pyspark"])
 @mark.notyet(
     ["postgres"], raises=TypeError, reason="postgres only supports map<string, string>"
 )
@@ -174,7 +171,7 @@ def add_one_pyarrow(s: int) -> int:  # s is series, int is the element type
             add_one_pyarrow,
             marks=[
                 mark.notyet(
-                    ["snowflake", "sqlite", "pyspark", "flink"],
+                    ["snowflake", "sqlite", "flink"],
                     raises=NotImplementedError,
                     reason="backend doesn't support pyarrow UDFs",
                 )

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -6,7 +6,11 @@ from pytest import mark, param
 
 import ibis.common.exceptions as com
 from ibis import _, udf
-from ibis.backends.pyspark import PYSPARK_LT_35
+try:
+    from ibis.backends.pyspark import PYSPARK_LT_35
+except ImportError:
+    # Workaround when pyspark is not installed
+    PYSPARK_LT_35 = True
 from ibis.backends.tests.errors import Py4JJavaError
 
 no_python_udfs = mark.notimpl(

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -6,12 +6,6 @@ from pytest import mark, param
 
 import ibis.common.exceptions as com
 from ibis import _, udf
-
-try:
-    from ibis.backends.pyspark import PYSPARK_LT_35
-except ImportError:
-    # Workaround when pyspark is not installed
-    PYSPARK_LT_35 = True
 from ibis.backends.tests.errors import Py4JJavaError
 
 no_python_udfs = mark.notimpl(
@@ -35,13 +29,6 @@ cloudpickle_version_mismatch = mark.notimpl(
     condition=sys.version_info >= (3, 11),
     raises=Py4JJavaError,
     reason="Docker image has Python 3.10, results in `cloudpickle` version mismatch",
-)
-
-pyspark_version_mismatch = mark.notimpl(
-    ["pyspark"],
-    condition=PYSPARK_LT_35,
-    raises=NotImplementedError,
-    reason="pyarrow UDFs require PySpark 3.5+",
 )
 
 
@@ -188,7 +175,7 @@ def add_one_pyarrow(s: int) -> int:  # s is series, int is the element type
                     raises=NotImplementedError,
                     reason="backend doesn't support pyarrow UDFs",
                 ),
-                pyspark_version_mismatch,
+                mark.xfail_version(pyspark=["pyspark<3.5"]),
             ],
         ),
     ],

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -6,6 +6,7 @@ from pytest import mark, param
 
 import ibis.common.exceptions as com
 from ibis import _, udf
+
 try:
     from ibis.backends.pyspark import PYSPARK_LT_35
 except ImportError:


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

This PR modifies the pyspark Backend so that it can support UDFs implemented in pure python or pyarrow by making use of the `pyspark.sql.udf` wrapper.

To successfully run the unit tests for a pyarrow UDF, I needed to ensure that the spark worker executed the correct python interpreter by setting
```bash
export PYSPARK_PYTHON=$(which python)
```
within my nix shell. This might require some further configuration of the nix environment in order to pass during the CI tests.


## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->

* Resolves #9074 