### PR TITLE
perf(backends): speed up most memtable existence checks

### DIFF
--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -243,6 +243,9 @@ class Backend(SQLBackend, CanCreateDatabase, CanCreateSchema):
             finally:
                 self.con.execute(drop_view)
 
+    def _in_memory_table_exists(self, name: str) -> bool:
+        return self.con.meta.table_exists(name)
+
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         schema = op.schema
         if null_columns := [col for col, dtype in schema.items() if dtype.is_null()]:

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -703,6 +703,16 @@ GO"""
             namespace=ops.Namespace(catalog=catalog, database=db),
         ).to_expr()
 
+    def _in_memory_table_exists(self, name: str) -> bool:
+        # The single character U here means user-defined table
+        # see https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-objects-transact-sql?view=sql-server-ver16
+        sql = sg.select(sg.func("object_id", sge.convert(name), sge.convert("U"))).sql(
+            self.dialect
+        )
+        with self.begin() as cur:
+            [(result,)] = cur.execute(sql).fetchall()
+        return result is not None
+
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         schema = op.schema
         if null_columns := [col for col, dtype in schema.items() if dtype.is_null()]:

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -24,7 +24,7 @@ import ibis.expr.types as ir
 from ibis import util
 from ibis.backends import CanListDatabase, CanListSchema
 from ibis.backends.sql import SQLBackend
-from ibis.backends.sql.compilers.base import STAR, C
+from ibis.backends.sql.compilers.base import NULL, STAR, C
 
 if TYPE_CHECKING:
     from urllib.parse import ParseResult
@@ -494,6 +494,21 @@ class Backend(SQLBackend, CanListDatabase, CanListSchema):
                 bind.execute(f"TRUNCATE TABLE {table.sql(self.name)}")
 
         super().drop_table(name, database=(catalog, db), force=force)
+
+    def _in_memory_table_exists(self, name: str) -> bool:
+        sql = (
+            sg.select(NULL)
+            .from_(sg.to_identifier("USER_OBJECTS", quoted=self.compiler.quoted))
+            .where(
+                C.OBJECT_TYPE.eq(sge.convert("TABLE")),
+                C.OBJECT_NAME.eq(sge.convert(name)),
+            )
+            .limit(sge.convert(1))
+            .sql(self.dialect)
+        )
+        with self.begin() as cur:
+            results = cur.execute(sql).fetchall()
+        return bool(results)
 
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         schema = op.schema

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -89,6 +89,21 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
 
         return self.connect(**kwargs)
 
+    def _in_memory_table_exists(self, name: str) -> bool:
+        import psycopg2.errors
+
+        ident = sg.to_identifier(name, quoted=self.compiler.quoted)
+        sql = sg.select(sge.convert(1)).from_(ident).limit(0).sql(self.dialect)
+
+        try:
+            with self.begin() as cur:
+                cur.execute(sql)
+                cur.fetchall()
+        except psycopg2.errors.UndefinedTable:
+            return False
+        else:
+            return True
+
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         from psycopg2.extras import execute_batch
 

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -411,10 +411,17 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
             self._session.udf.register(f"unwrap_json_{typ.__name__}", unwrap_json(typ))
         self._session.udf.register("unwrap_json_float", unwrap_json_float)
 
+    def _in_memory_table_exists(self, name: str) -> bool:
+        sql = f"SHOW TABLES IN {self.current_database} LIKE '{name}'"
+        return bool(self._session.sql(sql).count())
+
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         schema = PySparkSchema.from_ibis(op.schema)
         df = self._session.createDataFrame(data=op.data.to_frame(), schema=schema)
         df.createTempView(op.name)
+
+    def _finalize_memtable(self, name: str) -> None:
+        self._session.catalog.dropTempView(name)
 
     @contextlib.contextmanager
     def _safe_raw_sql(self, query: str) -> Any:

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -645,9 +645,23 @@ $$ {defn["source"]} $$"""
         return self._filter_with_like(tables + views, like=like)
 
     def _in_memory_table_exists(self, name: str) -> bool:
-        with self.con.cursor() as con:
-            result = con.execute(f"SHOW TABLES LIKE '{name}'").fetchone()
-        return bool(result)
+        import snowflake.connector
+
+        ident = sg.to_identifier(name, quoted=self.compiler.quoted)
+        sql = sg.select(sge.convert(1)).from_(ident).limit(0).sql(self.dialect)
+
+        try:
+            with self.con.cursor() as cur:
+                cur.execute(sql).fetchall()
+        except snowflake.connector.errors.ProgrammingError as e:
+            # this cryptic error message is the only generic and reliable way
+            # to tell if the error means "table not found for any reason"
+            # otherwise, we need to reraise the exception
+            if e.sqlstate == "42S02":
+                return False
+            raise
+        else:
+            return True
 
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         import pyarrow.parquet as pq

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -338,6 +338,18 @@ class Backend(SQLBackend, UrlFromPath):
 
         return sge.Create(kind="TABLE", this=target)
 
+    def _in_memory_table_exists(self, name: str) -> bool:
+        ident = sg.to_identifier(name, quoted=self.compiler.quoted)
+        query = sg.select(sge.convert(1)).from_(ident).limit(0).sql(self.dialect)
+        try:
+            with self.begin() as cur:
+                cur.execute(query)
+                cur.fetchall()
+        except sqlite3.OperationalError:
+            return False
+        else:
+            return True
+
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         table = sg.table(op.name, quoted=self.compiler.quoted, catalog="temp")
         create_stmt = self._generate_create_table(table, op.schema).sql(self.name)

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -552,6 +552,21 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, CanCreateSchema):
         df = TrinoPandasData.convert_table(df, schema)
         return df
 
+    def _in_memory_table_exists(self, name: str) -> bool:
+        ident = sg.to_identifier(name, quoted=self.compiler.quoted)
+        sql = sg.select(sge.convert(1)).from_(ident).limit(0).sql(self.dialect)
+
+        try:
+            with self.begin() as cur:
+                cur.execute(sql)
+                cur.fetchall()
+        except trino.exceptions.TrinoUserError as e:
+            if e.error_name == "TABLE_NOT_FOUND":
+                return False
+            raise
+        else:
+            return True
+
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         schema = op.schema
         if null_columns := [col for col, dtype in schema.items() if dtype.is_null()]:


### PR DESCRIPTION
Adds some slightly faster checks for memtable existence. At some point we may want to expand this to non-memtables, but for now these are only implemented for memtables.