### PR TITLE
fix(bigquery): adjust codegen for newer version of sqlglot

### DIFF
--- a/ibis/backends/sql/compilers/bigquery/__init__.py
+++ b/ibis/backends/sql/compilers/bigquery/__init__.py
@@ -391,7 +391,7 @@ class BigQueryCompiler(SQLGlotCompiler):
             arg = self.if_(where, arg, NULL)
 
         if order_by:
-            sep = sge.Order(this=sep, expressions=order_by)
+            arg = sge.Order(this=arg, expressions=order_by)
 
         return sge.GroupConcat(this=arg, separator=sep)
 


### PR DESCRIPTION
Fixes issue on `main` where codegen is incorrectly quoted due to incorrect use of `GroupConcat`