### PR TITLE
fix(flink): unit is ignored when str cast to timestamp

### DIFF
--- a/ibis/backends/flink/tests/test_compiler.py
+++ b/ibis/backends/flink/tests/test_compiler.py
@@ -104,5 +104,5 @@ def test_having(simple_table, assert_sql):
 
 def test_timestamp_cast_to_seconds_respects_unit():
     expr = ibis.now()
-    compiled = expr.cast("timestamp('s')").compile(dialect="flink")
+    compiled = ibis.to_sql(expr.cast("timestamp('s')"), dialect="flink")
     assert "yyyy-MM-dd HH:mm:ss.SSS" not in compiled

--- a/ibis/backends/flink/tests/test_compiler.py
+++ b/ibis/backends/flink/tests/test_compiler.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import pytest
 from pytest import param
 
+import ibis
+
 
 def test_sum(simple_table, assert_sql):
     expr = simple_table.a.sum()
@@ -98,3 +100,9 @@ def test_having(simple_table, assert_sql):
         .aggregate(simple_table.b.sum().name("b_sum"))
     )
     assert_sql(expr)
+
+
+def test_timestamp_cast_to_seconds_respects_unit():
+    expr = ibis.now()
+    compiled = expr.cast("timestamp('s')").compile(dialect="flink")
+    assert "yyyy-MM-dd HH:mm:ss.SSS" not in compiled

--- a/ibis/backends/sql/compilers/flink.py
+++ b/ibis/backends/sql/compilers/flink.py
@@ -423,6 +423,10 @@ class FlinkCompiler(SQLGlotCompiler):
                     self.f.convert_tz(self.cast(arg, dt.string), "UTC+0", tz)
                 )
             else:
+                from ibis.common.temporal import TimestampUnit
+
+                if to.unit == TimestampUnit.SECOND:
+                    return self.f.to_timestamp(arg)
                 return self.f.to_timestamp(arg, "yyyy-MM-dd HH:mm:ss.SSS")
         elif to.is_json():
             return arg


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->
When string like '2025-04-28 00:00:00' cast to dt.timestamp.from_unit('s'), the unit is ignored, sql is like:

``
TO_TIMESTAMP(COALESCE('2025-04-28 00:00:00','yyyy-MM-dd HH:mm:ss.SSS')
``

Fix it when unit is second:
``
TO_TIMESTAMP(COALESCE('2025-04-28 00:00:00')
``
the default value of the format string is 'yyyy-MM-dd HH:mm:ss' .
## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
