### PR TITLE
chore(dev-deps): bump pgvector, clang and llvm versions

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -38,7 +38,6 @@ services:
       - $PWD/docker/mysql:/docker-entrypoint-initdb.d:ro
 
   postgres:
-    user: postgres
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: ibis_testing

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgis/postgis:16-3.5-alpine AS pgvector-builder
-RUN apk add --no-cache git build-base clang15 llvm15-dev llvm15
+RUN apk add --no-cache git build-base clang19 llvm19-dev llvm19
 WORKDIR /tmp
-RUN git clone --branch v0.7.4 https://github.com/pgvector/pgvector.git
+RUN git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git
 WORKDIR /tmp/pgvector
 RUN make && make install
 

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,12 +1,12 @@
-FROM postgis/postgis:16-3.5-alpine AS pgvector-builder
+FROM postgis/postgis:17-3.5-alpine AS pgvector-builder
 RUN apk add --no-cache git build-base clang19 llvm19-dev llvm19
 WORKDIR /tmp
 RUN git clone --branch v0.8.0 https://github.com/pgvector/pgvector.git
 WORKDIR /tmp/pgvector
 RUN make && make install
 
-FROM postgis/postgis:16-3.5-alpine
-RUN apk add --no-cache postgresql16-plpython3
+FROM postgis/postgis:17-3.5-alpine
+RUN apk add --no-cache postgresql17-plpython3
 COPY --from=pgvector-builder /usr/local/lib/postgresql/bitcode/vector.index.bc /usr/local/lib/postgresql/bitcode/vector.index.bc
 COPY --from=pgvector-builder /usr/local/lib/postgresql/vector.so /usr/local/lib/postgresql/vector.so
 COPY --from=pgvector-builder /usr/local/share/postgresql/extension /usr/local/share/postgresql/extension


### PR DESCRIPTION
Fixes the failing build of pgvector discovered here: https://github.com/ibis-project/ibis/actions/runs/12497126794/job/34884330638?pr=10613