### PR TITLE
feat(polars): add `TimeFromHMS` op

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -1468,6 +1468,15 @@ def execute_timestamp_range(op, **kw):
     return pl.datetime_ranges(start, stop, f"{step}{unit}", closed="left")
 
 
+@translate.register(ops.TimeFromHMS)
+def execute_time_from_hms(op, **kw):
+    return pl.time(
+        hour=translate(op.hours, **kw),
+        minute=translate(op.minutes, **kw),
+        second=translate(op.seconds, **kw),
+    )
+
+
 @translate.register(ops.DropColumns)
 def execute_drop_columns(op, **kw):
     parent = translate(op.parent, **kw)

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -1535,7 +1535,7 @@ TIME_BACKEND_TYPES = {
 
 
 @pytest.mark.notimpl(
-    ["datafusion", "pyspark", "polars", "mysql", "oracle", "databricks"],
+    ["datafusion", "pyspark", "mysql", "oracle", "databricks"],
     raises=com.OperationNotDefinedError,
 )
 @pytest.mark.notyet(


### PR DESCRIPTION
## Description of changes

Adds [`ops.TimeFromHMS`](https://ibis-project.org/reference/operations#ibis.expr.operations.temporal.TimeFromHMS) support for the Polars backend using [`pl.time`](https://docs.pola.rs/api/python/dev/reference/expressions/api/polars.time.html).

I tried adding this to the `_date_methods` and even `_binops` dictionaries, but it
wasn't taking, so I split out a new function. 