### PR TITLE
fix(sql): properly parenthesize binary ops containing named expressions

### DIFF
--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -266,7 +266,7 @@ class Backend(SQLBackend):
     def _fetch_from_cursor(self, cursor, schema):
         from ibis.formats.pandas import PandasData
 
-        results = fetchall(cursor)
+        results = fetchall(cursor, schema.names)
         return PandasData.convert_table(results, schema)
 
     @contextlib.contextmanager
@@ -1260,9 +1260,10 @@ class Backend(SQLBackend):
                     cur.execute(insert_stmt, row)
 
 
-def fetchall(cur):
+def fetchall(cur, names=None):
     batches = cur.fetchcolumnar()
-    names = list(map(operator.itemgetter(0), cur.description))
+    if names is None:
+        names = list(map(operator.itemgetter(0), cur.description))
     df = _column_batches_to_dataframe(names, batches)
     return df
 

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -689,9 +689,6 @@ class SQLGlotCompiler(abc.ABC):
     def visit_ScalarSubquery(self, op, *, rel):
         return rel.this.subquery(copy=False)
 
-    def visit_Alias(self, op, *, arg, name):
-        return arg
-
     def visit_Literal(self, op, *, value, dtype):
         """Compile a literal value.
 

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -1017,7 +1017,14 @@ class BigQueryCompiler(SQLGlotCompiler):
         return sg.select(column).from_(parent)
 
     def visit_TableUnnest(
-        self, op, *, parent, column, offset: str | None, keep_empty: bool
+        self,
+        op,
+        *,
+        parent,
+        column,
+        column_name: str,
+        offset: str | None,
+        keep_empty: bool,
     ):
         quoted = self.quoted
 
@@ -1029,9 +1036,8 @@ class BigQueryCompiler(SQLGlotCompiler):
 
         table = sg.to_identifier(parent.alias_or_name, quoted=quoted)
 
-        opname = op.column.name
-        overlaps_with_parent = opname in op.parent.schema
-        computed_column = column_alias.as_(opname, quoted=quoted)
+        overlaps_with_parent = column_name in op.parent.schema
+        computed_column = column_alias.as_(column_name, quoted=quoted)
 
         # replace the existing column if the unnested column hasn't been
         # renamed

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -685,7 +685,14 @@ class ClickHouseCompiler(SQLGlotCompiler):
         return sg.select(column).from_(parent)
 
     def visit_TableUnnest(
-        self, op, *, parent, column, offset: str | None, keep_empty: bool
+        self,
+        op,
+        *,
+        parent,
+        column,
+        column_name: str,
+        offset: str | None,
+        keep_empty: bool,
     ):
         quoted = self.quoted
 
@@ -697,9 +704,8 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
         selcols = []
 
-        opname = op.column.name
-        overlaps_with_parent = opname in op.parent.schema
-        computed_column = column_alias.as_(opname, quoted=quoted)
+        overlaps_with_parent = column_name in op.parent.schema
+        computed_column = column_alias.as_(column_name, quoted=quoted)
 
         if offset is not None:
             if overlaps_with_parent:

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -718,7 +718,14 @@ class PostgresCompiler(SQLGlotCompiler):
         )
 
     def visit_TableUnnest(
-        self, op, *, parent, column, offset: str | None, keep_empty: bool
+        self,
+        op,
+        *,
+        parent,
+        column,
+        column_name: str,
+        offset: str | None,
+        keep_empty: bool,
     ):
         quoted = self.quoted
 
@@ -726,10 +733,9 @@ class PostgresCompiler(SQLGlotCompiler):
 
         parent_alias = parent.alias_or_name
 
-        opname = op.column.name
         parent_schema = op.parent.schema
-        overlaps_with_parent = opname in parent_schema
-        computed_column = column_alias.as_(opname, quoted=quoted)
+        overlaps_with_parent = column_name in parent_schema
+        computed_column = column_alias.as_(column_name, quoted=quoted)
 
         selcols = []
 

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -500,16 +500,22 @@ class PySparkCompiler(SQLGlotCompiler):
             raise NotImplementedError(f"No available hashing function for {how}")
 
     def visit_TableUnnest(
-        self, op, *, parent, column, offset: str | None, keep_empty: bool
+        self,
+        op,
+        *,
+        parent,
+        column,
+        column_name: str,
+        offset: str | None,
+        keep_empty: bool,
     ):
         quoted = self.quoted
 
         column_alias = sg.to_identifier(gen_name("table_unnest_column"), quoted=quoted)
 
-        opname = op.column.name
         parent_schema = op.parent.schema
-        overlaps_with_parent = opname in parent_schema
-        computed_column = column_alias.as_(opname, quoted=quoted)
+        overlaps_with_parent = column_name in parent_schema
+        computed_column = column_alias.as_(column_name, quoted=quoted)
 
         parent_alias = parent.alias_or_name
 

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -810,7 +810,14 @@ $$""",
         return sg.select(column).from_(parent)
 
     def visit_TableUnnest(
-        self, op, *, parent, column, offset: str | None, keep_empty: bool
+        self,
+        op,
+        *,
+        parent,
+        column,
+        column_name: str,
+        offset: str | None,
+        keep_empty: bool,
     ):
         quoted = self.quoted
 
