### PR TITLE
feat(pyspark): expose merge_schema option in create_table

### DIFF
--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -606,6 +606,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, PyArrowExampleLoade
         overwrite: bool = False,
         format: str = "parquet",
         partition_by: str | list[str] | None = None,
+        merge_schema: bool = False,
     ) -> ir.Table:
         """Create a new table in Spark.
 
@@ -631,6 +632,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, PyArrowExampleLoade
             Format of the table on disk
         partition_by
             Name(s) of partitioning column(s)
+        merge_schema
+            Forwarded to pyspark's `saveAsTable` method as the `mergeSchema` option.
 
         Returns
         -------
@@ -660,7 +663,11 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, PyArrowExampleLoade
                 self._run_pre_execute_hooks(table)
                 df = self._session.sql(query)
                 df.write.saveAsTable(
-                    name, format=format, mode=mode, partitionBy=partition_by
+                    name,
+                    format=format,
+                    mode=mode,
+                    partitionBy=partition_by,
+                    mergeSchema=merge_schema,
                 )
         elif schema is not None:
             schema = ibis.schema(schema)


### PR DESCRIPTION
Closes https://github.com/ibis-project/ibis/issues/10984

I didn't add any tests because I don't understand what this option does.
One of the requesters will need to explain this to me, and propose a general strategy for testing.

Another option would be to instead forward all kwargs opaquely as `**backend_specific_kwargs`, but I went with explicitly listing this as a named kwarg because that is what is already done with `partition_by`. But open to change this.
