### PR TITLE
ci(postgres): prevent hanging by limiting the deadlock surface area likely created by all the thread blas creates

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
+# since this isn't a script we allow unused variables to be set
+#
+# shellcheck disable=SC2034
 FLINK_VERSION=1.20.0
 CLOUDSDK_ACTIVE_CONFIG_NAME=ibis-gbq
 GOOGLE_CLOUD_PROJECT="$CLOUDSDK_ACTIVE_CONFIG_NAME"
@@ -6,3 +9,26 @@ MYSQL_PWD="ibis"
 MSSQL_SA_PASSWORD="1bis_Testing!"
 DRUID_URL="druid://localhost:8082/druid/v2/sql"
 SPARK_CONFIG=./docker/spark-connect/conf.properties
+
+# avoid creating a large thread surface area, to avoid deadlocks in the test
+# suite
+#
+# one of the BLASen is interacting with Python's GC to create a situation where
+# condition variables are not being released, causing a deadlock
+#
+# seems to be tickled at especially high rates when testing the postgres
+# backend but this deadlock has been observed when testing mysql, sqlite,
+# duckdb and mssql
+#
+# since we allow development on different systems, we use a pretty big hammer
+# and set everything to only allow use of a single thread
+OPENBLAS_NUM_THREADS=1
+MKL_NUM_THREADS=1
+BLAS_NUM_THREADS=1
+OMP_NUM_THREADS=1
+VECLIB_MAXIMUM_THREADS=1
+
+# perhaps there's also some polars and/or (py)arrow interaction with the Python
+# GC too?
+ARROW_NUM_THREADS=1
+POLARS_MAX_THREADS=1

--- a/.github/workflows/ibis-backends.yml
+++ b/.github/workflows/ibis-backends.yml
@@ -512,6 +512,13 @@ jobs:
           IBIS_TEST_IMPALA_HOST: localhost
           IBIS_TEST_IMPALA_PORT: 21050
           IBIS_EXAMPLES_DATA: ${{ runner.temp }}/examples-${{ matrix.backend.name }}-${{ matrix.os }}-${{ steps.install_python.outputs.python-version }}
+          OPENBLAS_NUM_THREADS: 1
+          MKL_NUM_THREADS: 1
+          BLAS_NUM_THREADS: 1
+          OMP_NUM_THREADS: 1
+          VECLIB_MAXIMUM_THREADS: 1
+          POLARS_MAX_THREADS: 1
+          ARROW_IO_THREADS: 1
 
       - name: "run serial tests: ${{ matrix.backend.name }}"
         if: matrix.backend.serial

--- a/docker/postgres/debug.sql
+++ b/docker/postgres/debug.sql
@@ -8,6 +8,6 @@ SELECT
   "query"
 FROM "pg_stat_activity"
 WHERE
-  "backend_type" = 'client backend' AND "state" = 'idle in transaction'
+  "wait_event_type" = 'Client'
 ORDER BY
   "backend_start"

--- a/ibis/conftest.py
+++ b/ibis/conftest.py
@@ -21,6 +21,16 @@ CI = os.environ.get("CI") is not None
 SPARK_REMOTE = os.environ.get("SPARK_REMOTE")
 IS_SPARK_REMOTE = bool(SPARK_REMOTE)
 
+if CI:
+    try:
+        import pyarrow as pa
+        import pyarrow_hotfix  # noqa: F401
+    except ModuleNotFoundError:
+        pass
+    else:
+        pa.set_cpu_count(1)
+        pa.set_io_thread_count(1)
+
 
 @pytest.fixture(autouse=True)
 def add_ibis(monkeypatch, doctest_namespace):


### PR DESCRIPTION
This PR addresses an issue where the Python GC seems to interact poorly with blas threads (or vice versa).

Disclaimer: I used Claude Opus 4 to work through parts of this. It was helpful as a rubber duck, suggesting some possible debugging paths to go down, a few of which were not fruitful at all, but ultimately this one proved useful.