### PR TITLE
test(cleanup): remove dead `xfail_version` clutter

### DIFF
--- a/ibis/backends/datafusion/tests/test_select.py
+++ b/ibis/backends/datafusion/tests/test_select.py
@@ -7,10 +7,6 @@ from ibis.backends.datafusion.tests.conftest import BackendTest
 pytest.importorskip("datafusion")
 
 
-@pytest.mark.xfail_version(
-    datafusion=["datafusion==28.0.0"],
-    reason="datafusion panics with with the float_col * 2 filter",
-)
 def test_where_multiple_conditions(alltypes, alltypes_df):
     expr = alltypes.filter(
         [

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -126,20 +126,14 @@ argidx_not_grouped_marks = [
 ]
 
 
-def make_argidx_params(marks, grouped=False):
+def make_argidx_params(marks):
     marks = [pytest.mark.notyet(marks, raises=com.OperationNotDefinedError)]
     return [
         param(
             lambda t: t.timestamp_col.argmin(t.id),
             lambda s: s.timestamp_col.iloc[s.id.argmin()],
             id="argmin",
-            marks=marks
-            + [
-                pytest.mark.xfail_version(
-                    polars=["polars>=0.19.12,<1"], raises=BaseException
-                )
-            ]
-            * grouped,
+            marks=marks,
         ),
         param(
             lambda t: t.double_col.argmax(t.id),
@@ -167,7 +161,7 @@ def test_aggregate(backend, alltypes, df, result_fn, expected_fn):
 
 @pytest.mark.parametrize(
     ("result_fn", "expected_fn"),
-    aggregate_test_params + make_argidx_params(argidx_not_grouped_marks, grouped=True),
+    aggregate_test_params + make_argidx_params(argidx_not_grouped_marks),
 )
 def test_aggregate_grouped(backend, alltypes, df, result_fn, expected_fn):
     grouping_key_col = "bigint_col"
@@ -1596,9 +1590,6 @@ def test_agg_sort(alltypes):
         query.order_by(alltypes.year)
 
 
-@pytest.mark.xfail_version(
-    polars=["polars==0.14.31"], reason="projection of scalars is broken"
-)
 def test_filter(backend, alltypes, df):
     expr = (
         alltypes[_.string_col == "1"]

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -58,11 +58,7 @@ def check_eq(left, right, how, **kwargs):
             # TODO: mysql will likely never support full outer join
             # syntax, but we might be able to work around that using
             # LEFT JOIN UNION RIGHT JOIN
-            marks=[
-                pytest.mark.notimpl(["mysql"]),
-                sqlite_right_or_full_mark,
-                pytest.mark.xfail_version(datafusion=["datafusion<31"]),
-            ],
+            marks=[pytest.mark.notimpl(["mysql"]), sqlite_right_or_full_mark],
         ),
     ],
 )

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -241,9 +241,6 @@ def test_map_table(backend):
 
 
 @pytest.mark.notimpl(["pandas", "dask"])
-@pytest.mark.xfail_version(
-    duckdb=["duckdb<0.8.0"], raises=exc.UnsupportedOperationError
-)
 @mark_notimpl_risingwave_hstore
 def test_column_map_values(backend):
     table = backend.map
@@ -254,9 +251,6 @@ def test_column_map_values(backend):
 
 
 @pytest.mark.notimpl(["pandas", "dask"])
-@pytest.mark.xfail_version(
-    duckdb=["duckdb<0.8.0"], raises=exc.UnsupportedOperationError
-)
 def test_column_map_merge(backend):
     table = backend.map
     expr = table.select(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -638,7 +638,6 @@ def test_string(backend, alltypes, df, result_func, expected_func):
                         "Polars does not support columnar argument Subtract(StringLength(date_string_col), 1)"
                     ),
                 ),
-                pytest.mark.xfail_version(datafusion=["datafusion==35"]),
             ],
         ),
         param(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -20,7 +20,6 @@ from ibis.backends.conftest import is_older_than
 from ibis.backends.tests.errors import (
     ArrowInvalid,
     ClickHouseDatabaseError,
-    DuckDBBinderException,
     DuckDBInvalidInputException,
     ExaQueryError,
     GoogleBadRequest,
@@ -978,12 +977,6 @@ no_mixed_timestamp_comparisons = [
         raises=TypeError,
         reason="Invalid comparison between dtype=datetime64[ns, UTC] and datetime",
     ),
-    pytest.mark.xfail_version(
-        duckdb=["duckdb>=0.10,<0.10.2"],
-        raises=DuckDBBinderException,
-        # perhaps we should consider disallowing this in ibis as well
-        reason="DuckDB doesn't allow comparing timestamp with and without timezones starting at version 0.10",
-    ),
 ]
 
 
@@ -1674,8 +1667,8 @@ INTERVAL_BACKEND_TYPES = {
     reason="BigQuery returns DateOffset arrays",
     raises=AssertionError,
 )
-@pytest.mark.xfail_version(
-    datafusion=["datafusion"],
+@pytest.mark.notyet(
+    ["datafusion"],
     raises=Exception,
     reason='This feature is not implemented: Can\'t create a scalar from array of type "Duration(Second)"',
 )

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -538,7 +538,6 @@ def test_elementwise_udf_overwrite_destruct_and_assign(udf_backend, udf_alltypes
     udf_backend.assert_frame_equal(result, expected, check_like=True)
 
 
-@pytest.mark.xfail_version(pyspark=["pyspark<3.1"])
 @pytest.mark.parametrize("method", ["destructure", "lift", "unpack"])
 def test_elementwise_udf_destructure_exact_once(udf_alltypes, method, tmp_path):
     with pytest.warns(FutureWarning, match="v9.0"):

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -634,7 +634,6 @@ def test_simple_ungrouped_unbound_following_window(
     raises=PsycoPg2InternalError,
     reason="Feature is not yet implemented: Window function with empty PARTITION BY is not supported yet",
 )
-@pytest.mark.xfail_version(datafusion=["datafusion==35"])
 def test_simple_ungrouped_window_with_scalar_order_by(alltypes):
     t = alltypes[alltypes.double_col < 50].order_by("id")
     w = ibis.window(rows=(0, None), order_by=ibis.null())


### PR DESCRIPTION
Remove some test decorator clutter that is no longer required.