### PR TITLE
fix(pyarrow-conversion): ensure that non-nullability is preserved

### DIFF
--- a/ibis/backends/sql/compilers/oracle.py
+++ b/ibis/backends/sql/compilers/oracle.py
@@ -166,7 +166,11 @@ class OracleCompiler(SQLGlotCompiler):
             return self._value_to_interval(arg, to.unit)
         elif from_.is_string() and to.is_date():
             return self.f.to_date(arg, "FXYYYY-MM-DD")
-        return self.cast(arg, to)
+
+        # casting anything to NOT NULL doesn't make sense, since nullability in
+        # SQL databases is a constraint on physical tables, not on the
+        # operations on the data
+        return self.cast(arg, to.copy(nullable=True))
 
     def visit_Limit(self, op, *, parent, n, offset):
         # push limit/offset into subqueries

--- a/ibis/backends/tests/test_export.py
+++ b/ibis/backends/tests/test_export.py
@@ -740,3 +740,11 @@ def test_all_null_scalar(con):
     e = ibis.literal(None)
     result = con.to_pyarrow(e)
     assert pat.is_null(result.type)
+
+
+def test_cast_non_null(con):
+    new_ids = ibis.memtable({"id": ["my_id"]}).cast({"id": "!string"})
+    assert not new_ids.schema()["id"].nullable
+
+    table = con.to_pyarrow(new_ids)
+    assert not table.schema.field("id").nullable

--- a/ibis/formats/pyarrow.py
+++ b/ibis/formats/pyarrow.py
@@ -332,7 +332,7 @@ class PyArrowData(DataMapper):
         arrays = [
             cls.convert_column(table[name], dtype) for name, dtype in schema.items()
         ]
-        return pa.Table.from_arrays(arrays, names=list(schema.keys()))
+        return pa.Table.from_arrays(arrays, schema=desired_schema)
 
 
 class PyArrowTableProxy(TableProxy[V]):


### PR DESCRIPTION
Fixes #10896.