### PR TITLE
docs(examples): add distinct and rest arg examples for `ibis.intersect` and `Table.intersect`

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2079,11 +2079,15 @@ def intersect(table: ir.Table, *rest: ir.Table, distinct: bool = True) -> ir.Tab
     Table
         A new table containing the intersection of all input tables.
 
+    See Also
+    --------
+    [`Table.intersect`](./expression-tables.qmd#ibis.expr.types.relations.Table.intersect)
+
     Examples
     --------
     >>> import ibis
     >>> ibis.options.interactive = True
-    >>> t1 = ibis.memtable({"a": [1, 2]})
+    >>> t1 = ibis.memtable({"a": [1, 2, 2]})
     >>> t1
     ┏━━━━━━━┓
     ┃ a     ┃
@@ -2092,14 +2096,16 @@ def intersect(table: ir.Table, *rest: ir.Table, distinct: bool = True) -> ir.Tab
     ├───────┤
     │     1 │
     │     2 │
+    │     2 │
     └───────┘
-    >>> t2 = ibis.memtable({"a": [2, 3]})
+    >>> t2 = ibis.memtable({"a": [2, 2, 3]})
     >>> t2
     ┏━━━━━━━┓
     ┃ a     ┃
     ┡━━━━━━━┩
     │ int64 │
     ├───────┤
+    │     2 │
     │     2 │
     │     3 │
     └───────┘
@@ -2111,7 +2117,15 @@ def intersect(table: ir.Table, *rest: ir.Table, distinct: bool = True) -> ir.Tab
     ├───────┤
     │     2 │
     └───────┘
-
+    >>> ibis.intersect(t1, t2, distinct=False)
+    ┏━━━━━━━┓
+    ┃ a     ┃
+    ┡━━━━━━━┩
+    │ int64 │
+    ├───────┤
+    │     2 │
+    │     2 │
+    └───────┘
     """
     return table.intersect(*rest, distinct=distinct) if rest else table
 

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -2126,6 +2126,17 @@ def intersect(table: ir.Table, *rest: ir.Table, distinct: bool = True) -> ir.Tab
     │     2 │
     │     2 │
     └───────┘
+
+    More than two table expressions can be intersected at once.
+    >>> t3 = ibis.memtable({"a": [2, 3, 3]})
+    >>> ibis.intersect(t1, t2, t3)
+    ┏━━━━━━━┓
+    ┃ a     ┃
+    ┡━━━━━━━┩
+    │ int64 │
+    ├───────┤
+    │     2 │
+    └───────┘
     """
     return table.intersect(*rest, distinct=distinct) if rest else table
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1757,6 +1757,17 @@ class Table(Expr, _FixedTextJupyterMixin):
         │     2 │
         │     2 │
         └───────┘
+
+        More than two table expressions can be intersected at once.
+        >>> t3 = ibis.memtable({"a": [2, 3, 3]})
+        >>> t1.intersect(t2, t3)
+        ┏━━━━━━━┓
+        ┃ a     ┃
+        ┡━━━━━━━┩
+        │ int64 │
+        ├───────┤
+        │     2 │
+        └───────┘
         """
         return self._assemble_set_op(ops.Intersection, table, *rest, distinct=distinct)
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1718,7 +1718,7 @@ class Table(Expr, _FixedTextJupyterMixin):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t1 = ibis.memtable({"a": [1, 2]})
+        >>> t1 = ibis.memtable({"a": [1, 2, 2]})
         >>> t1
         ┏━━━━━━━┓
         ┃ a     ┃
@@ -1727,14 +1727,16 @@ class Table(Expr, _FixedTextJupyterMixin):
         ├───────┤
         │     1 │
         │     2 │
+        │     2 │
         └───────┘
-        >>> t2 = ibis.memtable({"a": [2, 3]})
+        >>> t2 = ibis.memtable({"a": [2, 2, 3]})
         >>> t2
         ┏━━━━━━━┓
         ┃ a     ┃
         ┡━━━━━━━┩
         │ int64 │
         ├───────┤
+        │     2 │
         │     2 │
         │     3 │
         └───────┘
@@ -1744,6 +1746,15 @@ class Table(Expr, _FixedTextJupyterMixin):
         ┡━━━━━━━┩
         │ int64 │
         ├───────┤
+        │     2 │
+        └───────┘
+        >>> t1.intersect(t2, distinct=False)
+        ┏━━━━━━━┓
+        ┃ a     ┃
+        ┡━━━━━━━┩
+        │ int64 │
+        ├───────┤
+        │     2 │
         │     2 │
         └───────┘
         """


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds documentation examples to demonstrate `rest` and `distinct` usage for [`Table.intersect`](https://ibis-project.org/reference/expression-tables#ibis.expr.types.relations.Table.intersect) and [`ibis.intersect`](https://ibis-project.org/reference/expression-tables#ibis.intersect).

### TODOs on `difference` and `union` examples

I don't think I realized until today that `intersect`, `union`, and `difference` can handle more than two table expressions at once. This is super convenient. I can add `rest` examples for the other two soon.

I'm not sure about putting together a `distinct` example for `difference` and `union` already has one. 