### PR TITLE
 fix(distinct): allow deleting rows when `on` is unspecified 

### DIFF
--- a/ibis/backends/tests/test_generic.py
+++ b/ibis/backends/tests/test_generic.py
@@ -2548,3 +2548,9 @@ def test_order_by_preservation(con):
     tbl = ibis.memtable([{"id": 1, "col": "a"}, {"id": 2, "col": "b"}])
     expr = tbl.order_by("id").select("col").distinct()
     assert len(con.to_pandas(expr)) == 2
+
+
+def test_distinct_delete_duplicates_entirely(con):
+    expr = ibis.memtable({"c1": [1, 2, 3, 6, 6]}).distinct(keep=None)
+    res = con.execute(expr)
+    assert set(res["c1"].tolist()) == {1, 2, 3}

--- a/ibis/expr/types/relations.py
+++ b/ibis/expr/types/relations.py
@@ -1199,9 +1199,12 @@ class Table(Expr, FixedTextJupyterMixin):
 
         if on is None:
             # dedup everything
-            if keep != "first":
+            if keep is None:  # remove duplicates
+                return self.aggregate(by=self.columns, having=lambda t: t.count() == 1)
+            elif keep == "last":
                 raise com.IbisError(
-                    f"Only keep='first' (the default) makes sense when deduplicating all columns; got keep={keep!r}"
+                    "Only keep='first' and keep=`None` are well-defined when deduplicating "
+                    f"all columns; got keep={keep!r}"
                 )
             return ops.Distinct(self).to_expr()
 

--- a/ibis/tests/expr/test_table.py
+++ b/ibis/tests/expr/test_table.py
@@ -1979,7 +1979,7 @@ def test_invalid_deferred():
         ops.Greatest((t.value, ibis._.lagged_value))
 
 
-@pytest.mark.parametrize("keep", ["last", None])
+@pytest.mark.parametrize("keep", ["last"])
 def test_invalid_distinct(keep):
     t = ibis.table(dict(a="int"), name="t")
     with pytest.raises(com.IbisError, match="Only keep='first'"):


### PR DESCRIPTION
Fixes #11382.