### PR TITLE
refactor(aliasing): remove the need for renaming after execution

### DIFF
--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -519,15 +519,12 @@ class Backend(BaseBackend, NoUrl):
         streaming: bool = False,
         **kwargs: Any,
     ):
+        from ibis.formats.pyarrow import PyArrowData
+
         df = self._to_dataframe(
             expr, params=params, limit=limit, streaming=streaming, **kwargs
         )
-        table = df.to_arrow()
-        if isinstance(expr, (ir.Table, ir.Value)):
-            schema = expr.as_table().schema().to_pyarrow()
-            return table.rename_columns(schema.names).cast(schema)
-        else:
-            raise com.IbisError(f"Cannot execute expression of type: {type(expr)}")
+        return PyArrowData.convert_table(df.to_arrow(), expr.as_table().schema())
 
     def to_pyarrow(
         self,

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -59,19 +59,13 @@ def table(op, **_):
 
 @translate.register(ops.DummyTable)
 def dummy_table(op, **kw):
-    selections = [translate(arg, **kw) for name, arg in op.values.items()]
+    selections = [translate(arg, **kw).alias(name) for name, arg in op.values.items()]
     return pl.DataFrame().lazy().select(selections)
 
 
 @translate.register(ops.InMemoryTable)
 def in_memory_table(op, **_):
     return op.data.to_polars(op.schema).lazy()
-
-
-@translate.register(ops.Alias)
-def alias(op, **kw):
-    arg = translate(op.arg, **kw)
-    return arg.alias(op.name)
 
 
 def _make_duration(value, dtype):

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -2502,3 +2502,11 @@ def test_simple_pivot_wider(con, backend, monkeypatch):
     result = expr.to_pandas()
     expected = pd.DataFrame({"no": [4], "yes": [3]})
     backend.assert_frame_equal(result, expected)
+
+
+def test_named_literal(con, backend):
+    lit = ibis.literal(1, type="int64").name("one")
+    expr = lit.as_table()
+    result = con.to_pandas(expr)
+    expected = pd.DataFrame({"one": [1]})
+    backend.assert_frame_equal(result, expected)

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -456,7 +456,7 @@ class SQLStringView(Relation):
 class DummyTable(Relation):
     """A table constructed from literal values."""
 
-    values: FrozenOrderedDict[str, Value]
+    values: FrozenOrderedDict[str, Annotated[Value, ~InstanceOf(Alias)]]
 
     @attribute
     def schema(self):

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1342,10 +1342,13 @@ class Scalar(Value):
         >>> isinstance(lit, ir.Table)
         True
         """
-        parents = self.op().relations
+        from ibis.expr.types.relations import unwrap_alias
 
-        if len(parents) == 0:
-            return ops.DummyTable({self.get_name(): self}).to_expr()
+        op = self.op()
+        parents = op.relations
+
+        if not parents:
+            return ops.DummyTable({op.name: unwrap_alias(op)}).to_expr()
         elif len(parents) == 1:
             (parent,) = parents
             return parent.to_expr().aggregate(self)
@@ -1521,11 +1524,13 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> expr.equals(expected)
         True
         """
-        parents = self.op().relations
-        values = {self.get_name(): self}
+        from ibis.expr.types.relations import unwrap_alias
 
-        if len(parents) == 0:
-            return ops.DummyTable(values).to_expr()
+        op = self.op()
+        parents = op.relations
+
+        if not parents:
+            return ops.DummyTable({op.name: unwrap_alias(op)}).to_expr()
         elif len(parents) == 1:
             (parent,) = parents
             return parent.to_expr().select(self)

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -118,6 +118,14 @@ def bind(table: Table, value) -> Iterator[ir.Value]:
         yield literal(value)
 
 
+def unwrap_alias(node: ops.Value) -> ops.Value:
+    """Unwrap an alias node."""
+    if isinstance(node, ops.Alias):
+        return node.arg
+    else:
+        return node
+
+
 def unwrap_aliases(values: Iterator[ir.Value]) -> Mapping[str, ir.Value]:
     """Unwrap aliases into a mapping of {name: expression}."""
     result = {}
@@ -127,10 +135,7 @@ def unwrap_aliases(values: Iterator[ir.Value]) -> Mapping[str, ir.Value]:
             raise com.IbisInputError(
                 f"Duplicate column name {node.name!r} in result set"
             )
-        if isinstance(node, ops.Alias):
-            result[node.name] = node.arg
-        else:
-            result[node.name] = node
+        result[node.name] = unwrap_alias(node)
     return result
 
 

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -114,14 +114,11 @@ class PandasData(DataMapper):
                 "schema column count does not match input data column count"
             )
 
-        columns = []
-        for (_, series), dtype in zip(df.items(), schema.types):
-            columns.append(cls.convert_column(series, dtype))
-        df = cls.concat(columns, axis=1)
-
-        # return data with the schema's columns which may be different than the
-        # input columns
-        df.columns = schema.names
+        columns = {
+            name: cls.convert_column(series, dtype)
+            for (name, dtype), (_, series) in zip(schema.items(), df.items())
+        }
+        df = pd.DataFrame(columns)
 
         if geospatial_supported:
             from geopandas import GeoDataFrame
@@ -154,7 +151,7 @@ class PandasData(DataMapper):
 
     @classmethod
     def convert_scalar(cls, obj, dtype):
-        df = PandasData.convert_table(obj, sch.Schema({obj.columns[0]: dtype}))
+        df = PandasData.convert_table(obj, sch.Schema({str(obj.columns[0]): dtype}))
         return df.iat[0, 0]
 
     @classmethod

--- a/ibis/formats/polars.py
+++ b/ibis/formats/polars.py
@@ -166,9 +166,6 @@ class PolarsData(DataMapper):
     def convert_table(cls, df: pl.DataFrame, schema: Schema) -> pl.DataFrame:
         pl_schema = PolarsSchema.from_ibis(schema)
 
-        if tuple(df.columns) != tuple(schema.names):
-            df = df.rename(dict(zip(df.columns, schema.names)))
-
         if df.schema == pl_schema:
             return df
         return df.cast(pl_schema)

--- a/ibis/formats/tests/test_polars.py
+++ b/ibis/formats/tests/test_polars.py
@@ -162,7 +162,7 @@ def test_convert_column():
 
 
 def test_convert_table():
-    df = pl.DataFrame({"x": ["1", "2"], "y": ["a", "b"]})
+    df = pl.DataFrame({"x": ["1", "2"], "z": ["a", "b"]})
     schema = ibis.schema({"x": "int64", "z": "string"})
     df = PolarsData.convert_table(df, schema)
     sol = pl.DataFrame(

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -2192,3 +2192,10 @@ def test_table_fillna_depr_warn():
     t = ibis.table(schema={"a": "int", "b": "str"})
     with pytest.warns(FutureWarning, match="v9.1"):
         t.fillna({"b": "missing"})
+
+
+def test_dummy_table_disallows_aliases():
+    values = {"one": ops.Alias(ops.Literal(1, dtype=dt.int64), name="two")}
+
+    with pytest.raises(ValidationError):
+        ops.DummyTable(values)


### PR DESCRIPTION
Removes some code for renaming, which we were only doing because of `ops.DummyTable` and was ultimately unnecessary if we unalias its operations like we are doing elsewhere.