### PR TITLE
chore(docs): simply pip install ibis-framework instead of pre-installing a bunch of requirements

### DIFF
--- a/docs/_tabsets/repl_warning.qmd
+++ b/docs/_tabsets/repl_warning.qmd
@@ -1,9 +1,0 @@
-::: {.callout-warning collapse="true"}
-## Ibis in the browser is experimental.
-
-iOS is known to cause crashes on this page.
-
-Mobile Firefox may also not work (the page won't crash though).
-
-Please [open an issue on GitHub](https://github.com/ibis-project/ibis/issues/new/choose) if you encounter problems.
-:::

--- a/docs/tutorials/browser/repl.qmd
+++ b/docs/tutorials/browser/repl.qmd
@@ -8,7 +8,15 @@ format:
 Try our experimental JupyterLite console with Ibis, using the Palmer
 penguins[^1] dataset loaded into the DuckDB backend!
 
-{{< include ../../_tabsets/repl_warning.qmd >}}
+::: {.callout-warning collapse="true"}
+## Ibis in the browser is experimental.
+
+iOS is known to crash on this page.
+
+Mobile Firefox may also not work (the page won't crash though).
+
+Please [open an issue on GitHub](https://github.com/ibis-project/ibis/issues/new/choose) if you encounter problems.
+:::
 
 ```{python}
 #| echo: false

--- a/docs/tutorials/browser/repl.qmd
+++ b/docs/tutorials/browser/repl.qmd
@@ -16,11 +16,11 @@ penguins[^1] dataset loaded into the DuckDB backend!
 from urllib.parse import urlencode
 
 lines = """
-%pip install numpy pandas tzdata duckdb pyarrow
 import pathlib, js
 penguins_csv_url = "https://storage.googleapis.com/ibis-tutorial-data/penguins.csv"
-pathlib.Path("penguins.csv").write_text(await (await js.fetch(penguins_csv_url)).text())
-del pathlib, js, penguins_csv_url
+penguins_text = await (await js.fetch(penguins_csv_url)).text()
+pathlib.Path("penguins.csv").write_text(penguins_text)
+del pathlib, js, penguins_csv_url, penguins_text
 %clear
 %pip install 'ibis-framework[duckdb]'
 from ibis.interactive import *

--- a/flake.lock
+++ b/flake.lock
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737027406,
-        "narHash": "sha256-DkjaUjBEgw0mWUEGsPaxVIpmXt+ArpBb2nrWZ6pSi6U=",
+        "lastModified": 1737076171,
+        "narHash": "sha256-C8KdXxpAFu4nPzyLORxv8cOx5MzevJhVl8ffKkGedjY=",
         "owner": "adisbladis",
         "repo": "uv2nix",
-        "rev": "e0214a4fff5a73051e2bbfff42140f73719cbcba",
+        "rev": "c30b45f82e6ddff4410aa3ba8b15c52a9b4bd1f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Removes now-unnecessary pip installs of some dependencies, since `%pip install ibis-framework[duckdb]` "just works" now thanks to the hard work of many people.