### PR TITLE
perf(dot-columns): speed up heavily used `.columns`

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -221,7 +221,7 @@ class _FileIOHandler:
             table = pa.Table.from_batches(reader, schema=arrow_schema)
 
         return expr.__pyarrow_result__(
-            table.rename_columns(table_expr.columns).cast(arrow_schema)
+            table.rename_columns(list(table_expr.columns)).cast(arrow_schema)
         )
 
     @util.experimental

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -196,7 +196,7 @@ def test_parted_column(con, kind):
     table_name = f"{kind}_column_parted"
     t = con.table(table_name)
     expected_column = f"my_{kind}_parted_col"
-    assert t.columns == [expected_column, "string_col", "int_col"]
+    assert t.columns == (expected_column, "string_col", "int_col")
 
 
 def test_cross_project_query(public):

--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -334,5 +334,5 @@ def test_varchar_char_support(temp_char_table):
 
 
 def test_access_kudu_table(kudu_table):
-    assert kudu_table.columns == ["a"]
+    assert kudu_table.columns == ("a",)
     assert kudu_table["a"].type() == dt.string

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -667,7 +667,7 @@ def test_where_with_timestamp(snapshot):
 
 def test_filter_with_analytic(snapshot):
     x = ibis.table(ibis.schema([("col", "int32")]), "x")
-    with_filter_col = x.select(x.columns + [ibis.null().name("filter")])
+    with_filter_col = x.select(*x.columns, ibis.null().name("filter"))
     filtered = with_filter_col.filter(with_filter_col["filter"].isnull())
     subquery = filtered.select(filtered.columns)
 

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -303,7 +303,7 @@ def test_insert(con):
             }
         ],
     )
-    assert t.columns == ["ID", "NAME", "SCORE_1", "SCORE_2", "SCORE_3", "AGE"]
+    assert t.columns == ("ID", "NAME", "SCORE_1", "SCORE_2", "SCORE_3", "AGE")
     assert t.count().execute() == 1
 
 

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1615,7 +1615,7 @@ def test_group_concat_over_window(backend, con):
 
 def test_value_counts_on_expr(backend, alltypes, df):
     expr = alltypes.bigint_col.add(1).value_counts()
-    columns = expr.columns
+    columns = list(expr.columns)
     expr = expr.order_by(columns)
     result = expr.execute().sort_values(columns).reset_index(drop=True)
     expected = df.bigint_col.add(1).value_counts().reset_index()

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -1687,7 +1687,7 @@ def test_cross_database_join(con_create_database, monkeypatch):
     )
 
     expr = left.join(right, "a")
-    assert expr.columns == ["a", "b", "c"]
+    assert expr.columns == ("a", "b", "c")
 
     result = expr.to_pyarrow()
     expected = pa.Table.from_pydict({"a": [1], "b": [2], "c": [3]})

--- a/ibis/backends/tests/test_examples.py
+++ b/ibis/backends/tests/test_examples.py
@@ -61,5 +61,5 @@ pytest.importorskip("pins")
 )
 def test_load_examples(con, example, columns):
     t = getattr(ibis.examples, example).fetch(backend=con)
-    assert t.columns == columns
+    assert t.columns == tuple(columns)
     assert t.count().execute() > 0

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -722,8 +722,8 @@ def test_order_by_two_cols_nulls(con, op1, nf1, nf2, op2, expected):
 def test_table_info(alltypes):
     expr = alltypes.info()
     df = expr.execute()
-    assert alltypes.columns == list(df.name)
-    assert expr.columns == [
+    assert alltypes.columns == tuple(df.name)
+    assert expr.columns == (
         "name",
         "type",
         "nullable",
@@ -731,8 +731,8 @@ def test_table_info(alltypes):
         "non_nulls",
         "null_frac",
         "pos",
-    ]
-    assert expr.columns == list(df.columns)
+    )
+    assert expr.columns == tuple(df.columns)
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_set_ops.py
+++ b/ibis/backends/tests/test_set_ops.py
@@ -16,7 +16,7 @@ pd = pytest.importorskip("pandas")
 
 @pytest.fixture
 def union_subsets(alltypes, df):
-    cols_a, cols_b, cols_c = (alltypes.columns.copy() for _ in range(3))
+    cols_a, cols_b, cols_c = (list(alltypes.columns) for _ in range(3))
 
     random.seed(89)
     random.shuffle(cols_a)

