### PR TITLE
fix(oracle): boolean syntax error in older versions of oracle

### DIFF
--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -335,7 +335,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 C.data_type,
                 C.data_precision,
                 C.data_scale,
-                C.nullable.eq(sge.convert("Y")).as_("nullable"),
+                C.nullable,
             )
             .from_(sg.table("all_tab_columns"))
             .where(
@@ -357,7 +357,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 type_string=type_string,
                 precision=precision,
                 scale=scale,
-                nullable=nullable,
+                nullable=nullable == "Y",
             )
             for name, type_string, precision, scale, nullable in results
         }
@@ -582,7 +582,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 C.data_type,
                 C.data_precision,
                 C.data_scale,
-                C.nullable.eq(sge.convert("Y")),
+                C.nullable,
             )
             .from_("all_tab_columns")
             .where(C.table_name.eq(sge.convert(name)))
@@ -608,7 +608,7 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 type_string=type_string,
                 precision=precision,
                 scale=scale,
-                nullable=nullable,
+                nullable=nullable == "Y",
             )
             schema[name] = typ
 


### PR DESCRIPTION
## Description of changes

Oracle did not start supporting boolean operations until very recent versions (23c). Versions of Oracle, such as 19c are still not end-of-life until 2027+, given this, adjusted the Oracle Boolean logic into a Python function to allow the use of various Oracle versions vs. just the newest 23c. If you could please consider this or some other change to allow the Oracle connection to work, it would be greatly appreciated, thanks!
