### PR TITLE
docs(examples): add remaining non-TimeValue temporal examples

### DIFF
--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -27,7 +27,16 @@ class _DateComponentMixin:
     """Temporal expressions that have a date component."""
 
     def epoch_seconds(self) -> ir.IntegerValue:
-        """Extract UNIX epoch in seconds."""
+        """Extract UNIX epoch in seconds.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.date(2024, 12, 31).epoch_seconds()
+        ┌────────────┐
+        │ 1735603200 │
+        └────────────┘
+        """
         return ops.ExtractEpochSeconds(self).to_expr()
 
     def year(self) -> ir.IntegerValue:

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -174,6 +174,14 @@ class _TimeComponentMixin:
         -------
         TimeValue
             The time component of `self`
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.timestamp(2024, 12, 31, 23, 59, 59).time()
+        ┌──────────┐
+        │ 23:59:59 │
+        └──────────┘
         """
         return ops.Time(self).to_expr()
 

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -199,7 +199,16 @@ class _TimeComponentMixin:
         return ops.ExtractHour(self).to_expr()
 
     def minute(self) -> ir.IntegerValue:
-        """Extract the minute component."""
+        """Extract the minute component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.timestamp(2024, 12, 31, 23, 59, 59).minute()
+        ┌────┐
+        │ 59 │
+        └────┘
+        """
         return ops.ExtractMinute(self).to_expr()
 
     def second(self) -> ir.IntegerValue:

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -35,7 +35,16 @@ class _DateComponentMixin:
         return ops.ExtractYear(self).to_expr()
 
     def iso_year(self) -> ir.IntegerValue:
-        """Extract the ISO year component."""
+        """Extract the ISO year component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.date(2024, 12, 31).iso_year()
+        ┌──────┐
+        │ 2025 │
+        └──────┘
+        """
         return ops.ExtractIsoYear(self).to_expr()
 
     def month(self) -> ir.IntegerValue:

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -39,7 +39,16 @@ class _DateComponentMixin:
         return ops.ExtractIsoYear(self).to_expr()
 
     def month(self) -> ir.IntegerValue:
-        """Extract the month component."""
+        """Extract the month component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.date(2024, 12, 31).month()
+        ┌────┐
+        │ 12 │
+        └────┘
+        """
         return ops.ExtractMonth(self).to_expr()
 
     def day(self) -> ir.IntegerValue:

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -186,7 +186,16 @@ class _TimeComponentMixin:
         return ops.Time(self).to_expr()
 
     def hour(self) -> ir.IntegerValue:
-        """Extract the hour component."""
+        """Extract the hour component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.timestamp(2024, 12, 31, 23, 59, 59).hour()
+        ┌────┐
+        │ 23 │
+        └────┘
+        """
         return ops.ExtractHour(self).to_expr()
 
     def minute(self) -> ir.IntegerValue:

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -97,7 +97,16 @@ class _DateComponentMixin:
         return ops.ExtractQuarter(self).to_expr()
 
     def week_of_year(self) -> ir.IntegerValue:
-        """Extract the week of the year component."""
+        """Extract the week of the year component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.date(2024, 12, 31).week_of_year()
+        ┌───┐
+        │ 1 │
+        └───┘
+        """
         return ops.ExtractWeekOfYear(self).to_expr()
 
 

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -93,7 +93,16 @@ class _DateComponentMixin:
         return ops.ExtractDayOfYear(self).to_expr()
 
     def quarter(self) -> ir.IntegerValue:
-        """Extract the quarter component."""
+        """Extract the quarter component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.date(2024, 12, 31).quarter()
+        ┌───┐
+        │ 4 │
+        └───┘
+        """
         return ops.ExtractQuarter(self).to_expr()
 
     def week_of_year(self) -> ir.IntegerValue:

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -43,7 +43,16 @@ class _DateComponentMixin:
         return ops.ExtractMonth(self).to_expr()
 
     def day(self) -> ir.IntegerValue:
-        """Extract the day component."""
+        """Extract the day component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.date(2024, 12, 31).day()
+        ┌────┐
+        │ 31 │
+        └────┘
+        """
         return ops.ExtractDay(self).to_expr()
 
     @property

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -31,7 +31,16 @@ class _DateComponentMixin:
         return ops.ExtractEpochSeconds(self).to_expr()
 
     def year(self) -> ir.IntegerValue:
-        """Extract the year component."""
+        """Extract the year component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.date(2024, 12, 31).year()
+        ┌──────┐
+        │ 2024 │
+        └──────┘
+        """
         return ops.ExtractYear(self).to_expr()
 
     def iso_year(self) -> ir.IntegerValue:

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -225,7 +225,16 @@ class _TimeComponentMixin:
         return ops.ExtractSecond(self).to_expr()
 
     def microsecond(self) -> ir.IntegerValue:
-        """Extract the microsecond component."""
+        """Extract the microsecond component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.timestamp("2024-12-31 23:59:59.999").microsecond()
+        ┌────────┐
+        │ 999999 │
+        └────────┘
+        """
         return ops.ExtractMicrosecond(self).to_expr()
 
     def millisecond(self) -> ir.IntegerValue:

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -31,7 +31,8 @@ class _DateComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.date(2024, 12, 31).epoch_seconds()
         ┌────────────┐
         │ 1735603200 │
@@ -44,7 +45,8 @@ class _DateComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.date(2024, 12, 31).year()
         ┌──────┐
         │ 2024 │
@@ -57,7 +59,8 @@ class _DateComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.date(2024, 12, 31).iso_year()
         ┌──────┐
         │ 2025 │
@@ -70,7 +73,8 @@ class _DateComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.date(2024, 12, 31).month()
         ┌────┐
         │ 12 │
@@ -83,7 +87,8 @@ class _DateComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.date(2024, 12, 31).day()
         ┌────┐
         │ 31 │
@@ -142,7 +147,8 @@ class _DateComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.date(2024, 12, 31).quarter()
         ┌───┐
         │ 4 │
@@ -155,7 +161,8 @@ class _DateComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.date(2024, 12, 31).week_of_year()
         ┌───┐
         │ 1 │
@@ -177,7 +184,8 @@ class _TimeComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.timestamp(2024, 12, 31, 23, 59, 59).time()
         ┌──────────┐
         │ 23:59:59 │
@@ -190,7 +198,8 @@ class _TimeComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.timestamp(2024, 12, 31, 23, 59, 59).hour()
         ┌────┐
         │ 23 │
@@ -203,7 +212,8 @@ class _TimeComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.timestamp(2024, 12, 31, 23, 59, 59).minute()
         ┌────┐
         │ 59 │
@@ -216,7 +226,8 @@ class _TimeComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.timestamp(2024, 12, 31, 23, 59, 59).second()
         ┌────┐
         │ 59 │
@@ -229,7 +240,8 @@ class _TimeComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.timestamp("2024-12-31 23:59:59.999").microsecond()
         ┌────────┐
         │ 999999 │
@@ -242,7 +254,8 @@ class _TimeComponentMixin:
 
         Examples
         --------
-        >>> from ibis.interactive import *
+        >>> import ibis
+        >>> ibis.options.interactive = True
         >>> ibis.timestamp("2024-12-31 23:59:59.999").millisecond()
         ┌─────┐
         │ 999 │

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -238,7 +238,16 @@ class _TimeComponentMixin:
         return ops.ExtractMicrosecond(self).to_expr()
 
     def millisecond(self) -> ir.IntegerValue:
-        """Extract the millisecond component."""
+        """Extract the millisecond component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.timestamp("2024-12-31 23:59:59.999").millisecond()
+        ┌─────┐
+        │ 999 │
+        └─────┘
+        """
         return ops.ExtractMillisecond(self).to_expr()
 
     def between(

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -244,7 +244,7 @@ class _TimeComponentMixin:
         >>> ibis.options.interactive = True
         >>> ibis.timestamp("2024-12-31 23:59:59.999").microsecond()
         ┌────────┐
-        │ 999999 │
+        │ 999000 │
         └────────┘
         """
         return ops.ExtractMicrosecond(self).to_expr()

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -274,6 +274,21 @@ class _TimeComponentMixin:
         BooleanValue
             Whether `self` is between `lower` and `upper`, adjusting `timezone`
             as needed.
