### PR TITLE
ci(bigquery): avoid race condition in create table by using a dataset scoped to a specific user and python version

### DIFF
--- a/ibis/backends/bigquery/tests/system/test_connect.py
+++ b/ibis/backends/bigquery/tests/system/test_connect.py
@@ -241,15 +241,10 @@ def test_client_with_regional_endpoints(project_id, credentials, dataset_id):
     assert not len(alltypes.to_pyarrow())
 
 
-def test_create_table_from_memtable_needs_quotes(project_id, credentials):
+def test_create_table_from_memtable_needs_quotes(project_id, dataset_id, credentials):
     con = ibis.bigquery.connect(
-        project_id=project_id,
-        dataset_id=f"{project_id}.testing",
-        credentials=credentials,
+        project_id=project_id, dataset_id=dataset_id, credentials=credentials
     )
 
-    con.create_table(
-        "region-table",
-        schema=ibis.schema(dict(its_always="str", quoting="int")),
-    )
+    con.create_table("region-table", schema=dict(its_always="str", quoting="int"))
     con.drop_table("region-table")


### PR DESCRIPTION
We do this for other bigquery tests, to avoid failures like this: https://github.com/ibis-project/ibis/actions/runs/10921405259/job/30313419648.