### PR TITLE
revert: fix(datafusion): raise when attempting to create temp table (#10072)

### DIFF
--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -612,8 +612,10 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         if schema is not None:
             schema = ibis.schema(schema)
 
+        properties = []
+
         if temp:
-            raise NotImplementedError("DataFusion does not support temporary tables")
+            properties.append(sge.TemporaryProperty())
 
         quoted = self.compiler.quoted
 
@@ -657,6 +659,7 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase, CanCreateSchema, 
         create_stmt = sge.Create(
             kind="TABLE",
             this=target,
+            properties=sge.Properties(expressions=properties),
             expression=query,
             replace=overwrite,
         )

--- a/ibis/backends/datafusion/tests/test_register.py
+++ b/ibis/backends/datafusion/tests/test_register.py
@@ -56,12 +56,3 @@ def test_create_table_with_uppercase_name(conn):
     tab = pa.table({"x": [1, 2, 3]})
     conn.create_table("MY_TABLE", tab)
     assert conn.table("MY_TABLE").x.sum().execute() == 6
-
-
-def test_raise_create_temp_table(conn):
-    tab = pa.table({"x": [1, 2, 3]})
-    with pytest.raises(
-        NotImplementedError,
-        match="DataFusion does not support temporary tables",
-    ):
-        conn.create_table("my_temp_table", tab, temp=True)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -119,14 +119,7 @@ def test_create_table(backend, con, temp_table, func, sch):
             marks=[
                 pytest.mark.notyet(["clickhouse"], reason="Can't specify both"),
                 pytest.mark.notyet(
-                    [
-                        "pyspark",
-                        "trino",
-                        "exasol",
-                        "risingwave",
-                        "impala",
-                        "datafusion",
-                    ],
+                    ["pyspark", "trino", "exasol", "risingwave", "impala"],
                     reason="No support for temp tables",
                 ),
                 pytest.mark.notyet(
@@ -152,14 +145,7 @@ def test_create_table(backend, con, temp_table, func, sch):
             id="temp, no overwrite",
             marks=[
                 pytest.mark.notyet(
-                    [
-                        "pyspark",
-                        "trino",
-                        "exasol",
-                        "risingwave",
-                        "impala",
-                        "datafusion",
-                    ],
+                    ["pyspark", "trino", "exasol", "risingwave", "impala"],
                     reason="No support for temp tables",
                 ),
                 pytest.mark.notimpl(["mssql"], reason="Incorrect temp table syntax"),
@@ -321,9 +307,6 @@ def test_create_table_from_schema(con, new_schema, temp_table):
     ["flink"],
     raises=com.IbisError,
     reason="`tbl_properties` is required when creating table with schema",
-)
-@pytest.mark.notimpl(
-    ["datafusion"], raises=NotImplementedError, reason="no temp table support"
 )
 def test_create_temporary_table_from_schema(con_no_data, new_schema):
     if con_no_data.name == "snowflake" and os.environ.get("SNOWFLAKE_SNOWPARK"):
@@ -1579,9 +1562,6 @@ def test_json_to_pyarrow(con):
     assert result == expected
 
 
-@pytest.mark.notimpl(
-    ["datafusion"], raises=NotImplementedError, reason="no temp table support"
-)
 @pytest.mark.notyet(
     ["risingwave", "exasol"],
     raises=com.UnsupportedOperationError,

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -1059,14 +1059,7 @@ def string_temp_table(backend, con):
     )
 
     temp_table_name = gen_name("strings")
-    temp = backend.name() not in [
-        "exasol",
-        "impala",
-        "pyspark",
-        "risingwave",
-        "trino",
-        "datafusion",
-    ]
+    temp = backend.name() not in ["exasol", "impala", "pyspark", "risingwave", "trino"]
     if backend.name() == "druid":
         yield "I HATE DRUID"
     else:


### PR DESCRIPTION
This reverts commit 1cf54399c94849cf27782b2446efe3c2e31e2467.

The Datafusion temporary table aren't temporary tables in the sense of where they are registered in the `information_schema`, but they are definitely ephemeral.  Also, removing this broke a bunch of stuff that our CI didn't catch (yikes), so reverting while we sort that out.