### PR TITLE
docs(examples): add temporal `strftime` examples

### DIFF
--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -588,9 +588,9 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         >>> t = ibis.memtable(
         ...     {
         ...         "timestamp_col": [
-        ...             (datetime(2020, 10, 5, 8, 0, 0)),
-        ...             (datetime(2020, 11, 10, 10, 2, 15)),
-        ...             (datetime(2020, 12, 15, 12, 4, 30)),
+        ...             datetime(2020, 10, 5, 8, 0, 0),
+        ...             datetime(2020, 11, 10, 10, 2, 15),
+        ...             datetime(2020, 12, 15, 12, 4, 30),
         ...         ]
         ...     },
         ... )

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -584,12 +584,11 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         >>> import ibis
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable(
-        ...     [
+        ...     {"timestamp_col": [
         ...         (datetime(2020, 10, 5, 8, 0, 0)),
         ...         (datetime(2020, 11, 10, 10, 2, 15)),
         ...         (datetime(2020, 12, 15, 12, 4, 30)),
-        ...     ],
-        ...     schema=ibis.Schema({"timestamp_col": "timestamp"}),
+        ...     ]},
         ... )
 
         Return a string with the year and month.

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -346,11 +346,13 @@ class DateValue(Value, _DateComponentMixin):
         >>> import ibis
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable(
-        ...     {"date_col": [
-        ...         date(2020, 10, 5),
-        ...         date(2020, 11, 10),
-        ...         date(2020, 12, 15),
-        ...     ]},
+        ...     {
+        ...         "date_col": [
+        ...             date(2020, 10, 5),
+        ...             date(2020, 11, 10),
+        ...             date(2020, 12, 15),
+        ...         ]
+        ...     },
         ... )
 
         Return a string with the year and month.
@@ -584,11 +586,13 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         >>> import ibis
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable(
-        ...     {"timestamp_col": [
-        ...         (datetime(2020, 10, 5, 8, 0, 0)),
-        ...         (datetime(2020, 11, 10, 10, 2, 15)),
-        ...         (datetime(2020, 12, 15, 12, 4, 30)),
-        ...     ]},
+        ...     {
+        ...         "timestamp_col": [
+        ...             (datetime(2020, 10, 5, 8, 0, 0)),
+        ...             (datetime(2020, 11, 10, 10, 2, 15)),
+        ...             (datetime(2020, 12, 15, 12, 4, 30)),
+        ...         ]
+        ...     },
         ... )
 
         Return a string with the year and month.

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -346,12 +346,11 @@ class DateValue(Value, _DateComponentMixin):
         >>> import ibis
         >>> ibis.options.interactive = True
         >>> t = ibis.memtable(
-        ...     [
+        ...     {"date_col": [
         ...         date(2020, 10, 5),
         ...         date(2020, 11, 10),
         ...         date(2020, 12, 15),
-        ...     ],
-        ...     schema=ibis.Schema({"date_col": "date"}),
+        ...     ]},
         ... )
 
         Return a string with the year and month.

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -357,28 +357,28 @@ class DateValue(Value, _DateComponentMixin):
         Return a string with the year and month.
 
         >>> t.date_col.strftime("%Y-%m")
-        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-        ┃ Strftime(date_col, '%Y-%m')      ┃
-        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-        │ string                           │
-        ├──────────────────────────────────┤
-        │ 2020-10                          │
-        │ 2020-11                          │
-        │ 2020-12                          │
-        └──────────────────────────────────┘
-        
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Strftime(date_col, '%Y-%m') ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string                      │
+        ├─────────────────────────────┤
+        │ 2020-10                     │
+        │ 2020-11                     │
+        │ 2020-12                     │
+        └─────────────────────────────┘
+
         Return a string with the month name, day, and year.
 
         >>> t.date_col.strftime("%B %-d, %Y")
