### PR TITLE
fix(backends): ensure that memtable finalizers do not hold onto references to self

### DIFF
--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -235,9 +235,13 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             **kwargs,
         )
 
-    def _finalize_memtable(self, name: str) -> None:
+    def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         table_ref = bq.TableReference(self._session_dataset, name)
-        self.client.delete_table(table_ref, not_found_ok=True)
+
+        def finalizer(table_ref=table_ref, client=self.client) -> None:
+            client.delete_table(table_ref, not_found_ok=True)
+
+        return finalizer
 
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         table_ref = bq.TableReference(self._session_dataset, op.name)

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -6,7 +6,7 @@ import glob
 import re
 from contextlib import closing
 from functools import partial
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 from urllib.parse import unquote_plus
 
 import clickhouse_connect as cc
@@ -66,8 +66,9 @@ class Backend(SQLBackend, CanCreateDatabase, DirectExampleLoader):
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         """No-op."""
 
-    def _finalize_memtable(self, name: str) -> None:
+    def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         """No-op."""
+        return lambda: None
 
     def _from_url(self, url: ParseResult, **kwarg_overrides) -> BaseBackend:
         kwargs = {}

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -10,7 +10,7 @@ import os
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import databricks.sql
 import pyarrow as pa
@@ -446,16 +446,22 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
                 cur.execute(put_into)
                 cur.execute(sql)
 
-    def _finalize_memtable(self, name: str) -> None:
+    def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         path = f"{self._memtable_volume_path}/{name}.parquet"
         sql = sge.Drop(
             kind="VIEW",
             this=sg.to_identifier(name, quoted=self.compiler.quoted),
             exists=True,
         ).sql(self.dialect)
-        with self.con.cursor() as cur:
-            cur.execute(sql)
-            cur.execute(f"REMOVE '{path}'")
+
+        def finalizer(path=path, sql=sql, con=self.con) -> None:
+            """Finalizer for in-memory tables."""
+
+            with con.cursor() as cur:
+                cur.execute(sql)
+                cur.execute(f"REMOVE '{path}'")
+
+        return finalizer
 
     def create_database(
         self, name: str, /, *, catalog: str | None = None, force: bool = False

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -5,7 +5,7 @@ import inspect
 import typing
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import datafusion as df
 import pyarrow as pa
@@ -418,6 +418,12 @@ class Backend(
         # of constructing a datafusion DataFrame, which has a side effect
         # of registering the table
         self.con.from_arrow(op.data.to_pyarrow(op.schema), op.name)
+
+    def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
+        def finalizer(name=name, con=self.con) -> None:
+            con.deregister_table(name)
+
+        return finalizer
 
     def read_csv(
         self,

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -7,7 +7,7 @@ import contextlib
 import urllib
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import duckdb
 import sqlglot as sg
@@ -1714,7 +1714,7 @@ class Backend(
 
         self.con.register(op.name, obj)
 
-    def _finalize_memtable(self, name: str) -> None:
+    def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         # if we don't aggressively unregister tables duckdb will keep a
         # reference to every memtable ever registered, even if there's no
         # way for a user to access the operation anymore, resulting in a
@@ -1722,7 +1722,10 @@ class Backend(
         #
         # we can't use drop_table, because self.con.register creates a view, so
         # use the corresponding unregister method
-        self.con.unregister(name)
+        def finalizer(name=name, con=self.con) -> None:
+            con.unregister(name)
+
+        return finalizer
 
     def _register_udfs(self, expr: ir.Expr) -> None:
         con = self.con

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import datetime
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import unquote_plus
 
 import pyexasol
@@ -306,11 +306,28 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
 
     def _clean_up_tmp_table(self, name: str) -> None:
         ident = sg.to_identifier(name, quoted=self.compiler.quoted)
-        sql = sge.Drop(kind="TABLE", this=ident, exists=True, cascade=True)
-        with self._safe_raw_sql(sql):
+        drop_sql = sge.Drop(kind="TABLE", this=ident, exists=True, cascade=True)
+        with self._safe_raw_sql(drop_sql):
             pass
 
-    _finalize_memtable = _clean_up_tmp_table
+    def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
+        ident = sg.to_identifier(name, quoted=self.compiler.quoted)
+        drop_sql = sge.Drop(kind="TABLE", this=ident, exists=True, cascade=True).sql(
+            self.dialect
+        )
+
+        def finalizer(con=self.con, drop_sql=drop_sql) -> None:
+            # use try finally because sqlite3's cursor doesn't support the
+            # context manager protocol
+            try:
+                con.execute(drop_sql)
+            except Exception:
+                con.rollback()
+                raise
+            else:
+                con.commit()
+
+        return finalizer
 
     def create_table(
         self,

--- a/ibis/backends/pyspark/__init__.py
+++ b/ibis/backends/pyspark/__init__.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 from decimal import Decimal
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import pyspark
 import pyspark.sql.functions as F
@@ -462,12 +462,12 @@ class Backend(
 
         df.createOrReplaceTempView(op.name)
 
-    def _make_memtable_finalizer(self, name: str) -> None:
+    def _make_memtable_finalizer(self, name: str) -> Callable[..., None]:
         """No-op with Spark Connect, otherwise a deadlock can occur."""
 
         if isinstance(session := self._session, pyspark.sql.SparkSession):
 
-            def finalizer(name=name, session=session) -> None:
+            def finalizer(name: str = name, session=session) -> None:
                 """Finalizer to drop the temporary view."""
                 session.catalog.dropTempView(name)
         else:

--- a/ibis/tests/expr/mocks.py
+++ b/ibis/tests/expr/mocks.py
@@ -45,8 +45,8 @@ class MockBackend(BaseBackend):
     def _register_in_memory_table(self, op: ops.InMemoryTable) -> None:
         pass
 
-    def _finalize_memtable(self, name: str) -> None:
-        pass
+    def _make_memtable_finalizer(self, _: str) -> None:
+        return lambda: None  # pragma: no cover
 
     def table(self, name, **_):
         schema = self.get_schema(name)

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -79,6 +79,8 @@ let
     (pythonSet.mkVirtualEnv "ibis-${python.pythonVersion}" deps).overrideAttrs (_old: {
       # Add passthru.tests from ibis-framework to venv passthru.
       # This is used to build tests by CI.
+      inherit python;
+      separateDebugInfo = true;
       passthru = {
         inherit (pythonSet.ibis-framework.passthru) tests;
       };


### PR DESCRIPTION
Remove `self` references in memtable finalizers, which should hopefully address the deadlock observed in the postgres backend when calling its memtable finalizers.