### PR TITLE
refactor: rename `to_sqlglot` to `to_sqlglot_columns_definition`

### DIFF
--- a/ibis/backends/athena/__init__.py
+++ b/ibis/backends/athena/__init__.py
@@ -156,7 +156,8 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
 
         if schema is not None and obj is None:
             target = sge.Schema(
-                this=table_ref, expressions=schema.to_sqlglot(self.dialect)
+                this=table_ref,
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             )
         else:
             target = table_ref
@@ -179,7 +180,9 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
             property_list.append(
                 sge.PartitionedByProperty(
                     this=sge.Schema(
-                        expressions=ibis.schema(partitioned_by).to_sqlglot(self.dialect)
+                        expressions=ibis.schema(
+                            partitioned_by
+                        ).to_sqlglot_columns_definition(self.dialect)
                     )
                 )
             )
@@ -409,7 +412,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
                     catalog=self.current_catalog,
                     quoted=quoted,
                 ),
-                expressions=schema.to_sqlglot(self.dialect),
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             ),
             properties=sge.Properties(
                 expressions=[

--- a/ibis/backends/athena/__init__.py
+++ b/ibis/backends/athena/__init__.py
@@ -157,7 +157,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
         if schema is not None and obj is None:
             target = sge.Schema(
                 this=table_ref,
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             )
         else:
             target = table_ref
@@ -180,9 +180,9 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
             property_list.append(
                 sge.PartitionedByProperty(
                     this=sge.Schema(
-                        expressions=ibis.schema(
-                            partitioned_by
-                        ).to_sqlglot_columns_definition(self.dialect)
+                        expressions=ibis.schema(partitioned_by).to_sqlglot_column_defs(
+                            self.dialect
+                        )
                     )
                 )
             )
@@ -412,7 +412,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, NoExampleLoader):
                     catalog=self.current_catalog,
                     quoted=quoted,
                 ),
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             ),
             properties=sge.Properties(
                 expressions=[

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -1195,7 +1195,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             kind="TABLE",
             this=sge.Schema(
                 this=table,
-                expressions=schema.to_sqlglot_columns_definition(self.dialect)
+                expressions=schema.to_sqlglot_column_defs(self.dialect)
                 if schema
                 else None,
             ),

--- a/ibis/backends/bigquery/__init__.py
+++ b/ibis/backends/bigquery/__init__.py
@@ -1195,7 +1195,9 @@ class Backend(SQLBackend, CanCreateDatabase, DirectPyArrowExampleLoader):
             kind="TABLE",
             this=sge.Schema(
                 this=table,
-                expressions=schema.to_sqlglot(self.dialect) if schema else None,
+                expressions=schema.to_sqlglot_columns_definition(self.dialect)
+                if schema
+                else None,
             ),
             replace=overwrite,
             properties=sge.Properties(expressions=properties),

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -678,9 +678,7 @@ class Backend(SQLBackend, CanCreateDatabase, DirectExampleLoader):
 
         this = sge.Schema(
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
-            expressions=(schema or obj.schema()).to_sqlglot_columns_definition(
-                self.dialect
-            ),
+            expressions=(schema or obj.schema()).to_sqlglot_column_defs(self.dialect),
         )
         properties = [
             # the engine cannot be quoted, since clickhouse won't allow e.g.,

--- a/ibis/backends/clickhouse/__init__.py
+++ b/ibis/backends/clickhouse/__init__.py
@@ -678,7 +678,9 @@ class Backend(SQLBackend, CanCreateDatabase, DirectExampleLoader):
 
         this = sge.Schema(
             this=sg.table(name, db=database, quoted=self.compiler.quoted),
-            expressions=(schema or obj.schema()).to_sqlglot(self.dialect),
+            expressions=(schema or obj.schema()).to_sqlglot_columns_definition(
+                self.dialect
+            ),
         )
         properties = [
             # the engine cannot be quoted, since clickhouse won't allow e.g.,

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -212,7 +212,10 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         dialect = self.dialect
 
         initial_table = sg.table(temp_name, catalog=catalog, db=database, quoted=quoted)
-        target = sge.Schema(this=initial_table, expressions=schema.to_sqlglot(dialect))
+        target = sge.Schema(
+            this=initial_table,
+            expressions=schema.to_sqlglot_columns_definition(dialect),
+        )
 
         properties = sge.Properties(expressions=properties)
         create_stmt = sge.Create(kind="TABLE", this=target, properties=properties)

--- a/ibis/backends/databricks/__init__.py
+++ b/ibis/backends/databricks/__init__.py
@@ -214,7 +214,7 @@ class Backend(SQLBackend, CanCreateDatabase, UrlFromPath, PyArrowExampleLoader):
         initial_table = sg.table(temp_name, catalog=catalog, db=database, quoted=quoted)
         target = sge.Schema(
             this=initial_table,
-            expressions=schema.to_sqlglot_columns_definition(dialect),
+            expressions=schema.to_sqlglot_column_defs(dialect),
         )
 
         properties = sge.Properties(expressions=properties)

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -673,7 +673,7 @@ class Backend(
         if query is None:
             target = sge.Schema(
                 this=table_ident,
-                expressions=(schema or table.schema()).to_sqlglot_columns_definition(
+                expressions=(schema or table.schema()).to_sqlglot_column_defs(
                     self.dialect
                 ),
             )

--- a/ibis/backends/datafusion/__init__.py
+++ b/ibis/backends/datafusion/__init__.py
@@ -673,7 +673,9 @@ class Backend(
         if query is None:
             target = sge.Schema(
                 this=table_ident,
-                expressions=(schema or table.schema()).to_sqlglot(self.dialect),
+                expressions=(schema or table.schema()).to_sqlglot_columns_definition(
+                    self.dialect
+                ),
             )
         else:
             target = table_ident

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -200,7 +200,10 @@ class Backend(
             temp_name = name
 
         initial_table = sg.table(temp_name, catalog=catalog, db=database, quoted=quoted)
-        target = sge.Schema(this=initial_table, expressions=schema.to_sqlglot(dialect))
+        target = sge.Schema(
+            this=initial_table,
+            expressions=schema.to_sqlglot_columns_definition(dialect),
+        )
 
         create_stmt = sge.Create(
             kind="TABLE",

--- a/ibis/backends/duckdb/__init__.py
+++ b/ibis/backends/duckdb/__init__.py
@@ -202,7 +202,7 @@ class Backend(
         initial_table = sg.table(temp_name, catalog=catalog, db=database, quoted=quoted)
         target = sge.Schema(
             this=initial_table,
-            expressions=schema.to_sqlglot_columns_definition(dialect),
+            expressions=schema.to_sqlglot_column_defs(dialect),
         )
 
         create_stmt = sge.Create(

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -284,7 +284,10 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
         ident = sg.to_identifier(name, quoted=quoted)
         create_stmt = sg.exp.Create(
             kind="TABLE",
-            this=sg.exp.Schema(this=ident, expressions=schema.to_sqlglot(self.dialect)),
+            this=sg.exp.Schema(
+                this=ident,
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+            ),
         )
         create_stmt_sql = create_stmt.sql(self.name)
 
@@ -382,7 +385,8 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
 
         table_expr = sg.table(temp_name, catalog=database, quoted=quoted)
         target = sge.Schema(
-            this=table_expr, expressions=schema.to_sqlglot(self.dialect)
+            this=table_expr,
+            expressions=schema.to_sqlglot_columns_definition(self.dialect),
         )
 
         create_stmt = sge.Create(kind="TABLE", this=target)

--- a/ibis/backends/exasol/__init__.py
+++ b/ibis/backends/exasol/__init__.py
@@ -286,7 +286,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
             kind="TABLE",
             this=sg.exp.Schema(
                 this=ident,
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             ),
         )
         create_stmt_sql = create_stmt.sql(self.name)
@@ -386,7 +386,7 @@ class Backend(SQLBackend, CanCreateDatabase, NoExampleLoader):
         table_expr = sg.table(temp_name, catalog=database, quoted=quoted)
         target = sge.Schema(
             this=table_expr,
-            expressions=schema.to_sqlglot_columns_definition(self.dialect),
+            expressions=schema.to_sqlglot_column_defs(self.dialect),
         )
 
         create_stmt = sge.Create(kind="TABLE", this=target)

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -1403,7 +1403,7 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot(self.dialect),
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             ),
         ).sql(self.name, pretty=True)
 

--- a/ibis/backends/impala/__init__.py
+++ b/ibis/backends/impala/__init__.py
@@ -1403,7 +1403,7 @@ class Backend(SQLBackend, HasCurrentDatabase, NoExampleLoader):
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             ),
         ).sql(self.name, pretty=True)
 

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -688,7 +688,7 @@ GO"""
             this=sg.table(
                 "#" * bool(temp) + temp_name, catalog=catalog, db=db, quoted=quoted
             ),
-            expressions=schema.to_sqlglot_columns_definition(self.dialect),
+            expressions=schema.to_sqlglot_column_defs(self.dialect),
         )
 
         create_stmt = sge.Create(
@@ -755,7 +755,7 @@ GO"""
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             ),
         )
 

--- a/ibis/backends/mssql/__init__.py
+++ b/ibis/backends/mssql/__init__.py
@@ -688,7 +688,7 @@ GO"""
             this=sg.table(
                 "#" * bool(temp) + temp_name, catalog=catalog, db=db, quoted=quoted
             ),
-            expressions=schema.to_sqlglot(self.dialect),
+            expressions=schema.to_sqlglot_columns_definition(self.dialect),
         )
 
         create_stmt = sge.Create(
@@ -755,7 +755,7 @@ GO"""
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot(self.dialect),
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             ),
         )
 

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -408,7 +408,9 @@ class Backend(SQLBackend, CanCreateDatabase, HasCurrentDatabase, PyArrowExampleL
         dialect = self.dialect
 
         table_expr = sg.table(temp_name, catalog=database, quoted=quoted)
-        target = sge.Schema(this=table_expr, expressions=schema.to_sqlglot(dialect))
+        target = sge.Schema(
+            this=table_expr, expressions=schema.to_sqlglot_columns_definition(dialect)
+        )
 
         create_stmt = sge.Create(
             kind="TABLE", this=target, properties=sge.Properties(expressions=properties)
@@ -454,7 +456,7 @@ class Backend(SQLBackend, CanCreateDatabase, HasCurrentDatabase, PyArrowExampleL
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot(dialect),
+                expressions=schema.to_sqlglot_columns_definition(dialect),
             ),
             properties=sg.exp.Properties(expressions=[sge.TemporaryProperty()]),
         )

--- a/ibis/backends/mysql/__init__.py
+++ b/ibis/backends/mysql/__init__.py
@@ -409,7 +409,7 @@ class Backend(SQLBackend, CanCreateDatabase, HasCurrentDatabase, PyArrowExampleL
 
         table_expr = sg.table(temp_name, catalog=database, quoted=quoted)
         target = sge.Schema(
-            this=table_expr, expressions=schema.to_sqlglot_columns_definition(dialect)
+            this=table_expr, expressions=schema.to_sqlglot_column_defs(dialect)
         )
 
         create_stmt = sge.Create(
@@ -456,7 +456,7 @@ class Backend(SQLBackend, CanCreateDatabase, HasCurrentDatabase, PyArrowExampleL
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot_columns_definition(dialect),
+                expressions=schema.to_sqlglot_column_defs(dialect),
             ),
             properties=sg.exp.Properties(expressions=[sge.TemporaryProperty()]),
         )

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -442,7 +442,9 @@ class Backend(
         initial_table = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
         target = sge.Schema(
             this=initial_table,
-            expressions=(schema or table.schema()).to_sqlglot(self.dialect),
+            expressions=(schema or table.schema()).to_sqlglot_columns_definition(
+                self.dialect
+            ),
         )
 
         create_stmt = sge.Create(
@@ -513,7 +515,7 @@ class Backend(
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot(self.dialect),
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             ),
             properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
         ).sql(self.name)

--- a/ibis/backends/oracle/__init__.py
+++ b/ibis/backends/oracle/__init__.py
@@ -442,9 +442,7 @@ class Backend(
         initial_table = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
         target = sge.Schema(
             this=initial_table,
-            expressions=(schema or table.schema()).to_sqlglot_columns_definition(
-                self.dialect
-            ),
+            expressions=(schema or table.schema()).to_sqlglot_column_defs(self.dialect),
         )
 
         create_stmt = sge.Create(
@@ -515,7 +513,7 @@ class Backend(
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             ),
             properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
         ).sql(self.name)

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -91,7 +91,7 @@ class Backend(
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot(self.dialect),
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             ),
             properties=sg.exp.Properties(expressions=[sge.TemporaryProperty()]),
         )
@@ -631,7 +631,9 @@ ORDER BY a.attnum ASC"""
         dialect = self.dialect
 
         table_expr = sg.table(temp_name, db=database, quoted=quoted)
-        target = sge.Schema(this=table_expr, expressions=schema.to_sqlglot(dialect))
+        target = sge.Schema(
+            this=table_expr, expressions=schema.to_sqlglot_columns_definition(dialect)
+        )
 
         create_stmt = sge.Create(
             kind="TABLE",

--- a/ibis/backends/postgres/__init__.py
+++ b/ibis/backends/postgres/__init__.py
@@ -91,7 +91,7 @@ class Backend(
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             ),
             properties=sg.exp.Properties(expressions=[sge.TemporaryProperty()]),
         )
@@ -632,7 +632,7 @@ ORDER BY a.attnum ASC"""
 
         table_expr = sg.table(temp_name, db=database, quoted=quoted)
         target = sge.Schema(
-            this=table_expr, expressions=schema.to_sqlglot_columns_definition(dialect)
+            this=table_expr, expressions=schema.to_sqlglot_column_defs(dialect)
         )
 
         create_stmt = sge.Create(

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -562,7 +562,7 @@ class Backend(
         table_expr = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
         target = sge.Schema(
             this=table_expr,
-            expressions=schema.to_sqlglot_columns_definition(self.dialect),
+            expressions=schema.to_sqlglot_column_defs(self.dialect),
         )
 
         if connector_properties is None:
@@ -618,7 +618,7 @@ class Backend(
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             ),
         )
         create_stmt_sql = create_stmt.sql(self.dialect)
@@ -767,7 +767,7 @@ class Backend(
         quoted = self.compiler.quoted
         table = sg.table(name, db=database, quoted=quoted)
         target = sge.Schema(
-            this=table, expressions=schema.to_sqlglot_columns_definition(self.dialect)
+            this=table, expressions=schema.to_sqlglot_column_defs(self.dialect)
         )
 
         properties = sge.Properties.from_dict(connector_properties)

--- a/ibis/backends/risingwave/__init__.py
+++ b/ibis/backends/risingwave/__init__.py
@@ -561,7 +561,8 @@ class Backend(
 
         table_expr = sg.table(temp_name, db=database, quoted=self.compiler.quoted)
         target = sge.Schema(
-            this=table_expr, expressions=schema.to_sqlglot(self.dialect)
+            this=table_expr,
+            expressions=schema.to_sqlglot_columns_definition(self.dialect),
         )
 
         if connector_properties is None:
@@ -617,7 +618,7 @@ class Backend(
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot(self.dialect),
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             ),
         )
         create_stmt_sql = create_stmt.sql(self.dialect)
@@ -765,7 +766,9 @@ class Backend(
         """
         quoted = self.compiler.quoted
         table = sg.table(name, db=database, quoted=quoted)
-        target = sge.Schema(this=table, expressions=schema.to_sqlglot(self.dialect))
+        target = sge.Schema(
+            this=table, expressions=schema.to_sqlglot_columns_definition(self.dialect)
+        )
 
         properties = sge.Properties.from_dict(connector_properties)
         properties.expressions.extend(

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -793,7 +793,7 @@ $$ {defn["source"]} $$"""
         if schema:
             target = sge.Schema(
                 this=target,
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             )
 
         properties = []
@@ -1092,7 +1092,7 @@ $$ {defn["source"]} $$"""
                 kind="TABLE",
                 this=sge.Schema(
                     this=qtable,
-                    expressions=schema.to_sqlglot_columns_definition(dialect),
+                    expressions=schema.to_sqlglot_column_defs(dialect),
                 ),
                 properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
             ).sql(dialect),

--- a/ibis/backends/snowflake/__init__.py
+++ b/ibis/backends/snowflake/__init__.py
@@ -792,7 +792,8 @@ $$ {defn["source"]} $$"""
 
         if schema:
             target = sge.Schema(
-                this=target, expressions=schema.to_sqlglot(self.dialect)
+                this=target,
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             )
 
         properties = []
@@ -1089,7 +1090,10 @@ $$ {defn["source"]} $$"""
             f"CREATE TEMP STAGE {stage} FILE_FORMAT = (TYPE = PARQUET {options})",
             sge.Create(
                 kind="TABLE",
-                this=sge.Schema(this=qtable, expressions=schema.to_sqlglot(dialect)),
+                this=sge.Schema(
+                    this=qtable,
+                    expressions=schema.to_sqlglot_columns_definition(dialect),
+                ),
                 properties=sge.Properties(expressions=[sge.TemporaryProperty()]),
             ).sql(dialect),
         ]

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -334,7 +334,9 @@ class Backend(
         return table.to_reader(max_chunksize=chunk_size)
 
     def _generate_create_table(self, table: sge.Table, schema: sch.Schema):
-        target = sge.Schema(this=table, expressions=schema.to_sqlglot(self.dialect))
+        target = sge.Schema(
+            this=table, expressions=schema.to_sqlglot_columns_definition(self.dialect)
+        )
 
         return sge.Create(kind="TABLE", this=target)
 

--- a/ibis/backends/sqlite/__init__.py
+++ b/ibis/backends/sqlite/__init__.py
@@ -335,7 +335,7 @@ class Backend(
 
     def _generate_create_table(self, table: sge.Table, schema: sch.Schema):
         target = sge.Schema(
-            this=table, expressions=schema.to_sqlglot_columns_definition(self.dialect)
+            this=table, expressions=schema.to_sqlglot_column_defs(self.dialect)
         )
 
         return sge.Create(kind="TABLE", this=target)

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -464,7 +464,8 @@ class Backend(
 
         if schema is not None and obj is None:
             target = sge.Schema(
-                this=table_ref, expressions=schema.to_sqlglot(self.dialect)
+                this=table_ref,
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             )
         else:
             target = table_ref
@@ -564,7 +565,7 @@ class Backend(
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot(self.dialect),
+                expressions=schema.to_sqlglot_columns_definition(self.dialect),
             ),
         ).sql(self.name)
 

--- a/ibis/backends/trino/__init__.py
+++ b/ibis/backends/trino/__init__.py
@@ -465,7 +465,7 @@ class Backend(
         if schema is not None and obj is None:
             target = sge.Schema(
                 this=table_ref,
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             )
         else:
             target = table_ref
@@ -565,7 +565,7 @@ class Backend(
             kind="TABLE",
             this=sg.exp.Schema(
                 this=sg.to_identifier(name, quoted=quoted),
-                expressions=schema.to_sqlglot_columns_definition(self.dialect),
+                expressions=schema.to_sqlglot_column_defs(self.dialect),
             ),
         ).sql(self.name)
 

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -182,7 +182,7 @@ def generate_tpc_tables(suite_name, *, data_dir):
             exists=True,
             this=sge.Schema(
                 this=sg.table(name, db=suite_name, catalog="hive", quoted=True),
-                expressions=schema.to_sqlglot_columns_definition("trino"),
+                expressions=schema.to_sqlglot_column_defs("trino"),
             ),
             properties=sge.Properties(
                 expressions=[

--- a/ibis/backends/trino/tests/conftest.py
+++ b/ibis/backends/trino/tests/conftest.py
@@ -182,7 +182,7 @@ def generate_tpc_tables(suite_name, *, data_dir):
             exists=True,
             this=sge.Schema(
                 this=sg.table(name, db=suite_name, catalog="hive", quoted=True),
-                expressions=schema.to_sqlglot("trino"),
+                expressions=schema.to_sqlglot_columns_definition("trino"),
             ),
             properties=sge.Properties(
                 expressions=[

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -235,9 +235,7 @@ class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
         """
         return self.names[i]
 
-    def to_sqlglot_columns_definition(
-        self, dialect: str | sg.Dialect
-    ) -> list[sge.ColumnDef]:
+    def to_sqlglot_column_defs(self, dialect: str | sg.Dialect) -> list[sge.ColumnDef]:
         """Convert the schema to a list of SQL column definitions.
 
         Parameters
@@ -259,7 +257,7 @@ class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
           a  int64
           b  !string
         }
-        >>> columns = sch.to_sqlglot_columns_definition(dialect="duckdb")
+        >>> columns = sch.to_sqlglot_column_defs(dialect="duckdb")
         >>> columns
         [ColumnDef(
           this=Identifier(this='a', quoted=True),
@@ -306,11 +304,11 @@ class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
         ]
 
     @deprecated(
-        instead="use Schema.to_sqlglot_columns_definition() instead. In a future release, to_sqlglot() will return a sqlglot.schema.Schema object"
+        instead="use Schema.to_sqlglot_column_defs() instead. In a future release, to_sqlglot() will return a sqlglot.schema.Schema object"
     )
     def to_sqlglot(self, dialect: str | sg.Dialect) -> list[sge.ColumnDef]:
-        """DEPRECATED: use `to_sqlglot_columns_definition()` instead."""
-        return self.to_sqlglot_columns_definition(dialect)
+        """DEPRECATED: use `to_sqlglot_column_defs()` instead."""
+        return self.to_sqlglot_column_defs(dialect)
 
 
 SchemaLike: TypeAlias = Union[

--- a/ibis/expr/schema.py
+++ b/ibis/expr/schema.py
@@ -11,7 +11,7 @@ from ibis.common.dispatch import lazy_singledispatch
 from ibis.common.exceptions import InputTypeError, IntegrityError
 from ibis.common.grounds import Concrete
 from ibis.common.patterns import Coercible
-from ibis.util import indent
+from ibis.util import deprecated, indent
 
 if TYPE_CHECKING:
     import numpy as np
@@ -235,7 +235,9 @@ class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
         """
         return self.names[i]
 
-    def to_sqlglot(self, dialect: str | sg.Dialect) -> list[sge.ColumnDef]:
+    def to_sqlglot_columns_definition(
+        self, dialect: str | sg.Dialect
+    ) -> list[sge.ColumnDef]:
         """Convert the schema to a list of SQL column definitions.
 
         Parameters
@@ -257,7 +259,7 @@ class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
           a  int64
           b  !string
         }
-        >>> columns = sch.to_sqlglot(dialect="duckdb")
+        >>> columns = sch.to_sqlglot_columns_definition(dialect="duckdb")
         >>> columns
         [ColumnDef(
           this=Identifier(this='a', quoted=True),
@@ -302,6 +304,13 @@ class Schema(Concrete, Coercible, MapSet[str, dt.DataType]):
             )
             for name, dtype in self.items()
         ]
+
+    @deprecated(
+        instead="use Schema.to_sqlglot_columns_definition() instead. In a future release, to_sqlglot() will return a sqlglot.schema.Schema object"
+    )
+    def to_sqlglot(self, dialect: str | sg.Dialect) -> list[sge.ColumnDef]:
+        """DEPRECATED: use `to_sqlglot_columns_definition()` instead."""
+        return self.to_sqlglot_columns_definition(dialect)
 
 
 SchemaLike: TypeAlias = Union[

--- a/ibis/expr/tests/test_schema.py
+++ b/ibis/expr/tests/test_schema.py
@@ -439,11 +439,11 @@ def test_null_fields():
     assert sch.schema({"a": "null", "b": "null"}).null_fields == ("a", "b")
 
 
-def test_to_sqlglot_columns_definition():
+def test_to_sqlglot_column_defs():
     import sqlglot.expressions as sge
 
     schema = sch.schema({"a": "int64", "b": "string", "c": "!string"})
-    columns = schema.to_sqlglot_columns_definition("duckdb")
+    columns = schema.to_sqlglot_column_defs("duckdb")
 
     assert len(columns) == 3
     assert all(isinstance(col, sge.ColumnDef) for col in columns)
@@ -456,18 +456,18 @@ def test_to_sqlglot_columns_definition():
     assert isinstance(columns[2].constraints[0].kind, sge.NotNullColumnConstraint)
 
 
-def test_to_sqlglot_columns_definition_empty_schema():
+def test_to_sqlglot_column_defs_empty_schema():
     schema = sch.schema({})
-    columns = schema.to_sqlglot_columns_definition("duckdb")
+    columns = schema.to_sqlglot_column_defs("duckdb")
     assert columns == []
 
 
-def test_to_sqlglot_columns_definition_create_table_integration():
+def test_to_sqlglot_column_defs_create_table_integration():
     import sqlglot as sg
     import sqlglot.expressions as sge
 
     schema = sch.schema({"id": "!int64", "name": "string"})
-    columns = schema.to_sqlglot_columns_definition("duckdb")
+    columns = schema.to_sqlglot_column_defs("duckdb")
 
     table = sg.table("test_table", quoted=True)
     create_stmt = sge.Create(


### PR DESCRIPTION
## Description of changes

I renamed the `to_sqlglot` method to `to_sqlglot_columns_definition` and updated backend implementations to use the new name. I also added a test for this as I did not see one for `to_sqlglot`. 

I deprecated the old with the note that we will likely still keep it and change to be a SQLGlot schema, but wanted to be sure that was the intention. 

## Issues closed

Closes #11310 
