### PR TITLE
docs: improve docstrings on methods using the `database` param

### DIFF
--- a/docs/concepts/backend-table-hierarchy.qmd
+++ b/docs/concepts/backend-table-hierarchy.qmd
@@ -2,14 +2,17 @@
 title: Backend Table Hierarchy
 ---
 
-Several SQL backends support two levels of hierarchy in organizing tables
-(although the levels are also used for other purposes, like data access,
-billing, etc.).
+Most SQL backends organize tables into groups, and some use a two-level hierarchy.
+They use terms such as `catalog`, `database`, and/or `schema` to refer to these groups.
 
-Ibis uses the following terminology:
+Ibis uses the following terminology throughout its codebase, API, and documentation:
 
 - `database`: a collection of tables
 - `catalog`: a collection of databases
+
+In other words, the full specification of a table in Ibis is either
+- `catalog.database.table`
+- `database.table`
 
 Below is a table with the terminology used by each backend for the two levels of
 hierarchy. This is provided as a reference, note that when using Ibis, we will
@@ -33,5 +36,6 @@ use the terms `catalog` and `database` and map them onto the appropriate fields.
 | postgres   | database       | schema     |
 | pyspark    |                | database   |
 | risingwave | database       | schema     |
+| sqlite     |                | schema     |
 | snowflake  |                | database   |
 | trino      | catalog        | schema     |

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -629,15 +629,17 @@ class CanListCatalog(abc.ABC):
         A collection of `database` is referred to as a `catalog`.
 
         These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
+        backend (where available), regardless of the terminology the backend uses.
+
+        See the
+        [Table Heirarchy Concepts Guide](/concepts/backend-table-heirarchy.qmd)
+        for more info.
         :::
 
         Parameters
         ----------
         like
-            A pattern in Python's regex format to filter returned database
-            names.
+            A pattern in Python's regex format to filter returned catalog names.
 
         Returns
         -------
@@ -659,8 +661,11 @@ class CanCreateCatalog(CanListCatalog):
         A collection of `database` is referred to as a `catalog`.
 
         These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
+        backend (where available), regardless of the terminology the backend uses.
+
+        See the
+        [Table Heirarchy Concepts Guide](/concepts/backend-table-heirarchy.qmd)
+        for more info.
         :::
 
         Parameters
@@ -682,8 +687,11 @@ class CanCreateCatalog(CanListCatalog):
         A collection of `database` is referred to as a `catalog`.
 
         These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
+        backend (where available), regardless of the terminology the backend uses.
+
+        See the
+        [Table Heirarchy Concepts Guide](/concepts/backend-table-heirarchy.qmd)
+        for more info.
         :::
 
         Parameters
@@ -709,8 +717,11 @@ class CanListDatabase(abc.ABC):
         A collection of `database` is referred to as a `catalog`.
 
         These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
+        backend (where available), regardless of the terminology the backend uses.
+
+        See the
+        [Table Heirarchy Concepts Guide](/concepts/backend-table-heirarchy.qmd)
+        for more info.
         :::
 
         Parameters
@@ -737,6 +748,20 @@ class CanCreateDatabase(CanListDatabase):
     ) -> None:
         """Create a database named `name` in `catalog`.
 
+        ::: {.callout-note}
+        ## Ibis does not use the word `schema` to refer to database hierarchy.
+
+        A collection of `table` is referred to as a `database`.
+        A collection of `database` is referred to as a `catalog`.
+
+        These terms are mapped onto the corresponding features in each
+        backend (where available), regardless of the terminology the backend uses.
+
+        See the
+        [Table Heirarchy Concepts Guide](/concepts/backend-table-heirarchy.qmd)
+        for more info.
+        :::
+
         Parameters
         ----------
         name
@@ -755,13 +780,27 @@ class CanCreateDatabase(CanListDatabase):
     ) -> None:
         """Drop the database with `name` in `catalog`.
 
+        ::: {.callout-note}
+        ## Ibis does not use the word `schema` to refer to database hierarchy.
+
+        A collection of `table` is referred to as a `database`.
+        A collection of `database` is referred to as a `catalog`.
+
+        These terms are mapped onto the corresponding features in each
+        backend (where available), regardless of the terminology the backend uses.
+
+        See the
+        [Table Heirarchy Concepts Guide](/concepts/backend-table-heirarchy.qmd)
+        for more info.
+        :::
+
         Parameters
         ----------
         name
             Name of the schema to drop.
         catalog
