### PR TITLE
perf(duckdb): make default backend initialization a bit cheaper

### DIFF
--- a/ibis/config.py
+++ b/ibis/config.py
@@ -178,7 +178,7 @@ def _default_backend() -> Any:
         return backend
 
     try:
-        import duckdb as _  # noqa: F401
+        import duckdb
     except ImportError:
         raise com.IbisError(
             """\
@@ -203,7 +203,9 @@ For more information on available backends, visit https://ibis-project.org/insta
 
     import ibis
 
-    options.default_backend = con = ibis.duckdb.connect(":memory:")
+    options.default_backend = con = ibis.duckdb.from_connection(
+        duckdb.default_connection
+    )
     return con
 
 


### PR DESCRIPTION
## Description of changes

This PR makes the default backend slightly faster to initialize by using the
`duckdb` module's `default_connection` attribute.

Not a massive savings, but local testing shows around a 10% speedup without a ton
of additional code on our side.
