### PR TITLE
docs(datafusion): add imdb live demo reference to end of presentation

### DIFF
--- a/docs/presentations/datafusion-meetup-nyc-2024/talk.qmd
+++ b/docs/presentations/datafusion-meetup-nyc-2024/talk.qmd
@@ -369,6 +369,24 @@ Nope. You should use Ibis _with_ `X`.
 
 ::: {.panel-tabset}
 
+### IMDB Top 10
+
+```python
+import ibis
+
+con = ibis.datafusion.connect()
+ibis.set_backend(con)
+
+ratings = ibis.examples.imdb_title_ratings.fetch()
+basics = ibis.examples.imdb_title_basics.fetch()
+
+basics.filter(basics.titleType == "movie", basics.isAdult == 0).join(
+    ratings, "tconst"
+).filter(ratings.numVotes > 100_000).order_by(ratings.averageRating.desc()).select(
+    "primaryTitle", "averageRating"
+).limit(10)
+```
+
 ### Pandas PyPI
 
 ```python


### PR DESCRIPTION
I forgot to add this reference and I wanted to make sure people had access to (more or less) what I typed during the live demo.