### PR TITLE
fix(duckdb): always create temp tables in `temp.main`

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -155,6 +155,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, DirectExampleLoader):
         if temp:
             properties.append(sge.TemporaryProperty())
             catalog = "temp"
+            database = "main"
 
         if obj is not None:
             if not isinstance(obj, ir.Expr):

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -469,6 +469,7 @@ def test_create_table_with_nulls(con, kwargs):
 
 def test_create_temp_table_in_nondefault_schema():
     con = ibis.duckdb.connect()
-    con.create_database("my_schema")
-    con.raw_sql("USE my_schema")
+    database = gen_name("nondefault_schema")
+    con.create_database(database)
+    con.con.execute(f"USE {database}")
     con.create_table("foo", {"id": [1, 2, 3]}, temp=True)

--- a/ibis/backends/duckdb/tests/test_client.py
+++ b/ibis/backends/duckdb/tests/test_client.py
@@ -465,3 +465,10 @@ def test_create_table_with_nulls(con, kwargs):
 
     with pytest.raises(com.IbisTypeError, match="NULL typed columns"):
         con.create_table(name, **kwargs)
+
+
+def test_create_temp_table_in_nondefault_schema():
+    con = ibis.duckdb.connect()
+    con.create_database("my_schema")
+    con.raw_sql("USE my_schema")
+    con.create_table("foo", {"id": [1, 2, 3]}, temp=True)


### PR DESCRIPTION
fixes https://github.com/ibis-project/ibis/issues/11091