### PR TITLE
test: add test that `/` performs true division, not floor division

### DIFF
--- a/ibis/backends/sql/compilers/flink.py
+++ b/ibis/backends/sql/compilers/flink.py
@@ -328,6 +328,10 @@ class FlinkCompiler(SQLGlotCompiler):
             )
         return sge.TryCast(this=arg, to=type_mapper.from_ibis(to))
 
+    def visit_Divide(self, op, *, left, right):
+        dtype = op.dtype
+        return self.cast(left, dtype) / self.cast(right, dtype)
+
     def visit_FloorDivide(self, op, *, left, right):
         return self.f.floor(sge.paren(left) / sge.paren(right))
 

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -1099,6 +1099,13 @@ def test_binary_arithmetic_operations(backend, alltypes, df, op):
     backend.assert_series_equal(result, expected, check_exact=False)
 
 
+@pytest.mark.notimpl("flink", raises=AssertionError, reason="Flink does floor division")
+def test_integer_truediv(con):
+    expr = 1 / ibis.literal(2)
+    result = con.execute(expr)
+    assert result == 0.5
+
+
 def test_mod(backend, alltypes, df):
     expr = operator.mod(alltypes.smallint_col, alltypes.smallint_col + 1).name("tmp")
 

--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -1099,7 +1099,6 @@ def test_binary_arithmetic_operations(backend, alltypes, df, op):
     backend.assert_series_equal(result, expected, check_exact=False)
 
 
-@pytest.mark.notimpl("flink", raises=AssertionError, reason="Flink does floor division")
 def test_integer_truediv(con):
     expr = 1 / ibis.literal(2)
     result = con.execute(expr)
@@ -1149,11 +1148,6 @@ def test_floating_mod(backend, alltypes, df):
                     raises=OracleDatabaseError,
                     reason="Oracle doesn't do integer division by zero",
                 ),
-                pytest.mark.notyet(
-                    "flink",
-                    raises=Py4JJavaError,
-                    reason="Flink doesn't do integer division by zero",
-                ),
             ],
         ),
         param(
@@ -1164,11 +1158,6 @@ def test_floating_mod(backend, alltypes, df):
                     "oracle",
                     raises=OracleDatabaseError,
                     reason="Oracle doesn't do integer division by zero",
-                ),
-                pytest.mark.notyet(
-                    "flink",
-                    raises=Py4JJavaError,
-                    reason="Flink doesn't do integer division by zero",
                 ),
             ],
         ),
@@ -1181,11 +1170,6 @@ def test_floating_mod(backend, alltypes, df):
                     raises=OracleDatabaseError,
                     reason="Oracle doesn't do integer division by zero",
                 ),
-                pytest.mark.notyet(
-                    "flink",
-                    raises=Py4JJavaError,
-                    reason="Flink doesn't do integer division by zero",
-                ),
             ],
         ),
         param(
@@ -1196,11 +1180,6 @@ def test_floating_mod(backend, alltypes, df):
                     "oracle",
                     raises=OracleDatabaseError,
                     reason="Oracle doesn't do integer division by zero",
-                ),
-                pytest.mark.notyet(
-                    "flink",
-                    raises=Py4JJavaError,
-                    reason="Flink doesn't do integer division by zero",
                 ),
             ],
         ),
@@ -1216,11 +1195,6 @@ def test_floating_mod(backend, alltypes, df):
                     reason="Oracle doesn't do integer division by zero",
                 ),
                 pytest.mark.never(["impala"], reason="doesn't allow divide by zero"),
-                pytest.mark.notyet(
-                    "flink",
-                    raises=Py4JJavaError,
-                    reason="Flink doesn't do integer division by zero",
-                ),
             ],
         ),
         param(
@@ -1233,11 +1207,6 @@ def test_floating_mod(backend, alltypes, df):
                     reason="Oracle doesn't do integer division by zero",
                 ),
                 pytest.mark.never(["impala"], reason="doesn't allow divide by zero"),
-                pytest.mark.notyet(
-                    "flink",
-                    raises=Py4JJavaError,
-                    reason="Flink doesn't do integer division by zero",
-                ),
             ],
         ),
         param(
@@ -1250,11 +1219,6 @@ def test_floating_mod(backend, alltypes, df):
                     reason="Oracle doesn't do integer division by zero",
                 ),
                 pytest.mark.never(["impala"], reason="doesn't allow divide by zero"),
-                pytest.mark.notyet(
-                    "flink",
-                    raises=Py4JJavaError,
-                    reason="Flink doesn't do integer division by zero",
-                ),
             ],
         ),
         param(
@@ -1267,11 +1231,6 @@ def test_floating_mod(backend, alltypes, df):
                     reason="Oracle doesn't do integer division by zero",
                 ),
                 pytest.mark.never(["impala"], reason="doesn't allow divide by zero"),
-                pytest.mark.notyet(
-                    "flink",
-                    raises=Py4JJavaError,
-                    reason="Flink doesn't do integer division by zero",
-                ),
             ],
         ),
         param(


### PR DESCRIPTION
I can file an issue to track the actual flink fix for this if you want.