-            Name of the catalog to drop the database from. If `None`, the
-            current catalog is used.
+            Name of the catalog to drop the database from.
+            If `None`, the current catalog is used.
         force
             If `False`, an exception is raised if the database does not exist.
 
@@ -981,73 +1020,105 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """Return the list of table names in the current database.
+        """The table names that match `like` in the given `database`.
 
         For some backends, the tables may be files in a directory,
         or other equivalent entities in a SQL database.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
 
         Parameters
         ----------
         like
             A pattern in Python's regex format.
         database
-            The database from which to list tables.
-            If not provided, the current database is used.
+            The database, or (catalog, database) from which to list tables.
+
+            For backends that support a single-level table hierarchy,
+            you can pass in a string like `"bar"`.
             For backends that support multi-level table hierarchies, you can
             pass in a dotted string path like `"catalog.database"` or a tuple of
             strings like `("catalog", "database")`.
+            If not provided, the current database
+            (and catalog, if applicable for this backend) is used.
+
+            See the
+            [Table Heirarchy Concepts Guide](/concepts/backend-table-heirarchy.qmd)
+            for more info.
 
         Returns
         -------
         list[str]
             The list of the table names that match the pattern `like`.
 
+        Examples
+        --------
+        >>> import ibis
+        >>> con = ibis.duckdb.connect()
+        >>> foo = con.create_table("foo", schema=ibis.schema(dict(a="int")))
+        >>> con.list_tables()
+        ['foo']
+        >>> bar = con.create_view("bar", foo)
+        >>> con.list_tables()
+        ['bar', 'foo']
+        >>> con.create_database("my_database")
+        >>> con.list_tables(database="my_database")
+        []
+        >>> con.raw_sql("CREATE TABLE my_database.baz (a INTEGER)")  # doctest: +ELLIPSIS
+        <duckdb.duckdb.DuckDBPyConnection object at 0x...>
+        >>> con.list_tables(database="my_database")
+        ['baz']
         """
 
     @abc.abstractmethod
     def table(
         self, name: str, /, *, database: tuple[str, str] | str | None = None
     ) -> ir.Table:
-        """Construct a table expression.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
+        """Construct a table expression from the corresponding table in the backend.
 
         Parameters
         ----------
         name
             Table name
         database
-            Database name
-            If not provided, the current database is used.
+            The database, or (catalog, database) from which to get the table.
+
+            For backends that support a single-level table hierarchy,
+            you can pass in a string like `"bar"`.
             For backends that support multi-level table hierarchies, you can
             pass in a dotted string path like `"catalog.database"` or a tuple of
             strings like `("catalog", "database")`.
+            If not provided, the current database
+            (and catalog, if applicable for this backend) is used.
+
+            See the
+            [Table Heirarchy Concepts Guide](/concepts/backend-table-heirarchy.qmd)
+            for more info.
 
         Returns
         -------
         Table
             Table expression
 
+        Examples
+        --------
+        >>> import ibis
+        >>> backend = ibis.duckdb.connect()
+
+        Get the "foo" table from the current database
+        (and catalog, if applicable for this backend):
+
+        >>> backend.table("foo")  # doctest: +SKIP
+
+        Get the "foo" table from the "bar" database
+        (in duckdb's language they would say the "bar" schema,
+        in SQL this would be `"bar"."foo"`)
+
+        >>> backend.table("foo", database="bar")  # doctest: +SKIP
+
+        Get the "foo" table from the "bar" database, within the "baz" catalog
+        (in duckdb's language they would say the "bar" schema, and "baz" database,
+        in SQL this would be `"baz"."bar"."foo"`)
+
+        >>> backend.table("foo", database=("baz", "bar"))  # doctest: +SKIP
         """
 
     @property

--- a/ibis/backends/athena/__init__.py
+++ b/ibis/backends/athena/__init__.py
@@ -210,20 +210,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
         return self.table(orig_table_ref.name, database=(catalog, db))
 
     def table(self, name: str, /, *, database: str | None = None) -> ir.Table:
-        """Construct a table expression.
-
-        Parameters
-        ----------
-        name
-            Table name
-        database
-            Database name
-
-        Returns
-        -------
-        Table
-            Table expression
-        """
         table_loc = self._to_sqlglot_table(database)
 
         # TODO: set these to better defaults
@@ -311,20 +297,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
     def list_databases(
         self, like: str | None = None, catalog: str | None = None
     ) -> list[str]:
