### PR TITLE
docs(examples): add unbind example

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -723,7 +723,26 @@ class Expr(Immutable, Coercible):
         )
 
     def unbind(self) -> ir.Table:
-        """Return an expression built on `UnboundTable` instead of backend-specific objects."""
+        """Return an expression built on `UnboundTable` instead of backend-specific objects.
+
+        Examples
+        --------
+        >>> import ibis
+        >>> import pandas as pd
+        >>> duckdb_con = ibis.duckdb.connect()
+        >>> polars_con = ibis.polars.connect()
+        >>> for backend in (duckdb_con, polars_con):
+        ...     t = backend.create_table("t", pd.DataFrame({"a": [1, 2, 3]}))
+        >>> bound_table = duckdb_con.table("t")
+        >>> bound_table.get_backend().name
+        'duckdb'
+        >>> unbound_table = bound_table.unbind()
+        >>> polars_con.execute(unbound_table)
+           a
+        0  1
+        1  2
+        2  3
+        """
         from ibis.expr.rewrites import _, d, p
 
         rule = p.DatabaseTable >> d.UnboundTable(


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds an example demonstrating that given a table in both DuckDB and Polars, we can take the table from DuckDB, unbind it, and then execute it using the Polars backend. 