### PR TITLE
fix(duckdb): support materializing enum types to pyarrow

### DIFF
--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -1452,6 +1452,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, DirectExampleLoader):
                     col.to_pylist()
                     if (
                         pat.is_nested(col.type)
+                        or pat.is_dictionary(col.type)
                         or
                         # pyarrow / duckdb type null literals columns as int32?
                         # but calling `to_pylist()` will render it as None

--- a/ibis/backends/duckdb/tests/test_datatypes.py
+++ b/ibis/backends/duckdb/tests/test_datatypes.py
@@ -25,6 +25,7 @@ from ibis.backends.sql.datatypes import DuckDBType
             ("DATE", dt.date),
             ("DOUBLE", dt.float64),
             ("DECIMAL(10, 3)", dt.Decimal(10, 3)),
+            ("ENUM('a', 'b')", dt.string),
             ("INTEGER", dt.int32),
             ("INTERVAL", dt.Interval("us")),
             ("FLOAT", dt.float32),

--- a/ibis/backends/duckdb/tests/test_geospatial.py
+++ b/ibis/backends/duckdb/tests/test_geospatial.py
@@ -5,7 +5,6 @@ from operator import attrgetter, methodcaller
 
 import numpy.testing as npt
 import pandas.testing as tm
-import pyarrow as pa
 import pytest
 from packaging.version import parse as vparse
 from pytest import param
@@ -54,7 +53,9 @@ def test_geospatial_dwithin(assert_sql):
             "geometry_type",
             "geom_type",
             id="geometry_type",
-            marks=pytest.mark.xfail(raises=pa.lib.ArrowTypeError),
+            marks=pytest.mark.xfail(
+                raises=AssertionError, reason="capitalization is different"
+            ),
         ),
     ],
 )


### PR DESCRIPTION
See the added test, and the comment.

I'm not sure if this approach, of `pa_table.cast(ibis_table.schema().to_pyarrow())`, is too broad.
Instead of casting the entire pyarrow table to the expected schema, we could look for the specific case of
when the ibis type is `string` and the pyarrow type is `dictionary<values=string, indices=[intlike]>)`, and just convert those columns. For instance, this approach could be masking some other semantic mistake that we are making. I assume that pyarrow is smart enough to not actually perform computation unless the cast is really required, so I don't think this should be computationally wasteful.

This also makes it much more explicit that to get to pandas, we first convert to pyarrow, then to pandas, further cementing pyarrow as our first-class citizen, before pandas. I think I remember seeing this as a desire in a different issue/comment. It certainly makes it easier to reason about consistencies between to_pyarrow() and to_pandas()