### PR TITLE
ci: fix incorrect cloud ci yaml spec

### DIFF
--- a/.github/workflows/ibis-backends-cloud.yml
+++ b/.github/workflows/ibis-backends-cloud.yml
@@ -54,7 +54,7 @@ jobs:
               - --extra athena
         include:
           - os: ubuntu-latest
-          - python-version: "3.9"
+            python-version: "3.9"
             backend:
               name: bigquery
               title: BigQuery


### PR DESCRIPTION
Fix a hiccup from reverting to allow python 3.9 again