-        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-        ┃ Strftime(date_col, '%B %-d, %Y')      ┃
-        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-        │ string                                │
-        ├───────────────────────────────────────┤
-        │ October 5, 2020                       │
-        │ November 10, 2020                     │
-        │ December 15, 2020                     │
-        └───────────────────────────────────────┘
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Strftime(date_col, '%B %-d, %Y') ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string                           │
+        ├──────────────────────────────────┤
+        │ October 5, 2020                  │
+        │ November 10, 2020                │
+        │ December 15, 2020                │
+        └──────────────────────────────────┘
         """
         return ops.Strftime(self, format_str).to_expr()
 
@@ -605,7 +605,7 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         │ 2020-11                          │
         │ 2020-12                          │
         └──────────────────────────────────┘
-        
+
         Return a string with the month, day, and year.
 
         >>> t.timestamp_col.strftime("%B %-d, %Y")
@@ -620,7 +620,7 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         └───────────────────────────────────────┘
 
         Return a string with the month, day, year, hour, minute, and AM/PM.
-        
+
         >>> t.timestamp_col.strftime("%B %-d, %Y at %I:%M %p")
         ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ Strftime(timestamp_col, '%B %-d, %Y at %I:%M %p') ┃

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -339,6 +339,46 @@ class DateValue(Value, _DateComponentMixin):
         -------
         StringValue
             Formatted version of `arg`
+
+        Examples
+        --------
+        >>> from datetime import date
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.memtable(
+        ...     [
+        ...         date(2020, 10, 5),
+        ...         date(2020, 11, 10),
+        ...         date(2020, 12, 15),
+        ...     ],
+        ...     schema=ibis.Schema({"date_col": "date"}),
+        ... )
+
+        Return a string with the year and month.
+
+        >>> t.date_col.strftime("%Y-%m")
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Strftime(date_col, '%Y-%m')      ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string                           │
+        ├──────────────────────────────────┤
+        │ 2020-10                          │
+        │ 2020-11                          │
+        │ 2020-12                          │
+        └──────────────────────────────────┘
+        
+        Return a string with the month name, day, and year.
+
+        >>> t.date_col.strftime("%B %-d, %Y")
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Strftime(date_col, '%B %-d, %Y')      ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string                                │
+        ├───────────────────────────────────────┤
+        │ October 5, 2020                       │
+        │ November 10, 2020                     │
+        │ December 15, 2020                     │
+        └───────────────────────────────────────┘
         """
         return ops.Strftime(self, format_str).to_expr()
 
@@ -538,6 +578,59 @@ class TimestampValue(_DateComponentMixin, _TimeComponentMixin, Value):
         -------
         StringValue
             Formatted version of `arg`
+
+        Examples
+        --------
+        >>> from datetime import datetime
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.memtable(
+        ...     [
+        ...         (datetime(2020, 10, 5, 8, 0, 0)),
+        ...         (datetime(2020, 11, 10, 10, 2, 15)),
+        ...         (datetime(2020, 12, 15, 12, 4, 30)),
+        ...     ],
+        ...     schema=ibis.Schema({"timestamp_col": "timestamp"}),
+        ... )
+
+        Return a string with the year and month.
+
+        >>> t.timestamp_col.strftime("%Y-%m")
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Strftime(timestamp_col, '%Y-%m') ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string                           │
+        ├──────────────────────────────────┤
+        │ 2020-10                          │
+        │ 2020-11                          │
+        │ 2020-12                          │
+        └──────────────────────────────────┘
+        
+        Return a string with the month, day, and year.
+
+        >>> t.timestamp_col.strftime("%B %-d, %Y")
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Strftime(timestamp_col, '%B %-d, %Y') ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string                                │
+        ├───────────────────────────────────────┤
+        │ October 5, 2020                       │
+        │ November 10, 2020                     │
+        │ December 15, 2020                     │
+        └───────────────────────────────────────┘
+
+        Return a string with the month, day, year, hour, minute, and AM/PM.
+        
+        >>> t.timestamp_col.strftime("%B %-d, %Y at %I:%M %p")
+        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+        ┃ Strftime(timestamp_col, '%B %-d, %Y at %I:%M %p') ┃
+        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+        │ string                                            │
+        ├───────────────────────────────────────────────────┤
+        │ October 5, 2020 at 08:00 AM                       │
+        │ November 10, 2020 at 10:02 AM                     │
+        │ December 15, 2020 at 12:04 PM                     │
+        └───────────────────────────────────────────────────┘
         """
         return ops.Strftime(self, format_str).to_expr()
 


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adding examples for TimestampValue and DateValue `strftime` methods. 

I wanted to cover what I felt like were common usage patterns.

## Issues closed

Resolves #10354 

^^ I intend to keep adding more of these, but don't know it it's worthwhile to keep that issue open. 