### PR TITLE
fix(interactive-repr): ensure that null scalars can be repr'd interactively

### DIFF
--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2895,7 +2895,7 @@ def null(type: dt.DataType | str | None = None, /) -> Value:
     AttributeError: 'NullScalar' object has no attribute 'upper'
     >>> ibis.null(str).upper()
     ┌──────┐
-    │ None │
+    │ NULL │
     └──────┘
     >>> ibis.null(str).upper().isnull()
     ┌──────┐

--- a/ibis/expr/types/pretty.py
+++ b/ibis/expr/types/pretty.py
@@ -294,14 +294,20 @@ def _to_rich_scalar(
     max_string: int | None = None,
     max_depth: int | None = None,
 ) -> Pretty:
-    value = format_values(
-        expr.type(),
-        [expr.to_pyarrow().as_py()],
-        max_length=max_length or ibis.options.repr.interactive.max_length,
-        max_string=max_string or ibis.options.repr.interactive.max_string,
-        max_depth=max_depth or ibis.options.repr.interactive.max_depth,
-    )[0]
-    return Panel(value, expand=False, box=box.SQUARE)
+    value = expr.to_pyarrow().as_py()
+
+    if value is None:
+        formatted_value = Text.styled("NULL", style="dim")
+    else:
+        (formatted_value,) = format_values(
+            expr.type(),
+            [value],
+            max_length=max_length or ibis.options.repr.interactive.max_length,
+            max_string=max_string or ibis.options.repr.interactive.max_string,
+            max_depth=max_depth or ibis.options.repr.interactive.max_depth,
+        )
+
+    return Panel(formatted_value, expand=False, box=box.SQUARE)
 
 
 def _to_rich_table(

--- a/ibis/tests/strategies.py
+++ b/ibis/tests/strategies.py
@@ -128,7 +128,7 @@ def interval_dtype(interval=_interval, nullable=_nullable):
     return st.builds(dt.Interval, unit=interval, nullable=nullable)
 
 
-def temporal_dtypes(timezone=_timezone, interval=_interval, nullable=_nullable):
+def temporal_dtypes(timezone=_timezone, nullable=_nullable):
     return st.one_of(
         date_dtype(nullable=nullable),
         time_dtype(nullable=nullable),
@@ -136,15 +136,17 @@ def temporal_dtypes(timezone=_timezone, interval=_interval, nullable=_nullable):
     )
 
 
-def primitive_dtypes(nullable=_nullable):
-    return st.one_of(
-        null_dtype,
-        boolean_dtype(nullable=nullable),
-        integer_dtypes(nullable=nullable),
-        floating_dtypes(nullable=nullable),
-        date_dtype(nullable=nullable),
-        time_dtype(nullable=nullable),
+def primitive_dtypes(nullable=_nullable, include_null=True):
+    primitive = (
+        boolean_dtype(nullable=nullable)
+        | integer_dtypes(nullable=nullable)
+        | floating_dtypes(nullable=nullable)
+        | date_dtype(nullable=nullable)
+        | time_dtype(nullable=nullable)
     )
+    if include_null:
+        primitive |= null_dtype
+    return primitive
 
 
 _item_strategy = primitive_dtypes()
@@ -174,7 +176,7 @@ def struct_dtypes(
     nullable=_nullable,
 ):
     num_fields = draw(num_fields)
-    names = draw(st.lists(names, min_size=num_fields, max_size=num_fields))
+    names = draw(st.lists(names, min_size=num_fields, max_size=num_fields, unique=True))
     types = draw(st.lists(types, min_size=num_fields, max_size=num_fields))
     fields = dict(zip(names, types))
     return dt.Struct(fields, nullable=draw(nullable))


### PR DESCRIPTION
Fixes #10780.