### PR TITLE
docs: fix typo in query docstring

### DIFF
--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -1437,7 +1437,7 @@ class StringValue(Value):
         return ops.ExtractPath(self).to_expr()
 
     def query(self, key: str | StringValue | None = None):
-        """Parse a URL and returns query strring or query string parameter.
+        """Parse a URL and returns query string or query string parameter.
 
         If key is passed, return the value of the query string parameter named.
         If key is absent, return the query string.


### PR DESCRIPTION
## Description of changes

Ironically, the word string was misspelled in the docstring of a method in the strings file. 😄 

I opened https://github.com/codespell-project/codespell/pull/3565 so that this may be automatically caught in the future (if approved). 