### PR TITLE
fix(scalar-subquery): ensure that scalar subqueries `value` is resolvable with no underlying projection

### DIFF
--- a/ibis/backends/tests/test_dot_sql.py
+++ b/ibis/backends/tests/test_dot_sql.py
@@ -343,3 +343,9 @@ def test_unnamed_columns(con):
 
     assert types[0].is_string()
     assert types[1].is_integer()
+
+
+def test_scalar_dot_sql(con):
+    sql = sg.select(sge.convert(1).as_("a")).sql(con.dialect)
+    expr = con.sql(sql).as_scalar()
+    assert expr.type().is_numeric()

--- a/ibis/expr/operations/subqueries.py
+++ b/ibis/expr/operations/subqueries.py
@@ -48,7 +48,12 @@ class ScalarSubquery(Subquery):
 
     @attribute
     def value(self):
-        (value,) = self.rel.values.values()
+        rel = self.rel
+
+        if values := rel.values:
+            (value,) = values.values()
+        else:
+            (value,) = rel.fields.values()
         return value
 
     @attribute


### PR DESCRIPTION
Fixes #11121.