### PR TITLE
docs: add introduction to pandas users for adding columns with single text values (literal)

### DIFF
--- a/docs/tutorials/coming-from/pandas.qmd
+++ b/docs/tutorials/coming-from/pandas.qmd
@@ -240,7 +240,6 @@ To add a column with a single text value, you can use `ibis.literal`.
 mutated = t.mutate(two=ibis.literal('two'))
 ```
 
-
 ### Renaming columns
 
 In addition to replacing columns, you can rename them as well. This is done with

--- a/docs/tutorials/coming-from/pandas.qmd
+++ b/docs/tutorials/coming-from/pandas.qmd
@@ -234,10 +234,10 @@ mutated = t.mutate(two=t.two * 2)
 mutated
 ```
 
-To add a column with a single text value, you can use `ibis.literal`.
+To add a column with a single text value on all rows, you can use `ibis.literal`.
 
 ```{python}
-mutated = t.mutate(two=ibis.literal('two'))
+mutated = t.mutate(two_string=ibis.literal('two'))
 ```
 
 ### Renaming columns

--- a/docs/tutorials/coming-from/pandas.qmd
+++ b/docs/tutorials/coming-from/pandas.qmd
@@ -234,6 +234,13 @@ mutated = t.mutate(two=t.two * 2)
 mutated
 ```
 
+To add a column with a scalar text value, you can use `ibis.literal`.
+
+```{python}
+mutated = t.mutate(two=ibis.literal('two'))
+```
+
+
 ### Renaming columns
 
 In addition to replacing columns, you can rename them as well. This is done with

--- a/docs/tutorials/coming-from/pandas.qmd
+++ b/docs/tutorials/coming-from/pandas.qmd
@@ -234,7 +234,7 @@ mutated = t.mutate(two=t.two * 2)
 mutated
 ```
 
-To add a column with a scalar text value, you can use `ibis.literal`.
+To add a column with a single text value, you can use `ibis.literal`.
 
 ```{python}
 mutated = t.mutate(two=ibis.literal('two'))


### PR DESCRIPTION
## Description of changes

ibis generally follows pandas syntax for mutating columns, with the exception of adding string columns where `ibis.literal` is needed. `ibis.literal` is not mentioned yet in the pandas' user introductions, so it would be helpful to include this as it's not clear to the user why adding a float column or summing two columns together uses the same syntax as pandas, while a adding a single-valued string column does not. 

This is the reason https://github.com/ibis-project/ibis/discussions/11009 was opened (as a q&a link to send to new users).

Including it in the pandas introduction docs would reduce friction for switching to ibis for pandas users.