### PR TITLE
docs(snowflake): document using private key to connect to snowflake

### DIFF
--- a/docs/backends/snowflake.qmd
+++ b/docs/backends/snowflake.qmd
@@ -131,8 +131,38 @@ con = ibis.snowflake.connect(
 
 ```python
 con = ibis.connect(
-    f"snowflake://{user}@{account}/{database}?warehouse={warehouse}",
+    f"snowflake://{user}@{account}/{database}/{schema}?warehouse={warehouse}",
     authenticator="externalbrowser",
+)
+```
+
+### Authenticating with Key Pair Authentication
+
+Ibis supports connecting to Snowflake warehouses using private keys.
+
+You can use it in the explicit-parameters-style or in the URL-style connection
+APIs.
+
+#### Explicit
+
+```python
+con = ibis.snowflake.connect(
+    user="user",
+    account="safpqpq-sq55555",
+    database="my_database",
+    schema="my_schema",
+    warehouse="my_warehouse",
+    # extracted private key from .p8 file
+    private_key=os.getenv(SNOWFLAKE_PKEY),
+)
+```
+
+#### URL
+
+```python
+con = ibis.connect(
+    f"snowflake://{user}@{account}/{database}/{schema}?warehouse={warehouse}",
+    private_key=os.getenv(SNOWFLAKE_PKEY),
 )
 ```
 


### PR DESCRIPTION
## Description of changes

Document user-confirmed method of connecting to snowflake using a private key
instead of a password.


## Issues closed

xref #9837
