### PR TITLE
fix(trino): remove hack that silently breaks join transpilation

### DIFF
--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -446,18 +446,9 @@ Snowflake.Generator.TRANSFORMS |= {
 SQLite.Generator.TYPE_MAPPING |= {sge.DataType.Type.BOOLEAN: "BOOLEAN"}
 
 
-# TODO(cpcloud): remove this hack once
-# https://github.com/tobymao/sqlglot/issues/2735 is resolved
-def make_cross_joins_explicit(node):
-    if not (node.kind or node.side):
-        node.args["kind"] = "CROSS"
-    return node
-
-
 Trino.Generator.TRANSFORMS |= {
     sge.BitwiseLeftShift: rename_func("bitwise_left_shift"),
     sge.BitwiseRightShift: rename_func("bitwise_right_shift"),
     sge.FirstValue: rename_func("first_value"),
-    sge.Join: transforms.preprocess([make_cross_joins_explicit]),
     sge.LastValue: rename_func("last_value"),
 }

--- a/ibis/backends/sql/tests/test_compiler.py
+++ b/ibis/backends/sql/tests/test_compiler.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import sqlglot as sg
+
 import ibis
 from ibis import _
+from ibis.backends.sql.dialects import Trino
 
 
 def test_window_with_row_number_compiles():
@@ -16,3 +19,10 @@ def test_window_with_row_number_compiles():
         .filter(~_.is_test)
     )
     assert ibis.to_sql(expr)
+
+
+def test_transpile_join():
+    (result,) = sg.transpile(
+        "SELECT * FROM t1 JOIN t2 ON x = y", read="duckdb", write=Trino
+    )
+    assert "CROSS JOIN" not in result


### PR DESCRIPTION
Fixes an issue discovered in #9933 where my failing to remove a workaround caused a bug in transpilation joins.