### PR TITLE
fix(joins): allow chaining positional and cross joins

### DIFF
--- a/ibis/expr/types/joins.py
+++ b/ibis/expr/types/joins.py
@@ -248,7 +248,7 @@ class Join(Table):
     def join(
         self,
         right,
-        predicates: Any,
+        predicates: Any = (),
         how: JoinKind = "inner",
         *,
         lname: str = "",


### PR DESCRIPTION
A user on Zulip
https://ibis-project.zulipchat.com/#narrow/stream/405265-tech-support/topic/Creating.20a.20new.20column.20from.20a.20numpy.20array.3F/near/470013765
reported an error about a missing `predicate` argument when trying to
chain positional joins.

This allows chaining the join types that don't have
predicates (`positional` and `cross`).