### PR TITLE
docs(examples): add `having` example for GroupedTable

### DIFF
--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -94,6 +94,7 @@ class GroupedTable(Concrete):
         ...     t.group_by(t.grouper)
         ...     .having(t.count() < 3)
         ...     .aggregate(values_count=t.count(), values_sum=t.values.sum())
+        ...     .order_by(t.grouper)
         ... )
         >>> expr
         ┏━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓

--- a/ibis/expr/types/groupby.py
+++ b/ibis/expr/types/groupby.py
@@ -82,6 +82,28 @@ class GroupedTable(Concrete):
         -------
         GroupedTable
             A grouped table expression
+
+        Examples
+        --------
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.memtable(
+        ...     {"grouper": ["a", "a", "a", "b", "b", "c"], "values": [1, 2, 3, 1, 2, 1]}
+        ... )
+        >>> expr = (
+        ...     t.group_by(t.grouper)
+        ...     .having(t.count() < 3)
+        ...     .aggregate(values_count=t.count(), values_sum=t.values.sum())
+        ... )
+        >>> expr
+        ┏━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
+        ┃ grouper ┃ values_count ┃ values_sum ┃
+        ┡━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
+        │ string  │ int64        │ int64      │
+        ├─────────┼──────────────┼────────────┤
+        │ b       │            2 │          3 │
+        │ c       │            1 │          1 │
+        └─────────┴──────────────┴────────────┘
         """
         table = self.table.to_expr()
         havings = table.bind(*predicates)


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

This adds a [`having`](https://ibis-project.org/reference/expression-tables#ibis.expr.types.groupby.GroupedTable.having) example for usage on a `GroupedTable`. I followed it up with an `aggregation` to show the removal of the "a" rows. 

It could be useful also to show the `having` method without aggregation results in a `GroupedTable,` but I wasn't 100% sure if that would be worth showing. 
