### PR TITLE
fix(duckdb): use the `delta` extension for reading deltalake data

### DIFF
--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -12,7 +12,6 @@ import ibis.expr.datatypes as dt
 from ibis import util
 from ibis.backends.tests.errors import (
     DatabricksServerOperationError,
-    DuckDBInvalidInputException,
     DuckDBNotImplementedException,
     DuckDBParserException,
     ExaQueryError,
@@ -475,11 +474,6 @@ def test_to_pyarrow_decimal(backend, dtype, pyarrow_dtype):
     pyspark=["pyspark<4"],
     condition=CI and IS_SPARK_REMOTE,
     reason="not supported until pyspark 4",
-)
-@pytest.mark.xfail_version(
-    duckdb=["pyarrow>=19"],
-    raises=DuckDBInvalidInputException,
-    reason="decoding delta file fails",
 )
 @pytest.mark.xfail_version(
     datafusion=["pyarrow>=19", "datafusion>=44"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ druid = [
   "rich>=12.4.4,<14",
 ]
 duckdb = [
-  "duckdb>=0.10,<2",
+  "duckdb>=0.10.3,<2",
   "pyarrow>=10.0.1",
   "pyarrow-hotfix>=0.4,<1",
   "numpy>=1.23.2,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -2270,7 +2270,7 @@ requires-dist = [
     { name = "datafusion", marker = "extra == 'datafusion'", specifier = ">=0.6,<45" },
     { name = "db-dtypes", marker = "extra == 'bigquery'", specifier = ">=0.3,<2" },
     { name = "deltalake", marker = "extra == 'deltalake'", specifier = ">=0.9.0,<1" },
-    { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.10,<2" },
+    { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.10.3,<2" },
     { name = "fsspec", extras = ["s3"], marker = "extra == 'athena'" },
     { name = "geoarrow-types", marker = "extra == 'geospatial'", specifier = ">=0.2,<1" },
     { name = "geopandas", marker = "extra == 'geospatial'", specifier = ">=0.6,<2" },


### PR DESCRIPTION
Switch to use the DuckDB `delta` extension for reading deltalake data.

Closes #10829.