### PR TITLE
fix(snowflake): bring back `where` filter support in `group_concat`; fix `array_agg` ordering

### DIFF
--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -361,7 +361,7 @@ class SnowflakeCompiler(SQLGlotCompiler):
         timestamp_units_to_scale = {"s": 0, "ms": 3, "us": 6, "ns": 9}
         return self.f.to_timestamp(arg, timestamp_units_to_scale[unit.short])
 
-    def visit_ArrayCollect(self, op, *, arg, where, order_by):
+    def _array_collect(self, *, arg, where, order_by):
         if where is not None:
             arg = self.if_(where, arg, NULL)
 
@@ -372,26 +372,15 @@ class SnowflakeCompiler(SQLGlotCompiler):
 
         return out
 
+    def visit_ArrayCollect(self, op, *, arg, where, order_by):
+        return self._array_collect(arg=arg, where=where, order_by=order_by)
+
     def visit_First(self, op, *, arg, where, order_by):
-        if where is not None:
-            arg = self.if_(where, arg, NULL)
-
-        out = self.f.array_agg(arg)
-
-        if order_by:
-            out = sge.WithinGroup(this=out, expression=sge.Order(expressions=order_by))
-
+        out = self._array_collect(arg=arg, where=where, order_by=order_by)
         return self.f.get(out, 0)
 
     def visit_Last(self, op, *, arg, where, order_by):
-        if where is not None:
-            arg = self.if_(where, arg, NULL)
-
-        out = self.f.array_agg(arg)
-
-        if order_by:
-            out = sge.WithinGroup(this=out, expression=sge.Order(expressions=order_by))
-
+        out = self._array_collect(arg=arg, where=where, order_by=order_by)
         return self.f.get(out, self.f.array_size(out) - 1)
 
     def visit_GroupConcat(self, op, *, arg, where, sep, order_by):

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -377,7 +377,10 @@ class SnowflakeCompiler(SQLGlotCompiler):
         if order_by:
             out = sge.WithinGroup(this=out, expression=sge.Order(expressions=order_by))
 
-        return out
+        if where is None:
+            return out
+
+        return self.if_(self.f.count_if(where) > 0, out, NULL)
 
     def visit_TimestampBucket(self, op, *, arg, interval, offset):
         if offset is not None:


### PR DESCRIPTION
Fixes two bugs introduced in #9729.

- `where` handling was accidentally removed. This PR brings it back.
- `array_agg` must be ordered using `WITHIN GROUP`, it doesn't accept a trailing `ORDER BY` in the call.