### PR TITLE
feat(api): add `distinct` option to `collect`

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1003,7 +1003,10 @@ def array_collect(op, in_group_by=False, **kw):
     if op.order_by:
         keys = [translate(k.expr, **kw).filter(predicate) for k in op.order_by]
         descending = [k.descending for k in op.order_by]
-        arg = arg.sort_by(keys, descending=descending)
+        arg = arg.sort_by(keys, descending=descending, nulls_last=True)
+
+    if op.distinct:
+        arg = arg.unique(maintain_order=op.order_by is not None)
 
     # Polars' behavior changes for `implode` within a `group_by` currently.
     # See https://github.com/pola-rs/polars/issues/16756

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -611,12 +611,13 @@ class ClickHouseCompiler(SQLGlotCompiler):
     def visit_ArrayZip(self, op: ops.ArrayZip, *, arg, **_: Any) -> str:
         return self.f.arrayZip(*arg)
 
-    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null):
+    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null, distinct):
         if include_null:
             raise com.UnsupportedOperationError(
                 "`include_null=True` is not supported by the clickhouse backend"
             )
-        return self.agg.groupArray(arg, where=where, order_by=order_by)
+        func = self.agg.groupUniqArray if distinct else self.agg.groupArray
+        return func(arg, where=where, order_by=order_by)
 
     def visit_First(self, op, *, arg, where, order_by, include_null):
         if include_null:

--- a/ibis/backends/sql/compilers/datafusion.py
+++ b/ibis/backends/sql/compilers/datafusion.py
@@ -327,7 +327,11 @@ class DataFusionCompiler(SQLGlotCompiler):
     def visit_ArrayPosition(self, op, *, arg, other):
         return self.f.coalesce(self.f.array_position(arg, other), 0)
 
-    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null):
+    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null, distinct):
+        if distinct:
+            raise com.UnsupportedOperationError(
+                "`collect` with `distinct=True` is not supported"
+            )
         if not include_null:
             cond = arg.is_(sg.not_(NULL, copy=False))
             where = cond if where is None else sge.And(this=cond, expression=where)

--- a/ibis/backends/sql/compilers/duckdb.py
+++ b/ibis/backends/sql/compilers/duckdb.py
@@ -156,10 +156,12 @@ class DuckDBCompiler(SQLGlotCompiler):
             self.f.coalesce(self.f.list_indexof(arg, other), 0),
         )
 
-    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null):
+    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null, distinct):
         if not include_null:
             cond = arg.is_(sg.not_(NULL, copy=False))
             where = cond if where is None else sge.And(this=cond, expression=where)
+        if distinct:
+            arg = sge.Distinct(expressions=[arg])
         return self.agg.array_agg(arg, where=where, order_by=order_by)
 
     def visit_ArrayIndex(self, op, *, arg, index):

--- a/ibis/backends/sql/compilers/flink.py
+++ b/ibis/backends/sql/compilers/flink.py
@@ -572,20 +572,24 @@ class FlinkCompiler(SQLGlotCompiler):
     def visit_StructColumn(self, op, *, names, values):
         return self.cast(sge.Struct(expressions=list(values)), op.dtype)
 
-    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null):
+    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null, distinct):
         if order_by:
             raise com.UnsupportedOperationError(
                 "ordering of order-sensitive aggregations via `order_by` is "
                 "not supported for this backend"
             )
-        # the only way to get filtering *and* respecting nulls is to use
-        # `FILTER` syntax, but it's broken in various ways for other aggregates
-        out = self.f.array_agg(arg)
         if not include_null:
             cond = arg.is_(sg.not_(NULL, copy=False))
             where = cond if where is None else sge.And(this=cond, expression=where)
+        out = self.f.array_agg(arg)
         if where is not None:
             out = sge.Filter(this=out, expression=sge.Where(this=where))
+        if distinct:
+            # TODO: Flink supposedly supports `ARRAY_AGG(DISTINCT ...)`, but it
+            # doesn't work with filtering (either `include_null=False` or
+            # additional filtering). Their `array_distinct` function does maintain
+            # ordering though, so we can use it here.
+            out = self.f.array_distinct(out)
         return out
 
     def visit_Strip(self, op, *, arg):

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -372,10 +372,12 @@ class PostgresCompiler(SQLGlotCompiler):
             )
         )
 
-    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null):
+    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null, distinct):
         if not include_null:
             cond = arg.is_(sg.not_(NULL, copy=False))
             where = cond if where is None else sge.And(this=cond, expression=where)
+        if distinct:
+            arg = sge.Distinct(expressions=[arg])
         return self.agg.array_agg(arg, where=where, order_by=order_by)
 
     def visit_First(self, op, *, arg, where, order_by, include_null):

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -182,10 +182,12 @@ class TrinoCompiler(SQLGlotCompiler):
             NULL,
         )
 
-    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null):
+    def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null, distinct):
         if not include_null:
             cond = arg.is_(sg.not_(NULL, copy=False))
             where = cond if where is None else sge.And(this=cond, expression=where)
+        if distinct:
+            arg = sge.Distinct(expressions=[arg])
         return self.agg.array_agg(arg, where=where, order_by=order_by)
 
     def visit_JSONGetItem(self, op, *, arg, index):

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -9,7 +9,7 @@ from public import public
 import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.rules as rlz
-from ibis.common.annotations import attribute
+from ibis.common.annotations import ValidationError, attribute
 from ibis.common.typing import VarTuple  # noqa: TCH001
 from ibis.expr.operations.core import Column, Value
 from ibis.expr.operations.relations import Relation  # noqa: TCH001
@@ -376,6 +376,15 @@ class ArrayCollect(Filterable, Reduction):
     arg: Column
     order_by: VarTuple[SortKey] = ()
     include_null: bool = False