-        """List databases.
-
-        Parameters
-        ----------
-        like
-            Regular expression to use to match database names.
-        catalog
-            Catalog in which to search for databases.
-
-        Returns
-        -------
-        list[str]
-            A list of databases in `catalog` matching the pattern `like`.
-        """
         if catalog is None:
             catalog = self.current_catalog
         with self.con.cursor() as cur:
@@ -483,57 +455,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List tables and views.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            Regex to filter by table/view name.
-        database
-            Database location. If not passed, uses the current database.
-
-            By default uses the current `database` (`self.current_database`) and
-            `catalog` (`self.current_catalog`).
-
-            To specify a table in a separate catalog, you can pass in the
-            catalog and database as a string `"catalog.database"`, or as a tuple of
-            strings `("catalog", "database")`.
-
-        Returns
-        -------
-        list[str]
-            List of table and view names.
-
-        Examples
-        --------
-        >>> import ibis
-        >>> con = ibis.athena.connect()
-        >>> foo = con.create_table("foo", schema=ibis.schema(dict(a="int")))
-        >>> con.list_tables()
-        ['foo']
-        >>> bar = con.create_view("bar", foo)
-        >>> con.list_tables()
-        ['bar', 'foo']
-        >>> con.create_database("my_database")
-        >>> con.list_tables(database="my_database")
-        []
-        >>> con.raw_sql("CREATE TABLE my_database.baz (a INTEGER)")  # doctest: +ELLIPSIS
-        <... object at 0x...>
-        >>> con.list_tables(database="my_database")
-        ['baz']
-
-        """
         table_loc = self._to_sqlglot_table(database)
 
         catalog = table_loc.catalog or self.current_catalog

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -911,33 +911,6 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            The database location to perform the list against.
-
-            By default uses the current `dataset` (`self.current_database`) and
-            `project` (`self.current_catalog`).
-
-            To specify a table in a separate BigQuery dataset, you can pass in the
-            dataset and project as a string `"dataset.project"`, or as a tuple of
-            strings `(dataset, project)`.
-        """
         table_loc = self._to_sqlglot_table(database)
 
         project, dataset = self._parse_project_and_dataset(table_loc)

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -215,23 +215,6 @@ class Backend(SQLBackend, CanCreateDatabase, DirectExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: str | None = None
     ) -> list[str]:
-        """List the tables in `database` matching the pattern `like`.
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Database to list tables from. Default behavior is to show tables in
-            the current database.
-
-        Returns
-        -------
-        list[str]
-            List of table names in `database` matching the optional pattern
-            `like`.
-        """
-
         query = sg.select(C.name).from_(sg.table("tables", db="system"))
 
         if database is None:

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -201,21 +201,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         return self.table(name, database=(catalog, database))
 
     def table(self, name: str, /, *, database: str | None = None) -> ir.Table:
-        """Construct a table expression.
-
-        Parameters
-        ----------
-        name
-            Table name
-        database
-            Database name
-
-        Returns
-        -------
-        Table
-            Table expression
-
-        """
         table_loc = self._to_sqlglot_table(database)
 
         # TODO: set these to better defaults
@@ -443,57 +428,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List tables and views.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            Regex to filter by table/view name.
-        database
-            Database location. If not passed, uses the current database.
-
-            By default uses the current `database` (`self.current_database`) and
-            `catalog` (`self.current_catalog`).
-
-            To specify a table in a separate catalog, you can pass in the
-            catalog and database as a string `"catalog.database"`, or as a tuple of
-            strings `("catalog", "database")`.
-
-        Returns
-        -------
-        list[str]
-            List of table and view names.
-
-        Examples
-        --------
-        >>> import ibis
-        >>> con = ibis.databricks.connect()
-        >>> foo = con.create_table("foo", schema=ibis.schema(dict(a="int")))
-        >>> con.list_tables()
-        ['foo']
-        >>> bar = con.create_view("bar", foo)
-        >>> con.list_tables()
-        ['bar', 'foo']
-        >>> con.create_database("my_database")
-        >>> con.list_tables(database="my_database")
-        []
-        >>> con.raw_sql("CREATE TABLE my_database.baz (a INTEGER)")  # doctest: +ELLIPSIS
-        <... object at 0x...>
-        >>> con.list_tables(database="my_database")
-        ['baz']
-
-        """
         table_loc = self._to_sqlglot_table(database)
 
         catalog = table_loc.catalog or self.current_catalog

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -345,20 +345,6 @@ class Backend(
     def list_tables(
         self, *, like: str | None = None, database: str | None = None
     ) -> list[str]:
-        """Return the list of table names in the current database.
-
-        Parameters
-        ----------
-        like
-            A pattern in Python's regex format.
-        database
-            Unused in the datafusion backend.
-
-        Returns
-        -------
-        list[str]
-            The list of the table names that match the pattern `like`.
-        """
         database = database or "public"
         query = (
             sg.select("table_name")

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -222,16 +222,6 @@ class Backend(SQLBackend, NoExampleLoader):
     def list_tables(
         self, like: str | None = None, database: str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Database to list tables from. Default behavior is to show tables in
-            the current database.
-        """
         t = sg.table("TABLES", db="INFORMATION_SCHEMA", quoted=True)
         c = self.compiler
         query = sg.select(sg.column("TABLE_NAME", quoted=True)).from_(t).sql(c.dialect)

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -235,21 +235,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, DirectExampleLoader):
         return self.table(name, database=(catalog, database))
 
     def table(self, name: str, /, *, database: str | None = None) -> ir.Table:
