### PR TITLE
feat(exasol): implement `cov`/`corr`, fix int64 support

### DIFF
--- a/ibis/backends/exasol/converter.py
+++ b/ibis/backends/exasol/converter.py
@@ -14,6 +14,15 @@ class ExasolPandasData(PandasData):
             return s
 
     @classmethod
+    def convert_Int64(cls, s, dtype, pandas_dtype):
+        if s.dtype == "object":
+            # exasol returns BIGINT types as strings (or None for NULL).
+            # s.astype("int64") will fail in this case, using `Series.map`
+            # is the best we can do.
+            return s.map(int, na_action="ignore")
+        return s if s.dtype == pandas_dtype else s.astype(pandas_dtype)
+
+    @classmethod
     def convert_Interval(cls, s, dtype, pandas_dtype):
         def parse_timedelta(value):
             # format is '(+|-)days hour:minute:second.millisecond'

--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -76,6 +76,7 @@ class Exasol(Postgres):
         TRANSFORMS = Postgres.Generator.TRANSFORMS.copy() | {
             sge.Interval: _interval,
             sge.GroupConcat: _group_concat,
+            sge.ApproxDistinct: rename_func("approximate_count_distinct"),
         }
         TYPE_MAPPING = Postgres.Generator.TYPE_MAPPING.copy() | {
             sge.DataType.Type.TIMESTAMPTZ: "TIMESTAMP WITH LOCAL TIME ZONE",

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -13,6 +13,7 @@ from ibis import _
 from ibis import literal as L
 from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
+    ExaQueryError,
     GoogleBadRequest,
     ImpalaHiveServer2Error,
     MySQLNotSupportedError,
@@ -790,7 +791,6 @@ def test_arbitrary(backend, alltypes, df, filtered):
     raises=com.OperationNotDefinedError,
     reason="no one has attempted implementation yet",
 )
-@pytest.mark.notimpl(["exasol"], raises=com.UnsupportedOperationError)
 def test_count_distinct_star(alltypes, df, ibis_cond, pandas_cond):
     table = alltypes[["int_col", "double_col", "string_col"]]
     expr = table.nunique(where=ibis_cond(table))

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1013,7 +1013,7 @@ def test_quantile(
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(
-                    ["postgres", "duckdb", "snowflake", "risingwave"],
+                    ["postgres", "duckdb", "snowflake", "risingwave", "exasol"],
                     raises=com.UnsupportedOperationError,
                     reason="backend only implements population correlation coefficient",
                 ),
@@ -1114,7 +1114,7 @@ def test_quantile(
         ),
     ],
 )
-@pytest.mark.notimpl(["mssql", "exasol"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError)
 def test_corr_cov(
     con,
     batting,

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -13,7 +13,6 @@ from ibis import _
 from ibis import literal as L
 from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
-    ExaQueryError,
     GoogleBadRequest,
     ImpalaHiveServer2Error,
     MySQLNotSupportedError,
@@ -298,7 +297,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     raises=AttributeError,
                     reason="'IntegerColumn' object has no attribute 'notany'",
                 ),
-                pytest.mark.notimpl(["exasol"], raises=ExaQueryError),
             ],
         ),
         param(
@@ -311,7 +309,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     raises=AttributeError,
                     reason="'IntegerColumn' object has no attribute 'any'",
                 ),
-                pytest.mark.notimpl(["exasol"], raises=ExaQueryError),
             ],
         ),
         param(
@@ -336,7 +333,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     raises=AttributeError,
                     reason="'IntegerColumn' object has no attribute 'notall'",
                 ),
-                pytest.mark.notimpl(["exasol"], raises=ExaQueryError),
             ],
         ),
         param(
@@ -349,7 +345,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     raises=AttributeError,
                     reason="'IntegerColumn' object has no attribute 'all'",
                 ),
