### PR TITLE
fix(bigquery): ensure that count distinct can be used in window functions without a specified window

### DIFF
--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -327,8 +327,14 @@ class BigQueryCompiler(SQLGlotCompiler):
     @staticmethod
     def _minimize_spec(op, spec):
         # bigquery doesn't allow certain window functions to specify a window frame
-        if isinstance(func := op.func, ops.Analytic) and not isinstance(
-            func, (ops.First, ops.Last, FirstValue, LastValue, ops.NthValue)
+        if (
+            isinstance(func := op.func, ops.CountDistinct)
+            and (spec.args["start"], spec.args["end"]) == ("UNBOUNDED", "UNBOUNDED")
+        ) or (
+            isinstance(func, ops.Analytic)
+            and not isinstance(
+                func, (ops.First, ops.Last, FirstValue, LastValue, ops.NthValue)
+            )
         ):
             return None
         return spec


### PR DESCRIPTION
Allow bigquery count distinct in window functions if window is the whole table. Closes #10390.