### PR TITLE
docs(duckdb): remove warning of duckdb not supporting chunk_size param

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1383,10 +1383,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         For analytics use cases this is usually nothing to fret about. In some cases you
         may need to explicit release the cursor.
 
-        ::: {.callout-warning}
-        ## DuckDB returns 1024 size batches regardless of what value of `chunk_size` argument is passed.
-        :::
-
         Parameters
         ----------
         expr


### PR DESCRIPTION
## Description of changes

In DuckDB this has been fixed in
https://github.com/duckdb/duckdb/pull/6840#issuecomment-1481387587. This PR is to remove the warning about DuckDB size restriction.

Would it be welcome for me to add tests for use of `chunk_size` with DuckDB `to_pyarrow_batches`?

## Issues closed

Resolves #10443
