### PR TITLE
test: use more precise marker for backends that don't support arrays

### DIFF
--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -827,8 +827,13 @@ def test_capitalize(con, inp, expected):
         assert pd.isnull(result)
 
 
+@pytest.mark.notyet(
+    ["exasol", "impala", "mssql", "mysql", "sqlite"],
+    reason="Backend doesn't support arrays",
+    raises=(com.OperationNotDefinedError, com.UnsupportedBackendType),
+)
 @pytest.mark.notimpl(
-    ["polars", "oracle", "flink", "sqlite", "mssql", "mysql", "exasol", "impala"],
+    ["polars", "oracle", "flink"],
     raises=com.OperationNotDefinedError,
 )
 def test_array_string_join(con):


### PR DESCRIPTION
I'm cherry-picking some of the changes that I have in https://github.com/ibis-project/ibis/pull/9473/ that are still useful without the rest of that PR.