### PR TITLE
fix(duckdb): use simple GEOMETRY type for all geospatial data (#10324)

### DIFF
--- a/ibis/backends/duckdb/tests/test_geospatial.py
+++ b/ibis/backends/duckdb/tests/test_geospatial.py
@@ -562,3 +562,11 @@ def test_to_geo_geom_only(con, driver, tmp_path):
     dread = con.read_geo(out)
 
     assert dread.count().execute() == 2
+
+
+def test_cache_geometry(con):
+    # ibis issue #10324
+    data = ibis.memtable({"x": [1, 3], "y": [2, 4]})
+    data = data.mutate(geom=data.x.point(data.y)).cache()
+    result = data.execute()
+    assert result["geom"].iloc[0] == shapely.Point(1, 2)

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -624,6 +624,10 @@ class DuckDBType(SqlglotType):
         ), "DuckDB only supports geometry types; geography types are not supported"
         return sge.DataType(this=typecode.GEOMETRY)
 
+    _from_ibis_Point = _from_ibis_LineString = _from_ibis_Polygon = (
+        _from_ibis_MultiLineString
+    ) = _from_ibis_MultiPoint = _from_ibis_MultiPolygon = _from_ibis_GeoSpatial
+
 
 class TrinoType(SqlglotType):
     dialect = "trino"


### PR DESCRIPTION
Ensure compatibility with DuckDB's implementation of geospatial types.

I would love to add tests. Which is the appropriate test file?

- [ ] added tests 

## Description of changes

In https://github.com/ibis-project/ibis/issues/10324 the temporary table generated the incorrect SQL definition of `GEOMETRY(POINT)` instead of the simple `GEOMETRY`. This ensures that the simple `GEOMETRY` will be used for all geospatial types.

## Issues closed

* Resolves #10324 
