### PR TITLE
test(sqlite): fix test flakiness caused by failing to close `sqlite3.Connection` objects

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1036,13 +1036,15 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         >>> import ibis
         >>> import sqlite3
         >>> ibis.options.interactive = True
-        >>> with sqlite3.connect("/tmp/sqlite.db") as con:
+        >>> con = sqlite3.connect("/tmp/sqlite.db")
+        >>> with con:
         ...     con.execute("DROP TABLE IF EXISTS t")  # doctest: +ELLIPSIS
         ...     con.execute("CREATE TABLE t (a INT, b TEXT)")  # doctest: +ELLIPSIS
         ...     con.execute(
         ...         "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')"
         ...     )  # doctest: +ELLIPSIS
         <...>
+        >>> con.close()
         >>> con = ibis.connect("duckdb://")
         >>> t = con.read_sqlite(path="/tmp/sqlite.db", table_name="t")
         >>> t
@@ -1130,13 +1132,15 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath):
         --------
         >>> import ibis
         >>> import sqlite3
-        >>> with sqlite3.connect("/tmp/attach_sqlite.db") as con:
+        >>> con = sqlite3.connect("/tmp/attach_sqlite.db")
+        >>> with con:
         ...     con.execute("DROP TABLE IF EXISTS t")  # doctest: +ELLIPSIS
         ...     con.execute("CREATE TABLE t (a INT, b TEXT)")  # doctest: +ELLIPSIS
         ...     con.execute(
         ...         "INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c')"
         ...     )  # doctest: +ELLIPSIS
         <...>
+        >>> con.close()
         >>> con = ibis.connect("duckdb://")
         >>> con.list_tables()
         []

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -413,11 +413,10 @@ lat,lon,geom
     assert t.schema()["geom"].is_geospatial()
 
 
-def test_memtable_doesnt_leak(con, monkeypatch):
-    monkeypatch.setattr(ibis.options, "default_backend", con)
-    name = "memtable_doesnt_leak"
+def test_memtable_doesnt_leak(con):
+    name = gen_name("memtable_doesnt_leak")
     assert name not in con.list_tables()
-    df = ibis.memtable({"a": [1, 2, 3]}, name=name).execute()
+    df = con.execute(ibis.memtable({"a": [1, 2, 3]}, name=name))
     assert name not in con.list_tables()
     assert len(df) == 3
 

--- a/ibis/backends/sqlite/tests/test_client.py
+++ b/ibis/backends/sqlite/tests/test_client.py
@@ -71,8 +71,9 @@ def test_builtin_agg_udf(con):
 )
 def test_connect(url, ext, tmp_path):
     path = os.path.abspath(tmp_path / f"test.{ext}")
-    with sqlite3.connect(path):
-        pass
+
+    sqlite3.connect(path).close()
+
     con = ibis.connect(url(path))
     one = ibis.literal(1)
     assert con.execute(one) == 1

--- a/ibis/backends/sqlite/tests/test_types.py
+++ b/ibis/backends/sqlite/tests/test_types.py
@@ -36,24 +36,30 @@ TIMESTAMPS_TZ = [
 @pytest.fixture(scope="session")
 def db(tmp_path_factory):
     path = str(tmp_path_factory.mktemp("databases") / "formats.db")
-    with sqlite3.connect(path) as con:
-        con.execute("CREATE TABLE timestamps (ts TIMESTAMP)")
-        con.execute("CREATE TABLE timestamps_tz (ts TIMESTAMPTZ)")
-        con.execute("CREATE TABLE weird (str_col STRING, date_col ITSADATE)")
-        con.execute("CREATE TABLE basic (a INTEGER, b REAL, c BOOLEAN, d BLOB)")
-        con.executemany("INSERT INTO timestamps VALUES (?)", [(t,) for t in TIMESTAMPS])
-        con.executemany(
-            "INSERT INTO timestamps_tz VALUES (?)", [(t,) for t in TIMESTAMPS_TZ]
-        )
-        con.executemany(
-            "INSERT INTO weird VALUES (?, ?)",
-            [
-                ("a", "2022-01-01"),
-                ("b", "2022-01-02"),
-                ("c", "2022-01-03"),
-                ("d", "2022-01-04"),
-            ],
-        )
+    con = sqlite3.connect(path)
+    try:
+        with con:
+            con.execute("CREATE TABLE timestamps (ts TIMESTAMP)")
+            con.execute("CREATE TABLE timestamps_tz (ts TIMESTAMPTZ)")
+            con.execute("CREATE TABLE weird (str_col STRING, date_col ITSADATE)")
+            con.execute("CREATE TABLE basic (a INTEGER, b REAL, c BOOLEAN, d BLOB)")
+            con.executemany(
+                "INSERT INTO timestamps VALUES (?)", [(t,) for t in TIMESTAMPS]
+            )
+            con.executemany(
+                "INSERT INTO timestamps_tz VALUES (?)", [(t,) for t in TIMESTAMPS_TZ]
+            )
+            con.executemany(
+                "INSERT INTO weird VALUES (?, ?)",
+                [
+                    ("a", "2022-01-01"),
+                    ("b", "2022-01-02"),
+                    ("c", "2022-01-03"),
+                    ("d", "2022-01-04"),
+                ],
+            )
+    finally:
+        con.close()
     return path
 
 


### PR DESCRIPTION
Continued to observe this, so I took a closer look and it turns out that the context manager does not close the connection, it only handles transaction behavior. This PR fixes the resource warnings that show up only in Python 3.13