### PR TITLE
docs(examples): add usage examples for `get_backend` and `get_name`

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -383,6 +383,16 @@ class Expr(Immutable, Coercible):
         BaseBackend
             The Ibis backend.
 
+        Examples
+        --------
+        >>> import ibis
+        >>> con = ibis.duckdb.connect()
+        >>> t = con.create_table("t", {"id": [1, 2, 3]})
+        >>> backend = t.get_backend()
+        >>> backend.name
+        'duckdb'
+        >>> type(backend)
+        <class 'ibis.backends.duckdb.Backend'>
         """
         return self._find_backend(use_default=True)
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -182,7 +182,16 @@ class Table(Expr, _FixedTextJupyterMixin):
     __array_ufunc__ = None
 
     def get_name(self) -> str:
-        """Return the fully qualified name of the table."""
+        """Return the fully qualified name of the table.
+
+        Examples
+        --------
+        >>> import ibis
+        >>> con = ibis.duckdb.connect()
+        >>> t = con.create_table("t", {"id": [1, 2, 3]})
+        >>> t.get_name()
+        'memory.main.t'
+        """
         arg = self._arg
         namespace = getattr(arg, "namespace", ops.Namespace())
         pieces = namespace.catalog, namespace.database, arg.name


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds examples by creating a table using an in-memory duckdb connection for [`get_backend`](https://ibis-project.org/reference/expression-tables#ibis.expr.types.relations.Table.get_backend) and [`get_name`](https://ibis-project.org/reference/expression-tables#ibis.expr.types.relations.Table.get_name). 

I did `backend.name` to get "duckdb" in the example for `get_backend` rather than `backend` to avoid getting something like "<ibis.backends.duckdb.Backend at 0x7fffd919b470>".  I'm not sure if both that and the `type` usage are necessary; maybe we could use one or the other if we don't want to use both. 