### PR TITLE
fix(dev-tools): ensure that bump is minimal so that later release sort properly

### DIFF
--- a/ci/release/bump_version.py
+++ b/ci/release/bump_version.py
@@ -6,7 +6,7 @@ def main():
 
     version = Version.from_git(latest_tag=True, pattern="default-unprefixed")
     if version.distance:
-        version = version.bump(index=0)
+        version = version.bump(index=-1)
         format = "{base}.dev{distance}"
     else:
         format = None


### PR DESCRIPTION
This fixes an issue with `bump_version.py` where we were originally bumping to major, but that results in an incorrect ordering when the next release after a pre-release is not a major release. 

For example,

Let's say the current version is 10.0.0, and the next release will be 10.1.0--a feature release. If the **pre**-release is published as 11.0.0.devNNN then the 10.1.0 release will sort before the pre-release, which is incorrect.

The solution is to always bump the pre-release by only its minor version.