-                pytest.mark.notimpl(["exasol"], raises=ExaQueryError),
             ],
         ),
         param(
@@ -485,7 +480,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             id="bit_and",
             marks=[
                 pytest.mark.notimpl(
-                    ["polars", "mssql"],
+                    ["polars", "mssql", "exasol"],
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notimpl(["druid"], strict=False, raises=AssertionError),
@@ -500,7 +495,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             id="bit_or",
             marks=[
                 pytest.mark.notimpl(
-                    ["polars", "mssql"],
+                    ["polars", "mssql", "exasol"],
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(
@@ -514,7 +509,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             id="bit_xor",
             marks=[
                 pytest.mark.notimpl(
-                    ["polars", "mssql"],
+                    ["polars", "mssql", "exasol"],
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(
@@ -532,39 +527,11 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
 @pytest.mark.parametrize(
     ("ibis_cond", "pandas_cond"),
     [
-        param(
-            lambda _: None,
-            lambda _: slice(None),
-            marks=pytest.mark.notimpl(
-                ["exasol"],
-                raises=(com.OperationNotDefinedError, ExaQueryError),
-                strict=False,
-            ),
-            id="no_cond",
-        ),
+        param(lambda _: None, lambda _: slice(None), id="no_cond"),
         param(
             lambda t: t.string_col.isin(["1", "7"]),
             lambda t: t.string_col.isin(["1", "7"]),
-            marks=[
-                pytest.mark.notimpl(
-                    ["exasol"],
-                    raises=(com.OperationNotDefinedError, ExaQueryError),
-                    strict=False,
-                ),
-            ],
             id="is_in",
-        ),
-        param(
-            lambda _: ibis._.string_col.isin(["1", "7"]),
-            lambda t: t.string_col.isin(["1", "7"]),
-            marks=[
-                pytest.mark.notimpl(
-                    ["exasol"],
-                    raises=(com.OperationNotDefinedError, ExaQueryError),
-                    strict=False,
-                ),
-            ],
-            id="is_in_deferred",
         ),
     ],
 )

--- a/ibis/backends/tests/test_conditionals.py
+++ b/ibis/backends/tests/test_conditionals.py
@@ -90,11 +90,6 @@ def test_value_cases_scalar(con, inp, exp):
         assert result == exp
 
 
-@pytest.mark.notimpl(
-    "exasol",
-    reason="the int64 RBI column is .to_pandas()ed to an object column, which is incomparable to ints",
-    raises=AssertionError,
-)
 def test_value_cases_column(batting):
     np = pytest.importorskip("numpy")
 
@@ -124,7 +119,7 @@ def test_ibis_cases_scalar():
 
 
 @pytest.mark.notimpl(
-    ["sqlite", "exasol"],
+    ["sqlite"],
     reason="the int64 RBI column is .to_pandas()ed to an object column, which is incomparable to 5",
     raises=TypeError,
 )

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -782,10 +782,7 @@ def test_table_info_large(con):
     reason="quantile and mode is not supported",
 )
 @pytest.mark.notimpl(
-    [
-        "exasol",
-        "druid",
-    ],
+    ["druid"],
     raises=com.OperationNotDefinedError,
     reason="Mode and StandardDev is not supported",
 )
@@ -829,10 +826,10 @@ def test_table_info_large(con):
                 pytest.mark.notimpl(
                     [
                         "clickhouse",
-                        "pyspark",
-                        "clickhouse",
-                        "risingwave",
+                        "exasol",
                         "impala",
+                        "pyspark",
+                        "risingwave",
                     ],
                     raises=com.OperationNotDefinedError,
                     reason="mode is not supported",
@@ -911,10 +908,10 @@ def test_table_info_large(con):
                 pytest.mark.notimpl(
                     [
                         "clickhouse",
-                        "pyspark",
-                        "clickhouse",
-                        "risingwave",
+                        "exasol",
                         "impala",
+                        "pyspark",
+                        "risingwave",
                     ],
                     raises=com.OperationNotDefinedError,
                     reason="mode is not supported",
@@ -958,10 +955,7 @@ def test_table_describe(alltypes, selector, expected_columns):
     reason="quantile is not supported",
 )
 @pytest.mark.notimpl(
-    [
-        "exasol",
-        "druid",
-    ],
+    ["druid"],
     raises=com.OperationNotDefinedError,
     reason="StandardDev is not supported",
 )

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -637,7 +637,7 @@ def test_order_by_nulls(con, op, nulls_first, expected):
 
 @pytest.mark.notimpl(["druid"])
 @pytest.mark.never(
-    ["exasol", "mysql"],
+    ["mysql"],
     raises=AssertionError,
     reason="someone decided a long time ago that 'A' = 'a' is true in these systems",
 )

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -51,12 +51,7 @@ def check_eq(left, right, how, **kwargs):
         "left",
         param(
             "right",
-            marks=[
-                pytest.mark.notimpl(
-                    ["exasol"], raises=AssertionError, reasons="results don't match"
-                ),
-                sqlite_right_or_full_mark,
-            ],
+            marks=[sqlite_right_or_full_mark],
         ),
         param(
             "outer",
@@ -67,9 +62,6 @@ def check_eq(left, right, how, **kwargs):
                 pytest.mark.notimpl(["mysql"]),
                 sqlite_right_or_full_mark,
                 pytest.mark.xfail_version(datafusion=["datafusion<31"]),
-                pytest.mark.notimpl(
-                    ["exasol"], raises=AssertionError, reasons="results don't match"
-                ),
             ],
         ),
     ],


### PR DESCRIPTION
This:
- Fixes a bug where returning `int64` values wasn't properly handled
- Based on this fix, implements `cov`/`corr`

Based on #9870.