### PR TITLE
feat(duckdb): add `read_xlsx` and `to_xlsx`

### DIFF
--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -700,6 +700,60 @@ class Expr(Immutable, Coercible):
             self, path, params=params, **kwargs
         )
 
+    def to_xlsx(
+        self,
+        path: str | Path,
+        /,
+        *,
+        sheet: str = "Sheet1",
+        header: bool = False,
+        params: Mapping[ir.Scalar, Any] | None = None,
+        **kwargs: Any,
+    ):
+        """Write a table to an Excel file.
+
+        Parameters
+        ----------
+        expr
+            Ibis table expression to write to an excel file.
+        path
+            Excel output path.
+        sheet
+            The name of the sheet to write to, eg 'Sheet3'.
+        header
+            Whether to include the column names as the first row.
+        params
+            Additional Ibis expression parameters to pass to the backend's
+            write function.
+        kwargs
+            Additional arguments passed to the backend's write function.
+
+        Notes
+        -----
+        Requires DuckDB >= 1.2.0.
+
+        See Also
+        --------
+        [DuckDB's `excel` extension docs for writing](https://duckdb.org/docs/stable/extensions/excel.html#writing-xlsx-files)
+
+        Examples
+        --------
+        >>> import os
+        >>> import ibis
+        >>> con = ibis.duckdb.connect()
+        >>> t = con.create_table(
+        ...     "t",
+        ...     ibis.memtable({"a": [1, 2, 3], "b": ["a", "b", "c"]}),
+        ...     temp=True,
+        ... )
+        >>> t.to_xlsx("/tmp/test.xlsx")
+        >>> os.path.exists("/tmp/test.xlsx")
+        True
+        """
+        self._find_backend(use_default=True).to_xlsx(
+            self, path, sheet=sheet, header=header, params=params, **kwargs
+        )
+
     @experimental
     def to_parquet_dir(
         self,


### PR DESCRIPTION
Fairly straightforward PR adding a `read_xlsx` function to the duckdb backend.

I tried to make the API generic enough that in case other backends support something similar they can use the same API. I also put the `test.xlsx` file in the general backends test folder. This was because I thought this might want to get shared by other backends. But let me know, I can put it some where else. I opted to just inline it into the source code because it is 6kb, I didn't want to go through the hassle of putting it in the test data repo, but let me know how to do that and I will :)

OR, if we expand the scope of this PR to include `to_xlsx()` function, then we would not commit the test file to git, and instead just test both read and write with a round trip of `assert original = conn.read_xlsx(original.to_xlsx())`

We could add a check for duckdb>=1.2.0 which would give a more helpful error for anyone using an older duckdb version, but I opted to keep it simple here.
