### PR TITLE
fix(datafusion): handle `NULL`s in array `flatten`

### DIFF
--- a/ibis/backends/sql/compilers/datafusion.py
+++ b/ibis/backends/sql/compilers/datafusion.py
@@ -499,5 +499,8 @@ class DataFusionCompiler(SQLGlotCompiler):
             op, arg=arg, sep=sep, where=where, order_by=order_by
         )
 
+    def visit_ArrayFlatten(self, op, *, arg):
+        return self.if_(arg.is_(NULL), NULL, self.f.flatten(arg))
+
 
 compiler = DataFusionCompiler()

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -1033,7 +1033,6 @@ def flatten_data():
                     reason="Arrays are never nullable",
                     raises=AssertionError,
                 ),
-                pytest.mark.notimpl(["datafusion"], raises=AssertionError),
             ],
         ),
         param(
@@ -1051,7 +1050,6 @@ def flatten_data():
                     raises=TypeError,
                     reason="comparison of nested arrays doesn't work in pandas testing module",
                 ),
-                pytest.mark.notimpl(["datafusion"], raises=AssertionError),
             ],
         ),
     ],


### PR DESCRIPTION
Works around a bug in the datafusion implementation of `ArrayFlatten` where a flattened `NULL` value returns an empty array instead of `NULL`.