### PR TITLE
perf(postgres): improve `to_pyarrow_batches` by using server-side cursors

### DIFF
--- a/ibis/backends/conftest.py
+++ b/ibis/backends/conftest.py
@@ -5,7 +5,6 @@ import importlib
 import importlib.metadata
 import itertools
 from functools import cache
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import _pytest
@@ -146,20 +145,6 @@ FILES_WITH_STRICT_EXCEPTION_CHECK = [
 ]
 
 ALL_BACKENDS = set(_get_backend_names())
-
-
-@pytest.fixture(scope="session")
-def data_dir() -> Path:
-    """Return the test data directory.
-
-    Returns
-    -------
-    Path
-        Test data directory
-    """
-    root = Path(__file__).absolute().parents[2]
-
-    return root / "ci" / "ibis-testing-data"
 
 
 def _get_backend_conf(backend_str: str):

--- a/ibis/conftest.py
+++ b/ibis/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import os
 import platform
+from pathlib import Path
 
 import pytest
 
@@ -44,3 +45,17 @@ not_windows = pytest.mark.skipif(
     condition=WINDOWS,
     reason="windows prevents two connections to the same file even in the same process",
 )
+
+
+@pytest.fixture(scope="session")
+def data_dir() -> Path:
+    """Return the test data directory.
+
+    Returns
+    -------
+    Path
+        Test data directory
+    """
+    root = Path(__file__).absolute().parents[1]
+
+    return root / "ci" / "ibis-testing-data"


### PR DESCRIPTION
This adds a specific `to_pyarrow_batches` implementation to the PostgreSQL backend, which uses server side cursors. This allows ibis to allocate memory needed only for `chunk_size` results of the query instead of the whole set.

Resolves #10938