### PR TITLE
fix(databricks): use `AS JSON` for programmatic output of schema information

### DIFF
--- a/ibis/backends/databricks/tests/conftest.py
+++ b/ibis/backends/databricks/tests/conftest.py
@@ -6,6 +6,8 @@ import sys
 from os import environ as env
 from typing import TYPE_CHECKING, Any
 
+import pytest
+
 import ibis
 from ibis.backends.tests.base import BackendTest
 
@@ -73,3 +75,9 @@ class TestConf(BackendTest):
             schema="default",
             **kw,
         )
+
+
+@pytest.fixture(scope="session")
+def con(tmp_path_factory, data_dir, worker_id):
+    with TestConf.load_data(data_dir, tmp_path_factory, worker_id) as be:
+        yield be.connection

--- a/ibis/backends/databricks/tests/test_datatypes.py
+++ b/ibis/backends/databricks/tests/test_datatypes.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+import ibis.expr.datatypes as dt
+import ibis.expr.schema as sch
+from ibis.util import gen_name
+
+
+@pytest.fixture
+def tmp_table(con):
+    name = gen_name("databricks_tmp_table")
+    yield name
+    con.drop_table(name, force=True)
+
+
+def test_nested(con, tmp_table):
+    schema = sch.Schema(
+        {
+            "nums": "decimal(33, 2)",
+            "time": "timestamp('UTC')",
+            "operationName": "string",
+            "category": "string",
+            "tenantId": "string",
+            "properties": dt.Struct(
+                {
+                    "Timestamp": "timestamp('UTC')",
+                    "ActionType": "string",
+                    "Application": "string",
+                    "ApplicationId": "int32",
+                    "AppInstanceId": "int32",
+                    "AccountObjectId": "string",
+                    "AccountId": "string",
+                    "AccountDisplayName": "string",
+                    "IsAdminOperation": "boolean",
+                    "DeviceType": "string",
+                    "OSPlatform": "string",
+                    "IPAddress": "string",
+                    "IsAnonymousProxy": "boolean",
+                    "CountryCode": "string",
+                    "City": "string",
+                    "ISP": "string",
+                    "UserAgent": "string",
+                    "ActivityType": "string",
+                    "ActivityObjects": "string",
+                    "ObjectName": "string",
+                    "ObjectType": "string",
+                    "ObjectId": "string",
+                    "ReportId": "string",
+                    "AccountType": "string",
+                    "IsExternalUser": "boolean",
+                    "IsImpersonated": "boolean",
+                    "IPTags": "string",
+                    "IPCategory": "string",
+                    "UserAgentTags": "string",
+                    "RawEventData": "string",
+                    "AdditionalFields": "string",
+                }
+            ),
+            "Tenant": "string",
+            "_rescued_data": "string",
+            "timestamp": "timestamp('UTC')",
+            "parse_details": dt.Struct(
+                {
+                    "status": "string",
+                    "at": "timestamp('UTC')",
+                    "info": dt.Struct({"input-file-name": "string"}),
+                }
+            ),
+            "p_date": "string",
+            "foo": "array<struct<a: map<string, array<struct<b: string>>>>>",
+            "a": "array<int>",
+            "b": "map<string, int>",
+        }
+    )
+
+    t = con.create_table(tmp_table, schema=schema)
+    assert t.schema() == schema

--- a/ibis/backends/tests/test_client.py
+++ b/ibis/backends/tests/test_client.py
@@ -407,7 +407,7 @@ def test_rename_table(con, temp_table, temp_table_orig):
 
 
 @mark.notimpl(["polars", "druid", "athena"])
-@mark.never(["impala", "pyspark", "databricks"], reason="No non-nullable datatypes")
+@mark.never(["impala", "pyspark"], reason="No non-nullable datatypes")
 @pytest.mark.notimpl(
     ["flink"],
     raises=com.IbisError,


### PR DESCRIPTION
Fix databricks datatype parsing using `DESCRIBE EXTENDED … AS JSON`. Closes #11130.