### PR TITLE
fix(examples): use memtables for examples to allow backends that do not support temporary tables to support examples

### DIFF
--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 import datafusion as df
 import pyarrow as pa
+import pyarrow.dataset as ds
 import pyarrow_hotfix  # noqa: F401
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -372,7 +373,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
             self.con.deregister_table(table_name)
             self.con.register_record_batches(table_name, [[source]])
             return self.table(table_name)
-        elif isinstance(source, pa.dataset.Dataset):
+        elif isinstance(source, ds.Dataset):
             self.con.deregister_table(table_name)
             self.con.register_dataset(table_name, source)
             return self.table(table_name)

--- a/ibis/backends/datafusion/tests/test_register.py
+++ b/ibis/backends/datafusion/tests/test_register.py
@@ -33,14 +33,14 @@ def test_register_pandas(conn):
     df = pd.DataFrame({"x": [1, 2, 3]})
     with pytest.warns(FutureWarning, match="v9.1"):
         conn.register(df, "my_table")
-        assert conn.table("my_table").x.sum().execute() == 6
+    assert conn.table("my_table").x.sum().execute() == 6
 
 
 def test_register_batches(conn):
     batch = pa.record_batch([pa.array([1, 2, 3])], names=["x"])
     with pytest.warns(FutureWarning, match="v9.1"):
         conn.register(batch, "my_table")
-        assert conn.table("my_table").x.sum().execute() == 6
+    assert conn.table("my_table").x.sum().execute() == 6
 
 
 def test_register_dataset(conn):
@@ -50,7 +50,7 @@ def test_register_dataset(conn):
     dataset = ds.InMemoryDataset(tab)
     with pytest.warns(FutureWarning, match="v9.1"):
         conn.register(dataset, "my_table")
-        assert conn.table("my_table").x.sum().execute() == 6
+    assert conn.table("my_table").x.sum().execute() == 6
 
 
 def test_create_table_with_uppercase_name(conn):

--- a/ibis/backends/datafusion/tests/test_register.py
+++ b/ibis/backends/datafusion/tests/test_register.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pandas as pd
 import pyarrow as pa
-import pyarrow.dataset as ds
 import pytest
 
 import ibis
@@ -45,6 +44,8 @@ def test_register_batches(conn):
 
 
 def test_register_dataset(conn):
+    import pyarrow.dataset as ds
+
     tab = pa.table({"x": [1, 2, 3]})
     dataset = ds.InMemoryDataset(tab)
     with pytest.warns(FutureWarning, match="v9.1"):

--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -78,11 +78,7 @@ class Example(Concrete):
                     if pyarrow.types.is_null(field.type):
                         table = table.set_column(i, field.name, table[i].cast("string"))
 
-            # TODO: It should be possible to avoid this memtable call, once all
-            # backends support passing a `pyarrow.Table` to `create_table`
-            # directly.
-            obj = ibis.memtable(table)
-            return backend.create_table(table_name, obj, temp=True, overwrite=True)
+            return ibis.memtable(table, name=table_name)
 
 
 _FETCH_DOCSTRING_TEMPLATE = """\

--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -80,7 +80,7 @@ class Example(Concrete):
 
             obj = ibis.memtable(table, name=table_name)
             backend._register_in_memory_tables(obj)
-            return backend.table(table_name)
+            return backend.table(table_name).cache()
 
 
 _FETCH_DOCSTRING_TEMPLATE = """\

--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -78,7 +78,9 @@ class Example(Concrete):
                     if pyarrow.types.is_null(field.type):
                         table = table.set_column(i, field.name, table[i].cast("string"))
 
-            return ibis.memtable(table, name=table_name)
+            obj = ibis.memtable(table, name=table_name)
+            backend._register_in_memory_tables(obj)
+            return backend.table(table_name)
 
 
 _FETCH_DOCSTRING_TEMPLATE = """\


### PR DESCRIPTION
Fixes an import bug that can show up when calling register on the datafusion backend without having imported `pyarrow.dataset` before calling `register`, as well as moving to memtables for examples to bypass `temp=True` shenanigans.

The import bug wasn't caught due to importing `pyarrow.dataset` at the top of the test module.