### PR TITLE
fix(backends): pass kwargs to _from_url() in every case

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1396,11 +1396,12 @@ def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
         if len(value) == 1:
             kwargs[name] = value[0]
 
+    # Merge explicit kwargs with query string, explicit kwargs
+    # taking precedence
+    kwargs.update(orig_kwargs)
+
     if scheme == "file":
         path = parsed.netloc + parsed.path
-        # Merge explicit kwargs with query string, explicit kwargs
-        # taking precedence
-        kwargs.update(orig_kwargs)
         if path.endswith(".duckdb"):
             return ibis.duckdb.connect(path, **kwargs)
         elif path.endswith((".sqlite", ".db")):

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -375,7 +375,18 @@ def test_from_url(con):
     )
 
 
-def test_invalid_port(con):
+def test_from_url_with_kwargs(con):
+    # since explicit kwargs take precedence, this passes, because we're passing
+    # `database` explicitly, even though our connection string says to use a
+    # random database
+    database = ibis.util.gen_name("clickhouse_database")
+    assert ibis.connect(
+        f"clickhouse://{CLICKHOUSE_USER}:{CLICKHOUSE_PASS}@{CLICKHOUSE_HOST}:{CLICKHOUSE_PORT}/{database}",
+        database=IBIS_TEST_CLICKHOUSE_DB,
+    )
+
+
+def test_invalid_port():
     port = 9999
     url = f"clickhouse://{CLICKHOUSE_USER}:{CLICKHOUSE_PASS}@{CLICKHOUSE_HOST}:{port}/{IBIS_TEST_CLICKHOUSE_DB}"
     with pytest.raises(cc.driver.exceptions.DatabaseError):


### PR DESCRIPTION
The original `kwargs` are not passed to the `backend._from_url()` if `scheme != "file"`
