### PR TITLE
feat(timestamps): add support for timestamp/date +/- intervals for additional backends

### DIFF
--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -942,9 +942,7 @@ class SQLGlotCompiler(abc.ABC):
         )
 
     def visit_IntervalFromInteger(self, op, *, arg, unit):
-        return sge.Interval(
-            this=sge.convert(arg), unit=sge.Var(this=unit.singular.upper())
-        )
+        return sge.Interval(this=arg, unit=self.v[unit.singular.upper()])
 
     ### String Instruments
     def visit_Strip(self, op, *, arg):

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -120,22 +120,16 @@ class MySQLCompiler(SQLGlotCompiler):
             # for TEXT (except when casting of course!)
             return arg
         elif from_.is_integer() and to.is_interval():
-            return self.visit_IntervalFromInteger(
-                ops.IntervalFromInteger(op.arg, unit=to.unit), arg=arg, unit=to.unit
-            )
+            return sge.Interval(this=arg, unit=self.v[to.unit.singular.upper()])
         elif from_.is_integer() and to.is_timestamp():
             return self.f.from_unixtime(arg)
         return super().visit_Cast(op, arg=arg, to=to)
 
     def visit_TimestampDiff(self, op, *, left, right):
-        return self.f.timestampdiff(
-            sge.Var(this="SECOND"), right, left, dialect=self.dialect
-        )
+        return self.f.timestampdiff(self.v.SECOND, right, left, dialect=self.dialect)
 
     def visit_DateDiff(self, op, *, left, right):
-        return self.f.timestampdiff(
-            sge.Var(this="DAY"), right, left, dialect=self.dialect
-        )
+        return self.f.timestampdiff(self.v.DAY, right, left, dialect=self.dialect)
 
     def visit_ApproxCountDistinct(self, op, *, arg, where):
         if where is not None:
@@ -317,16 +311,16 @@ class MySQLCompiler(SQLGlotCompiler):
 
     def visit_DateTimeDelta(self, op, *, left, right, part):
         return self.f.timestampdiff(
-            sge.Var(this=part.this), right, left, dialect=self.dialect
+            self.v[part.this], right, left, dialect=self.dialect
         )
 
     visit_TimeDelta = visit_DateDelta = visit_DateTimeDelta
 
     def visit_ExtractMillisecond(self, op, *, arg):
-        return self.f.floor(self.f.extract(sge.Var(this="microsecond"), arg) / 1_000)
+        return self.f.floor(self.f.extract(self.v.microsecond, arg) / 1_000)
 
     def visit_ExtractMicrosecond(self, op, *, arg):
-        return self.f.floor(self.f.extract(sge.Var(this="microsecond"), arg))
+        return self.f.floor(self.f.extract(self.v.microsecond, arg))
 
     def visit_Strip(self, op, *, arg):
         return self.visit_LRStrip(op, arg=arg, position="BOTH")
@@ -337,14 +331,9 @@ class MySQLCompiler(SQLGlotCompiler):
     def visit_RStrip(self, op, *, arg):
         return self.visit_LRStrip(op, arg=arg, position="TRAILING")
 
-    def visit_IntervalFromInteger(self, op, *, arg, unit):
-        return sge.Interval(this=arg, unit=sge.Var(this=op.resolution.upper()))
-
     def visit_TimestampAdd(self, op, *, left, right):
         if op.right.dtype.unit.short == "ms":
