### PR TITLE
fix(mssql): escape special characters in passwords

### DIFF
--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -176,12 +176,16 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase):
         self.con = pyodbc.connect(
             user=user,
             server=f"{host},{port}",
-            password=password,
+            password=self._escape_special_characters(password),
             driver=driver,
             **kwargs,
         )
 
         self._post_connect()
+
+    @staticmethod
+    def _escape_special_characters(value: str) -> str:
+        return "{" + value.replace("}", "}}") + "}"
 
     @util.experimental
     @classmethod

--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -300,3 +300,14 @@ def test_create_temp_table(con, temp):
         assert t.columns == ("a",)
     finally:
         con.drop_table(name)
+
+
+def test_escape_special_characters():
+    test_func = ibis.backends.mssql.Backend._escape_special_characters
+    assert test_func("1bis_Testing!") == "{1bis_Testing!}"
+    assert test_func("{1bis_Testing!") == "{{1bis_Testing!}"
+    assert test_func("1bis_Testing!}") == "{1bis_Testing!}}}"
+    assert test_func("{1bis_Testing!}") == "{{1bis_Testing!}}}"
+    assert test_func("1bis}Testing!") == "{1bis}}Testing!}"
+    assert test_func("{R;3G1/8Al2AniRye") == "{{R;3G1/8Al2AniRye}"
+    assert test_func("{R;3G1/8Al2AniRye}") == "{{R;3G1/8Al2AniRye}}}"


### PR DESCRIPTION
## Description of changes
I found the error 
```
'IM002', '[IM002] [unixODBC][Driver Manager]Data source name not found and no default driver specified (0) (SQLDriverConnect)'
```
Because the password of mssql includes special characters like `{R;3G1/8Al2AniRye` that start with `{` or include `;`.
It should be covered by `{` and `}` and replace `}` with`}}`.

Reference:
https://github.com/mkleehammer/pyodbc/wiki/Connecting-to-databases
https://stackoverflow.com/questions/78531086/pyodbc-connection-string-correctly-escaping-password-with-special-characters/78532507#78532507