### PR TITLE
test(druid): xfail because druid cannot sort by anything but timestamps

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -537,6 +537,7 @@ def test_drop_null_invalid(alltypes):
         param(["col_1", "col_3"], id="one-and-three"),
     ],
 )
+@pytest.mark.notimpl(["druid"], strict=False)
 def test_drop_null_table(backend, alltypes, how, subset):
     is_two = alltypes.int_col == 2
     is_four = alltypes.int_col == 4


### PR DESCRIPTION
Fixes the tests that I broke.