### PR TITLE
fix: make column.unnest().topk() work

### DIFF
--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+import ibis.common.exceptions as com
+from ibis.backends.tests.errors import MySQLOperationalError
+
+
+def combine_marks(marks: list) -> callable:
+    def decorator(func):
+        for mark in reversed(marks):
+            func = mark(func)
+        return func
+
+    return decorator
+
+
+NO_ARRAY_SUPPORT_MARKS = [
+    pytest.mark.never(
+        ["sqlite", "mysql", "exasol"], reason="No array support", raises=Exception
+    ),
+    pytest.mark.never(
+        ["mssql"],
+        reason="No array support",
+        raises=(
+            com.UnsupportedBackendType,
+            com.OperationNotDefinedError,
+            AssertionError,
+        ),
+    ),
+    pytest.mark.never(
+        ["mysql"],
+        reason="No array support",
+        raises=(
+            com.UnsupportedBackendType,
+            com.OperationNotDefinedError,
+            MySQLOperationalError,
+        ),
+    ),
+    pytest.mark.notyet(
+        ["impala"],
+        reason="No array support",
+        raises=(
+            com.UnsupportedBackendType,
+            com.OperationNotDefinedError,
+            com.TableNotFound,
+        ),
+    ),
+    pytest.mark.notimpl(["druid", "oracle"], raises=Exception),
+]
+NO_ARRAY_SUPPORT = combine_marks(NO_ARRAY_SUPPORT_MARKS)
+
+
+NO_STRUCT_SUPPORT_MARKS = [
+    pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
+    pytest.mark.notyet(["impala"]),
+    pytest.mark.notimpl(["druid", "oracle", "exasol"]),
+]
+NO_STRUCT_SUPPORT = combine_marks(NO_STRUCT_SUPPORT_MARKS)
+
+NO_MAP_SUPPORT_MARKS = [
+    pytest.mark.never(
+        ["sqlite", "mysql", "mssql"], reason="Unlikely to ever add map support"
+    ),
+    pytest.mark.notyet(
+        ["bigquery", "impala"], reason="Backend doesn't yet implement map types"
+    ),
+    pytest.mark.notimpl(
+        ["exasol", "polars", "druid", "oracle"],
+        reason="Not yet implemented in ibis",
+    ),
+]
+NO_MAP_SUPPORT = combine_marks(NO_MAP_SUPPORT_MARKS)
+
+NO_JSON_SUPPORT_MARKS = [
+    pytest.mark.never(["impala"], reason="doesn't support JSON and never will"),
+    pytest.mark.notyet(["clickhouse"], reason="upstream is broken"),
+    pytest.mark.notimpl(["datafusion", "exasol", "mssql", "druid", "oracle"]),
+]
+NO_JSON_SUPPORT = combine_marks(NO_JSON_SUPPORT_MARKS)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -15,6 +15,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
+from ibis.backends.tests.conftest import NO_ARRAY_SUPPORT_MARKS
 from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
     DatabricksServerOperationError,
@@ -39,39 +40,7 @@ np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 tm = pytest.importorskip("pandas.testing")
 
-pytestmark = [
-    pytest.mark.never(
-        ["sqlite", "mysql", "exasol"], reason="No array support", raises=Exception
-    ),
-    pytest.mark.never(
-        ["mssql"],
-        reason="No array support",
-        raises=(
-            com.UnsupportedBackendType,
-            com.OperationNotDefinedError,
-            AssertionError,
-        ),
-    ),
-    pytest.mark.never(
-        ["mysql"],
-        reason="No array support",
-        raises=(
-            com.UnsupportedBackendType,
-            com.OperationNotDefinedError,
-            MySQLOperationalError,
-        ),
-    ),
-    pytest.mark.notyet(
-        ["impala"],
-        reason="No array support",
-        raises=(
-            com.UnsupportedBackendType,
-            com.OperationNotDefinedError,
-            com.TableNotFound,
-        ),
-    ),
-    pytest.mark.notimpl(["druid", "oracle"], raises=Exception),
-]
+pytestmark = NO_ARRAY_SUPPORT_MARKS
 
 # NB: We don't check whether results are numpy arrays or lists because this
 # varies across backends. At some point we should unify the result type to be

--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -16,6 +16,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datatypes as dt
 import ibis.selectors as s
 from ibis import _
+from ibis.backends.tests.conftest import NO_ARRAY_SUPPORT
 from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
     ExaQueryError,
@@ -2388,6 +2389,38 @@ def test_topk_counts_null(con):
     tkf = tk.filter(_.x.isnull())[1]
     result = con.to_pyarrow(tkf)
     assert result[0].as_py() == 1
