### PR TITLE
feat(python): support python 3.9 again

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -37,7 +37,7 @@ jobs:
         os:
           - ubuntu-latest
         python-version:
-          - "3.10"
+          - "3.9"
           - "3.13"
         backend:
           - name: snowflake
@@ -54,7 +54,7 @@ jobs:
               - --extra athena
         include:
           - os: ubuntu-latest
-            python-version: "3.10"
+          - python-version: "3.9"
             backend:
               name: bigquery
               title: BigQuery

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -52,7 +52,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version:
-          - "3.10"
+          - "3.9"
           - "3.13"
     steps:
       - name: checkout
@@ -92,7 +92,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version:
-          - "3.10"
+          - "3.9"
           - "3.13"
         backend:
           - name: duckdb
@@ -547,7 +547,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.10"
+          - python-version: "3.9"
             pyspark-minor-version: "3.3"
             tag: local
             deps:

--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -44,8 +44,10 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - windows-latest
         python-version:
+          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -67,7 +69,7 @@ jobs:
         uses: astral-sh/setup-uv@v5.3.1
 
       - name: install ${{ matrix.os }} system dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           set -euo pipefail
 
@@ -117,7 +119,7 @@ jobs:
         uses: actions/setup-python@v5
         id: install_python
         with:
-          python-version: "3.13"
+          python-version: "3.9"
 
       - name: install uv
         uses: astral-sh/setup-uv@v5.3.1
@@ -150,7 +152,7 @@ jobs:
         uses: actions/setup-python@v5
         id: install_python
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: install uv
         uses: astral-sh/setup-uv@v5.3.1

--- a/.github/workflows/nix-skip-helper.yml
+++ b/.github/workflows/nix-skip-helper.yml
@@ -41,8 +41,16 @@ jobs:
           - "3.13"
         include:
           - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
             python-version: "3.10"
           - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-24.04-arm
+            python-version: "3.9"
+          - os: ubuntu-24.04-arm
+            python-version: "3.10"
+          - os: ubuntu-24.04-arm
             python-version: "3.11"
     steps:
       - run: echo "No build required"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -43,8 +43,16 @@ jobs:
           - "3.13"
         include:
           - os: ubuntu-latest
+            python-version: "3.9"
+          - os: ubuntu-latest
             python-version: "3.10"
           - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-24.04-arm
+            python-version: "3.9"
+          - os: ubuntu-24.04-arm
+            python-version: "3.10"
+          - os: ubuntu-24.04-arm
             python-version: "3.11"
     steps:
       - name: checkout

--- a/flake.nix
+++ b/flake.nix
@@ -93,9 +93,6 @@
 
           # Get repository root using git. This is expanded at runtime by the editable `.pth` machinery.
           export REPO_ROOT=$(git rev-parse --show-toplevel)
