### PR TITLE
docs(blog): fix metric print output in classification blog

### DIFF
--- a/docs/posts/classification-metrics-on-the-backend/index.qmd
+++ b/docs/posts/classification-metrics-on-the-backend/index.qmd
@@ -215,7 +215,7 @@ f1_score_expr = 2 * tp / (t.actual.sum() + t.prediction.sum())
 print(
     f"accuracy={accuracy_expr.to_pyarrow().as_py()}",
     f"precision={precision_expr.to_pyarrow().as_py()}",
-    f"precision={recall_expr.to_pyarrow().as_py()}",
+    f"recall_expr={recall_expr.to_pyarrow().as_py()}",
     f"f1_score={f1_score_expr.to_pyarrow().as_py()}",
     sep="\n",
 )


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

I accidentally left two precision score prints, one of which was the recall score. 
