### PR TITLE
feat: add Expr.to_sql()

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -301,8 +301,10 @@ quartodoc:
             # types
             - name: Value
               package: ibis.expr.types.generic
+              include_inherited: true
             - name: Column
               package: ibis.expr.types.generic
+              include_inherited: true
             - name: Deferred
               package: ibis.common.deferred
             - name: Scalar

--- a/ibis/backends/__init__.py
+++ b/ibis/backends/__init__.py
@@ -1329,8 +1329,8 @@ class BaseBackend(abc.ABC, _FileIOHandler, CacheHandler):
         limit: str | int | None = None,
         params: Mapping[ir.Expr, Any] | None = None,
         **kwargs: Any,
-    ) -> Any:
-        """Compile an expression.
+    ) -> str | pl.LazyFrame:
+        """Compile `expr` to a SQL string (for SQL backends) or a LazyFrame (for the polars backend).
 
         Parameters
         ----------

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -529,7 +529,7 @@ class Expr(Immutable, Coercible):
         [`Value.to_sql()`](./expression-generic.qmd#ibis.expr.types.generic.Value.to_sql)
         [`Table.to_sql()`](./expression-tables.qmd#ibis.expr.types.relations.Table.to_sql)
         """
-        return self._find_backend(use_default=True).compile(
+        return self._find_backend().compile(
             self, limit=limit, params=params, pretty=pretty
         )
 

--- a/ibis/expr/types/core.py
+++ b/ibis/expr/types/core.py
@@ -453,17 +453,17 @@ class Expr(Immutable, Coercible):
         >>> expr = t.mutate(c=t.a + t.b)
         >>> expr.to_sql()  # doctest: +SKIP
         SELECT
-        "t0"."a",
-        "t0"."b",
-        "t0"."a" + "t0"."b" AS "c"
+          "t0"."a",
+          "t0"."b",
+          "t0"."a" + "t0"."b" AS "c"
         FROM "t" AS "t0"
 
         You can also specify the SQL dialect to use for compilation:
         >>> expr.to_sql(dialect="mysql")  # doctest: +SKIP
         SELECT
-        `t0`.`a`,
-        `t0`.`b`,
-        `t0`.`a` + `t0`.`b` AS `c`
+          `t0`.`a`,
+          `t0`.`b`,
+          `t0`.`a` + `t0`.`b` AS `c`
         FROM `t` AS `t0`
 
         See Also


### PR DESCRIPTION
This is mostly an ergonomics thing.

I don't want to have to `import ibis; ibis.to_sql(e)`, I want to just do `e.to_sql()`

This also makes the docstring to compile() less confusing, and adds these methods to Columns and Values in the docs.