### PR TITLE
ci: add job to set the milestone of linked issues to match the milestone of the PR [skip ci]

### DIFF
--- a/.github/workflows/set-milestone-on-issue.yml
+++ b/.github/workflows/set-milestone-on-issue.yml
@@ -1,0 +1,24 @@
+name: Set milestone on issues closed by PR
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  set-milestone:
+    if: github.repository == 'ibis-project/ibis'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: set milestone
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./ci/set-milestone-on-issue.sh "${GITHUB_SHA}"

--- a/ci/linked-issues.gql
+++ b/ci/linked-issues.gql
@@ -1,0 +1,11 @@
+query ($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      closingIssuesReferences(first: 100) {
+        nodes {
+          number
+        }
+      }
+    }
+  }
+}

--- a/ci/set-milestone-on-issue.sh
+++ b/ci/set-milestone-on-issue.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+top="$(dirname "$(readlink -f "$0")")"
+
+# find all pull requests associated with commit
+linked_issues_query='.data.repository.pullRequest.closingIssuesReferences.nodes[].number'
+
+gh pr list --search "$1" --state merged --json number --jq '.[].number' |
+  sed '/^$/d' |
+  while read -r pr; do
+    milestone="$(gh pr view "${pr}" --json milestone --jq '.milestone.title')"
+
+    if [ -n "${milestone}" ]; then
+      # find all issues associated with said pull requests
+      # taken from https://github.com/cli/cli/discussions/7097#discussioncomment-5229031
+      readarray -t issues < <(
+        gh api graphql -F owner=ibis-project -F repo=ibis -F pr="${pr}" -F query="@${top}/linked-issues.gql" \
+        --jq "${linked_issues_query}" | sed '/^$/d')
+
+      if [ "${#issues[@]}" -gt 0 ]; then
+        gh issue edit "${issues[@]}" --milestone "${milestone}"
+      fi
+    fi
+  done


### PR DESCRIPTION
Add an action to automatically set the milestone on linked issues after they are resolved by a PR.