### PR TITLE
docs(api): avoid quartodoc warning about missing parameter

### DIFF
--- a/ibis/common/deferred.py
+++ b/ibis/common/deferred.py
@@ -70,7 +70,7 @@ class Deferred(Slotted, Immutable, Final):
 
     Parameters
     ----------
-    deferred
+    obj
         The deferred object to provide syntax sugar for.
     repr
         An optional fixed string to use when repr-ing the deferred expression,


### PR DESCRIPTION
Addresses a warning shown by `quartodoc` about a missing parameter.