### PR TITLE
feat(sql): support inserts with default constraints

### DIFF
--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -241,7 +241,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
 
     @property
     def current_database(self) -> str:
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def list_catalogs(self, like: str | None = None) -> list[str]:
         code = (

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -439,7 +439,6 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
             columns=[sg.to_identifier(col, quoted=quoted) for col in columns],
             dialect=compiler.dialect,
         )
-
         return query
 
     def _build_insert_template(

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -425,10 +425,13 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         # Compare the columns between the target table and the object to be inserted
         # If source is a subset of target, use source columns for insert list
         # Otherwise, assume auto-generated column names and use positional ordering.
-        source_cols = source.columns
-        target_cols = self.get_schema(target).names
+        target_cols = self.get_schema(target).keys()
 
-        columns = source_cols if set(source_cols).issubset(target_cols) else target_cols
+        columns = (
+            source_cols
+            if (source_cols := source.schema().keys()) <= target_cols
+            else target_cols
+        )
 
         query = sge.insert(
             expression=self.compile(source),

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -427,17 +427,19 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
         # ordering.
         source_cols = source.columns
         columns = (
-            source_cols
-            if not set(target_cols := self.get_schema(target).names).difference(
-                source_cols
-            )
-            else target_cols
+            target_cols
+            if set(target_cols := self.get_schema(target).names).difference(source_cols)
+            else source_cols
         )
 
         query = sge.insert(
             expression=self.compile(source),
             into=sg.table(target, db=db, catalog=catalog, quoted=quoted),
-            columns=[sg.to_identifier(col, quoted=quoted) for col in columns],
+            columns=[
+                sg.to_identifier(col, quoted=quoted)
+                for col in columns
+                if col in source_cols
+            ],
             dialect=compiler.dialect,
         )
         return query

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1758,9 +1758,6 @@ def test_cross_database_join(con_create_database, monkeypatch):
 )
 @pytest.mark.notimpl(["clickhouse"], reason="create table isn't implemented")
 @pytest.mark.notyet(["pandas", "dask", "polars"], reason="Doesn't support insert")
-@pytest.mark.notimpl(
-    ["flink"], reason="Temp tables are implemented as views, which don't support insert"
-)
 @pytest.mark.notyet(["exasol"], reason="Backend does not support raw_sql")
 @pytest.mark.notimpl(
     ["impala", "pyspark", "trino"], reason="Default constraints are not supported"

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1765,7 +1765,11 @@ def test_cross_database_join(con_create_database, monkeypatch):
     ["impala", "pyspark", "trino"], reason="Default constraints are not supported"
 )
 def test_insert_into_table_missing_columns(con, temp_table):
-    ct_sql = f'CREATE TABLE "{temp_table}" ("a" INT DEFAULT 1, "b" INT)'
+    ident = sg.table(
+        temp_table, db=con.current_database, catalog=con.current_catalog, quoted=True
+    )
+    raw_ident = ident.sql("duckdb")
+    ct_sql = f'CREATE TABLE {raw_ident} ("a" INT DEFAULT 1, "b" INT)'
     sg_expr = sg.parse_one(ct_sql, read="duckdb")
     con.raw_sql(sg_expr.sql(dialect=con.dialect))
     con.insert(temp_table, [{"b": 1}])

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1764,13 +1764,13 @@ def test_cross_database_join(con_create_database, monkeypatch):
 )
 def test_insert_into_table_missing_columns(con):
     table_name = gen_name("table")
-    ct_sql = f"CREATE TABLE {table_name} (a INT DEFAULT 1, b VARCHAR(10));"
+    ct_sql = f'CREATE TABLE "{table_name}" ("a" INT DEFAULT 1, "b" INT);'
     sg_expr = sg.parse_one(ct_sql, read="duckdb")
     con.raw_sql(sg_expr.sql(dialect=con.dialect))
-    con.insert(table_name, [{"b": "hello"}])
+    con.insert(table_name, [{"b": 1}])
 
     result = con.table(table_name).to_pyarrow().to_pydict()
-    expected_result = {"a": [1], "b": ["hello"]}
+    expected_result = {"a": [1], "b": [1]}
 
     assert result == expected_result
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1764,16 +1764,13 @@ def test_cross_database_join(con_create_database, monkeypatch):
 @pytest.mark.notimpl(
     ["impala", "pyspark", "trino"], reason="Default constraints are not supported"
 )
