### PR TITLE
feat(polars): add ArrayDistinct operation

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1539,3 +1539,9 @@ def visit_ArrayUnion(op, **kw):
     left = translate(op.left, **kw)
     right = translate(op.right, **kw)
     return left.list.set_union(right)
+
+
+@translate.register(ops.ArrayDistinct)
+def visit_ArrayDistinct(op, **kw):
+    arg = translate(op.arg, **kw)
+    return arg.list.unique()

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -749,7 +749,7 @@ def test_array_remove(con, input, expected):
 
 
 @builtin_array
-@pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
+@pytest.mark.notimpl(["datafusion"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(
     ["sqlite"], raises=com.UnsupportedBackendType, reason="Unsupported type: Array..."
 )
@@ -779,6 +779,11 @@ def test_array_remove(con, input, expected):
             [{3, 1}, set(), {42}, set(), {None}, None],
             id="null",
             marks=[
+                pytest.mark.notyet(
+                    ["polars"],
+                    raises=AssertionError,
+                    reason="Null elements are transformed to NaN",
+                ),
                 pytest.mark.notyet(
                     ["pyspark"],
                     condition=IS_SPARK_REMOTE,


### PR DESCRIPTION
## Description of changes

Implements ArrayUnion with [pl.Series.list.unique](https://docs.pola.rs/api/python/stable/reference/series/api/polars.Series.list.unique.html).

### The test marker

Similar to what I was experiencing when implementing `ArrayUnion`, I'm getting nan/floats when there is a None in the `array<int64>` column. Here is some of the code I was using to test this behavior:

```pycon
In [1]: import polars as pl
   ...: from ibis.interactive import *

In [2]: d_con = ibis.connect("duckdb://")
   ...: p_con = ibis.connect("polars://")

In [3]: df = pl.DataFrame({"a": [[1, 3, 3], [], [42, 42], [], [None], None]})
   ...: t = ibis.memtable(df)

In [4]: expr = t.select("a", uniqued=_.a.unique())

In [5]: d_con.execute(expr)
Out[5]: 
           a uniqued
0  [1, 3, 3]  [3, 1]
1         []      []
2   [42, 42]    [42]
3         []      []
4     [None]  [None]
5       None    None

In [6]: p_con.execute(expr)
Out[6]: 
                 a     uniqued
0  [1.0, 3.0, 3.0]  [1.0, 3.0]
1               []          []
2     [42.0, 42.0]      [42.0]
3               []          []
4            [nan]       [nan]
5             None        None

In [7]: df.select(pl.col("a"), pl.col("a").list.unique().alias("uniqued"))
Out[7]: 
shape: (6, 2)
┌───────────┬───────────┐
│ a         ┆ uniqued   │
│ ---       ┆ ---       │
│ list[i64] ┆ list[i64] │
╞═══════════╪═══════════╡
│ [1, 3, 3] ┆ [1, 3]    │
│ []        ┆ []        │
│ [42, 42]  ┆ [42]      │
│ []        ┆ []        │
│ [null]    ┆ [null]    │
│ null      ┆ null      │
└───────────┴───────────┘
```