### PR TITLE
docs: geospatial install

### DIFF
--- a/docs/backends/duckdb.qmd
+++ b/docs/backends/duckdb.qmd
@@ -171,13 +171,13 @@ pip install 'ibis-framework[geospatial]'
 ## `conda`
 
 ```bash
-conda install -c conda-forge geopandas 'shapely>=2,<3'
+conda install -c conda-forge ibis-framework geopandas 'shapely>=2,<3'
 ```
 
 ## `mamba`
 
 ```bash
-mamba install -c conda-forge geopandas 'shapely>=2,<3'
+mamba install -c conda-forge ibis-framework geopandas 'shapely>=2,<3'
 ```
 
 :::


### PR DESCRIPTION
Noticed the conda/mamba install commands for geopspatial tools was missing ibis-framework