-
-          # Prevent uv from downloading managed Python's
-          export UV_PYTHON_DOWNLOADS=never
         '';
 
         preCommitDeps = with pkgs; [
@@ -163,11 +160,12 @@
         packages = {
           default = packages.ibis313;
 
-          inherit (pkgs) ibis310 ibis311 ibis312 ibis313
+          inherit (pkgs) ibis39 ibis310 ibis311 ibis312 ibis313
             update-lock-files check-release-notes-spelling;
         };
 
         checks = {
+          ibis39-pytest = pkgs.ibis39.passthru.tests.pytest;
           ibis310-pytest = pkgs.ibis310.passthru.tests.pytest;
           ibis311-pytest = pkgs.ibis311.passthru.tests.pytest;
           ibis312-pytest = pkgs.ibis312.passthru.tests.pytest;
@@ -175,6 +173,7 @@
         };
 
         devShells = rec {
+          ibis39 = mkDevShell pkgs.ibisDevEnv39;
           ibis310 = mkDevShell pkgs.ibisDevEnv310;
           ibis311 = mkDevShell pkgs.ibisDevEnv311;
           ibis312 = mkDevShell pkgs.ibisDevEnv312;

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1528,7 +1528,10 @@ def _get_backend_names(*, exclude: tuple[str] = ()) -> frozenset[str]:
 
     """
 
-    entrypoints = importlib.metadata.entry_points(group="ibis.backends")
+    if sys.version_info < (3, 10):
+        entrypoints = importlib.metadata.entry_points()["ibis.backends"]
+    else:
+        entrypoints = importlib.metadata.entry_points(group="ibis.backends")
     return frozenset(ep.name for ep in entrypoints).difference(exclude)
 
 

--- a/ibis/backends/postgres/tests/test_udf.py
+++ b/ibis/backends/postgres/tests/test_udf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import sys
 
 import pytest
 
@@ -118,6 +119,11 @@ def test_udf(test_database, table):
     assert result["mult_result"].iat[0] == 8
 
 
+@pytest.mark.xfail(
+    condition=sys.version_info[:2] < (3, 9),
+    raises=TypeError,
+    reason="no straightforward way to use new (Python 3.9) annotations syntax",
+)
 def test_array_type(test_database, table):
     """Test that usage of Array types work Other scalar types can be
     represented either by the class or an instance, but Array types work

--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -7,7 +7,7 @@ import math
 import operator
 import string
 from functools import partial, reduce
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
 import sqlglot as sg
 import sqlglot.expressions as sge
@@ -51,7 +51,7 @@ except ImportError:
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Mapping
+    from collections.abc import Iterable, Mapping
 
     import ibis.expr.schema as sch
     import ibis.expr.types as ir

--- a/ibis/backends/sql/compilers/bigquery/udf/core.py
+++ b/ibis/backends/sql/compilers/bigquery/udf/core.py
@@ -9,13 +9,10 @@ import inspect
 import textwrap
 from collections import ChainMap
 from inspect import _empty as EMPTY
-from typing import TYPE_CHECKING
+from typing import Callable
 
 from ibis.backends.sql.compilers.bigquery.udf.find import find_names
 from ibis.backends.sql.compilers.bigquery.udf.rewrite import rewrite
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 class SymbolTable(ChainMap):

--- a/ibis/backends/sqlite/udf.py
+++ b/ibis/backends/sqlite/udf.py
@@ -6,12 +6,9 @@ import math
 import operator
 from collections import defaultdict
 from datetime import date
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import Any, Callable, NamedTuple
 from urllib.parse import parse_qs, urlsplit
 from uuid import uuid4
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 try:
     import regex as re

--- a/ibis/backends/tests/test_udf.py
+++ b/ibis/backends/tests/test_udf.py
@@ -63,6 +63,11 @@ def test_udf(batting):
     ["postgres"], raises=TypeError, reason="postgres only supports map<string, string>"
 )
 @mark.notimpl(["polars"])
+@mark.never(
+    ["flink"],
+    condition=sys.version_info < (3, 10),
+    reason="broken with Python 3.9; works in Python 3.10",
+)
 @mark.notyet(["datafusion"], raises=NotImplementedError)
 @mark.notyet(
     ["sqlite"], raises=com.IbisTypeError, reason="sqlite doesn't support map types"
@@ -92,6 +97,11 @@ def test_map_udf(batting):
     ["postgres"], raises=TypeError, reason="postgres only supports map<string, string>"
 )
 @mark.notimpl(["polars"])
+@mark.never(
+    ["flink"],
+    condition=sys.version_info < (3, 10),
+    reason="broken with Python 3.9; works in Python 3.10",
+)
 @mark.notyet(["datafusion"], raises=NotImplementedError)
 @mark.notyet(["sqlite"], raises=TypeError, reason="sqlite doesn't support map types")
 def test_map_merge_udf(batting):

--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import inspect
 import types
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 from typing import Any as AnyType
 
 from typing_extensions import Self
@@ -21,7 +21,7 @@ from ibis.common.patterns import pattern as ensure_pattern
 from ibis.common.typing import format_typehint, get_type_hints
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Sequence
 
 EMPTY = inspect.Parameter.empty  # marker for missing argument
 KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY

--- a/ibis/common/caching.py
+++ b/ibis/common/caching.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from typing import Callable
 
 
 def memoize(func: Callable) -> Callable:

--- a/ibis/common/deferred.py
+++ b/ibis/common/deferred.py
@@ -5,8 +5,7 @@ import functools
 import inspect
 import operator
 from abc import abstractmethod
-from collections.abc import Callable
-from typing import Any, TypeVar, overload
+from typing import Any, Callable, TypeVar, overload
 
 from ibis.common.bases import Final, FrozenSlotted, Hashable, Immutable, Slotted
 from ibis.common.collections import FrozenDict

--- a/ibis/common/dispatch.py
+++ b/ibis/common/dispatch.py
@@ -3,14 +3,9 @@ from __future__ import annotations
 import abc
 import functools
 from collections import defaultdict
-from types import UnionType
 from typing import Union
 
-from ibis.common.typing import (
-    evaluate_annotations,
-    get_args,
-    get_origin,
-)
+from ibis.common.typing import UnionType, evaluate_annotations, get_args, get_origin
 from ibis.util import import_object, unalias_package
 
 

--- a/ibis/common/exceptions.py
+++ b/ibis/common/exceptions.py
@@ -15,10 +15,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
+from typing import Any, Callable
 
 
 class TableNotFound(Exception):

--- a/ibis/common/graph.py
+++ b/ibis/common/graph.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import itertools
 from abc import abstractmethod
 from collections import deque
-from collections.abc import Callable, Iterable, Iterator, KeysView, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union
+from collections.abc import Iterable, Iterator, KeysView, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 
 from ibis.common.bases import Hashable
 from ibis.common.patterns import NoMatch, Pattern
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 Finder = Callable[["Node"], bool]
 FinderLike = Union[Finder, Pattern, _ClassInfo]
 
-Replacer = Callable[["Node", dict["Node", Any] | None], "Node"]
+Replacer = Callable[["Node", Optional[dict["Node", Any]]], "Node"]
 ReplacerLike = Union[Replacer, Pattern, Mapping]
 
 

--- a/ibis/common/tests/conftest.py
+++ b/ibis/common/tests/conftest.py
@@ -1,3 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 collect_ignore: list[str] = []
+if sys.version_info < (3, 10):
+    collect_ignore.append("test_grounds_py310.py")

--- a/ibis/common/tests/test_grounds.py
+++ b/ibis/common/tests/test_grounds.py
@@ -5,8 +5,7 @@ import pickle
 import sys
 import weakref
 from abc import ABCMeta
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Generic, Optional, TypeVar, Union
 
 import pytest
 

--- a/ibis/common/tests/test_patterns.py
+++ b/ibis/common/tests/test_patterns.py
@@ -1338,3 +1338,17 @@ def test_node():
     )
     result = six.replace(pat)
     assert result == Mul(two, Add(Lit(101), two))
