### PR TITLE
docs(support-matrix): do not escape the HTML links

### DIFF
--- a/docs/backends/support/matrix.qmd
+++ b/docs/backends/support/matrix.qmd
@@ -147,5 +147,6 @@ show(
     ordering=False,
     paging=False,
     buttons=["copy", "excel", "csv"],
+    allow_html=True,
 )
 ```


### PR DESCRIPTION
## Description of changes

The links in the tables aren't rendering. This probably just broke 5 days ago; see https://mwouts.github.io/itables/options/allow_html.html.

## Issues closed

Noticed it yesterday; also reported by @filipeo2-mck today. No issue raised.