### PR TITLE
feat: add `Schema.from_sqlglot` method to produce an Ibis schema from SQLGlot

### DIFF
--- a/ibis/backends/sql/datatypes.py
+++ b/ibis/backends/sql/datatypes.py
@@ -862,7 +862,6 @@ class SnowflakeType(SqlglotType):
         length: sge.Literal | None = None,
         nullable: bool | None = None,
     ) -> dt.Array:
-        assert value_type is None
         return dt.Array(dt.json, nullable=nullable)
 
     @classmethod


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to Ibis!

Please ensure that your pull request title matches the conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Description of changes

I wanted to tackle #11310 by adding a new class method for Schema.

I wrote a unit test that tries a ton of types (it may be overkill), but it seems to be working and
my manual testing has been successful too. 

Should this also support a dialect argument? I wasn't sure if this should be a requirement for
the end user (It's defaulting to duckdb now to map the types).

## Issues (partially) closed

#11310 - I can tackle renaming to_sqlglot to to_sqlglot_columns_definition and 
change the behavior of the former in a separate PR.