### PR TITLE
test(join): add test that colliding column names will get merged into one

### DIFF
--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1786,6 +1786,9 @@ def test_join_lname_rname(how):
     expr = method(right, rname="right_{name}", lname="left_{name}")
     assert expr.columns == ("left_id", "first_name", "right_id", "last_name")
 
+    expr = method(right, rname="{name}_z", lname="{name}_z")
+    assert expr.columns == ("id_z", "first_name", "last_name")
+
 
 def test_join_lname_rname_still_collide():
     t1 = ibis.table({"id": "int64", "col1": "int64", "col2": "int64"})


### PR DESCRIPTION
I'm adding this PR mostly as a demo of what I think might be undesirable behavior. Should this instead error, because the two input columns are getting mapped to the same output column?