### PR TITLE
fix(polars): use `drop_table` when cleaning the cache and remove duplicated `_remove_table` method

### DIFF
--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -148,10 +148,6 @@ class Backend(BaseBackend, NoUrl):
         self._tables[name] = obj
         self._context.register(name, obj)
 
-    def _remove_table(self, name: str) -> None:
-        del self._tables[name]
-        self._context.unregister(name)
-
     def sql(
         self, query: str, schema: sch.Schema | None = None, dialect: str | None = None
     ) -> ir.Table:
@@ -407,6 +403,7 @@ class Backend(BaseBackend, NoUrl):
     def drop_table(self, name: str, *, force: bool = False) -> None:
         if name in self._tables:
             del self._tables[name]
+            self._context.unregister(name)
         elif not force:
             raise com.IbisError(f"Table {name!r} does not exist")
 
@@ -559,7 +556,7 @@ class Backend(BaseBackend, NoUrl):
         self.create_table(name, self.compile(expr).cache())
 
     def _clean_up_cached_table(self, name):
-        self._remove_table(name)
+        self.drop_table(name, force=True)
 
 
 @lazy_singledispatch

--- a/ibis/backends/polars/tests/test_client.py
+++ b/ibis/backends/polars/tests/test_client.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from ibis.backends.tests.errors import PolarsSQLInterfaceError
+from ibis.util import gen_name
+
+
+def test_cannot_run_sql_after_drop(con):
+    t = con.table("functional_alltypes")
+    n = t.count().execute()
+
+    name = gen_name("polars_dot_sql")
+    con.create_table(name, t)
+
+    sql = f"SELECT COUNT(*) FROM {name}"
+
+    expr = con.sql(sql)
+    result = expr.execute()
+    assert result.iat[0, 0] == n
+
+    con.drop_table(name)
+    with pytest.raises(PolarsSQLInterfaceError):
+        con.sql(sql)

--- a/ibis/backends/tests/errors.py
+++ b/ibis/backends/tests/errors.py
@@ -65,10 +65,11 @@ try:
     from polars.exceptions import InvalidOperationError as PolarsInvalidOperationError
     from polars.exceptions import PanicException as PolarsPanicException
     from polars.exceptions import SchemaError as PolarsSchemaError
+    from polars.exceptions import SQLInterfaceError as PolarsSQLInterfaceError
 except ImportError:
     PolarsComputeError = PolarsPanicException = PolarsInvalidOperationError = (
         PolarsSchemaError
-    ) = PolarsColumnNotFoundError = None
+    ) = PolarsColumnNotFoundError = PolarsSQLInterfaceError = None
 
 try:
     from pyarrow import ArrowInvalid, ArrowNotImplementedError


### PR DESCRIPTION
Fixes an issue in the polars backend where tables were still visible in SQL queries after being dropped. Ripped out of #9903.