### PR TITLE
fix(repr): remove expression printing from exception message

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1366,7 +1366,7 @@ class Scalar(Value):
             return parent.to_expr().aggregate(self)
         else:
             raise com.RelationError(
-                f"The scalar expression {self} cannot be converted to a "
+                "The scalar expression cannot be converted to a "
                 "table expression because it involves multiple base table "
                 "references"
             )


### PR DESCRIPTION
There is some deeper work in this area to audit the places where we are doing this and 1) remove it and possibly 2) figure out a way to turn off interactive mode whenever an Ibis exception is raised. Closes #10124.