### PR TITLE
refactor(duckdb): remove the pyarrow `read_parquet` fallback

### DIFF
--- a/conda/environment-arm64-flink.yml
+++ b/conda/environment-arm64-flink.yml
@@ -59,7 +59,6 @@ dependencies:
   - pytest-benchmark >=3.4.1,<5
   - pytest-clarity >=1.0.1,<2
   - pytest-cov >=3.0.0,<5
-  - pytest-httpserver >=1.0.5,<2
   - pytest-mock >=3.6.1,<4
   - pytest-randomly >=3.10.1,<4
   - pytest-repeat >=0.9.1,<0.10

--- a/conda/environment-arm64.yml
+++ b/conda/environment-arm64.yml
@@ -58,7 +58,6 @@ dependencies:
   - pytest-benchmark >=3.4.1,<5
   - pytest-clarity >=1.0.1,<2
   - pytest-cov >=3.0.0,<5
-  - pytest-httpserver >=1.0.5,<2
   - pytest-mock >=3.6.1,<4
   - pytest-randomly >=3.10.1,<4
   - pytest-repeat >=0.9.1,<0.10

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -61,7 +61,6 @@ dependencies:
   - pytest-benchmark >=3.4.1,<5
   - pytest-clarity >=1.0.1,<2
   - pytest-cov >=3.0.0,<5
-  - pytest-httpserver >=1.0.5,<2
   - pytest-mock >=3.6.1,<4
   - pytest-randomly >=3.10.1,<4
   - pytest-repeat >=0.9.1,<0.10

--- a/docs/backends/duckdb.qmd
+++ b/docs/backends/duckdb.qmd
@@ -117,6 +117,26 @@ Given an empty path, `ibis.connect` will connect to an ephemeral, in-memory data
 con = ibis.connect("duckdb://")
 ```
 
+## Cloud bucket reads
+
+DuckDB has [a secret management
+system](https://duckdb.org/docs/configuration/secrets_manager.html) that is
+designed to support reading data from both public and private cloud blob
+storage systems like Amazon's S3.
+
+To make your life easier, you should probably start with the `CREDENTIAL_CHAIN`
+provider, which mimics the default behavior of the `aws` CLI and SDKs.
+
+Ibis doesn't have an Ibis-native API for dealing with DuckDB's secrets, but you can of course
+run `raw_sql` to set them up:
+
+```{python}
+con.raw_sql("CREATE SECRET s3 (TYPE S3, PROVIDER CREDENTIAL_CHAIN)")
+```
+
+Assuming you've got the appropriate authorizations in AWS, this should allow
+DuckDB to read from any bucket you're authorized to access.
+
 ## MotherDuck
 
 The DuckDB backend supports [MotherDuck](https://motherduck.com). If you have an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,6 @@ tests = [
   "pytest-deadfixtures>=2.2.1,<3",
   "pytest-clarity>=1.0.1,<2",
   "pytest-cov>=5,<7",
-  "pytest-httpserver>=1.0.5,<2",
   "pytest-mock>=3.6.1,<4",
   "pytest-randomly>=3.10.1,<4",
   "pytest-repeat>=0.9.1,<0.10",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -212,7 +212,6 @@ pytest-benchmark==5.1.0
 pytest-clarity==1.0.1
 pytest-cov==6.0.0
 pytest-deadfixtures==2.2.1
-pytest-httpserver==1.1.1
 pytest-mock==3.14.0
 pytest-randomly==3.16.0
 pytest-repeat==0.9.3
@@ -281,7 +280,6 @@ wcwidth==0.2.13
 webcolors==24.11.1
 webencodings==0.5.1
 websocket-client==1.8.0
-werkzeug==3.1.3
 widgetsnbextension==4.0.13
 wrapt==1.17.2
 xxhash==3.5.0

--- a/uv.lock
+++ b/uv.lock
@@ -2251,7 +2251,6 @@ tests = [
     { name = "pytest-clarity" },
     { name = "pytest-cov" },
     { name = "pytest-deadfixtures" },
-    { name = "pytest-httpserver" },
     { name = "pytest-mock" },
     { name = "pytest-randomly" },
     { name = "pytest-repeat" },
@@ -2455,7 +2454,6 @@ tests = [
     { name = "pytest-clarity", specifier = ">=1.0.1,<2" },
     { name = "pytest-cov", specifier = ">=5,<7" },
     { name = "pytest-deadfixtures", specifier = ">=2.2.1,<3" },
-    { name = "pytest-httpserver", specifier = ">=1.0.5,<2" },
     { name = "pytest-mock", specifier = ">=3.6.1,<4" },
     { name = "pytest-randomly", specifier = ">=3.10.1,<4" },
     { name = "pytest-repeat", specifier = ">=0.9.1,<0.10" },
@@ -4685,18 +4683,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-httpserver"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/8a/98d9f2dc6a7f486bc3467935db766255509ffd47efc6b47bd2231b2bf009/pytest_httpserver-1.1.1.tar.gz", hash = "sha256:e5c46c62c0aa65e5d4331228cb2cb7db846c36e429c3e74ca806f284806bf7c6", size = 68190 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/52/b9148e455166fba9bc2f6a5293d7d01e305155231d9863f10cb4e968c4fb/pytest_httpserver-1.1.1-py3-none-any.whl", hash = "sha256:aadc744bfac773a2ea93d05c2ef51fa23c087e3cc5dace3ea9d45cdd4bfe1fe8", size = 20723 },
-]
-
-[[package]]
 name = "pytest-mock"
 version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5951,18 +5937,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826 },
-]
-
-[[package]]
-name = "werkzeug"
-version = "3.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498 },
 ]
 
 [[package]]


### PR DESCRIPTION
Remove DuckDB fallback for reading from S3 using PyArrow. After this PR, users may need to use the DuckDB secret management mechanism to read from S3.