### PR TITLE
fix(api): ensure consistent typing in `round` output type

### DIFF
--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_translate_math_functions/round/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_translate_math_functions/round/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  ROUND("t0"."double_col") AS "Round(double_col)"
+  CAST(ROUND("t0"."double_col", 0) AS Nullable(Int64)) AS "Round(double_col, 0)"
 FROM "functional_alltypes" AS "t0"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_translate_math_functions/round_0/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_translate_math_functions/round_0/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  ROUND("t0"."double_col", 0) AS "Round(double_col, 0)"
+  CAST(ROUND("t0"."double_col", 0) AS Nullable(Int64)) AS "Round(double_col, 0)"
 FROM "functional_alltypes" AS "t0"

--- a/ibis/backends/clickhouse/tests/snapshots/test_functions/test_translate_math_functions/round_2/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_functions/test_translate_math_functions/round_2/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  ROUND("t0"."double_col", 2) AS "Round(double_col, 2)"
+  CAST(ROUND("t0"."double_col", 2) AS Nullable(Float64)) AS "Round(double_col, 2)"
 FROM "functional_alltypes" AS "t0"

--- a/ibis/backends/impala/tests/snapshots/test_unary_builtins/test_numeric/round_no_args/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_unary_builtins/test_numeric/round_no_args/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  CAST(ROUND(`t0`.`double_col`) AS BIGINT) AS `Round(double_col)`
+  CAST(ROUND(`t0`.`double_col`, 0) AS BIGINT) AS `Round(double_col, 0)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/impala/tests/snapshots/test_unary_builtins/test_numeric/round_zero/out.sql
+++ b/ibis/backends/impala/tests/snapshots/test_unary_builtins/test_numeric/round_zero/out.sql
@@ -1,3 +1,3 @@
 SELECT
-  ROUND(`t0`.`double_col`, 0) AS `Round(double_col, 0)`
+  CAST(ROUND(`t0`.`double_col`, 0) AS BIGINT) AS `Round(double_col, 0)`
 FROM `functional_alltypes` AS `t0`

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -856,9 +856,7 @@ class SQLGlotCompiler(abc.ABC):
         return self.cast(self.f.floor(arg), op.dtype)
 
     def visit_Round(self, op, *, arg, digits):
-        if digits is not None:
-            return sge.Round(this=arg, decimals=digits)
-        return sge.Round(this=arg)
+        return self.cast(self.f.round(arg, digits), op.dtype)
 
     ### Random Noise
 

--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -500,5 +500,10 @@ class OracleCompiler(SQLGlotCompiler):
         # remove.
         return self.visit_RStrip(op, arg=self.visit_LStrip(op, arg=arg))
 
+    def visit_Round(self, op, *, arg, digits):
+        if op.dtype.is_integer():
+            return self.f.round(arg)
+        return self.cast(self.f.round(arg, digits), op.dtype)
+
 
 compiler = OracleCompiler()

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -535,13 +535,14 @@ class PostgresCompiler(SQLGlotCompiler):
         )
 
     def visit_Round(self, op, *, arg, digits):
-        if digits is None:
-            return self.f.round(arg)
+        dtype = op.dtype
 
-        result = self.f.round(self.cast(arg, dt.decimal), digits)
-        if op.arg.dtype.is_decimal():
-            return result
-        return self.cast(result, dt.float64)
+        if dtype.is_integer():
+            result = self.f.round(arg)
+        else:
+            result = self.f.round(self.cast(arg, dt.decimal), digits)
+
+        return self.cast(result, dtype)
 
     def visit_Modulus(self, op, *, left, right):
         # postgres doesn't allow modulus of double precision values, so upcast and

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -1516,3 +1516,25 @@ def test_bitwise_not_col(backend, alltypes, df):
     result = expr.execute()
     expected = ~df.int_col
     backend.assert_series_equal(result, expected.rename("tmp"))
+
+
+def test_column_round_is_integer(con):
+    t = ibis.memtable({"x": [1.2, 3.4]})
+    expr = t.x.round().cast(int)
+    result = con.execute(expr)
+
+    one, three = sorted(result.tolist())
+
+    assert one == 1
+    assert isinstance(one, int)
+
+    assert three == 3
+    assert isinstance(three, int)
+
+
+def test_scalar_round_is_integer(con):
+    expr = ibis.literal(1.2).round().cast(int)
+    result = con.execute(expr)
+
+    assert result == 1
+    assert isinstance(result, int)

--- a/ibis/expr/tests/snapshots/test_format/test_aggregate_arg_names/repr.txt
+++ b/ibis/expr/tests/snapshots/test_format/test_aggregate_arg_names/repr.txt
@@ -14,7 +14,7 @@ r0 := UnboundTable: alltypes
 Aggregate[r0]
   groups:
     key1: r0.g
-    key2: Round(r0.f)
+    key2: Round(r0.f, digits=0)
   metrics:
     c: Sum(r0.c)
     d: Mean(r0.d)

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -56,7 +56,7 @@ class NumericValue(Value):
         """
         return self.negate()
 
-    def round(self, digits: int | IntegerValue | None = None) -> NumericValue:
+    def round(self, digits: int | IntegerValue = 0) -> NumericValue:
         """Round values to an indicated number of decimal places.
 
         Parameters
@@ -94,16 +94,16 @@ class NumericValue(Value):
         │    2.54 │
         └─────────┘
         >>> t.values.round()
-        ┏━━━━━━━━━━━━━━━┓
-        ┃ Round(values) ┃
-        ┡━━━━━━━━━━━━━━━┩
-        │ int64         │
-        ├───────────────┤
-        │             1 │
-        │             2 │
-        │             2 │
-        │             3 │
-        └───────────────┘
+        ┏━━━━━━━━━━━━━━━━━━┓
+        ┃ Round(values, 0) ┃
+        ┡━━━━━━━━━━━━━━━━━━┩
+        │ int64            │
+        ├──────────────────┤
+        │                1 │
+        │                2 │
+        │                2 │
+        │                3 │
+        └──────────────────┘
         >>> t.values.round(digits=1)
         ┏━━━━━━━━━━━━━━━━━━┓
         ┃ Round(values, 1) ┃

--- a/ibis/tests/expr/test_sql_builtins.py
+++ b/ibis/tests/expr/test_sql_builtins.py
@@ -148,7 +148,7 @@ def test_sign(functional_alltypes, lineitem):
 def test_round(functional_alltypes, lineitem):
     result = functional_alltypes.double_col.round()
     assert isinstance(result, ir.IntegerColumn)
-    assert result.op().args[1] is None
+    assert result.op().args[1] == ibis.literal(0).op()
 
     result = functional_alltypes.double_col.round(2)
     assert isinstance(result, ir.FloatingColumn)


### PR DESCRIPTION
Fixes #10262.

BREAKING CHANGE: `None` is no longer allowed as the `digits` argument to `round`. Use `0` instead. Default behavior is unchanged.