### PR TITLE
fix(ir): make ibis.to_sql() parse join limits and projections

### DIFF
--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_join_subquery/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_join_subquery/decompiled.py
@@ -14,11 +14,12 @@ call = ibis.table(
 agg = call.aggregate([call.call_attempts.mean().name("mean")])
 
 result = call.inner_join(
-    agg, [(agg.mean < call.call_attempts), ibis.literal(True)]
+    agg, [(call.call_attempts > agg.mean), ibis.literal(True)]
 ).select(
     call.start_time,
     call.end_time,
     call.employee_id,
     call.call_outcome_id,
     call.call_attempts,
+    agg.mean,
 )

--- a/ibis/expr/tests/snapshots/test_sql/test_parse_sql_limited_join/decompiled.py
+++ b/ibis/expr/tests/snapshots/test_sql/test_parse_sql_limited_join/decompiled.py
@@ -1,0 +1,33 @@
+import ibis
+
+
+employee = ibis.table(
+    name="employee",
+    schema={"first_name": "string", "last_name": "string", "id": "int64"},
+)
+call = ibis.table(
+    name="call",
+    schema={
+        "start_time": "timestamp",
+        "end_time": "timestamp",
+        "employee_id": "int64",
+        "call_outcome_id": "int64",
+        "call_attempts": "int64",
+    },
+)
+
+result = (
+    employee.inner_join(call, [(employee.id == call.employee_id), ibis.literal(True)])
+    .select(
+        employee.first_name,
+        employee.last_name,
+        employee.id,
+        call.start_time,
+        call.end_time,
+        call.employee_id,
+        call.call_outcome_id,
+        call.call_attempts,
+        employee.first_name.name("first"),
+    )
+    .limit(3)
+)


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

When parsing SQL to Ibis using `parse_sql`, neither limit nor select statements contained in the sqlglot output were interpreted when parsing joins.

I've refactored both limit and projections into a helper function to limit duplicated code, and call them at the end of a join operation.

### Tests
- Added `test_parse_sql_limited_join` to test the implementation of a limited join
- Changed expected output of `test_parse_sql_scalar_subquery`: The SQL from the test **does not** select the aggregated mean from the sub query, so it mustn't be included after the join
- Added a new test `test_parse_sql_join_subquery`  that actually selects the aggregated mean from the sub query to replicate the desired output  from the previous `test_parse_sql_scalar_subquery` implementation
- Changed SQL of `test_parse_sql_multiple_joins`: The SQL from the test contained a column clash (`employee.id` and `call_outcome.id` both result in an `id` column - which is valid in duckdb but not in Ibis). Now that the join actually applies sqlglot's schema, that clash surfaces with "Duplicate column name 'id' in result set" (as it should!), so the SQL needs to specify what to rename and how.

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed
* Resolves #11105

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->