### PR TITLE
ci(snowflake): acquiesce to the dependency gods and unpin cloudpickle

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7789,4 +7789,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "62afcbaa70b8379af5f0f4e7555bd78839f225939edf5e71832fdac6e284e160"
+content-hash = "dd60a8b5aa71e5fc3c1eef1d72245d31655f4a700dff7eaf6aedb760fe2991e2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ ruff = ">=0.1.8"
 tqdm = ">=4.66.1,<5"
 
 [tool.poetry.group.test.dependencies]
-cloudpickle = ">=3,<4"
+cloudpickle = "*"
 filelock = ">=3.7.0,<4"
 hypothesis = ">=6.58.0,<7"
 packaging = ">=21.3,<25"


### PR DESCRIPTION
Unpinning cloudpickle because the specific version does not matter for the test case we are using it in.