### PR TITLE
feat(bigquery): add job_id_prefix to functions that produce bigquery loadjobs

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -333,12 +333,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         return self.table(table_name, database=(catalog, database))
 
     def read_parquet(
-        self,
-        path: str | Path,
-        /,
-        *,
-        table_name: str | None = None,
-        **kwargs: Any,
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ):
         """Read Parquet data into a BigQuery table.
 
@@ -367,12 +362,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         )
 
     def read_csv(
-        self,
-        path: str | Path,
-        /,
-        *,
-        table_name: str | None = None,
-        **kwargs: Any,
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Read CSV data into a BigQuery table.
 
@@ -384,7 +374,6 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             Path to a CSV file on GCS or the local filesystem. Globs are supported.
         table_name
             Optional table name
-
         kwargs
             Additional keyword arguments passed to
             `google.cloud.bigquery.LoadJobConfig`.
@@ -400,11 +389,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             skip_leading_rows=1,
             **kwargs,
         )
-        return self._read_file(
-            path,
-            table_name=table_name,
-            job_config=job_config,
-        )
+        return self._read_file(path, table_name=table_name, job_config=job_config)
 
     def read_json(
         self,
@@ -888,7 +873,6 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             Name of the attached database that the table is located in.
         overwrite
             If `True` then replace existing contents of table.
-
         """
         table_loc = self._to_sqlglot_table(database)
         catalog, db = self._to_catalog_db_tuple(table_loc)
@@ -898,31 +882,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         if db is None:
             db = self.current_database
 
