### PR TITLE
chore(dev-tools): define `PYSPARK_PYTHON` outside of shellHook since it is already known at build time

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,6 @@
 
         # necessary for quarto and quartodoc
         export PYTHONPATH=''${PWD}''${PYTHONPATH:+:}''${PYTHONPATH}:''${PWD}/docs
-        export PYSPARK_PYTHON="$(which python)"
       '';
 
       preCommitDeps = with pkgs; [
@@ -110,6 +109,7 @@
 
         inherit shellHook;
 
+        PYSPARK_PYTHON = "${env}/bin/python";
         PGPASSWORD = "postgres";
         MYSQL_PWD = "ibis";
         MSSQL_SA_PASSWORD = "1bis_Testing!";


### PR DESCRIPTION
Slight improvement on the previous shellHook approach, which isn't necessary because we know the interpreter path at build time.