### PR TITLE
docs(setup): add `just` recipe and setup entry for `uv`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv venv && just sync-light
+    uv venv && just sync duckdb
 
 ENV VENV_DIR=.venv
 RUN chown -R $USERNAME $VENV_DIR && chmod -R 755 $VENV_DIR

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.6.4 /uv /uvx /bin/
 ARG USERNAME=vscode
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends libgdal-dev && \
+  apt-get install -y --no-install-recommends libgdal-dev python3-dev && \
   rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install pipx --no-cache-dir
@@ -24,8 +24,7 @@ COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv venv && uv sync --group dev --group tests \
-        --extra duckdb --extra clickhouse  --extra examples --extra geospatial
+    uv venv && just sync-light
 
 ENV VENV_DIR=.venv
 RUN chown -R $USERNAME $VENV_DIR && chmod -R 755 $VENV_DIR

--- a/docs/contribute/01_environment.qmd
+++ b/docs/contribute/01_environment.qmd
@@ -246,6 +246,47 @@ for manager, params in managers.items():
     * `Rebuild Container` to copy files from the local Git repo and have the build
     run `uv sync`.
 
+## uv
+
+::: {.callout-warning}
+## `uv` will not handle installation of system dependencies
+
+`uv` will not install system dependencies needed for some packages such as `psycopg2` and `kerberos`.
+
+For a better development experience see the `conda/mamba` or `nix` setup instructions.
+:::
+
+1. [Install `uv`](https://docs.astral.sh/uv/getting-started/installation/)
+
+1. [Install `gh`](https://cli.github.com/manual/installation)
+
+1. Fork and clone the ibis repository:
+
+   ```sh
+   gh repo fork --clone --remote ibis-project/ibis
+   ```
+
+1. Change directory into `ibis`:
+
+   ```sh
+   cd ibis
+   ```
+
+1. Install development dependencies
+
+   This will create a virtual environment at `.venv` and install all dependencies inside.
+   It will also install Ibis in development mode as `ibis-framework`.
+
+   ```sh
+   just sync
+   ```
+
+1. Activate the virtual environment
+
+   ```sh
+   source .venv/bin/activate
+   ```
+
 ## pip
 
 ::: {.callout-warning}

--- a/justfile
+++ b/justfile
@@ -6,13 +6,14 @@ default:
 clean:
     git clean -fdx -e 'ci/ibis-testing-data'
 
-# install all dependencies
-sync:
-    uv sync --all-groups --all-extras
-
-# install most useful dependencies for a lightweight dev environment
-sync-light:
-    uv sync --group dev --group tests --extra duckdb --extra examples --extra geospatial
+# install dependencies for a given backend, or all dependencies if none is given
+sync backend="":
+    #!/usr/bin/env bash
+    if [ ! "{{ backend }}" ]; then
+        uv sync --all-groups --all-extras
+    else
+        uv sync --group dev --group tests --extra {{ backend }} --extra examples --extra geospatial
+    fi
 
 # lock dependencies without updating existing versions
 lock:

--- a/justfile
+++ b/justfile
@@ -6,6 +6,14 @@ default:
 clean:
     git clean -fdx -e 'ci/ibis-testing-data'
 
+# install all dependencies
+sync:
+    uv sync --all-groups --all-extras
+
+# install most useful dependencies for a lightweight dev environment
+sync-light:
+    uv sync --group dev --group tests --extra duckdb --extra examples --extra geospatial
+
 # lock dependencies without updating existing versions
 lock:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Description of changes

Hi! This PR addresses https://github.com/ibis-project/ibis/issues/10554 by adding an entry for `uv` to the "Setting up a development environment" tab panel.

It also adds a new `just sync <backend>` recipe, where `<backend>` is optional,  to make installing the adequate dependencies easier. Better names are of course welcome!

## Issues closed

* Resolves #10554
