### PR TITLE
fix(typing): update common typing to skip non-existent attributes

### DIFF
--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -60,7 +60,11 @@ def get_type_hints(
 
     if include_properties:
         for name in dir(obj):
-            attr = getattr(obj, name)
+            try:
+                attr = getattr(obj, name)
+            except AttributeError:
+                # What else can be done besides skipping and continuing?
+                continue
             if isinstance(attr, property):
                 annots = _get_type_hints(attr.fget, include_extras=include_extras)
                 if return_annot := annots.get("return"):

--- a/ibis/tests/test_typing.py
+++ b/ibis/tests/test_typing.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from ibis.common.typing import get_type_hints

--- a/ibis/tests/test_typing.py
+++ b/ibis/tests/test_typing.py
@@ -1,4 +1,3 @@
-import pytest
 from typing import Any
 
 from ibis.common.typing import get_type_hints

--- a/ibis/tests/test_typing.py
+++ b/ibis/tests/test_typing.py
@@ -1,0 +1,17 @@
+import pytest
+from typing import Any
+
+from ibis.common.typing import get_type_hints
+
+class TestClass:
+    a: int
+    @property
+    def b(self) -> str:
+        return "test"
+    @property
+    def c(self) -> Any:
+        raise AttributeError("Property 'c' raises AttributeError")
+
+def test_get_type_hints_with_attribute_error():
+    hints = get_type_hints(TestClass, include_properties=True)
+    assert hints == {"a": int, "b": str}

--- a/ibis/tests/test_typing.py
+++ b/ibis/tests/test_typing.py
@@ -4,14 +4,18 @@ from typing import Any
 
 from ibis.common.typing import get_type_hints
 
+
 class TestClass:
     a: int
+
     @property
     def b(self) -> str:
         return "test"
+
     @property
     def c(self) -> Any:
         raise AttributeError("Property 'c' raises AttributeError")
+
 
 def test_get_type_hints_with_attribute_error():
     hints = get_type_hints(TestClass, include_properties=True)


### PR DESCRIPTION
Update common typing to skip attributes when attempting to load properties for various data type objects and do not exist.

Resolves #10665 