### PR TITLE
ci(databricks): enable databricks ci job

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -47,6 +47,10 @@ jobs:
             title: Snowflake
             extras:
               - snowflake
+          - name: databricks
+            title: Databricks
+            extras:
+              - databricks
         include:
           - python-version: "3.10"
             backend:


### PR DESCRIPTION
Testing tends to be much more helpful when it is actually enabled.