### PR TITLE
fix(snowflake): make semantics of array filtering match everything else

### DIFF
--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -172,57 +172,58 @@ class TrinoCompiler(SQLGlotCompiler):
             )
 
     def visit_ArrayFilter(self, op, *, arg, param, body, index):
+        # no index, life is simpler
         if index is None:
             return self.f.filter(arg, sge.Lambda(this=body, expressions=[param]))
-        else:
-            placeholder = sg.to_identifier("__trino_filter__")
-            index = sg.to_identifier(index)
-            keep, value = map(sg.to_identifier, ("keep", "value"))
 
-            # first, zip the array with the index and call the user's function,
-            # returning a struct of {"keep": value-of-predicate, "value": array-element}
-            zipped = self.f.zip_with(
-                arg,
-                # users are limited to 10_000 elements here because it
-                # seems like trino won't ever actually address the limit
-                self.f.sequence(0, self.f.cardinality(arg) - 1),
-                sge.Lambda(
-                    this=self.cast(
-                        sge.Struct(
-                            expressions=[
-                                sge.PropertyEQ(this=keep, expression=body),
-                                sge.PropertyEQ(this=value, expression=param),
-                            ]
-                        ),
-                        dt.Struct(
-                            {
-                                "keep": dt.boolean,
-                                "value": op.arg.dtype.value_type,
-                            }
-                        ),
+        placeholder = sg.to_identifier("__trino_filter__")
+        index = sg.to_identifier(index)
+        keep, value = map(sg.to_identifier, ("keep", "value"))
+
+        # first, zip the array with the index and call the user's function,
+        # returning a struct of {"keep": value-of-predicate, "value": array-element}
+        zipped = self.f.zip_with(
+            arg,
+            # users are limited to 10_000 elements here because it
+            # seems like trino won't ever actually address the limit
+            self.f.sequence(0, self.f.cardinality(arg) - 1),
+            sge.Lambda(
+                this=self.cast(
+                    sge.Struct(
+                        expressions=[
+                            sge.PropertyEQ(this=keep, expression=body),
+                            sge.PropertyEQ(this=value, expression=param),
+                        ]
                     ),
-                    expressions=[param, index],
+                    dt.Struct(
+                        {
+                            "keep": dt.boolean,
+                            "value": op.arg.dtype.value_type,
+                        }
+                    ),
                 ),
-            )
+                expressions=[param, index],
+            ),
+        )
 
-            # second, keep only the elements whose predicate returned true
-            filtered = self.f.filter(
-                # then, filter out elements that are null
-                zipped,
-                sge.Lambda(
-                    this=sge.Dot(this=placeholder, expression=keep),
-                    expressions=[placeholder],
-                ),
-            )
+        # second, keep only the elements whose predicate returned true
+        filtered = self.f.filter(
+            # then, filter out elements that are null
+            zipped,
+            sge.Lambda(
+                this=sge.Dot(this=placeholder, expression=keep),
+                expressions=[placeholder],
+            ),
+        )
 
-            # finally, extract the "value" field from the struct
-            return self.f.transform(
-                filtered,
-                sge.Lambda(
-                    this=sge.Dot(this=placeholder, expression=value),
-                    expressions=[placeholder],
-                ),
-            )
+        # finally, extract the "value" field from the struct
+        return self.f.transform(
+            filtered,
+            sge.Lambda(
+                this=sge.Dot(this=placeholder, expression=value),
+                expressions=[placeholder],
+            ),
+        )
 
     def visit_ArrayContains(self, op, *, arg, other):
         return self.if_(


### PR DESCRIPTION
- **style(trino): dedent**
- **fix(snowflake): make semantics of array filtering match everything else**

Fixes snowflake failures on `main`, caused by slightly different behavior around `NULL`s used in array filtering.

This PR ensures that behavior is the same for all backends that support array
filtering with an index.

Snowflake is a bit more complex because its higher order functions only accept
a single argument, so before we compile we run a rewrite rule (the use of
a rewrite is **not** new in this PR) to extract the field being referenced in
the body of the function.

The changes here are only relevant for the case of array filtering with an
index. If an index isn't used, then the behavior is the same as before.

This changes here are effectively making the snowflake backend implement array
filtering with an index like Trino and PySpark, where we construct a struct
containing whether to keep a value or not, along with the value.

This allows preservation of `NULL` values when the index is used for filtering,
for example.
