### PR TITLE
test(sigcheck): check function signature parity across backends

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -407,6 +407,19 @@ def backend_cls(request) -> BaseBackend:
     return cls
 
 
+@pytest.fixture(
+    params=_get_backends_to_test(discard=("dask", "pandas", "polars")),
+    scope="session",
+)
+def backend_sql_cls(request, data_dir, tmp_path_factory, worker_id):
+    """Return the uninstantiated backend class, unconnected.
+
+    SQL backends only.
+    This is used for signature checking and nothing should be executed."""
+    cls = _get_backend_cls(request.param)
+    return cls
+
+
 @pytest.fixture(params=_get_backends_to_test(), scope="session")
 def backend(request, data_dir, tmp_path_factory, worker_id) -> BackendTest:
     """Return an instance of BackendTest, loaded with data."""

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -26,6 +26,7 @@ from ibis.conftest import WINDOWS
 from ibis.util import promote_tuple
 
 if TYPE_CHECKING:
+    from ibis.backends import BaseBackend
     from ibis.backends.tests.base import BackendTest
 
 
@@ -388,6 +389,22 @@ def pytest_runtest_call(item):
             reason += f"; {provided_reason}"
         if failing_specs:
             item.add_marker(pytest.mark.xfail(reason=reason, **kwargs))
+
+
+def _get_backend_cls(backend_str: str):
+    """Convert a backend string to the test class for the backend."""
+    backend_mod = importlib.import_module(f"ibis.backends.{backend_str}")
+    return backend_mod.Backend
+
+
+@pytest.fixture(params=_get_backends_to_test(), scope="session")
+def backend_cls(request) -> BaseBackend:
+    """Return the uninstantiated backend class, unconnected.
+
+    This is used for signature checking and nothing should be executed."""
+
+    cls = _get_backend_cls(request.param)
+    return cls
 
 
 @pytest.fixture(params=_get_backends_to_test(), scope="session")

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -312,6 +312,14 @@ def pytest_runtest_call(item):
     if not backend:
         # Check item path to see if test is in backend-specific folder
         backend = set(_get_backend_names()).intersection(item.path.parts)
+    if not backend:
+        # Check if this is one of the uninstantiated backend class fixture
+        # used for signature checking
+        backend = [
+            backend.name
+            for key, backend in item.funcargs.items()
+            if key.endswith("backend_cls")
+        ]
 
     if not backend:
         return
