### PR TITLE
chore(docs): clean up current pyodide build

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -77,7 +77,7 @@ jobs:
           path: docs/**/.jupyter_cache
 
       - name: build docs
-        run: nix develop --ignore-environment --keep HOME -c just docs-build-all
+        run: nix develop '.#ibis311' --ignore-environment --keep HOME -c just docs-build-all
 
       - name: install netlify cli
         run: npm install -g netlify-cli

--- a/.github/workflows/ibis-docs-main.yml
+++ b/.github/workflows/ibis-docs-main.yml
@@ -67,10 +67,10 @@ jobs:
           path: docs/**/.jupyter_cache
 
       - name: build api docs
-        run: nix develop --ignore-environment -c just docs-apigen --verbose
+        run: nix develop '.#ibis311' --ignore-environment -c just docs-apigen --verbose
 
       - name: build docs
-        run: nix develop --ignore-environment --keep HOME -c just docs-render
+        run: nix develop '.#ibis311' --ignore-environment --keep HOME -c just docs-render
 
       - name: cache rendered notebooks
         uses: actions/cache/save@v4
@@ -79,7 +79,7 @@ jobs:
           path: docs/**/.jupyter_cache
 
       - name: build jupyterlite
-        run: nix develop --ignore-environment --keep HOME -c just build-jupyterlite
+        run: nix develop '.#ibis311' --ignore-environment --keep HOME -c just build-jupyterlite
 
       - name: check that all frozen computations were done before push
         run: git diff --exit-code --stat

--- a/.github/workflows/ibis-docs-pr.yml
+++ b/.github/workflows/ibis-docs-pr.yml
@@ -67,13 +67,13 @@ jobs:
           path: docs/**/.jupyter_cache
 
       - name: generate api docs
-        run: nix develop --ignore-environment -c just docs-apigen --verbose
+        run: nix develop '.#ibis311' --ignore-environment -c just docs-apigen --verbose
 
       - name: build docs
-        run: nix develop --ignore-environment --keep HOME -c just docs-render
+        run: nix develop '.#ibis311' --ignore-environment --keep HOME -c just docs-render
 
       - name: build jupyterlite
-        run: nix develop --ignore-environment --keep HOME -c just build-jupyterlite
+        run: nix develop '.#ibis311' --ignore-environment --keep HOME -c just build-jupyterlite
 
       - name: check that all frozen computations were done before push
         run: git diff --exit-code --stat

--- a/docs/tutorials/browser/repl.qmd
+++ b/docs/tutorials/browser/repl.qmd
@@ -18,9 +18,12 @@ from urllib.parse import urlencode
 lines = """
 %pip install numpy pandas tzdata
 import pyodide_js, pathlib, js
-await pyodide_js.loadPackage("https://storage.googleapis.com/ibis-wasm-wheels/pyarrow-16.0.0.dev2661%2Bg9bddb87fd-cp311-cp311-emscripten_3_1_46_wasm32.whl")
-pathlib.Path("penguins.csv").write_text(await (await js.fetch("https://storage.googleapis.com/ibis-tutorial-data/penguins.csv")).text())
-del pyodide_js, pathlib, js
+wheel_url = "https://storage.googleapis.com/ibis-wasm-wheels/pyarrow-17.0.0-cp311-cp311-emscripten_3_1_46_wasm32.whl"
+await pyodide_js.loadPackage(wheel_url)
+penguins_csv_url = "https://storage.googleapis.com/ibis-tutorial-data/penguins.csv"
+penguins_text = await (await js.fetch(penguins_csv_url)).text()
+pathlib.Path("penguins.csv").write_text(penguins_text)
+del pyodide_js, pathlib, js, wheel_url, penguins_csv_url, penguins_text
 %clear
 %pip install 'ibis-framework[duckdb]'
 from ibis.interactive import *

--- a/justfile
+++ b/justfile
@@ -249,33 +249,24 @@ docs-api-preview:
 docs-deploy:
     quarto publish --no-prompt --no-browser --no-render netlify docs
 
-# build an ibis_framework wheel that works with pyodide
-build-ibis-for-pyodide:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    # TODO(cpcloud): remove when:
-    # 1. pyarrow release contains pyodide
-    # 2. ibis supports this version of pyarrow
-    rm -rf dist/
-    poetry add 'pyarrow>=10.0.1' --allow-prereleases
-    poetry build --format wheel
-    git checkout poetry.lock pyproject.toml
-    jq '{"PipliteAddon": {"piplite_urls": [$ibis, $duckdb]}}' -nM \
-        --arg ibis dist/*.whl \
-        --arg duckdb "https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-1.0.0-cp311-cp311-emscripten_3_1_46_wasm32.whl" \
-        > docs/jupyter_lite_config.json
-
-# build the jupyterlite deployment
-build-jupyterlite: build-ibis-for-pyodide
+# build jupyterlite repl
+build-jupyterlite:
     #!/usr/bin/env bash
     set -euo pipefail
 
     mkdir -p docs/_output/jupyterlite
+
+    rm -rf dist/
+    poetry-dynamic-versioning
+    ibis_dev_version="$(poetry version | cut -d ' ' -f2)"
+    poetry build --format wheel
+    git checkout pyproject.toml ibis/__init__.py
+
     jupyter lite build \
         --debug \
         --no-libarchive \
-        --config docs/jupyter_lite_config.json \
+        --piplite-wheels "dist/ibis_framework-${ibis_dev_version}-py3-none-any.whl" \
+        --piplite-wheels "https://duckdb.github.io/duckdb-pyodide/wheels/duckdb-1.1.0-cp311-cp311-emscripten_3_1_46_wasm32.whl" \
         --apps repl \
         --no-unused-shared-packages \
         --output-dir docs/_output/jupyterlite


### PR DESCRIPTION
While we cannot yet upgrade to using python3.12, we can clean up the current jupyterlite build a bit