### PR TITLE
perf(duckdb): reduce branching factor for generated ArrayDistinct code

### DIFF
--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -779,8 +779,8 @@ def test_array_remove(con, input, expected):
     ("input", "expected"),
     [
         param(
-            {"a": [[1, 3, 3], [], [42, 42], [], [None], None]},
-            [{3, 1}, set(), {42}, set(), {None}, None],
+            {"a": [[1, 3, 3], [1, 3, None, 3], [42, 42], [], [None], None]},
+            [{3, 1}, {1, 3, None}, {42}, set(), {None}, None],
             id="null",
             marks=[
                 pytest.mark.notyet(


### PR DESCRIPTION
If I do something like `some_really_complex_array_expression.unique()`, then the SQL for `some_really_complex_array_expression` was duplicated 4 times. Now it is only duplicated 3 times.

This is important for perf, because duckdb sometimes appears to not be smart, and actually does a computation for each time a subexpression appears.
See https://github.com/duckdb/duckdb/discussions/14649.
So this can reduce the computation time to 3/4 of what it was.

I want to go through our other compilation steps and do similar optimizations whenever possible.

<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
