### PR TITLE
fix(oracle): cast string to int for the precision and scale of decimal

### DIFF
--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -68,7 +68,7 @@ def metadata_row_to_type(
         and precision is not None
         and (scale is not None and scale > 0)
     ):
-        typ = dt.Decimal(precision=precision, scale=scale, nullable=nullable)
+        typ = dt.Decimal(precision=int(precision), scale=int(scale), nullable=nullable)
 
     else:
         typ = type_mapper.from_string(type_string, nullable=nullable)

--- a/ibis/backends/oracle/tests/test_datatypes.py
+++ b/ibis/backends/oracle/tests/test_datatypes.py
@@ -37,3 +37,18 @@ def test_string(typ, length):
     expected = sg.parse_one(typ, read="oracle", into=sge.DataType)
     result = OracleType.from_ibis(dt.String(length=length))
     assert result == expected
+
+
+def test_number(con):
+    con.drop_table("number_table", force=True)
+
+    with con.begin() as bind:
+        bind.execute(
+            """CREATE TABLE "number_table" ("number_8_2" NUMBER(8, 2), "number_8" NUMBER(8), "number_default" NUMBER)"""
+        )
+
+    raw_blob = con.table("number_table")
+
+    assert raw_blob.schema() == ibis.Schema(
+        dict(number_8_2="decimal(8, 2)", number_8="int64", number_default="int64")
+    )


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes
The type mapping for Oracle number type can't handle the number type with precision and scale.
For example, given a table like
```sql
CREATE TABLE "number_table" ("number_8_2" NUMBER(8, 2))
```
In the Ibis side, we will get `Number('8', '2')`, we should cast them to int from string.
<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->

## Issues closed
No corresponding issue currently.
<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->
