### PR TITLE
chore(dev-deps): remove gen-examples script from dev-shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
 
         default = pkgs.ibisCore312;
 
-        inherit (pkgs) update-lock-files gen-examples check-release-notes-spelling;
+        inherit (pkgs) update-lock-files check-release-notes-spelling;
       };
 
       devShells = rec {


### PR DESCRIPTION
The script can be run using `nix run .\#gen-examples`. There is no real need to actually include this large derviation in the dev shell.