+
+
+@NO_ARRAY_SUPPORT
+def test_topk_unnest_count(con: ibis.BaseBackend):
+    t = con.create_table(
+        ibis.util.gen_name("topk_unnest_count"),
+        {"x": [[1, 2, 3], [1, 2, None], []]},
+        temp=True,
+    )
+    tk = t.x.unnest().topk(name="n")
+    n_1s = tk.filter(_.x == 1)["n"].as_scalar()
+    result = con.to_pyarrow(n_1s).as_py()
+    assert result == 2
+
+    tk = t.x.unnest().topk()
+    n_1s = tk.filter(_.x == 1)["x_count"].as_scalar()
+    result = con.to_pyarrow(n_1s).as_py()
+    assert result == 2
+
+
+@pytest.mark.xfail(reason="The unnest is not placed in the right place in the query")
+def test_topk_unnest_max(con: ibis.BaseBackend):
+    t = con.create_table(
+        ibis.util.gen_name("topk_counts_unnest"),
+        {"x": [[1, 2, 3], [1, 2, None], []]},
+        temp=True,
+    )
+    v = t.x.unnest()
+    tk = v.topk(by=v.max(), name="n")
+    n_1s = tk.filter(_.x == 1)["n"].as_scalar()
+    result = con.to_pyarrow(n_1s).as_py()
+    assert result == 1
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_json.py
+++ b/ibis/backends/tests/test_json.py
@@ -8,17 +8,14 @@ import pytest
 from packaging.version import parse as vparse
 
 import ibis.expr.types as ir
+from ibis.backends.tests.conftest import NO_JSON_SUPPORT_MARKS
 from ibis.backends.tests.errors import PySparkPythonException
 from ibis.conftest import IS_SPARK_REMOTE
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 
-pytestmark = [
-    pytest.mark.never(["impala"], reason="doesn't support JSON and never will"),
-    pytest.mark.notyet(["clickhouse"], reason="upstream is broken"),
-    pytest.mark.notimpl(["datafusion", "exasol", "mssql", "druid", "oracle"]),
-]
+pytestmark = NO_JSON_SUPPORT_MARKS
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -6,6 +6,7 @@ from pytest import param
 import ibis
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
+from ibis.backends.tests.conftest import NO_MAP_SUPPORT_MARKS
 from ibis.backends.tests.errors import (
     PsycoPg2InternalError,
     Py4JJavaError,
@@ -17,18 +18,7 @@ pd = pytest.importorskip("pandas")
 tm = pytest.importorskip("pandas.testing")
 pa = pytest.importorskip("pyarrow")
 
-pytestmark = [
-    pytest.mark.never(
-        ["sqlite", "mysql", "mssql"], reason="Unlikely to ever add map support"
-    ),
-    pytest.mark.notyet(
-        ["bigquery", "impala"], reason="Backend doesn't yet implement map types"
-    ),
-    pytest.mark.notimpl(
-        ["exasol", "polars", "druid", "oracle"],
-        reason="Not yet implemented in ibis",
-    ),
-]
+pytestmark = NO_MAP_SUPPORT_MARKS
 
 mark_notyet_postgres = pytest.mark.notyet(
     "postgres", reason="only supports string -> string"

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -9,6 +9,7 @@ from pytest import param
 import ibis
 import ibis.expr.datatypes as dt
 from ibis import util
+from ibis.backends.tests.conftest import NO_STRUCT_SUPPORT_MARKS
 from ibis.backends.tests.errors import (
     DatabricksServerOperationError,
     PolarsColumnNotFoundError,
@@ -25,11 +26,7 @@ np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 tm = pytest.importorskip("pandas.testing")
 
-pytestmark = [
-    pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
-    pytest.mark.notyet(["impala"]),
-    pytest.mark.notimpl(["druid", "oracle", "exasol"]),
-]
+pytestmark = NO_STRUCT_SUPPORT_MARKS
 
 
 @pytest.mark.parametrize(

--- a/ibis/expr/types/generic.py
+++ b/ibis/expr/types/generic.py
@@ -2215,18 +2215,14 @@ class Column(Value, _FixedTextJupyterMixin):
         """
         from ibis.expr.types.relations import bind
 
+        if by is None:
+            return self.as_table().topk(k=k, name=name)
+
         try:
-            (table,) = self.op().relations
+            (table_op,) = self.op().relations
         except ValueError:
             raise com.IbisTypeError("TopK must depend on exactly one table.")
-
-        table = table.to_expr()
-
-        if by is None and name is None:
-            # if `by` is something more complex, the _count doesn't make sense.
-            name = f"{self.get_name()}_count"
-        if by is None:
-            by = lambda t: t.count()
+        table: ibis.Table = table_op.to_expr()
 
         (metric,) = bind(table, by)
         if name is not None:


### PR DESCRIPTION
Also simplifies the implementation of Column.topk() and
makes it re-use the implementation of Table.topk()

This does NOT fix `column.unnest().topk(by=<anything besides None>)`. This is a rare case so I decided to just punt on implementing it

This also factors out the common marks for when arrays, structs, maps, json are not supported by a backend. I wanted to reuse that mark, and I bet there are many existing tests that could benefit from this utilility.