### PR TITLE
ci(publishing): use oidc for publishing to pypi and test pypi

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -51,11 +51,8 @@ jobs:
 
       - name: Get all changed qmd files
         id: changed-qmd-files
-        uses: tj-actions/changed-files@v46
-        with:
-          # Avoid using single or double quotes for multiline patterns
-          files: |
-            **.qmd
+        run: |
+          echo "CHANGED_QMD_FILES=($(git diff-tree --no-commit-id --name-only -r HEAD | grep -P '\.qmd$'))" >> "$GITHUB_ENV"
 
       - name: get preview links
         env:
@@ -64,7 +61,7 @@ jobs:
         run: |
           {
             echo 'Docs preview: https://${{ steps.get_alias.outputs.id }}--ibis-quarto.netlify.app'
-            for file in ${ALL_CHANGED_FILES}; do
+            for file in "${CHANGED_QMD_FILES[@]}"; do
               link="${file#docs/}"
               echo "- [${file}](${PREVIEW_URL}/${link%.qmd})"
             done

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -46,12 +46,10 @@ jobs:
 
       - name: publish pre-release wheel to test pypi index
         if: contains(steps.get-version.outputs.value, '.dev')
-        run: uv publish --publish-url https://test.pypi.org/legacy/
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          repository-url: https://test.pypi.org/legacy/
 
       - name: publish pre-release wheel to pypi
         if: contains(steps.get-version.outputs.value, '.dev')
-        run: uv publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: publish pre-release wheel to test pypi index
         if: contains(steps.get-version.outputs.value, '.dev')
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: publish pre-release wheel to pypi
         if: contains(steps.get-version.outputs.value, '.dev')
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,7 @@ jobs:
       - name: run semantic-release
         run: ./ci/release/run.sh
         env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -63,11 +63,9 @@ module.exports = {
     [
       "@semantic-release/exec",
       {
-        verifyConditionsCmd:
-          "ci/release/verify_conditions.sh ${options.dryRun}",
+        verifyConditionsCmd: "ci/release/verify_conditions.sh",
         verifyReleaseCmd: "ci/release/verify_release.sh ${nextRelease.version}",
-        prepareCmd: "ci/release/prepare.sh ${nextRelease.version}",
-        publishCmd: "ci/release/publish.sh"
+        prepareCmd: "ci/release/prepare.sh ${nextRelease.version}"
       }
     ],
     [

--- a/ci/release/publish.sh
+++ b/ci/release/publish.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-nix develop '.#release' -c uv publish

--- a/ci/release/verify_conditions.sh
+++ b/ci/release/verify_conditions.sh
@@ -2,12 +2,5 @@
 
 set -euo pipefail
 
-dry_run="${1:-false}"
-
 # verify that the lock file matches pyproject.toml
 nix develop '.#release' -c uv lock --locked
-
-# verify that we have a token available to push to pypi using set -u
-if [ "${dry_run}" = "false" ]; then
-  : "${UV_PUBLISH_TOKEN}"
-fi


### PR DESCRIPTION
Move our CI to use trusted publishing to PyPI for releases.