### PR TITLE
chore(devcontainer): add openjdk to devcontainer for pyspark dev

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,12 +3,15 @@ COPY --from=ghcr.io/astral-sh/uv:0.6.14 /uv /uvx /bin/
 ARG USERNAME=vscode
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends libgdal-dev python3-dev && \
+  apt-get install -y --no-install-recommends libgdal-dev python3-dev openjdk-17-jdk && \
   rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install pipx --no-cache-dir
 RUN python3 -m pipx ensurepath
 RUN pipx install rust-just
+
+RUN echo 'export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))' >> /etc/profile.d/java.sh && \
+  echo 'export PATH=$JAVA_HOME/bin:$PATH' >> /etc/profile.d/java.sh
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description of changes

- Added `openjdk-17-jdk` dependency in Dockerfile to enable development with pyspark backend in devcontainer dev environment

## Issues closed

N/A
