### PR TITLE
feat: make `name` param optional to create_table()

### DIFF
--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1248,8 +1248,7 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
     @abc.abstractmethod
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: ibis.Schema | None = None,
@@ -1263,6 +1262,7 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
         ----------
         name
             Name of the new table.
+            If None, a unique name will be generated.
         obj
             An Ibis table expression or pandas table that will be used to
             extract the schema and the data of the new table. If not provided,
@@ -1283,6 +1283,13 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
         Table
             The table that was created.
         """
+
+    @staticmethod
+    def _create_table_name(name: str | None) -> str:
+        """Util for subclasses to generate a table name."""
+        if name is None:
+            name = util.gen_name("table")
+        return name
 
     @abc.abstractmethod
     def drop_table(

--- a/ibis/backends/athena/__init__.py
+++ b/ibis/backends/athena/__init__.py
@@ -70,8 +70,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -93,7 +92,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
         Parameters
         ----------
         name
-            Name of the table to create
+            Name of the table to create. If not provided, a name will be generated automatically.
         obj
             The data with which to populate the table; optional, but one of `obj`
             or `schema` must be specified
@@ -123,6 +122,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
         stored_as
             The file format in which to store table data. Defaults to parquet.
         """
+        name = self._create_table_name(name)
         if overwrite is not None:
             raise com.UnsupportedOperationError(
                 "Amazon Athena does not support REPLACE syntax, nor does it "

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -973,8 +973,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -997,7 +996,8 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         Parameters
         ----------
         name
-            Name of the table to create
+            Name of the table to create.
+            If not provided, a unique name will be generated.
         obj
             The data with which to populate the table; optional, but one of `obj`
             or `schema` must be specified
@@ -1032,6 +1032,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         Table
             The table that was just created
         """
+        name = self._create_table_name(name)
         if obj is None and schema is None:
             raise com.IbisError("One of the `schema` or `obj` parameter is required")
         if schema is not None:

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -624,8 +624,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -649,7 +648,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectExampleLoader):
         Parameters
         ----------
         name
-            Name of the table to create
+            Name of the table to create. If not provided, a unique name will be generated.
         obj
             Optional data to create the table with
         schema
@@ -680,6 +679,8 @@ class Backend(SQLBackend, CanCreateDatabase, DirectExampleLoader):
         Table
             The new table
         """
+        name = self._create_table_name(name)
+
         if temp and overwrite:
             raise com.IbisInputError(
                 "Cannot specify both `temp=True` and `overwrite=True` for ClickHouse"

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -117,8 +117,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -139,7 +138,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         Parameters
         ----------
         name
-            Name of the table to create
+            Name of the table to create. If not provided, a unique name will be generated.
         obj
             The data with which to populate the table; optional, but at least
             one of `obj` or `schema` must be specified
@@ -165,6 +164,8 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         tblproperties
             Table properties
         """
+        name = self._create_table_name(name)
+
         if temp:
             raise exc.UnsupportedOperationError("Temporary tables not yet supported")
 

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -572,8 +572,7 @@ class Backend(
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -587,7 +586,7 @@ class Backend(
         database: str | None = None,
         temp: bool = False,
         overwrite: bool = False,
-    ):
+    ) -> ir.Table:
         """Create a table in DataFusion.
 
         Parameters
@@ -606,9 +605,15 @@ class Backend(
         temp
             Create a temporary table
         overwrite
-            If `True`, replace the table if it already exists, otherwise fail
-            if the table exists
+            If `True`, replace the table if it already exists, otherwise fail if the table exists
+
+        Returns
+        -------
+        Table
+            The table that was just created
         """
+        name = self._create_table_name(name)
+
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
         if schema is not None:

--- a/ibis/backends/druid/__init__.py
+++ b/ibis/backends/druid/__init__.py
@@ -190,8 +190,7 @@ class Backend(SQLBackend, NoExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: sch.Schema | None = None,

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -94,8 +94,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, DirectExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -132,7 +131,13 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, DirectExampleLoader):
         overwrite
             If `True`, replace the table if it already exists, otherwise fail
             if the table exists
+
+        Returns
+        -------
+        Table
+            The table that was just created
         """
+        name = self._create_table_name(name)
         table_loc = self._to_sqlglot_table(database)
 
         if getattr(table_loc, "catalog", False) and temp:

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -324,8 +324,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -343,7 +342,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
         Parameters
         ----------
         name
-            Name of the table to create
+            Name of the table to create. If not provided, a unique name will be generated.
         obj
             The data with which to populate the table; optional, but at least
             one of `obj` or `schema` must be specified
@@ -357,7 +356,14 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
             if the table exists
         temp
             Create a temporary table (not supported)
+
+        Returns
+        -------
+        Table
+            The table that was just created
         """
+        name = self._create_table_name(name)
+
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
         if schema is not None:

--- a/ibis/backends/flink/__init__.py
+++ b/ibis/backends/flink/__init__.py
@@ -425,8 +425,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl, PyArrowExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: pd.DataFrame | pa.Table | ir.Table | None = None,
         *,
         schema: sch.Schema | None = None,
@@ -453,7 +452,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl, PyArrowExampleLoader):
         Parameters
         ----------
         name
-            Name of the new table.
+            Name of the new table. If not provided, a unique name will be generated.
         obj
             An Ibis table expression, pandas DataFrame, or PyArrow Table that will
             be used to extract the schema and the data of the new table. An
@@ -493,6 +492,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoUrl, PyArrowExampleLoader):
 
         import ibis.expr.types as ir
 
+        name = self._create_table_name(name)
         if obj is None and schema is None:
             raise exc.IbisError("`schema` or `obj` is required")
         if isinstance(obj, (pd.DataFrame, pa.Table)) and not temp:

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -607,8 +607,7 @@ GO"""
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -626,7 +625,7 @@ GO"""
         Parameters
         ----------
         name
-            Name of the new table.
+            Name of the new table. If not provided, a unique name will be generated.
         obj
             An Ibis table expression or pandas table that will be used to
             extract the schema and the data of the new table. If not provided,
@@ -654,6 +653,8 @@ GO"""
         Table
             The table that was created.
         """
+        name = self._create_table_name(name)
+
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
         if schema is not None:

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -381,8 +381,7 @@ class Backend(SQLBackend, CanCreateDatabase, PyArrowExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -395,6 +394,7 @@ class Backend(SQLBackend, CanCreateDatabase, PyArrowExampleLoader):
         temp: bool = False,
         overwrite: bool = False,
     ) -> ir.Table:
+        name = self._create_table_name(name)
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
         if schema is not None:

--- a/ibis/backends/polars/__init__.py
+++ b/ibis/backends/polars/__init__.py
@@ -317,8 +317,7 @@ class Backend(BaseBackend, NoUrl, DirectExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -333,6 +332,8 @@ class Backend(BaseBackend, NoUrl, DirectExampleLoader):
         temp: bool | None = None,
         overwrite: bool = False,
     ) -> ir.Table:
+        name = self._create_table_name(name)
+
         if database is not None:
             raise com.IbisError(
                 "Passing `database` to the Polars backend's `create_table()` method is "

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -583,8 +583,7 @@ ORDER BY a.attnum ASC"""
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -617,7 +616,14 @@ ORDER BY a.attnum ASC"""
         overwrite
             If `True`, replace the table if it already exists, otherwise fail
             if the table exists
+
+        Returns
+        -------
+        Table
+            The table that was just created
         """
+        name = self._create_table_name(name)
+
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
         if schema is not None:

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -475,8 +475,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, NoExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -499,7 +498,7 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, NoExampleLoader):
         Parameters
         ----------
         name
-            Name of the table to create
+            Name of the table to create. If not provided, a unique name will be generated.
         obj
             The data with which to populate the table; optional, but at least
             one of `obj` or `schema` must be specified
@@ -529,6 +528,8 @@ class Backend(SQLBackend, CanListCatalog, CanCreateDatabase, NoExampleLoader):
         Table
             Table expression
         """
+        name = self._create_table_name(name)
+
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
         if schema is not None:

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -746,8 +746,7 @@ $$ {defn["source"]} $$"""
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -766,7 +765,7 @@ $$ {defn["source"]} $$"""
         Parameters
         ----------
         name
-            Name of the table to create
+            Name of the table to create. If not provided, a unique name will be generated.
         obj
             The data with which to populate the table; optional, but at least
             one of `obj` or `schema` must be specified
@@ -784,7 +783,13 @@ $$ {defn["source"]} $$"""
         comment
             Add a comment to the table
 
+        Returns
+        -------
+        Table
+            The table that was just created
         """
+        name = self._create_table_name(name)
+
         if obj is None and schema is None:
             raise ValueError("Either `obj` or `schema` must be specified")
         if schema is not None:

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -423,8 +423,7 @@ class Backend(SQLBackend, UrlFromPath, PyArrowExampleLoader):
 
     def create_table(
         self,
-        name: str,
-        /,
+        name: str | None = None,
         obj: ir.Table
         | pd.DataFrame
         | pa.Table
@@ -442,7 +441,7 @@ class Backend(SQLBackend, UrlFromPath, PyArrowExampleLoader):
         Parameters
         ----------
         name
-            Name of the table to create
+            Name of the table to create. If not provided, a unique name will be generated.
         obj
             The data with which to populate the table; optional, but at least
             one of `obj` or `schema` must be specified
@@ -457,7 +456,14 @@ class Backend(SQLBackend, UrlFromPath, PyArrowExampleLoader):
         overwrite
             If `True`, replace the table if it already exists, otherwise fail
             if the table exists
+
+        Returns
+        -------
+        Table
+            The table that was just created
         """
+        name = self._create_table_name(name)
+
         if schema is None and obj is None:
             raise ValueError("Either `obj` or `schema` must be specified")
 


### PR DESCRIPTION
Sometimes, I just need to load some temp data into a backend, but I don't care what the table name is. now `conn.create_table(obj=data, temp=True)` is a nice short way to do that.