### PR TITLE
feat(polars): add ArraySlice operation

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -406,7 +406,7 @@ def test_unnest_default_name(backend):
         ),
     ],
 )
-@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 def test_array_slice(backend, start, stop):
     array_types = backend.array_types
     expr = array_types.select(sliced=array_types.y[start:stop])


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds support for ArraySlicing by pushing down `pl.list.slice` methods on the array following the Python style of slicing. 

I wasn't sure if it was best to include an inner function, but it seemed to help avoid a bit of redundancy. 
