### PR TITLE
feat(api): add `name` argument to `topk`/`value_counts`

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2002,17 +2002,52 @@ class Column(Value, _FixedTextJupyterMixin):
     def topk(self, k: int, by: ir.Value | None = None) -> ir.Table:
         """Return a "top k" expression.
 
+        Computes a Table containing the top `k` values by a certain metric
+        (defaults to count).
+
         Parameters
         ----------
         k
-            Return this number of rows
+            The number of rows to return.
         by
-            An expression. Defaults to `count`.
+            The metric to compute "top" by. Defaults to `count`.
 
         Returns
         -------
         Table
-            A top-k expression
+            The top `k` values.
+
+        Examples
+        --------
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.examples.diamonds.fetch()
+
+        Compute the top 3 diamond colors by frequency:
+
+        >>> t.color.topk(3)
+        ┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ color  ┃ CountStar(diamonds) ┃
+        ┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
+        │ string │ int64               │
+        ├────────┼─────────────────────┤
+        │ G      │               11292 │
+        │ E      │                9797 │
+        │ F      │                9542 │
+        └────────┴─────────────────────┘
+
+        Compute the top 3 diamond colors by mean price:
+
+        >>> t.color.topk(3, by=t.price.mean())
+        ┏━━━━━━━━┳━━━━━━━━━━━━━┓
+        ┃ color  ┃ Mean(price) ┃
+        ┡━━━━━━━━╇━━━━━━━━━━━━━┩
+        │ string │ float64     │
+        ├────────┼─────────────┤
+        │ J      │ 5323.818020 │
+        │ I      │ 5091.874954 │
+        │ H      │ 4486.669196 │
+        └────────┴─────────────┘
         """
         from ibis.expr.types.relations import bind
 

--- a/ibis/tests/expr/test_analytics.py
+++ b/ibis/tests/expr/test_analytics.py
@@ -17,6 +17,7 @@ import pytest
 
 import ibis
 import ibis.expr.types as ir
+from ibis import _
 from ibis.common.annotations import ValidationError
 from ibis.tests.expr.mocks import MockBackend
 from ibis.tests.util import assert_equal
@@ -110,3 +111,15 @@ def test_topk_function_late_bind(airlines):
     expr2 = airlines.dest.topk(5, by=airlines.arrdelay.mean())
 
     assert_equal(expr1, expr2)
+
+
+def test_topk_name(airlines):
+    expr1 = airlines.dest.topk(5, name="mycol")
+    expr2 = airlines.dest.topk(5, by=_.count().name("mycol"))
+    assert expr1.columns == ["dest", "mycol"]
+    assert_equal(expr1, expr2)
+
+    expr3 = airlines.dest.topk(5, by=_.arrdelay.mean(), name="mycol")
+    expr4 = airlines.dest.topk(5, by=_.arrdelay.mean().name("mycol"))
+    assert expr3.columns == ["dest", "mycol"]
+    assert_equal(expr3, expr4)

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -289,12 +289,6 @@ def test_isin_notin_list(table, container):
     assert isinstance(not_expr.op().arg, ops.InValues)
 
 
-def test_value_counts(table, string_col):
-    bool_clause = table[string_col].notin(["1", "4", "7"])
-    expr = table.filter(bool_clause)[string_col].value_counts()
-    assert isinstance(expr, ir.Table)
-
-
 def test_isin_notin_scalars():
     a, b, c = (ibis.literal(x) for x in [1, 1, 2])
 


### PR DESCRIPTION
This adds a new `name` argument to `topk` & `value_counts`. Fixes #9948.

I think adding a `name` arg to these helpers makes sense. For other builtin aggregate methods you can chain a `.name("myname")` call on the end, but in these cases the return type is a `Table`. Adding an option to specify the name of the new column is nice for ux.

I opted to go for a simple `name: str | None` version, rather than supporting format strings/callables like `rename`. If a user wants to programmatically generate the name then they can do so themselves outside of this method. Keep it simple.

One open question is whether this argument should be keyword only. I went with positional or keyword for now, no strong thoughts.

Also added a docstring example for `topk` while I was at it.