### PR TITLE
docs: fix spelling in pivot_longer explanation

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -3759,7 +3759,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ ABW     │ SP.URB.TOTL │ 2004   │ 42317.0 │
         └─────────┴─────────────┴────────┴─────────┘
 
-        `pivot_longer` has some preprocessing capabiltiies like stripping a prefix and applying
+        `pivot_longer` has some preprocessing capabilities like stripping a prefix and applying
         a function to column names
 
         >>> billboard = ibis.examples.billboard.fetch()


### PR DESCRIPTION
Fixing typo in `pivot_longer` explanation. 

I have also submitted an upstream PR to catch this in the future, although it's unlikely we'll re-encounter it. 

https://github.com/codespell-project/codespell/pull/3507
