### PR TITLE
perf(duckdb): use builtin negative array slicing in newer duckdbs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8320,4 +8320,4 @@ visualization = ["graphviz"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "57cd24fa8ce375c12cceb19da95e5f7b7df1e6fd79c06774ab09d3c811c448ff"
+content-hash = "ae46582f4fb9967aa0b3c51e8c104aecbc62720505c4bf17cd643112e8ab2109"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ clickhouse-connect = { version = ">=0.5.23,<1", optional = true, extras = [
 datafusion = { version = ">=0.6,<43", optional = true }
 db-dtypes = { version = ">=0.3,<2", optional = true }
 deltalake = { version = ">=0.9.0,<1", optional = true }
-duckdb = { version = ">=0.8.1,<1.2", optional = true }
+duckdb = { version = ">=0.10,<1.2", optional = true }
 geopandas = { version = ">=0.6,<2", optional = true }
 geoarrow-types = { version = ">=0.2,<1", optional = true }
 pyproj = { version = ">=3.3.0,<4", optional = true }


### PR DESCRIPTION
Similar rationale to https://github.com/ibis-project/ibis/pull/10410