### PR TITLE
chore: remove unused `Dispatched` utility

### DIFF
--- a/ibis/common/tests/test_dispatch.py
+++ b/ibis/common/tests/test_dispatch.py
@@ -2,16 +2,8 @@ from __future__ import annotations
 
 import collections
 import decimal
-from typing import TYPE_CHECKING, Union
 
-import pytest
-
-from ibis.common.dispatch import Dispatched, lazy_singledispatch
-
-# ruff: noqa: F811
-if TYPE_CHECKING:
-    import pandas as pd
-    import pyarrow as pa
+from ibis.common.dispatch import lazy_singledispatch
 
 
 def test_lazy_singledispatch():
@@ -126,110 +118,3 @@ def test_lazy_singledispatch_abc():
     assert foo({}) == "mapping"
     assert foo(mydict()) == "mydict"  # concrete takes precedence
     assert foo(sum) == "callable"
-
-
-class A:
-    pass
-
-
-class B:
-    pass
-
-
-class Visitor(Dispatched):
-    def a(self):
-        return "a"
-
-    def b(self, x: int):
-        return "b_int"
-
-    def b(self, x: str):
-        return "b_str"
-
-    def b(self, x: Union[A, B]):
-        return "b_union"
-
-    @classmethod
-    def c(cls, x: int, **kwargs):
-        return "c_int"
-
-    @classmethod
-    def c(cls, x: str, a=0, b=1):
-        return "c_str"
-
-    def d(self, x: int):
-        return "d_int"
-
-    def d(self, x: str):
-        return "d_str"
-
-    @staticmethod
-    def e(x: int):
-        return "e_int"
-
-    @staticmethod
-    def e(x: str):
-        return "e_str"
-
-    def f(self, df: dict):
-        return "f_dict"
-
-    def f(self, df: pd.DataFrame):
-        return "f_pandas"
-
-    def f(self, df: pa.Table):
-        return "f_pyarrow"
-
-
-class Subvisitor(Visitor):
-    def b(self, x):
-        return super().b(x)
-
-    def b(self, x: float):
-        return "b_float"
-
-    @classmethod
-    def c(cls, x):
-        return super().c(x)
-
-    @classmethod
-    def c(cls, s: float):
-        return "c_float"
-
-
-def test_dispatched():
-    v = Visitor()
-    assert v.a() == "a"
-    assert v.b(1) == "b_int"
-    assert v.b("1") == "b_str"
-    assert v.b(A()) == "b_union"
-    assert v.b(B()) == "b_union"
-    assert v.d(1) == "d_int"
-    assert v.d("1") == "d_str"
-
-    w = Subvisitor()
-    assert w.b(1) == "b_int"
-    assert w.b(1.1) == "b_float"
-
-    assert Visitor.c(1, a=0, b=0) == "c_int"
-    assert Visitor.c("1") == "c_str"
-
-    assert Visitor.e("1") == "e_str"
-    assert Visitor.e(1) == "e_int"
-
-    assert Subvisitor.c(1) == "c_int"
-    assert Subvisitor.c(1.1) == "c_float"
-
-    assert Subvisitor.e(1) == "e_int"
-
-
-def test_dispatched_lazy():
-    pa = pytest.importorskip("pyarrow")
-
-    empty_pyarrow_table = pa.Table.from_arrays([])
-    empty_pandas_table = empty_pyarrow_table.to_pandas()
-
-    v = Visitor()
-    assert v.f({}) == "f_dict"
-    assert v.f(empty_pyarrow_table) == "f_pyarrow"
-    assert v.f(empty_pandas_table) == "f_pandas"


### PR DESCRIPTION
This was used in the pandas/dask backends, but is no longer used.