### PR TITLE
fix(trino/athena): ensure that `DateDiff` operands are in the correct order

### DIFF
--- a/ci/schema/trino.sql
+++ b/ci/schema/trino.sql
@@ -1,3 +1,5 @@
+SET SESSION task_concurrency = 1;
+
 CREATE TABLE IF NOT EXISTS hive.default.diamonds (
     "carat" DOUBLE,
     "cut" VARCHAR,

--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -498,8 +498,8 @@ class TrinoCompiler(SQLGlotCompiler):
         # trino truncates _after_ the delta, whereas many other backends
         # truncate each operand
         return sge.DateDiff(
-            this=self.f.date_trunc(part, right),
-            expression=self.f.date_trunc(part, left),
+            this=self.f.date_trunc(part, left),
+            expression=self.f.date_trunc(part, right),
             unit=part,
         )
 


### PR DESCRIPTION
Fixes failing Trino and Athena CI due to reversed operands in `DateDiff`