### PR TITLE
docs: update README backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This allows you to combine the flexibility of Python with the scale and performa
 
 ## Backends
 
-Ibis supports 20+ backends:
+Ibis supports nearly 20 backends:
 
 - [Apache DataFusion](https://ibis-project.org/backends/datafusion/)
 - [Apache Druid](https://ibis-project.org/backends/druid/)
@@ -148,7 +148,6 @@ Ibis supports 20+ backends:
 - [Exasol](https://ibis-project.org/backends/exasol)
 - [MySQL](https://ibis-project.org/backends/mysql/)
 - [Oracle](https://ibis-project.org/backends/oracle/)
-- [pandas](https://ibis-project.org/backends/pandas/)
 - [Polars](https://ibis-project.org/backends/polars/)
 - [PostgreSQL](https://ibis-project.org/backends/postgresql/)
 - [RisingWave](https://ibis-project.org/backends/risingwave/)


### PR DESCRIPTION
## Description of changes

Removing pandas from the list of backends in the README and adjusting the phrasing around the count. 

I wasn't sure whether to say "15+ backends" or "nearly 20," so I opted for the latter, which was closer to the actual number, 18.