### PR TITLE
docs: correct link to blog post in selectors file

### DIFF
--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -1,7 +1,7 @@
 """Convenient column selectors.
 
 ::: {.callout-tip}
-## Check out the [blog post on selectors](../posts/selectors) for examples!
+## Check out the [blog post on selectors](https://ibis-project.org/posts/selectors/) for examples!
 :::
 
 ## Rationale


### PR DESCRIPTION
Fix the link to the blog post about selectors