### PR TITLE
feat: Support read_csv for backends with no native support

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -9,6 +9,7 @@ import re
 import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
+import glob
 
 import ibis
 import ibis.common.exceptions as exc
@@ -1235,6 +1236,98 @@ class BaseBackend(abc.ABC, _FileIOHandler):
         raise NotImplementedError(
             f"{cls.name} backend has not implemented `has_operation` API"
         )
+
+  
+    def read_csv(
+            self, path: str | Path, table_name: str | None = None, **kwargs: Any
+        ) -> ir.Table:
+            """Register a CSV file as a table in the current backend.
+
+            Parameters
+            ----------
+            path
+                The data source. A string or Path to the CSV file.
+            table_name
+                An optional name to use for the created table. This defaults to
+                a sequentially generated name.
+            **kwargs
+                Additional keyword arguments passed to the backend loading function. 
+
+            Returns
+            -------
+            ir.Table
+                The just-registered table
+
+            Examples
+            --------
+            Connect to a SQLite database:
+
+            >>> con = ibis.sqlite.connect()
+
+            Read a single csv file:
+
+            >>> table = con.read_csv("path/to/file.csv")
+
+            Read all csv files in a directory:
+
+            >>> table = con.read_parquet("path/to/csv_directory/*")
+
+            Read all csv files with a glob pattern:
+
+            >>> table = con.read_csv("path/to/csv_directory/test_*.csv")
+
+            Read csv file from s3:
+
+            >>> table = con.read_csv("s3://bucket/path/to/file.csv")
+
+            """
+            pa = self._import_pyarrow()
+            import pyarrow.csv as pcsv
+            import pyarrow.fs as fs
+
+            read_options_args = {}
+            parse_options_args = {}
+            convert_options_args = {}
+            memory_pool = None
+            
+            for key, value in kwargs.items():
+                if hasattr(pcsv.ReadOptions, key):
+                    read_options_args[key] = value 
+                elif hasattr(pcsv.ParseOptions, key):
+                    parse_options_args[key] = value 
+                elif hasattr(pcsv.ConvertOptions, key):
+                    convert_options_args[key] = value
+                elif key == "memory_pool":
+                    memory_pool = value
+                else:
+                    raise ValueError(f"Invalid args: {key!r}")
+                
+            read_options = pcsv.ReadOptions(**read_options_args)
+            parse_options = pcsv.ParseOptions(**parse_options_args)
+            convert_options = pcsv.ConvertOptions(**convert_options_args)
+            if memory_pool:
+                memory_pool = pa.default_memory_pool()
+
+            path = str(path)
+            file_system, path = fs.FileSystem.from_uri(path)
+
+            if isinstance(file_system, fs.LocalFileSystem):
+                paths = glob.glob(path)
+                if not paths:
+                    raise FileNotFoundError(f"No files found at {path!r}")
+            else:
+                paths = [path] 
+
+            pyarrow_tables = []
+            for path in paths:
+                with file_system.open_input_file(path) as f:
+                    pyarrow_table = pcsv.read_csv(f, read_options=read_options, parse_options=parse_options, convert_options=convert_options, memory_pool=memory_pool)
+                    pyarrow_tables.append(pyarrow_table)
+                          
+            pyarrow_table = pa.concat_tables(pyarrow_tables)
+            table_name = table_name or util.gen_name("read_csv")
+            self.create_table(table_name, pyarrow_table)
+            return self.table(table_name)
 
     def _cached(self, expr: ir.Table):
         """Cache the provided expression.

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -488,14 +488,7 @@ def test_read_parquet_glob(con, tmp_path, ft_data):
 @pytest.mark.notyet(
     [
         "flink",
-        "impala",
-        "mssql",
-        "mysql",
         "pandas",
-        "postgres",
-        "risingwave",
-        "sqlite",
-        "trino",
     ]
 )
 def test_read_csv_glob(con, tmp_path, ft_data):
@@ -578,13 +571,13 @@ DIAMONDS_COLUMN_TYPES = {
     [param(None, id="default"), param("fancy_stones", id="file_name")],
 )
 @pytest.mark.notyet(
-    ["flink", "impala", "mssql", "mysql", "postgres", "risingwave", "sqlite", "trino"]
+    ["flink"]
 )
 def test_read_csv(con, data_dir, in_table_name, num_diamonds):
     fname = "diamonds.csv"
     with pushd(data_dir / "csv"):
-        if con.name == "pyspark":
-            # pyspark doesn't respect CWD
+        if con.name in ("pyspark", "sqlite"):
+            # pyspark and sqlite doesn't respect CWD
             fname = str(Path(fname).absolute())
         table = con.read_csv(fname, table_name=in_table_name)
 

--- a/ibis/backends/tests/test_register.py
+++ b/ibis/backends/tests/test_register.py
@@ -570,9 +570,7 @@ DIAMONDS_COLUMN_TYPES = {
     "in_table_name",
     [param(None, id="default"), param("fancy_stones", id="file_name")],
 )
-@pytest.mark.notyet(
-    ["flink"]
-)
+@pytest.mark.notyet(["flink"])
 def test_read_csv(con, data_dir, in_table_name, num_diamonds):
     fname = "diamonds.csv"
     with pushd(data_dir / "csv"):


### PR DESCRIPTION


## Description of changes

For backends that lack native read_csv support, `pyarrow.csv.read_csv()` will be used.

- Read a single file
- Read all files in a directory, something like this:  `./directory/*`
- Read files matching a glob pattern
- Support cloud storage systems like S3 and GCP


## Issues closed

Partially solve #9448 
