### PR TITLE
fix(duckdb): fix create_table() in databases with spaces in the name

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -674,7 +674,7 @@ class Backend(SQLBackend, CanCreateDatabase):
             schema = obj.schema()
 
         this = sge.Schema(
-            this=sg.table(name, db=database),
+            this=sg.table(name, db=database, quoted=self.compiler.quoted),
             expressions=[
                 sge.ColumnDef(
                     this=sg.to_identifier(name, quoted=self.compiler.quoted),

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -187,10 +187,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         else:
             temp_name = name
 
-        initial_table = sge.Table(
-            this=sg.to_identifier(temp_name, quoted=self.compiler.quoted),
-            catalog=catalog,
-            db=database,
+        initial_table = sg.table(
+            temp_name, catalog=catalog, db=database, quoted=self.compiler.quoted
         )
         target = sge.Schema(this=initial_table, expressions=column_defs)
 
@@ -201,10 +199,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         )
 
         # This is the same table as initial_table unless overwrite == True
-        final_table = sge.Table(
-            this=sg.to_identifier(name, quoted=self.compiler.quoted),
-            catalog=catalog,
-            db=database,
+        final_table = sg.table(
+            name, catalog=catalog, db=database, quoted=self.compiler.quoted
         )
         with self._safe_raw_sql(create_stmt) as cur:
             if query is not None:

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -327,6 +327,20 @@ def test_connect_named_in_memory_db():
 
 
 @pytest.mark.parametrize(
+    "database_file",
+    [
+        "with spaces.ddb",
+        "space catalog.duckdb.db",
+    ],
+)
+def test_create_table_quoting(database_file, tmp_path):
+    conn = ibis.duckdb.connect(tmp_path / database_file)
+    t = conn.create_table("t", {"a": [0, 1, 2]})
+    result = set(conn.execute(t.a))
+    assert result == {0, 1, 2}
+
+
+@pytest.mark.parametrize(
     ("url", "method_name"),
     [
         ("hf://datasets/datasets-examples/doc-formats-csv-1/data.csv", "read_csv"),


### PR DESCRIPTION
If you tried

```python
import ibis

conn = ibis.duckdb.connect("with space.duckdb")
conn.create_table("foo", {"a": [0,1,2]})
```

then you would get the DDL `CREATE TABLE with space.main."foo" ("a" BIGINT)`. Now, the database name is quoted.

I went through the create_table() method in all the backends and looked for where we forgot to use "quoted", but I almost definitely missed some cases.

I need to add a test for this, but I would love your help with this:
- should it add/modify a create_table() test to check for a database with spaces in the name?
- should it go somewhere near other tests that check for spaces? I think we have those?
- or should we go larger, and modify the `con` fixture to sometimes be a database with spaces in the name?