### PR TITLE
fix(bigquery): undo removal of `job_id_prefix` functionality from `raw_sql`

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -777,7 +777,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
         with contextlib.suppress(AttributeError):
             query = query.sql(self.dialect)
 
-        return self.client.query_and_wait(
+        return self._client_query(
             query, job_config=job_config, project=self.billing_project
         )
 


### PR DESCRIPTION
Fixes the failing bigquery tests related to adding a `job_id` prefix. There was just a small spot where an upstream merge clobbered previous work. Thankfully, we had tests for this!