-        """Construct a table expression.
-
-        Parameters
-        ----------
-        name
-            Table name
-        database
-            Database name
-
-        Returns
-        -------
-        Table
-            Table expression
-
-        """
         table_loc = self._to_sqlglot_table(database)
 
         # TODO: set these to better defaults
@@ -855,57 +840,6 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, DirectExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List tables and views.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            Regex to filter by table/view name.
-        database
-            Database location. If not passed, uses the current database.
-
-            By default uses the current `database` (`self.current_database`) and
-            `catalog` (`self.current_catalog`).
-
-            To specify a table in a separate catalog, you can pass in the
-            catalog and database as a string `"catalog.database"`, or as a tuple of
-            strings `("catalog", "database")`.
-
-        Returns
-        -------
-        list[str]
-            List of table and view names.
-
-        Examples
-        --------
-        >>> import ibis
-        >>> con = ibis.duckdb.connect()
-        >>> foo = con.create_table("foo", schema=ibis.schema(dict(a="int")))
-        >>> con.list_tables()
-        ['foo']
-        >>> bar = con.create_view("bar", foo)
-        >>> con.list_tables()
-        ['bar', 'foo']
-        >>> con.create_database("my_database")
-        >>> con.list_tables(database="my_database")
-        []
-        >>> con.raw_sql("CREATE TABLE my_database.baz (a INTEGER)")  # doctest: +ELLIPSIS
-        <duckdb.duckdb.DuckDBPyConnection object at 0x...>
-        >>> con.list_tables(database="my_database")
-        ['baz']
-
-        """
         table_loc = self._to_sqlglot_table(database)
 
         catalog = table_loc.catalog or self.current_catalog

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -191,16 +191,6 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: str | tuple[str, str] | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Database to list tables from. Default behavior is to show tables in
-            the current database.
-        """
         tables = sg.select("table_name").from_(
             sg.table("EXA_ALL_TABLES", catalog="SYS")
         )

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -206,22 +206,6 @@ class Backend(SQLBackend, NoExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: str | None = None
     ) -> list[str]:
-        """Return the list of table names in the current database.
-
-        Parameters
-        ----------
-        like
-            A pattern in Python's regex format.
-        database
-            The database from which to list tables.
-            If not provided, the current database is used.
-
-        Returns
-        -------
-        list[str]
-            The list of the table names that match the pattern `like`.
-        """
-
         statement = "SHOW TABLES"
         if database is not None:
             statement += f" IN {database}"

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -562,30 +562,6 @@ GO"""
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Table location. If not passed, uses the current catalog and database.
-
-            To specify a table in a separate catalog, you can pass in the
-            catalog and database as a string `"catalog.database"`, or as a tuple of
-            strings `("catalog", "database")`.
-        """
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
 

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -320,27 +320,6 @@ class Backend(SQLBackend, CanCreateDatabase, PyArrowExampleLoader):
         like: str | None = None,
         database: tuple[str, str] | str | None = None,
     ) -> list[str]:
