### PR TITLE
test(flink): disable pyarrow c stream test

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1222,7 +1222,10 @@ def test_memtable_construct_from_pyarrow(backend, con, monkeypatch):
     )
 
 
-def test_memtable_construct_from_pyarrow_c_stream(backend, con):
+@pytest.mark.notimpl(
+    ["flink"], raises=TypeError, reason="doesn't support pyarrow objects yet"
+)
+def test_memtable_construct_from_pyarrow_c_stream(con):
     pa = pytest.importorskip("pyarrow")
 
     class Opaque:


### PR DESCRIPTION
Fixes failing upstream test.