### PR TITLE
feat: make Backend._from_url() consistently use kwargs as overrides

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -328,12 +328,14 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         )
         return self._read_file(path, table_name=table_name, job_config=job_config)
 
-    def _from_url(self, url: ParseResult, **kwargs):
-        return self.connect(
-            project_id=url.netloc or kwargs.get("project_id", [""])[0],
-            dataset_id=url.path[1:] or kwargs.get("dataset_id", [""])[0],
-            **kwargs,
-        )
+    def _from_url(self, url: ParseResult, **kwarg_overrides):
+        kwargs = {}
+        if url.netloc:
+            kwargs["project_id"] = url.netloc
+        if url.path:
+            kwargs["dataset_id"] = url.path[1:]
+        kwargs.update(kwarg_overrides)
+        return self.connect(**kwargs)
 
     def do_connect(
         self,

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -69,36 +69,20 @@ class Backend(SQLBackend, CanCreateDatabase, DirectExampleLoader):
     def _finalize_memtable(self, name: str) -> None:
         """No-op."""
 
-    def _from_url(self, url: ParseResult, **kwargs) -> BaseBackend:
-        """Connect to a backend using a URL `url`.
-
-        Parameters
-        ----------
-        url
-            URL with which to connect to a backend.
-        kwargs
-            Additional keyword arguments
-
-        Returns
-        -------
-        BaseBackend
-            A backend instance
-
-        """
-        database = url.path[1:]
-
-        connect_args = {
-            "user": url.username,
-            "password": unquote_plus(url.password or ""),
-            "host": url.hostname,
-            "database": database or "",
-            "port": url.port,
-            **kwargs,
-        }
-
-        kwargs.update(connect_args)
+    def _from_url(self, url: ParseResult, **kwarg_overrides) -> BaseBackend:
+        kwargs = {}
+        if url.username:
+            kwargs["user"] = url.username
+        if url.password:
+            kwargs["password"] = unquote_plus(url.password)
+        if url.hostname:
+            kwargs["host"] = url.hostname
+        if url.port:
+            kwargs["port"] = url.port
+        if database := url.path[1:]:
+            kwargs["database"] = database
+        kwargs.update(kwarg_overrides)
         self._convert_kwargs(kwargs)
-
         return self.connect(**kwargs)
 
     def _convert_kwargs(self, kwargs):

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -44,35 +44,20 @@ class Backend(SQLBackend, NoExampleLoader):
             [(version,)] = result.fetchall()
         return version
 
-    def _from_url(self, url: ParseResult, **kwargs):
-        """Connect to a backend using a URL `url`.
-
-        Parameters
-        ----------
-        url
-            URL with which to connect to a backend.
-        kwargs
-            Additional keyword arguments
-
-        Returns
-        -------
-        BaseBackend
-            A backend instance
-
-        """
-        kwargs = {
-            "user": url.username,
-            "password": unquote_plus(url.password)
-            if url.password is not None
-            else None,
-            "host": url.hostname,
-            "path": url.path,
-            "port": url.port,
-            **kwargs,
-        }
-
+    def _from_url(self, url: ParseResult, **kwarg_overrides):
+        kwargs = {}
+        if url.username:
+            kwargs["user"] = url.username
+        if url.password:
+            kwargs["password"] = unquote_plus(url.password)
+        if url.hostname:
+            kwargs["host"] = url.hostname
+        if url.path:
+            kwargs["path"] = url.path
+        if url.port:
+            kwargs["port"] = url.port
+        kwargs.update(kwarg_overrides)
         self._convert_kwargs(kwargs)
-
         return self.connect(**kwargs)
 
     @property

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -151,21 +151,20 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
         with self.begin() as con:
             con.execute(f"ALTER SESSION SET TIME_ZONE = {timezone!r}")
 
-    def _from_url(self, url: ParseResult, **kwargs) -> BaseBackend:
-        """Construct an ibis backend from a URL."""
-        kwargs = {
-            "user": url.username,
-            "password": unquote_plus(url.password)
-            if url.password is not None
-            else None,
-            "schema": url.path[1:] or None,
-            "host": url.hostname,
-            "port": url.port,
-            **kwargs,
-        }
-
+    def _from_url(self, url: ParseResult, **kwarg_overrides) -> BaseBackend:
+        kwargs = {}
+        if url.username:
+            kwargs["user"] = url.username
+        if url.password:
+            kwargs["password"] = unquote_plus(url.password)
+        if url.hostname:
+            kwargs["host"] = url.hostname
+        if schema := url.path[1:]:
+            kwargs["schema"] = schema
+        if url.port:
+            kwargs["port"] = url.port
+        kwargs.update(kwarg_overrides)
         self._convert_kwargs(kwargs)
-
         return self.connect(**kwargs)
 
     @contextlib.contextmanager

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -206,16 +206,21 @@ class Backend(SQLBackend, CanListDatabase, PyArrowExampleLoader):
         # Set to ensure decimals come back as decimals
         oracledb.defaults.fetch_decimals = True
 
-    def _from_url(self, url: ParseResult, **kwargs):
-        self.do_connect(
-            user=url.username,
-            password=unquote_plus(url.password) if url.password is not None else None,
-            database=url.path.removeprefix("/"),
-            port=url.port,
-            **kwargs,
-        )
-
-        return self
+    def _from_url(self, url: ParseResult, **kwarg_overrides):
+        kwargs = {}
+        if url.username:
+            kwargs["user"] = url.username
+        if url.password:
+            kwargs["password"] = unquote_plus(url.password)
+        if url.hostname:
+            kwargs["host"] = url.hostname
+        if database := url.path.removeprefix("/"):
+            kwargs["database"] = database
+        if url.port:
+            kwargs["port"] = url.port
+        kwargs.update(kwarg_overrides)
+        self._convert_kwargs(kwargs)
+        return self.connect(**kwargs)
 
     @property
     def current_catalog(self) -> str:

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -119,13 +119,14 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, PyArrowExampleLoade
 
         treat_nan_as_null: bool = False
 
-    def _from_url(self, url: ParseResult, **kwargs) -> Backend:
+    def _from_url(self, url: ParseResult, **kwarg_overrides) -> Backend:
         """Construct a PySpark backend from a URL `url`."""
-        conf = SparkConf().setAll(kwargs.items())
-
+        kwargs = {}
         if database := url.path[1:]:
-            conf = conf.set("spark.sql.warehouse.dir", str(Path(database).absolute()))
+            kwargs["spark.sql.warehouse.dir"] = str(Path(database).absolute())
+        kwargs.update(kwarg_overrides)
 
+        conf = SparkConf().setAll(kwargs.items())
         builder = SparkSession.builder.config(conf=conf)
         session = builder.getOrCreate()
         return self.connect(session, **kwargs)

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -56,53 +56,23 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, NoExampleLoader):
     compiler = sc.risingwave.compiler
     supports_python_udfs = False
 
