### PR TITLE
docs(selectors): render the module instead of hand-picking the documented components

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -573,30 +573,10 @@ quartodoc:
             - udf
             - window
         - kind: page
-          summary:
-            name: Column selectors
-            desc: Choose Table columns based on dtype, regex, and other criteria
           path: selectors
-          package: ibis.selectors
+          package: ibis
           contents:
-            - where
-            - numeric
-            - of_type
-            - startswith
-            - endswith
-            - contains
-            - matches
-            - any_of
-            - all_of
-            - cols
-            - across
-            - if_any
-            - if_all
-            - index
-            - first
-            - last
-            - all
-            - none
+            - selectors
 
     - title: Type System
       desc: "Data types and schemas"


### PR DESCRIPTION
Render `ibis/selectors.py` directly instead of manually curating the documented elements.