### PR TITLE
chore(types): add type hints to lots of core stuff

### DIFF
--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -1346,7 +1346,7 @@ class AthenaType(SqlglotType):
     dialect = "athena"
 
 
-TYPE_MAPPERS = {
+TYPE_MAPPERS: dict[str, SqlglotType] = {
     mapper.dialect: mapper
     for mapper in set(get_subclasses(SqlglotType)) - {SqlglotType, BigQueryUDFType}
 }

--- a/ibis/common/bases.py
+++ b/ibis/common/bases.py
@@ -82,10 +82,10 @@ class Abstract(metaclass=AbstractMeta):
 class Immutable(Abstract):
     """Prohibit attribute assignment on the instance."""
 
-    def __copy__(self):
+    def __copy__(self) -> Self:
         return self
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo) -> Self:
         return self
 
     def __setattr__(self, name: str, _: Any) -> None:
@@ -101,7 +101,7 @@ class Singleton(Abstract):
     __instances__: Mapping[Any, Self] = WeakValueDictionary()
 
     @classmethod
-    def __create__(cls, *args, **kwargs):
+    def __create__(cls, *args, **kwargs) -> Self:
         key = (cls, args, tuple(kwargs.items()))
         try:
             return cls.__instances__[key]
@@ -187,6 +187,8 @@ class Slotted(Abstract, metaclass=SlottedMeta):
     The class is mostly used to reduce boilerplate code.
     """
 
+    __fields__: tuple[str, ...]
+
     def __init__(self, **kwargs) -> None:
         for field in self.__fields__:
             object.__setattr__(self, field, kwargs[field])
@@ -198,14 +200,14 @@ class Slotted(Abstract, metaclass=SlottedMeta):
             return NotImplemented
         return all(getattr(self, n) == getattr(other, n) for n in self.__fields__)
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         return {k: getattr(self, k) for k in self.__fields__}
 
-    def __setstate__(self, state):
+    def __setstate__(self, state) -> None:
         for name, value in state.items():
             object.__setattr__(self, name, value)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         fields = {k: getattr(self, k) for k in self.__fields__}
         fieldstring = ", ".join(f"{k}={v!r}" for k, v in fields.items())
         return f"{self.__class__.__name__}({fieldstring})"

--- a/ibis/common/collections.py
+++ b/ibis/common/collections.py
@@ -120,15 +120,15 @@ class Mapping(Collection[K], Generic[K, V]):
     """Mapping abstract base class for quicker isinstance checks."""
 
     @abstractmethod
-    def __getitem__(self, key): ...
+    def __getitem__(self, key) -> V: ...
 
-    def get(self, key, default=None):
+    def get(self, key, default=None) -> V | None:
         try:
             return self[key]
         except KeyError:
             return default
 
-    def __contains__(self, key):
+    def __contains__(self, key) -> bool:
         try:
             self[key]
         except KeyError:
@@ -136,16 +136,16 @@ class Mapping(Collection[K], Generic[K, V]):
         else:
             return True
 
-    def keys(self):
+    def keys(self) -> collections.abc.KeysView[K]:
         return collections.abc.KeysView(self)
 
-    def items(self):
+    def items(self) -> collections.abc.ItemsView[K, V]:
         return collections.abc.ItemsView(self)
 
     def values(self):
         return collections.abc.ValuesView(self)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, collections.abc.Mapping):
             return NotImplemented
         return dict(self.items()) == dict(other.items())
@@ -347,20 +347,20 @@ class RewindableIterator(Iterator[V]):
 
     __slots__ = ("_checkpoint", "_iterator")
 
-    def __init__(self, iterable):
+    def __init__(self, iterable: collections.abc.Iterable[V]) -> None:
         self._iterator = iter(iterable)
         self._checkpoint = None
 
-    def __next__(self):
+    def __next__(self) -> V:
         return next(self._iterator)
 
-    def rewind(self):
+    def rewind(self) -> None:
         """Rewind the iterator to the last checkpoint."""
         if self._checkpoint is None:
             raise ValueError("No checkpoint to rewind to.")
         self._iterator, self._checkpoint = tee(self._checkpoint)
 
-    def checkpoint(self):
+    def checkpoint(self) -> None:
         """Create a checkpoint of the current iterator state."""
         self._iterator, self._checkpoint = tee(self._iterator)
 

--- a/ibis/common/deferred.py
+++ b/ibis/common/deferred.py
@@ -5,7 +5,7 @@ import functools
 import inspect
 import operator
 from abc import abstractmethod
-from typing import Any, Callable, TypeVar, overload
+from typing import Any, Callable, NoReturn, TypeVar, overload
 
 from ibis.common.bases import Final, FrozenSlotted, Hashable, Immutable, Slotted
 from ibis.common.collections import FrozenDict
@@ -89,23 +89,23 @@ class Deferred(Slotted, Immutable, Final):
         context = {"_": _, **kwargs}
         return self._resolver.resolve(context)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self._resolver) if self._repr is None else self._repr
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Deferred:
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
         return Deferred(Attr(self, name))
 
-    def __iter__(self):
+    def __iter__(self) -> NoReturn:
         raise TypeError(f"{self.__class__.__name__!r} object is not iterable")
 
-    def __bool__(self):
+    def __bool__(self) -> NoReturn:
         raise TypeError(
             f"The truth value of {self.__class__.__name__} objects is not defined"
         )
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Deferred:
         return Deferred(Item(self, name))
 
     def __call__(self, *args, **kwargs):

--- a/ibis/common/numeric.py
+++ b/ibis/common/numeric.py
@@ -8,7 +8,7 @@ def normalize_decimal(
     precision: int | None = None,
     scale: int | None = None,
     strict: bool = True,
-):
+) -> Decimal:
     context = Context(prec=38 if precision is None else precision)
 
     try:

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -14,12 +14,15 @@ from ibis.common.patterns import Coercible
 from ibis.util import indent
 
 if TYPE_CHECKING:
+    import numpy as np
+    import pyarrow as pa
     import sqlglot as sg
     import sqlglot.expressions as sge
-    from typing_extensions import TypeAlias
+    from pandas.api.extensions import ExtensionDtype
+    from typing_extensions import Self, TypeAlias
 
 
-class Schema(Concrete, Coercible, MapSet):
+class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
     """An ordered mapping of str -> [datatype](./datatypes.qmd), used to hold a [Table](./expression-tables.qmd#ibis.expr.tables.Table)'s schema."""
 
     fields: FrozenOrderedDict[str, dt.DataType]
@@ -108,7 +111,7 @@ class Schema(Concrete, Coercible, MapSet):
     def from_tuples(
         cls,
         values: Iterable[tuple[str, str | dt.DataType]],
-    ) -> Schema:
+    ) -> Self:
         """Construct a `Schema` from an iterable of pairs.
 
         Parameters
@@ -150,46 +153,46 @@ class Schema(Concrete, Coercible, MapSet):
         return cls(dict(zip(names, types)))
 
     @classmethod
-    def from_numpy(cls, numpy_schema):
+    def from_numpy(cls, numpy_schema) -> Self:
         """Return the equivalent ibis schema."""
         from ibis.formats.numpy import NumpySchema
 
         return NumpySchema.to_ibis(numpy_schema)
 
     @classmethod
-    def from_pandas(cls, pandas_schema):
+    def from_pandas(cls, pandas_schema) -> Self:
         """Return the equivalent ibis schema."""
         from ibis.formats.pandas import PandasSchema
 
         return PandasSchema.to_ibis(pandas_schema)
 
     @classmethod
-    def from_pyarrow(cls, pyarrow_schema):
+    def from_pyarrow(cls, pyarrow_schema) -> Self:
         """Return the equivalent ibis schema."""
         from ibis.formats.pyarrow import PyArrowSchema
 
         return PyArrowSchema.to_ibis(pyarrow_schema)
 
     @classmethod
-    def from_polars(cls, polars_schema):
+    def from_polars(cls, polars_schema) -> Self:
         """Return the equivalent ibis schema."""
         from ibis.formats.polars import PolarsSchema
 
         return PolarsSchema.to_ibis(polars_schema)
 
-    def to_numpy(self):
+    def to_numpy(self) -> list[tuple[str, np.dtype]]:
         """Return the equivalent numpy dtypes."""
         from ibis.formats.numpy import NumpySchema
 
         return NumpySchema.from_ibis(self)
 
-    def to_pandas(self):
+    def to_pandas(self) -> list[tuple[str, np.dtype | ExtensionDtype]]:
         """Return the equivalent pandas datatypes."""
         from ibis.formats.pandas import PandasSchema
 
         return PandasSchema.from_ibis(self)
 
-    def to_pyarrow(self):
+    def to_pyarrow(self) -> pa.Schema:
         """Return the equivalent pyarrow schema."""
         from ibis.formats.pyarrow import PyArrowSchema
 

--- a/ibis/formats/numpy.py
+++ b/ibis/formats/numpy.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import toolz
 
 import ibis.expr.datatypes as dt
 import ibis.expr.schema as sch
 from ibis.formats import SchemaMapper, TypeMapper
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 _from_numpy_types = toolz.keymap(
     np.dtype,
@@ -92,11 +97,11 @@ class NumpyType(TypeMapper[np.dtype]):
 
 class NumpySchema(SchemaMapper):
     @classmethod
-    def from_ibis(cls, schema):
+    def from_ibis(cls, schema) -> list[tuple[str, np.dtype]]:
         numpy_types = map(NumpyType.from_ibis, schema.types)
         return list(zip(schema.names, numpy_types))
 
     @classmethod
-    def to_ibis(cls, schema):
+    def to_ibis(cls, schema: Iterable[tuple[str, np.dtype]]) -> sch.Schema:
         ibis_types = {name: NumpyType.to_ibis(typ) for name, typ in schema}
         return sch.Schema(ibis_types)


### PR DESCRIPTION
I particularly wanted it for Schema.values() and .keys(), but then I just kept going