### PR TITLE
test(sqlite): squash remaining resource warning failures from unclosed connections

### DIFF
--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -124,10 +124,7 @@ class Backend(SQLBackend, UrlFromPath, PyArrowExampleLoader):
     def _post_connect(
         self, type_map: dict[str, str | dt.DataType] | None = None
     ) -> None:
-        if type_map:
-            self._type_map = {k.lower(): ibis.dtype(v) for k, v in type_map.items()}
-        else:
-            self._type_map = {}
+        self._type_map = {k.lower(): ibis.dtype(v) for k, v in (type_map or {}).items()}
 
         register_all(self.con)
         self.con.execute("PRAGMA case_sensitive_like=ON")

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -362,6 +362,7 @@ def test_create_temporary_table_from_schema(con_no_data, new_schema):
             == column_type
         )
 
+    con_no_data.disconnect()
     con_no_data.reconnect()
     # verify table no longer exist after reconnect
     assert temp_table not in con_no_data.list_tables()
@@ -1261,7 +1262,11 @@ def test_set_backend_name(name, monkeypatch):
     # plumbed through correctly.
     monkeypatch.setattr(ibis.options, "default_backend", None)
     ibis.set_backend(name)
-    assert ibis.get_backend().name == name
+    try:
+        con = ibis.get_backend()
+        assert con.name == name
+    finally:
+        con.disconnect()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is the result of going through our test suite with `-W always::ResourceWarning` and `PYTHONTRACEMALLOC=20` and finding the places where `sqlite3.Connection`s are not being cleaned up.