### PR TITLE
refactor(backends): replace register usage with read

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1425,10 +1425,15 @@ def connect(resource: Path | str, **kwargs: Any) -> BaseBackend:
             return ibis.duckdb.connect(path, **kwargs)
         elif path.endswith((".sqlite", ".db")):
             return ibis.sqlite.connect(path, **kwargs)
-        elif path.endswith((".parquet", ".csv", ".csv.gz")):
-            # Load parquet/csv/csv.gz files with duckdb by default
+        elif path.endswith((".csv", ".csv.gz")):
+            # Load csv/csv.gz files with duckdb by default
             con = ibis.duckdb.connect(**kwargs)
-            con.register(path)
+            con.read_csv(path)
+            return con
+        elif path.endswith(".parquet"):
+            # Load parquet files with duckdb by default
+            con = ibis.duckdb.connect(**kwargs)
+            con.read_parquet(path)
             return con
         else:
             raise ValueError(f"Don't know how to connect to {resource!r}")

--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -28,13 +28,10 @@ class TestConf(BackendTest):
         con = self.connection
         for table_name in TEST_TABLES:
             path = self.data_dir / "parquet" / f"{table_name}.parquet"
-            with pytest.warns(FutureWarning, match="v9.1"):
-                con.register(path, table_name=table_name)
-        # TODO: remove warnings and replace register when implementing 8858
-        with pytest.warns(FutureWarning, match="v9.1"):
-            con.register(array_types, table_name="array_types")
-            con.register(win, table_name="win")
-            con.register(topk, table_name="topk")
+            con.read_parquet(path, table_name=table_name)
+        con.create_table("array_types", array_types)
+        con.create_table("win", win)
+        con.create_table("topk", topk)
 
     @staticmethod
     def connect(*, tmpdir, worker_id, **kw):

--- a/ibis/backends/datafusion/tests/test_register.py
+++ b/ibis/backends/datafusion/tests/test_register.py
@@ -24,23 +24,20 @@ def test_read_parquet(conn, data_dir):
 
 def test_register_table(conn):
     tab = pa.table({"x": [1, 2, 3]})
-    with pytest.warns(FutureWarning, match="v9.1"):
-        conn.register(tab, "my_table")
+    conn.create_table("my_table", tab)
     assert conn.table("my_table").x.sum().execute() == 6
 
 
 def test_register_pandas(conn):
     df = pd.DataFrame({"x": [1, 2, 3]})
-    with pytest.warns(FutureWarning, match="v9.1"):
-        conn.register(df, "my_table")
-        assert conn.table("my_table").x.sum().execute() == 6
+    conn.create_table("my_table", df)
+    assert conn.table("my_table").x.sum().execute() == 6
 
 
 def test_register_batches(conn):
     batch = pa.record_batch([pa.array([1, 2, 3])], names=["x"])
-    with pytest.warns(FutureWarning, match="v9.1"):
-        conn.register(batch, "my_table")
-        assert conn.table("my_table").x.sum().execute() == 6
+    conn.create_table("my_table", batch)
+    assert conn.table("my_table").x.sum().execute() == 6
 
 
 def test_register_dataset(conn):

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -270,9 +270,7 @@ def test_connect_local_file(out_method, extension, tmp_path):
     df = pd.DataFrame({"a": [1, 2, 3]})
     path = tmp_path / f"out.{extension}"
     getattr(df, out_method)(path)
-    with pytest.warns(FutureWarning, match="v9.1"):
-        # ibis.connect uses con.register
-        con = ibis.connect(path)
+    con = ibis.connect(path)
     t = next(iter(con.tables.values()))
     assert not t.head().execute().empty
 


### PR DESCRIPTION
## Description of changes

Replacing a few additional existing "register" methods from the 9.1 deprecation.