### PR TITLE
depr(expr-api): deprecate useless `has_name` method

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -17,7 +17,7 @@ from ibis.common.typing import get_defining_scope
 from ibis.config import _default_backend
 from ibis.config import options as opts
 from ibis.expr.format import pretty
-from ibis.util import experimental
+from ibis.util import deprecated, experimental
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -182,6 +182,11 @@ class Expr(Immutable, Coercible):
 
     __nonzero__ = __bool__
 
+    @deprecated(
+        instead="remove any usage of `has_name`, since it is always `True`",
+        as_of="9.4",
+        removed_in="10.0",
+    )
     def has_name(self):
         """Check whether this expression has an explicit name."""
         return hasattr(self._arg, "name")

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -71,7 +71,7 @@ class Value(Expr):
         # TODO(kszucs): shouldn't do simplification here, but rather later
         # when simplifying the whole operation tree
         # the expression's name is idendical to the new one
-        if self.has_name() and self.get_name() == name:
+        if self.get_name() == name:
             return self
 
         if isinstance(self.op(), ops.Alias):


### PR DESCRIPTION
~Remove~ Deprecate a method that apparently has no effect anymore since every operation has a name since 9.0.