@@ -403,19 +411,6 @@ def backend_cls(request) -> BaseBackend:
 
     This is used for signature checking and nothing should be executed."""
 
-    cls = _get_backend_cls(request.param)
-    return cls
-
-
-@pytest.fixture(
-    params=_get_backends_to_test(discard=("dask", "pandas", "polars")),
-    scope="session",
-)
-def backend_sql_cls(request, data_dir, tmp_path_factory, worker_id):
-    """Return the uninstantiated backend class, unconnected.
-
-    SQL backends only.
-    This is used for signature checking and nothing should be executed."""
     cls = _get_backend_cls(request.param)
     return cls
 

--- a/ibis/backends/tests/signature/tests/test_compatible.py
+++ b/ibis/backends/tests/signature/tests/test_compatible.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # noqa: INP001
 
 from inspect import signature
+from typing import Any
 
 import pytest
 from pytest import param
@@ -8,8 +9,26 @@ from pytest import param
 from ibis.backends.tests.signature.typecheck import compatible
 
 
+def a1(posarg: int): ...
+
+
+def b1(posarg: str): ...
+
+
+def a2(posarg: int, **kwargs: Any): ...
+def b2(posarg: str, **kwargs): ...
+
+
+def a3(posarg: int, other_kwarg: bool = True, **kwargs: Any): ...
+def b3(posarg: str, **kwargs: Any): ...
+
+
+def a4(posarg: int, other_kwarg=True, **kwargs: Any): ...
+def b4(posarg: str, **kwargs: Any): ...
+
+
 @pytest.mark.parametrize(
-    "a, b, expected",
+    "a, b, check_annotations",
     [
         param(
             lambda posarg, *, kwarg1=None, kwarg2=None: ...,
@@ -30,19 +49,71 @@ from ibis.backends.tests.signature.typecheck import compatible
             id="swapped kwarg order w/extra kwarg second",
         ),
         param(
+            a1,
+            b1,
+            False,
+            id="annotations diff types w/out anno check",
+        ),
+        param(
+            a2,
+            b3,
+            False,
+            id="annotations different but parity in annotations",
+        ),
+        param(
+            a3,
+            b3,
+            False,
+            id="annotations different but parity in annotations for matching kwargs",
+        ),
+        param(
+            a4,
+            b4,
+            False,
+            id="annotations different but parity in annotations for matching kwargs",
+        ),
+        param(
+            a2,
+            b2,
+            False,
+            id="annotations different, no anno check, but missing annotation",
+        ),
+    ],
+)
+def test_sigs_compatible(a, b, check_annotations):
+    sig_a, sig_b = signature(a), signature(b)
+    assert compatible(sig_a, sig_b, check_annotations=check_annotations)
+
+
+@pytest.mark.parametrize(
+    "a, b, check_annotations",
+    [
+        param(
             lambda posarg, /, *, kwarg2=None, kwarg1=None: ...,
             lambda posarg, *, kwarg1=None, kwarg2=None, kwarg3=None: ...,
-            False,
+            True,
             id="one positional only",
         ),
         param(
             lambda posarg, *, kwarg1=None, kwarg2=None: ...,
             lambda posarg, kwarg1=None, kwarg2=None: ...,
-            False,
+            True,
             id="not kwarg only",
+        ),
+        param(
+            a1,
+            b1,
+            True,
+            id="annotations diff types w/anno check",
+        ),
+        param(
+            a2,
+            b3,
+            True,
+            id="annotations different but parity in annotations",
         ),
     ],
 )
-def test_sigs_compatible(a, b, expected):
+def test_sigs_incompatible(a, b, check_annotations):
     sig_a, sig_b = signature(a), signature(b)
-    assert compatible(sig_a, sig_b) == expected
+    assert not compatible(sig_a, sig_b, check_annotations=check_annotations)

--- a/ibis/backends/tests/signature/tests/test_compatible.py
+++ b/ibis/backends/tests/signature/tests/test_compatible.py
@@ -1,0 +1,48 @@
+from __future__ import annotations  # noqa: INP001
+
+from inspect import signature
+
+import pytest
+from pytest import param
+
+from ibis.backends.tests.signature.typecheck import compatible
+
+
+@pytest.mark.parametrize(
+    "a, b, expected",
+    [
+        param(
+            lambda posarg, *, kwarg1=None, kwarg2=None: ...,
+            lambda posarg, *, kwarg2=None, kwarg1=None: ...,
+            True,
+            id="swapped kwarg order",
+        ),
+        param(
+            lambda posarg, *, kwarg1=None, kwarg2=None, kwarg3=None: ...,
+            lambda posarg, *, kwarg2=None, kwarg1=None: ...,
+            True,
+            id="swapped kwarg order w/extra kwarg first",
+        ),
+        param(
+            lambda posarg, *, kwarg2=None, kwarg1=None: ...,
+            lambda posarg, *, kwarg1=None, kwarg2=None, kwarg3=None: ...,
+            True,
+            id="swapped kwarg order w/extra kwarg second",
+        ),
+        param(
+            lambda posarg, /, *, kwarg2=None, kwarg1=None: ...,
+            lambda posarg, *, kwarg1=None, kwarg2=None, kwarg3=None: ...,
+            False,
+            id="one positional only",
+        ),
+        param(
+            lambda posarg, *, kwarg1=None, kwarg2=None: ...,
+            lambda posarg, kwarg1=None, kwarg2=None: ...,
+            False,
+            id="not kwarg only",
+        ),
+    ],
+)
+def test_sigs_compatible(a, b, expected):
+    sig_a, sig_b = signature(a), signature(b)
+    assert compatible(sig_a, sig_b) == expected

--- a/ibis/backends/tests/signature/tests/test_compatible.py
+++ b/ibis/backends/tests/signature/tests/test_compatible.py
@@ -27,6 +27,10 @@ def a4(posarg: int, other_kwarg=True, **kwargs: Any): ...
 def b4(posarg: str, **kwargs: Any): ...
 
 
+def a5(posarg: int, /): ...
+def b5(posarg2: str, /): ...
+
+
 @pytest.mark.parametrize(
     "a, b, check_annotations",
     [
@@ -111,6 +115,12 @@ def test_sigs_compatible(a, b, check_annotations):
             b3,
             True,
             id="annotations different but parity in annotations",
+        ),
+        param(
+            a5,
+            b5,
+            False,
+            id="names different, but positional only",
         ),
     ],
 )

--- a/ibis/backends/tests/signature/typecheck.py
+++ b/ibis/backends/tests/signature/typecheck.py
@@ -1,0 +1,116 @@
+"""The following was forked from the python-interface project:
+
+* Copyright (c) 2016-2021, Scott Sanderson
+
+Utilities for typed interfaces.
+"""
+
+# ruff: noqa: D205, D415, D400
+
+from __future__ import annotations
+
+from inspect import Parameter, Signature
+from itertools import starmap, takewhile, zip_longest
+
+
+def valfilter(f, d):
+    return {k: v for k, v in d.items() if f(v)}
+
+
+def dzip(left, right):
+    return {k: (left.get(k), right.get(k)) for k in left.keys() & right.keys()}
+
+
+def complement(f):
+    def not_f(*args, **kwargs):
+        return not f(*args, **kwargs)
+
+    return not_f
+
+
+def compatible(impl_sig: Signature, iface_sig: Signature) -> bool:
+    """Check whether ``impl_sig`` is compatible with ``iface_sig``.
+
+    Parameters
+    ----------
+    impl_sig
+        The signature of the implementation function.
+    iface_sig
+        The signature of the interface function.
+
+    In general, an implementation is compatible with an interface if any valid
+    way of passing parameters to the interface method is also valid for the
+    implementation.
+
+    Consequently, the following differences are allowed between the signature
+    of an implementation method and the signature of its interface definition:
+
+    1. An implementation may add new arguments to an interface iff:
+       a. All new arguments have default values.
+       b. All new arguments accepted positionally (i.e. all non-keyword-only
+          arguments) occur after any arguments declared by the interface.
+       c. Keyword-only arguments may be reordered by the implementation.
+
+    2. For type-annotated interfaces, type annotations my differ as follows:
+       a. Arguments to implementations of an interface may be annotated with
+          a **superclass** of the type specified by the interface.
+       b. The return type of an implementation may be annotated with a
+          **subclass** of the type specified by the interface.
+    """
+    # Unwrap to get the underlying inspect.Signature objects.
+    return all(
+        [
+            positionals_compatible(
+                takewhile(is_positional, impl_sig.parameters.values()),
+                takewhile(is_positional, iface_sig.parameters.values()),
+            ),
+            keywords_compatible(
+                valfilter(complement(is_positional), impl_sig.parameters),
+                valfilter(complement(is_positional), iface_sig.parameters),
+            ),
+        ]
+    )
+
+
+_POSITIONALS = frozenset([Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD])
+
+
+def is_positional(arg):
+    return arg.kind in _POSITIONALS
+
+
+def has_default(arg):
+    """Does ``arg`` provide a default?."""
+    return arg.default is not Parameter.empty
+
+
+def params_compatible(impl, iface):
+    if impl is None:
+        return False
+
+    if iface is None:
+        return has_default(impl)
+
+    return (
+        impl.name == iface.name
+        and impl.kind == iface.kind
+        and has_default(impl) == has_default(iface)
+        and annotations_compatible(impl, iface)
+    )
+
+
+def positionals_compatible(impl_positionals, iface_positionals):
+    return all(
+        starmap(params_compatible, zip_longest(impl_positionals, iface_positionals))
+    )
+
+
+def keywords_compatible(impl_keywords, iface_keywords):
+    return all(starmap(params_compatible, dzip(impl_keywords, iface_keywords).values()))
+
+
+def annotations_compatible(impl, iface):
+    """Check whether the type annotations of an implementation are compatible with
+    the annotations of the interface it implements.
+    """
+    return impl.annotation == iface.annotation

--- a/ibis/backends/tests/test_signatures.py
+++ b/ibis/backends/tests/test_signatures.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from ibis.backends import _FileIOHandler
+from ibis.backends.tests.signature.typecheck import compatible
+
+params = []
+
+for module in [_FileIOHandler]:
+    methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
+    for method in methods:
+        params.append((_FileIOHandler, method))
+
+
+@pytest.mark.parametrize("base_cls, method", params)
+def test_signatures(base_cls, method, backend_cls):
+    if not hasattr(backend_cls, method):
+        pytest.skip(f"Method {method} not present in {backend_cls}, skipping...")
+
+    base_sig = inspect.signature(getattr(base_cls, method))
+    backend_sig = inspect.signature(getattr(backend_cls, method))
+
+    # Usage is compatible(implementation_signature, defined_interface_signature, ...)
+    assert compatible(backend_sig, base_sig, check_annotations=False)

--- a/ibis/backends/tests/test_signatures.py
+++ b/ibis/backends/tests/test_signatures.py
@@ -4,15 +4,30 @@ import inspect
 
 import pytest
 
-from ibis.backends import _FileIOHandler
+from ibis.backends import (
+    BaseBackend,
+    CanCreateCatalog,
+    CanCreateDatabase,
+    CanListCatalog,
+    CanListDatabase,
+    _FileIOHandler,
+)
+from ibis.backends.sql import SQLBackend
 from ibis.backends.tests.signature.typecheck import compatible
 
 params = []
 
-for module in [_FileIOHandler]:
+for module in [
+    BaseBackend,
+    CanCreateCatalog,
+    CanCreateDatabase,
+    CanListCatalog,
+    CanListDatabase,
+    _FileIOHandler,
+]:
     methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
     for method in methods:
-        params.append((_FileIOHandler, method))
+        params.append((module, method))
 
 
 @pytest.mark.parametrize("base_cls, method", params)
@@ -20,8 +35,38 @@ def test_signatures(base_cls, method, backend_cls):
     if not hasattr(backend_cls, method):
         pytest.skip(f"Method {method} not present in {backend_cls}, skipping...")
 
-    base_sig = inspect.signature(getattr(base_cls, method))
+    if not callable(base_method := getattr(base_cls, method)):
+        pytest.skip(
+            f"Method {method} in {base_cls} isn't callable, can't grab signature"
+        )
+
+    base_sig = inspect.signature(base_method)
     backend_sig = inspect.signature(getattr(backend_cls, method))
+
+    # Usage is compatible(implementation_signature, defined_interface_signature, ...)
+    assert compatible(backend_sig, base_sig, check_annotations=False)
+
+
+sql_backend_params = []
+
+for module in [SQLBackend]:
+    methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
+    for method in methods:
+        sql_backend_params.append((module, method))
+
+
+@pytest.mark.parametrize("base_cls, method", sql_backend_params)
+def test_signatures_sql_backends(base_cls, method, backend_sql_cls):
+    if not hasattr(backend_sql_cls, method):
+        pytest.skip(f"Method {method} not present in {backend_sql_cls}, skipping...")
+
+    if not callable(base_method := getattr(base_cls, method)):
+        pytest.skip(
+            f"Method {method} in {base_cls} isn't callable, can't grab signature"
+        )
+
+    base_sig = inspect.signature(getattr(base_method))
+    backend_sig = inspect.signature(getattr(backend_sql_cls, method))
 
     # Usage is compatible(implementation_signature, defined_interface_signature, ...)
     assert compatible(backend_sig, base_sig, check_annotations=False)

--- a/ibis/backends/tests/test_signatures.py
+++ b/ibis/backends/tests/test_signatures.py
@@ -10,24 +10,177 @@ from ibis.backends import (
     CanCreateDatabase,
     CanListCatalog,
     CanListDatabase,
-    _FileIOHandler,
 )
 from ibis.backends.sql import SQLBackend
 from ibis.backends.tests.signature.typecheck import compatible
 
-params = []
+SKIP_METHODS = ["do_connect", "from_connection"]
 
-for module in [
-    BaseBackend,
-    CanCreateCatalog,
-    CanCreateDatabase,
-    CanListCatalog,
-    CanListDatabase,
-    _FileIOHandler,
-]:
-    methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
-    for method in methods:
-        params.append((module, method))
+
+def _scrape_methods(modules, params):
+    params = []
+    for module in modules:
+        methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
+        for method in methods:
+            # Only test methods that are callable (so we can grab the signature)
+            # and skip any methods that we don't want to check
+            if (
+                method not in SKIP_METHODS
+                and method not in marks.keys()
+                and callable(getattr(module, method))
+            ):
+                params.append((module, method))
+
+    return params
+
+
+marks = {
+    "compile": pytest.param(
+        BaseBackend,
+        "compile",
+        marks=pytest.mark.notyet(
+            [
+                "bigquery",
+                "clickhouse",
+                "datafusion",
+                "druid",
+                "duckdb",
+                "exasol",
+                "impala",
+                "mssql",
+                "mysql",
+                "oracle",
+                "pandas",
+                "postgres",
+                "pyspark",
+                "risingwave",
+                "snowflake",
+                "sqlite",
+                "trino",
+            ]
+        ),
+    ),
+    "create_database": pytest.param(
+        CanCreateDatabase,
+        "create_database",
+        marks=pytest.mark.notyet(["clickhouse", "flink", "impala", "mysql", "pyspark"]),
+    ),
+    "drop_database": pytest.param(
+        CanCreateDatabase,
+        "drop_database",
+        marks=pytest.mark.notyet(["clickhouse", "impala", "mysql", "pyspark"]),
+    ),
+    "drop_table": pytest.param(
+        SQLBackend,
+        "drop_table",
+        marks=pytest.mark.notyet(
+            ["bigquery", "dask", "druid", "flink", "impala", "pandas", "polars"]
+        ),
+    ),
+    "execute": pytest.param(
+        SQLBackend,
+        "execute",
+        marks=pytest.mark.notyet(
+            ["clickhouse", "datafusion", "flink", "mysql", "pandas"]
+        ),
+    ),
+    "insert": pytest.param(
+        SQLBackend,
+        "insert",
+        marks=pytest.mark.notyet(["clickhouse", "flink", "impala", "sqlite"]),
+    ),
+    "list_databases": pytest.param(
+        CanCreateDatabase,
+        "list_databases",
+        marks=pytest.mark.notyet(
+            [
+                "clickhouse",
+                "flink",
+                "impala",
+                "mysql",
+                "postgres",
+                "risingwave",
+                "sqlite",
+            ]
+        ),
+    ),
+    "list_tables": pytest.param(
+        BaseBackend,
+        "list_tables",
+        marks=pytest.mark.notyet(
+            ["flink", "mysql", "oracle", "postgres", "risingwave"]
+        ),
+    ),
+    "read_csv": pytest.param(
+        BaseBackend,
+        "read_csv",
+        marks=pytest.mark.notyet(["dask", "duckdb", "flink", "pandas", "pyspark"]),
+    ),
+    "read_delta": pytest.param(
+        BaseBackend,
+        "read_delta",
+        marks=pytest.mark.notyet(["datafusion", "duckdb", "polars", "pyspark"]),
+    ),
+    "read_json": pytest.param(
+        BaseBackend,
+        "read_json",
+        marks=pytest.mark.notyet(["duckdb", "flink", "pyspark"]),
+    ),
+    "read_parquet": pytest.param(
+        BaseBackend,
+        "read_parquet",
+        marks=pytest.mark.notyet(["dask", "duckdb", "flink", "pandas"]),
+    ),
+    "table": pytest.param(
+        BaseBackend,
+        "table",
+        marks=pytest.mark.notyet(
+            [
+                "clickhouse",
+                "dask",
+                "datafusion",
+                "druid",
+                "duckdb",
+                "exasol",
+                "mssql",
+                "mysql",
+                "oracle",
+                "pandas",
+                "polars",
+                "postgres",
+                "risingwave",
+                "snowflake",
+                "sqlite",
+                "trino",
+                "pyspark",
+            ]
+        ),
+    ),
+    "to_parquet_dir": pytest.param(
+        BaseBackend,
+        "to_parquet_dir",
+        marks=pytest.mark.notyet(["pyspark"]),
+    ),
+    "truncate_table": pytest.param(
+        SQLBackend,
+        "truncate_table",
+        marks=pytest.mark.notyet(["clickhouse", "impala"]),
+    ),
+}
+
+params = _scrape_methods(
+    [
+        BaseBackend,
+        SQLBackend,
+        CanCreateCatalog,
+        CanCreateDatabase,
+        CanListCatalog,
+        CanListDatabase,
+    ],
+    marks,
+)
+
+params.extend(marks.values())
 
 
 @pytest.mark.parametrize("base_cls, method", params)
@@ -35,38 +188,8 @@ def test_signatures(base_cls, method, backend_cls):
     if not hasattr(backend_cls, method):
         pytest.skip(f"Method {method} not present in {backend_cls}, skipping...")
 
-    if not callable(base_method := getattr(base_cls, method)):
-        pytest.skip(
-            f"Method {method} in {base_cls} isn't callable, can't grab signature"
-        )
-
-    base_sig = inspect.signature(base_method)
+    base_sig = inspect.signature(getattr(base_cls, method))
     backend_sig = inspect.signature(getattr(backend_cls, method))
-
-    # Usage is compatible(implementation_signature, defined_interface_signature, ...)
-    assert compatible(backend_sig, base_sig, check_annotations=False)
-
-
-sql_backend_params = []
-
-for module in [SQLBackend]:
-    methods = list(filter(lambda x: not x.startswith("_"), dir(module)))
-    for method in methods:
-        sql_backend_params.append((module, method))
-
-
-@pytest.mark.parametrize("base_cls, method", sql_backend_params)
-def test_signatures_sql_backends(base_cls, method, backend_sql_cls):
-    if not hasattr(backend_sql_cls, method):
-        pytest.skip(f"Method {method} not present in {backend_sql_cls}, skipping...")
-
-    if not callable(base_method := getattr(base_cls, method)):
-        pytest.skip(
-            f"Method {method} in {base_cls} isn't callable, can't grab signature"
-        )
-
-    base_sig = inspect.signature(getattr(base_method))
-    backend_sig = inspect.signature(getattr(backend_sql_cls, method))
 
     # Usage is compatible(implementation_signature, defined_interface_signature, ...)
     assert compatible(backend_sig, base_sig, check_annotations=False)


### PR DESCRIPTION
Opening this in favor of #9383 -- that PR also included all of the breaking changes to unify function signatures and it was too much at once.  This PR adds only the signature checking mechanism, plus the requisite xfails to lay out which inconsistencies are currently in Ibis.

## Motivation

We want to ensure that, for a given backend, that the argument names, plus usage of positional, positional-only, keyword, and keyword-only arguments match, so that there is API consistency when moving between backends.

I've grabbed a few small parts of some of the utilities in Scott Sanderson's
`python-interface` project (https://github.com/ssanderson/python-interface).

While the upstream is no longer maintained, the goal of that project
aligns quite well with some of the issues we face with maintaining
consistent interfaces across backends.

Note that while the upstream project focused on _runtime_ enforcement of these signatures matching, here it is only run in the test suite.

## Rough procedure

Any method that doesn't match can be skipped entirely (this is useful for things like `do_connect`, which cannot reasonably be assumed to match) or individually (by specifying a `pytest.param` and marking the failing backends).

Then we scrape across the common parent classes and add any methods that are NOT currently specified in the pre-existing xfailed ones.  It's a bit of a nuisance, but it's done, and ideally the manual listing of the inconsistent methods goes away as we unify things.


I've opted for not checking that type annotations match, because that seems... unreasonable.

This would satisfy #9125 once all of the xfail markers are removed, e.g., it checks that all keyword and positional arguments are standardized.