-        """List the tables in the database.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Database to list tables from. Default behavior is to show tables in
-            the current database (`self.current_database`).
-        """
         if database is not None:
             table_loc = self._to_sqlglot_table(database)
         else:

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -270,27 +270,6 @@ class Backend(SQLBackend, CanListDatabase, PyArrowExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Database to list tables from. Default behavior is to show tables in
-            the current database.
-        """
         if database is not None:
             table_loc = database
         else:

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -336,28 +336,6 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, PyArrowExampleLoade
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Database to list tables from. Default behavior is to show tables in
-            the current database.
-        """
-
         if database is not None:
             table_loc = database
         else:

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -363,20 +363,6 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, PyArrowExampleLoade
     def list_tables(
         self, *, like: str | None = None, database: str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Database to list tables from. Default behavior is to show tables in
-            the current catalog and database.
-
-            To specify a table in a separate catalog, you can pass in the
-            catalog and database as a string `"catalog.database"`, or as a tuple of
-            strings `("catalog", "database")`.
-        """
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
         with self._active_catalog(catalog):

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -187,28 +187,6 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, NoExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Database to list tables from. Default behavior is to show tables in
-            the current database.
-        """
-
         if database is not None:
             table_loc = database
         else:

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -631,30 +631,6 @@ $$ {defn["source"]} $$"""
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        ::: {.callout-note}
-        ## Ibis does not use the word `schema` to refer to database hierarchy.
-
-        A collection of tables is referred to as a `database`.
-        A collection of `database` is referred to as a `catalog`.
-
-        These terms are mapped onto the corresponding features in each
-        backend (where available), regardless of whether the backend itself
-        uses the same terminology.
-        :::
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Table location. If not passed, uses the current catalog and database.
-
-            To specify a table in a separate Snowflake catalog, you can pass in the
-            catalog and database as a string `"catalog.database"`, or as a tuple of
-            strings `("catalog", "database")`.
-        """
         table_loc = self._to_sqlglot_table(database)
 
         tables_query = "SHOW TABLES"

--- a/ibis/backends/sql/__init__.py
+++ b/ibis/backends/sql/__init__.py
@@ -55,6 +55,19 @@ class SQLBackend(BaseBackend):
             compiler.visit_Unsupported,
         )
 
+    @property
+    def current_catalog(self) -> str:
+        """The name of the current catalog."""
+        with self._safe_raw_sql(sg.select(self.compiler.f.current_database())) as cur:
+            [(db,)] = cur.fetchall()
+        return db
+
+    @property
+    def current_database(self) -> str:
+        with self._safe_raw_sql(sg.select(self.compiler.f.current_schema())) as cur:
+            [(db,)] = cur.fetchall()
+        return db
+
     def _fetch_from_cursor(self, cursor, schema: sch.Schema) -> pd.DataFrame:
         import pandas as pd
 
@@ -77,21 +90,6 @@ class SQLBackend(BaseBackend):
     def table(
         self, name: str, /, *, database: tuple[str, str] | str | None = None
     ) -> ir.Table:
-        """Construct a table expression.
-
-        Parameters
-        ----------
-        name
-            Table name
-        database
-            Database name
-
-        Returns
-        -------
-        Table
-            Table expression
-
-        """
         table_loc = self._to_sqlglot_table(database)
 
         catalog = table_loc.catalog or None

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -161,19 +161,6 @@ class Backend(SQLBackend, UrlFromPath, PyArrowExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        If `database` is None, the current database is used, and temporary
-        tables are included in the result.
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            Database to list tables from. Default behavior is to show tables in
-            the current database.
-        """
         if database is None:
             database = "main"
             schemas = [database, "temp"]

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -212,22 +212,6 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, NoExampleLoader):
     def list_tables(
         self, *, like: str | None = None, database: tuple[str, str] | str | None = None
     ) -> list[str]:
-        """List the tables in the database.
-
-        Parameters
-        ----------
-        like
-            A pattern to use for listing tables.
-        database
-            The database location to perform the list against.
-
-            By default uses the current `database` (`self.current_database`) and
-            `catalog` (`self.current_catalog`).
-
-            To specify a table in a separate catalog, you can pass in the
-            catalog and database as a string `"catalog.database"`, or as a tuple of
-            strings `("catalog", "database")`.
-        """
         table_loc = self._to_sqlglot_table(database)
 
         query = "SHOW TABLES"


### PR DESCRIPTION
I removed many docstrings from subclasses, which should lead to them inheriting the docstring of the base class. This should make the docstrings easier to maintain and less lilely to drift.

I also linked to the concepts doc that @gforsyth wrote, but that never was included in the index or linked to anywhere. I think it should be surfaced somewhere more obvious.