### PR TITLE
fix(postgres): handle enums by delegating to the parent class

### DIFF
--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -193,12 +193,11 @@ class SqlglotType(TypeMapper):
 
         try:
             sgtype = sg.parse_one(text, into=sge.DataType, read=cls.dialect)
-            return cls.to_ibis(sgtype, nullable=nullable)
         except sg.errors.ParseError:
             # If sqlglot can't parse the type fall back to `dt.unknown`
-            pass
-
-        return dt.unknown
+            return dt.unknown
+        else:
+            return cls.to_ibis(sgtype, nullable=nullable)
 
     @classmethod
     def to_string(cls, dtype: dt.DataType) -> str:

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -467,11 +467,8 @@ class PostgresType(SqlglotType):
     def from_string(cls, text: str, nullable: bool | None = None) -> dt.DataType:
         if text.lower().startswith("vector"):
             text = "vector"
-        if dtype := cls.unknown_type_strings.get(text.lower()):
-            return dtype
 
-        sgtype = sg.parse_one(text, into=sge.DataType, read=cls.dialect)
-        return cls.to_ibis(sgtype, nullable=nullable)
+        return super().from_string(text, nullable=nullable)
 
 
 class RisingWaveType(PostgresType):


### PR DESCRIPTION
Handle postgres enum types as unknown. Closes #9295.