### PR TITLE
feat(polars): allow user to specify "engine" kwarg

### DIFF
--- a/ibis/backends/polars/tests/test_client.py
+++ b/ibis/backends/polars/tests/test_client.py
@@ -65,18 +65,14 @@ def test_memtable_polars_types(con):
 @pytest.mark.parametrize("to_method", ["to_pyarrow", "to_polars"])
 def test_streaming(con, mocker, to_method):
     t = con.table("functional_alltypes")
-    to_method_spy = mocker.spy(con, to_method)
     mocked_collect = mocker.patch("polars.LazyFrame.collect")
     getattr(con, to_method)(t, streaming=True)
-    to_method_spy.assert_called_once_with(t, streaming=True)
     mocked_collect.assert_called_once_with(streaming=True, engine="cpu")
 
 
 @pytest.mark.parametrize("to_method", ["to_pyarrow", "to_polars"])
 def test_engine(con, mocker, to_method):
     t = con.table("functional_alltypes")
-    to_method_spy = mocker.spy(con, to_method)
     mocked_collect = mocker.patch("polars.LazyFrame.collect")
     getattr(con, to_method)(t, engine="gpu")
-    to_method_spy.assert_called_once_with(t, engine="gpu")
     mocked_collect.assert_called_once_with(streaming=False, engine="gpu")


### PR DESCRIPTION
## Description of changes

Modeled after support for "streaming" kwarg, but I have a couple questions:

1. I don't see any tests for "streaming", so I didn't add any for "engine"; is this fine?
2. I didn't see any attempt to support older Polars versions that didn't accept "streaming", so I didn't try to do that for "engine", either. However, Polars is technically stable now; should we not force people to get latest?