### PR TITLE
fix(clickhouse): workaround `EXCEPT` and `INTERSECT` generation in sqlglot; add tpcds query 87

### DIFF
--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -1912,11 +1912,6 @@ def test_37(item, inventory, date_dim, catalog_sales):
 
 
 @tpc_test("ds")
-@pytest.mark.notyet(
-    ["clickhouse"],
-    raises=AssertionError,
-    reason="clickhouse returns an incorrect result for this query",
-)
 def test_38(store_sales, catalog_sales, web_sales, date_dim, customer):
     dates = date_dim.filter(_.d_month_seq.between(1200, 1200 + 11))
     columns = "c_last_name", "c_first_name", "d_date"

--- a/ibis/backends/tests/tpc/queries/duckdb/ds/87.sql
+++ b/ibis/backends/tests/tpc/queries/duckdb/ds/87.sql
@@ -1,4 +1,4 @@
-SELECT count(*)
+SELECT count(*) num_cool
 FROM ((SELECT DISTINCT c_last_name,
                          c_first_name,
                          d_date


### PR DESCRIPTION
Add query 87 and workaround a bug in sqlglot (fixed upstream in https://github.com/tobymao/sqlglot/pull/4007)