### PR TITLE
refactor(api): make unit required in IntegerValue.as_timestamp

### DIFF
--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -438,7 +438,7 @@ def test_literal_none_to_nullable_column(alltypes):
 
 def test_timestamp_from_integer(con, alltypes, assert_sql):
     # timestamp_col has datetime type
-    expr = alltypes.int_col.as_timestamp()
+    expr = alltypes.int_col.as_timestamp("s")
     assert_sql(expr, "out.sql")
     assert len(con.execute(expr))
 

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -58,7 +58,7 @@ def test_builtins(con, alltypes):
         i4.as_timestamp("s"),
         i4.as_timestamp("ms"),
         i4.as_timestamp("us"),
-        i8.as_timestamp(),
+        i8.as_timestamp("s"),
         d.abs(),
         d.cast("decimal(12, 2)"),
         d.cast("int32"),
@@ -193,7 +193,7 @@ def test_column_types(alltypes_df, col, expected):
     [
         (L(50000).as_timestamp("s"), pd.to_datetime(50000, unit="s")),
         (L(50000).as_timestamp("ms"), pd.to_datetime(50000, unit="ms")),
-        (L(5 * 10**8).as_timestamp(), pd.to_datetime(5 * 10**8, unit="s")),
+        (L(5 * 10**8).as_timestamp("s"), pd.to_datetime(5 * 10**8, unit="s")),
         (
             ibis.timestamp("2009-05-17 12:34:56").truncate("y"),
             pd.Timestamp("2009-01-01"),

--- a/ibis/backends/impala/tests/test_value_exprs.py
+++ b/ibis/backends/impala/tests/test_value_exprs.py
@@ -235,7 +235,7 @@ def test_timestamp_day_of_week(method_name, snapshot):
 @pytest.mark.parametrize(
     "expr_fn",
     [
-        lambda col: col.as_timestamp(),
+        lambda col: col.as_timestamp("s"),
         lambda col: col.as_timestamp("ms"),
         lambda col: col.as_timestamp("us"),
     ],

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -1016,7 +1016,7 @@ class NumericColumn(Column, NumericValue):
 class IntegerValue(NumericValue):
     def as_timestamp(
         self,
-        unit: Literal["s", "ms", "us"] = "s",
+        unit: Literal["s", "ms", "us"],
     ) -> ir.TimestampValue:
         """Convert an integral UNIX timestamp to a timestamp expression.
 


### PR DESCRIPTION
Partially addresses https://github.com/ibis-project/ibis/issues/9854