### PR TITLE
fix(sql): insert now works with specific database/catalog

### DIFF
--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -436,7 +436,7 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         source_cols = source.columns
         columns = (
             source_cols
-            if not set(target_cols := self.get_schema(target).names).difference(
+            if not set(target_cols := self.get_schema(target, catalog=catalog, database=db).names).difference(
                 source_cols
             )
             else target_cols


### PR DESCRIPTION
self.get_schema should be passed the database and catalog. When doing an insert into a duckdb table specific to a database, this line causes a table not found error.

## Description of changes

One line was modified to pass database and catalog to the `_build_insert_from_table` function in the SQL backend.

