### PR TITLE
fix(sql): remove constants in `order_by` calls during select merging

### DIFF
--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -320,7 +320,9 @@ def merge_select_select(_, **kwargs):
         selections=selections,
         predicates=unique_predicates,
         qualified=unique_qualified,
-        sort_keys=unique_sort_keys,
+        sort_keys=tuple(
+            key for key in unique_sort_keys if not isinstance(key.expr, ops.Literal)
+        ),
         distinct=distinct,
     )
     return result if complexity(result) <= complexity(_) else _

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/bigquery/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  `t0`.`a`,
+  9 AS `i`,
+  'foo' AS `s`
+FROM `test` AS `t0`
+ORDER BY
+  `t0`.`a` ASC NULLS LAST

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/clickhouse/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a" AS "a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/databricks/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/databricks/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  `t0`.`a`,
+  9 AS `i`,
+  'foo' AS `s`
+FROM `test` AS `t0`
+ORDER BY
+  `t0`.`a` ASC NULLS LAST

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/datafusion/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/datafusion/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/druid/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/druid/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/duckdb/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/exasol/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/exasol/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/flink/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/flink/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  `t0`.`a`,
+  9 AS `i`,
+  'foo' AS `s`
+FROM `test` AS `t0`
+ORDER BY
+  `t0`.`a` ASC NULLS LAST

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/impala/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/impala/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  `t0`.`a`,
+  9 AS `i`,
+  'foo' AS `s`
+FROM `test` AS `t0`
+ORDER BY
+  `t0`.`a` ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/mssql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/mssql/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  [t0].[a],
+  9 AS [i],
+  'foo' AS [s]
+FROM [test] AS [t0]
+ORDER BY
+  CASE WHEN [t0].[a] IS NULL THEN 1 ELSE 0 END, [t0].[a] ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/mysql/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/mysql/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  `t0`.`a`,
+  9 AS `i`,
+  'foo' AS `s`
+FROM `test` AS `t0`
+ORDER BY
+  CASE WHEN `t0`.`a` IS NULL THEN 1 ELSE 0 END, `t0`.`a` ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/oracle/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/oracle/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/postgres/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/pyspark/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/pyspark/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  `t0`.`a`,
+  9 AS `i`,
+  'foo' AS `s`
+FROM `test` AS `t0`
+ORDER BY
+  `t0`.`a` ASC NULLS LAST

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/risingwave/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/risingwave/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/snowflake/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/snowflake/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/sqlite/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/sqlite/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC NULLS LAST

--- a/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_order_by_no_deference_literals/trino/out.sql
@@ -1,0 +1,7 @@
+SELECT
+  "t0"."a",
+  9 AS "i",
+  'foo' AS "s"
+FROM "test" AS "t0"
+ORDER BY
+  "t0"."a" ASC

--- a/ibis/backends/tests/test_sql.py
+++ b/ibis/backends/tests/test_sql.py
@@ -259,3 +259,13 @@ def test_sample(backend_name, snapshot, subquery):
     row = ibis.to_sql(t.sample(0.5, method="row"), dialect=backend_name)
     snapshot.assert_match(block, "block.sql")
     snapshot.assert_match(row, "row.sql")
+
+
+@pytest.mark.parametrize("backend_name", _get_backends_to_test())
+@pytest.mark.notimpl(["polars"], raises=ValueError, reason="not a SQL backend")
+def test_order_by_no_deference_literals(backend_name, snapshot):
+    t = ibis.table({"a": "int"}, name="test")
+    s = t.select("a", i=ibis.literal(9), s=ibis.literal("foo"))
+    o = s.order_by("a", "i", "s")
+    sql = ibis.to_sql(o, dialect=backend_name)
+    snapshot.assert_match(sql, "out.sql")


### PR DESCRIPTION
Remove literals in `ORDER BY` when sorting tables. Fixes #10428.