### PR TITLE
fix(api): ensure memtable schema and columns match

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -408,6 +408,12 @@ def memtable(
             "passing `columns` and schema` is ambiguous; "
             "pass one or the other but not both"
         )
+
+    if schema is not None:
+        import ibis
+
+        schema = ibis.schema(schema)
+
     return _memtable(data, name=name, schema=schema, columns=columns)
 
 

--- a/ibis/expr/tests/test_api.py
+++ b/ibis/expr/tests/test_api.py
@@ -143,6 +143,15 @@ def test_duplicate_columns_in_memtable_not_allowed():
         ibis.memtable(df)
 
 
+def test_memtable_column_names_match_schema():
+    pd = pytest.importorskip("pandas")
+
+    df = pd.DataFrame([[1, 2], [3, 4]])
+    schema = {"a": "int64", "b": "int64"}
+    t = ibis.memtable(df, schema=schema)
+    t.a.execute()  # Raises a KeyError if the column name does not match
+
+
 @pytest.mark.parametrize(
     "op",
     [

--- a/ibis/expr/tests/test_api.py
+++ b/ibis/expr/tests/test_api.py
@@ -149,7 +149,7 @@ def test_memtable_column_names_match_schema():
     df = pd.DataFrame([[1, 2], [3, 4]])
     schema = {"a": "int64", "b": "int64"}
     t = ibis.memtable(df, schema=schema)
-    t.a.execute()  # Raises a KeyError if the column name does not match
+    assert t.op().data.to_frame().columns.tolist() == ["a", "b"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description of changes

Before this change, if you pass a `SchemaLike` that isn't actually a `Schema`, it won't automatically rename the auto-generated pandas column names. For example:

```python
import pandas as pd

df = pd.DataFrame([[1, 2], [3, 4]])
schema = {"a": "int64", "b": "int64"}
t = ibis.memtable(df, schema=schema)
t.a.execute()  # Raises a KeyError
```

This PR goes ahead and constructs the `Schema`, if passed—work that was going to be done anyway. That way, `getattr(schema, "names")` finds the passed names, and the rename is performed.