### PR TITLE
docs(examples): add type example

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -88,7 +88,30 @@ class Value(Expr):
 
     # TODO(kszucs): should rename to dtype
     def type(self) -> dt.DataType:
-        """Return the [DataType](./datatypes.qmd) of `self`."""
+        """Return the [DataType](./datatypes.qmd) of `self`.
+
+        Examples
+        --------
+        >>> from datetime import datetime
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.memtable(
+        ...     {
+        ...         "int_col": [1],
+        ...         "timestamp_col": [
+        ...             datetime(2024, 11, 2, 10, 5, 2),
+        ...         ],
+        ...         "string_col": ["a"],
+        ...     }
+        ... )
+
+        >>> t.int_col.type()
+        Int64(nullable=True)
+        >>> t.timestamp_col.type()
+        Timestamp(timezone=None, scale=None, nullable=True)
+        >>> t.string_col.type()
+        String(nullable=True)
+        """
         return self.op().dtype
 
     def hash(self) -> ir.IntegerValue:


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds a few examples given different data types and the the output of `column.type`. I wanted to include the timestamp here since it shows the output class of that type with more than nullable. 

Here's a doc preview:

<img width="636" alt="image" src="https://github.com/user-attachments/assets/b441e711-53ae-4c0c-9649-0fdb99111cac">