### PR TITLE
docs: add callout notes for some APIs changes and additions

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -392,7 +392,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         >>> import ibis
         >>> ibis.duckdb.connect(threads=4, memory_limit="1GB")  # doctest: +ELLIPSIS
         <ibis.backends.duckdb.Backend object at 0x...>
-
         """
         if not isinstance(database, Path) and not database.startswith(
             ("md:", "motherduck:", ":memory:")

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -365,6 +365,15 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
     ) -> None:
         """Create an Ibis client connected to a DuckDB database.
 
+        ::: {.callout-note title="Changed in version 10.0.0"}
+        Before, we had special handling if the user passed the `temp_directory`
+        parameter, setting a custom default, and creating intermediate
+        directories if necessary. Now, we do nothing, and just pass the value
+        directly to DuckDB. You may need to add
+        `Path(your_temp_dir).mkdir(exists_ok=True, parents=True)`
+        to your code to maintain the old behavior.
+        :::
+
         Parameters
         ----------
         database
@@ -383,6 +392,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         >>> import ibis
         >>> ibis.duckdb.connect(threads=4, memory_limit="1GB")  # doctest: +ELLIPSIS
         <ibis.backends.duckdb.Backend object at 0x...>
+
         """
         if not isinstance(database, Path) and not database.startswith(
             ("md:", "motherduck:", ":memory:")

--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -1184,6 +1184,9 @@ def cases(
 
     Equivalent to a SQL `CASE` statement.
 
+    ::: {.callout-note title="Added in version 10.0.0"}
+    :::
+
     Parameters
     ----------
     branch

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2064,6 +2064,9 @@ class Column(Value, _FixedTextJupyterMixin):
         Computes a Table containing the top `k` values by a certain metric
         (defaults to count).
 
+        ::: {.callout-note title="Changed in version 9.5.0"}
+        Added `name` parameter.
+
         Parameters
         ----------
         k
@@ -2122,6 +2125,7 @@ class Column(Value, _FixedTextJupyterMixin):
         │ J      │      5.01 │
         │ H      │      4.13 │
         └────────┴───────────┘
+        :::
         """
         from ibis.expr.types.relations import bind
 
@@ -2268,6 +2272,9 @@ class Column(Value, _FixedTextJupyterMixin):
         │ c      │     3 │
         │ d      │     4 │
         └────────┴───────┘
+
+        ::: {.callout-note title="Added in version 9.5.0"}
+        :::
         """
         colname = self.get_name()
         if name is None:
@@ -2774,6 +2781,9 @@ class Column(Value, _FixedTextJupyterMixin):
         >>> t = ibis.examples.penguins.fetch()
         >>> t.bill_length_mm.to_list(limit=5)
         [39.1, 39.5, 40.3, None, 36.7]
+
+        ::: {.callout-note title="Added in version 10.0.0"}
+        :::
         """
         return self.to_pyarrow(**kwargs).to_pylist()
 

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2066,6 +2066,7 @@ class Column(Value, _FixedTextJupyterMixin):
 
         ::: {.callout-note title="Changed in version 9.5.0"}
         Added `name` parameter.
+        :::
 
         Parameters
         ----------
@@ -2125,7 +2126,6 @@ class Column(Value, _FixedTextJupyterMixin):
         │ J      │      5.01 │
         │ H      │      4.13 │
         └────────┴───────────┘
-        :::
         """
         from ibis.expr.types.relations import bind
 

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -4688,6 +4688,10 @@ class Table(Expr, _FixedTextJupyterMixin):
     def value_counts(self, *, name: str | None = None) -> ir.Table:
         """Compute a frequency table of this table's values.
 
+        ::: {.callout-note title="Changed in version 10.0.0"}
+        Added `name` parameter.
+        :::
+
         Parameters
         ----------
         name


### PR DESCRIPTION
fixes https://github.com/ibis-project/ibis/issues/10535

Other things I considered:

## using some other mechanism, like sphinx versionadded directives

like https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded

but I don't think our doc system uses sphinx. So I think we are limited to using quarto's constructs?

## using a different callout type

[There is warning, tip, etc](https://quarto.org/docs/authoring/callouts.html#callout-types). I thought note made the most sense.

## Adding a `@versionadded` decorator

Similar to the `@experimental` and `@deprecated` decorators in util.py. But I thought adding them inline like this wasn't that hard.

## Placing the callout in a different place in the docstring

eg further up, where it might be more obvious. [But the official python docs put them down at the bottom](https://docs.python.org/3/library/enum.html#enum.Enum.__format__), so I chose to follow that convention. I think that future-proofs us if there are multiple callouts in a row.

## Some sort of autocheck

In future PRs, how can we be sure that docstrings are updated like this? I couldn't think of a good way to do it. Maybe if there is a `breaking-change` tag on the issue? but that doesn't work for `Added in version` changes. I think the best we can do is to just have all maintainers be aware of this. If we like this approach then we can tag in all the maintainers into this issue?