### PR TITLE
fix(pyspark): generate `IF NOT EXISTS` if `force=True`

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -507,7 +507,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
 
         sql = sge.Create(
             kind="DATABASE",
-            exist=force,
+            exists=force,
             this=sg.to_identifier(name, quoted=self.compiler.quoted),
             properties=properties,
         )
@@ -533,7 +533,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase):
         """
         sql = sge.Drop(
             kind="DATABASE",
-            exist=force,
+            exists=force,
             this=sg.to_identifier(name, quoted=self.compiler.quoted),
             cascade=force,
         )

--- a/ibis/backends/pyspark/tests/test_ddl.py
+++ b/ibis/backends/pyspark/tests/test_ddl.py
@@ -180,6 +180,11 @@ def test_create_table_reserved_identifier(con, alltypes, keyword_t):
     assert result == expected
 
 
+@pytest.mark.xfail_version(
+    pyspark=["pyspark<3.5"],
+    raises=ValueError,
+    reason="PySparkAnalysisException is not available in PySpark <3.5",
+)
 def test_create_database_exists(con):
     con.create_database(dbname := util.gen_name("dbname"))
 
@@ -191,6 +196,11 @@ def test_create_database_exists(con):
     con.drop_database(dbname, force=True)
 
 
+@pytest.mark.xfail_version(
+    pyspark=["pyspark<3.5"],
+    raises=ValueError,
+    reason="PySparkAnalysisException is not available in PySpark <3.5",
+)
 def test_drop_database_exists(con):
     con.create_database(dbname := util.gen_name("dbname"))
 

--- a/ibis/backends/pyspark/tests/test_ddl.py
+++ b/ibis/backends/pyspark/tests/test_ddl.py
@@ -9,6 +9,7 @@ import pytest
 
 import ibis
 from ibis import util
+from ibis.backends.tests.errors import PySparkAnalysisException
 from ibis.tests.util import assert_equal
 
 pyspark = pytest.importorskip("pyspark")
@@ -177,3 +178,25 @@ def test_create_table_reserved_identifier(con, alltypes, keyword_t):
     t = con.create_table(keyword_t, expr)
     result = t.count().execute()
     assert result == expected
+
+
+def test_create_database_exists(con):
+    con.create_database(dbname := util.gen_name("dbname"))
+
+    with pytest.raises(PySparkAnalysisException):
+        con.create_database(dbname)
+
+    con.create_database(dbname, force=True)
+
+    con.drop_database(dbname, force=True)
+
+
+def test_drop_database_exists(con):
+    con.create_database(dbname := util.gen_name("dbname"))
+
+    con.drop_database(dbname)
+
+    with pytest.raises(PySparkAnalysisException):
+        con.drop_database(dbname)
+
+    con.drop_database(dbname, force=True)


### PR DESCRIPTION
## Description of changes

We were using the wrong keyword in `sqlglot` for this so it was being
swallowed silently.


## Issues closed

xref #10749