### PR TITLE
chore: re-enable the dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "rangeStrategy": "widen",
-  "extends": ["config:base", ":enablePreCommit", ":disableDependencyDashboard"],
+  "extends": ["config:base", ":enablePreCommit", ":dependencyDashboard"],
   "schedule": ["after 10pm and before 5am every weekday", "every weekend"],
   "semanticCommits": "enabled",
   "lockFileMaintenance": { "enabled": true },


### PR DESCRIPTION
Would like to bring this back in order to see what is currently outdated.