### PR TITLE
docs: add aggregate-udfs api page to index

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -168,6 +168,7 @@ website:
         - section: UDFs
           contents:
             - reference/scalar-udfs.qmd
+            - reference/aggregate-udfs.qmd
 
         - section: Connection APIs
           contents:


### PR DESCRIPTION
This page existed but wasn't indexed.