### PR TITLE
chore: show deprecation warning at caller level

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -688,6 +688,7 @@ class Table(Expr, _FixedTextJupyterMixin):
             "deprecated and will be removed in version 10.0. Please use "
             "`Table.select` or `Table.filter` instead.",
             FutureWarning,
+            stacklevel=2,
         )
         values = self.bind(args)
 


### PR DESCRIPTION
Consider this code:

```python
import ibis

t = ibis.table({"x": int})
t[ibis._.x]
```

Before this change, I see a warning such as

```
/Users/nc/code/ibis/ibis/expr/types/relations.py:686: FutureWarning: Selecting/filtering arbitrary expressions in `Table.__getitem__` is deprecated and will be removed in version 10.0. Please use `Table.select` or `Table.filter` instead.
  warnings.warn(
```

After this change, the actual offending code is highlighted:

```
/var/folders/0b/tpgpsvx54f9g1gg1lkq45syc0000gp/T/ipykernel_2186/2779650478.py:4: FutureWarning: Selecting/filtering arbitrary expressions in `Table.__getitem__` is deprecated and will be removed in version 10.0. Please use `Table.select` or `Table.filter` instead.
  t[_.x]
```

<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
