### PR TITLE
docs: correct link generated in operations matrix

### DIFF
--- a/docs/backends/support/matrix.qmd
+++ b/docs/backends/support/matrix.qmd
@@ -88,7 +88,7 @@ def make_support_matrix():
 
     def make_link(parts):
         module, op = parts[-2:]
-        return f'<a href="./operations.html#ibis.expr.operations.{module}.{op}">{op}</a>'
+        return f'<a href="/reference/operations#ibis.expr.operations.{module}.{op}">{op}</a>'
 
     support_matrix = (
         pd.DataFrame(support)


### PR DESCRIPTION
## Description of changes

The [operation support matrix](https://ibis-project.org/backends/support/matrix) has links to each operation, but they don’t work. This fixes that by updating the link to the current address of those operations.

## Issues closed

- Resolves #10270