+    distinct: bool = False
+
+    def __init__(self, arg, order_by, distinct, **kwargs):
+        if distinct and order_by and [arg] != [key.expr for key in order_by]:
+            raise ValidationError(
+                "`collect` with `order_by` and `distinct=True` and may only "
+                "order by the collected column"
+            )
+        super().__init__(arg=arg, order_by=order_by, distinct=distinct, **kwargs)
 
     @attribute
     def dtype(self):

--- a/ibis/expr/tests/test_reductions.py
+++ b/ibis/expr/tests/test_reductions.py
@@ -6,6 +6,7 @@ from pytest import param
 import ibis
 import ibis.expr.operations as ops
 from ibis import _
+from ibis.common.annotations import ValidationError
 from ibis.common.deferred import Deferred
 from ibis.common.exceptions import IbisTypeError
 
@@ -161,3 +162,22 @@ def test_ordered_aggregations_no_order(method):
     q3 = func(order_by=())
     assert q1.equals(q2)
     assert q1.equals(q3)
+
+
+def test_collect_distinct():
+    t = ibis.table({"a": "string", "b": "int", "c": "int"}, name="t")
+    # Fine
+    t.a.collect(distinct=True)
+    t.a.collect(distinct=True, order_by=t.a.desc())
+    (t.a + 1).collect(distinct=True, order_by=(t.a + 1).desc())
+
+    with pytest.raises(ValidationError, match="only order by the collected column"):
+        t.b.collect(distinct=True, order_by=t.a)
+    with pytest.raises(ValidationError, match="only order by the collected column"):
+        t.b.collect(
+            distinct=True,
+            order_by=(
+                t.a,
+                t.b,
+            ),
+        )

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1022,6 +1022,7 @@ class Value(Expr):
         where: ir.BooleanValue | None = None,
         order_by: Any = None,
         include_null: bool = False,
+        distinct: bool = False,
     ) -> ir.ArrayScalar:
         """Aggregate this expression's elements into an array.
 
@@ -1039,19 +1040,22 @@ class Value(Expr):
         include_null
             Whether to include null values when performing this aggregation. Set
             to `True` to include nulls in the result.
+        distinct
+            Whether to collect only distinct elements.
 
         Returns
         -------
         ArrayScalar
-            Collected array
+            An array of all the collected elements.
 
         Examples
         --------
         Basic collect usage
 
         >>> import ibis
+        >>> from ibis import _
         >>> ibis.options.interactive = True
-        >>> t = ibis.memtable({"key": list("aaabb"), "value": [1, 2, 3, 4, 5]})
+        >>> t = ibis.memtable({"key": list("aaabb"), "value": [1, 1, 2, 3, 5]})
         >>> t
         ┏━━━━━━━━┳━━━━━━━┓
         ┃ key    ┃ value ┃
@@ -1059,40 +1063,37 @@ class Value(Expr):
         │ string │ int64 │
         ├────────┼───────┤
         │ a      │     1 │
+        │ a      │     1 │
         │ a      │     2 │
-        │ a      │     3 │
-        │ b      │     4 │
+        │ b      │     3 │
         │ b      │     5 │
         └────────┴───────┘
-        >>> t.value.collect()
-        ┌────────────────┐
-        │ [1, 2, ... +3] │
-        └────────────────┘
-        >>> type(t.value.collect())
-        <class 'ibis.expr.types.arrays.ArrayScalar'>
 
-        Collect elements per group
+        Collect all elements into an array scalar:
 
-        >>> t.group_by("key").agg(v=lambda t: t.value.collect()).order_by("key")
+        >>> t.value.collect().to_pandas()
+        [1, 1, 2, 3, 5]
+
+        Collect only unique elements:
+
+        >>> t.value.collect(distinct=True).to_pandas()  # doctest: +SKIP
+        [1, 2, 3, 5]
+
+        Collect elements in a specified order:
+
+        >>> t.value.collect(order_by=_.value.desc()).to_pandas()
+        [5, 3, 2, 1, 1]
+
+        Collect elements per group, filtering out values <= 1:
+
+        >>> t.group_by("key").agg(v=t.value.collect(where=_.value > 1)).order_by("key")
         ┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ key    ┃ v                    ┃
         ┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
         │ string │ array<int64>         │
         ├────────┼──────────────────────┤
-        │ a      │ [1, 2, ... +1]       │
-        │ b      │ [4, 5]               │
-        └────────┴──────────────────────┘
-
-        Collect elements per group using a filter
-
-        >>> t.group_by("key").agg(v=lambda t: t.value.collect(where=t.value > 1)).order_by("key")
-        ┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
-        ┃ key    ┃ v                    ┃
-        ┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
-        │ string │ array<int64>         │
-        ├────────┼──────────────────────┤
-        │ a      │ [2, 3]               │
-        │ b      │ [4, 5]               │
+        │ a      │ [2]                  │
+        │ b      │ [3, 5]               │
         └────────┴──────────────────────┘
         """
         return ops.ArrayCollect(
@@ -1100,6 +1101,7 @@ class Value(Expr):
             where=self._bind_to_parent_table(where),
             order_by=self._bind_order_by(order_by),
             include_null=include_null,
+            distinct=distinct,
         ).to_expr()
 
     def identical_to(self, other: Value) -> ir.BooleanValue:


### PR DESCRIPTION
This adds a new `distinct` option to `collect` (defaulting to `False`). When True, only distinct elements are collected.

Depending on the backend calling `x.collect(distinct=True)` may be more efficient than `x.collect().unique()`, and has the added benefit of not disrupting array ordering for backends where `unique` may not respect ordering.