### PR TITLE
feat(polars): add bitwise operations (`bit_and`, `bit_or`, `bit_xor`)

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -717,6 +717,9 @@ _reductions = {
     ops.Median: "median",
     ops.Min: "min",
     ops.Sum: "sum",
+    ops.BitOr: "bitwise_or",
+    ops.BitAnd: "bitwise_and",
+    ops.BitXor: "bitwise_xor",
 }
 
 
@@ -1614,21 +1617,3 @@ def visit_StringFind(op, **kw):
     end = translate(op.end, **kw) if op.end is not None else None
     expr = arg.str.slice(start, end).str.find(_literal_value(op.substr), literal=True)
     return pl.when(expr.is_null()).then(-1).otherwise(expr + start)
-
-
-@translate.register(ops.BitAnd)
-def visit_BitAnd(op, **kw):
-    arg = translate(op.arg, **kw)
-    return arg.bitwise_and()
-
-
-@translate.register(ops.BitOr)
-def visit_BitOr(op, **kw):
-    arg = translate(op.arg, **kw)
-    return arg.bitwise_or()
-
-
-@translate.register(ops.BitXor)
-def visit_BitXor(op, **kw):
-    arg = translate(op.arg, **kw)
-    return arg.bitwise_xor()

--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1614,3 +1614,21 @@ def visit_StringFind(op, **kw):
     end = translate(op.end, **kw) if op.end is not None else None
     expr = arg.str.slice(start, end).str.find(_literal_value(op.substr), literal=True)
     return pl.when(expr.is_null()).then(-1).otherwise(expr + start)
+
+
+@translate.register(ops.BitAnd)
+def visit_BitAnd(op, **kw):
+    arg = translate(op.arg, **kw)
+    return arg.bitwise_and()
+
+
+@translate.register(ops.BitOr)
+def visit_BitOr(op, **kw):
+    arg = translate(op.arg, **kw)
+    return arg.bitwise_or()
+
+
+@translate.register(ops.BitXor)
+def visit_BitXor(op, **kw):
+    arg = translate(op.arg, **kw)
+    return arg.bitwise_xor()

--- a/ibis/backends/tests/test_aggregation.py
+++ b/ibis/backends/tests/test_aggregation.py
@@ -490,7 +490,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             id="bit_and",
             marks=[
                 pytest.mark.notimpl(
-                    ["polars", "mssql", "exasol"],
+                    ["mssql", "exasol"],
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notimpl(["druid"], strict=False, raises=AssertionError),
@@ -505,7 +505,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             id="bit_or",
             marks=[
                 pytest.mark.notimpl(
-                    ["polars", "mssql", "exasol"],
+                    ["mssql", "exasol"],
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(
@@ -519,7 +519,7 @@ def test_aggregate_multikey_group_reduction_udf(backend, alltypes, df):
             id="bit_xor",
             marks=[
                 pytest.mark.notimpl(
-                    ["polars", "mssql", "exasol"],
+                    ["mssql", "exasol"],
                     raises=com.OperationNotDefinedError,
                 ),
                 pytest.mark.notyet(


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Add support for [`bit_and`], [`bit_or`], and [`bit_xor`] for the Polars backend. This uses [`bitwise_and`](https://docs.pola.rs/api/python/dev/reference/expressions/api/polars.Expr.bitwise_and.html#), [`bitwise_or`](https://docs.pola.rs/api/python/dev/reference/expressions/api/polars.Expr.bitwise_or.html#), and [`bitwise_xor`](https://docs.pola.rs/api/python/dev/reference/expressions/api/polars.Expr.bitwise_xor.html#) Polars expression methods. 

The `is_in` tests are failing still:
FAILED ibis/backends/tests/test_aggregation.py::test_reduction_ops[polars-is_in-bit_xor] - AssertionError: 
FAILED ibis/backends/tests/test_aggregation.py::test_reduction_ops[polars-is_in-bit_and] - AssertionError: 
FAILED ibis/backends/tests/test_aggregation.py::test_reduction_ops[polars-is_in-bit_or] - AssertionError: 

I've tried to repro to see why they are failing, but I may be overlooking something. Here is how I repro'd:

```pycon
In [1]: from ibis.interactive import *
In [2]: import numpy as np
In [3]: import pandas as pd
In [4]: ibis.set_backend("polars")
In [5]: alltypes = ibis.read_parquet("ci/ibis-testing-data/parquet/functional_alltypes.parquet")
In [6]: alltypes = alltypes.filter(_.id < 1550, _.string_col.isin(["1", "7"]))
In [7]: alltypes.agg(tmp=_.bigint_col.bit_or())
Out[7]: 
┏━━━━━━━┓
┃ tmp   ┃
┡━━━━━━━┩
│ int64 │
├───────┤
│    78 │
└───────┘
In [8]: np.bitwise_or.reduce(alltypes.execute().bigint_col).squeeze()
Out[8]: np.int64(78)
```

Here is what the test is reporting:
```
E           AssertionError: 
E           Not equal to tolerance rtol=0.001, atol=0
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference among violations: 48
E           Max relative difference among violations: 0.61538462
E            ACTUAL: array(126)
E            DESIRED: array(78)

ibis/backends/tests/test_aggregation.py:568: AssertionError
============================================== short test summary info ==============================================
FAILED ibis/backends/tests/test_aggregation.py::test_reduction_ops[polars-is_in-bit_or] - AssertionError: 
```

I'm wondering maybe if rows aren't being properly filtered or something. 

## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
