### PR TITLE
fix(oracle): implement current_catalog and current_database correctly

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -615,11 +615,6 @@ class CanListCatalog(abc.ABC):
 
         """
 
-    @property
-    @abc.abstractmethod
-    def current_catalog(self) -> str:
-        """The current catalog in use."""
-
 
 class CanCreateCatalog(CanListCatalog):
     @abc.abstractmethod
@@ -705,11 +700,6 @@ class CanListDatabase(abc.ABC):
             the `like` pattern if provided.
 
         """
-
-    @property
-    @abc.abstractmethod
-    def current_database(self) -> str:
-        """The current database in use."""
 
 
 class CanCreateDatabase(CanListDatabase):

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -235,14 +235,6 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         self._log(query)
         return self.con.sql(query)
 
-    @property
-    def current_catalog(self) -> str:
-        raise NotImplementedError()
-
-    @property
-    def current_database(self) -> str:
-        raise NotImplementedError()
-
     def list_catalogs(self, like: str | None = None) -> list[str]:
         code = (
             sg.select(C.table_catalog)

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -192,8 +192,16 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
         return self
 
     @property
-    def current_database(self) -> str:
+    def current_catalog(self) -> str:
         with self._safe_raw_sql(sg.select(STAR).from_("global_name")) as cur:
+            [(catalog,)] = cur.fetchall()
+        return catalog
+
+    @property
+    def current_database(self) -> str:
+        # databases correspond to users, other than that there's
+        # no notion of a database inside a catalog for oracle
+        with self._safe_raw_sql(sg.select("user").from_("dual")) as cur:
             [(database,)] = cur.fetchall()
         return database
 

--- a/ibis/backends/tests/test_api.py
+++ b/ibis/backends/tests/test_api.py
@@ -25,6 +25,7 @@ def test_version(backend):
         "clickhouse",
         "sqlite",
         "dask",
+        "datafusion",
         "exasol",
         "pandas",
         "druid",
@@ -36,11 +37,6 @@ def test_version(backend):
     ],
     reason="backend does not support catalogs",
     raises=AttributeError,
-)
-@pytest.mark.notimpl(
-    ["datafusion"],
-    raises=NotImplementedError,
-    reason="current_catalog isn't implemented",
 )
 @pytest.mark.xfail_version(pyspark=["pyspark<3.4"])
 def test_catalog_consistency(backend, con):

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1753,24 +1753,13 @@ def test_cross_database_join(con_create_database, monkeypatch):
     ["impala", "pyspark", "trino"], reason="Default constraints are not supported"
 )
 def test_insert_into_table_missing_columns(con, temp_table):
-    try:
-        db = getattr(con, "current_database", None)
-    except NotImplementedError:
-        db = None
+    db = getattr(con, "current_database", None)
 
-    # UGH
-    if con.name == "oracle":
-        db = None
-
-    try:
-        catalog = getattr(con, "current_catalog", None)
-    except NotImplementedError:
-        catalog = None
-
-    raw_ident = ".".join(
-        sg.to_identifier(i, quoted=True).sql("duckdb")
-        for i in filter(None, (catalog, db, temp_table))
-    )
+    raw_ident = sg.table(
+        temp_table,
+        db=db if db is None else sg.to_identifier(db, quoted=True),
+        quoted=True,
+    ).sql("duckdb")
 
     ct_sql = f'CREATE TABLE {raw_ident} ("a" INT DEFAULT 1, "b" INT)'
     sg_expr = sg.parse_one(ct_sql, read="duckdb")


### PR DESCRIPTION
Fixes some hacks around `current_catalog` and `current_database` for the Oracle backend