### PR TITLE
Introducing Ibis Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Build status](https://github.com/ibis-project/ibis/actions/workflows/ibis-main.yml/badge.svg)](https://github.com/ibis-project/ibis/actions/workflows/ibis-main.yml?query=branch%3Amain)
 [![Build status](https://github.com/ibis-project/ibis/actions/workflows/ibis-backends.yml/badge.svg)](https://github.com/ibis-project/ibis/actions/workflows/ibis-backends.yml?query=branch%3Amain)
 [![Codecov branch](https://img.shields.io/codecov/c/github/ibis-project/ibis/main.svg)](https://codecov.io/gh/ibis-project/ibis)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Ibis%20Guru-006BFF)](https://gurubase.io/g/ibis)
 
 ## What is Ibis?
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Ibis Guru](https://gurubase.io/g/ibis) to Gurubase. Ibis Guru uses the data from this repo and data from the [docs](https://ibis-project.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Ibis Guru" badge, which highlights that Ibis now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Ibis Guru in Gurubase, just let me know that's totally fine.
