### PR TITLE
docs: avoid needing to render API docs for any preview/render invocation

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -122,7 +122,10 @@ website:
       collapse-level: 2
       contents:
         - auto: backends/*.qmd
-        - auto: backends/support
+        - section: Support
+          contents:
+            - auto: backends/support/*.qmd
+            - reference/operations.qmd
     - id: how-to
       title: "How-to"
       style: "docked"

--- a/docs/backends/support/operations.qmd
+++ b/docs/backends/support/operations.qmd
@@ -1,1 +1,0 @@
-{{< include ../../reference/operations.qmd >}}


### PR DESCRIPTION
Because we include a generated file, this forces developers to render API docs, or delete the file that references the generated file. This PR fixes that by deleting the file using the include, and referencing the included file directly in `_quarto.yml`