### PR TITLE
test(pyspark): simplify clean up by making `__del__` a no-op in the spark case

### DIFF
--- a/ibis/backends/clickhouse/tests/conftest.py
+++ b/ibis/backends/clickhouse/tests/conftest.py
@@ -178,13 +178,13 @@ class TestConf(ServiceBackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(data_dir, tmp_path_factory, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection
 
 
 @pytest.fixture(scope="session")

--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -470,9 +470,7 @@ def ddl_backend(request, data_dir, tmp_path_factory, worker_id):
 @pytest.fixture(scope="session")
 def ddl_con(ddl_backend):
     """Instance of Client, already connected to the db (if applies)."""
-    connection = ddl_backend.connection
-    yield connection
-    connection.disconnect()
+    return ddl_backend.connection
 
 
 @pytest.fixture(

--- a/ibis/backends/datafusion/tests/conftest.py
+++ b/ibis/backends/datafusion/tests/conftest.py
@@ -74,13 +74,13 @@ class TestConf(BackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(data_dir, tmp_path_factory, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection
 
 
 @pytest.fixture(scope="session")

--- a/ibis/backends/duckdb/tests/conftest.py
+++ b/ibis/backends/duckdb/tests/conftest.py
@@ -138,13 +138,13 @@ class TestConf(BackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(data_dir, tmp_path_factory, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection
 
 
 @pytest.fixture(scope="session")

--- a/ibis/backends/flink/tests/conftest.py
+++ b/ibis/backends/flink/tests/conftest.py
@@ -122,6 +122,9 @@ class TestConf(BackendTest):
         )
         con.create_table("topk", topk, temp=True)
 
+    def __del__(self):
+        pass
+
 
 class TestConfForStreaming(TestConf):
     @staticmethod
@@ -133,6 +136,9 @@ class TestConfForStreaming(TestConf):
 
         table_env = get_table_env(local_env=True, streaming_mode=True)
         return ibis.flink.connect(table_env, **kw)
+
+    def __del__(self):
+        pass
 
 
 @pytest.fixture

--- a/ibis/backends/flink/tests/conftest.py
+++ b/ibis/backends/flink/tests/conftest.py
@@ -158,10 +158,13 @@ def simple_table(simple_schema):
 
 
 @pytest.fixture(scope="session")
-def con(tmp_path_factory, data_dir, worker_id):
-    return TestConfForStreaming.load_data(
-        data_dir, tmp_path_factory, worker_id
-    ).connection
+def local_backend(data_dir, tmp_path_factory, worker_id):
+    return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
+
+
+@pytest.fixture(scope="session")
+def con(local_backend):
+    return local_backend.connection
 
 
 @pytest.fixture

--- a/ibis/backends/mssql/tests/conftest.py
+++ b/ibis/backends/mssql/tests/conftest.py
@@ -60,10 +60,10 @@ class TestConf(ServiceBackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(data_dir, tmp_path_factory, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection

--- a/ibis/backends/mysql/tests/conftest.py
+++ b/ibis/backends/mysql/tests/conftest.py
@@ -75,10 +75,10 @@ class TestConf(ServiceBackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(tmp_path_factory, data_dir, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection

--- a/ibis/backends/oracle/tests/conftest.py
+++ b/ibis/backends/oracle/tests/conftest.py
@@ -133,13 +133,13 @@ class TestConf(ServiceBackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(data_dir, tmp_path_factory, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection
 
 
 def init_oracle_database(

--- a/ibis/backends/polars/tests/conftest.py
+++ b/ibis/backends/polars/tests/conftest.py
@@ -44,13 +44,13 @@ class TestConf(BackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(data_dir, tmp_path_factory, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection
 
 
 @pytest.fixture(scope="session")

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -69,13 +69,13 @@ class TestConf(ServiceBackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(data_dir, tmp_path_factory, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection
 
 
 @pytest.fixture(scope="module")

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -324,6 +324,9 @@ else:
             spark = configure_spark_with_delta_pip(config).getOrCreate()
             return ibis.pyspark.connect(spark, **kw)
 
+        def __del__(self):
+            pass
+
     class TestConfForStreaming(BackendTest):
         deps = ("pyspark",)
 
@@ -379,6 +382,9 @@ else:
             spark = SparkSession.getActiveSession().newSession()
             con = ibis.pyspark.connect(spark, mode="streaming", **kw)
             return con
+
+        def __del__(self):
+            pass
 
     @pytest.fixture(scope="session")
     def con_streaming(data_dir, tmp_path_factory, worker_id):

--- a/ibis/backends/risingwave/tests/conftest.py
+++ b/ibis/backends/risingwave/tests/conftest.py
@@ -68,13 +68,13 @@ class TestConf(ServiceBackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(tmp_path_factory, data_dir, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection
 
 
 @pytest.fixture(scope="module")

--- a/ibis/backends/snowflake/tests/conftest.py
+++ b/ibis/backends/snowflake/tests/conftest.py
@@ -215,10 +215,10 @@ class TestConf(BackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(data_dir, tmp_path_factory, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection

--- a/ibis/backends/sqlite/tests/conftest.py
+++ b/ibis/backends/sqlite/tests/conftest.py
@@ -55,10 +55,10 @@ class TestConf(BackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(data_dir, tmp_path_factory, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection

--- a/ibis/backends/tests/base.py
+++ b/ibis/backends/tests/base.py
@@ -63,12 +63,6 @@ class BackendTest(abc.ABC):
     tpc_absolute_tolerance: float | None = None
     "Absolute tolerance for floating point comparisons with pytest.approx in TPC correctness tests."
 
-    def __del__(self):
-        try:  # noqa: SIM105
-            self.connection.disconnect()
-        except AttributeError:
-            pass
-
     @property
     @abc.abstractmethod
     def deps(self) -> Iterable[str]:
@@ -331,6 +325,12 @@ class BackendTest(abc.ABC):
             path.with_suffix("").name
             for path in self.data_dir.joinpath(f"tpc{suite}").rglob("*.parquet")
         )
+
+    def __del__(self):
+        try:  # noqa: SIM105
+            self.connection.disconnect()
+        except AttributeError:
+            pass
 
 
 class ServiceBackendTest(BackendTest):

--- a/ibis/backends/tests/errors.py
+++ b/ibis/backends/tests/errors.py
@@ -56,15 +56,12 @@ try:
     from pyspark.errors.exceptions.base import PySparkValueError
     from pyspark.errors.exceptions.base import PythonException as PySparkPythonException
     from pyspark.errors.exceptions.connect import (
-        SparkConnectException as PySparkConnectException,
-    )
-    from pyspark.errors.exceptions.connect import (
         SparkConnectGrpcException as PySparkConnectGrpcException,
     )
 except ImportError:
     PySparkParseException = PySparkAnalysisException = PySparkArithmeticException = (
         PySparkPythonException
-    ) = PySparkConnectException = PySparkConnectGrpcException = PySparkValueError = None
+    ) = PySparkConnectGrpcException = PySparkValueError = None
 
 try:
     from google.api_core.exceptions import BadRequest as GoogleBadRequest

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -22,10 +22,11 @@ from ibis.backends.tests.errors import (
     GoogleBadRequest,
     MySQLOperationalError,
     PolarsComputeError,
+    PsycoPg2ArraySubscriptError,
     PsycoPg2IndeterminateDatatype,
     PsycoPg2InternalError,
     PsycoPg2ProgrammingError,
-    PsycoPgInvalidTextRepresentation,
+    PsycoPg2SyntaxError,
     PsycoPgSyntaxError,
     Py4JJavaError,
     PyAthenaDatabaseError,
@@ -1117,7 +1118,7 @@ def test_unnest_struct(con):
 
 
 @builtin_array
-@pytest.mark.notimpl(["postgres"], raises=PsycoPgSyntaxError)
+@pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError)
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2InternalError)
 @pytest.mark.notimpl(
     ["trino"], reason="inserting maps into structs doesn't work", raises=TrinoUserError
@@ -1208,7 +1209,7 @@ def test_zip_null(con, fn):
 
 
 @builtin_array
-@pytest.mark.notimpl(["postgres"], raises=PsycoPgSyntaxError)
+@pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError)
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2ProgrammingError)
 @pytest.mark.notimpl(["datafusion"], raises=Exception, reason="not yet supported")
 @pytest.mark.notimpl(
@@ -1768,7 +1769,7 @@ def test_table_unnest_column_expr(backend):
 @pytest.mark.notimpl(["datafusion", "polars"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["trino"], raises=TrinoUserError)
 @pytest.mark.notimpl(["athena"], raises=PyAthenaOperationalError)
-@pytest.mark.notimpl(["postgres"], raises=PsycoPgSyntaxError)
+@pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError)
 @pytest.mark.notimpl(["risingwave"], raises=PsycoPg2ProgrammingError)
 @pytest.mark.notyet(
     ["risingwave"], raises=PsycoPg2InternalError, reason="not supported in risingwave"
@@ -1889,7 +1890,7 @@ def test_array_agg_bool(con, data, agg, baseline_func):
 
 @pytest.mark.notyet(
     ["postgres"],
-    raises=PsycoPgInvalidTextRepresentation,
+    raises=PsycoPg2ArraySubscriptError,
     reason="all dimensions must match in size",
 )
 @pytest.mark.notimpl(["risingwave", "flink"], raises=com.OperationNotDefinedError)

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -32,7 +32,7 @@ from ibis.backends.tests.errors import (
     ImpalaHiveServer2Error,
     OracleDatabaseError,
     PsycoPg2InternalError,
-    PsycoPgUndefinedObject,
+    PsycoPg2UndefinedObject,
     Py4JJavaError,
     PyAthenaDatabaseError,
     PyODBCProgrammingError,
@@ -725,7 +725,7 @@ def test_list_database_contents(con):
 @pytest.mark.notyet(["databricks"], raises=DatabricksServerOperationError)
 @pytest.mark.notyet(["bigquery"], raises=com.UnsupportedBackendType)
 @pytest.mark.notyet(
-    ["postgres"], raises=PsycoPgUndefinedObject, reason="no unsigned int types"
+    ["postgres"], raises=PsycoPg2UndefinedObject, reason="no unsigned int types"
 )
 @pytest.mark.notyet(
     ["oracle"], raises=OracleDatabaseError, reason="no unsigned int types"

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -25,7 +25,7 @@ from ibis.backends.tests.errors import (
     OracleDatabaseError,
     PolarsInvalidOperationError,
     PsycoPg2InternalError,
-    PsycoPgSyntaxError,
+    PsycoPg2SyntaxError,
     Py4JJavaError,
     PyAthenaDatabaseError,
     PyAthenaOperationalError,
@@ -1736,7 +1736,7 @@ def test_hexdigest(backend, alltypes):
                 pytest.mark.notimpl(["flink"], raises=Py4JJavaError),
                 pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError),
                 pytest.mark.notimpl(["oracle"], raises=OracleDatabaseError),
-                pytest.mark.notimpl(["postgres"], raises=PsycoPgSyntaxError),
+                pytest.mark.notimpl(["postgres"], raises=PsycoPg2SyntaxError),
                 pytest.mark.notimpl(["risingwave"], raises=PsycoPg2InternalError),
                 pytest.mark.notimpl(["snowflake"], raises=AssertionError),
                 pytest.mark.never(

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -13,7 +13,7 @@ from ibis.backends.tests.errors import (
     DatabricksServerOperationError,
     PolarsColumnNotFoundError,
     PsycoPg2InternalError,
-    PsycoPgSyntaxError,
+    PsycoPg2SyntaxError,
     Py4JJavaError,
     PyAthenaDatabaseError,
     PyAthenaOperationalError,
@@ -138,7 +138,7 @@ def test_collect_into_struct(alltypes):
 
 
 @pytest.mark.notimpl(
-    ["postgres"], reason="struct literals not implemented", raises=PsycoPgSyntaxError
+    ["postgres"], reason="struct literals not implemented", raises=PsycoPg2SyntaxError
 )
 @pytest.mark.notimpl(
     ["risingwave"],
@@ -155,7 +155,7 @@ def test_field_access_after_case(con):
 
 
 @pytest.mark.notimpl(
-    ["postgres"], reason="struct literals not implemented", raises=PsycoPgSyntaxError
+    ["postgres"], reason="struct literals not implemented", raises=PsycoPg2SyntaxError
 )
 @pytest.mark.notimpl(["flink"], raises=IbisError, reason="not implemented in ibis")
 @pytest.mark.parametrize(
@@ -242,7 +242,7 @@ def test_keyword_fields(con, nullable):
 
 @pytest.mark.notyet(
     ["postgres"],
-    raises=PsycoPgSyntaxError,
+    raises=PsycoPg2SyntaxError,
     reason="sqlglot doesn't implement structs for postgres correctly",
 )
 @pytest.mark.notyet(

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -162,13 +162,13 @@ class TestConf(ServiceBackendTest):
 
 
 @pytest.fixture(scope="session")
-def backend(tmp_path_factory, data_dir, worker_id):
+def local_backend(data_dir, tmp_path_factory, worker_id):
     return TestConf.load_data(data_dir, tmp_path_factory, worker_id)
 
 
 @pytest.fixture(scope="session")
-def con(backend):
-    return backend.connection
+def con(local_backend):
+    return local_backend.connection
 
 
 def generate_tpc_tables(suite_name, *, data_dir):


### PR DESCRIPTION
This should clear up the flaky spark-remote tests in CI.