### PR TITLE
docs(development): update dev env matrices for accuracy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.11
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.13
 COPY --from=ghcr.io/astral-sh/uv:0.5.9 /uv /uvx /bin/
 ARG USERNAME=vscode
 

--- a/docs/contribute/01_environment.qmd
+++ b/docs/contribute/01_environment.qmd
@@ -24,7 +24,6 @@ architectures.
 
 |                                            |   Python 3.10                |   Python 3.11    |   Python 3.12    |
 | -----------------------------------------: | :--------------------------: | :--------------: | :--------------: |
-|                                            |                              |                  |                  |
 |                                  **Linux** | {{< fa check >}}[^supported] | {{< fa check >}} | {{< fa check >}} |
 |                         **macOS (x86_64)** | {{< fa check >}}             | {{< fa check >}} | {{< fa check >}} |
 |                        **macOS (aarch64)** | {{< fa check >}}             | {{< fa check >}} | {{< fa check >}} |
@@ -124,13 +123,13 @@ for manager, params in managers.items():
 
 ### Support matrix
 
-|                          |  Python 3.10                 |   Python 3.11             |   Python 3.12             |   Python 3.13             |
-| -----------------------: | :--------------------------: | :-----------------------: | :-----------------------: | :-----------------------: |
-|       **Linux (x86_64)** | {{< fa check >}}[^supported] | {{< fa check >}}          | {{< fa check >}}          | {{< fa check >}}          |
-|        **Linux (arm64)** | {{< fa check >}}             | {{< fa check >}}          | {{< fa check >}}          | {{< fa check >}}          |
-|       **macOS (x86_64)** | {{< fa check >}}             | {{< fa check >}}          | {{< fa check >}}          | {{< fa check >}}          |
-|  **macOS (arm64/M1/M2)** | {{< fa check >}}             | {{< fa check >}}          | {{< fa check >}}          | {{< fa check >}}          |
-|              **Windows** | {{< fa ban >}}[^unlikely]    | {{< fa ban >}}[^unlikely] | {{< fa ban >}}[^unlikely] | {{< fa ban >}}[^unlikely] |
+|                          | Python 3.10                  | Python 3.11        | Python 3.12        | Python 3.13        |
+| -----------------------: | :--------------------------: | :----------------: | :----------------: | :----------------: |
+|       **Linux (x86_64)** | {{< fa check >}}[^supported] | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   |
+|        **Linux (arm64)** | {{< fa check >}}             | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   |
+|       **macOS (x86_64)** | {{< fa check >}}             | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   |
+|  **macOS (arm64/M1/M2)** | {{< fa check >}}             | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   |
+|              **Windows** | {{< fa ban >}}[^unlikely]    | {{< fa ban >}}     | {{< fa ban >}}     | {{< fa ban >}}     |
 
 1.  [Install `nix`](https://nixos.org/download.html)
 1.  Configure `nix`
@@ -185,13 +184,12 @@ for manager, params in managers.items():
 
 ### Support matrix
 
-|                                            |  Python 3.9                  |  Python 3.10              |   Python 3.11             |
-| -----------------------------------------: | :--------------------------: | :-----------------------: | :-----------------------: |
-|                                            |                              |                           |                           |
-|                                  **Linux** | {{< fa check >}}             | {{< fa check >}}          | {{< fa check >}}          |
-|                         **macOS (x86_64)** | {{< fa check >}}             | {{< fa check >}}          | {{< fa check >}}          |
-|                    **macOS (arm64/M1/M2)** | {{< fa check >}}             | {{< fa check >}}          | {{< fa check >}}          |
-|                                **Windows** | {{< fa check >}}             | {{< fa check >}}          | {{< fa check >}}          |
+|                         | Python 3.10        | Python 3.11        | Python 3.12        | Python 3.13        |
+| ----------------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+|               **Linux** | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   |
+|      **macOS (x86_64)** | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   |
+| **macOS (arm64/M1/M2)** | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   |
+|             **Windows** | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   | {{< fa check >}}   |
 
 1. Git clone the project repository.
 


### PR DESCRIPTION
Bump the devcontainer python version to 3.13 and update dev env matrices for accuracy