### PR TITLE
feat(bigquery): Add the ability to specify a bigquery job ID

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -544,7 +544,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         catalog: str | None = None,
         force: bool = False,
         collate: str | None = None,
-        bigquery_job_id: str | None = None,
+        job_id: str | None = None,
         **options: Any,
     ) -> None:
         properties = [
@@ -564,7 +564,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             properties=sge.Properties(expressions=properties),
         )
 
-        self.raw_sql(stmt.sql(self.name), bigquery_job_id=bigquery_job_id)
+        self.raw_sql(stmt.sql(self.name), job_id=job_id)
 
     def drop_database(
         self,
@@ -574,7 +574,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         catalog: str | None = None,
         force: bool = False,
         cascade: bool = False,
-        bigquery_job_id: str | None = None,
+        job_id: str | None = None,
     ) -> None:
         """Drop a BigQuery dataset."""
         stmt = sge.Drop(
@@ -584,7 +584,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             cascade=cascade,
         )
 
-        self.raw_sql(stmt.sql(self.name), bigquery_job_id=bigquery_job_id)
+        self.raw_sql(stmt.sql(self.name), job_id=job_id)
 
     def table(
         self,
@@ -670,7 +670,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         return BigQuerySchema.to_ibis(job.schema)
 
     def raw_sql(
-        self, query: str, params=None, bigquery_job_id: str | None = None
+        self, query: str, params=None, job_id: str | None = None
     ) -> RowIterator:
         query_parameters = [
             bigquery_param(param.type(), value, param.get_name())
@@ -681,12 +681,12 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
 
         job_config = bq.job.QueryJobConfig(query_parameters=query_parameters or [])
 
-        if bigquery_job_id is not None:
+        if job_id is not None:
             return self.client.query(
                 query,
                 job_config=job_config,
                 project=self.billing_project,
-                job_id=bigquery_job_id,
+                job_id=job_id,
             ).result()
         else:
             return self.client.query_and_wait(
@@ -781,14 +781,14 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         *,
         params: Mapping[ir.Scalar, Any] | None = None,
         limit: int | str | None = None,
-        bigquery_job_id: str | None = None,
+        job_id: str | None = None,
         **kwargs: Any,
     ) -> RowIterator:
         self._run_pre_execute_hooks(table_expr)
         sql = self.compile(table_expr, limit=limit, params=params, **kwargs)
         self._log(sql)
 
-        return self.raw_sql(sql, params=params, bigquery_job_id=bigquery_job_id)
+        return self.raw_sql(sql, params=params, job_id=job_id)
 
     def to_pyarrow(
         self,
@@ -982,7 +982,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         partition_by: str | None = None,
         cluster_by: Iterable[str] | None = None,
         options: Mapping[str, Any] | None = None,
-        bigquery_job_id: str | None = None,
+        job_id: str | None = None,
     ) -> ir.Table:
         """Create a table in BigQuery.
 
@@ -1015,7 +1015,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         options
             BigQuery-specific table options; see the BigQuery documentation for
             details: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#table_option_list
-        bigquery_job_id
+        job_id
             Optional custom job ID; when specified, bigquery will use this job ID instead
             of a randomly generated one
 
@@ -1109,7 +1109,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
 
         sql = stmt.sql(self.name)
 
-        self.raw_sql(sql, bigquery_job_id=bigquery_job_id)
+        self.raw_sql(sql, job_id=job_id)
         return self.table(table.name, database=(table.catalog, table.db))
 
     def drop_table(
@@ -1119,7 +1119,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         *,
         database: tuple[str | str] | str | None = None,
         force: bool = False,
-        bigquery_job_id: str | None = None,
+        job_id: str | None = None,
     ) -> None:
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
@@ -1132,7 +1132,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             ),
             exists=force,
         )
-        self.raw_sql(stmt.sql(self.name), bigquery_job_id=bigquery_job_id)
+        self.raw_sql(stmt.sql(self.name), job_id=job_id)
 
     def create_view(
         self,
@@ -1142,7 +1142,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         *,
         database: str | None = None,
         overwrite: bool = False,
-        bigquery_job_id: str | None = None,
+        job_id: str | None = None,
     ) -> ir.Table:
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
@@ -1158,7 +1158,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             replace=overwrite,
         )
         self._run_pre_execute_hooks(obj)
-        self.raw_sql(stmt.sql(self.name), bigquery_job_id=bigquery_job_id)
+        self.raw_sql(stmt.sql(self.name), job_id=job_id)
         return self.table(name, database=(catalog, database))
 
     def drop_view(
@@ -1168,7 +1168,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         *,
         database: str | None = None,
         force: bool = False,
-        bigquery_job_id: str | None = None,
+        job_id: str | None = None,
     ) -> None:
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
@@ -1182,7 +1182,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             ),
             exists=force,
         )
-        self.raw_sql(stmt.sql(self.name), bigquery_job_id=bigquery_job_id)
+        self.raw_sql(stmt.sql(self.name), job_id=job_id)
 
     def _drop_cached_table(self, name):
         self.drop_table(

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -5,6 +5,7 @@ import datetime
 import decimal
 import os
 from urllib.parse import urlparse
+from uuid import uuid4
 
 import pandas as pd
 import pandas.testing as tm
@@ -546,3 +547,10 @@ def test_window_with_count_distinct(tmp_table, expr, query):
         .reset_index(drop=True)
     )
     tm.assert_frame_equal(result, expected)
+
+
+def test_create_job_with_custom_job_id(con):
+    job_id = f"test_job_id_{uuid4()}"
+    query = "SELECT 1"
+    result = con.raw_sql(query, bigquery_job_id=job_id)
+    assert result.job_id == job_id

--- a/ibis/backends/bigquery/tests/system/test_client.py
+++ b/ibis/backends/bigquery/tests/system/test_client.py
@@ -552,5 +552,5 @@ def test_window_with_count_distinct(tmp_table, expr, query):
 def test_create_job_with_custom_job_id(con):
     job_id = f"test_job_id_{uuid4()}"
     query = "SELECT 1"
-    result = con.raw_sql(query, bigquery_job_id=job_id)
+    result = con.raw_sql(query, job_id=job_id)
     assert result.job_id == job_id


### PR DESCRIPTION
 ## Description of changes

Add the ability to specify a bigquery job ID in a query, and when specified, ensure bigquery creates a job with that ID.  It does this by using `.query` when a job ID is specified, which takes a job ID to use in creating the bigquery job, versus `.query_and_wait` which does not because it may not create a job.

## Issues closed

* Resolves #11229 
