### PR TITLE
refactor(intervals): conslidate interval conversion under `_make_interval` base compiler implementation

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -481,6 +481,10 @@ jobs:
       - name: show installed deps
         run: poetry run pip list
 
+      - name: show version of python-linked sqlite
+        if: matrix.backend.name == 'sqlite'
+        run: poetry run python -c 'import sqlite3; print(sqlite3.sqlite_version)'
+
       - name: "run parallel tests: ${{ matrix.backend.name }}"
         if: ${{ !matrix.backend.serial }}
         run: just ci-check -m ${{ matrix.backend.name }} --numprocesses auto --dist=loadgroup

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -151,7 +151,7 @@ TEST_TABLES = {
 # For now, many of our tests don't do this, and we're working to change this situation
 # by improving all tests file by file. All files that have already been improved are
 # added to this list to prevent regression.
-FIlES_WITH_STRICT_EXCEPTION_CHECK = [
+FILES_WITH_STRICT_EXCEPTION_CHECK = [
     "ibis/backends/tests/test_api.py",
     "ibis/backends/tests/test_array.py",
     "ibis/backends/tests/test_aggregation.py",
@@ -337,7 +337,7 @@ def pytest_runtest_call(item):
     for marker in item.iter_markers(name="notimpl"):
         if backend in marker.args[0]:
             if (
-                item.location[0] in FIlES_WITH_STRICT_EXCEPTION_CHECK
+                item.location[0] in FILES_WITH_STRICT_EXCEPTION_CHECK
                 and "raises" not in marker.kwargs.keys()
             ):
                 raise ValueError("notimpl requires a raises")
@@ -351,7 +351,7 @@ def pytest_runtest_call(item):
     for marker in item.iter_markers(name="notyet"):
         if backend in marker.args[0]:
             if (
-                item.location[0] in FIlES_WITH_STRICT_EXCEPTION_CHECK
+                item.location[0] in FILES_WITH_STRICT_EXCEPTION_CHECK
                 and "raises" not in marker.kwargs.keys()
             ):
                 raise ValueError("notyet requires a raises")

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -584,8 +584,6 @@ class BigQueryCompiler(SQLGlotCompiler):
                     f"BigQuery does not allow extracting date part `{from_.unit}` from intervals"
                 )
             return self.f.extract(self.v[to.resolution.upper()], arg)
-        elif from_.is_integer() and to.is_interval():
-            return sge.Interval(this=arg, unit=self.v[to.unit.singular])
         elif from_.is_floating() and to.is_integer():
             return self.cast(self.f.trunc(arg), dt.int64)
         return super().visit_Cast(op, arg=arg, to=to)

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -191,9 +191,7 @@ class ImpalaCompiler(SQLGlotCompiler):
 
     def visit_Cast(self, op, *, arg, to):
         from_ = op.arg.dtype
-        if from_.is_integer() and to.is_interval():
-            return sge.Interval(this=sge.convert(arg), unit=to.unit.singular.upper())
-        elif from_.is_temporal() and to.is_integer():
+        if from_.is_temporal() and to.is_integer():
             return 1_000_000 * self.f.unix_timestamp(arg)
         return super().visit_Cast(op, arg=arg, to=to)
 

--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -400,8 +400,6 @@ class MSSQLCompiler(SQLGlotCompiler):
             return arg
         elif from_.is_integer() and to.is_timestamp():
             return self.f.dateadd(self.v.s, arg, "1970-01-01 00:00:00")
-        elif from_.is_integer() and to.is_interval():
-            return sge.Interval(this=arg, unit=self.v[to.unit.singular])
         return super().visit_Cast(op, arg=arg, to=to)
 
     def visit_Sum(self, op, *, arg, where):

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -119,8 +119,6 @@ class MySQLCompiler(SQLGlotCompiler):
             # MariaDB does not support casting to JSON because it's an alias
             # for TEXT (except when casting of course!)
             return arg
-        elif from_.is_integer() and to.is_interval():
-            return sge.Interval(this=arg, unit=self.v[to.unit.singular.upper()])
         elif from_.is_integer() and to.is_timestamp():
             return self.f.from_unixtime(arg)
         return super().visit_Cast(op, arg=arg, to=to)

--- a/ibis/backends/sql/compilers/risingwave.py
+++ b/ibis/backends/sql/compilers/risingwave.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import sqlglot.expressions as sge
 
 import ibis.common.exceptions as com
-import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.backends.sql.compilers import PostgresCompiler
@@ -87,13 +86,8 @@ class RisingWaveCompiler(PostgresCompiler):
 
     visit_TimeTruncate = visit_DateTruncate = visit_TimestampTruncate
 
-    def visit_IntervalFromInteger(self, op, *, arg, unit):
-        if op.arg.shape == ds.scalar:
-            return sge.Interval(this=arg, unit=self.v[unit.name])
-        elif op.arg.shape == ds.columnar:
-            return arg * sge.Interval(this=sge.convert(1), unit=self.v[unit.name])
-        else:
-            raise ValueError("Invalid shape for converting to interval")
+    def _make_interval(self, arg, unit):
+        return arg * sge.Interval(this=sge.convert(1), unit=self.v[unit.name])
 
     def visit_NonNullLiteral(self, op, *, value, dtype):
         if dtype.is_binary():

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -268,9 +268,7 @@ $$""",
             return self.if_(self.f.is_object(arg), arg, NULL)
         elif to.is_array():
             return self.if_(self.f.is_array(arg), arg, NULL)
-        elif op.arg.dtype.is_integer() and to.is_interval():
-            return sge.Interval(this=arg, unit=self.v[to.unit.name])
-        return self.cast(arg, to)
+        return super().visit_Cast(op, arg=arg, to=to)
 
     def visit_ToJSONMap(self, op, *, arg):
         return self.if_(self.f.is_object(arg), arg, NULL)

--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import sqlite3
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -19,6 +20,8 @@ class SQLiteCompiler(SQLGlotCompiler):
 
     dialect = SQLite
     type_mapper = SQLiteType
+    supports_time_shift_modifiers = sqlite3.sqlite_version_info >= (3, 46, 0)
+    supports_subsec = sqlite3.sqlite_version_info >= (3, 42, 0)
 
     # We could set `supports_order_by=True` for SQLite >= 3.44.0 (2023-11-01).
     agg = AggGen(supports_filter=True)
@@ -53,10 +56,7 @@ class SQLiteCompiler(SQLGlotCompiler):
         ops.IntervalSubtract,
         ops.IntervalMultiply,
         ops.IntervalFloorDivide,
-        ops.IntervalFromInteger,
         ops.TimestampBucket,
-        ops.TimestampAdd,
-        ops.TimestampSub,
         ops.TimestampDiff,
         ops.StringToDate,
         ops.StringToTimestamp,
@@ -333,18 +333,65 @@ class SQLiteCompiler(SQLGlotCompiler):
         return self._temporal_truncate(self.f.anon.datetime, arg, unit)
 
     def visit_DateArithmetic(self, op, *, left, right):
-        unit = op.right.dtype.unit
-        sign = "+" if isinstance(op, ops.DateAdd) else "-"
-        if unit not in (IntervalUnit.YEAR, IntervalUnit.MONTH, IntervalUnit.DAY):
-            raise com.UnsupportedOperationError(
-                "SQLite does not allow binary op {sign!r} with INTERVAL offset {unit}"
-            )
-        if isinstance(op.right, ops.Literal):
-            return self.f.date(left, f"{sign}{op.right.value} {unit.plural}")
-        else:
-            return self.f.date(left, self.f.concat(sign, right, f" {unit.plural}"))
+        right = right.this
 
-    visit_DateAdd = visit_DateSub = visit_DateArithmetic
+        if (unit := op.right.dtype.unit) in (
+            IntervalUnit.QUARTER,
+            IntervalUnit.MICROSECOND,
+            IntervalUnit.NANOSECOND,
+        ):
+            raise com.UnsupportedOperationError(
+                f"SQLite does not support `{unit}` units in temporal arithmetic"
+            )
+        elif unit == IntervalUnit.WEEK:
+            unit = IntervalUnit.DAY
+            right *= 7
+        elif unit == IntervalUnit.MILLISECOND:
+            # sqlite doesn't allow milliseconds, so divide milliseconds by 1e3 to
+            # get seconds, and change the unit to seconds
+            unit = IntervalUnit.SECOND
+            right /= 1e3
+
+        # compute whether we're adding or subtracting an interval
+        sign = "+" if isinstance(op, (ops.DateAdd, ops.TimestampAdd)) else "-"
+
+        modifiers = []
+
+        # floor the result if the unit is a year, month, or day to match other
+        # backend behavior
+        if unit in (IntervalUnit.YEAR, IntervalUnit.MONTH, IntervalUnit.DAY):
+            if not self.supports_time_shift_modifiers:
+                raise com.UnsupportedOperationError(
+                    "SQLite does not support time shift modifiers until version 3.46; "
+                    f"found version {sqlite3.sqlite_version}"
+                )
+            modifiers.append("floor")
+
+        if isinstance(op, (ops.TimestampAdd, ops.TimestampSub)):
+            # if the left operand is a timestamp, return as much precision as
+            # possible
+            if not self.supports_subsec:
+                raise com.UnsupportedOperationError(
+                    "SQLite does not support subsecond resolution until version 3.42; "
+                    f"found version {sqlite3.sqlite_version}"
+                )
+            func = self.f.datetime
+            modifiers.append("subsec")
+        else:
+            func = self.f.date
+
+        return func(
+            left,
+            self.f.concat(
+                sign, self.cast(right, dt.string), " ", unit.singular.lower()
+            ),
+            *modifiers,
+            dialect=self.dialect,
+        )
+
+    visit_TimestampAdd = visit_TimestampSub = visit_DateAdd = visit_DateSub = (
+        visit_DateArithmetic
+    )
 
     def visit_DateDiff(self, op, *, left, right):
         return self.f.julianday(left) - self.f.julianday(right)

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -505,11 +505,6 @@ def test_date_truncate(backend, alltypes, df, unit):
                     reason="duration() got an unexpected keyword argument 'months'",
                 ),
                 pytest.mark.notyet(
-                    ["trino"],
-                    raises=com.UnsupportedOperationError,
-                    reason="month not implemented",
-                ),
-                pytest.mark.notyet(
                     ["oracle"],
                     raises=OracleInterfaceError,
                     reason="cursor not open, probably a bug in the sql generated",
@@ -624,7 +619,6 @@ def test_integer_to_interval_timestamp(
         param(
             "Y",
             marks=[
-                pytest.mark.notyet(["trino"], raises=com.UnsupportedOperationError),
                 pytest.mark.notyet(
                     ["polars"], raises=TypeError, reason="not supported by polars"
                 ),
@@ -635,7 +629,6 @@ def test_integer_to_interval_timestamp(
         param(
             "M",
             marks=[
-                pytest.mark.notyet(["trino"], raises=com.UnsupportedOperationError),
                 pytest.mark.notyet(
                     ["polars"], raises=TypeError, reason="not supported by polars"
                 ),

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -11,7 +11,6 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
-    ExaQueryError,
     GoogleBadRequest,
     ImpalaHiveServer2Error,
     MySQLOperationalError,
@@ -1100,11 +1099,6 @@ def test_first_last(backend):
     ["mssql"], raises=PyODBCProgrammingError, reason="not support by the backend"
 )
 @pytest.mark.notyet(["flink"], raises=Py4JJavaError, reason="bug in Flink")
-@pytest.mark.notyet(
-    ["exasol"],
-    raises=ExaQueryError,
-    reason="database can't handle UTC timestamps in DataFrames",
-)
 @pytest.mark.notyet(
     ["risingwave"],
     raises=PsycoPg2InternalError,


### PR DESCRIPTION
Follow-up to #9799 to consolidate some repetitive interval-handling code.