--- a/ibis/expr/types/dataframe_interchange.py
+++ b/ibis/expr/types/dataframe_interchange.py
@@ -68,7 +68,7 @@ class IbisDataFrame:
         return len(self._table.columns)
 
     def column_names(self):
-        return self._table.columns
+        return list(self._table.columns)
 
     def get_column(self, i: int) -> IbisColumn:
         name = self._table.columns[i]

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -674,8 +674,9 @@ class Table(Expr, _FixedTextJupyterMixin):
             limit, offset = util.slice_to_limit_offset(what, self.count())
             return self.limit(limit, offset=offset)
 
+        columns = self.columns
         args = [
-            self.columns[arg] if isinstance(arg, int) else arg
+            columns[arg] if isinstance(arg, int) else arg
             for arg in util.promote_list(what)
         ]
         if util.all_of(args, str):
@@ -765,8 +766,8 @@ class Table(Expr, _FixedTextJupyterMixin):
         return self.columns
 
     @property
-    def columns(self) -> list[str]:
-        """The list of column names in this table.
+    def columns(self) -> tuple[str, ...]:
+        """Return a [](`tuple`) of column names in this table.
 
         Examples
         --------
@@ -774,16 +775,16 @@ class Table(Expr, _FixedTextJupyterMixin):
         >>> ibis.options.interactive = True
         >>> t = ibis.examples.penguins.fetch()
         >>> t.columns
-        ['species',
+        ('species',
          'island',
          'bill_length_mm',
          'bill_depth_mm',
          'flipper_length_mm',
          'body_mass_g',
          'sex',
-         'year']
+         'year')
         """
-        return list(self.schema().names)
+        return self._arg.schema.names
 
     def schema(self) -> sch.Schema:
         """Return the [Schema](./schemas.qmd#ibis.expr.schema.Schema) for this table.

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -413,7 +413,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         Columns not present in the input schema will be passed through unchanged
 
         >>> t.columns
-        ['species', 'island', 'bill_length_mm', 'bill_depth_mm', 'flipper_length_mm', 'body_mass_g', 'sex', 'year']
+        ('species', 'island', 'bill_length_mm', 'bill_depth_mm', 'flipper_length_mm', 'body_mass_g', 'sex', 'year')
         >>> expr = t.cast({"body_mass_g": "float64", "bill_length_mm": "int"})
         >>> expr.select(*cols).head()
         ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
@@ -3263,7 +3263,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         │ …       │ …         │              … │             … │                 … │ … │
         └─────────┴───────────┴────────────────┴───────────────┴───────────────────┴───┘
         >>> expr.columns
-        ['species',
+        ('species',
          'island',
          'bill_length_mm',
          'bill_depth_mm',
@@ -3274,7 +3274,7 @@ class Table(Expr, _FixedTextJupyterMixin):
          'bill_length_mm_right',
          'bill_depth_mm_right',
          'flipper_length_mm_right',
-         'body_mass_g_right']
+         'body_mass_g_right')
         >>> expr.count()
         ┌─────┐
         │ 344 │

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -19,14 +19,14 @@ Without selectors this becomes quite verbose and tedious to write:
 >>> t = ibis.table(dict(a="int", b="string", c="array<int>", abcd="float"))
 >>> expr = t.select([t[c] for c in t.columns if t[c].type().is_numeric()])
 >>> expr.columns
-['a', 'abcd']
+('a', 'abcd')
 
 Compare that to the [`numeric`](#ibis.selectors.numeric) selector:
 
 >>> import ibis.selectors as s
 >>> expr = t.select(s.numeric())
 >>> expr.columns
-['a', 'abcd']
+('a', 'abcd')
 
 When there are multiple properties to check it gets worse:
 
@@ -39,13 +39,13 @@ When there are multiple properties to check it gets worse:
 ...     ]
 ... )
 >>> expr.columns
-['a', 'b', 'abcd']
+('a', 'b', 'abcd')
 
 Using a composition of selectors this is much less tiresome:
 
 >>> expr = t.select((s.numeric() | s.of_type("string")) & s.contains(("a", "b", "cd")))
 >>> expr.columns
-['a', 'b', 'abcd']
+('a', 'b', 'abcd')
 """
 
 from __future__ import annotations
@@ -112,7 +112,7 @@ def where(predicate: Callable[[ir.Value], bool]) -> Selector:
     >>> t = ibis.table(dict(a="float32"), name="t")
     >>> expr = t.select(s.where(lambda col: col.get_name() == "a"))
     >>> expr.columns
-    ['a']
+    ('a',)
 
     """
     return Where(predicate)
