### PR TITLE
refactor(api): re-enable deprecation checks

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -65,8 +65,7 @@ module.exports = {
       {
         verifyConditionsCmd:
           "ci/release/verify_conditions.sh ${options.dryRun}",
-        // TODO(cpcloud): re-enable once deprecation removals for 10.0 are merged
-        // verifyReleaseCmd: "ci/release/verify_release.sh ${nextRelease.version}",
+        verifyReleaseCmd: "ci/release/verify_release.sh ${nextRelease.version}",
         prepareCmd: "ci/release/prepare.sh ${nextRelease.version}",
         publishCmd: "ci/release/publish.sh"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -188,7 +188,14 @@
 
           release = pkgs.mkShell {
             name = "release";
-            packages = with pkgs; [ git uv nodejs_20 unzip gnugrep python3 ];
+            packages = with pkgs; [
+              git
+              uv
+              nodejs_20
+              unzip
+              gnugrep
+              (python3.withPackages (p: [ p.packaging ]))
+            ];
           };
         };
       }

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1330,7 +1330,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         *,
         params: Mapping[ir.Scalar, Any] | None = None,
         limit: int | str | None = None,
-        **kwargs: Any,
+        **_: Any,
     ) -> dict[str, torch.Tensor]:
         """Execute an expression and return results as a dictionary of torch tensors.
 
@@ -1641,7 +1641,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
 
 
 @lazy_singledispatch
-def _read_in_memory(source: Any, table_name: str, _conn: Backend, **kwargs: Any):
+def _read_in_memory(source: Any, table_name: str, _conn: Backend, **_: Any):
     raise NotImplementedError(
         f"The `{_conn.name}` backend currently does not support "
         f"reading data of {type(source)!r}"
@@ -1653,12 +1653,12 @@ def _read_in_memory(source: Any, table_name: str, _conn: Backend, **kwargs: Any)
 @_read_in_memory.register("pyarrow.Table")
 @_read_in_memory.register("pandas.DataFrame")
 @_read_in_memory.register("pyarrow.dataset.Dataset")
-def _default(source, table_name, _conn, **kwargs: Any):
+def _default(source, table_name, _conn, **_: Any):
     _conn.con.register(table_name, source)
 
 
 @_read_in_memory.register("pyarrow.RecordBatchReader")
-def _pyarrow_rbr(source, table_name, _conn, **kwargs: Any):
+def _pyarrow_rbr(source, table_name, _conn, **_: Any):
     _conn.con.register(table_name, source)
     # Ensure the reader isn't marked as started, in case the name is
     # being overwritten.

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -808,43 +808,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         # by the time we execute against this so we register it
         # explicitly.
 
-    @util.deprecated(
-        instead="Pass in-memory data to `memtable` instead.",
-        as_of="9.1",
-        removed_in="10.0",
-    )
-    def read_in_memory(
-        self,
-        source: pd.DataFrame
-        | pa.Table
-        | pa.RecordBatchReader
-        | pl.DataFrame
-        | pl.LazyFrame,
-        table_name: str | None = None,
-    ) -> ir.Table:
-        """Register an in-memory table object in the current database.
-
-        Supported objects include pandas DataFrame, a Polars
-        DataFrame/LazyFrame, or a PyArrow Table or RecordBatchReader.
-
-        Parameters
-        ----------
-        source
-            The data source.
-        table_name
-            An optional name to use for the created table. This defaults to
-            a sequentially generated name.
-
-        Returns
-        -------
-        ir.Table
-            The just-registered table
-
-        """
-        table_name = table_name or util.gen_name("read_in_memory")
-        _read_in_memory(source, table_name, self)
-        return self.table(table_name)
-
     def read_delta(
         self,
         source_table: str,

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -14,7 +14,7 @@ from ibis.common.deferred import Deferred, _, deferrable
 from ibis.common.grounds import Singleton
 from ibis.expr.rewrites import rewrite_window_input
 from ibis.expr.types.core import Expr, _binop, _FixedTextJupyterMixin, _is_null_literal
-from ibis.util import deprecated, promote_list, warn_deprecated
+from ibis.util import deprecated, promote_list
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -2142,9 +2142,7 @@ class Column(Value, _FixedTextJupyterMixin):
 
         return table.aggregate(metric, by=[self]).order_by(metric.desc()).limit(k)
 
-    def arbitrary(
-        self, where: ir.BooleanValue | None = None, how: Any = None
-    ) -> Scalar:
+    def arbitrary(self, where: ir.BooleanValue | None = None) -> Scalar:
         """Select an arbitrary value in a column.
 
         Returns an arbitrary (nondeterministic, backend-specific) value from
