### PR TITLE
fix(examples): ensure that examples work on mssql and avoid using overwrite

### DIFF
--- a/ibis/backends/mssql/tests/test_client.py
+++ b/ibis/backends/mssql/tests/test_client.py
@@ -200,17 +200,20 @@ def test_create_temp_table_from_obj(con):
 
     t = con.create_table("team", obj, temp=True)
 
-    t2 = con.table("##team", database="tempdb.dbo")
+    try:
+        t2 = con.table("##team", database="tempdb.dbo")
 
-    assert t.to_pyarrow().equals(t2.to_pyarrow())
+        assert t.to_pyarrow().equals(t2.to_pyarrow())
 
-    persisted_from_temp = con.create_table("fuhreal", t2)
+        persisted_from_temp = con.create_table("fuhreal", t2)
 
-    assert "fuhreal" in con.list_tables()
-
-    assert persisted_from_temp.to_pyarrow().equals(t2.to_pyarrow())
-
-    con.drop_table("fuhreal")
+        try:
+            assert "fuhreal" in con.list_tables()
+            assert persisted_from_temp.to_pyarrow().equals(t2.to_pyarrow())
+        finally:
+            con.drop_table("fuhreal")
+    finally:
+        con.drop_table("#team", force=True)
 
 
 @pytest.mark.parametrize("explicit_schema", [False, True])

--- a/ibis/backends/tests/test_examples.py
+++ b/ibis/backends/tests/test_examples.py
@@ -4,6 +4,7 @@ import pytest
 from pytest import param
 
 import ibis
+from ibis.backends.tests.errors import PyODBCProgrammingError
 from ibis.conftest import LINUX, MACOS, SANDBOXED
 
 pytestmark = pytest.mark.examples
@@ -16,18 +17,7 @@ pytest.importorskip("pins")
     reason="nix on linux cannot download duckdb extensions or data due to sandboxing",
 )
 @pytest.mark.notimpl(["pyspark", "exasol", "databricks"])
-@pytest.mark.notyet(
-    [
-        "clickhouse",
-        "druid",
-        "impala",
-        "mssql",
-        "trino",
-        "risingwave",
-        "datafusion",
-        "athena",
-    ]
-)
+@pytest.mark.notyet(["druid", "impala", "trino", "risingwave", "datafusion", "athena"])
 @pytest.mark.parametrize(
     ("example", "columns"),
     [
@@ -67,6 +57,7 @@ pytest.importorskip("pins")
                 "year",
             ],
             id="has-null-integer-values",
+            marks=pytest.mark.notyet(["mssql"], raises=PyODBCProgrammingError),
         ),
     ],
 )

--- a/ibis/examples/__init__.py
+++ b/ibis/examples/__init__.py
@@ -82,7 +82,7 @@ class Example(Concrete):
             # backends support passing a `pyarrow.Table` to `create_table`
             # directly.
             obj = ibis.memtable(table)
-            return backend.create_table(table_name, obj, temp=True, overwrite=True)
+            return backend.create_table(table_name, obj, temp=True)
 
 
 _FETCH_DOCSTRING_TEMPLATE = """\


### PR DESCRIPTION
Let's see whether we can get examples working on mssql. Closes #9095.