### PR TITLE
feat(polars): add ArrayRemove operation

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1521,3 +1521,10 @@ def visit_ArrayContains(op, **kw):
     arg = translate(op.arg, **kw)
     value = translate(op.other, **kw)
     return arg.list.contains(value)
+
+
+@translate.register(ops.ArrayRemove)
+def visit_ArrayRemove(op, **kw):
+    arg = translate(op.arg, **kw)
+    value = _literal_value(op.other)
+    return arg.list.set_difference(pl.lit([value]))

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -680,7 +680,6 @@ def test_array_position(con, a, expected_array):
 
 
 @builtin_array
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.parametrize(
     ("input", "expected"),
     [


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds ArrayRemove support for the Polars backend via [polars.Series.list.set_difference](https://docs.pola.rs/api/python/stable/reference/series/api/polars.Series.list.set_difference.html#).

I didn't `translate` `op.other` this time around, I was having issues when doing that (it wasn't returning anything for some reason). Happy to make any changes if it is necessary to do the `translate` or otherwise adjust.
