### PR TITLE
test(tpcds): increase timeout marker for trino

### DIFF
--- a/ibis/backends/tests/tpc/conftest.py
+++ b/ibis/backends/tests/tpc/conftest.py
@@ -59,7 +59,7 @@ def tpc_test(suite_name: Literal["h", "ds"], *, result_is_empty=False):
         # func_only=True doesn't include the fixture setup time in the duration
         # of the test run, which is important since backends can take a hugely
         # variable amount of time to load all the TPC-$WHATEVER tables.
-        @pytest.mark.timeout(60, func_only=True)
+        @pytest.mark.timeout(90, func_only=True)
         @pytest.mark.usefixtures("backend")
         @pytest.mark.xdist_group(name)
         @getattr(pytest.mark, name)

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -3506,7 +3506,6 @@ def test_71(item, web_sales, date_dim, catalog_sales, store_sales, time_dim):
     raises=OperationNotDefinedError,
     reason="No DateDelta op defined",
 )
-@pytest.mark.timeout(120)  # apparently trino needs extra time sometimes
 @tpc_test("ds")
 def test_72(
     catalog_sales,


### PR DESCRIPTION
Should fix the upstream flakiness