### PR TITLE
fix: log DDL SQL in verbose mode

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -666,6 +666,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         ]
         with contextlib.suppress(AttributeError):
             query = query.sql(self.dialect)
+        self._log(query)
 
         job_config = bq.job.QueryJobConfig(query_parameters=query_parameters or [])
         return self.client.query_and_wait(
@@ -737,7 +738,6 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         schema = expr.as_table().schema() - ibis.schema({"_TABLE_SUFFIX": "string"})
 
         sql = self.compile(expr, limit=limit, params=params, **kwargs)
-        self._log(sql)
         query = self.raw_sql(sql, params=params, **kwargs)
 
         arrow_t = query.to_arrow(
@@ -799,7 +799,6 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         self._import_pyarrow()
         self._register_in_memory_tables(expr)
         sql = self.compile(expr, limit=limit, params=params, **kwargs)
-        self._log(sql)
         query = self.raw_sql(sql, params=params, **kwargs)
         table = query.to_arrow(
             progress_bar_type=None, bqstorage_client=self.storage_client
@@ -822,7 +821,6 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
 
         self._register_in_memory_tables(expr)
         sql = self.compile(expr, limit=limit, params=params, **kwargs)
-        self._log(sql)
         query = self.raw_sql(sql, params=params, page_size=chunk_size, **kwargs)
         batch_iter = query.to_arrow_iterable(bqstorage_client=self.storage_client)
         return pa.ipc.RecordBatchReader.from_batches(schema.to_pyarrow(), batch_iter)

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -88,6 +88,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl):
         pass
 
     def raw_sql(self, query: str) -> TableResult:
+        self._log(query)
         return self._table_env.execute_sql(query)
 
     def _get_schema_using_query(self, query: str) -> sch.Schema:

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -247,12 +247,12 @@ class Backend(SQLBackend):
         try:
             for k, v in self.options.items():
                 q = f"SET {k} = {v!r}"
-                util.log(q)
+                self._log(q)
                 cursor.execute_async(q)
 
             cursor._wait_to_finish()
 
-            util.log(query)
+            self._log(query)
             cursor.execute_async(query)
 
             cursor._wait_to_finish()

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -338,6 +338,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
     def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
         with contextlib.suppress(AttributeError):
             query = query.sql(self.dialect)
+        self._log(query)
 
         con = self.con
         cursor = con.cursor()

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -275,6 +275,7 @@ class Backend(SQLBackend, CanCreateDatabase):
     def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
         with contextlib.suppress(AttributeError):
             query = query.sql(dialect=self.name)
+        self._log(query)
 
         con = self.con
         cursor = con.cursor()

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -219,6 +219,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
     def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
         with contextlib.suppress(AttributeError):
             query = query.sql(dialect=self.name)
+        self._log(query)
 
         con = self.con
         cursor = con.cursor()

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -747,7 +747,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
 
         with contextlib.suppress(AttributeError):
             query = query.sql(dialect=self.dialect)
-
+        self._log(query)
         con = self.con
         cursor = con.cursor()
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -410,6 +410,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
         with contextlib.suppress(AttributeError):
             query = query.sql(dialect=self.dialect)
+        self._log(query)
         return self._session.sql(query, **kwargs)
 
     def execute(

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -728,6 +728,7 @@ $$ {defn["source"]} $$"""
     def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
         with contextlib.suppress(AttributeError):
             query = query.sql(dialect=self.name)
+        self._log(query)
         cur = self.con.cursor()
         try:
             cur.execute(query, **kwargs)

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -126,6 +126,7 @@ class Backend(SQLBackend, UrlFromPath):
     def raw_sql(self, query: str | sg.Expression, **kwargs: Any) -> Any:
         if not isinstance(query, str):
             query = query.sql(dialect=self.name)
+        self._log(query)
         return self.con.execute(query, **kwargs)
 
     @contextlib.contextmanager

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -57,7 +57,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         """Execute a raw SQL query."""
         with contextlib.suppress(AttributeError):
             query = query.sql(dialect=self.name, pretty=True)
-
+        self._log(query)
         con = self.con
         cur = con.cursor()
         try:


### PR DESCRIPTION
Before (and still), we log the SQL inside Backend.compile().
I *think* what this means is that we are logging all SELECT statements.
But, any DDL statements like from create_table() were not logged.
Now they are.
Some SQL statements may be logged twice now, in .compile() and in .raw_sql(), but I don't think that's a big problem?