### PR TITLE
fix(duckdb): handle null propagation correctly in array concatenation

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -82,6 +82,9 @@ def literal(op, **_):
     value = op.value
     dtype = op.dtype
 
+    if value is None:
+        return pl.lit(None, dtype=PolarsType.from_ibis(dtype))
+
     if dtype.is_array():
         value = pl.Series("", value)
         typ = PolarsType.from_ibis(dtype)

--- a/ibis/backends/sql/compilers/duckdb.py
+++ b/ibis/backends/sql/compilers/duckdb.py
@@ -349,8 +349,12 @@ class DuckDBCompiler(SQLGlotCompiler):
         )
 
     def visit_ArrayConcat(self, op, *, arg):
-        # TODO(cpcloud): map ArrayConcat to this in sqlglot instead of here
-        return reduce(self.f.list_concat, arg)
+        return reduce(
+            lambda x, y: self.if_(
+                x.is_(NULL).or_(y.is_(NULL)), NULL, self.f.list_concat(x, y)
+            ),
+            arg,
+        )
 
     def visit_IntervalFromInteger(self, op, *, arg, unit):
         if unit.short == "ns":

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -313,7 +313,12 @@ class PostgresCompiler(SQLGlotCompiler):
         return reduce(lambda x, y: sge.DPipe(this=x, expression=y), arg)
 
     def visit_ArrayConcat(self, op, *, arg):
-        return reduce(self.f.array_cat, map(partial(self.cast, to=op.dtype), arg))
+        return reduce(
+            lambda x, y: self.if_(
+                x.is_(NULL).or_(y.is_(NULL)), NULL, self.f.array_cat(x, y)
+            ),
+            map(partial(self.cast, to=op.dtype), arg),
+        )
 
     def visit_ArrayContains(self, op, *, arg, other):
         arg_dtype = op.arg.dtype

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -197,7 +197,7 @@ class ArrayValue(Value):
         ├────────────────────────┤
         │ [7, 4]                 │
         │ [3, 4]                 │
-        │ [4]                    │
+        │ NULL                   │
         └────────────────────────┘
 
         `concat` is also available using the `+` operator
@@ -210,7 +210,7 @@ class ArrayValue(Value):
         ├────────────────────────┤
         │ [1, 7]                 │
         │ [1, 3]                 │
-        │ [1]                    │
+        │ NULL                   │
         └────────────────────────┘
         >>> t.a + [1]
         ┏━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -220,7 +220,7 @@ class ArrayValue(Value):
         ├────────────────────────┤
         │ [7, 1]                 │
         │ [3, 1]                 │
-        │ [1]                    │
+        │ NULL                   │
         └────────────────────────┘
         """
         return ops.ArrayConcat((self, other, *args)).to_expr()


### PR DESCRIPTION
Fixes a bug in NULL handling of our DuckDB implementation of `ops.ArrayConcat`. Previously NULL concatted with non-null returned the non-null value. This PR changes the behavior to return NULL if any of the lists being concatenated are null.