### PR TITLE
docs: fix reference to incorrect value

### DIFF
--- a/docs/tutorials/ibis-for-pandas-users.qmd
+++ b/docs/tutorials/ibis-for-pandas-users.qmd
@@ -311,8 +311,8 @@ We can evaluate the value counts to see how many rows we will expect to get back
 expr.value_counts()
 ```
 
-Now we apply the filter to the table. Since there are 6 True values in the expression, we should
-get 6 rows back.
+Now we apply the filter to the table. Since there are 300 True values in the expression, we should
+get 300 rows back.
 
 
 ```{python}


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

This is a very minor update. In the [Pandas Tutorial](https://ibis-project.org/tutorials/ibis-for-pandas-users#filtering-rows), there's a reference to an expected "6" True rows that should be "300" True rows, based on the screenshots and executing the code:
<img width="772" alt="image" src="https://github.com/user-attachments/assets/dc3c3ab3-1d9f-4deb-83c7-3691deab70fd" />
 
