### PR TITLE
chore(oracle): remove duplicate `ops.Hash` specification

### DIFF
--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -84,11 +84,11 @@ class OracleCompiler(SQLGlotCompiler):
         ops.BitXor: "bit_xor_agg",
         ops.BitwiseAnd: "bitand",
         ops.Hash: "hash",
+        ops.Hash: "ora_hash",
         ops.LPad: "lpad",
         ops.RPad: "rpad",
         ops.StringAscii: "ascii",
         ops.Strip: "trim",
-        ops.Hash: "ora_hash",
     }
 
     @staticmethod

--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -83,7 +83,6 @@ class OracleCompiler(SQLGlotCompiler):
         ops.BitOr: "bit_or_agg",
         ops.BitXor: "bit_xor_agg",
         ops.BitwiseAnd: "bitand",
-        ops.Hash: "hash",
         ops.Hash: "ora_hash",
         ops.LPad: "lpad",
         ops.RPad: "rpad",


### PR DESCRIPTION
Remove a duplicate `ops.Hash` mapping in the Oracle backend `SIMPLE_OPS` mapping.