### PR TITLE
feat(output-formats): add support for to_parquet_dir

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -477,7 +477,7 @@ class _FileIOHandler:
     def to_parquet_dir(
         self,
         expr: ir.Table,
-        path: str | Path,
+        directory: str | Path,
         *,
         params: Mapping[ir.Scalar, Any] | None = None,
         **kwargs: Any,

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -504,12 +504,10 @@ class _FileIOHandler:
         self._import_pyarrow()
         import pyarrow.dataset as ds
 
-        dir_path = Path(path)
-
         # by default write_dataset creates the directory
         with expr.to_pyarrow_batches(params=params) as batch_reader:
             ds.write_dataset(
-                batch_reader, base_dir=dir_path, format="parquet", **kwargs
+                batch_reader, base_dir=directory, format="parquet", **kwargs
             )
 
     @util.experimental

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -507,11 +507,9 @@ class _FileIOHandler:
         dir_path = Path(path)
         dir_path.mkdir(parents=True, exist_ok=True)
 
+        import pyarrow.dataset as ds
         with expr.to_pyarrow_batches(params=params) as batch_reader:
-            for i, batch in enumerate(batch_reader):
-                file_path = f"{dir_path}/out_{i}.parquet"
-                with pq.ParquetWriter(file_path, batch.schema, **kwargs) as writer:
-                    writer.write_batch(batch)
+            ds.write_dataset(batch_reader, base_dir=dir_path, format="parquet", **kwargs)
 
     @util.experimental
     def to_csv(

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -491,7 +491,7 @@ class _FileIOHandler:
         ----------
         expr
             The ibis expression to execute and persist to parquet.
-        path
+        directory
             The data source. A string or Path to the directory where the parquet file will be written.
         params
             Mapping of scalar parameter expressions to value.

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -496,20 +496,21 @@ class _FileIOHandler:
         params
             Mapping of scalar parameter expressions to value.
         **kwargs
-            Additional keyword arguments passed to pyarrow.parquet.ParquetWriter
+            Additional keyword arguments passed to pyarrow.dataset.write_dataset
 
-        https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html
+        https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html
 
         """
         self._import_pyarrow()
-        import pyarrow.parquet as pq
+        import pyarrow.dataset as ds
 
         dir_path = Path(path)
-        dir_path.mkdir(parents=True, exist_ok=True)
 
-        import pyarrow.dataset as ds
+        # by default write_dataset creates the directory
         with expr.to_pyarrow_batches(params=params) as batch_reader:
-            ds.write_dataset(batch_reader, base_dir=dir_path, format="parquet", **kwargs)
+            ds.write_dataset(
+                batch_reader, base_dir=dir_path, format="parquet", **kwargs
+            )
 
     @util.experimental
     def to_csv(

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1283,10 +1283,12 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     ) -> StreamingQuery | None:
         df = self._session.sql(self.compile(expr, params=params, limit=limit))
         if self.mode == "batch":
-            df = df.write.format(format)
+            df = df.write.format(format).mode(
+                "overwrite"
+            )  # df = df.write.format(format)
             for k, v in (options or {}).items():
                 df = df.option(k, v)
-            df.save(path)
+            df.save(os.fspath(path))  # df.save(path)
             return None
         sq = df.writeStream.format(format)
         sq = sq.option("path", os.fspath(path))

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1283,12 +1283,10 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     ) -> StreamingQuery | None:
         df = self._session.sql(self.compile(expr, params=params, limit=limit))
         if self.mode == "batch":
-            df = df.write.format(format).mode(
-                "overwrite"
-            )  # df = df.write.format(format)
+            df = df.write.format(format)
             for k, v in (options or {}).items():
                 df = df.option(k, v)
-            df.save(os.fspath(path))  # df.save(path)
+            df.save(os.fspath(path))
             return None
         sq = df.writeStream.format(format)
         sq = sq.option("path", os.fspath(path))

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -217,7 +217,10 @@ def test_table_to_parquet(tmp_path, backend, awards_players):
 
 def test_table_to_parquet_dir(tmp_path, backend, awards_players):
     outparquet_dir = tmp_path / "out"
-    awards_players.to_parquet_dir(outparquet_dir)
+    # max_ force to write more than one parquet file
+    awards_players.to_parquet_dir(
+        outparquet_dir, max_rows_per_file=3000, max_rows_per_group=3000
+    )
 
     parquet_files = list(outparquet_dir.glob("*.parquet"))
     df_list = [pd.read_parquet(file) for file in parquet_files]

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -215,7 +215,6 @@ def test_table_to_parquet(tmp_path, backend, awards_players):
     )
 
 
-###new-test###
 def test_table_to_parquet_dir(tmp_path, backend, awards_players):
     outparquet_dir = tmp_path
     awards_players.to_parquet_dir(outparquet_dir)
@@ -228,9 +227,6 @@ def test_table_to_parquet_dir(tmp_path, backend, awards_players):
     backend.assert_frame_equal(
         awards_players.to_pandas().fillna(pd.NA), df.fillna(pd.NA)
     )
-
-
-###new test
 
 
 @pytest.mark.notimpl(

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -227,15 +227,16 @@ def test_table_to_parquet_dir(tmp_path, backend, awards_players):
             outparquet_dir, max_rows_per_file=3000, max_rows_per_group=3000
         )
 
-    parquet_files = sorted(outparquet_dir.glob("*.parquet"), key=lambda path: int(path.with_suffix("").name.split("-")[1])
+    parquet_files = sorted(
+        outparquet_dir.glob("*.parquet"),
+        key=lambda path: int(path.with_suffix("").name.split("-")[1]),
+    )
+
     df_list = [pd.read_parquet(file) for file in parquet_files]
     df = pd.concat(df_list).reset_index(drop=True)
 
-    awd_df = awards_players.to_pandas().fillna(pd.NA)
-    columns = list(set(awd_df.columns) & set(df.columns))
-
     backend.assert_frame_equal(
-        awd_df.sort_values(by=columns), df.fillna(pd.NA).sort_values(by=columns)
+        awards_players.to_pandas().fillna(pd.NA), df.fillna(pd.NA)
     )
 
 

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -227,7 +227,7 @@ def test_table_to_parquet_dir(tmp_path, backend, awards_players):
             outparquet_dir, max_rows_per_file=3000, max_rows_per_group=3000
         )
 
-    parquet_files = list(outparquet_dir.glob("*.parquet"))
+    parquet_files = sorted(outparquet_dir.glob("*.parquet"), key=lambda path: int(path.with_suffix("").name.split("-")[1])
     df_list = [pd.read_parquet(file) for file in parquet_files]
     df = pd.concat(df_list).reset_index(drop=True)
 

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -216,10 +216,9 @@ def test_table_to_parquet(tmp_path, backend, awards_players):
 
 
 def test_table_to_parquet_dir(tmp_path, backend, awards_players):
-    outparquet_dir = tmp_path
+    outparquet_dir = tmp_path / "out"
     awards_players.to_parquet_dir(outparquet_dir)
 
-    # the batch is so small we write only one, wonder if we should modify test
     parquet_files = list(outparquet_dir.glob("*.parquet"))
     df_list = [pd.read_parquet(file) for file in parquet_files]
     df = pd.concat(df_list).reset_index(drop=True)

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -216,18 +216,14 @@ def test_table_to_parquet(tmp_path, backend, awards_players):
 
 
 ###new-test###
-@pytest.mark.parametrize("write_batches", [True, False])
-def test_table_to_parquet_dir(tmp_path, backend, awards_players, write_batches):
+def test_table_to_parquet_dir(tmp_path, backend, awards_players):
     outparquet_dir = tmp_path
-    awards_players.to_parquet_dir(outparquet_dir, "out", write_batches=write_batches)
+    awards_players.to_parquet_dir(outparquet_dir)
 
-    if write_batches:
-        # the batch is so small we write only one, wonder if we should modify test
-        parquet_files = list(outparquet_dir.glob("*.parquet"))
-        df_list = [pd.read_parquet(file) for file in parquet_files]
-        df = pd.concat(df_list).reset_index(drop=True)
-    else:
-        df = pd.read_parquet(f"{outparquet_dir}/out.parquet")
+    # the batch is so small we write only one, wonder if we should modify test
+    parquet_files = list(outparquet_dir.glob("*.parquet"))
+    df_list = [pd.read_parquet(file) for file in parquet_files]
+    df = pd.concat(df_list).reset_index(drop=True)
 
     backend.assert_frame_equal(
         awards_players.to_pandas().fillna(pd.NA), df.fillna(pd.NA)

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -215,6 +215,28 @@ def test_table_to_parquet(tmp_path, backend, awards_players):
     )
 
 
+###new-test###
+@pytest.mark.parametrize("write_batches", [True, False])
+def test_table_to_parquet_dir(tmp_path, backend, awards_players, write_batches):
+    outparquet_dir = tmp_path
+    awards_players.to_parquet_dir(outparquet_dir, "out", write_batches=write_batches)
+
+    if write_batches:
+        # the batch is so small we write only one, wonder if we should modify test
+        parquet_files = list(outparquet_dir.glob("*.parquet"))
+        df_list = [pd.read_parquet(file) for file in parquet_files]
+        df = pd.concat(df_list).reset_index(drop=True)
+    else:
+        df = pd.read_parquet(f"{outparquet_dir}/out.parquet")
+
+    backend.assert_frame_equal(
+        awards_players.to_pandas().fillna(pd.NA), df.fillna(pd.NA)
+    )
+
+
+###new test
+
+
 @pytest.mark.notimpl(
     ["duckdb"],
     reason="cannot inline WriteOptions objects",

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -605,6 +605,41 @@ class Expr(Immutable, Coercible):
         self._find_backend(use_default=True).to_parquet(self, path, **kwargs)
 
     @experimental
+    def to_parquet_dir(
+        self,
+        path: str | Path,
+        filename_prefix: str = "out",
+        write_batches: bool = False,
+        *,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Write the results of executing the given expression to a parquet file in a directory.
+
+        This method is eager and will execute the associated expression
+        immediately.
+
+        Parameters
+        ----------
+        path
+            The data source. A string or Path to the directory where the parquet file will be written.
+        filename_prefix
+            The prefix name of the parquet file. What is before `.parquet`.
+        write_batches
+            If True writes each batch into a different file.
+        params
+            Mapping of scalar parameter expressions to value.
+        **kwargs
+            Additional keyword arguments passed to pyarrow.parquet.ParquetWriter
+
+        https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html
+
+        """
+        self._find_backend(use_default=True).to_parquet_dir(
+            self, path, filename_prefix, write_batches, **kwargs
+        )
+
+    @experimental
     def to_csv(
         self,
         path: str | Path,

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -620,7 +620,7 @@ class Expr(Immutable, Coercible):
         Parameters
         ----------
         directory
-            The data source. A string or Path to the directory where the parquet file will be written.
+            The data target. A string or Path to the directory where the parquet file will be written.
         params
             Mapping of scalar parameter expressions to value.
         **kwargs

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -608,8 +608,6 @@ class Expr(Immutable, Coercible):
     def to_parquet_dir(
         self,
         path: str | Path,
-        filename_prefix: str = "out",
-        write_batches: bool = False,
         *,
         params: Mapping[ir.Scalar, Any] | None = None,
         **kwargs: Any,
@@ -635,9 +633,7 @@ class Expr(Immutable, Coercible):
         https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html
 
         """
-        self._find_backend(use_default=True).to_parquet_dir(
-            self, path, filename_prefix, write_batches, **kwargs
-        )
+        self._find_backend(use_default=True).to_parquet_dir(self, path, **kwargs)
 
     @experimental
     def to_csv(

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -624,9 +624,9 @@ class Expr(Immutable, Coercible):
         params
             Mapping of scalar parameter expressions to value.
         **kwargs
-            Additional keyword arguments passed to pyarrow.parquet.ParquetWriter
-
-        https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html
+            Additional keyword arguments passed to pyarrow.dataset.write_dataset
+            
+        https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html
 
         """
         self._find_backend(use_default=True).to_parquet_dir(self, directory, **kwargs)

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -625,7 +625,7 @@ class Expr(Immutable, Coercible):
             Mapping of scalar parameter expressions to value.
         **kwargs
             Additional keyword arguments passed to pyarrow.dataset.write_dataset
-            
+
         https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html
 
         """

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -607,7 +607,7 @@ class Expr(Immutable, Coercible):
     @experimental
     def to_parquet_dir(
         self,
-        path: str | Path,
+        directory: str | Path,
         *,
         params: Mapping[ir.Scalar, Any] | None = None,
         **kwargs: Any,
@@ -619,12 +619,8 @@ class Expr(Immutable, Coercible):
 
         Parameters
         ----------
-        path
+        directory
             The data source. A string or Path to the directory where the parquet file will be written.
-        filename_prefix
-            The prefix name of the parquet file. What is before `.parquet`.
-        write_batches
-            If True writes each batch into a different file.
         params
             Mapping of scalar parameter expressions to value.
         **kwargs
@@ -633,7 +629,7 @@ class Expr(Immutable, Coercible):
         https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetWriter.html
 
         """
-        self._find_backend(use_default=True).to_parquet_dir(self, path, **kwargs)
+        self._find_backend(use_default=True).to_parquet_dir(self, directory, **kwargs)
 
     @experimental
     def to_csv(


### PR DESCRIPTION
Initial implementation to add support to write parquet files to a directory as a single file or writing each batch to a different file. 

Partially resolves https://github.com/ibis-project/ibis/issues/8584#issue-2174862538 (it doesn't cover writing csv to dirs)

TODOs: 

- [x] Implement DuckDB case (EDIT) -> looks like duckdb only supports multiple files writing when `partitioned_by` which is already supported via `to_parquet`, unless I'm missing something. 
- [x] remove? `limit= ` from pyspark, not sure why is there. Looks like this was a request for `to_delta` (see https://github.com/ibis-project/ibis/issues/8898), and it was replicated for` to_parquet_dir`
- [ ] Understand why in `ibis/expr/types/core.py`  the method `to_parquet` in the `class Expr` doesn't pass through the `params`?