### PR TITLE
fix(backends): array string join on empty array now consistently returns `None` across all supported backends

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -572,7 +572,7 @@ def string_join(op, **kw):
 def array_string_join(op, **kw):
     arg = translate(op.arg, **kw)
     sep = _literal_value(op.sep)
-    return arg.list.join(sep)
+    return pl.when(arg.list.len() > 0).then(arg.list.join(sep)).otherwise(None)
 
 
 @translate.register(ops.Substring)

--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -766,6 +766,11 @@ class BigQueryCompiler(SQLGlotCompiler):
         array = self.f.array_reverse(self.f.array_agg(arg))
         return array[self.f.safe_offset(0)]
 
+    def visit_ArrayStringJoin(self, op, *, arg, sep):
+        return self.if_(
+            self.f.array_length(arg) > 0, self.f.array_to_string(arg, sep), NULL
+        )
+
     def visit_ArrayFilter(self, op, *, arg, body, param, index):
         return self.f.array(
             sg.select(param)

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -605,7 +605,9 @@ class ClickHouseCompiler(SQLGlotCompiler):
             return self.f.queryString(arg)
 
     def visit_ArrayStringJoin(self, op, *, arg, sep):
-        return self.f.arrayStringConcat(arg, sep)
+        return self.if_(
+            self.f.array_length(arg) > 0, self.f.arrayStringConcat(arg, sep), NULL
+        )
 
     def visit_ArrayMap(self, op, *, arg, param, body, index):
         expressions = [param]

--- a/ibis/backends/sql/compilers/datafusion.py
+++ b/ibis/backends/sql/compilers/datafusion.py
@@ -381,7 +381,7 @@ class DataFusionCompiler(SQLGlotCompiler):
         return sg.and_(arg.is_(sg.not_(NULL)), self.f.isnan(arg))
 
     def visit_ArrayStringJoin(self, op, *, sep, arg):
-        return self.f.array_join(arg, sep)
+        return self.if_(self.f.array_length(arg) > 0, self.f.array_join(arg, sep), NULL)
 
     def visit_FindInSet(self, op, *, needle, values):
         return self.f.coalesce(

--- a/ibis/backends/sql/compilers/mysql.py
+++ b/ibis/backends/sql/compilers/mysql.py
@@ -68,6 +68,7 @@ class MySQLCompiler(SQLGlotCompiler):
         ops.Array,
         ops.ArrayFlatten,
         ops.ArrayMap,
+        ops.ArrayStringJoin,
         ops.ArgMax,
         ops.ArgMin,
         ops.Covariance,

--- a/ibis/backends/sql/compilers/postgres.py
+++ b/ibis/backends/sql/compilers/postgres.py
@@ -844,6 +844,13 @@ $$""".format(
             .subquery()
         )
 
+    def visit_ArrayStringJoin(self, op, *, arg, sep):
+        dtype = op.arg.dtype
+        return self.f.array_to_string(
+            self.f.nullif(self.cast(arg, dtype), self.cast(self.f.array(), dtype)),
+            sep,
+        )
+
     def visit_ArrayMin(self, op, *, arg):
         return self._array_reduction(arg=arg, reduction="min")
 

--- a/ibis/backends/sql/compilers/pyspark.py
+++ b/ibis/backends/sql/compilers/pyspark.py
@@ -426,7 +426,7 @@ class PySparkCompiler(SQLGlotCompiler):
         )
 
     def visit_ArrayStringJoin(self, op, *, arg, sep):
-        return self.f.concat_ws(sep, arg)
+        return self.if_(self.f.array_length(arg) > 0, self.f.concat_ws(sep, arg), NULL)
 
     def visit_ArrayCollect(self, op, *, arg, where, order_by, include_null, distinct):
         if include_null:

--- a/ibis/backends/sql/compilers/snowflake.py
+++ b/ibis/backends/sql/compilers/snowflake.py
@@ -417,6 +417,9 @@ $$""",
     def visit_TypeOf(self, op, *, arg):
         return self.f.typeof(self.f.to_variant(arg))
 
+    def visit_ArrayStringJoin(self, op, *, arg, sep):
+        return self.f.array_to_string(self.f.nullif(arg, self.f.array()), sep)
+
     def visit_ArrayRepeat(self, op, *, arg, times):
         return self.f.udf.array_repeat(arg, times)
 

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -286,7 +286,9 @@ class TrinoCompiler(SQLGlotCompiler):
         return self.f.substr(arg, -self.f.length(end)).eq(end)
 
     def visit_Repeat(self, op, *, arg, times):
-        return self.f.array_join(self.f.repeat(arg, times), "")
+        return self.f.array_join(
+            self.f.nullif(self.f.repeat(arg, times), self.f.array()), ""
+        )
 
     def visit_DateTimestampTruncate(self, op, *, arg, unit):
         _truncate_precisions = {
@@ -425,7 +427,7 @@ class TrinoCompiler(SQLGlotCompiler):
         )
 
     def visit_ArrayStringJoin(self, op, *, sep, arg):
-        return self.f.array_join(arg, sep)
+        return self.f.array_join(self.f.nullif(arg, self.f.array()), sep)
 
     def visit_First(self, op, *, arg, where, order_by, include_null):
         if not include_null:
@@ -449,7 +451,7 @@ class TrinoCompiler(SQLGlotCompiler):
         array = self.agg.array_agg(
             self.cast(arg, dt.string), where=where, order_by=order_by
         )
-        return self.f.array_join(array, sep)
+        return self.f.array_join(self.f.nullif(array, self.f.array()), sep)
 
     def visit_ArrayZip(self, op, *, arg):
         max_zip_arguments = 5

--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -586,6 +586,10 @@ class MySQLType(SqlglotType):
         return dt.Timestamp(timezone="UTC", nullable=nullable)
 
     @classmethod
+    def _from_ibis_Array(cls, dtype: dt.Array) -> sge.DataType:
+        raise com.UnsupportedBackendType("Array types aren't supported in MySQL")
+
+    @classmethod
     def _from_ibis_String(cls, dtype: dt.String) -> sge.DataType:
         return sge.DataType(this=typecode.TEXT)
 
@@ -723,6 +727,10 @@ class OracleType(SqlglotType):
     default_temporal_scale = 9
 
     unknown_type_strings = FrozenDict({"raw": dt.binary})
+
+    @classmethod
+    def _from_ibis_Array(cls, dtype: dt.Array) -> sge.DataType:
+        raise com.UnsupportedBackendType("Array types aren't supported in Oracle")
 
     @classmethod
     def _from_sqlglot_FLOAT(cls, nullable: bool | None = None) -> dt.Float64:

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -1329,6 +1329,9 @@ def test_memtable_column_naming_mismatch(con, monkeypatch, df, columns):
     reason="unable to handle the varbinary geometry column",
     raises=SnowflakeProgrammingError,
 )
+@pytest.mark.notyet(
+    ["druid"], raises=PyDruidProgrammingError, reason="doesn't support a binary type"
+)
 def test_memtable_from_geopandas_dataframe(con, data_dir):
     gpd = pytest.importorskip("geopandas")
     gdf = gpd.read_file(data_dir / "geojson" / "zones.geojson")[:5]
@@ -1718,7 +1721,7 @@ def test_hexdigest(backend, alltypes):
             ["0", "1", "2"],
             marks=[
                 pytest.mark.notimpl(["druid"], raises=PyDruidProgrammingError),
-                pytest.mark.notimpl(["oracle"], raises=OracleDatabaseError),
+                pytest.mark.notimpl(["oracle"], raises=com.UnsupportedBackendType),
                 pytest.mark.notyet(["bigquery"], raises=GoogleBadRequest),
                 pytest.mark.notimpl(["snowflake"], raises=AssertionError),
                 pytest.mark.never(

--- a/ibis/backends/tests/test_string.py
+++ b/ibis/backends/tests/test_string.py
@@ -15,6 +15,7 @@ from ibis.backends.tests.errors import (
     MySQLOperationalError,
     OracleDatabaseError,
     PsycoPg2InternalError,
+    PyDruidProgrammingError,
     PyODBCProgrammingError,
 )
 from ibis.common.annotations import ValidationError
@@ -829,13 +830,9 @@ def test_capitalize(con, inp, expected):
 
 
 @pytest.mark.notyet(
-    ["exasol", "impala", "mssql", "mysql", "sqlite"],
+    ["exasol", "impala", "mssql", "mysql", "sqlite", "oracle", "flink"],
     reason="Backend doesn't support arrays",
     raises=(com.OperationNotDefinedError, com.UnsupportedBackendType),
-)
-@pytest.mark.notimpl(
-    ["oracle", "flink"],
-    raises=com.OperationNotDefinedError,
 )
 def test_array_string_join(con):
     s = ibis.array(["a", "b", "c"])
@@ -845,6 +842,23 @@ def test_array_string_join(con):
 
     expr = s.join(",")
     assert con.execute(expr) == expected
+
+
+@pytest.mark.notyet(
+    ["exasol", "impala", "mssql", "mysql", "sqlite", "oracle", "flink"],
+    reason="Backend doesn't support arrays",
+    raises=(com.OperationNotDefinedError, com.UnsupportedBackendType),
+)
+@pytest.mark.notyet(
+    ["druid"],
+    raises=PyDruidProgrammingError,
+    reason="druid doesn't support empty array construction",
+)
+def test_empty_array_string_join(con):
+    t = ibis.memtable({"arr": [[], ["a", "b", "c"]]})
+
+    expr = t.arr.join(",")
+    assert set(con.execute(expr)) == {None, "a,b,c"}
 
 
 @pytest.mark.notimpl(


### PR DESCRIPTION
## Description of changes

ArrayStringJoin for polars now returns None when the array is empty

## Issues closed

* Resolves #10910