### PR TITLE
test(duckdb): add test for supporting fixed-size array types

### DIFF
--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -36,6 +36,7 @@ from ibis.backends.sql.datatypes import DuckDBType
             ("UUID", dt.uuid),
             ("VARCHAR", dt.string),
             ("INTEGER[]", dt.Array(dt.int32)),
+            ("INTEGER[3]", dt.Array(dt.int32)),
             ("MAP(VARCHAR, BIGINT)", dt.Map(dt.string, dt.int64)),
             (
                 "STRUCT(a INTEGER, b VARCHAR, c MAP(VARCHAR, DOUBLE[])[])",


### PR DESCRIPTION
These are already supported automatically through sqlglot, just adding a test here. Fixes #7963.

One open question: currently these are cast to variable-length lists in `to_pyarrow` (matching the existing behavior of `dt.Array` types), but it could be argued that we should pass them through as fixed-length lists instead. This would require a bit of work, but nothing too tricky.