+
+        Examples
+        --------
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> lower = ibis.date(2024, 12, 30)
+        >>> upper = ibis.date(2025, 1, 1)
+        >>> ibis.date(2024, 12, 31).between(lower, upper)
+        ┌──────┐
+        │ True │
+        └──────┘
+        >>> ibis.date(2020, 12, 31).between(lower, upper)
+        ┌───────┐
+        │ False │
+        └───────┘
         """
         op = self.op()
         if isinstance(op, ops.Time):

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -1217,6 +1217,23 @@ class IntervalValue(Value):
         -------
         IntervalValue
             A negated interval value expression
+
+        Examples
+        --------
+        >>> import ibis
+        >>> ibis.options.interactive = True
+
+        Negate a positive interval of one day to subtract a day from a specific date.
+        >>> ibis.date(2024, 11, 1) + ibis.interval(days=1).negate()
+        ┌────────────┐
+        │ 2024-10-31 │
+        └────────────┘
+
+        Negate a negative interval of one day to add a day to a specific date.
+        >>> ibis.date(2024, 11, 1) + ibis.interval(days=-1).negate()
+        ┌────────────┐
+        │ 2024-11-02 │
+        └────────────┘
         """
         return ops.Negate(self).to_expr()
 

--- a/ibis/expr/types/temporal.py
+++ b/ibis/expr/types/temporal.py
@@ -212,7 +212,16 @@ class _TimeComponentMixin:
         return ops.ExtractMinute(self).to_expr()
 
     def second(self) -> ir.IntegerValue:
-        """Extract the second component."""
+        """Extract the second component.
+
+        Examples
+        --------
+        >>> from ibis.interactive import *
+        >>> ibis.timestamp(2024, 12, 31, 23, 59, 59).second()
+        ┌────┐
+        │ 59 │
+        └────┘
+        """
         return ops.ExtractSecond(self).to_expr()
 
     def microsecond(self) -> ir.IntegerValue:


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Add examples for the remaining non-TimeValue-only temporal operations. This time, I opted not to use memtable examples and used the scalar options to demonstrate functionality. 

There's a lot here, so I broke them into separate commits if we wanted to pluck any out that seemed self-explanatory. Admittedly, many of these did feel self-explanatory, but I didn't know if it was still better to have examples for all of them for completeness. I am okay with squashing all of these commits if we want to proceed with these examples if that is better. 

I also used `ibis.date` and `ibis.timestamp` rather than `datetime.date` or `datetime.datetime`. It might be worth standardizing all these examples to use one or the other, but I figured we could discuss that or pick it up in a different PR. 
