### PR TITLE
docs: mention theseus in the readme and docs landing page diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Ibis supports nearly 20 backends:
 - [SQL Server](https://ibis-project.org/backends/mssql/)
 - [SQLite](https://ibis-project.org/backends/sqlite/)
 - [Snowflake](https://ibis-project.org/backends/snowflake)
+- [Theseus](https://voltrondata.com/start)
 - [Trino](https://ibis-project.org/backends/trino/)
 
 ## How it works

--- a/docs/backends_sankey.py
+++ b/docs/backends_sankey.py
@@ -40,6 +40,7 @@ backend_categories = {
         "RisingWave",
         "Snowflake",
         "SQLite",
+        "Theseus",
         "Trino",
     ],
     list(category_colors.keys())[2]: ["Polars"],


### PR DESCRIPTION
Adds Theseus--the Voltron Data query engine--to a couple places that list our backends.