### PR TITLE
fix: forward ops.First.include_null when translating to FirstValue in window functions

### DIFF
--- a/ibis/backends/sql/compilers/base.py
+++ b/ibis/backends/sql/compilers/base.py
@@ -18,8 +18,6 @@ import ibis.common.patterns as pats
 import ibis.expr.datatypes as dt
 import ibis.expr.operations as ops
 from ibis.backends.sql.rewrites import (
-    FirstValue,
-    LastValue,
     add_one_to_nth_value_input,
     add_order_by_to_empty_ranking_window_functions,
     empty_in_values_right_side,
@@ -337,13 +335,11 @@ class SQLGlotCompiler(abc.ABC):
         ops.Degrees: "degrees",
         ops.DenseRank: "dense_rank",
         ops.Exp: "exp",
-        FirstValue: "first_value",
         ops.GroupConcat: "group_concat",
         ops.IfElse: "if",
         ops.IsInf: "isinf",
         ops.IsNan: "isnan",
         ops.JSONGetItem: "json_extract",
-        LastValue: "last_value",
         ops.Levenshtein: "levenshtein",
         ops.Ln: "ln",
         ops.Log10: "log",
@@ -1208,6 +1204,18 @@ class SQLGlotCompiler(abc.ABC):
         return self.f[type(op).__name__.lower()](*args)
 
     visit_Lag = visit_Lead = visit_LagLead
+
+    def visit_FirstValue(self, op, *, arg, include_null):
+        if include_null:
+            return sge.RespectNulls(this=self.f.first_value(arg))
+        else:
+            return sge.IgnoreNulls(this=self.f.first_value(arg))
+
+    def visit_LastValue(self, op, *, arg, include_null):
+        if include_null:
+            return sge.RespectNulls(this=self.f.last_value(arg))
+        else:
+            return sge.IgnoreNulls(this=self.f.last_value(arg))
 
     def visit_Argument(self, op, *, name: str, shape, dtype):
         return sg.to_identifier(op.param)

--- a/ibis/backends/sql/compilers/sqlite.py
+++ b/ibis/backends/sql/compilers/sqlite.py
@@ -251,6 +251,20 @@ class SQLiteCompiler(SQLGlotCompiler):
         func = "_ibis_last_include_null" if include_null else "_ibis_last"
         return self.agg[func](arg, where=where, order_by=order_by)
 
+    def visit_FirstValue(self, op, *, arg, include_null):
+        if not include_null:
+            raise com.UnsupportedOperationError(
+                "SQLite does not support `include_null=False` for FirstValue"
+            )
+        return self.f.first_value(arg)
+
+    def visit_LastValue(self, op, *, arg, include_null):
+        if not include_null:
+            raise com.UnsupportedOperationError(
+                "SQLite does not support `include_null=False` for LastValue"
+            )
+        return self.f.last_value(arg)
+
     def visit_Variance(self, op, *, arg, how, where):
         return self.agg[f"_ibis_var_{op.how}"](arg, where=where)
 

--- a/ibis/backends/sql/rewrites.py
+++ b/ibis/backends/sql/rewrites.py
@@ -73,6 +73,7 @@ class FirstValue(ops.Analytic):
     """Retrieve the first element."""
 
     arg: ops.Column[dt.Any]
+    include_null: bool = False
 
     @attribute
     def dtype(self):
@@ -84,6 +85,7 @@ class LastValue(ops.Analytic):
     """Retrieve the last element."""
 
     arg: ops.Column[dt.Any]
+    include_null: bool = False
 
     @attribute
     def dtype(self):
@@ -204,7 +206,7 @@ def first_to_firstvalue(_, **kwargs):
             "in a window function"
         )
     klass = FirstValue if isinstance(_.func, ops.First) else LastValue
