### PR TITLE
test(snowflake,bigquery,databricks): xfail test for pyarrow decimal memtable construction with ints

### DIFF
--- a/ibis/backends/tests/test_numeric.py
+++ b/ibis/backends/tests/test_numeric.py
@@ -1551,7 +1551,15 @@ def test_scalar_round_is_integer(con):
             [1, 2, 3],
             marks=[
                 pytest.mark.notyet(
-                    ["duckdb", "clickhouse", "datafusion"], raises=pa.ArrowInvalid
+                    [
+                        "duckdb",
+                        "clickhouse",
+                        "datafusion",
+                        "snowflake",
+                        "databricks",
+                        "bigquery",
+                    ],
+                    raises=pa.ArrowInvalid,
                 ),
                 pytest.mark.notyet(
                     ["pyspark"],


### PR DESCRIPTION
Fixes upstream cloud test failures.