### PR TITLE
fix(snowflake): use `as_posix` instead of `as_uri` to avoid escaping special characters

### DIFF
--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -149,7 +149,7 @@ class Backend(SQLBackend, CanCreateDatabase):
         Examples
         --------
         >>> import ibis
-        >>> client = ibis.clickhouse.connect()
+        >>> client = ibis.clickhouse.connect(user="ibis")
         >>> client
         <ibis.backends.clickhouse.Backend object at 0x...>
         """

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -137,11 +137,6 @@ return count !== 0 ? true : null;""",
 }
 
 
-def as_uri(path: str | Path) -> str:
-    """Convert a path to a file URI."""
-    return Path(path).absolute().as_uri()
-
-
 class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase):
     name = "snowflake"
     compiler = sc.snowflake.compiler
@@ -926,10 +921,12 @@ $$ {defn["source"]} $$"""
                     urlretrieve(path, filename=tmpname)  # noqa: S310
                     tmp.flush()
                     cur.execute(
-                        f"PUT '{as_uri(tmpname)}' @{stage} PARALLEL = {threads:d}"
+                        f"PUT 'file://{Path(tmpname).absolute().as_posix()}' @{stage} PARALLEL = {threads:d}"
                     )
             else:
-                cur.execute(f"PUT '{as_uri(path)}' @{stage} PARALLEL = {threads:d}")
+                cur.execute(
+                    f"PUT 'file://{Path(path).absolute().as_posix()}' @{stage} PARALLEL = {threads:d}"
+                )
 
             # handle setting up the schema in python because snowflake is
             # broken for csv globs: it cannot parse the result of the following
@@ -1055,7 +1052,7 @@ $$ {defn["source"]} $$"""
         )
         with self._safe_raw_sql(";\n".join(stmts)) as cur:
             cur.execute(
-                f"PUT 'file://{Path(path).absolute()}' @{stage} PARALLEL = {threads:d}"
+                f"PUT 'file://{Path(path).absolute().as_posix()}' @{stage} PARALLEL = {threads:d}"
             )
             cur.execute(
                 ";\n".join(
@@ -1104,7 +1101,7 @@ $$ {defn["source"]} $$"""
 
         from ibis.formats.pyarrow import PyArrowSchema
 
-        abspath = Path(path).absolute()
+        abspath = Path(path).absolute().as_posix()
         schema = PyArrowSchema.to_ibis(
             ds.dataset(glob.glob(str(abspath)), format="parquet").schema
         )


### PR DESCRIPTION
Fixes failing Snowflake CI