### PR TITLE
fix(pyspark): fix a bug in spark's to_parquet_dir method

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -1286,7 +1286,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
             df = df.write.format(format)
             for k, v in (options or {}).items():
                 df = df.option(k, v)
-            df.save(path)
+            df.save(os.fspath(path))
             return None
         sq = df.writeStream.format(format)
         sq = sq.option("path", os.fspath(path))


### PR DESCRIPTION
## Description of changes

Fix a bug in spark's to_parquet_dir method. Spark's write method only accepts strings as paths, and the current implementation will throw something like
```python
AttributeError: 'PosixPath' object has no attribute '_get_object_id'
```

I was already doing this in streaming mode, just forgot to do this in batch mode.

xref: #9781 