### PR TITLE
feat(geospatial): accept geopandas GDFs in `memtable`

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1294,6 +1294,19 @@ def test_memtable_column_naming_mismatch(con, monkeypatch, df, columns):
         ibis.memtable(df, columns=columns)
 
 
+@pytest.mark.notyet(
+    ["mssql", "mysql", "exasol", "impala"], reason="various syntax errors reported"
+)
+def test_memtable_from_geopandas_dataframe(con, data_dir):
+    gpd = pytest.importorskip("geopandas")
+    gdf = gpd.read_file(data_dir / "geojson" / "zones.geojson")[:5]
+
+    # Read in memtable
+    t = ibis.memtable(gdf)
+    # Execute a few rows to force ingestion
+    con.to_pandas(t.limit(2).select("geometry"))
+
+
 @pytest.mark.notimpl(["oracle", "exasol"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["druid"], raises=AssertionError)
 @pytest.mark.notyet(


### PR DESCRIPTION
## Description of changes

Passing a `geopandas.GeoDataFrame` directly to `memtable` will yield a bunch of
errors because our various `to_arrow` and other proxy methods don't know how to
handle the bundled geo data.

As an intermediate bit of functionality until things like `geoarrow` are more
widely supported, this PR adds an extra dispatch to the `memtable` constructor
to cast geometry columns to WKB, which allows most backends to ingest the
resulting data with the geo columns as binary, which can then be cast to
`geometry` columns in backends that support that.

## Issues closed

Resolves #10453