+
+
+@pytest.mark.parametrize(
+    ("p1", "p2"),
+    [
+        (InstanceOf((str, int)), InstanceOf((int, str))),
+        (
+            AnyOf(InstanceOf(int), InstanceOf(str)),
+            AnyOf(InstanceOf(str), InstanceOf(int)),
+        ),
+    ],
+)
+def test_order_does_not_matter(p1, p2):
+    assert p1 == p2

--- a/ibis/common/typing.py
+++ b/ibis/common/typing.py
@@ -5,7 +5,7 @@ import re
 import sys
 from abc import abstractmethod
 from itertools import zip_longest
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, get_args, get_origin
 from typing import get_type_hints as _get_type_hints
 
 from ibis.common.bases import Abstract
@@ -14,11 +14,18 @@ from ibis.common.caching import memoize
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-from types import UnionType
-from typing import TypeAlias
 
-# Keep this alias in sync with unittest.case._ClassInfo
-_ClassInfo: TypeAlias = type | UnionType | tuple["_ClassInfo", ...]
+if sys.version_info >= (3, 10):
+    from types import UnionType
+    from typing import TypeAlias
+
+    # Keep this alias in sync with unittest.case._ClassInfo
+    _ClassInfo: TypeAlias = type | UnionType | tuple["_ClassInfo", ...]
+else:
+    from typing_extensions import TypeAlias
+
+    UnionType = object()
+    _ClassInfo: TypeAlias = Union[type, tuple["_ClassInfo", ...]]
 
 
 T = TypeVar("T")

--- a/ibis/config.py
+++ b/ibis/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable  # noqa: TC003
-from typing import Annotated, Any, Optional
+from typing import Annotated, Any, Callable, Optional
 
 from public import public
 

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -15,14 +15,12 @@ from typing import (
     NamedTuple,
     Optional,
     TypeVar,
-    get_args,
-    get_origin,
     get_type_hints,
 )
 
 import toolz
 from public import public
-from typing_extensions import Self
+from typing_extensions import Self, get_args, get_origin
 
 from ibis.common.annotations import attribute
 from ibis.common.collections import FrozenOrderedDict, MapSet
