### PR TITLE
fix(mssql): ensure `ibis.random()` generates a new value per call

### DIFF
--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -171,6 +171,12 @@ class MSSQLCompiler(SQLGlotCompiler):
     def visit_RandomUUID(self, op, **_):
         return self.f.newid()
 
+    def visit_RandomScalar(self, op, **_):
+        # By default RAND() will generate the same value for all calls within a
+        # query. The standard way to work around this is to pass in a unique
+        # value per call, which `CHECKSUM(NEWID())` provides.
+        return self.f.rand(self.f.checksum(self.f.newid()))
+
     def visit_StringLength(self, op, *, arg):
         """The MSSQL LEN function doesn't count trailing spaces.
 

--- a/ibis/backends/tests/snapshots/test_sql/test_rewrite_context/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_rewrite_context/mssql/out.sql
@@ -1,4 +1,4 @@
 SELECT
 TOP 10
-  NTILE(2) OVER (ORDER BY RAND() ASC) - 1 AS [new_col]
+  NTILE(2) OVER (ORDER BY RAND(CHECKSUM(NEWID())) ASC) - 1 AS [new_col]
 FROM [test] AS [t0]

--- a/ibis/backends/tests/snapshots/test_sql/test_selects_with_impure_operations_not_merged/mssql-random/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_selects_with_impure_operations_not_merged/mssql-random/out.sql
@@ -6,7 +6,7 @@ SELECT
 FROM (
   SELECT
     [t0].[x],
-    RAND() AS [y],
-    RAND() AS [z]
+    RAND(CHECKSUM(NEWID())) AS [y],
+    RAND(CHECKSUM(NEWID())) AS [z]
   FROM [t] AS [t0]
 ) AS [t1]

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -569,7 +569,7 @@ def test_order_by(backend, alltypes, df, key, df_kwargs):
     backend.assert_frame_equal(result, expected)
 
 
-@pytest.mark.notimpl(["polars", "mssql", "druid"])
+@pytest.mark.notimpl(["polars", "druid"])
 @pytest.mark.notimpl(
     ["risingwave"],
     raises=PsycoPg2InternalError,

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -1309,6 +1309,18 @@ def test_random(con):
     assert 0 <= result <= 1
 
 
+@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError)
+@pytest.mark.notimpl(
+    ["risingwave"],
+    raises=PsycoPg2InternalError,
+    reason="function random() does not exist",
+)
+def test_random_different_per_row(alltypes):
+    result = alltypes.select("int_col", rand_col=ibis.random()).execute()
+    assert result.rand_col.nunique() > 1
+
+
 @pytest.mark.parametrize(
     ("ibis_func", "pandas_func"),
     [


### PR DESCRIPTION
Fixes #10142.