### PR TITLE
feat(pyspark)!: forward kwargs in `create_table` to pyspark methods

### DIFF
--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -306,12 +306,15 @@ else:
                 .config("spark.sql.execution.arrow.pyspark.enabled", "false")
                 .config("spark.sql.shuffle.partitions", "1")
                 .config("spark.storage.blockManagerSlaveTimeoutMs", "4200s")
+                .config("spark.driver.memory", "5g")
             )
 
             try:
                 from delta.pip_utils import configure_spark_with_delta_pip
             except ImportError:
-                configure_spark_with_delta_pip = lambda cfg: cfg
+
+                def configure_spark_with_delta_pip(cfg):
+                    return cfg
             else:
                 config = config.config(
                     "spark.sql.catalog.spark_catalog",

--- a/ibis/backends/pyspark/tests/conftest.py
+++ b/ibis/backends/pyspark/tests/conftest.py
@@ -306,15 +306,12 @@ else:
                 .config("spark.sql.execution.arrow.pyspark.enabled", "false")
                 .config("spark.sql.shuffle.partitions", "1")
                 .config("spark.storage.blockManagerSlaveTimeoutMs", "4200s")
-                .config("spark.driver.memory", "5g")
             )
 
             try:
                 from delta.pip_utils import configure_spark_with_delta_pip
             except ImportError:
