### PR TITLE
fix(bigquery): allow sane use of `params` with `raw_sql`

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -663,15 +663,7 @@ class Backend(SQLBackend, CanCreateDatabase):
 
     def raw_sql(self, query: str, params=None, page_size: int | None = None):
         query_parameters = [
-            bigquery_param(
-                param.type(),
-                value,
-                (
-                    param.get_name()
-                    if not isinstance(op := param.op(), ops.Alias)
-                    else op.arg.name
-                ),
-            )
+            bigquery_param(param.type(), value, param.get_name())
             for param, value in (params or {}).items()
         ]
         with contextlib.suppress(AttributeError):

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -496,3 +496,12 @@ def test_geom_from_pyarrow(con, monkeypatch):
         assert len(t.to_pandas()) == 2
     finally:
         con.drop_table(name)
+
+
+def test_raw_sql_params_with_alias(con):
+    name = "cutoff"
+    cutoff = ibis.param("date").name(name)
+    value = datetime.date(2024, 10, 28)
+    query_parameters = {cutoff: value}
+    result = con.raw_sql(f"SELECT @{name} AS {name}", params=query_parameters)
+    assert list(map(dict, result)) == [{name: value}]


### PR DESCRIPTION
Closes #10861. The alias munging is no longer needed, so passing `params` to BigQuery `raw_sql` gets more convenient after this PR.