### PR TITLE
fix(compiler-internals): define unsupported operations after simple operations

### DIFF
--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -434,14 +434,17 @@ class SQLGlotCompiler(abc.ABC):
 
             return impl
 
+        for op, target_name in cls.SIMPLE_OPS.items():
+            setattr(cls, methodname(op), make_impl(op, target_name))
+
         # unconditionally raise an exception for unsupported operations
+        #
+        # these *must* be defined after SIMPLE_OPS to handle compilers that
+        # subclass other compilers
         for op in cls.UNSUPPORTED_OPS:
             # change to visit_Unsupported in a follow up
             # TODO: handle geoespatial ops as a separate case?
             setattr(cls, methodname(op), cls.visit_Undefined)
-
-        for op, target_name in cls.SIMPLE_OPS.items():
-            setattr(cls, methodname(op), make_impl(op, target_name))
 
         # raise on any remaining unsupported operations
         for op in ALL_OPERATIONS:

--- a/ibis/backends/sql/compilers/risingwave.py
+++ b/ibis/backends/sql/compilers/risingwave.py
@@ -32,11 +32,6 @@ class RisingWaveCompiler(PostgresCompiler):
         ),
     )
 
-    SIMPLE_OPS = {
-        ops.First: "first_value",
-        ops.Last: "last_value",
-    }
-
     def visit_DateNow(self, op):
         return self.cast(sge.CurrentTimestamp(), dt.date)
 
@@ -48,6 +43,12 @@ class RisingWaveCompiler(PostgresCompiler):
         return super().visit_Correlation(
             op, left=left, right=right, how=how, where=where
         )
+
+    def visit_First(self, op, *, arg, where):
+        return self.agg.first_value(arg, where=where)
+
+    def visit_Last(self, op, *, arg, where):
+        return self.agg.last_value(arg, where=where)
 
     def visit_TimestampTruncate(self, op, *, arg, unit):
         unit_mapping = {


### PR DESCRIPTION
This avoids the case of a base class `SIMPLE_OPS` dict overriding the `UNSUPPORTED_OPS` list.