### PR TITLE
docs: expand ibis-for-sql-users set operator examples

### DIFF
--- a/docs/tutorials/ibis-for-sql-users.qmd
+++ b/docs/tutorials/ibis-for-sql-users.qmd
@@ -1151,7 +1151,12 @@ engine.
 
 To appear.
 
-## Unions
+## Set operators
+
+Set operations are a common SQL idiom for combining or comparing rows
+from different relations. Ibis supports the following set operations:
+
+### Unions
 
 SQL dialects often support two kinds of `UNION` operations:
 
@@ -1163,10 +1168,39 @@ The Ibis `union` function by default is a `UNION ALL`, and you can set
 `distinct=True` to get the normal `UNION` behavior:
 
 ```{python}
-expr1 = t1.limit(10)
-expr2 = t1.limit(10, offset=10)
+#| code-fold: true
+sales_2023 = ibis.table(
+    dict(product_name="string", order_quantity="int64"),
+    name="sales_2023",
+)
+sales_2024 = ibis.table(
+    dict(product_name="string", order_quantity="int64"),
+    name="sales_2024",
+)
+```
+
+```{python}
+expr1 = sales_2023.limit(10)
+expr2 = sales_2024.limit(10, offset=10)
 
 expr = expr1.union(expr2)
+ibis.to_sql(expr)
+```
+
+### Intersect/Except
+
+SQL dialects support `INTERSECT` and `EXCEPT` operators that returns rows that
+are in both tables or only in one table, respectively.
+
+In Ibis, we can perform these operations using `intersection` and `difference`.
+
+```{python}
+expr = ibis.difference(sales_2023, sales_2024)
+ibis.to_sql(expr)
+```
+
+```{python}
+expr = ibis.intersect(sales_2023, sales_2024)
 ibis.to_sql(expr)
 ```
 

--- a/docs/tutorials/ibis-for-sql-users.qmd
+++ b/docs/tutorials/ibis-for-sql-users.qmd
@@ -1187,7 +1187,7 @@ expr = expr1.union(expr2)
 ibis.to_sql(expr)
 ```
 
-### Intersect/Except
+### Intersection and difference
 
 SQL dialects support `INTERSECT` and `EXCEPT` operators that returns rows that
 are in both tables or only in one table, respectively.


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Expanding upon the `UNION` and `UNION ALL` examples in [Tutorial: Ibis for SQL users](https://ibis-project.org/tutorials/ibis-for-sql-users)
to include coverage for `INTERSECT` and `EXCEPT`.

Many dataframe APIs do this differently (e.g., [snowflake.snowpark.DataFrame.minus](https://docs.snowflake.com/en/developer-guide/snowpark/reference/python/1.23.0/snowpark/api/snowflake.snowpark.DataFrame.minus),
[pyspark.sql.DataFrame.exceptAll](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrame.exceptAll.html#)), so I'm hoping this will help clarify things for how to perform these ops in Ibis for SQL users.
