### PR TITLE
fix(postgres): add dtype mapping for postgres OID type

### DIFF
--- a/docs/reference/cursed_knowledge.qmd
+++ b/docs/reference/cursed_knowledge.qmd
@@ -24,3 +24,10 @@ execution engines.
   so to get two unique random numbers, users must defeat that optimization.
   This is done by passing **any** argument to those functions. It's left as an
   exercise for the reader to figure out how to generate two unique inputs.
+
+## Postgres
+
+* Postgres doesn't have unsigned integer datatypes, except that it does.  It's
+  called [`OID`](https://www.postgresql.org/docs/current/datatype-oid.html) for
+  "Object ID" and it's a 4-byte unsigned int, mostly only used in certain
+  internal tables.

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -432,3 +432,9 @@ def enum_table(con):
 def test_enum_table(con, enum_table):
     t = con.table(enum_table)
     assert t.mood.type() == dt.unknown
+
+
+def test_parsing_oid_dtype(con):
+    # Load a table that uses the OID type and check that we map it to Int64
+    t = con.table("pg_class", database="pg_catalog")
+    assert t.oid.type() == ibis.dtype("int64")

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -488,6 +488,10 @@ class PostgresType(SqlglotType):
             "information_schema.yes_or_no": dt.string,
             # a case-insensitive string that has it's own type for some reason
             "citext": dt.string,
+            # "Object ID" is an unsigned 4-byte integer in Postgres, but
+            # Postgres doesn't expose unsigned int types otherwise, so just map
+            # it to a signed int64 so we capture the range of values.
+            "oid": dt.int64,
         }
     )
 


### PR DESCRIPTION
## Description of changes

Postgres has a wacky unsigned integer dtype called `OID` that's only used internally.  It's technically a 4-byte UINT, but I'm mapping it to a signed int64 because that's accurate enough to capture the valid values.


## Issues closed

Resolves #10456
