### PR TITLE
chore(backends): convert scalars to non-numpy python objects

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1065,15 +1065,10 @@ def test_int_column(alltypes):
     assert result.dtype == np.int8
 
 
-@pytest.mark.notimpl(["druid", "oracle"])
-@pytest.mark.never(
-    ["bigquery", "sqlite", "snowflake"], reason="backend only implements int64"
-)
 def test_int_scalar(alltypes):
     expr = alltypes.int_col.min()
-    result = expr.execute()
-    assert expr.type() == dt.int32
-    assert result.dtype == np.int32
+    assert expr.type().is_integer()
+    assert isinstance(expr.execute(), int)
 
 
 @pytest.mark.notimpl(["datafusion", "polars", "druid"])

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -199,11 +199,11 @@ def param(type: dt.DataType) -> ir.Scalar:
     ... )
     >>> expr = t.filter(t.date_col >= start).value.sum()
     >>> expr.execute(params={start: date(2013, 1, 1)})
-    np.float64(6.0)
+    6.0
     >>> expr.execute(params={start: date(2013, 1, 2)})
-    np.float64(5.0)
+    5.0
     >>> expr.execute(params={start: date(2013, 1, 3)})
-    np.float64(3.0)
+    3.0
     """
     return ops.ScalarParameter(type).to_expr()
 

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -239,8 +239,7 @@ class scalar(_UDF):
         >>> expr = hamming("duck", "luck")
         >>> con = ibis.connect("duckdb://")
         >>> con.execute(expr)
-        np.int64(1)
-
+        1
         """
         return _wrap(
             cls._make_wrapper,

--- a/ibis/formats/pandas.py
+++ b/ibis/formats/pandas.py
@@ -149,7 +149,18 @@ class PandasData(DataMapper):
     @classmethod
     def convert_scalar(cls, obj, dtype):
         df = PandasData.convert_table(obj, sch.Schema({str(obj.columns[0]): dtype}))
-        return df.iat[0, 0]
+        value = df.iat[0, 0]
+
+        if dtype.is_array():
+            try:
+                return value.tolist()
+            except AttributeError:
+                return value
+
+        try:
+            return value.item()
+        except AttributeError:
+            return value
 
     @classmethod
     def convert_GeoSpatial(cls, s, dtype, pandas_type):


### PR DESCRIPTION
This PR converts scalar numpy objects into their non-numpy Python equivalents for consistent scalar return types for all backends.

BREAKING CHANGE: `execute` now returns non-numpy objects for scalar values.