### PR TITLE
feat(api): make topk() and value_counts() more flexible

### DIFF
--- a/ibis/backends/polars/compiler.py
+++ b/ibis/backends/polars/compiler.py
@@ -55,6 +55,11 @@ def operation(op, **_):
     raise com.OperationNotDefinedError(f"No translation rule for {type(op)}")
 
 
+@translate.register(ops.Alias)
+def alias(op, **kw):
+    return translate(op.arg, **kw).alias(op.name)
+
+
 @translate.register(ops.DatabaseTable)
 def table(op, **_):
     return op.source._tables[op.name]

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_chain_limit_doesnt_collapse/result.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_chain_limit_doesnt_collapse/result.sql
@@ -6,13 +6,13 @@ FROM (
   FROM (
     SELECT
       "t0"."city",
-      COUNT(*) AS "CountStar(tbl)"
+      COUNT(*) AS "city_count"
     FROM "tbl" AS "t0"
     GROUP BY
       1
   ) AS "t1"
   ORDER BY
-    "t1"."CountStar(tbl)" DESC
+    "t1"."city_count" DESC
   LIMIT 10
 ) AS "t3"
 LIMIT 5
@@ -25,13 +25,13 @@ OFFSET (
     FROM (
       SELECT
         "t0"."city",
-        COUNT(*) AS "CountStar(tbl)"
+        COUNT(*) AS "city_count"
       FROM "tbl" AS "t0"
       GROUP BY
         1
     ) AS "t1"
     ORDER BY
-      "t1"."CountStar(tbl)" DESC
+      "t1"."city_count" DESC
     LIMIT 10
   ) AS "t3"
 )

--- a/ibis/backends/tests/sql/snapshots/test_select_sql/test_topk_operation/e2.sql
+++ b/ibis/backends/tests/sql/snapshots/test_select_sql/test_topk_operation/e2.sql
@@ -11,13 +11,13 @@ SEMI JOIN (
   FROM (
     SELECT
       "t0"."city",
-      COUNT(*) AS "CountStar(tbl)"
+      COUNT(*) AS "city_count"
     FROM "tbl" AS "t0"
     GROUP BY
       1
   ) AS "t2"
   ORDER BY
-    "t2"."CountStar(tbl)" DESC
+    "t2"."city_count" DESC
   LIMIT 10
 ) AS "t5"
   ON "t1"."city" = "t5"."city"


### PR DESCRIPTION
This PR changes many things. I bet we don't want all of them, but I thought it would be easiest to just put up a laundry list and then I will prune out the things we don't like.

- Add a Table.topk(). I want this frequently to check for duplicates. I don't think it makes sense to provide a `by` argument here?
- Add "See Also" links to the docstrings
- made the "k" param to topk() be optional. If you don't supply one, it just ranks the values in descending order without limiting them. I do this often in interactive analysis, I like less typing, the .head(10) during the repr in interactive mode takes care of it for me. This isn't breaking for anyone.
- Makes the default column name for Column.topk() be `{column_name}_count`, which is the same as for Column.value_counts(). This default is better because it is more consistent, and because it allows you to use .column syntax  in subsequent expressions, eg `col.topk().col_n.max()`, where the current default with the parenthesis makes this impossible. For more complex `by` clauses, this suffix doesn't make sense, so I left the current behavior as is. This IS a breaking change for people relying on the old generation scheme, but IDK, they probably shouldn't have been relying on it. We could in fact add a note saying "consider this unstable" going forward, so we are more free later to change this again.
- improved the top-line docstring for Column.topk(). The old `Return a "top k" expression.` is self-referential and fairly useless.

With all these changes, Column and Table both have .topk() and .value_counts(), and they all behave consistently, except Column.topk() has a `by` param, and Table.topk() does not.