### PR TITLE
feat(polars): add ArrayStringJoin op

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -568,6 +568,13 @@ def string_join(op, **kw):
     return pl.concat_str(args, separator=sep)
 
 
+@translate.register(ops.ArrayStringJoin)
+def array_string_join(op, **kw):
+    arg = translate(op.arg, **kw)
+    sep = _literal_value(op.sep)
+    return arg.list.join(sep)
+
+
 @translate.register(ops.Substring)
 def string_substring(op, **kw):
     arg = translate(op.arg, **kw)

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -829,7 +829,7 @@ def test_capitalize(con, inp, expected):
     raises=(com.OperationNotDefinedError, com.UnsupportedBackendType),
 )
 @pytest.mark.notimpl(
-    ["polars", "oracle", "flink"],
+    ["oracle", "flink"],
     raises=com.OperationNotDefinedError,
 )
 def test_array_string_join(con):


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

Adds support for the [`ArrayStringJoin`](https://ibis-project.org/reference/operations#ibis.expr.operations.strings.ArrayStringJoin) operation for the Polars backend. 

I tried my initial implementation using [`polars.Expr.str.join`](https://docs.pola.rs/api/python/dev/reference/expressions/api/polars.Expr.str.join.html#), but it seemed it needed [`polars.Expr.list.join`](https://docs.pola.rs/api/python/dev/reference/expressions/api/polars.Expr.list.join.html#) instead. 

## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