@@ -128,10 +128,10 @@ def numeric() -> Selector:
     >>> import ibis.selectors as s
     >>> t = ibis.table(dict(a="int", b="string", c="array<string>"), name="t")
     >>> t.columns
-    ['a', 'b', 'c']
+    ('a', 'b', 'c')
     >>> expr = t.select(s.numeric())  # `a` has integer type, so it's numeric
     >>> expr.columns
-    ['a']
+    ('a',)
 
     See Also
     --------
@@ -168,13 +168,13 @@ def of_type(dtype: dt.DataType | str | type[dt.DataType]) -> Selector:
     >>> t = ibis.table(dict(name="string", siblings="array<string>", parents="array<int64>"))
     >>> expr = t.select(s.of_type(dt.Array(dt.string)))
     >>> expr.columns
-    ['siblings']
+    ('siblings',)
 
     Strings are also accepted
 
     >>> expr = t.select(s.of_type("array<string>"))
     >>> expr.columns
-    ['siblings']
+    ('siblings',)
 
     Abstract/unparametrized types may also be specified by their string name
     (e.g. "integer" for any integer type), or by passing in a `DataType` class
@@ -185,7 +185,7 @@ def of_type(dtype: dt.DataType | str | type[dt.DataType]) -> Selector:
     >>> expr1.equals(expr2)
     True
     >>> expr2.columns
-    ['siblings', 'parents']
+    ('siblings', 'parents')
 
     See Also
     --------
@@ -247,7 +247,7 @@ def startswith(prefixes: str | tuple[str, ...]) -> Selector:
     >>> t = ibis.table(dict(apples="int", oranges="float", bananas="bool"), name="t")
     >>> expr = t.select(s.startswith(("a", "b")))
     >>> expr.columns
-    ['apples', 'bananas']
+    ('apples', 'bananas')
 
     See Also
     --------
@@ -319,14 +319,14 @@ def contains(
     ... )
     >>> expr = t.select(s.contains(("a", "b")))
     >>> expr.columns
-    ['a', 'b', 'ab']
+    ('a', 'b', 'ab')
 
     Select columns that contain all of `"a"` and `"b"`, that is, both `"a"` and
     `"b"` must be in each column's name to match.
 
     >>> expr = t.select(s.contains(("a", "b"), how=all))
     >>> expr.columns
-    ['ab']
+    ('ab',)
 
     See Also
     --------
@@ -359,7 +359,7 @@ def matches(regex: str | re.Pattern) -> Selector:
     >>> t = ibis.table(dict(ab="string", abd="int", be="array<string>"))
     >>> expr = t.select(s.matches(r"ab+"))
     >>> expr.columns
-    ['ab', 'abd']
+    ('ab', 'abd')
 
     See Also
     --------
@@ -410,7 +410,7 @@ def cols(*names: str | ir.Column) -> Selector:
     >>> t = ibis.table({"a": "int", "b": "int", "c": "int"})
     >>> expr = t.select(s.cols("a", "b"))
     >>> expr.columns
-    ['a', 'b']
+    ('a', 'b')
 
     See Also
     --------

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -993,6 +993,13 @@ def test_selectors(benchmark, cols):
     benchmark(sel.expand, t)
 
 
+@pytest.mark.parametrize("ncols", [10_000, 100_000, 1_000_000])
+def test_dot_columns(benchmark, ncols):
+    t = ibis.table(name="t", schema={f"col{i}": "int" for i in range(ncols)})
+    result = benchmark(lambda t: t.columns, t)
+    assert len(result) == ncols
+
+
 def test_dedup_schema_failure_mode(benchmark):
     def dedup_schema(pairs):
         with contextlib.suppress(exc.IntegrityError):

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -186,12 +186,12 @@ def test_filter_self_join():
 
 def test_is_ancestor_analytic():
     x = ibis.table(ibis.schema([("col", "int32")]), "x")
-    with_filter_col = x.select(x.columns + [ibis.null().name("filter")])
+    with_filter_col = x.select(*x.columns, ibis.null().name("filter"))
     filtered = with_filter_col.filter(with_filter_col["filter"].isnull())
-    subquery = filtered.select(filtered.columns)
+    subquery = filtered.select(*filtered.columns)
 
     with_analytic = subquery.select(
-        subquery.columns + [subquery.count().name("analytic")]
+        *subquery.columns, subquery.count().name("analytic")
     )
 
     assert not subquery.op().equals(with_analytic.op())

