### PR TITLE
docs(examples): add example and see also ref for `compile` and `ibis.to_sql`

### DIFF
--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -470,7 +470,7 @@ def to_sql(
     >>> import ibis
     >>> t = ibis.table({"a": "int", "b": "int"}, name="t")
     >>> expr = t.mutate(c=t.a + t.b)
-    >>> ibis.to_sql(expr)
+    >>> ibis.to_sql(expr)  # doctest: +SKIP
     SELECT
       "t0"."a",
       "t0"."b",
@@ -478,7 +478,7 @@ def to_sql(
     FROM "t" AS "t0"
 
     You can also specify the SQL dialect to use for compilation:
-    >>> ibis.to_sql(expr, dialect="mysql")
+    >>> ibis.to_sql(expr, dialect="mysql")  # doctest: +SKIP
     SELECT
       `t0`.`a`,
       `t0`.`b`,

--- a/ibis/expr/sql.py
+++ b/ibis/expr/sql.py
@@ -465,6 +465,30 @@ def to_sql(
     str
         Formatted SQL string
 
+    Examples
+    --------
+    >>> import ibis
+    >>> t = ibis.table({"a": "int", "b": "int"}, name="t")
+    >>> expr = t.mutate(c=t.a + t.b)
+    >>> ibis.to_sql(expr)
+    SELECT
+      "t0"."a",
+      "t0"."b",
+      "t0"."a" + "t0"."b" AS "c"
+    FROM "t" AS "t0"
+
+    You can also specify the SQL dialect to use for compilation:
+    >>> ibis.to_sql(expr, dialect="mysql")
+    SELECT
+      `t0`.`a`,
+      `t0`.`b`,
+      `t0`.`a` + `t0`.`b` AS `c`
+    FROM `t` AS `t0`
+
+    See Also
+    --------
+    [`Table.compile()`](./expression-tables.qmd#ibis.expr.types.relations.Table.compile)
+
     """
     import ibis.backends.sql.compilers as sc
 


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds Examples section and See Also reference for [`Table.compile()`](https://ibis-project.org/reference/expression-tables.html#ibis.expr.types.relations.Table.compile) and [`ibis.to_sql()`](https://ibis-project.org/reference/expression-generic.html#ibis.to_sql)

Adds return type information for `Table.compile()`. 

There might be an opportunity to improve the wording of `to_sql` regarding the usage of the word "formatted - I will add suggestion if we think this is something we want to do. 