### PR TITLE
test(tpcds): add query 64

### DIFF
--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -120,7 +120,7 @@ class TestConf(BackendTest):
             # duckdb automatically infers the sf= as a hive partition so we
             # need to disable it
             con.con.execute(
-                f"CREATE OR REPLACE VIEW {schema}.{table_name} AS "
+                f"CREATE TABLE IF NOT EXISTS {schema}.{table_name} AS "
                 f"FROM read_parquet({str(path)!r}, hive_partitioning=false)"
             )
 

--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -112,16 +112,17 @@ class TestConf(BackendTest):
     def _load_tpc(self, *, suite, scale_factor):
         con = self.connection
         schema = f"tpc{suite}"
-        con.con.execute(f"CREATE OR REPLACE SCHEMA {schema}")
+        con.create_database(schema, force=True)
         parquet_dir = self.data_dir.joinpath(schema, f"sf={scale_factor}", "parquet")
         assert parquet_dir.exists(), parquet_dir
         for path in parquet_dir.glob("*.parquet"):
             table_name = path.with_suffix("").name
             # duckdb automatically infers the sf= as a hive partition so we
             # need to disable it
-            con.con.execute(
-                f"CREATE TABLE IF NOT EXISTS {schema}.{table_name} AS "
-                f"FROM read_parquet({str(path)!r}, hive_partitioning=false)"
+            con.create_table(
+                table_name,
+                con.read_parquet(path, hive_partitioning=False),
+                database=schema,
             )
 
     def _transform_tpc_sql(self, parsed, *, suite, leaves):

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -3209,14 +3209,6 @@ def test_63(item, store_sales, date_dim, store):
 
 
 @tpc_test("ds", result_is_empty=True)
-@pytest.mark.notyet(
-    ["duckdb"],
-    reason=(
-        "This query times out on DuckDB _only_ when run via pytest. "
-        "No, we have no idea why this happens."
-    ),
-    strict=False,
-)
 def test_64(
     catalog_sales,
     catalog_returns,

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import calendar as cal
 from operator import ge, itemgetter, lt
-from pathlib import Path
 
 import pytest
 
@@ -5184,7 +5183,6 @@ def test_99(catalog_sales, warehouse, ship_mode, call_center, date_dim):
     )
 
 
-@pytest.mark.xfail(raises=AssertionError, reason="not all queries are implemented yet")
 def test_all_queries_are_written():
     variables = globals()
     numbers = range(1, 100)
@@ -5195,12 +5193,5 @@ def test_all_queries_are_written():
         if f"test_{query_number:02d}" in variables:
             query_numbers.remove(query_number)
 
-    file_size = (
-        lambda qn: Path(__file__)
-        .parents[1]
-        .joinpath("queries", "duckdb", "ds", f"{qn:d}.sql")
-        .stat()
-        .st_size
-    )
-    remaining_queries = sorted(query_numbers, key=file_size)
+    remaining_queries = sorted(query_numbers)
     assert remaining_queries == []

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -3215,6 +3215,7 @@ def test_63(item, store_sales, date_dim, store):
         "This query times out on DuckDB _only_ when run via pytest. "
         "No, we have no idea why this happens."
     ),
