### PR TITLE
refactor(test): centralize marks for no array, struct, etc support

### DIFF
--- a/ibis/backends/tests/conftest.py
+++ b/ibis/backends/tests/conftest.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+import ibis.common.exceptions as com
+from ibis.backends.tests.errors import MySQLOperationalError
+
+
+def combine_marks(marks: list) -> callable:
+    def decorator(func):
+        for mark in reversed(marks):
+            func = mark(func)
+        return func
+
+    return decorator
+
+
+NO_ARRAY_SUPPORT_MARKS = [
+    pytest.mark.never(
+        ["sqlite", "mysql", "exasol"], reason="No array support", raises=Exception
+    ),
+    pytest.mark.never(
+        ["mssql"],
+        reason="No array support",
+        raises=(
+            com.UnsupportedBackendType,
+            com.OperationNotDefinedError,
+            AssertionError,
+        ),
+    ),
+    pytest.mark.never(
+        ["mysql"],
+        reason="No array support",
+        raises=(
+            com.UnsupportedBackendType,
+            com.OperationNotDefinedError,
+            MySQLOperationalError,
+        ),
+    ),
+    pytest.mark.notyet(
+        ["impala"],
+        reason="No array support",
+        raises=(
+            com.UnsupportedBackendType,
+            com.OperationNotDefinedError,
+            com.TableNotFound,
+        ),
+    ),
+    pytest.mark.notimpl(["druid", "oracle"], raises=Exception),
+]
+NO_ARRAY_SUPPORT = combine_marks(NO_ARRAY_SUPPORT_MARKS)
+
+
+NO_STRUCT_SUPPORT_MARKS = [
+    pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
+    pytest.mark.notyet(["impala"]),
+    pytest.mark.notimpl(["druid", "oracle", "exasol"]),
+]
+NO_STRUCT_SUPPORT = combine_marks(NO_STRUCT_SUPPORT_MARKS)
+
+NO_MAP_SUPPORT_MARKS = [
+    pytest.mark.never(
+        ["sqlite", "mysql", "mssql"], reason="Unlikely to ever add map support"
+    ),
+    pytest.mark.notyet(
+        ["bigquery", "impala"], reason="Backend doesn't yet implement map types"
+    ),
+    pytest.mark.notimpl(
+        ["exasol", "polars", "druid", "oracle"],
+        reason="Not yet implemented in ibis",
+    ),
+]
+NO_MAP_SUPPORT = combine_marks(NO_MAP_SUPPORT_MARKS)
+
+NO_JSON_SUPPORT_MARKS = [
+    pytest.mark.never(["impala"], reason="doesn't support JSON and never will"),
+    pytest.mark.notyet(["clickhouse"], reason="upstream is broken"),
+    pytest.mark.notimpl(["datafusion", "exasol", "mssql", "druid", "oracle"]),
+]
+NO_JSON_SUPPORT = combine_marks(NO_JSON_SUPPORT_MARKS)

--- a/ibis/backends/tests/test_array.py
+++ b/ibis/backends/tests/test_array.py
@@ -15,6 +15,7 @@ import ibis.common.exceptions as com
 import ibis.expr.datashape as ds
 import ibis.expr.datatypes as dt
 import ibis.expr.types as ir
