### PR TITLE
fix: deal with null literals in `Struct.__getitem__`

### DIFF
--- a/ibis/expr/rules.py
+++ b/ibis/expr/rules.py
@@ -92,7 +92,7 @@ def _promote_integral_binop(exprs, op):
     bounds, dtypes = [], []
     for arg in exprs:
         dtypes.append(arg.dtype)
-        if isinstance(arg, ops.Literal):
+        if isinstance(arg, ops.Literal) and arg.value is not None:
             bounds.append([arg.value])
         else:
             bounds.append(arg.dtype.bounds)

--- a/ibis/expr/types/structs.py
+++ b/ibis/expr/types/structs.py
@@ -215,7 +215,10 @@ class StructValue(Value):
             return op.values[op.names.index(name)].to_expr()
         # and then do the same if the underlying value is a field access
         elif isinstance(op, ops.Literal):
-            return ops.Literal(op.value[name], dtype=self.fields[name]).to_expr()
+            return ops.Literal(
+                op.value[name] if op.value is not None else None,
+                dtype=self.fields[name],
+            ).to_expr()
         else:
             return ops.StructField(self, name).to_expr()
 

--- a/ibis/tests/expr/test_struct.py
+++ b/ibis/tests/expr/test_struct.py
@@ -43,6 +43,14 @@ def test_struct_getattr():
         expr.bad  # # noqa: B018
 
 
+def test_null_literal_getitem():
+    expr = ibis.literal(None, type="struct<a: int64, b: string>")
+    field = expr["a"]
+    assert isinstance(field, ir.IntegerValue)
+    assert isinstance(field.op(), ops.Literal)
+    assert field.op().value is None
+
+
 def test_struct_tab_completion():
     t = ibis.table([("struct_col", "struct<my_field: string, for: int64>")])
     # Only valid python identifiers in getattr completions

--- a/ibis/tests/expr/test_value_exprs.py
+++ b/ibis/tests/expr/test_value_exprs.py
@@ -793,6 +793,14 @@ def test_literal_promotions(table, op, name, case, ex_type):
     assert result.type() == dt.dtype(ex_type)
 
 
+def test_null_literal_promotions():
+    added = ibis.literal(12, "int8") + ibis.literal(None, type="int16")
+    assert added.type() == dt.int32
+
+    added = ibis.null("int8") + ibis.literal(None, type="int16")
+    assert added.type() == dt.int32
+
+
 @pytest.mark.parametrize(
     ("op", "left_fn", "right_fn", "ex_type"),
     [


### PR DESCRIPTION
ops.Literal.value can be None if it's a null literal. We weren't dealing with this case in `StructValue.__getitem__`.

When I made this fix, it also revealed a different bug when promoting the types of eg `ops.Literal(<int>) + ops.Literal(<int>)`, so I fixed that bug as well.