### PR TITLE
feat(pyspark): support ToJSONArray operation

### DIFF
--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -181,6 +181,34 @@ class BaseSparkTestConf(abc.ABC):
 
         df_time_indexed.createTempView("time_indexed_table")
 
+        nested_json_table = s.createDataFrame(
+            [
+                [
+                    "llm",
+                    """[
+                    {
+                        "description": "version 1",
+                        "details": {
+                            "major_version": 1,
+                            "released": true,
+                            "accurate_rate": 0.83
+                        }
+                    },
+                    {
+                        "description": "version 2",
+                        "details": {
+                            "major_version": 2,
+                            "released": false,
+                            "accurate_rate": 0.97
+                        }
+                    }
+                    ]""",
+                ],
+            ],
+            ["product", "version_detail"],
+        )
+        nested_json_table.createTempView("nested_json_table")
+
         if not IS_SPARK_REMOTE:
             # TODO(cpcloud): understand why this doesn't work with spark connect
             df_interval = s.createDataFrame(

--- a/ibis/backends/pyspark/tests/test_json.py
+++ b/ibis/backends/pyspark/tests/test_json.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+
+import pandas.testing as tm
+import pytest
+
+pytest.importorskip("pyspark")
+
+
+def test_json_array(con):
+    table = con.table("nested_json_table")
+    table_pandas = table.execute()
+
+    result = (
+        table.mutate(
+            version_detail=table["version_detail"]
+            .cast("json")
+            .unwrap_as(
+                "array<struct<description: string, details: struct<major_version: int64, released: bool, accurate_rate: float64>>>"
+            )
+        )
+        .execute()
+        .reset_index(drop=True)
+    )
+    expected = table_pandas.assign(
+        version_detail=table_pandas.version_detail.apply(json.loads),
+    ).reset_index(drop=True)
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- use `FROM_JSON` function to unwrap the json
- compress the casting operation to match user's intention

fixes #11036

## Description of changes
This MR enables the `pyspark` backend to support the `ToJSONArray` operation.

In this MR, I use the `FROM_JSON` function to convert the JSON string into an array object.

Additionally, this MR modifies the `visit_Cast` function to reuse the `FROM_JSON` function when casting the value returned by from_json to other types.

For typical usage, users might use the following snippet:
```python
import ibis
backend = ibis.pyspark.connect()
tab = backend.table("my_table")
tab.select(tab.val.unwrap_as("array<struct<a: int64>>").name("value")).execute()
```

However, the generated SQL currently looks like this, which leads to incorrect results:
```sql
SELECT CAST(FROM_JSON(`t0`.`val`, 'array<string>') AS ARRAY<STRUCT<`a`: BIGINT>>) AS `value` FROM `my_table`
```

The correct SQL should be:
```sql
SELECT FROM_JSON(`t0`.`val`, 'array<struct<a:bigint>>') AS `value` FROM `my_table`
```

Please let me know if this MR helps. Thank you! :D

## Issues closed

* Resolves #11036