-    return _.copy(func=klass(_.func.arg))
+    return _.copy(func=klass(_.func.arg, _.func.include_null))
 
 
 @replace(p.Alias)

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/athena/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/athena/out.sql
@@ -15,16 +15,8 @@ WITH "t5" AS (
         "t2"."field_of_study",
         "t2"."years",
         "t2"."degrees",
-        FIRST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "earliest_degrees",
-        LAST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "latest_degrees"
+        FIRST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+        LAST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
       FROM (
         SELECT
           "t1"."field_of_study",

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/bigquery/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/bigquery/out.sql
@@ -15,16 +15,8 @@ WITH `t5` AS (
         `t2`.`field_of_study`,
         `t2`.`years`,
         `t2`.`degrees`,
-        FIRST_VALUE(`t2`.`degrees`) OVER (
-          PARTITION BY `t2`.`field_of_study`
-          ORDER BY `t2`.`years` ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS `earliest_degrees`,
-        LAST_VALUE(`t2`.`degrees`) OVER (
-          PARTITION BY `t2`.`field_of_study`
-          ORDER BY `t2`.`years` ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS `latest_degrees`
+        FIRST_VALUE(`t2`.`degrees` IGNORE NULLS) OVER (PARTITION BY `t2`.`field_of_study` ORDER BY `t2`.`years` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS `earliest_degrees`,
+        LAST_VALUE(`t2`.`degrees` IGNORE NULLS) OVER (PARTITION BY `t2`.`field_of_study` ORDER BY `t2`.`years` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS `latest_degrees`
       FROM (
         SELECT
           `t1`.`field_of_study`,

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/clickhouse/out.sql
@@ -15,16 +15,8 @@ WITH "t5" AS (
         "t2"."field_of_study" AS "field_of_study",
         "t2"."years" AS "years",
         "t2"."degrees" AS "degrees",
-        FIRST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "earliest_degrees",
-        LAST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "latest_degrees"
+        FIRST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+        LAST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
       FROM (
         SELECT
           "t1"."field_of_study" AS "field_of_study",

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/datafusion/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/datafusion/out.sql
@@ -24,16 +24,8 @@ WITH "t5" AS (
           "t2"."field_of_study",
           "t2"."years",
           "t2"."degrees",
-          FIRST_VALUE("t2"."degrees") OVER (
-            PARTITION BY "t2"."field_of_study"
-            ORDER BY "t2"."years" ASC
-            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-          ) AS "earliest_degrees",
-          LAST_VALUE("t2"."degrees") OVER (
-            PARTITION BY "t2"."field_of_study"
-            ORDER BY "t2"."years" ASC
-            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-          ) AS "latest_degrees"
+          FIRST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+          LAST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
         FROM (
           SELECT
             "t1"."field_of_study",

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/duckdb/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/duckdb/out.sql
@@ -15,16 +15,8 @@ WITH "t5" AS (
         "t2"."field_of_study",
         "t2"."years",
         "t2"."degrees",
-        FIRST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "earliest_degrees",
-        LAST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "latest_degrees"
+        FIRST_VALUE("t2"."degrees" IGNORE NULLS) OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+        LAST_VALUE("t2"."degrees" IGNORE NULLS) OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
       FROM (
         SELECT
           "t1"."field_of_study",

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/postgres/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/postgres/out.sql
@@ -15,16 +15,8 @@ WITH "t5" AS (
         "t2"."field_of_study",
         "t2"."years",
         "t2"."degrees",
-        FIRST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "earliest_degrees",
-        LAST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "latest_degrees"
+        FIRST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+        LAST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
       FROM (
         SELECT
           "t1"."field_of_study",

--- a/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/trino/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_union_aliasing/trino/out.sql
@@ -15,16 +15,8 @@ WITH "t5" AS (
         "t2"."field_of_study",
         "t2"."years",
         "t2"."degrees",
-        FIRST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "earliest_degrees",
-        LAST_VALUE("t2"."degrees") OVER (
-          PARTITION BY "t2"."field_of_study"
-          ORDER BY "t2"."years" ASC
-          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-        ) AS "latest_degrees"
+        FIRST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "earliest_degrees",
+        LAST_VALUE("t2"."degrees") IGNORE NULLS OVER (PARTITION BY "t2"."field_of_study" ORDER BY "t2"."years" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS "latest_degrees"
       FROM (
         SELECT
           "t1"."field_of_study",

--- a/ibis/backends/tests/test_window.py
+++ b/ibis/backends/tests/test_window.py
@@ -1286,3 +1286,78 @@ def test_duplicate_ordered_sum(con):
     # final position, since the *output* order doesn't depend on ORDER BY
     # provided by the user
     assert result[2:] in ([60, 100], [70, 100], [100, 60], [100, 70])
+
+
+mark_sqlite_no_collect = pytest.mark.never(
+    ["sqlite"],
+    raises=com.OperationNotDefinedError,
+    reason="sqlite doesn't have array types",
+)
+mark_sqlite_no_ignore_nulls = pytest.mark.never(
+    "sqlite",
+    reason="sqlite doesn't support the `IGNORE NULLS` option for first_value()",
+)
+
+
+@pytest.mark.notimpl(
+    ["polars"],
+    raises=com.OperationNotDefinedError,
+    reason="window functions aren't yet implemented for the polars backend",
+)
+@pytest.mark.parametrize(
+    "aggname,include_null,expected",
+    [
+        ("first", True, [None, None, 6, 6]),
+        pytest.param(
+            "first",
+            False,
+            [5, 5, 6, 6],
+            marks=[mark_sqlite_no_ignore_nulls],
+        ),
+        ("last", True, [5, 5, None, None]),
+        pytest.param(
+            "last",
+            False,
+            [5, 5, 6, 6],
+            marks=[mark_sqlite_no_ignore_nulls],
+        ),
+        pytest.param(
+            "collect",
+            True,
+            [[None, 5], [None, 5], [6, None], [6, None]],
+            marks=[mark_sqlite_no_collect],
+        ),
+        pytest.param(
+            "collect",
+            False,
+            [[5], [5], [6], [6]],
+            marks=[
+                # pytest.mark.notyet(
+                #     ["datafusion"],
+                #     raises=AssertionError,
+                #     reason="gives the same as for include_null=True, but should be different",
+                # ),
+                mark_sqlite_no_collect,
+            ],
+        ),
+    ],
+)
+def test_ignore_null(con, aggname, include_null, expected):
+    t = ibis.memtable(
+        [
+            (0, 0, None),
+            (0, 1, 5),
+            (1, 2, 6),
+            (1, 3, None),
+        ],
+        schema={"group_by": "int64", "order_by": "int64", "val": "int64"},
+    )
+    agg = getattr(t.val, aggname)
+    t = t.mutate(
+        val_first=agg(include_null=include_null).over(
+            group_by="group_by", order_by="order_by"
+        )
+    ).order_by("order_by")
+    print(ibis.to_sql(t, dialect="datafusion"))
+    result = con.to_pyarrow(t.val_first).to_pylist()
+    assert expected == result


### PR DESCRIPTION
Before, `t.mutate(t.x.first(ignore_nulls=True).over(group_by=y))` would behave the same as `t.mutate(t.x.first(ignore_nulls=False).over(group_by=y))`. Now they behave differently for some backends.

I am seeing what CI says before updating the tests/implementation for the other backends