### PR TITLE
fix(postgres): fix insertion of `NaT`/`None` into timestamp columns

### DIFF
--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -8,6 +8,7 @@ from operator import itemgetter
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote_plus
 
+import psycopg
 import sqlglot as sg
 import sqlglot.expressions as sge
 from pandas.api.types import is_float_dtype
@@ -31,8 +32,12 @@ if TYPE_CHECKING:
 
     import pandas as pd
     import polars as pl
-    import psycopg
     import pyarrow as pa
+
+
+class NatDumper(psycopg.adapt.Dumper):
+    def dump(self, obj, context: Any | None = None) -> str | None:
+        return None
 
 
 class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
@@ -233,6 +238,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
           year            int32
           month           int32
         """
+        import pandas as pd
         import psycopg
         import psycopg.types.json
 
@@ -247,6 +253,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
             options=(f"-csearch_path={schema}" * (schema is not None)) or None,
             **kwargs,
         )
+
+        self.con.adapters.register_dumper(type(pd.NaT), NatDumper)
 
         self._post_connect()
 

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -122,7 +122,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
     def _fetch_from_cursor(self, cursor, schema: sch.Schema) -> pd.DataFrame:
         import pandas as pd
 
-        from ibis.backends.postgres.converter import PostgresPandasData
+        from ibis.backends.risingwave.converter import RisingWavePandasData
 
         try:
             df = pd.DataFrame.from_records(
@@ -135,7 +135,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
             # artificially locked tables
             cursor.close()
             raise
-        df = PostgresPandasData.convert_table(df, schema)
+        df = RisingWavePandasData.convert_table(df, schema)
         return df
 
     @property

--- a/ibis/backends/risingwave/converter.py
+++ b/ibis/backends/risingwave/converter.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from ibis.formats.pandas import PandasData
+
+
+class RisingWavePandasData(PandasData):
+    @classmethod
+    def convert_Binary(cls, s, dtype, pandas_type):
+        return s.map(bytes, na_action="ignore")


### PR DESCRIPTION
Fixes #10742.
