### PR TITLE
docs(examples): align Table.get_backend with ibis.get_backend examples

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -388,11 +388,12 @@ class Expr(Immutable, Coercible):
         >>> import ibis
         >>> con = ibis.duckdb.connect()
         >>> t = con.create_table("t", {"id": [1, 2, 3]})
-        >>> backend = t.get_backend()
-        >>> backend.name
-        'duckdb'
-        >>> type(backend)
-        <class 'ibis.backends.duckdb.Backend'>
+        >>> t.get_backend()  # doctest: +ELLIPSIS
+        <ibis.backends.duckdb.Backend object at 0x...>
+
+        See Also
+        --------
+        [`ibis.get_backend()`](./connection.qmd#ibis.get_backend)
         """
         return self._find_backend(use_default=True)
 


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

This makes the example more concise and similar to the `ibis.get_backend()` example. That `# doctest: +ELLIPSIS` usage comes in handy. 

Adds the "See Also" to link to the other `ibis.get_backend` method. 

