### PR TITLE
test(strings): improve selected string tests

### DIFF
--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -513,7 +513,7 @@ class Backend(SQLBackend):
         if schema is not None:
             schema = ibis.schema(schema)
 
-        if temp is not None:
+        if temp:
             raise NotImplementedError(
                 "Impala backend does not yet support temporary tables"
             )

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/lstrip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/lstrip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  LTRIM(`t0`.`string_col`) AS `LStrip(string_col)`
+  LTRIM(`t0`.`string_col`, ' \t\n\r\v\f') AS `LStrip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/rstrip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/rstrip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  RTRIM(`t0`.`string_col`) AS `RStrip(string_col)`
+  RTRIM(`t0`.`string_col`, ' \t\n\r\v\f') AS `RStrip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_string_builtins/test_string_builtins/strip/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  TRIM(`t0`.`string_col`) AS `Strip(string_col)`
+  RTRIM(LTRIM(`t0`.`string_col`, ' \t\n\r\v\f'), ' \t\n\r\v\f') AS `Strip(string_col)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import calendar
 import math
+from string import whitespace
 from typing import TYPE_CHECKING, Any
 
 import sqlglot as sg
@@ -96,7 +97,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
         ops.IsInf: "isInfinite",
         ops.IsNan: "isNaN",
         ops.IsNull: "isNull",
-        ops.LStrip: "trimLeft",
         ops.Ln: "log",
         ops.Log10: "log10",
         ops.MapKeys: "mapKeys",
@@ -106,7 +106,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
         ops.Median: "quantileExactExclusive",
         ops.NotNull: "isNotNull",
         ops.NullIf: "nullIf",
-        ops.RStrip: "trimRight",
         ops.RegexReplace: "replaceRegexpAll",
         ops.RowNumber: "row_number",
         ops.StartsWith: "startsWith",
@@ -114,7 +113,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
         ops.Strftime: "formatDateTime",
         ops.StringLength: "length",
         ops.StringReplace: "replaceAll",
-        ops.Strip: "trimBoth",
         ops.TimestampNow: "now",
         ops.TypeOf: "toTypeName",
         ops.Unnest: "arrayJoin",
@@ -476,6 +474,11 @@ class ClickHouseCompiler(SQLGlotCompiler):
 
     def visit_StringContains(self, op, haystack, needle):
         return self.f.position(haystack, needle) > 0
+
+    def visit_Strip(self, op, *, arg):
+        return sge.Trim(
+            this=arg, position="BOTH", expression=sge.Literal.string(whitespace)
+        )
 
     def visit_DayOfWeekIndex(self, op, *, arg):
         weekdays = len(calendar.day_name)

--- a/ibis/backends/sql/compilers/flink.py
+++ b/ibis/backends/sql/compilers/flink.py
@@ -110,7 +110,6 @@ class FlinkCompiler(SQLGlotCompiler):
         ops.StringLength: "char_length",
         ops.StringToDate: "to_date",
         ops.StringToTimestamp: "to_timestamp",
-        ops.Strip: "trim",
         ops.TypeOf: "typeof",
     }
 
@@ -588,6 +587,11 @@ class FlinkCompiler(SQLGlotCompiler):
         if where is not None:
             out = sge.Filter(this=out, expression=sge.Where(this=where))
         return out
+
+    def visit_Strip(self, op, *, arg):
+        # TODO: at some point, the upstream `BTRIM` function should work, but it
+        # currently doesn't, so we use a combination of left and right trim here
+        return self.visit_RStrip(op, arg=self.visit_LStrip(op, arg=arg))
 
 
 compiler = FlinkCompiler()

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -60,10 +60,7 @@ class ImpalaCompiler(SQLGlotCompiler):
         ops.DayOfWeekName: "dayname",
         ops.ExtractEpochSeconds: "unix_timestamp",
         ops.Hash: "fnv_hash",
-        ops.LStrip: "ltrim",
         ops.Ln: "ln",
-        ops.RStrip: "rtrim",
-        ops.Strip: "trim",
         ops.TypeOf: "typeof",
     }
 
@@ -323,6 +320,12 @@ class ImpalaCompiler(SQLGlotCompiler):
                 f"Only 'day' part is supported for date delta in the {self.dialect} backend"
             )
         return self.f.datediff(left, right)
+
+    def visit_Strip(self, op, *, arg):
+        # Impala's `TRIM` doesn't allow specifying characters to trim off, unlike
+        # Impala's `RTRIM` and `LTRIM` which accept a set of characters to
+        # remove.
+        return self.visit_RStrip(op, arg=self.visit_LStrip(op, arg=arg))
 
 
 compiler = ImpalaCompiler()

--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import string
-
 import sqlglot as sg
 import sqlglot.expressions as sge
 import toolz
@@ -87,7 +85,6 @@ class OracleCompiler(SQLGlotCompiler):
         ops.LPad: "lpad",
         ops.RPad: "rpad",
         ops.StringAscii: "ascii",
-        ops.Strip: "trim",
         ops.Mode: "stats_mode",
     }
 
@@ -492,11 +489,11 @@ class OracleCompiler(SQLGlotCompiler):
             )
         return left - right
 
-    def visit_RStrip(self, op, *, arg):
-        return self.f.anon.rtrim(arg, string.whitespace)
-
-    def visit_LStrip(self, op, *, arg):
-        return self.f.anon.ltrim(arg, string.whitespace)
+    def visit_Strip(self, op, *, arg):
+        # Oracle's `TRIM` only accepts a single character to trim off, unlike
+        # Oracle's `RTRIM` and `LTRIM` which accept a set of characters to
+        # remove.
+        return self.visit_RStrip(op, arg=self.visit_LStrip(op, arg=arg))
 
 
 compiler = OracleCompiler()

--- a/ibis/backends/sql/dialects.py
+++ b/ibis/backends/sql/dialects.py
@@ -330,7 +330,6 @@ class MSSQL(TSQL):
             sge.Variance: rename_func("var"),
             sge.VariancePop: rename_func("varp"),
             sge.Ceil: rename_func("ceiling"),
-            sge.Trim: lambda self, e: f"TRIM({e.this.sql(self.dialect)})",
             sge.DateFromParts: rename_func("datefromparts"),
         }
 

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -119,7 +119,7 @@ def test_create_table(backend, con, temp_table, func, sch):
             marks=[
                 pytest.mark.notyet(["clickhouse"], reason="Can't specify both"),
                 pytest.mark.notyet(
-                    ["pyspark", "trino", "exasol", "risingwave"],
+                    ["pyspark", "trino", "exasol", "risingwave", "impala"],
                     reason="No support for temp tables",
                 ),
                 pytest.mark.notyet(
@@ -145,7 +145,7 @@ def test_create_table(backend, con, temp_table, func, sch):
             id="temp, no overwrite",
             marks=[
                 pytest.mark.notyet(
-                    ["pyspark", "trino", "exasol", "risingwave"],
+                    ["pyspark", "trino", "exasol", "risingwave", "impala"],
                     reason="No support for temp tables",
                 ),
                 pytest.mark.notimpl(["mssql"], reason="Incorrect temp table syntax"),
@@ -157,7 +157,7 @@ def test_create_table(backend, con, temp_table, func, sch):
         ),
     ],
 )
-@pytest.mark.notimpl(["druid", "impala"])
+@pytest.mark.notimpl(["druid"])
 def test_create_table_overwrite_temp(backend, con, temp_table, temp, overwrite):
     df = pd.DataFrame(
         {

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1264,10 +1264,10 @@ def string_temp_table(backend, con):
             lambda t: t.str.lstrip(),
             id="lstrip",
             marks=[
-                pytest.mark.notimpl(
+                pytest.mark.notyet(
                     ["pyspark"],
                     raises=AssertionError,
-                    reason="doesn't strip newline or tabs",
+                    reason="Spark SQL LTRIM doesn't accept characters to trim",
                 ),
                 pytest.mark.notimpl(
                     ["bigquery", "snowflake"],
@@ -1281,10 +1281,10 @@ def string_temp_table(backend, con):
             lambda t: t.str.rstrip(),
             id="rstrip",
             marks=[
-                pytest.mark.notimpl(
+                pytest.mark.notyet(
                     ["pyspark"],
                     raises=AssertionError,
-                    reason="doesn't strip newline or tabs",
+                    reason="Spark SQL RTRIM doesn't accept characters to trim",
                 ),
                 pytest.mark.notimpl(
                     ["bigquery", "snowflake"],

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1309,14 +1309,6 @@ def string_temp_table(backend, con):
                     """,
                 ),
                 pytest.mark.notimpl(
-                    ["oracle"],
-                    raises=AssertionError,
-                    reason="""
-                    Oracle `trim` doesn't accept characters to trim
-                    (unlike oracle `rtrim` and `ltrim`)
-                    """,
-                ),
-                pytest.mark.notimpl(
                     ["flink"],
                     raises=AssertionError,
                     reason="""

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1265,7 +1265,7 @@ def string_temp_table(backend, con):
             id="lstrip",
             marks=[
                 pytest.mark.notimpl(
-                    ["impala", "pyspark"],
+                    ["pyspark"],
                     raises=AssertionError,
                     reason="doesn't strip newline or tabs",
                 ),
@@ -1282,7 +1282,7 @@ def string_temp_table(backend, con):
             id="rstrip",
             marks=[
                 pytest.mark.notimpl(
-                    ["impala", "pyspark"],
+                    ["pyspark"],
                     raises=AssertionError,
                     reason="doesn't strip newline or tabs",
                 ),
@@ -1298,16 +1298,6 @@ def string_temp_table(backend, con):
             lambda t: t.str.strip(),
             id="strip",
             marks=[
-                pytest.mark.notimpl(
-                    ["impala"],
-                    raises=AssertionError,
-                    reason="""
-                    not stripping anything but space
-                    can use
-                    TRIM(TRAILING '\t\n\r ' FROM string_col)
-                    TRIM(LEADING '\t\n\r ' FROM string_col)
-                    """,
-                ),
                 pytest.mark.notimpl(
                     ["flink"],
                     raises=AssertionError,

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1265,7 +1265,7 @@ def string_temp_table(backend, con):
             id="lstrip",
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse", "impala", "pyspark"],
+                    ["impala", "pyspark"],
                     raises=AssertionError,
                     reason="doesn't strip newline or tabs",
                 ),
@@ -1282,7 +1282,7 @@ def string_temp_table(backend, con):
             id="rstrip",
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse", "impala", "pyspark"],
+                    ["impala", "pyspark"],
                     raises=AssertionError,
                     reason="doesn't strip newline or tabs",
                 ),
@@ -1323,13 +1323,6 @@ def string_temp_table(backend, con):
                     Flink TRIM doesn't respect strip characters
                     but rstrip and lstrip work.
                     There's `BTRIM` but maybe only in dev?
-                    """,
-                ),
-                pytest.mark.notimpl(
-                    ["clickhouse"],
-                    raises=AssertionError,
-                    reason="""
-                    Clickhouse supports this, but something in our compiler is dropping it
                     """,
                 ),
             ],

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1297,17 +1297,6 @@ def string_temp_table(backend, con):
             lambda t: t.string_col.strip(),
             lambda t: t.str.strip(),
             id="strip",
-            marks=[
-                pytest.mark.notimpl(
-                    ["flink"],
-                    raises=AssertionError,
-                    reason="""
-                    Flink TRIM doesn't respect strip characters
-                    but rstrip and lstrip work.
-                    There's `BTRIM` but maybe only in dev?
-                    """,
-                ),
-            ],
         ),
         param(
             lambda t: t.string_col.upper(),

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -12,11 +12,13 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
+    MySQLOperationalError,
     OracleDatabaseError,
     PsycoPg2InternalError,
     PyODBCProgrammingError,
 )
 from ibis.common.annotations import ValidationError
+from ibis.util import gen_name
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
@@ -1047,3 +1049,349 @@ def test_concat_with_null(con, fn):
 def test_concat(con, args, method):
     expr = method(args)
     assert pd.isna(con.execute(expr))
+
+
+## String tests with hand-crafted memtables
+## (These will all fail on Druid b/c no table creation)
+
+
+@pytest.fixture(scope="session")
+def string_temp_table(backend, con):
+    better_strings = pd.DataFrame(
+        {
+            "string_col": [
+                "AbC\t",
+                "\n123\n   ",
+                "abc, 123",
+                "123",
+                "aBc",
+                "🐍",
+                "ÉéÈèêç",
+            ],
+            "index_col": [0, 1, 2, 3, 4, 5, 6],
+        }
+    )
+
+    temp_table_name = gen_name("strings")
+    temp = backend.name() not in ["exasol", "impala", "pyspark", "risingwave", "trino"]
+    if backend.name() == "druid":
+        yield "I HATE DRUID"
+    else:
+        t = con.create_table(temp_table_name, better_strings, temp=temp)
+        yield t
+        con.drop_table(temp_table_name, force=True)
+
+
+@pytest.mark.never(["druid"], reason="can't create tables")
+@pytest.mark.parametrize(
+    "result_mut, expected_func",
+    [
+        param(
+            lambda t: t.string_col.contains("c,"),
+            lambda t: t.str.contains("c,"),
+            id="contains",
+            marks=pytest.mark.notyet(
+                ["mssql"],
+                raises=PyODBCProgrammingError,
+                reason="need to fulltext index the column!?",
+            ),
+        ),
+        param(
+            lambda t: t.string_col.contains("123"),
+            lambda t: t.str.contains("123"),
+            id="contains_multi",
+            marks=pytest.mark.notyet(
+                ["mssql"],
+                raises=PyODBCProgrammingError,
+                reason="need to fulltext index the column!?",
+            ),
+        ),
+        param(
+            lambda t: t.string_col.find("123"),
+            lambda t: t.str.find("123"),
+            id="find",
+            marks=pytest.mark.notimpl("polars", raises=com.OperationNotDefinedError),
+        ),
+        param(
+            lambda t: t.string_col.rpad(4, "-"),
+            lambda t: t.str[:4].str.pad(4, side="right", fillchar="-"),
+            id="rpad",
+            marks=[
+                pytest.mark.notimpl(
+                    ["mssql"],
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notyet(
+                    ["flink", "oracle"],
+                    raises=AssertionError,
+                    reason="Treats len(🐍) == 2 so padding is off",
+                ),
+                pytest.mark.notyet(
+                    ["impala"],
+                    raises=AssertionError,
+                    reason="Treats len(🐍) == 4, len(Éé) == 4",
+                ),
+                pytest.mark.notyet(
+                    ["dask", "pandas", "polars"],
+                    raises=AssertionError,
+                    reason="Python style padding, e.g. doesn't trim strings to pad-length",
+                ),
+                pytest.mark.notyet(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="Can use rightPadUTF8 instead",
+                ),
+            ],
+        ),
+        param(
+            lambda t: t.string_col.lpad(4, "-"),
+            lambda t: t.str[:4].str.pad(4, side="left", fillchar="-"),
+            id="lpad",
+            marks=[
+                pytest.mark.notimpl(
+                    ["mssql"],
+                    raises=com.OperationNotDefinedError,
+                ),
+                pytest.mark.notyet(
+                    ["flink", "oracle"],
+                    raises=AssertionError,
+                    reason="Treats len(🐍) == 2 so padding is off",
+                ),
+                pytest.mark.notyet(
+                    ["impala"],
+                    raises=AssertionError,
+                    reason="Treats len(🐍) == 4, len(Éé) == 4",
+                ),
+                pytest.mark.notyet(
+                    ["dask", "pandas", "polars"],
+                    raises=AssertionError,
+                    reason="Python style padding, e.g. doesn't trim strings to pad-length",
+                ),
+                pytest.mark.notyet(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="Can use leftPadUTF8 instead",
+                ),
+            ],
+        ),
+        param(
+            lambda t: t.string_col.length(),
+            lambda t: t.str.len().astype("int32"),
+            id="len",
+            marks=[
+                pytest.mark.notyet(
+                    ["mysql"],
+                    raises=AssertionError,
+                    reason="thinks emoji are 4 characters long",
+                ),
+                pytest.mark.notyet(
+                    ["impala", "polars"],
+                    raises=AssertionError,
+                    reason="thinks emoji are 4 characters long, double-counts accented characters",
+                ),
+                pytest.mark.notyet(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="Can use lengthUTF8 instead",
+                ),
+            ],
+        ),
+        param(
+            lambda t: t.string_col.find_in_set(["aBc", "123"]),
+            lambda t: pd.Series([-1, -1, -1, 1, 0, -1, -1], name="tmp"),
+            id="find_in_set",
+            marks=[
+                pytest.mark.notyet(
+                    ["mysql"],
+                    raises=MySQLOperationalError,
+                    reason="operand should contain 1 column",
+                ),
+                pytest.mark.notimpl(
+                    [
+                        "bigquery",
+                        "exasol",
+                        "flink",
+                        "pyspark",
+                        "mssql",
+                        "oracle",
+                        "polars",
+                        "snowflake",
+                        "sqlite",
+                        "trino",
+                    ],
+                    raises=com.OperationNotDefinedError,
+                ),
+            ],
+        ),
+        param(
+            lambda t: t.string_col.find_in_set(["abc, 123"]),
+            lambda t: pd.Series([-1, -1, -1, -1, -1, -1, -1], name="tmp"),
+            id="find_in_set_w_comma",
+            marks=[
+                pytest.mark.notyet(
+                    [
+                        "clickhouse",
+                        "dask",
+                        "datafusion",
+                        "duckdb",
+                        "mysql",
+                        "pandas",
+                        "postgres",
+                        "risingwave",
+                    ],
+                    raises=AssertionError,
+                    reason="should return -1 if comma in field according to docstring",
+                ),
+                pytest.mark.notimpl(
+                    [
+                        "bigquery",
+                        "exasol",
+                        "flink",
+                        "pyspark",
+                        "mssql",
+                        "oracle",
+                        "polars",
+                        "snowflake",
+                        "sqlite",
+                        "trino",
+                    ],
+                    raises=com.OperationNotDefinedError,
+                ),
+            ],
+        ),
+        param(
+            lambda t: t.string_col.lstrip(),
+            lambda t: t.str.lstrip(),
+            id="lstrip",
+            marks=[
+                pytest.mark.notimpl(
+                    ["clickhouse", "impala", "pyspark", "mssql"],
+                    raises=AssertionError,
+                    reason="doesn't strip newline or tabs",
+                ),
+                pytest.mark.notimpl(
+                    ["bigquery", "snowflake"],
+                    raises=AssertionError,
+                    reason="does a full `strip` instead",
+                ),
+            ],
+        ),
+        param(
+            lambda t: t.string_col.rstrip(),
+            lambda t: t.str.rstrip(),
+            id="rstrip",
+            marks=[
+                pytest.mark.notimpl(
+                    ["clickhouse", "impala", "pyspark", "mssql"],
+                    raises=AssertionError,
+                    reason="doesn't strip newline or tabs",
+                ),
+                pytest.mark.notimpl(
+                    ["bigquery", "snowflake"],
+                    raises=AssertionError,
+                    reason="does a full `strip` instead",
+                ),
+            ],
+        ),
+        param(
+            lambda t: t.string_col.strip(),
+            lambda t: t.str.strip(),
+            id="strip",
+            marks=[
+                pytest.mark.notimpl(
+                    ["impala", "mssql"],
+                    raises=AssertionError,
+                    reason="""
+                    not stripping anything but space
+                    can use
+                    TRIM(TRAILING '\t\n\r ' FROM string_col)
+                    TRIM(LEADING '\t\n\r ' FROM string_col)
+                    """,
+                ),
+                pytest.mark.notimpl(
+                    ["oracle"],
+                    raises=AssertionError,
+                    reason="""
+                    Oracle `trim` doesn't accept characters to trim
+                    (unlike oracle `rtrim` and `ltrim`)
+                    """,
+                ),
+                pytest.mark.notimpl(
+                    ["flink"],
+                    raises=AssertionError,
+                    reason="""
+                    Flink TRIM doesn't respect strip characters
+                    but rstrip and lstrip work.
+                    There's `BTRIM` but maybe only in dev?
+                    """,
+                ),
+                pytest.mark.notimpl(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="""
+                    Clickhouse supports this, but something in our compiler is dropping it
+                    """,
+                ),
+            ],
+        ),
+        param(
+            lambda t: t.string_col.upper(),
+            lambda t: t.str.upper(),
+            id="upper",
+            marks=[
+                pytest.mark.notyet(
+                    ["impala", "risingwave", "sqlite"],
+                    raises=AssertionError,
+                    reason="no upper on accented characters",
+                ),
+                pytest.mark.notyet(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="no upper on accented characters, can use upperUTF8 instead",
+                ),
+            ],
+        ),
+        param(
+            lambda t: t.string_col.lower(),
+            lambda t: t.str.lower(),
+            id="lower",
+            marks=[
+                pytest.mark.notyet(
+                    ["impala", "risingwave", "sqlite"],
+                    raises=AssertionError,
+                    reason="no lower on accented characters",
+                ),
+                pytest.mark.notyet(
+                    ["clickhouse"],
+                    raises=AssertionError,
+                    reason="no lower on accented characters, can use lowerUTF8 instead",
+                ),
+            ],
+        ),
+    ],
+)
+def test_string_methods_no_regex(string_temp_table, backend, result_mut, expected_func):
+    """
+    ┏━━━━━━━━━━━━┓
+    ┃ string_col ┃
+    ┡━━━━━━━━━━━━┩
+    │ string     │
+    ├────────────┤
+    │ AbC\t      │
+    │ \n123\n    │
+    │ abc, 123   │
+    │ 123        │
+    │ aBc        │
+    │ 🐍         │
+    │ ÉéÈèêç     │
+    └────────────┘
+    """
+    t = string_temp_table
+    series = t.order_by(t.index_col).string_col.name("tmp").to_pandas()
+
+    expr = t.mutate(string_col=result_mut).order_by(t.index_col)
+    result = expr.string_col.name("tmp").to_pandas()
+
+    expected = expected_func(series)
+
+    backend.assert_series_equal(result, expected)

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1265,7 +1265,7 @@ def string_temp_table(backend, con):
             id="lstrip",
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse", "impala", "pyspark", "mssql"],
+                    ["clickhouse", "impala", "pyspark"],
                     raises=AssertionError,
                     reason="doesn't strip newline or tabs",
                 ),
@@ -1282,7 +1282,7 @@ def string_temp_table(backend, con):
             id="rstrip",
             marks=[
                 pytest.mark.notimpl(
-                    ["clickhouse", "impala", "pyspark", "mssql"],
+                    ["clickhouse", "impala", "pyspark"],
                     raises=AssertionError,
                     reason="doesn't strip newline or tabs",
                 ),
@@ -1299,7 +1299,7 @@ def string_temp_table(backend, con):
             id="strip",
             marks=[
                 pytest.mark.notimpl(
-                    ["impala", "mssql"],
+                    ["impala"],
                     raises=AssertionError,
                     reason="""
                     not stripping anything but space


### PR DESCRIPTION
BigQuery:

-   `rstrip` and `lstrip` are broken because of a SQLGlot bug, already fixed upstream.

Snowflake:

-   `rstrip` and `lstrip` are broken because of a SQLGlot bug, already fixed upstream.

MSSQL:

-   `contains` might work, but requires &ldquo;fulltext index&rdquo; and I can&rsquo;t be bothered
-   `rpad` not defined
-   `lpad` not defined
-   `find_in_set` not defined

Oracle:

-   Treats `len(🐍) == 2`, should be able to use `LENGTHC` instead
-   `strip` maps to `trim`, but `TRIM` doesn&rsquo;t accept custom characters, unlike `RTRIM` and `LTRIM`

Flink:

-   Treats `len(🐍) == 2`
-   `strip` maps to `trim`, but `TRIM` doesn&rsquo;t accept custom characters, unlike `RTRIM` and `LTRIM`
    There is a function in the docs called `BTRIM` but maybe it&rsquo;s only in dev?  But that should work?

Impala (woof):

-   Treats `len(🐍) == 4`, `len(Éé) == 4`
-   No `TRIM` for anything but whitespace.  This appears to be a limitation of our Impala compiler.
-   Accented characters do not get upper-cased or lower-cased, just left as-is.

Risingwave

-   Accented characters do not get upper-cased or lower-cased, just left as-is.

MySQL

-   Treats `len(🐍) == 4`, should use `CHAR_LENGTH`

PySpark

-   `TRIM` only trims spaces

SQLite

-   Accented characters do not get upper-cased or lower-cased, just left as-is.

Clickhouse

-   Lengths of accented characters and emoji are of byte width, not character length
-   This also impacts padding
    BUT:
    There are UTF8 aware versionf for all of these


<a id="org8b87fa0"></a>

# What should the string APIs do?

## `find_in_set`

We state in the docs for `find_in_set` that if a value contains a comma, we
return `-1` (the same behavior as if there is no match).  Currently no backend
does this, the 5 backends that support the operation all return the index of the
comma-containing field (`duckdb`, `datafusion`, `mysql`, `postgres`,
`risingwave`)

We can just update the docstring?


<a id="org1899fed"></a>

## Padding

The SQL convention with padding is that if the original string is longer than
the pad length, the string is trimmed to that length.

The Python convention is to leave strings >= pad<sub>length</sub> alone.

Which would we like to adopt?

I think the SQL convention here is <span class="underline">terrible</span> and we should follow Python.


<a id="org641a8d5"></a>

## UTF-8

Some backends will support this, some won&rsquo;t, but, we should be consistent.

I think that `length`, `lpad`, and `rpad` should all be UTF-8 variants.

Propose adding `len_bytes` as an additional string method for the byte length of a string.
