### PR TITLE
fix(mssql): ensure that dot-sql can be executed when column names are not provided

### DIFF
--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -307,6 +307,9 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema):
             elif newtyp.is_timestamp():
                 newtyp = newtyp.copy(scale=scale)
 
+            if name is None:
+                name = util.gen_name("col")
+
             schema[name] = newtyp
 
         return sch.Schema(schema)

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -13,7 +13,11 @@ import ibis.common.exceptions as com
 from ibis import _
 from ibis.backends import _get_backend_names
 from ibis.backends.tests.base import PYTHON_SHORT_VERSION
-from ibis.backends.tests.errors import GoogleBadRequest, OracleDatabaseError
+from ibis.backends.tests.errors import (
+    ExaQueryError,
+    GoogleBadRequest,
+    OracleDatabaseError,
+)
 
 pd = pytest.importorskip("pandas")
 tm = pytest.importorskip("pandas.testing")
@@ -333,6 +337,10 @@ def test_embedded_cte(alltypes, ftname_raw):
 
 
 @dot_sql_never
+@pytest.mark.never(["exasol"], raises=ExaQueryError, reason="backend requires aliasing")
+@pytest.mark.never(
+    ["oracle"], raises=OracleDatabaseError, reason="backend requires aliasing"
+)
 def test_unnamed_columns(con):
     sql = "SELECT 'a', 1 AS col42"
     sgexpr = sg.parse_one(sql, read="duckdb")

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -330,3 +330,22 @@ def test_embedded_cte(alltypes, ftname_raw):
     expr = alltypes.sql(sql, dialect="duckdb")
     result = expr.head(1).execute()
     assert len(result) == 1
+
+
+@dot_sql_never
+def test_unnamed_columns(con):
+    sql = "SELECT 'a' || 'b', 1 AS col42"
+    sgexpr = sg.parse_one(sql, read="duckdb")
+    expr = con.sql(sgexpr.sql(con.dialect))
+
+    schema = expr.schema()
+    names = schema.names
+    types = schema.types
+
+    assert len(names) == 2
+
+    assert names[0]
+    assert names[1] == "col42"
+
+    assert types[0].is_string()
+    assert types[1].is_integer()

--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -334,7 +334,7 @@ def test_embedded_cte(alltypes, ftname_raw):
 
 @dot_sql_never
 def test_unnamed_columns(con):
-    sql = "SELECT 'a' || 'b', 1 AS col42"
+    sql = "SELECT 'a', 1 AS col42"
     sgexpr = sg.parse_one(sql, read="duckdb")
     expr = con.sql(sgexpr.sql(con.dialect))
 


### PR DESCRIPTION
Closes #10025.