--- a/ibis/tests/expr/test_analytics.py
+++ b/ibis/tests/expr/test_analytics.py
@@ -116,10 +116,10 @@ def test_topk_function_late_bind(airlines):
 def test_topk_name(airlines):
     expr1 = airlines.dest.topk(5, name="mycol")
     expr2 = airlines.dest.topk(5, by=_.count().name("mycol"))
-    assert expr1.columns == ["dest", "mycol"]
+    assert expr1.columns == ("dest", "mycol")
     assert_equal(expr1, expr2)
 
     expr3 = airlines.dest.topk(5, by=_.arrdelay.mean(), name="mycol")
     expr4 = airlines.dest.topk(5, by=_.arrdelay.mean().name("mycol"))
-    assert expr3.columns == ["dest", "mycol"]
+    assert expr3.columns == ("dest", "mycol")
     assert_equal(expr3, expr4)

--- a/ibis/tests/expr/test_relocate.py
+++ b/ibis/tests/expr/test_relocate.py
@@ -9,31 +9,31 @@ import ibis.selectors as s
 
 def test_individual_columns():
     t = ibis.table(dict(x="int", y="int"))
-    assert t.relocate("x", after="y").columns == list("yx")
-    assert t.relocate("y", before="x").columns == list("yx")
+    assert t.relocate("x", after="y").columns == tuple("yx")
+    assert t.relocate("y", before="x").columns == tuple("yx")
 
 
 def test_move_blocks():
     t = ibis.table(dict(x="int", a="string", y="int", b="string"))
-    assert t.relocate(s.of_type("string")).columns == list("abxy")
-    assert t.relocate(s.of_type("string"), after=s.numeric()).columns == list("xyab")
+    assert t.relocate(s.of_type("string")).columns == tuple("abxy")
+    assert t.relocate(s.of_type("string"), after=s.numeric()).columns == tuple("xyab")
 
 
 def test_duplicates_not_renamed():
     t = ibis.table(dict(x="int", y="int"))
-    assert t.relocate("y", s.numeric()).columns == list("yx")
-    assert t.relocate("y", s.numeric(), "y").columns == list("yx")
+    assert t.relocate("y", s.numeric()).columns == tuple("yx")
+    assert t.relocate("y", s.numeric(), "y").columns == tuple("yx")
 
 
 def test_keep_non_contiguous_variables():
     t = ibis.table(dict.fromkeys("abcde", "int"))
-    assert t.relocate("b", after=s.cols("a", "c", "e")).columns == list("acdeb")
-    assert t.relocate("e", before=s.cols("b", "d")).columns == list("aebcd")
+    assert t.relocate("b", after=s.cols("a", "c", "e")).columns == tuple("acdeb")
+    assert t.relocate("e", before=s.cols("b", "d")).columns == tuple("aebcd")
 
 
 def test_before_after_does_not_move_to_front():
     t = ibis.table(dict(x="int", y="int"))
-    assert t.relocate("y").columns == list("yx")
+    assert t.relocate("y").columns == tuple("yx")
 
 
 def test_only_one_of_before_and_after():
@@ -45,47 +45,47 @@ def test_only_one_of_before_and_after():
 
 def test_respects_order():
     t = ibis.table(dict.fromkeys("axbzy", "int"))
-    assert t.relocate("x", "y", "z", before="x").columns == list("axyzb")
-    assert t.relocate("x", "y", "z", before=s.last()).columns == list("abxyz")
-    assert t.relocate("x", "a", "z").columns == list("xazby")
+    assert t.relocate("x", "y", "z", before="x").columns == tuple("axyzb")
+    assert t.relocate("x", "y", "z", before=s.last()).columns == tuple("abxyz")
+    assert t.relocate("x", "a", "z").columns == tuple("xazby")
 
 
 def test_relocate_can_rename():
     t = ibis.table(dict(a="int", b="int", c="int", d="string", e="string", f=r"string"))
-    assert t.relocate(ffff="f").columns == ["ffff", *"abcde"]
-    assert t.relocate(ffff="f", before="c").columns == [*"ab", "ffff", *"cde"]
-    assert t.relocate(ffff="f", after="c").columns == [*"abc", "ffff", *"de"]
+    assert t.relocate(ffff="f").columns == ("ffff", *"abcde")
+    assert t.relocate(ffff="f", before="c").columns == (*"ab", "ffff", *"cde")
+    assert t.relocate(ffff="f", after="c").columns == (*"abc", "ffff", *"de")
 
 
 def test_retains_last_duplicate_when_renaming_and_moving():
     t = ibis.table(dict(x="int"))
