### PR TITLE
test(sqlite): use context managers for sqlite connections to avoid `ResourceWarning` in python 3.13

### DIFF
--- a/ibis/backends/duckdb/tests/test_io.py
+++ b/ibis/backends/duckdb/tests/test_io.py
@@ -211,8 +211,8 @@ def test_read_mysql(con, mysqlurl):  # pragma: no cover
 def test_read_sqlite(con, tmp_path):
     path = tmp_path / "test.db"
 
-    sqlite_con = sqlite3.connect(str(path))
-    sqlite_con.execute("CREATE TABLE t AS SELECT 1 a UNION SELECT 2 UNION SELECT 3")
+    with sqlite3.connect(str(path)) as sqlite_con:
+        sqlite_con.execute("CREATE TABLE t AS SELECT 1 a UNION SELECT 2 UNION SELECT 3")
 
     ft = con.read_sqlite(path, table_name="t")
     assert ft.count().execute()
@@ -221,12 +221,11 @@ def test_read_sqlite(con, tmp_path):
 def test_read_sqlite_no_table_name(con, tmp_path):
     path = tmp_path / "test.db"
 
-    sqlite3.connect(str(path))
+    with sqlite3.connect(str(path)) as _:
+        assert path.exists()
 
-    assert path.exists()
-
-    with pytest.raises(ValueError):
-        con.read_sqlite(path)
+        with pytest.raises(ValueError):
+            con.read_sqlite(path)
 
 
 # Because we create a new connection and the test requires loading/installing a

--- a/ibis/backends/sqlite/tests/test_types.py
+++ b/ibis/backends/sqlite/tests/test_types.py
@@ -36,16 +36,14 @@ TIMESTAMPS_TZ = [
 @pytest.fixture(scope="session")
 def db(tmp_path_factory):
     path = str(tmp_path_factory.mktemp("databases") / "formats.db")
-    con = sqlite3.connect(path)
-    con.execute("CREATE TABLE timestamps (ts TIMESTAMP)")
-    con.execute("CREATE TABLE timestamps_tz (ts TIMESTAMPTZ)")
-    con.execute("CREATE TABLE weird (str_col STRING, date_col ITSADATE)")
-    con.execute("CREATE TABLE basic (a INTEGER, b REAL, c BOOLEAN, d BLOB)")
-    with con:
+    with sqlite3.connect(path) as con:
+        con.execute("CREATE TABLE timestamps (ts TIMESTAMP)")
+        con.execute("CREATE TABLE timestamps_tz (ts TIMESTAMPTZ)")
+        con.execute("CREATE TABLE weird (str_col STRING, date_col ITSADATE)")
+        con.execute("CREATE TABLE basic (a INTEGER, b REAL, c BOOLEAN, d BLOB)")
         con.executemany("INSERT INTO timestamps VALUES (?)", [(t,) for t in TIMESTAMPS])
         con.executemany(
-            "INSERT INTO timestamps_tz VALUES (?)",
-            [(t,) for t in TIMESTAMPS_TZ],
+            "INSERT INTO timestamps_tz VALUES (?)", [(t,) for t in TIMESTAMPS_TZ]
         )
         con.executemany(
             "INSERT INTO weird VALUES (?, ?)",
@@ -56,7 +54,6 @@ def db(tmp_path_factory):
                 ("d", "2022-01-04"),
             ],
         )
-    con.close()
     return path
 
 


### PR DESCRIPTION
Observed in the wild here: https://github.com/ibis-project/ibis/actions/runs/12373195788/job/34533064464?pr=10589