### PR TITLE
refactor(ir): remove unnecessary overrides of `relations` property

### DIFF
--- a/ibis/expr/operations/core.py
+++ b/ibis/expr/operations/core.py
@@ -160,10 +160,6 @@ class Unary(Value):
     def shape(self) -> ds.DataShape:
         return self.arg.shape
 
-    @attribute
-    def relations(self):
-        return self.arg.relations
-
 
 @public
 class Binary(Value):
@@ -175,10 +171,6 @@ class Binary(Value):
     @attribute
     def shape(self) -> ds.DataShape:
         return max(self.left.shape, self.right.shape)
-
-    @attribute
-    def relations(self):
-        return self.left.relations | self.right.relations
 
 
 @public

--- a/ibis/expr/operations/reductions.py
+++ b/ibis/expr/operations/reductions.py
@@ -45,10 +45,6 @@ class CountStar(Filterable, Reduction):
 
     dtype = dt.int64
 
-    @attribute
-    def relations(self):
-        return frozenset({self.arg})
-
 
 @public
 class CountDistinctStar(Filterable, Reduction):
@@ -57,10 +53,6 @@ class CountDistinctStar(Filterable, Reduction):
     arg: Relation
 
     dtype = dt.int64
-
-    @attribute
-    def relations(self):
-        return frozenset({self.arg})
 
 
 @public


### PR DESCRIPTION
These overrides are redundant with the parent class implementation.