+    strict=False,
 )
 def test_64(
     catalog_sales,

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -3209,6 +3209,176 @@ def test_63(item, store_sales, date_dim, store):
 
 
 @tpc_test("ds", result_is_empty=True)
+@pytest.mark.notyet(
+    ["duckdb"],
+    reason=(
+        "This query times out on DuckDB _only_ when run via pytest. "
+        "No, we have no idea why this happens."
+    ),
+)
+def test_64(
+    catalog_sales,
+    catalog_returns,
+    store_sales,
+    store_returns,
+    date_dim,
+    store,
+    customer,
+    customer_demographics,
+    promotion,
+    household_demographics,
+    customer_address,
+    income_band,
+    item,
+):
+    cs_ui = (
+        catalog_sales.join(
+            catalog_returns,
+            [
+                _.cs_item_sk == catalog_returns.cr_item_sk,
+                _.cs_order_number == catalog_returns.cr_order_number,
+            ],
+        )
+        .group_by(_.cs_item_sk)
+        .having(
+            _.cs_ext_list_price.sum()
+            > (
+                2
+                * (_.cr_refunded_cash + _.cr_reversed_charge + _.cr_store_credit).sum()
+            )
+        )
+        .agg(
+            sale=_.cs_ext_list_price.sum(),
+            refund=(
+                _.cr_refunded_cash + _.cr_reversed_charge + _.cr_store_credit
+            ).sum(),
+        )
+    )
+
+    d1 = date_dim.mutate(syear=_.d_year)
+    d2 = date_dim.view().mutate(fsyear=_.d_year)
+    d3 = date_dim.view().mutate(s2year=_.d_year)
+
+    cd1 = customer_demographics
+    cd2 = customer_demographics.view()
+
+    hd1 = household_demographics
+    hd2 = household_demographics.view()
+
+    ad1 = customer_address
+    ad2 = customer_address.view()
+
+    ib1 = income_band
+    ib2 = income_band.view()
+
+    cross_sales = (
+        store_sales.join(
+            store_returns,
+            [("ss_item_sk", "sr_item_sk"), ("ss_ticket_number", "sr_ticket_number")],
+        )
+        .join(cs_ui, _.ss_item_sk == cs_ui.cs_item_sk)
+        .join(customer, _.ss_customer_sk == customer.c_customer_sk)
+        .join(d1, _.ss_sold_date_sk == d1.d_date_sk)
+        .join(d2, _.c_first_sales_date_sk == d2.d_date_sk)
+        .join(d3, _.c_first_shipto_date_sk == d3.d_date_sk)
+        .join(store, _.ss_store_sk == store.s_store_sk)
+        .join(cd1, _.ss_cdemo_sk == cd1.cd_demo_sk)
+        .join(
+            cd2,
+            [
+                _.c_current_cdemo_sk == cd2.cd_demo_sk,
+                _.cd_marital_status != cd2.cd_marital_status,
+            ],
+        )
+        .join(promotion, _.ss_promo_sk == promotion.p_promo_sk)
+        .join(hd1, _.ss_hdemo_sk == hd1.hd_demo_sk)
+        .join(hd2, _.c_current_hdemo_sk == hd2.hd_demo_sk)
+        .join(ad1, _.ss_addr_sk == ad1.ca_address_sk)
+        .join(ad2, _.c_current_addr_sk == ad2.ca_address_sk)
+        .join(ib1, hd1.hd_income_band_sk == ib1.ib_income_band_sk)
+        .join(ib2, hd2.hd_income_band_sk == ib2.ib_income_band_sk)
+        .join(
+            item,
+            [
+                _.ss_item_sk == item.i_item_sk,
+                item.i_color.isin(
+                    ["purple", "burlywood", "indian", "spring", "floral", "medium"]
+                ),
+                item.i_current_price.between(64, 74),
+                item.i_current_price.between(65, 79),
+            ],
+        )
+        .group_by(
+            product_name=_.i_product_name,
+            item_sk=_.i_item_sk,
+            store_zip=_.s_zip,
+            store_name=_.s_store_name,
+            b_street_number=ad1.ca_street_number,
+            b_street_name=ad1.ca_street_name,
+            b_city=ad1.ca_city,
+            b_zip=ad1.ca_zip,
+            c_street_number=ad2.ca_street_number,
+            c_street_name=ad2.ca_street_name,
+            c_city=ad2.ca_city,
+            c_zip=ad2.ca_zip,
+            syear=_.syear,
+            fsyear=_.fsyear,
+            s2year=_.s2year,
+        )
+        .agg(
+            cnt=_.count(),
+            s1=_.ss_wholesale_cost.sum(),
+            s2=_.ss_list_price.sum(),
+            s3=_.ss_coupon_amt.sum(),
+        )
+    )
+
+    cs1 = cross_sales
+    cs2 = cross_sales.view()
+
+    expr = (
+        cs1.join(
+            cs2,
+            [
+                ("item_sk", "item_sk"),
+                _.syear == 1999,
+                cs2.syear == 2000,
+                cs2.cnt <= _.cnt,
+                _.store_name == cs2.store_name,
+                _.store_zip == cs2.store_zip,
+            ],
+        )
+        .order_by(cs1.product_name, cs1.store_name, cs2.cnt, cs1.s1, cs2.s2)
+        .select(
+            _.product_name,
+            _.store_name,
+            _.store_zip,
+            _.b_street_number,
+            _.b_street_name,
+            _.b_city,
+            _.b_zip,
+            _.c_street_number,
+            _.c_street_name,
+            _.c_city,
+            _.c_zip,
+            cs2.syear,
+            cs2.cnt,
+            cs1syear=cs1.syear,
+            cs1cnt=cs1.cnt,
+            s11=cs1.s1,
+            s21=cs1.s2,
+            s31=cs1.s3,
+            s12=cs2.s1,
+            s22=cs2.s2,
+            s32=cs2.s3,
+        )
+        .relocate(cs2.syear, cs2.cnt, after="s32")
+    )
+
+    return expr
+
+
+@tpc_test("ds", result_is_empty=True)
 def test_65(store, item, store_sales, date_dim):
     sa = (
         store_sales.join(

--- a/ibis/backends/tests/tpc/queries/clickhouse/ds/64.sql
+++ b/ibis/backends/tests/tpc/queries/clickhouse/ds/64.sql
@@ -1,0 +1,125 @@
+WITH cs_ui AS
+  (SELECT cs_item_sk,
+          sum(cs_ext_list_price) AS sale,
+          sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit) AS refund
+   FROM catalog_sales
+   JOIN catalog_returns
+     ON cs_item_sk = cr_item_sk
+      AND cs_order_number = cr_order_number
+   GROUP BY cs_item_sk
+   HAVING sum(cs_ext_list_price)>2*sum(cr_refunded_cash+cr_reversed_charge+cr_store_credit)),
+     cross_sales AS
+  (SELECT i_product_name product_name,
+          i_item_sk item_sk,
+          s_store_name store_name,
+          s_zip store_zip,
+          ad1.ca_street_number b_street_number,
+          ad1.ca_street_name b_street_name,
+          ad1.ca_city b_city,
+          ad1.ca_zip b_zip,
+          ad2.ca_street_number c_street_number,
+          ad2.ca_street_name c_street_name,
+          ad2.ca_city c_city,
+          ad2.ca_zip c_zip,
+          d1.d_year AS syear,
+          d2.d_year AS fsyear,
+          d3.d_year s2year,
+          count(*) cnt,
+          sum(ss_wholesale_cost) s1,
+          sum(ss_list_price) s2,
+          sum(ss_coupon_amt) s3
+   FROM store_sales
+   JOIN store_returns
+     ON ss_item_sk = sr_item_sk
+      AND ss_ticket_number = sr_ticket_number
+   JOIN cs_ui
+     ON ss_item_sk = cs_ui.cs_item_sk
+   JOIN date_dim d1
+     ON ss_sold_date_sk = d1.d_date_sk
+   JOIN customer
+     ON ss_customer_sk = c_customer_sk
+   JOIN date_dim d2
+     ON c_first_sales_date_sk = d2.d_date_sk
+   JOIN date_dim d3
+     ON c_first_shipto_date_sk = d3.d_date_sk
+   JOIN store
+     ON ss_store_sk = s_store_sk
+   JOIN customer_demographics cd1
+     ON ss_cdemo_sk= cd1.cd_demo_sk
+   JOIN customer_demographics cd2
+     ON cd1.cd_marital_status <> cd2.cd_marital_status
+     AND c_current_cdemo_sk = cd2.cd_demo_sk
+   JOIN promotion
+     ON ss_promo_sk = p_promo_sk
+   JOIN household_demographics hd1
+     ON ss_hdemo_sk = hd1.hd_demo_sk
+   JOIN household_demographics hd2
+     ON c_current_hdemo_sk = hd2.hd_demo_sk
+   JOIN customer_address ad1
+     ON ss_addr_sk = ad1.ca_address_sk
+   JOIN customer_address ad2
+     ON c_current_addr_sk = ad2.ca_address_sk
+   JOIN income_band ib1
+     ON hd1.hd_income_band_sk = ib1.ib_income_band_sk
+   JOIN income_band ib2
+     ON hd2.hd_income_band_sk = ib2.ib_income_band_sk
+   JOIN item
+     ON ss_item_sk = i_item_sk
+   WHERE
+     i_color IN ('purple',
+                     'burlywood',
+                     'indian',
+                     'spring',
+                     'floral',
+                     'medium')
+     AND i_current_price BETWEEN 64 AND 64 + 10
+     AND i_current_price BETWEEN 64 + 1 AND 64 + 15
+   GROUP BY i_product_name,
+            i_item_sk,
+            s_store_name,
+            s_zip,
+            ad1.ca_street_number,
+            ad1.ca_street_name,
+            ad1.ca_city,
+            ad1.ca_zip,
+            ad2.ca_street_number,
+            ad2.ca_street_name,
+            ad2.ca_city,
+            ad2.ca_zip,
+            d1.d_year,
+            d2.d_year,
+            d3.d_year)
+SELECT cs1.product_name,
+       cs1.store_name,
+       cs1.store_zip,
+       cs1.b_street_number,
+       cs1.b_street_name,
+       cs1.b_city,
+       cs1.b_zip,
+       cs1.c_street_number,
+       cs1.c_street_name,
+       cs1.c_city,
+       cs1.c_zip,
+       cs1.syear cs1syear,
+       cs1.cnt cs1cnt,
+       cs1.s1 AS s11,
+       cs1.s2 AS s21,
+       cs1.s3 AS s31,
+       cs2.s1 AS s12,
+       cs2.s2 AS s22,
+       cs2.s3 AS s32,
+       cs2.syear,
+       cs2.cnt
+FROM cross_sales cs1
+JOIN cross_sales cs2
+  ON cs1.item_sk=cs2.item_sk
+    AND cs2.cnt <= cs1.cnt
+    AND cs1.store_name = cs2.store_name
+    AND cs1.store_zip = cs2.store_zip
+WHERE cs1.syear = 1999
+  AND cs2.syear = 1999 + 1
+ORDER BY cs1.product_name,
+         cs1.store_name,
+         cs2.cnt,
+         cs1.s1,
+         cs2.s1;

--- a/nix/ibis.nix
+++ b/nix/ibis.nix
@@ -51,7 +51,7 @@ poetry2nix.mkPoetryApplication {
 
       runHook preCheck
 
-      pytest -m 'not tpcds and (${markers})' --randomly-dont-reorganize -x
+      pytest -m 'not tpcds and (${markers})'
 
       runHook postCheck
     '';

--- a/nix/ibis.nix
+++ b/nix/ibis.nix
@@ -51,7 +51,7 @@ poetry2nix.mkPoetryApplication {
 
       runHook preCheck
 
-      pytest -m 'not tpcds and (${markers})' --numprocesses "$NIX_BUILD_CORES" --dist loadgroup
+      pytest -m 'not tpcds and (${markers})' --randomly-dont-reorganize -x
 
       runHook postCheck
     '';


### PR DESCRIPTION
So this should probably not get merged yet?  Or we can merge it and mark the
DuckDB failure and investigate further.

My notes so far:

There is some _weird_ stuff happening _only_ inside Pytest when running
this query on DuckDB.  This doesn't happen with any other tpc-ds
queries, and the query in question seems to run without issue on the
other backends that can run the tpc-ds queries.

If I generate sf=1 tpc-ds data in the DuckDB CLI, then run the included
sql file (which is the SQL generated by Ibis for this query), it runs in
about half a second.

If I `%load ibis_tpcds_64_local.py` and then run the `expr` there (which
is a copy-paste of the test code), it takes about half a second.

If I remove the `pytest.timeout` from the `tpc_test` decorator, this
same query, even at sf=.45 (which is empty at that size), takes
_minutes_ to run.


I also thought it might be the difference between using `memory` as the catalog instead of `tpcds`, but no, if I create `tpcds.ddb`, then create the tables in there, it still runs very quickly.