### PR TITLE
fix(mssql): ensure that we only escape passwords if the password is not `None`

### DIFF
--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -173,10 +173,13 @@ class Backend(SQLBackend, CanCreateCatalog, CanCreateDatabase):
             # connection string and use it as a database
             kwargs["database"] = database
 
+        if password is not None:
+            password = self._escape_special_characters(password)
+
         self.con = pyodbc.connect(
             user=user,
             server=f"{host},{port}",
-            password=self._escape_special_characters(password),
+            password=password,
             driver=driver,
             **kwargs,
         )

--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -319,3 +319,17 @@ def test_non_ascii_column_name(con):
     names = schema.names
     assert len(names) == 1
     assert names[0] == "калона"
+
+
+def test_mssql_without_password_is_valid():
+    with pytest.raises(
+        PyODBCProgrammingError, match=f"Login failed for user '{MSSQL_USER}'"
+    ):
+        ibis.mssql.connect(
+            user=MSSQL_USER,
+            host=MSSQL_HOST,
+            password=None,
+            port=MSSQL_PORT,
+            database=IBIS_TEST_MSSQL_DB,
+            driver=MSSQL_PYODBC_DRIVER,
+        )


### PR DESCRIPTION
Closes #10818.