### PR TITLE
feat(duckdb): add to_json() to Table and duckdb backend

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -586,6 +586,32 @@ class _FileIOHandler:
         with expr.to_pyarrow_batches(params=params) as batch_reader:
             write_deltalake(path, batch_reader, **kwargs)
 
+    @util.experimental
+    def to_json(
+        self,
+        expr: ir.Table,
+        path: str | Path,
+        **kwargs: Any,
+    ) -> None:
+        """Write the results of `expr` to a json file of [{column -> value}, ...] objects.
+
+        This method is eager and will execute the associated expression
+        immediately.
+
+        Parameters
+        ----------
+        expr
+            The ibis expression to execute and persist to Delta Lake table.
+        path
+            The data source. A string or Path to the Delta Lake table.
+        kwargs
+            Additional, backend-specifc keyword arguments.
+        """
+        backend = expr._find_backend(use_default=True)
+        raise NotImplementedError(
+            f"{backend.__class__.__name__} does not support writing to JSON."
+        )
+
 
 class CanListCatalog(abc.ABC):
     @abc.abstractmethod

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -348,6 +348,38 @@ def test_table_to_csv(tmp_path, backend, awards_players):
 
 
 @pytest.mark.notimpl(
+    [
+        "athena",
+        "bigquery",
+        "clickhouse",
+        "databricks",
+        "datafusion",
+        "druid",
+        "exasol",
+        "flink",
+        "impala",
+        "mssql",
+        "mysql",
+        "oracle",
+        "polars",
+        "postgres",
+        "pyspark",
+        "risingwave",
+        "snowflake",
+        "sqlite",
+        "trino",
+    ],
+    reason="haven't gotten to them yet. Might be easy!",
+    raises=NotImplementedError,
+)
+def test_to_json(backend, tmp_path, awards_players):
+    out_path = tmp_path / "out.json"
+    awards_players.to_json(out_path)
+    df = pd.read_json(out_path, orient="records")
+    backend.assert_frame_equal(awards_players.to_pandas(), df)
+
+
+@pytest.mark.notimpl(
     ["duckdb"],
     reason="cannot inline WriteOptions objects",
     raises=DuckDBParserException,

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -772,6 +772,28 @@ class Expr(Immutable, Coercible):
         self._find_backend(use_default=True).to_delta(self, path, **kwargs)
 
     @experimental
+    def to_json(
+        self,
+        path: str | Path,
+        **kwargs: Any,
+    ) -> None:
+        """Write the results of `expr` to a json file of [{column -> value}, ...] objects.
+
+        This method is eager and will execute the associated expression
+        immediately.
+
+        Parameters
+        ----------
+        expr
+            The ibis expression to execute and persist to Delta Lake table.
+        path
+            The data source. A string or Path to the Delta Lake table.
+        kwargs
+            Additional, backend-specifc keyword arguments.
+        """
+        self._find_backend(use_default=True).to_json(self, path, **kwargs)
+
+    @experimental
     def to_torch(
         self,
         *,


### PR DESCRIPTION
Fixes https://github.com/ibis-project/ibis/issues/10413

I didn't bother adding this to any of the other backends. There is no handy pyarrow.to_json() function that can save the day here. I think we would need to to backend-specific implementations.

Open todos that could come later, but I don't think should be blocking for this PR:
- Consider taking some of the [duckdb-specific config options](https://duckdb.org/docs/sql/statements/copy.html#json-options), and hoisting them to be "official" options across all backends. I could see a `format=Literal["array", "jsonl"] = "array"` being the most likely choice, but not needed until we survey the other backends.
- For dates/datetimes/decimals, where there is no corresponding JSON type, we need to decide what to do.
- Once we decide, implement that.
- Maybe add more tests to ensure that backends produce the same JSON strings? eg maybe the implementation of the test currently, of just reading back using pandas, is too lenient, and multiple on-disk values would lead to the same result. Maybe we actually want to look at the on-disk representation.