-
-                def configure_spark_with_delta_pip(cfg):
-                    return cfg
+                configure_spark_with_delta_pip = lambda cfg: cfg
             else:
                 config = config.config(
                     "spark.sql.catalog.spark_catalog",

--- a/ibis/backends/pyspark/tests/test_client.py
+++ b/ibis/backends/pyspark/tests/test_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
+from pyspark.errors.exceptions.captured import AnalysisException
 
 import ibis
 
@@ -62,8 +63,20 @@ def test_create_table_no_catalog(con):
     assert con.current_database != "default"
 
 
-@pytest.mark.xfail_version(pyspark=["pyspark<3.4"], reason="no catalog support")
-def test_create_table_with_partition_and_catalog(con):
+@pytest.mark.parametrize(
+    "database_param",
+    [
+        pytest.param(
+            ("spark_catalog", "ibis_testing"),
+            marks=pytest.mark.xfail_version(
+                condition=["pyspark<3.4"], reason="no catalog support"
+            ),
+            id="with_catalog",
+        ),
+        pytest.param(None, id="no_catalog"),
+    ],
+)
+def test_create_table_with_partitions(con, database_param):
     # Create a sample table with a partition column
     data = {
         "epoch": [1712848119, 1712848121, 1712848155, 1712848169],
@@ -73,49 +86,54 @@ def test_create_table_with_partition_and_catalog(con):
 
     t = ibis.memtable(data)
 
+    db_ref = database_param
+    db_str = "spark_catalog.ibis_testing" if db_ref else None
+
     # 1D partition
     table_name = "pt1"
 
     con.create_table(
         table_name,
-        database=("spark_catalog", "default"),
+        database=db_ref,
         obj=t,
         overwrite=True,
         partitionBy="category1",
     )
-    assert table_name in con.list_tables(database="spark_catalog.default")
+    assert table_name in con.list_tables(database=db_str)
 
-    partitions = (
-        con.raw_sql(f"SHOW PARTITIONS spark_catalog.default.{table_name}")
-        .toPandas()
-        .to_dict()
+    loc = (
+        f"spark_catalog.ibis_testing.{table_name}"
+        if db_ref
+        else f"ibis_testing.{table_name}"
     )
+    partitions = con.raw_sql(f"SHOW PARTITIONS {loc}").toPandas().to_dict()
     expected_partitions = {
         "partition": {0: "category1=A", 1: "category1=B", 2: "category1=C"}
     }
     assert partitions == expected_partitions
 
     # Cleanup
-    con.drop_table(table_name, database="spark_catalog.default")
-    assert table_name not in con.list_tables(database="spark_catalog.default")
+    con.drop_table(table_name, database=db_str)
+    assert table_name not in con.list_tables(database=db_str)
 
     # 2D partition
     table_name = "pt2"
 
     con.create_table(
         table_name,
-        database=("spark_catalog", "default"),
+        database=db_ref,
         obj=t,
         overwrite=True,
         partitionBy=["category1", "category2"],
     )
-    assert table_name in con.list_tables(database="spark_catalog.default")
+    assert table_name in con.list_tables(database=db_str)
 
-    partitions = (
-        con.raw_sql(f"SHOW PARTITIONS spark_catalog.default.{table_name}")
-        .toPandas()
-        .to_dict()
+    loc = (
+        f"spark_catalog.ibis_testing.{table_name}"
+        if db_ref
+        else f"ibis_testing.{table_name}"
     )
+    partitions = con.raw_sql(f"SHOW PARTITIONS {loc}").toPandas().to_dict()
     expected_partitions = {
         "partition": {
             0: "category1=A/category2=G",
@@ -126,72 +144,28 @@ def test_create_table_with_partition_and_catalog(con):
     assert partitions == expected_partitions
 
     # Cleanup
-    con.drop_table(table_name, database="spark_catalog.default")
-    assert table_name not in con.list_tables(database="spark_catalog.default")
+    con.drop_table(table_name, database=db_str)
+    assert table_name not in con.list_tables(database=db_str)
 
 
-def test_create_table_with_partition_no_catalog(con):
-    data = {
-        "epoch": [1712848119, 1712848121, 1712848155, 1712848169],
-        "category1": ["A", "B", "A", "C"],
-        "category2": ["G", "J", "G", "H"],
-    }
-
-    t = ibis.memtable(data)
-
-    # 1D partition
-    table_name = "pt1"
-
-    con.create_table(
-        table_name,
-        obj=t,
-        overwrite=True,
-        partitionBy="category1",
-    )
-    assert table_name in con.list_tables()
-
-    partitions = (
-        con.raw_sql(f"SHOW PARTITIONS ibis_testing.{table_name}").toPandas().to_dict()
-    )
-    expected_partitions = {
-        "partition": {0: "category1=A", 1: "category1=B", 2: "category1=C"}
-    }
-    assert partitions == expected_partitions
-
-    # Cleanup
-    con.drop_table(table_name)
-    assert table_name not in con.list_tables()
-
-    # 2D partition
-    table_name = "pt2"
-
-    con.create_table(
-        table_name,
-        obj=t,
-        overwrite=True,
-        partitionBy=["category1", "category2"],
-    )
-    assert table_name in con.list_tables()
-
-    partitions = (
-        con.raw_sql(f"SHOW PARTITIONS ibis_testing.{table_name}").toPandas().to_dict()
-    )
-    expected_partitions = {
-        "partition": {
-            0: "category1=A/category2=G",
-            1: "category1=B/category2=J",
-            2: "category1=C/category2=H",
-        }
-    }
-    assert partitions == expected_partitions
-
-    # Cleanup
-    con.drop_table(table_name)
-    assert table_name not in con.list_tables()
-
-
-@pytest.mark.xfail_version(pyspark=["pyspark<3.4"], reason="no catalog support")
-def test_create_table_kwargs(con):
+@pytest.mark.parametrize(
+    "format",
+    ["delta", "parquet", "csv"],
+)
+@pytest.mark.parametrize(
+    "database_param",
+    [
+        pytest.param(
+            ("spark_catalog", "ibis_testing"),
+            marks=pytest.mark.xfail_version(
+                condition=["pyspark<3.4"], reason="no catalog support"
+            ),
+            id="with_catalog",
+        ),
+        pytest.param(None, id="no_catalog"),
+    ],
+)
+def test_create_table_kwargs(con, format, database_param):
     def compare_tables(t_out, t_in):
         cols = list(t_out.columns)
         expected = t_out[cols].sort_values(cols).reset_index(drop=True)
@@ -203,15 +177,15 @@ def test_create_table_kwargs(con):
         "category1": ["A", "B", "A", "C"],
     }
 
-    table_name = "kwarg_test"
-    db_ref = ("spark_catalog", "default")
-    db_str = "spark_catalog.default"
+    table_name = f"kwarg_test_{format}"
+    db_ref = database_param
+    db_str = "spark_catalog.ibis_testing" if db_ref else None
 
     # Helper to get table
     def get_table():
         return con.table(table_name, database=db_ref).to_pandas()
 
-    # 1. Create db table (partitionBy & format kwargs)
+    # 1. Create db table
     t = ibis.memtable(base_data)
     con.create_table(
         table_name,
@@ -219,19 +193,21 @@ def test_create_table_kwargs(con):
         obj=t,
         overwrite=True,
         partitionBy="category1",
-        format="delta",
+        format=format,
     )
 
     assert table_name in con.list_tables(database=db_str)
     compare_tables(t.to_pandas(), get_table())
 
-    # 2. Append, same schema (mode & format kwargs)
+    # 2. Append, same schema (mode & format kwargs) - this is similar behavior to `insert` method
     con.create_table(
         table_name,
         database=db_ref,
         obj=t,
+        overwrite=True,  # Will get overwritten by mode
         mode="append",
-        format="delta",
+        partitionBy="category1",
+        format=format,
     )
 
     assert table_name in con.list_tables(database=db_str)
@@ -251,7 +227,7 @@ def test_create_table_kwargs(con):
         obj=t2,
         mode="overwrite",
         overwriteSchema=True,
-        format="delta",
+        format=format,
     )
 
     assert table_name in con.list_tables(database=db_str)
@@ -261,115 +237,33 @@ def test_create_table_kwargs(con):
     data_merge = {**data2, "category3": ["W", "Z", "Q", "X"]}
     t_merge = ibis.memtable(data_merge)
 
-    con.create_table(
-        table_name,
-        database=db_ref,
-        obj=t_merge,
-        mode="append",
-        mergeSchema=True,
-        format="delta",
-    )
+    if format == "delta":
+        con.create_table(
+            table_name,
+            database=db_ref,
+            obj=t_merge,
+            mode="append",
+            mergeSchema=True,
+            format=format,
+        )
 
-    assert table_name in con.list_tables(database=db_str)
-    expected_merged = pd.concat(
-        [t2.to_pandas(), t_merge.to_pandas()], ignore_index=True
-    ).fillna(value=pd.NA)
+        assert table_name in con.list_tables(database=db_str)
+        expected_merged = pd.concat(
+            [t2.to_pandas(), t_merge.to_pandas()], ignore_index=True
+        ).fillna(value=pd.NA)
 
-    compare_tables(expected_merged, get_table().fillna(value=pd.NA))
+        compare_tables(expected_merged, get_table().fillna(value=pd.NA))
+    else:  # Not supported on write for parquet or csv
+        with pytest.raises(AnalysisException) as _:
+            con.create_table(
+                table_name,
+                database=db_ref,
+                obj=t_merge,
+                mode="append",
+                mergeSchema=True,
+                format=format,
+            )
 
-
-# @pytest.mark.xfail_version(pyspark=["pyspark<3.4"], reason="no catalog support")
-# def test_create_table_kwargs(con):
-
-#     def compare_t_out_t_in(t_out, t_in):
-#         cols = list(t_out.columns)
-#         expected = t_out[cols].sort_values(
-#             cols).reset_index(drop=True)
-#         result = t_in[cols].sort_values(
-#             cols).reset_index(drop=True)
-#         assert_frame_equal(expected, result)
-
-#     data = {
-#         "epoch": [1712848119, 1712848121, 1712848155, 1712848169],
-#         "category1": ["A", "B", "A", "C"],
-#     }
-
-#     t = ibis.memtable(data)
-#     table_name = 'kwarg_test'
-
-#     # 1. Create db table (mode, partitionBy, & format kwargs)
-#     con.create_table(
-#         table_name,
-#         database=('spark_catalog', 'default'),
-#         obj=t,
-#         mode='overwrite',
-#         partitionBy="category1",
-#         format="delta"
-#     )
-#     assert table_name in con.list_tables(database="spark_catalog.default")
-#     t_out = t.to_pandas()
-#     t_in = con.table(table_name, database=(
-#         'spark_catalog', 'default')).to_pandas()
-#     compare_t_out_t_in(t_out, t_in)
-
-#     # 2. Append, same schema (mode & format kwargs)
-#     con.create_table(
-#         table_name,
-#         database=('spark_catalog', 'default'),
-#         obj=t,
-#         mode='append',
-#         format='delta',
-#     )
-#     assert table_name in con.list_tables(database="spark_catalog.default")
-#     t_out = pd.concat([t.to_pandas()] * 2, ignore_index=True)
-#     t_in = con.table(table_name, database=(
-#         'spark_catalog', 'default')).to_pandas()
-#     compare_t_out_t_in(t_out, t_in)
-
-#     # 3. Overwrite table & schema (mode, overwriteSchema, & format kwargs)
-#     data2 = {
-#         "epoch": [1712848119, 1712848121, 1712848155, 1712848169],
-#         "category1": ["A", "B", "A", "C"],
-#         "category2": ["G", "J", "G", "H"],
-#     }
-
-#     t2 = ibis.memtable(data2)
-#     con.create_table(
-#         table_name,
-#         database=('spark_catalog', 'default'),
-#         obj=t2,
-#         mode='overwrite',
-#         overwriteSchema=True,
-#         format="delta"
-#     )
-#     assert table_name in con.list_tables(database="spark_catalog.default")
-
-#     t_out = t2.to_pandas()
-#     t_in = con.table(table_name, database=(
-#         'spark_catalog', 'default')).to_pandas()
-#     compare_t_out_t_in(t_out, t_in)
-
-#     # 4. Append and merge schema (mode, mergeSchema, & format kwargs)
-#     data_merge = {
-#         "epoch": [1712848119, 1712848121, 1712848155, 1712848169],
-#         "category1": ["A", "B", "A", "C"],
-#         "category2": ["G", "J", "G", "H"],
-#         "category3": ["W", "Z", "Q", "X"]
-#     }
-
-#     t_merge = ibis.memtable(data_merge)
-#     con.create_table(
-#         table_name,
-#         database=('spark_catalog', 'default'),
-#         obj=t_merge,
-#         mode='append',
-#         mergeSchema=True,
-#         format="delta"
-#     )
-#     assert table_name in con.list_tables(database="spark_catalog.default")
-
-#     t_out = pd.concat([t2.to_pandas(), t_merge.to_pandas()],
-#                       ignore_index=True).fillna(value=pd.NA)
-#     t_in = con.table(table_name, database=(
-#         'spark_catalog', 'default')).to_pandas().fillna(value=pd.NA)
-#     compare_t_out_t_in(t_out, t_in)
+    # Cleanup
+    con.drop_table(table_name, database=db_str)
+    assert table_name not in con.list_tables()


### PR DESCRIPTION
## Description of changes

- Follow-up on  #11071
- Forward kwargs in `create_table` method to respective pyspark methods - [pyspark.sql.DataFrameWriter.saveAsTable](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.saveAsTable.html#pyspark.sql.DataFrameWriter.saveAsTable)
            if `obj` is passed or [pyspark.sql.Catalog.createTable](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Catalog.createTable.html#pyspark.sql.Catalog.createTable) if `schema` is passed. 
  - If `mode` kwarg is passed, it will take precedence over `overwrite`.
- Changes are to improve api consistency with `to_delta` and `to_parquet` for pyspark backend, while increasing flexibility of `create_table` method in correspondence with [pyspark.sql.DataFrameWriter.saveAsTable](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.saveAsTable.html#pyspark.sql.DataFrameWriter.saveAsTable)

- **Breaking:** We removed `partition_by` and `format` kwargs of `create_table` in favor
of forwarding kwargs directly to pyspark methods. This is breaking for users of `partition_by` kwarg in `create_table`, which will now need to be passed as `partitionBy`

- **Testing:** `test_create_table_kwargs` demonstrates & tests some general usage patterns of `create_table` method. Note, in example 2, when `append` is passed with an input table of same schema as db table, this behavior will be similar to that of `insert` method. 
  - This behavior is not directly exposed to Ibis users in the docs, but does create a clear mapping between `create_table` &  [`pyspark.sql.DataFrameWriter.saveAsTable`](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.saveAsTable.html#pyspark.sql.DataFrameWriter.saveAsTable) and `insert` and [`pyspark.sql.DataFrameWriter.insertInto`](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.insertInto.html) for pyspark users


## Issues closed

* Resolves #10984 

