### PR TITLE
chore(ci): skip nixos on mac-14, python3.12 for docs only prs

### DIFF
--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -40,6 +40,8 @@ jobs:
           - os: ubuntu-arm64-24.04
             python-version: "3.12"
           - os: macos-14
-            python-version: "3.10"
+            python-version:
+              - "3.10"
+              - "3.12"
     steps:
       - run: echo "No build required"


### PR DESCRIPTION
## Description of changes

Adding one more entry to the nix skip helper so we aren't waiting forever for a job that will never run
