### PR TITLE
docs: move __getitem__ docs so that quarto publishes them

### DIFF
--- a/ibis/expr/types/json.py
+++ b/ibis/expr/types/json.py
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
 
 @public
 class JSONValue(Value):
-    """
+    """A json-like collection with dynamic keys and values.
+    
     Examples
     --------
     Construct a table with a JSON column
@@ -84,6 +85,7 @@ class JSONValue(Value):
     │ NULL                │
     └─────────────────────┘
     """
+
     def __getitem__(
         self, key: str | int | ir.StringValue | ir.IntegerValue
     ) -> JSONValue:

--- a/ibis/expr/types/json.py
+++ b/ibis/expr/types/json.py
@@ -17,6 +17,73 @@ if TYPE_CHECKING:
 
 @public
 class JSONValue(Value):
+    """
+    Examples
+    --------
+    Construct a table with a JSON column
+
+    >>> import json, ibis
+    >>> ibis.options.interactive = True
+    >>> rows = [{"js": json.dumps({"a": [i, 1]})} for i in range(2)]
+    >>> t = ibis.memtable(rows, schema=ibis.schema(dict(js="json")))
+    >>> t
+    ┏━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ js                   ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━┩
+    │ json                 │
+    ├──────────────────────┤
+    │ {'a': [...]}         │
+    │ {'a': [...]}         │
+    └──────────────────────┘
+
+    Extract the `"a"` field
+
+    >>> t.js["a"]
+    ┏━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ JSONGetItem(js, 'a') ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━┩
+    │ json                 │
+    ├──────────────────────┤
+    │ [0, 1]               │
+    │ [1, 1]               │
+    └──────────────────────┘
+
+    Extract the first element of the JSON array at `"a"`
+
+    >>> t.js["a"][0]
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ JSONGetItem(JSONGetItem(js, 'a'), 0) ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │ json                                 │
+    ├──────────────────────────────────────┤
+    │ 0                                    │
+    │ 1                                    │
+    └──────────────────────────────────────┘
+
+    Extract a non-existent field
+
+    >>> t.js["a"]["foo"]
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ JSONGetItem(JSONGetItem(js, 'a'), 'foo') ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │ json                                     │
+    ├──────────────────────────────────────────┤
+    │ NULL                                     │
+    │ NULL                                     │
+    └──────────────────────────────────────────┘
+
+    Try to extract an array element, returns `NULL`
+
+    >>> t.js[20]
+    ┏━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ JSONGetItem(js, 20) ┃
+    ┡━━━━━━━━━━━━━━━━━━━━━┩
+    │ json                │
+    ├─────────────────────┤
+    │ NULL                │
+    │ NULL                │
+    └─────────────────────┘
+    """
     def __getitem__(
         self, key: str | int | ir.StringValue | ir.IntegerValue
     ) -> JSONValue:
@@ -31,72 +98,6 @@ class JSONValue(Value):
         -------
         JSONValue
             Element located at `key`
-
-        Examples
-        --------
-        Construct a table with a JSON column
-
-        >>> import json, ibis
-        >>> ibis.options.interactive = True
-        >>> rows = [{"js": json.dumps({"a": [i, 1]})} for i in range(2)]
-        >>> t = ibis.memtable(rows, schema=ibis.schema(dict(js="json")))
-        >>> t
-        ┏━━━━━━━━━━━━━━━━━━━━━━┓
-        ┃ js                   ┃
-        ┡━━━━━━━━━━━━━━━━━━━━━━┩
-        │ json                 │
-        ├──────────────────────┤
-        │ {'a': [...]}         │
-        │ {'a': [...]}         │
-        └──────────────────────┘
-
-        Extract the `"a"` field
-
-        >>> t.js["a"]
-        ┏━━━━━━━━━━━━━━━━━━━━━━┓
-        ┃ JSONGetItem(js, 'a') ┃
-        ┡━━━━━━━━━━━━━━━━━━━━━━┩
-        │ json                 │
-        ├──────────────────────┤
-        │ [0, 1]               │
-        │ [1, 1]               │
-        └──────────────────────┘
-
-        Extract the first element of the JSON array at `"a"`
-
-        >>> t.js["a"][0]
-        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-        ┃ JSONGetItem(JSONGetItem(js, 'a'), 0) ┃
-        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-        │ json                                 │
-        ├──────────────────────────────────────┤
-        │ 0                                    │
-        │ 1                                    │
-        └──────────────────────────────────────┘
-
-        Extract a non-existent field
-
-        >>> t.js["a"]["foo"]
-        ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-        ┃ JSONGetItem(JSONGetItem(js, 'a'), 'foo') ┃
-        ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-        │ json                                     │
-        ├──────────────────────────────────────────┤
-        │ NULL                                     │
-        │ NULL                                     │
-        └──────────────────────────────────────────┘
-
-        Try to extract an array element, returns `NULL`
-
-        >>> t.js[20]
-        ┏━━━━━━━━━━━━━━━━━━━━━┓
-        ┃ JSONGetItem(js, 20) ┃
-        ┡━━━━━━━━━━━━━━━━━━━━━┩
-        │ json                │
-        ├─────────────────────┤
-        │ NULL                │
-        │ NULL                │
-        └─────────────────────┘
         """
         return ops.JSONGetItem(self, key).to_expr()
 

--- a/ibis/expr/types/json.py
+++ b/ibis/expr/types/json.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 @public
 class JSONValue(Value):
     """A json-like collection with dynamic keys and values.
-    
+
     Examples
     --------
     Construct a table with a JSON column


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes
The Examples section of JSONValue.__getitem__ is not published by Quartodoc because it does not publish private methods. They are great examples that help understand how to use JSON columns. Moving them to the class docstring should ensure that they are also published to the docs.
<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->


## Issues closed
The issue in which I mentioned this is already closed, the part solved by this PR is mentioned in this message:
https://github.com/ibis-project/ibis/issues/10721#issuecomment-2624174148
<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
