### PR TITLE
fix(snowflake, bigquery): minor adjustments for passsing in `dialect` to `sg.func`

### DIFF
--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -201,8 +201,6 @@ class BigQueryCompiler(SQLGlotCompiler):
         ops.ExtractHost: "net.host",
         ops.ArgMin: "min_by",
         ops.ArgMax: "max_by",
-        ops.TimeDelta: "time_diff",
-        ops.DateDelta: "date_diff",
     }
 
     def to_sqlglot(
@@ -383,14 +381,20 @@ class BigQueryCompiler(SQLGlotCompiler):
     def visit_E(self, op):
         return self.f.exp(1)
 
+    def visit_TimeDelta(self, op, *, left, right, part):
+        return self.f.time_diff(left, right, self.v[part])
+
+    def visit_DateDelta(self, op, *, left, right, part):
+        return self.f.date_diff(left, right, self.v[part])
+
     def visit_TimestampDelta(self, op, *, left, right, part):
         left_tz = op.left.dtype.timezone
         right_tz = op.right.dtype.timezone
 
         if left_tz is None and right_tz is None:
-            return self.f.datetime_diff(left, right, part)
+            return self.f.datetime_diff(left, right, self.v[part])
         elif left_tz is not None and right_tz is not None:
-            return self.f.timestamp_diff(left, right, part)
+            return self.f.timestamp_diff(left, right, self.v[part])
 
         raise com.UnsupportedOperationError(
             "timestamp difference with mixed timezone/timezoneless values is not implemented"

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -366,8 +366,8 @@ $$""",
 
     def visit_MapContains(self, op, *, arg, key):
         return self.f.array_contains(
-            self.if_(self.f.is_object(arg), self.f.object_keys(arg), NULL),
             self.f.to_variant(key),
+            self.if_(self.f.is_object(arg), self.f.object_keys(arg), NULL),
         )
 
     def visit_MapMerge(self, op, *, left, right):
@@ -447,7 +447,7 @@ $$""",
         return self.f.array_distinct(self.f.array_cat(left, right))
 
     def visit_ArrayContains(self, op, *, arg, other):
-        return self.f.array_contains(arg, self.f.to_variant(other))
+        return self.f.array_contains(self.f.to_variant(other), arg)
 
     def visit_ArrayConcat(self, op, *, arg):
         # array_cat only accepts two arguments

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1196,21 +1196,11 @@ def test_string_as_timestamp(alltypes, fmt):
         param(
             "%m/%d/%y",
             id="mysql_format",
-            marks=[
-                pytest.mark.never(
-                    ["snowflake"],
-                    reason=(
-                        "(snowflake.connector.errors.ProgrammingError) 100096 (22007): "
-                        "Can't parse '11/01/10' as timestamp with format '%m/%d/%y'"
-                    ),
-                    raises=SnowflakeProgrammingError,
-                ),
-                pytest.mark.never(
-                    ["flink"],
-                    raises=ValueError,
-                    reason="Datetime formatting style is not supported.",
-                ),
-            ],
+            marks=pytest.mark.never(
+                ["flink"],
+                raises=ValueError,
+                reason="Datetime formatting style is not supported.",
+            ),
         ),
         param(
             "MM/dd/yy",


### PR DESCRIPTION
- **fix(snowflake): adjust `array_contains` invocations for use of `dialect` in `sg.func`**
- **test(snowflake): enable xpassing test**
- **fix(bigquery): ensure that delta function `part` argument is not compiled as a string**