-    def _from_url(self, url: ParseResult, **kwargs):
-        """Connect to a backend using a URL `url`.
-
-        Parameters
-        ----------
-        url
-            URL with which to connect to a backend.
-        kwargs
-            Additional keyword arguments
-
-        Returns
-        -------
-        BaseBackend
-            A backend instance
-
-        """
+    def _from_url(self, url: ParseResult, **kwarg_overrides):
+        kwargs = {}
         database, *schema = url.path[1:].split("/", 1)
-        connect_args = {
-            "user": url.username,
-            "password": unquote_plus(url.password or ""),
-            "host": url.hostname,
-            "database": database or "",
-            "schema": schema[0] if schema else "",
-            "port": url.port,
-        }
-
-        kwargs.update(connect_args)
+        if url.username:
+            kwargs["user"] = url.username
+        if url.password:
+            kwargs["password"] = unquote_plus(url.password)
+        if url.hostname:
+            kwargs["host"] = url.hostname
+        if database:
+            kwargs["database"] = database
+        if url.port:
+            kwargs["port"] = url.port
+        if schema:
+            kwargs["schema"] = schema[0]
+        kwargs.update(kwarg_overrides)
         self._convert_kwargs(kwargs)
-
-        if "user" in kwargs and not kwargs["user"]:
-            del kwargs["user"]
-
-        if "host" in kwargs and not kwargs["host"]:
-            del kwargs["host"]
-
-        if "database" in kwargs and not kwargs["database"]:
-            del kwargs["database"]
-
-        if "schema" in kwargs and not kwargs["schema"]:
-            del kwargs["schema"]
-
-        if "password" in kwargs and kwargs["password"] is None:
-            del kwargs["password"]
-
-        if "port" in kwargs and kwargs["port"] is None:
-            del kwargs["port"]
-
         return self.connect(**kwargs)
 
     @contextlib.contextmanager


### PR DESCRIPTION
Before, if you did `ibis.postgres.connect("postgresql://user:password@host/my_db", schema="my_schema")`, then the schema in the url (in this case, it is blank) took precendence, and the backend would get a schema argument of "". Now, we consistently use the url as the defaults, but then always override them with what you pass explicitly as a kwarg.

This also just is a refactor and cleans up many implementations.

For example, it now makes it so that if a section of the url is missing, such as the password, then do_connect() is simply called without a "password" param. Before, for some backends, it was called with a default. This made it brittle in case we ever changed the default, or renamed params.

It also removes some unneeded boilderplate for snowflake, that is taken care of inside the do_connect(). in general, I think we should make it so that _from_url() is very minimal and does very little parameter coercion and setting defaults, and make do_connect() be responsible for that. If we do this, then we are more likely to keep consistency between the ibis.connect() and ibis.backend.connect() code paths.