### PR TITLE
docs(api): deprecate `to_array` in favor of `as_scalar` in docstring

### DIFF
--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1812,13 +1812,8 @@ class Table(Expr, _FixedTextJupyterMixin):
 
     @deprecated(as_of="9.0", instead="use table.as_scalar() instead")
     def to_array(self) -> ir.Column:
-        """View a single column table as an array.
+        """Deprecated - use `as_scalar` instead."""
 
-        Returns
-        -------
-        Value
-            A single column view of a table
-        """
         schema = self.schema()
         if len(schema) != 1:
             raise com.ExpressionError(


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

While reviewing the remaining table expression methods that needed examples, I noticed that [`to_array`](https://ibis-project.org/reference/expression-tables#ibis.expr.types.relations.Table.to_array) did not include the deprecation docstring. The added deprecation note is similar to that of [`dropna`](https://ibis-project.org/reference/expression-tables#ibis.expr.types.relations.Table.dropna) and [`relabel`](https://ibis-project.org/reference/expression-tables#ibis.expr.types.relations.Table.relabel).  
