### PR TITLE
feat(join): support Deferreds as conditions to join()

### DIFF
--- a/ibis/expr/types/joins.py
+++ b/ibis/expr/types/joins.py
@@ -7,7 +7,6 @@ from public import public
 
 import ibis.expr.operations as ops
 from ibis import util
-from ibis.common.deferred import Deferred
 from ibis.common.egraph import DisjointSet
 from ibis.common.exceptions import (
     ExpressionError,
@@ -168,7 +167,7 @@ def prepare_predicates(
 
     left, right = chain.to_expr(), right.to_expr()
     for pred in util.promote_list(predicates):
-        if isinstance(pred, (Value, Deferred, bool)):
+        if isinstance(pred, (Value, bool)):
             for bound in bind(left, pred):
                 yield deref_both.dereference(bound.op())
         else:

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -904,12 +904,10 @@ def test_join_no_predicate_list(con):
         assert joined.op() == expected
 
 
-def test_join_deferred(con):
+def test_join_deferred_in_2tuple(con):
     region = con.table("tpch_region")
     nation = con.table("tpch_nation")
-
-    res = region.join(nation, _.r_regionkey == nation.n_regionkey)
-
+    res = region.join(nation, [(_.r_regionkey, nation.n_regionkey)])
     with join_tables(res) as (r1, r2):
         expected = ops.JoinChain(
             first=r1,
@@ -921,6 +919,61 @@ def test_join_deferred(con):
                 "n_nationkey": r2.n_nationkey,
                 "n_name": r2.n_name,
                 "n_regionkey": r2.n_regionkey,
+                "n_comment": r2.n_comment,
+            },
+        )
+        assert res.op() == expected
+
+
+def test_join_deferred_left(con):
+    region = con.table("tpch_region")
+    nation = con.table("tpch_nation")
+    with pytest.raises(AttributeError, match="r_regionkey"):
+        region.join(nation, _.r_regionkey == nation.n_regionkey)
+
+
+def test_join_deferred_both_simple(con):
+    region = con.table("tpch_region").rename(regionkey="r_regionkey")
+    nation = con.table("tpch_nation").rename(regionkey="n_regionkey")
+
+    res = region.join(nation, _.regionkey)
+    with join_tables(res) as (r1, r2):
+        expected = ops.JoinChain(
+            first=r1,
+            rest=[ops.JoinLink("inner", r2, [r1.regionkey == r2.regionkey])],
+            values={
+                "regionkey": r1.regionkey,
+                "r_name": r1.r_name,
+                "r_comment": r1.r_comment,
+                "n_nationkey": r2.n_nationkey,
+                "n_name": r2.n_name,
+                # Since this is simple equlity, there is only a single "regionkey"
+                # in the output.
+                "n_comment": r2.n_comment,
+            },
+        )
+        assert res.op() == expected
+
+
+def test_join_deferred_both_complex(con):
+    region = con.table("tpch_region").rename(regionkey="r_regionkey")
+    nation = con.table("tpch_nation").rename(regionkey="n_regionkey")
+    res = region.join(nation, _.regionkey.abs())
+    with join_tables(res) as (r1, r2):
+        expected = ops.JoinChain(
+            first=r1,
+            rest=[
+                ops.JoinLink("inner", r2, [r1.regionkey.abs() == r2.regionkey.abs()])
+            ],
+            values={
+                "regionkey": r1.regionkey,
+                "r_name": r1.r_name,
+                "r_comment": r1.r_comment,
+                "n_nationkey": r2.n_nationkey,
+                "n_name": r2.n_name,
+                "regionkey_right": r2.regionkey,
+                # since the join key is an expression, we have to keep both
+                # regionkey columns
                 "n_comment": r2.n_comment,
             },
         )


### PR DESCRIPTION
A fresh attempt at solving https://github.com/ibis-project/ibis/issues/10703.

So far, I only added support for Deferreds. Still working to support `lambda left, right: ...`.