### PR TITLE
feat(api): add `to_geo` methods for writing geospatial output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,10 +81,11 @@
       ];
 
       mkDevShell = env: pkgs.mkShell {
-        name = "ibis-${env.python.version}";
-        nativeBuildInputs = (with pkgs; [
+        name = "ibis-${env.pythonVersion}";
+        nativeBuildInputs = [
           # python dev environment
           env
+        ] ++ (with pkgs; [
           # poetry executable
           poetry
           # rendering release notes
@@ -116,6 +117,8 @@
           [FreeTDS]
           Driver = ${pkgs.lib.makeLibraryPath [ pkgs.freetds ]}/libtdsodbc.so
         '';
+
+        GDAL_DATA = "${pkgs.gdal}/share/gdal";
 
         __darwinAllowLocalNetworking = true;
       };


### PR DESCRIPTION
Adds an experimental `to_geo` method to the duckdb backend.

Closes #10296.