### PR TITLE
chore(snowflake): fix dot sql test on snowflake (casing)

### DIFF
--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -353,7 +353,8 @@ def test_unnamed_columns(con):
     assert len(names) == 2
 
     assert names[0]
-    assert names[1] == "col42"
+    # Snowflake shouts everything
+    assert names[1].lower() == "col42"
 
     assert types[0].is_string()
     assert types[1].is_integer()


### PR DESCRIPTION
## Description of changes
Getting CI passing again on `main`

Test is now passing on Snowflake:

```sh
🐚 pytest -m snowflake ibis/backends/tests/test_dot_sql.py::test_unnamed_columns
================================ test session starts ================================
platform linux -- Python 3.10.14, pytest-8.3.2, pluggy-1.5.0
Using --randomly-seed=2220534719
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/gil/github.com/ibis-project/ibis
configfile: pyproject.toml
plugins: pytest_httpserver-1.1.0, snapshot-0.9.0, anyio-4.4.0, randomly-3.15.0, mock-3.14.0, benchmark-4.0.0, timeout-2.3.1, cov-5.0.0, deadfixtures-2.2.1, repeat-0.9.3, clarity-1.0.1, xdist-3.6.1, hypothesis-6.111.2
collected 20 items / 19 deselected / 1 selected                                     

ibis/backends/tests/test_dot_sql.py .                                         [100%]

========================= 1 passed, 19 deselected in 22.81s =========================
```