### PR TITLE
feat(api): support named filtering on fields in Table.filter()

### DIFF
--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1502,6 +1502,20 @@ def test_filter(table):
     expected = m.filter([m.foo > 10, m.bar < 0])
     assert_equal(result, expected)
 
+    result = m.filter(
+        m.e == 5,
+        foo=10,
+        bar=_ < 0,
+        b=lambda col: col.notnull(),
+    )
+    expected = m.filter(
+        m.e == 5,
+        m.foo == 10,
+        m.bar < 0,
+        m.b.notnull(),
+    )
+    assert_equal(result, expected)
+
 
 def test_order_by2(table):
     m = table.mutate(foo=table.e + table.f)


### PR DESCRIPTION
This is a very rough prototype of an idea I have. I wanted to post it to see if you think it is worth pursuing. Should I add some more tests and fixup the docstrings, or is this not a direction we want to head?

For equality conditions (which are fairly common for me) it allows me to not have to import Deferred. Before I could either do `t.filter(_.x == 5)` (requires importing _), or `t.filter(t.x == 5)` which forces me to hardcode the variable name in multiple places, which I like to avoid doing. After this change, I can express this as `t.filter(x=5)`

The big reason I could see for not doing this is it forever closes the door for us to add other kwarg parameters to .filter() in the future. IDK how likely we think that is.