### PR TITLE
fix(deps): enable running uv lock command in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --group dev --group tests \
+    uv venv && uv sync --group dev --group tests \
         --extra duckdb --extra clickhouse  --extra examples --extra geospatial
 
 ENV VENV_DIR=.venv
@@ -35,6 +35,8 @@ RUN chown -R $USERNAME $IBIS_PROJECT
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"
+
+SHELL ["/bin/bash", "-c", "source .venv/bin/activate"]
 
 ENTRYPOINT []
 

--- a/docs/contribute/01_environment.qmd
+++ b/docs/contribute/01_environment.qmd
@@ -238,10 +238,11 @@ for manager, params in managers.items():
 1. To exit a container, click the `Dev Container` button on the lower left of the
     window and select the last menu option, `Close Remote Connection`.
 
-1. To ensure you have the latest dependencies from the main branch based on
+1. To ensure you have the latest dependencies from the main upstream branch based on
     `pyproject.toml`:
 
     * Exit any running container.
+    * Sync your fork.
     * From your local Git repo, `git pull origin main`.
     * Reopen the project in a new container.
     * `Rebuild Container` to copy files from the local Git repo and have the build


### PR DESCRIPTION
## Description of changes

Update devcontainer through build (.devcontainer/Dockerfile) to name the virtual environment using the default uv virtual environment name ('venv') and activate it.

## Issues closed

Resolves #10575