+from ibis.backends.tests.conftest import NO_ARRAY_SUPPORT_MARKS
 from ibis.backends.tests.errors import (
     ClickHouseDatabaseError,
     DatabricksServerOperationError,
@@ -39,39 +40,7 @@ np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 tm = pytest.importorskip("pandas.testing")
 
-pytestmark = [
-    pytest.mark.never(
-        ["sqlite", "mysql", "exasol"], reason="No array support", raises=Exception
-    ),
-    pytest.mark.never(
-        ["mssql"],
-        reason="No array support",
-        raises=(
-            com.UnsupportedBackendType,
-            com.OperationNotDefinedError,
-            AssertionError,
-        ),
-    ),
-    pytest.mark.never(
-        ["mysql"],
-        reason="No array support",
-        raises=(
-            com.UnsupportedBackendType,
-            com.OperationNotDefinedError,
-            MySQLOperationalError,
-        ),
-    ),
-    pytest.mark.notyet(
-        ["impala"],
-        reason="No array support",
-        raises=(
-            com.UnsupportedBackendType,
-            com.OperationNotDefinedError,
-            com.TableNotFound,
-        ),
-    ),
-    pytest.mark.notimpl(["druid", "oracle"], raises=Exception),
-]
+pytestmark = NO_ARRAY_SUPPORT_MARKS
 
 # NB: We don't check whether results are numpy arrays or lists because this
 # varies across backends. At some point we should unify the result type to be

--- a/ibis/backends/tests/test_json.py
+++ b/ibis/backends/tests/test_json.py
@@ -8,17 +8,14 @@ import pytest
 from packaging.version import parse as vparse
 
 import ibis.expr.types as ir
+from ibis.backends.tests.conftest import NO_JSON_SUPPORT_MARKS
 from ibis.backends.tests.errors import PySparkPythonException
 from ibis.conftest import IS_SPARK_REMOTE
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 
-pytestmark = [
-    pytest.mark.never(["impala"], reason="doesn't support JSON and never will"),
-    pytest.mark.notyet(["clickhouse"], reason="upstream is broken"),
-    pytest.mark.notimpl(["datafusion", "exasol", "mssql", "druid", "oracle"]),
-]
+pytestmark = NO_JSON_SUPPORT_MARKS
 
 
 @pytest.mark.notyet(

--- a/ibis/backends/tests/test_map.py
+++ b/ibis/backends/tests/test_map.py
@@ -6,6 +6,7 @@ from pytest import param
 import ibis
 import ibis.common.exceptions as exc
 import ibis.expr.datatypes as dt
+from ibis.backends.tests.conftest import NO_MAP_SUPPORT_MARKS
 from ibis.backends.tests.errors import (
     PsycoPg2InternalError,
     Py4JJavaError,
@@ -17,18 +18,7 @@ pd = pytest.importorskip("pandas")
 tm = pytest.importorskip("pandas.testing")
 pa = pytest.importorskip("pyarrow")
 
-pytestmark = [
-    pytest.mark.never(
-        ["sqlite", "mysql", "mssql"], reason="Unlikely to ever add map support"
-    ),
-    pytest.mark.notyet(
-        ["bigquery", "impala"], reason="Backend doesn't yet implement map types"
-    ),
-    pytest.mark.notimpl(
-        ["exasol", "polars", "druid", "oracle"],
-        reason="Not yet implemented in ibis",
-    ),
-]
+pytestmark = NO_MAP_SUPPORT_MARKS
 
 mark_notyet_postgres = pytest.mark.notyet(
     "postgres", reason="only supports string -> string"

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -9,6 +9,7 @@ from pytest import param
 import ibis
 import ibis.expr.datatypes as dt
 from ibis import util
+from ibis.backends.tests.conftest import NO_STRUCT_SUPPORT_MARKS
 from ibis.backends.tests.errors import (
     DatabricksServerOperationError,
     PolarsColumnNotFoundError,
@@ -25,11 +26,7 @@ np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
 tm = pytest.importorskip("pandas.testing")
 
-pytestmark = [
-    pytest.mark.never(["mysql", "sqlite", "mssql"], reason="No struct support"),
-    pytest.mark.notyet(["impala"]),
-    pytest.mark.notimpl(["druid", "oracle", "exasol"]),
-]
+pytestmark = NO_STRUCT_SUPPORT_MARKS
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Now tests can reference these easily if they rely on one of these datatypes

I wanted to use this in https://github.com/ibis-project/ibis/pull/11314 to mark the test case that relies on .collect()