### PR TITLE
feat: include type of bad value in SignatureValidationError

### DIFF
--- a/ibis/common/annotations.py
+++ b/ibis/common/annotations.py
@@ -88,7 +88,7 @@ class SignatureValidationError(ValidationError):
 
         errors = ""
         for name, value, pattern in self.errors:
-            errors += f"\n  `{name}`: {value!r} is not {pattern.describe()}"
+            errors += f"\n  `{name}`: {value!r} of type {type(value)} is not {pattern.describe()}"
 
         sig = f"{self.func.__name__}{self.sig}"
         cause = str(self.__cause__) if self.__cause__ else ""

--- a/ibis/common/tests/snapshots/test_grounds/test_error_message/error_message.txt
+++ b/ibis/common/tests/snapshots/test_grounds/test_error_message/error_message.txt
@@ -1,8 +1,8 @@
 Example('1', '2', '3', '4', '5', []) has failed due to the following errors:
-  `a`: '1' is not an int
-  `b`: '2' is not an int
-  `d`: '4' is not either None or a float
-  `e`: '5' is not a tuple of ints
-  `f`: [] is not coercible to an int
+  `a`: '1' of type <class 'str'> is not an int
+  `b`: '2' of type <class 'str'> is not an int
+  `d`: '4' of type <class 'str'> is not either None or a float
+  `e`: '5' of type <class 'str'> is not a tuple of ints
+  `f`: [] of type <class 'list'> is not coercible to an int
 
 Expected signature: Example(a: int, b: int = 0, c: str = 'foo', d: Optional[float] = None, e: tuple = (1, 2, 3), f: CoercedTo[int] = 1)

--- a/ibis/common/tests/snapshots/test_grounds/test_error_message/error_message_py311.txt
+++ b/ibis/common/tests/snapshots/test_grounds/test_error_message/error_message_py311.txt
@@ -1,8 +1,8 @@
 Example('1', '2', '3', '4', '5', []) has failed due to the following errors:
-  `a`: '1' is not an int
-  `b`: '2' is not an int
-  `d`: '4' is not either None or a float
-  `e`: '5' is not a tuple of ints
-  `f`: [] is not coercible to an int
+  `a`: '1' of type <class 'str'> is not an int
+  `b`: '2' of type <class 'str'> is not an int
+  `d`: '4' of type <class 'str'> is not either None or a float
+  `e`: '5' of type <class 'str'> is not a tuple of ints
+  `f`: [] of type <class 'list'> is not coercible to an int
 
 Expected signature: Example(a: int, b: int = 0, c: str = 'foo', d: Optional[float] = None, e: tuple[int, ...] = (1, 2, 3), f: CoercedTo[int] = 1)

--- a/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call4-invalid_dtype/invalid_dtype.txt
+++ b/ibis/expr/operations/tests/snapshots/test_generic/test_error_message_when_constructing_literal/call4-invalid_dtype/invalid_dtype.txt
@@ -1,4 +1,4 @@
 Literal(1, 4) has failed due to the following errors:
-  `dtype`: 4 is not coercible to a DataType
+  `dtype`: 4 of type <class 'int'> is not coercible to a DataType
 
 Expected signature: Literal(value: Annotated[Any, Not(pattern=InstanceOf(type=<class 'Deferred'>))], dtype: DataType)


### PR DESCRIPTION
While trying to do some refactoring in ibis, I was getting

```
SignatureValidationError: ArrayContains(┏━━━━━━━━━━━━━━━━┓
┃ arr            ┃
┡━━━━━━━━━━━━━━━━┩
│ array<int64>   │
├────────────────┤
│ [1, 2, ... +1] │
│ [2, 3, ... +1] │
└────────────────┘, _.x) has failed due to the following errors:
  `other`: _.x is not coercible to a Value

Expected signature: ArrayContains(arg: Value[Array, DataShape], other: Value)
```
and this was very confusign to me, because it looks like _.x is a Deferred, which should be coercible. But actually it was a `deferred.BinaryOperator`. Now this actually will show this in the error message, making it easier to debug.