### PR TITLE
depr(api): deprecate filtering/expression projection in `Table.__getitem__`

### DIFF
--- a/docs/how-to/extending/builtin.qmd
+++ b/docs/how-to/extending/builtin.qmd
@@ -79,7 +79,7 @@ rest of the library:
 pkgs = ibis.read_parquet(
    "https://storage.googleapis.com/ibis-tutorial-data/pypi/2024-04-24/packages.parquet"
 )
-pandas_ish = pkgs[jw_sim(pkgs.name, "pandas") >= 0.9]
+pandas_ish = pkgs.filter(jw_sim(pkgs.name, "pandas") >= 0.9)
 pandas_ish
 ```
 

--- a/docs/tutorials/ibis-for-pandas-users.qmd
+++ b/docs/tutorials/ibis-for-pandas-users.qmd
@@ -126,13 +126,6 @@ Selecting columns is very similar to in pandas. In fact, you can use the same sy
 t[["one", "two"]]
 ```
 
-However, since row-level indexing is not supported in Ibis, the inner list is not necessary.
-
-
-```{python}
-t["one", "two"]
-```
-
 ## Selecting columns
 
 Selecting columns is done using the same syntax as in pandas `DataFrames`. You can use either
@@ -192,11 +185,11 @@ new_col = unnamed.name("new_col")
 new_col
 ```
 
-You can then add this column to the table using a projection.
+You can then add this column to the table using `mutate`
 
 
 ```{python}
-proj = t["one", "two", new_col]
+proj = t.mutate(new_col)
 proj
 ```
 
@@ -301,10 +294,9 @@ penguins.limit(5)
 ### Filtering rows
 
 In addition to limiting the number of rows that are returned, it is possible to
-filter the rows using expressions. Expressions are constructed very similarly to
-the way they are in pandas.  Ibis expressions are constructed from operations on
-columns in a table which return a boolean result.  This result is then used to
-filter the table.
+filter the rows using expressions. This is done using the `filter` method in
+ibis. Ibis expressions are constructed from operations on columns in a table
+which return a boolean result. This result is then used to filter the table.
 
 
 ```{python}
@@ -324,7 +316,7 @@ get 6 rows back.
 
 
 ```{python}
-filtered = penguins[expr]
+filtered = penguins.filter(expr)
 filtered
 ```
 
@@ -332,24 +324,22 @@ Of course, the filtering expression can be applied inline as well.
 
 
 ```{python}
-filtered = penguins[penguins.bill_length_mm > 37.0]
+filtered = penguins.filter(penguins.bill_length_mm > 37.0)
 filtered
 ```
 
