### PR TITLE
fix(api): use `to_pyarrow()` instead of `execute()` when pretty printing scalars

### DIFF
--- a/ibis/backends/tests/test_interactive.py
+++ b/ibis/backends/tests/test_interactive.py
@@ -107,6 +107,10 @@ def test_no_recursion_error(con, monkeypatch):
         repr(expr)
 
 
+@pytest.mark.notimpl(
+    ["impala", "flink", "pyspark"],
+    reason="backend calls `execute` as part of pyarrow conversion",
+)
 def test_scalar_uses_pyarrow(con, table, monkeypatch, mocker):
     monkeypatch.setattr(ibis.options, "interactive", True)
 

--- a/ibis/backends/tests/test_interactive.py
+++ b/ibis/backends/tests/test_interactive.py
@@ -105,3 +105,18 @@ def test_no_recursion_error(con, monkeypatch):
         exc.RelationError, match="The scalar expression cannot be converted"
     ):
         repr(expr)
+
+
+def test_scalar_uses_pyarrow(con, table, monkeypatch, mocker):
+    monkeypatch.setattr(ibis.options, "interactive", True)
+
+    execute_spy = mocker.spy(con, "execute")
+    to_pyarrow_spy = mocker.spy(con, "to_pyarrow")
+
+    repr(table.limit(1).string_col)
+
+    # execute doesn't get called
+    execute_spy.assert_not_called()
+
+    # pyarrow does get called
+    to_pyarrow_spy.assert_called_once()

--- a/ibis/backends/tests/test_interactive.py
+++ b/ibis/backends/tests/test_interactive.py
@@ -119,8 +119,8 @@ def test_scalar_uses_pyarrow(con, table, monkeypatch, mocker):
 
     repr(table.limit(1).string_col)
 
-    # execute doesn't get called
-    execute_spy.assert_not_called()
-
     # pyarrow does get called
     to_pyarrow_spy.assert_called_once()
+
+    # execute doesn't get called
+    execute_spy.assert_not_called()

--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -291,7 +291,7 @@ def _to_rich_scalar(
 ) -> Pretty:
     value = format_values(
         expr.type(),
-        [expr.execute()],
+        [expr.to_pyarrow().as_py()],
         max_length=max_length or ibis.options.repr.interactive.max_length,
         max_string=max_string or ibis.options.repr.interactive.max_string,
         max_depth=max_depth or ibis.options.repr.interactive.max_depth,


### PR DESCRIPTION
Closes #10185.