### PR TITLE
test(risingwave): bump to latest risingwave release and enable now-passing tests

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -547,7 +547,7 @@ services:
       - impala
 
   risingwave:
-    image: ghcr.io/risingwavelabs/risingwave:nightly-20240204
+    image: ghcr.io/risingwavelabs/risingwave:v1.10.1
     command: "standalone --meta-opts=\" \
       --advertise-addr 0.0.0.0:5690 \
       --backend mem \

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -679,9 +679,6 @@ def test_array_remove(con, input, expected):
     raises=(AssertionError, GoogleBadRequest),
     reason="bigquery doesn't support null elements in arrays",
 )
-@pytest.mark.notimpl(
-    ["risingwave"], raises=AssertionError, reason="TODO(Kexiang): seems a bug"
-)
 @pytest.mark.notyet(
     ["flink"], raises=Py4JJavaError, reason="empty arrays not supported"
 )
@@ -719,11 +716,6 @@ def test_array_unique(con, input, expected):
                     ["flink"],
                     raises=Py4JJavaError,
                     reason="flink cannot handle empty arrays",
-                ),
-                pytest.mark.notyet(
-                    ["risingwave"],
-                    raises=AssertionError,
-                    reason="Refer to https://github.com/risingwavelabs/risingwave/issues/14735",
                 ),
             ],
             id="empty",

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -921,11 +921,6 @@ def test_ungrouped_unbounded_window(
     raises=MySQLOperationalError,
     reason="https://github.com/tobymao/sqlglot/issues/2779",
 )
-@pytest.mark.notimpl(
-    ["risingwave"],
-    raises=PsycoPg2InternalError,
-    reason="Feature is not yet implemented: window frame in `RANGE` mode is not supported yet",
-)
 def test_grouped_bounded_range_window(backend, alltypes, df):
     # Explanation of the range window spec below:
     #


### PR DESCRIPTION
I noticed we had a very old version of RisingWave, and bumped it to the latest release, which fixed a number of bugs and added support for `RANGE` window function frames, which caused a number of tests to start XPASS-ing.