### PR TITLE
docs(table-expr): include inherited methods (all `to_*` methods)

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -220,6 +220,7 @@ quartodoc:
           contents:
             - name: Table
               package: ibis.expr.types.relations
+              include_inherited: true
             - name: GroupedTable
               package: ibis.expr.types.groupby
             - name: read_csv


### PR DESCRIPTION
I just noticed that `to_polars` and `to_pyarrow` weren't showing up in
searches, that's because we aren't including methods from the
`_FileIOHandler` mixin in the reference docs.  Now we do.