### PR TITLE
refactor(api): remove `IntegerValue.label`

### DIFF
--- a/ibis/backends/impala/tests/test_bucket_histogram.py
+++ b/ibis/backends/impala/tests/test_bucket_histogram.py
@@ -81,8 +81,8 @@ def test_bucket_assign_labels(table, snapshot):
     bucket = table.f.bucket(buckets, include_under=True)
 
     size = table.group_by(bucket.name("tier")).size()
-    labelled = size.tier.label(
-        ["Under 0", "0 to 10", "10 to 25", "25 to 50"], nulls="error"
+    labelled = size.tier.cases(
+        *enumerate(["Under 0", "0 to 10", "10 to 25", "25 to 50"]), else_="error"
     ).name("tier2")
     expr = size.select(labelled, size[1])
 

--- a/ibis/backends/postgres/tests/test_functions.py
+++ b/ibis/backends/postgres/tests/test_functions.py
@@ -357,21 +357,14 @@ def test_coalesce(con, expr, expected):
 
 
 @pytest.mark.parametrize(
-    ("expr", "expected"),
+    "expr",
     [
-        param(ibis.coalesce(ibis.null(), ibis.null()), None, id="all_null"),
-        param(
-            ibis.coalesce(
-                ibis.null().cast("int8"),
-                ibis.null().cast("int8"),
-                ibis.null().cast("int8"),
-            ),
-            None,
-            id="all_nulls_with_all_cast",
-        ),
+        ibis.coalesce(*([ibis.null()] * 2)),
+        ibis.coalesce(*([ibis.null().cast("int8")] * 3)),
     ],
+    ids=["all", "all_with_cast"],
 )
-def test_coalesce_all_na(con, expr, expected):
+def test_coalesce_all_na(con, expr):
     assert con.execute(expr) is None
 
 
@@ -469,7 +462,7 @@ def test_category_label(alltypes, df):
     bins = [0, 10, 25, 50, 100]
     labels = ["a", "b", "c", "d"]
     bucket = d.bucket(bins)
-    expr = bucket.label(labels)
+    expr = bucket.cases(*enumerate(labels), else_=None)
     result = expr.execute()
 
     with warnings.catch_warnings():
@@ -497,68 +490,68 @@ def test_union_cte(alltypes, distinct, assert_sql):
     ("func", "pandas_func"),
     [
         param(
-            lambda t, cond: t.bool_col.count(),
-            lambda df, cond: df.bool_col.count(),
+            lambda t, _: t.bool_col.count(),
+            lambda df, _: df.bool_col.count(),
             id="count",
         ),
         param(
-            lambda t, cond: t.bool_col.any(),
-            lambda df, cond: df.bool_col.any(),
+            lambda t, _: t.bool_col.any(),
+            lambda df, _: df.bool_col.any(),
             id="any",
         ),
         param(
-            lambda t, cond: t.bool_col.all(),
-            lambda df, cond: df.bool_col.all(),
+            lambda t, _: t.bool_col.all(),
+            lambda df, _: df.bool_col.all(),
             id="all",
         ),
         param(
-            lambda t, cond: t.bool_col.notany(),
-            lambda df, cond: ~df.bool_col.any(),
+            lambda t, _: t.bool_col.notany(),
+            lambda df, _: ~df.bool_col.any(),
             id="notany",
         ),
         param(
-            lambda t, cond: t.bool_col.notall(),
-            lambda df, cond: ~df.bool_col.all(),
+            lambda t, _: t.bool_col.notall(),
+            lambda df, _: ~df.bool_col.all(),
             id="notall",
         ),
         param(
-            lambda t, cond: t.double_col.sum(),
-            lambda df, cond: df.double_col.sum(),
+            lambda t, _: t.double_col.sum(),
+            lambda df, _: df.double_col.sum(),
             id="sum",
         ),
         param(
-            lambda t, cond: t.double_col.mean(),
-            lambda df, cond: df.double_col.mean(),
+            lambda t, _: t.double_col.mean(),
+            lambda df, _: df.double_col.mean(),
             id="mean",
         ),
         param(
-            lambda t, cond: t.double_col.min(),
-            lambda df, cond: df.double_col.min(),
+            lambda t, _: t.double_col.min(),
+            lambda df, _: df.double_col.min(),
             id="min",
         ),
         param(
-            lambda t, cond: t.double_col.max(),
-            lambda df, cond: df.double_col.max(),
+            lambda t, _: t.double_col.max(),
+            lambda df, _: df.double_col.max(),
             id="max",
         ),
         param(
-            lambda t, cond: t.double_col.var(),
-            lambda df, cond: df.double_col.var(),
+            lambda t, _: t.double_col.var(),
+            lambda df, _: df.double_col.var(),
             id="var",
         ),
         param(
-            lambda t, cond: t.double_col.std(),
-            lambda df, cond: df.double_col.std(),
+            lambda t, _: t.double_col.std(),
+            lambda df, _: df.double_col.std(),
             id="std",
         ),
         param(
-            lambda t, cond: t.double_col.var(how="sample"),
-            lambda df, cond: df.double_col.var(ddof=1),
+            lambda t, _: t.double_col.var(how="sample"),
+            lambda df, _: df.double_col.var(ddof=1),
             id="samp_var",
         ),
         param(
-            lambda t, cond: t.double_col.std(how="pop"),
-            lambda df, cond: df.double_col.std(ddof=0),
+            lambda t, _: t.double_col.std(how="pop"),
+            lambda df, _: df.double_col.std(ddof=0),
             id="pop_std",
         ),
         param(

--- a/ibis/backends/risingwave/tests/test_functions.py
+++ b/ibis/backends/risingwave/tests/test_functions.py
@@ -301,7 +301,7 @@ def test_category_label(alltypes, df):
     bins = [0, 10, 25, 50, 100]
     labels = ["a", "b", "c", "d"]
     bucket = d.bucket(bins)
-    expr = bucket.label(labels)
+    expr = bucket.cases(*enumerate(labels), else_=None)
     result = expr.execute()
 
     with warnings.catch_warnings():

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -13,8 +13,6 @@ from ibis.expr.types.generic import Column, Scalar, Value
 from ibis.util import deprecated
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
     import ibis.expr.types as ir
 
 
@@ -1593,41 +1591,6 @@ class IntegerValue(NumericValue):
             return NotImplemented
         else:
             return node.to_expr()
-
-    def label(self, labels: Iterable[str], nulls: str | None = None) -> ir.StringValue:
-        """Label a set of integer values with strings.
-
-        Parameters
-        ----------
-        labels
-            An iterable of string labels. Each integer value in `self` will be mapped to
-            a value in `labels`.
-        nulls
-            String label to use for `NULL` values
-
-        Returns
-        -------
-        StringValue
-            `self` labeled with `labels`
-
-        Examples
-        --------
-        >>> import ibis
-        >>> ibis.options.interactive = True
-        >>> t = ibis.memtable({"a": [0, 1, 0, 2]})
-        >>> t.select(t.a, labeled=t.a.label(["a", "b", "c"]))
-        ┏━━━━━━━┳━━━━━━━━━┓
-        ┃ a     ┃ labeled ┃
-        ┡━━━━━━━╇━━━━━━━━━┩
-        │ int64 │ string  │
-        ├───────┼─────────┤
-        │     0 │ a       │
-        │     1 │ b       │
-        │     0 │ a       │
-        │     2 │ c       │
-        └───────┴─────────┘
-        """
-        return self.cases(*enumerate(labels), else_=nulls)
 
 
 @public


### PR DESCRIPTION
Closes #9612.

BREAKING CHANGE: `IntegerValue.label` is redundant with the `IntegerValue.cases` method, use that instead. Replace `expr.label(labels)` with `expr.cases(*enumerate(labels))`