-        return super().insert(
-            name,
-            obj,
-            database=(catalog, db),
-            overwrite=overwrite,
-        )
-
-    def truncate_table(self, name: str, /, *, database: str | None = None) -> None:
-        """Delete all rows from a table.
-
-        Parameters
-        ----------
-        name
-            The name of the table to truncate.
-        database
-            Name of the attached database that the table is located in.
-        """
-        table_loc = self._to_sqlglot_table(database)
-        catalog, db = self._to_catalog_db_tuple(table_loc)
-
-        ident = sg.table(name, db=db, catalog=catalog, quoted=self.compiler.quoted).sql(
-            self.dialect
-        )
-        with self._safe_raw_sql(f"TRUNCATE TABLE {ident}"):
-            pass
+        return super().insert(name, obj, database=(catalog, db), overwrite=overwrite)
 
     def _to_query(
         self,
@@ -952,12 +912,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         table_expr = expr.as_table()
         schema = table_expr.schema() - ibis.schema({"_TABLE_SUFFIX": "string"})
 
-        query = self._to_query(
-            table_expr,
-            params=params,
-            limit=limit,
-            **kwargs,
-        )
+        query = self._to_query(table_expr, params=params, limit=limit, **kwargs)
         table = query.to_arrow(
             progress_bar_type=None, bqstorage_client=self.storage_client
         )
@@ -980,12 +935,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         schema = table_expr.schema() - ibis.schema({"_TABLE_SUFFIX": "string"})
         colnames = list(schema.names)
 
-        query = self._to_query(
-            table_expr,
-            params=params,
-            limit=limit,
-            **kwargs,
-        )
+        query = self._to_query(table_expr, params=params, limit=limit, **kwargs)
         batch_iter = query.to_arrow_iterable(bqstorage_client=self.storage_client)
         return pa.ipc.RecordBatchReader.from_batches(
             schema.to_pyarrow(),
@@ -1028,12 +978,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
 
         table_expr = expr.as_table()
         schema = table_expr.schema() - ibis.schema({"_TABLE_SUFFIX": "string"})
-        query = self._to_query(
-            table_expr,
-            params=params,
-            limit=limit,
-            **kwargs,
-        )
+        query = self._to_query(table_expr, params=params, limit=limit, **kwargs)
         df = query.to_arrow(
             progress_bar_type=None, bqstorage_client=self.storage_client
         ).to_pandas(timestamp_as_object=True)

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -749,10 +749,11 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         return None
 
     def _get_schema_using_query(self, query: str) -> sch.Schema:
-        job = self._client_query(
+        job = self.client.query(
             query,
             job_config=bq.QueryJobConfig(dry_run=True, use_query_cache=False),
             project=self.billing_project,
+            job_id_prefix=self._generate_job_id_prefix(),
         )
         return BigQuerySchema.to_ibis(job.schema)
 

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -392,12 +392,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         return self._read_file(path, table_name=table_name, job_config=job_config)
 
     def read_json(
-        self,
-        path: str | Path,
-        /,
-        *,
-        table_name: str | None = None,
-        **kwargs: Any,
+        self, path: str | Path, /, *, table_name: str | None = None, **kwargs: Any
     ) -> ir.Table:
         """Read newline-delimited JSON data into a BigQuery table.
 
@@ -424,11 +419,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             autodetect=True,
             **kwargs,
         )
-        return self._read_file(
-            path,
-            table_name=table_name,
-            job_config=job_config,
-        )
+        return self._read_file(path, table_name=table_name, job_config=job_config)
 
     def _from_url(self, url: ParseResult, **kwarg_overrides):
         kwargs = {}
@@ -779,7 +770,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         return None
 
     def _get_schema_using_query(self, query: str) -> sch.Schema:
-        job = self.client.query(
+        job = self._client_query(
             query,
             job_config=bq.QueryJobConfig(dry_run=True, use_query_cache=False),
             project=self.billing_project,
@@ -796,11 +787,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
 
         job_config = bq.job.QueryJobConfig(query_parameters=query_parameters or [])
 
-        self._client_query(
-            query,
-            job_config=job_config,
-            project=self.billing_project,
-        )
+        self._client_query(query, job_config=job_config, project=self.billing_project)
 
     @property
     def current_catalog(self) -> str:

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -187,8 +187,9 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         else:
             # If a job_id_prefix is provided, use the method that allows for job_id_prefix
             # to be passed in
-            kwargs["job_id_prefix"] = job_id_prefix
-            return self.client.query(query, **kwargs).result()
+            return self.client.query(
+                query, job_id_prefix=job_id_prefix, **kwargs
+            ).result()
 
     def _client_load_table_from_dataframe(
         self,
@@ -197,10 +198,12 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         **kwargs,
     ) -> bq.LoadJob:
         """Load a DataFrame into a BigQuery table, possibly with a job_id_prefix."""
-
-        kwargs["job_id_prefix"] = self._generate_job_id_prefix()
-
-        return self.client.load_table_from_dataframe(dataframe, destination, **kwargs)
+        return self.client.load_table_from_dataframe(
+            dataframe,
+            destination,
+            job_id_prefix=self._generate_job_id_prefix(),
+            **kwargs,
+        )
 
     def _client_load_table_from_file(
         self,
@@ -209,10 +212,12 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         **kwargs,
     ) -> bq.LoadJob:
         """Load data from a file into a BigQuery table, possibly with a job_id_prefix."""
-
-        kwargs["job_id_prefix"] = self._generate_job_id_prefix()
-
-        return self.client.load_table_from_file(file_obj, destination, **kwargs)
+        return self.client.load_table_from_file(
+            file_obj,
+            destination,
+            job_id_prefix=self._generate_job_id_prefix(),
+            **kwargs,
+        )
 
     def _client_load_table_from_uri(
         self,
@@ -221,9 +226,12 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         **kwargs,
     ) -> bq.LoadJob:
         """Load data from a URI into a BigQuery table, possibly with a job_id_prefix."""
-
-        kwargs["job_id_prefix"] = self._generate_job_id_prefix()
-        return self.client.load_table_from_uri(source_uris, destination, **kwargs)
+        return self.client.load_table_from_uri(
+            source_uris,
+            destination,
+            job_id_prefix=self._generate_job_id_prefix(),
+            **kwargs,
+        )
 
     def _finalize_memtable(self, name: str) -> None:
         table_ref = bq.TableReference(self._session_dataset, name)
@@ -277,7 +285,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
 
         # drop the table if it exists
         #
-        # we could do this with write_disposition = WRITE_TRUNCATE but then the
+        # we could do this with write_disposition = WRITE_TRUNCATE but then
         # concurrent append jobs aren't possible
         #
         # dropping the table first means all write_dispositions can be

--- a/ibis/backends/bigquery/tests/system/conftest.py
+++ b/ibis/backends/bigquery/tests/system/conftest.py
@@ -89,6 +89,22 @@ def con2(credentials, project_id, dataset_id):
 
 
 @pytest.fixture(scope="session")
+def con3(credentials, project_id, dataset_id):
+    con = ibis.bigquery.connect(
+        project_id=project_id,
+        dataset_id=dataset_id,
+        credentials=credentials,
+        generate_job_id_prefix=lambda: "ibis_test_",
+    )
+    try:
+        con.sql("SELECT 1")
+    except gexc.Forbidden:
+        pytest.skip("Cannot access BigQuery")
+    else:
+        return con
+
+
+@pytest.fixture(scope="session")
 def alltypes(con):
     return con.table("functional_alltypes")
 


### PR DESCRIPTION
## Description of changes

I realized that my changes in https://github.com/ibis-project/ibis/pull/11233 and https://github.com/ibis-project/ibis/pull/11237 I completely focused on directly-created query jobs and completely overlooked functions which create bigquery load jobs and other queries, mainly in the process of uploading data.  Granted, the directly-created query jobs comprise the bulk of what I am concerned with, but it seemed proper to include other types of queries in this feature.

However, this has proved a bit stickier than anticipated.  The main situation I wasn't quite sure how to address was where one function call potentially creates several bigquery jobs, such as a job to truncate or drop a table if it already exists, a job to upload the data to a (temporary?) table in bq, and a job to select everything from that table and insert it into the target table.  I chose to address this with more specificity rather than less, creating kwargs such as `drop_job_id_prefix` and `insert_job_id_prefix`, and have attempted to be consistent about applying that, but I could be convinced that this is overkill and we should just pass along one `job_id_prefix` for any jobs stemming from a certain ibis function call.  (This would be ok for my purposes at least.)  

I believe I have added the kwargs to all relevant methods consistently, but it is worth a close review.  A notable exception is I did not add the kwargs to the `_run_pre_execute_hooks` call from `create_view`, since I assume that should not be creating a load job to upload data since it's creating a view, but that assumption could use verification.

It's notable that this required essentially copying the parent class' `insert`, `register_in_memory_tables`, and other methods in order to pass down a job_id_prefix variable.

In addition, since these methods do not return anything - there are no "results" from a drop table query that you would generally desire to return - I'm not immediately seeing a straightforward way to write unit tests for these.  But I have yet to explore some options.

## Issues closed

* Resolves #11229
