### PR TITLE
feat(sql): load parsed but unsupported types as unknown

### DIFF
--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -169,8 +169,10 @@ class SqlglotType(TypeMapper):
 
         if method := getattr(cls, f"_from_sqlglot_{typecode.name}", None):
             dtype = method(*typ.expressions)
+        elif (known_typ := _from_sqlglot_types.get(typecode)) is not None:
+            dtype = known_typ(nullable=cls.default_nullable)
         else:
-            dtype = _from_sqlglot_types[typecode](nullable=cls.default_nullable)
+            dtype = dt.unknown
 
         if nullable is not None:
             return dtype.copy(nullable=nullable)

--- a/ibis/backends/sql/tests/test_datatypes.py
+++ b/ibis/backends/sql/tests/test_datatypes.py
@@ -8,7 +8,12 @@ import sqlglot.expressions as sge
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.tests.strategies as its
-from ibis.backends.sql.datatypes import DuckDBType, PostgresType, SqlglotType
+from ibis.backends.sql.datatypes import (
+    ClickHouseType,
+    DuckDBType,
+    PostgresType,
+    SqlglotType,
+)
 
 
 def assert_dtype_roundtrip(ibis_type, sqlglot_expected=None):
@@ -63,3 +68,20 @@ def test_interval_without_unit():
         SqlglotType.from_string("INTERVAL")
     assert PostgresType.from_string("INTERVAL") == dt.Interval("s")
     assert DuckDBType.from_string("INTERVAL") == dt.Interval("us")
+
+
+@pytest.mark.parametrize(
+    "typ",
+    [
+        sge.DataType.Type.UINT256,
+        sge.DataType.Type.UINT128,
+        sge.DataType.Type.BIGSERIAL,
+        sge.DataType.Type.HLLSKETCH,
+    ],
+)
+@pytest.mark.parametrize(
+    "typengine",
+    [ClickHouseType, PostgresType, DuckDBType],
+)
+def test_unsupported_dtypes_are_unknown(typengine, typ):
+    assert typengine.to_ibis(sge.DataType(this=typ)) == dt.unknown


### PR DESCRIPTION
## Description of changes

This is a loose follow-up to #9576.

In that PR, I added support for falling back to `dt.unknown` when `sqlglot`
failed to parse a type string.  In that case, it was usually handling things
like user-defined types in Postgres.

This is a related change, where we mark a dtype as `unknown` if `sqlglot` _does_
parse it correctly, but we don't have support for the dtype.  The user can't
operate on the column in question, but at least the table will load.

A representative issue is loading a table in Clickhouse that has a `uint256` column

## Issues closed

xref #9861

Closes #9869.