### PR TITLE
depr(api): deprecate `StructValue.destructure` API

### DIFF
--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -539,7 +539,7 @@ def test_elementwise_udf_overwrite_destruct_and_assign(udf_backend, udf_alltypes
 
 
 @pytest.mark.xfail_version(pyspark=["pyspark<3.1"])
-@pytest.mark.parametrize("method", ["destructure", "unpack"])
+@pytest.mark.parametrize("method", ["destructure", "lift", "unpack"])
 def test_elementwise_udf_destructure_exact_once(udf_alltypes, method, tmp_path):
     with pytest.warns(FutureWarning, match="v9.0"):
 
@@ -558,6 +558,8 @@ def test_elementwise_udf_destructure_exact_once(udf_alltypes, method, tmp_path):
 
     if method == "destructure":
         expr = udf_alltypes.mutate(struct.destructure())
+    elif method == "lift":
+        expr = udf_alltypes.mutate(struct=struct).struct.lift()
     elif method == "unpack":
         expr = udf_alltypes.mutate(struct=struct).unpack("struct")
     else:

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from public import public
 
 import ibis.expr.operations as ops
+from ibis import util
 from ibis.common.deferred import deferrable
 from ibis.common.exceptions import IbisError
 from ibis.expr.types.generic import Column, Scalar, Value, literal
@@ -340,6 +341,7 @@ class StructValue(Value):
 
         return table.to_expr().select([self[name] for name in self.names])
 
+    @util.deprecated(as_of="10.0", instead="use lift or unpack instead")
     def destructure(self) -> list[ir.Value]:
         """Destructure a `StructValue` into the corresponding struct fields.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,11 +338,12 @@ filterwarnings = [
   # numpy, coming from a pandas call
   'ignore:In the future `np\.bool` will be defined as the corresponding NumPy scalar:FutureWarning',
   # pandas by way of polars when comparing arrays
-  'ignore:The truth value of an empty array is ambiguous.:DeprecationWarning',
+  'ignore:The truth value of an empty array is ambiguous\.:DeprecationWarning',
   # druid
   'ignore:Dialect druid.rest will not make use of SQL compilation caching:',
   # ibis
   'ignore:`(Base)?Backend.database` is deprecated:FutureWarning',
+  'ignore:`StructValue\.destructure` is deprecated as of v10\.0; use lift or unpack instead:FutureWarning',
   # spark
   "ignore:distutils Version classes are deprecated:DeprecationWarning",
   "ignore:The distutils package is deprecated and slated for removal:DeprecationWarning",


### PR DESCRIPTION
## Description of changes

Deprecate `StructValue.destructure` in favor of `StructValue.lift` or `Table.unpack`.