### PR TITLE
feat(bigquery): non-nullable schema support for embedded fields in struct

### DIFF
--- a/ibis/backends/bigquery/tests/unit/test_datatypes.py
+++ b/ibis/backends/bigquery/tests/unit/test_datatypes.py
@@ -25,6 +25,11 @@ from ibis.backends.bigquery.datatypes import BigQueryType
         param(dt.Array(dt.int64), "ARRAY<INT64>", id="array<int64>"),
         param(dt.Array(dt.string), "ARRAY<STRING>", id="array<string>"),
         param(
+            dt.Struct({"a": dt.String(nullable=False)}),
+            "STRUCT<`a` STRING NOT NULL>",
+            id="struct<a: !string>",
+        ),
+        param(
             dt.Struct.from_tuples(
                 [("a", dt.int64), ("b", dt.string), ("c", dt.Array(dt.string))]
             ),


### PR DESCRIPTION
Bigquery supports embedded non-nullable checks inside bigquery schemas, allowing any non-nullable fields in the schema to persist down into bigquery.

## Description of changes

Override _from_ibis_Struct for bigquery to allow the adding of a non-nullable field constraint

## Issues closed

Resolves #10188, at least for bigquery. There might be opportunities to implement this change in other backends as well.
