### PR TITLE
refactor(duckdb): pass `temp_directory` through as-is to `duckdb.connect`

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ast
 import contextlib
-import os
 import urllib
 import warnings
 from operator import itemgetter
@@ -362,7 +361,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         self,
         database: str | Path = ":memory:",
         read_only: bool = False,
-        temp_directory: str | Path | None = None,
         extensions: Sequence[str] | None = None,
         **config: Any,
     ) -> None:
@@ -374,9 +372,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
             Path to a duckdb database.
         read_only
             Whether the database is read-only.
-        temp_directory
-            Directory to use for spilling to disk. Only set by default for
-            in-memory connections.
         extensions
             A list of duckdb extensions to install/load upon connection.
         config
@@ -394,19 +389,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
             ("md:", "motherduck:", ":memory:")
         ):
             database = Path(database).absolute()
-
-        if temp_directory is None:
-            temp_directory = (
-                Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
-                / "ibis-duckdb"
-                / str(os.getpid())
-            )
-        else:
-            Path(temp_directory).mkdir(parents=True, exist_ok=True)
-            config["temp_directory"] = str(temp_directory)
-
         self.con = duckdb.connect(str(database), config=config, read_only=read_only)
-
         self._post_connect(extensions)
 
     @util.experimental


### PR DESCRIPTION
Let's make the pass-through from ibis to duckdb more transparent, so you get closer to the same behavior as when using `import duckdb; duckdb.connect()`.

I considered also removing the nicety of creating the temp_dir for users, but decided to keep it.
Now, we only create parent. duckdb will make dir itself only if it needs. This means that for low-memory loads,
a dir might never be needed. This better matches duckdb's behavior.
Also, adjust our test to really check for the end desired behavior, not an implementation detail
of if WE create the dir.

Related to https://github.com/ibis-project/ibis/issues/6974

BREAKING CHANGE: Special handling of the `temp_directory` argument passed to Ibis is removed in favor of passing the argument through directly to `duckdb.connect`. Interior nodes of directory trees must be created, e.g., using `Path.mkdir(exists_ok=True, parents=True)`, `mkdir -p`, etc.