-    assert t.relocate(a="x", b="x").columns == ["b"]
+    assert t.relocate(a="x", b="x").columns == ("b",)
 
     # TODO: test against .rename once that's implemented
 
     t = ibis.table(dict(x="int", y="int"))
-    assert t.relocate(a="x", b="y", c="x").columns == list("bc")
+    assert t.relocate(a="x", b="y", c="x").columns == tuple("bc")
 
 
 def test_everything():
     t = ibis.table(dict(w="int", x="int", y="int", z="int"))
-    assert t.relocate("y", "z", before=s.all()).columns == list("yzwx")
-    assert t.relocate("y", "z", after=s.all()).columns == list("wxyz")
+    assert t.relocate("y", "z", before=s.all()).columns == tuple("yzwx")
+    assert t.relocate("y", "z", after=s.all()).columns == tuple("wxyz")
 
 
 def test_moves_to_front_with_no_before_and_no_after():
     t = ibis.table(dict(x="int", y="int", z="int"))
-    assert t.relocate("z", "y").columns == list("zyx")
+    assert t.relocate("z", "y").columns == tuple("zyx")
 
 
 def test_empty_before_moves_to_front():
     t = ibis.table(dict(x="int", y="int", z="int"))
-    assert t.relocate("y", before=s.of_type("string")).columns == list("yxz")
+    assert t.relocate("y", before=s.of_type("string")).columns == tuple("yxz")
 
 
 def test_empty_after_moves_to_end():
     t = ibis.table(dict(x="int", y="int", z="int"))
-    assert t.relocate("y", after=s.of_type("string")).columns == list("xzy")
+    assert t.relocate("y", after=s.of_type("string")).columns == tuple("xzy")
 
 
 def test_no_arguments():
@@ -96,7 +96,7 @@ def test_no_arguments():
 
 def test_tuple_input():
     t = ibis.table(dict(x="int", y="int", z="int"))
-    assert t.relocate(("y", "z")).columns == list("yzx")
+    assert t.relocate(("y", "z")).columns == tuple("yzx")
 
     # not allowed, because this would be technically inconsistent with `select`
     # though, the tuple is unambiguous here and could never be interpreted as a

--- a/ibis/tests/expr/test_selectors.py
+++ b/ibis/tests/expr/test_selectors.py
@@ -537,7 +537,7 @@ def test_methods(penguins):
 
     selector = s.across(s.all(), ibis.null(_.type()))
     bound = selector.expand(penguins)
-    assert [col.get_name() for col in bound] == penguins.columns
+    assert [col.get_name() for col in bound] == list(penguins.columns)
 
 
 @pytest.mark.parametrize("sel", [s.none(), s.cols(), []])

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -874,18 +874,18 @@ def test_group_by_column_select_api(table):
 def test_value_counts(table):
     expr1 = table.g.value_counts()
     expr2 = table[["g"]].group_by("g").aggregate(g_count=_.count())
-    assert expr1.columns == ["g", "g_count"]
+    assert expr1.columns == ("g", "g_count")
     assert_equal(expr1, expr2)
 
     expr3 = table.g.value_counts(name="freq")
     expr4 = table[["g"]].group_by("g").aggregate(freq=_.count())
-    assert expr3.columns == ["g", "freq"]
+    assert expr3.columns == ("g", "freq")
     assert_equal(expr3, expr4)
 
 
 def test_value_counts_on_window_function(table):
     expr = (table.a - table.a.mean()).name("x").value_counts(name="count")
-    assert expr.columns == ["x", "count"]
+    assert expr.columns == ("x", "count")
 
 
 def test_value_counts_unnamed_expr(con):


### PR DESCRIPTION
## Description of changes

This PR changes the `Table.columns` property to return the underlying
`tuple` of names from the operation's `schema` attribute.

Right now, every `.columns` access incurs the overhead of creating a `list`,
which remained for backwards compatibility.

I was refactoring selectors in #9917, and noticed some performance differences
that boiled down to accessing this attribute many times in the case of
selectors operating on very wide tables.

The other approach I considered was t continue returning a `list`, and speed up
the access using `functools.cached_property`.

While this doesn't break the API, it seemed incredibly wasteful to store two
copies of every table's columns, especially in these slower cases where
tables have a ton of columns.

BREAKING CHANGE: `Table.columns` is now a `tuple` instead of a `list`. Your usage of `.columns` may require updating if you're depending specifically on `.columns` being a `list`.
