### PR TITLE
chore: remove `poetry.lock` from nix label patterns

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -79,7 +79,6 @@ tests:
 nix:
   - changed-files:
       - any-glob-to-any-file: "**/*.nix"
-      - any-glob-to-any-file: "poetry.lock"
 
 datatypes:
   - changed-files:


### PR DESCRIPTION
No sense in adding the nix label for all `poetry.lock` updates.