### PR TITLE
chore: fix running clouds on 39 due to use of 310-only tempfile features

### DIFF
--- a/ibis/backends/athena/__init__.py
+++ b/ibis/backends/athena/__init__.py
@@ -7,7 +7,6 @@ import getpass
 import os
 import re
 import sys
-import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -435,8 +434,8 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
         raw_upstream_dir = upstream_path.removeprefix("s3://")
         raw_upstream_path = f"{raw_upstream_dir}/data.parquet"
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
-            data = op.data.to_pyarrow(schema=schema)
+        data = op.data.to_pyarrow(schema=schema)
+        with util.mktempd() as tmpdir:
             path = Path(tmpdir, name)
             # optimize for bandwidth so use zstd which typically compresses
             # better than the other options without much loss in speed

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -404,8 +404,8 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
                 sg.table(upstream_path, db="parquet", quoted=quoted)
             ),
         ).sql(self.dialect)
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
-            data = op.data.to_pyarrow(schema=op.schema)
+        data = op.data.to_pyarrow(schema=op.schema)
+        with util.mktempd() as tmpdir:
             path = Path(tmpdir, stem)
             put_into = f"PUT '{path}' INTO '{upstream_path}' OVERWRITE"
             # optimize for bandwidth so use zstd which typically compresses

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -6,7 +6,6 @@ import glob
 import itertools
 import json
 import os
-import tempfile
 import warnings
 from operator import itemgetter
 from pathlib import Path
@@ -341,8 +340,8 @@ $$ {defn["source"]} $$"""
                         f"Unable to create Ibis UDFs, some functionality will not work: {e}"
                     )
 
-    @util.deprecated(as_of="10.0", instead="use from_connection instead")
     @classmethod
+    @util.deprecated(as_of="10.0", instead="use from_connection instead")
     def from_snowpark(
         cls, session: snowflake.snowpark.Session, *, create_object_udfs: bool = True
     ) -> Backend:
@@ -678,7 +677,7 @@ $$ {defn["source"]} $$"""
         name = op.name
         data = op.data.to_pyarrow(schema=op.schema)
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
+        with util.mktempd() as tmpdir:
             path = Path(tmpdir, f"{name}.parquet")
             # optimize for bandwidth so use zstd which typically compresses
             # better than the other options without much loss in speed

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -196,7 +196,7 @@ def test_array_concat_scalar(con, op):
 )
 @pytest.mark.notyet(
     ["bigquery"],
-    raises=ValueError,
+    raises=(AssertionError, ValueError),
     reason=(
         "bigquery treats null arrays as empty "
         "and a ValueError is raised from `pd.isna` "
@@ -208,7 +208,8 @@ def test_array_concat_with_null(con, op):
     null_value = ibis.null(non_null_value.type())
     expr = op(non_null_value, null_value)
     result = con.execute(expr)
-    assert pd.isna(result)
+    isna = pd.isna(result)
+    assert isna is True or isna is np.True_
 
 
 @pytest.mark.notyet(

--- a/ibis/util.py
+++ b/ibis/util.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import collections
 import collections.abc
+import contextlib
 import functools
 import importlib.metadata
 import itertools
@@ -12,6 +13,7 @@ import operator
 import os
 import re
 import sys
+import tempfile
 import textwrap
 import types
 import uuid
@@ -751,3 +753,19 @@ def get_subclasses(obj: type[T]) -> Iterator[type[S]]:
     for child_class in obj.__subclasses__():
         yield child_class
         yield from get_subclasses(child_class)
+
+
+if sys.version_info[:2] < (3, 10):
+
+    @contextlib.contextmanager
+    def mktempd():
+        tmpdir = tempfile.TemporaryDirectory()
+        try:
+            yield tmpdir.name
+        finally:
+            with contextlib.suppress(Exception):
+                tmpdir.cleanup()
+else:
+
+    def mktempd():
+        return tempfile.TemporaryDirectory(ignore_cleanup_errors=True)


### PR DESCRIPTION
Fix running cloud backends against python 3.9