### PR TITLE
docs(blog): use more reliable URL for geospatial data

### DIFF
--- a/docs/posts/ibis-duckdb-geospatial/index.qmd
+++ b/docs/posts/ibis-duckdb-geospatial/index.qmd
@@ -38,21 +38,9 @@ subway stations, streets, neighborhood, census data and, homicides. The datasets
 18N projection, EPSG:26918.
 
 ```{python}
-from pathlib import Path
-from zipfile import ZipFile
 from urllib.request import urlretrieve
 
-# Download and unzip
-url = "https://open.gishub.org/data/duckdb/nyc_data.db.zip"
-zip_path = Path("nyc_data.db.zip")
-db_path = Path("nyc_data.db")
-
-if not zip_path.exists():
-    urlretrieve(url, zip_path)
-
-if not db_path.exists():
-    with ZipFile(zip_path) as zip_file:
-        zip_file.extract("nyc_data.db")
+path, _ = urlretrieve("https://storage.googleapis.com/ibis-blog-data-public/nyc_data.ddb")
 ```
 
 ## Let's get started
@@ -65,7 +53,7 @@ from ibis import _
 
 ibis.options.interactive = True
 
-con = ibis.duckdb.connect("nyc_data.db")
+con = ibis.duckdb.connect(path)
 con.list_tables()
 ```
 


### PR DESCRIPTION
Apparently the original URL that served the DuckDB database no longer exists.
This changes the geospatial blog to use upstream data from the postgis website, which
I then used to create a new duckdb database that I then uploaded to our ibis-blog-data-public
GCS bucket.
