### PR TITLE
docs(build): disable misbehaving duckdb spatial optimizer

### DIFF
--- a/docs/posts/ibis-duckdb-geospatial/index.qmd
+++ b/docs/posts/ibis-duckdb-geospatial/index.qmd
@@ -57,6 +57,11 @@ con = ibis.duckdb.connect(path)
 con.list_tables()
 ```
 
+```{python}
+#| echo: false
+con.con.execute("PRAGMA disabled_optimizers='extension'")
+```
+
 We have multiple tables with information about New York City. Following Dr. Wu's class, we'll take a look at some
 spatial relations.
 


### PR DESCRIPTION
Looks like https://github.com/duckdb/duckdb-spatial/issues/506 might be the culprit. Disabling extension optimizers for the ibis-duckdb-geospatial blog at least gets builds passing again.