### PR TITLE
fix(mssql): catch and bubble up exceptions from .sql

### DIFF
--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -8,6 +8,7 @@ import sqlglot.expressions as sge
 from pytest import param
 
 import ibis
+import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 from ibis import udf
 from ibis.backends.mssql.tests.conftest import (
@@ -261,6 +262,11 @@ def test_dot_sql_with_unnamed_columns(con):
 
     df = expr.execute()
     assert len(df) == 1
+
+
+def test_dot_sql_error_handling(con):
+    with pytest.raises(com.IbisInputError, match="Invalid column name"):
+        con.sql("SELECT not_a_column")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description of changes

`dm_exec_describe_first_result_set` can return error codes and error messages.
In order to better handle invalid SQL being passed to `.sql`, we check that the
`err_num` isn't NULL (NULL indicates success (because of course it does)) and
then raise the corresponding error message.


## Issues closed

Fixes #10331
