### PR TITLE
build(ruff): remove unnecessary target-version use

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -443,7 +443,6 @@ markers = [
 line-length = 88
 respect-gitignore = true
 exclude = [".direnv", "result-*", "*_py310.py", "decompiled.py", "out_tpch.py"]
-target-version = "py310"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Description of changes

`target-version` is duplicative/unnecessarily-overriding `requires-python`; see https://docs.astral.sh/ruff/settings/#target-version.