-            right = sge.Interval(
-                this=right.this * 1_000, unit=sge.Var(this="MICROSECOND")
-            )
+            right = sge.Interval(this=right.this * 1_000, unit=self.v.MICROSECOND)
         return self.f.date_add(left, right, dialect=self.dialect)
 
     def visit_UnwrapJSONString(self, op, *, arg):

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -378,9 +378,6 @@ $$""",
     visit_DateAdd = visit_TimestampAdd
     visit_DateSub = visit_TimestampSub
 
-    def visit_IntervalFromInteger(self, op, *, arg, unit):
-        return sge.Interval(this=arg, unit=self.v[unit.name])
-
     def visit_IntegerRange(self, op, *, start, stop, step):
         return self.if_(
             step.neq(0), self.f.array_generate_range(start, stop, step), self.f.array()

--- a/ibis/backends/tests/errors.py
+++ b/ibis/backends/tests/errors.py
@@ -133,8 +133,9 @@ except ImportError:
 
 try:
     from oracledb.exceptions import DatabaseError as OracleDatabaseError
+    from oracledb.exceptions import InterfaceError as OracleInterfaceError
 except ImportError:
-    OracleDatabaseError = None
+    OracleDatabaseError = OracleInterfaceError = None
 
 try:
     from pyodbc import DataError as PyODBCDataError

--- a/ibis/backends/tests/test_param.py
+++ b/ibis/backends/tests/test_param.py
@@ -157,7 +157,7 @@ def test_scalar_param(backend, alltypes, df, value, dtype, col):
     ["2009-01-20", datetime.date(2009, 1, 20), datetime.datetime(2009, 1, 20)],
     ids=["string", "date", "datetime"],
 )
-@pytest.mark.notimpl(["druid", "oracle"])
+@pytest.mark.notimpl(["druid"])
 def test_scalar_param_date(backend, alltypes, value):
     param = ibis.param("date")
     ds_col = alltypes.date_string_col

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -708,7 +708,7 @@ timestamp_value = pd.Timestamp("2018-01-01 18:18:18")
             id="timestamp-add-interval-binop",
             marks=[
                 pytest.mark.notimpl(
-                    ["snowflake", "sqlite", "bigquery", "exasol"],
+                    ["snowflake", "sqlite", "bigquery", "exasol", "mssql"],
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notimpl(["impala"], raises=com.UnsupportedOperationError),
@@ -729,7 +729,7 @@ timestamp_value = pd.Timestamp("2018-01-01 18:18:18")
             id="timestamp-add-interval-binop-different-units",
             marks=[
                 pytest.mark.notimpl(
-                    ["sqlite", "polars", "snowflake", "bigquery", "exasol"],
+                    ["sqlite", "polars", "snowflake", "bigquery", "exasol", "mssql"],
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notimpl(["impala"], raises=com.UnsupportedOperationError),
@@ -786,7 +786,7 @@ timestamp_value = pd.Timestamp("2018-01-01 18:18:18")
             id="timestamp-subtract-timestamp",
             marks=[
                 pytest.mark.notimpl(
-                    ["bigquery", "snowflake", "sqlite", "exasol"],
+                    ["bigquery", "snowflake", "sqlite", "exasol", "mssql"],
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError),
@@ -829,7 +829,8 @@ timestamp_value = pd.Timestamp("2018-01-01 18:18:18")
                     reason="DayTimeIntervalType added in pyspark 3.3",
                 ),
                 pytest.mark.notimpl(
-                    ["bigquery", "druid", "flink"], raises=com.OperationNotDefinedError
+                    ["bigquery", "druid", "flink", "mssql"],
+                    raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(
                     ["datafusion"],
@@ -845,7 +846,6 @@ timestamp_value = pd.Timestamp("2018-01-01 18:18:18")
         ),
     ],
 )
-@pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError)
 def test_temporal_binop(backend, con, alltypes, df, expr_fn, expected_fn):
     expr = expr_fn(alltypes, backend).name("tmp")
     expected = expected_fn(df, backend)
@@ -916,7 +916,7 @@ minus = lambda t, td: t.timestamp_col - pd.Timedelta(td)
     ],
 )
 @pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError)
-@pytest.mark.notimpl(["sqlite", "mssql"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["sqlite"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_temporal_binop_pandas_timedelta(
     backend, con, alltypes, df, timedelta, temporal_fn
@@ -1016,7 +1016,7 @@ def test_timestamp_comparison_filter_numpy(backend, con, alltypes, df, func_name
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["mssql", "exasol", "druid"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["exasol", "druid"], raises=com.OperationNotDefinedError)
 def test_interval_add_cast_scalar(backend, alltypes):
     timestamp_date = alltypes.timestamp_col.date()
     delta = ibis.literal(10).cast("interval('D')")
@@ -1026,7 +1026,7 @@ def test_interval_add_cast_scalar(backend, alltypes):
     backend.assert_series_equal(result, expected.astype(result.dtype))
 
 
-@pytest.mark.notimpl(["mssql", "exasol", "druid"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["exasol", "druid"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["flink"], raises=AssertionError, reason="incorrect results")
 def test_interval_add_cast_column(backend, alltypes, df):
     timestamp_date = alltypes.timestamp_col.date()

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -643,13 +643,18 @@ def test_integer_to_interval_timestamp(
                     raises=PsycoPg2InternalError,
                     reason="Bind error: Invalid unit: week",
                 ),
+                pytest.mark.notimpl(
+                    ["flink"],
+                    raises=Py4JJavaError,
+                    reason="week is not a valid unit in Flink",
+                ),
             ],
         ),
         "D",
     ],
 )
 @pytest.mark.notimpl(
-    ["datafusion", "flink", "sqlite", "druid"], raises=com.OperationNotDefinedError
+    ["datafusion", "sqlite", "druid"], raises=com.OperationNotDefinedError
 )
 @pytest.mark.notimpl(
     ["sqlite"],

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -611,13 +611,21 @@ def test_integer_to_interval_timestamp(
     [
         param(
             "Y",
-            marks=pytest.mark.notyet(["trino"], raises=com.UnsupportedOperationError),
+            marks=[
+                pytest.mark.notyet(["trino"], raises=com.UnsupportedOperationError),
+                pytest.mark.notyet(
+                    ["polars"], raises=TypeError, reason="not supported by polars"
+                ),
+            ],
         ),
         param("Q", marks=pytest.mark.xfail),
         param(
             "M",
             marks=[
                 pytest.mark.notyet(["trino"], raises=com.UnsupportedOperationError),
+                pytest.mark.notyet(
+                    ["polars"], raises=TypeError, reason="not supported by polars"
+                ),
                 pytest.mark.notyet(
                     ["oracle"],
                     raises=OracleInterfaceError,
@@ -641,7 +649,7 @@ def test_integer_to_interval_timestamp(
     ],
 )
 @pytest.mark.notimpl(
-    ["datafusion", "flink", "impala", "sqlite", "polars", "druid"],
+    ["datafusion", "flink", "impala", "sqlite", "druid"],
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.notimpl(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -649,8 +649,7 @@ def test_integer_to_interval_timestamp(
     ],
 )
 @pytest.mark.notimpl(
-    ["datafusion", "flink", "impala", "sqlite", "druid"],
-    raises=com.OperationNotDefinedError,
+    ["datafusion", "flink", "sqlite", "druid"], raises=com.OperationNotDefinedError
 )
 @pytest.mark.notimpl(
     ["sqlite"],


### PR DESCRIPTION
Based on #9794, I decided to investigate whether we can do a bit better on date/timestamp +/- interval-style operations.

Many backends support adding and subtracting intervals from dates and timestamps, but do **not** support intervals as a first-class type, and we can allow that functionality to work.

This PR adds support for those operations to mssql and oracle and consolidates some existing implementation details around the `IntervalFromInteger` operation.