@@ -913,7 +911,7 @@ class Array(Variadic, Parametric, Generic[T]):
 
     value_type: T
     """Element type of the array."""
-    length: Annotated[int, Between(lower=0)] | None = None
+    length: Optional[Annotated[int, Between(lower=0)]] = None
     """The length of the array if known."""
 
     scalar = "ArrayScalar"

--- a/ibis/expr/operations/tests/conftest.py
+++ b/ibis/expr/operations/tests/conftest.py
@@ -1,3 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 collect_ignore: list[str] = []
+if sys.version_info < (3, 10):
+    collect_ignore.append("test_core_py310.py")

--- a/ibis/expr/operations/udf.py
+++ b/ibis/expr/operations/udf.py
@@ -9,7 +9,7 @@ import functools
 import inspect
 import itertools
 import typing
-from typing import TYPE_CHECKING, Any, Optional, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, overload
 
 from public import public
 
@@ -24,7 +24,7 @@ from ibis.common.collections import FrozenDict
 from ibis.common.deferred import deferrable
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, MutableMapping
+    from collections.abc import Iterable, MutableMapping
 
     import ibis.expr.types as ir
 

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -14,10 +14,9 @@ from ibis.common.patterns import Coercible
 from ibis.util import indent
 
 if TYPE_CHECKING:
-    from typing import TypeAlias
-
     import sqlglot as sg
     import sqlglot.expressions as sge
+    from typing_extensions import TypeAlias
 
 
 class Schema(Concrete, Coercible, MapSet):

--- a/ibis/expr/types/arrays.py
+++ b/ibis/expr/types/arrays.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from public import public
 
@@ -12,7 +12,7 @@ from ibis.common.deferred import Deferred, deferrable
 from ibis.expr.types.generic import Column, Scalar, Value
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Iterable
 
     import ibis.expr.types as ir
     from ibis.expr.types.typing import V

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -5,9 +5,9 @@ import operator
 import re
 import warnings
 from collections import deque
-from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from keyword import iskeyword
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, overload
+from typing import TYPE_CHECKING, Any, Callable, Literal, NoReturn, overload
 
 import toolz
 from public import public

--- a/ibis/expr/types/temporal_windows.py
+++ b/ibis/expr/types/temporal_windows.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, Optional
 
 from public import public
 
@@ -22,12 +22,12 @@ class WindowedTable(Concrete):
 
     parent: ir.Table
     time_col: ops.Column
-    window_type: Literal["tumble", "hop"] | None = None
-    window_size: ir.IntervalScalar | None = None
-    window_slide: ir.IntervalScalar | None = None
-    window_offset: ir.IntervalScalar | None = None
-    groups: FrozenOrderedDict[str, Unaliased[ops.Column]] | None = None
-    metrics: FrozenOrderedDict[str, Unaliased[ops.Column]] | None = None
+    window_type: Optional[Literal["tumble", "hop"]] = None
+    window_size: Optional[ir.IntervalScalar] = None
+    window_slide: Optional[ir.IntervalScalar] = None
+    window_offset: Optional[ir.IntervalScalar] = None
+    groups: Optional[FrozenOrderedDict[str, Unaliased[ops.Column]]] = None
+    metrics: Optional[FrozenOrderedDict[str, Unaliased[ops.Column]]] = None
 
     def __init__(self, time_col: ops.Column, **kwargs):
         if time_col is None:

--- a/ibis/expr/visualize.py
+++ b/ibis/expr/visualize.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import contextlib
 import sys
 import tempfile
-from collections.abc import Callable
 from html import escape
-from typing import Optional
+from typing import Callable, Optional
 
 import graphviz as gv
 

--- a/ibis/legacy/udf/validate.py
+++ b/ibis/legacy/udf/validate.py
@@ -8,13 +8,10 @@ DO NOT USE DIRECTLY.
 from __future__ import annotations
 
 from inspect import Parameter, Signature, signature
-from typing import TYPE_CHECKING, Any
+from typing import Any, Callable
 
 import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 def _parameter_count(funcsig: Signature) -> int:

--- a/ibis/selectors.py
+++ b/ibis/selectors.py
@@ -54,9 +54,9 @@ import builtins
 import inspect
 import operator
 import re
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from functools import reduce
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 from public import public
 
@@ -207,7 +207,7 @@ def of_type(dtype: dt.DataType | str | type[dt.DataType]) -> Selector:
 
 
 class StartsWith(Selector):
