### PR TITLE
fix(repr): format scalar values with same logic as columnar values

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -825,16 +825,16 @@ def timestamp(
     Create a timestamp scalar from a string
 
     >>> ibis.timestamp("2023-01-02T03:04:05")
-    ┌──────────────────────────────────┐
-    │ Timestamp('2023-01-02 03:04:05') │
-    └──────────────────────────────────┘
+    ┌─────────────────────┐
+    │ 2023-01-02 03:04:05 │
+    └─────────────────────┘
 
     Create a timestamp scalar from components
 
     >>> ibis.timestamp(2023, 1, 2, 3, 4, 5)
-    ┌──────────────────────────────────┐
-    │ Timestamp('2023-01-02 03:04:05') │
-    └──────────────────────────────────┘
+    ┌─────────────────────┐
+    │ 2023-01-02 03:04:05 │
+    └─────────────────────┘
 
     Create a timestamp column from components
 
@@ -910,16 +910,16 @@ def date(value_or_year, month=None, day=None, /):
     Create a date scalar from a string
 
     >>> ibis.date("2023-01-02")
-    ┌───────────────────────────┐
-    │ datetime.date(2023, 1, 2) │
-    └───────────────────────────┘
+    ┌────────────┐
+    │ 2023-01-02 │
+    └────────────┘
 
     Create a date scalar from year, month, and day
 
     >>> ibis.date(2023, 1, 2)
-    ┌───────────────────────────┐
-    │ datetime.date(2023, 1, 2) │
-    └───────────────────────────┘
+    ┌────────────┐
+    │ 2023-01-02 │
+    └────────────┘
 
     Create a date column from year, month, and day
 
@@ -983,16 +983,16 @@ def time(value_or_hour, minute=None, second=None, /):
     Create a time scalar from a string
 
     >>> ibis.time("01:02:03")
-    ┌────────────────────────┐
-    │ datetime.time(1, 2, 3) │
-    └────────────────────────┘
+    ┌──────────┐
+    │ 01:02:03 │
+    └──────────┘
 
     Create a time scalar from hour, minute, and second
 
     >>> ibis.time(1, 2, 3)
-    ┌────────────────────────┐
-    │ datetime.time(1, 2, 3) │
-    └────────────────────────┘
+    ┌──────────┐
+    │ 01:02:03 │
+    └──────────┘
 
     Create a time column from hour, minute, and second
 
@@ -2409,9 +2409,9 @@ def coalesce(*args: Any) -> ir.Value:
     >>> import ibis
     >>> ibis.options.interactive = True
     >>> ibis.coalesce(None, 4, 5)
-    ┌────────────┐
-    │ np.int8(4) │
-    └────────────┘
+    ┌───┐
+    │ 4 │
+    └───┘
     """
     return ops.Coalesce(args).to_expr()
 
@@ -2435,9 +2435,9 @@ def greatest(*args: Any) -> ir.Value:
     >>> import ibis
     >>> ibis.options.interactive = True
     >>> ibis.greatest(None, 4, 5)
-    ┌────────────┐
-    │ np.int8(5) │
-    └────────────┘
+    ┌───┐
+    │ 5 │
+    └───┘
     """
     return ops.Greatest(args).to_expr()
 
@@ -2461,8 +2461,8 @@ def least(*args: Any) -> ir.Value:
     >>> import ibis
     >>> ibis.options.interactive = True
     >>> ibis.least(None, 4, 5)
-    ┌────────────┐
-    │ np.int8(4) │
-    └────────────┘
+    ┌───┐
+    │ 4 │
+    └───┘
     """
     return ops.Least(args).to_expr()

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -626,12 +626,10 @@ class agg(_UDF):
         ... def favg(a: float) -> float:
         ...     '''Compute the average of a column using Kahan summation.'''
         >>> t = ibis.examples.penguins.fetch()
-        >>> expr = favg(t.bill_length_mm)
-        >>> expr
-        ┌──────────────────────────────┐
-        │ np.float64(43.9219298245614) │
-        └──────────────────────────────┘
-
+        >>> favg(t.bill_length_mm)
+        ┌──────────┐
+        │ 43.92193 │
+        └──────────┘
         """
         return _wrap(
             cls._make_wrapper,

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1123,9 +1123,9 @@ class Value(Expr):
         >>> one = ibis.literal(1)
         >>> two = ibis.literal(2)
         >>> two.identical_to(one + one)
-        ┌──────────┐
-        │ np.True_ │
-        └──────────┘
+        ┌──────┐
+        │ True │
+        └──────┘
         """
         try:
             return ops.IdenticalTo(self, other).to_expr()
@@ -1175,19 +1175,19 @@ class Value(Expr):
         │           36.7 │          19.3 │
         └────────────────┴───────────────┘
         >>> t.bill_length_mm.group_concat()
-        ┌───────────────────────┐
-        │ '39.1,39.5,40.3,36.7' │
-        └───────────────────────┘
+        ┌─────────────────────┐
+        │ 39.1,39.5,40.3,36.7 │
+        └─────────────────────┘
 
         >>> t.bill_length_mm.group_concat(sep=": ")
-        ┌──────────────────────────┐
-        │ '39.1: 39.5: 40.3: 36.7' │
-        └──────────────────────────┘
+        ┌────────────────────────┐
+        │ 39.1: 39.5: 40.3: 36.7 │
+        └────────────────────────┘
 
         >>> t.bill_length_mm.group_concat(sep=": ", where=t.bill_depth_mm > 18)
-        ┌──────────────┐
-        │ '39.1: 36.7' │
-        └──────────────┘
+        ┌────────────┐
+        │ 39.1: 36.7 │
+        └────────────┘
         """
         return ops.GroupConcat(
             self,
@@ -1602,13 +1602,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.approx_nunique()
-        ┌──────────────┐
-        │ np.int64(94) │
-        └──────────────┘
+        ┌────┐
+        │ 94 │
+        └────┘
         >>> t.body_mass_g.approx_nunique(where=t.species == "Adelie")
-        ┌──────────────┐
-        │ np.int64(55) │
-        └──────────────┘
+        ┌────┐
+        │ 55 │
+        └────┘
         """
         return ops.ApproxCountDistinct(
             self, where=self._bind_to_parent_table(where)
@@ -1644,13 +1644,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.approx_median()
-        ┌────────────────┐
-        │ np.int64(4030) │
-        └────────────────┘
+        ┌──────┐
+        │ 4030 │
+        └──────┘
         >>> t.body_mass_g.approx_median(where=t.species == "Chinstrap")
-        ┌────────────────┐
-        │ np.int64(3700) │
-        └────────────────┘
+        ┌──────┐
+        │ 3700 │
+        └──────┘
         """
         return ops.ApproxMedian(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -1673,13 +1673,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.mode()
-        ┌────────────────┐
-        │ np.int64(3800) │
-        └────────────────┘
+        ┌──────┐
+        │ 3800 │
+        └──────┘
         >>> t.body_mass_g.mode(where=(t.species == "Gentoo") & (t.sex == "male"))
-        ┌────────────────┐
-        │ np.int64(5550) │
-        └────────────────┘
+        ┌──────┐
+        │ 5550 │
+        └──────┘
         """
         return ops.Mode(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -1702,13 +1702,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.max()
-        ┌────────────────┐
-        │ np.int64(6300) │
-        └────────────────┘
+        ┌──────┐
+        │ 6300 │
+        └──────┘
         >>> t.body_mass_g.max(where=t.species == "Chinstrap")
-        ┌────────────────┐
-        │ np.int64(4800) │
-        └────────────────┘
+        ┌──────┐
+        │ 4800 │
+        └──────┘
         """
         return ops.Max(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -1731,13 +1731,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.min()
-        ┌────────────────┐
-        │ np.int64(2700) │
-        └────────────────┘
+        ┌──────┐
+        │ 2700 │
+        └──────┘
         >>> t.body_mass_g.min(where=t.species == "Adelie")
-        ┌────────────────┐
-        │ np.int64(2850) │
-        └────────────────┘
+        ┌──────┐
+        │ 2850 │
+        └──────┘
         """
         return ops.Min(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -1762,13 +1762,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.species.argmax(t.body_mass_g)
-        ┌──────────┐
-        │ 'Gentoo' │
-        └──────────┘
+        ┌────────┐
+        │ Gentoo │
+        └────────┘
         >>> t.species.argmax(t.body_mass_g, where=t.island == "Dream")
-        ┌─────────────┐
-        │ 'Chinstrap' │
-        └─────────────┘
+        ┌───────────┐
+        │ Chinstrap │
+        └───────────┘
         """
         return ops.ArgMax(
             self,
@@ -1797,14 +1797,14 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.species.argmin(t.body_mass_g)
-        ┌─────────────┐
-        │ 'Chinstrap' │
-        └─────────────┘
+        ┌───────────┐
+        │ Chinstrap │
+        └───────────┘
 
         >>> t.species.argmin(t.body_mass_g, where=t.island == "Biscoe")
-        ┌──────────┐
-        │ 'Adelie' │
-        └──────────┘
+        ┌────────┐
+        │ Adelie │
+        └────────┘
         """
         return ops.ArgMin(
             self,
@@ -1835,9 +1835,9 @@ class Column(Value, _FixedTextJupyterMixin):
         Compute the median of `bill_depth_mm`
 
         >>> t.bill_depth_mm.median()
-        ┌──────────────────┐
-        │ np.float64(17.3) │
-        └──────────────────┘
+        ┌──────┐
+        │ 17.3 │
+        └──────┘
         >>> t.group_by(t.species).agg(median_bill_depth=t.bill_depth_mm.median()).order_by(
         ...     ibis.desc("median_bill_depth")
         ... )
@@ -1901,9 +1901,9 @@ class Column(Value, _FixedTextJupyterMixin):
         Compute the 99th percentile of `bill_depth`
 
         >>> t.bill_depth_mm.quantile(0.99)
-        ┌──────────────────┐
-        │ np.float64(21.1) │
-        └──────────────────┘
+        ┌──────┐
+        │ 21.1 │
+        └──────┘
         >>> t.group_by(t.species).agg(p99_bill_depth=t.bill_depth_mm.quantile(0.99)).order_by(
         ...     ibis.desc("p99_bill_depth")
         ... )
@@ -1960,13 +1960,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.body_mass_g.nunique()
-        ┌──────────────┐
-        │ np.int64(94) │
-        └──────────────┘
+        ┌────┐
+        │ 94 │
+        └────┘
         >>> t.body_mass_g.nunique(where=t.species == "Adelie")
-        ┌──────────────┐
-        │ np.int64(55) │
-        └──────────────┘
+        ┌────┐
+        │ 55 │
+        └────┘
         """
         return ops.CountDistinct(
             self, where=self._bind_to_parent_table(where)
@@ -2154,13 +2154,13 @@ class Column(Value, _FixedTextJupyterMixin):
         │ d      │
         └────────┘
         >>> t.chars.first()
-        ┌─────┐
-        │ 'a' │
-        └─────┘
+        ┌───┐
+        │ a │
+        └───┘
         >>> t.chars.first(where=t.chars != "a")
-        ┌─────┐
-        │ 'b' │
-        └─────┘
+        ┌───┐
+        │ b │
+        └───┘
         """
         return ops.First(
             self,
@@ -2207,13 +2207,13 @@ class Column(Value, _FixedTextJupyterMixin):
         │ d      │
         └────────┘
         >>> t.chars.last()
-        ┌─────┐
-        │ 'd' │
-        └─────┘
+        ┌───┐
+        │ d │
+        └───┘
         >>> t.chars.last(where=t.chars != "d")
-        ┌─────┐
-        │ 'c' │
-        └─────┘
+        ┌───┐
+        │ c │
+        └───┘
         """
         return ops.Last(
             self,
@@ -2416,9 +2416,9 @@ def null(type: dt.DataType | str | None = None) -> Value:
     │ None │
     └──────┘
     >>> ibis.null(str).upper().isnull()
-    ┌──────────┐
-    │ np.True_ │
-    └──────────┘
+    ┌──────┐
+    │ True │
+    └──────┘
     """
     if type is None:
         type = dt.null

--- a/ibis/expr/types/geospatial.py
+++ b/ibis/expr/types/geospatial.py
@@ -803,9 +803,9 @@ class GeoSpatialValue(NumericValue):
         >>> line = shapely.LineString([[0, 0], [1, 0], [1, 1]])
         >>> line_lit = ibis.literal(line, type="geometry")
         >>> line_lit.length()
-        ┌─────────────────┐
-        │ np.float64(2.0) │
-        └─────────────────┘
+        ┌─────┐
+        │ 2.0 │
+        └─────┘
         >>> t = ibis.examples.zones.fetch()
         >>> t.geom.length()
         ┏━━━━━━━━━━━━━━━━━┓

--- a/ibis/expr/types/logical.py
+++ b/ibis/expr/types/logical.py
@@ -322,17 +322,17 @@ class BooleanColumn(NumericColumn, BooleanValue):
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable({"arr": [1, 2, 3, None]})
         >>> (t.arr > 2).any()
-        ┌──────────┐
-        │ np.True_ │
-        └──────────┘
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> (t.arr > 4).any()
-        ┌───────────┐
-        │ np.False_ │
-        └───────────┘
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> (t.arr == None).any(where=t.arr != None)
-        ┌───────────┐
-        │ np.False_ │
-        └───────────┘
+        ┌───────┐
+        │ False │
+        └───────┘
         """
         from ibis.common.deferred import Call, Deferred, _
 
@@ -375,18 +375,18 @@ class BooleanColumn(NumericColumn, BooleanValue):
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable({"arr": [1, 2, 3, 4]})
         >>> (t.arr > 1).notany()
-        ┌───────────┐
-        │ np.False_ │
-        └───────────┘
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> (t.arr > 4).notany()
-        ┌──────────┐
-        │ np.True_ │
-        └──────────┘
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> m = ibis.memtable({"arr": [True, True, True, False]})
         >>> (t.arr == None).notany(where=t.arr != None)
-        ┌──────────┐
-        │ np.True_ │
-        └──────────┘
+        ┌──────┐
+        │ True │
+        └──────┘
         """
         return ~self.any(where=where)
 
@@ -409,21 +409,21 @@ class BooleanColumn(NumericColumn, BooleanValue):
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable({"arr": [1, 2, 3, 4]})
         >>> (t.arr >= 1).all()
-        ┌──────────┐
-        │ np.True_ │
-        └──────────┘
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> (t.arr > 2).all()
-        ┌───────────┐
-        │ np.False_ │
-        └───────────┘
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> (t.arr == 2).all(where=t.arr == 2)
-        ┌──────────┐
-        │ np.True_ │
-        └──────────┘
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> (t.arr == 2).all(where=t.arr >= 2)
-        ┌───────────┐
-        │ np.False_ │
-        └───────────┘
+        ┌───────┐
+        │ False │
+        └───────┘
         """
         return ops.All(self, where=self._bind_to_parent_table(where)).to_expr()
 
@@ -446,21 +446,21 @@ class BooleanColumn(NumericColumn, BooleanValue):
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable({"arr": [1, 2, 3, 4]})
         >>> (t.arr >= 1).notall()
-        ┌───────────┐
-        │ np.False_ │
-        └───────────┘
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> (t.arr > 2).notall()
-        ┌──────────┐
-        │ np.True_ │
-        └──────────┘
+        ┌──────┐
+        │ True │
+        └──────┘
         >>> (t.arr == 2).notall(where=t.arr == 2)
-        ┌───────────┐
-        │ np.False_ │
-        └───────────┘
+        ┌───────┐
+        │ False │
+        └───────┘
         >>> (t.arr == 2).notall(where=t.arr >= 2)
-        ┌──────────┐
-        │ np.True_ │
-        └──────────┘
+        ┌──────┐
+        │ True │
+        └──────┘
         """
         return ~self.all(where=where)
 

--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -57,7 +57,8 @@ def _(dtype, values, **fmt_kwargs):
     import shapely
 
     return _format_nested(
-        [None if v is None else shapely.from_wkb(v) for v in values], **fmt_kwargs
+        [shapely.from_wkb(v) if isinstance(v, (bytes, str)) else v for v in values],
+        **fmt_kwargs,
     )
 
 
@@ -288,13 +289,14 @@ def _to_rich_scalar(
     max_string: int | None = None,
     max_depth: int | None = None,
 ) -> Pretty:
-    scalar = Pretty(
-        expr.execute(),
+    value = format_values(
+        expr.type(),
+        [expr.execute()],
         max_length=max_length or ibis.options.repr.interactive.max_length,
         max_string=max_string or ibis.options.repr.interactive.max_string,
         max_depth=max_depth or ibis.options.repr.interactive.max_depth,
-    )
-    return Panel(scalar, expand=False, box=box.SQUARE)
+    )[0]
+    return Panel(value, expand=False, box=box.SQUARE)
 
 
 def _to_rich_table(

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1238,13 +1238,13 @@ class Table(Expr, _FixedTextJupyterMixin):
 
         >>> expr = t.distinct(on=["species", "island", "year", "bill_length_mm"], keep=None)
         >>> expr.count()
-        ┌───────────────┐
-        │ np.int64(273) │
-        └───────────────┘
+        ┌─────┐
+        │ 273 │
+        └─────┘
         >>> t.count()
-        ┌───────────────┐
-        │ np.int64(344) │
-        └───────────────┘
+        ┌─────┐
+        │ 344 │
+        └─────┘
 
         You can pass [`selectors`](./selectors.qmd) to `on`
 
@@ -2608,13 +2608,13 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ bar    │
         └────────┘
         >>> t.nunique()
-        ┌─────────────┐
-        │ np.int64(2) │
-        └─────────────┘
+        ┌───┐
+        │ 2 │
+        └───┘
         >>> t.nunique(t.a != "foo")
-        ┌─────────────┐
-        │ np.int64(1) │
-        └─────────────┘
+        ┌───┐
+        │ 1 │
+        └───┘
         """
         if where is not None:
             (where,) = bind(self, where)
@@ -2649,13 +2649,13 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ baz    │
         └────────┘
         >>> t.count()
-        ┌─────────────┐
-        │ np.int64(3) │
-        └─────────────┘
+        ┌───┐
+        │ 3 │
+        └───┘
         >>> t.count(t.a != "foo")
-        ┌─────────────┐
-        │ np.int64(2) │
-        └─────────────┘
+        ┌───┐
+        │ 2 │
+        └───┘
         >>> type(t.count())
         <class 'ibis.expr.types.numeric.IntegerScalar'>
         """
@@ -2709,17 +2709,17 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ …       │ …         │              … │             … │                 … │ … │
         └─────────┴───────────┴────────────────┴───────────────┴───────────────────┴───┘
         >>> t.count()
-        ┌───────────────┐
-        │ np.int64(344) │
-        └───────────────┘
+        ┌─────┐
+        │ 344 │
+        └─────┘
         >>> t.drop_null(["bill_length_mm", "body_mass_g"]).count()
-        ┌───────────────┐
-        │ np.int64(342) │
-        └───────────────┘
+        ┌─────┐
+        │ 342 │
+        └─────┘
         >>> t.drop_null(how="all").count()  # no rows where all columns are null
-        ┌───────────────┐
-        │ np.int64(344) │
-        └───────────────┘
+        ┌─────┐
+        │ 344 │
+        └─────┘
         """
         if subset is not None:
             subset = self.bind(subset)
@@ -3353,9 +3353,9 @@ class Table(Expr, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.count()
-        ┌───────────────┐
-        │ np.int64(344) │
-        └───────────────┘
+        ┌─────┐
+        │ 344 │
+        └─────┘
         >>> agg = t.drop("year").agg(s.across(s.numeric(), _.mean()))
         >>> expr = t.cross_join(agg)
         >>> expr
@@ -3390,9 +3390,9 @@ class Table(Expr, _FixedTextJupyterMixin):
          'flipper_length_mm_right',
          'body_mass_g_right']
         >>> expr.count()
-        ┌───────────────┐
-        │ np.int64(344) │
-        └───────────────┘
+        ┌─────┐
+        │ 344 │
+        └─────┘
         """
         from ibis.expr.types.joins import Join
 

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -1695,9 +1695,9 @@ class StringValue(Value):
         >>> ibis.options.interactive = True
         >>> s = ibis.literal("kitten")
         >>> s.levenshtein("sitting")
-        ┌─────────────┐
-        │ np.int64(3) │
-        └─────────────┘
+        ┌───┐
+        │ 3 │
+        └───┘
         """
         return ops.Levenshtein(self, other).to_expr()
 

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -278,9 +278,9 @@ class TimeValue(_TimeComponentMixin, Value):
         >>> start = ibis.time("01:58:00")
         >>> end = ibis.time("23:59:59")
         >>> end.delta(start, "hour")
-        ┌──────────────┐
-        │ np.int64(22) │
-        └──────────────┘
+        ┌────┐
+        │ 22 │
+        └────┘
         >>> data = '''tpep_pickup_datetime,tpep_dropoff_datetime
         ... 2016-02-01T00:23:56,2016-02-01T00:42:28
         ... 2016-02-01T00:12:14,2016-02-01T00:21:41
@@ -445,9 +445,9 @@ class DateValue(Value, _DateComponentMixin):
         >>> start = ibis.date("1992-09-30")
         >>> end = ibis.date("1992-10-01")
         >>> end.delta(start, "day")
-        ┌─────────────┐
-        │ np.int64(1) │
-        └─────────────┘
+        ┌───┐
+        │ 1 │
+        └───┘
         >>> prez = ibis.examples.presidential.fetch()
         >>> prez.mutate(
         ...     years_in_office=prez.end.delta(prez.start, "year"),
@@ -779,9 +779,9 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         >>> start = ibis.time("01:58:00")
         >>> end = ibis.time("23:59:59")
         >>> end.delta(start, "hour")
-        ┌──────────────┐
-        │ np.int64(22) │
-        └──────────────┘
+        ┌────┐
+        │ 22 │
+        └────┘
         >>> data = '''tpep_pickup_datetime,tpep_dropoff_datetime
         ... 2016-02-01T00:23:56,2016-02-01T00:42:28
         ... 2016-02-01T00:12:14,2016-02-01T00:21:41


### PR DESCRIPTION
Previously our interactive repr just called `str(value)` on scalars before passing off to `rich`. We now apply the same logic we do for columnar values to scalars as well. This provides a more uniform interactive repr experience, where scalars and columns have identical formatting rules.

Fixes #9820