### PR TITLE
feat(polars): add `StringFind` operation

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1555,3 +1555,12 @@ def visit_ArrayIntersect(op, **kw):
     left = translate(op.left, **kw)
     right = translate(op.right, **kw)
     return left.list.set_intersection(right)
+
+
+@translate.register(ops.StringFind)
+def visit_StringFind(op, **kw):
+    arg = translate(op.arg, **kw)
+    start = translate(op.start, **kw) if op.start is not None else 0
+    end = translate(op.end, **kw) if op.end is not None else None
+    expr = arg.str.slice(start, end).str.find(_literal_value(op.substr), literal=True)
+    return pl.when(expr.is_null()).then(-1).otherwise(expr + start)

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -406,15 +406,11 @@ def uses_java_re(t):
             lambda t: t.string_col.find("a"),
             lambda t: t.string_col.str.find("a"),
             id="find",
-            marks=pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError),
         ),
         param(
             lambda t: t.date_string_col.find("13", 3),
             lambda t: t.date_string_col.str.find("13", 3),
             id="find_start",
-            marks=[
-                pytest.mark.notimpl(["polars"], raises=com.OperationNotDefinedError),
-            ],
         ),
         param(
             lambda t: t.string_col.lpad(10, "a"),
@@ -1084,7 +1080,6 @@ def string_temp_table(backend, con):
             lambda t: t.string_col.find("123"),
             lambda t: t.str.find("123"),
             id="find",
-            marks=pytest.mark.notimpl("polars", raises=com.OperationNotDefinedError),
         ),
         param(
             lambda t: t.string_col.rpad(4, "-"),


### PR DESCRIPTION
## Description of changes

Adds the [`StringFind`](https://ibis-project.org/reference/operations#ibis.expr.operations.strings.StringFind) operation for the Polars backend using [`pl.Expr.str.find`](https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.str.find.html#). 