### PR TITLE
ci(bench): spin up postgres for benchmarks

### DIFF
--- a/.github/workflows/ibis-benchmarks.yml
+++ b/.github/workflows/ibis-benchmarks.yml
@@ -35,6 +35,13 @@ jobs:
       - name: install uv
         uses: astral-sh/setup-uv@v5.3.1
 
+      - uses: extractions/setup-just@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: spin up services
+        run: just up postgres
+
       - name: install system dependencies
         run: sudo apt-get install -qq -y build-essential libgeos-dev freetds-dev unixodbc-dev
 


### PR DESCRIPTION
Fix benchmarks in CI by spinning up postgres before running them.