### PR TITLE
ci(pyspark): name the output path when downloading jar

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -650,7 +650,7 @@ jobs:
         run: docker compose logs
 
   test_pyspark:
-    name: PySpark ${{ matrix.pyspark-version }} ubuntu-latest python-${{ matrix.python-version }}
+    name: PySpark ${{ matrix.pyspark-minor-version }} ubuntu-latest python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -658,16 +658,19 @@ jobs:
         include:
           - python-version: "3.10"
             pyspark-version: "3.3.3"
+            pyspark-minor-version: "3.3"
             deps:
               - "'pandas@<2'"
               - "'numpy@<1.24'"
           - python-version: "3.11"
-            pyspark-version: "3.5"
+            pyspark-version: "3.5.2"
+            pyspark-minor-version: "3.5"
             deps:
               - "'pandas@>2'"
               - "'numpy@>1.24'"
           - python-version: "3.12"
-            pyspark-version: "3.5"
+            pyspark-version: "3.5.2"
+            pyspark-minor-version: "3.5"
             deps:
               - "'pandas@>2'"
               - "'numpy@>1.24'"
@@ -722,8 +725,7 @@ jobs:
 
       - name: install iceberg
         shell: bash
-        if: matrix.pyspark-version == '3.5'
-        run: pushd "$(poetry run python -c "import pyspark; print(pyspark.__file__.rsplit('/', 1)[0])")/jars" && curl -LO https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.5.2/iceberg-spark-runtime-3.5_2.12-1.5.2.jar
+        run: just download-iceberg-jar ${{ matrix.pyspark-minor-version }}
 
       - name: run tests
         run: just ci-check -m pyspark

--- a/ibis/backends/pyspark/tests/test_client.py
+++ b/ibis/backends/pyspark/tests/test_client.py
@@ -6,8 +6,7 @@ import ibis
 
 
 @pytest.mark.xfail_version(pyspark=["pyspark<3.4"], reason="no catalog support")
-def test_catalog_db_args(con, monkeypatch):
-    monkeypatch.setattr(ibis.options, "default_backend", con)
+def test_catalog_db_args(con):
     t = ibis.memtable({"epoch": [1712848119, 1712848121, 1712848155]})
 
     assert con.current_catalog == "spark_catalog"
@@ -40,8 +39,7 @@ def test_catalog_db_args(con, monkeypatch):
     assert con.current_database == "ibis_testing"
 
 
-def test_create_table_no_catalog(con, monkeypatch):
-    monkeypatch.setattr(ibis.options, "default_backend", con)
+def test_create_table_no_catalog(con):
     t = ibis.memtable({"epoch": [1712848119, 1712848121, 1712848155]})
 
     assert con.current_database != "default"

--- a/justfile
+++ b/justfile
@@ -135,6 +135,23 @@ download-data owner="ibis-project" repo="testing-data" rev="master":
         git -C "${outdir}" checkout "{{ rev }}"
     fi
 
+# download the iceberg jar used for testing pyspark and iceberg integration
+download-iceberg-jar pyspark scala="2.12" iceberg="1.5.2":
+    #!/usr/bin/env bash
+    set -eo pipefail
+
+    runner=(python)
+
+    if [ -n "${CI}" ]; then
+        runner=(poetry run python)
+    fi
+    pyspark="$("${runner[@]}" -c "import pyspark; print(pyspark.__file__.rsplit('/', 1)[0])")"
+    pushd "${pyspark}/jars"
+    jar="iceberg-spark-runtime-{{ pyspark }}_{{ scala }}-{{ iceberg }}.jar"
+    url="https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-{{ pyspark }}_{{ scala }}/{{ iceberg }}/${jar}"
+    curl -qSsL -o "${jar}" "${url}"
+    ls "${jar}"
+
 # start backends using docker compose; no arguments starts all backends
 up *backends:
     docker compose up --build --wait {{ backends }}

--- a/poetry-overrides.nix
+++ b/poetry-overrides.nix
@@ -1,11 +1,20 @@
 final: prev: {
   pyspark = prev.pyspark.overridePythonAttrs (attrs:
     let
-      icebergJarUrl = "https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.5.2/iceberg-spark-runtime-3.5_2.12-1.5.2.jar";
-      icebergJar = final.pkgs.fetchurl {
-        name = "iceberg-spark-runtime-3.5_2.12-1.5.2.jar";
+      inherit (final) pkgs lib;
+      pysparkVersion = lib.versions.majorMinor attrs.version;
+      jarHashes = {
+        "3.5" = "sha256-KuxLeNgGzIHU5QMls1H2NJyQ3mQVROZExgMvAAk4YYs=";
+        "3.3" = "sha256-W3ij6mwrIDOc4zGqtpCsbg563qHmdMc8eZnLX6bnl2M=";
+      };
+      icebergVersion = "1.5.2";
+      scalaVersion = "2.12";
+      jarName = "iceberg-spark-runtime-${pysparkVersion}_${scalaVersion}-${icebergVersion}.jar";
+      icebergJarUrl = "https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-${pysparkVersion}_${scalaVersion}/${icebergVersion}/${jarName}";
+      icebergJar = pkgs.fetchurl {
+        name = jarName;
         url = icebergJarUrl;
-        sha256 = "12v1704h0bq3qr2fci0mckg9171lyr8v6983wpa83k06v1w4pv1a";
+        sha256 = jarHashes."${pysparkVersion}";
       };
     in
     {


### PR DESCRIPTION
If we don't do this, sometimes the jar ends up as `remotecontent` instead of a basename like `iceberg-spark-runtime-3.5_2.12-1.6.1.jar`.

Fixes #10148.