### PR TITLE
feat(polars): add `Intersection` and `Difference` ops

### DIFF
--- a/ibis/backends/tests/test_set_ops.py
+++ b/ibis/backends/tests/test_set_ops.py
@@ -6,7 +6,6 @@ import pytest
 from pytest import param
 
 import ibis
-import ibis.common.exceptions as com
 import ibis.expr.types as ir
 from ibis import _
 from ibis.backends.tests.errors import PsycoPg2InternalError, PyDruidProgrammingError
@@ -84,7 +83,6 @@ def test_union_mixed_distinct(backend, union_subsets):
         param(True, id="distinct"),
     ],
 )
-@pytest.mark.notimpl(["polars"])
 @pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError)
 def test_intersect(backend, alltypes, df, distinct):
     a = alltypes.filter((_.id >= 5200) & (_.id <= 5210))
@@ -129,7 +127,6 @@ def test_intersect(backend, alltypes, df, distinct):
         param(True, id="distinct"),
     ],
 )
-@pytest.mark.notimpl(["polars"])
 @pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError)
 def test_difference(backend, alltypes, df, distinct):
     a = alltypes.filter((_.id >= 5200) & (_.id <= 5210))
@@ -238,7 +235,6 @@ def test_top_level_union(backend, con, alltypes, distinct, ordered):
         ),
     ],
 )
-@pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError)
 def test_top_level_intersect_difference(
     backend, con, alltypes, distinct, opname, expected, ordered


### PR DESCRIPTION
## Description of changes

Adds support for [`Intersection`](https://ibis-project.org/reference/operations.html#ibis.expr.operations.relations.Intersection) and [`Difference`](https://ibis-project.org/reference/operations.html#ibis.expr.operations.relations.Difference) operations for the Polars backend. The approach uses pl.SQLContext to register the dataframes and query using [INTERSECT](https://docs.pola.rs/api/python/stable/reference/sql/set_operations.html#intersect) and [EXCEPT](https://docs.pola.rs/api/python/stable/reference/sql/set_operations.html#except), respectively. 

I saw that a few other functions used a `ctx` argument which might be using `pl.SQLContext` in a similar manner, I wasn't sure if that argument could be used here to avoid some of the boilerplate. Here are some of those functions I am referring to:

https://github.com/ibis-project/ibis/blob/28bafd14153cb7bb5bcc44063975f9346d55b76a/ibis/backends/polars/compiler.py#L69-L72

https://github.com/ibis-project/ibis/blob/28bafd14153cb7bb5bcc44063975f9346d55b76a/ibis/backends/polars/compiler.py#L1287-L1297