-    prefixes: str | VarTuple[str]
+    prefixes: Union[str, VarTuple[str]]
 
     def expand_names(self, table: ir.Table) -> frozenset[str]:
         prefixes = self.prefixes
@@ -240,7 +240,7 @@ def startswith(prefixes: str | tuple[str, ...]) -> Selector:
 
 
 class EndsWith(Selector):
-    suffixes: str | VarTuple[str]
+    suffixes: Union[str, VarTuple[str]]
 
     def expand_names(self, table: ir.Table) -> frozenset[str]:
         suffixes = self.suffixes
@@ -636,13 +636,13 @@ def if_all(selector: Selector, predicate: Deferred | Callable) -> IfAnyAll:
 
 
 class Slice(Concrete):
-    start: int | str | None = None
-    stop: int | str | None = None
-    step: int | None = None
+    start: Optional[Union[int, str]] = None
+    stop: Optional[Union[int, str]] = None
+    step: Optional[int] = None
 
 
 class ColumnIndex(Selector):
-    key: str | int | Slice | VarTuple[int | str]
+    key: Union[str, int, Slice, VarTuple[Union[int, str]]]
 
     @staticmethod
     def slice_key_to_int(

--- a/ibis/tests/util.py
+++ b/ibis/tests/util.py
@@ -3,16 +3,13 @@
 from __future__ import annotations
 
 import pickle
-from typing import TYPE_CHECKING
+from typing import Callable
 
 import pytest
 
 import ibis
 import ibis.expr.types as ir
 from ibis import util
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 
 def assert_equal(left, right):

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -17,7 +17,7 @@ import types
 import uuid
 import warnings
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 from uuid import uuid4
 
 import toolz
@@ -25,7 +25,7 @@ import toolz
 from ibis.common.typing import Coercible
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Sequence
+    from collections.abc import Iterator, Sequence
     from numbers import Real
     from pathlib import Path
 
@@ -449,7 +449,10 @@ def experimental(func):
 def backend_entry_points() -> list[importlib.metadata.EntryPoint]:
     """Get the list of installed `ibis.backend` entrypoints."""
 
-    eps = importlib.metadata.entry_points(group="ibis.backends")
+    if sys.version_info < (3, 10):
+        eps = importlib.metadata.entry_points()["ibis.backends"]
+    else:
+        eps = importlib.metadata.entry_points(group="ibis.backends")
     return sorted(eps)
 
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -99,11 +99,13 @@ in
     sha256 = "sha256-1fenQNQB+Q0pbb0cbK2S/UIwZDE4PXXG15MH3aVbyLU=";
   };
 
+  ibis39 = mkEnv pkgs.python39;
   ibis310 = mkEnv pkgs.python310;
   ibis311 = mkEnv pkgs.python311;
   ibis312 = mkEnv pkgs.python312;
   ibis313 = mkEnv pkgs.python313;
 
+  ibisDevEnv39 = mkDevEnv pkgs.python39;
   ibisDevEnv310 = mkDevEnv pkgs.python310;
   ibisDevEnv311 = mkDevEnv pkgs.python311;
   ibisDevEnv312 = mkDevEnv pkgs.python312;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -477,10 +477,18 @@ markers = [
   "tpcds: TPC-DS tests",
 ]
 
+[tool.uv]
+python-downloads = "never"
+concurrent-installs = 1
+compile-bytecode = false
+
 [tool.ruff]
 line-length = 88
 respect-gitignore = true
 exclude = [".direnv", "result-*", "*_py310.py", "decompiled.py", "out_tpch.py"]
+
+[tool.ruff.per-file-target-version]
+"ibis/common/tests/test_grounds_py310.py" = "py310"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Description of changes

This PR brings back support for Python 3.9, which I know is maybe a bit controversial.

In retrospect, I'm not sure that Ibis should necessarily follow NEP 29 given that it's not particularly
sensitive to things that NumPy and SciPy are, like ABI changes across Python versions.

Of course, given what this PR does, the previous statement may seem a bit self-serving, but I do think that it will be less effort to support the official Python lifecycle than it is for NumPy.

I know there's also an ask for this in #10064, which hopefully this PR will resolve. Ibis has an external customer that is also requesting support for Ibis 3.9 to deploy it across an organization.

## Issues closed

Resolves #10064.
