### PR TITLE
feat(datatypes): add support for fixed length arrays

### DIFF
--- a/ibis/backends/clickhouse/tests/test_datatypes.py
+++ b/ibis/backends/clickhouse/tests/test_datatypes.py
@@ -296,7 +296,7 @@ roundtrippable_types = st.deferred(
         | its.date_dtype()
         | its.time_dtype()
         | its.timestamp_dtype(scale=st.integers(0, 9))
-        | its.array_dtypes(roundtrippable_types, nullable=false)
+        | its.array_dtypes(roundtrippable_types, nullable=false, length=st.none())
         | its.map_dtypes(map_key_types, roundtrippable_types, nullable=false)
     )
 )

--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -36,7 +36,7 @@ from ibis.backends.sql.datatypes import DuckDBType
             ("UUID", dt.uuid),
             ("VARCHAR", dt.string),
             ("INTEGER[]", dt.Array(dt.int32)),
-            ("INTEGER[3]", dt.Array(dt.int32)),
+            ("INTEGER[3]", dt.Array(dt.int32, length=3)),
             ("MAP(VARCHAR, BIGINT)", dt.Map(dt.string, dt.int64)),
             (
                 "STRUCT(a INTEGER, b VARCHAR, c MAP(VARCHAR, DOUBLE[])[])",

--- a/ibis/expr/datatypes/parse.py
+++ b/ibis/expr/datatypes/parse.py
@@ -74,7 +74,7 @@ def parse(
     >>> import ibis
     >>> import ibis.expr.datatypes as dt
     >>> dt.parse("array<int64>")
-    Array(value_type=Int64(nullable=True), nullable=True)
+    Array(value_type=Int64(nullable=True), length=None, nullable=True)
 
     You can avoid parsing altogether by constructing objects directly
 
@@ -182,8 +182,13 @@ def parse(
     )
 
     ty = parsy.forward_declaration()
-    angle_type = LANGLE.then(ty).skip(RANGLE)
-    array = spaceless_string("array").then(angle_type).map(dt.Array)
+
+    array = (
+        spaceless_string("array")
+        .then(LANGLE)
+        .then(parsy.seq(ty, COMMA.then(LENGTH).optional()).combine(dt.Array))
+        .skip(RANGLE)
+    )
 
     map = (
         spaceless_string("map")

--- a/ibis/expr/datatypes/tests/test_core.py
+++ b/ibis/expr/datatypes/tests/test_core.py
@@ -571,6 +571,14 @@ def test_is_methods(dtype_class):
     assert is_dtype is True
 
 
+def test_is_fixed_length_array():
+    dtype = dt.Array(dt.int8)
+    assert not dtype.is_fixed_length_array()
+
+    dtype = dt.Array(dt.int8, 10)
+    assert dtype.is_fixed_length_array()
+
+
 def test_is_array():
     assert dt.Array(dt.string).is_array()
     assert not dt.string.is_array()

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -149,9 +149,11 @@ def primitive_dtypes(nullable=_nullable):
 
 _item_strategy = primitive_dtypes()
 
+_length = st.one_of(st.none(), st.integers(min_value=0))
 
-def array_dtypes(value_type=_item_strategy, nullable=_nullable):
-    return st.builds(dt.Array, value_type=value_type, nullable=nullable)
+
+def array_dtypes(value_type=_item_strategy, nullable=_nullable, length=_length):
+    return st.builds(dt.Array, value_type=value_type, nullable=nullable, length=length)
 
 
 def map_dtypes(key_type=_item_strategy, value_type=_item_strategy, nullable=_nullable):
@@ -180,7 +182,7 @@ def struct_dtypes(
 
 def geospatial_dtypes(nullable=_nullable):
     geotype = st.one_of(st.just("geography"), st.just("geometry"))
-    srid = st.one_of(st.just(None), st.integers(min_value=0))
+    srid = st.one_of(st.none(), st.integers(min_value=0))
     return st.one_of(
         st.builds(dt.Point, geotype=geotype, nullable=nullable, srid=srid),
         st.builds(dt.LineString, geotype=geotype, nullable=nullable, srid=srid),


### PR DESCRIPTION
Add `length` field to `Array` datatypes to support fixed-length arrays.

Closes #10719.
