### PR TITLE
fix(datatypes): ensure that decimals can be upcast when source precision, scale are lte to their target fields

### DIFF
--- a/ibis/expr/datatypes/cast.py
+++ b/ibis/expr/datatypes/cast.py
@@ -67,17 +67,17 @@ def castable(source: dt.DataType, target: dt.DataType, value: Any = None) -> boo
             return source.is_integer()
     elif target.is_decimal():
         if source.is_decimal():
-            downcast_precision = (
+            upcast_precision = (
                 source.precision is not None
                 and target.precision is not None
-                and source.precision < target.precision
+                and source.precision <= target.precision
             )
-            downcast_scale = (
+            upcast_scale = (
                 source.scale is not None
                 and target.scale is not None
-                and source.scale < target.scale
+                and source.scale <= target.scale
             )
-            return not (downcast_precision or downcast_scale)
+            return upcast_precision and upcast_scale
         else:
             return source.is_numeric()
     elif target.is_string():

--- a/ibis/expr/datatypes/tests/test_cast.py
+++ b/ibis/expr/datatypes/tests/test_cast.py
@@ -119,3 +119,26 @@ def test_struct_different_fields():
     # Missing fields entirely from each other
     assert not x.castable(y)
     assert not y.castable(x)
+
+
+@pytest.mark.parametrize(
+    ("source", "target", "expected"),
+    [
+        # Fixed precision
+        ((12, 2), (12, 3), True),
+        ((12, 3), (12, 2), False),
+        # Fixed scale
+        ((12, 2), (13, 2), True),
+        ((13, 2), (12, 2), False),
+        # Equal
+        ((12, 2), (12, 2), True),
+        # Not equal
+        ((12, 2), (13, 3), True),
+        ((13, 2), (12, 3), False),
+        ((13, 2), (12, 1), False),
+    ],
+)
+def test_castable_decimal_to_decimal(source, target, expected):
+    left = dt.Decimal(*source)
+    right = dt.Decimal(*target)
+    assert left.castable(right) is expected

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -2981,7 +2981,12 @@ class Table(Expr, _FixedTextJupyterMixin):
             )
             aggs.append(agg)
 
-        t = ibis.union(*aggs)
+        names = aggs[0].schema().names
+        new_schema = {
+            name: dt.highest_precedence(types)
+            for name, *types in zip(names, *(agg.schema().types for agg in aggs))
+        }
+        t = ibis.union(*(agg.cast(new_schema) for agg in aggs))
 
         # TODO(jiting): Need a better way to remove columns with all NULL
         if string_col and not numeric_col:


### PR DESCRIPTION
Looks like we had some flipped logic in the `castable` branch for decimals that did not allow upcasting. Fixes #10467.