### PR TITLE
feat(dtypes): allow passing `nullable` kwarg to string parsed dtypes

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -73,8 +73,8 @@ def dtype(value: Any, nullable: bool = True) -> DataType:
 
 
 @dtype.register(str)
-def from_string(value):
-    return DataType.from_string(value)
+def from_string(value, nullable: bool = True):
+    return DataType.from_string(value, nullable)
 
 
 @dtype.register("numpy.dtype")
@@ -165,13 +165,17 @@ class DataType(Concrete, Coercible):
         return castable(self, to, **kwargs)
 
     @classmethod
-    def from_string(cls, value) -> Self:
+    def from_string(cls, value, nullable: bool = True) -> Self:
         from ibis.expr.datatypes.parse import parse
 
         try:
-            return parse(value)
+            typ = parse(value)
         except SyntaxError:
             raise TypeError(f"{value!r} cannot be parsed as a datatype")
+
+        if not nullable:
+            return typ.copy(nullable=nullable)
+        return typ
 
     @classmethod
     def from_typehint(cls, typ, nullable=True) -> Self:

--- a/ibis/expr/datatypes/tests/test_parse.py
+++ b/ibis/expr/datatypes/tests/test_parse.py
@@ -13,6 +13,7 @@ import ibis.tests.strategies as its
 from ibis.common.annotations import ValidationError
 
 
+@pytest.mark.parametrize("nullable", [True, False])
 @pytest.mark.parametrize(
     ("spec", "expected"),
     [
@@ -43,8 +44,8 @@ from ibis.common.annotations import ValidationError
         ("multipolygon", dt.multipolygon),
     ],
 )
-def test_primitive_from_string(spec, expected):
-    assert dt.dtype(spec) == expected
+def test_primitive_from_string(nullable, spec, expected):
+    assert dt.dtype(spec, nullable=nullable) == expected(nullable=nullable)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description of changes

Noted in #10243, passing `nullable` to `ibis.dtype` when using a string name for
the dtype leads to an unhelpful error.  Instead, we should just support this.

This adds support for 'primitive' dtype specifications -- there's no defined
behavior for how to specify nested nullable types with a single keyword
argument, but this should cover most cases.

## Issues closed

xref #10243 but doesn't close it