@@ -825,12 +832,10 @@ $$""",
 
         selcols = []
 
-        opcol = op.column
-        opname = opcol.name
-        overlaps_with_parent = opname in op.parent.schema
+        overlaps_with_parent = column_name in op.parent.schema
         computed_column = self.cast(
-            self.f.nullif(column_alias, null_sentinel), opcol.dtype.value_type
-        ).as_(opname, quoted=quoted)
+            self.f.nullif(column_alias, null_sentinel), op.column.dtype.value_type
+        ).as_(column_name, quoted=quoted)
 
         if overlaps_with_parent:
             selcols.append(

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -546,16 +546,22 @@ class TrinoCompiler(SQLGlotCompiler):
         )
 
     def visit_TableUnnest(
-        self, op, *, parent, column, offset: str | None, keep_empty: bool
+        self,
+        op,
+        *,
+        parent,
+        column,
+        column_name: str,
+        offset: str | None,
+        keep_empty: bool,
     ):
         quoted = self.quoted
 
         column_alias = sg.to_identifier(gen_name("table_unnest_column"), quoted=quoted)
 
-        opname = op.column.name
         parent_schema = op.parent.schema
-        overlaps_with_parent = opname in parent_schema
-        computed_column = column_alias.as_(opname, quoted=quoted)
+        overlaps_with_parent = column_name in parent_schema
+        computed_column = column_alias.as_(column_name, quoted=quoted)
 
         parent_alias_or_name = parent.alias_or_name
 

--- a/ibis/backends/tests/sql/snapshots/test_compiler/test_subquery_where_location/decompiled.py
+++ b/ibis/backends/tests/sql/snapshots/test_compiler/test_subquery_where_location/decompiled.py
@@ -11,7 +11,7 @@ alltypes = ibis.table(
     },
 )
 param = ibis.param("timestamp")
-f = alltypes.filter((alltypes.timestamp_col < param.name("my_param")))
+f = alltypes.filter((alltypes.timestamp_col < param))
 agg = f.aggregate([f.float_col.sum().name("foo")], by=[f.string_col])
 
 result = agg.foo.count()

--- a/ibis/backends/tests/sql/snapshots/test_sql/test_binop_with_alias_still_parenthesized/out.sql
+++ b/ibis/backends/tests/sql/snapshots/test_sql/test_binop_with_alias_still_parenthesized/out.sql
@@ -1,0 +1,5 @@
+SELECT
+  (
+    "t0"."a" + "t0"."b"
+  ) * "t0"."c" AS "x"
+FROM "t" AS "t0"

--- a/ibis/backends/tests/sql/test_compiler.py
+++ b/ibis/backends/tests/sql/test_compiler.py
@@ -196,7 +196,7 @@ def test_subquery_where_location(snapshot):
         ],
         name="alltypes",
     )
-    param = ibis.param("timestamp").name("my_param")
+    param = ibis.param("timestamp")
     expr = (
         t[["float_col", "timestamp_col", "int_col", "string_col"]][
             lambda t: t.timestamp_col < param

--- a/ibis/backends/tests/sql/test_sql.py
+++ b/ibis/backends/tests/sql/test_sql.py
@@ -143,6 +143,12 @@ def test_binop_parens(snapshot, opname, dtype, associative):
     snapshot.assert_match(combined, "out.sql")
 
 
+def test_binop_with_alias_still_parenthesized(snapshot):
+    t = ibis.table({"a": "int", "b": "int", "c": "int"}, name="t")
+    sql = to_sql(((t.a + t.b).name("d") * t.c).name("x"))
+    snapshot.assert_match(sql, "out.sql")
+
+
 @pytest.mark.parametrize(
     "expr_fn",
     [

--- a/ibis/expr/operations/relations.py
+++ b/ibis/expr/operations/relations.py
@@ -498,6 +498,7 @@ class TableUnnest(Relation):
 
     parent: Relation
     column: Value[dt.Array]
+    column_name: str
     offset: typing.Union[str, None]
     keep_empty: bool
 
@@ -507,15 +508,11 @@ class TableUnnest(Relation):
 
     @attribute
     def schema(self):
-        column = self.column
-        offset = self.offset
-
         base = self.parent.schema.fields.copy()
+        base[self.column_name] = self.column.dtype.value_type
 
-        base[column.name] = column.dtype.value_type
-
-        if offset is not None:
-            base[offset] = dt.int64
+        if self.offset is not None:
+            base[self.offset] = dt.int64
 
         return Schema(base)
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -4890,7 +4890,11 @@ class Table(Expr, _FixedTextJupyterMixin):
         """
         (column,) = self.bind(column)
         return ops.TableUnnest(
-            parent=self, column=column, offset=offset, keep_empty=keep_empty
+            parent=self,
+            column=column,
+            column_name=column.get_name(),
+            offset=offset,
+            keep_empty=keep_empty,
         ).to_expr()
 
 

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -109,14 +109,11 @@ class PandasData(DataMapper):
 
     @classmethod
     def convert_table(cls, df, schema):
