### PR TITLE
fix(mssql): exclude window frame from rank

### DIFF
--- a/ibis/backends/mssql/tests/snapshots/test_window/test_rank_no_window_frame/out.sql
+++ b/ibis/backends/mssql/tests/snapshots/test_window/test_rank_no_window_frame/out.sql
@@ -1,0 +1,5 @@
+SELECT
+  [t0].[color],
+  [t0].[price],
+  RANK() OVER (PARTITION BY [t0].[color] ORDER BY CASE WHEN [t0].[price] IS NULL THEN 1 ELSE 0 END, [t0].[price] ASC) - 1 AS [MinRank()]
+FROM [diamonds_sample] AS [t0]

--- a/ibis/backends/mssql/tests/test_window.py
+++ b/ibis/backends/mssql/tests/test_window.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import ibis
+
+
+def test_rank_no_window_frame(con, snapshot):
+    t = ibis.table(schema=dict(color=str, price=int), name="diamonds_sample")
+    expr = t.mutate(ibis.rank().over(group_by="color", order_by="price"))
+    sql = ibis.to_sql(expr, dialect="mssql")
+
+    snapshot.assert_match(sql, "out.sql")

--- a/ibis/backends/sql/compilers/mssql.py
+++ b/ibis/backends/sql/compilers/mssql.py
@@ -21,6 +21,7 @@ from ibis.backends.sql.datatypes import MSSQLType
 from ibis.backends.sql.dialects import MSSQL
 from ibis.backends.sql.rewrites import (
     exclude_unsupported_window_frame_from_ops,
+    exclude_unsupported_window_frame_from_rank,
     exclude_unsupported_window_frame_from_row_number,
     lower_sample,
     p,
@@ -68,6 +69,7 @@ class MSSQLCompiler(SQLGlotCompiler):
     rewrites = (
         exclude_unsupported_window_frame_from_ops,
         exclude_unsupported_window_frame_from_row_number,
+        exclude_unsupported_window_frame_from_rank,
         rewrite_rows_range_order_by_window,
         *SQLGlotCompiler.rewrites,
     )


### PR DESCRIPTION
## Description of changes

Resolves an error where the RANK window function added a `ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING` window frame, which is unsupported by MSSQL. 

> The <rows or range clause/> of the OVER clause cannot be specified for the RANK function. For more information, see [OVER Clause (Transact-SQL)](https://learn.microsoft.com/en-us/sql/t-sql/queries/select-over-clause-transact-sql?view=sql-server-ver16).

## Issues closed

Resolves #10291 