-Multiple filtering expressions can be combined into a single expression or chained onto existing
-table expressions.
+Multiple filtering expressions may be passed in to a single call (filtering
+only rows where they're all true), or combined together using common boolean
+operators like (`&`, `|`). The expressions below are equivalent:
 
 
 ```{python}
-filtered = penguins[(penguins.bill_length_mm > 37.0) & (penguins.bill_depth_mm > 18.0)]
+filtered = penguins.filter(penguins.bill_length_mm > 37.0, penguins.bill_depth_mm > 18.0)
 filtered
 ```
 
-The code above will return the same rows as the code below.
-
-
 ```{python}
-filtered = penguins[penguins.bill_length_mm > 37.0][penguins.bill_depth_mm > 18.0]
+filtered = penguins.filter((penguins.bill_length_mm > 37.0) & (penguins.bill_depth_mm > 18.0))
 filtered
 ```
 
@@ -359,7 +349,7 @@ is greater than the mean.
 
 
 ```{python}
-filtered = penguins[penguins.bill_length_mm > penguins.bill_length_mm.mean()]
+filtered = penguins.filter(penguins.bill_length_mm > penguins.bill_length_mm.mean())
 filtered
 ```
 

--- a/docs/tutorials/ibis-for-sql-users.qmd
+++ b/docs/tutorials/ibis-for-sql-users.qmd
@@ -47,12 +47,6 @@ FROM my_data
 In Ibis, this is
 
 ```{python}
-proj = t["two", "one"]
-```
-
-or
-
-```{python}
 proj = t.select("two", "one")
 ```
 
@@ -78,7 +72,7 @@ new_col = (t.three * 2).name("new_col")
 Now, we have:
 
 ```{python}
-proj = t["two", "one", new_col]
+proj = t.select("two", "one", new_col)
 ibis.to_sql(proj)
 ```
 
@@ -113,7 +107,7 @@ select all columns in a table using the `SELECT *` construct. To do this, use
 the table expression itself in a projection:
 
 ```{python}
-proj = t[t]
+proj = t.select(t)
 ibis.to_sql(proj)
 ```
 
@@ -121,7 +115,7 @@ This is how `mutate` is implemented. The example above
 `t.mutate(new_col=t.three * 2)` can be written as a normal projection:
 
 ```{python}
-proj = t[t, new_col]
+proj = t.select(t, new_col)
 ibis.to_sql(proj)
 ```
 
@@ -144,7 +138,7 @@ To write this with Ibis, it is:
 
 ```{python}
 diff = (t.two - t2.value).name("diff")
-joined = t.join(t2, t.one == t2.key)[t, diff]
+joined = t.join(t2, t.one == t2.key).select(t, diff)
 ```
 
 And verify the generated SQL:
@@ -188,19 +182,18 @@ ibis.to_sql(expr)
 
 ## Filtering / `WHERE`
 
-You can add filter clauses to a table expression either by indexing with
-`[]` (similar to pandas) or use the `filter` method:
+You can add filter clauses to a table expression by using the `filter` method:
 
 ```{python}
-filtered = t[t.two > 0]
+filtered = t.filter(t.two > 0)
 ibis.to_sql(filtered)
 ```
 
-`filter` can take a list of expressions, which must all be satisfied for
+`filter` can take multiple expressions, which must all be satisfied for
 a row to appear in the result:
 
 ```{python}
-filtered = t.filter([t.two > 0, t.one.isin(["A", "B"])])
+filtered = t.filter(t.two > 0, t.one.isin(["A", "B"]))
 ibis.to_sql(filtered)
 ```
 
@@ -209,7 +202,7 @@ To compose boolean expressions with `AND` or `OR`, use the respective
 
 ```{python}
 cond = (t.two < 0) | ((t.two > 0) | t.one.isin(["A", "B"]))
-filtered = t[cond]
+filtered = t.filter(cond)
 ibis.to_sql(filtered)
 ```
 
@@ -617,7 +610,7 @@ ibis.to_sql(expr)
 
 ```{python}
 agged = (
-    expr[expr.one.notnull()]
+    expr.filter(expr.one.notnull())
     .group_by("is_valid")
     .aggregate(three_count=lambda t: t.three.notnull().sum())
 )
@@ -632,7 +625,7 @@ keyword. The result of `between` is boolean and can be used with any
 other boolean expression:
 
 ```{python}
-expr = t[t.two.between(10, 50) & t.one.notnull()]
+expr = t.filter(t.two.between(10, 50) & t.one.notnull())
 ibis.to_sql(expr)
 ```
 
@@ -684,7 +677,7 @@ After one or more joins, you can reference any of the joined tables in
 a projection immediately after:
 
 ```{python}
-expr = joined[t1, t2.value2]
+expr = joined.select(t1, t2.value2)
 ibis.to_sql(expr)
 ```
 
@@ -692,7 +685,7 @@ If you need to compute an expression that involves both tables, you can
 do that also:
 
 ```{python}
-expr = joined[t1.key1, (t1.value1 - t2.value2).name("diff")]
+expr = joined.select(t1.key1, (t1.value1 - t2.value2).name("diff"))
 ibis.to_sql(expr)
 ```
 
@@ -800,7 +793,7 @@ In these case, we can specify a list of common join keys:
 
 ```{python}
 joined = t4.join(t5, ["key1", "key2", "key3"])
-expr = joined[t4, t5.value2]
+expr = joined.select(t4, t5.value2)
 ibis.to_sql(expr)
 ```
 
@@ -808,7 +801,7 @@ You can mix the overlapping key names with other expressions:
 
 ```{python}
 joined = t4.join(t5, ["key1", "key2", t4.key3.left(4) == t5.key3.left(4)])
-expr = joined[t4, t5.value2]
+expr = joined.select(t4, t5.value2)
 ibis.to_sql(expr)
 ```
 
@@ -885,7 +878,7 @@ cond = (events.user_id == purchases.user_id).any()
 This can now be used to filter `events`:
 
 ```{python}
-expr = events[cond]
+expr = events.filter(cond)
 ibis.to_sql(expr)
 ```
 
@@ -893,7 +886,7 @@ If you negate the condition, it will instead give you only event data
 from user *that have not made a purchase*:
 
 ```{python}
-expr = events[-cond]
+expr = events.filter(-cond)
 ibis.to_sql(expr)
 ```
 
@@ -916,7 +909,7 @@ you can write with Ibis:
 
 ```{python}
 cond = events.user_id.isin(purchases.user_id)
-expr = events[cond]
+expr = events.filter(cond)
 ibis.to_sql(expr)
 ```
 
@@ -941,7 +934,7 @@ WHERE value1 > (
 With Ibis, the code is simpler and more pandas-like:
 
 ```{python}
-expr = t1[t1.value1 > t2.value2.max()]
+expr = t1.filter(t1.value1 > t2.value2.max())
 ibis.to_sql(expr)
 ```
 
@@ -968,8 +961,8 @@ With Ibis, the code is similar, but you add the correlated filter to the
 average statistic:
 
 ```{python}
-stat = t2[t1.key1 == t2.key3].value2.mean()
-expr = t1[t1.value1 > stat]
+stat = t2.filter(t1.key1 == t2.key3).value2.mean()
+expr = t1.filter(t1.value1 > stat)
 ibis.to_sql(expr)
 ```
 
@@ -1118,7 +1111,7 @@ Ibis provides a `row_number()` function that allows you to do this:
 expr = purchases.mutate(
   row_number=ibis.row_number().over(group_by=[_.user_id], order_by=_.price)
 )
-expr = expr[_.row_number < 3]
+expr = expr.filter(_.row_number < 3)
 ```
 
 The output of this is a table with the three most expensive items that each user has purchased
@@ -1149,7 +1142,7 @@ Ibis has a set of interval APIs that allow you to do date/time
 arithmetic. For example:
 
 ```{python}
-expr = events[events.ts > (ibis.now() - ibis.interval(years=1))]
+expr = events.filter(events.ts > (ibis.now() - ibis.interval(years=1)))
 ibis.to_sql(expr)
 ```
 
@@ -1214,12 +1207,13 @@ purchases = ibis.table(
 metric = purchases.amount.sum().name("total")
 agged = purchases.group_by(["region", "kind"]).aggregate(metric)
 
-left = agged[agged.kind == "foo"]
-right = agged[agged.kind == "bar"]
+left = agged.filter(agged.kind == "foo")
+right = agged.filter(agged.kind == "bar")
 
-result = left.join(right, left.region == right.region)[
-    left.region, (left.total - right.total).name("diff")
-]
+result = (
+    left.join(right, left.region == right.region)
+    .select(left.region, (left.total - right.total).name("diff"))
+)
 ```
 
 Ibis automatically creates a CTE for `agged`:

--- a/docs/tutorials/open-source-software/apache-flink/1_single_feature.qmd
+++ b/docs/tutorials/open-source-software/apache-flink/1_single_feature.qmd
@@ -184,7 +184,7 @@ transaction count over the past five hours may be useful features. Let’s write
 out each of these using Ibis API:
 
 ```{python}
-user_trans_amt_last_360m_agg = source_table[
+user_trans_amt_last_360m_agg = source_table.select(
     source_table.user_id,
     # Calculate the average transaction amount over the past six hours
     source_table.amt.mean()
@@ -207,7 +207,7 @@ user_trans_amt_last_360m_agg = source_table[
     )
     .name("user_trans_count_last_360min"),
     source_table.trans_date_trans_time,
-]
+)
 ```
 
 `over()` creates an [over

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -186,7 +186,7 @@ def test_scalar_param_partition_time(parted_alltypes):
     assert "PARTITIONTIME" in parted_alltypes.columns
     assert "PARTITIONTIME" in parted_alltypes.schema()
     param = ibis.param("timestamp('UTC')")
-    expr = parted_alltypes[param > parted_alltypes.PARTITIONTIME]
+    expr = parted_alltypes.filter(param > parted_alltypes.PARTITIONTIME)
     df = expr.execute(params={param: "2017-01-01"})
     assert df.empty
 
@@ -201,7 +201,7 @@ def test_parted_column(con, kind):
 
 def test_cross_project_query(public):
     table = public.table("posts_questions")
-    expr = table[table.tags.contains("ibis")][["title", "tags"]]
+    expr = table.filter(table.tags.contains("ibis"))[["title", "tags"]]
     n = 5
     df = expr.limit(n).execute()
     assert len(df) == n
@@ -231,7 +231,7 @@ def test_multiple_project_queries_execute(con):
     trips = con.table("trips", database="nyc-tlc.yellow").limit(5)
     predicate = posts_questions.tags == trips.rate_code
     cols = [posts_questions.title]
-    join = posts_questions.left_join(trips, predicate)[cols]
+    join = posts_questions.left_join(trips, predicate).select(cols)
     result = join.execute()
     assert list(result.columns) == ["title"]
     assert len(result) == 5

--- a/ibis/backends/bigquery/tests/system/udf/test_udf_execute.py
+++ b/ibis/backends/bigquery/tests/system/udf/test_udf_execute.py
@@ -18,7 +18,7 @@ DATASET_ID = "testing"
 @pytest.fixture(scope="module")
 def alltypes(con):
     t = con.table("functional_alltypes")
-    expr = t[t.bigint_col.isin([10, 20])].limit(10)
+    expr = t.filter(t.bigint_col.isin([10, 20])).limit(10)
     return expr
 
 

--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -151,11 +151,11 @@ def test_projection_fusion_only_peeks_at_immediate_parent(snapshot):
         ("val", "int64"),
     ]
     table = ibis.table(schema, name="unbound_table")
-    table = table[table.PARTITIONTIME < ibis.date("2017-01-01")]
+    table = table.filter(table.PARTITIONTIME < ibis.date("2017-01-01"))
     table = table.mutate(file_date=table.file_date.cast("date"))
-    table = table[table.file_date < ibis.date("2017-01-01")]
+    table = table.filter(table.file_date < ibis.date("2017-01-01"))
     table = table.mutate(XYZ=table.val * 2)
-    expr = table.join(table.view())[table]
+    expr = table.join(table.view()).select(table)
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -276,7 +276,7 @@ def test_large_compile():
     for _ in range(num_joins):  # noqa: F402
         table = table.mutate(dummy=ibis.literal(""))
         table_ = table.view()
-        table = table.left_join(table_, ["dummy"])[[table_]]
+        table = table.left_join(table_, ["dummy"]).select(table_)
 
     start = time.time()
     table.compile()
@@ -417,9 +417,9 @@ def test_divide_by_zero(alltypes, op, snapshot):
 
 
 def test_identical_to(alltypes, snapshot):
-    expr = alltypes[
+    expr = alltypes.filter(
         _.string_col.identical_to("a") & _.date_string_col.identical_to("b")
-    ]
+    )
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 

--- a/ibis/backends/clickhouse/tests/test_aggregations.py
+++ b/ibis/backends/clickhouse/tests/test_aggregations.py
@@ -163,7 +163,7 @@ def test_boolean_reduction(alltypes, op, df):
 
 def test_anonymous_aggregate(alltypes, df):
     t = alltypes
-    expr = t[t.double_col > t.double_col.mean()]
+    expr = t.filter(t.double_col > t.double_col.mean())
     result = expr.execute().set_index("id")
     expected = df[df.double_col > df.double_col.mean()].set_index("id")
     tm.assert_frame_equal(result, expected, check_like=True)

--- a/ibis/backends/clickhouse/tests/test_client.py
+++ b/ibis/backends/clickhouse/tests/test_client.py
@@ -129,7 +129,7 @@ def test_sql_query_limits(alltypes):
 def test_embedded_identifier_quoting(alltypes):
     t = alltypes
 
-    expr = t[[(t.double_col * 2).name("double(fun)")]]["double(fun)"].sum()
+    expr = t.select((t.double_col * 2).name("double(fun)"))["double(fun)"].sum()
     expr.execute()
 
 

--- a/ibis/backends/clickhouse/tests/test_functions.py
+++ b/ibis/backends/clickhouse/tests/test_functions.py
@@ -476,7 +476,7 @@ def test_udf_in_array_map(alltypes):
 
     n = 5
     expr = (
-        alltypes[alltypes.int_col == 1]
+        alltypes.filter(alltypes.int_col == 1)
         .limit(n)
         .int_col.collect()
         .map(lambda x: my_add(x, 1))

--- a/ibis/backends/dask/tests/test_arrays.py
+++ b/ibis/backends/dask/tests/test_arrays.py
@@ -59,7 +59,7 @@ def test_array_collect(t, df):
 def test_array_collect_rolling_partitioned(t, df):
     window = ibis.trailing_window(1, order_by=t.plain_int64)
     colexpr = t.plain_float64.collect().over(window)
-    expr = t["dup_strings", "plain_int64", colexpr.name("collected")]
+    expr = t.select("dup_strings", "plain_int64", colexpr.name("collected"))
     result = expr.compile()
     expected = dd.from_pandas(
         pd.DataFrame(
@@ -134,7 +134,7 @@ def test_array_slice_scalar(client, start, stop):
     [1, 3, 4, 11, -11],
 )
 def test_array_index(t, df, index):
-    expr = t[t.array_of_float64[index].name("indexed")]
+    expr = t.select(t.array_of_float64[index].name("indexed"))
     result = expr.execute()
     expected = pd.DataFrame(
         {

--- a/ibis/backends/dask/tests/test_operations.py
+++ b/ibis/backends/dask/tests/test_operations.py
@@ -32,7 +32,9 @@ def test_literal(client):
 
 
 def test_selection(t, df):
-    expr = t[((t.plain_strings == "a") | (t.plain_int64 == 3)) & (t.dup_strings == "d")]
+    expr = t.filter(
+        ((t.plain_strings == "a") | (t.plain_int64 == 3)) & (t.dup_strings == "d")
+    )
     result = expr.compile()
     expected = df[
         ((df.plain_strings == "a") | (df.plain_int64 == 3)) & (df.dup_strings == "d")
@@ -56,12 +58,10 @@ def test_mutate(t, df):
 @pytest.mark.xfail(reason="TODO - windowing - #2553")
 def test_project_scope_does_not_override(t, df):
     col = t.plain_int64
-    expr = t[
-        [
-            col.name("new_col"),
-            col.sum().over(ibis.window(group_by="dup_strings")).name("grouped"),
-        ]
-    ]
+    expr = t.select(
+        col.name("new_col"),
+        col.sum().over(ibis.window(group_by="dup_strings")).name("grouped"),
+    )
     result = expr.compile()
     expected = dd.concat(
         [
@@ -402,7 +402,7 @@ def test_nullif_inf(con):
 
 def test_group_concat(t, df):
     expr = (
-        t[t.dup_ints == 1]
+        t.filter(t.dup_ints == 1)
         .group_by(t.dup_strings)
         .aggregate(foo=t.dup_ints.group_concat(","))
     )

--- a/ibis/backends/dask/tests/test_window.py
+++ b/ibis/backends/dask/tests/test_window.py
@@ -161,7 +161,7 @@ def test_players(players, players_df):
 
 
 def test_batting_filter_mean(batting, batting_df):
-    expr = batting[batting.G > batting.G.mean()]
+    expr = batting.filter(batting.G > batting.G.mean())
     result = expr.execute()
     expected = (
         batting_df[batting_df.G > batting_df.G.mean()].reset_index(drop=True).compute()
@@ -348,7 +348,7 @@ def test_mutate_with_window_after_join(con, sort_kind):
     right = ibis.memtable(right_df)
 
     joined = left.outer_join(right, left.ints == right.group)
-    proj = joined[left, right.value]
+    proj = joined.select(left, right.value)
     expr = proj.group_by("ints").mutate(sum=proj.value.sum())
     result = con.execute(expr)
     expected = pd.DataFrame(
@@ -380,7 +380,7 @@ def test_mutate_scalar_with_window_after_join(npartitions):
     left, right = map(con.table, ("left", "right"))
 
     joined = left.outer_join(right, left.ints == right.group)
-    proj = joined[left, right.value]
+    proj = joined.select(left, right.value)
     expr = proj.mutate(sum=proj.value.sum(), const=ibis.literal(1))
     result = expr.execute()
     result = result.sort_values(["ints", "value"]).reset_index(drop=True)
@@ -415,8 +415,8 @@ def test_project_scalar_after_join(npartitions):
     left, right = map(con.table, ("left", "right"))
 
     joined = left.outer_join(right, left.ints == right.group)
-    proj = joined[left, right.value]
-    expr = proj[proj.value.sum().name("sum"), ibis.literal(1).name("const")]
+    proj = joined.select(left, right.value)
+    expr = proj.select(proj.value.sum().name("sum"), ibis.literal(1).name("const"))
     result = expr.execute().reset_index(drop=True)
     expected = pd.DataFrame(
         {

--- a/ibis/backends/flink/tests/test_compiler.py
+++ b/ibis/backends/flink/tests/test_compiler.py
@@ -37,9 +37,9 @@ def test_complex_projections(simple_table, assert_sql):
 
 
 def test_filter(simple_table, assert_sql):
-    expr = simple_table[
+    expr = simple_table.filter(
         ((simple_table.c > 0) | (simple_table.c < 0)) & simple_table.g.isin(["A", "B"])
-    ]
+    )
     assert_sql(expr)
 
 

--- a/ibis/backends/impala/tests/test_bucket_histogram.py
+++ b/ibis/backends/impala/tests/test_bucket_histogram.py
@@ -84,6 +84,6 @@ def test_bucket_assign_labels(table, snapshot):
     labelled = size.tier.label(
         ["Under 0", "0 to 10", "10 to 25", "25 to 50"], nulls="error"
     ).name("tier2")
-    expr = size[labelled, size[1]]
+    expr = size.select(labelled, size[1])
 
     snapshot.assert_match(translate(expr), "out.sql")

--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -159,19 +159,21 @@ def test_insert_validate_types(con, alltypes, test_data_db, temp_table):
 
     t = con.table(temp_table, database=db)
 
-    to_insert = expr[
+    to_insert = expr.select(
         expr.tinyint_col, expr.smallint_col.name("int_col"), expr.string_col
-    ]
+    )
     t.insert(to_insert.limit(10))
 
-    to_insert = expr[
+    to_insert = expr.select(
         expr.tinyint_col,
         expr.smallint_col.cast("int32").name("int_col"),
         expr.string_col,
-    ]
+    )
     t.insert(to_insert.limit(10))
 
-    to_insert = expr[expr.tinyint_col, expr.bigint_col.name("int_col"), expr.string_col]
+    to_insert = expr.select(
+        expr.tinyint_col, expr.bigint_col.name("int_col"), expr.string_col
+    )
 
     limit_expr = to_insert.limit(10)
     with pytest.raises(com.IbisError):
@@ -296,7 +298,7 @@ def test_query_delimited_file_directory(con, test_data_dir, temp_table):
     table = con.delimited_file(hdfs_path, schema, name=temp_table, delimiter=",")
 
     expr = (
-        table[table.bar > 0]
+        table.filter(table.bar > 0)
         .group_by("foo")
         .aggregate(
             [

--- a/ibis/backends/impala/tests/test_ddl_compilation.py
+++ b/ibis/backends/impala/tests/test_ddl_compilation.py
@@ -168,7 +168,7 @@ def test_alter_table_properties(part_schema, table_name, snapshot):
 
 @pytest.fixture
 def expr(t):
-    return t[t.bigint_col > 0]
+    return t.filter(t.bigint_col > 0)
 
 
 def test_create_external_table_as(mockcon, snapshot):

--- a/ibis/backends/impala/tests/test_exprs.py
+++ b/ibis/backends/impala/tests/test_exprs.py
@@ -17,7 +17,7 @@ from ibis.expr import api
 def test_embedded_identifier_quoting(alltypes):
     t = alltypes
 
-    expr = t[[(t.double_col * 2).name("double(fun)")]]["double(fun)"].sum()
+    expr = t.select((t.double_col * 2).name("double(fun)"))["double(fun)"].sum()
     expr.execute()
 
 
@@ -134,7 +134,7 @@ def test_builtins(con, alltypes):
 
     proj_exprs = [expr.name("e%d" % i) for i, expr in enumerate(exprs)]
 
-    projection = table[proj_exprs]
+    projection = table.select(proj_exprs)
     projection.limit(10).execute()
 
     _check_impala_output_types_match(con, projection)
@@ -352,7 +352,7 @@ def test_filter_predicates(con):
 
     expr = t
     for pred in predicates:
-        expr = expr[pred(expr)].select(expr)
+        expr = expr.filter(pred(expr)).select(expr)
 
     expr.execute()
 
@@ -420,7 +420,7 @@ def test_decimal_timestamp_builtins(con):
 
     proj_exprs = [expr.name("e%d" % i) for i, expr in enumerate(exprs)]
 
-    projection = table[proj_exprs].limit(10)
+    projection = table.select(proj_exprs).limit(10)
     projection.execute()
 
 
@@ -520,7 +520,7 @@ def test_analytic_functions(alltypes):
 def test_anti_join_self_reference_works(con, alltypes):
     t = alltypes.limit(100)
     t2 = t.view()
-    case = t[-((t.string_col == t2.string_col).any())]
+    case = t.filter(~((t.string_col == t2.string_col).any()))
     con.explain(case)
 
 
@@ -540,7 +540,8 @@ def test_tpch_self_join_failure(con):
     joined_all = (
         region.join(nation, region.r_regionkey == nation.n_regionkey)
         .join(customer, customer.c_nationkey == nation.n_nationkey)
-        .join(orders, orders.o_custkey == customer.c_custkey)[fields_of_interest]
+        .join(orders, orders.o_custkey == customer.c_custkey)
+        .select(fields_of_interest)
     )
 
     year = joined_all.odate.year().name("year")
@@ -554,7 +555,7 @@ def test_tpch_self_join_failure(con):
     yoy = current.join(
         prior,
         ((current.region == prior.region) & (current.year == (prior.year - 1))),
-    )[current.region, current.year, yoy_change]
+    ).select(current.region, current.year, yoy_change)
 
     # no analysis failure
     con.explain(yoy)
@@ -577,14 +578,15 @@ def test_tpch_correlated_subquery_failure(con):
     tpch = (
         region.join(nation, region.r_regionkey == nation.n_regionkey)
         .join(customer, customer.c_nationkey == nation.n_nationkey)
-        .join(orders, orders.o_custkey == customer.c_custkey)[fields_of_interest]
+        .join(orders, orders.o_custkey == customer.c_custkey)
+        .select(fields_of_interest)
     )
 
     t2 = tpch.view()
-    conditional_avg = t2[(t2.region == tpch.region)].amount.mean()
+    conditional_avg = t2.filter(t2.region == tpch.region).amount.mean()
     amount_filter = tpch.amount > conditional_avg
 
-    expr = tpch[amount_filter].limit(0)
+    expr = tpch.filter(amount_filter).limit(0)
 
     # impala can't plan this because its correlated subquery implementation is
     # broken: it cannot detect the outer reference inside the inner query
@@ -622,7 +624,7 @@ def test_unions_with_ctes(con, alltypes):
     )
     expr2 = expr1.view()
 
-    join1 = expr1.join(expr2, expr1.string_col == expr2.string_col)[[expr1]]
+    join1 = expr1.join(expr2, expr1.string_col == expr2.string_col).select(expr1)
     join2 = join1.view()
 
     expr = join1.union(join2)
@@ -665,12 +667,12 @@ def test_where_with_timestamp(snapshot):
 
 def test_filter_with_analytic(snapshot):
     x = ibis.table(ibis.schema([("col", "int32")]), "x")
-    with_filter_col = x[x.columns + [ibis.null().name("filter")]]
-    filtered = with_filter_col[with_filter_col["filter"].isnull()]
-    subquery = filtered[filtered.columns]
+    with_filter_col = x.select(x.columns + [ibis.null().name("filter")])
+    filtered = with_filter_col.filter(with_filter_col["filter"].isnull())
+    subquery = filtered.select(filtered.columns)
 
-    with_analytic = subquery[["col", subquery.count().name("analytic")]]
-    expr = with_analytic[with_analytic.columns]
+    with_analytic = subquery.select("col", subquery.count().name("analytic"))
+    expr = with_analytic.select(with_analytic.columns)
 
     snapshot.assert_match(ibis.impala.compile(expr), "out.sql")
 

--- a/ibis/backends/impala/tests/test_in_not_in.py
+++ b/ibis/backends/impala/tests/test_in_not_in.py
@@ -33,6 +33,6 @@ def test_literal_in_fields(table, method_name, snapshot):
 def test_isin_notin_in_select(table, method_name, snapshot):
     values = ["foo", "bar"]
     method = getattr(table.g, method_name)
-    filtered = table[method(values)]
+    filtered = table.filter(method(values))
     result = translate(filtered)
     snapshot.assert_match(result, "out.sql")

--- a/ibis/backends/impala/tests/test_partition.py
+++ b/ibis/backends/impala/tests/test_partition.py
@@ -111,7 +111,9 @@ def test_insert_select_partitioned_table(con, df, temp_table, unpart_t):
     unique_keys = df[part_keys].drop_duplicates()
 
     for i, (year, month) in enumerate(unique_keys.itertuples(index=False)):
-        select_stmt = unpart_t[(unpart_t.year == year) & (unpart_t.month == month)]
+        select_stmt = unpart_t.filter(
+            (unpart_t.year == year) & (unpart_t.month == month)
+        )
 
         # test both styles of insert
         if i:
@@ -132,7 +134,7 @@ def tmp_parted(con):
 
 def test_create_partitioned_table_from_expr(con, alltypes, tmp_parted):
     t = alltypes
-    expr = t[t.id <= 10][["id", "double_col", "month", "year"]]
+    expr = t.filter(t.id <= 10)[["id", "double_col", "month", "year"]]
     name = tmp_parted
     con.create_table(name, expr, partition=[t.year])
     new = con.table(name)

--- a/ibis/backends/impala/tests/test_value_exprs.py
+++ b/ibis/backends/impala/tests/test_value_exprs.py
@@ -175,11 +175,11 @@ def test_timestamp_extract_field(table, field, snapshot):
 
 def test_sql_extract(table, snapshot):
     # integration with SQL translation
-    expr = table[
+    expr = table.select(
         table.i.year().name("year"),
         table.i.month().name("month"),
         table.i.day().name("day"),
-    ]
+    )
 
     result = ibis.to_sql(expr, dialect="impala")
     snapshot.assert_match(result, "out.sql")
@@ -252,8 +252,8 @@ def test_correlated_predicate_subquery(table, snapshot):
     t1 = t0.view()
 
     # both are valid constructions
-    expr1 = t0[t0.g == t1.g]
-    expr2 = t1[t0.g == t1.g]
+    expr1 = t0.filter(t0.g == t1.g)
+    expr2 = t1.filter(t0.g == t1.g)
 
     snapshot.assert_match(translate(expr1), "out1.sql")
     snapshot.assert_match(translate(expr2), "out2.sql")

--- a/ibis/backends/impala/tests/test_window.py
+++ b/ibis/backends/impala/tests/test_window.py
@@ -22,7 +22,7 @@ def assert_sql_equal(expr, snapshot, out="out.sql"):
 
 def test_aggregate_in_projection(alltypes, snapshot):
     t = alltypes
-    proj = t[t, (t.f / t.f.sum()).name("normed_f")]
+    proj = t.select(t, (t.f / t.f.sum()).name("normed_f"))
     assert_sql_equal(proj, snapshot)
 
 
@@ -93,7 +93,7 @@ def test_nested_analytic_function(alltypes, snapshot):
 def test_rank_functions(alltypes, snapshot):
     t = alltypes
 
-    proj = t[t.g, t.f.rank().name("minr"), t.f.dense_rank().name("denser")]
+    proj = t.select(t.g, t.f.rank().name("minr"), t.f.dense_rank().name("denser"))
     assert_sql_equal(proj, snapshot)
 
 
@@ -113,7 +113,7 @@ def test_order_by_desc(alltypes, snapshot):
 
     w = window(order_by=ibis.desc(t.f))
 
-    proj = t[t.f, ibis.row_number().over(w).name("revrank")]
+    proj = t.select(t.f, ibis.row_number().over(w).name("revrank"))
     assert_sql_equal(proj, snapshot, "out1.sql")
 
     expr = t.group_by("g").order_by(ibis.desc(t.f))[t.d.lag().name("foo"), t.a.max()]

--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -159,7 +159,7 @@ def test_builtin_agg_udf_filtered(con):
     expr = count_big(ft.id)
 
     expr = count_big(ft.id, where=ft.id == 1)
-    assert expr.execute() == ft[ft.id == 1].count().execute()
+    assert expr.execute() == ft.filter(ft.id == 1).count().execute()
 
 
 @pytest.mark.parametrize("string", ["a", " ", "a ", " a", ""])

--- a/ibis/backends/pandas/tests/test_arrays.py
+++ b/ibis/backends/pandas/tests/test_arrays.py
@@ -74,7 +74,7 @@ def test_array_collect_grouped(t, df):
 def test_array_collect_rolling_partitioned(t, df):
     window = ibis.trailing_window(1, order_by=t.plain_int64)
     colexpr = t.plain_float64.collect().over(window)
-    expr = t["dup_strings", "plain_int64", colexpr.name("collected")]
+    expr = t.select("dup_strings", "plain_int64", colexpr.name("collected"))
     result = expr.execute()
     expected = pd.DataFrame(
         {
@@ -134,7 +134,7 @@ def test_array_slice_scalar(client, start, stop):
 
 @pytest.mark.parametrize("index", [1, 3, 4, 11, -11])
 def test_array_index(t, df, index):
-    expr = t[t.array_of_float64[index].name("indexed")]
+    expr = t.select(t.array_of_float64[index].name("indexed"))
     result = expr.execute()
     expected = pd.DataFrame(
         {

--- a/ibis/backends/pandas/tests/test_operations.py
+++ b/ibis/backends/pandas/tests/test_operations.py
@@ -28,7 +28,9 @@ def test_literal(client):
 
 
 def test_selection(t, df):
-    expr = t[((t.plain_strings == "a") | (t.plain_int64 == 3)) & (t.dup_strings == "d")]
+    expr = t.filter(
+        ((t.plain_strings == "a") | (t.plain_int64 == 3)) & (t.dup_strings == "d")
+    )
     result = expr.execute()
     expected = df[
         ((df.plain_strings == "a") | (df.plain_int64 == 3)) & (df.dup_strings == "d")
@@ -45,12 +47,10 @@ def test_mutate(t, df):
 
 def test_project_scope_does_not_override(t, df):
     col = t.plain_int64
-    expr = t[
-        [
-            col.name("new_col"),
-            col.sum().over(ibis.window(group_by="dup_strings")).name("grouped"),
-        ]
-    ]
+    expr = t.select(
+        col.name("new_col"),
+        col.sum().over(ibis.window(group_by="dup_strings")).name("grouped"),
+    )
     result = expr.execute()
     expected = pd.concat(
         [

--- a/ibis/backends/pandas/tests/test_window.py
+++ b/ibis/backends/pandas/tests/test_window.py
@@ -172,7 +172,7 @@ def test_players(players, players_df):
 
 
 def test_batting_filter_mean(batting, batting_df):
-    expr = batting[batting.G > batting.G.mean()]
+    expr = batting.filter(batting.G > batting.G.mean())
     result = expr.execute()
     expected = batting_df[batting_df.G > batting_df.G.mean()].reset_index(drop=True)
     tm.assert_frame_equal(result[expected.columns], expected)
@@ -361,7 +361,7 @@ def test_mutate_with_window_after_join(sort_kind):
     left, right = map(con.table, ("left", "right"))
 
     joined = left.outer_join(right, left.ints == right.group)
-    proj = joined[left, right.value]
+    proj = joined.select(left, right.value)
     expr = proj.group_by("ints").mutate(sum=proj.value.sum())
     result = expr.execute()
     expected = pd.DataFrame(
@@ -390,7 +390,7 @@ def test_mutate_scalar_with_window_after_join():
     left, right = map(con.table, ("left", "right"))
 
     joined = left.outer_join(right, left.ints == right.group)
-    proj = joined[left, right.value]
+    proj = joined.select(left, right.value)
     expr = proj.mutate(sum=proj.value.sum(), const=ibis.literal(1))
     result = expr.execute()
     expected = pd.DataFrame(
@@ -416,8 +416,8 @@ def test_project_scalar_after_join():
     left, right = map(con.table, ("left", "right"))
 
     joined = left.outer_join(right, left.ints == right.group)
-    proj = joined[left, right.value]
-    expr = proj[proj.value.sum().name("sum"), ibis.literal(1).name("const")]
+    proj = joined.select(left, right.value)
+    expr = proj.select(proj.value.sum().name("sum"), ibis.literal(1).name("const"))
     result = expr.execute()
     expected = pd.DataFrame(
         {

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -647,7 +647,7 @@ def test_not_exists(alltypes, df):
     t = alltypes
     t2 = t.view()
 
-    expr = t[~((t.string_col == t2.string_col).any())]
+    expr = t.filter(~((t.string_col == t2.string_col).any()))
     result = expr.execute()
 
     left, right = df, t2.execute()
@@ -855,7 +855,7 @@ def test_window_with_arithmetic(alltypes, df):
 
 def test_anonymous_aggregate(alltypes, df):
     t = alltypes
-    expr = t[t.double_col > t.double_col.mean()]
+    expr = t.filter(t.double_col > t.double_col.mean())
     result = expr.execute()
     expected = df[df.double_col > df.double_col.mean()].reset_index(drop=True)
     tm.assert_frame_equal(result, expected)
@@ -908,7 +908,7 @@ def test_array_collect(array_types):
 
 @pytest.mark.parametrize("index", [0, 1, 3, 4, 11, -1, -3, -4, -11])
 def test_array_index(array_types, index):
-    expr = array_types[array_types.y[index].name("indexed")]
+    expr = array_types.select(array_types.y[index].name("indexed"))
     result = expr.execute()
     expected = pd.DataFrame(
         {

--- a/ibis/backends/postgres/tests/test_geospatial.py
+++ b/ibis/backends/postgres/tests/test_geospatial.py
@@ -232,7 +232,7 @@ def test_get_point(geotable, expr_fn, expected):
     # boundaries with the contains predicate. Work around this by adding a
     # small buffer.
     expr = geotable["geo_linestring"].buffer(0.01).contains(arg)
-    result = geotable[geotable, expr.name("tmp")].execute()["tmp"]
+    result = geotable.select(geotable, expr.name("tmp")).execute()["tmp"]
     testing.assert_almost_equal(result, expected, decimal=2)
 
 
@@ -257,7 +257,7 @@ def test_area(con, geotable):
 )
 def test_srid(geotable, condition, expected):
     """Testing for geo spatial srid operation."""
-    expr = geotable[geotable.id, condition(geotable).name("tmp")]
+    expr = geotable.select(geotable.id, condition(geotable).name("tmp"))
     result = expr.execute()["tmp"][[0]]
     assert np.all(result == expected)
 
@@ -275,7 +275,7 @@ def test_srid(geotable, condition, expected):
 )
 def test_set_srid(geotable, condition, expected):
     """Testing for geo spatial set_srid operation."""
-    expr = geotable[geotable.id, condition(geotable).name("tmp")]
+    expr = geotable.select(geotable.id, condition(geotable).name("tmp"))
     result = expr.execute()["tmp"][[0]]
     assert np.all(result == expected)
 
@@ -305,7 +305,7 @@ def test_set_srid(geotable, condition, expected):
 )
 def test_transform(geotable, condition, expected):
     """Testing for geo spatial transform operation."""
-    expr = geotable[geotable.id, condition(geotable).name("tmp")]
+    expr = geotable.select(geotable.id, condition(geotable).name("tmp"))
     result = expr.execute()["tmp"][[0]]
     assert np.all(result == expected)
 
@@ -325,7 +325,7 @@ def test_transform(geotable, condition, expected):
 def test_cast_geography(geotable, expr_fn):
     """Testing for geo spatial transform operation."""
     p = expr_fn(geotable).cast("geography")
-    expr = geotable[geotable.id, p.distance(p).name("tmp")]
+    expr = geotable.select(geotable.id, p.distance(p).name("tmp"))
     result = expr.execute()["tmp"][[0]]
     # distance from a point to a same point should be 0
     assert np.all(result == 0)
@@ -346,7 +346,7 @@ def test_cast_geography(geotable, expr_fn):
 def test_cast_geometry(geotable, expr_fn):
     """Testing for geo spatial transform operation."""
     p = expr_fn(geotable).cast("geometry")
-    expr = geotable[geotable.id, p.distance(p).name("tmp")]
+    expr = geotable.select(geotable.id, p.distance(p).name("tmp"))
     result = expr.execute()["tmp"][[0]]
     # distance from a point to a same point should be 0
     assert np.all(result == 0)

--- a/ibis/backends/postgres/tests/test_json.py
+++ b/ibis/backends/postgres/tests/test_json.py
@@ -23,7 +23,7 @@ def jsonb_t(con):
 @pytest.mark.parametrize("data", [param({"status": True}, id="status")])
 def test_json(data, alltypes):
     lit = ibis.literal(json.dumps(data), type="json").name("tmp")
-    expr = alltypes[[alltypes.id, lit]].head(1)
+    expr = alltypes.select(alltypes.id, lit).head(1)
     df = expr.execute()
     assert df["tmp"].iloc[0] == data
 

--- a/ibis/backends/postgres/tests/test_postgis.py
+++ b/ibis/backends/postgres/tests/test_postgis.py
@@ -21,7 +21,7 @@ def test_load_geodata(con):
 
 
 def test_empty_select(geotable):
-    expr = geotable[geotable.geo_point.geo_equals(geotable.geo_linestring)]
+    expr = geotable.filter(geotable.geo_point.geo_equals(geotable.geo_linestring))
     result = expr.execute()
     assert len(result) == 0
 

--- a/ibis/backends/postgres/tests/test_string.py
+++ b/ibis/backends/postgres/tests/test_string.py
@@ -15,6 +15,6 @@ import ibis
 @pytest.mark.usefixtures("con")
 def test_special_strings(alltypes, data, data_type):
     lit = ibis.literal(data, type=data_type).name("tmp")
-    expr = alltypes[[alltypes.id, lit]].head(1)
+    expr = alltypes.select(alltypes.id, lit).head(1)
     df = expr.execute()
     assert df["tmp"].iloc[0] == uuid.UUID(data)

--- a/ibis/backends/postgres/tests/test_udf.py
+++ b/ibis/backends/postgres/tests/test_udf.py
@@ -85,7 +85,9 @@ def test_existing_sql_udf(con_for_udf, test_database, table):
     """Test creating ibis UDF object based on existing UDF in the database."""
     # Create ibis UDF objects referring to UDFs already created in the database
     custom_length_udf = con_for_udf.function("custom_len", database=test_database)
-    result_obj = table[table, custom_length_udf(table["user_name"]).name("custom_len")]
+    result_obj = table.select(
+        table, custom_length_udf(table["user_name"]).name("custom_len")
+    )
     result = result_obj.execute()
     assert result["custom_len"].sum() == result["name_length"].sum()
 
@@ -93,7 +95,9 @@ def test_existing_sql_udf(con_for_udf, test_database, table):
 def test_existing_plpython_udf(con_for_udf, test_database, table):
     # Create ibis UDF objects referring to UDFs already created in the database
     py_length_udf = con_for_udf.function("pylen", database=test_database)
-    result_obj = table[table, py_length_udf(table["user_name"]).name("custom_len")]
+    result_obj = table.select(
+        table, py_length_udf(table["user_name"]).name("custom_len")
+    )
     result = result_obj.execute()
     assert result["custom_len"].sum() == result["name_length"].sum()
 

--- a/ibis/backends/pyspark/tests/test_array.py
+++ b/ibis/backends/pyspark/tests/test_array.py
@@ -82,7 +82,7 @@ def test_array_slice_scalar(con, start, stop):
 
 @pytest.mark.parametrize("index", [1, 3, 4, 11, -11])
 def test_array_index(t, df, index):
-    expr = t[t.array_int[index].name("indexed")]
+    expr = t.select(t.array_int[index].name("indexed"))
     result = expr.execute()
 
     expected = pd.DataFrame(

--- a/ibis/backends/pyspark/tests/test_ddl.py
+++ b/ibis/backends/pyspark/tests/test_ddl.py
@@ -134,16 +134,16 @@ def test_insert_validate_types(con, alltypes, test_data_db, temp_table):
         database=db,
     )
 
-    to_insert = expr[
+    to_insert = expr.select(
         expr.tinyint_col, expr.smallint_col.name("int_col"), expr.string_col
-    ]
+    )
     con.insert(temp_table, to_insert.limit(10))
 
-    to_insert = expr[
+    to_insert = expr.select(
         expr.tinyint_col,
         expr.smallint_col.cast("int32").name("int_col"),
         expr.string_col,
-    ]
+    )
     con.insert(temp_table, to_insert.limit(10))
 
 

--- a/ibis/backends/pyspark/tests/test_null.py
+++ b/ibis/backends/pyspark/tests/test_null.py
@@ -11,7 +11,7 @@ def test_isnull(con):
     table_pandas = table.execute()
 
     for col, _ in table_pandas.items():
-        result = table[table[col].isnull()].execute().reset_index(drop=True)
+        result = table.filter(table[col].isnull()).execute().reset_index(drop=True)
         expected = table_pandas[table_pandas[col].isnull()].reset_index(drop=True)
         tm.assert_frame_equal(result, expected)
 
@@ -21,6 +21,6 @@ def test_notnull(con):
     table_pandas = table.execute()
 
     for col, _ in table_pandas.items():
-        result = table[table[col].notnull()].execute().reset_index(drop=True)
+        result = table.filter(table[col].notnull()).execute().reset_index(drop=True)
         expected = table_pandas[table_pandas[col].notnull()].reset_index(drop=True)
         tm.assert_frame_equal(result, expected)

--- a/ibis/backends/risingwave/tests/test_functions.py
+++ b/ibis/backends/risingwave/tests/test_functions.py
@@ -448,7 +448,7 @@ def test_not_exists(alltypes, df):
     t = alltypes
     t2 = t.view()
 
-    expr = t[~((t.string_col == t2.string_col).any())]
+    expr = t.filter(~((t.string_col == t2.string_col).any()))
     result = expr.execute()
 
     left, right = df, t2.execute()
@@ -615,7 +615,7 @@ def test_window_with_arithmetic(alltypes, df):
 
 def test_anonymous_aggregate(alltypes, df):
     t = alltypes
-    expr = t[t.double_col > t.double_col.mean()]
+    expr = t.filter(t.double_col > t.double_col.mean())
     result = expr.execute()
     expected = df[df.double_col > df.double_col.mean()].reset_index(drop=True)
     tm.assert_frame_equal(result, expected)

--- a/ibis/backends/risingwave/tests/test_json.py
+++ b/ibis/backends/risingwave/tests/test_json.py
@@ -13,6 +13,6 @@ import ibis
 @pytest.mark.parametrize("data", [param({"status": True}, id="status")])
 def test_json(data, alltypes):
     lit = ibis.literal(json.dumps(data), type="json").name("tmp")
-    expr = alltypes[[alltypes.id, lit]].head(1)
+    expr = alltypes.select(alltypes.id, lit).head(1)
     df = expr.execute()
     assert df["tmp"].iloc[0] == data

--- a/ibis/backends/tests/sql/conftest.py
+++ b/ibis/backends/tests/sql/conftest.py
@@ -93,20 +93,20 @@ def t2(con):
 
 @pytest.fixture(scope="module")
 def not_exists(foo_t, bar_t):
-    return foo_t[-(foo_t.key1 == bar_t.key1).any()]
+    return foo_t.filter(~(foo_t.key1 == bar_t.key1).any())
 
 
 @pytest.fixture(scope="module")
 def union(con):
     table = con.table("functional_alltypes")
 
-    t1 = table[table.int_col > 0][
+    t1 = table.filter(table.int_col > 0).select(
         table.string_col.name("key"),
         table.float_col.cast("double").name("value"),
-    ]
-    t2 = table[table.int_col <= 0][
+    )
+    t2 = table.filter(table.int_col <= 0).select(
         table.string_col.name("key"), table.double_col.name("value")
-    ]
+    )
 
     return t1.union(t2, distinct=True)
 
@@ -115,13 +115,13 @@ def union(con):
 def union_all(con):
     table = con.table("functional_alltypes")
 
-    t1 = table[table.int_col > 0][
+    t1 = table.filter(table.int_col > 0).select(
         table.string_col.name("key"),
         table.float_col.cast("double").name("value"),
-    ]
-    t2 = table[table.int_col <= 0][
+    )
+    t2 = table.filter(table.int_col <= 0).select(
         table.string_col.name("key"), table.double_col.name("value")
-    ]
+    )
 
     return t1.union(t2, distinct=False)
 
@@ -130,13 +130,13 @@ def union_all(con):
 def intersect(con):
     table = con.table("functional_alltypes")
 
-    t1 = table[table.int_col > 0][
+    t1 = table.filter(table.int_col > 0).select(
         table.string_col.name("key"),
         table.float_col.cast("double").name("value"),
-    ]
-    t2 = table[table.int_col <= 0][
+    )
+    t2 = table.filter(table.int_col <= 0).select(
         table.string_col.name("key"), table.double_col.name("value")
-    ]
+    )
 
     return t1.intersect(t2)
 
@@ -145,13 +145,13 @@ def intersect(con):
 def difference(con):
     table = con.table("functional_alltypes")
 
-    t1 = table[table.int_col > 0][
+    t1 = table.filter(table.int_col > 0).select(
         table.string_col.name("key"),
         table.float_col.cast("double").name("value"),
-    ]
-    t2 = table[table.int_col <= 0][
+    )
+    t2 = table.filter(table.int_col <= 0).select(
         table.string_col.name("key"), table.double_col.name("value")
-    ]
+    )
 
     return t1.difference(t2)
 
@@ -193,12 +193,12 @@ def projection_fuse_filter():
     proj = t["a", "b", "c"]
 
     # Rewrite a little more aggressively here
-    expr1 = proj[t.a > 0]
+    expr1 = proj.filter(t.a > 0)
 
     # at one point these yielded different results
-    filtered = t[t.a > 0]
+    filtered = t.filter(t.a > 0)
 
-    expr2 = filtered[t.a, t.b, t.c]
+    expr2 = filtered.select(t.a, t.b, t.c)
     expr3 = filtered.select(["a", "b", "c"])
 
     return expr1, expr2, expr3

--- a/ibis/backends/tests/sql/test_compiler.py
+++ b/ibis/backends/tests/sql/test_compiler.py
@@ -18,7 +18,7 @@ def test_union(union, snapshot):
 
 def test_union_project_column(union_all, snapshot):
     # select a column, get a subquery
-    expr = union_all[[union_all.key]]
+    expr = union_all.select(union_all.key)
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot, eq=schemas_eq)
 
@@ -35,14 +35,14 @@ def test_table_difference(difference, snapshot):
 
 def test_intersect_project_column(intersect, snapshot):
     # select a column, get a subquery
-    expr = intersect[[intersect.key]]
+    expr = intersect.select(intersect.key)
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot, eq=schemas_eq)
 
 
 def test_difference_project_column(difference, snapshot):
     # select a column, get a subquery
-    expr = difference[[difference.key]]
+    expr = difference.select(difference.key)
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot, eq=schemas_eq)
 
@@ -50,14 +50,14 @@ def test_difference_project_column(difference, snapshot):
 def test_table_distinct(con, snapshot):
     t = con.table("functional_alltypes")
 
-    expr = t[t.string_col, t.int_col].distinct()
+    expr = t.select(t.string_col, t.int_col).distinct()
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot)
 
 
 def test_column_distinct(con, snapshot):
     t = con.table("functional_alltypes")
-    expr = t[t.string_col].distinct()
+    expr = t.select(t.string_col).distinct()
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot)
 
@@ -66,7 +66,7 @@ def test_count_distinct(con, snapshot):
     t = con.table("functional_alltypes")
 
     metric = t.int_col.nunique().name("nunique")
-    expr = t[t.bigint_col > 0].group_by("string_col").aggregate([metric])
+    expr = t.filter(t.bigint_col > 0).group_by("string_col").aggregate([metric])
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot)
 
@@ -96,8 +96,8 @@ def test_pushdown_with_or(snapshot):
         ],
         "functional_alltypes",
     )
-    subset = t[(t.double_col > 3.14) & t.string_col.contains("foo")]
-    expr = subset[(subset.int_col - 1 == 0) | (subset.float_col <= 1.34)]
+    subset = t.filter((t.double_col > 3.14) & t.string_col.contains("foo"))
+    expr = subset.filter((subset.int_col - 1 == 0) | (subset.float_col <= 1.34))
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -117,7 +117,7 @@ def test_having_size(snapshot):
 
 def test_having_from_filter(snapshot):
     t = ibis.table([("a", "int64"), ("b", "string")], "t")
-    filt = t[t.b == "m"]
+    filt = t.filter(t.b == "m")
     gb = filt.group_by(filt.b)
     having = gb.having(filt.a.max() == 2)
     expr = having.aggregate(filt.a.sum().name("sum"))
@@ -128,16 +128,16 @@ def test_having_from_filter(snapshot):
 
 def test_simple_agg_filter(snapshot):
     t = ibis.table([("a", "int64"), ("b", "string")], name="my_table")
-    filt = t[t.a < 100]
-    expr = filt[filt.a == filt.a.max()]
+    filt = t.filter(t.a < 100)
+    expr = filt.filter(filt.a == filt.a.max())
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
 def test_agg_and_non_agg_filter(snapshot):
     t = ibis.table([("a", "int64"), ("b", "string")], name="my_table")
-    filt = t[t.a < 100]
-    expr = filt[filt.a == filt.a.max()]
-    expr = expr[expr.b == "a"]
+    filt = t.filter(t.a < 100)
+    expr = filt.filter(filt.a == filt.a.max())
+    expr = expr.filter(expr.b == "a")
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -145,8 +145,8 @@ def test_agg_filter(snapshot):
     t = ibis.table([("a", "int64"), ("b", "int64")], name="my_table")
     t = t.mutate(b2=t.b * 2)
     t = t[["a", "b2"]]
-    filt = t[t.a < 100]
-    expr = filt[filt.a == filt.a.max().name("blah")]
+    filt = t.filter(t.a < 100)
+    expr = filt.filter(filt.a == filt.a.max().name("blah"))
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -154,8 +154,8 @@ def test_agg_filter_with_alias(snapshot):
     t = ibis.table([("a", "int64"), ("b", "int64")], name="my_table")
     t = t.mutate(b2=t.b * 2)
     t = t[["a", "b2"]]
-    filt = t[t.a < 100]
-    expr = filt[filt.a.name("A") == filt.a.max().name("blah")]
+    filt = t.filter(t.a < 100)
+    expr = filt.filter(filt.a.name("A") == filt.a.max().name("blah"))
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -169,7 +169,7 @@ def test_table_drop_with_filter(snapshot):
 
     right = ibis.table([("b", "string")], name="s")
     joined = left.join(right, left.b == right.b)
-    joined = joined[left.a]
+    joined = joined.select(left.a)
     expr = joined.filter(joined.a < 1.0)
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot, eq=schemas_eq)
@@ -198,9 +198,8 @@ def test_subquery_where_location(snapshot):
     )
     param = ibis.param("timestamp")
     expr = (
-        t[["float_col", "timestamp_col", "int_col", "string_col"]][
-            lambda t: t.timestamp_col < param
-        ]
+        t.select("float_col", "timestamp_col", "int_col", "string_col")
+        .filter(lambda t: t.timestamp_col < param)
         .group_by("string_col")
         .aggregate(foo=lambda t: t.float_col.sum())
         .foo.count()

--- a/ibis/backends/tests/sql/test_select_sql.py
+++ b/ibis/backends/tests/sql/test_select_sql.py
@@ -29,9 +29,12 @@ pytestmark = pytest.mark.duckdb
         param(lambda star1, **_: star1.order_by("f"), id="single_column"),
         param(lambda star1, **_: star1.limit(10), id="limit_simple"),
         param(lambda star1, **_: star1.limit(10, offset=5), id="limit_with_offset"),
-        param(lambda star1, **_: star1[star1.f > 0].limit(10), id="filter_then_limit"),
         param(
-            lambda star1, **_: star1.limit(10)[lambda x: x.f > 0],
+            lambda star1, **_: star1.filter(star1.f > 0).limit(10),
+            id="filter_then_limit",
+        ),
+        param(
+            lambda star1, **_: star1.limit(10).filter(lambda x: x.f > 0),
             id="limit_then_filter",
         ),
         param(lambda star1, **_: star1.count(), id="aggregate_table_count_metric"),
@@ -60,16 +63,16 @@ def test_simple_joins(star1, star2, snapshot):
     pred = t1["foo_id"] == t2["foo_id"]
     pred2 = t1["bar_id"] == t2["foo_id"]
 
-    expr = t1.inner_join(t2, [pred])[[t1]]
+    expr = t1.inner_join(t2, [pred]).select(t1)
     snapshot.assert_match(to_sql(expr), "inner.sql")
 
-    expr = t1.left_join(t2, [pred])[[t1]]
+    expr = t1.left_join(t2, [pred]).select(t1)
     snapshot.assert_match(to_sql(expr), "left.sql")
 
-    expr = t1.outer_join(t2, [pred])[[t1]]
+    expr = t1.outer_join(t2, [pred]).select(t1)
     snapshot.assert_match(to_sql(expr), "outer.sql")
 
-    expr = t1.inner_join(t2, [pred, pred2])[[t1]]
+    expr = t1.inner_join(t2, [pred, pred2]).select(t1)
     snapshot.assert_match(to_sql(expr), "inner_two_preds.sql")
     assert_decompile_roundtrip(expr, snapshot)
 
@@ -103,8 +106,8 @@ def test_join_between_joins(snapshot):
         "third",
     )
     t4 = ibis.table([("key3", "string"), ("value4", "double")], "fourth")
-    left = t1.inner_join(t2, [("key1", "key1")])[t1, t2.value2]
-    right = t3.inner_join(t4, [("key3", "key3")])[t3, t4.value4]
+    left = t1.inner_join(t2, [("key1", "key1")]).select(t1, t2.value2)
+    right = t3.inner_join(t4, [("key3", "key3")]).select(t3, t4.value4)
 
     joined = left.inner_join(right, [("key2", "key2")])
 
@@ -130,13 +133,13 @@ def test_join_just_materialized(nation, region, customer, snapshot):
 
 
 def test_semi_join(star1, star2, snapshot):
-    expr = star1.semi_join(star2, [star1.foo_id == star2.foo_id])[[star1]]
+    expr = star1.semi_join(star2, [star1.foo_id == star2.foo_id]).select(star1)
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot)
 
 
 def test_anti_join(star1, star2, snapshot):
-    expr = star1.anti_join(star2, [star1.foo_id == star2.foo_id])[[star1]]
+    expr = star1.anti_join(star2, [star1.foo_id == star2.foo_id]).select(star1)
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot)
 
@@ -145,11 +148,11 @@ def test_where_no_pushdown_possible(star1, star2, snapshot):
     t1 = star1
     t2 = star2
 
-    joined = t1.inner_join(t2, [t1.foo_id == t2.foo_id])[
+    joined = t1.inner_join(t2, [t1.foo_id == t2.foo_id]).select(
         t1, (t1.f - t2.value1).name("diff")
-    ]
+    )
 
-    expr = joined[joined.diff > 1]
+    expr = joined.filter(joined.diff > 1)
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot)
 
@@ -186,7 +189,7 @@ def test_bug_duplicated_where(airlines, snapshot):
         dest_avg=t.arrdelay.mean(), dev=t.arrdelay - t.arrdelay.mean()
     )
 
-    tmp1 = expr[expr.dev.notnull()]
+    tmp1 = expr.filter(expr.dev.notnull())
     tmp2 = tmp1.order_by(ibis.desc("dev"))
     expr = tmp2.limit(10)
     snapshot.assert_match(to_sql(expr), "out.sql")
@@ -229,8 +232,8 @@ def test_fuse_projections(snapshot):
     f1 = (table["foo"] + table["bar"]).name("baz")
     pred = table["value"] > 0
 
-    table2 = table[table, f1]
-    table2_filtered = table2[pred]
+    table2 = table.select(table, f1)
+    table2_filtered = table2.filter(pred)
 
     f2 = (table2["foo"] * 2).name("qux")
 
@@ -321,7 +324,7 @@ def test_bug_project_multiple_times(customer, nation, region, snapshot):
         nation, [customer.c_nationkey == nation.n_nationkey]
     ).inner_join(region, [nation.n_regionkey == region.r_regionkey])
     proj1 = [customer, nation.n_name, region.r_name]
-    step1 = joined[proj1]
+    step1 = joined.select(proj1)
 
     topk_by = step1.c_acctbal.cast("double").sum()
 
@@ -335,19 +338,19 @@ def test_bug_project_multiple_times(customer, nation, region, snapshot):
 def test_aggregate_projection_subquery(alltypes, snapshot):
     t = alltypes
 
-    proj = t[t.f > 0][t, (t.a + t.b).name("foo")]
+    proj = t.filter(t.f > 0).select(t, (t.a + t.b).name("foo"))
 
     def agg(x):
         return x.aggregate([x.foo.sum().name("foo total")], by=["g"])
 
     # predicate gets pushed down
-    filtered = proj[proj.g == "bar"]
+    filtered = proj.filter(proj.g == "bar")
 
     # Pushdown is not possible (in Impala, Postgres, others)
     snapshot.assert_match(to_sql(proj), "proj.sql")
     snapshot.assert_match(to_sql(filtered), "filtered.sql")
     snapshot.assert_match(to_sql(agg(filtered)), "agg_filtered.sql")
-    snapshot.assert_match(to_sql(agg(proj[proj.foo < 10])), "agg_filtered2.sql")
+    snapshot.assert_match(to_sql(agg(proj.filter(proj.foo < 10))), "agg_filtered2.sql")
 
 
 def test_double_nested_subquery_no_aliases(snapshot):
@@ -373,7 +376,7 @@ def test_aggregate_projection_alias_bug(star1, star2, snapshot):
     t1 = star1
     t2 = star2
 
-    what = t1.inner_join(t2, [t1.foo_id == t2.foo_id])[[t1, t2.value1]]
+    what = t1.inner_join(t2, [t1.foo_id == t2.foo_id]).select(t1, t2.value1)
 
     # TODO: Not fusing the aggregation with the projection yet
     expr = what.aggregate([what.value1.sum().name("total")], by=[what.foo_id])
@@ -386,7 +389,7 @@ def test_subquery_in_union(alltypes, snapshot):
     expr1 = t.group_by(["a", "g"]).aggregate(t.f.sum().name("metric"))
     expr2 = expr1.view()
 
-    join1 = expr1.join(expr2, expr1.g == expr2.g)[[expr1]]
+    join1 = expr1.join(expr2, expr1.g == expr2.g).select(expr1)
     join2 = join1.view()
 
     expr = join1.union(join2)
@@ -405,11 +408,11 @@ def test_limit_with_self_join(functional_alltypes, snapshot):
 
 def test_topk_predicate_pushdown_bug(nation, customer, region, snapshot):
     # Observed on TPCH data
-    cplusgeo = customer.inner_join(
-        nation, [customer.c_nationkey == nation.n_nationkey]
-    ).inner_join(region, [nation.n_regionkey == region.r_regionkey])[
-        customer, nation.n_name, region.r_name
-    ]
+    cplusgeo = (
+        customer.inner_join(nation, [customer.c_nationkey == nation.n_nationkey])
+        .inner_join(region, [nation.n_regionkey == region.r_regionkey])
+        .select(customer, nation.n_name, region.r_name)
+    )
 
     expr = cplusgeo.semi_join(
         cplusgeo.n_name.topk(10, by=cplusgeo.c_acctbal.sum()), "n_name"
@@ -425,7 +428,7 @@ def test_topk_analysis_bug(snapshot):
     )
 
     dests = ("ORD", "JFK", "SFO")
-    t = airlines[airlines.dest.isin(dests)]
+    t = airlines.filter(airlines.dest.isin(dests))
     expr = (
         t.semi_join(t.dest.topk(10, by=t.arrdelay.mean()), "dest")
         .group_by("origin")
@@ -451,7 +454,7 @@ def test_bool_bool(snapshot):
     )
 
     x = ibis.literal(True)
-    expr = t[(t.dest.cast("int64") == 0) == x]
+    expr = t.filter((t.dest.cast("int64") == 0) == x)
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot)
 
@@ -460,7 +463,7 @@ def test_case_in_projection(alltypes, snapshot):
     t = alltypes
     expr = t.g.case().when("foo", "bar").when("baz", "qux").else_("default").end()
     expr2 = ibis.case().when(t.g == "foo", "bar").when(t.g == "baz", t.g).end()
-    expr = t[expr.name("col1"), expr2.name("col2"), t]
+    expr = t.select(expr.name("col1"), expr2.name("col2"), t)
 
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert_decompile_roundtrip(expr, snapshot, eq=schemas_eq)
@@ -469,12 +472,12 @@ def test_case_in_projection(alltypes, snapshot):
 def test_identifier_quoting(snapshot):
     data = ibis.table([("date", "int32"), ("explain", "string")], "table")
 
-    expr = data[data.date.name("else"), data.explain.name("join")]
+    expr = data.select(data.date.name("else"), data.explain.name("join"))
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
 def test_scalar_subquery_different_table(foo, bar, snapshot):
-    expr = foo[foo.y > bar.x.max()]
+    expr = foo.filter(foo.y > bar.x.max())
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -482,7 +485,7 @@ def test_exists_subquery(t1, t2, snapshot):
     # GH #660
 
     cond = t1.key1 == t2.key1
-    expr = t1[cond.any()]
+    expr = t1.filter(cond.any())
 
     snapshot.assert_match(to_sql(expr), "out.sql")
     assert repr(expr)
@@ -509,8 +512,8 @@ def test_filter_inside_exists(snapshot):
         "purchases",
     )
     filt = purchases.ts > "2015-08-15"
-    cond = (events.user_id == purchases[filt].user_id).any()
-    expr = events[cond]
+    cond = (events.user_id == purchases.filter(filt).user_id).any()
+    expr = events.filter(cond)
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -532,7 +535,7 @@ def test_order_by_on_limit_yield_subquery(functional_alltypes, snapshot):
 
 def test_join_with_limited_table(star1, star2, snapshot):
     limited = star1.limit(100)
-    expr = limited.inner_join(star2, [limited.foo_id == star2.foo_id])[[limited]]
+    expr = limited.inner_join(star2, [limited.foo_id == star2.foo_id]).select(limited)
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -571,7 +574,7 @@ def test_join_filtered_tables_no_pushdown(snapshot):
     tbl_b_filter = tbl_b.filter([tbl_b.year == 2016, tbl_b.month == 2, tbl_b.day == 29])
 
     joined = tbl_a_filter.left_join(tbl_b_filter, ["year", "month", "day"])
-    result = joined[tbl_a_filter.value_a, tbl_b_filter.value_b]
+    result = joined.select(tbl_a_filter.value_a, tbl_b_filter.value_b)
 
     snapshot.assert_match(to_sql(result), "out.sql")
 
@@ -580,14 +583,14 @@ def test_loj_subquery_filter_handling(snapshot):
     # #781
     left = ibis.table([("id", "int32"), ("desc", "string")], "foo")
     right = ibis.table([("id", "int32"), ("desc", "string")], "bar")
-    left = left[left.id < 2]
-    right = right[right.id < 3]
+    left = left.filter(left.id < 2)
+    right = right.filter(right.id < 3)
 
     joined = left.left_join(right, ["id", "desc"])
-    expr = joined[
+    expr = joined.select(
         [left[name].name("left_" + name) for name in left.columns]
         + [right[name].name("right_" + name) for name in right.columns]
-    ]
+    )
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -622,16 +625,16 @@ def test_filter_predicates(snapshot):
 
 def test_join_projection_subquery_bug(nation, region, customer, snapshot):
     # From an observed bug, derived from tpch tables
-    geo = nation.inner_join(region, [("n_regionkey", "r_regionkey")])[
+    geo = nation.inner_join(region, [("n_regionkey", "r_regionkey")]).select(
         nation.n_nationkey,
         nation.n_name.name("nation"),
         region.r_name.name("region"),
-    ]
+    )
 
-    expr = geo.inner_join(customer, [("n_nationkey", "c_nationkey")])[
+    expr = geo.inner_join(customer, [("n_nationkey", "c_nationkey")]).select(
         customer,
         geo,
-    ]
+    )
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -695,15 +698,16 @@ def test_subquery_factor_correlated_subquery(con, snapshot):
     tpch = (
         region.join(nation, region.r_regionkey == nation.n_regionkey)
         .join(customer, customer.c_nationkey == nation.n_nationkey)
-        .join(orders, orders.o_custkey == customer.c_custkey)[fields_of_interest]
+        .join(orders, orders.o_custkey == customer.c_custkey)
+        .select(fields_of_interest)
     )
 
     # Self-reference + correlated subquery complicates things
     t2 = tpch.view()
-    conditional_avg = t2[t2.region == tpch.region].amount.mean()
+    conditional_avg = t2.filter(t2.region == tpch.region).amount.mean()
     amount_filter = tpch.amount > conditional_avg
 
-    expr = tpch[amount_filter].limit(10)
+    expr = tpch.filter(amount_filter).limit(10)
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -711,13 +715,17 @@ def test_self_join_subquery_distinct_equal(con, snapshot):
     region = con.table("tpch_region")
     nation = con.table("tpch_nation")
 
-    j1 = region.join(nation, region.r_regionkey == nation.n_regionkey)[region, nation]
-
-    j2 = region.join(nation, region.r_regionkey == nation.n_regionkey)[
+    j1 = region.join(nation, region.r_regionkey == nation.n_regionkey).select(
         region, nation
-    ].view()
+    )
 
-    expr = j1.join(j2, j1.r_regionkey == j2.r_regionkey)[j1.r_name, j2.n_name]
+    j2 = (
+        region.join(nation, region.r_regionkey == nation.n_regionkey)
+        .select(region, nation)
+        .view()
+    )
+
+    expr = j1.join(j2, j1.r_regionkey == j2.r_regionkey).select(j1.r_name, j2.n_name)
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 
@@ -739,7 +747,8 @@ def test_tpch_self_join_failure(con, snapshot):
     joined_all = (
         region.join(nation, region.r_regionkey == nation.n_regionkey)
         .join(customer, customer.c_nationkey == nation.n_nationkey)
-        .join(orders, orders.o_custkey == customer.c_custkey)[fields_of_interest]
+        .join(orders, orders.o_custkey == customer.c_custkey)
+        .select(fields_of_interest)
     )
 
     year = joined_all.odate.year().name("year")
@@ -750,9 +759,9 @@ def test_tpch_self_join_failure(con, snapshot):
     prior = annual_amounts.view()
 
     yoy_change = (current.total - prior.total).name("yoy_change")
-    yoy = current.join(prior, current.year == (prior.year - 1))[
+    yoy = current.join(prior, current.year == (prior.year - 1)).select(
         current.region, current.year, yoy_change
-    ]
+    )
     snapshot.assert_match(to_sql(yoy), "out.sql")
     #  Compiler.to_sql(yoy)  # fail
 
@@ -762,13 +771,13 @@ def test_subquery_in_filter_predicate(star1, snapshot):
     t1 = star1
 
     pred = t1.f > t1.f.mean()
-    expr = t1[pred]
+    expr = t1.filter(pred)
     snapshot.assert_match(to_sql(expr), "expr.sql")
 
     # This brought out another expression rewriting bug, since the filtered
     # table isn't found elsewhere in the expression.
-    pred2 = t1.f > t1[t1.foo_id == "foo"].f.mean()
-    expr2 = t1[pred2]
+    pred2 = t1.f > t1.filter(t1.foo_id == "foo").f.mean()
+    expr2 = t1.filter(pred2)
     snapshot.assert_match(to_sql(expr2), "expr2.sql")
 
 
@@ -776,11 +785,11 @@ def test_filter_subquery_derived_reduction(star1, snapshot):
     t1 = star1
 
     # Reduction can be nested inside some scalar expression
-    pred3 = t1.f > t1[t1.foo_id == "foo"].f.mean().log()
-    pred4 = t1.f > (t1[t1.foo_id == "foo"].f.mean().log() + 1)
+    pred3 = t1.f > t1.filter(t1.foo_id == "foo").f.mean().log()
+    pred4 = t1.f > (t1.filter(t1.foo_id == "foo").f.mean().log() + 1)
 
-    expr3 = t1[pred3]
-    expr4 = t1[pred4]
+    expr3 = t1.filter(pred3)
+    expr4 = t1.filter(pred4)
 
     snapshot.assert_match(to_sql(expr3), "expr3.sql")
     snapshot.assert_match(to_sql(expr4), "expr4.sql")
@@ -838,11 +847,11 @@ def test_filter_self_join_analysis_bug(snapshot):
     metric = purchases.amount.sum().name("total")
     agged = purchases.group_by(["region", "kind"]).aggregate(metric)
 
-    left = agged[agged.kind == "foo"]
-    right = agged[agged.kind == "bar"]
+    left = agged.filter(agged.kind == "foo")
+    right = agged.filter(agged.kind == "bar")
 
     joined = left.join(right, left.region == right.region)
-    result = joined[left.region, (left.total - right.total).name("diff")]
+    result = joined.select(left.region, (left.total - right.total).name("diff"))
 
     snapshot.assert_match(to_sql(result), "result.sql")
 
@@ -907,8 +916,8 @@ def test_chain_limit_doesnt_collapse(snapshot):
 def test_join_with_conditional_aggregate(snapshot):
     left = ibis.table({"on": "int", "by": "string"}, name="left")
     right = ibis.table({"on": "int", "by": "string", "val": "float"}, name="right")
-    stat = right[(right.by == left.by) & (right.on <= left.on)]["on"].max()
-    merged = left.join(right, how="left", predicates=left.by == right.by)[
+    stat = right.filter(right.by == left.by, right.on <= left.on)["on"].max()
+    merged = left.join(right, how="left", predicates=left.by == right.by).filter(
         right.on == stat
-    ]
+    )
     snapshot.assert_match(to_sql(merged), "result.sql")

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -1596,7 +1596,7 @@ def test_agg_sort(alltypes):
 
 def test_filter(backend, alltypes, df):
     expr = (
-        alltypes[_.string_col == "1"]
+        alltypes.filter(_.string_col == "1")
         .mutate(x=L(1, "int64"))
         .group_by(_.x)
         .aggregate(sum=_.double_col.sum())

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -218,7 +218,7 @@ def test_load_data(backend, con, temp_table, lamduh):
     [
         param(lambda t: t.string_col, [("string_col", dt.String)], id="column"),
         param(
-            lambda t: t[t.string_col, t.bigint_col],
+            lambda t: t.select(t.string_col, t.bigint_col),
             [("string_col", dt.String), ("bigint_col", dt.Int64)],
             id="table",
         ),

--- a/ibis/backends/tests/test_interactive.py
+++ b/ibis/backends/tests/test_interactive.py
@@ -86,6 +86,6 @@ def test_interactive_non_compilable_repr_does_not_fail(table):
 
 def test_isin_rule_suppressed_exception_repr_not_fail(table):
     bool_clause = table["string_col"].notin(["1", "4", "7"])
-    expr = table[bool_clause]["string_col"].value_counts()
+    expr = table.filter(bool_clause)["string_col"].value_counts()
 
     repr(expr)

--- a/ibis/backends/tests/test_join.py
+++ b/ibis/backends/tests/test_join.py
@@ -64,8 +64,8 @@ def check_eq(left, right, how, **kwargs):
 )
 @pytest.mark.notimpl(["druid"])
 def test_mutating_join(backend, batting, awards_players, how):
-    left = batting[batting.yearID == 2015]
-    right = awards_players[awards_players.lgID == "NL"].drop("yearID", "lgID")
+    left = batting.filter(batting.yearID == 2015)
+    right = awards_players.filter(awards_players.lgID == "NL").drop("yearID", "lgID")
 
     left_df = left.execute()
     right_df = right.execute()
@@ -114,8 +114,8 @@ def test_mutating_join(backend, batting, awards_players, how):
 @pytest.mark.notimpl(["dask", "druid"])
 @pytest.mark.notyet(["flink"], reason="Flink doesn't support semi joins or anti joins")
 def test_filtering_join(backend, batting, awards_players, how):
-    left = batting[batting.yearID == 2015]
-    right = awards_players[awards_players.lgID == "NL"].drop("yearID", "lgID")
+    left = batting.filter(batting.yearID == 2015)
+    right = awards_players.filter(awards_players.lgID == "NL").drop("yearID", "lgID")
 
     left_df = left.execute()
     right_df = right.execute()
@@ -142,10 +142,10 @@ def test_filtering_join(backend, batting, awards_players, how):
 
 
 def test_join_then_filter_no_column_overlap(awards_players, batting):
-    left = batting[batting.yearID == 2015]
+    left = batting.filter(batting.yearID == 2015)
     year = left.yearID.name("year")
-    left = left[year, "RBI"]
-    right = awards_players[awards_players.lgID == "NL"]
+    left = left.select(year, "RBI")
+    right = awards_players.filter(awards_players.lgID == "NL")
 
     expr = left.join(right, left.year == right.yearID)
     filters = [expr.RBI == 9]
@@ -196,8 +196,8 @@ def test_semi_join_topk(con, batting, awards_players, func):
     reason="postgres can't handle null types columns",
 )
 def test_join_with_pandas(batting, awards_players):
-    batting_filt = batting[lambda t: t.yearID < 1900]
-    awards_players_filt = awards_players[lambda t: t.yearID < 1900].execute()
+    batting_filt = batting.filter(lambda t: t.yearID < 1900)
+    awards_players_filt = awards_players.filter(lambda t: t.yearID < 1900).execute()
     assert isinstance(awards_players_filt, pd.DataFrame)
     expr = batting_filt.join(awards_players_filt, "yearID")
     df = expr.execute()
@@ -205,10 +205,10 @@ def test_join_with_pandas(batting, awards_players):
 
 
 def test_join_with_pandas_non_null_typed_columns(batting, awards_players):
-    batting_filt = batting[lambda t: t.yearID < 1900][["yearID"]]
-    awards_players_filt = awards_players[lambda t: t.yearID < 1900][
-        ["yearID"]
-    ].execute()
+    batting_filt = batting.filter(lambda t: t.yearID < 1900).select("yearID")
+    awards_players_filt = (
+        awards_players.filter(lambda t: t.yearID < 1900).select("yearID").execute()
+    )
 
     # ensure that none of the columns of either table have type null
     batting_schema = batting_filt.schema()

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -88,7 +88,7 @@ def test_cte_refs_in_topo_order(backend, snapshot):
 @pytest.mark.never(["pandas", "dask", "polars"], reason="not SQL", raises=ValueError)
 def test_isin_bug(con, snapshot):
     t = ibis.table(dict(x="int"), name="t")
-    good = t[t.x > 2].x
+    good = t.filter(t.x > 2).x
     expr = t.x.isin(good)
     snapshot.assert_match(str(ibis.to_sql(expr, dialect=con.name)), "out.sql")
 

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -120,7 +120,7 @@ def test_collect_into_struct(alltypes):
 
     t = alltypes
     expr = (
-        t[_.string_col.isin(("0", "1"))]
+        t.filter(_.string_col.isin(("0", "1")))
         .group_by(group="string_col")
         .agg(
             val=lambda t: ibis.struct(

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1037,7 +1037,7 @@ def test_interval_add_cast_scalar(backend, alltypes):
 def test_interval_add_cast_column(backend, alltypes, df):
     timestamp_date = alltypes.timestamp_col.date()
     delta = alltypes.bigint_col.cast("interval('D')")
-    expr = alltypes["id", (timestamp_date + delta).name("tmp")]
+    expr = alltypes.select("id", (timestamp_date + delta).name("tmp"))
     result = expr.execute().sort_values("id").reset_index().tmp
     df = df.sort_values("id").reset_index(drop=True)
     expected = (
@@ -1702,7 +1702,7 @@ def test_interval_literal(con, backend):
 def test_date_column_from_ymd(backend, con, alltypes, df):
     c = alltypes.timestamp_col
     expr = ibis.date(c.year(), c.month(), c.day())
-    tbl = alltypes[expr.name("timestamp_col")]
+    tbl = alltypes.select(expr.name("timestamp_col"))
     result = con.execute(tbl)
 
     golden = df.timestamp_col.dt.date.astype(result.timestamp_col.dtype)
@@ -1719,7 +1719,7 @@ def test_timestamp_column_from_ymdhms(backend, con, alltypes, df):
     expr = ibis.timestamp(
         c.year(), c.month(), c.day(), c.hour(), c.minute(), c.second()
     )
-    tbl = alltypes[expr.name("timestamp_col")]
+    tbl = alltypes.select(expr.name("timestamp_col"))
     result = con.execute(tbl)
 
     golden = df.timestamp_col.dt.floor("s").astype(result.timestamp_col.dtype)

--- a/ibis/backends/tests/test_vectorized_udf.py
+++ b/ibis/backends/tests/test_vectorized_udf.py
@@ -339,7 +339,7 @@ def test_reduction_udf_array_return_type(udf_backend, udf_alltypes, udf_df):
 def test_reduction_udf_on_empty_data(udf_backend, udf_alltypes):
     """Test that summarization can handle empty data."""
     # First filter down to zero rows
-    t = udf_alltypes[udf_alltypes["int_col"] > np.inf]
+    t = udf_alltypes.filter(udf_alltypes["int_col"] > np.inf)
     result = t.group_by("year").aggregate(mean=calc_mean(t["int_col"])).execute()
     expected = pd.DataFrame({"year": [], "mean": []})
     # We check that the result is an empty DataFrame,

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -610,7 +610,7 @@ def test_grouped_unbounded_window(
 def test_simple_ungrouped_unbound_following_window(
     backend, alltypes, ibis_method, pandas_fn
 ):
-    t = alltypes[alltypes.double_col < 50].order_by("id")
+    t = alltypes.filter(alltypes.double_col < 50).order_by("id")
     df = t.execute()
 
     w = ibis.window(rows=(0, None), order_by=t.id)
@@ -635,7 +635,7 @@ def test_simple_ungrouped_unbound_following_window(
     reason="Feature is not yet implemented: Window function with empty PARTITION BY is not supported yet",
 )
 def test_simple_ungrouped_window_with_scalar_order_by(alltypes):
-    t = alltypes[alltypes.double_col < 50].order_by("id")
+    t = alltypes.filter(alltypes.double_col < 50).order_by("id")
     w = ibis.window(rows=(0, None), order_by=ibis.null())
     expr = t.double_col.sum().over(w).name("double_col")
     # hard to reproduce this in pandas, so just test that it actually executes

--- a/ibis/backends/tests/tpc/ds/test_queries.py
+++ b/ibis/backends/tests/tpc/ds/test_queries.py
@@ -3480,11 +3480,12 @@ def test_66(web_sales, catalog_sales, warehouse, date_dim, time_dim, ship_mode):
             )
             .join(date_dim, sales[f"{ns}_sold_date_sk"] == date_dim.d_date_sk)
             .join(time_dim, sales[f"{ns}_sold_time_sk"] == time_dim.t_time_sk)
-            .join(ship_mode, sales[f"{ns}_ship_mode_sk"] == ship_mode.sm_ship_mode_sk)[
-                (_.d_year == 2001)
-                & (_.t_time.between(30838, 30838 + 28800))
-                & (_.sm_carrier.isin(["DHL", "BARIAN"]))
-            ]
+            .join(ship_mode, sales[f"{ns}_ship_mode_sk"] == ship_mode.sm_ship_mode_sk)
+            .filter(
+                (_.d_year == 2001),
+                (_.t_time.between(30838, 30838 + 28800)),
+                (_.sm_carrier.isin(["DHL", "BARIAN"])),
+            )
             .group_by(
                 "w_warehouse_name",
                 "w_warehouse_sq_ft",

--- a/ibis/backends/tests/tpc/h/test_queries.py
+++ b/ibis/backends/tests/tpc/h/test_queries.py
@@ -66,9 +66,9 @@ def test_02(part, supplier, partsupp, nation, region):
         .join(region, nation.n_regionkey == region.r_regionkey)
     )
 
-    subexpr = subexpr[
+    subexpr = subexpr.filter(
         (subexpr.r_name == REGION) & (expr.p_partkey == subexpr.ps_partkey)
-    ]
+    )
 
     filters = [
         expr.p_size == SIZE,
@@ -210,7 +210,7 @@ def test_07(supplier, lineitem, orders, customer, nation):
     q = q.join(n1, supplier.s_nationkey == n1.n_nationkey)
     q = q.join(n2, customer.c_nationkey == n2.n_nationkey)
 
-    q = q[
+    q = q.select(
         n1.n_name.name("supp_nation"),
         n2.n_name.name("cust_nation"),
         lineitem.l_shipdate,
@@ -218,7 +218,7 @@ def test_07(supplier, lineitem, orders, customer, nation):
         lineitem.l_discount,
         lineitem.l_shipdate.year().name("l_year"),
         (lineitem.l_extendedprice * (1 - lineitem.l_discount)).name("volume"),
-    ]
+    )
 
     q = q.filter(
         [
@@ -255,14 +255,14 @@ def test_08(part, supplier, region, lineitem, orders, customer, nation):
     q = q.join(region, n1.n_regionkey == region.r_regionkey)
     q = q.join(n2, supplier.s_nationkey == n2.n_nationkey)
 
-    q = q[
+    q = q.select(
         orders.o_orderdate.year().name("o_year"),
         (lineitem.l_extendedprice * (1 - lineitem.l_discount)).name("volume"),
         n2.n_name.name("nation"),
         region.r_name,
         orders.o_orderdate,
         part.p_type,
-    ]
+    )
 
     q = q.filter(
         [
@@ -297,14 +297,14 @@ def test_09(part, supplier, lineitem, partsupp, orders, nation):
     q = q.join(orders, orders.o_orderkey == lineitem.l_orderkey)
     q = q.join(nation, supplier.s_nationkey == nation.n_nationkey)
 
-    q = q[
+    q = q.select(
         (q.l_extendedprice * (1 - q.l_discount) - q.ps_supplycost * q.l_quantity).name(
             "amount"
         ),
         q.o_orderdate.year().name("o_year"),
         q.n_name.name("nation"),
         q.p_name,
-    ]
+    )
 
     q = q.filter([q.p_name.like("%" + COLOR + "%")])
 
@@ -494,7 +494,7 @@ def test_15(lineitem, supplier):
 
     q = supplier.join(qrev, supplier.s_suppkey == qrev.l_suppkey)
     q = q.filter([q.total_revenue == qrev.total_revenue.max()])
-    q = q[q.s_suppkey, q.s_name, q.s_address, q.s_phone, q.total_revenue]
+    q = q.select(q.s_suppkey, q.s_name, q.s_address, q.s_phone, q.total_revenue)
     return q.order_by([q.s_suppkey])
 
 
@@ -679,7 +679,7 @@ def test_20(supplier, nation, partsupp, part, lineitem):
 
     q1 = q1.filter([q1.n_name == NATION, q1.s_suppkey.isin(q2.ps_suppkey)])
 
-    q1 = q1[q1.s_name, q1.s_address]
+    q1 = q1.select(q1.s_name, q1.s_address)
 
     return q1.order_by(q1.s_name)
 
@@ -704,7 +704,7 @@ def test_21(supplier, lineitem, orders, nation):
     q = q.join(lineitem, supplier.s_suppkey == lineitem.l_suppkey)
     q = q.join(orders, orders.o_orderkey == lineitem.l_orderkey)
     q = q.join(nation, supplier.s_nationkey == nation.n_nationkey)
-    q = q[
+    q = q.select(
         q.l_orderkey.name("l1_orderkey"),
         q.o_orderstatus,
         q.l_receiptdate,
@@ -712,7 +712,7 @@ def test_21(supplier, lineitem, orders, nation):
         q.l_suppkey.name("l1_suppkey"),
         q.s_name,
         q.n_name,
-    ]
+    )
     q = q.filter(
         [
             q.o_orderstatus == "F",
@@ -764,9 +764,9 @@ def test_22(customer, orders):
             ~(orders.o_custkey == customer.c_custkey).any(),
         ]
     )
-    custsale = custsale[
+    custsale = custsale.select(
         customer.c_phone.substr(0, 2).name("cntrycode"), customer.c_acctbal
-    ]
+    )
 
     gq = custsale.group_by(custsale.cntrycode)
     outerq = gq.aggregate(numcust=custsale.count(), totacctbal=custsale.c_acctbal.sum())

--- a/ibis/expr/tests/test_format.py
+++ b/ibis/expr/tests/test_format.py
@@ -89,7 +89,7 @@ def test_format_multiple_join_with_projection(snapshot):
 
     table3 = ibis.table([("bar_id", "string"), ("value2", "double")], "three")
 
-    filtered = table[table["f"] > 0]
+    filtered = table.filter(table["f"] > 0)
 
     pred1 = filtered["foo_id"] == table2["foo_id"]
     pred2 = filtered["bar_id"] == table3["bar_id"]
@@ -98,7 +98,7 @@ def test_format_multiple_join_with_projection(snapshot):
     j2 = j1.inner_join(table3, [pred2])
 
     # Project out the desired fields
-    view = j2[[filtered, table2["value1"], table3["value2"]]]
+    view = j2.select(filtered, table2["value1"], table3["value2"])
 
     # it works!
     result = repr(view)
@@ -112,7 +112,7 @@ def test_memoize_filtered_table(snapshot):
     )
 
     dests = ["ORD", "JFK", "SFO"]
-    t = airlines[airlines.dest.isin(dests)]
+    t = airlines.filter(airlines.dest.isin(dests))
     delay_filter = t.dest.topk(10, by=t.arrdelay.mean())
 
     result = repr(delay_filter)
@@ -149,11 +149,11 @@ def test_memoize_filtered_tables_in_join(snapshot):
     metric = purchases.amount.sum().name("total")
     agged = purchases.group_by(["region", "kind"]).aggregate(metric)
 
-    left = agged[agged.kind == "foo"]
-    right = agged[agged.kind == "bar"]
+    left = agged.filter(agged.kind == "foo")
+    right = agged.filter(agged.kind == "bar")
 
     cond = left.region == right.region
-    joined = left.join(right, cond)[left, right.total.name("right_total")]
+    joined = left.join(right, cond).select(left, right.total.name("right_total"))
 
     result = repr(joined)
     snapshot.assert_match(result, "repr.txt")
@@ -179,7 +179,7 @@ def test_scalar_parameter_formatting():
 
 def test_same_column_multiple_aliases(snapshot):
     table = ibis.table([("col", "int64")], name="t")
-    expr = table[table.col.name("fakealias1"), table.col.name("fakealias2")]
+    expr = table.select(table.col.name("fakealias1"), table.col.name("fakealias2"))
     result = repr(expr)
 
     assert "UnboundTable: t" in result
@@ -412,7 +412,7 @@ def test_format_new_relational_operation(alltypes, snapshot):
             return {}
 
     table = MyRelation(alltypes, kind="foo").to_expr()
-    expr = table[table, table.a.name("a2")]
+    expr = table.select(table, table.a.name("a2"))
     result = repr(expr)
 
     snapshot.assert_match(result, "repr.txt")
@@ -441,7 +441,7 @@ def test_format_new_value_operation(alltypes, snapshot):
 def test_format_show_variables(monkeypatch, alltypes, snapshot):
     monkeypatch.setattr(ibis.options.repr, "show_variables", True)
 
-    filtered = alltypes[alltypes.f > 0]
+    filtered = alltypes.filter(alltypes.f > 0)
     ordered = filtered.order_by("f")
     projected = ordered[["a", "b", "f"]]
 

--- a/ibis/expr/tests/test_visualize.py
+++ b/ibis/expr/tests/test_visualize.py
@@ -30,8 +30,8 @@ def key(node):
         lambda t: t.a,
         lambda t: t.a + t.b,
         lambda t: t.a + t.b > 3**t.a,
-        lambda t: t[(t.a + t.b * 2 * t.b / t.b**3 > 4) & (t.b > 5)],
-        lambda t: t[(t.a + t.b * 2 * t.b / t.b**3 > 4) & (t.b > 5)]
+        lambda t: t.filter((t.a + t.b * 2 * t.b / t.b**3 > 4) & (t.b > 5)),
+        lambda t: t.filter((t.a + t.b * 2 * t.b / t.b**3 > 4) & (t.b > 5))
         .group_by("c")
         .aggregate(amean=lambda f: f.a.mean(), bsum=lambda f: f.b.sum()),
     ],
@@ -86,7 +86,7 @@ def test_join(how):
     left = ibis.table([("a", "int64"), ("b", "string")])
     right = ibis.table([("b", "string"), ("c", "int64")])
     joined = left.join(right, left.b == right.b, how=how)
-    result = joined[left.a, right.c]
+    result = joined.select(left.a, right.c)
     graph = viz.to_graph(result)
     assert key(result.op()) in graph.source
 
@@ -134,7 +134,7 @@ def test_asof_join():
     right = right.mutate(foo=1)
 
     joined = api.asof_join(left, right, "time")
-    result = joined[left, right.foo]
+    result = joined.select(left, right.foo)
     graph = viz.to_graph(result)
     assert key(result.op()) in graph.source
 

--- a/ibis/tests/benchmarks/test_benchmarks.py
+++ b/ibis/tests/benchmarks/test_benchmarks.py
@@ -53,7 +53,7 @@ def t():
 
 
 def make_base(t):
-    return t[
+    return t.filter(
         (
             (t.year > 2016)
             | ((t.year == 2016) & (t.month > 6))
@@ -80,7 +80,7 @@ def make_base(t):
                 & (t.minute <= 5)
             )
         )
-    ]
+    )
 
 
 @pytest.fixture(scope="module")
@@ -394,9 +394,9 @@ def tpc_h02(part, supplier, partsupp, nation, region):
         .join(region, nation.n_regionkey == region.r_regionkey)
     )
 
-    subexpr = subexpr[
+    subexpr = subexpr.filter(
         (subexpr.r_name == REGION) & (expr.p_partkey == subexpr.ps_partkey)
-    ]
+    )
 
     filters = [
         expr.p_size == SIZE,
@@ -529,7 +529,7 @@ def test_eq_datatypes(benchmark, dtypes):
 def multiple_joins(table, num_joins):
     for _ in range(num_joins):
         table = table.mutate(dummy=ibis.literal(""))
-        table = table.left_join(table.view(), ["dummy"])[[table]]
+        table = table.left_join(table.view(), ["dummy"]).select(table)
 
 
 @pytest.mark.parametrize("num_joins", [1, 10])

--- a/ibis/tests/expr/test_analysis.py
+++ b/ibis/tests/expr/test_analysis.py
@@ -17,7 +17,7 @@ def test_rewrite_join_projection_without_other_ops(con):
     table2 = con.table("star2")
     table3 = con.table("star3")
 
-    filtered = table[table["f"] > 0]
+    filtered = table.filter(table["f"] > 0)
 
     pred1 = table["foo_id"] == table2["foo_id"]
     pred2 = filtered["bar_id"] == table3["bar_id"]
@@ -25,7 +25,7 @@ def test_rewrite_join_projection_without_other_ops(con):
     j1 = filtered.left_join(table2, [pred1])
     j2 = j1.inner_join(table3, [pred2])
     # Project out the desired fields
-    view = j2[[filtered, table2["value1"], table3["value2"]]]
+    view = j2.select(filtered, table2["value1"], table3["value2"])
 
     with join_tables(j2) as (r1, r2, r3):
         # Construct the thing we expect to obtain
@@ -90,11 +90,11 @@ def test_filter_on_projected_field(con):
         .join(orders, orders.o_custkey == customer.c_custkey)
     )
 
-    tpch = all_join[fields_of_interest]
+    tpch = all_join.select(*fields_of_interest)
 
     # Correlated subquery, yikes!
     t2 = tpch.view()
-    conditional_avg = t2[(t2.region == tpch.region)].amount.mean()
+    conditional_avg = t2.filter(t2.region == tpch.region).amount.mean()
 
     # `amount` is part of the projection above as an aliased field
     amount_filter = tpch.amount > conditional_avg
@@ -116,7 +116,7 @@ def test_join_predicate_from_derived_raises():
     table2 = ibis.table([("key", "string"), ("value", "double")], "bar_table")
 
     filter_pred = table["f"] > 0
-    table3 = table[filter_pred]
+    table3 = table.filter(filter_pred)
 
     with pytest.raises(com.IntegrityError, match="they belong to another relation"):
         # TODO(kszucs): could be smarter actually and rewrite the predicate
@@ -153,8 +153,8 @@ def test_filter_self_join():
         metrics={"total": purchases.amount.sum()},
     )
 
-    left = agged[agged.kind == "foo"]
-    right = agged[agged.kind == "bar"]
+    left = agged.filter(agged.kind == "foo")
+    right = agged.filter(agged.kind == "bar")
     assert left.op() == ops.Filter(
         parent=agged,
         predicates=[agged.kind == "foo"],
@@ -186,11 +186,13 @@ def test_filter_self_join():
 
 def test_is_ancestor_analytic():
     x = ibis.table(ibis.schema([("col", "int32")]), "x")
-    with_filter_col = x[x.columns + [ibis.null().name("filter")]]
-    filtered = with_filter_col[with_filter_col["filter"].isnull()]
-    subquery = filtered[filtered.columns]
+    with_filter_col = x.select(x.columns + [ibis.null().name("filter")])
+    filtered = with_filter_col.filter(with_filter_col["filter"].isnull())
+    subquery = filtered.select(filtered.columns)
 
-    with_analytic = subquery[subquery.columns + [subquery.count().name("analytic")]]
+    with_analytic = subquery.select(
+        subquery.columns + [subquery.count().name("analytic")]
+    )
 
     assert not subquery.op().equals(with_analytic.op())
 
@@ -252,10 +254,10 @@ def test_select_filter_mutate_fusion():
 
     t = ibis.table(ibis.schema([("col", "float32")]), "t")
 
-    t1 = t[["col"]]
+    t1 = t.select("col")
     assert t1.op() == ops.Project(parent=t, values={"col": t.col})
 
-    t2 = t1[t1["col"].isnan()]
+    t2 = t1.filter(t1["col"].isnan())
     assert t2.op() == ops.Filter(parent=t1, predicates=[t1.col.isnan()])
 
     t3 = t2.mutate(col=t2["col"].cast("int32"))

--- a/ibis/tests/expr/test_analytics.py
+++ b/ibis/tests/expr/test_analytics.py
@@ -44,7 +44,7 @@ def test_category_project(alltypes):
     t = alltypes
 
     tier = t.double_col.bucket([0, 50, 100]).name("tier")
-    expr = t[tier, t]
+    expr = t.select(tier, t)
 
     assert isinstance(expr.tier, ir.IntegerColumn)
 
@@ -99,7 +99,7 @@ def test_histogram(alltypes):
 def test_topk_analysis_bug(airlines):
     # GH #398
     dests = ["ORD", "JFK", "SFO"]
-    t = airlines[airlines.dest.isin(dests)]
+    t = airlines.filter(airlines.dest.isin(dests))
     filtered = t.semi_join(t.origin.topk(10, by=t.arrdelay.mean()), "origin")
     assert filtered is not None
 

--- a/ibis/tests/expr/test_case.py
+++ b/ibis/tests/expr/test_case.py
@@ -211,7 +211,7 @@ def test_case_mixed_type():
     expr = (
         t0.three.case().when(0, "low").when(1, "high").else_("null").end().name("label")
     )
-    result = t0[expr]
+    result = t0.select(expr)
     assert result["label"].type().equals(dt.string)
 
 

--- a/ibis/tests/expr/test_format_sql_operations.py
+++ b/ibis/tests/expr/test_format_sql_operations.py
@@ -31,7 +31,7 @@ def test_memoize_database_table(con, snapshot):
     table2 = con.table("test2")
 
     filter_pred = table["f"] > 0
-    table3 = table[filter_pred]
+    table3 = table.filter(filter_pred)
     join_pred = table3["g"] == table2["key"]
 
     joined = table2.inner_join(table3, [join_pred])
@@ -56,7 +56,7 @@ def test_memoize_insert_sort_key(con, snapshot):
         dest_avg=t.arrdelay.mean(), dev=t.arrdelay - t.arrdelay.mean()
     )
 
-    worst = expr[expr.dev.notnull()].order_by(ibis.desc("dev")).limit(10)
+    worst = expr.filter(expr.dev.notnull()).order_by(ibis.desc("dev")).limit(10)
 
     result = repr(worst)
     assert result.count("airlines") == 1

--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -62,11 +62,11 @@ def test_struct_pickle():
 
 
 def test_lift(t):
-    assert t.a.lift().equals(t[_.a.b, _.a.c])
+    assert t.a.lift().equals(t.select(_.a.b, _.a.c))
 
 
 def test_unpack_from_table(t):
-    assert t.unpack("a").equals(t[_.a.b, _.a.c, _.d])
+    assert t.unpack("a").equals(t.select(_.a.b, _.a.c, _.d))
 
 
 def test_lift_join(t, s):
@@ -86,7 +86,7 @@ def test_lift_join(t, s):
 def test_unpack_join_from_table(t, s):
     join = t.join(s, t.d == s.a.g)
     result = join.unpack("a_right")
-    expected = join[_.a, _.d, _.a_right.f, _.a_right.g]
+    expected = join.select(_.a, _.d, _.a_right.f, _.a_right.g)
     assert result.equals(expected)
 
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -97,7 +97,7 @@ def test_getitem_column_select(table):
 
 
 def test_select_using_selector(table):
-    expr = table[s.numeric()]
+    expr = table.select(s.numeric())
     expected = table.select(
         table.a,
         table.b,
@@ -124,9 +124,8 @@ def test_getitem_attribute(table):
     result = table.a
     assert_equal(result, table["a"])
 
-    # Project and add a name that conflicts with a Table built-in
-    # attribute
-    view = table[[table, table["a"].name("schema")]]
+    # Project and add a name that conflicts with a Table built-in attribute
+    view = table.mutate(schema=table.a)
     assert not isinstance(view.schema, Column)
 
 
@@ -176,7 +175,7 @@ def test_projection_with_exprs(table):
 
     col_exprs = [table["b"].log().name("log_b"), mean_diff.name("mean_diff")]
 
-    proj = table[col_exprs + ["g"]]
+    proj = table.select(col_exprs + ["g"])
     schema = proj.schema()
     assert schema.names == ("log_b", "mean_diff", "g")
     assert schema.types == (dt.double, dt.double, dt.string)
@@ -219,7 +218,7 @@ def test_projection_with_star_expr(table):
     t = table
 
     # it lives!
-    proj = t[t, new_expr]
+    proj = t.select(t, new_expr)
     repr(proj)
 
     ex_names = table.schema().names + ("bigger_a",)
@@ -228,14 +227,35 @@ def test_projection_with_star_expr(table):
     # cannot pass an invalid table expression
     t2 = t.aggregate([t["a"].sum().name("sum(a)")], by=["g"])
     with pytest.raises(IntegrityError):
-        t[[t2]]
+        t.select(t2)
     # TODO: there may be some ways this can be invalid
 
 
-def test_projection_convenient_syntax(table):
-    proj = table[table, table["a"].name("foo")]
-    proj2 = table[[table, table["a"].name("foo")]]
-    assert_equal(proj, proj2)
+def test_deprecated_getitem_select_filter(table):
+    # Select
+    sol1 = table.select(table, table.a.name("foo"))
+    with pytest.warns(FutureWarning):
+        e1 = table[table, table["a"].name("foo")]
+        e2 = table[[table, table["a"].name("foo")]]
+
+    assert_equal(e1, sol1)
+    assert_equal(e2, sol1)
+
+    # Select with selector
+    sol2 = table.select(s.numeric())
+    with pytest.warns(FutureWarning):
+        e3 = table[s.numeric()]
+
+    assert_equal(e3, sol2)
+
+    # Filter
+    sol3 = table.filter(table.a > 10, table.a < 20)
+    with pytest.warns(FutureWarning):
+        e4 = table[table.a > 10, table.a < 20]
+        e5 = table[[table.a > 10, table.a < 20]]
+
+    assert_equal(e4, sol3)
+    assert_equal(e5, sol3)
 
 
 def test_projection_mutate_analysis_bug(con):
@@ -243,25 +263,12 @@ def test_projection_mutate_analysis_bug(con):
 
     t = con.table("airlines")
 
-    filtered = t[t.depdelay.notnull()]
+    filtered = t.filter(t.depdelay.notnull())
     leg = ibis.literal("-").join([t.origin, t.dest])
     mutated = filtered.mutate(leg=leg)
 
     # it works!
     mutated["year", "month", "day", "depdelay", "leg"]
-
-
-def test_projection_self(table):
-    result = table[table]
-    expected = table.select(table)
-
-    assert_equal(result, expected)
-
-
-def test_projection_array_expr(table):
-    result = table[table.a]
-    expected = table[[table.a]]
-    assert_equal(result, expected)
 
 
 @pytest.mark.parametrize("empty", [list(), dict()])
@@ -299,7 +306,7 @@ def test_mutate(table):
         kw5=ibis.literal(9),
         kw6=ibis.literal("ten"),
     )
-    expected = table[
+    expected = table.select(
         table,
         (table.a + 1).name("x1"),
         table.b.sum().name("x2"),
@@ -313,7 +320,7 @@ def test_mutate(table):
         (table.a + 8).name("kw4"),
         ibis.literal(9).name("kw5"),
         ibis.literal("ten").name("kw6"),
-    ]
+    )
     assert_equal(expr, expected)
 
 
@@ -322,7 +329,7 @@ def test_mutate_alter_existing_columns(table):
     foo = table.d * 2
     expr = table.mutate(f=new_f, foo=foo)
 
-    expected = table[
+    expected = table.select(
         "a",
         "b",
         "c",
@@ -335,7 +342,7 @@ def test_mutate_alter_existing_columns(table):
         "j",
         "k",
         foo.name("foo"),
-    ]
+    )
 
     assert_equal(expr, expected)
 
@@ -345,23 +352,9 @@ def test_replace_column():
 
     expr = tb.b.cast("int32")
     tb2 = tb.mutate(b=expr)
-    expected = tb[tb.a, expr.name("b"), tb.c]
+    expected = tb.select(tb.a, expr.name("b"), tb.c)
 
     assert_equal(tb2, expected)
-
-
-def test_filter_no_list(table):
-    pred = table.a > 5
-
-    result = table.filter(pred)
-    expected = table[pred]
-    assert_equal(result, expected)
-
-
-def test_add_predicate(table):
-    pred = table["a"] > 5
-    result = table[pred]
-    assert isinstance(result.op(), ops.Filter)
 
 
 def test_invalid_predicate(table, schema):
@@ -379,12 +372,12 @@ def test_add_predicate_coalesce(table):
     pred1 = table["a"] > 5
     pred2 = table["b"] > 0
 
-    result = simplify(table[pred1][pred2].op()).to_expr()
+    result = simplify(table.filter(pred1).filter(pred2).op()).to_expr()
     expected = table.filter([pred1, pred2])
     assert_equal(result, expected)
 
     # 59, if we are not careful, we can obtain broken refs
-    subset = table[pred1]
+    subset = table.filter(pred1)
     result = simplify(subset.filter([subset["b"] > 0]).op()).to_expr()
     assert_equal(result, expected)
 
@@ -392,7 +385,7 @@ def test_add_predicate_coalesce(table):
 def test_repr_same_but_distinct_objects(con):
     t = con.table("test1")
     t_copy = con.table("test1")
-    table2 = t[t_copy["f"] > 0]
+    table2 = t.filter(t_copy["f"] > 0)
 
     result = repr(table2)
     assert result.count("DatabaseTable") == 1
@@ -402,10 +395,10 @@ def test_filter_fusion_distinct_table_objects(con):
     t = con.table("test1")
     tt = con.table("test1")
 
-    expr = t[t.f > 0][t.c > 0]
-    expr2 = t[t.f > 0][tt.c > 0]
-    expr3 = t[tt.f > 0][tt.c > 0]
-    expr4 = t[tt.f > 0][t.c > 0]
+    expr = t.filter(t.f > 0).filter(t.c > 0)
+    expr2 = t.filter(t.f > 0).filter(tt.c > 0)
+    expr3 = t.filter(tt.f > 0).filter(tt.c > 0)
+    expr4 = t.filter(tt.f > 0).filter(t.c > 0)
 
     assert_equal(expr, expr2)
     assert repr(expr) == repr(expr2)
@@ -1095,18 +1088,6 @@ def test_join_combo_with_projection(table):
     repr(proj)
 
 
-def test_join_getitem_projection(con):
-    region = con.table("tpch_region")
-    nation = con.table("tpch_nation")
-
-    pred = region.r_regionkey == nation.n_regionkey
-    joined = region.inner_join(nation, pred)
-
-    result = joined[nation]
-    expected = joined.select(nation)
-    assert_equal(result, expected)
-
-
 def test_self_join(table):
     # Self-joins are problematic with this design because column
     # expressions may reference either the left or right  For example:
@@ -1127,7 +1108,7 @@ def test_self_join(table):
     joined = left.inner_join(right, [right["g"] == left["g"]])
 
     # Project out left table schema
-    proj = joined[[left]]
+    proj = joined.select(left)
     assert_equal(proj.schema(), left.schema())
 
     # Try aggregating on top of joined
@@ -1146,18 +1127,6 @@ def test_self_join_no_view_convenience(table):
     # equivalent columns from the right table is not implemented yet
     expected_cols.extend(f"{c}_right" for c in table.columns if c != "g")
     assert result.columns == expected_cols
-
-
-def test_join_reference_bug(con):
-    # GH#403
-    orders = con.table("tpch_orders")
-    customer = con.table("tpch_customer")
-    lineitem = con.table("tpch_lineitem")
-
-    items = orders.join(lineitem, orders.o_orderkey == lineitem.l_orderkey)[
-        lineitem, orders.o_custkey, orders.o_orderpriority
-    ].join(customer, [("o_custkey", "c_custkey")])
-    items["o_orderpriority"].value_counts()
 
 
 def test_join_project_after(table):
@@ -1494,21 +1463,12 @@ def test_unresolved_existence_predicate(t1, t2):
     filtered = t2.filter(t1.key1 == t2.key1)
     subquery = ops.ExistsSubquery(filtered)
     expected = ops.Filter(parent=t1, predicates=[subquery])
-    assert t1[expr].op() == expected
+    assert t1.filter(expr).op() == expected
 
     filtered = t1.filter(t1.key1 == t2.key1)
     subquery = ops.ExistsSubquery(filtered)
     expected = ops.Filter(parent=t2, predicates=[subquery])
-    assert t2[expr].op() == expected
-
-
-def test_resolve_existence_predicate(t1, t2):
-    expr = t1[(t1.key1 == t2.key1).any()]
-    op = expr.op()
-    assert isinstance(op, ops.Filter)
-
-    pred = op.predicates[0].to_expr()
-    assert isinstance(pred.op(), ops.ExistsSubquery)
+    assert t2.filter(expr).op() == expected
 
 
 def test_aggregate_metrics(table):
@@ -1564,11 +1524,8 @@ def test_filter(table):
     m = table.mutate(foo=table.f * 2, bar=table.e / 2)
 
     result = m.filter(lambda x: x.foo > 10)
-    result2 = m[lambda x: x.foo > 10]
-    expected = m[m.foo > 10]
-
+    expected = m.filter(m.foo > 10)
     assert_equal(result, expected)
-    assert_equal(result2, expected)
 
     result = m.filter([lambda x: x.foo > 10, lambda x: x.bar < 0])
     expected = m.filter([m.foo > 10, m.bar < 0])
@@ -1602,10 +1559,8 @@ def test_projection2(table):
         return (x.foo * 2).name("bar")
 
     result = m.select([f, "f"])
-    result2 = m[f, "f"]
     expected = m.select([f(m), "f"])
     assert_equal(result, expected)
-    assert_equal(result2, expected)
 
 
 def test_mutate2(table):
@@ -1774,20 +1729,14 @@ def test_merge_as_of_allows_overlapping_columns():
         name="t",
     )
 
-    signal_one = table[
+    signal_one = table.filter(
         table["field"].contains("signal_one") & table["field"].contains("current")
-    ]
-    signal_one = signal_one[
-        "value", "timestamp_received", "field"
-    ]  # select columns we care about
+    )["value", "timestamp_received", "field"]
     signal_one = signal_one.rename(current="value", signal_one="field")
 
-    signal_two = table[
+    signal_two = table.filter(
         table["field"].contains("signal_two") & table["field"].contains("voltage")
-    ]
-    signal_two = signal_two[
-        "value", "timestamp_received", "field"
-    ]  # select columns we care about
+    )["value", "timestamp_received", "field"]
     signal_two = signal_two.rename(voltage="value", signal_two="field")
 
     merged = signal_one.asof_join(signal_two, "timestamp_received")
@@ -1806,7 +1755,7 @@ def test_select_from_unambiguous_join_with_strings():
     t = ibis.table([("a", "int64"), ("b", "string")])
     s = ibis.table([("b", "int64"), ("c", "string")])
     joined = t.left_join(s, [t.b == s.c])
-    expr = joined[t, "c"]
+    expr = joined.select(t, "c")
     assert expr.columns == ["a", "b", "c"]
 
 
@@ -1911,12 +1860,6 @@ def test_default_backend_with_unbound_table():
         match="Expression contains unbound tables",
     ):
         assert expr.execute()
-
-
-def test_array_string_compare():
-    t = ibis.table(schema=dict(by="string", words="array<string>"), name="t")
-    expr = t[t.by == "foo"].mutate(words=_.words.unnest()).filter(_.words == "the")
-    assert expr is not None
 
 
 @pytest.mark.parametrize("value", [True, False])

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -291,7 +291,7 @@ def test_isin_notin_list(table, container):
 
 def test_value_counts(table, string_col):
     bool_clause = table[string_col].notin(["1", "4", "7"])
-    expr = table[bool_clause][string_col].value_counts()
+    expr = table.filter(bool_clause)[string_col].value_counts()
     assert isinstance(expr, ir.Table)
 
 
@@ -1362,7 +1362,7 @@ def test_select_on_unambiguous_join(join_method):
 def test_chained_select_on_join():
     t = ibis.table([("a", dt.int64)], name="t")
     s = ibis.table([("a", dt.int64), ("b", dt.string)], name="s")
-    join = t.join(s)[t.a, s.b]
+    join = t.join(s).select(t.a, s.b)
     expr1 = join["a", "b"]
     expr2 = join.select(["a", "b"])
     assert expr1.equals(expr2)
@@ -1376,7 +1376,7 @@ def test_repr_list_of_lists():
 def test_repr_list_of_lists_in_table():
     t = ibis.table([("a", "int64")], name="t")
     lit = ibis.literal([[1]])
-    expr = t[t, lit.name("array_of_array")]
+    expr = t.select(t, lit.name("array_of_array"))
     repr(expr)
 
 
@@ -1504,7 +1504,7 @@ def test_deferred_r_ops(op_name, expected_left, expected_right):
     right = _.a
 
     op = getattr(operator, op_name)
-    expr = t[op(left, right).name("b")]
+    expr = t.select(op(left, right).name("b"))
     node = expr.op().values["b"]
     assert node.left.equals(expected_left(t).op())
     assert node.right.equals(expected_right(t).op())
@@ -1675,7 +1675,7 @@ def test_rowid_only_physical_tables():
     table = ibis.table({"x": "int", "y": "string"}, name="t")
 
     table.rowid()  # works
-    table[table.rowid(), table.x].filter(_.x > 10)  # works
+    table.select(table.rowid(), table.x).filter(_.x > 10)  # works
     with pytest.raises(com.IbisTypeError, match="only valid for physical tables"):
         table.filter(table.x > 0).rowid()
 

--- a/ibis/tests/expr/test_window_frames.py
+++ b/ibis/tests/expr/test_window_frames.py
@@ -511,7 +511,9 @@ def test_window_analysis_auto_windowize_bug():
         return x.arrdelay.mean().name("avg_delay")
 
     annual_delay = (
-        t[t.dest.isin(["JFK", "SFO"])].group_by(["dest", "year"]).aggregate(metric)
+        t.filter(t.dest.isin(["JFK", "SFO"]))
+        .group_by(["dest", "year"])
+        .aggregate(metric)
     )
     what = annual_delay.group_by("dest")
     enriched = what.mutate(grand_avg=annual_delay.avg_delay.mean())
@@ -521,7 +523,7 @@ def test_window_analysis_auto_windowize_bug():
         .name("grand_avg")
         .over(ibis.window(group_by=annual_delay.dest))
     )
-    expected = annual_delay[annual_delay, expr]
+    expected = annual_delay.select(annual_delay, expr)
 
     assert enriched.equals(expected)
 


### PR DESCRIPTION
This PR deprecates filtering and expression projection in `Table.__getitem__`. See the relevant issue (#10045) for reasoning.

Currently the warning says we'll remove in 10.0 - if we think that's too short a deprecation period I'm happy to bump to 11.0.

The magic syntax is _old_ and was used in quite a few places in the test suite and docs. I _think_ I got most of them, but won't be surprised if this PR fails CI initially due to a few lingering references.

Fixes #10045.