### PR TITLE
fix(sql): standardize NULL handling of `argmin`/`argmax`

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1256,20 +1256,15 @@ def execute_hash(op, **kw):
 
 
 def _arg_min_max(op, func, **kw):
-    key = op.key
-    arg = op.arg
+    key = translate(op.key, **kw)
+    arg = translate(op.arg, **kw)
 
-    if (op_where := op.where) is not None:
-        key = ops.IfElse(op_where, key, None)
-        arg = ops.IfElse(op_where, arg, None)
+    if op.where is not None:
+        where = translate(op.where, **kw)
+        arg = arg.filter(where)
+        key = key.filter(where)
 
-    translate_arg = translate(arg, **kw)
-    translate_key = translate(key, **kw)
-
-    not_null_mask = translate_arg.is_not_null() & translate_key.is_not_null()
-    return translate_arg.filter(not_null_mask).get(
-        func(translate_key.filter(not_null_mask))
-    )
+    return arg.get(func(key))
 
 
 @translate.register(ops.ArgMax)

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -306,8 +306,6 @@ class SQLGlotCompiler(abc.ABC):
         ops.All: "bool_and",
         ops.Any: "bool_or",
         ops.ApproxCountDistinct: "approx_distinct",
-        ops.ArgMax: "max_by",
-        ops.ArgMin: "min_by",
         ops.ArrayContains: "array_contains",
         ops.ArrayFlatten: "flatten",
         ops.ArrayLength: "array_size",

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -200,6 +200,8 @@ class BigQueryCompiler(SQLGlotCompiler):
         ops.TimeFromHMS: "time_from_parts",
         ops.TimestampNow: "current_timestamp",
         ops.ExtractHost: "net.host",
+        ops.ArgMin: "min_by",
+        ops.ArgMax: "max_by",
     }
 
     def to_sqlglot(

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -62,8 +62,6 @@ class ClickHouseCompiler(SQLGlotCompiler):
         ops.ApproxCountDistinct: "uniqHLL12",
         ops.ApproxMedian: "median",
         ops.Arbitrary: "any",
-        ops.ArgMax: "argMax",
-        ops.ArgMin: "argMin",
         ops.ArrayContains: "has",
         ops.ArrayFlatten: "arrayFlatten",
         ops.ArrayIntersect: "arrayIntersect",
@@ -672,6 +670,18 @@ class ClickHouseCompiler(SQLGlotCompiler):
                 "`include_null=True` is not supported by the clickhouse backend"
             )
         return self.agg.anyLast(arg, where=where, order_by=order_by)