-        if len(schema) != len(df.columns):
-            raise ValueError(
-                "schema column count does not match input data column count"
-            )
+        if schema.names != tuple(df.columns):
+            raise ValueError("schema names don't match input data columns")
 
         columns = {
-            name: cls.convert_column(series, dtype)
-            for (name, dtype), (_, series) in zip(schema.items(), df.items())
+            name: cls.convert_column(df[name], dtype) for name, dtype in schema.items()
         }
         df = pd.DataFrame(columns)
 

--- a/ibis/formats/tests/test_pandas.py
+++ b/ibis/formats/tests/test_pandas.py
@@ -433,3 +433,10 @@ def test_convert_dataframe_with_timezone():
     desired_schema = ibis.schema(dict(time='timestamp("EST")'))
     result = PandasData.convert_table(df.copy(), desired_schema)
     tm.assert_frame_equal(expected, result)
+
+
+def test_schema_doesnt_match_input_columns():
+    df = pd.DataFrame({"x": [1], "y": [2]})
+    schema = sch.Schema({"a": "int64", "b": "int64"})
+    with pytest.raises(ValueError, match="schema names don't match"):
+        PandasData.convert_table(df, schema)


### PR DESCRIPTION
Fixes #9975.

In the long run the best fix is probably something like #8135 (except for `Alias`) so we could automatically coerce aliases to their core values within `Value.__coerce__` (except for the very few ops where we care about preserving them). For now though this is a pragmatic fix that resolves the issue.