### PR TITLE
docs(security): update security report address to point to private Zulip channel

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,9 @@ Security updates are provided by releasing a new version of Ibis.
 
 ## Reporting a Vulnerability
 
-- Send security reports to security@ibis-project.org
+- Privately send security reports to [the security
+  team](ibis-security.fc04057de4d981273b23058268b61817.show-sender@streams.zulipchat.com)
+  Emails sent to this address are sent to a private Zulip channel where only
+  members of the Ibis security team can see them.
 - Vulnerability reports are published on GitHub at https://github.com/ibis-project/ibis/security/advisories
 - If a vulnerability is accepted we will attempt to address it as soon as possible, by cutting a new release.


### PR DESCRIPTION
## Description of changes

Updating the reporting mechanism for security reports -- now there's an email that points to a private Zulip channel.