### PR TITLE
fix(dot-sql): ensure that CTEs can be used in `.sql`

### DIFF
--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -191,18 +191,10 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
             The schema inferred from `query`
         """
 
-    def _get_sql_string_view_schema(self, name, table, query) -> sch.Schema:
-        compiler = self.compiler
-        dialect = compiler.dialect
-
-        cte = compiler.to_sqlglot(table)
-        parsed = sg.parse_one(query, read=dialect)
-        parsed.args["with"] = cte.args.pop("with", [])
-        parsed = parsed.with_(
-            sg.to_identifier(name, quoted=compiler.quoted), as_=cte, dialect=dialect
-        )
-
-        sql = parsed.sql(dialect)
+    def _get_sql_string_view_schema(
+        self, *, name: str, table: ir.Table, query: str
+    ) -> sch.Schema:
+        sql = self.compiler.add_query_to_expr(name=name, table=table, query=query)
         return self._get_schema_using_query(sql)
 
     def _register_udfs(self, expr: ir.Expr) -> None:

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -5,6 +5,7 @@ import getpass
 
 import pytest
 import sqlglot as sg
+import sqlglot.expressions as sge
 from pytest import param
 
 import ibis
@@ -24,11 +25,21 @@ dot_sql_never = pytest.mark.never(
 
 _NAMES = {
     "bigquery": f"ibis_gbq_testing_{getpass.getuser()}_{PYTHON_SHORT_VERSION}.functional_alltypes",
-    "exasol": '"functional_alltypes"',
 }
 
 
-@pytest.mark.notyet(["oracle"], reason="table quoting behavior")
+@pytest.fixture(scope="module")
+def ftname_raw(con):
+    return _NAMES.get(con.name, "functional_alltypes")
+
+
+@pytest.fixture(scope="module")
+def ftname(con, ftname_raw):
+    table = sg.parse_one(ftname_raw, into=sge.Table)
+    table = sg.table(table.name, db=table.db, catalog=table.catalog, quoted=True)
+    return table.sql(con.dialect)
+
+
 @dot_sql_never
 @pytest.mark.parametrize(
     "schema",
@@ -37,10 +48,9 @@ _NAMES = {
         param({"s": "string", "new_col": "double"}, id="explicit_schema"),
     ],
 )
-def test_con_dot_sql(backend, con, schema):
+def test_con_dot_sql(backend, con, schema, ftname):
     alltypes = backend.functional_alltypes
     # pull out the quoted name
-    name = _NAMES.get(con.name, "functional_alltypes")
     quoted = True
     cols = [
         sg.column("string_col", quoted=quoted).as_("s", quoted=quoted).sql(con.dialect),
@@ -50,7 +60,7 @@ def test_con_dot_sql(backend, con, schema):
     ]
     t = (
         con.sql(
-            f"SELECT {', '.join(cols)} FROM {name}",
+            f"SELECT {', '.join(cols)} FROM {ftname}",
             schema=schema,
         )
         .group_by("s")  # group by a column from SQL
@@ -325,9 +335,16 @@ def test_cte(alltypes, df):
 
 
 @dot_sql_never
-def test_bare_minimum(con, alltypes, df):
+def test_bare_minimum(alltypes, df, ftname_raw):
     """Test that a backend that supports dot sql can do the most basic thing."""
 
-    name = _NAMES.get(con.name, "functional_alltypes").replace('"', "")
-    expr = alltypes.sql(f'SELECT COUNT(*) AS "n" FROM "{name}"', dialect="duckdb")
+    expr = alltypes.sql(f'SELECT COUNT(*) AS "n" FROM "{ftname_raw}"', dialect="duckdb")
     assert expr.to_pandas().iat[0, 0] == len(df)
+
+
+@dot_sql_never
+def test_embedded_cte(alltypes, ftname_raw):
+    sql = f'WITH "x" AS (SELECT * FROM "{ftname_raw}") SELECT * FROM "x"'
+    expr = alltypes.sql(sql, dialect="duckdb")
+    result = expr.head(1).execute()
+    assert len(result) == 1

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -3553,7 +3553,7 @@ class Table(Expr, _FixedTextJupyterMixin):
             name = util.gen_name("sql_query")
             expr = self
 
-        schema = backend._get_sql_string_view_schema(name, expr, query)
+        schema = backend._get_sql_string_view_schema(name=name, table=expr, query=query)
         node = ops.SQLStringView(child=self.op(), query=query, schema=schema)
         return node.to_expr()
 


### PR DESCRIPTION
Fixes #8933.