### PR TITLE
docs(blog): convert case to cases in blog posts

### DIFF
--- a/docs/posts/classification-metrics-on-the-backend/index.qmd
+++ b/docs/posts/classification-metrics-on-the-backend/index.qmd
@@ -98,13 +98,11 @@ We can use the `case` function to create a new column that categorizes the outco
 
 ```{python}
 
-case_expr = (
-    ibis.case()
-    .when((_.actual == 0) & (_.prediction == 0), "TN")
-    .when((_.actual == 0) & (_.prediction == 1), "FP")
-    .when((_.actual == 1) & (_.prediction == 0), "FN")
-    .when((_.actual == 1) & (_.prediction == 1), "TP")
-    .end()
+case_expr = ibis.cases(
+    ((_.actual == 0) & (_.prediction == 0), "TN"),
+    ((_.actual == 0) & (_.prediction == 1), "FP"),
+    ((_.actual == 1) & (_.prediction == 0), "FN"),
+    ((_.actual == 1) & (_.prediction == 1), "TP"),
 )
 
 t = t.mutate(outcome=case_expr)

--- a/docs/posts/ibis-bench/index.qmd
+++ b/docs/posts/ibis-bench/index.qmd
@@ -278,51 +278,56 @@ type, number of cores, and memory in gigabytes:
 ```{python}
 #| code-fold: true
 #| code-summary: "Show code to get instance details"
-cpu_type_cases = (
-    ibis.case()
-    .when(
+cpu_type_cases = ibis.cases(
+    (
         ibis._["instance_type"].startswith("n2d"),
         "AMD EPYC",
-    )
-    .when(
+    ),
+    (
         ibis._["instance_type"].startswith("n2"),
         "Intel Cascade and Ice Lake",
-    )
-    .when(
+    ),
+    (
         ibis._["instance_type"].startswith("c3"),
         "Intel Sapphire Rapids",
-    )
-    .when(
+    ),
+    (
         ibis._["instance_type"] == "work laptop",
         "Apple M1 Max",
-    )
-    .when(
+    ),
+    (
         ibis._["instance_type"] == "personal laptop",
         "Apple M2 Max",
-    )
-    .else_("unknown")
-    .end()
+    ),
+    else_="unknown",
 )
-cpu_num_cases = (
-    ibis.case()
-    .when(
+
+cpu_num_cases = ibis.cases(
+    (
         ibis._["instance_type"].contains("-"),
         ibis._["instance_type"].split("-")[-1].cast("int"),
-    )
-    .when(ibis._["instance_type"].contains("laptop"), 12)
-    .else_(0)
-    .end()
+    ),
+    (
+        ibis._["instance_type"].contains("laptop"),
+        12,
+    ),
+    else_=0,
 )
-memory_gb_cases = (
-    ibis.case()
-    .when(
+
+memory_gb_cases = ibis.cases(
+    (
         ibis._["instance_type"].contains("-"),
         ibis._["instance_type"].split("-")[-1].cast("int") * 4,
-    )
-    .when(ibis._["instance_type"] == "work laptop", 32)
-    .when(ibis._["instance_type"] == "personal laptop", 96)
-    .else_(0)
-    .end()
+    ),
+    (
+        ibis._["instance_type"] == "work laptop",
+        32,
+    ),
+    (
+        ibis._["instance_type"] == "personal laptop",
+        96,
+    ),
+    else_=0,
 )
 
 instance_details = (


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

> [!NOTE]  
> I wanted to prep this to easy swap when 10.0 is released and `ibis.case()` is deprecated. We should keep the current usage of `ibis.case()` until 10.0 is ready.

## Description of changes

I noticed today that the classification metrics blog post still used `ibis.case()` rather than `ibis.cases()`. This was intended so that if readers installed using PyPI or conda, the `case` example would still be viable. 

This fixes the usage in the following posts:
- [Ibis benchmarking: DuckDB, DataFusion, Polars](https://ibis-project.org/posts/ibis-bench/)
- [Classification metrics on the backend](https://ibis-project.org/posts/classification-metrics-on-the-backend/)
