### PR TITLE
fix(docs): add null examples header and expected failure

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2723,9 +2723,11 @@ def null(type: dt.DataType | str | None = None) -> Value:
     `NULL`s with an unspecified type are castable and comparable to values,
     but lack datatype-specific methods:
 
+    Examples
+    --------
     >>> import ibis
     >>> ibis.options.interactive = True
-    >>> ibis.null().upper()
+    >>> ibis.null().upper()  # quartodoc: +EXPECTED_FAILURE
     Traceback (most recent call last):
         ...
     AttributeError: 'NullScalar' object has no attribute 'upper'


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds the section header for the examples for [null](https://ibis-project.org/reference/expression-generic#ibis.null). 

I added the expected failure annotation, but the `# quartodoc: +EXPECTED_FAILURE` comment still shows up in the render. 

<img width="626" alt="image" src="https://github.com/user-attachments/assets/e4335aef-fffc-400e-a444-b491f8711922">

I wasn't sure if there was something special I needed to do for it not to show up, like how this is here but the # doesn't show up in the [pivot_longer examples](https://ibis-project.org/reference/expression-tables.html#examples-28). 

https://github.com/ibis-project/ibis/blob/4d9901897fbcb4a480bafda3f98d85a9a32f9ed6/ibis/expr/types/relations.py#L3807-L3811

<img width="701" alt="image" src="https://github.com/user-attachments/assets/73b4af83-719c-458e-9b9f-cfe815169751">
