### PR TITLE
refactor(internals): simplify the query cache

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -16,7 +16,7 @@ import ibis.config
 import ibis.expr.operations as ops
 import ibis.expr.types as ir
 from ibis import util
-from ibis.common.caching import RefCountedCache
+from ibis.common.caching import QueryCache
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Mapping, MutableMapping
@@ -805,12 +805,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         self._con_args: tuple[Any] = args
         self._con_kwargs: dict[str, Any] = kwargs
         self._can_reconnect: bool = True
-        # expression cache
-        self._query_cache = RefCountedCache(
-            populate=self._load_into_cache,
-            lookup=lambda name: self.table(name).op(),
-            finalize=self._clean_up_cached_table,
-        )
+        self._query_cache = QueryCache(self)
 
     @property
     @abc.abstractmethod

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1267,7 +1267,7 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         raise NotImplementedError(self.name)
 
     def _clean_up_cached_table(self, name):
-        raise NotImplementedError(self.name)
+        self.drop_table(name, force=True)
 
     def _transpile_sql(self, query: str, *, dialect: str | None = None) -> str:
         # only transpile if dialect was passed

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -148,10 +148,6 @@ class Backend(BaseBackend, NoUrl):
         self._tables[name] = obj
         self._context.register(name, obj)
 
-    def _remove_table(self, name: str) -> None:
-        del self._tables[name]
-        self._context.unregister(name)
-
     def sql(
         self, query: str, schema: sch.Schema | None = None, dialect: str | None = None
     ) -> ir.Table:
@@ -407,6 +403,7 @@ class Backend(BaseBackend, NoUrl):
     def drop_table(self, name: str, *, force: bool = False) -> None:
         if name in self._tables:
             del self._tables[name]
+            self._context.unregister(name)
         elif not force:
             raise com.IbisError(f"Table {name!r} does not exist")
 
@@ -557,9 +554,6 @@ class Backend(BaseBackend, NoUrl):
 
     def _load_into_cache(self, name, expr):
         self.create_table(name, self.compile(expr).cache())
-
-    def _clean_up_cached_table(self, name):
-        self._remove_table(name)
 
 
 @lazy_singledispatch

--- a/ibis/backends/polars/tests/test_client.py
+++ b/ibis/backends/polars/tests/test_client.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from ibis.backends.tests.errors import PolarsSQLInterfaceError
+from ibis.util import gen_name
+
+
+def test_cannot_run_sql_after_drop(con):
+    t = con.table("functional_alltypes")
+    n = t.count().execute()
+
+    name = gen_name("polars_dot_sql")
+    con.create_table(name, t)
+
+    sql = f"SELECT COUNT(*) FROM {name}"
+
+    expr = con.sql(sql)
+    result = expr.execute()
+    assert result.iat[0, 0] == n
+
+    con.drop_table(name)
+    with pytest.raises(PolarsSQLInterfaceError):
+        con.sql(sql)

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -257,9 +257,6 @@ class SQLBackend(BaseBackend, _DatabaseSchemaHandler):
     def _load_into_cache(self, name, expr):
         self.create_table(name, expr, schema=expr.schema(), temp=True)
 
-    def _clean_up_cached_table(self, name):
-        self.drop_table(name, force=True)
-
     def execute(
         self,
         expr: ir.Expr,

--- a/ibis/backends/tests/errors.py
+++ b/ibis/backends/tests/errors.py
@@ -65,10 +65,11 @@ try:
     from polars.exceptions import InvalidOperationError as PolarsInvalidOperationError
     from polars.exceptions import PanicException as PolarsPanicException
     from polars.exceptions import SchemaError as PolarsSchemaError
+    from polars.exceptions import SQLInterfaceError as PolarsSQLInterfaceError
 except ImportError:
     PolarsComputeError = PolarsPanicException = PolarsInvalidOperationError = (
         PolarsSchemaError
-    ) = PolarsColumnNotFoundError = None
+    ) = PolarsColumnNotFoundError = PolarsSQLInterfaceError = None
 
 try:
     from pyarrow import ArrowInvalid, ArrowNotImplementedError

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -84,9 +84,6 @@ class MockBackend(BaseBackend):
     def _load_into_cache(self, *_):
         raise NotImplementedError(self.name)
 
-    def _clean_up_cached_table(self, _):
-        raise NotImplementedError(self.name)
-
     def _get_schema_using_query(self, query):
         return self.sql_query_schemas[query]
 


### PR DESCRIPTION
Remove unnecessary generalization and parameterization of inputs to the query cache.