### PR TITLE
feat: return DSL string for DataDatatype.__repr__()

### DIFF
--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -47,29 +47,36 @@ def dtype(value: Any, nullable: bool = True) -> DataType:
     Examples
     --------
     >>> import ibis
-    >>> ibis.dtype("int32")
-    Int32(nullable=True)
-    >>> ibis.dtype("array<float>")
-    Array(value_type=Float64(nullable=True), nullable=True)
+    >>> type(ibis.dtype("int32"))
+    <class 'ibis.expr.datatypes.core.Int32>
+    >>> dt = ibis.dtype("array<!float>")
+    >>> type(dt)
+    <class 'ibis.expr.datatypes.core.Array'>
+    >>> type(dt.value_type)
+    <class 'ibis.expr.datatypes.core.Float64'>
+    >>> dt.nullable
+    True
+    >>> dt.value_type.nullable
+    False
 
     DataType objects may also be created from Python types:
 
     >>> ibis.dtype(int)
-    Int64(nullable=True)
+    int64
     >>> ibis.dtype(list[float])
-    Array(value_type=Float64(nullable=True), nullable=True)
+    array<float64>
 
     Or other type systems, like numpy/pandas/pyarrow types:
 
     >>> import pyarrow as pa
     >>> ibis.dtype(pa.int32())
-    Int32(nullable=True)
+    int32
 
     """
     if isinstance(value, DataType):
         return value
     else:
-        return DataType.from_typehint(value)
+        return DataType.from_typehint(value, nullable=nullable)
 
 
 @dtype.register(str)

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -145,6 +145,9 @@ class DataType(Concrete, Coercible):
         prefix = "!" * (not self.nullable)
         return f"{prefix}{self.name.lower()}{self._pretty_piece}"
 
+    def __repr__(self) -> str:
+        return str(self)
+
     def equals(self, other):
         if not isinstance(other, DataType):
             raise TypeError(

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -487,14 +487,14 @@ def test_timestamp_with_invalid_timezone():
     assert str(ts) == "timestamp('Foo/Bar&234')"
 
 
-def test_timestamp_with_timezone_repr():
-    ts = dt.Timestamp("UTC")
-    assert repr(ts) == "Timestamp(timezone='UTC', scale=None, nullable=True)"
-
-
 def test_timestamp_with_timezone_str():
     ts = dt.Timestamp("UTC")
     assert str(ts) == "timestamp('UTC')"
+
+
+def test_timestamp_with_timezone_scale_str():
+    ts = dt.Timestamp("UTC", scale=4)
+    assert str(ts) == "timestamp('UTC', 4)"
 
 
 def test_time_str():

--- a/ibis/expr/datatypes/tests/test_pandas_numpy_value.py
+++ b/ibis/expr/datatypes/tests/test_pandas_numpy_value.py
@@ -195,5 +195,5 @@ def test_infer_numpy_array(numpy_array, expected_dtypes):
 def test_normalize_non_convertible_boolean():
     typ = dt.boolean
     value = np.array([1, 2, 3])
-    with pytest.raises(TypeError, match="Unable to normalize .+ to Boolean"):
+    with pytest.raises(TypeError, match="Unable to normalize .+ to boolean"):
         dt.normalize(typ, value)

--- a/ibis/expr/datatypes/tests/test_value.py
+++ b/ibis/expr/datatypes/tests/test_value.py
@@ -200,14 +200,14 @@ def test_normalize_none_with_non_nullable_type():
 @pytest.mark.parametrize("kind", ["uint", "int"])
 def test_normalize_non_convertible_int(kind, bits):
     typ = getattr(dt, f"{kind}{bits:d}")
-    with pytest.raises(TypeError, match="Unable to normalize .+ to U?Int"):
+    with pytest.raises(TypeError, match="Unable to normalize .+ to u?int"):
         dt.normalize(typ, "not convertible")
 
 
 @pytest.mark.parametrize("typename", ["float32", "float64"])
 def test_normalize_non_convertible_float(typename):
     typ = getattr(dt, typename)
-    with pytest.raises(TypeError, match="Unable to normalize .+ to Float"):
+    with pytest.raises(TypeError, match="Unable to normalize .+ to float"):
         dt.normalize(typ, "not convertible")
 
 

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call1-too_many_positional_arguments/too_many_positional_arguments.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call1-too_many_positional_arguments/too_many_positional_arguments.txt
@@ -1,3 +1,3 @@
-Literal(1, Int8(nullable=True), 'foo') too many positional arguments
+Literal(1, int8, 'foo') too many positional arguments
 
 Expected signature: Literal(value: Annotated[Any, Not(pattern=InstanceOf(type=<class 'Deferred'>))], dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call2-got_an_unexpected_keyword/got_an_unexpected_keyword.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call2-got_an_unexpected_keyword/got_an_unexpected_keyword.txt
@@ -1,3 +1,3 @@
-Literal(1, Int8(nullable=True), name='foo') got an unexpected keyword argument 'name'
+Literal(1, int8, name='foo') got an unexpected keyword argument 'name'
 
 Expected signature: Literal(value: Annotated[Any, Not(pattern=InstanceOf(type=<class 'Deferred'>))], dtype: DataType)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call3-multiple_values_for_argument/multiple_values_for_argument.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call3-multiple_values_for_argument/multiple_values_for_argument.txt
@@ -1,3 +1,3 @@
-Literal(1, Int8(nullable=True), dtype=Int16(nullable=True)) multiple values for argument 'dtype'
+Literal(1, int8, dtype=int16) multiple values for argument 'dtype'
 
 Expected signature: Literal(value: Annotated[Any, Not(pattern=InstanceOf(type=<class 'Deferred'>))], dtype: DataType)

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -104,16 +104,16 @@ class Value(Expr):
         ...         "timestamp_col": [
         ...             datetime(2024, 11, 2, 10, 5, 2),
         ...         ],
-        ...         "string_col": ["a"],
+        ...         "array_of_string_col": [["a", "b", "c"]],
         ...     }
         ... )
 
-        >>> t.int_col.type()
-        Int64(nullable=True)
-        >>> t.timestamp_col.type()
-        Timestamp(timezone=None, scale=None, nullable=True)
-        >>> t.string_col.type()
-        String(nullable=True)
+        >>> t.int_col.type(), type(t.int_col.type())
+        (int64, <class 'ibis.expr.datatypes.core.Int64'>)
+        >>> t.timestamp_col.type(), type(t.timestamp_col.type())
+        (timestamp, <class 'ibis.expr.datatypes.core.Timestamp'>)
+        >>> t.timestamp_col.type(), type(t.array_of_string_col.type())
+        (array<string>, <class 'ibis.expr.datatypes.core.Array'>)
         """
         return self.op().dtype
 
