### PR TITLE
docs: reword backend counting to nearly 20 from 20+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ibis is the portable Python dataframe library:
 - Lazy dataframe expressions
 - Interactive mode for iterative data exploration
 - [Compose Python dataframe and SQL code](#python--sql-better-together)
-- Use the same dataframe API for [20+ backends](#backends)
+- Use the same dataframe API for [nearly 20 backends](#backends)
 - Iterate locally and deploy remotely by [changing a single line of code](#portability)
 
 See the documentation on ["Why Ibis?"](https://ibis-project.org/why) to learn more.

--- a/docs/how-to/extending/unbound_expression.qmd
+++ b/docs/how-to/extending/unbound_expression.qmd
@@ -107,7 +107,7 @@ con.table("results").to_pandas()
 
 Because Ibis separates the transformation logic from the execution engine, you
 can easily reuse the written transformation for another backend. Here we use
-Polars as an example, but you can do the same for any of Ibis' 20+ supported
+Polars as an example, but you can do the same for any of Ibis' nearly 20 supported
 backends as long as that particular backend supports the operations
 (see [the operation support matrix](../../backends/support/matrix.qmd)).
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -46,7 +46,7 @@ about:
 
 ### An open source dataframe library that works with any data system
 
-- Use the same API for 20+ backends
+- Use the same API for nearly 20 backends
 - Fast local dataframes with embedded DuckDB (default), Polars, or DataFusion
 - Iterate locally and deploy remotely by changing a single line of code
 - Compose SQL and Python dataframe code, bridging the gap between data engineering and data science
@@ -90,9 +90,9 @@ grouped  # <2>
 1. Transform the table.
 2. Display the transformed table.
 
-### One API for 20+ backends
+### One API for nearly 20 backends
 
-Use the same dataframe API for 20+ backends:
+Use the same dataframe API for nearly 20 backends:
 
 ```{python}
 #| code-fold: true

--- a/docs/why.qmd
+++ b/docs/why.qmd
@@ -3,7 +3,7 @@ title: "Why Ibis?"
 ---
 
 Ibis defines a Python dataframe API that executes on any query engine -- the
-frontend for any backend data platform, with 20+ backends today.  This allows
+frontend for any backend data platform, with nearly 20 backends today. This allows
 Ibis to have excellent performance -- as good as the backend it is connected to
 -- with a consistent user experience.
 
@@ -186,7 +186,7 @@ practitioners. It also allows organizations to:
 
 Python developers creating libraries can use Ibis to:
 
-- instantly support 20+ data backends
+- instantly support nearly 20 data backends
 - instantly support pandas, PyArrow, and Polars objects
 - read and write from all common file formats (depending on the backend)
 - trace column-level lineage through Ibis expressions


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Back in https://github.com/ibis-project/ibis/pull/10259, I adjusted the messaging around the backend count in the README to represent the changes after removing the pandas and Dask backends. This PR applies this fix in more locations. I did not adjust any presentations or previous blog posts, as the count was correct then. 