### PR TITLE
fix(trino/athena): ensure that regex extract compiler dispatch method is spelled correctly

### DIFF
--- a/ibis/backends/sql/compilers/trino.py
+++ b/ibis/backends/sql/compilers/trino.py
@@ -587,7 +587,7 @@ class TrinoCompiler(SQLGlotCompiler):
     def visit_StringContains(self, op, *, haystack, needle):
         return self.f.strpos(haystack, needle) > 0
 
-    def visit_RegexpExtract(self, op, *, arg, pattern, index):
+    def visit_RegexExtract(self, op, *, arg, pattern, index):
         # sqlglot doesn't support the third `group` argument for trino so work
         # around that limitation using an anonymous function
         return self.f.anon.regexp_extract(arg, pattern, index)


### PR DESCRIPTION
Fix spelling of athena and trino regular expression extraction method