-def test_insert_into_table_missing_columns(con):
-    table_name = gen_name("table")
-    ct_sql = f'CREATE TABLE "{table_name}" ("a" INT DEFAULT 1, "b" INT);'
+def test_insert_into_table_missing_columns(con, temp_table):
+    ct_sql = f'CREATE TABLE "{temp_table}" ("a" INT DEFAULT 1, "b" INT)'
     sg_expr = sg.parse_one(ct_sql, read="duckdb")
     con.raw_sql(sg_expr.sql(dialect=con.dialect))
-    con.insert(table_name, [{"b": 1}])
+    con.insert(temp_table, [{"b": 1}])
 
-    result = con.table(table_name).to_pyarrow().to_pydict()
+    result = con.table(temp_table).to_pyarrow().to_pydict()
     expected_result = {"a": [1], "b": [1]}
 
     assert result == expected_result
-
-    con.drop_table(table_name)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -34,6 +34,7 @@ from ibis.backends.tests.errors import (
     OracleDatabaseError,
     PsycoPg2InternalError,
     PsycoPg2UndefinedObject,
+    Py4JJavaError,
     PyODBCProgrammingError,
     PySparkAnalysisException,
     SnowflakeProgrammingError,
@@ -1757,6 +1758,7 @@ def test_cross_database_join(con_create_database, monkeypatch):
     ["druid"], raises=NotImplementedError, reason="doesn't support create_table"
 )
 @pytest.mark.notimpl(["clickhouse"], reason="create table isn't implemented")
+@pytest.mark.notyet(["flink"], raises=Py4JJavaError)
 @pytest.mark.notyet(["pandas", "dask", "polars"], reason="Doesn't support insert")
 @pytest.mark.notyet(["exasol"], reason="Backend does not support raw_sql")
 @pytest.mark.notimpl(

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1754,8 +1754,8 @@ def test_cross_database_join(con_create_database, monkeypatch):
     con.drop_database(dbname)
 
 
-@pytest.mark.notyet(
-    ["druid"], raises=NotImplementedError, reason="doesn't support create_table"
+@pytest.mark.notimpl(
+    ["druid"], raises=AttributeError, reason="doesn't implement `raw_sql`"
 )
 @pytest.mark.notimpl(["clickhouse"], reason="create table isn't implemented")
 @pytest.mark.notyet(["flink"], raises=Py4JJavaError)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1758,6 +1758,7 @@ def test_cross_database_join(con_create_database, monkeypatch):
 @pytest.mark.notyet(
     ["druid"], raises=NotImplementedError, reason="doesn't support create_table"
 )
+@pytest.mark.notimpl(["clickhouse"], reason="create table isn't implemented")
 @pytest.mark.notyet(["pandas", "dask", "polars"], reason="Doesn't support insert")
 @pytest.mark.notimpl(
     ["flink"], reason="Temp tables are implemented as views, which don't support insert"

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -61,6 +61,7 @@ from public import public
 
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common.collections import frozendict  # noqa: TCH001
@@ -403,7 +404,10 @@ class Across(Selector):
                 else:
                     name = names.format(col=orig_col.get_name(), fn=func_name)
 
-                expanded.append(col.name(name))
+                if not isinstance(col.op(), ops.Alias):
+                    col = col.name(name)
+
+                expanded.append(col)
 
         return expanded
 


### PR DESCRIPTION
## Description of changes

This change intends to support scenarios where a user needs to insert into a table where a table contains DEFAULT values on columns, meaning the incoming object may have fewer columns than the target table schema. 

It's common to insert into tables with DEFAULT constraints; in many cases, these are sequences, and it is a bit tricky to provide the sequence "nextval" approach today. 

This topic was initially brought up in [Zulip](https://ibis-project.zulipchat.com/#narrow/stream/405263-general/topic/insert.20with.20default.20columns.20on.20target.20table).

Here is an example of this in practice:

```py
import ibis
import pandas as pd

con = ibis.duckdb.connect()
con.raw_sql("CREATE TABLE example (a INTEGER DEFAULT 1, b VARCHAR NOT NULL);")

df = pd.DataFrame(
    {
        "a": [1, 2, 3],
        "b": ["foo", "bar", "baz"],
    }
)
```

### Backend error
If the user excludes a required column (e.g., NOT NULL without a DEFAULT) from the container used for insert, the backend will error out with its respective error. 

```py
con.insert("example", df[["a"]])
```

### Successful insert with excluded columns
```py
con.insert("example", df[["b"]])
con.table("example").to_pandas()
```

a | b
-- | --
1 | foo
1 | bar
1 | baz

I'm still working through the tests for this, but wanted to put this out here in case anyone wanted to take a look before I can return to it. 