+
+    def visit_ArgMin(self, op, *, arg, key, where):
+        return sge.Dot(
+            this=self.agg.argMin(self.f.tuple(arg), key, where=where),
+            expression=sge.convert(1),
+        )
+
+    def visit_ArgMax(self, op, *, arg, key, where):
+        return sge.Dot(
+            this=self.agg.argMax(self.f.tuple(arg), key, where=where),
+            expression=sge.convert(1),
+        )
 
     def visit_CountDistinctStar(
         self, op: ops.CountDistinctStar, *, where, **_: Any

--- a/ibis/backends/sql/compilers/druid.py
+++ b/ibis/backends/sql/compilers/druid.py
@@ -25,8 +25,6 @@ class DruidCompiler(SQLGlotCompiler):
 
     UNSUPPORTED_OPS = (
         ops.ApproxMedian,
-        ops.ArgMax,
-        ops.ArgMin,
         ops.ArrayDistinct,
         ops.ArrayFilter,
         ops.ArrayFlatten,

--- a/ibis/backends/sql/compilers/duckdb.py
+++ b/ibis/backends/sql/compilers/duckdb.py
@@ -543,6 +543,14 @@ class DuckDBCompiler(SQLGlotCompiler):
             where = cond if where is None else sge.And(this=cond, expression=where)
         return self.agg.last(arg, where=where, order_by=order_by)
 
+    def visit_ArgMin(self, op, *, arg, key, where):
+        return self.agg.first(arg, where=where, order_by=[sge.Ordered(this=key)])
+
+    def visit_ArgMax(self, op, *, arg, key, where):
+        return self.agg.first(
+            arg, where=where, order_by=[sge.Ordered(this=key, desc=True)]
+        )
+
     def visit_Quantile(self, op, *, arg, quantile, where):
         suffix = "cont" if op.arg.dtype.is_numeric() else "disc"
         funcname = f"percentile_{suffix}"

--- a/ibis/backends/sql/compilers/exasol.py
+++ b/ibis/backends/sql/compilers/exasol.py
@@ -32,8 +32,6 @@ class ExasolCompiler(SQLGlotCompiler):
 
     UNSUPPORTED_OPS = (
         ops.AnalyticVectorizedUDF,
-        ops.ArgMax,
-        ops.ArgMin,
         ops.ArrayDistinct,
         ops.ArrayFilter,
         ops.ArrayFlatten,

--- a/ibis/backends/sql/compilers/flink.py
+++ b/ibis/backends/sql/compilers/flink.py
@@ -69,8 +69,6 @@ class FlinkCompiler(SQLGlotCompiler):
     UNSUPPORTED_OPS = (
         ops.AnalyticVectorizedUDF,
         ops.ApproxMedian,
-        ops.ArgMax,
-        ops.ArgMin,
         ops.ArrayFlatten,
         ops.ArrayStringJoin,
         ops.Correlation,

--- a/ibis/backends/sql/compilers/impala.py
+++ b/ibis/backends/sql/compilers/impala.py
@@ -30,8 +30,6 @@ class ImpalaCompiler(SQLGlotCompiler):
     }
 
     UNSUPPORTED_OPS = (
-        ops.ArgMax,
-        ops.ArgMin,
         ops.ArrayPosition,
         ops.Array,
         ops.Covariance,

--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -82,8 +82,6 @@ class MSSQLCompiler(SQLGlotCompiler):
 
     UNSUPPORTED_OPS = (
         ops.ApproxMedian,
-        ops.ArgMax,
-        ops.ArgMin,
         ops.Array,
         ops.ArrayDistinct,
         ops.ArrayFlatten,

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -65,8 +65,6 @@ class MySQLCompiler(SQLGlotCompiler):
     NEG_INF = POS_INF
     UNSUPPORTED_OPS = (
         ops.ApproxMedian,
-        ops.ArgMax,
-        ops.ArgMin,
         ops.Array,
         ops.ArrayFlatten,
         ops.ArrayMap,

--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -51,8 +51,6 @@ class OracleCompiler(SQLGlotCompiler):
     }
 
     UNSUPPORTED_OPS = (
-        ops.ArgMax,
-        ops.ArgMin,
         ops.Array,
         ops.ArrayFlatten,
         ops.ArrayMap,

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -70,6 +70,8 @@ class PySparkCompiler(SQLGlotCompiler):
     }
 
     SIMPLE_OPS = {
+        ops.ArgMax: "max_by",
+        ops.ArgMin: "min_by",
         ops.ArrayDistinct: "array_distinct",
         ops.ArrayFlatten: "flatten",
         ops.ArrayIntersect: "array_intersect",

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -106,6 +106,8 @@ class SnowflakeCompiler(SQLGlotCompiler):
     SIMPLE_OPS = {
         ops.All: "min",
         ops.Any: "max",
+        ops.ArgMax: "max_by",
+        ops.ArgMin: "min_by",
         ops.ArrayDistinct: "array_distinct",
         ops.ArrayFlatten: "array_flatten",
         ops.ArrayIndex: "get",

--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -206,12 +206,7 @@ class SQLiteCompiler(SQLGlotCompiler):
         return self._visit_arg_reduction("max", *args, **kwargs)
 
     def _visit_arg_reduction(self, func, op, *, arg, key, where):
-        cond = arg.is_(sg.not_(NULL))
-
-        if op.where is not None:
-            cond = sg.and_(cond, where)
-
-        agg = self.agg[func](key, where=cond)
+        agg = self.agg[func](key, where=where)
         return self.f.anon.json_extract(self.f.json_array(arg, agg), "$[0]")
 
     def visit_UnwrapJSONString(self, op, *, arg):

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -60,6 +60,8 @@ class TrinoCompiler(SQLGlotCompiler):
 
     SIMPLE_OPS = {
         ops.Arbitrary: "any_value",
+        ops.ArgMax: "max_by",
+        ops.ArgMin: "min_by",
         ops.Pi: "pi",
         ops.E: "e",
         ops.RegexReplace: "regexp_replace",

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -691,6 +691,40 @@ def test_first_last_ordered(alltypes, method, filtered, include_null):
 
 @pytest.mark.notimpl(
     [
+        "datafusion",
+        "druid",
+        "exasol",
+        "flink",
+        "impala",
+        "mssql",
+        "mysql",
+        "oracle",
+    ],
+    raises=com.OperationNotDefinedError,
+)
+@pytest.mark.parametrize("method", ["argmin", "argmax"])
+@pytest.mark.parametrize("filtered", [True, False], ids=["filtered", "unfiltered"])
+@pytest.mark.parametrize("null_result", [True, False], ids=["null", "non-null"])
+def test_argmin_argmax(alltypes, method, filtered, null_result):
+    t = alltypes.mutate(by_col=_.int_col.nullif(0).nullif(9), val_col=10 * _.int_col)
+
+    if filtered:
+        where = _.int_col != (1 if method == "argmin" else 8)
+        sol = 20 if method == "argmin" else 70
+    else:
+        where = None
+        sol = 10 if method == "argmin" else 80
+
+    if null_result:
+        t = t.mutate(val_col=_.val_col.nullif(sol))
+
+    expr = getattr(t.val_col, method)("by_col", where=where)
+    res = expr.execute()
+    assert pd.isna(res) if null_result else res == sol
+
+
+@pytest.mark.notimpl(
+    [
         "impala",
         "mysql",
         "mssql",

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -123,7 +123,6 @@ aggregate_test_params = [
 ]
 
 argidx_not_grouped_marks = [
-    "datafusion",
     "impala",
     "mysql",
     "mssql",
@@ -411,7 +410,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     [
                         "impala",
                         "mysql",
-                        "datafusion",
                         "mssql",
                         "druid",
                         "oracle",
@@ -431,7 +429,6 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
                     [
                         "impala",
                         "mysql",
-                        "datafusion",
                         "mssql",
                         "druid",
                         "oracle",
@@ -691,7 +688,6 @@ def test_first_last_ordered(alltypes, method, filtered, include_null):
 
 @pytest.mark.notimpl(
     [
-        "datafusion",
         "druid",
         "exasol",
         "flink",

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1766,6 +1766,9 @@ class Column(Value, _FixedTextJupyterMixin):
     def argmax(self, key: ir.Value, where: ir.BooleanValue | None = None) -> Scalar:
         """Return the value of `self` that maximizes `key`.
 
+        If more than one value maximizes `key`, the returned value is backend
+        specific. The result may be `NULL`.
+
         Parameters
         ----------
         key
@@ -1800,6 +1803,9 @@ class Column(Value, _FixedTextJupyterMixin):
 
     def argmin(self, key: ir.Value, where: ir.BooleanValue | None = None) -> Scalar:
         """Return the value of `self` that minimizes `key`.
+
+        If more than one value minimizes `key`, the returned value is backend
+        specific. The result may be `NULL`.
 
         Parameters
         ----------


### PR DESCRIPTION
This standardizes the NULL handling behavior of `argmin`/`argmax` to better match user expectations and the common implementation of the SQL `min_by`/`max_by` methods.

Previously some backends would jump through hoops to avoid returning `NULL` values from these methods, even if the value that minimized the column was `NULL`. We now no longer do this (and workaround the compatibility issues in a few backends that did this by default). Fixes #10193.