### PR TITLE
fix(graphviz): ensure all lines are left-justified

### DIFF
--- a/ibis/expr/visualize.py
+++ b/ibis/expr/visualize.py
@@ -72,18 +72,18 @@ def get_label(node):
     )
     if nodename is not None:
         if isinstance(node, ops.Relation):
-            label_fmt = "<<I>{}</I>: <B>{}</B>{}>"
+            label_fmt = "<<I>{}</I>: <B>{}</B>{}"
         else:
-            label_fmt = '<<I>{}</I>: <B>{}</B><BR ALIGN="LEFT" />:: {}>'
+            label_fmt = '<<I>{}</I>: <B>{}</B><BR ALIGN="LEFT" />:: {}'
         # typename is already escaped
         label = label_fmt.format(escape(nodename), escape(name), typename)
     else:
         if isinstance(node, ops.Relation):
-            label_fmt = "<<B>{}</B>{}>"
+            label_fmt = "<<B>{}</B>{}"
         else:
-            label_fmt = '<<B>{}</B><BR ALIGN="LEFT" />:: {}>'
+            label_fmt = '<<B>{}</B><BR ALIGN="LEFT" />:: {}'
         label = label_fmt.format(escape(name), typename)
-    return label
+    return f'{label}<BR ALIGN="LEFT" />>'
 
 
 DEFAULT_NODE_ATTRS = {"shape": "box", "fontname": "Deja Vu Sans Mono"}


### PR DESCRIPTION
## Description of changes

Make sure the last lines of multi-line labels are left-justified (not centered) by adding a trailing left-aligned break.

Solution: https://stackoverflow.com/q/49568399

### Before

![image](https://github.com/user-attachments/assets/fa7b9cf1-7953-4c9d-82bb-60a68d144022)

### After

![image](https://github.com/user-attachments/assets/eb3ef550-3432-44e2-b1c5-421fc096607e)
