### PR TITLE
feat(polars): add ArrayIndex operation

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1481,3 +1481,10 @@ def execute_date_delta(op, **kw):
     delta = left - right
     method_name = f"total_{_literal_value(op.part)}s"
     return getattr(delta.dt, method_name)()
+
+
+@translate.register(ops.ArrayIndex)
+def execute_array_index(op, **kw):
+    arg = translate(op.arg, **kw)
+    index = translate(op.index, **kw)
+    return arg.list.get(index)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -204,7 +204,6 @@ def test_np_array_literal(con):
 
 
 @pytest.mark.parametrize("idx", range(3))
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 def test_array_index(con, idx):
     arr = [1, 2, 3]
     expr = ibis.literal(arr)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -406,10 +406,7 @@ def test_unnest_default_name(backend):
         ),
     ],
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
-@pytest.mark.notimpl(
-    ["datafusion"], raises=Exception, reason="array_types table isn't defined"
-)
+@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
 def test_array_slice(backend, start, stop):
     array_types = backend.array_types
     expr = array_types.select(sliced=array_types.y[start:stop])


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds the ArrayIndex operation to the Polars backend. 

I also fixed one of the markers for the DataFusion backend as well, it looks like the `array_types` tables gets created in the conftest.

https://github.com/ibis-project/ibis/blob/f817a7ad6ed5ba02afa5e1208896ba8e03439858/ibis/backends/datafusion/tests/conftest.py#L32