### PR TITLE
chore(datafusion): unxfail passing `approx_quantile` test

### DIFF
--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -876,23 +876,7 @@ def test_quantile(
     assert pytest.approx(result) == expected
 
 
-@pytest.mark.parametrize(
-    "filtered",
-    [
-        False,
-        param(
-            True,
-            marks=[
-                pytest.mark.notyet(
-                    ["datafusion"],
-                    raises=Exception,
-                    reason="datafusion 38.0.1 has a bug in FILTER handling that causes this test to fail",
-                    strict=False,
-                )
-            ],
-        ),
-    ],
-)
+@pytest.mark.parametrize("filtered", [False, True])
 @pytest.mark.parametrize(
     "multi",
     [


### PR DESCRIPTION
Test added in #9881 now passes since #9884.