### PR TITLE
fix(bigquery): maintain custom client project id when provided

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -410,7 +410,8 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             An instance of the BigQuery backend.
 
         """
-        default_project_id = client.project if client is not None else project_id
+        client_project_id = client.project if client is not None else None
+        default_project_id = None
 
         # Only need `credentials` to create a `client` and
         # `storage_client`, so only one or the other needs to be set.
@@ -443,7 +444,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
                 use_local_webserver=auth_local_webserver,
             )
 
-        project_id = project_id or default_project_id
+        project_id = client_project_id or project_id or default_project_id
 
         (
             self.data_project,

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -446,6 +446,13 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
 
         project_id = client_project_id or project_id or default_project_id
 
+        if project_id is None:
+            raise ValueError(
+                "Project ID could not be identified. "
+                "Provide either explicit `project_id`, `client` with project, "
+                "or don't provide an explicit `credentials` object."
+            )
+
         (
             self.data_project,
             self.billing_project,

--- a/ibis/backends/bigquery/tests/system/test_connect.py
+++ b/ibis/backends/bigquery/tests/system/test_connect.py
@@ -274,3 +274,8 @@ def test_project_id_from_default(default_credentials):
     # `connect()` re-evaluates default credentials and sets project_id since no client nor explicit project_id is provided
     con = ibis.bigquery.connect()
     assert con.project_id == default_project_id
+
+
+def test_project_id_missing(credentials):
+    with pytest.raises(ValueError, match="Project ID could not be identified.*"):
+        ibis.bigquery.connect(credentials=credentials)

--- a/ibis/backends/bigquery/tests/system/test_connect.py
+++ b/ibis/backends/bigquery/tests/system/test_connect.py
@@ -256,3 +256,21 @@ def test_create_table_from_memtable_needs_quotes(project_id, dataset_id, credent
         assert t.schema() == ibis.schema(schema)
     finally:
         con.drop_table(name)
+
+
+def test_project_id_from_arg(project_id):
+    con = ibis.bigquery.connect(project_id=project_id)
+    assert con.project_id == project_id
+
+
+def test_project_id_from_client(project_id):
+    bq_client = bq.Client(project=project_id)
+    con = ibis.bigquery.connect(client=bq_client, project_id="not-a-real-project")
+    assert con.project_id == project_id
+
+
+def test_project_id_from_default(default_credentials):
+    _, default_project_id = default_credentials
+    # `connect()` re-evaluates default credentials and sets project_id since no client nor explicit project_id is provided
+    con = ibis.bigquery.connect()
+    assert con.project_id == default_project_id


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

<!--
Write a description of the changes commensurate with the pull request's scope.

Extremely small changes such as fixing typos do not need a description.
-->
Fixes resolution order of project id during `connect()`/`do_connect()` when a custom BigQuery Client is provided. Previously, if only a `client` was provided, the system default project id was used by Ibis instead of the one provided with the `client`.

Project id resolution order now makes intuitive sense when providing any combination of `client`, `credential`, and `project_id`.
1. `client.project` (if defined)
2. `project_id` (if provided)
3. `default_project_id` (acquired during credential creation)


## Issues closed

<!--
Please add Resolves #<issue number> (no angle brackets) if this pull request
resolves any outstanding issues.

For example, if your pull requests resolves issues 1000, 2000 and 3000 write:

* Resolves #1000
* Resolves #2000
* Resolves #3000

If your pull request doesn't resolve any issues, you can delete this section
entirely, including the `## Issues closed` section header.
-->

* Resolves #11230 