### PR TITLE
refactor(pyarrow-format): avoid constructing unnecessary array to produce a scalar

### DIFF
--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -304,9 +304,7 @@ class PyArrowData(DataMapper):
             except pa.ArrowNotImplementedError:
                 # pyarrow doesn't support some scalar casts that are supported
                 # when using arrays or tables
-                return pa.array([scalar.as_py()], type=scalar_type).cast(desired_type)[
-                    0
-                ]
+                return pa.scalar(scalar.as_py(), type=scalar_type).cast(desired_type)
         else:
             return scalar
 


### PR DESCRIPTION
No reason to construct an entire array just to access the first and only element; pyarrow has APIs for handling scalars.