### PR TITLE
feat(mssql): add startswith and endswith ops

### DIFF
--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -89,7 +89,6 @@ class MSSQLCompiler(SQLGlotCompiler):
         ops.Covariance,
         ops.CountDistinctStar,
         ops.DateDiff,
-        ops.EndsWith,
         ops.IntervalAdd,
         ops.IntervalSubtract,
         ops.IntervalMultiply,
@@ -108,7 +107,6 @@ class MSSQLCompiler(SQLGlotCompiler):
         ops.RegexSplit,
         ops.RowID,
         ops.RPad,
-        ops.StartsWith,
         ops.StringSplit,
         ops.StringToDate,
         ops.StringToTimestamp,
@@ -521,6 +519,12 @@ class MSSQLCompiler(SQLGlotCompiler):
 
     visit_DateAdd = visit_TimestampAdd
     visit_DateSub = visit_TimestampSub
+
+    def visit_StartsWith(self, op, *, arg, start):
+        return arg.like(self.f.concat(start, "%"))
+
+    def visit_EndsWith(self, op, *, arg, end):
+        return arg.like(self.f.concat("%", end))
 
 
 compiler = MSSQLCompiler()

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -513,9 +513,6 @@ def uses_java_re(t):
             ),
             lambda t: t.int_col == 1,
             id="startswith",
-            marks=[
-                pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError),
-            ],
         ),
         param(
             lambda t: t.int_col.cases([(1, "abcd"), (2, "ABCD")], "dabc").endswith(
@@ -523,25 +520,16 @@ def uses_java_re(t):
             ),
             lambda t: t.int_col == 1,
             id="endswith",
-            marks=[
-                pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError),
-            ],
         ),
         param(
             lambda t: t.date_string_col.startswith("2010-01"),
             lambda t: t.date_string_col.str.startswith("2010-01"),
             id="startswith-simple",
-            marks=[
-                pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError),
-            ],
         ),
         param(
             lambda t: t.date_string_col.endswith("/10"),
             lambda t: t.date_string_col.str.endswith("/10"),
             id="endswith-simple",
-            marks=[
-                pytest.mark.notimpl(["mssql"], raises=com.OperationNotDefinedError),
-            ],
         ),
         param(
             lambda t: t.string_col.strip(),


### PR DESCRIPTION
## Description of changes
Support the StartsWith and EndsWith string operations for the Microsoft SQL Server backend. I noticed that MSSQL was the only backend missing these. 

Admittedly, I borrowed the implementations from the SQLite compiler, but it all seems to work as intended. 

https://github.com/ibis-project/ibis/blob/92e88f05afca6c10a34b399a43c75deae2d1e593/ibis/backends/sql/compilers/sqlite.py#L144-L148
