### PR TITLE
chore(deps): move `uv` in nix environment to vendored version from `uv2nix`

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -76,9 +76,6 @@ jobs:
           key: docs-${{ github.event.pull_request.base.sha }}
           path: docs/**/.jupyter_cache
 
-      - name: run quarto check
-        run: nix develop '.#ibis311' --ignore-environment --keep HOME -c quarto check
-
       - name: build docs
         run: nix develop '.#ibis311' --ignore-environment --keep HOME -c just docs-build-all
 

--- a/.github/workflows/ibis-docs-main.yml
+++ b/.github/workflows/ibis-docs-main.yml
@@ -68,9 +68,6 @@ jobs:
           key: docs-${{ github.event.before }}
           path: docs/**/.jupyter_cache
 
-      - name: run quarto check
-        run: nix develop '.#ibis311' --ignore-environment --keep HOME -c quarto check
-
       - name: build api docs
         run: nix develop '.#ibis311' --ignore-environment -c just docs-apigen --verbose
 

--- a/.github/workflows/ibis-docs-pr.yml
+++ b/.github/workflows/ibis-docs-pr.yml
@@ -41,6 +41,28 @@ jobs:
         # that for extensions
         run: nix develop '.#ibis311' --ignore-environment --keep HOME --keep HYPOTHESIS_PROFILE -c just doctest
 
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: setup cachix
+        uses: cachix/cachix-action@v15
+        with:
+          name: ibis
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extraPullNames: nix-community
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: run quarto check
+        run: nix develop '.#ibis311' --ignore-environment --keep HOME -c quarto check
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -65,9 +87,6 @@ jobs:
         with:
           key: docs-${{ github.event.pull_request.base.sha }}
           path: docs/**/.jupyter_cache
-
-      - name: run quarto check
-        run: nix develop '.#ibis311' --ignore-environment --keep HOME -c quarto check
 
       - name: generate api docs
         run: nix develop '.#ibis311' --ignore-environment -c just docs-apigen --verbose

--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735268880,
-        "narHash": "sha256-7QEFnKkzD13SPxs+UFR5bUFN2fRw+GlL0am72ZjNre4=",
+        "lastModified": 1735356430,
+        "narHash": "sha256-73YXKKpWvVud34OxcxMs33BHx+/VWnX+4nLakT68R5k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7cc0bff31a3a705d3ac4fdceb030a17239412210",
+        "rev": "c0b0a559cfda174531d820221b1fde9a599eb367",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735033632,
-        "narHash": "sha256-pxpWoFbS5Vt5T4b0TUWwRDkzZHzaWPF7bjz+nCzybnI=",
+        "lastModified": 1735354525,
+        "narHash": "sha256-n7r2ZaG7U+7FmSaWGdWAicxlONE7jL305dJnnfaoGBU=",
         "owner": "nix-community",
         "repo": "pyproject.nix",
-        "rev": "11e4d96ac29a5a96d761d07374860d8a1945bd58",
+        "rev": "91a9d41bf56289c84bff7a40ed69d3da9b276fd2",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735253524,
-        "narHash": "sha256-WybikMGQh395a17fGR9qge0GGn0y/eoH7Y9sxgdSsoA=",
+        "lastModified": 1735342428,
+        "narHash": "sha256-tRp7ZyD3Tuhkj7Gzqp+wyzFAS7TfR1HhHpGvR05iHa8=",
         "owner": "adisbladis",
         "repo": "uv2nix",
-        "rev": "f1fe5767a2a3668ea5b564baf6aeb98b941095f3",
+        "rev": "e4f7193604cf1af77094034fb5e278cf0e1920ae",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,9 @@
 
           # Get repository root using git. This is expanded at runtime by the editable `.pth` machinery.
           export REPO_ROOT=$(git rev-parse --show-toplevel)
+
+          # Prevent uv from downloading managed Python's
+          export UV_PYTHON_DOWNLOADS=never
         '';
 
         preCommitDeps = with pkgs; [

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -124,6 +124,7 @@ in
   );
 
   quarto = pkgs.callPackage ./quarto { };
+  uv = uv2nix.packages.${pkgs.system}.uv-bin;
 
   changelog = pkgs.writeShellApplication {
     name = "changelog";

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -86,7 +86,7 @@ h11==0.14.0
 httpcore==1.0.7
 httpx==0.28.1
 humanize==4.11.0
-hypothesis==6.123.1
+hypothesis==6.123.2
 identify==2.6.3
 idna==3.10
 importlib-metadata==8.5.0

--- a/uv.lock
+++ b/uv.lock
@@ -1872,16 +1872,16 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.123.1"
+version = "6.123.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/10/92bed8bbec8d87e34ca665177efea0c061ce45abedbcc10a25d1f3f9067c/hypothesis-6.123.1.tar.gz", hash = "sha256:eb2bf646537ad818270feff6428c34f57813a4ef78781861ec1693b0840ab1d8", size = 418131 }
+sdist = { url = "https://files.pythonhosted.org/packages/62/6e/25e0c7b2ce3bd80f32d5dc194eb522e89feb5909951ae4ba1a7614739360/hypothesis-6.123.2.tar.gz", hash = "sha256:02c25552783764146b191c69eef69d8375827b58a75074055705ab8fdbc95fc5", size = 417823 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/bc/d7dcb30183f0a5bbbff008a7d0a231b1a4301272e771c5f13af2c3a44872/hypothesis-6.123.1-py3-none-any.whl", hash = "sha256:acf177faeff578f02afef2744c00b9ec3ce03f3b72ffbb6d7013f7baeebaac5e", size = 480140 },
+    { url = "https://files.pythonhosted.org/packages/61/0b/7f61da4015f561b288c3b91e745c8ba81b98a2d02f414e9e1c9388050aee/hypothesis-6.123.2-py3-none-any.whl", hash = "sha256:0a8bf07753f1436f1b8697a13ea955f3fef3ef7b477c2972869b1d142bcdb30e", size = 479816 },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump nix flakes and move uv derivation to vendored version from uv2nix to track updates to uv at a faster pace.