### PR TITLE
feat(polars): add ArrayUnion operation

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1532,3 +1532,10 @@ def visit_ArrayRemove(op, **kw):
     arg = translate(op.arg, **kw)
     value = _literal_value(op.other)
     return arg.list.set_difference(pl.lit([value]))
+
+
+@translate.register(ops.ArrayUnion)
+def visit_ArrayUnion(op, **kw):
+    left = translate(op.left, **kw)
+    right = translate(op.right, **kw)
+    return left.list.set_union(right)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -832,7 +832,6 @@ def test_array_sort(con, data):
 
 
 @builtin_array
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.parametrize(
     ("a", "b", "expected_array"),
     [
@@ -853,9 +852,9 @@ def test_array_sort(con, data):
                     reason="BigQuery doesn't support arrays with null elements",
                 ),
                 pytest.mark.notyet(
-                    ["datafusion"],
+                    ["datafusion", "polars"],
                     raises=AssertionError,
-                    reason="DataFusion transforms null elements to NAN",
+                    reason="Null elements are transformed to NaN",
                 ),
                 pytest.mark.notyet(
                     ["pyspark"],


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Implements ArrayUnion with [pl.Series.list.set_union](https://docs.pola.rs/api/python/stable/reference/series/api/polars.Series.list.set_union.html#). 

### Reasoning for test marker adjustment

I was also running into the NaN issue that occurs with DataFusion. Here's some code I was using to test this.

```pycon
In [1]: import polars as pl
   ...: from ibis.interactive import *

In [2]: left, right = [[3, 2], [], []], [[1, 3], [None], [5]]

In [3]: df = pl.DataFrame([left, right], schema=["left", "right"])

In [4]: df
Out[4]: 
shape: (3, 2)
┌───────────┬───────────┐
│ left      ┆ right     │
│ ---       ┆ ---       │
│ list[i64] ┆ list[i64] │
╞═══════════╪═══════════╡
│ [3, 2]    ┆ [1, 3]    │
│ []        ┆ [null]    │
│ []        ┆ [5]       │
└───────────┴───────────┘

In [5]: duck_con = ibis.connect("duckdb://")
   ...: polars_con = ibis.connect("polars://")

In [6]: for con in (duck_con, polars_con):
   ...:     t = con.create_table("t", df, overwrite=True)
   ...:     expr = t.left.union(t.right)
   ...:     print(t.get_backend().name)
   ...:     print(con.execute(expr))
   ...: 
duckdb
0    [1, 2, 3]
1       [None]
2          [5]
Name: ArrayUnion(left, right), dtype: object
polars
0    [3.0, 2.0, 1.0]
1              [nan]
2              [5.0]
Name: ArrayUnion(left, right), dtype: object
```

The following is mentioned in the docs at https://docs.pola.rs/user-guide/expressions/missing-data/#notanumber-or-nan-values:

> In pandas by default a NaN value in an integer column causes the column to be cast to float. This does not happen in Polars - instead an exception is raised.

I wonder if this happens when going to pandas by way of `execute`. 