### PR TITLE
feat(api): expose DataType publicly at ibis.DataType

### DIFF
--- a/ibis/expr/api.py
+++ b/ibis/expr/api.py
@@ -23,6 +23,7 @@ from ibis.common.dispatch import lazy_singledispatch
 from ibis.common.exceptions import IbisInputError
 from ibis.common.grounds import Concrete
 from ibis.common.temporal import normalize_datetime, normalize_timezone
+from ibis.expr.datatypes import DataType
 from ibis.expr.decompile import decompile
 from ibis.expr.schema import Schema
 from ibis.expr.sql import parse_sql, to_sql
@@ -57,6 +58,7 @@ if TYPE_CHECKING:
 
 __all__ = (
     "Column",
+    "DataType",
     "Deferred",
     "Expr",
     "Scalar",

--- a/ibis/expr/datatypes/core.py
+++ b/ibis/expr/datatypes/core.py
@@ -107,10 +107,21 @@ del dtype.register
 class DataType(Concrete, Coercible):
     """Base class for all data types.
 
+    Don't instantiate this class directly, use the
+    [ibis.dtype](./datatypes.qmd#ibis.dtype) function instead.
     Instances are immutable.
+
+    Examples
+    --------
+    >>> import ibis
+    >>> ibis.dtype("int32")
+    Int32(nullable=True)
+    >>> isinstance(ibis.dtype("int32"), ibis.DataType)
+    True
     """
 
     nullable: bool = True
+    """A bool of whether the type is nullable."""
 
     @property
     @abstractmethod


### PR DESCRIPTION
It's nice to be able to just `import ibis; ... ; isinstace(x, ibis.DataType)` 