### PR TITLE
fix(datatype): convert from sqlglot VARCHAR(MAX) correctly

### DIFF
--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -220,9 +220,29 @@ class SqlglotType(TypeMapper):
             nullable=nullable,
         )
 
-    _from_sqlglot_NVARCHAR = _from_sqlglot_NCHAR = _from_sqlglot_CHAR = (
-        _from_sqlglot_FIXEDSTRING
-    ) = _from_sqlglot_VARCHAR
+    @classmethod
+    def _from_sqlglot_NVARCHAR(
+        cls, length: sge.DataTypeParam | None = None, nullable: bool | None = None
+    ) -> dt.String:
+        return cls._from_sqlglot_VARCHAR(length, nullable=nullable)
+
+    @classmethod
+    def _from_sqlglot_NCHAR(
+        cls, length: sge.DataTypeParam | None = None, nullable: bool | None = None
+    ) -> dt.String:
+        return cls._from_sqlglot_VARCHAR(length, nullable=nullable)
+
+    @classmethod
+    def _from_sqlglot_CHAR(
+        cls, length: sge.DataTypeParam | None = None, nullable: bool | None = None
+    ) -> dt.String:
+        return cls._from_sqlglot_VARCHAR(length, nullable=nullable)
+
+    @classmethod
+    def _from_sqlglot_FIXEDSTRING(
+        cls, length: sge.DataTypeParam | None = None, nullable: bool | None = None
+    ) -> dt.String:
+        return cls._from_sqlglot_VARCHAR(length, nullable=nullable)
 
     @classmethod
     def _from_sqlglot_MAP(
@@ -470,6 +490,10 @@ class SqlglotType(TypeMapper):
         this = getattr(typecode, dtype.geotype.upper())
         return sge.DataType(this=this, expressions=expressions)
 
+    # warning: this does early binding, so if you call eg `PostgresType._from_ibis_Point`
+    # this will resolve to `SqlglotType._from_ibis_SpecificGeometry`, not
+    # `PostgresType._from_ibis_SpecificGeometry`.
+    # At this point, not a problem, but be careful if you override this in subclasses.
     _from_ibis_Point = _from_ibis_LineString = _from_ibis_Polygon = (
         _from_ibis_MultiLineString
     ) = _from_ibis_MultiPoint = _from_ibis_MultiPolygon = _from_ibis_SpecificGeometry


### PR DESCRIPTION
Fixes https://github.com/ibis-project/ibis/issues/11191

I'd like to add a test for this. I think checking for roundtripping ibis.string -> sqglot.DataType -> ibis.string across all backends sounds like the best approach.