### PR TITLE
refactor(api)!: make `as_timestamp` and `as_interval` positional-only

### DIFF
--- a/ibis/backends/bigquery/tests/unit/test_compiler.py
+++ b/ibis/backends/bigquery/tests/unit/test_compiler.py
@@ -111,7 +111,7 @@ def test_hashbytes(case, how, dtype, snapshot):
     ),
 )
 def test_integer_to_timestamp(case, unit, snapshot):
-    expr = ibis.literal(case, type=dt.int64).as_timestamp(unit=unit).name("tmp")
+    expr = ibis.literal(case, type=dt.int64).as_timestamp(unit).name("tmp")
     snapshot.assert_match(to_sql(expr), "out.sql")
 
 

--- a/ibis/backends/druid/tests/conftest.py
+++ b/ibis/backends/druid/tests/conftest.py
@@ -115,7 +115,7 @@ class TestConf(ServiceBackendTest):
             # tool that calls itself a time series database or "good for
             # working with time series", that lacks a first-class timestamp
             # type.
-            timestamp_col=t.timestamp_col.as_timestamp(unit="ms"),
+            timestamp_col=t.timestamp_col.as_timestamp("ms"),
         )
 
     @property

--- a/ibis/backends/flink/tests/test_compiler.py
+++ b/ibis/backends/flink/tests/test_compiler.py
@@ -22,7 +22,7 @@ def test_count_star(simple_table, assert_sql):
     ],
 )
 def test_timestamp_from_unix(simple_table, unit, assert_sql):
-    expr = simple_table.d.as_timestamp(unit=unit)
+    expr = simple_table.d.as_timestamp(unit)
     assert_sql(expr)
 
 

--- a/ibis/backends/tests/test_temporal.py
+++ b/ibis/backends/tests/test_temporal.py
@@ -556,7 +556,7 @@ def test_date_truncate(backend, alltypes, df, unit):
 def test_integer_to_interval_timestamp(
     backend, con, alltypes, df, unit, displacement_type
 ):
-    interval = alltypes.int_col.as_interval(unit=unit)
+    interval = alltypes.int_col.as_interval(unit)
     expr = (alltypes.timestamp_col + interval).name("tmp")
 
     def convert_to_offset(offset, displacement_type=displacement_type):
@@ -629,7 +629,7 @@ def test_integer_to_interval_timestamp(
 @pytest.mark.notimpl(["datafusion", "druid"], raises=com.OperationNotDefinedError)
 @pytest.mark.notimpl(["exasol"], raises=com.OperationNotDefinedError)
 def test_integer_to_interval_date(backend, con, alltypes, df, unit):
-    interval = alltypes.int_col.as_interval(unit=unit)
+    interval = alltypes.int_col.as_interval(unit)
     month = alltypes.date_string_col[:2]
     day = alltypes.date_string_col[3:5]
     year = alltypes.date_string_col[6:8]

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -1420,10 +1420,7 @@ class NumericColumn(Column, NumericValue):
 
 @public
 class IntegerValue(NumericValue):
-    def as_timestamp(
-        self,
-        unit: Literal["s", "ms", "us"],
-    ) -> ir.TimestampValue:
+    def as_timestamp(self, unit: Literal["s", "ms", "us"], /) -> ir.TimestampValue:
         """Convert an integral UNIX timestamp to a timestamp expression.
 
         Parameters
@@ -1440,11 +1437,7 @@ class IntegerValue(NumericValue):
         --------
         >>> import ibis
         >>> ibis.options.interactive = True
-        >>> t = ibis.memtable(
-        ...     {
-        ...         "int_col": [0, 1730501716, 2147483647],
-        ...     }
-        ... )
+        >>> t = ibis.memtable({"int_col": [0, 1730501716, 2147483647]})
         >>> t.int_col.as_timestamp("s")
         ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
         ┃ TimestampFromUNIX(int_col, SECOND) ┃
@@ -1513,12 +1506,13 @@ class IntegerValue(NumericValue):
         """
         return ops.IntervalFromInteger(self, unit).to_expr()
 
-    @deprecated(as_of="10.0", removed_in="11.0", instead="use as_timestamp() instead")
+    @deprecated(
+        as_of="10.0", removed_in="11.0", instead="use as_timestamp(unit) instead"
+    )
     def to_timestamp(
-        self,
-        unit: Literal["s", "ms", "us"] = "s",
+        self, unit: Literal["s", "ms", "us"] = "s", /
     ) -> ir.TimestampValue:
-        return self.as_timestamp(unit=unit)
+        return self.as_timestamp(unit)
 
     @deprecated(as_of="10.0", removed_in="11.0", instead="use as_interval() instead")
     def to_interval(

--- a/ibis/expr/types/numeric.py
+++ b/ibis/expr/types/numeric.py
@@ -1454,6 +1454,7 @@ class IntegerValue(NumericValue):
     def as_interval(
         self,
         unit: Literal["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns"] = "s",
+        /,
     ) -> ir.IntervalValue:
         """Convert an integer to an interval.
 
@@ -1518,8 +1519,9 @@ class IntegerValue(NumericValue):
     def to_interval(
         self,
         unit: Literal["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "ns"] = "s",
+        /,
     ) -> ir.IntervalValue:
-        return self.as_interval(unit=unit)
+        return self.as_interval(unit)
 
     def convert_base(
         self,

--- a/ibis/tests/expr/test_temporal.py
+++ b/ibis/tests/expr/test_temporal.py
@@ -641,10 +641,10 @@ def test_integer_to_interval(column, unit, table):
 @pytest.mark.parametrize(
     "operands",
     [
-        lambda t, u: (api.interval(3, unit=u), api.interval(2, unit=u)),
-        lambda t, u: (api.interval(3, unit=u), api.interval(3, unit=u)),
-        lambda t, u: (t.c.as_interval(unit=u), api.interval(2, unit=u)),
-        lambda t, u: (t.c.as_interval(unit=u), t.d.as_interval(unit=u)),
+        lambda _, u: (api.interval(3, unit=u), api.interval(2, unit=u)),
+        lambda _, u: (api.interval(3, unit=u), api.interval(3, unit=u)),
+        lambda t, u: (t.c.as_interval(u), api.interval(2, unit=u)),
+        lambda t, u: (t.c.as_interval(u), t.d.as_interval(u)),
     ],
 )
 @pytest.mark.parametrize(
@@ -688,15 +688,15 @@ def test_interval_comparisons(unit, operands, operator, table):
 @pytest.mark.parametrize(
     "interval",
     [
-        lambda t: api.interval(years=4),
-        lambda t: api.interval(quarters=4),
-        lambda t: api.interval(months=3),
-        lambda t: api.interval(weeks=2),
-        lambda t: api.interval(days=1),
-        lambda t: t.c.as_interval(unit="Y"),
-        lambda t: t.c.as_interval(unit="M"),
-        lambda t: t.c.as_interval(unit="W"),
-        lambda t: t.c.as_interval(unit="D"),
+        lambda _: api.interval(years=4),
+        lambda _: api.interval(quarters=4),
+        lambda _: api.interval(months=3),
+        lambda _: api.interval(weeks=2),
+        lambda _: api.interval(days=1),
+        lambda t: t.c.as_interval("Y"),
+        lambda t: t.c.as_interval("M"),
+        lambda t: t.c.as_interval("W"),
+        lambda t: t.c.as_interval("D"),
     ],
     ids=[
         "years",


### PR DESCRIPTION
The final pre-10.0 API changes: change `as_timestamp` and `as_interval` to be positional-only.