### PR TITLE
fix(impala): make create_database follow the CanCreateDatabase API

### DIFF
--- a/ibis/backends/impala/tests/test_ddl.py
+++ b/ibis/backends/impala/tests/test_ddl.py
@@ -53,7 +53,7 @@ def temp_db(con, tmp_dir):
 
 def test_create_database_with_location(con, temp_db):
     name = os.path.basename(temp_db)
-    con.create_database(name, path=temp_db)
+    con.create_database(name, catalog=temp_db)
     assert name in con.list_databases()
 
 

--- a/ibis/backends/tests/test_signatures.py
+++ b/ibis/backends/tests/test_signatures.py
@@ -42,14 +42,10 @@ def _scrape_methods(modules, params):
 marks = {
     "compile": pytest.param(BaseBackend, "compile"),
     "create_database": pytest.param(
-        CanCreateDatabase,
-        "create_database",
-        marks=pytest.mark.notyet(["impala", "mysql"]),
+        CanCreateDatabase, "create_database", marks=pytest.mark.notyet(["mysql"])
     ),
     "drop_database": pytest.param(
-        CanCreateDatabase,
-        "drop_database",
-        marks=pytest.mark.notyet(["impala", "mysql"]),
+        CanCreateDatabase, "drop_database", marks=pytest.mark.notyet(["mysql"])
     ),
     "drop_table": pytest.param(
         SQLBackend, "drop_table", marks=pytest.mark.notyet(["druid"])


### PR DESCRIPTION
Followup to a bug I found in https://github.com/ibis-project/ibis/pull/11112.

In that PR, I added CanCreateDatabase as a superclass of Impala, and then tests started failing. So I'm trying to fix this here.

This is a breaking change by renaming the params of the funciton and making the kwarg-only