### PR TITLE
feat(selectors): allow naming in the `across` selector and support non-expression methods

### DIFF
--- a/ibis/common/tests/test_deferred.py
+++ b/ibis/common/tests/test_deferred.py
@@ -6,6 +6,7 @@ import pickle
 import pytest
 from pytest import param
 
+import ibis
 from ibis.common.bases import Slotted
 from ibis.common.collections import FrozenDict
 from ibis.common.deferred import (
@@ -296,6 +297,9 @@ class ColumnMock(ValueMock):
 
     def __deferred_repr__(self):
         return f"<column[{self.dtype}]>"
+
+    def type(self):
+        return self.dtype
 
 
 class UnaryMock(ValueMock):
@@ -602,3 +606,9 @@ def test_deferred_namespace(table):
 def test_custom_deferred_repr(table):
     expr = _.x + table.a
     assert repr(expr) == "(_.x + <column[int]>)"
+
+
+def test_null_deferrable(table):
+    result = ibis.null(_.a.type()).resolve(table).op()
+    expected = ibis.null(table.a.type()).op()
+    assert result == expected

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2399,6 +2399,7 @@ class NullColumn(Column, NullValue):
 
 
 @public
+@deferrable
 def null(type: dt.DataType | str | None = None) -> Value:
     """Create a NULL scalar.
 

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -61,6 +61,7 @@ from public import public
 
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
+import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import util
 from ibis.common.collections import frozendict  # noqa: TCH001
@@ -403,7 +404,10 @@ class Across(Selector):
                 else:
                     name = names.format(col=orig_col.get_name(), fn=func_name)
 
-                expanded.append(col.name(name))
+                if not isinstance(col.op(), ops.Alias):
+                    col = col.name(name)
+
+                expanded.append(col)
 
         return expanded
 

--- a/ibis/tests/expr/test_selectors.py
+++ b/ibis/tests/expr/test_selectors.py
@@ -517,3 +517,15 @@ def test_window_function_group_by_order_by(penguins):
             order_by=[penguins.sex, penguins.year],
         )
     )
+
+
+def test_methods(penguins):
+    selector = s.across(s.all(), ibis.null(_.type()).name("foo_" + _.get_name()))
+    bound = selector.expand(penguins)
+    assert [col.get_name() for col in bound] == [
+        f"foo_{col}" for col in penguins.columns
+    ]
+
+    selector = s.across(s.all(), ibis.null(_.type()))
+    bound = selector.expand(penguins)
+    assert [col.get_name() for col in bound] == penguins.columns


### PR DESCRIPTION
Test method calls in across selector; allow naming to work in across calls.

Closes #9900.