### PR TITLE
fix(postgres): use `.transaction` method instead of managing our own

### DIFF
--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -141,6 +141,7 @@ jobs:
               - default-libmysqlclient-dev
           - name: postgres
             title: PostgreSQL
+            serial: true
             extras:
               - --extra postgres
               - --extra geospatial
@@ -150,6 +151,7 @@ jobs:
               - libgeos-dev
           - name: postgres
             title: PostgreSQL + Torch
+            serial: true
             extras:
               - --extra postgres
               - --extra geospatial
@@ -318,6 +320,7 @@ jobs:
             backend:
               name: postgres
               title: PostgreSQL
+              serial: true
               extras:
                 - --extra postgres
                 - --extra geospatial
@@ -338,6 +341,7 @@ jobs:
             backend:
               name: postgres
               title: PostgreSQL + Torch
+              serial: true
               extras:
                 - --extra postgres
                 - --extra geospatial

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -280,6 +280,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, PyArrowExampleLoade
 
         try:
             # try to load hstore
+            with self.begin() as cursor:
+                cursor.execute("CREATE EXTENSION IF NOT EXISTS hstore")
             psycopg.types.hstore.register_hstore(
                 psycopg.types.TypeInfo.fetch(self.con, "hstore"), self.con
             )

--- a/ibis/backends/postgres/tests/conftest.py
+++ b/ibis/backends/postgres/tests/conftest.py
@@ -64,6 +64,7 @@ class TestConf(ServiceBackendTest):
             user=PG_USER,
             password=PG_PASS,
             database=IBIS_TEST_POSTGRES_DB,
+            application_name="Ibis test suite",
             **kw,
         )
 

--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -255,7 +255,10 @@ def test_kwargs_passthrough_in_connect():
     con = ibis.connect(
         "postgresql://postgres:postgres@localhost:5432/ibis_testing?sslmode=allow"
     )
-    assert con.current_catalog == "ibis_testing"
+    try:
+        assert con.current_catalog == "ibis_testing"
+    finally:
+        con.disconnect()
 
 
 def test_port():

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -819,8 +819,10 @@ def test_unsigned_integer_type(con, temp_table):
 )
 def test_connect_url(url):
     con = ibis.connect(url)
-    one = ibis.literal(1)
-    assert con.execute(one) == 1
+    try:
+        assert con.execute(ibis.literal(1)) == 1
+    finally:
+        con.disconnect()
 
 
 @pytest.mark.parametrize(
@@ -1295,7 +1297,11 @@ def test_set_backend_url(url, monkeypatch):
     monkeypatch.setattr(ibis.options, "default_backend", None)
     name = url.split("://")[0]
     ibis.set_backend(url)
-    assert ibis.get_backend().name == name
+    con = ibis.get_backend()
+    try:
+        assert con.name == name
+    finally:
+        con.disconnect()
 
 
 @pytest.mark.notyet(


### PR DESCRIPTION
This PR is the result of going through our test suite with `-W always::ResourceWarning` and finding places where we were not cleaning up postgres connections. I also attempted to fix the test hang, since I was able to reproduce it locally, and observed that some operations were idle in a transaction. The fix for that was to use `con.transaction()` instead of managing rollbacks/commits ourselves.