### PR TITLE
feat(duckdb): forward UDF configuration dict as kwargs during registration

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1735,21 +1735,18 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
                 registration_func(con)
 
     def _register_udf(self, udf_node: ops.ScalarUDF):
-        func = udf_node.__func__
-        name = type(udf_node).__name__
         type_mapper = self.compiler.type_mapper
         input_types = [
             type_mapper.to_string(param.annotation.pattern.dtype)
             for param in udf_node.__signature__.parameters.values()
         ]
-        output_type = type_mapper.to_string(udf_node.dtype)
 
         def register_udf(con):
             return con.create_function(
-                name,
-                func,
-                input_types,
-                output_type,
+                name=type(udf_node).__name__,
+                function=udf_node.__func__,
+                parameters=input_types,
+                return_type=type_mapper.to_string(udf_node.dtype),
                 type=_UDF_INPUT_TYPE_MAPPING[udf_node.__input_type__],
             )
 

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1748,6 +1748,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
                 parameters=input_types,
                 return_type=type_mapper.to_string(udf_node.dtype),
                 type=_UDF_INPUT_TYPE_MAPPING[udf_node.__input_type__],
+                **udf_node.__config__,
             )
 
         return register_udf


### PR DESCRIPTION
The backend-specific kwargs were not forwarded during udf registration. Now they are.

I discovered this when I hit an error just like the test shows.

I also did a little refactoring beforehand, I can remove that commit if you want.

I think a lot of the other backends also suffer from this bug, jusdging by how I don't see their registration hooks using `udf_node.__config__` at all. But this is a tricky thing to test, since the args are backend-specific.

If you can think of a better way to test this I'm open to it, the way I did here seems sort of brittle, dependent on implementation details of duckdb?