### PR TITLE
fix(duckdb): allow setting `auto_detect` to `False` by fixing translation of columns argument

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -593,6 +593,7 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         self,
         source_list: str | list[str] | tuple[str],
         table_name: str | None = None,
+        columns: Mapping[str, str] | None = None,
         **kwargs,
     ) -> ir.Table:
         """Read newline-delimited JSON into an ibis table.
@@ -607,6 +608,8 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
             File or list of files
         table_name
             Optional table name
+        columns
+            Optional mapping from string column name to duckdb type string.
         **kwargs
             Additional keyword arguments passed to DuckDB's `read_json_auto` function
 
@@ -622,6 +625,21 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         options = [
             sg.to_identifier(key).eq(sge.convert(val)) for key, val in kwargs.items()
         ]
+
+        if columns:
+            options.append(
+                sg.to_identifier("columns").eq(
+                    sge.Struct.from_arg_list(
+                        [
+                            sge.PropertyEQ(
+                                this=sg.to_identifier(key),
+                                expression=sge.convert(value),
+                            )
+                            for key, value in columns.items()
+                        ]
+                    )
+                )
+            )
 
         self._create_temp_view(
             table_name,

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -611,7 +611,10 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema, UrlFromPath):
         columns
             Optional mapping from string column name to duckdb type string.
         **kwargs
-            Additional keyword arguments passed to DuckDB's `read_json_auto` function
+            Additional keyword arguments passed to DuckDB's `read_json_auto` function.
+
+            See https://duckdb.org/docs/data/json/overview.html#json-loading
+            for parameters and more information about reading JSON.
 
         Returns
         -------

--- a/ibis/backends/duckdb/tests/test_register.py
+++ b/ibis/backends/duckdb/tests/test_register.py
@@ -505,3 +505,16 @@ def test_memtable_null_column_parquet_dtype_roundtrip(con, tmp_path):
     after = con.read_parquet(tmp_path / "tmp.parquet")
 
     assert before.a.type() == after.a.type()
+
+
+def test_read_json_no_auto_detection(con, tmp_path):
+    ndjson_data = """
+    {"year": 2007}
+    {"year": 2008}
+    {"year": 2009}
+    """
+    path = tmp_path.joinpath("test.ndjson")
+    path.write_text(ndjson_data)
+
+    t = con.read_json(path, auto_detect=False, columns={"year": "varchar"})
+    assert t.year.type() == dt.string


### PR DESCRIPTION
Fixes translation of the `columns` argument to `read_json`. Reported in [this Zulip thread](https://ibis-project.zulipchat.com/#narrow/stream/405265-tech-support/topic/Specifying.20the.20schema.20when.20reading.20JSON.20and.20DLQs).