### PR TITLE
feat(postgres): add support for reading enum types as strings

### DIFF
--- a/ibis/backends/postgres/tests/test_client.py
+++ b/ibis/backends/postgres/tests/test_client.py
@@ -429,6 +429,7 @@ def enum_table(con):
     name = gen_name("enum_table")
     with con._safe_raw_sql("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')") as cur:
         cur.execute(f"CREATE TEMP TABLE {name} (mood mood)")
+        cur.execute(f"INSERT INTO {name} (mood) VALUES ('happy'), ('ok')")
         yield name
         cur.execute(f"DROP TABLE {name}")
         cur.execute("DROP TYPE mood")
@@ -436,7 +437,10 @@ def enum_table(con):
 
 def test_enum_table(con, enum_table):
     t = con.table(enum_table)
-    assert t.mood.type() == dt.unknown
+    assert t.mood.type().is_string()
+    e = t.filter(t.mood == "ok")
+    result = e.execute()
+    assert len(result) == 1
 
 
 def test_parsing_oid_dtype(con):


### PR DESCRIPTION
Related to, but not a full implementation, for https://github.com/ibis-project/ibis/issues/10991.

Just curious @cpcloud, is there a reason why we build up these schema queries using sqlglot instead of just raw SQL? Since we know this will only ever run on postgres, the portability/translation benefits of sqlglot are wasted. It seems like just writing the raw SQL string will be faster to execute, more stable, more familiar to more maintainers, and is easier to edit with LLMs (what I did here was compile this to SQL, ask an LLM to adjust it, and then translated the response back to sqlglot).