@@ -2155,8 +2153,6 @@ class Column(Value, _FixedTextJupyterMixin):
         ----------
         where
             A filter expression
-        how
-            DEPRECATED
 
         Returns
         -------
@@ -2188,13 +2184,6 @@ class Column(Value, _FixedTextJupyterMixin):
         │     2 │ a      │     8.3 │
         └───────┴────────┴─────────┘
         """
-        if how is not None:
-            warn_deprecated(
-                name="how",
-                as_of="9.0",
-                removed_in="10.0",
-                instead="call `first` or `last` explicitly",
-            )
         return ops.Arbitrary(self, where=self._bind_to_parent_table(where)).to_expr()
 
     def count(self, where: ir.BooleanValue | None = None) -> ir.IntegerScalar:

--- a/ibis/expr/types/strings.py
+++ b/ibis/expr/types/strings.py
@@ -410,13 +410,6 @@ class StringValue(Value):
         """
         return ops.Capitalize(self).to_expr()
 
-    @util.deprecated(
-        instead="use the `capitalize` method", as_of="9.0", removed_in="10.0"
-    )
-    def initcap(self) -> StringValue:
-        """Deprecated. Use `capitalize` instead."""
-        return self.capitalize()
-
     def __contains__(self, *_: Any) -> bool:
         raise TypeError("Use string_expr.contains(arg)")
 

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -442,7 +442,7 @@ def test_cast_same_type_noop(table):
     assert i.cast("int8") is i
 
 
-def test_string_slice_step(table):
+def test_string_slice_step():
     s = ibis.literal("abcde")
     s[1:3]
     s[1:3:1]
@@ -509,7 +509,7 @@ def test_negate_boolean_column(table):
 
 
 @pytest.mark.parametrize("column", ["a", "b"])
-@pytest.mark.parametrize("condition_fn", [lambda t: None, lambda t: t.a > 8])
+@pytest.mark.parametrize("condition_fn", [lambda _: None, lambda t: t.a > 8])
 def test_arbitrary(table, column, condition_fn):
     col = table[column]
     where = condition_fn(table)
@@ -517,12 +517,6 @@ def test_arbitrary(table, column, condition_fn):
     assert expr.type() == col.type()
     assert isinstance(expr, ir.Scalar)
     assert isinstance(expr.op(), ops.Arbitrary)
-
-
-def test_arbitrary_how_deprecated(table):
-    with pytest.warns(FutureWarning, match="v9.0"):
-        out = table.a.arbitrary(how="last")
-    assert isinstance(out.op(), ops.Arbitrary)
 
 
 @pytest.mark.parametrize(
@@ -803,12 +797,12 @@ def test_literal_promotions(table, op, name, case, ex_type):
 @pytest.mark.parametrize(
     ("op", "left_fn", "right_fn", "ex_type"),
     [
-        (operator.sub, lambda t: t["a"], lambda t: 0, "int8"),
-        (operator.sub, lambda t: 0, lambda t: t["a"], "int16"),
-        (operator.sub, lambda t: t["b"], lambda t: 0, "int16"),
-        (operator.sub, lambda t: 0, lambda t: t["b"], "int32"),
-        (operator.sub, lambda t: t["c"], lambda t: 0, "int32"),
-        (operator.sub, lambda t: 0, lambda t: t["c"], "int64"),
+        (operator.sub, lambda t: t["a"], lambda _: 0, "int8"),
+        (operator.sub, lambda _: 0, lambda t: t["a"], "int16"),
+        (operator.sub, lambda t: t["b"], lambda _: 0, "int16"),
+        (operator.sub, lambda _: 0, lambda t: t["b"], "int32"),
+        (operator.sub, lambda t: t["c"], lambda _: 0, "int32"),
+        (operator.sub, lambda _: 0, lambda t: t["c"], "int64"),
     ],
     ids=lambda arg: str(getattr(arg, "__name__", arg)),
 )


### PR DESCRIPTION
Remove remaining 10.0 deprecations and re-enable deprecation checks in CI. Closes #10110.