### PR TITLE
fix(pickle): make `Parameter` instances pickleable

### DIFF
--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -6,6 +6,8 @@ import types
 from typing import TYPE_CHECKING
 from typing import Any as AnyType
 
+from typing_extensions import Self
+
 from ibis.common.bases import Immutable, Slotted
 from ibis.common.patterns import (
     Any,
@@ -258,18 +260,6 @@ class Parameter(inspect.Parameter):
 
     __slots__ = ()
 
-    def __init__(self, name, annotation):
-        if not isinstance(annotation, Argument):
-            raise TypeError(
-                f"annotation must be an instance of Argument, got {annotation}"
-            )
-        super().__init__(
-            name,
-            kind=annotation.kind,
-            default=annotation.default,
-            annotation=annotation,
-        )
-
     def __str__(self):
         formatted = self._name
 
@@ -289,6 +279,20 @@ class Parameter(inspect.Parameter):
             formatted = "**" + formatted
 
         return formatted
+
+    @classmethod
+    def from_argument(cls, name: str, annotation: Argument) -> Self:
+        """Construct a Parameter from an Argument annotation."""
+        if not isinstance(annotation, Argument):
+            raise TypeError(
+                f"annotation must be an instance of Argument, got {annotation}"
+            )
+        return cls(
+            name,
+            kind=annotation.kind,
+            default=annotation.default,
+            annotation=annotation,
+        )
 
 
 class Signature(inspect.Signature):
@@ -324,7 +328,7 @@ class Signature(inspect.Signature):
 
         inherited = set(params.keys())
         for name, annot in annotations.items():
-            params[name] = Parameter(name, annotation=annot)
+            params[name] = Parameter.from_argument(name, annotation=annot)
 
         # mandatory fields without default values must precede the optional
         # ones in the function signature, the partial ordering will be kept
@@ -406,7 +410,7 @@ class Signature(inspect.Signature):
             else:
                 annot = Argument(pattern, kind=kind, default=default, typehint=typehint)
 
-            parameters.append(Parameter(param.name, annot))
+            parameters.append(Parameter.from_argument(param.name, annot))
 
         if return_pattern is not None:
             return_annotation = return_pattern

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -449,33 +449,41 @@ def test_signature_inheritance():
 
     assert IntBinop.__signature__ == Signature(
         [
-            Parameter("left", annotation=Argument(is_int)),
-            Parameter("right", annotation=Argument(is_int)),
+            Parameter.from_argument("left", annotation=Argument(is_int)),
+            Parameter.from_argument("right", annotation=Argument(is_int)),
         ]
     )
 
     assert FloatAddRhs.__signature__ == Signature(
         [
-            Parameter("left", annotation=Argument(is_int)),
-            Parameter("right", annotation=Argument(is_float)),
+            Parameter.from_argument("left", annotation=Argument(is_int)),
+            Parameter.from_argument("right", annotation=Argument(is_float)),
         ]
     )
 
     assert FloatAddClip.__signature__ == Signature(
         [
-            Parameter("left", annotation=Argument(is_float)),
-            Parameter("right", annotation=Argument(is_float)),
-            Parameter("clip_lower", annotation=optional(is_int, default=0)),
-            Parameter("clip_upper", annotation=optional(is_int, default=10)),
+            Parameter.from_argument("left", annotation=Argument(is_float)),
+            Parameter.from_argument("right", annotation=Argument(is_float)),
+            Parameter.from_argument(
+                "clip_lower", annotation=optional(is_int, default=0)
+            ),
+            Parameter.from_argument(
+                "clip_upper", annotation=optional(is_int, default=10)
+            ),
         ]
     )
 
     assert IntAddClip.__signature__ == Signature(
         [
-            Parameter("left", annotation=Argument(is_int)),
-            Parameter("right", annotation=Argument(is_int)),
-            Parameter("clip_lower", annotation=optional(is_int, default=0)),
-            Parameter("clip_upper", annotation=optional(is_int, default=10)),
+            Parameter.from_argument("left", annotation=Argument(is_int)),
+            Parameter.from_argument("right", annotation=Argument(is_int)),
+            Parameter.from_argument(
+                "clip_lower", annotation=optional(is_int, default=0)
+            ),
+            Parameter.from_argument(
+                "clip_upper", annotation=optional(is_int, default=10)
+            ),
         ]
     )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7789,4 +7789,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "96eeb24a6d09280de35c84f663b9fc3c1d77c06671fcb9604cf1bf81c704c0a6"
+content-hash = "62afcbaa70b8379af5f0f4e7555bd78839f225939edf5e71832fdac6e284e160"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ ruff = ">=0.1.8"
 tqdm = ">=4.66.1,<5"
 
 [tool.poetry.group.test.dependencies]
+cloudpickle = ">=3,<4"
 filelock = ">=3.7.0,<4"
 hypothesis = ">=6.58.0,<7"
 packaging = ">=21.3,<25"


### PR DESCRIPTION
The pickles expect a specific constructor for `Parameter`, so remove our custom constructor and provide a `classmethod` with the previous behavior for convenience. Closes #9793.