### PR TITLE
fix(docs): render func args as args, not list of args

### DIFF
--- a/docs/backends/_utils.py
+++ b/docs/backends/_utils.py
@@ -63,7 +63,7 @@ def render_method(*, member, renderer: MdRenderer) -> Iterator[str]:
     yield f"{header} {name} {{ #{member.path} }}"
     yield "\n"
     if params is not None:
-        yield f"`{name}({params})`"
+        yield f"`{name}({', '.join(params)})`"
     yield "\n"
 
     yield get_renderer(header_level + 1).render(find_member_with_docstring(member))


### PR DESCRIPTION
## Description of changes

Fixes the way we render docstrings in the docs so that we show the argument
names, and keyword defaults, as they should be entered, and not as a list of
strings.

## Issues closed

Fixes #10558