### PR TITLE
perf: disallow __dunder__ attributes on Deferred

### DIFF
--- a/ibis/common/deferred.py
+++ b/ibis/common/deferred.py
@@ -94,6 +94,8 @@ class Deferred(Slotted, Immutable, Final):
         return repr(self._resolver) if self._repr is None else self._repr
 
     def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
         return Deferred(Attr(self, name))
 
     def __iter__(self):


### PR DESCRIPTION
Fixes https://github.com/ibis-project/ibis/issues/10887

Without this change, running `pytest --collect-only --doctest-modules --full-trace` on https://github.com/NickCrews/mismo takes 2.5 seconds. With this change, it takes 1.6 seconds