### PR TITLE
refactor(backends): split memtable existence check out

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1109,11 +1109,15 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
         if self.supports_python_udfs:
             raise NotImplementedError(self.name)
 
+    def _in_memory_table_exists(self, name: str) -> bool:
+        return name in self.list_tables()
+
     def _register_in_memory_tables(self, expr: ir.Expr) -> None:
         for memtable in expr.op().find(ops.InMemoryTable):
-            self._register_in_memory_table(memtable)
+            if not self._in_memory_table_exists(memtable.name):
+                self._register_in_memory_table(memtable)
 
-    def _register_in_memory_table(self, op: ops.InMemoryTable):
+    def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         if self.supports_in_memory_tables:
             raise NotImplementedError(
                 f"{self.name} must implement `_register_in_memory_table` to support in-memory tables"

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -33,7 +33,6 @@ class Backend(SQLBackend):
     name = "druid"
     compiler = sc.druid.compiler
     supports_create_or_replace = False
-    supports_in_memory_tables = True
 
     @property
     def version(self) -> str:

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -75,9 +75,11 @@ class Backend(BaseBackend, NoUrl):
         schema = sch.infer(self._tables[name])
         return ops.DatabaseTable(name, schema, self).to_expr()
 
+    def _in_memory_table_exists(self, name: str) -> bool:
+        return name in self._tables
+
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
-        if (name := op.name) not in self._tables:
-            self._add_table(name, op.data.to_polars(op.schema).lazy())
+        self._add_table(op.name, op.data.to_polars(op.schema).lazy())
 
     @deprecated(
         as_of="9.1",

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -414,7 +414,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         schema = PySparkSchema.from_ibis(op.schema)
         df = self._session.createDataFrame(data=op.data.to_frame(), schema=schema)
-        df.createOrReplaceTempView(op.name)
+        df.createTempView(op.name)
 
     @contextlib.contextmanager
     def _safe_raw_sql(self, query: str) -> Any:

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -270,27 +270,26 @@ class Backend(PostgresBackend):
                 f"got null typed columns: {null_columns}"
             )
 
-        # only register if we haven't already done so
-        if (name := op.name) not in self.list_tables():
-            quoted = self.compiler.quoted
+        name = op.name
+        quoted = self.compiler.quoted
 
-            create_stmt = sg.exp.Create(
-                kind="TABLE",
-                this=sg.exp.Schema(
-                    this=sg.to_identifier(name, quoted=quoted),
-                    expressions=schema.to_sqlglot(self.dialect),
-                ),
-            )
-            create_stmt_sql = create_stmt.sql(self.dialect)
+        create_stmt = sg.exp.Create(
+            kind="TABLE",
+            this=sg.exp.Schema(
+                this=sg.to_identifier(name, quoted=quoted),
+                expressions=schema.to_sqlglot(self.dialect),
+            ),
+        )
+        create_stmt_sql = create_stmt.sql(self.dialect)
 
-            df = op.data.to_frame()
-            data = df.itertuples(index=False)
-            sql = self._build_insert_template(
-                name, schema=schema, columns=True, placeholder="%s"
-            )
-            with self.begin() as cur:
-                cur.execute(create_stmt_sql)
-                extras.execute_batch(cur, sql, data, 128)
+        df = op.data.to_frame()
+        data = df.itertuples(index=False)
+        sql = self._build_insert_template(
+            name, schema=schema, columns=True, placeholder="%s"
+        )
+        with self.begin() as cur:
+            cur.execute(create_stmt_sql)
+            extras.execute_batch(cur, sql, data, 128)
 
     def list_databases(
         self, *, like: str | None = None, catalog: str | None = None

--- a/ibis/backends/snowflake/tests/test_client.py
+++ b/ibis/backends/snowflake/tests/test_client.py
@@ -97,8 +97,8 @@ def test_repeated_memtable_registration(simple_con, mocker):
     for _ in range(n):
         tm.assert_frame_equal(simple_con.execute(t), expected)
 
-    # assert that we called _register_in_memory_table exactly n times
-    assert spy.call_count == n
+    # assert that we called _register_in_memory_table exactly once
+    spy.assert_called_once()
 
 
 def test_timestamp_tz_column(simple_con):

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -369,9 +369,6 @@ def test_rename_table(con, temp_table, temp_table_orig):
 
 @mark.notimpl(["polars", "druid"])
 @mark.never(["impala", "pyspark"], reason="No non-nullable datatypes")
-@mark.notyet(
-    ["trino"], reason="trino doesn't support NOT NULL in its in-memory catalog"
-)
 @pytest.mark.notimpl(
     ["flink"],
     raises=com.IbisError,

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -11,7 +11,6 @@ import sqlglot.expressions as sge
 import ibis
 import ibis.expr.schema as sch
 from ibis.backends.conftest import TEST_TABLES
-from ibis.backends.sql.datatypes import TrinoType
 from ibis.backends.tests.base import ServiceBackendTest
 
 if TYPE_CHECKING:
@@ -182,13 +181,7 @@ def generate_tpc_tables(suite_name, *, data_dir):
             exists=True,
             this=sge.Schema(
                 this=sg.table(name, db=suite_name, catalog="hive", quoted=True),
-                expressions=[
-                    sge.ColumnDef(
-                        this=sg.to_identifier(col, quoted=True),
-                        kind=TrinoType.from_ibis(dtype),
-                    )
-                    for col, dtype in schema.items()
-                ],
+                expressions=schema.to_sqlglot("trino"),
             ),
             properties=sge.Properties(
                 expressions=[


### PR DESCRIPTION
First of ~two~ a few PRs to implement #10044. This one factors out memtable existence checks to allow a generic implementation of register-only-if-not-exists, as well as to allow improvement over time of this check as we discover faster existence check implementations.