### PR TITLE
feat(export): implement the `Column.to_list()` API

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,5 @@ ibis/examples/pixi.lock linguist-generated=true
 requirements-dev.txt linguist-generated=true
 docs/_freeze/**/html.json linguist-generated=true
 docs/**/*.excalidraw linguist-generated=true
+# GitHub syntax highlighting
+pixi.lock linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,7 @@ docs/**/*.html
 .jupyterlite.doit.db
 docs/jupyter_lite_config.json
 *.quarto_ipynb
+
+# pixi environments
+.pixi
+*.egg-info

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -591,6 +591,15 @@ def test_column_to_memory(limit, awards_players, output_format, expected_column_
     ) == awards_players.count().execute()
 
 
+@pytest.mark.parametrize("limit", limit_no_limit)
+def test_column_to_list(limit, awards_players):
+    res = awards_players.awardID.to_list(limit=limit)
+    assert isinstance(res, list)
+    assert (limit is not None and len(res) == limit) or len(
+        res
+    ) == awards_players.count().execute()
+
+
 @pytest.mark.parametrize("limit", no_limit)
 @pytest.mark.parametrize(
     ("output_format", "converter"),

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -586,18 +586,22 @@ def test_column_to_memory(limit, awards_players, output_format, expected_column_
     method = methodcaller(f"to_{output_format}", limit=limit)
     res = method(awards_players.awardID)
     assert isinstance(res, getattr(mod, expected_column_type))
-    assert (limit is not None and len(res) == limit) or len(
-        res
-    ) == awards_players.count().execute()
+    assert (
+        (len(res) == limit)
+        if limit is not None
+        else len(res) == awards_players.count().execute()
+    )
 
 
 @pytest.mark.parametrize("limit", limit_no_limit)
 def test_column_to_list(limit, awards_players):
     res = awards_players.awardID.to_list(limit=limit)
     assert isinstance(res, list)
-    assert (limit is not None and len(res) == limit) or len(
-        res
-    ) == awards_players.count().execute()
+    assert (
+        (len(res) == limit)
+        if limit is not None
+        else len(res) == awards_players.count().execute()
+    )
 
 
 @pytest.mark.parametrize("limit", no_limit)

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1200,7 +1200,7 @@ class Value(Expr):
         return ops.SortKey(self, ascending=False, nulls_first=nulls_first).to_expr()
 
     def to_pandas(self, **kwargs) -> pd.Series:
-        """Convert a column expression to a pandas Series or scalar object.
+        """Convert an expression to a pandas or scalar object.
 
         Parameters
         ----------
@@ -2683,6 +2683,24 @@ class Column(Value, _FixedTextJupyterMixin):
         └────────┴───────┘
         """
         return ops.NthValue(self, n).to_expr()
+
+    def to_list(self, **kwargs) -> list:
+        """Convert a column expression to a list.
+
+        Parameters
+        ----------
+        kwargs
+            Same as keyword arguments to [`to_pyarrow`](#ibis.expr.types.core.Expr.to_pyarrow)
+
+        Examples
+        --------
+        >>> import ibis
+        >>> ibis.options.interactive = True
+        >>> t = ibis.examples.penguins.fetch().limit(5)
+        >>> t.bill_length_mm.to_list()
+        [39.1, 39.5, 40.3, None, 36.7]
+        """
+        return self.to_pyarrow(**kwargs).to_pylist()
 
 
 @public

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -1211,8 +1211,8 @@ class Value(Expr):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.examples.penguins.fetch().limit(5)
-        >>> t.to_pandas()
+        >>> t = ibis.examples.penguins.fetch()
+        >>> t.to_pandas(limit=5)
           species     island  bill_length_mm  ...  body_mass_g     sex  year
         0  Adelie  Torgersen            39.1  ...       3750.0    male  2007
         1  Adelie  Torgersen            39.5  ...       3800.0  female  2007
@@ -2696,8 +2696,8 @@ class Column(Value, _FixedTextJupyterMixin):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.examples.penguins.fetch().limit(5)
-        >>> t.bill_length_mm.to_list()
+        >>> t = ibis.examples.penguins.fetch()
+        >>> t.bill_length_mm.to_list(limit=5)
         [39.1, 39.5, 40.3, None, 36.7]
         """
         return self.to_pyarrow(**kwargs).to_pylist()


### PR DESCRIPTION
## Description of changes

Implement `Column.to_list()` convenience method to avoid having to do `Column.to_pyarrow().to_pylist()` manually.

## Issues closed

* Resolves #10102
