### PR TITLE
fix(sqlite): list temporary tables by default

### DIFF
--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -187,7 +187,7 @@ class Backend(SQLBackend, UrlFromPath):
                     sge.convert("sqlite_temp_master"),
                 ),
             )
-            .sql(self.name)
+            .sql(self.dialect)
         )
         with self._safe_raw_sql(sql) as cur:
             results = [r[0] for r in cur.fetchall()]

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -180,13 +180,11 @@ class Backend(SQLBackend, UrlFromPath):
             .where(
                 C.schema.isin(*map(sge.convert, schemas)),
                 C.type.isin(sge.convert("table"), sge.convert("view")),
-                ~(
-                    C.name.isin(
-                        sge.convert("sqlite_schema"),
-                        sge.convert("sqlite_master"),
-                        sge.convert("sqlite_temp_schema"),
-                        sge.convert("sqlite_temp_master"),
-                    )
+                ~C.name.isin(
+                    sge.convert("sqlite_schema"),
+                    sge.convert("sqlite_master"),
+                    sge.convert("sqlite_temp_schema"),
+                    sge.convert("sqlite_temp_master"),
                 ),
             )
             .sql(self.name)

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -175,7 +175,7 @@ class Backend(SQLBackend, UrlFromPath):
             schemas = [database]
 
         sql = (
-            sg.select("name")
+            sg.select(C.name)
             .from_(F.pragma_table_list())
             .where(
                 C.schema.isin(*map(sge.convert, schemas)),

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -159,6 +159,9 @@ class Backend(SQLBackend, UrlFromPath):
     ) -> list[str]:
         """List the tables in the database.
 
+        If `database` is None, the current database is used, and temporary
+        tables are included in the result.
+
         Parameters
         ----------
         like
@@ -169,12 +172,15 @@ class Backend(SQLBackend, UrlFromPath):
         """
         if database is None:
             database = "main"
+            schemas = [database, "temp"]
+        else:
+            schemas = [database]
 
         sql = (
             sg.select("name")
             .from_(F.pragma_table_list())
             .where(
-                C.schema.eq(sge.convert(database)),
+                C.schema.isin(*map(sge.convert, schemas)),
                 C.type.isin(sge.convert("table"), sge.convert("view")),
                 ~(
                     C.name.isin(

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -153,9 +153,7 @@ class Backend(SQLBackend, UrlFromPath):
         return sorted(self._filter_with_like(results, like))
 
     def list_tables(
-        self,
-        like: str | None = None,
-        database: str | None = None,
+        self, like: str | None = None, database: str | None = None
     ) -> list[str]:
         """List the tables in the database.
 

--- a/ibis/backends/sqlite/tests/test_client.py
+++ b/ibis/backends/sqlite/tests/test_client.py
@@ -88,3 +88,10 @@ def test_has_operation(con):
     assert con.has_operation(ops.Sample)
     # Handled by visit_* method
     assert con.has_operation(ops.Cast)
+
+
+def test_list_temp_tables_by_default(con):
+    name = ibis.util.gen_name("sqlite_temp_table")
+    con.create_table(name, schema={"a": "int"}, temp=True)
+    assert name in con.list_tables(database="temp")
+    assert name in con.list_tables()


### PR DESCRIPTION
List temporary tables in sqlite by default when `database` is `None`.