### PR TITLE
docs(examples): add remaining selectors examples

### DIFF
--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -274,6 +274,15 @@ def endswith(suffixes: str | tuple[str, ...]) -> Selector:
     suffixes
         Suffixes to compare column names against
 
+    Examples
+    --------
+    >>> import ibis
+    >>> import ibis.selectors as s
+    >>> t = ibis.table(dict(model_id="int", model_name="str", user_id="int"), name="t")
+    >>> expr = t.select(s.endswith("id"))
+    >>> expr.columns
+    ('model_id', 'user_id')
+
     See Also
     --------
     [`startswith`](#ibis.selectors.startswith)
@@ -371,13 +380,33 @@ def matches(regex: str | re.Pattern) -> Selector:
 
 @public
 def any_of(*predicates: str | Selector) -> Selector:
-    """Include columns satisfying any of `predicates`."""
+    """Include columns satisfying any of `predicates`.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> import ibis.selectors as s
+    >>> t = ibis.table(dict(model_id="int", model_name="str", user_id="int"), name="t")
+    >>> expr = t.select(s.any_of(s.endswith("id"), s.startswith("m")))
+    >>> expr.columns
+    ('model_id', 'model_name', 'user_id')
+    """
     return Any(tuple(map(_to_selector, predicates)))
 
 
 @public
 def all_of(*predicates: str | Selector) -> Selector:
-    """Include columns satisfying all of `predicates`."""
+    """Include columns satisfying all of `predicates`.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> import ibis.selectors as s
+    >>> t = ibis.table(dict(model_id="int", model_name="str", user_id="int"), name="t")
+    >>> expr = t.select(s.all_of(s.endswith("id"), s.startswith("m")))
+    >>> expr.columns
+    ('model_id',)
+    """
     return All(tuple(map(_to_selector, predicates)))
 
 
@@ -726,7 +755,17 @@ class First(Singleton, Selector):
 
 @public
 def first() -> Selector:
-    """Return the first column of a table."""
+    """Return the first column of a table.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> import ibis.selectors as s
+    >>> t = ibis.table(dict(model_id="int", model_name="str", user_id="int"), name="t")
+    >>> expr = t.select(s.first())
+    >>> expr.columns
+    ('model_id',)
+    """
     return First()
 
 
@@ -740,7 +779,17 @@ class Last(Singleton, Selector):
 
 @public
 def last() -> Selector:
-    """Return the last column of a table."""
+    """Return the last column of a table.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> import ibis.selectors as s
+    >>> t = ibis.table(dict(model_id="int", model_name="str", user_id="int"), name="t")
+    >>> expr = t.select(s.last())
+    >>> expr.columns
+    ('user_id',)
+    """
     return Last()
 
 
@@ -754,7 +803,17 @@ class AllColumns(Singleton, Selector):
 
 @public
 def all() -> Selector:
-    """Return every column from a table."""
+    """Return every column from a table.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> import ibis.selectors as s
+    >>> t = ibis.table(dict(model_id="int", model_name="str", user_id="int"), name="t")
+    >>> expr = t.select(s.all())
+    >>> expr.columns
+    ('model_id', 'model_name', 'user_id')
+    """
     return AllColumns()
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

This adds examples for the remaining selectors except `s.none()`. I need to brainstorm for a good example of that one, unless anyone has ideas off the bat.

Selectors may still be my favorite Ibis feature, so I am happy to provide direct examples for using them. 😎 
