### PR TITLE
docs(jupyterlite): disable insecure extensions

### DIFF
--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -1,0 +1,11 @@
+{
+  "jupyter-lite-schema-version": 0,
+  "jupyter-config-data": {
+    "appName": "Ibis JupyterLite Console",
+    "disabledExtensions": [
+      "@jupyterlab/markdownviewer-extension:plugin",
+      "@jupyterlab/mathjax-extension:plugin",
+      "@jupyterlab/mathjax2-extension:plugin"
+    ]
+  }
+}


### PR DESCRIPTION
## Description of changes

In #10046, our robot overlords determined that we should upgrade jupyterlite,
but that is not tenable for us until the next release of Pyodide.

So, until that happens, we need to disable the insecure extensions.

Users will lose the ability to display math in our web console for now.
