### PR TITLE
feat(polars): support is_in queries from uncorrelated tables

### DIFF
--- a/ibis/backends/clickhouse/tests/snapshots/test_select/test_array_join_in_subquery/out.sql
+++ b/ibis/backends/clickhouse/tests/snapshots/test_select/test_array_join_in_subquery/out.sql
@@ -1,7 +1,7 @@
 SELECT
-  "t0"."id" IN (
+  CAST("t0"."id" IN (
     SELECT
       arrayJoin("t1"."ids") AS "ids"
     FROM "way_view" AS "t1"
-  ) AS "InSubquery(id)"
+  ) AS Nullable(Bool)) AS "InSubquery(id)"
 FROM "node_view" AS "t0"

--- a/ibis/backends/sql/compilers/clickhouse.py
+++ b/ibis/backends/sql/compilers/clickhouse.py
@@ -880,5 +880,10 @@ class ClickHouseCompiler(SQLGlotCompiler):
             sg.or_(arg.is_(NULL), key.is_(NULL)), NULL, self.f.mapContains(arg, key)
         )
 
+    def visit_InSubquery(self, op, *, needle, rel):
+        # clickhouse returns `a IN b` as integers so we have to cast to get
+        # booleans
+        return self.cast(super().visit_InSubquery(op, needle=needle, rel=rel), op.dtype)
+
 
 compiler = ClickHouseCompiler()

--- a/ibis/backends/tests/snapshots/test_sql/test_isin_bug/clickhouse/out.sql
+++ b/ibis/backends/tests/snapshots/test_sql/test_isin_bug/clickhouse/out.sql
@@ -1,9 +1,9 @@
 SELECT
-  "t0"."x" IN (
+  CAST("t0"."x" IN (
     SELECT
       *
     FROM "t" AS "t0"
     WHERE
       "t0"."x" > 2
-  ) AS "InSubquery(x)"
+  ) AS Nullable(Bool)) AS "InSubquery(x)"
 FROM "t" AS "t0"

--- a/ibis/backends/tests/test_struct.py
+++ b/ibis/backends/tests/test_struct.py
@@ -12,7 +12,6 @@ from ibis import util
 from ibis.backends.tests.conftest import NO_STRUCT_SUPPORT_MARKS
 from ibis.backends.tests.errors import (
     DatabricksServerOperationError,
-    PolarsColumnNotFoundError,
     PsycoPg2InternalError,
     PsycoPg2ProgrammingError,
     PsycoPgSyntaxError,
@@ -21,7 +20,7 @@ from ibis.backends.tests.errors import (
     PyAthenaOperationalError,
     PySparkAnalysisException,
 )
-from ibis.common.exceptions import IbisError
+from ibis.common.exceptions import IbisError, UnsupportedOperationError
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
@@ -240,8 +239,8 @@ def test_keyword_fields(con, nullable):
 )
 @pytest.mark.notyet(
     ["polars"],
-    raises=PolarsColumnNotFoundError,
-    reason="doesn't seem to support IN-style subqueries on structs",
+    raises=UnsupportedOperationError,
+    reason="doesn't support IN-style subqueries on structs",
 )
 @pytest.mark.xfail_version(
     pyspark=["pyspark<3.5"],


### PR DESCRIPTION
Add support for isin-style queries on unrelated dataframes. I could not figure out a way to do this that does not trigger computation. Definitely open to alternative implementations here. cc @MarcoGorelli.