### PR TITLE
ci: remove unused junitxml report in testing

### DIFF
--- a/.github/workflows/ibis-main.yml
+++ b/.github/workflows/ibis-main.yml
@@ -162,7 +162,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: run doctests
-        run: just doctest --junitxml=junit.xml --cov=ibis --cov-report=xml:coverage.xml
+        run: just doctest --cov=ibis --cov-report=xml:coverage.xml
 
       - name: check for dead fixtures
         run: uv run --all-extras --group tests pytest --dead-fixtures -m 'not flink'

--- a/justfile
+++ b/justfile
@@ -71,7 +71,7 @@ check *args:
 
 # run pytest for ci; additional arguments are forwarded to pytest
 ci-check extras *args:
-    uv run --group tests {{ extras }} pytest --junitxml=junit.xml --cov=ibis --cov-report=xml:coverage.xml {{ args }}
+    uv run --group tests {{ extras }} pytest --cov=ibis --cov-report=xml:coverage.xml {{ args }}
 
 # run backend doctests
 backend-doctests backend *args:


### PR DESCRIPTION
It seems that coverage, the junit plugin and one or more backend drivers might be interacting so as to cause a deadlock. This PR is an attempt to falsify that theory.