### PR TITLE
fix(compiler): use the correct exception type for a failed import

### DIFF
--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -46,7 +46,7 @@ else:
 
 try:
     from sqlglot.expressions import AlterRename as RenameTable
-except AttributeError:
+except ImportError:
     from sqlglot.expressions import RenameTable  # noqa: F401
 
 


### PR DESCRIPTION
Fixes an issue with sqlglot backwards compatibility, where we were somehow catching AttributeError instead of ImportError.