### PR TITLE
feat(snowflake): add `userinfo` URL parsing

### DIFF
--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -559,6 +559,12 @@ $$""",
             self.f.as_varchar(self.f.get(self.f.parse_url(arg, 1), "fragment")), ""
         )
 
+    def visit_ExtractUserInfo(self, op, *, arg):
+        host = self.f.get(self.f.parse_url(arg), "host")
+        return self.if_(
+            host.like(sge.convert("%@%")), self.f.split_part(host, "@", 1), NULL
+        )
+
     def visit_Unnest(self, op, *, arg):
         sep = sge.convert(util.guid())
         split = self.f.split(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -729,7 +729,7 @@ def test_substr_with_null_values(backend, alltypes, df):
             "user:pass",
             marks=[
                 pytest.mark.notyet(
-                    ["bigquery", "clickhouse", "snowflake", "trino"],
+                    ["bigquery", "clickhouse", "trino"],
                     raises=com.OperationNotDefinedError,
                     reason="doesn't support `USERINFO`",
                 )


### PR DESCRIPTION
Add `userinfo` URL parsing to Snowflake. Thanks to @krzysztof-kwitt for the suggestion!