### PR TITLE
feat(api): add `to_sqlglot` method to `Schema` objects

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -674,13 +674,7 @@ class Backend(SQLBackend, CanCreateDatabase):
 
         this = sge.Schema(
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
-            expressions=[
-                sge.ColumnDef(
-                    this=sg.to_identifier(name, quoted=self.compiler.quoted),
-                    kind=self.compiler.type_mapper.from_ibis(typ),
-                )
-                for name, typ in (schema or obj.schema()).items()
-            ],
+            expressions=(schema or obj.schema()).to_sqlglot(self.dialect),
         )
         properties = [
             # the engine cannot be quoted, since clickhouse won't allow e.g.,

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -657,20 +657,10 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         table_ident = sg.table(name, db=database, quoted=quoted)
 
         if query is None:
-            column_defs = [
-                sge.ColumnDef(
-                    this=sg.to_identifier(colname, quoted=quoted),
-                    kind=self.compiler.type_mapper.from_ibis(typ),
-                    constraints=(
-                        None
-                        if typ.nullable
-                        else [sge.ColumnConstraint(kind=sge.NotNullColumnConstraint())]
-                    ),
-                )
-                for colname, typ in (schema or table.schema()).items()
-            ]
-
-            target = sge.Schema(this=table_ident, expressions=column_defs)
+            target = sge.Schema(
+                this=table_ident,
+                expressions=(schema or table.schema()).to_sqlglot(self.dialect),
+            )
         else:
             target = table_ident
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -173,19 +173,6 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         else:
             query = None
 
-        column_defs = [
-            sge.ColumnDef(
-                this=sg.to_identifier(colname, quoted=self.compiler.quoted),
-                kind=self.compiler.type_mapper.from_ibis(typ),
-                constraints=(
-                    None
-                    if typ.nullable
-                    else [sge.ColumnConstraint(kind=sge.NotNullColumnConstraint())]
-                ),
-            )
-            for colname, typ in (schema or table.schema()).items()
-        ]
-
         if overwrite:
             temp_name = util.gen_name("duckdb_table")
         else:
@@ -194,7 +181,10 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         initial_table = sg.table(
             temp_name, catalog=catalog, db=database, quoted=self.compiler.quoted
         )
-        target = sge.Schema(this=initial_table, expressions=column_defs)
+        target = sge.Schema(
+            this=initial_table,
+            expressions=(schema or table.schema()).to_sqlglot(self.dialect),
+        )
 
         create_stmt = sge.Create(
             kind="TABLE",

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -357,10 +357,11 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
         else:
             temp_name = name
 
+        if not schema:
+            schema = table.schema()
+
         table = sg.table(temp_name, catalog=database, quoted=quoted)
-        target = sge.Schema(
-            this=table, expressions=(schema or table.schema()).to_sqlglot(self.dialect)
-        )
+        target = sge.Schema(this=table, expressions=schema.to_sqlglot(self.dialect))
 
         create_stmt = sge.Create(kind="TABLE", this=target)
 

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -644,13 +644,14 @@ GO"""
         else:
             temp_name = name
 
+        if not schema:
+            schema = table.schema()
+
         table = sg.table(
             "#" * temp + temp_name, catalog=catalog, db=db, quoted=self.compiler.quoted
         )
         raw_table = sg.table(temp_name, catalog=catalog, db=db, quoted=False)
-        target = sge.Schema(
-            this=table, expressions=(schema or table.schema()).to_sqlglot(self.dialect)
-        )
+        target = sge.Schema(this=table, expressions=schema.to_sqlglot(self.dialect))
 
         create_stmt = sge.Create(
             kind="TABLE",

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -639,19 +639,6 @@ GO"""
         else:
             query = None
 
-        column_defs = [
-            sge.ColumnDef(
-                this=sg.to_identifier(colname, quoted=self.compiler.quoted),
-                kind=self.compiler.type_mapper.from_ibis(typ),
-                constraints=(
-                    None
-                    if typ.nullable
-                    else [sge.ColumnConstraint(kind=sge.NotNullColumnConstraint())]
-                ),
-            )
-            for colname, typ in (schema or table.schema()).items()
-        ]
-
         if overwrite:
             temp_name = util.gen_name(f"{self.name}_table")
         else:
@@ -661,7 +648,9 @@ GO"""
             "#" * temp + temp_name, catalog=catalog, db=db, quoted=self.compiler.quoted
         )
         raw_table = sg.table(temp_name, catalog=catalog, db=db, quoted=False)
-        target = sge.Schema(this=table, expressions=column_defs)
+        target = sge.Schema(
+            this=table, expressions=(schema or table.schema()).to_sqlglot(self.dialect)
+        )
 
         create_stmt = sge.Create(
             kind="TABLE",

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -417,26 +417,15 @@ class Backend(SQLBackend, CanCreateDatabase):
         else:
             query = None
 
-        column_defs = [
-            sge.ColumnDef(
-                this=sg.to_identifier(colname, quoted=self.compiler.quoted),
-                kind=self.compiler.type_mapper.from_ibis(typ),
-                constraints=(
-                    None
-                    if typ.nullable
-                    else [sge.ColumnConstraint(kind=sge.NotNullColumnConstraint())]
-                ),
-            )
-            for colname, typ in (schema or table.schema()).items()
-        ]
-
         if overwrite:
             temp_name = util.gen_name(f"{self.name}_table")
         else:
             temp_name = name
 
         table = sg.table(temp_name, catalog=database, quoted=self.compiler.quoted)
-        target = sge.Schema(this=table, expressions=column_defs)
+        target = sge.Schema(
+            this=table, expressions=(schema or table.schema()).to_sqlglot(self.dialect)
+        )
 
         create_stmt = sge.Create(
             kind="TABLE",

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -422,10 +422,11 @@ class Backend(SQLBackend, CanCreateDatabase):
         else:
             temp_name = name
 
+        if not schema:
+            schema = table.schema()
+
         table = sg.table(temp_name, catalog=database, quoted=self.compiler.quoted)
-        target = sge.Schema(
-            this=table, expressions=(schema or table.schema()).to_sqlglot(self.dialect)
-        )
+        target = sge.Schema(this=table, expressions=schema.to_sqlglot(self.dialect))
 
         create_stmt = sge.Create(
             kind="TABLE",

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -433,26 +433,16 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
         else:
             query = None
 
-        column_defs = [
-            sge.ColumnDef(
-                this=sg.to_identifier(colname, quoted=self.compiler.quoted),
-                kind=self.compiler.type_mapper.from_ibis(typ),
-                constraints=(
-                    None
-                    if typ.nullable
-                    else [sge.ColumnConstraint(kind=sge.NotNullColumnConstraint())]
-                ),
-            )
-            for colname, typ in (schema or table.schema()).items()
-        ]
-
         if overwrite:
             temp_name = util.gen_name(f"{self.name}_table")
         else:
             temp_name = name
 
         initial_table = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
-        target = sge.Schema(this=initial_table, expressions=column_defs)
+        target = sge.Schema(
+            this=initial_table,
+            expressions=(schema or table.schema()).to_sqlglot(self.dialect),
+        )
 
         create_stmt = sge.Create(
             kind="TABLE",
@@ -518,27 +508,11 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
         # only register if we haven't already done so
         if (name := op.name) not in self.list_tables():
             quoted = self.compiler.quoted
-            column_defs = [
-                sge.ColumnDef(
-                    this=sg.to_identifier(colname, quoted=quoted),
-                    kind=self.compiler.type_mapper.from_ibis(typ),
-                    constraints=(
-                        None
-                        if typ.nullable
-                        else [
-                            sg.exp.ColumnConstraint(
-                                kind=sg.exp.NotNullColumnConstraint()
-                            )
-                        ]
-                    ),
-                )
-                for colname, typ in schema.items()
-            ]
-
             create_stmt = sge.Create(
                 kind="TABLE",
                 this=sg.exp.Schema(
-                    this=sg.to_identifier(name, quoted=quoted), expressions=column_defs
+                    this=sg.to_identifier(name, quoted=quoted),
+                    expressions=schema.to_sqlglot(self.dialect),
                 ),
                 properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
             ).sql(self.name)

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -102,27 +102,11 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         # only register if we haven't already done so
         if (name := op.name) not in self.list_tables():
             quoted = self.compiler.quoted
-            column_defs = [
-                sg.exp.ColumnDef(
-                    this=sg.to_identifier(colname, quoted=quoted),
-                    kind=self.compiler.type_mapper.from_ibis(typ),
-                    constraints=(
-                        None
-                        if typ.nullable
-                        else [
-                            sg.exp.ColumnConstraint(
-                                kind=sg.exp.NotNullColumnConstraint()
-                            )
-                        ]
-                    ),
-                )
-                for colname, typ in schema.items()
-            ]
-
             create_stmt = sg.exp.Create(
                 kind="TABLE",
                 this=sg.exp.Schema(
-                    this=sg.to_identifier(name, quoted=quoted), expressions=column_defs
+                    this=sg.to_identifier(name, quoted=quoted),
+                    expressions=schema.to_sqlglot(self.dialect),
                 ),
                 properties=sg.exp.Properties(expressions=[sge.TemporaryProperty()]),
             )
@@ -672,26 +656,15 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         else:
             query = None
 
-        column_defs = [
-            sge.ColumnDef(
-                this=sg.to_identifier(colname, quoted=self.compiler.quoted),
-                kind=self.compiler.type_mapper.from_ibis(typ),
-                constraints=(
-                    None
-                    if typ.nullable
-                    else [sge.ColumnConstraint(kind=sge.NotNullColumnConstraint())]
-                ),
-            )
-            for colname, typ in (schema or table.schema()).items()
-        ]
-
         if overwrite:
             temp_name = util.gen_name(f"{self.name}_table")
         else:
             temp_name = name
 
         table = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
-        target = sge.Schema(this=table, expressions=column_defs)
+        target = sge.Schema(
+            this=table, expressions=(schema or table.schema()).to_sqlglot(self.dialect)
+        )
 
         create_stmt = sge.Create(
             kind="TABLE",

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -661,10 +661,11 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         else:
             temp_name = name
 
+        if not schema:
+            schema = table.schema()
+
         table = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
-        target = sge.Schema(
-            this=table, expressions=(schema or table.schema()).to_sqlglot(self.dialect)
-        )
+        target = sge.Schema(this=table, expressions=schema.to_sqlglot(self.dialect))
 
         create_stmt = sge.Create(
             kind="TABLE",

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -209,26 +209,15 @@ class Backend(PostgresBackend):
         else:
             query = None
 
-        column_defs = [
-            sge.ColumnDef(
-                this=sg.to_identifier(colname, quoted=self.compiler.quoted),
-                kind=self.compiler.type_mapper.from_ibis(typ),
-                constraints=(
-                    None
-                    if typ.nullable
-                    else [sge.ColumnConstraint(kind=sge.NotNullColumnConstraint())]
-                ),
-            )
-            for colname, typ in (schema or table.schema()).items()
-        ]
-
         if overwrite:
             temp_name = util.gen_name(f"{self.name}_table")
         else:
             temp_name = name
 
         table = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
-        target = sge.Schema(this=table, expressions=column_defs)
+        target = sge.Schema(
+            this=table, expressions=(schema or table.schema()).to_sqlglot(self.dialect)
+        )
 
         if connector_properties is None:
             create_stmt = sge.Create(
@@ -283,27 +272,12 @@ class Backend(PostgresBackend):
         # only register if we haven't already done so
         if (name := op.name) not in self.list_tables():
             quoted = self.compiler.quoted
-            column_defs = [
-                sg.exp.ColumnDef(
-                    this=sg.to_identifier(colname, quoted=quoted),
-                    kind=self.compiler.type_mapper.from_ibis(typ),
-                    constraints=(
-                        None
-                        if typ.nullable
-                        else [
-                            sg.exp.ColumnConstraint(
-                                kind=sg.exp.NotNullColumnConstraint()
-                            )
-                        ]
-                    ),
-                )
-                for colname, typ in schema.items()
-            ]
 
             create_stmt = sg.exp.Create(
                 kind="TABLE",
                 this=sg.exp.Schema(
-                    this=sg.to_identifier(name, quoted=quoted), expressions=column_defs
+                    this=sg.to_identifier(name, quoted=quoted),
+                    expressions=schema.to_sqlglot(self.dialect),
                 ),
             )
             create_stmt_sql = create_stmt.sql(self.dialect)
@@ -442,21 +416,8 @@ class Backend(PostgresBackend):
         Table
             Table expression
         """
-        column_defs = [
-            sge.ColumnDef(
-                this=sg.to_identifier(colname, quoted=self.compiler.quoted),
-                kind=self.compiler.type_mapper.from_ibis(typ),
-                constraints=(
-                    None
-                    if typ.nullable
-                    else [sge.ColumnConstraint(kind=sge.NotNullColumnConstraint())]
-                ),
-            )
-            for colname, typ in schema.items()
-        ]
-
         table = sg.table(name, db=database, quoted=self.compiler.quoted)
-        target = sge.Schema(this=table, expressions=column_defs)
+        target = sge.Schema(this=table, expressions=schema.to_sqlglot(self.dialect))
 
         create_stmt = sge.Create(
             kind="SOURCE",

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -214,10 +214,11 @@ class Backend(PostgresBackend):
         else:
             temp_name = name
 
+        if not schema:
+            schema = table.schema()
+
         table = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
-        target = sge.Schema(
-            this=table, expressions=(schema or table.schema()).to_sqlglot(self.dialect)
-        )
+        target = sge.Schema(this=table, expressions=schema.to_sqlglot(self.dialect))
 
         if connector_properties is None:
             create_stmt = sge.Create(

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -32,6 +32,7 @@ from ibis.backends.sql.rewrites import (
 from ibis.config import options
 from ibis.expr.operations.udf import InputType
 from ibis.expr.rewrites import lower_stringslice
+from ibis.util import get_subclasses
 
 try:
     from sqlglot.expressions import Alter
@@ -51,15 +52,7 @@ if TYPE_CHECKING:
     from ibis.backends.sql.datatypes import SqlglotType
 
 
-def get_leaf_classes(op):
-    for child_class in op.__subclasses__():
-        if not child_class.__subclasses__():
-            yield child_class
-        else:
-            yield from get_leaf_classes(child_class)
-
-
-ALL_OPERATIONS = frozenset(get_leaf_classes(ops.Node))
+ALL_OPERATIONS = frozenset(get_subclasses(ops.Node))
 
 
 class AggGen:

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -14,7 +14,6 @@ from sqlglot.dialects import BigQuery
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
-import ibis.expr.schema as sch
 from ibis import util
 from ibis.backends.sql.compilers.base import NULL, STAR, AggGen, SQLGlotCompiler
 from ibis.backends.sql.compilers.bigquery.udf.core import PythonToJavaScriptTranslator
@@ -280,12 +279,13 @@ class BigQueryCompiler(SQLGlotCompiler):
         config = udf_node.__config__
         libraries = config.get("libraries", [])
 
-        signature = sch.Schema(
-            {
-                param_name: param.annotation.pattern.dtype
-                for param_name, param in udf_node.__signature__.parameters.items()
-            }
-        )
+        signature = [
+            sge.ColumnDef(
+                this=sg.to_identifier(name, quoted=self.quoted),
+                kind=type_mapper.from_ibis(param.annotation.pattern.dtype),
+            )
+            for name, param in udf_node.__signature__.parameters.items()
+        ]
 
         lines = ['"""']
 
@@ -302,9 +302,7 @@ class BigQueryCompiler(SQLGlotCompiler):
         func = sge.Create(
             kind="FUNCTION",
             this=sge.UserDefinedFunction(
-                this=sg.to_identifier(name),
-                expressions=signature.to_sqlglot(self.dialect),
-                wrapped=True,
+                this=sg.to_identifier(name), expressions=signature, wrapped=True
             ),
             # not exactly what I had in mind, but it works
             #

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -494,6 +494,7 @@ class RisingWaveType(PostgresType):
 
 
 class DataFusionType(PostgresType):
+    dialect = "datafusion"
     unknown_type_strings = {
         "utf8": dt.string,
         "float64": dt.float64,

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -1162,5 +1162,5 @@ class FlinkType(SqlglotType):
 
 TYPE_MAPPERS = {
     mapper.dialect: mapper
-    for mapper in set(get_subclasses(SqlglotType)) - {SqlglotType}
+    for mapper in set(get_subclasses(SqlglotType)) - {SqlglotType, BigQueryUDFType}
 }

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -10,6 +10,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis.common.collections import FrozenDict
 from ibis.formats import TypeMapper
+from ibis.util import get_subclasses
 
 typecode = sge.DataType.Type
 
@@ -1158,4 +1159,7 @@ class FlinkType(SqlglotType):
         )
 
 
-TYPE_MAPPERS = {mapper.dialect: mapper for mapper in SqlglotType.__subclasses__()}
+TYPE_MAPPERS = {
+    mapper.dialect: mapper
+    for mapper in set(get_subclasses(SqlglotType)) - {SqlglotType}
+}

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -1156,3 +1156,6 @@ class FlinkType(SqlglotType):
             ],
             nested=True,
         )
+
+
+TYPE_MAPPERS = {mapper.dialect: mapper for mapper in SqlglotType.__subclasses__()}

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -332,20 +332,7 @@ class Backend(SQLBackend, UrlFromPath):
         return table.to_reader(max_chunksize=chunk_size)
 
     def _generate_create_table(self, table: sge.Table, schema: sch.Schema):
-        column_defs = [
-            sge.ColumnDef(
-                this=sg.to_identifier(colname, quoted=self.compiler.quoted),
-                kind=self.compiler.type_mapper.from_ibis(typ),
-                constraints=(
-                    None
-                    if typ.nullable
-                    else [sge.ColumnConstraint(kind=sge.NotNullColumnConstraint())]
-                ),
-            )
-            for colname, typ in schema.items()
-        ]
-
-        target = sge.Schema(this=table, expressions=column_defs)
+        target = sge.Schema(this=table, expressions=schema.to_sqlglot(self.dialect))
 
         return sge.Create(kind="TABLE", this=target)
 

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -13,6 +13,7 @@ import ibis.expr.datatypes as dt
 from ibis.common.annotations import ValidationError
 from ibis.common.patterns import As, Attrs, NoMatch, Pattern
 from ibis.common.temporal import TimestampUnit, TimeUnit
+from ibis.util import get_subclasses
 
 
 def test_validate_type():
@@ -541,15 +542,9 @@ def test_timestamp_from_unit():
     )
 
 
-def get_leaf_classes(op):
-    for child_class in op.__subclasses__():
-        yield child_class
-        yield from get_leaf_classes(child_class)
-
-
 @pytest.mark.parametrize(
     "dtype_class",
-    set(get_leaf_classes(dt.DataType))
+    set(get_subclasses(dt.DataType))
     - {
         # these require special case tests
         dt.Array,

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -702,3 +702,10 @@ def chunks(n: int, *, chunk_size: int) -> Iterator[tuple[int, int]]:
     [(0, 4), (4, 8), (8, 10)]
     """
     return ((start, min(start + chunk_size, n)) for start in range(0, n, chunk_size))
+
+
+def get_subclasses(obj):
+    """Recursively compute all subclasses of `op`."""
+    for child_class in obj.__subclasses__():
+        yield child_class
+        yield from get_subclasses(child_class)

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     import ibis.expr.types as ir
 
 T = TypeVar("T", covariant=True)
+S = TypeVar("S", bound=T, covariant=True)
 U = TypeVar("U", covariant=True)
 K = TypeVar("K")
 V = TypeVar("V")
@@ -704,8 +705,45 @@ def chunks(n: int, *, chunk_size: int) -> Iterator[tuple[int, int]]:
     return ((start, min(start + chunk_size, n)) for start in range(0, n, chunk_size))
 
 
-def get_subclasses(obj):
-    """Recursively compute all subclasses of `op`."""
+def get_subclasses(obj: type[T]) -> Iterator[type[S]]:
+    """Recursively compute all subclasses of `obj`.
+
+    ::: {.callout-note}
+    ## The resulting iterator does **not** include the input type object.
+    :::
+
+    Parameters
+    ----------
+    obj
+        Any type object
+
+    Examples
+    --------
+    >>> class Base: ...
+    >>> class Subclass1(Base): ...
+    >>> class Subclass2(Base): ...
+    >>> class TransitiveSubclass(Subclass2): ...
+
+    Everything inherits `Base` (directly or transitively)
+
+    >>> list(get_subclasses(Base))
+    [<class 'ibis.util.Subclass1'>, <class 'ibis.util.Subclass2'>, <class 'ibis.util.TransitiveSubclass'>]
+
+    Nothing inherits from `Subclass1`
+
+    >>> list(get_subclasses(Subclass1))
+    []
+
+    Only `TransitiveSubclass` inherits from `Subclass2`
+
+    >>> list(get_subclasses(Subclass2))
+    [<class 'ibis.util.TransitiveSubclass'>]
+
+    Nothing inherits from `TransitiveSubclass`
+
+    >>> list(get_subclasses(TransitiveSubclass))
+    []
+    """
     for child_class in obj.__subclasses__():
         yield child_class
         yield from get_subclasses(child_class)


### PR DESCRIPTION
Consolidate code to turn Ibis schemas into sqlglot objects under a `Schema.to_sqlglot` method.