### PR TITLE
ci(nix): make skip helper python version match the non-skipped job

### DIFF
--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -40,8 +40,6 @@ jobs:
           - os: ubuntu-arm64-24.04
             python-version: "3.12"
           - os: macos-14
-            python-version:
-              - "3.10"
-              - "3.12"
+            python-version: "3.12"
     steps:
       - run: echo "No build required"


### PR DESCRIPTION
This PR should allow jobs to complete again.