### PR TITLE
docs(druid): fix connect kwarg example

### DIFF
--- a/docs/backends/druid.qmd
+++ b/docs/backends/druid.qmd
@@ -74,7 +74,7 @@ con = ibis.druid.connect()  # <1>
 con = ibis.druid.connect(
     host="hostname",
     port=8082,
-    database="druid/v2/sql",
+    path="druid/v2/sql",
 )
 ```
 


### PR DESCRIPTION
## Description of changes

Fix the incorrect kwarg in the docs for connecting to Druid

## Issues closed

Resolves #10368