@@ -2934,13 +2934,13 @@ def literal(value: Any, type: dt.DataType | str | None = None) -> Scalar:
     >>> import ibis
     >>> x = ibis.literal(42)
     >>> x.type()
-    Int8(nullable=True)
+    int8
 
     Construct a `float64` literal from an `int`
 
     >>> y = ibis.literal(42, type="double")
     >>> y.type()
-    Float64(nullable=True)
+    float64
 
     Ibis checks for invalid types
 

--- a/ibis/tests/expr/test_decimal.py
+++ b/ibis/tests/expr/test_decimal.py
@@ -146,5 +146,5 @@ def test_decimal_str(lineitem):
 def test_decimal_repr(lineitem):
     col = lineitem.l_extendedprice
     t = col.type()
-    expected = f"Decimal(precision={t.precision:d}, scale={t.scale:d}, nullable=True)"
+    expected = f"decimal({t.precision:d}, {t.scale:d})"
     assert repr(t) == expected


### PR DESCRIPTION
fixes https://github.com/ibis-project/ibis/issues/10391

I can add more tests or otherwise modify them if you think wise, but probably I think what we have here is sufficient.

One sanity check could be a roundtrip check?
```python
for dsl in ["int8", "uint8" ,...]:
    dt = ibis.dtype(dsl)
    assert dsl == str(dt)
    assert dsl == repr(dt)
```
      